### PR TITLE
systemcmds/tests: split out individual module test commands

### DIFF
--- a/Tools/HIL/run_tests.py
+++ b/Tools/HIL/run_tests.py
@@ -103,12 +103,6 @@ class TestHardwareMethods(unittest.TestCase):
     def test_bson(self):
         self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "bson"))
 
-    def test_commander(self):
-        self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "commander"))
-
-    def test_controllib(self):
-        self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "controllib"))
-
     # def test_dataman(self):
     #     self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "dataman"))
 
@@ -171,9 +165,6 @@ class TestHardwareMethods(unittest.TestCase):
 
     def test_time(self):
         self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "time"))
-
-    def test_uorb(self):
-        self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "uorb"))
 
     def test_versioning(self):
         self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "versioning"))

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -14,6 +14,7 @@ px4_add_board(
 		camera_trigger
 		#differential_pressure # all available differential pressure drivers
 		#distance_sensor # all available distance sensor drivers
+		distance_sensor/lightware_laser_serial
 		gps
 		#imu # all available imu drivers
 		#magnetometer # all available magnetometer drivers

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -2,14 +2,12 @@
 # tests
 #
 
-# TODO: find a way to keep this in sync with tests_main
+# tests command arguments
 set(tests
 	atomic_bitset
 	bezier
 	bitset
 	bson
-	commander
-	controllib
 	conv
 	dataman
 	file2
@@ -30,27 +28,11 @@ set(tests
 	param
 	parameters
 	perf
-	rc
 	search_min
 	servo
-	#lightware_laser
 	sleep
-	uorb
 	versioning
-	)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	list(REMOVE_ITEM tests
-		mixer
-		uorb
-	)
-endif()
-
-if (CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
-	list(REMOVE_ITEM tests
-		uorb
-	)
-endif()
+)
 
 foreach(test_name ${tests})
 	set(test_name_prefix sitl-${test_name})
@@ -71,6 +53,35 @@ foreach(test_name ${tests})
 endforeach()
 
 
+# standalone tests
+set(cmd_tests
+	commander_tests
+	controllib_test
+	lightware_laser_test
+	rc_tests
+	uorb_tests
+)
+
+foreach(test_name ${cmd_tests})
+	set(test_name_prefix sitl-${test_name})
+	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_cmd_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_${test_name}_generated)
+
+	add_test(NAME ${test_name_prefix}
+		COMMAND $<TARGET_FILE:px4>
+			-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_${test_name}_generated
+			-t ${PX4_SOURCE_DIR}/test_data
+			${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+		WORKING_DIRECTORY ${SITL_WORKING_DIR}
+	)
+
+	set_tests_properties(${test_name_prefix} PROPERTIES FAIL_REGULAR_EXPRESSION "FAIL")
+	set_tests_properties(${test_name_prefix} PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
+
+	sanitizer_fail_test_on_error(${test_name_prefix})
+endforeach()
+
+
+
 # Mavlink test requires mavlink running
 add_test(NAME sitl-mavlink
 	COMMAND $<TARGET_FILE:px4>
@@ -80,25 +91,26 @@ add_test(NAME sitl-mavlink
 	WORKING_DIRECTORY ${SITL_WORKING_DIR}
 )
 
-set_tests_properties(sitl-mavlink PROPERTIES FAIL_REGULAR_EXPRESSION "mavlink FAILED")
-set_tests_properties(sitl-mavlink PROPERTIES PASS_REGULAR_EXPRESSION "mavlink PASSED")
+set_tests_properties(sitl-mavlink PROPERTIES FAIL_REGULAR_EXPRESSION "FAIL")
+set_tests_properties(sitl-mavlink PROPERTIES PASS_REGULAR_EXPRESSION "ALL TESTS PASSED")
 sanitizer_fail_test_on_error(sitl-mavlink)
 
-# A mystery why this fails on Cygwin currently.
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
-	# Shutdown test
-	add_test(NAME sitl-shutdown
-		COMMAND $<TARGET_FILE:px4>
-			-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_shutdown
-			-t ${PX4_SOURCE_DIR}/test_data
-			${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
-		WORKING_DIRECTORY ${SITL_WORKING_DIR}
-	)
 
-	#set_tests_properties(shutdown PROPERTIES FAIL_REGULAR_EXPRESSION "shutdown FAILED")
-	set_tests_properties(sitl-shutdown PROPERTIES PASS_REGULAR_EXPRESSION "Exiting NOW.")
-	sanitizer_fail_test_on_error(sitl-shutdown)
-endif()
+
+# # Shutdown test
+# add_test(NAME sitl-shutdown
+# 	COMMAND $<TARGET_FILE:px4>
+# 		-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_shutdown
+# 		-t ${PX4_SOURCE_DIR}/test_data
+# 		${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+# 	WORKING_DIRECTORY ${SITL_WORKING_DIR}
+# )
+
+# #set_tests_properties(shutdown PROPERTIES FAIL_REGULAR_EXPRESSION "shutdown FAILED")
+# set_tests_properties(sitl-shutdown PROPERTIES PASS_REGULAR_EXPRESSION "Exiting NOW.")
+# sanitizer_fail_test_on_error(sitl-shutdown)
+
+
 
 # Dynamic module loading test
 add_test(NAME dyn
@@ -114,6 +126,7 @@ add_test(NAME dyn
 	WORKING_DIRECTORY ${SITL_WORKING_DIR})
 set_tests_properties(dyn PROPERTIES PASS_REGULAR_EXPRESSION "1: PASSED")
 sanitizer_fail_test_on_error(dyn)
+
 
 # run arbitrary commands
 set(test_cmds
@@ -136,6 +149,7 @@ foreach(cmd_name ${test_cmds})
 	sanitizer_fail_test_on_error(posix_${cmd_name})
 	set_tests_properties(posix_${cmd_name} PROPERTIES PASS_REGULAR_EXPRESSION "Exiting NOW.")
 endforeach()
+
 
 if(CMAKE_BUILD_TYPE STREQUAL Coverage)
 	setup_target_for_coverage(test_coverage "${CMAKE_CTEST_COMMAND} --output-on-failure -T Test" tests)

--- a/posix-configs/SITL/init/test/test_cmd_template.in
+++ b/posix-configs/SITL/init/test/test_cmd_template.in
@@ -9,6 +9,6 @@ simulator start
 tone_alarm start
 pwm_out_sim start
 
-tests @test_name@
+@test_name@
 
 shutdown

--- a/posix-configs/SITL/init/test/test_mavlink
+++ b/posix-configs/SITL/init/test/test_mavlink
@@ -19,8 +19,6 @@ ver all
 mavlink start -x -u 14556 -r 2000000 -p
 mavlink boot_complete
 
-tests mavlink
-
-dataman status
+mavlink_tests
 
 shutdown

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -75,8 +75,6 @@ const struct {
 	{"uart_baudchange",	test_uart_baudchange,	OPT_NOJIGTEST},
 	{"uart_break",		test_uart_break,	OPT_NOJIGTEST | OPT_NOALLTEST},
 	{"uart_console",	test_uart_console,	OPT_NOJIGTEST | OPT_NOALLTEST},
-#else
-	{"rc",			rc_tests_main,		0},
 #endif /* __PX4_NUTTX */
 
 	{"adc",			test_adc,		OPT_NOJIGTEST},
@@ -118,15 +116,6 @@ const struct {
 	{"uart_send",		test_uart_send,		OPT_NOJIGTEST | OPT_NOALLTEST},
 	{"versioning",		test_versioning,	0},
 	{"cli",			test_cli,		0},
-
-	/* external tests */
-	{"commander",		commander_tests_main,	0},
-	{"controllib",		controllib_test_main,	0},
-	{"mavlink",		mavlink_tests_main,	0},
-#ifdef __PX4_NUTTX
-	{"lightware_laser",	lightware_laser_test_main,	0},
-#endif
-	{"uorb",		uorb_tests_main,	0},
 
 	{NULL,			NULL, 		0}
 };

--- a/src/systemcmds/tests/tests_main.h
+++ b/src/systemcmds/tests/tests_main.h
@@ -89,14 +89,6 @@ extern int test_uart_send(int argc, char *argv[]);
 extern int test_versioning(int argc, char *argv[]);
 extern int test_cli(int argc, char *argv[]);
 
-/* external */
-extern int commander_tests_main(int argc, char *argv[]);
-extern int mavlink_tests_main(int argc, char *argv[]);
-extern int controllib_test_main(int argc, char *argv[]);
-extern int uorb_tests_main(int argc, char *argv[]);
-extern int rc_tests_main(int argc, char *argv[]);
-extern int lightware_laser_test_main(int argc, char *argv[]);
-
 __END_DECLS
 
 #endif /* __APPS_PX4_TESTS_H */


### PR DESCRIPTION
The main stack of the `tests` systemcmd is quite large (10 kB), so it's increasingly problematic on older boards that don't have enough memory to run both the `tests` runner and allocate a new task or thread for their test activity.