### PR TITLE
RTL: Perform transition towards home location

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -257,6 +257,7 @@ void RTL::on_activation()
 
 	const vehicle_global_position_s &global_position = *_navigator->get_global_position();
 
+	_rtl_loiter_rad = _param_rtl_loiter_rad.get();
 	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 		_rtl_alt = calculate_return_alt_from_cone_half_angle((float)_param_rtl_cone_half_angle_deg.get());
 
@@ -408,6 +409,10 @@ void RTL::set_rtl_item()
 
 			} else {
 				_mission_item.yaw = _destination.yaw;
+			}
+
+			if (_navigator->get_vstatus()->is_vtol) {
+				_mission_item.loiter_radius = _rtl_loiter_rad;
 			}
 
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -148,6 +148,7 @@ private:
 
 	float _rtl_alt{0.0f};	// AMSL altitude at which the vehicle should return to the home position
 	bool _rtl_alt_min{false};
+	float _rtl_loiter_rad{50.0f};		// radius at which a fixed wing would loiter while descending
 	bool _climb_and_return_done{false};	// this flag is set to true if RTL is active and we are past the climb state and return state
 	bool _deny_mission_landing{false};
 
@@ -159,7 +160,8 @@ private:
 		(ParamInt<px4::params::RTL_TYPE>) _param_rtl_type,
 		(ParamInt<px4::params::RTL_CONE_ANG>) _param_rtl_cone_half_angle_deg,
 		(ParamFloat<px4::params::RTL_FLT_TIME>) _param_rtl_flt_time,
-		(ParamInt<px4::params::RTL_PLD_MD>) _param_rtl_pld_md
+		(ParamInt<px4::params::RTL_PLD_MD>) _param_rtl_pld_md,
+		(ParamFloat<px4::params::RTL_LOITER_RAD>) _param_rtl_loiter_rad
 	)
 
 	// These need to point at different parameters depending on vehicle type.

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -121,6 +121,7 @@ private:
 		RTL_MOVE_TO_LAND_HOVER_VTOL,
 		RTL_STATE_LAND,
 		RTL_STATE_LANDED,
+		RTL_STATE_HEAD_TO_CENTER,
 	} _rtl_state{RTL_STATE_NONE};
 
 	struct RTLPosition {

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -159,3 +159,17 @@ PARAM_DEFINE_FLOAT(RTL_FLT_TIME, 15);
  * @group Return To Land
  */
 PARAM_DEFINE_INT32(RTL_PLD_MD, 0);
+
+/**
+ * Loiter radius for rtl descend
+ *
+ * Set the radius for loitering to a safe altitude for VTOL transition.
+ *
+ * @unit m
+ * @min 25
+ * @max 1000
+ * @decimal 1
+ * @increment 0.5
+ * @group Return Mode
+ */
+PARAM_DEFINE_FLOAT(RTL_LOITER_RAD, 50.0f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Followup on https://github.com/PX4/Firmware/pull/14728. To prevent performing a transition while still loitering around the home location, this PR makes sure that the drone heads towards the home location before triggering the transition. For this purpose, it is reasonable to add a new parameter RTL_LOITER_RAD to allow the user to set a loiter radius for the altitude descending that still allows the drone to turn towards the home location before initiating a transition.

**Test data / coverage**
Sitl gazebo log: https://review.px4.io/plot_app?log=b71abace-d7ba-4f9d-a2ef-71ac005d09e1