### PR TITLE
Add typhoon h480 support to gazebo multiple sim

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -16,7 +16,7 @@ function spawn_model() {
 	MODEL=$1
 	N=$2 #Instance Number
 
-	SUPPORTED_MODELS=("iris" "iris_rtps" "plane" "standard_vtol" "rover" "r1_rover")
+	SUPPORTED_MODELS=("iris" "iris_rtps" "plane" "standard_vtol" "rover" "r1_rover" "typhoon_h480")
 	if [[ " ${SUPPORTED_MODELS[*]} " != *"$MODEL "* ]];
 	then
 		echo "ERROR: Currently only vehicle model $MODEL is not supported!"


### PR DESCRIPTION
This commit adds support for the typhoon_h480 model for the gazebo_sitl_multiple_run.sh script. This will allow multiple typhoon_h480 models to run in the simulator at the same time.

Literally just adds typhoon_h480 to SUPPORTED_MODELS.

Depends on [this sitl_gazebo PR](https://github.com/PX4/PX4-SITL_gazebo/pull/655) being merged.