### PR TITLE
[RFC] system acceleration cleanup

### DIFF
--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -31,10 +31,6 @@ uint8 vxy_reset_counter
 
 float32 delta_vz
 uint8 vz_reset_counter
-# Acceleration in NED frame
-float32 ax        # North velocity derivative in NED earth-fixed frame, (metres/sec^2)
-float32 ay        # East velocity derivative in NED earth-fixed frame, (metres/sec^2)
-float32 az        # Down velocity derivative in NED earth-fixed frame, (metres/sec^2)
 
 # Heading
 float32 yaw				# Euler yaw angle transforming the tangent plane relative to NED earth-fixed frame, -PI..+PI,  (radians)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1280,13 +1280,6 @@ void Ekf2::Run()
 				// vertical position time derivative (m/s)
 				_ekf.get_pos_d_deriv(&lpos.z_deriv);
 
-				// Acceleration of body origin in local NED frame
-				float vel_deriv[3];
-				_ekf.get_vel_deriv_ned(vel_deriv);
-				lpos.ax = vel_deriv[0];
-				lpos.ay = vel_deriv[1];
-				lpos.az = vel_deriv[2];
-
 				// TODO: better status reporting
 				lpos.xy_valid = _ekf.local_position_is_valid() && !_preflt_checker.hasHorizFailed();
 				lpos.z_valid = !_preflt_checker.hasVertFailed();

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -88,7 +88,6 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	_parameter_handles.throttle_damp = param_find("FW_T_THR_DAMP");
 	_parameter_handles.integrator_gain = param_find("FW_T_INTEG_GAIN");
 	_parameter_handles.vertical_accel_limit = param_find("FW_T_VERT_ACC");
-	_parameter_handles.height_comp_filter_omega = param_find("FW_T_HGT_OMEGA");
 	_parameter_handles.speed_comp_filter_omega = param_find("FW_T_SPD_OMEGA");
 	_parameter_handles.roll_throttle_compensation = param_find("FW_T_RLL2THR");
 	_parameter_handles.speed_weight = param_find("FW_T_SPDWEIGHT");
@@ -238,10 +237,6 @@ FixedwingPositionControl::parameters_update()
 
 	if (param_get(_parameter_handles.vertical_accel_limit, &v) == PX4_OK) {
 		_tecs.set_vertical_accel_limit(v);
-	}
-
-	if (param_get(_parameter_handles.height_comp_filter_omega, &v) == PX4_OK) {
-		_tecs.set_height_comp_filter_omega(v);
 	}
 
 	if (param_get(_parameter_handles.speed_comp_filter_omega, &v) == PX4_OK) {
@@ -1914,7 +1909,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float airspee
 	/* update TECS vehicle state estimates */
 	_tecs.update_vehicle_state_estimates(_airspeed, _R_nb,
 					     accel_body, (_global_pos.timestamp > 0), in_air_alt_control,
-					     _global_pos.alt, _local_pos.v_z_valid, _local_pos.vz, _local_pos.az);
+					     _global_pos.alt, _local_pos.vz);
 
 	/* scale throttle cruise by baro pressure */
 	if (_parameters.throttle_alt_scale > FLT_EPSILON) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -163,6 +163,8 @@ private:
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};		///< vehicle command subscription */
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};	///< vehicle land detected subscription */
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};			///< vehicle status subscription */
+	uORB::SubscriptionData<airspeed_s>			_airspeed_sub{ORB_ID(airspeed)};
+	uORB::SubscriptionData<vehicle_acceleration_s>		_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 	uORB::SubscriptionData<vehicle_angular_velocity_s>	_vehicle_rates_sub{ORB_ID(vehicle_angular_velocity)};
 
 	orb_advert_t	_attitude_sp_pub{nullptr};		///< attitude setpoint */
@@ -182,9 +184,6 @@ private:
 	vehicle_local_position_s	_local_pos {};			///< vehicle local position */
 	vehicle_land_detected_s		_vehicle_land_detected {};	///< vehicle land detected */
 	vehicle_status_s		_vehicle_status {};		///< vehicle status */
-
-	SubscriptionData<airspeed_s>			_airspeed_sub{ORB_ID(airspeed)};
-	SubscriptionData<vehicle_acceleration_s>	_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 
 	perf_counter_t	_loop_perf;				///< loop performance counter */
 
@@ -329,7 +328,6 @@ private:
 		param_t throttle_damp;
 		param_t integrator_gain;
 		param_t vertical_accel_limit;
-		param_t height_comp_filter_omega;
 		param_t speed_comp_filter_omega;
 		param_t roll_throttle_compensation;
 		param_t speed_weight;

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -602,24 +602,6 @@ PARAM_DEFINE_FLOAT(FW_T_INTEG_GAIN, 0.1f);
 PARAM_DEFINE_FLOAT(FW_T_VERT_ACC, 7.0f);
 
 /**
- * Complementary filter "omega" parameter for height
- *
- * This is the cross-over frequency (in radians/second) of the complementary
- * filter used to fuse vertical acceleration and barometric height to obtain
- * an estimate of height rate and height. Increasing this frequency weights
- * the solution more towards use of the barometer, whilst reducing it weights
- * the solution more towards use of the accelerometer data.
- *
- * @unit rad/s
- * @min 1.0
- * @max 10.0
- * @decimal 1
- * @increment 0.5
- * @group FW TECS
- */
-PARAM_DEFINE_FLOAT(FW_T_HGT_OMEGA, 3.0f);
-
-/**
  * Complementary filter "omega" parameter for speed
  *
  * This is the cross-over frequency (in radians/second) of the complementary

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -603,10 +603,6 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
 		_pub_lpos.get().z_deriv = xLP(X_vz);
 
-		_pub_lpos.get().ax = _u(U_ax);		// north
-		_pub_lpos.get().ay = _u(U_ay);		// east
-		_pub_lpos.get().az = _u(U_az);		// down
-
 		_pub_lpos.get().xy_global = _estimatorInitialized & EST_XY;
 		_pub_lpos.get().z_global = !(_sensorTimeout & SENSOR_BARO) && _altOriginGlobal;
 		_pub_lpos.get().ref_timestamp = _time_origin;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -4852,9 +4852,9 @@ protected:
 			msg.vz = lpos.vz * 1e2f;
 			msg.ind_airspeed = 0;
 			msg.true_airspeed = 0;
-			msg.xacc = lpos.ax;
-			msg.yacc = lpos.ay;
-			msg.zacc = lpos.az;
+			// msg.xacc = lpos.ax;
+			// msg.yacc = lpos.ay;
+			// msg.zacc = lpos.az;
 
 			mavlink_msg_hil_state_quaternion_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
For discussion only at this point. Should we remove the acceleration fields from vehicle_local_position to prevent accidental usage? We have a standalone `vehicle_acceleration` that's filtered.

 - remove vehicle_local_position ax, ay, az (derivative of IMU delta velocity)
 - TECS updated to require valid vertical velocity estimate https://github.com/PX4/ecl/pull/670
