### PR TITLE
mavlink: use RADIO_STATUS to regulate parameter sending

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1476,6 +1476,11 @@ Mavlink::update_radio_status(const radio_status_s &radio_status)
 			/* this indicates spare bandwidth, increase by 2.5% */
 			_radio_status_mult *= 1.025f;
 		}
+
+		/* Constrain radio status multiplier between 1% and 100% to allow recovery */
+		if (_radio_status_mult > 1.0f) { _radio_status_mult = 1.0f; }
+
+		if (_radio_status_mult < 0.01f) { _radio_status_mult = 0.01f; }
 	}
 }
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1478,9 +1478,7 @@ Mavlink::update_radio_status(const radio_status_s &radio_status)
 		}
 
 		/* Constrain radio status multiplier between 1% and 100% to allow recovery */
-		if (_radio_status_mult > 1.0f) { _radio_status_mult = 1.0f; }
-
-		if (_radio_status_mult < 0.01f) { _radio_status_mult = 0.01f; }
+		_radio_status_mult = math::constrain(_radio_status_mult, 0.01f, 1.0f);
 	}
 }
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -518,7 +518,7 @@ public:
 
 	static hrt_abstime &get_first_start_time() { return _first_start_time; }
 
-	bool radio_status_critical() { return _radio_status_critical; }
+	bool radio_status_critical() const { return _radio_status_critical; }
 
 private:
 	int			_instance_id{0};

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -518,6 +518,8 @@ public:
 
 	static hrt_abstime &get_first_start_time() { return _first_start_time; }
 
+	bool radio_status_critical() { return _radio_status_critical; }
+
 private:
 	int			_instance_id{0};
 

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -329,7 +329,8 @@ MavlinkParametersManager::send()
 	int i = 0;
 
 	// Send while burst is not exceeded, we still have buffer space and still something to send
-	while ((i++ < max_num_to_send) && (_mavlink->get_free_tx_buf() >= get_size()) && send_params()) {}
+	while ((i++ < max_num_to_send) && (_mavlink->get_free_tx_buf() >= get_size()) && !_mavlink->radio_status_critical()
+	       && send_params()) {}
 }
 
 bool
@@ -390,7 +391,8 @@ MavlinkParametersManager::send_untransmitted()
 					break;
 				}
 			}
-		} while ((_mavlink->get_free_tx_buf() >= get_size()) && (_param_update_index < (int) param_count()));
+		} while ((_mavlink->get_free_tx_buf() >= get_size()) && !_mavlink->radio_status_critical()
+			 && (_param_update_index < (int) param_count()));
 
 		// Flag work as done once all params have been sent
 		if (_param_update_index >= (int) param_count()) {


### PR DESCRIPTION
This avoids parameter message loss because of radio buffer overrun.

Fix a long standing issue with parameter download overrunning the radio's transmit FIFO on slow radio links with no hardware flow control, but, which utilize RADIO_STATUS messages to provide txbuf usage info.

Make the _radio_status_critical bool available via a new predicate method and use it where we check the serial port's transmit buffer,_mavlink->get_free_tx_buf() in the parameter download code.  Note, that because we allow parameter messages to use available space up to RADIO_BUFFER_CRITICAL_LOW_PERCENTAGE, other message streams will have their rate gradually reduced during parameter download by update_radio_status().  This is intentional and desirable.  I also include a change to this function to ensure that the rate multiplier doesn't get too far from it's normal range.  These bounds help speed up recovery to the best rate once parameter download completes.

This strategy is less disruptive and simpler than rewriting buik parameter download code to use the rate multiplier based stream flow control used for most MAVLink messages.

This change was tested with QGroundControl over the TBS Crossfire radio system with several released and unreleased versions of the Crossfire firmware.  It improved parameter download time from about 40 seconds to 20-25 seconds by eliminating dropped messages in the first phase of parameter download so few or no additional individual parameter requests were needed.  Without this fix, most messages in the first phase of the bulk parameter download are dropped by the Crossfire receiver and needed to be fetched by QGroundControl individually, slowing down parameter download and reducing it's reliability.

See [issue 10618](https://github.com/PX4/PX4-Autopilot/issues/10618) and [QGC issue 6890](https://github.com/mavlink/qgroundcontrol/issues/6890) for some past discussion.