### PR TITLE
sensors/vehicle_angular_velocity: unify filtering for both FIFO and regular use cases

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -75,11 +75,17 @@ public:
 private:
 	void Run() override;
 
+	void CalibrateAndPublish(const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity,
+				 const matrix::Vector3f &angular_acceleration, float scale = 1.f);
+
+	float FilterAngularVelocity(int axis, float data[], int N);
+	float FilterAngularAcceleration(int axis, float data[], int N, float dt_s);
+
 	void DisableDynamicNotchEscRpm();
 	void DisableDynamicNotchFFT();
 	void ParametersUpdate(bool force = false);
-	void Publish(const hrt_abstime &timestamp_sample);
-	void ResetFilters(const matrix::Vector3f &angular_velocity, const matrix::Vector3f &angular_acceleration);
+
+	void ResetFilters();
 	void SensorBiasUpdate(bool force = false);
 	bool SensorSelectionUpdate(bool force = false);
 	void UpdateDynamicNotchEscRpm(bool force = false);
@@ -88,6 +94,7 @@ private:
 
 	// scaled appropriately for current FIFO mode
 	matrix::Vector3f GetResetAngularVelocity() const;
+	matrix::Vector3f GetResetAngularAcceleration() const;
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
 


### PR DESCRIPTION
For efficiency reasons when using FIFO gyro data we perform all filtering (angular velocity, angular acceleration) directly on all available raw data per axis, then apply the sensor calibration and corrections on the filtered value right before publication. This PR unifies that filtering so that it's the same for both FIFO and non-FIFO gyros. The code is a bit uglier, but this reduces the maintenance burden and any surprises when switching between FIFO and non-FIFO gyro sources (could happen midflight).