### PR TITLE
boards: CUAV CAN GPS flash based parameters

### DIFF
--- a/boards/cuav/can-gps-v1/src/board_config.h
+++ b/boards/cuav/can-gps-v1/src/board_config.h
@@ -73,6 +73,8 @@
 #define HRT_TIMER                    3  /* use timer 3 for the HRT */
 #define HRT_TIMER_CHANNEL            4  /* use capture/compare channel 4 */
 
+#define FLASH_BASED_PARAMS
+
 __BEGIN_DECLS
 #define BOARD_HAS_N_S_RGB_LED       8  /* Uses 8 SK6812 digital led chip */
 #define BOARD_MAX_LEDS              BOARD_HAS_N_S_RGB_LED

--- a/boards/cuav/can-gps-v1/src/init.c
+++ b/boards/cuav/can-gps-v1/src/init.c
@@ -71,6 +71,10 @@
 
 #include <px4_platform_common/init.h>
 
+# if defined(FLASH_BASED_PARAMS)
+#  include <parameters/flashparams/flashfs.h>
+#endif
+
 /************************************************************************************
  * Name: stm32_boardinitialize
  *
@@ -126,9 +130,24 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 {
 	px4_platform_init();
 
-	/* Configure the HW based on the manifest */
+#if defined(FLASH_BASED_PARAMS)
+	static sector_descriptor_t params_sector_map[] = {
+		{2, 16 * 1024, 0x08008000},
+		{3, 16 * 1024, 0x0800C000},
+		{0, 0, 0},
+	};
 
-	px4_platform_configure();
+	/* Initialize the flashfs layer to use heap allocated memory */
+	int result = parameter_flashfs_init(params_sector_map, NULL, 0);
+
+	if (result != OK) {
+		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
+		return -ENODEV;
+	}
+
+#endif // FLASH_BASED_PARAMS
+
+	//px4_platform_configure();
 
 	return OK;
 }


### PR DESCRIPTION
``` Console
nsh> param show
Symbols: x = used, + = saved, * = unsaved
x   CANNODE_BITRATE [0,24] : 1000000
x   CANNODE_NODE_ID [1,25] : 120
x   GPS_1_GNSS [2,40] : 0
x   GPS_DUMP_COMM [3,44] : 0
x + GPS_UBX_DYNMODEL [4,45] : 6
x   GPS_UBX_MODE [5,46] : 0
x   GPS_YAW_OFFSET [6,47] : 0.0000

 7/74 parameters used.
```