### PR TITLE
Support relative altitude for offboard global position setpoints

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1085,8 +1085,17 @@ MavlinkReceiver::handle_message_set_position_target_global_int(mavlink_message_t
 							pos_sp_triplet.current.position_valid = false;
 
 						} else {
+							float target_altitude;
+
+							if (set_position_target_global_int.coordinate_frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+								target_altitude = set_position_target_global_int.alt + local_pos.ref_alt;
+
+							} else {
+								target_altitude = set_position_target_global_int.alt; //MAV_FRAME_GLOBAL_INT
+							}
+
 							globallocalconverter_tolocal(set_position_target_global_int.lat_int / 1e7,
-										     set_position_target_global_int.lon_int / 1e7, set_position_target_global_int.alt,
+										     set_position_target_global_int.lon_int / 1e7, target_altitude,
 										     &pos_sp_triplet.current.x, &pos_sp_triplet.current.y, &pos_sp_triplet.current.z);
 							pos_sp_triplet.current.cruising_speed = get_offb_cruising_speed();
 							pos_sp_triplet.current.position_valid = true;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously the `coordinate_frame` field in the mavlink message `SET_POSITION_TARGET_GLOBAL_INT` message was not handled correctly. This results in the vehicle not being able handle relative altitude when controlling the vehicle in offboard mode with global position setpoints.

**Describe your solution**
This PR parses the coordinate_frame flag and applies the relative altitude correctly, when the coordinate frame is defined as `MAV_FRAME_GLOBAL_RELATIVE_ALT_INT`

If the coordinate frame is unknown, the behavior falls back to the default behavior considering the altitude as global altitude.

**Test data / coverage**
Tested by sending global position setpoints through mavros on topic `~setpoint_raw/global` with coordinate_frame = 6

**Additional context**
- Fixes https://github.com/PX4/PX4-Autopilot/issues/16432
