### PR TITLE
mc.defaults: MPC_TILTMAX_XXX parameters fixed

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -32,9 +32,9 @@ then
 	param set MPC_Z_VEL_D 0.0
 	param set MPC_Z_VEL_MAX 3
 	param set MPC_Z_FF 0.5
-	param set MPC_TILT_MAX 1.0
+	param set MPC_TILTMAX_AIR 45.0
+	param set MPC_TILTMAX_LND 15.0
 	param set MPC_LAND_SPEED 1.0
-	param set MPC_LAND_TILT 0.3
 fi
 
 set PWM_RATE 400


### PR DESCRIPTION
This fixes autoconfig function on all MC setups.

@LorenzMeier, @julianoes, could you please also update parameters on Wiki.
