### PR TITLE
increase vehicle command queue depth and updates modules to consume all available queued commands

### DIFF
--- a/msg/vehicle_command.msg
+++ b/msg/vehicle_command.msg
@@ -134,7 +134,7 @@ uint8 FAILURE_TYPE_SLOW = 5
 uint8 FAILURE_TYPE_DELAYED = 6
 uint8 FAILURE_TYPE_INTERMITTENT = 7
 
-uint8 ORB_QUEUE_LENGTH = 4
+uint8 ORB_QUEUE_LENGTH = 8
 
 float32 param1			# Parameter 1, as defined by MAVLink uint16 VEHICLE_CMD enum.
 float32 param2			# Parameter 2, as defined by MAVLink uint16 VEHICLE_CMD enum.

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2415,7 +2415,7 @@ Commander::run()
 		}
 
 		/* handle commands last, as the system needs to be updated to handle them */
-		if (_cmd_sub.updated()) {
+		while (_cmd_sub.updated()) {
 			/* got command */
 			const unsigned last_generation = _cmd_sub.get_last_generation();
 			vehicle_command_s cmd;

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -440,43 +440,44 @@ void FlightModeManager::send_vehicle_cmd_do(uint8_t nav_state)
 void FlightModeManager::handleCommand()
 {
 	// get command
-	vehicle_command_s command{};
-	_vehicle_command_sub.copy(&command);
+	vehicle_command_s command;
 
-	// check what command it is
-	FlightTaskIndex desired_task = switchVehicleCommand(command.command);
+	while (_vehicle_command_sub.update(&command)) {
+		// check what command it is
+		FlightTaskIndex desired_task = switchVehicleCommand(command.command);
 
-	// ignore all unkown commands
-	if (desired_task != FlightTaskIndex::None) {
-		// switch to the commanded task
-		FlightTaskError switch_result = switchTask(desired_task);
-		uint8_t cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
+		// ignore all unkown commands
+		if (desired_task != FlightTaskIndex::None) {
+			// switch to the commanded task
+			FlightTaskError switch_result = switchTask(desired_task);
+			uint8_t cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
 
-		// if we are in/switched to the desired task
-		if (switch_result >= FlightTaskError::NoError) {
-			cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
+			// if we are in/switched to the desired task
+			if (switch_result >= FlightTaskError::NoError) {
+				cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 
-			// if the task is running apply parameters to it and see if it rejects
-			if (isAnyTaskActive() && !_current_task.task->applyCommandParameters(command)) {
-				cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_DENIED;
+				// if the task is running apply parameters to it and see if it rejects
+				if (isAnyTaskActive() && !_current_task.task->applyCommandParameters(command)) {
+					cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_DENIED;
 
-				// if we just switched and parameters are not accepted, go to failsafe
-				if (switch_result >= FlightTaskError::NoError) {
-					switchTask(FlightTaskIndex::ManualPosition);
-					cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
+					// if we just switched and parameters are not accepted, go to failsafe
+					if (switch_result >= FlightTaskError::NoError) {
+						switchTask(FlightTaskIndex::ManualPosition);
+						cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
+					}
 				}
 			}
-		}
 
-		// send back acknowledgment
-		vehicle_command_ack_s command_ack{};
-		command_ack.command = command.command;
-		command_ack.result = cmd_result;
-		command_ack.result_param1 = static_cast<int>(switch_result);
-		command_ack.target_system = command.source_system;
-		command_ack.target_component = command.source_component;
-		command_ack.timestamp = hrt_absolute_time();
-		_vehicle_command_ack_pub.publish(command_ack);
+			// send back acknowledgment
+			vehicle_command_ack_s command_ack{};
+			command_ack.command = command.command;
+			command_ack.result = cmd_result;
+			command_ack.result_param1 = static_cast<int>(switch_result);
+			command_ack.target_system = command.source_system;
+			command_ack.target_component = command.source_component;
+			command_ack.timestamp = hrt_absolute_time();
+			_vehicle_command_ack_pub.publish(command_ack);
+		}
 	}
 }
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -170,7 +170,6 @@ private:
 	position_setpoint_triplet_s	_pos_sp_triplet {};		///< triplet of mission items
 	vehicle_attitude_s		_att {};			///< vehicle attitude setpoint
 	vehicle_attitude_setpoint_s	_att_sp {};			///< vehicle attitude setpoint
-	vehicle_command_s		_vehicle_command {};		///< vehicle commands
 	vehicle_control_mode_s		_control_mode {};		///< control mode
 	vehicle_local_position_s	_local_pos {};			///< vehicle local position
 	vehicle_land_detected_s		_vehicle_land_detected {};	///< vehicle land detected
@@ -345,11 +344,6 @@ private:
 
 	float		get_demanded_airspeed();
 	float		calculate_target_airspeed(float airspeed_demand, const Vector2f &ground_speed);
-
-	/**
-	 * Handle incoming vehicle commands
-	 */
-	void		handle_command();
 
 	void		reset_takeoff_state(bool force = false);
 	void		reset_landing_state();

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -75,6 +75,9 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/radio_status.h>
 #include <uORB/topics/telemetry_status.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include "mavlink_command_sender.h"
 #include "mavlink_messages.h"
@@ -530,9 +533,13 @@ private:
 
 	orb_advert_t		_mavlink_log_pub{nullptr};
 
-	uORB::PublicationMulti<telemetry_status_s> _telem_status_pub{ORB_ID(telemetry_status)};
+	uORB::Publication<vehicle_command_ack_s> _vehicle_command_ack_pub{ORB_ID(vehicle_command_ack)};
+	uORB::PublicationMulti<telemetry_status_s> _telemetry_status_pub{ORB_ID(telemetry_status)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
+	uORB::Subscription _vehicle_command_ack_sub{ORB_ID(vehicle_command_ack)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	bool			_task_running{true};
 	static bool		_boot_complete;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -506,7 +506,7 @@ public:
 	}
 
 private:
-	uORB::Subscription _cmd_sub{ORB_ID(vehicle_command)};
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
 
 	/* do not allow top copying this class */
 	MavlinkStreamCommandLong(MavlinkStreamCommandLong &) = delete;
@@ -518,19 +518,28 @@ protected:
 
 	bool send() override
 	{
-		struct vehicle_command_s cmd;
 		bool sent = false;
 
-		if (_cmd_sub.update(&cmd)) {
+		while ((_mavlink->get_free_tx_buf() >= get_size()) && _vehicle_command_sub.updated()) {
 
-			if (!cmd.from_external) {
-				PX4_DEBUG("sending command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
+			const unsigned last_generation = _vehicle_command_sub.get_last_generation();
+			vehicle_command_s cmd;
 
-				MavlinkCommandSender::instance().handle_vehicle_command(cmd, _mavlink->get_channel());
-				sent = true;
+			if (_vehicle_command_sub.update(&cmd)) {
+				if (_vehicle_command_sub.get_last_generation() != last_generation + 1) {
+					PX4_ERR("COMMAND_LONG vehicle_command lost, generation %d -> %d", last_generation,
+						_vehicle_command_sub.get_last_generation());
+				}
 
-			} else {
-				PX4_DEBUG("not forwarding command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
+				if (!cmd.from_external) {
+					PX4_DEBUG("sending command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
+
+					MavlinkCommandSender::instance().handle_vehicle_command(cmd, _mavlink->get_channel());
+					sent = true;
+
+				} else {
+					PX4_DEBUG("not forwarding command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
+				}
 			}
 		}
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -212,7 +212,7 @@ Navigator::run()
 		_position_controller_status_sub.update();
 		_home_pos_sub.update(&_home_pos);
 
-		if (_vehicle_command_sub.updated()) {
+		while (_vehicle_command_sub.updated()) {
 			const unsigned last_generation = _vehicle_command_sub.get_last_generation();
 			vehicle_command_s cmd{};
 			_vehicle_command_sub.copy(&cmd);

--- a/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
@@ -181,7 +181,7 @@ void TemperatureCompensationModule::Run()
 	perf_begin(_loop_perf);
 
 	// Check if user has requested to run the calibration routine
-	if (_vehicle_command_sub.updated()) {
+	while (_vehicle_command_sub.updated()) {
 		vehicle_command_s cmd;
 
 		if (_vehicle_command_sub.copy(&cmd)) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -172,7 +172,6 @@ private:
 	position_setpoint_triplet_s		_pos_sp_triplet{};
 	tecs_status_s				_tecs_status{};
 	vehicle_attitude_s			_v_att{};				//vehicle attitude
-	vehicle_command_s			_vehicle_cmd{};
 	vehicle_control_mode_s			_v_control_mode{};	//vehicle control mode
 	vehicle_land_detected_s			_land_detected{};
 	vehicle_local_position_s		_local_pos{};
@@ -232,6 +231,4 @@ private:
 	void		vehicle_cmd_poll();
 
 	int 		parameters_update();			//Update local parameter cache
-
-	void		handle_command();
 };


### PR DESCRIPTION
This is to prevent the possible loss of vehicle_commands. At the moment it's likely only problematic in the case of high rate vehicle_commands from things like vmount, but better safe than sorry.

 - fixes https://github.com/PX4/PX4-Autopilot/issues/16630