### PR TITLE
UART flow control

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -156,6 +156,8 @@ public:
 
 	bool		get_hil_enabled() { return _mavlink_hil_enabled; };
 
+	bool		get_flow_control_enabled() { return _flow_control_enabled; }
+
 	/**
 	 * Handle waypoint related messages.
 	 */
@@ -247,6 +249,8 @@ private:
 
 	char 	*_subscribe_to_stream;
 	float	_subscribe_to_stream_rate;
+
+	bool		_flow_control_enabled;
 
 	/**
 	 * Send one parameter.


### PR DESCRIPTION
This change helps with 3DR radios with the flow control lines and speeds up param transmission considerably. Same for waypoints. Bench, but not range tested.

If the buffer under-runs flow control is disabled after half a second, assuming the RTS / CTS lines are not present or broken (best effort approach).
