### PR TITLE
Add tiltrotor model to SITL testing

### DIFF
--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -21,6 +21,12 @@
             "vehicle": "tailsitter",
             "test_filter": "[multicopter][vtol]",
             "timeout_min": 10
+        },
+        {
+            "model": "tiltrotor",
+            "vehicle": "tiltrotor",
+            "test_filter": "[multicopter][vtol]",
+            "timeout_min": 10
         }
     ]
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
The tiltrotor model has been excluded from SITL testing, therefore wasn't being verified with firmware changes.

The tiltrotor model is a quad plane model, which the motors tilt forward for fixedwing flight. 

**Describe your solution**
This adds the tiltrotor model to SITL testing

**Test data / coverage**

**Additional context**
- This is a follow PR of #16078 where the tailsitter VTOL model was added to testing
- This only includes multicopter and VTOL testing