### PR TITLE
Improve tailsitter tuning master

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -16,17 +16,13 @@ then
 
 	param set MC_ROLLRATE_P 0.3
 
-	param set MIS_LTRMIN_ALT 10
-	param set MIS_TAKEOFF_ALT 10
 	param set MIS_YAW_TMT 10
 
 	param set MPC_ACC_HOR_MAX 2
 	param set MPC_ACC_HOR_MAX 2
-	param set MPC_THR_MIN 0.1
-	param set MPC_TKO_SPEED 1
+	param set MPC_THR_MIN 0.3
 	param set MPC_XY_P 0.15
 	param set MPC_XY_VEL_D_ACC 0.1
-	param set MPC_XY_VEL_I_ACC 4
 	param set MPC_XY_VEL_P_ACC 1
 	param set MPC_Z_VEL_MAX_DN 1.5
 	param set MPC_Z_VEL_P_ACC 16
@@ -37,6 +33,8 @@ then
 	param set VT_F_TRANS_DUR 1.5
 	param set VT_F_TRANS_THR 0.7
 	param set VT_TYPE 0
+
+	param set WV_EN 0
 
 fi
 

--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -15,6 +15,12 @@
             "vehicle": "standard_vtol",
             "test_filter": "[multicopter][vtol]",
             "timeout_min": 10
+        },
+        {
+            "model": "tailsitter",
+            "vehicle": "tailsitter",
+            "test_filter": "[multicopter][vtol]",
+            "timeout_min": 10
         }
     ]
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
Current hover tuning leads to instability during takeoff.

**Describe your solution**
Some little tweaks to the hover tuning. Don't know exactly which change has the biggest impact, my guess is setting `MPC_XY_VEL_I_ACC` to default (was 10x default)

**Test data / coverage**
Some SITL testing.

**Additional context**
Should help with https://github.com/PX4/PX4-Autopilot/pull/16074.

I've also removed some params that I deem unnecessary to specify (like takeoff altitude, using the one from vtol_defaults, 20m, should be fine).
