### PR TITLE
log_message increase queue depth 2->4

### DIFF
--- a/msg/log_message.msg
+++ b/msg/log_message.msg
@@ -4,3 +4,5 @@ uint64 timestamp		# time since system start (microseconds)
 
 uint8 severity # log level (same as in the linux kernel, starting with 0)
 char[127] text
+
+uint8 ORB_QUEUE_LENGTH = 4

--- a/platforms/common/px4_log.cpp
+++ b/platforms/common/px4_log.cpp
@@ -66,7 +66,7 @@ void px4_log_initialize(void)
 	log_message.severity = 6; //info
 	strcpy((char *)log_message.text, "initialized uORB logging");
 
-	orb_log_message_pub = orb_advertise_queue(ORB_ID(log_message), &log_message, 2);
+	orb_log_message_pub = orb_advertise_queue(ORB_ID(log_message), &log_message, log_message_s::ORB_QUEUE_LENGTH);
 
 	if (!orb_log_message_pub) {
 		PX4_ERR("failed to advertise log_message");


### PR DESCRIPTION
Wherever possible I want to reduce dependence on console and mavlink messages for log review, but there are still situations where we seem to be dropping these.