### PR TITLE
Handle MAV_CMD_DO_CHANGE_SPEED command for FW Offboard global positio…

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3119,7 +3119,13 @@ MavlinkReceiver::get_offb_cruising_speed()
 	vehicle_status_s vehicle_status{};
 	_vehicle_status_sub.copy(&vehicle_status);
 
-	if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING && _offb_cruising_speed_mc > 0.0f) {
+	    return _offb_cruising_speed_mc;
+	} else if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && _offb_cruising_speed_fw > 0.0f) {
+	    return _offb_cruising_speed_fw;
+	} else {
+	    return -1.0f;
+	}
 		if (_offb_cruising_speed_mc > 0.0f) {
 			return _offb_cruising_speed_mc;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3120,26 +3120,13 @@ MavlinkReceiver::get_offb_cruising_speed()
 	_vehicle_status_sub.copy(&vehicle_status);
 
 	if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING && _offb_cruising_speed_mc > 0.0f) {
-	    return _offb_cruising_speed_mc;
+		return _offb_cruising_speed_mc;
+
 	} else if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && _offb_cruising_speed_fw > 0.0f) {
-	    return _offb_cruising_speed_fw;
-	} else {
-	    return -1.0f;
-	}
-		if (_offb_cruising_speed_mc > 0.0f) {
-			return _offb_cruising_speed_mc;
-
-		} else {
-			return -1.0f;
-		}
+		return _offb_cruising_speed_fw;
 
 	} else {
-		if (_offb_cruising_speed_fw > 0.0f) {
-			return _offb_cruising_speed_fw;
-
-		} else {
-			return -1.0f;
-		}
+		return -1.0f;
 	}
 }
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -516,11 +516,12 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 
 		} else if (cmd_mavlink.command == MAV_CMD_LOGGING_STOP) {
 			_mavlink->request_stop_ulog_streaming();
-		}
 
-		if (cmd_mavlink.command == MAV_CMD_DO_CHANGE_SPEED) {
-			// Not differentiating between airspeed and groundspeed yet
-			set_offb_cruising_speed(cmd_mavlink.param2);
+		} else if (cmd_mavlink.command == MAV_CMD_DO_CHANGE_SPEED) {
+			if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_OFFBOARD) {
+				// Not differentiating between airspeed and groundspeed yet
+				set_offb_cruising_speed(cmd_mavlink.param2);
+			}
 		}
 
 		if (!send_ack) {
@@ -1524,7 +1525,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						att_sp.yaw_sp_move_rate = 0.0f;
 					}
 
-					if (!offboard_control_mode.ignore_thrust) { // dont't overwrite thrust if it's invalid
+					if (!offboard_control_mode.ignore_thrust) { // don't overwrite thrust if it's invalid
 						fill_thrust(att_sp.thrust_body, _vehicle_status.vehicle_type, set_attitude_target.thrust);
 					}
 
@@ -1562,7 +1563,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						rates_sp.yaw = set_attitude_target.body_yaw_rate;
 					}
 
-					if (!offboard_control_mode.ignore_thrust) { // dont't overwrite thrust if it's invalid
+					if (!offboard_control_mode.ignore_thrust) { // don't overwrite thrust if it's invalid
 						fill_thrust(rates_sp.thrust_body, _vehicle_status.vehicle_type, set_attitude_target.thrust);
 					}
 
@@ -2957,14 +2958,7 @@ MavlinkReceiver::Run()
 			updateParams();
 		}
 
-		// reset cruising speed on mode changes
-		if (_vehicle_status_sub.update(&_vehicle_status)) {
-			if (_last_nav_state != _vehicle_status.nav_state) {
-				reset_offb_cruising_speed();
-				_last_nav_state = _vehicle_status.nav_state;
-			}
-		}
-
+		_vehicle_status_sub.update(&_vehicle_status);
 
 		int ret = poll(&fds[0], 1, timeout);
 
@@ -3145,11 +3139,4 @@ MavlinkReceiver::set_offb_cruising_speed(float speed)
 	} else {
 		_offb_cruising_speed_fw = speed;
 	}
-}
-
-void
-MavlinkReceiver::reset_offb_cruising_speed()
-{
-	_offb_cruising_speed_mc = -1.0f;
-	_offb_cruising_speed_fw = -1.0f;
 }

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -518,7 +518,10 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 			_mavlink->request_stop_ulog_streaming();
 
 		} else if (cmd_mavlink.command == MAV_CMD_DO_CHANGE_SPEED) {
-			if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_OFFBOARD) {
+			vehicle_control_mode_s control_mode{};
+			_control_mode_sub.copy(&control_mode);
+
+			if (control_mode.flag_control_offboard_enabled) {
 				// Not differentiating between airspeed and groundspeed yet
 				set_offb_cruising_speed(cmd_mavlink.param2);
 			}
@@ -1509,6 +1512,8 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 			_control_mode_sub.copy(&control_mode);
 
 			if (control_mode.flag_control_offboard_enabled) {
+				vehicle_status_s vehicle_status{};
+				_vehicle_status_sub.copy(&vehicle_status);
 
 				/* Publish attitude setpoint if attitude and thrust ignore bits are not set */
 				if (!(offboard_control_mode.ignore_attitude)) {
@@ -1527,14 +1532,14 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 					}
 
 					if (!offboard_control_mode.ignore_thrust) { // don't overwrite thrust if it's invalid
-						fill_thrust(att_sp.thrust_body, _vehicle_status.vehicle_type, set_attitude_target.thrust);
+						fill_thrust(att_sp.thrust_body, vehicle_status.vehicle_type, set_attitude_target.thrust);
 					}
 
 					// Publish attitude setpoint
-					if (_vehicle_status.is_vtol && (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
+					if (vehicle_status.is_vtol && (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
 						_mc_virtual_att_sp_pub.publish(att_sp);
 
-					} else if (_vehicle_status.is_vtol && (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
+					} else if (vehicle_status.is_vtol && (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
 						_fw_virtual_att_sp_pub.publish(att_sp);
 
 					} else {
@@ -1565,7 +1570,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 					}
 
 					if (!offboard_control_mode.ignore_thrust) { // don't overwrite thrust if it's invalid
-						fill_thrust(rates_sp.thrust_body, _vehicle_status.vehicle_type, set_attitude_target.thrust);
+						fill_thrust(rates_sp.thrust_body, vehicle_status.vehicle_type, set_attitude_target.thrust);
 					}
 
 					_rates_sp_pub.publish(rates_sp);
@@ -2959,8 +2964,6 @@ MavlinkReceiver::Run()
 			updateParams();
 		}
 
-		_vehicle_status_sub.update(&_vehicle_status);
-
 		int ret = poll(&fds[0], 1, timeout);
 
 		if (ret > 0) {
@@ -3113,7 +3116,10 @@ MavlinkReceiver::receive_start(pthread_t *thread, Mavlink *parent)
 float
 MavlinkReceiver::get_offb_cruising_speed()
 {
-	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	vehicle_status_s vehicle_status{};
+	_vehicle_status_sub.copy(&vehicle_status);
+
+	if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 		if (_offb_cruising_speed_mc > 0.0f) {
 			return _offb_cruising_speed_mc;
 
@@ -3134,7 +3140,10 @@ MavlinkReceiver::get_offb_cruising_speed()
 void
 MavlinkReceiver::set_offb_cruising_speed(float speed)
 {
-	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	vehicle_status_s vehicle_status{};
+	_vehicle_status_sub.copy(&vehicle_status);
+
+	if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 		_offb_cruising_speed_mc = speed;
 
 	} else {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -520,7 +520,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 
 		if (cmd_mavlink.command == MAV_CMD_DO_CHANGE_SPEED) {
 			// Not differentiating between airspeed and groundspeed yet
-			set_cruising_speed(cmd_mavlink.param2);
+			set_offb_cruising_speed(cmd_mavlink.param2);
 		}
 
 		if (!send_ack) {
@@ -1067,7 +1067,7 @@ MavlinkReceiver::handle_message_set_position_target_global_int(mavlink_message_t
 							globallocalconverter_tolocal(set_position_target_global_int.lat_int / 1e7,
 										     set_position_target_global_int.lon_int / 1e7, set_position_target_global_int.alt,
 										     &pos_sp_triplet.current.x, &pos_sp_triplet.current.y, &pos_sp_triplet.current.z);
-							pos_sp_triplet.current.cruising_speed = get_cruising_speed();
+							pos_sp_triplet.current.cruising_speed = get_offb_cruising_speed();
 							pos_sp_triplet.current.position_valid = true;
 						}
 
@@ -2960,7 +2960,7 @@ MavlinkReceiver::Run()
 		// reset cruising speed on mode changes
 		if (_vehicle_status_sub.update(&_vehicle_status)) {
 			if (_last_nav_state != _vehicle_status.nav_state) {
-				reset_cruising_speed();
+				reset_offb_cruising_speed();
 				_last_nav_state = _vehicle_status.nav_state;
 			}
 		}
@@ -3116,19 +3116,19 @@ MavlinkReceiver::receive_start(pthread_t *thread, Mavlink *parent)
 }
 
 float
-MavlinkReceiver::get_cruising_speed()
+MavlinkReceiver::get_offb_cruising_speed()
 {
 	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-		if (_cruising_speed_mc > 0.0f) {
-			return _cruising_speed_mc;
+		if (_offb_cruising_speed_mc > 0.0f) {
+			return _offb_cruising_speed_mc;
 
 		} else {
 			return -1.0f;
 		}
 
 	} else {
-		if (_cruising_speed_fw > 0.0f) {
-			return _cruising_speed_fw;
+		if (_offb_cruising_speed_fw > 0.0f) {
+			return _offb_cruising_speed_fw;
 
 		} else {
 			return -1.0f;
@@ -3137,19 +3137,19 @@ MavlinkReceiver::get_cruising_speed()
 }
 
 void
-MavlinkReceiver::set_cruising_speed(float speed)
+MavlinkReceiver::set_offb_cruising_speed(float speed)
 {
 	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-		_cruising_speed_mc = speed;
+		_offb_cruising_speed_mc = speed;
 
 	} else {
-		_cruising_speed_fw = speed;
+		_offb_cruising_speed_fw = speed;
 	}
 }
 
 void
-MavlinkReceiver::reset_cruising_speed()
+MavlinkReceiver::reset_offb_cruising_speed()
 {
-	_cruising_speed_mc = -1.0f;
-	_cruising_speed_fw = -1.0f;
+	_offb_cruising_speed_mc = -1.0f;
+	_offb_cruising_speed_fw = -1.0f;
 }

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -518,6 +518,11 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 			_mavlink->request_stop_ulog_streaming();
 		}
 
+		if (cmd_mavlink.command == MAV_CMD_DO_CHANGE_SPEED) {
+			// Not differentiating between airspeed and groundspeed yet
+			set_cruising_speed(cmd_mavlink.param2);
+		}
+
 		if (!send_ack) {
 			_cmd_pub.publish(vehicle_command);
 		}
@@ -1062,6 +1067,7 @@ MavlinkReceiver::handle_message_set_position_target_global_int(mavlink_message_t
 							globallocalconverter_tolocal(set_position_target_global_int.lat_int / 1e7,
 										     set_position_target_global_int.lon_int / 1e7, set_position_target_global_int.alt,
 										     &pos_sp_triplet.current.x, &pos_sp_triplet.current.y, &pos_sp_triplet.current.z);
+							pos_sp_triplet.current.cruising_speed = get_cruising_speed();
 							pos_sp_triplet.current.position_valid = true;
 						}
 
@@ -1501,8 +1507,6 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 			_control_mode_sub.copy(&control_mode);
 
 			if (control_mode.flag_control_offboard_enabled) {
-				vehicle_status_s vehicle_status{};
-				_vehicle_status_sub.copy(&vehicle_status);
 
 				/* Publish attitude setpoint if attitude and thrust ignore bits are not set */
 				if (!(offboard_control_mode.ignore_attitude)) {
@@ -1520,15 +1524,15 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						att_sp.yaw_sp_move_rate = 0.0f;
 					}
 
-					if (!offboard_control_mode.ignore_thrust) { // don't overwrite thrust if it's invalid
-						fill_thrust(att_sp.thrust_body, vehicle_status.vehicle_type, set_attitude_target.thrust);
+					if (!offboard_control_mode.ignore_thrust) { // dont't overwrite thrust if it's invalid
+						fill_thrust(att_sp.thrust_body, _vehicle_status.vehicle_type, set_attitude_target.thrust);
 					}
 
 					// Publish attitude setpoint
-					if (vehicle_status.is_vtol && (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
+					if (_vehicle_status.is_vtol && (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
 						_mc_virtual_att_sp_pub.publish(att_sp);
 
-					} else if (vehicle_status.is_vtol && (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
+					} else if (_vehicle_status.is_vtol && (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {
 						_fw_virtual_att_sp_pub.publish(att_sp);
 
 					} else {
@@ -1558,8 +1562,8 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						rates_sp.yaw = set_attitude_target.body_yaw_rate;
 					}
 
-					if (!offboard_control_mode.ignore_thrust) { // don't overwrite thrust if it's invalid
-						fill_thrust(rates_sp.thrust_body, vehicle_status.vehicle_type, set_attitude_target.thrust);
+					if (!offboard_control_mode.ignore_thrust) { // dont't overwrite thrust if it's invalid
+						fill_thrust(rates_sp.thrust_body, _vehicle_status.vehicle_type, set_attitude_target.thrust);
 					}
 
 					_rates_sp_pub.publish(rates_sp);
@@ -2953,6 +2957,15 @@ MavlinkReceiver::Run()
 			updateParams();
 		}
 
+		// reset cruising speed on mode changes
+		if (_vehicle_status_sub.update(&_vehicle_status)) {
+			if (_last_nav_state != _vehicle_status.nav_state) {
+				reset_cruising_speed();
+				_last_nav_state = _vehicle_status.nav_state;
+			}
+		}
+
+
 		int ret = poll(&fds[0], 1, timeout);
 
 		if (ret > 0) {
@@ -3100,4 +3113,43 @@ MavlinkReceiver::receive_start(pthread_t *thread, Mavlink *parent)
 	pthread_create(thread, &receiveloop_attr, MavlinkReceiver::start_helper, (void *)parent);
 
 	pthread_attr_destroy(&receiveloop_attr);
+}
+
+float
+MavlinkReceiver::get_cruising_speed()
+{
+	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+		if (_cruising_speed_mc > 0.0f) {
+			return _cruising_speed_mc;
+
+		} else {
+			return -1.0f;
+		}
+
+	} else {
+		if (_cruising_speed_fw > 0.0f) {
+			return _cruising_speed_fw;
+
+		} else {
+			return -1.0f;
+		}
+	}
+}
+
+void
+MavlinkReceiver::set_cruising_speed(float speed)
+{
+	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+		_cruising_speed_mc = speed;
+
+	} else {
+		_cruising_speed_fw = speed;
+	}
+}
+
+void
+MavlinkReceiver::reset_cruising_speed()
+{
+	_cruising_speed_mc = -1.0f;
+	_cruising_speed_fw = -1.0f;
 }

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -891,6 +891,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 						pos_sp_triplet.current.x = set_position_target_local_ned.x;
 						pos_sp_triplet.current.y = set_position_target_local_ned.y;
 						pos_sp_triplet.current.z = set_position_target_local_ned.z;
+						pos_sp_triplet.current.cruising_speed = get_offb_cruising_speed();
 
 					} else {
 						pos_sp_triplet.current.position_valid = false;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -123,14 +123,14 @@ public:
 	static void *start_helper(void *context);
 
 	/**
-	 * Get the cruising speed
+	 * Get the cruising speed in offboard control
 	 *
 	 * @return the desired cruising speed for the current flight mode
 	 */
-	float get_cruising_speed();
+	float get_offb_cruising_speed();
 
 	/**
-	 * Set the cruising speed
+	 * Set the cruising speed in offboard control
 	 *
 	 * Passing a negative value or leaving the parameter away will reset the cruising speed
 	 * to its default value.
@@ -138,12 +138,12 @@ public:
 	 * Sets cruising speed for current flight mode only (resets on mode changes).
 	 *
 	 */
-	void set_cruising_speed(float speed = -1.0f);
+	void set_offb_cruising_speed(float speed = -1.0f);
 
 	/**
-	 * Reset all cruising speeds to default values
+	 * Reset all offboard cruising speeds to default values
 	 */
-	void reset_cruising_speed();
+	void reset_offb_cruising_speed();
 
 private:
 
@@ -342,8 +342,8 @@ private:
 	vehicle_status_s		_vehicle_status{};
 	uint8_t				_last_nav_state{0};
 
-	float 				_cruising_speed_mc{-1.0f};
-	float 				_cruising_speed_fw{-1.0f};
+	float 				_offb_cruising_speed_mc{-1.0f};
+	float 				_offb_cruising_speed_fw{-1.0f};
 
 	// Allocated if needed.
 	TunePublisher *_tune_publisher{nullptr};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -122,6 +122,29 @@ public:
 
 	static void *start_helper(void *context);
 
+	/**
+	 * Get the cruising speed
+	 *
+	 * @return the desired cruising speed for the current flight mode
+	 */
+	float get_cruising_speed();
+
+	/**
+	 * Set the cruising speed
+	 *
+	 * Passing a negative value or leaving the parameter away will reset the cruising speed
+	 * to its default value.
+	 *
+	 * Sets cruising speed for current flight mode only (resets on mode changes).
+	 *
+	 */
+	void set_cruising_speed(float speed = -1.0f);
+
+	/**
+	 * Reset all cruising speeds to default values
+	 */
+	void reset_cruising_speed();
+
 private:
 
 	void acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, uint8_t result);
@@ -315,6 +338,12 @@ private:
 	bool				_hil_local_proj_inited{false};
 
 	hrt_abstime			_last_utm_global_pos_com{0};
+
+	vehicle_status_s		_vehicle_status{};
+	uint8_t				_last_nav_state{0};
+
+	float 				_cruising_speed_mc{-1.0f};
+	float 				_cruising_speed_fw{-1.0f};
 
 	// Allocated if needed.
 	TunePublisher *_tune_publisher{nullptr};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -140,11 +140,6 @@ public:
 	 */
 	void set_offb_cruising_speed(float speed = -1.0f);
 
-	/**
-	 * Reset all offboard cruising speeds to default values
-	 */
-	void reset_offb_cruising_speed();
-
 private:
 
 	void acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, uint8_t result);
@@ -340,7 +335,6 @@ private:
 	hrt_abstime			_last_utm_global_pos_com{0};
 
 	vehicle_status_s		_vehicle_status{};
-	uint8_t				_last_nav_state{0};
 
 	float 				_offb_cruising_speed_mc{-1.0f};
 	float 				_offb_cruising_speed_fw{-1.0f};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -334,8 +334,6 @@ private:
 
 	hrt_abstime			_last_utm_global_pos_com{0};
 
-	vehicle_status_s		_vehicle_status{};
-
 	float 				_offb_cruising_speed_mc{-1.0f};
 	float 				_offb_cruising_speed_fw{-1.0f};
 


### PR DESCRIPTION
…n control.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.
Initial slack conversation with @dagar : https://px4.slack.com/archives/C7L8W6DAL/p1593439308005400

Maybe @Jaeyoung-Lim who has added support for SET_POSITION_TARGET_GLOBAL_INT in the first place is also interested in this PR :)

**Describe problem solved by this pull request**
In FW Offboard control using SET_POSITION_TARGET_GLOBAL_INT the command  MAV_CMD_DO_CHANGE_SPEED had no effect. This PR adds support for this without affecting any existing behaviour.

**Describe your solution**
The MavlinkReceiver class handles MAV_CMD_DO_CHANGE_SPEED commands by saving the desired speed to a member variable based on whether the drone is in FW or in MC mode. This speed is then accessed in `MavlinkReceiver::handle_message_set_position_target_global_int(mavlink_message_t *msg)` when position control is active and published in the `pos_sp_triplet.current.cruising_speed` field.

Upon a flight mode change, the cruising speed values are reset to default. 

**Describe possible alternatives**
I had also briefly considered an option where the cruising speed would only be set for the flight mode in which the command is received and would stick in this mode even when switching to a different mode and back (e.g. offboard --> loiter --> offboard). I decided against this approach as there might be unwanted old cruising speeds lingering around.

See Additional context for more details.

**Test data / coverage**
Gazebo standard vtol:

1. Two change speed commands in offboard mode: first one in NW corner to 18m/s, second one back to default before back transition. : https://logs.px4.io/plot_app?log=17171469-7155-4f56-b9fe-4541070a8ffb

2. Change speed to 18m/s in NW corner, followed by Loiter which resets to default. Then continuing in offboard, showing that the old change speed command is indeed forgotten: https://logs.px4.io/plot_app?log=d15040f0-3ea1-4ccf-8efa-494b32f02ef0

3. Change speed to 18m/s in NW corner, followed by RTL which resets to default. https://logs.px4.io/plot_app?log=726f8af1-2a2b-462c-a8c2-7f536574ca51

4. Change speed in Mission, FW mode: behaviour unchanged. https://logs.px4.io/plot_app?log=8e5d2ee9-2ed1-4922-8e91-693be4411ee1

5. Change speed in Mission, MC mode: behaviour unchanged. https://logs.px4.io/plot_app?log=4ed13e70-d137-4c2a-9f4d-7743f54ae0ab


**Additional context**
As said in the description, this PR only adds support in FW offboard mode without affecting existing behaviour. This was a choice on purpose, but in principle the approach could also be used for all other modes for which the MAV_CMD_DO_CHANGE_SPEED command could make sense. You would just have to publish the desired cruising speed in a uorb topic to which the different flight mode modules subscribe. 

Going through all PX4 flightmodes, the following are the ones in which IMO it could make sense to have MAV_CMD_DO_CHANGE_SPEED supported:

- Offboard Position control:
1. Our usecase (this PR): change speed in FW offboard position control using SET_POSITION_TARGET_GLOBAL_INT
2. same, but for MC: With this PR the desired MC speed is also published in the `pos_sp_triplet.current.cruising_speed` field, but it's not of much use as the offboard flight task doesn't directly expose a way to set this. It would need to be passed to https://github.com/PX4/Firmware/blob/master/src/modules/mc_pos_control/mc_pos_control_main.cpp#L369 .

- Mission:
Already handled in the navigator module. Architecturally it might make more sense to unify where  MAV_CMD_DO_CHANGE_SPEED is handled (in MavlinkReceiver) and then access this from the navigator (if the decision is taken to add support for the change speed command for multiple flight modes).

- RTL:
The main reason why I decided to reset the cruising speed to default after every mode change. In (the relatively unlikely) case that a bad change speed command has put the drone in a state that requires an RTL action then this bad cruising speed should certainly not stick around.
I currently don't know exactly where the speed is set in RTL mode, but I imagine that with a uorb topic published from MavlinkReceiver it should be relatively easy to have this working.


- FW Loiter:
Would be easy to implement with the uorb topic.

- Orbit:
A mode that we have never used and probably never will on our VTOL drone, but I guess if you set the cruising speed as a limit in the MC Position control module it should also apply to orbit.



We currently only need MAV_CMD_DO_CHANGE_SPEED for FW offboard and would be really happy to have this merged into master without having to sort out all the details about the other flight modes first. In case there is enough positive feedback to also implement it for the other flight modes, I would prefer to have a separate follow-up PR for that.

Any inputs are welcome :)