### PR TITLE
Fixes #16467: Camera feedback: Indicate success

### DIFF
--- a/src/modules/camera_feedback/CameraFeedback.cpp
+++ b/src/modules/camera_feedback/CameraFeedback.cpp
@@ -105,15 +105,7 @@ CameraFeedback::Run()
 		capture.q[1] = att.q[1];
 		capture.q[2] = att.q[2];
 		capture.q[3] = att.q[3];
-
-		// Indicate whether capture feedback from camera is available
-		// What is case 0 for capture.result?
-		if (!_param_camera_capture_feedback.get()) {
-			capture.result = 0;
-
-		} else {
-			capture.result = 1;
-		}
+		capture.result = 1;
 
 		_capture_pub.publish(capture);
 	}

--- a/src/modules/camera_feedback/CameraFeedback.hpp
+++ b/src/modules/camera_feedback/CameraFeedback.hpp
@@ -83,9 +83,4 @@ private:
 	uORB::Subscription	_att_sub{ORB_ID(vehicle_attitude)};
 
 	uORB::Publication<camera_capture_s>	_capture_pub{ORB_ID(camera_capture)};
-
-	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::CAM_CAP_FBACK>) _param_camera_capture_feedback
-	)
-
 };


### PR DESCRIPTION
If the feedback module is loaded then we want to provide capture feedback.
