### PR TITLE
extend uuv_att_control module by thrust in y/z-direction

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -87,52 +87,58 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 
 	int _system_type = _param_mav_type.get();
 
-	unsigned motors_count;
+	/* 'pos_thrust_motors_count' indicates number of motor channels which are configured with 0..1 range (positive thrust)
+	all other motors are configured for -1..1 range */
+	unsigned pos_thrust_motors_count;
 	bool is_fixed_wing;
 
 	switch (_system_type) {
 	case MAV_TYPE_AIRSHIP:
 	case MAV_TYPE_VTOL_DUOROTOR:
 	case MAV_TYPE_COAXIAL:
-		motors_count = 2;
+		pos_thrust_motors_count = 2;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_TRICOPTER:
-		motors_count = 3;
+		pos_thrust_motors_count = 3;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_QUADROTOR:
 	case MAV_TYPE_VTOL_QUADROTOR:
 	case MAV_TYPE_VTOL_TILTROTOR:
-		motors_count = 4;
+		pos_thrust_motors_count = 4;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_VTOL_RESERVED2:
-		motors_count = 5;
+		pos_thrust_motors_count = 5;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_HEXAROTOR:
-		motors_count = 6;
+		pos_thrust_motors_count = 6;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_OCTOROTOR:
+		pos_thrust_motors_count = 8;
+		is_fixed_wing = false;
+		break;
+
 	case MAV_TYPE_SUBMARINE:
-		motors_count = 8;
+		pos_thrust_motors_count = 0;
 		is_fixed_wing = false;
 		break;
 
 	case MAV_TYPE_FIXED_WING:
-		motors_count = 0;
+		pos_thrust_motors_count = 0;
 		is_fixed_wing = true;
 		break;
 
 	default:
-		motors_count = 0;
+		pos_thrust_motors_count = 0;
 		is_fixed_wing = false;
 		break;
 	}
@@ -143,7 +149,7 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 			msg->controls[i] = 0.0f;
 
 		} else if ((is_fixed_wing && i == 4) ||
-			   (!is_fixed_wing && i < motors_count)) {	//multirotor, rotor channel
+			   (!is_fixed_wing && i < pos_thrust_motors_count)) {	//multirotor, rotor channel
 			/* scale PWM out PWM_DEFAULT_MIN..PWM_DEFAULT_MAX us to 0..1 for rotors */
 			msg->controls[i] = (_actuator_outputs.output[i] - PWM_DEFAULT_MIN) / (PWM_DEFAULT_MAX - PWM_DEFAULT_MIN);
 			msg->controls[i] = math::constrain(msg->controls[i], 0.f, 1.f);

--- a/src/modules/uuv_att_control/uuv_att_control.cpp
+++ b/src/modules/uuv_att_control/uuv_att_control.cpp
@@ -94,7 +94,7 @@ void UUVAttitudeControl::parameters_update(bool force)
 }
 
 void UUVAttitudeControl::constrain_actuator_commands(float roll_u, float pitch_u, float yaw_u,
-						     float thrust_x,float thrust_y, float thrust_z)
+		float thrust_x, float thrust_y, float thrust_z)
 {
 	if (PX4_ISFINITE(roll_u)) {
 		roll_u = math::constrain(roll_u, -1.0f, 1.0f);
@@ -136,7 +136,7 @@ void UUVAttitudeControl::constrain_actuator_commands(float roll_u, float pitch_u
 		_actuators.control[actuator_controls_s::INDEX_FLAPS] = 0.0f;
 	}
 
-		if (PX4_ISFINITE(thrust_z)) {
+	if (PX4_ISFINITE(thrust_z)) {
 		thrust_z = math::constrain(thrust_z, -1.0f, 1.0f);
 		_actuators.control[actuator_controls_s::INDEX_SPOILERS] = thrust_z;
 

--- a/src/modules/uuv_att_control/uuv_att_control.cpp
+++ b/src/modules/uuv_att_control/uuv_att_control.cpp
@@ -93,7 +93,8 @@ void UUVAttitudeControl::parameters_update(bool force)
 	}
 }
 
-void UUVAttitudeControl::constrain_actuator_commands(float roll_u, float pitch_u, float yaw_u, float thrust_u)
+void UUVAttitudeControl::constrain_actuator_commands(float roll_u, float pitch_u, float yaw_u,
+						     float thrust_x,float thrust_y, float thrust_z)
 {
 	if (PX4_ISFINITE(roll_u)) {
 		roll_u = math::constrain(roll_u, -1.0f, 1.0f);
@@ -119,12 +120,28 @@ void UUVAttitudeControl::constrain_actuator_commands(float roll_u, float pitch_u
 		_actuators.control[actuator_controls_s::INDEX_YAW] = 0.0f;
 	}
 
-	if (PX4_ISFINITE(thrust_u)) {
-		thrust_u = math::constrain(thrust_u, -1.0f, 1.0f);
-		_actuators.control[actuator_controls_s::INDEX_THROTTLE] = thrust_u;
+	if (PX4_ISFINITE(thrust_x)) {
+		thrust_x = math::constrain(thrust_x, -1.0f, 1.0f);
+		_actuators.control[actuator_controls_s::INDEX_THROTTLE] = thrust_x;
 
 	} else {
 		_actuators.control[actuator_controls_s::INDEX_THROTTLE] = 0.0f;
+	}
+
+	if (PX4_ISFINITE(thrust_y)) {
+		thrust_y = math::constrain(thrust_y, -1.0f, 1.0f);
+		_actuators.control[actuator_controls_s::INDEX_FLAPS] = thrust_y;
+
+	} else {
+		_actuators.control[actuator_controls_s::INDEX_FLAPS] = 0.0f;
+	}
+
+		if (PX4_ISFINITE(thrust_z)) {
+		thrust_z = math::constrain(thrust_z, -1.0f, 1.0f);
+		_actuators.control[actuator_controls_s::INDEX_SPOILERS] = thrust_z;
+
+	} else {
+		_actuators.control[actuator_controls_s::INDEX_SPOILERS] = 0.0f;
 	}
 }
 
@@ -143,7 +160,9 @@ void UUVAttitudeControl::control_attitude_geo(const vehicle_attitude_s &attitude
 	float roll_u;
 	float pitch_u;
 	float yaw_u;
-	float thrust_u;
+	float thrust_x;
+	float thrust_y;
+	float thrust_z;
 
 	float roll_body = attitude_setpoint.roll_body;
 	float pitch_body = attitude_setpoint.pitch_body;
@@ -191,9 +210,12 @@ void UUVAttitudeControl::control_attitude_geo(const vehicle_attitude_s &attitude
 	yaw_u = torques(2);
 
 	// take thrust as
-	thrust_u = attitude_setpoint.thrust_body[0];
+	thrust_x = attitude_setpoint.thrust_body[0];
+	thrust_y = attitude_setpoint.thrust_body[1];
+	thrust_z = attitude_setpoint.thrust_body[2];
 
-	constrain_actuator_commands(roll_u, pitch_u, yaw_u, thrust_u);
+
+	constrain_actuator_commands(roll_u, pitch_u, yaw_u, thrust_x, thrust_y, thrust_z);
 	/* Geometric Controller END*/
 }
 
@@ -235,6 +257,8 @@ void UUVAttitudeControl::Run()
 				_attitude_setpoint.pitch_body = _param_direct_pitch.get();
 				_attitude_setpoint.yaw_body = _param_direct_yaw.get();
 				_attitude_setpoint.thrust_body[0] = _param_direct_thrust.get();
+				_attitude_setpoint.thrust_body[1] = 0.f;
+				_attitude_setpoint.thrust_body[2] = 0.f;
 			}
 
 			/* Geometric Control*/
@@ -242,7 +266,7 @@ void UUVAttitudeControl::Run()
 
 			if (skip_controller) {
 				constrain_actuator_commands(_rates_setpoint.roll, _rates_setpoint.pitch, _rates_setpoint.yaw,
-							    _rates_setpoint.thrust_body[0]);
+							    _rates_setpoint.thrust_body[0], _rates_setpoint.thrust_body[1], _rates_setpoint.thrust_body[2]);
 
 			} else {
 				control_attitude_geo(attitude, _attitude_setpoint, angular_velocity, _rates_setpoint);
@@ -257,7 +281,8 @@ void UUVAttitudeControl::Run()
 		if (_vcontrol_mode.flag_control_manual_enabled && !_vcontrol_mode.flag_control_rates_enabled) {
 			/* manual/direct control */
 			constrain_actuator_commands(_manual_control_setpoint.y, -_manual_control_setpoint.x,
-						    _manual_control_setpoint.r, _manual_control_setpoint.z);
+						    _manual_control_setpoint.r,
+						    _manual_control_setpoint.z, 0.f, 0.f);
 		}
 
 	}

--- a/src/modules/uuv_att_control/uuv_att_control.hpp
+++ b/src/modules/uuv_att_control/uuv_att_control.hpp
@@ -147,5 +147,5 @@ private:
 	void control_attitude_geo(const vehicle_attitude_s &attitude, const vehicle_attitude_setpoint_s &attitude_setpoint,
 				  const vehicle_angular_velocity_s &angular_velocity, const vehicle_rates_setpoint_s &rates_setpoint);
 	void constrain_actuator_commands(float roll_u, float pitch_u, float yaw_u,
-					 float thrust_x,float thrust_y, float thrust_z);
+					 float thrust_x, float thrust_y, float thrust_z);
 };

--- a/src/modules/uuv_att_control/uuv_att_control.hpp
+++ b/src/modules/uuv_att_control/uuv_att_control.hpp
@@ -146,5 +146,6 @@ private:
 	 */
 	void control_attitude_geo(const vehicle_attitude_s &attitude, const vehicle_attitude_setpoint_s &attitude_setpoint,
 				  const vehicle_angular_velocity_s &angular_velocity, const vehicle_rates_setpoint_s &rates_setpoint);
-	void constrain_actuator_commands(float roll_u, float pitch_u, float yaw_u, float thrust_u);
+	void constrain_actuator_commands(float roll_u, float pitch_u, float yaw_u,
+					 float thrust_x,float thrust_y, float thrust_z);
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR is related to  PR (https://github.com/PX4/PX4-Autopilot/pull/16610). However, as we want to introduce a 6DOF uuv_pos_control module, we need to extend uuv_att_control with a feed-through for the translational DOF in y- and z- directions

**Describe your solution**
extending the 4DOF to 6DOF by adding feed-through for thrust in y and z-direction

**Describe possible alternatives**
Build individual attitude controller specific for 6DOF UUVs. However, a generalized version which is capable handling both 4 and 6DOF seems preferable.

**Test data / coverage**
So far testing is only done in Gazebo.

