### PR TITLE
mc_pos_control: only update constraints if topic updated

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -249,12 +249,14 @@ void MulticopterPositionControl::Run()
 			_control.setState(_states);
 
 			vehicle_constraints_s constraints;
-			_vehicle_constraints_sub.update(&constraints);
-			_control.setConstraints(constraints);
-			_control.setThrustLimits(constraints.minimum_thrust, _param_mpc_thr_max.get());
 
-			if (constraints.reset_integral) {
-				_control.resetIntegral();
+			if (_vehicle_constraints_sub.update(&constraints)) {
+				_control.setConstraints(constraints);
+				_control.setThrustLimits(constraints.minimum_thrust, _param_mpc_thr_max.get());
+
+				if (constraints.reset_integral) {
+					_control.resetIntegral();
+				}
 			}
 
 			// Run position control
@@ -269,8 +271,12 @@ void MulticopterPositionControl::Run()
 				}
 
 				failsafe(time_stamp_now, setpoint, _states, !was_in_failsafe);
+
 				_control.setInputSetpoint(setpoint);
+
 				constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, false, {}};
+				_control.setConstraints(constraints);
+
 				_control.update(dt);
 			}
 


### PR DESCRIPTION
It's not really a bug in current usage, but we should be sure to only update the constraints if the topic has updated.

@MaEtUgR can you verify the desired behavior in the failsafe condition?
