### PR TITLE
Improved UAVCAN status reporting

### DIFF
--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -70,6 +70,16 @@ unsigned UavcanGnssBridge::get_num_redundant_channels() const
 	return (_receiver_node_id < 0) ? 0 : 1;
 }
 
+void UavcanGnssBridge::print_status() const
+{
+	printf("RX errors: %d, receiver node id: ", _sub_fix.getFailureCount());
+	if (_receiver_node_id < 0) {
+		printf("N/A\n");
+	} else {
+		printf("%d\n", _receiver_node_id);
+	}
+}
+
 void UavcanGnssBridge::gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix> &msg)
 {
 	// This bridge does not support redundant GNSS receivers yet.

--- a/src/modules/uavcan/sensors/gnss.hpp
+++ b/src/modules/uavcan/sensors/gnss.hpp
@@ -66,6 +66,8 @@ public:
 
 	unsigned get_num_redundant_channels() const override;
 
+	void print_status() const override;
+
 private:
 	/**
 	 * GNSS fix message will be reported via this callback.

--- a/src/modules/uavcan/sensors/sensor_bridge.hpp
+++ b/src/modules/uavcan/sensors/sensor_bridge.hpp
@@ -69,6 +69,11 @@ public:
 	virtual unsigned get_num_redundant_channels() const = 0;
 
 	/**
+	 * Prints current status in a human readable format to stdout.
+	 */
+	virtual void print_status() const = 0;
+
+	/**
 	 * Sensor bridge factory.
 	 * Creates a bridge object by its ASCII name, e.g. "gnss", "mag".
 	 * @return nullptr if such bridge can't be created.
@@ -84,7 +89,7 @@ class UavcanCDevSensorBridgeBase : public IUavcanSensorBridge, public device::CD
 {
 	struct Channel
 	{
-		int redunancy_channel_id = -1;
+		int node_id              = -1;
 		orb_id_t orb_id          = nullptr;
 		orb_advert_t orb_advert  = -1;
 		int class_instance       = -1;
@@ -112,13 +117,15 @@ protected:
 	/**
 	 * Sends one measurement into appropriate ORB topic.
 	 * New redundancy channels will be registered automatically.
-	 * @param redundancy_channel_id Redundant sensor identifier (e.g. UAVCAN Node ID)
-	 * @param report                ORB message object
+	 * @param node_id Sensor's Node ID
+	 * @param report  Pointer to ORB message object
 	 */
-	void publish(const int redundancy_channel_id, const void *report);
+	void publish(const int node_id, const void *report);
 
 public:
 	virtual ~UavcanCDevSensorBridgeBase();
 
 	unsigned get_num_redundant_channels() const override;
+
+	void print_status() const override;
 };

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -548,14 +548,16 @@ UavcanNode::print_info()
 	(void)pthread_mutex_lock(&_node_mutex);
 
 	// ESC mixer status
-	warnx("ESC actuators control groups: sub: %u / req: %u / fds: %u",
-	      (unsigned)_groups_subscribed, (unsigned)_groups_required, _poll_fds_num);
-	warnx("ESC mixer: %s", (_mixers == nullptr) ? "NONE" : "OK");
+	printf("ESC actuators control groups: sub: %u / req: %u / fds: %u\n",
+	       (unsigned)_groups_subscribed, (unsigned)_groups_required, _poll_fds_num);
+	printf("ESC mixer: %s\n", (_mixers == nullptr) ? "NONE" : "OK");
 
 	// Sensor bridges
 	auto br = _sensor_bridges.getHead();
 	while (br != nullptr) {
-		warnx("Sensor '%s': channels: %u", br->get_name(), br->get_num_redundant_channels());
+		printf("Sensor '%s':\n", br->get_name());
+		br->print_status();
+		printf("\n");
 		br = br->getSibling();
 	}
 


### PR DESCRIPTION
```
nsh> uavcan status
ESC actuators control groups: sub: 1 / req: 1 / fds: 2
ESC mixer: OK
Sensor 'gnss':
RX errors: 0, receiver node id: 50

Sensor 'mag':
devname: /dev/mag
channel 0: node id 50 --> class instance 1
channel 1: empty
channel 2: empty

Sensor 'baro':
devname: /dev/baro
channel 0: node id 50 --> class instance 1
channel 1: empty
```
