### PR TITLE
MAVSDK tests: Use full system timeout off

### DIFF
--- a/src/drivers/tone_alarm/ToneAlarm.cpp
+++ b/src/drivers/tone_alarm/ToneAlarm.cpp
@@ -134,19 +134,19 @@ void ToneAlarm::Run()
 						break;
 
 					case tune_control_s::TUNE_ID_NOTIFY_NEGATIVE:
-						PX4_ERR("notify negative");
+						PX4_INFO("notify negative");
 						break;
 
 					case tune_control_s::TUNE_ID_ARMING_WARNING:
-						PX4_WARN("arming warning");
+						PX4_INFO("arming warning");
 						break;
 
 					case tune_control_s::TUNE_ID_BATTERY_WARNING_SLOW:
-						PX4_WARN("battery warning (slow)");
+						PX4_INFO("battery warning (slow)");
 						break;
 
 					case tune_control_s::TUNE_ID_BATTERY_WARNING_FAST:
-						PX4_WARN("battery warning (fast)");
+						PX4_INFO("battery warning (fast)");
 						break;
 
 					case tune_control_s::TUNE_ID_ARMING_FAILURE:
@@ -154,7 +154,7 @@ void ToneAlarm::Run()
 						break;
 
 					case tune_control_s::TUNE_ID_SINGLE_BEEP:
-						PX4_WARN("beep");
+						PX4_INFO("beep");
 						break;
 
 					case tune_control_s::TUNE_ID_HOME_SET:

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -134,8 +134,10 @@ private:
 				// The reason not to include an absolute timeout here is that it can happen if the host is
 				// busy and PX4 doesn't run fast enough.
 				const int64_t elapsed_time_ms = _info->get_flight_information().second.time_boot_ms - start_time;
+
 				if (elapsed_time_ms > duration_ms.count()) {
-					std::cout << "Timeout, connected to vehicle but waiting for test for " << elapsed_time_ms / 1000.0 << " seconds" << std::endl;
+					std::cout << "Timeout, connected to vehicle but waiting for test for " << elapsed_time_ms / 1000.0 << " seconds" <<
+						  std::endl;
 					return false;
 				}
 			}
@@ -146,7 +148,9 @@ private:
 
 			while (!fun()) {
 				std::this_thread::sleep_for(duration_ms / 100);
-				const int64_t elapsed_time_us = std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - start_time).count();
+				const int64_t elapsed_time_us = std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() -
+								start_time).count();
+
 				if (elapsed_time_us > duration_ms.count() * 1000) {
 					std::cout << "Timeout, waiting for the vehicle for " << elapsed_time_us / 1000000.0 << " seconds" << std::endl;
 					return false;


### PR DESCRIPTION
Depending on loop iterations for timeouts is not accurate, as usleep behavior depends on the system load and asking for a 0 ms sleep can potentially return immediately.