### PR TITLE
fix bug introduced by #16214

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -131,7 +131,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		readarray -d : -t paths <<< ${GAZEBO_MODEL_PATH}
 		for possibleModelPath in "${paths[@]}"; do
 			# trim \r from path
-			possibleModelPath = $(echo $possibleModelPath | tr -d '\r')
+			possibleModelPath=$(echo $possibleModelPath | tr -d '\r')
 			if test -f "${possibleModelPath}/${model}/${model}.sdf" ; then
 				modelpath=$possibleModelPath
 				break


### PR DESCRIPTION
**Describe problem solved by this pull request**
A small typo bug was introduced in a recent commit with spaces around an equals sign in a shell script. 

**Describe your solution**
Removed the spaces around the equals sign.

**Describe possible alternatives**
N/A

**Test data / coverage**
Empirical success with `make px4 gazebo`