### PR TITLE
Make rc.mavlink_override work with change environment 

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -261,7 +261,7 @@ fi
 if [ -e etc/init.d-posix/rc.mavlink_override ]
 then
 	echo "Running non-default mavlink config rc.mavlink_override"
-	sh etc/init.d-posix/rc.mavlink_override
+	. ${R}etc/init.d-posix/rc.mavlink_override
 else
 	# GCS link
 	mavlink start -x -u $udp_gcs_port_local -r 4000000 -f


### PR DESCRIPTION
**How this PR solves the problem**
changes to the execution of ROMFS/px4fmu_common/init.d-posix/rcS where not applied on the execution of rc.mavlink_override so far.

**Additional context**
Simulation is broken with current develop branch otherwise.