### PR TITLE
Enabled uavcan flags in holybro/durandal board description.

### DIFF
--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -10,7 +10,7 @@ px4_add_board(
 	BUILD_BOOTLOADER
 	IO px4_io-v2_default
 	TESTING
-#	UAVCAN_INTERFACES 2  - No H7 or FD can support in UAVCAN
+	UAVCAN_INTERFACES 2
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1
@@ -54,7 +54,7 @@ px4_add_board(
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
-#		uavcan - No H7 or FD can support in UAVCAN yet
+		uavcan
 	MODULES
 		airspeed_selector
 		attitude_estimator_q

--- a/boards/holybro/durandal-v1/nuttx-config/include/board.h
+++ b/boards/holybro/durandal-v1/nuttx-config/include/board.h
@@ -250,6 +250,9 @@
 
 #define STM32_RCC_D3CCIPR_ADCSEL     RCC_D3CCIPR_ADCSEL_PLL2
 
+/* CAN FD clock source */
+#define STM32_FDCANCLK STM32_HSE_FREQUENCY
+
 /* FLASH wait states
  *
  *  ------------ ---------- -----------


### PR DESCRIPTION
**Problem:** The Holybro Durandal v1 board boasts two can ports for interfacing uavcan devices, but the px4 board file does not reflect this. 

**Progress:** I added uavcan to the durandal px4_add_board-call, under both DRIVERS and MODULES. This after @dagar had indicated an old comment "_No H7 or FD can support in UAVCAN yet_" was no longer true. He suggested me to create a draft PR to collaborate on updating the code.

As of the creation of this PR, the code does not build, i.e. make holybro_durandal-v1 fails.