### PR TITLE
Fix quadchute during backtransition

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -160,7 +160,7 @@ void Standard::update_vtol_state()
 		if (_vtol_schedule.flight_mode == vtol_mode::MC_MODE || _vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_MC) {
 			// start transition to fw mode
 			/* NOTE: The failsafe transition to fixed-wing was removed because it can result in an
-			* unsafe flying state. */
+			 * unsafe flying state. */
 			_vtol_schedule.flight_mode = vtol_mode::TRANSITION_TO_FW;
 			_vtol_schedule.transition_start = hrt_absolute_time();
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -117,7 +117,6 @@ void Standard::update_vtol_state()
 			_vtol_vehicle_status->vtol_transition_failsafe = false;
 		}
 
-
 	} else if (!_attc->is_fixed_wing_requested()) {
 
 		// the transition to fw mode switch is off
@@ -141,7 +140,6 @@ void Standard::update_vtol_state()
 			_pusher_throttle = 0.0f;
 			_reverse_output = 0.0f;
 
-
 		} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_MC) {
 			// transition to MC mode if transition time has passed or forward velocity drops below MPC cruise speed
 
@@ -155,7 +153,6 @@ void Standard::update_vtol_state()
 			    can_transition_on_ground()) {
 				_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 			}
-
 		}
 
 	} else {

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -272,7 +272,7 @@ void Standard::update_transition_state()
 		if (_params->front_trans_timeout > FLT_EPSILON) {
 			if (time_since_trans_start > _params->front_trans_timeout) {
 				// transition timeout occured, abort transition
-				_attc->abort_front_transition("Transition timeout");
+				_attc->quadchute("Transition timeout");
 			}
 		}
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -80,7 +80,16 @@ void Tailsitter::update_vtol_state()
 
 	float pitch = Eulerf(Quatf(_v_att->q)).theta();
 
-	if (!_attc->is_fixed_wing_requested()) {
+	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+		// Failsafe event, switch to MC mode immediately
+		_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
+
+		//reset failsafe when FW is no longer requested
+		if (!_attc->is_fixed_wing_requested()) {
+			_vtol_vehicle_status->vtol_transition_failsafe = false;
+		}
+
+	} else if (!_attc->is_fixed_wing_requested()) {
 
 		switch (_vtol_schedule.flight_mode) { // user switchig to MC mode
 		case vtol_mode::MC_MODE:

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -100,7 +100,16 @@ void Tiltrotor::update_vtol_state()
 	 * forward completely. For the backtransition the motors simply rotate back.
 	*/
 
-	if (!_attc->is_fixed_wing_requested()) {
+	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+		// Failsafe event, switch to MC mode immediately
+		_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
+
+		//reset failsafe when FW is no longer requested
+		if (!_attc->is_fixed_wing_requested()) {
+			_vtol_vehicle_status->vtol_transition_failsafe = false;
+		}
+
+	} else 	if (!_attc->is_fixed_wing_requested()) {
 
 		// plane is in multicopter mode
 		switch (_vtol_schedule.flight_mode) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -207,27 +207,14 @@ VtolAttitudeControl::is_fixed_wing_requested()
 		to_fw = (_transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
 	}
 
-	// handle abort request
-	if (_abort_front_transition) {
-		if (to_fw) {
-			to_fw = false;
-
-		} else {
-			// the state changed to mc mode, reset the abort request
-			_abort_front_transition = false;
-			_vtol_vehicle_status.vtol_transition_failsafe = false;
-		}
-	}
-
 	return to_fw;
 }
 
 void
 VtolAttitudeControl::abort_front_transition(const char *reason)
 {
-	if (!_abort_front_transition) {
+	if (!_vtol_vehicle_status.vtol_transition_failsafe) {
 		mavlink_log_critical(&_mavlink_log_pub, "Abort: %s", reason);
-		_abort_front_transition = true;
 		_vtol_vehicle_status.vtol_transition_failsafe = true;
 	}
 }

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -211,7 +211,7 @@ VtolAttitudeControl::is_fixed_wing_requested()
 }
 
 void
-VtolAttitudeControl::abort_front_transition(const char *reason)
+VtolAttitudeControl::quadchute(const char *reason)
 {
 	if (!_vtol_vehicle_status.vtol_transition_failsafe) {
 		mavlink_log_critical(&_mavlink_log_pub, "Abort: %s", reason);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -219,7 +219,6 @@ private:
 	 * for fixed wings we want to have an idle speed of zero since we do not want
 	 * to waste energy when gliding. */
 	int		_transition_command{vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC};
-	bool		_abort_front_transition{false};
 
 	VtolType	*_vtol_type{nullptr};	// base class for different vtol types
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -105,7 +105,7 @@ public:
 	bool init();
 
 	bool is_fixed_wing_requested();
-	void abort_front_transition(const char *reason);
+	void quadchute(const char *reason);
 
 	struct actuator_controls_s 			*get_actuators_fw_in() {return &_actuators_fw_in;}
 	struct actuator_controls_s 			*get_actuators_mc_in() {return &_actuators_mc_in;}

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -245,7 +245,7 @@ void VtolType::check_quadchute_condition()
 		if (_params->fw_min_alt > FLT_EPSILON) {
 
 			if (-(_local_pos->z) < _params->fw_min_alt) {
-				_attc->abort_front_transition("QuadChute: Minimum altitude breached");
+				_attc->quadchute("QuadChute: Minimum altitude breached");
 			}
 		}
 
@@ -263,7 +263,7 @@ void VtolType::check_quadchute_condition()
 				    (_ra_hrate < -1.0f) &&
 				    (_ra_hrate_sp > 1.0f)) {
 
-					_attc->abort_front_transition("QuadChute: loss of altitude");
+					_attc->quadchute("QuadChute: loss of altitude");
 				}
 
 			} else {
@@ -271,7 +271,7 @@ void VtolType::check_quadchute_condition()
 				const bool height_rate_error = _local_pos->v_z_valid && (_local_pos->vz > 1.0f) && (_local_pos->z_deriv > 1.0f);
 
 				if (height_error && height_rate_error) {
-					_attc->abort_front_transition("QuadChute: large altitude error");
+					_attc->quadchute("QuadChute: large altitude error");
 				}
 			}
 		}
@@ -280,7 +280,7 @@ void VtolType::check_quadchute_condition()
 		if (_params->fw_qc_max_pitch > 0) {
 
 			if (fabsf(euler.theta()) > fabsf(math::radians(_params->fw_qc_max_pitch))) {
-				_attc->abort_front_transition("Maximum pitch angle exceeded");
+				_attc->quadchute("Maximum pitch angle exceeded");
 			}
 		}
 
@@ -288,7 +288,7 @@ void VtolType::check_quadchute_condition()
 		if (_params->fw_qc_max_roll > 0) {
 
 			if (fabsf(euler.phi()) > fabsf(math::radians(_params->fw_qc_max_roll))) {
-				_attc->abort_front_transition("Maximum roll angle exceeded");
+				_attc->quadchute("Maximum roll angle exceeded");
 			}
 		}
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes the quadchute issue during backtransition of #16427

**Describe your solution**
in `void Standard::update_vtol_state()`, check first if the drone needs to quadchute before doing anything else to ensure it's triggered correctly. Reset the failsafe state when no longer needed (FW no longer requested).

I also removed and replaced `_abort_front_transition` which is an unnecessary variable as it has the same purpose as `_vtol_vehicle_status->vtol_transition_failsafe`

**Describe possible alternatives**
Always happy if someone finds something more elegant.

Also, I was hesitant to rename the function `VtolAttitudeControl::abort_front_transition(const char *reason)` to `VtolAttitudeControl::quadchute(const char *reason)`. Do you think it's worth it?

**Test data / coverage**
Basic SITL tests in a mission and flying manually with a Nintendo Switch Pro controller. I triggered the quadchute during front transition, FW flight and back transition by setting VT_FW_MIN_ALT to higher than flight altitude.