### PR TITLE
missionlib: Added geo.h include, 

### DIFF
--- a/src/modules/mavlink/missionlib.c
+++ b/src/modules/mavlink/missionlib.c
@@ -64,6 +64,7 @@
 #include <systemlib/systemlib.h>
 #include <mavlink/mavlink_log.h>
 
+#include "geo/geo.h"
 #include "waypoints.h"
 #include "orb_topics.h"
 #include "missionlib.h"


### PR DESCRIPTION
without this the _wrap_pi function returned garbage (e.g. for the yaw setpoint in auto)
