### PR TITLE
Navigator: change default of GF_ACTION to 2 (Hold)

### DIFF
--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -62,7 +62,7 @@
  * @value 5 Land mode
  * @group Geofence
  */
-PARAM_DEFINE_INT32(GF_ACTION, 1);
+PARAM_DEFINE_INT32(GF_ACTION, 2);
 
 /**
  * Geofence altitude mode


### PR DESCRIPTION

**Describe problem solved by this pull request**
Current geofence action is at "Warning", so to have the fence actually active the user needs to change the settings.

**Describe your solution**
In my opinion, with adding a geofence the user normally has the intent of not allowing the vehicle to go out of the defined area, and not just to get a warning. Thus the default would be changed to 2 (Hold). 
