### PR TITLE
mavlink: count items in dataman storage on startup

### DIFF
--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -51,7 +51,7 @@ extern "C" {
 		DM_KEY_SAFE_POINTS = 0,		/* Safe points coordinates, safe point 0 is home point */
 		DM_KEY_FENCE_POINTS,		/* Fence vertex coordinates */
 		DM_KEY_WAYPOINTS_OFFBOARD_0,	/* Mission way point coordinates sent over mavlink */
-		DM_KEY_WAYPOINTS_OFFBOARD_1,	/* (alernate between 0 and 1) */
+		DM_KEY_WAYPOINTS_OFFBOARD_1,	/* (alternate between 0 and 1) */
 		DM_KEY_WAYPOINTS_ONBOARD,	/* Mission way point coordinates generated onboard */
 		DM_KEY_NUM_KEYS			/* Total number of item types defined */
 	} dm_item_t;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -962,6 +962,17 @@ void Mavlink::mavlink_wpm_init(mavlink_wpm_storage *state)
 	state->timestamp_last_send_request = 0;
 	state->timeout = MAVLINK_WPM_PROTOCOL_TIMEOUT_DEFAULT;
 	state->current_dataman_id = 0;
+
+	/* count items in dataman storage */
+	struct mission_item_s mission_item;
+	ssize_t len = sizeof(struct mission_item_s);
+
+	int seq = 0;
+	while (dm_read(DM_KEY_WAYPOINTS_OFFBOARD_0, seq++, &mission_item, len) == len);
+
+	state->size = seq;
+	mission.count = state->size;
+	mission.dataman_id = state->current_dataman_id;
 }
 
 /*


### PR DESCRIPTION
@LorenzMeier, @julianoes, @thomasgubler, @jean-m-cyr
WIP, not for merging

On mavlink initialization need to read waypoints count in dataman storage to init `_wpm` and `mission` structs. But there are two storages: DM_KEY_WAYPOINTS_OFFBOARD_0 and DM_KEY_WAYPOINTS_OFFBOARD_1, and which should be used NOT saved in dataman.

Now I count always DM_KEY_WAYPOINTS_OFFBOARD_0, but it's not correct. How to do this better?
Possible solutions that I see:
- Clear unused storage once full new mission received: if reboot happens on mission transfer it will be impossible to detect which mission is old, and which is not completed new
- Use storage 0 as main and 1 as temp, at the end of receiving mission copy 1 to 0 and clear 1: some overhead + if reboot happens while copying from 1 to 0 mission will be corrupted

I.e. both ways are non-ideal. But I think we can and must do atomic mission updates properly. Lat's think together how to do this. It looks like need to extend dataman functionality to store not only data itself, but also some metadata, e.g. items count or `in progress` flags.

It looks like nobody actually thought about testing persistent missions yet :(
