### PR TITLE
fw_pos_ctrl: subtract trim pitch setpoint before TECS everywhere

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -817,8 +817,8 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 		tecs_update_pitch_throttle(_hold_alt,
 					   altctrl_airspeed,
-					   radians(_param_fw_p_lim_min.get()),
-					   radians(_param_fw_p_lim_max.get()),
+					   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
+					   radians(_param_fw_p_lim_max.get()) - radians(_param_fw_psp_off.get()),
 					   _param_fw_thr_min.get(),
 					   throttle_max,
 					   _param_fw_thr_cruise.get(),
@@ -919,8 +919,8 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 		tecs_update_pitch_throttle(_hold_alt,
 					   altctrl_airspeed,
-					   radians(_param_fw_p_lim_min.get()),
-					   radians(_param_fw_p_lim_max.get()),
+					   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
+					   radians(_param_fw_p_lim_max.get()) - radians(_param_fw_psp_off.get()),
 					   _param_fw_thr_min.get(),
 					   throttle_max,
 					   _param_fw_thr_cruise.get(),
@@ -1073,8 +1073,8 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 
 		tecs_update_pitch_throttle(pos_sp_curr.alt,
 					   calculate_target_airspeed(_runway_takeoff.getMinAirspeedScaling() * _param_fw_airspd_min.get(), ground_speed),
-					   radians(_param_fw_p_lim_min.get()),
-					   radians(takeoff_pitch_max_deg),
+					   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
+					   radians(takeoff_pitch_max_deg) - radians(_param_fw_psp_off.get()),
 					   _param_fw_thr_min.get(),
 					   _param_fw_thr_max.get(), // XXX should we also set runway_takeoff_throttle here?
 					   _param_fw_thr_cruise.get(),
@@ -1144,8 +1144,8 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 				/* enforce a minimum of 10 degrees pitch up on takeoff, or take parameter */
 				tecs_update_pitch_throttle(pos_sp_curr.alt,
 							   _param_fw_airspd_trim.get(),
-							   radians(_param_fw_p_lim_min.get()),
-							   radians(takeoff_pitch_max_deg),
+							   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
+							   radians(takeoff_pitch_max_deg) - radians(_param_fw_psp_off.get()),
 							   _param_fw_thr_min.get(),
 							   takeoff_throttle,
 							   _param_fw_thr_cruise.get(),
@@ -1159,8 +1159,8 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 			} else {
 				tecs_update_pitch_throttle(pos_sp_curr.alt,
 							   calculate_target_airspeed(_param_fw_airspd_trim.get(), ground_speed),
-							   radians(_param_fw_p_lim_min.get()),
-							   radians(_param_fw_p_lim_max.get()),
+							   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
+							   radians(_param_fw_p_lim_max.get()) - radians(_param_fw_psp_off.get()),
 							   _param_fw_thr_min.get(),
 							   takeoff_throttle,
 							   _param_fw_thr_cruise.get(),
@@ -1374,8 +1374,8 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 
 		tecs_update_pitch_throttle(terrain_alt + flare_curve_alt_rel,
 					   calculate_target_airspeed(airspeed_land, ground_speed),
-					   radians(_param_fw_lnd_fl_pmin.get()),
-					   radians(_param_fw_lnd_fl_pmax.get()),
+					   radians(_param_fw_lnd_fl_pmin.get()) - radians(_param_fw_psp_off.get()),
+					   radians(_param_fw_lnd_fl_pmax.get()) - radians(_param_fw_psp_off.get()),
 					   0.0f,
 					   throttle_max,
 					   throttle_land,
@@ -1442,8 +1442,8 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 
 		tecs_update_pitch_throttle(altitude_desired,
 					   calculate_target_airspeed(airspeed_approach, ground_speed),
-					   radians(_param_fw_p_lim_min.get()),
-					   radians(_param_fw_p_lim_max.get()),
+					   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
+					   radians(_param_fw_p_lim_max.get()) - radians(_param_fw_psp_off.get()),
 					   _param_fw_thr_min.get(),
 					   _param_fw_thr_max.get(),
 					   _param_fw_thr_cruise.get(),


### PR DESCRIPTION
@sfuhrer @RomanBapst As discussed on Slack I don't understand why we would not subtract the trim pitch setpoint everywhere before pushing it into TECS. I noticed that the plane behaved differently when flying in position control mode compared to mission. I also added the change to places which I could not test, e.g. fw takeoff, so please review that more carefully.

**Describe problem solved by this pull request**
The limitation of the pitch setpoint was different in mission and position control

**Describe your solution**
Subract the trim pitch sp for position control mode in the same way as it is done for mission

**Describe possible alternatives**
A massive cleanup of the fw pos controller

**Test data / coverage**
I only tested position control so far
