### PR TITLE
Make the check for an empty string more compatible with linux distros

### DIFF
--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -3,7 +3,7 @@
 if [ -d NuttX/nuttx ];
 	then
 	STATUSRETVAL=$(git status --porcelain | grep -i "NuttX")
-	if [ -z $STATUSRETVAL ]; then
+	if [ -z "$STATUSRETVAL" ]; then
 		echo "Checked NuttX submodule, correct version found"
 	else
 		echo "NuttX sub repo not at correct version. Try 'make updatesubmodules'"
@@ -19,7 +19,7 @@ fi
 if [ -d mavlink/include/mavlink/v1.0 ];
 	then
 	STATUSRETVAL=$(git status --porcelain | grep -i "mavlink/include/mavlink/v1.0")
-	if [ -z $STATUSRETVAL ]; then
+	if [ -z "$STATUSRETVAL" ]; then
 		echo "Checked mavlink submodule, correct version found"
 	else
 		echo "mavlink sub repo not at correct version. Try 'make updatesubmodules'"


### PR DESCRIPTION
The current method would work but it depends on what a given linux distribution points /bin/sh to. In my case Debian was failing this test, bash is fine though.
