### PR TITLE
rc.VTOL_defaults: enable wind estimation in EKF by default

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -15,8 +15,10 @@ then
 	param set MIS_TAKEOFF_ALT 20
 	param set MIS_YAW_TMT 10
 
+	param set EKF2_ARSP_THR 10
+	param set EKF2_FUSE_BETA 1
+
 	param set MPC_ACC_HOR_MAX 2
-	param set MPC_LAND_SPEED 0.7
 	param set MPC_TKO_SPEED 1
 	param set MPC_VEL_MANUAL 3
 	param set MPC_XY_CRUISE 3


### PR DESCRIPTION
**Describe problem solved by this pull request**
By default, the wind estimation in EKF is not enabled for VTOLs, while it is for fixed-wings. Wind estimation is needed for dead-reckoning inside EKF. 

**Describe your solution**
Enable airspeed and sideslip fusing by default also for VTOLs. Set airspeed threshold to 10m/s. 

I've also removed `MPC_LAND_SPEED` from the defaults, because it was actually just set to the normal param default again (0.7m/s).

**Additional context**
Would it actually make sense to include `EKF2_FUSE_BETA` in `EKF2_AID_MASK` ? And instad of `EKF2_ARSP_THR`, we could use `ASPD_STALL` (though I'm not sure if we want "external" params used by EKF), and also add it as a boolean in the `EKF2_AID_MASK` "airspeed fusion on". 
