### PR TITLE
use github CI to deploy metadata to S3

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -1,0 +1,77 @@
+name: Deploy metadata for all targets
+
+on:
+  push:
+    branches:
+    - 'master'
+    - 'release/*'
+    - 'pr-metadata-test'
+
+jobs:
+  enumerate_targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{secrets.ACCESS_TOKEN}}
+    - id: set-matrix
+      run: echo "::set-output name=matrix::$(./Tools/generate_board_targets_json.py)"
+  build:
+    runs-on: ubuntu-latest
+    needs: enumerate_targets
+    strategy:
+      matrix: ${{fromJson(needs.enumerate_targets.outputs.matrix)}}
+    container: px4io/px4-dev-${{ matrix.container }}:2021-02-04
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{secrets.ACCESS_TOKEN}}
+
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+    - name: ccache cache files
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: ${{matrix.target}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+        restore-keys: ${{matrix.target}}-ccache-
+    - name: setup ccache
+      run: |
+          mkdir -p ~/.ccache
+          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          echo "compression_level = 5" >> ~/.ccache/ccache.conf
+          echo "max_size = 100M" >> ~/.ccache/ccache.conf
+          ccache -s
+          ccache -z
+
+    - name: make ${{matrix.target}}
+      run: make ${{matrix.target}}
+    - name: ccache post-run
+      run: ccache -s
+
+    - name: parameter metadata
+      run: |
+        make ${{matrix.target}} ver_gen
+        ./src/lib/version/get_git_tag_or_branch_version.sh build/${{ matrix.target }} >> $GITHUB_ENV
+        cd build/${{ matrix.target }}
+        mkdir _metadata || true
+        cp parameters.* _metadata
+
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read
+      env:
+        AWS_S3_BUCKET: 'px4-travis'
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-west-1'
+        SOURCE_DIR: 'build/${{ matrix.target }}/_metadata/'
+        DEST_DIR: 'Firmware/${{ env.version }}/${{ matrix.target }}/'
+

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
     - 'master'
-  pull_request:
-    branches:
-    - '*'
+    - 'release/*'
+    - 'pr-metadata-test'
 
 jobs:
 
@@ -51,9 +50,18 @@ jobs:
     - name: parameter metadata
       run: |
         make parameters_metadata
-        cd build/px4_sitl_default/docs
-        ls -ls *
-      # TODO: deploy 'parameters.md, parameters.xml to S3 px4-travis:Firmware/master/
+        ./src/lib/version/get_git_tag_or_branch_version.sh build/px4_sitl_default >> $GITHUB_ENV
+
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read
+      env:
+        AWS_S3_BUCKET: 'px4-travis'
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-west-1'
+        SOURCE_DIR: 'build/px4_sitl_default/docs/'
+        DEST_DIR: 'Firmware/${{ env.version }}/_general/'
 
   uorb_graph:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ include(px4_parse_function_args)
 include(px4_git)
 
 execute_process(
-	COMMAND git describe --always --tags
+	COMMAND git describe --exclude ext/* --always --tags
 	OUTPUT_VARIABLE PX4_GIT_TAG
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ coverity_scan: px4_sitl_default
 .PHONY: parameters_metadata airframe_metadata module_documentation px4_metadata doxygen
 
 parameters_metadata:
-	@$(MAKE) --no-print-directory px4_sitl_default metadata_parameters
+	@$(MAKE) --no-print-directory px4_sitl_default metadata_parameters ver_gen
 
 airframe_metadata:
 	@$(MAKE) --no-print-directory px4_sitl_default metadata_airframes

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -22,7 +22,11 @@ verbose = args.verbose
 build_configs = []
 excluded_manufacturers = ['atlflight']
 excluded_platforms = ['qurt']
-excluded_labels = ['stackcheck', 'nolockstep', 'replay', 'test']
+excluded_labels = [
+    'stackcheck',
+    'nolockstep', 'replay', 'test',
+    'uavcanv1' # TODO: fix and enable
+    ]
 
 def process_target(cmake_file, target_name):
     ret = None

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+""" Script to generate a JSON config with all build targets (for CI) """
+
+import argparse
+import os
+import sys
+import json
+import re
+
+source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+
+parser = argparse.ArgumentParser(description='Generate build targets')
+
+parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
+                    help='Verbose Output')
+parser.add_argument('-p', '--pretty', dest='pretty', action='store_true',
+                    help='Pretty output instead of a single line')
+
+args = parser.parse_args()
+verbose = args.verbose
+
+build_configs = []
+excluded_manufacturers = ['atlflight']
+excluded_platforms = ['qurt']
+excluded_labels = ['stackcheck', 'nolockstep', 'replay', 'test']
+
+def process_target(cmake_file, target_name):
+    ret = None
+    is_board_def = False
+    platform = None
+    toolchain = None
+    for line in open(cmake_file, 'r'):
+        if 'px4_add_board' in line:
+            is_board_def = True
+        if not is_board_def:
+            continue
+
+        re_platform = re.search('PLATFORM\s+([^\s]+)', line)
+        if re_platform: platform = re_platform.group(1)
+
+        re_toolchain = re.search('TOOLCHAIN\s+([^\s]+)', line)
+        if re_toolchain: toolchain = re_toolchain.group(1)
+
+    if is_board_def:
+        assert platform, f"PLATFORM not found in {cmake_file}"
+
+        if platform not in excluded_platforms:
+            # get the container based on the platform and toolchain
+            container = platform
+            if platform == 'posix':
+                container = 'base-focal'
+                if toolchain:
+                    if toolchain.startswith('aarch64'):
+                        container = 'aarch64'
+                    elif toolchain == 'arm-linux-gnueabihf':
+                        container = 'armhf'
+                    else:
+                        if verbose: print(f'possibly unmatched toolchain: {toolchain}')
+            elif platform == 'nuttx':
+                container = 'nuttx-focal'
+
+            ret = {'target': target_name, 'container': container}
+    return ret
+
+for manufacturer in os.scandir(os.path.join(source_dir, 'boards')):
+    if not manufacturer.is_dir():
+        continue
+    if manufacturer.name in excluded_manufacturers:
+        if verbose: print(f'excluding manufacturer {manufacturer.name}')
+        continue
+
+    for board in os.scandir(manufacturer.path):
+        if not board.is_dir():
+            continue
+        for files in os.scandir(board.path):
+            if files.is_file() and files.name.endswith('.cmake'):
+                label = files.name[:-6]
+                target_name = manufacturer.name + '_' + board.name + '_' + label
+                if label in excluded_labels:
+                    if verbose: print(f'excluding label {label} ({target_name})')
+                    continue
+                target = process_target(files.path, target_name)
+                if target is not None:
+                    build_configs.append(target)
+
+
+github_action_config = { 'include': build_configs }
+extra_args = {}
+if args.pretty:
+    extra_args['indent'] = 2
+print(json.dumps(github_action_config, **extra_args))
+

--- a/Tools/px4.py
+++ b/Tools/px4.py
@@ -65,7 +65,7 @@ def get_version():
 
     if os.path.isdir(os.path.join(px4_dir, '.git')):
         # If inside a clone PX4 Firmware repository, get version from "git describe"
-        cmd = 'git describe --abbrev=0 --tags'
+        cmd = 'git describe --exclude ext/* --abbrev=0 --tags'
         try:
             version = subprocess.check_output(
                 cmd, cwd=px4_dir, shell=True).decode().strip()

--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -99,7 +99,7 @@ if args.summary != None:
 if args.description != None:
 	desc['description']	= str(args.description)
 if args.git_identity != None:
-	cmd = "git --git-dir '{:}/.git' describe --always --tags".format(args.git_identity)
+	cmd = "git --git-dir '{:}/.git' describe --exclude ext/* --always --tags".format(args.git_identity)
 	p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
 	desc['git_identity']	= str(p.read().strip())
 	p.close()

--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -101,11 +101,11 @@ if args.description != None:
 if args.git_identity != None:
 	cmd = "git --git-dir '{:}/.git' describe --exclude ext/* --always --tags".format(args.git_identity)
 	p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-	desc['git_identity']	= str(p.read().strip())
+	desc['git_identity']	= p.read().strip().decode('utf-8')
 	p.close()
 	cmd = "git --git-dir '{:}/.git' rev-parse --verify HEAD".format(args.git_identity)
 	p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE).stdout
-	desc['git_hash']	= str(p.read().strip())
+	desc['git_hash']	= p.read().strip().decode('utf-8')
 	p.close()
 if args.parameter_xml != None:
 	f = open(args.parameter_xml, "rb")

--- a/boards/px4/fmu-v4/uavcanv1.cmake
+++ b/boards/px4/fmu-v4/uavcanv1.cmake
@@ -50,7 +50,6 @@ px4_add_board(
 		rc_input
 		roboclaw
 		safety_button
-		tap_esc
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
@@ -125,7 +124,6 @@ px4_add_board(
 		fake_gyro
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
-		gyro_fft
 		hello
 		hwtest # Hardware test
 		#matlab_csv_serial

--- a/src/lib/version/get_git_tag_or_branch_version.sh
+++ b/src/lib/version/get_git_tag_or_branch_version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Script to extract PX4_GIT_TAG_OR_BRANCH_NAME to be used by CI
+
+build_dir="$1"
+if [ ! -d "$build_dir" ]; then
+	echo "usage: $0 <build directory>"
+	exit -1
+fi
+
+version_file="$build_dir/src/lib/version/build_git_version.h"
+
+if [ ! -f "$version_file" ]; then
+	echo "Version file not found. Did you run the target 'ver_gen'?"
+	exit -1
+fi
+
+sed -n 's/.*PX4_GIT_TAG_OR_BRANCH_NAME\s*"\(.*\)".*/version=\1/p' "$version_file"
+

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -37,7 +37,7 @@ header = """
 
 
 # PX4
-git_tag = subprocess.check_output('git describe --always --tags --dirty'.split(),
+git_tag = subprocess.check_output('git describe --exclude ext/* --always --tags --dirty'.split(),
                                   stderr=subprocess.STDOUT).decode('utf-8').strip()
 if validate:
     if verbose:

--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -84,15 +84,26 @@ except:
     git_branch_name = ''
 git_version_short = git_version[0:16]
 
+# OEM version
+try:
+    oem_tag = subprocess.check_output('git describe --match ext/oem-* --tags'.split(),
+                                      stderr=subprocess.STDOUT).decode('utf-8').strip()
+    oem_tag = oem_tag[8:]
+except:
+    oem_tag = ''
+
 header += """
 #define PX4_GIT_VERSION_STR  "{git_version}"
 #define PX4_GIT_VERSION_BINARY 0x{git_version_short}
 #define PX4_GIT_TAG_STR  "{git_tag}"
 #define PX4_GIT_BRANCH_NAME  "{git_branch_name}"
+
+#define PX4_GIT_OEM_VERSION_STR  "{oem_tag}"
 """.format(git_tag=git_tag,
            git_version=git_version,
            git_version_short=git_version_short,
-           git_branch_name=git_branch_name)
+           git_branch_name=git_branch_name,
+           oem_tag=oem_tag)
 
 
 # ECL

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -370,3 +370,8 @@ uint64_t px4_os_version_binary(void)
 #endif
 }
 
+const char *px4_firmware_oem_version_string(void)
+{
+	return PX4_GIT_OEM_VERSION_STR;
+}
+

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -187,5 +187,10 @@ __EXPORT uint64_t px4_mavlink_lib_version_binary(void);
  */
 __EXPORT uint64_t px4_os_version_binary(void);
 
+/**
+ * get the git oem version tag (can be empty, no particular format)
+ */
+__EXPORT const char *px4_firmware_oem_version_string(void);
+
 __END_DECLS
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1781,6 +1781,13 @@ void Logger::write_version(LogType type)
 		write_info(type, "sys_os_ver", os_version);
 	}
 
+	const char *oem_version = px4_firmware_oem_version_string();
+
+	if (oem_version && oem_version[0]) {
+		write_info(type, "ver_oem", oem_version);
+	}
+
+
 	write_info(type, "sys_os_ver_release", px4_os_version());
 	write_info(type, "sys_toolchain", px4_toolchain_name());
 	write_info(type, "sys_toolchain_ver", px4_toolchain_version());


### PR DESCRIPTION
- enumerate all existing build targets & variants automatically (with some excludes, like qurt or sitl replay)
  - pushes parameter metadata to S3. This can be extended to other metadata & binaries as well (replacing Jenkins)
  - directory structure is as below
  - there's some inconsistency with container naming (some add `-focal` while others do not) that should be fixed
- ignores `ext/*` git tags, to allow for external/extra git tags

### S3 directory structure
- general metadata, containing all modules (e.g. for flight review): `Firmware/<version>/_general/`
- per-board: `Firmware/<version>/<board>/`
  - `version`: if on a git tag, it's the git tag, if on a `release/x.y` branch, it's `release-x.y`, otherwise it's `master`. This could also be made more granular (e.g. commits on master) if needed.
  - `board`: this is the build target, e.g. `px4_fmu-v4_uavcanv1`