### PR TITLE
MultiCopterPositionControl: hotfix emergency failsafe

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -398,12 +398,14 @@ void MulticopterPositionControl::Run()
 					_last_warn = time_stamp_now;
 				}
 
-				failsafe(time_stamp_now, _setpoint, states, !was_in_failsafe);
+				vehicle_local_position_setpoint_s failsafe_setpoint{};
+
+				failsafe(time_stamp_now, failsafe_setpoint, states, !was_in_failsafe);
 
 				// reset constraints
 				_vehicle_constraints = {0, NAN, NAN, NAN, false, {}};
 
-				_control.setInputSetpoint(_setpoint);
+				_control.setInputSetpoint(failsafe_setpoint);
 				_control.setVelocityLimits(_param_mpc_xy_vel_max.get(), _param_mpc_z_vel_max_up.get(), _param_mpc_z_vel_max_dn.get());
 				_control.update(dt);
 			}


### PR DESCRIPTION
**Describe problem solved by this pull request**
The emergency failsafe that prevents the vehicle from crashing with invalid setpoints or states broke with #16869 when the scheduling of the position control module and the setpoint generation got independent. The failsafe mechanism assumed the setpoint is overwirtten by the possibly infeasible trajectory_setpoint on every loop iteration which is not the case anymore. As a result the failsafe reset its hysteresis based on the failsafe setpoint from the last loop iteration and would therefore toggle again every time there's a new unfeasible trajectory_setpoint.

**Describe your solution**
Keeping the `failsafe_setpoint` separate solves this issue. Note that these failsafe setpoints do the bare minimum to keep the vehicle safely in the air and do not suffer from sideffects ignoring the EKF reset.

**Test data / coverage**
I tested by simply injecting malicious unfeasible setpoints when trying to reproduce an unrelated initialization issue. Before this pr the vehicle would come down like a stone. With this pr it works exactly as expected again. Keeping the vehicle in a sane flight condition such that you can take over again, logging regular messages such that you see what's happening.
