### PR TITLE
Added yaw to CMD_DO_SET_HOME

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -73,6 +73,7 @@
 #include <math.h>
 #include <float.h>
 #include <cstring>
+#include <matrix/math.hpp>
 
 #include <uORB/topics/mavlink_log.h>
 
@@ -958,6 +959,8 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				}
 
 			} else {
+				float yaw = matrix::wrap_2pi(math::radians(cmd.param4));
+				yaw = PX4_ISFINITE(yaw) ? yaw : NAN;
 				const double lat = cmd.param5;
 				const double lon = cmd.param6;
 				const float alt = cmd.param7;
@@ -981,7 +984,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 						float home_y;
 						map_projection_project(&ref_pos, lat, lon, &home_x, &home_y);
 						const float home_z = -(alt - local_pos.ref_alt);
-						fillLocalHomePos(home, home_x, home_y, home_z, 0.f);
+						fillLocalHomePos(home, home_x, home_y, home_z, yaw);
 
 						/* mark home position as set */
 						_status_flags.condition_home_position_valid = _home_pub.update(home);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Before, CMD_DO_SET_HOME had no yaw angle specified, which renders it a bit useless compared to SET_HOME_POSITION. With this PR param4 will be used as the yaw in degrees. A PR to the mavlink documentation will follow.