### PR TITLE
IRIS PWM range

### DIFF
--- a/ROMFS/px4fmu_common/init.d/16_3dr_iris
+++ b/ROMFS/px4fmu_common/init.d/16_3dr_iris
@@ -67,8 +67,7 @@ pwm rate -c 1234 -r 400
 # Set disarmed, min and max PWM signals
 #
 pwm disarmed -c 1234 -p 900
-pwm min -c 1234 -p 1200
-pwm max -c 1234 -p 1800
+pwm min -c 1234 -p 1050
 
 #
 # Start common for all multirotors apps


### PR DESCRIPTION
- Don't limit the PWM output maximum for the IRIS to use the whole thrust range
- Slow down the minimum

This works reasonable after esc_calib has been used on the IRIS.
