### PR TITLE
uavcan:Beep Repeated tunes are OK

### DIFF
--- a/src/drivers/uavcan/beep.cpp
+++ b/src/drivers/uavcan/beep.cpp
@@ -64,7 +64,8 @@ void UavcanBeep::periodic_update(const uavcan::TimerEvent &)
 		_tune_control_sub.copy(&_tune);
 
 		if (_tune.timestamp > 0) {
-			_play_tone = (_tunes.set_control(_tune) == Tunes::ControlResult::Success);
+			Tunes::ControlResult result =  _tunes.set_control(_tune);
+			_play_tone = (result == Tunes::ControlResult::Success) || (result == Tunes::ControlResult::AlreadyPlaying);
 		}
 	}
 


### PR DESCRIPTION
commit 3d668d8 blocks repeated tunes. But that should not stop the tune state machine of the playing tune. It will never finish and that tune can not be played again, without an interposing tune played. This fixes that