### PR TITLE
gitignore remove core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ Testing/
 Packages/*
 build/*
 build_*/
-core
 cscope.out
 cscope.in.out
 cscope.po.out


### PR DESCRIPTION
This is too generic and causing files to be ignored in https://github.com/PX4/Firmware/pull/12575.