### PR TITLE
Rover cleanup + arch fixes

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1060_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1060_rover
@@ -16,7 +16,6 @@ then
 	param set GND_SPEED_THR_SC 1
 	param set GND_SPEED_TRIM 4
 	param set GND_THR_CRUISE 0.3
-	param set GND_THR_IDLE 0
 	param set GND_THR_MAX 0.5
 	param set GND_THR_MIN 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1060_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1060_rover
@@ -8,6 +8,7 @@
 if [ $AUTOCNF = yes ]
 then
 	param set GND_L1_DIST 5
+	param set GND_L1_PERIOD 10
 	param set GND_SP_CTRL_MODE 1
 	param set GND_SPEED_D 0.001
 	param set GND_SPEED_I 3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1061_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1061_r1_rover
@@ -17,7 +17,6 @@ then
 	param set GND_SPEED_THR_SC 1
 	param set GND_SPEED_TRIM 4
 	param set GND_THR_CRUISE 0.3
-	param set GND_THR_IDLE 0
 	param set GND_THR_MAX 0.5
 	param set GND_THR_MIN 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1062_tf-r1
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1062_tf-r1
@@ -22,7 +22,6 @@ then
 	param set GND_SPEED_TRIM 15
 	param set GND_SPEED_MAX 25
 	param set GND_THR_CRUISE 0.3
-	param set GND_THR_IDLE 0
 	param set GND_THR_MAX 0.5
 	param set GND_THR_MIN 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1070_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1070_boat
@@ -17,7 +17,6 @@ then
 	param set GND_SPEED_THR_SC 1
 	param set GND_SPEED_TRIM 1
 	param set GND_THR_CRUISE 0.85
-	param set GND_THR_IDLE 0
 	param set GND_THR_MAX 1
 	param set GND_THR_MIN 0
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -27,7 +27,9 @@ param set-default FW_AIRSPD_MAX 3
 param set-default FW_AIRSPD_MIN 0
 param set-default FW_AIRSPD_TRIM 1
 
-param set-default GND_L1_DIST 10
+# Settings for a typical wheelbase 0f 0.3m
+param set-default GND_L1_DIST 1
+param set-default GND_L1_PERIOD 5
 param set-default GND_SP_CTRL_MODE 1
 param set-default GND_SPEED_P 0.25
 param set-default GND_SPEED_I 3
@@ -37,10 +39,6 @@ param set-default GND_SPEED_THR_SC 1
 param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
-param set-default GND_WR_P 2
-param set-default GND_WR_I 0.9674
-param set-default GND_WR_IMAX 0.1
-param set-default GND_WR_D 1.2
 
 param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -34,7 +34,6 @@ param set-default GND_SPEED_I 3
 param set-default GND_SPEED_D 0.001
 param set-default GND_SPEED_IMAX 0.125
 param set-default GND_SPEED_THR_SC 1
-param set-default GND_THR_IDLE 0
 param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0

--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -35,7 +35,6 @@ param set-default FW_AIRSPD_MAX 3
 param set-default GND_SP_CTRL_MODE 1
 param set-default GND_L1_DIST 5
 param set-default GND_L1_PERIOD 3
-param set-default GND_THR_IDLE 0
 param set-default GND_THR_CRUISE 0.7
 param set-default GND_THR_MAX 0.5
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
@@ -32,7 +32,6 @@ param set-default FW_AIRSPD_MIN 0
 param set-default FW_AIRSPD_TRIM 1
 param set-default FW_AIRSPD_MAX 3
 
-param set-default GND_THR_IDLE 0
 param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 

--- a/ROMFS/px4fmu_common/mixers/rover_diff_and_servo.main.mix
+++ b/ROMFS/px4fmu_common/mixers/rover_diff_and_servo.main.mix
@@ -13,25 +13,28 @@ Inputs to the mixer come from channel group 0 (vehicle attitude), channels 0 (ro
 See the README for more information on the scaler format.
 
 
-Output 0
+Output 1 - Empty
 -----------------------------------------
 Z:
 
-Steering mixer using roll on output 1
+Output 2 - Steering mixer using yaw
 ------------------------------------------
 M: 1
+O: 10000 10000 0 -10000 10000 5000
 S: 0 2  10000   10000     0 -10000  10000
 
 
-Output 2
+Output 3 - Left row of wheels using yaw and throttle (1s rise time)
 ------------------------------------------
 M: 2
+O: 10000 10000 0 -10000 10000 10000
 S: 0 2   -500   -500      0      0  10000
 S: 0 3  10000  10000      0 -10000  10000
 
 
-Output 3
+Output 4 - Right row of wheels using yaw and throttle (1s rise time)
 ------------------------------------------
 M: 2
+O: 10000 10000 0 -10000 10000 10000
 S: 0 2    500    500      0      0  10000
 S: 0 3  10000  10000      0 -10000  10000

--- a/ROMFS/px4fmu_common/mixers/rover_generic.main.mix
+++ b/ROMFS/px4fmu_common/mixers/rover_generic.main.mix
@@ -13,23 +13,25 @@ Inputs to the mixer come from channel group 0 (vehicle attitude), channels 2 (ya
 See the README for more information on the scaler format.
 
 
-Output 0
+Output 1: Empty
 ---------------------------------------
 Z:
 
-Steering mixer using roll on output 1
+Output 2: Steering mixer using yaw, with 0.5s rise time
 ---------------------------------------
 M: 1
+O: 10000 10000 0 -10000 10000 5000
 S: 0 2   10000   10000      0 -10000  10000
 
 
-Output 2
+Output 3: Empty
 ---------------------------------------
 This mixer is empty.
 Z:
 
 
-Output 3
+Output 4: Throttle with 2s rise time
 ---------------------------------------
 M: 1
+O: 10000 10000 0 -10000 10000 20000
 S: 0 3  10000  10000      0 -10000  10000

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -8,22 +8,52 @@ board_adc start
 ina226 -X -b 1 -t 1 -k start
 ina226 -X -b 2 -t 2 -k start
 
-# Internal SPI BMI088
-bmi088 -A -R 4 -s start
-bmi088 -G -R 4 -s start
+if ver hwtypecmp V5X90 V5X91 V5Xa0 V5Xa1
+then
+	#SKYNODE base fmu board orientation
 
-# Internal SPI bus ICM42688p
-icm42688p -R 6 -s start
+	# Internal SPI BMI088
+	bmi088 -A -R 2 -s start
+	bmi088 -G -R 2 -s start
 
-# Internal SPI bus ICM-20602 (hard-mounted)
-icm20602 -R 10 -s start
+	# Internal SPI bus ICM42688p
+	icm42688p -R 4 -s start
 
-# Internal magnetometer on I2c
-bmm150 -I start
+	# Internal SPI bus ICM-20602 (hard-mounted)
+	icm20602 -R 8 -s start
+
+	# Internal magnetometer on I2c
+	bmm150 -I -R 6 start
+
+else
+	#FMUv5Xbase board orientation
+
+	# Internal SPI BMI088
+	bmi088 -A -R 4 -s start
+	bmi088 -G -R 4 -s start
+
+	# Internal SPI bus ICM42688p
+	icm42688p -R 6 -s start
+
+	# Internal SPI bus ICM-20602 (hard-mounted)
+	icm20602 -R 10 -s start
+
+	# Internal magnetometer on I2c
+	bmm150 -I start
+
+fi
 
 # Possible internal Baro
-bmp388 -I -a 0x77 start
-bmp388 -I start
 
-# Baro on I2C3
-ms5611 -X start
+# Disable startup of internal baros if param is set to false
+if param compare SENS_INT_BARO_EN 1
+then
+	bmp388 -I -a 0x77 start
+	if ver hwtypecmp V5X91 V5Xa1
+	then
+		bmp388 -X -b 2 start
+	else
+		bmp388 -I start
+	fi
+
+fi

--- a/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
+++ b/boards/px4/fmu-v5x/nuttx-config/scripts/script.ld
@@ -127,6 +127,14 @@ SECTIONS
 		_einit = ABSOLUTE(.);
 	} > FLASH_AXIM
 
+	/*
+	 * Construction data for parameters.
+	 */
+	__param ALIGN(4): {
+		__param_start = ABSOLUTE(.);
+		KEEP(*(__param*))
+		__param_end = ABSOLUTE(.);
+	} > FLASH_AXIM
 
 	.ARM.extab : {
 		*(.ARM.extab*)

--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -434,6 +434,7 @@
 
 #define BOARD_NUM_IO_TIMERS 5
 
+
 #define PX4_I2C_BUS_MTD      4,5
 
 __BEGIN_DECLS

--- a/boards/px4/fmu-v5x/src/init.cpp
+++ b/boards/px4/fmu-v5x/src/init.cpp
@@ -286,5 +286,31 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	px4_platform_configure();
 
+	int hw_version = board_get_hw_version();
+
+	if (hw_version == 0x9 || hw_version == 0xa) {
+		static MCP23009 mcp23009{3, 0x25};
+
+		// No USB
+		if (hw_version == 0x9) {
+			// < P8
+			ret = mcp23009.init(0xf0, 0xf0, 0x0f);
+			// >= P8
+			//ret = mcp23009.init(0xf1, 0xf0, 0x0f);
+		}
+
+		if (hw_version == 0xa) {
+			// < P6
+			//ret = mcp23009.init(0xf0, 0xf0, 0x0f);
+			// >= P6
+			ret = mcp23009.init(0xf1, 0xf0, 0x0f);
+		}
+
+		if (ret != OK) {
+			led_on(LED_RED);
+			return ret;
+		}
+	}
+
 	return OK;
 }

--- a/src/lib/circuit_breaker/circuit_breaker_params.c
+++ b/src/lib/circuit_breaker/circuit_breaker_params.c
@@ -84,7 +84,7 @@ PARAM_DEFINE_INT32(CBRK_RATE_CTRL, 0);
  * @category Developer
  * @group Circuit Breaker
  */
-PARAM_DEFINE_INT32(CBRK_IO_SAFETY, 0);
+PARAM_DEFINE_INT32(CBRK_IO_SAFETY, 22027);
 
 /**
  * Circuit breaker for airspeed sensor

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -53,7 +53,8 @@ bool Sticks::checkAndSetStickInputs()
 		// Linear scale
 		_positions(0) = manual_control_setpoint.x; // NED x, pitch [-1,1]
 		_positions(1) = manual_control_setpoint.y; // NED y, roll [-1,1]
-		_positions(2) = -(manual_control_setpoint.z - 0.5f) * 2.f; // NED z, thrust resacaled from [0,1] to [-1,1]
+		_positions(2) = -(math::constrain(manual_control_setpoint.z, 0.0f,
+						  1.0f) - 0.5f) * 2.f; // NED z, thrust resacaled from [0,1] to [-1,1]
 		_positions(3) = manual_control_setpoint.r; // yaw [-1,1]
 
 		// Exponential scale

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -165,7 +165,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 								       -radians(_param_fw_man_p_max.get()), radians(_param_fw_man_p_max.get()));
 
 					_att_sp.yaw_body = 0.0f;
-					_att_sp.thrust_body[0] = _manual_control_setpoint.z;
+					_att_sp.thrust_body[0] = math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f);
 
 					Quatf q(Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body));
 					q.copyTo(_att_sp.q_d);
@@ -182,7 +182,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 					_rates_sp.roll = _manual_control_setpoint.y * radians(_param_fw_acro_x_max.get());
 					_rates_sp.pitch = -_manual_control_setpoint.x * radians(_param_fw_acro_y_max.get());
 					_rates_sp.yaw = _manual_control_setpoint.r * radians(_param_fw_acro_z_max.get());
-					_rates_sp.thrust_body[0] = _manual_control_setpoint.z;
+					_rates_sp.thrust_body[0] = math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f);
 
 					_rate_sp_pub.publish(_rates_sp);
 
@@ -194,7 +194,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 						-_manual_control_setpoint.x * _param_fw_man_p_sc.get() + _param_trim_pitch.get();
 					_actuators.control[actuator_controls_s::INDEX_YAW] =
 						_manual_control_setpoint.r * _param_fw_man_y_sc.get() + _param_trim_yaw.get();
-					_actuators.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.z;
+					_actuators.control[actuator_controls_s::INDEX_THROTTLE] = math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f);
 				}
 			}
 		}

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -233,14 +233,14 @@ FixedwingPositionControl::manual_control_setpoint_poll()
 	_manual_control_setpoint_sub.update(&_manual_control_setpoint);
 
 	_manual_control_setpoint_altitude = _manual_control_setpoint.x;
-	_manual_control_setpoint_airspeed = _manual_control_setpoint.z;
+	_manual_control_setpoint_airspeed = math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f);
 
 	if (_param_fw_posctl_inv_st.get()) {
 		/* Alternate stick allocation (similar concept as for multirotor systems:
 		 * demanding up/down with the throttle stick, and move faster/break with the pitch one.
 		 */
-		_manual_control_setpoint_altitude = -(_manual_control_setpoint.z * 2.f - 1.f);
-		_manual_control_setpoint_airspeed = _manual_control_setpoint.x / 2.f + 0.5f;
+		_manual_control_setpoint_altitude = -(math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f) * 2.f - 1.f);
+		_manual_control_setpoint_airspeed = math::constrain(_manual_control_setpoint.x, 0.0f, 1.0f) / 2.f + 0.5f;
 	}
 }
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -127,7 +127,8 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt,
 	if (reset_yaw_sp) {
 		_man_yaw_sp = yaw;
 
-	} else if (_manual_control_setpoint.z > 0.05f || _param_mc_airmode.get() == (int32_t)Mixer::Airmode::roll_pitch_yaw) {
+	} else if (math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f) > 0.05f
+		   || _param_mc_airmode.get() == (int32_t)Mixer::Airmode::roll_pitch_yaw) {
 
 		const float yaw_rate = math::radians(_param_mpc_man_y_max.get());
 		attitude_setpoint.yaw_sp_move_rate = _manual_control_setpoint.r * yaw_rate;
@@ -210,7 +211,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt,
 	Quatf q_sp = Eulerf(attitude_setpoint.roll_body, attitude_setpoint.pitch_body, attitude_setpoint.yaw_body);
 	q_sp.copyTo(attitude_setpoint.q_d);
 
-	attitude_setpoint.thrust_body[2] = -throttle_curve(_manual_control_setpoint.z);
+	attitude_setpoint.thrust_body[2] = -throttle_curve(math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f));
 	attitude_setpoint.timestamp = hrt_absolute_time();
 
 	_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -192,7 +192,7 @@ MulticopterRateControl::Run()
 					math::superexpo(_manual_control_setpoint.r, _param_mc_acro_expo_y.get(), _param_mc_acro_supexpoy.get())};
 
 				_rates_sp = man_rate_sp.emult(_acro_rate_max);
-				_thrust_sp = _manual_control_setpoint.z;
+				_thrust_sp = math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f);
 
 				// publish rate setpoint
 				vehicle_rates_setpoint_s v_rates_sp{};

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -153,7 +153,7 @@ GpsFailure::advance_gpsf()
 	switch (_gpsf_state) {
 	case GPSF_STATE_NONE:
 		_gpsf_state = GPSF_STATE_LOITER;
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Global position failure: fixed bank loiter");
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Global position failure: loitering");
 		break;
 
 	case GPSF_STATE_LOITER:

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -587,7 +587,7 @@ void RCUpdate::UpdateManualSetpoint(const hrt_abstime &timestamp_sample)
 	manual_control_setpoint.y     = get_rc_value(rc_channels_s::FUNCTION_ROLL,    -1.f, 1.f);
 	manual_control_setpoint.x     = get_rc_value(rc_channels_s::FUNCTION_PITCH,   -1.f, 1.f);
 	manual_control_setpoint.r     = get_rc_value(rc_channels_s::FUNCTION_YAW,     -1.f, 1.f);
-	manual_control_setpoint.z     = get_rc_value(rc_channels_s::FUNCTION_THROTTLE, 0.f, 1.f);
+	manual_control_setpoint.z     = get_rc_value(rc_channels_s::FUNCTION_THROTTLE, -1.f, 1.f);
 	manual_control_setpoint.flaps = get_rc_value(rc_channels_s::FUNCTION_FLAPS,   -1.f, 1.f);
 	manual_control_setpoint.aux1  = get_rc_value(rc_channels_s::FUNCTION_AUX_1,   -1.f, 1.f);
 	manual_control_setpoint.aux2  = get_rc_value(rc_channels_s::FUNCTION_AUX_2,   -1.f, 1.f);

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -136,7 +136,7 @@ RoverPositionControl::manual_control_setpoint_poll()
 
 					} else {
 						const float yaw_rate = math::radians(_param_gnd_man_y_max.get());
-						_att_sp.yaw_sp_move_rate = _manual_control_setpoint.r * yaw_rate;
+						_att_sp.yaw_sp_move_rate = _manual_control_setpoint.y * yaw_rate;
 						_manual_yaw_sp = wrap_pi(_manual_yaw_sp + _att_sp.yaw_sp_move_rate * dt);
 					}
 

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -62,7 +62,6 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
-#include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
@@ -109,7 +108,6 @@ private:
 	int		_pos_sp_triplet_sub{-1};
 	int		_att_sp_sub{-1};
 	int		_vehicle_attitude_sub{-1};
-	int		_sensor_combined_sub{-1};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
@@ -121,7 +119,6 @@ private:
 	vehicle_local_position_s		_local_pos{};			/**< global vehicle position */
 	actuator_controls_s				_act_controls{};		/**< direct control of actuators */
 	vehicle_attitude_s				_vehicle_att{};
-	sensor_combined_s				_sensor_combined{};
 
 	uORB::SubscriptionData<vehicle_acceleration_s>		_vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
 
@@ -181,7 +178,6 @@ private:
 	 */
 	void parameters_update(bool force = false);
 
-	void		manual_control_setpoint_poll();
 	void		position_setpoint_triplet_poll();
 	void		attitude_setpoint_poll();
 	void		vehicle_control_mode_poll();

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -102,6 +102,7 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
+	uORB::Publication<vehicle_attitude_setpoint_s>	_attitude_sp_pub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Publication<position_controller_status_s>	_pos_ctrl_status_pub{ORB_ID(position_controller_status)};  /**< navigation capabilities publication */
 	uORB::Publication<actuator_controls_s>		_actuator_controls_pub{ORB_ID(actuator_controls_0)};  /**< actuator controls publication */
 
@@ -126,6 +127,7 @@ private:
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
 	hrt_abstime _control_position_last_called{0}; 	/**<last call of control_position  */
+	hrt_abstime _manual_setpoint_last_called{0};
 
 	/* Pid controller for the speed. Here we assume we can control airspeed but the control variable is actually on
 	 the throttle. For now just assuming a proportional scaler between controlled airspeed and throttle output.*/
@@ -150,6 +152,9 @@ private:
 	/* previous waypoint */
 	matrix::Vector2d _prev_wp{0, 0};
 
+	float _manual_yaw_sp{0.0};
+	bool _reset_yaw_sp{true};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::GND_L1_PERIOD>) _param_l1_period,
 		(ParamFloat<px4::params::GND_L1_DAMPING>) _param_l1_damping,
@@ -171,6 +176,7 @@ private:
 
 		(ParamFloat<px4::params::GND_WHEEL_BASE>) _param_wheel_base,
 		(ParamFloat<px4::params::GND_MAX_ANG>) _param_max_turn_angle,
+		(ParamFloat<px4::params::GND_MAN_Y_MAX>) _param_gnd_man_y_max,
 		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad	/**< loiter radius for Rover */
 	)
 

--- a/src/modules/rover_pos_control/rover_pos_control_params.c
+++ b/src/modules/rover_pos_control/rover_pos_control_params.c
@@ -273,3 +273,14 @@ PARAM_DEFINE_FLOAT(GND_SPEED_MAX, 10.0f);
  * @group Rover Position Control
  */
 PARAM_DEFINE_FLOAT(GND_MAX_ANG, 0.7854f);
+
+/**
+ * Max manual yaw rate
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 400
+ * @decimal 1
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_MAN_Y_MAX, 150.0f);

--- a/src/modules/rover_pos_control/rover_pos_control_params.c
+++ b/src/modules/rover_pos_control/rover_pos_control_params.c
@@ -139,21 +139,6 @@ PARAM_DEFINE_FLOAT(GND_THR_MAX, 0.3f);
 PARAM_DEFINE_FLOAT(GND_THR_MIN, 0.0f);
 
 /**
- * Idle throttle
- *
- * This is the minimum throttle while on the ground, it should be 0 for a rover
- *
- *
- * @unit norm
- * @min 0.0
- * @max 0.4
- * @decimal 2
- * @increment 0.01
- * @group Rover Position Control
- */
-PARAM_DEFINE_FLOAT(GND_THR_IDLE, 0.0f);
-
-/**
  * Control mode for speed
  *
  * This allows the user to choose between closed loop gps speed or open loop cruise throttle speed

--- a/src/modules/rover_pos_control/rover_pos_control_params.c
+++ b/src/modules/rover_pos_control/rover_pos_control_params.c
@@ -49,36 +49,50 @@
  */
 
 /**
- * L1 distance
+ * Distance from front axle to rear axle
  *
- * This is the waypoint radius
- *
+ * A value of 0.31 is typical for 1/10 RC cars.
  *
  * @unit m
  * @min 0.0
- * @max 100.0
+ * @decimal 3
+ * @increment 0.01
+ * @group Rover Position Control
+ */
+PARAM_DEFINE_FLOAT(GND_WHEEL_BASE, 0.31f);
+
+/**
+ * L1 distance
+ *
+ * This is the distance at which the next waypoint is activated. This should be set
+ * to about 2-4x of GND_WHEEL_BASE and not smaller than one meter (due to GPS accuracy).
+ *
+ *
+ * @unit m
+ * @min 1.0
+ * @max 50.0
  * @decimal 1
  * @increment 0.1
  * @group Rover Position Control
  */
-PARAM_DEFINE_FLOAT(GND_L1_DIST, 5.0f);
+PARAM_DEFINE_FLOAT(GND_L1_DIST, 1.0f);
 
 /**
  * L1 period
  *
  * This is the L1 distance and defines the tracking
  * point ahead of the rover it's following.
- * Using values around 2-5 for a traxxas stampede. Shorten
+ * Use values around 2-5m for a 0.3m wheel base. Tuning instructions: Shorten
  * slowly during tuning until response is sharp without oscillation.
  *
  * @unit m
- * @min 0.0
+ * @min 0.5
  * @max 50.0
  * @decimal 1
  * @increment 0.5
  * @group Rover Position Control
  */
-PARAM_DEFINE_FLOAT(GND_L1_PERIOD, 10.0f);
+PARAM_DEFINE_FLOAT(GND_L1_PERIOD, 5.0f);
 
 /**
  * L1 damping
@@ -245,18 +259,6 @@ PARAM_DEFINE_FLOAT(GND_SPEED_TRIM, 3.0f);
  * @group Rover Position Control
  */
 PARAM_DEFINE_FLOAT(GND_SPEED_MAX, 10.0f);
-
-/**
- * Distance from front axle to rear axle
- *
- *
- * @unit m
- * @min 0.0
- * @decimal 3
- * @increment 0.01
- * @group Rover Position Control
- */
-PARAM_DEFINE_FLOAT(GND_WHEEL_BASE, 2.0f);
 
 /**
  * Maximum turn angle for Ackerman steering.

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -221,3 +221,15 @@ PARAM_DEFINE_INT32(SENS_EXT_I2C_PRB, 1);
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_IMU_MODE, 1);
+
+/**
+ * Enable internal barometers
+ *
+ * For systems with an external barometer, this should be set to false to make sure that the external is used.
+ *
+ * @boolean
+ * @reboot_required true
+ * @category system
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(SENS_INT_BARO_EN, 1);


### PR DESCRIPTION
This cleans up some rover specific things, but also adds / fixes two fundamentals (@dagar):

- It allows for the manual -1 to +1 input range, as originally designed. This is important for reversing vehicles. I have added hardening because I was concerned about corner cases for multicopters and fixed wings.
- The reverse setting for PWM channels on PX4IO was off by one. While we will refresh this architecture soon, there is no point of leaving it in the current broken state.

To get to a -1 to 1 scaling for reversing vehicles the calibration in QGC will need to be changed - QGC sets the throttle channel MIN == TRIM, effectively eliminating the negative range. We should change that behavior going forward for reversing vehicle classes.