### PR TITLE
[WIP] Voltage inconsistency checks on ESCs reporting esc_status

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -244,6 +244,8 @@ private:
 	hrt_abstime	_high_latency_datalink_lost{0};
 
 	int  _last_esc_online_flags{-1};
+	uint64_t _esc_last_excedeed_time[esc_status_s::CONNECTED_ESC_MAX];
+	uint8_t  _last_esc_inconsistency_flags{0};
 
 	uORB::Subscription _battery_sub{ORB_ID(battery_status)};
 	uint8_t _battery_warning{battery_status_s::BATTERY_WARNING_NONE};


### PR DESCRIPTION

**Describe problem solved by the proposed pull request**
This PR is an incremental piece of #12641 and adds voltage inconsistency checks for ESCs reporting their status (i.e UAVCAN escs).
The check evaluates the delta between each ESC reported voltage and battery voltage. If the delta is greater than 0.5V for more than 2 seconds then a warning message is displayed.
The introduced check is useful to identify critical hardware issues such as bad connection between the power rail and the ESC that may cause voltage drops.

Currently the threshold values are hard-coded; early tests have provided good results but further testing will follow to have better coverage on false positives.

**Test data / coverage**
Coverage will be provided soon

FYI @RomanBapst @bkueng 
