### PR TITLE
Iris parameter hotfix: Dropped default gains

### DIFF
--- a/ROMFS/px4fmu_common/init.d/10016_3dr_iris
+++ b/ROMFS/px4fmu_common/init.d/10016_3dr_iris
@@ -10,11 +10,11 @@ sh /etc/init.d/rc.mc_defaults
 if [ $DO_AUTOCONFIG == yes ]
 then
 	# TODO tune roll/pitch separately
-	param set MC_ROLL_P 9.0
+	param set MC_ROLL_P 7.0
 	param set MC_ROLLRATE_P 0.13
 	param set MC_ROLLRATE_I 0.0
 	param set MC_ROLLRATE_D 0.004
-	param set MC_PITCH_P 9.0
+	param set MC_PITCH_P 7.0
 	param set MC_PITCHRATE_P 0.13
 	param set MC_PITCHRATE_I 0.0
 	param set MC_PITCHRATE_D 0.004


### PR DESCRIPTION
Defaults of 9.0 seem excessive for a quad of that size. @DrTon What do you think?
