### PR TITLE
Commander: Separate out manual control setpoint processing

### DIFF
--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -50,6 +50,7 @@ px4_add_module(
 		level_calibration.cpp
 		lm_fit.cpp
 		mag_calibration.cpp
+		ManualControl.cpp
 		rc_calibration.cpp
 		state_machine_helper.cpp
 		worker_thread.cpp

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2096,11 +2096,9 @@ Commander::run()
 		}
 
 		// abort autonomous mode and switch to position mode if sticks are moved significantly
-		if ((_param_rc_override.get() != 0)
-		    && (_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
+		if ((_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
 		    && !in_low_battery_failsafe && !_geofence_warning_action_on
-		    && _manual_control.wantsOverride(_param_rc_override.get(), _param_com_rc_stick_ov.get(), _vehicle_control_mode,
-						     !_status.rc_signal_lost)) {
+		    && _manual_control.wantsOverride(_vehicle_control_mode, !_status.rc_signal_lost)) {
 			if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 						  &_internal_state) == TRANSITION_CHANGED) {
 				tune_positive(true);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -427,14 +427,14 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 	if (run_preflight_checks) {
 		if (_vehicle_control_mode.flag_control_manual_enabled) {
 			if (_vehicle_control_mode.flag_control_climb_rate_enabled && _manual_control.isThrottleAboveCenter()) {
-				mavlink_log_critical(&_mavlink_log_pub, "Arming denied because throttle above center");
+				mavlink_log_critical(&_mavlink_log_pub, "Arming denied: throttle above center");
 				tune_negative(true);
 				return TRANSITION_DENIED;
 
 			}
 
 			if (!_vehicle_control_mode.flag_control_climb_rate_enabled && !_manual_control.isThrottleLow()) {
-				mavlink_log_critical(&_mavlink_log_pub, "Arming denied because of high throttle");
+				mavlink_log_critical(&_mavlink_log_pub, "Arming denied: high throttle");
 				tune_negative(true);
 				return TRANSITION_DENIED;
 			}
@@ -2230,7 +2230,7 @@ Commander::run()
 				if (!_status_flags.condition_calibration_enabled && !_status_flags.rc_input_blocked) {
 					mavlink_log_critical(&_mavlink_log_pub, "Manual control lost");
 					_status.rc_signal_lost = true;
-					_rc_signal_lost_timestamp = _manual_control.getLastRCTimestamp();
+					_rc_signal_lost_timestamp = _manual_control.getLastRcTimestamp();
 					set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_RCRECEIVER, true, true, false, _status);
 					_status_changed = true;
 				}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2705,6 +2705,7 @@ Commander::run()
 		_last_condition_global_position_valid = _status_flags.condition_global_position_valid;
 
 		_was_armed = _armed.armed;
+		_last_manual_control_setpoint = _manual_control_setpoint;
 
 		arm_auth_update(now, params_updated || param_init_forced);
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2144,26 +2144,21 @@ Commander::run()
 
 			_status.rc_signal_lost = false;
 
-			/* DISARM
-			 * check if left stick is in lower left position or arm button is pushed or arm switch has transition from arm to disarm
-			 * and we are in MANUAL, Rattitude, or AUTO_READY mode or (ASSIST mode and landed)
-			 * do it only for rotary wings in manual mode or fixed wing if landed.
-			 * Disable stick-disarming if arming switch or button is mapped */
-			if (_manual_control.wantsDisarm(_vehicle_control_mode, _status, _manual_control_switches, _land_detector.landed)) {
-				disarm(arm_disarm_reason_t::RC_STICK);
-			}
+			const bool rc_arming_enabled = (_status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF);
 
-			/* ARM
-			 * check if left stick is in lower right position or arm button is pushed or arm switch has transition from disarm to arm
-			 * and we're in MANUAL mode.
-			 * Disable stick-arming if arming switch or button is mapped */
-			if (_manual_control.wantsArm(_vehicle_control_mode, _status, _manual_control_switches, _land_detector.landed)) {
-				if (_vehicle_control_mode.flag_control_manual_enabled) {
-					arm(arm_disarm_reason_t::RC_STICK);
+			if (rc_arming_enabled) {
+				if (_manual_control.wantsDisarm(_vehicle_control_mode, _status, _manual_control_switches, _land_detector.landed)) {
+					disarm(arm_disarm_reason_t::RC_STICK);
+				}
 
-				} else {
-					mavlink_log_critical(&_mavlink_log_pub, "Not arming! Switch to a manual mode first");
-					tune_negative(true);
+				if (_manual_control.wantsArm(_vehicle_control_mode, _status, _manual_control_switches, _land_detector.landed)) {
+					if (_vehicle_control_mode.flag_control_manual_enabled) {
+						arm(arm_disarm_reason_t::RC_STICK);
+
+					} else {
+						mavlink_log_critical(&_mavlink_log_pub, "Not arming! Switch to a manual mode first");
+						tune_negative(true);
+					}
 				}
 			}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2107,10 +2107,14 @@ Commander::run()
 			if ((override_auto_mode || override_offboard_mode) && !in_low_battery_failsafe && !_geofence_warning_action_on) {
 				const float minimum_stick_deflection = 0.01f * _param_com_rc_stick_ov.get();
 
-				if (!_status.rc_signal_lost &&
-				    ((fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
-				     (fabsf(_manual_control_setpoint.y) > minimum_stick_deflection))) {
+				const bool rpy_deflected = (fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
+							(fabsf(_manual_control_setpoint.y) > minimum_stick_deflection)
+							|| (fabsf(_manual_control_setpoint.r) > minimum_stick_deflection);
+				const bool throttle_deflected = fabsf(_manual_control_setpoint.z - 0.5f) * 2.f > minimum_stick_deflection;
+				const bool use_throttle = !(_param_rc_override.get() & OVERRIDE_IGNORE_THROTTLE_BIT);
 
+				if (!_status.rc_signal_lost &&
+				(rpy_deflected || (use_throttle && throttle_deflected))) {
 					if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 								  &_internal_state) == TRANSITION_CHANGED) {
 						tune_positive(true);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2105,16 +2105,17 @@ Commander::run()
 							    && _vehicle_control_mode.flag_control_offboard_enabled;
 
 			if ((override_auto_mode || override_offboard_mode) && !in_low_battery_failsafe && !_geofence_warning_action_on) {
-				const float minimum_stick_deflection = 0.01f * _param_com_rc_stick_ov.get();
+				const float minimum_stick_change = .01f * _param_com_rc_stick_ov.get();
 
-				const bool rpy_deflected = (fabsf(_manual_control_setpoint.x) > minimum_stick_deflection) ||
-							(fabsf(_manual_control_setpoint.y) > minimum_stick_deflection)
-							|| (fabsf(_manual_control_setpoint.r) > minimum_stick_deflection);
-				const bool throttle_deflected = fabsf(_manual_control_setpoint.z - 0.5f) * 2.f > minimum_stick_deflection;
+				const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
+						|| (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
+						|| (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
+				const bool throttle_moved =
+					(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
 				const bool use_throttle = !(_param_rc_override.get() & OVERRIDE_IGNORE_THROTTLE_BIT);
 
 				if (!_status.rc_signal_lost &&
-				(rpy_deflected || (use_throttle && throttle_deflected))) {
+				(rpy_moved || (use_throttle && throttle_moved))) {
 					if (main_state_transition(_status, commander_state_s::MAIN_STATE_POSCTL, _status_flags,
 								  &_internal_state) == TRANSITION_CHANGED) {
 						tune_positive(true);

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -37,6 +37,7 @@
 /*   Helper classes  */
 #include "Arming/PreFlightCheck/PreFlightCheck.hpp"
 #include "failure_detector/FailureDetector.hpp"
+#include "ManualControl.hpp"
 #include "state_machine_helper.h"
 #include "worker_thread.hpp"
 
@@ -70,7 +71,6 @@
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/iridiumsbd_status.h>
-#include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/manual_control_switches.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
@@ -286,12 +286,6 @@ private:
 		ALWAYS = 2
 	};
 
-	enum OverrideMode {
-		OVERRIDE_AUTO_MODE_BIT = (1 << 0),
-		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1),
-		OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
-	};
-
 	/* Decouple update interval and hysteresis counters, all depends on intervals */
 	static constexpr uint64_t COMMANDER_MONITORING_INTERVAL{10_ms};
 	static constexpr float COMMANDER_MONITORING_LOOPSPERMSEC{1 / (COMMANDER_MONITORING_INTERVAL / 1000.0f)};
@@ -367,6 +361,7 @@ private:
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
+	ManualControl _manual_control;
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
 	int32_t		_flight_mode_slots[manual_control_switches_s::MODE_SLOT_NUM] {};
 	uint8_t		_last_manual_control_switches_arm_switch{manual_control_switches_s::SWITCH_POS_NONE};
@@ -417,7 +412,6 @@ private:
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_land_detector_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription					_safety_sub{ORB_ID(safety)};
-	uORB::Subscription					_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription					_manual_control_switches_sub{ORB_ID(manual_control_switches)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
 	uORB::Subscription					_vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -195,7 +195,6 @@ private:
 		(ParamInt<px4::params::COM_HLDL_REG_T>) _param_com_hldl_reg_t,
 
 		(ParamInt<px4::params::NAV_RCL_ACT>) _param_nav_rcl_act,
-		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamFloat<px4::params::COM_RCL_ACT_T>) _param_com_rcl_act_t,
 
 		(ParamFloat<px4::params::COM_HOME_H_T>) _param_com_home_h_t,
@@ -356,7 +355,6 @@ private:
 	unsigned int	_leds_counter{0};
 
 	manual_control_setpoint_s _manual_control_setpoint{};
-	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
 	ManualControl _manual_control{this};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -363,7 +363,8 @@ private:
 
 	unsigned int	_leds_counter{0};
 
-	manual_control_setpoint_s _manual_control_setpoint{};		///< the current manual control setpoint
+	manual_control_setpoint_s _manual_control_setpoint{};
+	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -235,7 +235,6 @@ private:
 		(ParamFloat<px4::params::COM_EF_TIME>) _param_ef_time_thres,
 
 		(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_arm_without_gps,
-		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_arm_switch_is_button,
 		(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_arm_mission_required,
 		(ParamBool<px4::params::COM_ARM_AUTH_REQ>) _param_arm_auth_required,
 		(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required,
@@ -245,7 +244,6 @@ private:
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,
 
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_rc_in_off,
-		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
 
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,
 		(ParamInt<px4::params::COM_FLTMODE2>) _param_fltmode_2,
@@ -285,9 +283,6 @@ private:
 
 	/* Decouple update interval and hysteresis counters, all depends on intervals */
 	static constexpr uint64_t COMMANDER_MONITORING_INTERVAL{10_ms};
-	static constexpr float COMMANDER_MONITORING_LOOPSPERMSEC{1 / (COMMANDER_MONITORING_INTERVAL / 1000.0f)};
-
-	static constexpr float STICK_ON_OFF_LIMIT{0.9f};
 
 	static constexpr uint64_t HOTPLUG_SENS_TIMEOUT{8_s};	/**< wait for hotplug sensors to come online for upto 8 seconds */
 	static constexpr uint64_t PRINT_MODE_REJECT_INTERVAL{500_ms};
@@ -360,9 +355,6 @@ private:
 	ManualControl _manual_control{this};
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
 	int32_t		_flight_mode_slots[manual_control_switches_s::MODE_SLOT_NUM] {};
-	uint8_t		_last_manual_control_switches_arm_switch{manual_control_switches_s::SWITCH_POS_NONE};
-	uint32_t	_stick_off_counter{0};
-	uint32_t	_stick_on_counter{0};
 
 	hrt_abstime	_boot_timestamp{0};
 	hrt_abstime	_last_disarmed_timestamp{0};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -245,10 +245,8 @@ private:
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,
 
-		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_rc_in_off,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
-		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
 
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,
 		(ParamInt<px4::params::COM_FLTMODE2>) _param_fltmode_2,
@@ -361,7 +359,7 @@ private:
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
-	ManualControl _manual_control;
+	ManualControl _manual_control{this};
 	hrt_abstime	_rc_signal_lost_timestamp{0};		///< Time at which the RC reception was lost
 	int32_t		_flight_mode_slots[manual_control_switches_s::MODE_SLOT_NUM] {};
 	uint8_t		_last_manual_control_switches_arm_switch{manual_control_switches_s::SWITCH_POS_NONE};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -349,7 +349,6 @@ private:
 
 	unsigned int	_leds_counter{0};
 
-	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_switches_s _manual_control_switches{};
 	manual_control_switches_s _last_manual_control_switches{};
 	ManualControl _manual_control{this};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -287,9 +287,9 @@ private:
 	};
 
 	enum OverrideMode {
-		OVERRIDE_DISABLED = 0,
 		OVERRIDE_AUTO_MODE_BIT = (1 << 0),
-		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1)
+		OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1),
+		OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
 	};
 
 	/* Decouple update interval and hysteresis counters, all depends on intervals */

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ManualControl.hpp"
+
+enum OverrideBits {
+	OVERRIDE_AUTO_MODE_BIT = (1 << 0),
+	OVERRIDE_OFFBOARD_MODE_BIT = (1 << 1),
+	OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
+};
+
+void ManualControl::update()
+{
+	if (_manual_control_setpoint_sub.updated()) {
+		manual_control_setpoint_s manual_control_setpoint;
+
+		if (_manual_control_setpoint_sub.copy(&manual_control_setpoint)) {
+			process(manual_control_setpoint);
+		}
+	}
+}
+
+void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)
+{
+	_last_manual_control_setpoint = _manual_control_setpoint;
+	_manual_control_setpoint = manual_control_setpoint;
+}
+
+bool ManualControl::wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
+				  const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available)
+{
+	const bool override_auto_mode = (param_rc_override & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
+					&& vehicle_control_mode.flag_control_auto_enabled;
+
+	const bool override_offboard_mode = (param_rc_override & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
+					    && vehicle_control_mode.flag_control_offboard_enabled;
+
+	if (rc_available && (override_auto_mode || override_offboard_mode)) {
+		const float minimum_stick_change = .01f * param_com_rc_stick_ov;
+
+		const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
+				       || (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
+				       || (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
+		const bool throttle_moved =
+			(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
+		const bool use_throttle = !(param_rc_override & OverrideBits::OVERRIDE_IGNORE_THROTTLE_BIT);
+
+		if (rpy_moved || (use_throttle && throttle_moved)) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -101,7 +101,7 @@ bool ManualControl::wantsDisarm(const vehicle_control_mode_s &vehicle_control_mo
 	const bool arm_button_pressed = _param_arm_switch_is_button.get()
 					&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
 	const bool stick_in_lower_left = _manual_control_setpoint.r < -.9f
-					 && (_manual_control_setpoint.z < .1f)
+					 && isThrottleLow()
 					 && !arm_switch_or_button_mapped;
 	const bool arm_switch_to_disarm_transition = !_param_arm_switch_is_button.get()
 			&& (_last_manual_control_switches_arm_switch == manual_control_switches_s::SWITCH_POS_ON)
@@ -142,7 +142,7 @@ bool ManualControl::wantsArm(const vehicle_control_mode_s &vehicle_control_mode,
 	const bool arm_button_pressed = _param_arm_switch_is_button.get()
 					&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
 	const bool stick_in_lower_right = _manual_control_setpoint.r > .9f
-					  && _manual_control_setpoint.z < 0.1f
+					  && isThrottleLow()
 					  && !arm_switch_or_button_mapped;
 
 	const bool arm_switch_to_arm_transition = !_param_arm_switch_is_button.get()

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -42,8 +42,10 @@ enum OverrideBits {
 	OVERRIDE_IGNORE_THROTTLE_BIT = (1 << 2)
 };
 
-void ManualControl::update()
+bool ManualControl::update()
 {
+	bool ret = false;
+
 	_rc_available = _rc_allowed
 			&& _last_manual_control_setpoint.timestamp != 0
 			&& (hrt_elapsed_time(&_last_manual_control_setpoint.timestamp) < (_param_com_rc_loss_t.get() * 1_s));
@@ -54,7 +56,11 @@ void ManualControl::update()
 		if (_manual_control_setpoint_sub.copy(&manual_control_setpoint)) {
 			process(manual_control_setpoint);
 		}
+
+		ret = true;
 	}
+
+	return ret && _rc_available;
 }
 
 void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -95,15 +95,20 @@ bool ManualControl::wantsDisarm(const vehicle_control_mode_s &vehicle_control_mo
 {
 	bool ret = false;
 
+	// no switch or button is mapped
+	const bool use_stick = manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_NONE;
+	// arm switch mapped and "switch is button" configured
+	const bool use_button = !use_stick && _param_com_arm_swisbtn.get();
+	// arm switch mapped and "switch_is_button" configured
+	const bool use_switch = !use_stick && !use_button;
+
 	const bool armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
-	const bool arm_switch_or_button_mapped =
-		manual_control_switches.arm_switch != manual_control_switches_s::SWITCH_POS_NONE;
-	const bool arm_button_pressed = _param_arm_switch_is_button.get()
-					&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
-	const bool stick_in_lower_left = _manual_control_setpoint.r < -.9f
+	const bool stick_in_lower_left = use_stick
 					 && isThrottleLow()
-					 && !arm_switch_or_button_mapped;
-	const bool arm_switch_to_disarm_transition = !_param_arm_switch_is_button.get()
+					 && _manual_control_setpoint.r < -.9f;
+	const bool arm_button_pressed = (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON)
+					&& use_button;
+	const bool arm_switch_to_disarm_transition = use_switch
 			&& (_last_manual_control_switches_arm_switch == manual_control_switches_s::SWITCH_POS_ON)
 			&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_OFF);
 	const bool mc_manual_thrust_mode = vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
@@ -136,16 +141,20 @@ bool ManualControl::wantsArm(const vehicle_control_mode_s &vehicle_control_mode,
 {
 	bool ret = false;
 
-	const bool armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
-	const bool arm_switch_or_button_mapped =
-		manual_control_switches.arm_switch != manual_control_switches_s::SWITCH_POS_NONE;
-	const bool arm_button_pressed = _param_arm_switch_is_button.get()
-					&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
-	const bool stick_in_lower_right = _manual_control_setpoint.r > .9f
-					  && isThrottleLow()
-					  && !arm_switch_or_button_mapped;
+	// no switch or button is mapped
+	const bool use_stick = manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_NONE;
+	// arm switch mapped and "switch is button" configured
+	const bool use_button = !use_stick && _param_com_arm_swisbtn.get();
+	// arm switch mapped and "switch_is_button" configured
+	const bool use_switch = !use_stick && !use_button;
 
-	const bool arm_switch_to_arm_transition = !_param_arm_switch_is_button.get()
+	const bool armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+	const bool stick_in_lower_right = use_stick
+					  && isThrottleLow()
+					  && _manual_control_setpoint.r > .9f;
+	const bool arm_button_pressed = use_button
+					&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
+	const bool arm_switch_to_arm_transition = use_switch
 			&& (_last_manual_control_switches_arm_switch == manual_control_switches_s::SWITCH_POS_OFF)
 			&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
 

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -56,24 +56,23 @@ void ManualControl::process(manual_control_setpoint_s &manual_control_setpoint)
 	_manual_control_setpoint = manual_control_setpoint;
 }
 
-bool ManualControl::wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
-				  const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available)
+bool ManualControl::wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available)
 {
-	const bool override_auto_mode = (param_rc_override & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
+	const bool override_auto_mode = (_param_rc_override.get() & OverrideBits::OVERRIDE_AUTO_MODE_BIT)
 					&& vehicle_control_mode.flag_control_auto_enabled;
 
-	const bool override_offboard_mode = (param_rc_override & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
+	const bool override_offboard_mode = (_param_rc_override.get() & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
 					    && vehicle_control_mode.flag_control_offboard_enabled;
 
 	if (rc_available && (override_auto_mode || override_offboard_mode)) {
-		const float minimum_stick_change = .01f * param_com_rc_stick_ov;
+		const float minimum_stick_change = .01f * _param_com_rc_stick_ov.get();
 
 		const bool rpy_moved = (fabsf(_manual_control_setpoint.x - _last_manual_control_setpoint.x) > minimum_stick_change)
 				       || (fabsf(_manual_control_setpoint.y - _last_manual_control_setpoint.y) > minimum_stick_change)
 				       || (fabsf(_manual_control_setpoint.r - _last_manual_control_setpoint.r) > minimum_stick_change);
 		const bool throttle_moved =
 			(fabsf(_manual_control_setpoint.z - _last_manual_control_setpoint.z) * 2.f > minimum_stick_change);
-		const bool use_throttle = !(param_rc_override & OverrideBits::OVERRIDE_IGNORE_THROTTLE_BIT);
+		const bool use_throttle = !(_param_rc_override.get() & OverrideBits::OVERRIDE_IGNORE_THROTTLE_BIT);
 
 		if (rpy_moved || (use_throttle && throttle_moved)) {
 			return true;

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -115,9 +115,10 @@ bool ManualControl::wantsDisarm(const vehicle_control_mode_s &vehicle_control_mo
 		const bool manual_thrust_mode = vehicle_control_mode.flag_control_manual_enabled
 						&& !vehicle_control_mode.flag_control_climb_rate_enabled;
 
-		bool disarm_trigger = _stick_disarm_hysteresis.get_state();
+		const bool last_disarm_hysteresis = _stick_disarm_hysteresis.get_state();
 		_stick_disarm_hysteresis.set_state_and_update(true, hrt_absolute_time());
-		disarm_trigger = !disarm_trigger && _stick_disarm_hysteresis.get_state();
+		const bool disarm_trigger = !last_disarm_hysteresis && _stick_disarm_hysteresis.get_state()
+					    && !_stick_arm_hysteresis.get_state();
 
 		const bool rc_wants_disarm = (disarm_trigger) || arm_switch_to_disarm_transition;
 
@@ -125,8 +126,7 @@ bool ManualControl::wantsDisarm(const vehicle_control_mode_s &vehicle_control_mo
 			ret = true;
 		}
 
-	} else if (!(_param_arm_switch_is_button.get()
-		     && manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON)) {
+	} else if (!arm_button_pressed) {
 
 		_stick_disarm_hysteresis.set_state_and_update(false, hrt_absolute_time());
 	}
@@ -156,16 +156,16 @@ bool ManualControl::wantsArm(const vehicle_control_mode_s &vehicle_control_mode,
 	    && (vehicle_status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF)
 	    && (stick_in_lower_right || arm_button_pressed || arm_switch_to_arm_transition)) {
 
-		bool arm_trigger = _stick_arm_hysteresis.get_state();
+		const bool last_arm_hysteresis = _stick_arm_hysteresis.get_state();
 		_stick_arm_hysteresis.set_state_and_update(true, hrt_absolute_time());
-		arm_trigger = !arm_trigger && _stick_arm_hysteresis.get_state();
+		const bool arm_trigger = !last_arm_hysteresis && _stick_arm_hysteresis.get_state()
+					 && !_stick_disarm_hysteresis.get_state();
 
 		if (arm_trigger || arm_switch_to_arm_transition) {
 			ret = true;
 		}
 
-	} else if (!(_param_arm_switch_is_button.get()
-		     && manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON)) {
+	} else if (!arm_button_pressed) {
 
 		_stick_arm_hysteresis.set_state_and_update(false, hrt_absolute_time());
 	}

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -111,7 +111,6 @@ bool ManualControl::wantsDisarm(const vehicle_control_mode_s &vehicle_control_mo
 					   && !vehicle_control_mode.flag_control_climb_rate_enabled;
 
 	if (armed
-	    && (vehicle_status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF)
 	    && (landed || mc_manual_thrust_mode)
 	    && (stick_in_lower_left || arm_button_pressed || arm_switch_to_disarm_transition)) {
 
@@ -151,7 +150,6 @@ bool ManualControl::wantsArm(const vehicle_control_mode_s &vehicle_control_mode,
 			&& (manual_control_switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON);
 
 	if (!armed
-	    && (vehicle_status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF)
 	    && (stick_in_lower_right || arm_button_pressed || arm_switch_to_arm_transition)) {
 
 		const bool last_arm_hysteresis = _stick_arm_hysteresis.get_state();

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -46,10 +46,6 @@ bool ManualControl::update()
 {
 	bool ret = false;
 
-	_rc_available = _rc_allowed
-			&& _last_manual_control_setpoint.timestamp != 0
-			&& (hrt_elapsed_time(&_last_manual_control_setpoint.timestamp) < (_param_com_rc_loss_t.get() * 1_s));
-
 	if (_manual_control_setpoint_sub.updated()) {
 		manual_control_setpoint_s manual_control_setpoint;
 
@@ -59,6 +55,10 @@ bool ManualControl::update()
 
 		ret = true;
 	}
+
+	_rc_available = _rc_allowed
+			&& _manual_control_setpoint.timestamp != 0
+			&& (hrt_elapsed_time(&_manual_control_setpoint.timestamp) < (_param_com_rc_loss_t.get() * 1_s));
 
 	return ret && _rc_available;
 }

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -41,19 +41,20 @@
 
 #pragma once
 
+#include <px4_platform_common/module_params.h>
+
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 
-class ManualControl
+class ManualControl : ModuleParams
 {
 public:
-	ManualControl() = default;
-	~ManualControl() = default;
+	ManualControl(ModuleParams *parent) : ModuleParams(parent) {};
+	~ManualControl() override = default;
 
 	void update();
-	bool wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
-			   const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
+	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
 
 //private:
 	void process(manual_control_setpoint_s &manual_control_setpoint);
@@ -61,4 +62,9 @@ public:
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
+		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov
+	)
 };

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -58,11 +58,12 @@ public:
 	bool isRCAvailable() { return _rc_available; }
 	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
 
-//private:
+	manual_control_setpoint_s _manual_control_setpoint{};
+
+private:
 	void process(manual_control_setpoint_s &manual_control_setpoint);
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
-	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 
 	bool _rc_allowed{false};

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ManualControl.hpp
+ *
+ * @brief Logic for handling RC or Joystick input
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/vehicle_control_mode.h>
+
+class ManualControl
+{
+public:
+	ManualControl() = default;
+	~ManualControl() = default;
+
+	void update();
+	bool wantsOverride(const int param_rc_override, const float param_com_rc_stick_ov,
+			   const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
+
+//private:
+	void process(manual_control_setpoint_s &manual_control_setpoint);
+
+	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	manual_control_setpoint_s _manual_control_setpoint{};
+	manual_control_setpoint_s _last_manual_control_setpoint{};
+};

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -63,19 +63,19 @@ public:
 	 * @return true if there was new data
 	 */
 	bool update();
-	bool isRCAvailable() { return _rc_available; }
+	bool isRCAvailable() const { return _rc_available; }
 	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
 	bool wantsDisarm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,
 			 manual_control_switches_s &manual_control_switches, const bool landed);
 	bool wantsArm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,
-		      manual_control_switches_s &manual_control_switches, const bool landed);
-	bool isThrottleLow() { return _last_manual_control_setpoint.z < 0.1f; }
-	bool isThrottleAboveCenter() { return _last_manual_control_setpoint.z > 0.6f; }
-	hrt_abstime getLastRCTimestamp() { return _last_manual_control_setpoint.timestamp; }
+		      const manual_control_switches_s &manual_control_switches, const bool landed);
+	bool isThrottleLow() const { return _last_manual_control_setpoint.z < 0.1f; }
+	bool isThrottleAboveCenter() const { return _last_manual_control_setpoint.z > 0.6f; }
+	hrt_abstime getLastRcTimestamp() const { return _last_manual_control_setpoint.timestamp; }
 
 private:
 	void updateParams() override;
-	void process(manual_control_setpoint_s &manual_control_setpoint);
+	void process(const manual_control_setpoint_s &manual_control_setpoint);
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	manual_control_setpoint_s _manual_control_setpoint{};

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -57,7 +57,12 @@ public:
 	~ManualControl() override = default;
 
 	void setRCAllowed(const bool rc_allowed) { _rc_allowed = rc_allowed; }
-	void update();
+
+	/**
+	 * Check for manual control input changes and process them
+	 * @return true if there was new data
+	 */
+	bool update();
 	bool isRCAvailable() { return _rc_available; }
 	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
 	bool wantsDisarm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -53,8 +53,10 @@ public:
 	ManualControl(ModuleParams *parent) : ModuleParams(parent) {};
 	~ManualControl() override = default;
 
+	void setRCAllowed(const bool rc_allowed) { _rc_allowed = rc_allowed; }
 	void update();
-	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const bool rc_available);
+	bool isRCAvailable() { return _rc_available; }
+	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode);
 
 //private:
 	void process(manual_control_setpoint_s &manual_control_setpoint);
@@ -63,7 +65,11 @@ public:
 	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 
+	bool _rc_allowed{false};
+	bool _rc_available{false};
+
 	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov
 	)

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -64,14 +64,16 @@ public:
 			 manual_control_switches_s &manual_control_switches, const bool landed);
 	bool wantsArm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,
 		      manual_control_switches_s &manual_control_switches, const bool landed);
-
-	manual_control_setpoint_s _manual_control_setpoint{};
+	bool isThrottleLow() { return _last_manual_control_setpoint.z < 0.1f; }
+	bool isThrottleAboveCenter() { return _last_manual_control_setpoint.z > 0.6f; }
+	hrt_abstime getLastRCTimestamp() { return _last_manual_control_setpoint.timestamp; }
 
 private:
 	void updateParams() override;
 	void process(manual_control_setpoint_s &manual_control_setpoint);
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	manual_control_setpoint_s _manual_control_setpoint{};
 	manual_control_setpoint_s _last_manual_control_setpoint{};
 
 	// Availability

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -88,7 +88,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
-		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_arm_switch_is_button,
+		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_com_arm_swisbtn,
 		(ParamBool<px4::params::COM_REARM_GRACE>) _param_com_rearm_grace,
 		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -638,9 +638,10 @@ PARAM_DEFINE_INT32(COM_REARM_GRACE, 1);
  * Note: Only has an effect on multicopters, and VTOLs in multicopter mode.
  *
  * @min 0
- * @max 3
+ * @max 7
  * @bit 0 Enable override during auto modes (except for in critical battery reaction)
  * @bit 1 Enable override during offboard mode
+ * @bit 2 Ignore throttle stick
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
@@ -648,8 +649,8 @@ PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
 /**
  * RC stick override threshold
  *
- * If COM_RC_OVERRIDE is enabled and the joystick input controlling the horizontally axis (right stick for RC in mode 2)
- * is moved more than this threshold from the center the autopilot switches to position mode and the pilot takes over control.
+ * If COM_RC_OVERRIDE is enabled and the joystick input is moved more than this threshold from the center
+ * the autopilot switches to position mode and the pilot takes over control.
  *
  * @group Commander
  * @unit %

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -649,8 +649,8 @@ PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 1);
 /**
  * RC stick override threshold
  *
- * If COM_RC_OVERRIDE is enabled and the joystick input is moved more than this threshold from the center
- * the autopilot switches to position mode and the pilot takes over control.
+ * If COM_RC_OVERRIDE is enabled and the joystick input is moved more than this threshold
+ * the autopilot the pilot takes over control.
  *
  * @group Commander
  * @unit %

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -313,10 +313,11 @@ PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 
 /**
- * Arm switch is only a button
+ * Arm switch is a momentary button
  *
- * The default uses the arm switch as real switch.
- * If parameter set button gets handled like stick arming.
+ * 0: Arming/disarming triggers on switch transition.
+ * 1: Arming/disarming triggers when holding the momentary button down
+ * for COM_RC_ARM_HYST like the stick gesture.
  *
  * @group Commander
  * @boolean


### PR DESCRIPTION
**Describe problem/solution in this pull request**
New `ManualControl` class for handling `manual_control_setpoint` (and later switches) holding subscription, parameters and state necessary. It handles in this pr RC loss, RC override, RC arming/disarming.

- RC override: option to ignore throttle stick
- RC override: based on change (not centered stick)
- RC arming: based on Hysteresis instead of "loop ticker"
- RC arming: simplify the logic
- manual_control_setpoint message 

Note: This is the first stab at it and I'd like to do incremental steps to not create a non-understandable monster pr.

**Test data / coverage**
I tested the different cases during development but will do a final pass testing all the things with this state.

**Additional context**
Follow up after being in the loop from reviewing #16266 and doing work on RC override.
