### PR TITLE
CI: fix colcon build in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,11 +67,9 @@ pipeline {
               unset ROS_DISTRO;
               mkdir -p colcon_ws/src;
               cd colcon_ws;
-              git -C ${WORKSPACE}/colcon_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
-              git clone --recursive ${WORKSPACE}/colcon_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
+              git -C ${WORKSPACE}/colcon_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo;
               git -C ${WORKSPACE}/colcon_ws/src/Firmware fetch --tags;
-              source /opt/ros/bouncy/setup.sh;
-              source /opt/ros/melodic/setup.sh;
+              source /opt/ros/foxy/setup.sh;
               colcon build --event-handlers console_direct+ --symlink-install;
             '''
           }


### PR DESCRIPTION
**Describe problem solved by this pull request**
`sitl_gazebo` was looking for system-wide installed libs, since it was at the same src level as the firmware code. Ex: http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2FPX4-Autopilot/detail/master/498/pipeline#step-135-log-302. This is blocking the rest of the Jenkins pipeline.

**Describe your solution**
Remove the top level sitl_gazebo, and build it as part of the default Firmware build.

**Describe possible alternatives**
Eventually the build system needs to be adjusted if we want to make the PX4 SITL executable a ROS 2-visible executable.
