### PR TITLE
Fix twitch when relaxing takeoff tilt limit

### DIFF
--- a/src/lib/slew_rate/CMakeLists.txt
+++ b/src/lib/slew_rate/CMakeLists.txt
@@ -32,7 +32,8 @@
 ############################################################################
 
 px4_add_library(SlewRate
-	dummy.cpp
+	SlewRate.hpp
+	SlewRateYaw.hpp
 )
 target_include_directories(SlewRate
 	PUBLIC

--- a/src/lib/slew_rate/SlewRateTest.cpp
+++ b/src/lib/slew_rate/SlewRateTest.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include <gtest/gtest.h>
-#include <SlewRate.hpp>
+#include "SlewRate.hpp"
 
 TEST(SlewRateTest, SlewUpLimited)
 {

--- a/src/lib/slew_rate/SlewRateYawTest.cpp
+++ b/src/lib/slew_rate/SlewRateYawTest.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include <gtest/gtest.h>
-#include <SlewRateYaw.hpp>
+#include "SlewRateYaw.hpp"
 
 TEST(SlewRateYawTest, SlewUpLimited)
 {

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -44,8 +44,8 @@
 #include "FlightTaskManualAltitudeSmoothVel.hpp"
 #include <uORB/Publication.hpp>
 #include <uORB/topics/orbit_status.h>
-#include <StraightLine.hpp>
-#include <SlewRateYaw.hpp>
+#include "StraightLine.hpp"
+#include <lib/slew_rate/SlewRateYaw.hpp>
 
 class FlightTaskOrbit : public FlightTaskManualAltitudeSmoothVel
 {

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -47,4 +47,5 @@ px4_add_module(
 		controllib
 		git_ecl
 		ecl_geo
+		SlewRate
 	)

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -375,13 +375,9 @@ void MulticopterPositionControl::Run()
 			}
 
 			// limit tilt during takeoff ramupup
-			float tilt_limit = math::radians(_param_mpc_tiltmax_air.get());
-
-			if (_takeoff.getTakeoffState() < TakeoffState::flight) {
-				tilt_limit = math::radians(_param_mpc_tiltmax_lnd.get());
-			}
-
-			_control.setTiltLimit(_tilt_limit_slew_rate.update(tilt_limit, dt));
+			const float tilt_limit_deg = (_takeoff.getTakeoffState() < TakeoffState::flight)
+						     ? _param_mpc_tiltmax_lnd.get() : _param_mpc_tiltmax_air.get();
+			_control.setTiltLimit(_tilt_limit_slew_rate.update(math::radians(tilt_limit_deg), dt));
 
 			const float speed_up = _takeoff.updateRamp(dt,
 					       PX4_ISFINITE(_vehicle_constraints.speed_up) ? _vehicle_constraints.speed_up : _param_mpc_z_vel_max_up.get());

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -44,6 +44,7 @@
 #include <lib/controllib/blocks.hpp>
 #include <lib/hysteresis/hysteresis.h>
 #include <lib/perf/perf_counter.h>
+#include <lib/slew_rate/SlewRateYaw.hpp>
 #include <lib/systemlib/mavlink_log.h>
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/defines.h>
@@ -197,6 +198,7 @@ private:
 	static constexpr float MAX_SAFE_TILT_DEG = 89.f; // Numerical issues above this value due to tanf
 
 	systemlib::Hysteresis _failsafe_land_hysteresis{false}; /**< becomes true if task did not update correctly for LOITER_TIME_BEFORE_DESCEND */
+	SlewRate<float> _tilt_limit_slew_rate;
 
 	uint8_t _old_takeoff_state{};
 

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -72,7 +72,7 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 	case TakeoffState::ready_for_takeoff:
 		if (want_takeoff) {
 			_takeoff_state = TakeoffState::rampup;
-			_takeoff_ramp_vz = _takeoff_ramp_vz_init;
+			_takeoff_ramp_progress = 0.f;
 
 		} else {
 			break;
@@ -80,7 +80,7 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 
 	// FALLTHROUGH
 	case TakeoffState::rampup:
-		if (_takeoff_ramp_vz >= takeoff_desired_vz) {
+		if (_takeoff_ramp_progress >= 1.f) {
 			_takeoff_state = TakeoffState::flight;
 
 		} else {
@@ -119,14 +119,14 @@ float Takeoff::updateRamp(const float dt, const float takeoff_desired_vz)
 
 	if (_takeoff_state == TakeoffState::rampup) {
 		if (_takeoff_ramp_time > dt) {
-			_takeoff_ramp_vz += (takeoff_desired_vz - _takeoff_ramp_vz_init) * dt / _takeoff_ramp_time;
+			_takeoff_ramp_progress += dt / _takeoff_ramp_time;
 
 		} else {
-			_takeoff_ramp_vz = takeoff_desired_vz;
+			_takeoff_ramp_progress = 1.f;
 		}
 
-		if (_takeoff_ramp_vz < takeoff_desired_vz) {
-			upwards_velocity_limit = _takeoff_ramp_vz;
+		if (_takeoff_ramp_progress < 1.f) {
+			upwards_velocity_limit = _takeoff_ramp_vz_init + _takeoff_ramp_progress * (takeoff_desired_vz - _takeoff_ramp_vz_init);
 		}
 	}
 

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -111,8 +111,10 @@ void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool
 
 float Takeoff::updateRamp(const float dt, const float takeoff_desired_vz)
 {
+	float upwards_velocity_limit = takeoff_desired_vz;
+
 	if (_takeoff_state < TakeoffState::rampup) {
-		return _takeoff_ramp_vz_init;
+		upwards_velocity_limit = _takeoff_ramp_vz_init;
 	}
 
 	if (_takeoff_state == TakeoffState::rampup) {
@@ -124,9 +126,9 @@ float Takeoff::updateRamp(const float dt, const float takeoff_desired_vz)
 		}
 
 		if (_takeoff_ramp_vz < takeoff_desired_vz) {
-			return _takeoff_ramp_vz;
+			upwards_velocity_limit = _takeoff_ramp_vz;
 		}
 	}
 
-	return takeoff_desired_vz;
+	return upwards_velocity_limit;
 }

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.hpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.hpp
@@ -94,9 +94,9 @@ public:
 private:
 	TakeoffState _takeoff_state = TakeoffState::disarmed;
 
-	systemlib::Hysteresis _spoolup_time_hysteresis{false}; /**< becomes true MPC_SPOOLUP_TIME seconds after the vehicle was armed */
+	systemlib::Hysteresis _spoolup_time_hysteresis{false}; ///< becomes true MPC_SPOOLUP_TIME seconds after the vehicle was armed
 
-	float _takeoff_ramp_time = 0.f;
-	float _takeoff_ramp_vz_init = 0.f;
-	float _takeoff_ramp_vz = 0.f;
+	float _takeoff_ramp_time{0.f};
+	float _takeoff_ramp_vz_init{0.f}; ///< verticval velocity resulting in zero thrust
+	float _takeoff_ramp_progress{0.f}; ///< asecnding from 0 to 1
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
When taking off e.g. in altitude mode the maximum tilt is limited to [MPC_TILTMAX_LND](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#MPC_TILTMAX_LND) degree and after takeoff in general flight to [MPC_TILTMAX_AIR](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#MPC_TILTMAX_AIR). The current implementation causes a twitch when relaxing that limit after takeoff.

**Describe your solution**
I was investigating multiple possibilities to solve the issue. The first one was to just ramp the tilt limit with the takeoff ramp but it doesn't result in the correct user experience. But what's left is:
- Refactor the takeoff ramp to work with an internal progress value between 0 and 1. It makes it more readable and will allow the adoption to e.g. also ramp down again or ramping up other quantities for flight.
What resulted in the right user experience was ramping the tilt limit after the takeoff is for sure completely done. I did that with the `SlewRate` library and:
- Adapt SlewRate includes to convention
- Use SlewRate to ramp the tilt limit to avoid a step/twitch

**Test data / coverage**
I SITL tested and analyzed the log:
![image](https://user-images.githubusercontent.com/4668506/112001308-240cd580-8b1f-11eb-96e9-457997b9d7a7.png)

