### PR TITLE
Fix compiler warnings

### DIFF
--- a/makefiles/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/toolchain_gnu-arm-eabi.mk
@@ -139,7 +139,11 @@ ARCHWARNINGS		 = -Wall \
 			   -Werror=format-security \
 			   -Werror=array-bounds \
 			   -Wfatal-errors \
-			   -Wformat=1
+			   -Wformat=1 \
+			   -Werror=unused-but-set-variable \
+			   -Werror=unused-variable \
+			   -Werror=double-promotion \
+			   -Werror=reorder
 #   -Wcast-qual  - generates spurious noreturn attribute warnings, try again later
 #   -Wconversion - would be nice, but too many "risky-but-safe" conversions in the code
 #   -Wcast-align - would help catch bad casts in some cases, but generates too many false positives

--- a/src/modules/ekf_att_pos_estimator/estimator_23states.cpp
+++ b/src/modules/ekf_att_pos_estimator/estimator_23states.cpp
@@ -1742,7 +1742,6 @@ void AttPosEKF::FuseOptFlow()
     static float vd = 0.0f;
     static float pd = 0.0f;
     static float ptd = 0.0f;
-    static Vector3f delAng;
     static float R_LOS = 0.01f;
     static float losPred[2];
 
@@ -1819,9 +1818,6 @@ void AttPosEKF::FuseOptFlow()
 
             // calculate relative velocity in sensor frame
             relVelSensor = Tns*velNED_local;
-
-            // calculate delta angles in sensor axes
-            Vector3f delAngRel = Tbs*delAng;
 
             // divide velocity by range  and include angular rate effects to get predicted angular LOS rates relative to X and Y axes
             losPred[0] =  relVelSensor.y/range;
@@ -1959,7 +1955,7 @@ void AttPosEKF::FuseOptFlow()
             }
             // normalise the quaternion states
             float quatMag = sqrt(states[0]*states[0] + states[1]*states[1] + states[2]*states[2] + states[3]*states[3]);
-            if (quatMag > 1e-12)
+            if (quatMag > 1e-12f)
             {
                 for (uint8_t j= 0; j<=3; j++)
                 {

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -65,11 +65,11 @@ Mission::Mission(Navigator *navigator, const char *name) :
 	_offboard_mission({0}),
 	_current_onboard_mission_index(-1),
 	_current_offboard_mission_index(-1),
+	_need_takeoff(true),
+	_takeoff(false),
 	_mission_result_pub(-1),
 	_mission_result({0}),
-	_mission_type(MISSION_TYPE_NONE),
-	_need_takeoff(true),
-	_takeoff(false)
+	_mission_type(MISSION_TYPE_NONE)
 {
 	/* load initial params */
 	updateParams();
@@ -334,7 +334,7 @@ Mission::set_mission_items()
 			takeoff_alt = fmaxf(takeoff_alt, _navigator->get_home_position()->alt + _param_takeoff_alt.get());
 		}
 
-		mavlink_log_info(_navigator->get_mavlink_fd(), "#audio: takeoff to %.1fm above home", takeoff_alt - _navigator->get_home_position()->alt);
+		mavlink_log_info(_navigator->get_mavlink_fd(), "#audio: takeoff to %.1fm above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 		_mission_item.lat = _navigator->get_global_position()->lat;
 		_mission_item.lon = _navigator->get_global_position()->lon;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -57,10 +57,10 @@
 
 MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
 	NavigatorMode(navigator, name),
+	_mission_item({0}),
 	_waypoint_position_reached(false),
 	_waypoint_yaw_reached(false),
-	_time_first_inside_orbit(0),
-	_mission_item({0})
+	_time_first_inside_orbit(0)
 {
 }
 

--- a/src/modules/uORB/topics/telemetry_status.h
+++ b/src/modules/uORB/topics/telemetry_status.h
@@ -86,4 +86,14 @@ static const struct orb_metadata *telemetry_status_orb_id[TELEMETRY_STATUS_ORB_I
 	ORB_ID(telemetry_status_3),
 };
 
+// This is a hack to quiet an unused-variable warning for when telemetry_status.h is
+// included but telemetry_status_orb_id is not referenced. The inline works if you
+// choose to use it, but you can continue to just directly index into the array as well.
+// If you don't use the inline this ends up being a no-op with no additional code emitted.
+extern inline const struct orb_metadata *telemetry_status_orb_id_lookup(size_t index);
+extern inline const struct orb_metadata *telemetry_status_orb_id_lookup(size_t index)
+{
+	return telemetry_status_orb_id[index];
+}
+
 #endif /* TOPIC_TELEMETRY_STATUS_H */

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -231,7 +231,6 @@ do_show_print(void *arg, param_t param)
 		/* start search */
 		const char *ss = search_string;
 		const char *pp = p_name;
-		bool mismatch = false;
 
 		/* XXX this comparison is only ok for trailing wildcards */
 		while (*ss != '\0' && *pp != '\0') {

--- a/src/systemcmds/tests/test_mathlib.cpp
+++ b/src/systemcmds/tests/test_mathlib.cpp
@@ -98,6 +98,8 @@ int test_mathlib(int argc, char *argv[])
 		TEST_OP("Vector<3> length squared", v1.length_squared());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
+		// Need pragma here intead of moving variable out of TEST_OP and just reference because
+		// TEST_OP measures performance of vector operations.
 		TEST_OP("Vector<3> element read", volatile float a = v1(0));
 		TEST_OP("Vector<3> element read direct", volatile float a = v1.data[0]);
 #pragma GCC diagnostic pop


### PR DESCRIPTION
With this set of changes, the codebase is clear of the following warnings: unused-but-set-variable, unused-variable, double-promotion, reorder. Given that I've turned these warnings into errors so that we don't lose forward progress.
