### PR TITLE
Made safer reset of timer

### DIFF
--- a/src/drivers/stm32/drv_io_timer.c
+++ b/src/drivers/stm32/drv_io_timer.c
@@ -131,6 +131,9 @@
 #else
 #define CCER_C1_INIT  GTIM_CCER_CC1E
 #endif
+
+#define CNT_VALUE_SAFE_TO_WRITE 3000 * 1000000/BOARD_ONESHOT_FREQ
+
 //												 				  NotUsed   PWMOut  PWMIn Capture OneShot Trigger
 io_timer_channel_allocation_t channel_allocations[IOTimerChanModeSize] = { UINT8_MAX,   0,  0,  0, 0, 0 };
 
@@ -505,7 +508,7 @@ void io_timer_trigger(void)
 			if (validate_timer_index(timer) == 0) {
 				int channels = get_timer_channels(timer);
 
-				if (oneshots & channels) {
+				if (oneshots & channels & rCNT(timer) > CNT_VALUE_SAFE_TO_WRITE) {
 					action_cache[actions++] = io_timers[timer].base;
 				}
 			}

--- a/src/drivers/stm32/drv_io_timer.c
+++ b/src/drivers/stm32/drv_io_timer.c
@@ -132,7 +132,7 @@
 #define CCER_C1_INIT  GTIM_CCER_CC1E
 #endif
 
-#define CNT_VALUE_SAFE_TO_WRITE 3000 * 1000000/BOARD_ONESHOT_FREQ
+#define CNT_VALUE_SAFE_TO_WRITE ((unsigned int)3000 * 1000000/BOARD_ONESHOT_FREQ)
 
 //												 				  NotUsed   PWMOut  PWMIn Capture OneShot Trigger
 io_timer_channel_allocation_t channel_allocations[IOTimerChanModeSize] = { UINT8_MAX,   0,  0,  0, 0, 0 };
@@ -508,7 +508,7 @@ void io_timer_trigger(void)
 			if (validate_timer_index(timer) == 0) {
 				int channels = get_timer_channels(timer);
 
-				if (oneshots & channels & rCNT(timer) > CNT_VALUE_SAFE_TO_WRITE) {
+				if (oneshots & channels & (rCNT(timer) > CNT_VALUE_SAFE_TO_WRITE)) {
 					action_cache[actions++] = io_timers[timer].base;
 				}
 			}


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
With PWM in one shot mode, at 8 MHz frequency of the timer, the overflow time for a 16-bit timer is known to be 8.192 ms (2^16/8e6 s). As we are running our controllers faster than that, the timers should never overflow. However, if there is an unexpected delay on the update of the timers' value, they will overflow and start again the PWM cycle with the compare value that was set the previous time.

The problem comes when we are so unlucky that the update of the compare value and reset of the timer happens when we are sending a HIGH signal in the PWM sequence, i.e., at 8 MHz, when we are in the first 250 us of signal. In this case, we would reset the counter in the middle of a HIGH PWM value and keep it high during more time than desired, rendering unexpected behaviour and possibly undesired full thrust/full flap deflections.

With this PR we only reset the timers if the current CNT value is well above a safe value, when we are 100% sure that the state of the PWM signal is low.
