### PR TITLE
Revert "cmake: Limit color output to terminals"

### DIFF
--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -114,8 +114,8 @@ function(px4_add_common_flags)
 	elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
 		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
-			# enable color for gcc > 4.9 when stdout is terminal
-			add_compile_options(-fdiagnostics-color=auto)
+			# force color for gcc > 4.9
+			add_compile_options(-fdiagnostics-color=always)
 		endif()
 
 		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.3)


### PR DESCRIPTION
This reverts commit c1da999748aade38240f47eee179cdd58c144c78.

@dgeorge83616 this broke color output in all my typical usage with ninja-build, can we find another way to disable it more selectively for you? https://github.com/PX4/PX4-Autopilot/pull/16694

Is there a particular environment variable or anything that can be checked?