### PR TITLE
Fmuv1 ram cleanup

### DIFF
--- a/src/modules/position_estimator_inav/position_estimator_inav_main.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.c
@@ -133,7 +133,7 @@ int position_estimator_inav_main(int argc, char *argv[])
 
 		thread_should_exit = false;
 		position_estimator_inav_task = task_spawn_cmd("position_estimator_inav",
-					       SCHED_RR, SCHED_PRIORITY_MAX - 5, 3000,
+					       SCHED_RR, SCHED_PRIORITY_MAX - 5, 4096,
 					       position_estimator_inav_thread_main,
 					       (argv) ? (const char **) &argv[2] : (const char **) NULL);
 		exit(0);


### PR DESCRIPTION
I've tested the position_estimator_inav from master using 3000 successfully, so I'm assuming it should work in beta as well.

Since the sdlog2 is logging slower on FMUv1 anyway, a buffer of 8000 bytes should be fine. Tested on bench.
