### PR TITLE
RTL_LAND_DELAY default to 0 and MIS_DIST_WPS to 5km for VTOL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/3011_hexarotor_x
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/3011_hexarotor_x
@@ -21,7 +21,6 @@ then
 	param set MPC_XY_VEL_P_ACC 3
 
 	param set RTL_DESCEND_ALT 10
-	param set RTL_LAND_DELAY 0
 
 	param set TRIG_INTERFACE 3
 	param set TRIG_MODE 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
@@ -19,7 +19,6 @@ then
 	param set MPC_XY_VEL_P_ACC 3
 
 	param set RTL_DESCEND_ALT 10
-	param set RTL_LAND_DELAY 0
 
 	param set TRIG_INTERFACE 3
 	param set TRIG_MODE 4

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -55,7 +55,6 @@ then
 	param set NAV_LOITER_RAD 80
 
 	param set RTL_DESCEND_ALT 10
-	param set RTL_LAND_DELAY 0
 	param set RTL_RETURN_ALT 30
 
 	param set SDLOG_DIRS_MAX 7

--- a/ROMFS/px4fmu_common/init.d/airframes/24001_dodeca_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/24001_dodeca_cox
@@ -42,7 +42,6 @@ then
 	param set PWM_RATE 400
 
 	param set RTL_DESCEND_ALT 10
-	param set RTL_LAND_DELAY 0
 	param set RTL_RETURN_ALT 30
 fi
 

--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -112,7 +112,6 @@ then
 
 	# RTL Parameters
 	param set RTL_DESCEND_ALT 5
-	param set RTL_LAND_DELAY 0
 	param set RTL_RETURN_ALT 5
 	param set RTL_CONE_ANG 45
 

--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -41,6 +41,7 @@ then
 	#
 	param set NAV_ACC_RAD 10
 
+	param set MIS_DIST_WPS 5000
 	param set MIS_LTRMIN_ALT 25
 	param set MIS_TAKEOFF_ALT 25
 

--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -13,7 +13,6 @@ then
 
 	param set RTL_RETURN_ALT 30
 	param set RTL_DESCEND_ALT 10
-	param set RTL_LAND_DELAY 0
 
 	param set PWM_MAX 1950
 	param set PWM_MIN 1075

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -18,6 +18,8 @@ then
 	param set EKF2_ARSP_THR 10
 	param set EKF2_FUSE_BETA 1
 
+	param set MIS_DIST_WPS 5000
+
 	param set MPC_ACC_HOR_MAX 2
 	param set MPC_TKO_SPEED 1
 	param set MPC_VEL_MANUAL 3

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -33,7 +33,6 @@ then
 	param set PWM_AUX_RATE 50
 	param set PWM_RATE 400
 
-	param set RTL_LAND_DELAY 0
 	param set RTL_TYPE 1
 
 	param set WV_EN 1

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -87,7 +87,7 @@ PARAM_DEFINE_FLOAT(RTL_DESCEND_ALT, 30);
  * @increment 0.5
  * @group Return Mode
  */
-PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, -1.0f);
+PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, 0.0f);
 
 /**
  * Horizontal radius from return point within which special rules for return mode apply.


### PR DESCRIPTION
**Describe problem solved by this pull request**
- find it annoying that RTL_LAND_DELAY is by default at -1 (do not land but loiter), even though for most applications that's not the default (only for FW usually). For FW, RTL_LAND_DELAY is already set to -1 in the defaults.
- the max distance between waypoints is too low with 900m for VTOLs


