### PR TITLE
lib/drivers: Fix magnetometer, etc. over UAVCAN

### DIFF
--- a/src/lib/drivers/barometer/PX4Barometer.hpp
+++ b/src/lib/drivers/barometer/PX4Barometer.hpp
@@ -54,7 +54,11 @@ public:
 
 	void update(const hrt_abstime &timestamp_sample, float pressure);
 
-	int get_instance() { return _sensor_baro_pub.get_instance(); };
+	int get_instance()
+	{
+		_sensor_baro_pub.advertise();
+		return _sensor_baro_pub.get_instance();
+	}
 
 private:
 

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
@@ -56,7 +56,11 @@ public:
 
 	void update(const hrt_abstime &timestamp_sample, float x, float y, float z);
 
-	int get_instance() { return _sensor_pub.get_instance(); };
+	int get_instance()
+	{
+		_sensor_pub.advertise();
+		return _sensor_pub.get_instance();
+	}
 
 private:
 	uORB::PublicationMulti<sensor_mag_s> _sensor_pub{ORB_ID(sensor_mag)};

--- a/src/lib/drivers/rangefinder/PX4Rangefinder.hpp
+++ b/src/lib/drivers/rangefinder/PX4Rangefinder.hpp
@@ -62,7 +62,11 @@ public:
 
 	void update(const hrt_abstime &timestamp_sample, const float distance, const int8_t quality = -1);
 
-	int get_instance() { return _distance_sensor_pub.get_instance(); };
+	int get_instance()
+	{
+		_distance_sensor_pub.advertise();
+		return _distance_sensor_pub.get_instance();
+	}
 
 private:
 	uORB::PublicationMultiData<distance_sensor_s> _distance_sensor_pub{ORB_ID(distance_sensor)};


### PR DESCRIPTION
**Describe problem solved by this pull request**
Here3 magnetometer doesn't work on master. Gives [(from here)](https://github.com/PX4/PX4-Autopilot/blob/143ebbad9872691797e947314efc2f56cdc902c6/src/drivers/uavcan/sensors/mag.cpp#L140-L145)
```
uavcan_mag adding channel for topic sensor_mag node 125...
ERROR [uavcan] UavcanMag: Unable to get an instance
uavcan_mag INIT ERROR node 125 errno -1
```

**Describe your solution**
Due to #16699 the PX4{Barometer,Magnetometer,Rangefinder} classes don't advertise in constructor, so `get_instance()` returns -1 until `update` is called. Rather than calling `update` with garbage data in `init_driver`, just have `get_instance()` advertise.

**Test data / coverage**
Tested on CubeOrange with Here3. Errors are gone and `sensors_mag` is published. I do not have other UAVCAN sensors to test with but the code is very similar.
