### PR TITLE
drivers: no longer any need to advertise immediately (baro, mag, rangefinder)

### DIFF
--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -38,8 +38,6 @@
 
 PX4Barometer::PX4Barometer(uint32_t device_id)
 {
-	_sensor_baro_pub.advertise();
-
 	_sensor_baro_pub.get().device_id = device_id;
 }
 

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
@@ -40,8 +40,6 @@ PX4Magnetometer::PX4Magnetometer(uint32_t device_id, enum Rotation rotation) :
 	_device_id{device_id},
 	_rotation{rotation}
 {
-	// advertise immediately to keep instance numbering in sync
-	_sensor_pub.advertise();
 }
 
 PX4Magnetometer::~PX4Magnetometer()

--- a/src/lib/drivers/rangefinder/PX4Rangefinder.cpp
+++ b/src/lib/drivers/rangefinder/PX4Rangefinder.cpp
@@ -37,8 +37,6 @@
 
 PX4Rangefinder::PX4Rangefinder(const uint32_t device_id, const uint8_t device_orientation)
 {
-	_distance_sensor_pub.advertise();
-
 	set_device_id(device_id);
 	set_orientation(device_orientation);
 	set_rangefinder_type(distance_sensor_s::MAV_DISTANCE_SENSOR_LASER); // Default to type LASER


### PR DESCRIPTION
Advertising immediately was previously done to ensure consistent numbering between uORB publication instances (eg sensor_mag:0) and character devices (eg /dev/mag0). The character devices have now been removed for all of these driver types so this is no longer necessary. It saves a small amount of memory by preventing the unnecessary allocation of an extra uORBDeviceNode when probing mags at startup.