### PR TITLE
Re-added the roll, pitch and yaw offsets to attitude_estimator_ekf

### DIFF
--- a/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -512,10 +512,11 @@ const unsigned int loop_interval_alarm = 6500;	// loop interval in microseconds
 
 					/* send out */
 					att.timestamp = raw.timestamp;
-
-					att.roll = euler[0];
-					att.pitch = euler[1];
-					att.yaw = euler[2] + ekf_params.mag_decl;
+					
+					/* Compensate for fmu placement offsets and magnetic declination */
+					att.roll = euler[0] - ekf_params.roll_off;
+					att.pitch = euler[1] - ekf_params.pitch_off;
+					att.yaw = euler[2] + ekf_params.mag_decl - ekf_params.yaw_off;
 
 					att.rollspeed = x_aposteriori[0];
 					att.pitchspeed = x_aposteriori[1];


### PR DESCRIPTION
These were removed in 61a3177979838649af2a6e8e50bea7d15e2765f4, rendering the ATT_XXX_OFF3 parameters useless. It appears to be an oversight, but if it's a feature then I apologize for the unnecessary pull request.

I personally found them very useful for fine-trimming, and compensating for fmu placement imperfection.
