### PR TITLE
[UPDATE] - Default to EKF2 with no MAG

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -19,8 +19,10 @@
 set MIXER quad_x_cw
 set PWM_OUT 1234
 
-param set-default SYS_MC_EST_GROUP 3
+param set-default SYS_MC_EST_GROUP 2
 param set-default SYS_HAS_MAG 0
+param set-default EKF2_AID_MASK 2
+param set-default EKF2_MAG_TYPE 5
 
 param set-default BAT_N_CELLS 1
 param set-default BAT1_N_CELLS 1
@@ -58,7 +60,7 @@ param set-default MPC_MAX_FLOW_HGT 3
 param set-default NAV_RCL_ACT 3
 
 param set-default PWM_MAIN_DISARM 0
-param set-default PWM_MAIN_MIN 0
+param set-default PWM_MAIN_MIN 20
 param set-default PWM_MAIN_MAX 255
 
 # Run the motors at 328.125 kHz (recommended)


### PR DESCRIPTION
1. Change crazyflie 2.1 default to `EKF2` and no `MAG`
2. Increase `PWM_MAIN_MIN` to spin the motors when armed

