### PR TITLE
cmake: Limit color output to terminals

### DIFF
--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -114,8 +114,8 @@ function(px4_add_common_flags)
 	elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
 		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
-			# force color for gcc > 4.9
-			add_compile_options(-fdiagnostics-color=always)
+			# enable color for gcc > 4.9 when stdout is terminal
+			add_compile_options(-fdiagnostics-color=auto)
 		endif()
 
 		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.3)


### PR DESCRIPTION
VIm's Quickfix window doesn't handle escape sequences embedded in compiler output.

Please consider this PR that enables gcc to sense when output device is a terminal and otherwise omit color.

![before](https://user-images.githubusercontent.com/434667/106332772-49c2e000-623c-11eb-9500-34e2373bc39d.png)
Quickfix opens a new empty file because the escapes remain in the path it uses.

![after](https://user-images.githubusercontent.com/434667/106332903-7d056f00-623c-11eb-9aeb-24de0dd47e95.png)
Quickfix opens the right file and positions on the fake error I introduced for sake of example.