### PR TITLE
Fix bugs found by Warnings work

### DIFF
--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -131,8 +131,8 @@ public:
 	int		set_motor_count(unsigned count);
 	int		set_motor_test(bool motortest);
 	int		set_overrideSecurityChecks(bool overrideSecurityChecks);
-	int		set_px4mode(int px4mode);
-	int		set_frametype(int frametype);
+	void	set_px4mode(int px4mode);
+	void	set_frametype(int frametype);
 	unsigned int		mk_check_for_blctrl(unsigned int count, bool showOutput, bool initI2C);
 
 private:
@@ -330,13 +330,13 @@ MK::set_update_rate(unsigned rate)
 	return OK;
 }
 
-int
+void
 MK::set_px4mode(int px4mode)
 {
 	_px4mode = px4mode;
 }
 
-int
+void
 MK::set_frametype(int frametype)
 {
 	_frametype = frametype;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -741,7 +741,7 @@ PX4FMU::task_main()
 	}
 
 	for (unsigned i = 0; i < NUM_ACTUATOR_CONTROL_GROUPS; i++) {
-		if (_control_subs > 0) {
+		if (_control_subs[i] > 0) {
 			::close(_control_subs[i]);
 			_control_subs[i] = -1;
 		}

--- a/src/drivers/roboclaw/RoboClaw.cpp
+++ b/src/drivers/roboclaw/RoboClaw.cpp
@@ -182,7 +182,10 @@ float RoboClaw::getMotorPosition(e_motor motor)
 		return _motor1Position;
 	} else if (motor == MOTOR_2) {
 		return _motor2Position;
-	}
+	} else {
+        warnx("Unknown motor value passed to RoboClaw::getMotorPosition");
+        return NAN;
+    }
 }
 
 float RoboClaw::getMotorSpeed(e_motor motor)
@@ -191,7 +194,10 @@ float RoboClaw::getMotorSpeed(e_motor motor)
 		return _motor1Speed;
 	} else if (motor == MOTOR_2) {
 		return _motor2Speed;
-	}
+	} else {
+        warnx("Unknown motor value passed to RoboClaw::getMotorPosition");
+        return NAN;
+    }
 }
 
 int RoboClaw::setMotorSpeed(e_motor motor, float value)

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -631,6 +631,7 @@ bool handle_command(struct vehicle_status_s *status, const struct safety_s *safe
 		// XXX TODO
 	}
 
+    return ret;
 }
 
 int commander_thread_main(int argc, char *argv[])

--- a/src/modules/ekf_att_pos_estimator/estimator.cpp
+++ b/src/modules/ekf_att_pos_estimator/estimator.cpp
@@ -1986,7 +1986,7 @@ void AttPosEKF::calcposNED(float (&posNED)[3], double lat, double lon, float hgt
     posNED[2] = -(hgt - hgtRef);
 }
 
-void AttPosEKF::calcLLH(float (&posNED)[3], float lat, float lon, float hgt, float latRef, float lonRef, float hgtRef)
+void AttPosEKF::calcLLH(float posNED[3], float &lat, float &lon, float &hgt, float latRef, float lonRef, float hgtRef)
 {
     lat = latRef + posNED[0] * earthRadiusInv;
     lon = lonRef + posNED[1] * earthRadiusInv / cos(latRef);

--- a/src/modules/ekf_att_pos_estimator/estimator.h
+++ b/src/modules/ekf_att_pos_estimator/estimator.h
@@ -301,7 +301,7 @@ static void calcvelNED(float (&velNED)[3], float gpsCourse, float gpsGndSpd, flo
 
 static void calcposNED(float (&posNED)[3], double lat, double lon, float hgt, double latRef, double lonRef, float hgtRef);
 
-static void calcLLH(float (&posNED)[3], float lat, float lon, float hgt, float latRef, float lonRef, float hgtRef);
+static void calcLLH(float posNED[3], float &lat, float &lon, float &hgt, float latRef, float lonRef, float hgtRef);
 
 static void quat2Tnb(Mat3f &Tnb, const float (&quat)[4]);
 

--- a/src/modules/gpio_led/gpio_led.c
+++ b/src/modules/gpio_led/gpio_led.c
@@ -189,7 +189,8 @@ int gpio_led_main(int argc, char *argv[])
 		} else if (!strcmp(argv[1], "stop")) {
 			if (gpio_led_started) {
 				gpio_led_started = false;
-				warnx("stop");
+                // FIXME: Is this correct? changed from warnx
+				errx(0, "stop");
 
 			} else {
 				errx(1, "not running");

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -213,8 +213,8 @@ bool MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size
 		}
 	}
 
-
-//	float slope_alt = wp_altitude + _H0 * expf(-math::max(0.0f, _flare_length - wp_distance)/_flare_constant) - _H1_virt;
+    // FIXME: Should there be some sort of mavlink message here?
+    return false;
 }
 
 void MissionFeasibilityChecker::updateNavigationCapabilities()

--- a/src/modules/px4iofirmware/sbus.c
+++ b/src/modules/px4iofirmware/sbus.c
@@ -119,13 +119,19 @@ sbus_init(const char *device)
 bool
 sbus1_output(uint16_t *values, uint16_t num_values)
 {
-	write(sbus_fd, 'A', 1);
+    // FIXME: I assume this was NYI, not suppossed to be the previous code
+    ssize_t cBytes = num_values * sizeof(values[0]);
+	ssize_t cBytesWritten = write(sbus_fd, values, cBytes);
+    return cBytesWritten == cBytes;
 }
 
 bool
 sbus2_output(uint16_t *values, uint16_t num_values)
 {
-	write(sbus_fd, 'B', 1);
+    // FIXME: I assume this was NYI, not suppossed to be the previous code
+    ssize_t cBytes = num_values * sizeof(values[0]);
+	ssize_t cBytesWritten = write(sbus_fd, values, cBytes);
+    return cBytesWritten == cBytes;
 }
 
 bool

--- a/src/systemcmds/mtd/mtd.c
+++ b/src/systemcmds/mtd/mtd.c
@@ -193,8 +193,12 @@ ramtron_attach(void)
 		errx(1, "failed to initialize mtd driver");
 
 	int ret = mtd_dev->ioctl(mtd_dev, MTDIOC_SETSPEED, (unsigned long)10*1000*1000);
-        if (ret != OK)
-            warnx(1, "failed to set bus speed");
+    if (ret != OK) {
+        // FIXME: From the previous warnx call, it looked like this should have been an errx instead. Tried
+        // that but setting the bug speed does fail all the time. Which was then exiting and the board would
+        // not run correctly. So changed to warnx.
+        warnx("failed to set bus speed");
+    }
 
 	attached = true;
 }
@@ -455,8 +459,8 @@ mtd_rwtest(char *partition_names[], unsigned n_partitions)
 
 	uint8_t v[128], v2[128];
 	for (uint8_t i = 0; i < n_partitions; i++) {
-		uint32_t count = 0;
-                off_t offset = 0;
+		ssize_t count = 0;
+        off_t offset = 0;
 		printf("rwtest %s testing %u bytes\n", partition_names[i], expected_size);
 		int fd = open(partition_names[i], O_RDWR);
 		if (fd == -1) {

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -372,6 +372,7 @@ int test_mixer(int argc, char *argv[])
 	}
 
 	warnx("SUCCESS: No errors in mixer test");
+    return 0;
 }
 
 static int


### PR DESCRIPTION
I started a separate pull to work on fixing compiler warnings. These are the bugs I found during that work which I am pushing up separately so they get better scrutiny. Especially note the ones which have FIXME comments where some questions still remain. If you could comment on those and then I will update and/or remove the FIXME comments.

Also just noticed that in mtd.c one of the straight warnings fixes slipped through for signed/unisgned changes. No real bug in that part, just a warning.
