### PR TITLE
Play SOS if the SD card can't be mounted

### DIFF
--- a/ROMFS/scripts/rcS
+++ b/ROMFS/scripts/rcS
@@ -21,9 +21,9 @@ set MODE autostart
 set USB autoconnect
 
 #
-# Start playing the startup tune
+
 #
-tone_alarm start
+
 
 #
 # Try to mount the microSD card.
@@ -32,8 +32,12 @@ echo "[init] looking for microSD..."
 if mount -t vfat /dev/mmcsd0 /fs/microsd
 then
 	echo "[init] card mounted at /fs/microsd"
+	# Start playing the startup tune
+	tone_alarm start
 else
 	echo "[init] no microSD card found"
+	# Play SOS
+	tone_alarm 2
 fi
 
 #


### PR DESCRIPTION
Sometimes people's board don't seem to function correctly but it's just the SD card that can't be mounted. 
So what about notifying them using an alarm?
