### PR TITLE
boards: CUAV Nora don't start icm20649 on SPI6 by default

### DIFF
--- a/boards/cuav/nora/init/rc.board_sensors
+++ b/boards/cuav/nora/init/rc.board_sensors
@@ -16,7 +16,7 @@ bmi088 -s -b 4 -G -R 2 start
 ms5611 -s -b 4 start
 
 # SPI6
-icm20649 -s -b 6 -R 2 start
+#icm20649 -s -b 6 -R 2 start # TODO: not started by default until NuttX SPI6 BDMA is fixed
 ms5611 -s -b 6 start
 
 # External compass on GPS1/I2C1: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)


### PR DESCRIPTION
 - waiting on NuttX SPI6 BDMA to be fixed

Without DMA working the cpu usage of these IMU drivers is a bit absurd.

![Screenshot from 2021-02-22 11-35-03](https://user-images.githubusercontent.com/84712/108738918-181efb00-7502-11eb-891c-d39637d8ade3.png)

FYI @davids5 
