### PR TITLE
battery_status: simplify update api

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -268,8 +268,6 @@ Syslink::open_serial(const char *dev)
 	return fd;
 }
 
-
-
 int
 Syslink::task_main_trampoline(int argc, char *argv[])
 {
@@ -286,11 +284,6 @@ Syslink::task_main()
 	_memory = new SyslinkMemory(this);
 	_memory->init();
 
-	_battery.reset();
-
-
-	//	int ret;
-
 	/* Open serial port */
 	const char *dev = "/dev/ttyS2";
 	_fd = open_serial(dev);
@@ -299,7 +292,6 @@ Syslink::task_main()
 		err(1, "can't open %s", dev);
 		return;
 	}
-
 
 	/* Set non-blocking */
 	/*
@@ -408,9 +400,7 @@ Syslink::handle_message(syslink_message_t *msg)
 		memcpy(&vbat, &msg->data[1], sizeof(float));
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
-		_battery.updateBatteryStatus(t, vbat, -1, true,
-					     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0);
-
+		_battery.updateBatteryStatus(vbat);
 
 		// Update battery charge state
 		if (charging) {

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -9,13 +9,11 @@ float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
 int32 cell_count			# Number of cells
-bool connected				# Whether or not a battery is connected, based on a voltage threshold
 
 uint8 BATTERY_SOURCE_POWER_MODULE = 0
 uint8 BATTERY_SOURCE_EXTERNAL = 1
 uint8 BATTERY_SOURCE_ESCS = 2
 uint8 source				# Battery source
-uint8 priority				# Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity				# actual capacity of the battery
 uint16 cycle_count			# number of discharge cycles the battery has experienced
 uint16 run_time_to_empty	# predicted remaining battery capacity based on the present rate of discharge in min

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -106,8 +106,6 @@ void BATT_SMBUS::RunImpl()
 	// Set time of reading.
 	new_report.timestamp = hrt_absolute_time();
 
-	new_report.connected = true;
-
 	ret |= _interface->read_word(BATT_SMBUS_VOLTAGE, result);
 
 	ret |= get_cell_voltages();

--- a/src/drivers/osd/atxxxx/atxxxx.cpp
+++ b/src/drivers/osd/atxxxx/atxxxx.cpp
@@ -321,19 +321,14 @@ int
 OSDatxxxx::update_topics()
 {
 	/* update battery subscription */
-	if (_battery_sub.updated()) {
-		battery_status_s battery{};
-		_battery_sub.copy(&battery);
+	battery_status_s battery{};
 
-		if (battery.connected) {
-			_battery_voltage_filtered_v = battery.voltage_filtered_v;
-			_battery_discharge_mah = battery.discharged_mah;
-			_battery_valid = true;
-
-		} else {
-			_battery_valid = false;
-		}
+	if (_battery_sub.copy(&battery)) {
+		_battery_voltage_filtered_v = battery.voltage_filtered_v;
+		_battery_discharge_mah = battery.discharged_mah;
 	}
+
+	_battery_valid = (hrt_elapsed_time(&battery.timestamp) < 1_s);
 
 	/* update vehicle local position subscription */
 	if (_local_position_sub.updated()) {

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -47,7 +47,6 @@
 #include <drivers/drv_hrt.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/parameter_update.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
@@ -190,9 +189,7 @@ private:
 	perf_counter_t 		_collection_errors;
 	perf_counter_t 		_measure_errors;
 
-	int16_t           _bus_voltage{0};
 	int16_t           _power{0};
-	int16_t           _current{0};
 	int16_t           _shunt{0};
 	int16_t           _cal{0};
 	bool              _mode_triggered{false};
@@ -203,10 +200,8 @@ private:
 	float             _current_lsb{_max_current / DN_MAX};
 	float             _power_lsb{25.0f * _current_lsb};
 
-	actuator_controls_s  _actuator_controls{};
-
 	Battery 		  _battery;
-	uORB::Subscription  _actuators_sub{ORB_ID(actuator_controls_0)};
+
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	int read(uint8_t address, int16_t &data);

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -70,18 +70,6 @@ VOXLPM::init()
 	_initialized = false;
 	int ret = PX4_ERROR;
 
-	if (_ch_type == VOXLPM_CH_TYPE_VBATT) {
-		_battery.updateBatteryStatus(
-			hrt_absolute_time(),
-			0.0,
-			0.0,
-			false,
-			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-			0,
-			0.0
-		);
-	}
-
 	/* do I2C init, it will probe the bus for two possible configurations, LTC2946 or INA231 */
 	if (I2C::init() != OK) {
 		return ret;
@@ -345,17 +333,8 @@ VOXLPM::measure()
 
 	if (ret == PX4_OK) {
 		switch (_ch_type) {
-		case VOXLPM_CH_TYPE_VBATT: {
-				_actuators_sub.copy(&_actuator_controls);
-
-				_battery.updateBatteryStatus(tnow,
-							     _voltage,
-							     _amperage,
-							     true,
-							     battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-							     0,
-							     _actuator_controls.control[actuator_controls_s::INDEX_THROTTLE]);
-			}
+		case VOXLPM_CH_TYPE_VBATT:
+			_battery.updateBatteryStatus(_voltage, _amperage);
 
 		// fallthrough
 		case VOXLPM_CH_TYPE_P5VDC:
@@ -374,22 +353,6 @@ VOXLPM::measure()
 
 	} else {
 		perf_count(_comms_errors);
-
-		switch (_ch_type) {
-		case VOXLPM_CH_TYPE_VBATT: {
-				_battery.updateBatteryStatus(tnow,
-							     0.0,
-							     0.0,
-							     true,
-							     battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-							     0,
-							     0.0);
-			}
-			break;
-
-		default:
-			break;
-		}
 	}
 
 	perf_end(_sample_perf);

--- a/src/drivers/power_monitor/voxlpm/voxlpm.hpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.hpp
@@ -90,7 +90,6 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/power_monitor.h>
 #include <uORB/topics/parameter_update.h>
@@ -268,8 +267,6 @@ private:
 	int16_t			_cal{0};
 
 	Battery 		_battery;
-	uORB::Subscription	_actuators_sub{ORB_ID(actuator_controls_0)};
-	actuator_controls_s	_actuator_controls{};
 
 	uint8_t 		read_reg(uint8_t addr);
 	int 			read_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len);

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -78,7 +78,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	// battery.scale = msg.; // Power scaling factor, >= 1, or -1 if unknown
 	battery.temperature = msg.temperature + CONSTANTS_ABSOLUTE_NULL_CELSIUS; // Kelvin to Celcius
 	// battery.cell_count = msg.;
-	battery.connected = true;
+
 	battery.source = msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_IN_USE;
 	// battery.priority = msg.;
 	battery.capacity = msg.full_charge_capacity_wh;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -54,6 +54,8 @@
 #include <lib/parameters/param.h>
 #include <lib/ecl/AlphaFilter/AlphaFilter.hpp>
 #include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
 
 /**
@@ -93,13 +95,12 @@ public:
 	 *
 	 * @param voltage_raw: Battery voltage, in Volts
 	 * @param current_raw: Battery current, in Amps
-	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
 	 * @param source: Source type in relation to BAT%d_SOURCE param.
-	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
-	 * @param throttle_normalized: Throttle of the vehicle, between 0 and 1
 	 */
-	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
-				 int source, int priority, float throttle_normalized);
+	void updateBatteryStatus(float voltage_v, float current_a = -1.f,
+				 int source = battery_status_s::BATTERY_SOURCE_POWER_MODULE);
+
+	bool advertise() { return _battery_status_pub.advertise(); }
 
 protected:
 	struct {
@@ -148,8 +149,6 @@ protected:
 		int source_old;
 	} _params{};
 
-	battery_status_s _battery_status{};
-
 	const int _index;
 
 	bool _first_parameter_update{true};
@@ -197,12 +196,14 @@ protected:
 private:
 	void sumDischarged(const hrt_abstime &timestamp, float current_a);
 	void estimateRemaining(const float voltage_v, const float current_a, const float throttle);
-	void determineWarning(bool connected);
 	void computeScale();
 
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
 	bool _battery_initialized{false};
+
+	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
+
 	AlphaFilter<float> _voltage_filter_v;
 	AlphaFilter<float> _current_filter_a;
 	AlphaFilter<float> _throttle_filter;
@@ -211,6 +212,5 @@ private:
 	float _remaining_voltage{-1.f};		///< normalized battery charge level remaining based on voltage
 	float _remaining{-1.f};			///< normalized battery charge level, selected based on config param
 	float _scale{1.f};
-	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 };

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -74,8 +74,7 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 }
 
 void
-AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				      int source, int priority, float throttle_normalized)
+AnalogBattery::updateBatteryStatusADC(float voltage_raw, float current_raw)
 {
 	float voltage_v = voltage_raw * _analog_params.v_div;
 	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
@@ -83,9 +82,9 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 	bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
 			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
-
-	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected,
-				     source, priority, throttle_normalized);
+	if (connected) {
+		Battery::updateBatteryStatus(voltage_v, current_a);
+	}
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -46,13 +46,8 @@ public:
 	 *
 	 * @param voltage_raw Battery voltage read from ADC, volts
 	 * @param current_raw Voltage of current sense resistor, volts
-	 * @param timestamp Time at which the ADC was read (use hrt_absolute_time())
-	 * @param source The source as defined by param BAT%d_SOURCE
-	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
-	 * @param throttle_normalized Throttle of the vehicle, between 0 and 1
 	 */
-	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				    int source, int priority, float throttle_normalized);
+	void updateBatteryStatusADC(float voltage_raw, float current_raw);
 
 	/**
 	 * Whether the ADC channel for the voltage of this battery is valid.

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -219,18 +219,7 @@ BatteryStatus::adc_poll()
 		}
 
 		for (int b = 0; b < BOARD_NUMBER_BRICKS; b++) {
-
-			actuator_controls_s ctrl{};
-			_actuator_ctrl_0_sub.copy(&ctrl);
-
-			_analogBatteries[b]->updateBatteryStatusADC(
-				hrt_absolute_time(),
-				bat_voltage_adc_readings[b],
-				bat_current_adc_readings[b],
-				battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-				b,
-				ctrl.control[actuator_controls_s::INDEX_THROTTLE]
-			);
+			_analogBatteries[b]->updateBatteryStatusADC(bat_voltage_adc_readings[b], bat_current_adc_readings[b]);
 		}
 	}
 }

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -99,20 +99,7 @@ EscBattery::Run()
 
 		average_voltage_v /= esc_status.esc_count;
 
-		const bool connected = true;
-		const int priority = 0;
-
-		actuator_controls_s ctrl;
-		_actuator_ctrl_0_sub.copy(&ctrl);
-
-		_battery.updateBatteryStatus(
-			esc_status.timestamp,
-			average_voltage_v,
-			total_current_a,
-			connected,
-			battery_status_s::BATTERY_SOURCE_ESCS,
-			priority,
-			ctrl.control[actuator_controls_s::INDEX_THROTTLE]);
+		_battery.updateBatteryStatus(average_voltage_v, total_current_a, battery_status_s::BATTERY_SOURCE_ESCS);
 	}
 }
 

--- a/src/modules/esc_battery/EscBattery.hpp
+++ b/src/modules/esc_battery/EscBattery.hpp
@@ -44,7 +44,6 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/actuator_controls.h>
 #include <battery/battery.h>
 
 using namespace time_literals;
@@ -72,7 +71,6 @@ private:
 	void parameters_updated();
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};
 	uORB::SubscriptionCallbackWorkItem _esc_status_sub{this, ORB_ID(esc_status)};
 
 	static constexpr uint32_t ESC_BATTERY_INTERVAL_US = 20_ms; // assume higher frequency esc feedback than 50Hz

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1723,7 +1723,6 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
 	battery_status.discharged_mah = (float)battery_mavlink.current_consumed;
 	battery_status.cell_count = cell_count;
-	battery_status.connected = true;
 
 	// Set the battery warning based on remaining charge.
 	//  Note: Smallest values must come first in evaluation.

--- a/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
+++ b/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
@@ -274,7 +274,6 @@ private:
 
 			if (_batteries[i].subscription.update(&battery)) {
 				updated = true;
-				_batteries[i].connected = battery.connected;
 
 				if (battery.warning > battery_status_s::BATTERY_WARNING_LOW) {
 					msg->failure_flags |= HL_FAILURE_FLAG_BATTERY;
@@ -535,7 +534,7 @@ private:
 
 		for (int i = 0; i < battery_status_s::MAX_INSTANCES; i++) {
 			if (_batteries[i].subscription.update(&battery)) {
-				_batteries[i].connected = battery.connected;
+				_batteries[i].connected = (hrt_elapsed_time(&battery.timestamp) < 2_s);
 				_batteries[i].analyzer.add_value(battery.remaining, _update_rate_filtered);
 			}
 		}

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -99,8 +99,7 @@ void BatterySimulator::Run()
 	float vbatt = math::gradual(_battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 	vbatt *= _battery.cell_count();
 
-	const float throttle = 0.0f; // simulate no throttle compensation to make the estimate predictable
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, throttle);
+	_battery.updateBatteryStatus(vbatt, ibatt);
 
 	perf_end(_loop_perf);
 }


### PR DESCRIPTION
 - move normalized throttle update into library
     - smart battery or power module drivers shouldn't be directly accessing vehicle throttle
 - add default values for power module source and current (-1 no current)
 - remove unneeded priority and source fields
 - only publish if connected rather than multiple instances of empty `battery_status` at 100 Hz
 - ESC calibration and logger handle multiple battery instances