### PR TITLE
Battery: add average consumption parameters for multicopter and fixedwing 

### DIFF
--- a/src/lib/battery/battery_params_common.c
+++ b/src/lib/battery/battery_params_common.c
@@ -88,3 +88,29 @@ PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
  * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(BAT_EMERGEN_THR, 0.05f);
+
+/**
+ * Average current consumption in multicopter flight.
+ *
+ * A negative value means that the value is unkown and dependent features disabled.
+ *
+ * @group Battery Calibration
+ * @unit A
+ * @min -1
+ * @max 500
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(BAT_AVG_I_MC, -1.0f);
+
+/**
+ * Average current consumption in fixed-wing flight.
+ *
+ * A negative value means that the value is unkown and dependent features disabled.
+ *
+ * @group Battery Calibration
+ * @unit A
+ * @min -1
+ * @max 500
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(BAT_AVG_I_FW, -1.0f);

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -82,6 +82,8 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 
 	(void)param_find("BAT_V_DIV");
 	(void)param_find("BAT_A_PER_V");
+	(void)param_find("BAT_AVG_I_MC");
+	(void)param_find("BAT_AVG_I_FW");
 
 	(void)param_find("CAL_ACC0_ID");
 	(void)param_find("CAL_GYRO0_ID");


### PR DESCRIPTION
This PR adds two new, vehicle-specific parameters: BAT_AVG_I_MC and BAT_AVG_I_FW. They are intended to reflect the average current needed for hover and fixed-wing flight, respectively. While with this PR they are not yet consumed anywhere, having them would allow:
- to calculate remaining flight time while in-air
- to calculate remaining flight distance --> could be used to make battery RTL "smarter" by returning early enough when far away
- to use at the planning stage, to indicate if a mission is feasible or not (plus for VTOL, it could be used to indicate if vehicle can reach home/land/safe points in hover mode from every location on the mission, after a quadchute for example)
- simulate battery drainage more precisely in SITL

For most applications these new params make only sense when you have an accurate current measurement on the vehicle and BAT_CAPACITY set. Or a smart battery that automatically gives you back remaining capacity.