### PR TITLE
mag_cal: fix race condition causing invalid mag calibration

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -551,8 +551,13 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 							sphere_fit_success = true;
 
 						} else {
-							// stop here if fit has previously succeeded
-							if (sphere_fit_success) {
+							// stop here if fit has previously succeeded an if it is good enough
+							// TODO: extract those conditions for the unit test
+							if (sphere_fit_success
+							    && (i > 10)
+							    && (fitness < 0.01f)
+							    && (sphere_radius[cur_mag] >= 0.2f)
+							    && (sphere_radius[cur_mag] <= 0.7f)) {
 								break;
 							}
 						}


### PR DESCRIPTION
In some cases, the fitness of the optimizer does not shrink at each iteration, causing the "decreasing fitness check" to fail. This stops the optimization and returns with sub-optimal, or unrealistic results.

Found using some replay data from @sfuhrer 

```
fitness: 0.050174	sphere_lambda: 1.000   radius: -0.222
fitness: 0.050174	sphere_lambda: 10.000  radius: -0.222 <== previously stopped here
fitness: 0.021021	sphere_lambda: 10.000  radius: 0.076
fitness: 0.001488	sphere_lambda: 1.000   radius: 0.346
fitness: 0.000987	sphere_lambda: 0.100   radius: 0.362
fitness: 0.000987	sphere_lambda: 0.010   radius: 0.362 <=== now stops here
```