### PR TITLE
FlightTaskManualAcceleration: adapt position reset to new structure

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -79,37 +79,10 @@ bool FlightTaskManualAcceleration::update()
 
 void FlightTaskManualAcceleration::_ekfResetHandlerPositionXY()
 {
-	if (PX4_ISFINITE(_position_setpoint(0))) {
-		_position_setpoint(0) = _position(0);
-		_position_setpoint(1) = _position(1);
-	}
+	_stick_acceleration_xy.resetPosition();
 }
 
 void FlightTaskManualAcceleration::_ekfResetHandlerVelocityXY()
 {
-	if (PX4_ISFINITE(_velocity_setpoint(0))) {
-		_velocity_setpoint(0) = _velocity(0);
-		_velocity_setpoint(1) = _velocity(1);
-	}
-}
-
-void FlightTaskManualAcceleration::_ekfResetHandlerPositionZ()
-{
-	if (PX4_ISFINITE(_position_setpoint(2))) {
-		_position_setpoint(2) = _position(2);
-	}
-}
-
-void FlightTaskManualAcceleration::_ekfResetHandlerVelocityZ()
-{
-	if (PX4_ISFINITE(_velocity_setpoint(2))) {
-		_velocity_setpoint(2) = _velocity(2);
-	}
-}
-
-void FlightTaskManualAcceleration::_ekfResetHandlerHeading(float delta_psi)
-{
-	if (PX4_ISFINITE(_yaw_setpoint)) {
-		_yaw_setpoint += delta_psi;
-	}
+	_stick_acceleration_xy.resetVelocity(Vector2f(_velocity));
 }

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -51,7 +51,7 @@ bool FlightTaskManualAcceleration::activate(const vehicle_local_position_setpoin
 		_velocity_setpoint.xy() = Vector2f(last_setpoint.vx, last_setpoint.vy);
 
 	} else {
-		_velocity_setpoint.xy() = Vector2f(_velocity);
+		_velocity_setpoint.xy() = _velocity.xy();
 	}
 
 	_stick_acceleration_xy.resetPosition();
@@ -70,7 +70,7 @@ bool FlightTaskManualAcceleration::update()
 	_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _yaw_setpoint,
 				       _sticks.getPositionExpo()(3) * math::radians(_param_mpc_man_y_max.get()), _yaw, _deltatime);
 	_stick_acceleration_xy.generateSetpoints(_sticks.getPositionExpo().slice<2, 1>(0, 0), _yaw, _yaw_setpoint, _position,
-			Vector2f(_velocity_setpoint_feedback), _deltatime);
+			_velocity_setpoint_feedback.xy(), _deltatime);
 	_stick_acceleration_xy.getSetpoints(_position_setpoint, _velocity_setpoint, _acceleration_setpoint);
 
 	_constraints.want_takeoff = _checkTakeoff();
@@ -84,5 +84,5 @@ void FlightTaskManualAcceleration::_ekfResetHandlerPositionXY()
 
 void FlightTaskManualAcceleration::_ekfResetHandlerVelocityXY()
 {
-	_stick_acceleration_xy.resetVelocity(Vector2f(_velocity));
+	_stick_acceleration_xy.resetVelocity(_velocity.xy());
 }

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.hpp
@@ -58,7 +58,4 @@ private:
 
 	void _ekfResetHandlerPositionXY() override;
 	void _ekfResetHandlerVelocityXY() override;
-	void _ekfResetHandlerPositionZ() override;
-	void _ekfResetHandlerVelocityZ() override;
-	void _ekfResetHandlerHeading(float delta_psi) override;
 };

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -112,8 +112,7 @@ void FlightTaskManualPosition::_scaleSticks()
 
 	// collision prevention
 	if (_collision_prevention.is_active()) {
-		_collision_prevention.modifySetpoint(vel_sp_xy, _velocity_scale, Vector2f(_position),
-						     Vector2f(_velocity));
+		_collision_prevention.modifySetpoint(vel_sp_xy, _velocity_scale, _position.xy(), _velocity.xy());
 	}
 
 	_velocity_setpoint.xy() = vel_sp_xy;

--- a/src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -69,7 +69,7 @@ void FlightTaskManualPositionSmoothVel::reActivate()
 	FlightTaskManualPosition::reActivate();
 	// The task is reacivated while the vehicle is on the ground. To detect takeoff in mc_pos_control_main properly
 	// using the generated jerk, reset the z derivatives to zero
-	_smoothing_xy.reset(Vector2f(), Vector2f(_velocity), Vector2f(_position));
+	_smoothing_xy.reset(Vector2f(), _velocity.xy(), _position.xy());
 	_smoothing_z.reset(0.f, 0.f, _position(2));
 }
 
@@ -136,19 +136,19 @@ void FlightTaskManualPositionSmoothVel::_updateTrajConstraintsZ()
 
 void FlightTaskManualPositionSmoothVel::_updateTrajVelFeedback()
 {
-	_smoothing_xy.setVelSpFeedback(Vector2f(_velocity_setpoint_feedback));
+	_smoothing_xy.setVelSpFeedback(_velocity_setpoint_feedback.xy());
 	_smoothing_z.setVelSpFeedback(_velocity_setpoint_feedback(2));
 }
 
 void FlightTaskManualPositionSmoothVel::_updateTrajCurrentPositionEstimate()
 {
-	_smoothing_xy.setCurrentPositionEstimate(Vector2f(_position));
+	_smoothing_xy.setCurrentPositionEstimate(_position.xy());
 	_smoothing_z.setCurrentPositionEstimate(_position(2));
 }
 
 void FlightTaskManualPositionSmoothVel::_updateTrajectories(Vector3f vel_target)
 {
-	_smoothing_xy.update(_deltatime, Vector2f(vel_target));
+	_smoothing_xy.update(_deltatime, vel_target.xy());
 	_smoothing_z.update(_deltatime, vel_target(2));
 }
 

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -159,7 +159,7 @@ bool FlightTaskOrbit::activate(const vehicle_local_position_setpoint_s &last_set
 	bool ret = FlightTaskManualAltitudeSmoothVel::activate(last_setpoint);
 	_r = _radius_min;
 	_v =  1.f;
-	_center = Vector2f(_position);
+	_center = _position.xy();
 	_center(0) -= _r;
 	_initial_heading = _yaw;
 	_slew_rate_yaw.setForcedValue(_yaw);

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -151,7 +151,7 @@ void StickAccelerationXY::lockPosition(const Vector3f &pos, const matrix::Vector
 {
 	if (_velocity_setpoint.norm_squared() < FLT_EPSILON) {
 		if (!PX4_ISFINITE(_position_setpoint(0))) {
-			_position_setpoint = Vector2f(pos);
+			_position_setpoint = pos.xy();
 		}
 
 	} else {


### PR DESCRIPTION
**Describe problem solved by this pull request**
EKF position resets not getting handled correctly in position mode.

The mapping itself was seprated out into a calls because it was reused for the experimental nudging implementation. The position resets which were handled correctly before now change the wrong setpoints and I adjusted.

The nudging has to be before any filtering, then these member setpoints which are essentially copies are not needed anymore.

**Describe your solution**
I had prepared functions to reset the position and velocity but didn't use them in the EKF reset event.

**Test data / coverage**
@bresch Could you please give this a quick spin?

**Additional context**
Report by @bresch :
> While doing some nav failure sitl tests, I found that the EKF position reset isn't propagated properly in position mode
> ![DeepinScreenshot_select-area_20210209162037](https://user-images.githubusercontent.com/4668506/107394418-26c9e300-6afc-11eb-85af-b8600ddecc16.png)

