### PR TITLE
Fix roslaunch multivehicle regression caused by #16497

### DIFF
--- a/launch/single_vehicle_spawn.launch
+++ b/launch/single_vehicle_spawn.launch
@@ -20,10 +20,11 @@
     <arg name="gst_udp_port" default="5600"/>
     <arg name="video_uri" default="5600"/>
     <arg name="mavlink_cam_udp_port" default="14530"/>
+    <arg name="mavlink_id" value="$(eval 1 + arg('ID'))" />
     <!-- PX4 configs -->
     <arg name="interactive" default="true"/>
     <!-- generate sdf vehicle model -->
-    <arg name="cmd" default="$(find mavlink_sitl_gazebo)/scripts/jinja_gen.py --stdout --mavlink_id=$(eval 1 + arg('ID')) --mavlink_udp_port=$(arg mavlink_udp_port) --mavlink_tcp_port=$(arg mavlink_tcp_port) --gst_udp_port=$(arg gst_udp_port) --video_uri=$(arg video_uri) --mavlink_cam_udp_port=$(arg mavlink_cam_udp_port) $(find mavlink_sitl_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf.jinja $(find mavlink_sitl_gazebo)"/>
+    <arg name="cmd" default="$(find mavlink_sitl_gazebo)/scripts/jinja_gen.py --stdout --mavlink_id=$(arg mavlink_id) --mavlink_udp_port=$(arg mavlink_udp_port) --mavlink_tcp_port=$(arg mavlink_tcp_port) --gst_udp_port=$(arg gst_udp_port) --video_uri=$(arg video_uri) --mavlink_cam_udp_port=$(arg mavlink_cam_udp_port) $(find mavlink_sitl_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf.jinja $(find mavlink_sitl_gazebo)"/>
     <param command="$(arg cmd)" name="sdf_$(arg vehicle)$(arg ID)"/>
     <!-- PX4 SITL -->
     <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>


### PR DESCRIPTION
**Describe problem solved by this pull request**
This fixes a regression/bug introduced by https://github.com/PX4/PX4-Autopilot/pull/16497

The `eval` syntax doesn't seem to work properly with the current syntax. Also, it is unnecessary to add a 1 to the mavlink ID therefore has been removed.

**Test data / coverage**
Tested in SITL Gazebo with the following command
```
roslaunch px4 multi_uav_mavros_sitl.launch
```

**Additional context**
- Fixes https://github.com/PX4/PX4-Autopilot/issues/16538
