### PR TITLE
boards: px4/fmu-v5 disable px4io in rc.board_defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -272,57 +272,6 @@ else
 	fi
 
 	#
-	# Check if PX4IO present and update firmware if needed.
-	# Assumption IOFW set to firmware file and IO_PRESENT = no
-	#
-
-	if [ -f $IOFW ]
-	then
-		# Check for the mini using build with px4io fw file
-		# but not a px4IO
-		if ver hwtypecmp V540 V560
-		then
-			param set SYS_USE_IO 0
-		else
-			if px4io checkcrc ${IOFW}
-			then
-				set IO_PRESENT yes
-			else
-				# tune Program PX4IO
-				tune_control play -t 16 # tune 16 = PROG_PX4IO
-
-				if px4io start
-				then
-					# Try to safety px4 io so motor outputs don't go crazy.
-					if ! px4io safety_on
-					then
-						# px4io did not respond to the safety command.
-						px4io stop
-					fi
-				fi
-
-				if px4io forceupdate 14662 ${IOFW}
-				then
-					usleep 10000
-					tune_control stop
-					if px4io checkcrc ${IOFW}
-					then
-						echo "PX4IO CRC OK after updating"
-						tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
-						set IO_PRESENT yes
-					fi
-				fi
-
-				if [ $IO_PRESENT = no ]
-				then
-					echo "PX4IO update failed"
-					tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
-				fi
-			fi
-		fi
-	fi
-
-	#
 	# Set USE_IO flag.
 	#
 	if param compare -s SYS_USE_IO 1
@@ -330,10 +279,54 @@ else
 		set USE_IO yes
 	fi
 
-	if [ $USE_IO = yes -a $IO_PRESENT = no ]
+	#
+	# Check if PX4IO present and update firmware if needed.
+	# Assumption IOFW set to firmware file and IO_PRESENT = no
+	#
+
+	if [ -f $IOFW -a $USE_IO = yes ]
 	then
-		echo "PX4IO not found"
-		tune_control play error
+		if px4io checkcrc ${IOFW}
+		then
+			set IO_PRESENT yes
+		else
+			# tune Program PX4IO
+			tune_control play -t 16 # tune 16 = PROG_PX4IO
+
+			if px4io start
+			then
+				# Try to safety px4 io so motor outputs don't go crazy.
+				if ! px4io safety_on
+				then
+					# px4io did not respond to the safety command.
+					px4io stop
+				fi
+			fi
+
+			if px4io forceupdate 14662 ${IOFW}
+			then
+				usleep 10000
+				tune_control stop
+				if px4io checkcrc ${IOFW}
+				then
+					echo "PX4IO CRC OK after updating"
+					tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
+					set IO_PRESENT yes
+				fi
+			fi
+
+			if [ $IO_PRESENT = no ]
+			then
+				echo "PX4IO update failed"
+				tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
+			fi
+		fi
+
+		if [ $USE_IO = yes -a $IO_PRESENT = no ]
+		then
+			echo "PX4IO not found"
+			tune_control play error
+		fi
 	fi
 
 	#

--- a/boards/px4/fmu-v5/init/rc.board_defaults
+++ b/boards/px4/fmu-v5/init/rc.board_defaults
@@ -9,6 +9,12 @@ then
 
 fi
 
+# disable px4io on HolyBro mini (V540) and CUAV V5nano (V560)
+if ver hwtypecmp V540 V560
+then
+	param set SYS_USE_IO 0
+fi
+
 set LOGGER_BUF 64
 
 rgbled_pwm start


### PR DESCRIPTION
 - avoid keeping this kind of logic in the common rcS


**TODO:** Is the CUAV v5 Nano V560 or V600?

https://github.com/PX4/PX4-Autopilot/blob/adb98d57022dd515e0a2056341280200576deffb/ROMFS/px4fmu_common/init.d/rcS#L283

https://github.com/PX4/PX4-Autopilot/blob/adb98d57022dd515e0a2056341280200576deffb/boards/px4/fmu-v5/src/manifest.c#L157-L163