### PR TITLE
Fix IO Firmware build warnings

### DIFF
--- a/src/modules/px4iofirmware/i2c.c
+++ b/src/modules/px4iofirmware/i2c.c
@@ -64,12 +64,15 @@
 #define rCCR		REG(STM32_I2C_CCR_OFFSET)
 #define rTRISE		REG(STM32_I2C_TRISE_OFFSET)
 
+void			i2c_reset(void);
 static int		i2c_interrupt(int irq, void *context);
 static void		i2c_rx_setup(void);
 static void		i2c_tx_setup(void);
 static void		i2c_rx_complete(void);
 static void		i2c_tx_complete(void);
+#ifdef DEBUG
 static void		i2c_dump(void);
+#endif
 
 static DMA_HANDLE	rx_dma;
 static DMA_HANDLE	tx_dma;

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -219,8 +219,8 @@ extern bool	dsm_input(uint16_t *values, uint16_t *num_values);
 extern void	dsm_bind(uint16_t cmd, int pulses);
 extern int	sbus_init(const char *device);
 extern bool	sbus_input(uint16_t *values, uint16_t *num_values, bool *sbus_failsafe, bool *sbus_frame_drop, uint16_t max_channels);
-extern bool	sbus1_output(uint16_t *values, uint16_t num_values);
-extern bool	sbus2_output(uint16_t *values, uint16_t num_values);
+extern void	sbus1_output(uint16_t *values, uint16_t num_values);
+extern void	sbus2_output(uint16_t *values, uint16_t num_values);
 
 /** global debug level for isr_debug() */
 extern volatile uint8_t debug_level;

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -711,7 +711,7 @@ registers_get(uint8_t page, uint8_t offset, uint16_t **values, unsigned *num_val
 {
 #define SELECT_PAGE(_page_name)							\
 	do {									\
-		*values = &_page_name[0];					\
+		*values = (uint16_t *)&_page_name[0];				\
 		*num_values = sizeof(_page_name) / sizeof(_page_name[0]);	\
 	} while(0)
 

--- a/src/modules/px4iofirmware/sbus.c
+++ b/src/modules/px4iofirmware/sbus.c
@@ -116,14 +116,14 @@ sbus_init(const char *device)
 	return sbus_fd;
 }
 
-bool
+void
 sbus1_output(uint16_t *values, uint16_t num_values)
 {
 	char a = 'A';
 	write(sbus_fd, &a, 1);
 }
 
-bool
+void
 sbus2_output(uint16_t *values, uint16_t num_values)
 {
 	char b = 'B';


### PR DESCRIPTION
@px4dev These are the warnings I referred to:

``` gcc
%% MODULE_MK           = /Users/user/src/Firmware/src/modules/px4iofirmware/module.mk
%  MODULE_NAME         = px4iofirmware
%  MODULE_SRC          = /Users/user/src/Firmware/src/modules/px4iofirmware/
%  MODULE_OBJ          = /Users/user/src/Firmware/Build/px4io-v1_default.build//Users/user/src/Firmware/src/modules/px4iofirmware/module.pre.o
%  MODULE_WORK_DIR     = /Users/user/src/Firmware/Build/px4io-v1_default.build//Users/user/src/Firmware/src/modules/px4iofirmware
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/adc.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/controls.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/dsm.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/px4io.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/registers.c
/Users/user/src/Firmware/src/modules/px4iofirmware/registers.c: In function 'registers_get':
/Users/user/src/Firmware/src/modules/px4iofirmware/registers.c:846:3: warning: assignment discards 'const' qualifier from pointer target type [enabled by default]
/Users/user/src/Firmware/src/modules/px4iofirmware/registers.c:863:3: warning: assignment discards 'volatile' qualifier from pointer target type [enabled by default]
/Users/user/src/Firmware/src/modules/px4iofirmware/registers.c:866:3: warning: assignment discards 'volatile' qualifier from pointer target type [enabled by default]
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/safety.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/sbus.c
/Users/user/src/Firmware/src/modules/px4iofirmware/sbus.c: In function 'sbus2_output':
/Users/user/src/Firmware/src/modules/px4iofirmware/sbus.c:131:1: warning: control reaches end of non-void function [-Wreturn-type]
/Users/user/src/Firmware/src/modules/px4iofirmware/sbus.c: In function 'sbus1_output':
/Users/user/src/Firmware/src/modules/px4iofirmware/sbus.c:124:1: warning: control reaches end of non-void function [-Wreturn-type]
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/up_cxxinitialize.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/perf_counter.c
CXX:     /Users/user/src/Firmware/src/modules/px4iofirmware/mixer.cpp
CXX:     /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/mixer/mixer.cpp
CXX:     /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/mixer/mixer_group.cpp
CXX:     /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/mixer/mixer_multirotor.cpp
CXX:     /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/mixer/mixer_simple.cpp
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/../systemlib/pwm_limit/pwm_limit.c
CC:      /Users/user/src/Firmware/src/modules/px4iofirmware/i2c.c
/Users/user/src/Firmware/src/modules/px4iofirmware/i2c.c:157:1: warning: no previous prototype for 'i2c_reset' [-Wmissing-prototypes]
/Users/user/src/Firmware/src/modules/px4iofirmware/i2c.c:72:14: warning: 'i2c_dump' declared 'static' but never defined [-Wunused-function]
PRELINK: /Users/user/src/Firmware/Build/px4io-v1_default.build//Users/user/src/Firmware/src/modules/px4iofirmware/module.pre.o
LINK:    /Users/user/src/Firmware/Build/px4io-v1_default.build/firmware.elf
BIN:     /Users/user/src/Firmware/Build/px4io-v1_default.build/firmware.bin
```
