### PR TITLE
Optimize number of logical cores used during sitl builds.

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -30,6 +30,14 @@ px4_add_git_submodule(TARGET git_jsbsim_bridge PATH "${PX4_SOURCE_DIR}/Tools/jsb
 
 # Add support for external project building
 include(ExternalProject)
+include(ProcessorCount)
+
+set(build_cores 1)
+
+ProcessorCount(N)
+if(N GREATER_EQUAL 4)
+	math(EXPR build_cores "${N} - 2")
+endif()
 
 # project to build sitl_gazebo if necessary
 ExternalProject_Add(sitl_gazebo
@@ -45,7 +53,7 @@ ExternalProject_Add(sitl_gazebo
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
 	BUILD_ALWAYS 1
-	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j2
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${build_cores}
 )
 
 ExternalProject_Add(mavsdk_tests
@@ -95,7 +103,7 @@ set(models none shell
 	if750a iris iris_dual_gps iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_ctrlalloc iris_obs_avoid iris_rtps px4vision solo typhoon_h480
 	plane plane_cam plane_catapult plane_lidar techpod
 	standard_vtol tailsitter tiltrotor
-	rover r1_rover boat cloudship
+	rover r1_rover boat cloudship nxp_cupcar
 	uuv_hippocampus uuv_bluerov2_heavy)
 set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy yosemite)
 set(all_posix_vmd_make_targets)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes the painful sitl build time for those with 4 or more logical cores.

**Describe your solution**
If number of logical cores on system is greater than or equal to 4 use number of logical cores - 2.
Otherwise use 1 logical core.

**Test data / coverage**
Tested on: 
    2 logical core VM
    4 logical core VM
    64 core VM

Worked perfectly.