### PR TITLE
Add parameter to select the set of used GNSS systems

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -697,6 +697,17 @@ GPS::run()
 		}
 	}
 
+	int32_t gnssSystemsParam = static_cast<int32_t>(GPSHelper::GNSSSystemsMask::RECEIVER_DEFAULTS);
+
+	if (_instance == Instance::Main) {
+		handle = param_find("GPS_1_GNSS");
+		param_get(handle, &gnssSystemsParam);
+
+	} else if (_instance == Instance::Secondary) {
+		handle = param_find("GPS_2_GNSS");
+		param_get(handle, &gnssSystemsParam);
+	}
+
 	initializeCommunicationDump();
 
 	uint64_t last_rate_measurement = hrt_absolute_time();
@@ -769,8 +780,11 @@ GPS::run()
 			}
 
 			_baudrate = _configured_baudrate;
+			GPSHelper::GPSConfig gpsConfig{};
+			gpsConfig.output_mode = GPSHelper::OutputMode::GPS;
+			gpsConfig.gnss_systems = static_cast<GPSHelper::GNSSSystemsMask>(gnssSystemsParam);
 
-			if (_helper && _helper->configure(_baudrate, GPSHelper::OutputMode::GPS) == 0) {
+			if (_helper && _helper->configure(_baudrate, gpsConfig) == 0) {
 
 				/* reset report */
 				memset(&_report_gps_pos, 0, sizeof(_report_gps_pos));

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -146,3 +146,63 @@ PARAM_DEFINE_INT32(GPS_1_PROTOCOL, 1);
  * @group GPS
  */
 PARAM_DEFINE_INT32(GPS_2_PROTOCOL, 1);
+
+/**
+ * GNSS Systems for Primary GPS (integer bitmask)
+ *
+ * This integer bitmask controls the set of GNSS systems used by the receiver. Check your
+ * receiver's documentation on how many systems are supported to be used in parallel.
+ *
+ * Currently this functionality is just implemented for u-blox receivers.
+ *
+ * When no bits are set, the receiver's default configuration should be used.
+ *
+ * Set bits true to enable:
+ * 0 : Use GPS (with QZSS)
+ * 1 : Use SBAS (multiple GPS augmentation systems)
+ * 2 : Use Galileo
+ * 3 : Use BeiDou
+ * 4 : Use GLONASS
+ *
+ * @min 0
+ * @max 31
+ * @bit 0 GPS (with QZSS)
+ * @bit 1 SBAS
+ * @bit 2 Galileo
+ * @bit 3 BeiDou
+ * @bit 4 GLONASS
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_1_GNSS, 0);
+
+/**
+ * GNSS Systems for Secondary GPS (integer bitmask)
+ *
+ * This integer bitmask controls the set of GNSS systems used by the receiver. Check your
+ * receiver's documentation on how many systems are supported to be used in parallel.
+ *
+ * Currently this functionality is just implemented for u-blox receivers.
+ *
+ * When no bits are set, the receiver's default configuration should be used.
+ *
+ * Set bits true to enable:
+ * 0 : Use GPS (with QZSS)
+ * 1 : Use SBAS (multiple GPS augmentation systems)
+ * 2 : Use Galileo
+ * 3 : Use BeiDou
+ * 4 : Use GLONASS
+ *
+ * @min 0
+ * @max 31
+ * @bit 0 GPS (with QZSS)
+ * @bit 1 SBAS
+ * @bit 2 Galileo
+ * @bit 3 BeiDou
+ * @bit 4 GLONASS
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_2_GNSS, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Now, that the Galileo GNSS system is is a working condition, it would be nice to be able to select, which GNSS systems are used by the connected GNSS receiver. For example the pixhawk 4 GPS is using the uBlox NEO-M8N chipset, which is capable of receiving three of the four (GPS, Galileo, Beidou, GLONASS) available GNSS systems at once. But by default only GPS and GLONASS are enabled.

**Describe your solution**
This PR will introduce a new configuration parameter `GPS_x_GNSS`, which is a bit vector to enable the individual GNSS systems. When no bits are set, the receiver's configuration should not be changed.

**Additional context**
See https://github.com/PX4/PX4-Autopilot/issues/16370 for the general discussion.

This PR depends on changes in the GPSDrivers repository, which are not merged yet. Therefore I set this to a draft PR.
See https://github.com/PX4/PX4-GPSDrivers/issues/68 for progress tracking on implementing this parameter's functionality for all the different GPS receiver drivers.
