### PR TITLE
PX4IO: Robustify upgrade process

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -282,32 +282,17 @@ else
 				# tune Program PX4IO
 				tune_control play -t 16 # tune 16 = PROG_PX4IO
 
-				if px4io start
-				then
-					# Try to safety px4 io so motor outputs don't go crazy.
-					if ! px4io safety_on
-					then
-						# px4io did not respond to the safety command.
-						px4io stop
-					fi
-				fi
-
-				if px4io forceupdate 14662 ${IOFW}
+				if px4io update ${IOFW}
 				then
 					usleep 10000
 					tune_control stop
 					if px4io checkcrc ${IOFW}
 					then
-						echo "PX4IO CRC OK after updating"
 						tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
 						set IO_PRESENT yes
+					else
+						tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 					fi
-				fi
-
-				if [ $IO_PRESENT = no ]
-				then
-					echo "PX4IO update failed"
-					tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 				fi
 			fi
 		fi

--- a/ROMFS/px4fmu_test/init.d/rcS
+++ b/ROMFS/px4fmu_test/init.d/rcS
@@ -84,7 +84,7 @@ then
 else
 	echo "PX4IO CRC failure"
 	tune_control play -t 16 # tune 16 = PROG_PX4IO
-	if px4io forceupdate 14662 $io_file
+	if px4io update $io_file
 	then
 		if px4io start
 		then


### PR DESCRIPTION
These changes remove the two code paths to updates (forceupdate and update) and try to reboot and bootload IO independent of its state, wether it is in bootloader mode already, safety switch is off or if it is in "nominal state" (running and safety on). This ensures that there are no conditions where user error or boot sequence can prevent a successful upgrade. The only state where an upgrade will not be done is if the system is fully armed.
