### PR TITLE
CAN RTCM: Modify the way to clear Data

### DIFF
--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -476,7 +476,7 @@ bool UavcanGnssBridge::injectData(const uint8_t *const data, const size_t data_l
 		}
 
 		result = _pub_rtcm.broadcast(msg) >= 0;
-		msg.data = {};
+		msg.data.clear();
 	}
 
 	return result;


### PR DESCRIPTION
**issue:**
When using F9P as RTK BASE in QGC, no data will be sent out from the corresponding CAN interface. 
After debugging, it is found that the RTCM data transmission stays at msg.data = {}; 

**solution:**
msg.data.clear(); Replace msg.data = {}; 
![image](https://user-images.githubusercontent.com/30532769/110448920-a0092580-80fc-11eb-9fee-38e5a8bbb64c.png)


