### PR TITLE
Fix inaccurate velocity set-point transformation in FlightTaskOffboard

### DIFF
--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -174,7 +174,7 @@ bool FlightTaskOffboard::update()
 	//When velocity setpoint is given in Body-coordinate, transform it to Local(NED) coordinate.
 	Vector3f vel_setpoint_local;
 	if((_sub_triplet_setpoint.get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED) && (velocity_ctrl_xy || velocity_ctrl_z)) {
-		const matrix::Dcmf R_to_local(matrix::Quatf(_sub_attitude.get().q))
+		const matrix::Dcmf R_to_local(matrix::Quatf(_sub_attitude.get().q));
 		const Vector3f vel_valid_setpoints = Vector3f(velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vx) : 0.0f, velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vy) : 0.0f, velocity_ctrl_z ? (_sub_triplet_setpoint.get().current.vy) : 0.0f);
 		vel_setpoint_local = R_to_local * vel_valid_setpoints;
 	}

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -174,11 +174,11 @@ bool FlightTaskOffboard::update()
 	//When velocity setpoint is given in Body-coordinate, transform it to Local(NED) coordinate.
 	Vector3f vel_setpoint_local;
 	if((_sub_triplet_setpoint.get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED)
-		 && (velocity_ctrl_xy || velocity_ctrl_z)) {
+	    && (velocity_ctrl_xy || velocity_ctrl_z)) {
 		const matrix::Dcmf R_to_local(matrix::Quatf(_sub_attitude.get().q));
 		const Vector3f vel_valid_setpoints = Vector3f(velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vx) : 0.0f,
-			 velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vy) : 0.0f,
-			 velocity_ctrl_z ? (_sub_triplet_setpoint.get().current.vz) : 0.0f);
+						     velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vy) : 0.0f,
+						     velocity_ctrl_z ? (_sub_triplet_setpoint.get().current.vz) : 0.0f);
 		vel_setpoint_local = R_to_local * vel_valid_setpoints;
 	}
 

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -173,9 +173,12 @@ bool FlightTaskOffboard::update()
 
 	//When velocity setpoint is given in Body-coordinate, transform it to Local(NED) coordinate.
 	Vector3f vel_setpoint_local;
-	if((_sub_triplet_setpoint.get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED) && (velocity_ctrl_xy || velocity_ctrl_z)) {
+	if((_sub_triplet_setpoint.get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED)
+		 && (velocity_ctrl_xy || velocity_ctrl_z)) {
 		const matrix::Dcmf R_to_local(matrix::Quatf(_sub_attitude.get().q));
-		const Vector3f vel_valid_setpoints = Vector3f(velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vx) : 0.0f, velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vy) : 0.0f, velocity_ctrl_z ? (_sub_triplet_setpoint.get().current.vy) : 0.0f);
+		const Vector3f vel_valid_setpoints = Vector3f(velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vx) : 0.0f,
+			 velocity_ctrl_xy ? (_sub_triplet_setpoint.get().current.vy) : 0.0f,
+			 velocity_ctrl_z ? (_sub_triplet_setpoint.get().current.vz) : 0.0f);
 		vel_setpoint_local = R_to_local * vel_valid_setpoints;
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previous code '**assumed**' that the craft is parallel to the ground(pitch / roll = 0), when transforming velocity set-point from body-frame to local-frame(NED) for **Offboard velocity setpoint control in Body-Frame**. Thus, in most cases, if this was used, previously, velocity set-point was over-calculated(because of neglecting pitch / roll).

**Describe your solution**
By taking into account the craft's 'attitude', Rotation matrix will transform the Velocity set-point, if it is needed, i.e. `if(_sub_triplet_setpoint.get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED) && (velocity_ctrl_xy || velocity_ctrl_z)`

**Describe possible alternatives**
This is a pretty simple logic issue. So I guess there is no 'alternative'?

**Test data / coverage**
Not tested :(.

**Additional context**
- origin of discussion : #13363 comment section.

- I thought about the best way to implement this, as this calculation isn't always needed, so I finally settled on creating a local variable `vel_setpoint_local`, and perform the calculation only if the setpoint frame is `VELOCITY_FRAME_BODY_NED`. Also, because the velocity setpoints can be 'invalid', I also took that into account, basically Zero-ing the values(Velocity), if it's not valid.

**Any inputs / feedbacks are welcome!** I'm a newbie in PX4, so I definitely want to learn from more experienced developers :)