### PR TITLE
Github Actions: break up MAVSDK SITL tests

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo"} # Alaska
-          - {latitude: "-38.071235", longitude:  "145.281220", altitude:  "31", build_type: "RelWithDebInfo"} # Australia
-          - {latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo"} # Florida
-          - {latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage"} # Zurich
+          - {latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo", model: "iris"          } # Alaska
+          - {latitude: "-38.071235", longitude:  "145.281220", altitude:  "31", build_type: "RelWithDebInfo", model: "standard_vtol" } # Australia
+          - {latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo", model: "tailsitter"    } # Florida
+          - {latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage",       model: "standard_vtol" } # Zurich
     container:
       image: px4io/px4-dev-simulation-focal:2020-08-14
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
@@ -92,7 +92,7 @@ jobs:
         PX4_HOME_LON: ${{matrix.config.longitude}}
         PX4_HOME_ALT: ${{matrix.config.altitude}}
         PX4_CMAKE_BUILD_TYPE: ${{matrix.config.build_type}}
-      run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early test/mavsdk_tests/configs/sitl.json
+      run: test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early --model ${{matrix.config.model}} test/mavsdk_tests/configs/sitl.json
 
     - name: Look at core files
       if: failure()


### PR DESCRIPTION
Running all vehicle types at 4 different locations is a bit too slow on Github actions. This breaks it up to dedicate each Github Actions runner to 1 vehicle type.
