### PR TITLE
battery: don't init uint16_t with -1.0f

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -113,7 +113,7 @@ void Battery::reset()
 	// TODO: check if it is sane to reset warning to NONE
 	_battery_status.warning = battery_status_s::BATTERY_WARNING_NONE;
 	_battery_status.connected = false;
-	_battery_status.capacity = _params.capacity;
+	_battery_status.capacity = _params.capacity > 0.0f ? (uint16_t)_params.capacity : 0;
 	_battery_status.temperature = NAN;
 	_battery_status.id = (uint8_t) _index;
 }


### PR DESCRIPTION
This was flagged as undefined behaviour by fuzz testing.