### PR TITLE
logger: increase ulg format max length 1500 -> 1800 characters

### DIFF
--- a/src/modules/logger/messages.h
+++ b/src/modules/logger/messages.h
@@ -68,7 +68,7 @@ struct ulog_message_format_s {
 	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
 	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::FORMAT);
 
-	char format[1500];
+	char format[1800];
 };
 
 struct ulog_message_add_logged_s {


### PR DESCRIPTION
The new `estimator_status_flags` message added in https://github.com/PX4/PX4-Autopilot/pull/16383 is a bit too long for logger.

@bkueng Can we simply bump this limit? I don't see anything specified in https://dev.px4.io/master/en/log/ulog_file_format.html or pyulog.

``` Console
INFO  [logger] logger started (mode=all)
WARN  [logger] skip topic estimator_status_flags, format string is too large: 1787 (max is 1500)
WARN  [logger] skip topic estimator_status_flags, format string is too large: 1787 (max is 1500)
WARN  [logger] skip topic estimator_status_flags, format string is too large: 1787 (max is 1500)
WARN  [logger] skip topic estimator_status_flags, format string is too large: 1787 (max is 1500)
```