### PR TITLE
Multiple unaligned type cast

### DIFF
--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -164,7 +164,7 @@ void parameter_flashfs_free(void)
 
 static inline int blank_flash(uint8_t *pf)
 {
-        return *pf == (uint8_t)BlankSig;
+	return *pf == (uint8_t)BlankSig;
 }
 
 /****************************************************************************
@@ -186,8 +186,8 @@ static bool blank_check(flash_entry_header_t *pf,
 			size_t new_size)
 {
 	bool rv = true;
-        uint8_t *pm = (uint8_t *) pf;
-        new_size /= sizeof(uint8_t);
+	uint8_t *pm = (uint8_t *) pf;
+	new_size /= sizeof(uint8_t);
 
 	while (new_size-- && rv) {
 		if (!blank_flash(pm++)) {

--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -85,11 +85,10 @@ typedef enum  flash_flags_t {
 } flash_flags_t;
 
 
-/* File flash_entry_header_t will be sizeof(h_magic_t) aligned
+/* The struct flash_entry_header_t will be sizeof(h_magic_t) aligned
  * The Size will be the actual length of the header plus the data
  * and any padding needed to have the size be an even multiple of
  * sizeof(h_magic_t)
- *  The
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
@@ -163,9 +162,9 @@ void parameter_flashfs_free(void)
  *
  ****************************************************************************/
 
-static inline int blank_flash(uint32_t *pf)
+static inline int blank_flash(uint8_t *pf)
 {
-	return *pf == BlankSig;
+        return *pf == (uint8_t)BlankSig;
 }
 
 /****************************************************************************
@@ -187,8 +186,8 @@ static bool blank_check(flash_entry_header_t *pf,
 			size_t new_size)
 {
 	bool rv = true;
-	uint32_t *pm = (uint32_t *) pf;
-	new_size /= sizeof(uint32_t);
+        uint8_t *pm = (uint8_t *) pf;
+        new_size /= sizeof(uint8_t);
 
 	while (new_size-- && rv) {
 		if (!blank_flash(pm++)) {


### PR DESCRIPTION
Multiple unaligned type cast. May lead to 'Bus Error' on the ARM arch.
Fix by one byte check here.
Firmware/src/lib/parameters/flashparams/flashfs.c:190:2: error: converting a packed 'flash_entry_header_t' {aka 'struct flash_entry_header_t'} pointer (alignment 1) to a 'uint32_t' {aka 'unsigned int'} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  190 |  uint32_t *pm = (uint32_t *) pf;
      |  ^~~~~~~~
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors

To be fixed... but I am not sure, maybe should change crc32 to crc8
Firmware/src/lib/parameters/flashparams/flashfs.c:480:5: error: converting a packed 'flash_entry_header_t' {aka 'struct flash_entry_header_t'} pointer (alignment 1) to a 'h_magic_t' {aka 'unsigned int'} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  480 |     pmagic = (h_magic_t *) pf;
      |     ^~~~~~
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
