### PR TITLE
IMU drivers increase optimization to ${MAX_CUSTOM_OPT_LEVEL}

### DIFF
--- a/src/drivers/imu/bosch/bmi055/CMakeLists.txt
+++ b/src/drivers/imu/bosch/bmi055/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__bosch__bmi055
 	MAIN bmi055
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		Bosch_BMI055_Accelerometer_Registers.hpp
 		Bosch_BMI055_Gyroscope_Registers.hpp

--- a/src/drivers/imu/bosch/bmi088/CMakeLists.txt
+++ b/src/drivers/imu/bosch/bmi088/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__bosch__bmi088
 	MAIN bmi088
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		Bosch_BMI088_Accelerometer_Registers.hpp
 		Bosch_BMI088_Gyroscope_Registers.hpp

--- a/src/drivers/imu/invensense/icm20602/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm20602/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__icm20602
 	MAIN icm20602
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		ICM20602.cpp
 		ICM20602.hpp

--- a/src/drivers/imu/invensense/icm20608g/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm20608g/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__icm20608g
 	MAIN icm20608g
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		ICM20608G.cpp
 		ICM20608G.hpp

--- a/src/drivers/imu/invensense/icm20649/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm20649/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__icm20649
 	MAIN icm20649
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		ICM20649.cpp
 		ICM20649.hpp

--- a/src/drivers/imu/invensense/icm20689/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm20689/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__icm20689
 	MAIN icm20689
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		ICM20689.cpp
 		ICM20689.hpp

--- a/src/drivers/imu/invensense/icm20948/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm20948/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE drivers__imu__icm20948
 	MAIN icm20948
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		AKM_AK09916_registers.hpp
 		ICM20948.cpp

--- a/src/drivers/imu/invensense/icm40609d/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm40609d/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__icm40609d
 	MAIN icm40609d
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		icm40609d_main.cpp
 		ICM40609D.cpp

--- a/src/drivers/imu/invensense/icm42605/CMakeLists.txt
+++ b/src/drivers/imu/invensense/icm42605/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__icm42605
 	MAIN icm42605
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		icm42605_main.cpp
 		ICM42605.cpp

--- a/src/drivers/imu/invensense/mpu6000/CMakeLists.txt
+++ b/src/drivers/imu/invensense/mpu6000/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__mpu6000
 	MAIN mpu6000
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		MPU6000.cpp
 		MPU6000.hpp

--- a/src/drivers/imu/invensense/mpu6500/CMakeLists.txt
+++ b/src/drivers/imu/invensense/mpu6500/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__mpu6500
 	MAIN mpu6500
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		MPU6500.cpp
 		MPU6500.hpp

--- a/src/drivers/imu/invensense/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/invensense/mpu9250/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__mpu9250
 	MAIN mpu9250
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		AKM_AK8963_registers.hpp
 		InvenSense_MPU9250_registers.hpp
@@ -54,6 +55,7 @@ px4_add_module(
 	MODULE drivers__imu__invensense__mpu9250_i2c
 	MAIN mpu9250_i2c
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
 		InvenSense_MPU9250_registers.hpp
 		MPU9250_I2C.cpp

--- a/src/lib/drivers/device/CMakeLists.txt
+++ b/src/lib/drivers/device/CMakeLists.txt
@@ -34,29 +34,42 @@
 set(SRCS_PLATFORM)
 if (${PX4_PLATFORM} STREQUAL "nuttx")
 	if ("${CONFIG_I2C}" STREQUAL "y")
-		list(APPEND SRCS_PLATFORM nuttx/I2C.cpp)
+		list(APPEND SRCS_PLATFORM
+			nuttx/I2C.cpp
+			nuttx/I2C.hpp
+		)
 	endif()
 
 	if ("${CONFIG_SPI}" STREQUAL "y")
-		list(APPEND SRCS_PLATFORM nuttx/SPI.cpp)
+		list(APPEND SRCS_PLATFORM
+			nuttx/SPI.cpp
+			nuttx/SPI.hpp
+		)
 	endif()
 elseif((${PX4_PLATFORM} MATCHES "qurt"))
 	list(APPEND SRCS_PLATFORM
 		qurt/I2C.cpp
+		qurt/I2C.hpp
 		qurt/SPI.cpp
+		qurt/SPI.hpp
 	)
 elseif(UNIX AND NOT APPLE AND NOT (${PX4_PLATFORM} MATCHES "qurt")) #TODO: add linux PX4 platform type
 	# Linux I2Cdev and SPIdev
 	list(APPEND SRCS_PLATFORM
 		posix/I2C.cpp
+		posix/I2C.hpp
 		posix/SPI.cpp
+		posix/SPI.hpp
 	)
 endif()
 
 px4_add_library(drivers__device
 	CDev.cpp
+	CDev.hpp
 	${SRCS_PLATFORM}
-	)
+)
+
+target_compile_options(drivers__device PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 
 if (${PX4_PLATFORM} STREQUAL "nuttx")
 	target_link_libraries(drivers__device PRIVATE nuttx_arch)


### PR DESCRIPTION
 - defaults to -Os on flash constrained boards, otherwise -O2