### PR TITLE
systemcmds/topic_listener: remove excludes

### DIFF
--- a/src/systemcmds/topic_listener/generate_listener.py
+++ b/src/systemcmds/topic_listener/generate_listener.py
@@ -12,9 +12,6 @@ import re
 
 raw_messages = sys.argv[2:]
 
-# large and not worth printing
-raw_messages = [x for x in raw_messages if not any(exception in x for exception in ['qshell_req', 'ulog_stream', 'gps_inject_data', 'gps_dump'])]
-
 messages = []
 topics = []
 message_elements = []


### PR DESCRIPTION
This is a bit wasteful, but we can afford it for now everywhere listener is enabled. The message print helpers can be rewritten as a common function that prints using the msg o_fields we already store for logger, and save about 70 kB of flash in the process.

 - fixes https://github.com/PX4/PX4-Autopilot/issues/16135