### PR TITLE
Correct max instances of actuator_outputs logging

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -119,7 +119,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_actuator_setpoint", 20);
 
 	// multi topics
-	add_topic_multi("actuator_outputs", 100, 2);
+	add_topic_multi("actuator_outputs", 100, 3);
 	add_topic_multi("logger_status", 0, 2);
 	add_topic_multi("multirotor_motor_limits", 1000, 2);
 	add_topic_multi("rate_ctrl_status", 200, 2);


### PR DESCRIPTION
The max instances on the multi topic `actuator_outputs` was incorrectly set to 2 a while ago in #15647. This means that uavcan actuator output data would not be logged as it would be in the third instance (`.02`).

Tested on a Pixhawk 4 benchtest and it's logging fine now.

Closes #16414 