### PR TITLE
estimated IMU bias preflight checks

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
@@ -98,7 +98,6 @@ then
 	param set BAT_V_DIV 10.14
 	param set BAT_A_PER_V 18.18
 	#param set CBRK_IO_SAFETY 22027
-	param set COM_ARM_EKF_AB 0.005
 	param set COM_DISARM_LAND 2
 
 	# Filter settings

--- a/ROMFS/px4fmu_common/init.d/airframes/4072_draco
+++ b/ROMFS/px4fmu_common/init.d/airframes/4072_draco
@@ -77,7 +77,6 @@ then
 
 	param set BAT_SOURCE 0
 	param set CBRK_IO_SAFETY 22027
-	#param set COM_ARM_EKF_AB 0.005
 	#param set COM_DISARM_LAND 3
 
 	# Filter settings

--- a/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
+++ b/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
@@ -107,7 +107,6 @@ then
 	param set BAT_V_DIV 10.14
 	param set BAT_A_PER_V 18.18
 	#param set CBRK_IO_SAFETY 22027
-	param set COM_ARM_EKF_AB 0.005
 	param set COM_DISARM_LAND 2
 
 	# Filter settings

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -49,7 +49,6 @@ then
 	# sensor calibration
 	param set CAL_MAG_SIDES 63
 	param set SENS_BOARD_ROT 0
-	param set COM_ARM_EKF_AB 0.0032
 
 	# circuit breakers
 	param set CBRK_IO_SAFETY 22027

--- a/msg/estimator_sensor_bias.msg
+++ b/msg/estimator_sensor_bias.msg
@@ -3,22 +3,25 @@
 # scale errors, in-run bias and thermal drift (if thermal compensation is enabled and available).
 #
 
-uint64 timestamp		# time since system start (microseconds)
+uint64 timestamp                # time since system start (microseconds)
 uint64 timestamp_sample         # the timestamp of the raw data (microseconds)
 
 # In-run bias estimates (subtract from uncorrected data)
 
-uint32 gyro_device_id		# unique device ID for the sensor that does not change between power cycles
-float32[3] gyro_bias		# gyroscope in-run bias in body frame (rad/s)
+uint32 gyro_device_id           # unique device ID for the sensor that does not change between power cycles
+float32[3] gyro_bias            # gyroscope in-run bias in body frame (rad/s)
+float32 gyro_bias_limit         # magnitude of maximum gyroscope in-run bias in body frame (rad/s)
 float32[3] gyro_bias_variance
 bool gyro_bias_valid
 
-uint32 accel_device_id		# unique device ID for the sensor that does not change between power cycles
-float32[3] accel_bias		# accelerometer in-run bias in body frame (m/s^2)
+uint32 accel_device_id          # unique device ID for the sensor that does not change between power cycles
+float32[3] accel_bias           # accelerometer in-run bias in body frame (m/s^2)
+float32 accel_bias_limit        # magnitude of maximum accelerometer in-run bias in body frame (m/s^2)
 float32[3] accel_bias_variance
 bool accel_bias_valid
 
-uint32 mag_device_id		# unique device ID for the sensor that does not change between power cycles
-float32[3] mag_bias		# magnetometer in-run bias in body frame (Gauss)
+uint32 mag_device_id            # unique device ID for the sensor that does not change between power cycles
+float32[3] mag_bias             # magnetometer in-run bias in body frame (Gauss)
+float32 mag_bias_limit          # magnitude of maximum magnetometer in-run bias in body frame (Gauss)
 float32[3] mag_bias_variance
 bool mag_bias_valid

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -232,7 +232,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 			failed = true;
 		}
 
-		if (!ekf2CheckStates(mavlink_log_pub, report_failures && report_ekf_fail)) {
+		if (!ekf2CheckSensorBias(mavlink_log_pub, report_failures && report_ekf_fail)) {
 			failed = true;
 		}
 	}

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -111,7 +111,7 @@ private:
 	static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool optional,
 			      const bool report_fail, const bool enforce_gps_required);
 
-	static bool ekf2CheckStates(orb_advert_t *mavlink_log_pub, const bool report_fail);
+	static bool ekf2CheckSensorBias(orb_advert_t *mavlink_log_pub, const bool report_fail);
 
 	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,
 					 const bool prearm);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -557,31 +557,6 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_HGT, 1.0f);
 PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
 
 /**
- * Maximum value of EKF accelerometer delta velocity bias estimate that will allow arming.
- * Note: ekf2 will limit the delta velocity bias estimate magnitude to be less than EKF2_ABL_LIM * FILTER_UPDATE_PERIOD_MS * 0.001 so this parameter must be less than that to be useful.
- *
- * @group Commander
- * @unit m/s
- * @min 0.001
- * @max 0.01
- * @decimal 4
- * @increment 0.0001
- */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 0.0022f);
-
-/**
- * Maximum value of EKF gyro delta angle bias estimate that will allow arming
- *
- * @group Commander
- * @unit rad
- * @min 0.0001
- * @max 0.0017
- * @decimal 4
- * @increment 0.0001
- */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_GB, 0.0011f);
-
-/**
  * Maximum accelerometer inconsistency between IMU units that will allow arming
  *
  * @group Commander

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -867,6 +867,7 @@ void EKF2::PublishSensorBias(const hrt_abstime &timestamp)
 		if (_device_id_gyro != 0) {
 			bias.gyro_device_id = _device_id_gyro;
 			gyro_bias.copyTo(bias.gyro_bias);
+			bias.gyro_bias_limit = math::radians(20.f); // 20 degrees/s see Ekf::constrainStates()
 			_ekf.getGyroBiasVariance().copyTo(bias.gyro_bias_variance);
 			bias.gyro_bias_valid = true;
 
@@ -876,6 +877,7 @@ void EKF2::PublishSensorBias(const hrt_abstime &timestamp)
 		if ((_device_id_accel != 0) && !(_param_ekf2_aid_mask.get() & MASK_INHIBIT_ACC_BIAS)) {
 			bias.accel_device_id = _device_id_accel;
 			accel_bias.copyTo(bias.accel_bias);
+			bias.accel_bias_limit = _params->acc_bias_lim;
 			_ekf.getAccelBiasVariance().copyTo(bias.accel_bias_variance);
 			bias.accel_bias_valid = !_ekf.fault_status_flags().bad_acc_bias;
 
@@ -885,6 +887,7 @@ void EKF2::PublishSensorBias(const hrt_abstime &timestamp)
 		if (_device_id_mag != 0) {
 			bias.mag_device_id = _device_id_mag;
 			mag_bias.copyTo(bias.mag_bias);
+			bias.mag_bias_limit = 0.5f; // 0.5 Gauss see Ekf::constrainStates()
 			_mag_cal_last_bias_variance.copyTo(bias.mag_bias_variance);
 			bias.mag_bias_valid = _mag_cal_available;
 


### PR DESCRIPTION
There are 2 parts to this, and I could go either way on the 2nd. Commander shouldn't need to have intimate knowledge of everything to function. As much as possible I'd like to avoid having multiple tuning knobs at every level.
1. Commander preflight use `estimator_sensor_bias` message instead of directly using states and covariances at magic indices
2. Instead of independently configuring the bias limits in commander (COM_ARM_EKF_AB/COM_ARM_EKF_GB), publish them in `estimator_sensor_bias`. The commander parameters were a bit unintuitive and dependent on ecl/EKF internals like the filter update period. Commander blocks arming if you exceed 50% of the limit. The accel bias limit is set from the parameter EKF2_ABL_LIM, but the gyro and mag limits are hardcoded.


