### PR TITLE
Orbit Approach Smooth Yaw

### DIFF
--- a/src/lib/flight_tasks/tasks/Orbit/CMakeLists.txt
+++ b/src/lib/flight_tasks/tasks/Orbit/CMakeLists.txt
@@ -35,5 +35,5 @@ px4_add_library(FlightTaskOrbit
 	FlightTaskOrbit.cpp
 )
 
-target_link_libraries(FlightTaskOrbit PUBLIC FlightTaskManualAltitudeSmoothVel)
+target_link_libraries(FlightTaskOrbit PUBLIC FlightTaskManualAltitudeSmoothVel SlewRate)
 target_include_directories(FlightTaskOrbit PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -162,6 +162,8 @@ bool FlightTaskOrbit::activate(const vehicle_local_position_setpoint_s &last_set
 	_center = Vector2f(_position);
 	_center(0) -= _r;
 	_initial_heading = _yaw;
+	_slew_rate_yaw.setForcedValue(_yaw);
+	_slew_rate_yaw.setSlewRate(math::radians(_param_mpc_yawrauto_max.get()));
 
 	// need a valid position and velocity
 	ret = ret && PX4_ISFINITE(_position(0))
@@ -196,6 +198,9 @@ bool FlightTaskOrbit::update()
 		generate_circle_yaw_setpoints(center_to_position);
 	}
 
+	// Apply yaw smoothing
+	_yaw_setpoint = _slew_rate_yaw.update(_yaw_setpoint, _deltatime);
+
 	// publish information to UI
 	sendTelemetry();
 
@@ -204,15 +209,17 @@ bool FlightTaskOrbit::update()
 
 void FlightTaskOrbit::generate_circle_approach_setpoints(const Vector2f &center_to_position)
 {
+	const Vector2f start_to_circle = (_r - center_to_position.norm()) * center_to_position.unit_or_zero();
+
 	if (_circle_approach_line.isEndReached()) {
 		// calculate target point on circle and plan a line trajectory
-		const Vector2f start_to_circle = (_r - center_to_position.norm()) * center_to_position.unit_or_zero();
 		const Vector2f closest_circle_point = Vector2f(_position) + start_to_circle;
 		const Vector3f target = Vector3f(closest_circle_point(0), closest_circle_point(1), _position(2));
 		_circle_approach_line.setLineFromTo(_position, target);
 		_circle_approach_line.setSpeed(_param_mpc_xy_cruise.get());
-		_yaw_setpoint = atan2f(start_to_circle(1), start_to_circle(0));
 	}
+
+	_yaw_setpoint = atan2f(start_to_circle(1), start_to_circle(0));
 
 	// follow the planned line and switch to orbiting once the circle is reached
 	_circle_approach_line.generateSetpoints(_position_setpoint, _velocity_setpoint);

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -250,7 +250,7 @@ void FlightTaskOrbit::generate_circle_yaw_setpoints(const Vector2f &center_to_po
 		break;
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TANGENT_TO_CIRCLE:
-		_yaw_setpoint = wrap_pi(atan2f(center_to_position(1), center_to_position(0)) + (sign(_v) * M_PI_F / 2.f));
+		_yaw_setpoint = atan2f(sign(_v) * center_to_position(0), -sign(_v) * center_to_position(1));
 		_yawspeed_setpoint = _v / _r;
 		break;
 
@@ -260,7 +260,7 @@ void FlightTaskOrbit::generate_circle_yaw_setpoints(const Vector2f &center_to_po
 
 	case orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER:
 	default:
-		_yaw_setpoint = wrap_pi(atan2f(center_to_position(1), center_to_position(0)) + M_PI_F);
+		_yaw_setpoint = atan2f(-center_to_position(1), -center_to_position(0));
 		// yawspeed feed-forward because we know the necessary angular rate
 		_yawspeed_setpoint = _v / _r;
 		break;

--- a/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/lib/flight_tasks/tasks/Orbit/FlightTaskOrbit.hpp
@@ -45,6 +45,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/topics/orbit_status.h>
 #include <StraightLine.hpp>
+#include <SlewRateYaw.hpp>
 
 class FlightTaskOrbit : public FlightTaskManualAltitudeSmoothVel
 {
@@ -111,10 +112,12 @@ private:
 	/** yaw behaviour during the orbit flight according to MAVLink's ORBIT_YAW_BEHAVIOUR enum */
 	int _yaw_behaviour = orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER;
 	float _initial_heading = 0.f; /**< the heading of the drone when the orbit command was issued */
+	SlewRateYaw<float> _slew_rate_yaw;
 
 	uORB::Publication<orbit_status_s> _orbit_status_pub{ORB_ID(orbit_status)};
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise /**< cruise speed for circle approach */
+		(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise, /**< cruise speed for circle approach */
+		(ParamFloat<px4::params::MPC_YAWRAUTO_MAX>) _param_mpc_yawrauto_max
 	)
 };

--- a/src/lib/slew_rate/CMakeLists.txt
+++ b/src/lib/slew_rate/CMakeLists.txt
@@ -42,3 +42,4 @@ target_include_directories(SlewRate
 target_link_libraries(SlewRate PUBLIC mathlib)
 
 px4_add_unit_gtest(SRC SlewRateTest.cpp LINKLIBS SlewRate)
+px4_add_unit_gtest(SRC SlewRateYawTest.cpp LINKLIBS SlewRate)

--- a/src/lib/slew_rate/SlewRateYaw.hpp
+++ b/src/lib/slew_rate/SlewRateYaw.hpp
@@ -32,54 +32,33 @@
  ****************************************************************************/
 
 /**
- * @file SlewRate.hpp
+ * @file SlewRateYaw.hpp
  *
- * Library limit the rate of change of a value with a maximum slew rate.
+ * Library limit the rate of change of a [-pi,pi] range yaw value with a maximum slew rate.
  *
  * @author Matthias Grob <maetugr@gmail.com>
  */
 
 #pragma once
 
-#include <mathlib/mathlib.h>
-#include <matrix/math.hpp>
+#include "SlewRate.hpp"
 
 template<typename Type>
-class SlewRate
+class SlewRateYaw : public SlewRate<Type>
 {
 public:
-	SlewRate() = default;
-	~SlewRate() = default;
+	SlewRateYaw() = default;
+	~SlewRateYaw() = default;
 
 	/**
-	 * Set maximum rate of change for the value
-	 * @param slew_rate maximum rate of change
-	 */
-	void setSlewRate(const Type slew_rate) { _slew_rate = slew_rate; }
-
-	/**
-	 * Set value ignoring slew rate for initialization purpose
-	 * @param value new applied value
-	 */
-	void setForcedValue(const Type value) { _value = value; }
-
-	/**
-	 * Update slewrate
+	 * Update slewrate with yaw wrapping [-pi,pi]
 	 * @param new_value desired new value
 	 * @param deltatime time in seconds since last update
 	 * @return actual value that complies with the slew rate
 	 */
 	Type update(const Type new_value, const float deltatime)
 	{
-		// Limit the rate of change of the value
-		const Type dvalue_desired = new_value - _value;
-		const Type dvalue_max = _slew_rate * deltatime;
-		const Type dvalue = math::constrain(dvalue_desired, -dvalue_max, dvalue_max);
-		_value += dvalue;
-		return _value;
+		const Type d_wrapped = matrix::wrap_pi(new_value - this->_value);
+		return matrix::wrap_pi(SlewRate<Type>::update(this->_value + d_wrapped, deltatime));
 	}
-
-protected:
-	Type _slew_rate{}; ///< maximum rate of change for the value
-	Type _value{}; ///< state to keep last value of the slew rate
 };

--- a/src/lib/slew_rate/SlewRateYawTest.cpp
+++ b/src/lib/slew_rate/SlewRateYawTest.cpp
@@ -1,0 +1,122 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <SlewRateYaw.hpp>
+
+TEST(SlewRateYawTest, SlewUpLimited)
+{
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(.15f);
+	_slew_rate_yaw.setForcedValue(1.1f);
+
+	for (int i = 1; i <= 10; i++) {
+		EXPECT_FLOAT_EQ(_slew_rate_yaw.update(3.f, 1.f), 1.1f + i * .15f);
+	}
+}
+
+TEST(SlewRateYawTest, SlewDownLimited)
+{
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(.1f);
+	_slew_rate_yaw.setForcedValue(.5f);
+
+	for (int i = 1; i <= 10; i++) {
+		EXPECT_NEAR(_slew_rate_yaw.update(-2.f, 1.f), .5f - i * .1f, 1e-7f);
+	}
+}
+
+TEST(SlewRateYawTest, ReachValueSlewed)
+{
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(.2f);
+	_slew_rate_yaw.setForcedValue(1.f);
+
+	for (int i = 1; i <= 10; i++) {
+		EXPECT_FLOAT_EQ(_slew_rate_yaw.update(3.f, 1.f), 1.f + i * .2f);
+	}
+
+	for (int i = 1; i <= 10; i++) {
+		EXPECT_FLOAT_EQ(_slew_rate_yaw.update(3.f, 1.f), 3.f);
+	}
+}
+
+TEST(SlewRateYawTest, SlewUpWrappedOutput)
+{
+	// put the goal value always a bit further away such that at some point the output has to wrap
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(.2f);
+	_slew_rate_yaw.setForcedValue(0.f);
+
+	for (int i = 1; i <= 30; i++) {
+		EXPECT_NEAR(_slew_rate_yaw.update(i * .25f, 1.f), matrix::wrap_pi(i * .2f), 1e-5f);
+	}
+}
+
+TEST(SlewRateYawTest, SlewDownWrappedOutput)
+{
+	// put the goal value always a bit further away such that at some point the output has to wrap
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(.2f);
+	_slew_rate_yaw.setForcedValue(0.f);
+
+	for (int i = 1; i <= 50; i++) {
+		EXPECT_NEAR(_slew_rate_yaw.update(i * -.25f, 1.f), matrix::wrap_pi(i * -.2f), 1e-5f);
+	}
+}
+
+TEST(SlewRateYawTest, SlewUpWrappedInput)
+{
+	// put the goal value always a bit further away such that at some point the output has to wrap
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(.2f);
+	_slew_rate_yaw.setForcedValue(0.f);
+
+	for (int i = 1; i <= 50; i++) {
+		EXPECT_NEAR(_slew_rate_yaw.update(matrix::wrap_pi(i * .25f), 1.f), matrix::wrap_pi(i * .2f), 1e-5f);
+	}
+}
+
+TEST(SlewRateYawTest, SlewShortWayInput)
+{
+	SlewRateYaw<float> _slew_rate_yaw;
+	_slew_rate_yaw.setSlewRate(1.f);
+	_slew_rate_yaw.setForcedValue(0.f);
+
+	EXPECT_FLOAT_EQ(_slew_rate_yaw.update(3.f, 1.f), 1.f);
+	EXPECT_FLOAT_EQ(_slew_rate_yaw.update(5.f, 1.f), 0.f);
+	EXPECT_FLOAT_EQ(_slew_rate_yaw.update(5.f, 1.f), -1.f);
+	EXPECT_FLOAT_EQ(_slew_rate_yaw.update(4.f, 1.f), -2.f);
+	EXPECT_FLOAT_EQ(_slew_rate_yaw.update(3.f, 1.f), -3.f);
+	EXPECT_FLOAT_EQ(_slew_rate_yaw.update(5.f, 1.f), -2.f);
+}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -616,8 +616,8 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			// is not possible and therefore the internal_state needs to be adjusted.
 			internal_state->main_state = commander_state_s::MAIN_STATE_POSCTL;
 
-		} else if (rc_lost && !data_link_loss_act_configured && is_armed) {
-			// failsafe: RC is lost, datalink loss is not set up and rc loss is not disabled
+		} else if (rc_lost && status->data_link_lost && !data_link_loss_act_configured && is_armed) {
+			// Orbit does not depend on RC but while armed & all links lost & when datalink loss is not set up, we failsafe
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
 
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act);


### PR DESCRIPTION
**Describe problem solved by this pull request**
- The yaw setpoint during orbit approaches by previous design makes steps.
- Found during pr testing: Orbit not usable without RC


**Describe your solution**
- Put slew rate calculation for yaw used in mission into a library `SlewRateYaw`
It uses the existing `SlewRate` library but extends with correct handling of shortest turn deliberation and pi wrapping from https://github.com/PX4/PX4-Autopilot/pull/11920
- Allow Orbit without RC in commander only data link loss triggers failsafe
- Simplify circling yaws setpoint calculations based on my new knowledge.
- Use `SlewRateYaw` in Orbit to smooth out the absolute yaw setpoints

**Describe possible alternatives**
I did not use `SlewRateYaw` in missions yet because there's slightly more dependencies. I'll do that as a follow up to keep this pr lean.

**Test data / coverage**
- Added unit tests for the normal slew rate and wrapping cases of `SlewRateYaw`
- Successfully tested Orbit with SITL jmavsim without RC (data link loss still works), yaw to center and tangential yaw, smoothing, clockwise, counter clockwise, vehicle position in commended circle and outside

Typical yaw setpoint steps before:
![image](https://user-images.githubusercontent.com/4668506/102360294-1e4ca480-3fb2-11eb-84ea-52f664507acb.png)

Typical yaw ramps after:
![image](https://user-images.githubusercontent.com/4668506/102360481-5a800500-3fb2-11eb-92ef-384635c3597e.png)