### PR TITLE
Tools: add env variable to disable follow mode

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -49,6 +49,13 @@ else
 	verbose=""
 fi
 
+# Disable follow mode
+if [[ "$PX4_NO_FOLLOW_MODE" != "1" ]]; then
+    follow_mode="--gui-client-plugin libgazebo_user_camera_plugin.so"
+else
+    follow_mode=""
+fi
+
 if [ "$program" == "jmavsim" ]; then
 	jmavsim_pid=`ps aux | grep java | grep "\-jar jmavsim_run.jar" | awk '{ print $2 }'`
 	if [ -n "$jmavsim_pid" ]; then
@@ -163,7 +170,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 			# gzserver needs to be running to avoid a race. Since the launch
 			# is putting it into the background we need to avoid it by backing off
 			sleep 3
-			nice -n 20 gzclient --verbose --gui-client-plugin libgazebo_user_camera_plugin.so &
+			nice -n 20 gzclient --verbose $follow_mode &
 			GUI_PID=$!
 		fi
 	else


### PR DESCRIPTION
This adds the env variable PX4_NO_FOLLOW_MODE to disable the follow mode in Gazebo.

This was introduced in https://github.com/PX4/PX4-Autopilot/pull/16568 and I find it quite annoying because it means zoom is hardcoded at 8m, see https://github.com/osrf/gazebo/issues/1251.

FYI @JonasVautherin 