### PR TITLE
logging: add parameter defaults

### DIFF
--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -215,13 +215,22 @@ __EXPORT size_t		param_size(param_t param);
 __EXPORT int		param_get(param_t param, void *val);
 
 /**
- * Copy the default value of a parameter.
+ * Copy the (airframe-specific) default value of a parameter.
  *
  * @param param		A handle returned by param_find or passed by param_foreach.
- * @param val		Where to return the value, assumed to point to suitable storage for the parameter type.
+ * @param default_val		Where to return the value, assumed to point to suitable storage for the parameter type.
  * @return		Zero if the parameter's deafult value could be returned, nonzero otherwise.
  */
-__EXPORT int		param_get_default_value(param_t param, void *val);
+__EXPORT int		param_get_default_value(param_t param, void *default_val);
+
+/**
+ * Copy the system-wide default value of a parameter.
+ *
+ * @param param		A handle returned by param_find or passed by param_foreach.
+ * @param default_val		Where to return the value, assumed to point to suitable storage for the parameter type.
+ * @return		Zero if the parameter's deafult value could be returned, nonzero otherwise.
+ */
+__EXPORT int		param_get_system_default_value(param_t param, void *default_val);
 
 /**
  * Set the value of a parameter.

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -617,6 +617,34 @@ bool param_value_is_default(param_t param)
 	return false;
 }
 
+int
+param_get_system_default_value(param_t param, void *default_val)
+{
+	if (!handle_in_range(param)) {
+		return PX4_ERROR;
+	}
+
+	int ret = PX4_OK;
+	param_lock_reader();
+
+	switch (param_type(param)) {
+	case PARAM_TYPE_INT32:
+		memcpy(default_val, &px4::parameters[param].val.i, param_size(param));
+		break;
+
+	case PARAM_TYPE_FLOAT:
+		memcpy(default_val, &px4::parameters[param].val.f, param_size(param));
+		break;
+
+	default:
+		ret = PX4_ERROR;
+		break;
+	}
+
+	param_unlock_reader();
+	return ret;
+}
+
 /**
  * worker callback method to save the parameters
  * @param arg unused

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -258,6 +258,7 @@ private:
 	void write_info_template(LogType type, const char *name, T value, const char *type_str);
 
 	void write_parameters(LogType type);
+	void write_parameter_defaults(LogType type);
 
 	void write_changed_parameters(LogType type);
 

--- a/src/modules/logger/messages.h
+++ b/src/modules/logger/messages.h
@@ -33,12 +33,15 @@
 
 #pragma once
 
+#include <cstdint>
+
 enum class ULogMessageType : uint8_t {
 	FORMAT = 'F',
 	DATA = 'D',
 	INFO = 'I',
 	INFO_MULTIPLE = 'M',
 	PARAMETER = 'P',
+	PARAMETER_DEFAULT = 'Q',
 	ADD_LOGGED_MSG = 'A',
 	REMOVE_LOGGED_MSG = 'R',
 	SYNC = 'S',
@@ -152,8 +155,29 @@ struct ulog_message_parameter_header_s {
 	char key[255];
 };
 
+enum class ulog_parameter_default_type_t : uint8_t {
+	system = (1 << 0),
+	current_setup = (1 << 1) //airframe default
+};
+
+inline ulog_parameter_default_type_t operator|(ulog_parameter_default_type_t a, ulog_parameter_default_type_t b)
+{
+	return static_cast<ulog_parameter_default_type_t>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
+}
+
+struct ulog_message_parameter_default_header_s {
+	uint16_t msg_size;
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::PARAMETER_DEFAULT);
+
+	ulog_parameter_default_type_t default_types;
+	uint8_t key_len;
+	char key[255];
+};
+
 
 #define ULOG_INCOMPAT_FLAG0_DATA_APPENDED_MASK (1<<0)
+
+#define ULOG_COMPAT_FLAG0_DEFAULT_PARAMETERS_MASK (1<<0)
 
 struct ulog_message_flag_bits_s {
 	uint16_t msg_size;

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -843,7 +843,7 @@ do_set_custom_default(const char *name, const char *val)
 				int32_t newval = strtol(val, &end, 10);
 
 				if ((i != newval) && (param_set_default_value(param, &newval) == PX4_OK)) {
-					PARAM_PRINT(" parameter default: %s %d -> %d\n", param_name(param), i, newval);
+					PX4_DEBUG(" parameter default: %s %d -> %d", param_name(param), i, newval);
 				}
 			}
 		}
@@ -859,7 +859,7 @@ do_set_custom_default(const char *name, const char *val)
 				float newval = strtod(val, &end);
 
 				if ((fabsf(f - newval) > FLT_EPSILON) && (param_set_default_value(param, &newval) == PX4_OK)) {
-					PARAM_PRINT(" parameter default: %s %4.2f -> %4.2f\n", param_name(param), (double)f, (double)newval);
+					PX4_DEBUG(" parameter default: %s %4.2f -> %4.2f", param_name(param), (double)f, (double)newval);
 				}
 			}
 		}


### PR DESCRIPTION
- param: remove set-default print's during bootup 
- adds new ulog message & compatibility flag for default parameter values
- separately add airframe and system-wide defaults
- log only non-volatile defaults that are different from the current value
- additional size is ~3KB for 100 params