### PR TITLE
mavlink: is_published() fix

### DIFF
--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -88,6 +88,7 @@ MavlinkOrbSubscription::update(const hrt_abstime t)
 
 		if (_updated) {
 			orb_copy(_topic, _fd, _data);
+			_published = true;
 			return true;
 		}
 	}


### PR DESCRIPTION
Fixed bug: if update() called before is_published(), then is_published() may return false even if topic was updated.
