### PR TITLE
Set gyro to 500 deg/s range

### DIFF
--- a/apps/sensors/sensors.cpp
+++ b/apps/sensors/sensors.cpp
@@ -744,6 +744,9 @@ Sensors::gyro_init()
 		/* set the driver to poll at 500Hz */
 		ioctl(fd, SENSORIOCSPOLLRATE, 500);
 
+		/* set the gyro to 500 deg/s range */
+		ioctl(fd, GYROIOCSRANGE, 500);
+
 		warnx("using system gyro");
 		close(fd);
 	}


### PR DESCRIPTION
This enables a higher accuracy, 2000deg/s is not really required for 95% of applications.
