### PR TITLE
IMU_DGYRO_CUTOFF increase default 10 -> 20 Hz

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -121,7 +121,7 @@ PARAM_DEFINE_INT32(IMU_GYRO_RATEMAX, 400);
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 10.0f);
+PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 20.0f);
 
 /**
 * IMU gyro dynamic notch filtering


### PR DESCRIPTION
Searching for a less bad conservative default value.

@MaEtUgR 