### PR TITLE
Enable Offboard Bodyrate control for Rovers

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -90,6 +90,12 @@ void RoverPositionControl::parameters_update(bool force)
 				   _param_speed_d.get(),
 				   _param_speed_imax.get(),
 				   _param_gndspeed_max.get());
+
+		// _rate_control.set_k_p(_param_rate_p.get());
+		// _rate_control.set_k_i(_param_rate_i.get());
+		// _rate_control.set_k_ff(_param_rate_ff.get());
+		// _rate_control.set_integrator_max(_param_rate_imax.get());
+		// _rate_control.set_max_rate(_param_rate_max.get());
 	}
 }
 
@@ -145,6 +151,28 @@ RoverPositionControl::vehicle_attitude_poll()
 
 	if (att_updated) {
 		orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
+	}
+}
+
+void
+RoverPositionControl::rates_setpoint_poll()
+{
+	bool rates_sp_updated;
+	orb_check(_rates_sp_sub, &rates_sp_updated);
+
+	if (rates_sp_updated) {
+		orb_copy(ORB_ID(vehicle_rates_setpoint), _rates_sp_sub, &_rates_sp);
+	}
+}
+
+void
+RoverPositionControl::vehicle_angular_velocity_poll()
+{
+	bool rates_updated;
+	orb_check(_vehicle_angular_velocity_sub, &rates_updated);
+
+	if (rates_updated) {
+		orb_copy(ORB_ID(vehicle_angular_velocity), _vehicle_angular_velocity_sub, &_vehicle_rates);
 	}
 }
 
@@ -334,7 +362,12 @@ RoverPositionControl::control_attitude(const vehicle_attitude_s &att, const vehi
 	// quaternion attitude control law, qe is rotation from q to qd
 	const Quatf qe = Quatf(att.q).inversed() * Quatf(att_sp.q_d);
 	const Eulerf euler_sp = qe;
-
+	//TODO: Switch to rate controller
+	// struct ECL_ControlData control_input = {};
+	// control_input.yaw = euler_sp(2);
+	// _rate_control.control_attitude(control_input);
+	// control_input.yaw_rate_setpoint = _rate_control.get_desired_rate();
+	// float control_effort = att_control.control_bodyrate(control_input);
 	float control_effort = euler_sp(2) / _param_max_turn_angle.get();
 	control_effort = math::constrain(control_effort, -1.0f, 1.0f);
 
@@ -347,14 +380,43 @@ RoverPositionControl::control_attitude(const vehicle_attitude_s &att, const vehi
 }
 
 void
+RoverPositionControl::control_rates(const vehicle_angular_velocity_s &rates, const matrix::Vector3f &current_velocity,
+				    const vehicle_rates_setpoint_s &rates_sp)
+{
+	// struct ECL_ControlData control_input = {};
+	// const float current_speed = current_velocity.norm();
+
+	// Set scaling factor with local velocity
+	// control_input.groundspeed = current_speed;
+	// // Lock integrator when local velocity is small
+	// control_input.lock_integrator = (current_speed < _param_rate_i_minspeed.get());
+
+	// control_input.body_z_rate = rates.xyz[2];
+	// _rate_control.set_bodyrate_setpoint(rates_sp.yaw);
+
+	float control_effort = 0.0f;
+	// float control_effort = _rate_control.control_bodyrate(control_input);
+	control_effort = math::constrain(control_effort, -1.0f, 1.0f);
+
+	_act_controls.control[actuator_controls_s::INDEX_YAW] = control_effort;
+
+	const float control_throttle = rates_sp.thrust_body[0];
+
+	_act_controls.control[actuator_controls_s::INDEX_THROTTLE] =  math::constrain(control_throttle, 0.0f, 1.0f);
+}
+
+
+void
 RoverPositionControl::run()
 {
 	_control_mode_sub = orb_subscribe(ORB_ID(vehicle_control_mode));
 	_global_pos_sub = orb_subscribe(ORB_ID(vehicle_global_position));
 	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
+	_vehicle_angular_velocity_sub = orb_subscribe(ORB_ID(vehicle_angular_velocity));
 	_manual_control_setpoint_sub = orb_subscribe(ORB_ID(manual_control_setpoint));
 	_pos_sp_triplet_sub = orb_subscribe(ORB_ID(position_setpoint_triplet));
 	_att_sp_sub = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
+	_rates_sp_sub = orb_subscribe(ORB_ID(vehicle_rates_setpoint));
 
 	_vehicle_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
 	_sensor_combined_sub = orb_subscribe(ORB_ID(sensor_combined));
@@ -369,7 +431,7 @@ RoverPositionControl::run()
 	parameters_update(true);
 
 	/* wakeup source(s) */
-	px4_pollfd_struct_t fds[5];
+	px4_pollfd_struct_t fds[6];
 
 	/* Setup of loop */
 	fds[0].fd = _global_pos_sub;
@@ -382,6 +444,8 @@ RoverPositionControl::run()
 	fds[3].events = POLLIN;
 	fds[4].fd = _local_pos_sub;  // Added local position as source of position
 	fds[4].events = POLLIN;
+	fds[5].fd = _vehicle_angular_velocity_sub;  // Added local position as source of position
+	fds[5].events = POLLIN;
 
 	while (!should_exit()) {
 
@@ -397,6 +461,8 @@ RoverPositionControl::run()
 		/* check vehicle control mode for changes to publication state */
 		vehicle_control_mode_poll();
 		attitude_setpoint_poll();
+		rates_setpoint_poll();
+		vehicle_angular_velocity_poll();
 		//manual_control_setpoint_poll();
 
 		_vehicle_acceleration_sub.update();
@@ -480,14 +546,28 @@ RoverPositionControl::run()
 
 			vehicle_attitude_poll();
 
-			if (!manual_mode && _control_mode.flag_control_attitude_enabled
+			if (manual_mode && _control_mode.flag_control_attitude_enabled
 			    && !_control_mode.flag_control_position_enabled
 			    && !_control_mode.flag_control_velocity_enabled) {
-
 				control_attitude(_vehicle_att, _att_sp);
+				PX4_INFO("Control Attitude");
 
 			}
+		}
 
+		if (fds[5].revents & POLLIN) {
+			vehicle_angular_velocity_poll();
+
+			if (!manual_mode && _control_mode.flag_control_rates_enabled
+			    && !_control_mode.flag_control_attitude_enabled
+			    && !_control_mode.flag_control_position_enabled
+			    && !_control_mode.flag_control_velocity_enabled) {
+				//Offboard rate control
+				matrix::Vector3f vehicle_velocity(_local_pos.vx, _local_pos.vy, _local_pos.vz);
+				control_rates(_vehicle_rates, vehicle_velocity, _rates_sp);
+			}
+
+			//TODO: Add stabilized mode for rovers
 		}
 
 		if (fds[1].revents & POLLIN) {
@@ -517,6 +597,7 @@ RoverPositionControl::run()
 			if (_control_mode.flag_control_velocity_enabled ||
 			    _control_mode.flag_control_attitude_enabled ||
 			    _control_mode.flag_control_position_enabled ||
+			    _control_mode.flag_control_rates_enabled ||
 			    manual_mode) {
 				/* publish the actuator controls */
 				_actuator_controls_pub.publish(_act_controls);
@@ -530,7 +611,9 @@ RoverPositionControl::run()
 	orb_unsubscribe(_local_pos_sub);
 	orb_unsubscribe(_manual_control_setpoint_sub);
 	orb_unsubscribe(_pos_sp_triplet_sub);
+	orb_unsubscribe(_rates_sp_sub);
 	orb_unsubscribe(_vehicle_attitude_sub);
+	orb_unsubscribe(_vehicle_angular_velocity_sub);
 	orb_unsubscribe(_sensor_combined_sub);
 
 	warnx("exiting.\n");

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -41,8 +41,9 @@
  * @author Marco Zorzi <mzorzi@student.ethz.ch>
  */
 
-#include <float.h>
+#include <RoverRateControl.hpp>
 
+#include <float.h>
 #include <drivers/drv_hrt.h>
 #include <lib/ecl/geo/geo.h>
 #include <lib/l1/ECL_L1_Pos_Controller.hpp>
@@ -65,6 +66,8 @@
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
+#include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -108,7 +111,9 @@ private:
 	int		_manual_control_setpoint_sub{-1};		/**< notification of manual control updates */
 	int		_pos_sp_triplet_sub{-1};
 	int		_att_sp_sub{-1};
+	int		_rates_sp_sub{-1};
 	int		_vehicle_attitude_sub{-1};
+	int		_vehicle_angular_velocity_sub{-1};
 	int		_sensor_combined_sub{-1};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
@@ -116,11 +121,13 @@ private:
 	manual_control_setpoint_s		_manual_control_setpoint{};			    /**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
 	vehicle_attitude_setpoint_s		_att_sp{};			/**< attitude setpoint > */
+	vehicle_rates_setpoint_s		_rates_sp{};			/**< rate setpoint > */
 	vehicle_control_mode_s			_control_mode{};		/**< control mode */
 	vehicle_global_position_s		_global_pos{};			/**< global vehicle position */
 	vehicle_local_position_s		_local_pos{};			/**< global vehicle position */
 	actuator_controls_s				_act_controls{};		/**< direct control of actuators */
 	vehicle_attitude_s				_vehicle_att{};
+	vehicle_angular_velocity_s 		_vehicle_rates{};
 	sensor_combined_s				_sensor_combined{};
 
 	uORB::SubscriptionData<vehicle_acceleration_s>		_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
@@ -137,6 +144,7 @@ private:
 	uint8_t _pos_reset_counter{0};		// captures the number of times the estimator has reset the horizontal position
 
 	ECL_L1_Pos_Controller				_gnd_control;
+	RoverRateControl				_rate_control;
 
 	enum UGV_POSCTRL_MODE {
 		UGV_POSCTRL_MODE_AUTO,
@@ -167,6 +175,13 @@ private:
 		(ParamFloat<px4::params::GND_SPEED_IMAX>) _param_speed_imax,
 		(ParamFloat<px4::params::GND_SPEED_THR_SC>) _param_throttle_speed_scaler,
 
+		(ParamFloat<px4::params::GND_RATE_P>) _param_rate_p,
+		(ParamFloat<px4::params::GND_RATE_I>) _param_rate_i,
+		(ParamFloat<px4::params::GND_RATE_FF>) _param_rate_ff,
+		(ParamFloat<px4::params::GND_RATE_IMAX>) _param_rate_imax,
+		(ParamFloat<px4::params::GND_RATE_MAX>) _param_rate_max,
+		(ParamFloat<px4::params::GND_RATE_IMINSPD>) _param_rate_i_minspeed,
+
 		(ParamFloat<px4::params::GND_THR_MIN>) _param_throttle_min,
 		(ParamFloat<px4::params::GND_THR_MAX>) _param_throttle_max,
 		(ParamFloat<px4::params::GND_THR_CRUISE>) _param_throttle_cruise,
@@ -184,8 +199,10 @@ private:
 	void		manual_control_setpoint_poll();
 	void		position_setpoint_triplet_poll();
 	void		attitude_setpoint_poll();
+	void		rates_setpoint_poll();
 	void		vehicle_control_mode_poll();
 	void 		vehicle_attitude_poll();
+	void		vehicle_angular_velocity_poll();
 
 	/**
 	 * Control position.
@@ -194,5 +211,7 @@ private:
 					 const position_setpoint_triplet_s &_pos_sp_triplet);
 	void		control_velocity(const matrix::Vector3f &current_velocity, const position_setpoint_triplet_s &pos_sp_triplet);
 	void		control_attitude(const vehicle_attitude_s &att, const vehicle_attitude_setpoint_s &att_sp);
+	void		control_rates(const vehicle_angular_velocity_s &rates, const matrix::Vector3f &current_velocity,
+				      const vehicle_rates_setpoint_s &rates_sp);
 
 };

--- a/src/modules/rover_pos_control/RoverRateControl/CMakeLists.txt
+++ b/src/modules/rover_pos_control/RoverRateControl/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,16 +31,12 @@
 #
 ############################################################################
 
-add_subdirectory(RoverRateControl)
+px4_add_library(RoverRateControl
+	RoverRateControl.cpp
+	RoverRateControl.hpp
+)
+target_compile_options(RoverRateControl PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+target_include_directories(RoverRateControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(RoverRateControl PRIVATE mathlib)
 
-px4_add_module(
-	MODULE modules__rover_pos_control
-	MAIN rover_pos_control
-	SRCS
-		RoverPositionControl.cpp
-		RoverPositionControl.hpp
-	DEPENDS
-		RoverRateControl
-		l1
-		pid
-	)
+px4_add_unit_gtest(SRC RoverRateControlTest.cpp LINKLIBS RateControl)

--- a/src/modules/rover_pos_control/RoverRateControl/RoverRateControl.cpp
+++ b/src/modules/rover_pos_control/RoverRateControl/RoverRateControl.cpp
@@ -1,0 +1,168 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file RoverRateControl.cpp
+ */
+
+#include <RoverRateControl.hpp>
+#include <px4_platform_common/defines.h>
+
+using namespace matrix;
+
+void RoverRateControl::setGains(const Vector3f &P, const Vector3f &I, const Vector3f &D)
+{
+	_gain_p = P;
+	_gain_i = I;
+	_gain_d = D;
+}
+
+void RoverRateControl::setSaturationStatus(const MultirotorMixer::saturation_status &status)
+{
+	_mixer_saturation_positive[0] = status.flags.roll_pos;
+	_mixer_saturation_positive[1] = status.flags.pitch_pos;
+	_mixer_saturation_positive[2] = status.flags.yaw_pos;
+	_mixer_saturation_negative[0] = status.flags.roll_neg;
+	_mixer_saturation_negative[1] = status.flags.pitch_neg;
+	_mixer_saturation_negative[2] = status.flags.yaw_neg;
+}
+
+Vector3f RoverRateControl::update(const Vector3f &rate, const Vector3f &rate_sp, const Vector3f &angular_accel,
+				  const float dt, const bool landed)
+{
+	// /* Do not calculate control signal with bad inputs */
+	// if (!(PX4_ISFINITE(ctl_data.body_z_rate))) {
+
+	// 	return math::constrain(_last_output, -1.0f, 1.0f);
+	// }
+
+	// /* get the usual dt estimate */
+	// uint64_t dt_micros = hrt_elapsed_time(&_last_run);
+	// _last_run = hrt_absolute_time();
+	// float dt = (float)dt_micros * 1e-6f;
+
+	// /* lock integral for long intervals */
+	// bool lock_integrator = ctl_data.lock_integrator;
+
+	// if (dt_micros > 500000) {
+	// 	lock_integrator = true;
+	// }
+
+	// //TODO: Handle differential rover and ackerman differently
+	// // A. Integrator should not integrate if there is no groundspeed for ackerman
+	// // B. speed scaling should not be done in differential rovers
+
+	// //Only using vehicle kinematiccs, without considering tire slip
+
+	// /* Calculate body angular rate error */
+	// _rate_error = _bodyrate_setpoint - ctl_data.body_z_rate; // body angular rate error
+
+	// float scaler = math::max(ctl_data.groundspeed, 0.1f);
+
+	// if (!lock_integrator && _k_i > 0.0f) {
+
+	// 	float id = _rate_error * dt;
+
+	// 	/*
+	// 	 * anti-windup: do not allow integrator to increase if actuator is at limit
+	// 	 */
+	// 	if (_last_output < -1.0f) {
+	// 		/* only allow motion to center: increase value */
+	// 		id = math::max(id, 0.0f);
+
+	// 	} else if (_last_output > 1.0f) {
+	// 		/* only allow motion to center: decrease value */
+	// 		id = math::min(id, 0.0f);
+	// 	}
+
+	// 	/* add and constrain */
+	// 	_integrator = math::constrain(_integrator + id * _k_i, -_integrator_max, _integrator_max);
+	// }
+
+	// /* Apply PI rate controller and store non-limited output */
+	// _last_output = (_bodyrate_setpoint * _k_ff + _rate_error * _k_p) / scaler + _integrator;
+	// _last_output = math::constrain(_last_output, -1.0f, 1.0f);
+	// return _last_output;
+
+	// angular rates error
+	Vector3f rate_error = rate_sp - rate;
+
+	// PID control with feed forward
+	const Vector3f torque = _gain_p.emult(rate_error) + _rate_int - _gain_d.emult(angular_accel) + _gain_ff.emult(rate_sp);
+
+	// update integral only if we are not landed
+	if (!landed) {
+		updateIntegral(rate_error, dt);
+	}
+
+	return torque;
+}
+
+void RoverRateControl::updateIntegral(Vector3f &rate_error, const float dt)
+{
+	for (int i = 0; i < 3; i++) {
+		// prevent further positive control saturation
+		if (_mixer_saturation_positive[i]) {
+			rate_error(i) = math::min(rate_error(i), 0.f);
+		}
+
+		// prevent further negative control saturation
+		if (_mixer_saturation_negative[i]) {
+			rate_error(i) = math::max(rate_error(i), 0.f);
+		}
+
+		// I term factor: reduce the I gain with increasing rate error.
+		// This counteracts a non-linear effect where the integral builds up quickly upon a large setpoint
+		// change (noticeable in a bounce-back effect after a flip).
+		// The formula leads to a gradual decrease w/o steps, while only affecting the cases where it should:
+		// with the parameter set to 400 degrees, up to 100 deg rate error, i_factor is almost 1 (having no effect),
+		// and up to 200 deg error leads to <25% reduction of I.
+		float i_factor = rate_error(i) / math::radians(400.f);
+		i_factor = math::max(0.0f, 1.f - i_factor * i_factor);
+
+		// Perform the integration using a first order method
+		float rate_i = _rate_int(i) + i_factor * _gain_i(i) * rate_error(i) * dt;
+
+		// do not propagate the result if out of range or invalid
+		if (PX4_ISFINITE(rate_i)) {
+			_rate_int(i) = math::constrain(rate_i, -_lim_int(i), _lim_int(i));
+		}
+	}
+}
+
+void RoverRateControl::getRoverRateControlStatus(rate_ctrl_status_s &rate_ctrl_status)
+{
+	rate_ctrl_status.rollspeed_integ = _rate_int(0);
+	rate_ctrl_status.pitchspeed_integ = _rate_int(1);
+	rate_ctrl_status.yawspeed_integ = _rate_int(2);
+}

--- a/src/modules/rover_pos_control/RoverRateControl/RoverRateControl.hpp
+++ b/src/modules/rover_pos_control/RoverRateControl/RoverRateControl.hpp
@@ -1,0 +1,118 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file RoverRateControl.hpp
+ *
+ * PID 3 axis angular rate / angular velocity control.
+ */
+
+#pragma once
+
+#include <matrix/matrix/math.hpp>
+#include <mathlib/math/filter/LowPassFilter2pVector3f.hpp>
+
+#include <lib/mixer/MultirotorMixer/MultirotorMixer.hpp>
+#include <uORB/topics/rate_ctrl_status.h>
+
+class RoverRateControl
+{
+public:
+	RoverRateControl() = default;
+	~RoverRateControl() = default;
+
+	/**
+	 * Set the rate control gains
+	 * @param P 3D vector of proportional gains for body x,y,z axis
+	 * @param I 3D vector of integral gains
+	 * @param D 3D vector of derivative gains
+	 */
+	void setGains(const matrix::Vector3f &P, const matrix::Vector3f &I, const matrix::Vector3f &D);
+
+	/**
+	 * Set the mximum absolute value of the integrator for all axes
+	 * @param integrator_limit limit value for all axes x, y, z
+	 */
+	void setIntegratorLimit(const matrix::Vector3f &integrator_limit) { _lim_int = integrator_limit; };
+
+	/**
+	 * Set direct rate to torque feed forward gain
+	 * @see _gain_ff
+	 * @param FF 3D vector of feed forward gains for body x,y,z axis
+	 */
+	void setFeedForwardGain(const matrix::Vector3f &FF) { _gain_ff = FF; };
+
+	/**
+	 * Set saturation status
+	 * @param status message from mixer reporting about saturation
+	 */
+	void setSaturationStatus(const MultirotorMixer::saturation_status &status);
+
+	/**
+	 * Run one control loop cycle calculation
+	 * @param rate estimation of the current vehicle angular rate
+	 * @param rate_sp desired vehicle angular rate setpoint
+	 * @param dt desired vehicle angular rate setpoint
+	 * @return [-1,1] normalized torque vector to apply to the vehicle
+	 */
+	matrix::Vector3f update(const matrix::Vector3f &rate, const matrix::Vector3f &rate_sp,
+				const matrix::Vector3f &angular_accel, const float dt, const bool landed);
+
+	/**
+	 * Set the integral term to 0 to prevent windup
+	 * @see _rate_int
+	 */
+	void resetIntegral() { _rate_int.zero(); }
+
+	/**
+	 * Get status message of controller for logging/debugging
+	 * @param rate_ctrl_status status message to fill with internal states
+	 */
+	void getRoverRateControlStatus(rate_ctrl_status_s &rate_ctrl_status);
+
+private:
+	void updateIntegral(matrix::Vector3f &rate_error, const float dt);
+
+	// Gains
+	matrix::Vector3f _gain_p; ///< rate control proportional gain for all axes x, y, z
+	matrix::Vector3f _gain_i; ///< rate control integral gain
+	matrix::Vector3f _gain_d; ///< rate control derivative gain
+	matrix::Vector3f _lim_int; ///< integrator term maximum absolute value
+	matrix::Vector3f _gain_ff; ///< direct rate to torque feed forward gain only useful for helicopters
+
+	// States
+	matrix::Vector3f _rate_int; ///< integral term of the rate controller
+
+	bool _mixer_saturation_positive[3] {};
+	bool _mixer_saturation_negative[3] {};
+};

--- a/src/modules/rover_pos_control/RoverRateControl/RoverRateControlTest.cpp
+++ b/src/modules/rover_pos_control/RoverRateControl/RoverRateControlTest.cpp
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <RoverRateControl.hpp>
+
+using namespace matrix;
+
+TEST(RoverRateControlTest, AllZeroCase)
+{
+	RoverRateControl rate_control;
+	Vector3f torque = rate_control.update(Vector3f(), Vector3f(), Vector3f(), 0.f, false);
+	EXPECT_EQ(torque, Vector3f());
+}

--- a/src/modules/rover_pos_control/rover_pos_control_params.c
+++ b/src/modules/rover_pos_control/rover_pos_control_params.c
@@ -286,3 +286,76 @@ PARAM_DEFINE_FLOAT(GND_WHEEL_BASE, 2.0f);
  * @group Rover Position Control
  */
 PARAM_DEFINE_FLOAT(GND_MAX_ANG, 0.7854f);
+
+/**
+ * Rover Rate Proportional Gain
+ *
+ * @unit rad/s
+ * @min 0.0
+ * @max 10.0
+ * @decimal 3
+ * @increment 0.01
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_RATE_P, 5.0f);
+
+/**
+ * Rover Rate Integral Gain
+ *
+ * @unit rad/s
+ * @min 0.0
+ * @max 1.0
+ * @decimal 3
+ * @increment 0.005
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_RATE_I, 0.5f);
+
+/**
+ * Rover Rate Proportional Gain
+ *
+ * @unit rad/s
+ * @min 0.0
+ * @max 10.0
+ * @decimal 3
+ * @increment 0.01
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_RATE_FF, 1.6f);
+
+/**
+ * Rover Rate Maximum Integral Gain
+ *
+ * @unit rad/s
+ * @min 0.0
+ * @max 50.0
+ * @decimal 3
+ * @increment 0.005
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_RATE_IMAX, 1.0f);
+
+/**
+ * Rover Rate Maximum Rate
+ *
+ * @unit rad/s
+ * @min 0.0
+ * @max 50.0
+ * @decimal 3
+ * @increment 0.005
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_RATE_MAX, 5.0f);
+
+/**
+ * Rover Rate Integral Minimum speed
+ * Rate integral is locked below this speed
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 50.0
+ * @decimal 3
+ * @increment 0.005
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_RATE_IMINSPD, 0.3f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, rover steering control has been mainly done in a open-loop fashion by simply setting the steering angle from the controller.

However, this results in unstable and unpredictable steering behaviors in high speed as well as uneven terrain. This open loop control also have been shown to introduce oscillations when using on boats. 

**Describe your solution**
This PR adds a bodyrate controller (yaw) that can be activated through offboard control on the rover. This is mainly to demonstrate the rate control behaviors on the rover.

This also moves the [ECL_Controller](https://github.com/PX4/Firmware/blob/master/src/modules/fw_att_control/ecl_controller.h) baseclass that was recently moved to the firmware from PX4/ecl to a library, so that it can be used in the `rover_pos_controller` as well as the `fw_att_controller`



**Test data / coverage**
Offboard control log: https://review.px4.io/plot_app?log=a30ebfd4-96cb-4fc8-9e55-8606fb5ef4b5

**Additional Context**
Switching to a body rate based controller will bring the following benefits
- Introduce stabilized mode to rover
- Deprecate the parameter `GND_MAX_ANG` and minimize the difference between the differential rover and ackerman steering vehicle (https://github.com/PX4/Firmware/issues/13468)