### PR TITLE
Also log transponder_report and satellite_info

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -83,6 +83,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("tecs_status", 200);
 	add_topic("test_motor", 500);
 	add_topic("trajectory_setpoint", 200);
+	add_topic("transponder_report");
 	add_topic("vehicle_acceleration", 50);
 	add_topic("vehicle_air_data", 200);
 	add_topic("vehicle_angular_velocity", 20);
@@ -183,6 +184,7 @@ void LoggedTopics::add_debug_topics()
 	add_topic("debug_key_value");
 	add_topic("debug_value");
 	add_topic("debug_vect");
+	add_topic_multi("satellite_info", 1000, 2);
 }
 
 void LoggedTopics::add_estimator_replay_topics()


### PR DESCRIPTION
**Describe problem solved by this pull request**
We missed some uORB topics from the default log in our recent flight tests:
- transponder_report (ADS-B, UTM_GLOBAL_POSITION) is needed to analyze collision avoidance features, e.g. in UTM systems currently under development
- Publishing of satellite information (uORB satellite_info/ MAVLink GPS_STATUS) can be enabled in the gps driver, but will not be logged at all.

**Describe your solution**
- transponder_report will be logged at full data rate by default
- satellite_info will be logged as part of the debug group. 1 Hz and 2 GPS receivers should be enough?

**Describe possible alternatives**
I don't know, whether it might make more sense to add these two topics to other groups. Please let me know, if I should move them around.
I just want to be able to enable logging of these topics without creating a logger_topic.txt on the SD card, which might not be up to date with the latest changes.
