### PR TITLE
Add support for specifying spawn location in Gazebo multi sim

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -15,6 +15,10 @@ function cleanup() {
 function spawn_model() {
 	MODEL=$1
 	N=$2 #Instance Number
+	X=$3
+	Y=$4
+	X=${X:=0.0}
+	Y=${Y:=$((3*${N}))}
 
 	SUPPORTED_MODELS=("iris" "iris_rtps" "plane" "standard_vtol" "rover" "r1_rover" "typhoon_h480")
 	if [[ " ${SUPPORTED_MODELS[*]} " != *"$MODEL"* ]];
@@ -33,9 +37,9 @@ function spawn_model() {
 	../bin/px4 -i $N -d "$build_path/etc" -w sitl_${MODEL}_${N} -s etc/init.d-posix/rcS >out.log 2>err.log &
 	python3 ${src_path}/Tools/sitl_gazebo/scripts/jinja_gen.py ${src_path}/Tools/sitl_gazebo/models/${MODEL}/${MODEL}.sdf.jinja ${src_path}/Tools/sitl_gazebo --mavlink_tcp_port $((4560+${N})) --mavlink_udp_port $((14560+${N})) --mavlink_id $((1+${N})) --gst_udp_port $((5600+${N})) --video_uri $((5600+${N})) --mavlink_cam_udp_port $((14530+${N})) --output-file /tmp/${MODEL}_${N}.sdf
 
-	echo "Spawning ${MODEL}_${N}"
+	echo "Spawning ${MODEL}_${N} at ${X} ${Y}"
 
-	gz model --spawn-file=/tmp/${MODEL}_${N}.sdf --model-name=${MODEL}_${N} -x 0.0 -y $((3*${N})) -z 0.0
+	gz model --spawn-file=/tmp/${MODEL}_${N}.sdf --model-name=${MODEL}_${N} -x ${X} -y ${Y} -z 0.0
 
 	popd &>/dev/null
 
@@ -100,8 +104,10 @@ else
 	IFS=,
 	for target in ${SCRIPT}; do
 		target="$(echo "$target" | tr -d ' ')" #Remove spaces
-		target_vehicle="${target%:*}"
-		target_number="${target#*:}"
+		target_vehicle=$(echo $target | cut -f1 -d:)
+		target_number=$(echo $target | cut -f2 -d:)
+		target_x=$(echo $target | cut -f3 -d:)
+		target_y=$(echo $target | cut -f4 -d:)
 
 		if [ $n -gt 255 ]
 		then
@@ -111,7 +117,7 @@ else
 
 		m=0
 		while [ $m -lt ${target_number} ]; do
-			spawn_model ${target_vehicle} $n
+			spawn_model ${target_vehicle} $n $target_x $target_y
 			m=$(($m + 1))
 			n=$(($n + 1))
 		done


### PR DESCRIPTION
This commit adds support for specifying the spawn location of vehicles
in the Gazebo multi-vehicle simulator script (`frame:number:x:y`). Adding support for this allows developers more flexibility in how to set up the simulator.

The behavior when x and y are not specified remains the same as before.
