### PR TITLE
Fix RC mapping indices - 0 index induces issues right now

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1279,7 +1279,7 @@ PX4IO::io_set_rc_config()
 
 	if ((ichan >= 0) && (ichan < (int)_max_rc_input)) {
 		/* use out of normal bounds index to indicate special channel */
-		input_map[ichan - 1] = PX4IO_P_RC_CONFIG_ASSIGNMENT_MODESWITCH;
+		input_map[ichan] = PX4IO_P_RC_CONFIG_ASSIGNMENT_MODESWITCH;
 	}
 
 	/*


### PR DESCRIPTION
This fixes an index check fail, found by @thomasgubler here:
https://github.com/PX4/Firmware/pull/1390/files#r19883021

Thanks!
