### PR TITLE
navigator: new navigator_status msg split out of mission_result

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -97,6 +97,7 @@ set(msg_files
 	mount_orientation.msg
 	multirotor_motor_limits.msg
 	navigator_mission_item.msg
+	navigator_status.msg
 	obstacle_distance.msg
 	offboard_control_mode.msg
 	onboard_computer_status.msg

--- a/msg/mission_result.msg
+++ b/msg/mission_result.msg
@@ -1,24 +1,26 @@
 uint64 timestamp				# time since system start (microseconds)
-uint8 MISSION_EXECUTION_MODE_NORMAL = 0	# Execute the mission according to the planned items
-uint8 MISSION_EXECUTION_MODE_REVERSE = 1	# Execute the mission in reverse order, ignoring commands and converting all waypoints to normal ones
-uint8 MISSION_EXECUTION_MODE_FAST_FORWARD = 2	# Execute the mission as fast as possible, for example converting loiter waypoints to normal ones
 
 uint32 instance_count		# Instance count of this mission. Increments monotonically whenever the mission is modified
+
+uint64 mission_timestamp
+uint8 mission_dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
 
 int32 seq_reached		# Sequence of the mission item which has been reached, default -1
 uint16 seq_current		# Sequence of the current mission item
 uint16 seq_total		# Total number of mission items
 
+bool active                    # true if mission is currently active (executing)
 bool valid			# true if mission is valid
 bool warning			# true if mission is valid, but has potentially problematic items leading to safety warnings
 bool finished			# true if mission has been completed
 bool failure			# true if the mission cannot continue or be completed for some reason
 
-bool stay_in_failsafe		# true if the commander should not switch out of the failsafe mode
-bool flight_termination		# true if the navigator demands a flight termination from the commander app
-
 bool item_do_jump_changed	# true if the number of do jumps remaining has changed
 uint16 item_changed_index	# indicate which item has changed
 uint16 item_do_jump_remaining	# set to the number of do jumps remaining for that item
+
+uint8 MISSION_EXECUTION_MODE_NORMAL = 0	# Execute the mission according to the planned items
+uint8 MISSION_EXECUTION_MODE_REVERSE = 1	# Execute the mission in reverse order, ignoring commands and converting all waypoints to normal ones
+uint8 MISSION_EXECUTION_MODE_FAST_FORWARD = 2	# Execute the mission as fast as possible, for example converting loiter waypoints to normal ones
 
 uint8 execution_mode	# indicates the mode in which the mission is executed

--- a/msg/navigator_status.msg
+++ b/msg/navigator_status.msg
@@ -1,0 +1,8 @@
+uint64 timestamp				# time since system start (microseconds)
+
+bool finished			# true if mission has been completed
+
+bool flight_termination		# true if the navigator demands a flight termination from the commander app
+
+uint8 nav_state
+uint8 nav_state_prev

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -74,6 +74,7 @@
 #include <uORB/topics/manual_control_switches.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
+#include <uORB/topics/navigator_status.h>
 #include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/power_button_state.h>
@@ -396,6 +397,7 @@ private:
 	uORB::Subscription					_geofence_result_sub{ORB_ID(geofence_result)};
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_land_detector_sub{ORB_ID(vehicle_land_detected)};
+	uORB::Subscription					_navigator_status_sub{ORB_ID(navigator_status)};
 	uORB::Subscription					_safety_sub{ORB_ID(safety)};
 	uORB::Subscription					_manual_control_switches_sub{ORB_ID(manual_control_switches)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -406,7 +406,7 @@ void enable_failsafe(vehicle_status_s *status, bool old_failsafe, orb_advert_t *
  */
 bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_state_s *internal_state,
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
-		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
+		   const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
@@ -543,7 +543,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
-		} else if (!stay_in_failsafe) {
+		} else {
 			// normal mission operation if there's no need to stay in failsafe
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION;
 		}

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -128,7 +128,7 @@ void enable_failsafe(vehicle_status_s *status, bool old_failsafe, orb_advert_t *
 
 bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_state_s *internal_state,
 		   orb_advert_t *mavlink_log_pub, const link_loss_actions_t data_link_loss_act, const bool mission_finished,
-		   const bool stay_in_failsafe, const vehicle_status_flags_s &status_flags, bool landed,
+		   const vehicle_status_flags_s &status_flags, bool landed,
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -134,8 +134,8 @@ GpsFailure::set_gpsf_item()
 	switch (_gpsf_state) {
 	case GPSF_STATE_TERMINATE: {
 			/* Request flight termination from commander */
-			_navigator->get_mission_result()->flight_termination = true;
-			_navigator->set_mission_result_updated();
+			_navigator->navigator_status().flight_termination = true;
+			_navigator->navigator_status_updated();
 			PX4_WARN("GPS failure: request flight termination");
 		}
 		break;

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -51,8 +51,10 @@ Land::on_activation()
 {
 	/* set current mission item to Land */
 	set_land_item(&_mission_item, true);
-	_navigator->get_mission_result()->finished = false;
-	_navigator->set_mission_result_updated();
+
+	_navigator->navigator_status().finished = false;
+	_navigator->navigator_status_updated();
+
 	reset_mission_item_reached();
 
 	/* convert mission item to current setpoint */
@@ -81,8 +83,9 @@ Land::on_active()
 
 
 	if (_navigator->get_land_detected()->landed) {
-		_navigator->get_mission_result()->finished = true;
-		_navigator->set_mission_result_updated();
+		_navigator->navigator_status().finished = true;
+		_navigator->navigator_status_updated();
+
 		set_idle_item(&_mission_item);
 
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -79,6 +79,8 @@ public:
 
 	bool set_current_mission_index(uint16_t index);
 
+	bool mission_valid() const { return _mission_result.valid; }
+
 	bool land_start();
 	bool landing();
 
@@ -103,6 +105,16 @@ public:
 	 * For a list of the different modes refer to mission_result.msg
 	 */
 	void set_execution_mode(const uint8_t mode);
+
+	void set_failure() override
+	{
+		if (!_mission_result.failure) {
+			_mission_result.failure = true;
+
+			_mission_result_updated = true;
+		}
+	}
+
 private:
 
 	/**
@@ -235,6 +247,7 @@ private:
 
 	bool position_setpoint_equal(const position_setpoint_s *p1, const position_setpoint_s *p2) const;
 
+	void publish_mission_result();
 	void publish_navigator_mission_item();
 
 	DEFINE_PARAMETERS(
@@ -243,10 +256,14 @@ private:
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mis_mnt_yaw_ctl
 	)
 
+	uORB::Publication<mission_result_s> _mission_result_pub{ORB_ID::mission_result};
 	uORB::Publication<navigator_mission_item_s> _navigator_mission_item_pub{ORB_ID::navigator_mission_item};
 
 	uORB::Subscription	_mission_sub{ORB_ID(mission)};		/**< mission subscription */
 	mission_s		_mission {};
+
+	mission_result_s _mission_result{};
+	bool _mission_result_updated{false};
 
 	int32_t _current_mission_index{-1};
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -338,7 +338,8 @@ MissionBlock::is_mission_item_reached()
 			    (_navigator->get_yaw_timeout() >= FLT_EPSILON) &&
 			    (now - _time_wp_reached >= (hrt_abstime)_navigator->get_yaw_timeout() * 1e6f)) {
 
-				_navigator->set_mission_failure("unable to reach heading within timeout");
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "unable to reach heading within timeout");
+				set_failure();
 			}
 
 		} else {

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -144,6 +144,8 @@ protected:
 
 	float get_absolute_altitude_for_item(const mission_item_s &mission_item) const;
 
+	virtual void set_failure() {}
+
 	mission_item_s _mission_item{};
 
 	bool _waypoint_position_reached{false};

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -43,6 +43,7 @@
 #pragma once
 
 #include <dataman/dataman.h>
+#include <lib/systemlib/mavlink_log.h>
 #include <uORB/topics/mission.h>
 
 class Geofence;
@@ -50,6 +51,20 @@ class Navigator;
 
 class MissionFeasibilityChecker
 {
+public:
+	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}
+	~MissionFeasibilityChecker() = default;
+
+	MissionFeasibilityChecker(const MissionFeasibilityChecker &) = delete;
+	MissionFeasibilityChecker &operator=(const MissionFeasibilityChecker &) = delete;
+
+	/*
+	 * Returns true if mission is feasible and false otherwise
+	 */
+	bool checkMissionFeasible(const mission_s &mission,
+				  float max_distance_to_1st_waypoint, float max_distance_between_waypoints,
+				  bool land_start_req);
+
 private:
 	Navigator *_navigator{nullptr};
 
@@ -76,18 +91,5 @@ private:
 	bool checkVTOL(const mission_s &mission, float home_alt, bool land_start_req);
 	bool checkVTOLLanding(const mission_s &mission, bool land_start_req);
 
-public:
-	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}
-	~MissionFeasibilityChecker() = default;
-
-	MissionFeasibilityChecker(const MissionFeasibilityChecker &) = delete;
-	MissionFeasibilityChecker &operator=(const MissionFeasibilityChecker &) = delete;
-
-	/*
-	 * Returns true if mission is feasible and false otherwise
-	 */
-	bool checkMissionFeasible(const mission_s &mission,
-				  float max_distance_to_1st_waypoint, float max_distance_between_waypoints,
-				  bool land_start_req);
-
+	orb_advert_t _mavlink_log_pub{nullptr};
 };

--- a/src/modules/navigator/navigator_mode.cpp
+++ b/src/modules/navigator/navigator_mode.cpp
@@ -56,8 +56,7 @@ NavigatorMode::run(bool active)
 	if (active) {
 		if (!_active) {
 			/* first run, reset stay in failsafe flag */
-			_navigator->get_mission_result()->stay_in_failsafe = false;
-			_navigator->set_mission_result_updated();
+			_navigator->navigator_status_updated();
 			on_activation();
 
 		} else {

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -61,9 +61,9 @@ Takeoff::on_active()
 		// reset the position
 		set_takeoff_position();
 
-	} else if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
-		_navigator->get_mission_result()->finished = true;
-		_navigator->set_mission_result_updated();
+	} else if (is_mission_item_reached() && !_navigator->navigator_status().finished) {
+		_navigator->navigator_status().finished = true;
+		_navigator->navigator_status_updated();
 
 		// set loiter item so position controllers stop doing takeoff logic
 		set_loiter_item(&_mission_item);
@@ -120,8 +120,8 @@ Takeoff::set_takeoff_position()
 
 	// set current mission item to takeoff
 	set_takeoff_item(&_mission_item, abs_altitude);
-	_navigator->get_mission_result()->finished = false;
-	_navigator->set_mission_result_updated();
+	_navigator->navigator_status().finished = false;
+	_navigator->navigator_status_updated();
 	reset_mission_item_reached();
 
 	// convert mission item to current setpoint


### PR DESCRIPTION
This is another small step towards turning navigator into a simpler (dumber) mission manager.

The `mission_result` contained a mix of general navigation state feedback and actual mission specifics. Now `mission_result` is dedicated entirely to the actual mission.