### PR TITLE
px4_work_queue: increase wq:nav_and_controllers stack

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -66,7 +66,7 @@ static constexpr wq_config_t I2C3{"wq:I2C3", 2336, -11};
 static constexpr wq_config_t I2C4{"wq:I2C4", 2336, -12};
 
 // PX4 att/pos controllers, highest priority after sensors.
-static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 1824, -13};
+static constexpr wq_config_t nav_and_controllers{"wq:nav_and_controllers", 2164, -13};
 
 static constexpr wq_config_t INS0{"wq:INS0", 6000, -14};
 static constexpr wq_config_t INS1{"wq:INS1", 6000, -15};


### PR DESCRIPTION
Current master with MPC_POS_MODE 3 (ManualPositionSmoothVel) using collision prevention requires more than the current 1824 bytes of stack.

``` Console
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
 376 wq:nav_and_controllers         53  5.296  1864/ 2828 242 (242)  w:sem  5
```

