### PR TITLE
FTP: Add skip entry information for proper offset calculation.

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -351,16 +351,20 @@ MavlinkFTP::_workList(PayloadHeader* payload)
 		case DTYPE_DIRECTORY:
 			if (strcmp(entry.d_name, ".") == 0 || strcmp(entry.d_name, "..") == 0) {
 				// Don't bother sending these back
-				continue;
+				direntType = kDirentSkip;
+			} else {
+				direntType = kDirentDir;
 			}
-			direntType = kDirentDir;
 			break;
 		default:
 			// We only send back file and diretory entries, skip everything else
-			continue;
+			direntType = kDirentSkip;
 		}
 		
-		if (entry.d_type == DTYPE_FILE) {
+		if (direntType == kDirentSkip) {
+			// Skip send only dirent identifier
+			buf[0] = '\0';
+		} else if (direntType == kDirentFile) {
 			// Files send filename and file length
 			snprintf(buf, sizeof(buf), "%s\t%d", entry.d_name, fileSize);
 		} else {

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -159,6 +159,7 @@ private:
 	
 	static const char	kDirentFile = 'F';	///< Identifies File returned from List command
 	static const char	kDirentDir = 'D';	///< Identifies Directory returned from List command
+	static const char	kDirentSkip = 'S';	///< Identifies Skipped entry from List command
 	
 	/// @brief Maximum data size in RequestHeader::data
 	static const uint8_t	kMaxDataLength = MAVLINK_MSG_FILE_TRANSFER_PROTOCOL_FIELD_PAYLOAD_LEN - sizeof(PayloadHeader);


### PR DESCRIPTION
This PR fix list directory offset calculation by adding 'skip' entries.

https://github.com/PX4/Firmware/issues/1324#issuecomment-55625780
