### PR TITLE
Add mag fault preflt check

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3809,6 +3809,7 @@ void Commander::estimator_check()
 
 		if (!mag_fault_prev && mag_fault) {
 			mavlink_log_critical(&_mavlink_log_pub, "Stopping compass use! Check calibration on landing");
+			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG, true, true, false, _status);
 		}
 
 		/* Check estimator status for signs of bad yaw induced post takeoff navigation failure

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3849,7 +3849,7 @@ void Commander::estimator_check()
 					} else if (innovation_fail) {
 						_time_last_innov_fail = hrt_absolute_time();
 
-						if (!_nav_test_failed && hrt_elapsed_time(&_time_last_innov_pass) > 1_s) {
+						if (!_nav_test_failed && hrt_elapsed_time(&_time_last_innov_pass) > 2_s) {
 							// if the innovation test has failed continuously, declare the nav as failed
 							_nav_test_failed = true;
 							mavlink_log_emergency(&_mavlink_log_pub, "Navigation failure! Land and recalibrate sensors");


### PR DESCRIPTION
**Describe problem solved by this pull request**
The user isn't noticed if EKF2 rejected the mag completely (e.g.: during a yaw emergency reset) and is allowed to takeoff again.

**Describe your solution**
Check the `mag_fault` flag of each estimator and fail the pre-flight check for the used mag. This works with multi-ekfs and multi mags.

Additional modifications:
- increase the "nav failed" timeout to 2s in order to give more time to EKF2 to trigger a yaw emergency reset (that has 1s probation period)
- update ECL to include https://github.com/PX4/PX4-ECL/pull/992, allowing faster convergence when using better GNSS receivers

**Test data / coverage**
Sitl and flight tests.