### PR TITLE
micro_hal: use inline methods instead of #define's

### DIFF
--- a/platforms/posix/src/px4/common/include/px4_platform/micro_hal.h
+++ b/platforms/posix/src/px4/common/include/px4_platform/micro_hal.h
@@ -32,11 +32,17 @@
  ****************************************************************************/
 #pragma once
 
-#define px4_arch_configgpio(pinset)              -1
-#define px4_arch_unconfiggpio(pinset)
-#define px4_arch_gpioread(pinset)                -1
-#define px4_arch_gpiowrite(pinset, value)        -1
-#define px4_arch_gpiosetevent(pinset,r,f,e,fp,a) -1
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef int (*xcpt_t)(int irq, void *context, void *arg);
+
+static inline int px4_arch_configgpio(uint32_t pinset) { return -1; }
+static inline int px4_arch_unconfiggpio(uint32_t pinset) { return -1; }
+static inline bool px4_arch_gpioread(uint32_t pinset) { return false; }
+static inline void px4_arch_gpiowrite(uint32_t pinset, bool value) { }
+static inline int px4_arch_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
+					bool event, xcpt_t func, void *arg) { return -1; }
 
 #define px4_udelay(usec) px4_usleep(usec)
 #define px4_mdelay(msec) px4_msleep(msec)


### PR DESCRIPTION
Fixes errors in the form of 'error: statement has no effect'

fixes #17173

@Pskoog3 can you test this?