### PR TITLE
ROMFS: tune_control stop if px4io update fails

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -285,6 +285,8 @@ else
 					else
 						tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 					fi
+				else
+					tune_control stop
 				fi
 			fi
 		fi


### PR DESCRIPTION
Boards on the test rack are periodically getting stuck playing the IO update tune.