### PR TITLE
[WIP] Use gps data with increased precision

### DIFF
--- a/msg/sensor_gps.msg
+++ b/msg/sensor_gps.msg
@@ -1,15 +1,15 @@
 # GPS position in WGS84 coordinates.
 # the field 'timestamp' is for the position & velocity (microseconds)
 uint64 timestamp		# time since system start (microseconds)
-
-int32 lat			# Latitude in 1E-7 degrees
-int32 lon			# Longitude in 1E-7 degrees
-int32 alt			# Altitude in 1E-3 meters above MSL, (millimetres)
-int32 alt_ellipsoid 		# Altitude in 1E-3 meters bove Ellipsoid, (millimetres)
-
+float64 lat				# Latitude in degrees
+float64 lon				# Longitude in degrees
+float32 alt				# Altitude AMSL, (meters)
+float32 alt_ellipsoid	# Altitude above ellipsoid, (meters)
 float32 s_variance_m_s		# GPS speed accuracy estimate, (metres/sec)
 float32 c_variance_rad		# GPS course accuracy estimate, (radians)
 uint8 fix_type # 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time Kinematic, float, 6: Real-Time Kinematic, fixed, 8: Extrapolated. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.
+
+float32 dgps_age    # Age of Differential GPS data (seconds) 
 
 float32 eph			# GPS horizontal position accuracy (metres)
 float32 epv			# GPS vertical position accuracy (metres)

--- a/msg/vehicle_gps_position.msg
+++ b/msg/vehicle_gps_position.msg
@@ -2,14 +2,16 @@
 # the field 'timestamp' is for the position & velocity (microseconds)
 uint64 timestamp		# time since system start (microseconds)
 
-int32 lat			# Latitude in 1E-7 degrees
-int32 lon			# Longitude in 1E-7 degrees
-int32 alt			# Altitude in 1E-3 meters above MSL, (millimetres)
-int32 alt_ellipsoid 		# Altitude in 1E-3 meters bove Ellipsoid, (millimetres)
+float64 lat				# Latitude in degrees
+float64 lon				# Longitude in degrees
+float32 alt				# Altitude AMSL, (meters)
+float32 alt_ellipsoid	# Altitude above ellipsoid, (meters)
 
 float32 s_variance_m_s		# GPS speed accuracy estimate, (metres/sec)
 float32 c_variance_rad		# GPS course accuracy estimate, (radians)
 uint8 fix_type # 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time Kinematic, float, 6: Real-Time Kinematic, fixed, 8: Extrapolated. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.
+
+float32 dgps_age    # Age of Differential GPS data (seconds) 
 
 float32 eph			# GPS horizontal position accuracy (metres)
 float32 epv			# GPS vertical position accuracy (metres)

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -722,10 +722,10 @@ GPS::run()
 
 		if (_fake_gps) {
 			_report_gps_pos.timestamp = hrt_absolute_time();
-			_report_gps_pos.lat = (int32_t)47.378301e7f;
-			_report_gps_pos.lon = (int32_t)8.538777e7f;
-			_report_gps_pos.alt = (int32_t)1200e3f;
-			_report_gps_pos.alt_ellipsoid = 10000;
+			_report_gps_pos.lat = 47.378301;
+			_report_gps_pos.lon = 8.538777;
+			_report_gps_pos.alt = 1200;
+			_report_gps_pos.alt_ellipsoid = 10;
 			_report_gps_pos.s_variance_m_s = 0.5f;
 			_report_gps_pos.c_variance_rad = 0.1f;
 			_report_gps_pos.fix_type = 3;

--- a/src/drivers/rc_input/crsf_telemetry.cpp
+++ b/src/drivers/rc_input/crsf_telemetry.cpp
@@ -96,8 +96,8 @@ bool CRSFTelemetry::send_gps()
 		return false;
 	}
 
-	int32_t latitude = vehicle_gps_position.lat;
-	int32_t longitude = vehicle_gps_position.lon;
+	int32_t latitude = vehicle_gps_position.lat * 1e7;
+	int32_t longitude = vehicle_gps_position.lon * 1e7;
 	uint16_t groundspeed = vehicle_gps_position.vel_d_m_s / 3.6f * 10.f;
 	uint16_t gps_heading = math::degrees(vehicle_gps_position.cog_rad) * 100.f;
 	uint16_t altitude = vehicle_gps_position.alt + 1000;

--- a/src/drivers/telemetry/bst/bst.cpp
+++ b/src/drivers/telemetry/bst/bst.cpp
@@ -273,9 +273,9 @@ void BST::RunImpl()
 		if (gps.fix_type >= 3 && gps.eph < 50.0f) {
 			BSTPacket<BSTGPSPosition> bst_gps = {};
 			bst_gps.type = 0x02;
-			bst_gps.payload.lat = swap_int32(gps.lat);
-			bst_gps.payload.lon = swap_int32(gps.lon);
-			bst_gps.payload.alt = swap_int16(gps.alt / 1000 + 1000);
+			bst_gps.payload.lat = swap_int32(gps.lat * 1e+7);
+			bst_gps.payload.lon = swap_int32(gps.lon * 1e+7);
+			bst_gps.payload.alt = swap_int16(gps.alt + 1000);
 			bst_gps.payload.gs = swap_int16(gps.vel_m_s * 360.0f);
 			bst_gps.payload.heading = swap_int16(gps.cog_rad * 18000.0f / M_PI_F);
 			bst_gps.payload.sats = gps.satellites_used;

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -238,7 +238,7 @@ build_gps_response(uint8_t *buffer, size_t *size)
 		msg.gps_speed_H = (uint8_t)(speed >> 8) & 0xff;
 
 		/* Get latitude in degrees, minutes and seconds */
-		double lat = ((double)(gps.lat)) * 1e-7d;
+		double lat = gps.lat;
 
 		/* Set the N or S specifier */
 		msg.latitude_ns = 0;
@@ -261,7 +261,7 @@ build_gps_response(uint8_t *buffer, size_t *size)
 		msg.latitude_sec_H = (uint8_t)(lat_sec >> 8) & 0xff;
 
 		/* Get longitude in degrees, minutes and seconds */
-		double lon = ((double)(gps.lon)) * 1e-7d;
+		double lon = gps.lon;
 
 		/* Set the E or W specifier */
 		msg.longitude_ew = 0;
@@ -281,7 +281,7 @@ build_gps_response(uint8_t *buffer, size_t *size)
 		msg.longitude_sec_H = (uint8_t)(lon_sec >> 8) & 0xff;
 
 		/* Altitude */
-		uint16_t alt = (uint16_t)(gps.alt * 1e-3f + 500.0f);
+		uint16_t alt = (uint16_t)(gps.alt + 500.0f);
 		msg.altitude_L = (uint8_t)alt & 0xff;
 		msg.altitude_H = (uint8_t)(alt >> 8) & 0xff;
 

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -471,10 +471,10 @@ void UavcanNode::Run()
 
 			fix2.gnss_time_standard = fix2.GNSS_TIME_STANDARD_UTC;
 			fix2.gnss_timestamp.usec = gps.time_utc_usec;
-			fix2.latitude_deg_1e8 = (int64_t)gps.lat * 10;
-			fix2.longitude_deg_1e8 = (int64_t)gps.lon * 10;
-			fix2.height_msl_mm = gps.alt;
-			fix2.height_ellipsoid_mm = gps.alt_ellipsoid;
+			fix2.latitude_deg_1e8 = (int64_t)(gps.lat * 1e+8d);
+			fix2.longitude_deg_1e8 = (int64_t)(gps.lon * 1e+8d);
+			fix2.height_msl_mm = gps.alt * 1e3f;
+			fix2.height_ellipsoid_mm = gps.alt_ellipsoid * 1e3f;
 			fix2.status = gps.fix_type;
 			fix2.ned_velocity[0] = gps.vel_n_m_s;
 			fix2.ned_velocity[1] = gps.vel_e_m_s;

--- a/src/examples/fake_magnetometer/FakeMagnetometer.cpp
+++ b/src/examples/fake_magnetometer/FakeMagnetometer.cpp
@@ -67,8 +67,8 @@ void FakeMagnetometer::Run()
 		if (_vehicle_gps_position_sub.copy(&gps)) {
 			if (gps.eph < 1000) {
 
-				const double lat = gps.lat / 1.e7;
-				const double lon = gps.lon / 1.e7;
+				const double lat = gps.lat;
+				const double lon = gps.lon;
 
 				// magnetic field data returned by the geo library using the current GPS position
 				const float mag_declination_gps = get_mag_declination_radians(lat, lon);

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -236,11 +236,9 @@ static float get_sphere_radius()
 
 		if (gps_sub.copy(&gps)) {
 			if (hrt_elapsed_time(&gps.timestamp) < 100_s && (gps.fix_type >= 2) && (gps.eph < 1000)) {
-				const double lat = gps.lat / 1.e7;
-				const double lon = gps.lon / 1.e7;
 
 				// magnetic field data returned by the geo library using the current GPS position
-				return get_mag_strength_gauss(lat, lon);
+				return get_mag_strength_gauss(gps.lat, gps.lon);
 			}
 		}
 	}
@@ -970,8 +968,8 @@ int do_mag_calibration_quick(orb_advert_t *mavlink_log_pub, float heading_radian
 
 		if (vehicle_gps_position_sub.copy(&gps)) {
 			if ((gps.timestamp != 0) && (gps.eph < 1000)) {
-				latitude = gps.lat / 1.e7f;
-				longitude = gps.lon / 1.e7f;
+				latitude = (float)gps.lat;
+				longitude = (float)gps.lon;
 				mag_earth_available = true;
 			}
 		}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1134,7 +1134,7 @@ void EKF2::PublishOpticalFlowVel(const hrt_abstime &timestamp, const optical_flo
 
 float EKF2::filter_altitude_ellipsoid(float amsl_hgt)
 {
-	float height_diff = static_cast<float>(_gps_alttitude_ellipsoid) * 1e-3f - amsl_hgt;
+	float height_diff = _gps_alttitude_ellipsoid - amsl_hgt;
 
 	if (_gps_alttitude_ellipsoid_previous_timestamp == 0) {
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -188,7 +188,7 @@ private:
 	bool _had_valid_terrain{false};			///< true if at any time there was a valid terrain estimate
 
 	uint64_t _gps_time_usec{0};
-	int32_t _gps_alttitude_ellipsoid{0};			///< altitude in 1E-3 meters (millimeters) above ellipsoid
+	float _gps_alttitude_ellipsoid{0.0f};			///< altitude in meters above ellipsoid
 	uint64_t _gps_alttitude_ellipsoid_previous_timestamp{0}; ///< storage for previous timestamp to compute dt
 	float   _wgs84_hgt_offset = 0;  ///< height offset between AMSL and WGS84
 

--- a/src/modules/local_position_estimator/sensors/gps.cpp
+++ b/src/modules/local_position_estimator/sensors/gps.cpp
@@ -92,9 +92,9 @@ int BlockLocalPositionEstimator::gpsMeasure(Vector<double, n_y_gps> &y)
 {
 	// gps measurement
 	y.setZero();
-	y(0) = _sub_gps.get().lat * 1e-7;
-	y(1) = _sub_gps.get().lon * 1e-7;
-	y(2) = _sub_gps.get().alt * 1e-3;
+	y(0) = _sub_gps.get().lat;
+	y(1) = _sub_gps.get().lon;
+	y(2) = _sub_gps.get().alt;
 	y(3) = (double)_sub_gps.get().vel_n_m_s;
 	y(4) = (double)_sub_gps.get().vel_e_m_s;
 	y(5) = (double)_sub_gps.get().vel_d_m_s;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1371,10 +1371,10 @@ protected:
 
 			msg.time_usec = gps.timestamp;
 			msg.fix_type = gps.fix_type;
-			msg.lat = gps.lat;
-			msg.lon = gps.lon;
-			msg.alt = gps.alt;
-			msg.alt_ellipsoid = gps.alt_ellipsoid;
+			msg.lat = gps.lat * 1e+7;
+			msg.lon = gps.lon * 1e+7;
+			msg.alt = gps.alt * 1e3f;
+			msg.alt_ellipsoid = gps.alt_ellipsoid * 1e3f;
 			msg.eph = gps.hdop * 100;
 			msg.epv = gps.vdop * 100;
 			msg.h_acc = gps.eph * 1e3f;
@@ -1447,16 +1447,16 @@ protected:
 
 			msg.time_usec = gps.timestamp;
 			msg.fix_type = gps.fix_type;
-			msg.lat = gps.lat;
-			msg.lon = gps.lon;
-			msg.alt = gps.alt;
+			msg.lat = (int32_t)(gps.lat * 1e+7);
+			msg.lon = (int32_t)(gps.lon * 1e+7);
+			msg.alt = (int32_t)(gps.alt * 1e3f);
 			msg.eph = gps.eph * 1e3f;
 			msg.epv = gps.epv * 1e3f;
 			msg.vel = cm_uint16_from_m_float(gps.vel_m_s);
 			msg.cog = math::degrees(wrap_2pi(gps.cog_rad)) * 1e2f;
 			msg.satellites_visible = gps.satellites_used;
+			msg.dgps_age = gps.dgps_age;
 			//msg.dgps_numch = // Number of DGPS satellites
-			//msg.dgps_age = // Age of DGPS info
 
 			mavlink_msg_gps2_raw_send_struct(_mavlink->get_channel(), &msg);
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2348,9 +2348,9 @@ MavlinkReceiver::handle_message_hil_gps(mavlink_message_t *msg)
 	hil_gps.time_utc_usec = gps.time_usec;
 
 	hil_gps.timestamp = timestamp;
-	hil_gps.lat = gps.lat;
-	hil_gps.lon = gps.lon;
-	hil_gps.alt = gps.alt;
+	hil_gps.lat = gps.lat * 1e+7;
+	hil_gps.lon = gps.lon * 1e+7;
+	hil_gps.alt = gps.alt * 1e+3;
 	hil_gps.eph = (float)gps.eph * 1e-2f; // from cm to m
 	hil_gps.epv = (float)gps.epv * 1e-2f; // from cm to m
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -197,8 +197,7 @@ bool Geofence::check(const vehicle_global_position_s &global_position, const veh
 			return checkAll(global_position);
 
 		} else {
-			return checkAll((double)gps_position.lat * 1.0e-7, (double)gps_position.lon * 1.0e-7,
-					(double)gps_position.alt * 1.0e-3);
+			return checkAll(gps_position.lat, gps_position.lon, gps_position.alt);
 		}
 
 	} else {
@@ -210,7 +209,7 @@ bool Geofence::check(const vehicle_global_position_s &global_position, const veh
 			return checkAll(global_position, baro_altitude_amsl);
 
 		} else {
-			return checkAll((double)gps_position.lat * 1.0e-7, (double)gps_position.lon * 1.0e-7, baro_altitude_amsl);
+			return checkAll(gps_position.lat, gps_position.lon, baro_altitude_amsl);
 		}
 	}
 }

--- a/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
+++ b/src/modules/sensors/vehicle_gps_position/VehicleGPSPosition.hpp
@@ -122,7 +122,7 @@ private:
 	sensor_gps_s _gps_state[GPS_MAX_RECEIVERS] {}; ///< internal state data for the physical GPS
 
 	matrix::Vector2f _NE_pos_offset_m[GPS_MAX_RECEIVERS] {}; ///< Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)
-	float _hgt_offset_mm[GPS_MAX_RECEIVERS] {};	///< Filtered height offset from GPS instance relative to blended solution in _output_state.location (mm)
+	float _hgt_offset_m[GPS_MAX_RECEIVERS] {};	///< Filtered height offset from GPS instance relative to blended solution in _output_state.location (m)
 
 	uint64_t _time_prev_us[GPS_MAX_RECEIVERS] {};	///< the previous value of time_us for that GPS instance - used to detect new data.
 	uint8_t _gps_time_ref_index{0};			///< index of the receiver that is used as the timing reference for the blending update

--- a/src/modules/sih/sih.cpp
+++ b/src/modules/sih/sih.cpp
@@ -352,10 +352,10 @@ void Sih::send_IMU()
 void Sih::send_gps()
 {
 	_sensor_gps.timestamp = _now;
-	_sensor_gps.lat = (int32_t)(_gps_lat * 1e7);       // Latitude in 1E-7 degrees
-	_sensor_gps.lon = (int32_t)(_gps_lon * 1e7); // Longitude in 1E-7 degrees
-	_sensor_gps.alt = (int32_t)(_gps_alt * 1000.0f); // Altitude in 1E-3 meters above MSL, (millimetres)
-	_sensor_gps.alt_ellipsoid = (int32_t)(_gps_alt * 1000); // Altitude in 1E-3 meters bove Ellipsoid, (millimetres)
+	_sensor_gps.lat = _gps_lat; // Latitude in degrees
+	_sensor_gps.lon = _gps_lon; // Longitude in degrees
+	_sensor_gps.alt = _gps_alt; // Altitude in meters above MSL
+	_sensor_gps.alt_ellipsoid = _gps_alt; // Altitude in meters above Ellipsoid
 	_sensor_gps.vel_ned_valid = true;              // True if NED velocity is valid
 	_sensor_gps.vel_m_s = sqrtf(_gps_vel(0) * _gps_vel(0) + _gps_vel(1) * _gps_vel(
 					    1)); // GPS ground speed, (metres/sec)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -333,9 +333,9 @@ void Simulator::handle_message_hil_gps(const mavlink_message_t *msg)
 		gps.timestamp = hrt_absolute_time();
 		gps.time_utc_usec = hil_gps.time_usec;
 		gps.fix_type = hil_gps.fix_type;
-		gps.lat = hil_gps.lat;
-		gps.lon = hil_gps.lon;
-		gps.alt = hil_gps.alt;
+		gps.lat = hil_gps.lat * 1e-7;
+		gps.lon = hil_gps.lon * 1e-7;
+		gps.alt = hil_gps.alt * 1e-3f;
 		gps.eph = (float)hil_gps.eph * 1e-2f; // cm -> m
 		gps.epv = (float)hil_gps.epv * 1e-2f; // cm -> m
 		gps.vel_m_s = (float)(hil_gps.vel) / 100.0f; // cm/s -> m/s


### PR DESCRIPTION
double for lat and lon in degrees, float for alt in meters.

1. 1e7 deg precision for lat and long can be not enough in several specific cases (for example RTK)
2. In most calculations (especially in ekf) px4 internally already uses lat, lon as doubles converting them on input and output every time back and forward from deg/1e-7deg (and m/mm for alt).
3. 1e7 deg precision is still used as output in legacy things, like current gps mavlink messages.

todo: gps drives need to be updated

Also dgps_age field added to sensor_gps.msg and vehicle_gps_position.msg  (and filled for MavlinkStreamGPS2Raw). It should be parsed it gps drivers where available. But probably this change should go to separate PR.