### PR TITLE
ekf2: multi instance numbering consistent with uORB publication instances

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -96,7 +96,7 @@ class EKF2 final : public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
 	EKF2() = delete;
-	EKF2(int instance, const px4::wq_config_t &config, int imu, int mag, bool replay_mode);
+	EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode);
 	~EKF2() override;
 
 	/** @see ModuleBase */
@@ -117,6 +117,10 @@ public:
 	static void lock_module() { pthread_mutex_lock(&ekf2_module_mutex); }
 	static bool trylock_module() { return (pthread_mutex_trylock(&ekf2_module_mutex) == 0); }
 	static void unlock_module() { pthread_mutex_unlock(&ekf2_module_mutex); }
+
+	bool multi_init(int imu, int mag);
+
+	int instance() const { return _instance; }
 
 private:
 	void Run() override;
@@ -158,7 +162,7 @@ private:
 
 	const bool _replay_mode{false};			///< true when we use replay data from a log
 	const bool _multi_mode;
-	const int _instance;
+	int _instance{0};
 
 	px4::atomic_bool _task_should_exit{false};
 

--- a/src/modules/uORB/PublicationMulti.hpp
+++ b/src/modules/uORB/PublicationMulti.hpp
@@ -41,6 +41,7 @@
 #include <px4_platform_common/defines.h>
 #include <systemlib/err.h>
 #include <uORB/uORB.h>
+#include "uORBDeviceNode.hpp"
 
 #include "Publication.hpp"
 
@@ -89,6 +90,15 @@ public:
 		}
 
 		return (orb_publish(get_topic(), _handle, &data) == PX4_OK);
+	}
+
+	int get_instance() const
+	{
+		if (_handle) {
+			return static_cast<uORB::DeviceNode *>(_handle)->get_instance();
+		}
+
+		return -1;
 	}
 };
 


### PR DESCRIPTION
This ensures that ekf2 instance numbering is consistent with uORB publication instances.

![Screenshot from 2021-01-08 13-35-00](https://user-images.githubusercontent.com/84712/104051567-53fe3b00-51b6-11eb-8751-418a235c3e89.png)

![Screenshot from 2021-01-08 13-35-19](https://user-images.githubusercontent.com/84712/104051594-5eb8d000-51b6-11eb-99b7-10e074ba0fbd.png)

For convenience when comparing logged output with specific messages.