### PR TITLE
lib/battery: Fix cell voltages with >10S

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -158,9 +158,11 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 		static constexpr int uorb_max_cells = sizeof(_battery_status.voltage_cell_v) / sizeof(
 				_battery_status.voltage_cell_v[0]);
 
+		int max_cells = math::min(_battery_status.cell_count, uorb_max_cells);
+
 		// Fill cell voltages with average values to work around MAVLink BATTERY_STATUS not allowing to report just total voltage
-		for (int i = 0; (i < _battery_status.cell_count) && (i < uorb_max_cells); i++) {
-			_battery_status.voltage_cell_v[i] = _battery_status.voltage_filtered_v / _battery_status.cell_count;
+		for (int i = 0; i < max_cells; i++) {
+			_battery_status.voltage_cell_v[i] = _battery_status.voltage_filtered_v / max_cells;
 		}
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
QGroundControl display incorrect voltage with 12S battery. When the log shows ~55V, QGC shows ~45V.

This is due to the fact that `battery_status` only allocates room for 10 cells. It fills those in by the average per cell voltage, but truncates to 10 cells. Which [QGC happily sums](https://github.com/PX4/PX4-Autopilot/blob/9d47f7ecda2153cc3fde3a2a63096723b3467651/src/lib/battery/battery.cpp#L161-L163) to obtain 10/12 of the correct voltage.

**Describe your solution**
Average over the number of cell voltages reported, so when QGC sums it gets the correct answer.

**Describe possible alternatives**
 * Do what [UAVCAN battery does](https://github.com/PX4/PX4-Autopilot/blob/9d47f7ecda2153cc3fde3a2a63096723b3467651/src/drivers/uavcan/sensors/battery.cpp#L91-L95) and just set the first cell voltage. But then it would have to lie about `cell_count`
 * Have `MavlinkStreamBatteryStatus` fill in the cell voltages with either total / 10, or just the first cell voltage. But then battery drivers which actually do report cell voltages wouldn't work.
 * Increase the number of cell voltages in `battery_status` to the max supported 16. Then `MavlinkStreamBatteryStatus` could put the rest in `voltages_ext`, but QGroundControl doesn't use that field.

**Test data / coverage**
Testing pending

