### PR TITLE
logger: skip message copies until buffer available

### DIFF
--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -261,8 +261,6 @@ private:
 
 	void write_changed_parameters(LogType type);
 
-	inline bool copy_if_updated(int sub_idx, void *buffer, bool try_to_subscribe);
-
 	/**
 	 * Write exactly one ulog message to the logger and handle dropouts.
 	 * Must be called with _writer.lock() held.


### PR DESCRIPTION
Two small logger changes.
1. ~~log gaps in uORB copies for messages with no interval set (full rate messages)~~ https://github.com/PX4/Firmware/pull/15440
2. only copy messages (regular subscriptions) if there's sufficient space in the buffer

This has implications for mavlink logging, but I'm opening this now to start discussing. Overall I've found this can work quite well with potential logging dropouts being avoided, instead leaving the data in uORB until the buffer becomes available.