### PR TITLE
[1.11] PX4 compile flags: disable Wlogical-op for GCC 10

### DIFF
--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -89,6 +89,7 @@ function(px4_add_common_flags)
 		-Wno-missing-field-initializers
 		-Wno-missing-include-dirs # TODO: fix and enable
 		-Wno-unused-parameter
+		-Wno-logical-op # to compile 1.11 release on GCC 10 see https://github.com/PX4/PX4-Matrix/pull/146
 		)
 
 	# compiler specific flags


### PR DESCRIPTION
**Describe problem solved by this pull request**
See https://github.com/PX4/PX4-Matrix/pull/146

There is a proper fix for this already on master
but it's a rabbit hole to cherry-pick it:
-> update matrix
-> dependency on changing ecl
-> dependency on a lot of autopilot changes

**Describe your solution**
Disable Wlogical-op since the warning did not exist before.

**Test data / coverage**
Using this backported for months now. Since Arch updated to GCC 10.
