### PR TITLE
Add a simple commandline tool

### DIFF
--- a/px4
+++ b/px4
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import os
+import argparse
+
+# Dependencies:
+# Install MAVSDK: https://mavsdk.mavlink.io/develop/en/getting_started/installation.html
+
+# Usage:
+# Run SITL tests as in CI: ./px4 tests sitl
+
+# For convenience: You can add the directory to the PATH
+# Warning: If you work with multiple PX4 installations in
+# parallel, this can cause confusion as to what you are running
+# only recommended if a single directory is being used.
+
+# On MacOS, add this to your ~/.zshenv file:
+# export PATH=$PATH:~/src/PX4-Autopilot
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose",
+                        help="Verbose output", default=False)
+    args = parser.parse_args()
+
+    # Change working directory to root working directory
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    os.system('DONT_RUN=1 make px4_sitl_default gazebo mavsdk_tests')
+    os.system('test/mavsdk_tests/mavsdk_test_runner.py --speed-factor 20 --abort-early --model iris test/mavsdk_tests/configs/sitl.json')
+    sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This commandline tool will start to capture more and more aspects of the build and deploy process and become a very similar tool compared to ADB.

Not done yet, but as we're adding more commands it will quickly become a reference for some of the arcane PX4 commands and usage.