### PR TITLE
mc_pos_control: allow feed-forward offboard velocity control

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/ControlMath.cpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMath.cpp
@@ -258,4 +258,18 @@ void setZeroIfNanVector3f(Vector3f &vector)
 	addIfNotNanVector3f(vector, Vector3f());
 }
 
+void setIfNan(float &value, const float to_set)
+{
+	if (!PX4_ISFINITE(value)) {
+		value = to_set;
+	}
+}
+
+void setIfNanVector3(Vector3f &value, const Vector3f to_set)
+{
+	for (int i = 0; i < 3; i++) {
+		setIfNan(value(i), to_set(i));
+	}
+}
+
 } // ControlMath

--- a/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
+++ b/src/modules/mc_pos_control/PositionControl/ControlMath.hpp
@@ -115,4 +115,18 @@ void addIfNotNanVector3f(matrix::Vector3f &setpoint, const matrix::Vector3f &add
  * @param vector possibly containing NAN elements
  */
 void setZeroIfNanVector3f(matrix::Vector3f &vector);
+
+/**
+ * Replaces value with something if value is NAN.
+ * @param value Existing value.
+ * @param to_set New value to use.
+ */
+void setIfNan(float &value, const float to_set);
+
+/**
+ * Replaces value with second param if value is NAN.
+ * @param value Existing value.
+ * @param to_set New value to use.
+ */
+void setIfNanVector3(matrix::Vector3f &value, const matrix::Vector3f to_set);
 }

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -108,8 +108,9 @@ void PositionControl::_positionControl()
 {
 	// P-position controller
 	Vector3f vel_sp_position = (_pos_sp - _pos).emult(_gain_pos_p);
-	// Position and feed-forward velocity setpoints or position states being NAN results in them not having an influence
-	ControlMath::addIfNotNanVector3f(_vel_sp, vel_sp_position);
+	// We overwrite the velocity setpoint unless it's already set.
+	// This allows e.g. offboard control feed forward velocity setpoints.
+	ControlMath::setIfNanVector3(_vel_sp, vel_sp_position);
 	// make sure there are no NAN elements for further reference while constraining
 	ControlMath::setZeroIfNanVector3f(vel_sp_position);
 


### PR DESCRIPTION
This fixes feed-forward velocity input for offboard control where both velocity and position are set.
Without this change, the drone would just assume the requested position setpoint with the maximum velocity as specified by the parameters.

Fixes https://github.com/mavlink/MAVSDK-Python/issues/327.