### PR TITLE
update comment about condition_global_position_valid

### DIFF
--- a/src/modules/uORB/topics/vehicle_status.h
+++ b/src/modules/uORB/topics/vehicle_status.h
@@ -186,7 +186,7 @@ struct vehicle_status_s {
 	bool condition_system_sensors_initialized;
 	bool condition_system_returned_to_home;
 	bool condition_auto_mission_available;
-	bool condition_global_position_valid;		/**< set to true by the commander app if the quality of the gps signal is good enough to use it in the position estimator */
+	bool condition_global_position_valid;		/**< set to true by the commander app if the quality of the position estimate is good enough to use it for navigation */
 	bool condition_launch_position_valid;		/**< indicates a valid launch position */
 	bool condition_home_position_valid;		/**< indicates a valid home position (a valid home position is not always a valid launch) */
 	bool condition_local_position_valid;


### PR DESCRIPTION
As per https://github.com/PX4/Firmware/blob/master/src/modules/commander/commander.cpp#L1107
condition_global_position_valid is set as a result of the position estimation uncertainty and **not** as a result of the gps uncertainty.
