### PR TITLE
WIP for discussion mtd to be started from board level.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -153,9 +153,10 @@ then
 else
 
 	#
-	# Set the parameter file if mtd starts successfully.
+	# Set the parameter file the board supports params on
+	# MTD device.
 	#
-	if mtd start
+	if mft query -q -k MTD -s MTD_PARAMETERS -v /fs/mtd_params
 	then
 		set PARAM_FILE /fs/mtd_params
 	fi
@@ -163,13 +164,10 @@ else
 	#
 	# Load parameters.
 	#
-	# if MTD has a secondary storage it is used for (factory) calibration data
-	if mtd has-secondary
+	# if the board has a storage for (factory) calibration data
+	if mft query -q -k MTD -s MTD_CALDATA -v /fs/mtd_caldata
 	then
-		if mtd start -i 1 /fs/mtd_caldata
-		then
-			param load /fs/mtd_caldata
-		fi
+		param load /fs/mtd_caldata
 	fi
 
 	param select $PARAM_FILE

--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -87,6 +87,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/airmind/mindpx-v2/src/init.c
+++ b/boards/airmind/mindpx-v2/src/init.c
@@ -307,5 +307,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/av/x-v1/src/init.c
+++ b/boards/av/x-v1/src/init.c
@@ -192,6 +192,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	configure_switch();
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }
 

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -43,6 +43,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/bitcraze/crazyflie/nuttx-config/scripts/script.ld
+++ b/boards/bitcraze/crazyflie/nuttx-config/scripts/script.ld
@@ -64,6 +64,7 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
+EXTERN(board_get_manifest)
 
 SECTIONS
 {

--- a/boards/bitcraze/crazyflie/src/CMakeLists.txt
+++ b/boards/bitcraze/crazyflie/src/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(drivers_board
 	i2c.cpp
 	init.c
 	led.c
+	mtd.cpp
 	spi.cpp
 	timer_config.cpp
 	usb.c

--- a/boards/bitcraze/crazyflie/src/init.c
+++ b/boards/bitcraze/crazyflie/src/init.c
@@ -169,5 +169,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/bitcraze/crazyflie/src/mtd.cpp
+++ b/boards/bitcraze/crazyflie/src/mtd.cpp
@@ -1,0 +1,81 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <nuttx/spi/spi.h>
+#include <px4_platform_common/px4_manifest.h>
+//                                                                      KiB BS    nB
+static const px4_mft_device_t i2c1 = {             // 24AA64FT on Base  8K 32 X 256
+	.bus_type = px4_mft_device_t::I2C,
+	.devid    = PX4_MK_I2C_DEVID(1, 0x50)
+};
+
+
+static const px4_mtd_entry_t fmu_eeprom = {
+	.device = &i2c1,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_PARAMETERS,
+			.path = "/fs/mtd_params",
+			.nblocks = 128
+		},
+		{
+			.type = MTD_WAYPOINTS,
+			.path = "/fs/mtd_waypoints",
+			.nblocks = 128
+
+		}
+	},
+};
+
+static const px4_mtd_manifest_t board_mtd_config = {
+	.nconfigs   = 1,
+	.entries = {
+		&fmu_eeprom,
+	}
+};
+
+static const px4_mft_entry_s mtd_mft = {
+	.type = MTD,
+	.pmft = (void *) &board_mtd_config,
+};
+
+static const px4_mft_s mft = {
+	.nmft = 1,
+	.mfts = &mtd_mft
+};
+
+const px4_mft_s *board_get_manifest(void)
+{
+	return &mft;
+}

--- a/boards/cuav/can-gps-v1/default.cmake
+++ b/boards/cuav/can-gps-v1/default.cmake
@@ -51,6 +51,7 @@ px4_add_board(
 		#hardfault_log
 		#i2cdetect
 		#led_control
+		#mft
 		#mixer
 		#motor_ramp
 		#motor_test

--- a/boards/cuav/can-gps-v1/src/init.c
+++ b/boards/cuav/can-gps-v1/src/init.c
@@ -123,5 +123,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 {
 	px4_platform_init();
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/cuav/nora/default.cmake
+++ b/boards/cuav/nora/default.cmake
@@ -92,6 +92,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/cuav/nora/src/init.c
+++ b/boards/cuav/nora/src/init.c
@@ -209,5 +209,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio_mediachange(sdio_dev, true);
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/cuav/x7pro/src/init.c
+++ b/boards/cuav/x7pro/src/init.c
@@ -209,5 +209,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio_mediachange(sdio_dev, true);
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/cubepilot/cubeorange/console.cmake
+++ b/boards/cubepilot/cubeorange/console.cmake
@@ -97,6 +97,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/cubepilot/cubeorange/default.cmake
+++ b/boards/cubepilot/cubeorange/default.cmake
@@ -97,6 +97,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/cubepilot/cubeorange/src/init.c
+++ b/boards/cubepilot/cubeorange/src/init.c
@@ -189,5 +189,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio_mediachange(sdio_dev, true);
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/cubepilot/cubeyellow/console.cmake
+++ b/boards/cubepilot/cubeyellow/console.cmake
@@ -96,6 +96,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/cubepilot/cubeyellow/default.cmake
+++ b/boards/cubepilot/cubeyellow/default.cmake
@@ -96,6 +96,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/cubepilot/cubeyellow/src/init.c
+++ b/boards/cubepilot/cubeyellow/src/init.c
@@ -208,5 +208,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio_mediachange(sdio_dev, true);
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/holybro/durandal-v1/src/init.c
+++ b/boards/holybro/durandal-v1/src/init.c
@@ -280,5 +280,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/holybro/kakutef7/src/init.c
+++ b/boards/holybro/kakutef7/src/init.c
@@ -266,5 +266,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/holybro/pix32v5/default.cmake
+++ b/boards/holybro/pix32v5/default.cmake
@@ -100,6 +100,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/holybro/pix32v5/src/init.c
+++ b/boards/holybro/pix32v5/src/init.c
@@ -289,5 +289,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -69,6 +69,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/intel/aerofc-v1/nuttx-config/scripts/script.ld
+++ b/boards/intel/aerofc-v1/nuttx-config/scripts/script.ld
@@ -65,6 +65,7 @@ EXTERN(_vectors)	/* force the vectors to be included in the output */
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
 EXTERN(abort)
+EXTERN(board_get_manifest)
 
 SECTIONS
 {

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/intel/aerofc-v1/src/CMakeLists.txt
+++ b/boards/intel/aerofc-v1/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(drivers_board
 	i2c.cpp
 	init.c
 	led.c
+	mtd.cpp
 	spi.cpp
 	timer_config.cpp
 )

--- a/boards/intel/aerofc-v1/src/init.c
+++ b/boards/intel/aerofc-v1/src/init.c
@@ -219,5 +219,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	dm_flash_sector_description_set(&dm_sector_map);
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/intel/aerofc-v1/src/mtd.cpp
+++ b/boards/intel/aerofc-v1/src/mtd.cpp
@@ -1,0 +1,81 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <nuttx/spi/spi.h>
+#include <px4_platform_common/px4_manifest.h>
+//                                                                      KiB BS    nB
+static const px4_mft_device_t i2c3 = {             // 24AA64FT on Base  8K 32 X 256
+	.bus_type = px4_mft_device_t::I2C,
+	.devid    = PX4_MK_I2C_DEVID(3, 0x50)
+};
+
+
+static const px4_mtd_entry_t fmu_eeprom = {
+	.device = &i2c3,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_PARAMETERS,
+			.path = "/fs/mtd_params",
+			.nblocks = 128
+		},
+		{
+			.type = MTD_WAYPOINTS,
+			.path = "/fs/mtd_waypoints",
+			.nblocks = 128
+
+		}
+	},
+};
+
+static const px4_mtd_manifest_t board_mtd_config = {
+	.nconfigs   = 1,
+	.entries = {
+		&fmu_eeprom,
+	}
+};
+
+static const px4_mft_entry_s mtd_mft = {
+	.type = MTD,
+	.pmft = (void *) &board_mtd_config,
+};
+
+static const px4_mft_s mft = {
+	.nmft = 1,
+	.mfts = &mtd_mft
+};
+
+const px4_mft_s *board_get_manifest(void)
+{
+	return &mft;
+}

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -86,6 +86,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/modalai/fc-v1/src/init.c
+++ b/boards/modalai/fc-v1/src/init.c
@@ -293,5 +293,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -92,6 +92,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/mro/ctrl-zero-f7/src/init.c
+++ b/boards/mro/ctrl-zero-f7/src/init.c
@@ -242,5 +242,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/mro/x21-777/default.cmake
+++ b/boards/mro/x21-777/default.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/mro/x21-777/src/init.c
+++ b/boards/mro/x21-777/src/init.c
@@ -229,5 +229,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -89,6 +89,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/mro/x21/src/init.c
+++ b/boards/mro/x21/src/init.c
@@ -327,5 +327,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/nxp/fmuk66-e/default.cmake
+++ b/boards/nxp/fmuk66-e/default.cmake
@@ -88,6 +88,7 @@ px4_add_board(
 		#hardfault_log # Needs bbsrm
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/nxp/fmuk66-e/socketcan.cmake
+++ b/boards/nxp/fmuk66-e/socketcan.cmake
@@ -87,6 +87,7 @@ px4_add_board(
 		#hardfault_log # Needs bbsrm
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/nxp/fmuk66-e/src/init.c
+++ b/boards/nxp/fmuk66-e/src/init.c
@@ -300,5 +300,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -88,6 +88,7 @@ px4_add_board(
 		#hardfault_log # Needs bbsrm
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/nxp/fmuk66-v3/rtps.cmake
+++ b/boards/nxp/fmuk66-v3/rtps.cmake
@@ -88,6 +88,7 @@ px4_add_board(
 		#hardfault_log # Needs bbsrm
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/nxp/fmuk66-v3/socketcan.cmake
+++ b/boards/nxp/fmuk66-v3/socketcan.cmake
@@ -87,6 +87,7 @@ px4_add_board(
 		#hardfault_log # Needs bbsrm
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/nxp/fmuk66-v3/src/init.c
+++ b/boards/nxp/fmuk66-v3/src/init.c
@@ -292,5 +292,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/nxp/fmurt1062-v1/default.cmake
+++ b/boards/nxp/fmurt1062-v1/default.cmake
@@ -85,6 +85,7 @@ px4_add_board(
 		mixer
 		motor_ramp
 		motor_test
+		mft
 		mtd
 		nshterm
 		param

--- a/boards/nxp/fmurt1062-v1/src/init.c
+++ b/boards/nxp/fmurt1062-v1/src/init.c
@@ -320,6 +320,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		return ret;
 	}
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
 
 	return OK;
 }

--- a/boards/nxp/ucans32k146/src/init.c
+++ b/boards/nxp/ucans32k146/src/init.c
@@ -94,7 +94,13 @@ int board_app_initialize(uintptr_t arg)
 
 	/* Perform board-specific initialization */
 
-	return s32k1xx_bringup();
+	int rv = s32k1xx_bringup();
+
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
+	return rv;
 #endif
 }
 

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -76,6 +76,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		#mft
 		mixer
 		#motor_ramp
 		motor_test

--- a/boards/omnibus/f4sd/src/init.c
+++ b/boards/omnibus/f4sd/src/init.c
@@ -345,6 +345,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
 
 	return OK;
 }

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -105,6 +105,7 @@ px4_add_board(
 		hardfault_log
 		#i2cdetect
 		#led_control
+		mft
 		mixer
 		#motor_ramp
 		#motor_test

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		hardfault_log
 		#i2cdetect
 		#led_control
+		mft
 		mixer
 		#motor_ramp
 		#motor_test

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -92,6 +92,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		#led_control
+		mft
 		mixer
 		#motor_ramp
 		motor_test

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -65,6 +65,7 @@ px4_add_board(
 		hardfault_log
 		#i2cdetect
 		#led_control
+		mft
 		mixer
 		#motor_ramp
 		#motor_test

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -60,6 +60,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		#led_control
+		mft
 		mixer
 		#motor_ramp
 		#motor_test

--- a/boards/px4/fmu-v2/src/init.c
+++ b/boards/px4/fmu-v2/src/init.c
@@ -528,5 +528,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		hardfault_log
 		#i2cdetect
 		#led_control
+		mft
 		mixer
 		#motor_ramp
 		#motor_test

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -102,6 +102,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v3/src/init.c
+++ b/boards/px4/fmu-v3/src/init.c
@@ -528,5 +528,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4/cannode.cmake
+++ b/boards/px4/fmu-v4/cannode.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		#esc_calib
 		#hardfault_log
 		i2cdetect
+		mft
 		#led_control
 		#mixer
 		#motor_ramp

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -97,6 +97,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4/optimized.cmake
+++ b/boards/px4/fmu-v4/optimized.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4/src/init.c
+++ b/boards/px4/fmu-v4/src/init.c
@@ -379,5 +379,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -92,6 +92,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v4pro/src/init.c
+++ b/boards/px4/fmu-v4pro/src/init.c
@@ -404,5 +404,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -96,6 +96,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/debug.cmake
+++ b/boards/px4/fmu-v5/debug.cmake
@@ -101,6 +101,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -102,6 +102,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -97,6 +97,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -82,6 +82,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -97,6 +97,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5/src/init.c
+++ b/boards/px4/fmu-v5/src/init.c
@@ -219,7 +219,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	px4_platform_init();
 
-
 	if (OK == board_determine_hw_info()) {
 		syslog(LOG_INFO, "[boot] Rev 0x%1x : Ver 0x%1x %s\n", board_get_hw_revision(), board_get_hw_version(),
 		       board_get_hw_type_name());
@@ -231,6 +230,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	/* configure SPI interfaces (after we determined the HW version) */
 
 	stm32_spiinitialize();
+
 
 	/* Does this board have CAN 2 or CAN 3 if not decouple the RX
 	 * from IP block Leave TX connected
@@ -288,6 +288,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	}
 
 #endif /* CONFIG_MMCSD */
+
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
 
 	return OK;
 }

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -101,6 +101,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
+++ b/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -99,6 +99,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
@@ -90,6 +90,7 @@ ENTRY(_stext)
  */
 EXTERN(abort)
 EXTERN(_bootdelay_signature)
+EXTERN(board_get_manifest)
 
 SECTIONS
 {

--- a/boards/px4/fmu-v5x/src/CMakeLists.txt
+++ b/boards/px4/fmu-v5x/src/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(drivers_board
 	init.c
 	led.c
 	manifest.c
+	mtd.cpp
 	sdio.c
 	spi.cpp
 	timer_config.cpp

--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -116,8 +116,6 @@
 #define GPIO_I2C4_DRDY1_BMP388      /* PG5  */  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTG|GPIO_PIN5)
 #define GPIO_PG6                    /* PG6  */  (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTG|GPIO_PIN6)
 
-#define PX4_I2C_BUS_MTD 4
-
 /*
  * ADC channels
  *
@@ -431,6 +429,9 @@
 #define BOARD_ENABLE_CONSOLE_BUFFER
 
 #define BOARD_NUM_IO_TIMERS 5
+
+
+#define PX4_I2C_BUS_MTD      4,5
 
 __BEGIN_DECLS
 

--- a/boards/px4/fmu-v5x/src/init.c
+++ b/boards/px4/fmu-v5x/src/init.c
@@ -280,5 +280,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/px4/fmu-v5x/src/mtd.cpp
+++ b/boards/px4/fmu-v5x/src/mtd.cpp
@@ -1,0 +1,126 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <nuttx/spi/spi.h>
+#include <px4_platform_common/px4_manifest.h>
+//                                                              KiB BS    nB
+static const px4_mft_device_t spi5 = {             // FM25V02A on FMUM 32K 512 X 64
+	.bus_type = px4_mft_device_t::SPI,
+	.devid    = SPIDEV_FLASH(0)
+};
+static const px4_mft_device_t i2c3 = {             // 24LC64T on Base  8K 32 X 256
+	.bus_type = px4_mft_device_t::I2C,
+	.devid    = PX4_MK_I2C_DEVID(3, 0x51)
+};
+static const px4_mft_device_t i2c4 = {             // 24LC64T on IMU   8K 32 X 256
+	.bus_type =  px4_mft_device_t::I2C,
+	.devid    =  PX4_MK_I2C_DEVID(4, 0x50)
+};
+
+
+static const px4_mtd_entry_t fmum_fram = {
+	.device = &spi5,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_PARAMETERS,
+			.path = "/fs/mtd_params",
+			.nblocks = 32
+		},
+		{
+			.type = MTD_WAYPOINTS,
+			.path = "/fs/mtd_waypoints",
+			.nblocks = 32
+
+		}
+	},
+};
+
+static const px4_mtd_entry_t base_eeprom = {
+	.device = &i2c3,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_MFT,
+			.path = "/fs/mtd_mft",
+			.nblocks = 248
+		},
+		{
+			.type = MTD_NET,
+			.path = "/fs/mtd_net",
+			.nblocks = 8 // 256 = 32 * 8
+
+		}
+	},
+};
+
+static const px4_mtd_entry_t imu_eeprom = {
+	.device = &i2c4,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_ID,
+			.path = "/fs/mtd_id",
+			.nblocks = 8 // 256 = 32 * 8
+		},
+		{
+			.type = MTD_CALDATA,
+			.path = "/fs/mtd_caldata",
+			.nblocks = 248
+		}
+	},
+};
+
+static const px4_mtd_manifest_t board_mtd_config = {
+	.nconfigs   = 3,
+	.entries = {
+		&fmum_fram,
+		&base_eeprom,
+		&imu_eeprom
+	}
+};
+
+static const px4_mft_entry_s mtd_mft = {
+	.type = MTD,
+	.pmft = (void *) &board_mtd_config,
+};
+
+static const px4_mft_s mft = {
+	.nmft = 1,
+	.mfts = &mtd_mft
+};
+
+const px4_mft_s *board_get_manifest(void)
+{
+	return &mft;
+}

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/fmu-v6x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v6x/nuttx-config/scripts/script.ld
@@ -131,6 +131,7 @@ ENTRY(_stext)
  */
 EXTERN(abort)
 EXTERN(_bootdelay_signature)
+EXTERN(board_get_manifest)
 
 SECTIONS
 {

--- a/boards/px4/fmu-v6x/src/CMakeLists.txt
+++ b/boards/px4/fmu-v6x/src/CMakeLists.txt
@@ -49,6 +49,7 @@ else()
 		i2c.cpp
 		init.c
 		led.c
+		mtd.cpp
 		manifest.c
 		sdio.c
 		spi.cpp

--- a/boards/px4/fmu-v6x/src/board_config.h
+++ b/boards/px4/fmu-v6x/src/board_config.h
@@ -479,6 +479,9 @@
 
 #define BOARD_ENABLE_CONSOLE_BUFFER
 
+#define PX4_I2C_BUS_MTD      4,5
+
+
 #define BOARD_NUM_IO_TIMERS 5
 
 __BEGIN_DECLS

--- a/boards/px4/fmu-v6x/src/init.c
+++ b/boards/px4/fmu-v6x/src/init.c
@@ -286,5 +286,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif /* CONFIG_MMCSD */
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/px4/fmu-v6x/src/mtd.cpp
+++ b/boards/px4/fmu-v6x/src/mtd.cpp
@@ -1,0 +1,126 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <nuttx/spi/spi.h>
+#include <px4_platform_common/px4_manifest.h>
+//                                                              KiB BS    nB
+static const px4_mft_device_t spi5 = {             // FM25V02A on FMUM 32K 512 X 64
+	.bus_type = px4_mft_device_t::SPI,
+	.devid    = SPIDEV_FLASH(0)
+};
+static const px4_mft_device_t i2c3 = {             // 24LC64T on Base  8K 32 X 256
+	.bus_type = px4_mft_device_t::I2C,
+	.devid    = PX4_MK_I2C_DEVID(3, 0x51)
+};
+static const px4_mft_device_t i2c4 = {             // 24LC64T on IMU   8K 32 X 256
+	.bus_type =  px4_mft_device_t::I2C,
+	.devid    =  PX4_MK_I2C_DEVID(4, 0x50)
+};
+
+
+static const px4_mtd_entry_t fmum_fram = {
+	.device = &spi5,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_PARAMETERS,
+			.path = "/fs/mtd_params",
+			.nblocks = 32
+		},
+		{
+			.type = MTD_WAYPOINTS,
+			.path = "/fs/mtd_waypoints",
+			.nblocks = 32
+
+		}
+	},
+};
+
+static const px4_mtd_entry_t base_eeprom = {
+	.device = &i2c3,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_MFT,
+			.path = "/fs/mtd_mft",
+			.nblocks = 248
+		},
+		{
+			.type = MTD_NET,
+			.path = "/fs/mtd_net",
+			.nblocks = 8 // 256 = 32 * 8
+
+		}
+	},
+};
+
+static const px4_mtd_entry_t imu_eeprom = {
+	.device = &i2c4,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_ID,
+			.path = "/fs/mtd_id",
+			.nblocks = 8 // 256 = 32 * 8
+		},
+		{
+			.type = MTD_CALDATA,
+			.path = "/fs/mtd_caldata",
+			.nblocks = 248
+		}
+	},
+};
+
+static const px4_mtd_manifest_t board_mtd_config = {
+	.nconfigs   = 3,
+	.entries = {
+		&fmum_fram,
+		&base_eeprom,
+		&imu_eeprom
+	}
+};
+
+static const px4_mft_entry_s mtd_mft = {
+	.type = MTD,
+	.pmft = (void *) &board_mtd_config,
+};
+
+static const px4_mft_s mft = {
+	.nmft = 1,
+	.mfts = &mtd_mft
+};
+
+const px4_mft_s *board_get_manifest(void)
+{
+	return &mft;
+}

--- a/boards/px4/fmu-v6x/stackcheck.cmake
+++ b/boards/px4/fmu-v6x/stackcheck.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		esc_calib
 		failure
 		led_control
+		#mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		esc_calib
 		failure
 		led_control
+		#mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -61,6 +61,7 @@ px4_add_board(
 		dyn
 		esc_calib
 		led_control
+		#mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -59,6 +59,7 @@ px4_add_board(
 		dyn
 		esc_calib
 		led_control
+		#mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/spracing/h7extreme/default.cmake
+++ b/boards/spracing/h7extreme/default.cmake
@@ -90,6 +90,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		#mft
 		mixer
 		#motor_ramp
 		motor_test

--- a/boards/spracing/h7extreme/src/init.c
+++ b/boards/spracing/h7extreme/src/init.c
@@ -291,5 +291,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/boards/uvify/core/default.cmake
+++ b/boards/uvify/core/default.cmake
@@ -70,6 +70,7 @@ px4_add_board(
 		hardfault_log
 		i2cdetect
 		led_control
+		mft
 		mixer
 		motor_ramp
 		motor_test

--- a/boards/uvify/core/src/init.c
+++ b/boards/uvify/core/src/init.c
@@ -379,5 +379,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #endif
 
+	/* Configure the HW based on the manifest */
+
+	px4_platform_configure();
+
 	return OK;
 }

--- a/platforms/common/include/px4_platform_common/mtd_manifest.h
+++ b/platforms/common/include/px4_platform_common/mtd_manifest.h
@@ -41,6 +41,8 @@ typedef enum  {
 	MTD_ID          = 5,
 	MTD_NET         = 6,
 } px4_mtd_types_t;
+#define PX4_MFT_MTD_TYPES  {MTD_PARAMETERS, MTD_WAYPOINTS, MTD_CALDATA, MTD_MFT, MTD_ID, MTD_NET}
+#define PX4_MFT_MTD_STR_TYPES  {"MTD_PARAMETERS", "MTD_WAYPOINTS", "MTD_CALDATA", "MTD_MFT", "MTD_ID", "MTD_NET"}
 
 typedef struct  {
 	const px4_mtd_types_t   type;
@@ -76,5 +78,28 @@ __BEGIN_DECLS
  ************************************************************************************/
 
 __EXPORT int px4_mtd_config(const px4_mtd_manifest_t *mft_mtd);
+
+/************************************************************************************
+ * Name: px4_mtd_query
+ *
+ * Description:
+ *   A Query interface that will lookup a type and either a) verify it exists  by
+ *   value.
+ *
+ *   or it will return the path for a type.
+ *
+ *
+ * Input Parameters:
+ *  type  - a string-ized version of px4_mtd_types_t
+ *  value - string to verity is that type.
+ *  get   - a pointer to a string to optionally return the path for the type.
+ *
+ * Returned Value:
+ *   non zero if error
+ *   0 (get == null) item by type and value was found.
+ *   0 (get !=null) item by type's value is returned at get;
+ *
+ ************************************************************************************/
+__EXPORT int px4_mtd_query(const char *type, const char *val, const char **get = nullptr);
 
 __END_DECLS

--- a/platforms/common/include/px4_platform_common/mtd_manifest.h
+++ b/platforms/common/include/px4_platform_common/mtd_manifest.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,26 +30,51 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+#pragma once
+#include <stdint.h>
+
+typedef enum  {
+	MTD_PARAMETERS  = 1,
+	MTD_WAYPOINTS   = 2,
+	MTD_CALDATA     = 3,
+	MTD_MFT         = 4,
+	MTD_ID          = 5,
+	MTD_NET         = 6,
+} px4_mtd_types_t;
+
+typedef struct  {
+	const px4_mtd_types_t   type;
+	const char              *path;
+	const uint32_t          nblocks;
+} px4_mtd_part_t;
+
+typedef struct  {
+	const px4_mft_device_t  *device;
+	const uint32_t           npart;
+	const px4_mtd_part_t     partd[];
+} px4_mtd_entry_t;
+
+typedef struct  {
+	const uint32_t        nconfigs;
+	const px4_mtd_entry_t *entries[];
+} px4_mtd_manifest_t;
+
 
 __BEGIN_DECLS
+/************************************************************************************
+ * Name: px4_mtd_config
+ *
+ * Description:
+ *   A board will call this function, to set up the mtd partitions
+ *
+ * Input Parameters:
+ *  mtd_list    - px4_mtd_config list/count
+ *
+ * Returned Value:
+ *   non zero if error
+ *
+ ************************************************************************************/
 
-int px4_platform_init(void);
-int px4_platform_console_init(void);
-int px4_platform_configure(void);
+__EXPORT int px4_mtd_config(const px4_mtd_manifest_t *mft_mtd);
 
 __END_DECLS
-
-#ifdef __cplusplus
-
-namespace px4
-{
-
-/**
- * Startup init method. It has no specific functionality, just prints a welcome
- * message and sets the thread name
- */
-__EXPORT void init(int argc, char *argv[], const char *process_name);
-
-} // namespace px4
-
-#endif /* __cplusplus */

--- a/platforms/common/include/px4_platform_common/px4_manifest.h
+++ b/platforms/common/include/px4_platform_common/px4_manifest.h
@@ -36,8 +36,12 @@
 typedef enum  {
 	MFT = 0,
 	MTD = 1,
+	LAST_MFT_TYPE
 } px4_manifest_types_e;
 
+/* must match  px4_manifest_types_e */
+#define PX4_MFT_TYPES     {MFT, MTD}
+#define PX4_MFT_STR_TYPES {"MFT", "MTD"}
 
 typedef struct  {
 
@@ -99,4 +103,22 @@ __EXPORT const px4_mft_s *board_get_manifest(void);
  ************************************************************************************/
 
 __EXPORT int px4_mft_configure(const px4_mft_s *mft);
+
+/************************************************************************************
+ * Name: px4_mft_configure
+ *
+ * Description:
+ *   The Px4 layer will provide this interface to start/configure the
+ *   hardware.
+ *
+ * Input Parameters:
+ *  mft    - a pointer to the manifest
+ *
+ * Returned Value:
+ *   non zero if error
+ *
+ ************************************************************************************/
+
+__EXPORT int px4_mft_query(const px4_mft_s *mft, px4_manifest_types_e type,
+			   const char *sub, const char *val);
 __END_DECLS

--- a/platforms/common/include/px4_platform_common/px4_manifest.h
+++ b/platforms/common/include/px4_platform_common/px4_manifest.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,26 +30,73 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+#pragma once
+#include <stdint.h>
+
+typedef enum  {
+	MFT = 0,
+	MTD = 1,
+} px4_manifest_types_e;
+
+
+typedef struct  {
+
+	enum px4_bus_type {
+		I2C = 0,
+		SPI = 1,
+	} bus_type;
+
+	uint32_t devid;
+} px4_mft_device_t;
+
+#define PX4_MK_I2C_DEVID(b,a) ((b) << 16 | ((a) & 0xffff))
+#define PX4_I2C_DEVID_BUS(d)  (((d) >> 16) & 0xffff)
+#define PX4_I2C_DEVID_ADDR(d) ((d) & 0xffff)
+
+typedef struct {
+	const px4_manifest_types_e type;
+	const void           *pmft;
+} px4_mft_entry_s;
+
+typedef struct {
+	const uint32_t        nmft;
+	const px4_mft_entry_s *mfts;
+} px4_mft_s;
+
+#include "px4_platform_common/mtd_manifest.h"
+
 
 __BEGIN_DECLS
+/************************************************************************************
+ * Name: board_get_manifest
+ *
+ * Description:
+ *   A board will provide this function to return the manifest
+ *
+ * Input Parameters:
+ *  mft    - a pointer to the receive the manifest
+ *
+ * Returned Value:
+ *   non zero if error
+ *
+ ************************************************************************************/
 
-int px4_platform_init(void);
-int px4_platform_console_init(void);
-int px4_platform_configure(void);
+__EXPORT const px4_mft_s *board_get_manifest(void);
 
+/************************************************************************************
+ * Name: px4_mft_configure
+ *
+ * Description:
+ *   The Px4 layer will provide this interface to start/configure the
+ *   hardware.
+ *
+ * Input Parameters:
+ *  mft    - a pointer to the manifest
+ *
+ * Returned Value:
+ *   non zero if error
+ *
+ ************************************************************************************/
+
+__EXPORT int px4_mft_configure(const px4_mft_s *mft);
 __END_DECLS
-
-#ifdef __cplusplus
-
-namespace px4
-{
-
-/**
- * Startup init method. It has no specific functionality, just prints a welcome
- * message and sets the thread name
- */
-__EXPORT void init(int argc, char *argv[], const char *process_name);
-
-} // namespace px4
-
-#endif /* __cplusplus */

--- a/platforms/common/include/px4_platform_common/px4_mtd.h
+++ b/platforms/common/include/px4_platform_common/px4_mtd.h
@@ -40,6 +40,7 @@ __BEGIN_DECLS
 typedef struct {
 	struct mtd_dev_s *mtd_dev;
 	int              *partition_block_counts;
+	int              *partition_types;
 	const char       **partition_names;
 	struct mtd_dev_s **part_dev;
 	uint32_t         devid;

--- a/platforms/common/include/px4_platform_common/px4_mtd.h
+++ b/platforms/common/include/px4_platform_common/px4_mtd.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,26 +30,51 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+#pragma once
+#include <stdint.h>
 
 __BEGIN_DECLS
 
-int px4_platform_init(void);
-int px4_platform_console_init(void);
-int px4_platform_configure(void);
+// The data needed to interface with mtd device's
+
+typedef struct {
+	struct mtd_dev_s *mtd_dev;
+	int              *partition_block_counts;
+	const char       **partition_names;
+	struct mtd_dev_s **part_dev;
+	uint32_t         devid;
+	unsigned         n_partitions_current;
+} mtd_instance_s;
+
+/*
+  mtd operations
+ */
+
+/*
+ * Get device an pinter to the array of mtd_instance_s of the system
+ *  count - receives the number of instances pointed to by the pointer
+ *  retunred.
+ *
+ *  returns: - A pointer to the mtd_instance_s of the system
+ *            This can be  Null if there are no mtd instances.
+ *
+ */
+__EXPORT mtd_instance_s *px4_mtd_get_instances(unsigned int *count);
+
+/*
+  Get device complete geometry or a device
+ */
+
+
+__EXPORT int  px4_mtd_get_geometry(const mtd_instance_s *instance, unsigned long *blocksize, unsigned long *erasesize,
+				   unsigned long *neraseblocks, unsigned *blkpererase, unsigned *nblocks,
+				   unsigned *partsize);
+/*
+  Get size of a parttion on an instance.
+ */
+__EXPORT ssize_t px4_mtd_get_partition_size(const mtd_instance_s *instance, const char *partname);
+
+FAR struct mtd_dev_s *px4_at24c_initialize(FAR struct i2c_master_s *dev,
+		uint8_t address);
 
 __END_DECLS
-
-#ifdef __cplusplus
-
-namespace px4
-{
-
-/**
- * Startup init method. It has no specific functionality, just prints a welcome
- * message and sets the thread name
- */
-__EXPORT void init(int argc, char *argv[], const char *process_name);
-
-} // namespace px4
-
-#endif /* __cplusplus */

--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -45,6 +45,9 @@ if(NOT PX4_BOARD MATCHES "px4_io")
 		tasks.cpp
 		px4_nuttx_impl.cpp
 		px4_init.cpp
+		px4_manifest.cpp
+		px4_mtd.cpp
+		px4_24xxxx_mtd.c
 	)
 	target_link_libraries(px4_layer
 		PRIVATE

--- a/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
+++ b/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
@@ -51,6 +51,7 @@
  ************************************************************************************/
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/px4_mtd.h>
 #include <px4_platform_common/time.h>
 
 #include <sys/types.h>
@@ -536,8 +537,9 @@ static int at24c_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
  *   other functions (such as a block or character driver front end).
  *
  ************************************************************************************/
+FAR struct mtd_dev_s *px4_at24c_initialize(FAR struct i2c_master_s *dev,
+		uint8_t address)
 
-FAR struct mtd_dev_s *at24c_initialize(FAR struct i2c_master_s *dev)
 {
 	FAR struct at24c_dev_s *priv;
 
@@ -554,8 +556,7 @@ FAR struct mtd_dev_s *at24c_initialize(FAR struct i2c_master_s *dev)
 
 	if (priv) {
 		/* Initialize the allocated structure */
-
-		priv->addr       = CONFIG_AT24XX_ADDR;
+		priv->addr       = address;
 		priv->pagesize   = AT24XX_PAGESIZE;
 		priv->npages     = AT24XX_NPAGES;
 

--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -33,6 +33,7 @@
 
 #include <px4_platform_common/init.h>
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/px4_manifest.h>
 #include <px4_platform_common/console_buffer.h>
 #include <px4_platform_common/defines.h>
 #include <drivers/drv_hrt.h>
@@ -118,4 +119,10 @@ int px4_platform_init(void)
 	px4::WorkQueueManagerStart();
 
 	return PX4_OK;
+}
+
+int px4_platform_configure(void)
+{
+	return px4_mft_configure(board_get_manifest());
+
 }

--- a/platforms/nuttx/src/px4/common/px4_manifest.cpp
+++ b/platforms/nuttx/src/px4/common/px4_manifest.cpp
@@ -87,3 +87,27 @@ __EXPORT int px4_mft_configure(const px4_mft_s *mft)
 
 	return 0;
 }
+
+__EXPORT int px4_mft_query(const px4_mft_s *mft, px4_manifest_types_e type,
+			   const char *sub, const char *val)
+{
+	int rv = -EINVAL;
+
+	if (mft != nullptr) {
+		for (uint32_t m = 0; m < mft->nmft; m++) {
+			if (mft->mfts[m].type == type)
+				switch (type) {
+				case MTD:
+					return px4_mtd_query(sub, val);
+					break;
+
+				case MFT:
+				default:
+					rv = -ENODATA;
+					break;
+				}
+		}
+	}
+
+	return rv;
+}

--- a/platforms/nuttx/src/px4/common/px4_mtd.cpp
+++ b/platforms/nuttx/src/px4/common/px4_mtd.cpp
@@ -1,0 +1,408 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file px4_mtd.cpp
+ *
+ * mtd services.
+ *
+ * @author David Sidrane <david.sidrane@nscdg.com>
+ */
+
+#ifndef MODULE_NAME
+#define MODULE_NAME "PX4_MTD"
+#endif
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/px4_mtd.h>
+#include <px4_platform_common/px4_manifest.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/spi.h>
+
+#include <errno.h>
+#include <stdbool.h>
+
+#include <nuttx/drivers/drivers.h>
+#include <nuttx/spi/spi.h>
+#include <nuttx/mtd/mtd.h>
+
+extern "C" {
+	struct mtd_dev_s *ramtron_initialize(FAR struct spi_dev_s *dev);
+	struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
+					off_t firstblock, off_t nblocks);
+}
+static int num_instances = 0;
+static mtd_instance_s *instances = nullptr;
+
+
+static int ramtron_attach(mtd_instance_s &instance)
+{
+#if !defined(CONFIG_MTD_RAMTRON)
+	PX4_ERR("Misconfiguration CONFIG_MTD_RAMTRON not set");
+	return ENXIO;
+#else
+
+	/* initialize the right spi */
+	struct spi_dev_s *spi = px4_spibus_initialize(px4_find_spi_bus(instance.devid));
+
+	if (spi == nullptr) {
+		PX4_ERR("failed to locate spi bus");
+		return -ENXIO;
+	}
+
+	/* this resets the spi bus, set correct bus speed again */
+	SPI_SETFREQUENCY(spi, 10 * 1000 * 1000);
+	SPI_SETBITS(spi, 8);
+	SPI_SETMODE(spi, SPIDEV_MODE3);
+	SPI_SELECT(spi, instance.devid, false);
+
+	/* start the RAMTRON driver, attempt 5 times */
+
+	for (int i = 0; i < 5; i++) {
+		instance.mtd_dev = ramtron_initialize(spi);
+
+		if (instance.mtd_dev) {
+			/* abort on first valid result */
+			if (i > 0) {
+				PX4_WARN("mtd needed %d attempts to attach", i + 1);
+			}
+
+			break;
+		}
+	}
+
+	/* if last attempt is still unsuccessful, abort */
+	if (instance.mtd_dev == nullptr) {
+		PX4_ERR("failed to initialize mtd driver");
+		return -EIO;
+	}
+
+	int ret = instance.mtd_dev->ioctl(instance.mtd_dev, MTDIOC_SETSPEED, (unsigned long)10 * 1000 * 1000);
+
+	if (ret != OK) {
+		// FIXME: From the previous warning call, it looked like this should have been fatal error instead. Tried
+		// that but setting the bus speed does fail all the time. Which was then exiting and the board would
+		// not run correctly. So changed to PX4_WARN.
+		PX4_WARN("failed to set bus speed");
+	}
+
+	return 0;
+#endif
+}
+
+
+static int at24xxx_attach(mtd_instance_s &instance)
+{
+#if !defined(PX4_I2C_BUS_MTD)
+	PX4_ERR("Misconfiguration PX4_I2C_BUS_MTD not set");
+	return -ENXIO;
+#else
+
+	struct i2c_master_s *i2c = px4_i2cbus_initialize(PX4_I2C_DEVID_BUS(instance.devid));
+
+	if (i2c == nullptr) {
+		PX4_ERR("failed to locate I2C bus");
+		return -ENXIO;
+	}
+
+	/* start the MTD driver, attempt 5 times */
+	for (int i = 0; i < 5; i++) {
+		instance.mtd_dev = px4_at24c_initialize(i2c, PX4_I2C_DEVID_ADDR(instance.devid));
+
+		if (instance.mtd_dev) {
+			/* abort on first valid result */
+			if (i > 0) {
+				PX4_WARN("EEPROM needed %d attempts to attach", i + 1);
+			}
+
+			break;
+		}
+	}
+
+	/* if last attempt is still unsuccessful, abort */
+	if (instance.mtd_dev == nullptr) {
+		PX4_ERR("failed to initialize EEPROM driver");
+		return -EIO;
+	}
+
+	return 0;
+#endif
+}
+
+
+int px4_mtd_get_geometry(const mtd_instance_s *instance, unsigned long *blocksize, unsigned long *erasesize,
+			 unsigned long *neraseblocks,
+			 unsigned *blkpererase, unsigned *nblocks, unsigned *partsize)
+{
+	/* Get the geometry of the FLASH device */
+
+	FAR struct mtd_geometry_s geo;
+
+	int ret = instance->mtd_dev->ioctl(instance->mtd_dev, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
+
+	if (ret < 0) {
+		PX4_ERR("mtd->ioctl failed: %d", ret);
+		return ret;
+	}
+
+	*blocksize = geo.blocksize;
+	*erasesize = geo.erasesize;
+	*neraseblocks = geo.neraseblocks;
+
+	/* Determine the size of each partition.  Make each partition an even
+	 * multiple of the erase block size (perhaps not using some space at the
+	 * end of the FLASH).
+	 */
+
+	*blkpererase = geo.erasesize / geo.blocksize;
+	*nblocks     = (geo.neraseblocks / instance->n_partitions_current) * *blkpererase;
+	*partsize    = *nblocks * geo.blocksize;
+
+	return ret;
+}
+
+/*
+  get partition size in bytes
+ */
+ssize_t px4_mtd_get_partition_size(const mtd_instance_s *instance, const char *partname)
+{
+	unsigned long blocksize, erasesize, neraseblocks;
+	unsigned blkpererase, nblocks, partsize = 0;
+
+	int ret = px4_mtd_get_geometry(instance, &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
+
+	if (ret != OK) {
+		PX4_ERR("Failed to get geometry");
+		return 0;
+	}
+
+	unsigned partn = 0;
+
+	for (unsigned n = 0; n < instance->n_partitions_current; n++) {
+		if (instance->partition_names[n] != nullptr &&
+		    partname != nullptr &&
+		    strcmp(instance->partition_names[n], partname) == 0) {
+			partn = n;
+			break;
+		}
+	}
+
+	return instance->partition_block_counts[partn] * blocksize;
+}
+
+mtd_instance_s *px4_mtd_get_instances(unsigned int *count)
+{
+	*count = num_instances;
+	return instances;
+}
+
+// Define the default FRAM usage
+#if !defined(CONFIG_MTD_RAMTRON)
+
+static const px4_mtd_manifest_t default_mtd_config = {
+};
+
+#else
+
+const px4_mft_device_t spifram  = {             // FM25V02A on FMUM 32K 512 X 64
+	.bus_type = px4_mft_device_t::SPI,
+	.devid    = SPIDEV_FLASH(0)
+};
+
+const px4_mtd_entry_t fram = {
+	.device = &spifram,
+	.npart = 2,
+	.partd = {
+		{
+			.type = MTD_PARAMETERS,
+			.path = "/fs/mtd_params",
+			.nblocks = 32
+		},
+		{
+			.type = MTD_WAYPOINTS,
+			.path = "/fs/mtd_waypoints",
+			.nblocks = 32
+
+		}
+	},
+};
+
+
+static const px4_mtd_manifest_t default_mtd_config = {
+	.nconfigs   = 1,
+	.entries = {
+		&fram,
+	}
+};
+#endif
+
+int px4_mtd_config(const px4_mtd_manifest_t *mft_mtd)
+{
+	int rv = -EINVAL;
+
+	const px4_mtd_manifest_t *mtd_list = mft_mtd ? mft_mtd : &default_mtd_config;
+
+	if (mtd_list == nullptr) {
+		PX4_ERR("Invalid mtd configuration!");
+		return rv;
+	}
+
+	if (mtd_list->nconfigs == 0) {
+		return 0;
+	}
+
+	rv = -ENOMEM;
+	int total_blocks = 0;
+
+	instances = new mtd_instance_s[mtd_list->nconfigs];
+
+	if (instances == nullptr) {
+memoryout:
+		PX4_ERR("failed to allocate memory!");
+		return rv;
+	}
+
+	for (uint32_t i = 0; i < mtd_list->nconfigs; i++) {
+		num_instances++;
+		uint32_t nparts = mtd_list->entries[i]->npart;
+		instances[i].devid = mtd_list->entries[i]->device->devid;
+		instances[i].mtd_dev = nullptr;
+		instances[i].n_partitions_current = 0;
+
+		rv = -ENOMEM;
+		instances[i].part_dev = new FAR struct mtd_dev_s *[nparts];
+
+		if (instances[i].part_dev == nullptr) {
+			goto memoryout;
+		}
+
+		instances[i].partition_block_counts = new int[nparts];
+
+		if (instances[i].partition_block_counts == nullptr) {
+			goto memoryout;
+		}
+
+		instances[i].partition_names = new const char *[nparts];
+
+		if (instances[i].partition_names == nullptr) {
+			goto memoryout;
+		}
+
+		for (uint32_t p = 0; p < nparts; p++) {
+			instances[i].partition_block_counts[p] =  mtd_list->entries[i]->partd[p].nblocks;
+			instances[i].partition_names[p] = mtd_list->entries[i]->partd[p].path;
+		}
+
+		if (mtd_list->entries[i]->device->bus_type == px4_mft_device_t::I2C) {
+			rv = at24xxx_attach(instances[i]);
+
+		} else {
+			rv = ramtron_attach(instances[i]);
+		}
+
+		if (rv != 0) {
+			goto errout;
+		}
+
+		unsigned long blocksize;
+		unsigned long erasesize;
+		unsigned long neraseblocks;
+		unsigned int  blkpererase;
+		unsigned int  nblocks;
+		unsigned int  partsize;
+
+		rv = px4_mtd_get_geometry(&instances[i], &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
+
+		if (rv != 0) {
+			goto errout;
+		}
+
+		/* Now create MTD FLASH partitions */
+
+		char blockname[32];
+
+		unsigned offset;
+		unsigned part;
+
+		for (offset = 0, part = 0; rv == 0 && part < nparts; offset += instances[i].partition_block_counts[part], part++) {
+
+			/* Create the partition */
+
+			instances[i].part_dev[part] = mtd_partition(instances[i].mtd_dev, offset, instances[i].partition_block_counts[part]);
+
+			if (instances[i].part_dev[part] == nullptr) {
+				PX4_ERR("mtd_partition failed. offset=%lu nblocks=%lu",
+					(unsigned long)offset, (unsigned long)nblocks);
+				rv = -ENOSPC;
+				goto errout;
+			}
+
+			/* Initialize to provide an FTL block driver on the MTD FLASH interface */
+
+			snprintf(blockname, sizeof(blockname), "/dev/mtdblock%d", total_blocks);
+
+			rv = ftl_initialize(total_blocks, instances[i].part_dev[part]);
+
+			if (rv < 0) {
+				PX4_ERR("ftl_initialize %s failed: %d", blockname, rv);
+				goto errout;
+			}
+
+			total_blocks++;
+
+			/* Now create a character device on the block device */
+
+			rv = bchdev_register(blockname, instances[i].partition_names[part], false);
+
+			if (rv < 0) {
+				PX4_ERR("bchdev_register %s failed: %d", instances[i].partition_names[part], rv);
+				goto errout;
+			}
+
+			instances[i].n_partitions_current++;
+		}
+
+errout:
+
+		if (rv < 0) {
+			PX4_ERR("mtd failure: %d bus %d address %d class %d",
+				rv,
+				PX4_I2C_DEVID_BUS(instances[i].devid),
+				PX4_I2C_DEVID_ADDR(instances[i].devid),
+				mtd_list->entries[i]->partd[instances[i].n_partitions_current].type);
+			break;
+		}
+	}
+
+	return rv;
+}

--- a/src/systemcmds/mft/CMakeLists.txt
+++ b/src/systemcmds/mft/CMakeLists.txt
@@ -1,0 +1,40 @@
+############################################################################
+#
+#   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE systemcmds__mft
+	MAIN mft
+	COMPILE_FLAGS
+	SRCS
+		mft.cpp
+	DEPENDS
+	)

--- a/src/systemcmds/mft/mft.cpp
+++ b/src/systemcmds/mft/mft.cpp
@@ -1,0 +1,161 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2014 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mtd.c
+ *
+ * mtd service and utility app.
+ *
+ * @author Lorenz Meier <lm@inf.ethz.ch>
+ */
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/spi.h>
+#include <px4_platform_common/px4_manifest.h>
+#include <px4_platform_common/getopt.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <math.h>
+#include <fcntl.h>
+#include <sys/mount.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+
+#include <nuttx/spi/spi.h>
+#include <nuttx/mtd/mtd.h>
+#include <nuttx/fs/nxffs.h>
+#include <nuttx/fs/ioctl.h>
+#include <nuttx/drivers/drivers.h>
+
+#include <arch/board/board.h>
+
+#include "systemlib/px4_macros.h"
+#include <parameters/param.h>
+
+#include <board_config.h>
+
+extern "C" __EXPORT int mft_main(int argc, char *argv[]);
+
+static int mft_status(void)
+{
+	return 0;
+}
+
+static void print_usage(void)
+{
+	PRINT_MODULE_DESCRIPTION("Utility interact with the manifest");
+
+	PRINT_MODULE_USAGE_NAME("mfd", "command");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("query", "Returns true if not existed");
+}
+
+
+
+int mft_main(int argc, char *argv[])
+{
+	static const char *keys[] = PX4_MFT_STR_TYPES;
+	static const px4_manifest_types_e types[] = PX4_MFT_TYPES;
+
+	int myoptind = 1;
+	const char *myoptarg = nullptr;
+	int ch;
+
+	int silent = 0;
+	px4_manifest_types_e key = MFT;
+	const char *value   =   nullptr;
+	const char *subject =   nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "qk:v:s:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'q':
+			silent = 1;
+			break;
+
+		case 'k':
+			for (unsigned int k = 0; k < arraySize(keys); k++) {
+				if (!strcmp(keys[k], myoptarg)) {
+					key = types[k];
+					break;
+				}
+			}
+
+			break;
+
+		case 'v':
+			value = myoptarg;
+			break;
+
+		case 's':
+			subject = myoptarg;
+			break;
+
+		default:
+			print_usage();
+			return -1;
+			break;
+		}
+	}
+
+	if (myoptind < argc) {
+		int rv = 0;
+
+		if (!strcmp(argv[myoptind], "status")) {
+			return mft_status();
+		}
+
+		if (!strcmp(argv[myoptind], "query")) {
+			if (value && subject) {
+				rv = px4_mft_query(board_get_manifest(), key, subject, value);
+
+				if (!silent) {
+					printf("%s\n", value);
+				}
+
+				return rv;
+			}
+
+			return -EINVAL;
+		}
+
+	}
+
+	print_usage();
+	return 1;
+}

--- a/src/systemcmds/mtd/CMakeLists.txt
+++ b/src/systemcmds/mtd/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	COMPILE_FLAGS
 	SRCS
 		mtd.cpp
-		24xxxx_mtd.c
 	DEPENDS
 	)
 

--- a/src/systemcmds/mtd/mtd.cpp
+++ b/src/systemcmds/mtd/mtd.cpp
@@ -136,12 +136,15 @@ static int mtd_status(void)
 
 static void	print_usage(void)
 {
+#if !defined(CONSTRAINED_FLASH)
+
 	PRINT_MODULE_DESCRIPTION("Utility to mount and test partitions (based on FRAM/EEPROM storage as defined by the board)");
 
 	PRINT_MODULE_USAGE_NAME("mtd", "command");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("status", "Print status information");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("readtest", "Perform read test");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("rwtest", "Perform read-write test");
+
 	PRINT_MODULE_USAGE_COMMAND_DESCR("erase", "Erase partition(s)");
 	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'readtest' and 'rwtest' have an optional instance index:");
 	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 1, "storage index (if the board has multiple storages)", true);
@@ -149,6 +152,7 @@ static void	print_usage(void)
 	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'readtest', 'rwtest' and 'erase' have an optional parameter:");
 	PRINT_MODULE_USAGE_ARG("<partition_name1> [<partition_name2> ...]",
 			       "Partition names (eg. /fs/mtd_params), use system default if not provided", true);
+#endif
 }
 
 int mtd_erase(mtd_instance_s &instance)
@@ -177,6 +181,8 @@ int mtd_erase(mtd_instance_s &instance)
 
 	return 0;
 }
+
+#if !defined(CONSTRAINED_FLASH)
 
 /*
   readtest is useful during startup to validate the device is
@@ -292,6 +298,7 @@ int mtd_rwtest(const mtd_instance_s &instance)
 	printf("rwtest OK\n");
 	return 0;
 }
+#endif
 
 int mtd_main(int argc, char *argv[])
 {
@@ -327,6 +334,8 @@ int mtd_main(int argc, char *argv[])
 			return -1;
 		}
 
+#if !defined(CONSTRAINED_FLASH)
+
 		if (!strcmp(argv[myoptind], "readtest")) {
 			return mtd_readtest(instances[instance]);
 		}
@@ -335,6 +344,7 @@ int mtd_main(int argc, char *argv[])
 			return mtd_rwtest(instances[instance]);
 		}
 
+#endif
 
 		if (!strcmp(argv[myoptind], "status")) {
 			return mtd_status();

--- a/src/systemcmds/mtd/mtd.cpp
+++ b/src/systemcmds/mtd/mtd.cpp
@@ -43,8 +43,11 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/spi.h>
+#include <px4_platform_common/px4_mtd.h>
+#include <px4_platform_common/getopt.h>
 
 #include <stdio.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
@@ -70,89 +73,56 @@
 
 extern "C" __EXPORT int mtd_main(int argc, char *argv[]);
 
-#ifndef CONFIG_MTD
-
-/* create a fake command with decent warning to not confuse users */
-int mtd_main(int argc, char *argv[])
-{
-	PX4_WARN("MTD not enabled, skipping.");
-	return 1;
-}
-
-#else
-
-struct mtd_instance_s;
-
-#  if defined(BOARD_HAS_MTD_PARTITION_OVERRIDE)
-#    define MTD_PARTITION_TABLE  BOARD_HAS_MTD_PARTITION_OVERRIDE
-#  else
-#   define MTD_PARTITION_TABLE  {"/fs/mtd_params", "/fs/mtd_waypoints"}
-#  endif
-
-/* note, these will be equally sized */
-static const char *partition_names_default[] = MTD_PARTITION_TABLE;
-#if defined(BOARD_MTD_PARTITION_TABLE_SIZES)
-static const float partition_sizes_default[] = BOARD_MTD_PARTITION_TABLE_SIZES;
-#else
-#  define partition_sizes_default nullptr
-#endif
-
-
-#ifdef CONFIG_MTD_RAMTRON
-static int	ramtron_attach(mtd_instance_s &instance);
-#else
-
-#ifndef PX4_I2C_BUS_MTD
-#error "Board needs to define PX4_I2C_BUS_MTD for onboard EEPROM bus"
-#endif
-
-#endif
-
-#ifdef PX4_I2C_BUS_MTD
-static int	at24xxx_attach(mtd_instance_s &instance);
-#endif
-
-static int	mtd_start(mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions);
-static int	mtd_erase(const char *partition_names[], unsigned n_partitions);
-static int	mtd_readtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions);
-static int	mtd_rwtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions);
-static int	mtd_print_info(int instance);
-static int	mtd_get_geometry(const mtd_instance_s &instance, unsigned long *blocksize, unsigned long *erasesize,
-				 unsigned long *neraseblocks,
-				 unsigned *blkpererase, unsigned *nblocks, unsigned *partsize);
-
-struct mtd_instance_s {
-	int (*attach)(mtd_instance_s &instance);
-	bool attached;
-	bool started;
-	struct mtd_dev_s *mtd_dev;
-	unsigned n_partitions_current;
-	int *partition_block_counts;
-	const float *partition_percentages;
-	const char **partition_names;
-};
-
-static mtd_instance_s instances[] = {
-#ifdef CONFIG_MTD_RAMTRON
-	{&ramtron_attach, false, false, nullptr, 0, nullptr, partition_sizes_default, partition_names_default},
-#endif
-#ifdef PX4_I2C_BUS_MTD
-	{&at24xxx_attach, false, false, nullptr, 0, nullptr, nullptr, nullptr},
-#endif
-};
-static constexpr int num_instances = arraySize(instances);
-static const int n_partitions_default = arraySize(partition_names_default);
-
-static int
-mtd_status(void)
+static int mtd_status(void)
 {
 	int ret = 0;
 	bool running = false;
+	unsigned int num_instances;
 
-	for (int i = 0; i < num_instances; ++i) {
-		if (instances[i].attached) {
-			ret |= mtd_print_info(i);
-			running = true;
+	const mtd_instance_s *instances = px4_mtd_get_instances(&num_instances);
+
+	if (instances) {
+		for (unsigned int i = 0; i < num_instances; ++i) {
+			if (instances[i].mtd_dev) {
+
+				unsigned long blocksize;
+				unsigned long erasesize;
+				unsigned long neraseblocks;
+				unsigned int  blkpererase;
+				unsigned int  nblocks;
+				unsigned int  partsize;
+
+				ret = px4_mtd_get_geometry(&instances[i], &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
+
+				if (ret == 0) {
+
+					PX4_INFO("Flash Geometry of instance %i:", i);
+
+					printf("  blocksize:      %lu\n", blocksize);
+					printf("  erasesize:      %lu\n", erasesize);
+					printf("  neraseblocks:   %lu\n", neraseblocks);
+					printf("  No. partitions: %u\n", instances[i].n_partitions_current);
+
+
+					unsigned int  totalnblocks = 0;
+					unsigned int  totalpartsize = 0;
+
+					for (unsigned int p = 0; p < instances[i].n_partitions_current; p++) {
+						FAR struct mtd_geometry_s geo;
+						ret = instances[i].part_dev[p]->ioctl(instances[i].part_dev[p], MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
+						printf("    partition: %u:\n", p);
+						printf("     name:   %s\n", instances[i].partition_names[p]);
+						printf("     blocks: %u (%u bytes)\n", geo.neraseblocks, erasesize * geo.neraseblocks);
+						totalnblocks += geo.neraseblocks;
+						totalpartsize += erasesize * geo.neraseblocks;
+					}
+
+					printf("  Device size: %u Blocks (%u bytes)\n", totalnblocks, totalpartsize);
+					printf("  TOTAL SIZE: %u KiB\n", totalpartsize  / 1024);
+				}
+
+				running |= true;
+			}
 		}
 	}
 
@@ -170,389 +140,27 @@ static void	print_usage(void)
 
 	PRINT_MODULE_USAGE_NAME("mtd", "command");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("status", "Print status information");
-
-	PRINT_MODULE_USAGE_COMMAND_DESCR("start", "Mount partitions");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("readtest", "Perform read test");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("rwtest", "Perform read-write test");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("erase", "Erase partition(s)");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("has-secondary", "Check if the board has configured a secondary device");
-
-	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'start', 'readtest' and 'rwtest' have an optional instance index:");
+	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'readtest' and 'rwtest' have an optional instance index:");
 	PRINT_MODULE_USAGE_PARAM_INT('i', 0, 0, 1, "storage index (if the board has multiple storages)", true);
 
-	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'start', 'readtest', 'rwtest' and 'erase' have an optional parameter:");
+	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'readtest', 'rwtest' and 'erase' have an optional parameter:");
 	PRINT_MODULE_USAGE_ARG("<partition_name1> [<partition_name2> ...]",
 			       "Partition names (eg. /fs/mtd_params), use system default if not provided", true);
 }
 
-int mtd_main(int argc, char *argv[])
-{
-	if (argc >= 2) {
-		int instance = 0;
-		int partition_index = 2;
-
-		if (argc > 3 && !strcmp(argv[2], "-i")) {
-			instance = strtol(argv[3], nullptr, 10);
-
-			if (instance < 0 || instance >= num_instances) {
-				PX4_ERR("invalid instance");
-				return -1;
-			}
-
-			partition_index += 2;
-		}
-
-		if (!strcmp(argv[1], "start")) {
-
-			/* start mapping according to user request */
-			if (argc > partition_index) {
-				return mtd_start(instances[instance], (const char **)(argv + partition_index), argc - partition_index);
-
-			} else {
-				return mtd_start(instances[instance], partition_names_default, n_partitions_default);
-			}
-		}
-
-		if (!strcmp(argv[1], "readtest")) {
-			if (argc > partition_index) {
-				return mtd_readtest(instances[instance], (const char **)(argv + partition_index), argc - partition_index);
-
-			} else {
-				return mtd_readtest(instances[instance], partition_names_default, n_partitions_default);
-			}
-		}
-
-		if (!strcmp(argv[1], "rwtest")) {
-			if (argc > partition_index) {
-				return mtd_rwtest(instances[instance], (const char **)(argv + partition_index), argc - partition_index);
-
-			} else {
-				return mtd_rwtest(instances[instance], partition_names_default, n_partitions_default);
-			}
-		}
-
-		if (!strcmp(argv[1], "status")) {
-			return mtd_status();
-		}
-
-		if (!strcmp(argv[1], "erase")) {
-			if (argc > partition_index) {
-				return mtd_erase((const char **)(argv + partition_index), argc - partition_index);
-
-			} else {
-				return mtd_erase(partition_names_default, n_partitions_default);
-			}
-		}
-
-		if (!strcmp(argv[1], "has-secondary")) {
-			return num_instances > 1 ? 0 : 1;
-		}
-	}
-
-	print_usage();
-	return 1;
-}
-
-struct mtd_dev_s *ramtron_initialize(FAR struct spi_dev_s *dev);
-struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
-				off_t firstblock, off_t nblocks);
-
-#ifdef CONFIG_MTD_RAMTRON
-static int
-ramtron_attach(mtd_instance_s &instance)
-{
-	/* initialize the right spi */
-	struct spi_dev_s *spi = px4_spibus_initialize(px4_find_spi_bus(SPIDEV_FLASH(0)));
-
-	if (spi == nullptr) {
-		PX4_ERR("failed to locate spi bus");
-		return 1;
-	}
-
-	/* this resets the spi bus, set correct bus speed again */
-	SPI_SETFREQUENCY(spi, 10 * 1000 * 1000);
-	SPI_SETBITS(spi, 8);
-	SPI_SETMODE(spi, SPIDEV_MODE3);
-	SPI_SELECT(spi, SPIDEV_FLASH(0), false);
-
-	/* start the RAMTRON driver, attempt 5 times */
-
-	for (int i = 0; i < 5; i++) {
-		instance.mtd_dev = ramtron_initialize(spi);
-
-		if (instance.mtd_dev) {
-			/* abort on first valid result */
-			if (i > 0) {
-				PX4_WARN("mtd needed %d attempts to attach", i + 1);
-			}
-
-			break;
-		}
-	}
-
-	/* if last attempt is still unsuccessful, abort */
-	if (instance.mtd_dev == nullptr) {
-		PX4_ERR("failed to initialize mtd driver");
-		return 1;
-	}
-
-	int ret = instance.mtd_dev->ioctl(instance.mtd_dev, MTDIOC_SETSPEED, (unsigned long)10 * 1000 * 1000);
-
-	if (ret != OK) {
-		// FIXME: From the previous warning call, it looked like this should have been fatal error instead. Tried
-		// that but setting the bus speed does fail all the time. Which was then exiting and the board would
-		// not run correctly. So changed to PX4_WARN.
-		PX4_WARN("failed to set bus speed");
-	}
-
-	instance.attached = true;
-	return 0;
-}
-#endif
-
-#ifdef PX4_I2C_BUS_MTD
-
-static int
-at24xxx_attach(mtd_instance_s &instance)
-{
-	/* find the right I2C */
-	struct i2c_master_s *i2c = px4_i2cbus_initialize(PX4_I2C_BUS_MTD);
-
-	if (i2c == nullptr) {
-		PX4_ERR("failed to locate I2C bus");
-		return 1;
-	}
-
-	/* start the MTD driver, attempt 5 times */
-	for (int i = 0; i < 5; i++) {
-		instance.mtd_dev = at24c_initialize(i2c);
-
-		if (instance.mtd_dev) {
-			/* abort on first valid result */
-			if (i > 0) {
-				PX4_WARN("EEPROM needed %d attempts to attach", i + 1);
-			}
-
-			break;
-		}
-	}
-
-	/* if last attempt is still unsuccessful, abort */
-	if (instance.mtd_dev == nullptr) {
-		PX4_ERR("failed to initialize EEPROM driver");
-		return 1;
-	}
-
-	instance.attached = true;
-	return 0;
-}
-#endif
-
-static int
-mtd_start(mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions)
-{
-	int ret;
-
-	if (instance.started) {
-		PX4_ERR("mtd already mounted");
-		return 1;
-	}
-
-	if (!instance.attached) {
-		ret = instance.attach(instance);
-
-		if (ret != 0) {
-			return ret;
-		}
-	}
-
-	if (!instance.mtd_dev) {
-		PX4_ERR("Failed to create MTD instance");
-		return 1;
-	}
-
-	unsigned long blocksize, erasesize, neraseblocks;
-	unsigned blkpererase, nblocks, partsize;
-
-	instance.n_partitions_current = n_partitions;
-	ret = mtd_get_geometry(instance, &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
-
-	if (ret) {
-		return ret;
-	}
-
-	/* Now create MTD FLASH partitions */
-
-	FAR struct mtd_dev_s *part[n_partitions];
-	char blockname[32];
-
-	unsigned offset;
-	unsigned i;
-
-
-	instance.partition_block_counts = new int[n_partitions];
-
-	if (instance.partition_block_counts == nullptr) {
-		PX4_ERR("mtd_partition failed allocation counts");
-		return 1;
-	}
-
-	instance.partition_names = new const char *[n_partitions];
-
-	if (instance.partition_names == nullptr) {
-		PX4_ERR("mtd_partition failed allocation for names");
-		return 1;
-	}
-
-	for (unsigned int n = 0; n < n_partitions; n++) {
-		float percentage = instance.partition_percentages == nullptr  ?
-				   100.0f / n_partitions : instance.partition_percentages[n];
-		volatile int nb = neraseblocks * (percentage / 100.0f);
-		instance.partition_block_counts[n] = (nb == 0 ? 1 : nb);
-		instance.partition_names[n] = nullptr;
-	}
-
-	for (offset = 0, i = 0; i < n_partitions; offset += instance.partition_block_counts[i], i++) {
-
-		/* Create the partition */
-
-		part[i] = mtd_partition(instance.mtd_dev, offset, instance.partition_block_counts[i]);
-
-		if (!part[i]) {
-			PX4_ERR("mtd_partition failed. offset=%lu nblocks=%lu",
-				(unsigned long)offset, (unsigned long)nblocks);
-			return 1;
-		}
-
-		instance.partition_names[i] = strdup(partition_names[i]);
-
-		/* Initialize to provide an FTL block driver on the MTD FLASH interface */
-
-		ret = -1;
-
-		for (int dev_index = 0; ret != 0; ++dev_index) {
-			snprintf(blockname, sizeof(blockname), "/dev/mtdblock%d", i + dev_index);
-
-			ret = ftl_initialize(i + dev_index, part[i]);
-
-			if (ret == -EEXIST) {
-				continue;
-			}
-
-			if (ret < 0 || dev_index >= 9) {
-				PX4_ERR("ftl_initialize %s failed: %d", blockname, ret);
-				return 1;
-			}
-		}
-
-		/* Now create a character device on the block device */
-
-		ret = bchdev_register(blockname, partition_names[i], false);
-
-		if (ret < 0) {
-			PX4_ERR("bchdev_register %s failed: %d", partition_names[i], ret);
-			return 1;
-		}
-	}
-
-	instance.started = true;
-	return 0;
-}
-
-int mtd_get_geometry(const mtd_instance_s &instance, unsigned long *blocksize, unsigned long *erasesize,
-		     unsigned long *neraseblocks,
-		     unsigned *blkpererase, unsigned *nblocks, unsigned *partsize)
-{
-	/* Get the geometry of the FLASH device */
-
-	FAR struct mtd_geometry_s geo;
-
-	int ret = instance.mtd_dev->ioctl(instance.mtd_dev, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
-
-	if (ret < 0) {
-		PX4_ERR("mtd->ioctl failed: %d", ret);
-		return ret;
-	}
-
-	*blocksize = geo.blocksize;
-	*erasesize = geo.erasesize;
-	*neraseblocks = geo.neraseblocks;
-
-	/* Determine the size of each partition.  Make each partition an even
-	 * multiple of the erase block size (perhaps not using some space at the
-	 * end of the FLASH).
-	 */
-
-	*blkpererase = geo.erasesize / geo.blocksize;
-	*nblocks     = (geo.neraseblocks / instance.n_partitions_current) * *blkpererase;
-	*partsize    = *nblocks * geo.blocksize;
-
-	return ret;
-}
-
-/*
-  get partition size in bytes
- */
-static ssize_t mtd_get_partition_size(const mtd_instance_s &instance, const char *partname)
-{
-	unsigned long blocksize, erasesize, neraseblocks;
-	unsigned blkpererase, nblocks, partsize = 0;
-
-	int ret = mtd_get_geometry(instance, &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks, &partsize);
-
-	if (ret != OK) {
-		PX4_ERR("Failed to get geometry");
-		return 0;
-	}
-
-	unsigned partn = 0;
-
-	for (unsigned n = 0; n < instance.n_partitions_current; n++) {
-		if (instance.partition_names[n] != nullptr &&
-		    partname != nullptr &&
-		    strcmp(instance.partition_names[n], partname) == 0) {
-			partn = n;
-			break;
-		}
-	}
-
-	return instance.partition_block_counts[partn] * erasesize;
-}
-
-int mtd_print_info(int instance)
-{
-	unsigned long blocksize, erasesize, neraseblocks;
-	unsigned blkpererase, nblocks, partsize;
-
-	int ret = mtd_get_geometry(instances[instance], &blocksize, &erasesize, &neraseblocks, &blkpererase, &nblocks,
-				   &partsize);
-
-	if (ret) {
-		return ret;
-	}
-
-	PX4_INFO("Flash Geometry of instance %i:", instance);
-
-	printf("  blocksize:      %lu\n", blocksize);
-	printf("  erasesize:      %lu\n", erasesize);
-	printf("  neraseblocks:   %lu\n", neraseblocks);
-	printf("  No. partitions: %u\n", instances[instance].n_partitions_current);
-	printf("  Partition size: %u Blocks (%u bytes)\n", nblocks, partsize);
-	printf("  TOTAL SIZE: %u KiB\n", neraseblocks * erasesize / 1024);
-
-	return 0;
-}
-
-int
-mtd_erase(const char *partition_names[], unsigned n_partitions)
+int mtd_erase(mtd_instance_s &instance)
 {
 	uint8_t v[64];
 	memset(v, 0xFF, sizeof(v));
 
-	for (uint8_t i = 0; i < n_partitions; i++) {
+	for (uint8_t i = 0; i < instance.n_partitions_current; i++) {
+
 		uint32_t count = 0;
-		printf("Erasing %s\n", partition_names[i]);
-		int fd = open(partition_names[i], O_WRONLY);
+		printf("Erasing %s\n", instance.partition_names[i]);
+		int fd = open(instance.partition_names[i], O_WRONLY);
 
 		if (fd == -1) {
 			PX4_ERR("Failed to open partition");
@@ -575,25 +183,22 @@ mtd_erase(const char *partition_names[], unsigned n_partitions)
   responding on the bus. It relies on the driver returning an error on
   bad reads (the ramtron driver does return an error)
  */
-int
-mtd_readtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions)
+int mtd_readtest(const mtd_instance_s &instance)
 {
-
-
 	uint8_t v[128];
 
-	for (uint8_t i = 0; i < n_partitions; i++) {
+	for (uint8_t i = 0; i < instance.n_partitions_current; i++) {
 		ssize_t count = 0;
 
-		ssize_t expected_size = mtd_get_partition_size(instance, partition_names[i]);
+		ssize_t expected_size = px4_mtd_get_partition_size(&instance, instance.partition_names[i]);
 
 		if (expected_size == 0) {
 			PX4_ERR("Failed partition size is 0");
 			return 1;
 		}
 
-		printf("reading %s expecting %u bytes\n", partition_names[i], expected_size);
-		int fd = open(partition_names[i], O_RDONLY);
+		printf("reading %s expecting %u bytes\n", instance.partition_names[i], expected_size);
+		int fd = open(instance.partition_names[i], O_RDONLY);
 
 		if (fd == -1) {
 			PX4_ERR("Failed to open partition");
@@ -622,24 +227,23 @@ mtd_readtest(const mtd_instance_s &instance, const char *partition_names[], unsi
   blocks and writes the data back, then reads it again, failing if the
   data isn't the same
  */
-int
-mtd_rwtest(const mtd_instance_s &instance, const char *partition_names[], unsigned n_partitions)
+int mtd_rwtest(const mtd_instance_s &instance)
 {
 	uint8_t v[128], v2[128];
 
-	for (uint8_t i = 0; i < n_partitions; i++) {
+	for (uint8_t i = 0; i < instance.n_partitions_current; i++) {
 		ssize_t count = 0;
 		off_t offset = 0;
 
-		ssize_t expected_size = mtd_get_partition_size(instance, partition_names[i]);
+		ssize_t expected_size = px4_mtd_get_partition_size(&instance, instance.partition_names[i]);
 
 		if (expected_size == 0) {
 			PX4_ERR("Failed partition size is 0");
 			return 1;
 		}
 
-		printf("rwtest %s testing %u bytes\n", partition_names[i], expected_size);
-		int fd = open(partition_names[i], O_RDWR);
+		printf("rwtest %s testing %u bytes\n", instance.partition_names[i], expected_size);
+		int fd = open(instance.partition_names[i], O_RDWR);
 
 		if (fd == -1) {
 			PX4_ERR("Failed to open partition");
@@ -689,4 +293,58 @@ mtd_rwtest(const mtd_instance_s &instance, const char *partition_names[], unsign
 	return 0;
 }
 
-#endif
+int mtd_main(int argc, char *argv[])
+{
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+	int ch;
+	int instance = 0;
+
+	while ((ch = px4_getopt(argc, argv, "i:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'i':
+			instance = atoi(myoptarg);
+			break;
+
+		default:
+			print_usage();
+			return -1;
+			break;
+		}
+	}
+
+	if (myoptind < argc) {
+		unsigned int num_instances;
+		mtd_instance_s *instances = px4_mtd_get_instances(&num_instances);
+
+		if (instances == nullptr) {
+			PX4_ERR("Driver not running");
+			return -1;
+		}
+
+		if (instance < 0 || (unsigned) instance >= num_instances) {
+			PX4_ERR("invalid instance");
+			return -1;
+		}
+
+		if (!strcmp(argv[myoptind], "readtest")) {
+			return mtd_readtest(instances[instance]);
+		}
+
+		if (!strcmp(argv[myoptind], "rwtest")) {
+			return mtd_rwtest(instances[instance]);
+		}
+
+
+		if (!strcmp(argv[myoptind], "status")) {
+			return mtd_status();
+		}
+
+		if (!strcmp(argv[myoptind],  "erase")) {
+			return mtd_erase(instances[instance]);
+		}
+	}
+
+	print_usage();
+	return 1;
+}


### PR DESCRIPTION
Ultimately we want to have a device tree like description that can be statically compiled, and have overlays. See last section (DT Straw Man)

The changes here-in support a migration path to remove `mtd` from the rcS and only call it from the board start up code.

uorb is started from the board files (this and the mtd start can be moved to the px4_init layer once fully fleshed out)

`BOARD_MANAGED_MTD` is used to condition the mtd code. Once all the boards are converted (FLASH permitting) mtd.cpp can be refactored again and vastly simplified.

The digested  mtd section of DT is seen in the the board file [mtd.cpp](https://github.com/PX4/PX4-Autopilot/compare/pr-mtd-mgr?expand=1#diff-1b6b9fce0abee35f4fa573ce88a986254b8a8fcda2bbc3494c0b7a1a5ae4a6e5) (there is more work to be done here)

# DT Straw Man
The following is a file is used at compile time to build 
board.h from a template
 adding pin selection
 DMA etc

```
 board: fmuv5x {
  cpu: stm32f7 {
    main_osc: 16Mhz, 
    rtc_osc:  32khZ
  }
  
  buses {
   I2C1: {
     device:INA226 {
       driver:ina226
       address: 0x41
       policy {
         alternate: {I2C2 : INA226}
         boot: optional
         arm:  mandatory or alternate
       }
     }
    device: ist8310 {
       driver: ist8310@0xe
       address: 0x0e 
       policy {
         boot: optional
         arm:  mandatory
       }
    }
    
     device:LED {
       driver: rgbled@0x55, rgbled_ncp5623c@0x39
       address: 0x55, 0x39 
       policy {
         boot: optional
         arm:  optional
       }
     }
     
   }
   I2C2: {
     device: INA226 {
       driver:ina226
       address: 0x41
       policy {
         alternate: {I2C1 : INA226}
         boot: optional
         arm:  mandatory or alternate
     }
   }
   I2C3: {
     device:  MS5611 {
       driver:  ms5611
       address: 0x77
       policy {
         boot: mandatory
         arm:  mandatory
       }
     }

     device:  24LC64T {
       driver:  mtd
       partition: {
       		/fs/mtd_caldata,all
       } 
       address: 0x51
       policy {
         boot: mandatory
         arm:  mandatory
       }
     }
   }
   I2C4: {
     device:  BMP388 {
       driver:  bmp388
       address: 0x76
      PWR:   PG8
       policy {
         boot: mandatory
         arm:  mandatory
       }
     }

     device:  SE050 {
       driver:  na
       address: 0x48
      PWR:   PG8
       policy {
         boot: disabled
         arm:  disabled
       }
    }
   }
   
   SPI1: {
    device: ICM20602 {
    	driver: icm20602
    	paramaters: {
    	r 
    	}
      CS:     PI9
      DRDY:   PF2
      PWR:    PI11
     }
   }

   SPI2: {
    device: ISM330DLC {
      CS:      PH5}
      DRDY:   PH12
      PWR:    PD15
     }
   }

    SPI3: {
      device: DRV_GYR_DEVTYPE_BMI088 {
       CS:    PI8
       DRDY:  PI7
       PWR:   PE7
       }
       
       device: DRV_ACC_DEVTYPE_BMI088 {
         CS:    PI4
         PWR:   PE7
        }
     SPI4: {
       PWR: PG8
     }

      SPI5: {
        driver:  mtd
        partition: {
       		/fs/mtd_params,50,
       		/fs/mtd_waypoints,50
        } 
        policy {
         boot: mandatory
         arm:  mandatory
       }

        device: SPIDEV_FLASH(0) 
        CS:      PG7
        }
      }
        
    SPI6: {
      CS:   PI10
      DRDY: PD11
      CS:   PA15 
      DRDY  PD12
    }
  }
  
  USART6: {
    device: px4io
    driver: px4io
    TX: PC6
    RX: PC7
    
  }
  ETHERNET : {
  PWR: PG15
  }
}
```

to process mtd entries:
Query the dt for all mtd.
  Get's back an interator
  allocate an instance table sized but iteratior.count
  populate it from the interator.
  then for each I of the interator call mtd_start
```