### PR TITLE
pmw3901 optical flow support for fmu-v5

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -345,6 +345,9 @@ then
 
 	# Possible internal compass
 	ist8310 -C -b 5 start
+
+	# Possible pmw3901 optical flow sensor
+	pmw3901 start
 fi
 
 if ver hwcmp PX4_SAME70XPLAINED_V1

--- a/cmake/configs/nuttx_px4fmu-v5_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v5_default.cmake
@@ -32,6 +32,7 @@ set(config_module_list
 	drivers/irlock
 	drivers/mkblctrl
 	drivers/oreoled
+	drivers/pmw3901
 	drivers/pwm_input
 	drivers/pwm_out_sim
 	drivers/px4flow

--- a/src/drivers/pmw3901/pmw3901.cpp
+++ b/src/drivers/pmw3901/pmw3901.cpp
@@ -79,16 +79,20 @@
 #include <board_config.h>
 
 /* Configuration Constants */
-#ifdef PX4_SPI_BUS_EXPANSION
+#if defined PX4_SPI_BUS_EXPANSION		// crazyflie
 #define PMW3901_BUS PX4_SPI_BUS_EXPANSION
+#elif defined PX4_SPI_BUS_EXTERNAL1		// fmu-v5
+#define PMW3901_BUS PX4_SPI_BUS_EXTERNAL1
 #else
-#define PMW3901_BUS 0
+#error "add the required spi bus from board_config.h here"
 #endif
 
-#ifdef PX4_SPIDEV_EXPANSION_2
+#if defined PX4_SPIDEV_EXPANSION_2		// crazyflie flow deck
 #define PMW3901_SPIDEV PX4_SPIDEV_EXPANSION_2
+#elif defined PX4_SPIDEV_EXTERNAL1_1		// fmu-v5 ext CS1
+#define PMW3901_SPIDEV PX4_SPIDEV_EXTERNAL1_1
 #else
-#define PMW3901_SPIDEV 0
+#error "add the required spi dev from board_config.h here"
 #endif
 
 #define PMW3901_SPI_BUS_SPEED (2000000L) // 2MHz


### PR DESCRIPTION
If the pwm3901 module is plugged into the external SPI port on chip-select 1 on fmu-v5, it will start automatically. 

Currently it only runs on the crazyflie.