### PR TITLE
startup: phantom script was missing the default line

### DIFF
--- a/ROMFS/px4fmu_common/init.d/3031_phantom
+++ b/ROMFS/px4fmu_common/init.d/3031_phantom
@@ -5,4 +5,6 @@
 # Simon Wilks <sjwilks@gmail.com>
 #
 
+sh /etc/init.d/rc.fw_defaults
+
 set MIXER FMU_Q


### PR DESCRIPTION
This was needed to make the phantom fly.
