### PR TITLE
[WIP] mission_result split into mission_status and navigator_status

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -71,9 +71,10 @@ set(msg_files
 	manual_control_setpoint.msg
 	mavlink_log.msg
 	mission.msg
-	mission_result.msg
+	mission_status.msg
 	mount_orientation.msg
 	multirotor_motor_limits.msg
+	navigator_status.msg
 	obstacle_distance.msg
 	offboard_control_mode.msg
 	optical_flow.msg

--- a/msg/mission_status.msg
+++ b/msg/mission_status.msg
@@ -13,9 +13,6 @@ bool warning			# true if mission is valid, but has potentially problematic items
 bool finished			# true if mission has been completed
 bool failure			# true if the mission cannot continue or be completed for some reason
 
-bool stay_in_failsafe		# true if the commander should not switch out of the failsafe mode
-bool flight_termination		# true if the navigator demands a flight termination from the commander app
-
 bool item_do_jump_changed	# true if the number of do jumps remaining has changed
 uint16 item_changed_index	# indicate which item has changed
 uint16 item_do_jump_remaining	# set to the number of do jumps remaining for that item

--- a/msg/navigator_status.msg
+++ b/msg/navigator_status.msg
@@ -1,0 +1,8 @@
+
+bool stay_in_failsafe		# true if the commander should not switch out of the failsafe mode
+
+bool flight_termination		# true if the navigator demands a flight termination from the commander app
+
+bool failure			# true if the navigator cannot continue or be completed for some reason
+
+bool finished			# true if the current navigation task has completed

--- a/msg/tools/uorb_rtps_message_ids.py
+++ b/msg/tools/uorb_rtps_message_ids.py
@@ -43,7 +43,7 @@ msg_id_map = {
     'mavlink_log': 38,
     'mc_att_ctrl_status': 39,
     'mission': 40,
-    'mission_result': 41,
+    'mission_status': 41,
     'mount_orientation': 42,
     'multirotor_motor_limits': 43,
     'offboard_control_mode': 44,

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -54,7 +54,8 @@
 // subscriptions
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/geofence_result.h>
-#include <uORB/topics/mission_result.h>
+#include <uORB/topics/mission_status.h>
+#include <uORB/topics/navigator_status.h>
 #include <uORB/topics/safety.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -170,7 +171,8 @@ private:
 	} _telemetry[ORB_MULTI_MAX_INSTANCES];
 
 	// Subscriptions
-	Subscription<mission_result_s>			_mission_result_sub;
+	Subscription<mission_status_s>			_mission_status_sub{ORB_ID(mission_status)};
+	Subscription<navigator_status_s>		_navigator_status_sub{ORB_ID(navigator_status)};
 	Subscription<vehicle_global_position_s>		_global_position_sub;
 	Subscription<vehicle_local_position_s>		_local_position_sub;
 	Subscription<iridiumsbd_status_s> 		_iridiumsbd_status_sub;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -620,7 +620,8 @@ void Logger::add_default_topics()
 	add_topic("landing_target_pose");
 	add_topic("manual_control_setpoint", 200);
 	add_topic("mission");
-	add_topic("mission_result");
+	add_topic("mission_status");
+	add_topic("navigator_status");
 	add_topic("optical_flow", 50);
 	add_topic("ping");
 	add_topic("position_setpoint_triplet", 200);

--- a/src/modules/mavlink/mavlink_high_latency2.cpp
+++ b/src/modules/mavlink/mavlink_high_latency2.cpp
@@ -83,8 +83,8 @@ MavlinkStreamHighLatency2::MavlinkStreamHighLatency2(Mavlink *mavlink) : Mavlink
 	_global_pos_time(0),
 	_gps_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_gps_position))),
 	_gps_time(0),
-	_mission_result_sub(_mavlink->add_orb_subscription(ORB_ID(mission_result))),
-	_mission_result_time(0),
+	_mission_status_sub(_mavlink->add_orb_subscription(ORB_ID(mission_status))),
+	_mission_status_time(0),
 	_status_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_status))),
 	_status_time(0),
 	_status_flags_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_status_flags))),
@@ -130,7 +130,7 @@ bool MavlinkStreamHighLatency2::send(const hrt_abstime t)
 		updated |= write_fw_ctrl_status(&msg);
 		updated |= write_geofence_result(&msg);
 		updated |= write_global_position(&msg);
-		updated |= write_mission_result(&msg);
+		updated |= write_mission_status(&msg);
 		updated |= write_tecs_status(&msg);
 		updated |= write_vehicle_status(&msg);
 		updated |= write_vehicle_status_flags(&msg);
@@ -339,14 +339,14 @@ bool MavlinkStreamHighLatency2::write_global_position(mavlink_high_latency2_t *m
 	return updated;
 }
 
-bool MavlinkStreamHighLatency2::write_mission_result(mavlink_high_latency2_t *msg)
+bool MavlinkStreamHighLatency2::write_mission_status(mavlink_high_latency2_t *msg)
 {
-	struct mission_result_s mission_result;
+	struct mission_status_s mission_status;
 
-	const bool updated = _mission_result_sub->update(&_mission_result_time, &mission_result);
+	const bool updated = _mission_status_sub->update(&_mission_status_time, &mission_status);
 
-	if (_mission_result_time > 0) {
-		msg->wp_num = mission_result.seq_current;
+	if (_mission_status_time > 0) {
+		msg->wp_num = mission_status.seq_current;
 	}
 
 	return updated;

--- a/src/modules/mavlink/mavlink_high_latency2.h
+++ b/src/modules/mavlink/mavlink_high_latency2.h
@@ -113,8 +113,8 @@ private:
 	MavlinkOrbSubscription *_gps_sub;
 	uint64_t _gps_time;
 
-	MavlinkOrbSubscription *_mission_result_sub;
-	uint64_t _mission_result_time;
+	MavlinkOrbSubscription *_mission_status_sub;
+	uint64_t _mission_status_time;
 
 	MavlinkOrbSubscription *_status_sub;
 	uint64_t _status_time;
@@ -168,7 +168,7 @@ protected:
 
 	bool write_global_position(mavlink_high_latency2_t *msg);
 
-	bool write_mission_result(mavlink_high_latency2_t *msg);
+	bool write_mission_status(mavlink_high_latency2_t *msg);
 
 	bool write_tecs_status(mavlink_high_latency2_t *msg);
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -65,7 +65,7 @@
 
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
-#include <uORB/topics/mission_result.h>
+#include <uORB/topics/mission_status.h>
 #include <uORB/topics/telemetry_status.h>
 
 #include "mavlink_bridge_header.h"

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -125,7 +125,7 @@ private:
 	static bool		_transfer_in_progress;			///< Global variable checking for current transmission
 
 	int			_offboard_mission_sub{-1};
-	int			_mission_result_sub{-1};
+	int			_mission_status_sub{-1};
 
 	orb_advert_t		_offboard_mission_pub{nullptr};
 

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -132,8 +132,8 @@ DataLinkLoss::set_dll_item()
 
 	case DLL_STATE_TERMINATE: {
 			/* Request flight termination from the commander */
-			_navigator->get_mission_result()->flight_termination = true;
-			_navigator->set_mission_result_updated();
+			_navigator->get_navigator_status()->flight_termination = true;
+			_navigator->set_navigator_status_updated();
 			reset_mission_item_reached();
 			warnx("not switched to manual: request flight termination");
 			pos_sp_triplet->previous.valid = false;
@@ -167,8 +167,8 @@ DataLinkLoss::advance_dll()
 			warnx("%d data link losses, limit is %d, fly to airfield home",
 			      _navigator->get_vstatus()->data_link_lost_counter, _param_numberdatalinklosses.get());
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "too many DL losses, fly to airfield home");
-			_navigator->get_mission_result()->stay_in_failsafe = true;
-			_navigator->set_mission_result_updated();
+			_navigator->get_navigator_status()->stay_in_failsafe = true;
+			_navigator->set_navigator_status_updated();
 			reset_mission_item_reached();
 			_dll_state = DLL_STATE_FLYTOAIRFIELDHOMEWP;
 
@@ -192,8 +192,8 @@ DataLinkLoss::advance_dll()
 		warnx("fly to airfield home");
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "fly to airfield home");
 		_dll_state = DLL_STATE_FLYTOAIRFIELDHOMEWP;
-		_navigator->get_mission_result()->stay_in_failsafe = true;
-		_navigator->set_mission_result_updated();
+		_navigator->get_navigator_status()->stay_in_failsafe = true;
+		_navigator->set_navigator_status_updated();
 		reset_mission_item_reached();
 		break;
 
@@ -201,8 +201,8 @@ DataLinkLoss::advance_dll()
 		_dll_state = DLL_STATE_TERMINATE;
 		warnx("time is up, state should have been changed manually by now");
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "no manual control, terminating");
-		_navigator->get_mission_result()->stay_in_failsafe = true;
-		_navigator->set_mission_result_updated();
+		_navigator->get_navigator_status()->stay_in_failsafe = true;
+		_navigator->set_navigator_status_updated();
 		reset_mission_item_reached();
 		break;
 

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -135,8 +135,8 @@ GpsFailure::set_gpsf_item()
 	switch (_gpsf_state) {
 	case GPSF_STATE_TERMINATE: {
 			/* Request flight termination from commander */
-			_navigator->get_mission_result()->flight_termination = true;
-			_navigator->set_mission_result_updated();
+			_navigator->get_navigator_status()->flight_termination = true;
+			_navigator->set_navigator_status_updated();
 			PX4_WARN("GPS failure: request flight termination");
 		}
 		break;

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -51,8 +51,7 @@ Land::on_activation()
 {
 	/* set current mission item to Land */
 	set_land_item(&_mission_item, true);
-	_navigator->get_mission_result()->finished = false;
-	_navigator->set_mission_result_updated();
+	_navigator->set_navigator_status_updated();
 	reset_mission_item_reached();
 
 	/* convert mission item to current setpoint */
@@ -80,9 +79,9 @@ Land::on_active()
 	}
 
 
-	if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
-		_navigator->get_mission_result()->finished = true;
-		_navigator->set_mission_result_updated();
+	if (is_mission_item_reached() && !_navigator->get_navigator_status()->finished) {
+		_navigator->get_navigator_status()->finished = true;
+		_navigator->set_navigator_status_updated();
 		set_idle_item(&_mission_item);
 
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -343,7 +343,7 @@ MissionBlock::is_mission_item_reached()
 			    (_navigator->get_yaw_timeout() >= FLT_EPSILON) &&
 			    (now - _time_wp_reached >= (hrt_abstime)_navigator->get_yaw_timeout() * 1e6f)) {
 
-				_navigator->set_mission_failure("unable to reach heading within timeout");
+				_navigator->set_navigator_failure("unable to reach heading within timeout");
 			}
 
 		} else {

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -56,12 +56,13 @@ private:
 	/* Checks for all airframes */
 	bool checkGeofence(const mission_s &mission, float home_alt, bool home_valid);
 
-	bool checkHomePositionAltitude(const mission_s &mission, float home_alt, bool home_alt_valid, bool throw_error);
+	bool checkHomePositionAltitude(const mission_s &mission, float home_alt, bool home_alt_valid, bool throw_error,
+				       bool &warning);
 
 	bool checkMissionItemValidity(const mission_s &mission);
 
-	bool checkDistanceToFirstWaypoint(const mission_s &mission, float max_distance);
-	bool checkDistancesBetweenWaypoints(const mission_s &mission, float max_distance);
+	bool checkDistanceToFirstWaypoint(const mission_s &mission, float max_distance, bool &warning);
+	bool checkDistancesBetweenWaypoints(const mission_s &mission, float max_distance, bool &warning);
 
 	/* Checks specific to fixedwing airframes */
 	bool checkFixedwing(const mission_s &mission, float home_alt, bool home_alt_valid, bool land_start_req);
@@ -83,7 +84,7 @@ public:
 	 */
 	bool checkMissionFeasible(const mission_s &mission,
 				  float max_distance_to_1st_waypoint, float max_distance_between_waypoints,
-				  bool land_start_req);
+				  bool land_start_req, bool &warning);
 
 };
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -62,7 +62,7 @@
 #include <uORB/topics/fw_pos_ctrl_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/mission.h>
-#include <uORB/topics/mission_result.h>
+#include <uORB/topics/navigator_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
@@ -140,14 +140,14 @@ public:
 	 */
 	void		set_can_loiter_at_sp(bool can_loiter) { _can_loiter_at_sp = can_loiter; }
 	void		set_position_setpoint_triplet_updated() { _pos_sp_triplet_updated = true; }
-	void		set_mission_result_updated() { _mission_result_updated = true; }
+	void		set_navigator_status_updated() { _navigator_status_updated = true; }
 
 	/**
 	 * Getters
 	 */
 	struct fw_pos_ctrl_status_s *get_fw_pos_ctrl_status() { return &_fw_pos_ctrl_status; }
 	struct home_position_s *get_home_position() { return &_home_pos; }
-	struct mission_result_s *get_mission_result() { return &_mission_result; }
+	struct navigator_status_s *get_navigator_status() { return &_navigator_status; }
 	struct position_setpoint_triplet_s *get_position_setpoint_triplet() { return &_pos_sp_triplet; }
 	struct position_setpoint_triplet_s *get_reposition_triplet() { return &_reposition_triplet; }
 	struct position_setpoint_triplet_s *get_takeoff_triplet() { return &_takeoff_triplet; }
@@ -242,9 +242,7 @@ public:
 
 	orb_advert_t	*get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
-	void		increment_mission_instance_count() { _mission_result.instance_count++; }
-
-	void 		set_mission_failure(const char *reason);
+	void 		set_navigator_failure(const char *reason);
 
 	// MISSION
 	bool		is_planned_mission() const { return _navigation_mode == &_mission; }
@@ -285,7 +283,7 @@ private:
 
 	orb_advert_t	_geofence_result_pub{nullptr};
 	orb_advert_t	_mavlink_log_pub{nullptr};	/**< the uORB advert to send messages over mavlink */
-	orb_advert_t	_mission_result_pub{nullptr};
+	orb_advert_t	_navigator_status_pub{nullptr};
 	orb_advert_t	_pos_sp_triplet_pub{nullptr};
 	orb_advert_t	_vehicle_cmd_ack_pub{nullptr};
 	orb_advert_t	_vehicle_cmd_pub{nullptr};
@@ -294,7 +292,7 @@ private:
 	// Subscriptions
 	fw_pos_ctrl_status_s				_fw_pos_ctrl_status{};	/**< fixed wing navigation capabilities */
 	home_position_s					_home_pos{};		/**< home position for RTL */
-	mission_result_s				_mission_result{};
+	navigator_status_s				_navigator_status{};
 	vehicle_global_position_s			_global_pos{};		/**< global vehicle position */
 	vehicle_gps_position_s				_gps_pos{};		/**< gps position */
 	vehicle_land_detected_s				_land_detected{};	/**< vehicle land_detected */
@@ -316,7 +314,7 @@ private:
 	bool		_can_loiter_at_sp{false};			/**< flags if current position SP can be used to loiter */
 	bool		_pos_sp_triplet_updated{false};		/**< flags if position SP triplet needs to be published */
 	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
-	bool		_mission_result_updated{false};		/**< flags if mission result has seen an update */
+	bool		_navigator_status_updated{false};		/**< flags if mission result has seen an update */
 
 	NavigatorMode	*_navigation_mode{nullptr};		/**< abstract pointer to current navigation mode class */
 	Mission		_mission;			/**< class that handles the missions */
@@ -377,7 +375,7 @@ private:
 	/**
 	 * Publish the mission result so commander and mavlink know what is going on
 	 */
-	void		publish_mission_result();
+	void		publish_navigator_status();
 
 	void		publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
 };

--- a/src/modules/navigator/navigator_mode.cpp
+++ b/src/modules/navigator/navigator_mode.cpp
@@ -57,8 +57,8 @@ NavigatorMode::run(bool active)
 	if (active) {
 		if (!_active) {
 			/* first run, reset stay in failsafe flag */
-			_navigator->get_mission_result()->stay_in_failsafe = false;
-			_navigator->set_mission_result_updated();
+			_navigator->get_navigator_status()->stay_in_failsafe = false;
+			_navigator->set_navigator_status_updated();
 			on_activation();
 
 		} else {

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -114,8 +114,8 @@ RCLoss::set_rcl_item()
 
 	case RCL_STATE_TERMINATE: {
 			/* Request flight termination from the commander */
-			_navigator->get_mission_result()->flight_termination = true;
-			_navigator->set_mission_result_updated();
+			_navigator->get_navigator_status()->flight_termination = true;
+			_navigator->set_navigator_status_updated();
 			warnx("rc not recovered: request flight termination");
 			pos_sp_triplet->previous.valid = false;
 			pos_sp_triplet->current.valid = false;
@@ -151,8 +151,8 @@ RCLoss::advance_rcl()
 			warnx("RC loss, OBC mode, slip loiter, terminate");
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "rc loss, terminating");
 			_rcl_state = RCL_STATE_TERMINATE;
-			_navigator->get_mission_result()->stay_in_failsafe = true;
-			_navigator->set_mission_result_updated();
+			_navigator->get_navigator_status()->stay_in_failsafe = true;
+			_navigator->set_navigator_status_updated();
 			reset_mission_item_reached();
 		}
 
@@ -162,8 +162,8 @@ RCLoss::advance_rcl()
 		_rcl_state = RCL_STATE_TERMINATE;
 		warnx("time is up, no RC regain, terminating");
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "RC not regained, terminating");
-		_navigator->get_mission_result()->stay_in_failsafe = true;
-		_navigator->set_mission_result_updated();
+		_navigator->get_navigator_status()->stay_in_failsafe = true;
+		_navigator->set_navigator_status_updated();
 		reset_mission_item_reached();
 		break;
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -258,6 +258,9 @@ RTL::set_rtl_item()
 			} else {
 				_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
 				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, loitering");
+
+				_navigator->get_navigator_status()->finished = true;
+				_navigator->set_navigator_status_updated();
 			}
 
 			break;
@@ -283,6 +286,10 @@ RTL::set_rtl_item()
 	case RTL_STATE_LANDED: {
 			set_idle_item(&_mission_item);
 			set_return_alt_min(false);
+
+			_navigator->get_navigator_status()->finished = true;
+			_navigator->set_navigator_status_updated();
+
 			break;
 		}
 

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -61,9 +61,9 @@ Takeoff::on_active()
 		// reset the position
 		set_takeoff_position();
 
-	} else if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
-		_navigator->get_mission_result()->finished = true;
-		_navigator->set_mission_result_updated();
+	} else if (is_mission_item_reached() && !_navigator->get_navigator_status()->finished) {
+		_navigator->get_navigator_status()->finished = true;
+		_navigator->set_navigator_status_updated();
 
 		// set loiter item so position controllers stop doing takeoff logic
 		set_loiter_item(&_mission_item);
@@ -120,8 +120,7 @@ Takeoff::set_takeoff_position()
 
 	// set current mission item to takeoff
 	set_takeoff_item(&_mission_item, abs_altitude);
-	_navigator->get_mission_result()->finished = false;
-	_navigator->set_mission_result_updated();
+	_navigator->set_navigator_status_updated();
 	reset_mission_item_reached();
 
 	// convert mission item to current setpoint


### PR DESCRIPTION
The navigator message `mission_result` has become overloaded to contain both general navigator status, mission feasibility, and mission status. This has resulted in some confusion in both logs and usage from commander.

This PR splits mission_result into a general navigator_status message, and a mission_status that's specific to the planned dataman stored mission.