### PR TITLE
Update current year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2012 - 2020, PX4 Development Team
+Copyright (c) 2012 - 2021, PX4 Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
2020 now is in the past.

**Describe problem solved by this pull request**
Date in the license was 2020

**Describe your solution**
Now its 2021 :+1: 

**Describe possible alternatives**
:shrug: 

**Test data / coverage**
Looking at a calendar, it is indeed 2021

**Additional context**
none
