### PR TITLE
launch: add launch specific idle throttle param

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -727,9 +727,6 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 	/* no throttle limit as default */
 	float throttle_max = 1.0f;
 
-	/* default pre-takeoff throttle setting to idle */
-	float pre_takeoff_throttle = _parameters.throttle_idle;
-
 	/* save time when airplane is in air */
 	if (!_was_in_air && !_vehicle_land_detected.landed) {
 		_was_in_air = true;
@@ -866,7 +863,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 			control_landing(curr_pos, ground_speed, pos_sp_prev, pos_sp_curr);
 
 		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
-			control_takeoff(curr_pos, ground_speed, pos_sp_prev, pos_sp_curr, pre_takeoff_throttle);
+			control_takeoff(curr_pos, ground_speed, pos_sp_prev, pos_sp_curr);
 		}
 
 		/* reset landing state */
@@ -1063,7 +1060,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 		/* making sure again that the correct thrust is used,
 		 * without depending on library calls for safety reasons.
 		   the pre-takeoff throttle and the idle throttle normally map to the same parameter. */
-		_att_sp.thrust = pre_takeoff_throttle;
+		_att_sp.thrust = _launchDetector.getThrottleIdle(_parameters.throttle_idle);
 
 	} else if (_control_mode_current == FW_POSCTRL_MODE_AUTO &&
 		   pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF &&
@@ -1121,7 +1118,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 void
 FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector2f &ground_speed,
-		const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr, float &pre_takeoff_throttle)
+		const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
 	/* current waypoint (the one currently heading for) */
 	Vector2f curr_wp((float)pos_sp_curr.lat, (float)pos_sp_curr.lon);
@@ -1281,9 +1278,6 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 			/* Set default roll and pitch setpoints during detection phase */
 			_att_sp.roll_body = 0.0f;
 			_att_sp.pitch_body = max(radians(pos_sp_curr.pitch_min), radians(10.0f));
-
-			/* set pre-takeoff throttle to launch method specific idle */
-			pre_takeoff_throttle = _launchDetector.getThrottleIdle(_parameters.throttle_idle);
 		}
 	}
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1078,7 +1078,8 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 	} else {
 		/* Copy thrust and pitch values from tecs */
-		if (_vehicle_land_detected.landed) {
+		if (_vehicle_land_detected.landed && !(_launch_detection_state == LAUNCHDETECTION_RES_DETECTED_ENABLEMOTORS
+						       && pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
 			// when we are landed state we want the motor to spin at idle speed
 			_att_sp.thrust = min(_parameters.throttle_idle, throttle_max);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -418,7 +418,7 @@ private:
 	bool		control_position(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
 					 const position_setpoint_s &pos_sp_curr);
 	void		control_takeoff(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
-					const position_setpoint_s &pos_sp_curr, float &pre_takeoff_throttle);
+					const position_setpoint_s &pos_sp_curr);
 	void		control_landing(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
 					const position_setpoint_s &pos_sp_curr);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -418,7 +418,7 @@ private:
 	bool		control_position(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
 					 const position_setpoint_s &pos_sp_curr);
 	void		control_takeoff(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
-					const position_setpoint_s &pos_sp_curr);
+					const position_setpoint_s &pos_sp_curr, float &pre_takeoff_throttle);
 	void		control_landing(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
 					const position_setpoint_s &pos_sp_curr);
 

--- a/src/modules/fw_pos_control_l1/launchdetection/CatapultLaunchMethod.cpp
+++ b/src/modules/fw_pos_control_l1/launchdetection/CatapultLaunchMethod.cpp
@@ -124,4 +124,11 @@ float CatapultLaunchMethod::getPitchMax(float pitchMaxDefault)
 	}
 }
 
+float CatapultLaunchMethod::getThrottleIdle(float throttleIdleDefault)
+{
+	// use operator defined launching idle (ignore default idle)
+	return _throttleIdle.get();
+}
+
+
 } // namespace launchdetection

--- a/src/modules/fw_pos_control_l1/launchdetection/CatapultLaunchMethod.h
+++ b/src/modules/fw_pos_control_l1/launchdetection/CatapultLaunchMethod.h
@@ -59,6 +59,7 @@ public:
 	LaunchDetectionResult getLaunchDetected() const override;
 	void reset() override;
 	float getPitchMax(float pitchMaxDefault) override;
+	float getThrottleIdle(float throttleIdleDefault) override;
 
 private:
 	hrt_abstime _last_timestamp{0};
@@ -71,9 +72,10 @@ private:
 		(ParamFloat<px4::params::LAUN_CAT_A>) _thresholdAccel,
 		(ParamFloat<px4::params::LAUN_CAT_T>) _thresholdTime,
 		(ParamFloat<px4::params::LAUN_CAT_MDEL>) _motorDelay,
-		(ParamFloat<px4::params::LAUN_CAT_PMAX>) _pitchMaxPreThrottle /**< Upper pitch limit before throttle is turned on.
+		(ParamFloat<px4::params::LAUN_CAT_PMAX>) _pitchMaxPreThrottle, /**< Upper pitch limit before throttle is turned on.
 						       Can be used to make sure that the AC does not climb
 						       too much while attached to a bungee */
+		(ParamFloat<px4::params::LAUN_THR_IDLE>) _throttleIdle
 	)
 
 };

--- a/src/modules/fw_pos_control_l1/launchdetection/LaunchDetector.cpp
+++ b/src/modules/fw_pos_control_l1/launchdetection/LaunchDetector.cpp
@@ -119,4 +119,25 @@ float LaunchDetector::getPitchMax(float pitchMaxDefault)
 	}
 }
 
+float LaunchDetector::getThrottleIdle(float throttleIdleDefault)
+{
+	if (!launchDetectionEnabled()) {
+		return throttleIdleDefault;
+	}
+
+	/* if a lauchdetectionmethod is active or only one exists return the idle throttle from this method,
+	 * otherwise use the default */
+	if (_activeLaunchDetectionMethodIndex < 0) {
+		if (sizeof(_launchMethods) / sizeof(LaunchMethod *) > 1) {
+			return throttleIdleDefault;
+
+		} else {
+			return _launchMethods[0]->getThrottleIdle(throttleIdleDefault);
+		}
+
+	} else {
+		return _launchMethods[_activeLaunchDetectionMethodIndex]->getThrottleIdle(throttleIdleDefault);
+	}
+}
+
 } // namespace launchdetection

--- a/src/modules/fw_pos_control_l1/launchdetection/LaunchDetector.h
+++ b/src/modules/fw_pos_control_l1/launchdetection/LaunchDetector.h
@@ -64,6 +64,8 @@ public:
 
 	/* Returns a maximum pitch in deg. Different launch methods may impose upper pitch limits during launch */
 	float getPitchMax(float pitchMaxDefault);
+	/* Returns an idle throttle specific to the pre- "motors enabled" launch detection phase */
+	float getThrottleIdle(float throttleIdleDefault);
 
 private:
 	/* holds an index to the launchMethod in the array _launchMethods

--- a/src/modules/fw_pos_control_l1/launchdetection/LaunchMethod.h
+++ b/src/modules/fw_pos_control_l1/launchdetection/LaunchMethod.h
@@ -65,6 +65,8 @@ public:
 
 	/* Returns a upper pitch limit if required, otherwise returns pitchMaxDefault */
 	virtual float getPitchMax(float pitchMaxDefault) = 0;
+	/* Returns an idle throttle specific to the pre- "motors enabled" launch detection phase */
+	virtual float getThrottleIdle(float throttleIdleDefault) = 0;
 
 };
 

--- a/src/modules/fw_pos_control_l1/launchdetection/launchdetection_params.c
+++ b/src/modules/fw_pos_control_l1/launchdetection/launchdetection_params.c
@@ -108,3 +108,14 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_MDEL, 0.0f);
  * @group FW Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_PMAX, 30.0f);
+
+/**
+ * Idle throttle setting during launch detection before motors enabled.
+ *
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.05
+ * @group FW Launch detection
+ */
+PARAM_DEFINE_FLOAT(LAUN_THR_IDLE, 0.0f);


### PR DESCRIPTION
Depending on the platform, fixed-wing hand launches may require non-zero idle throttle while "in hand" and getting a running start (e.g. to push more prop-wash over the control surfaces while running slower than the stall speed). This conflicts with the idle throttle setting engaged after land detection, which, in this case, would then keep idling the motor at that same non-zero value, when for e.g. belly landings this is not desirable (should be set to zero).

This pr adds a pre-takeoff idle throttle for catapult (or hand launch) methods, which differs from the idle throttle set after land detection. It is only active until motors are enabled by the launch detection -- which then as before initiates climb out.

Current implementation seems to work testing outside on the bench. But maybe there are some recommendations on how better to structure the changes in the fw pos ctrl cpp, @dagar ?