### PR TITLE
'GPS_DUMP_COMM' dumps only main GNSS reciever. 

### DIFF
--- a/msg/gps_dump.msg
+++ b/msg/gps_dump.msg
@@ -3,10 +3,10 @@
 
 uint64 timestamp		# time since system start (microseconds)
 
-uint8 instance # Instance of GNSS reciever
+uint8 instance 		# Instance of GNSS reciever
 
 uint8 len			# length of data, MSB bit set = message to the gps device,
 				# clear = message from the device
-uint8[79] data			# data to write to the log
+uint8[79] data		# data to write to the log
 
 uint8 ORB_QUEUE_LENGTH = 8

--- a/msg/gps_dump.msg
+++ b/msg/gps_dump.msg
@@ -3,6 +3,8 @@
 
 uint64 timestamp		# time since system start (microseconds)
 
+uint8 instance # Instance of GNSS reciever
+
 uint8 len			# length of data, MSB bit set = message to the gps device,
 				# clear = message from the device
 uint8[79] data			# data to write to the log

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -579,10 +579,6 @@ void GPS::initializeCommunicationDump()
 		return; //dumping disabled
 	}
 
-	if (_instance != Instance::Main) {
-		return;
-	}
-
 	_dump_from_device = new gps_dump_s();
 	_dump_to_device = new gps_dump_s();
 
@@ -607,7 +603,8 @@ void GPS::dumpGpsData(uint8_t *data, size_t len, bool msg_to_gps_device)
 		return;
 	}
 
-	gps_dump_s *dump_data = msg_to_gps_device ? _dump_to_device : _dump_from_device;
+  gps_dump_s *dump_data  = msg_to_gps_device ? _dump_to_device : _dump_from_device;
+  dump_data->instance = (uint8_t) _instance;
 
 	while (len > 0) {
 		size_t write_len = len;

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -603,8 +603,8 @@ void GPS::dumpGpsData(uint8_t *data, size_t len, bool msg_to_gps_device)
 		return;
 	}
 
-  gps_dump_s *dump_data  = msg_to_gps_device ? _dump_to_device : _dump_from_device;
-  dump_data->instance = (uint8_t) _instance;
+	gps_dump_s *dump_data  = msg_to_gps_device ? _dump_to_device : _dump_from_device;
+	dump_data->instance = (uint8_t) _instance;
 
 	while (len > 0) {
 		size_t write_len = len;


### PR DESCRIPTION
The newly fixed function of GPS_DUMP (https://github.com/PX4/PX4-Autopilot/issues/16229, https://github.com/PX4/PX4-Autopilot/pull/16247) generates a dump only from the first (main) GPS. This PR extends the dump to all connected GPS receiver (currently main/secondary receiver).

This is resolved, that the 'gps_dump' uOrb message contains an 'instance' value that contains the GPS instance attribute. The main GPS is 0; secondary is 1, etc ..

I also modified a  python script to extract data from the .ulog log. It will be in the next PR in the pyulog repository.