### PR TITLE
ROMFS: startup remove bootlog.txt

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -22,7 +22,6 @@ fi
 # initialize script variables
 set AUX_MODE                    none
 set IO_PRESENT                  no
-set LOG_FILE                    bootlog.txt
 set MAV_TYPE                    none
 set MIXER                       none
 set MIXER_AUX                   none
@@ -52,10 +51,6 @@ else
 		echo "Info: found model autostart file as SYS_AUTOSTART=$REQUESTED_AUTOSTART"
 	fi
 fi
-
-# clear bootlog
-[ -f $LOG_FILE ] && rm $LOG_FILE
-
 
 uorb start
 

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -93,7 +93,7 @@ then
 	then
 		if ! $OUTPUT_CMD mode_$FMU_MODE
 		then
-			echo "$OUTPUT_CMD start failed" >> $LOG_FILE
+			echo "$OUTPUT_CMD start failed"
 			tune_control play error
 		fi
 	fi
@@ -172,7 +172,6 @@ then
 		echo "INFO  [init] Mixer: ${MIXER_FILE} on ${OUTPUT_DEV}"
 	else
 		echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}"
-		echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}" >> $LOG_FILE
 		tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 	fi
 
@@ -180,7 +179,6 @@ else
 	if [ $MIXER != skip ]
 	then
 		echo "ERROR  [init] Mixer undefined"
-		echo "ERROR  [init] Mixer undefined" >> $LOG_FILE
 		tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 	fi
 fi
@@ -213,7 +211,6 @@ then
 					echo "INFO  [init] Mixer: ${MIXER_AUX_FILE} appended to ${OUTPUT_DEV}"
 				else
 					echo "ERROR  [init] Failed appending mixer: ${MIXER_AUX_FILE}"
-					echo "ERROR  [init] Failed appending mixer: ${MIXER_AUX_FILE}" >> $LOG_FILE
 				fi
 			fi
 			if [ -e $OUTPUT_AUX_DEV -a $OUTPUT_MODE != hil ]
@@ -223,14 +220,13 @@ then
 					echo "INFO  [init] Mixer: ${MIXER_AUX_FILE} on ${OUTPUT_AUX_DEV}"
 				else
 					echo "ERROR  [init] Failed loading mixer: ${MIXER_AUX_FILE}"
-					echo "ERROR  [init] Failed loading mixer: ${MIXER_AUX_FILE}" >> $LOG_FILE
 				fi
 			else
 				set PWM_AUX_OUT none
 				set FAILSAFE_AUX none
 			fi
 		else
-			echo "ERROR: Could not start: pwm_out mode_pwm" >> $LOG_FILE
+			echo "ERROR: Could not start: pwm_out mode_pwm"
 			tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 			set PWM_AUX_OUT none
 			set FAILSAFE_AUX none

--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -17,7 +17,7 @@ then
 		# Allow PX4IO to recover from midair restarts.
 		px4io recovery
 	else
-		echo "PX4IO start failed" >> $LOG_FILE
+		echo "PX4IO start failed"
 		tune_control play -t 18 # PROG_PX4IO_ERR
 	fi
 fi

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -32,7 +32,6 @@ set FMU_MODE pwm
 set FRC /fs/microsd/etc/rc.txt
 set IOFW "/etc/extras/px4_io-v2_default.bin"
 set IO_PRESENT no
-set LOG_FILE /fs/microsd/bootlog.txt
 set LOGGER_ARGS ""
 set LOGGER_BUF  14
 set MAV_TYPE none
@@ -140,10 +139,7 @@ else
 		else
 			set STARTUP_TUNE 15 # tune 15 = SD_ERROR
 			echo "ERROR [init] format failed"
-			set LOG_FILE /dev/null
 		fi
-	else
-		set LOG_FILE /dev/null
 	fi
 fi
 
@@ -313,7 +309,7 @@ else
 					tune_control stop
 					if px4io checkcrc ${IOFW}
 					then
-						echo "PX4IO CRC OK after updating" >> $LOG_FILE
+						echo "PX4IO CRC OK after updating"
 						tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
 						set IO_PRESENT yes
 					fi
@@ -321,7 +317,7 @@ else
 
 				if [ $IO_PRESENT = no ]
 				then
-					echo "PX4IO update failed" >> $LOG_FILE
+					echo "PX4IO update failed"
 					tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 				fi
 			fi
@@ -338,7 +334,7 @@ else
 
 	if [ $USE_IO = yes -a $IO_PRESENT = no ]
 	then
-		echo "PX4IO not found" >> $LOG_FILE
+		echo "PX4IO not found"
 		tune_control play error
 	fi
 
@@ -593,7 +589,6 @@ unset FMU_MODE
 unset FRC
 unset IO_PRESENT
 unset IOFW
-unset LOG_FILE
 unset LOGGER_ARGS
 unset LOGGER_BUF
 unset MAV_TYPE


### PR DESCRIPTION
The bootlog could be useful, but our usage is inconsistent and only a small portion of startup errors are captured. We have a few cases that log to both the console and bootlog, some only to the bootlog, and the majority that doesn't go to bootlog at all.

I propose purging the existing bootlog.txt and work towards better mechanisms for getting this information out to users (mavlink most of the time).