### PR TITLE
Standard VTOL: set idle PWM for MC during backtransition

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -309,6 +309,11 @@ void Standard::update_transition_state()
 		if (_motor_state != motor_state::ENABLED) {
 			_motor_state = set_motor_state(_motor_state, motor_state::ENABLED);
 		}
+
+		// set idle speed for MC actuators
+		if (!_flag_idle_mc) {
+			_flag_idle_mc = set_idle_mc();
+		}
 	}
 
 	mc_weight = math::constrain(mc_weight, 0.0f, 1.0f);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -232,8 +232,8 @@ void Tailsitter::update_transition_state()
 
 		const float trans_pitch_rate = M_PI_2_F / _params->back_trans_duration;
 
-		if (!flag_idle_mc) {
-			flag_idle_mc = set_idle_mc();
+		if (!_flag_idle_mc) {
+			_flag_idle_mc = set_idle_mc();
 		}
 
 		if (tilt > 0.01f) {

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -351,8 +351,8 @@ void Tiltrotor::update_transition_state()
 
 
 		// set idle speed for rotary wing mode
-		if (!flag_idle_mc) {
-			flag_idle_mc = set_idle_mc();
+		if (!_flag_idle_mc) {
+			_flag_idle_mc = set_idle_mc();
 		}
 
 		// tilt rotors back

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -123,8 +123,8 @@ bool VtolType::init()
 
 void VtolType::update_mc_state()
 {
-	if (!flag_idle_mc) {
-		flag_idle_mc = set_idle_mc();
+	if (!_flag_idle_mc) {
+		_flag_idle_mc = set_idle_mc();
 	}
 
 	if (_motor_state != motor_state::ENABLED) {
@@ -142,8 +142,8 @@ void VtolType::update_mc_state()
 
 void VtolType::update_fw_state()
 {
-	if (flag_idle_mc) {
-		flag_idle_mc = !set_idle_fw();
+	if (_flag_idle_mc) {
+		_flag_idle_mc = !set_idle_fw();
 	}
 
 	if (_motor_state != motor_state::DISABLED) {

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -214,7 +214,7 @@ protected:
 
 	struct Params 					*_params;
 
-	bool flag_idle_mc = false;		//false = "idle is set for fixed wing mode"; true = "idle is set for multicopter mode"
+	bool _flag_idle_mc = false;		//false = "idle is set for fixed wing mode"; true = "idle is set for multicopter mode"
 
 	bool _pusher_active = false;
 	float _mc_roll_weight = 1.0f;	// weight for multicopter attitude controller roll output


### PR DESCRIPTION
**Describe problem solved by this pull request**
MC actuators are at disarmed value instead of idle value when back-transition of a standard VTOL is started. 

It is set correctly for tiltrotors.

**Describe your solution**
Sets the PWM for the MC actuators to idle during back-transition, such that they are always spinning.

**Test data / coverage**
SITL tested.

**Additional context**
![image](https://user-images.githubusercontent.com/26798987/103013527-96c8dd80-453d-11eb-9e76-d1bf261dfcf6.png)

