### PR TITLE
FlightTaskAcceleration: synchronize XY acceleration profiles

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -73,6 +73,7 @@ private:
 	matrix::Vector2f _position_setpoint;
 	matrix::Vector2f _velocity_setpoint;
 	matrix::Vector2f _acceleration_setpoint;
+	matrix::Vector2f _acceleration_setpoint_prev;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,


### PR DESCRIPTION
**Describe problem solved by this pull request**
When two or more axes have the same rate limitations, the resulting path is not straight if the endpoint isn't the same. The technique to make straight lines is known as "time synchronization" and can be difficult if multiples derivatives have their rate limited. In our case, the acceleration is controlled and only the jerk is limited, so we can simply adjust the amount of jerk allowed on each axis depending on the direction of the setpoint increment.

Before: Banana
![DeepinScreenshot_select-area_20210318103541](https://user-images.githubusercontent.com/14822839/111611099-601cff00-87dc-11eb-98f3-647d5ab39f16.png)

With this PR:
No Banana
![DeepinScreenshot_select-area_20210318113550](https://user-images.githubusercontent.com/14822839/111612786-1e8d5380-87de-11eb-9c85-35302e104c83.png)
![DeepinScreenshot_select-area_20210318113514](https://user-images.githubusercontent.com/14822839/111612794-20571700-87de-11eb-8a3a-10b2c9b1a9a0.png)
