### PR TITLE
mavsdk_tests: relax corridor radius default for missions

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -461,14 +461,14 @@ void AutopilotTester::fly_forward_in_posctl()
 		std::this_thread::sleep_for(adjust_to_lockstep_speed(std::chrono::milliseconds(1000 / manual_control_rate_hz)));
 	}
 
-	// Fly forward for 30 seconds
-	for (unsigned i = 0; i < 30 * manual_control_rate_hz; ++i) {
+	// Fly forward for 60 seconds
+	for (unsigned i = 0; i < 60 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.5f, 0.f, 0.5f, 0.f) == ManualControl::Result::Success);
 		std::this_thread::sleep_for(adjust_to_lockstep_speed(std::chrono::milliseconds(1000 / manual_control_rate_hz)));
 	}
 
 	// Descend until disarmed
-	for (unsigned i = 0; i < 30 * manual_control_rate_hz; ++i) {
+	for (unsigned i = 0; i < 60 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.f, 0.f, 0.0f, 0.f) == ManualControl::Result::Success);
 		std::this_thread::sleep_for(adjust_to_lockstep_speed(std::chrono::milliseconds(1000 / manual_control_rate_hz)));
 
@@ -496,14 +496,14 @@ void AutopilotTester::fly_forward_in_altctl()
 		std::this_thread::sleep_for(adjust_to_lockstep_speed(std::chrono::milliseconds(1000 / manual_control_rate_hz)));
 	}
 
-	// Fly forward for 30 seconds
-	for (unsigned i = 0; i < 30 * manual_control_rate_hz; ++i) {
+	// Fly forward for 60 seconds
+	for (unsigned i = 0; i < 60 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.5f, 0.f, 0.5f, 0.f) == ManualControl::Result::Success);
 		std::this_thread::sleep_for(adjust_to_lockstep_speed(std::chrono::milliseconds(1000 / manual_control_rate_hz)));
 	}
 
 	// Descend until disarmed
-	for (unsigned i = 0; i < 30 * manual_control_rate_hz; ++i) {
+	for (unsigned i = 0; i < 60 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.f, 0.f, 0.0f, 0.f) == ManualControl::Result::Success);
 		std::this_thread::sleep_for(adjust_to_lockstep_speed(std::chrono::milliseconds(1000 / manual_control_rate_hz)));
 

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -100,7 +100,7 @@ public:
 	void fly_forward_in_altctl();
 	void request_ground_truth();
 	void check_mission_item_speed_above(int item_index, float min_speed_m_s);
-	void check_tracks_mission(float corridor_radius_m = 1.0f);
+	void check_tracks_mission(float corridor_radius_m = 1.5f);
 
 
 private:


### PR DESCRIPTION
In MAVSDK SITL tests tailsitter is occasionally just outside of the 1 meter threshold.

![Screenshot from 2020-11-11 10-04-25](https://user-images.githubusercontent.com/84712/98827828-4ec67f00-2405-11eb-8f7f-4c2c1a44a1a8.png)

https://logs.px4.io/plot_app?log=0db3be38-b42f-4e29-b2ab-c249062a2c3a

![Screenshot from 2020-11-11 10-05-03](https://user-images.githubusercontent.com/84712/98827915-669e0300-2405-11eb-9ddd-8138f2965235.png)
