### PR TITLE
New  MPC_ALT_AUTO parameter that Specifies the behavior of climb and descend rate in Auto

### DIFF
--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -341,7 +341,7 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 		math::trajectory::clampToXYNorm(vel_sp_constrained, xy_speed, 0.5f);
 		math::trajectory::clampToZNorm(vel_sp_constrained, z_speed, 0.5f);
 
-		for (int i = 0; i < 3; i++) {
+		for (int i = 0; i < 2; i++) {
 			// If available, use the existing velocity as a feedforward, otherwise replace it
 			if (PX4_ISFINITE(_velocity_setpoint(i))) {
 				_velocity_setpoint(i) += vel_sp_constrained(i);
@@ -349,6 +349,31 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 			} else {
 				_velocity_setpoint(i) = vel_sp_constrained(i);
 			}
+		}
+
+		if (_param_mpc_alt_auto.get() == 1) {
+			// use max rates of climb and descend
+			const float z_dir = sign(_position_setpoint(2) - _trajectory[2].getCurrentPosition());
+			const float vel_sp_z = z_dir * z_speed;
+
+			// If available, use the existing velocity as a feedforward, otherwise replace it
+			if (PX4_ISFINITE(_velocity_setpoint(2))) {
+				_velocity_setpoint(2) += vel_sp_z;
+
+			} else {
+				_velocity_setpoint(2) = vel_sp_z;
+			}
+
+		} else {
+			// diagonal climbing and descending
+			// If available, use the existing velocity as a feedforward, otherwise replace it
+			if (PX4_ISFINITE(_velocity_setpoint(2))) {
+				_velocity_setpoint(2) += vel_sp_constrained(2);
+
+			} else {
+				_velocity_setpoint(2) = vel_sp_constrained(2);
+			}
+
 		}
 	}
 

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -95,6 +95,7 @@ protected:
 					(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor, // acceleration in flight
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
+					(ParamInt<px4::params::MPC_ALT_AUTO>) _param_mpc_alt_auto,
 					(ParamFloat<px4::params::MPC_JERK_AUTO>) _param_mpc_jerk_auto,
 					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
 					(ParamFloat<px4::params::MPC_XY_ERR_MAX>) _param_mpc_xy_err_max

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -594,6 +594,23 @@ PARAM_DEFINE_FLOAT(MPC_JERK_AUTO, 4.0f);
 PARAM_DEFINE_INT32(MPC_ALT_MODE, 0);
 
 /**
+ * Altitude velocity mode in auto mode
+ *
+ * Specifies the behavior of climb and descend rate in Auto.
+ *
+ * Set to 0 - Z velocity and X/Y velocity are synchronized for 3D waypoints.
+ * The vehicle will now fly straight lines between 3D waypoints of different altitudes.
+ * Set to 1 - Z velocity will be the maximum allowed regardless to XY waypoint distance
+ *
+ * @min 0
+ * @max 1
+ * @value 0 diagonal climbing and descending
+ * @value 1 max rates
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_ALT_AUTO, 0);
+
+/**
  * Manual position control stick exponential curve sensitivity
  *
  * The higher the value the less sensitivity the stick has around zero


### PR DESCRIPTION
**Describe problem solved by this pull request**
Many cases the operator wants to climb or descend on max z speed that drone allows. regardless of the horizontal destination.
for examples:
- emergency need to go to safe altitude and safe XY position.
- Need to climb to operation altitude of 200m and to 2km away, but not in diagonal path that will will be too modorate on the Z axis.

Current option is to to that in two steps, first climb/descend and then only to set new horizontal destination. but that might be too 'complex', and not safe.

**Describe your solution**
added MPC_ALT_AUTO parameter that Specifies the behavior of climb and descend rate in Auto.
Set to 0 - Z velocity and X/Y velocity are synchronized for 3D waypoints.
The vehicle will now fly straight lines between 3D waypoints of different altitudes.
[That is the current behavior]

Set to 1 - Z velocity will be the maximum allowed regardless to XY waypoint distance
[that is the 'new' behavior, That behavior is not new, that was the behaviour on version 1.9]

**Describe possible alternatives**
It might be prefered that for each reposition command, a new argument will decide if we want to do the 'diagonal' path or the 'max Z' path.
but that will require Mavlink update, and might cause some compatibility issues.
MAV_CMD_DO_REPOSITION has param 3 free for that...

Another approach is if the argument has not been set (value of 0/Nan), as for today the default will be used.
but values 1 and 2 will allow different path mode for each reposition 

**Test data / coverage**
SITL
