### PR TITLE
move fake GPS to standalone module

### DIFF
--- a/boards/aerotenna/ocpoc/default.cmake
+++ b/boards/aerotenna/ocpoc/default.cmake
@@ -87,6 +87,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		#hwtest # Hardware test

--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -110,6 +110,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/atlflight/eagle/default.cmake
+++ b/boards/atlflight/eagle/default.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/atlflight/excelsior/default.cmake
+++ b/boards/atlflight/excelsior/default.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -106,6 +106,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/beaglebone/blue/default.cmake
+++ b/boards/beaglebone/blue/default.cmake
@@ -83,6 +83,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		dyn_hello # dynamically loading modules example
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/cuav/nora/default.cmake
+++ b/boards/cuav/nora/default.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -117,6 +117,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/cubepilot/cubeorange/console.cmake
+++ b/boards/cubepilot/cubeorange/console.cmake
@@ -118,6 +118,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/cubepilot/cubeorange/default.cmake
+++ b/boards/cubepilot/cubeorange/default.cmake
@@ -118,6 +118,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/cubepilot/cubeyellow/console.cmake
+++ b/boards/cubepilot/cubeyellow/console.cmake
@@ -117,6 +117,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/cubepilot/cubeyellow/default.cmake
+++ b/boards/cubepilot/cubeyellow/default.cmake
@@ -117,6 +117,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -84,6 +84,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		#hwtest # Hardware test

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -115,6 +115,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/holybro/pix32v5/default.cmake
+++ b/boards/holybro/pix32v5/default.cmake
@@ -122,6 +122,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -92,6 +92,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -91,6 +91,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -109,6 +109,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/mro/ctrl-zero-f7-oem/default.cmake
+++ b/boards/mro/ctrl-zero-f7-oem/default.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/mro/pixracerpro/default.cmake
+++ b/boards/mro/pixracerpro/default.cmake
@@ -115,6 +115,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/mro/x21-777/default.cmake
+++ b/boards/mro/x21-777/default.cmake
@@ -116,6 +116,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/nxp/fmuk66-e/default.cmake
+++ b/boards/nxp/fmuk66-e/default.cmake
@@ -111,6 +111,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/nxp/fmuk66-e/socketcan.cmake
+++ b/boards/nxp/fmuk66-e/socketcan.cmake
@@ -110,6 +110,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -111,6 +111,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/nxp/fmuk66-v3/rtps.cmake
+++ b/boards/nxp/fmuk66-v3/rtps.cmake
@@ -111,6 +111,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/nxp/fmuk66-v3/socketcan.cmake
+++ b/boards/nxp/fmuk66-v3/socketcan.cmake
@@ -110,6 +110,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -128,6 +128,7 @@ px4_add_board(
 		#ver
 		#work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -113,6 +113,7 @@ px4_add_board(
 		work_queue
 
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -79,5 +79,4 @@ px4_add_board(
 		usb_connected
 		ver
 		work_queue
-
 	)

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -121,6 +121,7 @@ px4_add_board(
 		ver
 		#work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/px4/fmu-v3/ctrlalloc.cmake
+++ b/boards/px4/fmu-v3/ctrlalloc.cmake
@@ -127,6 +127,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -125,6 +125,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -121,6 +121,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -117,6 +117,7 @@ px4_add_board(
 		work_queue
 
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/px4/fmu-v4/ctrlalloc.cmake
+++ b/boards/px4/fmu-v4/ctrlalloc.cmake
@@ -124,6 +124,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_gyro
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -123,6 +123,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_gyro
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -117,6 +117,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -116,6 +116,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -119,6 +119,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -116,6 +116,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -118,6 +118,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v5/ctrlalloc.cmake
+++ b/boards/px4/fmu-v5/ctrlalloc.cmake
@@ -127,6 +127,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_gyro
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control

--- a/boards/px4/fmu-v5/debug.cmake
+++ b/boards/px4/fmu-v5/debug.cmake
@@ -123,6 +123,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -125,6 +125,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fake_gyro
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -119,6 +119,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -119,6 +119,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -123,6 +123,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/uavcanv1.cmake
+++ b/boards/px4/fmu-v5/uavcanv1.cmake
@@ -126,6 +126,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		#fake_gps
 		#fake_gyro
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control

--- a/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
+++ b/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
@@ -119,6 +119,7 @@ px4_add_board(
 		work_queue
 		serial_test
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -122,6 +122,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v6u/default.cmake
+++ b/boards/px4/fmu-v6u/default.cmake
@@ -122,6 +122,7 @@ px4_add_board(
 		work_queue
 		serial_test
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v6u/stackcheck.cmake
+++ b/boards/px4/fmu-v6u/stackcheck.cmake
@@ -122,6 +122,7 @@ px4_add_board(
 		work_queue
 		serial_test
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -120,6 +120,7 @@ px4_add_board(
 		work_queue
 		serial_test
 	EXAMPLES
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		hwtest # Hardware test

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -83,6 +83,7 @@ px4_add_board(
 		ver
 		work_queue
 	EXAMPLES
+		fake_gps
 		dyn_hello # dynamically loading modules example
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/ctrlalloc.cmake
+++ b/boards/px4/sitl/ctrlalloc.cmake
@@ -87,6 +87,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -85,6 +85,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -85,6 +85,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -84,6 +84,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -83,6 +83,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/scumaker/pilotpi/arm64.cmake
+++ b/boards/scumaker/pilotpi/arm64.cmake
@@ -84,6 +84,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		#hwtest # Hardware test

--- a/boards/scumaker/pilotpi/default.cmake
+++ b/boards/scumaker/pilotpi/default.cmake
@@ -84,6 +84,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
+		fake_gps
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello
 		#hwtest # Hardware test

--- a/src/examples/fake_gps/CMakeLists.txt
+++ b/src/examples/fake_gps/CMakeLists.txt
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE modules__fake_gps
+	MAIN fake_gps
+	COMPILE_FLAGS
+	SRCS
+		FakeGps.cpp
+		FakeGps.hpp
+	DEPENDS
+		px4_work_queue
+)

--- a/src/examples/fake_gps/FakeGps.cpp
+++ b/src/examples/fake_gps/FakeGps.cpp
@@ -1,0 +1,140 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "FakeGps.hpp"
+
+using namespace time_literals;
+
+FakeGps::FakeGps(double latitude_deg, double longitude_deg, float altitude_m) :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::lp_default),
+	_latitude(latitude_deg * 10e6),
+	_longitude(longitude_deg * 10e6),
+	_altitude(altitude_m * 10e2f)
+{
+}
+
+bool FakeGps::init()
+{
+	ScheduleOnInterval(SENSOR_INTERVAL_US);
+	return true;
+}
+
+void FakeGps::Run()
+{
+	if (should_exit()) {
+		ScheduleClear();
+		exit_and_cleanup();
+		return;
+	}
+
+	sensor_gps_s sensor_gps{};
+	sensor_gps.time_utc_usec = hrt_absolute_time() + 1613692609599954;
+	sensor_gps.lat = _latitude;
+	sensor_gps.lon = _longitude;
+	sensor_gps.alt = _altitude;
+	sensor_gps.alt_ellipsoid = _altitude;
+	sensor_gps.s_variance_m_s = 0.3740f;
+	sensor_gps.c_variance_rad = 0.6737f;
+	sensor_gps.eph = 2.1060f;
+	sensor_gps.epv = 3.8470f;
+	sensor_gps.hdop = 0.8800f;
+	sensor_gps.vdop = 1.3300f;
+	sensor_gps.noise_per_ms = 101;
+	sensor_gps.jamming_indicator = 35;
+	sensor_gps.vel_m_s = 0.0420f;
+	sensor_gps.vel_n_m_s = 0.0370f;
+	sensor_gps.vel_e_m_s = 0.0200f;
+	sensor_gps.vel_d_m_s = -0.0570f;
+	sensor_gps.cog_rad = 0.3988f;
+	sensor_gps.timestamp_time_relative = 0;
+	sensor_gps.heading = NAN;
+	sensor_gps.heading_offset = 0.0000;
+	sensor_gps.fix_type = 4;
+	sensor_gps.jamming_state = 0;
+	sensor_gps.vel_ned_valid = true;
+	sensor_gps.satellites_used = 14;
+	sensor_gps.timestamp = hrt_absolute_time();
+	_sensor_gps_pub.publish(sensor_gps);
+}
+
+int FakeGps::task_spawn(int argc, char *argv[])
+{
+	FakeGps *instance = new FakeGps();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int FakeGps::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int FakeGps::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("fake_gps", "driver");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+	return 0;
+}
+
+extern "C" __EXPORT int fake_gps_main(int argc, char *argv[])
+{
+	return FakeGps::main(argc, argv);
+}

--- a/src/examples/fake_gps/FakeGps.hpp
+++ b/src/examples/fake_gps/FakeGps.hpp
@@ -1,0 +1,73 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/sensor_gps.h>
+
+class FakeGps : public ModuleBase<FakeGps>, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	FakeGps(double latitude_deg = 29.6603018, double longitude_deg = -82.3160500, float altitude_m = 30.1f);
+
+	~FakeGps() override = default;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+private:
+	static constexpr uint32_t SENSOR_INTERVAL_US{1000000 / 5}; // 5 Hz
+
+	void Run() override;
+
+	uORB::PublicationMulti<sensor_gps_s> _sensor_gps_pub{ORB_ID(sensor_gps)};
+
+	int32_t _latitude{296603018};   // Latitude in 1e-7 degrees
+	int32_t _longitude{-823160500}; // Longitude in 1e-7 degrees
+	int32_t _altitude{30100};       // Altitude in 1e-3 meters above MSL, (millimetres)
+};


### PR DESCRIPTION
 - move `drivers/gps` fake GPS handling to new standalone `fake_gps` module
 - fake GPS data is hardcoded, but could trivially be customized if there's value
 - currently under `examples/` for lack of a better option (I didn't want to pollute `modules/`)

``` Console
nsh> fake_gps start
nsh> listener sensor_gps

TOPIC: sensor_gps
 sensor_gps_s
        timestamp: 89737064  (0.092808 seconds ago)
        time_utc_usec: 1613692699337017
        lat: 296603018
        lon: -823160500
        alt: 30100
        alt_ellipsoid: 30100
        s_variance_m_s: 0.3740
        c_variance_rad: 0.6737
        eph: 2.1060
        epv: 3.8470
        hdop: 0.8800
        vdop: 1.3300
        noise_per_ms: 101
        jamming_indicator: 35
        vel_m_s: 0.0420
        vel_n_m_s: 0.0370
        vel_e_m_s: 0.0200
        vel_d_m_s: -0.0570
        cog_rad: 0.3988
        timestamp_time_relative: 0
        heading: nan
        heading_offset: 0.0000
        fix_type: 4
        jamming_state: 0
        vel_ned_valid: True
        satellites_used: 14
```