### PR TITLE
Extend UAVCAN light control

### DIFF
--- a/src/drivers/uavcan/rgbled.hpp
+++ b/src/drivers/uavcan/rgbled.hpp
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <uORB/topics/actuator_armed.h>
+
 #include <uavcan/uavcan.hpp>
 #include <uavcan/equipment/indication/LightsCommand.hpp>
 
@@ -53,6 +55,8 @@ private:
 
 	void periodic_update(const uavcan::TimerEvent &);
 
+	uavcan::equipment::indication::RGB565 brightness_to_rgb565(uint8_t brightness);
+
 	typedef uavcan::MethodBinder<UavcanRGBController *, void (UavcanRGBController::*)(const uavcan::TimerEvent &)>
 	TimerCbBinder;
 
@@ -60,5 +64,20 @@ private:
 	uavcan::Publisher<uavcan::equipment::indication::LightsCommand> _uavcan_pub_lights_cmd;
 	uavcan::TimerEventForwarder<TimerCbBinder> _timer;
 
+	uORB::Subscription _armed_sub{ORB_ID(actuator_armed)};
+
 	LedController _led_controller;
+
+	// Enum defining light activation condition. Must match UAVCAN_LGT_* param values.
+	enum light_control_mode {
+		ALWAYS_OFF = 0,
+		PREARMED,
+		ARMED,
+		ALWAYS_ON
+	};
+
+	light_control_mode _mode_anti_col{ALWAYS_OFF};
+	light_control_mode _mode_strobe{ALWAYS_OFF};
+	light_control_mode _mode_nav{ALWAYS_OFF};
+	light_control_mode _mode_land{ALWAYS_OFF};
 };

--- a/src/drivers/uavcan/rgbled.hpp
+++ b/src/drivers/uavcan/rgbled.hpp
@@ -39,8 +39,9 @@
 #include <uavcan/equipment/indication/LightsCommand.hpp>
 
 #include <lib/led/led.h>
+#include <px4_platform_common/module_params.h>
 
-class UavcanRGBController
+class UavcanRGBController : public ModuleParams
 {
 public:
 	UavcanRGBController(uavcan::INode &node);
@@ -68,16 +69,10 @@ private:
 
 	LedController _led_controller;
 
-	// Enum defining light activation condition. Must match UAVCAN_LGT_* param values.
-	enum light_control_mode {
-		ALWAYS_OFF = 0,
-		PREARMED,
-		ARMED,
-		ALWAYS_ON
-	};
-
-	light_control_mode _mode_anti_col{ALWAYS_OFF};
-	light_control_mode _mode_strobe{ALWAYS_OFF};
-	light_control_mode _mode_nav{ALWAYS_OFF};
-	light_control_mode _mode_land{ALWAYS_OFF};
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::UAVCAN_LGT_ANTCL>) _param_mode_anti_col,
+		(ParamInt<px4::params::UAVCAN_LGT_STROB>) _param_mode_strobe,
+		(ParamInt<px4::params::UAVCAN_LGT_NAV>) _param_mode_nav,
+		(ParamInt<px4::params::UAVCAN_LGT_LAND>) _param_mode_land
+	)
 };

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -105,3 +105,91 @@ PARAM_DEFINE_FLOAT(UAVCAN_RNG_MIN, 0.3f);
  * @group UAVCAN
  */
 PARAM_DEFINE_FLOAT(UAVCAN_RNG_MAX, 200.0f);
+
+/**
+ * UAVCAN ANTI_COLLISION light operating mode
+ *
+ * This parameter defines the minimum condition under which the system will command
+ * the ANTI_COLLISION lights on
+ *
+ *  0 - Always off
+ *  1 - When autopilot is armed
+ *  2 - When autopilot is prearmed
+ *  3 - Always on
+ *
+ * @min 0
+ * @max 3
+ * @value 0 Always off
+ * @value 1 When autopilot is armed
+ * @value 2 When autopilot is prearmed
+ * @value 3 Always on
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_LGT_ANTCL, 2);
+
+/**
+ * UAVCAN STROBE light operating mode
+ *
+ * This parameter defines the minimum condition under which the system will command
+ * the STROBE lights on
+ *
+ *  0 - Always off
+ *  1 - When autopilot is armed
+ *  2 - When autopilot is prearmed
+ *  3 - Always on
+ *
+ * @min 0
+ * @max 3
+ * @value 0 Always off
+ * @value 1 When autopilot is armed
+ * @value 2 When autopilot is prearmed
+ * @value 3 Always on
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_LGT_STROB, 1);
+
+/**
+ * UAVCAN RIGHT_OF_WAY light operating mode
+ *
+ * This parameter defines the minimum condition under which the system will command
+ * the RIGHT_OF_WAY lights on
+ *
+ *  0 - Always off
+ *  1 - When autopilot is armed
+ *  2 - When autopilot is prearmed
+ *  3 - Always on
+ *
+ * @min 0
+ * @max 3
+ * @value 0 Always off
+ * @value 1 When autopilot is armed
+ * @value 2 When autopilot is prearmed
+ * @value 3 Always on
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_LGT_NAV, 3);
+
+/**
+ * UAVCAN LIGHT_ID_LANDING light operating mode
+ *
+ * This parameter defines the minimum condition under which the system will command
+ * the LIGHT_ID_LANDING lights on
+ *
+ *  0 - Always off
+ *  1 - When autopilot is armed
+ *  2 - When autopilot is prearmed
+ *  3 - Always on
+ *
+ * @min 0
+ * @max 3
+ * @value 0 Always off
+ * @value 1 When autopilot is armed
+ * @value 2 When autopilot is prearmed
+ * @value 3 Always on
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_LGT_LAND, 0);


### PR DESCRIPTION
Extends the existing UAVCAN "rgbled" for automatic control of more light types. Publishes commands for beacon, strobe, nav, and landings lights. Each is automatically controlled based on arming state and the behavior of each is configurable via params. For example, nav lights can be set to be always on while beacons turn on when the system is prearmed and strobes turn on only when armed.

This has been tested and works as expected with the soon-to-be-released [Avionics Anonymous UAVCAN light controller](https://docs.avionicsanonymous.com/devices/lightcontroller). It will of course also work with any other system that accepts commands using the standard UAVCAN light_id and color data. 

