### PR TITLE
Add NXP FMUK66E build to CI

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -59,6 +59,7 @@ pipeline {
                      "nxp_fmuk66-v3_default",
                      "nxp_fmuk66-v3_rtps",
                      "nxp_fmuk66-v3_socketcan",
+                     "nxp_fmuk66-e_default",
                      "nxp_fmurt1062-v1_default",
                      "nxp_ucans32k146_default",
                      "omnibus_f4sd_default",


### PR DESCRIPTION
This build was not yet available in the CI. This is a separate build for the new Rev. E version of FMUK66, previous Rev. C and D boards (fmuk66-v3) will not be abandoned.

@davids5 @dagar 