### PR TITLE
[WIP]: Tools/check_submodules.sh: improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,11 +450,14 @@ submodulesclean:
 	@git submodule update --quiet --init --recursive --force || true
 	@git submodule sync --recursive
 	@git submodule update --init --recursive --force
+	@git submodule foreach 'git checkout -q -B $$(git config -f $$toplevel/.gitmodules submodule.$$name.branch || echo master)'
 
 submodulesupdate:
-	@git submodule update --quiet --init --recursive || true
+	@git submodule update --quiet --init --recursive --jobs=8 || true
+	@git submodule update --quiet --init --recursive
 	@git submodule sync --recursive
-	@git submodule update --init --recursive
+	@git submodule update --remote
+	@git submodule foreach 'git checkout -q -B $$(git config -f $$toplevel/.gitmodules submodule.$$name.branch || echo master)'
 
 gazeboclean:
 	@rm -rf ~/.gazebo/*

--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -7,62 +7,80 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 
 	# CI environment always update
 	if [ "$CI" == "true" ]; then
-		git submodule --quiet sync --recursive -- $1
-		git submodule --quiet update --init --recursive --jobs=8 -- $1 || true
-		git submodule --quiet update --init --recursive -- $1
+		git_submodule_update $1
 		exit 0
 	fi
 
 	SUBMODULE_STATUS=$(git submodule summary "$1")
 	STATUSRETVAL=$(echo $SUBMODULE_STATUS | grep -A20 -i "$1")
+
+	echo "SUBMODULE_STATUS: ${SUBMODULE_STATUS}"
+	echo "STATUSRETVAL: ${STATUSRETVAL}"
+
 	if ! [[ -z "$STATUSRETVAL" ]]; then
-		echo -e "\033[31mChecked $1 submodule, ACTION REQUIRED:\033[0m"
-		echo ""
-		echo -e "Different commits:"
-		echo -e "$SUBMODULE_STATUS"
-		echo ""
-		echo ""
-		echo -e " *******************************************************************************"
-		echo -e " *   \033[31mIF YOU DID NOT CHANGE THIS FILE (OR YOU DON'T KNOW WHAT A SUBMODULE IS):\033[0m  *"
-		echo -e " *   \033[31mHit 'u' and <ENTER> to update ALL submodules and resolve this.\033[0m            *"
-		echo -e " *   (performs \033[94mgit submodule sync --recursive\033[0m                                  *"
-		echo -e " *    and \033[94mgit submodule update --init --recursive\033[0m )                            *"
-		echo -e " *******************************************************************************"
-		echo ""
-		echo ""
-		echo -e "   Only for EXPERTS:"
-		echo -e "   $1 submodule is not in the recommended version."
-		echo -e "   Hit 'y' and <ENTER> to continue the build with this version. Hit <ENTER> to resolve manually."
-		echo -e "   Use \033[94mgit add $1 && git commit -m 'Updated $1'\033[0m to choose this version (careful!)"
-		echo ""
-		read user_cmd
-		if [ "$user_cmd" == "y" ]; then
-			echo "Continuing build with manually overridden submodule.."
-		elif [ "$user_cmd" == "u" ]; then
-			git submodule sync --recursive -- $1
-			git submodule update --init --recursive --jobs=8 -- $1 || true
-			git submodule update --init --recursive --force -- $1
 
-			# put submodule on branch
-			git -C $1 checkout -q -B $(git config -f .gitmodules submodule.$1.branch || echo master)
 
-			echo "Submodule fixed, continuing build.."
+
+		# check submodule status as of previous commit (HEAD@{1})
+		GIT_SHA_PREV=$(git ls-tree -d HEAD@{1} $1 | awk '{print $3;}')
+		GIT_SHA_CURR=$(git -C $1 rev-parse HEAD)
+
+		echo "$1 GIT_SHA_PREV: ${GIT_SHA_PREV}"
+		echo "$1 GIT_SHA_CURR: ${GIT_SHA_CURR}"
+
+		if [ "${GIT_SHA_PREV}" == "${GIT_SHA_CURR}" ]; then
+			# submodule is currently on the wrong commit, but on previous HEAD it wasn't, therefore it's safe to update
+			echo "$1 GIT SHA matched previous, updating"
+			git_submodule_update $1
+
 		else
-			echo "Build aborted."
-			exit 1
+
+			echo -e "\033[31mChecked $1 submodule, ACTION REQUIRED:\033[0m"
+			echo ""
+			echo -e "Different commits:"
+			echo -e "$SUBMODULE_STATUS"
+			echo ""
+			echo ""
+			echo -e " *******************************************************************************"
+			echo -e " *   \033[31mIF YOU DID NOT CHANGE THIS FILE (OR YOU DON'T KNOW WHAT A SUBMODULE IS):\033[0m  *"
+			echo -e " *   \033[31mHit 'u' and <ENTER> to update ALL submodules and resolve this.\033[0m            *"
+			echo -e " *   (performs \033[94mgit submodule sync --recursive\033[0m                                  *"
+			echo -e " *    and \033[94mgit submodule update --init --recursive\033[0m )                            *"
+			echo -e " *******************************************************************************"
+			echo ""
+			echo ""
+			echo -e "   Only for EXPERTS:"
+			echo -e "   $1 submodule is not in the recommended version."
+			echo -e "   Hit 'y' and <ENTER> to continue the build with this version. Hit <ENTER> to resolve manually."
+			echo -e "   Use \033[94mgit add $1 && git commit -m 'Updated $1'\033[0m to choose this version (careful!)"
+			echo ""
+			read user_cmd
+			if [ "$user_cmd" == "y" ]; then
+				echo "Continuing build with manually overridden submodule.."
+			elif [ "$user_cmd" == "u" ]; then
+				git_submodule_update $1
+
+				echo "Submodule fixed, continuing build.."
+			else
+				echo "Build aborted."
+				exit 1
+			fi
 		fi
 	fi
 else
+	git_submodule_update $1
 
+fi
+
+}
+
+function git_submodule_update {
 	git submodule --quiet sync --recursive --quiet -- $1
 	git submodule --quiet update --init --recursive --jobs=8 -- $1  || true
 	git submodule --quiet update --init --recursive -- $1
 
 	# put submodule on branch
 	git -C $1 checkout -q -B $(git config -f .gitmodules submodule.$1.branch || echo master)
-
-fi
-
 }
 
 # If called with a path then respect $GIT_SUBMODULES_ARE_EVIL but do normal processing

--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -42,6 +42,10 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 			git submodule sync --recursive -- $1
 			git submodule update --init --recursive --jobs=8 -- $1 || true
 			git submodule update --init --recursive --force -- $1
+
+			# put submodule on branch
+			git -C $1 checkout -q -B $(git config -f .gitmodules submodule.$1.branch || echo master)
+
 			echo "Submodule fixed, continuing build.."
 		else
 			echo "Build aborted."
@@ -49,9 +53,14 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 		fi
 	fi
 else
+
 	git submodule --quiet sync --recursive --quiet -- $1
 	git submodule --quiet update --init --recursive --jobs=8 -- $1  || true
 	git submodule --quiet update --init --recursive -- $1
+
+	# put submodule on branch
+	git -C $1 checkout -q -B $(git config -f .gitmodules submodule.$1.branch || echo master)
+
 fi
 
 }

--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -8,8 +8,8 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 	# CI environment always update
 	if [ "$CI" == "true" ]; then
 		git submodule --quiet sync --recursive -- $1
-		git submodule --quiet update --init --recursive --jobs=8 -- $1  || true
-		git submodule --quiet update --init --recursive --jobs=8 -- $1
+		git submodule --quiet update --init --recursive --jobs=8 -- $1 || true
+		git submodule --quiet update --init --recursive -- $1
 		exit 0
 	fi
 
@@ -40,7 +40,7 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 			echo "Continuing build with manually overridden submodule.."
 		elif [ "$user_cmd" == "u" ]; then
 			git submodule sync --recursive -- $1
-			git submodule update --init --recursive -- $1 || true
+			git submodule update --init --recursive --jobs=8 -- $1 || true
 			git submodule update --init --recursive --force -- $1
 			echo "Submodule fixed, continuing build.."
 		else
@@ -50,7 +50,7 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 	fi
 else
 	git submodule --quiet sync --recursive --quiet -- $1
-	git submodule --quiet update --init --recursive -- $1  || true
+	git submodule --quiet update --init --recursive --jobs=8 -- $1  || true
 	git submodule --quiet update --init --recursive -- $1
 fi
 

--- a/cmake/px4_git.cmake
+++ b/cmake/px4_git.cmake
@@ -75,7 +75,7 @@ function(px4_add_git_submodule)
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/git_init_${NAME}.stamp
 		COMMAND Tools/check_submodules.sh ${REL_PATH}
 		COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/git_init_${NAME}.stamp
-		DEPENDS ${PX4_SOURCE_DIR}/.gitmodules ${PATH}/.git
+		DEPENDS ${PX4_SOURCE_DIR}/.gitmodules ${PATH}/.git ${PX4_SOURCE_DIR}/.git/modules/${REL_PATH}/index
 		COMMENT "git submodule ${REL_PATH}"
 		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 		USES_TERMINAL


### PR DESCRIPTION
This is a bit hacky, but let's us get away with typically using `--jobs` for submodule updates (since Git 2.9 ~ June 2016), while still being functional on previous versions.