### PR TITLE
[WIP] Data link loss reaction in all modes (when it's configured)

### DIFF
--- a/msg/mission_result.msg
+++ b/msg/mission_result.msg
@@ -14,7 +14,6 @@ bool warning			# true if mission is valid, but has potentially problematic items
 bool finished			# true if mission has been completed
 bool failure			# true if the mission cannot continue or be completed for some reason
 
-bool stay_in_failsafe		# true if the commander should not switch out of the failsafe mode
 bool flight_termination		# true if the navigator demands a flight termination from the commander app
 
 bool item_do_jump_changed	# true if the number of do jumps remaining has changed

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2539,7 +2539,6 @@ Commander::run()
 						       &_mavlink_log_pub,
 						       (link_loss_actions_t)_param_nav_dll_act.get(),
 						       _mission_result_sub.get().finished,
-						       _mission_result_sub.get().stay_in_failsafe,
 						       _status_flags,
 						       _land_detector.landed,
 						       (link_loss_actions_t)_param_nav_rcl_act.get(),

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -407,7 +407,7 @@ void enable_failsafe(vehicle_status_s *status, const bool old_failsafe, orb_adve
  */
 bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_state_s *internal_state,
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
-		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
+		   const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
@@ -546,7 +546,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
-		} else if (!stay_in_failsafe &&  !general_reaction) {
+		} else if (!general_reaction) {
 			// normal mission operation if there's no need to stay in failsafe
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION;
 		}

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -124,7 +124,8 @@ transition_result_t
 main_state_transition(const vehicle_status_s &status, const main_state_t new_main_state,
 		      const vehicle_status_flags_s &status_flags, commander_state_s *internal_state);
 
-void enable_failsafe(vehicle_status_s *status, bool old_failsafe, orb_advert_t *mavlink_log_pub, const char *reason);
+void enable_failsafe(vehicle_status_s *status, const bool old_failsafe, orb_advert_t *mavlink_log_pub,
+		     const char *reason);
 
 bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_state_s *internal_state,
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -129,7 +129,7 @@ void enable_failsafe(vehicle_status_s *status, const bool old_failsafe, orb_adve
 
 bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_state_s *internal_state,
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
-		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
+		   const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,

--- a/src/modules/navigator/navigator_mode.cpp
+++ b/src/modules/navigator/navigator_mode.cpp
@@ -55,8 +55,6 @@ NavigatorMode::run(bool active)
 {
 	if (active) {
 		if (!_active) {
-			/* first run, reset stay in failsafe flag */
-			_navigator->get_mission_result()->stay_in_failsafe = false;
 			_navigator->set_mission_result_updated();
 			on_activation();
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
The data link loss reaction is disabled by default. I got multiple reports of confused users that configured a reaction to data link loss but found that the reaction is executed only in certain unexpected undocumented modes.

**Describe your solution**
Define data link loss a general failsafe that applies in all modes.

**Test data / coverage**
I did SITL testing of all the cases I could think of.

**Additional context**
I found an unused flag `stay_in_failsafe` that got obsolete when removing the Casa Outback Challange failsafes: https://github.com/PX4/PX4-Autopilot/pull/14307
