### PR TITLE
libled: allow infinite flashing mode

### DIFF
--- a/msg/led_control.msg
+++ b/msg/led_control.msg
@@ -29,5 +29,5 @@ uint8 led_mask # bitmask which LED(s) to control, set to 0xff for all
 uint8 color # see COLOR_*
 uint8 mode # see MODE_*
 uint8 num_blinks # how many times to blink (number of on-off cycles if mode is one of MODE_BLINK_*) . Set to 0 for infinite
-                 # in MODE_FLASH it is the number of cycles (infinite is not possible)
+                 # in MODE_FLASH it is the number of cycles. Max number of blinks: 122 and max number of flash cycles: 20
 uint8 priority # priority: higher priority events will override current lower priority events (see MAX_PRIORITY)

--- a/src/lib/led/led.cpp
+++ b/src/lib/led/led.cpp
@@ -140,13 +140,12 @@ int LedController::update(LedControlData &control_data)
 				if ((_states[i].current_blinking_time += blink_delta_t) > current_blink_duration) {
 					_states[i].current_blinking_time -= current_blink_duration;
 
-					if (cur_data.blink_times_left == 254) {
-						// handle toggling for infinite case: toggle between 254 and 255
+					if (cur_data.blink_times_left == 246) {
+						// handle toggling for infinite case: decrease between 255 and 246
+						// In order to handle the flash mode infinite case it needs a
+						// total of 10 steps.
 						cur_data.blink_times_left = 255;
 						++num_blinking_do_not_change_state;
-
-					} else if (cur_data.blink_times_left == 255) {
-						cur_data.blink_times_left = 254;
 
 					} else if (--cur_data.blink_times_left == 0) {
 						cur_data.mode = led_control_s::MODE_DISABLED;

--- a/src/lib/led/led.h
+++ b/src/lib/led/led.h
@@ -158,7 +158,7 @@ private:
 
 			if (priority[next_priority].blink_times_left == 0) {
 				// handle infinite case
-				priority[next_priority].blink_times_left = 254;
+				priority[next_priority].blink_times_left = 246;
 			}
 
 


### PR DESCRIPTION
This allows to run the flash mode at infinite. 
The maximum number of blinks is now limited to 122 and the cycle in flash mode to 20.