### PR TITLE
parameters: add new param_get_default_value()

### DIFF
--- a/src/drivers/uavcannode/UavcanNodeParamManager.cpp
+++ b/src/drivers/uavcannode/UavcanNodeParamManager.cpp
@@ -108,14 +108,20 @@ void UavcanNodeParamManager::readParamDefaultMaxMin(const Name &name, Value &out
 	param_type_t value_type = param_type(param_handle);
 
 	if (value_type == PARAM_TYPE_INT32) {
-		out_max.to<uavcan::protocol::param::NumericValue::Tag::integer_value>() = INT32_MAX;
+		int32_t default_value = 0;
+		param_get_default_value(param_handle, &default_value);
+		out_default.to<uavcan::protocol::param::Value::Tag::integer_value>() = default_value;
+
 		out_min.to<uavcan::protocol::param::NumericValue::Tag::integer_value>() = INT32_MIN;
-		out_default.to<uavcan::protocol::param::Value::Tag::integer_value>() = 0;
+		out_max.to<uavcan::protocol::param::NumericValue::Tag::integer_value>() = INT32_MAX;
 
 	} else if (value_type == PARAM_TYPE_FLOAT) {
-		out_max.to<uavcan::protocol::param::NumericValue::Tag::real_value>() = FLT_MAX;
+		float default_value = 0;
+		param_get_default_value(param_handle, &default_value);
+		out_default.to<uavcan::protocol::param::Value::Tag::real_value>() = default_value;
+
 		out_min.to<uavcan::protocol::param::NumericValue::Tag::real_value>() = -FLT_MAX;
-		out_default.to<uavcan::protocol::param::Value::Tag::real_value>() = 0.0;
+		out_max.to<uavcan::protocol::param::NumericValue::Tag::real_value>() = FLT_MAX;
 	}
 }
 

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -216,6 +216,16 @@ __EXPORT size_t		param_size(param_t param);
 __EXPORT int		param_get(param_t param, void *val);
 
 /**
+ * Copy the default value of a parameter.
+ *
+ * @param param		A handle returned by param_find or passed by param_foreach.
+ * @param val		Where to return the value, assumed to point to suitable storage for the parameter type.
+ *			For structures, a bitwise copy of the structure is performed to this address.
+ * @return		Zero if the parameter's deafult value could be returned, nonzero otherwise.
+ */
+__EXPORT int		param_get_default_value(param_t param, void *val);
+
+/**
  * Set the value of a parameter.
  *
  * @param param		A handle returned by param_find or passed by param_foreach.

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -581,6 +581,24 @@ param_get(param_t param, void *val)
 	return result;
 }
 
+int
+param_get_default_value(param_t param, void *default_val)
+{
+	if (default_val && handle_in_range(param)) {
+		switch (param_type(param)) {
+		case PARAM_TYPE_INT32:
+			memcpy(default_val, &param_info_base[param].val.i, param_size(param));
+			return 0;
+
+		case PARAM_TYPE_FLOAT:
+			memcpy(default_val, &param_info_base[param].val.f, param_size(param));
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
 /**
  * worker callback method to save the parameters
  * @param arg unused


### PR DESCRIPTION
This adds a new param function param_get_default_value() that mirrors param_get(), except it returns the default value. Useful for things like the uavcannode.