### PR TITLE
Parameter markdown use page css for layout

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -3,21 +3,39 @@ import codecs
 
 class MarkdownTablesOutput():
     def __init__(self, groups):
-        result = ("# Parameter Reference\n"
-                  "> **Note** **This documentation was auto-generated from the source code for this PX4 version** (using `make parameters_metadata`).\n"
-                  "\n"
-                  "<span></span>\n"
-                  "> **Note** If a listed parameter is missing from the Firmware see: [Finding/Updating Parameters](http://docs.px4.io/master/en/advanced_config/parameters.html#missing).\n"
-                  "\n")
+        result = (
+"""# Parameter Reference
+
+:::note
+This documentation was auto-generated from the source code for this PX4 version (using `make parameters_metadata`).
+:::
+
+:::tip
+If a listed parameter is missing from the Firmware see: [Finding/Updating Parameters](http://docs.px4.io/master/en/advanced_config/parameters.html#missing).
+:::
+
+<!-- markdown generator: src/lib/parameters/px4params/markdownout.py -->
+
+<style>
+tr > * {
+    vertical-align : top;
+}
+</style>
+
+"""               
+                  )    
+
         for group in groups:
             result += '## %s\n\n' % group.GetName()
-            result += '<table>\n'
-            result += ' <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>\n'
-            result += ' <thead>\n'
-            result += '   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>\n'
-            result += ' </thead>\n'
-            result += '<tbody>\n'
-
+            result += (
+"""<table>
+ <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>
+ <thead>
+   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>
+ </thead>
+<tbody>
+"""
+            )
             for param in group.GetParams():
                 code = param.GetName()
                 name = param.GetFieldValue("short_desc") or ''
@@ -84,7 +102,7 @@ class MarkdownTablesOutput():
                 if is_boolean and def_val=='0':
                     def_val='Disabled (0)'
 
-                result += '<tr>\n <td style="vertical-align: top;">%s (%s)</td>\n <td style="vertical-align: top;"><p>%s</p>%s %s %s %s</td>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s</td>\n</tr>\n' % (code, type, name, long_desc, enum_output, bitmask_output, reboot_required, max_min_combined, def_val, unit)
+                result += '<tr>\n <td>%s (%s)</td>\n <td>%s %s %s %s %s</td>\n <td>%s</td>\n <td>%s</td>\n <td>%s</td>\n</tr>\n' % (code, type, name, long_desc, enum_output, bitmask_output, reboot_required, max_min_combined, def_val, unit)
 
             #Close the table.
             result += '</tbody></table>\n\n'


### PR DESCRIPTION
Modifies the parameter markdown output so that instead of having text alignment applied on each table element it is done using a style for the whole page (reduces file from 870Kb to 630Kb). Also changes to use the vuepress note syntax. 
