### PR TITLE
Silence MS5611 driver, the perf command still captures the error count /...

### DIFF
--- a/apps/drivers/ms5611/ms5611.cpp
+++ b/apps/drivers/ms5611/ms5611.cpp
@@ -595,7 +595,7 @@ MS5611::cycle()
 				 * spam the console with the message.
 				 */
 			} else {
-				log("collection error %d", ret);
+				//log("collection error %d", ret);
 			}
 			/* reset the collection state machine and try again */
 			start_cycle();
@@ -627,7 +627,7 @@ MS5611::cycle()
 	/* measurement phase */
 	ret = measure();
 	if (ret != OK) {
-		log("measure error %d", ret);
+		//log("measure error %d", ret);
 		/* reset the collection state machine and try again */
 		start_cycle();
 		return;


### PR DESCRIPTION
... rate. Unfortunately this is necessary as general users are concerned about something that is (at a reasonable rate) not actual safety critical and seems part of the normal behavior of this particular sensor.
