### PR TITLE
Added aerocore upload target.

### DIFF
--- a/makefiles/gumstix-aerocore.cfg
+++ b/makefiles/gumstix-aerocore.cfg
@@ -1,0 +1,10 @@
+# JTAG for the STM32F4x chip used on the Gumstix AeroCore is available on
+# the first interface of a Quad FTDI chip.  nTRST is bit 4.
+interface ftdi
+ftdi_vid_pid 0x0403 0x6011
+
+ftdi_layout_init 0x0000 0x001b
+ftdi_layout_signal nTRST -data 0x0010
+
+source [find target/stm32f4x.cfg]
+reset_config trst_only

--- a/makefiles/upload.mk
+++ b/makefiles/upload.mk
@@ -30,6 +30,11 @@ upload-serial-px4fmu-v1:	$(BUNDLE) $(UPLOADER)
 upload-serial-px4fmu-v2:	$(BUNDLE) $(UPLOADER)
 	$(Q) $(PYTHON) -u $(UPLOADER) --port $(SERIAL_PORTS) $(BUNDLE)
 
+upload-serial-aerocore:
+	openocd -f $(PX4_BASE)/makefiles/gumstix-aerocore.cfg -c 'init; reset halt; flash write_image erase $(PX4_BASE)/../Bootloader/px4aerocore_bl.bin 0x08000000; flash write_image erase $(PX4_BASE)/Build/aerocore_default.build/firmware.bin 0x08004000; reset run; exit'
+
+
+
 #
 # JTAG firmware uploading with OpenOCD
 #


### PR DESCRIPTION
Added target to support aerocore firmware upload. Note, assumes bootloader above firmware directory.
