### PR TITLE
cuav gps:Add Beep indication

### DIFF
--- a/boards/cuav/can-gps-v1/init/rc.board_defaults
+++ b/boards/cuav/can-gps-v1/init/rc.board_defaults
@@ -3,6 +3,7 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 neopixel start
+tone_alarm start
 
 if [ $AUTOCNF = yes ]
 then


### PR DESCRIPTION
This adds the tone_alarm. 

In testing 
after repeated (suspected too quickly) ` tune_control play -t 3`  the FMU stops sending  `BeepCommand` 