### PR TITLE
Enable offboard acceleration setpoints

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3491,7 +3491,7 @@ Commander::update_control_mode()
 					!control_mode.flag_control_acceleration_enabled;
 
 			control_mode.flag_control_climb_rate_enabled = (!offboard_control_mode.ignore_velocity ||
-					!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
+					!offboard_control_mode.ignore_position);
 
 			control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !_status.in_transition_mode &&
 					!control_mode.flag_control_acceleration_enabled;


### PR DESCRIPTION
**Describe problem solved by this pull request**
> The case when acceleration setpoints were being passed in offboard mode was triggering control_climbrate_mode. This prevented the vehicle from taking off, since it made the vehicle skip the rampup phase of the takeoff
This commit fixes this by handling the case properly

**Describe your solution**
Port @Jaeyoung-Lim 's important fix from https://github.com/PX4/PX4-Autopilot/pull/15707 to make acceleration setpoints work through the offboard interface. The acceleration based takeoff needs further investigation to not cause unwanted side-effects when a feed-forward is used.

**Test data / coverage**
@Jaeyoung-Lim tested and I can clearly see why it was failing before with this incorrect condition.

**Additional context**
We could add MAVSDK support JFYI @JonasVautherin since we were talking about it.