### PR TITLE
Fix to allow filter correction with vision position estimate

### DIFF
--- a/src/modules/position_estimator_inav/position_estimator_inav_main.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.c
@@ -781,8 +781,8 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 		epv += 0.005 * dt;	// add 1m to EPV each 200s (baro drift)
 
 		/* use GPS if it's valid and reference position initialized */
-		bool use_gps_xy = ref_inited && gps_valid && params.w_xy_gps_p > MIN_VALID_W;
-		bool use_gps_z = ref_inited && gps_valid && params.w_z_gps_p > MIN_VALID_W;
+		bool use_gps_xy = (ref_inited && gps_valid && params.w_xy_gps_p > MIN_VALID_W) || vision_valid;
+		bool use_gps_z = (ref_inited && gps_valid && params.w_z_gps_p > MIN_VALID_W) || vision_valid;
 		/* use flow if it's valid and (accurate or no GPS available) */
 		bool use_flow = flow_valid && (flow_accurate || !use_gps_xy);
 


### PR DESCRIPTION
When I tested the vision_estimate branch with sending vision_position_estimate mavlink messages I noticed the returned local_position_ned position wasn't the same. It appears it wasn't doing the filter correction.

This is my first pull request so hopefully I am doing it correctly.

Also I guess the vision code added https://github.com/PX4/Firmware/pull/1041 was just a quick hack to get the vision_position_estimate to work and will probably need to be written with its own bool use_vision_xy etc.?
