### PR TITLE
fix variable name in EKF2Selector (#16621)

### DIFF
--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -377,7 +377,7 @@ void EKF2Selector::PublishVehicleLocalPosition(bool reset)
 			// VZ reset
 			if (local_position.vz_reset_counter > _local_position_last.vz_reset_counter) {
 				++_vz_reset_counter;
-				_delta_z_reset = local_position.delta_vz;
+				_delta_vz_reset = local_position.delta_vz;
 			}
 
 			// heading reset


### PR DESCRIPTION
**Describe problem solved by this pull request**
In EKF2Selector::PublishVehicleLocalPosition(bool reset), _delta_z_reset was used at L380
I hardly know EKF, but _delta_vz_reset seems right in that position.

fixes https://github.com/PX4/PX4-Autopilot/issues/16621
