### PR TITLE
microRTPS: Timesync fixes

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
@@ -218,6 +218,7 @@ void micrortps_start_topics(struct timespec &begin, uint64_t &total_read, uint64
         while (0 < (read = transport_node->read(&topic_ID, data_buffer, BUFFER_SIZE)))
         {
             total_read += read;
+            uint64_t read_time = hrt_absolute_time();
             switch (topic_ID)
             {
 @[for idx, topic in enumerate(recv_topics)]@
@@ -225,6 +226,11 @@ void micrortps_start_topics(struct timespec &begin, uint64_t &total_read, uint64
                 {
                     @(receive_base_types[idx])_s @(topic)_data;
                     deserialize_@(receive_base_types[idx])(&reader, &@(topic)_data, data_buffer);
+                    if (@(topic)_data.timestamp > read_time)
+                    {
+                        // don't allow timestamps from the future
+                        @(topic)_data.timestamp = read_time;
+                    }
                     pubs->@(topic)_pub.publish(@(topic)_data);
                     ++received;
                 }

--- a/msg/templates/urtps/microRTPS_timesync.h.em
+++ b/msg/templates/urtps/microRTPS_timesync.h.em
@@ -130,23 +130,15 @@ public:
 
 	/**
 	 * @@brief Get clock monotonic time (raw) in nanoseconds
-	 * @@return System CLOCK_MONOTONIC_RAW time in nanoseconds
+	 * @@return System CLOCK_MONOTONIC time in nanoseconds
 	 */
-	inline int64_t getMonoRawTimeNSec() {
-		timespec t;
-		clock_gettime(CLOCK_MONOTONIC_RAW, &t);
-		return static_cast<int64_t>(t.tv_sec * 1000000000LL + t.tv_nsec);
-	}
+	static int64_t getTimeNSec();
 
 	/**
 	 * @@brief Get system monotonic time in microseconds
 	 * @@return System CLOCK_MONOTONIC time in microseconds
 	 */
-	inline int64_t getMonoTimeUSec() {
-		timespec t;
-		clock_gettime(CLOCK_MONOTONIC, &t);
-		return static_cast<int64_t>(t.tv_sec * 1000000000LL + t.tv_nsec) / 1000LL;
-	}
+	static int64_t getTimeUSec();
 
 	/**
 	 * @@brief Adds a time offset measurement to be filtered


### PR DESCRIPTION
**Describe problem solved by this pull request**
1.  Excessive calls `hrt_absolute_time()` might lead to accumulated skew which in turn can result on having the timesync from the agent setting offsets which when applied, resulting in timestamps from the future.
2. Using different time sources on the agent side was also resulting in wrong timestamps being set on the messages being sent.

**Describe your solution**
1. Clamp the timestamp to be at max equals to the PX4 system time;
2. Use the same time source (`CLOCK_MONOTONIC`).

**Test data / coverage**
Tested with PX4 SITL and Gazebo.
