### PR TITLE
commander: COM_PREARM_MODE disable by default

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -922,7 +922,7 @@ PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 1);
  *
  * @group Commander
  */
-PARAM_DEFINE_INT32(COM_PREARM_MODE, 1);
+PARAM_DEFINE_INT32(COM_PREARM_MODE, 0);
 
 /**
  * Enable Motor Testing


### PR DESCRIPTION
Now that the safety button is disabled by default on most boards I think it also makes sense to disable prearm mode by default as well. By default nothing in the system should be active until a user explicitly arms.