### PR TITLE
Improve SITL battery estimation

### DIFF
--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -89,6 +89,11 @@ public:
 	float full_cell_voltage() { return _params.v_charged; }
 
 	/**
+	 * Get the battery capacity
+	 */
+	float capacity() { return _params.capacity; }
+
+	/**
 	 * Update current battery status message.
 	 *
 	 * @param voltage_raw: Battery voltage, in Volts

--- a/src/lib/battery/battery_params_common.c
+++ b/src/lib/battery/battery_params_common.c
@@ -88,3 +88,42 @@ PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
  * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(BAT_EMERGEN_THR, 0.05f);
+
+/**
+ * Average current consumption in multicopter flight.
+ *
+ * A negative value means that the value is unkown and dependent features disabled.
+ *
+ * @group Battery Calibration
+ * @unit A
+ * @min -1
+ * @max 500
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(BAT_AVG_I_MC, -1.0f);
+
+/**
+ * Average current consumption in fixed-wing flight.
+ *
+ * A negative value means that the value is unkown and dependent features disabled.
+ *
+ * @group Battery Calibration
+ * @unit A
+ * @min -1
+ * @max 500
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(BAT_AVG_I_FW, -1.0f);
+
+/**
+ * Average current consumption for rovers.
+ *
+ * A negative value means that the value is unkown and dependent features disabled.
+ *
+ * @group Battery Calibration
+ * @unit A
+ * @min -1
+ * @max 500
+ * @increment 0.1
+ */
+PARAM_DEFINE_FLOAT(BAT_AVG_I_ROV, -1.0f);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -283,8 +283,9 @@ private:
 #endif
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::SIM_BAT_DRAIN>) _param_sim_bat_drain, ///< battery drain interval
-		(ParamFloat<px4::params::SIM_BAT_MIN_PCT>) _param_bat_min_pct, //< minimum battery percentage
+		(ParamFloat<px4::params::BAT_AVG_I_MC>) _param_bat_avg_i_mc,
+		(ParamFloat<px4::params::BAT_AVG_I_FW>) _param_bat_avg_i_fw,
+		(ParamFloat<px4::params::BAT_AVG_I_ROV>) _param_bat_avg_i_rov,
 		(ParamFloat<px4::params::SIM_GPS_NOISE_X>) _param_sim_gps_noise_x,
 		(ParamBool<px4::params::SIM_GPS_BLOCK>) _param_sim_gps_block,
 		(ParamBool<px4::params::SIM_ACCEL_BLOCK>) _param_sim_accel_block,

--- a/src/modules/simulator/simulator_params.c
+++ b/src/modules/simulator/simulator_params.c
@@ -40,32 +40,6 @@
  */
 
 /**
- * Simulator Battery drain interval
- *
- * @min 1
- * @max 86400
- * @increment 1
- * @unit s
- *
- * @group SITL
- */
-PARAM_DEFINE_FLOAT(SIM_BAT_DRAIN, 60);
-
-/**
- * Simulator Battery minimal percentage. Can be used to alter
- * the battery level during SITL- or HITL-simulation on the fly.
- * Particularly useful for testing different low-battery behaviour.
- *
- * @min 0
- * @max 100
- * @increment 0.1
- * @unit %
- *
- * @group SITL
- */
-PARAM_DEFINE_FLOAT(SIM_BAT_MIN_PCT, 50.0f);
-
-/**
  * Simulator GPS noise multiplier.
  *
  * @min 0


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the battery estimation in SITL wasn't realistic at all. There was no current and the battery drained at a fixed rate (SIM_BAT_DRAIN) until it reached a minimum level (SIM_BAT_MIN_PCT).

**Describe your solution**
This pull request uses new average current parameters (taken from @sfuhrer's https://github.com/PX4/Firmware/pull/14819), integrates the current and compares the result with the total battery capacity to get the battery percentage.

If not armed, the current is set to zero.

If the average current parameters are set at their default value -1.0, the battery remains full. The same is true for the default battery capacity of -1.

**Describe possible alternatives**
Using average currents based on the vehicle type is a simple way to already increase the precision of battery estimation in SITL, but it's still only a rough approximation.

For the future you could scale the current with thrust for example (for climbing or flying faster), but I wanted to keep it simple for now.

**Test data / coverage**
Log of flight with gazebo_standard_vtol: https://logs.px4.io/plot_app?log=d1d132cf-69a2-494a-9af3-bb5d8ba1ae5f

gazebo_iris: https://logs.px4.io/plot_app?log=d0c07c75-3b73-4e75-9020-09bcfe63f704

gazebo_plane: https://logs.px4.io/plot_app?log=7504cccf-50a9-4bd1-bc69-6421f4d4fb71

gazebo_rover: https://logs.px4.io/plot_app?log=2687f5c7-3643-442a-8127-71fb0d6156b4

Iris with default battery capacity (-1): https://logs.px4.io/plot_app?log=3eead2b3-fbde-4009-8340-27ab4839802d

**Additional context**
When this gets merged the dev guide needs to be updated to reflect this change
