### PR TITLE
cmake: sitl_target sort lists and trim a few options

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -4,29 +4,20 @@ file(MAKE_DIRECTORY ${SITL_WORKING_DIR}/rootfs)
 
 # add a symlink to the logs dir to make it easier to find them
 add_custom_command(OUTPUT ${PX4_BINARY_DIR}/logs
-		COMMAND ${CMAKE_COMMAND} -E create_symlink ${SITL_WORKING_DIR}/rootfs/log logs
-		WORKING_DIRECTORY ${PX4_BINARY_DIR})
+	COMMAND ${CMAKE_COMMAND} -E create_symlink ${SITL_WORKING_DIR}/rootfs/log logs
+	WORKING_DIRECTORY ${PX4_BINARY_DIR}
+)
 add_custom_target(logs_symlink DEPENDS ${PX4_BINARY_DIR}/logs)
-
 add_dependencies(px4 logs_symlink)
 
 add_custom_target(run_config
-		COMMAND Tools/sitl_run.sh
-			$<TARGET_FILE:px4>
-			${config_sitl_debugger}
-			${config_sitl_viewer}
-			${config_sitl_model}
-			${PX4_SOURCE_DIR}
-			${PX4_BINARY_DIR}
-		WORKING_DIRECTORY ${SITL_WORKING_DIR}
-		USES_TERMINAL
-		DEPENDS px4 logs_symlink
-		)
+	COMMAND Tools/sitl_run.sh $<TARGET_FILE:px4> ${config_sitl_debugger} ${config_sitl_viewer} ${config_sitl_model} ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
+	WORKING_DIRECTORY ${SITL_WORKING_DIR}
+	USES_TERMINAL
+	DEPENDS px4 logs_symlink
+)
 
-px4_add_git_submodule(TARGET git_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_gazebo")
 px4_add_git_submodule(TARGET git_jmavsim PATH "${PX4_SOURCE_DIR}/Tools/jMAVSim")
-px4_add_git_submodule(TARGET git_flightgear_bridge PATH "${PX4_SOURCE_DIR}/Tools/flightgear_bridge")
-px4_add_git_submodule(TARGET git_jsbsim_bridge PATH "${PX4_SOURCE_DIR}/Tools/jsbsim_bridge")
 
 # Add support for external project building
 include(ExternalProject)
@@ -40,6 +31,7 @@ if(N GREATER_EQUAL 4)
 endif()
 
 # project to build sitl_gazebo if necessary
+px4_add_git_submodule(TARGET git_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_gazebo")
 ExternalProject_Add(sitl_gazebo
 	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/sitl_gazebo
 	CMAKE_ARGS
@@ -47,8 +39,7 @@ ExternalProject_Add(sitl_gazebo
 		-DSEND_ODOMETRY_DATA=ON
 	BINARY_DIR ${PX4_BINARY_DIR}/build_gazebo
 	INSTALL_COMMAND ""
-	DEPENDS
-		git_gazebo
+	DEPENDS git_gazebo
 	USES_TERMINAL_CONFIGURE true
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
@@ -58,8 +49,7 @@ ExternalProject_Add(sitl_gazebo
 
 ExternalProject_Add(mavsdk_tests
 	SOURCE_DIR ${PX4_SOURCE_DIR}/test/mavsdk_tests
-	CMAKE_ARGS
-		-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 	BINARY_DIR ${PX4_BINARY_DIR}/mavsdk_tests
 	INSTALL_COMMAND ""
 	USES_TERMINAL_CONFIGURE true
@@ -68,28 +58,26 @@ ExternalProject_Add(mavsdk_tests
 	BUILD_ALWAYS 1
 )
 
+px4_add_git_submodule(TARGET git_flightgear_bridge PATH "${PX4_SOURCE_DIR}/Tools/flightgear_bridge")
 ExternalProject_Add(flightgear_bridge
 	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/flightgear_bridge
-	CMAKE_ARGS
-		-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 	BINARY_DIR ${PX4_BINARY_DIR}/build_flightgear_bridge
 	INSTALL_COMMAND ""
-	DEPENDS
-		git_flightgear_bridge
+	DEPENDS git_flightgear_bridge
 	USES_TERMINAL_CONFIGURE true
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
 	BUILD_ALWAYS 1
 )
 
+px4_add_git_submodule(TARGET git_jsbsim_bridge PATH "${PX4_SOURCE_DIR}/Tools/jsbsim_bridge")
 ExternalProject_Add(jsbsim_bridge
 	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/jsbsim_bridge
-	CMAKE_ARGS
-		-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 	BINARY_DIR ${PX4_BINARY_DIR}/build_jsbsim_bridge
 	INSTALL_COMMAND ""
-	DEPENDS
-		git_jsbsim_bridge
+	DEPENDS git_jsbsim_bridge
 	USES_TERMINAL_CONFIGURE true
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
@@ -97,29 +85,79 @@ ExternalProject_Add(jsbsim_bridge
 )
 
 # create targets for each viewer/model/debugger combination
-set(viewers none jmavsim gazebo)
-set(debuggers none ide gdb lldb ddd valgrind callgrind)
-set(models none shell
-	if750a iris iris_dual_gps iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_ctrlalloc iris_obs_avoid iris_rtps px4vision solo typhoon_h480
-	plane plane_cam plane_catapult plane_lidar techpod
-	standard_vtol tailsitter tiltrotor
-	rover r1_rover boat cloudship nxp_cupcar
-	uuv_hippocampus uuv_bluerov2_heavy)
-set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy yosemite)
+set(viewers
+	none
+	jmavsim
+	gazebo
+)
+
+set(debuggers
+	none
+	gdb
+	lldb
+	valgrind
+	callgrind
+)
+
+set(models
+	none
+	boat
+	cloudship
+	if750a
+	iris
+	iris_ctrlalloc
+	iris_dual_gps
+	iris_irlock
+	iris_obs_avoid
+	iris_opt_flow
+	iris_opt_flow_mockup
+	iris_rplidar
+	iris_rtps px4vision
+	iris_vision
+	nxp_cupcar
+	plane
+	plane_cam
+	plane_catapult
+	plane_lidar
+	r1_rover
+	rover
+	shell
+	solo
+	standard_vtol
+	tailsitter
+	techpod
+	tiltrotor
+	typhoon_h480
+	uuv_bluerov2_heavy
+	uuv_hippocampus
+)
+
+set(worlds
+	none
+	baylands
+	empty
+	ksql_airport
+	mcmillan_airfield
+	sonoma_raceway
+	warehouse
+	windy
+	yosemite
+)
+
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})
 		foreach(model ${models})
 			foreach(world ${worlds})
-				if (world STREQUAL "none")
-					if (debugger STREQUAL "none")
-						if (model STREQUAL "none")
+				if(world STREQUAL "none")
+					if(debugger STREQUAL "none")
+						if(model STREQUAL "none")
 							set(_targ_name "${viewer}")
 						else()
 							set(_targ_name "${viewer}_${model}")
 						endif()
 					else()
-						if (model STREQUAL "none")
+						if(model STREQUAL "none")
 							set(_targ_name "${viewer}___${debugger}")
 						else()
 							set(_targ_name "${viewer}_${model}_${debugger}")
@@ -127,35 +165,27 @@ foreach(viewer ${viewers})
 					endif()
 
 					add_custom_target(${_targ_name}
-						COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-							$<TARGET_FILE:px4>
-							${debugger}
-							${viewer}
-							${model}
-							${world}
-							${PX4_SOURCE_DIR}
-							${PX4_BINARY_DIR}
+						COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh $<TARGET_FILE:px4> ${debugger} ${viewer} ${model} ${world} ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
 						WORKING_DIRECTORY ${SITL_WORKING_DIR}
 						USES_TERMINAL
-						DEPENDS
-							logs_symlink
+						DEPENDS logs_symlink
 					)
 					list(APPEND all_posix_vmd_make_targets ${_targ_name})
-					if (viewer STREQUAL "gazebo")
+					if(viewer STREQUAL "gazebo")
 						add_dependencies(${_targ_name} px4 sitl_gazebo)
 					elseif(viewer STREQUAL "jmavsim")
 						add_dependencies(${_targ_name} px4 git_jmavsim)
 					endif()
 				else()
-					if (viewer STREQUAL "gazebo")
-						if (debugger STREQUAL "none")
-							if (model STREQUAL "none")
+					if(viewer STREQUAL "gazebo")
+						if(debugger STREQUAL "none")
+							if(model STREQUAL "none")
 								set(_targ_name "${viewer}___${world}")
 							else()
 								set(_targ_name "${viewer}_${model}__${world}")
 							endif()
 						else()
-							if (model STREQUAL "none")
+							if(model STREQUAL "none")
 								set(_targ_name "${viewer}__${debugger}_${world}")
 							else()
 								set(_targ_name "${viewer}_${model}_${debugger}_${world}")
@@ -163,14 +193,7 @@ foreach(viewer ${viewers})
 						endif()
 
 						add_custom_target(${_targ_name}
-							COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-								$<TARGET_FILE:px4>
-								${debugger}
-								${viewer}
-								${model}
-								${world}
-								${PX4_SOURCE_DIR}
-								${PX4_BINARY_DIR}
+							COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh $<TARGET_FILE:px4> ${debugger} ${viewer} ${model} ${world} ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
 							WORKING_DIRECTORY ${SITL_WORKING_DIR}
 							USES_TERMINAL
 							DEPENDS logs_symlink
@@ -185,20 +208,31 @@ foreach(viewer ${viewers})
 endforeach()
 
 # create targets for jsbsim
-set(models_jsbsim none rascal quadrotor_x hexarotor_x malolo)
-set(worlds_jsbsim none LSZH)
+set(models_jsbsim
+	none
+	rascal
+	quadrotor_x
+	hexarotor_x
+	malolo
+)
+
+set(worlds_jsbsim
+	none
+	LSZH
+)
+
 foreach(debugger ${debuggers})
 	foreach(model ${models_jsbsim})
 		foreach(world ${worlds_jsbsim})
-			if (world STREQUAL "none")
-				if (debugger STREQUAL "none")
-					if (model STREQUAL "none")
+			if(world STREQUAL "none")
+				if(debugger STREQUAL "none")
+					if(model STREQUAL "none")
 						set(_targ_name "jsbsim")
 					else()
 						set(_targ_name "jsbsim_${model}")
 					endif()
 				else()
-					if (model STREQUAL "none")
+					if(model STREQUAL "none")
 						set(_targ_name "jsbsim__${debugger}_${world}")
 					else()
 						set(_targ_name "jsbsim_${model}_${debugger}_${world}")
@@ -206,30 +240,22 @@ foreach(debugger ${debuggers})
 				endif()
 
 				add_custom_target(${_targ_name}
-				COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-					$<TARGET_FILE:px4>
-					${debugger}
-					jsbsim
-					${model}
-					"LSZH"
-					${PX4_SOURCE_DIR}
-					${PX4_BINARY_DIR}
-				WORKING_DIRECTORY ${SITL_WORKING_DIR}
-				USES_TERMINAL
-				DEPENDS
-					logs_symlink
+					COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh $<TARGET_FILE:px4> ${debugger} jsbsim ${model} "LSZH" ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
+					WORKING_DIRECTORY ${SITL_WORKING_DIR}
+					USES_TERMINAL
+					DEPENDS logs_symlink
 				)
 				list(APPEND all_posix_vmd_make_targets ${_targ_name})
 				add_dependencies(${_targ_name} px4 jsbsim_bridge)
 			else()
-				if (debugger STREQUAL "none")
-					if (model STREQUAL "none")
+				if(debugger STREQUAL "none")
+					if(model STREQUAL "none")
 						set(_targ_name "jsbsim___${world}")
 					else()
 						set(_targ_name "jsbsim_${model}__${world}")
 					endif()
 				else()
-					if (model STREQUAL "none")
+					if(model STREQUAL "none")
 						set(_targ_name "jsbsim___${debugger}_${world}")
 					else()
 						set(_targ_name "jsbsim_${model}_${debugger}_${world}")
@@ -237,18 +263,10 @@ foreach(debugger ${debuggers})
 				endif()
 
 				add_custom_target(${_targ_name}
-				COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-					$<TARGET_FILE:px4>
-					${debugger}
-					jsbsim
-					${model}
-					${world}
-					${PX4_SOURCE_DIR}
-					${PX4_BINARY_DIR}
-				WORKING_DIRECTORY ${SITL_WORKING_DIR}
-				USES_TERMINAL
-				DEPENDS
-					logs_symlink
+					COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh $<TARGET_FILE:px4> ${debugger} jsbsim ${model} ${world} ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
+					WORKING_DIRECTORY ${SITL_WORKING_DIR}
+					USES_TERMINAL
+					DEPENDS logs_symlink
 				)
 				list(APPEND all_posix_vmd_make_targets ${_targ_name})
 				add_dependencies(${_targ_name} px4 jsbsim_bridge)
@@ -257,32 +275,24 @@ foreach(debugger ${debuggers})
 	endforeach()
 endforeach()
 
-#add flighgear targets
-if( ENABLE_LOCKSTEP_SCHEDULER STREQUAL "no")
+# add flighgear targets
+if(ENABLE_LOCKSTEP_SCHEDULER STREQUAL "no")
 	set(models
 		rascal
 		rascal-electric
 		tf-g1
 		tf-r1
-		)
+	)
 	set(all_posix_vmd_make_targets)
 
 	foreach(model ${models})
 		set(_targ_name "flightgear_${model}")
 		add_custom_target(${_targ_name}
-			COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-				$<TARGET_FILE:px4>
-				none
-				flightgear
-				${model}
-				none
-				${PX4_SOURCE_DIR}
-				${PX4_BINARY_DIR}
+			COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh $<TARGET_FILE:px4> none flightgear ${model} none ${PX4_SOURCE_DIR} ${PX4_BINARY_DIR}
 			WORKING_DIRECTORY ${SITL_WORKING_DIR}
 			USES_TERMINAL
-			DEPENDS
-				logs_symlink
-			)
+			DEPENDS logs_symlink
+		)
 
 		add_dependencies(${_targ_name} px4 flightgear_bridge)
 		list(APPEND all_posix_vmd_make_targets ${_targ_name})


### PR DESCRIPTION
We've really got to find a better way to handle SITL targets because this isn't scaling. The generated ninja build file is 27M.

CMake should build the dependencies, not used for poor scripting like this. Generating targets for every possible permutation of simulator, model, world, debugger is an abuse of the build system that needs to be fixed.

``` Console
27M	px4_sitl_test/build.ninja
```