### PR TITLE
boards: px4_fmu-v6u_default address flash shortage

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -95,6 +95,7 @@ pipeline {
                      "px4_fmu-v5x_base_phy_DP83848C",
                      "px4_fmu-v5x_default",
                      "px4_fmu-v6u_default",
+                     "px4_fmu-v6u_test",
                      "px4_fmu-v6x_default",
                      "px4_io-v2_default",
                      "spracing_h7extreme_default",

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -72,6 +72,7 @@ jobs:
           px4_fmu-v5x_base_phy_DP83848C,
           px4_fmu-v5x_default,
           px4_fmu-v6u_default,
+          px4_fmu-v6u_test,
           px4_fmu-v6x_default,
           px4_io-v2_default,
           spracing_h7extreme_default,

--- a/boards/px4/fmu-v6u/test.cmake
+++ b/boards/px4/fmu-v6u/test.cmake
@@ -3,11 +3,12 @@ px4_add_board(
 	PLATFORM nuttx
 	VENDOR px4
 	MODEL fmu-v6u
-	LABEL default
+	LABEL test
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
 	BUILD_BOOTLOADER
+	TESTING
 	UAVCAN_INTERFACES 1
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
@@ -50,11 +51,12 @@ px4_add_board(
 		rpm
 		safety_button
 		telemetry # all available telemetry drivers
+		test_ppm
 		tone_alarm
 		uavcan
 	MODULES
 		airspeed_selector
-		attitude_estimator_q
+		#attitude_estimator_q
 		battery_status
 		camera_feedback
 		commander
@@ -70,7 +72,7 @@ px4_add_board(
 		land_detector
 		landing_target_estimator
 		load_mon
-		local_position_estimator
+		#local_position_estimator
 		logger
 		mavlink
 		mc_att_control
@@ -111,7 +113,7 @@ px4_add_board(
 		sd_bench
 		serial_test
 		system_time
-		#tests # tests and test runner
+		tests # tests and test runner
 		top
 		topic_listener
 		tune_control
@@ -121,7 +123,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		fake_gyro
 		fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello


### PR DESCRIPTION
 - create separate `px4_fmu-v6u_test` variant

I think this will become the pattern going forward as we bump up against flash limits in the default variants.