### PR TITLE
ll40ls: max distance according to datasheet

### DIFF
--- a/src/drivers/ll40ls/ll40ls.cpp
+++ b/src/drivers/ll40ls/ll40ls.cpp
@@ -89,7 +89,7 @@
 
 /* Device limits */
 #define LL40LS_MIN_DISTANCE (0.00f)
-#define LL40LS_MAX_DISTANCE (14.00f)
+#define LL40LS_MAX_DISTANCE (60.00f)
 
 #define LL40LS_CONVERSION_INTERVAL 100000 /* 100ms */
 


### PR DESCRIPTION
Datasheet:
http://pulsedlight3d.com/pl3d/wp-content/uploads/2014/11/LIDAR-Lite.pdf

60m is for the laser emitter version.

I don't know how many people use the LED version. If this is an issue we need to make this configurable via the startup configuration.
