### PR TITLE
Build on NixOS

### DIFF
--- a/Tools/setup/shell.nix
+++ b/Tools/setup/shell.nix
@@ -1,0 +1,64 @@
+let
+	pkgs = import (builtins.fetchTarball {
+		name = "nixos-20.09-2020-10-29";
+		url = "https://github.com/nixos/nixpkgs/archive/edb26126d98bc696f4f3e206583faa65d3d6e818.tar.gz";
+		sha256 = "1cl4ka4kk7kh3bl78g06dhiidazf65q8miyzaxi9930d6gwyzkci";
+	}) {};
+	empy = with pkgs.python3Packages; buildPythonPackage rec {
+		pname = "empy";
+		version = "3.3.4";
+		src = fetchPypi {
+			inherit pname version;
+			sha256 = "1cq1izl6l87i5i3vj0jcqfksh10kpiwpr2m19vgpj530bdw4kb3k";
+		};
+		doCheck = false;
+	};
+	pyros-genmsg = with pkgs.python3Packages; buildPythonPackage rec {
+		pname = "pyros-genmsg";
+		version = "0.5.8";
+		src = fetchPypi {
+			inherit version;
+			pname = "pyros_genmsg";
+			sha256 = "0y7l131lc77v0c1rhxza41cxnnxc7acfqzlqf84fdya0kiyv071w";
+		};
+		doCheck = false;
+	};
+	pyulog = with pkgs.python3Packages; buildPythonPackage rec {
+		pname = "pyulog";
+		version = "0.8.0";
+		src = fetchPypi {
+			inherit pname version;
+			sha256 = "1ivvhfi9rsrqdk9f06rj0q1d367ngyy0xyc2x9mdwjx3dazwgn45";
+		};
+		propagatedBuildInputs = [ numpy ];
+		doCheck = false;
+	};
+in pkgs.mkShell {
+	nativeBuildInputs = [ pkgs.cmake ];
+	buildInputs = [
+		pkgs.gcc-arm-embedded
+		pkgs.python3
+	] ++ (with pkgs.python3Packages; [
+		argcomplete
+		cerberus
+		coverage
+		empy
+		jinja2
+		matplotlib
+		numpy
+		packaging
+		pandas
+		pkgconfig
+		psutil
+		pygments
+		pyros-genmsg
+		pyserial
+		pyulog
+		pyyaml
+		requests
+		setuptools
+		six
+		toml
+		wheel
+	]);
+}

--- a/platforms/nuttx/Debug/poor-mans-profiler.sh
+++ b/platforms/nuttx/Debug/poor-mans-profiler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: Pavel Kirienko <pavel.kirienko@zubax.com>
 #

--- a/platforms/nuttx/NuttX/tools/kconfig-conf
+++ b/platforms/nuttx/NuttX/tools/kconfig-conf
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 echo "DEBUG: kconfiglib kconfig-conf wrapper, arguments: ${@}"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/platforms/nuttx/NuttX/tools/kconfig-tweak
+++ b/platforms/nuttx/NuttX/tools/kconfig-tweak
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 #echo "DEBUG: kconfiglib kconfig-tweak wrapper, arguments: ${@}"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/platforms/nuttx/NuttX/tools/px4_nuttx_make_olddefconfig.sh
+++ b/platforms/nuttx/NuttX/tools/px4_nuttx_make_olddefconfig.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/src/drivers/dshot/dshot.cpp
+++ b/src/drivers/dshot/dshot.cpp
@@ -1405,13 +1405,13 @@ int DShotOutput::custom_command(int argc, char *argv[])
 		}
 	}
 
-	struct Command {
+	struct VerbCommand {
 		const char *name;
 		dshot_command_t command;
 		int num_repetitions;
 	};
 
-	constexpr Command commands[] = {
+	constexpr VerbCommand commands[] = {
 		{"reverse", DShot_cmd_spin_direction_reversed, 10},
 		{"normal", DShot_cmd_spin_direction_normal, 10},
 		{"save", DShot_cmd_save_settings, 10},


### PR DESCRIPTION
**Describe problem solved by this pull request**

Greetings PX4 developers. These changes make it easier to build PX4 on [NixOS](https://nixos.org/).

**Describe your solution**

I changed the interpreter in some `platforms/nuttx` scripts as `/bin/bash` does not exist on clean NixOS installation. Then I added `Tools/setup/shell.nix`, which you can supply to `nix-shell` to obtain an environment in which PX4 will have its build dependencies.

Also see [this build error I had to fix](https://github.com/PX4/PX4-Autopilot/commit/0b5ee19b6b41383e63c1e3da6b9e3b6c1cce4a81). I guess it might be because of too old an ARM GCC (9-2019-q4-major)? Should I get the `shell.nix` environment to have newer version? That's doable with some additional effort.

**Describe possible alternatives**

Well you could use container with e.g. Ubuntu, but that's not a solution I like.

**Test data / coverage**

`make px4_fmu-v5` builds and produces good binaries. Let me know if there are other targets that you want me to test.

**Additional context**

Feel free to decide against inclusion if you don't see it worth the maintenance burden.

Also I have seen that cmake will ignore if `platforms/nuttx/NuttX/tools/px4_nuttx_make_olddefconfig.sh` fails, which caused a harder-to-explain build error later on. I don't know cmake good enough to fix that, neither do I know if that's intentional.