### PR TITLE
Require a digit ahead of the dot for a valid number for the SF0x output

### DIFF
--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -598,7 +598,8 @@ SF0X::collect()
 				memcpy(_linebuf, buf, (lend + 1) - (i + 1));
 			}
 
-			if (_linebuf[i] == '.') {
+			/* we need a digit before the dot and a dot for a valid number */
+			if (i > 0 && _linebuf[i] == '.') {
 				valid = true;
 			}
 		}


### PR DESCRIPTION
This addresses a corner case found in logs where the post-digit sequence was converted as the altitude in meters.
