### PR TITLE
makefiles: check for correct arm-none-eabi-gcc version

### DIFF
--- a/makefiles/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/toolchain_gnu-arm-eabi.mk
@@ -50,11 +50,11 @@ OBJDUMP			 = $(CROSSDEV)objdump
 
 # Check if the right version of the toolchain is available
 #
-CROSSDEV_VER_SUPPORTED	 = 4.7.4
+CROSSDEV_VER_SUPPORTED	 = 4.7
 CROSSDEV_VER_FOUND	 = $(shell $(CC) -dumpversion)
 
-ifneq ($(CROSSDEV_VER_SUPPORTED),$(CROSSDEV_VER_FOUND))
-$(error Unsupported version of $(CC), found: $(CROSSDEV_VER_FOUND) instead of $(CROSSDEV_VER_SUPPORTED))
+ifeq (,$(findstring $(CROSSDEV_VER_SUPPORTED),$(CROSSDEV_VER_FOUND)))
+$(error Unsupported version of $(CC), found: $(CROSSDEV_VER_FOUND) instead of $(CROSSDEV_VER_SUPPORTED).x)
 endif
 
 


### PR DESCRIPTION
This checks for the correct, so supported and recommended version of arm-none-eabi-gcc.
This should resolve #989.

Is this the right place to add this?
Do we want to specifically set it to 4.7.4 or only 4.7?
