### PR TITLE
[commander] more detailed print_status

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -384,6 +384,7 @@ int Commander::custom_command(int argc, char *argv[])
 int Commander::print_status()
 {
 	PX4_INFO("arming: %s", arming_state_names[_status.arming_state]);
+	PX4_INFO("navigation: %s", nav_state_names[_status.nav_state]);
 	return 0;
 }
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -85,6 +85,32 @@ const char *const arming_state_names[vehicle_status_s::ARMING_STATE_MAX] = {
 	"IN_AIR_RESTORE",
 };
 
+// You can index into the array with an navigation_state_t in order to get its textual representation
+const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
+	"MANUAL",
+	"ALTCTL",
+	"POSCTL",
+	"AUTO_MISSION",
+	"AUTO_LOITER",
+	"AUTO_RTL",
+	"6: unallocated",
+	"7: unallocated",
+	"AUTO_LANDENGFAIL",
+	"AUTO_LANDGPSFAIL",
+	"ACRO",
+	"11: UNUSED",
+	"DESCEND",
+	"TERMINATION",
+	"OFFBOARD",
+	"STAB",
+	"16: UNUSED2",
+	"AUTO_TAKEOFF",
+	"AUTO_LAND",
+	"AUTO_FOLLOW_TARGET",
+	"AUTO_PRECLAND",
+	"ORBIT"
+};
+
 static hrt_abstime last_preflight_check = 0;	///< initialize so it gets checked immediately
 
 void set_link_loss_nav_state(vehicle_status_s *status, actuator_armed_s *armed,

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -96,6 +96,7 @@ enum class position_nav_loss_actions_t {
 };
 
 extern const char *const arming_state_names[];
+extern const char *const nav_state_names[];
 
 enum class arm_disarm_reason_t {
 	TRANSITION_TO_STANDBY = 0,


### PR DESCRIPTION
- Added navigation state info to [commander] print_status
- You can see the navigation state when you type commander state in the mavlink shell
- It makes debugging more convenient