### PR TITLE
Fixed test outputs, decoupled tests from NuttX low-level output

### DIFF
--- a/apps/px4/tests/test_adc.c
+++ b/apps/px4/tests/test_adc.c
@@ -60,8 +60,10 @@ int test_adc(int argc, char *argv[])
 {
 	int fd = open(ADC_DEVICE_PATH, O_RDONLY);
 
-	if (fd < 0)
-		err(1, "can't open ADC device");
+	if (fd < 0) {
+		warnx("ERROR: can't open ADC device");
+		return 1;
+	}
 
 	for (unsigned i = 0; i < 5; i++) {
 		/* make space for a maximum of eight channels */
@@ -82,7 +84,7 @@ int test_adc(int argc, char *argv[])
 		usleep(150000);
 	}
 
-	message("\t ADC test successful.\n");
+	warnx("\t ADC test successful.\n");
 
 errout_with_dev:
 

--- a/apps/px4/tests/tests_main.c
+++ b/apps/px4/tests/tests_main.c
@@ -135,6 +135,7 @@ test_all(int argc, char *argv[])
 	unsigned	i;
 	char		*args[2] = {"all", NULL};
 	unsigned int failcount = 0;
+	unsigned int testcount = 0;
 	bool		passed[NTESTS];
 
 	printf("\nRunning all tests...\n\n");
@@ -156,6 +157,7 @@ test_all(int argc, char *argv[])
 				fflush(stdout);
 				passed[i] = true;
 			}
+			testcount++;
 		}
 	}
 
@@ -178,7 +180,7 @@ test_all(int argc, char *argv[])
 		printf("  \\ \\_\\ \\_\\  \\ \\_____\\  \\ \\_____\\     \\ \\_____\\  \\ \\_\\ \\_\\ \n");
 		printf("   \\/_/\\/_/   \\/_____/   \\/_____/      \\/_____/   \\/_/\\/_/ \n");
 		printf("\n");
-		printf(" All tests passed (%d of %d)\n", i, i);
+		printf(" All tests passed (%d of %d)\n", testcount, testcount);
 
 	} else {
 		printf("  ______   ______     __     __ \n");
@@ -187,7 +189,7 @@ test_all(int argc, char *argv[])
 		printf("  \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\  \\ \\_____\\ \n");
 		printf("   \\/_/     \\/_/\\/_/   \\/_/   \\/_____/ \n");
 		printf("\n");
-		printf(" Some tests failed (%d of %d)\n", failcount, i);
+		printf(" Some tests failed (%d of %d)\n", failcount, testcount);
 	}
 
 	printf("\n");
@@ -245,6 +247,7 @@ int test_jig(int argc, char *argv[])
 	unsigned	i;
 	char		*args[2] = {"jig", NULL};
 	unsigned int failcount = 0;
+	unsigned int testcount = 0;
 	bool		passed[NTESTS];
 
 	printf("\nRunning all tests...\n\n");
@@ -264,6 +267,7 @@ int test_jig(int argc, char *argv[])
 				fflush(stdout);
 				passed[i] = true;
 			}
+			testcount++;
 		}
 	}
 
@@ -284,7 +288,7 @@ int test_jig(int argc, char *argv[])
 		printf("  \\ \\_\\ \\_\\  \\ \\_____\\  \\ \\_____\\     \\ \\_____\\  \\ \\_\\ \\_\\ \n");
 		printf("   \\/_/\\/_/   \\/_____/   \\/_____/      \\/_____/   \\/_/\\/_/ \n");
 		printf("\n");
-		printf(" All tests passed (%d of %d)\n", i, i);
+		printf(" All tests passed (%d of %d)\n", testcount, testcount);
 	} else {
 		printf("  ______   ______     __     __ \n");
 		printf(" /\\  ___\\ /\\  __ \\   /\\ \\   /\\ \\    \n");
@@ -292,7 +296,7 @@ int test_jig(int argc, char *argv[])
 		printf("  \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\  \\ \\_____\\ \n");
 		printf("   \\/_/     \\/_/\\/_/   \\/_/   \\/_____/ \n");
 		printf("\n");
-		printf(" Some tests failed (%d of %d)\n", failcount, i);
+		printf(" Some tests failed (%d of %d)\n", failcount, testcount);
 	}
 	printf("\n");
 


### PR DESCRIPTION
This fixes / improves the tests output and does not abort on ADC fail, but rather reports it at the end as intended. This is important to be able to identify all issues of a board at once, and does not force to iterate several times for things that could have been spotted on the first attempt.
