### PR TITLE
uORB Subscription class: save isupdated variable and provide accessor

### DIFF
--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -57,9 +57,8 @@ namespace uORB
 
 bool __EXPORT SubscriptionBase::updated()
 {
-	bool isUpdated = false;
-	orb_check(_handle, &isUpdated);
-	return isUpdated;
+	orb_check(_handle, &_isUpdated);
+	return _isUpdated;
 }
 
 template<class T>

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -65,7 +65,8 @@ public:
 		List<SubscriptionBase *> * list,
 		const struct orb_metadata *meta) :
 		_meta(meta),
-		_handle() {
+		_handle(),
+		_isUpdated(false) {
 		if (list != NULL) list->add(this);
 	}
 	bool updated();
@@ -81,12 +82,14 @@ public:
 // accessors
 	const struct orb_metadata *getMeta() { return _meta; }
 	int getHandle() { return _handle; }
+	bool isUpdated(){ return _isUpdated; }
 protected:
 // accessors
 	void setHandle(int handle) { _handle = handle; }
 // attributes
 	const struct orb_metadata *_meta;
 	int _handle;
+	bool _isUpdated;
 };
 
 /**


### PR DESCRIPTION
This introduces a function to get the `isUpdated` state of a subscription during the last call to `updateParams()`
@jgoppert can you please comment if this breaks one of your intended design patterns?
