### PR TITLE
EKF: subscribe to airspeed_validated instead of airspeed topic

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1072,21 +1072,21 @@ float EKF2::filter_altitude_ellipsoid(float amsl_hgt)
 void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 {
 	// EKF airspeed sample
-	airspeed_s airspeed;
+	airspeed_validated_s airspeed_validated;
 
-	if (_airspeed_sub.update(&airspeed)) {
+	if (_airspeed_validated_sub.update(&airspeed_validated)) {
 		// only set airspeed data if condition for airspeed fusion are met
-		if ((_param_ekf2_arsp_thr.get() > FLT_EPSILON) && (airspeed.true_airspeed_m_s > _param_ekf2_arsp_thr.get())) {
+		if ((_param_ekf2_arsp_thr.get() > FLT_EPSILON) && (airspeed_validated.true_airspeed_m_s > _param_ekf2_arsp_thr.get())) {
 
 			airspeedSample airspeed_sample {
-				.true_airspeed = airspeed.true_airspeed_m_s,
-				.eas2tas = airspeed.true_airspeed_m_s / airspeed.indicated_airspeed_m_s,
-				.time_us = airspeed.timestamp,
+				.true_airspeed = airspeed_validated.true_airspeed_m_s,
+				.eas2tas = airspeed_validated.true_airspeed_m_s / airspeed_validated.calibrated_airspeed_m_s,
+				.time_us = airspeed_validated.timestamp,
 			};
 			_ekf.setAirspeedData(airspeed_sample);
 		}
 
-		ekf2_timestamps.airspeed_timestamp_rel = (int16_t)((int64_t)airspeed.timestamp / 100 -
+		ekf2_timestamps.airspeed_timestamp_rel = (int16_t)((int64_t)airspeed_validated.timestamp / 100 -
 				(int64_t)ekf2_timestamps.timestamp / 100);
 	}
 }

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -60,7 +60,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/SubscriptionMultiArray.hpp>
-#include <uORB/topics/airspeed.h>
+#include <uORB/topics/airspeed_validated.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/ekf2_timestamps.h>
 #include <uORB/topics/ekf_gps_drift.h>
@@ -206,7 +206,7 @@ private:
 	Vector3f _last_mag_bias{};
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
-	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
+	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};
 	uORB::Subscription _distance_sensor_sub{ORB_ID(distance_sensor)};
 	uORB::Subscription _ev_odom_sub{ORB_ID(vehicle_visual_odometry)};
 	uORB::Subscription _landing_target_pose_sub{ORB_ID(landing_target_pose)};


### PR DESCRIPTION
**Describe problem solved by this pull request**
EKF is currently the only GNC module that still subscribes to the original `airspeed` topic, instead of `airspeed_validated`. This means that it can't use CAS, but only IAS, and that also TAS is corrected for the calibration factor (IAS-->CAS). Thus, the wind estimate in EKF is wrong if the user has set a IAS-->CAL factor.  This PR would change that and also starts using airspeed_validated.CAS and TAS in EKF. 

The reason we (I) were hesitant to make EKF subscribe to `airspeed_validated` in the first place was that this could lead to a loop dependency: the airspeed selector uses local position from EKF to decide which airspeed to use, EKF uses airspeed validated from the airspeed validator. But as (afaik) the airspeed inside EKF is only used for estimation in the "dead-reckoning" case (where GPS is lost), I think we should rather make sure that if that's the case then the airspeed validity checks (against groundspeed-windspeed) should anyway be switched off. 


