### PR TITLE
EKF2: blend GPS antenna offsets

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -860,6 +860,33 @@ PARAM_DEFINE_FLOAT(EKF2_GPS_POS_Y, 0.0f);
 PARAM_DEFINE_FLOAT(EKF2_GPS_POS_Z, 0.0f);
 
 /**
+ * X position of GPS2 antenna in body frame
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(EKF2_GPS2_POS_X, 0.0f);
+
+/**
+ * Y position of GPS2 antenna in body frame
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(EKF2_GPS2_POS_Y, 0.0f);
+
+/**
+ * Z position of GPS2 antenna in body frame
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(EKF2_GPS2_POS_Z, 0.0f);
+
+/**
  * X position of range finder origin in body frame
  *
  * @group EKF2


### PR DESCRIPTION
**Describe problem solved by this pull request**
Blends the GPS antenna offsets for a main and secondary GPS module, see https://github.com/PX4/Firmware/issues/13896

**Test data / coverage**
Not tested yet

**Additional context**
- Comes together with https://github.com/PX4/ecl/pull/707
- This code only supports two GPS modules
