### PR TITLE
Add support for stabilized mode on rovers

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -116,8 +116,56 @@ RoverPositionControl::vehicle_control_mode_poll()
 void
 RoverPositionControl::manual_control_setpoint_poll()
 {
-	if (_manual_control_setpoint_sub.updated()) {
-		_manual_control_setpoint_sub.copy(&_manual_control_setpoint);
+	if (_control_mode.flag_control_manual_enabled) {
+		if (_manual_control_setpoint_sub.copy(&_manual_control_setpoint)) {
+			float dt = math::constrain(hrt_elapsed_time(&_manual_setpoint_last_called) * 1e-6f,  0.0002f, 0.04f);
+
+			if (!_control_mode.flag_control_climb_rate_enabled &&
+			    !_control_mode.flag_control_offboard_enabled) {
+
+				if (_control_mode.flag_control_attitude_enabled) {
+					// STABILIZED mode generate the attitude setpoint from manual user inputs
+					_att_sp.roll_body = 0.0;
+					_att_sp.pitch_body = 0.0;
+
+					/* reset yaw setpoint to current position if needed */
+					if (_reset_yaw_sp) {
+						const float vehicle_yaw = Eulerf(Quatf(_vehicle_att.q)).psi();
+						_manual_yaw_sp = vehicle_yaw;
+						_reset_yaw_sp = false;
+
+					} else {
+						const float yaw_rate = math::radians(_param_gnd_man_y_max.get());
+						_att_sp.yaw_sp_move_rate = _manual_control_setpoint.r * yaw_rate;
+						_manual_yaw_sp = wrap_pi(_manual_yaw_sp + _att_sp.yaw_sp_move_rate * dt);
+					}
+
+					_att_sp.yaw_body = _manual_yaw_sp;
+					_att_sp.thrust_body[0] = _manual_control_setpoint.z;
+
+					Quatf q(Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body));
+					q.copyTo(_att_sp.q_d);
+
+					_att_sp.timestamp = hrt_absolute_time();
+
+
+					_attitude_sp_pub.publish(_att_sp);
+
+				} else {
+					/* manual/direct control */
+					_act_controls.control[actuator_controls_s::INDEX_ROLL] = _manual_control_setpoint.y;
+					_act_controls.control[actuator_controls_s::INDEX_PITCH] = -_manual_control_setpoint.x;
+					_act_controls.control[actuator_controls_s::INDEX_YAW] = _manual_control_setpoint.r; //TODO: Readd yaw scale param
+					_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.z;
+					_reset_yaw_sp = true;
+				}
+
+			} else {
+				_reset_yaw_sp = true;
+			}
+
+			_manual_setpoint_last_called = hrt_absolute_time();
+		}
 	}
 }
 
@@ -353,8 +401,6 @@ RoverPositionControl::Run()
 		/* update parameters from storage */
 		parameters_update();
 
-		bool manual_mode = _control_mode.flag_control_manual_enabled;
-
 		/* only run controller if position changed */
 		if (_local_pos_sub.update(&_local_pos)) {
 
@@ -383,7 +429,7 @@ RoverPositionControl::Run()
 			matrix::Vector2d current_position(_global_pos.lat, _global_pos.lon);
 			matrix::Vector3f current_velocity(_local_pos.vx, _local_pos.vy, _local_pos.vz);
 
-			if (!manual_mode && _control_mode.flag_control_position_enabled) {
+			if (!_control_mode.flag_control_manual_enabled && _control_mode.flag_control_position_enabled) {
 
 				if (control_position(current_position, ground_speed, _pos_sp_triplet)) {
 
@@ -413,43 +459,29 @@ RoverPositionControl::Run()
 
 				}
 
-			} else if (!manual_mode && _control_mode.flag_control_velocity_enabled) {
+			} else if (!_control_mode.flag_control_manual_enabled && _control_mode.flag_control_velocity_enabled) {
 
 				control_velocity(current_velocity, _pos_sp_triplet);
 
 			}
 		}
 
-		if (!manual_mode && _control_mode.flag_control_attitude_enabled
+		if (_control_mode.flag_control_attitude_enabled
 		    && !_control_mode.flag_control_position_enabled
 		    && !_control_mode.flag_control_velocity_enabled) {
-
 			control_attitude(_vehicle_att, _att_sp);
 
 		}
 
-		if (manual_mode) {
-			/* manual/direct control */
-			//PX4_INFO("Manual mode!");
-			_act_controls.control[actuator_controls_s::INDEX_ROLL] = _manual_control_setpoint.y;
-			_act_controls.control[actuator_controls_s::INDEX_PITCH] = -_manual_control_setpoint.x;
-			_act_controls.control[actuator_controls_s::INDEX_YAW] = _manual_control_setpoint.r; //TODO: Readd yaw scale param
-			_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.z;
-		}
+		_act_controls.timestamp = hrt_absolute_time();
 
-		if (_sensor_combined_sub.update(&_sensor_combined)) {
-
-			//orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
-			_act_controls.timestamp = hrt_absolute_time();
-
-			/* Only publish if any of the proper modes are enabled */
-			if (_control_mode.flag_control_velocity_enabled ||
-			    _control_mode.flag_control_attitude_enabled ||
-			    _control_mode.flag_control_position_enabled ||
-			    manual_mode) {
-				/* publish the actuator controls */
-				_actuator_controls_pub.publish(_act_controls);
-			}
+		/* Only publish if any of the proper modes are enabled */
+		if (_control_mode.flag_control_velocity_enabled ||
+		    _control_mode.flag_control_attitude_enabled ||
+		    _control_mode.flag_control_position_enabled ||
+		    _control_mode.flag_control_manual_enabled) {
+			/* publish the actuator controls */
+			_actuator_controls_pub.publish(_act_controls);
 		}
 	}
 

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -58,14 +58,26 @@ extern "C" __EXPORT int rover_pos_control_main(int argc, char *argv[]);
 
 RoverPositionControl::RoverPositionControl() :
 	ModuleParams(nullptr),
+	WorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),
 	/* performance counters */
-	_loop_perf(perf_alloc(PC_ELAPSED, "rover position control")) // TODO : do we even need these perf counters
+	_loop_perf(perf_alloc(PC_ELAPSED,  MODULE_NAME": cycle")) // TODO : do we even need these perf counters
 {
 }
 
 RoverPositionControl::~RoverPositionControl()
 {
 	perf_free(_loop_perf);
+}
+
+bool
+RoverPositionControl::init()
+{
+	if (!_vehicle_attitude_sub.registerCallback()) {
+		PX4_ERR("vehicle attitude callback registration failed!");
+		return false;
+	}
+
+	return true;
 }
 
 void RoverPositionControl::parameters_update(bool force)
@@ -96,55 +108,32 @@ void RoverPositionControl::parameters_update(bool force)
 void
 RoverPositionControl::vehicle_control_mode_poll()
 {
-	bool updated;
-	orb_check(_control_mode_sub, &updated);
-
-	if (updated) {
-		orb_copy(ORB_ID(vehicle_control_mode), _control_mode_sub, &_control_mode);
+	if (_control_mode_sub.updated()) {
+		_control_mode_sub.copy(&_control_mode);
 	}
 }
 
 void
 RoverPositionControl::manual_control_setpoint_poll()
 {
-	bool manual_updated;
-	orb_check(_manual_control_setpoint_sub, &manual_updated);
-
-	if (manual_updated) {
-		orb_copy(ORB_ID(manual_control_setpoint), _manual_control_setpoint_sub, &_manual_control_setpoint);
+	if (_manual_control_setpoint_sub.updated()) {
+		_manual_control_setpoint_sub.copy(&_manual_control_setpoint);
 	}
 }
 
 void
 RoverPositionControl::position_setpoint_triplet_poll()
 {
-	bool pos_sp_triplet_updated;
-	orb_check(_pos_sp_triplet_sub, &pos_sp_triplet_updated);
-
-	if (pos_sp_triplet_updated) {
-		orb_copy(ORB_ID(position_setpoint_triplet), _pos_sp_triplet_sub, &_pos_sp_triplet);
+	if (_pos_sp_triplet_sub.updated()) {
+		_pos_sp_triplet_sub.copy(&_pos_sp_triplet);
 	}
 }
 
 void
 RoverPositionControl::attitude_setpoint_poll()
 {
-	bool att_sp_updated;
-	orb_check(_att_sp_sub, &att_sp_updated);
-
-	if (att_sp_updated) {
-		orb_copy(ORB_ID(vehicle_attitude_setpoint), _att_sp_sub, &_att_sp);
-	}
-}
-
-void
-RoverPositionControl::vehicle_attitude_poll()
-{
-	bool att_updated;
-	orb_check(_vehicle_attitude_sub, &att_updated);
-
-	if (att_updated) {
-		orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
+	if (_att_sp_sub.updated()) {
+		_att_sp_sub.copy(&_att_sp);
 	}
 }
 
@@ -347,57 +336,17 @@ RoverPositionControl::control_attitude(const vehicle_attitude_s &att, const vehi
 }
 
 void
-RoverPositionControl::run()
+RoverPositionControl::Run()
 {
-	_control_mode_sub = orb_subscribe(ORB_ID(vehicle_control_mode));
-	_global_pos_sub = orb_subscribe(ORB_ID(vehicle_global_position));
-	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
-	_manual_control_setpoint_sub = orb_subscribe(ORB_ID(manual_control_setpoint));
-	_pos_sp_triplet_sub = orb_subscribe(ORB_ID(position_setpoint_triplet));
-	_att_sp_sub = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
-
-	_vehicle_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
-	_sensor_combined_sub = orb_subscribe(ORB_ID(sensor_combined));
-
-	/* rate limit control mode updates to 5Hz */
-	orb_set_interval(_control_mode_sub, 200);
-
-	/* rate limit position updates to 50 Hz */
-	orb_set_interval(_global_pos_sub, 20);
-	orb_set_interval(_local_pos_sub, 20);
-
 	parameters_update(true);
 
-	/* wakeup source(s) */
-	px4_pollfd_struct_t fds[5];
-
-	/* Setup of loop */
-	fds[0].fd = _global_pos_sub;
-	fds[0].events = POLLIN;
-	fds[1].fd = _manual_control_setpoint_sub;
-	fds[1].events = POLLIN;
-	fds[2].fd = _sensor_combined_sub;
-	fds[2].events = POLLIN;
-	fds[3].fd = _vehicle_attitude_sub; // Poll attitude
-	fds[3].events = POLLIN;
-	fds[4].fd = _local_pos_sub;  // Added local position as source of position
-	fds[4].events = POLLIN;
-
-	while (!should_exit()) {
-
-		/* wait for up to 500ms for data */
-		int pret = px4_poll(&fds[0], (sizeof(fds) / sizeof(fds[0])), 500);
-
-		/* this is undesirable but not much we can do - might want to flag unhappy status */
-		if (pret < 0) {
-			warn("poll error %d, %d", pret, errno);
-			continue;
-		}
+	if (_vehicle_attitude_sub.update(&_vehicle_att)) {
+		perf_begin(_loop_perf);
 
 		/* check vehicle control mode for changes to publication state */
 		vehicle_control_mode_poll();
 		attitude_setpoint_poll();
-		//manual_control_setpoint_poll();
+		manual_control_setpoint_poll();
 
 		_vehicle_acceleration_sub.update();
 
@@ -407,12 +356,10 @@ RoverPositionControl::run()
 		bool manual_mode = _control_mode.flag_control_manual_enabled;
 
 		/* only run controller if position changed */
-		if (fds[0].revents & POLLIN || fds[4].revents & POLLIN) {
-			perf_begin(_loop_perf);
+		if (_local_pos_sub.update(&_local_pos)) {
 
 			/* load local copies */
-			orb_copy(ORB_ID(vehicle_global_position), _global_pos_sub, &_global_pos);
-			orb_copy(ORB_ID(vehicle_local_position), _local_pos_sub, &_local_pos);
+			_global_pos_sub.update(&_global_pos);
 
 			position_setpoint_triplet_poll();
 
@@ -471,44 +418,26 @@ RoverPositionControl::run()
 				control_velocity(current_velocity, _pos_sp_triplet);
 
 			}
-
-
-			perf_end(_loop_perf);
 		}
 
-		if (fds[3].revents & POLLIN) {
+		if (!manual_mode && _control_mode.flag_control_attitude_enabled
+		    && !_control_mode.flag_control_position_enabled
+		    && !_control_mode.flag_control_velocity_enabled) {
 
-			vehicle_attitude_poll();
-
-			if (!manual_mode && _control_mode.flag_control_attitude_enabled
-			    && !_control_mode.flag_control_position_enabled
-			    && !_control_mode.flag_control_velocity_enabled) {
-
-				control_attitude(_vehicle_att, _att_sp);
-
-			}
+			control_attitude(_vehicle_att, _att_sp);
 
 		}
 
-		if (fds[1].revents & POLLIN) {
-
-			// This should be copied even if not in manual mode. Otherwise, the poll(...) call will keep
-			// returning immediately and this loop will eat up resources.
-			orb_copy(ORB_ID(manual_control_setpoint), _manual_control_setpoint_sub, &_manual_control_setpoint);
-
-			if (manual_mode) {
-				/* manual/direct control */
-				//PX4_INFO("Manual mode!");
-				_act_controls.control[actuator_controls_s::INDEX_ROLL] = _manual_control_setpoint.y;
-				_act_controls.control[actuator_controls_s::INDEX_PITCH] = -_manual_control_setpoint.x;
-				_act_controls.control[actuator_controls_s::INDEX_YAW] = _manual_control_setpoint.r; //TODO: Readd yaw scale param
-				_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.z;
-			}
+		if (manual_mode) {
+			/* manual/direct control */
+			//PX4_INFO("Manual mode!");
+			_act_controls.control[actuator_controls_s::INDEX_ROLL] = _manual_control_setpoint.y;
+			_act_controls.control[actuator_controls_s::INDEX_PITCH] = -_manual_control_setpoint.x;
+			_act_controls.control[actuator_controls_s::INDEX_YAW] = _manual_control_setpoint.r; //TODO: Readd yaw scale param
+			_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.z;
 		}
 
-		if (fds[2].revents & POLLIN) {
-
-			orb_copy(ORB_ID(sensor_combined), _sensor_combined_sub, &_sensor_combined);
+		if (_sensor_combined_sub.update(&_sensor_combined)) {
 
 			//orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_att);
 			_act_controls.timestamp = hrt_absolute_time();
@@ -522,53 +451,32 @@ RoverPositionControl::run()
 				_actuator_controls_pub.publish(_act_controls);
 			}
 		}
-
 	}
 
-	orb_unsubscribe(_control_mode_sub);
-	orb_unsubscribe(_global_pos_sub);
-	orb_unsubscribe(_local_pos_sub);
-	orb_unsubscribe(_manual_control_setpoint_sub);
-	orb_unsubscribe(_pos_sp_triplet_sub);
-	orb_unsubscribe(_vehicle_attitude_sub);
-	orb_unsubscribe(_sensor_combined_sub);
-
-	warnx("exiting.\n");
+	perf_end(_loop_perf);
 }
 
 int RoverPositionControl::task_spawn(int argc, char *argv[])
 {
-	/* start the task */
-	_task_id = px4_task_spawn_cmd("rover_pos_ctrl",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_POSITION_CONTROL,
-				      1700,
-				      (px4_main_t)&RoverPositionControl::run_trampoline,
-				      nullptr);
-
-	if (_task_id < 0) {
-		warn("task start failed");
-		return -errno;
-	}
-
-	return OK;
-}
-
-RoverPositionControl *RoverPositionControl::instantiate(int argc, char *argv[])
-{
-
-	if (argc > 0) {
-		PX4_WARN("Command 'start' takes no arguments.");
-		return nullptr;
-	}
-
 	RoverPositionControl *instance = new RoverPositionControl();
 
-	if (instance == nullptr) {
-		PX4_ERR("Failed to instantiate RoverPositionControl object");
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
 	}
 
-	return instance;
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
 }
 
 int RoverPositionControl::custom_command(int argc, char *argv[])

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -103,6 +103,7 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
+	uORB::Publication<vehicle_attitude_setpoint_s>	_attitude_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Publication<position_controller_status_s>	_pos_ctrl_status_pub{ORB_ID(position_controller_status)};  /**< navigation capabilities publication */
 	uORB::Publication<actuator_controls_s>		_actuator_controls_pub{ORB_ID(actuator_controls_0)};  /**< actuator controls publication */
 
@@ -129,6 +130,7 @@ private:
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
 	hrt_abstime _control_position_last_called{0}; 	/**<last call of control_position  */
+	hrt_abstime _manual_setpoint_last_called{0};
 
 	/* Pid controller for the speed. Here we assume we can control airspeed but the control variable is actually on
 	 the throttle. For now just assuming a proportional scaler between controlled airspeed and throttle output.*/
@@ -153,6 +155,9 @@ private:
 	/* previous waypoint */
 	matrix::Vector2d _prev_wp{0, 0};
 
+	float _manual_yaw_sp{0.0};
+	bool _reset_yaw_sp{true};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::GND_L1_PERIOD>) _param_l1_period,
 		(ParamFloat<px4::params::GND_L1_DAMPING>) _param_l1_damping,
@@ -174,6 +179,7 @@ private:
 
 		(ParamFloat<px4::params::GND_WHEEL_BASE>) _param_wheel_base,
 		(ParamFloat<px4::params::GND_MAX_ANG>) _param_max_turn_angle,
+		(ParamFloat<px4::params::GND_MAN_Y_MAX>) _param_gnd_man_y_max,
 		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad	/**< loiter radius for Rover */
 	)
 

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -55,7 +55,9 @@
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/WorkItem.hpp>
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/topics/manual_control_setpoint.h>
@@ -75,7 +77,7 @@ using matrix::Dcmf;
 
 using namespace time_literals;
 
-class RoverPositionControl : public ModuleBase<RoverPositionControl>, public ModuleParams
+class RoverPositionControl final : public ModuleBase<RoverPositionControl>, public ModuleParams, public px4::WorkItem
 {
 public:
 	RoverPositionControl();
@@ -87,31 +89,30 @@ public:
 	static int task_spawn(int argc, char *argv[]);
 
 	/** @see ModuleBase */
-	static RoverPositionControl *instantiate(int argc, char *argv[]);
-
 	static int custom_command(int argc, char *argv[]);
 
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	/** @see ModuleBase::run() */
-	void run() override;
+	bool init();
 
 private:
+	void Run() override;
+
+	uORB::SubscriptionCallbackWorkItem _vehicle_attitude_sub{this, ORB_ID(vehicle_attitude)};
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Publication<position_controller_status_s>	_pos_ctrl_status_pub{ORB_ID(position_controller_status)};  /**< navigation capabilities publication */
 	uORB::Publication<actuator_controls_s>		_actuator_controls_pub{ORB_ID(actuator_controls_0)};  /**< actuator controls publication */
 
-	int		_control_mode_sub{-1};		/**< control mode subscription */
-	int		_global_pos_sub{-1};
-	int		_local_pos_sub{-1};
-	int		_manual_control_setpoint_sub{-1};		/**< notification of manual control updates */
-	int		_pos_sp_triplet_sub{-1};
-	int		_att_sp_sub{-1};
-	int		_vehicle_attitude_sub{-1};
-	int		_sensor_combined_sub{-1};
-
-	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _control_mode_sub{ORB_ID(vehicle_control_mode)}; /**< control mode subscription */
+	uORB::Subscription _global_pos_sub{ORB_ID(vehicle_global_position)};
+	uORB::Subscription _local_pos_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)}; /**< notification of manual control updates */
+	uORB::Subscription _pos_sp_triplet_sub{ORB_ID(position_setpoint_triplet)};
+	uORB::Subscription _att_sp_sub{ORB_ID(vehicle_attitude_setpoint)};
+	uORB::Subscription _sensor_combined_sub{ORB_ID(sensor_combined)};
 
 	manual_control_setpoint_s		_manual_control_setpoint{};			    /**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */

--- a/src/modules/rover_pos_control/rover_pos_control_params.c
+++ b/src/modules/rover_pos_control/rover_pos_control_params.c
@@ -286,3 +286,14 @@ PARAM_DEFINE_FLOAT(GND_WHEEL_BASE, 2.0f);
  * @group Rover Position Control
  */
 PARAM_DEFINE_FLOAT(GND_MAX_ANG, 0.7854f);
+
+/**
+ * Max manual yaw rate
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 400
+ * @decimal 1
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_MAN_Y_MAX, 150.0f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently rovers only support manual mode and mission modes. However, manual mode can result in the heading constantly being changed when traversing in rough terrain. Therefore, it is better to be able to keep a constant heading while navigating rough terrain.

**Describe your solution**
This PR adds support for stabilized flight mode for rovers. In stabilized, the rover will try to keep a constant heading that can be moved using a manual stick input.

Since we already support attitude control in offboard mode, simply re-wiring this controller to the manual stick inputs allows support for stabilized mode. 

Additional cleanups along the way are the following
- updated the uORB API
- Changed the module to use the px4 work que in order to remove the while loop it was using previously. 
- Removed all the loops that were running in different frequencies with `fds`. Now the controller runs every time there is an attitude update

The cleanup and feature for stabilized are separated in different commits

**Test data / coverage**
- [x] SITL Testing
```
make px4_sitl gazebo_rover
```
Log: https://review.px4.io/plot_app?log=a43e5d2f-c3cf-4d47-b122-9059279955ed

- [ ] Real hardware testing

**Additional context**
- Next steps: This is something that is needed to prepare the `rover_pos_control` module to add the rate controller. This will probably happen by separating the attitude control functionality to a separate module. I believe that the poor performance of yaw tracking can be greatly improved by a rate controller.