### PR TITLE
Fix bug causing excessive EKF primary instance changes

### DIFF
--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -281,7 +281,7 @@ bool EKF2Selector::UpdateErrorScores()
 				const float error_delta = _instance[i].combined_test_ratio - _instance[_selected_instance].combined_test_ratio;
 
 				// reduce error only if its better than the primary instance by at least EKF2_SEL_ERR_RED to prevent unnecessary selection changes
-				const float threshold = _gyro_fault_detected ? fmaxf(_param_ekf2_sel_err_red.get(), 0.05f) : 0.0f;
+				const float threshold = _gyro_fault_detected ? 0.0f : fmaxf(_param_ekf2_sel_err_red.get(), 0.05f);
 
 				if (error_delta > 0 || error_delta < -threshold) {
 					_instance[i].relative_test_ratio += error_delta;


### PR DESCRIPTION
Flight testing master with 4 EKF's running using 2  IMU and 2 compass units showed continual changes in the primary EKF selected:

<img width="1287" alt="Screen Shot 2020-11-25 at 8 21 50 pm" src="https://user-images.githubusercontent.com/3596952/100207883-35bce280-2f5c-11eb-9c22-f206fbdb7d45.png">

Code inspection showed that the ternary operator used to set the relative error score change threshold to zero when a gyro inconsistency fault had been detected was reversed, meaning that the EKF2_SEL_ERR_RED parameter was not being used.

The fix restores the intent of the EKF2_SEL_ERR_RED parameter and prevents switching to a different EKF instance due to minor improvements in error score.

<img width="1276" alt="Screen Shot 2020-11-25 at 8 21 28 pm" src="https://user-images.githubusercontent.com/3596952/100208099-7157ac80-2f5c-11eb-8929-6de9bf670578.png">
