### PR TITLE
RCinput: removed subscption to adc_report if not needed, and unify rssi type

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -552,7 +552,7 @@ Syslink::handle_raw(syslink_message_t *sys)
 		rc.values[3] = cmd->thrust * 1000 / USHRT_MAX + 1000;
 		rc.values[4] = 1000; // Dummy channel as px4 needs at least 5
 
-		_rc_pub.publish(rc);
+		_input_rc_pub.publish(rc);
 
 	} else if (c->port == CRTP_PORT_MAVLINK) {
 		_count_in++;

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -96,7 +96,7 @@ Syslink::Syslink() :
 	_fd(0),
 	_queue(2, sizeof(syslink_message_t)),
 	_writebuffer(16, sizeof(crtp_message_t)),
-	_rssi(RC_INPUT_RSSI_MAX),
+	_rssi(input_rc_s::RC_RSSI_MAX),
 	_bstate(BAT_DISCHARGING)
 {
 	px4_sem_init(&memory_sem, 0, 0);

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.h
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.h
@@ -135,7 +135,7 @@ private:
 	hrt_abstime _params_update[3]; // Time at which the parameters were updated
 	hrt_abstime _params_ack[3]; // Time at which the parameters were acknowledged by the nrf module
 
-	uORB::PublicationMulti<input_rc_s>		_rc_pub{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>		_input_rc_pub{ORB_ID(input_rc)};
 
 	// nrf chip schedules battery updates with SYSLINK_SEND_PERIOD_MS
 	static constexpr uint32_t SYSLINK_BATTERY_STATUS_INTERVAL_US = 10_ms;

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.h
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.h
@@ -141,7 +141,7 @@ private:
 	static constexpr uint32_t SYSLINK_BATTERY_STATUS_INTERVAL_US = 10_ms;
 	Battery _battery{1, nullptr, SYSLINK_BATTERY_STATUS_INTERVAL_US};
 
-	int32_t _rssi;
+	uint8_t _rssi;
 	battery_state _bstate;
 
 	px4_sem_t memory_sem;

--- a/msg/input_rc.msg
+++ b/msg/input_rc.msg
@@ -22,7 +22,11 @@ uint64 timestamp_last_signal		# last valid reception time
 
 uint8 channel_count			# number of channels actually being seen
 
-int32 rssi				# receive signal strength indicator (RSSI): < 0: Undefined, 0: no signal, 100: full reception
+uint8 RC_RSSI_NO_SIGNAL = 0		# no signal
+uint8 RC_RSSI_MAX = 100			# full reception
+uint8 RC_RSSI_UNDEFINED = 255		# no indication of rssi strength
+
+uint8 rssi				# receive signal strength indicator (RSSI)
 
 bool rc_failsafe			# explicit failsafe flag: true on TX failure or TX out of range , false otherwise. Only the true state is reliable, as there are some (PPM) receivers on the market going into failsafe without telling us explicitly.
 bool rc_lost				# RC receiver connection status: True,if no frame has arrived in the expected time, false otherwise. True usually means that the receiver has been disconnected, but can also indicate a radio link loss on "stupid" systems. Will remain false, if a RX with failsafe option continues to transmit frames after a link loss.

--- a/src/drivers/drv_rc_input.h
+++ b/src/drivers/drv_rc_input.h
@@ -59,11 +59,6 @@
 #define RC_INPUT0_DEVICE_PATH	"/dev/input_rc0"
 
 /**
- * Maximum RSSI value
- */
-#define RC_INPUT_RSSI_MAX	100
-
-/**
  * Input signal type, value is a control position from zero to 100
  * percent.
  */

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -83,7 +83,7 @@ int     _armed_sub = -1;
 
 // publications
 orb_advert_t    _outputs_pub = nullptr;
-orb_advert_t    _rc_pub = nullptr;
+orb_advert_t    _input_rc_pub = nullptr;
 
 perf_counter_t	_perf_control_latency = nullptr;
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -251,7 +251,7 @@ private:
 	bool			_param_update_force;	///< force a parameter update
 
 	/* advertised topics */
-	uORB::PublicationMulti<input_rc_s>			_to_input_rc{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>			_input_rc_pub{ORB_ID(input_rc)};
 	uORB::PublicationMulti<actuator_outputs_s>		_to_outputs{ORB_ID(actuator_outputs)};
 	uORB::PublicationMulti<multirotor_motor_limits_s>	_to_mixer_status{ORB_ID(multirotor_motor_limits)};
 	uORB::Publication<px4io_status_s>			_px4io_status_pub{ORB_ID(px4io_status)};
@@ -2143,7 +2143,7 @@ PX4IO::io_publish_raw_rc()
 		}
 	}
 
-	_to_input_rc.publish(rc_val);
+	_input_rc_pub.publish(rc_val);
 
 	return OK;
 }

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2095,11 +2095,10 @@ PX4IO::io_get_raw_rc_input(input_rc_s &input_rc)
 
 	/* get RSSI from input channel */
 	if (_rssi_pwm_chan > 0 && _rssi_pwm_chan <= input_rc_s::RC_INPUT_MAX_CHANNELS && _rssi_pwm_max - _rssi_pwm_min != 0) {
-		int rssi = ((input_rc.values[_rssi_pwm_chan - 1] - _rssi_pwm_min) * 100) /
-			   (_rssi_pwm_max - _rssi_pwm_min);
-		rssi = rssi > 100 ? 100 : rssi;
-		rssi = rssi < 0 ? 0 : rssi;
-		input_rc.rssi = rssi;
+		uint8_t rssi = ((input_rc.values[_rssi_pwm_chan - 1] - _rssi_pwm_min) * 100) /
+			       (_rssi_pwm_max - _rssi_pwm_min);
+
+		input_rc.rssi = math::constrain(rssi, (uint8_t)0, (uint8_t)100);
 	}
 
 	return ret;

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -170,7 +170,7 @@ void
 RCInput::fill_rc_in(uint16_t raw_rc_count_local,
 		    uint16_t raw_rc_values_local[input_rc_s::RC_INPUT_MAX_CHANNELS],
 		    hrt_abstime now, bool frame_drop, bool failsafe,
-		    unsigned frame_drops, int rssi = -1)
+		    unsigned frame_drops, uint8_t rssi = input_rc_s::RC_RSSI_UNDEFINED)
 {
 	// fill rc_in struct for publishing
 	_rc_in.channel_count = raw_rc_count_local;
@@ -197,7 +197,7 @@ RCInput::fill_rc_in(uint16_t raw_rc_count_local,
 	_rc_in.rc_ppm_frame_length = 0;
 
 	/* fake rssi if no value was provided */
-	if (rssi == -1) {
+	if (rssi == input_rc_s::RC_RSSI_UNDEFINED) {
 #ifdef ADC_RC_RSSI_CHANNEL
 
 		if ((_param_rc_rssi_pwm_chan.get() > 0) && (_param_rc_rssi_pwm_chan.get() < _rc_in.channel_count)) {
@@ -214,22 +214,14 @@ RCInput::fill_rc_in(uint16_t raw_rc_count_local,
 			// set RSSI if analog RSSI input is present
 			float rssi_analog = ((_analog_rc_rssi_volt - 0.2f) / 3.0f) * 100.0f;
 
-			if (rssi_analog > 100.0f) {
-				rssi_analog = 100.0f;
-			}
-
-			if (rssi_analog < 0.0f) {
-				rssi_analog = 0.0f;
-			}
-
-			_rc_in.rssi = rssi_analog;
+			_rc_in.rssi = math::constrain(rssi_analog, 0.f, 100.f);
 
 		} else {
-			_rc_in.rssi = 255;
+			_rc_in.rssi = input_rc_s::RC_RSSI_UNDEFINED;
 		}
 
 #else
-		_rc_in.rssi = 255;
+		_rc_in.rssi = input_rc_s::RC_RSSI_UNDEFINED;
 #endif
 
 	} else {
@@ -237,7 +229,7 @@ RCInput::fill_rc_in(uint16_t raw_rc_count_local,
 	}
 
 	if (valid_chans == 0) {
-		_rc_in.rssi = 0;
+		_rc_in.rssi = input_rc_s::RC_RSSI_NO_SIGNAL;
 	}
 
 	_rc_in.rc_failsafe = failsafe;
@@ -446,7 +438,7 @@ void RCInput::Run()
 				   || cycle_timestamp - _rc_scan_begin < rc_scan_max) {
 
 				if (newBytes > 0) {
-					int8_t dsm_rssi;
+					uint8_t dsm_rssi;
 
 					// parse new data
 					rc_updated = dsm_parse(cycle_timestamp, &_rcs_buf[0], newBytes, &_raw_rc_values[0], &_raw_rc_count,
@@ -486,7 +478,7 @@ void RCInput::Run()
 
 					for (unsigned i = 0; i < (unsigned)newBytes; i++) {
 						/* set updated flag if one complete packet was parsed */
-						st24_rssi = RC_INPUT_RSSI_MAX;
+						st24_rssi = input_rc_s::RC_RSSI_MAX;
 						rc_updated = (OK == st24_decode(_rcs_buf[i], &st24_rssi, &lost_count,
 										&_raw_rc_count, _raw_rc_values, input_rc_s::RC_INPUT_MAX_CHANNELS));
 					}
@@ -535,7 +527,7 @@ void RCInput::Run()
 
 					for (unsigned i = 0; i < (unsigned)newBytes; i++) {
 						/* set updated flag if one complete packet was parsed */
-						sumd_rssi = RC_INPUT_RSSI_MAX;
+						sumd_rssi = input_rc_s::RC_RSSI_MAX;
 						rc_updated = (OK == sumd_decode(_rcs_buf[i], &sumd_rssi, &rx_count,
 										&_raw_rc_count, _raw_rc_values, input_rc_s::RC_INPUT_MAX_CHANNELS, &sumd_failsafe));
 					}

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -637,7 +637,7 @@ void RCInput::Run()
 		if (rc_updated) {
 			perf_count(_publish_interval_perf);
 
-			_to_input_rc.publish(_rc_in);
+			_input_rc_pub.publish(_rc_in);
 
 		} else if (!rc_updated && ((hrt_absolute_time() - _rc_in.timestamp_last_signal) > 1_s)) {
 			_rc_scan_locked = false;

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -792,7 +792,11 @@ This module does the RC input parsing and auto-selecting the method. Supported m
 
 	PRINT_MODULE_USAGE_NAME("rc_input", "driver");
 	PRINT_MODULE_USAGE_COMMAND("start");
-	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyS3", "<file:dev>", "RC device", true);
+#if defined(RC_SERIAL_PORT)
+	PRINT_MODULE_USAGE_PARAM_STRING('d', RC_SERIAL_PORT, "<file:dev>", "RC device", true);
+#else
+	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, "<file:dev>", "RC device", true);
+#endif
 
 #if defined(SPEKTRUM_POWER)
 	PRINT_MODULE_USAGE_COMMAND_DESCR("bind", "Send a DSM bind command (module must be running)");

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -198,7 +198,10 @@ RCInput::fill_rc_in(uint16_t raw_rc_count_local,
 
 	/* fake rssi if no value was provided */
 	if (rssi == -1) {
+#ifdef ADC_RC_RSSI_CHANNEL
+
 		if ((_param_rc_rssi_pwm_chan.get() > 0) && (_param_rc_rssi_pwm_chan.get() < _rc_in.channel_count)) {
+
 			const int32_t rssi_pwm_chan = _param_rc_rssi_pwm_chan.get();
 			const int32_t rssi_pwm_min = _param_rc_rssi_pwm_min.get();
 			const int32_t rssi_pwm_max = _param_rc_rssi_pwm_max.get();
@@ -224,6 +227,10 @@ RCInput::fill_rc_in(uint16_t raw_rc_count_local,
 		} else {
 			_rc_in.rssi = 255;
 		}
+
+#else
+		_rc_in.rssi = 255;
+#endif
 
 	} else {
 		_rc_in.rssi = rssi;

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -140,12 +140,14 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription	_vehicle_cmd_sub{ORB_ID(vehicle_command)};
-	uORB::Subscription	_adc_sub{ORB_ID(adc_report)};
 
-	input_rc_s	_rc_in{};
-
+#ifdef ADC_RC_RSSI_CHANNEL
+	uORB::Subscription	_adc_sub {ORB_ID(adc_report)};
 	float		_analog_rc_rssi_volt{-1.0f};
 	bool		_analog_rc_rssi_stable{false};
+#endif
+
+	input_rc_s	_rc_in{};
 
 
 	uORB::PublicationMulti<input_rc_s>	_to_input_rc{ORB_ID(input_rc)};

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -149,8 +149,7 @@ private:
 
 	input_rc_s	_rc_in{};
 
-
-	uORB::PublicationMulti<input_rc_s>	_to_input_rc{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>	_input_rc_pub{ORB_ID(input_rc)};
 
 	int		_rcs_fd{-1};
 	char		_device[20] {};					///< device / serial port path

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -115,7 +115,7 @@ private:
 	void fill_rc_in(uint16_t raw_rc_count_local,
 			uint16_t raw_rc_values_local[input_rc_s::RC_INPUT_MAX_CHANNELS],
 			hrt_abstime now, bool frame_drop, bool failsafe,
-			unsigned frame_drops, int rssi);
+			unsigned frame_drops, uint8_t rssi);
 
 	void set_rc_scan_state(RC_SCAN _rc_scan_state);
 

--- a/src/drivers/rpi_rc_in/rpi_rc_in.cpp
+++ b/src/drivers/rpi_rc_in/rpi_rc_in.cpp
@@ -117,7 +117,7 @@ void RcInput::_measure(void)
 	_data.timestamp = ts;
 	_data.timestamp_last_signal = ts;
 	_data.channel_count = _channels;
-	_data.rssi = 100;
+	_data.rssi = input_rc_s::RC_RSSI_MAX;
 	_data.rc_lost_frame_count = 0;
 	_data.rc_total_frame_count = 1;
 	_data.rc_ppm_frame_length = 100;

--- a/src/drivers/spektrum_rc/spektrum_rc.cpp
+++ b/src/drivers/spektrum_rc/spektrum_rc.cpp
@@ -102,7 +102,7 @@ void task_main(int argc, char *argv[])
 		return;
 	}
 
-	orb_advert_t rc_pub = nullptr;
+	orb_advert_t input_rc_pub = nullptr;
 
 	// Use a buffer size of the double of the minimum, just to be safe.
 	uint8_t rx_buf[2 * DSM_BUFFER_SIZE];
@@ -143,11 +143,11 @@ void task_main(int argc, char *argv[])
 			fill_input_rc(raw_rc_count, raw_rc_values, now, false, false, frame_drops, dsm_rssi,
 				      input_rc);
 
-			if (rc_pub == nullptr) {
-				rc_pub = orb_advertise(ORB_ID(input_rc), &input_rc);
+			if (input_input_rc_pub == nullptr) {
+				input_rc_pub = orb_advertise(ORB_ID(input_rc), &input_rc);
 
 			} else {
-				orb_publish(ORB_ID(input_rc), rc_pub, &input_rc);
+				orb_publish(ORB_ID(input_rc), input_rc_pub, &input_rc);
 			}
 		}
 
@@ -156,7 +156,7 @@ void task_main(int argc, char *argv[])
 
 	}
 
-	orb_unadvertise(rc_pub);
+	orb_unadvertise(input_rc_pub);
 	dsm_deinit();
 
 	_is_running = false;

--- a/src/drivers/spektrum_rc/spektrum_rc.cpp
+++ b/src/drivers/spektrum_rc/spektrum_rc.cpp
@@ -74,7 +74,7 @@ void usage();
 void task_main(int argc, char *argv[]);
 
 void fill_input_rc(uint16_t raw_rc_count, uint16_t raw_rc_values[input_rc_s::RC_INPUT_MAX_CHANNELS],
-		   hrt_abstime now, bool frame_drop, bool failsafe, unsigned frame_drops, int rssi,
+		   hrt_abstime now, bool frame_drop, bool failsafe, unsigned frame_drops, uint8_t rssi,
 		   input_rc_s &input_rc);
 
 void task_main(int argc, char *argv[])
@@ -129,7 +129,7 @@ void task_main(int argc, char *argv[])
 
 		bool dsm_11_bit;
 		unsigned frame_drops;
-		int8_t dsm_rssi;
+		uint8_t dsm_rssi;
 
 		// parse new data
 		bool rc_updated = dsm_parse(now, rx_buf, newbytes, &raw_rc_values[0], &raw_rc_count,
@@ -163,7 +163,7 @@ void task_main(int argc, char *argv[])
 }
 
 void fill_input_rc(uint16_t raw_rc_count, uint16_t raw_rc_values[input_rc_s::RC_INPUT_MAX_CHANNELS],
-		   hrt_abstime now, bool frame_drop, bool failsafe, unsigned frame_drops, int rssi,
+		   hrt_abstime now, bool frame_drop, bool failsafe, unsigned frame_drops, uint8_t rssi,
 		   input_rc_s &input_rc)
 {
 	input_rc.input_source = input_rc_s::RC_INPUT_SOURCE_QURT;
@@ -188,17 +188,8 @@ void fill_input_rc(uint16_t raw_rc_count, uint16_t raw_rc_values[input_rc_s::RC_
 	input_rc.timestamp_last_signal = input_rc.timestamp;
 	input_rc.rc_ppm_frame_length = 0;
 
-	/* fake rssi if no value was provided */
-	if (rssi == -1) {
-
-		input_rc.rssi = 255;
-
-	} else {
-		input_rc.rssi = rssi;
-	}
-
 	if (valid_chans == 0) {
-		input_rc.rssi = 0;
+		input_rc.rssi = input_rc_s::RC_RSSI_NO_SIGNAL;
 	}
 
 	input_rc.rc_failsafe = failsafe;

--- a/src/lib/rc/common_rc.h
+++ b/src/lib/rc/common_rc.h
@@ -22,3 +22,7 @@ typedef  struct rc_decode_buf_ {
 #pragma pack(pop)
 
 extern rc_decode_buf_t rc_decode_buf;
+
+#define RC_INPUT_RSSI_MAX		100 //should be same as  input_rc_s::RC_RSSI_MAX
+#define RC_INPUT_RSSI_MIN		0   //should be same as  input_rc_s::RC_RSSI_MIN
+#define RC_INPUT_RSSI_UNDEFINED	255 //should be same as  input_rc_s::RC_RSSI_UNDEFINED

--- a/src/lib/rc/dsm.cpp
+++ b/src/lib/rc/dsm.cpp
@@ -508,7 +508,7 @@ void dsm_bind(uint16_t cmd, int pulses)
  * @return true=DSM frame successfully decoded, false=no update
  */
 bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, unsigned max_values,
-		int8_t *rssi_percent)
+		uint8_t *rssi_percent)
 {
 	/*
 	debug("DSM dsm_frame %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x",
@@ -547,7 +547,7 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
 			int8_t dbm = (int8_t)dsm_frame[0];
 
 			if (dbm == -128) {
-				*rssi_percent = 0;
+				*rssi_percent = RC_INPUT_RSSI_MIN;
 
 			} else {
 				*rssi_percent = spek_dbm_to_percent(dbm);
@@ -555,7 +555,7 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
 
 		} else {
 			/* if we don't know the rssi, anything over 100 will invalidate it */
-			*rssi_percent = 127;
+			*rssi_percent = RC_INPUT_RSSI_UNDEFINED;
 		}
 	}
 
@@ -704,13 +704,13 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
  * @param[out] num_values pointer to number of raw channel values returned, high order bit 0:10 bit data, 1:11 bit data
  * @param[out] n_butes number of bytes read
  * @param[out] bytes pointer to the buffer of read bytes
- * @param[out] rssi value in percent, if supported, or 127
+ * @param[out] rssi value in percent, if supported, or RC_RSSI_UNDEFINED
  * @param[out] frame_drops dropped frames (indication of an unstable link)
  * @param[in] max_values maximum number of channels the receiver can process
  * @return true=decoded raw channel values updated, false=no update
  */
 bool dsm_input(int fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes, uint8_t **bytes,
-	       int8_t *rssi, unsigned *frame_drops, unsigned max_values)
+	       uint8_t *rssi, unsigned *frame_drops, unsigned max_values)
 {
 	/*
 	 * The S.BUS protocol doesn't provide reliable framing,
@@ -752,7 +752,7 @@ bool dsm_input(int fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit,
 }
 
 bool dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
-	       uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, int8_t *rssi_percent, uint16_t max_channels)
+	       uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint8_t *rssi_percent, uint16_t max_channels)
 {
 	/* this is set by the decoding state machine and will default to false
 	 * once everything that was decodable has been decoded.

--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -70,10 +70,10 @@ __EXPORT void	dsm_deinit(void);
 __EXPORT void	dsm_proto_init(void);
 __EXPORT int	dsm_config(int dsm_fd);
 __EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes,
-			  uint8_t **bytes, int8_t *rssi, unsigned *frame_drops, unsigned max_values);
+			  uint8_t **bytes, uint8_t *rssi, unsigned *frame_drops, unsigned max_values);
 
 __EXPORT bool	dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
-			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, int8_t *rssi_percent, uint16_t max_channels);
+			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint8_t *rssi_percent, uint16_t max_channels);
 
 #ifdef SPEKTRUM_POWER
 __EXPORT void	dsm_bind(uint16_t cmd, int pulses);

--- a/src/lib/rc/sumd.cpp
+++ b/src/lib/rc/sumd.cpp
@@ -308,7 +308,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			uint8_t _cnt = *rx_count + 1;
 			*rx_count = _cnt;
 
-			*rssi = 100;
+			*rssi = RC_INPUT_RSSI_MAX;
 
 			/* failsafe flag */
 			*failsafe = (_rxpacket.status == SUMD_ID_FAILSAFE);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2003,7 +2003,7 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	// metadata
 	rc.timestamp = hrt_absolute_time();
 	rc.timestamp_last_signal = rc.timestamp;
-	rc.rssi = RC_INPUT_RSSI_MAX;
+	rc.rssi = input_rc_s::RC_RSSI_MAX;
 	rc.rc_failsafe = false;
 	rc.rc_lost = false;
 	rc.rc_lost_frame_count = 0;
@@ -2075,7 +2075,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 		rc.rc_total_frame_count = 1;
 		rc.rc_ppm_frame_length = 0;
 		rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
-		rc.rssi = RC_INPUT_RSSI_MAX;
+		rc.rssi = input_rc_s::RC_RSSI_MAX;
 
 		rc.values[0] = man.x / 2 + 1500;	// roll
 		rc.values[1] = man.y / 2 + 1500;	// pitch

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2048,7 +2048,7 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	}
 
 	// publish uORB message
-	_rc_pub.publish(rc);
+	_input_rc_pub.publish(rc);
 }
 
 void
@@ -2097,7 +2097,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 
 		_mom_switch_state = man.buttons;
 
-		_rc_pub.publish(rc);
+		_input_rc_pub.publish(rc);
 
 	} else {
 		manual_control_setpoint_s manual{};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2003,7 +2003,7 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	// metadata
 	rc.timestamp = hrt_absolute_time();
 	rc.timestamp_last_signal = rc.timestamp;
-	rc.rssi = input_rc_s::RC_RSSI_MAX;
+	rc.rssi = input_rc_s::RC_RSSI_UNDEFINED;
 	rc.rc_failsafe = false;
 	rc.rc_lost = false;
 	rc.rc_lost_frame_count = 0;
@@ -2075,7 +2075,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 		rc.rc_total_frame_count = 1;
 		rc.rc_ppm_frame_length = 0;
 		rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
-		rc.rssi = input_rc_s::RC_RSSI_MAX;
+		rc.rssi = input_rc_s::RC_RSSI_UNDEFINED;
 
 		rc.values[0] = man.x / 2 + 1500;	// roll
 		rc.values[1] = man.y / 2 + 1500;	// pitch

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -385,7 +385,7 @@ private:
 	// ORB publications (multi)
 	uORB::PublicationMulti<distance_sensor_s>		_distance_sensor_pub{ORB_ID(distance_sensor)};
 	uORB::PublicationMulti<distance_sensor_s>		_flow_distance_sensor_pub{ORB_ID(distance_sensor)};
-	uORB::PublicationMulti<input_rc_s>			_rc_pub{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>			_input_rc_pub{ORB_ID(input_rc)};
 	uORB::PublicationMulti<manual_control_setpoint_s>	_manual_control_setpoint_pub{ORB_ID(manual_control_setpoint)};
 	uORB::PublicationMulti<ping_s>				_ping_pub{ORB_ID(ping)};
 	uORB::PublicationMulti<radio_status_s>			_radio_status_pub{ORB_ID(radio_status)};

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -60,7 +60,7 @@
 #define RC_CHANNEL_LOW_THRESH		-8000	/* 10% threshold */
 
 static bool	ppm_input(uint16_t *values, uint16_t *num_values, uint16_t *frame_len);
-static bool	dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated);
+static bool	dsm_port_input(uint8_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated);
 
 #if defined(PX4IO_PERF)
 static perf_counter_t c_gather_dsm;
@@ -79,10 +79,10 @@ static unsigned _rssi_adc_counts = 0;
 
 /* receive signal strenght indicator (RSSI). 0 = no connection, 100 (RC_INPUT_RSSI_MAX): perfect connection */
 /* Note: this is static because RC-provided telemetry does not occur every tick */
-static uint16_t _rssi = 0;
+static uint8_t _rssi = RC_INPUT_RSSI_MIN;
 static unsigned _frame_drops = 0;
 
-bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated)
+bool dsm_port_input(uint8_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated)
 {
 #if defined(PX4IO_PERF)
 	perf_begin(c_gather_dsm);
@@ -90,7 +90,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 	uint8_t n_bytes = 0;
 	uint8_t *bytes;
 	bool dsm_11_bit;
-	int8_t spektrum_rssi;
+	uint8_t spektrum_rssi;
 	unsigned frame_drops;
 	*dsm_updated = dsm_input(_dsm_fd, r_raw_rc_values, &r_raw_rc_count, &dsm_11_bit, &n_bytes, &bytes,
 				 &spektrum_rssi, &frame_drops, PX4IO_RC_INPUT_CHANNELS);
@@ -114,7 +114,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 		_frame_drops = frame_drops;
 		r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FAILSAFE);
 
-		if (spektrum_rssi >= 0 && spektrum_rssi <= 100) {
+		if (spektrum_rssi <= RC_INPUT_RSSI_MAX) {
 
 			/* ensure ADC RSSI is disabled */
 			r_setup_features &= ~(PX4IO_P_SETUP_FEATURES_ADC_RSSI);
@@ -256,7 +256,7 @@ controls_tick()
 
 	/* zero RSSI if signal is lost */
 	if (!(r_raw_rc_flags & (PX4IO_P_RAW_RC_FLAGS_RC_OK))) {
-		_rssi = 0;
+		_rssi = RC_INPUT_RSSI_MIN;
 	}
 
 #if defined(PX4IO_PERF)
@@ -270,7 +270,7 @@ controls_tick()
 	if (sbus_updated) {
 		atomic_modify_or(&r_status_flags, PX4IO_P_STATUS_FLAGS_RC_SBUS);
 
-		unsigned sbus_rssi = RC_INPUT_RSSI_MAX;
+		uint8_t sbus_rssi = RC_INPUT_RSSI_MAX;
 
 		if (sbus_frame_drop) {
 			r_raw_rc_flags |= PX4IO_P_RAW_RC_FLAGS_FRAME_DROP;

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -230,6 +230,10 @@ extern uint16_t	adc_measure(unsigned channel);
 extern void	controls_init(void);
 extern void	controls_tick(void);
 
+#define RC_INPUT_RSSI_MAX		100 //should be same as  input_rc_s::RC_RSSI_MAX
+#define RC_INPUT_RSSI_MIN		0   //should be same as  input_rc_s::RC_RSSI_MIN
+#define RC_INPUT_RSSI_UNDEFINED	255 //should be same as  input_rc_s::RC_RSSI_UNDEFINED
+
 /** global debug level for isr_debug() */
 extern volatile uint8_t debug_level;
 

--- a/src/systemcmds/tests/test_ppm_loopback.c
+++ b/src/systemcmds/tests/test_ppm_loopback.c
@@ -60,7 +60,7 @@
 int test_ppm_loopback(int argc, char *argv[])
 {
 
-	int _rc_sub = orb_subscribe(ORB_ID(input_rc));
+	int input_rc_sub = orb_subscribe(ORB_ID(input_rc));
 
 	int servo_fd, result;
 	servo_position_t pos;
@@ -134,17 +134,17 @@ int test_ppm_loopback(int argc, char *argv[])
 
 	/* read low-level values from FMU or IO RC inputs (PPM, Spektrum, S.Bus) */
 	struct input_rc_s rc_input;
-	orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
+	orb_copy(ORB_ID(input_rc), input_rc_sub, &rc_input);
 	px4_usleep(100000);
 
 	/* open PPM input and expect values close to the output values */
 
 	bool rc_updated;
-	orb_check(_rc_sub, &rc_updated);
+	orb_check(input_rc_sub, &rc_updated);
 
 	if (rc_updated) {
 
-		orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
+		orb_copy(ORB_ID(input_rc), input_rc_sub, &rc_input);
 
 		// int ppm_fd = open(RC_INPUT_DEVICE_PATH, O_RDONLY);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
adc_report uorb is not needed for RCinput, if there is no analog RSSI channel.
this pr, remove the subscriber, reduce some memory, and make that fact clearer