### PR TITLE
format smart battery serial number as string on mavlink

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -21,7 +21,7 @@ uint16 cycle_count			# number of discharge cycles the battery has experienced
 uint16 run_time_to_empty	# predicted remaining battery capacity based on the present rate of discharge in min
 uint16 average_time_to_empty	# predicted remaining battery capacity based on the average rate of discharge in min
 uint16 serial_number		# serial number of the battery pack
-uint16 manufacture_date		# manufacture date, part of serial number of the battery pack
+uint16 manufacture_date		# manufacture date, part of serial number of the battery pack. formated as: Day + Month×32 + (Year–1980)×512
 uint16 state_of_health		# state of health. FullChargeCapacity/DesignCapacity.
 uint16 max_error			# max error, expected margin of error in % in the state-of-charge calculation with a range of 1 to 100%
 uint8 id					# ID number of a battery. Should be unique and consistent for the lifetime of a vehicle. 1-indexed.

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -830,7 +830,19 @@ protected:
 				msg.capacity_full_specification = battery_status.capacity;
 				msg.capacity_full = (int32_t)((float)(battery_status.state_of_health * battery_status.capacity) / 100.f);
 				msg.cycle_count = battery_status.cycle_count;
-				msg.serial_number = battery_status.serial_number + (battery_status.manufacture_date << 16);
+
+				if (battery_status.manufacture_date) {
+					uint16_t day = battery_status.manufacture_date % 32;
+					uint16_t month = (battery_status.manufacture_date >> 5) % 16;
+					uint16_t year = (80 + (battery_status.manufacture_date >> 9)) % 100;
+
+					//Formatted as 'dd/mm/yy-123456' (maxed 15 + 1 chars)
+					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d/%d/%d-%d", day, month, year, battery_status.serial_number);
+
+				} else {
+					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d", battery_status.serial_number);
+				}
+
 				//msg.device_name = ??
 				msg.weight = -1;
 				msg.discharge_minimum_voltage = -1;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Mavlink message SMART_BATTERY_INFO changed the serial_number field from uint to string. so this change fixes that.

**Describe your solution**
set the serial number with this format: 'dd/mm/yy-123456'