### PR TITLE
Hotfix Hex Startup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/12-13_hex
+++ b/ROMFS/px4fmu_common/init.d/12-13_hex
@@ -78,7 +78,7 @@ mixer load /dev/pwm_output /etc/mixers/FMU_hex_x.mix
 #
 # Set PWM output frequency to 400 Hz
 #
-pwm rate -c 123456 -r 400
+pwm rate -a -r 400
 
 #
 # Set disarmed, min and max PWM signals


### PR DESCRIPTION
Set rate of all 8 PWM outputs (6 are not possible because rate can only be changed for channel groups.

Tested on FMUv2, should work fine everywhere though.
