### PR TITLE
Multicopter rounded turns

### DIFF
--- a/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/flight_tasks/tasks/Auto/FlightTaskAuto.cpp
@@ -451,11 +451,11 @@ State FlightTaskAuto::_getCurrentState()
 		// Target is behind.
 		return_state = State::target_behind;
 
-	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed) {
+	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _target_acceptance_radius) {
 		// Current position is more than cruise speed in front of previous setpoint.
 		return_state = State::previous_infront;
 
-	} else if (Vector2f(Vector2f(_position) - _closest_pt).length() > _mc_cruise_speed) {
+	} else if (Vector2f(Vector2f(_position) - _closest_pt).length() > _target_acceptance_radius) {
 		// Vehicle is more than cruise speed off track.
 		return_state = State::offtrack;
 

--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -116,6 +116,7 @@ void FlightTaskAutoLineSmoothVel::_ekfResetHandlerHeading(float delta_psi)
 
 void FlightTaskAutoLineSmoothVel::_generateSetpoints()
 {
+	_updateTurningCheck();
 	_prepareSetpoints();
 	_generateTrajectory();
 
@@ -123,6 +124,26 @@ void FlightTaskAutoLineSmoothVel::_generateSetpoints()
 		// no valid heading -> generate heading in this flight task
 		_generateHeading();
 	}
+}
+
+void FlightTaskAutoLineSmoothVel::_updateTurningCheck()
+{
+	const Vector2f vel_traj(_trajectory[0].getCurrentVelocity(),
+				_trajectory[1].getCurrentVelocity());
+	const Vector2f pos_traj(_trajectory[0].getCurrentPosition(),
+				_trajectory[1].getCurrentPosition());
+	const Vector2f target_xy(_target);
+	const Vector2f u_vel_traj = vel_traj.unit_or_zero();
+	const Vector2f pos_to_target = Vector2f(target_xy - pos_traj);
+	const float cos_align = u_vel_traj * pos_to_target.unit_or_zero();
+
+	// The vehicle is turning if the angle between the velocity vector
+	// and the direction to the target is greater than 10 degrees, the
+	// velocity is large enough and the drone isn't in the acceptance
+	// radius of the last WP.
+	_is_turning = vel_traj.longerThan(0.2f)
+		      && cos_align < 0.98f
+		      && pos_to_target.longerThan(_target_acceptance_radius);
 }
 
 void FlightTaskAutoLineSmoothVel::_generateHeading()
@@ -140,7 +161,7 @@ bool FlightTaskAutoLineSmoothVel::_generateHeadingAlongTraj()
 	Vector2f traj_to_target = Vector2f(_target) - Vector2f(_position);
 
 	if ((vel_sp_xy.length() > .1f) &&
-	    (traj_to_target.length() > _target_acceptance_radius)) {
+	    (traj_to_target.length() > 2.f)) {
 		// Generate heading from velocity vector, only if it is long enough
 		// and if the drone is far enough from the target
 		_compute_heading_from_2D_vector(_yaw_setpoint, vel_sp_xy);
@@ -183,13 +204,10 @@ float FlightTaskAutoLineSmoothVel::_getMaxXYSpeed() const
 
 	// constrain velocity to go to the position setpoint first if the position setpoint has been modified by an external source
 	// (eg. Obstacle Avoidance)
-	bool xy_modified = (_target - _position_setpoint).xy().longerThan(FLT_EPSILON);
-	bool z_valid = PX4_ISFINITE(_position_setpoint(2));
-	bool z_modified =  z_valid && fabs((_target - _position_setpoint)(2)) > FLT_EPSILON;
 
 	Vector3f waypoints[3] = {pos_traj, _target, _next_wp};
 
-	if (xy_modified || z_modified) {
+	if (isTargetModified()) {
 		waypoints[2] = waypoints[1] = _position_setpoint;
 	}
 
@@ -224,6 +242,64 @@ float FlightTaskAutoLineSmoothVel::_getMaxZSpeed() const
 	return max_speed;
 }
 
+Vector3f FlightTaskAutoLineSmoothVel::getCrossingPoint() const
+{
+	Vector3f pos_crossing_point{};
+
+	if (isTargetModified()) {
+		// Strictly follow the modified setpoint
+		pos_crossing_point = _position_setpoint;
+
+	} else {
+		if (_is_turning) {
+			// Get the crossing point using L1-style guidance
+			pos_crossing_point.xy() = getL1Point();
+			pos_crossing_point(2) = _target(2);
+
+		} else {
+			pos_crossing_point = _target;
+		}
+	}
+
+	return pos_crossing_point;
+}
+
+bool FlightTaskAutoLineSmoothVel::isTargetModified() const
+{
+	const bool xy_modified = (_target - _position_setpoint).xy().longerThan(FLT_EPSILON);
+	const bool z_valid = PX4_ISFINITE(_position_setpoint(2));
+	const bool z_modified =  z_valid && fabs((_target - _position_setpoint)(2)) > FLT_EPSILON;
+
+	return xy_modified || z_modified;
+}
+
+Vector2f FlightTaskAutoLineSmoothVel::getL1Point() const
+{
+	const Vector2f pos_traj(_trajectory[0].getCurrentPosition(),
+				_trajectory[1].getCurrentPosition());
+	const Vector2f target_xy(_target);
+	const Vector2f u_prev_to_target = Vector2f(target_xy - Vector2f(_prev_wp)).unit_or_zero();
+	const Vector2f prev_to_pos(pos_traj - Vector2f(_prev_wp));
+	const Vector2f prev_to_closest(u_prev_to_target * (prev_to_pos * u_prev_to_target));
+	const Vector2f closest_pt = Vector2f(_prev_wp) + prev_to_closest;
+
+	// Compute along-track error using L1 distance and cross-track error
+	const float crosstrack_error = Vector2f(closest_pt - pos_traj).length();
+
+	const float l1 = math::max(_target_acceptance_radius, 5.f);
+	float alongtrack_error = 0.f;
+
+	// Protect against sqrt of a negative number
+	if (l1 > crosstrack_error) {
+		alongtrack_error = sqrtf(l1 * l1 - crosstrack_error * crosstrack_error);
+	}
+
+	// Position of the point on the line where L1 intersect the line between the two waypoints
+	const Vector2f l1_point = closest_pt + alongtrack_error * u_prev_to_target;
+
+	return l1_point;
+}
+
 void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 {
 	// Interface: A valid position setpoint generates a velocity target using conservative motion constraints.
@@ -246,10 +322,19 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			Vector3f pos_traj(_trajectory[0].getCurrentPosition(),
 					  _trajectory[1].getCurrentPosition(),
 					  _trajectory[2].getCurrentPosition());
-			Vector3f u_pos_traj_to_dest = (_position_setpoint - pos_traj).unit_or_zero();
 
-			const float xy_speed = _getMaxXYSpeed();
+			const Vector3f u_pos_traj_to_dest((getCrossingPoint() - pos_traj).unit_or_zero());
+
+			float xy_speed = _getMaxXYSpeed();
 			const float z_speed = _getMaxZSpeed();
+
+			if (_is_turning) {
+				// Lock speed during turn
+				xy_speed = math::min(_max_speed_prev, xy_speed);
+
+			} else {
+				_max_speed_prev = xy_speed;
+			}
 
 			Vector3f vel_sp_constrained = u_pos_traj_to_dest * sqrtf(xy_speed * xy_speed + z_speed * z_speed);
 			math::trajectory::clampToXYNorm(vel_sp_constrained, xy_speed, 0.5f);
@@ -271,10 +356,20 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 
 			// Get various path specific vectors
 			Vector2f pos_traj(_trajectory[0].getCurrentPosition(), _trajectory[1].getCurrentPosition());
-			Vector2f pos_traj_to_dest_xy = Vector2f(_position_setpoint.xy()) - pos_traj;
+			Vector2f pos_traj_to_dest_xy = Vector2f(getCrossingPoint()) - pos_traj;
 			Vector2f u_pos_traj_to_dest_xy(pos_traj_to_dest_xy.unit_or_zero());
 
-			Vector2f vel_sp_constrained_xy = u_pos_traj_to_dest_xy * _getMaxXYSpeed();
+			float xy_speed = _getMaxXYSpeed();
+
+			if (_is_turning) {
+				// Lock speed during turn
+				xy_speed = math::min(_max_speed_prev, xy_speed);
+
+			} else {
+				_max_speed_prev = xy_speed;
+			}
+
+			Vector2f vel_sp_constrained_xy = u_pos_traj_to_dest_xy * xy_speed;
 
 			for (int i = 0; i < 2; i++) {
 				// If available, use the existing velocity as a feedforward, otherwise replace it

--- a/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/flight_tasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -63,6 +63,7 @@ protected:
 
 	void _generateSetpoints() override; /**< Generate setpoints along line. */
 	void _generateHeading();
+	void _updateTurningCheck();
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
 
 	static float _constrainOneSide(float val, float constraint); /**< Constrain val between INF and constraint */
@@ -71,6 +72,13 @@ protected:
 
 	float _getMaxXYSpeed() const;
 	float _getMaxZSpeed() const;
+
+	matrix::Vector3f getCrossingPoint() const;
+	bool isTargetModified() const;
+	matrix::Vector2f getL1Point() const;
+
+	float _max_speed_prev{};
+	bool _is_turning{false};
 
 	void _prepareSetpoints(); /**< Generate velocity target points for the trajectory generator. */
 	void _updateTrajConstraints();


### PR DESCRIPTION
This creates more rounded turns in multirotor mission using l1-style guidance logic in corners.

Example of what can be done (default acc/jerk, acceptance radius of from 2m to 8m):
https://logs.px4.io/plot_app?log=616bf543-eb2f-44a8-90fa-63cc4b7795f6
![DeepinScreenshot_select-area_20201211134534](https://user-images.githubusercontent.com/14822839/101905689-1f4b9380-3bb8-11eb-906b-b9e5fd6d98d8.png)

- This will only change mission flights
- The drone doesn't stop at each waypoint but decelerates to make a turn at constant speed
- The turning radius is defined by the waypoint acceptance radius `NAV_ACC_RAD`
- A wide range of accelerations (`MPC_ACC_HOR`), jerk (`MPC_JERK_AUTO`) and velocities (`MPC_XY_CRUISE`) should work.
- Use [MPC_YAW_MODE](https://dev.px4.io/master/en/advanced/parameter_reference.html#MPC_YAW_MODE) "along trajectory" for a nice yaw coordinated turn

Other example:
![Rounded_turns](https://user-images.githubusercontent.com/14822839/87161364-b4bec080-c2c4-11ea-9c7d-7de6f940150d.png)