### PR TITLE
Added small subset of MISRA C++:2008 rules that can be checked using clang-tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,18 @@ px4_sitl_default-clang:
 	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && cmake "$(SRC_DIR)" $(CMAKE_ARGS) -G"$(PX4_CMAKE_GENERATOR)" -DCONFIG=px4_sitl_default -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 	@$(PX4_MAKE) -C "$(SRC_DIR)"/build/px4_sitl_default-clang
 
+misra-basic: px4_sitl_default-clang
+	@echo "Basic MISRA checks using clang-tidy"
+	@echo "This is not MISRA compliant!!"
+	@echo "Checking Rule 2-13-4: Literal suffixes shall be upper case"
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -checks=-*,readability-uppercase-literal-suffix -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
+	@echo "Checking Rule 5-0-7: There shall be no explicit floating-integral conversions of a cvalue expression"
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -checks=-*,bugprone-integer-division -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
+	@echo "Checking Rule 0–2–1: An object shall not be assigned to an overlapping object"
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -checks=-*,cppcoreguidelines-pro-type-union-access -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
+	@echo "Checking Rule 5–0–15: Array indexing shall be the only form of pointer arithmetic"
+	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -checks=-*,cppcoreguidelines-pro-bounds-pointer-arithmetic -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
+
 clang-tidy: px4_sitl_default-clang
 	@cd "$(SRC_DIR)"/build/px4_sitl_default-clang && "$(SRC_DIR)"/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j_clang_tidy) -p .
 


### PR DESCRIPTION
This is to keep the discussion going that @Igor-Misic started this week, I was thinking we should first try to utilize free OSS to implement some basic MISRA rules checking, before considering commercial tooling.

This patch adds the `make misra-basic` target, that tests some Misra rules using clang-tidy.

This can be extended by CppCheck as well, however CppCheck can't check on rule basis but generates an complete overview. But it's addons module does implement a nice set of Misra C rules see https://github.com/danmar/cppcheck/blob/main/addons/misra.py