### PR TITLE
Fix IGNORE_YAW_RATE handling for attitude setpoints in offboard

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1398,7 +1398,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 
 			// TODO: review use case
 			attitude_setpoint.yaw_sp_move_rate = (type_mask & ATTITUDE_TARGET_TYPEMASK_BODY_YAW_RATE_IGNORE) ?
-							     attitude_target.body_yaw_rate : NAN;
+							     NAN : attitude_target.body_yaw_rate;
 
 			if (!(attitude_target.type_mask & ATTITUDE_TARGET_TYPEMASK_THROTTLE_IGNORE)) {
 				fill_thrust(attitude_setpoint.thrust_body, vehicle_status.vehicle_type, attitude_target.thrust);

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
@@ -97,7 +97,9 @@ matrix::Vector3f AttitudeControl::update(const Quatf &q) const
 	// and multiply it by the yaw setpoint rate (yawspeed_setpoint).
 	// This yields a vector representing the commanded rotatation around the world z-axis expressed in the body frame
 	// such that it can be added to the rates setpoint.
-	rate_setpoint += q.inversed().dcm_z() * _yawspeed_setpoint;
+	if (is_finite(_yawspeed_setpoint)) {
+		rate_setpoint += q.inversed().dcm_z() * _yawspeed_setpoint;
+	}
 
 	// limit rates
 	for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
When sending ignore_yaw_rate flag for attitude setpoints in offboard mode, the case handling seems to be reversed. 

**Describe your solution**
This PR fixes the yaw rate ignore case handling for offboard control using the SET_ATTITUDE_TARGET message.

For multirotors, the fix resulted in invalidating the rate setpoints all together with multiplying the `yawspeed_setpoint =nan` directly to the rates setpoints. Therefore a check was added to the MC attitude controller if the yaw speed setpoint is valid

**Test data / coverage**
Before PR: Even if the yaw_rate_ignore flag is set, the vehicle still follows the yaw rate commands in the mavlink message
https://review.px4.io/plot_app?log=a801deb4-346f-48b1-8370-78541b21b832

After PR: :sunglasses: 
https://review.px4.io/plot_app?log=52e7ed56-0bf8-4dd2-bd14-921c8ea258c1

**Additional context**
- Probably my testing in https://github.com/PX4/PX4-Autopilot/pull/16739 was actually not valid for the attitude setpoint since it seems like it was actually following rates (log: https://logs.px4.io/plot_app?log=445e91f6-3c21-4cfd-8549-21ac8363eeda)