### PR TITLE
Switch into last mode after landing and disarming after RTL/Land

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1843,12 +1843,9 @@ Commander::run()
 				}
 
 				// TODO Transition into the last state, not just directly to Manual
-				const bool in_right_state = internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL ||
-							    internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
-							    internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION;
-
-				if (in_right_state && mission_result.finished && land_detector.landed && !armed.armed) {
-					main_state_transition(status, commander_state_s::MAIN_STATE_MANUAL, status_flags, &internal_state);
+				if (is_auto_state(internal_state.main_state) && mission_result.finished && land_detector.landed && !armed.armed
+				    && last_non_auto_state != commander_state_s::MAIN_STATE_MAX) {
+					main_state_transition(status, last_non_auto_state, status_flags, &internal_state);
 				}
 			}
 		}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1842,7 +1842,11 @@ Commander::run()
 					}
 				}
 
-				if (is_auto_state(internal_state.main_state) && mission_result.finished && land_detector.landed && !armed.armed
+				// TODO: Determine what to do with `was_armed`. It updates one loop iteration before this code
+				// is reached, so it's not correct here.
+				// One possible solution: Keep track of time of last arm-disarm transition, and see if it's
+				// less than 1 second ago (or less than 0.1 seconds, or whatever time works)
+				if (is_auto_state(internal_state.main_state) && mission_result.finished && !armed.armed // && was_armed
 				    && last_non_auto_state != commander_state_s::MAIN_STATE_MAX) {
 					main_state_transition(status, last_non_auto_state, status_flags, &internal_state);
 				}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1842,7 +1842,6 @@ Commander::run()
 					}
 				}
 
-				// TODO Transition into the last state, not just directly to Manual
 				if (is_auto_state(internal_state.main_state) && mission_result.finished && land_detector.landed && !armed.armed
 				    && last_non_auto_state != commander_state_s::MAIN_STATE_MAX) {
 					main_state_transition(status, last_non_auto_state, status_flags, &internal_state);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1846,10 +1846,11 @@ Commander::run()
 		}
 
 		const bool just_disarmed = !armed.armed && was_armed;
-		const bool just_finished_auto_mission = is_auto_state(internal_state.main_state) && _mission_result_sub.get().finished;
+		const bool just_finished_rtl = internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL
+				&& _mission_result_sub.get().finished;
 		const bool last_state_valid = last_non_auto_state != commander_state_s::MAIN_STATE_MAX;
 
-		if(just_disarmed && land_detector.landed && just_finished_auto_mission && last_state_valid){
+		if(just_disarmed && land_detector.landed && just_finished_rtl && last_state_valid){
 			PX4_INFO("Just finished auto mission, transitioning back to last manual mode.");
 			main_state_transition(status, last_non_auto_state, status_flags, &internal_state);
 		}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1841,6 +1841,15 @@ Commander::run()
 						tune_mission_ok(true);
 					}
 				}
+
+				// TODO Transition into the last state, not just directly to Manual
+				const bool in_right_state = internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL ||
+							    internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
+							    internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION;
+
+				if (in_right_state && mission_result.finished && land_detector.landed && !armed.armed) {
+					main_state_transition(status, commander_state_s::MAIN_STATE_MANUAL, status_flags, &internal_state);
+				}
 			}
 		}
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -251,6 +251,9 @@ private:
 
 	uORB::Subscription _telemetry_status_sub{ORB_ID(telemetry_status)};
 
+	// Time of the last received `mission_result` message where finished == True
+	hrt_abstime _last_mission_result_finished{0};
+
 	hrt_abstime	_datalink_last_heartbeat_gcs{0};
 
 	hrt_abstime	_datalink_last_heartbeat_onboard_controller{0};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -251,9 +251,6 @@ private:
 
 	uORB::Subscription _telemetry_status_sub{ORB_ID(telemetry_status)};
 
-	// Time of the last received `mission_result` message where finished == True
-	hrt_abstime _last_mission_result_finished{0};
-
 	hrt_abstime	_datalink_last_heartbeat_gcs{0};
 
 	hrt_abstime	_datalink_last_heartbeat_onboard_controller{0};

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -147,4 +147,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		      const vehicle_status_flags_s &status_flags, commander_state_s *internal_state, const uint8_t battery_warning,
 		      const low_battery_action_t low_bat_action);
 
+extern main_state_t last_non_auto_state;
+bool is_auto_state(main_state_t state);
+
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -103,6 +103,7 @@ RTL::on_active()
 
 	} else {
 		_navigator->get_mission_result()->finished = true;
+		_navigator->set_mission_result_updated();
 	}
 }
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -95,9 +95,14 @@ RTL::on_activation()
 void
 RTL::on_active()
 {
-	if (_rtl_state != RTL_STATE_LANDED && is_mission_item_reached()) {
-		advance_rtl();
-		set_rtl_item();
+	if (_rtl_state != RTL_STATE_LANDED) {
+		if (is_mission_item_reached()) {
+			advance_rtl();
+			set_rtl_item();
+		}
+
+	} else {
+		_navigator->get_mission_result()->finished = true;
 	}
 }
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Closes #12354 .

**Test data / coverage**
Ran several missions in SITL, starting from every non-auto mode. After landing (Either via RTL or just landing in place), I verified that the mode returned to the most recent non-auto mode.

**Describe your preferred solution**
After an RTL or Auto Landing, and after disarming, the Commander will now automatically switch to the last mode that was used before the auto mission. For example, if the sequence of modes is:

Position -> Auto Mission -> Auto RTL

After the landing and disarming, it will switch back to Position.