### PR TITLE
[WIP] Collision Prevention in AUTO Modes

### DIFF
--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -289,6 +289,7 @@ CollisionPrevention::_adaptSetpointDirection(Vector2f &setpoint_dir, int &setpoi
 	const int guidance_bins = floor(_param_cp_guide_ang.get() / INTERNAL_MAP_INCREMENT_DEG);
 	const int sp_index_original = setpoint_index;
 	float best_cost = 9999.f;
+	int new_sp_index = setpoint_index;
 
 	for (int i = sp_index_original - guidance_bins; i <= sp_index_original + guidance_bins; i++) {
 
@@ -314,12 +315,16 @@ CollisionPrevention::_adaptSetpointDirection(Vector2f &setpoint_dir, int &setpoi
 
 		if (bin_cost < best_cost && _obstacle_map_body_frame.distances[bin] != UINT16_MAX) {
 			best_cost = bin_cost;
-
-			float angle = math::radians((float)bin * INTERNAL_MAP_INCREMENT_DEG + _obstacle_map_body_frame.angle_offset);
-			angle = wrap_2pi(vehicle_yaw_angle_rad + angle);
-			setpoint_dir = {cosf(angle), sinf(angle)};
-			setpoint_index = bin;
+			new_sp_index = bin;
 		}
+	}
+
+	//only change setpoint direction if it was moved to a different bin
+	if (new_sp_index != setpoint_index) {
+		float angle = math::radians((float)new_sp_index * INTERNAL_MAP_INCREMENT_DEG + _obstacle_map_body_frame.angle_offset);
+		angle = wrap_2pi(vehicle_yaw_angle_rad + angle);
+		setpoint_dir = {cosf(angle), sinf(angle)};
+		setpoint_index = new_sp_index;
 	}
 }
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -43,7 +43,7 @@ using namespace matrix;
 static constexpr float SIGMA_NORM	= 0.001f;
 
 FlightTaskAuto::FlightTaskAuto() :
-	_obstacle_avoidance(this)
+	_collision_prevention(this), _obstacle_avoidance(this)
 {
 
 }

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -87,7 +87,7 @@ public:
 	 */
 	void setYawHandler(WeatherVane *ext_yaw_handler) override {_ext_yaw_handler = ext_yaw_handler;}
 
-	CollisionPrevention _collision_prevention;	/**< collision avoidance setpoint amendment */
+	CollisionPrevention _collision_prevention;
 
 protected:
 	void _setDefaultConstraints() override;

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -47,6 +47,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <lib/ecl/geo/geo.h>
 #include <ObstacleAvoidance.hpp>
+#include <CollisionPrevention/CollisionPrevention.hpp>
 
 /**
  * This enum has to agree with position_setpoint_s type definition
@@ -85,6 +86,8 @@ public:
 	 * Sets an external yaw handler which can be used to implement a different yaw control strategy.
 	 */
 	void setYawHandler(WeatherVane *ext_yaw_handler) override {_ext_yaw_handler = ext_yaw_handler;}
+
+	CollisionPrevention _collision_prevention;	/**< collision avoidance setpoint amendment */
 
 protected:
 	void _setDefaultConstraints() override;

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -94,6 +94,7 @@ protected:
 	matrix::Vector2f _getTargetVelocityXY(); /**< only used for follow-me and only here because of legacy reason.*/
 	void _updateInternalWaypoints(); /**< Depending on state of vehicle, the internal waypoints might differ from target (for instance if offtrack). */
 	bool _compute_heading_from_2D_vector(float &heading, matrix::Vector2f v); /**< Computes and sets heading a 2D vector */
+	void _collision_prevention_limit_setpoint(); /**< Limits the final velocity setpoint respecting collision prevention constraints */
 
 	matrix::Vector3f _prev_prev_wp{}; /**< Pre-previous waypoint (local frame). This will be used for smoothing trajectories -> not used yet. */
 	matrix::Vector3f _prev_wp{}; /**< Previous waypoint  (local frame). If no previous triplet is available, the prev_wp is set to current position. */

--- a/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp
@@ -51,44 +51,6 @@ void FlightTaskAutoLine::_generateSetpoints()
 
 	_generateAltitudeSetpoints();
 	_generateXYsetpoints();
-
-	// COLLISION PREVENTION
-	if (_collision_prevention.is_active()) {
-
-		Vector2f vel_sp_original = Vector2f(_velocity_setpoint);
-		Vector2f vel_sp_modified = vel_sp_original;
-		// use the minimum of the estimator and user specified limit
-		float velocity_scale = fminf(_constraints.speed_xy, _sub_vehicle_local_position.get().vxy_max);
-		// Allow for a minimum of 0.3 m/s for repositioning
-		velocity_scale = fmaxf(velocity_scale, 0.3f);
-
-		_collision_prevention.modifySetpoint(vel_sp_modified, velocity_scale, Vector2f(_position),
-						     Vector2f(_velocity));
-
-		// switch to hold if the collision prevention limits the setpoint to zero
-		if (vel_sp_modified.norm() < 0.01f && vel_sp_original.norm() > 0.01f) {
-			_request_position_lock = true;
-		}
-
-		_velocity_setpoint(0) = vel_sp_modified(0);
-		_velocity_setpoint(1) = vel_sp_modified(1);
-	}
-
-
-	//Position Lock
-	if ((_param_mpc_yaw_mode.get() == 4 && !_yaw_sp_aligned) || _request_position_lock) {
-		// Wait for the yaw setpoint to be aligned
-		if (!_position_locked) {
-			_velocity_setpoint.setAll(0.f);
-			_position_setpoint = _position;
-			_position_locked = true;
-		}
-
-		_request_position_lock = false;
-
-	} else {
-		_position_locked = false;
-	}
 }
 
 void FlightTaskAutoLine::_setSpeedAtTarget()

--- a/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.hpp
@@ -66,4 +66,5 @@ private:
 	void _setSpeedAtTarget(); /**< Sets desiered speed at target */
 	float _speed_at_target{0.0f};
 	bool _position_locked{false};
+	bool _request_position_lock{false};
 };

--- a/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.hpp
@@ -65,6 +65,4 @@ protected:
 private:
 	void _setSpeedAtTarget(); /**< Sets desiered speed at target */
 	float _speed_at_target{0.0f};
-	bool _position_locked{false};
-	bool _request_position_lock{false};
 };

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -94,31 +94,17 @@ bool FlightTaskAutoMapper::update()
 
 	// COLLISION PREVENTION
 	if (_collision_prevention.is_active() && follow_line) {
-
-		//from position to velocity setpoints
-		if (!PX4_ISFINITE(_velocity_setpoint(0)) || !PX4_ISFINITE(_velocity_setpoint(1))) {
-			_velocity_setpoint = _position_setpoint - _position;
-		}
-
 		Vector2f vel_sp_original = Vector2f(_velocity_setpoint);
-		Vector2f vel_sp_modified = vel_sp_original;
-		// use the minimum of the estimator and user specified limit
-		float velocity_scale = fminf(_constraints.speed_xy, _sub_vehicle_local_position.get().vxy_max);
-		// Allow for a minimum of 0.3 m/s for repositioning
-		velocity_scale = fmaxf(velocity_scale, 0.3f);
 
-		_collision_prevention.modifySetpoint(vel_sp_modified, velocity_scale, Vector2f(_position),
-						     Vector2f(_velocity));
+		_collision_prevention_limit_setpoint();
 
-		// switch to hold if the collision prevention limits the setpoint to zero
+		//update the position lock
+		Vector2f vel_sp_modified = Vector2f(_velocity_setpoint);
+
 		if (vel_sp_modified.norm() < 0.01f && vel_sp_original.norm() > 0.01f) {
 			_request_position_lock = true;
 		}
 
-		_velocity_setpoint(0) = vel_sp_modified(0);
-		_velocity_setpoint(1) = vel_sp_modified(1);
-		_position_setpoint(0) = NAN;
-		_position_setpoint(1) = NAN;
 		_compute_heading_from_2D_vector(_yaw_setpoint, Vector2f(_velocity_setpoint));
 		_checkPositionLock();
 	}

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
@@ -77,6 +77,10 @@ protected:
 private:
 
 	void _reset(); /**< Resets member variables to current vehicle state */
+	void _checkPositionLock(); /**< check whether position should be locked */
 	WaypointType _type_previous{WaypointType::idle}; /**< Previous type of current target triplet. */
 	bool _highEnoughForLandingGear(); /**< Checks if gears can be lowered. */
+	bool _position_locked{false};
+	bool _request_position_lock{false};
+	matrix::Vector3f _locked_position; /**< position at which vehicle is locked */
 };

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -100,6 +100,14 @@ bool FlightTaskAutoMapper2::update()
 
 	_generateSetpoints();
 
+	// COLLISION PREVENTION
+	bool follow_line = _type == WaypointType::loiter || _type == WaypointType::position;
+
+	if (_collision_prevention.is_active() && follow_line) {
+		_collision_prevention_limit_setpoint();
+	}
+
+
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -76,5 +76,5 @@ private:
 	WeatherVane *_weathervane_yaw_handler =
 		nullptr;	/**< external weathervane library, used to implement a yaw control law that turns the vehicle nose into the wind */
 
-	CollisionPrevention _collision_prevention;	/**< collision avoidance setpoint amendment */
+	CollisionPrevention _collision_prevention;
 };


### PR DESCRIPTION
This is a first draft for enabling collision prevention for missions. It is working for MPC_AUTO_MODE=`default_line_tracking` right now, and I would have to replicate it with slight changes to work also for `jerk-limited trajectories`. I'm still working on the dynamics to get a smooth stopping behavior and nice transitions to and from position lock. It is SITL tested but not yet flight tested.
