### PR TITLE
Add Land as Geofence Action

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -4,6 +4,7 @@ uint8 GF_ACTION_WARN = 1                    # critical mavlink message
 uint8 GF_ACTION_LOITER = 2                  # switch to AUTO|LOITER
 uint8 GF_ACTION_RTL = 3                     # switch to AUTO|RTL
 uint8 GF_ACTION_TERMINATE = 4               # flight termination
+uint8 GF_ACTION_LAND = 5		    # switch to AUTO|LAND
 
 bool geofence_violated		# true if the geofence is violated
 uint8 geofence_action       	# action to take when geofence is violated

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1765,6 +1765,15 @@ Commander::run()
 						break;
 					}
 
+				case (geofence_result_s::GF_ACTION_LAND) : {
+						if (TRANSITION_CHANGED == main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LAND, status_flags,
+								&_internal_state)) {
+							_geofence_land_on = true;
+						}
+
+						break;
+					}
+
 				case (geofence_result_s::GF_ACTION_TERMINATE) : {
 						PX4_WARN("Flight termination because of geofence");
 						mavlink_log_critical(&mavlink_log_pub, "Geofence violation! Flight terminated");
@@ -1794,12 +1803,21 @@ Commander::run()
 				_geofence_rtl_on = false;
 			}
 
-			_geofence_warning_action_on = _geofence_warning_action_on || (_geofence_loiter_on || _geofence_rtl_on);
+			// reset if no longer in LAND or if manually switched to LAND
+			const bool in_land_mode = _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND;
+
+			if (!in_land_mode) {
+				_geofence_land_on = false;
+			}
+
+			_geofence_warning_action_on = _geofence_warning_action_on || (_geofence_loiter_on || _geofence_rtl_on
+						      || _geofence_land_on);
 
 		} else {
 			// No geofence checks, reset flags
 			_geofence_loiter_on = false;
 			_geofence_rtl_on = false;
+			_geofence_land_on = false;
 			_geofence_warning_action_on = false;
 			_geofence_violated_prev = false;
 		}

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -304,6 +304,7 @@ private:
 
 	bool		_geofence_loiter_on{false};
 	bool		_geofence_rtl_on{false};
+	bool		_geofence_land_on{false};
 	bool		_geofence_warning_action_on{false};
 	bool		_geofence_violated_prev{false};
 

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -53,12 +53,13 @@
  * to be reset to 0 to really shut down the system.
  *
  * @min 0
- * @max 4
+ * @max 5
  * @value 0 None
  * @value 1 Warning
  * @value 2 Hold mode
  * @value 3 Return mode
  * @value 4 Terminate
+ * @value 5 Land mode
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_ACTION, 1);

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -248,7 +248,7 @@ void VehicleIMU::Run()
 
 			// rotate sensor clip counts into vehicle body frame
 			const Vector3f clipping{_accel_calibration.getBoardRotation() *
-				Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
+						Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
 
 			// round to get reasonble clip counts per axis (after board rotation)
 			const uint8_t clip_x = roundf(fabsf(clipping(0)));

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -248,7 +248,7 @@ void VehicleIMU::Run()
 
 			// rotate sensor clip counts into vehicle body frame
 			const Vector3f clipping{_accel_calibration.getBoardRotation() *
-						Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
+				Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
 
 			// round to get reasonble clip counts per axis (after board rotation)
 			const uint8_t clip_x = roundf(fabsf(clipping(0)));


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.
@dagar 

**Describe problem solved by this pull request**
Entering Land mode as Geofence breach action is currently not supported. 

**Describe your solution**
This PR adds the Land mode as possible Geofence action when [GF_ACTION](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#GF_ACTION) is set to 5. 

**Describe possible alternatives**
For the severity logic of the GF_ACTION it would make more sense to have Land as 4 and push Terminate to 5, but doing so would affect all the users who have currently set it to Terminate. If it is very important to keep the logic in the enum, then we'd need to make sure that all users affected by this change are warned in a way that can't be overlooked.

**Test data / coverage**
Tested with SITL gazebo_standard_vtol: 

1. Fly a mission with a rally point outside of the Geofence and trigger RTL from QGC : https://logs.px4.io/plot_app?log=68231183-0708-4ced-9ee8-1a730ae69fc1
Land mode is triggered when it should. Initiating a transition to MC as NAV_FORCE_VT is set.

2. Fly in Stabilized MC mode with PS4 controller as Joystick: https://logs.px4.io/plot_app?log=09bbfe95-bca8-49dc-b95c-e9ac94d162f2
Land mode is triggered when it should. (Actually, thrust is doing weird things in Land mode, but that's unrelated to this PR.) 
Switching back to Stabilized works.

3. Refusing Takeoff outside geofence: https://logs.px4.io/plot_app?log=55e2fa2b-faba-4e7a-b593-fd482aae6d7a

4. Geofence breach in Stabilised FW mode: https://logs.px4.io/plot_app?log=8f7db78b-055b-470d-b815-10ec596d56fc
Behaviour as expected, same as in FW RTL.

5. A first Geofence breach in Stabilised FW, afterwards overriding Land mode with MC Position mode, flying back into Geofence and outside of it again: https://logs.px4.io/plot_app?log=ac9ec13f-35aa-4b8b-888e-cb1776f9f682
The geofence action is taken on both breaches.

**Additional context**
I'm not sure if there is the possibility to have a dedicated Land switch when flying in manual (as there is for RTL and Loiter). So I took out this switch check for setting `_geofence_land_on`. Apart from that I copied from the RTL geofence action.

It would be really nice if this could still make it into v1.11 release. It would really help us with our operations. :)