### PR TITLE
px_uploader:Fixes breakage for real serial ports caused by 00e6d11

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -345,10 +345,10 @@ class uploader(object):
             self.__getSync(False)
         except:
             # if it fails we are on a real serial port - only leave this enabled on Windows
-            if _platform.system() == 'Windows':
+            if sys.platform.startswith('win'):
                 self.ackWindowedMode = True
-
-        self.port.baudrate = self.baudrate_bootloader
+        finally:
+            self.port.baudrate = self.baudrate_bootloader
 
     # send the GET_DEVICE command and wait for an info parameter
     def __getInfo(self, param):


### PR DESCRIPTION
The code was pitching an exception. It was invalid. That then left
   the baud rate AFU

