### PR TITLE
uavcan_stm32h7:can driver preserve ordering & respect timeouts on borked hardware

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/can.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/can.hpp
@@ -20,10 +20,12 @@ static const uavcan::int16_t ErrNotImplemented          = 1001; ///< Feature not
 static const uavcan::int16_t ErrInvalidBitRate          = 1002; ///< Bit rate not supported
 static const uavcan::int16_t ErrLogic                   = 1003; ///< Internal logic error
 static const uavcan::int16_t ErrUnsupportedFrame        = 1004; ///< Frame not supported (e.g. RTR, CAN FD, etc)
-static const uavcan::int16_t ErrMsrInakNotSet           = 1005; ///< INAK bit of the MSR register is not 1
-static const uavcan::int16_t ErrMsrInakNotCleared       = 1006; ///< INAK bit of the MSR register is not 0
+static const uavcan::int16_t ErrCCCrCSANotSet           = 1005; ///< CSA bit of the CCCR register is not 1
+static const uavcan::int16_t ErrCCCrCSANotCleared       = 1006; ///< CSA bit of the CCCR register is not 0
 static const uavcan::int16_t ErrBitRateNotDetected      = 1007; ///< Auto bit rate detection could not be finished
 static const uavcan::int16_t ErrFilterNumConfigs        = 1008; ///< Number of filters is more than supported
+static const uavcan::int16_t ErrCCCrINITNotSet          = 1000; ///< INIT bit of the CCCR register is not 1
+static const uavcan::int16_t ErrCCCrINITNotCleared      = 1010; ///< INIT bit of the CCCR register is not 0
 
 /**
  * RX queue item.
@@ -138,6 +140,8 @@ class CanIface : public uavcan::ICanIface, uavcan::Noncopyable
 			uavcan::uint16_t num_configs);
 
 	virtual uavcan::uint16_t getNumFilters() const { return NumFilters; }
+
+	bool waitCCCRBitStateChange(uint32_t mask, bool target_state);
 
 public:
 	enum { MaxRxQueueCapacity = 64 };

--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/can.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/include/uavcan_stm32h7/can.hpp
@@ -112,7 +112,7 @@ class CanIface : public uavcan::ICanIface, uavcan::Noncopyable
 		uavcan::uint32_t ExtIdFilterSA;
 		uavcan::uint32_t RxFIFO0SA;
 		uavcan::uint32_t RxFIFO1SA;
-		uavcan::uint32_t TxQueueSA;
+		uavcan::uint32_t TxFIFOSA;
 	} message_ram_;
 
 	enum { NumTxMailboxes = 32 }; // Should match the number of Tx FIFOs available in message RAM


### PR DESCRIPTION


     Referring to the refernece manual:

     Tx queue operation is configured by programming FDCAN_TXBC.TFQM to 1. Messages
     stored in the Tx queue are transmitted starting with the message with the lowest message
     ID (highest priority). **In case that multiple queue buffers are configured with the same
     message ID, the queue buffer with the lowest buffer number is transmitted first**

    Tx FIFO operation is configured by programming FDCAN_TXBC.TFQM to 0. Messages
    stored in the Tx FIFO are transmitted starting with the message referenced by the get index
    FDCAN_TXFQS.TFGI. After each transmission the get index is incremented cyclically until
    the Tx FIFO is empty. The Tx FIFO enables transmission of messages with the same
    message ID from different Tx buffers in the order these messages have been written to the
    Tx FIFO

    The issue will be cancelation:

    The FDCAN supports transmit cancellation. To cancel a requested transmission from a
    dedicated Tx buffer or a Tx queue buffer the Host has to write a 1 to the corresponding bit
    position (= number of Tx buffer) of register FDCAN_TXBCR. Transmit cancellation is not
    intended for Tx FIFO operation.

    But there is nothing preventing it. This seems to indicate it will
    work. When a transmission request for the Tx buffer referenced by the get index is canceled, the
    get index is incremented to the next Tx buffer with pending transmission request and the Tx
    FIFO free level is recalculated. When transmission cancellation is applied to any other Tx
    buffer, the get index and the FIFO free level remain unchanged.