### PR TITLE
HIL simulation at 200Hz

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.usb
+++ b/ROMFS/px4fmu_common/init.d/rc.usb
@@ -3,7 +3,7 @@
 # USB MAVLink start
 #
 
-mavlink start -r 10000 -d /dev/ttyACM0 -x
+mavlink start -r 20000 -d /dev/ttyACM0 -x
 # Enable a number of interesting streams we want via USB
 mavlink stream -d /dev/ttyACM0 -s PARAM_VALUE -r 200
 usleep 100000

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -90,7 +90,7 @@
 static const int ERROR = -1;
 
 #define DEFAULT_DEVICE_NAME	"/dev/ttyS1"
-#define MAX_DATA_RATE	10000	// max data rate in bytes/s
+#define MAX_DATA_RATE	20000	// max data rate in bytes/s
 #define MAIN_LOOP_DELAY 10000	// 100 Hz @ 1000 bytes/s data rate
 
 #define TX_BUFFER_GAP MAVLINK_MAX_PACKET_LEN
@@ -694,7 +694,7 @@ Mavlink::set_hil_enabled(bool hil_enabled)
 	/* enable HIL */
 	if (hil_enabled && !_hil_enabled) {
 		_hil_enabled = true;
-		configure_stream("HIL_CONTROLS", 150.0f);
+		configure_stream("HIL_CONTROLS", 200.0f);
 	}
 
 	/* disable HIL */


### PR DESCRIPTION
Increased data rate on USB and HIL_CONTROLS rate that allows HIL simulation at 200Hz.

Free CPU is ~22% during simulation.

Mavlink status:

```
instance #1:
    GCS heartbeat:  231196 us ago
    type:       UNKNOWN RADIO
    rssi:       0
    remote rssi:    0
    txbuf:      0
    noise:      0
    remote noise:   0
    rx errors:  0
    fixed:      0
    rates:
    tx: 10.150 kB/s
    txerr: 0.000 kB/s
    rx: 14.602 kB/s
    rate mult: 1.000
```
