### PR TITLE
reenable WV after Front Transition alignment

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -999,6 +999,9 @@ Mission::set_mission_items()
 
 					new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 
+					/* re-enable weather vane again after alignment */
+					pos_sp_triplet->current.disable_weather_vane = false;
+
 					/* set position setpoint to target during the transition */
 					pos_sp_triplet->previous = pos_sp_triplet->current;
 					generate_waypoint_from_heading(&pos_sp_triplet->current, pos_sp_triplet->current.yaw);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes https://github.com/PX4/PX4-Autopilot/issues/16305

@sfuhrer @dagar 

**Describe your solution**
Reenable Weathervane after front transition alignment also for VTOL Transition item.

**Describe possible alternatives**


**Test data / coverage**
SITL gazebo standard vtol: https://logs.px4.io/plot_app?log=7fa8edf3-84bc-4c9b-918b-a16c53b8d2b0

**Additional context**
