### PR TITLE
tunes: Fix repeating tunes that do not stop

### DIFF
--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -78,11 +78,11 @@ void Tunes::reset(bool repeat_flag)
 	_tempo       = _default_tempo;
 }
 
-int Tunes::set_control(const tune_control_s &tune_control)
+Tunes::ControlResult Tunes::set_control(const tune_control_s &tune_control)
 {
 	// Sanity check
 	if (tune_control.tune_id >= _default_tunes_size) {
-		return -EINVAL;
+		return ControlResult::InvalidTune;
 	}
 
 	// Accept new tune or a stop?
@@ -93,7 +93,7 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		// Check if this exact tune is already being played back
 		if (tune_control.tune_id != static_cast<int>(TuneID::CUSTOM) &&
 		    _tune == _default_tunes[tune_control.tune_id]) {
-			return OK; // Nothing to do
+			return ControlResult::AlreadyPlaying; // Nothing to do
 		}
 
 		// Reset repeat flag. Can jump to true again while tune is being parsed later
@@ -126,9 +126,10 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		}
 
 		_current_tune_id = tune_control.tune_id;
+		return ControlResult::Success;
 	}
 
-	return OK;
+	return ControlResult::WouldInterrupt;
 }
 
 void Tunes::set_string(const char *const string, uint8_t volume)

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <errno.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/tune_control.h>
 #include "tune_definition.h"
@@ -64,6 +65,13 @@ public:
 		Error = -1,
 	};
 
+	enum class ControlResult {
+		Success = 0,
+		AlreadyPlaying = 1,
+		InvalidTune = -EINVAL,
+		WouldInterrupt = -EBUSY,
+	};
+
 	/**
 	 * Constructor with the default parameters set to:
 	 * default_tempo: TUNE_DEFAULT_TEMPO
@@ -83,9 +91,12 @@ public:
 	 * the call to this function will be ignored, unless the override flag is set
 	 * or the tune being already played is a repeated tune.
 	 * @param  tune_control struct containig the uORB message
-	 * @return              return -EINVAL if the default tune does not exist.
+	 * @return              return ControlResult::InvalidTune if the default tune does not exist,
+	 * 			ControlResult::WouldInterrupt if tune was already playing and not interruptable,
+	 * 			ControlResult::AlreadyPlaying if same tune was already playing,
+	 * 			ControlResult::Success if new tune was set.
 	 */
-	int set_control(const tune_control_s &tune_control);
+	ControlResult set_control(const tune_control_s &tune_control);
 
 	/**
 	 * Set tune to be played using a string.

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -187,9 +187,9 @@ extern "C" __EXPORT int tune_control_main(int argc, char *argv[])
 		}
 
 	} else if (!strcmp(argv[myoptind], "libtest")) {
-		int ret = tunes.set_control(tune_control);
+		Tunes::ControlResult ret = tunes.set_control(tune_control);
 
-		if (ret == -EINVAL) {
+		if (ret == Tunes::ControlResult::InvalidTune) {
 			PX4_WARN("Tune ID not recognized.");
 		}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Repeating tunes started by Commander like failsafe would never stop. This is because `tone_alarm` would reject the `tune_control` to stop the tune since the repeating tune is still playing. 
Can reproduce by
```
tune_control play -t 7 # play battery warning slow
tune_control play -t 8 # battery warning fast does not play
tune_control stop # this will stop the tune, but only because it has tune_override = true
``` 

**Describe your solution**
`Tunes` already has some logic for deciding whether a tune should be interrupted or not, as well as special cases
for `tune_id = 0` for stopping tunes. So I expose that logic through return codes and use that to decided whether
or not to interrupt a tune.

**Describe possible alternatives**
Duplicate the logic from `Tunes.cpp` in `ToneAlarm.cpp`, but I would rather avoid this. 

**Test data / coverage**
Ran this on my CubeOrange and it solved the issue.
