### PR TITLE
Reconfig fix

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -134,8 +134,8 @@ then
 	then
 		# We can't be sure the defaults haven't changed, so
 		# if someone requests a re-configuration, we do it
-		# cleanly from scratch
-		param reset
+		# cleanly from scratch (except autostart / autoconfig)
+		param reset_nostart
 		set DO_AUTOCONFIG yes
 	else
 		set DO_AUTOCONFIG no

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -64,6 +64,7 @@ static void	do_show_print(void *arg, param_t param);
 static void	do_set(const char* name, const char* val, bool fail_on_not_found);
 static void	do_compare(const char* name, const char* vals[], unsigned comparisons);
 static void	do_reset(void);
+static void	do_reset_nostart(void);
 
 int
 param_main(int argc, char *argv[])
@@ -141,6 +142,10 @@ param_main(int argc, char *argv[])
 
 		if (!strcmp(argv[1], "reset")) {
 			do_reset();
+		}
+
+		if (!strcmp(argv[1], "reset_nostart")) {
+			do_reset_nostart();
 		}
 	}
 	
@@ -419,6 +424,29 @@ static void
 do_reset(void)
 {
 	param_reset_all();
+
+	if (param_save_default()) {
+		warnx("Param export failed.");
+		exit(1);
+	} else {
+		exit(0);
+	}
+}
+
+static void
+do_reset_nostart(void)
+{
+
+	int32_t autostart;
+	int32_t autoconfig;
+
+	(void)param_get(param_find("SYS_AUTOSTART"), &autostart);
+	(void)param_get(param_find("SYS_AUTOCONFIG"), &autoconfig);
+
+	param_reset_all();
+
+	(void)param_set(param_find("SYS_AUTOSTART"), &autostart);
+	(void)param_set(param_find("SYS_AUTOCONFIG"), &autoconfig);
 
 	if (param_save_default()) {
 		warnx("Param export failed.");


### PR DESCRIPTION
On updating controllers / estimators etc. the platform-specific scripts do not always update, but rather the global defaults update. If an user does an airframe reconfiguration and _selects to reset the tuning parameters to the defaults_ he expects them to really reset.

This will also ensure we have a path for troubled users to really reset their autopilot (through the airframe config) and not be bothered with stale parameter values. Note that pro users and devs can just un-tick the checkbox for the config reset when re-configuring for a different airframe.

This intentionally also resets RC config and other params.
