### PR TITLE
microRTPS: enable required streams for PX4 Avoidance

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -185,6 +185,7 @@ rtps:
     id: 86
   - msg: vehicle_attitude
     id: 87
+    send: true
   - msg: vehicle_attitude_setpoint
     id: 88
   - msg: vehicle_command
@@ -205,6 +206,7 @@ rtps:
     id: 95
   - msg: vehicle_local_position
     id: 96
+    send: true
   - msg: vehicle_local_position_setpoint
     id: 97
     receive: true
@@ -219,11 +221,12 @@ rtps:
     id: 101
   - msg: vehicle_status
     id: 102
+    send: true
   - msg: vehicle_status_flags
     id: 103
   - msg: vehicle_trajectory_waypoint
     id: 104
-    receive: true
+    send: true
   - msg: vtol_vehicle_status
     id: 105
   - msg: wind
@@ -241,6 +244,7 @@ rtps:
     id: 111
   - msg: vehicle_angular_velocity
     id: 112
+    send: true
   - msg: vehicle_acceleration
     id: 113
   - msg: airspeed_validated
@@ -268,8 +272,10 @@ rtps:
     id: 125
   - msg: trajectory_bezier
     id: 126
+    receive: true
   - msg: vehicle_trajectory_bezier
     id: 127
+    receive: true
   - msg: timesync_status
     id: 128
   - msg: orb_test

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -160,6 +160,7 @@ rtps:
     id: 75
   - msg: telemetry_status
     id: 76
+    receive: true
   - msg: test_motor
     id: 77
   - msg: timesync
@@ -169,6 +170,7 @@ rtps:
   - msg: trajectory_waypoint
     id: 79
     receive: true
+    send: true
   - msg: transponder_report
     id: 80
   - msg: tune_control
@@ -226,7 +228,7 @@ rtps:
     id: 103
   - msg: vehicle_trajectory_waypoint
     id: 104
-    send: true
+    receive: true
   - msg: vtol_vehicle_status
     id: 105
   - msg: wind
@@ -385,6 +387,7 @@ rtps:
   - msg: vehicle_trajectory_waypoint_desired
     id: 183
     alias: vehicle_trajectory_waypoint
+    send: true
   - msg: obstacle_distance_fused
     id: 184
     alias: obstacle_distance


### PR DESCRIPTION
**Describe problem solved by this pull request**
Some uORB streams required for PX4/Avoidance to work are not enabled by default.

**Describe your solution**
Enable sending:

- `trajectory_waypoint`
- `vehicle_attitude`
- `vehicle_angular_velocity`
- `vehicle_local_position`
- `vehicle_status`
- `vehicle_trajectory_waypoint_desired`

Enable receiving:

- `telemetry_status`
- `trajectory_bezier`
- `vehicle_trajectory_bezier`

**Test data / coverage**
Tested with PX4 SITL and Gazebo.
