### PR TITLE
Add BMI090L IMU Support

### DIFF
--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
@@ -99,7 +99,13 @@ int BMI088_Accelerometer::probe()
 
 	const uint8_t ACC_CHIP_ID = RegisterRead(Register::ACC_CHIP_ID);
 
-	if (ACC_CHIP_ID != ID) {
+	if (ACC_CHIP_ID == ID_088) {
+		DEVICE_DEBUG("BMI088 Accel");
+
+	} else if (ACC_CHIP_ID == ID_090L) {
+		DEVICE_DEBUG("BMI090L Accel");
+
+	} else {
 		DEVICE_DEBUG("unexpected ACC_CHIP_ID 0x%02x", ACC_CHIP_ID);
 		return PX4_ERROR;
 	}
@@ -122,7 +128,7 @@ void BMI088_Accelerometer::RunImpl()
 		break;
 
 	case STATE::WAIT_FOR_RESET:
-		if (RegisterRead(Register::ACC_CHIP_ID) == ID) {
+		if ((RegisterRead(Register::ACC_CHIP_ID) == ID_088) || (RegisterRead(Register::ACC_CHIP_ID) == ID_090L)) {
 			// ACC_PWR_CONF: Power on sensor
 			RegisterWrite(Register::ACC_PWR_CONF, 0);
 

--- a/src/drivers/imu/bosch/bmi088/Bosch_BMI088_Accelerometer_Registers.hpp
+++ b/src/drivers/imu/bosch/bmi088/Bosch_BMI088_Accelerometer_Registers.hpp
@@ -49,7 +49,8 @@ static constexpr uint8_t Bit7 = (1 << 7);
 static constexpr uint32_t SPI_SPEED = 10 * 1000 * 1000; // 10MHz SPI serial interface
 static constexpr uint8_t DIR_READ = 0x80;
 
-static constexpr uint8_t ID = 0x1E;
+static constexpr uint8_t ID_088 = 0x1E;
+static constexpr uint8_t ID_090L = 0x1A;
 
 enum class Register : uint8_t {
 	ACC_CHIP_ID        = 0x00,


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds support for the Bosch BMI090L IMU. The BMI090L is the long life industrial version of the BMI088. Comparing the datasheets and register sets, only the accelerometer ID value is different.

https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi088.html
https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi090l/

**Describe your solution**
This solution adds a check for the BMI090L accelerometer ID to the BMI088 driver.

**Describe possible alternatives**
An independent BMI090L driver could be created but might pose issues for manufacturers who want to use the BMI090L as an alternate for the BMI088. Since the gyro ID is exactly the same in both devices, you can't differentiate between them without checking which accelerometer ID is present.

**Test data / coverage**
This PR was tested on a custom FMUV5 drone.

Here is a basic first flight. More extensive logs to come.
https://review.px4.io/plot_app?log=8b404641-6ab4-4cba-955b-ec7bce795efb

**Additional context**
I ended up using a BMI090L as an alternate for the BMI088 that I designed in. The BMI088 is out of stock currently until at least the end of March. The BMI090L is in stock currently.
