### PR TITLE
Disable unmaintained MAVROS tests

### DIFF
--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -17,12 +17,12 @@ jobs:
         config:
           - {vehicle: "iris",          mission: "MC_mission_box",  build_type: "RelWithDebInfo"}
           - {vehicle: "rover",         mission: "rover_mission_1", build_type: "RelWithDebInfo"}
-          - {vehicle: "plane",         mission: "FW_mission_1",    build_type: "RelWithDebInfo"}
-          - {vehicle: "plane_catapult",mission: "FW_mission_1",    build_type: "RelWithDebInfo"}
-          - {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "Coverage"}
-          - {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "AddressSanitizer"}
+          #- {vehicle: "plane",         mission: "FW_mission_1",    build_type: "RelWithDebInfo"}
+          #- {vehicle: "plane_catapult",mission: "FW_mission_1",    build_type: "RelWithDebInfo"}
+          #- {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "Coverage"}
+          #- {vehicle: "standard_vtol", mission: "VTOL_mission_1",  build_type: "AddressSanitizer"}
           #- {vehicle: "tailsitter",    mission: "VTOL_mission_1",  build_type: "RelWithDebInfo"}
-          - {vehicle: "tiltrotor",     mission: "VTOL_mission_1",  build_type: "RelWithDebInfo"}
+          #- {vehicle: "tiltrotor",     mission: "VTOL_mission_1",  build_type: "RelWithDebInfo"}
 
     container:
       image: px4io/px4-dev-ros-melodic:2020-11-18


### PR DESCRIPTION
The overhead of the MAVROS setup means that most developers are not using it, leading to tests that are not suitable for day-to-day workflows. We are replacing these with MAVSDK tests that can be run locally pre-commit.
