### PR TITLE
boards: cubepilot orange and yellow start icm20602 IMU first

### DIFF
--- a/boards/cubepilot/cubeorange/init/rc.board_sensors
+++ b/boards/cubepilot/cubeorange/init/rc.board_sensors
@@ -4,14 +4,14 @@
 #------------------------------------------------------------------------------
 board_adc start
 
-# SPI1
-ms5611 -s -b 1 start
-icm20649 -s -b 1 start
-
 # SPI4
 ms5611 -s -b 4 start
 icm20602 -s -b 4 -R 12 start
 icm20948 -s -b 4 -R 10 -M start
+
+# SPI1
+ms5611 -s -b 1 start
+icm20649 -s -b 1 start
 
 # standard Here/Here2 connected to GPS1
 ak09916 -X -b 1 -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw

--- a/boards/cubepilot/cubeyellow/init/rc.board_sensors
+++ b/boards/cubepilot/cubeyellow/init/rc.board_sensors
@@ -4,14 +4,14 @@
 #------------------------------------------------------------------------------
 board_adc start
 
-# SPI1
-ms5611 -s -b 1 start
-icm20649 -s -b 1 start
-
 # SPI4
 ms5611 -s -b 4 start
 icm20602 -s -b 4 -R 12 start
 icm20948 -s -b 4 -R 10 -M start
+
+# SPI1
+ms5611 -s -b 1 start
+icm20649 -s -b 1 start
 
 # standard Here/Here2 connected to GPS1
 ak09916 -X -b 1 -R 6 start # external AK09916 (Here2) is rotated 270 degrees yaw


### PR DESCRIPTION
Quick solution to https://github.com/PX4/PX4-Autopilot/issues/16194.

The isolated sensors are on SPI4, but by default we end up using the non-isolated sensors on SPI1 simply because they're started first.

This will probably be one of the first boards where multi-EKF will be enabled by default, but for the startup order is quite important.