### PR TITLE
geofence: lat/lon is double

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -76,11 +76,7 @@ Geofence::~Geofence()
 
 bool Geofence::inside(const struct vehicle_global_position_s *vehicle)
 {
-	double lat = vehicle->lat / 1e7d;
-	double lon = vehicle->lon / 1e7d;
-	//float	alt = vehicle->alt;
-
-	return inside(lat, lon, vehicle->alt);
+	return inside(vehicle->lat, vehicle->lon, vehicle->alt);
 }
 
 bool Geofence::inside(double lat, double lon, float altitude)


### PR DESCRIPTION
This is the same change as 5832948371866aec8f0c7f16b13869f270d36aad from #1213 but
against the master branch.

Some time ago the type of lat and lon in the global_pos uorb topic was
changed but this use here was missed.

Fixes #1364
