### PR TITLE
Pullrequest ll40ls probe

### DIFF
--- a/src/drivers/ll40ls/ll40ls.cpp
+++ b/src/drivers/ll40ls/ll40ls.cpp
@@ -325,7 +325,9 @@ LL40LS::probe()
 
 ok:
 	_retries = 3;
-	return OK;
+
+	// start a measurement
+	return measure();
 }
 
 void


### PR DESCRIPTION
improved probe of ll40ls so it can distinguish it from px4flow, and handle both I2C addresses
