### PR TITLE
First stab at Mavlink signing

### DIFF
--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -44,6 +44,7 @@ param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 4010
 param set SYS_MC_EST_GROUP 2
 param set SYS_RESTART_TYPE 2
+param set MAV_PROTO_VER 2
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/src/modules/mavlink/mavlink_bridge_header.h
+++ b/src/modules/mavlink/mavlink_bridge_header.h
@@ -50,6 +50,9 @@
 #define MAVLINK_START_UART_SEND mavlink_start_uart_send
 #define MAVLINK_END_UART_SEND mavlink_end_uart_send
 
+#define MAVLINK_START_SIGN_STREAM mavlink_start_sign_stream
+#define MAVLINK_END_SIGN_STREAM mavlink_end_sign_stream
+
 #define MAVLINK_GET_CHANNEL_BUFFER mavlink_get_channel_buffer
 #define MAVLINK_GET_CHANNEL_STATUS mavlink_get_channel_status
 
@@ -80,6 +83,9 @@ void mavlink_send_uart_bytes(mavlink_channel_t chan, const uint8_t *ch, int leng
 
 void mavlink_start_uart_send(mavlink_channel_t chan, int length);
 void mavlink_end_uart_send(mavlink_channel_t chan, int length);
+
+void mavlink_start_sign_stream(uint8_t chan);
+void mavlink_end_sign_stream(uint8_t chan);
 
 extern mavlink_status_t *mavlink_get_channel_status(uint8_t chan);
 extern mavlink_message_t *mavlink_get_channel_buffer(uint8_t chan);

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -111,6 +111,8 @@ public:
 
 	static Mavlink		*get_instance(unsigned instance);
 
+	static Mavlink		*get_instance_for_status(const mavlink_status_t *status);
+
 	static Mavlink 		*get_instance_for_device(const char *device_name);
 
 	static Mavlink 		*get_instance_for_network_port(unsigned long port);
@@ -177,6 +179,12 @@ public:
 	enum BROADCAST_MODE {
 		BROADCAST_MODE_OFF = 0,
 		BROADCAST_MODE_ON
+	};
+
+	enum PROTO_SIGN {
+		PROTO_SIGN_OPTIONAL = 0,
+		PROTO_SIGN_NON_USB,
+		PROTO_SIGN_ALWAYS
 	};
 
 	static const char *mavlink_mode_str(enum MAVLINK_MODE mode)
@@ -305,6 +313,9 @@ public:
 	 */
 	int             	send_packet();
 
+	void			begin_signing();
+	void			end_signing();
+
 	/**
 	 * Resend message as is, don't change sequence number and CRC.
 	 */
@@ -424,6 +435,12 @@ public:
 
 	Protocol 		get_protocol() { return _protocol; }
 
+	unsigned		get_proto_sign() { return _proto_sign; }
+
+	void			increase_proto_sign_err() { _proto_sign_err++; }
+
+	unsigned		get_proto_sign_err() { return _proto_sign_err; }
+
 	unsigned short		get_network_port() { return _network_port; }
 
 	unsigned short		get_remote_port() { return _remote_port; }
@@ -491,6 +508,7 @@ private:
 	static constexpr float MAVLINK_MIN_MULTIPLIER = 0.0005f;
 	mavlink_message_t _mavlink_buffer;
 	mavlink_status_t _mavlink_status;
+	mavlink_signing_t _mavlink_signing;
 
 	/* states */
 	bool			_hil_enabled;		/**< Hardware In the Loop mode */
@@ -589,12 +607,14 @@ private:
 
 	pthread_mutex_t		_message_buffer_mutex;
 	pthread_mutex_t		_send_mutex;
+	pthread_mutex_t		_signing_mutex;
 
 	bool			_param_initialized;
 	uint32_t		_broadcast_mode;
 
 	param_t			_param_system_id;
 	param_t			_param_component_id;
+	param_t			_param_proto_sign;
 	param_t			_param_proto_ver;
 	param_t			_param_radio_id;
 	param_t			_param_system_type;
@@ -603,6 +623,8 @@ private:
 	param_t			_param_broadcast;
 
 	unsigned		_system_type;
+	unsigned		_proto_sign;
+	unsigned		_proto_sign_err;
 	static bool		_config_link_on;
 
 	perf_counter_t		_loop_perf;			/**< loop performance counter */

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -50,6 +50,15 @@ PARAM_DEFINE_INT32(MAV_SYS_ID, 1);
 PARAM_DEFINE_INT32(MAV_COMP_ID, 1);
 
 /**
+ * MAVLink protocol signing
+ * @group MAVLink
+ * @value 0 Do not require signing
+ * @value 1 Signing enabled on UART
+ * @value 2 Signing always enabled
+ */
+PARAM_DEFINE_INT32(MAV_PROTO_SIGN, 0);
+
+/**
  * MAVLink protocol version
  * @group MAVLink
  * @value 0 Default to 1, switch to 2 if GCS sends version 2


### PR DESCRIPTION
DO NOT MERGE! First attempt to enable MAVLink v2 signing.

A modification is need in the mavlink module. This one https://github.com/mavlink/pymavlink/pull/1 in order to work.
This adds a signing variable to each MAVLink instances.
Right now the key is hard coded this need to be replaced with loading from a persistent memory.

ToDos:
- [ ] Load Key from persistent memory
- [ ] Save and update time stamp
- [ ] End to end testing