### PR TITLE
check sensor count in preflight checks

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -51,7 +51,7 @@ param set-default MPC_MAN_TILT_MAX 60
 param set-default MOT_ORDERING 1
 param set-default DSHOT_CONFIG 600
 
-param set-default SYS_HAS_BARO 0
+param set-default SENS_BARO_MIN_NB 0
 param set-default SENS_MAG_MIN_NB 0
 
 param set-default BAT_N_CELLS 2

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -52,7 +52,7 @@ param set-default MOT_ORDERING 1
 param set-default DSHOT_CONFIG 600
 
 param set-default SYS_HAS_BARO 0
-param set-default SYS_HAS_MAG 0
+param set-default SENS_MAG_MIN_NB 0
 
 param set-default BAT_N_CELLS 2
 # The Whoop uses reversed props

--- a/ROMFS/px4fmu_common/init.d/airframes/4072_draco
+++ b/ROMFS/px4fmu_common/init.d/airframes/4072_draco
@@ -31,7 +31,7 @@ param set-default SYS_MC_EST_GROUP 3
 param set-default ATT_ACC_COMP 0
 param set-default ATT_W_ACC 0.4
 param set-default ATT_W_GYRO_BIAS 0
-param set-default SYS_HAS_MAG 0
+param set-default SENS_MAG_MIN_NB 0
 
 # Attitude & rate gains
 param set-default MC_ROLL_P 8.0

--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -20,7 +20,7 @@ set MIXER quad_x_cw
 set PWM_OUT 1234
 
 param set-default SYS_MC_EST_GROUP 2
-param set-default SYS_HAS_MAG 0
+param set-default SENS_MAG_MIN_NB 0
 param set-default EKF2_AID_MASK 2
 param set-default EKF2_MAG_TYPE 5
 

--- a/boards/holybro/kakutef7/init/rc.board_defaults
+++ b/boards/holybro/kakutef7/init/rc.board_defaults
@@ -15,7 +15,7 @@ param set-default ATT_ACC_COMP 0
 param set-default ATT_W_ACC 0.4000
 param set-default ATT_W_GYRO_BIAS 0.0000
 
-param set-default SYS_HAS_MAG 0
+param set-default SENS_MAG_MIN_NB 0
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090

--- a/boards/omnibus/f4sd/init/rc.board_defaults
+++ b/boards/omnibus/f4sd/init/rc.board_defaults
@@ -15,4 +15,4 @@ param set-default ATT_ACC_COMP 0
 param set-default ATT_W_ACC 0.4000
 param set-default ATT_W_GYRO_BIAS 0.0000
 
-param set-default SYS_HAS_MAG 0
+param set-default SENS_MAG_MIN_NB 0

--- a/boards/spracing/h7extreme/init/rc.board_defaults
+++ b/boards/spracing/h7extreme/init/rc.board_defaults
@@ -15,6 +15,6 @@ param set-default ATT_ACC_COMP 0
 param set-default ATT_W_ACC 0.4000
 param set-default ATT_W_GYRO_BIAS 0.0000
 
-param set-default SYS_HAS_MAG 0
+param set-default SENS_MAG_MIN_NB 0
 
 param set-default DSHOT_CONFIG 600

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -206,21 +206,6 @@ PARAM_DEFINE_INT32(SYS_CAL_TMIN, 5);
 PARAM_DEFINE_INT32(SYS_CAL_TMAX, 10);
 
 /**
- * Control if the vehicle has a barometer
- *
- * Disable this if the board has no barometer, such as some of the Omnibus
- * F4 SD variants.
- * If disabled, the preflight checks will not check for the presence of a
- * barometer.
- *
- * @boolean
- * @reboot_required true
- *
- * @group System
- */
-PARAM_DEFINE_INT32(SYS_HAS_BARO, 1);
-
-/**
  * Enable factory calibration mode
  *
  * If enabled, future sensor calibrations will be stored to /fs/mtd_caldata.

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -206,20 +206,6 @@ PARAM_DEFINE_INT32(SYS_CAL_TMIN, 5);
 PARAM_DEFINE_INT32(SYS_CAL_TMAX, 10);
 
 /**
- * Control if the vehicle has a magnetometer
- *
- * Disable this if the board has no magnetometer, such as the Omnibus F4 SD.
- * If disabled, the preflight checks will not check for the presence of a
- * magnetometer.
- *
- * @boolean
- * @reboot_required true
- *
- * @group System
- */
-PARAM_DEFINE_INT32(SYS_HAS_MAG, 1);
-
-/**
  * Control if the vehicle has a barometer
  *
  * Disable this if the board has no barometer, such as some of the Omnibus

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -152,7 +152,7 @@ private:
 		(ParamInt<px4::params::ATT_EXT_HDG_M>) _param_att_ext_hdg_m,
 		(ParamInt<px4::params::ATT_ACC_COMP>) _param_att_acc_comp,
 		(ParamFloat<px4::params::ATT_BIAS_MAX>) _param_att_bias_mas,
-		(ParamInt<px4::params::SYS_HAS_MAG>) _param_sys_has_mag
+		(ParamInt<px4::params::SENS_MAG_MIN_NB>) _param_sens_mag_min_nb
 	)
 };
 
@@ -373,7 +373,7 @@ AttitudeEstimatorQ::update_parameters(bool force)
 		updateParams();
 
 		// disable mag fusion if the system does not have a mag
-		if (_param_sys_has_mag.get() == 0) {
+		if (_param_sens_mag_min_nb.get() == 0) {
 			_param_att_w_mag.set(0.0f);
 		}
 

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -49,7 +49,6 @@ static constexpr unsigned max_mandatory_gyro_count = 1;
 static constexpr unsigned max_optional_gyro_count = 4;
 static constexpr unsigned max_mandatory_accel_count = 1;
 static constexpr unsigned max_optional_accel_count = 4;
-static constexpr unsigned max_mandatory_mag_count = 1;
 static constexpr unsigned max_optional_mag_count = 4;
 static constexpr unsigned max_mandatory_baro_count = 1;
 static constexpr unsigned max_optional_baro_count = 4;
@@ -68,14 +67,14 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 
 	/* ---- MAG ---- */
 	{
-		int32_t sys_has_mag = 1;
-		param_get(param_find("SYS_HAS_MAG"), &sys_has_mag);
+		int32_t mandatory_mag_count = 1;
+		param_get(param_find("SENS_MAG_MIN_NB"), &mandatory_mag_count);
 
-		if (sys_has_mag == 1) {
+		if (mandatory_mag_count >= 1) {
 
 			/* check all sensors individually, but fail only for mandatory ones */
 			for (unsigned i = 0; i < max_optional_mag_count; i++) {
-				const bool required = (i < max_mandatory_mag_count) && (sys_has_mag == 1);
+				const bool required = (i < (uint32_t) mandatory_mag_count);
 				bool report_fail = report_failures;
 
 				int32_t device_id = -1;

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -50,7 +50,6 @@ static constexpr unsigned max_optional_gyro_count = 4;
 static constexpr unsigned max_mandatory_accel_count = 1;
 static constexpr unsigned max_optional_accel_count = 4;
 static constexpr unsigned max_optional_mag_count = 4;
-static constexpr unsigned max_mandatory_baro_count = 1;
 static constexpr unsigned max_optional_baro_count = 4;
 
 bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
@@ -141,14 +140,14 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 
 	/* ---- BARO ---- */
 	{
-		int32_t sys_has_baro = 1;
-		param_get(param_find("SYS_HAS_BARO"), &sys_has_baro);
+		int32_t mandatory_baro_count = 1;
+		param_get(param_find("SENS_BARO_MIN_NB"), &mandatory_baro_count);
 
 		bool baro_fail_reported = false;
 
 		/* check all sensors, but fail only for mandatory ones */
 		for (unsigned i = 0; i < max_optional_baro_count; i++) {
-			const bool required = (i < max_mandatory_baro_count) && (sys_has_baro == 1);
+			const bool required = (i < (uint32_t) mandatory_baro_count);
 			bool report_fail = (report_failures && !baro_fail_reported);
 
 			int32_t device_id = -1;

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -47,7 +47,6 @@ using namespace time_literals;
 
 static constexpr unsigned max_mandatory_gyro_count = 1;
 static constexpr unsigned max_optional_gyro_count = 4;
-static constexpr unsigned max_mandatory_accel_count = 1;
 static constexpr unsigned max_optional_accel_count = 4;
 static constexpr unsigned max_optional_mag_count = 4;
 static constexpr unsigned max_optional_baro_count = 4;
@@ -99,8 +98,11 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	/* ---- ACCEL ---- */
 	{
 		/* check all sensors individually, but fail only for mandatory ones */
+		int32_t mandatory_accel_count = 1;
+		param_get(param_find("SENS_ACC_MIN_NB"), &mandatory_accel_count);
+
 		for (unsigned i = 0; i < max_optional_accel_count; i++) {
-			const bool required = (i < max_mandatory_accel_count);
+			const bool required = (i < (uint32_t) mandatory_accel_count);
 			bool report_fail = report_failures;
 
 			int32_t device_id = -1;

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -45,7 +45,6 @@
 
 using namespace time_literals;
 
-static constexpr unsigned max_mandatory_gyro_count = 1;
 static constexpr unsigned max_optional_gyro_count = 4;
 static constexpr unsigned max_optional_accel_count = 4;
 static constexpr unsigned max_optional_mag_count = 4;
@@ -122,8 +121,11 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	/* ---- GYRO ---- */
 	{
 		/* check all sensors individually, but fail only for mandatory ones */
+		int32_t mandatory_gyro_count = 1;
+		param_get(param_find("SENS_GYRO_MIN_NB"), &mandatory_gyro_count);
+
 		for (unsigned i = 0; i < max_optional_gyro_count; i++) {
-			const bool required = (i < max_mandatory_gyro_count);
+			const bool required = (i < (uint32_t) mandatory_gyro_count);
 			bool report_fail = report_failures;
 
 			int32_t device_id = -1;

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -259,3 +259,15 @@ PARAM_DEFINE_INT32(SENS_MAG_MIN_NB, 1);
  * @group System
  */
 PARAM_DEFINE_INT32(SENS_BARO_MIN_NB, 1);
+
+
+/**
+ * Number of mandatory accelerometer
+ *
+ * @reboot_required true
+ *
+ * @min 1
+ * @max 4
+ * @group System
+ */
+PARAM_DEFINE_INT32(SENS_ACC_MIN_NB, 1);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -271,3 +271,15 @@ PARAM_DEFINE_INT32(SENS_BARO_MIN_NB, 1);
  * @group System
  */
 PARAM_DEFINE_INT32(SENS_ACC_MIN_NB, 1);
+
+
+/**
+ * Number of mandatory gyroscopes
+ *
+ * @reboot_required true
+ *
+ * @min 1
+ * @max 4
+ * @group System
+ */
+PARAM_DEFINE_INT32(SENS_GYRO_MIN_NB, 1);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -246,3 +246,16 @@ PARAM_DEFINE_INT32(SENS_INT_BARO_EN, 1);
  * @group System
  */
 PARAM_DEFINE_INT32(SENS_MAG_MIN_NB, 1);
+
+/**
+ * Number of mandatory barometers
+ *
+ * If set to 0, no barometers will be used even if one is found
+ *
+ * @reboot_required true
+ *
+ * @min 0
+ * @max 4
+ * @group System
+ */
+PARAM_DEFINE_INT32(SENS_BARO_MIN_NB, 1);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -233,3 +233,16 @@ PARAM_DEFINE_INT32(SENS_IMU_MODE, 1);
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_INT_BARO_EN, 1);
+
+/**
+ * Number of mandatory magnetometers
+ *
+ * If set to 0, no magnetometers will be used even if one is found
+ *
+ * @reboot_required true
+ *
+ * @min 0
+ * @max 4
+ * @group System
+ */
+PARAM_DEFINE_INT32(SENS_MAG_MIN_NB, 1);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -211,7 +211,7 @@ private:
 	void		InitializeVehicleMagnetometer();
 
 	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::SYS_HAS_BARO>) _param_sys_has_baro,
+		(ParamBool<px4::params::SENS_BARO_MIN_NB>) _param_sens_baro_min_nb,
 		(ParamBool<px4::params::SENS_MAG_MIN_NB>) _param_sens_mag_min_nb,
 		(ParamBool<px4::params::SENS_IMU_MODE>) _param_sens_imu_mode
 	)
@@ -477,7 +477,7 @@ void Sensors::adc_poll()
 
 void Sensors::InitializeVehicleAirData()
 {
-	if (_param_sys_has_baro.get()) {
+	if (_param_sens_baro_min_nb.get() > 0) {
 		if (_vehicle_air_data == nullptr) {
 			if (orb_exists(ORB_ID(sensor_baro), 0) == PX4_OK) {
 				_vehicle_air_data = new VehicleAirData();

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -212,7 +212,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamBool<px4::params::SYS_HAS_BARO>) _param_sys_has_baro,
-		(ParamBool<px4::params::SYS_HAS_MAG>) _param_sys_has_mag,
+		(ParamBool<px4::params::SENS_MAG_MIN_NB>) _param_sens_mag_min_nb,
 		(ParamBool<px4::params::SENS_IMU_MODE>) _param_sens_imu_mode
 	)
 };
@@ -545,7 +545,7 @@ void Sensors::InitializeVehicleIMU()
 
 void Sensors::InitializeVehicleMagnetometer()
 {
-	if (_param_sys_has_mag.get()) {
+	if (_param_sens_mag_min_nb.get() > 0) {
 		if (_vehicle_magnetometer == nullptr) {
 			if (orb_exists(ORB_ID(sensor_mag), 0) == PX4_OK) {
 				_vehicle_magnetometer = new VehicleMagnetometer();


### PR DESCRIPTION
**Describe problem solved by this pull request**
I want to be able to refuse takeoff in case I don't have sensors redundancy.
At first this was added because my external mag failed from time to time (hardware issue). In this case, the user could re-calibrate and fly with the autopilot embedded mag. I prefer not to allow this because the autopilot mag is too much disturbed by the payloads.

**Describe your solution**
I added parameters to choose the number of mandatory sensors for accel, gyro, baro and mag.

`SYS_HAS_MAG` and `SYS_HAS_BARO` have been replaced by these new parameters

