### PR TITLE
FW Position Control: remove duplicated position_sp_triplet update

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1683,7 +1683,6 @@ FixedwingPositionControl::Run()
 		}
 
 		manual_control_setpoint_poll();
-		_pos_sp_triplet_sub.update(&_pos_sp_triplet);
 		vehicle_attitude_poll();
 		vehicle_command_poll();
 		vehicle_control_mode_poll();


### PR DESCRIPTION
This removes a duplicated update of `_pos_sp_triplet_sub` that slipped in with https://github.com/PX4/PX4-Autopilot/pull/16104