### PR TITLE
SlewRate: add back dummy file for mac build

### DIFF
--- a/src/lib/slew_rate/CMakeLists.txt
+++ b/src/lib/slew_rate/CMakeLists.txt
@@ -32,6 +32,7 @@
 ############################################################################
 
 px4_add_library(SlewRate
+	dummy.cpp
 	SlewRate.hpp
 	SlewRateYaw.hpp
 )


### PR DESCRIPTION
**Describe problem solved by this pull request**
I realized that https://github.com/PX4/PX4-Autopilot/pull/17066/commits/428be5cbba99d15fc0b15639df488dd4fa5d1b0a broke the Mac build only. Didn't see it in the huge list of successful CI jobs.

**Describe your solution**
I'm adding back the dummy cpp source to hopefully make whatever cmake generator mac uses happy again. It's the only difference I see to how include other libraries.

**Test data / coverage**
Let's see CI, I have no mac.