### PR TITLE
Log fetcher utility

### DIFF
--- a/Tools/fetch_log.py
+++ b/Tools/fetch_log.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+############################################################################
+#
+#   Copyright (C) 2012, 2013 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#
+# Log fetcher
+#
+# Print list of logs:
+#     python fetch_log.py
+#
+# Fetch log:
+#     python fetch_log.py sess001/log001.bin
+#
+
+import serial, time, sys, os
+
+def wait_for_string(ser, s, timeout=1.0, debug=False):
+    t0 = time.time()
+    buf = []
+    res = []
+    n = 0
+    while (True):
+        c = ser.read()
+        if debug:
+            sys.stderr.write(c)
+        buf.append(c)
+        if len(buf) > len(s):
+            res.append(buf.pop(0))
+            n += 1
+            if n % 10000 == 0:
+                sys.stderr.write(str(n) + "\n")
+        if "".join(buf) == s:
+            break
+        if timeout > 0.0 and time.time() - t0 > timeout:
+            raise Exception("Timeout while waiting for: " + s)
+    return "".join(res)
+
+def exec_cmd(ser, cmd, timeout):
+    ser.write(cmd + "\n")
+    ser.flush()
+    wait_for_string(ser, cmd + "\r\n", timeout)
+    return wait_for_string(ser, "nsh> \x1b[K", timeout)
+
+def ls_dir(ser, dir, timeout=1.0):
+    res = []
+    for line in exec_cmd(ser, "ls -l " + dir, timeout).splitlines()[1:]:
+        res.append((line[20:], int(line[11:19].strip()), line[1] == "d"))
+    return res
+
+def list_logs(ser):
+    logs_dir = "/fs/microsd/log"
+    res = []
+    for d in ls_dir(ser, logs_dir):
+        if d[2]:
+            sess_dir = d[0][:-1]
+            for f in ls_dir(ser, logs_dir + "/" + sess_dir):
+                log_file = f[0]
+                log_size = f[1]
+                res.append(sess_dir + "/" + log_file + "\t" + str(log_size))
+    return "\n".join(res)
+
+def fetch_log(ser, fn, timeout):
+    cmd = "dumpfile " + fn
+    ser.write(cmd + "\n")
+    ser.flush()
+    wait_for_string(ser, cmd + "\r\n", timeout, True)
+    res = wait_for_string(ser, "\n", timeout, True)
+    data = []
+    if res.startswith("OK"):
+        size = int(res.split()[1])
+        n = 0
+        print "Reading data:"
+        while (n < size):
+            buf = ser.read(min(size - n, 8192))
+            data.append(buf)
+            n += len(buf)
+            sys.stdout.write(".")
+            sys.stdout.flush()
+        print
+    else:
+        raise Exception("Error reading log")
+    wait_for_string(ser, "nsh> \x1b[K", timeout)
+    return "".join(data)
+
+def main():
+    dev = "/dev/tty.usbmodem1"
+    ser = serial.Serial(dev, "115200", timeout=0.2)
+    if len(sys.argv) < 2:
+        print list_logs(ser)
+    else:
+        log_file = sys.argv[1]
+        data = fetch_log(ser, "/fs/microsd/log/" + log_file, 1.0)
+        try:
+            os.mkdir(log_file.split("/")[0])
+        except:
+            pass
+        fout = open(log_file, "wb")
+        fout.write(data)
+        fout.close()
+    ser.close()
+
+if __name__ == "__main__":
+    main()

--- a/makefiles/config_px4fmu-v1_default.mk
+++ b/makefiles/config_px4fmu-v1_default.mk
@@ -56,6 +56,7 @@ MODULES		+= systemcmds/tests
 MODULES		+= systemcmds/config
 MODULES		+= systemcmds/nshterm
 MODULES		+= systemcmds/hw_ver
+MODULES		+= systemcmds/dumpfile
 
 #
 # General system control

--- a/makefiles/config_px4fmu-v2_default.mk
+++ b/makefiles/config_px4fmu-v2_default.mk
@@ -63,6 +63,7 @@ MODULES		+= systemcmds/config
 MODULES		+= systemcmds/nshterm
 MODULES		+= systemcmds/mtd
 MODULES		+= systemcmds/hw_ver
+MODULES		+= systemcmds/dumpfile
 
 #
 # General system control

--- a/src/systemcmds/dumpfile/dumpfile.c
+++ b/src/systemcmds/dumpfile/dumpfile.c
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2014 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file dumpfile.c
+ *
+ * Dump file utility. Prints file size and contents in binary mode (don't replace LF with CR LF) to stdout.
+ *
+ * @author Anton Babushkin <anton.babushkin@me.com>
+ */
+
+#include <nuttx/config.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <termios.h>
+
+#include <systemlib/err.h>
+
+__EXPORT int dumpfile_main(int argc, char *argv[]);
+
+int
+dumpfile_main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		errx(1, "usage: dumpfile <filename>");
+	}
+
+	/* open input file */
+	FILE *f;
+	f = fopen(argv[1], "r");
+
+	if (f == NULL) {
+		printf("ERROR\n");
+		exit(1);
+	}
+
+	/* get file size */
+	fseek(f, 0L, SEEK_END);
+	int size = ftell(f);
+	fseek(f, 0L, SEEK_SET);
+
+	printf("OK %d\n", size);
+
+	/* configure stdout */
+	int out = fileno(stdout);
+
+	struct termios tc;
+	struct termios tc_old;
+	tcgetattr(out, &tc);
+
+	/* save old terminal attributes to restore it later on exit */
+	memcpy(&tc_old, &tc, sizeof(tc));
+
+	/* don't add CR on each LF*/
+	tc.c_oflag &= ~ONLCR;
+
+	if (tcsetattr(out, TCSANOW, &tc) < 0) {
+		warnx("ERROR setting stdout attributes");
+		exit(1);
+	}
+
+	char buf[512];
+	int nread;
+
+	/* dump file */
+	while ((nread = fread(buf, 1, sizeof(buf), f)) > 0) {
+		if (write(out, buf, nread) <= 0) {
+			warnx("error dumping file");
+			break;
+		}
+	}
+
+	fsync(out);
+	fclose(f);
+
+	/* restore old terminal attributes */
+	if (tcsetattr(out, TCSANOW, &tc_old) < 0) {
+		warnx("ERROR restoring stdout attributes");
+		exit(1);
+	}
+
+	return OK;
+}

--- a/src/systemcmds/dumpfile/module.mk
+++ b/src/systemcmds/dumpfile/module.mk
@@ -1,0 +1,41 @@
+############################################################################
+#
+#   Copyright (c) 2014 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#
+# Dump file utility
+#
+
+MODULE_COMMAND	 = dumpfile
+SRCS		 = dumpfile.c
+
+MAXOPTIMIZATION	 = -Os


### PR DESCRIPTION
This simple utility allows to fetch log via nsh console on USB. It uses `ls` and `dumpfile` commands on FMU side. It's first version, not very stable, but works. Only Mac OS supported now (hardcoded tty device), need to add support for other OS, custom devices and make python3-friendly. 

@LorenzMeier, I know, you don't like this approach, but I think it may be useful for somebody (including me). BTW, what is the state of mavlink file transfer?
