### PR TITLE
boards: holybro/kakutef7 disable CONSTRAINED_FLASH to increase optimization

### DIFF
--- a/boards/holybro/kakutef7/default.cmake
+++ b/boards/holybro/kakutef7/default.cmake
@@ -7,7 +7,6 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
-	CONSTRAINED_FLASH
 	SERIAL_PORTS
 		TEL1:/dev/ttyS0 # UART1
 		TEL2:/dev/ttyS1 # UART2
@@ -22,13 +21,15 @@ px4_add_board(
 		gps
 		imu/invensense/icm20689
 		imu/invensense/mpu6000
-		magnetometer
-		optical_flow/px4flow
+		#magnetometer
+		magnetometer/isentek/ist8310
+		#optical_flow/px4flow
 		osd
-		pwm_out_sim
+		#pwm_out_sim
 		pwm_out
 		rc_input
-		telemetry
+		#telemetry
+		telemetry/frsky_telemetry
 		tone_alarm
 	MODULES
 		attitude_estimator_q
@@ -56,26 +57,26 @@ px4_add_board(
 	SYSTEMCMDS
 		bl_update
 		dmesg
-		dumpfile
-		esc_calib
+		#dumpfile
+		#esc_calib
 		hardfault_log
-		i2cdetect
-		led_control
+		#i2cdetect
+		#led_control
 		mixer
 		#motor_ramp
-		motor_test
-		nshterm
+		#motor_test
+		#nshterm
 		param
 		perf
 		pwm
 		reboot
-		reflect
-		sd_bench
+		#reflect
+		#sd_bench
 		top
-		topic_listener
-		tune_control
-		uorb
-		usb_connected
+		#topic_listener
+		#tune_control
+		#uorb
+		#usb_connected
 		ver
 		work_queue
 	)


### PR DESCRIPTION
@bkueng can you give this a quick try? If this helps then please take a look at the subset of included drivers to add any magnetometer drivers actually needed.