### PR TITLE
AirspeedValidator: fuse true airspeed before sideslip

### DIFF
--- a/src/lib/airspeed_validator/AirspeedValidator.cpp
+++ b/src/lib/airspeed_validator/AirspeedValidator.cpp
@@ -77,12 +77,14 @@ AirspeedValidator::update_wind_estimator(const uint64_t time_now_usec, float air
 		Vector3f vI(lpos_vx, lpos_vy, lpos_vz);
 		Quatf q(att_q);
 
-		// sideslip fusion
-		_wind_estimator.fuse_beta(time_now_usec, vI, q);
-
 		// airspeed fusion (with raw TAS)
 		const Vector3f vel_var{Dcmf(q) *Vector3f{lpos_evh, lpos_evh, lpos_evv}};
 		_wind_estimator.fuse_airspeed(time_now_usec, airspeed_true_raw, vI, Vector2f{vel_var(0), vel_var(1)});
+
+		// sideslip fusion
+		_wind_estimator.fuse_beta(time_now_usec, vI, q);
+
+
 	}
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
The wind estimator uses either true airspeed measurement or sideslip measurement to initialise, whichever comes first.
It makes more sense to initialize with true airspeed as it's more accurate.

**Describe your solution**
Initialize with true airspeed instead.


**Test data / coverage**
Flight tested on multiple vehicles.

**Additional context**
The plots below show the wind estimates for the main ekf and the wind estimators. At 60s the wind is switched from south wind to west wind. Initialization works as expected (note that instance 02 only uses sideslip measurements and thus converges slower)
![image](https://user-images.githubusercontent.com/26798987/101782400-3ecfb700-3af9-11eb-8a36-f1a8985ed7a6.png)

