### PR TITLE
VTOL GPSF: fix fixed bank loiter

### DIFF
--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -93,7 +93,12 @@ GpsFailure::on_active()
 			q.copyTo(att_sp.q_d);
 			att_sp.q_d_valid = true;
 
-			_att_sp_pub.publish(att_sp);
+            if (_navigator->get_vstatus()->is_vtol) {
+                _virt_att_sp_pub.publish(att_sp);
+            }
+            else {
+                _att_sp_pub.publish(att_sp);
+            }
 
 			/* Measure time */
 			if ((_param_nav_gpsf_lt.get() > FLT_EPSILON) &&

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -72,14 +72,6 @@ GpsFailure::on_activation()
 {
 	_gpsf_state = GPSF_STATE_NONE;
 	_timestamp_activation = hrt_absolute_time();
-    if(!_att_setpoint_id) {
-        if (_navigator->get_vstatus()->is_vtol) {
-            _att_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
-        }
-        else {
-            _att_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
-        }
-    }
 	advance_gpsf();
 	set_gpsf_item();
 }
@@ -101,12 +93,13 @@ GpsFailure::on_active()
 			q.copyTo(att_sp.q_d);
 			att_sp.q_d_valid = true;
 
-            if (_att_sp_pub != nullptr){
-                orb_publish(_att_setpoint_id, _att_sp_pub, &att_sp);
-            } else if (_att_setpoint_id) {
-                _att_sp_pub = orb_advertise(_att_setpoint_id, &att_sp);
+			if (_navigator->get_vstatus()->is_vtol) {
+				_fw_virtual_att_sp_pub.publish(att_sp);
 
-            }
+			} else {
+				_att_sp_pub.publish(att_sp);
+
+			}
 
 			/* Measure time */
 			if ((_param_nav_gpsf_lt.get() > FLT_EPSILON) &&

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -75,8 +75,8 @@ private:
 
 	hrt_abstime _timestamp_activation{0}; //*< timestamp when this mode was activated */
 
-        orb_advert_t _att_sp_pub{nullptr};
-        orb_id_t _att_setpoint_id{nullptr};
+	uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+	uORB::Publication<vehicle_attitude_setpoint_s>	_fw_virtual_att_sp_pub{ORB_ID(fw_virtual_attitude_setpoint)};
 	/**
 	 * Set the GPSF item
 	 */

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -75,7 +75,8 @@ private:
 
 	hrt_abstime _timestamp_activation{0}; //*< timestamp when this mode was activated */
 
-	uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+    uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+    uORB::Publication<vehicle_attitude_setpoint_s>	_virt_att_sp_pub{ORB_ID(fw_virtual_attitude_setpoint)};
 
 	/**
 	 * Set the GPSF item

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -75,9 +75,9 @@ private:
 
 	hrt_abstime _timestamp_activation{0}; //*< timestamp when this mode was activated */
 
-    	uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
-    	uORB::Publication<vehicle_attitude_setpoint_s>	_virt_att_sp_pub{ORB_ID(fw_virtual_attitude_setpoint)};
-
+        //uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{nullptr};
+        orb_advert_t _att_sp_pub{nullptr};
+        orb_id_t _att_setpoint_id{nullptr};
 	/**
 	 * Set the GPSF item
 	 */

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -75,7 +75,6 @@ private:
 
 	hrt_abstime _timestamp_activation{0}; //*< timestamp when this mode was activated */
 
-        //uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{nullptr};
         orb_advert_t _att_sp_pub{nullptr};
         orb_id_t _att_setpoint_id{nullptr};
 	/**

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -75,8 +75,8 @@ private:
 
 	hrt_abstime _timestamp_activation{0}; //*< timestamp when this mode was activated */
 
-    uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
-    uORB::Publication<vehicle_attitude_setpoint_s>	_virt_att_sp_pub{ORB_ID(fw_virtual_attitude_setpoint)};
+    	uORB::Publication<vehicle_attitude_setpoint_s>	_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+    	uORB::Publication<vehicle_attitude_setpoint_s>	_virt_att_sp_pub{ORB_ID(fw_virtual_attitude_setpoint)};
 
 	/**
 	 * Set the GPSF item


### PR DESCRIPTION
Pull request fixing part of [#12758](https://github.com/PX4/Firmware/issues/12758)

**Describe problem solved by the proposed pull request**
Fixed bank loiter after a No Global Position Failsafe wasn't working for VTOLs in FW mode. 

**Test data / coverage**
Tested in SITL `make px4_sitl gazebo_standard_vtol` by stopping `gpssim` driver. I also reactivated the `gpssim` driver to see if the vehicle recovers its position and continues its mission afterwards.

Logs:
Working fixed bank loiter, late recovery:
https://logs.px4.io/plot_app?log=217b432a-9452-4f67-862d-32322aaefe96

Working recovery:
https://logs.px4.io/plot_app?log=b165d3ea-54cc-4145-aeb7-acf75892611e
(running on an older commit head, but meanwhile it doesn't work anymore on this one, see this log: https://logs.px4.io/plot_app?log=2aad8195-476f-4af6-b289-c214e61fe853)

GPSF is still working on normal planes : 
https://logs.px4.io/plot_app?log=79b5e483-f698-4aa0-8b30-265d25a3cd14

**Describe your preferred solution**
Publishing the failsafe values to `fw_virtual_attitude_setpoint` topic if the vehicle is a VTOL so that `VtolType::update_fw_state()` doesn't overwrite them with old values anymore.

**Describe possible alternatives**

**Additional context**
This PR does not fix the GPS recovery & continuing the automatic flight problems. 
Also, the landing after "Terminate" is not working, the drone keeps loitering in fixed bank angle mode

