### PR TITLE
mavlink: Change to size optimization

### DIFF
--- a/src/modules/mavlink/module.mk
+++ b/src/modules/mavlink/module.mk
@@ -46,3 +46,5 @@ SRCS		 += mavlink_main.cpp \
 			mavlink_commands.cpp
 
 INCLUDE_DIRS	 += $(MAVLINK_SRC)/include/mavlink
+
+MAXOPTIMIZATION		 = -Os


### PR DESCRIPTION
@thomasgubler: I think it makes sense to merge this to our WIP. I've flown this today successfully and it saves a ton of flash. Note that Tridge also runs mavlink in -Os mode.
