### PR TITLE
boards: enable UAVCAN sensors by default on F7/H7

### DIFF
--- a/boards/cuav/nora/init/rc.board_defaults
+++ b/boards/cuav/nora/init/rc.board_defaults
@@ -39,6 +39,8 @@ then
 
 	# Enable IMU thermal control
 	param set SENS_EN_THERMAL 1
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/cuav/x7pro/init/rc.board_defaults
+++ b/boards/cuav/x7pro/init/rc.board_defaults
@@ -39,6 +39,8 @@ then
 
 	# Enable IMU thermal control
 	param set SENS_EN_THERMAL 1
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/cubepilot/cubeorange/init/rc.board_defaults
+++ b/boards/cubepilot/cubeorange/init/rc.board_defaults
@@ -39,6 +39,8 @@ then
 
 	# Disable IMU thermal control
 	param set SENS_EN_THERMAL 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/cubepilot/cubeyellow/init/rc.board_defaults
+++ b/boards/cubepilot/cubeyellow/init/rc.board_defaults
@@ -20,6 +20,8 @@ then
 
 	# Disable IMU thermal control
 	param set SENS_EN_THERMAL 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/holybro/durandal-v1/init/rc.board_defaults
+++ b/boards/holybro/durandal-v1/init/rc.board_defaults
@@ -32,6 +32,8 @@ then
 
 	# Enable IMU thermal control
 	param set SENS_EN_THERMAL 1
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/holybro/pix32v5/init/rc.board_defaults
+++ b/boards/holybro/pix32v5/init/rc.board_defaults
@@ -11,6 +11,8 @@ then
 	param set SENS_IMU_MODE 0
 	param set EKF2_MULTI_MAG 2
 	param set SENS_MAG_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/modalai/fc-v1/init/rc.board_defaults
+++ b/boards/modalai/fc-v1/init/rc.board_defaults
@@ -30,6 +30,8 @@ then
 	# Multi-EKF
 	param set EKF2_MULTI_IMU 3
 	param set SENS_IMU_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 #

--- a/boards/mro/ctrl-zero-f7/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-f7/init/rc.board_defaults
@@ -9,6 +9,8 @@ then
 	# Multi-EKF
 	param set EKF2_MULTI_IMU 3
 	param set SENS_IMU_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/mro/pixracerpro/init/rc.board_defaults
+++ b/boards/mro/pixracerpro/init/rc.board_defaults
@@ -35,6 +35,8 @@ then
 	param set EKF2_MULTI_MAG 3
 	param set SENS_MAG_MODE 0
 
+	param set UAVCAN_ENABLE 2
+
 fi
 
 set LOGGER_BUF 64

--- a/boards/mro/x21-777/init/rc.board_defaults
+++ b/boards/mro/x21-777/init/rc.board_defaults
@@ -11,6 +11,8 @@ then
 	param set SENS_IMU_MODE 0
 	param set EKF2_MULTI_MAG 2
 	param set SENS_MAG_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v4pro/init/rc.board_defaults
+++ b/boards/px4/fmu-v4pro/init/rc.board_defaults
@@ -9,6 +9,8 @@ then
 	# Multi-EKF
 	param set EKF2_MULTI_IMU 3
 	param set SENS_IMU_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v5/init/rc.board_defaults
+++ b/boards/px4/fmu-v5/init/rc.board_defaults
@@ -19,6 +19,8 @@ then
 		param set EKF2_MULTI_MAG 2
 		param set SENS_MAG_MODE 0
 	fi
+
+	param set UAVCAN_ENABLE 2
 fi
 
 # disable px4io on HolyBro mini (V540) and CUAV V5nano (V560)

--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -9,6 +9,8 @@ then
 	# Multi-EKF
 	param set EKF2_MULTI_IMU 3
 	param set SENS_IMU_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -11,6 +11,8 @@ then
 	param set SENS_IMU_MODE 0
 	param set EKF2_MULTI_MAG 3
 	param set SENS_MAG_MODE 0
+
+	param set UAVCAN_ENABLE 2
 fi
 
 set LOGGER_BUF 64


### PR DESCRIPTION
With a growing number of UAVCAN GPS units readily available (CUAV NEO 3 Pro, Here 3, Zubax GNSS 2) it's worth enabling UAVCAN by default (sensors only) where we can afford it for a better user experience.

I'll verify required resources before merging.