### PR TITLE
boards: nxp_fmurt1062-v1 remove irlock and lights/blinkm to save flash

### DIFF
--- a/boards/nxp/fmurt1062-v1/default.cmake
+++ b/boards/nxp/fmurt1062-v1/default.cmake
@@ -32,8 +32,8 @@ px4_add_board(
 		imu/invensense/icm20602
 		imu/invensense/icm20689
 		#imu/mpu6000 # legacy icm20602/icm20689 driver
-		irlock
-		lights/blinkm
+		#irlock
+		#lights/blinkm
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		lights/rgbled_pwm


### PR DESCRIPTION
We're right on the edge and causing new unrelated PRs to fail.