### PR TITLE
cmake: NuttX apps build updates

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -272,7 +272,7 @@ add_custom_target(nuttx_builtin_list_target DEPENDS ${nuttx_builtin_list})
 # APPS
 
 # libapps.a
-add_custom_command(OUTPUT ${APPS_DIR}/libapps.a ${APPS_DIR}/platform/.built
+add_custom_command(OUTPUT ${APPS_DIR}/libapps.a
 	COMMAND find ${APPS_DIR} -name \*.o -delete
 	COMMAND make ${nuttx_build_options} --no-print-directory TOPDIR="${NUTTX_DIR}" > nuttx_apps.log
 	DEPENDS


### PR DESCRIPTION
 - NuttX Apps no longer generates the .built file
 - fixes https://github.com/PX4/PX4-Autopilot/issues/16162