### PR TITLE
Enable some pre-arm checks in HIL modes

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/1000_rc_fw_easystar.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1000_rc_fw_easystar.hil
@@ -47,4 +47,13 @@ param set-default RWTO_TKOFF 1
 
 param set SYS_HITL 1
 
+# disable some checks to allow to fly
+# - with usb
+param set-default CBRK_USB_CHK 197848
+# - without real battery
+param set-default CBRK_SUPPLY_CHK 894281
+# - without safety switch
+param set-default COM_PREARM_MODE 0
+param set-default CBRK_IO_SAFETY 22027
+
 set MIXER AERT

--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -14,3 +14,12 @@ set MIXER quad_x
 set PWM_OUT 1234
 
 param set SYS_HITL 1
+
+# disable some checks to allow to fly
+# - with usb
+param set-default CBRK_USB_CHK 197848
+# - without real battery
+param set-default CBRK_SUPPLY_CHK 894281
+# - without safety switch
+param set-default COM_PREARM_MODE 0
+param set-default CBRK_IO_SAFETY 22027

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -66,6 +66,15 @@ param set-default VT_TYPE 2
 
 param set SYS_HITL 1
 
+# disable some checks to allow to fly
+# - with usb
+param set-default CBRK_USB_CHK 197848
+# - without real battery
+param set-default CBRK_SUPPLY_CHK 894281
+# - without safety switch
+param set-default COM_PREARM_MODE 0
+param set-default CBRK_IO_SAFETY 22027
+
 set MAV_TYPE 22
 
 set MIXER standard_vtol_hitl

--- a/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil
@@ -17,3 +17,12 @@ set PWM_OUT 1234
 
 # set SYS_HITL to 2 to start the SIH and avoid sensors startup
 param set SYS_HITL 2
+
+# disable some checks to allow to fly:
+# - with usb
+param set-default CBRK_USB_CHK 197848
+# - without real battery
+param set-default CBRK_SUPPLY_CHK 894281
+# - without safety switch
+param set-default COM_PREARM_MODE 0
+param set-default CBRK_IO_SAFETY 22027

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -173,7 +173,7 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const safe
 
 				//      Do not perform pre-arm checks if coming from in air restore
 				//      Allow if vehicle_status_s::HIL_STATE_ON
-				if (status->arming_state != vehicle_status_s::ARMING_STATE_IN_AIR_RESTORE && !hil_enabled) {
+				if (status->arming_state != vehicle_status_s::ARMING_STATE_IN_AIR_RESTORE) {
 
 					bool prearm_check_ret = true;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
We use HIL for as part as our system validation and we want it to be as close as possible to the real system.
That is why I want to enable some pre-arm check.  In particular, I want to enable authorization request but I think some other tests can be activated.

**Describe your solution**
Enable pre-arm checks in HIL mode but disable some specific tests.
The following test are still disabled: 
 - usb check
 - power checks
 - safety switch
 - esc checks

These tests are enabled:
- valid mission
- valid global position
- valid avoidance system
- specific vtol state
- arm authorization request 

**Additional context**
I would like to also enable power tests. My tests are done with a (fake) battery and successfully enable power tests by starting board_adc module in HIL mode but I am afraid this will not be ok for most HIL use case...
Do you think I can start board_adc on all boards in HIL mode and add a parameter to request a battery even in HIIL ?
