### PR TITLE
Allow mixer upload when PWM is on

### DIFF
--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -358,8 +358,8 @@ static unsigned mixer_text_length = 0;
 void
 mixer_handle_text(const void *buffer, size_t length)
 {
-	/* do not allow a mixer change while outputs armed */
-	if ((r_status_flags & PX4IO_P_STATUS_FLAGS_OUTPUTS_ARMED)) {
+	/* do not allow a mixer change while safety off */
+	if ((r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)) {
 		return;
 	}
 


### PR DESCRIPTION
This solves the bug:

```
<px4io> mixer rejected by IO
mixer: error loading mixers from /etc/mixers/FMU_quad_x.mix: Invalid argument
```

Since the outputs are "armed" when after an idle PWM is sent, the mixer wont arrive. Therefore I think it makes more sense to check if the safety is off or not.
