### PR TITLE
when exiting offboard state, do no go back to takeoff

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -848,8 +848,14 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 			} else {
 				/* If the mavlink command is used to enable or disable offboard control:
-				 * switch back to previous mode when disabling */
-				res = main_state_transition(_status, _main_state_pre_offboard, _status_flags, &_internal_state);
+				 * switch back to previous mode when disabling excepted if it was takeoff*/
+				if (_main_state_pre_offboard != commander_state_s::MAIN_STATE_AUTO_TAKEOFF) {
+					res = main_state_transition(_status, _main_state_pre_offboard, _status_flags, &_internal_state);
+
+				} else {
+					res = main_state_transition(_status, commander_state_s::MAIN_STATE_AUTO_LOITER, _status_flags, &_internal_state);
+				}
+
 				_status_flags.offboard_control_set_by_command = false;
 			}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
If offboard mode is entered during takeoff, when exiting offboard mode, the drone go back to takeoff. Than does not seems coherent and leads to an unexpected behaviors: the drone start climbing (depending on the drone state on the transition form takeoff to offboard).

**Describe your solution**
With this pull request, when the drone exits offboard mode and previous mode is takeoff, the transition is changed to auto_loiter.

This new behavior is safer and seems more natural in our use cases, not sure it is always the case.


