### PR TITLE
update uorb_rtps_message_ids.yaml for id: 30

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -63,6 +63,7 @@ rtps:
     id: 29
   - msg: input_rc
     id: 30
+    send: true
   - msg: iridiumsbd_status
     id: 31
   - msg: irlock_report


### PR DESCRIPTION
For some usecases like starting video recording on a companion computer or triggering a ROS based (offboard control) mission control execution the status of RC channel is needed in ROS(2). This allows the user to start/stop such functionalities from the RC transmitter.

Therefore InputRc to be changed accordingly.
add 'Set send: true' for id: 30

This will solve https://github.com/PX4/PX4-Autopilot/issues/16741