### PR TITLE
px4io: move to WQ to reduce control latency

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -16,9 +16,7 @@ then
 	then
 		# Allow PX4IO to recover from midair restarts.
 		px4io recovery
-	
-		# Adjust PX4IO update rate limit.
-		px4io limit 400
+
 	else
 		echo "PX4IO start failed" >> $LOG_FILE
 		tune_control play -t 20

--- a/boards/holybro/durandal-v1/src/board_config.h
+++ b/boards/holybro/durandal-v1/src/board_config.h
@@ -54,8 +54,6 @@
  ****************************************************************************************************/
 
 /* PX4IO connection configuration */
-
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS6"
 #define PX4IO_SERIAL_TX_GPIO           GPIO_UART8_TX
 #define PX4IO_SERIAL_RX_GPIO           GPIO_UART8_RX

--- a/boards/mro/x21-777/src/board_config.h
+++ b/boards/mro/x21-777/src/board_config.h
@@ -54,8 +54,6 @@
  ****************************************************************************************************/
 
 /* PX4IO connection configuration */
-
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS4"
 #define PX4IO_SERIAL_TX_GPIO           GPIO_USART6_TX
 #define PX4IO_SERIAL_RX_GPIO           GPIO_USART6_RX

--- a/boards/mro/x21/src/board_config.h
+++ b/boards/mro/x21/src/board_config.h
@@ -53,7 +53,6 @@
 /* Configuration ************************************************************************************/
 
 /* PX4IO connection configuration */
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE	"/dev/ttyS4"
 #define PX4IO_SERIAL_TX_GPIO	GPIO_USART6_TX
 #define PX4IO_SERIAL_RX_GPIO	GPIO_USART6_RX
@@ -139,6 +138,7 @@
 #define BOARD_HAS_ON_RESET 1
 
 #define BOARD_HAS_STATIC_MANIFEST 1
+#define PX4_MFT_HW_SUPPORTED_PX4_MFT_PX4IO 1
 
 __BEGIN_DECLS
 

--- a/boards/nxp/fmurt1062-v1/src/board_config.h
+++ b/boards/nxp/fmurt1062-v1/src/board_config.h
@@ -61,7 +61,6 @@
 
 #if 0 // There is no PX4IO Support on first out
 // This requires serial DMA driver
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS6"
 #define PX4IO_SERIAL_TX_GPIO           GPIO_LPUART8_TX_2
 #define PX4IO_SERIAL_RX_GPIO           GPIO_LPUART8_RX_2

--- a/boards/px4/fmu-v2/src/board_config.h
+++ b/boards/px4/fmu-v2/src/board_config.h
@@ -68,7 +68,6 @@
 /* Configuration ************************************************************************************/
 
 /* PX4IO connection configuration */
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE	"/dev/ttyS4"
 #define PX4IO_SERIAL_TX_GPIO	GPIO_USART6_TX
 #define PX4IO_SERIAL_RX_GPIO	GPIO_USART6_RX

--- a/boards/px4/fmu-v3/src/board_config.h
+++ b/boards/px4/fmu-v3/src/board_config.h
@@ -68,7 +68,6 @@
 /* Configuration ************************************************************************************/
 
 /* PX4IO connection configuration */
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE	"/dev/ttyS4"
 #define PX4IO_SERIAL_TX_GPIO	GPIO_USART6_TX
 #define PX4IO_SERIAL_RX_GPIO	GPIO_USART6_RX

--- a/boards/px4/fmu-v4pro/src/board_config.h
+++ b/boards/px4/fmu-v4pro/src/board_config.h
@@ -52,7 +52,6 @@
  ****************************************************************************************************/
 
 /* PX4IO connection configuration */
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE     "/dev/ttyS4"
 #define PX4IO_SERIAL_TX_GPIO    GPIO_USART6_TX
 #define PX4IO_SERIAL_RX_GPIO    GPIO_USART6_RX
@@ -204,6 +203,7 @@
 #define BOARD_HAS_ON_RESET 1
 
 #define BOARD_HAS_STATIC_MANIFEST 1
+#define PX4_MFT_HW_SUPPORTED_PX4_MFT_PX4IO 1
 
 __BEGIN_DECLS
 

--- a/boards/px4/fmu-v5/src/board_config.h
+++ b/boards/px4/fmu-v5/src/board_config.h
@@ -54,8 +54,6 @@
  ****************************************************************************************************/
 
 /* PX4IO connection configuration */
-
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS6"
 #define PX4IO_SERIAL_TX_GPIO           GPIO_UART8_TX
 #define PX4IO_SERIAL_RX_GPIO           GPIO_UART8_RX

--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -54,8 +54,6 @@
  ****************************************************************************************************/
 
 /* PX4IO connection configuration */
-
-#define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS5"
 #define PX4IO_SERIAL_TX_GPIO           GPIO_USART6_TX
 #define PX4IO_SERIAL_RX_GPIO           GPIO_USART6_RX

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -201,26 +201,6 @@
 #define BOARD_BATTERY2_A_PER_V 0.0f
 #endif
 
-/* Conditional use of PX4 PIO is Used to determine if the board
- * has a PX4IO processor.
- * We then publish the logical BOARD_USES_PX4IO
- */
-#if defined(BOARD_USES_PX4IO_VERSION)
-#  define BOARD_USES_PX4IO	1
-#  if defined(BOARD_HAS_STATIC_MANIFEST) && BOARD_HAS_STATIC_MANIFEST == 1
-#     define PX4_MFT_HW_SUPPORTED_PX4_MFT_PX4IO 1
-#  endif
-/*  Allow a board_config to override the PX4IO FW search paths */
-#  if defined(BOARD_PX4IO_FW_SEARCH_PATHS)
-#    define PX4IO_FW_SEARCH_PATHS BOARD_PX4IO_FW_SEARCH_PATHS
-#  else
-/*  Use PX4IO FW search paths defaults based on version */
-#    if BOARD_USES_PX4IO_VERSION == 2
-#      define PX4IO_FW_SEARCH_PATHS {"/etc/extras/px4_io-v2_default.bin","/fs/microsd/px4_io-v2_default.bin", "/fs/microsd/px4io2.bin", nullptr }
-#    endif
-#  endif
-#endif
-
 /* Provide an overridable default nop
  * for BOARD_EEPROM_WP_CTRL
  */

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -36,13 +36,15 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS
-		px4io.cpp
 		px4io_serial.cpp
 		px4io_uploader.cpp
+		PX4IO.cpp
+		PX4IO.hpp
 	DEPENDS
 		arch_px4io_serial
 		circuit_breaker
 		mixer
+		px4_work_queue
 	)
 
 # include the px4io binary in ROMFS

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MAIN px4io
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
+	STACK_MAIN 4096
 	SRCS
 		px4io_serial.cpp
 		px4io_uploader.cpp

--- a/src/drivers/px4io/PX4IO.cpp
+++ b/src/drivers/px4io/PX4IO.cpp
@@ -31,398 +31,15 @@
  *
  ****************************************************************************/
 
-/**
- * @file px4io.cpp
- * Driver for the PX4IO board.
- *
- * PX4IO is connected via DMA enabled high-speed UART.
- */
-#include <px4_platform_common/defines.h>
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/module_params.h>
-#include <px4_platform_common/posix.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_platform_common/sem.hpp>
-
-#include <crc32.h>
-
-#include <drivers/device/device.h>
-#include <drivers/drv_hrt.h>
-#include <drivers/drv_mixer.h>
-#include <drivers/drv_pwm_output.h>
-#include <drivers/drv_rc_input.h>
-#include <drivers/drv_sbus.h>
-#include <lib/circuit_breaker/circuit_breaker.h>
-#include <lib/mathlib/mathlib.h>
-#include <lib/mixer/MixerGroup.hpp>
-#include <lib/mixer/MultirotorMixer/MultirotorMixer.hpp>
-#include <lib/parameters/param.h>
-#include <lib/perf/perf_counter.h>
-#include <lib/rc/dsm.h>
-#include <lib/systemlib/mavlink_log.h>
-#include <uORB/Publication.hpp>
-#include <uORB/PublicationMulti.hpp>
-#include <uORB/Publication.hpp>
-#include <uORB/Subscription.hpp>
-#include <uORB/SubscriptionCallback.hpp>
-#include <uORB/topics/actuator_armed.h>
-#include <uORB/topics/actuator_controls.h>
-#include <uORB/topics/actuator_outputs.h>
-#include <uORB/topics/multirotor_motor_limits.h>
-#include <uORB/topics/parameter_update.h>
-#include <uORB/topics/rc_channels.h>
-#include <uORB/topics/safety.h>
-#include <uORB/topics/servorail_status.h>
-#include <uORB/topics/test_motor.h>
-#include <uORB/topics/vehicle_command.h>
-#include <uORB/topics/vehicle_control_mode.h>
-
-#include <debug.h>
-
-#include <modules/px4iofirmware/protocol.h>
-
-#include "uploader.h"
-
-#include "modules/dataman/dataman.h"
-
-#include "px4io_driver.h"
-
-#define PX4IO_SET_DEBUG			_IOC(0xff00, 0)
-#define PX4IO_INAIR_RESTART_ENABLE	_IOC(0xff00, 1)
-#define PX4IO_REBOOT_BOOTLOADER		_IOC(0xff00, 2)
-#define PX4IO_CHECK_CRC			_IOC(0xff00, 3)
-
-static constexpr unsigned UPDATE_INTERVAL_MIN{2};	// 2 ms	-> 500 Hz
-static constexpr unsigned UPDATE_INTERVAL_MAX{100};	// 100 ms -> 10 Hz
-
-using namespace time_literals;
-
-/**
- * The PX4IO class.
- *
- * Encapsulates PX4FMU to PX4IO communications modeled as file operations.
- */
-class PX4IO : public cdev::CDev, public px4::ScheduledWorkItem
-{
-public:
-	/**
-	 * Constructor.
-	 *
-	 * Initialize all class variables.
-	 */
-	PX4IO() = delete;
-	explicit PX4IO(device::Device *interface);
-
-	/**
-	 * Destructor.
-	 *
-	 * Wait for worker thread to terminate.
-	 */
-	~PX4IO() override;
-
-	/**
-	 * Initialize the PX4IO class.
-	 *
-	 * Retrieve relevant initial system parameters. Initialize PX4IO registers.
-	 */
-	int		init() override;
-
-	/**
-	 * Initialize the PX4IO class.
-	 *
-	 * Retrieve relevant initial system parameters. Initialize PX4IO registers.
-	 *
-	 * @param disable_rc_handling set to true to forbid override / RC handling on IO
-	 * @param hitl_mode set to suppress publication of actuator_outputs - instead defer to pwm_out_sim
-	 */
-	int			init(bool disable_rc_handling, bool hitl_mode);
-
-	/**
-	 * Detect if a PX4IO is connected.
-	 *
-	 * Only validate if there is a PX4IO to talk to.
-	 */
-	virtual int		detect();
-
-	/**
-	 * IO Control handler.
-	 *
-	 * Handle all IOCTL calls to the PX4IO file descriptor.
-	 *
-	 * @param[in] filp file handle (not used). This function is always called directly through object reference
-	 * @param[in] cmd the IOCTL command
-	 * @param[in] the IOCTL command parameter (optional)
-	 */
-	virtual int		ioctl(file *filp, int cmd, unsigned long arg);
-
-	/**
-	 * Disable RC input handling
-	 */
-	int			disable_rc_handling();
-
-	/**
-	 * Print IO status.
-	 *
-	 * Print all relevant IO status information
-	 *
-	 * @param extended_status Shows more verbose information (in particular RC config)
-	 */
-	void			print_status(bool extended_status);
-
-	/**
-	 * Fetch and print debug console output.
-	 */
-	int			print_debug();
-
-	/*
-	 * To test what happens if IO stops receiving updates from FMU.
-	 *
-	 * @param is_fail	true for failure condition, false for normal operation.
-	 */
-	void			test_fmu_fail(bool is_fail) { _test_fmu_fail = is_fail; };
-
-	inline uint16_t		system_status() const { return _status; }
-
-private:
-	void Run() override;
-
-	device::Device		*_interface{nullptr};
-
-	unsigned		_hardware{0};		///< Hardware revision
-	unsigned		_max_actuators{0};		///< Maximum # of actuators supported by PX4IO
-	unsigned		_max_controls{0};		///< Maximum # of controls supported by PX4IO
-	unsigned		_max_rc_input{0};		///< Maximum receiver channels supported by PX4IO
-	unsigned		_max_relays{0};		///< Maximum relays supported by PX4IO
-	unsigned		_max_transfer{16};		///< Maximum number of I2C transfers supported by PX4IO
-
-	bool			_rc_handling_disabled{false};	///< If set, IO does not evaluate, but only forward the RC values
-	unsigned		_rc_chan_count{0};		///< Internal copy of the last seen number of RC channels
-	uint64_t		_rc_last_valid{0};		///< last valid timestamp
-
-	volatile int		_task{-1};			///< worker task id
-	volatile bool		_task_should_exit{false};	///< worker terminate flag
-
-	hrt_abstime		_poll_last{0};
-	hrt_abstime		_orb_check_last{0};
-
-	orb_advert_t		_mavlink_log_pub{nullptr};	///< mavlink log pub
-
-	perf_counter_t		_perf_update{perf_alloc(PC_ELAPSED, MODULE_NAME": update")};		///< local performance counter for status updates
-	perf_counter_t		_perf_write{perf_alloc(PC_ELAPSED, MODULE_NAME": write")};		///< local performance counter for PWM control writes
-	perf_counter_t		_perf_sample_latency{perf_alloc(PC_ELAPSED, MODULE_NAME": control latency")};	///< total system latency (based on passed-through timestamp)
-
-	/* cached IO state */
-	uint16_t		_status{0};		///< Various IO status flags
-	uint16_t		_alarms{0};		///< Various IO alarms
-	uint16_t		_last_written_arming_s{0};	///< the last written arming state reg
-	uint16_t		_last_written_arming_c{0};	///< the last written arming state reg
-
-	/* subscribed topics */
-	uORB::SubscriptionCallbackWorkItem _t_actuator_controls_0{this, ORB_ID(actuator_controls_0)};
-
-	uORB::Subscription	_t_actuator_controls_1{ORB_ID(actuator_controls_1)};	///< actuator controls group 1 topic
-	uORB::Subscription	_t_actuator_controls_2{ORB_ID(actuator_controls_2)};;	///< actuator controls group 2 topic
-	uORB::Subscription	_t_actuator_controls_3{ORB_ID(actuator_controls_3)};;	///< actuator controls group 3 topic
-	uORB::Subscription	_t_actuator_armed{ORB_ID(actuator_armed)};		///< system armed control topic
-	uORB::Subscription 	_t_vehicle_control_mode{ORB_ID(vehicle_control_mode)};	///< vehicle control mode topic
-	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};	///< parameter update topic
-	uORB::Subscription	_t_vehicle_command{ORB_ID(vehicle_command)};		///< vehicle command topic
-
-	bool			_param_update_force{true};	///< force a parameter update
-
-	/* advertised topics */
-	uORB::PublicationMulti<input_rc_s>			_to_input_rc{ORB_ID(input_rc)};
-	uORB::PublicationMulti<actuator_outputs_s>		_to_outputs{ORB_ID(actuator_outputs)};
-	uORB::PublicationMulti<multirotor_motor_limits_s>	_to_mixer_status{ORB_ID(multirotor_motor_limits)};
-	uORB::Publication<servorail_status_s>			_to_servorail{ORB_ID(servorail_status)};
-	uORB::Publication<safety_s>				_to_safety{ORB_ID(safety)};
-
-	bool			_primary_pwm_device{false};	///< true if we are the default PWM output
-	bool			_lockdown_override{false};	///< allow to override the safety lockdown
-	bool			_armed{false};			///< wether the system is armed
-	bool			_override_available{false};	///< true if manual reversion mode is enabled
-
-	bool			_cb_flighttermination{true};	///< true if the flight termination circuit breaker is enabled
-	bool 			_in_esc_calibration_mode{false};	///< do not send control outputs to IO (used for esc calibration)
-
-	int32_t			_rssi_pwm_chan{0}; ///< RSSI PWM input channel
-	int32_t			_rssi_pwm_max{0}; ///< max RSSI input on PWM channel
-	int32_t			_rssi_pwm_min{0}; ///< min RSSI input on PWM channel
-	int32_t			_thermal_control{-1}; ///< thermal control state
-	bool			_analog_rc_rssi_stable{false}; ///< true when analog RSSI input is stable
-	float			_analog_rc_rssi_volt{-1.f}; ///< analog RSSI voltage
-
-	bool			_test_fmu_fail{false}; ///< To test what happens if IO loses FMU
-
-	struct MotorTest {
-		uORB::Subscription test_motor_sub{ORB_ID(test_motor)};
-		bool in_test_mode{false};
-		hrt_abstime timeout{0};
-	};
-	MotorTest _motor_test;
-	bool                    _hitl_mode{false};     ///< Hardware-in-the-loop simulation mode - don't publish actuator_outputs
-
-	/**
-	 * Send controls for one group to IO
-	 */
-	int			io_set_control_state(unsigned group);
-
-	/**
-	 * Send all controls to IO
-	 */
-	int			io_set_control_groups();
-
-	/**
-	 * Update IO's arming-related state
-	 */
-	int			io_set_arming_state();
-
-	/**
-	 * Push RC channel configuration to IO.
-	 */
-	int			io_set_rc_config();
-
-	/**
-	 * Fetch status and alarms from IO
-	 *
-	 * Also publishes battery voltage/current.
-	 */
-	int			io_get_status();
-
-	/**
-	 * Disable RC input handling
-	 */
-	int			io_disable_rc_handling();
-
-	/**
-	 * Fetch RC inputs from IO.
-	 *
-	 * @param input_rc	Input structure to populate.
-	 * @return		OK if data was returned.
-	 */
-	int			io_get_raw_rc_input(input_rc_s &input_rc);
-
-	/**
-	 * Fetch and publish raw RC input data.
-	 */
-	int			io_publish_raw_rc();
-
-	/**
-	 * Fetch and publish the PWM servo outputs.
-	 */
-	int			io_publish_pwm_outputs();
-
-	/**
-	 * write register(s)
-	 *
-	 * @param page		Register page to write to.
-	 * @param offset	Register offset to start writing at.
-	 * @param values	Pointer to array of values to write.
-	 * @param num_values	The number of values to write.
-	 * @return		OK if all values were successfully written.
-	 */
-	int			io_reg_set(uint8_t page, uint8_t offset, const uint16_t *values, unsigned num_values);
-
-	/**
-	 * write a register
-	 *
-	 * @param page		Register page to write to.
-	 * @param offset	Register offset to write to.
-	 * @param value		Value to write.
-	 * @return		OK if the value was written successfully.
-	 */
-	int			io_reg_set(uint8_t page, uint8_t offset, const uint16_t value);
-
-	/**
-	 * read register(s)
-	 *
-	 * @param page		Register page to read from.
-	 * @param offset	Register offset to start reading from.
-	 * @param values	Pointer to array where values should be stored.
-	 * @param num_values	The number of values to read.
-	 * @return		OK if all values were successfully read.
-	 */
-	int			io_reg_get(uint8_t page, uint8_t offset, uint16_t *values, unsigned num_values);
-
-	/**
-	 * read a register
-	 *
-	 * @param page		Register page to read from.
-	 * @param offset	Register offset to start reading from.
-	 * @return		Register value that was read, or _io_reg_get_error on error.
-	 */
-	uint32_t		io_reg_get(uint8_t page, uint8_t offset);
-	static const uint32_t	_io_reg_get_error = 0x80000000;
-
-	/**
-	 * modify a register
-	 *
-	 * @param page		Register page to modify.
-	 * @param offset	Register offset to modify.
-	 * @param clearbits	Bits to clear in the register.
-	 * @param setbits	Bits to set in the register.
-	 */
-	int			io_reg_modify(uint8_t page, uint8_t offset, uint16_t clearbits, uint16_t setbits);
-
-	/**
-	 * Send mixer definition text to IO
-	 */
-	int			mixer_send(const char *buf, unsigned buflen, unsigned retries = 3);
-
-	/**
-	 * Handle a status update from IO.
-	 *
-	 * Publish IO status information if necessary.
-	 *
-	 * @param status	The status register
-	 */
-	int			io_handle_status(uint16_t status);
-
-	/**
-	 * Handle an alarm update from IO.
-	 *
-	 * Publish IO alarm information if necessary.
-	 *
-	 * @param alarm		The status register
-	 */
-	int			io_handle_alarms(uint16_t alarms);
-
-	/**
-	 * Handle issuing dsm bind ioctl to px4io.
-	 *
-	 * @param dsmMode	0:dsm2, 1:dsmx
-	 */
-	void			dsm_bind_ioctl(int dsmMode);
-
-	/**
-	 * Handle a servorail update from IO.
-	 *
-	 * Publish servo rail information if necessary.
-	 *
-	 * @param vservo	vservo register
-	 * @param vrssi 	vrssi register
-	 */
-	void			io_handle_vservo(uint16_t vservo, uint16_t vrssi);
-
-	/**
-	 * check and handle test_motor topic updates
-	 */
-	void handle_motor_test();
-
-	/* do not allow to copy this class due to ptr data members */
-	PX4IO(const PX4IO &);
-	PX4IO operator=(const PX4IO &);
-};
+#include "PX4IO.hpp"
 
 namespace
 {
 PX4IO	*g_dev = nullptr;
 }
 
-#define PX4IO_DEVICE_PATH	"/dev/px4io"
-
 PX4IO::PX4IO(device::Device *interface) :
-	CDev(PX4IO_DEVICE_PATH),
+	CDev("/dev/px4io"),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
 	_interface(interface)
 {
@@ -461,8 +78,7 @@ PX4IO::~PX4IO()
 	g_dev = nullptr;
 }
 
-int
-PX4IO::detect()
+int PX4IO::detect()
 {
 	int ret;
 
@@ -496,16 +112,14 @@ PX4IO::detect()
 	return 0;
 }
 
-int
-PX4IO::init(bool rc_handling_disabled, bool hitl_mode)
+int PX4IO::init(bool rc_handling_disabled, bool hitl_mode)
 {
 	_rc_handling_disabled = rc_handling_disabled;
 	_hitl_mode = hitl_mode;
 	return init();
 }
 
-int
-PX4IO::init()
+int PX4IO::init()
 {
 	param_t sys_restart_param = param_find("SYS_RESTART_TYPE");
 	int32_t sys_restart_val = DM_INIT_REASON_VOLATILE;
@@ -985,8 +599,7 @@ void PX4IO::Run()
 				// update trim values
 				struct pwm_output_values pwm_values {};
 
-//				memset(&pwm_values, 0, sizeof(pwm_values));
-//				ret = io_reg_get(PX4IO_PAGE_CONTROL_TRIM_PWM, 0, (uint16_t *)pwm_values.values, _max_actuators);
+				//ret = io_reg_get(PX4IO_PAGE_CONTROL_TRIM_PWM, 0, (uint16_t *)pwm_values.values, _max_actuators);
 
 				for (unsigned i = 0; i < _max_actuators; i++) {
 					char pname[16];

--- a/src/drivers/px4io/PX4IO.hpp
+++ b/src/drivers/px4io/PX4IO.hpp
@@ -1,0 +1,410 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file PX4IO.hpp
+ * Driver for the PX4IO board.
+ *
+ * PX4IO is connected via DMA enabled high-speed UART.
+ */
+
+#pragma once
+
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <px4_platform_common/sem.hpp>
+
+#include <crc32.h>
+
+#include <drivers/device/device.h>
+#include <drivers/drv_hrt.h>
+#include <drivers/drv_mixer.h>
+#include <drivers/drv_pwm_output.h>
+#include <drivers/drv_rc_input.h>
+#include <drivers/drv_sbus.h>
+#include <lib/circuit_breaker/circuit_breaker.h>
+#include <lib/mathlib/mathlib.h>
+#include <lib/mixer/MixerGroup.hpp>
+#include <lib/mixer/MultirotorMixer/MultirotorMixer.hpp>
+#include <lib/parameters/param.h>
+#include <lib/perf/perf_counter.h>
+#include <lib/rc/dsm.h>
+#include <lib/systemlib/mavlink_log.h>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/actuator_controls.h>
+#include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/multirotor_motor_limits.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/rc_channels.h>
+#include <uORB/topics/safety.h>
+#include <uORB/topics/servorail_status.h>
+#include <uORB/topics/test_motor.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_control_mode.h>
+
+#include <debug.h>
+
+#include <modules/px4iofirmware/protocol.h>
+
+#include "uploader.h"
+
+#include "modules/dataman/dataman.h"
+
+#include "px4io_driver.h"
+
+#define PX4IO_SET_DEBUG			_IOC(0xff00, 0)
+#define PX4IO_INAIR_RESTART_ENABLE	_IOC(0xff00, 1)
+#define PX4IO_REBOOT_BOOTLOADER		_IOC(0xff00, 2)
+#define PX4IO_CHECK_CRC			_IOC(0xff00, 3)
+
+using namespace time_literals;
+
+/**
+ * The PX4IO class.
+ *
+ * Encapsulates PX4FMU to PX4IO communications modeled as file operations.
+ */
+class PX4IO : public cdev::CDev, public px4::ScheduledWorkItem
+{
+public:
+	/**
+	 * Constructor.
+	 *
+	 * Initialize all class variables.
+	 */
+	PX4IO() = delete;
+	explicit PX4IO(device::Device *interface);
+
+	/**
+	 * Destructor.
+	 *
+	 * Wait for worker thread to terminate.
+	 */
+	~PX4IO() override;
+
+	/**
+	 * Initialize the PX4IO class.
+	 *
+	 * Retrieve relevant initial system parameters. Initialize PX4IO registers.
+	 */
+	int		init() override;
+
+	/**
+	 * Initialize the PX4IO class.
+	 *
+	 * Retrieve relevant initial system parameters. Initialize PX4IO registers.
+	 *
+	 * @param disable_rc_handling set to true to forbid override / RC handling on IO
+	 * @param hitl_mode set to suppress publication of actuator_outputs - instead defer to pwm_out_sim
+	 */
+	int			init(bool disable_rc_handling, bool hitl_mode);
+
+	/**
+	 * Detect if a PX4IO is connected.
+	 *
+	 * Only validate if there is a PX4IO to talk to.
+	 */
+	virtual int		detect();
+
+	/**
+	 * IO Control handler.
+	 *
+	 * Handle all IOCTL calls to the PX4IO file descriptor.
+	 *
+	 * @param[in] filp file handle (not used). This function is always called directly through object reference
+	 * @param[in] cmd the IOCTL command
+	 * @param[in] the IOCTL command parameter (optional)
+	 */
+	virtual int		ioctl(file *filp, int cmd, unsigned long arg);
+
+	/**
+	 * Disable RC input handling
+	 */
+	int			disable_rc_handling();
+
+	/**
+	 * Print IO status.
+	 *
+	 * Print all relevant IO status information
+	 *
+	 * @param extended_status Shows more verbose information (in particular RC config)
+	 */
+	void			print_status(bool extended_status);
+
+	/**
+	 * Fetch and print debug console output.
+	 */
+	int			print_debug();
+
+	/*
+	 * To test what happens if IO stops receiving updates from FMU.
+	 *
+	 * @param is_fail	true for failure condition, false for normal operation.
+	 */
+	void			test_fmu_fail(bool is_fail) { _test_fmu_fail = is_fail; };
+
+	inline uint16_t		system_status() const { return _status; }
+
+private:
+	void Run() override;
+
+	device::Device		*_interface{nullptr};
+
+	unsigned		_hardware{0};		///< Hardware revision
+	unsigned		_max_actuators{0};		///< Maximum # of actuators supported by PX4IO
+	unsigned		_max_controls{0};		///< Maximum # of controls supported by PX4IO
+	unsigned		_max_rc_input{0};		///< Maximum receiver channels supported by PX4IO
+	unsigned		_max_relays{0};		///< Maximum relays supported by PX4IO
+	unsigned		_max_transfer{16};		///< Maximum number of I2C transfers supported by PX4IO
+
+	bool			_rc_handling_disabled{false};	///< If set, IO does not evaluate, but only forward the RC values
+	unsigned		_rc_chan_count{0};		///< Internal copy of the last seen number of RC channels
+	uint64_t		_rc_last_valid{0};		///< last valid timestamp
+
+	volatile int		_task{-1};			///< worker task id
+	volatile bool		_task_should_exit{false};	///< worker terminate flag
+
+	hrt_abstime		_poll_last{0};
+	hrt_abstime		_orb_check_last{0};
+
+	orb_advert_t		_mavlink_log_pub{nullptr};	///< mavlink log pub
+
+	perf_counter_t		_perf_update{perf_alloc(PC_ELAPSED, MODULE_NAME": update")};		///< local performance counter for status updates
+	perf_counter_t		_perf_write{perf_alloc(PC_ELAPSED, MODULE_NAME": write")};		///< local performance counter for PWM control writes
+	perf_counter_t		_perf_sample_latency{perf_alloc(PC_ELAPSED, MODULE_NAME": control latency")};	///< total system latency (based on passed-through timestamp)
+
+	/* cached IO state */
+	uint16_t		_status{0};		///< Various IO status flags
+	uint16_t		_alarms{0};		///< Various IO alarms
+	uint16_t		_last_written_arming_s{0};	///< the last written arming state reg
+	uint16_t		_last_written_arming_c{0};	///< the last written arming state reg
+
+	/* subscribed topics */
+	uORB::SubscriptionCallbackWorkItem _t_actuator_controls_0{this, ORB_ID(actuator_controls_0)};
+
+	uORB::Subscription	_t_actuator_controls_1{ORB_ID(actuator_controls_1)};	///< actuator controls group 1 topic
+	uORB::Subscription	_t_actuator_controls_2{ORB_ID(actuator_controls_2)};;	///< actuator controls group 2 topic
+	uORB::Subscription	_t_actuator_controls_3{ORB_ID(actuator_controls_3)};;	///< actuator controls group 3 topic
+	uORB::Subscription	_t_actuator_armed{ORB_ID(actuator_armed)};		///< system armed control topic
+	uORB::Subscription 	_t_vehicle_control_mode{ORB_ID(vehicle_control_mode)};	///< vehicle control mode topic
+	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};	///< parameter update topic
+	uORB::Subscription	_t_vehicle_command{ORB_ID(vehicle_command)};		///< vehicle command topic
+
+	bool			_param_update_force{true};	///< force a parameter update
+
+	/* advertised topics */
+	uORB::PublicationMulti<input_rc_s>			_to_input_rc{ORB_ID(input_rc)};
+	uORB::PublicationMulti<actuator_outputs_s>		_to_outputs{ORB_ID(actuator_outputs)};
+	uORB::PublicationMulti<multirotor_motor_limits_s>	_to_mixer_status{ORB_ID(multirotor_motor_limits)};
+	uORB::Publication<servorail_status_s>			_to_servorail{ORB_ID(servorail_status)};
+	uORB::Publication<safety_s>				_to_safety{ORB_ID(safety)};
+
+	bool			_primary_pwm_device{false};	///< true if we are the default PWM output
+	bool			_lockdown_override{false};	///< allow to override the safety lockdown
+	bool			_armed{false};			///< wether the system is armed
+	bool			_override_available{false};	///< true if manual reversion mode is enabled
+
+	bool			_cb_flighttermination{true};	///< true if the flight termination circuit breaker is enabled
+	bool 			_in_esc_calibration_mode{false};	///< do not send control outputs to IO (used for esc calibration)
+
+	int32_t			_rssi_pwm_chan{0}; ///< RSSI PWM input channel
+	int32_t			_rssi_pwm_max{0}; ///< max RSSI input on PWM channel
+	int32_t			_rssi_pwm_min{0}; ///< min RSSI input on PWM channel
+	int32_t			_thermal_control{-1}; ///< thermal control state
+	bool			_analog_rc_rssi_stable{false}; ///< true when analog RSSI input is stable
+	float			_analog_rc_rssi_volt{-1.f}; ///< analog RSSI voltage
+
+	bool			_test_fmu_fail{false}; ///< To test what happens if IO loses FMU
+
+	struct MotorTest {
+		uORB::Subscription test_motor_sub{ORB_ID(test_motor)};
+		bool in_test_mode{false};
+		hrt_abstime timeout{0};
+	};
+	MotorTest _motor_test;
+	bool                    _hitl_mode{false};     ///< Hardware-in-the-loop simulation mode - don't publish actuator_outputs
+
+	/**
+	 * Send controls for one group to IO
+	 */
+	int			io_set_control_state(unsigned group);
+
+	/**
+	 * Send all controls to IO
+	 */
+	int			io_set_control_groups();
+
+	/**
+	 * Update IO's arming-related state
+	 */
+	int			io_set_arming_state();
+
+	/**
+	 * Push RC channel configuration to IO.
+	 */
+	int			io_set_rc_config();
+
+	/**
+	 * Fetch status and alarms from IO
+	 *
+	 * Also publishes battery voltage/current.
+	 */
+	int			io_get_status();
+
+	/**
+	 * Disable RC input handling
+	 */
+	int			io_disable_rc_handling();
+
+	/**
+	 * Fetch RC inputs from IO.
+	 *
+	 * @param input_rc	Input structure to populate.
+	 * @return		OK if data was returned.
+	 */
+	int			io_get_raw_rc_input(input_rc_s &input_rc);
+
+	/**
+	 * Fetch and publish raw RC input data.
+	 */
+	int			io_publish_raw_rc();
+
+	/**
+	 * Fetch and publish the PWM servo outputs.
+	 */
+	int			io_publish_pwm_outputs();
+
+	/**
+	 * write register(s)
+	 *
+	 * @param page		Register page to write to.
+	 * @param offset	Register offset to start writing at.
+	 * @param values	Pointer to array of values to write.
+	 * @param num_values	The number of values to write.
+	 * @return		OK if all values were successfully written.
+	 */
+	int			io_reg_set(uint8_t page, uint8_t offset, const uint16_t *values, unsigned num_values);
+
+	/**
+	 * write a register
+	 *
+	 * @param page		Register page to write to.
+	 * @param offset	Register offset to write to.
+	 * @param value		Value to write.
+	 * @return		OK if the value was written successfully.
+	 */
+	int			io_reg_set(uint8_t page, uint8_t offset, const uint16_t value);
+
+	/**
+	 * read register(s)
+	 *
+	 * @param page		Register page to read from.
+	 * @param offset	Register offset to start reading from.
+	 * @param values	Pointer to array where values should be stored.
+	 * @param num_values	The number of values to read.
+	 * @return		OK if all values were successfully read.
+	 */
+	int			io_reg_get(uint8_t page, uint8_t offset, uint16_t *values, unsigned num_values);
+
+	/**
+	 * read a register
+	 *
+	 * @param page		Register page to read from.
+	 * @param offset	Register offset to start reading from.
+	 * @return		Register value that was read, or _io_reg_get_error on error.
+	 */
+	uint32_t		io_reg_get(uint8_t page, uint8_t offset);
+	static const uint32_t	_io_reg_get_error = 0x80000000;
+
+	/**
+	 * modify a register
+	 *
+	 * @param page		Register page to modify.
+	 * @param offset	Register offset to modify.
+	 * @param clearbits	Bits to clear in the register.
+	 * @param setbits	Bits to set in the register.
+	 */
+	int			io_reg_modify(uint8_t page, uint8_t offset, uint16_t clearbits, uint16_t setbits);
+
+	/**
+	 * Send mixer definition text to IO
+	 */
+	int			mixer_send(const char *buf, unsigned buflen, unsigned retries = 3);
+
+	/**
+	 * Handle a status update from IO.
+	 *
+	 * Publish IO status information if necessary.
+	 *
+	 * @param status	The status register
+	 */
+	int			io_handle_status(uint16_t status);
+
+	/**
+	 * Handle an alarm update from IO.
+	 *
+	 * Publish IO alarm information if necessary.
+	 *
+	 * @param alarm		The status register
+	 */
+	int			io_handle_alarms(uint16_t alarms);
+
+	/**
+	 * Handle issuing dsm bind ioctl to px4io.
+	 *
+	 * @param dsmMode	0:dsm2, 1:dsmx
+	 */
+	void			dsm_bind_ioctl(int dsmMode);
+
+	/**
+	 * Handle a servorail update from IO.
+	 *
+	 * Publish servo rail information if necessary.
+	 *
+	 * @param vservo	vservo register
+	 * @param vrssi 	vrssi register
+	 */
+	void			io_handle_vservo(uint16_t vservo, uint16_t vrssi);
+
+	/**
+	 * check and handle test_motor topic updates
+	 */
+	void handle_motor_test();
+};

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -110,21 +110,22 @@ public:
 	 *
 	 * Initialize all class variables.
 	 */
-	PX4IO(device::Device *interface);
+	PX4IO() = delete;
+	explicit PX4IO(device::Device *interface);
 
 	/**
 	 * Destructor.
 	 *
 	 * Wait for worker thread to terminate.
 	 */
-	virtual ~PX4IO();
+	~PX4IO() override;
 
 	/**
 	 * Initialize the PX4IO class.
 	 *
 	 * Retrieve relevant initial system parameters. Initialize PX4IO registers.
 	 */
-	virtual int		init();
+	int		init() override;
 
 	/**
 	 * Initialize the PX4IO class.
@@ -185,7 +186,7 @@ public:
 private:
 	void Run() override;
 
-	device::Device		*_interface;
+	device::Device		*_interface{nullptr};
 
 	unsigned		_hardware{0};		///< Hardware revision
 	unsigned		_max_actuators{0};		///< Maximum # of actuators supported by PX4IO
@@ -3079,7 +3080,7 @@ int px4io_main(int argc, char *argv[])
 
 		/* Assume we are using default paths */
 
-		const char *fn[4] = PX4IO_FW_SEARCH_PATHS;
+		const char *fn[4] {"/etc/extras/px4_io-v2_default.bin", "/fs/microsd/px4_io-v2_default.bin", "/fs/microsd/px4io2.bin", nullptr};
 
 		/* Override defaults if a path is passed on command line */
 		if (argc > 2) {

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -155,18 +155,6 @@ public:
 	virtual int		ioctl(file *filp, int cmd, unsigned long arg);
 
 	/**
-	 * write handler.
-	 *
-	 * Handle writes to the PX4IO file descriptor.
-	 *
-	 * @param[in] filp file handle (not used). This function is always called directly through object reference
-	 * @param[in] buffer pointer to the data buffer to be written
-	 * @param[in] len size in bytes to be written
-	 * @return number of bytes written
-	 */
-	virtual ssize_t		write(file *filp, const char *buffer, size_t len);
-
-	/**
 	 * Disable RC input handling
 	 */
 	int			disable_rc_handling();
@@ -2744,36 +2732,6 @@ int PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 	}
 
 	return ret;
-}
-
-ssize_t PX4IO::write(file * /*filp*/, const char *buffer, size_t len)
-/* Make it obvious that file * isn't used here */
-{
-	unsigned count = len / 2;
-
-	if (count > _max_actuators) {
-		count = _max_actuators;
-	}
-
-	if (count > 0) {
-
-		perf_begin(_perf_write);
-
-		int ret = OK;
-
-		/* The write() is silently ignored in test mode. */
-		if (!_test_fmu_fail) {
-			ret = io_reg_set(PX4IO_PAGE_DIRECT_PWM, 0, (uint16_t *)buffer, count);
-		}
-
-		perf_end(_perf_write);
-
-		if (ret != OK) {
-			return ret;
-		}
-	}
-
-	return count * 2;
 }
 
 extern "C" __EXPORT int px4io_main(int argc, char *argv[]);

--- a/src/drivers/px4io/px4io_serial.cpp
+++ b/src/drivers/px4io/px4io_serial.cpp
@@ -51,24 +51,14 @@ device::Device
 
 PX4IO_serial::PX4IO_serial() :
 	Device("PX4IO_serial"),
-	_pc_txns(perf_alloc(PC_ELAPSED, "io_txns")),
-#if 0
-	_pc_retries(perf_alloc(PC_COUNT,	"io_retries  ")),
-	_pc_timeouts(perf_alloc(PC_COUNT,	"io_timeouts ")),
-	_pc_crcerrs(perf_alloc(PC_COUNT,	"io_crcerrs  ")),
-	_pc_protoerrs(perf_alloc(PC_COUNT,	"io_protoerrs")),
-	_pc_uerrs(perf_alloc(PC_COUNT,		"io_uarterrs ")),
-	_pc_idle(perf_alloc(PC_COUNT,		"io_idle     ")),
-	_pc_badidle(perf_alloc(PC_COUNT,	"io_badidle  ")),
-#else
-	_pc_retries(nullptr),
-	_pc_timeouts(nullptr),
-	_pc_crcerrs(nullptr),
-	_pc_protoerrs(nullptr),
-	_pc_uerrs(nullptr),
-	_pc_idle(nullptr),
-	_pc_badidle(nullptr),
-#endif
+	_pc_txns(perf_alloc(PC_ELAPSED, MODULE_NAME": txns")),
+	_pc_retries(perf_alloc(PC_COUNT, MODULE_NAME": retries")),
+	_pc_timeouts(perf_alloc(PC_COUNT, MODULE_NAME": timeouts")),
+	_pc_crcerrs(perf_alloc(PC_COUNT, MODULE_NAME": crcerrs")),
+	_pc_protoerrs(perf_alloc(PC_COUNT, MODULE_NAME": protoerrs")),
+	_pc_uerrs(perf_alloc(PC_COUNT, MODULE_NAME": uarterrs")),
+	_pc_idle(perf_alloc(PC_COUNT, MODULE_NAME": idle")),
+	_pc_badidle(perf_alloc(PC_COUNT, MODULE_NAME": badidle")),
 	_bus_semaphore(SEM_INITIALIZER(0))
 {
 	g_interface = this;


### PR DESCRIPTION
I noticed the px4io control latency increased substantially (> 1 ms in some cases), likely due to the number of things that have moved to work queues (sensors most recently) that further reduced the relative priority of the px4io task. Moving px4io to the inner loop WQ thread (wq:rate_ctrl) gives it the lowest possible latency. It also saves a little bit of memory (~3.3 kB) and cpu (~1%) relative to current master.