### PR TITLE
mavlink: STATUSTEXT check TX buffer before sending

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -508,9 +508,9 @@ protected:
 
 	bool send() override
 	{
-		if (!_mavlink->get_logbuffer()->empty() && _mavlink->is_connected()) {
+		if (!_mavlink->get_logbuffer()->empty() && _mavlink->is_connected() && _mavlink->get_free_tx_buf() >= get_size()) {
 
-			mavlink_log_s mavlink_log{};
+			mavlink_log_s mavlink_log;
 
 			if (_mavlink->get_logbuffer()->get(&mavlink_log)) {
 


### PR DESCRIPTION
Theoretically could help with calibration (https://github.com/PX4/PX4-Autopilot/pull/16166), but should be harmless regardless.