### PR TITLE
add SYS_USE_IO param

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -108,7 +108,6 @@ then
 	set HIL no
 	set VEHICLE_TYPE none
 	set MIXER none
-	set USE_IO yes
 	set OUTPUT_MODE none
 	set PWM_OUTPUTS none
 	set PWM_RATE none
@@ -128,6 +127,16 @@ then
 		set DO_AUTOCONFIG yes
 	else
 		set DO_AUTOCONFIG no
+	fi
+	
+	#
+	# Set USE_IO flag
+	#
+	if param compare SYS_USE_IO 1
+	then
+		set USE_IO yes
+	else
+		set USE_IO no
 	fi
 		
 	#

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -60,3 +60,14 @@ PARAM_DEFINE_INT32(SYS_AUTOSTART, 0);
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
+
+/**
+ * Set usage of IO board
+ *
+ * Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.
+ *
+ * @min 0
+ * @max 1
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_USE_IO, 1);


### PR DESCRIPTION
This allows using standard start-up scripts in FMU only mode (e.g. the wing wing script)
