### PR TITLE
Send PWM_MIN value after a PWM_MAX value while calibrating ESCs

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -273,6 +273,12 @@ struct pwm_output_rc_config {
 #define PWM_SERVO_EXIT_TEST_MODE   18
 #define PWM_SERVO_SET_MODE         _PX4_IOC(_PWM_SERVO_BASE, 34)
 
+/** set calibration low pwm */
+#define PWM_SERVO_SET_CAL_LOW			_PX4_IOC(_PWM_SERVO_BASE, 35)
+
+/** set calibration high pwm */
+#define PWM_SERVO_SET_CAL_HIGH			_PX4_IOC(_PWM_SERVO_BASE, 36)
+
 /*
  *
  *


### PR DESCRIPTION
When the ESC calibration is performed through QGC, the PWM_MIN value is not written appropriately. This can be verified by connecting to the ESC directly through BlHeli Suite.
ESC calibration should be done using the following procedure: Send PWM_MAX value for at least 3 seconds, followed by the PWM_MIN value for at least 3 more seconds. Instead the current implementation sends PWM_MAX value followed by the PWM_DISARMED value.
On the ESCs that I tested, this results in setting the PWM_MIN esc setting to 1012 regardless of the PX4's PWM_MIN value.
The following fix is proposed. Note: PWM values are being sent for 5 seconds, since 3 second long signals weren't detected reliably.
Using this fix, the values written in the ESC (checked with BlHeli Suite) matched PX4 PWM_MIN and PWM_MAX parameter values.
Following plots provide PWM output values during calibration, before and after the fix
![pwm_bad](https://user-images.githubusercontent.com/35773661/54448019-127fde80-474b-11e9-92f0-c8be78b1cf22.png)
![pwm_fixed](https://user-images.githubusercontent.com/35773661/54448077-304d4380-474b-11e9-8300-2d7e8a3846ee.png)