### PR TITLE
change typhoon_h480 roll-/pitchrate P gain to reduce oscillations

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
@@ -9,11 +9,11 @@
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_PITCHRATE_P 0.1000
+	param set MC_PITCHRATE_P 0.0800
 	param set MC_PITCHRATE_I 0.0400
 	param set MC_PITCHRATE_D 0.0010
 	param set MC_PITCH_P 9.0
-	param set MC_ROLLRATE_P 0.1000
+	param set MC_ROLLRATE_P 0.0800
 	param set MC_ROLLRATE_I 0.0400
 	param set MC_ROLLRATE_D 0.0010
 	param set MC_ROLL_P 9.0


### PR DESCRIPTION
**Describe problem solved by this pull request**
Starting up the typhoon_h480 gazebo simulation model (on latest master) resulted in huge roll and pitch oscillations. Retuning the roll-/pitchrate p gain helped achieving nicer flying behavior. 

**Describe your solution**
Change of roll-/pitchrate p gain for the typhoon_h480 model

**Describe possible alternatives**
none

**Test data / coverage**
As an example just the Roll-Axis:
As it was: [link to ulog](https://review.px4.io/plot_app?log=69b6d790-1d34-4d5d-ab99-daf9d3d6204a)
![image](https://user-images.githubusercontent.com/17237189/110247269-af0c9e00-7f6b-11eb-946d-ab53397f68da.png)

Tuned: [link to ulog](https://review.px4.io/plot_app?log=75bb8db5-87ff-45e9-a75b-81e51c7dec5a)
![image](https://user-images.githubusercontent.com/17237189/110247306-e5e2b400-7f6b-11eb-9ba4-eeaa29d2ce23.png)

Its not perfectly tuned, but it more or less flies nicely in the simulation. 

**Additional context**
-
