### PR TITLE
Simple mixer: add output slew rate

### DIFF
--- a/src/lib/mixer/MixerBase/Mixer.hpp
+++ b/src/lib/mixer/MixerBase/Mixer.hpp
@@ -229,6 +229,8 @@ public:
 
 	virtual unsigned		get_multirotor_count()  { return 0; }
 
+	virtual void 			set_dt_once(float dt) {}
+
 protected:
 
 	/** client-supplied callback used when fetching control values */

--- a/src/lib/mixer/MixerGroup.cpp
+++ b/src/lib/mixer/MixerGroup.cpp
@@ -243,3 +243,11 @@ void MixerGroup::set_max_delta_out_once(float delta_out_max)
 		mixer->set_max_delta_out_once(delta_out_max);
 	}
 }
+
+void
+MixerGroup::set_dt_once(float dt)
+{
+	for (auto mixer : _mixers) {
+		mixer->set_dt_once(dt);
+	}
+}

--- a/src/lib/mixer/MixerGroup.hpp
+++ b/src/lib/mixer/MixerGroup.hpp
@@ -165,6 +165,8 @@ public:
 
 	unsigned			get_multirotor_count();
 
+	void 				set_dt_once(float dt);
+
 private:
 	List<Mixer *>			_mixers;	/**< linked list of mixers */
 };

--- a/src/lib/mixer/SimpleMixer/SimpleMixer.hpp
+++ b/src/lib/mixer/SimpleMixer/SimpleMixer.hpp
@@ -57,6 +57,7 @@ struct mixer_control_s {
 struct mixer_simple_s {
 	uint8_t			control_count;	/**< number of inputs */
 	mixer_scaler_s		output_scaler;	/**< scaling for the output */
+	float 			slew_rate_rise_time{0.0f}; /**< output max rise time (slew rate limit)*/
 	mixer_control_s		controls[];	/**< actual size of the array is set by control_count */
 };
 
@@ -119,6 +120,7 @@ public:
 
 	unsigned			set_trim(float trim) override;
 	unsigned			get_trim(float *trim) override;
+	void				set_dt_once(float dt) override;
 
 private:
 
@@ -139,9 +141,12 @@ private:
 	 */
 	static int			scale_check(struct mixer_scaler_s &scaler);
 
-	static int parse_output_scaler(const char *buf, unsigned &buflen, mixer_scaler_s &scaler);
+	static int parse_output_scaler(const char *buf, unsigned &buflen, mixer_scaler_s &scaler, float &slew_rate_rise_time);
 	static int parse_control_scaler(const char *buf, unsigned &buflen, mixer_scaler_s &scaler, uint8_t &control_group,
 					uint8_t &control_index);
+
+	float 				_output_prev{0.f};
+	float				_dt{0.f};
 
 	mixer_simple_s			*_pinfo;
 

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -191,7 +191,8 @@ private:
 
 	unsigned motorTest();
 
-	void updateOutputSlewrate();
+	void updateOutputSlewrateMultirotorMixer();
+	void updateOutputSlewrateSimplemixer();
 	void setAndPublishActuatorOutputs(unsigned num_outputs, actuator_outputs_s &actuator_outputs);
 	void publishMixerStatus(const actuator_outputs_s &actuator_outputs);
 	void updateLatencyPerfCounter(const actuator_outputs_s &actuator_outputs);
@@ -244,7 +245,8 @@ private:
 	actuator_controls_s _controls[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS] {};
 	actuator_armed_s _armed{};
 
-	hrt_abstime _time_last_mix{0};
+	hrt_abstime _time_last_dt_update_multicopter{0};
+	hrt_abstime _time_last_dt_update_simple_mixer{0};
 	unsigned _max_topic_update_interval_us{0}; ///< max _control_subs topic update interval (0=unlimited)
 
 	bool _throttle_armed{false};

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -304,6 +304,9 @@ mixer_tick()
 			mixer_group.set_max_delta_out_once(delta_out_max);
 		}
 
+		/*  set dt to be used in simple mixer for slew rate limiting */
+		mixer_group.set_dt_once(dt);
+
 		/* update parameter for mc thrust model if it updated */
 		if (update_mc_thrust_param) {
 			mixer_group.set_thrust_factor(REG_TO_FLOAT(r_setup_thr_fac));
@@ -656,6 +659,9 @@ mixer_set_failsafe()
 					      r_setup_slew_max);
 		mixer_group.set_max_delta_out_once(delta_out_max);
 	}
+
+	/*  set dt to be used in simple mixer for slew rate limiting */
+	mixer_group.set_dt_once(dt);
 
 	/* update parameter for mc thrust model if it updated */
 	if (update_mc_thrust_param) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
Some actuators don't like it if their setpoint changes too quickly, e.g. as it increases wear on the actuator and increases likelihood of failure. To this end, there exists already the possibility to add slew rate limiting on the Multicopter mixer (see `MOT_SLEW_MAX`). But not yet on simple mixers, used for control of servos mainly. 

**Describe your solution**
This adds the option to limit the rate of change (slew rate) of an output that's mixed by a simple mixer.
To enable it, a positive number has to be added at the end (6th number) of the output scaler line of the mixer,
specifying the min rise time of this output.
E.g. O:      10000  10000      0 -10000  10000 20000 for a rise time of 2s, resp. a max slew rate of 0.5s^-1.

E.g. for a min 4s rise time/0.25/s max slew rate of the tilt of a tiltrotor VTOL: 
M: 2
O:      10000  10000      0 -10000  10000 40000
S: 1 4      0  20000 -10000 -10000  10000
S: 0 2   8000   8000      0 -10000  10000
![image](https://user-images.githubusercontent.com/26798987/99947900-eec2c780-2d78-11eb-819e-2426cd1a2a4f.png)


**Test data / coverage**
Flight tested on several tiltrotor VTOLs, with the slew rate limiting being applied on the tilt servo. 

**Additional context**
I will add documentation in https://dev.px4.io/master/en/concept/mixing.html once it is merged.
