### PR TITLE
Add support for alpha/beta/rc on the vendor version

### DIFF
--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -47,7 +47,8 @@ if validate:
     # remove optional -<num_commits>-g<commit_hash> at the end (in case we are not on a tagged commit)
     git_tag_test = re.sub(r'-[0-9]+-g[0-9a-fA-F]+$', '', git_tag_test)
     # now check the version format
-    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+([-]?rc[0-9]+)?(-beta[0-9]+)?(-[0-9]+\.[0-9]+\.[0-9]+)?$', git_tag_test)
+    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+(-dev)?(-alpha[0-9]+)?(-beta[0-9]+)?(-rc[0-9]+)?'\
+                 r'(-[0-9]+\.[0-9]+\.[0-9]+(-dev)?(-alpha[0-9]+)?(-beta[0-9]+)?([-]?rc[0-9]+)?)?$', git_tag_test)
     if m:
         # format matches, check the major and minor numbers
         major = int(m.group(1))
@@ -63,13 +64,13 @@ if validate:
         print("Error: the git tag '{:}' does not match the expected format.".format(git_tag_test))
         print("")
         print("The expected format is 'v<PX4 version>[-<custom version>]'")
-        print("  <PX4 version>: v<major>.<minor>.<patch>[-rc<rc>|-beta<beta>]")
-        print("  <custom version>: <major>.<minor>.<patch>")
+        print("  <PX4 version>: v<major>.<minor>.<patch>[-rc<rc>|-beta<beta>|-alpha<alpha>|-dev]")
+        print("  <custom version>: <major>.<minor>.<patch>[-rc<rc>|-beta<beta>|-alpha<alpha>|-dev]")
         print("Examples:")
-        print("  v1.9.0rc3 (deprecated)")
         print("  v1.9.0-rc3 (preferred)")
         print("  v1.9.0-beta1")
         print("  v1.9.0-1.0.0")
+        print("  v1.9.0-1.0.0-alpha2")
         print("See also https://dev.px4.io/master/en/setup/building_px4.html#firmware_version")
         print("")
         sys.exit(1)

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -47,8 +47,8 @@ if validate:
     # remove optional -<num_commits>-g<commit_hash> at the end (in case we are not on a tagged commit)
     git_tag_test = re.sub(r'-[0-9]+-g[0-9a-fA-F]+$', '', git_tag_test)
     # now check the version format
-    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+(-dev)?(-alpha[0-9]+)?(-beta[0-9]+)?(-rc[0-9]+)?'\
-                 r'(-[0-9]+\.[0-9]+\.[0-9]+(-dev)?(-alpha[0-9]+)?(-beta[0-9]+)?([-]?rc[0-9]+)?)?$', git_tag_test)
+    m = re.match(r'v([0-9]+)\.([0-9]+)\.[0-9]+(((-dev)|(-alpha[0-9]+)|(-beta[0-9]+)|(-rc[0-9]+))|'\
+                 r'(-[0-9]+\.[0-9]+\.[0-9]+((-dev)|(-alpha[0-9]+)|(-beta[0-9]+)|([-]?rc[0-9]+))?))?$', git_tag_test)
     if m:
         # format matches, check the major and minor numbers
         major = int(m.group(1))

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -159,6 +159,9 @@ bool VersioningTest::run_tests()
 	ut_assert_true(_test_tag_to_version_number("v1.8.2dev4-dirty", 					0x01080200, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("v1.8.2dev4-67-g1d5e979-dirty", 		0x01080200, 0x00000000));
 
+	//TODO: fix me, this is unexpected behavior
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-rc2-1.2.3-rc3", 				0x01060200, 0x00000000));
+
 	return (_tests_failed == 0);
 }
 


### PR DESCRIPTION
Support for alpha/beta/rc on the vendor version is part of the actual parser, but is disallowed by the regex in the build scripts. This adds support for alpha/beta/rc on the vendor version by changing the regex.

Additionally, this allows the -dev suffix, for anybody who needs to use it.

I tested this on the test data for the parser (hooray for test data), and it all seems to make sense:
![image](https://user-images.githubusercontent.com/1746276/98012938-fafed900-1df9-11eb-81c4-72d3174368c1.png)
