### PR TITLE
Stop the servo suddenly jumping when it goes out of the deadzone in one direction

### DIFF
--- a/apps/px4io/controls.c
+++ b/apps/px4io/controls.c
@@ -177,7 +177,7 @@ controls_tick() {
 					scaled = 10000.0f * ((raw - conf[PX4IO_P_RC_CONFIG_CENTER] - conf[PX4IO_P_RC_CONFIG_DEADZONE]) / (float)(conf[PX4IO_P_RC_CONFIG_MAX] - conf[PX4IO_P_RC_CONFIG_CENTER] - conf[PX4IO_P_RC_CONFIG_DEADZONE]));
 
 				} else if (raw < (conf[PX4IO_P_RC_CONFIG_CENTER] - conf[PX4IO_P_RC_CONFIG_DEADZONE])) {
-					scaled = 10000.0f * ((raw - conf[PX4IO_P_RC_CONFIG_CENTER] - conf[PX4IO_P_RC_CONFIG_DEADZONE]) / (float)(conf[PX4IO_P_RC_CONFIG_CENTER] - conf[PX4IO_P_RC_CONFIG_DEADZONE] - conf[PX4IO_P_RC_CONFIG_MIN]));
+					scaled = 10000.0f * ((raw - conf[PX4IO_P_RC_CONFIG_CENTER] + conf[PX4IO_P_RC_CONFIG_DEADZONE]) / (float)(conf[PX4IO_P_RC_CONFIG_CENTER] - conf[PX4IO_P_RC_CONFIG_DEADZONE] - conf[PX4IO_P_RC_CONFIG_MIN]));
 
 				} else {
 					/* in the configured dead zone, output zero */


### PR DESCRIPTION
Servo value normalisation should result in a value between -1 and 1. This fixes an issue where the numerator can be larger than the denominator resulting in a value > 1 when raw servo values are at their minimum value. The side effect of this is that there is a noticeable jump in the scaled value when moving the servo in one direction resulting in a sudden servo arm jump.

The calculation can be verified by considering a raw = 1000 and a raw = 2000 with center = 1500 and deadzone = 50. Prior to this change you would end up with a 1000 - 1500 - 50 / 1500 - 1000 - 50 = -550 / 450.
