### PR TITLE
Parse velocity fields from mavlink's follow_target message

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2276,6 +2276,9 @@ MavlinkReceiver::handle_message_follow_target(mavlink_message_t *msg)
 	follow_target_topic.lat = follow_target_msg.lat * 1e-7;
 	follow_target_topic.lon = follow_target_msg.lon * 1e-7;
 	follow_target_topic.alt = follow_target_msg.alt;
+	follow_target_topic.vx = follow_target_msg.vel[0];
+	follow_target_topic.vy = follow_target_msg.vel[1];
+	follow_target_topic.vz = follow_target_msg.vel[2];
 
 	_follow_target_pub.publish(follow_target_topic);
 }


### PR DESCRIPTION
The mavlink message FOLLOW_TARGET has additional fields that are not being parsed here. See https://mavlink.io/en/messages/common.html#FOLLOW_TARGET for more details.

The follow_target message in PX4 has fields for the velocity:
https://github.com/PX4/PX4-Autopilot/blob/015849b402c67f263225dd81914edff7372b35d1/msg/follow_target.msg#L1-L8

Any reason not to populate these fields in the mavlink_receiver?

I don't think this currently affects any code, as https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/navigator/follow_target.cpp does not use the velocity provided by the target, but rather estimates it from the target's moving position. 