### PR TITLE
Fix for missing battery voltage from UAVCAN power modules

### DIFF
--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -95,7 +95,12 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	battery.serial_number = msg.model_instance_id;
 	battery.id = msg.getSrcNodeID().get();
 
-	// battery.voltage_cell_v[0] = msg.;
+	// Mavlink 2 needs individual cell voltages or cell[0] if cell voltages are not available.
+	battery.voltage_cell_v[0] = msg.voltage;
+
+	// Set cell count to 1 so the the battery code in mavlink_messages.cpp copies the values correctly (hack?)
+	battery.cell_count = 1;
+	
 	// battery.max_cell_voltage_delta = msg.;
 
 	// battery.is_powering_off = msg.;

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -100,7 +100,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 
 	// Set cell count to 1 so the the battery code in mavlink_messages.cpp copies the values correctly (hack?)
 	battery.cell_count = 1;
-	
+
 	// battery.max_cell_voltage_delta = msg.;
 
 	// battery.is_powering_off = msg.;


### PR DESCRIPTION
**Describe problem solved by this pull request**
It seems that battery.voltage_* is no longer used and QGC is getting voltage data from the cell voltage array instead.

**Describe your solution**
MAVLINK 2 requires that if no cell voltage information is available the total voltage is written into the first array element of the voltages array in the battery_status message. This solution writes the voltage data into the first element of the voltages array. 