### PR TITLE
Set cruise trottle to non-zero for Rover

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -36,7 +36,7 @@ then
 	param set GND_SPEED_IMAX 0.125
 	param set GND_SPEED_THR_SC 1
 	param set GND_THR_IDLE 0
-	param set GND_THR_CRUISE 0
+	param set GND_THR_CRUISE 0.3
 	param set GND_THR_MAX 0.5
 	param set GND_THR_MIN 0
 	param set GND_WR_P 2

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
@@ -34,7 +34,7 @@ then
 	param set FW_AIRSPD_MAX 3
 
 	param set GND_THR_IDLE 0
-	param set GND_THR_CRUISE 0
+	param set GND_THR_CRUISE 0.3
 	param set GND_THR_MAX 0.5
 
 	# Differential drive acts like ackermann steering with a maximum turn angle of 60 degrees, or pi/3 radians


### PR DESCRIPTION
**Describe problem solved by this pull request**
It was reported that rover was not moving, when in mission mode. This issue was something not visible in SITL.
It seems that this behavior was caused by setting the `GND_THR_CRUISE` which defines the mission throttle to zero. 

**Describe your solution**
Set the cruise throttle of the rover vehicle to a non-zero value

**Test data / coverage**
- TODO

**Additional context**
- Fixes https://github.com/PX4/PX4-Autopilot/issues/16586
