### PR TITLE
isentek: fix compiler warning

### DIFF
--- a/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
@@ -179,7 +179,7 @@ void IST8308::RunImpl()
 					int16_t z = combine(buffer.DATAZH, buffer.DATAZL);
 
 					// sensor's frame is +x forward, +y right, +z up
-					z = (z == INT16_MIN) ? INT16_MAX : -z; // flip z
+					z = (z <= INT16_MIN) ? INT16_MAX : -z; // flip z
 
 					_px4_mag.set_error_count(perf_event_count(_bad_register_perf) + perf_event_count(_bad_transfer_perf));
 					_px4_mag.update(now, x, y, z);

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -185,7 +185,7 @@ void IST8310::RunImpl()
 					int16_t z = combine(buffer.DATAZH, buffer.DATAZL);
 
 					// sensor's frame is +x forward, +y right, +z up
-					z = (z == INT16_MIN) ? INT16_MAX : -z; // flip z
+					z = (z <= INT16_MIN) ? INT16_MAX : -z; // flip z
 
 					_px4_mag.set_error_count(perf_event_count(_bad_register_perf) + perf_event_count(_bad_transfer_perf));
 					_px4_mag.update(now, x, y, z);


### PR DESCRIPTION
arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10-2020-q4-major)
        10.2.1 20201103 (release) warns about `float == int`.
        Perhaps the float can never be less than `INT16_MIN`, by
        protocol, but <= will always work without warning.
