### PR TITLE
drivers/distance_sensor: add drivers_rangefinder linking dependency

### DIFF
--- a/src/drivers/distance_sensor/leddar_one/CMakeLists.txt
+++ b/src/drivers/distance_sensor/leddar_one/CMakeLists.txt
@@ -41,4 +41,6 @@ px4_add_module(
 		leddar_one_main.cpp
 	MODULE_CONFIG
 		module.yaml
+	DEPENDS
+		drivers_rangefinder
 	)

--- a/src/drivers/distance_sensor/lightware_laser_i2c/CMakeLists.txt
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/CMakeLists.txt
@@ -36,5 +36,6 @@ px4_add_module(
 	SRCS
 		lightware_laser_i2c.cpp
 	DEPENDS
+		drivers_rangefinder
 	)
 

--- a/src/drivers/distance_sensor/mappydot/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mappydot/CMakeLists.txt
@@ -35,4 +35,6 @@ px4_add_module(
 	MAIN mappydot
 	SRCS
 		MappyDot.cpp
+	DEPENDS
+		drivers_rangefinder
 	)

--- a/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
@@ -37,4 +37,6 @@ px4_add_module(
 		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		mb12xx.cpp
+	DEPENDS
+		drivers_rangefinder
 	)

--- a/src/drivers/distance_sensor/pga460/CMakeLists.txt
+++ b/src/drivers/distance_sensor/pga460/CMakeLists.txt
@@ -37,4 +37,6 @@ px4_add_module(
 	MAIN pga460
 	SRCS
 		pga460.cpp
+	DEPENDS
+		drivers_rangefinder
 	)


### PR DESCRIPTION
 - fixes https://github.com/PX4/PX4-Autopilot/issues/16715

These missing linking dependencies go unnoticed in larger builds where something else brings it in.
