### PR TITLE
Tailsitter: remove integrator lock in hover and increase elevon deflection

### DIFF
--- a/ROMFS/px4fmu_common/mixers/vtol_tailsitter_duo.main.mix
+++ b/ROMFS/px4fmu_common/mixers/vtol_tailsitter_duo.main.mix
@@ -29,11 +29,9 @@ Channel 5 connects to the right (starboard) elevon.
 Channel 6 connects to the left (port) elevon.
 
 M: 2
-O:        7500    7500    0 -10000  10000
 S: 1 0   10000   10000    0 -10000  10000
 S: 1 1   10000   10000    0 -10000  10000
 
 M: 2
-O:        7500    7500    0 -10000  10000
 S: 1 0   10000   10000    0 -10000  10000
 S: 1 1  -10000  -10000    0 -10000  10000

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -380,9 +380,10 @@ void FixedwingAttitudeControl::Run()
 			wheel_control = true;
 		}
 
-		/* lock integrator until control is started or for long intervals (> 20 ms) */
+		// lock integrator if no rate control enabled, or in RW mode (but not transitioning VTOL or tailsitter), or for long intervals (> 20 ms)
 		bool lock_integrator = !_vcontrol_mode.flag_control_rates_enabled
-				       || (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING && ! _vehicle_status.in_transition_mode)
+				       || (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
+					   !_vehicle_status.in_transition_mode && !_is_tailsitter)
 				       || (dt > 0.02f);
 
 		/* if we are in rotary wing mode, do nothing */
@@ -413,11 +414,11 @@ void FixedwingAttitudeControl::Run()
 			}
 
 			/* Reset integrators if the aircraft is on ground
-			 * or a multicopter (but not transitioning VTOL)
+			 * or a multicopter (but not transitioning VTOL or tailsitter)
 			 */
 			if (_landed
 			    || (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-				&& !_vehicle_status.in_transition_mode)) {
+				&& !_vehicle_status.in_transition_mode && !_is_tailsitter)) {
 
 				_roll_ctrl.reset_integrator();
 				_pitch_ctrl.reset_integrator();


### PR DESCRIPTION

**Describe problem solved by this pull request**
I realized that there is no integrator on the pitch and roll axis of a tailsitter atm, because it uses the fixed-wing rate controller on these axis and that one had the integrators locked when not in fixed-wing flight or in transition. 
Having integrator action is especially important on the pitch axis, to stabilize the system in wind plus to help to avoid tipping over.

I've further noticed that the elevon deflection is scaled by 0.75 atm, thus reducing the maximal control output around the pitch and yaw axis. 

**Describe your solution**
- Enable integrators in fixed-wing rate controller always when the system is a tailsitter. 
- Remove the elevon scale.

**Test data / coverage**
Testflown on a small tailsitter (Xvert).

**Additional context**
To avoid tipping-over on the pitch axis, the max  tilt limit should be decreased. As that though limits the ability to move in windy conditions, adding an asymmetrical max tilt would be cool (e.g. tilt forwards, tilt backwards, tilt sidewards). 
