### PR TITLE
Add parameter for requiring Geofence for arming

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -5,6 +5,7 @@ uint8 GF_ACTION_LOITER = 2                  # switch to AUTO|LOITER
 uint8 GF_ACTION_RTL = 3                     # switch to AUTO|RTL
 uint8 GF_ACTION_TERMINATE = 4               # flight termination
 
+bool empty			# true if geofence is not set
 bool geofence_violated		# true if the geofence is violated
 uint8 geofence_action       	# action to take when geofence is violated
 

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -59,6 +59,7 @@
 #include <uORB/topics/sensor_preflight.h>
 #include <uORB/topics/subsystem_info.h>
 #include <uORB/topics/system_power.h>
+#include <uORB/topics/geofence_result.h>
 
 using namespace time_literals;
 
@@ -674,6 +675,46 @@ out:
 	return success;
 }
 
+static bool geofenceCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, bool report_fail)
+{
+
+	int32_t com_arm_geofence;
+	param_get(param_find("COM_ARM_GEOFENCE"), &com_arm_geofence);
+
+	if (com_arm_geofence == 0) {
+		// geofence is not required
+		return true;
+	}
+
+	if (com_arm_geofence == 1 && vehicle_status.nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION) {
+		// check only in mission mode
+		return true;
+	}
+
+	int geofence_sub = orb_subscribe(ORB_ID(geofence_result));
+	geofence_result_s geofence_result;
+	int res = orb_copy(ORB_ID(geofence_result), geofence_sub, &geofence_result);
+	orb_unsubscribe(geofence_sub);
+
+	if (res != PX4_OK) {
+		if (report_fail) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Failed to check GeoFence");
+		}
+
+		return false;
+	}
+
+	if (geofence_result.empty) {
+		if (report_fail) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: GeoFence is not set");
+		}
+
+		return false;
+	}
+
+	return true;
+}
+
 bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 		    vehicle_status_flags_s &status_flags, bool checkGNSS, bool reportFailures, bool prearm,
 		    const hrt_abstime &time_since_boot)
@@ -942,6 +983,11 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 		if (!ekf2Check(mavlink_log_pub, status, false, reportFailures && report_ekf_fail && !failed, checkGNSS)) {
 			failed = true;
 		}
+	}
+
+	/* ---- GeoFence ---- */
+	if (!geofenceCheck(mavlink_log_pub, status, reportFailures && !failed)) {
+		failed = true;
 	}
 
 	/* Report status */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -286,6 +286,20 @@ PARAM_DEFINE_FLOAT(COM_DISARM_LAND, -1.0f);
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 
 /**
+ * Require GeoFence to be set for arming
+ *
+ * The default allows to arm the vehicle without GeoFence
+ *
+ * @group Commander
+ * @min 0
+ * @max 2
+ * @value 0 Allow arming without GeoFence
+ * @value 1 Require GeoFence to arm in mission mode
+ * @value 2 Require GeoFence to arm in all modes
+ */
+PARAM_DEFINE_INT32(COM_ARM_GEOFENCE, 0);
+
+/**
  * Arm switch is only a button
  *
  * The default uses the arm switch as real switch.

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -549,6 +549,7 @@ Navigator::run()
 			have_geofence_position_data = false;
 
 			_geofence_result.timestamp = hrt_absolute_time();
+			_geofence_result.empty = _geofence.isEmpty();
 			_geofence_result.geofence_action = _geofence.getGeofenceAction();
 			_geofence_result.home_required = _geofence.isHomeRequired();
 


### PR DESCRIPTION
For autonomous systems GeoFence can do much job, even rescuing some property from damage (if system's GPS functioning properly).

I propose adding a parameter (`COM_ARM_GEOFENCE`), which makes GeoFence required for arming.

The options are to require GeoFence only for mission mode or for all the modes. The alternative may be requiring it for all the position assisted modes (`OFFBOARD`, `POSCTL`, `TAKEOFF`, ...), which may be more complicated.

Tested in SITL.