### PR TITLE
Improve ekf2 preflight check

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -236,18 +236,19 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	}
 
 	if (estimator_type == 2) {
-		bool ekf_healthy = false;
 
-		// don't report ekf failures for the first 10 seconds to allow time for the filter to start
-		if (time_since_boot > 10_s) {
+		const bool ekf_healthy = ekf2Check(mavlink_log_pub, status, false, report_failures) &&
+					 ekf2CheckSensorBias(mavlink_log_pub, report_failures);
 
-			ekf_healthy = ekf2Check(mavlink_log_pub, status, false, report_failures) &&
-				      ekf2CheckSensorBias(mavlink_log_pub, report_failures);
+		// For the first 10 seconds the ekf2 can be unhealthy, and we just mark it
+		// as not present.
+		// After that or if report_failures is true, we'll set the flags as is.
 
-			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_AHRS, true, true, ekf_healthy, status);
+		if (!ekf_healthy && time_since_boot < 10_s && !report_failures) {
+			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_AHRS, true, false, false, status);
 
 		} else {
-			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_AHRS, true, false, false, status);
+			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_AHRS, true, true, ekf_healthy, status);
 		}
 
 		failed |= !ekf_healthy;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2479,7 +2479,8 @@ Commander::run()
 
 			// Evaluate current prearm status
 			if (!_armed.armed && !_status_flags.condition_calibration_enabled) {
-				bool preflight_check_res = PreFlightCheck::preflightCheck(nullptr, _status, _status_flags, false, true, 30_s);
+				bool preflight_check_res = PreFlightCheck::preflightCheck(nullptr, _status, _status_flags, false, true,
+							   hrt_elapsed_time(&_boot_timestamp));
 
 				// skip arm authorization check until actual arming attempt
 				PreFlightCheck::arm_requirements_t arm_req = _arm_requirements;


### PR DESCRIPTION
This should prevent some of the timeouts we have been seeing in CI tests where arming silently fails.

When reviewing check the individual commit messages.

https://github.com/PX4/PX4-Autopilot/pull/17158/checks?check_run_id=2138194910#step:17:212
https://github.com/PX4/PX4-Autopilot/pull/17158/checks?check_run_id=2138194952#step:17:212