### PR TITLE
Fix uavcannode build Closes #16899

### DIFF
--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -76,7 +76,9 @@ namespace uavcannode
 */
 boot_app_shared_section app_descriptor_t AppDescriptor = {
 	.signature = APP_DESCRIPTOR_SIGNATURE,
-	.image_crc = 0,
+	{
+		0,
+	},
 	.image_size = 0,
 	.git_hash  = 0,
 	.major_version = APP_VERSION_MAJOR,


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes the AppDescriptor initializer to work with the new uavcan bootloader work.

**Describe your solution**
Initialize union. 

**Test data / coverage**
ark_can_flow_default and cuav_can-gps-v1_default were tested and now build.

**Additional context**
Closes #16899