### PR TITLE
Handle takeoff waypoints for rover

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -174,6 +174,13 @@ MissionBlock::is_mission_item_reached()
 				_waypoint_position_reached = true;
 			}
 
+		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
+			   && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
+			/* for takeoff mission items use the parameter for the takeoff acceptance radius */
+			if (dist_xy >= 0.0f && dist_xy <= _navigator->get_acceptance_radius()) {
+				_waypoint_position_reached = true;
+			}
+
 		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF) {
 			/* for takeoff mission items use the parameter for the takeoff acceptance radius */
 			if (dist >= 0.0f && dist <= _navigator->get_acceptance_radius()


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, rover vehicles were not able to handle Takeoff waypoints. The behavior when a takeoff waypoint was passed to a rover vehicle was:
- The vehicle would not move since the waypoint was too close
- The takeoff waypoint would not get accepted since rovers are not able to climb and reach the altitude

I think it might be obvious that one "should not" pass takeoff waypoints to a vehicle. However, QGroundControl only lets you plan a mission that starts with a takeoff waypoint. While this should also be an improvement on the QGC side, I think it is still useful to handle this case on the vehicle side so that the vehicle can still progress with the mission even with a takeoff waypoint

**Describe your solution**
This adds a special case when handling takeoff waypoints for rover vehicles. The acceptance radius is set to only consider horizontal distance to the waypoint, if the vehicle type is rover.

**Test data / coverage**
- This was tested in SITL gazebo, with the rover model.
```
make px4_sitl gazebo_rover
```
This log shows a full mission successfully finished starting with a Takeoff waypoint and finished with a RTL: https://review.px4.io/plot_app?log=25fe983b-44d0-4a11-a7c2-2ab9662c35d4
