### PR TITLE
ekf2: completely ignore mag data if EKF2_MAG_TYPE none

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -878,7 +878,7 @@ void Ekf2::Run()
 		publish_attitude(now);
 
 		// read mag data
-		if (_magnetometer_sub.updated()) {
+		if ((_param_ekf2_mag_type.get() != MAG_FUSE_TYPE_NONE) && _magnetometer_sub.updated()) {
 			vehicle_magnetometer_s magnetometer;
 
 			if (_magnetometer_sub.copy(&magnetometer)) {


### PR DESCRIPTION
 - this is a small optimization to skip copying the data, allocating the buffer in the ecl/EKF backend, etc
