### PR TITLE
MC auto: add parameter to set the trajectory slow-down

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -24,6 +24,7 @@ then
 	param set MPC_TKO_SPEED 1
 	param set MPC_VEL_MANUAL 3
 	param set MPC_XY_CRUISE 3
+	param set MPC_XY_ERR_MAX 5
 	param set MPC_XY_VEL_MAX 4
 	param set MPC_Z_VEL_MAX_DN 1.5
 	param set MPC_JERK_MAX 4.5

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -455,7 +455,7 @@ void FlightTaskAutoLineSmoothVel::_generateTrajectory()
 	Vector2f drone_to_trajectory_xy(position_trajectory_xy - position_xy);
 	float position_error = drone_to_trajectory_xy.length();
 
-	float time_stretch = 1.f - math::constrain(position_error * 0.5f, 0.f, 1.f);
+	float time_stretch = 1.f - math::constrain(position_error / _param_mpc_xy_err_max.get(), 0.f, 1.f);
 
 	// Don't stretch time if the drone is ahead of the position setpoint
 	if (drone_to_trajectory_xy.dot(vel_traj_xy) < 0.f) {

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -96,6 +96,7 @@ protected:
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
 					(ParamFloat<px4::params::MPC_JERK_AUTO>) _param_mpc_jerk_auto,
-					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p
+					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
+					(ParamFloat<px4::params::MPC_XY_ERR_MAX>) _param_mpc_xy_err_max
 				       );
 };

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -282,6 +282,24 @@ PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_XY_TRAJ_P, 0.5f);
 
 /**
+ * Maximum horizontal error allowed by the trajectory generator
+ *
+ * The integration speed of the trajectory setpoint is linearly
+ * reduced with the horizontal position tracking error. When the
+ * error is above this parameter, the integration of the
+ * trajectory is stopped to wait for the drone.
+ *
+ * This value can be adjusted depending on the tracking
+ * capabilities of the vehicle.
+ *
+ * @min 0.1
+ * @max 10.0
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_XY_ERR_MAX, 2.0f);
+
+/**
  * Maximum horizontal velocity setpoint for manual controlled mode
  * If velocity setpoint larger than MPC_XY_VEL_MAX is set, then
  * the setpoint will be capped to MPC_XY_VEL_MAX


### PR DESCRIPTION
In some cases e.g.: (VTOL in wind) a good tracking cannot be achieved. This condition then needs to be relaxed, otherwise the drone cannot land properly.

Tested on a VTOL standard plane.