### PR TITLE
Update ubuntu.sh to allow multiple host architectures

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -13,6 +13,7 @@
 
 INSTALL_NUTTX="true"
 INSTALL_SIM="true"
+INSTALL_ARCH=`uname -m`
 
 # Parse arguments
 for arg in "$@"
@@ -149,7 +150,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 
 	else
 		echo "Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
-		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${NUTTX_GCC_VERSION_SHORT}/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-x86_64-linux.tar.bz2 && \
+		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${NUTTX_GCC_VERSION_SHORT}/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-${INSTALL_ARCH}-linux.tar.bz2 && \
 			sudo tar -jxf /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 -C /opt/;
 
 		# add arm-none-eabi-gcc to user's PATH


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
When using `ubuntu.sh` the script fails if using an architecture different from the x86-64.

**Describe your solution**
The correct version of the cross-compiler for ARM is get with wget from the correct repository.

**Describe possible alternatives**
Use alternative commands to get CPU architecture.

**Test data / coverage**
A check has been made to understand which versions of the `gcc-arm-none-eabi` are available for which architectures.

**Additional context**
Tested with Ubuntu 18.04 on Jetson TX2.