### PR TITLE
Reduce data manager SD card wear and tear

### DIFF
--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -79,7 +79,7 @@ extern "C" {
 	} dm_reset_reason;
 
 	/* Maximum size in bytes of a single item instance */
-	#define DM_MAX_DATA_SIZE 126
+	#define DM_MAX_DATA_SIZE 124
 
 	/* Retrieve from the data manager store */
 	__EXPORT ssize_t


### PR DESCRIPTION
When the data manager was first designed each file record contained a 2 byte header and an 126 byte data section, resulting in a record length of 128 bytes. Along the way it was decided to add 2 spare bytes to the record header, but regrettably the data section was not correspondingly reduced in size so we end up with a record length of 130 bytes. This is bad since it does not align with SD card flash sectors and results in more erase/write flash cycles than necessary thus reducing the SD cards life.

This update reduced the data section of the data manager to 124, resulting in an optimal record length of 128 bytes. Current use of data manager stored items is well below this new 124 byte data size limit.

In order to avoid the reuse of data previously written in the old format, which could result in catastrophic misinterpretation, the data manager file is checked at startup. If it is found to be in the old format, it is deleted and recreated with in the new record length. In this case previously stored data is lost, but that is far safer than the unpredictable result of using the old file interpreted in the new format.
