### PR TITLE
Enable crsf and ghst telemetry on supported boards

### DIFF
--- a/boards/modalai/fc-v1/src/board_config.h
+++ b/boards/modalai/fc-v1/src/board_config.h
@@ -184,6 +184,7 @@
 /* RC Serial port */
 
 #define RC_SERIAL_PORT                     "/dev/ttyS5"
+#define BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 /* Safety Switch: Enable the FMU to control it as there is no px4io in ModalAI FC-v1 */
 #define GPIO_SAFETY_SWITCH_IN              /* PF3 */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTF|GPIO_PIN3)

--- a/boards/omnibus/f4sd/src/board_config.h
+++ b/boards/omnibus/f4sd/src/board_config.h
@@ -132,6 +132,7 @@
 #define GPIO_PPM_IN                  (GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN8)
 
 #define RC_SERIAL_PORT               "/dev/ttyS0"
+#define BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 /*
  * One RC_IN

--- a/boards/px4/fmu-v5/src/board_config.h
+++ b/boards/px4/fmu-v5/src/board_config.h
@@ -307,6 +307,7 @@
 
 #define RC_SERIAL_PORT                     "/dev/ttyS4"
 #define RC_SERIAL_SINGLEWIRE
+#define BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 /* Input Capture Channels. */
 #define INPUT_CAP1_TIMER                  2

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -621,9 +621,8 @@ void RCInput::Run()
 						_rc_in.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_CRSF;
 						fill_rc_in(_raw_rc_count, _raw_rc_values, cycle_timestamp, false, false, 0);
 
-						// Enable CRSF Telemetry only on the Omnibus, because on Pixhawk (-related) boards
-						// we cannot write to the RC UART
-						// It might work on FMU-v5. Or another option is to use a different UART port
+						// on Pixhawk (-related) boards we cannot write to the RC UART
+						// another option is to use a different UART port
 #ifdef BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 						if (!_rc_scan_locked && !_crsf_telemetry) {
@@ -669,13 +668,15 @@ void RCInput::Run()
 						fill_rc_in(_raw_rc_count, _raw_rc_values, cycle_timestamp, false, false, 0, ghst_rssi);
 
 						// ghst telemetry works on fmu-v5
-						// on other Pixhawk (-related) boards it does not work because
-						// we cannot write to the RC UART
+						// on other Pixhawk (-related) boards we cannot write to the RC UART
+						// another option is to use a different UART port
+#ifdef BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 						if (!_rc_scan_locked && !_ghst_telemetry) {
 							_ghst_telemetry = new GHSTTelemetry(_rcs_fd);
 						}
 
+#endif /* BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT */
 
 						_rc_scan_locked = true;
 

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -624,13 +624,13 @@ void RCInput::Run()
 						// Enable CRSF Telemetry only on the Omnibus, because on Pixhawk (-related) boards
 						// we cannot write to the RC UART
 						// It might work on FMU-v5. Or another option is to use a different UART port
-#ifdef CONFIG_ARCH_BOARD_OMNIBUS_F4SD
+#ifdef BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 						if (!_rc_scan_locked && !_crsf_telemetry) {
 							_crsf_telemetry = new CRSFTelemetry(_rcs_fd);
 						}
 
-#endif /* CONFIG_ARCH_BOARD_OMNIBUS_F4SD */
+#endif /* BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT */
 
 						_rc_scan_locked = true;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
See issue https://github.com/PX4/PX4-Autopilot/issues/17232

**Describe your solution**
I added BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT define to the supported board configs and changed the check for CONFIG_ARCH_BOARD_OMNIBUS_F4SD to BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT in RCInput.cpp.

**Test data / coverage**
Tested on modalaiFC-V1 board with a crossfire receiver sending telemetry to my radiomaster TX16s transmitter