### PR TITLE
mc_pos_control: takeoff fix implicit switch fallthrough

### DIFF
--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	MODULE modules__mc_pos_control
 	MAIN mc_pos_control
 	COMPILE_FLAGS
+		-Wno-implicit-fallthrough # TODO: fix and remove
 	STACK_MAIN 1500
 	SRCS
 		mc_pos_control_main.cpp

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -58,6 +58,7 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 			break;
 		}
 
+	// FALLTHROUGH
 	case TakeoffState::spoolup:
 		if (_spoolup_time_hysteresis.get_state()) {
 			_takeoff_state = TakeoffState::ready_for_takeoff;
@@ -66,6 +67,7 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 			break;
 		}
 
+	// FALLTHROUGH
 	case TakeoffState::ready_for_takeoff:
 		if (want_takeoff) {
 			_takeoff_state = TakeoffState::rampup;
@@ -75,6 +77,7 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 			break;
 		}
 
+	// FALLTHROUGH
 	case TakeoffState::rampup:
 		if (_takeoff_ramp_vz >= takeoff_desired_vz) {
 			_takeoff_state = TakeoffState::flight;
@@ -83,6 +86,7 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 			break;
 		}
 
+	// FALLTHROUGH
 	case TakeoffState::flight:
 		if (landed) {
 			_takeoff_state = TakeoffState::ready_for_takeoff;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/84712/63858877-528ef280-c974-11e9-9546-2bb9cd8f0d41.png)


These can change to `[[fallthrough]]` with c++17.