### PR TITLE
boards: ark/can-flow add debug build and reduce default

### DIFF
--- a/boards/ark/can-flow/debug.cmake
+++ b/boards/ark/can-flow/debug.cmake
@@ -4,10 +4,9 @@ px4_add_board(
 	PLATFORM nuttx
 	VENDOR ark
 	MODEL can-flow
-	LABEL default
+	LABEL debug
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
-	CONSTRAINED_FLASH
 	CONSTRAINED_MEMORY
 	ROMFSROOT cannode
 	UAVCAN_INTERFACES 1
@@ -18,17 +17,17 @@ px4_add_board(
 		uavcannode
 	MODULES
 		#ekf2
-		#load_mon
+		load_mon
 		#sensors
 	SYSTEMCMDS
 		mft
 		mtd
 		param
-		#perf
-		#reboot
-		#system_time
-		#top
-		#topic_listener
-		#ver
-		#work_queue
+		perf
+		reboot
+		system_time
+		top
+		topic_listener
+		ver
+		work_queue
 )


### PR DESCRIPTION
This strips out the command line debug helpers from `ark_can-flow_default` to reduce the binary size. Everything is still available in  `ark_can-flow_debug`.

### Before
``` Console
Memory region         Used Size  Region Size  %age Used
           flash:      397481 B       448 KB     86.64%
            sram:       12672 B       192 KB      6.45%
```

### After
``` Console
Memory region         Used Size  Region Size  %age Used
           flash:      268753 B       448 KB     58.58%
            sram:       12588 B       192 KB      6.40%

```