### PR TITLE
Fixes error that prevents the code from compiling

### DIFF
--- a/nuttx/arch/arm/src/stm32/stm32f40xxx_rcc.c
+++ b/nuttx/arch/arm/src/stm32/stm32f40xxx_rcc.c
@@ -618,7 +618,7 @@ static void stm32_stdclockconfig(void)
       /* Set the PLL dividers and multiplers to configure the main PLL */
 
       regval = (STM32_PLLCFG_PLLM | STM32_PLLCFG_PLLN |STM32_PLLCFG_PLLP |
-                RCC_PLLCFG_PLLSRC_HSE | STM32_PLLCFG_PLLQ);
+                RCC_PLLCFG_PLLSRC_HSE | STM32_PLLCFG_PPQ);
       putreg32(regval, STM32_RCC_PLLCFG);
 
       /* Enable the main PLL */


### PR DESCRIPTION
In the last merge STM32_PLLCFG_PPQ was changed to STM32_PLLCFG_PLLQ which doesn't exist.  I switched it back and am now able to compile the FMU code again.
