### PR TITLE
uORB2 added, WIP

### DIFF
--- a/makefiles/config_px4fmu-v2_uorb2.mk
+++ b/makefiles/config_px4fmu-v2_uorb2.mk
@@ -1,0 +1,71 @@
+#
+# Makefile for the px4fmu_default configuration
+#
+
+#
+# Use the configuration's ROMFS, copy the px4iov2 firmware into
+# the ROMFS if it's available
+#
+ROMFS_ROOT	 = $(PX4_BASE)/ROMFS/px4fmu_common
+ROMFS_OPTIONAL_FILES = $(PX4_BASE)/Images/px4io-v2_default.bin
+
+#
+# Board support modules
+#
+MODULES		+= drivers/device
+MODULES		+= drivers/stm32
+MODULES		+= drivers/led
+MODULES		+= drivers/boards/px4fmu-v2
+
+
+# Needs to be burned to the ground and re-written; for now,
+# just don't build it.
+#MODULES		+= drivers/mkblctrl
+
+#
+# System commands
+#
+MODULES		+= systemcmds/bl_update
+MODULES		+= systemcmds/boardinfo
+MODULES		+= systemcmds/perf
+MODULES		+= systemcmds/reboot
+MODULES		+= systemcmds/top
+MODULES		+= systemcmds/config
+MODULES		+= systemcmds/nshterm
+
+#
+# Library modules
+#
+MODULES		+= modules/systemlib
+MODULES		+= modules/uORB
+MODULES		+= modules/uORB2
+
+#
+# Libraries
+#
+LIBRARIES	+= lib/mathlib/CMSIS
+MODULES		+= lib/mathlib
+MODULES		+= lib/mathlib/math/filter
+MODULES		+= lib/ecl
+MODULES		+= lib/external_lgpl
+MODULES		+= lib/geo
+MODULES		+= lib/geo_lookup
+MODULES		+= lib/conversion
+MODULES		+= lib/launchdetection
+
+#
+# Transitional support - add commands from the NuttX export archive.
+#
+# In general, these should move to modules over time.
+#
+# Each entry here is <command>.<priority>.<stacksize>.<entrypoint> but we use a helper macro
+# to make the table a bit more readable.
+#
+define _B
+	$(strip $1).$(or $(strip $2),SCHED_PRIORITY_DEFAULT).$(or $(strip $3),CONFIG_PTHREAD_STACK_DEFAULT).$(strip $4)
+endef
+
+#                  command                 priority                   stack  entrypoint
+BUILTIN_COMMANDS := \
+	$(call _B, sercon,                 ,                          2048,  sercon_main                ) \
+	$(call _B, serdis,                 ,                          2048,  serdis_main                )

--- a/src/modules/uORB2/module.mk
+++ b/src/modules/uORB2/module.mk
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2012, 2013 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+#
+# Makefile to build uORB2
+#
+
+MODULE_COMMAND		= uorb2
+
+MODULE_STACKSIZE	= 4096
+
+SRCS			= uORB2.cpp

--- a/src/modules/uORB2/uORB2.cpp
+++ b/src/modules/uORB2/uORB2.cpp
@@ -1,0 +1,87 @@
+#include <errno.h>
+#include <systemlib/err.h>
+#include <drivers/drv_hrt.h>
+
+#include "uORB2.hpp"
+
+/*
+ * uORB server 'main'.
+ */
+extern "C" { __EXPORT int uorb2_main(int argc, char *argv[]); }
+
+namespace uORB2 {
+
+ORBMaster	*g_dev;
+
+struct uorb2_test_topic_s {
+
+	int	val;
+};
+
+ORB_DECLARE(uorb2_test_topic);
+ORB_DEFINE(uorb2_test_topic, struct uorb2_test_topic_s, 5);
+
+int test();
+
+int test()
+{
+	Publication pub(g_dev->get_topic(ORB_ID(uorb2_test_topic)));
+
+	struct uorb2_test_topic_s t;
+
+	uint64_t t_start = hrt_absolute_time();
+	for (unsigned i = 0; i < 1000000; i++) {
+		t.val = i;
+		pub.publish(&t);
+	}
+	uint64_t t_end = hrt_absolute_time();
+	warnx("pub: data=%i t=%llu", t.val, t_end - t_start);
+
+	Subscription sub(g_dev->get_topic(ORB_ID(uorb2_test_topic)));
+
+	struct uorb2_test_topic_s t1;
+	for (int i = 0; i < 10; i++) {
+		bool res = sub.update(&t1);
+		warnx("sub next: updated=%i, data=%i", (int)res, t1.val);
+	}
+
+	return 0;
+}
+
+}
+
+int
+uorb2_main(int argc, char *argv[])
+{
+	/*
+	 * Start/load the driver.
+	 *
+	 * XXX it would be nice to have a wrapper for this...
+	 */
+	if (!strcmp(argv[1], "start")) {
+
+		if (uORB2::g_dev != nullptr) {
+			warnx("already loaded");
+			/* user wanted to start uorb2, its already running, no error */
+			return 0;
+		}
+
+		/* create the driver */
+		uORB2::g_dev = new uORB2::ORBMaster();
+
+		if (uORB2::g_dev == nullptr) {
+			warnx("driver alloc failed");
+			return -ENOMEM;
+		}
+
+		warnx("ready");
+		return OK;
+	}
+
+	/*
+	 * Test the driver/device.
+	 */
+	if (!strcmp(argv[1], "test")) {
+		return uORB2::test();
+	}
+}

--- a/src/modules/uORB2/uORB2.hpp
+++ b/src/modules/uORB2/uORB2.hpp
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <systemlib/visibility.h>
+#include <systemlib/err.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/wqueue.h>
+#include <nuttx/clock.h>
+
+namespace uORB2 {
+
+/**
+ * Object metadata.
+ */
+struct orb_metadata {
+	const char *o_name;			/**< unique object name */
+	const size_t o_size;		/**< object size */
+	const size_t queue_size;	/**< queue size */
+};
+
+typedef const struct orb_metadata *orb_id_t;
+
+/**
+ * Generates a pointer to the uORB metadata structure for
+ * a given topic.
+ *
+ * The topic must have been declared previously in scope
+ * with ORB_DECLARE().
+ *
+ * @param _name		The name of the topic.
+ */
+#define ORB_ID(_name)		&__orb_##_name
+
+#define ORB_DECLARE(_name)		extern "C" const struct orb_metadata __orb_##_name __EXPORT
+#define ORB_DECLARE_OPTIONAL(_name)	extern "C" const struct orb_metadata __orb_##_name __EXPORT __attribute__((weak))
+
+/**
+ * Define (instantiate) the uORB metadata for a topic.
+ *
+ * The uORB metadata is used to help ensure that updates and
+ * copies are accessing the right data.
+ *
+ * Note that there must be no more than one instance of this macro
+ * for each topic.
+ *
+ * @param _name		The name of the topic.
+ * @param _struct	The structure the topic provides.
+ */
+#define ORB_DEFINE(_name, _struct, _queue_size)			\
+	const struct orb_metadata __orb_##_name = {	\
+		#_name,					\
+		sizeof(_struct),		\
+		_queue_size				\
+	};
+
+/**
+ * Thread-safe storage class for topic data.
+ */
+class Topic {
+public:
+	Topic* next = nullptr;
+
+	Topic(orb_id_t orb_id) :
+		_orb_id(orb_id),
+		_buffer(new char[orb_id->o_size * orb_id->queue_size])
+	{
+	}
+
+	~Topic()
+	{
+		if (_buffer) {
+			delete _buffer;
+		}
+	}
+
+	/**
+	 * Get topic data to buffer. Return generation number, 0 means no data.
+	 */
+	uint64_t get(void* buffer, uint64_t generation_have, uint64_t generation_get) {
+		irqstate_t flags = irqsave();
+
+		if (generation_have >= _generation) {
+			/* caller already has current generation, nothing to do */
+			return 0;
+		}
+
+		if (generation_get) {
+			/* minimum available generation */
+			uint64_t g_min = _generation - _orb_id->queue_size + 1;
+			generation_get = generation_get < g_min ? g_min : generation_get;
+
+		} else {
+			/* 0 generation in argument means get latest generation */
+			generation_get = _generation;
+		}
+
+		memcpy(buffer, get_buffer_ptr(generation_get), _orb_id->o_size);
+		irqrestore(flags);
+		//warnx("Topic::get, gen %uul", generation_get);
+		return generation_get;
+	}
+
+	/**
+	 * Publish data from buffer to topic. Buffer size
+	 */
+	void put(void* buffer)
+	{
+		irqstate_t flags = irqsave();
+		_generation++;
+		memcpy(get_buffer_ptr(_generation), buffer, _orb_id->o_size);
+		//warnx("Topic::put, gen %llu", _generation);
+		irqrestore(flags);
+	}
+
+	orb_id_t get_orb_id()
+	{
+		return _orb_id;
+	}
+
+private:
+	orb_id_t	_orb_id;
+	char*		_buffer = nullptr;
+	uint64_t	_generation = 0;
+
+	inline void* get_buffer_ptr(uint64_t generation) {
+		return _buffer + (generation % _orb_id->queue_size) * _orb_id->o_size;
+	}
+};
+
+
+/**
+ * Subscription object. Subscriber must create subscription to receive data.
+ */
+class Subscription {
+public:
+	Subscription(Topic& topic) :
+		_topic(topic)
+	{
+	}
+
+	/**
+	 * Get last update on topic.
+	 *
+	 * @return true if got update and it was copied to buffer
+	 */
+	bool update(void* buffer)
+	{
+		uint64_t res = _topic.get(buffer, _generation, 0);
+
+		if (res) {
+			_generation = res;
+			return true;
+
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Get next update on topic. May skip updates in case of topic buffer overflow.
+	 *
+	 * @return true if got update and it was copied to buffer
+	 */
+	bool next(void* buffer)
+	{
+		uint64_t res = _topic.get(buffer, _generation, _generation + 1);
+
+		if (res != 0) {
+			_generation = res;
+			return true;
+
+		} else {
+			return false;
+		}
+	}
+
+private:
+	Topic&		_topic;
+	uint64_t	_generation = 0;
+};
+
+/**
+ * Publication object. Publisher must create publication to publish data.
+ */
+class Publication {
+public:
+	Publication(Topic& topic) :
+		_topic(topic)
+	{
+	}
+
+	void publish(void* buffer)
+	{
+		_topic.put(buffer);
+	}
+
+private:
+	Topic&		_topic;
+};
+
+
+/**
+ * Poll set of subscriptions.
+ * @return number of updated subscription, 0 on timeout.
+ */
+int uORB_poll(Subscription* subs, bool* updated, ssize_t n, unsigned timeout);
+
+
+/**
+ * Topics manager.
+ */
+class ORBMaster {
+public:
+	/**
+	 * Get topic by ID. If topic doesn't exists, create it.
+	 */
+	Topic& get_topic(const orb_id_t orb_id) {
+		irqstate_t flags = irqsave();
+
+		for (Topic* t = _topics_head; t != nullptr; t = t->next) {
+			if (t->get_orb_id() == orb_id) {
+				/* Topic found in list */
+				irqrestore(flags);
+
+				warnx("ORBMaster: topic found: %s", t->get_orb_id()->o_name);
+				return *t;
+			}
+		}
+
+		/* Topic not found, create it */
+		Topic* t = new Topic(orb_id);
+		if (_topics_tail) {
+			_topics_tail->next = t;
+
+		} else {
+			_topics_head = t;
+			_topics_tail = t;
+		}
+
+		irqrestore(flags);
+
+		warnx("ORBMaster: new topic created: %s", t->get_orb_id()->o_name);
+		return *t;
+	}
+
+private:
+	Topic*		_topics_head = nullptr;
+	Topic*		_topics_tail = nullptr;
+};
+
+}


### PR DESCRIPTION
New version of uORB implemented, attempt to fix issues with old uORB version:
- Using file descriptors requires a lot of memory when app uses a lot of subscriptions.
- Updates queue is useful for some kind of topics, e.g. vehicle_command, to avoid loosing multiple commands that sent immediately.
- Old style C API is verbose and not convinient, it's very easy to make bugs. C++ wrappers needed to make code more beautiful.

Features:
- Written in C++, including client API.
- Not uses files / file descriptors, subscriptions/publications are very memory-cheap.
- Threads synchronization via irqsave()/irqrestore().
- More simple API for publishing, not advertise/publish, but create Publisher and publish.
- Queues support: it's possible to specify queue size in topic definition, subscriber can get next or last value. Useful for commands or text messages.

TODO
- Semaphores and blocking poll() function to get updates on topics immediately.
- Now it's C++ only, C wrappers may be added later for backward compatibility. C++ apps will use native API, i.e. not C++ -> C -> C++ as with uorb_tiny/controllib.
