### PR TITLE
gyro_fft: run by default on STM32H7

### DIFF
--- a/platforms/nuttx/init/stm32h7/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32h7/rc.board_arch_defaults
@@ -9,6 +9,8 @@ param set-default SENS_IMU_MODE 0
 param set-default EKF2_MULTI_MAG 3
 param set-default SENS_MAG_MODE 0
 
+param set-default IMU_GYRO_FFT_EN 1
+
 param set-default UAVCAN_ENABLE 2
 
 set LOGGER_BUF 64

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -84,7 +84,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("safety");
 	add_topic("sensor_combined");
 	add_topic("sensor_correction");
-	add_topic("sensor_gyro_fft");
+	add_topic("sensor_gyro_fft", 100);
 	add_topic("sensor_preflight_mag", 500);
 	add_topic("sensor_selection");
 	add_topic("sensors_status_imu", 200);


### PR DESCRIPTION
On STM32H7 the `gyro_fft` module costs < 2% cpu and runs in wq:lp_default. Let's run it by default to start getting some data.

<img width="567" alt="Screen Shot 2021-03-11 at 10 31 35 PM" src="https://user-images.githubusercontent.com/84712/110888136-924ccf00-82b9-11eb-9911-b00fbdbb174f.png">


Note you have to set `IMU_GYRO_DYN_NF` to actually use the detected peak frequencies for the bank of gyro notch filters.