### PR TITLE
keep the possibility of skipping controllers

### DIFF
--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
@@ -107,6 +107,7 @@ void FlightTask::_resetSetpoints()
 	_velocity_setpoint.setNaN();
 	_acceleration_setpoint.setNaN();
 	_jerk_setpoint.setNaN();
+     _thrust_setpoint.setNaN();
 	_yaw_setpoint = _yawspeed_setpoint = NAN;
 }
 

--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
@@ -245,6 +245,7 @@ protected:
 	matrix::Vector3f _velocity_setpoint;
 	matrix::Vector3f _acceleration_setpoint;
 	matrix::Vector3f _jerk_setpoint;
+    matrix::Vector3f _thrust_setpoint;
 	float _yaw_setpoint{};
 	float _yawspeed_setpoint{};
 	matrix::Vector3f _velocity_setpoint_feedback;

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -218,4 +218,6 @@ private:
 	matrix::Vector3f _thr_sp; /**< desired thrust */
 	float _yaw_sp{}; /**< desired heading */
 	float _yawspeed_sp{}; /** desired yaw-speed */
+
+    bool _skip_controller{false}; /**< Keep Skip Controller to allow use thrusy setpints in OFFBOARD mode*/
 };


### PR DESCRIPTION
**Problem solved by this pull request**
These changes will allow to used thrust_setpoint from companion computer, as it was possible in version V1.10.0 stable.
It would allow to use the normal pipeline of the mc_pos_control for offboard applications that sends thrust setpoints.

**Solution**
The solution basically creates a flag in mc_pos_control module (PositionControl.cpp) that will check if valid thrust_setpoints are given or not. If thrust_setpoint are give, position, velocity and acceleration control will not run.
To get this solution working, thrust-setpoints need to be initialized with NaN in the flight tasks and a "if" condition in PositionControl.cpp should be used to check if controllers (position, velocity and acceleartion) should be run or not.

**Possible alternatives**
A alternative would be the users to change PX4 code the by themselves when necessary to keep compatibility with already developed companion solutions, but it would not be the best way since it does not allow modular development and would be a change in the PX4 master core that would not verified during the PX4 Master update process. 

**Test data / coverage**
The change was tested in SITL by engaging modes that control position, altitude, velocity and it worked without any verifiable problem.
Takeoff in Postion and Altitude mode were done without any verifiable problem.
Changes from manual to Position, Altitude and Mission modes were done without any verifiable problem.
HITL was not tested because this version presents some bugs that does not allow the test (disarm in flight and does not reset PIXAWK after upload)

