### PR TITLE
Tools/setup: requirments add pymavlink

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -11,6 +11,7 @@ pandas>=0.21
 pkgconfig
 psutil
 pygments
+pymavlink
 pyros-genmsg
 pyserial>=3.0
 pyulog>=0.5.0


### PR DESCRIPTION
Needed for `./Tools/mavlink_shell.py`.