### PR TITLE
FW Position Control: re-add wrongly removed airspeed_poll()

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1682,6 +1682,7 @@ FixedwingPositionControl::Run()
 			_min_current_sp_distance_xy = FLT_MAX;
 		}
 
+		airspeed_poll();
 		manual_control_setpoint_poll();
 		vehicle_attitude_poll();
 		vehicle_command_poll();


### PR DESCRIPTION
**Describe problem solved by this pull request**
With https://github.com/PX4/PX4-Autopilot/pull/16104/commits/574c7c5d90e328fb8eea0dda1a93353a660dfdee the airspeed_poll() was wrongly removed from the fixed-wing position controller. This PR reverts that.

**Test data / coverage**
SITL tested.
