### PR TITLE
process_sensor_caldata.py: Fix 2nd barometer plot

### DIFF
--- a/Tools/process_sensor_caldata.py
+++ b/Tools/process_sensor_caldata.py
@@ -1099,7 +1099,7 @@ if num_baros >= 2:
     baro_1_x_resample = fit_coef_baro_1_x(temp_rel_resample)
 
     # baro 2 vs temperature
-    plt.figure(9,figsize=(20,13))
+    plt.figure(10,figsize=(20,13))
 
     # draw plots
     plt.plot(sensor_baro_1['temperature'],100*sensor_baro_1['pressure']-100*median_pressure,'b')
@@ -1157,7 +1157,7 @@ if num_baros >= 3:
     baro_2_x_resample = fit_coef_baro_2_x(temp_rel_resample)
 
     # baro 2 vs temperature
-    plt.figure(10,figsize=(20,13))
+    plt.figure(11,figsize=(20,13))
 
     # draw plots
     plt.plot(sensor_baro_2['temperature'],100*sensor_baro_2['pressure']-100*median_pressure,'b')
@@ -1210,7 +1210,7 @@ if num_baros >= 4:
     baro_3_x_resample = fit_coef_baro_3_x(temp_rel_resample)
 
     # baro 3 vs temperature
-    plt.figure(11,figsize=(20,13))
+    plt.figure(12,figsize=(20,13))
 
     # draw plots
     plt.plot(sensor_baro_3['temperature'],100*sensor_baro_3['pressure']-100*median_pressure,'b')


### PR DESCRIPTION
fixed the figure numbers to avoid plot conflicts

**Describe problem solved by this pull request**
The first and second barometer plots are overlapping each other as you can see below
![image](https://user-images.githubusercontent.com/70697874/112442814-4be97c80-8d5d-11eb-8973-45389453393d.png)

**Describe your solution**
Baro0 and Baro1 figure numbers were identical. Separating them solved the issue.