### PR TITLE
simulator: fix lidar sensors

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -198,7 +198,7 @@ private:
 	uORB::Publication<vehicle_command_ack_s>	_command_ack_pub{ORB_ID(vehicle_command_ack)};
 
 	uORB::PublicationMulti<distance_sensor_s>	*_dist_pubs[ORB_MULTI_MAX_INSTANCES] {};
-	uint8_t _dist_sensor_ids[ORB_MULTI_MAX_INSTANCES] {};
+	uint32_t _dist_sensor_ids[ORB_MULTI_MAX_INSTANCES] {};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 


### PR DESCRIPTION
`uint8_t` is not enough to hold simulated sensor IDs. This caused distance sensor values to be published only 10 times on different distance_sensor instances:

```
ERROR [simulator] 7 has device id 4 and publisher 0x7f998c004360
ERROR [simulator] 8 has device id 4 and publisher (nil)
ERROR [simulator] Publish 2.110000 to 8 with device id 10092548
ERROR [simulator] 0 has device id 4 and publisher 0x7f998c003730
ERROR [simulator] 1 has device id 4 and publisher 0x7f998c0038b0
ERROR [simulator] 2 has device id 4 and publisher 0x7f998c003be0
ERROR [simulator] 3 has device id 4 and publisher 0x7f998c003d60
ERROR [simulator] 4 has device id 4 and publisher 0x7f998c003ee0
ERROR [simulator] 5 has device id 4 and publisher 0x7f998c004060
ERROR [simulator] 6 has device id 4 and publisher 0x7f998c0041e0
ERROR [simulator] 7 has device id 4 and publisher 0x7f998c004360
ERROR [simulator] 8 has device id 4 and publisher 0x7f998c0044e0
ERROR [simulator] 9 has device id 4 and publisher (nil)
ERROR [simulator] Publish 1.890000 to 9 with device id 10092548
```

This PR fixes this issue by putting the distance sensor IDs in `uint32_t`.