### PR TITLE
Control Zero F7 - Fix for voltage/current sensing

### DIFF
--- a/boards/mro/ctrl-zero-f7/src/board_config.h
+++ b/boards/mro/ctrl-zero-f7/src/board_config.h
@@ -175,7 +175,7 @@
 #define BOARD_ADC_USB_CONNECTED	       (px4_arch_gpioread(GPIO_OTGFS_VBUS))
 #define BOARD_ADC_USB_VALID            BOARD_ADC_USB_CONNECTED
 #define BOARD_ADC_SERVO_VALID          (1)	/* never powers off the Servo rail */
-#define BOARD_ADC_BRICK_VALID.         (px4_arch_gpioread(GPIO_nVDD_BRICK1_VALID))
+#define BOARD_ADC_BRICK_VALID          (px4_arch_gpioread(GPIO_nVDD_BRICK1_VALID))
 
 #define BOARD_HAS_PWM  DIRECT_PWM_OUTPUT_CHANNELS
 

--- a/boards/mro/ctrl-zero-f7/src/board_config.h
+++ b/boards/mro/ctrl-zero-f7/src/board_config.h
@@ -175,7 +175,7 @@
 #define BOARD_ADC_USB_CONNECTED	       (px4_arch_gpioread(GPIO_OTGFS_VBUS))
 #define BOARD_ADC_USB_VALID            BOARD_ADC_USB_CONNECTED
 #define BOARD_ADC_SERVO_VALID          (1)	/* never powers off the Servo rail */
-#define BOARD_ADC_BRICK_VALID          (!px4_arch_gpioread(GPIO_nVDD_BRICK1_VALID))
+#define BOARD_ADC_BRICK_VALID.         (px4_arch_gpioread(GPIO_nVDD_BRICK1_VALID))
 
 #define BOARD_HAS_PWM  DIRECT_PWM_OUTPUT_CHANNELS
 

--- a/boards/mro/ctrl-zero-f7/src/board_config.h
+++ b/boards/mro/ctrl-zero-f7/src/board_config.h
@@ -112,7 +112,7 @@
 /* Power supply control and monitoring GPIOs */
 #define GPIO_nPOWER_IN_A                /* PB5 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN5)
 
-#define GPIO_nVDD_BRICK1_VALID          GPIO_nPOWER_IN_A /* Brick 1 Is Chosen */
+#define GPIO_VDD_BRICK1_VALID          GPIO_nPOWER_IN_A /* Brick 1 Is Chosen */
 #define BOARD_NUMBER_BRICKS             1
 
 #define GPIO_VDD_3V3_SPEKTRUM_POWER_EN  /* PE4  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)

--- a/boards/mro/ctrl-zero-f7/src/board_config.h
+++ b/boards/mro/ctrl-zero-f7/src/board_config.h
@@ -175,7 +175,7 @@
 #define BOARD_ADC_USB_CONNECTED	       (px4_arch_gpioread(GPIO_OTGFS_VBUS))
 #define BOARD_ADC_USB_VALID            BOARD_ADC_USB_CONNECTED
 #define BOARD_ADC_SERVO_VALID          (1)	/* never powers off the Servo rail */
-#define BOARD_ADC_BRICK_VALID          (px4_arch_gpioread(GPIO_nVDD_BRICK1_VALID))
+#define BOARD_ADC_BRICK_VALID          (px4_arch_gpioread(GPIO_VDD_BRICK1_VALID))
 
 #define BOARD_HAS_PWM  DIRECT_PWM_OUTPUT_CHANNELS
 


### PR DESCRIPTION
Fix to enable standard current/voltage sensor to display voltage and current readings on Control Zero F7.



