### PR TITLE
Discussion: vehicle responsiveness configuration

### DIFF
--- a/platforms/common/include/px4_platform_common/param.h
+++ b/platforms/common/include/px4_platform_common/param.h
@@ -40,6 +40,8 @@
 #pragma once
 
 #include "param_macros.h"
+#include <float.h>
+#include <math.h>
 
 #include <parameters/px4_parameters_public.h>
 
@@ -130,6 +132,18 @@ public:
 	/// Store the parameter value to the parameter storage, w/o notifying the system (@see param_set_no_notification())
 	bool commit_no_notification() const { return param_set_no_notification(handle(), &_val) == 0; }
 
+	/// Set and commit a new value. Returns true if the value changed.
+	bool commit_no_notification(float val)
+	{
+		if (fabsf(val - _val) > FLT_EPSILON) {
+			set(val);
+			commit_no_notification();
+			return true;
+		}
+
+		return false;
+	}
+
 	void set(float val) { _val = val; }
 
 	void reset()
@@ -170,6 +184,18 @@ public:
 	/// Store the parameter value to the parameter storage, w/o notifying the system (@see param_set_no_notification())
 	bool commit_no_notification() const { return param_set_no_notification(handle(), &_val) == 0; }
 
+	/// Set and commit a new value. Returns true if the value changed.
+	bool commit_no_notification(float val)
+	{
+		if (fabsf(val - _val) > FLT_EPSILON) {
+			set(val);
+			commit_no_notification();
+			return true;
+		}
+
+		return false;
+	}
+
 	void set(float val) { _val = val; }
 
 	void reset()
@@ -207,6 +233,18 @@ public:
 
 	/// Store the parameter value to the parameter storage, w/o notifying the system (@see param_set_no_notification())
 	bool commit_no_notification() const { return param_set_no_notification(handle(), &_val) == 0; }
+
+	/// Set and commit a new value. Returns true if the value changed.
+	bool commit_no_notification(int32_t val)
+	{
+		if (val != _val) {
+			set(val);
+			commit_no_notification();
+			return true;
+		}
+
+		return false;
+	}
 
 	void set(int32_t val) { _val = val; }
 
@@ -247,6 +285,18 @@ public:
 
 	/// Store the parameter value to the parameter storage, w/o notifying the system (@see param_set_no_notification())
 	bool commit_no_notification() const { return param_set_no_notification(handle(), &_val) == 0; }
+
+	/// Set and commit a new value. Returns true if the value changed.
+	bool commit_no_notification(int32_t val)
+	{
+		if (val != _val) {
+			set(val);
+			commit_no_notification();
+			return true;
+		}
+
+		return false;
+	}
 
 	void set(int32_t val) { _val = val; }
 
@@ -292,6 +342,18 @@ public:
 	{
 		int32_t value_int = (int32_t)_val;
 		return param_set_no_notification(handle(), &value_int) == 0;
+	}
+
+	/// Set and commit a new value. Returns true if the value changed.
+	bool commit_no_notification(bool val)
+	{
+		if (val != _val) {
+			set(val);
+			commit_no_notification();
+			return true;
+		}
+
+		return false;
 	}
 
 	void set(bool val) { _val = val; }

--- a/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
@@ -57,6 +57,8 @@ apps_map_type Pxh::_apps = {};
 
 Pxh::Pxh()
 {
+	_history.try_to_add("commander takeoff"); // for convenience
+	_history.reset_to_end();
 	_instance = this;
 }
 

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -198,4 +198,16 @@ const T sqrt_linear(const T &value)
 	}
 }
 
+/*
+ * Linear interpolation between 2 points a, and b.
+ * s=0 return a
+ * s=1 returns b
+ * Any value for s is valid.
+ */
+template<typename T>
+const T lerp(const T &a, const T &b, const T &s)
+{
+	return (static_cast<T>(1) - s) * a + s * b;
+}
+
 } /* namespace math */

--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -194,3 +194,15 @@ TEST(FunctionsTest, sqrt_linear)
 	EXPECT_FLOAT_EQ(sqrt_linear(2.f), 2.f);
 	EXPECT_FLOAT_EQ(sqrt_linear(120.f), 120.f);
 }
+
+TEST(FunctionsTest, lerp)
+{
+	EXPECT_FLOAT_EQ(lerp(0.f, 1.f, -.123f), -.123f);
+	EXPECT_FLOAT_EQ(lerp(0.f, 1.f, 0.f), 0.f);
+	EXPECT_FLOAT_EQ(lerp(0.f, 1.f, .123f), .123f);
+	EXPECT_FLOAT_EQ(lerp(0.f, 1.f, 1.f), 1.f);
+	EXPECT_FLOAT_EQ(lerp(0.f, 1.f, 1.123f), 1.123f);
+
+	EXPECT_FLOAT_EQ(lerp(.2f, .3f, -.1f), .19f);
+	EXPECT_FLOAT_EQ(lerp(-.4f, .3f, 1.1f), .37f);
+}

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -195,7 +195,7 @@ static calibrate_return check_calibration_result(float offset_x, float offset_y,
 
 	// earth field between 0.25 and 0.65 Gauss
 	if (sphere_radius < 0.2f || sphere_radius >= 0.7f) {
-		calibration_log_emergency(mavlink_log_pub, "Retry calibration (mag %u sphere radius invaid %.3f)", cur_mag,
+		calibration_log_emergency(mavlink_log_pub, "Retry calibration (mag %u sphere radius invalid %.3f)", cur_mag,
 					  (double)sphere_radius);
 		return calibrate_return_error;
 	}

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -123,7 +123,7 @@ Vector2f StickAccelerationXY::calculateDrag(Vector2f drag_coefficient, const flo
 	_brake_boost_filter.setParameters(dt, .8f);
 
 	if (stick_xy.norm_squared() < FLT_EPSILON) {
-		_brake_boost_filter.update(2.f);
+		_brake_boost_filter.update(math::max(2.f, sqrtf(_param_mpc_vel_manual.get())));
 
 	} else {
 		_brake_boost_filter.update(1.f);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -135,7 +135,21 @@ private:
 		(ParamInt<px4::params::MPC_ALT_MODE>) _param_mpc_alt_mode,
 		(ParamFloat<px4::params::MPC_TILTMAX_LND>) _param_mpc_tiltmax_lnd, /**< maximum tilt for landing and smooth takeoff */
 		(ParamFloat<px4::params::MPC_THR_MIN>) _param_mpc_thr_min,
-		(ParamFloat<px4::params::MPC_THR_MAX>) _param_mpc_thr_max
+		(ParamFloat<px4::params::MPC_THR_MAX>) _param_mpc_thr_max,
+
+		(ParamFloat<px4::params::SYS_VEHICLE_RESP>) _param_sys_vehicle_resp,
+		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor,
+		(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
+		(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
+		(ParamFloat<px4::params::MPC_ACC_HOR_MAX>) _param_mpc_acc_hor_max,
+		(ParamFloat<px4::params::MPC_JERK_AUTO>) _param_mpc_jerk_auto,
+		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
+		(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max,
+		(ParamFloat<px4::params::MPC_MAN_Y_TAU>) _param_mpc_man_y_tau,
+
+		(ParamFloat<px4::params::MPC_XY_VEL_ALL>) _param_mpc_xy_vel_all,
+		(ParamFloat<px4::params::MPC_Z_VEL_ALL>) _param_mpc_z_vel_all,
+		(ParamFloat<px4::params::MPC_LAND_VEL_XY>) _param_mpc_land_vel_xy
 	);
 
 	control::BlockDerivative _vel_x_deriv; /**< velocity derivative in x */

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -789,3 +789,51 @@ PARAM_DEFINE_FLOAT(MPC_SPOOLUP_TIME, 1.0f);
  * @group Mission
  */
 PARAM_DEFINE_INT32(MPC_YAW_MODE, 0);
+
+/**
+ * Responsiveness
+ *
+ * Changes the overall responsiveness of the vehicle.
+ * The higher the value, the faster the vehicle will react.
+ *
+ * If set to a value greater than zero, other parameters are automatically set (such as
+ * the acceleration or jerk limits).
+ * If set to -1, the existing individual parameters are used.
+ *
+ * @min -1
+ * @max 1
+ * @decimal 2
+ * @increment 0.05
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(SYS_VEHICLE_RESP, -0.4f);
+
+/**
+ * Overall Horizonal Velocity Limit
+ *
+ * If set to a value greater than zero, other parameters are automatically set (such as
+ * MPC_XY_VEL_MAX or MPC_VEL_MANUAL).
+ * If set to -1, the existing individual parameters are used.
+ *
+ * @min -20
+ * @max 20
+ * @decimal 1
+ * @increment 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_XY_VEL_ALL, -10.0f);
+
+/**
+ * Overall Vertical Velocity Limit
+ *
+ * If set to a value greater than zero, other parameters are automatically set (such as
+ * MPC_Z_VEL_MAX_UP or MPC_LAND_SPEED).
+ * If set to -1, the existing individual parameters are used.
+ *
+ * @min -3
+ * @max 8
+ * @decimal 1
+ * @increment 0.5
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Z_VEL_ALL, -3.0f);

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -511,20 +511,6 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 3.0f);
 
 /**
- * Slow horizontal manual deceleration for manual mode
- *
- * Note: This is only used when MPC_POS_MODE is set to 1.
- *
- * @unit m/s^2
- * @min 0.5
- * @max 10.0
- * @increment 1
- * @decimal 2
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
-
-/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s^2
@@ -567,29 +553,6 @@ PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 3.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 8.0f);
-
-/**
- * Velocity-based jerk limit
- *
- * If this is not zero, a velocity-based maximum jerk limit is used: the applied
- * jerk limit linearly increases with the vehicle's velocity between
- * MPC_JERK_MIN (zero velocity) and MPC_JERK_MAX (maximum velocity).
- *
- * This means that the vehicle's motions are smooth for low velocities, but
- * still allows fast direction changes or breaking at higher velocities.
- *
- * Set this to zero to use a fixed maximum jerk limit (MPC_JERK_MAX).
- *
- * Note: This is only used when MPC_POS_MODE is set to 1.
- *
- * @unit m/s^3
- * @min 0
- * @max 30.0
- * @increment 1
- * @decimal 2
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 8.0f);
 
 /**
  * Jerk limit in auto mode

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -151,7 +151,7 @@ PARAM_DEFINE_FLOAT(MPC_Z_P, 1.0f);
  * defined as correction acceleration in m/s^2 per m/s velocity error
  *
  * @min 2.0
- * @max 8.0
+ * @max 15.0
  * @decimal 2
  * @group Multicopter Position Control
  */
@@ -165,7 +165,7 @@ PARAM_DEFINE_FLOAT(MPC_Z_VEL_P_ACC, 4.0f);
  * Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.
  *
  * @min 0.2
- * @max 2.0
+ * @max 3.0
  * @decimal 3
  * @group Multicopter Position Control
  */
@@ -224,7 +224,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_P, 0.95f);
  * defined as correction acceleration in m/s^2 per m/s velocity error
  *
  * @min 1.2
- * @max 3.0
+ * @max 5.0
  * @decimal 2
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
The goal of this is to expose the vehicle's responsiveness as one or a few simple sliders in QGC. Probably most people who discussed this, know that:
- responsiveness is subjective, what works for one pilot does not for another,
- it is use-case dependent, e.g. for an inspection the vehicle should react very slowly.

Current configuration is however scattered over multiple parameters, and different conditions/modes use other parameters.
So this adds an overall responsiveness param that automatically sets the rest if enabled (accel, jerk, tilt limits etc).

discussion points:
- I can imagine that the maximum velocity should be separately configurable, and maybe split it into horizonal and vertical (which also adjusts landing speed, etc)
- it should apply to fixed-wing as well, question is if it should be a separate parameter
- rate controller limits are not changed
- generally reducing the amount of parameters around that wouldn't hurt either
- so far I just quickly tested this for MC position mode