### PR TITLE
PX4IO_CONTROL_CHANNELS and PX4IO_INPUT_CHANNELS redundant

### DIFF
--- a/src/modules/px4iofirmware/dsm.c
+++ b/src/modules/px4iofirmware/dsm.c
@@ -355,7 +355,7 @@ dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values)
 			continue;
 
 		/* ignore channels out of range */
-		if (channel >= PX4IO_INPUT_CHANNELS)
+		if (channel >= PX4IO_CONTROL_CHANNELS)
 			continue;
 
 		/* update the decoded channel count */
@@ -370,7 +370,7 @@ dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values)
 
 		/*
 		 * Store the decoded channel into the R/C input buffer, taking into
-		 * account the different ideas about channel assignement that we have.
+		 * account the different ideas about channel assignment that we have.
 		 *
 		 * Specifically, the first four channels in rc_channel_data are roll, pitch, thrust, yaw,
 		 * but the first four channels from the DSM receiver are thrust, roll, pitch, yaw.
@@ -390,8 +390,6 @@ dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values)
 		default:
 			break;
 		}
-
-		values[channel] = value;
 	}
 
 	if (dsm_channel_shift == 11) {

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -51,7 +51,6 @@
  */
 #define PX4IO_SERVO_COUNT		8
 #define PX4IO_CONTROL_CHANNELS		8
-#define PX4IO_INPUT_CHANNELS		8 // XXX this should be 18 channels
 
 /*
  * Debug logging

--- a/src/modules/px4iofirmware/sbus.c
+++ b/src/modules/px4iofirmware/sbus.c
@@ -239,7 +239,7 @@ sbus_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, uint
 	}
 
 	/* decode switch channels if data fields are wide enough */
-	if (PX4IO_INPUT_CHANNELS > 17 && chancount > 15) {
+	if (PX4IO_CONTROL_CHANNELS > 17 && chancount > 15) {
 		chancount = 18;
 
 		/* channel 17 (index 16) */


### PR DESCRIPTION
PX4IO_CONTROL_CHANNELS and PX4IO_INPUT_CHANNELS #defines both mean the
same thing. Use one and delete the other to avoid errors.
