### PR TITLE
heater: px4io: Add support for heaters on IO MCU

### DIFF
--- a/boards/px4/fmu-v3/src/board_config.h
+++ b/boards/px4/fmu-v3/src/board_config.h
@@ -168,6 +168,12 @@
 
 #define BOARD_DSHOT_MOTOR_ASSIGNMENT {3, 2, 1, 0, 4, 5};
 
+/* Internal IMU Heater
+ *
+ * Connected to the IO MCU; tell compiler to enable support
+ */
+#define PX4IO_HEATER_ENABLED
+
 __BEGIN_DECLS
 
 /****************************************************************************************************

--- a/src/drivers/drv_io_heater.h
+++ b/src/drivers/drv_io_heater.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file drv_io_heater.h
+ *
+ * IO IMU heater control interface (PX4IO)
+ */
+
+#ifndef _DRV_IO_HEATER_H
+#define _DRV_IO_HEATER_H
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+/*
+ * ioctl() definitions
+ */
+
+#define IO_HEATER_DEVICE_PATH	"/dev/px4io"
+
+#define _IO_HEATER_BASE		(0x2e00)
+
+#define PX4IO_HEATER_CONTROL		_PX4_IOC(_IO_HEATER_BASE, 0)
+
+/* ... to IOX_SET_VALUE + 8 */
+
+/* enum passed to IO_HEATER_CONTROL ioctl()*/
+enum IO_HEATER_MODE {
+	HEATER_MODE_OFF = 0,
+	HEATER_MODE_ON = 1,
+	HEATER_MODE_DISABLED = -1
+};
+
+#endif

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-20 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
  * @author Mark Sauder <mcsauder@gmail.com>
  * @author Alex Klimaj <alexklimaj@gmail.com>
  * @author Jake Dahl <dahl.jakejacob@gmail.com>
+ * @author Jacob Crabill <jacob@flyvoly.com>
  */
 
 #pragma once
@@ -163,8 +164,33 @@ private:
 	 */
 	void update_params(const bool force = false);
 
+	/**
+	 * @brief Enables / configures the heater (either by GPIO or PX4IO)
+	 */
+	void heater_enable();
+
+	/**
+	 * @brief Disnables the heater (either by GPIO or PX4IO)
+	 */
+	void heater_disable();
+
+	/**
+	 * @brief Turns the heater on (either by GPIO or PX4IO)
+	 */
+	void heater_on();
+
+	/**
+	 * @brief Turns the heater off (either by GPIO or PX4IO)
+	 */
+	void heater_off();
+
 	/** Work queue struct for the RTOS scheduler. */
 	static struct work_s _work;
+
+	/** File descriptor for PX4IO for heater ioctl's */
+#if defined(HEATER_PX4IO)
+	int _io_fd;
+#endif
 
 	int _controller_period_usec = CONTROLLER_PERIOD_DEFAULT;
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -65,6 +65,7 @@
 #include <drivers/drv_pwm_output.h>
 #include <drivers/drv_sbus.h>
 #include <drivers/drv_hrt.h>
+#include <drivers/drv_io_heater.h>
 #include <drivers/drv_mixer.h>
 
 #include <rc/dsm.h>
@@ -2847,6 +2848,20 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 		} else {
 			ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_FEATURES,
 					    (PX4IO_P_SETUP_FEATURES_SBUS1_OUT | PX4IO_P_SETUP_FEATURES_SBUS2_OUT), 0);
+		}
+
+		break;
+
+	case PX4IO_HEATER_CONTROL:
+		if (arg == (unsigned long)HEATER_MODE_DISABLED) {
+			io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_THERMAL, PX4IO_THERMAL_IGNORE);
+
+		} else if (arg == 1) {
+			io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_THERMAL, PX4IO_THERMAL_FULL);
+
+		} else {
+			io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_THERMAL, PX4IO_THERMAL_OFF);
+
 		}
 
 		break;


### PR DESCRIPTION
Adds support for boards which have an IMU heater pin on the IO MCU.  Uses ioctl calls to PX4IO to turn the heater on/off, and abstracts the heater_on / heater_off calls in the heater driver to use either the ioctl call for PX4IO, or to directly toggle an FMU-connected pin, as configured by the board config.

I know the goal is to move away from inter-thread communications via ioctl calls, but this was the easiest method.

**Test data / coverage**
Tested using a Black Cube on my desk setup.  This was using custom firmware so I'm not sharing that specific log.  The heater module will still have to be added to whatever board you want to test this on.

FYI @dagar 

@mirkix maybe you would like to test this on a yellow/orange Cube?