### PR TITLE
simulator: delete PublicationMulti ptrs for sensor_gps

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -145,6 +145,10 @@ private:
 
 		px4_lockstep_unregister_component(_lockstep_component);
 
+		for (size_t i = 0; i < sizeof(_sensor_gps_pubs) / sizeof(_sensor_gps_pubs[0]); i++) {
+			delete _sensor_gps_pubs[i];
+		}
+
 		_instance = nullptr;
 	}
 


### PR DESCRIPTION
Formatter also complained about `VehicleIMU.cpp` format, which also gets address in this PR.
