### PR TITLE
commander: rework nav failure check

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4041,7 +4041,7 @@ void Commander::estimator_check()
 						if (!_nav_test_failed && hrt_elapsed_time(&_time_last_innov_pass) > 1_s) {
 							// if the innovation test has failed continuously, declare the nav as failed
 							_nav_test_failed = true;
-							mavlink_log_emergency(&_mavlink_log_pub, "Navigation failure! Recalibrate sensors");
+							mavlink_log_emergency(&_mavlink_log_pub, "Navigation failure! Land and recalibrate sensors");
 						}
 					}
 				}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4016,7 +4016,10 @@ void Commander::estimator_check()
 
 			} else {
 				if (!_nav_test_passed) {
-					const bool innovation_pass = (estimator_status.vel_test_ratio < 1.0f) && (estimator_status.pos_test_ratio < 1.0f);
+					// Both test ratios need to pass/fail together to change the nav test status
+					const bool innovation_pass = (estimator_status.vel_test_ratio < 1.0f) && (estimator_status.pos_test_ratio < 1.0f)
+								     && (estimator_status.vel_test_ratio > FLT_EPSILON) && (estimator_status.pos_test_ratio > FLT_EPSILON);
+					const bool innovation_fail = (estimator_status.vel_test_ratio >= 1.0f) && (estimator_status.pos_test_ratio >= 1.0f);
 
 					if (innovation_pass) {
 						_time_last_innov_pass = hrt_absolute_time();
@@ -4032,7 +4035,7 @@ void Commander::estimator_check()
 							_nav_test_failed = false;
 						}
 
-					} else {
+					} else if (innovation_fail) {
 						_time_last_innov_fail = hrt_absolute_time();
 
 						if (!_nav_test_failed && hrt_elapsed_time(&_time_last_innov_pass) > 1_s) {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -319,7 +319,8 @@ private:
 	hrt_abstime	_lvel_probation_time_us = POSVEL_PROBATION_MIN;
 
 	/* class variables used to check for navigation failure after takeoff */
-	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity or position innovations passed */
+	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity and position innovations passed */
+	hrt_abstime	_time_last_innov_fail{0};	/**< last time velocity and position innovations failed */
 	bool		_nav_test_passed{false};	/**< true if the post takeoff navigation test has passed */
 	bool		_nav_test_failed{false};	/**< true if the post takeoff navigation test has failed */
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
In most cases, the EKF can recover from a bad yaw using the yaw estimator and commander should not completely stop using the position estimate.

**Describe your solution**
Allow the "nav test" to pass after it failed if the test conditions are fulfilled for a long period of time.

**Describe possible alternatives**
Remove this part of the code completely as EKF2 should handle a bad initial heading properly.

**Test data / coverage**
SITL jMAVSim tests