### PR TITLE
Improve tuning of the SITL VTOL models

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -19,6 +19,7 @@ then
 	param set FW_P_LIM_MIN -15
 	param set FW_RR_FF 0.1
 	param set FW_RR_P 0.3
+	param set FW_THR_CRUISE 0.25
 	param set FW_THR_MAX 0.6
 	param set FW_THR_MIN 0.05
 	param set FW_T_ALT_TC 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -9,40 +9,45 @@
 
 if [ $AUTOCNF = yes ]
 then
-	param set FW_AIRSPD_MAX 25
-	param set FW_AIRSPD_MIN 14
-	param set FW_AIRSPD_TRIM 16
 	param set FW_L1_PERIOD 12
-
+	param set FW_MAN_P_MAX 30
+	param set FW_PR_FF 0.2
+	param set FW_PR_I 0.4
+	param set FW_PR_P 0.9
+	param set FW_PSP_OFF 2
+	param set FW_P_LIM_MAX 32
+	param set FW_P_LIM_MIN -15
 	param set FW_RR_FF 0.1
-	param set FW_RR_P 0.01
+	param set FW_RR_P 0.3
+	param set FW_THR_MAX 0.6
+	param set FW_THR_MIN 0.05
+	param set FW_T_ALT_TC 2
+	param set FW_T_CLMB_MAX 8
+	param set FW_T_HRATE_FF 0.5
+	param set FW_T_SINK_MAX 2.7
+	param set FW_T_SINK_MIN 2.2
+	param set FW_T_TAS_TC 2
 
 	param set MC_ROLLRATE_P 0.3
+	param set MC_YAW_P 1.6
 
-	param set MIS_LTRMIN_ALT 10
 	param set MIS_TAKEOFF_ALT 10
-	param set MIS_YAW_TMT 10
 
 	param set MPC_ACC_HOR_MAX 2
-	param set MPC_ACC_HOR_MAX 2
-	param set MPC_THR_HOVER 0.58
-	param set MPC_TKO_SPEED 1
 	param set MPC_XY_P 0.8
 	param set MPC_XY_VEL_P_ACC 3
 	param set MPC_XY_VEL_I_ACC 4
 	param set MPC_XY_VEL_D_ACC 0.1
-	param set MPC_Z_VEL_MAX_DN 1.5
 
 	param set NAV_ACC_RAD 5
 	param set NAV_LOITER_RAD 80
 
-	param set VT_F_TRANS_DUR 5
+	param set VT_FWD_THRUST_EN 4
 	param set VT_F_TRANS_THR 0.75
-	param set VT_ARSP_TRANS 16
 	param set VT_MOT_ID 1234
 	param set VT_FW_MOT_OFFID 1234
-	param set VT_TYPE 2
 	param set VT_B_TRANS_DUR 8
+	param set VT_TYPE 2
 
 fi
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -17,6 +17,7 @@ then
 	param set FW_P_LIM_MAX 32
 	param set FW_P_LIM_MIN -15
 	param set FW_RR_P 0.3
+	param set FW_THR_CRUISE 0.33
 	param set FW_THR_MAX 0.6
 	param set FW_THR_MIN 0.05
 	param set FW_T_ALT_TC 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -9,23 +9,30 @@
 
 if [ $AUTOCNF = yes ]
 then
-	param set FW_AIRSPD_MAX 25
-	param set FW_AIRSPD_MIN 14
-	param set FW_AIRSPD_TRIM 16
 	param set FW_L1_PERIOD 12
+	param set FW_MAN_P_MAX 30
+	param set FW_PR_I 0.2
+	param set FW_PR_P 0.3
+	param set FW_PSP_OFF 2
+	param set FW_P_LIM_MAX 32
+	param set FW_P_LIM_MIN -15
+	param set FW_RR_P 0.3
+	param set FW_THR_MAX 0.6
+	param set FW_THR_MIN 0.05
+	param set FW_T_ALT_TC 2
+	param set FW_T_CLMB_MAX 8
+	param set FW_T_HRATE_FF 0.5
+	param set FW_T_SINK_MAX 2.7
+	param set FW_T_SINK_MIN 2.2
+	param set FW_T_TAS_TC 2
 
 	param set MC_ROLLRATE_P 0.3
 
-	param set MIS_YAW_TMT 10
-
 	param set MPC_ACC_HOR_MAX 2
-	param set MPC_ACC_HOR_MAX 2
-	param set MPC_THR_MIN 0.3
-	param set MPC_XY_P 0.15
+	param set MPC_XY_P 0.8
+	param set MPC_XY_VEL_P_ACC 3
+	param set MPC_XY_VEL_I_ACC 4
 	param set MPC_XY_VEL_D_ACC 0.1
-	param set MPC_XY_VEL_P_ACC 1
-	param set MPC_Z_VEL_MAX_DN 1.5
-	param set MPC_Z_VEL_P_ACC 16
 
 	param set NAV_ACC_RAD 5
 	param set NAV_LOITER_RAD 80

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -14,9 +14,19 @@ then
 	param set FW_PR_FF 0.2
 	param set FW_PR_I 0.4
 	param set FW_PR_P 0.9
-	param set FW_PSP_OFF 3
+	param set FW_PSP_OFF 2
+	param set FW_P_LIM_MAX 32
+	param set FW_P_LIM_MIN -15
 	param set FW_RR_FF 0.1
 	param set FW_RR_P 0.3
+	param set FW_THR_MAX 0.6
+	param set FW_THR_MIN 0.05
+	param set FW_T_ALT_TC 2
+	param set FW_T_CLMB_MAX 8
+	param set FW_T_HRATE_FF 0.5
+	param set FW_T_SINK_MAX 2.7
+	param set FW_T_SINK_MIN 2.2
+	param set FW_T_TAS_TC 2
 
 	param set MC_YAW_P 1.6
 
@@ -28,10 +38,10 @@ then
 	param set MPC_XY_VEL_I_ACC 4
 	param set MPC_XY_VEL_D_ACC 0.1
 
-	param set NAV_LOITER_RAD 100
+	param set NAV_ACC_RAD 5
+	param set NAV_LOITER_RAD 80
 
 	param set VT_B_TRANS_DUR 8
-	param set VT_ELEV_MC_LOCK 0
 	param set VT_FWD_THRUST_EN 4
 	param set VT_MOT_ID 1234
 	param set VT_TILT_TRANS 0.6

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -19,6 +19,7 @@ then
 	param set FW_P_LIM_MIN -15
 	param set FW_RR_FF 0.1
 	param set FW_RR_P 0.3
+	param set FW_THR_CRUISE 0.38
 	param set FW_THR_MAX 0.6
 	param set FW_THR_MIN 0.05
 	param set FW_T_ALT_TC 2


### PR DESCRIPTION

**Describe problem solved by this pull request**
Improves tuning of Standard VTOL and removes unnecessary params from config (e.g. params that got reset to their default values or that are not important to set for STIL in my opinion.
Tuning improvements mainly focused around TECS tuning:
new:
![image](https://user-images.githubusercontent.com/26798987/102354514-f7d73b00-3faa-11eb-9093-ecdbdfbc6fe2.png)

old:
![image](https://user-images.githubusercontent.com/26798987/102355063-a3808b00-3fab-11eb-87ce-b7341ca7e201.png)


**Additional context**
FW fine-tuned with new TECS controller parameters (https://github.com/PX4/PX4-Autopilot/pull/16362). This amount of tuning would not be required to fly safely, but shows how 
