### PR TITLE
px4io: Use proper task_spawn_cmd() instead of task_create(), sets schedu...

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -794,7 +794,13 @@ PX4IO::init()
 	}
 
 	/* start the IO interface task */
-	_task = task_create("px4io", SCHED_PRIORITY_ACTUATOR_OUTPUTS, 2048, (main_t)&PX4IO::task_main_trampoline, nullptr);
+	_task = task_create("px4io", SCHED_PRIORITY_ACTUATOR_OUTPUTS, 2000, (main_t)&PX4IO::task_main_trampoline, nullptr);
+	_task = task_spawn_cmd("px4io",
+				       SCHED_DEFAULT,
+				       SCHED_PRIORITY_ACTUATOR_OUTPUTS,
+				       2000,
+				       (main_t)&PX4IO::task_main_trampoline,
+				       nullptr);
 
 	if (_task < 0) {
 		debug("task start failed: %d", errno);


### PR DESCRIPTION
...ling policy we want. This harmonizes the start call to PX4IO to other tasks. It also reduces the stack by 50 bytes, current measurements indicate it consumes less than one K during operation.
