### PR TITLE
Quadchute from external command

### DIFF
--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -4,7 +4,6 @@ uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_FW = 1
 uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_MC = 2
 uint8 VEHICLE_VTOL_STATE_MC = 3
 uint8 VEHICLE_VTOL_STATE_FW = 4
-uint8 VEHICLE_VTOL_STATE_QC = 5
 
 uint64 timestamp			# time since system start (microseconds)
 

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -4,6 +4,7 @@ uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_FW = 1
 uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_MC = 2
 uint8 VEHICLE_VTOL_STATE_MC = 3
 uint8 VEHICLE_VTOL_STATE_FW = 4
+uint8 VEHICLE_VTOL_STATE_QC = 5
 
 uint64 timestamp			# time since system start (microseconds)
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -160,6 +160,7 @@ void VtolAttitudeControl::vehicle_cmd_poll()
 
 			} else {
 				_transition_command = int(vehicle_command.param1 + 0.5f);
+				_immediate_transition = int(vehicle_command.param2 + 0.5f);
 			}
 
 			if (vehicle_command.from_external) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -108,12 +108,13 @@ public:
 
 	bool is_fixed_wing_requested();
 	void quadchute(const char *reason);
+	int get_transition_command() {return _transition_command;}
 
 	struct actuator_controls_s 			*get_actuators_fw_in() {return &_actuators_fw_in;}
 	struct actuator_controls_s 			*get_actuators_mc_in() {return &_actuators_mc_in;}
 	struct actuator_controls_s 			*get_actuators_out0() {return &_actuators_out_0;}
 	struct actuator_controls_s 			*get_actuators_out1() {return &_actuators_out_1;}
-	struct airspeed_validated_s 				*get_airspeed() {return &_airspeed_validated;}
+	struct airspeed_validated_s 			*get_airspeed() {return &_airspeed_validated;}
 	struct position_setpoint_triplet_s		*get_pos_sp_triplet() {return &_pos_sp_triplet;}
 	struct tecs_status_s 				*get_tecs_status() {return &_tecs_status;}
 	struct vehicle_attitude_s 			*get_att() {return &_v_att;}

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -109,6 +109,8 @@ public:
 	bool is_fixed_wing_requested();
 	void quadchute(const char *reason);
 	int get_transition_command() {return _transition_command;}
+	bool get_immediate_transition() {return _immediate_transition;}
+	void reset_immediate_transition() {_immediate_transition = false;}
 
 	struct actuator_controls_s 			*get_actuators_fw_in() {return &_actuators_fw_in;}
 	struct actuator_controls_s 			*get_actuators_mc_in() {return &_actuators_mc_in;}
@@ -222,6 +224,7 @@ private:
 	 * for fixed wings we want to have an idle speed of zero since we do not want
 	 * to waste energy when gliding. */
 	int		_transition_command{vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC};
+	bool		_immediate_transition{false};
 
 	VtolType	*_vtol_type{nullptr};	// base class for different vtol types
 

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -235,6 +235,17 @@ bool VtolType::can_transition_on_ground()
 
 void VtolType::check_quadchute_condition()
 {
+	//TODO: adapt https://mavlink.io/en/messages/common.html#MAV_VTOL_STATE to contain MAV_VTOL_STATE_QC
+	//instead of hardcoded 5.
+	if (_attc->get_transition_command() == 5 && !_quadchute_command_treated) {
+		_attc->quadchute("QuadChute by command");
+		_quadchute_command_treated = true;
+
+	} else {
+		_quadchute_command_treated = false;
+	}
+
+
 
 	if (!_tecs_running) {
 		// reset the filtered height rate and heigh rate setpoint if TECS is not running

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -235,15 +235,15 @@ bool VtolType::can_transition_on_ground()
 
 void VtolType::check_quadchute_condition()
 {
-	if (_attc->get_transition_command() == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_QC && !_quadchute_command_treated) {
-		_attc->quadchute("QuadChute by command");
+	if (_attc->get_transition_command() == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC && _attc->get_immediate_transition()
+	    && !_quadchute_command_treated) {
+		_attc->quadchute("QuadChute by external command");
 		_quadchute_command_treated = true;
+		_attc->reset_immediate_transition();
 
 	} else {
 		_quadchute_command_treated = false;
 	}
-
-
 
 	if (!_tecs_running) {
 		// reset the filtered height rate and heigh rate setpoint if TECS is not running

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -235,9 +235,7 @@ bool VtolType::can_transition_on_ground()
 
 void VtolType::check_quadchute_condition()
 {
-	//TODO: adapt https://mavlink.io/en/messages/common.html#MAV_VTOL_STATE to contain MAV_VTOL_STATE_QC
-	//instead of hardcoded 5.
-	if (_attc->get_transition_command() == 5 && !_quadchute_command_treated) {
+	if (_attc->get_transition_command() == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_QC && !_quadchute_command_treated) {
 		_attc->quadchute("QuadChute by command");
 		_quadchute_command_treated = true;
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -247,6 +247,8 @@ protected:
 
 	float _accel_to_pitch_integ = 0;
 
+	bool _quadchute_command_treated = 0;
+
 
 
 	/**

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -250,7 +250,6 @@ protected:
 	bool _quadchute_command_treated = 0;
 
 
-
 	/**
 	 * @brief      Sets mc motor minimum pwm to VT_IDLE_PWM_MC which ensures
 	 *             that they are spinning in mc mode.


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds the ability to trigger a QuadChute over a mavlink command. This enables e.g. more advanced situation assessment on the offboard computer and detect additional problems in-flight. With proper support from QGC you could also manually trigger it, for example if the drone heads towards a Geofence.

**Describe your solution**
Sending a [MAV_CMD_DO_VTOL_TRANSITION](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_VTOL_TRANSITION) command with Param1 set to 5 (hardcoded for now) triggers a Quadchute, an immediate switch to MC mode. 


**Describe possible alternatives**
This is still a stub and too much hardcoded. For a proper implementation it would be nice to add a field "MAV_VTOL_STATE_QC" to [MAV_VTOL_STATE](https://mavlink.io/en/messages/common.html#MAV_VTOL_STATE) in order to send a clean command.

Also, it could be discussed to modify [this line](https://github.com/ThomasRigi/Firmware/blob/668f5188cb9e56de4a192f73d44b512c14c58e5a/src/modules/vtol_att_control/standard.cpp#L116) (and its counterparts in tailsitter.cpp and tiltrotor.cpp) to keep the drone in failsafe mode for as long as no new transition command is sent. IMO it's not necessary, but if desired I could add it.

**Test data / coverage**
SITL on gazebo_standard_vtol: https://logs.px4.io/plot_app?log=c2a87dea-9f6a-47dc-966e-0021cf8e8158

The command was sent over MAVROS sending a CommandLong with the following values:
```
	mavros_msgs::CommandLong command;
	command.request.command = 3000; //MAV_CMD_DO_VTOL_TRANSITION
	command.request.param1 = 5; // Quadchute not yet in MAVLINK message
```

**Additional context**
Initial slack conversation with @dagar and @sfuhrer : https://px4.slack.com/archives/C52DXKYLV/p1609944258226100
