### PR TITLE
Enhancement: More calibration related parameters are preserved when o…

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -153,7 +153,7 @@ else
 		if param compare SYS_AUTOCONFIG 1
 		then
 			# Wipe out params except RC*, flight modes, total flight time, accel cal, gyro cal, next flight UUID
-			param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO* COM_FLIGHT_UUID
+			param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_MAG* CAL_GYRO* SENS_BOARD* EKF2_MAGBIAS* COM_FLIGHT_UUID
 		fi
 
 		set AUTOCNF yes


### PR DESCRIPTION
**Describe problem solved by this pull request**
Current rcS script invalidated magnetometer calibration data when SYS_AUTOCONFIG sets to 1 with AUTOSTART number given.

**Describe your solution**
More calibration related parameters are preserved when only autoconfig reset happened. Current setup makes magnetometer and offset data invalidated.