### PR TITLE
px4_work_queue: increase wq:rate_ctrl stack

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -48,7 +48,7 @@ struct wq_config_t {
 
 namespace wq_configurations
 {
-static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1888, 0}; // PX4 inner loop highest priority
+static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1920, 0}; // PX4 inner loop highest priority
 static constexpr wq_config_t ctrl_alloc{"wq:ctrl_alloc", 9500, 0}; // PX4 control allocation, same priority as rate_ctrl
 
 static constexpr wq_config_t SPI0{"wq:SPI0", 2336, -1};


### PR DESCRIPTION
``` Console
WARN  [load_mon] wq:rate_ctrl low on stack! (296 bytes left)
WARN  [load_mon] wq:rate_ctrl low on stack! (296 bytes left)
WARN  [load_mon] wq:rate_ctrl low on stack! (296 bytes left)
WARN  [load_mon] wq:rate_ctrl low on stack! (296 bytes left)
WARN  [load_mon] wq:rate_ctrl low on stack! (296 bytes left)
```