### PR TITLE
Fix incorrect docs URLs in airframes definitions

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
@@ -2,7 +2,7 @@
 #
 # @name Wing Wing (aka Z-84) Flying Wing
 #
-# @url https://docs.px4.io/master/en/framebuild_plane/wing_wing_z84.html
+# @url https://docs.px4.io/master/en/frames_plane/wing_wing_z84.html
 #
 # @type Flying Wing
 # @class Plane

--- a/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
+++ b/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # @name Spedix S250AQ
-# @url https://docs.px4.io/master/en/framebuild_multicopter/spedix_s250_pixracer.html
+# @url https://docs.px4.io/master/en/frames_multicopter/spedix_s250_pixracer.html
 #
 # @type Quadrotor asymmetric
 # @class Copter


### PR DESCRIPTION
There was an incorrect link in generated docs to https://docs.px4.io/master/en/frames_multicopter/spedix_s250_pixracer.html and https://docs.px4.io/master/en/framebuild_plane/wing_wing_z84.html