### PR TITLE
Use smaller loiter radius for rovers

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.rover_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_defaults
@@ -17,9 +17,15 @@ then
 
 	param set NAV_DLL_ACT 0
 	param set NAV_ACC_RAD 2
+	param set NAV_LOITER_RAD 2
 
 	# Temporary.
 	param set NAV_FW_ALT_RAD 1000
+fi
+
+if param greater -s NAV_LOITER_RAD 2.5
+then
+	param set NAV_LOITER_RAD 2
 fi
 
 #


### PR DESCRIPTION
**Describe problem solved by this pull request**
The rover position controller goes in a "STOPPING" state when the next waypoint is smaller than the loiter radius(set by `NAV_LOITER_RAD`): https://github.com/PX4/PX4-Autopilot/blob/5b44bd67bb37c91c0b15ceee70c873b8c0e28cfa/src/modules/rover_pos_control/RoverPositionControl.cpp#L233-L234 

However, since the default is `NAV_LOITER_RAD=50` it effectly prevents from anybody planning a mission within a 50m radius from where the vehicle is. 

This problem was not obvious since all vehicles in SITL were effectly already using `NAV_LOITER_RAD=2`

**Describe your solution**
While the stopping logic is something that definitely needs fixing, reducing `NAV_LOITER_RAD` for all rover vehicles as a hot fix. 

**Additional context**
- Discussion in [slack](https://px4.slack.com/archives/CJ1AJ8YQZ/p1613062885061500?thread_ts=1612178954.028100&cid=CJ1AJ8YQZ)
- Fixes https://github.com/PX4/PX4-Autopilot/issues/16775