### PR TITLE
SITL boat: tune L1 and speed controllers

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1070_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1070_boat
@@ -8,16 +8,17 @@
 if [ $AUTOCNF = yes ]
 then
 	param set GND_L1_DIST 5
+	param set GND_L1_PERIOD 100
 	param set GND_SP_CTRL_MODE 1
 	param set GND_SPEED_D 0.001
-	param set GND_SPEED_I 3
+	param set GND_SPEED_I 8
 	param set GND_SPEED_IMAX 0.125
-	param set GND_SPEED_P 0.25
+	param set GND_SPEED_P 2
 	param set GND_SPEED_THR_SC 1
-	param set GND_SPEED_TRIM 4
-	param set GND_THR_CRUISE 0.3
+	param set GND_SPEED_TRIM 1
+	param set GND_THR_CRUISE 0.85
 	param set GND_THR_IDLE 0
-	param set GND_THR_MAX 0.5
+	param set GND_THR_MAX 1
 	param set GND_THR_MIN 0
 
 	param set MIS_LTRMIN_ALT 0.01


### PR DESCRIPTION
The cruise and speed controllers of the Gazebo boat model were not tuned properly, resulting in large yaw oscillation and poor speed tracking.

Those tuning gains are good enough to control the boat in auto mode, even if I do not think the rover controller is good enough for a boat with this amount of drift; a yaw/yaw rate controller should be added.

Test:
`make px4_sitl gazebo_boat`