### PR TITLE
ModuleBase add common base and cleanup

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -712,6 +712,7 @@ void statusFTDI() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "ls /proc"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "mavlink status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "mavlink status streams"'
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "modules status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "mtd status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param show"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param status"'
@@ -757,6 +758,7 @@ void statusSEGGER() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "ls /proc"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "mavlink status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "mavlink status streams"'
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "modules status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "mtd status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param show"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param status"'
@@ -774,7 +776,7 @@ void statusSEGGER() {
 }
 
 void cleanupFTDI() {
-  // wipe sdcard
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "modules stop-all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "commander stop"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "mavlink stop-all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "navigator stop"'
@@ -795,7 +797,7 @@ void cleanupFTDI() {
 }
 
 void cleanupSEGGER() {
-  // wipe sdcard
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "modules stop-all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "commander stop"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "mavlink stop-all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "navigator stop"'

--- a/boards/aerotenna/ocpoc/default.cmake
+++ b/boards/aerotenna/ocpoc/default.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		param
 		perf

--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -88,6 +88,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/atlflight/eagle/default.cmake
+++ b/boards/atlflight/eagle/default.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		#hardfault_log
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		#mtd

--- a/boards/atlflight/excelsior/default.cmake
+++ b/boards/atlflight/excelsior/default.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		#hardfault_log
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		#mtd

--- a/boards/auav/x21/default.cmake
+++ b/boards/auav/x21/default.cmake
@@ -88,6 +88,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -88,6 +88,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		nshterm

--- a/boards/beaglebone/blue/default.cmake
+++ b/boards/beaglebone/blue/default.cmake
@@ -60,6 +60,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		param
 		perf

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -42,6 +42,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		param
 		perf

--- a/boards/emlid/navio2/navio_rgbled/NavioRGBLed.cpp
+++ b/boards/emlid/navio2/navio_rgbled/NavioRGBLed.cpp
@@ -130,8 +130,7 @@ int NavioRGBLed::task_spawn(int argc, char *argv[])
 	NavioRGBLed *instance = new NavioRGBLed();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init() == PX4_OK) {
 			return PX4_OK;
@@ -142,8 +141,6 @@ int NavioRGBLed::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/holybro/durandal-v1/stackcheck.cmake
+++ b/boards/holybro/durandal-v1/stackcheck.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -86,6 +86,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -92,6 +92,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -90,6 +90,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -91,6 +91,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -89,6 +89,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -89,6 +89,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -90,6 +90,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -58,6 +58,7 @@ px4_add_board(
 		uavcan
 
 	MODULES
+		airspeed_selector
 		attitude_estimator_q
 		camera_feedback
 		commander
@@ -66,7 +67,6 @@ px4_add_board(
 		events
 		fw_att_control
 		fw_pos_control_l1
-		rover_pos_control
 		land_detector
 		landing_target_estimator
 		load_mon
@@ -77,13 +77,12 @@ px4_add_board(
 		mc_rate_control
 		mc_pos_control
 		navigator
-		battery_status
 		rc_update
+		rover_pos_control
 		sensors
 		sih
 		vmount
 		vtol_att_control
-		airspeed_selector
 
 	SYSTEMCMDS
 		bl_update
@@ -95,6 +94,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -70,6 +70,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -58,6 +58,7 @@ px4_add_board(
 		uavcan
 
 	MODULES
+		airspeed_selector
 		attitude_estimator_q
 		camera_feedback
 		commander
@@ -66,7 +67,6 @@ px4_add_board(
 		events
 		fw_att_control
 		fw_pos_control_l1
-		rover_pos_control
 		land_detector
 		landing_target_estimator
 		load_mon
@@ -77,13 +77,12 @@ px4_add_board(
 		mc_rate_control
 		mc_pos_control
 		navigator
-		battery_status
 		rc_update
+		rover_pos_control
 		sensors
 		sih
 		vmount
 		vtol_att_control
-		airspeed_selector
 
 	SYSTEMCMDS
 		bl_update
@@ -95,6 +94,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -80,6 +80,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -70,6 +70,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -60,6 +60,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		param
 		perf

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -54,6 +54,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		#mtd

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -56,6 +56,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		#mtd

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -54,6 +54,7 @@ px4_add_board(
 		esc_calib
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		#mtd

--- a/boards/uvify/core/default.cmake
+++ b/boards/uvify/core/default.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		i2cdetect
 		led_control
 		mixer
+		modules
 		motor_ramp
 		motor_test
 		mtd

--- a/platforms/common/include/px4_platform_common/module.h
+++ b/platforms/common/include/px4_platform_common/module.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,12 +44,22 @@
 #include <px4_platform_common/atomic.h>
 #include <px4_platform_common/time.h>
 #include <px4_platform_common/log.h>
+#include <px4_platform_common/posix.h>
 #include <px4_platform_common/tasks.h>
 #include <systemlib/px4_macros.h>
 
 #ifdef __cplusplus
 
+#include <containers/List.hpp>
+#include <containers/LockGuard.hpp>
+
 #include <cstring>
+
+/** @var task_id_is_work_queue Value to indicate if the task runs on the work queue. */
+static constexpr const int task_id_is_work_queue = -2;
+
+class ModuleBaseInterface;
+extern List<ModuleBaseInterface *> px4_modules_list;
 
 /**
  * @brief This mutex protects against race conditions during startup & shutdown of modules.
@@ -58,6 +68,87 @@
  *        contention here, as module startup is sequential.
  */
 extern pthread_mutex_t px4_modules_mutex;
+
+class ModuleBaseInterface : public ListNode<ModuleBaseInterface *>
+{
+public:
+	ModuleBaseInterface(const char *name) :
+		_module_name(name)
+	{
+		px4_modules_list.add(this);
+	}
+
+	virtual ~ModuleBaseInterface()
+	{
+		px4_modules_list.remove(this);
+	}
+
+	const char *get_name() const { return _module_name; }
+
+	/**
+	 * @brief Print the status if the module is running. This can be overridden by the module to provide
+	 * more specific information.
+	 * @return Returns 0 iff successful, -1 otherwise.
+	 */
+	virtual int print_status()
+	{
+		PX4_INFO_RAW("[%s] running", _module_name);
+		return 0;
+	}
+
+	/**
+	 * @brief Tells the module to stop (used from outside or inside the module thread).
+	 */
+	virtual void request_stop() { _task_should_exit.store(true); }
+
+	int task_id() const { return _task_id.load(); }
+	void set_task_id(int id) { _task_id.store(id); }
+
+	/**
+	 * @brief Main loop method for modules running in their own thread. Called from run_trampoline().
+	 *        This method must return when should_exit() returns true.
+	 */
+	virtual void run() {};
+
+	bool running() { return (task_id() != -1); }
+
+	/**
+	 * @brief Checks if the module should stop (used within the module thread).
+	 * @return Returns True iff successful, false otherwise.
+	 */
+	bool should_exit() const { return _task_should_exit.load(); }
+
+protected:
+
+	/**
+	 * @brief lock_module Mutex to lock the module thread.
+	 */
+	static void lock_module() { pthread_mutex_lock(&px4_modules_mutex); }
+
+	/**
+	 * @brief unlock_module Mutex to unlock the module thread.
+	 */
+	static void unlock_module() { pthread_mutex_unlock(&px4_modules_mutex); }
+
+	const char *_module_name;
+
+	/** @var _task_should_exit Boolean flag to indicate if the task should exit. */
+	px4::atomic_bool _task_should_exit{false};
+
+	/** @var _task_id The task handle: -1 = invalid, otherwise task is assumed to be running. */
+	px4::atomic_int _task_id{-1};
+
+};
+
+ModuleBaseInterface *moduleInstance(const char *name);
+bool moduleRunning(const char *name);
+int moduleStop(const char *name);
+int moduleStatus(const char *name);
+void moduleExitAndCleanup(const char *name);
+int moduleWaitUntilRunning(const char *name);
+
+void modulesStatusAll();
+void modulesStopAll();
 
 /**
  * @class ModuleBase
@@ -75,9 +166,8 @@ extern pthread_mutex_t px4_modules_mutex;
  *      static int task_spawn(int argc, char *argv[])
  *      {
  *              // call px4_task_spawn_cmd() with &run_trampoline as startup method
- *              // optional: wait until _object is not null, which means the task got initialized (use a timeout)
- *              // set _task_id and return 0
- *              // on error return != 0 (and _task_id must be -1)
+ *              // optional: wait until object is not null, which means the task got initialized (use a timeout)
+ *              // on error return != 0
  *      }
  *
  *      static T *instantiate(int argc, char *argv[])
@@ -104,19 +194,24 @@ extern pthread_mutex_t px4_modules_mutex;
  * - custom_command & print_usage as above
  *      static int task_spawn(int argc, char *argv[]) {
  *              // parse the arguments
- *              // set _object (here or from the work_queue() callback)
+ *              // set object (here or from the work_queue() callback)
  *              // call work_queue() (with a custom cycle trampoline)
- *              // optional: wait until _object is not null, which means the task got initialized (use a timeout)
- *              // set _task_id to task_id_is_work_queue and return 0
- *              // on error return != 0 (and _task_id must be -1)
+ *              // instance->set_task_id(task_id_is_work_queue); and return 0
+ *              // on error return != 0
  *      }
  */
 template<class T>
-class ModuleBase
+class ModuleBase : public ModuleBaseInterface
 {
 public:
-	ModuleBase() : _task_should_exit{false} {}
-	virtual ~ModuleBase() {}
+	ModuleBase() : ModuleBaseInterface(get_name_static())
+	{}
+
+	virtual ~ModuleBase() = default;
+
+#if defined(MODULE_NAME)
+	static constexpr const char *get_name_static() { return MODULE_NAME; }
+#endif // MODULE_NAME
 
 	/**
 	 * @brief main Main entry point to the module that should be
@@ -132,6 +227,7 @@ public:
 		    strcmp(argv[1], "help")  == 0 ||
 		    strcmp(argv[1], "info")  == 0 ||
 		    strcmp(argv[1], "usage") == 0) {
+
 			return T::print_usage();
 		}
 
@@ -141,18 +237,14 @@ public:
 		}
 
 		if (strcmp(argv[1], "status") == 0) {
-			return status_command();
+			return moduleStatus(get_name_static());
 		}
 
 		if (strcmp(argv[1], "stop") == 0) {
-			return stop_command();
+			return moduleStop(get_name_static());
 		}
 
-		lock_module(); // Lock here, as the method could access _object.
-		int ret = T::custom_command(argc - 1, argv + 1);
-		unlock_module();
-
-		return ret;
+		return T::custom_command(argc - 1, argv + 1);
 	}
 
 	/**
@@ -175,15 +267,19 @@ public:
 		argv += 1;
 #endif
 
+		// lock module, instantiate will create module object and add to list
+		lock_module();
 		T *object = T::instantiate(argc, argv);
-		_object.store(object);
 
 		if (object) {
+			object->set_task_id(px4_getpid());
+			unlock_module();
 			object->run();
 
 		} else {
 			PX4_ERR("failed to instantiate object");
 			ret = -1;
+			unlock_module();
 		}
 
 		exit_and_cleanup();
@@ -201,9 +297,9 @@ public:
 	static int start_command_base(int argc, char *argv[])
 	{
 		int ret = 0;
-		lock_module();
+		LockGuard lg(px4_modules_mutex);
 
-		if (is_running()) {
+		if (moduleRunning(get_name_static())) {
 			ret = -1;
 			PX4_ERR("Task already running");
 
@@ -215,100 +311,14 @@ public:
 			}
 		}
 
-		unlock_module();
 		return ret;
-	}
-
-	/**
-	 * @brief Stops the command, ('command stop'), checks if it is running and if it is, request the module to stop
-	 *        and waits for the task to complete.
-	 * @return Returns 0 iff successful, -1 otherwise.
-	 */
-	static int stop_command()
-	{
-		int ret = 0;
-		lock_module();
-
-		if (is_running()) {
-			T *object = _object.load();
-
-			if (object) {
-				object->request_stop();
-
-				unsigned int i = 0;
-
-				do {
-					unlock_module();
-					px4_usleep(20000); // 20 ms
-					lock_module();
-
-					if (++i > 100 && _task_id != -1) { // wait at most 2 sec
-						if (_task_id != task_id_is_work_queue) {
-							px4_task_delete(_task_id);
-						}
-
-						_task_id = -1;
-
-						delete _object.load();
-						_object.store(nullptr);
-
-						ret = -1;
-						break;
-					}
-				} while (_task_id != -1);
-
-			} else {
-				// In the very unlikely event that can only happen on work queues,
-				// if the starting thread does not wait for the work queue to initialize,
-				// and inside the work queue, the allocation of _object fails
-				// and exit_and_cleanup() is not called, set the _task_id as invalid.
-				_task_id = -1;
-			}
-		}
-
-		unlock_module();
-		return ret;
-	}
-
-	/**
-	 * @brief Handle 'command status': check if running and call print_status() if it is
-	 * @return Returns 0 iff successful, -1 otherwise.
-	 */
-	static int status_command()
-	{
-		int ret = -1;
-		lock_module();
-
-		if (is_running() && _object.load()) {
-			T *object = _object.load();
-			ret = object->print_status();
-
-		} else {
-			PX4_INFO("not running");
-		}
-
-		unlock_module();
-		return ret;
-	}
-
-	/**
-	 * @brief Print the status if the module is running. This can be overridden by the module to provide
-	 * more specific information.
-	 * @return Returns 0 iff successful, -1 otherwise.
-	 */
-	virtual int print_status()
-	{
-		PX4_INFO("running");
-		return 0;
 	}
 
 	/**
 	 * @brief Main loop method for modules running in their own thread. Called from run_trampoline().
 	 *        This method must return when should_exit() returns true.
 	 */
-	virtual void run()
-	{
-	}
+	virtual void run() {}
 
 	/**
 	 * @brief Returns the status of the module.
@@ -316,117 +326,35 @@ public:
 	 */
 	static bool is_running()
 	{
-		return _task_id != -1;
+		LockGuard lg(px4_modules_mutex);
+		return moduleRunning(get_name_static());
 	}
 
 protected:
-
-	/**
-	 * @brief Tells the module to stop (used from outside or inside the module thread).
-	 */
-	virtual void request_stop()
-	{
-		_task_should_exit.store(true);
-	}
-
-	/**
-	 * @brief Checks if the module should stop (used within the module thread).
-	 * @return Returns True iff successful, false otherwise.
-	 */
-	bool should_exit() const
-	{
-		return _task_should_exit.load();
-	}
 
 	/**
 	 * @brief Exits the module and delete the object. Called from within the module's thread.
 	 *        For work queue modules, this needs to be called from the derived class in the
 	 *        cycle method, when should_exit() returns true.
 	 */
-	static void exit_and_cleanup()
-	{
-		// Take the lock here:
-		// - if startup fails and we're faster than the parent thread, it will set
-		//   _task_id and subsequently it will look like the task is running.
-		// - deleting the object must take place inside the lock.
-		lock_module();
-
-		delete _object.load();
-		_object.store(nullptr);
-
-		_task_id = -1; // Signal a potentially waiting thread for the module to exit that it can continue.
-		unlock_module();
-	}
+	static void exit_and_cleanup() { moduleExitAndCleanup(get_name_static()); }
 
 	/**
 	 * @brief Waits until _object is initialized, (from the new thread). This can be called from task_spawn().
 	 * @return Returns 0 iff successful, -1 on timeout or otherwise.
 	 */
-	static int wait_until_running()
-	{
-		int i = 0;
-
-		do {
-			/* Wait up to 1s. */
-			px4_usleep(2500);
-
-		} while (!_object.load() && ++i < 400);
-
-		if (i == 400) {
-			PX4_ERR("Timed out while waiting for thread to start");
-			return -1;
-		}
-
-		return 0;
-	}
+	static int wait_until_running() { return moduleWaitUntilRunning(get_name_static()); }
 
 	/**
 	 * @brief Get the module's object instance, (this is null if it's not running).
 	 */
 	static T *get_instance()
 	{
-		return (T *)_object.load();
+		LockGuard lg(px4_modules_mutex);
+		return (T *)moduleInstance(get_name_static());
 	}
 
-	/**
-	 * @var _object Instance if the module is running.
-	 * @note There will be one instance for each template type.
-	 */
-	static px4::atomic<T *> _object;
-
-	/** @var _task_id The task handle: -1 = invalid, otherwise task is assumed to be running. */
-	static int _task_id;
-
-	/** @var task_id_is_work_queue Value to indicate if the task runs on the work queue. */
-	static constexpr const int task_id_is_work_queue = -2;
-
-private:
-	/**
-	 * @brief lock_module Mutex to lock the module thread.
-	 */
-	static void lock_module()
-	{
-		pthread_mutex_lock(&px4_modules_mutex);
-	}
-
-	/**
-	 * @brief unlock_module Mutex to unlock the module thread.
-	 */
-	static void unlock_module()
-	{
-		pthread_mutex_unlock(&px4_modules_mutex);
-	}
-
-	/** @var _task_should_exit Boolean flag to indicate if the task should exit. */
-	px4::atomic_bool _task_should_exit{false};
 };
-
-template<class T>
-px4::atomic<T *> ModuleBase<T>::_object{nullptr};
-
-template<class T>
-int ModuleBase<T>::_task_id = -1;
-
 
 #endif /* __cplusplus */
 

--- a/platforms/common/module.cpp
+++ b/platforms/common/module.cpp
@@ -43,8 +43,149 @@
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/defines.h>
 #include <px4_platform_common/log.h>
+#include <containers/LockGuard.hpp>
 
 pthread_mutex_t px4_modules_mutex = PTHREAD_MUTEX_INITIALIZER;
+List<ModuleBaseInterface *> px4_modules_list;
+
+ModuleBaseInterface *moduleInstance(const char *name)
+{
+	// search list
+	for (ModuleBaseInterface *module : px4_modules_list) {
+		if (strcmp(module->get_name(), name) == 0) {
+			return module;
+		}
+	}
+
+	return nullptr;
+}
+
+bool moduleRunning(const char *name)
+{
+	// search list
+	ModuleBaseInterface *module = moduleInstance(name);
+
+	if (module != nullptr) {
+		return module->running();
+	}
+
+	return false;
+}
+
+int moduleStop(const char *name)
+{
+	int ret = 0;
+	pthread_mutex_lock(&px4_modules_mutex);
+
+	if (moduleRunning(name)) {
+
+		ModuleBaseInterface *object = nullptr;
+		unsigned int i = 0;
+
+		do {
+			// search for module again to request stop
+			object = moduleInstance(name);
+
+			if (object != nullptr) {
+				object->request_stop();
+
+				pthread_mutex_unlock(&px4_modules_mutex);
+				px4_usleep(20000); // 20 ms
+				pthread_mutex_lock(&px4_modules_mutex);
+
+				// search for module again to check status
+				object = moduleInstance(name);
+
+				if (++i > 100 && (object != nullptr)) { // wait at most 2 sec
+					const int task_id = object->task_id();
+
+					if (task_id != task_id_is_work_queue) {
+						px4_task_delete(task_id);
+					}
+
+					delete object;
+					object = nullptr;
+
+					ret = -1;
+					break;
+				}
+			}
+		} while (object != nullptr);
+	}
+
+	pthread_mutex_unlock(&px4_modules_mutex);
+	return ret;
+}
+
+void moduleExitAndCleanup(const char *name)
+{
+	// Take the lock here:
+	// - if startup fails and we're faster than the parent thread, it will set
+	//   _task_id and subsequently it will look like the task is running.
+	// - deleting the object must take place inside the lock.
+	LockGuard lg(px4_modules_mutex);
+	delete moduleInstance(name);
+}
+
+int moduleWaitUntilRunning(const char *name)
+{
+	int i = 0;
+
+	do {
+		// Wait up to 1s.
+		px4_usleep(2500);
+
+	} while (!moduleInstance(name) && ++i < 400);
+
+	if (i == 400) {
+		PX4_ERR("Timed out while waiting for %s thread to start", name);
+		return -1;
+	}
+
+	return 0;
+}
+
+int moduleStatus(const char *name)
+{
+	LockGuard lg(px4_modules_mutex);
+	ModuleBaseInterface *object = moduleInstance(name);
+
+	if (object && object->running()) {
+		return object->print_status();
+
+	} else {
+		PX4_INFO("%s not running", name);
+	}
+
+	return -1;
+}
+
+void modulesStatusAll()
+{
+	LockGuard lg(px4_modules_mutex);
+
+	for (ModuleBaseInterface *module : px4_modules_list) {
+		if (module->task_id() == task_id_is_work_queue) {
+			PX4_INFO("Running: %s (WQ)", module->get_name());
+
+		} else if (module->task_id() > 0) {
+			PX4_INFO("Running: %s (PID: %d)", module->get_name(), module->task_id());
+
+		} else {
+			PX4_ERR("Invalid task id: %s (ID: %d)", module->get_name(), module->task_id());
+		}
+	}
+}
+
+void modulesStopAll()
+{
+	LockGuard lg(px4_modules_mutex);
+
+	for (ModuleBaseInterface *module : px4_modules_list) {
+		PX4_INFO("Stopping: %s", module->get_name());
+		module->request_stop();
+	}
+}
 
 #ifndef __PX4_NUTTX
 

--- a/posix-configs/SITL/init/test/test_shutdown
+++ b/posix-configs/SITL/init/test/test_shutdown
@@ -65,19 +65,9 @@ uorb status
 
 # stop all
 echo "Stopping all modules"
+modules stop-all
 logger stop
-pwm_out_sim stop
-mc_rate_control stop
-mc_att_control stop
-fw_att_control stop
-mc_pos_control stop
-fw_pos_control_l1 stop
-navigator stop
 commander stop
-land_detector stop
-ekf2 stop
-airspeed_selector stop
-sensors stop
 
 sleep 2
 
@@ -85,6 +75,7 @@ simulator stop
 tone_alarm stop
 
 dataman stop
+sleep 2
 #uorb stop
 
 shutdown

--- a/src/drivers/adc/ADC.cpp
+++ b/src/drivers/adc/ADC.cpp
@@ -289,7 +289,7 @@ int ADC::custom_command(int argc, char *argv[])
 
 	if (!strcmp(verb, "test")) {
 		if (is_running()) {
-			return _object.load()->test();
+			return get_instance()->test();
 		}
 
 		return PX4_ERROR;
@@ -303,8 +303,7 @@ int ADC::task_spawn(int argc, char *argv[])
 	ADC *instance = new ADC(SYSTEM_ADC_BASE, ADC_CHANNELS);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init() == PX4_OK) {
 			return PX4_OK;
@@ -315,8 +314,6 @@ int ADC::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -132,8 +132,7 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 			}
 
 			// Successful read of device type, we've found our battery
-			_object.store(dev);
-			_task_id = task_id_is_work_queue;
+			dev->set_task_id(task_id_is_work_queue);
 
 			dev->ScheduleOnInterval(BATT_SMBUS_MEASUREMENT_INTERVAL_US);
 

--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -749,11 +749,8 @@ int PGA460::task_spawn(int argc, char *argv[])
 					 entry_point, (char *const *)argv);
 
 	if (task_id < 0) {
-		task_id = -1;
 		return -errno;
 	}
-
-	_task_id = task_id;
 
 	return PX4_OK;
 }

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -470,8 +470,7 @@ DShotOutput::task_spawn(int argc, char *argv[])
 	DShotOutput *instance = new DShotOutput();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init() == PX4_OK) {
 			return PX4_OK;
@@ -482,8 +481,6 @@ DShotOutput::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1075,10 +1075,6 @@ int GPS::task_spawn(int argc, char *argv[], Instance instance)
 		return -errno;
 	}
 
-	if (instance == Instance::Main) {
-		_task_id = task_id;
-	}
-
 	return 0;
 }
 

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -185,8 +185,7 @@ int Heater::task_spawn(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	_object.store(heater);
-	_task_id = task_id_is_work_queue;
+	heater->set_task_id(task_id_is_work_queue);
 
 	heater->start();
 

--- a/src/drivers/osd/atxxxx/atxxxx.cpp
+++ b/src/drivers/osd/atxxxx/atxxxx.cpp
@@ -86,8 +86,7 @@ OSDatxxxx::task_spawn(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	_object.store(osd);
-	_task_id = task_id_is_work_queue;
+	osd->set_task_id(task_id_is_work_queue);
 
 	osd->start();
 

--- a/src/drivers/osd/atxxxx/atxxxx.h
+++ b/src/drivers/osd/atxxxx/atxxxx.h
@@ -78,7 +78,8 @@
 
 extern "C" __EXPORT int atxxxx_main(int argc, char *argv[]);
 
-class OSDatxxxx : public device::SPI, public ModuleBase<OSDatxxxx>, public ModuleParams, public px4::ScheduledWorkItem
+class OSDatxxxx : public device::SPI, public ModuleBase<OSDatxxxx>, public ModuleParams,
+	public px4::ScheduledWorkItem
 {
 public:
 	OSDatxxxx(int bus = OSD_BUS);

--- a/src/drivers/pwm_input/pwm_input.cpp
+++ b/src/drivers/pwm_input/pwm_input.cpp
@@ -43,8 +43,7 @@ PWMIN::task_spawn(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	_object.store(pwmin);
-	_task_id = task_id_is_work_queue;
+	pwmin->set_task_id(task_id_is_work_queue);
 
 	pwmin->start();
 
@@ -60,7 +59,6 @@ PWMIN::start()
 	// Initialize the timer isr for measuring pulse widths. Publishing is done inside the isr.
 	timer_init();
 }
-
 
 void
 PWMIN::timer_init(void)

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -259,8 +259,7 @@ PWMSim::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
-	_object.store(instance);
-	_task_id = task_id_is_work_queue;
+	instance->set_task_id(task_id_is_work_queue);
 	instance->ScheduleNow();
 	return 0;
 }

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -131,6 +131,8 @@ public:
 
 	void Run() override;
 
+	void request_stop() override { _task_should_exit.store(true); ScheduleNow(); }
+
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
@@ -670,8 +672,7 @@ PX4FMU::task_spawn(int argc, char *argv[])
 	PX4FMU *instance = new PX4FMU();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init() == PX4_OK) {
 			return PX4_OK;
@@ -682,8 +683,6 @@ PX4FMU::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -155,8 +155,7 @@ RCInput::task_spawn(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	_object.store(instance);
-	_task_id = task_id_is_work_queue;
+	instance->set_task_id(task_id_is_work_queue);
 
 	instance->ScheduleOnInterval(_current_update_interval);
 

--- a/src/drivers/safety_button/SafetyButton.cpp
+++ b/src/drivers/safety_button/SafetyButton.cpp
@@ -166,8 +166,7 @@ SafetyButton::task_spawn(int argc, char *argv[])
 		SafetyButton *instance = new SafetyButton();
 
 		if (instance) {
-			_object.store(instance);
-			_task_id = task_id_is_work_queue;
+			instance->set_task_id(task_id_is_work_queue);
 
 			if (instance->Start() == PX4_OK) {
 				return PX4_OK;
@@ -178,8 +177,6 @@ SafetyButton::task_spawn(int argc, char *argv[])
 		}
 
 		delete instance;
-		_object.store(nullptr);
-		_task_id = -1;
 	}
 
 	return PX4_ERROR;

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -724,22 +724,20 @@ void TAP_ESC::run()
 int TAP_ESC::task_spawn(int argc, char *argv[])
 {
 	/* start the task */
-	_task_id = px4_task_spawn_cmd("tap_esc",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_ACTUATOR_OUTPUTS,
-				      1180,
-				      (px4_main_t)&run_trampoline,
-				      argv);
+	int task_id = px4_task_spawn_cmd("tap_esc",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_ACTUATOR_OUTPUTS,
+					 1180,
+					 (px4_main_t)&run_trampoline,
+					 argv);
 
-	if (_task_id < 0) {
+	if (task_id < 0) {
 		PX4_ERR("task start failed");
-		_task_id = -1;
 		return PX4_ERROR;
 	}
 
 	// wait until task is up & running
 	if (wait_until_running() < 0) {
-		_task_id = -1;
 		return -1;
 	}
 

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -202,13 +202,12 @@ AirspeedModule::task_spawn(int argc, char *argv[])
 		return PX4_ERROR;
 	}
 
-	_object.store(dev);
+	dev->set_task_id(task_id_is_work_queue);
 
 	dev->ScheduleOnInterval(SCHEDULE_INTERVAL, 10000);
-	_task_id = task_id_is_work_queue;
 	return PX4_OK;
-
 }
+
 void
 AirspeedModule::init()
 {

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -559,8 +559,7 @@ AttitudeEstimatorQ::task_spawn(int argc, char *argv[])
 	AttitudeEstimatorQ *instance = new AttitudeEstimatorQ();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -571,8 +570,6 @@ AttitudeEstimatorQ::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -286,8 +286,7 @@ BatteryStatus::task_spawn(int argc, char *argv[])
 	BatteryStatus *instance = new BatteryStatus();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -298,8 +297,6 @@ BatteryStatus::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/camera_feedback/CameraFeedback.cpp
+++ b/src/modules/camera_feedback/CameraFeedback.cpp
@@ -125,8 +125,7 @@ CameraFeedback::task_spawn(int argc, char *argv[])
 	CameraFeedback *instance = new CameraFeedback();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -137,8 +136,6 @@ CameraFeedback::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3463,15 +3463,14 @@ int Commander::custom_command(int argc, char *argv[])
 
 int Commander::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("commander",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_DEFAULT + 40,
-				      3250,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("commander",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_DEFAULT + 40,
+					 3250,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -2417,8 +2417,7 @@ int Ekf2::task_spawn(int argc, char *argv[])
 	Ekf2 *instance = new Ekf2(replay_mode);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -2429,8 +2428,6 @@ int Ekf2::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/events/send_event.cpp
+++ b/src/modules/events/send_event.cpp
@@ -57,14 +57,6 @@ int SendEvent::task_spawn(int argc, char *argv[])
 		return ret;
 	}
 
-	ret = wait_until_running();
-
-	if (ret < 0) {
-		return ret;
-	}
-
-	_task_id = task_id_is_work_queue;
-
 	return 0;
 }
 
@@ -109,8 +101,8 @@ void SendEvent::initialize_trampoline(void *arg)
 		return;
 	}
 
+	send_event->set_task_id(task_id_is_work_queue);
 	send_event->start();
-	_object.store(send_event);
 }
 
 void SendEvent::cycle_trampoline(void *arg)

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -713,8 +713,7 @@ int FixedwingAttitudeControl::task_spawn(int argc, char *argv[])
 	FixedwingAttitudeControl *instance = new FixedwingAttitudeControl(vtol);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -725,8 +724,6 @@ int FixedwingAttitudeControl::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -90,6 +90,8 @@ public:
 
 	void Run() override;
 
+	void request_stop() override { _task_should_exit.store(true); ScheduleNow(); }
+
 	bool init();
 
 private:

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1925,8 +1925,7 @@ int FixedwingPositionControl::task_spawn(int argc, char *argv[])
 	FixedwingPositionControl *instance = new FixedwingPositionControl(vtol);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -1937,8 +1936,6 @@ int FixedwingPositionControl::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -165,6 +165,8 @@ private:
 
 	void Run() override;
 
+	void request_stop() override { _task_should_exit.store(true); ScheduleNow(); }
+
 	void _update_state();
 
 	void _update_total_flight_time();

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -93,9 +93,7 @@ int LandDetector::task_spawn(int argc, char *argv[])
 	strncpy(_currentMode, argv[1], sizeof(_currentMode) - 1);
 	_currentMode[sizeof(_currentMode) - 1] = '\0';
 
-	_object.store(obj);
-	_task_id = task_id_is_work_queue;
-
+	obj->set_task_id(task_id_is_work_queue);
 	obj->start();
 
 	return PX4_OK;

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -90,6 +90,8 @@ private:
 	/** Do a compute and schedule the next cycle. */
 	void Run() override;
 
+	void request_stop() override { _task_should_exit.store(true); ScheduleNow(); }
+
 	/** Do a calculation of the CPU load and publish it. */
 	void _cpuload();
 
@@ -139,8 +141,7 @@ int LoadMon::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
-	_object.store(obj);
-	_task_id = task_id_is_work_queue;
+	obj->set_task_id(task_id_is_work_queue);
 
 	/* Schedule a cycle to start things. */
 	obj->start();

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -1005,8 +1005,7 @@ BlockLocalPositionEstimator::task_spawn(int argc, char *argv[])
 	BlockLocalPositionEstimator *instance = new BlockLocalPositionEstimator();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -1017,8 +1016,6 @@ BlockLocalPositionEstimator::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -158,15 +158,14 @@ int Logger::custom_command(int argc, char *argv[])
 
 int Logger::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("logger",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_LOG_CAPTURE,
-				      3700,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("logger",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_LOG_CAPTURE,
+					 3700,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -80,6 +80,8 @@ public:
 
 	void Run() override;
 
+	void request_stop() override { ModuleBaseInterface::request_stop(); ScheduleNow(); }
+
 	bool init();
 
 private:

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -360,8 +360,7 @@ int MulticopterAttitudeControl::task_spawn(int argc, char *argv[])
 	MulticopterAttitudeControl *instance = new MulticopterAttitudeControl(vtol);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -372,8 +371,6 @@ int MulticopterAttitudeControl::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1052,8 +1052,7 @@ int MulticopterPositionControl::task_spawn(int argc, char *argv[])
 	MulticopterPositionControl *instance = new MulticopterPositionControl(vtol);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -1064,8 +1063,6 @@ int MulticopterPositionControl::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -338,8 +338,7 @@ int MulticopterRateControl::task_spawn(int argc, char *argv[])
 	MulticopterRateControl *instance = new MulticopterRateControl(vtol);
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -350,8 +349,6 @@ int MulticopterRateControl::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -90,7 +90,7 @@ class Navigator : public ModuleBase<Navigator>, public ModuleParams
 {
 public:
 	Navigator();
-	~Navigator() override;
+	virtual ~Navigator() override;
 
 	Navigator(const Navigator &) = delete;
 	Navigator operator=(const Navigator &) = delete;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -697,15 +697,14 @@ Navigator::run()
 
 int Navigator::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("navigator",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_NAVIGATION,
-				      1800,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("navigator",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_NAVIGATION,
+					 1800,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -558,8 +558,7 @@ RCUpdate::task_spawn(int argc, char *argv[])
 	RCUpdate *instance = new RCUpdate();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -570,8 +569,6 @@ RCUpdate::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/replay/Replay.cpp
+++ b/src/modules/replay/Replay.cpp
@@ -967,15 +967,14 @@ Replay::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
-	_task_id = px4_task_spawn_cmd("replay",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_MAX - 5,
-				      4000,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("replay",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_MAX - 5,
+					 4000,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -538,14 +538,14 @@ RoverPositionControl::run()
 int RoverPositionControl::task_spawn(int argc, char *argv[])
 {
 	/* start the task */
-	_task_id = px4_task_spawn_cmd("rover_pos_ctrl",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_POSITION_CONTROL,
-				      1700,
-				      (px4_main_t)&RoverPositionControl::run_trampoline,
-				      nullptr);
+	int task_id = px4_task_spawn_cmd("rover_pos_ctrl",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_POSITION_CONTROL,
+					 1700,
+					 (px4_main_t)&RoverPositionControl::run_trampoline,
+					 nullptr);
 
-	if (_task_id < 0) {
+	if (task_id < 0) {
 		warn("task start failed");
 		return -errno;
 	}

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -499,15 +499,14 @@ Sensors::run()
 int Sensors::task_spawn(int argc, char *argv[])
 {
 	/* start the task */
-	_task_id = px4_task_spawn_cmd("sensors",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_SENSOR_HUB,
-				      2000,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("sensors",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_SENSOR_HUB,
+					 2000,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 

--- a/src/modules/sih/sih.cpp
+++ b/src/modules/sih/sih.cpp
@@ -64,15 +64,14 @@ int Sih::custom_command(int argc, char *argv[])
 
 int Sih::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("sih",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_MAX,
-				      1024,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("sih",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_MAX,
+					 1024,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -438,8 +438,7 @@ VtolAttitudeControl::task_spawn(int argc, char *argv[])
 	VtolAttitudeControl *instance = new VtolAttitudeControl();
 
 	if (instance) {
-		_object.store(instance);
-		_task_id = task_id_is_work_queue;
+		instance->set_task_id(task_id_is_work_queue);
 
 		if (instance->init()) {
 			return PX4_OK;
@@ -450,8 +449,6 @@ VtolAttitudeControl::task_spawn(int argc, char *argv[])
 	}
 
 	delete instance;
-	_object.store(nullptr);
-	_task_id = -1;
 
 	return PX4_ERROR;
 }

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -104,6 +104,8 @@ public:
 
 	void Run() override;
 
+	void request_stop() override { _task_should_exit.store(true); ScheduleNow(); }
+
 	bool init();
 
 	bool is_fixed_wing_requested();

--- a/src/systemcmds/modules/CMakeLists.txt
+++ b/src/systemcmds/modules/CMakeLists.txt
@@ -1,0 +1,41 @@
+############################################################################
+#
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE systemcmds__modules
+	MAIN modules
+	STACK_MAIN 2500
+	COMPILE_FLAGS
+	SRCS
+		modules.cpp
+	DEPENDS
+	)

--- a/src/systemcmds/modules/modules.cpp
+++ b/src/systemcmds/modules/modules.cpp
@@ -1,0 +1,80 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file modules.cpp
+ *
+ * Modules tool.
+ */
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/posix.h>
+
+__BEGIN_DECLS
+__EXPORT int modules_main(int argc, char *argv[]);
+__END_DECLS
+
+static void print_usage()
+{
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("modules", "command");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("status", "Print status of all running modules in the system");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("stop-all", "Stop all modules");
+}
+
+int
+modules_main(int argc, char *argv[])
+{
+	if (argc >= 2) {
+		if (!strcmp(argv[1], "status")) {
+			modulesStatusAll();
+			return PX4_OK;
+		}
+
+		if (!strcmp(argv[1], "stop-all")) {
+			modulesStopAll();
+			return PX4_OK;
+		}
+	}
+
+	print_usage();
+	return 1;
+}

--- a/src/templates/module/module.cpp
+++ b/src/templates/module/module.cpp
@@ -70,15 +70,14 @@ int Module::custom_command(int argc, char *argv[])
 
 int Module::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("module",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_DEFAULT,
-				      1024,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	int task_id = px4_task_spawn_cmd("module",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_DEFAULT,
+					 1024,
+					 (px4_main_t)&run_trampoline,
+					 (char *const *)argv);
 
-	if (_task_id < 0) {
-		_task_id = -1;
+	if (task_id < 0) {
 		return -errno;
 	}
 


### PR DESCRIPTION
This PR updates `ModuleBase<T>` (px4_module.h) to have a non-template base class `ModuleBaseInterface`. Then instead of each module having a static _object pointer there's a single LinkedList.

Then methods like `ModuleBase<T>::stop_command()` have been refactored so that the bulk of the code is common, with each module frontend finding its object pointer by name from the LinkedList, rather than statically. Getting the bulk of this code out of the template is where flash is saved.

This is an incremental step towards expanding ModuleBase to optionally handle multiple instances of a module.

![image](https://user-images.githubusercontent.com/84712/58963901-fef97800-877b-11e9-97f8-948468290665.png)
