### PR TITLE
Support multivehicle SITL simulations for rover in gazebo

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -16,7 +16,7 @@ function spawn_model() {
 	MODEL=$1
 	N=$2 #Instance Number
 
-	SUPPORTED_MODELS=("iris" "iris_rtps" "plane" "standard_vtol")
+	SUPPORTED_MODELS=("iris" "iris_rtps" "plane" "standard_vtol" "rover" "r1_rover")
 	if [[ " ${SUPPORTED_MODELS[*]} " != *"$MODEL "* ]];
 	then
 		echo "ERROR: Currently only vehicle model $MODEL is not supported!"


### PR DESCRIPTION
**Describe problem solved by this pull request**
This adds support to simulate multiple rover vehicles at once. Previously this was not easy since the rover vehicle had to be ported into xacro macros to be able to support multivehicle simulations.

**Describe your solution**
This is the result of the migration of rover models into jinja templates in https://github.com/PX4/sitl_gazebo/pull/629


**Test data / coverage**
![image](https://user-images.githubusercontent.com/5248102/95345908-8ba9ce00-08bb-11eb-90dc-a46f66ded0ac.png)


**Additional context**
- This PR requires https://github.com/PX4/sitl_gazebo/pull/629 to be merged in the  PX4/sitl_gazebo submodule
