### PR TITLE
simple online gyro auto calibration module

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -1000,6 +1000,7 @@ void statusFTDI() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "df"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "dmesg"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "gps status"'
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "gyro_calibration status; param show CAL_GYRO*"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "listener adc_report"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "listener battery_status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "listener cpuload"'
@@ -1062,6 +1063,7 @@ void statusFTDI() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "uorb top -1 -a"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "ver all"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "work_queue status"'
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "gyro_calibration status; param show CAL_GYRO*"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "ekf2 status"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "free"'
   // stop logger

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -505,6 +505,11 @@ else
 		gyro_fft start
 	fi
 
+	if param compare -s IMU_GYRO_CAL_EN 1
+	then
+		gyro_calibration start
+	fi
+
 	#
 	# Optional board supplied extras: rc.board_extras
 	#

--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -61,6 +61,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/atlflight/eagle/default.cmake
+++ b/boards/atlflight/eagle/default.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/atlflight/eagle/qurt.cmake
+++ b/boards/atlflight/eagle/qurt.cmake
@@ -58,6 +58,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/atlflight/excelsior/default.cmake
+++ b/boards/atlflight/excelsior/default.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/atlflight/excelsior/qurt.cmake
+++ b/boards/atlflight/excelsior/qurt.cmake
@@ -58,6 +58,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -61,6 +61,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/beaglebone/blue/default.cmake
+++ b/boards/beaglebone/blue/default.cmake
@@ -43,6 +43,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/cuav/nora/default.cmake
+++ b/boards/cuav/nora/default.cmake
@@ -65,6 +65,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/cubepilot/cubeorange/console.cmake
+++ b/boards/cubepilot/cubeorange/console.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/cubepilot/cubeorange/default.cmake
+++ b/boards/cubepilot/cubeorange/default.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/cubepilot/cubeyellow/console.cmake
+++ b/boards/cubepilot/cubeyellow/console.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/cubepilot/cubeyellow/default.cmake
+++ b/boards/cubepilot/cubeyellow/default.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -44,6 +44,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/holybro/kakutef7/default.cmake
+++ b/boards/holybro/kakutef7/default.cmake
@@ -38,6 +38,7 @@ px4_add_board(
 		#ekf2
 		events
 		flight_mode_manager
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		load_mon

--- a/boards/holybro/pix32v5/default.cmake
+++ b/boards/holybro/pix32v5/default.cmake
@@ -70,6 +70,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -60,6 +60,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/ctrl-zero-f7-oem/default.cmake
+++ b/boards/mro/ctrl-zero-f7-oem/default.cmake
@@ -64,6 +64,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -64,6 +64,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/ctrl-zero-h7-oem/default.cmake
+++ b/boards/mro/ctrl-zero-h7-oem/default.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/ctrl-zero-h7/default.cmake
+++ b/boards/mro/ctrl-zero-h7/default.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/pixracerpro/default.cmake
+++ b/boards/mro/pixracerpro/default.cmake
@@ -65,6 +65,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/x21-777/default.cmake
+++ b/boards/mro/x21-777/default.cmake
@@ -65,6 +65,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/nxp/fmuk66-e/default.cmake
+++ b/boards/nxp/fmuk66-e/default.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/nxp/fmuk66-e/socketcan.cmake
+++ b/boards/nxp/fmuk66-e/socketcan.cmake
@@ -61,6 +61,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/nxp/fmuk66-v3/rtps.cmake
+++ b/boards/nxp/fmuk66-v3/rtps.cmake
@@ -61,6 +61,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/nxp/fmuk66-v3/socketcan.cmake
+++ b/boards/nxp/fmuk66-v3/socketcan.cmake
@@ -61,6 +61,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/nxp/fmurt1062-v1/default.cmake
+++ b/boards/nxp/fmurt1062-v1/default.cmake
@@ -56,6 +56,7 @@ px4_add_board(
 		ekf2
 		events
 		flight_mode_manager
+		#gyro_calibration
 		#gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -50,6 +50,7 @@ px4_add_board(
 		flight_mode_manager
 		#fw_att_control
 		#fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		#landing_target_estimator

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -77,6 +77,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		#landing_target_estimator

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -52,6 +52,7 @@ px4_add_board(
 		#events
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		load_mon

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -43,6 +43,7 @@ px4_add_board(
 		dataman
 		ekf2
 		flight_mode_manager
+		gyro_calibration
 		#gyro_fft
 		#events
 		land_detector

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -74,6 +74,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -70,6 +70,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v4/uavcanv1.cmake
+++ b/boards/px4/fmu-v4/uavcanv1.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v5/ctrlalloc.cmake
+++ b/boards/px4/fmu-v5/ctrlalloc.cmake
@@ -73,6 +73,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v5/debug.cmake
+++ b/boards/px4/fmu-v5/debug.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		#landing_target_estimator

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -53,6 +53,7 @@ px4_add_board(
 		events
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		load_mon

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -64,6 +64,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		#landing_target_estimator

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		#landing_target_estimator

--- a/boards/px4/fmu-v5/uavcanv0periph.cmake
+++ b/boards/px4/fmu-v5/uavcanv0periph.cmake
@@ -73,6 +73,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		#gyro_fft
 		land_detector
 		landing_target_estimator
@@ -129,7 +130,6 @@ px4_add_board(
 		#fake_gyro
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
-		#gyro_fft
 		#hello
 		#hwtest # Hardware test
 		#matlab_csv_serial

--- a/boards/px4/fmu-v5/uavcanv1.cmake
+++ b/boards/px4/fmu-v5/uavcanv1.cmake
@@ -72,6 +72,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator
@@ -129,7 +130,6 @@ px4_add_board(
 		#fake_gyro
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
-		#gyro_fft
 		#hello
 		#hwtest # Hardware test
 		#matlab_csv_serial

--- a/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
+++ b/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v6u/default.cmake
+++ b/boards/px4/fmu-v6u/default.cmake
@@ -65,6 +65,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -69,6 +69,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -42,6 +42,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/sitl/ctrlalloc.cmake
+++ b/boards/px4/sitl/ctrlalloc.cmake
@@ -37,6 +37,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -36,6 +36,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -35,6 +35,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -35,6 +35,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -35,6 +35,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/scumaker/pilotpi/arm64.cmake
+++ b/boards/scumaker/pilotpi/arm64.cmake
@@ -44,6 +44,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/boards/scumaker/pilotpi/default.cmake
+++ b/boards/scumaker/pilotpi/default.cmake
@@ -44,6 +44,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
+		gyro_calibration
 		gyro_fft
 		land_detector
 		landing_target_estimator

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -48,7 +48,7 @@ struct wq_config_t {
 
 namespace wq_configurations
 {
-static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1888, 0}; // PX4 inner loop highest priority
+static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1920, 0}; // PX4 inner loop highest priority
 static constexpr wq_config_t ctrl_alloc{"wq:ctrl_alloc", 9500, 0}; // PX4 control allocation, same priority as rate_ctrl
 
 static constexpr wq_config_t SPI0{"wq:SPI0", 2336, -1};
@@ -88,7 +88,7 @@ static constexpr wq_config_t UART7{"wq:UART7", 1400, -28};
 static constexpr wq_config_t UART8{"wq:UART8", 1400, -29};
 static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1400, -30};
 
-static constexpr wq_config_t lp_default{"wq:lp_default", 1700, -50};
+static constexpr wq_config_t lp_default{"wq:lp_default", 1920, -50};
 
 static constexpr wq_config_t test1{"wq:test1", 2000, 0};
 static constexpr wq_config_t test2{"wq:test2", 2000, 0};

--- a/src/lib/mathlib/math/WelfordMean.hpp
+++ b/src/lib/mathlib/math/WelfordMean.hpp
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file WelfordMean.hpp
+ *
+ * Welford's online algorithm for computing mean and variance.
+ */
+
+#pragma once
+
+namespace math
+{
+
+template<typename T>
+class WelfordMean
+{
+public:
+	// For a new value, compute the new count, new mean, the new M2.
+	void update(const T &new_value)
+	{
+		if (_count == 0) {
+			_mean = new_value;
+		}
+
+		_count++;
+
+		// mean accumulates the mean of the entire dataset
+		const T delta{new_value - _mean};
+		_mean += delta / _count;
+
+		// M2 aggregates the squared distance from the mean
+		// count aggregates the number of samples seen so far
+		_M2 += delta.emult(new_value - _mean);
+	}
+
+	bool valid() const { return _count > 2; }
+	unsigned count() const { return _count; }
+
+	void reset()
+	{
+		_count = 0;
+		_mean = {};
+		_M2 = {};
+	}
+
+	// Retrieve the mean, variance and sample variance
+	T mean() const { return _mean; }
+	T variance() const { return _M2 / _count; }
+	T sample_variance() const { return _M2 / (_count - 1); }
+private:
+	T _mean{};
+	T _M2{};
+	unsigned _count{0};
+};
+
+} // namespace math

--- a/src/lib/sensor_calibration/Gyroscope.hpp
+++ b/src/lib/sensor_calibration/Gyroscope.hpp
@@ -73,6 +73,7 @@ public:
 	const int32_t &priority() const { return _priority; }
 	const matrix::Dcmf &rotation() const { return _rotation; }
 	const Rotation &rotation_enum() const { return _rotation_enum; }
+	const matrix::Vector3f &thermal_offset() const { return _thermal_offset; }
 
 	// apply offsets and scale
 	// rotate corrected measurements from sensor to body frame

--- a/src/modules/gyro_calibration/CMakeLists.txt
+++ b/src/modules/gyro_calibration/CMakeLists.txt
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE modules__gyro_calibration
+	MAIN gyro_calibration
+	COMPILE_FLAGS
+	SRCS
+		GyroCalibration.cpp
+		GyroCalibration.hpp
+	DEPENDS
+		px4_work_queue
+	)

--- a/src/modules/gyro_calibration/GyroCalibration.cpp
+++ b/src/modules/gyro_calibration/GyroCalibration.cpp
@@ -1,0 +1,328 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "GyroCalibration.hpp"
+
+#include <lib/ecl/geo/geo.h>
+
+using namespace time_literals;
+using matrix::Vector3f;
+
+GyroCalibration::GyroCalibration() :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::lp_default)
+{
+}
+
+GyroCalibration::~GyroCalibration()
+{
+	perf_free(_loop_interval_perf);
+	perf_free(_calibration_updated_perf);
+}
+
+bool GyroCalibration::init()
+{
+	ScheduleOnInterval(INTERVAL_US);
+	return true;
+}
+
+void GyroCalibration::Run()
+{
+	if (should_exit()) {
+		ScheduleClear();
+		exit_and_cleanup();
+		return;
+	}
+
+	perf_count(_loop_interval_perf);
+
+	if (_vehicle_status_sub.updated()) {
+		vehicle_status_s vehicle_status;
+
+		if (_vehicle_status_sub.copy(&vehicle_status)) {
+			const bool armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+
+			if (armed != _armed) {
+				if (!_armed && armed) {
+					// disarmed -> armed: run at minimal rate until disarmed
+					ScheduleOnInterval(10_s);
+
+				} else if (_armed && !armed) {
+					// armed -> disarmed: start running again
+					ScheduleOnInterval(INTERVAL_US);
+				}
+
+				_armed = armed;
+				Reset();
+			}
+		}
+	}
+
+	if (_armed) {
+		// do nothing if armed
+		return;
+	}
+
+	if (_vehicle_status_flags_sub.updated()) {
+		vehicle_status_flags_s vehicle_status_flags;
+
+		if (_vehicle_status_flags_sub.copy(&vehicle_status_flags)) {
+			if (_system_calibrating != vehicle_status_flags.condition_calibration_enabled) {
+				Reset();
+				_system_calibrating = vehicle_status_flags.condition_calibration_enabled;
+			}
+		}
+	}
+
+	if (_system_calibrating) {
+		// do nothing if system is calibrating
+		return;
+	}
+
+
+	// Check if parameters have changed
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s param_update;
+
+		if (_parameter_update_sub.copy(&param_update)) {
+			// minimize updates immediately following parameter changes
+			_last_calibration_update = param_update.timestamp;
+		}
+
+		for (auto &cal : _gyro_calibration) {
+			cal.ParametersUpdate();
+		}
+	}
+
+
+	// collect raw data from all available gyroscopes (sensor_gyro)
+	for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
+		sensor_gyro_s sensor_gyro;
+
+		while (_sensor_gyro_subs[gyro].update(&sensor_gyro)) {
+			if (PX4_ISFINITE(sensor_gyro.temperature)) {
+				if ((fabsf(_temperature[gyro] - sensor_gyro.temperature) > 1.f) || !PX4_ISFINITE(_temperature[gyro])) {
+					PX4_DEBUG("gyro %d temperature change, resetting all %.6f -> %.6f", gyro, (double)_temperature[gyro],
+						  (double)sensor_gyro.temperature);
+
+					_temperature[gyro] = sensor_gyro.temperature;
+
+					// reset all on any temperature change
+					Reset();
+				}
+
+			} else {
+				_temperature[gyro] = NAN;
+			}
+
+			if (_gyro_calibration[gyro].device_id() == sensor_gyro.device_id) {
+				const Vector3f val{Vector3f{sensor_gyro.x, sensor_gyro.y, sensor_gyro.z} - _gyro_calibration[gyro].thermal_offset()};
+				_gyro_mean[gyro].update(val);
+
+			} else {
+				// setting device id, reset all
+				_gyro_calibration[gyro].set_device_id(sensor_gyro.device_id);
+				Reset();
+			}
+		}
+	}
+
+
+	// check all accelerometers for possible movement
+	for (int accel = 0; accel < _sensor_accel_subs.size(); accel++) {
+		sensor_accel_s sensor_accel;
+
+		if (_sensor_accel_subs[accel].update(&sensor_accel)) {
+			const Vector3f acceleration{sensor_accel.x, sensor_accel.y, sensor_accel.z};
+
+			if ((acceleration - _acceleration[accel]).longerThan(0.5f)) {
+				// reset all on any change
+				PX4_DEBUG("accel %d changed, resetting all %.5f", accel, (double)(acceleration - _acceleration[accel]).length());
+
+				_acceleration[accel] = acceleration;
+				Reset();
+				return;
+
+			} else if (acceleration.longerThan(CONSTANTS_ONE_G * 1.3f)) {
+				Reset();
+				return;
+			}
+		}
+	}
+
+
+	// check if sufficient data has been gathered to update calibration
+	bool sufficient_samples = false;
+
+	for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
+		if (_gyro_calibration[gyro].device_id() != 0) {
+			// periodically check variance
+			if ((_gyro_mean[gyro].count() % 100 == 0)) {
+				PX4_DEBUG("gyro %d (%d) variance, [%.9f, %.9f, %.9f] %.9f", gyro, _gyro_calibration[gyro].device_id(),
+					  (double)_gyro_mean[gyro].variance()(0), (double)_gyro_mean[gyro].variance()(1), (double)_gyro_mean[gyro].variance()(2),
+					  (double)_gyro_mean[gyro].variance().length());
+
+				if (_gyro_mean[gyro].variance().longerThan(0.001f)) {
+					// reset all
+					Reset();
+					return;
+				}
+			}
+
+			if (_gyro_mean[gyro].count() > 3000) {
+				sufficient_samples = true;
+
+			} else {
+				sufficient_samples = false;
+				return;
+			}
+		}
+	}
+
+
+	// update calibrations for all available gyros
+	if (sufficient_samples && (hrt_elapsed_time(&_last_calibration_update) > 10_s)) {
+		bool calibration_updated = false;
+
+		for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
+			if (_gyro_calibration[gyro].device_id() != 0) {
+				_gyro_calibration[gyro].set_calibration_index(gyro);
+
+				const Vector3f old_offset{_gyro_calibration[gyro].offset()};
+
+				if (_gyro_calibration[gyro].set_offset(_gyro_mean[gyro].mean())) {
+					calibration_updated = true;
+
+					PX4_INFO("gyro %d (%d) updating calibration, [%.4f, %.4f, %.4f] -> [%.4f, %.4f, %.4f] %.1f°C",
+						 gyro, _gyro_calibration[gyro].device_id(),
+						 (double)old_offset(0), (double)old_offset(1), (double)old_offset(2),
+						 (double)_gyro_mean[gyro].mean()(0), (double)_gyro_mean[gyro].mean()(1), (double)_gyro_mean[gyro].mean()(2),
+						 (double)_temperature[gyro]);
+
+					perf_count(_calibration_updated_perf);
+				}
+			}
+		}
+
+		// save all calibrations
+		if (calibration_updated) {
+			bool param_save = false;
+
+			for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
+				if (_gyro_calibration[gyro].device_id() != 0) {
+					if (_gyro_calibration[gyro].ParametersSave()) {
+						param_save = true;
+					}
+				}
+			}
+
+			if (param_save) {
+				param_notify_changes();
+				_last_calibration_update = hrt_absolute_time();
+			}
+		}
+
+		Reset();
+	}
+}
+
+int GyroCalibration::task_spawn(int argc, char *argv[])
+{
+	GyroCalibration *instance = new GyroCalibration();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int GyroCalibration::print_status()
+{
+	for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
+		if (_gyro_calibration[gyro].device_id() != 0) {
+			PX4_INFO_RAW("gyro %d (%d), [%.5f, %.5f, %.5f] var: [%.9f, %.9f, %.9f] %.1f°C (count %d)\n",
+				     gyro, _gyro_calibration[gyro].device_id(),
+				     (double)_gyro_mean[gyro].mean()(0), (double)_gyro_mean[gyro].mean()(1), (double)_gyro_mean[gyro].mean()(2),
+				     (double)_gyro_mean[gyro].variance()(0), (double)_gyro_mean[gyro].variance()(1), (double)_gyro_mean[gyro].variance()(2),
+				     (double)_temperature[gyro], _gyro_mean[gyro].count());
+		}
+	}
+
+	perf_print_counter(_loop_interval_perf);
+	perf_print_counter(_calibration_updated_perf);
+	return 0;
+}
+
+int GyroCalibration::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int GyroCalibration::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+Simple online gyroscope calibration.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("gyro_calibration", "system");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int gyro_calibration_main(int argc, char *argv[])
+{
+	return GyroCalibration::main(argc, argv);
+}

--- a/src/modules/gyro_calibration/GyroCalibration.hpp
+++ b/src/modules/gyro_calibration/GyroCalibration.hpp
@@ -1,0 +1,108 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <drivers/drv_hrt.h>
+#include <lib/mathlib/math/WelfordMean.hpp>
+#include <lib/perf/perf_counter.h>
+#include <lib/sensor_calibration/Gyroscope.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_status_flags.h>
+
+using namespace time_literals;
+
+class GyroCalibration : public ModuleBase<GyroCalibration>, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	GyroCalibration();
+	~GyroCalibration() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+	int print_status() override;
+
+private:
+	static constexpr hrt_abstime INTERVAL_US = 20000_us;
+	static constexpr int MAX_SENSORS = 4;
+
+	void Run() override;
+
+	void Reset()
+	{
+		for (auto &m : _gyro_mean) {
+			m.reset();
+		}
+	}
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_status_sub{ORB_ID::vehicle_status};
+	uORB::Subscription _vehicle_status_flags_sub{ORB_ID::vehicle_status_flags};
+
+	uORB::SubscriptionMultiArray<sensor_accel_s, MAX_SENSORS> _sensor_accel_subs{ORB_ID::sensor_accel};
+	uORB::SubscriptionMultiArray<sensor_gyro_s, MAX_SENSORS>  _sensor_gyro_subs{ORB_ID::sensor_gyro};
+
+	calibration::Gyroscope _gyro_calibration[MAX_SENSORS] {};
+	math::WelfordMean<matrix::Vector3f> _gyro_mean[MAX_SENSORS] {};
+	float _temperature[MAX_SENSORS] {};
+
+	matrix::Vector3f _acceleration[MAX_SENSORS] {};
+
+	hrt_abstime _last_calibration_update{0};
+
+	bool _armed{false};
+	bool _system_calibrating{false};
+
+	perf_counter_t _loop_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": interval")};
+	perf_counter_t _calibration_updated_perf{perf_alloc(PC_COUNT, MODULE_NAME": calibration updated")};
+};

--- a/src/modules/gyro_calibration/parameters.c
+++ b/src/modules/gyro_calibration/parameters.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+* IMU gyro auto calibration enable.
+*
+* @boolean
+* @reboot_required true
+* @group Sensors
+*/
+PARAM_DEFINE_INT32(IMU_GYRO_CAL_EN, 1);


### PR DESCRIPTION
This is a new module that automatically calibrates all available gyros when disarmed and still. Although convenient, the motivation isn't to save users the 5 seconds it normally takes to click calibrate, but to automatically handle ZRO variation and thermal drift right up to operation. This provides the best of both worlds, typically zeroing gyros before most usage, but not strictly requiring it (boats, etc).

The module monitors all available gyroscopes (and accelerometers) and calculates an online mean for each. There must be no movement or temperature change across all sensors simultaneously for several thousand consecutive samples (a few seconds) when determining any new gyro offset. It's more conservative than the manual gyro calibration. 

``` Console
INFO  [gyro_calibration] gyro 0 (3670026) updating calibration, [0.0000, 0.0000, 0.0000] -> [0.0022, -0.0164, 0.0061] 36.1 °C
INFO  [gyro_calibration] gyro 1 (3932170) updating calibration, [0.0000, 0.0000, 0.0000] -> [0.0048, 0.0196, -0.0024] 35.8 °C
INFO  [gyro_calibration] gyro 2 (4325386) updating calibration, [0.0000, 0.0000, 0.0000] -> [0.0013, 0.0045, 0.0019] nan °C
INFO  [ekf2] 0 - resetting IMU bias
INFO  [ekf2] 4 - resetting IMU bias
INFO  [ekf2] 2 - resetting IMU bias
INFO  [ekf2] 5 - resetting IMU bias
INFO  [ekf2] 1 - resetting IMU bias
INFO  [ekf2] 3 - resetting IMU bias

```


``` Console
nsh> gyro_calibration status
gyro 0 (3670026), [0.00220, -0.01651, 0.00621] var: [0.000010790, 0.000006699, 0.000007130] 36.1 °C (count 2408)
gyro 1 (3932170), [0.00461, 0.01957, -0.00252] var: [0.000006456, 0.000014577, 0.000004577] 35.8 °C (count 2401)
gyro 2 (4325386), [0.00095, 0.00457, 0.00185] var: [0.000152278, 0.000119887, 0.000165898] nan °C (count 2398)
gyro_calibration: interval: 1154 events, 19999.97us avg, min 7261us max 38351us 1180.224us rms
gyro_calibration: calibration updated: 3 events
```