### PR TITLE
[DO NOT MERGE] consider removing Matrix default initializer

### DIFF
--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -248,14 +248,14 @@ WorkQueueManagerRun(int, char **)
 		if (wq != nullptr) {
 			// create new work queue
 
-			pthread_attr_t attr;
+			pthread_attr_t attr{};
 			int ret_attr_init = pthread_attr_init(&attr);
 
 			if (ret_attr_init != 0) {
 				PX4_ERR("attr init for %s failed (%i)", wq->name, ret_attr_init);
 			}
 
-			sched_param param;
+			sched_param param{};
 			int ret_getschedparam = pthread_attr_getschedparam(&attr, &param);
 
 			if (ret_getschedparam != 0) {
@@ -300,7 +300,7 @@ WorkQueueManagerRun(int, char **)
 			}
 
 			// create thread
-			pthread_t thread;
+			pthread_t thread{};
 			int ret_create = pthread_create(&thread, &attr, WorkQueueRunner, (void *)wq);
 
 			if (ret_create == 0) {

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -45,7 +45,7 @@ ExternalProject_Add(sitl_gazebo
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
 	BUILD_ALWAYS 1
-	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR>
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -j1
 )
 
 ExternalProject_Add(mavsdk_tests

--- a/src/lib/bezier/BezierNTest.cpp
+++ b/src/lib/bezier/BezierNTest.cpp
@@ -67,7 +67,8 @@ TEST(BezierN_calculateBezier, work_1_point)
 {
 	// GIVEN: a single point bezier curve
 	matrix::Vector3f points[2] = {matrix::Vector3f(1, 2, 3), matrix::Vector3f(NAN, NAN, NAN)};
-	matrix::Vector3f pos, vel;
+	matrix::Vector3f pos{};
+	matrix::Vector3f vel{};
 	pos *= NAN;
 	vel *= NAN;
 
@@ -83,7 +84,8 @@ TEST(BezierN_calculateBezier, works_2_points)
 {
 	// GIVEN: a 2-point bezier curve
 	matrix::Vector3f points[3] = {matrix::Vector3f(1, 2, 3), matrix::Vector3f(5, 0, 1), matrix::Vector3f(NAN, NAN, NAN)};
-	matrix::Vector3f pos, vel;
+	matrix::Vector3f pos{};
+	matrix::Vector3f vel{};
 	pos *= NAN;
 	vel *= NAN;
 
@@ -113,7 +115,8 @@ TEST(BezierN_calculateBezier, works_3_points_zero_accel)
 {
 	// GIVEN: 3 points bezier, evenly spaced in a straight line
 	matrix::Vector3f points[4] = {matrix::Vector3f(1, 2, 3), matrix::Vector3f(5, 0, 1), matrix::Vector3f(9, -2, -1), matrix::Vector3f(NAN, NAN, NAN)};
-	matrix::Vector3f pos, vel;
+	matrix::Vector3f pos{};
+	matrix::Vector3f vel{};
 	pos *= NAN;
 	vel *= NAN;
 
@@ -161,16 +164,20 @@ TEST(BezierN_calculateBezier, works_3_points_accel)
 {
 	// GIVEN: 3 points bezier, in a curve
 	matrix::Vector3f points[4] = {matrix::Vector3f(1, 2, 3), matrix::Vector3f(5, 0, 1), matrix::Vector3f(19, -8, 1), matrix::Vector3f(NAN, NAN, NAN)};
-	matrix::Vector3f pos, vel;
+	matrix::Vector3f pos{};
+	matrix::Vector3f vel{};
 	pos *= NAN;
 	vel *= NAN;
 
-	matrix::Vector3f pos2;
+	matrix::Vector3f pos2{};
 	pos2 *= NAN;
 
-	matrix::Vector3f accel_start, accel_mid, accel_end;
-	matrix::Vector3f vel_start, vel_mid, vel_end;
-
+	matrix::Vector3f accel_start{};
+	matrix::Vector3f accel_mid{};
+	matrix::Vector3f accel_end{};
+	matrix::Vector3f vel_start{};
+	matrix::Vector3f vel_mid{};
+	matrix::Vector3f vel_end{};
 
 	// WHEN: we check at the beginning
 	EXPECT_TRUE(bezier::calculateBezierPosVel(points, 3, 0.f, pos, vel));

--- a/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingXY.hpp
+++ b/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingXY.hpp
@@ -118,9 +118,9 @@ private:
 	Vector2f _position_estimate{};
 
 	struct {
-		Vector2f j;
-		Vector2f a;
-		Vector2f v;
-		Vector2f x;
+		Vector2f j{};
+		Vector2f a{};
+		Vector2f v{};
+		Vector2f x{};
 	} _state{};
 };

--- a/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingXYTest.cpp
+++ b/src/lib/flight_tasks/tasks/Utility/ManualVelocitySmoothingXYTest.cpp
@@ -70,10 +70,10 @@ TEST_F(ManualVelocitySmoothingXYTest, getCurrentState)
 	_smoothing.setCurrentVelocity(v0);
 
 	// WHEN: we get the current state
-	Vector3f j_end;
-	Vector3f a_end;
-	Vector3f v_end;
-	Vector3f x_end;
+	Vector3f j_end{};
+	Vector3f a_end{};
+	Vector3f v_end{};
+	Vector3f x_end{};
 	j_end.xy() = _smoothing.getCurrentJerk();
 	a_end.xy() = _smoothing.getCurrentAcceleration();
 	v_end.xy() = _smoothing.getCurrentVelocity();

--- a/src/lib/mathlib/math/filter/LowPassFilter2p.hpp
+++ b/src/lib/mathlib/math/filter/LowPassFilter2p.hpp
@@ -68,17 +68,17 @@ public:
 
 protected:
 
-	float _cutoff_freq{0.0f};
+	float _cutoff_freq{0.f};
 
-	float _a1{0.0f};
-	float _a2{0.0f};
+	float _a1{0.f};
+	float _a2{0.f};
 
-	float _b0{0.0f};
-	float _b1{0.0f};
-	float _b2{0.0f};
+	float _b0{0.f};
+	float _b1{0.f};
+	float _b2{0.f};
 
-	float _delay_element_1{0.0f};	// buffered sample -1
-	float _delay_element_2{0.0f};	// buffered sample -2
+	float _delay_element_1{0.f};	// buffered sample -1
+	float _delay_element_2{0.f};	// buffered sample -2
 };
 
 } // namespace math

--- a/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.hpp
+++ b/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.hpp
@@ -79,17 +79,17 @@ public:
 
 private:
 
-	float _cutoff_freq{0.0f};
+	float _cutoff_freq{0.f};
 
-	float _a1{0.0f};
-	float _a2{0.0f};
+	float _a1{0.f};
+	float _a2{0.f};
 
-	float _b0{0.0f};
-	float _b1{0.0f};
-	float _b2{0.0f};
+	float _b0{0.f};
+	float _b1{0.f};
+	float _b2{0.f};
 
-	matrix::Vector3f _delay_element_1{0.0f, 0.0f, 0.0f};	// buffered sample -1
-	matrix::Vector3f _delay_element_2{0.0f, 0.0f, 0.0f};	// buffered sample -2
+	matrix::Vector3f _delay_element_1{};	// buffered sample -1
+	matrix::Vector3f _delay_element_2{};	// buffered sample -2
 };
 
 } // namespace math

--- a/src/lib/mathlib/math/filter/NotchFilter.hpp
+++ b/src/lib/mathlib/math/filter/NotchFilter.hpp
@@ -153,10 +153,10 @@ protected:
 	float _b1{};
 	float _b2{};
 
-	T _delay_element_1;
-	T _delay_element_2;
-	T _delay_element_output_1;
-	T _delay_element_output_2;
+	T _delay_element_1{};
+	T _delay_element_2{};
+	T _delay_element_output_1{};
+	T _delay_element_output_2{};
 };
 
 /**

--- a/src/lib/mathlib/math/filter/NotchFilterTest.cpp
+++ b/src/lib/mathlib/math/filter/NotchFilterTest.cpp
@@ -47,8 +47,8 @@ using matrix::Vector3f;
 class NotchFilterTest : public ::testing::Test
 {
 public:
-	NotchFilter<float> _notch_float;
-	NotchFilter<Vector3f> _notch_vector3f;
+	NotchFilter<float> _notch_float{};
+	NotchFilter<Vector3f> _notch_vector3f{};
 	const float _sample_freq = 1000.f;
 	const float _notch_freq = 50.f;
 	const float _bandwidth = 15.f;

--- a/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
+++ b/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
@@ -94,6 +94,7 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb, uintptr_t cb_handle
 {
 	for (unsigned i = 0; i < _rotor_count; ++i) {
 		_outputs_prev[i] = -1.f;
+		_tmp_array[i] = 0.f;
 	}
 }
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -456,7 +456,7 @@ AttitudeEstimatorQ::update(float dt)
 	Quatf q_last = _q;
 
 	// Angular rate of correction
-	Vector3f corr;
+	Vector3f corr{};
 	float spinRate = _gyro.length();
 
 	if (_param_att_ext_hdg_m.get() > 0 && _ext_hdg_good) {

--- a/src/modules/landing_target_estimator/KalmanFilter.cpp
+++ b/src/modules/landing_target_estimator/KalmanFilter.cpp
@@ -71,12 +71,12 @@ void KalmanFilter::predict(float dt, float acc, float acc_unc)
 	_x(0) += _x(1) * dt + dt * dt / 2 * acc;
 	_x(1) += acc * dt;
 
-	matrix::Matrix<float, 2, 2> A; // propagation matrix
+	matrix::Matrix<float, 2, 2> A{}; // propagation matrix
 	A(0, 0) = 1;
 	A(1, 1) = 1;
 	A(0, 1) = dt;
 
-	matrix::Matrix<float, 2, 1> G; // noise model
+	matrix::Matrix<float, 2, 1> G{}; // noise model
 	G(0, 0) = dt * dt / 2;
 	G(1, 0) = dt;
 
@@ -112,7 +112,7 @@ bool KalmanFilter::update(float meas, float measUnc)
 	matrix::Matrix<float, 2, 2> identity;
 	identity.identity();
 
-	matrix::Matrix<float, 2, 2> KH; // kalmanGain * H
+	matrix::Matrix<float, 2, 2> KH{}; // kalmanGain * H
 	KH(0, 0) = kalmanGain(0);
 	KH(1, 0) = kalmanGain(1);
 

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.hpp
@@ -92,10 +92,10 @@ public:
 	matrix::Vector3f update(const matrix::Quatf &q) const;
 
 private:
-	matrix::Vector3f _proportional_gain;
-	matrix::Vector3f _rate_limit;
+	matrix::Vector3f _proportional_gain{};
+	matrix::Vector3f _rate_limit{};
 	float _yaw_w{0.f}; ///< yaw weight [0,1] to deprioritize caompared to roll and pitch
 
-	matrix::Quatf _attitude_setpoint_q; ///< latest known attitude setpoint e.g. from position control
+	matrix::Quatf _attitude_setpoint_q{}; ///< latest known attitude setpoint e.g. from position control
 	float _yawspeed_setpoint{0.f}; ///< latest known yawspeed feed-forward setpoint
 };

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -80,7 +80,7 @@ public:
 		EXPECT_GT(i, 0);
 	}
 
-	AttitudeControl _attitude_control;
+	AttitudeControl _attitude_control{};
 	Quatf _quat_state;
 	Quatf _quat_goal;
 };

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -187,10 +187,10 @@ private:
 	void _accelerationControl(); ///< Acceleration setpoint processing
 
 	// Gains
-	matrix::Vector3f _gain_pos_p; ///< Position control proportional gain
-	matrix::Vector3f _gain_vel_p; ///< Velocity control proportional gain
-	matrix::Vector3f _gain_vel_i; ///< Velocity control integral gain
-	matrix::Vector3f _gain_vel_d; ///< Velocity control derivative gain
+	matrix::Vector3f _gain_pos_p{}; ///< Position control proportional gain
+	matrix::Vector3f _gain_vel_p{}; ///< Velocity control proportional gain
+	matrix::Vector3f _gain_vel_i{}; ///< Velocity control integral gain
+	matrix::Vector3f _gain_vel_d{}; ///< Velocity control derivative gain
 
 	// Limits
 	float _lim_vel_horizontal{}; ///< Horizontal velocity limit with feed forward and position control
@@ -203,19 +203,19 @@ private:
 	float _hover_thrust{}; ///< Thrust [0,1] with which the vehicle hovers not accelerating down or up with level orientation
 
 	// States
-	matrix::Vector3f _pos; /**< current position */
-	matrix::Vector3f _vel; /**< current velocity */
-	matrix::Vector3f _vel_dot; /**< velocity derivative (replacement for acceleration estimate) */
-	matrix::Vector3f _vel_int; /**< integral term of the velocity controller */
+	matrix::Vector3f _pos{}; /**< current position */
+	matrix::Vector3f _vel{}; /**< current velocity */
+	matrix::Vector3f _vel_dot{}; /**< velocity derivative (replacement for acceleration estimate) */
+	matrix::Vector3f _vel_int{}; /**< integral term of the velocity controller */
 	float _yaw{}; /**< current heading */
 
 	vehicle_constraints_s _constraints{}; /**< variable constraints */
 
 	// Setpoints
-	matrix::Vector3f _pos_sp; /**< desired position */
-	matrix::Vector3f _vel_sp; /**< desired velocity */
-	matrix::Vector3f _acc_sp; /**< desired acceleration */
-	matrix::Vector3f _thr_sp; /**< desired thrust */
+	matrix::Vector3f _pos_sp{}; /**< desired position */
+	matrix::Vector3f _vel_sp{}; /**< desired velocity */
+	matrix::Vector3f _acc_sp{}; /**< desired acceleration */
+	matrix::Vector3f _thr_sp{}; /**< desired thrust */
 	float _yaw_sp{}; /**< desired heading */
 	float _yawspeed_sp{}; /** desired yaw-speed */
 };

--- a/src/modules/mc_rate_control/RateControl/RateControl.hpp
+++ b/src/modules/mc_rate_control/RateControl/RateControl.hpp
@@ -104,14 +104,14 @@ private:
 	void updateIntegral(matrix::Vector3f &rate_error, const float dt);
 
 	// Gains
-	matrix::Vector3f _gain_p; ///< rate control proportional gain for all axes x, y, z
-	matrix::Vector3f _gain_i; ///< rate control integral gain
-	matrix::Vector3f _gain_d; ///< rate control derivative gain
-	matrix::Vector3f _lim_int; ///< integrator term maximum absolute value
-	matrix::Vector3f _gain_ff; ///< direct rate to torque feed forward gain only useful for helicopters
+	matrix::Vector3f _gain_p{}; ///< rate control proportional gain for all axes x, y, z
+	matrix::Vector3f _gain_i{}; ///< rate control integral gain
+	matrix::Vector3f _gain_d{}; ///< rate control derivative gain
+	matrix::Vector3f _lim_int{}; ///< integrator term maximum absolute value
+	matrix::Vector3f _gain_ff{}; ///< direct rate to torque feed forward gain only useful for helicopters
 
 	// States
-	matrix::Vector3f _rate_int; ///< integral term of the rate controller
+	matrix::Vector3f _rate_int{}; ///< integral term of the rate controller
 
 	bool _mixer_saturation_positive[3] {};
 	bool _mixer_saturation_negative[3] {};

--- a/src/systemcmds/tests/test_mathlib.cpp
+++ b/src/systemcmds/tests/test_mathlib.cpp
@@ -88,11 +88,11 @@ using namespace math;
 bool MathlibTest::testVector2()
 {
 	{
-		matrix::Vector2f v;
+		matrix::Vector2f v{};
 		matrix::Vector2f v1(1.0f, 2.0f);
 		matrix::Vector2f v2(1.0f, -1.0f);
 		float data[2] = {1.0f, 2.0f};
-		TEST_OP("Constructor matrix::Vector2f()", matrix::Vector2f v3);
+		TEST_OP("Constructor matrix::Vector2f()", matrix::Vector2f v3{});
 		TEST_OP("Constructor matrix::Vector2f(matrix::Vector2f)", matrix::Vector2f v3(v1); ut_assert_true(v3 == v1); v3.zero());
 		TEST_OP("Constructor matrix::Vector2f(float[])", matrix::Vector2f v3(data));
 		TEST_OP("Constructor matrix::Vector2f(float, float)", matrix::Vector2f v3(1.0f, 2.0f));

--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -119,13 +119,13 @@ bool MatrixTest::attitudeTests()
 
 
 	// euler default ctor
-	Eulerf e;
+	Eulerf e{};
 	Eulerf e_zero = zeros<float, 3, 1>();
 	ut_test(isEqual(e, e_zero));
 	ut_test(isEqual(e, e));
 
 	// euler vector ctor
-	Vector<float, 3> v;
+	Vector<float, 3> v{};
 	v(0) = 0.1f;
 	v(1) = 0.2f;
 	v(2) = 0.3f;
@@ -652,7 +652,7 @@ bool MatrixTest::vector2Tests()
 	Vector2f b(0, 1);
 	ut_test(fabs(a % b - 1.0f) < 1e-5);
 
-	Vector2f c;
+	Vector2f c{};
 	ut_test(fabs(c(0) - 0) < 1e-5);
 	ut_test(fabs(c(1) - 0) < 1e-5);
 


### PR DESCRIPTION
In Matrix we're currently initializing things more than once in many cases, this PR considers removing that default.

The downside is the danger of potentially using something uninitialized from Matrix. So far the compiler has caught many cases and I'll see with Valgrind and Address Sanitizer what we've missed.

Saves about 3% cpu on px4_fmu-v4_default.
