### PR TITLE
Modify the code of follow_target.

### DIFF
--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -177,7 +177,8 @@ void FollowTarget::on_active()
 			// just traveling at the exact velocity of the target will not
 			// get any closer or farther from the target
 
-			_acceleration_m_s2 = ((_est_target_vel - _current_vel) + (_target_position_offset + _target_distance) * FF_K) / (dt_ms / 1000.0f);
+			_acceleration_m_s2 = ((_est_target_vel - _current_vel) + (_target_position_offset + _target_distance) * FF_K) /
+					     (dt_ms / 1000.0f);
 
 			// if we are less than 1 meter from the target don't worry about trying to yaw
 			// lock the yaw until we are at a distance that makes sense

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -310,7 +310,7 @@ void FollowTarget::on_active()
 		}
 	}
 
-	last_update_time = current_time;
+	_last_update_time = current_time;
 }
 
 void FollowTarget::update_position_sp(bool use_velocity, bool use_position, float yaw_rate)

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -65,7 +65,7 @@ FollowTarget::FollowTarget(Navigator *navigator) :
 	ModuleParams(navigator)
 {
 	_current_vel.zero();
-	_step_vel.zero();
+	_acceleration_m_s2.zero();
 	_est_target_vel.zero();
 	_target_distance.zero();
 	_target_position_offset.zero();
@@ -177,9 +177,7 @@ void FollowTarget::on_active()
 			// just traveling at the exact velocity of the target will not
 			// get any closer or farther from the target
 
-			_step_vel = (_est_target_vel - _current_vel) + (_target_position_offset + _target_distance) * FF_K;
-			_step_vel /= (dt_ms / 1000.0F * (float) INTERPOLATION_PNTS);
-			_step_time_in_ms = (dt_ms / (float) INTERPOLATION_PNTS);
+			_acceleration_m_s2 = ((_est_target_vel - _current_vel) + (_target_position_offset + _target_distance) * FF_K) / (dt_ms / 1000.0f);
 
 			// if we are less than 1 meter from the target don't worry about trying to yaw
 			// lock the yaw until we are at a distance that makes sense
@@ -203,9 +201,9 @@ void FollowTarget::on_active()
 			}
 		}
 
-//		warnx(" _step_vel x %3.6f y %3.6f cur vel %3.6f %3.6f tar vel %3.6f %3.6f dist = %3.6f (%3.6f) mode = %d yaw rate = %3.6f",
-//				(double) _step_vel(0),
-//				(double) _step_vel(1),
+//		warnx(" _acceleration_m_s2 x %3.6f y %3.6f cur vel %3.6f %3.6f tar vel %3.6f %3.6f dist = %3.6f (%3.6f) mode = %d yaw rate = %3.6f",
+//				(double) _acceleration_m_s2(0),
+//				(double) _acceleration_m_s2(1),
 //				(double) _current_vel(0),
 //				(double) _current_vel(1),
 //				(double) _est_target_vel(0),
@@ -264,9 +262,8 @@ void FollowTarget::on_active()
 
 			} else if (target_velocity_valid()) {
 
-				if ((float)(current_time - _last_update_time) / 1000.0f >= _step_time_in_ms) {
-					_current_vel += _step_vel;
-					_last_update_time = current_time;
+				if (0 != _last_update_time) {
+					_current_vel += _acceleration_m_s2 * ((float)(current_time - _last_update_time) / 1000000.0f);
 				}
 
 				set_follow_target_item(&_mission_item, _param_nav_min_ft_ht.get(), target_motion_with_offset, _yaw_angle);
@@ -312,6 +309,8 @@ void FollowTarget::on_active()
 			break;
 		}
 	}
+
+	last_update_time = current_time;
 }
 
 void FollowTarget::update_position_sp(bool use_velocity, bool use_position, float yaw_rate)
@@ -343,8 +342,9 @@ void FollowTarget::reset_target_validity()
 	_previous_target_motion = {};
 	_current_target_motion = {};
 	_target_updates = 0;
+	_last_update_time = 0;
 	_current_vel.zero();
-	_step_vel.zero();
+	_acceleration_m_s2.zero();
 	_est_target_vel.zero();
 	_target_distance.zero();
 	_target_position_offset.zero();

--- a/src/modules/navigator/follow_target.h
+++ b/src/modules/navigator/follow_target.h
@@ -65,7 +65,6 @@ private:
 
 	static constexpr int TARGET_TIMEOUT_MS = 2500;
 	static constexpr int TARGET_ACCEPTANCE_RADIUS_M = 5;
-	static constexpr int INTERPOLATION_PNTS = 20;
 	static constexpr float FF_K = .25F;
 	static constexpr float OFFSET_M = 8;
 
@@ -101,14 +100,13 @@ private:
 	int _follow_target_position{FOLLOW_FROM_BEHIND};
 
 	uORB::Subscription _follow_target_sub{ORB_ID(follow_target)};
-	float _step_time_in_ms{0.0f};
 	float _follow_offset{OFFSET_M};
 
 	uint64_t _target_updates{0};
 	uint64_t _last_update_time{0};
 
 	matrix::Vector3f _current_vel;
-	matrix::Vector3f _step_vel;
+	matrix::Vector3f _acceleration_m_s2;
 	matrix::Vector3f _est_target_vel;
 	matrix::Vector3f _target_distance;
 	matrix::Vector3f _target_position_offset;


### PR DESCRIPTION
If the frequency of sending follow_target orb messages is very high, the dt_ms variable will be a short time, and dt_ms/INTERPOLATION_PNTS will be less than the execution cycle of the FollowTarget::on_active() function, so the actual acceleration will be very slow.