### PR TITLE
[WIP]: fw_pos_control_l1: landing speed for FW Landing and alternate min airspeed with flaps deployed

### DIFF
--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -112,8 +112,11 @@ public:
 	void set_heightrate_ff(float heightrate_ff) { _height_setpoint_gain_ff = heightrate_ff; }
 	void set_height_error_time_constant(float time_const) { _height_error_gain = 1.0f / math::max(time_const, 0.1f); }
 
-	void set_equivalent_airspeed_max(float airspeed) { _equivalent_airspeed_max = airspeed; }
+	float equivalent_airspeed_min() const { return _equivalent_airspeed_min; }
 	void set_equivalent_airspeed_min(float airspeed) { _equivalent_airspeed_min = airspeed; }
+
+	float equivalent_airspeed_max() const { return _equivalent_airspeed_max; }
+	void set_equivalent_airspeed_max(float airspeed) { _equivalent_airspeed_max = airspeed; }
 
 	void set_pitch_damping(float damping) { _pitch_damping_gain = damping; }
 	void set_vertical_accel_limit(float limit) { _vert_accel_limit = limit; }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -359,9 +359,10 @@ private:
 
 	DEFINE_PARAMETERS(
 
-		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
 		(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_fw_airspd_min,
+		(ParamFloat<px4::params::FW_AIRSPD_FLAPS>) _param_fw_airspd_flaps,
 		(ParamFloat<px4::params::FW_AIRSPD_TRIM>) _param_fw_airspd_trim,
+		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
 
 		(ParamFloat<px4::params::FW_CLMBOUT_DIFF>) _param_fw_clmbout_diff,
 
@@ -372,7 +373,7 @@ private:
 		(ParamFloat<px4::params::FW_L1_R_SLEW_MAX>) _param_fw_l1_r_slew_max,
 		(ParamFloat<px4::params::FW_R_LIM>) _param_fw_r_lim,
 
-		(ParamFloat<px4::params::FW_LND_AIRSPD_SC>) _param_fw_lnd_airspd_sc,
+		(ParamFloat<px4::params::FW_LND_AIRSPEED>) _param_fw_lnd_airspeed,
 		(ParamFloat<px4::params::FW_LND_ANG>) _param_fw_lnd_ang,
 		(ParamFloat<px4::params::FW_LND_FL_PMAX>) _param_fw_lnd_fl_pmax,
 		(ParamFloat<px4::params::FW_LND_FL_PMIN>) _param_fw_lnd_fl_pmin,

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -378,20 +378,18 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
 PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
 
 /**
- * Min. airspeed scaling factor for landing
+ * Landing Airspeed
  *
- * Multiplying this factor with the minimum airspeed of the plane
- * gives the target airspeed the landing approach.
- * FW_AIRSPD_MIN * FW_LND_AIRSPD_SC
+ * This is the airspeed you would like to land at.
  *
- * @unit norm
- * @min 1.0
- * @max 1.5
- * @decimal 2
- * @increment 0.01
- * @group FW L1 Control
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
+PARAM_DEFINE_FLOAT(FW_LND_AIRSPEED, 10.0f);
 
 /**
  * Altitude time constant factor for landing
@@ -431,6 +429,20 @@ PARAM_DEFINE_FLOAT(FW_LND_THRTC_SC, 1.0f);
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
+
+/**
+ * Minimum Airspeed (CAS) Flaps
+ *
+ * Minimum airspeed when flaps are deployed.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_FLAPS, 10.0f);
 
 /**
  * Maximum Airspeed (CAS)


### PR DESCRIPTION
This is a brief first pass at adding a landing speed parameter to fixed wing for landing.

The rationale being that landing speed should be independent of minimum speed and be able to be below minimum speed.

If flaps are used the stall speed is lowered and therefor a new lower landing/minimum speed should be able to be used.

You don't want to alter minimum speed overall as if flaps aren't deployed you run the risk of stalling when under-speed.

Ideally, (as @dagar notes) minimum speed should really be tied to flap deployment amount and scale accordingly but this in needed in one form or another.

Also, fw_lnd_airspd_sc is not able to go below 100%. Even with force saving it, it does not cause any attempt in hitting the target landing airspeed below the minimum airspeed.