### PR TITLE
mavsdk_tests: adjust px4 and gzserver priority relative to mavsdk_test

### DIFF
--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -203,8 +203,9 @@ class GzserverRunner(Runner):
         self.env["GAZEBO_MODEL_PATH"] = \
             workspace_dir + "/Tools/sitl_gazebo/models"
         self.env["PX4_SIM_SPEED_FACTOR"] = str(speed_factor)
-        self.cmd = "gzserver"
-        self.args = ["--verbose",
+        self.cmd = "nice"
+        self.args = ["-n 1",
+                     "gzserver", "--verbose",
                      workspace_dir + "/Tools/sitl_gazebo/worlds/" +
                      "empty.world"]
 

--- a/test/mavsdk_tests/test_multicopter_failsafe.cpp
+++ b/test/mavsdk_tests/test_multicopter_failsafe.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Land on GPS lost during mission (baro height mode)", "[multicopter][v
 	tester.prepare_square_mission(mission_options);
 	tester.arm();
 	tester.execute_mission_and_lose_gps();
-	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(90);
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 }
 
@@ -64,7 +64,7 @@ TEST_CASE("Land on GPS lost during mission (GPS height mode)", "[multicopter][vt
 	tester.prepare_square_mission(mission_options);
 	tester.arm();
 	tester.execute_mission_and_lose_gps();
-	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(90);
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 }
 

--- a/test/mavsdk_tests/test_multicopter_manual.cpp
+++ b/test/mavsdk_tests/test_multicopter_manual.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Fly forward in position control", "[multicopter][vtol]")
 	tester.store_home();
 	tester.arm();
 	tester.fly_forward_in_posctl();
-	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(90);
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 	tester.check_home_not_within(5.f);
 }
@@ -55,7 +55,7 @@ TEST_CASE("Fly forward in altitude control", "[multicopter][vtol]")
 	tester.store_home();
 	tester.arm();
 	tester.fly_forward_in_altctl();
-	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(90);
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 	tester.check_home_not_within(5.f);
 }

--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Takeoff and Land", "[multicopter][vtol]")
 	tester.takeoff();
 	tester.wait_until_hovering();
 	tester.land();
-	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(30);
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 }
 
@@ -97,6 +97,6 @@ TEST_CASE("Fly straight Multicopter Mission", "[multicopter]")
 	tester.execute_mission();
 	tester.wait_until_hovering();
 	tester.execute_rtl();
-	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(120);
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 }


### PR DESCRIPTION
This is an experiment to hunt down one of the remaining MAVSDK test intermittent failures.
