### PR TITLE
fix code style script: enforce max line width of 120 chars

### DIFF
--- a/Tools/fix_code_style.sh
+++ b/Tools/fix_code_style.sh
@@ -16,5 +16,6 @@ astyle \
     --ignore-exclude-errors-x	\
     --lineend=linux		\
     --exclude=EASTL		\
-    --add-brackets \
+    --add-brackets		\
+    --max-code-length=120	\
     $*


### PR DESCRIPTION
This was briefly discussed by some of the devs on skype and I put it here to open the discussion to everybody. Currently some part of our code contains very long lines which makes it unreadable side by side even on a large monitor. In my opinion it makes sense to enforce a line width limit at least for new code to get this under control.

I selected 120 because we have tabwidth 8 and most (but not all) code fits 120. Also it's a moderate limit compared to 80 and leaves enough room also for people who like to write longer lines.

I don't want to kick off a religious discussion about linewidths and editors. If the general agreement is that we need a standard for this then lets merge it, otherwise I am happy to close this PR.
