### PR TITLE
Retune Typhoon H480 PID

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
@@ -9,12 +9,14 @@
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_PITCHRATE_P 0.1
-	param set MC_PITCHRATE_I 0.05
-	param set MC_PITCH_P 6.0
-	param set MC_ROLLRATE_P 0.15
-	param set MC_ROLLRATE_I 0.1
-	param set MC_ROLL_P 6.0
+	param set MC_PITCHRATE_P 0.1000
+	param set MC_PITCHRATE_I 0.0400
+	param set MC_PITCHRATE_D 0.0010
+	param set MC_PITCH_P 9.0
+	param set MC_ROLLRATE_P 0.1000
+	param set MC_ROLLRATE_I 0.0400
+	param set MC_ROLLRATE_D 0.0010
+	param set MC_ROLL_P 9.0
 	param set MPC_XY_VEL_I_ACC 4
 	param set MPC_XY_VEL_P_ACC 3
 


### PR DESCRIPTION
**Describe the bug**
Hi, I am having stability issues with Gazebo SITL Typhoon h480. In the hover it gets worse with time, descending and ascending with no major problems.


**To Reproduce**
Steps to reproduce the behavior:
1. Build the repository with `make px4_sitl gazebo_typhoon_h480`
2. Open QGroundControl and Takeoff to any height
3. Oscillation can be observed. While waiting oscillation gets amplified. 

**Expected behavior**
Expected behavior is of course a hover without major oscillations but small tuning errors are always acceptable for simulating the real world conditions. 

**Screenshots**

https://user-images.githubusercontent.com/21319327/104027976-32fb1180-51d9-11eb-8344-c3e1b38ab3ca.mp4


**Drone:**
- Typhoon H480 SITL 

**Proposed Solution**

I have made a rough tuning with [PX4 Multicopter PID Tuning Guide](https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html) below you can see the values and flight video. I am going to open a pull request as soon as possible.


https://user-images.githubusercontent.com/21319327/104028300-9dac4d00-51d9-11eb-8ad0-7cb32d296f31.mp4

The tuning is not very good I am aware of it but it can fly fine now.
Pitch:
![pitch](https://user-images.githubusercontent.com/21319327/104028431-c3d1ed00-51d9-11eb-911a-34b5d843484e.png)

Roll:
![roll](https://user-images.githubusercontent.com/21319327/104028449-ca606480-51d9-11eb-8a26-4318e8e446f0.png)

Yaw (Not changed I think):
![yaw](https://user-images.githubusercontent.com/21319327/104028484-d3513600-51d9-11eb-8572-a174825dc993.png)

This should solve the issues #16517 and #14953 

Thank you