### PR TITLE
Enable SITL tests for macos

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -15,8 +15,7 @@ jobs:
       matrix:
         config: [
           px4_fmu-v5_default,
-          px4_sitl_default,
-          #tests, # includes px4_sitl
+          tests, # includes px4_sitl
           ]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
**Describe problem solved by this pull request**
This commit re-enables SITL testing on macOS

This was removed with intermittent SITL failures in https://github.com/PX4/PX4-Autopilot/pull/15234

**Additional context**
- Gazebo builds are being tested in macos-10.15 and macos-11.0 in `sitl_gazebo` : https://github.com/PX4/PX4-SITL_gazebo/pull/663, but the unfortunately firmware is unable to build on Big Sur (macos-11.0)
- Fixes https://github.com/PX4/PX4-Autopilot/issues/15225
- Fixes https://github.com/PX4/PX4-Autopilot/issues/15476
