### PR TITLE
MAVLink FTP: Update implementation according to updates specs

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -215,7 +215,7 @@ MavlinkFTP::_process_request(
 		break;
 
 	case kCmdCreateFile:
-		errorCode = _workOpen(payload, O_CREAT | O_EXCL | O_WRONLY);
+		errorCode = _workOpen(payload, O_CREAT | O_TRUNC | O_WRONLY);
 		break;
 
 	case kCmdOpenFileWO:


### PR DESCRIPTION
The MAVLink specs for CreateFile in MAVLink FTP were updated on Dec 23, 2020 (today) with a behavior change to truncate a file if it already existed, following the UNIX standard behavior: https://pubs.opengroup.org/onlinepubs/9699919799/functions/creat.html. This change is tracking that spec change. While it is a functional change, the limited usage of the FTP protocol and the fact that implementations should not rely on error states to determine wether to truncate a file or not makes this a viable change.