### PR TITLE
v5X: Register board variants

### DIFF
--- a/boards/px4/fmu-v5x/src/manifest.c
+++ b/boards/px4/fmu-v5x/src/manifest.c
@@ -115,6 +115,9 @@ static px4_hw_mft_list_entry_t mft_lists[] = {
 	{0x0001, hw_mft_list_v0500, arraySize(hw_mft_list_v0500)},
 	{0x0100, hw_mft_list_v0510, arraySize(hw_mft_list_v0510)},
 	{0x0900, hw_mft_list_v0509, arraySize(hw_mft_list_v0509)},
+	{0x0901, hw_mft_list_v0509, arraySize(hw_mft_list_v0509)},
+	{0x0a00, hw_mft_list_v0509, arraySize(hw_mft_list_v0509)},
+	{0x0a01, hw_mft_list_v0509, arraySize(hw_mft_list_v0509)},
 };
 
 


### PR DESCRIPTION
This is needed to properly identify new variants.