### PR TITLE
ROMFS: Fix typo in S500 CtrlAlloc airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4018_s500_ctrlalloc
+++ b/ROMFS/px4fmu_common/init.d/airframes/4018_s500_ctrlalloc
@@ -8,7 +8,7 @@
 # @maintainer Silvan Fuhrer
 #
 
-. ${R}etcinit.d/rc.mc_defaults
+. ${R}etc/init.d/rc.mc_defaults
 . ${R}etc/init.d/rc.ctrlalloc
 
 if [ $AUTOCNF = yes ]


### PR DESCRIPTION
One-character typo fix.  Found when trying to test the new Control Allocation module.