### PR TITLE
[WIP] L1 enhancements: handling small loiter radii and high winds

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -534,12 +534,13 @@ FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand, const
 
 	if (_wind_estimate_valid && _parameters.l1_airsp_incr_en == 1) {
 		Vector2f airspeed_2d = ground_speed - _wind_speed_vector;
-		airsp_incr = _l1_control.airspeed_incr(airspeed_2d.length(), airspeed_demand, _parameters.airspeed_max,
+		airsp_incr = _l1_control.airspeed_incr(airspeed_2d.length(), airspeed_demand * _eas2tas,
+						       _parameters.airspeed_max * _eas2tas,
 						       _wind_speed_vector.length(), _parameters.l1_min_ground_speed);
 	}
 
 	// sanity check: limit to range
-	return constrain(airspeed_demand + airsp_incr, adjusted_min_airspeed, _parameters.airspeed_max);
+	return constrain(airspeed_demand + airsp_incr / _eas2tas, adjusted_min_airspeed, _parameters.airspeed_max);
 }
 
 void

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -39,12 +39,15 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	ModuleParams(nullptr),
 	_sub_airspeed(ORB_ID(airspeed)),
 	_sub_sensors(ORB_ID(sensor_bias)),
+	_sub_wind_estimate(ORB_ID(wind_estimate)),
 	_loop_perf(perf_alloc(PC_ELAPSED, "fw l1 control")),
 	_launchDetector(this),
 	_runway_takeoff(this)
 {
 	_parameter_handles.l1_period = param_find("FW_L1_PERIOD");
 	_parameter_handles.l1_damping = param_find("FW_L1_DAMPING");
+	_parameter_handles.l1_airsp_incr_en = param_find("FW_L1_AIRSP_INCR");
+	_parameter_handles.l1_min_ground_speed = param_find("FW_L1_GSP_MIN");
 	_parameter_handles.roll_slew_deg_sec = param_find("FW_L1_R_SLEW_MAX");
 
 	_parameter_handles.airspeed_min = param_find("FW_AIRSPD_MIN");
@@ -180,6 +183,9 @@ FixedwingPositionControl::parameters_update()
 	if (param_get(_parameter_handles.roll_slew_deg_sec, &v) == PX4_OK) {
 		_l1_control.set_roll_slew_rate(radians(v));
 	}
+
+	param_get(_parameter_handles.l1_airsp_incr_en, &(_parameters.l1_airsp_incr_en));
+	param_get(_parameter_handles.l1_min_ground_speed, &(_parameters.l1_min_ground_speed));
 
 	// TECS parameters
 
@@ -446,6 +452,29 @@ FixedwingPositionControl::position_setpoint_triplet_poll()
 	}
 }
 
+void
+FixedwingPositionControl::wind_estimate_poll()
+{
+	if (_sub_wind_estimate.updated()) {
+		_sub_wind_estimate.update();
+		_wind_estimate_valid = PX4_ISFINITE(_sub_wind_estimate.get().windspeed_north)
+				       && PX4_ISFINITE(_sub_wind_estimate.get().windspeed_east);
+		_wind_estimate_last_received = hrt_absolute_time();
+		/* use low-passed wind estimate in l1 control */
+		_wind_speed_vector(0) = _sub_wind_estimate.get().windspeed_north;
+		_wind_speed_vector(1) = _sub_wind_estimate.get().windspeed_east;
+
+	} else {
+		/* no wind updates for 10 seconds */
+		if (_wind_estimate_valid && (hrt_absolute_time() - _wind_estimate_last_received) > 1e7) {
+			_wind_estimate_valid = false;
+			/* consideration of wind estimate in l1 disabled, reverting to ground speed only formulation */
+			_wind_speed_vector(0) = 0.0f;
+			_wind_speed_vector(1) = 0.0f;
+		}
+	}
+}
+
 float
 FixedwingPositionControl::get_demanded_airspeed()
 {
@@ -469,7 +498,7 @@ FixedwingPositionControl::get_demanded_airspeed()
 }
 
 float
-FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand)
+FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand, const Vector2f &ground_speed)
 {
 	/*
 	 * Calculate accelerated stall airspeed factor from commanded bank angle and use it to increase minimum airspeed.
@@ -494,51 +523,23 @@ FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand)
 						  _parameters.airspeed_max);
 	}
 
-	// add minimum ground speed undershoot (only non-zero in presence of sufficient wind)
-	// sanity check: limit to range
-	return constrain(airspeed_demand + _groundspeed_undershoot, adjusted_min_airspeed, _parameters.airspeed_max);
-}
+	/*
+	 * Calculate airspeed reference increment for high wind scenarios.
+	 *
+	 *  If the wind estimate is valid, and the corresponding parameter (FW_L1_AIRSP_INCR) is enabled, l1 mitigates run-away
+	 *  in high wind scenarios and, in the case that the maximum airspeed allows, maintains a minimum desired ground speed.
+	 *
+	 */
+	float airsp_incr = 0.0f;
 
-void
-FixedwingPositionControl::calculate_gndspeed_undershoot(const Vector2f &curr_pos,
-		const Vector2f &ground_speed,
-		const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
-{
-	if (pos_sp_curr.valid && !_l1_control.circle_mode()) {
-		/* rotate ground speed vector with current attitude */
-		Vector2f yaw_vector(_R_nb(0, 0), _R_nb(1, 0));
-		yaw_vector.normalize();
-		float ground_speed_body = yaw_vector * ground_speed;
-
-		/* The minimum desired ground speed is the minimum airspeed projected on to the ground using the altitude and horizontal difference between the waypoints if available*/
-		float distance = 0.0f;
-		float delta_altitude = 0.0f;
-
-		if (pos_sp_prev.valid) {
-			distance = get_distance_to_next_waypoint(pos_sp_prev.lat, pos_sp_prev.lon, pos_sp_curr.lat, pos_sp_curr.lon);
-			delta_altitude = pos_sp_curr.alt - pos_sp_prev.alt;
-
-		} else {
-			distance = get_distance_to_next_waypoint((double)curr_pos(0), (double)curr_pos(1), pos_sp_curr.lat, pos_sp_curr.lon);
-			delta_altitude = pos_sp_curr.alt - _global_pos.alt;
-		}
-
-		float ground_speed_desired = _parameters.airspeed_min * cosf(atan2f(delta_altitude, distance));
-
-		/*
-		 * Ground speed undershoot is the amount of ground velocity not reached
-		 * by the plane. Consequently it is zero if airspeed is >= min ground speed
-		 * and positive if airspeed < min ground speed.
-		 *
-		 * This error value ensures that a plane (as long as its throttle capability is
-		 * not exceeded) travels towards a waypoint (and is not pushed more and more away
-		 * by wind). Not countering this would lead to a fly-away.
-		 */
-		_groundspeed_undershoot = max(ground_speed_desired - ground_speed_body, 0.0f);
-
-	} else {
-		_groundspeed_undershoot = 0.0f;
+	if (_wind_estimate_valid && _parameters.l1_airsp_incr_en == 1) {
+		Vector2f airspeed_2d = ground_speed - _wind_speed_vector;
+		airsp_incr = _l1_control.airspeed_incr(airspeed_2d.length(), airspeed_demand, _parameters.airspeed_max,
+						       _wind_speed_vector.length(), _parameters.l1_min_ground_speed);
 	}
+
+	// sanity check: limit to range
+	return constrain(airspeed_demand + airsp_incr, adjusted_min_airspeed, _parameters.airspeed_max);
 }
 
 void
@@ -717,24 +718,6 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 	_att_sp.fw_control_yaw = false;		// by default we don't want yaw to be contoller directly with rudder
 	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;		// by default we don't use flaps
 
-	calculate_gndspeed_undershoot(curr_pos, ground_speed, pos_sp_prev, pos_sp_curr);
-
-	// l1 navigation logic breaks down when wind speed exceeds max airspeed
-	// compute 2D groundspeed from airspeed-heading projection
-	Vector2f air_speed_2d{_airspeed * cosf(_yaw), _airspeed * sinf(_yaw)};
-	Vector2f nav_speed_2d{0.0f, 0.0f};
-
-	// angle between air_speed_2d and ground_speed
-	float air_gnd_angle = acosf((air_speed_2d * ground_speed) / (air_speed_2d.length() * ground_speed.length()));
-
-	// if angle > 90 degrees or groundspeed is less than threshold, replace groundspeed with airspeed projection
-	if ((fabsf(air_gnd_angle) > M_PI_2_F) || (ground_speed.length() < 3.0f)) {
-		nav_speed_2d = air_speed_2d;
-
-	} else {
-		nav_speed_2d = ground_speed;
-	}
-
 	/* no throttle limit as default */
 	float throttle_max = 1.0f;
 
@@ -820,12 +803,12 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
 			/* waypoint is a plain navigation waypoint */
-			_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, nav_speed_2d);
+			_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_speed_vector);
 			_att_sp.roll_body = _l1_control.get_roll_setpoint();
 			_att_sp.yaw_body = _l1_control.nav_bearing();
 
 			tecs_update_pitch_throttle(pos_sp_curr.alt,
-						   calculate_target_airspeed(mission_airspeed),
+						   calculate_target_airspeed(mission_airspeed, ground_speed),
 						   radians(_parameters.pitch_limit_min) - _parameters.pitchsp_offset_rad,
 						   radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
 						   _parameters.throttle_min,
@@ -838,7 +821,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 			/* waypoint is a loiter waypoint */
 			_l1_control.navigate_loiter(curr_wp, curr_pos, pos_sp_curr.loiter_radius,
-						    pos_sp_curr.loiter_direction, nav_speed_2d);
+						    pos_sp_curr.loiter_direction, ground_speed, _wind_speed_vector);
 			_att_sp.roll_body = _l1_control.get_roll_setpoint();
 			_att_sp.yaw_body = _l1_control.nav_bearing();
 
@@ -861,7 +844,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 			}
 
 			tecs_update_pitch_throttle(alt_sp,
-						   calculate_target_airspeed(mission_airspeed),
+						   calculate_target_airspeed(mission_airspeed, ground_speed),
 						   radians(_parameters.pitch_limit_min) - _parameters.pitchsp_offset_rad,
 						   radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
 						   _parameters.throttle_min,
@@ -982,7 +965,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 				Vector2f curr_wp{(float)_hdg_hold_curr_wp.lat, (float)_hdg_hold_curr_wp.lon};
 
 				/* populate l1 control setpoint */
-				_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed);
+				_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_speed_vector);
 
 				_att_sp.roll_body = _l1_control.get_roll_setpoint();
 				_att_sp.yaw_body = _l1_control.nav_bearing();
@@ -1181,13 +1164,13 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 		 * Update navigation: _runway_takeoff returns the start WP according to mode and phase.
 		 * If we use the navigator heading or not is decided later.
 		 */
-		_l1_control.navigate_waypoints(_runway_takeoff.getStartWP(), curr_wp, curr_pos, ground_speed);
+		_l1_control.navigate_waypoints(_runway_takeoff.getStartWP(), curr_wp, curr_pos, ground_speed, _wind_speed_vector);
 
 		// update tecs
 		const float takeoff_pitch_max_deg = _runway_takeoff.getMaxPitch(_parameters.pitch_limit_max);
 
 		tecs_update_pitch_throttle(pos_sp_curr.alt,
-					   calculate_target_airspeed(_runway_takeoff.getMinAirspeedScaling() * _parameters.airspeed_min),
+					   calculate_target_airspeed(_runway_takeoff.getMinAirspeedScaling() * _parameters.airspeed_min, ground_speed),
 					   radians(_parameters.pitch_limit_min),
 					   radians(takeoff_pitch_max_deg),
 					   _parameters.throttle_min,
@@ -1237,7 +1220,7 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 		if (_launch_detection_state != LAUNCHDETECTION_RES_NONE) {
 			/* Launch has been detected, hence we have to control the plane. */
 
-			_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed);
+			_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_speed_vector);
 			_att_sp.roll_body = _l1_control.get_roll_setpoint();
 			_att_sp.yaw_body = _l1_control.nav_bearing();
 
@@ -1273,7 +1256,7 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 
 			} else {
 				tecs_update_pitch_throttle(pos_sp_curr.alt,
-							   calculate_target_airspeed(_parameters.airspeed_trim),
+							   calculate_target_airspeed(_parameters.airspeed_trim, ground_speed),
 							   radians(_parameters.pitch_limit_min),
 							   radians(_parameters.pitch_limit_max),
 							   _parameters.throttle_min,
@@ -1385,11 +1368,11 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 
 	if (_land_noreturn_horizontal) {
 		// heading hold
-		_l1_control.navigate_heading(_target_bearing, _yaw, ground_speed);
+		_l1_control.navigate_heading(_target_bearing, _yaw, ground_speed, _wind_speed_vector);
 
 	} else {
 		// normal navigation
-		_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed);
+		_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_speed_vector);
 	}
 
 	_att_sp.roll_body = _l1_control.get_roll_setpoint();
@@ -1484,7 +1467,7 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 		const float throttle_land = _parameters.throttle_min + (_parameters.throttle_max - _parameters.throttle_min) * 0.1f;
 
 		tecs_update_pitch_throttle(terrain_alt + flare_curve_alt_rel,
-					   calculate_target_airspeed(airspeed_land),
+					   calculate_target_airspeed(airspeed_land, ground_speed),
 					   radians(_parameters.land_flare_pitch_min_deg),
 					   radians(_parameters.land_flare_pitch_max_deg),
 					   0.0f,
@@ -1552,7 +1535,7 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 		const float airspeed_approach = _parameters.land_airspeed_scale * _parameters.airspeed_min;
 
 		tecs_update_pitch_throttle(altitude_desired,
-					   calculate_target_airspeed(airspeed_approach),
+					   calculate_target_airspeed(airspeed_approach, ground_speed),
 					   radians(_parameters.pitch_limit_min),
 					   radians(_parameters.pitch_limit_max),
 					   _parameters.throttle_min,
@@ -1701,6 +1684,7 @@ FixedwingPositionControl::run()
 			vehicle_control_mode_poll();
 			vehicle_land_detected_poll();
 			vehicle_status_poll();
+			wind_estimate_poll();
 
 			Vector2f curr_pos((float)_global_pos.lat, (float)_global_pos.lon);
 			Vector2f ground_speed(_global_pos.vel_n, _global_pos.vel_e);

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -442,8 +442,6 @@ private:
 
 	float		get_demanded_airspeed();
 	float		calculate_target_airspeed(float airspeed_demand, const Vector2f &ground_speed);
-	void		calculate_gndspeed_undershoot(const Vector2f &curr_pos, const Vector2f &ground_speed,
-			const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr);
 
 	/**
 	 * Handle incoming vehicle commands

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -74,6 +74,32 @@ PARAM_DEFINE_FLOAT(FW_L1_PERIOD, 20.0f);
 PARAM_DEFINE_FLOAT(FW_L1_DAMPING, 0.75f);
 
 /**
+ * Enable L1 airspeed reference incrementing
+ *
+ * Enable airspeed compensation from L1 control during high wind scenarios.
+ *
+ * @min 0
+ * @max 1
+ * @boolean
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_INT32(FW_L1_AIRSP_INCR, 0);
+
+/**
+ * L1 minimum ground speed
+ *
+ * Minimum forward ground speed which must be maintained (airspeed reference increment allowing)
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 5.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_L1_GSP_MIN, 0.0f);
+
+/**
  * L1 controller roll slew rate limit.
  *
  * The maxium change in roll angle setpoint per second.

--- a/src/modules/gnd_pos_control/GroundRoverPositionControl.cpp
+++ b/src/modules/gnd_pos_control/GroundRoverPositionControl.cpp
@@ -218,6 +218,8 @@ GroundRoverPositionControl::control_position(const matrix::Vector2f &current_pos
 
 	bool setpoint = true;
 
+	matrix::Vector2f wind_speed_vector {0.0f, 0.0f}; // ground rover does not consider wind speed
+
 	if (_control_mode.flag_control_auto_enabled && pos_sp_triplet.current.valid) {
 		/* AUTONOMOUS FLIGHT */
 
@@ -285,7 +287,7 @@ GroundRoverPositionControl::control_position(const matrix::Vector2f &current_pos
 			   || (pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
 
 			/* waypoint is a plain navigation waypoint or the takeoff waypoint, does not matter */
-			_gnd_control.navigate_waypoints(prev_wp, curr_wp, current_position, ground_speed_2d);
+			_gnd_control.navigate_waypoints(prev_wp, curr_wp, current_position, ground_speed_2d, wind_speed_vector);
 			_att_sp.roll_body = _gnd_control.get_roll_setpoint();
 			_att_sp.pitch_body = 0.0f;
 			_att_sp.yaw_body = _gnd_control.nav_bearing();
@@ -296,7 +298,7 @@ GroundRoverPositionControl::control_position(const matrix::Vector2f &current_pos
 
 			/* waypoint is a loiter waypoint so we want to stop*/
 			_gnd_control.navigate_loiter(curr_wp, current_position, pos_sp_triplet.current.loiter_radius,
-						     pos_sp_triplet.current.loiter_direction, ground_speed_2d);
+						     pos_sp_triplet.current.loiter_direction, ground_speed_2d, wind_speed_vector);
 
 			_att_sp.roll_body = _gnd_control.get_roll_setpoint();
 			_att_sp.pitch_body = 0.0f;


### PR DESCRIPTION
Corresponding ECL PR: https://github.com/PX4/ecl/pull/494

This PR does the following:

***Handling small loiter radii***
- Replace L1 PD controller with adaptive period on original L1 logic for adequately tracking small loiter radii. *why?*: L1 was designed to track circles, and the original paper described the criteria for choosing a period which guarantees convergence to a circle with a given radius. Reverting to original L1 (more specifically the L2+ formulation) keeps the logic throughout the l1 controller more consistent, straight forward, and avoids any other complications from the current PD / L1 switching behavior. Further, the PD anyway suffers the same problem of not tracking circles when not tuned for it. Here the adaptive logic handles this.

***Handling high winds***
- Remove ground speed undershoot. *why?*: this logic is overly conservative and ends up unnecessarily adding very large airspeed references in high winds. This PR replaces this logic with more efficient geometric considerations. (see more details below).
- Add wind estimate subscription. 
- Use wind estimate in l1 guidance for handling case of wind speed > nominal airspeed reference. *why?*: the current wind robustification logic sets a hard switch from ground speed to airspeed vector after some arbitrarily defined minimum ground speed threshold, this causes large nasty jumps in the commanded roll reference, and further doesn't fully address the issue specific to the wind orientation.
- Add minimum ground speed parameter (used in l1 adaptations). @Antiheavy
- Revert to previous ground speed only formulation if wind estimate is invalid (default behavior).
- Update corresponding ecl submodule.

For more general information on the logic / background, additional information not specific to the PX4 implementation here can be found in https://arxiv.org/abs/1804.04209 and https://ieeexplore.ieee.org/document/7963609/ . I will update the prior link soon with the ground speed minimum formulation.

**Replacing ground speed undershoot**
The primary issue with ground speed undershoot as currently implemented is that it considers the wrong angle, the "air-to-ground" angle doesn't consider the orientation or magnitude of the wind, and thus results in very large airspeed increments when not necessary. See in the following figure that e.g. when the current airspeed is close to the minimum airspeed (could be the case for example during landings), the ground speed undershoot (which is added to the airspeed reference) approaches the minimum airspeed when flying in head wind. This means the airspeed reference effectively *doubles*, when really all that would be necessary is a few m/s increase to maintain some minimum forward ground speed.

![ground_speed_undershoot](https://user-images.githubusercontent.com/8026163/44004351-a4762440-9e61-11e8-828b-d20a7838273a.png)

This minimum forward ground speed can be achieved most efficiently utilizing the bearing feasibility function developed in the papers cited above (see a nice plot and description on the arXiv brief). This is just a geometric relationship (considering the wind triangle -- i.e. airspeed vector + wind speed vector = ground speed vector) which only increases the airspeed reference as much as necessary to maintain the given forward ground speed (where forward ground speed is defined as the projection of ground speed on the airspeed vector, so negative values mean the aircraft is flying backwards with respect to the ground). The plots below show the effect of this function and the resulting airspeed increments commanded for the case of various wind speeds, airspeed nominal reference  = 12 m/s, and airspeed max = 16 m/s. The plots assume the aircraft is following the corresponding orientation commands from the wind robustified l1 controller. The forward ground speed is maintained up until such point that the airspeed maximum does not have any more reserve.

![min_ground_sp](https://user-images.githubusercontent.com/8026163/44004463-5a4a8594-9e63-11e8-9835-efcd5ea80ece.png)

**Simulations**

All simulations were performed in MATLAB with a simple 2D coordinated turn model with representative first order roll and airspeed response dynamics (see https://arxiv.org/pdf/1804.04209.pdf for a more detailed description of the model). All guidance gains (e.g. operator defined period=25 and damping=0.707) were kept the same for each control formulation for a fair comparison. Nominal airspeed reference was defined to 10 m/s.

***Tracking small radii*** with the adaptive period in the standard L1 formulation can be seen in the following simulation. A 20m radius is tracked. The PD control approach currently implemented does not achieve this.

![pd-vs-adapt_pos](https://user-images.githubusercontent.com/8026163/44003815-41e8d898-9e59-11e8-94f1-cbb56e51d0b0.png)

Note the effective period automatically adapts (reduces) to track the circle.

![pd-vs-adapt_roll-period](https://user-images.githubusercontent.com/8026163/44003816-4573727a-9e59-11e8-94a1-0729041dd824.png)

***Handling of high winds*** is compared in the next simulation. Here a 50m radius loiter is commanded, however, the wind speed (12 m/s here) is greater than the airspeed. The maximum allowed airspeed reference is set to 15 m/s. Four control formulations are displayed:
1) the current PX4 logic
2) new logic with airspeed incrementing disabled
3) new logic with airspeed incrementing enabled and min ground speed = 0 m/s
4) new logic with airspeed incrementing enabled and min ground speed = 3 m/s 

![high-wind_min-gsp-feas_pos](https://user-images.githubusercontent.com/8026163/44003891-9d2c9aa4-9e5a-11e8-86d9-f09d143c779a.png)

The current PX4 logic has large jumps in roll setpoint due to the hard switch based on the "air-ground" angle and arbitrarily defined 3 m/s ground speed threshold.

![high-wind_min-gsp-feas_roll](https://user-images.githubusercontent.com/8026163/44007035-8fa6187c-9e8e-11e8-9288-7900a42ae84b.png)

The new logic shows each of three modes, 1) run-away mitigation (attempt to reduce the run-away to a minimum), 2) run-away prevention (bring run-away to a halt and hold position), and 3) min ground speed maintenance -- note the forward ground speed does not go below the commanded minimum (if the maximum airspeed would be lower, then the logic would attempt to maintain as much of the minimum as possible, then default to each of the lesser solutions). Airspeed references and forward ground speeds are shown below along with the "bearing feasibility". (note the lagged airspeed response is not shown to de-clutter things, but has a time constant of 1s).

![high-wind_min-gsp-feas_speeds](https://user-images.githubusercontent.com/8026163/44004005-e4e88a0a-9e5b-11e8-9422-b9c6931e7af8.png)

**HITL logs (x-plane, hilstar)**

***Log for small loiter radii (first commit):*** https://review.px4.io/plot_app?log=07bac744-e5dd-4ca4-abc8-524125878682 .  Verified general WP following still works (should not have changed), and both large and small circles are tracked properly with reformulated loiter logic -- the small circle used the automatic period adaptation now present in the controller.

***Log for high winds (first+second commit):***  https://review.px4.io/plot_app?log=dba557a7-8abb-44ec-bd13-43698d6ddf2e . Testing in very high winds (approx. 14 m/s with nominal airspeed reference = 13 m/s). Note my laptop is not powerful enough to send data to x-plane as fast as the EKF always wants -- so when the winds were getting increased, sometimes the GPS position was reset do to the lag in messages -- but after the initial increase in wind speed, things were stable enough in the EKF to test the functionality. Log timeline:
1) stabilized take-off and climb to altitude (also stayed in stabilized while increasing the wind speed)
2) once wind speeds were high enough, auto engaged
3) aircraft "falls" back into first loiter, attempting to follow as best it can while flying with tail wind (very fast!) then as the feasibility function reduces to zero (infeasible tracking), the aircraft turns against the wind to minimize the run-away from the loiter. 
4) params are first set to not increment the airspeed, which means the aircraft is slowly running away at this point.
5) airspeed incrementing is then enabled with minimum ground speed set to zero, the aircraft then increases its airspeed reference to match that of the wind speed and maintain a zero ground velocity (run-away prevention).
6) the minimum ground speed parameter is then changed to a positive value (and the airspeed max also increased to allow the extra reference), and the airspeed reference is increased to maintain this minimum ground speed and follow the loiter. Note on the down-wind segment of the loiter, the airspeed reference is decreased again, as there is no need to waste throttle when the ground speed minimum is not being violated.
7) on the second time around the first loiter - the airspeed max is decreased again to 16 to demonstrate that the minimum ground speed of course cannot be maintained in the head wind leg now, but that the controller maintains as much of this minimum speed as it can -- here 2 m/s of the 3 that are commanded.
8) some general WP following is now commanded -- straight lines may also be tracked with minimum ground speed maintained.

**Open questions on implementation:**
- [x] The airspeed increment is calculated in a 2D approximate of "true airspeed" (i.e. speed relative to the airmass, *not indicated). At the moment, this increment is just directly added to the *indicated airspeed setpoint for TECS -- to be completely correct, this should probably be converted from TAS to IAS before getting added, thought it won't make a huge difference at low altitudes and is anyway only incrementing the total setpoint. -- thoughts? I could make the conversion quite quickly in one more commit.
- [ ] Related to the bullet above, but in my opinion not completely necessary with the small angles considered, is that yet another conversion from 2D to the total airspeed could be done based on the current flight path angle.
- [x] Is the radius already limited to some value greater than zero anywhere else in the navigator or position controller? If not, a minimum can be placed in the ecl controller to avoid the potential of the L1 ratio getting set to zero here [ecl_l1_pos_controller.cpp#L265](https://github.com/PX4/ecl/blob/pr-l1_updates/l1/ecl_l1_pos_controller.cpp#L265). If L1 ratio = 0, this causes a singularity in the acceleration command equation.
**answer:** yes it is constrained in the mission block. [navigator/mission_block.cpp#L508](https://github.com/PX4/Firmware/blob/master/src/modules/navigator/mission_block.cpp#L508)
- [ ] The navigate_heading function was left untouched. Mainly because I was unclear on what the actually goal of the navigate heading function is -- i.e. we should be clear the difference between "heading" and "course" and "yaw". At the moment, it is only used as a yaw controller in fw pos ctrl. This is fine, but perhaps the ground speed based logic for defining the lateral-acceleration doesn't really make sense in that case, as it is anyway controlling something about the air-mass relative (or assuming no sideslip -- body) axis. Probably better to use the airspeed as the nav speed for yaw control. If one wants to use this for course control (e.g. follow a bearing, ground relative), then these same wind robust adaptations can be applied, but would require a little bit of change to the function -- i.e. one would need to specify what exactly the input args are used for.
- [ ] navigate_level_flight function was also left untouched -- this is not currently used anywhere in the fw pos ctrl cpp. However, it may cause erroneous airspeed increases if someone does use this and then also calls the airspeed incrementing function. One way to deal with this would be to place a flag in the navigate level flight function that disables any airspeed increment output. But I wanted some other opinions on this, as the other approach could be that it is the responsibility of whoever uses these functions to call them properly.
- [ ] I wasn't sure what the ground rover module is doing. So I simply added a "zero" wind vector to it to ensure that functionality there has not changed at all.
- [ ] implications for people not using airspeed sensors -- we should probably think about how this should be handled here. @CarlOlsson @dagar
- [ ] Should EKF2_WIND_NOISE be increased to capture some gusting? Or should guidance calculate it's own wind estimate from ground speed, TAS, and yaw (perhaps with some complementary filter on TAS)? -- unless the very low-passed wind estimate is being used elsewhere, better IMHO to do the prior. @priseborough 

**Further work:**
- [ ] This PR only covers the case that the prescribed airspeed maximum is sufficient in the given cases (and that no extra throttle is available even if one wanted to increase the airspeed reference further). If an aircraft has more thrust available for faster airspeeds in even higher wind scenarios - this should be a sequential PR to this and handle that case at the level of TECS. My proposal would be to make a separate guidance specific airspeed maximum (i.e. the maximum airspeed one can command in over-wind scenarios above the TECS specific airspeed max which is set for climb performance and probably should not change, e.g. FW_L1_AIRSP_MAX). Then some likely linear increase in the output thrust from TECS should be used to achieve this airspeed (as @CarlOlsson mentioned in #10078). @priseborough any thoughts on this?

This is quite a big PR, so any help testing this for corner cases etc would be very much appreciated. Also happy to get feedback on anything I've missed / not considered while implementing. @dagar @Antiheavy @CarlOlsson @priseborough