### PR TITLE
change mavlink_log from critical to info for battery state

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2106,7 +2106,7 @@ Commander::run()
 
 				_flight_termination_triggered = true;
 
-				mavlink_log_critical(&mavlink_log_pub, "Critical failure detected: terminate flight");
+				mavlink_log_emergency(&mavlink_log_pub, "Critical failure detected: terminate flight");
 				set_tune_override(TONE_PARACHUTE_RELEASE_TUNE);
 			}
 		}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -989,7 +989,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		break;
 
 	case battery_status_s::BATTERY_WARNING_LOW:
-		mavlink_log_critical(mavlink_log_pub, "Low battery level! Return advised");
+		mavlink_log_info(mavlink_log_pub, "Low battery level! Return advised");
 		break;
 
 	case battery_status_s::BATTERY_WARNING_CRITICAL:
@@ -998,7 +998,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 
 		switch (low_battery_action) {
 		case LOW_BAT_ACTION::WARNING:
-			mavlink_log_critical(mavlink_log_pub, "%s, landing advised", battery_critical);
+			mavlink_log_info(mavlink_log_pub, "%s, landing advised", battery_critical);
 			break;
 
 		case LOW_BAT_ACTION::RETURN:
@@ -1009,11 +1009,12 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 			if (status_flags.condition_global_position_valid && status_flags.condition_home_position_valid) {
 				internal_state->main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
 				internal_state->timestamp = hrt_absolute_time();
-				mavlink_log_critical(mavlink_log_pub, "%s, executing RTL", battery_critical);
+				mavlink_log_info(mavlink_log_pub, "%s, executing RTL", battery_critical);
 
 			} else {
 				internal_state->main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 				internal_state->timestamp = hrt_absolute_time();
+				// This warning is still sent out as an emergency because it is something critical if the user doesn't understand what is happening
 				mavlink_log_emergency(mavlink_log_pub, "%s, can't execute RTL, landing instead", battery_critical);
 			}
 
@@ -1022,7 +1023,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		case LOW_BAT_ACTION::LAND:
 			internal_state->main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 			internal_state->timestamp = hrt_absolute_time();
-			mavlink_log_emergency(mavlink_log_pub, "%s, landing", battery_critical);
+			mavlink_log_info(mavlink_log_pub, "%s, landing", battery_critical);
 
 			break;
 		}


### PR DESCRIPTION
This is only for BATTERY_WARNING_LOW and BATTERY_WARNING_CRITICAL states. BATTERY_WARNING_EMERGENCY stays the same for now since we don't have any better way of showing this in QGC.