### PR TITLE
ekf2: try reselecting distance_sensor on timeout

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -232,6 +232,7 @@ private:
 	bool _standby{false}; // standby arming state
 
 	hrt_abstime _last_status_flag_update{0};
+	hrt_abstime _last_range_sensor_update{0};
 
 	uint32_t _filter_control_status{0};
 	uint32_t _filter_fault_status{0};


### PR DESCRIPTION
EKF2 selects the first downward facing `distance_sensor` publication. This PR updates the requirement to be both downward facing and non-stale data. It also deselects the current if it hasn't updated for more than 1 second.

This shouldn't impact most people, but there are setups where this will be better than doing nothing.