### PR TITLE
v6x: fix icm20649 rotation

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -16,7 +16,7 @@ bmi088 -G -R 4 -s start
 icm42688p -R 6 -s start
 
 # Internal SPI bus ICM-20649 (hard-mounted)
-icm20649 -R 2 -s start
+icm20649 -R 14 -s start
 
 # Internal magnetometer on I2c
 bmm150 -I start


### PR DESCRIPTION
This commit fixes the sensor rotation for the ICM20649 on the FMUv6x board

**Test data / coverage**
It flies!
https://review.px4.io/plot_app?log=1ead2f64-2a67-4f5d-8e5a-ccc928262c0d
