### PR TITLE
Fix navigator load

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -289,8 +289,9 @@ Navigator::task_main()
 	navigation_capabilities_update();
 	params_update();
 
-	/* rate limit position updates to 50 Hz */
+	/* rate limit position and sensor updates to 50 Hz */
 	orb_set_interval(_global_pos_sub, 20);
+	orb_set_interval(_sensor_combined_sub, 20);
 
 	hrt_abstime mavlink_open_time = 0;
 	const hrt_abstime mavlink_open_interval = 500000;


### PR DESCRIPTION
Slow navigator down from 8% CPU to 1-2% by only updating the sensor combined with 50Hz and therefore only running at 50Hz.

Fixes #1457 .

```
Processes: 21 total, 2 running, 19 sleeping
CPU usage: 57.87% tasks, 0.94% sched, 41.20% idle
Uptime: 14.500s total, 5.163s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
   0 Idle Task                    5162 41.198     0/    0   0 (  0)  READY 
   1 hpwork                        233  1.779   604/ 1992 192 (192)  w:sig 
   2 lpwork                        101  0.749   668/ 1992  50 ( 50)  READY 
   3 init                         1671  0.000  1348/ 2992 100 (100)  w:sem 
   6 nshterm                         2  0.000   916/ 1592  70 ( 70)  w:sem 
 133 top                           153  2.153  1284/ 1696 100 (100)  RUN   
  56 dataman                        57  0.000   772/ 1992 100 (100)  w:sem 
  58 commander                     220  0.374  2604/ 3192 215 (215)  w:sig 
  59 commander_low_prio              5  0.000   572/ 2896  50 ( 50)  w:sem 
  61 fmuhil                        102  0.936   924/ 1192 100 (100)  READY 
  63 px4io                         807  6.273   900/ 1992 240 (240)  w:sem 
  73 mavlink_if0                   223  1.498  2004/ 2896 100 (100)  READY 
  74 mavlink_rcv_if0                 2  0.000   836/ 2896 175 (175)  w:sem 
 103 sensors_task                  710  5.617  1092/ 1992 250 (250)  w:sem 
 109 sdlog2                        124  0.655  2084/ 2992  70 ( 70)  READY 
 111 gps                            43  0.093   764/ 1496 220 (220)  w:sem 
 115 attitude_estimator_ekf       3162 25.936 13012/13992 250 (250)  w:sem 
 117 position_estimator_inav       392  3.370  4172/ 4992 250 (250)  w:sem 
 119 mc_att_control                699  5.617  1156/ 1992 250 (250)  w:sem 
 124 mc_pos_control                 97  0.936  1100/ 1992 250 (250)  w:sem 
 132 navigator                     256  1.872   940/ 1992 250 (250)  w:sem
```
