### PR TITLE
add esc_battery module to modalai/fc-v1 build

### DIFF
--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -57,6 +57,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		esc_battery
 		events
 		fw_att_control
 		fw_pos_control_l1


### PR DESCRIPTION
**problem solved by this pull request**
To get current and voltage readings from escs when no power module is included

**solution**
Add the new esc_battery module to the fc-v1 build

**Test data / coverage**
With the esc_battery module included in a custom build, my voxl-flight now reads out the voltage and current readings from the escs. This was done by using the daily build of QGC and selecting Source as ESCs
![image](https://user-images.githubusercontent.com/9113272/103309625-9324d300-49e3-11eb-92d6-acd7039ccaa5.png)

