### PR TITLE
Autostart scripts

### DIFF
--- a/ROMFS/scripts/rc.PX4IO
+++ b/ROMFS/scripts/rc.PX4IO
@@ -23,8 +23,8 @@ fi
 px4io start
 
 #
-# Load an appropriate mixer. FMU_pass.mix is a passthru mixer.
-# See ROMFS/mixers for a full list of mixers.
+# Load an appropriate mixer. FMU_pass.mix is a passthru mixer
+# which is good for testing. See ROMFS/mixers for a full list of mixers.
 #
 mixer load /dev/pwm_output /etc/mixers/FMU_pass.mix
 
@@ -56,9 +56,9 @@ fixedwing_att_control start
 fixedwing_pos_control start
 
 #
-# Start GPS capture
+# Start GPS capture. Comment this out if you do not have a GPS.
 #
-#gps start
+gps start
 
 #
 # Start logging to microSD if we can


### PR DESCRIPTION
While setting up the PX4IO for the first time I noticed there are several versions for at least the PX4IO startup script.

Is anything missing or wrong with this? I have already updated the wiki page (https://pixhawk.ethz.ch/px4/users/apps/auto_starting_apps?&#fixed_wing_autostart_default) to reflect this change. 
