### PR TITLE
add bootloader flash helper target (jlink_flash_bootloader)

### DIFF
--- a/platforms/nuttx/Debug/flash_bootloader.jlink.in
+++ b/platforms/nuttx/Debug/flash_bootloader.jlink.in
@@ -1,0 +1,9 @@
+Device @DEBUG_DEVICE@
+eoe 1
+si SWD
+speed auto
+r
+h
+loadbin @BOARD_BL_FIRMWARE_BIN@,0x08000000
+go
+qc

--- a/platforms/nuttx/cmake/jlink.cmake
+++ b/platforms/nuttx/cmake/jlink.cmake
@@ -81,3 +81,26 @@ if(Ozone_PATH)
 		USES_TERMINAL
 	)
 endif()
+
+if(bootloader_bin OR (EXISTS "${PX4_BOARD_DIR}/bootloader/${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_bootloader.bin"))
+	# jlink_flash_bootloader
+	find_program(JLinkExe_PATH JLinkExe)
+	if(JLinkExe_PATH)
+
+		if(bootloader_bin)
+			set(BOARD_BL_FIRMWARE_BIN ${bootloader_bin})
+		else()
+			set(BOARD_BL_FIRMWARE_BIN ${PX4_BOARD_DIR}/bootloader/${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_bootloader.bin)
+		endif()
+
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Debug/flash_bootloader.jlink.in ${PX4_BINARY_DIR}/flash_bootloader.jlink @ONLY)
+		add_custom_target(jlink_flash_bootloader
+			COMMAND ${JLinkExe_PATH} -CommandFile ${PX4_BINARY_DIR}/flash_bootloader.jlink
+			DEPENDS
+				px4
+				${CMAKE_CURRENT_SOURCE_DIR}/Debug/flash_bootloader.jlink.in
+			WORKING_DIRECTORY ${PX4_BINARY_DIR}
+			USES_TERMINAL
+		)
+	endif()
+endif()


### PR DESCRIPTION
Works for all boards that build their own bootlooder in tree (eg STM32H7) or carry a bootloader binary in their board directory. The target will not exist if the bootloader isn't available.

``` Console
dagar@dagar-desktop:~/git/PX4-Autopilot$ make cuav_nora_default jlink_flash_bootloader
[0/4] Performing build step for 'bootloader_firmware'
ninja: no work to do.
[3/4] cd /home/dagar/git/PX4-Autopilot/build/cuav_nora_default && /usr/bin/JLinkExe -CommandFile /home/dagar/git/PX4-Autopilot/build/cuav_nora_default/flash_bootloader.jlink
SEGGER J-Link Commander V6.88 (Compiled Nov 12 2020 18:43:04)
DLL version V6.88, compiled Nov 12 2020 18:42:52


J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Trace PRO V2 Cortex-M compiled Nov 12 2020 10:10:59
Hardware version: V2.00
S/N: 752001441
License(s): RDI, FlashBP, FlashDL, JFlash, GDB
IP-Addr: DHCP (no addr. received yet)
Emulator has RAWTRACE capability
VTref=4.550V

J-Link Commander will now exit on Error

Selecting SWD as current target interface.

Selecting auto as target interface speed

Target connection not established yet but required for command.
Device "STM32H743XI" selected.

Connecting to target via SWD
Found SW-DP with ID 0x6BA02477
Found SW-DP with ID 0x6BA02477
DPIDR: 0x6BA02477
Scanning AP map to find all available APs
AP[3]: Stopped AP scan as end of AP map has been reached
AP[0]: AHB-AP (IDR: 0x84770001)
AP[1]: AHB-AP (IDR: 0x84770001)
AP[2]: APB-AP (IDR: 0x54770002)
Iterating through AP map to find AHB-AP to use
AP[0]: Core found
AP[0]: AHB-AP ROM base: 0xE00FE000
CPUID register: 0x411FC271. Implementer code: 0x41 (ARM)
Found Cortex-M7 r1p1, Little endian.
FPUnit: 8 code (BP) slots and 0 literal slots
CoreSight components:
ROMTbl[0] @ E00FE000
ROMTbl[0][0]: E00FF000, CID: B105100D, PID: 000BB4C7 ROM Table
ROMTbl[1] @ E00FF000
ROMTbl[1][0]: E000E000, CID: B105E00D, PID: 000BB00C SCS-M7
ROMTbl[1][1]: E0001000, CID: B105E00D, PID: 000BB002 DWT
ROMTbl[1][2]: E0002000, CID: B105E00D, PID: 000BB00E FPB-M7
ROMTbl[1][3]: E0000000, CID: B105E00D, PID: 000BB001 ITM
ROMTbl[0][1]: E0041000, CID: B105900D, PID: 001BB975 ETM-M7
ROMTbl[0][2]: E0043000, CID: B105900D, PID: 004BB906 CTI
Cache: Separate I- and D-cache.
I-Cache L1: 16 KB, 256 Sets, 32 Bytes/Line, 2-Way
D-Cache L1: 16 KB, 128 Sets, 32 Bytes/Line, 4-Way
Cortex-M7 identified.
Reset delay: 0 ms
Reset type NORMAL: Resets core & peripherals via SYSRESETREQ & VECTRESET bit.
Reset: Halt core after reset via DEMCR.VC_CORERESET.
Reset: Reset device via AIRCR.SYSRESETREQ.

PC = 0800034C, CycleCnt = 00000000
R0 = 00000000, R1 = 00000000, R2 = 00000000, R3 = 00000000
R4 = 00000000, R5 = 00000000, R6 = 00000000, R7 = 00000000
R8 = 00000000, R9 = 00000000, R10= 00000000, R11= 00000000
R12= 00000000
SP(R13)= 24002988, MSP= 24002988, PSP= 00000000, R14(LR) = FFFFFFFF
XPSR = 01000000: APSR = nzcvq, EPSR = 01000000, IPSR = 000 (NoException)
CFBP = 00000000, CONTROL = 00, FAULTMASK = 00, BASEPRI = 00, PRIMASK = 00

FPS0 = 00000000, FPS1 = 00000000, FPS2 = 00000000, FPS3 = 00000000
FPS4 = 00000000, FPS5 = 00000000, FPS6 = 00000000, FPS7 = 00000000
FPS8 = 00000000, FPS9 = 00000000, FPS10= 00000000, FPS11= 00000000
FPS12= 00000000, FPS13= 00000000, FPS14= 00000000, FPS15= FFFFFFFF
FPS16= 00000000, FPS17= 00000000, FPS18= 00000000, FPS19= 00000000
FPS20= 00000000, FPS21= 00000000, FPS22= 00000000, FPS23= 00000000
FPS24= 00000000, FPS25= 00000000, FPS26= 00000000, FPS27= 00000000
FPS28= 00000000, FPS29= 00000000, FPS30= 00000000, FPS31= FFFFFFFF
FPSCR= 00000000

Downloading file [/home/dagar/git/PX4-Autopilot/build/cuav_nora_default/romfs_extras/bootloader.bin]...

J-Link: Flash download: Bank 0 @ 0x08000000: Skipped. Contents already match
O.K.


Script processing completed.

```