### PR TITLE
Implement 'binddsm' px4io parameter

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -115,6 +115,12 @@ ORB_DECLARE(output_pwm);
 /** clear the 'ARM ok' bit, which deactivates the safety switch */
 #define PWM_SERVO_CLEAR_ARM_OK	_IOC(_PWM_SERVO_BASE, 6)
 
+/** start DSM bind */
+#define PWM_DSM_BIND_START	_IOC(_PWM_SERVO_BASE, 7)
+
+/** stop DSM bind */
+#define PWM_DSM_BIND_STOP	_IOC(_PWM_SERVO_BASE, 8)
+
 /** set a single servo to a specific value */
 #define PWM_SERVO_SET(_servo)	_IOC(_PWM_SERVO_BASE, 0x20 + _servo)
 

--- a/src/modules/px4iofirmware/dsm.c
+++ b/src/modules/px4iofirmware/dsm.c
@@ -40,10 +40,12 @@
  */
 
 #include <nuttx/config.h>
+#include <nuttx/arch.h>
 
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
+#include <string.h>
 
 #include <drivers/drv_hrt.h>
 
@@ -73,11 +75,15 @@ static bool dsm_decode(hrt_abstime now, uint16_t *values, uint16_t *num_values);
 int
 dsm_init(const char *device)
 {
-	if (dsm_fd < 0)
+	if (dsm_fd < 0) {
 		dsm_fd = open(device, O_RDONLY | O_NONBLOCK);
+	}
 
 	if (dsm_fd >= 0) {
 		struct termios t;
+
+		/* power on the DSM satellite */
+		POWER_RELAY1(1);
 
 		/* 115200bps, no parity, one stop bit */
 		tcgetattr(dsm_fd, &t);
@@ -99,6 +105,45 @@ dsm_init(const char *device)
 	}
 
 	return dsm_fd;
+}
+
+void
+dsm_bind(uint16_t cmd)
+{
+	const uint32_t usart0RxAsOutp = GPIO_OUTPUT|GPIO_CNF_OUTPP|GPIO_MODE_50MHz|GPIO_OUTPUT_SET|GPIO_PORTA|GPIO_PIN10;
+	switch (cmd) {
+	case dsm_bind_power_down:
+		if (dsm_fd >= 0) {
+			// power down DSM satellite
+			POWER_RELAY1(0);
+		}
+		break;
+	case dsm_bind_power_up:
+		if (dsm_fd >= 0) {
+			POWER_RELAY1(1);		}
+		break;
+	case dsm_bind_set_rx_out:
+		if (dsm_fd >= 0) {
+			stm32_configgpio(usart0RxAsOutp);
+		}
+		break;
+	case dsm_bind_set_rx_pulse:
+		if (dsm_fd >= 0) {
+			for (int i = 0; i < 3; i++) {
+				stm32_gpiowrite(usart0RxAsOutp, false);
+				up_udelay(50);
+				stm32_gpiowrite(usart0RxAsOutp, true);
+				up_udelay(50);
+			}
+		}
+		break;
+	case dsm_bind_reinit_uart:
+		if (dsm_fd >= 0) {
+			// Restore USART rx pin
+			stm32_configgpio(GPIO_USART1_RX);
+		}
+		break;
+	}
 }
 
 bool

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -157,6 +157,14 @@
 #define PX4IO_P_SETUP_PWM_ALTRATE		4	/* 'high' PWM frame output rate in Hz */
 #define PX4IO_P_SETUP_RELAYS			5	/* bitmask of relay/switch outputs, 0 = off, 1 = on */
 #define PX4IO_P_SETUP_VBATT_SCALE		6	/* battery voltage correction factor (float) */
+#define PX4IO_P_SETUP_DSM		        7	/* DSM bind state */
+enum {                                      /* DSM bind states */
+	dsm_bind_power_down = 0,
+	dsm_bind_power_up,
+	dsm_bind_set_rx_out,
+	dsm_bind_set_rx_pulse,
+	dsm_bind_reinit_uart
+};
 #define PX4IO_P_SETUP_SET_DEBUG			9	/* debug level for IO board */
 
 /* autopilot control values, -10000..10000 */

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -184,6 +184,7 @@ extern void	controls_init(void);
 extern void	controls_tick(void);
 extern int	dsm_init(const char *device);
 extern bool	dsm_input(uint16_t *values, uint16_t *num_values);
+extern void     dsm_bind(uint16_t cmd);
 extern int	sbus_init(const char *device);
 extern bool	sbus_input(uint16_t *values, uint16_t *num_values);
 

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -360,6 +360,10 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			isr_debug(0, "set debug %u\n", (unsigned)r_page_setup[PX4IO_P_SETUP_SET_DEBUG]);
 			break;
 
+		case PX4IO_P_SETUP_DSM:
+			dsm_bind(value);
+			break;
+
 		default:
 			return -1;
 		}


### PR DESCRIPTION
Implement 'binddsm' px4io parameter. Supports binding of DSM satellite receiver connected to PX4IO board with power line (red wire) switched via relay 1.
