### PR TITLE
Made MPU-6000 gyro optional

### DIFF
--- a/apps/drivers/mpu6000/mpu6000.cpp
+++ b/apps/drivers/mpu6000/mpu6000.cpp
@@ -450,7 +450,6 @@ MPU6000::init()
 	int gyro_ret = _gyro->init();
 
 	if (gyro_ret != OK) {
-		::close(_gyro_topic);
 		_gyro_topic = -1;
 	}
 


### PR DESCRIPTION
This change makes the gyro of the MPU-6000 optional, allowing to start the (better) L3GD20 gyro first and then only use the accel of the MPU-6000.
