### PR TITLE
Run mc_pos_control for acceleration control mode flag

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3336,8 +3336,6 @@ Commander::update_control_mode()
 		_vehicle_control_mode.flag_control_climb_rate_enabled = true;
 		_vehicle_control_mode.flag_control_position_enabled = !_status.in_transition_mode;
 		_vehicle_control_mode.flag_control_velocity_enabled = !_status.in_transition_mode;
-		_vehicle_control_mode.flag_control_acceleration_enabled = false;
-		_vehicle_control_mode.flag_control_termination_enabled = false;
 		break;
 
 	default:

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -292,7 +292,7 @@ void MulticopterPositionControl::Run()
 
 		PositionControlStates states{set_vehicle_states(local_pos)};
 
-		if (_control_mode.flag_control_climb_rate_enabled) {
+		if (_control_mode.flag_control_acceleration_enabled || _control_mode.flag_control_climb_rate_enabled) {
 
 			_trajectory_setpoint_sub.update(&_setpoint);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Reported by @JonasVautherin the acceleration setpoints are not executed in offboard.

**Describe your solution**
I had a look at his log and the position controller is not running because it only listens to the climb_rate control mode flag, not the acceleration one. I made this for him to test. As it stands the position controller has to run for acceleration setpoints and we should probably also add the flag to the velocity controlled modes for completeness.

**Test data / coverage**
@JonasVautherin ? :innocent: 

**Additional context**
Previous related changes:
- Make acceleration setpoints work: https://github.com/PX4/PX4-Autopilot/pull/16498
- Control flags refactor: https://github.com/PX4/PX4-Autopilot/pull/16266/files#diff-e4b611e75eba3844661619867ee06befbcf230aced354a14f167f7d0ebbca8e0L3494
- Schedule position control based on climb rate flag: https://github.com/PX4/PX4-Autopilot/pull/16869/files#diff-3fd0d86b4d06526da0551f7256a003ae78e84a241f68fc48f15b1aeff0386d9aR295

Log with which I found the issue:
![image](https://user-images.githubusercontent.com/4668506/110794173-c1d9e800-8275-11eb-87ea-44520c51c8f4.png)
