### PR TITLE
ekf2: enable range aid by default

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1062,7 +1062,7 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_PITCH, 0.0f);
  * @value 0 Range aid disabled
  * @value 1 Range aid enabled
  */
-PARAM_DEFINE_INT32(EKF2_RNG_AID, 0);
+PARAM_DEFINE_INT32(EKF2_RNG_AID, 1);
 
 /**
  * Maximum horizontal velocity allowed for range aid mode.


### PR DESCRIPTION
The range aid defaults are fairly conservative (max horizontal velocity 1 m/s, and range aid gate 1 SD), I think it should be safe to enable by default. This is to help more users get the benefit (by default) and perhaps circumvent the common mistake of setting EKF2_HGT_MODE to range sensor.