### PR TITLE
platforms: make args consistent for NuttX/Posix

### DIFF
--- a/platforms/posix/src/px4_layer/px4_posix_tasks.cpp
+++ b/platforms/posix/src/px4_layer/px4_posix_tasks.cpp
@@ -128,9 +128,6 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 	struct sched_param param = {};
 	char *p = (char *)argv;
 
-	// The name is added as the first argument.
-	len += strlen(name) + 1;
-
 	// Calculate argc
 	while (p != (char *)nullptr) {
 		p = argv[argc];
@@ -143,7 +140,8 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 		len += strlen(p) + 1;
 	}
 
-	// We add one argument for the name as argv[0].
+	// The name is added as the first argument argv[0].
+	len += strlen(name) + 1;
 	++argc;
 
 	// argc + 1 because we have to add nullptr at the end.

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1107,11 +1107,8 @@ int GPS::task_spawn(int argc, char *argv[], Instance instance)
 int GPS::run_trampoline_secondary(int argc, char *argv[])
 {
 
-#ifdef __PX4_NUTTX
-	// on NuttX task_create() adds the task name as first argument
 	argc -= 1;
 	argv += 1;
-#endif
 
 	GPS *gps = instantiate(argc, argv, Instance::Secondary);
 	if (gps) {

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -99,14 +99,14 @@ int Simulator::start(int argc, char *argv[])
 	if (_instance) {
 		drv_led_start();
 
-		if (argc == 4 && strcmp(argv[2], "-u") == 0) {
+		if (argc == 5 && strcmp(argv[3], "-u") == 0) {
 			_instance->set_ip(InternetProtocol::UDP);
-			_instance->set_port(atoi(argv[3]));
+			_instance->set_port(atoi(argv[4]));
 		}
 
-		if (argc == 4 && strcmp(argv[2], "-c") == 0) {
+		if (argc == 5 && strcmp(argv[3], "-c") == 0) {
 			_instance->set_ip(InternetProtocol::TCP);
-			_instance->set_port(atoi(argv[3]));
+			_instance->set_port(atoi(argv[4]));
 		}
 
 #ifndef __PX4_QURT

--- a/src/modules/vmount/vmount.cpp
+++ b/src/modules/vmount/vmount.cpp
@@ -192,16 +192,9 @@ static int vmount_thread_main(int argc, char *argv[])
 
 	InputTest *test_input = nullptr;
 
-#ifdef __PX4_NUTTX
-	/* the NuttX optarg handler does not
-	 * ignore argv[0] like the POSIX handler
-	 * does, nor does it deal with non-flag
-	 * verbs well. So we Remove the application
-	 * name and the verb.
-	 */
+	/* We Remove the application name.  */
 	argc -= 1;
 	argv += 1;
-#endif
 
 	if (argc > 0 && !strcmp(argv[0], "test")) {
 		PX4_INFO("Starting in test mode");

--- a/src/platforms/px4_module.h
+++ b/src/platforms/px4_module.h
@@ -169,11 +169,9 @@ public:
 	{
 		int ret = 0;
 
-#ifdef __PX4_NUTTX
-		// On NuttX task_create() adds the task name as first argument.
+		// We remove the application name.
 		argc -= 1;
 		argv += 1;
-#endif
 
 		T *object = T::instantiate(argc, argv);
 		_object.store(object);


### PR DESCRIPTION
The implementation of task_spawn in NuttX is according to the POSIX specs and adds the name of the task as the first argument `argv[0]`.
For Linux/macOS/Cygwin we did not adhere to this in `px4_task_spawn_cmd`. This meant that some of the modules manually did

`#ifdef __PX4_NUTTX argc -= 1; argv += 1; #endif`

to overcome the inconsistency.

This change makes the "posix" implementation behave like NuttX.

Also, in this commit, we remove the NutX only hacks to remove the first argument in various places because it is now needed generally.

Fixes #12104.