### PR TITLE
parameters: fix runtime default edge case

### DIFF
--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -77,7 +77,7 @@ if (px4_constrained_flash_build)
 endif()
 if(PX4_ETHERNET)
 	set(added_arguments ${added_arguments} --ethernet)
-endif()	
+endif()
 add_custom_command(OUTPUT ${generated_serial_params_file}
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${generated_params_dir}
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/serial/generate_config.py

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -570,6 +570,8 @@ param_get_default_value(param_t param, void *default_val)
 
 bool param_value_is_default(param_t param)
 {
+	// the param_values dynamic array might carry things that have been set
+	// back to default, so we don't rely on the params_changed bitset here
 	if (handle_in_range(param)) {
 		switch (param_type(param)) {
 		case PARAM_TYPE_INT32: {


### PR DESCRIPTION
This fixes an edge case with the new runtime parameter default mechanism where if you manually set a parameter with a custom runtime default to the underlying default value it will be lost on the next import. This is because the param set during  import wouldn't store anything being set to default, but the custom airframe defaults hadn't been loaded yet (early in boot).

 - keep param_set() even if setting to default (runtime or static)
 - param export skip defaults
 - param_value_is_default() is more expensive now (actually finds the value and compares), but it's used infrequently
 - fixes https://github.com/PX4/PX4-Autopilot/issues/17016