### PR TITLE
MRO Ctrl Zero H7 OEM - Remove mkblctrl from default.cmake

### DIFF
--- a/boards/mro/ctrl-zero-h7-oem/default.cmake
+++ b/boards/mro/ctrl-zero-h7-oem/default.cmake
@@ -37,7 +37,6 @@ px4_add_board(
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		magnetometer # all available magnetometer drivers
-		mkblctrl
 		optical_flow # all available optical flow drivers
 		#osd
 		pca9685


### PR DESCRIPTION
Mkblctrl needs to be removed for the build to now succeed.