### PR TITLE
Fix non-determinstic boot hang with crashdumps

### DIFF
--- a/platforms/nuttx/src/px4/common/board_crashdump.c
+++ b/platforms/nuttx/src/px4/common/board_crashdump.c
@@ -130,7 +130,7 @@ int board_hardfault_init(int display_to_console, bool allow_prompt)
 
 		/* Also end the misery for a user that holds for a key down on the console */
 
-		int bytesWaiting;
+		int bytesWaiting = 0;
 		ioctl(fileno(stdin), FIONREAD, (unsigned long)((uintptr_t) &bytesWaiting));
 
 		if (reboots > display_to_console || bytesWaiting != 0) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
Sometimes my FCU would hang on boot, before the boot tune but after the bootloader.
On boot, if board_hardfault_init finds a hardfault stored in BBSRAM, it
checks if there is any data available on stdin to see if there is
somebody there to respond to a prompt. But on boards such as cubeorange
where there is not a serial console by default, the ioctl fails and
`bytesWaiting` is uninitialized. So it will non-deterministally hang the
boot process with no outside feedback if that value is not zero.

**Describe your solution**
Initialize `bytesWaiting`

**Describe possible alternatives**
N/A

**Test data / coverage**
I have tested this and it fixed my boot hang.

