### PR TITLE
Predict and use braking distance when Pausing auto modes (for multicopters)

### DIFF
--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -400,8 +400,13 @@ private:
 
 	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
 	param_t _handle_reverse_delay{PARAM_INVALID};
+	param_t _handle_mpc_jerk_max{PARAM_INVALID};
+	param_t _handle_mpc_acc_hor{PARAM_INVALID};
+
 	float _param_back_trans_dec_mss{0.f};
 	float _param_reverse_delay{0.f};
+	float _param_mpc_jerk_max{8.f};	/**< initialized with the default jerk max value to prevent division by 0 if the parameter is accidentally set to 0 */
+	float _param_mpc_acc_hor{3.f}; /**< initialized with the default horizontal acc value to prevent division by 0 if the parameter is accidentally set to 0 */
 
 	float _mission_cruising_speed_mc{-1.0f};
 	float _mission_cruising_speed_fw{-1.0f};

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -400,12 +400,12 @@ private:
 
 	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
 	param_t _handle_reverse_delay{PARAM_INVALID};
-	param_t _handle_mpc_jerk_max{PARAM_INVALID};
+	param_t _handle_mpc_jerk_auto{PARAM_INVALID};
 	param_t _handle_mpc_acc_hor{PARAM_INVALID};
 
 	float _param_back_trans_dec_mss{0.f};
 	float _param_reverse_delay{0.f};
-	float _param_mpc_jerk_max{8.f};	/**< initialized with the default jerk max value to prevent division by 0 if the parameter is accidentally set to 0 */
+	float _param_mpc_jerk_auto{4.f}; /**< initialized with the default jerk auto value to prevent division by 0 if the parameter is accidentally set to 0 */
 	float _param_mpc_acc_hor{3.f}; /**< initialized with the default horizontal acc value to prevent division by 0 if the parameter is accidentally set to 0 */
 
 	float _mission_cruising_speed_mc{-1.0f};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -99,7 +99,7 @@ Navigator::Navigator() :
 	_handle_back_trans_dec_mss = param_find("VT_B_DEC_MSS");
 	_handle_reverse_delay = param_find("VT_B_REV_DEL");
 
-	_handle_mpc_jerk_max = param_find("MPC_JERK_MAX");
+	_handle_mpc_jerk_auto = param_find("MPC_JERK_AUTO");
 	_handle_mpc_acc_hor = param_find("MPC_ACC_HOR");
 
 	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
@@ -130,8 +130,8 @@ Navigator::params_update()
 		param_get(_handle_reverse_delay, &_param_reverse_delay);
 	}
 
-	if (_handle_mpc_jerk_max != PARAM_INVALID) {
-		param_get(_handle_mpc_jerk_max, &_param_mpc_jerk_max);
+	if (_handle_mpc_jerk_auto != PARAM_INVALID) {
+		param_get(_handle_mpc_jerk_auto, &_param_mpc_jerk_auto);
 	}
 
 	if (_handle_mpc_acc_hor != PARAM_INVALID) {
@@ -337,7 +337,7 @@ Navigator::run()
 							const float velocity_hor_abs = sqrtf(_local_pos.vx * _local_pos.vx + _local_pos.vy * _local_pos.vy);
 
 							float multirotor_braking_distance = math::trajectory::computeBrakingDistanceFromVelocity(velocity_hor_abs,
-											    _param_mpc_jerk_max, _param_mpc_acc_hor, 0.6f * _param_mpc_jerk_max);
+											    _param_mpc_jerk_auto, _param_mpc_acc_hor, 0.6f * _param_mpc_jerk_auto);
 
 							waypoint_from_heading_and_distance(get_global_position()->lat, get_global_position()->lon, course_over_ground,
 											   multirotor_braking_distance, &lat, &lon);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, when pausing a vehicle during a mission/RTL/Orbit navigator will take the current position of the vehicle as loiter point. This makes the vehicle overshoot the loiter position and then bounce back to the desired setpoint as the braking distance is not taken into account.

**Describe your solution**
This PR takes into account the vehicle braking distance to predict and set as loiter point the position where the vehicle will actually be able to stop.


**Describe possible alternatives**
If we had motion primitives in place we could have used those to predict the braking trajectory, but still this implementation is an enhancement compared to the current state.

**Test data / coverage**
Tested in SITL

**Additional context**
Add any other related context or media.
