### PR TITLE
Fix SENS_EN_SF1XX max value

### DIFF
--- a/src/drivers/distance_sensor/sf1xx/parameters.c
+++ b/src/drivers/distance_sensor/sf1xx/parameters.c
@@ -36,7 +36,7 @@
  *
  * @reboot_required true
  * @min 0
- * @max 5
+ * @max 6
  * @group Sensors
  * @value 0 Disabled
  * @value 1 SF10/a


### PR DESCRIPTION
Fixes the incorrect max value of `SENS_EN_SF1XX` that was missed in #12918 when a new model was added.

I'm not 100% sure if this will be automatically reflected in QGC on a new update but if not let me know and I can make the changes there as well.