### PR TITLE
Escape < and > in maintainer field

### DIFF
--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -1,6 +1,7 @@
 from xml.sax.saxutils import escape
 import codecs
 import os
+import html
 
 class MarkdownTablesOutput():
     def __init__(self, groups, board, image_path):
@@ -89,7 +90,7 @@ class MarkdownTablesOutput():
                     maintainer = param.GetMaintainer()
                     maintainer_entry = ''
                     if maintainer != '':
-                        maintainer_entry = '<p>Maintainer: %s</p>' % (maintainer.replace('<', '&lt;').replace('>', '&gt;'))
+                        maintainer_entry = '<p>Maintainer: %s</p>' % (html.escape(maintainer))
                     url = param.GetFieldValue('url')
                     name_anchor='id="%s_%s_%s"' % (group.GetClass(),group.GetName(),name)
                     name_anchor=name_anchor.replace(' ','_').lower()

--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -89,7 +89,7 @@ class MarkdownTablesOutput():
                     maintainer = param.GetMaintainer()
                     maintainer_entry = ''
                     if maintainer != '':
-                        maintainer_entry = '<p>Maintainer: %s</p>' % (maintainer)
+                        maintainer_entry = '<p>Maintainer: %s</p>' % (maintainer.replace('<', '&lt;').replace('>', '&gt;'))
                     url = param.GetFieldValue('url')
                     name_anchor='id="%s_%s_%s"' % (group.GetClass(),group.GetName(),name)
                     name_anchor=name_anchor.replace(' ','_').lower()


### PR DESCRIPTION
The airframes reference includes text like this `<p>Maintainer: SomeName <some_email></p>`. The < and > make the email address into an un-closed tag. Browsers handle this, but we should do the right thing as I get errors reported.
This PR just changes those to `&lt;` and `&gt;`