### PR TITLE
vtol_defaults: set the default GPS model

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -13,6 +13,8 @@ param set-default MIS_YAW_TMT 10
 param set-default EKF2_ARSP_THR 10
 param set-default EKF2_FUSE_BETA 1
 
+param set-default GPS_UBX_DYNMODEL 7
+
 param set-default MIS_DIST_WPS 5000
 
 param set-default MPC_ACC_HOR_MAX 2


### PR DESCRIPTION
**Describe problem solved by this pull request**
When using a multicopter airframe and switching to a VTOL airframe the GPS model is not changed back to the default anymore.

**Describe your solution**
I specify explicitly the default GPS model for VTOL such that it gets set.

**Test data / coverage**
We are using this GPS model for VTOLs already it's just the global default and not explicitly for VTOL.
