### PR TITLE
mc_pos_control_params: correct cruise speed description

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -258,9 +258,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D_ACC, 0.2f);
 /**
  * Maximum horizontal velocity in mission
  *
- * Normal horizontal velocity in AUTO modes (includes
- * also RTL / hold / etc.) and endpoint for
- * position stabilized mode (POSCTRL).
+ * Horizontal velocity used when flying autonomously in e.g. Missions, RTL, Goto.
  *
  * @unit m/s
  * @min 3.0


### PR DESCRIPTION
**Describe problem solved by this pull request**
It is used in autonomous modes only and has no influence on Position mode.
