### PR TITLE
gyro_fft: limit to FFT length 512 for now

### DIFF
--- a/boards/cubepilot/cubeorange/console.cmake
+++ b/boards/cubepilot/cubeorange/console.cmake
@@ -57,7 +57,7 @@ px4_add_board(
 		uavcan
 	MODULES
 		airspeed_selector
-		attitude_estimator_q
+		#attitude_estimator_q
 		battery_status
 		camera_feedback
 		commander
@@ -69,11 +69,11 @@ px4_add_board(
 		fw_att_control
 		fw_pos_control_l1
 		gyro_calibration
-		#gyro_fft
+		gyro_fft
 		land_detector
 		landing_target_estimator
 		load_mon
-		local_position_estimator
+		#local_position_estimator
 		logger
 		mavlink
 		mc_att_control
@@ -83,10 +83,10 @@ px4_add_board(
 		#micrortps_bridge
 		navigator
 		rc_update
-		rover_pos_control
+		#rover_pos_control
 		sensors
-		sih
-		temperature_compensation
+		#sih
+		#temperature_compensation
 		vmount
 		vtol_att_control
 	SYSTEMCMDS

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -72,7 +72,7 @@ px4_add_board(
 		fw_att_control
 		fw_pos_control_l1
 		gyro_calibration
-		#gyro_fft
+		gyro_fft
 		land_detector
 		#landing_target_estimator
 		load_mon

--- a/src/modules/gyro_fft/GyroFFT.cpp
+++ b/src/modules/gyro_fft/GyroFFT.cpp
@@ -56,18 +56,6 @@ GyroFFT::GyroFFT() :
 		AllocateBuffers<512>();
 		break;
 
-	case 1024:
-		AllocateBuffers<1024>();
-		break;
-
-	case 2048:
-		AllocateBuffers<2048>();
-		break;
-
-	case 4096:
-		AllocateBuffers<4096>();
-		break;
-
 	default:
 		// otherwise default to 256
 		PX4_ERR("Invalid IMU_GYRO_FFT_LEN=%.3f, resetting", (double)_param_imu_gyro_fft_len.get());

--- a/src/modules/gyro_fft/parameters.c
+++ b/src/modules/gyro_fft/parameters.c
@@ -68,11 +68,8 @@ PARAM_DEFINE_FLOAT(IMU_GYRO_FFT_MAX, 256.f);
 * @value 128 128
 * @value 256 256
 * @value 512 512
-* @value 1024 1024
-* @value 2048 2048
-* @value 4096 4096
 * @unit Hz
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_INT32(IMU_GYRO_FFT_LEN, 1024);
+PARAM_DEFINE_INT32(IMU_GYRO_FFT_LEN, 512);


### PR DESCRIPTION
Temporarily disabling the larger FFT sizes (1024, 2048, 4096) as they seem to be causing problems. These were all flight tested on older hardware (px4_fmu-v4_default), but currently aren't working. https://github.com/PX4/PX4-Autopilot/pull/16385

Something may have broken during the large gyro_fft refactor bringing minimal CMSIS DSP in tree.

