### PR TITLE
Set IO PX4_I2C_BUS_ONBOARD I2C speed to 400KHz

### DIFF
--- a/src/drivers/px4io/px4io_i2c.cpp
+++ b/src/drivers/px4io/px4io_i2c.cpp
@@ -79,7 +79,7 @@ device::Device
 }
 
 PX4IO_I2C::PX4IO_I2C(int bus, uint8_t address) :
-	I2C("PX4IO_i2c", nullptr, bus, address, 320000)
+	I2C("PX4IO_i2c", nullptr, bus, address, 400000)
 {
 	_retries = 3;
 }


### PR DESCRIPTION
The PX4_I2C_BUS_ONBOARD I2C speed is set to 320KHz. But the other bus members like MS5611 and HMC5883 running at 400KHz.
