### PR TITLE
px4flow: try a 22 byte transfer in probe()

### DIFF
--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -249,6 +249,17 @@ out:
 int
 PX4FLOW::probe()
 {
+	uint8_t val[22];
+
+	// to be sure this is not a ll40ls Lidar (which can also be on
+	// 0x42) we check if a 22 byte transfer works from address
+	// 0. The ll40ls gives an error for that, whereas the flow
+	// happily returns some data
+	if (transfer(nullptr, 0, &val[0], 22) != OK) {
+		return -EIO;
+	}
+	
+	// that worked, so start a measurement cycle
 	return measure();
 }
 


### PR DESCRIPTION
this allows us to distinguish between a ll40ls and px4flow on I2C
address 0x42
