### PR TITLE
Initialize MAVLink on v5X variants

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_mavlink
+++ b/boards/px4/fmu-v5x/init/rc.board_mavlink
@@ -3,5 +3,11 @@
 # PX4 FMUv5X specific board MAVLink startup script.
 #------------------------------------------------------------------------------
 
+if ver hwtypecmp V5Xa0 V5X91 V5Xa1
+then
+# Start MAVLink on the UART connected to the mission computer
+mavlink start -d /dev/ttyS4 -b 3000000 -r 290000 -m onboard -x -z
+else
 # Start MAVLink on the USB port
 mavlink start -d /dev/ttyACM0
+fi


### PR DESCRIPTION
This will ensure that the different baseboard configurations are properly accounted for depending on HW variants.
