### PR TITLE
MulticopterPositionControl: Reset task between auto mode switches

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -478,7 +478,9 @@ void MulticopterPositionControl::start_flight_task()
 	}
 
 	// Switch to clean new task when mode switches e.g. to reset state when switching between auto modes
-	if (_last_vehicle_nav_state != _vehicle_status.nav_state) {
+	// exclude Orbit mode since the task is initiated in FlightTasks through the vehicle_command and we should not switch out
+	if (_last_vehicle_nav_state != _vehicle_status.nav_state
+	    && _vehicle_status.nav_state != vehicle_status_s::NAVIGATION_STATE_ORBIT) {
 		_flight_tasks.switchTask(FlightTaskIndex::None);
 	}
 

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -477,6 +477,11 @@ void MulticopterPositionControl::start_flight_task()
 		return;
 	}
 
+	// Switch to clean new task when mode switches e.g. to reset state when switching between auto modes
+	if (_last_vehicle_nav_state != _vehicle_status.nav_state) {
+		_flight_tasks.switchTask(FlightTaskIndex::None);
+	}
+
 	if (_vehicle_status.in_transition_mode) {
 		should_disable_task = false;
 		FlightTaskError error = _flight_tasks.switchTask(FlightTaskIndex::Transition);
@@ -666,6 +671,8 @@ void MulticopterPositionControl::start_flight_task()
 	} else if (should_disable_task) {
 		_flight_tasks.switchTask(FlightTaskIndex::None);
 	}
+
+	_last_vehicle_nav_state = _vehicle_status.nav_state;
 }
 
 void MulticopterPositionControl::failsafe(const hrt_abstime &now, vehicle_local_position_setpoint_s &setpoint,

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -203,6 +203,8 @@ private:
 
 	perf_counter_t _cycle_perf;
 
+	uint8_t _last_vehicle_nav_state{0};
+
 	/**
 	 * Update our local parameter cache.
 	 * Parameter update can be forced when argument is true.


### PR DESCRIPTION
**Describe problem solved by this pull request**
When switching between auto modes the state of the FlightTaskAuto stays which is known but sometimes not desirable because you have to take care of resetting certain member variables in every other possible use case the task will get executed for after the original intent.

**Describe your solution**
I load the flight task from scratch whenever the mode is switched to avoid the initialization problem of switching back and forth between modes that currently use the same task. I do it this way because it's in line with our plans to have one unique implementation per mode and just reusing code through libraries.

**Test data / coverage**
I SITL tested and it was real-world tested. The only problem that was found and fixed is that the way of just unloading the task is not good for the Orbit case. This exclusivity should go away with the separate mode implementations. 

**Additional context**
The wider context is the next step to separate flight tasks before proceeding with separating the mode implementations. https://github.com/PX4/PX4-Autopilot/pull/14665
