### PR TITLE
msg: rtps: improve verbosity when the the client/agent are not capable of parsing a specific ID

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
@@ -231,7 +231,7 @@ void micrortps_start_topics(struct timespec &begin, uint64_t &total_read, uint64
                 break;
 @[end for]@
                 default:
-                    PX4_WARN("Unexpected topic ID\n");
+                    PX4_WARN("Unexpected topic ID '%hhu' to getMsg. Please make sure the client is capable of parsing the message associated to the topic ID '%hhu'", topic_ID, topic_ID);
                 break;
             }
         }

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -119,7 +119,7 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
         break;
 @[end for]@
         default:
-            printf("\033[1;33m[   micrortps_agent   ]\tUnexpected topic ID to publish\033[0m\n");
+            printf("\033[1;33m[   micrortps_agent   ]\tUnexpected topic ID '%hhu' to publish Please make sure the agent is capable of parsing the message associated to the topic ID '%hhu'\033[0m\n", topic_ID, topic_ID);
         break;
     }
 }
@@ -153,7 +153,7 @@ bool RtpsTopics::getMsg(const uint8_t topic_ID, eprosima::fastcdr::Cdr &scdr)
         break;
 @[end for]@
         default:
-            printf("\033[1;33m[   micrortps_agent   ]\tUnexpected topic ID '%hhu' to getMsg\033[0m\n", topic_ID);
+            printf("\033[1;33m[   micrortps_agent   ]\tUnexpected topic ID '%hhu' to getMsg. Please make sure the agent is capable of parsing the message associated to the topic ID '%hhu'\033[0m\n", topic_ID, topic_ID);
         break;
     }
 


### PR DESCRIPTION
Time-to-time, people might encounter a problem where the micro-RTPS agent or client are not capable of parsing certain messages since the defined messages and ID's are not in sync between the client and the agent. This somehow helps understand which ones are not in sync and provides a hint.