### PR TITLE
Flesh out PX4IO documentation comments and delete unnecessary class var

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1667,7 +1667,8 @@ PX4IO::ioctl(file * /*filep*/, int cmd, unsigned long arg)
 }
 
 ssize_t
-PX4IO::write(file */*filp*/, const char *buffer, size_t len)
+PX4IO::write(file * /*filp*/, const char *buffer, size_t len)
+/* Make it obvious that file * isn't used here */
 {
 	unsigned count = len / 2;
 


### PR DESCRIPTION
Armed status was already held locally, no need for a separate variable.

Document more PX4IO privates and statics even if Doxygen is configured to ignore them.
