### PR TITLE
boards: px4/fmu-v5x disable optional external IMU drivers

### DIFF
--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -31,8 +31,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi088
 		imu/invensense/icm20602
 		imu/invensense/icm42688p


### PR DESCRIPTION
PX4 fmu-v5x slipped over the flash limit in master once a number of things had merged.