### PR TITLE
EKF2: added absolute range altimeter param

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -397,6 +397,8 @@ private:
 		_rng_aid_height_max,	///< maximum allowed absolute altitude (AGL) for range aid (m)
 		(ParamExtFloat<px4::params::EKF2_RNG_A_IGATE>)
 		_rng_aid_innov_gate,	///< gate size used for innovation consistency checks for range aid fusion (STD)
+		(ParamExtInt<px4::params::EKF2_RNG_ABS>)
+		_rng_abs,	///< Boolean. A value of 1 indicates that the range finder sensor always gives an absolute altitude independently from the orientation of the vehicle.
 
 		// vision estimate fusion
 		(ParamFloat<px4::params::EKF2_EVP_NOISE>)
@@ -570,6 +572,7 @@ Ekf2::Ekf2():
 	_rng_aid_hor_vel_max(_params->max_vel_for_range_aid),
 	_rng_aid_height_max(_params->max_hagl_for_range_aid),
 	_rng_aid_innov_gate(_params->range_aid_innov_gate),
+	_rng_abs(_params->rng_abs),
 	_ev_innov_gate(_params->ev_innov_gate),
 	_flow_noise(_params->flow_noise),
 	_flow_noise_qual_min(_params->flow_noise_qual_min),

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -671,6 +671,16 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_GATE, 5.0f);
  */
 PARAM_DEFINE_FLOAT(EKF2_MIN_RNG, 0.1f);
 
+/**
+ * Absolute range finder
+ * 
+ * Boolean. A value of 1 indicates that the range finder sensor always gives an absolute altitude independently from the orientation of the vehicle.
+ * Useful for gimbal-mounted range finders or other absolute sensors.
+ * 
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_RNG_ABS, 0);
 
 /**
  * Measurement noise for vision position observations used when the vision system does not supply error estimates


### PR DESCRIPTION
Added support for absolute distance altimeter or for range finders mounted on a gimbal such that they are always vertical. No need to rotate from body to earth frame.
Used in case of absolute distance provided, no matter of which orientation the copter have.
Be careful that the max limit in roll/pitch to have a valid measure is still active.
A parameter (EKF2_RNG_ABS) is used to enable this feature.

WARNING: requires also the pull request in PX4/ecl with the appropriate modifications to EKF lib.

WARNING2: I was able to see the param in QGC, but I wasn't able to see the meta. Probably it's a QGC cache problem. Double check that metadata is correct.