### PR TITLE
mc_pos_control, mc_att_control: feed forward attitude rates

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -721,6 +721,10 @@ MulticopterPositionControl::task_main()
 				_att_sp.yaw_body = _att.yaw;
 				_att_sp.thrust = 0.0f;
 
+				_att_sp.rollrate_ff = 0.0f;
+				_att_sp.pitchrate_ff = 0.0f;
+				_att_sp.yawrate_ff = 0.0f;
+
 				_att_sp.timestamp = hrt_absolute_time();
 
 				/* publish attitude setpoint */
@@ -1004,6 +1008,18 @@ MulticopterPositionControl::task_main()
 						_att_sp.pitch_body = euler(1);
 						/* yaw already used to construct rot matrix, but actual rotation matrix can have different yaw near singularity */
 
+						math::Vector<3> rates_ff;
+						if (thrust_abs > SIGMA) {
+							rates_ff = (thrust_sp % vel_err_d) * _params.vel_p(0) / thrust_abs / thrust_abs;
+
+						} else {
+							rates_ff.zero();
+						}
+
+						_att_sp.rollrate_ff = rates_ff(0);
+						_att_sp.pitchrate_ff = rates_ff(1);
+						_att_sp.yawrate_ff = rates_ff(2);
+
 					} else if (!_control_mode.flag_control_manual_enabled) {
 						/* autonomous altitude control without position control (failsafe landing),
 						 * force level attitude, don't change yaw */
@@ -1015,6 +1031,10 @@ MulticopterPositionControl::task_main()
 
 						_att_sp.roll_body = 0.0f;
 						_att_sp.pitch_body = 0.0f;
+
+						_att_sp.rollrate_ff = 0.0f;
+						_att_sp.pitchrate_ff = 0.0f;
+						_att_sp.yawrate_ff = 0.0f;
 					}
 
 					_att_sp.thrust = thrust_abs;

--- a/src/modules/uORB/topics/vehicle_attitude_setpoint.h
+++ b/src/modules/uORB/topics/vehicle_attitude_setpoint.h
@@ -60,6 +60,10 @@ struct vehicle_attitude_setpoint_s {
 	float yaw_body;					/**< body angle in NED frame		*/
 	//float body_valid;				/**< Set to true if body angles are valid */
 
+	float rollrate_ff;				/**< feed forward roll rate in NED frame		*/
+	float pitchrate_ff;				/**< feed forward pitch rate in NED frame		*/
+	float yawrate_ff;				/**< feed forward yaw rate in NED frame		*/
+
 	float R_body[3][3];				/**< Rotation matrix describing the setpoint as rotation from the current body frame */
 	bool R_valid;					/**< Set to true if rotation matrix is valid */
 


### PR DESCRIPTION
One interesting idea about improving position controller performance. Feeding forward attitude rates (we can calculate them with high precision) allows to reduce offset between attitude setpoint and actual setpoint on slow attitude setpoint changes, makes sence for loiter and arriving to waypoint. HIL tests show that D component in velocity controller not needed anymore, i.e. we have -1 parameter and more accurate model of control.

I want to make position controller homogeneous for XY and Z axes, because only difference is that on hovering we have external force vector only along Z. But for fast flight we have also significant air drag forces, so we should have no difference between XY and Z. As result we will have common P and VEL_P / VEL_I parameters for all axes.

Tested in HIL, not tested in flight yet.
