### PR TITLE
VTOL: Transition with zero roll

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2015-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -265,7 +265,8 @@ void Standard::update_transition_state()
 		// ramp up FW_PSP_OFF
 		_v_att_sp->pitch_body = _params_standard.pitch_setpoint_offset * (1.0f - mc_weight);
 
-		_v_att_sp->roll_body = _fw_virtual_att_sp->roll_body;
+		// keep the wings level during transition
+		_v_att_sp->roll_body = 0.0f;
 
 		const Quatf q_sp(Eulerf(_v_att_sp->roll_body, _v_att_sp->pitch_body, _v_att_sp->yaw_body));
 		q_sp.copyTo(_v_att_sp->q_d);
@@ -280,7 +281,8 @@ void Standard::update_transition_state()
 
 	} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_MC) {
 
-		_v_att_sp->roll_body = _fw_virtual_att_sp->roll_body;
+		// keep the wings level during transition
+		_v_att_sp->roll_body = 0.0f;
 
 		if (_v_control_mode->flag_control_climb_rate_enabled) {
 			// control backtransition deceleration using pitch.

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2015-2020 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -275,7 +275,8 @@ void Tiltrotor::update_transition_state()
 	// copy virtual attitude setpoint to real attitude setpoint (we use multicopter att sp)
 	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 
-	_v_att_sp->roll_body = _fw_virtual_att_sp->roll_body;
+	// keep the wings level during transition
+	_v_att_sp->roll_body = 0.0f;
 
 	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 


### PR DESCRIPTION
We have seen some roll movements on various airframes during transition and I'm wondering if the current implementation isn't prone to some recursive control output / wind-up issues if the fixed wing output is taken into account before or after the system is in fixed wing flight.

We should in general discourage any transitions that are not straight and level and rather ensure that transitions do not take very long and are pre-planned on straight flight segments.

The tailsitter controller alreaded forces the wings level.

@sfuhrer FYI