### PR TITLE
Add GPS_GLOBAL_ORIGIN mavlink msg.

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1666,6 +1666,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("EXTENDED_SYS_STATE", 5.0f);
 		configure_stream_local("GLOBAL_POSITION_INT", 50.0f);
 		configure_stream_local("GPS2_RAW", unlimited_rate);
+		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS_RAW_INT", unlimited_rate);
 		configure_stream_local("HIGHRES_IMU", 50.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
@@ -1711,6 +1712,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
 		configure_stream_local("GLOBAL_POSITION_INT", 5.0f);
 		configure_stream_local("GPS2_RAW", 1.0f);
+		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS_RAW_INT", 1.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
 		configure_stream_local("LOCAL_POSITION_NED", 30.0f);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1666,7 +1666,6 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("EXTENDED_SYS_STATE", 5.0f);
 		configure_stream_local("GLOBAL_POSITION_INT", 50.0f);
 		configure_stream_local("GPS2_RAW", unlimited_rate);
-		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS_RAW_INT", unlimited_rate);
 		configure_stream_local("HIGHRES_IMU", 50.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
@@ -1712,7 +1711,6 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
 		configure_stream_local("GLOBAL_POSITION_INT", 5.0f);
 		configure_stream_local("GPS2_RAW", 1.0f);
-		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS_RAW_INT", 1.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
 		configure_stream_local("LOCAL_POSITION_NED", 30.0f);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -5108,7 +5108,7 @@ protected:
 				return true;
 			}
 		}
-		
+
 
 		return false;
 	}


### PR DESCRIPTION

Adds a previously unsupported common mavlink message [GPS_GLOBAL_ORIGIN](https://mavlink.io/en/messages/common.html#GPS_GLOBAL_ORIGIN).

The motivation is to allow external systems and companion computers to know the global location of the local frame origin.

## Testing

I ran a few simulated flights to test. The local frame origin is set by the state estimator and is published as part of the vehicle_local_position msg. Here are the relevant fields of that message:
```
pxh> listener vehicle_local_position

TOPIC: vehicle_local_position instance 0 #1
 vehicle_local_position_s
        ...
        ref_lat: 47.397742
        ref_lon: 8.545593
        ref_alt: 0.0000
        ...
        xy_global: True
        z_global: True
        ...
```

I enabled GPS_GLOBAL_ORIGIN to be published to QGC with this command:
```
mavlink stream -u 14570 -s GPS_GLOBAL_ORIGIN -r 1.0
```

and you can see in the following image that QGC is receiving the same values from the vehicle_local_position msg:

![global_origin_pos_text](https://user-images.githubusercontent.com/1399452/62725519-43ef9400-b9e3-11e9-8847-a5c65f29cac2.png)

The lat/lon values of GPS_GLOBAL_ORIGIN in the image above are similar to the lat/lon of the GLOBAL_POSITION_INT message, which is expected because I didn't fly far from the first gps fix position during this simulation.

The following two images show GLOBAL_POSITION_INT.latitude (red) vs GPS_GLOBAL_ORIGIN.latitude (white) and GLOBAL_POSITION_INT.longitude (blue) vs GPS_GLOBAL_ORIGIN.longitude (red) respectively. In both graphs, the vehicle takes off from the first vehicle position of the simulation then eventually returns home. As expected, the vehicle lat/lon aligns with the global origin lat/lon at the beginning and ending.

![global_origin_and_pos_lat](https://user-images.githubusercontent.com/1399452/62726653-bfeadb80-b9e5-11e9-9c77-6c85db456f99.png)
![global_origin_pos_lon](https://user-images.githubusercontent.com/1399452/62726656-c24d3580-b9e5-11e9-82b2-1d14e64a28a5.png)

As a test on the altitude, we expect the global origin altitude plus the vehicle local altitude to equal the vehicle global altitude. The first graph below is the global origin altitude (white) and the vehicle local altitude (red), and if you add them together, you would get the same shape as the second graph below, which has the vehicle global altitude (orange). The reason we use the shape as our test instead of actual values is because the two graphs are at different scales.

![global_origin_local_alt](https://user-images.githubusercontent.com/1399452/62726964-6636e100-b9e6-11e9-9176-0c325c4bf0e7.png)
![global_origin_and_pos_alt](https://user-images.githubusercontent.com/1399452/62726968-67680e00-b9e6-11e9-8056-48df27e4a501.png)
