### PR TITLE
sensors: filtered control data (accel & gyro) always get measured sample rate from vehicle_imu_status

### DIFF
--- a/msg/vehicle_imu_status.msg
+++ b/msg/vehicle_imu_status.msg
@@ -8,8 +8,8 @@ uint32[3] accel_clipping        # total clipping per axis
 uint32 accel_error_count
 uint32 gyro_error_count
 
-uint16 accel_rate_hz
-uint16 gyro_rate_hz
+float32 accel_rate_hz
+float32 gyro_rate_hz
 
 float32 accel_vibration_metric  # high frequency vibration level in the IMU delta velocity data (m/s)
 float32 gyro_vibration_metric   # high frequency vibration level in the IMU delta velocity data (m/s)

--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.hpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.hpp
@@ -68,7 +68,7 @@ public:
 private:
 	void Run() override;
 
-	void CheckFilters();
+	void CheckAndUpdateFilters();
 	void ParametersUpdate(bool force = false);
 	void SensorBiasUpdate(bool force = false);
 	bool SensorSelectionUpdate(bool force = false);
@@ -86,25 +86,14 @@ private:
 
 	calibration::Accelerometer _calibration{};
 
-	matrix::Vector3f _bias{0.f, 0.f, 0.f};
+	matrix::Vector3f _bias{};
 
-	matrix::Vector3f _acceleration_prev{0.f, 0.f, 0.f};
+	matrix::Vector3f _acceleration_prev{};
 
-	static constexpr const float kInitialRateHz{1000.0f}; /**< sensor update rate used for initialization */
-	float _update_rate_hz{kInitialRateHz}; /**< current rate-controller loop update rate in [Hz] */
-
-	uint8_t _required_sample_updates{0}; /**< number or sensor publications required for configured rate */
-
-	math::LowPassFilter2pVector3f _lp_filter{kInitialRateHz, 30.0f};
-
+	static constexpr const float kInitialRateHz{1000.f}; /**< sensor update rate used for initialization */
 	float _filter_sample_rate{kInitialRateHz};
 
-	uint32_t _selected_sensor_device_id{0};
-	uint8_t _selected_sensor_sub_index{0};
-
-	hrt_abstime _timestamp_sample_last{0};
-	float _interval_sum{0.f};
-	float _interval_count{0.f};
+	math::LowPassFilter2pVector3f _lp_filter{kInitialRateHz, 30.f};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::IMU_ACCEL_CUTOFF>) _param_imu_accel_cutoff,

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -70,7 +70,7 @@ public:
 private:
 	void Run() override;
 
-	void CheckFilters();
+	void CheckAndUpdateFilters();
 	void ParametersUpdate(bool force = false);
 	void SensorBiasUpdate(bool force = false);
 	bool SensorSelectionUpdate(bool force = false);
@@ -89,33 +89,22 @@ private:
 
 	calibration::Gyroscope _calibration{};
 
-	matrix::Vector3f _bias{0.f, 0.f, 0.f};
+	matrix::Vector3f _bias{};
 
-	matrix::Vector3f _angular_acceleration_prev{0.f, 0.f, 0.f};
-	matrix::Vector3f _angular_velocity_prev{0.f, 0.f, 0.f};
+	matrix::Vector3f _angular_acceleration_prev{};
+	matrix::Vector3f _angular_velocity_prev{};
 	hrt_abstime _timestamp_sample_prev{0};
 
 	hrt_abstime _last_publish{0};
-	static constexpr const float kInitialRateHz{1000.0f}; /**< sensor update rate used for initialization */
-	float _update_rate_hz{kInitialRateHz}; /**< current rate-controller loop update rate in [Hz] */
-
-	uint8_t _required_sample_updates{0}; /**< number or sensor publications required for configured rate */
+	static constexpr const float kInitialRateHz{1000.f}; /**< sensor update rate used for initialization */
+	float _filter_sample_rate{kInitialRateHz};
 
 	// angular velocity filters
-	math::LowPassFilter2pVector3f _lp_filter_velocity{kInitialRateHz, 30.0f};
+	math::LowPassFilter2pVector3f _lp_filter_velocity{kInitialRateHz, 30.f};
 	math::NotchFilter<matrix::Vector3f> _notch_filter_velocity{};
 
 	// angular acceleration filter
-	math::LowPassFilter2pVector3f _lp_filter_acceleration{kInitialRateHz, 30.0f};
-
-	float _filter_sample_rate{kInitialRateHz};
-
-	uint32_t _selected_sensor_device_id{0};
-	uint8_t _selected_sensor_sub_index{0};
-
-	hrt_abstime _timestamp_sample_last{0};
-	float _interval_sum{0.f};
-	float _interval_count{0.f};
+	math::LowPassFilter2pVector3f _lp_filter_acceleration{kInitialRateHz, 30.f};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::IMU_GYRO_CUTOFF>) _param_imu_gyro_cutoff,

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -226,7 +226,7 @@ void VehicleIMU::Run()
 			if (!_intervals_configured && UpdateIntervalAverage(_gyro_interval, gyro.timestamp_sample)) {
 				update_integrator_config = true;
 				publish_status = true;
-				_status.gyro_rate_hz = roundf(1e6f / _gyro_interval.update_interval);
+				_status.gyro_rate_hz = 1e6f / _gyro_interval.update_interval;
 			}
 		}
 
@@ -272,7 +272,7 @@ void VehicleIMU::Run()
 			if (!_intervals_configured && UpdateIntervalAverage(_accel_interval, accel.timestamp_sample)) {
 				update_integrator_config = true;
 				publish_status = true;
-				_status.accel_rate_hz = roundf(1e6f / _accel_interval.update_interval);
+				_status.accel_rate_hz = 1e6f / _accel_interval.update_interval;
 			}
 		}
 


### PR DESCRIPTION
Rather than all of these separate WorkItems independently calculating the sample rate for accel or gyro this PR updates `sensors/vehicle_angular_velocity` and `sensors/vehicle_acceleration` to always use the value calculated by the integrator(s) and published in `vehicle_imu_status`.

Small prelude before https://github.com/PX4/PX4-Autopilot/pull/15820.