### PR TITLE
tools: make sure that uORB type names found as part of field names are not capitalized as ROS types

### DIFF
--- a/msg/tools/uorb_to_ros_msgs.py
+++ b/msg/tools/uorb_to_ros_msgs.py
@@ -5,6 +5,7 @@ Adapted from https://github.com/eProsima/px4_to_ros/blob/master/px4_to_ros2_PoC/
 """
 
 import os
+import re
 import sys
 from shutil import copyfile
 
@@ -90,7 +91,7 @@ for filename in os.listdir(output_dir):
                         fileUpdated = True
                         line = line.replace(('px4/' + msg_type),
                                             msg_type.partition(".")[0].title().replace('_', ''))
-                    if ('' + msg_type + '[') in line.partition('#')[0] or ('' + msg_type + ' ') in line.partition('#')[0]:
+                    if re.findall('^' + msg_type + '[\s\[]', line.partition('#')[0]):
                         fileUpdated = True
                         line = line.replace(msg_type,
                                             msg_type.partition(".")[0].title().replace('_', ''))


### PR DESCRIPTION
**Describe problem solved by this pull request**
An bug on the `uorb_to_ros_msgs.py` was leading to uORB type names found as part of field names be capitalized as ROS types, leading to wrongly generated fields:

```console
  NameError: 'fs_bad_Airspeed' is an invalid field name.  It should have the
  pattern '^(?!.*__)(?!.*_$)[a-z][a-z0-9_]*$'
```

**Describe your solution**
An update to the script, using regex, quickly fixes the issue.
