### PR TITLE
Fixed-wing pitch and roll offset clean up

### DIFF
--- a/integrationtests/python_src/px4_it/mavros/missions/FW_mission_1.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/FW_mission_1.plan
@@ -22,7 +22,7 @@
                 "doJumpId": 1,
                 "frame": 3,
                 "params": [
-                    15,
+                    0,
                     0,
                     0,
                     null,

--- a/integrationtests/python_src/px4_it/mavros/missions/MC_mission_box.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/MC_mission_box.plan
@@ -22,7 +22,7 @@
                 "doJumpId": 1,
                 "frame": 3,
                 "params": [
-                    15,
+                    0,
                     0,
                     0,
                     null,

--- a/integrationtests/python_src/px4_it/mavros/missions/VTOL_mission_1.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/VTOL_mission_1.plan
@@ -22,7 +22,7 @@
                 "doJumpId": 1,
                 "frame": 3,
                 "params": [
-                    15,
+                    0,
                     0,
                     0,
                     null,

--- a/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
@@ -22,7 +22,7 @@
                 "doJumpId": 1,
                 "frame": 3,
                 "params": [
-                    15,
+                    0,
                     0,
                     0,
                     null,

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -42,7 +42,6 @@ int8 landing_gear		# landing gear: see definition of the states in landing_gear.
 
 float32 loiter_radius		# loiter radius (only for fixed wing), in m
 int8 loiter_direction		# loiter direction: 1 = CW, -1 = CCW
-float32 pitch_min		# minimal pitch angle for fixed wing takeoff waypoints
 
 float32 a_x			# acceleration x setpoint
 float32 a_y			# acceleration y setpoint

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -157,9 +157,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 				if (_vcontrol_mode.flag_control_attitude_enabled) {
 					// STABILIZED mode generate the attitude setpoint from manual user inputs
 
-					_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get()) + radians(_param_fw_rsp_off.get());
-					_att_sp.roll_body = constrain(_att_sp.roll_body,
-								      -radians(_param_fw_man_r_max.get()), radians(_param_fw_man_r_max.get()));
+					_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());
 
 					_att_sp.pitch_body = -_manual_control_setpoint.x * radians(_param_fw_man_p_max.get())
 							     + radians(_param_fw_psp_off.get());

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -193,7 +193,6 @@ private:
 		(ParamFloat<px4::params::FW_RR_I>) _param_fw_rr_i,
 		(ParamFloat<px4::params::FW_RR_IMAX>) _param_fw_rr_imax,
 		(ParamFloat<px4::params::FW_RR_P>) _param_fw_rr_p,
-		(ParamFloat<px4::params::FW_RSP_OFF>) _param_fw_rsp_off,
 
 		(ParamBool<px4::params::FW_W_EN>) _param_fw_w_en,
 		(ParamFloat<px4::params::FW_W_RMAX>) _param_fw_w_rmax,

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -414,22 +414,6 @@ PARAM_DEFINE_FLOAT(FW_YR_FF, 0.3f);
 PARAM_DEFINE_FLOAT(FW_WR_FF, 0.2f);
 
 /**
- * Roll setpoint offset
- *
- * An airframe specific offset of the roll setpoint in degrees, the value is
- * added to the roll setpoint and should correspond to the typical cruise speed
- * of the airframe.
- *
- * @unit deg
- * @min -90.0
- * @max 90.0
- * @decimal 1
- * @increment 0.5
- * @group FW Attitude Control
- */
-PARAM_DEFINE_FLOAT(FW_RSP_OFF, 0.0f);
-
-/**
  * Pitch setpoint offset (pitch at level flight)
  *
  * An airframe specific offset of the pitch setpoint in degrees, the value is

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -430,11 +430,11 @@ PARAM_DEFINE_FLOAT(FW_WR_FF, 0.2f);
 PARAM_DEFINE_FLOAT(FW_RSP_OFF, 0.0f);
 
 /**
- * Pitch setpoint offset
+ * Pitch setpoint offset (pitch at level flight)
  *
  * An airframe specific offset of the pitch setpoint in degrees, the value is
- * added to the pitch setpoint and should correspond to the typical cruise
- * speed of the airframe.
+ * added to the pitch setpoint and should correspond to the pitch at
+ * typical cruise speed of the airframe.
  *
  * @unit deg
  * @min -90.0

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1715,9 +1715,6 @@ FixedwingPositionControl::Run()
 		if (control_position(_local_pos.timestamp, curr_pos, ground_speed, _pos_sp_triplet.previous, _pos_sp_triplet.current,
 				     _pos_sp_triplet.next)) {
 
-			// add attitude roll setpoint offset (pitch is handled earlier)
-			_att_sp.roll_body += radians(_param_fw_rsp_off.get());
-
 			if (_control_mode.flag_control_manual_enabled) {
 				_att_sp.roll_body = constrain(_att_sp.roll_body, -radians(_param_fw_man_r_max.get()),
 							      radians(_param_fw_man_r_max.get()));

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -789,7 +789,7 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 		if (position_sp_type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
 			_att_sp.thrust_body[0] = 0.0f;
 			_att_sp.roll_body = 0.0f;
-			_att_sp.pitch_body = 0.0f;
+			_att_sp.pitch_body = radians(_param_fw_psp_off.get());
 
 		} else if (position_sp_type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
 			// waypoint is a plain navigation waypoint
@@ -834,8 +834,8 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 
 			tecs_update_pitch_throttle(now, position_sp_alt,
 						   calculate_target_airspeed(mission_airspeed, ground_speed),
-						   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
-						   radians(_param_fw_p_lim_max.get()) - radians(_param_fw_psp_off.get()),
+						   radians(_param_fw_p_lim_min.get()),
+						   radians(_param_fw_p_lim_max.get()),
 						   tecs_fw_thr_min,
 						   tecs_fw_thr_max,
 						   tecs_fw_mission_throttle,
@@ -891,8 +891,8 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 
 			tecs_update_pitch_throttle(now, alt_sp,
 						   calculate_target_airspeed(mission_airspeed, ground_speed),
-						   radians(_param_fw_p_lim_min.get()) - radians(_param_fw_psp_off.get()),
-						   radians(_param_fw_p_lim_max.get()) - radians(_param_fw_psp_off.get()),
+						   radians(_param_fw_p_lim_min.get()),
+						   radians(_param_fw_p_lim_max.get()),
 						   tecs_fw_thr_min,
 						   tecs_fw_thr_max,
 						   tecs_fw_mission_throttle,
@@ -1528,7 +1528,7 @@ FixedwingPositionControl::control_landing(const hrt_abstime &now, const Vector2f
 
 		if (!_land_noreturn_vertical) {
 			// just started with the flaring phase
-			_flare_pitch_sp = 0.0f;
+			_flare_pitch_sp = radians(_param_fw_psp_off.get());
 			_flare_height = _current_altitude - terrain_alt;
 			mavlink_log_info(&_mavlink_log_pub, "Landing, flaring");
 			_land_noreturn_vertical = true;
@@ -1599,11 +1599,11 @@ float
 FixedwingPositionControl::get_tecs_pitch()
 {
 	if (_is_tecs_running) {
-		return _tecs.get_pitch_setpoint();
+		return _tecs.get_pitch_setpoint() + radians(_param_fw_psp_off.get());
 	}
 
-	// return 0 to prevent stale tecs state when it's not running
-	return 0.0f;
+	// return level flight pitch offset to prevent stale tecs state when it's not running
+	return radians(_param_fw_psp_off.get());
 }
 
 float
@@ -1715,10 +1715,8 @@ FixedwingPositionControl::Run()
 		if (control_position(_local_pos.timestamp, curr_pos, ground_speed, _pos_sp_triplet.previous, _pos_sp_triplet.current,
 				     _pos_sp_triplet.next)) {
 
-
-			// add attitude setpoint offsets
+			// add attitude roll setpoint offset (pitch is handled earlier)
 			_att_sp.roll_body += radians(_param_fw_rsp_off.get());
-			_att_sp.pitch_body += radians(_param_fw_psp_off.get());
 
 			if (_control_mode.flag_control_manual_enabled) {
 				_att_sp.roll_body = constrain(_att_sp.roll_body, -radians(_param_fw_man_r_max.get()),
@@ -1827,14 +1825,14 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const hrt_abstime &now, flo
 
 		} else if (_was_in_transition) {
 			// after transition we ramp up desired airspeed from the speed we had coming out of the transition
-			_asp_after_transition += dt * 2; // increase 2m/s
+			_asp_after_transition += dt * 2.0f; // increase 2m/s
 
 			if (_asp_after_transition < airspeed_sp && _airspeed < airspeed_sp) {
 				airspeed_sp = max(_asp_after_transition, _airspeed);
 
 			} else {
 				_was_in_transition = false;
-				_asp_after_transition = 0;
+				_asp_after_transition = 0.0f;
 			}
 		}
 	}
@@ -1854,16 +1852,13 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const hrt_abstime &now, flo
 
 	if (_vehicle_status.engine_failure) {
 		/* Force the slow downwards spiral */
-		pitch_min_rad = M_DEG_TO_RAD_F * -1.0f;
-		pitch_max_rad = M_DEG_TO_RAD_F * 5.0f;
+		pitch_min_rad = radians(-1.0f);
+		pitch_max_rad = radians(5.0f);
 	}
 
 	/* No underspeed protection in landing mode */
 	_tecs.set_detect_underspeed_enabled(!(mode == tecs_status_s::TECS_MODE_LAND
 					      || mode == tecs_status_s::TECS_MODE_LAND_THROTTLELIM));
-
-	/* Using tecs library */
-	float pitch_for_tecs = _pitch - radians(_param_fw_psp_off.get());
 
 	/* tell TECS to update its state, but let it know when it cannot actually control the plane */
 	bool in_air_alt_control = (!_landed &&
@@ -1892,12 +1887,14 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const hrt_abstime &now, flo
 		}
 	}
 
-	_tecs.update_pitch_throttle(pitch_for_tecs,
+	_tecs.update_pitch_throttle(_pitch - radians(_param_fw_psp_off.get()),
 				    _current_altitude, alt_sp,
 				    airspeed_sp, _airspeed, _eas2tas,
-				    climbout_mode, climbout_pitch_min_rad,
+				    climbout_mode,
+				    climbout_pitch_min_rad - radians(_param_fw_psp_off.get()),
 				    throttle_min, throttle_max, throttle_cruise,
-				    pitch_min_rad, pitch_max_rad);
+				    pitch_min_rad - radians(_param_fw_psp_off.get()),
+				    pitch_max_rad - radians(_param_fw_psp_off.get()));
 
 	tecs_status_publish();
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1222,7 +1222,7 @@ FixedwingPositionControl::control_takeoff(const hrt_abstime &now, const Vector2f
 					   _param_fw_thr_max.get(), // XXX should we also set runway_takeoff_throttle here?
 					   _param_fw_thr_cruise.get(),
 					   _runway_takeoff.climbout(),
-					   radians(_runway_takeoff.getMinPitch(pos_sp_curr.pitch_min, 10.0f, _param_fw_p_lim_min.get())),
+					   radians(_runway_takeoff.getMinPitch(_takeoff_pitch_min.get(), _param_fw_p_lim_min.get())),
 					   tecs_status_s::TECS_MODE_TAKEOFF);
 
 		// assign values
@@ -1293,7 +1293,7 @@ FixedwingPositionControl::control_takeoff(const hrt_abstime &now, const Vector2f
 							   takeoff_throttle,
 							   _param_fw_thr_cruise.get(),
 							   true,
-							   max(radians(pos_sp_curr.pitch_min), radians(10.0f)),
+							   radians(_takeoff_pitch_min.get()),
 							   tecs_status_s::TECS_MODE_TAKEOFF);
 
 				/* limit roll motion to ensure enough lift */
@@ -1320,7 +1320,7 @@ FixedwingPositionControl::control_takeoff(const hrt_abstime &now, const Vector2f
 
 			/* Set default roll and pitch setpoints during detection phase */
 			_att_sp.roll_body = 0.0f;
-			_att_sp.pitch_body = max(radians(pos_sp_curr.pitch_min), radians(10.0f));
+			_att_sp.pitch_body = radians(_takeoff_pitch_min.get());
 		}
 	}
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -413,7 +413,6 @@ private:
 		(ParamInt<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,
 
 		(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off,
-		(ParamFloat<px4::params::FW_RSP_OFF>) _param_fw_rsp_off,
 		(ParamFloat<px4::params::FW_MAN_P_MAX>) _param_fw_man_p_max,
 		(ParamFloat<px4::params::FW_MAN_R_MAX>) _param_fw_man_r_max,
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -417,7 +417,9 @@ private:
 		(ParamFloat<px4::params::FW_MAN_P_MAX>) _param_fw_man_p_max,
 		(ParamFloat<px4::params::FW_MAN_R_MAX>) _param_fw_man_r_max,
 
-		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad
+		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,
+
+		(ParamFloat<px4::params::FW_TKO_PITCH_MIN>) _takeoff_pitch_min
 
 	)
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -269,6 +269,18 @@ PARAM_DEFINE_FLOAT(FW_CLMBOUT_DIFF, 10.0f);
 PARAM_DEFINE_FLOAT(FW_LND_ANG, 5.0f);
 
 /**
+ * Minimum pitch during takeoff.
+ *
+ * @unit deg
+ * @min -5.0
+ * @max 30.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_TKO_PITCH_MIN, 10.0f);
+
+/**
  *
  *
  * @unit m

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
@@ -221,13 +221,12 @@ bool RunwayTakeoff::resetIntegrators()
  * the climbtout minimum pitch (parameter).
  * Otherwise use the minimum that is enforced generally (parameter).
  */
-float RunwayTakeoff::getMinPitch(float sp_min, float climbout_min, float min)
+float RunwayTakeoff::getMinPitch(float climbout_min, float min)
 {
 	if (_state < RunwayTakeoffState::FLY) {
-		return math::max(sp_min, climbout_min);
-	}
+		return climbout_min;
 
-	else {
+	} else {
 		return min;
 	}
 }

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -86,7 +86,7 @@ public:
 	float getYaw(float navigatorYaw);
 	float getThrottle(const hrt_abstime &now, float tecsThrottle);
 	bool resetIntegrators();
-	float getMinPitch(float sp_min, float climbout_min, float min);
+	float getMinPitch(float climbout_min, float min);
 	float getMaxPitch(float max);
 	matrix::Vector2f getStartWP();
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1305,13 +1305,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 			mission_item->altitude_is_relative = true;
 		}
 
-		/* this field is shared with pitch_min (and circle_radius for geofence) in memory and
-		 * exclusive in the MAVLink spec. Set it to 0 first
-		 * and then set minimum pitch later only for the
-		 * corresponding item
-		 */
-		mission_item->time_inside = 0.0f;
-
 		switch (mavlink_mission_item->command) {
 		case MAV_CMD_NAV_WAYPOINT:
 			mission_item->nav_cmd = NAV_CMD_WAYPOINT;
@@ -1345,9 +1338,17 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 			break;
 
 		case MAV_CMD_NAV_TAKEOFF:
-			mission_item->nav_cmd = NAV_CMD_TAKEOFF;
-			mission_item->pitch_min = mavlink_mission_item->param1;
-			mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
+
+			// reject takeoff item if minimum pitch (parameter 1) is set
+			if (PX4_ISFINITE(mavlink_mission_item->param1) && (fabsf(mavlink_mission_item->param1) > FLT_EPSILON)) {
+				_mavlink->send_statustext_critical("Takeoff rejected, remove deprecated minimum pitch");
+				return MAV_MISSION_INVALID_PARAM1;
+
+			} else {
+				mission_item->nav_cmd = NAV_CMD_TAKEOFF;
+				mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
+			}
+
 			break;
 
 		case MAV_CMD_NAV_LOITER_TO_ALT:
@@ -1652,7 +1653,6 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 			break;
 
 		case NAV_CMD_TAKEOFF:
-			mavlink_mission_item->param1 = mission_item->pitch_min;
 			mavlink_mission_item->param4 = math::degrees(mission_item->yaw);
 			break;
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -752,11 +752,6 @@ Mission::set_mission_items()
 					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 					/* ignore yaw here, otherwise it might yaw before heading_sp_update takes over */
 					_mission_item.yaw = NAN;
-					/* since _mission_item.time_inside and and _mission_item.pitch_min build a union, we need to set time_inside to zero
-					 * since in NAV_CMD_TAKEOFF mode there is currently no time_inside.
-					 * Note also that resetting time_inside to zero will cause pitch_min to be zero as well.
-					 */
-					_mission_item.time_inside = 0.0f;
 
 				} else if (_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF
 					   && _work_item_type == WORK_ITEM_TYPE_DEFAULT
@@ -783,10 +778,6 @@ Mission::set_mission_items()
 					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 					/* ignore yaw here, otherwise it might yaw before heading_sp_update takes over */
 					_mission_item.yaw = NAN;
-					/* since _mission_item.time_inside and and _mission_item.pitch_min build a union, we need to set time_inside to zero
-					 * since in NAV_CMD_TAKEOFF mode there is currently no time_inside.
-					 */
-					_mission_item.time_inside = 0.0f;
 				}
 
 				/* if we just did a VTOL takeoff, prepare transition */
@@ -1864,7 +1855,6 @@ bool Mission::position_setpoint_equal(const position_setpoint_s *p1, const posit
 		(p1->yawspeed_valid == p2->yawspeed_valid) &&
 		(fabsf(p1->loiter_radius - p2->loiter_radius) < FLT_EPSILON) &&
 		(p1->loiter_direction == p2->loiter_direction) &&
-		(fabsf(p1->pitch_min - p2->pitch_min) < FLT_EPSILON) &&
 		(fabsf(p1->a_x - p2->a_x) < FLT_EPSILON) &&
 		(fabsf(p1->a_y - p2->a_y) < FLT_EPSILON) &&
 		(fabsf(p1->a_z - p2->a_z) < FLT_EPSILON) &&

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -582,9 +582,6 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 		} else {
 			sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
-
-			// set pitch and ensure that the hold time is zero
-			sp->pitch_min = item.pitch_min;
 		}
 
 		break;
@@ -667,7 +664,7 @@ MissionBlock::set_loiter_item(struct mission_item_s *item, float min_clearance)
 }
 
 void
-MissionBlock::set_takeoff_item(struct mission_item_s *item, float abs_altitude, float min_pitch)
+MissionBlock::set_takeoff_item(struct mission_item_s *item, float abs_altitude)
 {
 	item->nav_cmd = NAV_CMD_TAKEOFF;
 
@@ -680,7 +677,6 @@ MissionBlock::set_takeoff_item(struct mission_item_s *item, float abs_altitude, 
 	item->altitude_is_relative = false;
 
 	item->loiter_radius = _navigator->get_loiter_radius();
-	item->pitch_min = min_pitch;
 	item->autocontinue = false;
 	item->origin = ORIGIN_ONBOARD;
 }

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -116,7 +116,7 @@ protected:
 	/**
 	 * Set a takeoff mission item
 	 */
-	void set_takeoff_item(struct mission_item_s *item, float abs_altitude, float min_pitch = 0.0f);
+	void set_takeoff_item(struct mission_item_s *item, float abs_altitude);
 
 	/**
 	 * Set a land mission item

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -153,7 +153,6 @@ struct mission_item_s {
 		struct {
 			union {
 				float time_inside;		/**< time that the MAV should stay inside the radius before advancing in seconds */
-				float pitch_min;		/**< minimal pitch angle for fixed wing takeoff waypoints */
 				float circle_radius;		/**< geofence circle radius in meters (only used for NAV_CMD_NAV_FENCE_CIRCLE*) */
 			};
 			float acceptance_radius;		/**< default radius in which the mission is accepted as reached in meters */


### PR DESCRIPTION
Replaces https://github.com/PX4/PX4-Autopilot/pull/11845.

**Describe problem solved by this pull request**
- replace minimum pitch angle set by mission item during fixed-wing takeoff by vehicle parameter (FW_TKO_PITCH_MIN)
- apply pitch offset centrally in fw_pos_control
- removes (unused/unnecessary) FW_RSP_OFF param

**Describe your solution**
The following parameters are now all referring to the same "absolute" pitch angle. 

FW_P_LIM_MIN (no change for AUTO and LOITER, other modes: now absolute, before PSP_OFF was added to min after TECS)
FW_P_LIM_MAX (no change for AUTO and LOITER, other modes: now absolute, before PSP_OFF was added to max after TECS)
FW_TKO_PITCH_MIN (new param)
FW_LND_FL_PMIN (now absolute, before PSP_OFF was added after TECS)
FW_LND_FL_PMAX (now absolute, before PSP_OFF was added after TECS)
FW_MAN_P_MAX (no difference, pitch_sp = manual_input * FW_MAN_P_MAX + PSP_OFF, constrained to +/-FW_MAN_P_MAX)

"Absolute" pitch is defined as
- for VTOL, the angle of the multicopter propeller plane relative to the ground (0 pitch for level MC flight)
- for FW it can be more freely defined, but in general having it parallel to the wing makes most sense (adaption of FW_PSP_OFF may be necessary) (is this correct or can/should we define it closer @RomanBapst ?)

FW_PSP_OFF is the pitch angle required for level flight at trim airspeed. TECS gets the absolute pitch minus the offset, and also all the min/max parameters are used inside TECS are offset by the offset prior passing them into TECS.

**Describe possible alternatives**
Pass the absolute pitch angle into TECS, together with the offset parameter, and initialize the pitch (output) at the offset value. 

**Test data / coverage**
SITL tested with VTOLs and Plane. 
