### PR TITLE
commander: use control mode flags and cleanup arm_disarm

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -434,7 +434,9 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 				tune_negative(true);
 				return TRANSITION_DENIED;
 
-			} else if (throttle_above_low) {
+			}
+
+			if (!_vehicle_control_mode.flag_control_climb_rate_enabled && throttle_above_low) {
 				mavlink_log_critical(&_mavlink_log_pub, "Arming denied! Throttle not zero");
 				tune_negative(true);
 				return TRANSITION_DENIED;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -707,12 +707,13 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 			// Adhere to MAVLink specs, but base on knowledge that these fundamentally encode ints
 			// for logic state parameters
-			if (static_cast<int>(cmd.param1 + 0.5f) != 0 && static_cast<int>(cmd.param1 + 0.5f) != 1) {
+			const int param1_arm = static_cast<int>(roundf(cmd.param1));
+
+			if (param1_arm != 0 && param1_arm != 1) {
 				mavlink_log_critical(&_mavlink_log_pub, "Unsupported ARM_DISARM param: %.3f", (double)cmd.param1);
 
 			} else {
-
-				bool cmd_arms = (static_cast<int>(cmd.param1 + 0.5f) == 1);
+				const bool cmd_arms = (param1_arm == 1);
 
 				// Arm is forced (checks skipped) when param2 is set to a magic number.
 				const bool forced = (static_cast<int>(roundf(cmd.param2)) == 21196);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2089,7 +2089,7 @@ Commander::run()
 			_geofence_violated_prev = false;
 		}
 
-		// abort auto mode or geofence reaction if sticks are moved significantly
+		// abort autonomous mode and switch to position mode if sticks are moved significantly
 		if ((_param_rc_override.get() != 0) && (_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)) {
 
 			const bool override_auto_mode = (_param_rc_override.get() & OVERRIDE_AUTO_MODE_BIT)
@@ -2101,12 +2101,10 @@ Commander::run()
 			if ((override_auto_mode || override_offboard_mode) && !in_low_battery_failsafe && !_geofence_warning_action_on) {
 				const float minimum_stick_deflection = 0.01f * _param_com_rc_stick_ov.get();
 
-				// transition to previous state if sticks are touched
 				if (!_status.rc_signal_lost &&
 				    ((fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
 				     (fabsf(_manual_control_setpoint.y) > minimum_stick_deflection))) {
 
-					// revert to position control in any case
 					if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 								  &_internal_state) == TRANSITION_CHANGED) {
 						tune_positive(true);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2192,13 +2192,9 @@ Commander::run()
 					} else {
 						disarm(arm_disarm_reason_t::RC_STICK);
 					}
-
-					// reset counter
-					_stick_off_counter = 0;
-
-				} else {
-					_stick_off_counter++;
 				}
+
+				_stick_off_counter++;
 
 			} else if (!(_param_arm_switch_is_button.get()
 				     && _manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON)) {
@@ -2244,13 +2240,9 @@ Commander::run()
 							arm(arm_disarm_reason_t::RC_STICK);
 						}
 					}
-
-					// reset counter
-					_stick_on_counter = 0;
-
-				} else {
-					_stick_on_counter++;
 				}
+
+				_stick_on_counter++;
 
 			} else if (!(_param_arm_switch_is_button.get()
 				     && _manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON)) {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -391,15 +391,18 @@ private:
 
 	main_state_t	_main_state_pre_offboard{commander_state_s::MAIN_STATE_MANUAL};
 
-	actuator_armed_s	_armed{};
-	commander_state_s	_internal_state{};
 	cpuload_s		_cpuload{};
 	geofence_result_s	_geofence_result{};
 	vehicle_land_detected_s	_land_detector{};
 	safety_s		_safety{};
-	vehicle_status_s	_status{};
-	vehicle_status_flags_s	_status_flags{};
 	vtol_vehicle_status_s	_vtol_status{};
+
+	// commander publications
+	actuator_armed_s        _armed{};
+	commander_state_s       _internal_state{};
+	vehicle_control_mode_s  _vehicle_control_mode{};
+	vehicle_status_s        _status{};
+	vehicle_status_flags_s  _status_flags{};
 
 	WorkerThread _worker_thread;
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -124,7 +124,8 @@ public:
 private:
 	void answer_command(const vehicle_command_s &cmd, uint8_t result);
 
-	transition_result_t arm_disarm(bool arm, bool run_preflight_checks, arm_disarm_reason_t calling_reason);
+	transition_result_t arm(arm_disarm_reason_t calling_reason, bool run_preflight_checks = true);
+	transition_result_t disarm(arm_disarm_reason_t calling_reason);
 
 	void battery_status_check();
 
@@ -153,7 +154,6 @@ private:
 
 	void offboard_control_update();
 
-	void print_reject_arm(const char *msg);
 	void print_reject_mode(const char *msg);
 
 	void reset_posvel_validity();


### PR DESCRIPTION
Commander improvements on top of https://github.com/PX4/PX4-Autopilot/pull/16264.

 - keep `vehicle_control_mode` last state in commander and use appropriate flags in place of various main_state and nav_state checks
 - consolidate scattered arming requirements in `arm_disarm()`
   - there were a number of different requirements from arming via RC vs Mavlink that don't make any sense
        - if geofence enabled require valid home before arming
        - throttle requirements for manual modes
 - remove unnecessary mavlink feedback that differs between arming interfaces (mavlink vs RC)
      - let the preflight/prearm checks respond directly in most cases 