### PR TITLE
Fix bash error when running SITL Gazebo

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -131,7 +131,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		readarray -d : -t paths <<< ${GAZEBO_MODEL_PATH}
 		for possibleModelPath in "${paths[@]}"; do
 			# trim \r from path
-			possibleModelPath = $(echo $possibleModelPath | tr -d '\r')
+			possibleModelPath=$(echo $possibleModelPath | tr -d '\r')
 			if test -f "${possibleModelPath}/${model}/${model}.sdf" ; then
 				modelpath=$possibleModelPath
 				break


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is a followup on #16214, where a syntax error in `sitl_run.sh` was preventing SITL from running properly

**Describe your solution**
Remove the spaces


**Test data / coverage**
Tested locally, with
```
make px4_sitl gazebo
```

**Additional context**
- The problem was intrduced in #16214
