### PR TITLE
Fix navstates

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2225,7 +2225,6 @@ set_control_mode()
 		control_mode.flag_control_termination_enabled = false;
 		break;
 
-
 	case NAVIGATION_STATE_AUTO_MISSION:
 	case NAVIGATION_STATE_AUTO_LOITER:
 	case NAVIGATION_STATE_AUTO_RTL:


### PR DESCRIPTION
The navigation_state RCRECOVER was not present in the switch which caused the offboard flag to stay after the mode was deactivated.

The rest is just reordering of the states to match the enum.

Tested in HIL, review and merge please.
