### PR TITLE
BUGFIX Hard fault Commander Calibration

### DIFF
--- a/src/modules/commander/worker_thread.cpp
+++ b/src/modules/commander/worker_thread.cpp
@@ -67,7 +67,7 @@ void WorkerThread::startTask(Request request)
 	/* initialize low priority thread */
 	pthread_attr_t low_prio_attr;
 	pthread_attr_init(&low_prio_attr);
-	pthread_attr_setstacksize(&low_prio_attr, PX4_STACK_ADJUSTED(3304));
+	pthread_attr_setstacksize(&low_prio_attr, PX4_STACK_ADJUSTED(3804));
 
 #ifndef __PX4_QURT
 	// This is not supported by QURT (yet).


### PR DESCRIPTION
I found this on FMUK66 on compass calibration.

Caused by https://github.com/PX4/PX4-Autopilot/pull/16625#issuecomment-765602973


```
479 commander_low_prio           1491  0.533  3508/ 3308  50 ( 50)  READY  5
```

@jkflying Testing really needs to be done on real HW and all the the archs before you merge.  