### PR TITLE
geofence: GF_ALTMODE clarification

### DIFF
--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -67,13 +67,13 @@ PARAM_DEFINE_INT32(GF_ACTION, 1);
 /**
  * Geofence altitude mode
  *
- * Select which altitude reference should be used
- * 0 = WGS84, 1 = AMSL
+ * Select which altitude source should be used
+ * 0 = Estimated altitude (GPS/IMU etc.), 1 = Barometer altitude.
  *
  * @min 0
  * @max 1
- * @value 0 WGS84
- * @value 1 AMSL
+ * @value 0 Estimated altitude
+ * @value 1 Barometer altitude
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_ALTMODE, 0);

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -67,13 +67,13 @@ PARAM_DEFINE_INT32(GF_ACTION, 1);
 /**
  * Geofence altitude mode
  *
- * Select which altitude source should be used
- * 0 = Estimated altitude (GPS/IMU etc.), 1 = Barometer altitude.
+ * Select which altitude source should be used:
+ * 0 = AMSL provided by GPS, 1 = Barometer AMSL altitude (assuming standard atmosphere pressure).
  *
  * @min 0
  * @max 1
- * @value 0 Estimated altitude
- * @value 1 Barometer altitude
+ * @value 0 AMSL provided by GPS
+ * @value 1 Barometer AMSL altitude
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_ALTMODE, 0);

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -67,13 +67,12 @@ PARAM_DEFINE_INT32(GF_ACTION, 1);
 /**
  * Geofence altitude mode
  *
- * Select which altitude source should be used:
- * 0 = AMSL provided by GPS, 1 = Barometer AMSL altitude (assuming standard atmosphere pressure).
+ * Select which altitude (AMSL) source should be used for geofence calculations.
  *
  * @min 0
  * @max 1
- * @value 0 AMSL provided by GPS
- * @value 1 Barometer AMSL altitude
+ * @value 0 Autopilot estimator global position altitude (GPS)
+ * @value 1 Raw barometer altitude (assuming standard atmospheric pressure)
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_ALTMODE, 0);


### PR DESCRIPTION
Clarify that GF_ALTMODE is estimated altitude vs barometer atl (not WGS84 vs AMSL). Comes from discussion on slack: https://px4.slack.com/archives/C581ST17V/p1576169863167400,