### PR TITLE
add PX4_NO_OPTIMIZATION for vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -221,6 +221,7 @@
                 "env": {
                     "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "PX4_NO_OPTIMIZATION": "px4;^modules__uORB;^modules__systemlib$",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },
@@ -261,6 +262,7 @@
                 "env": {
                     "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "PX4_NO_OPTIMIZATION": "px4;^modules__uORB;^modules__systemlib$",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -98,6 +98,7 @@
                 "env": {
                     "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "PX4_NO_OPTIMIZATION": "px4;^modules__uORB;^modules__systemlib$",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },
@@ -138,6 +139,7 @@
                 "env": {
                     "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "PX4_NO_OPTIMIZATION": "px4;^modules__uORB;^modules__systemlib$",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },
@@ -178,6 +180,7 @@
                 "env": {
                     "GAZEBO_PLUGIN_PATH": "${workspaceRoot}/build/px4_sitl_default/build_gazebo",
                     "GAZEBO_MODEL_PATH": "${workspaceRoot}/Tools/sitl_gazebo/models",
+                    "PX4_NO_OPTIMIZATION": "px4;^modules__uORB;^modules__systemlib$",
                     "PX4_SIM_SPEED_FACTOR": "1"
                 }
             },


### PR DESCRIPTION
if user set environment variable PX4_NO_OPTIMIZATION, it can't work in VS Code.
need to set it in tasks.json.