### PR TITLE
Add SITL testing for tailsitter VTOLs

### DIFF
--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -15,6 +15,12 @@
             "vehicle": "standard_vtol",
             "test_filter": "[multicopter][vtol]",
             "timeout_min": 10
+        },
+        {
+            "model": "tailsitter",
+            "vehicle": "tailsitter",
+            "test_filter": "[multicopter][vtol]",
+            "timeout_min": 10
         }
     ]
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since tailsitter vehicles have not been part of SITL testing, it is hard to identify regressions/issues. (e.g. https://github.com/PX4/Firmware/issues/16057)

**Describe your solution**
This enables SITL testing for Tailsitter vehicles


**Additional context**
- This was mentioned on the dev call 28/Oct/2020
