### PR TITLE
Add a payload drop model for drone delivery scenarios in SITL Gazebo

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# @name Standard VTOL
+#
+# @type Standard VTOL
+#
+
+. ${R}etc/init.d/rc.vtol_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set FW_L1_PERIOD 12
+	param set FW_MAN_P_MAX 30
+	param set FW_PR_FF 0.2
+	param set FW_PR_I 0.4
+	param set FW_PR_P 0.9
+	param set FW_PSP_OFF 2
+	param set FW_P_LIM_MAX 32
+	param set FW_P_LIM_MIN -15
+	param set FW_RR_FF 0.1
+	param set FW_RR_P 0.3
+	param set FW_THR_CRUISE 0.25
+	param set FW_THR_MAX 0.6
+	param set FW_THR_MIN 0.05
+	param set FW_T_ALT_TC 2
+	param set FW_T_CLMB_MAX 8
+	param set FW_T_HRATE_FF 0.5
+	param set FW_T_SINK_MAX 2.7
+	param set FW_T_SINK_MIN 2.2
+	param set FW_T_TAS_TC 2
+
+	param set MC_ROLLRATE_P 0.3
+	param set MC_YAW_P 1.6
+
+	param set MIS_TAKEOFF_ALT 10
+
+	param set MPC_ACC_HOR_MAX 2
+	param set MPC_XY_P 0.8
+	param set MPC_XY_VEL_P_ACC 3
+	param set MPC_XY_VEL_I_ACC 4
+	param set MPC_XY_VEL_D_ACC 0.1
+
+	param set NAV_ACC_RAD 5
+	param set NAV_LOITER_RAD 80
+
+	param set VT_FWD_THRUST_EN 4
+	param set VT_F_TRANS_THR 0.75
+	param set VT_MOT_ID 1234
+	param set VT_FW_MOT_OFFID 1234
+	param set VT_B_TRANS_DUR 8
+	param set VT_TYPE 2
+
+fi
+
+set MAV_TYPE 22
+
+set MIXER_FILE etc/mixers-sitl/standard_vtol_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
@@ -50,6 +50,9 @@ then
 	param set VT_B_TRANS_DUR 8
 	param set VT_TYPE 2
 
+	param set RC_MAP_AUX1 8
+	param set RC_MAP_AUX2 9
+	param set RC_MAP_AUX3 10
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop.post
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop.post
@@ -1,0 +1,1 @@
+mixer append /dev/pwm_output0 etc/mixers-sitl/package_drop.aux.mix

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -65,6 +65,7 @@ px4_add_romfs_files(
 	1041_tailsitter
 	1042_tiltrotor
 	1043_standard_vtol_drop
+	1043_standard_vtol_drop.post
 	1060_rover
 	1061_r1_rover
 	1062_tf-r1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -64,6 +64,7 @@ px4_add_romfs_files(
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor
+	1043_standard_vtol_drop
 	1060_rover
 	1061_r1_rover
 	1062_tf-r1

--- a/ROMFS/px4fmu_common/mixers-sitl/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/mixers-sitl/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_romfs_files(
 	autogyro_sitl.main.mix
 	boat_sitl.main.mix
 	delta_wing_sitl.main.mix
+	package_drop.aux.mix
 	plane_sitl.main.mix
 	quad_x_vtol.main.mix
 	rover_ackermann_sitl.main.mix

--- a/ROMFS/px4fmu_common/mixers-sitl/package_drop.aux.mix
+++ b/ROMFS/px4fmu_common/mixers-sitl/package_drop.aux.mix
@@ -1,0 +1,12 @@
+
+# Roll channel for mount
+M: 1
+S: 3 5  10000  10000      0 -10000  10000
+
+# Pitch channel for mount
+M: 1
+S: 3 6  10000  10000      0 -10000  10000
+
+# Yaw channel for mount
+M: 1
+S: 3 7  10000  10000      0 -10000  10000

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -124,6 +124,7 @@ set(models
 	shell
 	solo
 	standard_vtol
+	standard_vtol_drop
 	tailsitter
 	techpod
 	tiltrotor


### PR DESCRIPTION
**Describe problem solved by this pull request**
As drone deliveries are becoming more and more important, we need to add a way to test drone delivery scenarios in PX4.

**Describe your solution**
This PR adds a model called `standard_vtol_drop`, which simulates a drone delivery scenario in SITL Gazebo.

**Test data / coverage**
This was tested with a mavsdk application sending `MAV_CMD_DO_SET_ACTUATOR` commands.
```
make px4_sitl gazebo_standard_vtol_drop
```

[![Demo](https://img.youtube.com/vi/RdvxvoZ1rwA/0.jpg)](https://youtu.be/RdvxvoZ1rwA)



**Additional context**
- This is based on the `MAV_CMD_DO_SET_ACTUATOR` support added in https://github.com/PX4/PX4-Autopilot/pull/16758
- This PR depends on a sitl_gazebo PR: https://github.com/PX4/PX4-SITL_gazebo/pull/724