### PR TITLE
Don't override MAVLink behavior in SITL .rc file

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -232,15 +232,6 @@ sh etc/init.d/rc.vehicle_setup
 
 # GCS link
 mavlink start -x -u $udp_gcs_port_local -r 4000000
-mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u $udp_gcs_port_local
-mavlink stream -r 50 -s LOCAL_POSITION_NED -u $udp_gcs_port_local
-mavlink stream -r 50 -s GLOBAL_POSITION_INT -u $udp_gcs_port_local
-mavlink stream -r 50 -s ATTITUDE -u $udp_gcs_port_local
-mavlink stream -r 50 -s ATTITUDE_QUATERNION -u $udp_gcs_port_local
-mavlink stream -r 50 -s ATTITUDE_TARGET -u $udp_gcs_port_local
-mavlink stream -r 50 -s SERVO_OUTPUT_RAW_0 -u $udp_gcs_port_local
-mavlink stream -r 20 -s RC_CHANNELS -u $udp_gcs_port_local
-mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u $udp_gcs_port_local
 
 # API/Offboard link
 mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offboard_port_remote


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
While testing SITL I discovered that MAVLink is sending some messages at unexpected rates (#12613). The console output indicates a stream with the "normal" profile on port 14570

    INFO  [mavlink] mode: Normal, data rate: 4000000 B/s on udp port 14570 remote port 14550

However subsequent `mavlink stream` commands override the normal mode for some messages and turn rates up to 50 messages per second.

**Test data / coverage**
I tested the changed SITL setup with Gazebo/QGroundControl and a basic mission. I verified that the normal MAVLink profile is now used by checking QGroundControl's MAVLink Inspector.

**Describe your preferred solution**
Delete the commands that re-configure MAVLink.

**Describe possible alternatives**
* Keep the commands but trigger a warning message at the console from the rc file
* Raise the log message in [`Mavlink::configure_stream`](https://github.com/PX4/Firmware/blob/d3ba9c59e0fad71361ee2e58857774750887587a/src/modules/mavlink/mavlink_main.cpp#L1282) from debug to info level
