### PR TITLE
sensors: correct comment logic

### DIFF
--- a/src/modules/sensors/data_validator/DataValidatorGroup.cpp
+++ b/src/modules/sensors/data_validator/DataValidatorGroup.cpp
@@ -164,7 +164,7 @@ float *DataValidatorGroup::get_best(uint64_t timestamp, int *index)
 		/*
 		 * Switch if:
 		 * 1) the confidence is higher and priority is equal or higher
-		 * 2) the confidence is no less than 1% different and the priority is higher
+		 * 2) the confidence is less than 1% different and the priority is higher
 		 */
 		if ((((max_confidence < MIN_REGULAR_CONFIDENCE) && (confidence >= MIN_REGULAR_CONFIDENCE)) ||
 		     (confidence > max_confidence && (next->priority() >= max_priority)) ||


### PR DESCRIPTION
By removing the no the comment matches the implementation (which I think makes sense).

This was brought up by Yusuf.K in https://px4.slack.com/archives/C0V533X4N/p1607942208088600.