### PR TITLE
Fixed PX4IO uploader debug output

### DIFF
--- a/src/drivers/px4io/px4io_uploader.cpp
+++ b/src/drivers/px4io/px4io_uploader.cpp
@@ -268,7 +268,7 @@ PX4IO_Uploader::recv_byte_with_timeout(uint8_t *c, unsigned timeout)
 
 	read(_io_fd, c, 1);
 #ifdef UDEBUG
-	log("recv_bytes 0x%02x", c);
+	log("recv_bytes 0x%02x", *c);
 #endif
 	return OK;
 }
@@ -315,7 +315,17 @@ int
 PX4IO_Uploader::send(uint8_t c)
 {
 #ifdef UDEBUG
-	log("send 0x%02x", c);
+	static uint8_t cnt = 0;
+
+	if (c == 0) {
+		if (cnt == 0 || cnt == 32 || cnt == 64 || cnt == 128) { log("send+ 0x%02x", c); }
+
+		cnt++;
+
+	} else {
+		log("send 0x%02x", c);
+	}
+
 #endif
 
 	if (write(_io_fd, &c, 1) != 1) {


### PR DESCRIPTION
The Debug code was broken and not useful.

This rat limits the syncs and fixed the `recv_bytes` to print the data.