### PR TITLE
NXP UCANS32K146: Configure PWM timer for production version

### DIFF
--- a/boards/nxp/ucans32k146/src/timer_config.cpp
+++ b/boards/nxp/ucans32k146/src/timer_config.cpp
@@ -105,13 +105,11 @@
 #define rPWMLOAD(t)    REG(t,S32K1XX_FTM_PWMLOAD_OFFSET)
 
 constexpr io_timers_t io_timers[MAX_IO_TIMERS] = {
-	initIOTimer(Timer::FTM0),
-	//initIOTimer(Timer::FTM2),
+	initIOTimer(Timer::FTM2),
 };
 
 constexpr timer_io_channels_t timer_io_channels[MAX_TIMER_IO_CHANNELS] = {
-	initIOTimerChannel(io_timers, {Timer::FTM0, Timer::Channel7}, {GPIO::PortE, GPIO::Pin9}),
-	//initIOTimerChannel(io_timers, {Timer::FTM2, Timer::Channel1}, {GPIO::PortA, GPIO::Pin0}),
+	initIOTimerChannel(io_timers, {Timer::FTM2, Timer::Channel1}, {GPIO::PortA, GPIO::Pin0}),
 };
 
 constexpr io_timers_channel_mapping_t io_timers_channel_mapping =


### PR DESCRIPTION
The initial PWM timer configuration was made for and tested on a pre-production version of the hardware. It's about time we change this to enable PWM on the released version of the board. @davids5 @dagar 

FYI @igalloway 