### PR TITLE
[WIP] Secure Bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ px4fmu_firmware: \
 	check_px4_fmu-v4_default \
 	check_px4_fmu-v4pro_default \
 	check_px4_fmu-v5_default \
+	check_px4_fmu-v5_crypto_btl \
 	check_px4_fmu-v5x_default \
 	sizes
 

--- a/Tools/cryptotools.py
+++ b/Tools/cryptotools.py
@@ -1,0 +1,102 @@
+import nacl.encoding
+import nacl.signing
+import nacl.encoding
+import nacl.hash
+import struct
+import binascii
+
+meta_data ={'appp_size':0,
+            'app_hash':0,
+            }
+
+META_DATA_STRUCT = "<I64s60x" # [4 length][64 sha512][60 padding]
+META_DATA_LEN = 128
+
+def pack_meta_data(meta_data):
+    return struct.pack(META_DATA_STRUCT, meta_data['appp_size'],
+                                         meta_data['app_hash'])
+def generate_sha512_header():
+    with open("../build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5.bin" ,mode='rb') as f:
+        source_bin = f.read()
+
+        # metadata is already included into the source bin,
+        # but filled with dummy data
+
+        meta_data['appp_size']=  len(source_bin)-META_DATA_LEN
+        meta_data['app_hash'] = nacl.hash.sha512(source_bin[META_DATA_LEN:], encoder=nacl.encoding.RawEncoder)
+
+        print("size of binary is: ", meta_data['appp_size'],hex(meta_data['appp_size'],))
+        print("SHA512 of binary is: ",meta_data['app_hash'])
+
+    with open("../build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5crypto.bin" ,mode='wb') as f:
+        data = pack_meta_data(meta_data)
+        print("meta data heder: ", binascii.hexlify(data),len(data))
+
+        f.write(data)
+        f.write(source_bin[META_DATA_LEN:])
+
+print("new crypto bin written")
+
+
+def ed25519_sign():
+     with open("build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5.bin" ,mode='rb') as f:
+        source_bin = f.read()
+
+        # metadata is already included into the source bin,
+        # but filled with dummy data
+
+        meta_data['appp_size']=  len(source_bin)-META_DATA_LEN
+
+
+        # Generate a new random signing key
+        signing_key = nacl.signing.SigningKey.generate()
+        private_key =b'e874323dea846720715f2179ae2c03f3c80a9caaa5e25eb3951096fd80f71ab7'
+
+        signing_key = nacl.signing.SigningKey(private_key, encoder=nacl.encoding.HexEncoder)
+
+        # Sign a message with the signing key
+        signed = signing_key.sign(source_bin[META_DATA_LEN:],encoder=nacl.encoding.RawEncoder)
+
+        meta_data['app_hash'] = signed.signature
+
+        # Obtain the verify key for a given signing key
+        verify_key = signing_key.verify_key
+
+        # Serialize the verify key to send it to a third party
+        verify_key_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
+
+        print(len(signed.signature), "signature:" ,binascii.hexlify(signed.signature))
+        print('Public key: ', verify_key_hex)
+
+        with open("build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5crypto.bin" ,mode='wb') as f:
+            data = pack_meta_data(meta_data)
+            print("meta data header: ", binascii.hexlify(data),len(data))
+
+            f.write(data)
+            f.write(source_bin[META_DATA_LEN:])
+
+
+
+
+if(__name__ == "__main__"):
+    #generate_sha512_header()
+    ed25519_sign()
+
+#import monocypher
+
+## Generate a new random signing key
+#signing_key = nacl.signing.SigningKey.generate()
+#
+## Sign a message with the signing key
+#signed = signing_key.sign(b"Attack at Dawn")
+#
+## Obtain the verify key for a given signing key
+#verify_key = signing_key.verify_key
+#
+## Serialize the verify key to send it to a third party
+#verify_key_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
+#print(verify_key_hex)
+#print(signed)
+#print(signed)
+#print(signing_key)
+#

--- a/Tools/cryptotools.py
+++ b/Tools/cryptotools.py
@@ -1,10 +1,19 @@
+#!/usr/bin/env python3
+
 import nacl.encoding
 import nacl.signing
 import nacl.encoding
 import nacl.hash
 import struct
 import binascii
+import json
+import time
+import argparse
+from pathlib import Path
+import sys
 
+
+# Definitins for the meta data heder of the signed application
 meta_data ={'appp_size':0,
             'app_hash':0,
             }
@@ -12,91 +21,144 @@ meta_data ={'appp_size':0,
 META_DATA_STRUCT = "<I64s60x" # [4 length][64 sha512][60 padding]
 META_DATA_LEN = 128
 
+
 def pack_meta_data(meta_data):
+    """
+    Packs the given meta data into a binary struct, to be written
+    on top of the binary application file.
+    """
     return struct.pack(META_DATA_STRUCT, meta_data['appp_size'],
                                          meta_data['app_hash'])
-def generate_sha512_header():
-    with open("../build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5.bin" ,mode='rb') as f:
-        source_bin = f.read()
 
-        # metadata is already included into the source bin,
-        # but filled with dummy data
+def make_public_key_h_file(signing_key):
+    """
+    This file generate the public key header file 
+    to be included into the bootloader build.
+    """
+    public_key_c=''
+    public_key_c="const uint8_t public_key={\n"
+    for i,c in enumerate(signing_key.verify_key.encode(encoder=nacl.encoding.RawEncoder)):
+        public_key_c+= hex(c)
+        public_key_c+= ', '
+        if((i+1)%8==0):
+            public_key_c+= '\n'
+    public_key_c+= "};"
+    with open("public_key.h" ,mode='w') as f:
+        f.write("//Public key to verify signed binaries")
+        f.write(public_key_c)
 
-        meta_data['appp_size']=  len(source_bin)-META_DATA_LEN
-        meta_data['app_hash'] = nacl.hash.sha512(source_bin[META_DATA_LEN:], encoder=nacl.encoding.RawEncoder)
+def make_key_file(signing_key):
+    """
+    Writes the key.json file.
+    Attention do not override your existing key files.
+    Do not publish your private key!!
+    """
 
-        print("size of binary is: ", meta_data['appp_size'],hex(meta_data['appp_size'],))
-        print("SHA512 of binary is: ",meta_data['app_hash'])
+    key_file = Path("keys.json")
+    if key_file.is_file():
+        print("ATTENTION: key.json already exists, are you sure you wnat to overwrite it?")
+        print("Remove file and run script again.")
+        print("Script aborted!")
+        sys.exit(-1)
+            
 
-    with open("../build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5crypto.bin" ,mode='wb') as f:
+    keys={}
+    keys["date"] = time.asctime()
+    keys["public"] = (signing_key.verify_key.encode(encoder=nacl.encoding.HexEncoder)).decode()
+    keys["private"] = binascii.hexlify(signing_key._seed).decode()
+    print (keys)
+    with open("keys.json", "w") as write_file:
+        json.dump(keys, write_file)
+
+def ed25519_sign(private_key, signee_bin):
+    """
+    This functino does the magic. It tkaes the pricate key and the binary file 
+    and generates the signed binary. it adds the meta data to the beginning of the file
+    Ouput: "SignedBin.bin"
+    """
+
+    # metadata is already included into the source bin,
+    # but filled with dummy data
+
+    meta_data['appp_size'] =  len(signee_bin) - META_DATA_LEN
+
+    signing_key = nacl.signing.SigningKey(private_key, encoder=nacl.encoding.HexEncoder)
+
+    # Sign a message with the signing key
+    signed = signing_key.sign(signee_bin[META_DATA_LEN:],encoder=nacl.encoding.RawEncoder)
+
+    meta_data['app_hash'] = signed.signature
+
+    # Obtain the verify key for a given signing key
+    verify_key = signing_key.verify_key
+
+    # Serialize the verify key to send it to a third party
+    verify_key_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
+
+    print(len(signed.signature), "signature:" ,binascii.hexlify(signed.signature))
+    print('Public key: ', verify_key_hex)
+
+    with open("SignedBin.bin" ,mode='wb') as f:
         data = pack_meta_data(meta_data)
-        print("meta data heder: ", binascii.hexlify(data),len(data))
+        print("meta data header: ", binascii.hexlify(data),len(data))
 
         f.write(data)
-        f.write(source_bin[META_DATA_LEN:])
+        f.write(signee_bin[META_DATA_LEN:])
 
-print("new crypto bin written")
+def sign(bin_file_path, key_file_path=None):
+    """
+    reads the binary file and the key file.
+    If the key file does not exist, it generates a 
+    new key file.
+    """
+
+    with open(bin_file_path,mode='rb') as f:
+        signee_bin = f.read()
+    if key_file_path == None:
+        print('generating new key')
+        generate_key()
+        key_file_path = 'keys.json'
+    
+    with open(key_file_path,mode='r') as f:
+        keys = json.load(f)
+        print(keys)      
+
+    ed25519_sign(keys["private"], signee_bin)
 
 
-def ed25519_sign():
-     with open("build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5.bin" ,mode='rb') as f:
-        source_bin = f.read()
 
-        # metadata is already included into the source bin,
-        # but filled with dummy data
+def generate_key():
+    """
+    Call it and it generate two files,
+    one file is made to be include in the bootloader build
+    so its the "public_key.h" containg the verfication key.
+    The other file key.json, containt both private and public key.
+    Do not leak or loose the key file. This is mandatory for signing 
+    all future binaries you want to deploy!
 
-        meta_data['appp_size']=  len(source_bin)-META_DATA_LEN
+    """
+    
+    # Generate a new random signing key
+    signing_key = nacl.signing.SigningKey.generate()
+     # Serialize the verify key to send it to a third party
+    verify_key_hex = signing_key.verify_key.encode(encoder=nacl.encoding.HexEncoder)
+    print("public key :",verify_key_hex)
 
+    private_key_hex=binascii.hexlify(signing_key._seed)
+    print("private key :",private_key_hex)
 
-        # Generate a new random signing key
-        signing_key = nacl.signing.SigningKey.generate()
-        private_key =b'e874323dea846720715f2179ae2c03f3c80a9caaa5e25eb3951096fd80f71ab7'
-
-        signing_key = nacl.signing.SigningKey(private_key, encoder=nacl.encoding.HexEncoder)
-
-        # Sign a message with the signing key
-        signed = signing_key.sign(source_bin[META_DATA_LEN:],encoder=nacl.encoding.RawEncoder)
-
-        meta_data['app_hash'] = signed.signature
-
-        # Obtain the verify key for a given signing key
-        verify_key = signing_key.verify_key
-
-        # Serialize the verify key to send it to a third party
-        verify_key_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
-
-        print(len(signed.signature), "signature:" ,binascii.hexlify(signed.signature))
-        print('Public key: ', verify_key_hex)
-
-        with open("build/px4_fmu-v5_crypto_btl_default/px4_fmu-v5crypto.bin" ,mode='wb') as f:
-            data = pack_meta_data(meta_data)
-            print("meta data header: ", binascii.hexlify(data),len(data))
-
-            f.write(data)
-            f.write(source_bin[META_DATA_LEN:])
-
+    make_key_file(signing_key)
+    make_public_key_h_file(signing_key)
 
 
 
 if(__name__ == "__main__"):
-    #generate_sha512_header()
-    ed25519_sign()
 
-#import monocypher
+    parser = argparse.ArgumentParser(description="""CLI tool to calculate and add signature to px4. bin files\n
+                                                  if given it takes an existing key file, else it generate new keys""",
+                                    epilog="Output: SignedBin.bin and a key.json file")
+    parser.add_argument("signee", help=".bin file to add signature")
+    parser.add_argument("--key", help="key.json file", default=None)
+    args = parser.parse_args()
 
-## Generate a new random signing key
-#signing_key = nacl.signing.SigningKey.generate()
-#
-## Sign a message with the signing key
-#signed = signing_key.sign(b"Attack at Dawn")
-#
-## Obtain the verify key for a given signing key
-#verify_key = signing_key.verify_key
-#
-## Serialize the verify key to send it to a third party
-#verify_key_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
-#print(verify_key_hex)
-#print(signed)
-#print(signed)
-#print(signing_key)
-#
+    sign(args.signee, args.key)

--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -177,7 +177,7 @@ class uploader(object):
 
     INFO_BL_REV     = b'\x01'        # bootloader protocol revision
     BL_REV_MIN      = 2              # minimum supported bootloader protocol
-    BL_REV_MAX      = 5              # maximum supported bootloader protocol
+    BL_REV_MAX      = 7              # maximum supported bootloader protocol
     INFO_BOARD_ID   = b'\x02'        # board type
     INFO_BOARD_REV  = b'\x03'        # board revision
     INFO_FLASH_SIZE = b'\x04'        # max firmware size in bytes
@@ -342,7 +342,7 @@ class uploader(object):
             self.__getSync(False)
         except:
             # if it fails we are on a real Serial Port
-            self.ackWindowedMode = True
+            self.ackWindowedMode = False
 
         self.port.baudrate = self.baudrate_bootloader
 
@@ -733,13 +733,13 @@ def main():
             pyserial_installed = True
     except:
         pass
-    
+
     try:
         if serial.VERSION:
             pyserial_installed = True
     except:
         pass
-    
+
     if not pyserial_installed:
         print("Error: pyserial not installed!")
         print("    (Install using: sudo pip install pyserial)")

--- a/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
@@ -7,7 +7,7 @@
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
- * are met:
+ * are met:`
  *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
@@ -92,8 +92,14 @@ EXTERN(_bootdelay_signature)
 SECTIONS
 {
 	.text : {
+		_application_meta_data = ABSOLUTE(.);
+		FILL(0xba);
+		. += 100;
+
+		. = ALIGN(128);
+
 		_stext = ABSOLUTE(.);
-		*(.vectors)
+		*(.vectors);
 		. = ALIGN(32);
 		/*
 		This signature provides the bootloader with a way to delay booting
@@ -101,10 +107,6 @@ SECTIONS
 		_bootdelay_signature = ABSOLUTE(.);
 		FILL(0xffecc2925d7d05c5)
 		. += 8;
-		_application_signature = ABSOLUTE(.);
-		FILL(0xba)
-		. += 64;
-
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)

--- a/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/script.ld
@@ -101,6 +101,10 @@ SECTIONS
 		_bootdelay_signature = ABSOLUTE(.);
 		FILL(0xffecc2925d7d05c5)
 		. += 8;
+		_application_signature = ABSOLUTE(.);
+		FILL(0xba)
+		. += 64;
+
 		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)


### PR DESCRIPTION
To support a secure bootloader with a signed image, the linker file of the px4 needs to be adapted. the whole image is shifted up in memory area by 128 bytes to give space for a crypto header.
This header contains the length and the signature of the image.
To generate this signed image a new tool has been added to the tools folder, cryptotools.py
it takes a px image( linked with the new linker file) and adds the ed25519 signature.
Images linked with this linker file are not anymore compatible with the bootloader version 5 and less.
