### PR TITLE
Correct airspeed used by EKF for calibration errors

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -164,9 +164,10 @@ EKF2::EKF2(int instance, const px4::wq_config_t &config, int imu, int mag, bool 
 	updateParams();
 
 	// The airspeed scale factor correcton is only available via parameter as used by the airspeed module
-	param_t rot = param_find("ASPD_SCALE");
-	if (rot != PARAM_INVALID) {
-		param_get(rot, &_airspeed_scale_factor);
+	param_t param_aspd_scale = param_find("ASPD_SCALE");
+
+	if (param_aspd_scale != PARAM_INVALID) {
+		param_get(param_aspd_scale, &_airspeed_scale_factor);
 	}
 
 	_ekf.set_min_required_gps_health_time(_param_ekf2_req_gps_h.get() * 1_s);
@@ -1163,6 +1164,7 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 		// was used instead, however this would introduce a potential circular dependency
 		// via the wind estimator that uses EKF velocity estimates.
 		const float true_airspeed_m_s = airspeed.true_airspeed_m_s * _airspeed_scale_factor;
+
 		// only set airspeed data if condition for airspeed fusion are met
 		if ((_param_ekf2_arsp_thr.get() > FLT_EPSILON) && (true_airspeed_m_s > _param_ekf2_arsp_thr.get())) {
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -207,6 +207,8 @@ private:
 	Vector3f _last_gyro_bias{};
 	Vector3f _last_mag_bias{};
 
+	float _airspeed_scale_factor{1.0f}; ///< scale factor correction applied to airspeed measurements
+
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
 	uORB::Subscription _distance_sensor_sub{ORB_ID(distance_sensor)};


### PR DESCRIPTION
The EKF module uses true airspeed as published by the sensors module, however this is not corrected for scale factor errors that can be estimated by the wind estimator and corrected using the ASPD_SCALE parameter that is applied to the true airspeed published by the airspeed_selector module. The effect of a scale factor error, learned and applied by the airspeed_selector, but not on the airspeed as used by the EKF is shown below using data from a flight where the uncorrected scale factor in airspeed data used by the EKF resulted in a significant along track position error when dead reckoning without GPS:

<img width="1122" alt="Screen Shot 2021-01-05 at 2 33 19 pm" src="https://user-images.githubusercontent.com/3596952/103603550-fcb45c80-4f62-11eb-9efa-1ef343daa0e6.png">

The innovations and learned wind states for the EKF (using uncorrected airspeed) and sensor_selector wind estimator (using scale factor corrected airspeed) is shown below and causes large airspeed innovations in the EKF.

<img width="1135" alt="Screen Shot 2021-01-05 at 2 38 48 pm" src="https://user-images.githubusercontent.com/3596952/103603952-eb1f8480-4f63-11eb-8129-4697015ef09a.png">

This solution applies the same ASPD_SCALE parameter that the sensor_selector module uses. The alternative which was to use the airspeed_validated.true_airspeed_m_s data directly was rejected because it introduced the possibility for a circular dependency if the sensor selector was learning the scale factor using the EKF velocities and also was not compatible with future use of different airspeed sensors for different EKF instances.

Testing was performed by flying the gazebo_plane sitl simulation in a loiter circle with ARSPD_SCALE_EST set to 1 to start airspeed scale factor calibration. After a few circles, ARSPD_SCALE_EST was set to 0 to turn off calibration and save the scale factor which changed from 1.0 to 0.947. The flight was repeated with ARSPD_SCALE_EST left at 0. This showed good agreement between the EKF and wind estimator innovations:

<img width="1118" alt="Screen Shot 2021-01-05 at 3 03 39 pm" src="https://user-images.githubusercontent.com/3596952/103605314-b31a4080-4f67-11eb-9a92-6d867109f667.png">

<img width="1107" alt="Screen Shot 2021-01-05 at 3 10 07 pm" src="https://user-images.githubusercontent.com/3596952/103605503-24f28a00-4f68-11eb-893b-5be649eaa121.png">
