### PR TITLE
FTP List, Open, Read, Terminate commands working end to end with QGC

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -228,6 +228,9 @@ public:
 	bool			should_transmit() { return (!_wait_to_transmit || (_wait_to_transmit && _received_messages)); }
 
 	bool			message_buffer_write(void *ptr, int size);
+    
+    void lockMessageBufferMutex(void) { pthread_mutex_lock(&_message_buffer_mutex); }
+    void unlockMessageBufferMutex(void) { pthread_mutex_unlock(&_message_buffer_mutex); }
 
 protected:
 	Mavlink			*next;


### PR DESCRIPTION
In combination with this pull: https://github.com/mavlink/qgroundcontrol/pull/733, all of this now works end to end. 

Fixed various bugs. Ran into a bunch of problems with Session handling. I flattened Mavlink::Session class while fixing bugs in this area to make it easier to understand.

Note the significant change in _mavlink_main.cpp where it uses mavlink_resend_uart to send the messages out on the wire from the ring buffer. Previous code was causing bad data to be sent on the wire. Also hardcore review of the mutex changes (also in mavlink_ftp.h) would be helpful.
