### PR TITLE
Add option for custom mavlink configuration for SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -238,24 +238,30 @@ fi
 #
 . ${R}etc/init.d/rc.vehicle_setup
 
-# GCS link
-mavlink start -x -u $udp_gcs_port_local -r 4000000
-mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u $udp_gcs_port_local
-mavlink stream -r 50 -s LOCAL_POSITION_NED -u $udp_gcs_port_local
-mavlink stream -r 50 -s GLOBAL_POSITION_INT -u $udp_gcs_port_local
-mavlink stream -r 50 -s ATTITUDE -u $udp_gcs_port_local
-mavlink stream -r 50 -s ATTITUDE_QUATERNION -u $udp_gcs_port_local
-mavlink stream -r 50 -s ATTITUDE_TARGET -u $udp_gcs_port_local
-mavlink stream -r 50 -s SERVO_OUTPUT_RAW_0 -u $udp_gcs_port_local
-mavlink stream -r 20 -s RC_CHANNELS -u $udp_gcs_port_local
-mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u $udp_gcs_port_local
+if [ -e etc/init.d-posix/rc.mavlink_override ]
+then
+	echo "Running non-default mavlink config rc.mavlink_override"
+	sh etc/init.d-posix/rc.mavlink_override
+else
+	# GCS link
+	mavlink start -x -u $udp_gcs_port_local -r 4000000
+	mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u $udp_gcs_port_local
+	mavlink stream -r 50 -s LOCAL_POSITION_NED -u $udp_gcs_port_local
+	mavlink stream -r 50 -s GLOBAL_POSITION_INT -u $udp_gcs_port_local
+	mavlink stream -r 50 -s ATTITUDE -u $udp_gcs_port_local
+	mavlink stream -r 50 -s ATTITUDE_QUATERNION -u $udp_gcs_port_local
+	mavlink stream -r 50 -s ATTITUDE_TARGET -u $udp_gcs_port_local
+	mavlink stream -r 50 -s SERVO_OUTPUT_RAW_0 -u $udp_gcs_port_local
+	mavlink stream -r 20 -s RC_CHANNELS -u $udp_gcs_port_local
+	mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u $udp_gcs_port_local
 
-# API/Offboard link
-mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offboard_port_remote
+	# API/Offboard link
+	mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offboard_port_remote
 
-# Onboard link to camera
-mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $udp_onboard_payload_port_remote
+	# Onboard link to camera
+	mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $udp_onboard_payload_port_remote
 
+fi
 # execute autostart post script if any
 [ -e "$autostart_file".post ] && . "$autostart_file".post
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
For simulated instances, it was hard to configure mavlink instances since 4 mavlink instances would start as a default.
Some projects, e.g. [https://github.com/JonasVautherin/px4-gazebo-headless](https://github.com/JonasVautherin/px4-gazebo-headless/blob/ac0611f4eff3ed8eb150bd85c28dd6828b5a935d/edit_rcS.bash#L50) take the approach of directly editing the rcS file.

However, this quickly becomes hard to maintain, since everytime there are changes in the `rcS` file the script editing would break

**Describe your solution**
This commit enables the option for users to add a custom mavlink configuration by adding a file `rc.mavlink_override`

**Test data / coverage**
This does not interfere with the default SITL setup, but enables users that want to have something beyond the default setup.

**Additional context**

