### PR TITLE
PreFlightCheck: Check if SD card is present only once and store the result

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -34,6 +34,7 @@ bool rc_input_blocked                                # set if RC input should be
 bool rc_calibration_valid                            # set if RC calibration is valid
 bool vtol_transition_failure                        # Set to true if vtol transition failed
 bool usb_connected                                # status of the USB power supply
+bool sd_card_detected_once                        # set to true if the SD card was detected
 
 bool avoidance_system_required					  # Set to true if avoidance system is enabled via COM_OBS_AVOID parameter
 bool avoidance_system_valid                       # Status of the obstacle avoidance system

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -64,7 +64,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	bool failed = false;
 
 	failed = failed || !airframeCheck(mavlink_log_pub, status);
-	failed = failed || !sdcardCheck(mavlink_log_pub, report_failures);
+	failed = failed || !sdcardCheck(mavlink_log_pub, status_flags.sd_card_detected_once, report_failures);
 
 	/* ---- MAG ---- */
 	{

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -119,5 +119,5 @@ private:
 	static bool manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
 	static bool airframeCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status);
 	static bool cpuResourceCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
-	static bool sdcardCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
+	static bool sdcardCheck(orb_advert_t *mavlink_log_pub, bool &sd_card_detected_once, const bool report_fail);
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
statfs accesses the file-system and can be blocking for an extended period. Since the SD card check is part of the preflight checks in the main thread of commander, it could block its execution and cause various issues. Yet, the SD card is only mounted in rcS during boot so the state will not change after the first check.

**Describe your solution**
Store the SD card check result and only run statfs again if the card was not detected before.

**Describe possible alternatives**
Run check in a separate thread or module to not block commander, but unless there are multiple SD cards I don't think this is needed.

**Test data / coverage**
Tested on a Pixhawk 4.

**Additional context**
None
