### PR TITLE
Fix actuator controls timestamps for MAV_CMD_DO_SET_ACTUATOR

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -506,10 +506,10 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		// index should be 0, otherwise ignore the message
 		if (((int) vehicle_command.param7) == 0) {
 			actuator_controls_s actuator_controls{};
-			actuator_controls.timestamp = hrt_absolute_time();
-
 			// update with existing values to avoid changing unspecified controls
 			_actuator_controls_3_sub.update(&actuator_controls);
+
+			actuator_controls.timestamp = hrt_absolute_time();
 
 			bool updated = false;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR fixes the timestamps of `actuator_controls_3` uORB message when `MAV_CMD_DO_SET_ACTUATOR` is being set.

The timestamp was being removed when updating the `actuator_controls_3` uORB message. This messes up when visualizing the log since the timestamp field is empty when running in SITL

**Test data / coverage**
Run any SITL simulation, and send `MAV_CMD_DO_SET_ACTUATOR`
e.g.
```
make px4_sitl gazebo_standard_vtol
```

**Additional context**
- This is a follow up PR of https://github.com/PX4/PX4-Autopilot/pull/16758