### PR TITLE
startup scripts: replace ” by "

### DIFF
--- a/ROMFS/px4fmu_common/init.d/11001_hexa_cox
+++ b/ROMFS/px4fmu_common/init.d/11001_hexa_cox
@@ -2,7 +2,7 @@
 #
 # UNTESTED UNTESTED!
 #
-# Generic 10” Hexa coaxial geometry
+# Generic 10" Hexa coaxial geometry
 #
 # Lorenz Meier <lm@inf.ethz.ch>
 #

--- a/ROMFS/px4fmu_common/init.d/12001_octo_cox
+++ b/ROMFS/px4fmu_common/init.d/12001_octo_cox
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Octo coaxial geometry
+# Generic 10" Octo coaxial geometry
 #
 # Lorenz Meier <lm@inf.ethz.ch>
 #

--- a/ROMFS/px4fmu_common/init.d/4001_quad_x
+++ b/ROMFS/px4fmu_common/init.d/4001_quad_x
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Quad X geometry
+# Generic 10" Quad X geometry
 #
 # Lorenz Meier <lm@inf.ethz.ch>
 #

--- a/ROMFS/px4fmu_common/init.d/5001_quad_+
+++ b/ROMFS/px4fmu_common/init.d/5001_quad_+
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Quad + geometry
+# Generic 10" Quad + geometry
 #
 # Anton Babushkin <anton.babushkin@me.com>
 #

--- a/ROMFS/px4fmu_common/init.d/6001_hexa_x
+++ b/ROMFS/px4fmu_common/init.d/6001_hexa_x
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Hexa X geometry
+# Generic 10" Hexa X geometry
 #
 # Anton Babushkin <anton.babushkin@me.com>
 #

--- a/ROMFS/px4fmu_common/init.d/7001_hexa_+
+++ b/ROMFS/px4fmu_common/init.d/7001_hexa_+
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Hexa + geometry
+# Generic 10" Hexa + geometry
 #
 # Anton Babushkin <anton.babushkin@me.com>
 #

--- a/ROMFS/px4fmu_common/init.d/8001_octo_x
+++ b/ROMFS/px4fmu_common/init.d/8001_octo_x
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Octo X geometry
+# Generic 10" Octo X geometry
 #
 # Anton Babushkin <anton.babushkin@me.com>
 #

--- a/ROMFS/px4fmu_common/init.d/9001_octo_+
+++ b/ROMFS/px4fmu_common/init.d/9001_octo_+
@@ -1,6 +1,6 @@
 #!nsh
 #
-# Generic 10” Octo + geometry
+# Generic 10" Octo + geometry
 #
 # Anton Babushkin <anton.babushkin@me.com>
 #


### PR DESCRIPTION
romfs_pruner doesn't seem to know the inch symbols when used in eclipse, therefore replaced these
