### PR TITLE
In-air home position

### DIFF
--- a/msg/home_position.msg
+++ b/msg/home_position.msg
@@ -14,5 +14,6 @@ float32 yaw				# Yaw angle in radians
 
 bool valid_alt		# true when the altitude has been set
 bool valid_hpos		# true when the latitude and longitude have been set
+bool valid_lpos		# true when the local position (xyz) has been set
 
 bool manual_home	# true when home position was set manually

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -295,9 +295,11 @@ build_gps_response(uint8_t *buffer, size_t *size)
 			memset(&home, 0, sizeof(home));
 			orb_copy(ORB_ID(home_position), _home_sub, &home);
 
-			_home_lat = home.lat;
-			_home_lon = home.lon;
-			_home_position_set = true;
+			if (home.valid_hpos) {
+				_home_lat = home.lat;
+				_home_lon = home.lon;
+				_home_position_set = true;
+			}
 		}
 
 		/* Distance from home */

--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -329,14 +329,14 @@ void FlightTaskAuto::_set_heading_from_mode()
 		break;
 
 	case 1: // Heading points towards home.
-		if (_sub_home_position.get().valid_hpos) {
+		if (_sub_home_position.get().valid_lpos) {
 			v = Vector2f(&_sub_home_position.get().x) - Vector2f(_position);
 		}
 
 		break;
 
 	case 2: // Heading point away from home.
-		if (_sub_home_position.get().valid_hpos) {
+		if (_sub_home_position.get().valid_lpos) {
 			v = Vector2f(_position) - Vector2f(&_sub_home_position.get().x);
 		}
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -157,6 +157,12 @@ private:
 
 	bool set_home_position();
 	bool set_home_position_alt_only();
+	bool set_in_air_home_position();
+	bool isGPosGoodForInitializingHomePos(const vehicle_global_position_s &gpos) const;
+	void fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos) const;
+	void fillGlobalHomePos(home_position_s &home, const vehicle_global_position_s &gpos) const;
+	void fillGlobalHomePos(home_position_s &home, double lat, double lon, float alt) const;
+	void setHomePosValid();
 	void updateHomePositionYaw(float yaw);
 
 	void update_control_mode();
@@ -187,6 +193,7 @@ private:
 
 		(ParamFloat<px4::params::COM_HOME_H_T>) _param_com_home_h_t,
 		(ParamFloat<px4::params::COM_HOME_V_T>) _param_com_home_v_t,
+		(ParamBool<px4::params::COM_HOME_IN_AIR>) _param_com_home_in_air,
 
 		(ParamFloat<px4::params::COM_POS_FS_EPH>) _param_com_pos_fs_eph,
 		(ParamFloat<px4::params::COM_POS_FS_EPV>) _param_com_pos_fs_epv, 	/*Not realy used for now*/

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -160,6 +160,7 @@ private:
 	bool set_in_air_home_position();
 	bool isGPosGoodForInitializingHomePos(const vehicle_global_position_s &gpos) const;
 	void fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos) const;
+	void fillLocalHomePos(home_position_s &home, float x, float y, float z, float heading) const;
 	void fillGlobalHomePos(home_position_s &home, const vehicle_global_position_s &gpos) const;
 	void fillGlobalHomePos(home_position_s &home, double lat, double lon, float alt) const;
 	void setHomePosValid();

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -214,6 +214,18 @@ PARAM_DEFINE_FLOAT(COM_HOME_H_T, 5.0f);
 PARAM_DEFINE_FLOAT(COM_HOME_V_T, 10.0f);
 
 /**
+ * Allows setting the home position after takeoff
+ *
+ * If set to true, the autopilot is allowed to set its home position after takeoff
+ * The true home position is back-computed if a local position is estimate if available.
+ * If no local position is available, home is set to the current position.
+ *
+ * @boolean
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
+
+/**
  * RC control input mode
  *
  * The default value of 0 requires a valid RC transmitter setup.

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -162,7 +162,7 @@ public:
 	void reset_vroi() { _vroi = {}; }
 
 	bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
-	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos); }
+	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos && _home_pos.valid_lpos); }
 
 	Geofence	&get_geofence() { return _geofence; }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When taking off without a home position, RTL is impossible, even if good GPS data is obtained just after takeoff.

**Describe your solution**
If another horizontal aiding source is available, the original home location can be back-computed as soon as a GPS lock is available.
If no aiding source is available, a home position can be set at the current location. Given that this will only occur when flying LOS, doing an RTL to this position is a reasonable choice.

Enable the functionality by setting `COM_HOME_IN_AIR = 1`

**Describe possible alternatives**
Always set the home position to the current position as back-computing could be worse if the local estimate wasn't good.

**Test data / coverage**
Gazebo SITL tests with the Iris optical flow: takeoff with flow, move, enable GPS fusion (EKF2_AID_MASK), trigger RTL -> the vehicle goes back to the takeoff location.

![Screen Capture_select-area_20201020132824](https://user-images.githubusercontent.com/14822839/96596091-a41edd00-12ec-11eb-9736-e7f7e40d4832.png)