### PR TITLE
boards: start enabling multi-EKF by default on F7/H7

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -102,6 +102,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 13000"' // generic vtol standard
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "px4io forceupdate 14662 /etc/extras/px4_io-v2_default.bin" || true' // force px4io update
@@ -175,6 +176,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 4001"'  // generic multicopter
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "reboot" || true'                // reboot to apply
@@ -247,6 +249,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 13000"' // generic vtol standard
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "px4io forceupdate 14662 /etc/extras/px4_io-v2_default.bin" || true' // force px4io update
@@ -320,6 +323,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 13000"' // generic vtol standard
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set IMU_GYRO_RATEMAX 2000"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
@@ -471,6 +475,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 13000"' // generic vtol standard
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "reboot" || true'                // reboot to apply
@@ -620,6 +625,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param set SYS_AUTOSTART 4001"'  // generic vtol standardulticopter
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-SEGGER_*` --cmd "reboot" || true'                // reboot to apply
@@ -694,6 +700,7 @@ pipeline {
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'    // disable buzzer
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set DSHOT_CONFIG 600"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set IMU_GYRO_RATEMAX 4000"'
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 4001"'    // generic quadcopter
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_BL_UPDATE 1"'       // update bootloader
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_USE_IO 0"'          // for dshot
@@ -770,6 +777,7 @@ pipeline {
                   steps {
                     // configure
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set CBRK_BUZZER 782097"'  // disable buzzer
+                    sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOCONFIG 2"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param set SYS_AUTOSTART 4001"'  // generic multicopter
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "param save"'
                     sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-FTDI_*` --cmd "reboot" || true'                // reboot to apply

--- a/boards/av/x-v1/init/rc.board_defaults
+++ b/boards/av/x-v1/init/rc.board_defaults
@@ -8,7 +8,9 @@ param set CBRK_SUPPLY_CHK 894281
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/cuav/nora/init/rc.board_defaults
+++ b/boards/cuav/nora/init/rc.board_defaults
@@ -31,6 +31,12 @@ then
 	param set BAT1_A_PER_V 24
 	param set BAT2_A_PER_V 24
 
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 3
+	param set SENS_MAG_MODE 0
+
 	# Enable IMU thermal control
 	param set SENS_EN_THERMAL 1
 fi

--- a/boards/cuav/x7pro/init/rc.board_defaults
+++ b/boards/cuav/x7pro/init/rc.board_defaults
@@ -31,6 +31,12 @@ then
 	param set BAT1_A_PER_V 24
 	param set BAT2_A_PER_V 24
 
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 3
+	param set SENS_MAG_MODE 0
+
 	# Enable IMU thermal control
 	param set SENS_EN_THERMAL 1
 fi

--- a/boards/cubepilot/cubeorange/init/rc.board_defaults
+++ b/boards/cubepilot/cubeorange/init/rc.board_defaults
@@ -31,6 +31,12 @@ then
 	param set BAT1_A_PER_V 17
 	param set BAT2_A_PER_V 17
 
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 3
+	param set SENS_MAG_MODE 0
+
 	# Disable IMU thermal control
 	param set SENS_EN_THERMAL 0
 fi

--- a/boards/cubepilot/cubeyellow/init/rc.board_defaults
+++ b/boards/cubepilot/cubeyellow/init/rc.board_defaults
@@ -14,6 +14,10 @@ then
 	param set BAT1_A_PER_V 17
 	param set BAT2_A_PER_V 17
 
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+
 	# Disable IMU thermal control
 	param set SENS_EN_THERMAL 0
 fi

--- a/boards/holybro/durandal-v1/init/rc.board_defaults
+++ b/boards/holybro/durandal-v1/init/rc.board_defaults
@@ -24,6 +24,12 @@ unset BL_FILE
 
 if [ $AUTOCNF = yes ]
 then
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 3
+	param set SENS_MAG_MODE 0
+
 	# Enable IMU thermal control
 	param set SENS_EN_THERMAL 1
 fi

--- a/boards/holybro/pix32v5/init/rc.board_defaults
+++ b/boards/holybro/pix32v5/init/rc.board_defaults
@@ -6,7 +6,11 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 2
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 2
+	param set SENS_MAG_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/modalai/fc-v1/init/rc.board_defaults
+++ b/boards/modalai/fc-v1/init/rc.board_defaults
@@ -26,6 +26,10 @@ then
 	#  V110 - J1011 pin 5
 	#
 	param set CBRK_IO_SAFETY 22027
+
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
 fi
 
 #

--- a/boards/mro/ctrl-zero-f7/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-f7/init/rc.board_defaults
@@ -6,7 +6,9 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/mro/pixracerpro/init/rc.board_defaults
+++ b/boards/mro/pixracerpro/init/rc.board_defaults
@@ -29,6 +29,12 @@ then
 	param set BAT_A_PER_V 17
 	param set BAT1_A_PER_V 17
 
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 3
+	param set SENS_MAG_MODE 0
+
 fi
 
 set LOGGER_BUF 64

--- a/boards/mro/x21-777/init/rc.board_defaults
+++ b/boards/mro/x21-777/init/rc.board_defaults
@@ -6,7 +6,11 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 2
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 2
+	param set SENS_MAG_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v4pro/init/rc.board_defaults
+++ b/boards/px4/fmu-v4pro/init/rc.board_defaults
@@ -6,7 +6,9 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v5/init/rc.board_defaults
+++ b/boards/px4/fmu-v5/init/rc.board_defaults
@@ -6,7 +6,19 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	if ver hwtypecmp V550 V560
+	then
+		# CUAV V5+ (V550) and V5nano (V560) have 3 IMUs
+		# Multi-EKF (IMUs only)
+		param set EKF2_MULTI_IMU 3
+		param set SENS_IMU_MODE 0
+	else
+		# Multi-EKF
+		param set EKF2_MULTI_IMU 2
+		param set SENS_IMU_MODE 0
+		param set EKF2_MULTI_MAG 2
+		param set SENS_MAG_MODE 0
+	fi
 fi
 
 # disable px4io on HolyBro mini (V540) and CUAV V5nano (V560)

--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -6,7 +6,9 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -6,7 +6,11 @@
 
 if [ $AUTOCNF = yes ]
 then
-
+	# Multi-EKF
+	param set EKF2_MULTI_IMU 3
+	param set SENS_IMU_MODE 0
+	param set EKF2_MULTI_MAG 3
+	param set SENS_MAG_MODE 0
 fi
 
 set LOGGER_BUF 64

--- a/posix-configs/rpi/pilotpi_mc.config
+++ b/posix-configs/rpi/pilotpi_mc.config
@@ -14,6 +14,12 @@ param set CBRK_SUPPLY_CHK 894281
 param set MAV_BROADCAST 1
 param set MAV_TYPE 2
 
+# Multi-EKF
+param set EKF2_MULTI_IMU 2
+param set SENS_IMU_MODE 0
+param set EKF2_MULTI_MAG 3
+param set SENS_MAG_MODE 0
+
 dataman start
 
 load_mon start

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -17,6 +17,12 @@ param set MAV_BROADCAST 1
 param set MAV_TYPE 2
 param set IMU_GYRO_RATEMAX 400
 
+# Multi-EKF
+param set EKF2_MULTI_IMU 2
+param set SENS_IMU_MODE 0
+param set EKF2_MULTI_MAG 3
+param set SENS_MAG_MODE 0
+
 dataman start
 
 load_mon start

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -17,6 +17,12 @@ param set SYS_AUTOSTART 2100
 param set MAV_TYPE 1
 param set IMU_GYRO_RATEMAX 400
 
+# Multi-EKF
+param set EKF2_MULTI_IMU 2
+param set SENS_IMU_MODE 0
+param set EKF2_MULTI_MAG 3
+param set SENS_MAG_MODE 0
+
 dataman start
 
 load_mon start

--- a/posix-configs/rpi/px4_hil.config
+++ b/posix-configs/rpi/px4_hil.config
@@ -18,6 +18,12 @@ param set SYS_AUTOSTART 1001
 param set MAV_BROADCAST 1
 param set MAV_TYPE 2
 
+# Multi-EKF
+param set EKF2_MULTI_IMU 2
+param set SENS_IMU_MODE 0
+param set EKF2_MULTI_MAG 3
+param set SENS_MAG_MODE 0
+
 dataman start
 
 load_mon start

--- a/posix-configs/rpi/px4_test.config
+++ b/posix-configs/rpi/px4_test.config
@@ -17,6 +17,12 @@ param set MAV_BROADCAST 1
 param set MAV_TYPE 2
 param set IMU_GYRO_RATEMAX 400
 
+# Multi-EKF
+param set EKF2_MULTI_IMU 2
+param set SENS_IMU_MODE 0
+param set EKF2_MULTI_MAG 3
+param set SENS_MAG_MODE 0
+
 dataman start
 
 load_mon start


### PR DESCRIPTION
 - stm32f7 start with 1 ekf2 instance per IMU
 - stm32h7 ekf2 instances across all IMUs and mags

Both have plenty of memory for this, on stm32f7 cpu can start to become limiting with 3 IMUs and multiple mags, especially depending on the configuration of things like IMU_GYRO_RATEMAX. This is a conservative start until we can allocate more effectively.

Enabling this via rc.board_defaults isn't a great mechanism as it will only apply to newly configured systems (SYS_AUTOCONFIG). Later I'd like to do this properly with different defaults per board handled by the parameter system (https://github.com/PX4/PX4-Autopilot/pull/14363).
