### PR TITLE
Simulator: Fix for arg count increase breaking remote host option.

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -79,10 +79,10 @@ int Simulator::start(int argc, char *argv[])
 			_instance->set_port(atoi(argv[4]));
 		}
 
-		if (argc == 5 && strcmp(argv[2], "-t") == 0) {
+		if (argc == 6 && strcmp(argv[3], "-t") == 0) {
 			_instance->set_ip(InternetProtocol::TCP);
-			_instance->set_tcp_remote_ipaddr(argv[3]);
-			_instance->set_port(atoi(argv[4]));
+			_instance->set_tcp_remote_ipaddr(argv[4]);
+			_instance->set_port(atoi(argv[5]));
 		}
 
 		_instance->run();


### PR DESCRIPTION
The number of arguments was increased by one, see: https://github.com/PX4/PX4-Autopilot/commit/1719ff9892f3c3d034f2b44e94d15527ab09cec6

Because the above commit was merged before https://github.com/PX4/PX4-Autopilot/pull/15443 . It broke support for the remote host option.

This has been fixed in this commit by increasing all argv's by one.

Signed-off-by: Peter Blom <peterblom.mail@gmail.com>