### PR TITLE
airspeed: use _retries=2 for I2C retries once initialised

### DIFF
--- a/src/drivers/airspeed/airspeed.cpp
+++ b/src/drivers/airspeed/airspeed.cpp
@@ -159,13 +159,15 @@ out:
 int
 Airspeed::probe()
 {
-	/* on initial power up the device needs more than one retry
-	   for detection. Once it is running then retries aren't
-	   needed 
+	/* on initial power up the device may need more than one retry
+	   for detection. Once it is running the number of retries can
+	   be reduced
 	*/
 	_retries = 4;
 	int ret = measure();
-	_retries = 0;
+
+        // drop back to 2 retries once initialised
+	_retries = 2;
 	return ret;
 }
 


### PR DESCRIPTION
airspeed sensors often need to be on longer cables due to having to be
outside the prop wash.
