### PR TITLE
#69: Improved termios support for the STM32 UART driver.

### DIFF
--- a/nuttx/include/nuttx/fs/ioctl.h
+++ b/nuttx/include/nuttx/fs/ioctl.h
@@ -106,6 +106,10 @@
                                            * OUT: None
                                            */
 
+#define FIONREAD        _FIOC(0x0004)     /* IN:  Location to return value (int *)
+                                           * OUT: Bytes readable from this fd
+                                           */
+
 /* NuttX file system ioctl definitions **************************************/
 
 #define _DIOCVALID(c)   (_IOC_TYPE(c)==_DIOCBASE)

--- a/nuttx/include/nuttx/serial/serial.h
+++ b/nuttx/include/nuttx/serial/serial.h
@@ -46,7 +46,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <semaphore.h>
-#include <termios.h>
+#ifdef CONFIG_SERIAL_TERMIOS
+#  include <termios.h> 
+#endif
 #include <nuttx/fs/fs.h>
 
 /************************************************************************************
@@ -216,7 +218,12 @@ struct uart_dev_s
 #endif
 
   /* Terminal control flags */
-  struct termios termios_s;
+
+#ifdef CONFIG_SERIAL_TERMIOS
+  tcflag_t  tc_iflag;        /* Input modes */
+  tcflag_t  tc_oflag;        /* Output modes */
+  tcflag_t  tc_lflag;        /* Local modes */
+#endif
 
 };
 typedef struct uart_dev_s uart_dev_t;

--- a/nuttx/include/termios.h
+++ b/nuttx/include/termios.h
@@ -58,7 +58,7 @@
 #define INLCR     (1 << 5)  /* Bit 5:  Map NL to CR on input */
 #define INPCK     (1 << 6)  /* Bit 6:  Enable input parity check */
 #define ISTRIP    (1 << 7)  /* Bit 7:  Strip character */
-#define IUCLC     (1 << 8)  /* Bit 8:  Map upper-case to lower-case on input (LEGACY) */
+                            /* Bit 8:  unused */
 #define IXANY     (1 << 9)  /* Bit 9:  Enable any character to restart output */
 #define IXOFF     (1 << 10) /* Bit 10: Enable start/stop input control */
 #define IXON      (1 << 11) /* Bit 11: Enable start/stop output control */
@@ -67,7 +67,7 @@
 /* Terminal output modes (c_oflag in the termios structure) */
 
 #define OPOST     (1 << 0)  /* Bit 0:  Post-process output */
-#define OLCUC     (1 << 1)  /* Bit 1:  Map lower-case to upper-case on output (LEGACY) */
+                            /* Bit 1:  unused */
 #define ONLCR     (1 << 2)  /* Bit 2:  Map NL to CR-NL on output */
 #define OCRNL     (1 << 3)  /* Bit 3:  Map CR to NL on output */
 #define ONOCR     (1 << 4)  /* Bit 4:  No CR output at column 0 */
@@ -98,17 +98,20 @@
 
 /* Control Modes (c_cflag in the termios structure) */
 
-#define CSIZE     (3 << 0)  /* Bits 0-1: Character size: */
-#  define CS5     (0 << 0)  /*   5 bits */
-#  define CS6     (1 << 0)  /*   6 bits */
-#  define CS7     (2 << 0)  /*   7 bits */
-#  define CS8     (3 << 0)  /*   8 bits */
-#define CSTOPB    (1 << 2)  /* Bit 2: Send two stop bits, else one */
-#define CREAD     (1 << 3)  /* Bit 3: Enable receiver */
-#define PARENB    (1 << 4)  /* Bit 4: Parity enable */
-#define PARODD    (1 << 5)  /* Bit 5: Odd parity, else even */
-#define HUPCL     (1 << 6)  /* Bit 6: Hang up on last close */
-#define CLOCAL    (1 << 7)  /* Bit 7: Ignore modem status lines */
+#define CSIZE       (3 << 0)  /* Bits 0-1: Character size: */
+#  define CS5       (0 << 0)  /*   5 bits */
+#  define CS6       (1 << 0)  /*   6 bits */
+#  define CS7       (2 << 0)  /*   7 bits */
+#  define CS8       (3 << 0)  /*   8 bits */
+#define CSTOPB      (1 << 2)  /* Bit 2: Send two stop bits, else one */
+#define CREAD       (1 << 3)  /* Bit 3: Enable receiver */
+#define PARENB      (1 << 4)  /* Bit 4: Parity enable */
+#define PARODD      (1 << 5)  /* Bit 5: Odd parity, else even */
+#define HUPCL       (1 << 6)  /* Bit 6: Hang up on last close */
+#define CLOCAL      (1 << 7)  /* Bit 7: Ignore modem status lines */
+#define CCTS_OFLOW  (1 << 8)  /* Bit 8: CTS flow control of output */
+#define CRTSCTS     CCTS_OFLOW
+#define CRTS_IFLOW  (1 << 9)  /* Bit 9: RTS flow control of input */
 
 /* Local Modes (c_lflag in the termios structure) */
 
@@ -121,7 +124,6 @@
 #define ISIG      (1 << 6)  /* Bit 6:  Enable signals */
 #define NOFLSH    (1 << 7)  /* Bit 7:  Disable flush after interrupt or quit */
 #define TOSTOP    (1 << 8)  /* Bit 8:  Send SIGTTOU for background output */
-#define XCASE     (1 << 9)  /* Bit 9:  Canonical upper/lower presentation (LEGACY) */
 
 /* The following are subscript names for the termios c_cc array */
 


### PR DESCRIPTION
Changes for #69.

Also add a little more termios processing to the generic serial layer.  Implement FIONREAD.
