### PR TITLE
boards: modalai fc-v1 add rtps cmake

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -59,6 +59,7 @@ pipeline {
                      "holybro_kakutef7_default",
                      "holybro_pix32v5_default",
                      "modalai_fc-v1_default",
+                     "modalai_fc-v1_rtps",
                      "mro_ctrl-zero-f7_default",
                      "mro_ctrl-zero-f7-oem_default",
                      "mro_ctrl-zero-h7_default",

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -42,6 +42,7 @@ jobs:
           holybro_kakutef7_default,
           holybro_pix32v5_default,
           modalai_fc-v1_default,
+          modalai_fc-v1_rtps,
           mro_ctrl-zero-f7-oem_default,
           mro_ctrl-zero-f7_default,
           mro_ctrl-zero-h7-oem_default,

--- a/boards/modalai/fc-v1/rtps.cmake
+++ b/boards/modalai/fc-v1/rtps.cmake
@@ -1,0 +1,132 @@
+
+px4_add_board(
+	PLATFORM nuttx
+	VENDOR modalai
+	MODEL fc-v1
+	LABEL rtps
+	TOOLCHAIN arm-none-eabi
+	ARCHITECTURE cortex-m7
+	ROMFSROOT px4fmu_common
+	TESTING
+	UAVCAN_INTERFACES 1
+	SERIAL_PORTS
+		GPS1:/dev/ttyS0 # UART1  / J10
+		TEL1:/dev/ttyS6 # UART7  / J5
+		TEL2:/dev/ttyS4 # UART5  / J1
+		TEL3:/dev/ttyS1 # USART2 / J4
+	DRIVERS
+		adc/ads1115
+		adc/board_adc
+		barometer # all available barometer drivers
+		batt_smbus
+		camera_capture
+		camera_trigger
+		differential_pressure # all available differential pressure drivers
+		distance_sensor # all available distance sensor drivers
+		dshot
+		gps
+		imu/bosch/bmi088
+		imu/invensense/icm20602
+		imu/invensense/icm20948 # required for ak09916 mag
+		imu/invensense/icm42688p
+		irlock
+		lights # all available light drivers
+		magnetometer # all available magnetometer drivers
+		optical_flow # all available optical flow drivers
+		osd
+		pca9685
+		pca9685_pwm_out
+		power_monitor/ina226
+		power_monitor/voxlpm
+		#protocol_splitter
+		#pwm_input
+		pwm_out_sim
+		pwm_out
+		rc_input
+		roboclaw
+		rpm
+		safety_button
+		telemetry # all available telemetry drivers
+		test_ppm
+		#tone_alarm
+		uavcan
+	MODULES
+		airspeed_selector
+		attitude_estimator_q
+		camera_feedback
+		commander
+		dataman
+		ekf2
+		esc_battery
+		events
+		flight_mode_manager
+		fw_att_control
+		fw_pos_control_l1
+		gyro_calibration
+		gyro_fft
+		land_detector
+		landing_target_estimator
+		load_mon
+		local_position_estimator
+		logger
+		mavlink
+		mc_att_control
+		mc_hover_thrust_estimator
+		mc_pos_control
+		mc_rate_control
+		micrortps_bridge
+		navigator
+		rc_update
+		rover_pos_control
+		sensors
+		sih
+		temperature_compensation
+		uuv_att_control
+		uuv_pos_control
+		vmount
+		vtol_att_control
+	SYSTEMCMDS
+		bl_update
+		dmesg
+		dumpfile
+		esc_calib
+		gpio
+		hardfault_log
+		i2cdetect
+		led_control
+		mft
+		mixer
+		motor_ramp
+		motor_test
+		mtd
+		nshterm
+		param
+		perf
+		pwm
+		reboot
+		reflect
+		sd_bench
+		serial_test
+		system_time
+		tests # tests and test runner
+		top
+		topic_listener
+		tune_control
+		uorb
+		usb_connected
+		ver
+		work_queue
+	EXAMPLES
+		fake_gps
+		fake_gyro
+		fake_magnetometer
+		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
+		hello
+		hwtest # Hardware test
+		#matlab_csv_serial
+		px4_mavlink_debug # Tutorial code from http://dev.px4.io/en/debug/debug_values.html
+		px4_simple_app # Tutorial code from http://dev.px4.io/en/apps/hello_sky.html
+		rover_steering_control # Rover example app
+		uuv_example_app
+		work_item
+	)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Adds rtps support for modalai/fc-v1

**Describe your solution**
Copied modalai/fc-v1/default.cmake to modalai/fc-v1/rtps.cmake and changed the LABEL to rtps and un-commented the micrortps_bridge module, then added "modalai_fc-v1_rtps" to Jenkinsfile-compile

**Test data / coverage**
I started the module on Telem1 and connected to voxl's microhard usb port with an FTDI adapter. Running the micrortps_agent, I'm able to echo ros topics 
