### PR TITLE
easystar startup script: load mixer from sd-card if available

### DIFF
--- a/ROMFS/px4fmu_common/init.d/100_mpx_easystar
+++ b/ROMFS/px4fmu_common/init.d/100_mpx_easystar
@@ -69,7 +69,14 @@ att_pos_estimator_ekf start
 #
 # Load mixer and start controllers (depends on px4io)
 #
-mixer load /dev/pwm_output /etc/mixers/FMU_RET.mix
+if [ -f /fs/microsd/etc/mixers/FMU_RET.mix ]
+then
+	echo "Using FMU_RET mixer from sd card"
+	mixer load /dev/pwm_output /fs/microsd/etc/mixers/FMU_RET.mix
+else
+	echo "Using standard FMU_RET mixer"
+	mixer load /dev/pwm_output /etc/mixers/FMU_RET.mix
+fi
 fw_att_control start
 # Not ready yet for prime-time
 #fw_pos_control_l1 start


### PR DESCRIPTION
is this a good idea? If yes, this can be added to the other scripts too
