### PR TITLE
fw_pos_control_l1: merge loiter + position handling

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -702,7 +702,7 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 					if ((dist_curr_z > dist_z_threshold) || !pos_sp_next.valid) {
 						// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER
 						//  - achieve position setpoint altitude via loiter if close to
-						//    waypoint, but altitude error greater than twice climbout difference
+						//    waypoint, but altitude error greater than twice altitude acceptance radius
 						//  - loiter if there isn't another valid setpoint
 						position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 					}

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -265,6 +265,7 @@ private:
 	TECS			_tecs;
 
 	uint8_t _type{0};
+
 	enum FW_POSCTRL_MODE {
 		FW_POSCTRL_MODE_AUTO,
 		FW_POSCTRL_MODE_POSITION,
@@ -423,8 +424,8 @@ private:
 		(ParamFloat<px4::params::FW_MAN_P_MAX>) _param_fw_man_p_max,
 		(ParamFloat<px4::params::FW_MAN_R_MAX>) _param_fw_man_r_max,
 
-		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad
-
+		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,
+		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>) _param_nav_fw_altl_rad
 	)
 
 };


### PR DESCRIPTION
 - merge loiter + position handling to simplify handling all special cases (takeoff situation, gliding, custom mission throttle, airspeed, etc)
 - improve xy and z values for automatic switching LOITER <=> POSITION
     - use FW altitude acceptance radius (NAV_FW_ALTL_RAD) rather than climbout diff
     - use real loiter radius acceptance