### PR TITLE
Python uploader: Ignore exceptions when sending reboot tries

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -370,14 +370,17 @@ class uploader(object):
                 self.port.close()
                 
         def send_reboot(self):
-                # try reboot via NSH first
-                self.__send(uploader.NSH_INIT)
-                self.__send(uploader.NSH_REBOOT_BL)
-                self.__send(uploader.NSH_INIT)
-                self.__send(uploader.NSH_REBOOT)
-                # then try MAVLINK command
-                self.__send(uploader.MAVLINK_REBOOT_ID1)
-                self.__send(uploader.MAVLINK_REBOOT_ID0)
+                try:
+                    # try reboot via NSH first
+                    self.__send(uploader.NSH_INIT)
+                    self.__send(uploader.NSH_REBOOT_BL)
+                    self.__send(uploader.NSH_INIT)
+                    self.__send(uploader.NSH_REBOOT)
+                    # then try MAVLINK command
+                    self.__send(uploader.MAVLINK_REBOOT_ID1)
+                    self.__send(uploader.MAVLINK_REBOOT_ID0)
+                except:
+                    return
                 
                 
 


### PR DESCRIPTION
This fixes the exception error which occurs when you press the reset button on the FMU while python tries to send reboot commands.

Tested on Ubuntu (python2.7)
