### PR TITLE
re-add boolean attribute to the parameters xml

### DIFF
--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -52,8 +52,8 @@ class JsonOutput():
                     if (param.GetCategory()):
                         curr_param['category'] = param.GetCategory()
 
-                    if (param.GetVolatile() == "true"):
-                        curr_param['volatile'] = param.GetVolatile()
+                    if param.GetVolatile():
+                        curr_param['volatile'] = "True"
 
                     last_param_name = param.GetName()
                     for code in param.GetFieldCodes():

--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -58,8 +58,8 @@ class Parameter(object):
         self.name = name
         self.type = type
         self.default = default
-        self.volatile = "false"
         self.category = ""
+        self.volatile = False
         self.boolean = False
 
     def GetName(self):
@@ -102,7 +102,7 @@ class Parameter(object):
         """
         Set volatile flag
         """
-        self.volatile = "true"
+        self.volatile = True
 
     def SetBoolean(self):
         """

--- a/src/lib/parameters/px4params/xmlout.py
+++ b/src/lib/parameters/px4params/xmlout.py
@@ -39,8 +39,10 @@ class XMLOutput():
                     xml_param.attrib["name"] = param.GetName()
                     xml_param.attrib["default"] = param.GetDefault()
                     xml_param.attrib["type"] = param.GetType()
-                    if (param.GetVolatile() == "true"):
-                        xml_param.attrib["volatile"] = param.GetVolatile()
+                    if param.GetVolatile():
+                        xml_param.attrib["volatile"] = "true"
+                    if param.GetBoolean():
+                        xml_param.attrib["boolean"] = "true"
                     if (param.GetCategory()):
                         xml_param.attrib["category"] = param.GetCategory()
                     last_param_name = param.GetName()


### PR DESCRIPTION
**Describe problem solved by this pull request**
its seems that since commit 564b29c0f83737c9065c0f5f8294e0a2897759fe the boolean flag of parameters doesn't expressed on the generated XML file.
that fixes it by adding "Boolean" attribute.

**Describe your solution**
re-add the information as attribute

**Describe possible alternatives**
Note that on pre 564b29c0f83737c9065c0f5f8294e0a2897759fe  the expression were not an attribute but an element.

**Test data / coverage**

**Additional context**
I am not sure how QGC handled that on the past 15 month, has it stopped to show boolean parameters as checkbox?
What need to be done there in order to make it look at the 'new' attribute?

and small cleanup, make Volatile as bool in the internal variable
