### PR TITLE
uavcannode: use correct vertical position uncertainty

### DIFF
--- a/src/drivers/uavcannode/Publishers/GnssFix2.hpp
+++ b/src/drivers/uavcannode/Publishers/GnssFix2.hpp
@@ -91,7 +91,7 @@ public:
 			// position variances -- Xx, Yy, Zz
 			fix2.covariance.push_back(gps.eph);
 			fix2.covariance.push_back(gps.eph);
-			fix2.covariance.push_back(gps.eph);
+			fix2.covariance.push_back(gps.epv);
 			// velocity variance -- Vxx, Vyy, Vzz
 			fix2.covariance.push_back(gps.s_variance_m_s);
 			fix2.covariance.push_back(gps.s_variance_m_s);


### PR DESCRIPTION
or maybe there was a reason to use eph also for the vertical uncertainty?