### PR TITLE
Don't go into an error state if we are temporarily powering via USB on the bench

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1407,8 +1407,8 @@ int commander_thread_main(int argc, char *argv[])
 			last_idle_time = system_load.tasks[0].total_runtime;
 
 			/* check if board is connected via USB */
-			//struct stat statbuf;
-			//on_usb_power = (stat("/dev/ttyACM0", &statbuf) == 0);
+			struct stat statbuf;
+			on_usb_power = (stat("/dev/ttyACM0", &statbuf) == 0);
 		}
 
 		/* if battery voltage is getting lower, warn using buzzer, etc. */
@@ -1418,7 +1418,7 @@ int commander_thread_main(int argc, char *argv[])
 			status.battery_warning = VEHICLE_BATTERY_WARNING_LOW;
 			status_changed = true;
 
-		} else if (status.condition_battery_voltage_valid && status.battery_remaining < 0.09f
+		} else if (!on_usb_power && status.condition_battery_voltage_valid && status.battery_remaining < 0.09f
 			   && !critical_battery_voltage_actions_done && low_battery_voltage_actions_done) {
 			/* critical battery voltage, this is rather an emergency, change state machine */
 			critical_battery_voltage_actions_done = true;


### PR DESCRIPTION
Not fully tested yet, nor am I sure this is the right approach, however this is to initiate an attempt to fix a bug which prevents calibrating sensors with a fresh airframe configuration that sets the battery cell count > 1. Currently sensor calibration will be rejected with a "command denied: 241" error.

There are various ways to fix this. The downside of this approach could be if someone attempts to power via USB for flight they won't get the battery voltage error state.
