### PR TITLE
fmu v4: add option to run DShot telemetry on WIFI uart

### DIFF
--- a/Tools/serial/generate_config.py
+++ b/Tools/serial/generate_config.py
@@ -115,6 +115,14 @@ serial_ports = {
         "default_baudrate": 0,
         },
 
+    # WIFI Port (PixRacer)
+    "WIFI": {
+        "label": "Wifi Port",
+        "index": 301,
+        "default_baudrate": 1, # set default to an unusable value to detect that this serial port has not been configured
+        },
+
+
     }
 
 parser = argparse.ArgumentParser(description='Generate Serial params & startup script')

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -13,6 +13,8 @@ px4_add_board(
 		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
+		WIFI:/dev/ttyS0
+
 	DRIVERS
 		adc
 		barometer # all available barometer drivers

--- a/boards/px4/fmu-v4/init/rc.board_defaults
+++ b/boards/px4/fmu-v4/init/rc.board_defaults
@@ -9,6 +9,25 @@ then
 	# Disable safety switch by default
 	param set CBRK_IO_SAFETY 22027
 
+	# start MAVLink on Wifi (ESP8266 port). Except for the TealOne airframe.
+	if ! param compare SYS_AUTOSTART 4250
+	then
+		param set MAV_2_CONFIG 301
+		param set MAV_2_RATE 20000
+		param set SER_WIFI_BAUD 921600
+	fi
+fi
+
+if param compare SER_WIFI_BAUD 1
+then
+	# Transitional support: The Wifi port has not been configured by the user,
+	# configure it for MAVLink via the ESP8266 Wifi module. Except for the TealOne airframe.
+	if ! param compare SYS_AUTOSTART 4250
+	then
+		param set MAV_2_CONFIG 301
+		param set MAV_2_RATE 20000
+		param set SER_WIFI_BAUD 921600
+	fi
 fi
 
 safety_button start

--- a/boards/px4/fmu-v4/init/rc.board_mavlink
+++ b/boards/px4/fmu-v4/init/rc.board_mavlink
@@ -6,8 +6,3 @@
 # Start MAVLink on the USB port
 mavlink start -d /dev/ttyACM0
 
-# Pixracer: start MAVLink on Wifi (ESP8266 port). Except for the TealOne airframe.
-if ! param compare SYS_AUTOSTART 4250
-then
-	mavlink start -r 20000 -b 921600 -d /dev/ttyS0
-fi


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, dshot telemetry can only be used on TELEM1, TELEM2, or GPS1 on a PixRacer.
This adds the option of putting it on the UART that usually runs the mavlink instance for the ESP WIFI module.

**Additional context**
The parameter description for [DSHOT_TEL_CFG](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#DSHOT_TEL_CFG) implies that 8 different outputs can be selected. This is not true for a PixRacer. Either all of them should be added to the v4 config or the parameter description should indicate which are available for which board.

Open points:

- [x] Add the remaining ports that are available for v4.
- [x] Ensure the mavlink instance on `/dev/ttyS0` is not run when dshot telmetry is configured for that port.