### PR TITLE
simulator mavlink actuator limits

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -230,7 +230,7 @@ private:
 
 	static void *sending_trampoline(void *);
 
-	mavlink_hil_actuator_controls_t actuator_controls_from_outputs();
+	void actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *msg);
 
 
 	// uORB publisher handlers


### PR DESCRIPTION
fixed case that actuator that wasn't set (value 0 "PWM") results output of -3  
using unified way to decide which output should be scale as rotor
more minor cleanups

**Describe problem solved by this pull request**
I notice that if actuator on actuator_outputs (that is on 'pwm' units of 1000-2000) hasn't been set, because it not used. the actuator_controls (which is in units of 0 to +1 to rotors, and -1 to +1 of other actuators) get -3 value.

**Test data / coverage**
tested iris, and cloudship