### PR TITLE
Fix SPI struct unitialized use warning

### DIFF
--- a/src/drivers/device/spi.cpp
+++ b/src/drivers/device/spi.cpp
@@ -133,26 +133,44 @@ SPI::probe()
 int
 SPI::transfer(uint8_t *send, uint8_t *recv, unsigned len)
 {
-	irqstate_t	state;
+	int result;
 
 	if ((send == nullptr) && (recv == nullptr))
 		return -EINVAL;
 
-	/* lock the bus as required */
-	if (!up_interrupt_context()) {
-		switch (locking_mode) {
-		default:
-		case LOCK_PREEMPTION:
-			state = irqsave();
-			break;
-		case LOCK_THREADS:
-			SPI_LOCK(_dev, true);
-			break;
-		case LOCK_NONE:
-			break;
-		}
-	}
+	LockMode mode = up_interrupt_context() ? LOCK_NONE : locking_mode;
 
+	/* lock the bus as required */
+	switch (mode) {
+	default:
+	case LOCK_PREEMPTION:
+		{
+			irqstate_t state = irqsave();
+			result = _transfer(send, recv, len);
+			irqrestore(state);
+		}
+		break;
+	case LOCK_THREADS:
+		SPI_LOCK(_dev, true);
+		result = _transfer(send, recv, len);
+		SPI_LOCK(_dev, false);
+		break;
+	case LOCK_NONE:
+		result = _transfer(send, recv, len);
+		break;
+	}
+	return result;
+}
+
+void 
+SPI::set_frequency(uint32_t frequency)
+{
+	_frequency = frequency;
+}
+
+int
+SPI::_transfer(uint8_t *send, uint8_t *recv, unsigned len)
+{
 	SPI_SETFREQUENCY(_dev, _frequency);
 	SPI_SETMODE(_dev, _mode);
 	SPI_SETBITS(_dev, 8);
@@ -164,27 +182,7 @@ SPI::transfer(uint8_t *send, uint8_t *recv, unsigned len)
 	/* and clean up */
 	SPI_SELECT(_dev, _device, false);
 
-	if (!up_interrupt_context()) {
-		switch (locking_mode) {
-		default:
-		case LOCK_PREEMPTION:
-			irqrestore(state);
-			break;
-		case LOCK_THREADS:
-			SPI_LOCK(_dev, false);
-			break;
-		case LOCK_NONE:
-			break;
-		}
-	}
-
 	return OK;
-}
-
-void 
-SPI::set_frequency(uint32_t frequency)
-{
-	_frequency = frequency;
 }
 
 } // namespace device

--- a/src/drivers/device/spi.h
+++ b/src/drivers/device/spi.h
@@ -129,6 +129,8 @@ private:
 	enum spi_mode_e		_mode;
 	uint32_t		_frequency;
 	struct spi_dev_s	*_dev;
+
+	int	_transfer(uint8_t *send, uint8_t *recv, unsigned len);
 };
 
 } // namespace device


### PR DESCRIPTION
@px4dev Another warning you might want to look at:

```
%% MODULE_MK           = /Users/user/src/Firmware/src/drivers/device/module.mk
%  MODULE_NAME         = device
%  MODULE_SRC          = /Users/user/src/Firmware/src/drivers/device/
%  MODULE_OBJ          = /Users/user/src/Firmware/Build/px4fmu-v1_default.build//Users/user/src/Firmware/src/drivers/device/module.pre.o
%  MODULE_WORK_DIR     = /Users/user/src/Firmware/Build/px4fmu-v1_default.build//Users/user/src/Firmware/src/drivers/device
CXX:     /Users/user/src/Firmware/src/drivers/device/cdev.cpp
CXX:     /Users/user/src/Firmware/src/drivers/device/device.cpp
CXX:     /Users/user/src/Firmware/src/drivers/device/i2c.cpp
CXX:     /Users/user/src/Firmware/src/drivers/device/pio.cpp
CXX:     /Users/user/src/Firmware/src/drivers/device/spi.cpp
In file included from /Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/arch/irq.h:60:0,
                 from /Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/nuttx/irq.h:70,
                 from /Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/nuttx/sched.h:54,
                 from /Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/sched.h:47,
                 from /Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/nuttx/arch.h:48,
                 from /Users/user/src/Firmware/src/drivers/device/spi.cpp:48:
/Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/arch/armv7-m/irq.h: In member function 'int device::SPI::transfer(uint8_t*, uint8_t*, unsigned int)':
/Users/user/src/Firmware/Build/px4fmu-v1_default.build/nuttx-export/include/arch/armv7-m/irq.h:293:29: warning: 'state' may be used uninitialized in this function [-Wmaybe-uninitialized]
/Users/user/src/Firmware/src/drivers/device/spi.cpp:136:13: note: 'state' was declared here
PRELINK: /Users/user/src/Firmware/Build/px4fmu-v1_default.build//Users/user/src/Firmware/src/drivers/device/module.pre.o
```
