### PR TITLE
Fixed-wing position control: remove manually triggered climbout mode 

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -447,7 +447,7 @@ FixedwingPositionControl::get_terrain_altitude_takeoff(float takeoff_alt)
 	return takeoff_alt;
 }
 
-bool
+void
 FixedwingPositionControl::update_desired_altitude(float dt)
 {
 	/*
@@ -462,9 +462,6 @@ FixedwingPositionControl::update_desired_altitude(float dt)
 	 * due to the deadband
 	 */
 	const float factor = 1.0f - deadBand;
-
-	/* Climbout mode sets maximum throttle and pitch up */
-	bool climbout_mode = false;
 
 	/*
 	 * Reset the hold altitude to the current altitude if the uncertainty
@@ -494,7 +491,6 @@ FixedwingPositionControl::update_desired_altitude(float dt)
 		float pitch = -(_manual_control_setpoint.x + deadBand) / factor;
 		_hold_alt += (_param_fw_t_clmb_max.get() * dt) * pitch;
 		_was_in_deadband = false;
-		climbout_mode = (pitch > MANUAL_THROTTLE_CLIMBOUT_THRESH);
 
 	} else if (!_was_in_deadband) {
 		/* store altitude at which manual.x was inside deadBand
@@ -511,7 +507,6 @@ FixedwingPositionControl::update_desired_altitude(float dt)
 		}
 	}
 
-	return climbout_mode;
 }
 
 bool
@@ -916,7 +911,7 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 		float altctrl_airspeed = get_demanded_airspeed();
 
 		/* update desired altitude based on user pitch stick input */
-		bool climbout_requested = update_desired_altitude(dt);
+		update_desired_altitude(dt);
 
 		// if we assume that user is taking off then help by demanding altitude setpoint well above ground
 		// and set limit to pitch angle to prevent steering into ground
@@ -938,8 +933,8 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 					   _param_fw_thr_min.get(),
 					   throttle_max,
 					   _param_fw_thr_cruise.get(),
-					   climbout_requested,
-					   climbout_requested ? radians(10.0f) : pitch_limit_min,
+					   false,
+					   pitch_limit_min,
 					   tecs_status_s::TECS_MODE_NORMAL);
 
 		/* heading control */
@@ -1018,7 +1013,7 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 		float altctrl_airspeed = get_demanded_airspeed();
 
 		/* update desired altitude based on user pitch stick input */
-		bool climbout_requested = update_desired_altitude(dt);
+		update_desired_altitude(dt);
 
 		// if we assume that user is taking off then help by demanding altitude setpoint well above ground
 		// and set limit to pitch angle to prevent steering into ground
@@ -1040,8 +1035,8 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 					   _param_fw_thr_min.get(),
 					   throttle_max,
 					   _param_fw_thr_cruise.get(),
-					   climbout_requested,
-					   climbout_requested ? radians(10.0f) : pitch_limit_min,
+					   false,
+					   pitch_limit_min,
 					   tecs_status_s::TECS_MODE_NORMAL);
 
 		_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -121,8 +121,6 @@ static constexpr hrt_abstime T_ALT_TIMEOUT = 1_s; // time after which we abort l
 
 static constexpr float THROTTLE_THRESH =
 	0.05f;	///< max throttle from user which will not lead to motors spinning up in altitude controlled modes
-static constexpr float MANUAL_THROTTLE_CLIMBOUT_THRESH =
-	0.85f; ///< a throttle / pitch input above this value leads to the system switching to climbout mode
 static constexpr float ALTHOLD_EPV_RESET_THRESH = 5.0f;
 
 class FixedwingPositionControl final : public ModuleBase<FixedwingPositionControl>, public ModuleParams,
@@ -324,9 +322,8 @@ private:
 	 * Update desired altitude base on user pitch stick input
 	 *
 	 * @param dt Time step
-	 * @return true if climbout mode was requested by user (climb with max rate and min airspeed)
 	 */
-	bool		update_desired_altitude(float dt);
+	void		update_desired_altitude(float dt);
 
 	bool		control_position(const hrt_abstime &now, const Vector2f &curr_pos, const Vector2f &ground_speed,
 					 const position_setpoint_s &pos_sp_prev,


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, there is a hard-coded limit of 85% on the pitch stick (pulling) setpoint that triggers the climbout mode when flying in fixed-wing position or altitude controlled mode. The vehicle will then give max throttle and try to climb as fast as physics allow. 
This prevents a precise, but still dynamic control of the vehicle, as it is impossible to climb fast without entering the climbout mode, that was (I believe) originally implemented rather as a safety feature. 

**Describe your solution**
~Add parameter to disable climbout mode via sticks (boolean).~
Remove the manually triggered climbout mode (pitch stick below 85% in altitude/position controlled flight). 
Note that this doesn't have any impact on the automatically triggered climbouts during fixed-wing handlaunch or runway takeoff. 

**Describe possible alternatives**
- ~Instead of a boolean "climbout enabled" the parameter could be a float, specifying the threshold where the climbout mode is entered (currently that would be 0.85).~
- We could also change the trigger for the climbout: Instead of only pulling on the throttle stick, the user would have to push the airspeed stick to the maximum for example. Then the user could still climb fast without entering climbout mode if he wants that.

**Test data / coverage**
Flight tested, felt much nicer, especially on vehicles with a lot of excessive power (e.g. tiltrotor).

