### PR TITLE
Tools: Python >3.7 requires the wheel packge

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -11,6 +11,7 @@ pandas>=0.21
 pkgconfig
 psutil
 pygments
+wheel>=0.31.1
 pymavlink
 pyros-genmsg
 pyserial>=3.0
@@ -20,4 +21,3 @@ requests
 setuptools>=39.2.0
 six>=1.12.0
 toml>=0.9
-wheel>=0.31.1


### PR DESCRIPTION
currently installing `pymavlink` without the wheel package results in an error when using Python 3.7 or later

https://github.com/ArduPilot/pymavlink/issues/486