### PR TITLE
Workaround to prevent crash during mag calibration

### DIFF
--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -962,11 +962,12 @@ int HMC5883::calibrate(struct file *filp, unsigned enable)
 	warnx("sampling 500 samples for scaling offset");
 
 	/* set the queue depth to 10 */
-	if (OK != ioctl(filp, SENSORIOCSQUEUEDEPTH, 10)) {
-		warn("failed to set queue depth");
-		ret = 1;
-		goto out;
-	}
+	/* don't do this for now, it can lead to a crash in start() respectively work_queue() */
+//	if (OK != ioctl(filp, SENSORIOCSQUEUEDEPTH, 10)) {
+//		warn("failed to set queue depth");
+//		ret = 1;
+//		goto out;
+//	}
 
 	/* start the sensor polling at 50 Hz */
 	if (OK != ioctl(filp, SENSORIOCSPOLLRATE, 50)) {


### PR DESCRIPTION
This seems to resolve #378.
