### PR TITLE
Remove hardcoded units in land_detector_params

### DIFF
--- a/src/modules/land_detector/land_detector_params_fw.c
+++ b/src/modules/land_detector/land_detector_params_fw.c
@@ -34,7 +34,7 @@
 /**
  * Fixedwing max horizontal velocity
  *
- * Maximum horizontal velocity allowed in the landed state (m/s)
+ * Maximum horizontal velocity allowed in the landed state
  *
  * @unit m/s
  * @min 0.5
@@ -48,7 +48,7 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 5.0f);
 /**
  * Fixedwing max climb rate
  *
- * Maximum vertical velocity allowed in the landed state (m/s up and down)
+ * Maximum vertical velocity allowed in the landed state
  *
  * @unit m/s
  * @min 0.1
@@ -62,7 +62,7 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 3.0f);
 /**
  * Fixedwing max horizontal acceleration
  *
- * Maximum horizontal (x,y body axes) acceleration allowed in the landed state (m/s^2)
+ * Maximum horizontal (x,y body axes) acceleration allowed in the landed state
  *
  * @unit m/s^2
  * @min 2
@@ -76,7 +76,7 @@ PARAM_DEFINE_FLOAT(LNDFW_XYACC_MAX, 8.0f);
 /**
  * Airspeed max
  *
- * Maximum airspeed allowed in the landed state (m/s)
+ * Maximum airspeed allowed in the landed state
  *
  * @unit m/s
  * @min 4

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -34,7 +34,7 @@
 /**
  * Multicopter max climb rate
  *
- * Maximum vertical velocity allowed in the landed state (m/s up and down)
+ * Maximum vertical velocity allowed in the landed state
  *
  * @unit m/s
  * @decimal 1
@@ -46,7 +46,7 @@ PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.50f);
 /**
  * Multicopter max horizontal velocity
  *
- * Maximum horizontal velocity allowed in the landed state (m/s)
+ * Maximum horizontal velocity allowed in the landed state
  *
  * @unit m/s
  * @decimal 1


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

cc @bresch 

**Describe problem solved by this pull request**
When using units besides the SI system, the description of the units used by the parameter and the unit expected as input don't agree. For example, someone whose ground control software is using mph will see the parameter field take mph as input, but the description claims that this parameter should be given input in m/s.

**Describe your solution**
By removing the units from the descriptive comments in the land_detector_params files, the user should not see disagreeing units between the input field and the description of the parameter.

**Additional context**
![Image](https://user-images.githubusercontent.com/103444/111973259-36264e00-8af6-11eb-8440-5dc22396ee46.jpeg)
