### PR TITLE
VTOL: keep status (MC/FW) when switching out of mission mode

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -216,6 +216,8 @@ private:
 
 	bool		_initialized{false};
 
+	bool _previous_transition_switch_to_fw{false}; // true if transition switch was at the position for FW previously
+
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 	perf_counter_t	_loop_interval_perf;		/**< loop interval performance counter */
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Addresses https://github.com/PX4/Firmware/issues/12680. 

With this PR it is no longer the position of transition switch that sets the VTOL status when changing out of mission into manual mode, but the current VTOL status (MC or FW) is kept until the transition switch is moved to the position that is mapped to the opposite VTOL status.

**Test data / coverage**
Only SITL tested yet (and there the problem described in https://github.com/PX4/Firmware/issues/12680 is anyway not reproducible, as the transition switch on a joystick is doesn't have states but only triggers events)

