### PR TITLE
px4_fmu-v5x:Manifest Update Adde Rev 1 HW and fix VER 1

### DIFF
--- a/boards/px4/fmu-v5x/src/manifest.c
+++ b/boards/px4/fmu-v5x/src/manifest.c
@@ -84,7 +84,7 @@ static const px4_hw_mft_item_t hw_mft_list_v0500[] = {
 	},
 };
 
-static const px4_hw_mft_item_t hw_mft_list_v0501[] = {
+static const px4_hw_mft_item_t hw_mft_list_v0510[] = {
 	{
 		.present     = 0,
 		.mandatory   = 0,
@@ -112,7 +112,8 @@ static const px4_hw_mft_item_t hw_mft_list_v0509[] = {
 
 static px4_hw_mft_list_entry_t mft_lists[] = {
 	{0x0000, hw_mft_list_v0500, arraySize(hw_mft_list_v0500)},
-	{0x0001, hw_mft_list_v0501, arraySize(hw_mft_list_v0501)},
+	{0x0001, hw_mft_list_v0500, arraySize(hw_mft_list_v0500)},
+	{0x0100, hw_mft_list_v0510, arraySize(hw_mft_list_v0510)},
 	{0x0900, hw_mft_list_v0509, arraySize(hw_mft_list_v0509)},
 };
 


### PR DESCRIPTION
   VER is on BASE
   REV is on FMU
     ver|rev
     bas|fmu
    {0x0000, hw_mft_list_v0500, ...(hw_mft_list_v0500)},
    {0x0001, hw_mft_list_v0501, ...(hw_mft_list_v0501)}, <-- was wrong

    This falsely selected the NO I/O version

