### PR TITLE
mavlink: Only sending HIL control commands if the system is actually armed

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -823,7 +823,7 @@ protected:
 		(void)pos_sp_triplet_sub->update(t);
 		(void)status_sub->update(t);
 
-		if (updated && (status.arming_state == ARMING_STATE_ARMED)) {
+		if (updated && (status->arming_state == ARMING_STATE_ARMED)) {
 			/* translate the current syste state to mavlink state and mode */
 			uint8_t mavlink_state;
 			uint8_t mavlink_base_mode;


### PR DESCRIPTION
This fixes confusing results in HIL when the system is outputting actuator controls when the system is actually disarmed and some of the other onboard logic is not initialized properly / still in a disarmed state. This ensures the HIL experience is the same as in the field.
