### PR TITLE
SITL iris: reduce pitch rate D slightly to hotfix jMAVSim oscillation issue

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10016_iris
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10016_iris
@@ -9,4 +9,10 @@
 
 . ${R}etc/init.d/rc.mc_defaults
 
+if [ $AUTOCNF = yes ]
+then
+	# Hotfix for jMAVSim pitch oscillations after the default D term cutoff was lowered
+	param set MC_PITCHRATE_D 0.0025
+fi
+
 set MIXER quad_w


### PR DESCRIPTION
**Describe problem solved by this pull request**
https://github.com/PX4/PX4-Autopilot/issues/17006

**Describe your solution**
It's unclear why it starts oscillating only on pitch. A quick look at the jMAVSim implementation shows the quadcopter is symmetric. Loading a quad_x mixer instead of the iris asymmetric mixer didn't solve the issue in my test. So further investigation is necessary but adjusting the gain slightly hotfixes the issue such that noone gets blocked.

**Test data / coverage**
I found this to work testing in SITL. What also works is increasing the gyro d term cutoff again, lowering the rate p gain.
