### PR TITLE
Sketch: Commander: Debounce mode switches

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -347,6 +347,7 @@ private:
 
 	unsigned int	_leds_counter{0};
 
+	manual_control_setpoint_s	_prev_manual_control_setpoint{};	///< the previous manual control setpoint
 	manual_control_setpoint_s	_manual_control_setpoint{};		///< the current manual control setpoint
 	manual_control_setpoint_s	_last_manual_control_setpoint{};	///< the manual control setpoint valid at the last mode switch
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
@@ -357,7 +358,8 @@ private:
 
 	hrt_abstime	_boot_timestamp{0};
 	hrt_abstime	_last_disarmed_timestamp{0};
-	hrt_abstime	_timestamp_engine_healthy{0}; ///< absolute time when engine was healty
+	hrt_abstime	_timestamp_engine_healthy{0};	///< absolute time when engine was healthy
+	hrt_abstime	_overload_start{0};		///< time when CPU overload started
 
 	uint32_t	_counter{0};
 	uint8_t		_heading_reset_counter{0};


### PR DESCRIPTION
This PR is a conceptional sketch - it needs proper testing and I'm not 100% sure if it is worthwhile, as we could still break out of an auto mode from a r/p/y/t stick glitch. But I wanted to put it up for discussion.

This change forces mode switches (for flight mode changes) to have two consecutive radio frames with the same switch position before the switch gets evaluated. As most radios have a ~50 Hz update rate this adds just 20 ms delay, but prevents spurious mode switches. If the mode switch is triggered because a different control input (roll / pitch, etc) is moved, the hysteresis will not apply, however, if this happens this is really a problem on the RC system side.

This is a partial solution (assuming it is RC glitches) for https://github.com/PX4/PX4-Autopilot/issues/16235 - but if the glitch hits roll/pitch/yaw/throttle it will still cause a mode switch and while we could prevent this, it would come at the expense of inducing lag in the control system.