### PR TITLE
FlightTaskOrbit: NACK command if coordinates could not get applied

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -77,16 +77,24 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 	_initial_heading = _yaw;
 
 	// commanded center coordinates
-	if (map_projection_initialized(&_global_local_proj_ref)) {
-		if (PX4_ISFINITE(command.param5) && PX4_ISFINITE(command.param6)) {
+	if (PX4_ISFINITE(command.param5) && PX4_ISFINITE(command.param6)) {
+		if (map_projection_initialized(&_global_local_proj_ref)) {
 			map_projection_project(&_global_local_proj_ref,
 					       command.param5, command.param6,
 					       &_center(0), &_center(1));
-		}
 
-		// commanded altitude
-		if (PX4_ISFINITE(command.param7)) {
+		} else {
+			ret = false;
+		}
+	}
+
+	// commanded altitude
+	if (PX4_ISFINITE(command.param7)) {
+		if (map_projection_initialized(&_global_local_proj_ref)) {
 			_position_setpoint(2) = _global_local_alt0 - command.param7;
+
+		} else {
+			ret = false;
 		}
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -167,7 +167,6 @@ bool FlightTaskOrbit::activate(const vehicle_local_position_setpoint_s &last_set
 	_r = _radius_min;
 	_v =  1.f;
 	_center = _position.xy();
-	_center(0) -= _r;
 	_initial_heading = _yaw;
 	_slew_rate_yaw.setForcedValue(_yaw);
 	_slew_rate_yaw.setSlewRate(math::radians(_param_mpc_yawrauto_max.get()));


### PR DESCRIPTION
**Describe problem solved by this pull request**
Thanks to @dagar the coordinates and altitude can now be applied independently see https://github.com/PX4/PX4-Autopilot/commit/263b00b65fc89c7fd9383f0364760fceb15ea12a#diff-89127f427c1fc4e2fb02b97822ec75dc1bc7a4690ae4cd3aba8bc4f811250717R80

But now if the coordinates or altitude could not get set the command is still acknowledged.

**Describe your solution**
- I make sure to send a not acknowledge to the command if any coordinates or altitude were commanded but it failed.
- I also changed the default center location to be exactly where the vehicle currently is to allow exact positioning of the center by flying there manually and command the Orbit without any center coordinates. The radius offset comes from an early testing stage where the logic broke when initializing far from the radius. JFYI @cmic0 

**Test data / coverage**
SITL tested that Orbit still works as expected with the QGC commands.
