### PR TITLE
Ensure that the max/min pwm changes take effect

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -51,4 +51,4 @@ set MAV_TYPE 19
 
 set MIXER vtol_tailsitter_duo
 
-set PWM_OUT 1234
+set PWM_OUT 123456


### PR DESCRIPTION
**Describe problem solved by this pull request**
When I tested my two motor tailsitter aircraft, I found that the maximum output pwm value did not change (I have set pwm_max to 2100)

**Test data / coverage**
![Screenshot from 2021-01-13 16-25-02](https://user-images.githubusercontent.com/24932258/104425691-ee49ee80-55bb-11eb-8c67-4f4bfcad8c79.png)
