### PR TITLE
FFT add simple median filter

### DIFF
--- a/msg/sensor_gyro_fft.msg
+++ b/msg/sensor_gyro_fft.msg
@@ -7,6 +7,8 @@ float32 dt                # delta time between samples (microseconds)
 
 float32 resolution_hz
 
-float32[2] peak_frequency_x # x axis peak frequencies
-float32[2] peak_frequency_y # y axis peak frequencies
-float32[2] peak_frequency_z # z axis peak frequencies
+float32[3] peak_frequency # peak frequency per axis
+
+float32[4] peak_frequencies_x # x axis peak frequencies
+float32[4] peak_frequencies_y # y axis peak frequencies
+float32[4] peak_frequencies_z # z axis peak frequencies

--- a/src/examples/gyro_fft/GyroFFT.hpp
+++ b/src/examples/gyro_fft/GyroFFT.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/defines.h>
@@ -110,6 +111,8 @@ private:
 	int _fft_buffer_index[3] {};
 
 	unsigned _gyro_last_generation{0};
+
+	math::MedianFilter<float, 3> _median_filter[3] {};
 
 	sensor_gyro_fft_s _sensor_gyro_fft{};
 

--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -38,5 +38,6 @@ px4_add_library(mathlib
 	math/filter/LowPassFilter2pVector3f.cpp
 )
 
+px4_add_unit_gtest(SRC math/filter/MedianFilterTest.cpp)
 px4_add_unit_gtest(SRC math/filter/NotchFilterTest.cpp)
 px4_add_unit_gtest(SRC math/FunctionsTest.cpp)

--- a/src/lib/mathlib/math/filter/MedianFilter.hpp
+++ b/src/lib/mathlib/math/filter/MedianFilter.hpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/*
+ * @file MedianFilter.hpp
+ *
+ * @brief Implementation of a median filter with C qsort.
+ *
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+namespace math
+{
+
+template<typename T, int WINDOW = 3>
+class MedianFilter
+{
+public:
+	static_assert(WINDOW >= 3, "MedianFilter window size must be >= 3");
+	static_assert(WINDOW % 2, "MedianFilter window size must be odd"); // odd
+
+	MedianFilter() = default;
+
+	void insert(const T &sample)
+	{
+		_head = (_head + 1) % WINDOW;
+		_buffer[_head] = sample;
+	}
+
+	T median()
+	{
+		T sorted[WINDOW];
+		memcpy(sorted, _buffer, sizeof(_buffer));
+		qsort(&sorted, WINDOW, sizeof(T), cmp);
+
+		return sorted[WINDOW / 2];
+	}
+
+	T apply(const T &sample)
+	{
+		insert(sample);
+		return median();
+	}
+
+private:
+
+	static int cmp(const void *a, const void *b)
+	{
+		return (*(T *)a >= *(T *)b) ? 1 : -1;
+	}
+
+	T _buffer[WINDOW] {};
+	uint8_t _head{0};
+};
+
+} // namespace math

--- a/src/lib/mathlib/math/filter/MedianFilterTest.cpp
+++ b/src/lib/mathlib/math/filter/MedianFilterTest.cpp
@@ -1,0 +1,93 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Test code for the Median filter
+ * Run this test only using make tests TESTFILTER=MedianFilter
+ */
+
+#include <gtest/gtest.h>
+#include <matrix/matrix/math.hpp>
+#include <mathlib/mathlib.h>
+
+#include "MedianFilter.hpp"
+
+using namespace math;
+using matrix::Vector3f;
+
+class MedianFilterTest : public ::testing::Test
+{
+public:
+
+
+};
+
+TEST_F(MedianFilterTest, test3f_simple)
+{
+	MedianFilter<float, 3> median_filter3;
+
+	for (int i = 0; i < 3; i++) {
+		median_filter3.insert(i);
+	}
+
+	EXPECT_EQ(median_filter3.median(), 1); // 0, 1, 2
+}
+
+TEST_F(MedianFilterTest, test3f_100)
+{
+	MedianFilter<float, 3> median_filter3;
+
+	for (int i = 0; i < 100; i++) {
+		EXPECT_EQ(median_filter3.apply(i), max(0, i - 1));
+	}
+}
+
+TEST_F(MedianFilterTest, test5u_simple)
+{
+	MedianFilter<uint16_t, 5> median_filter5;
+
+	for (int i = 0; i < 5; i++) {
+		median_filter5.insert(i);
+	}
+
+	EXPECT_EQ(median_filter5.median(), 2); // 0, 1, 2, 4, 5
+}
+
+TEST_F(MedianFilterTest, test5i_100)
+{
+	MedianFilter<uint16_t, 5> median_filter5;
+
+	for (int i = 0; i < 100; i++) {
+		EXPECT_EQ(median_filter5.apply(i), max(0, i - 2));
+	}
+}

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -49,10 +49,11 @@
 #include <px4_platform_common/time.h>
 
 #include <drivers/drv_hrt.h>
-#include <lib/sensor_calibration/Gyroscope.hpp>
-#include <lib/sensor_calibration/Utilities.hpp>
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
 #include <lib/mathlib/mathlib.h>
 #include <lib/parameters/param.h>
+#include <lib/sensor_calibration/Gyroscope.hpp>
+#include <lib/sensor_calibration/Utilities.hpp>
 #include <lib/systemlib/mavlink_log.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionBlocking.hpp>
@@ -72,21 +73,8 @@ struct gyro_worker_data_t {
 
 	Vector3f offset[MAX_GYROS] {};
 
-	static constexpr int last_num_samples = 9; ///< number of samples for the motion detection median filter
-	float last_sample_0_x[last_num_samples];
-	float last_sample_0_y[last_num_samples];
-	float last_sample_0_z[last_num_samples];
-	int last_sample_0_idx;
+	math::MedianFilter<float, 9> filter[3] {};
 };
-
-static int float_cmp(const void *elem1, const void *elem2)
-{
-	if (*(const float *)elem1 < * (const float *)elem2) {
-		return -1;
-	}
-
-	return *(const float *)elem1 > *(const float *)elem2;
-}
 
 static calibrate_return gyro_calibration_worker(gyro_worker_data_t &worker_data)
 {
@@ -104,11 +92,6 @@ static calibrate_return gyro_calibration_worker(gyro_worker_data_t &worker_data)
 		{ORB_ID(sensor_gyro), 0, 2},
 		{ORB_ID(sensor_gyro), 0, 3},
 	};
-
-	memset(&worker_data.last_sample_0_x, 0, sizeof(worker_data.last_sample_0_x));
-	memset(&worker_data.last_sample_0_y, 0, sizeof(worker_data.last_sample_0_y));
-	memset(&worker_data.last_sample_0_z, 0, sizeof(worker_data.last_sample_0_z));
-	worker_data.last_sample_0_idx = 0;
 
 	/* use slowest gyro to pace, but count correctly per-gyro for statistics */
 	unsigned slow_count = 0;
@@ -162,10 +145,9 @@ static calibrate_return gyro_calibration_worker(gyro_worker_data_t &worker_data)
 						calibration_counter[gyro_index]++;
 
 						if (gyro_index == 0) {
-							worker_data.last_sample_0_x[worker_data.last_sample_0_idx] = gyro_report.x - offset(0);
-							worker_data.last_sample_0_y[worker_data.last_sample_0_idx] = gyro_report.y - offset(1);
-							worker_data.last_sample_0_z[worker_data.last_sample_0_idx] = gyro_report.z - offset(2);
-							worker_data.last_sample_0_idx = (worker_data.last_sample_0_idx + 1) % gyro_worker_data_t::last_num_samples;
+							worker_data.filter[0].insert(gyro_report.x - offset(0));
+							worker_data.filter[1].insert(gyro_report.y - offset(1));
+							worker_data.filter[2].insert(gyro_report.z - offset(2));
 						}
 					}
 
@@ -257,13 +239,9 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 
 		} else {
 			/* check offsets using a median filter */
-			qsort(worker_data.last_sample_0_x, gyro_worker_data_t::last_num_samples, sizeof(float), float_cmp);
-			qsort(worker_data.last_sample_0_y, gyro_worker_data_t::last_num_samples, sizeof(float), float_cmp);
-			qsort(worker_data.last_sample_0_z, gyro_worker_data_t::last_num_samples, sizeof(float), float_cmp);
-
-			float xdiff = worker_data.last_sample_0_x[gyro_worker_data_t::last_num_samples / 2] - worker_data.offset[0](0);
-			float ydiff = worker_data.last_sample_0_y[gyro_worker_data_t::last_num_samples / 2] - worker_data.offset[0](1);
-			float zdiff = worker_data.last_sample_0_z[gyro_worker_data_t::last_num_samples / 2] - worker_data.offset[0](2);
+			float xdiff = worker_data.filter[0].median() - worker_data.offset[0](0);
+			float ydiff = worker_data.filter[1].median() - worker_data.offset[0](1);
+			float zdiff = worker_data.filter[2].median() - worker_data.offset[0](2);
 
 			/* maximum allowable calibration error */
 			static constexpr float maxoff = math::radians(0.6f);


### PR DESCRIPTION
This is a crude and somewhat lazy MedianFilter that I created to use in the gyro FFT module for peak detection.

There's plenty of room for improvement if anyone's interested. I initially implemented this using a sorting networks (SWAP macros) and a fixed size, but qsort was good enough for now.