### PR TITLE
Commander/preflight checks: Add monitoring to ESC failures

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -17,6 +17,7 @@ bool condition_home_position_valid		# indicates a valid home position (a valid h
 bool condition_power_input_valid                # set if input power is valid
 bool condition_battery_healthy                # set if battery is available and not low
 bool condition_escs_error		      # set to true if one or more ESCs reporting esc_status are offline
+bool condition_escs_failure		      # set to true if one or more ESCs reporting esc_status has a failure
 
 bool circuit_breaker_engaged_power_check
 bool circuit_breaker_engaged_airspd_check

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -140,6 +140,14 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		}
 	}
 
+	if (arm_requirements.esc_check && status_flags.condition_escs_failure) {
+		if (prearm_ok) {
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! One or more ESCs have a failure"); }
+
+			prearm_ok = false;
+		}
+	}
+
 	if (status.is_vtol) {
 
 		if (status.in_transition_mode) {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -143,7 +143,7 @@ private:
 
 	void avoidance_check();
 
-	void esc_status_check(const esc_status_s &esc_status);
+	void esc_status_check();
 
 	void estimator_check();
 
@@ -334,7 +334,7 @@ private:
 
 	int		_last_esc_online_flags{-1};
 	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {0};
-	bool		_esc_status_was_updated{false};
+	hrt_abstime	_last_esc_status_updated{0};
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	float		_battery_current{0.0f};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -333,6 +333,8 @@ private:
 	hrt_abstime	_high_latency_datalink_lost{0};
 
 	int		_last_esc_online_flags{-1};
+	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {0};
+	bool		_esc_status_was_updated{false};
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	float		_battery_current{0.0f};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -333,7 +333,7 @@ private:
 	hrt_abstime	_high_latency_datalink_lost{0};
 
 	int		_last_esc_online_flags{-1};
-	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {0};
+	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {};
 	hrt_abstime	_last_esc_status_updated{0};
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -904,12 +904,12 @@ PARAM_DEFINE_INT32(COM_FLT_PROFILE, 0);
  * Enable checks on ESCs that report telemetry.
  *
  * If this parameter is set, the system will check ESC's online status and failures.
- * This param is specific for ESCs reporting status. Normal ESCs configurations are not affected by the change of this param.
+ * This param is specific for ESCs reporting status. It shall be used only if ESCs support telemetry.
  *
  * @group Commander
  * @boolean
  */
-PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 1);
+PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 0);
 
 /**
  * Condition to enter prearmed mode

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -901,8 +901,9 @@ PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
 PARAM_DEFINE_INT32(COM_FLT_PROFILE, 0);
 
 /**
- * Require all the ESCs to be detected to arm.
+ * Enable checks on ESCs that report telemetry.
  *
+ * If this parameter is set, the system will check ESC's online status and failures.
  * This param is specific for ESCs reporting status. Normal ESCs configurations are not affected by the change of this param.
  *
  * @group Commander


### PR DESCRIPTION
Resurrected version of https://github.com/PX4/PX4-Autopilot/pull/14800.

**Describe problem solved by this pull request**
This PR extends monitoring to failures reported by ESCs with telemetry.

ESC checks are enabled/disabled with the `COM_ARM_CHK_ESCS` parameter.

**Test data / coverage**
I've been flying this exact code with smart ESCs since the first PR was opened.

