### PR TITLE
Minor cleanup and add back feedforward term to the heater driver

### DIFF
--- a/src/drivers/drv_io_heater.h
+++ b/src/drivers/drv_io_heater.h
@@ -47,11 +47,11 @@
  * ioctl() definitions
  */
 
-#define IO_HEATER_DEVICE_PATH	"/dev/px4io"
+#define IO_HEATER_DEVICE_PATH "/dev/px4io"
 
-#define _IO_HEATER_BASE		(0x2e00)
+#define _IO_HEATER_BASE       (0x2e00)
 
-#define PX4IO_HEATER_CONTROL		_PX4_IOC(_IO_HEATER_BASE, 0)
+#define PX4IO_HEATER_CONTROL  _PX4_IOC(_IO_HEATER_BASE, 0)
 
 /* ... to IOX_SET_VALUE + 8 */
 

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -104,6 +104,9 @@ public:
 	 */
 	int controller_period(char *argv[]);
 
+	/** @brief Returns the id of the target sensor. */
+	uint32_t get_sensor_id();
+
 	/**
 	 * @brief Sets and/or reports the heater controller integrator gain value.
 	 * @param argv Pointer to the input argument array.
@@ -117,12 +120,6 @@ public:
 	 * @return Returns the heater proportional gain value iff successful, 0.0f otherwise.
 	 */
 	float proportional(char *argv[]);
-
-	/**
-	 * @brief Reports the heater target sensor.
-	 * @return Returns the id of the target sensor
-	 */
-	uint32_t sensor_id();
 
 	/**
 	 * @brief Initiates the heater driver work queue, starts a new background task,
@@ -146,18 +143,12 @@ public:
 
 protected:
 
-	/**
-	 * @brief Called once to initialize uORB topics.
-	 */
+	/** @brief Called once to initialize uORB topics. */
 	void initialize_topics();
 
 private:
 
-	/**
-	 * @brief Calculates the heater element on/off time, carries out
-	 *        closed loop feedback and feedforward temperature control,
-	 *        and schedules the next cycle.
-	 */
+	/** @brief Calculates the heater element on/off time and schedules the next cycle. */
 	void Run() override;
 
 	/**
@@ -166,27 +157,19 @@ private:
 	 */
 	void update_params(const bool force = false);
 
-	/**
-	 * @brief Enables / configures the heater (either by GPIO or PX4IO)
-	 */
+	/** Enables / configures the heater (either by GPIO or PX4IO). */
 	void heater_enable();
 
-	/**
-	 * @brief Disnables the heater (either by GPIO or PX4IO)
-	 */
+	/** Disnables the heater (either by GPIO or PX4IO). */
 	void heater_disable();
 
-	/**
-	 * @brief Turns the heater on (either by GPIO or PX4IO)
-	 */
+	/** Turns the heater on (either by GPIO or PX4IO). */
 	void heater_on();
 
-	/**
-	 * @brief Turns the heater off (either by GPIO or PX4IO)
-	 */
+	/** Turns the heater off (either by GPIO or PX4IO). */
 	void heater_off();
 
-	/** Work queue struct for the RTOS scheduler. */
+	/** Work queue struct for the scheduler. */
 	static struct work_s _work;
 
 	/** File descriptor for PX4IO for heater ioctl's */
@@ -194,28 +177,24 @@ private:
 	int _io_fd;
 #endif
 
-	int _controller_period_usec = CONTROLLER_PERIOD_DEFAULT;
-
-	int _controller_time_on_usec = 0;
-
 	bool _heater_on = false;
 
-	float _integrator_value = 0.0f;
+	int _controller_period_usec = CONTROLLER_PERIOD_DEFAULT;
+	int _controller_time_on_usec = 0;
+
+	float _integrator_value   = 0.0f;
+	float _proportional_value = 0.0f;
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-
-	float _proportional_value = 0.0f;
 
 	uORB::Subscription _sensor_accel_sub{ORB_ID(sensor_accel)};
 	sensor_accel_s _sensor_accel{};
 
-	float _sensor_temperature = 0.0f;
-
-	/** @note Declare local parameters using defined parameters. */
 	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::SENS_IMU_TEMP_FF>) _param_sens_imu_temp_ff,
 		(ParamFloat<px4::params::SENS_IMU_TEMP_I>)  _param_sens_imu_temp_i,
 		(ParamFloat<px4::params::SENS_IMU_TEMP_P>)  _param_sens_imu_temp_p,
-		(ParamInt<px4::params::SENS_TEMP_ID>) _param_sens_temp_id,
-		(ParamFloat<px4::params::SENS_IMU_TEMP>) _param_sens_imu_temp
+		(ParamInt<px4::params::SENS_TEMP_ID>)       _param_sens_temp_id,
+		(ParamFloat<px4::params::SENS_IMU_TEMP>)    _param_sens_imu_temp
 	)
 };

--- a/src/drivers/heater/heater_params.c
+++ b/src/drivers/heater/heater_params.c
@@ -61,6 +61,18 @@ PARAM_DEFINE_INT32(SENS_TEMP_ID, 0);
 PARAM_DEFINE_FLOAT(SENS_IMU_TEMP, 55.0f);
 
 /**
+ * IMU heater controller feedforward value.
+ *
+ * @category system
+ * @group Sensors
+ * @unit %
+ * @min 0
+ * @max 1.0
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_FF, 0.05f);
+
+/**
  * IMU heater controller integrator gain value.
  *
  * @category system


### PR DESCRIPTION
Hi. This PR adds the feed forward term back into the IMU heater driver, adds a corner case check to the integrator gain so that when it is set close to zero the old integration value is reset, and also performs some formatting cleanup.  C-style casts have been converted to static_casts and the order of function definitions has been alphabetized.

**Test data / coverage**
@AlexKlimaj has tested this PR on an fmu-v5 based flight controller and custom IMU board with GPIO controlled heating elements.  Results are as expected once values have been tuned for the system:

```
nsh> heater status
INFO  [heater] Sensor ID: 3932170,       Sensor Temperature: 54.865C,   Setpoint: 55.00C,       Duty Cycle (usec): 100000
INFO  [heater] Feed Forward control effort: 5.900%,     Proportional control effort: 1.077%,    Integrator control effort: 0.1419%,      Heater cycle: 7.119%
nsh>
```

Please let me know if you have any questions on this PR.

Thanks.

-Mark
