### PR TITLE
Clean up PX4 main and cli args

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -40,6 +40,11 @@ set RUN_MINIMAL_SHELL           no
 if [ "$PX4_SIM_MODEL" = "shell" ]; then
 	set RUN_MINIMAL_SHELL yes
 else
+	# Chose iris as default model if none is given.
+	if [ -n ${PX4_SIM_MODEL} ]; then
+		PX4_SIM_MODEL="iris"
+	fi
+
 	# Find the matching Autostart ID (file name has the form: [0-9]+_${PX4_SIM_MODEL})
 	# TODO: unify with rc.autostart generation
 	# shellcheck disable=SC2012

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -197,9 +197,9 @@ pushd "$rootfs" >/dev/null
 set +e
 
 if [[ ${model} == test_* ]] || [[ ${model} == *_generated ]]; then
-	sitl_command="\"$sitl_bin\" $no_pxh \"$src_path/ROMFS/px4fmu_test\" -s \"${src_path}/posix-configs/SITL/init/test/${model}\" -t \"$src_path\"/test_data"
+	sitl_command="\"$sitl_bin\" $no_pxh -s \"${src_path}/posix-configs/SITL/init/test/${model}\" -t \"$src_path\"/test_data"
 else
-	sitl_command="\"$sitl_bin\" $no_pxh \"$build_path\"/etc -s etc/init.d-posix/rcS -t \"$src_path\"/test_data"
+	sitl_command="\"$sitl_bin\" $no_pxh -s etc/init.d-posix/rcS -t \"$src_path/test_data\""
 fi
 
 echo SITL COMMAND: $sitl_command

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -197,7 +197,7 @@ pushd "$rootfs" >/dev/null
 set +e
 
 if [[ ${model} == test_* ]] || [[ ${model} == *_generated ]]; then
-	sitl_command="\"$sitl_bin\" $no_pxh \"$src_path\"/ROMFS/px4fmu_test -s \"${src_path}\"/posix-configs/SITL/init/test/${model} -t \"$src_path\"/test_data"
+	sitl_command="\"$sitl_bin\" $no_pxh \"$src_path/ROMFS/px4fmu_test\" -s \"${src_path}/posix-configs/SITL/init/test/${model}\" -t \"$src_path\"/test_data"
 else
 	sitl_command="\"$sitl_bin\" $no_pxh \"$build_path\"/etc -s etc/init.d-posix/rcS -t \"$src_path\"/test_data"
 fi

--- a/launch/posix_sitl.launch
+++ b/launch/posix_sitl.launch
@@ -29,7 +29,7 @@
     <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
     <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
     <node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4)/build/px4_sitl_default/etc -s etc/init.d-posix/rcS $(arg px4_command_arg1)" required="true"/>
+        args="-w $(find px4)/build/px4_sitl_default/tmp/rootfs -s etc/init.d-posix/rcS $(arg px4_command_arg1)" required="true"/>
 
     <!-- Gazebo sim -->
     <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -70,6 +70,36 @@ else()
 
 	target_link_libraries(px4 PRIVATE modules__uORB)
 
+	if(BUILD_TESTING)
+		set(romfs_foldername "px4fmu_test")
+	else()
+		set(romfs_foldername "px4fmu_common")
+	endif()
+
+	# We copy the ROMFS files over to the rootfs for SITL
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/tmp/rootfs/etc
+		COMMAND ${CMAKE_COMMAND} -E copy_directory ${PX4_SOURCE_DIR}/ROMFS/${romfs_foldername} ${PX4_BINARY_DIR}/tmp/rootfs/etc
+		)
+
+	add_custom_target(px4_sitl_etc_files
+		DEPENDS ${PX4_BINARY_DIR}/tmp/rootfs/etc
+		)
+
+	# We copy the test_data over to the rootfs for SITL
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/tmp/rootfs/test_data
+		COMMAND ${CMAKE_COMMAND} -E copy_directory ${PX4_SOURCE_DIR}/test_data ${PX4_BINARY_DIR}/tmp/rootfs/test_data
+		)
+
+	add_custom_target(px4_sitl_test_data
+		DEPENDS ${PX4_BINARY_DIR}/tmp/rootfs/test_data
+		)
+
+	add_dependencies(px4
+		px4_sitl_etc_files
+		px4_sitl_test_data
+		)
+
+
 	#=============================================================================
 	# install
 	#

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -114,13 +114,7 @@ static std::string pwd();
 static int change_directory(const std::string &directory);
 
 
-#ifdef __PX4_SITL_MAIN_OVERRIDE
-int SITL_MAIN(int argc, char **argv);
-
-int SITL_MAIN(int argc, char **argv)
-#else
 int main(int argc, char **argv)
-#endif
 {
 	bool is_client = false;
 	bool pxh_off = false;

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 		/* Server/daemon apps need to parse the command line arguments. */
 
 		std::string data_path{};
-		std::string commands_file = "etc/init.d/rcS";
+		std::string commands_file = "etc/init.d-posix/rcS";
 		std::string test_data_path{};
 		std::string working_directory{};
 		int instance = 0;
@@ -558,7 +558,7 @@ void print_usage()
 	printf("\n");
 	printf("    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [<rootfs_directory>] [-i <instance>] [-w <working_directory>]\n");
 	printf("\n");
-	printf("    -s <startup_file>      shell script to be used as startup (default=etc/init.d/rcS)\n");
+	printf("    -s <startup_file>      shell script to be used as startup (default=etc/init.d-posix/rcS)\n");
 	printf("    <rootfs_directory>     directory where startup files and mixers are located,\n");
 	printf("                           (if not given, CWD is used)\n");
 	printf("    -i <instance>          px4 instance id to run multiple instances [0...N], default=0\n");

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -556,10 +556,9 @@ void print_usage()
 {
 	printf("Usage for Server/daemon process: \n");
 	printf("\n");
-	printf("    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [<rootfs_directory>] [-i <instance>] [-w <working_directory>]\n");
+	printf("    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [-i <instance>] [-w <working_directory>]\n");
 	printf("\n");
 	printf("    -s <startup_file>      shell script to be used as startup (default=etc/init.d-posix/rcS)\n");
-	printf("    <rootfs_directory>     directory where startup files and mixers are located,\n");
 	printf("                           (if not given, CWD is used)\n");
 	printf("    -i <instance>          px4 instance id to run multiple instances [0...N], default=0\n");
 	printf("    -w <working_directory> directory to change to\n");


### PR DESCRIPTION
This cleans up the px4 main function:
- Allow running PX4 without args and sane defaults.
- Don't create symlinks within PX4 but let cmake copy the necessary files.

For more details see commit descriptions.