### PR TITLE
Remove duplicate terms in text that is exported

### DIFF
--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -132,7 +132,7 @@ PARAM_DEFINE_INT32(SYS_PARAM_VER, 1);
  *
  * 0 : Set to 0 to do nothing
  * 1 : Set to 1 to start a calibration at next boot
- * This parameter is reset to zero when the the temperature calibration starts.
+ * This parameter is reset to zero when the temperature calibration starts.
  *
  * default (0, no calibration)
  *

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -147,7 +147,7 @@ PARAM_DEFINE_INT32(SYS_CAL_GYRO, 0);
  *
  * 0 : Set to 0 to do nothing
  * 1 : Set to 1 to start a calibration at next boot
- * This parameter is reset to zero when the the temperature calibration starts.
+ * This parameter is reset to zero when the temperature calibration starts.
  *
  * default (0, no calibration)
  *
@@ -162,7 +162,7 @@ PARAM_DEFINE_INT32(SYS_CAL_ACCEL, 0);
  *
  * 0 : Set to 0 to do nothing
  * 1 : Set to 1 to start a calibration at next boot
- * This parameter is reset to zero when the the temperature calibration starts.
+ * This parameter is reset to zero when the temperature calibration starts.
  *
  * default (0, no calibration)
  *
@@ -222,7 +222,7 @@ PARAM_DEFINE_INT32(SYS_HAS_MAG, 1);
 /**
  * Control if the vehicle has a barometer
  *
- * Disable this if the board has no barometer, such as some of the the Omnibus
+ * Disable this if the board has no barometer, such as some of the Omnibus
  * F4 SD variants.
  * If disabled, the preflight checks will not check for the presence of a
  * barometer.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -118,7 +118,7 @@ PARAM_DEFINE_INT32(COM_HLDL_LOSS_T, 120);
 /**
  * High Latency Datalink regain time threshold
  *
- * After a data link loss: after this this amount of seconds with a healthy datalink the 'datalink loss'
+ * After a data link loss: after this number of seconds with a healthy datalink the 'datalink loss'
  * flag is set back to false
  *
  * @group Commander


### PR DESCRIPTION
There are duplicates terms in param descriptions etc (e.g "the the"). This removes them. 