### PR TITLE
mc_att_control: MC_YAWRATE_MAX parameter added

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -175,6 +175,18 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_D, 0.0f);
 PARAM_DEFINE_FLOAT(MC_YAW_FF, 0.5f);
 
 /**
+ * Max yaw rate
+ *
+ * Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 360.0
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_YAWRATE_MAX, 120.0f);
+
+/**
  * Max manual roll
  *
  * @unit deg


### PR DESCRIPTION
As discussed here: https://github.com/PX4/Firmware/pull/877
Yaw feed forward for manual control bypassed this limiting, because manual control shouldn't be too large to cause mixer saturation.

Tested in HIL, not tested in flight yet.
