### PR TITLE
Device: Add MAVLINK bus type

### DIFF
--- a/src/lib/drivers/device/Device.hpp
+++ b/src/lib/drivers/device/Device.hpp
@@ -148,6 +148,7 @@ public:
 		DeviceBusType_UAVCAN  = 3,
 		DeviceBusType_SIMULATION = 4,
 		DeviceBusType_SERIAL = 5,
+		DeviceBusType_MAVLINK = 6,
 	};
 
 	/*
@@ -195,6 +196,9 @@ public:
 
 		case DeviceBusType_SERIAL:
 			return "SERIAL";
+
+		case DeviceBusType_MAVLINK:
+			return "MAVLINK";
 
 		case DeviceBusType_UNKNOWN:
 		default:

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -643,7 +643,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 		distance_sensor_s d{};
 
 		device::Device::DeviceId device_id;
-		device_id.devid_s.bus = device::Device::DeviceBusType::DeviceBusType_SERIAL;
+		device_id.devid_s.bus = device::Device::DeviceBusType::DeviceBusType_MAVLINK;
 		device_id.devid_s.devtype = DRV_DIST_DEVTYPE_MAVLINK;
 		device_id.devid_s.address = msg->sysid;
 
@@ -688,7 +688,7 @@ MavlinkReceiver::handle_message_hil_optical_flow(mavlink_message_t *msg)
 	distance_sensor_s d{};
 
 	device::Device::DeviceId device_id;
-	device_id.devid_s.bus = device::Device::DeviceBusType::DeviceBusType_SERIAL;
+	device_id.devid_s.bus = device::Device::DeviceBusType::DeviceBusType_MAVLINK;
 	device_id.devid_s.devtype = DRV_DIST_DEVTYPE_MAVLINK;
 	device_id.devid_s.address = msg->sysid;
 
@@ -742,7 +742,7 @@ MavlinkReceiver::handle_message_distance_sensor(mavlink_message_t *msg)
 	distance_sensor_s ds{};
 
 	device::Device::DeviceId device_id;
-	device_id.devid_s.bus = device::Device::DeviceBusType::DeviceBusType_SERIAL;
+	device_id.devid_s.bus = device::Device::DeviceBusType::DeviceBusType_MAVLINK;
 	device_id.devid_s.devtype = DRV_DIST_DEVTYPE_MAVLINK;
 	device_id.devid_s.address = dist_sensor.id;
 


### PR DESCRIPTION
Continuation of https://github.com/PX4/PX4-Autopilot/pull/16409#discussion_r565695228

Adds `DeviceBusType_MAVLINK` for device IDs, and makes use of it in `MavlinkReceiver`
