### PR TITLE
uORB: PublicationMulti get_instance() advertise if not already advertised

### DIFF
--- a/platforms/common/uORB/PublicationMulti.hpp
+++ b/platforms/common/uORB/PublicationMulti.hpp
@@ -92,9 +92,10 @@ public:
 		return (orb_publish(get_topic(), _handle, &data) == PX4_OK);
 	}
 
-	int get_instance() const
+	int get_instance()
 	{
-		if (_handle) {
+		// advertise if not already advertised
+		if (advertise()) {
 			return static_cast<uORB::DeviceNode *>(_handle)->get_instance();
 		}
 


### PR DESCRIPTION
 - fixes UAVCANv0 sensor bridge uORB usage, but also a reason thing to do in general
 - simple alternative to https://github.com/PX4/PX4-Autopilot/pull/16973

Big thanks to @amikhalev for actually debugging this after I broke it with https://github.com/PX4/PX4-Autopilot/pull/16699.