### PR TITLE
Add support for STM32F42x/STM32F43x rev. 5/B

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/version/board_mcu_version.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/version/board_mcu_version.c
@@ -50,8 +50,8 @@ enum MCU_REV {
 	MCU_REV_STM32F4_REV_3 = 0x2001,
 	MCU_REV_STM32F4_REV_5 = 0x2003,
 	MCU_REV_STM32F4_REV_B = MCU_REV_STM32F4_REV_5,
-	MCU_REV_STM32F7_REV_X = MCU_REV_STM32F4_REV_3,
-	MCU_REV_STM32F7_REV_V = 0x2003
+	MCU_REV_STM32H7_REV_X = MCU_REV_STM32F4_REV_3,
+	MCU_REV_STM32H7_REV_V = 0x2003
 };
 
 /* Define any issues with the Silicon as lines separated by \n
@@ -155,7 +155,7 @@ int board_mcu_version(char *rev, const char **revstr, const char **errata)
 
 	case MCU_REV_STM32F4_REV_5:
 		// MCU_REV_STM32F4_REV_B shares the same REV_ID
-		// MCU_REV_STM32F7_REV_V shares the same REV_ID
+		// MCU_REV_STM32H7_REV_V shares the same REV_ID
 		*rev = chip_version == STM32H74xx_75xx ? 'V' : '5';
 		chip_errata = NULL;
 		break;

--- a/platforms/nuttx/src/px4/stm/stm32_common/version/board_mcu_version.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/version/board_mcu_version.c
@@ -48,6 +48,8 @@ enum MCU_REV {
 	MCU_REV_STM32F4_REV_Y = 0x1003,
 	MCU_REV_STM32F4_REV_1 = 0x1007,
 	MCU_REV_STM32F4_REV_3 = 0x2001,
+	MCU_REV_STM32F4_REV_5 = 0x2003,
+	MCU_REV_STM32F4_REV_B = MCU_REV_STM32F4_REV_5,
 	MCU_REV_STM32F7_REV_X = MCU_REV_STM32F4_REV_3,
 	MCU_REV_STM32F7_REV_V = 0x2003
 };
@@ -151,8 +153,10 @@ int board_mcu_version(char *rev, const char **revstr, const char **errata)
 		chip_errata = NULL;
 		break;
 
-	case MCU_REV_STM32F7_REV_V:
-		*rev = 'V';
+	case MCU_REV_STM32F4_REV_5:
+		// MCU_REV_STM32F4_REV_B shares the same REV_ID
+		// MCU_REV_STM32F7_REV_V shares the same REV_ID
+		*rev = chip_version == STM32H74xx_75xx ? 'V' : '5';
 		chip_errata = NULL;
 		break;
 


### PR DESCRIPTION
This P/R adds `REV_ID`s for STM32F427 rev. 5 and B.

Note that, accoding to https://www.st.com/resource/en/errata_sheet/dm00068628-stm32f427437-and-stm32f429439-line-limitations-stmicroelectronics.pdf, both 5 and B share the same `REV_ID`. This patch reports both as rev. 5.

Fixes #15406