### PR TITLE
mavsdk_tests: add VTOL mission tests

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -28,9 +28,9 @@ jobs:
         token: ${{ secrets.ACCESS_TOKEN }}
 
     - name: Download MAVSDK
-      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.36.0/mavsdk_0.36.0_ubuntu20.04_amd64.deb
+      run: wget https://github.com/mavlink/MAVSDK/releases/download/v0.38.0/mavsdk_0.38.0_ubuntu20.04_amd64.deb
     - name: Install MAVSDK
-      run: dpkg -i mavsdk_0.36.0_ubuntu20.04_amd64.deb
+      run: dpkg -i mavsdk_0.38.0_ubuntu20.04_amd64.deb
 
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp

--- a/test/mavsdk_tests/CMakeLists.txt
+++ b/test/mavsdk_tests/CMakeLists.txt
@@ -27,6 +27,7 @@ if(MAVSDK_FOUND)
         MAVSDK::mavsdk_info
         MAVSDK::mavsdk_manual_control
         MAVSDK::mavsdk_mission
+        MAVSDK::mavsdk_mission_raw
         MAVSDK::mavsdk_offboard
         MAVSDK::mavsdk_param
         MAVSDK::mavsdk_telemetry

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -345,7 +345,7 @@ void AutopilotTester::execute_mission_raw()
 
 	// TODO: Adapt time limit based on mission size, flight speed, sim speed factor, etc.
 
-	wait_for_mission_raw_finished(std::chrono::seconds(60));
+	wait_for_mission_raw_finished(std::chrono::seconds(120));
 }
 
 void AutopilotTester::execute_rtl()

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -44,13 +44,16 @@
 #include <mavsdk/plugins/telemetry/telemetry.h>
 #include <mavsdk/plugins/param/param.h>
 #include "catch2/catch.hpp"
+#include <atomic>
 #include <chrono>
 #include <ctime>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <thread>
 
 extern std::string connection_url;
+extern std::optional<float> speed_factor;
 
 using namespace mavsdk;
 using namespace mavsdk::geometry;
@@ -80,6 +83,9 @@ public:
 		Baro,
 		Gps
 	};
+
+	AutopilotTester();
+	~AutopilotTester();
 
 	void connect(const std::string uri);
 	void wait_until_ready();
@@ -130,6 +136,8 @@ private:
 	void wait_for_flight_mode(Telemetry::FlightMode flight_mode, std::chrono::seconds timeout);
 	void wait_for_landed_state(Telemetry::LandedState landed_state, std::chrono::seconds timeout);
 	void wait_for_mission_finished(std::chrono::seconds timeout);
+
+	void report_speed_factor();
 
 	template<typename Rep, typename Period>
 	bool poll_condition_with_timeout(
@@ -216,4 +224,7 @@ private:
 	std::unique_ptr<mavsdk::Telemetry> _telemetry{};
 
 	Telemetry::GroundTruth _home{NAN, NAN, NAN};
+
+	std::atomic<bool> _should_exit {false};
+	std::thread _real_time_report_thread {};
 };

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -40,6 +40,7 @@
 #include <mavsdk/plugins/info/info.h>
 #include <mavsdk/plugins/manual_control/manual_control.h>
 #include <mavsdk/plugins/mission/mission.h>
+#include <mavsdk/plugins/mission_raw/mission_raw.h>
 #include <mavsdk/plugins/offboard/offboard.h>
 #include <mavsdk/plugins/telemetry/telemetry.h>
 #include <mavsdk/plugins/param/param.h>
@@ -110,6 +111,8 @@ public:
 	void execute_mission_and_get_mag_stuck();
 	void execute_mission_and_lose_baro();
 	void execute_mission_and_get_baro_stuck();
+	void load_qgc_mission_raw(const std::string &plan_file);
+	void execute_mission_raw();
 	void execute_rtl();
 	void offboard_goto(const Offboard::PositionNedYaw &target, float acceptance_radius_m = 0.3f,
 			   std::chrono::seconds timeout_duration = std::chrono::seconds(60));
@@ -136,6 +139,7 @@ private:
 	void wait_for_flight_mode(Telemetry::FlightMode flight_mode, std::chrono::seconds timeout);
 	void wait_for_landed_state(Telemetry::LandedState landed_state, std::chrono::seconds timeout);
 	void wait_for_mission_finished(std::chrono::seconds timeout);
+	void wait_for_mission_raw_finished(std::chrono::seconds timeout);
 
 	void report_speed_factor();
 
@@ -219,6 +223,7 @@ private:
 	std::unique_ptr<mavsdk::Info> _info{};
 	std::unique_ptr<mavsdk::ManualControl> _manual_control{};
 	std::unique_ptr<mavsdk::Mission> _mission{};
+	std::unique_ptr<mavsdk::MissionRaw> _mission_raw{};
 	std::unique_ptr<mavsdk::Offboard> _offboard{};
 	std::unique_ptr<mavsdk::Param> _param{};
 	std::unique_ptr<mavsdk::Telemetry> _telemetry{};

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -111,7 +111,7 @@ public:
 	void execute_mission_and_get_mag_stuck();
 	void execute_mission_and_lose_baro();
 	void execute_mission_and_get_baro_stuck();
-	void load_qgc_mission_raw(const std::string &plan_file);
+	void load_qgc_mission_raw_and_move_here(const std::string &plan_file);
 	void execute_mission_raw();
 	void execute_rtl();
 	void offboard_goto(const Offboard::PositionNedYaw &target, float acceptance_radius_m = 0.3f,
@@ -140,6 +140,7 @@ private:
 	void wait_for_landed_state(Telemetry::LandedState landed_state, std::chrono::seconds timeout);
 	void wait_for_mission_finished(std::chrono::seconds timeout);
 	void wait_for_mission_raw_finished(std::chrono::seconds timeout);
+	void move_mission_raw_here(std::vector<mavsdk::MissionRaw::MissionItem> &mission_items);
 
 	void report_speed_factor();
 

--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -13,13 +13,13 @@
         {
             "model": "standard_vtol",
             "vehicle": "standard_vtol",
-            "test_filter": "[multicopter][vtol]",
+            "test_filter": "[vtol]",
             "timeout_min": 10
         },
         {
             "model": "tailsitter",
             "vehicle": "tailsitter",
-            "test_filter": "[multicopter][vtol]",
+            "test_filter": "[vtol]",
             "timeout_min": 10
         }
     ]

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -436,6 +436,7 @@ class Tester:
             test['model'],
             case,
             self.config['mavlink_connection'],
+            self.speed_factor,
             self.verbose)
         self.active_runners.append(mavsdk_tests_runner)
 

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -279,10 +279,13 @@ class TestRunner(Runner):
                  model: str,
                  case: str,
                  mavlink_connection: str,
+                 speed_factor: float,
                  verbose: bool):
         super().__init__(log_dir, model, case, verbose)
         self.name = "mavsdk_tests"
         self.cwd = workspace_dir
         self.cmd = workspace_dir + \
             "/build/px4_sitl_default/mavsdk_tests/mavsdk_tests"
-        self.args = ["--url", mavlink_connection, case]
+        self.args = ["--url", mavlink_connection,
+                     "--speed-factor", str(speed_factor),
+                     case]

--- a/test/mavsdk_tests/test_main.cpp
+++ b/test/mavsdk_tests/test_main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
 
 		if (argv_string == "-h") {
 			usage(argv[0]);
+			return 0;
 		}
 
 		if (argv_string == "--url") {
@@ -57,9 +58,37 @@ int main(int argc, char **argv)
 				connection_url = argv[i + 1];
 				remove_argv(argc, argv, i);
 				remove_argv(argc, argv, i);
+				--i;
 
 			} else {
 				std::cerr << "No connection URL supplied" << std::endl;
+				usage(argv[0]);
+				return -1;
+			}
+
+		}
+
+		if (argv_string == "--speed-factor") {
+			if (argc > i + 1) {
+				try {
+					speed_factor = std::make_optional(std::stof(argv[i + 1]));
+
+				} catch (const std::invalid_argument &) {
+					std::cerr << "Speed factor could not be parsed" << std::endl;
+					return -1;
+
+				} catch (const std::out_of_range &) {
+					std::cerr << "Speed factor is out of range" << std::endl;
+					return -1;
+				}
+
+				remove_argv(argc, argv, i);
+				remove_argv(argc, argv, i);
+				--i;
+
+
+			} else {
+				std::cerr << "No speed factor supplied" << std::endl;
 				usage(argv[0]);
 				return -1;
 			}
@@ -79,13 +108,16 @@ int main(int argc, char **argv)
 void usage(const std::string &bin_name)
 {
 	std::cout << std::endl
-		  << "Usage : " << bin_name << " [--url CONNECTION_URL] [catch2 arguments]" << std::endl
-		  << "Connection URL format should be :" << std::endl
-		  << " For TCP : tcp://[server_host][:server_port]" << std::endl
-		  << " For UDP : udp://[bind_host][:bind_port]" << std::endl
-		  << " For Serial : serial:///path/to/serial/dev[:baudrate]" << std::endl
-		  << "For example, to connect to the simulator use URL: udp://:14540" << std::endl
-		  << std::endl;
+		  << "Usage : " << bin_name << " [--url CONNECTION_URL] [--speed-factor SPEED_FACTOR] [catch2 arguments]\n"
+		  << "\n"
+		  << "  --url          Connection URL format should be :\n"
+		  << "                   For TCP : tcp://[server_host][:server_port]\n"
+		  << "                   For UDP : udp://[bind_host][:bind_port]\n"
+		  << "                   For Serial : serial:///path/to/serial/dev[:baudrate]\n"
+		  << "                 For example, to connect to the simulator use URL: udp://:14540\n"
+		  << "\n"
+		  << "  --speed-factor Speed factor to compare against, for information only\n"
+		  << std::flush;
 }
 
 void remove_argv(int &argc, char **argv, int pos)

--- a/test/mavsdk_tests/test_vtol_mission.cpp
+++ b/test/mavsdk_tests/test_vtol_mission.cpp
@@ -34,15 +34,13 @@
 #include "autopilot_tester.h"
 
 
-TEST_CASE("Takeoff and transition and RTL", "[vtol]")
+TEST_CASE("Fly VTOL mission", "[vtol]")
 {
 	AutopilotTester tester;
 	tester.connect(connection_url);
+	tester.load_qgc_mission_raw("test/mavsdk_tests/vtol_mission_allmend.plan");
 	tester.wait_until_ready();
 	tester.arm();
-	tester.takeoff();
-	tester.wait_until_hovering();
-	tester.transition_to_fixedwing();
-	tester.execute_rtl();
+	tester.execute_mission_raw();
 	tester.wait_until_disarmed();
 }

--- a/test/mavsdk_tests/test_vtol_mission.cpp
+++ b/test/mavsdk_tests/test_vtol_mission.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Fly VTOL mission", "[vtol]")
 	AutopilotTester tester;
 	tester.connect(connection_url);
 	tester.wait_until_ready();
-	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_allmend.plan");
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission.plan");
 	tester.arm();
 	tester.execute_mission_raw();
 	tester.wait_until_disarmed();

--- a/test/mavsdk_tests/test_vtol_mission.cpp
+++ b/test/mavsdk_tests/test_vtol_mission.cpp
@@ -38,8 +38,8 @@ TEST_CASE("Fly VTOL mission", "[vtol]")
 {
 	AutopilotTester tester;
 	tester.connect(connection_url);
-	tester.load_qgc_mission_raw("test/mavsdk_tests/vtol_mission_allmend.plan");
 	tester.wait_until_ready();
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_allmend.plan");
 	tester.arm();
 	tester.execute_mission_raw();
 	tester.wait_until_disarmed();

--- a/test/mavsdk_tests/vtol_mission.plan
+++ b/test/mavsdk_tests/vtol_mission.plan
@@ -15,7 +15,7 @@
         "hoverSpeed": 5,
         "items": [
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 20,
                 "Altitude": 20,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -27,14 +27,14 @@
                     0,
                     0,
                     null,
-                    47.35575503646861,
-                    8.52080660767436,
+                    47.39833113265167,
+                    8.545508725338607,
                     20
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 20,
                 "Altitude": 20,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -46,14 +46,14 @@
                     0,
                     0,
                     null,
-                    47.35537212,
-                    8.52207767,
+                    47.399332700068925,
+                    8.54481499384454,
                     20
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 30,
                 "Altitude": 30,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -65,14 +65,14 @@
                     0,
                     0,
                     null,
-                    47.35349688,
-                    8.52355825,
+                    47.39908888031702,
+                    8.54344001880591,
                     30
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 30,
                 "Altitude": 30,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -84,14 +84,14 @@
                     0,
                     0,
                     null,
-                    47.3528936,
-                    8.52294671,
+                    47.39760160279815,
+                    8.542394178137585,
                     30
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 30,
                 "Altitude": 30,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -103,14 +103,14 @@
                     0,
                     0,
                     null,
-                    47.35230484,
-                    8.52030742,
+                    47.396941861414504,
+                    8.54282818797708,
                     30
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 30,
                 "Altitude": 30,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -122,14 +122,14 @@
                     0,
                     0,
                     null,
-                    47.35294448,
-                    8.51882684,
+                    47.396686401111786,
+                    8.544419333554089,
                     30
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 30,
                 "Altitude": 30,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -141,14 +141,14 @@
                     0,
                     0,
                     null,
-                    47.35375855,
-                    8.52002847,
+                    47.397202447861446,
+                    8.545440338322464,
                     30
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 20,
                 "Altitude": 20,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -160,14 +160,14 @@
                     0,
                     0,
                     null,
-                    47.35552475934091,
-                    8.51881610700002,
+                    47.39766309343905,
+                    8.545713820298545,
                     20
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 0,
                 "Altitude": 0,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -179,17 +179,17 @@
                     0,
                     20,
                     null,
-                    47.3557210047974,
-                    8.518762469830165,
+                    47.397748880653054,
+                    8.545753080416318,
                     0
                 ],
                 "type": "SimpleItem"
             }
         ],
         "plannedHomePosition": [
-            47.3557317,
-            8.5187574,
-            419.8934400000014
+            47.39775218584113,
+            8.545620889782981,
+            489.0021493051957
         ],
         "vehicleType": 20,
         "version": 2

--- a/test/mavsdk_tests/vtol_mission_allmend.plan
+++ b/test/mavsdk_tests/vtol_mission_allmend.plan
@@ -1,0 +1,203 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 20,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 84,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35575503646861,
+                    8.52080660767436,
+                    20
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 20,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35537212,
+                    8.52207767,
+                    20
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 3,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35349688,
+                    8.52355825,
+                    30
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 4,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.3528936,
+                    8.52294671,
+                    30
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 5,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35230484,
+                    8.52030742,
+                    30
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 6,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35294448,
+                    8.51882684,
+                    30
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 7,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35375855,
+                    8.52002847,
+                    30
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 20,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 8,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.35552475934091,
+                    8.51881610700002,
+                    20
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 0,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 85,
+                "doJumpId": 9,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    20,
+                    null,
+                    47.3557210047974,
+                    8.518762469830165,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            47.3557317,
+            8.5187574,
+            419.8934400000014
+        ],
+        "vehicleType": 20,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}


### PR DESCRIPTION
This adds VTOL mission tests based on a QGC .plan mission imported using the MAVSDK MissionRaw plugin.