### PR TITLE
Add UAVCAN on FMUv6X and Durandal

### DIFF
--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -50,7 +50,7 @@ px4_add_board(
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
-#		uavcan - No H7 or FD can support in UAVCAN yet
+		uavcan
 	MODULES
 		airspeed_selector
 		attitude_estimator_q
@@ -110,7 +110,7 @@ px4_add_board(
 		sd_bench
 		serial_test
 		system_time
-		tests # tests and test runner
+#		tests # tests and test runner
 		top
 		topic_listener
 		tune_control

--- a/boards/holybro/durandal-v1/nuttx-config/include/board.h
+++ b/boards/holybro/durandal-v1/nuttx-config/include/board.h
@@ -250,6 +250,12 @@
 
 #define STM32_RCC_D3CCIPR_ADCSEL     RCC_D3CCIPR_ADCSEL_PLL2
 
+/* FDCAN 1 2 clock source */
+
+#define STM32_RCC_D2CCIP1R_FDCANSEL  RCC_D2CCIP1R_FDCANSEL_HSE   /* FDCAN 1 2 clock source */
+
+#define STM32_FDCANCLK               STM32_HSE_FREQUENCY
+
 /* FLASH wait states
  *
  *  ------------ ---------- -----------

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -11,6 +11,7 @@ px4_add_board(
 	IO px4_io-v2_default
 	TESTING
 	UAVCAN_INTERFACES 2
+	UAVCAN_TIMER_OVERRIDE 2
 	ETHERNET
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
@@ -54,7 +55,7 @@ px4_add_board(
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
-#		uavcan - No H7 or FD can support in UAVCAN yet
+		uavcan
 	MODULES
 		airspeed_selector
 		attitude_estimator_q
@@ -114,7 +115,7 @@ px4_add_board(
 		sd_bench
 		serial_test
 		system_time
-		tests # tests and test runner
+#		tests # tests and test runner
 		top
 		topic_listener
 		tune_control

--- a/boards/px4/fmu-v6x/nuttx-config/include/board.h
+++ b/boards/px4/fmu-v6x/nuttx-config/include/board.h
@@ -250,6 +250,12 @@
 
 #define STM32_RCC_D3CCIPR_ADCSEL     RCC_D3CCIPR_ADCSEL_PLL2
 
+/* FDCAN 1 2 clock source */
+
+#define STM32_RCC_D2CCIP1R_FDCANSEL  RCC_D2CCIP1R_FDCANSEL_HSE   /* FDCAN 1 2 clock source */
+
+#define STM32_FDCANCLK               STM32_HSE_FREQUENCY
+
 /* FLASH wait states
  *
  *  ------------ ---------- -----------


### PR DESCRIPTION
> @david_s5 uavcan (v0) still disabled on px4_fmu-v6x and holybro_durandal?

@dagar - now enabled. Had to disable tests to fit, is there a better choice of things to disable?