### PR TITLE
Add comment for reserve autostartIDs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -157,6 +157,8 @@ px4_add_romfs_files(
 	# [18000, 18999] High-altitude balloons
 	18001_TF-B1
 
+	# [22000, 22999] Reserve for custom models
+
 	24001_dodeca_cox
 
 	50000_generic_ground_vehicle


### PR DESCRIPTION
**Describe problem solved by this pull request**
When working on custom airframe configs, one would usually pick a random autostart ID to work with. However, whenever there is an airframe config with the same autostartID merged upstream it causes issues for the custom models. 

**Describe your solution**
This proposes reserving some of the autostartIDs for custom models to prevent the above from happening. This commit adds a comment where the autostart IDs 22000-22999 should be reserved for custom models


**Additional context**
- Discussed in the dev call 10/Feb/2021