### PR TITLE
[UAVCANv1] Added the notion of BaseSubscriber

### DIFF
--- a/src/drivers/uavcan_v1/ServiceClients/Access.hpp
+++ b/src/drivers/uavcan_v1/ServiceClients/Access.hpp
@@ -1,0 +1,134 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file Access.hpp
+ *
+ * Defines response to a Access request
+ *
+ * @author Peter van der Perk <peter.vanderperk@nxp.com>
+ */
+
+#pragma once
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/module.h>
+#include <version/version.h>
+
+#include "../ParamManager.hpp"
+
+#include <uavcan/node/ID_1_0.h>
+#include <uavcan/node/GetInfo_1_0.h>
+
+#include "../Subscribers/BaseSubscriber.hpp"
+
+class UavcanAccessResponse : public UavcanBaseSubscriber
+{
+public:
+	UavcanAccessResponse(CanardInstance &ins, UavcanParamManager &pmgr) :
+		UavcanBaseSubscriber(ins, "Access", 0),  _param_manager(pmgr) { };
+
+	void subscribe() override
+	{
+		// Subscribe to requests uavcan.pnp.NodeIDAllocationData
+		canardRxSubscribe(&_canard_instance,
+				  CanardTransferKindRequest,
+				  uavcan_register_Access_1_0_FIXED_PORT_ID_,
+				  uavcan_register_Access_Response_1_0_EXTENT_BYTES_,
+				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
+				  &_canard_sub);
+
+		_port_id = uavcan_register_Access_1_0_FIXED_PORT_ID_;
+
+	};
+
+	void callback(const CanardTransfer &receive) override
+	{
+		PX4_INFO("Access request");
+
+		uavcan_register_Access_Request_1_0 msg;
+		uavcan_register_Access_Request_1_0_initialize_(&msg);
+
+		size_t register_in_size_bits = receive.payload_size;
+		uavcan_register_Access_Request_1_0_deserialize_(&msg, (const uint8_t *)receive.payload, &register_in_size_bits);
+
+		int result {0};
+
+		uavcan_register_Value_1_0 value = msg.value;
+		uavcan_register_Name_1_0 name = msg.name;
+
+		/// TODO: get/set parameter based on whether empty or not
+		if (uavcan_register_Value_1_0_is_empty_(&value)) { // Tag Type: uavcan_primitive_Empty_1_0
+			// Value is empty -- 'Get' only
+			result = _param_manager.GetParamByName(name, value) ? 0 : -1;
+
+		} else {
+			// Set value
+			result = _param_manager.SetParamByName(name, value) ? 0 : -1;
+
+		}
+
+		/// TODO: Access_Response
+		uavcan_register_Access_Response_1_0 response {};
+		response.value = value;
+
+		uint8_t response_payload_buffer[uavcan_register_Access_Response_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_];
+
+		CanardTransfer transfer = {
+			.timestamp_usec = hrt_absolute_time(),      // Zero if transmission deadline is not limited.
+			.priority       = CanardPriorityNominal,
+			.transfer_kind  = CanardTransferKindResponse,
+			.port_id        = uavcan_register_Access_1_0_FIXED_PORT_ID_,                // This is the subject-ID.
+			.remote_node_id = receive.remote_node_id,       // Messages cannot be unicast, so use UNSET.
+			.transfer_id    = access_response_transfer_id, /// TODO: track register Access _response_ separately?
+			.payload_size   = uavcan_register_Access_Response_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_,
+			.payload        = &response_payload_buffer,
+		};
+
+		result = uavcan_register_Access_Response_1_0_serialize_(&response, response_payload_buffer, &transfer.payload_size);
+
+		if (result == 0) {
+			// set the data ready in the buffer and chop if needed
+			++access_response_transfer_id;  // The transfer-ID shall be incremented after every transmission on this subject.
+			result = canardTxPush(&_canard_instance, &transfer);
+		}
+
+		//return result;
+
+	};
+
+private:
+	UavcanParamManager &_param_manager;
+	CanardTransferID access_response_transfer_id = 0;
+
+};

--- a/src/drivers/uavcan_v1/ServiceClients/GetInfo.hpp
+++ b/src/drivers/uavcan_v1/ServiceClients/GetInfo.hpp
@@ -1,0 +1,147 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file GetInfo.hpp
+ *
+ * Defines response to a GetInfo request
+ *
+ * @author Peter van der Perk <peter.vanderperk@nxp.com>
+ */
+
+#pragma once
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/module.h>
+#include <version/version.h>
+
+#include "../NodeManager.hpp"
+
+#include <uavcan/node/ID_1_0.h>
+#include <uavcan/node/GetInfo_1_0.h>
+
+#include "../Subscribers/BaseSubscriber.hpp"
+
+class UavcanGetInfoResponse : public UavcanBaseSubscriber
+{
+public:
+	UavcanGetInfoResponse(CanardInstance &ins) :
+		UavcanBaseSubscriber(ins, "GetInfo", 0) { };
+
+	void subscribe() override
+	{
+		// Subscribe to requests uavcan.pnp.NodeIDAllocationData
+		canardRxSubscribe(&_canard_instance,
+				  CanardTransferKindRequest,
+				  uavcan_node_GetInfo_1_0_FIXED_PORT_ID_,
+				  uavcan_node_GetInfo_Request_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_,
+				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
+				  &_canard_sub);
+
+		_port_id = uavcan_node_GetInfo_1_0_FIXED_PORT_ID_;
+
+	};
+
+	void callback(const CanardTransfer &receive) override
+	{
+		PX4_INFO("GetInfo request");
+
+		// Setup node.GetInfo response
+
+		uavcan_node_GetInfo_Response_1_0 node_info;
+
+		uavcan_node_GetInfo_Response_1_0_initialize_(&node_info);
+
+		node_info.protocol_version.major = 1;
+		node_info.protocol_version.minor = 0;
+
+#if defined(BOARD_HAS_VERSIONING)
+		node_info.hardware_version.major = (uint8_t)px4_board_hw_version();
+		node_info.hardware_version.minor = (uint8_t)px4_board_hw_revision();
+#endif
+
+		unsigned fwver = px4_firmware_version();
+		node_info.software_version.major = (fwver >> (8 * 3)) & 0xFF;
+		node_info.software_version.minor = (fwver >> (8 * 2)) & 0xFF;
+
+		node_info.software_vcs_revision_id = px4_firmware_version_binary();
+
+		px4_guid_t px4_guid;
+		board_get_px4_guid(px4_guid);
+		memcpy(node_info.unique_id, px4_guid, sizeof(node_info.unique_id));
+
+		//TODO proper name
+		strncpy((char *)node_info.name.elements,
+			px4_board_name(),
+			uavcan_node_GetInfo_Response_1_0_name_ARRAY_CAPACITY_);
+
+		node_info.name.count = strlen(px4_board_name());
+
+		uint8_t response_payload_buffer[uavcan_node_GetInfo_Response_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_];
+
+		CanardMicrosecond transmission_deadline = hrt_absolute_time() + 1000 * 100;
+
+		CanardTransfer response = {
+			.timestamp_usec = transmission_deadline, // Zero if transmission deadline is not limited.
+			.priority       = CanardPriorityNominal,
+			.transfer_kind  = CanardTransferKindResponse,
+			.port_id        = uavcan_node_GetInfo_1_0_FIXED_PORT_ID_, // This is the subject-ID.
+			.remote_node_id = receive.remote_node_id,       // Send back to request Node
+			.transfer_id    = getinfo_response_transfer_id,
+			.payload_size   = uavcan_node_GetInfo_Response_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_,
+			.payload        = &response_payload_buffer,
+		};
+
+		int32_t result = uavcan_node_GetInfo_Response_1_0_serialize_(&node_info, (uint8_t *)&response_payload_buffer,
+				 &response.payload_size);
+
+		if (result == 0) {
+			// set the data ready in the buffer and chop if needed
+			++getinfo_response_transfer_id;  // The transfer-ID shall be incremented after every transmission on this subject.
+			result = canardTxPush(&_canard_instance, &response);
+		}
+
+		//TODO proper error handling
+		if (result < 0) {
+			// An error has occurred: either an argument is invalid or we've ran out of memory.
+			// It is possible to statically prove that an out-of-memory will never occur for a given application if the
+			// heap is sized correctly; for background, refer to the Robson's Proof and the documentation for O1Heap.
+			// return -UAVCAN_REGISTER_ERROR_SERIALIZATION;
+		}
+
+	};
+
+private:
+	CanardTransferID getinfo_response_transfer_id = 0;
+
+};

--- a/src/drivers/uavcan_v1/Services/AccessRequest.hpp
+++ b/src/drivers/uavcan_v1/Services/AccessRequest.hpp
@@ -1,0 +1,94 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file Access.hpp
+ *
+ * Defines a Access Service invoker and process Access responses
+ *
+ * @author Peter van der Perk <peter.vanderperk@nxp.com>
+ */
+
+#pragma once
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/module.h>
+#include <version/version.h>
+
+#include <uavcan/_register/Access_1_0.h>
+
+class UavcanAccessServiceRequest
+{
+public:
+	UavcanAccessServiceRequest(CanardInstance &ins) :
+		_canard_instance(ins) { };
+
+	void setPortId(CanardNodeID node_id, const char *register_name, uint16_t port_id)
+	{
+		int result {0};
+
+		uavcan_register_Access_Request_1_0 request_msg;
+		strncpy((char *)&request_msg.name.name.elements[0], register_name, sizeof(uavcan_register_Name_1_0));
+		request_msg.name.name.count = strlen(register_name);
+
+		uavcan_register_Value_1_0_select_natural16_(&request_msg.value);
+		request_msg.value.natural16.value.count = 1;
+		request_msg.value.natural16.value.elements[0] = port_id;
+
+		uint8_t request_payload_buffer[uavcan_register_Access_Request_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_];
+
+		CanardTransfer transfer = {
+			.timestamp_usec = hrt_absolute_time(),      // Zero if transmission deadline is not limited.
+			.priority       = CanardPriorityNominal,
+			.transfer_kind  = CanardTransferKindRequest,
+			.port_id        = uavcan_register_Access_1_0_FIXED_PORT_ID_,                // This is the subject-ID.
+			.remote_node_id = node_id,       // Messages cannot be unicast, so use UNSET.
+			.transfer_id    = access_request_transfer_id,
+			.payload_size   = uavcan_register_Access_Request_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_,
+			.payload        = &request_payload_buffer,
+		};
+
+		result = uavcan_register_Access_Request_1_0_serialize_(&request_msg, request_payload_buffer, &transfer.payload_size);
+
+		if (result == 0) {
+			// set the data ready in the buffer and chop if needed
+			++access_request_transfer_id;  // The transfer-ID shall be incremented after every transmission on this subject.
+			result = canardTxPush(&_canard_instance, &transfer);
+		}
+	};
+
+private:
+	CanardInstance &_canard_instance;
+	CanardTransferID access_request_transfer_id = 0;
+
+};

--- a/src/drivers/uavcan_v1/Services/ListReply.hpp
+++ b/src/drivers/uavcan_v1/Services/ListReply.hpp
@@ -32,65 +32,59 @@
  ****************************************************************************/
 
 /**
- * @file NodeManager.hpp
+ * @file List.hpp
  *
- * Defines basic implementation of UAVCAN PNP for dynamic Node ID
+ * Defines a List Service invoker and process List responses
  *
  * @author Peter van der Perk <peter.vanderperk@nxp.com>
  */
 
 #pragma once
 
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/module.h>
+#include <version/version.h>
 
-#include <px4_platform_common/defines.h>
-#include <drivers/drv_hrt.h>
+#include "../NodeManager.hpp"
 
-#include "CanardInterface.hpp"
+#include <uavcan/_register/List_1_0.h>
 
-#include <uavcan/node/ID_1_0.h>
-#include <uavcan/pnp/NodeIDAllocationData_1_0.h>
-#include <uavcan/pnp/NodeIDAllocationData_2_0.h>
+#include "../Subscribers/BaseSubscriber.hpp"
 
-
-class NodeManager;
-
-#include "Services/AccessRequest.hpp"
-#include "Services/ListRequest.hpp"
-
-//TODO make this an object instead?
-typedef struct {
-	uint8_t   node_id;
-	uint8_t   unique_id[16];
-	bool      register_setup;
-	uint16_t  register_index;
-} UavcanNodeEntry;
-
-class NodeManager
+class UavcanListServiceReply : public UavcanBaseSubscriber
 {
 public:
-	NodeManager(CanardInstance &ins) : _canard_instance(ins), _access_request(ins), _list_request(ins) { };
+	UavcanListServiceReply(CanardInstance &ins, NodeManager &nmgr) :
+		UavcanBaseSubscriber(ins, "List", 0), _nmgr(nmgr) { };
 
-	bool HandleNodeIDRequest(uavcan_pnp_NodeIDAllocationData_1_0 &msg);
-	bool HandleNodeIDRequest(uavcan_pnp_NodeIDAllocationData_2_0 &msg);
+	void subscribe() override
+	{
+		// Subscribe to requests uavcan.pnp.NodeIDAllocationData
+		canardRxSubscribe(&_canard_instance,
+				  CanardTransferKindResponse,
+				  uavcan_register_List_1_0_FIXED_PORT_ID_,
+				  uavcan_register_List_Response_1_0_EXTENT_BYTES_,
+				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
+				  &_canard_sub);
 
+		_port_id = uavcan_register_List_1_0_FIXED_PORT_ID_;
 
-	void HandleListResponse(CanardNodeID node_id, uavcan_register_List_Response_1_0 &msg);
+	};
 
-	void update();
+	void callback(const CanardTransfer &receive) override
+	{
+		PX4_INFO("List response");
+
+		uavcan_register_List_Response_1_0 msg;
+
+		size_t register_in_size_bits = receive.payload_size;
+		uavcan_register_List_Response_1_0_deserialize_(&msg, (const uint8_t *)receive.payload, &register_in_size_bits);
+
+		// Pass msg.name.name.elements to NodeManager
+		_nmgr.HandleListResponse(receive.remote_node_id, msg);
+	};
 
 private:
-	CanardInstance &_canard_instance;
-	CanardTransferID _uavcan_pnp_nodeidallocation_v1_transfer_id{0};
-	UavcanNodeEntry nodeid_registry[16] {0}; //TODO configurable or just rewrite
+	NodeManager &_nmgr;
 
-	UavcanAccessServiceRequest _access_request;
-	UavcanListServiceRequest _list_request;
-
-	bool nodeRegisterSetup = 0;
-
-	hrt_abstime _register_request_last{0};
-
-	//TODO work this out
-	const char *gps_uorb_register_name = "uavcan.pub.gnss_uorb.id";
-	const char *bms_status_register_name = "uavcan.pub.battery_status.id";
 };

--- a/src/drivers/uavcan_v1/Subscribers/BaseSubscriber.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/BaseSubscriber.hpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file Subscriber.hpp
+ * @file BaseSubscriber.hpp
  *
  * Defines basic functionality of UAVCAN v1 subscriber class
  *
@@ -45,18 +45,15 @@
 
 #include <lib/parameters/param.h>
 
-#include <uavcan/_register/Access_1_0.h>
-
 #include "../CanardInterface.hpp"
-#include "../ParamManager.hpp"
 
-class UavcanSubscriber
+class UavcanBaseSubscriber
 {
 public:
 	static constexpr uint16_t CANARD_PORT_ID_UNSET = 65535U;
 
-	UavcanSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, const char *subject_name, uint8_t instance = 0) :
-		_canard_instance(ins), _param_manager(pmgr), _subject_name(subject_name), _instance(instance) { };
+	UavcanBaseSubscriber(CanardInstance &ins, const char *subject_name, uint8_t instance = 0) :
+		_canard_instance(ins), _subject_name(subject_name), _instance(instance) { };
 
 	virtual void subscribe() = 0;
 	virtual void unsubscribe() { canardRxUnsubscribe(&_canard_instance, CanardTransferKindMessage, _port_id); };
@@ -64,35 +61,6 @@ public:
 	virtual void callback(const CanardTransfer &msg) = 0;
 
 	CanardPortID id() { return _port_id; };
-
-	void updateParam()
-	{
-		char uavcan_param[90];
-		sprintf(uavcan_param, "uavcan.sub.%s.%d.id", _subject_name, _instance);
-
-		// Set _port_id from _uavcan_param
-		uavcan_register_Value_1_0 value;
-		_param_manager.GetParamByName(uavcan_param, value);
-		int32_t new_id = value.integer32.value.elements[0];
-
-		if (_port_id != new_id) {
-			if (new_id == CANARD_PORT_ID_UNSET) {
-				// Cancel subscription
-				unsubscribe();
-
-			} else {
-				if (_port_id != CANARD_PORT_ID_UNSET) {
-					// Already active; unsubscribe first
-					unsubscribe();
-				}
-
-				// Subscribe on the new port ID
-				_port_id = (CanardPortID)new_id;
-				PX4_INFO("Subscribing %s.%d on port %d", _subject_name, _instance, _port_id);
-				subscribe();
-			}
-		}
-	};
 
 	void printInfo()
 	{
@@ -103,7 +71,6 @@ public:
 
 protected:
 	CanardInstance &_canard_instance;
-	UavcanParamManager &_param_manager;
 	CanardRxSubscription _canard_sub;
 	const char *_subject_name;
 	uint8_t _instance {0};

--- a/src/drivers/uavcan_v1/Subscribers/Battery.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/Battery.hpp
@@ -45,13 +45,13 @@
 #include <reg/drone/service/battery/Parameters_0_1.h>
 #include <reg/drone/service/battery/Status_0_1.h>
 
-#include "Subscriber.hpp"
+#include "DynamicPortSubscriber.hpp"
 
-class UavcanBmsSubscriber : public UavcanSubscriber
+class UavcanBmsSubscriber : public UavcanDynamicPortSubscriber
 {
 public:
 	UavcanBmsSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
-		UavcanSubscriber(ins, pmgr, "bms", instance) { };
+		UavcanDynamicPortSubscriber(ins, pmgr, "bms", instance) { };
 
 	void subscribe() override
 	{

--- a/src/drivers/uavcan_v1/Subscribers/Esc.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/Esc.hpp
@@ -49,13 +49,13 @@
 #include <reg/drone/service/actuator/common/sp/Vector8_0_1.h>
 #include <reg/drone/service/common/Readiness_0_1.h>
 
-#include "Subscriber.hpp"
+#include "DynamicPortSubscriber.hpp"
 
-class UavcanEscSubscriber : public UavcanSubscriber
+class UavcanEscSubscriber : public UavcanDynamicPortSubscriber
 {
 public:
 	UavcanEscSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
-		UavcanSubscriber(ins, pmgr, "esc", instance) { };
+		UavcanDynamicPortSubscriber(ins, pmgr, "esc", instance) { };
 
 	void subscribe() override
 	{

--- a/src/drivers/uavcan_v1/Subscribers/Gnss.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/Gnss.hpp
@@ -44,13 +44,13 @@
 // DS-15 Specification Messages
 #include <reg/drone/physics/kinematics/geodetic/Point_0_1.h>
 
-#include "Subscriber.hpp"
+#include "DynamicPortSubscriber.hpp"
 
-class UavcanGnssSubscriber : public UavcanSubscriber
+class UavcanGnssSubscriber : public UavcanDynamicPortSubscriber
 {
 public:
 	UavcanGnssSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
-		UavcanSubscriber(ins, pmgr, "gps", instance) { };
+		UavcanDynamicPortSubscriber(ins, pmgr, "gps", instance) { };
 
 	void subscribe() override
 	{

--- a/src/drivers/uavcan_v1/Subscribers/NodeIDAllocationData.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/NodeIDAllocationData.hpp
@@ -53,13 +53,13 @@
 #define PNP2_PORT_ID                                 uavcan_pnp_NodeIDAllocationData_2_0_FIXED_PORT_ID_
 #define PNP2_PAYLOAD_SIZE                            uavcan_pnp_NodeIDAllocationData_2_0_SERIALIZATION_BUFFER_SIZE_BYTES_
 
-#include "Subscriber.hpp"
+#include "BaseSubscriber.hpp"
 
-class UavcanNodeIDAllocationDataSubscriber : public UavcanSubscriber
+class UavcanNodeIDAllocationDataSubscriber : public UavcanBaseSubscriber
 {
 public:
-	UavcanNodeIDAllocationDataSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, NodeManager &nmgr) :
-		UavcanSubscriber(ins, pmgr, "NodeIDAllocationData", 0), _nmgr(nmgr) { };
+	UavcanNodeIDAllocationDataSubscriber(CanardInstance &ins, NodeManager &nmgr) :
+		UavcanBaseSubscriber(ins, "NodeIDAllocationData", 0), _nmgr(nmgr) { };
 
 	void subscribe() override
 	{

--- a/src/drivers/uavcan_v1/Uavcan.hpp
+++ b/src/drivers/uavcan_v1/Uavcan.hpp
@@ -71,11 +71,17 @@
 #include "Publishers/Publisher.hpp"
 #include "Publishers/Gnss.hpp"
 
-#include "Subscribers/Subscriber.hpp"
+#include "Subscribers/BaseSubscriber.hpp"
 #include "Subscribers/Battery.hpp"
 #include "Subscribers/Esc.hpp"
 #include "Subscribers/Gnss.hpp"
 #include "Subscribers/NodeIDAllocationData.hpp"
+
+#include "ServiceClients/GetInfo.hpp"
+#include "ServiceClients/Access.hpp"
+
+#include "Services/AccessReply.hpp"
+#include "Services/ListReply.hpp"
 
 #include "NodeManager.hpp"
 
@@ -239,10 +245,17 @@ private:
 	UavcanBmsSubscriber  _bms0_sub {_canard_instance, _param_manager, 0};
 	UavcanBmsSubscriber  _bms1_sub {_canard_instance, _param_manager, 1};
 	UavcanEscSubscriber  _esc_sub  {_canard_instance, _param_manager, 0};
-	UavcanNodeIDAllocationDataSubscriber _nodeid_sub {_canard_instance, _param_manager, _node_manager};
+	UavcanNodeIDAllocationDataSubscriber _nodeid_sub {_canard_instance, _node_manager};
+
+	UavcanGetInfoResponse _getinfo_rsp {_canard_instance};
+	UavcanAccessResponse  _access_rsp {_canard_instance, _param_manager};
+
+	UavcanAccessServiceReply _access_service {_canard_instance, _node_manager};
+	UavcanListServiceReply   _list_service {_canard_instance, _node_manager};
 
 	// Subscriber objects: Any object used to bridge a UAVCAN message to a uORB message
-	UavcanSubscriber *_subscribers[6] {&_gps0_sub, &_gps1_sub, &_bms0_sub, &_bms1_sub, &_esc_sub, &_nodeid_sub}; /// TODO: turn into List<UavcanSubscription*>
+	UavcanDynamicPortSubscriber *_dynsubscribers[5] {&_gps0_sub, &_gps1_sub, &_bms0_sub, &_bms1_sub, &_esc_sub}; /// TODO: turn into List<UavcanSubscription*>
+	UavcanBaseSubscriber *_subscribers[5] {&_nodeid_sub, &_getinfo_rsp, &_access_rsp, &_access_service, &_list_service}; /// TODO: turn into List<UavcanSubscription*>
 
 	UavcanMixingInterface _mixing_output {_node_mutex, _esc_controller};
 


### PR DESCRIPTION
Added the notion of BaseSubscriber which allows to subscription for services responses and requests and helps the usage of fixed port subscribers Furthermore move register autoconfigure logic from Uavcan.cpp to NodeManager.

As discussed in #16984 this is my take to create classes for the Request/response paradigm. This is done using the BaseSubscriber which is a simple class that doesn't take notion of messages, responses and requests, but the implemented use it to implement the specific logic, dynamic portid, response and requests. Uavcan.cpp doesn't have nation and just listens to a list of all BaseSubscribers.