### PR TITLE
FlightTask: reset _velocity_setpoint_feedback in case of ekf vel reset

### DIFF
--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -106,6 +106,7 @@ void FlightTaskAutoLineSmoothVel::_ekfResetHandlerPositionXY()
 
 void FlightTaskAutoLineSmoothVel::_ekfResetHandlerVelocityXY()
 {
+	FlightTaskAutoMapper::_ekfResetHandlerVelocityXY();
 	_trajectory[0].setCurrentVelocity(_velocity(0));
 	_trajectory[1].setCurrentVelocity(_velocity(1));
 }
@@ -117,6 +118,7 @@ void FlightTaskAutoLineSmoothVel::_ekfResetHandlerPositionZ()
 
 void FlightTaskAutoLineSmoothVel::_ekfResetHandlerVelocityZ()
 {
+	FlightTaskAutoMapper::_ekfResetHandlerVelocityZ();
 	_trajectory[2].setCurrentVelocity(_velocity(2));
 }
 

--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
@@ -213,9 +213,9 @@ protected:
 	 */
 	void _checkEkfResetCounters();
 	virtual void _ekfResetHandlerPositionXY() {};
-	virtual void _ekfResetHandlerVelocityXY() {};
+	virtual void _ekfResetHandlerVelocityXY() { _velocity_setpoint_feedback.xy() = matrix::Vector2f(_velocity); }
 	virtual void _ekfResetHandlerPositionZ() {};
-	virtual void _ekfResetHandlerVelocityZ() {};
+	virtual void _ekfResetHandlerVelocityZ() { _velocity_setpoint_feedback(2) = _velocity(2); }
 	virtual void _ekfResetHandlerHeading(float delta_psi) {};
 
 	/* Time abstraction */

--- a/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -79,6 +79,7 @@ void FlightTaskManualAltitudeSmoothVel::_ekfResetHandlerPositionZ()
 
 void FlightTaskManualAltitudeSmoothVel::_ekfResetHandlerVelocityZ()
 {
+	FlightTaskManualAltitude::_ekfResetHandlerVelocityZ();
 	_smoothing.setCurrentVelocity(_velocity(2));
 }
 

--- a/src/lib/flight_tasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -91,6 +91,7 @@ void FlightTaskManualPositionSmoothVel::_ekfResetHandlerPositionXY()
 
 void FlightTaskManualPositionSmoothVel::_ekfResetHandlerVelocityXY()
 {
+	FlightTaskManualPosition::_ekfResetHandlerVelocityXY();
 	_smoothing_xy.setCurrentVelocity(_velocity.xy());
 }
 
@@ -101,6 +102,7 @@ void FlightTaskManualPositionSmoothVel::_ekfResetHandlerPositionZ()
 
 void FlightTaskManualPositionSmoothVel::_ekfResetHandlerVelocityZ()
 {
+	FlightTaskManualPosition::_ekfResetHandlerVelocityZ();
 	_smoothing_z.setCurrentVelocity(_velocity(2));
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Hopefully fixes https://github.com/PX4/Firmware/issues/14926
I think the issue was that ekf velocity reset forces the ManualVelocitySmoothing to unlock the position because the setpoint is outside of the "lock" limits. However, the unlocking sequence sets the "velocity feedback" value to the current velocity setpoint and this one wasn't modified by the ekf reset handler.
https://github.com/PX4/Firmware/blob/6c16a29d26b2c79d63f1459be361c8972399d9ce/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingZ.cpp#L108-L115

**Describe your solution**
The default `ekfResetHandlerVelocityXY/Z()` function directly reset the  `_velocity_setpoint_feedback` value.

**Test data / coverage**
None yet
