### PR TITLE
VTOL/FW pressure scaling fixes

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1917,8 +1917,6 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const hrt_abstime &now, flo
 				// scale throttle as a function of sqrt(p0/p) (~ EAS -> TAS at low speeds and altitudes ignoring temperature)
 				const float eas2tas = sqrtf(CONSTANTS_STD_PRESSURE_PA / air_data.baro_pressure_pa);
 				const float scale = constrain((eas2tas - 1.0f) * _param_fw_thr_alt_scl.get() + 1.f, 1.f, 2.f);
-
-				throttle_max = constrain(throttle_max * scale, throttle_min, 1.0f);
 				throttle_cruise = constrain(throttle_cruise * scale, throttle_min + 0.01f, throttle_max - 0.01f);
 			}
 		}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -248,7 +248,7 @@ void Standard::update_transition_state()
 		    PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
 		    _airspeed_validated->calibrated_airspeed_m_s > 0.0f &&
 		    _airspeed_validated->calibrated_airspeed_m_s >= _params->airspeed_blend &&
-			time_since_trans_start > _attc->get_front_trans_time_min()) {
+		    time_since_trans_start > _attc->get_front_trans_time_min()) {
 
 			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - _params->airspeed_blend) /
 				    _airspeed_trans_blend_margin;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -174,7 +174,7 @@ void Standard::update_vtol_state()
 
 			const bool airspeed_triggers_transition = PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)
 					&& !_params->airspeed_disabled;
-			const bool minimum_trans_time_elapsed = time_since_trans_start > _params->front_trans_time_min;
+			const bool minimum_trans_time_elapsed = time_since_trans_start > _attc->get_front_trans_time_min();
 
 			bool transition_to_fw = false;
 
@@ -248,14 +248,14 @@ void Standard::update_transition_state()
 		    PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
 		    _airspeed_validated->calibrated_airspeed_m_s > 0.0f &&
 		    _airspeed_validated->calibrated_airspeed_m_s >= _params->airspeed_blend &&
-		    time_since_trans_start > _params->front_trans_time_min) {
+			time_since_trans_start > _attc->get_front_trans_time_min()) {
 
 			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - _params->airspeed_blend) /
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
 		} else if (_params->airspeed_disabled || !PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s)) {
-			mc_weight = 1.0f - time_since_trans_start / _params->front_trans_time_min;
+			mc_weight = 1.0f - time_since_trans_start / _attc->get_front_trans_time_min();
 			mc_weight = math::constrain(2.0f * mc_weight, 0.0f, 1.0f);
 
 		}

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -203,13 +203,17 @@ VtolAttitudeControl::is_fixed_wing_requested()
  * Returns front_trans_min_time optionally scaled over presure.
  */
 float
-VtolAttitudeControl::get_front_trans_time_min(){
+VtolAttitudeControl::get_front_trans_time_min()
+{
 	float front_trans_time_min = _params.front_trans_time_min;
+
 	if (PX4_ISFINITE(_air_data.baro_pressure_pa) && PX4_ISFINITE(_params.front_trans_time_min_scale)) {
 		const float eas2tas = sqrtf(CONSTANTS_STD_PRESSURE_PA / _air_data.baro_pressure_pa);
 		const float scale = math::constrain((eas2tas - 1.0f) * _params.front_trans_time_min_scale + 1.f, 1.f, 5.f);
-		front_trans_time_min = math::constrain(front_trans_time_min * scale, front_trans_time_min, _params.front_trans_timeout-0.5f);
+		front_trans_time_min = math::constrain(front_trans_time_min * scale, front_trans_time_min,
+						       _params.front_trans_timeout - 0.5f);
 	}
+
 	return front_trans_time_min;
 }
 
@@ -274,6 +278,7 @@ VtolAttitudeControl::parameters_update()
 		param_set_no_notification(_params_handles.front_trans_time_openloop, &_params.front_trans_time_openloop);
 		mavlink_log_critical(&_mavlink_log_pub, "OL transition time set larger than min transition time");
 	}
+
 	param_get(_params_handles.front_trans_time_min_scale, &_params.front_trans_time_min_scale);
 	param_get(_params_handles.front_trans_duration, &_params.front_trans_duration);
 	param_get(_params_handles.back_trans_duration, &_params.back_trans_duration);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -66,6 +66,7 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/airspeed_validated.h>
+#include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/manual_control_switches.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_setpoint_triplet.h>
@@ -107,6 +108,7 @@ public:
 	bool init();
 
 	bool is_fixed_wing_requested();
+	float get_front_trans_time_min();
 	void quadchute(const char *reason);
 
 	struct actuator_controls_s 			*get_actuators_fw_in() {return &_actuators_fw_in;}
@@ -114,6 +116,7 @@ public:
 	struct actuator_controls_s 			*get_actuators_out0() {return &_actuators_out_0;}
 	struct actuator_controls_s 			*get_actuators_out1() {return &_actuators_out_1;}
 	struct airspeed_validated_s 				*get_airspeed() {return &_airspeed_validated;}
+	struct vehicle_air_data_s 				*get_air_air_data() {return &_air_data;}
 	struct position_setpoint_triplet_s		*get_pos_sp_triplet() {return &_pos_sp_triplet;}
 	struct tecs_status_s 				*get_tecs_status() {return &_tecs_status;}
 	struct vehicle_attitude_s 			*get_att() {return &_v_att;}
@@ -138,6 +141,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _airspeed_validated_sub{ORB_ID(airspeed_validated)};			// airspeed subscription
+	uORB::Subscription _air_data_sub{ORB_ID(vehicle_air_data)};
 	uORB::Subscription _fw_virtual_att_sp_sub{ORB_ID(fw_virtual_attitude_setpoint)};
 	uORB::Subscription _land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription _local_pos_sp_sub{ORB_ID(vehicle_local_position_setpoint)};			// setpoint subscription
@@ -168,6 +172,7 @@ private:
 	actuator_controls_s			_actuators_out_1{};	//actuator controls going to the fw mixer (used for elevons)
 
 	airspeed_validated_s 				_airspeed_validated{};			// airspeed
+	vehicle_air_data_s			_air_data{};	// air data (baro)
 	manual_control_switches_s		_manual_control_switches{}; //manual control setpoint
 	position_setpoint_triplet_s		_pos_sp_triplet{};
 	tecs_status_s				_tecs_status{};
@@ -192,6 +197,7 @@ private:
 		param_t fw_qc_max_roll;
 		param_t front_trans_time_openloop;
 		param_t front_trans_time_min;
+		param_t front_trans_time_min_scale;
 		param_t front_trans_duration;
 		param_t back_trans_duration;
 		param_t transition_airspeed;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -219,6 +219,24 @@ PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);
 PARAM_DEFINE_FLOAT(VT_TRANS_MIN_TM, 2.0f);
 
 /**
+ * Front transition minimum time pressure scaling
+ *
+ * Enables scaling of minimum transition time by air pressure.
+ * Under standard atmospheric conditions:
+ * a value of 1.0 equals +- 1 extra second every 1000m above sea level
+ * a value of 4.0 equals +- 1 extra second every 250m above sea level
+ *
+ * Make sure that VT_TRANS_TIMEOUT is set large enough to accomodate.
+ * Set to -1 to disable
+ *
+ * @unit s
+ * @min -1.0
+ * @max 20.0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TRANS_TM_SCL, -1.0f);
+
+/**
  * QuadChute Altitude
  *
  * Minimum altitude for fixed wing flight, when in fixed wing the altitude drops below this altitude

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -58,6 +58,7 @@ struct Params {
 	float fw_qc_max_roll;		// maximum roll angle FW mode (QuadChute)
 	float front_trans_time_openloop;
 	float front_trans_time_min;
+	float front_trans_time_min_scale;
 	float front_trans_duration;
 	float back_trans_duration;
 	float transition_airspeed;
@@ -213,6 +214,7 @@ protected:
 	struct vehicle_local_position_s			*_local_pos;
 	struct vehicle_local_position_setpoint_s	*_local_pos_sp;
 	struct airspeed_validated_s 				*_airspeed_validated;					// airspeed
+	struct vehicle_air_data_s 				*_air_data;					// baro
 	struct tecs_status_s				*_tecs_status;
 	struct vehicle_land_detected_s			*_land_detected;
 


### PR DESCRIPTION
This fixes

1. no longer applying scaling to FW_THR_MAX (as this could lead to overheating esc's/motors)
2. introduce scaling pressure based factor for minimum transition time. Mostly used in airspeedsensorless vtols.