### PR TITLE
mavlink receiver: battery status - publish cells voltage and temperature

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1729,7 +1729,8 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	uint8_t cell_count = 0;
 
 	while (battery_mavlink.voltages[cell_count] < UINT16_MAX && cell_count < 10) {
-		voltage_sum += (float)(battery_mavlink.voltages[cell_count]) / 1000.0f;
+		battery_status.voltage_cell_v[cell_count] = (float)(battery_mavlink.voltages[cell_count]) / 1000.0f;
+		voltage_sum += battery_status.voltage_cell_v[cell_count];
 		cell_count++;
 	}
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1741,6 +1741,7 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
 	battery_status.discharged_mah = (float)battery_mavlink.current_consumed;
 	battery_status.cell_count = cell_count;
+	battery_status.temperature = (float)battery_mavlink.temperature;
 	battery_status.connected = true;
 
 	// Set the battery warning based on remaining charge.


### PR DESCRIPTION
This PR brings voltage and temperature for the external battery which is using mavlink to update status.

When selected **BAT1_SOURCE = external** QGC shows this for a battery voltage:

QGC v4.0.11 - without this PR
![image](https://user-images.githubusercontent.com/10188706/106361266-49e6dc80-631d-11eb-892a-8eab210a6a27.png)

QGC v4.0.11 - with this PR
![image](https://user-images.githubusercontent.com/10188706/106360961-a34e0c00-631b-11eb-919a-40dafe6ba03f.png)

QGC v4.1.1 - without this PR (missing voltage and temperature)
![image](https://user-images.githubusercontent.com/10188706/106362195-d09db880-6321-11eb-8248-c5ed15db99f9.png)

QGC v4.1.1 - with this PR (shows battery voltage and temperature)
![image](https://user-images.githubusercontent.com/10188706/106370210-18d7cd80-6358-11eb-99be-fdfa9795091d.png)
