### PR TITLE
mavlink: disable ACTUATOR_OUTPUT_STATUS stream

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1622,7 +1622,6 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("ODOMETRY", 30.0f);
 
 		configure_stream_local("ACTUATOR_CONTROL_TARGET0", 10.0f);
-		configure_stream_local("ACTUATOR_OUTPUT_STATUS", 10.0f);
 		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
 		configure_stream_local("ATTITUDE_QUATERNION", 50.0f);
 		configure_stream_local("ATTITUDE_TARGET", 10.0f);


### PR DESCRIPTION
I'm not yet sure how, but the presence of this stream appears to be causing the MAVSDK tests to fail.

![Screenshot from 2021-01-21 10-58-42](https://user-images.githubusercontent.com/84712/105376332-a4729100-5bd7-11eb-9c3f-311129f2653b.png)

https://github.com/PX4/PX4-Autopilot/runs/1742431144
