### PR TITLE
UUV introduce param to skip controller

### DIFF
--- a/src/modules/uuv_att_control/uuv_att_control.cpp
+++ b/src/modules/uuv_att_control/uuv_att_control.cpp
@@ -238,7 +238,13 @@ void UUVAttitudeControl::Run()
 			}
 
 			/* Geometric Control*/
-			control_attitude_geo(attitude, _attitude_setpoint, angular_velocity, _rates_setpoint);
+			int skip_controller = _param_skip_ctrl.get();
+
+			if (skip_controller) {
+				constrain_actuator_commands(_rates_setpoint.roll, _rates_setpoint.pitch, _rates_setpoint.yaw, _rates_setpoint.thrust_body[0]);
+			} else {
+				control_attitude_geo(attitude, _attitude_setpoint, angular_velocity, _rates_setpoint);
+			}
 		}
 	}
 

--- a/src/modules/uuv_att_control/uuv_att_control.cpp
+++ b/src/modules/uuv_att_control/uuv_att_control.cpp
@@ -241,7 +241,9 @@ void UUVAttitudeControl::Run()
 			int skip_controller = _param_skip_ctrl.get();
 
 			if (skip_controller) {
-				constrain_actuator_commands(_rates_setpoint.roll, _rates_setpoint.pitch, _rates_setpoint.yaw, _rates_setpoint.thrust_body[0]);
+				constrain_actuator_commands(_rates_setpoint.roll, _rates_setpoint.pitch, _rates_setpoint.yaw,
+							    _rates_setpoint.thrust_body[0]);
+
 			} else {
 				control_attitude_geo(attitude, _attitude_setpoint, angular_velocity, _rates_setpoint);
 			}

--- a/src/modules/uuv_att_control/uuv_att_control.hpp
+++ b/src/modules/uuv_att_control/uuv_att_control.hpp
@@ -88,10 +88,6 @@ public:
 	UUVAttitudeControl();
 	~UUVAttitudeControl();
 
-	UUVAttitudeControl(const UUVAttitudeControl &) = delete;
-	UUVAttitudeControl operator=(const UUVAttitudeControl &other) = delete;
-
-
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
 
@@ -132,6 +128,7 @@ private:
 		(ParamFloat<px4::params::UUV_YAW_D>) _param_yaw_d,
 		// control/input modes
 		(ParamInt<px4::params::UUV_INPUT_MODE>) _param_input_mode,
+		(ParamInt<px4::params::UUV_SKIP_CTRL>) _param_skip_ctrl,
 		// direct access to inputs
 		(ParamFloat<px4::params::UUV_DIRCT_ROLL>) _param_direct_roll,
 		(ParamFloat<px4::params::UUV_DIRCT_PITCH>) _param_direct_pitch,

--- a/src/modules/uuv_att_control/uuv_att_control_params.c
+++ b/src/modules/uuv_att_control/uuv_att_control_params.c
@@ -108,6 +108,14 @@ PARAM_DEFINE_FLOAT(UUV_YAW_D, 2.0f);
 PARAM_DEFINE_INT32(UUV_INPUT_MODE, 0);
 
 /**
+ * Skip the controller
+ *
+ * @value 0 use the module's controller
+ * @value 1 skip the controller and feedthrough the setpoints
+ */
+PARAM_DEFINE_INT32(UUV_SKIP_CTRL, 0);
+
+/**
  * Direct roll input
  *
  * @group UUV Attitude Control


### PR DESCRIPTION
**Describe problem solved by this pull request**
Now it's possible to skip the uuv_att_control module's controller and feed the setpoint to the mixer. 

So the companion computer can either send attitude setpoints and the onboard geometric controller of the uuv_att_control module controls the vehicle or the companion computer can send setpoints that are fed through the UUV's mixer. This depends on the UUV_SKIP_CTRL parameter.