### PR TITLE
UAVCAN Node Register/Parameter Server

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -73,9 +73,9 @@ static constexpr wq_config_t INS1{"wq:INS1", 6000, -15};
 static constexpr wq_config_t INS2{"wq:INS2", 6000, -16};
 static constexpr wq_config_t INS3{"wq:INS3", 6000, -17};
 
-static constexpr wq_config_t uavcan{"wq:uavcan", 4000, -16};
+static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
 
-static constexpr wq_config_t uavcan{"wq:uavcan", 3000, -19};
+static constexpr wq_config_t uavcan{"wq:uavcan", 4000, -19};
 
 static constexpr wq_config_t UART0{"wq:UART0", 1400, -21};
 static constexpr wq_config_t UART1{"wq:UART1", 1400, -22};

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -73,7 +73,7 @@ static constexpr wq_config_t INS1{"wq:INS1", 6000, -15};
 static constexpr wq_config_t INS2{"wq:INS2", 6000, -16};
 static constexpr wq_config_t INS3{"wq:INS3", 6000, -17};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
+static constexpr wq_config_t uavcan{"wq:uavcan", 4000, -16};
 
 static constexpr wq_config_t uavcan{"wq:uavcan", 3000, -19};
 

--- a/src/drivers/uavcannode/CMakeLists.txt
+++ b/src/drivers/uavcannode/CMakeLists.txt
@@ -124,6 +124,8 @@ px4_add_module(
 		uavcan_driver.hpp
 		UavcanNode.cpp
 		UavcanNode.hpp
+		UavcanNodeParamManager.hpp
+		UavcanNodeParamManager.cpp
 	DEPENDS
 		px4_uavcan_dsdlc
 

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -82,6 +82,7 @@ UavcanNode::UavcanNode(uavcan::ICanDriver &can_driver, uavcan::ISystemClock &sys
 	_raw_air_data_publisher(_node),
 	_range_sensor_measurement(_node),
 	_flow_measurement_publisher(_node),
+	_param_server(_node),
 	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle time")),
 	_interval_perf(perf_alloc(PC_INTERVAL, MODULE_NAME": cycle interval")),
 	_reset_timer(_node)
@@ -289,6 +290,7 @@ void UavcanNode::Run()
 	if (!_initialized) {
 
 		get_node().setRestartRequestHandler(&restart_request_handler);
+		_param_server.start(&_param_manager);
 
 		// Set up the time synchronization
 		const int slave_init_res = _time_sync_slave.start();

--- a/src/drivers/uavcannode/UavcanNode.hpp
+++ b/src/drivers/uavcannode/UavcanNode.hpp
@@ -48,6 +48,7 @@
 
 #include "uavcan_driver.hpp"
 #include "allocator.hpp"
+#include "UavcanNodeParamManager.hpp"
 
 #include <uavcan/helpers/heap_based_pool_allocator.hpp>
 #include <uavcan/protocol/global_time_sync_slave.hpp>
@@ -199,6 +200,9 @@ private:
 	uORB::SubscriptionCallbackWorkItem _sensor_baro_sub{this, ORB_ID(sensor_baro)};
 	uORB::SubscriptionCallbackWorkItem _sensor_mag_sub{this, ORB_ID(sensor_mag)};
 	uORB::SubscriptionCallbackWorkItem _sensor_gps_sub{this, ORB_ID(sensor_gps)};
+
+	UavcanNodeParamManager _param_manager;
+	uavcan::ParamServer _param_server;
 
 	perf_counter_t _cycle_perf;
 	perf_counter_t _interval_perf;

--- a/src/drivers/uavcannode/UavcanNodeParamManager.cpp
+++ b/src/drivers/uavcannode/UavcanNodeParamManager.cpp
@@ -1,0 +1,194 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 Volansi, Inc. All rights reserved.
+ *
+ ****************************************************************************/
+
+#include <lib/parameters/param.h>
+#include <px4_platform_common/defines.h>
+
+#include "UavcanNodeParamManager.hpp"
+
+UavcanNodeParamManager::UavcanNodeParamManager()
+{
+	init_parameters();
+}
+
+void UavcanNodeParamManager::getParamNameByIndex(Index index, Name &out_name) const
+{
+	if (index < _parameter_map.param_count) {
+		param_t param_handle = get_param_handle(index);
+		out_name = param_name(param_handle);
+	}
+}
+
+void UavcanNodeParamManager::assignParamValue(const Name &name, const Value &value)
+{
+	int index = get_param_index(name.c_str());
+
+	if (index < 0) {
+		// Invalid parameter name
+		return;
+	}
+
+	// Assign input value to parameter if types match
+	param_t param_handle = get_param_handle(index);
+	param_type_t value_type = param_type(param_handle);
+
+	if (value.is(uavcan::protocol::param::Value::Tag::integer_value) && (value_type == PARAM_TYPE_INT32)) {
+		auto val = *value.as<uavcan::protocol::param::Value::Tag::integer_value>();
+
+		if ((val <= INT32_MAX) || (val >= INT32_MIN)) {
+			int32_t in_param = val;
+			param_set(param_handle, &in_param);
+		}
+
+	} else if (value.is(uavcan::protocol::param::Value::Tag::real_value) && (value_type == PARAM_TYPE_FLOAT)) {
+		// TODO: min/max value checking for float
+		float in_param = *value.as<uavcan::protocol::param::Value::Tag::real_value>();
+		param_set(param_handle, &in_param);
+	}
+}
+
+void UavcanNodeParamManager::readParamValue(const Name &name, Value &out_value) const
+{
+	int index = get_param_index(name.c_str());
+
+	if (index < 0) {
+		// Invalid parameter name
+		return;
+	}
+
+	// Copy current parameter value to out_value
+	param_t param_handle = get_param_handle(index);
+	param_type_t value_type = param_type(param_handle);
+
+	if (value_type == PARAM_TYPE_INT32) {
+		int32_t current_value;
+		param_get(param_handle, &current_value);
+		out_value.to<uavcan::protocol::param::Value::Tag::integer_value>() = current_value;
+
+	} else if (value_type == PARAM_TYPE_FLOAT) {
+		float current_value;
+		param_get(param_handle, &current_value);
+		out_value.to<uavcan::protocol::param::Value::Tag::real_value>() = current_value;
+	}
+}
+
+void UavcanNodeParamManager::readParamDefaultMaxMin(const Name &name, Value &out_default,
+		NumericValue &out_max, NumericValue &out_min) const
+{
+	// TODO: get actual default value (will require a new function in param.h)
+
+	int index = get_param_index(name.c_str());
+
+	if (index < 0) {
+		// Invalid parameter name
+		return;
+	}
+
+	param_t param_handle = get_param_handle(index);
+	param_type_t value_type = param_type(param_handle);
+
+	if (value_type == PARAM_TYPE_INT32) {
+		auto integer_max = INT32_MAX;
+		auto integer_min = INT32_MIN;
+		out_max.to<uavcan::protocol::param::NumericValue::Tag::integer_value>() = integer_max;
+		out_min.to<uavcan::protocol::param::NumericValue::Tag::integer_value>() = integer_min;
+		out_default.to<uavcan::protocol::param::Value::Tag::integer_value>() = 0;
+
+	} else if (value_type == PARAM_TYPE_FLOAT) {
+		auto real_max = uavcan::protocol::param::Value::FieldTypes::integer_value::max();
+		auto real_min = uavcan::protocol::param::Value::FieldTypes::integer_value::min();
+		out_max.to<uavcan::protocol::param::NumericValue::Tag::real_value>() = real_max;
+		out_min.to<uavcan::protocol::param::NumericValue::Tag::real_value>() = real_min;
+		out_default.to<uavcan::protocol::param::Value::Tag::real_value>() = 0.0;
+	}
+}
+
+int UavcanNodeParamManager::saveAllParams()
+{
+	// Nothing to do here assuming autosave is turned on
+	return 0;
+}
+
+int UavcanNodeParamManager::eraseAllParams()
+{
+	for (unsigned int i = 0; i < _parameter_map.param_count; ++i) {
+		param_reset(get_param_handle(i));
+	}
+
+	return 0;
+}
+
+int UavcanNodeParamManager::get_param_index(const char *name) const
+{
+	int lhs = 0;
+	int rhs = _parameter_map.param_count;
+	int mid;
+
+	// Find parameter using binary search
+	while (lhs <= rhs) {
+		mid = (rhs + lhs) / 2;
+		const char *mid_name = param_name(get_param_handle(mid));
+		int res = strcmp(name, mid_name);
+
+		if (res == 0) {
+			return mid;
+
+		} else if (lhs == mid) {
+			return -1;
+
+		} else if (res < 0) {
+			rhs = mid;
+
+		} else {
+			lhs = mid;
+		}
+	}
+
+	return -1;
+}
+
+param_t UavcanNodeParamManager::get_param_handle(int index) const
+{
+	if (index < 0 || index >= (int)_parameter_map.param_count) {
+		return -1;
+	}
+
+	const param_t *param_array = (const param_t *)&_parameter_map;
+
+	return param_array[index];
+}
+
+/**
+ * Initialize the parameter map. This is hard-coded for now.
+ */
+int UavcanNodeParamManager::init_parameters()
+{
+	_parameter_map.uavcan_baro_t = param_find("UAVCAN_BARO_T");
+	_parameter_map.uavcan_mag_t = param_find("UAVCAN_MAG_T");
+	_parameter_map.cannode_node_id = param_find("CANNODE_NODE_ID");
+	_parameter_map.cannode_bitrate = param_find("CANNODE_BITRATE");
+	_parameter_map.cannode_esc_en = param_find("CANNODE_ESC_EN");
+	_parameter_map.cannode_esc_mask = param_find("CANNODE_ESC_MASK");
+	_parameter_map.cannode_esc0 = param_find("CANNODE_ESC0");
+	_parameter_map.cannode_esc1 = param_find("CANNODE_ESC1");
+	_parameter_map.cannode_esc2 = param_find("CANNODE_ESC2");
+	_parameter_map.cannode_esc3 = param_find("CANNODE_ESC3");
+	_parameter_map.cannode_esc4 = param_find("CANNODE_ESC4");
+	_parameter_map.cannode_esc5 = param_find("CANNODE_ESC5");
+	_parameter_map.cannode_esc6 = param_find("CANNODE_ESC6");
+	_parameter_map.cannode_esc7 = param_find("CANNODE_ESC7");
+	_parameter_map.cannode_esc8 = param_find("CANNODE_ESC8");
+	_parameter_map.cannode_esc9 = param_find("CANNODE_ESC9");
+	_parameter_map.cannode_esc10 = param_find("CANNODE_ESC10");
+	_parameter_map.cannode_esc11 = param_find("CANNODE_ESC11");
+	_parameter_map.cannode_esc12 = param_find("CANNODE_ESC12");
+	_parameter_map.cannode_esc13 = param_find("CANNODE_ESC13");
+	_parameter_map.cannode_esc14 = param_find("CANNODE_ESC14");
+
+	_parameter_map.param_count = 21;
+
+	return PX4_OK;
+}

--- a/src/drivers/uavcannode/UavcanNodeParamManager.hpp
+++ b/src/drivers/uavcannode/UavcanNodeParamManager.hpp
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 Volansi, Inc. All rights reserved.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <parameters/param.h>
+
+#include <uavcan/uavcan.hpp>
+#include <uavcan/protocol/param_server.hpp>
+
+class UavcanNodeParamManager : public uavcan::IParamManager
+{
+public:
+	UavcanNodeParamManager();
+
+	void getParamNameByIndex(Index index, Name &out_name) const override;
+	void assignParamValue(const Name &name, const Value &value) override;
+	void readParamValue(const Name &name, Value &out_value) const override;
+	void readParamDefaultMaxMin(const Name &name, Value &out_default,
+				    NumericValue &out_max, NumericValue &out_min) const override;
+	int saveAllParams() override;
+	int eraseAllParams() override;
+private:
+
+	/**
+	 * Get parameter index in parameter map.
+	 */
+	int get_param_index(const char *name) const;
+
+	/**
+	 * Get the param_t handle for the mapping at index.
+	 */
+	param_t get_param_handle(int index) const;
+
+	/**
+	 * Initialize the parameter map.
+	 */
+	int init_parameters();
+
+	/**
+	 * Parameter map from UAVCAN indices to param handles.
+	 * Must be in alphabetical order by parameter name.
+	 */
+	struct ParameterMap {
+		param_t cannode_bitrate;
+		param_t cannode_esc0;
+		param_t cannode_esc1;
+		param_t cannode_esc10;
+		param_t cannode_esc11;
+		param_t cannode_esc12;
+		param_t cannode_esc13;
+		param_t cannode_esc14;
+		param_t cannode_esc2;
+		param_t cannode_esc3;
+		param_t cannode_esc4;
+		param_t cannode_esc5;
+		param_t cannode_esc6;
+		param_t cannode_esc7;
+		param_t cannode_esc8;
+		param_t cannode_esc9;
+		param_t cannode_esc_en;
+		param_t cannode_esc_mask;
+		param_t cannode_node_id;
+		param_t uavcan_baro_t;
+		param_t uavcan_mag_t;
+		unsigned int param_count;
+	} _parameter_map{0};
+};

--- a/src/drivers/uavcannode/uavcannode_params.c
+++ b/src/drivers/uavcannode/uavcannode_params.c
@@ -50,3 +50,83 @@ PARAM_DEFINE_INT32(CANNODE_NODE_ID, 120);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(CANNODE_BITRATE, 1000000);
+
+/**
+ * UAVCAN barometer publication period
+ * @unit us
+ * @min 0
+ * @max 1000000
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_BARO_T, 100000);
+
+/**
+ * UAVCAN magnetometer publication period
+ * @unit us
+ * @min 0
+ * @max 1000000
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_MAG_T, 100000);
+
+/**
+ * UAVCANNODE ESC control enable.
+ *
+ * @reboot_required true
+ *
+ * @boolean
+ * @group UAVCANNODE
+ */
+PARAM_DEFINE_INT32(CANNODE_ESC_EN, 0);
+
+/**
+ * Bitmask which sets the number of ESCs controlled by the cannode. Each
+ * bit in the mask corresponds to one of the 8 actuator outputs.
+ *
+ * eg: cannode controls actuator 1,2,3,4 :: CANNODE_ESC_MASK = 15 (00001111)
+ *
+ * @min 0
+ * @max 255
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CANNODE_ESC_MASK, 15);
+
+
+/**
+ * Integer which controls mapping of incoming actuator index to
+ * the proper output channel.
+ *
+ * eg: if CANNODE_ESC0 = 5 then RawCommand[0] ==> actuator_output[5]
+ *
+ * @min 0
+ * @max 15
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CANNODE_ESC0, 0);
+PARAM_DEFINE_INT32(CANNODE_ESC1, 1);
+PARAM_DEFINE_INT32(CANNODE_ESC2, 2);
+PARAM_DEFINE_INT32(CANNODE_ESC3, 3);
+PARAM_DEFINE_INT32(CANNODE_ESC4, 4);
+PARAM_DEFINE_INT32(CANNODE_ESC5, 5);
+PARAM_DEFINE_INT32(CANNODE_ESC6, 6);
+PARAM_DEFINE_INT32(CANNODE_ESC7, 7);
+PARAM_DEFINE_INT32(CANNODE_ESC8, 8);
+PARAM_DEFINE_INT32(CANNODE_ESC9, 9);
+PARAM_DEFINE_INT32(CANNODE_ESC10, 10);
+PARAM_DEFINE_INT32(CANNODE_ESC11, 11);
+PARAM_DEFINE_INT32(CANNODE_ESC12, 12);
+PARAM_DEFINE_INT32(CANNODE_ESC13, 13);
+PARAM_DEFINE_INT32(CANNODE_ESC14, 14);
+
+/**
+ * Units associated with ADC measurement.
+ * 0 - unused
+ * 1 - mV
+ * 2 - mA
+ * 3 - cK
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(ADC1_UNIT_TYPE, 1);
+PARAM_DEFINE_INT32(ADC2_UNIT_TYPE, 2);
+PARAM_DEFINE_INT32(ADC3_UNIT_TYPE, 0);
+PARAM_DEFINE_INT32(ADC4_UNIT_TYPE, 0);


### PR DESCRIPTION
UAVCAN register/parameter access exists on the FMU side, but not on the node side. These changes implement a simple UAVCAN node register/parameter server.

**Describe your solution**
The server is implemented by using the PX4 parameter system as a back-end to provide storage. Configured PX4 parameters are exposed for RW access through the UAVCAN GetSet service. The server is implemented using the libuavcan ParamServer class.

**Describe possible alternatives**
Currently, UAVCAN parameter names are set up to match the PX4 parameter names. This limits the length of UAVCAN parameter names to 17 characters. To allow longer names (up to 92 characters as allowed in the GetSet service), we can store the full-length UAVCAN parameter name in a struct along with its associated PX4 parameter handle. We could search the available parameters using the UAVCAN parameter name and if a match is found we can get the associated PX4 parameter handle from the matching struct.

This parameter system only supports integers and floats. GetSet also allows boolean and string values. In order to support these data types we would need to create a new back-end instead of reusing the PX4 parameter system. A proper back-end would also enable constraining the parameter values and returning the correct minimum and maximum for each parameter (currently the returned min/max are the min/max value allowed for the corresponding data type).

Parameters must be added manually to the ParameterMap struct and care must be taken to ensure they are in alphabetical order (for binary search). Generating the ParameterMap struct could be handled at compile time in a similar way to the PX4 parameter system. This would make the system more modular as each module could add their own UAVCAN parameters. Setting up the parameter mappings at compile time would allow the resulting struct to be placed in flash instead of using RAM.

**Test data / coverage**
The system was tested using the `uavcan param` series of commands from the FC side.

