### PR TITLE
uORB: increase max path name length 64 -> 80 characters

### DIFF
--- a/src/modules/uORB/uORBCommon.hpp
+++ b/src/modules/uORB/uORBCommon.hpp
@@ -42,7 +42,7 @@
 
 namespace uORB
 {
-static constexpr unsigned orb_maxpath = 64;
+static constexpr unsigned orb_maxpath = 80;
 
 struct orb_advertdata {
 	const struct orb_metadata *meta;


### PR DESCRIPTION
No real impact other than removing the truncation in /obj. Memory increase should be negligible, but I'll verify as this goes through CI.

![Screenshot from 2020-10-27 12-37-02](https://user-images.githubusercontent.com/84712/97332697-21989f00-1851-11eb-9df2-27bbf56a6e4b.png)


**EDIT:** this doesn't add up, looks like the NuttX filename limit is to blame.