### PR TITLE
Add support for MavlinkShell on Linux platform

### DIFF
--- a/boards/aerotenna/ocpoc/default.cmake
+++ b/boards/aerotenna/ocpoc/default.cmake
@@ -1,5 +1,7 @@
 add_definitions(
 	-D__PX4_LINUX
+
+	-D__PX4_LINUX_CONSOLE
 )
 
 px4_add_board(

--- a/boards/beaglebone/blue/default.cmake
+++ b/boards/beaglebone/blue/default.cmake
@@ -2,6 +2,7 @@ add_definitions(
 	-D__PX4_LINUX
 
 	-DRC_AUTOPILOT_EXT  # Enable extensions in Robotics Cape Library, TODO: remove
+	-D__PX4_LINUX_CONSOLE
 )
 
 px4_add_board(

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -1,5 +1,7 @@
 add_definitions(
 	-D__PX4_LINUX
+
+	-D__PX4_LINUX_CONSOLE
 )
 
 px4_add_board(

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -1,5 +1,7 @@
 add_definitions(
 	-D__PX4_LINUX
+
+	-D__PX4_LINUX_CONSOLE
 )
 
 px4_add_board(

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -1,7 +1,5 @@
 add_definitions(
 	-D__PX4_LINUX
-
-	-D__PX4_LINUX_CONSOLE
 )
 
 px4_add_board(

--- a/platforms/common/px4_log.cpp
+++ b/platforms/common/px4_log.cpp
@@ -45,7 +45,7 @@
 #include <px4_daemon/server_io.h>
 #endif
 
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 #include <px4_daemon/px4_console.h>
 #endif
 
@@ -95,14 +95,14 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		if (use_color) { fputs(__px4_log_level_color[level], out); }
 
 		fprintf(out, __px4__log_level_fmt __px4__log_level_arg(level));
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		dprintf(from_console_output_fd(1), __px4__log_level_fmt __px4__log_level_arg(level));
 #endif
 
 		if (use_color) { fputs(PX4_ANSI_COLOR_GRAY, out); }
 
 		fprintf(out, __px4__log_modulename_pfmt, moduleName);
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		dprintf(from_console_output_fd(1), __px4__log_modulename_pfmt, moduleName);
 #endif
 
@@ -111,7 +111,7 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		va_list argptr;
 		va_start(argptr, fmt);
 		vfprintf(out, fmt, argptr);
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		vdprintf(from_console_output_fd(1), fmt, argptr);
 #endif
 		va_end(argptr);
@@ -119,7 +119,7 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		if (use_color) { fputs(PX4_ANSI_COLOR_RESET, out); }
 
 		fputc('\n', out);
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		dprintf(from_console_output_fd(1), "\n");
 #endif
 	}
@@ -173,7 +173,7 @@ __EXPORT void px4_log_raw(int level, const char *fmt, ...)
 		va_list argptr;
 		va_start(argptr, fmt);
 		vfprintf(out, fmt, argptr);
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		vdprintf(from_console_output_fd(1), fmt, argptr);
 #endif
 		va_end(argptr);

--- a/platforms/common/px4_log.cpp
+++ b/platforms/common/px4_log.cpp
@@ -45,6 +45,10 @@
 #include <px4_daemon/server_io.h>
 #endif
 
+#ifdef __PX4_LINUX
+#include <px4_daemon/px4_console.h>
+#endif
+
 #include <uORB/uORB.h>
 #include <uORB/topics/log_message.h>
 #include <drivers/drv_hrt.h>
@@ -91,21 +95,33 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		if (use_color) { fputs(__px4_log_level_color[level], out); }
 
 		fprintf(out, __px4__log_level_fmt __px4__log_level_arg(level));
+#ifdef __PX4_LINUX
+		dprintf(from_console_output_fd(1), __px4__log_level_fmt __px4__log_level_arg(level));
+#endif
 
 		if (use_color) { fputs(PX4_ANSI_COLOR_GRAY, out); }
 
 		fprintf(out, __px4__log_modulename_pfmt, moduleName);
+#ifdef __PX4_LINUX
+		dprintf(from_console_output_fd(1), __px4__log_modulename_pfmt, moduleName);
+#endif
 
 		if (use_color) { fputs(__px4_log_level_color[level], out); }
 
 		va_list argptr;
 		va_start(argptr, fmt);
 		vfprintf(out, fmt, argptr);
+#ifdef __PX4_LINUX
+		vdprintf(from_console_output_fd(1), fmt, argptr);
+#endif
 		va_end(argptr);
 
 		if (use_color) { fputs(PX4_ANSI_COLOR_RESET, out); }
 
 		fputc('\n', out);
+#ifdef __PX4_LINUX
+		dprintf(from_console_output_fd(1), "\n");
+#endif
 	}
 
 	/* publish an orb log message */
@@ -157,6 +173,9 @@ __EXPORT void px4_log_raw(int level, const char *fmt, ...)
 		va_list argptr;
 		va_start(argptr, fmt);
 		vfprintf(out, fmt, argptr);
+#ifdef __PX4_LINUX
+		vdprintf(from_console_output_fd(1), fmt, argptr);
+#endif
 		va_end(argptr);
 
 		if (use_color) { fputs(PX4_ANSI_COLOR_RESET, out); }

--- a/platforms/common/px4_log.cpp
+++ b/platforms/common/px4_log.cpp
@@ -45,7 +45,7 @@
 #include <px4_daemon/server_io.h>
 #endif
 
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 #include <px4_daemon/px4_console.h>
 #endif
 
@@ -95,14 +95,14 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		if (use_color) { fputs(__px4_log_level_color[level], out); }
 
 		fprintf(out, __px4__log_level_fmt __px4__log_level_arg(level));
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		dprintf(from_console_output_fd(1), __px4__log_level_fmt __px4__log_level_arg(level));
 #endif
 
 		if (use_color) { fputs(PX4_ANSI_COLOR_GRAY, out); }
 
 		fprintf(out, __px4__log_modulename_pfmt, moduleName);
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		dprintf(from_console_output_fd(1), __px4__log_modulename_pfmt, moduleName);
 #endif
 
@@ -111,7 +111,7 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		va_list argptr;
 		va_start(argptr, fmt);
 		vfprintf(out, fmt, argptr);
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		vdprintf(from_console_output_fd(1), fmt, argptr);
 #endif
 		va_end(argptr);
@@ -119,7 +119,7 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 		if (use_color) { fputs(PX4_ANSI_COLOR_RESET, out); }
 
 		fputc('\n', out);
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		dprintf(from_console_output_fd(1), "\n");
 #endif
 	}
@@ -173,7 +173,7 @@ __EXPORT void px4_log_raw(int level, const char *fmt, ...)
 		va_list argptr;
 		va_start(argptr, fmt);
 		vfprintf(out, fmt, argptr);
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		vdprintf(from_console_output_fd(1), fmt, argptr);
 #endif
 		va_end(argptr);

--- a/platforms/posix/include/px4_daemon/px4_console.h
+++ b/platforms/posix/include/px4_daemon/px4_console.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file px4_console.h
+ *
+ * This interface is designed for MavlinkShell on Linux
+ *
+ * @author SalimTerryLi <lhf2613@gmail.com>
+ */
+#pragma once
+
+__BEGIN_DECLS
+
+/**
+ * Read from the fd returned by this call.
+ * Data from PX4_XXXX() will be stored in this pipe until MavlinkShell reads.
+ *
+ * @return The fd which acts as stdout.
+ */
+__EXPORT int from_console_output_fd(int index);
+
+/**
+ * Write to the fd returned by this call.
+ * Data will be stored in this pipe until pxh processes.
+ *
+ * @return The fd which acts as stdin.
+ */
+__EXPORT int to_console_input_fd(int index);
+
+__END_DECLS

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -430,7 +430,7 @@ void register_sig_handler()
 void sig_int_handler(int sig_num)
 {
 	fflush(stdout);
-	printf("\nPX4 Exiting...\n");
+	PX4_INFO_RAW("\nPX4 Exiting...\n");
 	fflush(stdout);
 	px4_daemon::Pxh::stop();
 	_exit_requested = true;
@@ -439,7 +439,7 @@ void sig_int_handler(int sig_num)
 void sig_fpe_handler(int sig_num)
 {
 	fflush(stdout);
-	printf("\nfloating point exception\n");
+	PX4_INFO_RAW("\nfloating point exception\n");
 	fflush(stdout);
 	px4_daemon::Pxh::stop();
 	_exit_requested = true;
@@ -556,22 +556,22 @@ void wait_to_exit()
 
 void print_usage()
 {
-	printf("Usage for Server/daemon process: \n");
-	printf("\n");
-	printf("    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [<rootfs_directory>] [-i <instance>] [-w <working_directory>]\n");
-	printf("\n");
-	printf("    -s <startup_file>      shell script to be used as startup (default=etc/init.d/rcS)\n");
-	printf("    <rootfs_directory>     directory where startup files and mixers are located,\n");
-	printf("                           (if not given, CWD is used)\n");
-	printf("    -i <instance>          px4 instance id to run multiple instances [0...N], default=0\n");
-	printf("    -w <working_directory> directory to change to\n");
-	printf("    -h                     help/usage information\n");
-	printf("    -d                     daemon mode, don't start pxh shell\n");
-	printf("\n");
-	printf("Usage for client: \n");
-	printf("\n");
-	printf("    px4-MODULE [--instance <instance>] command using symlink.\n");
-	printf("        e.g.: px4-commander status\n");
+	PX4_INFO_RAW("Usage for Server/daemon process: \n");
+	PX4_INFO_RAW("\n");
+	PX4_INFO_RAW("    px4 [-h|-d] [-s <startup_file>] [-t <test_data_directory>] [<rootfs_directory>] [-i <instance>] [-w <working_directory>]\n");
+	PX4_INFO_RAW("\n");
+	PX4_INFO_RAW("    -s <startup_file>      shell script to be used as startup (default=etc/init.d/rcS)\n");
+	PX4_INFO_RAW("    <rootfs_directory>     directory where startup files and mixers are located,\n");
+	PX4_INFO_RAW("                           (if not given, CWD is used)\n");
+	PX4_INFO_RAW("    -i <instance>          px4 instance id to run multiple instances [0...N], default=0\n");
+	PX4_INFO_RAW("    -w <working_directory> directory to change to\n");
+	PX4_INFO_RAW("    -h                     help/usage information\n");
+	PX4_INFO_RAW("    -d                     daemon mode, don't start pxh shell\n");
+	PX4_INFO_RAW("\n");
+	PX4_INFO_RAW("Usage for client: \n");
+	PX4_INFO_RAW("\n");
+	PX4_INFO_RAW("    px4-MODULE [--instance <instance>] command using symlink.\n");
+	PX4_INFO_RAW("        e.g.: px4-commander status\n");
 }
 
 bool is_server_running(int instance, bool server)

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -74,6 +74,9 @@
 #include "px4_daemon/client.h"
 #include "px4_daemon/server.h"
 #include "px4_daemon/pxh.h"
+#ifdef __PX4_LINUX
+#include "px4_daemon/console.h"
+#endif
 
 #define MODULE_NAME "px4"
 
@@ -175,6 +178,15 @@ int main(int argc, char **argv)
 		return client.process_args(argc, (const char **)argv);
 
 	} else {
+#ifdef __PX4_LINUX
+
+		if (px4_console::prepare_fds() != 0) {
+			PX4_ERR("failed to prepare console fd");
+			return -1;
+		}
+
+		atexit(px4_console::clean_fds);
+#endif
 		/* Server/daemon apps need to parse the command line arguments. */
 
 		std::string data_path{};
@@ -281,6 +293,9 @@ int main(int argc, char **argv)
 		}
 
 		px4::init_once();
+#ifdef __PX4_LINUX
+		px4_console::launch_thread();
+#endif
 		px4::init(argc, argv, "px4");
 
 		ret = run_startup_script(commands_file, absolute_binary_path, instance);
@@ -305,6 +320,10 @@ int main(int argc, char **argv)
 		// TODO: we should check with px4_task_is_running("muorb") before stopping it.
 		std::string muorb_stop_cmd("muorb stop");
 		px4_daemon::Pxh::process_line(muorb_stop_cmd, true);
+#endif
+
+#ifdef __PX4_LINUX
+		px4_console::stop_thread();
 #endif
 
 		std::string cmd("shutdown");

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -74,7 +74,7 @@
 #include "px4_daemon/client.h"
 #include "px4_daemon/server.h"
 #include "px4_daemon/pxh.h"
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 #include "px4_daemon/console.h"
 #endif
 
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 		return client.process_args(argc, (const char **)argv);
 
 	} else {
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 
 		if (px4_console::prepare_fds() != 0) {
 			PX4_ERR("failed to prepare console fd");
@@ -293,7 +293,7 @@ int main(int argc, char **argv)
 		}
 
 		px4::init_once();
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		px4_console::launch_thread();
 #endif
 		px4::init(argc, argv, "px4");
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
 		px4_daemon::Pxh::process_line(muorb_stop_cmd, true);
 #endif
 
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		px4_console::stop_thread();
 #endif
 

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -74,7 +74,7 @@
 #include "px4_daemon/client.h"
 #include "px4_daemon/server.h"
 #include "px4_daemon/pxh.h"
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 #include "px4_daemon/console.h"
 #endif
 
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
 		return client.process_args(argc, (const char **)argv);
 
 	} else {
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 
 		if (px4_console::prepare_fds() != 0) {
 			PX4_ERR("failed to prepare console fd");
@@ -293,7 +293,7 @@ int main(int argc, char **argv)
 		}
 
 		px4::init_once();
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		px4_console::launch_thread();
 #endif
 		px4::init(argc, argv, "px4");
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
 		px4_daemon::Pxh::process_line(muorb_stop_cmd, true);
 #endif
 
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		px4_console::stop_thread();
 #endif
 

--- a/platforms/posix/src/px4/common/px4_daemon/CMakeLists.txt
+++ b/platforms/posix/src/px4/common/px4_daemon/CMakeLists.txt
@@ -38,5 +38,6 @@ px4_add_library(px4_daemon
 		server.cpp
 		server_io.cpp
 		sock_protocol.cpp
+		console.cpp
 	)
 

--- a/platforms/posix/src/px4/common/px4_daemon/console.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/console.cpp
@@ -36,7 +36,7 @@
  * @author SalimTerryLi <lhf2613@gmail.com>
  */
 
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 
 #include <unistd.h>
 #include <fcntl.h>

--- a/platforms/posix/src/px4/common/px4_daemon/console.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/console.cpp
@@ -93,6 +93,9 @@ int px4_console::prepare_fds()
 
 	fcntl(_sys_stdin_backup, F_SETFL, fcntl(_sys_stdin_backup, F_GETFL) | O_NONBLOCK);	// set stdin non blocking
 
+	fcntl(_mavshell_out_pipe[1], F_SETFL, fcntl(_mavshell_out_pipe[1],
+			F_GETFL) | O_NONBLOCK);	// prevent write blocking if pipe is full
+
 	ret = dup2(_fake_stdin_pipe[0], 0);	// override stdin
 
 	if (ret == -1) {

--- a/platforms/posix/src/px4/common/px4_daemon/console.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/console.cpp
@@ -36,7 +36,7 @@
  * @author SalimTerryLi <lhf2613@gmail.com>
  */
 
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 
 #include <unistd.h>
 #include <fcntl.h>

--- a/platforms/posix/src/px4/common/px4_daemon/console.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/console.cpp
@@ -1,0 +1,224 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file console.cpp
+ *
+ * @author SalimTerryLi <lhf2613@gmail.com>
+ */
+
+#ifdef __PX4_LINUX
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <poll.h>
+
+#include <px4_platform_common/tasks.h>
+#include <px4_platform_common/log.h>
+
+#include "console.h"
+#include <px4_daemon/px4_console.h>
+
+using namespace px4_console;
+
+int px4_console::_fake_stdin_pipe[2] = {-1, -1};
+int px4_console::_mavshell_out_pipe[2] = {-1, -1};
+int px4_console::_sys_stdin_backup = -1;
+
+px4_task_t _task;
+int _thread_should_exit_pipe[2] = {-1, -1};
+
+int from_console_output_fd(int index)
+{
+	return px4_console::_mavshell_out_pipe[index];
+}
+
+int to_console_input_fd(int index)
+{
+	return px4_console::_fake_stdin_pipe[index];
+}
+
+int px4_console::prepare_fds()
+{
+	int ret = 0;
+	ret = pipe(_fake_stdin_pipe);
+
+	if (ret == -1) {
+		return -errno;
+	}
+
+	ret = pipe(_mavshell_out_pipe);
+
+	if (ret == -1) {
+		clean_fds();
+		return -errno;
+	}
+
+	_sys_stdin_backup = dup(0);	// backup stdin
+
+	if (_sys_stdin_backup == -1) {
+		clean_fds();
+		return -errno;
+	}
+
+	fcntl(_sys_stdin_backup, F_SETFL, fcntl(_sys_stdin_backup, F_GETFL) | O_NONBLOCK);	// set stdin non blocking
+
+	ret = dup2(_fake_stdin_pipe[0], 0);	// override stdin
+
+	if (ret == -1) {
+		clean_fds();
+		return -errno;
+	}
+
+	return 0;
+}
+
+void px4_console::clean_fds()
+{
+	for (int i = 0; i < 2; ++i) {
+		if (_fake_stdin_pipe[i] >= 0) {
+			close(_fake_stdin_pipe[i]);
+			_fake_stdin_pipe[i] = -1;
+		}
+
+		if (_mavshell_out_pipe[i] >= 0) {
+			close(_mavshell_out_pipe[i]);
+			_mavshell_out_pipe[i] = -1;
+		}
+	}
+
+	if (_sys_stdin_backup >= 0) {
+		fcntl(_sys_stdin_backup, F_SETFL, fcntl(_sys_stdin_backup, F_GETFL) & ~O_NONBLOCK);	// reset stdin
+		dup2(_sys_stdin_backup, 0);	// reset stdin
+		close(_sys_stdin_backup);
+		_sys_stdin_backup = -1;
+	}
+}
+
+int console_thread(int argc, char *argv[])
+{
+	int ret = 0;
+	ret = pipe(_thread_should_exit_pipe);	// create signal pipe
+
+	if (ret == -1) {
+		// no more we can do.
+		PX4_ERR("failed to create pipe: %d", errno);
+		return -1;
+	}
+
+	while (true) {
+		pollfd fds[2];
+		fds[0].fd = _thread_should_exit_pipe[0];	// should exit
+		fds[0].events = POLLIN;
+		fds[1].fd = _sys_stdin_backup;	// capture stdin
+		fds[1].events = POLLIN;
+		ret = poll(fds, 2, -1);
+
+		if (ret == -1) {
+			if (errno == EINTR) {
+				continue;
+
+			} else {
+				// undefined behavior
+				PX4_ERR("poll failed");
+				break;
+			}
+		}
+
+		if (fds[0].revents == POLLIN) {
+			break;
+		}
+
+		if (fds[1].revents == POLLIN) {
+			char tmp[32];
+			ret = read(fds[1].fd, tmp, 32);
+
+			if (ret == 0) {	// EOF
+				// TODO: handle this
+			} else if (ret == -1) {
+				if (errno == EINTR) {
+					continue;
+
+				} else {
+					// this should not happen
+					PX4_ERR("failed to read from stdin");
+				}
+
+			} else {
+				ret = write(_fake_stdin_pipe[1], tmp, ret);
+
+				if (ret == -1) {
+					PX4_ERR("failed to write back to stdin");
+				}
+			}
+		}
+	}
+
+	close(_thread_should_exit_pipe[0]);
+	close(_thread_should_exit_pipe[1]);
+	_thread_should_exit_pipe[0] = -1;
+	_thread_should_exit_pipe[1] = -1;
+
+	return 0;
+}
+
+int px4_console::launch_thread()
+{
+	_task = px4_task_spawn_cmd("px4_console",
+				   SCHED_DEFAULT,
+				   SCHED_PRIORITY_DEFAULT,
+				   2048,
+				   &console_thread,
+				   nullptr);
+
+	if (_task < 0) {
+		PX4_ERR("failed to launch console thread");
+		return -1;
+	}
+
+	return 0;
+}
+
+void px4_console::stop_thread()
+{
+	if (_thread_should_exit_pipe[1] >= 0) {
+		char tmp = '\0';
+		int ret = write(_thread_should_exit_pipe[1], &tmp, 1);
+
+		if (ret == -1) {
+			PX4_ERR("failed to send exit signal");
+		}
+	}
+}
+
+#endif	// #ifdef __PX4_LINUX

--- a/platforms/posix/src/px4/common/px4_daemon/console.h
+++ b/platforms/posix/src/px4/common/px4_daemon/console.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file comsole.h
+ *
+ * @author SalimTerryLi <lhf2613@gmail.com>
+ */
+#pragma once
+
+namespace px4_console
+{
+extern int _fake_stdin_pipe[2];
+extern int _mavshell_out_pipe[2];
+extern int _sys_stdin_backup;
+
+int prepare_fds();
+void clean_fds();
+
+int launch_thread();
+void stop_thread();
+} // namespace px4_console

--- a/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 #include <stdio.h>
 
+#include <px4_platform_common/log.h>
 #include "pxh.h"
 
 namespace px4_daemon
@@ -107,7 +108,7 @@ int Pxh::process_line(const std::string &line, bool silently_fail)
 
 		if (retval) {
 			if (!silently_fail) {
-				printf("Command '%s' failed, returned %d.\n", command.c_str(), retval);
+				PX4_INFO_RAW("Command '%s' failed, returned %d.\n", command.c_str(), retval);
 			}
 		}
 
@@ -123,7 +124,7 @@ int Pxh::process_line(const std::string &line, bool silently_fail)
 
 	} else if (!silently_fail) {
 		//std::cout << "Invalid command: " << command << "\ntype 'help' for a list of commands" << endl;
-		printf("Invalid command: %s\ntype 'help' for a list of commands\n", command.c_str());
+		PX4_INFO_RAW("Invalid command: %s\ntype 'help' for a list of commands\n", command.c_str());
 		return -1;
 
 	} else {
@@ -166,7 +167,7 @@ void Pxh::run_pxh()
 			_history.try_to_add(mystr);
 			_history.reset_to_end();
 
-			printf("\n");
+			PX4_INFO_RAW("\n");
 			process_line(mystr, false);
 			// reset string and cursor position
 			mystr = "";
@@ -234,7 +235,7 @@ void Pxh::run_pxh()
 			mystr.insert(mystr.length() - cursor_position, add_string);
 			_clear_line();
 			_print_prompt();
-			printf("%s", mystr.c_str());
+			PX4_INFO_RAW("%s", mystr.c_str());
 
 			// Move the cursor to its position
 			if (cursor_position > 0) {
@@ -278,18 +279,18 @@ void Pxh::_restore_term()
 
 void Pxh::_print_prompt()
 {
-	fflush(stdout);
-	printf("pxh> ");
-	fflush(stdout);
+	//fflush(stdout);
+	PX4_INFO_RAW("pxh> ");
+	//fflush(stdout);
 }
 
 void Pxh::_clear_line()
 {
-	printf("%c[2K%c", (char)27, (char)13);
+	PX4_INFO_RAW("%c[2K%c", (char)27, (char)13);
 }
 void Pxh::_move_cursor(int position)
 {
-	printf("\033[%dD", position);
+	PX4_INFO_RAW("\033[%dD", position);
 }
 
 } // namespace px4_daemon

--- a/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
@@ -259,7 +259,7 @@ void Pxh::stop()
 void Pxh::_setup_term()
 {
 	int terminalfd = 0;
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 	terminalfd = px4_console::_sys_stdin_backup == -1 ? 0 : px4_console::_sys_stdin_backup;
 #endif
 	// Make sure we restore terminal at exit.
@@ -279,7 +279,7 @@ void Pxh::_restore_term()
 {
 	if (_instance) {
 		int terminalfd = 0;
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 		terminalfd = px4_console::_sys_stdin_backup == -1 ? 0 : px4_console::_sys_stdin_backup;
 #endif
 		tcsetattr(terminalfd, TCSANOW, &_instance->_orig_term);

--- a/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
@@ -259,7 +259,7 @@ void Pxh::stop()
 void Pxh::_setup_term()
 {
 	int terminalfd = 0;
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 	terminalfd = px4_console::_sys_stdin_backup == -1 ? 0 : px4_console::_sys_stdin_backup;
 #endif
 	// Make sure we restore terminal at exit.
@@ -279,7 +279,7 @@ void Pxh::_restore_term()
 {
 	if (_instance) {
 		int terminalfd = 0;
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 		terminalfd = px4_console::_sys_stdin_backup == -1 ? 0 : px4_console::_sys_stdin_backup;
 #endif
 		tcsetattr(terminalfd, TCSANOW, &_instance->_orig_term);

--- a/platforms/posix/src/px4/common/px4_posix_impl.cpp
+++ b/platforms/posix/src/px4/common/px4_posix_impl.cpp
@@ -77,16 +77,16 @@ void init_once()
 
 void init(int argc, char *argv[], const char *app_name)
 {
-	printf("\n");
-	printf("______  __   __    ___ \n");
-	printf("| ___ \\ \\ \\ / /   /   |\n");
-	printf("| |_/ /  \\ V /   / /| |\n");
-	printf("|  __/   /   \\  / /_| |\n");
-	printf("| |     / /^\\ \\ \\___  |\n");
-	printf("\\_|     \\/   \\/     |_/\n");
-	printf("\n");
-	printf("%s starting.\n", app_name);
-	printf("\n");
+	PX4_INFO_RAW("\n");
+	PX4_INFO_RAW("______  __   __    ___ \n");
+	PX4_INFO_RAW("| ___ \\ \\ \\ / /   /   |\n");
+	PX4_INFO_RAW("| |_/ /  \\ V /   / /| |\n");
+	PX4_INFO_RAW("|  __/   /   \\  / /_| |\n");
+	PX4_INFO_RAW("| |     / /^\\ \\ \\___  |\n");
+	PX4_INFO_RAW("\\_|     \\/   \\/     |_/\n");
+	PX4_INFO_RAW("\n");
+	PX4_INFO_RAW("%s starting.\n", app_name);
+	PX4_INFO_RAW("\n");
 
 	// set the threads name
 #ifdef __PX4_DARWIN

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -50,7 +50,7 @@
 #include <nshlib/nshlib.h>
 #endif /* __PX4_NUTTX */
 
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 #include <px4_daemon/px4_console.h>
 #endif
 
@@ -60,7 +60,7 @@
 
 MavlinkShell::~MavlinkShell()
 {
-#ifndef __PX4_LINUX_CONSOLE
+#ifndef __PX4_LINUX
 
 	//closing the pipes will stop the thread as well
 	if (_to_shell_fd >= 0) {
@@ -154,7 +154,7 @@ int MavlinkShell::start()
 	return ret;
 #endif /* __PX4_NUTTX */
 
-#ifdef __PX4_LINUX_CONSOLE
+#ifdef __PX4_LINUX
 	_to_shell_fd = to_console_input_fd(1);
 	_from_shell_fd = from_console_output_fd(0);
 	return 0;
@@ -164,7 +164,7 @@ int MavlinkShell::start()
 
 int MavlinkShell::shell_start_thread(int argc, char *argv[])
 {
-#ifndef __PX4_LINUX_CONSOLE
+#ifndef __PX4_LINUX
 	dup2(1, 2); //redirect stderror to stdout
 #endif
 

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -50,7 +50,7 @@
 #include <nshlib/nshlib.h>
 #endif /* __PX4_NUTTX */
 
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 #include <px4_daemon/px4_console.h>
 #endif
 
@@ -60,7 +60,7 @@
 
 MavlinkShell::~MavlinkShell()
 {
-#ifndef __PX4_LINUX
+#ifndef __PX4_LINUX_CONSOLE
 
 	//closing the pipes will stop the thread as well
 	if (_to_shell_fd >= 0) {
@@ -154,7 +154,7 @@ int MavlinkShell::start()
 	return ret;
 #endif /* __PX4_NUTTX */
 
-#ifdef __PX4_LINUX
+#ifdef __PX4_LINUX_CONSOLE
 	_to_shell_fd = to_console_input_fd(1);
 	_from_shell_fd = from_console_output_fd(0);
 	return 0;
@@ -164,7 +164,7 @@ int MavlinkShell::start()
 
 int MavlinkShell::shell_start_thread(int argc, char *argv[])
 {
-#ifndef __PX4_LINUX
+#ifndef __PX4_LINUX_CONSOLE
 	dup2(1, 2); //redirect stderror to stdout
 #endif
 

--- a/src/modules/mavlink/mavlink_shell.h
+++ b/src/modules/mavlink/mavlink_shell.h
@@ -81,8 +81,10 @@ private:
 
 	int _to_shell_fd = -1; /** fd to write to the shell */
 	int _from_shell_fd = -1; /** fd to read from the shell */
+#ifdef __PX4_NUTTX
 	int _shell_fds[2] = { -1, -1}; /** stdin & out used by the shell */
 	px4_task_t _task;
+#endif
 
 	static int shell_start_thread(int argc, char *argv[]);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR enables MavlinkShell on Linux based boards like RPi.

**Describe your solution**
A new thread is launched to capture and duplicate stdin.
Add extra codes in `px4_log.cpp` to duplicate stdout.

QGC doesn't deal with control characters so each `_print_prompt()` would mess up the latest line in QGC.

**Describe possible alternatives**
Better implement can only be achieved if the whole pxh is designed in another way which is similar to pty.(maybe)

**Test data / coverage**
Works on RPi. Screenshots here.
![pr-mavshell](https://user-images.githubusercontent.com/10492472/76734238-73e2ef00-679d-11ea-8292-0b167b410453.png)