### PR TITLE
bug-fix: indicate motor channel range 0..1 or -1..1 in simulation_mavlink.cpp

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -87,52 +87,54 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 
 	int _system_type = _param_mav_type.get();
 
-	unsigned motors_count;
+	/* 'pos_thrust_motors_count' indicates number of motor channels which are configured with 0..1 range (positive thrust)
+	all other motors are configured for -1..1 range */
+	unsigned pos_thrust_motors_count;
 	bool is_fixed_wing;
 
 	switch (_system_type) {
 	case MAV_TYPE_AIRSHIP:
 	case MAV_TYPE_VTOL_DUOROTOR:
 	case MAV_TYPE_COAXIAL:
-		motors_count = 2;
+		pos_thrust_motors_count = 2;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_TRICOPTER:
-		motors_count = 3;
+		pos_thrust_motors_count = 3;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_QUADROTOR:
 	case MAV_TYPE_VTOL_QUADROTOR:
 	case MAV_TYPE_VTOL_TILTROTOR:
-		motors_count = 4;
+		pos_thrust_motors_count = 4;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_VTOL_RESERVED2:
-		motors_count = 5;
+		pos_thrust_motors_count = 5;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_HEXAROTOR:
-		motors_count = 6;
+		pos_thrust_motors_count = 6;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_OCTOROTOR:
 	case MAV_TYPE_SUBMARINE:
-		motors_count = 8;
+		pos_thrust_motors_count = 0;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_FIXED_WING:
-		motors_count = 0;
+		pos_thrust_motors_count = 0;
 		is_fixed_wing = true;
 		break;
 
 	default:
-		motors_count = 0;
+		pos_thrust_motors_count = 0;
 		is_fixed_wing = false;
 		break;
 	}
@@ -143,7 +145,7 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 			msg->controls[i] = 0.0f;
 
 		} else if ((is_fixed_wing && i == 4) ||
-			   (!is_fixed_wing && i < motors_count)) {	//multirotor, rotor channel
+			   (!is_fixed_wing && i < pos_thrust_motors_count)) {	//multirotor, rotor channel
 			/* scale PWM out PWM_DEFAULT_MIN..PWM_DEFAULT_MAX us to 0..1 for rotors */
 			msg->controls[i] = (_actuator_outputs.output[i] - PWM_DEFAULT_MIN) / (PWM_DEFAULT_MAX - PWM_DEFAULT_MIN);
 			msg->controls[i] = math::constrain(msg->controls[i], 0.f, 1.f);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -123,9 +123,9 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 		break;
 
 	case MAV_TYPE_OCTOROTOR:
-	    	pos_thrust_motors_count = 8;
-	    	is_fixed_wing = false;
-	    	break;
+		pos_thrust_motors_count = 8;
+		is_fixed_wing = false;
+		break;
 
 	case MAV_TYPE_SUBMARINE:
 		pos_thrust_motors_count = 0;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -123,9 +123,10 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 		break;
 
 	case MAV_TYPE_OCTOROTOR:
-	    pos_thrust_motors_count = 8;
-	    is_fixed_wing = false;
-	    break;
+	    	pos_thrust_motors_count = 8;
+	    	is_fixed_wing = false;
+	    	break;
+
 	case MAV_TYPE_SUBMARINE:
 		pos_thrust_motors_count = 0;
 		is_fixed_wing = false;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -123,6 +123,9 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 		break;
 
 	case MAV_TYPE_OCTOROTOR:
+	    pos_thrust_motors_count = 8;
+	    is_fixed_wing = false;
+	    break;
 	case MAV_TYPE_SUBMARINE:
 		pos_thrust_motors_count = 0;
 		is_fixed_wing = false;


### PR DESCRIPTION
**Describe problem solved by this pull request**

This seems to be an older (minor) definition issue due to the definition that motors mostly have a range of 0..1 while servos have -1..1

However, since PR (https://github.com/PX4/PX4-Autopilot/pull/15861), vehicle type 'uuv' does not work anymore in simulation as UUV motors are now configured for 0..1 instead of the original working -1..1 range. A work-around is proposed by @Zarbokk in PR (https://github.com/PX4/PX4-SITL_gazebo/pull/696) which changes the vehicles sdf-files, what would work of course. However, I feel it makes more sense to address the root of the problem rather than the *.sdf-files:
Historically, px4 see 'motors' only in the 0..1 range.  Their number (represented by the variable 'motor_count') configures the first 0..motor_count channels to the 0..1 range. This seems to be the original cause for PR(https://github.com/PX4/PX4-Autopilot/pull/15861), which solved this for fixed_wings. Anyhow, it resulted in a bug for UUV, as vehicles exist  which have motors (not servos) which are able to spin in both directions, i.e. require the -1..1 range.


**Describe your solution**
Proposed renaming of the 'motor_count' variable to 'pos_thrust_motor_count' (feel free to propose better names). However, the goal is to explicitly state that this number counts only motors in 0..1 range NOT -1..1 motor channels.
With this renaming it makes sense to the change 'positive motor' number for UUVs from 8 to 0 which provides the UUVs again with -1..1 channels.

**Describe possible alternatives**
Alternatively, one could use an array as configuration mask for all motors indicating whether the individual motor channel are configured for 0..1 or -1..1 range, i.e.  [0,0,0,1,1,1,1,1] where channel 1-3 are 0..1 range while the others are -1..1.
However, this is more much more complex (but would avoid also the vehicle specific variable is_fixed_wing)

**Test data / coverage**
This is a minor renaming, which solves the problem for uuv  - tested in Gazebo.
