### PR TITLE
Hover thrust estimator improvements

### DIFF
--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -164,7 +164,10 @@ void MulticopterHoverThrustEstimator::Run()
 			if (PX4_ISFINITE(local_pos_sp.thrust[2])) {
 				// Inform the hover thrust estimator about the measured vertical
 				// acceleration (positive acceleration is up) and the current thrust (positive thrust is up)
-				_hover_thrust_ekf.fuseAccZ(-local_pos.az, -local_pos_sp.thrust[2]);
+				// Guard against fast up and down motions biasing the estimator due to large drag and prop wash effects
+				if (fabsf(local_pos.vz) < 2.f) {
+					_hover_thrust_ekf.fuseAccZ(-local_pos.az, -local_pos_sp.thrust[2]);
+				}
 
 				const bool valid = (_hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f)
 						   && (_hover_thrust_ekf.getInnovationTestRatio() < 1.f);

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -117,10 +117,13 @@ void MulticopterHoverThrustEstimator::Run()
 	if (_vehicle_local_position_sub.copy(&local_pos)) {
 		// This is only necessary because the landed
 		// flag of the land detector does not guarantee that
-		// the vehicle does not touch the ground anymore
+		// the vehicle does not touch the ground anymore.
+		// There is no check for the dist_bottom validity as
+		// this value is always good enough after takeoff for
+		// this use case.
 		// TODO: improve the landed flag
-		if (local_pos.dist_bottom_valid) {
-			if (!_landed && (local_pos.dist_bottom > 1.f)) {
+		if (!_landed) {
+			if (local_pos.dist_bottom > 1.f) {
 				_in_air = true;
 			}
 		}

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -59,7 +59,7 @@ MulticopterHoverThrustEstimator::~MulticopterHoverThrustEstimator()
 
 bool MulticopterHoverThrustEstimator::init()
 {
-	if (!_vehicle_local_position_setpoint_sub.registerCallback()) {
+	if (!_vehicle_local_position_sub.registerCallback()) {
 		PX4_ERR("vehicle_local_position_setpoint callback registration failed!");
 		return false;
 	}
@@ -91,13 +91,43 @@ void MulticopterHoverThrustEstimator::updateParams()
 void MulticopterHoverThrustEstimator::Run()
 {
 	if (should_exit()) {
-		_vehicle_local_position_setpoint_sub.unregisterCallback();
+		_vehicle_local_position_sub.unregisterCallback();
 		exit_and_cleanup();
 		return;
 	}
 
-	// new local position estimate and setpoint needed every iteration
-	if (!_vehicle_local_pos_sub.updated() || !_vehicle_local_position_setpoint_sub.updated()) {
+	if (_vehicle_land_detected_sub.updated()) {
+		vehicle_land_detected_s vehicle_land_detected;
+
+		if (_vehicle_land_detected_sub.copy(&vehicle_land_detected)) {
+			_landed = vehicle_land_detected.landed;
+
+			if (_landed) {
+				_in_air = false;
+			}
+		}
+	}
+
+	if (!_vehicle_local_position_sub.updated()) {
+		return;
+	}
+
+	vehicle_local_position_s local_pos{};
+
+	if (_vehicle_local_position_sub.copy(&local_pos)) {
+		// This is only necessary because the landed
+		// flag of the land detector does not guarantee that
+		// the vehicle does not touch the ground anymore
+		// TODO: improve the landed flag
+		if (local_pos.dist_bottom_valid) {
+			if (!_landed && (local_pos.dist_bottom > 1.f)) {
+				_in_air = true;
+			}
+		}
+	}
+
+	// new local position setpoint needed every iteration
+	if (!_vehicle_local_position_setpoint_sub.updated()) {
 		return;
 	}
 
@@ -113,14 +143,6 @@ void MulticopterHoverThrustEstimator::Run()
 
 	perf_begin(_cycle_perf);
 
-	if (_vehicle_land_detected_sub.updated()) {
-		vehicle_land_detected_s vehicle_land_detected;
-
-		if (_vehicle_land_detected_sub.copy(&vehicle_land_detected)) {
-			_landed = vehicle_land_detected.landed;
-		}
-	}
-
 	if (_vehicle_status_sub.updated()) {
 		vehicle_status_s vehicle_status;
 
@@ -129,36 +151,23 @@ void MulticopterHoverThrustEstimator::Run()
 		}
 	}
 
-	// always copy latest position estimate
-	vehicle_local_position_s local_pos{};
-
-	if (_vehicle_local_pos_sub.copy(&local_pos)) {
-		// This is only necessary because the landed
-		// flag of the land detector does not guarantee that
-		// the vehicle does not touch the ground anymore
-		// TODO: improve the landed flag
-		if (local_pos.dist_bottom_valid) {
-			_in_air = local_pos.dist_bottom > 1.f;
-		}
-	}
-
 	const float dt = (local_pos.timestamp - _timestamp_last) * 1e-6f;
 	_timestamp_last = local_pos.timestamp;
 
-	if (_armed && !_landed && (dt > 0.001f) && (dt < 1.f) && PX4_ISFINITE(local_pos.az)) {
+	if (_armed && _in_air && (dt > 0.001f) && (dt < 1.f) && PX4_ISFINITE(local_pos.az)) {
 
 		_hover_thrust_ekf.predict(dt);
 
 		vehicle_local_position_setpoint_s local_pos_sp;
 
-		if (_vehicle_local_position_setpoint_sub.update(&local_pos_sp)) {
+		if (_vehicle_local_position_setpoint_sub.copy(&local_pos_sp)) {
 			if (PX4_ISFINITE(local_pos_sp.thrust[2])) {
 				// Inform the hover thrust estimator about the measured vertical
 				// acceleration (positive acceleration is up) and the current thrust (positive thrust is up)
-				ZeroOrderHoverThrustEkf::status status;
+				ZeroOrderHoverThrustEkf::status status{};
 				_hover_thrust_ekf.fuseAccZ(-local_pos.az, -local_pos_sp.thrust[2], status);
 
-				const bool valid = _in_air && (status.hover_thrust_var < 0.001f) && (status.innov_test_ratio < 1.f);
+				const bool valid = (status.hover_thrust_var < 0.001f) && (status.innov_test_ratio < 1.f);
 				_valid_hysteresis.set_state_and_update(valid, local_pos.timestamp);
 				_valid = _valid_hysteresis.get_state();
 

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -196,7 +196,7 @@ void MulticopterHoverThrustEstimator::Run()
 void MulticopterHoverThrustEstimator::publishStatus(const hrt_abstime &timestamp_sample,
 		const ZeroOrderHoverThrustEkf::status &status)
 {
-	hover_thrust_estimate_s status_msg;
+	hover_thrust_estimate_s status_msg{};
 
 	status_msg.timestamp_sample = timestamp_sample;
 

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.hpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.hpp
@@ -88,7 +88,7 @@ private:
 
 	void reset();
 
-	void publishStatus(const hrt_abstime &timestamp_sample, const ZeroOrderHoverThrustEkf::status &status);
+	void publishStatus(const hrt_abstime &timestamp_sample);
 	void publishInvalidStatus();
 
 	ZeroOrderHoverThrustEkf _hover_thrust_ekf{};

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.hpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.hpp
@@ -95,12 +95,12 @@ private:
 
 	uORB::Publication<hover_thrust_estimate_s> _hover_thrust_ekf_pub{ORB_ID(hover_thrust_estimate)};
 
-	uORB::SubscriptionCallbackWorkItem _vehicle_local_position_setpoint_sub{this, ORB_ID(vehicle_local_position_setpoint)};
+	uORB::SubscriptionCallbackWorkItem _vehicle_local_position_sub{this, ORB_ID(vehicle_local_position)};
 
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
-	uORB::Subscription _vehicle_local_pos_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	hrt_abstime _timestamp_last{0};
 

--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
@@ -70,22 +70,13 @@
 class ZeroOrderHoverThrustEkf
 {
 public:
-	struct status {
-		float hover_thrust;
-		float hover_thrust_var;
-		float innov;
-		float innov_var;
-		float innov_test_ratio;
-		float accel_noise_var;
-	};
-
 	ZeroOrderHoverThrustEkf() = default;
 	~ZeroOrderHoverThrustEkf() = default;
 
 	void resetAccelNoise() { _acc_var = 5.f; };
 
-	void predict(float dt);
-	void fuseAccZ(float acc_z, float thrust, status &status_return);
+	void predict(float _dt);
+	void fuseAccZ(float acc_z, float thrust);
 
 	void setHoverThrust(float hover_thrust) { _hover_thr = math::constrain(hover_thrust, 0.1f, 0.9f); }
 	void setProcessNoiseStdDev(float process_noise) { _process_var = process_noise * process_noise; }
@@ -95,6 +86,9 @@ public:
 
 	float getHoverThrustEstimate() const { return _hover_thr; }
 	float getHoverThrustEstimateVar() const { return _state_var; }
+	float getInnovation() const { return _innov; }
+	float getInnovationVar() const { return _innov_var; }
+	float getInnovationTestRatio() const { return _innov_test_ratio; }
 	float getAccelNoiseVar() const { return _acc_var; }
 
 private:
@@ -105,6 +99,10 @@ private:
 	float _process_var{12.5e-6f}; ///< Hover thrust process noise variance (thrust^2/s^2)
 	float _acc_var{5.f}; ///< Acceleration variance (m^2/s^3)
 	float _dt{0.02f};
+
+	float _innov{0.f}; ///< Measurement innovation (m/s^2)
+	float _innov_var{0.f}; ///< Measurement innovation variance (m^2/s^3)
+	float _innov_test_ratio{0.f}; ///< Noramlized Innovation Squared test ratio
 
 	float _residual_lpf{}; ///< used to remove the constant bias of the residual
 	float _signed_innov_test_ratio_lpf{}; ///< used as a delay to trigger the recovery logic
@@ -130,8 +128,6 @@ private:
 	void bumpStateVariance();
 	void updateLpf(float residual, float signed_innov_test_ratio);
 	void updateMeasurementNoise(float residual, float H);
-
-	status packStatus(float innov, float innov_var, float innov_test_ratio) const;
 
 	static constexpr float _noise_learning_time_constant = 2.f; ///< in seconds
 	static constexpr float _lpf_time_constant = 1.f; ///< in seconds


### PR DESCRIPTION
requires #16401 

**Describe problem solved by this pull request**
The hover thrust estimator (HTE) starts at arming and learns an initial biased value because the vehicle is still touching ground.
It recovers after takeoff but this takes quite some time.
![DeepinScreenshot_select-area_20201216153308](https://user-images.githubusercontent.com/14822839/102362089-43421700-3fb4-11eb-81be-8894792bcf6d.png)


**Describe your solution**
1. Only start to run once truly in air:
Starting the estimator before takeoff makes it converge to a wrong initial value; once the variance is low, it takes then some time to recover after takeoff. The `_landed` flag only is not enough to tell if the drone is still touching ground or not. An additional check based on the altitude AGL is required.

2. Schedule on `vehicle_local_position` instead of `vehicle_position_setpoint`:
To have this in_air detection correctly updated, the module needs to be scheduled on the vehicle_local_position message as no setpoint is produced in non-assisted modes. Also, on vehicles without range finders, the `dist_bottom_valid` goes to `false` a few seconds after takeoff; it is then important to monitor this value even when not running the estimator as it mandatory to be able to start the estimator later on.

3. Set innovation/innov var, innov test ratios as member variables
This makes the logging part more independent from the measurement update; logging can continue even if the fusion is inhibited

4. Inhibit acceleration fusion during fast up/down motions
Drag and prop wash effects produce significant forces at high speed that can bias the estimator when applied for an extended period of time.

**Test data / coverage**
SITL test:
![DeepinScreenshot_select-area_20201216153233](https://user-images.githubusercontent.com/14822839/102362212-68368a00-3fb4-11eb-93ba-d513af173622.png)
