### PR TITLE
mavlink: send LINK_NODE_STATUS

### DIFF
--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -17,7 +17,7 @@ bool ftp
 
 uint8 streams
 
-float32 data_rate                       # configured maximum data rate (Bytes/s)
+uint32 data_rate                        # configured maximum data rate (Bytes/s)
 
 float32 rate_multiplier
 

--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -17,7 +17,7 @@ bool ftp
 
 uint8 streams
 
-uint32 data_rate                        # configured maximum data rate (Bytes/s)
+float32 data_rate                       # configured maximum data rate (Bytes/s)
 
 float32 rate_multiplier
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1608,6 +1608,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 1.0f);
 		configure_stream_local("DEBUG_VECT", 1.0f);
 		configure_stream_local("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream_local("LINK_NODE_STATUS", 1.0f);
 #endif // !CONSTRAINED_FLASH
 
 		break;
@@ -1664,6 +1665,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 10.0f);
 		configure_stream_local("DEBUG_VECT", 10.0f);
 		configure_stream_local("NAMED_VALUE_FLOAT", 10.0f);
+		configure_stream_local("LINK_NODE_STATUS", 1.0f);
 #endif // !CONSTRAINED_FLASH
 
 		break;
@@ -1715,6 +1717,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 1.0f);
 		configure_stream_local("DEBUG_VECT", 1.0f);
 		configure_stream_local("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream_local("LINK_NODE_STATUS", 1.0f);
 #endif // !CONSTRAINED_FLASH
 
 		break;
@@ -1798,6 +1801,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 50.0f);
 		configure_stream_local("DEBUG_VECT", 50.0f);
 		configure_stream_local("NAMED_VALUE_FLOAT", 50.0f);
+		configure_stream_local("LINK_NODE_STATUS", 1.0f);
 #endif // !CONSTRAINED_FLASH
 
 		break;
@@ -1817,6 +1821,11 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("RC_CHANNELS", 0.5f);
 		configure_stream_local("SYS_STATUS", 0.1f);
 		configure_stream_local("VFR_HUD", 1.0f);
+
+#if !defined(CONSTRAINED_FLASH)
+		configure_stream_local("LINK_NODE_STATUS", 1.0f);
+#endif // !CONSTRAINED_FLASH
+
 		break;
 
 	default:

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -137,6 +137,7 @@ using matrix::wrap_2pi;
 # include "streams/DEBUG_FLOAT_ARRAY.hpp"
 # include "streams/DEBUG_VECT.hpp"
 # include "streams/NAMED_VALUE_FLOAT.hpp"
+# include "streams/LINK_NODE_STATUS.hpp"
 #endif // !CONSTRAINED_FLASH
 
 // ensure PX4 rotation enum and MAV_SENSOR_ROTATION align
@@ -3144,6 +3145,9 @@ static const StreamListItem streams_list[] = {
 #if defined(GPS_STATUS_HPP)
 	create_stream_list_item<MavlinkStreamGPSStatus>(),
 #endif // GPS_STATUS_HPP
+#if defined(LINK_NODE_STATUS_HPP)
+	create_stream_list_item<MavlinkStreamLinkNodeStatus>(),
+#endif // LINK_NODE_STATUS_HPP
 #if defined(STORAGE_INFORMATION_HPP)
 	create_stream_list_item<MavlinkStreamStorageInformation>(),
 #endif // STORAGE_INFORMATION_HPP

--- a/src/modules/mavlink/streams/LINK_NODE_STATUS.hpp
+++ b/src/modules/mavlink/streams/LINK_NODE_STATUS.hpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef LINK_NODE_STATUS_HPP
+#define LINK_NODE_STATUS_HPP
+
+class MavlinkStreamLinkNodeStatus : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamLinkNodeStatus(mavlink); }
+
+	static constexpr const char *get_name_static() { return "LINK_NODE_STATUS"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_LINK_NODE_STATUS; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_LINK_NODE_STATUS_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+private:
+	explicit MavlinkStreamLinkNodeStatus(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	bool send() override
+	{
+		if (_mavlink->get_free_tx_buf() >= get_size()) {
+			mavlink_link_node_status_t link_node_status{};
+
+			const telemetry_status_s &tstatus = _mavlink->telemetry_status();
+			link_node_status.tx_buf = 0; // % TODO
+			link_node_status.rx_buf = 0; // % TODO
+			link_node_status.tx_rate = tstatus.tx_rate_avg;
+			link_node_status.rx_rate = tstatus.rx_rate_avg;
+			link_node_status.rx_parse_err = tstatus.rx_parse_errors;
+			link_node_status.tx_overflows = tstatus.tx_buffer_overruns;
+			link_node_status.rx_overflows = tstatus.rx_buffer_overruns;
+			link_node_status.messages_sent = tstatus.tx_message_count;
+			link_node_status.messages_received = tstatus.rx_message_count;
+			link_node_status.messages_lost = tstatus.rx_message_lost_count;
+
+			link_node_status.timestamp = hrt_absolute_time();
+
+			mavlink_msg_link_node_status_send_struct(_mavlink->get_channel(), &link_node_status);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // LINK_NODE_STATUS_HPP


### PR DESCRIPTION
This adds support to Mavlink for sending `LINK_NODE_STATUS`.

![Screenshot from 2020-10-09 14-28-09](https://user-images.githubusercontent.com/84712/95618825-adca5a00-0a3b-11eb-8055-62f702ae9ba1.png)

In the mavlink receiver I've implemented message sequence id tracking to estimate lost messages. This largely matches the logic implemented in QGC, but with only a subset of total possible system and component ids implemented (we can't afford 256 x 256 bytes).

Once QGC and other systems start broadcasting `LINK_NODE_STATUS` we can factor it into the mavlink transmit throttling (rate multiplier). This serves as congestion control at the mavlink level which is important for serial links that don't have flow control, but it's also quite useful for UDP links that degrade very poorly.

FYI @dogmaphobic @DonLakeFlyer 