### PR TITLE
Fix delay in reporting loss of navigation in vehicle_status_flags

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4048,7 +4048,7 @@ void Commander::estimator_check()
 	/* run global position accuracy checks */
 	// Check if quality checking of position accuracy and consistency is to be performed
 	if (run_quality_checks) {
-		if (_nav_test_failed) {
+		if (_nav_test_failed || !lpos.xy_valid) {
 			_status_flags.condition_global_position_valid = false;
 			_status_flags.condition_local_position_valid = false;
 			_status_flags.condition_local_velocity_valid = false;


### PR DESCRIPTION
When GPS is failed in SITL via the use of 'failure gps off' with the SYS_FAILURE_EN parameter set to 1, although the EKF correctly reports when it stops calculating a position and velocity estimate via the vehicle_local_position.xy_valid and stoppage of publishing the vehicle_global_position message, the vehicle_status_flags message delays the reporting of this via the condition_local_position_valid and condition_global_position_valid data.

The fix is to add a check of the vehicle_local_position.xy_valid in addition to the check of reported position accuracy.
It also includes the updates to ecl that fixed inconsistencies in the navigation validity reporting when dead reckoning without GPS

This was tested in SITL using the 'make px4_sitl gazebo_plane'  with he follwoign parameter modifications

EKF2_FUSE_BETA=0 to ensure a rapid loss of navigation when GPS is failed. If this is set to 1, then the EKF will continue to dead-reckon for several minutes after GPs is stopped
SYS_FAILURE_EN = 1 to enable sensors to be failed.

Load a short mission that enables an automatic takeoff. 

Takeoff and at the px4> prompt, enter 'failure gps off' to stop GPS

Before the fix, there is a delay from when the vehicle_local_position and vehicle_global_position messages report loss of navigation to when this is reported by the vehicle_status_flags

<img width="1126" alt="Screen Shot 2020-12-08 at 9 13 15 pm" src="https://user-images.githubusercontent.com/3596952/101754846-4d819280-3b28-11eb-913f-2a505e10dfcf.png">

After this fix the relevant vehicle_status_flags update immediately.

<img width="1114" alt="Screen Shot 2020-12-08 at 9 47 34 pm" src="https://user-images.githubusercontent.com/3596952/101755058-8d487a00-3b28-11eb-85d7-1e29e49fdbe8.png">

