### PR TITLE
Following vehicle on startup in Gazebo SITL when using make targets

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -84,6 +84,8 @@ for file in "$@"; do
 	cp "$file" $rootfs/
 done
 
+export PX4_SIM_MODEL=${model}
+
 SIM_PID=0
 
 if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]; then
@@ -161,7 +163,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 			# gzserver needs to be running to avoid a race. Since the launch
 			# is putting it into the background we need to avoid it by backing off
 			sleep 3
-			nice -n 20 gzclient --verbose &
+			nice -n 20 gzclient --verbose --gui-client-plugin libgazebo_user_camera_plugin.so &
 			GUI_PID=$!
 		fi
 	else
@@ -203,9 +205,6 @@ else
 fi
 
 echo SITL COMMAND: $sitl_command
-
-export PX4_SIM_MODEL=${model}
-
 
 if [ "$debugger" == "lldb" ]; then
 	eval lldb -- $sitl_command


### PR DESCRIPTION
**Problem Description**
When running SITL Gazebo simulations, very often you end up clicking the follow target through the gazebo GUI, and this is cumbersome. To prevent this, gazebo provides you an interface to predefine your visual follow target in your `world` file. However, this makes it complicating if you want to use a single world file for multiple vehicles(as we do in PX4/PX4-sitl_gazebo) or if you have multiple vehicles in your world. 

**Solution**
This commit starts a `user_camera_plugin` which has been added in https://github.com/PX4/PX4-SITL_gazebo/pull/691

Since this interacts directly with the gui API, this would help on further optimizing the viewpoints in the future. (e.g. Simulating view point from the ground)

Note that the plugin is loaded on the `gzclient` side and not `gzserver`. Therefore this does not influence any setups that are in headless mode or running the simulation in a different way(e.g. not using `sitl_run.sh`)

**Alternatives**
We can also try templating `.world` files, but I see this blow up for maintenance since there will be too many configurations.

**Tests**
```
make px4_sitl gazebo_standard_vtol
```

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5248102/104814427-18471f00-580f-11eb-8dcf-c0d33c84f31d.gif)

**Additional Context**
- This depends on https://github.com/PX4/PX4-SITL_gazebo/pull/691
