### PR TITLE
Fix sitl_run to run in macOS

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -128,16 +128,25 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		SIM_PID=$!
 
 		# Check all paths in ${GAZEBO_MODEL_PATH} for specified model
-		readarray -d : -t paths <<< ${GAZEBO_MODEL_PATH}
-		for possibleModelPath in "${paths[@]}"; do
+		IFS=":"
+		for possible_model_path in ${GAZEBO_MODEL_PATH}; do
+			if [ -z $possible_model_path ]; then
+				continue
+			fi
 			# trim \r from path
-			possibleModelPath=$(echo $possibleModelPath | tr -d '\r')
-			if test -f "${possibleModelPath}/${model}/${model}.sdf" ; then
-				modelpath=$possibleModelPath
+			possible_model_path=$(echo $possible_model_path | tr -d '\r')
+			if test -f "${possible_model_path}/${model}/${model}.sdf" ; then
+				modelpath=$possible_model_path
 				break
 			fi
 		done
-		echo "Using: ${modelpath}/${model}/${model}.sdf"
+
+		if [ -z $modelpath ]; then
+			echo "Model ${model} not found in model path: ${GAZEBO_MODEL_PATH}"
+			exit 1
+		else
+			echo "Using: ${modelpath}/${model}/${model}.sdf"
+		fi
 
 		while gz model --verbose --spawn-file="${modelpath}/${model}/${model_name}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep -q "An instance of Gazebo is not running."; do
 			echo "gzserver not ready yet, trying again!"

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -128,6 +128,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		SIM_PID=$!
 
 		# Check all paths in ${GAZEBO_MODEL_PATH} for specified model
+		IFS_bak=$IFS
 		IFS=":"
 		for possible_model_path in ${GAZEBO_MODEL_PATH}; do
 			if [ -z $possible_model_path ]; then
@@ -140,6 +141,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 				break
 			fi
 		done
+		IFS=$IFS_bak
 
 		if [ -z $modelpath ]; then
 			echo "Model ${model} not found in model path: ${GAZEBO_MODEL_PATH}"


### PR DESCRIPTION
**Describe problem solved by this pull request**
There was a regression on macOS that was introduced by https://github.com/PX4/PX4-Autopilot/pull/16214, where it searches for available models in `GAZEBO_MODEL_PATH` sequentially.

**Describe your solution**
This commit removes the `readarray` command from the Tools/sitl_run.sh. This fixes the issue where SITL was not able to run due to readarray not being available on macOS


**Test data / coverage**
Tested locally on Ubuntu 20.04

**Additional context**
- This fixes https://github.com/PX4/PX4-Autopilot/issues/16263
