### PR TITLE
microRTPS: remove byte ordering for nested types

### DIFF
--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -150,9 +150,7 @@ def get_children_fields(base_type, search_path):
     tmp_msg_context = genmsg.msg_loader.MsgContext.create_default()
     spec_temp = genmsg.msg_loader.load_msg_by_type(
         tmp_msg_context, '%s/%s' % (package, name), search_path)
-    sorted_fields = sorted(spec_temp.parsed_fields(),
-                           key=sizeof_field_type, reverse=True)
-    return sorted_fields
+    return spec_temp.parsed_fields()
 
 
 def add_padding_bytes(fields, search_path):


### PR DESCRIPTION
**Describe problem solved by this pull request**
On the serialization/deserialization templates, `get_children_fields()` was returning the message fields ordered by the size of the data types, resulting on mismatches between the expect message structure and the received/sent message structure for nested types - this was identified by @mickey13 while using `position_setpoint_triplet` for offboard control.

**Describe your solution**
As uCDR doesn't add padding bytes for serialization purposes, there's no need for byte ordering - this was initially removed in https://github.com/PX4/PX4-Autopilot/pull/12025, but not for nested types. This was now removed from the `get_children_fields()` functions as well.

**Test data / coverage**
Resulting `serialize_position_setpoint()` and `serialize_position_setpoint_triplet()` were compared for confirmation of the correct field ordering.

**Additional context**
[PX4 Slack discussion](https://px4.slack.com/archives/C7MTU2K17/p1606408558220300).
