### PR TITLE
rotation: add ROTATION_ROLL_270_YAW_225 and ROTATION_ROLL_270_YAW_315

### DIFF
--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -389,5 +389,21 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			return;
 		}
 
+	case ROTATION_ROLL_270_YAW_225: {
+			tmp = z; z = -y; y = tmp;
+			tmp = M_SQRT1_2_F * (y - x);
+			y   = -M_SQRT1_2_F * (x + y);
+			x = tmp;
+			return;
+		}
+
+	case ROTATION_ROLL_270_YAW_315: {
+			tmp = z; z = -y; y = tmp;
+			tmp = M_SQRT1_2_F * (x + y);
+			y   = M_SQRT1_2_F * (y - x);
+			x = tmp;
+			return;
+		}
+
 	}
 }

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -95,6 +95,8 @@ enum Rotation {
 	ROTATION_PITCH_90_YAW_180    = 43,
 	ROTATION_PITCH_9_YAW_180     = 44,
 	ROTATION_PITCH_45            = 45,
+	ROTATION_ROLL_270_YAW_225    = 46,
+	ROTATION_ROLL_270_YAW_315    = 47,
 	ROTATION_MAX
 };
 
@@ -151,6 +153,8 @@ const rot_lookup_t rot_lookup[] = {
 	{  0,  90, 180 },
 	{  0,   9, 180 },
 	{  0,  45,   0 },
+	{270,   0, 225 },
+	{270,   0, 315 },
 };
 
 /**

--- a/src/modules/sensors/sensor_params_mag0.c
+++ b/src/modules/sensors/sensor_params_mag0.c
@@ -102,9 +102,11 @@ PARAM_DEFINE_INT32(CAL_MAG0_EN, 1);
  * @value 43 Pitch 90°, Yaw 180°
  * @value 44 Pitch 9°, Yaw 180°
  * @value 45 Pitch 45°
+ * @value 46 Roll 270°, Yaw 225°
+ * @value 47 Roll 270°, Yaw 315°
  *
  * @min -1
- * @max 45
+ * @max 47
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag1.c
+++ b/src/modules/sensors/sensor_params_mag1.c
@@ -102,9 +102,11 @@ PARAM_DEFINE_INT32(CAL_MAG1_EN, 1);
  * @value 43 Pitch 90°, Yaw 180°
  * @value 44 Pitch 9°, Yaw 180°
  * @value 45 Pitch 45°
+ * @value 46 Roll 270°, Yaw 225°
+ * @value 47 Roll 270°, Yaw 315°
  *
  * @min -1
- * @max 45
+ * @max 47
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag2.c
+++ b/src/modules/sensors/sensor_params_mag2.c
@@ -102,9 +102,11 @@ PARAM_DEFINE_INT32(CAL_MAG2_EN, 1);
  * @value 43 Pitch 90°, Yaw 180°
  * @value 44 Pitch 9°, Yaw 180°
  * @value 45 Pitch 45°
+ * @value 46 Roll 270°, Yaw 225°
+ * @value 47 Roll 270°, Yaw 315°
  *
  * @min -1
- * @max 45
+ * @max 47
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag3.c
+++ b/src/modules/sensors/sensor_params_mag3.c
@@ -102,9 +102,11 @@ PARAM_DEFINE_INT32(CAL_MAG3_EN, 1);
  * @value 43 Pitch 90°, Yaw 180°
  * @value 44 Pitch 9°, Yaw 180°
  * @value 45 Pitch 45°
+ * @value 46 Roll 270°, Yaw 225°
+ * @value 47 Roll 270°, Yaw 315°
  *
  * @min -1
- * @max 45
+ * @max 47
  * @reboot_required true
  * @category system
  * @group Sensor Calibration


### PR DESCRIPTION
**Describe problem solved by this pull request**
These rotations were missing and there's no way to set completely custom ones.

**Describe possible alternatives**
This shows that we should enable to use custom rotations.

**Test data / coverage**
These were tested and used on a real vehicle.

**Additional context**
https://github.com/PX4/Firmware/pull/14797
https://github.com/PX4/Firmware/pull/15264/
