### PR TITLE
Enable acceleration setpoint based takeoff

### DIFF
--- a/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/flight_tasks/tasks/FlightTask/FlightTask.cpp
@@ -203,5 +203,12 @@ bool FlightTask::_checkTakeoff()
 		velocity_triggered_takeoff = _velocity_setpoint(2) < -0.3f;
 	}
 
-	return position_triggered_takeoff || velocity_triggered_takeoff;
+	// upwards acceleration setpoint
+	bool acceleration_triggered_takeoff = false;
+
+	if (PX4_ISFINITE(_acceleration_setpoint(2))) {
+		acceleration_triggered_takeoff = _acceleration_setpoint(2) < -0.3f;
+	}
+
+	return position_triggered_takeoff || velocity_triggered_takeoff || acceleration_triggered_takeoff;
 }

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3322,7 +3322,7 @@ Commander::update_control_mode()
 					!control_mode.flag_control_acceleration_enabled;
 
 			control_mode.flag_control_climb_rate_enabled = (!offboard_control_mode.ignore_velocity ||
-					!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
+					!offboard_control_mode.ignore_position);
 
 			control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !status.in_transition_mode &&
 					!control_mode.flag_control_acceleration_enabled;


### PR DESCRIPTION
**Describe problem solved by this pull request**
When sending acceleration setpoints as part of offboard position setpoints as part of [SET_POSITION_TARGET_LOCAL_NED](https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED) mavlink message, the vehicle would not take off.

The reason seems to be that a downward acceleration was being copied while the vehicle was in `flying_but_ground_contact=true` state.  

**Describe your solution**
This PR adds the following.
- Enables a acceleration triggered takeoff based on the acceleration setpoint
- Fixes the takeoff logic so that the vehicle is able to take off while acceleration setpoints are being sent

**Test data / coverage**
Having acceleration setpoints do seem to improve the performance of trajectory tracking.
The below examples show a log of the vehicle tracking a circular trajectory with and without acceleration feed forward inputs.

- (BeforePR) Without Acceleration feedforward setpoints: https://review.px4.io/plot_app?log=3f8f3643-991b-435e-8286-289aa2920803
![image](https://user-images.githubusercontent.com/5248102/92527345-249aea00-f227-11ea-9b63-0b526ac297d2.png)

- (AfterPR) With Acceleration feedforward setpoints: https://review.px4.io/plot_app?log=7515c5b1-bfc1-4026-9a11-8eabda5134c0
![image](https://user-images.githubusercontent.com/5248102/92527377-311f4280-f227-11ea-8983-cf28ee816341.png)


**Additional context**
- Acceleration feedforward control was added in https://github.com/PX4/Firmware/pull/14212, but was not functional for offboard control.