### PR TITLE
Online estimation of battery internal resistance

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rc.replay
+++ b/ROMFS/px4fmu_common/init.d-posix/rc.replay
@@ -26,5 +26,9 @@ param set SDLOG_PROFILE 3
 # apply all params before ekf starts, as some params cannot be changed after startup
 replay tryapplyparams
 ekf2 start -r
+#if param greater -s RIN_ENABLED 0
+#then
+	battery_resistance_est start
+#fi
 logger start -f -t -b 1000 -p vehicle_attitude
 replay start

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -279,6 +279,11 @@ then
 fi
 microdds_client start -t udp -p 8888 $microdds_ns
 
+if param greater -s RIN_ENABLED 0
+then
+	battery_resistance_est start
+fi
+
 if param greater -s MNT_MODE_IN -1
 then
 	gimbal start

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -528,6 +528,10 @@ else
 		fi
 	fi
 
+	if param greater -s RIN_ENABLED 0
+	then
+		battery_resistance_est start
+	fi
 #
 # End of autostart.
 #

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -106,6 +106,7 @@ set(msg_files
 	HomePosition.msg
 	HoverThrustEstimate.msg
 	InputRc.msg
+	internal_resistance.msg
 	InternalCombustionEngineStatus.msg
 	IridiumsbdStatus.msg
 	IrlockReport.msg

--- a/msg/internal_resistance.msg
+++ b/msg/internal_resistance.msg
@@ -1,0 +1,14 @@
+uint64 timestamp
+
+float32 r_t
+float32 r_s
+float32 v_oc
+float32 r_internal_est
+float32 best_r_internal_est
+
+float32 voltage_filtered_v
+float32 voltage_estimation
+float32 voltage_estimation_error
+
+float32[4] param_est
+float32[4] signal

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -90,6 +90,8 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 	snprintf(param_name, sizeof(param_name), "BAT%d_SOURCE", _index);
 	_param_handles.source = param_find(param_name);
 
+	_param_handles.r_in_enabled = param_find("RIN_ENABLED");
+
 	_param_handles.low_thr = param_find("BAT_LOW_THR");
 	_param_handles.crit_thr = param_find("BAT_CRIT_THR");
 	_param_handles.emergen_thr = param_find("BAT_EMERGEN_THR");
@@ -208,22 +210,44 @@ float Battery::calculateStateOfChargeVoltageBased(const float voltage_v, const f
 	// remaining battery capacity based on voltage
 	float cell_voltage = voltage_v / _params.n_cells;
 
-	// correct battery voltage locally for load drop to avoid estimation fluctuations
-	if (_params.r_internal >= 0.f && current_a > FLT_EPSILON) {
-		cell_voltage += _params.r_internal * current_a;
+	if (_params.r_in_enabled == 1) {
 
-	} else {
-		actuator_controls_s actuator_controls{};
-		_actuator_controls_0_sub.copy(&actuator_controls);
-		const float throttle = actuator_controls.control[actuator_controls_s::INDEX_THROTTLE];
-		_throttle_filter.update(throttle);
-
-		if (!_battery_initialized) {
-			_throttle_filter.reset(throttle);
+		if (_internal_resistance_sub.updated()) {
+			_internal_resistance_sub.copy(&_inter_res);
 		}
 
-		// assume linear relation between throttle and voltage drop
-		cell_voltage += throttle * _params.v_load_drop;
+		if (_inter_res.best_r_internal_est >= 0.f) {
+			cell_voltage += _inter_res.best_r_internal_est * current_a;
+
+		} else {
+			actuator_controls_s actuator_controls{};
+			_actuator_controls_0_sub.copy(&actuator_controls);
+			const float throttle = actuator_controls.control[actuator_controls_s::INDEX_THROTTLE];
+			_throttle_filter.update(throttle);
+			// used when initial value of _inter_res.best_r_internal_est is zero or undefined
+			cell_voltage += throttle * _params.v_load_drop;
+		}
+
+	} else {
+
+		// correct battery voltage locally for load drop to avoid estimation fluctuations
+		if (_params.r_internal >= 0.f && current_a > FLT_EPSILON) {
+			cell_voltage += _params.r_internal * current_a;
+
+		} else {
+			actuator_controls_s actuator_controls{};
+			_actuator_controls_0_sub.copy(&actuator_controls);
+			const float throttle = actuator_controls.control[actuator_controls_s::INDEX_THROTTLE];
+			_throttle_filter.update(throttle);
+
+			if (!_battery_initialized) {
+				_throttle_filter.reset(throttle);
+			}
+
+			// assume linear relation between throttle and voltage drop
+			cell_voltage += throttle * _params.v_load_drop;
+		}
+
 	}
 
 	return math::interpolate(cell_voltage, _params.v_empty, _params.v_charged, 0.f, 1.f);
@@ -322,6 +346,7 @@ void Battery::updateParams()
 	param_get(_param_handles.v_load_drop, &_params.v_load_drop);
 	param_get(_param_handles.r_internal, &_params.r_internal);
 	param_get(_param_handles.source, &_params.source);
+	param_get(_param_handles.r_in_enabled, &_params.r_in_enabled);
 	param_get(_param_handles.low_thr, &_params.low_thr);
 	param_get(_param_handles.crit_thr, &_params.crit_thr);
 	param_get(_param_handles.emergen_thr, &_params.emergen_thr);

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -42,6 +42,9 @@
 
 #pragma once
 
+#include <uORB/uORB.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/internal_resistance.h>
 #include <math.h>
 #include <float.h>
 
@@ -119,6 +122,7 @@ protected:
 		param_t capacity;
 		param_t v_load_drop;
 		param_t r_internal;
+		param_t r_in_enabled;
 		param_t low_thr;
 		param_t crit_thr;
 		param_t emergen_thr;
@@ -133,6 +137,7 @@ protected:
 		float capacity;
 		float v_load_drop;
 		float r_internal;
+		int r_in_enabled;
 		float low_thr;
 		float crit_thr;
 		float emergen_thr;
@@ -162,6 +167,10 @@ private:
 	bool _connected{false};
 	const uint8_t _source;
 	uint8_t _priority{0};
+	uORB::Subscription _internal_resistance_sub{ORB_ID(internal_resistance)};
+
+	internal_resistance_s _inter_res;
+
 	bool _battery_initialized{false};
 	float _voltage_v{0.f};
 	AlphaFilter<float> _voltage_filter_v;

--- a/src/lib/battery/battery_params_common.c
+++ b/src/lib/battery/battery_params_common.c
@@ -55,6 +55,18 @@
 PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
 
 /**
+ * Battery internal resistance online estimator
+ *
+ * Enables battery_resistance_est module. Set 0 to disable.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ * @max 1
+ */
+PARAM_DEFINE_INT32(RIN_ENABLED, 0);
+
+/**
  * Critical threshold
  *
  * Sets the threshold when the battery will be reported as critically low.

--- a/src/modules/battery_resistance_est/CMakeLists.txt
+++ b/src/modules/battery_resistance_est/CMakeLists.txt
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#############################################################################
+
+px4_add_module(
+	MODULE modules__battery_resistance_est
+	MAIN battery_resistance_est
+	COMPILE_FLAGS
+	SRCS
+		battery_resistance_est.cpp
+	DEPENDS
+		modules__uORB
+		px4_work_queue
+	)

--- a/src/modules/battery_resistance_est/battery_resistance_est.cpp
+++ b/src/modules/battery_resistance_est/battery_resistance_est.cpp
@@ -1,0 +1,277 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "battery_resistance_est.hpp"
+
+InternalRes::InternalRes() :
+	ModuleParams(nullptr),
+	WorkItem(MODULE_NAME, px4::wq_configurations::lp_default)
+{
+}
+
+bool InternalRes::init()
+{
+	if (!_battery_sub.registerCallback()) {
+		PX4_ERR("battery status callback registration failed!");
+		return false;
+	}
+
+	_param_est(0) = _param_r_s_init.get();
+	_param_est(1) = (_param_r_t_init.get() + _param_r_s_init.get()) / (_param_r_t_init.get() * _param_c_t_init.get());
+	_param_est(2) = 1.0f / (_param_r_t_init.get() * _param_c_t_init.get());
+	_param_est(3) = (_param_v_oc_init.get() * _param_bat1_n_cells.get()) / (_param_r_t_init.get() * _param_c_t_init.get());
+
+	_voltage_estimation = _param_v_est_init.get() * _param_bat1_n_cells.get();
+
+	_adaptation_gain.setAll(_param_param_gain.get());
+
+	_inter_res.best_r_internal_est = _param_inter_res_init.get();
+
+	return true;
+}
+
+Vector<float, 4> InternalRes::extract_ecm_parameters()
+{
+
+	Vector<float, 4> ecm_params;
+
+	ecm_params(0) = _param_est(0); //_r_steady_state
+	ecm_params(1) = (_param_est(1) / _param_est(2)) - _param_est(0); //_r_transient
+	ecm_params(2) = _param_est(3) / _param_est(2); //_voltage_open_circuit
+
+	//calculate bat1_r_internal
+	ecm_params(3) = (ecm_params(2) - _voltage_filtered_v) / (_current_filtered_a); //_internal_resistance_est
+
+	//logging
+	_inter_res.r_s = ecm_params(0);
+	_inter_res.r_t = ecm_params(1);
+	_inter_res.v_oc = ecm_params(2);
+	_inter_res.r_internal_est = ecm_params(3) / _param_bat1_n_cells.get();
+
+	return ecm_params;
+}
+
+
+void InternalRes::update_internal_resistance(const float voltage_estimation_error,
+		const Vector<float, 4> &esm_params_est)
+{
+
+	//store best esimate
+	if ((fabs(voltage_estimation_error)) <= fabs(_best_prediction_error)) {
+		_best_ecm_params_est = esm_params_est;
+		_best_prediction_error = voltage_estimation_error;
+
+	} else if (_best_prediction_error_reset) {
+		_best_ecm_params_est = esm_params_est;
+		_best_prediction_error = voltage_estimation_error;
+		_best_prediction_error_reset = false;
+	}
+
+	//clamp BAT1_R_INTERNAL
+	if (_best_ecm_params_est(3) > (_param_inter_res_est_max.get() *_param_bat1_n_cells.get())) {
+		_best_ecm_params_est(3) = _param_inter_res_est_max.get() * _param_bat1_n_cells.get();
+
+	} else if (_best_ecm_params_est(3) < (_param_inter_res_est_min.get() *_param_bat1_n_cells.get())) {
+		_best_ecm_params_est(3) = _param_inter_res_est_min.get() * _param_bat1_n_cells.get();
+	}
+
+	const float time_since_param_update = (hrt_absolute_time() - _last_param_update_time) / 1e6f;
+
+	// publish new bat1_r_internal only periodically
+	if (time_since_param_update >= _param_inter_res_update_period.get()) {
+		_inter_res.best_r_internal_est = _best_ecm_params_est(3) / _param_bat1_n_cells.get();
+		_last_param_update_time = hrt_absolute_time();
+		_best_prediction_error_reset = true;
+	}
+}
+
+float InternalRes::predict_voltage(const float dt)
+{
+
+	//process _signal
+	_signal(0) = -(_battery_status.current_filtered_a - _current_filtered_a_prev)
+		     / ((_battery_status.timestamp - _battery_time_prev) / 1e6f); //central difference method
+	_signal(1) = -_current_filtered_a;
+	_signal(2) = -_voltage_estimation;
+	_signal(3) = 1.f;
+
+	// Predict the voltage using the learned adaptive model
+	_voltage_estimation += (_param_est.transpose() * _signal * dt)(0, 0);
+
+	const float voltage_estimation_error = _voltage_filtered_v - _voltage_estimation;
+
+	_voltage_estimation += _lambda * dt * voltage_estimation_error;
+
+	//logging
+	_inter_res.voltage_estimation = _voltage_estimation;
+	_inter_res.voltage_estimation_error = fabs(voltage_estimation_error);
+
+	_param_est.copyTo(_inter_res.param_est);
+
+	_signal.copyTo(_inter_res.signal);
+
+	return voltage_estimation_error;
+}
+
+void InternalRes::Run()
+{
+
+	if (should_exit()) {
+		_battery_sub.unregisterCallback();
+		exit_and_cleanup();
+		return;
+	}
+
+	if (_vehicle_status_sub.update(&_vehicle_status)) {
+		_armed = (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+		_on_standby = (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY);
+	}
+
+
+	if (_battery_sub.update(&_battery_status)
+	    && _armed) {
+
+		if (_battery_time_prev != 0 && _battery_time != _battery_time_prev) {
+
+			const float dt = (_battery_time - _battery_time_prev) / 1e6f;
+
+			const float voltage_estimation_error = predict_voltage(dt);
+
+			const Vector<float, 4> ecm_params_est = extract_ecm_parameters();
+
+			update_internal_resistance(voltage_estimation_error, ecm_params_est);
+
+			//update the vector of parameters using the adaptive law
+			for (int i = 0; i < 4; i++) {
+				_param_est(i) += _adaptation_gain(i) * voltage_estimation_error * _signal(i) * dt;
+			}
+
+			//logging for debugging
+			_inter_res.timestamp = hrt_absolute_time();
+			_inter_res.voltage_filtered_v = _voltage_filtered_v; //for sync with ekfreplay
+			_internal_res_pub.publish(_inter_res);
+
+			_was_armed = true;
+
+		}
+
+		//save for central difference approximation of current derivative
+		_battery_time_prev = _battery_time;
+		_battery_time = _battery_status.timestamp;
+		_current_filtered_a_prev = _current_filtered_a;
+		_current_filtered_a = _battery_status.current_filtered_a;
+		_voltage_filtered_v = _battery_status.voltage_filtered_v;
+	}
+
+	//save ecm params on disarm after flight
+	if (!_param_bat_saved && _on_standby && _was_armed) {
+
+		_param_r_s_init.set(_best_ecm_params_est(0));
+		_param_r_s_init.commit_no_notification();
+
+		_param_r_t_init.set(_best_ecm_params_est(1));
+		_param_r_t_init.commit_no_notification();
+
+		_param_v_oc_init.set(_best_ecm_params_est(2) / _param_bat1_n_cells.get());
+		_param_v_oc_init.commit_no_notification();
+
+		_param_bat1_r_internal.set(round((_best_ecm_params_est(3) / _param_bat1_n_cells.get()) * 100) / 100);
+		_param_bat1_r_internal.commit_no_notification();
+
+		_param_inter_res_init.set(round((_best_ecm_params_est(3) / _param_bat1_n_cells.get()) * 1000) / 1000);
+		_param_inter_res_init.commit_no_notification();
+
+		_param_bat_saved = true;
+	}
+
+}
+
+int InternalRes::task_spawn(int argc, char *argv[])
+{
+	InternalRes *instance = new InternalRes();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int InternalRes::print_status()
+{
+	PX4_INFO("Running");
+	return 0;
+}
+
+int InternalRes::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int InternalRes::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+module uses current and voltage data​ to online estimate the
+battery internal resistance. Based on 'Online estimation of internal resistance and open-circuit voltage of lithium-ion
+batteries in electric vehicles' Yi-Hsien Chiang , Wu-Yang Sean, Jia-Cheng Ke
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("battery_resistance_est", "system");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int battery_resistance_est_main(int argc, char *argv[])
+{
+	return InternalRes::main(argc, argv);
+}

--- a/src/modules/battery_resistance_est/battery_resistance_est.hpp
+++ b/src/modules/battery_resistance_est/battery_resistance_est.hpp
@@ -1,0 +1,141 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAfieldES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAfieldE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file BatteryResistanceEstimator.hpp
+ *
+ * Estimator for the battery internal resistance parameter to run online using only the current and voltage data​.
+ *
+ * @author Mohamad Akkawi	<akkawi@protonmail.com>
+ *
+ * Implementation based on 'Online estimation of internal resistance and open-circuit voltage of lithium-ion
+ * batteries in electric vehicles' by Yi-Hsien Chiang , Wu-Yang Sean, Jia-Cheng Ke
+ *
+ */
+
+#pragma once
+
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+
+#include <uORB/topics/battery_status.h>
+#include <uORB/topics/internal_resistance.h>
+
+#include <matrix/math.hpp>
+
+#include <uORB/topics/vehicle_status.h>
+
+using namespace matrix;
+
+class InternalRes : public ModuleBase<InternalRes>, public ModuleParams, public px4::WorkItem
+{
+public:
+	InternalRes();
+	~InternalRes() {};
+
+	static int task_spawn(int argc, char *argv[]);
+
+	static int custom_command(int argc, char *argv[]);
+
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+	int print_status() override;
+
+	void update_internal_resistance(const float voltage_estimation_error, const Vector<float, 4> &esm_params_est);
+
+	Vector<float, 4> extract_ecm_parameters();
+
+	float predict_voltage(const float dt);
+
+private:
+	void Run() override;
+
+	internal_resistance_s _inter_res;
+	battery_status_s _battery_status;
+	vehicle_status_s _vehicle_status;
+
+	hrt_abstime _battery_time_prev{0};
+	hrt_abstime _battery_time{0};
+
+	hrt_abstime _last_param_update_time{0};
+
+	Vector<float, 4> _param_est;
+	Vector<float, 4> _adaptation_gain;
+	Vector<float, 4> _signal;
+	Vector<float, 4> _best_ecm_params_est;
+
+	float _lambda{0.8f};
+	float _voltage_estimation{0.f};
+
+	float _current_filtered_a{0.f};
+	float _voltage_filtered_v{0.f};
+	float _current_filtered_a_prev{0.f};
+
+	float _best_prediction_error{0.f};
+	bool _best_prediction_error_reset{true};
+
+//used to save estimated ecm params on disarm
+	bool _armed{false};
+	bool _was_armed{false};
+	bool _on_standby{false};
+	bool _param_bat_saved{false};
+
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+
+	uORB::SubscriptionCallbackWorkItem _battery_sub{this, ORB_ID(battery_status)};
+
+	uORB::Publication<internal_resistance_s> _internal_res_pub{ORB_ID(internal_resistance)};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::BAT1_R_INTERNAL>) _param_bat1_r_internal,
+		(ParamFloat<px4::params::BAT1_V_CHARGED>) _param_bat1_v_charged,
+		(ParamInt<px4::params::BAT1_N_CELLS>) _param_bat1_n_cells,
+		(ParamFloat<px4::params::BAT_VOC_INIT>) _param_v_oc_init,
+		(ParamFloat<px4::params::BAT_R_S_INIT>) _param_r_s_init,
+		(ParamFloat<px4::params::BAT_R_T_INIT>) _param_r_t_init,
+		(ParamFloat<px4::params::BAT_C_T_INIT>) _param_c_t_init,
+		(ParamFloat<px4::params::BAT_RIN_UPDATE>) _param_inter_res_update_period,
+		(ParamFloat<px4::params::BAT_RIN_EST_MAX>) _param_inter_res_est_max,
+		(ParamFloat<px4::params::BAT_RIN_EST_MIN>) _param_inter_res_est_min,
+		(ParamFloat<px4::params::BAT_RIN_EST_INIT>) _param_inter_res_init,
+		(ParamFloat<px4::params::BAT_PARAM_GAIN>) _param_param_gain,
+		(ParamFloat<px4::params::BAT_V_EST_INIT>) _param_v_est_init
+	)
+};

--- a/src/modules/battery_resistance_est/battery_resistance_est_params.c
+++ b/src/modules/battery_resistance_est/battery_resistance_est_params.c
@@ -1,0 +1,140 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Battery internal resistance online estimator
+ *
+ * Update period of BAT1_R_INTERNAL.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ * @unit s
+ */
+PARAM_DEFINE_FLOAT(BAT_RIN_UPDATE, 5.f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Initial per cell estimate of voltage open circuit in battery equivalent circuit model.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ * @unit V
+ */
+PARAM_DEFINE_FLOAT(BAT_VOC_INIT, 4.2f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Initial estimate of series ohmic resistor in battery (all cells) equivalent circuit model.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ * @unit Ohm
+ */
+PARAM_DEFINE_FLOAT(BAT_R_S_INIT, 0.1f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Initial estimate of ohmic resistor in RC network of battery (all cells) equivalent circuit model.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ * @unit Ohm
+ */
+PARAM_DEFINE_FLOAT(BAT_R_T_INIT, 0.05f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Initial estimate of capacitance (in farad, F) in RC network of battery (all cells) equivalent circuit model.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ */
+PARAM_DEFINE_FLOAT(BAT_C_T_INIT, 500.0f);
+
+/**
+ * Battery internal resistance online estimator
+ *
+ * Max of per cell estimation clamp
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @unit Ohm
+ */
+PARAM_DEFINE_FLOAT(BAT_RIN_EST_MAX, 1.0f);
+
+/**
+ * Battery internal resistance online estimator
+ *
+ * Min of per cell estimation clamp
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @unit Ohm
+ */
+PARAM_DEFINE_FLOAT(BAT_RIN_EST_MIN, 0.001f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Initial per cell estimate of battery internal resistance.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @unit Ohm
+ */
+PARAM_DEFINE_FLOAT(BAT_RIN_EST_INIT, 0.01f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Adaptation gain to update parameter vector of equivalent circuit model
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @unit Ohm
+ */
+PARAM_DEFINE_FLOAT(BAT_PARAM_GAIN, 0.001f);
+/**
+ * Battery internal resistance online estimator
+ *
+ * Initial per cell estimate of voltage load in battery equivalent circuit model.
+ *
+ * @group Battery Calibration
+ * @reboot_required true
+ * @min 0
+ * @unit V
+ */
+PARAM_DEFINE_FLOAT(BAT_V_EST_INIT, 4.05f);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -85,6 +85,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("launch_detection_status", 200);
 	add_optional_topic("magnetometer_bias_estimate", 200);
+	add_topic("internal_resistance", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
 	add_topic("mission_result");
@@ -340,6 +341,7 @@ void LoggedTopics::add_estimator_replay_topics()
 	add_topic("vehicle_status");
 	add_topic("vehicle_visual_odometry");
 	add_topic_multi("distance_sensor");
+	add_topic_multi("battery_status", 0, 2);
 }
 
 void LoggedTopics::add_thermal_calibration_topics()

--- a/src/modules/replay/ReplayEkf2.cpp
+++ b/src/modules/replay/ReplayEkf2.cpp
@@ -51,6 +51,7 @@
 #include <uORB/topics/vehicle_optical_flow.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_odometry.h>
+#include <uORB/topics/battery_status.h>
 
 #include "ReplayEkf2.hpp"
 
@@ -74,7 +75,7 @@ ReplayEkf2::handleTopicUpdate(Subscription &sub, void *data, std::ifstream &repl
 		return true;
 
 	} else if (sub.orb_meta == ORB_ID(vehicle_status) || sub.orb_meta == ORB_ID(vehicle_land_detected)
-		   || sub.orb_meta == ORB_ID(vehicle_gps_position)) {
+		   || sub.orb_meta == ORB_ID(vehicle_gps_position) || sub.orb_meta == ORB_ID(battery_status)) {
 		return publishTopic(sub, data);
 	} // else: do not publish
 
@@ -104,13 +105,15 @@ ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 
 	} else if (sub.orb_meta == ORB_ID(vehicle_visual_odometry)) {
 		_vehicle_visual_odometry_msg_id = msg_id;
+
 	}
 
 	// the main loop should only handle publication of the following topics, the sensor topics are
 	// handled separately in publishEkf2Topics()
 	// Note: the GPS is not treated here since not missing data is more important than the accuracy of the timestamp
 	sub.ignored = sub.orb_meta != ORB_ID(ekf2_timestamps) && sub.orb_meta != ORB_ID(vehicle_status)
-		      && sub.orb_meta != ORB_ID(vehicle_land_detected) && sub.orb_meta != ORB_ID(vehicle_gps_position);
+		      && sub.orb_meta != ORB_ID(vehicle_land_detected) && sub.orb_meta != ORB_ID(vehicle_gps_position)
+		      && sub.orb_meta != ORB_ID(battery_status);
 }
 
 bool


### PR DESCRIPTION
**Describe problem solved by this pull request**
Internal resistance of the battery is variable with age, temperature
and level of discharge.

**Describe your solution**
Method uses filtered voltage and current only and is based on the following paper:
[chiang2011.pdf](https://github.com/PX4/PX4-Autopilot/files/5731127/chiang2011.pdf)
Writes to BAT1_R_INTERNAL after disarming.

**Test data / coverage**
Tested on V.1.11.0 and this log https://logs.px4.io/plot_app?log=a7586dcb-6a71-4829-b797-793475b8887c
replay of log c361f511e74717abfd0b2e1c2dd0500dd06263b2
https://review.px4.io/plot_app?log=4e3b5623-91fd-439a-980c-34e227f9d98d
replay of log ff9ec7d64587f7a02aeb3f08ad87066e56395e9b
https://review.px4.io/plot_app?log=6379367c-bfd8-4532-86d9-8cc731982fc2

**Additional context**
Tested using ekf2 replay mode. ​https://github.com/PX4/PX4-Autopilot/issues/16307 
