### PR TITLE
UUV switch for varying actuator dofs

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1020_uuv_generic
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1020_uuv_generic
@@ -19,5 +19,10 @@ fi
 set MAV_TYPE 12
 param set MAV_TYPE ${MAV_TYPE}
 
+
+# set number of actuated degrees of freedom
+set UUV_DOF_ACTUATED 6
+
+# set mixer file
 set MIXER_FILE etc/mixers-sitl/uuv_x_sitl.main.mix
 set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1021_uuv_hippocampus
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1021_uuv_hippocampus
@@ -19,5 +19,10 @@ fi
 set MAV_TYPE 12
 param set MAV_TYPE ${MAV_TYPE}
 
+# set number of actuated degrees of freedom, i.e. 4 for the HippoCampus
+# as it is underactuated wrt to y/z-thrust
+set UUV_DOF_ACTUATED 4
+
+# set mixer file
 set MIXER_FILE etc/mixers-sitl/uuv_x_sitl.main.mix
 set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1022_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1022_uuv_bluerov2_heavy
@@ -16,5 +16,11 @@ then
 fi
 
 set PWM_OUT 12345678
+
+# set number of actuated degrees of freedom
+#  =6 for heavy-config, =5 for regular-config, which is not yet supported
+set UUV_DOF_ACTUATED 6
+
+# set mixer file
 set MIXER_FILE etc/mixers-sitl/vectored6dof_sitl.main.mix
 set MIXER custom

--- a/ROMFS/px4fmu_common/init.d/airframes/60000_uuv_generic
+++ b/ROMFS/px4fmu_common/init.d/airframes/60000_uuv_generic
@@ -28,4 +28,7 @@ fi
 set MAV_TYPE 12
 param set MAV_TYPE ${MAV_TYPE}
 
+# set number of actuated degrees of freedom
+set UUV_DOF_ACTUATED 6
+
 set MIXER uuv_x

--- a/ROMFS/px4fmu_common/init.d/airframes/60001_uuv_hippocampus
+++ b/ROMFS/px4fmu_common/init.d/airframes/60001_uuv_hippocampus
@@ -28,4 +28,8 @@ fi
 set MAV_TYPE 12
 param set MAV_TYPE ${MAV_TYPE}
 
+# set number of actuated degrees of freedom, i.e. 4 for the HippoCampus
+# as it is underactuated wrt to y/z-thrust
+set UUV_DOF_ACTUATED 4
+
 set MIXER uuv_x

--- a/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
@@ -46,6 +46,11 @@ then
 fi
 
 set PWM_OUT 12345678
+
+# set number of actuated degrees of freedom
+#  =6 for heavy-config, =5 for regular-config, which is not yet supported
+set UUV_DOF_ACTUATED 6
+
 # set MIXER IO_pass
 set MIXER vectored6dof
 

--- a/ROMFS/px4fmu_common/init.d/rc.uuv_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.uuv_apps
@@ -20,6 +20,16 @@ ekf2 start &
 #
 uuv_att_control start
 
+
+#
+# Start UUV Position Controller for UUV with 6DOF
+#
+if [ $UUV_DOF_ACTUATED = 6 ]
+then
+	uuv_pos_control start
+fi
+
+
 #
 # Start UUV Land Detector.
 #


### PR DESCRIPTION
**Describe problem solved by this pull request**
There is currently just a single vehicle_type uuv for all underwater vehicles. However, depending on the number of actuated DOF different configurations need to be used. Eg. HippoCampus UUV is underactuated and has 4 DOF while the BlueRov2 Heavy has 6 actuated DOF

**Describe your solution**
this PR introduces a new parameter UUV_DOF_ACTUATED to select different configurations. As a first step it starts the uuv_pos_controller which is proposed in PR https://github.com/PX4/PX4-Autopilot/pull/16688 . 

**Describe possible alternatives**
We could also go for multiple uuv vechicle_types e.g. uuv_4dof and uuv_6dof. However, this increases complexity while decreasing the idea of generalized modules

**Test data / coverage**
So far Gazebo only.
