### PR TITLE
Magnetometer data is not update

### DIFF
--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -880,7 +880,7 @@ LSM303D::mag_read(struct file *filp, char *buffer, size_t buflen)
 
 	/* manual measurement */
 	_mag_reports->flush();
-	measure();
+	_mag->measure();
 
 	/* measurement will have generated a report, copy it out */
 	if (_mag_reports->get(mrb))


### PR DESCRIPTION
Magnetometer is not updated during a read operation, because the function "lsm303d_mag::measure" is not called.

”!!!JUST A GUESS!!!“
