### PR TITLE
Sih: add distance sensor

### DIFF
--- a/src/modules/sih/sih.hpp
+++ b/src/modules/sih/sih.hpp
@@ -184,7 +184,7 @@ private:
 
 	int _gps_used;
 	float _baro_offset_m, _mag_offset_x, _mag_offset_y, _mag_offset_z;
-	float _distance_snsr_min, _distance_snsr_max;
+	float _distance_snsr_min, _distance_snsr_max, _distance_snsr_override;
 
 	// parameters defined in sih_params.c
 	DEFINE_PARAMETERS(
@@ -215,6 +215,7 @@ private:
 		(ParamFloat<px4::params::SIH_MAG_OFFSET_Y>) _sih_mag_offset_y,
 		(ParamFloat<px4::params::SIH_MAG_OFFSET_Z>) _sih_mag_offset_z,
 		(ParamFloat<px4::params::SIH_DISTSNSR_MIN>) _sih_distance_snsr_min,
-		(ParamFloat<px4::params::SIH_DISTSNSR_MAX>) _sih_distance_snsr_max
+		(ParamFloat<px4::params::SIH_DISTSNSR_MAX>) _sih_distance_snsr_max,
+		(ParamFloat<px4::params::SIH_DISTSNSR_OVR>) _sih_distance_snsr_override
 	)
 };

--- a/src/modules/sih/sih.hpp
+++ b/src/modules/sih/sih.hpp
@@ -56,6 +56,7 @@
 #include <uORB/topics/vehicle_angular_velocity.h>   // to publish groundtruth
 #include <uORB/topics/vehicle_attitude.h>           // to publish groundtruth
 #include <uORB/topics/vehicle_global_position.h>    // to publish groundtruth
+#include <uORB/topics/distance_sensor.h>
 
 using namespace time_literals;
 
@@ -96,6 +97,10 @@ private:
 	sensor_gps_s			_sensor_gps{};
 	uORB::Publication<sensor_gps_s>	_sensor_gps_pub{ORB_ID(sensor_gps)};
 
+	// to publish the distance sensor
+	distance_sensor_s                    _distance_snsr{};
+	uORB::Publication<distance_sensor_s> _distance_snsr_pub{ORB_ID(distance_sensor)};
+
 	// angular velocity groundtruth
 	vehicle_angular_velocity_s			_vehicle_angular_velocity_gt{};
 	uORB::Publication<vehicle_angular_velocity_s>	_vehicle_angular_velocity_gt_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
@@ -125,6 +130,7 @@ private:
 	void equations_of_motion();
 	void reconstruct_sensors_signals();
 	void send_gps();
+	void send_dist_snsr();
 	void publish_sih();
 
 	perf_counter_t  _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
@@ -135,6 +141,7 @@ private:
 	hrt_abstime _gps_time{0};
 	hrt_abstime _mag_time{0};
 	hrt_abstime _serial_time{0};
+	hrt_abstime _dist_snsr_time{0};
 	hrt_abstime _now{0};
 	float       _dt{0};         // sampling time [s]
 	bool        _grounded{true};// whether the vehicle is on the ground
@@ -177,6 +184,7 @@ private:
 
 	int _gps_used;
 	float _baro_offset_m, _mag_offset_x, _mag_offset_y, _mag_offset_z;
+	float _distance_snsr_min, _distance_snsr_max;
 
 	// parameters defined in sih_params.c
 	DEFINE_PARAMETERS(
@@ -205,6 +213,8 @@ private:
 		(ParamFloat<px4::params::SIH_BARO_OFFSET>) _sih_baro_offset,
 		(ParamFloat<px4::params::SIH_MAG_OFFSET_X>) _sih_mag_offset_x,
 		(ParamFloat<px4::params::SIH_MAG_OFFSET_Y>) _sih_mag_offset_y,
-		(ParamFloat<px4::params::SIH_MAG_OFFSET_Z>) _sih_mag_offset_z
+		(ParamFloat<px4::params::SIH_MAG_OFFSET_Z>) _sih_mag_offset_z,
+		(ParamFloat<px4::params::SIH_DISTSNSR_MIN>) _sih_distance_snsr_min,
+		(ParamFloat<px4::params::SIH_DISTSNSR_MAX>) _sih_distance_snsr_max
 	)
 };

--- a/src/modules/sih/sih_params.c
+++ b/src/modules/sih/sih_params.c
@@ -391,3 +391,27 @@ PARAM_DEFINE_FLOAT(SIH_MAG_OFFSET_Y,  0.0f);
  * @group Simulation In Hardware
  */
 PARAM_DEFINE_FLOAT(SIH_MAG_OFFSET_Z,  0.0f);
+
+/**
+ * distance sensor minimun range
+ *
+ * @unit m
+ * @min 0.0
+ * @max 10.0
+ * @decimal 4
+ * @increment 0.01
+ * @group Simulation In Hardware
+ */
+PARAM_DEFINE_FLOAT(SIH_DISTSNSR_MIN, 0.0f);
+
+/**
+ * distance sensor maximun range
+ *
+ * @unit m
+ * @min 0.0
+ * @max 1000.0
+ * @decimal 4
+ * @increment 0.01
+ * @group Simulation In Hardware
+ */
+PARAM_DEFINE_FLOAT(SIH_DISTSNSR_MAX, 100.0f);

--- a/src/modules/sih/sih_params.c
+++ b/src/modules/sih/sih_params.c
@@ -415,3 +415,12 @@ PARAM_DEFINE_FLOAT(SIH_DISTSNSR_MIN, 0.0f);
  * @group Simulation In Hardware
  */
 PARAM_DEFINE_FLOAT(SIH_DISTSNSR_MAX, 100.0f);
+
+/**
+ * if >= 0 the distance sensor measures will be overrided by this value
+ * Absolute value superior to 10000 will disable distance sensor
+ *
+ * @unit m
+ * @group Simulation In Hardware
+ */
+PARAM_DEFINE_FLOAT(SIH_DISTSNSR_OVR, -1.0f);


### PR DESCRIPTION
This PR add a distance sensor to SIH.

The behavior of this distance sensor is similar to what I can observe with a Lightware lw20 lidar.

A simple way to simulate defaults is also added.