### PR TITLE
Bring back RC throttle override with a parameter to disable it

### DIFF
--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -50,6 +50,7 @@ px4_add_module(
 		level_calibration.cpp
 		lm_fit.cpp
 		mag_calibration.cpp
+		ManualControl.cpp
 		rc_calibration.cpp
 		state_machine_helper.cpp
 		worker_thread.cpp

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2100,16 +2100,17 @@ Commander::run()
 							    && _vehicle_control_mode.flag_control_offboard_enabled;
 
 			if ((override_auto_mode || override_offboard_mode) && !in_low_battery_failsafe && !_geofence_warning_action_on) {
-				const float minimum_stick_deflection = 0.01f * _param_com_rc_stick_ov.get();
+				const float minimum_stick_change = .01f * _param_com_rc_stick_ov.get();
 
-				const bool rpy_deflected = (fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
-							(fabsf(_manual_control_setpoint.y) > minimum_stick_deflection)
-							|| (fabsf(_manual_control_setpoint.r) > minimum_stick_deflection);
-				const bool throttle_deflected = fabsf(_manual_control_setpoint.z - 0.5f) * 2.f > minimum_stick_deflection;
+				const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
+						|| (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
+						|| (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
+				const bool throttle_moved =
+					(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
 				const bool use_throttle = !(_param_rc_override.get() & OVERRIDE_IGNORE_THROTTLE_BIT);
 
 				if (!_status.rc_signal_lost &&
-				(rpy_deflected || (use_throttle && throttle_deflected))) {
+				(rpy_moved || (use_throttle && throttle_moved))) {
 					if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 								  &_internal_state) == TRANSITION_CHANGED) {
 						tune_positive(true);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1556,7 +1556,7 @@ Commander::run()
 	_last_lvel_fail_time_us = _boot_timestamp;
 
 	// user adjustable duration required to assert arm/disarm via throttle/rudder stick
-	uint32_t rc_arm_hyst = _param_rc_arm_hyst.get() * COMMANDER_MONITORING_LOOPSPERMSEC;
+	uint32_t rc_arm_hyst = _param_rc_arm_hyst.get() * COMMANDER_MONITORING_LOOPSPERMSEC; //
 
 	int32_t airmode = 0;
 	int32_t rc_map_arm_switch = 0;
@@ -2155,6 +2155,10 @@ Commander::run()
 			 * and we are in MANUAL, Rattitude, or AUTO_READY mode or (ASSIST mode and landed)
 			 * do it only for rotary wings in manual mode or fixed wing if landed.
 			 * Disable stick-disarming if arming switch or button is mapped */
+			if (_manual_control.wantsDisarm(_vehicle_control_mode, _status, _land_detector.landed)) {
+				disarm(arm_disarm_reason_t::RC_STICK);
+			}
+
 			const bool stick_in_lower_left = _manual_control_setpoint.r < -STICK_ON_OFF_LIMIT
 							 && (_manual_control_setpoint.z < 0.1f)
 							 && !arm_switch_or_button_mapped;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2719,6 +2719,7 @@ Commander::run()
 		_last_condition_global_position_valid = _status_flags.condition_global_position_valid;
 
 		_was_armed = _armed.armed;
+		_last_manual_control_setpoint = _manual_control_setpoint;
 
 		arm_auth_update(now, params_updated || param_init_forced);
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1986,9 +1986,6 @@ Commander::run()
 			}
 		}
 
-		_manual_control.update();
-		_manual_control_setpoint = _manual_control._manual_control_setpoint;
-
 		/* start geofence result check */
 		_geofence_result_sub.update(&_geofence_result);
 
@@ -2090,10 +2087,14 @@ Commander::run()
 			_geofence_violated_prev = false;
 		}
 
+		_manual_control.setRCAllowed(!_status_flags.rc_input_blocked);
+		_manual_control.update();
+		_manual_control_setpoint = _manual_control._manual_control_setpoint;
+
 		// abort autonomous mode and switch to position mode if sticks are moved significantly
 		if ((_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
 		    && !in_low_battery_failsafe && !_geofence_warning_action_on
-		    && _manual_control.wantsOverride(_vehicle_control_mode, !_status.rc_signal_lost)) {
+		    && _manual_control.wantsOverride(_vehicle_control_mode)) {
 			if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 						  &_internal_state) == TRANSITION_CHANGED) {
 				tune_positive(true);
@@ -2119,9 +2120,9 @@ Commander::run()
 			}
 		}
 
+
 		/* RC input check */
-		if (!_status_flags.rc_input_blocked && _manual_control_setpoint.timestamp != 0 &&
-		    (hrt_elapsed_time(&_manual_control_setpoint.timestamp) < (_param_com_rc_loss_t.get() * 1_s))) {
+		if (_manual_control.isRCAvailable()) {
 
 			/* handle the case where RC signal was regained */
 			if (!_status_flags.rc_signal_found_once) {
@@ -2701,7 +2702,6 @@ Commander::run()
 		_last_condition_global_position_valid = _status_flags.condition_global_position_valid;
 
 		_was_armed = _armed.armed;
-		_last_manual_control_setpoint = _manual_control_setpoint;
 
 		arm_auth_update(now, params_updated || param_init_forced);
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1986,8 +1986,8 @@ Commander::run()
 			}
 		}
 
-		// update manual_control_setpoint before geofence (which might check sticks or switches)
-		_manual_control_setpoint_sub.update(&_manual_control_setpoint);
+		_manual_control.update();
+		_manual_control_setpoint = _manual_control._manual_control_setpoint;
 
 		/* start geofence result check */
 		_geofence_result_sub.update(&_geofence_result);
@@ -2091,33 +2091,16 @@ Commander::run()
 		}
 
 		// abort autonomous mode and switch to position mode if sticks are moved significantly
-		if ((_param_rc_override.get() != 0) && (_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
-
-			const bool override_auto_mode = (_param_rc_override.get() & OVERRIDE_AUTO_MODE_BIT)
-							&& _vehicle_control_mode.flag_control_auto_enabled;
-
-			const bool override_offboard_mode = (_param_rc_override.get() & OVERRIDE_OFFBOARD_MODE_BIT)
-							    && _vehicle_control_mode.flag_control_offboard_enabled;
-
-			if ((override_auto_mode || override_offboard_mode) && !in_low_battery_failsafe && !_geofence_warning_action_on) {
-				const float minimum_stick_change = .01f * _param_com_rc_stick_ov.get();
-
-				const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
-						|| (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
-						|| (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
-				const bool throttle_moved =
-					(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
-				const bool use_throttle = !(_param_rc_override.get() & OVERRIDE_IGNORE_THROTTLE_BIT);
-
-				if (!_status.rc_signal_lost &&
-				(rpy_moved || (use_throttle && throttle_moved))) {
-					if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
-								  &_internal_state) == TRANSITION_CHANGED) {
-						tune_positive(true);
-						mavlink_log_info(&_mavlink_log_pub, "Pilot took over control using sticks");
-						_status_changed = true;
-					}
-				}
+		if ((_param_rc_override.get() != 0)
+		    && (_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
+		    && !in_low_battery_failsafe && !_geofence_warning_action_on
+		    && _manual_control.wantsOverride(_param_rc_override.get(), _param_com_rc_stick_ov.get(), _vehicle_control_mode,
+						     !_status.rc_signal_lost)) {
+			if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
+						  &_internal_state) == TRANSITION_CHANGED) {
+				tune_positive(true);
+				mavlink_log_info(&_mavlink_log_pub, "Pilot took over control using sticks");
+				_status_changed = true;
 			}
 		}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2091,11 +2091,9 @@ Commander::run()
 		}
 
 		// abort autonomous mode and switch to position mode if sticks are moved significantly
-		if ((_param_rc_override.get() != 0)
-		    && (_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
+		if ((_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
 		    && !in_low_battery_failsafe && !_geofence_warning_action_on
-		    && _manual_control.wantsOverride(_param_rc_override.get(), _param_com_rc_stick_ov.get(), _vehicle_control_mode,
-						     !_status.rc_signal_lost)) {
+		    && _manual_control.wantsOverride(_vehicle_control_mode, !_status.rc_signal_lost)) {
 			if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 						  &_internal_state) == TRANSITION_CHANGED) {
 				tune_positive(true);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2102,10 +2102,14 @@ Commander::run()
 			if ((override_auto_mode || override_offboard_mode) && !in_low_battery_failsafe && !_geofence_warning_action_on) {
 				const float minimum_stick_deflection = 0.01f * _param_com_rc_stick_ov.get();
 
-				if (!_status.rc_signal_lost &&
-				    ((fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
-				     (fabsf(_manual_control_setpoint.y) > minimum_stick_deflection))) {
+				const bool rpy_deflected = (fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
+							(fabsf(_manual_control_setpoint.y) > minimum_stick_deflection)
+							|| (fabsf(_manual_control_setpoint.r) > minimum_stick_deflection);
+				const bool throttle_deflected = fabsf(_manual_control_setpoint.z - 0.5f) * 2.f > minimum_stick_deflection;
+				const bool use_throttle = !(_param_rc_override.get() & OVERRIDE_IGNORE_THROTTLE_BIT);
 
+				if (!_status.rc_signal_lost &&
+				(rpy_deflected || (use_throttle && throttle_deflected))) {
 					if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 								  &_internal_state) == TRANSITION_CHANGED) {
 						tune_positive(true);

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -37,6 +37,7 @@
 /*   Helper classes  */
 #include "Arming/PreFlightCheck/PreFlightCheck.hpp"
 #include "failure_detector/FailureDetector.hpp"
+#include "ManualControl.hpp"
 #include "state_machine_helper.h"
 #include "worker_thread.hpp"
 
@@ -70,7 +71,6 @@
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/iridiumsbd_status.h>
-#include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/manual_control_switches.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
@@ -286,12 +286,6 @@ private:
 		ALWAYS = 2
 	};
 
-	enum OverrideMode {
-		OVERRIDE_AUTO_MODE_BIT = (1 << 0),
-		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1),
-		OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
-	};
-
 	/* Decouple update interval and hysteresis counters, all depends on intervals */
 	static constexpr uint64_t COMMANDER_MONITORING_INTERVAL{10_ms};
 	static constexpr float COMMANDER_MONITORING_LOOPSPERMSEC{1 / (COMMANDER_MONITORING_INTERVAL / 1000.0f)};
@@ -367,6 +361,7 @@ private:
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
+	ManualControl _manual_control;
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
 	int32_t		_flight_mode_slots[manual_control_switches_s::MODE_SLOT_NUM] {};
 	uint8_t		_last_manual_control_switches_arm_switch{manual_control_switches_s::SWITCH_POS_NONE};
@@ -417,7 +412,6 @@ private:
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_land_detector_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription					_safety_sub{ORB_ID(safety)};
-	uORB::Subscription					_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription					_manual_control_switches_sub{ORB_ID(manual_control_switches)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
 	uORB::Subscription					_vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -195,7 +195,6 @@ private:
 		(ParamInt<px4::params::COM_HLDL_REG_T>) _param_com_hldl_reg_t,
 
 		(ParamInt<px4::params::NAV_RCL_ACT>) _param_nav_rcl_act,
-		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamFloat<px4::params::COM_RCL_ACT_T>) _param_com_rcl_act_t,
 
 		(ParamFloat<px4::params::COM_HOME_H_T>) _param_com_home_h_t,
@@ -356,7 +355,6 @@ private:
 	unsigned int	_leds_counter{0};
 
 	manual_control_setpoint_s _manual_control_setpoint{};
-	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
 	ManualControl _manual_control{this};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -363,7 +363,8 @@ private:
 
 	unsigned int	_leds_counter{0};
 
-	manual_control_setpoint_s _manual_control_setpoint{};		///< the current manual control setpoint
+	manual_control_setpoint_s _manual_control_setpoint{};
+	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -245,10 +245,8 @@ private:
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,
 
-		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_rc_in_off,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
-		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
 
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,
 		(ParamInt<px4::params::COM_FLTMODE2>) _param_fltmode_2,
@@ -361,7 +359,7 @@ private:
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
-	ManualControl _manual_control;
+	ManualControl _manual_control{this};
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
 	int32_t		_flight_mode_slots[manual_control_switches_s::MODE_SLOT_NUM] {};
 	uint8_t		_last_manual_control_switches_arm_switch{manual_control_switches_s::SWITCH_POS_NONE};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -287,9 +287,9 @@ private:
 	};
 
 	enum OverrideMode {
-		OVERRIDE_DISABLED = 0,
 		OVERRIDE_AUTO_MODE_BIT = (1 << 0),
-		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1)
+		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1),
+		OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
 	};
 
 	/* Decouple update interval and hysteresis counters, all depends on intervals */

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -235,7 +235,7 @@ private:
 		(ParamFloat<px4::params::COM_EF_TIME>) _param_ef_time_thres,
 
 		(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_arm_without_gps,
-		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_arm_switch_is_button,
+		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_arm_switch_is_button, //
 		(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_arm_mission_required,
 		(ParamBool<px4::params::COM_ARM_AUTH_REQ>) _param_arm_auth_required,
 		(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required,
@@ -245,7 +245,7 @@ private:
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,
 
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_rc_in_off,
-		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
+		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst, //
 
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,
 		(ParamInt<px4::params::COM_FLTMODE2>) _param_fltmode_2,
@@ -287,7 +287,7 @@ private:
 	static constexpr uint64_t COMMANDER_MONITORING_INTERVAL{10_ms};
 	static constexpr float COMMANDER_MONITORING_LOOPSPERMSEC{1 / (COMMANDER_MONITORING_INTERVAL / 1000.0f)};
 
-	static constexpr float STICK_ON_OFF_LIMIT{0.9f};
+	static constexpr float STICK_ON_OFF_LIMIT{0.9f}; //
 
 	static constexpr uint64_t HOTPLUG_SENS_TIMEOUT{8_s};	/**< wait for hotplug sensors to come online for upto 8 seconds */
 	static constexpr uint64_t PRINT_MODE_REJECT_INTERVAL{500_ms};

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ManualControl.hpp"
+
+enum OverrideBits {
+	OVERRIDE_AUTO_MODE_BIT = (1 << 0),
+	OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1),
+	OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
+};
+
+void ManualControl::update()
+{
+	if (_manual_control_setpoint_sub.updated()) {
+		manual_control_setpoint_s manual_control_setpoint;
+
+		if (_manual_control_setpoint_sub.copy(&manual_control_setpoint)) {
+			process(manual_control_setpoint);
+		}
+	}
+}
+
+void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)
+{
+	_last_manual_control_setpoint = _manual_control_setpoint;
+	_manual_control_setpoint = manual_control_setpoint;
+}
+
+bool ManualControl::wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
+				  const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available)
+{
+	const bool override_auto_mode = (param_rc_override & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
+					&& vehicle_control_mode.flag_control_auto_enabled;
+
+	const bool override_offboard_mode = (param_rc_override & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
+					    && vehicle_control_mode.flag_control_offboard_enabled;
+
+	if (rc_available && (override_auto_mode || override_offboard_mode)) {
+		const float minimum_stick_change = .01f * param_com_rc_stick_ov;
+
+		const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
+				       || (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
+				       || (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
+		const bool throttle_moved =
+			(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
+		const bool use_throttle = !(param_rc_override & OverrideBits::OVERRIDE_IGNORE_THROTTLE_BIT);
+
+		if (rpy_moved || (use_throttle && throttle_moved)) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -56,24 +56,23 @@ void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)
 	_manual_control_setpoint = manual_control_setpoint;
 }
 
-bool ManualControl::wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
-				  const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available)
+bool ManualControl::wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available)
 {
-	const bool override_auto_mode = (param_rc_override & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
+	const bool override_auto_mode = (_param_rc_override.get() & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
 					&& vehicle_control_mode.flag_control_auto_enabled;
 
-	const bool override_offboard_mode = (param_rc_override & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
+	const bool override_offboard_mode = (_param_rc_override.get() & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
 					    && vehicle_control_mode.flag_control_offboard_enabled;
 
 	if (rc_available && (override_auto_mode || override_offboard_mode)) {
-		const float minimum_stick_change = .01f * param_com_rc_stick_ov;
+		const float minimum_stick_change = .01f * _param_com_rc_stick_ov.get();
 
 		const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
 				       || (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
 				       || (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
 		const bool throttle_moved =
 			(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
-		const bool use_throttle = !(param_rc_override & OverrideBits::OVERRIDE_IGNORE_THROTTLE_BIT);
+		const bool use_throttle = !(_param_rc_override.get() & OverrideBits::OVERRIDE_IGNORE_THROTTLE_BIT);
 
 		if (rpy_moved || (use_throttle && throttle_moved)) {
 			return true;

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -57,12 +57,6 @@ void ManualControl::update()
 	}
 }
 
-void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)
-{
-	_last_manual_control_setpoint = _manual_control_setpoint;
-	_manual_control_setpoint = manual_control_setpoint;
-}
-
 bool ManualControl::wantsOverride(const vehicle_control_mode_s &vehicle_control_mode)
 {
 	const bool override_auto_mode = (_param_rc_override.get() & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
@@ -87,4 +81,23 @@ bool ManualControl::wantsOverride(const vehicle_control_mode_s &vehicle_control_
 	}
 
 	return false;
+}
+
+bool ManualControl::wantsDisarm(const vehicle_control_mode_s &vehicle_control_mode,
+				const vehicle_status_s &vehicle_status, const bool landed)
+{
+	bool ret = false;
+	return ret;
+}
+
+void ManualControl::updateParams()
+{
+	ModuleParams::updateParams();
+	_stick_disarm_hysteresis.set_hysteresis_time_from(false, _param_rc_arm_hyst.get() * 1_ms);
+}
+
+void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)
+{
+	_last_manual_control_setpoint = _manual_control_setpoint;
+	_manual_control_setpoint = manual_control_setpoint;
 }

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -41,19 +41,20 @@
 
 #pragma once
 
+#include <px4_platform_common/module_params.h>
+
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 
-class ManualControl
+class ManualControl : ModuleParams
 {
 public:
-	ManualControl() = default;
-	~ManualControl() = default;
+	ManualControl(ModuleParams *parent) : ModuleParams(parent) {};
+	~ManualControl() override = default;
 
 	void update();
-	bool wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
-			   const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
+	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
 
 //private:
 	void process(manual_control_setpoint_s &manual_control_setpoint);
@@ -61,4 +62,9 @@ public:
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
+		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov
+	)
 };

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -58,11 +58,12 @@ public:
 	bool isRCAvailable() { return _rc_available; }
 	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
 
-//private:
+	manual_control_setpoint_s _manual_control_setpoint{};
+
+private:
 	void process(manual_control_setpoint_s &manual_control_setpoint);
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
-	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 
 	bool _rc_allowed{false};

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ManualControl.hpp
+ *
+ * @brief Logic for handling RC or Joystick input
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/vehicle_control_mode.h>
+
+class ManualControl
+{
+public:
+	ManualControl() = default;
+	~ManualControl() = default;
+
+	void update();
+	bool wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
+			   const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
+
+//private:
+	void process(manual_control_setpoint_s &manual_control_setpoint);
+
+	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	manual_control_setpoint_s _manual_control_setpoint{};
+	manual_control_setpoint_s _last_manual_control_setpoint{};
+};

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -53,8 +53,10 @@ public:
 	ManualControl(ModuleParams *parent) : ModuleParams(parent) {};
 	~ManualControl() override = default;
 
+	void setRCAllowed(const bool rc_allowed) { _rc_allowed = rc_allowed; }
 	void update();
-	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
+	bool isRCAvailable() { return _rc_available; }
+	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
 
 //private:
 	void process(manual_control_setpoint_s &manual_control_setpoint);
@@ -63,7 +65,11 @@ public:
 	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 
+	bool _rc_allowed{false};
+	bool _rc_available{false};
+
 	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov
 	)

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -41,11 +41,13 @@
 
 #pragma once
 
+#include <lib/hysteresis/hysteresis.h>
 #include <px4_platform_common/module_params.h>
 
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_status.h>
 
 class ManualControl : ModuleParams
 {
@@ -57,10 +59,13 @@ public:
 	void update();
 	bool isRCAvailable() { return _rc_available; }
 	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
+	bool wantsDisarm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,
+			 const bool landed);
 
 	manual_control_setpoint_s _manual_control_setpoint{};
 
 private:
+	void updateParams() override;
 	void process(manual_control_setpoint_s &manual_control_setpoint);
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
@@ -69,8 +74,11 @@ private:
 	bool _rc_allowed{false};
 	bool _rc_available{false};
 
+	systemlib::Hysteresis _stick_disarm_hysteresis{false};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
+		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
 		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov
 	)

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -637,9 +637,10 @@ PARAM_DEFINE_INT32(COM_REARM_GRACE, 1);
  * Note: Only has an effect on multicopters, and VTOLs in multicopter mode.
  *
  * @min 0
- * @max 3
+ * @max 7
  * @bit 0 Enable override during auto modes (except for in critical battery reaction)
  * @bit 1 Enable override during offboard mode
+ * @bit 2 Ignore throttle stick
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
@@ -647,8 +648,8 @@ PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
 /**
  * RC stick override threshold
  *
- * If COM_RC_OVERRIDE is enabled and the joystick input controlling the horizontally axis (right stick for RC in mode 2)
- * is moved more than this threshold from the center the autopilot switches to position mode and the pilot takes over control.
+ * If COM_RC_OVERRIDE is enabled and the joystick input is moved more than this threshold from the center
+ * the autopilot switches to position mode and the pilot takes over control.
  *
  * @group Commander
  * @unit %

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -648,8 +648,8 @@ PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
 /**
  * RC stick override threshold
  *
- * If COM_RC_OVERRIDE is enabled and the joystick input is moved more than this threshold from the center
- * the autopilot switches to position mode and the pilot takes over control.
+ * If COM_RC_OVERRIDE is enabled and the joystick input is moved more than this threshold
+ * the autopilot the pilot takes over control.
  *
  * @group Commander
  * @unit %

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -49,8 +49,6 @@
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/defines.h>
 #include <px4_platform_common/module.h>
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/module_params.h>
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>


### PR DESCRIPTION
**Describe problem solved by this pull request**
https://github.com/PX4/PX4-Autopilot/pull/15495 removed the possibility to take over control with the RC override feature using the throttle or yaw stick axis.

**Describe @jkflying's solution**
This pr is bringing back this functionality by default adding an option to not use throttle to break out of auto modes with RC using the third bit of the `COM_RC_OVERRIDE` parameter for the use cases where the throttle is not self-centering.

Thanks to @jkflying for addressing this!

**Describe possible alternatives**
Throttle centering could maybe be auto-detected in the future.

**Test data / coverage**
SITL jmavsim tested. Override works as expected. In the case the throttle is not centered and e.g. hold is commended from QGC the ground station tries to switch three times before giving up.

**Additional context**
Original related issue: https://github.com/PX4/PX4-Autopilot/issues/13061