### PR TITLE
RTPS: adjust timestamp_sample in urtps_agent

### DIFF
--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -139,10 +139,13 @@ bool RtpsTopics::getMsg(const uint8_t topic_ID, eprosima::fastcdr::Cdr &scdr)
 @[    if topic == 'Timesync' or topic == 'timesync']@
                 if (getMsgSysID(&msg) == 0) {
 @[    end if]@
-                // apply timestamp offset
+                // apply timestamps offset
                 uint64_t timestamp = getMsgTimestamp(&msg);
+                uint64_t timestamp_sample = getMsgTimestampSample(&msg);
                 _timesync->addOffset(timestamp);
                 setMsgTimestamp(&msg, timestamp);
+                _timesync->addOffset(timestamp_sample);
+                setMsgTimestampSample(&msg, timestamp_sample);
                 msg.serialize(scdr);
                 ret = true;
 @[    if topic == 'Timesync' or topic == 'timesync']@


### PR DESCRIPTION
This needed to use messages which contain timestamp_sample. Without timestamp_sample synchronization PX4 modules will discard them.

This implementation was done at the suggestion of @TSC21 ([previous PR](https://github.com/PX4/px4_ros_com/pull/66#pullrequestreview-588790862))