### PR TITLE
Navigator: VTOL transition command: make transitions smoother

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1031,30 +1031,6 @@ Mission::set_mission_items()
 					generate_waypoint_from_heading(&pos_sp_triplet->current, pos_sp_triplet->current.yaw);
 				}
 
-				/* don't advance mission after FW to MC command */
-				if (_mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
-				    && _work_item_type == WORK_ITEM_TYPE_DEFAULT
-				    && new_work_item_type == WORK_ITEM_TYPE_DEFAULT
-				    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING
-				    && !_navigator->get_land_detected()->landed
-				    && pos_sp_triplet->current.valid) {
-
-					new_work_item_type = WORK_ITEM_TYPE_CMD_BEFORE_MOVE;
-				}
-
-				/* after FW to MC transition finish moving to the waypoint */
-				if (_work_item_type == WORK_ITEM_TYPE_CMD_BEFORE_MOVE &&
-				    new_work_item_type == WORK_ITEM_TYPE_DEFAULT
-				    && pos_sp_triplet->current.valid) {
-
-					new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
-
-					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-					copy_position_if_valid(&_mission_item, &pos_sp_triplet->current);
-					_mission_item.autocontinue = true;
-					_mission_item.time_inside = 0.0f;
-				}
-
 				// ignore certain commands in mission fast forward
 				if ((_mission_execution_mode == mission_result_s::MISSION_EXECUTION_MODE_FAST_FORWARD) &&
 				    (_mission_item.nav_cmd == NAV_CMD_DELAY)) {

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -281,7 +281,6 @@ private:
 		WORK_ITEM_TYPE_TAKEOFF,		/**< takeoff before moving to waypoint */
 		WORK_ITEM_TYPE_MOVE_TO_LAND,	/**< move to land waypoint before descent */
 		WORK_ITEM_TYPE_ALIGN,		/**< align for next waypoint */
-		WORK_ITEM_TYPE_CMD_BEFORE_MOVE,
 		WORK_ITEM_TYPE_TRANSITON_AFTER_TAKEOFF,
 		WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION,
 		WORK_ITEM_TYPE_PRECISION_LAND

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -149,7 +149,6 @@ protected:
 	bool _waypoint_position_reached{false};
 	bool _waypoint_yaw_reached{false};
 
-	hrt_abstime _action_start{0};
 	hrt_abstime _time_wp_reached{0};
 
 	uORB::Publication<actuator_controls_s>	_actuator_pub{ORB_ID(actuator_controls_2)};


### PR DESCRIPTION
**Describe problem solved by this pull request**
The transition command waypoints, NAV_CMD_DO_VTOL_TRANSITION, are attached to the previous waypoint that contains a location (e.g. normal waypoint). It then triggers a transition as soon as this waypoint is reached, which happens when the vehicle is within L1 distance to it. Is the L1 distance smaller then the needed space for the transition, then the vehicle overshoots. The current logic is that for a transition waypoint, the waypoint has to be reached again in the new VTOL mode (e.g. in hover after a backtransition). Thus, if it overshoots, it turns around to accept it, and only then proceeds to the next waypoint.
I don't really get in which case this would be desired.

This can lead to ugly situations like this:
![VTOLtransitionmaster](https://user-images.githubusercontent.com/26798987/103775614-98f76580-502e-11eb-95ef-b0b14f675bba.png)


**Describe your solution**
Do not make it accept the waypoint again in the new VTOL mode, but directly proceed to the next:
![vtoltransition_withfixes](https://user-images.githubusercontent.com/26798987/103775628-9e54b000-502e-11eb-860b-d1f55a596d98.png)
That means that if you don't have the previous, current and next waypoint in one line, it will make a turn while transitioning. I don't think this should be a big issue, and what we on top could do is limiting the max roll angle during the transition.

**Describe possible alternatives**


**Test data / coverage**
Basic SITL testing.

**Additional context**
https://github.com/PX4/PX4-Autopilot/commit/c31d8ce2b6f04c30b2fde6af08040c074e70e762 looks like it only works with this stuff removed. @dagar Am I missing something or could we safely remove it? I don't really get what it was added for.

