### PR TITLE
mavlink: ODOMETRY handler accept all other estimator_types for now

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1406,14 +1406,13 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 			odometry.local_frame = vehicle_odometry_s::LOCAL_FRAME_FRD;
 		}
 
-		if (odom.estimator_type == MAV_ESTIMATOR_TYPE_VISION || odom.estimator_type == MAV_ESTIMATOR_TYPE_VIO) {
-			_visual_odometry_pub.publish(odometry);
-
-		} else if (odom.estimator_type == MAV_ESTIMATOR_TYPE_MOCAP) {
+		if (odom.estimator_type == MAV_ESTIMATOR_TYPE_MOCAP) {
 			_mocap_odometry_pub.publish(odometry);
 
 		} else {
-			PX4_ERR("Estimator source %u not supported. Unable to publish pose and velocity", odom.estimator_type);
+			// MAV_ESTIMATOR_TYPE_VISION, MAV_ESTIMATOR_TYPE_VIO
+			// publish anything else for now
+			_visual_odometry_pub.publish(odometry);
 		}
 
 	} else {


### PR DESCRIPTION
I'm missing context here, but given MAVROS only added the estimator_type field ~18 days ago (https://github.com/mavlink/mavros/pull/1525) it seems safer to accept all by default. We can explicitly reject unsupported frames if necessary.

Fixes https://discuss.px4.io/t/offboard-px4-with-t265-and-ros-does-not-take-off/20818/3
