### PR TITLE
Fix mavlink shell

### DIFF
--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -37,7 +37,7 @@ px4_add_board(
 		imu/invensense/icm20649
 		imu/invensense/icm20689
 		irlock
-		lights/blinkm
+		#lights/blinkm
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		lights/rgbled_pwm

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -74,9 +74,6 @@ int MavlinkShell::start()
 	return -1;
 #endif /* __PX4_NUTTX */
 
-
-	PX4_INFO("Starting mavlink shell");
-
 	int p1[2], p2[2];
 
 	/* Create the shell task and redirect its stdin & stdout. If we used pthread, we would redirect

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -74,6 +74,9 @@ int MavlinkShell::start()
 	return -1;
 #endif /* __PX4_NUTTX */
 
+
+	PX4_INFO("Starting mavlink shell");
+
 	int p1[2], p2[2];
 
 	/* Create the shell task and redirect its stdin & stdout. If we used pthread, we would redirect


### PR DESCRIPTION
This fixes the MAVLink shell for the X7 Pro (and likely other H7 targets). I would love to have additional hardening so we are not timing dependent. @bkueng could you maybe add a commit for that?