### PR TITLE
posix-configs: rpi multi-EKF updates

### DIFF
--- a/posix-configs/rpi/pilotpi_fw.config
+++ b/posix-configs/rpi/pilotpi_fw.config
@@ -17,12 +17,6 @@ param set SYS_AUTOCONFIG 0
 param set MAV_TYPE 1
 param set SYS_AUTOSTART 2100
 
-# Multi-EKF
-param set EKF2_MULTI_IMU 1
-param set SENS_IMU_MODE 0
-param set EKF2_MULTI_MAG 1
-param set SENS_MAG_MODE 0
-
 dataman start
 
 load_mon start

--- a/posix-configs/rpi/pilotpi_mc.config
+++ b/posix-configs/rpi/pilotpi_mc.config
@@ -17,12 +17,6 @@ param set SYS_AUTOCONFIG 0
 param set MAV_TYPE 2
 param set SYS_AUTOSTART 4001
 
-# Multi-EKF
-param set EKF2_MULTI_IMU 1
-param set SENS_IMU_MODE 0
-param set EKF2_MULTI_MAG 1
-param set SENS_MAG_MODE 0
-
 dataman start
 
 load_mon start

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -16,8 +16,6 @@ param set MAV_TYPE 2
 # Multi-EKF
 param set EKF2_MULTI_IMU 2
 param set SENS_IMU_MODE 0
-param set EKF2_MULTI_MAG 3
-param set SENS_MAG_MODE 0
 
 dataman start
 

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -16,8 +16,6 @@ param set MAV_TYPE 1
 # Multi-EKF
 param set EKF2_MULTI_IMU 2
 param set SENS_IMU_MODE 0
-param set EKF2_MULTI_MAG 3
-param set SENS_MAG_MODE 0
 
 dataman start
 

--- a/posix-configs/rpi/px4_hil.config
+++ b/posix-configs/rpi/px4_hil.config
@@ -18,8 +18,6 @@ param set MAV_TYPE 2
 # Multi-EKF
 param set EKF2_MULTI_IMU 2
 param set SENS_IMU_MODE 0
-param set EKF2_MULTI_MAG 3
-param set SENS_MAG_MODE 0
 
 dataman start
 

--- a/posix-configs/rpi/px4_test.config
+++ b/posix-configs/rpi/px4_test.config
@@ -16,8 +16,6 @@ param set MAV_TYPE 2
 # Multi-EKF
 param set EKF2_MULTI_IMU 2
 param set SENS_IMU_MODE 0
-param set EKF2_MULTI_MAG 3
-param set SENS_MAG_MODE 0
 
 dataman start
 


### PR DESCRIPTION
The ekf2 frontend typically runs in the background for up to 30 seconds waiting for all instances to appear, but this isn't supported by the legacy posix launcher.