### PR TITLE
mission: write next mission item into pos_sp_triplet->current if current mission item did not have position

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1081,7 +1081,15 @@ Mission::set_mission_items()
 		if (has_next_position_item) {
 			/* got next mission item, update setpoint triplet */
 			mission_apply_limitation(mission_item_next_position);
-			mission_item_to_position_setpoint(mission_item_next_position, &pos_sp_triplet->next);
+
+			if (pos_sp_triplet->current.valid) {
+				mission_item_to_position_setpoint(mission_item_next_position, &pos_sp_triplet->next);
+
+			} else {
+				mission_item_to_position_setpoint(mission_item_next_position, &pos_sp_triplet->current);
+				/* next mission item is not available */
+				pos_sp_triplet->next.valid = false;
+			}
 
 		} else {
 			/* next mission item is not available */


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/13668

I was only able to reproduce the issue described when the drone is already flying.

The problem is that, if a new mission begins and it's first item is a command, `Mission::set_mission_items()` will not write to `pos_sp_triplet->current`, but that was marked `invalid` by `reset_triplets()`.

`FlightTaskAuto` then goes into failsafe. 

https://github.com/PX4/Firmware/blob/master/src/modules/mc_pos_control/mc_pos_control_main.cpp#L564-L567

Additionally, depending on timing, the takeoff state machine uses NAN constraints to update its state, causing the state machine to fail to progress, which then makes it impossible to detect landing (we ~will make~ have a separate PR to guard against that:  https://github.com/PX4/Firmware/pull/13973).

https://github.com/PX4/Firmware/blob/master/src/modules/mc_pos_control/mc_pos_control_main.cpp#L598