### PR TITLE
Revert "Hotfix: Only orb_copy items in mavlink app if the timestamp changed"

### DIFF
--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -44,8 +44,6 @@
 #include <uORB/uORB.h>
 #include <stdio.h>
 
-#include <systemlib/err.h>
-
 #include "mavlink_orb_subscription.h"
 
 MavlinkOrbSubscription::MavlinkOrbSubscription(const orb_id_t topic) :
@@ -79,23 +77,21 @@ MavlinkOrbSubscription::update(uint64_t *time, void* data)
 		time_topic = 0;
 	}
 
-	if (time_topic != *time) {
-
-		if (orb_copy(_topic, _fd, data)) {
-			/* error copying topic data */
-			memset(data, 0, _topic->o_size);
-			//warnx("err copy, fd: %d, obj: %s, size: %d", _fd, _topic->o_name, _topic->o_size);
-			return false;
-
-		} else {
-			/* data copied successfully */
-			_published = true;
-			*time = time_topic;
-			return true;
-		}
+	if (orb_copy(_topic, _fd, data)) {
+		/* error copying topic data */
+		memset(data, 0, _topic->o_size);
+		return false;
 
 	} else {
-		return false;
+		/* data copied successfully */
+		_published = true;
+		if (time_topic != *time) {
+			*time = time_topic;
+			return true;
+
+		} else {
+			return false;
+		}
 	}
 }
 


### PR DESCRIPTION
This reverts commit a9653fa10db3884d3d17ee33f80f23aa2e3ef842.

As discussed on Skype: with that commit data does not get copied and therefore local copies may be uninitialized.
