### PR TITLE
Pr tfminiplus and command support

### DIFF
--- a/src/drivers/distance_sensor/tfmini/CMakeLists.txt
+++ b/src/drivers/distance_sensor/tfmini/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN tfmini
 	SRCS
 		TFMINI.cpp
-		TFMINI.hpp
 		tfmini_main.cpp
 		tfmini_parser.cpp
 	MODULE_CONFIG

--- a/src/drivers/distance_sensor/tfmini/parameters.c
+++ b/src/drivers/distance_sensor/tfmini/parameters.c
@@ -1,0 +1,45 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Benewake TFmini laser rangefinder
+ *
+ * @reboot_required true
+ *
+ * @boolean
+ * @group Sensors
+ * @value 0 undefined - prevent any non wanted commands to be executed
+ * @value 1 TFMINI
+ * @value 2 TFMINI-plus
+ */
+PARAM_DEFINE_INT32(SENS_EN_TFMINI, 0);

--- a/src/drivers/distance_sensor/tfmini/tfmini_main.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini_main.cpp
@@ -106,7 +106,7 @@ command(uint8_t *command, uint8_t framelen)
 
 	int counter = 0;
 
-	do {
+	while (counter < 10) { // wait 200ms for a command response - should be enough
 		if (g_dev->get_command_result()) {
 			uint8_t responselen;
 			uint8_t *cresponse = g_dev->get_command_response(&responselen);
@@ -123,7 +123,7 @@ command(uint8_t *command, uint8_t framelen)
 
 		px4_usleep(20000);
 		counter++;
-	} while (counter < 10); // wait 200ms for a command response - should be enough
+	}
 
 	PX4_ERR("command not confirmed");
 	return PX4_ERROR;

--- a/src/drivers/distance_sensor/tfmini/tfmini_parser.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini_parser.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,6 @@
 
 #include "tfmini_parser.h"
 #include <string.h>
-#include <stdlib.h>
 
 // #define TFMINI_DEBUG
 
@@ -52,26 +51,42 @@
 const char *parser_state[] = {
 	"0_UNSYNC",
 	"1_SYNC_1",
-	"2_SYNC_2",
-	"3_GOT_DIST_L",
-	"4_GOT_DIST_H",
-	"5_GOT_STRENGTH_L",
-	"6_GOT_STRENGTH_H",
-	"7_GOT_PRESERVED",
-	"8_GOT_QUALITY"
-	"9_GOT_CHECKSUM"
+	"1_SYNC_2",
+	"2_GOT_DIST_L",
+	"2_GOT_DIST_H",
+	"3_GOT_STRENGTH_L",
+	"3_GOT_STRENGTH_H",
+	"4_GOT_PRESERVED",
+	"5_GOT_QUALITY",
+	"6_GOT_CHECKSUM",
+	"7_GOT_COMMAND_RESPONSE",
+	"8_GOT_RESPONSE_CHECKSUM"
 };
 #endif
 
-int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARSE_STATE *state, float *dist)
+int tfmini_parse(uint8_t c, uint8_t *parserbuf, unsigned *parserbuf_index, TFMINI_PARSE_STATE *state,
+		 TFMINI_MODEL hw_model, float *dist, uint16_t *strength, float *temperature, uint8_t *commandresponse,
+		 uint8_t *commandresponse_size)
 {
 	int ret = -1;
 	//char *end;
+	unsigned char cksm = 0;
 
 	switch (*state) {
 	case TFMINI_PARSE_STATE::STATE6_GOT_CHECKSUM:
-		if (c == 'Y') {
+	case TFMINI_PARSE_STATE::STATE8_GOT_RESPONSE_CHECKSUM:
+		if (c == TFMINI_DATA_HEADER) {
 			*state = TFMINI_PARSE_STATE::STATE1_SYNC_1;
+			parserbuf[*parserbuf_index] = c;
+			(*parserbuf_index)++;
+
+		} else if (hw_model == TFMINI_MODEL::MODEL_TFMINI && c == TFMINI_CMD_HEADER1) {
+			*state = TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE;
+			parserbuf[*parserbuf_index] = c;
+			(*parserbuf_index)++;
+
+		} else if (hw_model == TFMINI_MODEL::MODEL_TFMINIPLUS && c == TFMINIPLUS_CMD_HEADER1) {
+			*state = TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE;
 			parserbuf[*parserbuf_index] = c;
 			(*parserbuf_index)++;
 
@@ -82,8 +97,18 @@ int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARS
 		break;
 
 	case TFMINI_PARSE_STATE::STATE0_UNSYNC:
-		if (c == 'Y') {
+		if (c == TFMINI_DATA_HEADER) {
 			*state = TFMINI_PARSE_STATE::STATE1_SYNC_1;
+			parserbuf[*parserbuf_index] = c;
+			(*parserbuf_index)++;
+
+		} else if (hw_model == TFMINI_MODEL::MODEL_TFMINI && c == TFMINI_CMD_HEADER1) {
+			*state = TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE;
+			parserbuf[*parserbuf_index] = c;
+			(*parserbuf_index)++;
+
+		} else if (hw_model == TFMINI_MODEL::MODEL_TFMINIPLUS && c == TFMINIPLUS_CMD_HEADER1) {
+			*state = TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE;
 			parserbuf[*parserbuf_index] = c;
 			(*parserbuf_index)++;
 		}
@@ -91,8 +116,18 @@ int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARS
 		break;
 
 	case TFMINI_PARSE_STATE::STATE1_SYNC_1:
-		if (c == 'Y') {
+		if (c == TFMINI_DATA_HEADER) {
 			*state = TFMINI_PARSE_STATE::STATE1_SYNC_2;
+			parserbuf[*parserbuf_index] = c;
+			(*parserbuf_index)++;
+
+		} else if (hw_model == TFMINI_MODEL::MODEL_TFMINI && c == TFMINI_CMD_HEADER1) {
+			*state = TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE;
+			parserbuf[*parserbuf_index] = c;
+			(*parserbuf_index)++;
+
+		} else if (hw_model == TFMINI_MODEL::MODEL_TFMINIPLUS && c == TFMINIPLUS_CMD_HEADER1) {
+			*state = TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE;
 			parserbuf[*parserbuf_index] = c;
 			(*parserbuf_index)++;
 
@@ -147,7 +182,7 @@ int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARS
 
 	case TFMINI_PARSE_STATE::STATE5_GOT_QUALITY:
 		// Find the checksum
-		unsigned char cksm = 0;
+		cksm = 0;
 
 		for (int i = 0; i < 8; i++) {
 			cksm += parserbuf[i];
@@ -155,11 +190,9 @@ int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARS
 
 		if (c == cksm) {
 			parserbuf[*parserbuf_index] = '\0';
-			unsigned int t1 = parserbuf[2];
-			unsigned int t2 = parserbuf[3];
-			t2 <<= 8;
-			t2 += t1;
-			*dist = ((float)t2) / 100;
+			*dist = static_cast<float>(parserbuf[2] + (parserbuf[3] << 8)) / 100.f;
+			*strength = parserbuf[4] + (parserbuf[5] << 8);
+			*temperature = static_cast<float>(parserbuf[6] + (parserbuf[7] << 8)) / 8.f - 256.f;
 			*state = TFMINI_PARSE_STATE::STATE6_GOT_CHECKSUM;
 			*parserbuf_index = 0;
 			ret = 0;
@@ -170,6 +203,67 @@ int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARS
 		}
 
 		break;
+
+	case TFMINI_PARSE_STATE::STATE7_GOT_COMMAND_RESPONSE:
+		parserbuf[*parserbuf_index] = c;
+		(*parserbuf_index)++;
+
+		// verify command line answers for tfmini
+		if (hw_model == TFMINI_MODEL::MODEL_TFMINI) {
+			if (parserbuf[1] != TFMINI_CMD_HEADER2) {
+				// discard first 2 bytes
+				*state = TFMINI_PARSE_STATE::STATE0_UNSYNC;
+				*parserbuf_index = 0;
+				break;
+			}
+
+			if ((*parserbuf_index) < TFMINI_CMD_SIZE) {
+				break;
+			}
+
+			*commandresponse_size = *parserbuf_index;
+			memcpy(commandresponse, parserbuf, *parserbuf_index);
+
+			*state = TFMINI_PARSE_STATE::STATE8_GOT_RESPONSE_CHECKSUM;
+			*parserbuf_index = 0;
+			break;
+		}
+
+		// verify command line answers for tfmini-plus
+		if (hw_model == TFMINI_MODEL::MODEL_TFMINIPLUS) {
+			if (*parserbuf_index < parserbuf[1]) {
+				break;
+			}
+
+			if (parserbuf[1] > 8) {
+				*state = TFMINI_PARSE_STATE::STATE0_UNSYNC;
+				*parserbuf_index = 0;
+				break;
+			}
+
+			// Find the checksum
+			cksm = 0;
+
+			for (uint8_t i = 0; i < (*parserbuf_index) - 1; i++) {
+				cksm += parserbuf[i];
+			}
+
+			if (c == cksm) {
+				*commandresponse_size = *parserbuf_index;
+				memcpy(commandresponse, parserbuf, *parserbuf_index);
+
+				*state = TFMINI_PARSE_STATE::STATE8_GOT_RESPONSE_CHECKSUM;
+				*parserbuf_index = 0;
+				break;
+			}
+
+			*state = TFMINI_PARSE_STATE::STATE0_UNSYNC;
+			*parserbuf_index = 0;
+			break;
+		}
+
+		break;
+
 	}
 
 #ifdef TFMINI_DEBUG

--- a/src/drivers/distance_sensor/tfmini/tfmini_parser.h
+++ b/src/drivers/distance_sensor/tfmini/tfmini_parser.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,19 +42,54 @@
 
 #pragma once
 
-// Data Format for Benewake TFmini
-// ===============================
-// 9 bytes total per message:
-// 1) 0x59
-// 2) 0x59
-// 3) Dist_L (low 8bit)
-// 4) Dist_H (high 8bit)
-// 5) Strength_L (low 8bit)
-// 6) Strength_H (high 8bit)
-// 7) Reserved bytes
-// 8) Original signal quality degree
-// 9) Checksum parity bit (low 8bit), Checksum = Byte1 + Byte2 +...+Byte8. This is only a low 8bit though
+#include <stdint.h>
+#include <stdlib.h>
 
+// Data Format for Benewake TFmini models
+// ======================================
+// 9 bytes total per message:
+// 0) 0x59
+// 1) 0x59
+// 2) Dist_L (low 8bit)
+// 3) Dist_H (high 8bit)
+// 4) Strength_L (low 8bit)
+// 5) Strength_H (high 8bit)
+// 6) Reserved bytes
+// 7) Original signal quality degree
+// 8) Checksum parity bit (low 8bit), Checksum = Byte1 + Byte2 +...+Byte8. This is only a low 8bit though
+
+// Command -and answers- Frame definitions for TFmini model
+// =============================================================
+// 8 bytes total per message:
+// 0) 0x42
+// 1) 0x57
+// 2) 0x02 by default
+// 3) 0x00 on sending - 0x01 or 0xFF or 0x0f on receiving
+// 4;5) EE FF double byte parameter, EE is low 8 bit; FF is high 8 bits
+// 6) GG single byte parameter
+// 7) HH instruction code
+
+// Command -and answers- Frame definitions for TFmini-plus model
+// =============================================================
+// 0) 0x5A
+// 1) Len: the total length of the frame（include Head and Checksum，unit: byte)
+// 2) ID: identifier code of command
+// 3;N-2) Data: data segment. Little endian format
+// N-1) Checksum: sum of all bytes from Head to payload. Lower 8 bits
+
+#define TFMINI_DATA_HEADER 0x59
+#define TFMINI_CMD_HEADER1 0x42
+#define TFMINI_CMD_HEADER2 0x57
+#define TFMINI_CMD_SIZE 8
+
+#define TFMINIPLUS_CMD_HEADER1 0x5A
+#define TFMINIPLUS_INVALID_MEASURE 0xFFFF
+
+enum class TFMINI_MODEL {
+	MODEL_UNKNOWN = 0,
+	MODEL_TFMINI,
+	MODEL_TFMINIPLUS
+};
 
 enum class TFMINI_PARSE_STATE {
 	STATE0_UNSYNC = 0,
@@ -66,7 +101,11 @@ enum class TFMINI_PARSE_STATE {
 	STATE3_GOT_STRENGTH_H,
 	STATE4_GOT_RESERVED,
 	STATE5_GOT_QUALITY,
-	STATE6_GOT_CHECKSUM
+	STATE6_GOT_CHECKSUM,
+	STATE7_GOT_COMMAND_RESPONSE,
+	STATE8_GOT_RESPONSE_CHECKSUM
 };
 
-int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARSE_STATE *state, float *dist);
+int tfmini_parse(uint8_t c, uint8_t *parserbuf, unsigned *parserbuf_index, TFMINI_PARSE_STATE *state,
+		 TFMINI_MODEL hw_model, float *dist, uint16_t *strength, float *temperature, uint8_t *commandresponse,
+		 uint8_t *commandresponse_size);


### PR DESCRIPTION
**Describe problem solved by this pull request**

* The first commit is fixing the FOV of TFMini model and removing an obsolete "tfmini test" command line description. Manual can be checked here: http://en.benewake.com/support_data?catename=03c54a91-8f9a-409f-985d-37acc68f7bf4&supportid=1324951b-e4d4-4594-9da9-fc76d72f98de&scroll=200
* The second commit improve to support various TFmini models and basic autosetup for TFMini-plus

**Describe your solution**

A new "tfmini command -c XXXXXX" is introduced to help device configuration
directly from the flight controler. TFMini and TFMini-plus are both supported.
    
The parser has been improved to support receiving confirmation from the device
after a command has been written.
    
The parameter SENS_EN_TFMINI is implemented again to let user define the TFMini
model that will be used. This helps to validate commands and validate command's answers.
    
SENS_EN_TFMINI is also required because TFMini models don't offer the same capabilities
for FOV and MIN-DISTANCE.
    
The parser has been improved to provide signal quality for TFMini-plus.
The same should be done in the future for TFMini model.
    
The driver has been improved to autoconfigure the mode AND enable the output for TFMini-plus upon starting.
The same should be done in the future for TFMini model.

**Describe possible alternatives**

The TFMini-plus has signal strength between 100 and 0xFFFF for valid values. However, from testing, values are usually between 100 and 20000 instead. The scaling may not be perfect, but I have decided to measure signal_quality (in percentage) as 100*strength/20000 instead of 100*strength/0xFFFF with maximum strength being 20000 instead of 0xFFFFF.

**Test data / coverage**

I have tested the patch on a drone with a flight controler running latest master branch, but without flying. I have no drone ready to fly. Most of the patch concerns configuration, so I don't feel this is critical. Of course, I hope someone can fly with the patch and report

I have implemented as much as I need about the TFMini-plus model, but I have decided to not write the autosetup for the TFMini model because I don't have the device. However, I could write it, if someone is willing to test it.

Here are some example of command lines that can be used to configure the TFmini-plus device using nsh:

    Retreive the version on a TFMINI-Plus: (0x5A 0x04 0x01 0x5F)
    $ tfmini command -c 5A04015F

    Configure TFMINI-Plus in Standard 9 bytes (cm) mode: (0x5A 0x05 0x05 0x01 0x65)
    $ tfmini command -c 5A05050165

    Configure TFMINI-Plus Frame Rate: (0x5A 0x06 0x03 0xLL 0xHH 0xSU) - Example for 100Hz
    $ tfmini command -c 5A06036400C7

    Apply and Save Settings for TFMINI-Plus: (0x5A 0x04 0x11 0x6F)
    $ tfmini command -c 5A04116F

