### PR TITLE
Simulator: Added remote host option

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -86,8 +86,8 @@ int Simulator::start(int argc, char *argv[])
 		}
 
 		if (argc == 5 && strcmp(argv[2], "-t") == 0) {
-			_instance->set_ip(InternetProtocol::TCP_REMOTE);
-			_instance->set_ipaddr(argv[3]);
+			_instance->set_ip(InternetProtocol::TCP);
+			_instance->set_tcp_remote_ipaddr(argv[3]);
 			_instance->set_port(atoi(argv[4]));
 		}
 
@@ -107,6 +107,7 @@ static void usage()
 	PX4_INFO("Start simulator:     simulator start");
 	PX4_INFO("Connect using UDP: simulator start -u udp_port");
 	PX4_INFO("Connect using TCP: simulator start -c tcp_port");
+	PX4_INFO("Connect to a remote server using TCP: simulator start -t ip_addr tcp_port");
 }
 
 __BEGIN_DECLS

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -85,6 +85,12 @@ int Simulator::start(int argc, char *argv[])
 			_instance->set_port(atoi(argv[3]));
 		}
 
+		if (argc == 5 && strcmp(argv[2], "-t") == 0) {
+			_instance->set_ip(InternetProtocol::TCP_REMOTE);
+			_instance->set_ipaddr(argv[3]);
+			_instance->set_port(atoi(argv[4]));
+		}
+
 		_instance->run();
 
 		return 0;

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -115,15 +115,14 @@ public:
 
 	enum class InternetProtocol {
 		TCP,
-		UDP,
-		TCP_REMOTE
+		UDP
 	};
 
 	static int start(int argc, char *argv[]);
 
 	void set_ip(InternetProtocol ip) { _ip = ip; }
 	void set_port(unsigned port) { _port = port; }
-	void set_ipaddr(char *ipaddr) { _ipaddr = ipaddr; }
+	void set_tcp_remote_ipaddr(char *tcp_remote_ipaddr) { _tcp_remote_ipaddr = tcp_remote_ipaddr; }
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 	bool has_initialized() { return _has_initialized.load(); }
@@ -182,7 +181,7 @@ private:
 
 	InternetProtocol _ip{InternetProtocol::UDP};
 
-	char *_ipaddr;
+	char *_tcp_remote_ipaddr{nullptr};
 
 	double _realtime_factor{1.0};		///< How fast the simulation runs in comparison to real system time
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -123,7 +123,7 @@ public:
 
 	void set_ip(InternetProtocol ip) { _ip = ip; }
 	void set_port(unsigned port) { _port = port; }
-	void set_ipaddr(char* ipaddr) { _ipaddr = ipaddr; }
+	void set_ipaddr(char *ipaddr) { _ipaddr = ipaddr; }
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 	bool has_initialized() { return _has_initialized.load(); }
@@ -182,7 +182,7 @@ private:
 
 	InternetProtocol _ip{InternetProtocol::UDP};
 
-	char* _ipaddr;
+	char *_ipaddr;
 
 	double _realtime_factor{1.0};		///< How fast the simulation runs in comparison to real system time
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -115,13 +115,15 @@ public:
 
 	enum class InternetProtocol {
 		TCP,
-		UDP
+		UDP,
+		TCP_REMOTE
 	};
 
 	static int start(int argc, char *argv[]);
 
 	void set_ip(InternetProtocol ip) { _ip = ip; }
 	void set_port(unsigned port) { _port = port; }
+	void set_ipaddr(char* ipaddr) { _ipaddr = ipaddr; }
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 	bool has_initialized() { return _has_initialized.load(); }
@@ -179,6 +181,8 @@ private:
 	unsigned int _port{14560};
 
 	InternetProtocol _ip{InternetProtocol::UDP};
+
+	char* _ipaddr;
 
 	double _realtime_factor{1.0};		///< How fast the simulation runs in comparison to real system time
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -631,8 +631,8 @@ void Simulator::run()
 	_myaddr.sin_addr.s_addr = htonl(INADDR_ANY);
 	_myaddr.sin_port = htons(_port);
 
-	if (_ip == InternetProtocol::TCP_REMOTE) {
-		_myaddr.sin_addr.s_addr = inet_addr(_ipaddr);
+	if (_tcp_remote_ipaddr != nullptr) {
+		_myaddr.sin_addr.s_addr = inet_addr(_tcp_remote_ipaddr);
 	}
 
 	if (_ip == InternetProtocol::UDP) {

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -631,7 +631,7 @@ void Simulator::run()
 	_myaddr.sin_addr.s_addr = htonl(INADDR_ANY);
 	_myaddr.sin_port = htons(_port);
 
-	if(_ip == InternetProtocol::TCP_REMOTE) {
+	if (_ip == InternetProtocol::TCP_REMOTE) {
 		_myaddr.sin_addr.s_addr = inet_addr(_ipaddr);
 	}
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -51,6 +51,7 @@
 #include <pthread.h>
 #include <sys/socket.h>
 #include <termios.h>
+#include <arpa/inet.h>
 
 #include <limits>
 
@@ -629,6 +630,10 @@ void Simulator::run()
 	_myaddr.sin_family = AF_INET;
 	_myaddr.sin_addr.s_addr = htonl(INADDR_ANY);
 	_myaddr.sin_port = htons(_port);
+
+	if(_ip == InternetProtocol::TCP_REMOTE) {
+		_myaddr.sin_addr.s_addr = inet_addr(_ipaddr);
+	}
 
 	if (_ip == InternetProtocol::UDP) {
 


### PR DESCRIPTION
Added an option to the Simulator module to connect to remote Gazebo servers.

This is usefull when the Gazebo simulation is running on a different host than the PX4 instance.
For example, we are running instances of PX4 with a companion application in multiple Dockers, for swarming simulations, which then connect to a remote Gazebo server.

A "-t" input argument has been added and can be called from the rcS startup script as: `simulator` start -t "192.168.178.122" $simulator_tcp_port`

Signed-off-by: Peter Blom <peterblom.mail@gmail.com>

Closes #15428.