### PR TITLE
RTPS: add alias messages RTPS id check

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -408,4 +408,10 @@ rtps:
   - msg: estimator_odometry
     id: 200
     alias: vehicle_odometry
+  - msg: actuator_controls_4
+    id: 201
+    alias: actuator_controls
+  - msg: actuator_controls_5
+    id: 202
+    alias: actuator_controls
   ########## multi topics: end ##########


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since the alias / multi-topics messages are also being mapped into ROS 2 messages, this means that they also need RTPS IDs assigned to them. Since there was no check regarding if these add IDs associated, but still the ROS message counterparts were being generated, this was resulting on having `px4_ros_com` failing to build because no IDs existed for those messages.

```sh
    raise AssertionError(
AssertionError: 
The following messages are not listen under  /home/nuno/PX4/px4_ros_com_ros2/src/px4_ros_com/templates/uorb_rtps_message_ids.yaml: ActuatorControls4, ActuatorControls5

Please add them to the yaml file with the respective ID and, if applicable, mark them to be sent or received by the micro-RTPS bridge.
NOTE: If the message has multi-topics (#TOPICS), these should be added as well.
```

**Describe your solution**
Add also a check to verify if the alias / multi-topics messages have RTPS IDs associated so to enforce that they get set.
