### PR TITLE
MacOS: Disable OS tests

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         config: [
           px4_fmu-v5_default,
-          tests, # includes px4_sitl
+          px4_sitl
+          #tests, # includes px4_sitl
           ]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This is suboptimal but survivable since MacOS is not a deployment target. We still need to identify the root cause.