### PR TITLE
px4io: publish pwm values when STATUS_FLAGS_FMU_OK is not set

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1651,10 +1651,6 @@ PX4IO::io_publish_raw_rc()
 int
 PX4IO::io_publish_pwm_outputs()
 {
-	/* if no FMU comms(!) just don't publish */
-	if (!(_status & PX4IO_P_STATUS_FLAGS_FMU_OK))
-		return OK;
-
 	/* data we are going to fetch */
 	actuator_outputs_s outputs;
 	outputs.timestamp = hrt_absolute_time();


### PR DESCRIPTION
this allows testing of FMU failure behaviour in px4io by monitoring
the reported PWM output when the vehicle code stops sending
updates. Otherwise testing needs to be done with "px4io status" which
is very tedious.

With this change a GCS can monitor the PWM outputs from the failsafe
mixer using normal mavlink messages
