### PR TITLE
Add generic mavlink sensors IDs

### DIFF
--- a/src/drivers/drv_sensor.h
+++ b/src/drivers/drv_sensor.h
@@ -163,6 +163,10 @@
 #define DRV_ADC_DEVTYPE_ADS1115	0x90
 #define DRV_DIST_DEVTYPE_VL53L1X 0x91
 
+// Generic types for unknown MAVLINK sensors
+#define DRV_GPS_DEVTYPE_MAVLINK	0x92
+#define DRV_MAG_DEVTYPE_MAVLINK	0x93
+
 #define DRV_DEVTYPE_UNUSED		0xff
 
 #endif /* _DRV_SENSOR_H */

--- a/src/lib/drivers/device/Device.hpp
+++ b/src/lib/drivers/device/Device.hpp
@@ -147,6 +147,7 @@ public:
 		DeviceBusType_SPI     = 2,
 		DeviceBusType_UAVCAN  = 3,
 		DeviceBusType_SIMULATION = 4,
+		DeviceBusType_MAVLINK = 5,
 	};
 
 	/*
@@ -191,6 +192,9 @@ public:
 
 		case DeviceBusType_SIMULATION:
 			return "SIMULATION";
+
+		case DeviceBusType_MAVLINK:
+			return "MAVLINK";
 
 		case DeviceBusType_UNKNOWN:
 		default:


### PR DESCRIPTION
This PR adds generic mavlink MAG and GPS IDs

@dagar Not really sure if this is all that is required but please tell me otherwise.
