### PR TITLE
Acceleration stick mapping: take over position error velocity setpoint when unlocking

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -70,7 +70,7 @@ bool FlightTaskManualAcceleration::update()
 	_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _yaw_setpoint,
 				       _sticks.getPositionExpo()(3) * math::radians(_param_mpc_man_y_max.get()), _yaw, _deltatime);
 	_stick_acceleration_xy.generateSetpoints(_sticks.getPositionExpo().slice<2, 1>(0, 0), _yaw, _yaw_setpoint, _position,
-			_deltatime);
+			Vector2f(_velocity_setpoint_feedback), _deltatime);
 	_stick_acceleration_xy.getSetpoints(_position_setpoint, _velocity_setpoint, _acceleration_setpoint);
 
 	_constraints.want_takeoff = _checkTakeoff();

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -71,9 +71,9 @@ private:
 	SlewRate<float> _acceleration_slew_rate_y;
 	AlphaFilter<float> _brake_boost_filter;
 
-	matrix::Vector2f _position;
-	matrix::Vector2f _velocity;
-	matrix::Vector2f _acceleration;
+	matrix::Vector2f _position_setpoint;
+	matrix::Vector2f _velocity_setpoint;
+	matrix::Vector2f _acceleration_setpoint;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -60,12 +60,11 @@ public:
 	void getSetpoints(matrix::Vector3f &pos_sp, matrix::Vector3f &vel_sp, matrix::Vector3f &acc_sp);
 
 private:
-	void applyFeasibilityLimit(matrix::Vector2f &acceleration, const float dt);
+	void applyFeasibilityLimit(const float dt);
 	matrix::Vector2f calculateDrag(matrix::Vector2f drag_coefficient, const float dt, const matrix::Vector2f &stick_xy,
 				       const matrix::Vector2f &vel_sp);
 	void applyTiltLimit(matrix::Vector2f &acceleration);
-	void lockPosition(const matrix::Vector2f &vel_sp, const matrix::Vector3f &pos, const float dt,
-			  matrix::Vector2f &pos_sp);
+	void lockPosition(const matrix::Vector3f &pos, const float dt);
 
 	SlewRate<float> _acceleration_slew_rate_x;
 	SlewRate<float> _acceleration_slew_rate_y;

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -56,7 +56,7 @@ public:
 	void resetVelocity(const matrix::Vector2f &velocity);
 	void resetAcceleration(const matrix::Vector2f &acceleration);
 	void generateSetpoints(matrix::Vector2f stick_xy, const float yaw, const float yaw_sp, const matrix::Vector3f &pos,
-			       const float dt);
+			       const matrix::Vector2f &vel_sp_feedback, const float dt);
 	void getSetpoints(matrix::Vector3f &pos_sp, matrix::Vector3f &vel_sp, matrix::Vector3f &acc_sp);
 
 private:
@@ -64,7 +64,7 @@ private:
 	matrix::Vector2f calculateDrag(matrix::Vector2f drag_coefficient, const float dt, const matrix::Vector2f &stick_xy,
 				       const matrix::Vector2f &vel_sp);
 	void applyTiltLimit(matrix::Vector2f &acceleration);
-	void lockPosition(const matrix::Vector3f &pos, const float dt);
+	void lockPosition(const matrix::Vector3f &pos, const matrix::Vector2f &vel_sp_feedback, const float dt);
 
 	SlewRate<float> _acceleration_slew_rate_x;
 	SlewRate<float> _acceleration_slew_rate_y;


### PR DESCRIPTION
**Describe problem solved by this pull request**
@bkueng reported he started seeing noticeable velocity setpoint jumps at the moment the position controller unlocks if there's still a large position error e.g. with more aggressive tuning/settings.

**Describe your solution**
I'm using the velocity setpoint feedback architecture we're already deploying in other mode implementations with the `SmoothVel` trajectory generation. I had this in mind but forgot/neglected to do that in the initial implementation. See last commit.

**Test data / coverage**
I quickly tested in SITL jMAVSim on default config where I can't see the difference from the vehicle but and here's the plot with the fix and it's clearly visible that the trajectory_setpoint velocity setpoint takes over where the position controller left when unlocking:
![image](https://user-images.githubusercontent.com/4668506/107267583-64b8ff80-6a47-11eb-96b8-5fdd25bdf22c.png)


**Additional context**
Related to:
https://github.com/PX4/PX4-Autopilot/pull/16744
https://github.com/PX4/PX4-Autopilot/pull/16786