### PR TITLE
Add Femtomes GPS Driver

### DIFF
--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -46,6 +46,7 @@ px4_add_module(
 		devices/src/ubx.cpp
 		devices/src/rtcm.cpp
 		devices/src/emlid_reach.cpp
+		devices/src/femtomes.cpp
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS


### PR DESCRIPTION
Femtomes GPS Driver already merged into GpsDrivers submodule https://github.com/PX4/GpsDrivers/pull/49

This PR makes it available to use.

But for now, looks should wait until #14447 merged to avoid conflict.

@bkueng Thanks for review.