### PR TITLE
vscode: do not enable "smart" case search in workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,7 +128,6 @@
                 "${workspaceFolder}/build": true
         },
         "search.showLineNumbers": true,
-        "search.smartCase": true,
         "telemetry.enableTelemetry": false,
         "terminal.integrated.copyOnSelection": true,
         "terminal.integrated.rightClickBehavior": "paste",


### PR DESCRIPTION
**Describe problem solved by this pull request**
This option comes down to user preference and I don't see a particular reason to change this based on the workspace. I found it confusing to have this non-default behavior just for PX4 editing.

@dagar Would it be ok for you to set this in the user settings?

**Test data / coverage**
Removing it solves my confusion with the search functionality.
