### PR TITLE
remove rotation 41 (ROLL_270_YAW_180)

### DIFF
--- a/src/lib/conversion/RotationTest.cpp
+++ b/src/lib/conversion/RotationTest.cpp
@@ -97,12 +97,6 @@ TEST(Rotations, duplicates)
 				if (j == ROTATION_ROLL_180_YAW_90 && i == ROTATION_PITCH_180_YAW_270) { continue; }
 
 
-				// ROTATION_ROLL_90_PITCH_180 (31) = ROTATION_ROLL_270_YAW_180 (41)
-				if (i == ROTATION_ROLL_90_PITCH_180 && j == ROTATION_ROLL_270_YAW_180) { continue; }
-
-				if (j == ROTATION_ROLL_90_PITCH_180 && i == ROTATION_ROLL_270_YAW_180) { continue; }
-
-
 				// otherwise all rotations should be different
 				ASSERT_GT((transformed_1 - transformed_2).norm(), 0) << "Rotation " << i << " and " << j << " equal";
 			}

--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -284,10 +284,7 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			return;
 		}
 
-	case ROTATION_ROLL_90_PITCH_180:
-
-	// FALLTHROUGH
-	case ROTATION_ROLL_270_YAW_180: {
+	case ROTATION_ROLL_90_PITCH_180: {
 			tmp = y;
 			x = -x;
 			y = -z;

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -90,18 +90,17 @@ enum Rotation {
 	ROTATION_ROLL_90_PITCH_68_YAW_293 = 38,
 	ROTATION_PITCH_315           = 39,
 	ROTATION_ROLL_90_PITCH_315   = 40,
-	ROTATION_ROLL_270_YAW_180    = 41,
 
 	ROTATION_MAX
 };
 
-typedef struct {
+struct rot_lookup_t {
 	uint16_t roll;
 	uint16_t pitch;
 	uint16_t yaw;
-} rot_lookup_t;
+};
 
-const rot_lookup_t rot_lookup[] = {
+static constexpr rot_lookup_t rot_lookup[ROTATION_MAX] = {
 	{  0,   0,   0 },
 	{  0,   0,  45 },
 	{  0,   0,  90 },
@@ -143,7 +142,6 @@ const rot_lookup_t rot_lookup[] = {
 	{ 90,  68, 293 },
 	{  0, 315,   0 },
 	{ 90, 315,   0 },
-	{270,   0, 180 },
 };
 
 /**

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -737,9 +737,6 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 							// FALLTHROUGH
 							case ROTATION_PITCH_180_YAW_270: // skip 27, same as 10 ROTATION_ROLL_180_YAW_90
-
-							// FALLTHROUGH
-							case ROTATION_ROLL_270_YAW_180:  // skip 41, same as 31 ROTATION_ROLL_90_PITCH_180
 								MSE[r] = FLT_MAX;
 								break;
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -222,9 +222,8 @@ static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293 == static_cast<MAV_SE
 static_assert(MAV_SENSOR_ROTATION_PITCH_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_315), "Pitch: 315");
 static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_PITCH_315),
 	      "Roll: 90, Pitch: 315");
-static_assert(MAV_SENSOR_ROTATION_ROLL_270_YAW_180 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_270_YAW_180),
-	      "Roll: 270, Yaw: 180");
-static_assert(42 == ROTATION_MAX, "Keep MAV_SENSOR_ROTATION and PX4 Rotation in sync");
+
+static_assert(41 == ROTATION_MAX, "Keep MAV_SENSOR_ROTATION and PX4 Rotation in sync");
 
 static uint16_t cm_uint16_from_m_float(float m)
 {

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -146,10 +146,9 @@ PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @group Sensors
  */

--- a/src/modules/sensors/sensor_params_acc0.c
+++ b/src/modules/sensors/sensor_params_acc0.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_ACC0_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_acc1.c
+++ b/src/modules/sensors/sensor_params_acc1.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_ACC1_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_acc2.c
+++ b/src/modules/sensors/sensor_params_acc2.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_ACC2_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_acc3.c
+++ b/src/modules/sensors/sensor_params_acc3.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_ACC3_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_gyro0.c
+++ b/src/modules/sensors/sensor_params_gyro0.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_GYRO0_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_gyro1.c
+++ b/src/modules/sensors/sensor_params_gyro1.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_GYRO1_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_gyro2.c
+++ b/src/modules/sensors/sensor_params_gyro2.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_GYRO2_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_gyro3.c
+++ b/src/modules/sensors/sensor_params_gyro3.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_GYRO3_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag0.c
+++ b/src/modules/sensors/sensor_params_mag0.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_MAG0_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag1.c
+++ b/src/modules/sensors/sensor_params_mag1.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_MAG1_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag2.c
+++ b/src/modules/sensors/sensor_params_mag2.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_MAG2_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_mag3.c
+++ b/src/modules/sensors/sensor_params_mag3.c
@@ -104,10 +104,9 @@ PARAM_DEFINE_INT32(CAL_MAG3_PRIO, -1);
  * @value 38 Roll 90°, Pitch 68°, Yaw 293°
  * @value 39 Pitch 315°
  * @value 40 Roll 90°, Pitch 315°
- * @value 41 Roll 270°, Yaw 180°
  *
  * @min -1
- * @max 41
+ * @max 40
  * @reboot_required true
  * @category system
  * @group Sensor Calibration


### PR DESCRIPTION
 - duplicate of 31 (ROLL_90_PITCH_180)
 - removed in https://github.com/mavlink/mavlink/pull/1540

This was only added to PX4 earlier this year (https://github.com/PX4/PX4-Autopilot/pull/14512). Unless anyone objects I'm not going to bother handling the parameter migration because it will only complicate further additions.
