### PR TITLE
flashfs: fix alignment ambiguity

### DIFF
--- a/src/lib/parameters/flashparams/CMakeLists.txt
+++ b/src/lib/parameters/flashparams/CMakeLists.txt
@@ -42,7 +42,6 @@ target_compile_options(flashparams
 	PRIVATE
 		-Wno-sign-compare # TODO: fix this
 		-Wno-cast-align # TODO: fix and enable
-		-Wno-address-of-packed-member # TODO: fix this
 )
 
 target_link_libraries(flashparams PRIVATE nuttx_arch)

--- a/src/lib/parameters/flashparams/flashfs.c
+++ b/src/lib/parameters/flashparams/flashfs.c
@@ -86,11 +86,10 @@ typedef enum  flash_flags_t {
 } flash_flags_t;
 
 
-/* File flash_entry_header_t will be sizeof(h_magic_t) aligned
+/* The struct flash_entry_header_t will be sizeof(uint32_t) aligned
  * The Size will be the actual length of the header plus the data
  * and any padding needed to have the size be an even multiple of
- * sizeof(h_magic_t)
- *  The
+ * sizeof(uint32_t)
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
@@ -102,7 +101,7 @@ typedef begin_packed_struct struct flash_entry_header_t {
                                                * Will result the offset of the next active file or
                                                * free space. */
 	flash_file_token_t   file_token;      /* file token type - essentially the name/type */
-} end_packed_struct flash_entry_header_t;
+} end_packed_struct flash_entry_header_t __attribute__((aligned(sizeof(uint32_t))));
 #pragma GCC diagnostic pop
 
 /****************************************************************************


### PR DESCRIPTION
**Describe problem solved by this pull request**
Follow up to:
https://github.com/PX4/PX4-Autopilot/pull/12319
https://github.com/Auterion/Firmware/pull/9

When we started using ARM GCC 9+ we got valid warnings about the ambiguity of the allignment of `flash_entry_header_t`.
We put compile flags to ignore the warnings and now we can fix it.
Thanks to @Ole2mail and @yuhaim for the suggestions.

**Describe your solution**
A combination of what was suggested telling the compiler explicitly that the struct is `uint32_t` alligned.

**Test data / coverage**
Compiles without the warning since the ambiguity is gone.

**Additional context**
https://github.com/PX4/PX4-Autopilot/pull/14159 and https://github.com/PX4/PX4-Autopilot/pull/14159/files#diff-df21f531032831043352bb121b8c0f8af21930005a79f3a69244b769677c0204R45
