### PR TITLE
Bug fix in gazebo_sitl_multiple_run.sh

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -53,13 +53,14 @@ do
 	case "${option}"
 	in
 		n) NUM_VEHICLES=${OPTARG};;
-		m) VEHICLE_MODEL=${OPTARG:=iris};;
+		m) VEHICLE_MODEL=${OPTARG};;
 		w) WORLD=${OPTARG};;
 		s) SCRIPT=${OPTARG};;
 	esac
 done
 
 num_vehicles=${NUM_VEHICLES:=3}
+model = ${VEHICLE_MODEL:=iris}
 world=${WORLD:=empty}
 echo ${SCRIPT}
 
@@ -91,7 +92,7 @@ if [ -z ${SCRIPT} ]; then
 	fi
 
 	while [ $n -lt $num_vehicles ]; do
-		spawn_model ${VEHICLE_MODEL} $n
+		spawn_model ${model} $n
 		n=$(($n + 1))
 	done
 else

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -53,7 +53,7 @@ do
 	case "${option}"
 	in
 		n) NUM_VEHICLES=${OPTARG};;
-		m) VEHICLE_MODEL=${OPTARG};;
+		m) VEHICLE_MODEL=${OPTARG:=iris};;
 		w) WORLD=${OPTARG};;
 		s) SCRIPT=${OPTARG};;
 	esac
@@ -91,7 +91,7 @@ if [ -z ${SCRIPT} ]; then
 	fi
 
 	while [ $n -lt $num_vehicles ]; do
-		spawn_model ${VEHICLE_MODEL:=iris} $n
+		spawn_model ${VEHICLE_MODEL} $n
 		n=$(($n + 1))
 	done
 else

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -91,7 +91,7 @@ if [ -z ${SCRIPT} ]; then
 	fi
 
 	while [ $n -lt $num_vehicles ]; do
-		spawn_model ${PX4_SIM_MODEL} $n
+		spawn_model ${VEHICLE_MODEL:=iris} $n
 		n=$(($n + 1))
 	done
 else

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -26,6 +26,7 @@ function spawn_model() {
 
 	pushd "$working_dir" &>/dev/null
 	echo "starting instance $n in $(pwd)"
+	export PX4_SIM_MODEL=${MODEL}
 	../bin/px4 -i $n -d "$src_path/ROMFS/px4fmu_common" -w sitl_${MODEL}_${n} -s etc/init.d-posix/rcS >out.log 2>err.log &
 	python3 ${src_path}/Tools/sitl_gazebo/scripts/xacro.py ${src_path}/Tools/sitl_gazebo/models/rotors_description/urdf/${MODEL}_base.xacro \
 		rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description mavlink_udp_port:=$(($mavlink_udp_port+$N)) \
@@ -59,7 +60,6 @@ do
 done
 
 num_vehicles=${NUM_VEHICLES:=3}
-export PX4_SIM_MODEL=${VEHICLE_MODEL:=iris}
 world=${WORLD:=empty}
 echo ${SCRIPT}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Change location of where `$PX4_SIM_MODEL` is set to avoid mixer issues. Before, the change px4 would start all models as `iris` whilst gazebo was spawning in the correct meshes. This resulted in both `plane` and `standard_vtol` running with the `quad_w` mixer.

**Describe your solution**
Define `$PX4_SIM_MODEL` within `spawn_model()` based on `$MODEL`, so that when `-s` is used the correct targets are used.

**Tests**
 - `-s plane:1,iris:1` - spawns 1 plane, 1 iris
 - `-m iris -n 3` - spawns 3 iris
 - `-n 3` -> spawns 3 iris
 - none -> spawns 3 iris

