### PR TITLE
sensor_calibration: increase threshold for updating offsets or scale

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.cpp
+++ b/src/lib/sensor_calibration/Accelerometer.cpp
@@ -125,7 +125,7 @@ void Accelerometer::SensorCorrectionsUpdate(bool force)
 
 bool Accelerometer::set_offset(const Vector3f &offset)
 {
-	if (Vector3f(_offset - offset).longerThan(0.001f)) {
+	if (Vector3f(_offset - offset).longerThan(0.01f)) {
 		_offset = offset;
 
 		_calibration_count++;
@@ -137,7 +137,7 @@ bool Accelerometer::set_offset(const Vector3f &offset)
 
 bool Accelerometer::set_scale(const Vector3f &scale)
 {
-	if (Vector3f(_scale - scale).longerThan(0.001f)) {
+	if (Vector3f(_scale - scale).longerThan(0.01f)) {
 		_scale = scale;
 
 		_calibration_count++;

--- a/src/lib/sensor_calibration/Gyroscope.cpp
+++ b/src/lib/sensor_calibration/Gyroscope.cpp
@@ -125,7 +125,7 @@ void Gyroscope::SensorCorrectionsUpdate(bool force)
 
 bool Gyroscope::set_offset(const Vector3f &offset)
 {
-	if (Vector3f(_offset - offset).longerThan(0.001f)) {
+	if (Vector3f(_offset - offset).longerThan(0.01f)) {
 		_offset = offset;
 
 		_calibration_count++;

--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -85,7 +85,7 @@ void Magnetometer::set_external(bool external)
 
 bool Magnetometer::set_offset(const Vector3f &offset)
 {
-	if (Vector3f(_offset - offset).longerThan(0.001f)) {
+	if (Vector3f(_offset - offset).longerThan(0.01f)) {
 		_offset = offset;
 
 		_calibration_count++;
@@ -97,7 +97,7 @@ bool Magnetometer::set_offset(const Vector3f &offset)
 
 bool Magnetometer::set_scale(const Vector3f &scale)
 {
-	if (Vector3f(_scale.diag() - scale).longerThan(0.001f)) {
+	if (Vector3f(_scale.diag() - scale).longerThan(0.01f)) {
 		_scale(0, 0) = scale(0);
 		_scale(1, 1) = scale(1);
 		_scale(2, 2) = scale(2);
@@ -111,7 +111,7 @@ bool Magnetometer::set_scale(const Vector3f &scale)
 
 bool Magnetometer::set_offdiagonal(const Vector3f &offdiagonal)
 {
-	if (Vector3f(Vector3f{_scale(0, 1), _scale(0, 2), _scale(1, 2)} - offdiagonal).longerThan(0.001f)) {
+	if (Vector3f(Vector3f{_scale(0, 1), _scale(0, 2), _scale(1, 2)} - offdiagonal).longerThan(0.01f)) {
 		_scale(0, 1) = offdiagonal(0);
 		_scale(1, 0) = offdiagonal(0);
 


### PR DESCRIPTION
This raises the threshold required for applying a sensor (accel/gyro/mag) calibration change. This is to minimize needlessly writing negligible parameter changes and triggering unnecessary estimator bias resets.

![Screenshot from 2021-02-22 12-42-37](https://user-images.githubusercontent.com/84712/108747483-79979780-750b-11eb-9ff8-3e0ca2a86ebe.png)

