### PR TITLE
Enable TELEM3 for Holybro Durandal

### DIFF
--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -15,6 +15,7 @@ px4_add_board(
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
+		TEL3:/dev/ttyS4
 		TEL4:/dev/ttyS3
 	DRIVERS
 		adc/board_adc


### PR DESCRIPTION
Didn't test yet.
Welcome suggestions.

Reference:
![image](https://user-images.githubusercontent.com/4748411/100331321-f9948b00-300a-11eb-8688-398ac610aa01.png)

tested start TFmini on TELEM3 works fine `tfmini start -d /dev/ttyS4`