### PR TITLE
TECS: Fix internal state init if dt is large

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -60,7 +60,7 @@ void TECS::update_vehicle_state_estimates(float equivalent_airspeed, const float
 {
 	// calculate the time lapsed since the last update
 	uint64_t now = hrt_absolute_time();
-	float dt = constrain((now - _state_update_timestamp) * 1.0e-6f, DT_MIN, DT_MAX);
+	float dt = fmaxf((now - _state_update_timestamp) * 1e-6f, DT_MIN);
 
 	bool reset_altitude = false;
 

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -536,7 +536,7 @@ void TECS::update_pitch_throttle(float pitch, float baro_altitude, float hgt_set
 {
 	// Calculate the time since last update (seconds)
 	uint64_t now = hrt_absolute_time();
-	_dt = constrain((now - _pitch_update_timestamp) * 1e-6f, DT_MIN, DT_MAX);
+	_dt = fmaxf((now - _pitch_update_timestamp) * 1e-6f, DT_MIN);
 
 	// Set class variables from inputs
 	_throttle_setpoint_max = throttle_max;


### PR DESCRIPTION
**Describe problem solved by this pull request**
There was a bug in TECS which made the `_dt > DT_MAX` part of [this check](https://github.com/PX4/PX4-Autopilot/blob/cec31fd68512988f1eba072e167c4b53d1d1035c/src/lib/tecs/TECS.cpp#L465-L465) never trigger since just before we call the function we limit the _dt to be max `DT_MAX` [here](https://github.com/PX4/PX4-Autopilot/blob/cec31fd68512988f1eba072e167c4b53d1d1035c/src/lib/tecs/TECS.cpp#L539-L539).

This results in the fact that the internal TECS states are not reset if a VTOL vehicle is doing a second transition to cruise

**Test data / coverage**
Tested on TECS similar to v1.10.1
