### PR TITLE
vscode add navio2 variant and native debug launch

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -86,6 +86,11 @@ CONFIG:
       buildType: MinSizeRel
       settings:
         CONFIG: cubepilot_cubeyellow_default
+    emlid_navio2_default:
+      short: emlid_navio2
+      buildType: MinSizeRel
+      settings:
+        CONFIG: emlid_navio2_default
     holybro_durandal-v1_default:
       short: holybro_durandal-v1
       buildType: MinSizeRel

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -115,7 +115,17 @@ if("${PX4_BOARD}" MATCHES "beaglebone_blue")
 elseif("${PX4_BOARD}" MATCHES "emlid_navio2")
 	target_link_libraries(px4 PRIVATE atomic)
 
+	# vscode launch.json
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_rpi.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
+
 elseif("${PX4_BOARD}" MATCHES "sitl")
+
+	# vscode launch.json
+	if(${PX4_BOARD_LABEL} MATCHES "replay")
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_replay.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
+	else()
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_sim.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
+	endif()
 
 	include(sitl_target)
 	if(BUILD_TESTING)

--- a/platforms/posix/Debug/launch_rpi.json.in
+++ b/platforms/posix/Debug/launch_rpi.json.in
@@ -1,0 +1,33 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PX4 posix-configs/rpi/px4.config",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${command:cmake.launchTargetPath}",
+            "args": [
+                "-s", "../../posix-configs/rpi/px4.config"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${command:cmake.buildDirectory}",
+            "externalConsole": false,
+            "linux": {
+                "MIMode": "gdb",
+                "externalConsole": false,
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "PX4 ignore wq signals",
+                        "text": "handle SIGCONT nostop noprint nopass",
+                        "ignoreFailures": true
+                    }
+                ]
+            }
+        },
+    ]
+}

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -288,10 +288,3 @@ add_custom_target(list_vmd_make_targets
 	COMMENT "List of acceptable '${PX4_BOARD}' <viewer_model_debugger> targets:"
 	VERBATIM
 	)
-
-# vscode launch.json
-if(${PX4_BOARD_LABEL} MATCHES "replay")
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_replay.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
-else()
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/launch_sim.json.in ${PX4_SOURCE_DIR}/.vscode/launch.json COPYONLY)
-endif()


### PR DESCRIPTION
This adds some basic VScode support for Emlid Navio2 PX4 development.

You can use this to develop and debug directly on a Raspberry pi from VSCode running anywhere. The initial compile is a little slow, but with ccache working it actually becomes quite tolerable. Debugging in place is very useful.

![Screenshot from 2020-11-10 09-42-35](https://user-images.githubusercontent.com/84712/98688661-16f20580-2339-11eb-886a-a3ff67cab70d.png)

FYI @blazczak @SalimTerryLi 



