### PR TITLE
L1: remove check for tangent_vel direction for nicer loiter entry behavior

### DIFF
--- a/src/lib/l1/ECL_L1_Pos_Controller.cpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.cpp
@@ -264,8 +264,8 @@ ECL_L1_Pos_Controller::navigate_loiter(const Vector2f &vector_A, const Vector2f 
 	/* calculate velocity on circle / along tangent */
 	float tangent_vel = xtrack_vel_center * loiter_direction;
 
-	/* prevent PD output from turning the wrong way */
-	if (tangent_vel < 0.0f) {
+	/* prevent PD output from turning the wrong way when in circle mode */
+	if (tangent_vel < 0.0f && _circle_mode) {
 		lateral_accel_sp_circle_pd = math::max(lateral_accel_sp_circle_pd, 0.0f);
 	}
 


### PR DESCRIPTION
Based on [discussion in slack](https://px4.slack.com/archives/C3B9NSHRQ/p1601298551006900?thread_ts=1601131103.003900&cid=C3B9NSHRQ).

**Describe problem solved by this pull request**
The current L1 logic often makes the vehicle first fly through center of loiter waypoint, instead of tracking the loiter circle as soon as it is close to it (or after already being inside the circle). 

**Describe your solution**
Remove check for the tangential velocity to "prevent PD output from turning the wrong way". AFAIK this causes the vehicle to fly straight to the loiter center if the tangential velocity is only slightly in the wrong direction (e.g. because it's hitting the loiter circle at a  91° angle).

**Describe possible alternatives**
Instead of removing check completely, allow small tangential velocities in the wrong direction, e.g. tangent_vel < 1.0f.

**Test data / coverage**
Basic SITL testing.

**Additional context**
Before:
![image](https://user-images.githubusercontent.com/26798987/94483601-68a45d80-01db-11eb-8081-2396767c73ad.png)

With this PR:
![image](https://user-images.githubusercontent.com/26798987/94483562-5d513200-01db-11eb-9e1b-6247329a96ed.png)

@priseborough can you shed some light why it is there? What are the conditions where it could turn the wrong way?
