### PR TITLE
Control Zero F7 - RSSI Fix - SBUS Only/PPM Partial

### DIFF
--- a/boards/mro/ctrl-zero-f7/src/board_config.h
+++ b/boards/mro/ctrl-zero-f7/src/board_config.h
@@ -87,13 +87,13 @@
 #define ADC_BATTERY_VOLTAGE_CHANNEL        /* PA2 */  ADC1_CH(2)
 #define ADC_BATTERY_CURRENT_CHANNEL        /* PA3 */  ADC1_CH(3)
 #define ADC_SCALED_V5_CHANNEL              /* PA4 */  ADC1_CH(4)
-#define ADC_RSSI_IN_CHANNEL                /* PC1 */  ADC1_CH(11)
+#define ADC_RC_RSSI_CHANNEL                /* PC1 */  ADC1_CH(11)
 
 #define ADC_CHANNELS \
 	((1 << ADC_BATTERY_VOLTAGE_CHANNEL)       | \
 	 (1 << ADC_BATTERY_CURRENT_CHANNEL)       | \
 	 (1 << ADC_SCALED_V5_CHANNEL)             | \
-	 (1 << ADC_RSSI_IN_CHANNEL))
+	 (1 << ADC_RC_RSSI_CHANNEL))
 
 /* Define Battery 1 Voltage Divider and A per V */
 #define BOARD_BATTERY1_V_DIV         (18.1f)     /* measured with the provided PM board */


### PR DESCRIPTION
This fixes RSSI for the Control Zero F7 but I have noticed that while this works perfectly for SBUS receivers, for PPM receivers it does not decrease the RSSI visual value in QGC when removing the RC transmitter connection.

When a PPM receiver is connected and the connection is lost the autopilot goes into RC Scan State Mode (in the RC Update Module) to determine what is connected (even though the receiver is already connected).

The main issue with this is that PPM receivers don't go into RC Failsafe but I don't think it is an issue with this autopilot. It looks to be an issue with the RC Update Module and how it is handled at the module level for non I/O coprocessor autopilots. 

Tested with an X8R (SBUS) and a Dragonlink (PPM) as well as a Dragonlink set to SBUS as the output. SBUS worked as intended. See screenshots below.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
