### PR TITLE
Add support for 3D thrust setpoints for offboard attitude control

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1381,6 +1381,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 		const bool attitude = !(type_mask & ATTITUDE_TARGET_TYPEMASK_ATTITUDE_IGNORE);
 		const bool body_rates = !(type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_ROLL_RATE_IGNORE)
 					&& !(type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_PITCH_RATE_IGNORE);
+		const bool thrust_body = (type_mask & ATTITUDE_TARGET_TYPEMASK_THRUST_BODY_SET);
 
 		vehicle_status_s vehicle_status{};
 		_vehicle_status_sub.copy(&vehicle_status);
@@ -1400,8 +1401,13 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 			attitude_setpoint.yaw_sp_move_rate = (type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_YAW_RATE_IGNORE) ?
 							     NAN : attitude_target.body_yaw_rate;
 
-			if (!(attitude_target.type_mask & ATTITUDE_TARGET_TYPEMASK_THROTTLE_IGNORE)) {
+			if (!thrust_body && !(attitude_target.type_mask & ATTITUDE_TARGET_TYPEMASK_THROTTLE_IGNORE)) {
 				fill_thrust(attitude_setpoint.thrust_body, vehicle_status.vehicle_type, attitude_target.thrust);
+
+			} else if (thrust_body) {
+				attitude_setpoint.thrust_body[0] = attitude_target.thrust_body[0];
+				attitude_setpoint.thrust_body[1] = attitude_target.thrust_body[1];
+				attitude_setpoint.thrust_body[2] = attitude_target.thrust_body[2];
 			}
 
 			// publish offboard_control_mode


### PR DESCRIPTION
**Describe problem solved by this pull request**
With the recent developments of control allocation and UUVs and also fully actuated systems, there needs to be a way to conveniently set 3D thrust setpoints when developing controllers.

Offboard mode provides an interface for this, but the interface for setting 3D thrust setpoints were missing in the `SET_ATTITUDE_TARGET` mavlink message

**Describe your solution**
This PR adds support for `thrust_body` where 3D thrust setpoints in the body frame can be set by the new mavlink extension. 


**Test data / coverage**
This has been tested with the generated mavlink v2 header library, and works as intended

**Additional context**
- This PR is written on top of https://github.com/PX4/PX4-Autopilot/pull/16739
- This requires the mavlink PR https://github.com/mavlink/mavlink/pull/1600 to be merged
- @DanielDuecker @Zarbokk FYI
