### PR TITLE
Hotfix: Really disarm servos in FMU standalone mode (Stuart Duncan)

### DIFF
--- a/apps/drivers/stm32/drv_pwm_servo.c
+++ b/apps/drivers/stm32/drv_pwm_servo.c
@@ -300,7 +300,7 @@ up_pwm_servo_arm(bool armed)
 
 			} else {
 				/* on disarm, just stop auto-reload so we don't generate runts */
-				rCR1(i) &= ~GTIM_CR1_ARPE;
+				rCR1(i) = 0;
 			}
 		}
 	}


### PR DESCRIPTION
The issue reported by Stuart:

"On boot: Groundstation says disarmed, slow blink, throttle stick does nothing.
On arming: GS says armed, fast blink, throttle controls motor speed.
On disarming: GS says disarmed, slow blink BUT throttle still controls motors.

I'm running standalone PWM mode, latest firmware (3e5cd26777aa209d6568036d43b33b543a364bee).
The RC script is just the x-quad script pinched from ROMFS/scripts/.
MAV_TYPE is 2 (had that problem earlier)"

This fix is based on his patch after reproducing the issue. Tested the fix on FMU in standalone mode and verified arming/disarming still works on FMU/IO.
