### PR TITLE
FW Position controller: add option to swap throttle and pitch stick

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -261,6 +261,9 @@ private:
 	uint8_t _pos_reset_counter{0};				///< captures the number of times the estimator has reset the horizontal position
 	uint8_t _alt_reset_counter{0};				///< captures the number of times the estimator has reset the altitude state
 
+	float _manual_control_setpoint_altitude{0.0f};
+	float _manual_control_setpoint_airspeed{0.0f};
+
 	ECL_L1_Pos_Controller	_l1_control;
 	TECS			_tecs;
 
@@ -281,6 +284,7 @@ private:
 	// Update subscriptions
 	void		airspeed_poll();
 	void		control_update();
+	void 		manual_control_setpoint_poll();
 	void		vehicle_attitude_poll();
 	void		vehicle_command_poll();
 	void		vehicle_control_mode_poll();
@@ -414,6 +418,8 @@ private:
 		(ParamFloat<px4::params::FW_THR_MAX>) _param_fw_thr_max,
 		(ParamFloat<px4::params::FW_THR_MIN>) _param_fw_thr_min,
 		(ParamFloat<px4::params::FW_THR_SLEW_MAX>) _param_fw_thr_slew_max,
+
+		(ParamBool<px4::params::FW_POSCTL_INV_ST>) _param_fw_posctl_inv_st,
 
 		// external parameters
 		(ParamInt<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -724,3 +724,16 @@ PARAM_DEFINE_FLOAT(FW_T_SRATE_P, 0.02f);
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_GND_SPD_MIN, 5.0f);
+
+/**
+ * RC stick mapping fixed-wing.
+ *
+ * Set RC/joystick configuration for fixed-wing position and altitude controlled flight.
+ *
+ * @min 0
+ * @max 1
+ * @value 0 Normal stick configuration (airspeed on throttle stick, altitude on pitch stick)
+ * @value 1 Alternative stick configuration (altitude on throttle stick, airspeed on pitch stick)
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_INT32(FW_POSCTL_INV_ST, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
In manual control, a VTOL atm (in position mode) is controlled to following way:
hover:
up/down: left stick
forward/backward: right stick

fixed-wing:
up/down: right stick, while up is pulling the stick down 'towards oneself', 'pitching up'
fly faster/slower: left stick

For non-trained operators, resp. that are trained with multicopters, this is quite confusing.

**Describe your solution**
This changes the RC stick allocation for fixed-wing position and altitude controlled flight to align fixed-wing with hover controls (same sticks for going up/down (left stick) and accelerate/de-accelerate (right stick).
hover:
up/down: left stick
forward/backward: right stick

fixed-wing:
up/down: left stick, up is up
fly faster/slower: right stick

**Test data / coverage**
Testflown, felt intuitive to me, not so much to others. But the expectation is that this change is more intuitive for non-trained pilots, or people that are used to flying multicopters.  
