### PR TITLE
Move Pauls EKF into a class and instantiate only when / if needed. 

### DIFF
--- a/src/modules/fw_att_pos_estimator/estimator.cpp
+++ b/src/modules/fw_att_pos_estimator/estimator.cpp
@@ -106,7 +106,16 @@ void swap_var(float &d1, float &d2)
     d2 = tmp;
 }
 
-void  AttPosEKF::UpdateStrapdownEquationsNED()
+AttPosEKF::AttPosEKF()
+{
+
+}
+
+AttPosEKF::~AttPosEKF()
+{
+}
+
+void AttPosEKF::UpdateStrapdownEquationsNED()
 {
     Vector3f delVelNav;
     float q00;

--- a/src/modules/fw_att_pos_estimator/estimator.h
+++ b/src/modules/fw_att_pos_estimator/estimator.h
@@ -78,6 +78,10 @@ struct ekf_status_report {
 class AttPosEKF {
 
 public:
+
+    AttPosEKF();
+    ~AttPosEKF();
+
     // Global variables
     float KH[n_states][n_states]; //  intermediate result used for covariance updates
     float KHP[n_states][n_states]; // intermediate result used for covariance updates

--- a/src/modules/fw_att_pos_estimator/fw_att_pos_estimator_main.cpp
+++ b/src/modules/fw_att_pos_estimator/fw_att_pos_estimator_main.cpp
@@ -292,7 +292,7 @@ FixedwingEstimator::FixedwingEstimator() :
 	_initialized(false),
 	_gps_initialized(false),
 	_mavlink_fd(-1),
-	_ekf(new AttPosEKF())
+	_ekf(nullptr)
 {
 
 	_mavlink_fd = open(MAVLINK_LOG_DEVICE, 0);
@@ -395,6 +395,8 @@ float dt = 0.0f; // time lapsed since last covariance prediction
 void
 FixedwingEstimator::task_main()
 {
+
+	_ekf = new AttPosEKF();
 
 	if (!_ekf) {
 		errx(1, "failed allocating EKF filter - out of RAM!");


### PR DESCRIPTION
Checking for low memory conditions as we should. I'm piping this right now through HIL to ensure it behaves - this fix is pretty critical to free RAM on FMUv1.
