### PR TITLE
Clarify SDLOG_MODE bit for thermal calibration

### DIFF
--- a/Tools/process_sensor_caldata.py
+++ b/Tools/process_sensor_caldata.py
@@ -15,7 +15,7 @@ Data can be gathered using the following sequence:
 
 1) Power up the board and set the TC_A_ENABLE, TC_B_ENABLE and TC_G_ENABLE parameters to 1
 2) Set all CAL_GYR and CAL_ACC parameters to defaults
-3) Set the SDLOG_MODE parameter to 2, and SDLOG_PROFILE parameter to 4 to enable logging of sensor data for calibration and power off
+3) Set the parameter SDLOG_MODE to 2, and SDLOG_PROFILE "Thermal calibration" bit (2) to enable logging of sensor data for calibration and power off
 4) Cold soak the board for 30 minutes
 5) Move to a warm dry, still air, constant pressure environment.
 6) Apply power for 45 minutes, keeping the board still.


### PR DESCRIPTION
This fixes https://github.com/PX4/Firmware/issues/8792 by clarifying that it is a bit that must be set, not a value.