### PR TITLE
SITL: add iris with fog-simulating lidar

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10018_iris_foggy_lidar
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10018_iris_foggy_lidar
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# @name 3DR Iris Quadrotor SITL (foggy_lidar)
+#
+# @type Quadrotor Wide
+#
+
+. ${R}etc/init.d-posix/airframes/10016_iris
+
+if [ $AUTOCNF = yes ]
+then
+	param set EKF2_RNG_AID 1
+	param set EKF2_RNG_A_HMAX 10
+fi

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -34,6 +34,7 @@
 px4_add_romfs_files(
 	10016_iris
 	10017_iris_ctrlalloc
+	10018_iris_foggy_lidar
 	10020_if750a
 	10030_px4vision
 	1010_iris_opt_flow

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -107,6 +107,7 @@ set(models
 	iris
 	iris_ctrlalloc
 	iris_dual_gps
+	iris_foggy_lidar
 	iris_irlock
 	iris_obs_avoid
 	iris_opt_flow


### PR DESCRIPTION
A follow-up on https://github.com/PX4/PX4-SITL_gazebo/pull/725, which allows to test the firmware behaviour in foggy environments.

This adds an iris with a lidar that measures distances as if the drone is within dense fog (compare with a real flight https://review.px4.io/plot_app?log=c9482a7a-0608-4cab-9ad3-5a6dbef7f2f7). 

@julianoes would this be a candidate for extending the failure injection?