### PR TITLE
Remove non-existent parameter from 4008_ardrone startup script.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4008_ardrone
+++ b/ROMFS/px4fmu_common/init.d/4008_ardrone
@@ -23,7 +23,6 @@ then
     param set MC_PITCHRATE_I 0.0
     param set MC_PITCHRATE_D 0.0
     param set MC_YAW_P 1.0
-    param set MC_YAW_D 0.1
     param set MC_YAWRATE_P 0.15
     param set MC_YAWRATE_I 0.0
     param set MC_YAWRATE_D 0.0


### PR DESCRIPTION
See https://groups.google.com/d/msg/px4users/w3tf2eazfwg/NA8RiofaRrwJ

Have the other parameter defaults been tested after re-creating this script in #705 ?
