### PR TITLE
fixed CAN pin definitions to PB13 and PB12

### DIFF
--- a/nuttx-configs/px4fmu-v1/include/board.h
+++ b/nuttx-configs/px4fmu-v1/include/board.h
@@ -252,8 +252,8 @@
  * CAN2 is routed to the expansion connector.
  */
 
-#define GPIO_CAN2_RX	GPIO_CAN2_RX_2
-#define GPIO_CAN2_TX	GPIO_CAN2_TX_2
+#define GPIO_CAN2_RX	GPIO_CAN2_RX_1
+#define GPIO_CAN2_TX	GPIO_CAN2_TX_1
 
 /*
  * I2C


### PR DESCRIPTION
Port mapping fix for CAN2 connected to RB12 and RB13
