### PR TITLE
[VTOL] impose minimum transition duration

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -279,6 +279,7 @@ VtolAttitudeControl::parameters_update()
 	 */
 	if (_params.front_trans_time_openloop * 0.9f < _params.front_trans_time_min) {
 		_params.front_trans_time_openloop = _params.front_trans_time_min * 1.1f;
+		param_set_no_notification(_params_handles.front_trans_time_openloop, &_params.front_trans_time_openloop);
 		mavlink_log_critical(&_mavlink_log_pub, "OL transition time set larger than min transition time");
 	}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -274,12 +274,13 @@ VtolAttitudeControl::parameters_update()
 	param_get(_params_handles.front_trans_time_min, &_params.front_trans_time_min);
 
 	/*
-	 * Minimum transition time can be maximum 90 percent of the open loop transition time,
+	 * Open loop transition time needs to be larger than minimum transition time,
 	 * anything else makes no sense and can potentially lead to numerical problems.
 	 */
-	_params.front_trans_time_min = math::min(_params.front_trans_time_openloop * 0.9f,
-				       _params.front_trans_time_min);
-
+	if (_params.front_trans_time_openloop * 0.9f < _params.front_trans_time_min) {
+		_params.front_trans_time_openloop = _params.front_trans_time_min * 1.1f;
+		mavlink_log_critical(&_mavlink_log_pub, "OL transition time set larger than min transition time");
+	}
 
 	param_get(_params_handles.front_trans_duration, &_params.front_trans_duration);
 	param_get(_params_handles.back_trans_duration, &_params.back_trans_duration);

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -277,7 +277,7 @@ VtolAttitudeControl::parameters_update()
 	 * Open loop transition time needs to be larger than minimum transition time,
 	 * anything else makes no sense and can potentially lead to numerical problems.
 	 */
-	if (_params.front_trans_time_openloop * 0.9f < _params.front_trans_time_min) {
+	if (_params.front_trans_time_openloop < _params.front_trans_time_min * 1.1f) {
 		_params.front_trans_time_openloop = _params.front_trans_time_min * 1.1f;
 		param_set_no_notification(_params_handles.front_trans_time_openloop, &_params.front_trans_time_openloop);
 		mavlink_log_critical(&_mavlink_log_pub, "OL transition time set larger than min transition time");


### PR DESCRIPTION
**Describe problem solved by this pull request**
Before this PR, VT_F_TR_OL_TM would silently reduce VT_TRANS_MIN_TM when VT_F_TR_OL_TM was smaller. This almost caused a crash on our quadplane because the (non-airspeed) transition was considered finished way too early. The drone lost 45m of altitude before the quadchute could stabilise it (luckily we transitioned at 50m altitude). 

**Describe your solution**
Increase the open loop transition duration if it is smaller than the minimum transition duration and notify the user.

**Test data / coverage**
gazebo standard vtol: Log showing logged messages and imposed 10s front transition: https://logs.px4.io/plot_app?log=4204093e-ffbc-4c4a-b029-21cf52a55c17
