### PR TITLE
[WIP]: Rate control: introduce torque_setpoint, angular_accel_setpoint, and inertia matrix

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/10016_iris
+++ b/ROMFS/px4fmu_common/init.d-posix/10016_iris
@@ -9,5 +9,18 @@
 
 sh /etc/init.d/rc.mc_defaults
 
+if [ $AUTOCNF = yes ]
+then
+	param set MC_ROLLRATE_P 18.0
+	param set MC_ROLLRATE_D 0.36
+	param set MC_PITCHRATE_P 18.0
+	param set MC_PITCHRATE_D 0.36
+	param set MC_YAWRATE_P 7.0
+	param set MC_YAWRATE_D 0.0
+
+	param set VM_INERTIA_XX 0.0083
+	param set VM_INERTIA_YY 0.0083
+	param set VM_INERTIA_ZZ 0.0286
+fi
 set MIXER quad_w
 

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -44,7 +44,7 @@ px4_add_board(
 		land_detector
 		landing_target_estimator
 		load_mon
-		local_position_estimator
+		#local_position_estimator
 		logger
 		mavlink
 		mc_att_control

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -89,7 +89,7 @@ px4_add_board(
 		shutdown
 		#tests # tests and test runner
 		top
-		topic_listener
+		#topic_listener
 		tune_control
 		usb_connected
 		ver

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -53,7 +53,7 @@ px4_add_board(
 		#pca9685
 		#protocol_splitter
 		#pwm_input
-		pwm_out_sim
+		#pwm_out_sim
 		px4fmu
 		px4io
 		#roboclaw

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -131,6 +131,7 @@ set(msg_files
 	vehicle_acceleration.msg
 	vehicle_air_data.msg
 	vehicle_angular_acceleration.msg
+	vehicle_angular_acceleration_setpoint.msg
 	vehicle_angular_velocity.msg
 	vehicle_attitude.msg
 	vehicle_attitude_setpoint.msg
@@ -149,6 +150,8 @@ set(msg_files
 	vehicle_roi.msg
 	vehicle_status.msg
 	vehicle_status_flags.msg
+	vehicle_thrust_setpoint.msg
+	vehicle_torque_setpoint.msg
 	vehicle_trajectory_waypoint.msg
 	vtol_vehicle_status.msg
 	wheel_encoders.msg

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -130,6 +130,7 @@ set(msg_files
 	ulog_stream_ack.msg
 	vehicle_acceleration.msg
 	vehicle_air_data.msg
+	vehicle_angular_acceleration.msg
 	vehicle_angular_velocity.msg
 	vehicle_attitude.msg
 	vehicle_attitude_setpoint.msg

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -265,6 +265,14 @@ rtps:
     id: 116
   - msg: cellular_status
     id: 117
+  - msg: vehicle_angular_acceleration
+    id: 118
+  - msg: vehicle_angular_acceleration_setpoint
+    id: 119
+  - msg: vehicle_torque_setpoint
+    id: 120
+  - msg: vehicle_thrust_setpoint
+    id: 121
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 150

--- a/msg/vehicle_angular_acceleration.msg
+++ b/msg/vehicle_angular_acceleration.msg
@@ -1,0 +1,7 @@
+
+uint64 timestamp	# time since system start (microseconds)
+uint64 timestamp_sample # timestamp of the data sample on which this message is based (microseconds)
+
+float32[3] xyz		# angular acceleration about X, Y, Z body axis in rad/s^2,
+			# computed by differentiating vehicle_angular_velocity and applying a low pass filter
+			# can be used to verify that the vehicle correctly tracks angular acceleration setpoints

--- a/msg/vehicle_angular_acceleration_setpoint.msg
+++ b/msg/vehicle_angular_acceleration_setpoint.msg
@@ -1,0 +1,5 @@
+
+uint64 timestamp	# time since system start (microseconds)
+uint64 timestamp_sample # timestamp of the data sample on which this message is based (microseconds)
+
+float32[3] xyz		# angular acceleration about X, Y, Z body axis in rad/s^2

--- a/msg/vehicle_thrust_setpoint.msg
+++ b/msg/vehicle_thrust_setpoint.msg
@@ -1,0 +1,5 @@
+
+uint64 timestamp	# time since system start (microseconds)
+uint64 timestamp_sample # timestamp of the data sample on which this message is based (microseconds)
+
+float32[3] xyz		# thrust setpoint along X, Y, Z body axis (in N)

--- a/msg/vehicle_torque_setpoint.msg
+++ b/msg/vehicle_torque_setpoint.msg
@@ -1,0 +1,5 @@
+
+uint64 timestamp	# time since system start (microseconds)
+uint64 timestamp_sample # timestamp of the data sample on which this message is based (microseconds)
+
+float32[3] xyz		# torque setpoint about X, Y, Z body axis (in N.m)

--- a/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.cpp
+++ b/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.cpp
@@ -43,6 +43,7 @@ namespace math
 void LowPassFilter2pVector3f::set_cutoff_frequency(float sample_freq, float cutoff_freq)
 {
 	_cutoff_freq = cutoff_freq;
+	_sample_freq = sample_freq;
 
 	// reset delay elements on filter change
 	_delay_element_1.zero();

--- a/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.hpp
+++ b/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.hpp
@@ -74,12 +74,16 @@ public:
 	// Return the cutoff frequency
 	float get_cutoff_freq() const { return _cutoff_freq; }
 
+	// Return the sample frequency
+	float get_sample_freq() const { return _sample_freq; }
+
 	// Reset the filter state to this value
 	matrix::Vector3f reset(const matrix::Vector3f &sample);
 
 private:
 
 	float _cutoff_freq{0.0f};
+	float _sample_freq{0.0f};
 
 	float _a1{0.0f};
 	float _a2{0.0f};

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -655,6 +655,28 @@ void FixedwingAttitudeControl::Run()
 			}
 
 			_actuators_2_pub.publish(_actuators_airframe);
+
+			/* publish thrust and torque setpoint */
+			if (!_vehicle_status.is_vtol
+			    || (_vehicle_status.is_vtol && (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING))
+			   ) {
+				vehicle_torque_setpoint_s v_torque_sp = {};
+				v_torque_sp.timestamp = hrt_absolute_time();
+				v_torque_sp.timestamp_sample = _att.timestamp;
+				v_torque_sp.xyz[0] = (PX4_ISFINITE(_actuators.control[0])) ? _actuators.control[0] : 0.0f;
+				v_torque_sp.xyz[1] = (PX4_ISFINITE(_actuators.control[1])) ? _actuators.control[1] : 0.0f;
+				v_torque_sp.xyz[2] = (PX4_ISFINITE(_actuators.control[2])) ? _actuators.control[2] : 0.0f;
+				_vehicle_torque_setpoint_pub.publish(v_torque_sp);
+
+				vehicle_thrust_setpoint_s v_thrust_sp = {};
+				v_thrust_sp.timestamp = hrt_absolute_time();
+				v_thrust_sp.timestamp_sample = _att.timestamp;
+				v_thrust_sp.xyz[0] = (PX4_ISFINITE(_actuators.control[3])) ? _actuators.control[3] : 0.0f;
+				v_thrust_sp.xyz[1] = 0.0f;
+				v_thrust_sp.xyz[2] = 0.0f;
+				_vehicle_thrust_setpoint_pub.publish(v_thrust_sp);
+
+			}
 		}
 	}
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -66,6 +66,8 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_thrust_setpoint.h>
+#include <uORB/topics/vehicle_torque_setpoint.h>
 
 using matrix::Eulerf;
 using matrix::Quatf;
@@ -115,6 +117,8 @@ private:
 	uORB::Publication<actuator_controls_s>		_actuators_2_pub{ORB_ID(actuator_controls_2)};		/**< actuator control group 1 setpoint (Airframe) */
 	uORB::Publication<vehicle_rates_setpoint_s>	_rate_sp_pub{ORB_ID(vehicle_rates_setpoint)};		/**< rate setpoint publication */
 	uORB::PublicationMulti<rate_ctrl_status_s>	_rate_ctrl_status_pub{ORB_ID(rate_ctrl_status)};	/**< rate controller status publication */
+	uORB::Publication<vehicle_thrust_setpoint_s>	_vehicle_thrust_setpoint_pub{ORB_ID(vehicle_thrust_setpoint)};		/**< vehicle_thrust_setpoint publication */
+	uORB::Publication<vehicle_torque_setpoint_s>	_vehicle_torque_setpoint_pub{ORB_ID(vehicle_torque_setpoint)};		/**< vehicle_torque_setpoint publication */
 
 	orb_id_t	_attitude_setpoint_id{nullptr};
 	orb_advert_t	_attitude_sp_pub{nullptr};	/**< attitude setpoint point */

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -653,6 +653,9 @@ void Logger::add_system_identification_topics()
 	add_topic("actuator_controls_0");
 	add_topic("actuator_controls_1");
 	add_topic("sensor_combined");
+	add_topic("vehicle_angular_acceleration");
+	add_topic("vehicle_angular_acceleration_setpoint");
+	add_topic("vehicle_torque_setpoint");
 }
 
 int Logger::add_topics_from_file(const char *fname)

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -309,10 +309,14 @@ MulticopterRateControl::Run()
 			_controller_status_pub.publish(rate_ctrl_status);
 
 			// publish controller output
-			publish_actuator_controls();
-			publish_angular_acceleration_setpoint();
-			publish_torque_setpoint();
-			publish_thrust_setpoint();
+			if (!_vehicle_status.is_vtol
+			    || (_vehicle_status.is_vtol && (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING))
+			    || (_vehicle_status.is_vtol && _vehicle_status.in_transition_mode)) {
+				publish_actuator_controls();
+				publish_angular_acceleration_setpoint();
+				publish_torque_setpoint();
+				publish_thrust_setpoint();
+			}
 
 		} else if (_v_control_mode.flag_control_termination_enabled) {
 			if (!_vehicle_status.is_vtol) {

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -54,11 +54,15 @@
 #include <uORB/topics/multirotor_motor_limits.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/rate_ctrl_status.h>
+#include <uORB/topics/vehicle_angular_acceleration_setpoint.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_thrust_setpoint.h>
+#include <uORB/topics/vehicle_torque_setpoint.h>
+
 
 class MulticopterRateControl : public ModuleBase<MulticopterRateControl>, public ModuleParams, public px4::WorkItem
 {
@@ -98,6 +102,11 @@ private:
 	 */
 	float		get_landing_gear_state();
 
+	void		publish_angular_acceleration_setpoint();
+	void		publish_torque_setpoint();
+	void		publish_thrust_setpoint();
+	void		publish_actuator_controls();
+
 	RateControl _rate_control; ///< class for rate control calculations
 
 	uORB::Subscription _v_rates_sp_sub{ORB_ID(vehicle_rates_setpoint)};		/**< vehicle rates setpoint subscription */
@@ -115,6 +124,9 @@ private:
 	uORB::PublicationMulti<rate_ctrl_status_s>	_controller_status_pub{ORB_ID(rate_ctrl_status), ORB_PRIO_DEFAULT};	/**< controller status publication */
 	uORB::Publication<landing_gear_s>		_landing_gear_pub{ORB_ID(landing_gear)};
 	uORB::Publication<vehicle_rates_setpoint_s>	_v_rates_sp_pub{ORB_ID(vehicle_rates_setpoint)};			/**< rate setpoint publication */
+	uORB::Publication<vehicle_angular_acceleration_setpoint_s> _vehicle_angular_acceleration_setpoint_pub{ORB_ID(vehicle_angular_acceleration_setpoint)};	/**< angular acceleration setpoint publication */
+	uORB::Publication<vehicle_thrust_setpoint_s>		   _vehicle_thrust_setpoint_pub{ORB_ID(vehicle_thrust_setpoint)};				/**< thrust setpoint publication */
+	uORB::Publication<vehicle_torque_setpoint_s>		   _vehicle_torque_setpoint_pub{ORB_ID(vehicle_torque_setpoint)};				/**< torque setpoint publication */
 
 	orb_advert_t	_actuators_0_pub{nullptr};		/**< attitude actuator controls publication */
 	orb_id_t _actuators_id{nullptr};	/**< pointer to correct actuator controls0 uORB metadata structure */
@@ -143,6 +155,7 @@ private:
 
 	hrt_abstime _task_start{hrt_absolute_time()};
 	hrt_abstime _last_run{0};
+	hrt_abstime _timestamp_sample{0};
 	float _dt_accumulator{0.0f};
 	int _loop_counter{0};
 
@@ -184,7 +197,14 @@ private:
 
 		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en,
 
-		(ParamInt<px4::params::CBRK_RATE_CTRL>) _param_cbrk_rate_ctrl
+		(ParamInt<px4::params::CBRK_RATE_CTRL>) _param_cbrk_rate_ctrl,
+
+		(ParamFloat<px4::params::VM_INERTIA_XX>) _param_vm_inertia_xx,			/**< vehicle inertia */
+		(ParamFloat<px4::params::VM_INERTIA_YY>) _param_vm_inertia_yy,
+		(ParamFloat<px4::params::VM_INERTIA_ZZ>) _param_vm_inertia_zz,
+		(ParamFloat<px4::params::VM_INERTIA_XY>) _param_vm_inertia_xy,
+		(ParamFloat<px4::params::VM_INERTIA_XZ>) _param_vm_inertia_xz,
+		(ParamFloat<px4::params::VM_INERTIA_YZ>) _param_vm_inertia_yz
 	)
 
 	matrix::Vector3f _acro_rate_max;	/**< max attitude rates in acro mode */

--- a/src/modules/mc_rate_control/RateControl/RateControl.cpp
+++ b/src/modules/mc_rate_control/RateControl/RateControl.cpp
@@ -66,7 +66,7 @@ void RateControl::setSaturationStatus(const MultirotorMixer::saturation_status &
 	_mixer_saturation_negative[2] = status.flags.yaw_neg;
 }
 
-Vector3f RateControl::update(const Vector3f &rate, const Vector3f &rate_sp, const float dt, const bool landed)
+void RateControl::update(const Vector3f &rate, const Vector3f &rate_sp, const float dt, const bool landed)
 {
 	// angular rates error
 	Vector3f rate_error = rate_sp - rate;
@@ -79,9 +79,28 @@ Vector3f RateControl::update(const Vector3f &rate, const Vector3f &rate_sp, cons
 		rate_d = (rate_filtered - _rate_prev_filtered) / dt;
 	}
 
-	// PID control with feed forward
-	const Vector3f torque = _gain_p.emult(rate_error) + _rate_int - _gain_d.emult(rate_d) + _gain_ff.emult(rate_sp);
+	// P + D control
+	_angular_accel_sp = _gain_p.emult(rate_error) - _gain_d.emult(rate_d);
 
+	// I + FF control
+	Vector3f torque_feedforward = _rate_int + _gain_ff.emult(rate_sp);
+
+	// compute torque setpoint
+	// Note: this may go into a separate module for general usage with FW and VTOLs
+	// if so, TODO:
+	// - [x] publish accel sp
+	// - [ ] publish torque ff sp
+	// - [ ] add dynamic model module
+	// - [ ] move params for inertia to that module
+	// - [ ] poll vehicle_angular_velocity & vehicle_angular_acceleration_setpoint & vehicle_torque_feedforward_setpoint => compute and publish vehicle_torque_setpoint
+	// - [ ] (eventually) add param for mass, poll vehicle_linear_acceleration_setpoint + vehicle_attitude => compute and publish vehicle_thrust_setpoint
+	_torque_sp = (
+			     _inertia * _angular_accel_sp
+			     + torque_feedforward
+			     + rate.cross(_inertia * rate)
+		     );
+
+	// save states
 	_rate_prev = rate;
 	_rate_prev_filtered = rate_filtered;
 
@@ -89,8 +108,6 @@ Vector3f RateControl::update(const Vector3f &rate, const Vector3f &rate_sp, cons
 	if (!landed) {
 		updateIntegral(rate_error, dt);
 	}
-
-	return torque;
 }
 
 void RateControl::updateIntegral(Vector3f &rate_error, const float dt)
@@ -123,6 +140,15 @@ void RateControl::updateIntegral(Vector3f &rate_error, const float dt)
 			_rate_int(i) = math::constrain(rate_i, -_lim_int(i), _lim_int(i));
 		}
 	}
+}
+
+void RateControl::reset()
+{
+	_rate_int.zero();
+	_rate_prev.zero();
+	_rate_prev_filtered.zero();
+	_torque_sp.zero();
+	_angular_accel_sp.zero();
 }
 
 void RateControl::getRateControlStatus(rate_ctrl_status_s &rate_ctrl_status)

--- a/src/modules/mc_rate_control/RateControl/RateControl.hpp
+++ b/src/modules/mc_rate_control/RateControl/RateControl.hpp
@@ -81,6 +81,13 @@ public:
 	void setFeedForwardGain(const matrix::Vector3f &FF) { _gain_ff = FF; };
 
 	/**
+	 * Set inertia matrix
+	 * @see _inertia
+	 * @param inertia inertia matrix
+	 */
+	void setInertiaMatrix(const matrix::Matrix3f &inertia) { _inertia = inertia; };
+
+	/**
 	 * Set saturation status
 	 * @param status message from mixer reporting about saturation
 	 */
@@ -91,16 +98,31 @@ public:
 	 * @param rate estimation of the current vehicle angular rate
 	 * @param rate_sp desired vehicle angular rate setpoint
 	 * @param dt desired vehicle angular rate setpoint
-	 * @return [-1,1] normalized torque vector to apply to the vehicle
 	 */
-	matrix::Vector3f update(const matrix::Vector3f &rate, const matrix::Vector3f &rate_sp, const float dt,
-				const bool landed);
+	void update(const matrix::Vector3f &rate, const matrix::Vector3f &rate_sp, const float dt, const bool landed);
+
+	/**
+	 * Get the desired angular acceleration
+	 * @see _angular_accel_sp
+	 */
+	const matrix::Vector3f &getAngularAccelerationSetpoint() {return _angular_accel_sp;};
+
+	/**
+	 * Get the torque vector to apply to the vehicle
+	 * @see _torque_sp
+	 */
+	const matrix::Vector3f &getTorqueSetpoint() {return _torque_sp;};
 
 	/**
 	 * Set the integral term to 0 to prevent windup
 	 * @see _rate_int
 	 */
 	void resetIntegral() { _rate_int.zero(); }
+
+	/**
+	 * ReSet the controller state
+	 */
+	void reset();
 
 	/**
 	 * Get status message of controller for logging/debugging
@@ -117,6 +139,7 @@ private:
 	matrix::Vector3f _gain_d; ///< rate control derivative gain
 	matrix::Vector3f _lim_int; ///< integrator term maximum absolute value
 	matrix::Vector3f _gain_ff; ///< direct rate to torque feed forward gain only useful for helicopters
+	matrix::Matrix3f _inertia{matrix::eye<float, 3>()}; ///< inertia matrix
 
 	// States
 	matrix::Vector3f _rate_prev; ///< angular rates of previous update
@@ -125,4 +148,8 @@ private:
 	math::LowPassFilter2pVector3f _lp_filters_d{0.f, 0.f}; ///< low-pass filters for D-term (roll, pitch & yaw)
 	bool _mixer_saturation_positive[3] {};
 	bool _mixer_saturation_negative[3] {};
+
+	// Output
+	matrix::Vector3f _angular_accel_sp; 	//< Angular acceleration setpoint computed using P and D gains
+	matrix::Vector3f _torque_sp;		//< Torque setpoint to apply to the vehicle
 };

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -412,4 +412,3 @@ PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
-

--- a/src/modules/mc_rate_control/vehicle_model_params.c
+++ b/src/modules/mc_rate_control/vehicle_model_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,15 +31,79 @@
  *
  ****************************************************************************/
 
-#include <gtest/gtest.h>
-#include <RateControl.hpp>
+/**
+ * @file vehicle_model_params.c
+ * Parameters for vehicle model.
+ *
+ * @author Julien Lecoeur <julien.lecoeur@gmail.com>
+ */
 
-using namespace matrix;
+/**
+ * Mass
+ *
+ * @unit kg
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_MASS, 1.f);
 
-TEST(RateControlTest, AllZeroCase)
-{
-	RateControl rate_control;
-	rate_control.update(Vector3f(), Vector3f(), 0.f, false);
-	Vector3f torque = rate_control.getTorqueSetpoint();
-	EXPECT_EQ(torque, Vector3f());
-}
+/**
+ * Inertia matrix, XX component
+ *
+ * @unit kg.m^2
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_INERTIA_XX, 1.f);
+
+/**
+ * Inertia matrix, YY component
+ *
+ * @unit kg.m^2
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_INERTIA_YY, 1.f);
+
+/**
+ * Inertia matrix, ZZ component
+ *
+ * @unit kg.m^2
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_INERTIA_ZZ, 1.f);
+
+/**
+ * Inertia matrix, XY component
+ *
+ * @unit kg.m^2
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_INERTIA_XY, 0.f);
+
+/**
+ * Inertia matrix, XZ component
+ *
+ * @unit kg.m^2
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_INERTIA_XZ, 0.f);
+
+/**
+ * Inertia matrix, YZ component
+ *
+ * @unit kg.m^2
+ * @decimal 5
+ * @increment 0.00001
+ * @group Vehicle Model
+ */
+PARAM_DEFINE_FLOAT(VM_INERTIA_YZ, 0.f);

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -65,6 +65,8 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 	parameter_handles.air_tube_length = param_find("CAL_AIR_TUBELEN");
 	parameter_handles.air_tube_diameter_mm = param_find("CAL_AIR_TUBED_MM");
 
+	parameter_handles.imu_dgyro_en = param_find("IMU_DGYRO_EN");
+
 	(void)param_find("BAT_V_DIV");
 	(void)param_find("BAT_A_PER_V");
 
@@ -112,6 +114,8 @@ void update_parameters(const ParameterHandles &parameter_handles, Parameters &pa
 	param_get(parameter_handles.air_cmodel, &parameters.air_cmodel);
 	param_get(parameter_handles.air_tube_length, &parameters.air_tube_length);
 	param_get(parameter_handles.air_tube_diameter_mm, &parameters.air_tube_diameter_mm);
+
+	param_get(parameter_handles.imu_dgyro_en, &parameters.imu_dgyro_en);
 }
 
 } /* namespace sensors */

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -61,6 +61,8 @@ struct Parameters {
 	int32_t air_cmodel;
 	float air_tube_length;
 	float air_tube_diameter_mm;
+
+	int32_t imu_dgyro_en;
 };
 
 struct ParameterHandles {
@@ -79,6 +81,7 @@ struct ParameterHandles {
 	param_t air_tube_length;
 	param_t air_tube_diameter_mm;
 
+	param_t imu_dgyro_en;
 };
 
 /**

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -228,6 +228,31 @@ PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
 
 /**
+* Enable computation of angular acceleration by gyro differentiation.
+*
+* @reboot_required true
+*
+* @boolean
+* @group Sensors
+*/
+PARAM_DEFINE_INT32(IMU_DGYRO_EN, 1);
+
+/**
+* Cutoff frequency for angular acceleration
+*
+* The cutoff frequency for the 2nd order butterworth filter used on
+* the time derivative of the measured angular velocity.
+* Set to 0 to disable the filter.
+*
+* @min 0
+* @max 1000
+* @unit Hz
+* @reboot_required true
+* @group Sensors
+*/
+PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 10.0f);
+
+/**
 * Gyro control data maximum publication rate
 *
 * This is the maximum rate the gyro control data (sensor_gyro_control) will be allowed to publish at.

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -75,6 +75,7 @@
 
 #include "vehicle_acceleration/VehicleAcceleration.hpp"
 #include "vehicle_angular_velocity/VehicleAngularVelocity.hpp"
+#include "vehicle_angular_acceleration/VehicleAngularAcceleration.hpp"
 
 using namespace DriverFramework;
 using namespace sensors;
@@ -143,8 +144,9 @@ private:
 	VotedSensorsUpdate _voted_sensors_update;
 
 
-	VehicleAcceleration	_vehicle_acceleration;
-	VehicleAngularVelocity	_vehicle_angular_velocity;
+	VehicleAcceleration		_vehicle_acceleration;
+	VehicleAngularVelocity		_vehicle_angular_velocity;
+	VehicleAngularAcceleration	_vehicle_angular_acceleration;
 
 
 	/**
@@ -187,18 +189,24 @@ Sensors::Sensors(bool hil_enabled) :
 	_voted_sensors_update(_parameters, hil_enabled)
 {
 	initialize_parameter_handles(_parameter_handles);
+	parameters_update();
 
 	_airspeed_validator.set_timeout(300000);
 	_airspeed_validator.set_equal_value_threshold(100);
 
 	_vehicle_acceleration.Start();
 	_vehicle_angular_velocity.Start();
+
+	if (_parameters.imu_dgyro_en) {
+		_vehicle_angular_acceleration.Start();
+	}
 }
 
 Sensors::~Sensors()
 {
 	_vehicle_acceleration.Stop();
 	_vehicle_angular_velocity.Stop();
+	_vehicle_angular_acceleration.Stop();
 }
 
 int
@@ -532,6 +540,7 @@ int Sensors::print_status()
 
 	_vehicle_acceleration.PrintStatus();
 	_vehicle_angular_velocity.PrintStatus();
+	_vehicle_angular_acceleration.PrintStatus();
 
 	return 0;
 }

--- a/src/modules/sensors/vehicle_angular_acceleration/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_angular_acceleration/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015-2019 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,28 +31,7 @@
 #
 ############################################################################
 
-add_subdirectory(vehicle_acceleration)
-add_subdirectory(vehicle_angular_velocity)
-add_subdirectory(vehicle_angular_acceleration)
-
-px4_add_module(
-	MODULE modules__sensors
-	MAIN sensors
-	PRIORITY "SCHED_PRIORITY_MAX-5"
-	SRCS
-		voted_sensors_update.cpp
-		sensors.cpp
-		parameters.cpp
-		temperature_compensation.cpp
-
-	DEPENDS
-		airspeed
-		conversion
-		drivers__device
-		git_ecl
-		ecl_validation
-		mathlib
-		vehicle_acceleration
-		vehicle_angular_velocity
-		vehicle_angular_acceleration
-	)
+px4_add_library(vehicle_angular_acceleration
+	VehicleAngularAcceleration.cpp
+)
+target_link_libraries(vehicle_angular_acceleration PRIVATE px4_work_queue)

--- a/src/modules/sensors/vehicle_angular_acceleration/VehicleAngularAcceleration.cpp
+++ b/src/modules/sensors/vehicle_angular_acceleration/VehicleAngularAcceleration.cpp
@@ -1,0 +1,156 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "VehicleAngularAcceleration.hpp"
+
+#include <px4_log.h>
+
+using namespace matrix;
+using namespace time_literals;
+
+VehicleAngularAcceleration::VehicleAngularAcceleration() :
+	ModuleParams(nullptr),
+	WorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
+	_cycle_perf(perf_alloc(PC_ELAPSED, "vehicle_angular_acceleration: cycle time")),
+	_sensor_latency_perf(perf_alloc(PC_ELAPSED, "vehicle_angular_acceleration: sensor latency"))
+{
+}
+
+VehicleAngularAcceleration::~VehicleAngularAcceleration()
+{
+	Stop();
+
+	perf_free(_cycle_perf);
+	perf_free(_sensor_latency_perf);
+}
+
+bool
+VehicleAngularAcceleration::Start()
+{
+	_angular_velocity_prev.zero();
+
+	// force initial updates
+	ParametersUpdate(true);
+
+	// Register callbacks
+	_vehicle_angular_velocity_sub.registerCallback();
+
+	return true;
+}
+
+void
+VehicleAngularAcceleration::Stop()
+{
+	Deinit();
+
+	// clear all registered callbacks
+	_vehicle_angular_velocity_sub.unregisterCallback();
+}
+
+void
+VehicleAngularAcceleration::ParametersUpdate(bool force)
+{
+	// Check if parameters have changed
+	if (_params_sub.updated() || force) {
+		// clear update
+		parameter_update_s param_update;
+		_params_sub.copy(&param_update);
+
+		updateParams();
+
+		// Low pass filter
+		if (fabsf(_lp_filter.get_cutoff_freq() - _param_imu_dgyro_cutoff.get()) > 0.01f) {
+			_lp_filter.set_cutoff_frequency(_loop_update_rate_hz, _param_imu_dgyro_cutoff.get());
+			_lp_filter.reset(_angular_velocity_prev);
+		}
+	}
+}
+
+void
+VehicleAngularAcceleration::Run()
+{
+	perf_begin(_cycle_perf);
+
+	vehicle_angular_velocity_s v_angular_velocity;
+
+	if (_vehicle_angular_velocity_sub.update(&v_angular_velocity)) {
+		perf_set_elapsed(_sensor_latency_perf, hrt_elapsed_time(&v_angular_velocity.timestamp));
+
+		ParametersUpdate();
+
+		// Guard against too small (< 0.2ms) and too large (> 20ms) dt's.
+		const float dt = math::constrain(((v_angular_velocity.timestamp_sample - _timestamp_sample_prev) / 1e6f), 0.0002f,
+						 0.02f);
+		_timestamp_sample_prev = v_angular_velocity.timestamp_sample;
+
+		// Differentiate angular velocity
+		Vector3f angular_velocity(v_angular_velocity.xyz);
+		Vector3f angular_acceleration_raw = (angular_velocity - _angular_velocity_prev) / dt;
+		_angular_velocity_prev = angular_velocity;
+
+		// Apply low pass filter
+		Vector3f angular_acceleration(_lp_filter.apply(angular_acceleration_raw));
+
+		// Publish
+		vehicle_angular_acceleration_s v_angular_acceleration;
+		v_angular_acceleration.timestamp = hrt_absolute_time();
+		v_angular_acceleration.timestamp_sample = v_angular_velocity.timestamp_sample;
+		angular_acceleration.copyTo(v_angular_acceleration.xyz);
+
+		_vehicle_angular_acceleration_pub.publish(v_angular_acceleration);
+
+		// Calculate loop rate
+		_dt_accumulator += dt;
+		++_loop_counter;
+
+		if (_dt_accumulator > 1.f) {
+			const float loop_update_rate = (float)_loop_counter / _dt_accumulator;
+			_loop_update_rate_hz = _loop_update_rate_hz * 0.5f + loop_update_rate * 0.5f;
+			_dt_accumulator = 0;
+			_loop_counter = 0;
+
+			if (fabsf(_lp_filter.get_sample_freq() - _loop_update_rate_hz) > 1.0f) {
+				_lp_filter.set_cutoff_frequency(_loop_update_rate_hz, _param_imu_dgyro_cutoff.get());
+			}
+		}
+	}
+
+	perf_end(_cycle_perf);
+}
+
+void
+VehicleAngularAcceleration::PrintStatus()
+{
+	perf_print_counter(_cycle_perf);
+	perf_print_counter(_sensor_latency_perf);
+}

--- a/src/modules/sensors/vehicle_angular_acceleration/VehicleAngularAcceleration.hpp
+++ b/src/modules/sensors/vehicle_angular_acceleration/VehicleAngularAcceleration.hpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <lib/mathlib/math/Limits.hpp>
+#include <mathlib/math/filter/LowPassFilter2pVector3f.hpp>
+#include <lib/matrix/matrix/math.hpp>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/WorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/parameter_update.h>
+
+#include <uORB/topics/vehicle_angular_velocity.h>
+#include <uORB/topics/vehicle_angular_acceleration.h>
+
+class VehicleAngularAcceleration : public ModuleParams, public px4::WorkItem
+{
+public:
+
+	VehicleAngularAcceleration();
+	virtual ~VehicleAngularAcceleration();
+
+	void	Run() override;
+
+	bool	Start();
+	void	Stop();
+
+	void	PrintStatus();
+
+private:
+
+	void	ParametersUpdate(bool force = false);
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::IMU_DGYRO_CUTOFF>) _param_imu_dgyro_cutoff
+	)
+
+	uORB::Publication<vehicle_angular_acceleration_s> _vehicle_angular_acceleration_pub{ORB_ID(vehicle_angular_acceleration)};
+
+	uORB::SubscriptionCallbackWorkItem 	_vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};	/**< angular velocity subscription */
+	uORB::Subscription			_params_sub{ORB_ID(parameter_update)};					/**< parameter updates subscription */
+
+	math::LowPassFilter2pVector3f _lp_filter{initial_update_rate_hz, 10.f};	/**< low-pass filter for angular acceleration */
+	static constexpr const float initial_update_rate_hz = 1000.f; 		/**< loop update rate used for initialization */
+	float _loop_update_rate_hz{initial_update_rate_hz};           		/**< current rate-controller loop update rate in [Hz] */
+
+	matrix::Vector3f			_angular_velocity_prev;
+
+	hrt_abstime _timestamp_sample_prev{0};
+	float _dt_accumulator{0.0f};
+	int _loop_counter{0};
+
+	perf_counter_t				_cycle_perf;
+	perf_counter_t				_sensor_latency_perf;
+};


### PR DESCRIPTION
This is a first step towards more unit-aware controllers. 

As of now, the output of the rate controller does not have unit (this is a normalized torque setpoint). Although this makes things simple and has always worked like it, this has a few limitations:
- This will limit the use of actual vehicle properties in a (future) control allocation scheme.
- There were a few requests for the possibility to provide torque setpoints in N.m.
- Not having a model of the vehicle inertia may be problematic for applications where inertia changes over time (with fuel consumption, package delivery, etc).
- Model-based control is difficult because of the lack of units.

I introduced several new things in this PR.  I would like to hear your opinion on a few additions. (Note that with the default parameters, it should not break anything.)
- computation of vehicle_angular_acceleration (in rad/s^2) and publication on a dedicated uORB topic. 
@dagar I did this in the sensor module although it is not a real sensor because I think this can be useful for more things than the MC controller, it is disabled by default.
@MaEtUgR we may use this data for the D term in the rate controller instead of computing the derivative inside the controller. This may save some computation in VTOLs because both the MC and the FW controller compute rate derivatives.
- addition of `vehicle_angular_acceleration_setpoint`, `vehicle_thrust_setpoint`, `vehicle_torque_setpoint` topics, with proper units.
- the inertia matrix is included in the controller module. 
Eventually this could be moved into a separate module. Either MC or FW or VTOL controller would publish an angular acceleration setpoint and a feedforward torque setpoint. The new module would subscribe to these topics and then compute a torque setpoint based on its model of the vehicle.
- split of the PD terms and I-FF terms (see the changes in RateControl.cpp).
I use the P and D term to generate an angular acceleration setpoint, which is later mapped to torque via the inertia matrix. The integral and feed-forward terms are directly generating torque values (called torque_feedforward).
If the I term was used to generate acceleration setpoints, you would have -- for an unbalanced system in equilibrium -- a steady-state angular acceleration setpoint, which does not make sense.

From there, I multiplied the P and D rate gains by 120 (roll), 120 (pitch) and 35 (yaw), and divided the inertia by the same amount. 
This way the behaviour is not changed, but units are now OK (see on the graphs below how the angular acceleration somewhat matches the angular acceleration setpoint). I obtain this during steps on roll, pitch and yaw:
![roll_step](https://user-images.githubusercontent.com/1379463/67569575-88abe100-f72f-11e9-9cc9-03de32a2829c.png)
![pitch_step](https://user-images.githubusercontent.com/1379463/67569581-8a75a480-f72f-11e9-8e69-9ae5c00ec7da.png)
![yaw_step](https://user-images.githubusercontent.com/1379463/67569588-8cd7fe80-f72f-11e9-9289-85746e3a449a.png)

The values of 120 and 35 were not chosen arbitrarily, we can in fact estimate them.
From a gazebo log, we can compute the time derivative of the vehicle angular acceleration and of the torque setpoint:
![sysID](https://user-images.githubusercontent.com/1379463/67569601-95303980-f72f-11e9-84ba-61b44918e146.png)
A quick eye fit gave me the inertia matrix
```
I = [1/120      0        0   ]
    [  0      1/120      0   ]
    [  0        0      1/35  ]
```

Let me know your opinion, shoot!