### PR TITLE
Fix the case where the flight controller is connected to the battery (charge 100), QGC shows no battery

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -599,7 +599,8 @@ protected:
 			int lowest_battery_index = 0;
 
 			for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
-				if (battery_status[i].connected && (battery_status[i].remaining < battery_status[lowest_battery_index].remaining)) {
+				if (battery_status[i].connected && ((!battery_status[lowest_battery_index].connected)
+								    || (battery_status[i].remaining < battery_status[lowest_battery_index].remaining))) {
 					lowest_battery_index = i;
 				}
 			}

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -598,6 +598,10 @@ protected:
 
 			int lowest_battery_index = 0;
 
+			//No battery is connected, select the first group
+			//Low battery judgment is performed only when the current battery is connected
+			//When the last cached battery is not connected or the current battery level is lower than the cached battery level,
+			//the current battery status is replaced with the cached value
 			for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 				if (battery_status[i].connected && ((!battery_status[lowest_battery_index].connected)
 								    || (battery_status[i].remaining < battery_status[lowest_battery_index].remaining))) {


### PR DESCRIPTION
I use the CAN PMU to power the CUAVv5+. When the CAN PMU reaches 100, the QGC shows no battery .
It was found that MAVLINK SYS_STATUS selected the first group of unconnected battery status. Instead of the actual battery status behind