### PR TITLE
land_detector: optionally decrease ground_contact/maybe_landed timing if minimal distance to ground

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -162,6 +162,22 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 
 	const bool lpos_available = ((time_now_us - _vehicle_local_position.timestamp) < 1_s);
 
+	// if distance to ground within LNDMC_GND_DIST drastically reduce hysteresis requirements
+	bool dist_bottom = false;
+
+	if (lpos_available && _vehicle_local_position.dist_bottom_valid
+	    && (_vehicle_local_position.dist_bottom < _param_lndmc_gnd_dist.get())) {
+
+		dist_bottom = true;
+
+		_ground_contact_hysteresis.set_hysteresis_time_from(false, 10_ms);
+		_maybe_landed_hysteresis.set_hysteresis_time_from(false, 10_ms);
+
+	} else {
+		_ground_contact_hysteresis.set_hysteresis_time_from(false, GROUND_CONTACT_TRIGGER_TIME_US);
+		_maybe_landed_hysteresis.set_hysteresis_time_from(false, MAYBE_LAND_DETECTOR_TRIGGER_TIME_US);
+	}
+
 	// land speed threshold, 90% of MPC_LAND_SPEED
 	const float land_speed_threshold = 0.9f * math::max(_params.landSpeed, 0.1f);
 
@@ -207,7 +223,13 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	}
 
 	// low thrust: 30% of throttle range between min and hover, relaxed to 60% if hover thrust estimate available
-	const float thr_pct_hover = _hover_thrust_estimate_valid ? 0.6f : 0.3f;
+	float thr_pct_hover = _hover_thrust_estimate_valid ? 0.6f : 0.3f;
+
+	if (dist_bottom) {
+		// if nearly on ground then further relax minimum throttle requirement
+		thr_pct_hover = 0.90f;
+	}
+
 	const float sys_low_throttle = _params.minThrottle + (_params.hoverThrottle - _params.minThrottle) * thr_pct_hover;
 	bool ground_contact = (_actuator_controls_throttle <= sys_low_throttle);
 
@@ -349,7 +371,6 @@ float MulticopterLandDetector::_get_gnd_effect_altitude()
 
 bool MulticopterLandDetector::_get_ground_effect_state()
 {
-
 	return (_in_descend && !_horizontal_movement) ||
 	       (_below_gnd_effect_hgt && _takeoff_state == takeoff_status_s::TAKEOFF_STATE_FLIGHT) ||
 	       _takeoff_state == takeoff_status_s::TAKEOFF_STATE_RAMPUP;

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -139,7 +139,8 @@ private:
 		(ParamFloat<px4::params::LNDMC_ROT_MAX>)    _param_lndmc_rot_max,
 		(ParamFloat<px4::params::LNDMC_XY_VEL_MAX>) _param_lndmc_xy_vel_max,
 		(ParamFloat<px4::params::LNDMC_Z_VEL_MAX>)  _param_lndmc_z_vel_max,
-		(ParamFloat<px4::params::LNDMC_ALT_GND>)    _param_lndmc_alt_gnd_effect
+		(ParamFloat<px4::params::LNDMC_ALT_GND>)    _param_lndmc_alt_gnd_effect,
+		(ParamFloat<px4::params::LNDMC_GND_DIST>)   _param_lndmc_gnd_dist
 	);
 };
 

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -98,3 +98,18 @@ PARAM_DEFINE_FLOAT(LNDMC_ALT_MAX, -1.0f);
  *
  */
 PARAM_DEFINE_FLOAT(LNDMC_ALT_GND, -1.0f);
+
+/**
+ * Multicopter max distance to ground
+ *
+ * Maximum distance to ground allowed in the landed state (m/s up and down).
+ * Disabled if 0.
+ *
+ * @unit m
+ * @min 0.0
+ * @max 0.2
+ * @decimal 2
+ *
+ * @group Land Detector
+ */
+PARAM_DEFINE_FLOAT(LNDMC_GND_DIST, 0.0f);


### PR DESCRIPTION
This updates the multicopter land detector to optionally respect the distance to ground (vehicle_local_position.dist_bottom) if it's available and use it to drastically reduce the ground_contact and maybe_landed requirements (hysteresis time). The motivation was a small quadcopter that would often bounce on landing, making it nearly impossible to disarm in position control mode.

There's also the potential for this to be dangerous if misused. Thoughts on other protections, warnings, etc to put in place?

 - configurable with new parameter `LNDMC_GND_DIST`

