### PR TITLE
[WIP] import minimal c++ stdlib from pigweed

### DIFF
--- a/platforms/nuttx/NuttX/include/cxx/algorithm
+++ b/platforms/nuttx/NuttX/include/cxx/algorithm
@@ -1,0 +1,96 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include <type_traits>
+
+namespace std {
+
+template <class InputIterator, class OutputIterator>
+constexpr OutputIterator copy(InputIterator first,
+                              InputIterator last,
+                              OutputIterator dest) {
+  while (first != last) {
+    *dest++ = *first++;
+  }
+  return dest;
+}
+
+template <typename T>
+constexpr const T& min(const T& lhs, const T& rhs) {
+  return (rhs < lhs) ? rhs : lhs;
+}
+
+template <typename T>
+constexpr const T& max(const T& lhs, const T& rhs) {
+  return (lhs < rhs) ? rhs : lhs;
+}
+
+template <class InputIterator, typename T>
+constexpr InputIterator find(InputIterator first,
+                             InputIterator last,
+                             const T& value) {
+  for (; first != last; ++first) {
+    if (*first == value) {
+      return first;
+    }
+  }
+  return last;
+}
+
+template <typename T>
+constexpr T&& forward(remove_reference_t<T>& value) {
+  return static_cast<T&&>(value);
+}
+
+template <typename T>
+constexpr T&& forward(remove_reference_t<T>&& value) {
+  return static_cast<T&&>(value);
+}
+
+template <class LhsIterator, class RhsIterator>
+constexpr bool equal(LhsIterator first_l,
+                     LhsIterator last_l,
+                     RhsIterator first_r,
+                     RhsIterator last_r) {
+  while (first_l != last_l && first_r != last_r) {
+    if (*first_l != *first_r) {
+      return false;
+    }
+    ++first_l;
+    ++first_r;
+  }
+  return first_l == last_l && first_r == last_r;
+}
+
+template <class LhsIterator, class RhsIterator>
+constexpr bool lexicographical_compare(LhsIterator first_l,
+                                       LhsIterator last_l,
+                                       RhsIterator first_r,
+                                       RhsIterator last_r) {
+  while (first_l != last_l && first_r != last_r) {
+    if (*first_l < *first_r) {
+      return true;
+    }
+    if (*first_r < *first_l) {
+      return false;
+    }
+
+    ++first_l;
+    ++first_r;
+  }
+  return (first_l == last_l) && (first_r != last_r);
+}
+
+}

--- a/platforms/nuttx/NuttX/include/cxx/array
+++ b/platforms/nuttx/NuttX/include/cxx/array
@@ -1,0 +1,103 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include <iterator>
+
+namespace std {
+
+template <typename T, decltype(sizeof(0)) kSize>
+struct array {
+  using value_type = T;
+  using size_type = decltype(kSize);
+  using difference_type =
+      decltype(static_cast<int*>(nullptr) - static_cast<int*>(nullptr));
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = T*;
+  using const_iterator = const T*;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  // NOT IMPLEMENTED: at() does not bounds checking.
+  constexpr reference at(size_type index) { return data()[index]; }
+  constexpr const_reference at(size_type index) const { return data()[index]; }
+
+  constexpr reference operator[](size_type index) { return data()[index]; }
+  constexpr const_reference operator[](size_type index) const {
+    return data()[index];
+  }
+
+  constexpr reference front() { return data()[0]; }
+  constexpr const_reference front() const { return data()[0]; }
+
+  constexpr reference back() {
+    static_assert(kSize > 0);
+    return data()[size() - 1];
+  }
+  constexpr const_reference back() const {
+    static_assert(kSize > 0);
+    return data()[size() - 1];
+  }
+
+  constexpr pointer data() noexcept {
+    static_assert(kSize > 0);
+    return __data;
+  }
+  constexpr const_pointer data() const noexcept {
+    static_assert(kSize > 0);
+    return __data;
+  }
+
+  constexpr iterator begin() noexcept { return data(); }
+  constexpr const_iterator begin() const noexcept { return data(); }
+  constexpr const_iterator cbegin() const noexcept { return begin(); }
+
+  constexpr iterator end() noexcept { return data() + kSize; }
+  constexpr const_iterator end() const noexcept { return data() + kSize; }
+  constexpr const_iterator cend() const noexcept { return end(); }
+
+  // NOT IMPLEMENTED
+  constexpr reverse_iterator rbegin() noexcept;
+  constexpr const_reverse_iterator rbegin() const noexcept;
+  constexpr const_reverse_iterator crbegin() const noexcept;
+
+  // NOT IMPLEMENTED
+  constexpr reverse_iterator rend() noexcept;
+  constexpr const_reverse_iterator rend() const noexcept;
+  constexpr const_reverse_iterator crend() const noexcept;
+
+  [[nodiscard]] constexpr bool empty() const noexcept { return kSize == 0u; }
+
+  constexpr size_type size() const noexcept { return kSize; }
+
+  constexpr size_type max_size() const noexcept { return size(); }
+
+  constexpr void fill(const T& value) {
+    for (T& array_value : __data) {
+      array_value = value;
+    }
+  }
+
+  // NOT IMPLEMENTED
+  constexpr void swap(array& other) noexcept;
+
+  T __data[kSize];
+};
+
+// NOT IMPLEMENTED: comparison operators, get, swap, tuple specializations
+
+}

--- a/platforms/nuttx/NuttX/include/cxx/initializer_list
+++ b/platforms/nuttx/NuttX/include/cxx/initializer_list
@@ -1,0 +1,42 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+namespace std {
+
+template <typename T>
+class initializer_list {
+ public:
+  using value_type = T;
+  using reference = const T&;
+  using const_reference = const T&;
+  using size_type = decltype(sizeof(0));
+  using iterator = const T*;
+  using const_iterator = const T*;
+
+  constexpr initializer_list() : begin_(nullptr), size_(0) {}
+
+  size_type size() const { return size_; }
+
+  iterator begin() const { return begin_; }
+  iterator end() const { return begin_ + size_; }
+
+ private:
+  // The order of these members must stay the same. The compiler makes
+  // assumptions about this class, and reordering these breaks things.
+  const T* begin_;
+  size_type size_;
+};
+
+}

--- a/platforms/nuttx/NuttX/include/cxx/iterator
+++ b/platforms/nuttx/NuttX/include/cxx/iterator
@@ -1,0 +1,75 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include <cstddef>
+
+namespace std {
+
+#define __cpp_lib_nonmember_container_access 201411L
+
+template <typename C>
+auto begin(C& container) -> decltype(container.begin()) {
+  return container.begin();
+}
+
+template <typename C>
+auto begin(const C& container) -> decltype(container.begin()) {
+  return container.begin();
+}
+
+template <typename C>
+constexpr auto data(C& container) -> decltype(container.data()) {
+  return container.data();
+}
+
+template <typename C>
+constexpr auto data(const C& container) -> decltype(container.data()) {
+  return container.data();
+}
+
+template <typename T, decltype(sizeof(int)) kSize>
+constexpr T* data(T (&array)[kSize]) noexcept {
+  return array;
+}
+
+template <typename C>
+auto end(C& container) -> decltype(container.end()) {
+  return container.end();
+}
+
+template <typename C>
+auto end(const C& container) -> decltype(container.end()) {
+  return container.end();
+}
+
+template <typename C>
+constexpr auto size(const C& container) -> decltype(container.size()) {
+  return container.size();
+}
+
+template <typename T, decltype(sizeof(int)) kSize>
+constexpr decltype(sizeof(int)) size(const T (&)[kSize]) noexcept {
+  return kSize;
+}
+
+// NOT IMPLEMENTED: iterator_traits does not work
+template <typename>
+struct iterator_traits {};
+
+// NOT IMPLEMENTED: Reverse iterators are not implemented.
+template <typename>
+struct reverse_iterator;
+
+}

--- a/platforms/nuttx/NuttX/include/cxx/limits
+++ b/platforms/nuttx/NuttX/include/cxx/limits
@@ -1,0 +1,65 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include <limits.h>
+
+namespace std {
+
+template <typename T>
+struct numeric_limits {
+  static constexpr bool is_specialized = false;
+};
+
+// Only a few of the numeric_limits methods are implemented.
+#define _PW_LIMITS_SPECIALIZATION(                               \
+    type, val_signed, val_int, min_value, max_value)             \
+  template <>                                                    \
+  struct numeric_limits<type> {                                  \
+    static constexpr bool is_specialized = true;                 \
+                                                                 \
+    static constexpr bool is_signed = (val_signed);              \
+    static constexpr bool is_integer = (val_int);                \
+                                                                 \
+    static constexpr type min() noexcept { return (min_value); } \
+    static constexpr type max() noexcept { return (max_value); } \
+  }
+
+#define _PW_INTEGRAL_LIMIT(type, sname, uname)            \
+  _PW_LIMITS_SPECIALIZATION(                              \
+      signed type, true, true, sname##_MIN, sname##_MAX); \
+  _PW_LIMITS_SPECIALIZATION(unsigned type, false, true, 0u, uname##_MAX)
+
+_PW_LIMITS_SPECIALIZATION(bool, false, true, false, true);
+_PW_LIMITS_SPECIALIZATION(char, char(-1) < char(0), true, CHAR_MIN, CHAR_MAX);
+
+_PW_INTEGRAL_LIMIT(char, SCHAR, UCHAR);
+_PW_INTEGRAL_LIMIT(short, SHRT, USHRT);
+_PW_INTEGRAL_LIMIT(int, INT, UINT);
+_PW_INTEGRAL_LIMIT(long, LONG, ULONG);
+
+#ifndef LLONG_MIN
+#define LLONG_MIN ((long long)(~0ull ^ (~0ull >> 1)))
+#define LLONG_MAX ((long long)(~0ull >> 1))
+
+#define ULLONG_MIN (0ull)
+#define ULLONG_MAX (~0ull)
+#endif  // LLONG_MIN
+
+_PW_INTEGRAL_LIMIT(long long, LLONG, ULLONG);
+
+#undef _PW_LIMITS_SPECIALIZATION
+#undef _PW_INTEGRAL_LIMIT
+
+}

--- a/platforms/nuttx/NuttX/include/cxx/type_traits
+++ b/platforms/nuttx/NuttX/include/cxx/type_traits
@@ -1,0 +1,450 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+namespace std {
+
+#define __cpp_lib_transformation_trait_aliases 201304L
+#define __cpp_lib_type_trait_variable_templates 201510L
+
+template <decltype(sizeof(0)) kLength,
+          decltype(sizeof(0)) kAlignment>  // no default
+struct aligned_storage {
+  struct type {
+    alignas(kAlignment) unsigned char __data[kLength];
+  };
+};
+
+template <decltype(sizeof(0)) kLength,
+          decltype(sizeof(0)) kAlignment>  // no default
+using aligned_storage_t = typename aligned_storage<kLength, kAlignment>::type;
+
+#define __cpp_lib_integral_constant_callable 201304L
+
+template <typename T, T kValue>
+struct integral_constant {
+  using value_type = T;
+  using type = integral_constant;
+
+  static constexpr T value = kValue;
+
+  constexpr operator value_type() const noexcept { return value; }
+
+  constexpr value_type operator()() const noexcept { return value; }
+};
+
+#define __cpp_lib_bool_constant 201505L
+
+template <bool kValue>
+using bool_constant = integral_constant<bool, kValue>;
+
+using true_type = bool_constant<true>;
+using false_type = bool_constant<false>;
+
+template <typename T>
+struct is_array : false_type {};
+
+template <typename T>
+struct is_array<T[]> : true_type {};
+
+template <typename T, decltype(sizeof(int)) kSize>
+struct is_array<T[kSize]> : true_type {};
+
+template <typename T>
+inline constexpr bool is_array_v = is_array<T>::value;
+
+template <typename T>
+struct is_const : false_type {};
+
+template <typename T>
+struct is_const<const T> : true_type {};
+
+// NOT IMPLEMENTED: is_enum requires compiler builtins.
+template <typename T>
+struct is_enum : false_type {};
+
+template <typename T>
+inline constexpr bool is_enum_v = is_enum<T>::value;
+
+template <typename T>
+struct remove_cv;  // Forward declaration
+
+namespace impl {
+
+template <typename T>
+struct is_floating_point : false_type {};
+
+template <>
+struct is_floating_point<float> : true_type {};
+template <>
+struct is_floating_point<double> : true_type {};
+template <>
+struct is_floating_point<long double> : true_type {};
+
+}  // namespace impl
+
+template <typename T>
+struct is_floating_point
+    : impl::is_floating_point<typename remove_cv<T>::type> {};
+
+template <typename T>
+inline constexpr bool is_floating_point_v = is_floating_point<T>::value;
+
+namespace impl {
+
+template <typename T>
+struct is_integral : false_type {};
+
+template <>
+struct is_integral<bool> : true_type {};
+template <>
+struct is_integral<char> : true_type {};
+template <>
+struct is_integral<char16_t> : true_type {};
+template <>
+struct is_integral<char32_t> : true_type {};
+template <>
+struct is_integral<wchar_t> : true_type {};
+
+template <>
+struct is_integral<short> : true_type {};
+template <>
+struct is_integral<unsigned short> : true_type {};
+template <>
+struct is_integral<int> : true_type {};
+template <>
+struct is_integral<unsigned int> : true_type {};
+template <>
+struct is_integral<long> : true_type {};
+template <>
+struct is_integral<unsigned long> : true_type {};
+template <>
+struct is_integral<long long> : true_type {};
+template <>
+struct is_integral<unsigned long long> : true_type {};
+
+}  // namespace impl
+
+template <typename T>
+struct is_integral : impl::is_integral<typename remove_cv<T>::type> {};
+
+template <typename T>
+inline constexpr bool is_integral_v = is_integral<T>::value;
+
+template <typename T>
+struct is_arithmetic
+    : bool_constant<is_integral_v<T> || is_floating_point_v<T>> {};
+
+template <typename T>
+inline constexpr bool is_arithmetic_v = is_arithmetic<T>::value;
+
+#define __cpp_lib_is_null_pointer 201309L
+
+template <typename T>
+struct is_null_pointer : false_type {};
+
+template <>
+struct is_null_pointer<decltype(nullptr)> : true_type {};
+
+template <typename T>
+inline constexpr bool is_null_pointer_v = is_null_pointer<T>::value;
+
+template <typename T>
+struct is_pointer : false_type {};
+
+template <typename T>
+struct is_pointer<T*> : true_type {};
+
+template <typename T>
+inline constexpr bool is_pointer_v = is_pointer<T>::value;
+
+template <typename T, typename U>
+struct is_same : false_type {};
+
+template <typename T>
+struct is_same<T, T> : true_type {};
+
+template <typename T, typename U>
+inline constexpr bool is_same_v = is_same<T, U>::value;
+
+namespace impl {
+
+template <typename T, bool = is_arithmetic<T>::value>
+struct is_signed : integral_constant<bool, T(-1) < T(0)> {};
+
+template <typename T>
+struct is_signed<T, false> : false_type {};
+
+}  // namespace impl
+
+template <typename T>
+struct is_signed : impl::is_signed<T>::type {};
+
+template <typename T>
+inline constexpr bool is_signed_v = is_signed<T>::value;
+
+template <typename T>
+struct is_unsigned : bool_constant<!is_signed_v<T>> {};
+
+template <typename T>
+inline constexpr bool is_unsigned_v = is_unsigned<T>::value;
+
+template <typename T>
+struct is_void : is_same<void, typename remove_cv<T>::type> {};
+
+template <typename T>
+inline constexpr bool is_void_v = is_void<T>::value;
+
+template <typename T>
+struct negation : bool_constant<!bool(T::value)> {};
+
+template <typename T>
+inline constexpr bool negation_v = negation<T>::value;
+
+template <bool kBool, typename TrueType, typename FalseType>
+struct conditional {
+  using type = TrueType;
+};
+
+template <typename TrueType, typename FalseType>
+struct conditional<false, TrueType, FalseType> {
+  using type = FalseType;
+};
+
+template <bool kBool, typename TrueType, typename FalseType>
+using conditional_t = typename conditional<kBool, TrueType, FalseType>::type;
+
+template <bool kEnable, typename T = void>
+struct enable_if {
+  using type = T;
+};
+
+template <typename T>
+struct enable_if<false, T> {};
+
+template <bool kEnable, typename T = void>
+using enable_if_t = typename enable_if<kEnable, T>::type;
+
+template <typename T>
+struct remove_const {
+  using type = T;
+};
+
+template <typename T>
+struct remove_const<const T> {
+  using type = T;
+};
+
+template <typename T>
+using remove_const_t = typename remove_const<T>::type;
+
+template <typename T>
+struct remove_volatile {
+  using type = T;
+};
+
+template <typename T>
+struct remove_volatile<volatile T> {
+  using type = T;
+};
+
+template <typename T>
+using remove_volatile_t = typename remove_volatile<T>::type;
+
+template <typename T>
+struct remove_cv {
+  using type = remove_volatile_t<remove_const_t<T>>;
+};
+
+template <typename T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+template <typename T>
+struct remove_extent {
+  using type = T;
+};
+
+template <typename T>
+struct remove_extent<T[]> {
+  using type = T;
+};
+
+template <typename T, decltype(sizeof(0)) kSize>
+struct remove_extent<T[kSize]> {
+  using type = T;
+};
+
+template <typename T>
+using remove_extent_t = typename remove_extent<T>::type;
+
+template <typename T>
+struct remove_pointer {
+  using type = T;
+};
+
+template <typename T>
+struct remove_pointer<T*> {
+  using type = T;
+};
+
+template <typename T>
+struct remove_pointer<T* const> {
+  using type = T;
+};
+
+template <typename T>
+struct remove_pointer<T* volatile> {
+  using type = T;
+};
+
+template <typename T>
+struct remove_pointer<T* const volatile> {
+  using type = T;
+};
+
+template <typename T>
+using remove_pointer_t = typename remove_pointer<T>::type;
+
+template <typename T>
+struct remove_reference {
+  using type = T;
+};
+
+template <typename T>
+struct remove_reference<T&> {
+  using type = T;
+};
+
+template <typename T>
+struct remove_reference<T&&> {
+  using type = T;
+};
+
+template <typename T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+// NOT IMPLEMENTED: This implementation is INCOMPLETE, as it does not cover
+// function types.
+template <typename T>
+struct decay {
+ private:
+  using U = remove_reference_t<T>;
+
+ public:
+  using type =
+      conditional_t<is_array<U>::value, remove_extent_t<U>*, remove_cv_t<U>>;
+};
+
+template <typename T>
+using decay_t = typename decay<T>::type;
+
+#define __cpp_lib_type_identity 201806
+
+template <class T>
+struct type_identity {
+  using type = T;
+};
+
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
+
+#define __cpp_lib_void_t void_t 201411L
+
+template <typename...>
+using void_t = void;
+
+namespace impl {
+
+template <typename T>
+type_identity<T&> AddLValueReference(int);
+
+template <typename T>
+type_identity<T> AddLValueReference(...);
+
+template <typename T>
+type_identity<T&&> AddRValueReference(int);
+
+template <typename T>
+type_identity<T> AddRValueReference(...);
+
+}  // namespace impl
+
+template <class T>
+struct add_lvalue_reference : decltype(impl::AddLValueReference<T>(0)) {};
+
+template <typename T>
+using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;
+
+template <class T>
+struct add_rvalue_reference : decltype(impl::AddRValueReference<T>(0)) {};
+
+template <typename T>
+using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;
+
+template <typename T>
+add_rvalue_reference_t<T> declval() noexcept;
+
+namespace impl {
+
+template <typename>
+using templated_true = true_type;
+
+template <typename T>
+auto returnable(int) -> templated_true<T()>;
+
+template <typename>
+auto returnable(...) -> false_type;
+
+template <typename From, typename To>
+auto convertible(int)
+    -> templated_true<decltype(declval<void (&)(To)>()(declval<From>()))>;
+
+template <typename, typename>
+auto convertible(...) -> false_type;
+
+}  // namespace impl
+
+template <typename From, typename To>
+struct is_convertible
+    : bool_constant<(decltype(impl::returnable<To>(0))() &&
+                     decltype(impl::convertible<From, To>(0))()) ||
+                    (is_void_v<From> && is_void_v<To>)> {};
+
+template <typename T, typename U>
+inline constexpr bool is_convertible_v = is_convertible<T, U>::value;
+
+// NOT IMPLEMENTED: Stubs are provided for these traits classes, but they do not
+// return useful values. Many of these would require compiler builtins.
+template <typename T>
+struct is_function : false_type {};
+template <typename T>
+struct is_trivially_copyable : true_type {};
+template <typename T>
+struct is_polymorphic : false_type {};
+template <typename T, typename U>
+struct is_base_of : false_type {};
+template <typename T>
+struct extent : integral_constant<decltype(sizeof(int)), 1> {};
+template <typename T>
+inline constexpr bool extent_v = extent<T>::value;
+template <typename T>
+struct underlying_type {
+  using type = T;
+};
+template <typename T>
+using underlying_type_t = typename underlying_type<T>::type;
+template <typename T>
+inline constexpr bool is_trivially_copyable_v = is_trivially_copyable<T>::value;
+
+}

--- a/platforms/nuttx/NuttX/include/cxx/utility
+++ b/platforms/nuttx/NuttX/include/cxx/utility
@@ -1,0 +1,32 @@
+// Copyright 2020 The Pigweed Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+#pragma once
+
+#include <type_traits>
+
+namespace std {
+
+template <typename T>
+constexpr remove_reference_t<T>&& move(T&& object) {
+  return (remove_reference_t<T> &&) object;
+}
+
+// Forward declare these classes, which are specialized in other headers.
+template <decltype(sizeof(0)), typename>
+struct tuple_element;
+
+template <typename>
+struct tuple_size;
+
+}


### PR DESCRIPTION
This imports most of the minimal c++ stdlib from Pigweed (https://pigweed.googlesource.com/pigweed/pigweed/+/refs/heads/master) other than what NuttX already provides (cmath, cstddef, cstdint, etc).

If we're going to carry this for NuttX (and possibly other platforms like QuRT) we should definitely add dedicated testing.

