### PR TITLE
mavlink: Removed warnx that references a deleted pointer and causes a ha...

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -948,7 +948,6 @@ Mavlink::configure_stream(const char *stream_name, const float rate)
 				/* delete stream */
 				LL_DELETE(_streams, stream);
 				delete stream;
-				warnx("deleted stream %s", stream->get_name());
 			}
 
 			return OK;


### PR DESCRIPTION
...rdfault.

To reproduce the hard fault, run something similar to the following in nsh:
`mavlink stream -s HEARTBEAT -r 0`
The warnx is removed instead of moved, as there is already a method of telling the user that the stream was disabled after checking for requested subscription using configure_stream().
