### PR TITLE
simulator: only send controls after components finish

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -143,6 +143,8 @@ private:
 			delete _dist_pubs[i];
 		}
 
+		px4_lockstep_unregister_component(_lockstep_component);
+
 		_instance = nullptr;
 	}
 
@@ -287,6 +289,8 @@ private:
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 	px4::atomic<bool> _has_initialized {false};
 #endif
+
+	int _lockstep_component{-1};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MAV_TYPE>) _param_mav_type,

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -385,6 +385,10 @@ void Simulator::handle_message_hil_gps(const mavlink_message_t *msg)
 
 void Simulator::handle_message_hil_sensor(const mavlink_message_t *msg)
 {
+	if (_lockstep_component == -1) {
+		_lockstep_component = px4_lockstep_register_component();
+	}
+
 	mavlink_hil_sensor_t imu;
 	mavlink_msg_hil_sensor_decode(msg, &imu);
 
@@ -416,6 +420,8 @@ void Simulator::handle_message_hil_sensor(const mavlink_message_t *msg)
 	}
 
 #endif
+
+	px4_lockstep_progress(_lockstep_component);
 }
 
 void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg)
@@ -644,9 +650,11 @@ void Simulator::send()
 			parameters_update(false);
 			check_failure_injections();
 			_vehicle_status_sub.update(&_vehicle_status);
-			send_controls();
+
 			// Wait for other modules, such as logger or ekf2
 			px4_lockstep_wait_for_components();
+
+			send_controls();
 		}
 	}
 }


### PR DESCRIPTION
Shouldn't we only allow the simulator to `send_controls()` after all lockstep components have completed? When `HIL_ACTUATOR_CONTROLS` is sent it unblocks the simulation (sitl_gazebo, etc) to update which then sends a new `HIL_SENSOR` to PX4 that steps the time forward.

