### PR TITLE
L1 position controller: use double precision floating point for all lat/lon

### DIFF
--- a/src/lib/l1/ECL_L1_Pos_Controller.hpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.hpp
@@ -143,8 +143,8 @@ public:
 	 *
 	 * @return sets _lateral_accel setpoint
 	 */
-	void navigate_waypoints(const matrix::Vector2f &vector_A, const matrix::Vector2f &vector_B,
-				const matrix::Vector2f &vector_curr_position, const matrix::Vector2f &ground_speed);
+	void navigate_waypoints(const matrix::Vector2d &vector_A, const matrix::Vector2d &vector_B,
+				const matrix::Vector2d &vector_curr_position, const matrix::Vector2f &ground_speed);
 
 	/**
 	 * Navigate on an orbit around a loiter waypoint.
@@ -154,7 +154,7 @@ public:
 	 *
 	 * @return sets _lateral_accel setpoint
 	 */
-	void navigate_loiter(const matrix::Vector2f &vector_A, const matrix::Vector2f &vector_curr_position, float radius,
+	void navigate_loiter(const matrix::Vector2d &vector_A, const matrix::Vector2d &vector_curr_position, float radius,
 			     int8_t loiter_direction, const matrix::Vector2f &ground_speed_vector);
 
 	/**
@@ -235,7 +235,7 @@ private:
 	 * @param wp The point to convert to into the local coordinates, in WGS84 coordinates
 	 * @return The vector in meters pointing from the reference position to the coordinates
 	 */
-	matrix::Vector2f get_local_planar_vector(const matrix::Vector2f &origin, const matrix::Vector2f &target) const;
+	matrix::Vector2f get_local_planar_vector(const matrix::Vector2d &origin, const matrix::Vector2d &target) const;
 
 	/**
 	 * Update roll angle setpoint. This will also apply slew rate limits if set.

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -89,21 +89,12 @@
 #include <uORB/uORB.h>
 #include <vtol_att_control/vtol_type.h>
 
-using math::constrain;
-using math::max;
-using math::min;
-using math::radians;
-
-using matrix::Dcmf;
-using matrix::Eulerf;
-using matrix::Quatf;
-using matrix::Vector2f;
-using matrix::Vector3f;
-using matrix::wrap_pi;
-
 using namespace launchdetection;
 using namespace runwaytakeoff;
 using namespace time_literals;
+
+using matrix::Vector2d;
+using matrix::Vector2f;
 
 static constexpr float HDG_HOLD_DIST_NEXT =
 	3000.0f; // initial distance of waypoint in front of plane in heading hold mode
@@ -248,7 +239,7 @@ private:
 
 	bool _vtol_tailsitter{false};
 
-	Vector2f _transition_waypoint{NAN, NAN};
+	matrix::Vector2d _transition_waypoint{(double)NAN, (double)NAN};
 
 	// estimator reset counters
 	uint8_t _pos_reset_counter{0};				///< captures the number of times the estimator has reset the horizontal position
@@ -324,13 +315,13 @@ private:
 	 */
 	void		update_desired_altitude(float dt);
 
-	bool		control_position(const hrt_abstime &now, const Vector2f &curr_pos, const Vector2f &ground_speed,
+	bool		control_position(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
 					 const position_setpoint_s &pos_sp_prev,
 					 const position_setpoint_s &pos_sp_curr, const position_setpoint_s &pos_sp_next);
-	void		control_takeoff(const hrt_abstime &now, const Vector2f &curr_pos, const Vector2f &ground_speed,
+	void		control_takeoff(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
 					const position_setpoint_s &pos_sp_prev,
 					const position_setpoint_s &pos_sp_curr);
-	void		control_landing(const hrt_abstime &now, const Vector2f &curr_pos, const Vector2f &ground_speed,
+	void		control_landing(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
 					const position_setpoint_s &pos_sp_prev,
 					const position_setpoint_s &pos_sp_curr);
 

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
@@ -46,7 +46,6 @@
 #include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 
-using matrix::Vector2f;
 using namespace time_literals;
 
 namespace runwaytakeoff
@@ -69,8 +68,8 @@ void RunwayTakeoff::init(const hrt_abstime &now, float yaw, double current_lat, 
 	_state = RunwayTakeoffState::THROTTLE_RAMP;
 	_initialized_time = now;
 	_climbout = true; // this is true until climbout is finished
-	_start_wp(0) = (float)current_lat;
-	_start_wp(1) = (float)current_lon;
+	_start_wp(0) = current_lat;
+	_start_wp(1) = current_lon;
 }
 
 void RunwayTakeoff::update(const hrt_abstime &now, float airspeed, float alt_agl,
@@ -103,8 +102,8 @@ void RunwayTakeoff::update(const hrt_abstime &now, float airspeed, float alt_agl
 			 * The navigator will take this as starting point to navigate towards the takeoff WP.
 			 */
 			if (_param_rwto_hdg.get() == 0) {
-				_start_wp(0) = (float)current_lat;
-				_start_wp(1) = (float)current_lon;
+				_start_wp(0) = current_lat;
+				_start_wp(1) = current_lon;
 			}
 
 			mavlink_log_info(mavlink_log_pub, "#Climbout");
@@ -247,14 +246,6 @@ float RunwayTakeoff::getMaxPitch(float max)
 	else {
 		return max;
 	}
-}
-
-/*
- * Returns the "previous" (start) WP for navigation.
- */
-Vector2f RunwayTakeoff::getStartWP()
-{
-	return _start_wp;
 }
 
 void RunwayTakeoff::reset()

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -88,7 +88,7 @@ public:
 	bool resetIntegrators();
 	float getMinPitch(float sp_min, float climbout_min, float min);
 	float getMaxPitch(float max);
-	matrix::Vector2f getStartWP();
+	const matrix::Vector2d &getStartWP() const { return _start_wp; };
 
 	void reset();
 
@@ -99,7 +99,7 @@ private:
 	hrt_abstime _initialized_time{0};
 	float _init_yaw{0.f};
 	bool _climbout{false};
-	matrix::Vector2f _start_wp;
+	matrix::Vector2d _start_wp;
 
 	DEFINE_PARAMETERS(
 		(ParamBool<px4::params::RWTO_TKOFF>) _param_rwto_tkoff,

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -149,7 +149,7 @@ RoverPositionControl::vehicle_attitude_poll()
 }
 
 bool
-RoverPositionControl::control_position(const matrix::Vector2f &current_position,
+RoverPositionControl::control_position(const matrix::Vector2d &current_position,
 				       const matrix::Vector3f &ground_speed, const position_setpoint_triplet_s &pos_sp_triplet)
 {
 	float dt = 0.01; // Using non zero value to a avoid division by zero
@@ -172,14 +172,14 @@ RoverPositionControl::control_position(const matrix::Vector2f &current_position,
 		//bool was_circle_mode = _gnd_control.circle_mode();
 
 		/* current waypoint (the one currently heading for) */
-		matrix::Vector2f curr_wp((float)pos_sp_triplet.current.lat, (float)pos_sp_triplet.current.lon);
+		matrix::Vector2d curr_wp(pos_sp_triplet.current.lat, pos_sp_triplet.current.lon);
 
 		/* previous waypoint */
-		matrix::Vector2f prev_wp = curr_wp;
+		matrix::Vector2d prev_wp = curr_wp;
 
 		if (pos_sp_triplet.previous.valid) {
-			prev_wp(0) = (float)pos_sp_triplet.previous.lat;
-			prev_wp(1) = (float)pos_sp_triplet.previous.lon;
+			prev_wp(0) = pos_sp_triplet.previous.lat;
+			prev_wp(1) = pos_sp_triplet.previous.lon;
 		}
 
 		matrix::Vector2f ground_speed_2d(ground_speed);
@@ -433,7 +433,7 @@ RoverPositionControl::run()
 			_pos_reset_counter = _global_pos.lat_lon_reset_counter;
 
 			matrix::Vector3f ground_speed(_local_pos.vx, _local_pos.vy,  _local_pos.vz);
-			matrix::Vector2f current_position((float)_global_pos.lat, (float)_global_pos.lon);
+			matrix::Vector2d current_position(_global_pos.lat, _global_pos.lon);
 			matrix::Vector3f current_velocity(_local_pos.vx, _local_pos.vy, _local_pos.vz);
 
 			if (!manual_mode && _control_mode.flag_control_position_enabled) {

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -150,7 +150,7 @@ private:
 	} _pos_ctrl_state {STOPPING};			/// Position control state machine
 
 	/* previous waypoint */
-	matrix::Vector2f _prev_wp{0.0f, 0.0f};
+	matrix::Vector2d _prev_wp{0, 0};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::GND_L1_PERIOD>) _param_l1_period,
@@ -190,7 +190,7 @@ private:
 	/**
 	 * Control position.
 	 */
-	bool		control_position(const matrix::Vector2f &global_pos, const matrix::Vector3f &ground_speed,
+	bool		control_position(const matrix::Vector2d &global_pos, const matrix::Vector3f &ground_speed,
 					 const position_setpoint_triplet_s &_pos_sp_triplet);
 	void		control_velocity(const matrix::Vector3f &current_velocity, const position_setpoint_triplet_s &pos_sp_triplet);
 	void		control_attitude(const vehicle_attitude_s &att, const vehicle_attitude_setpoint_s &att_sp);


### PR DESCRIPTION
Always use double precision floating point for working with latitude and longitude, otherwise float should be sufficient.

Needs to carefully checked that it covers all aspects of https://github.com/PX4/PX4-Autopilot/issues/16823. We also need to be fully aware of the performance implications on older boards that lack double precision floating point hardware.

 - fixes https://github.com/PX4/PX4-Autopilot/issues/16823
