### PR TITLE
[WIP] mc_att_control/mc_pos_control: use attitude setpoint yaw_body to disable yaw control

### DIFF
--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -2,7 +2,7 @@ uint64 timestamp		# time since system start (microseconds)
 
 float32 roll_body		# body angle in NED frame (can be NaN for FW)
 float32 pitch_body		# body angle in NED frame (can be NaN for FW)
-float32 yaw_body		# body angle in NED frame (can be NaN for FW)
+float32 yaw_body		# body angle in NED frame (can be NaN for FW or if invalid)
 
 float32 yaw_sp_move_rate	# rad/s (commanded by user)
 

--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -53,7 +53,8 @@ bool FlightTaskAuto::activate(const vehicle_local_position_setpoint_s &last_setp
 	bool ret = FlightTask::activate(last_setpoint);
 	_position_setpoint = _position;
 	_velocity_setpoint = _velocity;
-	_yaw_setpoint = _yaw_sp_prev = _yaw;
+	_yaw_setpoint = NAN;
+	_yaw_sp_prev = NAN;
 	_yawspeed_setpoint = 0.0f;
 	_setDefaultConstraints();
 	return ret;
@@ -143,7 +144,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 		// Best we can do is to just set all waypoints to current state
 		_prev_prev_wp = _triplet_prev_wp = _triplet_target = _triplet_next_wp = _position;
 		_type = WaypointType::loiter;
-		_yaw_setpoint = _yaw;
+		_yaw_setpoint = NAN;
 		_yawspeed_setpoint = NAN;
 		_target_acceptance_radius = _sub_triplet_setpoint.get().current.acceptance_radius;
 		_updateInternalWaypoints();
@@ -258,7 +259,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	// set heading
 	if (_ext_yaw_handler != nullptr && _ext_yaw_handler->is_active()) {
-		_yaw_setpoint = _yaw;
+		_yaw_setpoint = NAN;
 		// use the yawrate setpoint from WV only if not moving lateral (velocity setpoint below half of _param_mpc_xy_cruise)
 		// otherwise, keep heading constant (as output from WV is not according to wind in this case)
 		bool vehicle_is_moving_lateral = _velocity_setpoint.xy().longerThan(_param_mpc_xy_cruise.get() / 2.0f);
@@ -269,8 +270,6 @@ bool FlightTaskAuto::_evaluateTriplets()
 		} else {
 			_yawspeed_setpoint = _ext_yaw_handler->get_weathervane_yawrate();
 		}
-
-
 
 	} else if (_type == WaypointType::follow_target && _sub_triplet_setpoint.get().current.yawspeed_valid) {
 		_yawspeed_setpoint = _sub_triplet_setpoint.get().current.yawspeed;
@@ -510,7 +509,7 @@ bool FlightTaskAuto::_compute_heading_from_2D_vector(float &heading, Vector2f v)
 		// and multiply by the sign given of cross product of x and v.
 		// Dot product: (x(0)*v(0)+(x(1)*v(1)) = v(0)
 		// Cross product: x(0)*v(1) - v(0)*x(1) = v(1)
-		heading =  sign(v(1)) * wrap_pi(acosf(v(0)));
+		heading = sign(v(1)) * wrap_pi(acosf(v(0)));
 		return true;
 	}
 

--- a/src/lib/flight_tasks/tasks/Descend/FlightTaskDescend.cpp
+++ b/src/lib/flight_tasks/tasks/Descend/FlightTaskDescend.cpp
@@ -42,7 +42,7 @@ bool FlightTaskDescend::activate(const vehicle_local_position_setpoint_s &last_s
 	// stay level to minimize horizontal drift
 	_acceleration_setpoint = matrix::Vector3f(0.f, 0.f, NAN);
 	// keep heading
-	_yaw_setpoint = _yaw;
+	_yaw_setpoint = NAN;
 	return ret;
 }
 

--- a/src/lib/flight_tasks/tasks/Failsafe/FlightTaskFailsafe.cpp
+++ b/src/lib/flight_tasks/tasks/Failsafe/FlightTaskFailsafe.cpp
@@ -42,7 +42,7 @@ bool FlightTaskFailsafe::activate(const vehicle_local_position_setpoint_s &last_
 	_position_setpoint = _position;
 	_velocity_setpoint.zero();
 	_acceleration_setpoint = matrix::Vector3f(0.f, 0.f, .3f);
-	_yaw_setpoint = _yaw;
+	_yaw_setpoint = NAN;
 	_yawspeed_setpoint = 0.f;
 	return ret;
 }

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -131,16 +131,23 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("vehicle_imu_status", 1000, 3);
 
 #ifdef CONFIG_ARCH_BOARD_PX4_SITL
+	add_topic("actuator_controls_0");
 	add_topic("actuator_controls_virtual_fw");
 	add_topic("actuator_controls_virtual_mc");
+	add_topic("actuator_outputs");
 	add_topic("fw_virtual_attitude_setpoint");
 	add_topic("mc_virtual_attitude_setpoint");
 	add_topic("time_offset");
-	add_topic("vehicle_angular_acceleration", 10);
-	add_topic("vehicle_angular_velocity", 10);
-	add_topic("vehicle_attitude_groundtruth", 10);
+	add_topic("vehicle_angular_acceleration");
+	add_topic("vehicle_angular_velocity");
+	add_topic("vehicle_attitude");
+	add_topic("vehicle_attitude_groundtruth");
+	add_topic("vehicle_attitude_setpoint");
 	add_topic("vehicle_global_position_groundtruth", 100);
-	add_topic("vehicle_local_position_groundtruth", 100);
+	add_topic("vehicle_local_position");
+	add_topic("vehicle_local_position_setpoint");
+	add_topic("vehicle_local_position_groundtruth");
+	add_topic("vehicle_rates_setpoint");
 #endif /* CONFIG_ARCH_BOARD_PX4_SITL */
 }
 

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
@@ -38,6 +38,7 @@
 #include <AttitudeControl.hpp>
 
 #include <mathlib/math/Functions.hpp>
+#include <px4_platform_common/defines.h>
 
 using namespace matrix;
 
@@ -97,7 +98,9 @@ matrix::Vector3f AttitudeControl::update(const Quatf &q) const
 	// and multiply it by the yaw setpoint rate (yawspeed_setpoint).
 	// This yields a vector representing the commanded rotatation around the world z-axis expressed in the body frame
 	// such that it can be added to the rates setpoint.
-	rate_setpoint += q.inversed().dcm_z() * _yawspeed_setpoint;
+	if (PX4_ISFINITE(_yawspeed_setpoint)) {
+		rate_setpoint += q.inversed().dcm_z() * _yawspeed_setpoint;
+	}
 
 	// limit rates
 	for (int i = 0; i < 3; i++) {

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
@@ -94,8 +94,8 @@ public:
 private:
 	matrix::Vector3f _proportional_gain;
 	matrix::Vector3f _rate_limit;
-	float _yaw_w{0.f}; ///< yaw weight [0,1] to deprioritize caompared to roll and pitch
+	float _yaw_w{0.f}; ///< yaw weight [0,1] to deprioritize compared to roll and pitch
 
 	matrix::Quatf _attitude_setpoint_q; ///< latest known attitude setpoint e.g. from position control
-	float _yawspeed_setpoint{0.f}; ///< latest known yawspeed feed-forward setpoint
+	float _yawspeed_setpoint{NAN}; ///< latest known yawspeed feed-forward setpoint
 };

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -131,6 +131,7 @@ private:
 	bool _vtol{false};
 	bool _vtol_tailsitter{false};
 	bool _vtol_in_transition_mode{false};
+	bool _yaw_sp_valid{false};
 
 	uint8_t _quat_reset_counter{0};
 

--- a/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
@@ -65,9 +65,9 @@ void limitTilt(matrix::Vector3f &body_unit, const matrix::Vector3f &world_unit, 
  * Converts a body z vector and yaw set-point to a desired attitude.
  * @param body_z a world frame 3D vector in direction of the desired body z axis
  * @param yaw_sp the desired yaw setpoint
- * @param att_sp attitude setpoint to fill
+ * @return attitude setpoint quaternion
  */
-void bodyzToAttitude(matrix::Vector3f body_z, const float yaw_sp, vehicle_attitude_setpoint_s &att_sp);
+matrix::Quatf bodyzToAttitude(matrix::Vector3f body_z, const float yaw_sp);
 
 /**
  * Outputs the sum of two vectors but respecting the limits and priority.

--- a/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMathTest.cpp
@@ -125,7 +125,7 @@ TEST(ControlMathTest, ThrottleAttitudeMapping)
 	 * order is: 1. roll, 2. pitch, 3. yaw */
 	thr = Vector3f(0.f, 0.f, 1.f);
 	thrustToAttitude(thr, yaw, att);
-	EXPECT_FLOAT_EQ(att.roll_body, -M_PI_F);
+	EXPECT_FLOAT_EQ(att.roll_body, M_PI_F);
 	EXPECT_FLOAT_EQ(att.pitch_body, 0.f);
 	EXPECT_FLOAT_EQ(att.yaw_body, M_PI_2_F);
 	EXPECT_FLOAT_EQ(att.thrust_body[2], -1.f);

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -59,7 +59,7 @@ TEST(PositionControlTest, EmptySetpoint)
 	position_control.getAttitudeSetpoint(attitude);
 	EXPECT_FLOAT_EQ(attitude.roll_body, 0.f);
 	EXPECT_FLOAT_EQ(attitude.pitch_body, 0.f);
-	EXPECT_FLOAT_EQ(attitude.yaw_body, 0.f);
+	EXPECT_TRUE(!PX4_ISFINITE(attitude.yaw_body));
 	EXPECT_FLOAT_EQ(attitude.yaw_sp_move_rate, 0.f);
 	EXPECT_EQ(Quatf(attitude.q_d), Quatf(1.f, 0.f, 0.f, 0.f));
 	EXPECT_EQ(Vector3f(attitude.thrust_body), Vector3f(0.f, 0.f, 0.f));


### PR DESCRIPTION
The goal is to get rid of this, which is present in every multicopter mode with the position controller involved.

![Screenshot from 2020-10-19 15-57-45](https://user-images.githubusercontent.com/84712/96507075-a6b6ff00-1226-11eb-9a04-e6e953e8d55d.png)
![Screenshot from 2020-10-19 15-58-17](https://user-images.githubusercontent.com/84712/96507077-a9195900-1226-11eb-87b6-365a6e2ad61b.png)
<img width="810" alt="Screen Shot 2020-10-19 at 4 41 52 PM" src="https://user-images.githubusercontent.com/84712/96509437-0662d980-122a-11eb-8349-1170d925725c.png">
