### PR TITLE
Removed last bogus references to battery voltage from sensor combined topic

### DIFF
--- a/apps/commander/commander.c
+++ b/apps/commander/commander.c
@@ -1321,7 +1321,7 @@ int commander_thread_main(int argc, char *argv[])
 
 	/* Initialize to 0.0V */
 	float battery_voltage = 0.0f;
-	bool battery_voltage_valid = true;
+	bool battery_voltage_valid = false;
 	bool low_battery_voltage_actions_done = false;
 	bool critical_battery_voltage_actions_done = false;
 	uint8_t low_voltage_counter = 0;
@@ -1411,9 +1411,6 @@ int commander_thread_main(int argc, char *argv[])
 
 		if (new_data) {
 			orb_copy(ORB_ID(sensor_combined), sensor_sub, &sensors);
-
-		} else {
-			sensors.battery_voltage_valid = false;
 		}
 
 		orb_check(cmd_sub, &new_data);

--- a/apps/sensors/sensors.cpp
+++ b/apps/sensors/sensors.cpp
@@ -1014,7 +1014,6 @@ Sensors::adc_poll(struct sensor_combined_s &raw)
 					}
 				}
 
-				raw.battery_voltage_counter++;
 				_last_adc = hrt_absolute_time();
 				break;
 			}

--- a/apps/uORB/topics/sensor_combined.h
+++ b/apps/uORB/topics/sensor_combined.h
@@ -102,8 +102,6 @@ struct sensor_combined_s {
 	float adc_voltage_v[4];			/**< ADC voltages of ADC Chan 10/11/12/13 or -1      */
 	float mcu_temp_celcius;			/**< Internal temperature measurement of MCU */
 	uint32_t baro_counter;			/**< Number of raw baro measurements taken        */
-	uint32_t battery_voltage_counter;	/**< Number of voltage measurements taken         */
-	bool battery_voltage_valid;		/**< True if battery voltage can be measured      */
 
 };
 


### PR DESCRIPTION
This removes (unused) references to the battery data present in the sensor_combined topic. All battery information is now in the battery_status topic.
