### PR TITLE
[WIP] fw_pos_control_l1: apply roll slew rate on final setpoint before publication

### DIFF
--- a/src/lib/l1/ECL_L1_Pos_Controller.cpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.cpp
@@ -40,30 +40,12 @@
 
 #include "ECL_L1_Pos_Controller.hpp"
 
-#include <lib/ecl/geo/geo.h>
-
 #include <px4_platform_common/defines.h>
 
 #include <float.h>
 
 using matrix::Vector2f;
 using matrix::wrap_pi;
-
-void ECL_L1_Pos_Controller::update_roll_setpoint()
-{
-	float roll_new = atanf(_lateral_accel * 1.0f / CONSTANTS_ONE_G);
-	roll_new = math::constrain(roll_new, -_roll_lim_rad, _roll_lim_rad);
-
-	if (_dt > 0.0f && _roll_slew_rate > 0.0f) {
-		// slew rate limiting active
-		roll_new = math::constrain(roll_new, _roll_setpoint - _roll_slew_rate * _dt, _roll_setpoint + _roll_slew_rate * _dt);
-	}
-
-	if (PX4_ISFINITE(roll_new)) {
-		_roll_setpoint = roll_new;
-	}
-
-}
 
 float ECL_L1_Pos_Controller::switch_distance(float wp_radius)
 {
@@ -196,8 +178,6 @@ ECL_L1_Pos_Controller::navigate_waypoints(const Vector2f &vector_A, const Vector
 
 	/* the bearing angle, in NED frame */
 	_bearing_error = eta;
-
-	update_roll_setpoint();
 }
 
 void
@@ -298,8 +278,6 @@ ECL_L1_Pos_Controller::navigate_loiter(const Vector2f &vector_A, const Vector2f 
 		/* bearing from current position to L1 point */
 		_nav_bearing = atan2f(-vector_A_to_airplane_unit(1), -vector_A_to_airplane_unit(0));
 	}
-
-	update_roll_setpoint();
 }
 
 void ECL_L1_Pos_Controller::navigate_heading(float navigation_heading, float current_heading,
@@ -335,8 +313,6 @@ void ECL_L1_Pos_Controller::navigate_heading(float navigation_heading, float cur
 	/* limit eta to 90 degrees */
 	eta = math::constrain(eta, (-M_PI_F) / 2.0f, +M_PI_F / 2.0f);
 	_lateral_accel = 2.0f * sinf(eta) * omega_vel;
-
-	update_roll_setpoint();
 }
 
 void ECL_L1_Pos_Controller::navigate_level_flight(float current_heading)
@@ -352,8 +328,6 @@ void ECL_L1_Pos_Controller::navigate_level_flight(float current_heading)
 
 	/* not circling a waypoint when flying level */
 	_circle_mode = false;
-
-	update_roll_setpoint();
 }
 
 Vector2f ECL_L1_Pos_Controller::get_local_planar_vector(const Vector2f &origin, const Vector2f &target) const

--- a/src/lib/l1/ECL_L1_Pos_Controller.hpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.hpp
@@ -61,6 +61,7 @@
 #define ECL_L1_POS_CONTROLLER_H
 
 #include <matrix/math.hpp>
+#include <lib/ecl/geo/geo.h>
 #include <lib/mathlib/mathlib.h>
 
 /**
@@ -103,7 +104,7 @@ public:
 	 *
 	 * @return Roll angle (in NED frame)
 	 */
-	float get_roll_setpoint() { return _roll_setpoint; }
+	float get_roll_setpoint() const { return atanf(_lateral_accel * 1.0f / CONSTANTS_ONE_G); }
 
 	/**
 	 * Get the current crosstrack error.
@@ -188,21 +189,6 @@ public:
 	 */
 	void set_l1_damping(float damping);
 
-	/**
-	 * Set the maximum roll angle output in radians
-	 */
-	void set_l1_roll_limit(float roll_lim_rad) { _roll_lim_rad = roll_lim_rad; }
-
-	/**
-	 * Set roll angle slew rate. Set to zero to deactivate.
-	 */
-	void set_roll_slew_rate(float roll_slew_rate) { _roll_slew_rate = roll_slew_rate; }
-
-	/**
-	 * Set control loop dt. The value will be used to apply roll angle setpoint slew rate limiting.
-	 */
-	void set_dt(float dt) { _dt = dt;}
-
 private:
 
 	float _lateral_accel{0.0f};		///< Lateral acceleration setpoint in m/s^2
@@ -219,11 +205,6 @@ private:
 	float _K_L1{2.0f};			///< L1 control gain for _L1_damping
 	float _heading_omega{1.0f};		///< Normalized frequency
 
-	float _roll_lim_rad{math::radians(30.0f)};  ///<maximum roll angle in radians
-	float _roll_setpoint{0.0f};	///< current roll angle setpoint in radians
-	float _roll_slew_rate{0.0f};	///< roll angle setpoint slew rate limit in rad/s
-	float _dt{0};				///< control loop time in seconds
-
 	/**
 	 * Convert a 2D vector from WGS84 to planar coordinates.
 	 *
@@ -236,12 +217,6 @@ private:
 	 * @return The vector in meters pointing from the reference position to the coordinates
 	 */
 	matrix::Vector2f get_local_planar_vector(const matrix::Vector2f &origin, const matrix::Vector2f &target) const;
-
-	/**
-	 * Update roll angle setpoint. This will also apply slew rate limits if set.
-	 *
-	 */
-	void update_roll_setpoint();
 
 };
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -277,6 +277,9 @@ private:
 	param_t _param_handle_airspeed_trans{PARAM_INVALID};
 	float _param_airspeed_trans{NAN};
 
+	hrt_abstime _timestamp_roll_setpoint_prev_time{0};
+	float _roll_setpoint_prev{0.f};
+
 	// Update our local parameter cache.
 	int		parameters_update();
 
@@ -429,7 +432,6 @@ private:
 		(ParamFloat<px4::params::FW_MAN_R_MAX>) _param_fw_man_r_max,
 
 		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad
-
 	)
 
 };

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -81,7 +81,6 @@ void RoverPositionControl::parameters_update(bool force)
 
 		_gnd_control.set_l1_damping(_param_l1_damping.get());
 		_gnd_control.set_l1_period(_param_l1_period.get());
-		_gnd_control.set_l1_roll_limit(math::radians(0.0f));
 
 		pid_init(&_speed_ctrl, PID_MODE_DERIVATIV_CALC, 0.01f);
 		pid_set_parameters(&_speed_ctrl,


### PR DESCRIPTION
Debugging https://github.com/PX4/PX4-Autopilot/issues/16639.

<img width="836" alt="Screen Shot 2021-01-24 at 8 20 51 PM" src="https://user-images.githubusercontent.com/84712/105650390-acedf480-5e81-11eb-81a3-4ae4a0096a6a.png">

This should not be able to happen.
