### PR TITLE
Enable dshot driver for fmu-v4pro

### DIFF
--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -25,7 +25,7 @@ px4_add_board(
 		camera_trigger
 		differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
-		#dshot
+		dshot
 		gps
 		#heater
 		#imu # all available imu drivers


### PR DESCRIPTION
**Describe problem solved by this pull request**
The DShot driver is not built in the default.cmake of fmu-v4pro boards. This board has enough flash memory to add this driver.

**Describe your solution**
Enable DShot driver in the default.cmake of fmu-v4pro.

**Test data / coverage**
Flashed on a Pixhawk 3 Pro and DSHOT_CONFIG parameter checked.
