### PR TITLE
Can bootloaders use yield

### DIFF
--- a/boards/ark/can-flow/src/boot_config.h
+++ b/boards/ark/can-flow/src/boot_config.h
@@ -122,12 +122,7 @@
 
 /* If this board uses big flash that have large sectors */
 
-#if defined(CONFIG_STM32_FLASH_CONFIG_E) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_F) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_G) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_I)
 #define OPT_USE_YIELD
-#endif
 
 /* Bootloader Option*****************************************************************
  *

--- a/boards/cuav/can-gps-v1/src/boot_config.h
+++ b/boards/cuav/can-gps-v1/src/boot_config.h
@@ -123,12 +123,7 @@
 
 /* If this board uses big flash that have large sectors */
 
-#if defined(CONFIG_STM32_FLASH_CONFIG_E) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_F) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_G) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_I)
 #define OPT_USE_YIELD
-#endif
 
 /* Bootloader Option*****************************************************************
  *

--- a/boards/holybro/can-gps-v1/src/boot_config.h
+++ b/boards/holybro/can-gps-v1/src/boot_config.h
@@ -122,13 +122,7 @@
 #define APPLICATION_LAST_64BIT_ADDRRESS ((uint64_t *)((APPLICATION_LOAD_ADDRESS+APPLICATION_SIZE)-sizeof(uint64_t)))
 
 /* If this board uses big flash that have large sectors */
-
-#if defined(CONFIG_STM32_FLASH_CONFIG_E) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_F) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_G) || \
-   defined(CONFIG_STM32_FLASH_CONFIG_I)
 #define OPT_USE_YIELD
-#endif
 
 /* Bootloader Option*****************************************************************
  *


### PR DESCRIPTION
yield keeps the UAVCAN status active during long erase times.

This was previously selected by chip family. But that requires maintenance, that is not needed as it is known by the board.

