### PR TITLE
mavlink: init structs for HEARTBEAT if uORB topic copy failed

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -228,13 +228,13 @@ protected:
 
 		/* always send the heartbeat, independent of the update status of the topics */
 		if (!status_sub->update(&status)) {
-            /* if topic update failed fill it with defaults */
-            memset(&status, 0, sizeof(status));
+			/* if topic update failed fill it with defaults */
+			memset(&status, 0, sizeof(status));
 		}
 
 		if (!pos_sp_triplet_sub->update(&pos_sp_triplet)) {
-            /* if topic update failed fill it with defaults */
-            memset(&pos_sp_triplet, 0, sizeof(pos_sp_triplet));
+			/* if topic update failed fill it with defaults */
+			memset(&pos_sp_triplet, 0, sizeof(pos_sp_triplet));
 		}
 
 		uint8_t mavlink_state = 0;


### PR DESCRIPTION
As discussed in https://github.com/PX4/Firmware/pull/1080
