### PR TITLE
boards: remove optional external ADIS IMUs to save flash

### DIFF
--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -31,8 +31,6 @@ px4_add_board(
 		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi088
 		imu/invensense/icm20649
 		imu/invensense/icm20689

--- a/boards/cubepilot/cubeyellow/console.cmake
+++ b/boards/cubepilot/cubeyellow/console.cmake
@@ -30,8 +30,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/invensense/icm20602
 		imu/invensense/icm20649
 		imu/invensense/icm20948

--- a/boards/cubepilot/cubeyellow/default.cmake
+++ b/boards/cubepilot/cubeyellow/default.cmake
@@ -30,8 +30,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/invensense/icm20602
 		imu/invensense/icm20649
 		imu/invensense/icm20948

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -30,8 +30,6 @@ px4_add_board(
 		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi088
 		imu/invensense/icm20689
 		irlock

--- a/boards/holybro/pix32v5/default.cmake
+++ b/boards/holybro/pix32v5/default.cmake
@@ -29,8 +29,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -32,8 +32,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/l3gd20
 		imu/lsm303d
 		imu/invensense/icm20608g

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -30,8 +30,6 @@ px4_add_board(
 		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
 		imu/invensense/icm40609d

--- a/boards/px4/fmu-v4/uavcanv1.cmake
+++ b/boards/px4/fmu-v4/uavcanv1.cmake
@@ -29,8 +29,6 @@ px4_add_board(
 		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/invensense/icm20602
 		imu/invensense/icm20608g
 		imu/invensense/icm40609d

--- a/boards/px4/fmu-v5/ctrlalloc.cmake
+++ b/boards/px4/fmu-v5/ctrlalloc.cmake
@@ -29,8 +29,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -29,8 +29,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -24,8 +24,6 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		gps
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		#imu # all available imu drivers
 		imu/bosch/bmi055
 		imu/invensense/icm20602

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -25,8 +25,6 @@ px4_add_board(
 		dshot
 		gps
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		#imu # all available imu drivers
 		imu/bosch/bmi055
 		imu/invensense/icm20602

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -23,8 +23,6 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		gps
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -28,8 +28,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689

--- a/boards/px4/fmu-v5/uavcanv1.cmake
+++ b/boards/px4/fmu-v5/uavcanv1.cmake
@@ -29,8 +29,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi055
 		imu/invensense/icm20602
 		imu/invensense/icm20689

--- a/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
+++ b/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
@@ -29,8 +29,6 @@ px4_add_board(
 		#heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi088
 		imu/invensense/icm20602
 		imu/invensense/icm42688p

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -30,8 +30,6 @@ px4_add_board(
 		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
-		imu/adis16477
-		imu/adis16497
 		imu/bosch/bmi088
 		imu/invensense/icm20649
 		irlock


### PR DESCRIPTION
Looks like we're finally at that point with the 2 MB boards.