### PR TITLE
HMC5883 set_excitement minor fix.

### DIFF
--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -1283,14 +1283,13 @@ int HMC5883::set_excitement(unsigned enable)
 	if (OK != ret)
 		perf_count(_comms_errors);
 
+	_conf_reg &= ~0x03; // reset previous excitement mode
 	if (((int)enable) < 0) {
 		_conf_reg |= 0x01;
 
 	} else if (enable > 0) {
 		_conf_reg |= 0x02;
 
-	} else {
-		_conf_reg &= ~0x03;
 	}
 
         // ::printf("set_excitement enable=%d regA=0x%x\n", (int)enable, (unsigned)_conf_reg);


### PR DESCRIPTION
Since set_excitement method in the hmc5883 driver is exposed through ioctl MAGIOCEXSTRAP command, it's better to reset the two LSBs of configuration register A before or-ing with 0x01 or 0x02. Else calling the method with -1 as the argument followed by a call with 1 as the argument will produce 0x03 in the two LSBs which corresponds to the "Reserved" mode on the chip.
