### PR TITLE
ekf2: selector improve timeout handling and reporting

### DIFF
--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -104,7 +104,12 @@ private:
 		uORB::Subscription estimator_global_position_sub;
 		uORB::Subscription estimator_odometry_sub;
 
-		estimator_status_s status{};
+		uint64_t timestamp_sample_last{0};
+
+		uint32_t accel_device_id{0};
+		uint32_t gyro_device_id{0};
+		uint32_t baro_device_id{0};
+		uint32_t mag_device_id{0};
 
 		hrt_abstime time_last_selected{0};
 
@@ -113,6 +118,7 @@ private:
 
 		bool healthy{false};
 		bool filter_fault{false};
+		bool timeout{false};
 
 		const uint8_t instance;
 	};


### PR DESCRIPTION
 - relax estimator_status timeout unless attitude hasn't published recently
 - primary EKF changed message indicate if due to timeout, filter fault, gyro fault, accel fault

This avoids unnecessary EKF switches due to things like parameter updates on the ground while still maintaining a tight timeout if an estimator stops actually updating (IMU stopped or other error).