### PR TITLE
SIH/gps: express gps position noise in meters and reduce noise value

### DIFF
--- a/src/modules/sih/sih.cpp
+++ b/src/modules/sih/sih.cpp
@@ -294,9 +294,9 @@ void Sih::reconstruct_sensors_signals()
 	_gps_lon_noiseless = _LON0 + degrees((double)_p_I(1) / CONSTANTS_RADIUS_OF_EARTH) / _COS_LAT0;
 	_gps_alt_noiseless = _H0 - _p_I(2);
 
-	_gps_lat = _gps_lat_noiseless + (double)(generate_wgn() * 7.2e-6f); // latitude in degrees
-	_gps_lon = _gps_lon_noiseless + (double)(generate_wgn() * 1.75e-5f); // longitude in degrees
-	_gps_alt = _gps_alt_noiseless + generate_wgn() * 1.78f;
+	_gps_lat = _gps_lat_noiseless + degrees((double)generate_wgn() * 0.2 / CONSTANTS_RADIUS_OF_EARTH);
+	_gps_lon = _gps_lon_noiseless + degrees((double)generate_wgn() * 0.2 / CONSTANTS_RADIUS_OF_EARTH) / _COS_LAT0;
+	_gps_alt = _gps_alt_noiseless + generate_wgn() * 0.5f;
 	_gps_vel = _v_I + noiseGauss3f(0.06f, 0.077f, 0.158f);
 }
 


### PR DESCRIPTION
SIH previous horizontal position noise was a white Gaussian noise with std=0.8m. It results in a noise with high frequencies too high making some ekf position tests fail (test ratio to allow arming (I have some reduced COM_ARM* thresholds)).

The new noise values are below real GPS errors but as theses errors are generally low frequency, they cannot be modeled with a white noise.

GPS position noises are now in meters