### PR TITLE
mc_att_control_params: remove frequency unit from attitude gains

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -44,7 +44,6 @@
  *
  * Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.
  *
- * @unit Hz
  * @min 0.0
  * @max 12
  * @decimal 2
@@ -58,7 +57,6 @@ PARAM_DEFINE_FLOAT(MC_ROLL_P, 6.5f);
  *
  * Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.
  *
- * @unit Hz
  * @min 0.0
  * @max 12
  * @decimal 2
@@ -72,7 +70,6 @@ PARAM_DEFINE_FLOAT(MC_PITCH_P, 6.5f);
  *
  * Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.
  *
- * @unit Hz
  * @min 0.0
  * @max 5
  * @decimal 2
@@ -91,7 +88,6 @@ PARAM_DEFINE_FLOAT(MC_YAW_P, 2.8f);
  *
  * For yaw control tuning use MC_YAW_P. This ratio has no inpact on the yaw gain.
  *
- * @unit Hz
  * @min 0.0
  * @max 1.0
  * @decimal 2


### PR DESCRIPTION
**Describe problem solved by this pull request**
I just saw attitude gains now have the unit Hz and I consider this misleading. Even though 1/s is equivalent to Hz, Hz is used for frequency values and I would not consider the gain a frequency. It's the reciprocal of a timeconstant.

**Describe your solution**
I'd either write explicitly what ratio the gain has (rad/s) / rad if that's allowed to make it very clear. If that's not allowed I'd keep 1/s and if that's not possible anymore remove the units before confusing anyone.