### PR TITLE
UAVCANv1 menuconfig proposal

### DIFF
--- a/src/drivers/uavcan_v1/CMakeLists.txt
+++ b/src/drivers/uavcan_v1/CMakeLists.txt
@@ -31,6 +31,8 @@
 #
 ############################################################################
 
+set(UAVCAN_DEFCONFIG ${PX4_BOARD_DIR}/uavcanconfig CACHE FILEPATH "path to defconfig" FORCE)
+
 set(LIBCANARD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libcanard)
 set(DSDL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public_regulated_data_types)
 
@@ -88,3 +90,36 @@ px4_add_module(
 		git_public_regulated_data_types
 		version
 	)
+
+
+# Use uavcanconfig file for compile definitions
+file(STRINGS ${UAVCAN_DEFCONFIG} lines)
+
+FOREACH(i IN LISTS lines)
+        if(i MATCHES "#")
+        else()
+            string(REPLACE "\n" "" i ${i})
+            SET(uavcan_config "${uavcan_config}${i};")
+        endif()
+ENDFOREACH()
+
+target_compile_definitions(drivers__uavcan_v1 PRIVATE ${uavcan_config})
+
+# UAVCANv1 menuconfig
+add_custom_target(menuconfig_uavcan
+	COMMAND kconfig-mconf Kconfig
+	#DEPENDS nuttx_config_target ${CMAKE_CURRENT_SOURCE_DIR}/.config
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	USES_TERMINAL
+	)
+
+# UAVCANv1 menuconfig + savedefconfig back to PX4
+add_custom_target(uavcanconfig
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMAND ${CMAKE_COMMAND} -E copy ${UAVCAN_DEFCONFIG} ${CMAKE_CURRENT_SOURCE_DIR}/.config
+	COMMAND kconfig-mconf Kconfig
+	COMMENT "Running UAVCAN make menuconfig for ${UAVCAN_DEFCONFIG}"
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/.config ${UAVCAN_DEFCONFIG}
+	COMMENT "Saved config to ${UAVCAN_DEFCONFIG}"
+	USES_TERMINAL
+)

--- a/src/drivers/uavcan_v1/CMakeLists.txt
+++ b/src/drivers/uavcan_v1/CMakeLists.txt
@@ -47,6 +47,14 @@ else()
 	message(FATAL_ERROR "UAVCAN Nunavut nnvg not found")
 endif()
 
+find_program(KCONFIG_PATH kconfig-mconf)
+if(KCONFIG_PATH)
+    set(menuconfig ${KCONFIG_PATH})
+else()
+    set(menuconfig "python3")
+    set(menuconfig_arg "${NUTTX_SRC_DIR}/tools/menuconfig.py")
+endif()
+
 set(SRCS)
 if(${PX4_PLATFORM} MATCHES "nuttx")
 	if(CONFIG_NET_CAN)
@@ -105,19 +113,11 @@ ENDFOREACH()
 
 target_compile_definitions(drivers__uavcan_v1 PRIVATE ${uavcan_config})
 
-# UAVCANv1 menuconfig
-add_custom_target(menuconfig_uavcan
-	COMMAND kconfig-mconf Kconfig
-	#DEPENDS nuttx_config_target ${CMAKE_CURRENT_SOURCE_DIR}/.config
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	USES_TERMINAL
-	)
-
 # UAVCANv1 menuconfig + savedefconfig back to PX4
 add_custom_target(uavcanconfig
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	COMMAND ${CMAKE_COMMAND} -E copy ${UAVCAN_DEFCONFIG} ${CMAKE_CURRENT_SOURCE_DIR}/.config
-	COMMAND kconfig-mconf Kconfig
+	COMMAND ${menuconfig} ${menuconfig_arg} Kconfig
 	COMMENT "Running UAVCAN make menuconfig for ${UAVCAN_DEFCONFIG}"
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/.config ${UAVCAN_DEFCONFIG}
 	COMMENT "Saved config to ${UAVCAN_DEFCONFIG}"

--- a/src/drivers/uavcan_v1/CMakeLists.txt
+++ b/src/drivers/uavcan_v1/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-set(UAVCAN_DEFCONFIG ${PX4_BOARD_DIR}/uavcanconfig CACHE FILEPATH "path to defconfig" FORCE)
+set(UAVCAN_DEFCONFIG ${PX4_BOARD_DIR}/${PX4_BOARD_LABEL}-uavcanconfig CACHE FILEPATH "path to defconfig" FORCE)
 
 set(LIBCANARD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libcanard)
 set(DSDL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/public_regulated_data_types)
@@ -101,15 +101,19 @@ px4_add_module(
 
 
 # Use uavcanconfig file for compile definitions
-file(STRINGS ${UAVCAN_DEFCONFIG} lines)
+if(EXISTS ${UAVCAN_DEFCONFIG})
+    file(STRINGS ${UAVCAN_DEFCONFIG} lines)
 
-FOREACH(i IN LISTS lines)
-        if(i MATCHES "#")
-        else()
-            string(REPLACE "\n" "" i ${i})
-            SET(uavcan_config "${uavcan_config}${i};")
-        endif()
-ENDFOREACH()
+    FOREACH(i IN LISTS lines)
+            if(i MATCHES "#")
+            else()
+                string(REPLACE "\n" "" i ${i})
+                SET(uavcan_config "${uavcan_config}${i};")
+            endif()
+    ENDFOREACH()
+else()
+    file(TOUCH ${UAVCAN_DEFCONFIG} lines)
+endif()
 
 target_compile_definitions(drivers__uavcan_v1 PRIVATE ${uavcan_config})
 

--- a/src/drivers/uavcan_v1/CMakeLists.txt
+++ b/src/drivers/uavcan_v1/CMakeLists.txt
@@ -121,5 +121,7 @@ add_custom_target(uavcanconfig
 	COMMENT "Running UAVCAN make menuconfig for ${UAVCAN_DEFCONFIG}"
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/.config ${UAVCAN_DEFCONFIG}
 	COMMENT "Saved config to ${UAVCAN_DEFCONFIG}"
+	COMMENT "Reconfiguring ${PX4_BINARY_DIR}"
+	COMMAND ${CMAKE_COMMAND} --clean ${PX4_BINARY_DIR}
 	USES_TERMINAL
 )

--- a/src/drivers/uavcan_v1/Kconfig
+++ b/src/drivers/uavcan_v1/Kconfig
@@ -1,0 +1,28 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+choice
+    prompt "UAVCANv1 Mode"
+    default none
+
+config UAVCAN_V1_FMU
+    bool "Server (FMU)"
+
+config UAVCAN_V1_CLIENT
+    bool "Client (Peripheral)"
+
+endchoice
+
+config UAVCAN_V1_GETINFO_RESPONDER
+	bool "GetInfo1.0 responder"
+	default n
+
+config UAVCAN_V1_EXECUTECOMMAND_RESPONDER
+	bool "ExecuteCommand1.0 responder"
+	default n
+
+config UAVCAN_V1_GNSS_PUBLISHER
+	bool "GNSS Publisher"
+	default n


### PR DESCRIPTION
Regarding the unification attempt for FMU's and Node's of the UAVCANv1 implementation we want to create compile time configurations, to do this using manual CMake defines can be a bit tedious.

This PR proposes the use of menuconfig to configure a UAVCANv1 node, using make <target> uavcanconfig, the configuration will be saved in boards/<board>/uavcanconfig and can be easily be modified. Furthermore this helps with boards that are multipurpose e.g. the UCANS32K146 can act as a GNSS node but also as an IMU node. Thus you can create seperate UAVCAN configurations for that.

<img width="592" alt="uavcan_menuconfig" src="https://user-images.githubusercontent.com/57130844/110312612-9a7ce400-8005-11eb-8ca2-4d6ad810b22a.png">
