### PR TITLE
RC input selection

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -470,6 +470,12 @@ else
 
 	if [ $IO_PRESENT = no ]
 	then
+		# If IO is not present default RC to FMU
+		param set SYS_RC_SOURCE 2
+	fi
+	# Start the RC input if selected by parameter
+	if param compare -s SYS_RC_SOURCE 2
+	then
 		# Must be started after the serial config is read
 		rc_input start $RC_INPUT_ARGS
 	fi

--- a/boards/px4/fmu-v4/init/rc.board_defaults
+++ b/boards/px4/fmu-v4/init/rc.board_defaults
@@ -30,5 +30,8 @@ then
 	fi
 fi
 
+# Use always FMU as RC input
+param set SYS_RC_SOURCE 2
+
 safety_button start
 

--- a/boards/px4/fmu-v5/init/rc.board_defaults
+++ b/boards/px4/fmu-v5/init/rc.board_defaults
@@ -21,6 +21,9 @@ then
 	fi
 
 	param set UAVCAN_ENABLE 2
+
+	# Use always FMU as RC input
+	param set SYS_RC_SOURCE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -11,6 +11,9 @@ then
 	param set SENS_IMU_MODE 0
 
 	param set UAVCAN_ENABLE 2
+
+	# Use always FMU as RC input
+	param set SYS_RC_SOURCE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v6u/init/rc.board_defaults
+++ b/boards/px4/fmu-v6u/init/rc.board_defaults
@@ -13,6 +13,9 @@ then
 	param set SENS_MAG_MODE 0
 
 	param set UAVCAN_ENABLE 2
+
+	# Use always FMU as RC input
+	param set SYS_RC_SOURCE 2
 fi
 
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -13,6 +13,9 @@ then
 	param set SENS_MAG_MODE 0
 
 	param set UAVCAN_ENABLE 2
+
+	# Use always FMU as RC input
+	param set SYS_RC_SOURCE 2
 fi
 
 set LOGGER_BUF 64

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -638,7 +638,12 @@ void RCInput::Run()
 		if (rc_updated) {
 			perf_count(_publish_interval_perf);
 
-			_to_input_rc.publish(_rc_in);
+			// We are just skipping the publication itself
+			// to maintain stable timing / load
+			// independent of the configuration
+			if (_param_rc_publish_rc.get() == RC_INPUT_FMU) {
+				_to_input_rc.publish(_rc_in);
+			}
 
 		} else if (!rc_updated && ((hrt_absolute_time() - _rc_in.timestamp_last_signal) > 1_s)) {
 			_rc_scan_locked = false;

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -155,6 +155,8 @@ private:
 
 	uint8_t _rcs_buf[SBUS_BUFFER_SIZE] {};
 
+	static constexpr int	RC_INPUT_FMU{2};		///< FMU selected as RC source
+
 	uint16_t _raw_rc_values[input_rc_s::RC_INPUT_MAX_CHANNELS] {};
 	uint16_t _raw_rc_count{};
 
@@ -167,6 +169,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::RC_RSSI_PWM_CHAN>) _param_rc_rssi_pwm_chan,
 		(ParamInt<px4::params::RC_RSSI_PWM_MIN>) _param_rc_rssi_pwm_min,
-		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max
+		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max,
+		(ParamInt<px4::params::SYS_RC_SOURCE>) _param_rc_publish_rc
 	)
 };

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -270,6 +270,19 @@ PARAM_DEFINE_INT32(SYS_FAC_CAL_MODE, 0);
 PARAM_DEFINE_INT32(SYS_BL_UPDATE, 0);
 
 /**
+ * RC Input Source
+ *
+ *
+ * @boolean
+ * @value 0 RC input disabled
+ * @value 1 RC input from FMU
+ * @value 2 RC input from IO
+ * @reboot_required true
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_RC_SOURCE, 0);
+
+/**
  * Enable failure injection
  *
  * If enabled allows MAVLink INJECT_FAILURE commands.


### PR DESCRIPTION
This change makes the RC input selectable and defaults to FMU as the RC source for boards where both FMU and IO are hooked up.
