### PR TITLE
Add nxp_ucans32k146_canbootloader to CI archive to

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -71,6 +71,7 @@ pipeline {
                      "nxp_fmuk66-v3_socketcan",
                      "nxp_fmurt1062-v1_default",
                      "nxp_ucans32k146_default",
+                     "nxp_ucans32k146_canbootloader",
                      "omnibus_f4sd_default",
                      "px4_fmu-v2_default",
                      "px4_fmu-v2_fixedwing",

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -50,6 +50,7 @@ jobs:
           nxp_fmuk66-v3_socketcan,
           nxp_fmurt1062-v1_default,
           nxp_ucans32k146_default,
+          nxp_ucans32k146_canbootloader,
           omnibus_f4sd_default,
           px4_fmu-v2_default,
           px4_fmu-v2_fixedwing,


### PR DESCRIPTION
Add nxp_ucans32k146_canbootloader to CI archive to distribute UCANS32K146 bootloader on the web