### PR TITLE
[RFC] uORB: generate ORBTypeMap and example usage (uORB::Publication2)

### DIFF
--- a/msg/templates/uorb/msg.h.em
+++ b/msg/templates/uorb/msg.h.em
@@ -70,6 +70,10 @@ topic_name = spec.short_name
 
 #include <uORB/uORB.h>
 
+#ifdef __cplusplus
+#include <uORB/topics/uORBTopics.hpp>
+#endif
+
 @##############################
 @# Includes for dependencies
 @##############################
@@ -135,5 +139,11 @@ ORB_DECLARE(@multi_topic);
 @[end for]
 
 #ifdef __cplusplus
+@[for multi_topic in topics]@
+template<> struct ORBTypeMap<ORB_ID::@multi_topic> {
+    using type = @(uorb_struct);
+};
+@[end for]
+
 void print_message(const @uorb_struct& message);
 #endif


### PR DESCRIPTION
I did this during the discussion in https://github.com/PX4/Firmware/pull/15610 and it might be worth keeping.

@ShawnFeng0 @bkueng 

This PR creates a simple template map of ORB_ID (class enum per uORB topic) to data type. We could use this to further simplify the vast majority `uORB::Publication` and `uORB::Subscription` usage in the system while slightly decreasing memory usage and adding type safety.

For example `estimator_innovations` is a msg (data type) that's used by multiple uORB topics (estimator_innovations estimator_innovation_variances estimator_innovation_test_ratios).

Currently publishing all of these looks like this.

``` C++
#include <uORB/topics/estimator_innovations.h>
#include <uORB/Publication.hpp>

uORB::Publication<estimator_innovations_s> test_ratios_pub{ORB_ID(estimator_innovation_test_ratios)};
uORB::Publication<estimator_innovations_s> variances_pub{ORB_ID(estimator_innovation_variances)};
uORB::Publication<estimator_innovations_s> innovations_pub{ORB_ID(estimator_innovations)};
```

The data type (`estimator_innovations_s`) is the template argument, and the uORB topic (eg `ORB_ID(estimator_innovation_test_ratios)`) is passed to the constructor. This seems relatively clean and simple, but there's nothing that prevents using the wrong data type with the wrong topic. Additionally it requires storing the the ORB_ID per publication instance.

The most common `uORB::Subscription` usage is even more dangerous because it doesn't have the type and the copy method is little more than memcpy.

The generated `ORBTypeMap` is a simple template struct that maps `ORB_ID` to actual data types. Using it our `uORB::Publication` could turn into this.

``` C++
#include <uORB/topics/estimator_innovations.h>
#include <uORB/Publication2.hpp>

uORB::Publication2<ORB_ID::estimator_innovation_test_ratios> test_ratios_pub;
uORB::Publication2<ORB_ID::estimator_innovation_variances>   variances_pub;
uORB::Publication2<ORB_ID::estimator_innovations>            innovations_pub;
```

The uORB topic (eg ORB_ID::estimator_innovations) and data type (eg estimator_innovations_s) are now set statically and can't be wrong. Additionally the storage in each publication instance is now reduced to nothing more than a pointer to the corresponding uORB::DeviceNode.

This could exist nearly identically for subscriptions (with a different mechanism for logger).

Calling it Publication2 is only for comparison, I don't think I'd want to preserve both.