### PR TITLE
Fix and unify the maximum allowed PDOP references

### DIFF
--- a/Tools/ecl_ekf/analysis/post_processing.py
+++ b/Tools/ecl_ekf/analysis/post_processing.py
@@ -125,7 +125,7 @@ def get_gps_check_fail_flags(estimator_status: dict) -> dict:
 
     # 0 : insufficient fix type (no 3D solution)
     # 1 : minimum required sat count fail
-    # 2 : minimum required PDOP fail
+    # 2 : maximum allowed PDOP fail
     # 3 : maximum allowed horizontal position error fail
     # 4 : maximum allowed vertical position error fail
     # 5 : maximum allowed speed error fail

--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -12,7 +12,7 @@ uint16 gps_check_fail_flags     # Bitmask to indicate status of GPS checks - see
 # bits are true when corresponding test has failed
 uint8 GPS_CHECK_FAIL_GPS_FIX = 0		# 0 : insufficient fix type (no 3D solution)
 uint8 GPS_CHECK_FAIL_MIN_SAT_COUNT = 1		# 1 : minimum required sat count fail
-uint8 GPS_CHECK_FAIL_MIN_PDOP = 2		# 2 : minimum required PDOP fail
+uint8 GPS_CHECK_FAIL_MAX_PDOP = 2		# 2 : maximum allowed PDOP fail
 uint8 GPS_CHECK_FAIL_MAX_HORZ_ERR = 3		# 3 : maximum allowed horizontal position error fail
 uint8 GPS_CHECK_FAIL_MAX_VERT_ERR = 4		# 4 : maximum allowed vertical position error fail
 uint8 GPS_CHECK_FAIL_MAX_SPD_ERR = 5		# 5 : maximum allowed speed error fail

--- a/src/modules/commander/Arming/PreFlightCheck/checks/ekf2Check.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/ekf2Check.cpp
@@ -171,8 +171,8 @@ bool PreFlightCheck::ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_SAT_COUNT)) {
 					message = "Preflight%s: not enough GPS Satellites";
 
-				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_PDOP)) {
-					message = "Preflight%s: GPS PDOP too low";
+				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_PDOP)) {
+					message = "Preflight%s: GPS PDOP too high";
 
 				} else if (status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_ERR)) {
 					message = "Preflight%s: GPS Horizontal Pos Error too high";

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -153,7 +153,7 @@ PARAM_DEFINE_FLOAT(EKF2_AVEL_DELAY, 5);
  *
  * Set bits to 1 to enable checks. Checks enabled by the following bit positions
  * 0 : Minimum required sat count set by EKF2_REQ_NSATS
- * 1 : Minimum required PDOP set by EKF2_REQ_PDOP
+ * 1 : Maximum allowed PDOP set by EKF2_REQ_PDOP
  * 2 : Maximum allowed horizontal position error set by EKF2_REQ_EPH
  * 3 : Maximum allowed vertical position error set by EKF2_REQ_EPV
  * 4 : Maximum allowed speed error set by EKF2_REQ_SACC
@@ -166,7 +166,7 @@ PARAM_DEFINE_FLOAT(EKF2_AVEL_DELAY, 5);
  * @min 0
  * @max 511
  * @bit 0 Min sat count (EKF2_REQ_NSATS)
- * @bit 1 Min PDOP (EKF2_REQ_PDOP)
+ * @bit 1 Max PDOP (EKF2_REQ_PDOP)
  * @bit 2 Max horizontal position error (EKF2_REQ_EPH)
  * @bit 3 Max vertical position error (EKF2_REQ_EPV)
  * @bit 4 Max speed error (EKF2_REQ_SACC)
@@ -220,7 +220,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_SACC, 0.5f);
 PARAM_DEFINE_INT32(EKF2_REQ_NSATS, 6);
 
 /**
- * Required PDOP to use GPS.
+ * Maximum PDOP to use GPS.
  *
  * @group EKF2
  * @min 1.5


### PR DESCRIPTION
**Describe problem solved by this pull request**
Current master isn't consistent when talking about PDOP. Some files talk about minimum required PDOP while others use maximum allowed PDOP. This PR tries to fix those incorrect nomenclatures.

Lower values of PDOP are better and the code checks that the current value is under a threshold

**Describe your solution**
Replace the definitions of minimum required PDOP to maximum allowed PDOP.

**Test data / coverage**
PX4 SITL Gazebo

**Motivation**
This PR fixes #16731

**Extra information**
https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)

**Other external necessary modifications**
- Submodule https://github.com/PX4/PX4-ECL/ (src/lib/ecl) should also be updated (https://github.com/PX4/PX4-ECL/blob/b919f3ddf41ab422d09af91eaea2b2f9729fab13/EKF/common.h#L440) comment can result in confusion
- QGroundcontrol references to EFK2_REQ_PDOP should also be updated.

