### PR TITLE
Fix differential thrust for Tailsitter in FW mode

### DIFF
--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -268,11 +268,6 @@ void Tailsitter::update_fw_state()
 {
 	VtolType::update_fw_state();
 
-	// allow fw yawrate control via multirotor roll actuation. this is useful for vehicles
-	// which don't have a rudder to coordinate turns
-	if (_params->diff_thrust == 1) {
-		_mc_roll_weight = 1.0f;
-	}
 }
 
 /**
@@ -292,6 +287,11 @@ void Tailsitter::fill_actuator_outputs()
 
 	if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {
 		mc_out[actuator_controls_s::INDEX_THROTTLE] = fw_in[actuator_controls_s::INDEX_THROTTLE];
+
+		/* allow differential thrust if enabled */
+		if (_params->diff_thrust == 1) {
+			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _params->diff_thrust_scale;
+		}
 
 	} else {
 		mc_out[actuator_controls_s::INDEX_THROTTLE] = mc_in[actuator_controls_s::INDEX_THROTTLE];


### PR DESCRIPTION
Replaces #12518 

Closes #12302

Followed the same logic and just updated the PR with a quick test in SITL.

Log: https://logs.px4.io/plot_app?log=fb7ebb3e-53ac-4c8a-baa7-548dc4a8ede0

@sfuhrer If you could have a look, and perhaps @xdwgood can you test this in a tailsitter as well?

@dagar FYI