### PR TITLE
GPS: add u-blox F9P heading support, and GPS_PROTOCOL param for protocol selection

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -279,7 +279,25 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, GPSHelper::Interface interfac
 		memset(_p_report_sat_info, 0, sizeof(*_p_report_sat_info));
 	}
 
-	_mode_auto = mode == GPS_DRIVER_MODE_NONE;
+	if (_mode == GPS_DRIVER_MODE_NONE) {
+		// use parameter to select mode if not provided via CLI
+		char protocol_param_name[16];
+		snprintf(protocol_param_name, sizeof(protocol_param_name), "GPS_%i_PROTOCOL", (int)_instance + 1);
+		int32_t protocol = 0;
+		param_get(param_find(protocol_param_name), &protocol);
+
+		switch (protocol) {
+		case 1: _mode = GPS_DRIVER_MODE_UBX; break;
+
+		case 2: _mode = GPS_DRIVER_MODE_MTK; break;
+
+		case 3: _mode = GPS_DRIVER_MODE_ASHTECH; break;
+
+		case 4: _mode = GPS_DRIVER_MODE_EMLIDREACH; break;
+		}
+	}
+
+	_mode_auto = _mode == GPS_DRIVER_MODE_NONE;
 }
 
 GPS::~GPS()

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -107,3 +107,42 @@ PARAM_DEFINE_INT32(GPS_UBX_MODE, 0);
  */
 PARAM_DEFINE_FLOAT(GPS_YAW_OFFSET, 0.f);
 
+/**
+ * Protocol for Main GPS
+ *
+ * Select the GPS protocol over serial.
+ *
+ * Auto-detection will probe all protocols, and thus is a bit slower.
+ *
+ * @min 0
+ * @max 4
+ * @value 0 Auto detect
+ * @value 1 u-blox
+ * @value 2 MTK
+ * @value 3 Ashtech / Trimble
+ * @value 4 Emlid Reach
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_1_PROTOCOL, 1);
+
+/**
+ * Protocol for Secondary GPS
+ *
+ * Select the GPS protocol over serial.
+ *
+ * Auto-detection will probe all protocols, and thus is a bit slower.
+ *
+ * @min 0
+ * @max 4
+ * @value 0 Auto detect
+ * @value 1 u-blox
+ * @value 2 MTK
+ * @value 3 Ashtech / Trimble
+ * @value 4 Emlid Reach
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_2_PROTOCOL, 1);

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -64,6 +64,27 @@ PARAM_DEFINE_INT32(GPS_DUMP_COMM, 0);
  */
 PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
 
+/**
+ * u-blox GPS Mode
+ *
+ * Select the u-blox configuration setup. Most setups will use the default, including RTK and
+ * dual GPS without heading.
+ *
+ * The Heading mode requires 2 F9P devices to be attached. The main GPS will act as rover and output
+ * heading information, whereas the secondary will act as moving base, sending RTCM on UART2 to
+ * the rover GPS.
+ * RTK is still possible with this setup.
+ *
+ * @min 0
+ * @max 1
+ * @value 0 Default
+ * @value 1 Heading
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_UBX_MODE, 0);
+
 
 /**
  * Heading/Yaw offset for dual antenna GPS


### PR DESCRIPTION
- Adds support for heading output using 2 F9P devices. Setup is described here: https://www.u-blox.com/sites/default/files/ZED-F9P-MovingBase_AppNote_%28UBX-19009093%29.pdf.
  - Main GPS = Rover
  - Secondary GPS = Moving Base
- add `GPS_PROTOCOL` to select the protocol, default to u-blox. This should be a bit faster on startup for module detection.


### Heading Setup
- attach 2 F9P's (UART1 to Pixhawk) and enable them
- connect their UART2 to each other
- set `GPS_UBX_MODE` to 1
- reboot and wait until both devices have GPS. `gps status` should then show the main GPS going into RTK mode.

### General
- RTK is still possible (the main GPS will show RTK mode even w/o RTK, which might be a bit confusing). The secondary will show the actual RTK mode.
- u-blox also provides an F9H, specifically for heading, replacing one of the F9P's. However it does not have global position output and costs almost the same as an F9P. So I believe in practice everyone will use 2 F9P's.

- depends on https://github.com/PX4/GpsDrivers/pull/60

@hamishwillee docs will follow.