### PR TITLE
Display ESC data in the status output

### DIFF
--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -638,6 +638,8 @@ UavcanNode::print_info()
 			printf("%d",      esc.esc[i].esc_errorcount);
 			printf("\n");
 		}
+
+		orb_unsubscribe(esc_sub);
 	}
 
 	// Sensor bridges


### PR DESCRIPTION
There's a lot of useful information available for connected CAN ESCs so let's display it. This also provides us with a simple way of telling if communications with the ESCs is functioning.
