### PR TITLE
Added option for module config file in libraries

### DIFF
--- a/platforms/common/px4_work_queue/CMakeLists.txt
+++ b/platforms/common/px4_work_queue/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(px4_work_queue
-	ScheduledWorkItem.cpp
+px4_add_library(
+	LIBRARY px4_work_queue
+	SRCS ScheduledWorkItem.cpp
 	WorkItem.cpp
 	WorkQueue.cpp
 	WorkQueueManager.cpp

--- a/platforms/nuttx/src/px4/nxp/kinetis/adc/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/adc/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_adc
-	adc.cpp
+px4_add_library(
+	LIBRARY arch_adc
+	SRCS adc.cpp
 )

--- a/platforms/nuttx/src/px4/nxp/kinetis/board_critmon/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/board_critmon/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_board_critmon
-	board_critmon.c
+px4_add_library(
+	LIBRARY arch_board_critmon
+	SRCS board_critmon.c
 )

--- a/platforms/nuttx/src/px4/nxp/kinetis/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/board_reset/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_board_reset
-	board_reset.c
+px4_add_library(
+	LIBRARY arch_board_reset
+	SRCS board_reset.c
 )

--- a/platforms/nuttx/src/px4/nxp/kinetis/hrt/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/hrt/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(arch_hrt
-	hrt.c
+px4_add_library(
+	LIBRARY arch_hrt
+	SRCS hrt.c
 )
 target_compile_options(arch_hrt PRIVATE -Wno-cast-align) # TODO: fix and enable
 

--- a/platforms/nuttx/src/px4/nxp/kinetis/io_pins/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/io_pins/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(arch_io_pins
-	io_timer.c
+px4_add_library(
+	LIBRARY arch_io_pins
+	SRCS io_timer.c
 	pwm_servo.c
 	pwm_trigger.c
 	input_capture.c

--- a/platforms/nuttx/src/px4/nxp/kinetis/led_pwm/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/led_pwm/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_led_pwm
-	led_pwm.cpp
+px4_add_library(
+	LIBRARY arch_led_pwm
+	SRCS led_pwm.cpp
 )

--- a/platforms/nuttx/src/px4/nxp/kinetis/tone_alarm/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/tone_alarm/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_tone_alarm
-	ToneAlarmInterface.cpp
+px4_add_library(
+	LIBRARY arch_tone_alarm
+	SRCS ToneAlarmInterface.cpp
 )

--- a/platforms/nuttx/src/px4/nxp/kinetis/version/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/version/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(arch_version
-	board_identity.c
+px4_add_library(
+	LIBRARY arch_version
+	SRCS board_identity.c
 	board_mcu_version.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/adc/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/adc/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_adc
-	adc.cpp
+px4_add_library(
+	LIBRARY arch_adc
+	SRCS adc.cpp
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_critmon/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_critmon/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_board_critmon
-	board_critmon.c
+px4_add_library(
+	LIBRARY arch_board_critmon
+	SRCS board_critmon.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_board_hw_info
-	board_hw_rev_ver.c
+px4_add_library(
+	LIBRARY arch_board_hw_info
+	SRCS board_hw_rev_ver.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_reset/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_board_reset
-	board_reset.c
+px4_add_library(
+	LIBRARY arch_board_reset
+	SRCS board_reset.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/dshot/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/dshot/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_dshot
-	dshot.c
+px4_add_library(
+	LIBRARY arch_dshot
+	SRCS dshot.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/hrt/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/hrt/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(arch_hrt
-	hrt.c
+px4_add_library(
+	LIBRARY arch_hrt
+	SRCS hrt.c
 )
 target_compile_options(arch_hrt PRIVATE -Wno-cast-align) # TODO: fix and enable
 

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(arch_io_pins
-	io_timer.c
+px4_add_library(
+	LIBRARY arch_io_pins
+	SRCS io_timer.c
 	pwm_servo.c
 	pwm_trigger.c
 	input_capture.c

--- a/platforms/nuttx/src/px4/stm/stm32_common/led_pwm/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/led_pwm/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_led_pwm
-	led_pwm.cpp
+px4_add_library(
+	LIBRARY arch_led_pwm
+	SRCS led_pwm.cpp
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/tone_alarm/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/tone_alarm/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_tone_alarm
-	ToneAlarmInterface.cpp
+px4_add_library(
+	LIBRARY arch_tone_alarm
+	SRCS ToneAlarmInterface.cpp
 )

--- a/platforms/nuttx/src/px4/stm/stm32_common/version/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/version/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(arch_version
-	board_identity.c
+px4_add_library(
+	LIBRARY arch_version
+	SRCS board_identity.c
 	board_mcu_version.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32f3/board_critmon/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32f3/board_critmon/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_board_critmon
-	board_critmon.c
+px4_add_library(
+	LIBRARY arch_board_critmon
+	SRCS board_critmon.c
 )

--- a/platforms/nuttx/src/px4/stm/stm32f4/px4io_serial/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32f4/px4io_serial/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_px4io_serial
-	px4io_serial.cpp
+px4_add_library(
+	LIBRARY arch_px4io_serial
+	SRCS px4io_serial.cpp
 )

--- a/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_px4io_serial
-	px4io_serial.cpp
+px4_add_library(
+	LIBRARY arch_px4io_serial
+	SRCS px4io_serial.cpp
 )

--- a/platforms/nuttx/src/px4/stm/stm32h7/adc/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32h7/adc/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_adc
-	adc.cpp
+px4_add_library(
+	LIBRARY arch_adc
+	SRCS adc.cpp
 )

--- a/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_px4io_serial
-	px4io_serial.cpp
+px4_add_library(
+	LIBRARY arch_px4io_serial
+	SRCS px4io_serial.cpp
 )

--- a/platforms/posix/src/px4/common/gtest_runner/CMakeLists.txt
+++ b/platforms/posix/src/px4/common/gtest_runner/CMakeLists.txt
@@ -35,5 +35,7 @@ set(SRCS
     gtest_functional_main.cpp
    )
 
-px4_add_library(gtest_functional_main ${SRCS})
+px4_add_library(
+	LIBRARY gtest_functional_main
+	SRCS ${SRCS})
 target_link_libraries(gtest_functional_main PUBLIC gtest)

--- a/platforms/posix/src/px4/common/px4_daemon/CMakeLists.txt
+++ b/platforms/posix/src/px4/common/px4_daemon/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(px4_daemon
-		pxh.cpp
+px4_add_library(
+	LIBRARY px4_daemon
+	SRCS pxh.cpp
 		history.cpp
 		client.cpp
 		server.cpp

--- a/platforms/posix/src/px4/common/test_stubs/CMakeLists.txt
+++ b/platforms/posix/src/px4/common/test_stubs/CMakeLists.txt
@@ -37,5 +37,7 @@ set(SRCS
     stub_parameter.cpp
    )
 
-px4_add_library(test_stubs ${SRCS})
+px4_add_library(
+	LIBRARY test_stubs
+	SRCS ${SRCS})
 message("-- ADDING TEST STUBS")

--- a/platforms/posix/src/px4/generic/generic/tone_alarm/CMakeLists.txt
+++ b/platforms/posix/src/px4/generic/generic/tone_alarm/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(arch_tone_alarm
-	ToneAlarmInterface.cpp
+px4_add_library(
+	LIBRARY arch_tone_alarm
+	SRCS ToneAlarmInterface.cpp
 )

--- a/src/drivers/telemetry/hott/CMakeLists.txt
+++ b/src/drivers/telemetry/hott/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(drivers__hott
-	messages.cpp
+px4_add_library(
+	LIBRARY drivers__hott
+	SRCS messages.cpp
 	comms.cpp
 )
 

--- a/src/lib/airspeed/CMakeLists.txt
+++ b/src/lib/airspeed/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(airspeed airspeed.cpp)
+px4_add_library(
+	LIBRARY airspeed
+	SRCS airspeed.cpp)

--- a/src/lib/airspeed_validator/CMakeLists.txt
+++ b/src/lib/airspeed_validator/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(AirspeedValidator AirspeedValidator.cpp)
+px4_add_library(
+	LIBRARY AirspeedValidator
+	SRCS AirspeedValidator.cpp)
 
 target_include_directories(AirspeedValidator
 	PUBLIC

--- a/src/lib/battery/CMakeLists.txt
+++ b/src/lib/battery/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(battery battery.cpp)
+px4_add_library(
+	LIBRARY battery
+	SRCS battery.cpp)

--- a/src/lib/bezier/CMakeLists.txt
+++ b/src/lib/bezier/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(bezier
-		BezierQuad.cpp
+px4_add_library(
+	LIBRARY bezier
+	SRCS BezierQuad.cpp
 )

--- a/src/lib/cdev/CMakeLists.txt
+++ b/src/lib/cdev/CMakeLists.txt
@@ -43,7 +43,8 @@ else()
 	)
 endif()
 
-px4_add_library(cdev
+px4_add_library(LIBRARY cdev
+	SRCS
 	CDev.cpp
 	${SRCS_PLATFORM}
 	)

--- a/src/lib/circuit_breaker/CMakeLists.txt
+++ b/src/lib/circuit_breaker/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(circuit_breaker circuit_breaker.cpp)
+px4_add_library(
+	LIBRARY circuit_breaker
+	SRCS circuit_breaker.cpp)

--- a/src/lib/collision_prevention/CMakeLists.txt
+++ b/src/lib/collision_prevention/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(CollisionPrevention CollisionPrevention.cpp)
+px4_add_library(
+	LIBRARY CollisionPrevention
+	SRCS CollisionPrevention.cpp)
 target_compile_options(CollisionPrevention PRIVATE -Wno-cast-align) # TODO: fix and enable
 
 px4_add_functional_gtest(SRC CollisionPreventionTest.cpp LINKLIBS CollisionPrevention )

--- a/src/lib/controllib/CMakeLists.txt
+++ b/src/lib/controllib/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(controllib
+px4_add_library(
+	LIBRARY controllib
+	SRCS
 	block/Block.cpp
 	block/BlockParam.cpp
 	BlockDerivative.cpp

--- a/src/lib/conversion/CMakeLists.txt
+++ b/src/lib/conversion/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(conversion rotation.cpp)
+px4_add_library(
+	LIBRARY conversion
+	SRCS rotation.cpp)

--- a/src/lib/drivers/accelerometer/CMakeLists.txt
+++ b/src/lib/drivers/accelerometer/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(drivers_accelerometer PX4Accelerometer.cpp)
+px4_add_library(
+	LIBRARY drivers_accelerometer
+	SRCS PX4Accelerometer.cpp)
 target_link_libraries(drivers_accelerometer
 	PRIVATE
 		drivers__device

--- a/src/lib/drivers/airspeed/CMakeLists.txt
+++ b/src/lib/drivers/airspeed/CMakeLists.txt
@@ -31,5 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers__airspeed airspeed.cpp)
+px4_add_library(
+	LIBRARY drivers__airspeed
+	SRCS airspeed.cpp)
 target_link_libraries(drivers__airspeed PRIVATE drivers__device)

--- a/src/lib/drivers/barometer/CMakeLists.txt
+++ b/src/lib/drivers/barometer/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_barometer PX4Barometer.cpp)
+px4_add_library(
+	LIBRARY drivers_barometer
+	SRCS PX4Barometer.cpp)

--- a/src/lib/drivers/device/CMakeLists.txt
+++ b/src/lib/drivers/device/CMakeLists.txt
@@ -53,7 +53,8 @@ elseif(UNIX AND NOT APPLE AND NOT (${PX4_PLATFORM} MATCHES "qurt")) #TODO: add l
 	)
 endif()
 
-px4_add_library(drivers__device
+px4_add_library(LIBRARY drivers__device
+	SRCS
 	CDev.cpp
 	ringbuffer.cpp
 	integrator.cpp

--- a/src/lib/drivers/gyroscope/CMakeLists.txt
+++ b/src/lib/drivers/gyroscope/CMakeLists.txt
@@ -31,5 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers_gyroscope PX4Gyroscope.cpp)
+px4_add_library(
+	LIBRARY drivers_gyroscope
+	SRCS PX4Gyroscope.cpp)
 target_link_libraries(drivers_gyroscope PRIVATE drivers__device)

--- a/src/lib/drivers/led/CMakeLists.txt
+++ b/src/lib/drivers/led/CMakeLists.txt
@@ -31,5 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers__led led.cpp)
+px4_add_library(
+	LIBRARY drivers__led
+	SRCS led.cpp)
 target_link_libraries(drivers__led PRIVATE drivers__device)

--- a/src/lib/drivers/linux_gpio/CMakeLists.txt
+++ b/src/lib/drivers/linux_gpio/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(linux_gpio
-	linux_gpio.cpp
+px4_add_library(
+	LIBRARY linux_gpio
+	SRCS linux_gpio.cpp
 	)
 
 #add_subdirectory(test)

--- a/src/lib/drivers/magnetometer/CMakeLists.txt
+++ b/src/lib/drivers/magnetometer/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_magnetometer PX4Magnetometer.cpp)
+px4_add_library(
+	LIBRARY drivers_magnetometer
+	SRCS PX4Magnetometer.cpp)

--- a/src/lib/drivers/rangefinder/CMakeLists.txt
+++ b/src/lib/drivers/rangefinder/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers_rangefinder PX4Rangefinder.cpp)
+px4_add_library(
+	LIBRARY drivers_rangefinder
+	SRCS PX4Rangefinder.cpp)

--- a/src/lib/drivers/smbus/CMakeLists.txt
+++ b/src/lib/drivers/smbus/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(drivers__smbus SMBus.cpp)
+px4_add_library(
+	LIBRARY drivers__smbus
+	SRCS SMBus.cpp)

--- a/src/lib/flight_tasks/CMakeLists.txt
+++ b/src/lib/flight_tasks/CMakeLists.txt
@@ -111,8 +111,9 @@ add_compile_options(
 	-Wno-cast-align
 	) # TODO: fix and enable
 
-px4_add_library(FlightTasks
-	FlightTasks.cpp
+px4_add_library(
+	LIBRARY FlightTasks
+	SRCS FlightTasks.cpp
 	FlightTasks_generated.cpp
 )
 

--- a/src/lib/flight_tasks/tasks/Auto/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Auto/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskAuto
-	FlightTaskAuto.cpp
+px4_add_library(
+	LIBRARY FlightTaskAuto
+	SRCS FlightTaskAuto.cpp
 )
 
 target_link_libraries(FlightTaskAuto PUBLIC FlightTask FlightTaskUtility)

--- a/src/lib/flight_tasks/tasks/AutoFollowMe/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/AutoFollowMe/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskAutoFollowMe
-	FlightTaskAutoFollowMe.cpp
+px4_add_library(
+	LIBRARY FlightTaskAutoFollowMe
+	SRCS FlightTaskAutoFollowMe.cpp
 )
 
 target_link_libraries(FlightTaskAutoFollowMe PUBLIC FlightTaskAuto)

--- a/src/lib/flight_tasks/tasks/AutoLine/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/AutoLine/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskAutoLine
-	FlightTaskAutoLine.cpp
+px4_add_library(
+	LIBRARY FlightTaskAutoLine
+	SRCS FlightTaskAutoLine.cpp
 )
 
 target_link_libraries(FlightTaskAutoLine PUBLIC FlightTaskAutoMapper)

--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskAutoLineSmoothVel
-	FlightTaskAutoLineSmoothVel.cpp
+px4_add_library(
+	LIBRARY FlightTaskAutoLineSmoothVel
+	SRCS FlightTaskAutoLineSmoothVel.cpp
 )
 
 target_link_libraries(FlightTaskAutoLineSmoothVel PUBLIC FlightTaskAutoMapper2 FlightTaskUtility)

--- a/src/lib/flight_tasks/tasks/AutoMapper/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/AutoMapper/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskAutoMapper
-	FlightTaskAutoMapper.cpp
+px4_add_library(
+	LIBRARY FlightTaskAutoMapper
+	SRCS FlightTaskAutoMapper.cpp
 )
 
 target_link_libraries(FlightTaskAutoMapper PUBLIC FlightTaskAuto)

--- a/src/lib/flight_tasks/tasks/AutoMapper2/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/AutoMapper2/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskAutoMapper2
-	FlightTaskAutoMapper2.cpp
+px4_add_library(
+	LIBRARY FlightTaskAutoMapper2
+	SRCS FlightTaskAutoMapper2.cpp
 )
 
 target_link_libraries(FlightTaskAutoMapper2 PUBLIC FlightTaskAuto)

--- a/src/lib/flight_tasks/tasks/Descend/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Descend/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskDescend
-	FlightTaskDescend.cpp
+px4_add_library(
+	LIBRARY FlightTaskDescend
+	SRCS FlightTaskDescend.cpp
 )
 
 target_link_libraries(FlightTaskDescend PUBLIC FlightTask)

--- a/src/lib/flight_tasks/tasks/Failsafe/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Failsafe/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskFailsafe
-	FlightTaskFailsafe.cpp
+px4_add_library(
+	LIBRARY FlightTaskFailsafe
+	SRCS FlightTaskFailsafe.cpp
 )
 
 target_link_libraries(FlightTaskFailsafe PUBLIC FlightTask)

--- a/src/lib/flight_tasks/tasks/FlightTask/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/FlightTask/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTask
-	FlightTask.cpp
+px4_add_library(
+	LIBRARY FlightTask
+	SRCS FlightTask.cpp
 )
 
 target_include_directories(FlightTask PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/lib/flight_tasks/tasks/Manual/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Manual/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManual
-	FlightTaskManual.cpp
+px4_add_library(
+	LIBRARY FlightTaskManual
+	SRCS FlightTaskManual.cpp
 )
 
 target_link_libraries(FlightTaskManual PUBLIC FlightTask)

--- a/src/lib/flight_tasks/tasks/ManualAltitude/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/ManualAltitude/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManualAltitude
-	FlightTaskManualAltitude.cpp
+px4_add_library(
+	LIBRARY FlightTaskManualAltitude
+	SRCS FlightTaskManualAltitude.cpp
 )
 
 target_link_libraries(FlightTaskManualAltitude PUBLIC FlightTaskManual)

--- a/src/lib/flight_tasks/tasks/ManualAltitudeSmooth/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/ManualAltitudeSmooth/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManualAltitudeSmooth
-	FlightTaskManualAltitudeSmooth.cpp
+px4_add_library(
+	LIBRARY FlightTaskManualAltitudeSmooth
+	SRCS FlightTaskManualAltitudeSmooth.cpp
 )
 
 target_link_libraries(FlightTaskManualAltitudeSmooth PUBLIC FlightTaskManualAltitude FlightTaskUtility)

--- a/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManualAltitudeSmoothVel
-	FlightTaskManualAltitudeSmoothVel.cpp
+px4_add_library(
+	LIBRARY FlightTaskManualAltitudeSmoothVel
+	SRCS FlightTaskManualAltitudeSmoothVel.cpp
 )
 
 target_link_libraries(FlightTaskManualAltitudeSmoothVel PUBLIC FlightTaskManualAltitude FlightTaskUtility)

--- a/src/lib/flight_tasks/tasks/ManualPosition/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/ManualPosition/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManualPosition
-	FlightTaskManualPosition.cpp
+px4_add_library(
+	LIBRARY FlightTaskManualPosition
+	SRCS FlightTaskManualPosition.cpp
 )
 
 target_link_libraries(FlightTaskManualPosition PUBLIC FlightTaskManualAltitude)

--- a/src/lib/flight_tasks/tasks/ManualPositionSmooth/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/ManualPositionSmooth/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManualPositionSmooth
-	FlightTaskManualPositionSmooth.cpp
+px4_add_library(
+	LIBRARY FlightTaskManualPositionSmooth
+	SRCS FlightTaskManualPositionSmooth.cpp
 )
 
 target_link_libraries(FlightTaskManualPositionSmooth PUBLIC FlightTaskManualPosition FlightTaskUtility)

--- a/src/lib/flight_tasks/tasks/ManualPositionSmoothVel/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/ManualPositionSmoothVel/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskManualPositionSmoothVel
-	FlightTaskManualPositionSmoothVel.cpp
+px4_add_library(
+	LIBRARY FlightTaskManualPositionSmoothVel
+	SRCS FlightTaskManualPositionSmoothVel.cpp
 )
 
 target_link_libraries(FlightTaskManualPositionSmoothVel PUBLIC FlightTaskManualPosition FlightTaskUtility)

--- a/src/lib/flight_tasks/tasks/Offboard/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Offboard/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskOffboard
-	FlightTaskOffboard.cpp
+px4_add_library(
+	LIBRARY FlightTaskOffboard
+	SRCS FlightTaskOffboard.cpp
 )
 
 target_link_libraries(FlightTaskOffboard PUBLIC FlightTask)

--- a/src/lib/flight_tasks/tasks/Orbit/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Orbit/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskOrbit
-	FlightTaskOrbit.cpp
+px4_add_library(
+	LIBRARY FlightTaskOrbit
+	SRCS FlightTaskOrbit.cpp
 )
 
 target_link_libraries(FlightTaskOrbit PUBLIC FlightTaskManualAltitudeSmooth)

--- a/src/lib/flight_tasks/tasks/Transition/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Transition/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskTransition
-	FlightTaskTransition.cpp
+px4_add_library(
+	LIBRARY FlightTaskTransition
+	SRCS FlightTaskTransition.cpp
 )
 
 target_link_libraries(FlightTaskTransition PUBLIC FlightTask)

--- a/src/lib/flight_tasks/tasks/Utility/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Utility/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(FlightTaskUtility
-	ManualSmoothingZ.cpp
+px4_add_library(
+	LIBRARY FlightTaskUtility
+	SRCS ManualSmoothingZ.cpp
 	ManualSmoothingXY.cpp
 	ObstacleAvoidance.cpp
 	StraightLine.cpp

--- a/src/lib/hysteresis/CMakeLists.txt
+++ b/src/lib/hysteresis/CMakeLists.txt
@@ -31,6 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(hysteresis hysteresis.cpp)
+px4_add_library(
+	LIBRARY hysteresis
+	SRCS hysteresis.cpp)
 
 px4_add_unit_gtest(SRC HysteresisTest.cpp LINKLIBS hysteresis)

--- a/src/lib/landing_slope/CMakeLists.txt
+++ b/src/lib/landing_slope/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(landing_slope Landingslope.cpp)
+px4_add_library(
+	LIBRARY landing_slope
+	SRCS Landingslope.cpp)

--- a/src/lib/led/CMakeLists.txt
+++ b/src/lib/led/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(led led.cpp)
+px4_add_library(
+	LIBRARY led
+	SRCS led.cpp)
 target_compile_options(led
 	PRIVATE -Wno-implicit-fallthrough # TODO: fix and remove
 )

--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(mathlib
+px4_add_library(
+	LIBRARY mathlib
+	SRCS
 	math/test/test.cpp
 	math/matrix_alg.cpp
 	math/filter/LowPassFilter2p.cpp

--- a/src/lib/mixer_module/CMakeLists.txt
+++ b/src/lib/mixer_module/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(mixer_module mixer_module.cpp)
+px4_add_library(
+	LIBRARY mixer_module
+	SRCS mixer_module.cpp)

--- a/src/lib/output_limit/CMakeLists.txt
+++ b/src/lib/output_limit/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(output_limit output_limit.cpp)
+px4_add_library(
+	LIBRARY output_limit
+	SRCS output_limit.cpp)

--- a/src/lib/pid/CMakeLists.txt
+++ b/src/lib/pid/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(pid pid.cpp)
+px4_add_library(
+	LIBRARY pid
+	SRCS pid.cpp)

--- a/src/lib/systemlib/CMakeLists.txt
+++ b/src/lib/systemlib/CMakeLists.txt
@@ -49,4 +49,4 @@ else()
 		)
 endif()
 
-px4_add_library(systemlib ${SRCS})
+px4_add_library(LIBRARY systemlib SRCS ${SRCS})

--- a/src/lib/terrain_estimation/CMakeLists.txt
+++ b/src/lib/terrain_estimation/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(terrain_estimation terrain_estimator.cpp)
+px4_add_library(
+	LIBRARY terrain_estimation
+	SRCS terrain_estimator.cpp)

--- a/src/lib/tunes/CMakeLists.txt
+++ b/src/lib/tunes/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(tunes
-	tunes.cpp
+px4_add_library(
+	LIBRARY tunes
+	SRCS tunes.cpp
 	default_tunes.cpp
 )

--- a/src/lib/weather_vane/CMakeLists.txt
+++ b/src/lib/weather_vane/CMakeLists.txt
@@ -31,4 +31,6 @@
 #
 ############################################################################
 
-px4_add_library(WeatherVane WeatherVane.cpp)
+px4_add_library(
+	LIBRARY WeatherVane
+	SRCS WeatherVane.cpp)

--- a/src/modules/commander/Arming/ArmAuthorization/CMakeLists.txt
+++ b/src/modules/commander/Arming/ArmAuthorization/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(ArmAuthorization
-	ArmAuthorization.cpp
+px4_add_library(
+	LIBRARY ArmAuthorization
+	SRCS ArmAuthorization.cpp
 )
 target_include_directories(ArmAuthorization
 	PUBLIC

--- a/src/modules/commander/Arming/HealthFlags/CMakeLists.txt
+++ b/src/modules/commander/Arming/HealthFlags/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(HealthFlags
-	HealthFlags.cpp
+px4_add_library(
+	LIBRARY HealthFlags
+	SRCS HealthFlags.cpp
 )
 target_include_directories(HealthFlags PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
+++ b/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
@@ -31,7 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(PreFlightCheck
+px4_add_library(
+	LIBRARY PreFlightCheck
+	SRCS
 	PreFlightCheck.cpp
 	checks/preArmCheck.cpp
 	checks/magnetometerCheck.cpp

--- a/src/modules/commander/failure_detector/CMakeLists.txt
+++ b/src/modules/commander/failure_detector/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(failure_detector
-	FailureDetector.cpp
+px4_add_library(
+	LIBRARY failure_detector
+	SRCS FailureDetector.cpp
 )

--- a/src/modules/ekf2/Utility/CMakeLists.txt
+++ b/src/modules/ekf2/Utility/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 #############################################################################
 
-px4_add_library(Ekf2Utility
-	PreFlightChecker.cpp
+px4_add_library(
+	LIBRARY Ekf2Utility
+	SRCS PreFlightChecker.cpp
 )
 
 target_include_directories(Ekf2Utility

--- a/src/modules/fw_pos_control_l1/launchdetection/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/launchdetection/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(launchdetection
-	LaunchDetector.cpp
+px4_add_library(
+	LIBRARY launchdetection
+	SRCS LaunchDetector.cpp
 	CatapultLaunchMethod.cpp
 )

--- a/src/modules/fw_pos_control_l1/runway_takeoff/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(runway_takeoff
-	RunwayTakeoff.cpp
+px4_add_library(
+	LIBRARY runway_takeoff
+	SRCS RunwayTakeoff.cpp
 )

--- a/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
+++ b/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(AttitudeControl
-	AttitudeControl.cpp
+px4_add_library(
+	LIBRARY AttitudeControl
+	SRCS AttitudeControl.cpp
 )
 target_include_directories(AttitudeControl
 	PUBLIC

--- a/src/modules/mc_pos_control/PositionControl/CMakeLists.txt
+++ b/src/modules/mc_pos_control/PositionControl/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(PositionControl
-	PositionControl.cpp
+px4_add_library(
+	LIBRARY PositionControl
+	SRCS PositionControl.cpp
 	ControlMath.cpp
 )
 target_include_directories(PositionControl

--- a/src/modules/mc_pos_control/Takeoff/CMakeLists.txt
+++ b/src/modules/mc_pos_control/Takeoff/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(Takeoff
-	Takeoff.cpp
+px4_add_library(
+	LIBRARY Takeoff
+	SRCS Takeoff.cpp
 )
 target_include_directories(Takeoff
 	PUBLIC

--- a/src/modules/mc_rate_control/RateControl/CMakeLists.txt
+++ b/src/modules/mc_rate_control/RateControl/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(RateControl
-	RateControl.cpp
+px4_add_library(
+	LIBRARY RateControl
+	SRCS RateControl.cpp
 )
 target_include_directories(RateControl
 	PUBLIC

--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -159,7 +159,9 @@ if (GENERATE_RTPS_BRIDGE)
 		WORKING_DIRECTORY ${PX4_SOURCE_DIR}/msg/
 		VERBATIM
 		)
-	px4_add_library(uorb_msgs_microcdr ${uorb_sources_microcdr})
+	px4_add_library(
+		LIBRARY uorb_msgs_microcdr
+		SRCS ${uorb_sources_microcdr})
 	add_dependencies(uorb_msgs_microcdr
 		uorb_headers_microcdr_gen
 		git_micro_cdr

--- a/src/modules/muorb/adsp/CMakeLists.txt
+++ b/src/modules/muorb/adsp/CMakeLists.txt
@@ -31,8 +31,9 @@
 #
 ############################################################################
 
-px4_add_library(modules__muorb__adsp
-	px4muorb.cpp
+px4_add_library(
+	LIBRARY modules__muorb__adsp
+	SRCS px4muorb.cpp
 	uORBFastRpcChannel.cpp
 )
 target_include_directories(modules__muorb__adsp PRIVATE ${PX4_SOURCE_DIR}/src/modules/uORB)

--- a/src/modules/sensors/vehicle_acceleration/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_acceleration/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(vehicle_acceleration
-	VehicleAcceleration.cpp
+px4_add_library(
+	LIBRARY vehicle_acceleration
+	SRCS VehicleAcceleration.cpp
 )
 target_link_libraries(vehicle_acceleration PRIVATE px4_work_queue)

--- a/src/modules/sensors/vehicle_angular_velocity/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_angular_velocity/CMakeLists.txt
@@ -31,7 +31,8 @@
 #
 ############################################################################
 
-px4_add_library(vehicle_angular_velocity
-	VehicleAngularVelocity.cpp
+px4_add_library(
+	LIBRARY vehicle_angular_velocity
+	SRCS VehicleAngularVelocity.cpp
 )
 target_link_libraries(vehicle_angular_velocity PRIVATE px4_work_queue)

--- a/src/modules/simulator/ledsim/CMakeLists.txt
+++ b/src/modules/simulator/ledsim/CMakeLists.txt
@@ -31,5 +31,7 @@
 #
 ############################################################################
 
-px4_add_library(drivers__ledsim led.cpp)
+px4_add_library(
+	LIBRARY drivers__ledsim
+	SRCS led.cpp)
 target_link_libraries(drivers__ledsim PRIVATE drivers__led)


### PR DESCRIPTION
This is just a proposal at this point. It is a significant change that ripples throughout PX4, so it may be wise to not add it for now.

**Describe problem solved by this pull request**
As demonstrated in #12551 , it is helpful to be able to use `module.yaml` config files for declaring parameters in libraries. However, there was no easy way to use these config files outside of modules.

**Describe your solution**
Change the CMake function `px4_add_library` to behave more like `px4_add_module`. It now has the parameters `LIBRARY`, `SRCS`, and `LIBRARY_CONFIG`. This required changing every CMake file that called this function.

**Describe possible alternatives**
The `px4_add_library` function could be changed in such a way that it does not affect the places where it is already used. But I am not skilled enough in CMake to do this.

**Test data / coverage**
None yet, this is a WIP. I assume the continuous integration will catch a lot of problems at first. Once I sort those out, I will do some of my own testing.
