### PR TITLE
mc_pos_control: path following and smooth transitions on waypoints in AUTO

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -829,10 +829,12 @@ MulticopterPositionControl::control_auto(float dt)
 
 		/* move setpoint not faster than max allowed speed */
 		math::Vector<3> pos_sp_old_s = _pos_sp.emult(scale);
-		math::Vector<3> d_pos_s = pos_sp_s - pos_sp_old_s;
-		float d_pos_s_len = d_pos_s.length();
-		if (d_pos_s_len > dt) {
-			pos_sp_s = pos_sp_old_s + d_pos_s / d_pos_s_len * dt;
+
+		/* difference between current and desired position setpoints, 1 = max speed */
+		math::Vector<3> d_pos_m = (pos_sp_s - pos_sp_old_s).edivide(_params.pos_p);
+		float d_pos_m_len = d_pos_m.length();
+		if (d_pos_m_len > dt) {
+			pos_sp_s = pos_sp_old_s + (d_pos_m / d_pos_m_len * dt).emult(_params.pos_p);
 		}
 
 		/* scale result back to normal space */


### PR DESCRIPTION
Implemented L1-like, 3D path following:
- Copter follows path even if was disturbed.
- Horizontal and vertical axes normally have different max speeds (MPC_XY_VEL_MAX and MPC_Z_VEL_MAX), caused by physical limits. In 3D case need to use not sphere of radius L1, but ellipsoid. This done using space to unitless, so 1 == position error resulting max allowed speed.
- When passing via waypoint and the next one located on the same line copter will not slow down (if passes correctly) even if acceptance radius is smaller than L1.
- In the same time all waypoints, even with very small acceptance radius will be reached, because of smart control near waypoint.
- Position setpoint that used to calculate velocity moved continuously with <=max allowed speed. As result all transitions (even start of mission) are more smooth.

Tested in HIL.

TODO
- Add "L1 multiplier" parameter that will control how fast copter will go to desired path.
- More HIl and flight testing, and corner cases inspection.
