### PR TITLE
Prevent the uploader from blocking/hanging due to bad exception handling

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -382,7 +382,7 @@ while True:
 				# Windows, don't open POSIX ports
 				if not "/" in port:
 					up = uploader(port, args.baud)
-		except:
+		except Exception:
 			# open failed, rate-limit our attempts
 			time.sleep(0.05)
 
@@ -395,7 +395,7 @@ while True:
 			up.identify()
 			print("Found board %x,%x bootloader rev %x on %s" % (up.board_type, up.board_rev, up.bl_rev, port))
 
-		except:
+		except Exception:
 			# most probably a timeout talking to the port, no bootloader
 			continue
 


### PR DESCRIPTION
Prevent the uploader from blocking/hanging due to bad exception handling.

Specifically this changeset makes the uploader responsive again to user interrupts, i.e. SIGINT triggered by CTRL-C.
