### PR TITLE
not run transition flight task when not enable altitude control

### DIFF
--- a/src/lib/flight_tasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/flight_tasks/tasks/Transition/FlightTaskTransition.cpp
@@ -44,8 +44,6 @@ bool FlightTaskTransition::updateInitialize()
 
 bool FlightTaskTransition::activate(const vehicle_local_position_setpoint_s &last_setpoint)
 {
-	_transition_altitude = PX4_ISFINITE(last_setpoint.z) ? last_setpoint.z : _position(2);
-	_transition_yaw = PX4_ISFINITE(last_setpoint.yaw) ? last_setpoint.yaw : _yaw;
 	return FlightTask::activate(last_setpoint);
 }
 

--- a/src/lib/flight_tasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/flight_tasks/tasks/Transition/FlightTaskTransition.hpp
@@ -50,8 +50,4 @@ public:
 	bool activate(const vehicle_local_position_setpoint_s &last_setpoint) override;
 	bool updateInitialize() override;
 	bool update() override;
-
-private:
-	float _transition_altitude = 0.0f;
-	float _transition_yaw = 0.0f;
 };

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -477,7 +477,7 @@ void MulticopterPositionControl::start_flight_task()
 		return;
 	}
 
-	// Do not run transition flight task when not enable altitude control
+	// Do not run transition flight task if altitude control is not enabled (e.g. in Stabilized or Acro flight mode)
 	if (_vehicle_status.in_transition_mode && _control_mode.flag_control_altitude_enabled) {
 		should_disable_task = false;
 		FlightTaskError error = _flight_tasks.switchTask(FlightTaskIndex::Transition);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -477,7 +477,8 @@ void MulticopterPositionControl::start_flight_task()
 		return;
 	}
 
-	if (_vehicle_status.in_transition_mode) {
+	// Do not run transition flight task when not enable altitude control
+	if (_vehicle_status.in_transition_mode && _control_mode.flag_control_altitude_enabled) {
 		should_disable_task = false;
 		FlightTaskError error = _flight_tasks.switchTask(FlightTaskIndex::Transition);
 


### PR DESCRIPTION
.**Describe problem solved by this pull request**
To fix issue: https://github.com/PX4/PX4-Autopilot/issues/16057

**Describe your solution**
Do not run transition flight task when not enable altitude control

**Describe possible alternatives**
For all vtols, if altitude control is not enabled, the relevant thrust control information should not be published, but it is determined by the pilot's throttle stick

**Test data / coverage**
before this pr:
![Screenshot from 2020-10-30 09-09-36](https://user-images.githubusercontent.com/24932258/97648435-b557ae80-1a8f-11eb-993d-1e384af8d56e.png)

log link: https://review.px4.io/plot_app?log=31ecffd0-f99d-4169-99ab-f5fdc3778189

after this pr:
![Screenshot from 2020-10-30 09-09-50](https://user-images.githubusercontent.com/24932258/97648648-3adb5e80-1a90-11eb-8815-0e6c1ca7eb3b.png)

log link: https://review.px4.io/plot_app?log=39d29f3d-ab7a-4e43-bc9a-2d67d1d048bf

I also used simulation to verify that the drone state is normal after enabling altiude control.

**Additional context**
I also removed unused variables
`_transition_altitude` `_transition_yaw`

FYI @sfuhrer  @RicardoM17 