### PR TITLE
drivers/gps: limit to ublox only on flash constrained targets

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -61,9 +61,11 @@
 #include <uORB/topics/gps_inject_data.h>
 #include <uORB/topics/sensor_gps.h>
 
-#include "devices/src/ashtech.h"
-#include "devices/src/emlid_reach.h"
-#include "devices/src/mtk.h"
+#ifndef CONSTRAINED_FLASH
+# include "devices/src/ashtech.h"
+# include "devices/src/emlid_reach.h"
+# include "devices/src/mtk.h"
+#endif // CONSTRAINED_FLASH
 #include "devices/src/ubx.h"
 
 #ifdef __PX4_LINUX
@@ -288,12 +290,14 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, GPSHelper::Interface interfac
 
 		switch (protocol) {
 		case 1: _mode = GPS_DRIVER_MODE_UBX; break;
+#ifndef CONSTRAINED_FLASH
 
 		case 2: _mode = GPS_DRIVER_MODE_MTK; break;
 
 		case 3: _mode = GPS_DRIVER_MODE_ASHTECH; break;
 
 		case 4: _mode = GPS_DRIVER_MODE_EMLIDREACH; break;
+#endif // CONSTRAINED_FLASH
 		}
 	}
 
@@ -762,6 +766,7 @@ GPS::run()
 				_helper = new GPSDriverUBX(_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info,
 							   gps_ubx_dynmodel, heading_offset, ubx_mode);
 				break;
+#ifndef CONSTRAINED_FLASH
 
 			case GPS_DRIVER_MODE_MTK:
 				_helper = new GPSDriverMTK(&GPS::callback, this, &_report_gps_pos);
@@ -774,6 +779,7 @@ GPS::run()
 			case GPS_DRIVER_MODE_EMLIDREACH:
 				_helper = new GPSDriverEmlidReach(&GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
 				break;
+#endif // CONSTRAINED_FLASH
 
 			default:
 				break;
@@ -867,6 +873,7 @@ GPS::run()
 			if (_mode_auto) {
 				switch (_mode) {
 				case GPS_DRIVER_MODE_UBX:
+#ifndef CONSTRAINED_FLASH
 					_mode = GPS_DRIVER_MODE_MTK;
 					break;
 
@@ -879,6 +886,7 @@ GPS::run()
 					break;
 
 				case GPS_DRIVER_MODE_EMLIDREACH:
+#endif // CONSTRAINED_FLASH
 					_mode = GPS_DRIVER_MODE_UBX;
 					px4_usleep(500000); // tried all possible drivers. Wait a bit before next round
 					break;
@@ -928,6 +936,7 @@ GPS::print_status()
 		case GPS_DRIVER_MODE_UBX:
 			PX4_INFO("protocol: UBX");
 			break;
+#ifndef CONSTRAINED_FLASH
 
 		case GPS_DRIVER_MODE_MTK:
 			PX4_INFO("protocol: MTK");
@@ -940,6 +949,7 @@ GPS::print_status()
 		case GPS_DRIVER_MODE_EMLIDREACH:
 			PX4_INFO("protocol: EMLIDREACH");
 			break;
+#endif // CONSTRAINED_FLASH
 
 		default:
 			break;
@@ -1247,7 +1257,7 @@ GPS *GPS::instantiate(int argc, char *argv[], Instance instance)
 		case 'p':
 			if (!strcmp(myoptarg, "ubx")) {
 				mode = GPS_DRIVER_MODE_UBX;
-
+#ifndef CONSTRAINED_FLASH
 			} else if (!strcmp(myoptarg, "mtk")) {
 				mode = GPS_DRIVER_MODE_MTK;
 
@@ -1256,7 +1266,7 @@ GPS *GPS::instantiate(int argc, char *argv[], Instance instance)
 
 			} else if (!strcmp(myoptarg, "eml")) {
 				mode = GPS_DRIVER_MODE_EMLIDREACH;
-
+#endif // CONSTRAINED_FLASH
 			} else {
 				PX4_ERR("unknown protocol: %s", myoptarg);
 				error_flag = true;


### PR DESCRIPTION
I'm open to suggestions for alternative mechanisms with additional granularity. I also considered adding defines to enable each protocol with cmake options to enable, but I suspect no one would actually use them.

Saves 10.3 kB of flash on constrained boards.

``` Console
     VM SIZE    
 -------------- 
  +0.0%      +8    g_cromfs_image
  -9.1%      -2    GPSHelper::setBaudrate(int)
 -11.1%      -2    GPSHelper::write(void const*, int)
  -1.1%      -4    GPSDriverUBX::activateRTCMOutput()
  -3.4%      -4    GPSHelper::storeUpdateRates()
  [DEL]     -14    GPSDriverMTK::~GPSDriverMTK()
  [DEL]     -16    GPSDriverEmlidReach::~GPSDriverEmlidReach()
  [DEL]     -20    baudrates_to_try.9701
  -6.7%     -24    GPS::GPS(char const*, gps_driver_mode_t, GPSHelper::Interface, bool, bool, GPS::Instance, unsigned int)
  [DEL]     -24    GPSDriverMTK::addByteToChecksum(unsigned char)
  -8.0%     -32    GPS::print_status()
  [DEL]     -32    GPSDriverMTK::GPSDriverMTK(int (*)(GPSCallbackType, void*, int, void*), void*, sensor_gps_s*)
  [DEL]     -32    vtable for GPSDriverAshtech
  [DEL]     -32    vtable for GPSDriverEmlidReach
  [DEL]     -32    vtable for GPSDriverMTK
  [DEL]     -38    GPSDriverAshtech::writeAckedCommand(void const*, int, unsigned int)
  [DEL]     -40    GPSDriverEmlidReach::testConnection()
  [DEL]     -48    GPSDriverAshtech::receiveWait(unsigned int)
  [DEL]     -54    GPSDriverAshtech::~GPSDriverAshtech()
  [DEL]     -56    GPSDriverAshtech::sendSurveyInStatusUpdate(bool, bool, double, double, float)
  [DEL]     -60    GPSDriverAshtech::decodeInit()
 -11.6%     -64    GPS::instantiate(int, char**, GPS::Instance)
  [DEL]     -74    GPSDriverAshtech::waitForReply(GPSDriverAshtech::NMEACommand, unsigned int)
  [DEL]     -76    GPSDriverAshtech::activateRTCMOutput()
  [DEL]     -84    GPSDriverEmlidReach::GPSDriverEmlidReach(int (*)(GPSCallbackType, void*, int, void*), void*, sensor_gps_s*, satellite_info_s*)
  [DEL]     -92    GPSDriverAshtech::GPSDriverAshtech(int (*)(GPSCallbackType, void*, int, void*), void*, sensor_gps_s*, satellite_info_s*, float)
  [DEL]    -128    GPSDriverAshtech::receive(unsigned int)
  [DEL]    -128    GPSDriverEmlidReach::configure(unsigned int&, GPSHelper::GPSConfig const&)
  [DEL]    -128    GPSDriverMTK::receive(unsigned int)
 -11.6%    -132    GPS::run()
  [DEL]    -140    GPSDriverEmlidReach::receive(unsigned int)
  [DEL]    -140    GPSDriverMTK::parseChar(unsigned char, gps_mtk_packet_t&)
  [DEL]    -216    GPSDriverMTK::configure(unsigned int&, GPSHelper::GPSConfig const&)
  [DEL]    -272    GPSDriverEmlidReach::erbParseChar(unsigned char)
  [DEL]    -292    GPSDriverAshtech::parseChar(unsigned char)
  [DEL]    -476    GPSDriverMTK::handleMessage(gps_mtk_packet_t&)
  [DEL]    -480    GPSDriverAshtech::activateCorrectionOutput()
  [DEL]    -664    GPSDriverEmlidReach::handleErbSentence()
  [DEL]    -768    GPSDriverAshtech::configure(unsigned int&, GPSHelper::GPSConfig const&)
  -1.5% -1.19Ki    [section .text]
  [DEL] -4.27Ki    GPSDriverAshtech::handleMessage(int)
  -1.0% -10.3Ki    TOTAL
```