### PR TITLE
input_rc: take command from the last input_rc received

### DIFF
--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -2293,3 +2293,21 @@ PARAM_DEFINE_INT32(RC_RSSI_PWM_MIN, 1000);
  *
  */
 PARAM_DEFINE_INT32(RC_RSSI_PWM_MAX, 2000);
+
+/**
+ * Use multiple RC inputs
+ *
+ * The default value of 0 allow RC command only from the first provider.
+ * Setting this to 1 allows RC commands from any provider to be used.
+ * Priority will be the instance indexes (instance 0 will have higher priority, then 1, etc).
+ * Warning, in this case, if radio control is lost and other RC commands are recieved (for example
+ * joysticks with COM_RC_IN_MODE = 2), RC lost fail safe will not be triggered.
+ * Warning: all rc inputs must have the same channels mapping
+ *
+ * @group Radio Calibration
+ * @min 0
+ * @max 1
+ * @value 0 Use only first input
+ * @value 1 Use the all RC inputs
+ */
+PARAM_DEFINE_INT32(RC_MULTIPLE_IN, 0);

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -89,6 +89,8 @@ public:
 
 	int print_status() override;
 
+	const float _RC_UNAVAIBLE_T = 0.2; // [s] allow search for input with less priority after this time without signal
+
 private:
 
 	void Run() override;
@@ -156,7 +158,14 @@ private:
 								because these parameters are never read. */
 	} _parameter_handles{};
 
-	uORB::SubscriptionCallbackWorkItem _input_rc_sub{this, ORB_ID(input_rc)};
+	static constexpr int MAX_INPUT_RC = 4;
+
+	uORB::SubscriptionCallbackWorkItem _input_rc_subs[MAX_INPUT_RC] {
+		{this, ORB_ID(input_rc), 0},
+		{this, ORB_ID(input_rc), 1},
+		{this, ORB_ID(input_rc), 2},
+		{this, ORB_ID(input_rc), 3}
+	};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -239,7 +248,9 @@ private:
 		(ParamFloat<px4::params::RC_MAN_TH>) _param_rc_man_th,
 		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
 
-		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt
+		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt,
+
+		(ParamInt<px4::params::RC_MULTIPLE_IN>) _param_rc_multiple_inputs
 	)
 };
 } /* namespace RCUpdate */


### PR DESCRIPTION
Before this commit, if there are multiple instances of input_rc topic, only the first one is used.
We have 2 companions for redundancy, if the first one fail the second one is not able to take over control because commands are published in another input_rc instance.

This commit allow to use the instance with the last rc command received (with a maximum of thee instances). 

