### PR TITLE
boards: double logger buffer on stm32h7

### DIFF
--- a/boards/cuav/nora/init/rc.board_defaults
+++ b/boards/cuav/nora/init/rc.board_defaults
@@ -42,7 +42,7 @@ param set-default SENS_EN_THERMAL 1
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 
 rgbled_pwm start
 safety_button start

--- a/boards/cuav/x7pro/init/rc.board_defaults
+++ b/boards/cuav/x7pro/init/rc.board_defaults
@@ -42,7 +42,7 @@ param set-default SENS_EN_THERMAL 1
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 
 rgbled_pwm start
 safety_button start

--- a/boards/cubepilot/cubeorange/init/rc.board_defaults
+++ b/boards/cubepilot/cubeorange/init/rc.board_defaults
@@ -42,5 +42,5 @@ param set-default SENS_EN_THERMAL 0
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 set IOFW "/etc/extras/cubepilot_io-v2_default.bin"

--- a/boards/holybro/durandal-v1/init/rc.board_defaults
+++ b/boards/holybro/durandal-v1/init/rc.board_defaults
@@ -35,4 +35,4 @@ param set-default SENS_EN_THERMAL 1
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128

--- a/boards/mro/ctrl-zero-h7-oem/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-h7-oem/init/rc.board_defaults
@@ -37,6 +37,6 @@ param set-default SENS_MAG_MODE 0
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 
 safety_button start

--- a/boards/mro/ctrl-zero-h7/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-h7/init/rc.board_defaults
@@ -37,6 +37,6 @@ param set-default SENS_MAG_MODE 0
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 
 safety_button start

--- a/boards/mro/pixracerpro/init/rc.board_defaults
+++ b/boards/mro/pixracerpro/init/rc.board_defaults
@@ -37,5 +37,5 @@ param set-default SENS_MAG_MODE 0
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 set MIXER_AUX none

--- a/boards/px4/fmu-v6u/init/rc.board_defaults
+++ b/boards/px4/fmu-v6u/init/rc.board_defaults
@@ -12,6 +12,6 @@ param set-default SENS_MAG_MODE 0
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 
 safety_button start

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -12,6 +12,6 @@ param set-default SENS_MAG_MODE 0
 param set-default UAVCAN_ENABLE 2
 
 
-set LOGGER_BUF 64
+set LOGGER_BUF 128
 
 safety_button start


### PR DESCRIPTION
This can still matter depending on the logging rate and particular card.

For example Kingston Industrial microSD cards (https://www.kingston.com/unitedstates/us/memory-cards/industrial-temperature-microsd-uhs-i) are actually quite slow. We can comfortably afford this on most stm32h7 boards.

![image (1)](https://user-images.githubusercontent.com/84712/110500182-ee033680-80c6-11eb-9154-418061d33199.png)

