### PR TITLE
PID autotuner for velocity loop

### DIFF
--- a/msg/vehicle_constraints.msg
+++ b/msg/vehicle_constraints.msg
@@ -11,3 +11,4 @@ float32 tilt # in radians [0, PI]
 float32 min_distance_to_ground # in meters
 float32 max_distance_to_ground # in meters
 bool want_takeoff # tell the controller to initiate takeoff when idling (ignored during flight)
+bool rescale_xy_thrust # tell the controller to rescale xy thrust with max tilt and current Z thrust

--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -57,6 +57,7 @@ list(APPEND flight_tasks_all
 	ManualPosition
 	ManualPositionSmooth
 	ManualPositionSmoothVel
+	AutotuneVel
 	Sport
 	AutoLine
 	AutoLineSmoothVel

--- a/src/lib/FlightTasks/tasks/AutotuneVel/CMakeLists.txt
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,15 +31,9 @@
 #
 ############################################################################
 
-# add the core Flight tasks that the additional flight tasks depend on
-add_subdirectory(FlightTask)
-add_subdirectory(Utility)
-add_subdirectory(Manual)
-add_subdirectory(Auto)
-add_subdirectory(AutoMapper)
-add_subdirectory(AutoMapper2)
+px4_add_library(FlightTaskAutotuneVel
+	FlightTaskAutotuneVel.cpp
+)
 
-# add all additional flight tasks
-foreach(task ${flight_tasks_all})
-    add_subdirectory(${task})
-endforeach()
+target_link_libraries(FlightTaskAutotuneVel PUBLIC FlightTaskManual)
+target_include_directories(FlightTaskAutotuneVel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
@@ -113,6 +113,7 @@ void FlightTaskAutotuneVel::_updateSetpoints()
 	_thrust_setpoint(0) = _thrust_sat + pos_control_xy(0);
 	_thrust_setpoint(1) = 0.f + pos_control_xy(1);
 	_thrust_setpoint(2) = NAN;
+	_constraints.rescale_xy_thrust = false;
 }
 
 void FlightTaskAutotuneVel::_updateUltimateGain()

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
@@ -66,6 +66,7 @@ bool FlightTaskAutotuneVel::activate()
 	_yaw_setpoint = NAN;
 	_yawspeed_setpoint = 0.0f;
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, NAN);
+	_current_position_xy = matrix::Vector2f(_position);
 	_position_setpoint(2) = _position(2);
 	_velocity_setpoint(2) = 0.0f;
 	_setDefaultConstraints();
@@ -96,18 +97,21 @@ void FlightTaskAutotuneVel::_updateSetpoints()
 	_thrust = -_velocity(0) * _ku;
 
 	// Saturation block
-	if (_thrust_sat > _thrust_max) {
+	if (_thrust > _thrust_max) {
 		_thrust_sat = _thrust_max;
 
-	} else if (_thrust_sat < -_thrust_max) {
+	} else if (_thrust < -_thrust_max) {
 		_thrust_sat = -_thrust_max;
 
 	} else {
 		_thrust_sat = _thrust;
 	}
 
-	_thrust_setpoint(0) = _thrust_sat;
-	_thrust_setpoint(1) = 0.f;
+	// Loose position controller
+	const matrix::Vector2f pos_control_xy = (_current_position_xy - matrix::Vector2f(_position)) * 0.002f;
+
+	_thrust_setpoint(0) = _thrust_sat + pos_control_xy(0);
+	_thrust_setpoint(1) = 0.f + pos_control_xy(1);
 	_thrust_setpoint(2) = NAN;
 }
 

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
@@ -118,11 +118,11 @@ void FlightTaskAutotuneVel::_updateSetpoints()
 void FlightTaskAutotuneVel::_updateUltimateGain()
 {
 	// epsilon << alpha
-	float ku_dot = -_alpha * fabsf(_thrust - _thrust_sat) + _epsilon;
+	float ku_dot = -_param_mpc_atune_gain.get() * fabsf(_thrust - _thrust_sat) + _epsilon;
 	printf("ku = %.3f\n, ku_dot = %.3f\n", (double)_ku, (double)ku_dot);
 	_ku += ku_dot;
 
-	if (fabs(ku_dot) < 0.002f && _ku < 1.4f) {
+	if (fabs(ku_dot) < _param_mpc_atune_thr.get() && _ku < 1.4f) {
 		_convergence_counter++;
 
 	} else {
@@ -192,8 +192,8 @@ void FlightTaskAutotuneVel::_computeControlGains()
 
 void FlightTaskAutotuneVel::_exit()
 {
-	_param_mpc_xy_vel_atune.set(false);
-	_param_mpc_xy_vel_atune.commit();
+	_param_mpc_xy_atune.set(false);
+	_param_mpc_xy_atune.commit();
 	_done = true;
 }
 
@@ -210,7 +210,7 @@ bool FlightTaskAutotuneVel::update()
 
 	_updateSetpoints();
 
-	if (_convergence_counter < 500) {
+	if (_convergence_counter < _param_mpc_atune_cnt.get()) {
 		_updateUltimateGain();
 
 	} else {

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
@@ -60,9 +60,9 @@ bool FlightTaskAutotuneVel::updateInitialize()
 	       && PX4_ISFINITE(_velocity(1));
 }
 
-bool FlightTaskAutotuneVel::activate()
+bool FlightTaskAutotuneVel::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskManual::activate();
+	bool ret = FlightTaskManual::activate(last_setpoint);
 	_yaw_setpoint = 0.f; // Align North
 	_yawspeed_setpoint = 0.0f;
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, NAN);

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
@@ -63,7 +63,7 @@ bool FlightTaskAutotuneVel::updateInitialize()
 bool FlightTaskAutotuneVel::activate()
 {
 	bool ret = FlightTaskManual::activate();
-	_yaw_setpoint = NAN;
+	_yaw_setpoint = 0.f; // Align North
 	_yawspeed_setpoint = 0.0f;
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, NAN);
 	_current_position_xy = matrix::Vector2f(_position);
@@ -119,16 +119,18 @@ void FlightTaskAutotuneVel::_updateSetpoints()
 void FlightTaskAutotuneVel::_updateUltimateGain()
 {
 	// epsilon << alpha
-	float ku_dot = -_param_mpc_atune_gain.get() * fabsf(_thrust - _thrust_sat) + _epsilon;
+	float ku_dot = -_param_mpc_atune_p.get() * fabsf(_thrust - _thrust_sat) + _epsilon;
 	_ku += ku_dot;
 
 	_jerk_setpoint(0) = _ku;
+	_jerk_setpoint(1) = ku_dot;
 	if (fabs(ku_dot) < _param_mpc_atune_thr.get() && _ku < 1.4f) {
 		_convergence_counter++;
 
 	} else {
 		_convergence_counter = 0;
 	}
+	_jerk_setpoint(2) = _convergence_counter;
 }
 
 void FlightTaskAutotuneVel::_measureUltimatePeriod()

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.cpp
@@ -1,0 +1,225 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskAutotunevel.cpp
+ */
+
+#include "FlightTaskAutotuneVel.hpp"
+#include <float.h>
+#include <mathlib/mathlib.h>
+
+using namespace matrix;
+
+bool FlightTaskAutotuneVel::initializeSubscriptions(SubscriptionArray &subscription_array)
+{
+	if (!FlightTaskManual::initializeSubscriptions(subscription_array)) {
+		return false;
+	}
+
+	return true;
+}
+
+bool FlightTaskAutotuneVel::updateInitialize()
+{
+	bool ret = FlightTaskManual::updateInitialize();
+	// require valid position / velocity in xy
+	return ret && PX4_ISFINITE(_position(0))
+	       && PX4_ISFINITE(_position(1))
+	       && PX4_ISFINITE(_velocity(0))
+	       && PX4_ISFINITE(_velocity(1));
+}
+
+bool FlightTaskAutotuneVel::activate()
+{
+	bool ret = FlightTaskManual::activate();
+	_yaw_setpoint = NAN;
+	_yawspeed_setpoint = 0.0f;
+	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, NAN);
+	_position_setpoint(2) = _position(2);
+	_velocity_setpoint(2) = 0.0f;
+	_setDefaultConstraints();
+
+	_ku = 1.5f;
+	_period_u = 0.f;
+	_convergence_counter = 0;
+	_peak_counter = 0;
+	_peak_counter_state = SignalState::unknown;
+	_done = false;
+
+	return ret;
+}
+
+bool FlightTaskAutotuneVel::_checkSticks()
+{
+	// Abort if the user moves the sticks
+	if (Vector3f(&_sticks(0)).length() > 0.2f) {
+		return true;
+
+	} else {
+		return false;
+	}
+}
+
+void FlightTaskAutotuneVel::_updateSetpoints()
+{
+	_thrust = -_velocity(0) * _ku;
+
+	// Saturation block
+	if (_thrust_sat > _thrust_max) {
+		_thrust_sat = _thrust_max;
+
+	} else if (_thrust_sat < -_thrust_max) {
+		_thrust_sat = -_thrust_max;
+
+	} else {
+		_thrust_sat = _thrust;
+	}
+
+	_thrust_setpoint(0) = _thrust_sat;
+	_thrust_setpoint(1) = 0.f;
+	_thrust_setpoint(2) = NAN;
+}
+
+void FlightTaskAutotuneVel::_updateUltimateGain()
+{
+	// epsilon << alpha
+	float ku_dot = -_alpha * fabsf(_thrust - _thrust_sat) + _epsilon;
+	printf("ku = %.3f\n, ku_dot = %.3f\n", (double)_ku, (double)ku_dot);
+	_ku += ku_dot;
+
+	if (fabs(ku_dot) < 0.002f && _ku < 1.4f) {
+		_convergence_counter++;
+
+	} else {
+		_convergence_counter = 0;
+	}
+}
+
+void FlightTaskAutotuneVel::_measureUltimatePeriod()
+{
+	switch (_peak_counter_state) {
+	case SignalState::unknown:
+		if (_thrust > 0.9f * _thrust_max) {
+			_peak_counter_state = SignalState::high;
+			_start_time = hrt_absolute_time();
+
+		} else if (_thrust < -0.9f * _thrust_max) {
+			_peak_counter_state = SignalState::low;
+			_start_time = hrt_absolute_time();
+		}
+
+		break;
+
+	case SignalState::high:
+		if (_thrust < -0.9f * _thrust_max) {
+			_peak_counter_state = SignalState::low;
+			_peak_counter++;
+		}
+
+		break;
+
+	case SignalState::low:
+		if (_thrust > 0.9f * _thrust_max) {
+			_peak_counter_state = SignalState::high;
+			_peak_counter++;
+		}
+
+		break;
+	}
+
+	if (_peak_counter == 11) {
+		// 5 periods
+		_period_u = hrt_elapsed_time(&_start_time) * 2e-7;
+		printf("Period: %.3f seconds\n", (double)_period_u);
+	}
+}
+
+void FlightTaskAutotuneVel::_computeControlGains()
+{
+	// Compute Kp, Ki and Kd using robust Ziegler-Nichols rules
+	float kp = 0.3375f * _ku;
+	float ki = 0.3f * _ku / _period_u;
+	float kd = _ku * _period_u * 0.0375f;
+	printf("Kp = %.3f\tKi =%.3f\tKd = %.3f\n", (double)kp, (double)ki, (double)kd);
+
+	if (kp > 0.f && kp < 1.f && ki > 0.f && ki < 4.f && kd > 0.f && kd < 0.1f) {
+		_param_mpc_xy_vel_p.set(kp);
+		_param_mpc_xy_vel_p.commit();
+		_param_mpc_xy_vel_i.set(ki);
+		_param_mpc_xy_vel_i.commit();
+		_param_mpc_xy_vel_d.set(kd);
+		_param_mpc_xy_vel_d.commit();
+
+	} else {
+		printf("Autotuning failed");
+	}
+}
+
+void FlightTaskAutotuneVel::_exit()
+{
+	_param_mpc_xy_vel_atune.set(false);
+	_param_mpc_xy_vel_atune.commit();
+	_done = true;
+}
+
+bool FlightTaskAutotuneVel::update()
+{
+	if (_done) {
+		return false;
+	}
+
+	if (_checkSticks()) {
+		_exit();
+		return false;
+	}
+
+	_updateSetpoints();
+
+	if (_convergence_counter < 500) {
+		_updateUltimateGain();
+
+	} else {
+		_measureUltimatePeriod();
+	}
+
+	if (_peak_counter >= 11) {
+		// Ultimate gain found, start counting peaks
+		_computeControlGains();
+		// Done, exit flight task
+		_exit();
+		return false;
+	}
+
+	return true;
+}

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskAutotuneVel.hpp
+ *
+ * Flight task velocity PID autotuning
+ */
+
+#pragma once
+
+#include "FlightTaskManual.hpp"
+
+class FlightTaskAutotuneVel : public FlightTaskManual
+{
+public:
+	FlightTaskAutotuneVel() = default;
+	virtual ~FlightTaskAutotuneVel() = default;
+	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
+	bool activate() override;
+	bool updateInitialize() override;
+	bool update() override;
+
+protected:
+	virtual void _updateSetpoints(); /**< updates all setpoints */
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManual,
+					(ParamBool<px4::params::MPC_XY_VEL_ATUNE>) _param_mpc_xy_vel_atune,
+					(ParamFloat<px4::params::MPC_XY_VEL_P>) _param_mpc_xy_vel_p,
+					(ParamFloat<px4::params::MPC_XY_VEL_I>) _param_mpc_xy_vel_i,
+					(ParamFloat<px4::params::MPC_XY_VEL_D>) _param_mpc_xy_vel_d
+				       )
+private:
+	bool _checkSticks(); /**< check if the user wants to abort the autotuning */
+	void _updateUltimateGain();
+	void _measureUltimatePeriod();
+	void _computeControlGains();
+	void _exit();
+
+	float _thrust{};
+	float _thrust_sat{};
+	float _thrust_max{0.1f}; /**< maximum allowed thrust amplitude **/
+	float _ku{1.5f}; /**< ultimate gain of the controller */
+	float _period_u{}; /**< ultimate period is seconds **/
+	float _epsilon{0.0001};
+	float _alpha{0.05f};
+	bool _done{false};
+
+	int _convergence_counter{}; /**< counts how many times the exit criteria has been true **/
+
+	/* Period counter */
+	int _peak_counter{};
+	enum class SignalState {unknown, low, high};
+	SignalState _peak_counter_state{SignalState::unknown};
+	hrt_abstime _start_time{};
+};

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
@@ -55,10 +55,13 @@ protected:
 	virtual void _updateSetpoints(); /**< updates all setpoints */
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManual,
-					(ParamBool<px4::params::MPC_XY_VEL_ATUNE>) _param_mpc_xy_vel_atune,
 					(ParamFloat<px4::params::MPC_XY_VEL_P>) _param_mpc_xy_vel_p,
 					(ParamFloat<px4::params::MPC_XY_VEL_I>) _param_mpc_xy_vel_i,
-					(ParamFloat<px4::params::MPC_XY_VEL_D>) _param_mpc_xy_vel_d
+					(ParamFloat<px4::params::MPC_XY_VEL_D>) _param_mpc_xy_vel_d,
+					(ParamBool<px4::params::MPC_XY_ATUNE>) _param_mpc_xy_atune,
+					(ParamFloat<px4::params::MPC_XY_ATUNE_P>) _param_mpc_atune_gain,
+					(ParamInt<px4::params::MPC_XY_ATUNE_CNT>) _param_mpc_atune_cnt,
+					(ParamFloat<px4::params::MPC_XY_ATUNE_THR>) _param_mpc_atune_thr
 				       )
 private:
 	bool _checkSticks(); /**< check if the user wants to abort the autotuning */
@@ -73,7 +76,6 @@ private:
 	float _ku{}; /**< ultimate gain of the controller */
 	float _period_u{}; /**< ultimate period is seconds **/
 	float _epsilon{0.0001};
-	float _alpha{0.05f};
 	bool _done{false};
 
 	matrix::Vector2f _current_position_xy{};

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
@@ -70,11 +70,13 @@ private:
 	float _thrust{};
 	float _thrust_sat{};
 	float _thrust_max{0.1f}; /**< maximum allowed thrust amplitude **/
-	float _ku{1.5f}; /**< ultimate gain of the controller */
+	float _ku{}; /**< ultimate gain of the controller */
 	float _period_u{}; /**< ultimate period is seconds **/
 	float _epsilon{0.0001};
 	float _alpha{0.05f};
 	bool _done{false};
+
+	matrix::Vector2f _current_position_xy{};
 
 	int _convergence_counter{}; /**< counts how many times the exit criteria has been true **/
 

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
@@ -59,7 +59,7 @@ protected:
 					(ParamFloat<px4::params::MPC_XY_VEL_I>) _param_mpc_xy_vel_i,
 					(ParamFloat<px4::params::MPC_XY_VEL_D>) _param_mpc_xy_vel_d,
 					(ParamBool<px4::params::MPC_XY_ATUNE>) _param_mpc_xy_atune,
-					(ParamFloat<px4::params::MPC_XY_ATUNE_P>) _param_mpc_atune_gain,
+					(ParamFloat<px4::params::MPC_XY_ATUNE_P>) _param_mpc_atune_p,
 					(ParamInt<px4::params::MPC_XY_ATUNE_CNT>) _param_mpc_atune_cnt,
 					(ParamFloat<px4::params::MPC_XY_ATUNE_THR>) _param_mpc_atune_thr
 				       )
@@ -72,10 +72,10 @@ private:
 
 	float _thrust{};
 	float _thrust_sat{};
-	float _thrust_max{0.1f}; /**< maximum allowed thrust amplitude **/
+	float _thrust_max{0.3f}; /**< maximum allowed thrust amplitude **/
 	float _ku{}; /**< ultimate gain of the controller */
 	float _period_u{}; /**< ultimate period is seconds **/
-	float _epsilon{0.0001};
+	float _epsilon{0.00001};
 	bool _done{false};
 
 	matrix::Vector2f _current_position_xy{};

--- a/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutotuneVel/FlightTaskAutotuneVel.hpp
@@ -47,7 +47,7 @@ public:
 	FlightTaskAutotuneVel() = default;
 	virtual ~FlightTaskAutotuneVel() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool updateInitialize() override;
 	bool update() override;
 

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -6,7 +6,7 @@ constexpr uint64_t FlightTask::_timeout;
 // First index of empty_setpoint corresponds to time-stamp and requires a finite number.
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
 
-const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, false, {}};
+const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, false, false, {}};
 const landing_gear_s FlightTask::empty_landing_gear_default_keep = {0, landing_gear_s::GEAR_KEEP, {}};
 
 bool FlightTask::initializeSubscriptions(SubscriptionArray &subscription_array)
@@ -144,6 +144,7 @@ void FlightTask::_setDefaultConstraints()
 	_constraints.min_distance_to_ground = NAN;
 	_constraints.max_distance_to_ground = NAN;
 	_constraints.want_takeoff = false;
+	_constraints.rescale_xy_thrust = false;
 }
 
 bool FlightTask::_checkTakeoff()

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -71,6 +71,7 @@ bool FlightTaskManualAltitude::activate(vehicle_local_position_setpoint_s last_s
 	_velocity_setpoint(2) = 0.0f;
 	_setDefaultConstraints();
 
+	_constraints.rescale_xy_thrust = true;
 	_constraints.tilt = math::radians(_param_mpc_man_tilt_max.get());
 
 	if (PX4_ISFINITE(_sub_vehicle_local_position->get().hagl_min)) {

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -615,7 +615,7 @@ void Logger::add_default_topics()
 	add_topic("sensor_preflight", 200);
 	add_topic("system_power", 500);
 	add_topic("tecs_status", 200);
-	add_topic("trajectory_setpoint", 200);
+	add_topic("trajectory_setpoint");
 	add_topic("telemetry_status");
 	add_topic("vehicle_air_data", 200);
 	add_topic("vehicle_attitude", 30);

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -284,11 +284,16 @@ void PositionControl::_velocityController(const float &dt)
 	_thr_sp(2) = math::constrain(thrust_desired_D, uMin, uMax);
 
 	if (PX4_ISFINITE(_thr_sp(0)) && PX4_ISFINITE(_thr_sp(1))) {
-		// Thrust set-point in NE-direction is already provided. Only
-		// scaling by the maximum tilt is required.
-		float thr_xy_max = fabsf(_thr_sp(2)) * tanf(_constraints.tilt);
-		_thr_sp(0) *= thr_xy_max;
-		_thr_sp(1) *= thr_xy_max;
+		// Thrust set-point in NE-direction is already provided.
+		if (_constraints.rescale_xy_thrust) {
+			// Scaling by the maximum tilt is required.
+			float thr_xy_max = fabsf(_thr_sp(2)) * tanf(_constraints.tilt);
+			_thr_sp(0) *= thr_xy_max;
+			_thr_sp(1) *= thr_xy_max;
+
+		} else {
+			// Directly apply desired thrust
+		}
 
 	} else {
 		// PID-velocity controller for NE-direction.

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -40,6 +40,7 @@
 #include <mathlib/mathlib.h>
 #include "Utility/ControlMath.hpp"
 #include <px4_defines.h>
+#include <drivers/drv_hrt.h>
 
 using namespace matrix;
 
@@ -294,6 +295,7 @@ void PositionControl::_velocityController(const float &dt)
 		Vector2f thrust_desired_NE;
 		thrust_desired_NE(0) = _param_mpc_xy_vel_p.get() * vel_err(0) + _param_mpc_xy_vel_d.get() * _vel_dot(0) + _thr_int(0);
 		thrust_desired_NE(1) = _param_mpc_xy_vel_p.get() * vel_err(1) + _param_mpc_xy_vel_d.get() * _vel_dot(1) + _thr_int(1);
+
 
 		// Get maximum allowed thrust in NE based on tilt and excess thrust.
 		float thrust_max_NE_tilt = fabsf(_thr_sp(2)) * tanf(_constraints.tilt);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -157,7 +157,7 @@ private:
 		(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
 		(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2, /**< downwards speed limited below this altitude */
 		(ParamInt<px4::params::MPC_POS_MODE>) _param_mpc_pos_mode,
-		(ParamBool<px4::params::MPC_XY_VEL_ATUNE>) _param_mpc_xy_vel_atune,
+		(ParamBool<px4::params::MPC_XY_ATUNE>) _param_mpc_xy_atune,
 		(ParamInt<px4::params::MPC_AUTO_MODE>) _param_mpc_auto_mode,
 		(ParamInt<px4::params::MPC_ALT_MODE>) _param_mpc_alt_mode,
 		(ParamFloat<px4::params::MPC_SPOOLUP_TIME>) _param_mpc_spoolup_time, /**< time to let motors spool up after arming */
@@ -832,7 +832,7 @@ MulticopterPositionControl::start_flight_task()
 		should_disable_task = false;
 		int error = 0;
 
-		if (_param_mpc_xy_vel_atune.get()) {
+		if (_param_mpc_xy_atune.get()) {
 			error =  _flight_tasks.switchTask(FlightTaskIndex::AutotuneVel);
 
 		} else {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -157,6 +157,7 @@ private:
 		(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
 		(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2, /**< downwards speed limited below this altitude */
 		(ParamInt<px4::params::MPC_POS_MODE>) _param_mpc_pos_mode,
+		(ParamBool<px4::params::MPC_XY_VEL_ATUNE>) _param_mpc_xy_vel_atune,
 		(ParamInt<px4::params::MPC_AUTO_MODE>) _param_mpc_auto_mode,
 		(ParamInt<px4::params::MPC_ALT_MODE>) _param_mpc_alt_mode,
 		(ParamFloat<px4::params::MPC_SPOOLUP_TIME>) _param_mpc_spoolup_time, /**< time to let motors spool up after arming */
@@ -831,22 +832,27 @@ MulticopterPositionControl::start_flight_task()
 		should_disable_task = false;
 		int error = 0;
 
-		switch (_param_mpc_pos_mode.get()) {
-		case 1:
-			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmooth);
-			break;
+		if (_param_mpc_xy_vel_atune.get()) {
+			error =  _flight_tasks.switchTask(FlightTaskIndex::AutotuneVel);
 
-		case 2:
-			error =  _flight_tasks.switchTask(FlightTaskIndex::Sport);
-			break;
+		} else {
+			switch (_param_mpc_pos_mode.get()) {
+			case 1:
+				error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmooth);
+				break;
 
-		case 3:
-			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmoothVel);
-			break;
+			case 2:
+				error =  _flight_tasks.switchTask(FlightTaskIndex::Sport);
+				break;
 
-		default:
-			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPosition);
-			break;
+			case 3:
+				error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmoothVel);
+				break;
+
+			default:
+				error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPosition);
+				break;
+			}
 		}
 
 		if (error != 0) {

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -234,6 +234,15 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I, 0.02f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 
 /**
+ * Velocity PID auto-tuner
+ *
+ * @boolean
+ *
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_XY_VEL_ATUNE, 0);
+
+/**
  * Maximum horizontal velocity in mission
  *
  * Normal horizontal velocity in AUTO modes (includes

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -234,13 +234,43 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I, 0.02f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 
 /**
- * Velocity PID auto-tuner
+ * Velocity PID auto-tuner trigger
  *
  * @boolean
  *
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_XY_VEL_ATUNE, 0);
+PARAM_DEFINE_INT32(MPC_XY_ATUNE, 0);
+
+/**
+ * Velocity PID auto-tuner adaptation rate
+ *
+ * @boolean
+ *
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_XY_ATUNE_P, 0.05f);
+
+/**
+ * Velocity PID auto-tuner convergence criteria hysteresis width
+ *
+ * @boolean
+ *
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_XY_ATUNE_CNT, 500);
+
+/**
+ * Velocity PID auto-tuner convergence criteria
+ *
+ * @min 0.0001
+ * @max 0.1
+ * @increment 1
+ * @decimal 4
+ *
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_XY_ATUNE_THR, 0.002);
 
 /**
  * Maximum horizontal velocity in mission

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -249,16 +249,18 @@ PARAM_DEFINE_INT32(MPC_XY_ATUNE, 0);
  *
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_ATUNE_P, 0.05f);
+PARAM_DEFINE_FLOAT(MPC_XY_ATUNE_P, 0.03f);
 
 /**
  * Velocity PID auto-tuner convergence criteria hysteresis width
  *
- * @boolean
+ * @min 1
+ * @max 1000
+ * @increment 1
  *
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_XY_ATUNE_CNT, 500);
+PARAM_DEFINE_INT32(MPC_XY_ATUNE_CNT, 200);
 
 /**
  * Velocity PID auto-tuner convergence criteria


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
I've never seen anyone tuning the velocity loop. The main reason is that it's really hard to visualize the velocity tracking while flying and it usually "looks okay". After inspecting many log files, I realized that many velocity loops are poorly tuned.

A common practice of the users to "fix" the poorly tuned velocity loops is to modify the parameters of the setpoints such that the handling qualities requirements are fulfilled in most situations (e.g.:a fast-moving setpoint reduces the reaction delay of a poorly tuned loop). The drawback of this approach is that the response does not follow properly the setpoint and that limited dynamics of the setpoint won't be properly applied by the drone (the drone can exceed acceleration and jerk limits in some conditions).

The idea here is to provide a tool to the user to automatically adjust the PID gains of the velocity controller to easily achieve proper tracking.
The method is an improved version of the classical forced oscillation method that automates the tuning of the ultimate gain without introducing too many harmonics (a drawback of the relay-feedback experiment). Once the ultimate gain is found, the ultimate period is measured and the gains are computed using the well known Ziegler-Nichols rules (https://blog.opticontrols.com/archives/131)

Algorithm block diagram:
![autotuning(1)](https://user-images.githubusercontent.com/14822839/61217500-1da24580-a710-11e9-81f3-ee5040c24e08.png)

**Additional features:**
- A weak P controller is used to prevent the drone drifting too much during the autotuning sequence
- Moving the RC sticks during autotuning immediately switches back to manual position control mode
- The amplitude of the oscillation is bounded

**Usage:**
- During a calm day, takeoff and hover at around 15m is position mode
- Set `MPC_XY_ATUNE` to 1 and wait until the tuning finishes
- Adjust the P, I and D gains if needed

You can move the RC sticks at any time to abort the autotuning. To restart autotuning, set the parameter back to 1.

**SITL tests:**
Left: with parameters after the autotuning
Right: with default parameters
![2019-06-06_10-22-52_01_plot](https://user-images.githubusercontent.com/14822839/61217935-1def1080-a711-11e9-94d3-b9fb65485bfd.png)

**TODO**
- [ ] Trigger via MAVLink command
- [ ] Safety against bad parameters (to discuss: should QGC set the parameters? should it be a way to revert back to the previous set of gains?)