### PR TITLE
[Draft] Fix SITL offboard attitude for VTOL_TYPE_RESERVED2

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1412,7 +1412,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
                         _virt_att_sp_pub.publish(att_sp);
                         break;
                     default:
-                        //_att_sp_pub.publish(att_sp);
+                        _att_sp_pub.publish(att_sp);
                         break;
                     }
 				}

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1397,6 +1397,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						case MAV_TYPE_OCTOROTOR:
 						case MAV_TYPE_TRICOPTER:
 						case MAV_TYPE_HELICOPTER:
+                        case MAV_TYPE_VTOL_RESERVED2:
 							att_sp.thrust_body[2] = -set_attitude_target.thrust;
 							break;
 
@@ -1406,7 +1407,14 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						}
 					}
 
-					_att_sp_pub.publish(att_sp);
+                    switch (_mavlink->get_system_type()) {
+                    case MAV_TYPE_VTOL_RESERVED2:
+                        _virt_att_sp_pub.publish(att_sp);
+                        break;
+                    default:
+                        //_att_sp_pub.publish(att_sp);
+                        break;
+                    }
 				}
 
 				/* Publish attitude rate setpoint if bodyrate and thrust ignore bits are not set */

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1397,7 +1397,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						case MAV_TYPE_OCTOROTOR:
 						case MAV_TYPE_TRICOPTER:
 						case MAV_TYPE_HELICOPTER:
-                        case MAV_TYPE_VTOL_RESERVED2:
+						case MAV_TYPE_VTOL_RESERVED2:
 							att_sp.thrust_body[2] = -set_attitude_target.thrust;
 							break;
 
@@ -1407,14 +1407,15 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						}
 					}
 
-                    switch (_mavlink->get_system_type()) {
-                    case MAV_TYPE_VTOL_RESERVED2:
-                        _virt_att_sp_pub.publish(att_sp);
-                        break;
-                    default:
-                        _att_sp_pub.publish(att_sp);
-                        break;
-                    }
+					switch (_mavlink->get_system_type()) {
+					case MAV_TYPE_VTOL_RESERVED2:
+						_virt_att_sp_pub.publish(att_sp);
+						break;
+
+					default:
+						_att_sp_pub.publish(att_sp);
+						break;
+					}
 				}
 
 				/* Publish attitude rate setpoint if bodyrate and thrust ignore bits are not set */

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -228,7 +228,8 @@ private:
 	uORB::Publication<optical_flow_s>			_flow_pub{ORB_ID(optical_flow)};
 	uORB::Publication<position_setpoint_triplet_s>		_pos_sp_triplet_pub{ORB_ID(position_setpoint_triplet)};
 	uORB::Publication<vehicle_attitude_s>			_attitude_pub{ORB_ID(vehicle_attitude)};
-	uORB::Publication<vehicle_attitude_setpoint_s>		_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+    //uORB::Publication<vehicle_attitude_setpoint_s>		_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+    uORB::Publication<vehicle_attitude_setpoint_s>		_virt_att_sp_pub{ORB_ID(mc_virtual_attitude_setpoint)};
 	uORB::Publication<vehicle_global_position_s>		_global_pos_pub{ORB_ID(vehicle_global_position)};
 	uORB::Publication<vehicle_gps_position_s>		_gps_pub{ORB_ID(vehicle_gps_position)};
 	uORB::Publication<vehicle_land_detected_s>		_land_detector_pub{ORB_ID(vehicle_land_detected)};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -228,7 +228,7 @@ private:
 	uORB::Publication<optical_flow_s>			_flow_pub{ORB_ID(optical_flow)};
 	uORB::Publication<position_setpoint_triplet_s>		_pos_sp_triplet_pub{ORB_ID(position_setpoint_triplet)};
 	uORB::Publication<vehicle_attitude_s>			_attitude_pub{ORB_ID(vehicle_attitude)};
-    //uORB::Publication<vehicle_attitude_setpoint_s>		_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+    uORB::Publication<vehicle_attitude_setpoint_s>		_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
     uORB::Publication<vehicle_attitude_setpoint_s>		_virt_att_sp_pub{ORB_ID(mc_virtual_attitude_setpoint)};
 	uORB::Publication<vehicle_global_position_s>		_global_pos_pub{ORB_ID(vehicle_global_position)};
 	uORB::Publication<vehicle_gps_position_s>		_gps_pub{ORB_ID(vehicle_gps_position)};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -228,8 +228,8 @@ private:
 	uORB::Publication<optical_flow_s>			_flow_pub{ORB_ID(optical_flow)};
 	uORB::Publication<position_setpoint_triplet_s>		_pos_sp_triplet_pub{ORB_ID(position_setpoint_triplet)};
 	uORB::Publication<vehicle_attitude_s>			_attitude_pub{ORB_ID(vehicle_attitude)};
-    uORB::Publication<vehicle_attitude_setpoint_s>		_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
-    uORB::Publication<vehicle_attitude_setpoint_s>		_virt_att_sp_pub{ORB_ID(mc_virtual_attitude_setpoint)};
+	uORB::Publication<vehicle_attitude_setpoint_s>		_att_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
+	uORB::Publication<vehicle_attitude_setpoint_s>		_virt_att_sp_pub{ORB_ID(mc_virtual_attitude_setpoint)};
 	uORB::Publication<vehicle_global_position_s>		_global_pos_pub{ORB_ID(vehicle_global_position)};
 	uORB::Publication<vehicle_gps_position_s>		_gps_pub{ORB_ID(vehicle_gps_position)};
 	uORB::Publication<vehicle_land_detected_s>		_land_detector_pub{ORB_ID(vehicle_land_detected)};


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Partly fixes [#13092](https://github.com/PX4/Firmware/issues/13092) : 
Fixes offboard attitude control for VTOLs of type VTOL_TYPE_RESERVED2 in SITL.

Does not work with HIL and the big question is why?

**Test data / coverage**
Successfully tested in SITL with MAVSDK function `Offboard::set_attitude(Offboard::Attitude attitude)`: 
https://logs.px4.io/plot_app?log=870a9ef1-c346-4a18-beb9-1afb8c6a287a

Not working in HIL (with Pixhawk 4 as hardware) : 
https://logs.px4.io/plot_app?log=f714ce4f-828c-45bc-8753-f95fd6b2bbab

Not tested on real drones.

**Describe your preferred solution**
Changed the ORB ID of the attitude setpoint publication for VTOL_TYPE_RESERVED2. Other VTOL_TYPE_* vehicles can easily be added in the switch. Downside: needs a new ORB Publication with the new API.

**Describe possible alternatives**
Could also use vehicle_status.is_vtol flag , but that would need another ORB subscription to access that information.
Also, with the old ORB API, it would be possible to only have one publication in the header file and set the ORB ID accordingly in the switch before publication

**Additional context**
I could not figure out why it doesn't work in HIL, that's a big point of confusion for me. Would be good if someone else could have a look at that. :)