### PR TITLE
Fix failure to set ground effect flag before takeoff

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -47,6 +47,7 @@
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/takeoff_status.h>
 
 #include "LandDetector.h"
 
@@ -73,6 +74,8 @@ protected:
 
 	float _get_max_altitude() override;
 private:
+
+	float _get_gnd_effect_altitude();
 
 	/** Time in us that freefall has to hold before triggering freefall */
 	static constexpr hrt_abstime FREEFALL_TRIGGER_TIME_US = 300_ms;
@@ -111,6 +114,7 @@ private:
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
+	uORB::Subscription _takeoff_status_sub{ORB_ID(takeoff_status)};
 
 	hrt_abstime _hover_thrust_estimate_last_valid{0};
 
@@ -119,18 +123,22 @@ private:
 
 	float _actuator_controls_throttle{0.f};
 
+	uint8_t _takeoff_state{takeoff_status_s::TAKEOFF_STATE_DISARMED};
+
 	hrt_abstime _min_thrust_start{0};	///< timestamp when minimum trust was applied first
 	hrt_abstime _landed_time{0};
 
 	bool _in_descend{false};		///< vehicle is desending
 	bool _horizontal_movement{false};	///< vehicle is moving horizontally
+	bool _below_gnd_effect_hgt{false};	///< vehicle height above ground is below height where ground effect occurs
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(
 		LandDetector,
 		(ParamFloat<px4::params::LNDMC_ALT_MAX>)    _param_lndmc_alt_max,
 		(ParamFloat<px4::params::LNDMC_ROT_MAX>)    _param_lndmc_rot_max,
 		(ParamFloat<px4::params::LNDMC_XY_VEL_MAX>) _param_lndmc_xy_vel_max,
-		(ParamFloat<px4::params::LNDMC_Z_VEL_MAX>)  _param_lndmc_z_vel_max
+		(ParamFloat<px4::params::LNDMC_Z_VEL_MAX>)  _param_lndmc_z_vel_max,
+		(ParamFloat<px4::params::LNDMC_ALT_GND>)    _param_lndmc_alt_gnd_effect
 	);
 };
 

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -84,3 +84,17 @@ PARAM_DEFINE_FLOAT(LNDMC_ROT_MAX, 20.0f);
  *
  */
 PARAM_DEFINE_FLOAT(LNDMC_ALT_MAX, -1.0f);
+
+/**
+ * Ground effect altitude for multicopters
+ *
+ * The height above ground below which ground effect creates barometric altitude errors.
+ * A negative value indicates no ground effect.
+ *
+ * @unit m
+ * @min -1
+ * @decimal 2
+ * @group Land Detector
+ *
+ */
+PARAM_DEFINE_FLOAT(LNDMC_ALT_GND, -1.0f);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -78,8 +78,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("px4io_status");
 	add_topic("radio_status");
 	add_topic("rpm", 500);
-	add_topic("safety");
 	add_topic("rtl_flight_time", 1000);
+	add_topic("safety");
 	add_topic("sensor_combined");
 	add_topic("sensor_correction");
 	add_topic("sensor_gyro_fft");
@@ -87,6 +87,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("sensor_selection");
 	add_topic("sensors_status_imu", 200);
 	add_topic("system_power", 500);
+	add_topic("takeoff_status", 1000);
 	add_topic("tecs_status", 200);
 	add_topic("test_motor", 500);
 	add_topic("trajectory_setpoint", 200);


### PR DESCRIPTION
Relates to:

https://github.com/PX4/PX4-Autopilot/issues/15141
https://github.com/PX4/PX4-Autopilot/pull/16652

v1.11.0 of the PX4_Autopilot contained code in the ekf2-main.cpp module that set the ground effect flag if the vehicle was close to the ground, eg:

https://github.com/PX4/PX4-Autopilot/blob/21c82a48146fb8afc5a56263a5da21300ba3137e/src/modules/ekf2/ekf2_main.cpp#L1338-L1351

This functionality has subsequently been lost because the ekf2 module now uses the vehicle_land_detected.in_ground_effect message that does not anticipate a takeoff and set the flag accordingly, eg:

https://github.com/PX4/PX4-Autopilot/blob/8b0ec5a78e03514ade6f4ddd231f4db37f8ee500/src/modules/ekf2/EKF2.cpp#L398-L410

The solution proposed is to modify the logic used to set vehicle_land_detected.in_ground_effect so that it goes true when the vehicles height above ground is below the ground effect threshold height or if motors are ramping up and the vehicle is about to takeoff. The following shows a test on a MC without a range finder, EKF2_GND_MAX_HGT = 0.5 and  EKF2_GND_EFF_DZ = 0.5

![Screen Shot 2021-02-02 at 6 29 53 pm](https://user-images.githubusercontent.com/3596952/106566641-ae57a500-6584-11eb-9d44-c630bfa646ff.png)

The vehicle was flown in POSCTL mode and the vehicle_land_detected.in_ground_effect goes true before takeoff and immediately after touchdown

TODO

An improvement to the behaviour as tested would be for vehicle_land_detected.in_ground_effect  to not go true when armed, but to wait until takeoff_status.takeoff_state == 2 or 3