### PR TITLE
[WIP]: purge globallocal helpers (with hidden global variables)

### DIFF
--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
@@ -153,8 +153,15 @@ void FlightTask::_evaluateVehicleLocalPosition()
 
 		// global frame reference coordinates to enable conversions
 		if (_sub_vehicle_local_position.get().xy_global && _sub_vehicle_local_position.get().z_global) {
-			globallocalconverter_init(_sub_vehicle_local_position.get().ref_lat, _sub_vehicle_local_position.get().ref_lon,
-						  _sub_vehicle_local_position.get().ref_alt, _sub_vehicle_local_position.get().ref_timestamp);
+			if (!map_projection_initialized(&_global_local_proj_ref)
+			    || (_global_local_proj_ref.timestamp != _sub_vehicle_local_position.get().ref_timestamp)) {
+
+				map_projection_init_timestamped(&_global_local_proj_ref,
+								_sub_vehicle_local_position.get().ref_lat, _sub_vehicle_local_position.get().ref_lon,
+								_sub_vehicle_local_position.get().ref_timestamp);
+
+				_global_local_alt0 = _sub_vehicle_local_position.get().ref_alt;
+			}
 		}
 	}
 }

--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.hpp
@@ -43,6 +43,7 @@
 
 #include <px4_platform_common/module_params.h>
 #include <drivers/drv_hrt.h>
+#include <lib/ecl/geo/geo.h>
 #include <matrix/matrix/math.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/landing_gear.h>
@@ -191,6 +192,9 @@ protected:
 	uORB::SubscriptionData<vehicle_local_position_s> _sub_vehicle_local_position{ORB_ID(vehicle_local_position)};
 	uORB::SubscriptionData<vehicle_attitude_s> _sub_attitude{ORB_ID(vehicle_attitude)};
 	uORB::SubscriptionData<home_position_s> _sub_home_position{ORB_ID(home_position)};
+
+	map_projection_reference_s _global_local_proj_ref{};
+	float                      _global_local_alt0{0.f};
 
 	/** Reset all setpoints to NAN */
 	void _resetSetpoints();

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1557,16 +1557,22 @@ FixedwingPositionControl::Run()
 		Vector2f curr_pos((float)_current_latitude, (float)_current_longitude);
 		Vector2f ground_speed(_local_pos.vx, _local_pos.vy);
 
-		//Convert Local setpoints to global setpoints
+		// Convert local setpoints to global
 		if (_control_mode.flag_control_offboard_enabled) {
-			if (!globallocalconverter_initialized()) {
-				globallocalconverter_init(_local_pos.ref_lat, _local_pos.ref_lon,
-							  _local_pos.ref_alt, _local_pos.ref_timestamp);
+			if (!map_projection_initialized(&_global_local_proj_ref)
+			    || (_global_local_proj_ref.timestamp != _local_pos.ref_timestamp)) {
 
-			} else {
-				globallocalconverter_toglobal(_pos_sp_triplet.current.x, _pos_sp_triplet.current.y, _pos_sp_triplet.current.z,
-							      &_pos_sp_triplet.current.lat, &_pos_sp_triplet.current.lon, &_pos_sp_triplet.current.alt);
+				map_projection_init_timestamped(&_global_local_proj_ref, _local_pos.ref_lat, _local_pos.ref_lon,
+								_local_pos.ref_timestamp);
+				_global_local_alt0 = _local_pos.ref_alt;
 			}
+
+			map_projection_reproject(&_global_local_proj_ref,
+						 _pos_sp_triplet.current.x, _pos_sp_triplet.current.y,
+						 &_pos_sp_triplet.current.lat, &_pos_sp_triplet.current.lon);
+
+			_pos_sp_triplet.current.alt = _global_local_alt0 - _pos_sp_triplet.current.z;
+			_pos_sp_triplet.current.valid = true;
 		}
 
 		/*

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -180,6 +180,9 @@ private:
 	SubscriptionData<airspeed_validated_s>			_airspeed_validated_sub{ORB_ID(airspeed_validated)};
 	SubscriptionData<vehicle_acceleration_s>	_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 
+	map_projection_reference_s _global_local_proj_ref{};
+	float                      _global_local_alt0{0.f};
+
 	double _current_latitude{0};
 	double _current_longitude{0};
 	float _current_altitude{0.f};

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -378,6 +378,8 @@ private:
 
 	// local to global coversion related variables
 	bool _is_global_cov_init;
+	map_projection_reference_s _global_local_proj_ref{};
+	float                      _global_local_alt0{0.f};
 	uint64_t _global_ref_timestamp;
 	double _ref_lat;
 	double _ref_lon;

--- a/src/modules/local_position_estimator/sensors/mocap.cpp
+++ b/src/modules/local_position_estimator/sensors/mocap.cpp
@@ -37,14 +37,18 @@ void BlockLocalPositionEstimator::mocapInit()
 		_sensorFault &= ~SENSOR_MOCAP;
 
 		// get reference for global position
-		globallocalconverter_getref(&_ref_lat, &_ref_lon, &_ref_alt);
+		_ref_lat = math::degrees(_global_local_proj_ref.lat_rad);
+		_ref_lon = math::degrees(_global_local_proj_ref.lon_rad);
+		_ref_alt = _global_local_alt0;
+
 		_global_ref_timestamp = _timeStamp;
-		_is_global_cov_init = globallocalconverter_initialized();
+		_is_global_cov_init = map_projection_initialized(&_global_local_proj_ref);
 
 		if (!_map_ref.init_done && _is_global_cov_init && !_visionUpdated) {
 			// initialize global origin using the mocap estimator reference (only if the vision estimation is not being fused as well)
 			mavlink_log_info(&mavlink_log_pub, "[lpe] global origin init (mocap) : lat %6.2f lon %6.2f alt %5.1f m",
 					 double(_ref_lat), double(_ref_lon), double(_ref_alt));
+
 			map_projection_init(&_map_ref, _ref_lat, _ref_lon);
 			// set timestamp when origin was set to current time
 			_time_origin = _timeStamp;
@@ -53,7 +57,7 @@ void BlockLocalPositionEstimator::mocapInit()
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
 			_altOriginGlobal = true;
-			_altOrigin = globallocalconverter_initialized() ? _ref_alt : 0.0f;
+			_altOrigin = map_projection_initialized(&_global_local_proj_ref) ? _ref_alt : 0.0f;
 		}
 	}
 }

--- a/src/modules/local_position_estimator/sensors/vision.cpp
+++ b/src/modules/local_position_estimator/sensors/vision.cpp
@@ -42,9 +42,12 @@ void BlockLocalPositionEstimator::visionInit()
 		_sensorFault &= ~SENSOR_VISION;
 
 		// get reference for global position
-		globallocalconverter_getref(&_ref_lat, &_ref_lon, &_ref_alt);
+		_ref_lat = math::degrees(_global_local_proj_ref.lat_rad);
+		_ref_lon = math::degrees(_global_local_proj_ref.lon_rad);
+		_ref_alt = _global_local_alt0;
+
 		_global_ref_timestamp = _timeStamp;
-		_is_global_cov_init = globallocalconverter_initialized();
+		_is_global_cov_init = map_projection_initialized(&_global_local_proj_ref);
 
 		if (!_map_ref.init_done && _is_global_cov_init) {
 			// initialize global origin using the visual estimator reference
@@ -58,7 +61,7 @@ void BlockLocalPositionEstimator::visionInit()
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
 			_altOriginGlobal = true;
-			_altOrigin = globallocalconverter_initialized() ? _ref_alt : 0.0f;
+			_altOrigin = map_projection_initialized(&_global_local_proj_ref) ? _ref_alt : 0.0f;
 		}
 	}
 }

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -148,7 +148,7 @@ private:
 	void handle_message_debug_vect(mavlink_message_t *msg);
 	void handle_message_distance_sensor(mavlink_message_t *msg);
 	void handle_message_follow_target(mavlink_message_t *msg);
-	void handle_message_gps_global_origin(mavlink_message_t *msg);
+	void handle_message_set_gps_global_origin(mavlink_message_t *msg);
 	void handle_message_gps_rtcm_data(mavlink_message_t *msg);
 	void handle_message_heartbeat(mavlink_message_t *msg);
 	void handle_message_hil_gps(mavlink_message_t *msg);
@@ -300,11 +300,8 @@ private:
 	uint8_t				_mom_switch_pos[MOM_SWITCH_COUNT] {};
 	uint16_t			_mom_switch_state{0};
 
-	uint64_t			_global_ref_timestamp{0};
-
-	map_projection_reference_s	_hil_local_proj_ref{};
-	float				_hil_local_alt0{0.0f};
-	bool				_hil_local_proj_inited{false};
+	map_projection_reference_s	_global_local_proj_ref{};
+	float				_global_local_alt0{0.0f};
 
 	hrt_abstime			_last_utm_global_pos_com{0};
 

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -416,17 +416,25 @@ RoverPositionControl::run()
 
 			position_setpoint_triplet_poll();
 
-			//Convert Local setpoints to global setpoints
+			// Convert local setpoints to global
 			if (_control_mode.flag_control_offboard_enabled) {
-				if (!globallocalconverter_initialized()) {
-					globallocalconverter_init(_local_pos.ref_lat, _local_pos.ref_lon,
-								  _local_pos.ref_alt, _local_pos.ref_timestamp);
 
-				} else {
-					globallocalconverter_toglobal(_pos_sp_triplet.current.x, _pos_sp_triplet.current.y, _pos_sp_triplet.current.z,
-								      &_pos_sp_triplet.current.lat, &_pos_sp_triplet.current.lon, &_pos_sp_triplet.current.alt);
+				if (!map_projection_initialized(&_global_local_proj_ref)
+				    || (_global_local_proj_ref.timestamp != _local_pos.ref_timestamp)) {
 
+					map_projection_init_timestamped(&_global_local_proj_ref, _local_pos.ref_lat, _local_pos.ref_lon,
+									_local_pos.ref_timestamp);
+
+					_global_local_alt0 = _local_pos.ref_alt;
 				}
+
+				// local -> global
+				map_projection_reproject(&_global_local_proj_ref,
+							 _pos_sp_triplet.current.x, _pos_sp_triplet.current.y,
+							 &_pos_sp_triplet.current.lat, &_pos_sp_triplet.current.lon);
+
+				_pos_sp_triplet.current.alt = _global_local_alt0 - _pos_sp_triplet.current.z;
+				_pos_sp_triplet.current.valid = true;
 			}
 
 			// update the reset counters in any case

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -130,6 +130,9 @@ private:
 
 	hrt_abstime _control_position_last_called{0}; 	/**<last call of control_position  */
 
+	map_projection_reference_s _global_local_proj_ref{};
+	float                      _global_local_alt0{0.f};
+
 	/* Pid controller for the speed. Here we assume we can control airspeed but the control variable is actually on
 	 the throttle. For now just assuming a proportional scaler between controlled airspeed and throttle output.*/
 	PID_t _speed_ctrl{};


### PR DESCRIPTION
The globallocalconverter helper is just a wrapper around the map projections functions, but with a hidden global variable for the reference.

TODO:
 - [ ] review SET_GPS_GLOBAL_ORIGIN/GPS_GLOBAL_ORIGIN (and LPE)
      - what's actually used here and what should we support?