### PR TITLE
Acceleration stick mapping improvements

### DIFF
--- a/src/lib/flight_tasks/FlightTasks.cpp
+++ b/src/lib/flight_tasks/FlightTasks.cpp
@@ -82,7 +82,7 @@ FlightTaskError FlightTasks::switchTask(FlightTaskIndex new_task_index)
 		return FlightTaskError::InvalidTask;
 	}
 
-	if (!_current_task.task) {
+	if (!isAnyTaskActive()) {
 		// no task running
 		return FlightTaskError::NoError;
 	}
@@ -132,7 +132,7 @@ const char *FlightTasks::errorToString(const FlightTaskError error)
 
 void FlightTasks::reActivate()
 {
-	if (_current_task.task) {
+	if (isAnyTaskActive()) {
 		_current_task.task->reActivate();
 	}
 }

--- a/src/lib/flight_tasks/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/lib/flight_tasks/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -54,6 +54,8 @@ bool FlightTaskManualAcceleration::activate(const vehicle_local_position_setpoin
 		_velocity_setpoint.xy() = Vector2f(_velocity);
 	}
 
+	_stick_acceleration_xy.resetPosition();
+
 	if (PX4_ISFINITE(last_setpoint.acceleration[0])) {
 		_stick_acceleration_xy.resetAcceleration(Vector2f(last_setpoint.acceleration[0], last_setpoint.acceleration[1]));
 	}

--- a/src/lib/flight_tasks/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/StickAccelerationXY.cpp
@@ -121,7 +121,9 @@ Vector2f StickAccelerationXY::calculateDrag(Vector2f drag_coefficient, const flo
 
 	drag_coefficient *= _brake_boost_filter.getState();
 
-	return drag_coefficient.emult(vel_sp);
+	// increase drag with sqareroot function when velocity is lower than 1m/s
+	const Vector2f velocity_with_sqrt_boost = vel_sp.unit_or_zero() * math::sqrt_linear(vel_sp.norm());
+	return drag_coefficient.emult(velocity_with_sqrt_boost);
 }
 
 void StickAccelerationXY::applyTiltLimit(Vector2f &acceleration)
@@ -141,8 +143,6 @@ void StickAccelerationXY::lockPosition(const Vector2f &vel_sp, const Vector3f &p
 		if (!PX4_ISFINITE(pos_sp(0))) {
 			pos_sp = Vector2f(pos);
 		}
-
-		pos_sp += vel_sp * dt;
 
 	} else {
 		pos_sp.setNaN();

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -172,4 +172,30 @@ const T gradual3(const T &value,
 	}
 }
 
+/*
+ * Squareroot, linear function with fixed corner point at intersection (1,1)
+ *                     /
+ *      linear        /
+ *                   /
+ * 1                /
+ *                /
+ *      sqrt     |
+ *              |
+ * 0     -------
+ *             0    1
+ */
+template<typename T>
+const T sqrt_linear(const T &value)
+{
+	if (value < static_cast<T>(0)) {
+		return static_cast<T>(0);
+
+	} else if (value < static_cast<T>(1)) {
+		return sqrtf(value);
+
+	} else {
+		return value;
+	}
+}
+
 } /* namespace math */

--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -183,3 +183,14 @@ TEST(FunctionsTest, gradual3)
 				 0.f, .5f, 1.5f,
 				 1.f, 2.f, 3.f), 3.f);
 }
+
+TEST(FunctionsTest, sqrt_linear)
+{
+	EXPECT_FLOAT_EQ(sqrt_linear(-12.f), 0.f);
+	EXPECT_FLOAT_EQ(sqrt_linear(-2.f), 0.f);
+	EXPECT_FLOAT_EQ(sqrt_linear(0.f), 0.f);
+	EXPECT_FLOAT_EQ(sqrt_linear(.5f), 0.70710678f);
+	EXPECT_FLOAT_EQ(sqrt_linear(1.f), 1.f);
+	EXPECT_FLOAT_EQ(sqrt_linear(2.f), 2.f);
+	EXPECT_FLOAT_EQ(sqrt_linear(120.f), 120.f);
+}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Three reported issues from pilots:
1. It takes a long time (~5 seconds) until the position lock setpoint is set.
2. Vehicle flies back to original position when moved on the ground in position mode.
3. Vehicle takes too long to slow down to zero at the very end.

**Describe your solution**
1. See 3.
2. I made the `resetPosition();` function for exactly that purpose but in the end forgot to call it in the `activate()` function of the flight task -> added `_stick_acceleration_xy.resetPosition();` now like it was originally planned.
3. It takes so long to brake at the end because acceleration = velocity_dot = k * velocity results in an exponential decay and has nice characteristics but when velocity reaches close to zero it takes an eternity to reach exactly zero. The solution I came up with is a continuous function that is linear above 1 and square root below 1. It's used to boost the brake drag in low speeds.

**Test data / coverage**
I tested in SITL and it gives really nice results. I suggest we try it on a real large vehicle before emerging as well, I'll organize that.
I added unit tests for the  `sqrt_linear()` function.

**Additional context**
Function plot `sqrt_linear()` (negative input values result in zero output):
![image](https://user-images.githubusercontent.com/4668506/100889427-65696e80-34b7-11eb-8b5a-31c4ad6b41e5.png)

Brake from high velocity now starts like before but keeps more brake drag until the end:
![image](https://user-images.githubusercontent.com/4668506/100889828-e294e380-34b7-11eb-8d2b-298a0b096e0d.png)


