### PR TITLE
Proper data manager restart handling

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -91,6 +91,8 @@
 
 #include "uploader.h"
 
+#include "modules/dataman/dataman.h"
+
 extern device::Device *PX4IO_i2c_interface() weak_function;
 extern device::Device *PX4IO_serial_interface() weak_function;
 
@@ -568,8 +570,14 @@ int
 PX4IO::init()
 {
 	int ret;
+	param_t sys_restart_param;
+	int sys_restart_val = DM_INIT_REASON_VOLATILE;
 
 	ASSERT(_task == -1);
+
+	sys_restart_param = param_find("SYS_RESTART_TYPE");
+	/* Indicate restart type is unknown */
+	param_set(sys_restart_param, &sys_restart_val);
 
 	/* do regular cdev init */
 	ret = CDev::init();
@@ -720,6 +728,11 @@ PX4IO::init()
 			/* keep waiting for state change for 2 s */
 		} while (!safety.armed);
 
+		/* Indicate restart type is in-flight */
+		sys_restart_val = DM_INIT_REASON_IN_FLIGHT;
+		param_set(sys_restart_param, &sys_restart_val);
+
+
 		/* regular boot, no in-air restart, init IO */
 
 	} else {
@@ -744,6 +757,10 @@ PX4IO::init()
 				return ret;
 			}
 		}
+
+		/* Indicate restart type is power on */
+		sys_restart_val = DM_INIT_REASON_POWER_ON;
+		param_set(sys_restart_param, &sys_restart_val);
 
 	}
 

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -75,7 +75,8 @@ extern "C" {
 	/* The reason for the last reset */
 	typedef enum {
 		DM_INIT_REASON_POWER_ON = 0,	/* Data survives resets */
-		DM_INIT_REASON_IN_FLIGHT	/* Data survives in-flight resets only */
+		DM_INIT_REASON_IN_FLIGHT,		/* Data survives in-flight resets only */
+		DM_INIT_REASON_VOLATILE			/* Data does not survive reset */
 	} dm_reset_reason;
 
 	/* Maximum size in bytes of a single item instance */
@@ -100,7 +101,7 @@ extern "C" {
 		size_t buflen			/* Length in bytes of data to retrieve */
 	);
 
-	/* Retrieve from the data manager store */
+	/* Erase all items of this type */
 	__EXPORT int
 	dm_clear(
 		dm_item_t item			/* The item type to clear */

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -62,12 +62,23 @@ PARAM_DEFINE_INT32(SYS_AUTOSTART, 0);
 PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
 
 /**
- * Set usage of IO board
- *
- * Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.
- *
- * @min 0
- * @max 1
- * @group System
- */
+* Set usage of IO board
+*
+* Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.
+*
+* @min 0
+* @max 1
+* @group System
+*/
 PARAM_DEFINE_INT32(SYS_USE_IO, 1);
+
+/**
+* Set restart type
+*
+* Set by px4io to indicate type of restart
+*
+* @min 0
+* @max 2
+* @group System
+*/
+PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);


### PR DESCRIPTION
Introduce SYS_RESTART_TYPE parameter having one of 3 values: power on restart, inflight restart, or unknown restart, and defaulting to unknown restart.

px4io.cpp sets this parameter according to the type of restart detected.

All data manager items specify a persistence level when they are written. At startup dataman.c retrieves this parameter and clears data entries according to their persistence level. Does nothing if unknown restart. Not sure how px4fmu only controller deals with restarts but it should perhaps also set the SYS_RESTART_TYPE parameter. Presently it does not so the data manager will handle restarts as unknown.
