### PR TITLE
Hotfix to PX4IO uploader. There are no known mishaps due to it, but very...

### DIFF
--- a/src/drivers/px4io/px4io_uploader.cpp
+++ b/src/drivers/px4io/px4io_uploader.cpp
@@ -201,9 +201,14 @@ PX4IO_Uploader::upload(const char *filenames[])
 			continue;
 		}
 
-		if (bl_rev <= 2)
+		if (bl_rev <= 2) {
 			ret = verify_rev2(fw_size);
-		else if(bl_rev == 3) {
+		} else if(bl_rev == 3) {
+			ret = verify_rev3(fw_size);
+		} else {
+			/* verify rev 4 and higher still uses the same approach and
+			 * every version *needs* to be verified.
+			 */
 			ret = verify_rev3(fw_size);
 		}
 


### PR DESCRIPTION
... clearly the IO firmware flashing process should be verified after an upload.

@thomasgubler @julianoes @DrTon this is a critical bugfix and should go in as soon as possible. @tridge You will want to cross test and also merge this as soon as possible and definitely get this into the next release build.
