### PR TITLE
mc mixer: additional safe limiting of mixed out

### DIFF
--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -351,9 +351,9 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		scale_out = 1.0f;
 	}
 
-	/* scale outputs to range _idle_speed..1 */
+	/* scale outputs to range _idle_speed..1, and do final limiting */
 	for (unsigned i = 0; i < _rotor_count; i++) {
-		outputs[i] = _idle_speed + (outputs[i] * (1.0f - _idle_speed) * scale_out);
+		outputs[i] = constrain(_idle_speed + (outputs[i] * (1.0f - _idle_speed) * scale_out), _idle_speed, 1.0f);
 	}
 
 	return _rotor_count;


### PR DESCRIPTION
Fixes error on FMUv1 (cutting outs at full throttle saturation) caused by this lines:
https://github.com/PX4/Firmware/blob/master/src/drivers/px4fmu/fmu.cpp#L652

CRITICAL FIX
Merge ASAP after testing.
Not tested yet, should be tested on FMUv1 and v2 (at least bench) at full thrust.
