### PR TITLE
mavlink_receiver: remove unused decode_switch_pos function

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1894,13 +1894,6 @@ MavlinkReceiver::handle_message_trajectory_representation_waypoints(mavlink_mess
 	_trajectory_waypoint_pub.publish(trajectory_waypoint);
 }
 
-switch_pos_t
-MavlinkReceiver::decode_switch_pos(uint16_t buttons, unsigned sw)
-{
-	// This 2-bit method should be used in the future: (buttons >> (sw * 2)) & 3;
-	return (buttons & (1 << sw)) ? manual_control_setpoint_s::SWITCH_POS_ON : manual_control_setpoint_s::SWITCH_POS_OFF;
-}
-
 int
 MavlinkReceiver::decode_switch_pos_n(uint16_t buttons, unsigned sw)
 {

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -206,11 +206,6 @@ private:
 	void get_message_interval(int msgId);
 
 	/**
-	 * Decode a switch position from a bitfield.
-	 */
-	switch_pos_t decode_switch_pos(uint16_t buttons, unsigned sw);
-
-	/**
 	 * Decode a switch position from a bitfield and state.
 	 */
 	int decode_switch_pos_n(uint16_t buttons, unsigned sw);


### PR DESCRIPTION
**Describe your solution**
Removing a function I randomly saw that is not referenced anywhere.

**Test data / coverage**
Still compiles.
