### PR TITLE
Add support for simulators running on a different host than the PX4 instance

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -216,7 +216,21 @@ dataman start
 # only start the simulator if not in replay mode, as both control the lockstep time
 if ! replay tryapplyparams
 then
-	simulator start -c $simulator_tcp_port
+  # Check if PX4_SIM_HOSTNAME environment variable is empty
+  # If empty check if PX4_SIM_HOST_ADDR environment variable is empty
+  # If both are empty use localhost for simulator
+  if [ -z "${PX4_SIM_HOSTNAME}" ]; then
+    if [ -z "${PX4_SIM_HOST_ADDR}" ]; then
+      echo "PX4 SIM HOST: localhost"
+      simulator start -c $simulator_tcp_port
+    else
+      echo "PX4 SIM HOST: $PX4_SIM_HOST_ADDR"
+      simulator start -t $PX4_SIM_HOST_ADDR $simulator_tcp_port 
+    fi
+  else
+    echo "PX4 SIM HOST: $PX4_SIM_HOSTNAME"
+    simulator start -h $PX4_SIM_HOSTNAME $simulator_tcp_port 
+  fi
 fi
 load_mon start
 battery_simulator start

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -69,7 +69,7 @@ int Simulator::start(int argc, char *argv[])
 	_instance = new Simulator();
 
 	if (_instance) {
-		
+
 		if (argc == 5 && strcmp(argv[3], "-u") == 0) {
 			_instance->set_ip(InternetProtocol::UDP);
 			_instance->set_port(atoi(argv[4]));
@@ -112,7 +112,7 @@ static void usage()
 	PX4_INFO("Start simulator:     simulator start");
 	PX4_INFO("Connect using UDP: simulator start -u udp_port");
 	PX4_INFO("Connect using TCP: simulator start -c tcp_port");
-	PX4_INFO("Connect to a remote server using TCP: simulator start -t ip_addr tcp_port");	
+	PX4_INFO("Connect to a remote server using TCP: simulator start -t ip_addr tcp_port");
 	PX4_INFO("Connect to a remote server via hostname using TCP: simulator start -h hostname tcp_port");
 }
 

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -69,6 +69,7 @@ int Simulator::start(int argc, char *argv[])
 	_instance = new Simulator();
 
 	if (_instance) {
+		
 		if (argc == 5 && strcmp(argv[3], "-u") == 0) {
 			_instance->set_ip(InternetProtocol::UDP);
 			_instance->set_port(atoi(argv[4]));
@@ -80,8 +81,18 @@ int Simulator::start(int argc, char *argv[])
 		}
 
 		if (argc == 6 && strcmp(argv[3], "-t") == 0) {
+			PX4_INFO("Simulator using TCP on remote host %s port %s", argv[4], argv[5]);
+			PX4_WARN("Please ensure port %s is not blocked by a firewall.", argv[5]);
 			_instance->set_ip(InternetProtocol::TCP);
 			_instance->set_tcp_remote_ipaddr(argv[4]);
+			_instance->set_port(atoi(argv[5]));
+		}
+
+		if (argc == 6 && strcmp(argv[3], "-h") == 0) {
+			PX4_INFO("Simulator using TCP on remote host %s port %s", argv[4], argv[5]);
+			PX4_WARN("Please ensure port %s is not blocked by a firewall.", argv[5]);
+			_instance->set_ip(InternetProtocol::TCP);
+			_instance->set_hostname(argv[4]);
 			_instance->set_port(atoi(argv[5]));
 		}
 
@@ -101,7 +112,8 @@ static void usage()
 	PX4_INFO("Start simulator:     simulator start");
 	PX4_INFO("Connect using UDP: simulator start -u udp_port");
 	PX4_INFO("Connect using TCP: simulator start -c tcp_port");
-	PX4_INFO("Connect to a remote server using TCP: simulator start -t ip_addr tcp_port");
+	PX4_INFO("Connect to a remote server using TCP: simulator start -t ip_addr tcp_port");	
+	PX4_INFO("Connect to a remote server via hostname using TCP: simulator start -h hostname tcp_port");
 }
 
 __BEGIN_DECLS

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -123,6 +123,7 @@ public:
 
 	void set_ip(InternetProtocol ip) { _ip = ip; }
 	void set_port(unsigned port) { _port = port; }
+	void set_hostname(std::string hostname) { _hostname = hostname; }
 	void set_tcp_remote_ipaddr(char *tcp_remote_ipaddr) { _tcp_remote_ipaddr = tcp_remote_ipaddr; }
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
@@ -205,6 +206,8 @@ private:
 	unsigned int _port{14560};
 
 	InternetProtocol _ip{InternetProtocol::UDP};
+
+	std::string _hostname{""};
 
 	char *_tcp_remote_ipaddr{nullptr};
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -733,6 +733,7 @@ void Simulator::run()
 
 	if (_tcp_remote_ipaddr != nullptr) {
 		_myaddr.sin_addr.s_addr = inet_addr(_tcp_remote_ipaddr);
+
 	} else if (!_hostname.empty()) {
 		/* resolve hostname */
 		struct hostent *host;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -45,7 +45,9 @@
 #include <conversion/rotation.h>
 #include <mathlib/mathlib.h>
 
+#include <arpa/inet.h>
 #include <errno.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <poll.h>
@@ -731,7 +733,17 @@ void Simulator::run()
 
 	if (_tcp_remote_ipaddr != nullptr) {
 		_myaddr.sin_addr.s_addr = inet_addr(_tcp_remote_ipaddr);
+	} else if (!_hostname.empty()) {
+		/* resolve hostname */
+		struct hostent *host;
+		host = gethostbyname(_hostname.c_str());
+		memcpy(&_myaddr.sin_addr, host->h_addr_list[0], host->h_length);
+
+		char ip[30];
+		strcpy(ip, (char *)inet_ntoa((struct in_addr)_myaddr.sin_addr));
+		PX4_INFO("Resolved host '%s' to address: %s", _hostname.c_str(), ip);
 	}
+
 
 	if (_ip == InternetProtocol::UDP) {
 


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
This is a branched merge of the work done by FernandezR in [PR 15965](https://github.com/PX4/PX4-Autopilot/pull/15965).
Adds to the existing simulator "-t" support  the "-h" option passing remote host name instead of ip address.
Also adds environment variable support to etc/init.d-posix/rcS.

A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
Added use of PX4_SIM_HOSTNAME and PX4_SIM_HOST_ADDR environment variables to pass simulator hostname or ip address through the posix rcs script to the simulator module.

**Describe possible alternatives**
Didn't consider any other alternatives as this was the simplest implementation.

**Test data / coverage**
Tested using a docker compose implementation using a a private Unity Simulation, where simulator and PX4 instances exist in different containers. Also, tested on local machine to ensure continued support of localhost simulator.  Also tested AirSim can now work with PX4 in WSL 2.

**Additional context**
None.