### PR TITLE
boards: add CONSTRAINED_MEMORY build option

### DIFF
--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 1

--- a/boards/ark/can-flow/canbootloader.cmake
+++ b/boards/ark/can-flow/canbootloader.cmake
@@ -24,6 +24,7 @@ px4_add_board(
 	LABEL canbootloader
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	DRIVERS
 		bootloaders
 )

--- a/boards/ark/can-flow/default.cmake
+++ b/boards/ark/can-flow/default.cmake
@@ -25,6 +25,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT cannode
 	UAVCAN_INTERFACES 1
 	DRIVERS

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -5,6 +5,7 @@ px4_add_board(
 	MODEL crazyflie
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	CONSTRAINED_FLASH
 	DRIVERS

--- a/boards/bitcraze/crazyflie21/default.cmake
+++ b/boards/bitcraze/crazyflie21/default.cmake
@@ -5,6 +5,7 @@ px4_add_board(
 	MODEL crazyflie21
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	CONSTRAINED_FLASH
 	DRIVERS

--- a/boards/cuav/can-gps-v1/canbootloader.cmake
+++ b/boards/cuav/can-gps-v1/canbootloader.cmake
@@ -24,6 +24,7 @@ px4_add_board(
 	LABEL canbootloader
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	DRIVERS
 		bootloaders
 )

--- a/boards/cuav/can-gps-v1/default.cmake
+++ b/boards/cuav/can-gps-v1/default.cmake
@@ -26,6 +26,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT cannode
 	UAVCAN_INTERFACES 1
 	DRIVERS

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	CONSTRAINED_FLASH
 	SERIAL_PORTS

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL rtps
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	SERIAL_PORTS
 		GPS1:/dev/ttyS5

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/nxp/fmuk66-e/default.cmake
+++ b/boards/nxp/fmuk66-e/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 2

--- a/boards/nxp/fmuk66-e/socketcan.cmake
+++ b/boards/nxp/fmuk66-e/socketcan.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL socketcan
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 2

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 2

--- a/boards/nxp/fmuk66-v3/rtps.cmake
+++ b/boards/nxp/fmuk66-v3/rtps.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL rtps
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 2

--- a/boards/nxp/fmuk66-v3/socketcan.cmake
+++ b/boards/nxp/fmuk66-v3/socketcan.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL socketcan
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 2

--- a/boards/nxp/ucans32k146/default.cmake
+++ b/boards/nxp/ucans32k146/default.cmake
@@ -25,6 +25,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT cannode
 	UAVCAN_INTERFACES 2
 	DRIVERS

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -5,6 +5,7 @@ px4_add_board(
 	MODEL f4sd
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	CONSTRAINED_FLASH
 	SERIAL_PORTS

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	BOOTLOADER ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/extras/px4fmuv3_bl.bin
 	IO px4_io-v2_default

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL fixedwing
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	#TESTING

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL lpe
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	BOOTLOADER ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/extras/px4fmuv3_bl.bin
 	IO px4_io-v2_default

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL multicopter
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	#UAVCAN_INTERFACES 2

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL rover
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	CONSTRAINED_FLASH

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL test
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_test
 	IO px4_io-v2_default
 	TESTING

--- a/boards/px4/fmu-v3/ctrlalloc.cmake
+++ b/boards/px4/fmu-v3/ctrlalloc.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	LABEL ctrlalloc
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	LABEL rtps
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -8,6 +8,7 @@ px4_add_board(
 	LABEL stackcheck
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/px4/fmu-v4/cannode.cmake
+++ b/boards/px4/fmu-v4/cannode.cmake
@@ -25,6 +25,7 @@ px4_add_board(
 	LABEL cannode
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT cannode
 	UAVCAN_INTERFACES 1
 	SERIAL_PORTS

--- a/boards/px4/fmu-v4/ctrlalloc.cmake
+++ b/boards/px4/fmu-v4/ctrlalloc.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL ctrlalloc
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 1

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 1

--- a/boards/px4/fmu-v4/optimized.cmake
+++ b/boards/px4/fmu-v4/optimized.cmake
@@ -10,6 +10,7 @@ px4_add_board(
 	LABEL optimized
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 1

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL rtps
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	UAVCAN_INTERFACES 1

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL stackcheck
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	TESTING
 	#UAVCAN_INTERFACES 1

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL rtps
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	TESTING

--- a/boards/uvify/core/default.cmake
+++ b/boards/uvify/core/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
+	CONSTRAINED_MEMORY
 	ROMFSROOT px4fmu_common
 	UAVCAN_INTERFACES 1
 	SERIAL_PORTS

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -56,6 +56,7 @@
 #			[ EXAMPLES <list> ]
 #			[ SERIAL_PORTS <list> ]
 #			[ CONSTRAINED_FLASH ]
+#			[ CONSTRAINED_MEMORY ]
 #			[ TESTING ]
 #			[ LINKER_PREFIX <string> ]
 #			[ EMBEDDED_METADATA <string> ]
@@ -80,6 +81,7 @@
 #		SERIAL_PORTS		: mapping of user configurable serial ports and param facing name
 #		EMBEDDED_METADATA	: list of metadata to embed to ROMFS
 #		CONSTRAINED_FLASH	: flag to enable constrained flash options (eg limit init script status text)
+#		CONSTRAINED_MEMORY	: flag to enable constrained memory options (eg limit maximum number of uORB publications)
 #		TESTING			: flag to enable automatic inclusion of PX4 testing modules
 #		LINKER_PREFIX	: optional to prefix on the Linker script.
 #
@@ -156,6 +158,7 @@ function(px4_add_board)
 		OPTIONS
 			BUILD_BOOTLOADER
 			CONSTRAINED_FLASH
+			CONSTRAINED_MEMORY
 			TESTING
 		REQUIRED
 			PLATFORM
@@ -246,6 +249,11 @@ function(px4_add_board)
 	if(CONSTRAINED_FLASH)
 		set(px4_constrained_flash_build "1" CACHE INTERNAL "constrained flash build" FORCE)
 		add_definitions(-DCONSTRAINED_FLASH)
+	endif()
+
+	if(CONSTRAINED_MEMORY)
+		set(px4_constrained_memory_build "1" CACHE INTERNAL "constrained memory build" FORCE)
+		add_definitions(-DCONSTRAINED_MEMORY)
 	endif()
 
 	if(TESTING)

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -111,7 +111,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_status_flags");
 	add_topic("vtol_vehicle_status", 200);
 
-	// Control allocaton topics
+	// Control allocation topics
 	add_topic("vehicle_angular_acceleration_setpoint", 20);
 	add_topic("vehicle_angular_acceleration", 20);
 	add_topic("vehicle_thrust_setpoint", 20);
@@ -126,7 +126,12 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("telemetry_status", 1000, 4);
 
 	// EKF multi topics (currently max 9 estimators)
-	static constexpr uint8_t MAX_ESTIMATOR_INSTANCES = 4;
+#if CONSTRAINED_MEMORY
+	static constexpr uint8_t MAX_ESTIMATOR_INSTANCES = 2;
+#else
+	static constexpr uint8_t MAX_ESTIMATOR_INSTANCES = 6; // artificailly limited until PlotJuggler fixed
+#endif
+
 	add_topic("estimator_selector_status");
 	add_topic_multi("ekf_gps_drift", 1000, MAX_ESTIMATOR_INSTANCES);
 	add_topic_multi("estimator_attitude", 500, MAX_ESTIMATOR_INSTANCES);

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -58,9 +58,13 @@ struct orb_metadata {
 typedef const struct orb_metadata *orb_id_t;
 
 /**
- * Maximum number of multi topic instances
+ * Maximum number of multi topic instances. This must be <= 10 (because it's the last char of the node path)
  */
-#define ORB_MULTI_MAX_INSTANCES	10 // This must be <= 10 (because it's the last char of the node path)
+#if defined(CONSTRAINED_MEMORY)
+# define ORB_MULTI_MAX_INSTANCES 4
+#else
+# define ORB_MULTI_MAX_INSTANCES 10
+#endif
 
 /**
  * Generates a pointer to the uORB metadata structure for

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -727,12 +727,14 @@ int uORBTest::UnitTest::test_SubscriptionMulti()
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
+#if ORB_MULTI_MAX_INSTANCES > 4
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
 		ORB_ID::orb_test,
+#endif
 	};
 
 	uORB::SubscriptionMultiArray<orb_test_s> orb_test_sub_multi_array{ORB_ID::orb_test};


### PR DESCRIPTION
This adds a new board option `CONSTRAINED_MEMORY` that's analogous to the existing `CONSTRAINED_FLASH` option used for boards with < 1 MB of flash. 

 - currently the main change is that it reduces the max number of ORB multi instances to 4, but usage will be expanded as needed
 - limits number of EKF2 multi instances to 2.
 - enabled on all cortex m4 boards