### PR TITLE
Add CLI tests for basic soak testing

### DIFF
--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ set(srcs
 	test_uart_loopback.c
 	test_uart_send.c
 	test_versioning.cpp
+	test_cli.c
 	tests_main.c
 	)
 

--- a/src/systemcmds/tests/test_cli.c
+++ b/src/systemcmds/tests/test_cli.c
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ *  Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file test_uart_send.c
+ * Tests the uart send functionality.
+ *
+ * @author Lorenz Meier <lorenz@px4.io>
+ */
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
+
+#include <sys/types.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "tests_main.h"
+
+#ifdef PX4_NUTTX
+#define _px4_system(command) system(command)
+#else
+#define _px4_system(command) system("px4-"command)
+#endif
+
+int test_cli(int argc, char *argv[])
+{
+	// This is not a fully built out test
+	// suite yet and is more of a soak
+	// test to ensure that the command exists
+
+	// Run the commander CLI
+	if (_px4_system("commander start")) { return PX4_ERROR; }
+
+	if (_px4_system("commander check")) { return PX4_ERROR; }
+
+	if (_px4_system("commander stop")) { return PX4_ERROR; }
+
+	return 0;
+}

--- a/src/systemcmds/tests/test_cli.c
+++ b/src/systemcmds/tests/test_cli.c
@@ -49,7 +49,7 @@
 
 #include "tests_main.h"
 
-#ifdef PX4_NUTTX
+#ifdef __PX4_NUTTX
 #define _px4_system(command) system(command)
 #else
 #define _px4_system(command) system("px4-"command)
@@ -57,6 +57,7 @@
 
 int test_cli(int argc, char *argv[])
 {
+#ifndef __PX4_NUTTX
 	// This is not a fully built out test
 	// suite yet and is more of a soak
 	// test to ensure that the command exists
@@ -67,6 +68,8 @@ int test_cli(int argc, char *argv[])
 	if (_px4_system("commander check")) { return PX4_ERROR; }
 
 	if (_px4_system("commander stop")) { return PX4_ERROR; }
+
+#endif
 
 	return 0;
 }

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -116,7 +116,7 @@ const struct {
 	{"uart_loopback",	test_uart_loopback,	OPT_NOJIGTEST | OPT_NOALLTEST},
 	{"uart_send",		test_uart_send,		OPT_NOJIGTEST | OPT_NOALLTEST},
 	{"versioning",		test_versioning,	0},
-
+	{"cli",			test_cli,		0},
 
 	/* external tests */
 	{"commander",		commander_tests_main,	0},

--- a/src/systemcmds/tests/tests_main.h
+++ b/src/systemcmds/tests/tests_main.h
@@ -87,6 +87,7 @@ extern int test_uart_console(int argc, char *argv[]);
 extern int test_uart_loopback(int argc, char *argv[]);
 extern int test_uart_send(int argc, char *argv[]);
 extern int test_versioning(int argc, char *argv[]);
+extern int test_cli(int argc, char *argv[]);
 
 /* external */
 extern int commander_tests_main(int argc, char *argv[]);


### PR DESCRIPTION
This is in no way a complete test suite but is intended as a starting point to get minimal
test coverage for CLI handling tests in. This is necessary to QA the CLI handling
(e.g. removal of commands) and to ensure that we are exercising these code paths in
stack check and alike tests.