### PR TITLE
mavlink: ALTITUDE stream initialize local_pos

### DIFF
--- a/src/modules/mavlink/streams/ALTITUDE.hpp
+++ b/src/modules/mavlink/streams/ALTITUDE.hpp
@@ -84,7 +84,7 @@ private:
 
 		bool lpos_updated = false;
 
-		vehicle_local_position_s local_pos;
+		vehicle_local_position_s local_pos{};
 
 		if (_local_pos_sub.copy(&local_pos)) {
 


### PR DESCRIPTION
The local position timestamp is checked later on and this makes valgrind happy.