### PR TITLE
fixing the thrust being used in the attitude target raw mavlink messge

### DIFF
--- a/src/modules/mavlink/streams/ATTITUDE_TARGET.hpp
+++ b/src/modules/mavlink/streams/ATTITUDE_TARGET.hpp
@@ -100,7 +100,7 @@ protected:
 			msg.body_pitch_rate = att_rates_sp.pitch;
 			msg.body_yaw_rate = att_rates_sp.yaw;
 
-			msg.thrust = att_sp.thrust_body[0];
+			msg.thrust = att_sp.thrust_body[2];
 
 			mavlink_msg_attitude_target_send_struct(_mavlink->get_channel(), &msg);
 

--- a/src/modules/mavlink/streams/ATTITUDE_TARGET.hpp
+++ b/src/modules/mavlink/streams/ATTITUDE_TARGET.hpp
@@ -100,7 +100,7 @@ protected:
 			msg.body_pitch_rate = att_rates_sp.pitch;
 			msg.body_yaw_rate = att_rates_sp.yaw;
 
-			msg.thrust = att_sp.thrust_body[2];
+			msg.thrust = Vector3f(att_sp.thrust_body).norm();
 
 			mavlink_msg_attitude_target_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**

When using the attitude target over mavlink (listening on the setpoint being set by the attitude controller), the thrust field remains 0 the whole time. 

**Describe your solution**

I think the mavlink stream is pulling the wrong entry from the uorb message (being set [here](https://github.com/PX4/PX4-Autopilot/blob/0f411d6820e55f5e7cb58d064095725f28a7820a/src/modules/mc_att_control/mc_att_control_main.cpp#L213)). I just updated the mavlink stream.

**Describe possible alternatives**

I don't know how else to fix this. I think it's just a typo basically.

**Test data / coverage**

I flew in Gazebo and looked at the mavlink stream using mavros.

**Additional context**

The thrust reported over mavros is negative. I think this is fine since it's NED, but maybe should be flipped in mavros (which generally works ENU)?
