### PR TITLE
ekf2: multi-ekf force initial selection (and sensor_selection publication)

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1557,10 +1557,10 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 			if (inst) {
 				_ekf2_selector.store(inst);
-				inst->Start();
 
 			} else {
-				PX4_ERR("Failed to start EKF2 selector");
+				PX4_ERR("Failed to create EKF2 selector");
+				return PX4_ERROR;
 			}
 		}
 
@@ -1604,6 +1604,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 								ekf2_inst->ScheduleNow();
 								success = true;
 								multi_instances_allocated++;
+								_ekf2_selector.load()->ScheduleNow();
 
 							} else {
 								PX4_ERR("instance %d alloc failed", instance);

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -73,7 +73,7 @@ private:
 	void PublishVehicleAttitude(bool reset = false);
 	void PublishVehicleLocalPosition(bool reset = false);
 	void PublishVehicleGlobalPosition(bool reset = false);
-	void SelectInstance(uint8_t instance);
+	bool SelectInstance(uint8_t instance);
 
 	// Update the error scores for all available instances
 	bool UpdateErrorScores();
@@ -100,8 +100,8 @@ private:
 
 		hrt_abstime time_last_selected{0};
 
-		float combined_test_ratio{0.f};
-		float relative_test_ratio{0.f};
+		float combined_test_ratio{NAN};
+		float relative_test_ratio{NAN};
 
 		bool healthy{false};
 


### PR DESCRIPTION
 - fixes https://github.com/PX4/PX4-Autopilot/issues/16278

Depending on the particular sensor configuration and startup timing we were getting an initial `sensor_selection` publication without valid accel & gyro device ids. Only applies to Multi-EKf.