### PR TITLE
ESC calib: low PWM value was not set

### DIFF
--- a/src/systemcmds/esc_calib/esc_calib.c
+++ b/src/systemcmds/esc_calib/esc_calib.c
@@ -148,6 +148,7 @@ esc_calib_main(int argc, char *argv[])
 
 		case 'l':
 			/* Read in custom low value */
+			pwm_low = strtoul(optarg, &ep, 0);
 			if (*ep != '\0' || pwm_low < PWM_LOWEST_MIN || pwm_low > PWM_HIGHEST_MIN)
 				usage("low PWM invalid");
 			break;


### PR DESCRIPTION
Mistake raised in issue #572.
