### PR TITLE
RC loss Failsafe Delay

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -63,6 +63,7 @@ uint64 nav_state_timestamp              # time when current nav_state activated
 uint8 arming_state			# current arming state
 uint8 hil_state				# current hil state
 bool failsafe				# true if system is in failsafe state (e.g.:RTL, Hover, Terminate, ...)
+uint64 failsafe_timestamp               # time when failsafe was activated
 
 uint8 system_type			# system type, contains mavlink MAV_TYPE
 uint8 system_id			# system id, contains MAVLink's system ID field

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2545,7 +2545,8 @@ Commander::run()
 						       (link_loss_actions_t)_param_nav_rcl_act.get(),
 						       (offboard_loss_actions_t)_param_com_obl_act.get(),
 						       (offboard_loss_rc_actions_t)_param_com_obl_rc_act.get(),
-						       (position_nav_loss_actions_t)_param_com_posctl_navl.get());
+						       (position_nav_loss_actions_t)_param_com_posctl_navl.get(),
+						       _param_com_ll_delay.get());
 
 		if (nav_state_changed) {
 			_status.nav_state_timestamp = hrt_absolute_time();

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2546,7 +2546,7 @@ Commander::run()
 						       (offboard_loss_actions_t)_param_com_obl_act.get(),
 						       (offboard_loss_rc_actions_t)_param_com_obl_rc_act.get(),
 						       (position_nav_loss_actions_t)_param_com_posctl_navl.get(),
-						       _param_com_ll_delay.get());
+						       _param_com_rcl_act_t.get());
 
 		if (nav_state_changed) {
 			_status.nav_state_timestamp = hrt_absolute_time();

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -189,6 +189,7 @@ private:
 
 		(ParamInt<px4::params::NAV_DLL_ACT>) _param_nav_dll_act,
 		(ParamInt<px4::params::COM_DL_LOSS_T>) _param_com_dl_loss_t,
+		(ParamFloat<px4::params::COM_LL_DELAY>) _param_com_ll_delay,
 
 		(ParamInt<px4::params::COM_HLDL_LOSS_T>) _param_com_hldl_loss_t,
 		(ParamInt<px4::params::COM_HLDL_REG_T>) _param_com_hldl_reg_t,

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -189,13 +189,13 @@ private:
 
 		(ParamInt<px4::params::NAV_DLL_ACT>) _param_nav_dll_act,
 		(ParamInt<px4::params::COM_DL_LOSS_T>) _param_com_dl_loss_t,
-		(ParamFloat<px4::params::COM_LL_DELAY>) _param_com_ll_delay,
 
 		(ParamInt<px4::params::COM_HLDL_LOSS_T>) _param_com_hldl_loss_t,
 		(ParamInt<px4::params::COM_HLDL_REG_T>) _param_com_hldl_reg_t,
 
 		(ParamInt<px4::params::NAV_RCL_ACT>) _param_nav_rcl_act,
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
+		(ParamFloat<px4::params::COM_RCL_ACT_T>) _param_com_rcl_act_t,
 
 		(ParamFloat<px4::params::COM_HOME_H_T>) _param_com_home_h_t,
 		(ParamFloat<px4::params::COM_HOME_V_T>) _param_com_home_v_t,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -970,7 +970,7 @@ PARAM_DEFINE_FLOAT(COM_LKDOWN_TKO, 3.0f);
 PARAM_DEFINE_INT32(COM_ARM_ARSP_EN, 1);
 
 /**
- * Delay between link loss and configured reaction in Position and Mission mode
+ * Delay between RC loss and configured reaction
  *
  * A non-zero, positive value makes the failsafe reaction first stop the vehicle and wait
  * before proceeding with the configured failsafe reaction NAV_RCL_ACT.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -968,3 +968,18 @@ PARAM_DEFINE_FLOAT(COM_LKDOWN_TKO, 3.0f);
 * @value 1 Enabled
 */
 PARAM_DEFINE_INT32(COM_ARM_ARSP_EN, 1);
+
+/**
+ * Delay between link loss and configured reaction in Position and Mission mode
+ *
+ * A non-zero, positive value makes the failsafe reaction first stop the vehicle and wait
+ * before proceeding with the configured failsafe reaction NAV_RCL_ACT.
+ * A zero or negative value disables the delay.
+ *
+ * @group Commander
+ * @unit s
+ * @min -1.0
+ * @max 60.0
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(COM_LL_DELAY, 15.0f);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -174,7 +174,7 @@ PARAM_DEFINE_FLOAT(COM_EF_TIME, 10.0f);
 /**
  * RC loss time threshold
  *
- * After this amount of seconds without RC connection the rc lost flag is set to true
+ * After this amount of seconds without RC connection it's considered lost and not used anymore
  *
  * @group Commander
  * @unit s
@@ -184,6 +184,23 @@ PARAM_DEFINE_FLOAT(COM_EF_TIME, 10.0f);
  * @increment 0.1
  */
 PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
+
+/**
+ * Delay between RC loss and configured reaction
+ *
+ * RC signal not updated -> still use data for COM_RC_LOSS_T seconds
+ * Consider RC signal lost -> wait COM_RCL_ACT_T seconds on the spot waiting to regain signal
+ * React with failsafe action NAV_RCL_ACT
+ *
+ * A zero value disables the delay.
+ *
+ * @group Commander
+ * @unit s
+ * @min 0.0
+ * @max 25.0
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(COM_RCL_ACT_T, 15.0f);
 
 /**
  * Home set horizontal threshold
@@ -968,18 +985,3 @@ PARAM_DEFINE_FLOAT(COM_LKDOWN_TKO, 3.0f);
 * @value 1 Enabled
 */
 PARAM_DEFINE_INT32(COM_ARM_ARSP_EN, 1);
-
-/**
- * Delay between RC loss and configured reaction
- *
- * A non-zero, positive value makes the failsafe reaction first stop the vehicle and wait
- * before proceeding with the configured failsafe reaction NAV_RCL_ACT.
- * A zero or negative value disables the delay.
- *
- * @group Commander
- * @unit s
- * @min -1.0
- * @max 25.0
- * @decimal 3
- */
-PARAM_DEFINE_FLOAT(COM_LL_DELAY, 15.0f);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -979,7 +979,7 @@ PARAM_DEFINE_INT32(COM_ARM_ARSP_EN, 1);
  * @group Commander
  * @unit s
  * @min -1.0
- * @max 60.0
+ * @max 25.0
  * @decimal 3
  */
 PARAM_DEFINE_FLOAT(COM_LL_DELAY, 15.0f);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -389,8 +389,9 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 void enable_failsafe(vehicle_status_s *status, bool old_failsafe, orb_advert_t *mavlink_log_pub, const char *reason)
 {
 	if (!old_failsafe && status->arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
-		// make sure intermittent failsafes don't lead to infinite delay by not constatnly reseting the timestamp
-		if (hrt_elapsed_time(&status->failsafe_timestamp) > 30_s) {
+		// make sure intermittent failsafes don't lead to infinite delay by not constantly reseting the timestamp
+		if (status->failsafe_timestamp == 0 ||
+		    hrt_elapsed_time(&status->failsafe_timestamp) > 30_s) {
 			status->failsafe_timestamp = hrt_absolute_time();
 		}
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -409,7 +409,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
-		   const float param_com_ll_delay)
+		   const float param_com_rcl_act_t)
 {
 	const navigation_state_t nav_state_old = status->nav_state;
 
@@ -438,7 +438,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 		if (rc_lost && is_armed) {
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
 
-			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_ll_delay);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_rcl_act_t);
 
 		} else {
 			switch (internal_state->main_state) {
@@ -474,7 +474,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 
 			if (rc_lost && is_armed) {
 				enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
-				set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_ll_delay);
+				set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_rcl_act_t);
 
 				/* As long as there is RC, we can fallback to ALTCTL, or STAB. */
 				/* A local position estimate is enough for POSCTL for multirotors,

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -131,7 +131,8 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
-		   const position_nav_loss_actions_t posctl_nav_loss_act);
+		   const position_nav_loss_actions_t posctl_nav_loss_act,
+		   const float param_com_ll_delay);
 
 /*
  * Checks the validty of position data against the requirements of the current navigation

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -132,7 +132,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
-		   const float param_com_ll_delay);
+		   const float param_com_rcl_act_t);
 
 /*
  * Checks the validty of position data against the requirements of the current navigation


### PR DESCRIPTION
**Describe problem solved by this pull request**
I repetedly see the requirement to have a delay between losing the rc link and triggering the failsafe reaction. The rc loss timeout should not be increased for that because the vehicle will consider the last known stick position and might fly away or into an obstacle not knowing that there's no pilot commanding that. So there has to be an in between state where the vehicle just waits if the link is regained and if so continues as before.

The most simple example use case is flying to the border of RC reception where the signal starts to drop out intermittently. The vehicle immediately switches to RTL and starts to turn 180° even though the pilot might have just not oriented the antenna correctly and would like to continue with the original intent whenever possible.

**Describe your solution**
With this pr the vehicle upon rc link loss by default will wait 15 seconds (`COM_LL_DELAY`) in hold mode `nav_state` but with the original `main_state` for the signal to come back. If the signal is regained the mode/operation continues like before the loss. If the signal is not regained then the originally instant loss reaction is triggered to e.g. change the main state to RTL.

Note: The case where the signal drops in and out continuously is handled by not reseting the link loss timer until 30 seconds after the first loss. This ensures that the vehicle does not get stuck because the delay continues over and over again.

**Test data / coverage**
This was extensively tested both in simulation and with a real vehicle at the border of the link reception range.

**Additional context**
In the following Slack thread @mortenfyhn asked for exactly this feature independently of my development:
https://px4.slack.com/archives/C3B9NSHRQ/p1607501257121200
I suggest he gives this pr a try.
