### PR TITLE
[WIP] FW navigation first order hold move to position controller

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -915,9 +915,22 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 			mission_throttle = pos_sp_curr.cruising_throttle;
 		}
 
+
 		uint8_t position_sp_type = pos_sp_curr.type;
 
-		// achieve position setpoint altitude via loiter
+		// TAKEOFF: handle like a regular POSITION setpoint if already flying
+		if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+
+			const bool airspeed_min = (_airspeed >= _parameters.airspeed_min);
+
+			if (!in_takeoff_situation() && airspeed_min) {
+
+				// SETPOINT_TYPE_TAKEOFF -> SETPOINT_TYPE_POSITION
+				position_sp_type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+			}
+		}
+
+		// POSITION: achieve position setpoint altitude via loiter
 		if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
 
 			float dist_xy = -1.0f;
@@ -937,6 +950,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 				position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 			}
 		}
+
 
 		if (position_sp_type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
 			_att_sp.thrust = 0.0f;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -975,7 +975,8 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 				/* Do not try to find a solution if the last waypoint is inside the acceptance radius of the current one */
 				if ((distance_current_previous - pos_sp_curr.acceptance_radius) > FLT_EPSILON) {
 					/* Calculate distance to current waypoint */
-					const float d_current = get_distance_to_next_waypoint(pos_sp_curr.lat, pos_sp_curr.lon, curr_pos(0), curr_pos(1));
+					const float d_current = get_distance_to_next_waypoint(pos_sp_curr.lat, pos_sp_curr.lon, (double)curr_pos(0),
+								(double)curr_pos(1));
 
 					/* Save distance to waypoint if it is the smallest ever achieved, however make sure that
 					 * min_current_sp_distance_xy is never larger than the distance between the current and the previous wp */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -193,6 +193,8 @@ private:
 	float	_althold_epv{0.0f};				///< the position estimate accuracy when engaging alt hold */
 	bool	_was_in_deadband{false};			///< wether the last stick input was in althold deadband */
 
+	float	_min_current_sp_distance_xy{FLT_MAX};
+
 	position_setpoint_s _hdg_hold_prev_wp {};		///< position where heading hold started */
 	position_setpoint_s _hdg_hold_curr_wp {};		///< position to which heading hold flies */
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -54,6 +54,7 @@
 #include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <lib/ecl/geo/geo.h>
+#include <lib/mathlib/mathlib.h>
 #include <navigator/navigation.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
@@ -227,10 +228,6 @@ Mission::on_active()
 			advance_mission();
 			set_mission_items();
 		}
-
-	} else if (_mission_type != MISSION_TYPE_NONE && _param_altmode.get() == MISSION_ALTMODE_FOH) {
-
-		altitude_sp_foh_update();
 
 	} else {
 		/* if waypoint position reached allow loiter on the setpoint */
@@ -444,13 +441,12 @@ Mission::landing()
 void
 Mission::update_offboard_mission()
 {
-
 	bool failed = true;
 
 	/* reset triplets */
 	_navigator->reset_triplets();
 
-	struct mission_s old_offboard_mission = _offboard_mission;
+	mission_s old_offboard_mission = _offboard_mission;
 
 	if (orb_copy(ORB_ID(mission), _navigator->get_offboard_mission_sub(), &_offboard_mission) == OK) {
 		/* determine current index */
@@ -571,9 +567,6 @@ Mission::advance_mission()
 void
 Mission::set_mission_items()
 {
-	/* reset the altitude foh (first order hold) logic, if altitude foh is enabled (param) a new foh element starts now */
-	_min_current_sp_distance_xy = FLT_MAX;
-
 	/* the home dist check provides user feedback, so we initialize it to this */
 	bool user_feedback_done = false;
 
@@ -1048,14 +1041,6 @@ Mission::set_mission_items()
 		pos_sp_triplet->next.valid = false;
 	}
 
-	/* Save the distance between the current sp and the previous one */
-	if (pos_sp_triplet->current.valid && pos_sp_triplet->previous.valid) {
-
-		_distance_current_previous = get_distance_to_next_waypoint(
-						     pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
-						     pos_sp_triplet->previous.lat, pos_sp_triplet->previous.lon);
-	}
-
 	_navigator->set_position_setpoint_triplet_updated();
 }
 
@@ -1238,81 +1223,6 @@ Mission::heading_sp_update()
 		// we set yaw directly so we can run this in parallel to the FOH update
 		_navigator->set_position_setpoint_triplet_updated();
 	}
-}
-
-void
-Mission::altitude_sp_foh_update()
-{
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
-	/* Don't change setpoint if last and current waypoint are not valid
-	 * or if the previous altitude isn't from a position or loiter setpoint or
-	 * if rotary wing since that is handled in the mc_pos_control
-	 */
-
-
-	if (!pos_sp_triplet->previous.valid || !pos_sp_triplet->current.valid || !PX4_ISFINITE(pos_sp_triplet->previous.alt)
-	    || !(pos_sp_triplet->previous.type == position_setpoint_s::SETPOINT_TYPE_POSITION ||
-		 pos_sp_triplet->previous.type == position_setpoint_s::SETPOINT_TYPE_LOITER) ||
-	    _navigator->get_vstatus()->is_rotary_wing) {
-
-		return;
-	}
-
-	// Calculate acceptance radius, i.e. the radius within which we do not perform a first order hold anymore
-	float acc_rad = _navigator->get_acceptance_radius(_mission_item.acceptance_radius);
-
-	if (pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
-		acc_rad = _navigator->get_acceptance_radius(fabsf(_mission_item.loiter_radius) * 1.2f);
-	}
-
-	/* Do not try to find a solution if the last waypoint is inside the acceptance radius of the current one */
-	if (_distance_current_previous - acc_rad < FLT_EPSILON) {
-		return;
-	}
-
-	/* Don't do FOH for non-missions, landing and takeoff waypoints, the ground may be near
-	 * and the FW controller has a custom landing logic
-	 *
-	 * NAV_CMD_LOITER_TO_ALT doesn't change altitude until reaching desired lat/lon
-	 * */
-	if (_mission_item.nav_cmd == NAV_CMD_LAND
-	    || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND
-	    || _mission_item.nav_cmd == NAV_CMD_TAKEOFF
-	    || _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT
-	    || !_navigator->is_planned_mission()) {
-
-		return;
-	}
-
-	/* Calculate distance to current waypoint */
-	float d_current = get_distance_to_next_waypoint(_mission_item.lat, _mission_item.lon,
-			  _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
-
-	/* Save distance to waypoint if it is the smallest ever achieved, however make sure that
-	 * _min_current_sp_distance_xy is never larger than the distance between the current and the previous wp */
-	_min_current_sp_distance_xy = math::min(math::min(d_current, _min_current_sp_distance_xy),
-						_distance_current_previous);
-
-	/* if the minimal distance is smaller then the acceptance radius, we should be at waypoint alt
-	 * navigator will soon switch to the next waypoint item (if there is one) as soon as we reach this altitude */
-	if (_min_current_sp_distance_xy < acc_rad) {
-		pos_sp_triplet->current.alt = get_absolute_altitude_for_item(_mission_item);
-
-	} else {
-		/* update the altitude sp of the 'current' item in the sp triplet, but do not update the altitude sp
-		 * of the mission item as it is used to check if the mission item is reached
-		 * The setpoint is set linearly and such that the system reaches the current altitude at the acceptance
-		 * radius around the current waypoint
-		 **/
-		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - pos_sp_triplet->previous.alt);
-		float grad = -delta_alt / (_distance_current_previous - acc_rad);
-		float a = pos_sp_triplet->previous.alt - grad * _distance_current_previous;
-		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
-	}
-
-	// we set altitude directly so we can run this in parallel to the heading update
-	_navigator->set_position_setpoint_triplet_updated();
 }
 
 void

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -160,11 +160,6 @@ private:
 	void heading_sp_update();
 
 	/**
-	 * Updates the altitude sp to follow a foh
-	 */
-	void altitude_sp_foh_update();
-
-	/**
 	 * Update the cruising speed setpoint.
 	 */
 	void cruising_speed_sp_update();
@@ -189,7 +184,7 @@ private:
 	 *
 	 * @return true if successful
 	 */
-	bool read_mission_item(int offset, struct mission_item_s *mission_item);
+	bool read_mission_item(int offset, mission_item_s *mission_item);
 
 	/**
 	 * Save current offboard mission state to dataman
@@ -246,7 +241,6 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_dist_1wp,
 		(ParamFloat<px4::params::MIS_DIST_WPS>) _param_dist_between_wps,
-		(ParamInt<px4::params::MIS_ALTMODE>) _param_altmode,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mnt_yaw_ctl
 	)
 
@@ -270,11 +264,6 @@ private:
 	bool _need_mission_reset{false};
 	bool _mission_waypoints_changed{false};
 	bool _mission_changed{false}; /** < true if the mission changed since the mission mode was active */
-
-	float _min_current_sp_distance_xy{FLT_MAX}; /**< minimum distance which was achieved to the current waypoint  */
-
-	float _distance_current_previous{0.0f}; /**< distance from previous to current sp in pos_sp_triplet,
-					    only use if current and previous are valid */
 
 	enum work_item_type {
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -118,9 +118,13 @@ MissionBlock::is_mission_item_reached()
 		return true;
 
 	default:
-		/* do nothing, this is a 3D waypoint */
-		break;
+		return position_achieved(_mission_item);
 	}
+}
+
+bool
+MissionBlock::position_achieved(const mission_item_s &item)
+{
 
 	hrt_abstime now = hrt_absolute_time();
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -138,40 +138,6 @@ MissionBlock::is_mission_item_reached()
 				_navigator->get_global_position()->alt,
 				&dist_xy, &dist_z);
 
-		/* FW special case for NAV_CMD_WAYPOINT to achieve altitude via loiter */
-		if (!_navigator->get_vstatus()->is_rotary_wing &&
-		    (_mission_item.nav_cmd == NAV_CMD_WAYPOINT)) {
-
-			struct position_setpoint_s *curr_sp = &_navigator->get_position_setpoint_triplet()->current;
-
-			/* close to waypoint, but altitude error greater than twice acceptance */
-			if ((dist >= 0.0f)
-			    && (dist_z > 2 * _navigator->get_altitude_acceptance_radius())
-			    && (dist_xy < 2 * _navigator->get_loiter_radius())) {
-
-				/* SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER */
-				if (curr_sp->type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
-					curr_sp->type = position_setpoint_s::SETPOINT_TYPE_LOITER;
-					curr_sp->loiter_radius = _navigator->get_loiter_radius();
-					curr_sp->loiter_direction = 1;
-					_navigator->set_position_setpoint_triplet_updated();
-				}
-
-			} else {
-				/* restore SETPOINT_TYPE_POSITION */
-				if (curr_sp->type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
-					/* loiter acceptance criteria required to revert back to SETPOINT_TYPE_POSITION */
-					if ((dist >= 0.0f)
-					    && (dist_z < _navigator->get_loiter_radius())
-					    && (dist_xy <= _navigator->get_loiter_radius() * 1.2f)) {
-
-						curr_sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
-						_navigator->set_position_setpoint_triplet_updated();
-					}
-				}
-			}
-		}
-
 		if ((_mission_item.nav_cmd == NAV_CMD_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF)
 		    && _navigator->get_vstatus()->is_rotary_wing) {
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -59,8 +59,8 @@ using matrix::wrap_pi;
 MissionBlock::MissionBlock(Navigator *navigator) :
 	NavigatorMode(navigator)
 {
-	_mission_item.lat = NAN;
-	_mission_item.lon = NAN;
+	_mission_item.lat = (double)NAN;
+	_mission_item.lon = (double)NAN;
 
 	_mission_item.yaw = NAN;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -130,9 +130,7 @@ MissionBlock::is_mission_item_reached()
 		float dist_xy = -1.0f;
 		float dist_z = -1.0f;
 
-		float altitude_amsl = _mission_item.altitude_is_relative
-				      ? _mission_item.altitude + _navigator->get_home_position()->alt
-				      : _mission_item.altitude;
+		const float altitude_amsl = get_absolute_altitude_for_item(_mission_item);
 
 		dist = get_distance_to_point_global_wgs84(_mission_item.lat, _mission_item.lon, altitude_amsl,
 				_navigator->get_global_position()->lat,
@@ -502,7 +500,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 	sp->lat = item.lat;
 	sp->lon = item.lon;
-	sp->alt = item.altitude_is_relative ? item.altitude + _navigator->get_home_position()->alt : item.altitude;
+	sp->alt = get_absolute_altitude_for_item(item);
 	sp->yaw = item.yaw;
 	sp->yaw_valid = PX4_ISFINITE(item.yaw);
 	sp->loiter_radius = (fabsf(item.loiter_radius) > NAV_EPSILON_POSITION) ? fabsf(item.loiter_radius) :
@@ -721,7 +719,7 @@ MissionBlock::mission_apply_limitation(mission_item_s &item)
 }
 
 float
-MissionBlock::get_absolute_altitude_for_item(struct mission_item_s &mission_item) const
+MissionBlock::get_absolute_altitude_for_item(const mission_item_s &mission_item)
 {
 	if (mission_item.altitude_is_relative) {
 		return mission_item.altitude + _navigator->get_home_position()->alt;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -74,6 +74,8 @@ protected:
 	 */
 	bool is_mission_item_reached();
 
+	bool position_achieved(const mission_item_s &item);
+
 	/**
 	 * Reset all reached flags
 	 */

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -74,8 +74,6 @@ protected:
 	 */
 	bool is_mission_item_reached();
 
-	bool position_achieved(const mission_item_s &item);
-
 	/**
 	 * Reset all reached flags
 	 */
@@ -121,18 +119,25 @@ protected:
 
 	void issue_command(const mission_item_s &item);
 
-	float get_time_inside(const struct mission_item_s &item);
+	float get_time_inside(const mission_item_s &item) const ;
 
-	float get_absolute_altitude_for_item(const mission_item_s &mission_item);
+	float get_absolute_altitude_for_item(const mission_item_s &mission_item) const;
 
 	mission_item_s _mission_item{};
 
 	bool _waypoint_position_reached{false};
-	bool _waypoint_yaw_reached{false};
 
-	hrt_abstime _time_first_inside_orbit{0};
 	hrt_abstime _action_start{0};
-	hrt_abstime _time_wp_reached{0};
 
 	orb_advert_t    _actuator_pub{nullptr};
+
+private:
+	bool position_achieved(const mission_item_s &item);
+	bool loiter_achieved(const double &lat, const double &lon, const float &alt) const;
+	bool yaw_achieved(const mission_item_s &item) const;
+	bool time_inside_finished(const mission_item_s &item) const;
+
+	void set_loiter_exit(const mission_item_s &item);
+
+	hrt_abstime _time_wp_reached{UINT64_MAX};
 };

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -115,13 +115,13 @@ protected:
 	/**
 	 * General function used to adjust the mission item based on vehicle specific limitations
 	 */
-	void	mission_apply_limitation(mission_item_s &item);
+	void mission_apply_limitation(mission_item_s &item);
 
 	void issue_command(const mission_item_s &item);
 
 	float get_time_inside(const struct mission_item_s &item);
 
-	float get_absolute_altitude_for_item(struct mission_item_s &mission_item) const;
+	float get_absolute_altitude_for_item(const mission_item_s &mission_item);
 
 	mission_item_s _mission_item{};
 

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -105,21 +105,6 @@ PARAM_DEFINE_FLOAT(MIS_DIST_1WP, 900);
 PARAM_DEFINE_FLOAT(MIS_DIST_WPS, 900);
 
 /**
- * Altitude setpoint mode
- *
- * 0: the system will follow a zero order hold altitude setpoint
- * 1: the system will follow a first order hold altitude setpoint
- * values follow the definition in enum mission_altitude_mode
- *
- * @min 0
- * @max 1
- * @value 0 Zero Order Hold
- * @value 1 First Order Hold
- * @group Mission
- */
-PARAM_DEFINE_INT32(MIS_ALTMODE, 1);
-
-/**
 * Enable yaw control of the mount. (Only affects multicopters and ROI mission items)
 *
 * If enabled, yaw commands will be sent to the mount and the vehicle will follow its heading mode as specified by MIS_YAWMODE.


### PR DESCRIPTION
Navigator mission first order hold (FOH) altitude setpoint was limited to non-rotary wing missions within navigator. Given those restrictions it's a much better fit within the fixed wing position controller.

 - fixes https://github.com/PX4/Firmware/issues/6758
 - fixes https://github.com/PX4/Firmware/issues/8852
 - fixes loiter to alt for MC
 - fixes FOH changing altitude during FW loiter within mission