### PR TITLE
mission_feasibility_checker: added check for minimum take off altitude and added NAV_CMD_VTOL_TAKEOFF

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -346,7 +346,7 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 			// get the parameter for min take off altitude in meters
 			float takeoff_alt_min = _navigator->get_takeoff_min_alt();
 
-			// check if it is set to something meaning full and if the take off altitude is set above the parameter
+			// check if it is set to something meaningful and if the take off altitude is set above the parameter
 			if (takeoff_alt_min > 0 && takeoff_alt < takeoff_alt_min) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Takeoff altitude too low!");
 				return false;

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -323,7 +323,7 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 		}
 
 		// look for a takeoff waypoint
-		if (missionitem.nav_cmd == NAV_CMD_TAKEOFF) {
+		if (missionitem.nav_cmd == NAV_CMD_TAKEOFF || missionitem.nav_cmd == NAV_CMD_VTOL_TAKEOFF) {
 			// make sure that the altitude of the waypoint is at least one meter larger than the acceptance radius
 			// this makes sure that the takeoff waypoint is not reached before we are at least one meter in the air
 
@@ -339,6 +339,13 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 			}
 
 			if (takeoff_alt - 1.0f < acceptance_radius) {
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Takeoff altitude too low!");
+				return false;
+			}
+			// get the parameter for min take off altitude in meters
+			float takeoff_alt_min = _navigator->get_takeoff_min_alt();
+			// check if it is set to something meaning full and if the take off altitude is set above the parameter
+			if (takeoff_alt_min>0 && takeoff_alt < takeoff_alt_min) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Takeoff altitude too low!");
 				return false;
 			}

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -342,8 +342,10 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Takeoff altitude too low!");
 				return false;
 			}
+
 			// get the parameter for min take off altitude in meters
 			float takeoff_alt_min = _navigator->get_takeoff_min_alt();
+
 			// check if it is set to something meaning full and if the take off altitude is set above the parameter
 			if (takeoff_alt_min > 0 && takeoff_alt < takeoff_alt_min) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Takeoff altitude too low!");

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -345,7 +345,7 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 			// get the parameter for min take off altitude in meters
 			float takeoff_alt_min = _navigator->get_takeoff_min_alt();
 			// check if it is set to something meaning full and if the take off altitude is set above the parameter
-			if (takeoff_alt_min>0 && takeoff_alt < takeoff_alt_min) {
+			if (takeoff_alt_min > 0 && takeoff_alt < takeoff_alt_min) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Takeoff altitude too low!");
 				return false;
 			}


### PR DESCRIPTION
https://github.com/PX4/Firmware/blob/1c02c379551154d734d0440b40e5b014f2347b58/src/modules/navigator/mission_feasibility_checker.cpp#L341

Why is only the acceptance_radius used to check takeoff altitude
and not:

     _navigator->get_takeoff_min_alt();

maybe in addition to checking for the acceptance_radius?

Also:
https://github.com/PX4/Firmware/blob/1c02c379551154d734d0440b40e5b014f2347b58/src/modules/navigator/mission_feasibility_checker.cpp#L326

should be changed to:

     if (missionitem.nav_cmd == NAV_CMD_TAKEOFF || missionitem.nav_cmd == NAV_CMD_VTOL_TAKEOFF) {

See pull request.