### PR TITLE
VTOL: fix land detector during transitions to fix MC throttle drops

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -94,6 +94,7 @@ void MulticopterLandDetector::_update_topics()
 	_vehicle_control_mode_sub.update(&_vehicle_control_mode);
 	_vehicle_local_position_sub.update(&_vehicle_local_position);
 	_vehicle_local_position_setpoint_sub.update(&_vehicle_local_position_setpoint);
+	_vehicle_status_sub.update(&_vehicle_status);
 }
 
 void MulticopterLandDetector::_update_params()
@@ -298,7 +299,8 @@ bool MulticopterLandDetector::_has_low_thrust()
 				 _param_lndmc_low_t_thr.get();
 
 	// Check if thrust output is less than the minimum auto throttle param.
-	return _actuator_controls.control[actuator_controls_s::INDEX_THROTTLE] <= sys_min_throttle;
+	return (!_vehicle_status.in_transition_mode
+		&& _actuator_controls.control[actuator_controls_s::INDEX_THROTTLE] <= sys_min_throttle);
 }
 
 bool MulticopterLandDetector::_has_minimal_thrust()
@@ -312,7 +314,8 @@ bool MulticopterLandDetector::_has_minimal_thrust()
 	}
 
 	// Check if thrust output is less than the minimum auto throttle param.
-	return _actuator_controls.control[actuator_controls_s::INDEX_THROTTLE] <= sys_min_throttle;
+	return (!_vehicle_status.in_transition_mode
+		&& _actuator_controls.control[actuator_controls_s::INDEX_THROTTLE] <= sys_min_throttle);
 }
 
 bool MulticopterLandDetector::_get_ground_effect_state()

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -53,6 +53,7 @@
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include "LandDetector.h"
 
@@ -125,6 +126,7 @@ private:
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	actuator_controls_s               _actuator_controls {};
 	battery_status_s                  _battery_status {};
@@ -134,6 +136,7 @@ private:
 	vehicle_control_mode_s            _vehicle_control_mode {};
 	vehicle_local_position_s          _vehicle_local_position {};
 	vehicle_local_position_setpoint_s _vehicle_local_position_setpoint {};
+	vehicle_status_s 									_vehicle_status {};
 
 	hrt_abstime _min_trust_start{0};	///< timestamp when minimum trust was applied first
 	hrt_abstime _landed_time{0};


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/12877

Problem was that during the backtransitions, the MC land detector detected landing and because of that set the throttle to 0. 

With this PR, the min throttle check is disabled for transitions.

Only bench tested yet.

Currently only the MC land detector is running for VTOL. During FW flight it always returns false. https://github.com/PX4/Firmware/issues/12779 
For transitions the fixed-wing land detector could be used (with relaxed airspeed check), a dedicated VTOL land detector implemented or the land detector simply deactivated (as it's here more or less done).