### PR TITLE
Workaround to handle %n in sscanf

### DIFF
--- a/nuttx/libc/stdio/lib_sscanf.c
+++ b/nuttx/libc/stdio/lib_sscanf.c
@@ -197,7 +197,7 @@ int vsscanf(FAR char *buf, FAR const char *fmt, va_list ap)
   noassign = false;
   lflag    = false;
 
-  while (*fmt && *buf)
+  while ((*fmt && *buf) || (*fmt == '%' || *fmt == 'n' || isspace(*fmt)))
     {
       /* Skip over white space */
 


### PR DESCRIPTION
A %n was ignored in sscanf, so the multicopter mixer wasn't parsed correctly.
This is happening because
    while (*fmt && *buf)
stopped when the buffer is empty but *fmt still contains the %n

Please check, if the fix makes sense.

Thanks go to Richard who travelled all the way from Zurich to San Diego just to help me!
