### PR TITLE
module markdownout - explicit anchor not heading

### DIFF
--- a/Tools/px4moduledoc/markdownout.py
+++ b/Tools/px4moduledoc/markdownout.py
@@ -72,7 +72,7 @@ The generated files will be written to the `modules` directory.
                 result += "%s\n" % doc
             usage_string = module.usage_string()
             if len(usage_string) > 0:
-                result += "### Usage {#%s_usage}\n```\n%s\n```\n" % (module.name(), usage_string)
+                result += '<a id="%s_usage"></a>\n### Usage\n```\n%s\n```\n' % (module.name(), usage_string)
         return result
 
     def Save(self, dirname):


### PR DESCRIPTION
@bkueng Unfortunately Vuepress can't process explicit anchors in the heading like `## Usage {#thingy_usage}` so this changes the output to:
```
<a id="thingy_usage"></a>
## Usage
```

Because Vuepress is smarter at linking to a heading might be better to change as below?
```
## Usage (Thingy)
```
Thoughts? It will make the docs look a bit ugly. UP to you - just check and merge if you prefer what I have done.

![image](https://user-images.githubusercontent.com/5368500/98209963-e8b8a280-1f93-11eb-90ac-245590c9d280.png)


