### PR TITLE
gyro_fft: silence initial sensor selection attempt

### DIFF
--- a/src/modules/gyro_fft/GyroFFT.cpp
+++ b/src/modules/gyro_fft/GyroFFT.cpp
@@ -140,7 +140,6 @@ bool GyroFFT::init()
 		}
 
 		if (!SensorSelectionUpdate(true)) {
-			PX4_WARN("sensor_gyro callback registration failed!");
 			ScheduleDelayed(500_ms);
 		}
 


### PR DESCRIPTION
 - early in startup the selected gyro may not be published yet