### PR TITLE
Imu health reporting and preflight checks improvements

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -93,6 +93,8 @@ uint32 onboard_control_sensors_present
 uint32 onboard_control_sensors_enabled
 uint32 onboard_control_sensors_health
 
+uint32 imu_sensors_health	# bitmask (see SYS_STATUS mavlink message) containing health flags for the gyro, accel, mag and baro sensors sent by the sensors module
+
 # airspeed fault and airspeed use status
 float32 arspd_check_level	# integrated airspeed inconsistency as checked against the COM_TAS_FS_INTEG parameter
 bool aspd_check_failing		# true when airspeed consistency checks are failing

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -95,6 +95,8 @@ uint32 onboard_control_sensors_health
 
 uint32 imu_sensors_health	# bitmask (see SYS_STATUS mavlink message) containing health flags for the gyro, accel, mag and baro sensors sent by the sensors module
 
+bool preflight_checks_result	# set to true by the preflight checks if the checks passed
+
 # airspeed fault and airspeed use status
 float32 arspd_check_level	# integrated airspeed inconsistency as checked against the COM_TAS_FS_INTEG parameter
 bool aspd_check_failing		# true when airspeed consistency checks are failing

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -198,6 +198,8 @@ private:
 					    subsystem_info_s::SUBSYSTEM_TYPE_MAG | subsystem_info_s::SUBSYSTEM_TYPE_MAG2 |
 					    subsystem_info_s::SUBSYSTEM_TYPE_ABSPRESSURE;
 
+	uint64_t _last_preflight_check_time; /**< timestamp of the last preflight check initiated on the regular interval */
+
 	bool handle_command(vehicle_status_s *status, const vehicle_command_s &cmd, actuator_armed_s *armed,
 			    uORB::PublicationQueued<vehicle_command_ack_s> &command_ack_pub, bool *changed);
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -60,6 +60,7 @@
 #include <uORB/topics/iridiumsbd_status.h>
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/offboard_control_mode.h>
+#include <uORB/topics/subsystem_info.h>
 #include <uORB/topics/telemetry_status.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_command.h>
@@ -191,6 +192,11 @@ private:
 
 	FailureDetector _failure_detector;
 	bool _flight_termination_triggered{false};
+
+	const uint64_t IMU_SUBSYSTEM_MASK = subsystem_info_s::SUBSYSTEM_TYPE_GYRO | subsystem_info_s::SUBSYSTEM_TYPE_GYRO2 |
+					    subsystem_info_s::SUBSYSTEM_TYPE_ACC | subsystem_info_s::SUBSYSTEM_TYPE_ACC2 |
+					    subsystem_info_s::SUBSYSTEM_TYPE_MAG | subsystem_info_s::SUBSYSTEM_TYPE_MAG2 |
+					    subsystem_info_s::SUBSYSTEM_TYPE_ABSPRESSURE;
 
 	bool handle_command(vehicle_status_s *status, const vehicle_command_s &cmd, actuator_armed_s *armed,
 			    uORB::PublicationQueued<vehicle_command_ack_s> &command_ack_pub, bool *changed);

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -991,6 +991,8 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 		}
 	}
 
+	status.preflight_checks_result = !failed;
+
 	/* Report status */
 	return !failed;
 }

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -212,6 +212,14 @@ private:
 	bool checkFailover(SensorData &sensor, const char *sensor_name, const uint64_t type);
 
 	/**
+	 * Publish health on the subsystem info topic
+	 *
+	 * @param	subsystem_type	subsystem type defined with the enum in the subsystem_info_s uORB msg
+	 * @param	ok				health of the subsystem
+	 */
+	void publish_subsystem_info(uint64_t subsystem_type, bool ok);
+
+	/**
 	 * Apply a gyro calibration.
 	 *
 	 * @param h: reference to the DevHandle in use
@@ -248,6 +256,9 @@ private:
 	SensorData _baro {};
 
 	orb_advert_t _mavlink_log_pub{nullptr};
+
+	// subsystem info reporting
+	uint64_t _sensors_health = UINT64_MAX;
 
 	uORB::Publication<sensor_correction_s>	_sensor_correction_pub{ORB_ID(sensor_correction)};	/**< handle to the sensor correction uORB topic */
 	uORB::Publication<sensor_selection_s>	_sensor_selection_pub{ORB_ID(sensor_selection)};	/**< handle to the sensor selection uORB topic */

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -155,7 +155,7 @@ private:
 			  last_failover_count(0)
 		{
 			for (unsigned i = 0; i < SENSOR_COUNT_MAX; i++) {
-				enabled[i] = true;
+				enabled[i] = false;
 				subscription[i] = -1;
 				priority[i] = 0;
 			}


### PR DESCRIPTION
Main issues:
1) Gyro, accel, mag and baro health is evaluated by different modules  (sensors, commander) and each of them set the health bitmask inconsistently, furthermore each of them overrides the health reported by the other.
2) Preflight checks do not consider sensor failures reported by the sensors module

More detailed explanation and problem examples:

1) Sensors health bitmask is set in commander::status.onboard_control_sensors_health. It is set by preflight tests function, and by the health reported on the subsystem_info topic by sensors module.
Preflight checks set the bit in the health bitmask that matches the sensor instance. For example SUBSYSTEM_TYPE_GYRO bit is set for gyro 0, and SUBSYSTEM_TYPE_GYRO2 for gyro 1. On the other hand sensors module sets the bits considering the number of healthy sensors. Which means that in case of a gyro 0 failure, commander would set SUBSYSTEM_TYPE_GYRO to false, and sensors would set SUBSYSTEM_TYPE_GYRO2 to false. That behavior is not consistent.

- Solution: sensors module should also set the health of a specific sensor according to its index and not to the number of healthy sensors. This way we know which sensor failed by looking at the vehicle_status message. Especially useful when using external sensors, to be able to know which one to replace.
Furthermore, the health reported by different modules should be passed through a "logical and" function to get the final health. If any module reports a sensor failure, the sensor is flagged as failed.

2) Preflight checks do not consider health reported by sensors module (no data, stale data, timeout, high error count, high error density).
I could reproduce the following scenario: I set the required number of healthy sensors to 2 instead of default 1, enabled 2 mags, and had stale data on the second mag. The checks passed even though the second mag was broken.

- Solution: use the health reported by the sensors module together with the existing health checks in preflight tests.


Other fixes and improvements:
- Commander runs preflight tests every 2 seconds or when the health message is received, if the vehicle is unarmed. This way we have up to date health checks, and flight readiness, which can be reported over mavlink to the base station such that the user is informed about the system state and failures all the time and not only when arming is requested. Or be used otherwise.

- I encountered a bug where I had 1 mag enabled but got mag sensors inconsistency failure. This happened because mag 2 was disabled but still had priority set to 100 instead of zero. Mag enabled is initalized to true and overridden by the parameter setting inVotedSensorsUpdate::parametersUpdate(), but only if this sensors uorb instance was published. Due to race conditions this didnt happen before the initial parameter update, but after mag poll was called, so in VotedSensorsUpdate::magPoll since the enable was true, the priority 100 was assigned to the sensor and it was checked in the inconsistency test.
Solution: sensors enabled array is initialized to false. (priority is already 0 initially, and so should the enabled flags be).