### PR TITLE
[WIP] Different Attitude Setpoint Generation Strategy

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1593,8 +1593,9 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 	Quatf delta_q_reset;
 	_ekf.get_quat_reset(&delta_q_reset(0), &lpos.heading_reset_counter);
 
-	lpos.heading = Eulerf(_ekf.getQuaternion()).psi();
-	lpos.unaided_heading = _ekf.getUnaidedYaw();
+	const Quatf q = _ekf.getQuaternion();
+	lpos.heading = 2.f * atan2f(q(3), q(0));
+	lpos.unaided_heading = _ekf.getUnaidedYaw(); // TODO: Needs to change as well
 	lpos.delta_heading = Eulerf(delta_q_reset).psi();
 	lpos.heading_good_for_control = _ekf.isYawFinalAlignComplete();
 

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -138,3 +138,31 @@ TEST(AttitudeControlTest, YawWeightScaling)
 	// THEN: no actuation (also no NAN)
 	EXPECT_EQ(rate_setpoint, Vector3f());
 }
+
+TEST(AttitudeControlTest, HeadingCorrectness)
+{
+	//Quatf q(0.863f, 0.358f,  0.358f, 0.f);
+	Quatf q(0.733f, 0.462f, 0.191f, 0.462f);
+	q.normalize();
+	float yaw = matrix::Eulerf(q).psi();
+
+	Quatf q_red(Vector3f(0, 0, 1), q.dcm_z());
+	Quatf q_mix = q_red.inversed() * q;
+	q_mix.print();
+
+	Quatf q_mix2 = q;
+	q_mix2(1) = 0.f;
+	q_mix2(2) = 0.f;
+	q_mix2.normalize();
+	q_mix2.print();
+
+	q_mix2(3) = math::constrain(q_mix2(3), -1.f, 1.f);
+	float heading = 2.f * asinf(q_mix2(3));
+
+	float heading2 = 2.f * atan2f(q(3), q(0));
+	EXPECT_FLOAT_EQ(heading, heading2);
+
+	EXPECT_GT(fabsf(yaw), FLT_EPSILON);
+	EXPECT_LT(fabsf(heading), FLT_EPSILON);
+	EXPECT_TRUE(false);
+}

--- a/src/modules/mc_pos_control/PositionControl/CMakeLists.txt
+++ b/src/modules/mc_pos_control/PositionControl/CMakeLists.txt
@@ -41,3 +41,4 @@ target_include_directories(PositionControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 px4_add_unit_gtest(SRC ControlMathTest.cpp LINKLIBS PositionControl)
 px4_add_unit_gtest(SRC PositionControlTest.cpp LINKLIBS PositionControl)
+px4_add_unit_gtest(SRC PositionAttitudeTest.cpp LINKLIBS PositionControl AttitudeControl)

--- a/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
@@ -69,6 +69,8 @@ void limitTilt(matrix::Vector3f &body_unit, const matrix::Vector3f &world_unit, 
  */
 void bodyzToAttitude(matrix::Vector3f body_z, const float yaw_sp, vehicle_attitude_setpoint_s &att_sp);
 
+matrix::Quatf bodyzToQuaternion(matrix::Vector3f body_z, const float yaw_sp);
+
 /**
  * Outputs the sum of two vectors but respecting the limits and priority.
  * The sum of two vectors are constraint such that v0 has priority over v1.

--- a/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
@@ -151,7 +151,7 @@ TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingUpsideDownYaw90)
 	 * reason: thrust points straight down and order Euler
 	 * order is: 1. roll, 2. pitch, 3. yaw */
 	checkDirection(Vector3f(0.f, 0.f, 1.f), M_PI_2_F);
-	checkEuler(-M_PI_F, 0.f, M_PI_2_F);
+	checkEuler(M_PI_F, 0.f, -M_PI_2_F);
 }
 
 TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingRandomDirections)

--- a/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
@@ -100,37 +100,65 @@ TEST(ControlMathTest, LimitTilt10degree)
 	EXPECT_FLOAT_EQ(2.f * body(0), body(1));
 }
 
-TEST(ControlMathTest, ThrottleAttitudeMapping)
+class ControlMathAttitudeMappingTest : public ::testing::Test
+{
+public:
+	void checkDirection(const Vector3f thrust_setpoint, const float yaw)
+	{
+		thrustToAttitude(thrust_setpoint, yaw, _attitude_setpoint);
+		EXPECT_EQ(Quatf(_attitude_setpoint.q_d).dcm_z(), -thrust_setpoint.normalized());
+		EXPECT_EQ(_attitude_setpoint.thrust_body[2], -thrust_setpoint.length());
+	}
+
+	void checkEuler(const float roll, const float pitch, const float yaw)
+	{
+		EXPECT_FLOAT_EQ(_attitude_setpoint.roll_body, roll);
+		EXPECT_FLOAT_EQ(_attitude_setpoint.pitch_body, pitch);
+		EXPECT_FLOAT_EQ(_attitude_setpoint.yaw_body, yaw);
+	}
+
+	vehicle_attitude_setpoint_s _attitude_setpoint{};
+};
+
+TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingNoRotation)
 {
 	/* expected: zero roll, zero pitch, zero yaw, full thr mag
 	 * reason: thrust pointing full upward */
-	Vector3f thr{0.f, 0.f, -1.f};
-	float yaw = 0.f;
-	vehicle_attitude_setpoint_s att{};
-	thrustToAttitude(thr, yaw, att);
-	EXPECT_FLOAT_EQ(att.roll_body, 0.f);
-	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
-	EXPECT_FLOAT_EQ(att.yaw_body, 0.f);
-	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);
+	checkDirection(Vector3f(0.f, 0.f, -1.f), 0.f);
+	checkEuler(0.f, 0.f, 0.f);
+}
 
+TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingYaw90)
+{
 	/* expected: same as before but with 90 yaw
 	 * reason: only yaw changed */
-	yaw = M_PI_2_F;
-	thrustToAttitude(thr, yaw, att);
-	EXPECT_FLOAT_EQ(att.roll_body, 0.f);
-	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
-	EXPECT_FLOAT_EQ(att.yaw_body, M_PI_2_F);
-	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);
+	checkDirection(Vector3f(0.f, 0.f, -1.f), M_PI_2_F);
+	checkEuler(0.f, 0.f, M_PI_2_F);
+}
 
+TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingUpsideDown)
+{
 	/* expected: same as before but roll 180
 	 * reason: thrust points straight down and order Euler
 	 * order is: 1. roll, 2. pitch, 3. yaw */
-	thr = Vector3f(0.f, 0.f, 1.f);
-	thrustToAttitude(thr, yaw, att);
-	EXPECT_FLOAT_EQ(att.roll_body, -M_PI_F);
-	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
-	EXPECT_FLOAT_EQ(att.yaw_body, M_PI_2_F);
-	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);
+	checkDirection(Vector3f(0.f, 0.f, 1.f), 0.f);
+	checkEuler(M_PI_F, 0.f, 0.f);
+}
+
+TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingUpsideDownYaw90)
+{
+	/* expected: same as before but roll 180
+	 * reason: thrust points straight down and order Euler
+	 * order is: 1. roll, 2. pitch, 3. yaw */
+	checkDirection(Vector3f(0.f, 0.f, 1.f), M_PI_2_F);
+	checkEuler(-M_PI_F, 0.f, M_PI_2_F);
+}
+
+TEST_F(ControlMathAttitudeMappingTest, AttitudeMappingRandomDirections)
+{
+	checkDirection(Vector3f(0, .5f, -.5f), 1.f);
+	checkDirection(Vector3f(-2.f, 8.f, .1f), 2.f);
+	checkDirection(Vector3f(-.2f, -5.f, -30.f), 2.f);
 }
 
 TEST(ControlMathTest, ConstrainXYPriorities)

--- a/src/modules/mc_pos_control/PositionControl/PositionAttitudeTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionAttitudeTest.cpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <ControlMath.hpp>
+#include <AttitudeControl.hpp>
+#include <px4_defines.h>
+
+using namespace matrix;
+
+TEST(PositionControlTest, NavigationYawInfluence)
+{
+	const Vector3f thrust_setpoint(1.f, 1.f, -.5f);
+	const float yaw_setpoint = 0.f;
+
+	// Generate attitude
+	vehicle_attitude_setpoint_s attitude_setpoint{};
+	ControlMath::thrustToAttitude(thrust_setpoint, yaw_setpoint, attitude_setpoint);
+
+	// Set up attitude control
+	AttitudeControl attitude_control;
+	attitude_control.setProportionalGain(Vector3f(1.f, 1.f, 1.f));
+	attitude_control.setRateLimit(Vector3f(100.f, 100.f, 100.f));
+
+	// Execute on attitude
+	Quatf qd(attitude_setpoint.q_d);
+	const Vector3f rate_setpoint = attitude_control.update(Quatf(), qd, 0.f);
+	rate_setpoint.print();
+
+	// expect symmetric angular rate command towards thrust direction without any body yaw correction
+	EXPECT_GT(rate_setpoint(0), 0.f);
+	EXPECT_LT(rate_setpoint(1), 0.f);
+	EXPECT_FLOAT_EQ(fabsf(rate_setpoint(0)), fabsf(rate_setpoint(1)));
+	EXPECT_FLOAT_EQ(rate_setpoint(2), 0.f);
+}

--- a/src/modules/mc_pos_control/PositionControl/PositionAttitudeTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionAttitudeTest.cpp
@@ -49,12 +49,13 @@ TEST(PositionControlTest, NavigationYawInfluence)
 
 	// Set up attitude control
 	AttitudeControl attitude_control;
-	attitude_control.setProportionalGain(Vector3f(1.f, 1.f, 1.f));
+	attitude_control.setProportionalGain(Vector3f(1.f, 1.f, 1.f), 1.f);
 	attitude_control.setRateLimit(Vector3f(100.f, 100.f, 100.f));
 
 	// Execute on attitude
 	Quatf qd(attitude_setpoint.q_d);
-	const Vector3f rate_setpoint = attitude_control.update(Quatf(), qd, 0.f);
+	attitude_control.setAttitudeSetpoint(qd, 0.f);
+	const Vector3f rate_setpoint = attitude_control.update(Quatf());
 	rate_setpoint.print();
 
 	// expect symmetric angular rate command towards thrust direction without any body yaw correction
@@ -62,4 +63,8 @@ TEST(PositionControlTest, NavigationYawInfluence)
 	EXPECT_LT(rate_setpoint(1), 0.f);
 	EXPECT_FLOAT_EQ(fabsf(rate_setpoint(0)), fabsf(rate_setpoint(1)));
 	EXPECT_FLOAT_EQ(rate_setpoint(2), 0.f);
+
+	qd.print();
+	Eulerf(qd).print();
+	EXPECT_FLOAT_EQ(2.f * atan2f(qd(3), qd(0)), yaw_setpoint);
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, the position controller generates a thrust vector setpoint and forwards the desired yaw heading in the world frame. The setpoint generator then calculates an attitude that aligns the body z axis with the desired thrust (basic multicopter dynamics) and incorporates the world frame yaw heading in a way that the body x axis projected onto the world x-y-plane always point to the desired world yaw heading. This seems like a viable solution depending on the use case of the yaw setpoint but I see one big disadvantage of this solution: **The body yaw rate is coupled with a thrust vector**

**Describe your solution**
I calculate the desired attitude by aligning the body z axis with the thrust vector like before but this time directly using quaternion math. See https://github.com/PX4/Matrix/pull/55 for implementation details. Then yaw is applied on top with a different strategy: If the vehicle is level the yaw is the world frame heading but if the vehicle is tilted it just does the shortest roll/pitch tilting without correcting the body yaw angle to allign the body x-axis in to a world frame projection. This results in no body yaw rate corrections resulting from roll and pitch adjustments.

Note that all the **3-axis** gimbals for drones I have tested do the right thing when generating the attitude the way proposed in this pr and yaw off the desired world frame heading when aplying the current PX4 conversion.

**Test data / coverage**
SITL tested and I adjusted the existing unit tests in the following way:
- structure refactoring https://github.com/PX4/Firmware/pull/13535/commits/4b18af1c9fcb120cd97113bfa38becd60557c9d0
- additional body z-axis direction and thrust magnitude checks https://github.com/PX4/Firmware/commit/4b18af1c9fcb120cd97113bfa38becd60557c9d0#diff-ab7081b2f8b080c822f0c8b98f2cef20R47-R48
- adjustment to the new attitude generation strategy https://github.com/PX4/Firmware/pull/13535/commits/0faf1f8dba5ba562bd68226f08b42e11ac6c8083