### PR TITLE
Tiltrotor: allow to finish transition if groundspeed is below cruise

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -123,9 +123,12 @@ void Tiltrotor::update_vtol_state()
 			break;
 
 		case vtol_mode::TRANSITION_BACK:
-			float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
+			const float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
+			const float ground_speed = sqrtf(_local_pos->vx * _local_pos->vx + _local_pos->vy * _local_pos->vy);
+			const bool ground_speed_below_cruise = _local_pos->v_xy_valid && (ground_speed <= _params->mpc_xy_cruise);
 
-			if (_tilt_control <= _params_tiltrotor.tilt_mc && time_since_trans_start > _params->back_trans_duration) {
+			if (_tilt_control <= _params_tiltrotor.tilt_mc && (time_since_trans_start > _params->back_trans_duration
+					|| ground_speed_below_cruise)) {
 				_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 			}
 


### PR DESCRIPTION

**Describe problem solved by this pull request**
Currently, for tiltrotor the back transition only is finished once the back transition duration is over (VT_B_TRANS_DUR). In high head wind this could lead to situations where the vehicle flies backwards before switching to MC mode. 

**Describe your solution**
Switch to MC mode if either duration is over or groundspeed is below MPC_CRUISE. Similar logic is already in place for standard VTOLs. 

**Test data / coverage**
Flight tested on multiple vehicles.

