### PR TITLE
MPC_YAW_MODE - Change max to 3 to enable trajectory alignment

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -718,7 +718,7 @@ PARAM_DEFINE_INT32(MPC_OBS_AVOID, 0);
  * Specifies the heading in Auto.
  *
  * @min 0
- * @max 2
+ * @max 3
  * @value 0 towards waypoint
  * @value 1 towards home
  * @value 2 away from home


### PR DESCRIPTION
There are 4 yaw modes (0 to 3) in auto mode but the max allowed value was 3. 
```
 @value 0 towards waypoint
 @value 1 towards home
 @value 2 away from home
 @value 3 along trajectory
```