### PR TITLE
ADC analog airspeed sensor fix.

### DIFF
--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1176,9 +1176,27 @@ Sensors::adc_poll(struct sensor_combined_s &raw)
 
 		if (ret >= (int)sizeof(buf_adc[0])) {
 			for (unsigned i = 0; i < sizeof(buf_adc) / sizeof(buf_adc[0]); i++) {
-				/* Save raw voltage values */
-				if (i < (sizeof(raw.adc_voltage_v)) / sizeof(raw.adc_voltage_v[0])) {
-					raw.adc_voltage_v[i] = buf_adc[i].am_data / (4096.0f / 3.3f);
+			
+				/* Save raw voltage values, channels 10, 11, 13 and 14 */
+				switch((int)buf_adc[i].am_channel){
+				//Reading pin 10
+				case 10:
+					raw.adc_voltage_v[0] = buf_adc[i].am_data / (4096.0f / 3.3f);
+					break;
+				//Reading pin 11
+				case 11:
+					raw.adc_voltage_v[1] = buf_adc[i].am_data / (4096.0f / 3.3f);
+					break;
+				//Reading pin 13
+				case 13:
+					raw.adc_voltage_v[2] = buf_adc[i].am_data / (4096.0f / 3.3f);
+					break;
+				//Reading pin 14
+				case 14:
+					raw.adc_voltage_v[2] = buf_adc[i].am_data / (4096.0f / 3.3f);
+					break;	
+				default:
+					break;
 				}
 
 				/* look for specific channels and process the raw voltage to measurement data */

--- a/src/modules/uORB/topics/sensor_combined.h
+++ b/src/modules/uORB/topics/sensor_combined.h
@@ -99,7 +99,7 @@ struct sensor_combined_s {
 	float baro_pres_mbar;			/**< Barometric pressure, already temp. comp.     */
 	float baro_alt_meter;			/**< Altitude, already temp. comp.                */
 	float baro_temp_celcius;		/**< Temperature in degrees celsius               */
-	float adc_voltage_v[4];			/**< ADC voltages of ADC Chan 10/11/12/13 or -1      */
+	float adc_voltage_v[4];			/**< ADC voltages of ADC Chan 10/11/13/14 or -1      */
 	float mcu_temp_celcius;			/**< Internal temperature measurement of MCU */
 	uint32_t baro_counter;			/**< Number of raw baro measurements taken        */
 


### PR DESCRIPTION
...as the variable struct adc_msg_s buf_adc was only 8 channel long although pin 15 wrote into channel 10.

by extending the struct to a length of 10 (struct adc_msg_s buf_adc[10];), the adc will now contain all necessary information.
This fix will also ensure that line 1224-1251 are actually executed (they where not before).
