### PR TITLE
commander: entering LOITER requires global position, not home

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2383,7 +2383,7 @@ Commander::run()
 			 * we can as well just wait in a hold mode which enables tablet control.
 			 */
 			if (_status.rc_signal_lost && (_internal_state.main_state == commander_state_s::MAIN_STATE_MANUAL)
-			    && _status_flags.condition_home_position_valid) {
+			    && _status_flags.condition_global_position_valid) {
 
 				main_state_transition(_status, commander_state_s::MAIN_STATE_AUTO_LOITER, _status_flags, &_internal_state);
 			}


### PR DESCRIPTION
 - auto transition to LOITER if disarmed with no RC only requires a valid global position

Pretty minor, but there is a difference.