### PR TITLE
Update Phantom FPV (FX-61) defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/31_io_phantom
+++ b/ROMFS/px4fmu_common/init.d/31_io_phantom
@@ -8,30 +8,35 @@ echo "[init] PX4FMU v1, v2 with or without IO on Phantom FPV"
 if param compare SYS_AUTOCONFIG 1
 then
 	# Set all params here, then disable autoconfig
+	param set FW_AIRSPD_MIN 11.4
+	param set FW_AIRSPD_TRIM 14
+	param set FW_AIRSPD_MAX 22
+	param set FW_L1_PERIOD 15
 	param set FW_P_D 0
 	param set FW_P_I 0
 	param set FW_P_IMAX 15
-	param set FW_P_LIM_MAX 50
-	param set FW_P_LIM_MIN -50
+	param set FW_P_LIM_MAX 45
+	param set FW_P_LIM_MIN -45
 	param set FW_P_P 60
 	param set FW_P_RMAX_NEG 0
 	param set FW_P_RMAX_POS 0
-	param set FW_P_ROLLFF 1.1
+	param set FW_P_ROLLFF 2
 	param set FW_R_D 0
 	param set FW_R_I 5
-	param set FW_R_IMAX 20
-	param set FW_R_P 100
-	param set FW_R_RMAX 100
-	param set FW_THR_CRUISE 0.65
+	param set FW_R_IMAX 15
+	param set FW_R_P 80
+	param set FW_R_RMAX 60
+	param set FW_THR_CRUISE 0.8
+	param set FW_THR_LND_MAX 0
 	param set FW_THR_MAX 1
-	param set FW_THR_MIN 0
+	param set FW_THR_MIN 0.5
 	param set FW_T_SINK_MAX 5.0
-	param set FW_T_SINK_MIN 4.0
-	param set FW_Y_ROLLFF 1.1
-	param set FW_L1_PERIOD 17
-	param set RC_SCALE_ROLL 1.0
-	param set RC_SCALE_PITCH 1.0
-	
+	param set FW_T_SINK_MIN 2.0
+	param set FW_Y_ROLLFF 1.0
+	param set RC_SCALE_ROLL 0.6
+	param set RC_SCALE_PITCH 0.6
+	param set TRIM_PITCH 0.1
+
 	param set SYS_AUTOCONFIG 0
 	param save
 fi


### PR DESCRIPTION
Updated defaults following test flights a few weeks ago that included autostart and land.
