### PR TITLE
boards: cuav x7pro include correct adis IMU

### DIFF
--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -31,7 +31,7 @@ px4_add_board(
 		gps
 		heater
 		#imu # all available imu drivers
-		imu/analog_devices/adis16448
+		imu/analog_devices/adis16470
 		imu/bosch/bmi088
 		imu/invensense/icm20649
 		imu/invensense/icm20689


### PR DESCRIPTION
This was incorrectly dropped in the board sync. https://github.com/PX4/PX4-Autopilot/commit/631d1647d3339cff34dcdbbe55a8c1bcb1e603c1#diff-685d9a8f0fe5b5c6e79261ea48f7a70f7a9d9e18a726240d118c2274b115ba9c