### PR TITLE
Prevent TECS throttle from exceeding FW_THR_MAX in underspeed mode

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -276,7 +276,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 	// Calculate the throttle demand
 	if (_underspeed_detected) {
 		// always use full throttle to recover from an underspeed condition
-		_throttle_setpoint = 1.0f;
+		_throttle_setpoint = _throttle_setpoint_max;
 
 	} else {
 		// Adjust the demanded total energy rate to compensate for induced drag rise in turns.


### PR DESCRIPTION
When TECS goes into underspeed mode, it sets the throttle to 100%, instead of respecting `FW_THR_MAX`. 

This is obviously quite dangerous if people rely on `FW_THR_MAX` to keep their motor in a safe operating level. 

We've been flying this one-line fix for over a year now.

Fixes https://github.com/PX4/Firmware/issues/12716