### PR TITLE
Fix Return issue to landing pattern

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -388,7 +388,7 @@ Mission::find_mission_land_start()
 		}
 
 		// first check for DO_LAND_START marker
-		if ((missionitem.nav_cmd == NAV_CMD_DO_LAND_START) && (missionitem_prev.nav_cmd == NAV_CMD_WAYPOINT)) {
+		if (missionitem.nav_cmd == NAV_CMD_DO_LAND_START) {
 
 			_land_start_available = true;
 			_land_start_index = i;


### PR DESCRIPTION
fix this issue:
https://github.com/PX4/PX4-Autopilot/issues/16299

when we have "land start" after a survey drone can not return to landing pattern.

