### PR TITLE
Extend ESC checks to handle failures

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -15,6 +15,7 @@ bool condition_local_altitude_valid
 bool condition_power_input_valid                # set if input power is valid
 bool condition_battery_healthy                # set if battery is available and not low
 bool condition_escs_error		      # set to true if one or more ESCs reporting esc_status are offline
+bool condition_escs_failure		      # set to true if one or more ESCs reporting esc_status has a failure
 bool circuit_breaker_engaged_power_check
 bool circuit_breaker_engaged_airspd_check
 bool circuit_breaker_engaged_enginefailure_check
@@ -35,3 +36,6 @@ bool usb_connected                                # status of the USB power supp
 
 bool avoidance_system_required					  # Set to true if avoidance system is enabled via COM_OBS_AVOID parameter
 bool avoidance_system_valid                       # Status of the obstacle avoidance system
+
+bool onboard_logging_system_required              # Set to true if logging system is required for arming via the COM_ARM_WO_OBLOG parameter
+bool onboard_logging_system_valid                 # Status of the onboard logging system

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -140,6 +140,14 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		}
 	}
 
+	if (arm_requirements.esc_check && status_flags.condition_escs_failure) {
+		if (prearm_ok) {
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! One or more ESCs have a failure"); }
+
+			prearm_ok = false;
+		}
+	}
+
 	if (status.is_vtol) {
 
 		if (status.in_transition_mode) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4084,6 +4084,49 @@ Commander::offboard_control_update()
 
 void Commander::esc_status_check(const esc_status_s &esc_status)
 {
+	status_flags.condition_escs_failure = false;
+
+	for (int index = 0; index < esc_status.esc_count; index++) {
+
+		if (esc_status.esc[index].failures > esc_report_s::FAILURE_NONE) {
+			status_flags.condition_escs_failure = true;
+
+			if (esc_status.esc[index].failures != _last_esc_failure[index]) {
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_OVER_CURRENT_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: over current", index + 1);
+				}
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_OVER_VOLTAGE_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: over voltage", index + 1);
+				}
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_OVER_TEMPERATURE_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: over temperature", index + 1);
+				}
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_OVER_RPM_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: over RPM", index + 1);
+				}
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_INCONSISTENT_CMD_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: command inconsistency", index + 1);
+				}
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_MOTOR_STUCK_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: motor stuck", index + 1);
+				}
+
+				if (esc_status.esc[index].failures & esc_report_s::FAILURE_GENERIC_MASK) {
+					mavlink_log_critical(&mavlink_log_pub, "ESC%d: generic failure - code %d", index, esc_status.esc[index].esc_state);
+				}
+
+			}
+
+			_last_esc_failure[index] = esc_status.esc[index].failures;
+		}
+	}
+
 	char esc_fail_msg[50];
 	esc_fail_msg[0] = '\0';
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -323,6 +323,7 @@ private:
 	hrt_abstime	_high_latency_datalink_lost{0};
 
 	int		_last_esc_online_flags{-1};
+	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {0};
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	float		_battery_current{0.0f};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -324,6 +324,7 @@ private:
 
 	int		_last_esc_online_flags{-1};
 	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {0};
+	bool		_esc_status_was_updated{false};
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	float		_battery_current{0.0f};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -855,8 +855,9 @@ PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
 PARAM_DEFINE_INT32(COM_FLT_PROFILE, 0);
 
 /**
- * Require all the ESCs to be detected to arm.
+ * Enable checks on ESCs that report telemetry.
  *
+ * If this parameter is set, the system will check ESC's online status and failures.
  * This param is specific for ESCs reporting status. Normal ESCs configurations are not affected by the change of this param.
  *
  * @group Commander


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR extends ESCs checks to handle reported failures by the ESC.

It also ensures that no arming is possible if you have enabled some driver for ESCs reporting telemetry (i.e UAVCAN ESCs) but the telemetry line is disconnected since the vehicle is powered up.

With the previous implementation the vehicle could still arm because the esc checks were not executed if no telemetry data was published.

Such tests can be disabled by using the same parameter that was defined for checking ESCs online status COM_ARM_CHK_ESCS .

**Test data / coverage**
Tested on a vehicle with custom CAN ESCs.

TODO: 

- [ ] Test on a vehicle with UAVCAN ESCs