### PR TITLE
Pr fmuv 2 exclude unsupported

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/10015_tbs_discovery
+++ b/ROMFS/px4fmu_common/init.d/airframes/10015_tbs_discovery
@@ -19,6 +19,7 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10016_3dr_iris
+++ b/ROMFS/px4fmu_common/init.d/airframes/10016_3dr_iris
@@ -17,6 +17,7 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10017_steadidrone_qu4d
+++ b/ROMFS/px4fmu_common/init.d/airframes/10017_steadidrone_qu4d
@@ -19,6 +19,7 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10018_tbs_endurance
+++ b/ROMFS/px4fmu_common/init.d/airframes/10018_tbs_endurance
@@ -19,6 +19,7 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -7,6 +7,10 @@
 #
 # @maintainer Roman Bapst <roman@auterion.com>
 #
+# @board px4_fmu-v2 exclude
+# @board intel_aerofc-v1 exclude
+# @board bitcraze_crazyflie exclude
+#
 
 . ${R}etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/12002_steadidrone_mavrik
+++ b/ROMFS/px4fmu_common/init.d/airframes/12002_steadidrone_mavrik
@@ -16,6 +16,7 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
+++ b/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
@@ -17,6 +17,10 @@
 # @output AUX4 Rudder
 # @output AUX5 Throttle
 #
+# @board px4_fmu-v2 exclude
+# @board intel_aerofc-v1 exclude
+# @board bitcraze_crazyflie exclude
+#
 
 . ${R}etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -12,6 +12,10 @@
 #
 # @maintainer Roman Bapst <roman@px4.io>
 #
+# @board px4_fmu-v2 exclude
+# @board intel_aerofc-v1 exclude
+# @board bitcraze_crazyflie exclude
+#
 
 . ${R}etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
@@ -7,6 +7,10 @@
 #
 # @maintainer Roman Bapst <roman@px4.io>
 #
+# @board px4_fmu-v2 exclude
+# @board intel_aerofc-v1 exclude
+# @board bitcraze_crazyflie exclude
+#
 
 . ${R}etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -17,6 +17,7 @@
 # @output AUX4 Rudder
 # @output AUX5 Throttle
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -15,6 +15,7 @@
 # @output AUX2 Left elevon
 # @output AUX3 Motor
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -7,6 +7,7 @@
 #
 # @maintainer Sander Smeets <sander@droneslab.com>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -7,6 +7,7 @@
 #
 # @maintainer Sander Smeets <sander@droneslab.com>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -7,6 +7,7 @@
 #
 # @maintainer Andreas Antener <andreas@uaventure.com>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -16,6 +16,7 @@
 # @output MAIN7 Elevon right
 # @output MAIN8 Elevon left
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -16,6 +16,10 @@
 # @output MAIN7 Pusher motor
 # @output MAIN8 Pusher reverse channel
 #
+# @board px4_fmu-v2 exclude
+# @board intel_aerofc-v1 exclude
+# @board bitcraze_crazyflie exclude
+#
 
 . ${R}etc/init.d/rc.vtol_defaults
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
@@ -12,6 +12,7 @@
 #
 # @maintainer Roman Bapst <roman@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3031_phantom
+++ b/ROMFS/px4fmu_common/init.d/airframes/3031_phantom
@@ -17,6 +17,7 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3032_skywalker_x5
+++ b/ROMFS/px4fmu_common/init.d/airframes/3032_skywalker_x5
@@ -15,6 +15,7 @@
 #
 # @maintainer Julian Oes <julian@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
@@ -17,6 +17,7 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3035_viper
+++ b/ROMFS/px4fmu_common/init.d/airframes/3035_viper
@@ -14,6 +14,7 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3036_pigeon
+++ b/ROMFS/px4fmu_common/init.d/airframes/3036_pigeon
@@ -17,6 +17,7 @@
 #
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
+# @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4014_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4014_s500
@@ -7,6 +7,7 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
@@ -7,6 +7,7 @@
 #
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
+# @board px4_fmu-v2 exclude
 # @board intel_aerofc-v1 exclude
 # @board bitcraze_crazyflie exclude
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -5,8 +5,6 @@
 # @type Rover
 # @class Rover
 #
-# @board px4_fmu-v2 exclude
-#
 # @output MAIN2 steering
 # @output MAIN4 throttle
 #


### PR DESCRIPTION
This PR is removing configurations that are not supported on V2 (like VTOL) and is trimming down fixed wing configurations. It is also adding a warning to v2 uploads that people really should be upgrading their bootloader and be using v3.

This is clawing back a whopping 22K of memory (2.2% of 1020169 bytes)

```
[482/485] Linking CXX executable px4_fmu-v2_default.elf
Memory region         Used Size  Region Size  %age Used
           flash:     1020169 B      1008 KB     98.84%
            sram:       25144 B       192 KB     12.79%
          ccsram:          0 GB        64 KB      0.00%
```