### PR TITLE
FlightTasks: hotfix guard against accessing no task

### DIFF
--- a/src/lib/flight_tasks/FlightTasks.hpp
+++ b/src/lib/flight_tasks/FlightTasks.hpp
@@ -150,14 +150,24 @@ public:
 	/**
 	 * Sets an external yaw handler. The active flight task can use the yaw handler to implement a different yaw control strategy.
 	 */
-	void setYawHandler(WeatherVane *ext_yaw_handler) {_current_task.task->setYawHandler(ext_yaw_handler);}
+	void setYawHandler(WeatherVane *ext_yaw_handler)
+	{
+		if (isAnyTaskActive()) {
+			_current_task.task->setYawHandler(ext_yaw_handler);
+		}
+	}
 
 	/**
 	 *   This method will re-activate current task.
 	 */
 	void reActivate();
 
-	void updateVelocityControllerIO(const matrix::Vector3f &vel_sp, const matrix::Vector3f &thrust_sp) {_current_task.task->updateVelocityControllerIO(vel_sp, thrust_sp); }
+	void updateVelocityControllerIO(const matrix::Vector3f &vel_sp, const matrix::Vector3f &thrust_sp)
+	{
+		if (isAnyTaskActive()) {
+			_current_task.task->updateVelocityControllerIO(vel_sp, thrust_sp);
+		}
+	}
 
 private:
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When you lose GPS estimate and command an Orbit (not already running one) there's a null pointer exception:
1. The flight task update is called because a task is running, current_task not null
2. In the update, the vehicle commands handling gets called which can switch to a different task e.g. Orbit
3. If no GPS is available Orbit activation fails, not yet sure why this results in no task running
4. There's other things called on `_flight_tasks` that access the `current_task` pointer
5. The pointer access was guarded in every single case but people added more calls and ignored guarding which I did not see:
https://github.com/PX4/PX4-Autopilot/pull/10411/files#diff-e300be601083c82735501dd851cd44f0bd564c5a88200e72e7a66a01a9f8c6a5R132
https://github.com/PX4/PX4-Autopilot/pull/10746/files#diff-e300be601083c82735501dd851cd44f0bd564c5a88200e72e7a66a01a9f8c6a5R139

**Describe your solution**
Hotifx for 5.: Add missing safety guard for null pointer exception when accessing the current task but none is running.

**Describe possible alternatives**
This is fixed on master by fixing 2. which is the better way. See https://github.com/PX4/PX4-Autopilot/pull/16484#discussion_r555846374 and the follow-up to it. I still have to check what causes 3. and if the issue is still there.

**Test data / coverage**
We found this issue luckily while bench testing a vehicle (without GPS). The hard fault was reproducible in SITL as a segfault and hence gdb debuggable. With this hotfix the vehicle goes into failsafe instead of crashing.

**Additional context**
Note this was likely not found because it's a corner case. QGC doesn't allow commanding an Orbit without a position lock and I was not able to trick it in any way to work around that but commanded it in a different way. 
