### PR TITLE
VTOL: control surface support in hover: add scaling parameters

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -385,13 +385,16 @@ void Standard::fill_actuator_outputs()
 		} else {
 			// roll
 			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
+				_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL]  * _params->hover_gain_aileron;
 
 			// pitch
 			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
+				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] * _params->hover_gain_elevator;
 
-			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
+			// yaw
+			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
+				_actuators_mc_in->control[actuator_controls_s::INDEX_YAW] *
+				_params->hover_gain_rudder; // use MC controller for rudder control
 			_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;
 		}
 	}

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -432,16 +432,36 @@ void Tiltrotor::fill_actuator_outputs()
 
 	_actuators_out_1->control[4] = _tilt_control;
 
-	if (_params->elevons_mc_lock && _vtol_schedule.flight_mode == vtol_mode::MC_MODE) {
-		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = 0.0f;
-		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = 0.0f;
-		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
+	if (_vtol_schedule.flight_mode == vtol_mode::MC_MODE) {
+		if (_params->elevons_mc_lock) {
+			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = 0.0f;
+			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = 0.0f;
+			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
+
+		} else {
+			// roll
+			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
+				_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL]  * _params->hover_gain_aileron;
+
+			// pitch
+			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
+				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] * _params->hover_gain_elevator;
+
+			// yaw
+			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
+				_actuators_mc_in->control[actuator_controls_s::INDEX_YAW] *
+				_params->hover_gain_rudder; // use MC controller for rudder control
+		}
 
 	} else {
+		// roll
 		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
+
+		// pitch
 		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
+		// yaw
 		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];
 	}

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -89,6 +89,10 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_params_handles.dec_to_pitch_i = param_find("VT_B_DEC_I");
 	_params_handles.back_trans_dec_sp = param_find("VT_B_DEC_MSS");
 
+	_params_handles.hover_gain_aileron = param_find("VT_MC_AILE_GAIN");
+	_params_handles.hover_gain_elevator = param_find("VT_MC_ELEV_GAIN");
+	_params_handles.hover_gain_rudder = param_find("VT_MC_RUD_GAIN");
+
 
 	_params_handles.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
 	_params_handles.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
@@ -241,6 +245,11 @@ VtolAttitudeControl::parameters_update()
 	/* vtol lock elevons in multicopter */
 	param_get(_params_handles.elevons_mc_lock, &l);
 	_params.elevons_mc_lock = (l == 1);
+
+	// scales for FW actuators (aileron, elevon, rudder) in hover
+	param_get(_params_handles.hover_gain_aileron, &_params.hover_gain_aileron);
+	param_get(_params_handles.hover_gain_elevator, &_params.hover_gain_elevator);
+	param_get(_params_handles.hover_gain_rudder, &_params.hover_gain_rudder);
 
 	/* minimum relative altitude for FW mode (QuadChute) */
 	param_get(_params_handles.fw_min_alt, &v);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -210,6 +210,9 @@ private:
 		param_t vt_forward_thrust_enable_mode;
 		param_t mpc_land_alt1;
 		param_t mpc_land_alt2;
+		param_t hover_gain_aileron;
+		param_t hover_gain_elevator;
+		param_t hover_gain_rudder;
 	} _params_handles{};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -77,9 +77,9 @@ PARAM_DEFINE_INT32(VT_FW_PERM_STAB, 0);
 PARAM_DEFINE_INT32(VT_TYPE, 0);
 
 /**
- * Lock elevons in multicopter mode
+ * Lock the control surfaces in hover mode
  *
- * If set to 1 the elevons are locked in multicopter mode
+ * If set to 1 all the control surfaces are locked at their central position in multicopter mode.
  *
  * @boolean
  * @group VTOL Attitude Control
@@ -354,3 +354,45 @@ PARAM_DEFINE_FLOAT(VT_B_DEC_I, 0.1f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_MC_ON_FMU, 0);
+
+/**
+* Scale for roll acutation using fixed-wing actuators in hover.
+*
+* Determines the scale between attitude error and deflection of the roll controlling surfaces (i.e. ailerons or elevons) in hover.
+* If larger than 0, that will assist the multicopter motors to stabilize the attidue of the vehicle, and can be helpful if the
+* motors alone are saturating due to aerodynamic moments.
+* Applies to standard and tiltrotor VTOL.
+*
+* @min 0
+* @max 2
+* @group VTOL Attitude Control
+*/
+PARAM_DEFINE_FLOAT(VT_MC_AILE_GAIN, 0.5f);
+
+/**
+* Scale for pitch acutation using fixed-wing actuators in hover.
+*
+* Determines the scale between attitude error and deflection of the pitch controlling surfaces (i.e. elevator or elevons) in hover.
+* If larger than 0, that will assist the multicopter motors to stabilize the attidue of the vehicle, and can be helpful if the
+* motors alone are saturating due to aerodynamic moments.
+* Applies to standard and tiltrotor VTOL.
+*
+* @min 0
+* @max 2
+* @group VTOL Attitude Control
+*/
+PARAM_DEFINE_FLOAT(VT_MC_ELEV_GAIN, 0.5f);
+
+/**
+* Scale for yaw acutation using fixed-wing actuators in hover.
+*
+* Determines the scale between attitude error and deflection of the yaw controlling surface (rudder) in hover.
+* If larger than 0, that will assist the multicopter motors to stabilize the attidue of the vehicle, and can be helpful if the
+* motors alone are saturating due to aerodynamic moments.
+* Applies to standard and tiltrotor VTOL.
+*
+* @min 0
+* @max 2
+* @group VTOL Attitude Control
+*/
+PARAM_DEFINE_FLOAT(VT_MC_RUD_GAIN, 0.5f);

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -79,6 +79,9 @@ struct Params {
 	int vt_forward_thrust_enable_mode;
 	float mpc_land_alt1;
 	float mpc_land_alt2;
+	float hover_gain_aileron;
+	float hover_gain_elevator;
+	float hover_gain_rudder;
 };
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg


### PR DESCRIPTION
On standard and tiltrotor VTOLs, the control surfaces can be used in hover to support the multicopter motors to stabilize the vehicle's attitude. Is can be especially beneficial in high airspeed/wind situation, as then the aerodynamic moments are significant and can lead to saturation of the MC motors. This PR extends the possibilities of this feature by also using the rudder for yaw control, plus it enables individual tuning of the three body axes.

**Describe problem solved by this pull request**
- enables the use of the rudder in hover flight
- introduces ability to scale the amount of deflection of the control surfaces individually, e.g. disable it for the roll axis but enable on the pitch axis

**Describe your solution**
- 3 new parameters, VT_MC_AILE_GAIN, VT_MC_ELEV_GAIN, VT_MC_RUDD_GAIN
- rudder deflection is proportional to multicopter yaw actuation, while the aileron and elevator stay on the fixed-wing actuation (output of FW rate controller)

**Describe possible alternatives**
Also have the rudder controlled by the FW rate controller. It would then though also be deflected with pure roll commands due to the coordinated turn yaw rate setpoint of the fixed-wing controller.

We could think about removing the VT_ELEV_MC_LOCK parameter, as the feature would now already be disabled if all the 3 gains are set to 0.

**Test data / coverage**
bench tested.

