### PR TITLE
Fix bug where IO was in override mode for copter 

### DIFF
--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -300,6 +300,8 @@ controls_tick() {
 		} else {
 			r_status_flags &= ~PX4IO_P_STATUS_FLAGS_OVERRIDE;
 		}
+	} else {
+		r_status_flags &= ~PX4IO_P_STATUS_FLAGS_OVERRIDE;
 	}
 }
 


### PR DESCRIPTION
(workaround was to disconnect and reconnect Rx)

Should resolve the issue discussed here:
https://groups.google.com/forum/#!topic/px4users/FBr065pWO5c
