### PR TITLE
Add support for toggle buttons via RC channels

### DIFF
--- a/msg/rc_channels.msg
+++ b/msg/rc_channels.msg
@@ -1,38 +1,39 @@
 uint64 timestamp						# time since system start (microseconds)
 
-uint8 FUNCTION_THROTTLE   = 0
-uint8 FUNCTION_ROLL       = 1
-uint8 FUNCTION_PITCH      = 2
-uint8 FUNCTION_YAW        = 3
-uint8 FUNCTION_MODE       = 4
-uint8 FUNCTION_RETURN     = 5
-uint8 FUNCTION_POSCTL     = 6
-uint8 FUNCTION_LOITER     = 7
-uint8 FUNCTION_OFFBOARD   = 8
-uint8 FUNCTION_ACRO       = 9
-uint8 FUNCTION_FLAPS      = 10
-uint8 FUNCTION_AUX_1      = 11
-uint8 FUNCTION_AUX_2      = 12
-uint8 FUNCTION_AUX_3      = 13
-uint8 FUNCTION_AUX_4      = 14
-uint8 FUNCTION_AUX_5      = 15
-uint8 FUNCTION_PARAM_1    = 16
-uint8 FUNCTION_PARAM_2    = 17
-uint8 FUNCTION_PARAM_3_5  = 18
-uint8 FUNCTION_KILLSWITCH = 19
-uint8 FUNCTION_TRANSITION = 20
-uint8 FUNCTION_GEAR       = 21
-uint8 FUNCTION_ARMSWITCH  = 22
-uint8 FUNCTION_STAB       = 23
-uint8 FUNCTION_AUX_6      = 24
-uint8 FUNCTION_MAN        = 25
-uint8 FUNCTION_FLTBTN_SLOT_1=26
-uint8 FUNCTION_FLTBTN_SLOT_2=27
-uint8 FUNCTION_FLTBTN_SLOT_3=28
-uint8 FUNCTION_FLTBTN_SLOT_4=39
-uint8 FUNCTION_FLTBTN_SLOT_5=30
-uint8 FUNCTION_FLTBTN_SLOT_6=31
-uint8 FUNCTION_FLTBTN_NUM_SLOTS=6
+uint8 FUNCTION_THROTTLE      = 0
+uint8 FUNCTION_ROLL          = 1
+uint8 FUNCTION_PITCH         = 2
+uint8 FUNCTION_YAW           = 3
+uint8 FUNCTION_MODE          = 4
+uint8 FUNCTION_RETURN        = 5
+uint8 FUNCTION_POSCTL        = 6
+uint8 FUNCTION_LOITER        = 7
+uint8 FUNCTION_OFFBOARD      = 8
+uint8 FUNCTION_ACRO          = 9
+uint8 FUNCTION_FLAPS         = 10
+uint8 FUNCTION_AUX_1         = 11
+uint8 FUNCTION_AUX_2         = 12
+uint8 FUNCTION_AUX_3         = 13
+uint8 FUNCTION_AUX_4         = 14
+uint8 FUNCTION_AUX_5         = 15
+uint8 FUNCTION_PARAM_1       = 16
+uint8 FUNCTION_PARAM_2       = 17
+uint8 FUNCTION_PARAM_3_5     = 18
+uint8 FUNCTION_KILLSWITCH    = 19
+uint8 FUNCTION_TRANSITION    = 20
+uint8 FUNCTION_GEAR          = 21
+uint8 FUNCTION_ARMSWITCH     = 22
+uint8 FUNCTION_STAB          = 23
+uint8 FUNCTION_AUX_6         = 24
+uint8 FUNCTION_MAN           = 25
+uint8 FUNCTION_FLTBTN_SLOT_1 = 26
+uint8 FUNCTION_FLTBTN_SLOT_2 = 27
+uint8 FUNCTION_FLTBTN_SLOT_3 = 28
+uint8 FUNCTION_FLTBTN_SLOT_4 = 39
+uint8 FUNCTION_FLTBTN_SLOT_5 = 30
+uint8 FUNCTION_FLTBTN_SLOT_6 = 31
+
+uint8 FUNCTION_FLTBTN_SLOT_COUNT = 6
 
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
 float32[18] channels						# Scaled to -1..1 (throttle: 0..1)

--- a/msg/rc_channels.msg
+++ b/msg/rc_channels.msg
@@ -26,11 +26,18 @@ uint8 FUNCTION_ARMSWITCH  = 22
 uint8 FUNCTION_STAB       = 23
 uint8 FUNCTION_AUX_6      = 24
 uint8 FUNCTION_MAN        = 25
+uint8 FUNCTION_FLTBTN_SLOT_1=26
+uint8 FUNCTION_FLTBTN_SLOT_2=27
+uint8 FUNCTION_FLTBTN_SLOT_3=28
+uint8 FUNCTION_FLTBTN_SLOT_4=39
+uint8 FUNCTION_FLTBTN_SLOT_5=30
+uint8 FUNCTION_FLTBTN_SLOT_6=31
+uint8 FUNCTION_FLTBTN_NUM_SLOTS=6
 
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
 float32[18] channels						# Scaled to -1..1 (throttle: 0..1)
 uint8 channel_count						# Number of valid channels
-int8[26] function						# Functions mapping
+int8[32] function						# Functions mapping
 uint8 rssi							# Receive signal strength index
 bool signal_lost						# Control signal lost, should be checked together with topic timeout
 uint32 frame_drop_count						# Number of dropped frames

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2298,7 +2298,7 @@ Commander::run()
 				}
 			}
 
-			if (!_armed.armed && _manual_control.isMavlink() && (_internal_state.main_state_changes == 0)) {
+			if (!_armed.armed && _manual_control.isModeInitializationRequired() && (_internal_state.main_state_changes == 0)) {
 				// if there's never been a mode change force position control as initial state
 				_internal_state.main_state = commander_state_s::MAIN_STATE_POSCTL;
 			}

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -179,10 +179,10 @@ bool ManualControl::wantsArm(const vehicle_control_mode_s &vehicle_control_mode,
 
 bool ManualControl::isModeInitializationRequired()
 {
-	const bool isMavlink = _manual_control_setpoint.data_source > manual_control_setpoint_s::SOURCE_RC;
-	const bool rc_uses_toggle_buttons = !isMavlink && _param_rc_map_flightmode_buttons.get() > 0;
+	const bool is_mavlink = _manual_control_setpoint.data_source > manual_control_setpoint_s::SOURCE_RC;
+	const bool rc_uses_toggle_buttons = _param_rc_map_flightmode_buttons.get() > 0;
 
-	return (isMavlink || rc_uses_toggle_buttons);
+	return (is_mavlink || rc_uses_toggle_buttons);
 }
 
 void ManualControl::updateParams()

--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -177,6 +177,14 @@ bool ManualControl::wantsArm(const vehicle_control_mode_s &vehicle_control_mode,
 	return ret;
 }
 
+bool ManualControl::isModeInitializationRequired()
+{
+	const bool isMavlink = _manual_control_setpoint.data_source > manual_control_setpoint_s::SOURCE_RC;
+	const bool rc_uses_toggle_buttons = !isMavlink && _param_rc_map_flightmode_buttons.get() > 0;
+
+	return (isMavlink || rc_uses_toggle_buttons);
+}
+
 void ManualControl::updateParams()
 {
 	ModuleParams::updateParams();

--- a/src/modules/commander/ManualControl.hpp
+++ b/src/modules/commander/ManualControl.hpp
@@ -64,12 +64,12 @@ public:
 	 */
 	bool update();
 	bool isRCAvailable() const { return _rc_available; }
-	bool isMavlink() const { return _manual_control_setpoint.data_source > manual_control_setpoint_s::SOURCE_RC; }
 	bool wantsOverride(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status);
 	bool wantsDisarm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,
 			 manual_control_switches_s &manual_control_switches, const bool landed);
 	bool wantsArm(const vehicle_control_mode_s &vehicle_control_mode, const vehicle_status_s &vehicle_status,
 		      const manual_control_switches_s &manual_control_switches, const bool landed);
+	bool isModeInitializationRequired();
 	bool isThrottleLow() const { return _last_manual_control_setpoint.z < 0.1f; }
 	bool isThrottleAboveCenter() const { return _last_manual_control_setpoint.z > 0.6f; }
 	hrt_abstime getLastRcTimestamp() const { return _last_manual_control_setpoint.timestamp; }
@@ -96,6 +96,7 @@ private:
 		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_com_arm_swisbtn,
 		(ParamBool<px4::params::COM_REARM_GRACE>) _param_com_rearm_grace,
 		(ParamInt<px4::params::COM_RC_OVERRIDE>) _param_rc_override,
-		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov
+		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
+		(ParamInt<px4::params::RC_MAP_FLTM_BTN>) _param_rc_map_flightmode_buttons
 	)
 };

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1703,6 +1703,42 @@ PARAM_DEFINE_INT32(RC_MAP_STAB_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_MAN_SW, 0);
 
 /**
+ * Enables changing flight modes with multiple toggle buttons.
+ *
+ * This bitmask allows to specify multiple channels for changing flight modes.
+ * Each channel is assigned to a flight mode slot ((lowest channel = slot 1),
+ * the behavior of each flight mode is defined by the COM_FLTMODE1,COM_FLTMODE2,...
+ * parameters.
+ * The functionality can be used only if RC_MAP_FLTMODE is disabled.
+ *
+ * The maximum number of available slots is 6.
+ * @min 0
+ * @max 258048
+ * @group Radio Switches
+ * @bit 0 Enable Channel 1 as toggle button
+ * @bit 1 Enable Channel 2 as toggle button
+ * @bit 2 Enable Channel 3 as toggle button
+ * @bit 3 Enable Channel 4 as toggle button
+ * @bit 4 Enable Channel 5 as toggle button
+ * @bit 5 Enable Channel 6 as toggle button
+ * @bit 6 Enable Channel 7 as toggle button
+ * @bit 7 Enable Channel 8 as toggle button
+ * @bit 8 Enable Channel 9 as toggle button
+ * @bit 9 Enable Channel 10 as toggle button
+ * @bit 10 Enable Channel 11 as toggle button
+ * @bit 11 Enable Channel 12 as toggle button
+ * @bit 12 Enable Channel 13 as toggle button
+ * @bit 13 Enable Channel 14 as toggle button
+ * @bit 14 Enable Channel 15 as toggle button
+ * @bit 15 Enable Channel 16 as toggle button
+ * @bit 16 Enable Channel 17 as toggle button
+ * @bit 17 Enable Channel 18 as toggle button
+ *
+ */
+
+PARAM_DEFINE_INT32(RC_MAP_FLTM_BTN, 0);
+
+/**
  * AUX1 Passthrough RC channel
  *
  * Default function: Camera pitch

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1703,37 +1703,35 @@ PARAM_DEFINE_INT32(RC_MAP_STAB_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_MAN_SW, 0);
 
 /**
- * Enables changing flight modes with multiple toggle buttons.
+ * Button flight mode selection
  *
- * This bitmask allows to specify multiple channels for changing flight modes.
- * Each channel is assigned to a flight mode slot ((lowest channel = slot 1),
- * the behavior of each flight mode is defined by the COM_FLTMODE1,COM_FLTMODE2,...
- * parameters.
+ * This bitmask allows to specify multiple channels for changing flight modes using
+ * momentary buttons. Each channel is assigned to a mode slot ((lowest channel = slot 1).
+ * The resulting modes for each slot X is defined by the COM_FLTMODEX parameters.
  * The functionality can be used only if RC_MAP_FLTMODE is disabled.
  *
- * The maximum number of available slots is 6.
+ * The maximum number of available slots and hence bits set in the mask is 6.
  * @min 0
  * @max 258048
  * @group Radio Switches
- * @bit 0 Enable Channel 1 as toggle button
- * @bit 1 Enable Channel 2 as toggle button
- * @bit 2 Enable Channel 3 as toggle button
- * @bit 3 Enable Channel 4 as toggle button
- * @bit 4 Enable Channel 5 as toggle button
- * @bit 5 Enable Channel 6 as toggle button
- * @bit 6 Enable Channel 7 as toggle button
- * @bit 7 Enable Channel 8 as toggle button
- * @bit 8 Enable Channel 9 as toggle button
- * @bit 9 Enable Channel 10 as toggle button
- * @bit 10 Enable Channel 11 as toggle button
- * @bit 11 Enable Channel 12 as toggle button
- * @bit 12 Enable Channel 13 as toggle button
- * @bit 13 Enable Channel 14 as toggle button
- * @bit 14 Enable Channel 15 as toggle button
- * @bit 15 Enable Channel 16 as toggle button
- * @bit 16 Enable Channel 17 as toggle button
- * @bit 17 Enable Channel 18 as toggle button
- *
+ * @bit 0 Mask Channel 1 as a mode button
+ * @bit 1 Mask Channel 2 as a mode button
+ * @bit 2 Mask Channel 3 as a mode button
+ * @bit 3 Mask Channel 4 as a mode button
+ * @bit 4 Mask Channel 5 as a mode button
+ * @bit 5 Mask Channel 6 as a mode button
+ * @bit 6 Mask Channel 7 as a mode button
+ * @bit 7 Mask Channel 8 as a mode button
+ * @bit 8 Mask Channel 9 as a mode button
+ * @bit 9 Mask Channel 10 as a mode button
+ * @bit 10 Mask Channel 11 as a mode button
+ * @bit 11 Mask Channel 12 as a mode button
+ * @bit 12 Mask Channel 13 as a mode button
+ * @bit 13 Mask Channel 14 as a mode button
+ * @bit 14 Mask Channel 15 as a mode button
+ * @bit 15 Mask Channel 16 as a mode button
+ * @bit 16 Mask Channel 17 as a mode button
+ * @bit 17 Mask Channel 18 as a mode button
  */
 
 PARAM_DEFINE_INT32(RC_MAP_FLTM_BTN, 0);

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -59,6 +59,7 @@
 #include <uORB/topics/rc_channels.h>
 #include <uORB/topics/rc_parameter_map.h>
 #include <uORB/topics/parameter_update.h>
+#include <hysteresis/hysteresis.h>
 
 using namespace time_literals;
 
@@ -130,6 +131,8 @@ private:
 	 */
 	void		set_params_from_rc();
 
+	void		map_flight_modes_buttons();
+
 	static constexpr uint8_t RC_MAX_CHAN_COUNT{input_rc_s::RC_INPUT_MAX_CHANNELS}; /**< maximum number of r/c channels we handle */
 
 	struct Parameters {
@@ -186,6 +189,10 @@ private:
 	uint8_t _channel_count_previous{0};
 	uint8_t _input_source_previous{input_rc_s::RC_INPUT_SOURCE_UNKNOWN};
 
+	uint8_t _potential_button_press_slot{0};
+	systemlib::Hysteresis _button_pressed_hysteresis{false};
+	systemlib::Hysteresis _rc_signal_lost_hysteresis{true};
+
 	uint8_t _channel_count_max{0};
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
@@ -216,6 +223,7 @@ private:
 		(ParamInt<px4::params::RC_MAP_GEAR_SW>) _param_rc_map_gear_sw,
 		(ParamInt<px4::params::RC_MAP_STAB_SW>) _param_rc_map_stab_sw,
 		(ParamInt<px4::params::RC_MAP_MAN_SW>) _param_rc_map_man_sw,
+		(ParamInt<px4::params::RC_MAP_FLTM_BTN>) _param_rc_map_flightmode_buttons,
 
 		(ParamInt<px4::params::RC_MAP_AUX1>) _param_rc_map_aux1,
 		(ParamInt<px4::params::RC_MAP_AUX2>) _param_rc_map_aux2,


### PR DESCRIPTION

**Describe problem solved by this pull request**
This PR introduces a new configuration option which allows users to setup Toggle Buttons for flight mode switches, over the RC signals (e.g S.BUS).

An example application is for example with the Herelink controller, where the buttons can be assigned to specific RC channels which are then sent over S.BUS.

I also added a 100ms hysteresis before flagging that the signal has been regained, as I could experience some glitches on the S.BUS channels when the controller was rebooted. 

**Test data / coverage**
Tested with a herelink controller


