### PR TITLE
Acceleration stick mapping invalid setpoint corner case

### DIFF
--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -467,7 +467,7 @@ void FlightModeManager::generateTrajectorySetpoint(const float dt,
 		if (_vehicle_local_position_setpoint_sub.copy(&vehicle_local_position_setpoint)) {
 			const Vector3f vel_sp{vehicle_local_position_setpoint.vx, vehicle_local_position_setpoint.vy, vehicle_local_position_setpoint.vz};
 			const Vector3f acc_sp{vehicle_local_position_setpoint.acceleration};
-			_current_task.task->updateVelocityControllerIO(vel_sp, acc_sp);
+			_current_task.task->updateVelocityControllerFeedback(vel_sp, acc_sp);
 		}
 	}
 

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -175,13 +175,6 @@ void FlightModeManager::start_flight_task()
 		return;
 	}
 
-	// Switch to clean new task when mode switches e.g. to reset state when switching between auto modes
-	// exclude Orbit mode since the task is initiated in FlightTasks through the vehicle_command and we should not switch out
-	if (_last_vehicle_nav_state != _vehicle_status_sub.get().nav_state
-	    && _vehicle_status_sub.get().nav_state != vehicle_status_s::NAVIGATION_STATE_ORBIT) {
-		switchTask(FlightTaskIndex::None);
-	}
-
 	// Only run transition flight task if altitude control is enabled (e.g. in Altitdue, Position, Auto flight mode)
 	if (_vehicle_status_sub.get().in_transition_mode && _vehicle_control_mode_sub.get().flag_control_altitude_enabled) {
 

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -176,8 +176,8 @@ public:
 	 */
 	virtual void setYawHandler(WeatherVane *ext_yaw_handler) {}
 
-	void updateVelocityControllerIO(const matrix::Vector3f &vel_sp,
-					const matrix::Vector3f &acc_sp)
+	void updateVelocityControllerFeedback(const matrix::Vector3f &vel_sp,
+					      const matrix::Vector3f &acc_sp)
 	{
 		_velocity_setpoint_feedback = vel_sp;
 		_acceleration_setpoint_feedback = acc_sp;

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -48,10 +48,10 @@ bool FlightTaskManualAcceleration::activate(const vehicle_local_position_setpoin
 	bool ret = FlightTaskManualAltitudeSmoothVel::activate(last_setpoint);
 
 	if (PX4_ISFINITE(last_setpoint.vx)) {
-		_velocity_setpoint.xy() = Vector2f(last_setpoint.vx, last_setpoint.vy);
+		_stick_acceleration_xy.resetVelocity(Vector2f(last_setpoint.vx, last_setpoint.vy));
 
 	} else {
-		_velocity_setpoint.xy() = _velocity.xy();
+		_stick_acceleration_xy.resetVelocity(_velocity.xy());
 	}
 
 	_stick_acceleration_xy.resetPosition();


### PR DESCRIPTION
**Describe problem solved by this pull request**
3 Bugs:
1. In position mode when landing, moving the right stick during ground contact and taking off again in exactly the right timing it's possible to get invalid setpoints.
2. Every mode switch results in the task doing EKF reset handling.
3. The initialization of the acceleration stick mapping sets the wrong state.

**Describe your solution**
1.  When unlocking the position the velocity setpoint feedback is now considered since https://github.com/PX4/PX4-Autopilot/pull/16791. During ground contact the executed setpoint is NAN even though the task commanded a velocity. This is now handled gracefully by not considering the feedback if it's NAN.
2. This is occuring because of an idea to be able to reinitialize any task on mode change e.g. to allow reinitialization of internal states when switching from Hold mode to Land mode which are currently all still handled by FlightTaskAuto and don't require a task switch.

   But I found out it leads to issues because the last setpoint and the ekf reset counter state from the previous task are lost and as a result the setpoint transition cannot be handled consistently anymore.
3. I just set the correct state. The issue was hidden by the previous issue 2. because the unexpected EKF reset handling had a similar effect.

**Test data / coverage**
I SITL tested all the cases listed above. See also screenshot below.
For 1. I intentionally injected NANs and verified it's not possible anymore to reproduce the issue.

**Additional context**
1. Issue found before this pr:
![image](https://user-images.githubusercontent.com/4668506/110636567-b373c980-81ac-11eb-9cc7-2267d28b90e5.png)
3. Testing proper initialization with this pr:
![image](https://user-images.githubusercontent.com/4668506/110635742-bc17d000-81ab-11eb-801f-e16896d704f8.png)