### PR TITLE
Add logging of mag calibration data

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -79,6 +79,7 @@ set(msg_files
 	led_control.msg
 	log_message.msg
 	logger_status.msg
+	mag_worker_data.msg
 	manual_control_setpoint.msg
 	manual_control_switches.msg
 	mavlink_log.msg

--- a/msg/mag_worker_data.msg
+++ b/msg/mag_worker_data.msg
@@ -1,0 +1,13 @@
+uint64 timestamp          # time since system start (microseconds)
+uint64 timestamp_sample
+
+uint8 MAX_MAGS = 4
+
+uint32 done_count
+uint32 calibration_points_perside
+uint64 calibration_interval_perside_us
+uint32[4] calibration_counter_total
+bool[4] side_data_collected
+float32[4] x
+float32[4] y
+float32[4] z

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -308,6 +308,8 @@ rtps:
     id: 146
   - msg: control_allocator_status
     id: 147
+  - msg: mag_worker_data
+    id: 148
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 170

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -65,6 +65,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("home_position");
 	add_topic("hover_thrust_estimate", 100);
 	add_topic("input_rc", 500);
+	add_topic("mag_worker_data");
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
 	add_topic("mission");


### PR DESCRIPTION
**Describe problem solved by this pull request**
Debugging the mag calibration algorithm is difficult without having the exact data used during calibration. This PR adds logging of the `mag_cal_data` struct, containing the data used by the sphere/ellipsoid fitting algorithms

**Test data / coverage**
Tested on Pixhawk4 and Skynode
![DeepinScreenshot_select-area_20210119170149](https://user-images.githubusercontent.com/14822839/105183360-640b0880-5b2e-11eb-81d2-ee00a23df697.png)