### PR TITLE
Args consistency between Posix and NuttX

### DIFF
--- a/platforms/common/include/px4_platform_common/module.h
+++ b/platforms/common/include/px4_platform_common/module.h
@@ -169,11 +169,9 @@ public:
 	{
 		int ret = 0;
 
-#ifdef __PX4_NUTTX
-		// On NuttX task_create() adds the task name as first argument.
+		// We don't need the task name at this point.
 		argc -= 1;
 		argv += 1;
-#endif
 
 		T *object = T::instantiate(argc, argv);
 		_object.store(object);

--- a/platforms/posix/src/px4/common/tasks.cpp
+++ b/platforms/posix/src/px4/common/tasks.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
  *
- *   Copyright (C) 2015 Mark Charlebois. All rights reserved.
- *   Author: @author Mark Charlebois <charlebm#gmail.com>
+ *   Copyright (C) 2015-2020 Mark Charlebois. All rights reserved.
+ *   Author: @author Mark Charlebois <charlebm@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,6 @@
  ****************************************************************************/
 
 /**
- * @file px4_posix_tasks.c
  * Implementation of existing task API for Linux
  */
 
@@ -60,22 +59,18 @@
 #include <px4_platform_common/posix.h>
 #include <systemlib/err.h>
 
-#define MAX_CMD_LEN 100
-
 #define PX4_MAX_TASKS 50
-#define SHELL_TASK_ID (PX4_MAX_TASKS+1)
 
 pthread_t _shell_task_id = 0;
 pthread_mutex_t task_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 struct task_entry {
-	pthread_t pid;
-	std::string name;
-	bool isused;
-	task_entry() : isused(false) {}
+	pthread_t pid{0};
+	std::string name{};
+	bool isused {false};
 };
 
-static task_entry taskmap[PX4_MAX_TASKS] = {};
+static task_entry taskmap[PX4_MAX_TASKS] {};
 
 typedef struct {
 	px4_main_t entry;
@@ -89,13 +84,11 @@ static void *entry_adapter(void *ptr)
 {
 	pthdata_t *data = (pthdata_t *) ptr;
 
-	int rv;
-
 	// set the threads name
 #ifdef __PX4_DARWIN
-	rv = pthread_setname_np(data->name);
+	int rv = pthread_setname_np(data->name);
 #else
-	rv = pthread_setname_np(pthread_self(), data->name);
+	int rv = pthread_setname_np(pthread_self(), data->name);
 #endif
 
 	if (rv) {
@@ -114,8 +107,6 @@ static void *entry_adapter(void *ptr)
 px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_size, px4_main_t entry,
 			      char *const argv[])
 {
-
-	int i;
 	int argc = 0;
 	unsigned int len = 0;
 	struct sched_param param = {};
@@ -150,7 +141,7 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 	taskdata->entry = entry;
 	taskdata->argc = argc;
 
-	for (i = 0; i < argc; i++) {
+	for (int i = 0; i < argc; ++i) {
 		PX4_DEBUG("arg %d %s\n", i, argv[i]);
 		taskdata->argv[i] = (char *)offset;
 		strcpy((char *)offset, argv[i]);
@@ -225,6 +216,8 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 	pthread_mutex_lock(&task_mutex);
 
 	px4_task_t taskid = 0;
+
+	int i;
 
 	for (i = 0; i < PX4_MAX_TASKS; ++i) {
 		if (!taskmap[i].isused) {
@@ -307,10 +300,11 @@ int px4_task_delete(px4_task_t id)
 
 void px4_task_exit(int ret)
 {
-	int i;
 	pthread_t pid = pthread_self();
 
 	// Get pthread ID from the opaque ID
+	int i;
+
 	for (i = 0; i < PX4_MAX_TASKS; ++i) {
 		if (taskmap[i].pid == pid) {
 			pthread_mutex_lock(&task_mutex);
@@ -422,7 +416,7 @@ const char *px4_get_taskname()
 
 int px4_prctl(int option, const char *arg2, px4_task_t pid)
 {
-	int rv;
+	int rv = -1;
 
 	switch (option) {
 	case PR_SET_NAME:
@@ -435,7 +429,6 @@ int px4_prctl(int option, const char *arg2, px4_task_t pid)
 		break;
 
 	default:
-		rv = -1;
 		PX4_WARN("FAILED SETTING TASK NAME");
 		break;
 	}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1140,12 +1140,9 @@ int GPS::task_spawn(int argc, char *argv[], Instance instance)
 
 int GPS::run_trampoline_secondary(int argc, char *argv[])
 {
-
-#ifdef __PX4_NUTTX
-	// on NuttX task_create() adds the task name as first argument
+	// the task name is the first argument
 	argc -= 1;
 	argv += 1;
-#endif
 
 	GPS *gps = instantiate(argc, argv, Instance::Secondary);
 	if (gps) {

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1838,16 +1838,9 @@ Mavlink::task_main(int argc, char *argv[])
 
 	_interface_name = nullptr;
 
-#ifdef __PX4_NUTTX
-	/* the NuttX optarg handler does not
-	 * ignore argv[0] like the POSIX handler
-	 * does, nor does it deal with non-flag
-	 * verbs well. So we remove the application
-	 * name and the verb.
-	 */
+	// We don't care about the name and verb at this point.
 	argc -= 2;
 	argv += 2;
-#endif
 
 	/* don't exit from getopt loop to leave getopt global variables in consistent state,
 	 * set error flag instead */

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -69,14 +69,14 @@ int Simulator::start(int argc, char *argv[])
 	_instance = new Simulator();
 
 	if (_instance) {
-		if (argc == 4 && strcmp(argv[2], "-u") == 0) {
+		if (argc == 5 && strcmp(argv[3], "-u") == 0) {
 			_instance->set_ip(InternetProtocol::UDP);
-			_instance->set_port(atoi(argv[3]));
+			_instance->set_port(atoi(argv[4]));
 		}
 
-		if (argc == 4 && strcmp(argv[2], "-c") == 0) {
+		if (argc == 5 && strcmp(argv[3], "-c") == 0) {
 			_instance->set_ip(InternetProtocol::TCP);
-			_instance->set_port(atoi(argv[3]));
+			_instance->set_port(atoi(argv[4]));
 		}
 
 		_instance->run();

--- a/src/modules/vmount/vmount.cpp
+++ b/src/modules/vmount/vmount.cpp
@@ -163,16 +163,9 @@ static int vmount_thread_main(int argc, char *argv[])
 
 	InputTest *test_input = nullptr;
 
-#ifdef __PX4_NUTTX
-	/* the NuttX optarg handler does not
-	 * ignore argv[0] like the POSIX handler
-	 * does, nor does it deal with non-flag
-	 * verbs well. So we Remove the application
-	 * name and the verb.
-	 */
+	// We don't need the task name.
 	argc -= 1;
 	argv += 1;
-#endif
 
 	if (argc > 0 && !strcmp(argv[0], "test")) {
 		PX4_INFO("Starting in test mode");

--- a/src/systemcmds/tests/test_dataman.c
+++ b/src/systemcmds/tests/test_dataman.c
@@ -68,7 +68,7 @@ task_main(int argc, char *argv[])
 {
 	char buffer[DM_MAX_DATA_SIZE];
 
-	PX4_INFO("Starting dataman test task %s", argv[1]);
+	PX4_INFO("Starting dataman test task %s", argv[2]);
 	/* try to read an invalid item */
 	int my_id = atoi(argv[2]);
 

--- a/src/systemcmds/tests/test_dataman.c
+++ b/src/systemcmds/tests/test_dataman.c
@@ -70,7 +70,7 @@ task_main(int argc, char *argv[])
 
 	PX4_INFO("Starting dataman test task %s", argv[1]);
 	/* try to read an invalid item */
-	int my_id = atoi(argv[1]);
+	int my_id = atoi(argv[2]);
 
 	/* try to read an invalid item */
 	if (dm_read(DM_KEY_NUM_KEYS, 0, buffer, sizeof(buffer)) >= 0) {


### PR DESCRIPTION
This is a retry of #12200.

It looks like the behaviour of `px4_task_spawn_cmd` has been fixed in the meantime and the changes from https://github.com/PX4/PX4-Autopilot/pull/12200/commits/51fcd66be1c9ac18c93fc6e7288ba893766f08a3 are no longer required.

I've mostly just removed the remaining ifdefs for NuttX around this.