### PR TITLE
rc_update: only decode if RC input is stable (channels and source)

### DIFF
--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -167,6 +167,7 @@ private:
 	hrt_abstime _last_rc_to_param_map_time = 0;
 
 	uint8_t _channel_count_previous{0};
+	uint8_t _input_source_previous{input_rc_s::RC_INPUT_SOURCE_UNKNOWN};
 
 	perf_counter_t		_loop_perf;			/**< loop performance counter */
 


### PR DESCRIPTION
This updates the RC update pipeline to only do the final mapping + publish if the RC source is stable (source and number of channels consistently the same). It's a minor robustness improvement for certain failure cases.