### PR TITLE
Let GCC bitch about missing field initializers. 

### DIFF
--- a/makefiles/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/toolchain_gnu-arm-eabi.mk
@@ -121,7 +121,7 @@ INSTRUMENTATIONDEFINES	 = $(ARCHINSTRUMENTATIONDEFINES_$(CONFIG_ARCH))
 # Language-specific flags
 #
 ARCHCFLAGS		 = -std=gnu99
-ARCHCXXFLAGS		 = -fno-exceptions -fno-rtti -std=gnu++0x
+ARCHCXXFLAGS		 = -fno-exceptions -fno-rtti -std=gnu++0x -Weffc++
 
 # Generic warnings
 #


### PR DESCRIPTION
We really want this, but right now its creating a massive array of warnings. Used to track down and fix estimator issues. I'm sure there is more stuff luring around.
