### PR TITLE
uORB: fix: When multiple publishers publish data to the same node, any publisher cancels the publication and the node becomes invalid

### DIFF
--- a/platforms/common/uORB/uORBDeviceMaster.cpp
+++ b/platforms/common/uORB/uORBDeviceMaster.cpp
@@ -183,7 +183,7 @@ void uORB::DeviceMaster::printStatistics()
 		return;
 	}
 
-	PX4_INFO_RAW("%-*s INST #SUB #Q SIZE PATH\n", (int)max_topic_name_length - 2, "TOPIC NAME");
+	PX4_INFO_RAW("%-*s INST #PUB #SUB #Q SIZE PATH\n", (int)max_topic_name_length - 2, "TOPIC NAME");
 
 	cur_node = first_node;
 
@@ -386,16 +386,17 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 
 			PX4_INFO_RAW(CLEAR_LINE "update: 1s, topics: %i, total publications: %i, %.1f kB/s\n",
 				     num_topics, total_msgs, (double)(total_size / 1000.f));
-			PX4_INFO_RAW(CLEAR_LINE "%-*s INST #SUB RATE #Q SIZE\n", (int)max_topic_name_length - 2, "TOPIC NAME");
+			PX4_INFO_RAW(CLEAR_LINE "%-*s INST #PUB #SUB RATE #Q SIZE\n", (int)max_topic_name_length - 2, "TOPIC NAME");
 			cur_node = first_node;
 
 			while (cur_node) {
 
 				if (!print_active_only || (cur_node->pub_msg_delta > 0 && cur_node->node->subscriber_count() > 0)) {
-					PX4_INFO_RAW(CLEAR_LINE "%-*s %2i %4i %4i %2i %4i \n", (int)max_topic_name_length,
+					PX4_INFO_RAW(CLEAR_LINE "%-*s %2i %4i %4i %4i %2i %4i \n", (int)max_topic_name_length,
 						     cur_node->node->get_meta()->o_name, (int)cur_node->node->get_instance(),
-						     (int)cur_node->node->subscriber_count(), cur_node->pub_msg_delta,
-						     cur_node->node->get_queue_size(), cur_node->node->get_meta()->o_size);
+						     (int)cur_node->node->publisher_count(), (int)cur_node->node->subscriber_count(),
+						     cur_node->pub_msg_delta, cur_node->node->get_queue_size(),
+						     cur_node->node->get_meta()->o_size);
 				}
 
 				cur_node = cur_node->next;

--- a/platforms/common/uORB/uORBDeviceMaster.cpp
+++ b/platforms/common/uORB/uORBDeviceMaster.cpp
@@ -99,62 +99,60 @@ int uORB::DeviceMaster::advertise(const struct orb_metadata *meta, bool is_adver
 			*instance = group_tries;
 		}
 
-		/* construct the new node, passing the ownership of path to it */
-		uORB::DeviceNode *node = new uORB::DeviceNode(meta, group_tries, nodepath);
+		/* if the node exists already, get the existing one and check if it's advertised. */
+		uORB::DeviceNode *existing_node = getDeviceNodeLocked(meta, group_tries);
 
-		/* if we didn't get a device, that's bad */
-		if (node == nullptr) {
-			return -ENOMEM;
-		}
+		/*
+		 * We can claim an existing node in these cases:
+		 * - The node is not advertised (yet). It means there is already one or more subscribers or it was
+		 *   unadvertised.
+		 * - We are a single-instance advertiser requesting the first instance.
+		 * - We are a subscriber requesting a certain instance.
+		 *   (we usually don't end up in that case, but we might in case of a race condtion
+		 *   between an advertiser and subscriber).
+		 */
+		bool is_single_instance_advertiser = is_advertiser && !instance;
 
-		/* initialise the node - this may fail if e.g. a node with this name already exists */
-		ret = node->init();
-
-		/* if init failed, discard the node and its name */
-		if (ret != PX4_OK) {
-			delete node;
-
-			if (ret == -EEXIST) {
-				/* if the node exists already, get the existing one and check if it's advertised. */
-				uORB::DeviceNode *existing_node = getDeviceNodeLocked(meta, group_tries);
-
-				/*
-				 * We can claim an existing node in these cases:
-				 * - The node is not advertised (yet). It means there is already one or more subscribers or it was
-				 *   unadvertised.
-				 * - We are a single-instance advertiser requesting the first instance.
-				 *   (Usually we don't end up here, but we might in case of a race condition between 2
-				 *   advertisers).
-				 * - We are a subscriber requesting a certain instance.
-				 *   (Also we usually don't end up in that case, but we might in case of a race condtion
-				 *   between an advertiser and subscriber).
-				 */
-				bool is_single_instance_advertiser = is_advertiser && !instance;
-
-				if (existing_node != nullptr &&
-				    (!existing_node->is_advertised() || is_single_instance_advertiser || !is_advertiser)) {
-					if (is_advertiser) {
-						/* Set as advertised to avoid race conditions (otherwise 2 multi-instance advertisers
-						 * could get the same instance).
-						 */
-						existing_node->mark_as_advertised();
-					}
-
-					ret = PX4_OK;
-
-				} else {
-					/* otherwise: already advertised, keep looking */
+		if (existing_node != nullptr) {
+			if (!existing_node->is_advertised()
+			    || is_single_instance_advertiser
+			    || !is_advertiser) {
+				if (is_advertiser) {
+					existing_node->add_publisher();
 				}
+
+				ret = PX4_OK;
+				break; // Node has been found
+
+			} else {
+				/* otherwise: already advertised, keep looking */
 			}
 
-		} else {
-			if (is_advertiser) {
-				node->mark_as_advertised();
+		} else { // Node does not exist, try to create a new node
+
+			/* construct the new node, passing the ownership of path to it */
+			uORB::DeviceNode *node = new uORB::DeviceNode(meta, group_tries, nodepath);
+
+			/* if we didn't get a device, that's bad, free the path too */
+			if (node == nullptr) {
+				return -ENOMEM;
 			}
 
-			// add to the node map.
-			_node_list.add(node);
-			_node_exists[node->get_instance()].set((uint8_t)node->id(), true);
+			ret = node->init();
+
+			/* if init failed, discard the node and its name */
+			if (ret != PX4_OK) {
+				delete node;
+
+			} else {
+				if (is_advertiser) {
+					node->add_publisher();
+				}
+
+				// add to the node map.
+				_node_list.add(node);
+				_node_exists[node->get_instance()].set((uint8_t)node->id(), true);
+			}
 		}
 
 		group_tries++;

--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -391,13 +391,14 @@ uORB::DeviceNode::print_statistics(int max_topic_length)
 	lock();
 
 	const uint8_t instance = get_instance();
+	const int8_t pub_count = publisher_count();
 	const int8_t sub_count = subscriber_count();
 	const uint8_t queue_size = get_queue_size();
 
 	unlock();
 
-	PX4_INFO_RAW("%-*s %2i %4i %2i %4i %s\n", max_topic_length, get_meta()->o_name, (int)instance, (int)sub_count,
-		     queue_size, get_meta()->o_size, get_devname());
+	PX4_INFO_RAW("%-*s %2i %4i %4i %2i %4i %s\n", max_topic_length, get_meta()->o_name, (int)instance,
+		     (int)pub_count, (int)sub_count, queue_size, get_meta()->o_size, get_devname());
 
 	return true;
 }

--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -384,14 +384,14 @@ uORB::DeviceNode::poll_notify_one(px4_pollfd_struct_t *fds, px4_pollevent_t even
 bool
 uORB::DeviceNode::print_statistics(int max_topic_length)
 {
-	if (_publisher_count == 0) {
+	if (_publisher_count.load() == 0) {
 		return false;
 	}
 
 	lock();
 
 	const uint8_t instance = get_instance();
-	const int8_t pub_count = publisher_count();
+	const uint8_t pub_count = publisher_count();
 	const int8_t sub_count = subscriber_count();
 	const uint8_t queue_size = get_queue_size();
 
@@ -444,16 +444,12 @@ void uORB::DeviceNode::remove_internal_subscriber()
 
 void uORB::DeviceNode::add_publisher()
 {
-	lock();
-	_publisher_count++;
-	unlock();
+	_publisher_count.fetch_add(1);
 }
 
 void uORB::DeviceNode::remove_publisher()
 {
-	lock();
-	_publisher_count--;
-	unlock();
+	_publisher_count.fetch_sub(1);
 }
 
 #ifdef ORB_COMMUNICATOR

--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -169,13 +169,13 @@ public:
 	 *
 	 * This is used in the case of multi_pub/sub to check if it's valid to advertise
 	 * and publish to this node or if another node should be tried. */
-	bool is_advertised() const { return _publisher_count != 0; }
+	bool is_advertised() const { return _publisher_count.load() != 0; }
 
 	void add_publisher();
 
 	void remove_publisher();
 
-	int8_t publisher_count() const { return _publisher_count; }
+	uint8_t publisher_count() const { return _publisher_count.load(); }
 
 	/**
 	 * Try to change the size of the queue. This can only be done as long as nobody published yet.
@@ -293,7 +293,7 @@ private:
 
 	const uint8_t _instance; /**< orb multi instance identifier */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
-	uint8_t _publisher_count{0};
+	px4::atomic<uint8_t> _publisher_count{0};
 	int8_t _subscriber_count{0};
 
 

--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -169,9 +169,11 @@ public:
 	 *
 	 * This is used in the case of multi_pub/sub to check if it's valid to advertise
 	 * and publish to this node or if another node should be tried. */
-	bool is_advertised() const { return _advertised; }
+	bool is_advertised() const { return _publisher_count != 0; }
 
-	void mark_as_advertised() { _advertised = true; }
+	void add_publisher();
+
+	void remove_publisher();
 
 	/**
 	 * Try to change the size of the queue. This can only be done as long as nobody published yet.
@@ -288,8 +290,8 @@ private:
 	List<uORB::SubscriptionCallback *>	_callbacks;
 
 	const uint8_t _instance; /**< orb multi instance identifier */
-	bool _advertised{false};  /**< has ever been advertised (not necessarily published data yet) */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
+	uint8_t _publisher_count{0};
 	int8_t _subscriber_count{0};
 
 

--- a/platforms/common/uORB/uORBDeviceNode.hpp
+++ b/platforms/common/uORB/uORBDeviceNode.hpp
@@ -175,6 +175,8 @@ public:
 
 	void remove_publisher();
 
+	int8_t publisher_count() const { return _publisher_count; }
+
 	/**
 	 * Try to change the size of the queue. This can only be done as long as nobody published yet.
 	 * This is the case, for example when orb_subscribe was called before an orb_advertise.

--- a/platforms/common/uORB/uORB_tests/uORBTest_UnitTest.hpp
+++ b/platforms/common/uORB/uORB_tests/uORBTest_UnitTest.hpp
@@ -96,6 +96,7 @@ private:
 	orb_advert_t _pfd[4] {}; ///< used for test_multi and test_multi_reversed
 
 	int test_single();
+	int test_single_unadvertise();
 
 	/* These 3 depend on each other and must be called in this order */
 	int test_multi();


### PR DESCRIPTION
When multiple publishers use `DeviceNode` instance 0 to publish data in `uORB`, any node cancels publishing, which will cause the node to be marked as unadvertised, and the data cannot be obtained by subscribers.

This fix counts the number of publishers to determine whether there are still publishers.

To this end, a test case `uORBTest::UnitTest::test_single_unadvertise()` has been written to test this situation.

Note: The mismatch between `orb_advertise` and `orb_unadvertise` may cause errors. But if you use the C++ interface, this problem will not exist.

This fix is inspired by https://github.com/PX4/PX4-Autopilot/pull/16012#issuecomment-714895637