### PR TITLE
mavsdk_tests: relax MC "Fly straight" speed threshold

### DIFF
--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -91,7 +91,7 @@ TEST_CASE("Fly straight Multicopter Mission", "[multicopter]")
 	mission_options.rtl_at_end = false;
 	mission_options.fly_through = true;
 	tester.prepare_straight_mission(mission_options);
-	tester.check_mission_item_speed_above(2, 4.5);
+	tester.check_mission_item_speed_above(2, 4.0);
 	tester.check_tracks_mission(5.f);
 	tester.arm();
 	tester.execute_mission();


### PR DESCRIPTION
Arguably should be solved at the model level (tuning, etc), but this still seems sufficient.

![Screenshot from 2021-02-21 12-54-25](https://user-images.githubusercontent.com/84712/108633756-0414c400-7444-11eb-8e19-cf039786014c.png)

![Screenshot from 2021-02-21 12-55-17](https://user-images.githubusercontent.com/84712/108633770-14c53a00-7444-11eb-925e-bc6f9167ea47.png)

https://github.com/PX4/PX4-Autopilot/runs/1946715194

