### PR TITLE
ekf2: refactor data update and publications into separate methods

### DIFF
--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -7,6 +7,7 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
 	ROMFSROOT px4fmu_common
+	CONSTRAINED_FLASH
 	SERIAL_PORTS
 		GPS1:/dev/ttyS5
 		TEL1:/dev/ttyS3

--- a/boards/nxp/fmurt1062-v1/default.cmake
+++ b/boards/nxp/fmurt1062-v1/default.cmake
@@ -9,7 +9,7 @@ px4_add_board(
 	ROMFSROOT px4fmu_common
 	LINKER_PREFIX ocram
 #	UAVCAN_INTERFACES 2
-
+	CONSTRAINED_FLASH
 	SERIAL_PORTS
 		GPS1:/dev/ttyS1
 		TEL1:/dev/ttyS3

--- a/msg/estimator_innovations.msg
+++ b/msg/estimator_innovations.msg
@@ -13,12 +13,6 @@ float32    ev_vvel	# vertical external vision velocity innovation (m/sec) and in
 float32[2] ev_hpos	# horizontal external vision position innovation (m) and innovation variance (m**2)
 float32    ev_vpos	# vertical external vision position innovation (m) and innovation variance (m**2)
 
-# Fake Position and Velocity
-float32[2] fake_hvel	# fake horizontal velocity innovation (m/s) and innovation variance ((m/s)**2)
-float32    fake_vvel	# fake vertical velocity innovation (m/s) and innovation variance ((m/s)**2)
-float32[2] fake_hpos	# fake horizontal position innovation (m) and innovation variance (m**2)
-float32    fake_vpos	# fake vertical position innovation (m) and innovation variance (m**2)
-
 # Height sensors
 float32 rng_vpos	# range sensor height innovation (m) and innovation variance (m**2)
 float32 baro_vpos	# barometer height innovation (m) and innovation variance (m**2)

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -67,10 +67,10 @@ static constexpr wq_config_t I2C4{"wq:I2C4", 1472, -12};
 // PX4 att/pos controllers, highest priority after sensors.
 static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 1728, -13};
 
-static constexpr wq_config_t INS0{"wq:INS0", 7200, -14};
-static constexpr wq_config_t INS1{"wq:INS1", 7200, -15};
-static constexpr wq_config_t INS2{"wq:INS2", 7200, -16};
-static constexpr wq_config_t INS3{"wq:INS3", 7200, -17};
+static constexpr wq_config_t INS0{"wq:INS0", 6000, -14};
+static constexpr wq_config_t INS1{"wq:INS1", 6000, -15};
+static constexpr wq_config_t INS2{"wq:INS2", 6000, -16};
+static constexpr wq_config_t INS3{"wq:INS3", 6000, -17};
 
 static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
 

--- a/src/drivers/roboclaw/RoboClaw.cpp
+++ b/src/drivers/roboclaw/RoboClaw.cpp
@@ -52,9 +52,7 @@
 #include <systemlib/err.h>
 #include <systemlib/mavlink_log.h>
 
-
 #include <uORB/Publication.hpp>
-#include <uORB/topics/debug_key_value.h>
 #include <drivers/drv_hrt.h>
 #include <math.h>
 

--- a/src/modules/ekf2/CMakeLists.txt
+++ b/src/modules/ekf2/CMakeLists.txt
@@ -37,7 +37,7 @@ px4_add_module(
 	MODULE modules__ekf2
 	MAIN ekf2
 	COMPILE_FLAGS
-	STACK_MAX 2400
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		EKF2.cpp
 		EKF2.hpp

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1413,7 +1413,7 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 	_ekf.get_filter_fault_status(&fault_status.value);
 
 	// Check if conditions are OK for learning of magnetometer bias values
-	if (!_landed && _armed &&
+	if (control_status.flags.in_air && _armed &&
 	    !fault_status.value && // there are no filter faults
 	    control_status.flags.mag_3D) { // the EKF is operating in the correct mode
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -421,20 +421,7 @@ void EKF2::Run()
 			}
 		}
 
-		// read baro data
-		if (_airdata_sub.updated()) {
-			vehicle_air_data_s airdata;
-
-			if (_airdata_sub.copy(&airdata)) {
-				_ekf.set_air_density(airdata.rho);
-				const baroSample baro_sample {airdata.baro_alt_meter, airdata.timestamp_sample};
-				_ekf.setBaroData(baro_sample);
-				ekf2_timestamps.vehicle_air_data_timestamp_rel = (int16_t)((int64_t)airdata.timestamp / 100 -
-						(int64_t)ekf2_timestamps.timestamp / 100);
-
-				_device_id_baro = airdata.baro_device_id;
-			}
-		}
+		UpdateBaroSample(ekf2_timestamps);
 
 		if (_vehicle_gps_position_sub.updated()) {
 			vehicle_gps_position_s gps;
@@ -1369,6 +1356,24 @@ void EKF2::UpdateAuxVelSample(ekf2_timestamps_s &ekf2_timestamps)
 			};
 			_ekf.setAuxVelData(auxvel_sample);
 		}
+	}
+}
+
+void EKF2::UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps)
+{
+	// EKF baro sample
+	vehicle_air_data_s airdata;
+
+	if (_airdata_sub.update(&airdata)) {
+		_ekf.set_air_density(airdata.rho);
+
+		const baroSample baro_sample {airdata.baro_alt_meter, airdata.timestamp_sample};
+		_ekf.setBaroData(baro_sample);
+
+		_device_id_baro = airdata.baro_device_id;
+
+		ekf2_timestamps.vehicle_air_data_timestamp_rel = (int16_t)((int64_t)airdata.timestamp / 100 -
+				(int64_t)ekf2_timestamps.timestamp / 100);
 	}
 }
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -251,6 +251,16 @@ void EKF2::Run()
 		}
 	}
 
+	// check for parameter updates
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
+
+		// update parameters from storage
+		updateParams();
+	}
+
 	bool updated = false;
 	imuSample imu_sample_new {};
 
@@ -297,17 +307,6 @@ void EKF2::Run()
 	}
 
 	if (updated) {
-
-		// check for parameter updates
-		if (_parameter_update_sub.updated()) {
-			// clear update
-			parameter_update_s pupdate;
-			_parameter_update_sub.copy(&pupdate);
-
-			// update parameters from storage
-			updateParams();
-		}
-
 		const hrt_abstime now = imu_sample_new.time_us;
 
 		// ekf2_timestamps (using 0.1 ms relative timestamps)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -582,8 +582,7 @@ void EKF2::PublishInnovations(const hrt_abstime &timestamp, const imuSample &imu
 	_ekf.getHaglInnov(innovations.hagl);
 	// Not yet supported
 	innovations.aux_vvel = NAN;
-	innovations.fake_hpos[0] = innovations.fake_hpos[1] = innovations.fake_vpos = NAN;
-	innovations.fake_hvel[0] = innovations.fake_hvel[1] = innovations.fake_vvel = NAN;
+
 	innovations.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_innovations_pub.publish(innovations);
 
@@ -622,8 +621,6 @@ void EKF2::PublishInnovationTestRatios(const hrt_abstime &timestamp)
 	_ekf.getHaglInnovRatio(test_ratios.hagl);
 	// Not yet supported
 	test_ratios.aux_vvel = NAN;
-	test_ratios.fake_hpos[0] = test_ratios.fake_hpos[1] = test_ratios.fake_vpos = NAN;
-	test_ratios.fake_hvel[0] = test_ratios.fake_hvel[1] = test_ratios.fake_vvel = NAN;
 
 	test_ratios.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_innovation_test_ratios_pub.publish(test_ratios);
@@ -648,8 +645,6 @@ void EKF2::PublishInnovationVariances(const hrt_abstime &timestamp)
 	_ekf.getHaglInnovVar(variances.hagl);
 	// Not yet supported
 	variances.aux_vvel = NAN;
-	variances.fake_hpos[0] = variances.fake_hpos[1] = variances.fake_vpos = NAN;
-	variances.fake_hvel[0] = variances.fake_hvel[1] = variances.fake_vvel = NAN;
 
 	variances.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_innovation_variances_pub.publish(variances);

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -767,7 +767,6 @@ void EKF2::Run()
 			PublishGlobalPosition(now);
 			PublishSensorBias(now);
 			PublishWindEstimate(now);
-			PublishYawEstimatorStatus(now);
 
 			// publish status/logging messages
 			PublishEkfDriftMetrics(now);
@@ -776,6 +775,7 @@ void EKF2::Run()
 			PublishInnovations(now, imu_sample_new);
 			PublishInnovationTestRatios(now);
 			PublishInnovationVariances(now);
+			PublishYawEstimatorStatus(now);
 
 			if (!_mag_decl_saved && _standby) {
 				_mag_decl_saved = update_mag_decl(_param_ekf2_mag_decl);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -152,6 +152,7 @@ private:
 	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps, vehicle_odometry_s &ev_odom);
 	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps, optical_flow_s &optical_flow);
 	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
+	void UpdateMagSample(ekf2_timestamps_s &ekf2_timestamps);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -146,6 +146,8 @@ private:
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
+	void UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps);
+
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 
 	/*

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -137,6 +137,7 @@ private:
 	void PublishAttitude(const hrt_abstime &timestamp);
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishGlobalPosition(const hrt_abstime &timestamp);
+	void PublishInnovationTestRatios(const hrt_abstime &timestamp);
 	void PublishInnovationVariances(const hrt_abstime &timestamp);
 	void PublishLocalPosition(const hrt_abstime &timestamp);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -120,8 +120,6 @@ public:
 private:
 	void Run() override;
 
-	int getRangeSubIndex(); ///< get subscription index of first downward-facing range sensor
-
 	PreFlightChecker _preflt_checker;
 	void runPreFlightChecks(float dt, const filter_control_status_u &control_status,
 				const estimator_innovations_s &innov, const bool can_observe_heading_in_flight);
@@ -153,6 +151,7 @@ private:
 	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps, optical_flow_s &optical_flow);
 	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateMagSample(ekf2_timestamps_s &ekf2_timestamps);
+	void UpdateRangeSample(ekf2_timestamps_s &ekf2_timestamps);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 
@@ -212,6 +211,7 @@ private:
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
+	uORB::Subscription _distance_sensor_sub{ORB_ID(distance_sensor)};
 	uORB::Subscription _ev_odom_sub{ORB_ID(vehicle_visual_odometry)};
 	uORB::Subscription _landing_target_pose_sub{ORB_ID(landing_target_pose)};
 	uORB::Subscription _magnetometer_sub{ORB_ID(vehicle_magnetometer)};
@@ -228,10 +228,7 @@ private:
 	bool _callback_registered{false};
 	int _lockstep_component{-1};
 
-	// because we can have several distance sensor instances with different orientations
-	uORB::SubscriptionMultiArray<distance_sensor_s> _distance_sensor_subs{ORB_ID::distance_sensor};
-	int _range_finder_sub_index = -1; // index for downward-facing range finder subscription
-
+	bool _distance_sensor_selected{false}; // because we can have several distance sensor instances with different orientations
 	bool _armed{false};
 	bool _standby{false}; // standby arming state
 	bool _landed{true};

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -134,11 +134,11 @@ private:
 	template<typename Param>
 	bool update_mag_decl(Param &mag_decl_param);
 
-	void publish_attitude(const hrt_abstime &timestamp);
-	void publish_estimator_optical_flow_vel(const hrt_abstime &timestamp);
-	void publish_odometry(const hrt_abstime &timestamp, const imuSample &imu, const vehicle_local_position_s &lpos);
-	void publish_wind_estimate(const hrt_abstime &timestamp);
-	void publish_yaw_estimator_status(const hrt_abstime &timestamp);
+	void PublishAttitude(const hrt_abstime &timestamp);
+	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
+	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
+	void PublishWindEstimate(const hrt_abstime &timestamp);
+	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
 	/*
 	 * Calculate filtered WGS84 height from estimated AMSL height

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -137,6 +137,7 @@ private:
 	void PublishAttitude(const hrt_abstime &timestamp);
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishGlobalPosition(const hrt_abstime &timestamp);
+	void PublishInnovations(const hrt_abstime &timestamp, const imuSample &imu);
 	void PublishInnovationTestRatios(const hrt_abstime &timestamp);
 	void PublishInnovationVariances(const hrt_abstime &timestamp);
 	void PublishLocalPosition(const hrt_abstime &timestamp);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -173,7 +173,8 @@ private:
 	uint64_t _start_time_us = 0;		///< system time at EKF start (uSec)
 	int64_t _last_time_slip_us = 0;		///< Last time slip (uSec)
 
-	perf_counter_t _ekf_update_perf;
+	perf_counter_t _ecl_ekf_update_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": ECL update")};
+	perf_counter_t _ecl_ekf_update_full_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": ECL full update")};
 
 	// Initialise time stamps used to send sensor data to the EKF and for logging
 	uint8_t _invalid_mag_id_count = 0;	///< number of times an invalid magnetomer device ID has been detected

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -137,8 +137,9 @@ private:
 	void PublishAttitude(const hrt_abstime &timestamp);
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishGlobalPosition(const hrt_abstime &timestamp);
-	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
+	void PublishLocalPosition(const hrt_abstime &timestamp);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
+	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishSensorBias(const hrt_abstime &timestamp);
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -135,6 +135,7 @@ private:
 	bool update_mag_decl(Param &mag_decl_param);
 
 	void PublishAttitude(const hrt_abstime &timestamp);
+	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
 	void PublishWindEstimate(const hrt_abstime &timestamp);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -131,9 +131,6 @@ private:
 	template<typename Param>
 	void update_mag_bias(Param &mag_bias_param, int axis_index);
 
-	template<typename Param>
-	bool update_mag_decl(Param &mag_decl_param);
-
 	void PublishAttitude(const hrt_abstime &timestamp);
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishGlobalPosition(const hrt_abstime &timestamp);
@@ -148,6 +145,8 @@ private:
 	void PublishStatus(const hrt_abstime &timestamp);
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
+
+	void UpdateMagCalibration(const hrt_abstime &timestamp);
 
 	/*
 	 * Calculate filtered WGS84 height from estimated AMSL height
@@ -177,8 +176,8 @@ private:
 	hrt_abstime _total_cal_time_us = 0;	///< accumulated calibration time since the last save
 
 	float _last_valid_mag_cal[3] = {};	///< last valid XYZ magnetometer bias estimates (Gauss)
-	bool _valid_cal_available[3] = {};	///< true when an unsaved valid calibration for the XYZ magnetometer bias is available
 	float _last_valid_variance[3] = {};	///< variances for the last valid magnetometer XYZ bias estimates (Gauss**2)
+	bool _valid_cal_available{false};	///< true when an unsaved valid calibration for the XYZ magnetometer bias is available
 
 	// Used to control saving of mag declination to be used on next startup
 	bool _mag_decl_saved = false;	///< true when the magnetic declination has been saved

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -138,6 +138,7 @@ private:
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
+	void PublishSensorBias(const hrt_abstime &timestamp);
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
@@ -190,6 +191,10 @@ private:
 	uint32_t _device_id_mag{0};
 
 	Vector3f _last_local_position_for_gpos{};
+
+	Vector3f _last_accel_bias{};
+	Vector3f _last_gyro_bias{};
+	Vector3f _last_mag_bias{};
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -139,6 +139,7 @@ private:
 	void PublishInnovationVariances(const hrt_abstime &timestamp);
 	void PublishLocalPosition(const hrt_abstime &timestamp);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
+	void PublishOdometryAligned(const hrt_abstime &timestamp, const vehicle_odometry_s &ev_odom);
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishSensorBias(const hrt_abstime &timestamp);
 	void PublishStates(const hrt_abstime &timestamp);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -137,6 +137,7 @@ private:
 	void PublishAttitude(const hrt_abstime &timestamp);
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
 	void PublishGlobalPosition(const hrt_abstime &timestamp);
+	void PublishInnovationVariances(const hrt_abstime &timestamp);
 	void PublishLocalPosition(const hrt_abstime &timestamp);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -142,6 +142,7 @@ private:
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishSensorBias(const hrt_abstime &timestamp);
 	void PublishStates(const hrt_abstime &timestamp);
+	void PublishStatus(const hrt_abstime &timestamp);
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -136,6 +136,7 @@ private:
 
 	void PublishAttitude(const hrt_abstime &timestamp);
 	void PublishEkfDriftMetrics(const hrt_abstime &timestamp);
+	void PublishGlobalPosition(const hrt_abstime &timestamp);
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
 	void PublishSensorBias(const hrt_abstime &timestamp);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -141,6 +141,7 @@ private:
 	void PublishOdometry(const hrt_abstime &timestamp, const imuSample &imu);
 	void PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flow_s &optical_flow);
 	void PublishSensorBias(const hrt_abstime &timestamp);
+	void PublishStates(const hrt_abstime &timestamp);
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -227,7 +227,6 @@ private:
 	bool _distance_sensor_selected{false}; // because we can have several distance sensor instances with different orientations
 	bool _armed{false};
 	bool _standby{false}; // standby arming state
-	bool _in_ground_effect{false};
 
 	uORB::PublicationMulti<ekf2_timestamps_s>            _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};
 	uORB::PublicationMulti<ekf_gps_drift_s>              _ekf_gps_drift_pub{ORB_ID(ekf_gps_drift)};

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -149,6 +149,7 @@ private:
 	void UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateAuxVelSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps);
+	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps, vehicle_odometry_s &ev_odom);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -227,7 +227,6 @@ private:
 	bool _distance_sensor_selected{false}; // because we can have several distance sensor instances with different orientations
 	bool _armed{false};
 	bool _standby{false}; // standby arming state
-	bool _landed{true};
 	bool _in_ground_effect{false};
 
 	uORB::PublicationMulti<ekf2_timestamps_s>            _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -148,6 +148,7 @@ private:
 
 	void UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateAuxVelSample(ekf2_timestamps_s &ekf2_timestamps);
+	void UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -121,7 +121,6 @@ private:
 	void Run() override;
 
 	int getRangeSubIndex(); ///< get subscription index of first downward-facing range sensor
-	void fillGpsMsgWithVehicleGpsPosData(gps_message &msg, const vehicle_gps_position_s &data);
 
 	PreFlightChecker _preflt_checker;
 	void runPreFlightChecks(float dt, const filter_control_status_u &control_status,
@@ -152,6 +151,7 @@ private:
 	void UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps);
 	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps, vehicle_odometry_s &ev_odom);
 	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps, optical_flow_s &optical_flow);
+	void UpdateGpsSample(ekf2_timestamps_s &ekf2_timestamps);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -120,11 +120,6 @@ public:
 private:
 	void Run() override;
 
-	PreFlightChecker _preflt_checker;
-	void runPreFlightChecks(float dt, const filter_control_status_u &control_status,
-				const estimator_innovations_s &innov, const bool can_observe_heading_in_flight);
-	void resetPreFlightChecks();
-
 	template<typename Param>
 	void update_mag_bias(Param &mag_bias_param, int axis_index);
 
@@ -234,7 +229,6 @@ private:
 	bool _standby{false}; // standby arming state
 	bool _landed{true};
 	bool _in_ground_effect{false};
-	bool _can_observe_heading_in_flight{false};
 
 	uORB::PublicationMulti<ekf2_timestamps_s>            _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};
 	uORB::PublicationMulti<ekf_gps_drift_s>              _ekf_gps_drift_pub{ORB_ID(ekf_gps_drift)};
@@ -254,6 +248,8 @@ private:
 	uORB::PublicationMulti<vehicle_local_position_s>     _local_position_pub;
 	uORB::PublicationMulti<vehicle_global_position_s>    _global_position_pub;
 	uORB::PublicationMulti<vehicle_odometry_s>           _odometry_pub;
+
+	PreFlightChecker _preflt_checker;
 
 	Ekf _ekf;
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -151,6 +151,7 @@ private:
 	void UpdateAuxVelSample(ekf2_timestamps_s &ekf2_timestamps);
 	void UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps);
 	bool UpdateExtVisionSample(ekf2_timestamps_s &ekf2_timestamps, vehicle_odometry_s &ev_odom);
+	bool UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps, optical_flow_s &optical_flow);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -147,6 +147,7 @@ private:
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
 	void UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps);
+	void UpdateAuxVelSample(ekf2_timestamps_s &ekf2_timestamps);
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
 


### PR DESCRIPTION
  - refactor enormous Run() into separate methods for handling each ecl/EKF sample and each message publication
  - GPS, flow, and ExtVision updates skipped if disabled in EKF2_AID_MASK
  - preflightChecker only reset on arming state changes instead of constantly when armed
  - separate perf counters for ecl/EKF updates where only the output predictor is run
  - accel bias not populated in `estimator_sensor_bias` if inhibited by EKF2_AID_MASK
  - ekf2 module respect MAX_CUSTOM_OPT_LEVEL optimization level (-O2 unless flash constrained)
  - px4_work_queue reduce INSx stacks by 1200 bytes
