### PR TITLE
Add yosemite world as SITL target for gazebo

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -97,7 +97,7 @@ set(models none shell
 	standard_vtol tailsitter tiltrotor
 	rover r1_rover boat cloudship
 	uuv_hippocampus uuv_bluerov2_heavy)
-set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy)
+set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy yosemite)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})


### PR DESCRIPTION
**Describe problem solved by this pull request**
For some reason, the yosemite world was not in the SITL target list

**Describe your solution**
This commit adds yosemite world as a SITL target for gazebo


**Test data / coverage**
Tested with the following make target
```
make px4_sitl gazebo_iris__yosemite
```

**Additional context**
