### PR TITLE
Reduce excessive FMU stack usage

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -329,7 +329,7 @@ PX4FMU::init()
 	_task = task_spawn_cmd("fmuservo",
 			       SCHED_DEFAULT,
 			       SCHED_PRIORITY_DEFAULT,
-			       2048,
+			       1600,
 			       (main_t)&PX4FMU::task_main_trampoline,
 			       nullptr);
 


### PR DESCRIPTION
With mixers loaded we still have quite some spare stack after this change (800 bytes)

```
Processes: 19 total, 2 running, 17 sleeping
CPU usage: 38.52% tasks, 0.47% sched, 61.02% idle
Uptime: 124.981s total, 80.034s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
   0 Idle Task                   80034 61.015     0/    0   0 (  0)  READY 
   1 hpwork                       4163  3.437   684/ 2040 192 (192)  w:sig 
   2 lpwork                        553  0.390   404/ 2040  50 ( 50)  w:sig 
   3 init                          334  0.000  1212/ 3496 100 (100)  w:sem 
  56 nshterm                         0  0.000   500/ 1192 100 (100)  w:sem 
 118 top                           742  3.750  1244/ 1696 100 (100)  RUN   
  58 commander                     389  0.234  2068/ 2944 215 (215)  w:sig 
  59 commander_low_prio             38  0.000   604/ 2896  50 ( 50)  w:sem 
  61 mavlink_if0                  1382  1.093  1524/ 2696 100 (100)  w:sig 
  62 mavlink_rcv_if0                15  0.000   788/ 2896 215 (215)  w:sem 
  77 sensors_task                 3709  2.968   908/ 1992 250 (250)  w:sem 
 108 fmuservo                      286  0.468   828/ 1592 100 (100)  w:sem 
  81 sdlog2                        473  0.156  1940/ 2992  70 ( 70)  w:sig 
  83 gps                           123  0.078   732/ 1496 220 (220)  w:sem 
  89 ekf_att_pos_estimator       30039 24.765  3748/ 4992 215 (215)  w:sem 
  95 fw_att_control                948  0.781   828/ 2040 250 (250)  w:sem 
 101 fw_pos_control_l1              97  0.078   708/ 3496 250 (250)  w:sem 
 103 dataman                        23  0.000   692/ 1992 250 (250)  w:sem 
 105 navigator                     438  0.312   828/ 1992
```
