### PR TITLE
cmake: add install_python_requirements helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,3 +454,10 @@ add_custom_target(size
 	WORKING_DIRECTORY ${PX4_BINARY_DIR}
 	USES_TERMINAL
 	)
+
+# install python requirements using configured python
+add_custom_target(install_python_requirements
+	COMMAND ${PYTHON_EXECUTABLE} -m pip install --requirement ${PX4_SOURCE_DIR}/Tools/setup/requirements.txt
+	DEPENDS ${PX4_SOURCE_DIR}/Tools/setup/requirements.txt
+	USES_TERMINAL
+)


### PR DESCRIPTION
 - this is useful because it installs the python requirements using the python interpreter found and used by cmake