### PR TITLE
ROMFS: rcS start uavcan much earlier

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -255,6 +255,34 @@ else
 	fi
 
 	#
+	# Check if UAVCAN is enabled, default to it for ESCs.
+	#
+	if param greater -s UAVCAN_ENABLE 0
+	then
+		# Start core UAVCAN module.
+		if uavcan start
+		then
+			if param greater UAVCAN_ENABLE 1
+			then
+				# Start UAVCAN firmware update server and dynamic node ID allocation server.
+				uavcan start fw
+				tune_control play -t 1
+				if param greater UAVCAN_ENABLE 2
+				then
+					set OUTPUT_MODE uavcan_esc
+				fi
+			fi
+		else
+			tune_control play error
+		fi
+	else
+		if param greater -s UAVCAN_V1_ENABLE 0
+		then
+			uavcan_v1 start
+		fi
+	fi
+
+	#
 	# Check if PX4IO present and update firmware if needed.
 	# Assumption IOFW set to firmware file and IO_PRESENT = no
 	#
@@ -394,34 +422,6 @@ else
 
 		camera_trigger start
 		camera_feedback start
-	fi
-
-	#
-	# Check if UAVCAN is enabled, default to it for ESCs.
-	#
-	if param greater -s UAVCAN_ENABLE 0
-	then
-		# Start core UAVCAN module.
-		if uavcan start
-		then
-			if param greater UAVCAN_ENABLE 1
-			then
-				# Start UAVCAN firmware update server and dynamic node ID allocation server.
-				uavcan start fw
-				tune_control play -t 1
-				if param greater UAVCAN_ENABLE 2
-				then
-					set OUTPUT_MODE uavcan_esc
-				fi
-			fi
-		else
-			tune_control play error
-		fi
-	fi
-
-	if param greater -s UAVCAN_V1_ENABLE 0
-	then
-		uavcan_v1 start
 	fi
 
 	#


### PR DESCRIPTION
Supposedly this largely fixes connectivity issues with the Here 3, although I'd still like to understand and address the core issue. Regardless of that particular issue I think it still makes sense to start UAVCAN as early as possible for the sake of notifications (lights and buzzers on CAN), peripheral parameter sync, etc.


**NEEDS TESTING**