### PR TITLE
boards: mro ctrl zero f7 fix default power module calibration

### DIFF
--- a/boards/mro/ctrl-zero-f7/src/board_config.h
+++ b/boards/mro/ctrl-zero-f7/src/board_config.h
@@ -96,8 +96,8 @@
 	 (1 << ADC_RSSI_IN_CHANNEL))
 
 /* Define Battery 1 Voltage Divider and A per V */
-#define BOARD_BATTERY_V_DIV         (18.1f)     /* measured with the provided PM board */
-#define BOARD_BATTERY_A_PER_V       (36.367515152f)
+#define BOARD_BATTERY1_V_DIV         (18.1f)     /* measured with the provided PM board */
+#define BOARD_BATTERY1_A_PER_V       (36.367515152f)
 
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 #define BOARD_ADC_OPEN_CIRCUIT_V     (5.6f)


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/16541

@pkocmoud can you verify the default values?

@matthewoots FYI