### PR TITLE
Add support for actuator control via DO_SET_ACTUATOR

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -46,6 +46,7 @@
 #include <drivers/drv_rc_input.h>
 #include <ecl/geo/geo.h>
 #include <systemlib/px4_macros.h>
+#include <systemlib/mavlink_log.h>
 
 #include <math.h>
 #include <poll.h>
@@ -69,6 +70,8 @@
 #else
 #define MAVLINK_RECEIVER_NET_ADDED_STACK 0
 #endif
+
+extern orb_advert_t mavlink_log_pub;
 
 using matrix::wrap_2pi;
 
@@ -487,8 +490,58 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 			send_ack = true;
 		}
 
-	} else {
+	} else if (cmd_mavlink.command == MAV_CMD_DO_SET_ACTUATOR) {
+        mavlink_log_info(&mavlink_log_pub, "setting");
+        int input_mode = _param_mav_act_in_mode.get();
+        if (input_mode == 1) {
+            // Actuator control strictly on RC mode, so ignore this message
+            return;
+        }
 
+        actuator_controls_s actuator_controls{};
+        actuator_controls.timestamp = hrt_absolute_time();
+
+        //PX4_INFO("Hello!");
+        // copy the existing values in order to change only one output
+        //orb_copy(ORB_ID(actuator_controls_3), _actuator_controls_3_sub,
+                //&actuator_controls);
+        _actuator_controls_3_sub.update(&actuator_controls);
+        //PX4_INFO("Hello!");
+
+        bool updated = false;
+        if (PX4_ISFINITE(vehicle_command.param1)) {
+            actuator_controls.control[5] = vehicle_command.param1;
+            updated = true;
+        }
+        if (PX4_ISFINITE(vehicle_command.param2)) {
+            actuator_controls.control[6] = vehicle_command.param2;
+            updated = true;
+        }
+        if (PX4_ISFINITE(vehicle_command.param3)) {
+            actuator_controls.control[7] = vehicle_command.param3;
+            updated = true;
+        }
+        PX4_INFO("Hello! %d %d %f", updated, ((int) vehicle_command.param7 == 0),
+                (double) vehicle_command.param7);
+
+        // as of now we don't support more than 3 values
+        // (for aux1, aux2, and aux3, respectively)
+        // so if the offset index is > 0, we don't need to do anything
+        if (updated && ((int) vehicle_command.param7 == 0)) {
+            // useful for debugging, not removing this until after testing
+            PX4_INFO("Setting actuators (normalized): %f %f %f",
+                    (double) vehicle_command.param1,
+                    (double) vehicle_command.param2,
+                    (double) vehicle_command.param3);
+            mavlink_log_info(&mavlink_log_pub, "Setting actuators (normalized): %f %f %f",
+                    (double) vehicle_command.param1,
+                    (double) vehicle_command.param2,
+                    (double) vehicle_command.param3);
+
+            _actuator_controls_pubs[3].publish(actuator_controls);
+        }
+
+    } else {
 		send_ack = false;
 
 		if (msg->sysid == mavlink_system.sysid && msg->compid == mavlink_system.compid) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -491,55 +491,48 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		}
 
 	} else if (cmd_mavlink.command == MAV_CMD_DO_SET_ACTUATOR) {
-        mavlink_log_info(&mavlink_log_pub, "setting");
+		PX4_INFO("setting");
         int input_mode = _param_mav_act_in_mode.get();
-        if (input_mode == 1) {
-            // Actuator control strictly on RC mode, so ignore this message
-            return;
-        }
+		// input_mode == 1: Actuator control strictly on RC mode, so ignore this message
+        if (input_mode != 1) {
+			actuator_controls_s actuator_controls{};
+			actuator_controls.timestamp = hrt_absolute_time();
 
-        actuator_controls_s actuator_controls{};
-        actuator_controls.timestamp = hrt_absolute_time();
+			// copy the existing values in order to change only one output
+			//orb_copy(ORB_ID(actuator_controls_3), _actuator_controls_3_sub,
+					//&actuator_controls);
+			_actuator_controls_3_sub.update(&actuator_controls);
+			PX4_INFO("updated!");
 
-        //PX4_INFO("Hello!");
-        // copy the existing values in order to change only one output
-        //orb_copy(ORB_ID(actuator_controls_3), _actuator_controls_3_sub,
-                //&actuator_controls);
-        _actuator_controls_3_sub.update(&actuator_controls);
-        //PX4_INFO("Hello!");
+			bool updated = false;
+			if (PX4_ISFINITE(vehicle_command.param1)) {
+				actuator_controls.control[5] = vehicle_command.param1;
+				updated = true;
+			}
+			if (PX4_ISFINITE(vehicle_command.param2)) {
+				actuator_controls.control[6] = vehicle_command.param2;
+				updated = true;
+			}
+			if (PX4_ISFINITE(vehicle_command.param3)) {
+				actuator_controls.control[7] = vehicle_command.param3;
+				updated = true;
+			}
+			PX4_INFO("Hello! %d %d %f", updated, ((int) vehicle_command.param7 == 0),
+					(double) vehicle_command.param7);
 
-        bool updated = false;
-        if (PX4_ISFINITE(vehicle_command.param1)) {
-            actuator_controls.control[5] = vehicle_command.param1;
-            updated = true;
-        }
-        if (PX4_ISFINITE(vehicle_command.param2)) {
-            actuator_controls.control[6] = vehicle_command.param2;
-            updated = true;
-        }
-        if (PX4_ISFINITE(vehicle_command.param3)) {
-            actuator_controls.control[7] = vehicle_command.param3;
-            updated = true;
-        }
-        PX4_INFO("Hello! %d %d %f", updated, ((int) vehicle_command.param7 == 0),
-                (double) vehicle_command.param7);
+			// as of now we don't support more than 3 values
+			// (for aux1, aux2, and aux3, respectively)
+			// so if the offset index is > 0, we don't need to do anything
+			if (updated && ((int) vehicle_command.param7 == 0)) {
+				// useful for debugging, not removing this until after testing
+				PX4_INFO("Setting actuators (normalized): %f %f %f",
+						(double) vehicle_command.param1,
+						(double) vehicle_command.param2,
+						(double) vehicle_command.param3);
 
-        // as of now we don't support more than 3 values
-        // (for aux1, aux2, and aux3, respectively)
-        // so if the offset index is > 0, we don't need to do anything
-        if (updated && ((int) vehicle_command.param7 == 0)) {
-            // useful for debugging, not removing this until after testing
-            PX4_INFO("Setting actuators (normalized): %f %f %f",
-                    (double) vehicle_command.param1,
-                    (double) vehicle_command.param2,
-                    (double) vehicle_command.param3);
-            mavlink_log_info(&mavlink_log_pub, "Setting actuators (normalized): %f %f %f",
-                    (double) vehicle_command.param1,
-                    (double) vehicle_command.param2,
-                    (double) vehicle_command.param3);
-
-            _actuator_controls_pubs[3].publish(actuator_controls);
-        }
+				_actuator_controls_pubs[3].publish(actuator_controls);
+			}
+		}
 
     } else {
 		send_ack = false;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -310,7 +310,7 @@ private:
 	uORB::Subscription	_vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription	_vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription	_vehicle_status_sub{ORB_ID(vehicle_status)};
-    uORB::Subscription  _actuator_controls_3_sub{ORB_ID(actuator_controls_3)};
+	uORB::Subscription  _actuator_controls_3_sub{ORB_ID(actuator_controls_3)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -310,6 +310,7 @@ private:
 	uORB::Subscription	_vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription	_vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription	_vehicle_status_sub{ORB_ID(vehicle_status)};
+    uORB::Subscription  _actuator_controls_3_sub{ORB_ID(actuator_controls_3)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -369,7 +370,8 @@ private:
 		(ParamFloat<px4::params::SENS_FLOW_MAXHGT>) _param_sens_flow_maxhgt,
 		(ParamFloat<px4::params::SENS_FLOW_MAXR>)   _param_sens_flow_maxr,
 		(ParamFloat<px4::params::SENS_FLOW_MINHGT>) _param_sens_flow_minhgt,
-		(ParamInt<px4::params::SENS_FLOW_ROT>)      _param_sens_flow_rot
+		(ParamInt<px4::params::SENS_FLOW_ROT>)      _param_sens_flow_rot,
+		(ParamInt<px4::params::MAV_ACT_IN_MODE>)    _param_mav_act_in_mode
 	);
 
 	// Disallow copy construction and move assignment.

--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -95,3 +95,21 @@ parameters:
             reboot_required: true
             num_instances: *max_num_config_instances
             default: [true, true, true]
+        MAV_ACT_IN_MODE:
+            description:
+                short: Input mode for manual actuator control
+                long: |
+                    Sets the input source used to control actuators manually.
+                    
+                    Options are RC control, MAVLink control (see MAV_CMD_DO_SET_ACTUATOR),
+                    and `auto`.
+
+                    Set to `auto` automatically uses the latest value.
+
+            type: enum
+            reboot_required: true
+            values:
+                0: Auto
+                1: RC
+                2: MAVLink
+            default: 0

--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -100,7 +100,7 @@ parameters:
                 short: Input mode for manual actuator control
                 long: |
                     Sets the input source used to control actuators manually.
-                    
+
                     Options are RC control, MAVLink control (see MAV_CMD_DO_SET_ACTUATOR),
                     and `auto`.
 

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -454,6 +454,7 @@ void RCUpdate::Run()
 			/* copy from mapped manual_control_setpoint control to control group 3 */
 			actuator_controls_s actuator_group_3{};
 
+			/*
 			actuator_group_3.timestamp = rc_input.timestamp_last_signal;
 
 			actuator_group_3.control[0] = manual_control_setpoint.y;
@@ -480,6 +481,7 @@ void RCUpdate::Run()
             }
             //} else {
                 //// Auto mode
+            */
 
 			/* publish actuator_controls_3 topic */
 			_actuator_group_3_pub.publish(actuator_group_3);

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -162,6 +162,8 @@ private:
 
 	uORB::Subscription _rc_parameter_map_sub{ORB_ID(rc_parameter_map)};
 
+    uORB::Subscription  _actuator_controls_3_sub{ORB_ID(actuator_controls_3)};
+
 	uORB::Publication<rc_channels_s> _rc_channels_pub{ORB_ID(rc_channels)};
 	uORB::PublicationMulti<manual_control_setpoint_s> _manual_control_setpoint_pub{ORB_ID(manual_control_setpoint)};
 	uORB::Publication<manual_control_switches_s> _manual_control_switches_pub{ORB_ID(manual_control_switches)};
@@ -239,7 +241,9 @@ private:
 		(ParamFloat<px4::params::RC_MAN_TH>) _param_rc_man_th,
 		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
 
-		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt
+		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt,
+
+		(ParamInt<px4::params::MAV_ACT_IN_MODE>) _param_mav_act_in_mode
 	)
 };
 } /* namespace RCUpdate */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Implements MAV_CMD_DO_SET_SERVO

**Describe your solution**
The DO_SET_SERVO pwm value is normalized and fed written to a control group. There are 2 control groups allowed, set by the MAV_SET_SRV_GRP enum parameter. When in 0/RC mode (default), only 1, 2, or 3 are allowed for the instance number. This is mapped to RC aux 1, 2, and 3 on control group 3. When in 1/Payload mode, values from 1 - 8 are allowed, and are mapped to control group 6. Note that this requires a mixer for control group 6 to be defined prior to use.

**Describe possible alternatives**
This is still sort of hacky; I'm only implementing it because it's a simple solution for most people wanting to control a random actuator, and this feature has been requested many times. Use case-specific messages and control groups are preferred.

**Test data / coverage**
Unfortunately the only testing I was able to do was spin up SITL and do some logging. It seems to be working fine, and the values/calculations are all correc when I send MAV_CMD_DO_SET_SERVO, but I haven't tested on an actual drone to see if the servo value gets set. Unfortunately my only flight controller is currently in use; I will try to acquire a spare and test it in real life. If someone else could do this as well, that would be appreciated.

**Additional context**
Quick and dirty pymavlink script for testing:
```
from pymavlink import mavutil

conn = mavutil.mavlink_connection('udp:localhost:14552')
conn.wait_heartbeat()

conn.mav.command_long_send(
   conn.target_system, conn.target_component,
   mavutil.mavlink.MAV_CMD_DO_SET_SERVO, 0,
   1, 1700, 0, 0, 0, 0, 0) # replace 1 with the servo instance, and 1700 with the desired PWM
```
This PR builds on https://github.com/PX4/Firmware/pull/10320/. Also related https://github.com/mavlink/mavlink/pull/1414 for reference.