### PR TITLE
Support for multiple SPI drivers of a given type

### DIFF
--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -49,6 +49,31 @@
 static List<I2CSPIInstance *> i2c_spi_module_instances; ///< list of currently running instances
 static pthread_mutex_t i2c_spi_module_instances_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+
+I2CSPIDriverConfig::I2CSPIDriverConfig(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
+				       const px4::wq_config_t &wq_config_)
+	: module_name(iterator.moduleName()),
+	  devid_driver_index(iterator.devidDriverIndex()),
+	  bus_option(iterator.configuredBusOption()),
+	  bus_type(iterator.busType()),
+	  bus(iterator.bus()),
+	  i2c_address(cli.i2c_address),
+	  bus_frequency(cli.bus_frequency),
+	  drdy_gpio(iterator.DRDYGPIO()),
+	  spi_mode(cli.spi_mode),
+	  spi_devid(iterator.devid()),
+	  bus_device_index(iterator.busDeviceIndex()),
+	  rotation(cli.rotation),
+	  quiet_start(cli.quiet_start),
+	  keep_running(cli.keep_running),
+	  custom1(cli.custom1),
+	  custom2(cli.custom2),
+	  custom_data(cli.custom_data),
+	  wq_config(wq_config_)
+{
+
+}
+
 const char *BusCLIArguments::parseDefaultArguments(int argc, char *argv[])
 {
 	if (getOpt(argc, argv, "") == EOF) {
@@ -223,7 +248,7 @@ bool BusCLIArguments::validateConfiguration()
 
 BusInstanceIterator::BusInstanceIterator(const char *module_name,
 		const BusCLIArguments &cli_arguments, uint16_t devid_driver_index)
-	: _module_name(module_name), _bus_option(cli_arguments.bus_option), _type(cli_arguments.type),
+	: _module_name(module_name), _bus_option(cli_arguments.bus_option), _devid_driver_index(devid_driver_index),
 	  _i2c_address(cli_arguments.i2c_address),
 	  _spi_bus_iterator(spiFilter(cli_arguments.bus_option),
 			    cli_arguments.bus_option == I2CSPIBusOption::SPIExternal ? cli_arguments.chipselect_index : devid_driver_index,
@@ -256,7 +281,7 @@ bool BusInstanceIterator::next()
 
 		while (_current_instance != i2c_spi_module_instances.end()) {
 			if (strcmp((*_current_instance)->_module_name, _module_name) == 0 &&
-			    _type == (*_current_instance)->_type) {
+			    _devid_driver_index == (*_current_instance)->_devid_driver_index) {
 				return true;
 			}
 
@@ -287,7 +312,8 @@ bool BusInstanceIterator::next()
 			}
 
 			if (_bus_option == (*_current_instance)->_bus_option && bus == (*_current_instance)->_bus &&
-			    _type == (*_current_instance)->_type &&
+			    _devid_driver_index == (*_current_instance)->_devid_driver_index &&
+			    busDeviceIndex() == (*_current_instance)->_bus_device_index &&
 			    (!is_i2c || _i2c_address == (*_current_instance)->_i2c_address)) {
 				break;
 			}
@@ -422,6 +448,15 @@ int BusInstanceIterator::externalBusIndex() const
 	}
 }
 
+int BusInstanceIterator::busDeviceIndex() const
+{
+	if (busType() == BOARD_SPI_BUS) {
+		return _spi_bus_iterator.busDeviceIndex();
+	}
+
+	return -1;
+}
+
 I2CBusIterator::FilterType BusInstanceIterator::i2cFilter(I2CSPIBusOption bus_option)
 {
 	switch (bus_option) {
@@ -451,8 +486,7 @@ SPIBusIterator::FilterType BusInstanceIterator::spiFilter(I2CSPIBusOption bus_op
 }
 
 struct I2CSPIDriverInitializing {
-	const BusCLIArguments &cli;
-	const BusInstanceIterator &iterator;
+	const I2CSPIDriverConfig &config;
 	I2CSPIDriverBase::instantiate_method instantiate;
 	int runtime_instance;
 	I2CSPIDriverBase *instance{nullptr};
@@ -461,7 +495,7 @@ struct I2CSPIDriverInitializing {
 static void initializer_trampoline(void *argument)
 {
 	I2CSPIDriverInitializing *data = (I2CSPIDriverInitializing *)argument;
-	data->instance = data->instantiate(data->cli, data->iterator, data->runtime_instance);
+	data->instance = data->instantiate(data->config, data->runtime_instance);
 }
 
 int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterator &iterator,
@@ -493,10 +527,13 @@ int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterat
 		case BOARD_INVALID_BUS: device_id.devid_s.bus_type = device::Device::DeviceBusType_UNKNOWN; break;
 		}
 
+
+		const px4::wq_config_t &wq_config = px4::device_bus_to_wq(device_id.devid);
+		I2CSPIDriverConfig driver_config{cli, iterator, wq_config};
 		const int runtime_instance = iterator.runningInstancesCount();
-		I2CSPIDriverInitializing initializer_data{cli, iterator, instantiate, runtime_instance};
+		I2CSPIDriverInitializing initializer_data{driver_config, instantiate, runtime_instance};
 		// initialize the object and bus on the work queue thread - this will also probe for the device
-		px4::WorkItemSingleShot initializer(px4::device_bus_to_wq(device_id.devid), initializer_trampoline, &initializer_data);
+		px4::WorkItemSingleShot initializer(wq_config, initializer_trampoline, &initializer_data);
 		initializer.ScheduleNow();
 		initializer.wait();
 		I2CSPIDriverBase *instance = initializer_data.instance;
@@ -556,6 +593,10 @@ int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterat
 
 	if (!started && !cli.quiet_start) {
 		PX4_WARN("%s: no instance started (no device on bus?)", px4_get_taskname());
+
+		if (iterator.busType() == BOARD_I2C_BUS && cli.i2c_address == 0) {
+			PX4_ERR("%s: driver does not set i2c address", px4_get_taskname());
+		}
 	}
 
 	return started ? 0 : -1;

--- a/platforms/common/include/px4_platform_common/i2c_spi_buses.h
+++ b/platforms/common/include/px4_platform_common/i2c_spi_buses.h
@@ -54,6 +54,37 @@ enum class I2CSPIBusOption : uint8_t {
 	SPIExternal,
 };
 
+class BusCLIArguments;
+class BusInstanceIterator;
+
+struct I2CSPIDriverConfig {
+	I2CSPIDriverConfig(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
+			   const px4::wq_config_t &wq_config_);
+
+	const char *module_name;
+	uint16_t devid_driver_index;
+	I2CSPIBusOption bus_option;
+	board_bus_types bus_type;
+	int bus;
+	uint8_t i2c_address;
+	int bus_frequency;
+	spi_drdy_gpio_t drdy_gpio;
+	spi_mode_e spi_mode;
+	uint32_t spi_devid;
+	int bus_device_index;
+
+	Rotation rotation;
+
+	bool quiet_start;
+	bool keep_running;
+
+	int custom1;
+	int custom2;
+	void *custom_data;
+
+	const px4::wq_config_t &wq_config;
+};
+
 /**
  * @class I2CSPIInstance
  * I2C/SPI driver instance used by BusInstanceIterator to find running instances.
@@ -64,8 +95,10 @@ public:
 	virtual ~I2CSPIInstance() = default;
 
 private:
-	I2CSPIInstance(const char *module_name, I2CSPIBusOption bus_option, int bus, uint8_t i2c_address, uint16_t type)
-		: _module_name(module_name), _bus_option(bus_option), _bus(bus), _type(type), _i2c_address(i2c_address) {}
+	I2CSPIInstance(const I2CSPIDriverConfig &config)
+		: _module_name(config.module_name), _bus_option(config.bus_option), _bus(config.bus),
+		  _devid_driver_index(config.devid_driver_index), _bus_device_index(config.bus_device_index),
+		  _i2c_address(config.i2c_address) {}
 
 	friend class BusInstanceIterator;
 	friend class I2CSPIDriverBase;
@@ -73,7 +106,8 @@ private:
 	const char *_module_name;
 	const I2CSPIBusOption _bus_option;
 	const int _bus;
-	const int16_t _type; ///< device type (driver-specific)
+	const uint16_t _devid_driver_index;
+	const int8_t _bus_device_index;
 	const int8_t _i2c_address; ///< I2C address (optional)
 };
 
@@ -102,17 +136,15 @@ public:
 
 
 	I2CSPIBusOption bus_option{I2CSPIBusOption::All};
-	uint16_t type{0}; ///< device type (driver-specific)
 	int requested_bus{-1};
 	int chipselect_index{1};
-	Rotation rotation{ROTATION_NONE};
 	int bus_frequency{0};
 	spi_mode_e spi_mode{SPIDEV_MODE3};
-	uint8_t i2c_address{0}; ///< optional I2C address: a driver can set this to allow configuring the I2C address
+	uint8_t i2c_address{0}; ///< I2C address (a driver must set the default address)
 	bool quiet_start{false}; ///< do not print a message when startup fails
 	bool keep_running{false}; ///< keep driver running even if no device is detected on startup
 
-	uint8_t orientation{0}; ///< distance_sensor_s::ROTATION_*
+	Rotation rotation{ROTATION_NONE}; ///< sensor rotation (MAV_SENSOR_ROTATION_* or distance_sensor_s::ROTATION_*)
 
 	int custom1{0}; ///< driver-specific custom argument
 	int custom2{0}; ///< driver-specific custom argument
@@ -158,15 +190,20 @@ public:
 	spi_drdy_gpio_t DRDYGPIO() const;
 	bool external() const;
 	int externalBusIndex() const;
+	int busDeviceIndex() const;
 
 	void addInstance(I2CSPIInstance *instance);
 
 	static I2CBusIterator::FilterType i2cFilter(I2CSPIBusOption bus_option);
 	static SPIBusIterator::FilterType spiFilter(I2CSPIBusOption bus_option);
+
+	const char *moduleName() const { return _module_name; }
+	uint16_t devidDriverIndex() const { return _devid_driver_index; }
+
 private:
 	const char *_module_name;
 	const I2CSPIBusOption _bus_option;
-	const uint16_t _type;
+	const uint16_t _devid_driver_index;
 	const uint8_t _i2c_address;
 	SPIBusIterator _spi_bus_iterator;
 	I2CBusIterator _i2c_bus_iterator;
@@ -180,18 +217,16 @@ private:
 class I2CSPIDriverBase : public px4::ScheduledWorkItem, public I2CSPIInstance
 {
 public:
-	I2CSPIDriverBase(const char *module_name, const px4::wq_config_t &config, I2CSPIBusOption bus_option, int bus,
-			 uint8_t i2c_address, uint16_t type)
-		: ScheduledWorkItem(module_name, config),
-		  I2CSPIInstance(module_name, bus_option, bus, i2c_address, type) {}
+	I2CSPIDriverBase(const I2CSPIDriverConfig &config)
+		: ScheduledWorkItem(config.module_name, config.wq_config),
+		  I2CSPIInstance(config) {}
 
 	static int module_stop(BusInstanceIterator &iterator);
 	static int module_status(BusInstanceIterator &iterator);
 	static int module_custom_method(const BusCLIArguments &cli, BusInstanceIterator &iterator,
 					bool run_on_work_queue = true);
 
-	using instantiate_method = I2CSPIDriverBase * (*)(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				   int runtime_instance);
+	using instantiate_method = I2CSPIDriverBase * (*)(const I2CSPIDriverConfig &config, int runtime_instance);
 protected:
 	virtual ~I2CSPIDriverBase() = default;
 
@@ -230,13 +265,12 @@ class I2CSPIDriver : public I2CSPIDriverBase
 public:
 	static int module_start(const BusCLIArguments &cli, BusInstanceIterator &iterator)
 	{
-		return I2CSPIDriverBase::module_start(cli, iterator, &T::print_usage, &T::instantiate);
+		return I2CSPIDriverBase::module_start(cli, iterator, &T::print_usage, InstantiateHelper<T>::m);
 	}
 
 protected:
-	I2CSPIDriver(const char *module_name, const px4::wq_config_t &config, I2CSPIBusOption bus_option, int bus,
-		     uint8_t i2c_address = 0, uint16_t type = 0)
-		: I2CSPIDriverBase(module_name, config, bus_option, bus, i2c_address, type) {}
+	I2CSPIDriver(const I2CSPIDriverConfig &config)
+		: I2CSPIDriverBase(config) {}
 
 	virtual ~I2CSPIDriver() = default;
 
@@ -251,4 +285,33 @@ protected:
 	}
 	// *INDENT-ON*
 private:
+
+	// SFINAE to use R::instantiate if it exists, and R::instantiate_default otherwise
+	template <typename R>
+	class InstantiateHelper
+	{
+		template <typename C>
+		static constexpr I2CSPIDriverBase::instantiate_method get(decltype(&C::instantiate)) { return &C::instantiate; }
+		template <typename C>
+		static constexpr I2CSPIDriverBase::instantiate_method get(...) { return &C::instantiate_default; }
+	public:
+		static constexpr I2CSPIDriverBase::instantiate_method m = get<R>(0);
+	};
+
+	static I2CSPIDriverBase *instantiate_default(const I2CSPIDriverConfig &config, int runtime_instance)
+	{
+		T *instance = new T(config);
+
+		if (!instance) {
+			PX4_ERR("alloc failed");
+			return nullptr;
+		}
+
+		if (OK != instance->init()) {
+			delete instance;
+			return nullptr;
+		}
+
+		return instance;
+	}
 };

--- a/platforms/common/include/px4_platform_common/spi.h
+++ b/platforms/common/include/px4_platform_common/spi.h
@@ -158,11 +158,13 @@ public:
 
 	bool external() const { return px4_spi_bus_external(bus()); }
 
+	int busDeviceIndex() const { return _bus_device_index; }
+
 private:
 	const FilterType _filter;
 	const uint16_t _devid_driver_index;
 	const int _bus;
-	int _index{-1};
-	int _external_bus_counter{0};
-	int _bus_device_index{0};
+	int _index{0};
+	int _external_bus_counter{1};
+	int _bus_device_index{-1};
 };

--- a/platforms/nuttx/src/px4/nxp/imxrt/include/px4_arch/spi_hw_description.h
+++ b/platforms/nuttx/src/px4/nxp/imxrt/include/px4_arch/spi_hw_description.h
@@ -73,16 +73,22 @@ static inline constexpr px4_spi_bus_t initSPIBus(SPI::Bus bus, const px4_spi_bus
 	for (int i = 0; i < SPI_BUS_MAX_DEVICES; ++i) {
 		ret.devices[i] = devices.devices[i];
 
-		// check that the same device is configured only once (the chip-select code depends on that)
-		for (int j = i + 1; j < SPI_BUS_MAX_DEVICES; ++j) {
-			if (ret.devices[j].cs_gpio != 0) {
-				constexpr_assert(ret.devices[i].devid != ret.devices[j].devid, "Same device configured multiple times");
-			}
-		}
 
 		if (ret.devices[i].cs_gpio != 0) {
-			// A bus potentially requires locking if it is accessed by non-PX4 devices (i.e. NuttX drivers)
-			if (PX4_SPI_DEVICE_ID != PX4_SPIDEVID_TYPE(ret.devices[i].devid)) {
+			if (PX4_SPI_DEVICE_ID == PX4_SPIDEVID_TYPE(ret.devices[i].devid)) {
+				int same_devices_count = 0;
+
+				for (int j = 0; j < i; ++j) {
+					if (ret.devices[j].cs_gpio != 0) {
+						same_devices_count += (ret.devices[i].devid & 0xff) == (ret.devices[j].devid & 0xff);
+					}
+				}
+
+				// increment the 2. LSB byte to allow multiple devices of the same type
+				ret.devices[i].devid |= same_devices_count << 8;
+
+			} else {
+				// A bus potentially requires locking if it is accessed by non-PX4 devices (i.e. NuttX drivers)
 				ret.requires_locking = true;
 			}
 		}

--- a/platforms/nuttx/src/px4/nxp/kinetis/include/px4_arch/spi_hw_description.h
+++ b/platforms/nuttx/src/px4/nxp/kinetis/include/px4_arch/spi_hw_description.h
@@ -67,16 +67,22 @@ static inline constexpr px4_spi_bus_t initSPIBus(SPI::Bus bus, const px4_spi_bus
 	for (int i = 0; i < SPI_BUS_MAX_DEVICES; ++i) {
 		ret.devices[i] = devices.devices[i];
 
-		// check that the same device is configured only once (the chip-select code depends on that)
-		for (int j = i + 1; j < SPI_BUS_MAX_DEVICES; ++j) {
-			if (ret.devices[j].cs_gpio != 0) {
-				constexpr_assert(ret.devices[i].devid != ret.devices[j].devid, "Same device configured multiple times");
-			}
-		}
 
 		if (ret.devices[i].cs_gpio != 0) {
-			// A bus potentially requires locking if it is accessed by non-PX4 devices (i.e. NuttX drivers)
-			if (PX4_SPI_DEVICE_ID != PX4_SPIDEVID_TYPE(ret.devices[i].devid)) {
+			if (PX4_SPI_DEVICE_ID == PX4_SPIDEVID_TYPE(ret.devices[i].devid)) {
+				int same_devices_count = 0;
+
+				for (int j = 0; j < i; ++j) {
+					if (ret.devices[j].cs_gpio != 0) {
+						same_devices_count += (ret.devices[i].devid & 0xff) == (ret.devices[j].devid & 0xff);
+					}
+				}
+
+				// increment the 2. LSB byte to allow multiple devices of the same type
+				ret.devices[i].devid |= same_devices_count << 8;
+
+			} else {
+				// A bus potentially requires locking if it is accessed by non-PX4 devices (i.e. NuttX drivers)
 				ret.requires_locking = true;
 			}
 		}

--- a/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/spi_hw_description.h
+++ b/platforms/nuttx/src/px4/stm/stm32_common/include/px4_arch/spi_hw_description.h
@@ -69,16 +69,22 @@ static inline constexpr px4_spi_bus_t initSPIBus(SPI::Bus bus, const px4_spi_bus
 	for (int i = 0; i < SPI_BUS_MAX_DEVICES; ++i) {
 		ret.devices[i] = devices.devices[i];
 
-		// check that the same device is configured only once (the chip-select code depends on that)
-		for (int j = i + 1; j < SPI_BUS_MAX_DEVICES; ++j) {
-			if (ret.devices[j].cs_gpio != 0) {
-				constexpr_assert(ret.devices[i].devid != ret.devices[j].devid, "Same device configured multiple times");
-			}
-		}
 
 		if (ret.devices[i].cs_gpio != 0) {
-			// A bus potentially requires locking if it is accessed by non-PX4 devices (i.e. NuttX drivers)
-			if (PX4_SPI_DEVICE_ID != PX4_SPIDEVID_TYPE(ret.devices[i].devid)) {
+			if (PX4_SPI_DEVICE_ID == PX4_SPIDEVID_TYPE(ret.devices[i].devid)) {
+				int same_devices_count = 0;
+
+				for (int j = 0; j < i; ++j) {
+					if (ret.devices[j].cs_gpio != 0) {
+						same_devices_count += (ret.devices[i].devid & 0xff) == (ret.devices[j].devid & 0xff);
+					}
+				}
+
+				// increment the 2. LSB byte to allow multiple devices of the same type
+				ret.devices[i].devid |= same_devices_count << 8;
+
+			} else {
+				// A bus potentially requires locking if it is accessed by non-PX4 devices (i.e. NuttX drivers)
 				ret.requires_locking = true;
 			}
 		}

--- a/src/drivers/adc/ads1115/ADS1115.cpp
+++ b/src/drivers/adc/ads1115/ADS1115.cpp
@@ -47,7 +47,18 @@ int ADS1115::init()
 	config[0] = CONFIG_HIGH_OS_NOACT | CONFIG_HIGH_MUX_P0NG | CONFIG_HIGH_PGA_6144 | CONFIG_HIGH_MODE_SS;
 	config[1] = CONFIG_LOW_DR_250SPS | CONFIG_LOW_COMP_MODE_TRADITIONAL | CONFIG_LOW_COMP_POL_RESET |
 		    CONFIG_LOW_COMP_LAT_NONE | CONFIG_LOW_COMP_QU_DISABLE;
-	return writeReg(ADDRESSPOINTER_REG_CONFIG, config, 2);
+	ret = writeReg(ADDRESSPOINTER_REG_CONFIG, config, 2);
+
+	if (ret != PX4_OK) {
+		PX4_ERR("writeReg failed (%i)", ret);
+		return ret;
+	}
+
+	setChannel(ADS1115::A0);  // prepare for the first measure.
+
+	ScheduleOnInterval(SAMPLE_INTERVAL / 4, SAMPLE_INTERVAL / 4);
+
+	return PX4_OK;
 }
 
 int ADS1115::setChannel(ADS1115::ChannelSelection ch)

--- a/src/drivers/adc/ads1115/ADS1115.h
+++ b/src/drivers/adc/ads1115/ADS1115.h
@@ -105,23 +105,16 @@ using namespace time_literals;
 class ADS1115 : public device::I2C, public I2CSPIDriver<ADS1115>
 {
 public:
-	ADS1115(I2CSPIBusOption bus_option, int bus, int addr, int bus_frequency);
+	ADS1115(const I2CSPIDriverConfig &config);
 	~ADS1115() override;
 
-	int Begin();
-
 	int init() override;
-
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 
 	static void print_usage();
 
 	void RunImpl();
 
 protected:
-
-	adc_report_s _adc_report = {};
 
 	void print_status() override;
 
@@ -133,9 +126,11 @@ private:
 
 	static const hrt_abstime	SAMPLE_INTERVAL{50_ms};
 
+	adc_report_s _adc_report{};
+
 	perf_counter_t			_cycle_perf;
 
-	int     _channel_cycle_count = 0;
+	int     _channel_cycle_count{0};
 
 	// ADS1115 logic part
 	enum ChannelSelection {

--- a/src/drivers/barometer/bmp280/BMP280.cpp
+++ b/src/drivers/barometer/bmp280/BMP280.cpp
@@ -33,9 +33,8 @@
 
 #include "BMP280.hpp"
 
-BMP280::BMP280(I2CSPIBusOption bus_option, int bus, bmp280::IBMP280 *interface) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus,
-		     interface->get_device_address()),
+BMP280::BMP280(const I2CSPIDriverConfig &config, bmp280::IBMP280 *interface) :
+	I2CSPIDriver(config),
 	_px4_baro(interface->get_device_id()),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),

--- a/src/drivers/barometer/bmp280/BMP280.hpp
+++ b/src/drivers/barometer/bmp280/BMP280.hpp
@@ -45,11 +45,10 @@
 class BMP280 : public I2CSPIDriver<BMP280>
 {
 public:
-	BMP280(I2CSPIBusOption bus_option, int bus, bmp280::IBMP280 *interface);
+	BMP280(const I2CSPIDriverConfig &config, bmp280::IBMP280 *interface);
 	virtual ~BMP280();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int			init();

--- a/src/drivers/barometer/bmp280/bmp280_main.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_main.cpp
@@ -50,30 +50,29 @@ BMP280::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *BMP280::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *BMP280::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	bmp280::IBMP280 *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = bmp280_i2c_interface(iterator.bus(), cli.i2c_address, cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = bmp280_i2c_interface(config.bus, config.i2c_address, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = bmp280_spi_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = bmp280_spi_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	BMP280 *dev = new BMP280(iterator.configuredBusOption(), iterator.bus(), interface);
+	BMP280 *dev = new BMP280(config, interface);
 
 	if (dev == nullptr) {
 		delete interface;

--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -41,9 +41,8 @@
 
 #include "bmp388.h"
 
-BMP388::BMP388(I2CSPIBusOption bus_option, int bus, IBMP388 *interface) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus,
-		     interface->get_device_address()),
+BMP388::BMP388(const I2CSPIDriverConfig &config, IBMP388 *interface) :
+	I2CSPIDriver(config),
 	_px4_baro(interface->get_device_id()),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),

--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -308,11 +308,10 @@ public:
 class BMP388 : public I2CSPIDriver<BMP388>
 {
 public:
-	BMP388(I2CSPIBusOption bus_option, int bus, IBMP388 *interface);
+	BMP388(const I2CSPIDriverConfig &config, IBMP388 *interface);
 	virtual ~BMP388();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	virtual int		init();

--- a/src/drivers/barometer/bmp388/bmp388_main.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_main.cpp
@@ -48,30 +48,29 @@ BMP388::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *BMP388::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *BMP388::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	IBMP388 *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = bmp388_i2c_interface(iterator.bus(), cli.i2c_address, cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = bmp388_i2c_interface(config.bus, config.i2c_address, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = bmp388_spi_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = bmp388_spi_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	BMP388 *dev = new BMP388(iterator.configuredBusOption(), iterator.bus(), interface);
+	BMP388 *dev = new BMP388(config, interface);
 
 	if (dev == nullptr) {
 		delete interface;

--- a/src/drivers/barometer/dps310/DPS310.cpp
+++ b/src/drivers/barometer/dps310/DPS310.cpp
@@ -46,9 +46,8 @@ static void getTwosComplement(T &raw, uint8_t length)
 	}
 }
 
-DPS310::DPS310(I2CSPIBusOption bus_option, int bus, device::Device *interface) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus,
-		     interface->get_device_address()),
+DPS310::DPS310(const I2CSPIDriverConfig &config, device::Device *interface) :
+	I2CSPIDriver(config),
 	_px4_barometer(interface->get_device_id()),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),

--- a/src/drivers/barometer/dps310/DPS310.hpp
+++ b/src/drivers/barometer/dps310/DPS310.hpp
@@ -56,11 +56,10 @@ using Infineon_DPS310::Register;
 class DPS310 : public I2CSPIDriver<DPS310>
 {
 public:
-	DPS310(I2CSPIBusOption bus_option, int bus, device::Device *interface);
+	DPS310(const I2CSPIDriverConfig &config, device::Device *interface);
 	virtual ~DPS310();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int			init();

--- a/src/drivers/barometer/dps310/dps310_main.cpp
+++ b/src/drivers/barometer/dps310/dps310_main.cpp
@@ -55,30 +55,29 @@ DPS310::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *DPS310::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *DPS310::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = DPS310_I2C_interface(iterator.bus(), cli.i2c_address, cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = DPS310_I2C_interface(config.bus, config.i2c_address, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = DPS310_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = DPS310_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	DPS310 *dev = new DPS310(iterator.configuredBusOption(), iterator.bus(), interface);
+	DPS310 *dev = new DPS310(config, interface);
 
 	if (dev == nullptr) {
 		delete interface;

--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -42,8 +42,8 @@
 /* Max measurement rate is 25Hz */
 #define LPS22HB_CONVERSION_INTERVAL	(1000000 / 25)	/* microseconds */
 
-LPS22HB::LPS22HB(I2CSPIBusOption bus_option, int bus, device::Device *interface) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus),
+LPS22HB::LPS22HB(const I2CSPIDriverConfig &config, device::Device *interface) :
+	I2CSPIDriver(config),
 	_px4_baro(interface->get_device_id()),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),

--- a/src/drivers/barometer/lps22hb/LPS22HB.hpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.hpp
@@ -70,6 +70,8 @@ static constexpr uint8_t PRESS_OUT_H = 0x2A;
 static constexpr uint8_t TEMP_OUT_L = 0x2B;
 static constexpr uint8_t TEMP_OUT_H = 0x2C;
 
+#define LPS22HB_ADDRESS		0x5D
+
 /* interface factories */
 extern device::Device *LPS22HB_SPI_interface(int bus, uint32_t devid, int bus_frequency, spi_mode_e spi_mode);
 extern device::Device *LPS22HB_I2C_interface(int bus, int bus_frequency);
@@ -77,11 +79,10 @@ extern device::Device *LPS22HB_I2C_interface(int bus, int bus_frequency);
 class LPS22HB : public I2CSPIDriver<LPS22HB>
 {
 public:
-	LPS22HB(I2CSPIBusOption bus_option, int bus, device::Device *interface);
+	LPS22HB(const I2CSPIDriverConfig &config, device::Device *interface);
 	virtual ~LPS22HB();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int			init();

--- a/src/drivers/barometer/lps22hb/LPS22HB_I2C.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB_I2C.cpp
@@ -41,8 +41,6 @@
 
 #include <drivers/device/i2c.h>
 
-#define LPS22HB_ADDRESS		0x5D
-
 device::Device *LPS22HB_I2C_interface(int bus, int bus_frequency);
 
 class LPS22HB_I2C : public device::I2C

--- a/src/drivers/barometer/lps25h/LPS25H.cpp
+++ b/src/drivers/barometer/lps25h/LPS25H.cpp
@@ -33,8 +33,8 @@
 
 #include "LPS25H.hpp"
 
-LPS25H::LPS25H(I2CSPIBusOption bus_option, int bus, device::Device *interface) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus),
+LPS25H::LPS25H(const I2CSPIDriverConfig &config, device::Device *interface) :
+	I2CSPIDriver(config),
 	_px4_barometer(interface->get_device_id()),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),

--- a/src/drivers/barometer/lps25h/LPS25H.hpp
+++ b/src/drivers/barometer/lps25h/LPS25H.hpp
@@ -155,11 +155,10 @@
 class LPS25H : public I2CSPIDriver<LPS25H>
 {
 public:
-	LPS25H(I2CSPIBusOption bus_option, int bus, device::Device *interface);
+	LPS25H(const I2CSPIDriverConfig &config, device::Device *interface);
 	~LPS25H() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int		init();

--- a/src/drivers/barometer/lps25h/lps25h.h
+++ b/src/drivers/barometer/lps25h/lps25h.h
@@ -50,6 +50,8 @@
 
 #define ID_WHO_AM_I		0xBD
 
+#define LPS25H_ADDRESS		0x5D
+
 /* interface factories */
 extern device::Device *LPS25H_SPI_interface(int bus, uint32_t devid, int bus_frequency, spi_mode_e spi_mode);
 extern device::Device *LPS25H_I2C_interface(int bus, int bus_frequency);

--- a/src/drivers/barometer/lps25h/lps25h_i2c.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_i2c.cpp
@@ -41,8 +41,6 @@
 
 #include <drivers/device/i2c.h>
 
-#define LPS25H_ADDRESS		0x5D
-
 device::Device *LPS25H_I2C_interface(int bus, int bus_frequency);
 
 class LPS25H_I2C : public device::I2C

--- a/src/drivers/barometer/lps25h/lps25h_main.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_main.cpp
@@ -47,30 +47,29 @@ LPS25H::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *LPS25H::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *LPS25H::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = LPS25H_I2C_interface(iterator.bus(), cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = LPS25H_I2C_interface(config.bus, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = LPS25H_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = LPS25H_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	LPS25H *dev = new LPS25H(iterator.configuredBusOption(), iterator.bus(), interface);
+	LPS25H *dev = new LPS25H(config, interface);
 
 	if (dev == nullptr) {
 		delete interface;
@@ -98,6 +97,8 @@ extern "C" int lps25h_main(int argc, char *argv[])
 		ThisDriver::print_usage();
 		return -1;
 	}
+
+	cli.i2c_address = LPS25H_ADDRESS;
 
 	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_BARO_DEVTYPE_LPS25H);
 

--- a/src/drivers/barometer/lps33hw/lps33hw.cpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.cpp
@@ -47,14 +47,13 @@ static void getTwosComplement(T &raw, uint8_t length)
 	}
 }
 
-LPS33HW::LPS33HW(I2CSPIBusOption bus_option, int bus, device::Device *interface, bool keep_retrying) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus,
-		     interface->get_device_address()),
+LPS33HW::LPS33HW(const I2CSPIDriverConfig &config, device::Device *interface) :
+	I2CSPIDriver(config),
 	_px4_barometer(interface->get_device_id()),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comm errors")),
-	_keep_retrying(keep_retrying)
+	_keep_retrying(config.keep_running)
 {
 }
 

--- a/src/drivers/barometer/lps33hw/lps33hw.hpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.hpp
@@ -55,11 +55,10 @@ using ST_LPS33HW::Register;
 class LPS33HW : public I2CSPIDriver<LPS33HW>
 {
 public:
-	LPS33HW(I2CSPIBusOption bus_option, int bus, device::Device *interface, bool keep_retrying);
+	LPS33HW(const I2CSPIDriverConfig &config, device::Device *interface);
 	virtual ~LPS33HW();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int			init();

--- a/src/drivers/barometer/lps33hw/lps33hw_main.cpp
+++ b/src/drivers/barometer/lps33hw/lps33hw_main.cpp
@@ -56,30 +56,29 @@ LPS33HW::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *LPS33HW::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
+I2CSPIDriverBase *LPS33HW::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = LPS33HW_I2C_interface(iterator.bus(), cli.i2c_address, cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = LPS33HW_I2C_interface(config.bus, config.i2c_address, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = LPS33HW_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = LPS33HW_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	LPS33HW *dev = new LPS33HW(iterator.configuredBusOption(), iterator.bus(), interface, cli.keep_running);
+	LPS33HW *dev = new LPS33HW(config, interface);
 
 	if (dev == nullptr) {
 		delete interface;

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
@@ -33,8 +33,6 @@
 
 #include "MPL3115A2.hpp"
 
-#define MPL3115A2_ADDRESS        0x60
-
 #define MPL3115A2_REG_WHO_AM_I   0x0c
 #define MPL3115A2_WHO_AM_I       0xC4
 
@@ -54,9 +52,9 @@
 #define MPL3115A2_OSR                   2       /* Over Sample rate of 4 18MS Minimum time between data samples */
 #define MPL3115A2_CTRL_TRIGGER          (CTRL_REG1_OST | CTRL_REG1_OS(MPL3115A2_OSR))
 
-MPL3115A2::MPL3115A2(I2CSPIBusOption bus_option, const int bus, int bus_frequency) :
-	I2C(DRV_BARO_DEVTYPE_MPL3115A2, MODULE_NAME, bus, MPL3115A2_ADDRESS, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
+MPL3115A2::MPL3115A2(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
 	_px4_barometer(get_device_id()),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
@@ -48,14 +48,14 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
+#define MPL3115A2_ADDRESS        0x60
+
 class MPL3115A2 : public device::I2C, public I2CSPIDriver<MPL3115A2>
 {
 public:
-	MPL3115A2(I2CSPIBusOption bus_option, const int bus, int bus_frequency);
+	MPL3115A2(const I2CSPIDriverConfig &config);
 	~MPL3115A2() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2_main.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2_main.cpp
@@ -43,24 +43,8 @@ MPL3115A2::print_usage()
 	PRINT_MODULE_USAGE_SUBCATEGORY("baro");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x60);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *MPL3115A2::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	MPL3115A2 *dev = new MPL3115A2(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency);
-
-	if (dev == nullptr) {
-		return nullptr;
-	}
-
-	if (OK != dev->init()) {
-		delete dev;
-		return nullptr;
-	}
-
-	return dev;
 }
 
 extern "C" int mpl3115a2_main(int argc, char *argv[])
@@ -68,6 +52,7 @@ extern "C" int mpl3115a2_main(int argc, char *argv[])
 	using ThisDriver = MPL3115A2;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = 400000;
+	cli.i2c_address = MPL3115A2_ADDRESS;
 
 	const char *verb = cli.parseDefaultArguments(argc, argv);
 

--- a/src/drivers/barometer/ms5611/MS5611.hpp
+++ b/src/drivers/barometer/ms5611/MS5611.hpp
@@ -87,12 +87,10 @@ enum MS56XX_DEVICE_TYPES {
 class MS5611 : public I2CSPIDriver<MS5611>
 {
 public:
-	MS5611(device::Device *interface, ms5611::prom_u &prom_buf, enum MS56XX_DEVICE_TYPES device_type,
-	       I2CSPIBusOption bus_option, int bus);
+	MS5611(device::Device *interface, ms5611::prom_u &prom_buf, const I2CSPIDriverConfig &config);
 	~MS5611() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int		init();

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -41,17 +41,25 @@
 
 #include <cdev/CDev.hpp>
 
-MS5611::MS5611(device::Device *interface, ms5611::prom_u &prom_buf, enum MS56XX_DEVICE_TYPES device_type,
-	       I2CSPIBusOption bus_option, int bus) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus, 0, device_type),
+MS5611::MS5611(device::Device *interface, ms5611::prom_u &prom_buf, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
 	_px4_barometer(interface->get_device_id()),
 	_interface(interface),
 	_prom(prom_buf.s),
-	_device_type(device_type),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": measure")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": com_err"))
 {
+	switch (config.devid_driver_index) {
+	case DRV_BARO_DEVTYPE_MS5611:
+		_device_type = MS5611_DEVICE;
+		break;
+
+	case DRV_BARO_DEVTYPE_MS5607:
+	default:
+		_device_type = MS5607_DEVICE;
+		break;
+	}
 }
 
 MS5611::~MS5611()

--- a/src/drivers/barometer/ms5611/ms5611.h
+++ b/src/drivers/barometer/ms5611/ms5611.h
@@ -58,6 +58,10 @@
 #define IOCTL_RESET			2
 #define IOCTL_MEASURE			3
 
+#define MS5611_ADDRESS_1		0x76	/* address select pins pulled high (PX4FMU series v1.6+) */
+#define MS5611_ADDRESS_2		0x77    /* address select pins pulled low (PX4FMU prototypes) */
+
+
 namespace ms5611
 {
 

--- a/src/drivers/barometer/ms5611/ms5611_i2c.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_i2c.cpp
@@ -41,9 +41,6 @@
 
 #include "ms5611.h"
 
-#define MS5611_ADDRESS_1		0x76	/* address select pins pulled high (PX4FMU series v1.6+) */
-#define MS5611_ADDRESS_2		0x77    /* address select pins pulled low (PX4FMU prototypes) */
-
 class MS5611_I2C : public device::I2C
 {
 public:

--- a/src/drivers/barometer/ms5611/ms5611_main.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_main.cpp
@@ -40,17 +40,16 @@
 #include "MS5611.hpp"
 #include "ms5611.h"
 
-I2CSPIDriverBase *MS5611::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *MS5611::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	ms5611::prom_u prom_buf;
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = MS5611_i2c_interface(prom_buf, iterator.devid(), iterator.bus(), cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = MS5611_i2c_interface(prom_buf, config.spi_devid, config.bus, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = MS5611_spi_interface(prom_buf, iterator.devid(), iterator.bus(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = MS5611_spi_interface(prom_buf, config.spi_devid, config.bus, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -60,12 +59,11 @@ I2CSPIDriverBase *MS5611::instantiate(const BusCLIArguments &cli, const BusInsta
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%x)", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	MS5611 *dev = new MS5611(interface, prom_buf, (MS56XX_DEVICE_TYPES)cli.type, iterator.configuredBusOption(),
-				 iterator.bus());
+	MS5611 *dev = new MS5611(interface, prom_buf, config);
 
 	if (dev == nullptr) {
 		delete interface;
@@ -95,7 +93,6 @@ extern "C" int ms5611_main(int argc, char *argv[])
 	using ThisDriver = MS5611;
 	int ch;
 	BusCLIArguments cli{true, true};
-	cli.type = MS5611_DEVICE;
 	cli.default_i2c_frequency = 400000;
 	cli.default_spi_frequency = 20 * 1000 * 1000;
 	uint16_t dev_type_driver = DRV_BARO_DEVTYPE_MS5611;
@@ -106,11 +103,9 @@ extern "C" int ms5611_main(int argc, char *argv[])
 				int val = atoi(cli.optArg());
 
 				if (val == 5611) {
-					cli.type = MS5611_DEVICE;
 					dev_type_driver = DRV_BARO_DEVTYPE_MS5611;
 
 				} else if (val == 5607) {
-					cli.type = MS5607_DEVICE;
 					dev_type_driver = DRV_BARO_DEVTYPE_MS5607;
 				}
 			}
@@ -124,6 +119,8 @@ extern "C" int ms5611_main(int argc, char *argv[])
 		ThisDriver::print_usage();
 		return -1;
 	}
+
+	cli.i2c_address = MS5611_ADDRESS_1;
 
 	BusInstanceIterator iterator(MODULE_NAME, cli, dev_type_driver);
 

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -47,9 +47,8 @@
 
 extern "C" __EXPORT int batt_smbus_main(int argc, char *argv[]);
 
-BATT_SMBUS::BATT_SMBUS(I2CSPIBusOption bus_option, const int bus, SMBus *interface) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus,
-		     interface->get_device_address()),
+BATT_SMBUS::BATT_SMBUS(const I2CSPIDriverConfig &config, SMBus *interface) :
+	I2CSPIDriver(config),
 	_interface(interface)
 {
 	int32_t battsource = 1;
@@ -534,15 +533,14 @@ $ batt_smbus -X write_flash 19069 2 27 0
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *BATT_SMBUS::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *BATT_SMBUS::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
-	SMBus *interface = new SMBus(DRV_BAT_DEVTYPE_SMBUS, iterator.bus(), cli.i2c_address);
+	SMBus *interface = new SMBus(DRV_BAT_DEVTYPE_SMBUS, config.bus, config.i2c_address);
 	if (interface == nullptr) {
 		PX4_ERR("alloc failed");
 		return nullptr;
 	}
-	BATT_SMBUS *instance = new BATT_SMBUS(iterator.configuredBusOption(), iterator.bus(), interface);
+	BATT_SMBUS *instance = new BATT_SMBUS(config, interface);
 
 	if (instance == nullptr) {
 		PX4_ERR("alloc failed");

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -127,12 +127,11 @@ enum class SMBUS_DEVICE_TYPE {
 class BATT_SMBUS : public I2CSPIDriver<BATT_SMBUS>
 {
 public:
-	BATT_SMBUS(I2CSPIBusOption bus_option, const int bus, SMBus *interface);
+	BATT_SMBUS(const I2CSPIDriverConfig &config, SMBus *interface);
 
 	~BATT_SMBUS();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	friend SMBus;

--- a/src/drivers/differential_pressure/ms5525/MS5525.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525.cpp
@@ -33,6 +33,17 @@
 
 #include "MS5525.hpp"
 
+int	MS5525::init()
+{
+	int ret = Airspeed::init();
+
+	if (ret == PX4_OK) {
+		ScheduleNow();
+	}
+
+	return ret;
+}
+
 int
 MS5525::measure()
 {

--- a/src/drivers/differential_pressure/ms5525/MS5525.hpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525.hpp
@@ -51,19 +51,19 @@ static constexpr int64_t CONVERSION_INTERVAL = (1000000 / MEAS_RATE); /* microse
 class MS5525 : public Airspeed, public I2CSPIDriver<MS5525>
 {
 public:
-	MS5525(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int address = I2C_ADDRESS_1_MS5525DSO) :
-		Airspeed(bus, bus_frequency, address, CONVERSION_INTERVAL),
-		I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+	MS5525(const I2CSPIDriverConfig &config) :
+		Airspeed(config.bus, config.bus_frequency, config.i2c_address, CONVERSION_INTERVAL),
+		I2CSPIDriver(config)
 	{
 	}
 
 	virtual ~MS5525() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void	RunImpl();
+
+	int init() override;
 
 private:
 

--- a/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
@@ -35,26 +35,6 @@
 
 extern "C" __EXPORT int ms5525_airspeed_main(int argc, char *argv[]);
 
-I2CSPIDriverBase *MS5525::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	MS5525 *instance = new MS5525(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->ScheduleNow();
-	return instance;
-}
-
-
 void
 MS5525::print_usage()
 {
@@ -62,6 +42,7 @@ MS5525::print_usage()
 	PRINT_MODULE_USAGE_SUBCATEGORY("airspeed_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x76);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -71,6 +52,7 @@ ms5525_airspeed_main(int argc, char *argv[])
 	using ThisDriver = MS5525;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = 100000;
+	cli.i2c_address = I2C_ADDRESS_1_MS5525DSO;
 
 	const char *verb = cli.parseDefaultArguments(argc, argv);
 
@@ -79,8 +61,7 @@ ms5525_airspeed_main(int argc, char *argv[])
 		return -1;
 	}
 
-	BusInstanceIterator iterator(MODULE_NAME, cli,
-				     DRV_DIFF_PRESS_DEVTYPE_MS5525);
+	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_DIFF_PRESS_DEVTYPE_MS5525);
 
 	if (!strcmp(verb, "start")) {
 		return ThisDriver::module_start(cli, iterator);

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
@@ -124,10 +124,16 @@ SDP3X::read_scale()
 	return PX4_OK;
 }
 
-void SDP3X::start()
+int	SDP3X::init()
 {
-	// make sure to wait 10ms after configuring the measurement mode
-	ScheduleDelayed(10_ms);
+	int ret = Airspeed::init();
+
+	if (ret == PX4_OK) {
+		// make sure to wait 10ms after configuring the measurement mode
+		ScheduleDelayed(10_ms);
+	}
+
+	return ret;
 }
 
 int

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
@@ -69,23 +69,20 @@
 class SDP3X : public Airspeed, public I2CSPIDriver<SDP3X>
 {
 public:
-	SDP3X(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int address = I2C_ADDRESS_1_SDP3X,
-	      bool keep_retrying = false) :
-		Airspeed(bus, bus_frequency, address, CONVERSION_INTERVAL),
-		I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address),
-		_keep_retrying{keep_retrying}
+	SDP3X(const I2CSPIDriverConfig &config) :
+		Airspeed(config.bus, config.bus_frequency, config.i2c_address, CONVERSION_INTERVAL),
+		I2CSPIDriver(config),
+		_keep_retrying{config.keep_running}
 	{
 	}
 
 	virtual ~SDP3X() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void	RunImpl();
 
-	void start();
+	int init() override;
 
 private:
 	enum class State {

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -35,27 +35,6 @@
 
 extern "C" __EXPORT int sdp3x_airspeed_main(int argc, char *argv[]);
 
-I2CSPIDriverBase *SDP3X::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				     int runtime_instance)
-{
-	SDP3X *instance = new SDP3X(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.i2c_address,
-				    cli.keep_running);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-	return instance;
-}
-
-
 void
 SDP3X::print_usage()
 {

--- a/src/drivers/distance_sensor/gy_us42/GY_US42.cpp
+++ b/src/drivers/distance_sensor/gy_us42/GY_US42.cpp
@@ -33,10 +33,10 @@
 
 #include "GY_US42.hpp"
 
-GY_US42::GY_US42(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency, int address) :
-	I2C(DRV_DIST_DEVTYPE_GY_US42, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_rangefinder(get_device_id(), rotation)
+GY_US42::GY_US42(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_rangefinder(get_device_id(), config.rotation)
 {
 	_px4_rangefinder.set_max_distance(GY_US42_MAX_DISTANCE);
 	_px4_rangefinder.set_min_distance(GY_US42_MIN_DISTANCE);

--- a/src/drivers/distance_sensor/gy_us42/GY_US42.hpp
+++ b/src/drivers/distance_sensor/gy_us42/GY_US42.hpp
@@ -63,12 +63,9 @@
 class GY_US42 : public device::I2C, public I2CSPIDriver<GY_US42>
 {
 public:
-	GY_US42(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency,
-		int address = GY_US42_BASEADDR);
+	GY_US42(const I2CSPIDriverConfig &config);
 	~GY_US42() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int init() override;

--- a/src/drivers/distance_sensor/gy_us42/GY_US42_main.cpp
+++ b/src/drivers/distance_sensor/gy_us42/GY_US42_main.cpp
@@ -47,36 +47,18 @@ GY_US42::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *GY_US42::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	GY_US42 *instance = new GY_US42(iterator.configuredBusOption(), iterator.bus(), cli.orientation, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" __EXPORT int gy_us42_main(int argc, char *argv[])
 {
 	int ch;
 	using ThisDriver = GY_US42;
 	BusCLIArguments cli{true, false};
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optArg());
+			cli.rotation = (Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -41,11 +41,10 @@
 
 #include "LidarLiteI2C.h"
 
-LidarLiteI2C::LidarLiteI2C(I2CSPIBusOption bus_option, const int bus, const uint8_t orientation, int bus_frequency,
-			   const int address) :
-	I2C(DRV_RNG_DEVTYPE_LL40LS, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_rangefinder(get_device_id(), orientation)
+LidarLiteI2C::LidarLiteI2C(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_rangefinder(get_device_id(), config.rotation)
 {
 	_px4_rangefinder.set_min_distance(LL40LS_MIN_DISTANCE);
 	_px4_rangefinder.set_max_distance(LL40LS_MAX_DISTANCE);
@@ -72,6 +71,7 @@ LidarLiteI2C::init()
 		return PX4_ERROR;
 	}
 
+	start();
 	return PX4_OK;
 }
 

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -94,12 +94,9 @@ static constexpr uint32_t LL40LS_CONVERSION_TIMEOUT{100_ms};
 class LidarLiteI2C : public device::I2C, public I2CSPIDriver<LidarLiteI2C>
 {
 public:
-	LidarLiteI2C(I2CSPIBusOption bus_option, const int bus, const uint8_t orientation, int bus_frequency,
-		     const int address = LL40LS_BASEADDR);
+	LidarLiteI2C(const I2CSPIDriverConfig &config);
 	virtual ~LidarLiteI2C();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 

--- a/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
@@ -64,28 +64,10 @@ Setup/usage information: https://docs.px4.io/master/en/sensor/lidar_lite.html
 	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x62);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_COMMAND("regdump");
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *LidarLiteI2C::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	LidarLiteI2C* instance = new LidarLiteI2C(iterator.configuredBusOption(), iterator.bus(), cli.orientation, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-	return instance;
 }
 
 void
@@ -99,13 +81,14 @@ extern "C" __EXPORT int ll40ls_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = LidarLiteI2C;
 	BusCLIArguments cli{true, false};
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
+	cli.i2c_address = LL40LS_BASEADDR;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = (enum Rotation)atoi(cli.optArg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/distance_sensor/srf02/SRF02.cpp
+++ b/src/drivers/distance_sensor/srf02/SRF02.cpp
@@ -33,10 +33,10 @@
 
 #include "SRF02.hpp"
 
-SRF02::SRF02(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency, int address) :
-	I2C(DRV_DIST_DEVTYPE_SRF02, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_rangefinder(get_device_id(), rotation)
+SRF02::SRF02(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_rangefinder(get_device_id(), config.rotation)
 {
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_SRF02);
 	_px4_rangefinder.set_rangefinder_type(distance_sensor_s::MAV_DISTANCE_SENSOR_ULTRASOUND);
@@ -69,7 +69,13 @@ int SRF02::init()
 	// XXX we should find out why we need to wait 200 ms here
 	px4_usleep(200000);
 
-	return measure();
+	int ret = measure();
+
+	if (ret == PX4_OK) {
+		start();
+	}
+
+	return ret;
 }
 
 int SRF02::collect()

--- a/src/drivers/distance_sensor/srf02/SRF02.hpp
+++ b/src/drivers/distance_sensor/srf02/SRF02.hpp
@@ -65,12 +65,9 @@
 class SRF02 : public device::I2C, public I2CSPIDriver<SRF02>
 {
 public:
-	SRF02(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency,
-	      int address = SRF02_BASEADDR);
+	SRF02(const I2CSPIDriverConfig &config);
 	~SRF02() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int init() override;

--- a/src/drivers/distance_sensor/srf02/srf02_main.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02_main.cpp
@@ -43,27 +43,9 @@ SRF02::print_usage()
 	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x70);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *SRF02::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				     int runtime_instance)
-{
-	SRF02 *instance = new SRF02(iterator.configuredBusOption(), iterator.bus(), cli.orientation, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-	return instance;
 }
 
 extern "C" __EXPORT int srf02_main(int argc, char *argv[])
@@ -71,13 +53,14 @@ extern "C" __EXPORT int srf02_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = SRF02;
 	BusCLIArguments cli{true, false};
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
+	cli.i2c_address = SRF02_BASEADDR;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optArg());
+			cli.rotation = (Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/distance_sensor/teraranger/TERARANGER.cpp
+++ b/src/drivers/distance_sensor/teraranger/TERARANGER.cpp
@@ -73,10 +73,10 @@ static uint8_t crc8(uint8_t *p, uint8_t len)
 	return crc & 0xFF;
 }
 
-TERARANGER::TERARANGER(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency) :
-	I2C(DRV_DIST_DEVTYPE_TERARANGER, MODULE_NAME, bus, TERARANGER_ONE_BASEADDR, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_rangefinder(get_device_id(), rotation)
+TERARANGER::TERARANGER(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_rangefinder(get_device_id(), config.rotation)
 {
 	// up the retries since the device misses the first measure attempts
 	I2C::_retries = 3;
@@ -211,6 +211,8 @@ int TERARANGER::init()
 		PX4_ERR("invalid HW model %" PRId32 ".", hw_model);
 		return PX4_ERROR;
 	}
+
+	start();
 
 	return PX4_OK;
 }

--- a/src/drivers/distance_sensor/teraranger/TERARANGER.hpp
+++ b/src/drivers/distance_sensor/teraranger/TERARANGER.hpp
@@ -75,11 +75,9 @@ using namespace time_literals;
 class TERARANGER : public device::I2C, public I2CSPIDriver<TERARANGER>
 {
 public:
-	TERARANGER(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency);
+	TERARANGER(const I2CSPIDriverConfig &config);
 	~TERARANGER() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	virtual int init() override;

--- a/src/drivers/distance_sensor/teraranger/teraranger_main.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger_main.cpp
@@ -53,27 +53,9 @@ Setup/usage information: https://docs.px4.io/master/en/sensor/rangefinders.html#
 	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x30);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *TERARANGER::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				     int runtime_instance)
-{
-	TERARANGER *instance = new TERARANGER(iterator.configuredBusOption(), iterator.bus(), cli.orientation, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-	return instance;
 }
 
 extern "C" __EXPORT int teraranger_main(int argc, char *argv[])
@@ -81,13 +63,14 @@ extern "C" __EXPORT int teraranger_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = TERARANGER;
 	BusCLIArguments cli{true, false};
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
+	cli.i2c_address = TERARANGER_ONE_BASEADDR;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optArg());
+			cli.rotation = (Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
+++ b/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
@@ -59,10 +59,10 @@
 
 #define VL53L0X_BUS_CLOCK                               400000 // 400kHz bus clock speed
 
-VL53L0X::VL53L0X(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency, int address) :
-	I2C(DRV_DIST_DEVTYPE_VL53L0X, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_rangefinder(get_device_id(), rotation)
+VL53L0X::VL53L0X(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_rangefinder(get_device_id(), config.rotation)
 {
 	// VL53L0X typical range 0-2 meters with 25 degree field of view
 	_px4_rangefinder.set_min_distance(0.f);
@@ -80,6 +80,18 @@ VL53L0X::~VL53L0X()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
+}
+
+int VL53L0X::init()
+{
+	int ret = I2C::init();
+
+	if (ret != PX4_OK) {
+		return ret;
+	}
+
+	ScheduleNow();
+	return PX4_OK;
 }
 
 int VL53L0X::collect()
@@ -489,12 +501,6 @@ int VL53L0X::singleRefCalibration(const uint8_t byte)
 	return PX4_OK;
 }
 
-void VL53L0X::start()
-{
-	// Schedule the first cycle.
-	ScheduleNow();
-}
-
 int VL53L0X::writeRegister(const uint8_t reg_address, const uint8_t value)
 {
 	uint8_t cmd[2] {reg_address, value};
@@ -537,27 +543,9 @@ void VL53L0X::print_usage()
 	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x29);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 0, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *VL53L0X::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	VL53L0X *instance = new VL53L0X(iterator.configuredBusOption(), iterator.bus(), cli.orientation, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-	return instance;
 }
 
 extern "C" __EXPORT int vl53l0x_main(int argc, char *argv[])
@@ -566,12 +554,13 @@ extern "C" __EXPORT int vl53l0x_main(int argc, char *argv[])
 	using ThisDriver = VL53L0X;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = 400000;
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.i2c_address = VL53L0X_BASEADDR;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optArg());
+			cli.rotation = (Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/distance_sensor/vl53l0x/VL53L0X.hpp
+++ b/src/drivers/distance_sensor/vl53l0x/VL53L0X.hpp
@@ -54,13 +54,10 @@
 class VL53L0X : public device::I2C, public I2CSPIDriver<VL53L0X>
 {
 public:
-	VL53L0X(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency,
-		int address = VL53L0X_BASEADDR);
+	VL53L0X(const I2CSPIDriverConfig &config);
 
 	~VL53L0X() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	/**
@@ -69,15 +66,12 @@ public:
 	void print_status() override;
 
 	/**
-	 * Initialise the automatic measurement state machine and start it.
-	 */
-	void start();
-
-	/**
 	 * Perform a poll cycle; collect from the previous measurement
 	 * and start a new one.
 	 */
 	void RunImpl();
+
+	int init() override;
 
 private:
 	int probe() override;

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
@@ -140,10 +140,10 @@ static const uint8_t status_rtn[24] = { 255, 255, 255, 5, 2, 4, 1, 7, 3, 0,
 
 /* end ST */
 
-VL53L1X::VL53L1X(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency, int address) :
-	I2C(DRV_DIST_DEVTYPE_VL53L1X, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_rangefinder(get_device_id(), rotation)
+VL53L1X::VL53L1X(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_rangefinder(get_device_id(), config.rotation)
 {
 	// VL53L1X typical range 0-2 meters with 25 degree field of view
 	_px4_rangefinder.set_min_distance(0.f);
@@ -231,12 +231,6 @@ void VL53L1X::RunImpl()
 	ScheduleDelayed(VL53L1X_SAMPLE_RATE);
 }
 
-void VL53L1X::start()
-{
-	// Schedule the first cycle.
-	ScheduleNow();
-}
-
 int VL53L1X::init()
 {
 	int ret = PX4_OK;
@@ -258,13 +252,9 @@ int VL53L1X::init()
 		return PX4_ERROR;
 	}
 
-	PX4_INFO("vl53l1x init success");
+	PX4_DEBUG("vl53l1x init success");
+	ScheduleNow();
 	return PX4_OK;
-}
-
-void VL53L1X::stop()
-{
-	VL53L1X_StopRanging();
 }
 
 void VL53L1X::print_usage()
@@ -273,6 +263,7 @@ void VL53L1X::print_usage()
 	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x29);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 1, 25, "Sensor rotation - downward facing by default", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -658,37 +649,19 @@ int8_t VL53L1X::VL53L1X_ConfigBig(uint16_t DM, uint16_t TimingBudgetInMs)
 
 /* end ST */
 
-I2CSPIDriverBase *VL53L1X::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	VL53L1X *instance = new VL53L1X(iterator.configuredBusOption(), iterator.bus(), cli.orientation, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-	return instance;
-}
-
 extern "C" __EXPORT int vl53l1x_main(int argc, char *argv[])
 {
 	int ch;
 	using ThisDriver = VL53L1X;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = 400000;
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.i2c_address = VL53L1X_BASEADDR;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optArg());
+			cli.rotation = (Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.hpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.hpp
@@ -98,29 +98,16 @@
 class VL53L1X : public device::I2C, public I2CSPIDriver<VL53L1X>
 {
 public:
-	VL53L1X(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency,
-		int address = VL53L1X_BASEADDR);
+	VL53L1X(const I2CSPIDriverConfig &config);
 
 	~VL53L1X() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	/**
 	 * Diagnostics - print some basic information about the driver.
 	 */
 	void print_status() override;
-
-	/**
-	 * Initialise the automatic measurement state machine and start it.
-	 */
-	void start();
-
-	/**
-	 * Stop the automatic measurement state machine.
-	 */
-	void stop();
 
 	virtual int init() override;
 

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -53,15 +53,14 @@ static constexpr uint32_t ADIS16477_DEFAULT_RATE = 1000;
 
 using namespace time_literals;
 
-ADIS16477::ADIS16477(I2CSPIBusOption bus_option, int bus, int32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ADIS16477, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation),
+ADIS16477::ADIS16477(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_bad_transfers(perf_alloc(PC_COUNT, MODULE_NAME": bad transfers")),
-	_drdy_gpio(drdy_gpio)
+	_drdy_gpio(config.drdy_gpio)
 {
 #ifdef GPIO_SPI1_RESET_ADIS16477
 	// Configure hardware reset line

--- a/src/drivers/imu/adis16477/ADIS16477.hpp
+++ b/src/drivers/imu/adis16477/ADIS16477.hpp
@@ -50,12 +50,9 @@
 class ADIS16477 : public device::SPI, public I2CSPIDriver<ADIS16477>
 {
 public:
-	ADIS16477(I2CSPIBusOption bus_option, int bus, int32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ADIS16477(const I2CSPIDriverConfig &config);
 	virtual ~ADIS16477();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int		init();

--- a/src/drivers/imu/adis16477/adis16477_main.cpp
+++ b/src/drivers/imu/adis16477/adis16477_main.cpp
@@ -47,25 +47,6 @@ ADIS16477::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ADIS16477::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ADIS16477 *instance = new ADIS16477(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int adis16477_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/adis16497/ADIS16497.cpp
+++ b/src/drivers/imu/adis16497/ADIS16497.cpp
@@ -70,15 +70,14 @@ static constexpr uint32_t ADIS16497_DEFAULT_RATE = 1000;
 
 using namespace time_literals;
 
-ADIS16497::ADIS16497(I2CSPIBusOption bus_option, int bus, int32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ADIS16497, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation),
+ADIS16497::ADIS16497(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_bad_transfers(perf_alloc(PC_COUNT, MODULE_NAME": bad transfers")),
-	_drdy_gpio(drdy_gpio)
+	_drdy_gpio(config.drdy_gpio)
 {
 #ifdef GPIO_SPI1_RESET_ADIS16497
 	// Configure hardware reset line

--- a/src/drivers/imu/adis16497/ADIS16497.hpp
+++ b/src/drivers/imu/adis16497/ADIS16497.hpp
@@ -86,12 +86,9 @@ static constexpr uint32_t crc32_tab[] = {
 class ADIS16497 : public device::SPI, public I2CSPIDriver<ADIS16497>
 {
 public:
-	ADIS16497(I2CSPIBusOption bus_option, int bus, int32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ADIS16497(const I2CSPIDriverConfig &config);
 	virtual ~ADIS16497();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int		init() override;

--- a/src/drivers/imu/adis16497/adis16497_main.cpp
+++ b/src/drivers/imu/adis16497/adis16497_main.cpp
@@ -47,25 +47,6 @@ ADIS16497::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ADIS16497::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ADIS16497 *instance = new ADIS16497(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int adis16497_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/analog_devices/adis16448/ADIS16448.cpp
+++ b/src/drivers/imu/analog_devices/adis16448/ADIS16448.cpp
@@ -95,15 +95,14 @@ static int16_t convert12BitToINT16(uint16_t word)
 	return output;
 }
 
-ADIS16448::ADIS16448(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ADIS16448, MODULE_NAME, bus, device, SPIDEV_MODE3, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio), // TODO: DRDY disabled
-	_px4_accel(get_device_id(), rotation),
+ADIS16448::ADIS16448(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio), // TODO: DRDY disabled
+	_px4_accel(get_device_id(), config.rotation),
 	_px4_baro(get_device_id()),
-	_px4_gyro(get_device_id(), rotation),
-	_px4_mag(get_device_id(), rotation)
+	_px4_gyro(get_device_id(), config.rotation),
+	_px4_mag(get_device_id(), config.rotation)
 {
 }
 

--- a/src/drivers/imu/analog_devices/adis16448/ADIS16448.hpp
+++ b/src/drivers/imu/analog_devices/adis16448/ADIS16448.hpp
@@ -58,12 +58,9 @@ using namespace Analog_Devices_ADIS16448;
 class ADIS16448 : public device::SPI, public I2CSPIDriver<ADIS16448>
 {
 public:
-	ADIS16448(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_drdy_gpio_t drdy_gpio);
+	ADIS16448(const I2CSPIDriverConfig &config);
 	~ADIS16448() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/analog_devices/adis16448/adis16448_main.cpp
+++ b/src/drivers/imu/analog_devices/adis16448/adis16448_main.cpp
@@ -46,25 +46,6 @@ void ADIS16448::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ADIS16448::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ADIS16448 *instance = new ADIS16448(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int adis16448_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -40,13 +40,12 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ADIS16470::ADIS16470(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ADIS16470, MODULE_NAME, bus, device, SPIDEV_MODE3, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ADIS16470::ADIS16470(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
 }
 

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
@@ -56,12 +56,9 @@ using namespace Analog_Devices_ADIS16470;
 class ADIS16470 : public device::SPI, public I2CSPIDriver<ADIS16470>
 {
 public:
-	ADIS16470(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_drdy_gpio_t drdy_gpio);
+	ADIS16470(const I2CSPIDriverConfig &config);
 	~ADIS16470() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/analog_devices/adis16470/adis16470_main.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/adis16470_main.cpp
@@ -46,25 +46,6 @@ void ADIS16470::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ADIS16470::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ADIS16470 *instance = new ADIS16470(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int adis16470_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/bosch/bmi055/BMI055.cpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055.cpp
@@ -36,18 +36,15 @@
 #include "BMI055_Accelerometer.hpp"
 #include "BMI055_Gyroscope.hpp"
 
-I2CSPIDriverBase *BMI055::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *BMI055::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	BMI055 *instance = nullptr;
 
-	if (cli.type == DRV_ACC_DEVTYPE_BMI055) {
-		instance = new Bosch::BMI055::Accelerometer::BMI055_Accelerometer(iterator.configuredBusOption(), iterator.bus(),
-				iterator.devid(), cli.rotation, cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
+	if (config.devid_driver_index == DRV_ACC_DEVTYPE_BMI055) {
+		instance = new Bosch::BMI055::Accelerometer::BMI055_Accelerometer(config);
 
-	} else if (cli.type == DRV_GYR_DEVTYPE_BMI055) {
-		instance = new Bosch::BMI055::Gyroscope::BMI055_Gyroscope(iterator.configuredBusOption(), iterator.bus(),
-				iterator.devid(), cli.rotation, cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
+	} else if (config.devid_driver_index == DRV_GYR_DEVTYPE_BMI055) {
+		instance = new Bosch::BMI055::Gyroscope::BMI055_Gyroscope(config);
 	}
 
 	if (!instance) {
@@ -63,11 +60,10 @@ I2CSPIDriverBase *BMI055::instantiate(const BusCLIArguments &cli, const BusInsta
 	return instance;
 }
 
-BMI055::BMI055(uint8_t devtype, const char *name, I2CSPIBusOption bus_option, int bus, uint32_t device,
-	       enum spi_mode_e mode, uint32_t frequency, spi_drdy_gpio_t drdy_gpio) :
-	SPI(devtype, name, bus, device, mode, frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, devtype),
-	_drdy_gpio(drdy_gpio)
+BMI055::BMI055(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio)
 {
 }
 

--- a/src/drivers/imu/bosch/bmi055/BMI055.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055.hpp
@@ -43,13 +43,11 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) 
 class BMI055 : public device::SPI, public I2CSPIDriver<BMI055>
 {
 public:
-	BMI055(uint8_t devtype, const char *name, I2CSPIBusOption bus_option, int bus, uint32_t device, enum spi_mode_e mode,
-	       uint32_t frequency, spi_drdy_gpio_t drdy_gpio);
+	BMI055(const I2CSPIDriverConfig &config);
 
 	virtual ~BMI055() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	virtual void RunImpl() = 0;

--- a/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.cpp
@@ -40,12 +40,11 @@ using namespace time_literals;
 namespace Bosch::BMI055::Accelerometer
 {
 
-BMI055_Accelerometer::BMI055_Accelerometer(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-		int bus_frequency, spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	BMI055(DRV_ACC_DEVTYPE_BMI055, "BMI055_Accelerometer", bus_option, bus, device, spi_mode, bus_frequency, drdy_gpio),
-	_px4_accel(get_device_id(), rotation)
+BMI055_Accelerometer::BMI055_Accelerometer(const I2CSPIDriverConfig &config) :
+	BMI055(config),
+	_px4_accel(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_accel: DRDY missed");
 	}
 

--- a/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.hpp
@@ -45,8 +45,7 @@ namespace Bosch::BMI055::Accelerometer
 class BMI055_Accelerometer : public BMI055
 {
 public:
-	BMI055_Accelerometer(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-			     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	BMI055_Accelerometer(const I2CSPIDriverConfig &config);
 	~BMI055_Accelerometer() override;
 
 	void RunImpl() override;

--- a/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.cpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.cpp
@@ -40,12 +40,11 @@ using namespace time_literals;
 namespace Bosch::BMI055::Gyroscope
 {
 
-BMI055_Gyroscope::BMI055_Gyroscope(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-				   int bus_frequency, spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	BMI055(DRV_GYR_DEVTYPE_BMI055, "BMI055_Gyroscope", bus_option, bus, device, spi_mode, bus_frequency, drdy_gpio),
-	_px4_gyro(get_device_id(), rotation)
+BMI055_Gyroscope::BMI055_Gyroscope(const I2CSPIDriverConfig &config) :
+	BMI055(config),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_gyro: DRDY missed");
 	}
 

--- a/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Gyroscope.hpp
@@ -45,8 +45,7 @@ namespace Bosch::BMI055::Gyroscope
 class BMI055_Gyroscope : public BMI055
 {
 public:
-	BMI055_Gyroscope(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-			 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	BMI055_Gyroscope(const I2CSPIDriverConfig &config);
 	~BMI055_Gyroscope() override;
 
 	void RunImpl() override;

--- a/src/drivers/imu/bosch/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bosch/bmi055/bmi055_main.cpp
@@ -53,17 +53,20 @@ extern "C" int bmi055_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = BMI055;
 	BusCLIArguments cli{false, true};
-	cli.type = 0;
+	uint16_t type = 0;
 	cli.default_spi_frequency = 10000000;
+	const char *name = MODULE_NAME;
 
 	while ((ch = cli.getOpt(argc, argv, "AGR:")) != EOF) {
 		switch (ch) {
 		case 'A':
-			cli.type = DRV_ACC_DEVTYPE_BMI055;
+			type = DRV_ACC_DEVTYPE_BMI055;
+			name = MODULE_NAME "_accel";
 			break;
 
 		case 'G':
-			cli.type = DRV_GYR_DEVTYPE_BMI055;
+			type = DRV_GYR_DEVTYPE_BMI055;
+			name = MODULE_NAME "_gyro";
 			break;
 
 		case 'R':
@@ -74,12 +77,12 @@ extern "C" int bmi055_main(int argc, char *argv[])
 
 	const char *verb = cli.optArg();
 
-	if (!verb) {
+	if (!verb || type == 0) {
 		ThisDriver::print_usage();
 		return -1;
 	}
 
-	BusInstanceIterator iterator(MODULE_NAME, cli, cli.type);
+	BusInstanceIterator iterator(name, cli, type);
 
 	if (!strcmp(verb, "start")) {
 		return ThisDriver::module_start(cli, iterator);

--- a/src/drivers/imu/bosch/bmi088/BMI088.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088.cpp
@@ -36,18 +36,15 @@
 #include "BMI088_Accelerometer.hpp"
 #include "BMI088_Gyroscope.hpp"
 
-I2CSPIDriverBase *BMI088::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *BMI088::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	BMI088 *instance = nullptr;
 
-	if (cli.type == DRV_ACC_DEVTYPE_BMI088) {
-		instance = new Bosch::BMI088::Accelerometer::BMI088_Accelerometer(iterator.configuredBusOption(), iterator.bus(),
-				iterator.devid(), cli.rotation, cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
+	if (config.devid_driver_index == DRV_ACC_DEVTYPE_BMI088) {
+		instance = new Bosch::BMI088::Accelerometer::BMI088_Accelerometer(config);
 
-	} else if (cli.type == DRV_GYR_DEVTYPE_BMI088) {
-		instance = new Bosch::BMI088::Gyroscope::BMI088_Gyroscope(iterator.configuredBusOption(), iterator.bus(),
-				iterator.devid(), cli.rotation, cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
+	} else if (config.devid_driver_index == DRV_GYR_DEVTYPE_BMI088) {
+		instance = new Bosch::BMI088::Gyroscope::BMI088_Gyroscope(config);
 	}
 
 	if (!instance) {
@@ -63,11 +60,10 @@ I2CSPIDriverBase *BMI088::instantiate(const BusCLIArguments &cli, const BusInsta
 	return instance;
 }
 
-BMI088::BMI088(uint8_t devtype, const char *name, I2CSPIBusOption bus_option, int bus, uint32_t device,
-	       enum spi_mode_e mode, uint32_t frequency, spi_drdy_gpio_t drdy_gpio) :
-	SPI(devtype, name, bus, device, mode, frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, devtype),
-	_drdy_gpio(drdy_gpio)
+BMI088::BMI088(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio)
 {
 }
 

--- a/src/drivers/imu/bosch/bmi088/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088.hpp
@@ -43,13 +43,11 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) 
 class BMI088 : public device::SPI, public I2CSPIDriver<BMI088>
 {
 public:
-	BMI088(uint8_t devtype, const char *name, I2CSPIBusOption bus_option, int bus, uint32_t device, enum spi_mode_e mode,
-	       uint32_t frequency, spi_drdy_gpio_t drdy_gpio);
+	BMI088(const I2CSPIDriverConfig &config);
 
 	virtual ~BMI088() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	virtual void RunImpl() = 0;

--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
@@ -40,12 +40,11 @@ using namespace time_literals;
 namespace Bosch::BMI088::Accelerometer
 {
 
-BMI088_Accelerometer::BMI088_Accelerometer(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-		int bus_frequency, spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	BMI088(DRV_ACC_DEVTYPE_BMI088, "BMI088_Accelerometer", bus_option, bus, device, spi_mode, bus_frequency, drdy_gpio),
-	_px4_accel(get_device_id(), rotation)
+BMI088_Accelerometer::BMI088_Accelerometer(const I2CSPIDriverConfig &config) :
+	BMI088(config),
+	_px4_accel(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_accel: DRDY missed");
 	}
 

--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.hpp
@@ -45,8 +45,7 @@ namespace Bosch::BMI088::Accelerometer
 class BMI088_Accelerometer : public BMI088
 {
 public:
-	BMI088_Accelerometer(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-			     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	BMI088_Accelerometer(const I2CSPIDriverConfig &config);
 	~BMI088_Accelerometer() override;
 
 	void RunImpl() override;

--- a/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.cpp
@@ -40,12 +40,11 @@ using namespace time_literals;
 namespace Bosch::BMI088::Gyroscope
 {
 
-BMI088_Gyroscope::BMI088_Gyroscope(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-				   int bus_frequency, spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	BMI088(DRV_GYR_DEVTYPE_BMI088, "BMI088_Gyroscope", bus_option, bus, device, spi_mode, bus_frequency, drdy_gpio),
-	_px4_gyro(get_device_id(), rotation)
+BMI088_Gyroscope::BMI088_Gyroscope(const I2CSPIDriverConfig &config) :
+	BMI088(config),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_gyro: DRDY missed");
 	}
 

--- a/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.hpp
@@ -45,8 +45,7 @@ namespace Bosch::BMI088::Gyroscope
 class BMI088_Gyroscope : public BMI088
 {
 public:
-	BMI088_Gyroscope(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-			 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	BMI088_Gyroscope(const I2CSPIDriverConfig &config);
 	~BMI088_Gyroscope() override;
 
 	void RunImpl() override;

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088.cpp
@@ -36,18 +36,15 @@
 #include "BMI088_Accelerometer.hpp"
 #include "BMI088_Gyroscope.hpp"
 
-I2CSPIDriverBase *BMI088::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *BMI088::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	BMI088 *instance = nullptr;
 
-	if (cli.type == DRV_ACC_DEVTYPE_BMI088) {
-		instance = new Bosch::BMI088::Accelerometer::BMI088_Accelerometer(iterator.configuredBusOption(), iterator.bus(),
-				cli.i2c_address, cli.rotation, cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
+	if (config.devid_driver_index == DRV_ACC_DEVTYPE_BMI088) {
+		instance = new Bosch::BMI088::Accelerometer::BMI088_Accelerometer(config);
 
-	} else if (cli.type == DRV_GYR_DEVTYPE_BMI088) {
-		instance = new Bosch::BMI088::Gyroscope::BMI088_Gyroscope(iterator.configuredBusOption(), iterator.bus(),
-				cli.i2c_address, cli.rotation, cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
+	} else if (config.devid_driver_index == DRV_GYR_DEVTYPE_BMI088) {
+		instance = new Bosch::BMI088::Gyroscope::BMI088_Gyroscope(config);
 	}
 
 	if (!instance) {
@@ -63,11 +60,10 @@ I2CSPIDriverBase *BMI088::instantiate(const BusCLIArguments &cli, const BusInsta
 	return instance;
 }
 
-BMI088::BMI088(uint8_t devtype, const char *name, I2CSPIBusOption bus_option, int bus, uint32_t device,
-	       enum spi_mode_e mode, uint32_t frequency, spi_drdy_gpio_t drdy_gpio) :
-	I2C(devtype, name, bus, device, frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, devtype),
-	_drdy_gpio(drdy_gpio)
+BMI088::BMI088(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio)
 {
 }
 

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088.hpp
@@ -43,13 +43,11 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) 
 class BMI088 : public device::I2C, public I2CSPIDriver<BMI088>
 {
 public:
-	BMI088(uint8_t devtype, const char *name, I2CSPIBusOption bus_option, int bus, uint32_t device, enum spi_mode_e mode,
-	       uint32_t frequency, spi_drdy_gpio_t drdy_gpio);
+	BMI088(const I2CSPIDriverConfig &config);
 
 	virtual ~BMI088() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	virtual void RunImpl() = 0;

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Accelerometer.cpp
@@ -39,12 +39,11 @@ using namespace time_literals;
 
 namespace Bosch::BMI088::Accelerometer
 {
-BMI088_Accelerometer::BMI088_Accelerometer(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-		int bus_frequency, spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	BMI088(DRV_ACC_DEVTYPE_BMI088, "BMI088_Accelerometer", bus_option, bus, device, spi_mode, bus_frequency, drdy_gpio),
-	_px4_accel(get_device_id(), rotation)
+BMI088_Accelerometer::BMI088_Accelerometer(const I2CSPIDriverConfig &config) :
+	BMI088(config),
+	_px4_accel(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_accel: DRDY missed");
 	}
 

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Accelerometer.hpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Accelerometer.hpp
@@ -45,8 +45,7 @@ namespace Bosch::BMI088::Accelerometer
 class BMI088_Accelerometer : public BMI088
 {
 public:
-	BMI088_Accelerometer(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-			     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	BMI088_Accelerometer(const I2CSPIDriverConfig &config);
 	~BMI088_Accelerometer() override;
 
 	void RunImpl() override;

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Gyroscope.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Gyroscope.cpp
@@ -40,12 +40,11 @@ using namespace time_literals;
 namespace Bosch::BMI088::Gyroscope
 {
 
-BMI088_Gyroscope::BMI088_Gyroscope(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-				   int bus_frequency, spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	BMI088(DRV_GYR_DEVTYPE_BMI088, "BMI088_Gyroscope", bus_option, bus, device, spi_mode, bus_frequency, drdy_gpio),
-	_px4_gyro(get_device_id(), rotation)
+BMI088_Gyroscope::BMI088_Gyroscope(const I2CSPIDriverConfig &config) :
+	BMI088(config),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_gyro: DRDY missed");
 	}
 

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Gyroscope.hpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/BMI088_Gyroscope.hpp
@@ -45,8 +45,7 @@ namespace Bosch::BMI088::Gyroscope
 class BMI088_Gyroscope : public BMI088
 {
 public:
-	BMI088_Gyroscope(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-			 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	BMI088_Gyroscope(const I2CSPIDriverConfig &config);
 	~BMI088_Gyroscope() override;
 
 	void RunImpl() override;

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/bmi088_i2c_main.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/bmi088_i2c_main.cpp
@@ -45,7 +45,7 @@ void BMI088::print_usage()
 	PRINT_MODULE_USAGE_PARAM_FLAG('A', "Accel", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('G', "Gyro", true);
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
-	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x76);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x18);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -54,21 +54,24 @@ extern "C" int bmi088_i2c_main(int argc, char *argv[])
 {
 	int ch;
 	using ThisDriver = BMI088;
-	BusCLIArguments cli{true, true};
+	BusCLIArguments cli{true, false};
 	cli.i2c_address = 0x18;
 	cli.default_i2c_frequency = 400 * 1000;
-	cli.default_spi_frequency = 400 * 1000;
+	uint16_t type = 0;
+	const char *name = MODULE_NAME;
 
 
 	while ((ch = cli.getOpt(argc, argv, "AGR:")) != EOF) {
 		switch (ch) {
 		case 'A':
-			cli.type = DRV_ACC_DEVTYPE_BMI088;
+			type = DRV_ACC_DEVTYPE_BMI088;
+			name = MODULE_NAME "_accel";
 			cli.i2c_address = 0x18;
 			break;
 
 		case 'G':
-			cli.type = DRV_GYR_DEVTYPE_BMI088;
+			type = DRV_GYR_DEVTYPE_BMI088;
+			name = MODULE_NAME "_gyro";
 			cli.i2c_address = 0x69;
 			break;
 
@@ -80,12 +83,12 @@ extern "C" int bmi088_i2c_main(int argc, char *argv[])
 
 	const char *verb = cli.optArg();
 
-	if (!verb) {
+	if (!verb || type == 0) {
 		ThisDriver::print_usage();
 		return -1;
 	}
 
-	BusInstanceIterator iterator(MODULE_NAME, cli, cli.type);
+	BusInstanceIterator iterator(name, cli, type);
 
 	if (!strcmp(verb, "start")) {
 		return ThisDriver::module_start(cli, iterator);

--- a/src/drivers/imu/bosch/bmi088/bmi088_main.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_main.cpp
@@ -53,17 +53,20 @@ extern "C" int bmi088_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = BMI088;
 	BusCLIArguments cli{false, true};
-	cli.type = 0;
+	uint16_t type = 0;
 	cli.default_spi_frequency = 10000000;
+	const char *name = MODULE_NAME;
 
 	while ((ch = cli.getOpt(argc, argv, "AGR:")) != EOF) {
 		switch (ch) {
 		case 'A':
-			cli.type = DRV_ACC_DEVTYPE_BMI088;
+			type = DRV_ACC_DEVTYPE_BMI088;
+			name = MODULE_NAME "_accel";
 			break;
 
 		case 'G':
-			cli.type = DRV_GYR_DEVTYPE_BMI088;
+			type = DRV_GYR_DEVTYPE_BMI088;
+			name = MODULE_NAME "_gyro";
 			break;
 
 		case 'R':
@@ -74,12 +77,12 @@ extern "C" int bmi088_main(int argc, char *argv[])
 
 	const char *verb = cli.optArg();
 
-	if (!verb) {
+	if (!verb || type == 0) {
 		ThisDriver::print_usage();
 		return -1;
 	}
 
-	BusInstanceIterator iterator(MODULE_NAME, cli, cli.type);
+	BusInstanceIterator iterator(name, cli, type);
 
 	if (!strcmp(verb, "start")) {
 		return ThisDriver::module_start(cli, iterator);

--- a/src/drivers/imu/fxas21002c/FXAS21002C.cpp
+++ b/src/drivers/imu/fxas21002c/FXAS21002C.cpp
@@ -65,11 +65,10 @@ static constexpr uint8_t _checked_registers[] {
 
 using namespace time_literals;
 
-FXAS21002C::FXAS21002C(device::Device *interface, I2CSPIBusOption bus_option, int bus, enum Rotation rotation,
-		       int i2c_address) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus, i2c_address),
+FXAS21002C::FXAS21002C(device::Device *interface, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
 	_interface(interface),
-	_px4_gyro(_interface->get_device_id(), rotation),
+	_px4_gyro(_interface->get_device_id(), config.rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_errors(perf_alloc(PC_COUNT, MODULE_NAME": err")),
 	_bad_registers(perf_alloc(PC_COUNT, MODULE_NAME": bad register")),

--- a/src/drivers/imu/fxas21002c/FXAS21002C.hpp
+++ b/src/drivers/imu/fxas21002c/FXAS21002C.hpp
@@ -191,11 +191,10 @@ struct RawGyroReport {
 class FXAS21002C : public I2CSPIDriver<FXAS21002C>
 {
 public:
-	FXAS21002C(device::Device *interface, I2CSPIBusOption bus_option, int bus, enum Rotation rotation, int i2c_address);
+	FXAS21002C(device::Device *interface, const I2CSPIDriverConfig &config);
 	virtual ~FXAS21002C();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int		init();

--- a/src/drivers/imu/fxas21002c/fxas21002c_main.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c_main.cpp
@@ -50,16 +50,15 @@ FXAS21002C::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *FXAS21002C::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
+I2CSPIDriverBase *FXAS21002C::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = FXAS21002C_I2C_interface(iterator.bus(), cli.bus_frequency, cli.i2c_address);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = FXAS21002C_I2C_interface(config.bus, config.bus_frequency, config.i2c_address);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = FXAS21002C_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = FXAS21002C_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -67,8 +66,7 @@ I2CSPIDriverBase *FXAS21002C::instantiate(const BusCLIArguments &cli, const BusI
 		return nullptr;
 	}
 
-	FXAS21002C *dev = new FXAS21002C(interface, iterator.configuredBusOption(), iterator.bus(), cli.rotation,
-					 cli.i2c_address);
+	FXAS21002C *dev = new FXAS21002C(interface, config);
 
 	if (dev == nullptr) {
 		delete interface;

--- a/src/drivers/imu/fxos8701cq/FXOS8701CQ.cpp
+++ b/src/drivers/imu/fxos8701cq/FXOS8701CQ.cpp
@@ -53,13 +53,12 @@ const uint8_t FXOS8701CQ::_checked_registers[FXOS8701C_NUM_CHECKED_REGISTERS] = 
 	FXOS8701CQ_M_CTRL_REG2,
 };
 
-FXOS8701CQ::FXOS8701CQ(device::Device *interface, I2CSPIBusOption bus_option, int bus, enum Rotation rotation,
-		       int i2c_address) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus, i2c_address),
+FXOS8701CQ::FXOS8701CQ(device::Device *interface, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
 	_interface(interface),
-	_px4_accel(interface->get_device_id(), rotation),
+	_px4_accel(interface->get_device_id(), config.rotation),
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
-	_px4_mag(interface->get_device_id(), rotation),
+	_px4_mag(interface->get_device_id(), config.rotation),
 	_mag_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": mag read")),
 #endif
 	_accel_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": acc read")),

--- a/src/drivers/imu/fxos8701cq/FXOS8701CQ.hpp
+++ b/src/drivers/imu/fxos8701cq/FXOS8701CQ.hpp
@@ -138,11 +138,10 @@ extern device::Device *FXOS8701CQ_I2C_interface(int bus, int bus_frequency, int 
 class FXOS8701CQ : public I2CSPIDriver<FXOS8701CQ>
 {
 public:
-	FXOS8701CQ(device::Device *interface, I2CSPIBusOption bus_option, int bus, enum Rotation rotation, int i2c_address);
+	FXOS8701CQ(device::Device *interface, const I2CSPIDriverConfig &config);
 	virtual ~FXOS8701CQ();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	int		init();

--- a/src/drivers/imu/fxos8701cq/fxos8701cq_main.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq_main.cpp
@@ -56,16 +56,15 @@ FXOS8701CQ::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *FXOS8701CQ::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
+I2CSPIDriverBase *FXOS8701CQ::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = FXOS8701CQ_I2C_interface(iterator.bus(), cli.bus_frequency, cli.i2c_address);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = FXOS8701CQ_I2C_interface(config.bus, config.bus_frequency, config.i2c_address);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = FXOS8701CQ_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = FXOS8701CQ_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -73,8 +72,7 @@ I2CSPIDriverBase *FXOS8701CQ::instantiate(const BusCLIArguments &cli, const BusI
 		return nullptr;
 	}
 
-	FXOS8701CQ *dev = new FXOS8701CQ(interface, iterator.configuredBusOption(), iterator.bus(), cli.rotation,
-					 cli.i2c_address);
+	FXOS8701CQ *dev = new FXOS8701CQ(interface, config);
 
 	if (dev == nullptr) {
 		delete interface;

--- a/src/drivers/imu/invensense/icm20602/ICM20602.cpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM20602::ICM20602(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		   spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM20602, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ICM20602::ICM20602(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm20602/ICM20602.hpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM20602;
 class ICM20602 : public device::SPI, public I2CSPIDriver<ICM20602>
 {
 public:
-	ICM20602(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM20602(const I2CSPIDriverConfig &config);
 	~ICM20602() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm20602/icm20602_main.cpp
+++ b/src/drivers/imu/invensense/icm20602/icm20602_main.cpp
@@ -46,25 +46,6 @@ void ICM20602::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM20602::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					int runtime_instance)
-{
-	ICM20602 *instance = new ICM20602(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					  cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm20602_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm20608g/ICM20608G.cpp
+++ b/src/drivers/imu/invensense/icm20608g/ICM20608G.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM20608G::ICM20608G(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM20608G, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ICM20608G::ICM20608G(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
+++ b/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM20608G;
 class ICM20608G : public device::SPI, public I2CSPIDriver<ICM20608G>
 {
 public:
-	ICM20608G(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM20608G(const I2CSPIDriverConfig &config);
 	~ICM20608G() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm20608g/icm20608g_main.cpp
+++ b/src/drivers/imu/invensense/icm20608g/icm20608g_main.cpp
@@ -46,25 +46,6 @@ void ICM20608G::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM20608G::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ICM20608G *instance = new ICM20608G(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm20608g_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm20649/ICM20649.cpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM20649::ICM20649(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		   spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM20649, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ICM20649::ICM20649(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm20649/ICM20649.hpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM20649;
 class ICM20649 : public device::SPI, public I2CSPIDriver<ICM20649>
 {
 public:
-	ICM20649(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM20649(const I2CSPIDriverConfig &config);
 	~ICM20649() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm20649/icm20649_main.cpp
+++ b/src/drivers/imu/invensense/icm20649/icm20649_main.cpp
@@ -46,25 +46,6 @@ void ICM20649::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM20649::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					int runtime_instance)
-{
-	ICM20649 *instance = new ICM20649(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					  cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm20649_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm20689/ICM20689.cpp
+++ b/src/drivers/imu/invensense/icm20689/ICM20689.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM20689::ICM20689(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		   spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM20689, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ICM20689::ICM20689(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm20689/ICM20689.hpp
+++ b/src/drivers/imu/invensense/icm20689/ICM20689.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM20689;
 class ICM20689 : public device::SPI, public I2CSPIDriver<ICM20689>
 {
 public:
-	ICM20689(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM20689(const I2CSPIDriverConfig &config);
 	~ICM20689() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm20689/icm20689_main.cpp
+++ b/src/drivers/imu/invensense/icm20689/icm20689_main.cpp
@@ -46,25 +46,6 @@ void ICM20689::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM20689::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					int runtime_instance)
-{
-	ICM20689 *instance = new ICM20689(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					  cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm20689_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm20948/ICM20948.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.hpp
@@ -58,12 +58,9 @@ using namespace InvenSense_ICM20948;
 class ICM20948 : public device::SPI, public I2CSPIDriver<ICM20948>
 {
 public:
-	ICM20948(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio, bool enable_magnetometer = false);
+	ICM20948(const I2CSPIDriverConfig &config);
 	~ICM20948() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.cpp
@@ -40,10 +40,9 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM20948_I2C_Passthrough::ICM20948_I2C_Passthrough(I2CSPIBusOption bus_option, int bus, int bus_frequency,
-		const int address) :
-	I2C(DRV_IMU_DEVTYPE_ICM20948, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+ICM20948_I2C_Passthrough::ICM20948_I2C_Passthrough(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config)
 {
 }
 

--- a/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948_I2C_Passthrough.hpp
@@ -53,11 +53,9 @@ using namespace InvenSense_ICM20948;
 class ICM20948_I2C_Passthrough : public device::I2C, public I2CSPIDriver<ICM20948_I2C_Passthrough>
 {
 public:
-	ICM20948_I2C_Passthrough(I2CSPIBusOption bus_option, int bus, int bus_frequency, const int address);
+	ICM20948_I2C_Passthrough(const I2CSPIDriverConfig &config);
 	~ICM20948_I2C_Passthrough() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm20948/icm20948_i2c_passthrough_main.cpp
+++ b/src/drivers/imu/invensense/icm20948/icm20948_i2c_passthrough_main.cpp
@@ -46,25 +46,6 @@ void ICM20948_I2C_Passthrough::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM20948_I2C_Passthrough::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ICM20948_I2C_Passthrough *instance = new ICM20948_I2C_Passthrough(iterator.configuredBusOption(), iterator.bus(),
-			cli.bus_frequency, cli.i2c_address);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm20948_i2c_passthrough_main(int argc, char *argv[])
 {
 	using ThisDriver = ICM20948_I2C_Passthrough;

--- a/src/drivers/imu/invensense/icm20948/icm20948_main.cpp
+++ b/src/drivers/imu/invensense/icm20948/icm20948_main.cpp
@@ -47,26 +47,6 @@ void ICM20948::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM20948::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					int runtime_instance)
-{
-	bool mag = (cli.custom1 == 1);
-	ICM20948 *instance = new ICM20948(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					  cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO(), mag);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm20948_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.cpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM40609D::ICM40609D(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM40609D, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
+ICM40609D::ICM40609D(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
 	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM40609D;
 class ICM40609D : public device::SPI, public I2CSPIDriver<ICM40609D>
 {
 public:
-	ICM40609D(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM40609D(const I2CSPIDriverConfig &config);
 	~ICM40609D() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm40609d/icm40609d_main.cpp
+++ b/src/drivers/imu/invensense/icm40609d/icm40609d_main.cpp
@@ -46,25 +46,6 @@ void ICM40609D::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM40609D::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ICM40609D *instance = new ICM40609D(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm40609d_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm42605/ICM42605.cpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM42605::ICM42605(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		   spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM42605, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ICM42605::ICM42605(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm42605/ICM42605.hpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM42605;
 class ICM42605 : public device::SPI, public I2CSPIDriver<ICM42605>
 {
 public:
-	ICM42605(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM42605(const I2CSPIDriverConfig &config);
 	~ICM42605() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm42605/icm42605_main.cpp
+++ b/src/drivers/imu/invensense/icm42605/icm42605_main.cpp
@@ -46,25 +46,6 @@ void ICM42605::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM42605::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					int runtime_instance)
-{
-	ICM42605 *instance = new ICM42605(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					  cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm42605_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-ICM42688P::ICM42688P(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		     spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_ICM42688P, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+ICM42688P::ICM42688P(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_ICM42688P;
 class ICM42688P : public device::SPI, public I2CSPIDriver<ICM42688P>
 {
 public:
-	ICM42688P(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		  spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	ICM42688P(const I2CSPIDriverConfig &config);
 	~ICM42688P() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
+++ b/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
@@ -46,25 +46,6 @@ void ICM42688P::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *ICM42688P::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	ICM42688P *instance = new ICM42688P(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int icm42688p_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-MPU6000::MPU6000(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_MPU6000, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+MPU6000::MPU6000(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_MPU6000;
 class MPU6000 : public device::SPI, public I2CSPIDriver<MPU6000>
 {
 public:
-	MPU6000(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	MPU6000(const I2CSPIDriverConfig &config);
 	~MPU6000() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/mpu6000/mpu6000_main.cpp
+++ b/src/drivers/imu/invensense/mpu6000/mpu6000_main.cpp
@@ -46,25 +46,6 @@ void MPU6000::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *MPU6000::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	MPU6000 *instance = new MPU6000(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int mpu6000_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.cpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-MPU6500::MPU6500(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio) :
-	SPI(DRV_IMU_DEVTYPE_MPU6500, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+MPU6500::MPU6500(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (config.drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_MPU6500;
 class MPU6500 : public device::SPI, public I2CSPIDriver<MPU6500>
 {
 public:
-	MPU6500(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio);
+	MPU6500(const I2CSPIDriverConfig &config);
 	~MPU6500() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/mpu6500/mpu6500_main.cpp
+++ b/src/drivers/imu/invensense/mpu6500/mpu6500_main.cpp
@@ -46,25 +46,6 @@ void MPU6500::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *MPU6500::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	MPU6500 *instance = new MPU6500(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int mpu6500_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.cpp
@@ -42,22 +42,23 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-MPU9250::MPU9250(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio, bool enable_magnetometer) :
-	SPI(DRV_IMU_DEVTYPE_MPU9250, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+MPU9250::MPU9250(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 
 	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
 
+	bool enable_magnetometer = config.custom1 == 1;
+
 	if (enable_magnetometer) {
-		_slave_ak8963_magnetometer = new AKM_AK8963::MPU9250_AK8963(*this, rotation);
+		_slave_ak8963_magnetometer = new AKM_AK8963::MPU9250_AK8963(*this, config.rotation);
 
 		if (_slave_ak8963_magnetometer) {
 			for (auto &r : _register_cfg) {

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
@@ -58,12 +58,9 @@ using namespace InvenSense_MPU9250;
 class MPU9250 : public device::SPI, public I2CSPIDriver<MPU9250>
 {
 public:
-	MPU9250(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		spi_mode_e spi_mode, spi_drdy_gpio_t drdy_gpio, bool enable_magnetometer = false);
+	MPU9250(const I2CSPIDriverConfig &config);
 	~MPU9250() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.cpp
@@ -40,15 +40,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-MPU9250_I2C::MPU9250_I2C(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-			 int bus_frequency, int address, spi_drdy_gpio_t drdy_gpio) :
-	I2C(DRV_IMU_DEVTYPE_MPU9250, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+MPU9250_I2C::MPU9250_I2C(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
-	if (drdy_gpio != 0) {
+	if (_drdy_gpio != 0) {
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME": DRDY missed");
 	}
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.hpp
@@ -56,12 +56,9 @@ using namespace InvenSense_MPU9250;
 class MPU9250_I2C : public device::I2C, public I2CSPIDriver<MPU9250_I2C>
 {
 public:
-	MPU9250_I2C(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		    int address, spi_drdy_gpio_t drdy_gpio);
+	MPU9250_I2C(const I2CSPIDriverConfig &config);
 	~MPU9250_I2C() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/invensense/mpu9250/mpu9250_i2c_main.cpp
+++ b/src/drivers/imu/invensense/mpu9250/mpu9250_i2c_main.cpp
@@ -47,25 +47,6 @@ void MPU9250_I2C::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *MPU9250_I2C::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	MPU9250_I2C *instance = new MPU9250_I2C(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-						cli.bus_frequency, cli.i2c_address, iterator.DRDYGPIO());
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int mpu9250_i2c_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/invensense/mpu9250/mpu9250_main.cpp
+++ b/src/drivers/imu/invensense/mpu9250/mpu9250_main.cpp
@@ -47,26 +47,6 @@ void MPU9250::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *MPU9250::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	bool mag = (cli.custom1 == 1);
-	MPU9250 *instance = new MPU9250(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					cli.bus_frequency, cli.spi_mode, iterator.DRDYGPIO(), mag);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int mpu9250_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/l3gd20/L3GD20.cpp
+++ b/src/drivers/imu/l3gd20/L3GD20.cpp
@@ -35,11 +35,10 @@
 
 constexpr uint8_t L3GD20::_checked_registers[];
 
-L3GD20::L3GD20(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-	       spi_mode_e spi_mode) :
-	SPI(DRV_GYR_DEVTYPE_L3GD20, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_gyro(get_device_id(), rotation),
+L3GD20::L3GD20(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_gyro(get_device_id(), config.rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_errors(perf_alloc(PC_COUNT, MODULE_NAME": err")),
 	_bad_registers(perf_alloc(PC_COUNT, MODULE_NAME": bad_reg")),

--- a/src/drivers/imu/l3gd20/L3GD20.hpp
+++ b/src/drivers/imu/l3gd20/L3GD20.hpp
@@ -161,12 +161,9 @@
 class L3GD20 : public device::SPI, public I2CSPIDriver<L3GD20>
 {
 public:
-	L3GD20(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-	       spi_mode_e spi_mode);
+	L3GD20(const I2CSPIDriverConfig &config);
 	~L3GD20() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/l3gd20/l3gd20_main.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20_main.cpp
@@ -49,25 +49,6 @@ L3GD20::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *L3GD20::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	L3GD20 *instance = new L3GD20(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-				      cli.bus_frequency, cli.spi_mode);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void L3GD20::custom_method(const BusCLIArguments &cli)
 {
 	switch (cli.custom1) {

--- a/src/drivers/imu/lsm303d/LSM303D.cpp
+++ b/src/drivers/imu/lsm303d/LSM303D.cpp
@@ -53,12 +53,11 @@ static constexpr uint8_t _checked_registers[] = {
 	ADDR_CTRL_REG7
 };
 
-LSM303D::LSM303D(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode) :
-	SPI(DRV_IMU_DEVTYPE_LSM303D, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_accel(get_device_id(), rotation),
-	_px4_mag(get_device_id(), rotation),
+LSM303D::LSM303D(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_mag(get_device_id(), config.rotation),
 	_accel_sample_perf(perf_alloc(PC_ELAPSED, "lsm303d: acc_read")),
 	_mag_sample_perf(perf_alloc(PC_ELAPSED, "lsm303d: mag_read")),
 	_bad_registers(perf_alloc(PC_COUNT, "lsm303d: bad_reg")),

--- a/src/drivers/imu/lsm303d/LSM303D.hpp
+++ b/src/drivers/imu/lsm303d/LSM303D.hpp
@@ -141,12 +141,9 @@
 class LSM303D : public device::SPI, public I2CSPIDriver<LSM303D>
 {
 public:
-	LSM303D(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		spi_mode_e spi_mode);
+	LSM303D(const I2CSPIDriverConfig &config);
 	~LSM303D() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/lsm303d/lsm303d_main.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d_main.cpp
@@ -52,25 +52,6 @@ LSM303D::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *LSM303D::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	LSM303D *instance = new LSM303D(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					cli.bus_frequency, cli.spi_mode);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int lsm303d_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/imu/st/lsm9ds1/LSM9DS1.cpp
+++ b/src/drivers/imu/st/lsm9ds1/LSM9DS1.cpp
@@ -40,12 +40,11 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-LSM9DS1::LSM9DS1(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		 spi_mode_e spi_mode) :
-	SPI(DRV_IMU_DEVTYPE_ST_LSM9DS1_AG, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_accel(get_device_id(), rotation),
-	_px4_gyro(get_device_id(), rotation)
+LSM9DS1::LSM9DS1(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_accel(get_device_id(), config.rotation),
+	_px4_gyro(get_device_id(), config.rotation)
 {
 	ConfigureSampleRate(_px4_gyro.get_max_rate_hz());
 }

--- a/src/drivers/imu/st/lsm9ds1/LSM9DS1.hpp
+++ b/src/drivers/imu/st/lsm9ds1/LSM9DS1.hpp
@@ -55,12 +55,9 @@ using namespace ST_LSM9DS1;
 class LSM9DS1 : public device::SPI, public I2CSPIDriver<LSM9DS1>
 {
 public:
-	LSM9DS1(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		spi_mode_e spi_mode);
+	LSM9DS1(const I2CSPIDriverConfig &config);
 	~LSM9DS1() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/imu/st/lsm9ds1/lsm9ds1_main.cpp
+++ b/src/drivers/imu/st/lsm9ds1/lsm9ds1_main.cpp
@@ -46,25 +46,6 @@ void LSM9DS1::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *LSM9DS1::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	LSM9DS1 *instance = new LSM9DS1(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					cli.bus_frequency, cli.spi_mode);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int lsm9ds1_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/irlock/irlock.cpp
+++ b/src/drivers/irlock/irlock.cpp
@@ -92,11 +92,9 @@ struct irlock_s {
 class IRLOCK : public device::I2C, public I2CSPIDriver<IRLOCK>
 {
 public:
-	IRLOCK(I2CSPIBusOption bus_option, const int bus, int bus_frequency, const int address);
+	IRLOCK(const I2CSPIDriverConfig &config);
 	~IRLOCK() override = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int init() override;
@@ -119,9 +117,9 @@ private:
 	uORB::Publication<irlock_report_s> _irlock_report_topic{ORB_ID(irlock_report)};
 };
 
-IRLOCK::IRLOCK(I2CSPIBusOption bus_option, const int bus, int bus_frequency, const int address) :
-	I2C(DRV_SENS_DEVTYPE_IRLOCK, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+IRLOCK::IRLOCK(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config)
 {
 }
 
@@ -270,24 +268,6 @@ void IRLOCK::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
 	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x54);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *IRLOCK::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	IRLOCK *instance = new IRLOCK(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.i2c_address);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
 }
 
 extern "C" __EXPORT int irlock_main(int argc, char *argv[])

--- a/src/drivers/lights/rgbled/rgbled.cpp
+++ b/src/drivers/lights/rgbled/rgbled.cpp
@@ -68,11 +68,9 @@ using namespace time_literals;
 class RGBLED : public device::I2C, public I2CSPIDriver<RGBLED>
 {
 public:
-	RGBLED(I2CSPIBusOption bus_option, const int bus, int bus_frequency, const int address);
+	RGBLED(const I2CSPIDriverConfig &config);
 	virtual ~RGBLED() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int		init() override;
@@ -102,9 +100,9 @@ private:
 	void			update_params();
 };
 
-RGBLED::RGBLED(I2CSPIBusOption bus_option, const int bus, int bus_frequency, const int address) :
-	I2C(DRV_LED_DEVTYPE_RGBLED, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+RGBLED::RGBLED(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config)
 {
 }
 
@@ -332,24 +330,6 @@ RGBLED::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
 	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x55);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *RGBLED::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	RGBLED *instance = new RGBLED(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.i2c_address);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
 }
 
 extern "C" __EXPORT int rgbled_main(int argc, char *argv[])

--- a/src/drivers/lights/rgbled_ncp5623c/rgbled_ncp5623c.cpp
+++ b/src/drivers/lights/rgbled_ncp5623c/rgbled_ncp5623c.cpp
@@ -66,11 +66,9 @@ using namespace time_literals;
 class RGBLED_NCP5623C : public device::I2C, public I2CSPIDriver<RGBLED_NCP5623C>
 {
 public:
-	RGBLED_NCP5623C(I2CSPIBusOption bus_option, const int bus, int bus_frequency, const int address);
+	RGBLED_NCP5623C(const I2CSPIDriverConfig &config);
 	virtual ~RGBLED_NCP5623C() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int		init() override;
@@ -100,9 +98,9 @@ private:
 	int			write(uint8_t reg, uint8_t data);
 };
 
-RGBLED_NCP5623C::RGBLED_NCP5623C(I2CSPIBusOption bus_option, const int bus, int bus_frequency, const int address) :
-	I2C(DRV_LED_DEVTYPE_RGBLED_NCP5623C, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+RGBLED_NCP5623C::RGBLED_NCP5623C(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config)
 {
 }
 
@@ -247,25 +245,6 @@ RGBLED_NCP5623C::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
 	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x39);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *RGBLED_NCP5623C::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	RGBLED_NCP5623C *instance = new RGBLED_NCP5623C(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency,
-			cli.i2c_address);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
 }
 
 extern "C" __EXPORT int rgbled_ncp5623c_main(int argc, char *argv[])

--- a/src/drivers/magnetometer/akm/ak09916/AK09916.cpp
+++ b/src/drivers/magnetometer/akm/ak09916/AK09916.cpp
@@ -40,10 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-AK09916::AK09916(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_AK09916, MODULE_NAME, bus, I2C_ADDRESS_DEFAULT, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+AK09916::AK09916(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/akm/ak09916/AK09916.hpp
+++ b/src/drivers/magnetometer/akm/ak09916/AK09916.hpp
@@ -53,11 +53,9 @@ using namespace AKM_AK09916;
 class AK09916 : public device::I2C, public I2CSPIDriver<AK09916>
 {
 public:
-	AK09916(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	AK09916(const I2CSPIDriverConfig &config);
 	~AK09916() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/akm/ak09916/ak09916_main.cpp
+++ b/src/drivers/magnetometer/akm/ak09916/ak09916_main.cpp
@@ -36,31 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *AK09916::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	AK09916 *instance = new AK09916(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void AK09916::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("ak09916", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0c);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -71,6 +53,7 @@ extern "C" __EXPORT int ak09916_main(int argc, char *argv[])
 	using ThisDriver = AK09916;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
+	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {

--- a/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
+++ b/src/drivers/magnetometer/akm/ak8963/AK8963.cpp
@@ -40,10 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-AK8963::AK8963(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_AK8963, MODULE_NAME, bus, I2C_ADDRESS_DEFAULT, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+AK8963::AK8963(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/akm/ak8963/AK8963.hpp
+++ b/src/drivers/magnetometer/akm/ak8963/AK8963.hpp
@@ -53,11 +53,9 @@ using namespace AKM_AK8963;
 class AK8963 : public device::I2C, public I2CSPIDriver<AK8963>
 {
 public:
-	AK8963(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	AK8963(const I2CSPIDriverConfig &config);
 	~AK8963() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/akm/ak8963/ak8963_main.cpp
+++ b/src/drivers/magnetometer/akm/ak8963/ak8963_main.cpp
@@ -36,31 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *AK8963::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	AK8963 *instance = new AK8963(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void AK8963::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("ak8963", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0c);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -71,6 +53,7 @@ extern "C" __EXPORT int ak8963_main(int argc, char *argv[])
 	using ThisDriver = AK8963;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
+	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {

--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
@@ -35,10 +35,10 @@
 
 using namespace time_literals;
 
-BMM150::BMM150(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_BMM150, MODULE_NAME, bus, I2C_ADDRESS_DEFAULT, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+BMM150::BMM150(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.hpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.hpp
@@ -53,11 +53,9 @@ using namespace Bosch_BMM150;
 class BMM150 : public device::I2C, public I2CSPIDriver<BMM150>
 {
 public:
-	BMM150(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	BMM150(const I2CSPIDriverConfig &config);
 	~BMM150() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/bosch/bmm150/bmm150_main.cpp
+++ b/src/drivers/magnetometer/bosch/bmm150/bmm150_main.cpp
@@ -36,31 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *BMM150::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-{
-	BMM150 *instance = new BMM150(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void BMM150::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("bmm150", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x10);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -71,6 +53,7 @@ extern "C" int bmm150_main(int argc, char *argv[])
 	using ThisDriver = BMM150;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
+	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {

--- a/src/drivers/magnetometer/hmc5883/HMC5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/HMC5883.cpp
@@ -33,9 +33,9 @@
 
 #include "HMC5883.hpp"
 
-HMC5883::HMC5883(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus),
-	_px4_mag(interface->get_device_id(), rotation),
+HMC5883::HMC5883(device::Device *interface, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
+	_px4_mag(interface->get_device_id(), config.rotation),
 	_interface(interface),
 	_range_ga(1.9f),
 	_collect_phase(false),

--- a/src/drivers/magnetometer/hmc5883/HMC5883.hpp
+++ b/src/drivers/magnetometer/hmc5883/HMC5883.hpp
@@ -86,11 +86,10 @@
 class HMC5883 : public I2CSPIDriver<HMC5883>
 {
 public:
-	HMC5883(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus);
+	HMC5883(device::Device *interface, const I2CSPIDriverConfig &config);
 	virtual ~HMC5883();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	void			RunImpl();

--- a/src/drivers/magnetometer/hmc5883/hmc5883.h
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.h
@@ -42,6 +42,8 @@
 #include <drivers/device/Device.hpp>
 #include <drivers/device/spi.h>
 
+#define HMC5883L_ADDRESS		0x1E
+
 #define ADDR_ID_A			0x0a
 #define ADDR_ID_B			0x0b
 #define ADDR_ID_C			0x0c

--- a/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
@@ -42,8 +42,6 @@
 
 #include "hmc5883.h"
 
-#define HMC5883L_ADDRESS		0x1E
-
 device::Device *HMC5883_I2C_interface(int bus, int bus_frequency);
 
 class HMC5883_I2C : public device::I2C

--- a/src/drivers/magnetometer/hmc5883/hmc5883_main.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_main.cpp
@@ -45,16 +45,15 @@
 
 extern "C" __EXPORT int hmc5883_main(int argc, char *argv[]);
 
-I2CSPIDriverBase *HMC5883::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
+I2CSPIDriverBase *HMC5883::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = HMC5883_I2C_interface(iterator.bus(), cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = HMC5883_I2C_interface(config.bus, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = HMC5883_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = HMC5883_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -64,11 +63,11 @@ I2CSPIDriverBase *HMC5883::instantiate(const BusCLIArguments &cli, const BusInst
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%x)", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	HMC5883 *dev = new HMC5883(interface, cli.rotation, iterator.configuredBusOption(), iterator.bus());
+	HMC5883 *dev = new HMC5883(interface, config);
 
 	if (dev == nullptr) {
 		delete interface;
@@ -80,7 +79,7 @@ I2CSPIDriverBase *HMC5883::instantiate(const BusCLIArguments &cli, const BusInst
 		return nullptr;
 	}
 
-	bool enable_temp_compensation = cli.custom1 == 1;
+	bool enable_temp_compensation = config.custom1 == 1;
 
 	if (enable_temp_compensation) {
 		dev->set_temperature_compensation(1);
@@ -126,6 +125,8 @@ extern "C" int hmc5883_main(int argc, char *argv[])
 		ThisDriver::print_usage();
 		return -1;
 	}
+
+	cli.i2c_address = HMC5883L_ADDRESS;
 
 	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_HMC5883);
 

--- a/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
@@ -40,10 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-IST8308::IST8308(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_IST8308, MODULE_NAME, bus, I2C_ADDRESS_DEFAULT, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+IST8308::IST8308(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/isentek/ist8308/IST8308.hpp
+++ b/src/drivers/magnetometer/isentek/ist8308/IST8308.hpp
@@ -53,11 +53,9 @@ using namespace iSentek_IST8308;
 class IST8308 : public device::I2C, public I2CSPIDriver<IST8308>
 {
 public:
-	IST8308(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	IST8308(const I2CSPIDriverConfig &config);
 	~IST8308() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/isentek/ist8308/ist8308_main.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/ist8308_main.cpp
@@ -36,31 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *IST8308::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	IST8308 *instance = new IST8308(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void IST8308::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("ist8308", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0c);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -71,6 +53,7 @@ extern "C" int ist8308_main(int argc, char *argv[])
 	using ThisDriver = IST8308;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
+	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -40,10 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-IST8310::IST8310(I2CSPIBusOption bus_option, int bus, uint8_t addr, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_IST8310, MODULE_NAME, bus, addr, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, addr),
-	_px4_mag(get_device_id(), rotation)
+IST8310::IST8310(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.hpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.hpp
@@ -53,11 +53,9 @@ using namespace iSentek_IST8310;
 class IST8310 : public device::I2C, public I2CSPIDriver<IST8310>
 {
 public:
-	IST8310(I2CSPIBusOption bus_option, int bus, uint8_t addr, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	IST8310(const I2CSPIDriverConfig &config);
 	~IST8310() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/isentek/ist8310/ist8310_main.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/ist8310_main.cpp
@@ -36,26 +36,6 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *IST8310::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	IST8310 *instance = new IST8310(iterator.configuredBusOption(), iterator.bus(), cli.i2c_address, cli.bus_frequency,
-					cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void IST8310::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("ist8310", "driver");

--- a/src/drivers/magnetometer/lis2mdl/lis2mdl.cpp
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl.cpp
@@ -42,9 +42,9 @@
 #include <px4_platform_common/time.h>
 #include "lis2mdl.h"
 
-LIS2MDL::LIS2MDL(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus),
-	_px4_mag(interface->get_device_id(), rotation),
+LIS2MDL::LIS2MDL(device::Device *interface, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
+	_px4_mag(interface->get_device_id(), config.rotation),
 	_interface(interface),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms_errors")),
 	_conf_errors(perf_alloc(PC_COUNT, MODULE_NAME": conf_errors")),

--- a/src/drivers/magnetometer/lis2mdl/lis2mdl.h
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl.h
@@ -83,15 +83,15 @@
 extern device::Device *LIS2MDL_SPI_interface(int bus, uint32_t devid, int bus_frequency, spi_mode_e spi_mode);
 extern device::Device *LIS2MDL_I2C_interface(int bus, int bus_frequency);
 
+#define LIS2MDLL_ADDRESS        0x1e
 
 class LIS2MDL : public I2CSPIDriver<LIS2MDL>
 {
 public:
-	LIS2MDL(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus);
+	LIS2MDL(device::Device *interface, const I2CSPIDriverConfig &config);
 	virtual ~LIS2MDL();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	virtual int init();

--- a/src/drivers/magnetometer/lis2mdl/lis2mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl_i2c.cpp
@@ -53,8 +53,6 @@
 #include "board_config.h"
 #include "lis2mdl.h"
 
-#define LIS2MDLL_ADDRESS        0x1e
-
 class LIS2MDL_I2C : public device::I2C
 {
 public:

--- a/src/drivers/magnetometer/lis2mdl/lis2mdl_main.cpp
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl_main.cpp
@@ -41,16 +41,15 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *LIS2MDL::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
+I2CSPIDriverBase *LIS2MDL::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = LIS2MDL_I2C_interface(iterator.bus(), cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = LIS2MDL_I2C_interface(config.bus, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = LIS2MDL_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = LIS2MDL_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -60,11 +59,11 @@ I2CSPIDriverBase *LIS2MDL::instantiate(const BusCLIArguments &cli, const BusInst
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%x)", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	LIS2MDL *dev = new LIS2MDL(interface, cli.rotation, iterator.configuredBusOption(), iterator.bus());
+	LIS2MDL *dev = new LIS2MDL(interface, config);
 
 	if (dev == nullptr) {
 		delete interface;
@@ -85,6 +84,7 @@ void LIS2MDL::print_usage()
 	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, true);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x1e);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -111,6 +111,8 @@ extern "C" int lis2mdl_main(int argc, char *argv[])
 		ThisDriver::print_usage();
 		return -1;
 	}
+
+	cli.i2c_address = LIS2MDLL_ADDRESS;
 
 	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_LIS2MDL);
 

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
@@ -42,9 +42,9 @@
 #include <px4_platform_common/time.h>
 #include "lis3mdl.h"
 
-LIS3MDL::LIS3MDL(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus),
-	_px4_mag(interface->get_device_id(), rotation),
+LIS3MDL::LIS3MDL(device::Device *interface, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
+	_px4_mag(interface->get_device_id(), config.rotation),
 	_interface(interface),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms_errors")),
 	_conf_errors(perf_alloc(PC_COUNT, MODULE_NAME": conf_errors")),

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.h
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.h
@@ -92,14 +92,16 @@ enum OPERATING_MODE {
 	SINGLE
 };
 
+#define LIS3MDLL_ADDRESS        0x1e
+
+
 class LIS3MDL : public I2CSPIDriver<LIS3MDL>
 {
 public:
-	LIS3MDL(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus);
+	LIS3MDL(device::Device *interface, const I2CSPIDriverConfig &config);
 	virtual ~LIS3MDL();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	void custom_method(const BusCLIArguments &cli) override;

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
@@ -53,8 +53,6 @@
 #include "board_config.h"
 #include "lis3mdl.h"
 
-#define LIS3MDLL_ADDRESS        0x1e
-
 class LIS3MDL_I2C : public device::I2C
 {
 public:

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
@@ -41,16 +41,15 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *LIS3MDL::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
+I2CSPIDriverBase *LIS3MDL::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = LIS3MDL_I2C_interface(iterator.bus(), cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = LIS3MDL_I2C_interface(config.bus, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = LIS3MDL_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = LIS3MDL_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -60,11 +59,11 @@ I2CSPIDriverBase *LIS3MDL::instantiate(const BusCLIArguments &cli, const BusInst
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%x)", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	LIS3MDL *dev = new LIS3MDL(interface, cli.rotation, iterator.configuredBusOption(), iterator.bus());
+	LIS3MDL *dev = new LIS3MDL(interface, config);
 
 	if (dev == nullptr) {
 		delete interface;
@@ -118,6 +117,8 @@ extern "C" int lis3mdl_main(int argc, char *argv[])
 		ThisDriver::print_usage();
 		return -1;
 	}
+
+	cli.i2c_address = LIS3MDLL_ADDRESS;
 
 	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_LIS3MDL);
 

--- a/src/drivers/magnetometer/lsm303agr/LSM303AGR.cpp
+++ b/src/drivers/magnetometer/lsm303agr/LSM303AGR.cpp
@@ -61,11 +61,10 @@ static constexpr uint8_t LSM303AGR_WHO_AM_I_M = 0x40;
  */
 #define LSM303AGR_TIMER_REDUCTION				200
 
-LSM303AGR::LSM303AGR(I2CSPIBusOption bus_option, int bus, int device, enum Rotation rotation, int bus_frequency,
-		     spi_mode_e spi_mode) :
-	SPI(DRV_MAG_DEVTYPE_LSM303AGR, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation),
+LSM303AGR::LSM303AGR(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation),
 	_mag_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": mag_read")),
 	_bad_registers(perf_alloc(PC_COUNT, MODULE_NAME": bad_reg")),
 	_bad_values(perf_alloc(PC_COUNT, MODULE_NAME": bad_val"))

--- a/src/drivers/magnetometer/lsm303agr/LSM303AGR.hpp
+++ b/src/drivers/magnetometer/lsm303agr/LSM303AGR.hpp
@@ -85,12 +85,9 @@ static constexpr uint8_t OUTZ_H_REG_M = 0x6D;
 class LSM303AGR : public device::SPI, public I2CSPIDriver<LSM303AGR>
 {
 public:
-	LSM303AGR(I2CSPIBusOption bus_option, int bus, int device, enum Rotation rotation, int bus_frequency,
-		  spi_mode_e spi_mode);
+	LSM303AGR(const I2CSPIDriverConfig &config);
 	virtual ~LSM303AGR();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int		init() override;

--- a/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
+++ b/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
@@ -46,25 +46,6 @@ LSM303AGR::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *LSM303AGR::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	LSM303AGR *instance = new LSM303AGR(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					    cli.bus_frequency, cli.spi_mode);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" int lsm303agr_main(int argc, char *argv[])
 {
 	int ch;

--- a/src/drivers/magnetometer/lsm9ds1_mag/LSM9DS1_MAG.cpp
+++ b/src/drivers/magnetometer/lsm9ds1_mag/LSM9DS1_MAG.cpp
@@ -40,11 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-LSM9DS1_MAG::LSM9DS1_MAG(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation,
-			 int bus_frequency, spi_mode_e spi_mode) :
-	SPI(DRV_MAG_DEVTYPE_ST_LSM9DS1_M, MODULE_NAME, bus, device, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+LSM9DS1_MAG::LSM9DS1_MAG(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/lsm9ds1_mag/LSM9DS1_MAG.hpp
+++ b/src/drivers/magnetometer/lsm9ds1_mag/LSM9DS1_MAG.hpp
@@ -53,12 +53,9 @@ using namespace ST_LSM9DS1_MAG;
 class LSM9DS1_MAG : public device::SPI, public I2CSPIDriver<LSM9DS1_MAG>
 {
 public:
-	LSM9DS1_MAG(I2CSPIBusOption bus_option, int bus, uint32_t device, enum Rotation rotation, int bus_frequency,
-		    spi_mode_e spi_mode);
+	LSM9DS1_MAG(const I2CSPIDriverConfig &config);
 	~LSM9DS1_MAG() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/lsm9ds1_mag/lsm9ds1_mag_main.cpp
+++ b/src/drivers/magnetometer/lsm9ds1_mag/lsm9ds1_mag_main.cpp
@@ -36,26 +36,6 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *LSM9DS1_MAG::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-		int runtime_instance)
-{
-	LSM9DS1_MAG *instance = new LSM9DS1_MAG(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-						cli.bus_frequency, cli.spi_mode);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void LSM9DS1_MAG::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("lsm9ds1_mag", "driver");

--- a/src/drivers/magnetometer/qmc5883l/QMC5883L.cpp
+++ b/src/drivers/magnetometer/qmc5883l/QMC5883L.cpp
@@ -40,10 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-QMC5883L::QMC5883L(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_QMC5883L, MODULE_NAME, bus, I2C_ADDRESS_DEFAULT, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+QMC5883L::QMC5883L(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/qmc5883l/QMC5883L.hpp
+++ b/src/drivers/magnetometer/qmc5883l/QMC5883L.hpp
@@ -53,11 +53,9 @@ using namespace QST_QMC5883L;
 class QMC5883L : public device::I2C, public I2CSPIDriver<QMC5883L>
 {
 public:
-	QMC5883L(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	QMC5883L(const I2CSPIDriverConfig &config);
 	~QMC5883L() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/qmc5883l/qmc5883l_main.cpp
+++ b/src/drivers/magnetometer/qmc5883l/qmc5883l_main.cpp
@@ -36,31 +36,13 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *
-QMC5883L::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator, int runtime_instance)
-{
-	QMC5883L *instance = new QMC5883L(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void QMC5883L::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("qmc5883l", "driver");
 	PRINT_MODULE_USAGE_SUBCATEGORY("magnetometer");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x0d);
 	PRINT_MODULE_USAGE_PARAM_INT('R', 0, 0, 35, "Rotation", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
@@ -71,6 +53,7 @@ extern "C" int qmc5883l_main(int argc, char *argv[])
 	using ThisDriver = QMC5883L;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
+	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -41,9 +41,9 @@
 
 #include "rm3100.h"
 
-RM3100::RM3100(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus) :
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus),
-	_px4_mag(interface->get_device_id(), rotation),
+RM3100::RM3100(device::Device *interface, const I2CSPIDriverConfig &config) :
+	I2CSPIDriver(config),
+	_px4_mag(interface->get_device_id(), config.rotation),
 	_interface(interface),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms_errors")),
 	_conf_errors(perf_alloc(PC_COUNT, MODULE_NAME": conf_errors")),

--- a/src/drivers/magnetometer/rm3100/rm3100.h
+++ b/src/drivers/magnetometer/rm3100/rm3100.h
@@ -97,14 +97,15 @@ enum OPERATING_MODE {
 	SINGLE
 };
 
+#define RM3100_ADDRESS		0x20
+
 class RM3100 : public I2CSPIDriver<RM3100>
 {
 public:
-	RM3100(device::Device *interface, enum Rotation rotation, I2CSPIBusOption bus_option, int bus);
+	RM3100(device::Device *interface, const I2CSPIDriverConfig &config);
 	virtual ~RM3100();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	void custom_method(const BusCLIArguments &cli) override;

--- a/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
@@ -53,8 +53,6 @@
 #include "board_config.h"
 #include "rm3100.h"
 
-#define RM3100_ADDRESS		0x20
-
 class RM3100_I2C : public device::I2C
 {
 public:

--- a/src/drivers/magnetometer/rm3100/rm3100_main.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_main.cpp
@@ -41,16 +41,15 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-I2CSPIDriverBase *RM3100::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *RM3100::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
 	device::Device *interface = nullptr;
 
-	if (iterator.busType() == BOARD_I2C_BUS) {
-		interface = RM3100_I2C_interface(iterator.bus(), cli.bus_frequency);
+	if (config.bus_type == BOARD_I2C_BUS) {
+		interface = RM3100_I2C_interface(config.bus, config.bus_frequency);
 
-	} else if (iterator.busType() == BOARD_SPI_BUS) {
-		interface = RM3100_SPI_interface(iterator.bus(), iterator.devid(), cli.bus_frequency, cli.spi_mode);
+	} else if (config.bus_type == BOARD_SPI_BUS) {
+		interface = RM3100_SPI_interface(config.bus, config.spi_devid, config.bus_frequency, config.spi_mode);
 	}
 
 	if (interface == nullptr) {
@@ -60,11 +59,11 @@ I2CSPIDriverBase *RM3100::instantiate(const BusCLIArguments &cli, const BusInsta
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%x)", config.bus, config.spi_devid);
 		return nullptr;
 	}
 
-	RM3100 *dev = new RM3100(interface, cli.rotation, iterator.configuredBusOption(), iterator.bus());
+	RM3100 *dev = new RM3100(interface, config);
 
 	if (dev == nullptr) {
 		delete interface;
@@ -118,6 +117,8 @@ extern "C" int rm3100_main(int argc, char *argv[])
 		ThisDriver::print_usage();
 		return -1;
 	}
+
+	cli.i2c_address = RM3100_ADDRESS;
 
 	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_MAG_DEVTYPE_RM3100);
 

--- a/src/drivers/magnetometer/vtrantech/vcm1193l/VCM1193L.cpp
+++ b/src/drivers/magnetometer/vtrantech/vcm1193l/VCM1193L.cpp
@@ -40,10 +40,10 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-VCM1193L::VCM1193L(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation) :
-	I2C(DRV_MAG_DEVTYPE_VCM1193L, MODULE_NAME, bus, I2C_ADDRESS_DEFAULT, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_px4_mag(get_device_id(), rotation)
+VCM1193L::VCM1193L(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_px4_mag(get_device_id(), config.rotation)
 {
 	_px4_mag.set_external(external());
 }

--- a/src/drivers/magnetometer/vtrantech/vcm1193l/VCM1193L.hpp
+++ b/src/drivers/magnetometer/vtrantech/vcm1193l/VCM1193L.hpp
@@ -53,11 +53,9 @@ using namespace VTT_VCM1193L;
 class VCM1193L : public device::I2C, public I2CSPIDriver<VCM1193L>
 {
 public:
-	VCM1193L(I2CSPIBusOption bus_option, int bus, int bus_frequency, enum Rotation rotation = ROTATION_NONE);
+	VCM1193L(const I2CSPIDriverConfig &config);
 	~VCM1193L() override;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void RunImpl();

--- a/src/drivers/magnetometer/vtrantech/vcm1193l/vcm1193l_main.cpp
+++ b/src/drivers/magnetometer/vtrantech/vcm1193l/vcm1193l_main.cpp
@@ -35,25 +35,6 @@
 #include <px4_platform_common/module.h>
 #include "VCM1193L.hpp"
 
-I2CSPIDriverBase *
-VCM1193L::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator, int runtime_instance)
-{
-	VCM1193L *instance = new VCM1193L(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.rotation);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
-		return nullptr;
-	}
-
-	return instance;
-}
-
 void VCM1193L::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("vcm1193l", "driver");

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -38,13 +38,14 @@ static constexpr int16_t combine(uint8_t msb, uint8_t lsb)
 	return (msb << 8u) | lsb;
 }
 
-PAW3902::PAW3902(I2CSPIBusOption bus_option, int bus, int devid, int bus_frequency, spi_mode_e spi_mode,
-		 spi_drdy_gpio_t drdy_gpio, float yaw_rotation_degrees) :
-	SPI(DRV_FLOW_DEVTYPE_PAW3902, MODULE_NAME, bus, devid, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
-	_drdy_gpio(drdy_gpio)
+PAW3902::PAW3902(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
+	_drdy_gpio(config.drdy_gpio)
 {
-	if (PX4_ISFINITE(yaw_rotation_degrees)) {
+	float yaw_rotation_degrees = (float)config.custom1;
+
+	if (yaw_rotation_degrees >= 0.f) {
 		PX4_INFO("using yaw rotation %.3f degrees (%.3f radians)",
 			 (double)yaw_rotation_degrees, (double)math::radians(yaw_rotation_degrees));
 

--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -62,12 +62,9 @@ using namespace PixArt_PAW3902JF;
 class PAW3902 : public device::SPI, public I2CSPIDriver<PAW3902>
 {
 public:
-	PAW3902(I2CSPIBusOption bus_option, int bus, int devid, int bus_frequency, spi_mode_e spi_mode,
-		spi_drdy_gpio_t drdy_gpio, float yaw_rotation_degrees = NAN);
+	PAW3902(const I2CSPIDriverConfig &config);
 	virtual ~PAW3902();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int init() override;

--- a/src/drivers/optical_flow/paw3902/paw3902_main.cpp
+++ b/src/drivers/optical_flow/paw3902/paw3902_main.cpp
@@ -43,31 +43,6 @@ void PAW3902::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *PAW3902::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	float yaw_rotation_degrees = NAN;
-
-	if (cli.custom1 >= 0) {
-		yaw_rotation_degrees = cli.custom1;
-	}
-
-	PAW3902 *instance = new PAW3902(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.bus_frequency,
-					cli.spi_mode, iterator.DRDYGPIO(), yaw_rotation_degrees);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 extern "C" __EXPORT int paw3902_main(int argc, char *argv[])
 {
 	int ch = 0;

--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -35,13 +35,12 @@
 
 static constexpr uint32_t TIME_us_TSWW = 11; //  - actually 10.5us
 
-PMW3901::PMW3901(I2CSPIBusOption bus_option, int bus, int devid, enum Rotation yaw_rotation, int bus_frequency,
-		 spi_mode_e spi_mode) :
-	SPI(DRV_FLOW_DEVTYPE_PMW3901, MODULE_NAME, bus, devid, spi_mode, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
+PMW3901::PMW3901(const I2CSPIDriverConfig &config) :
+	SPI(config),
+	I2CSPIDriver(config),
 	_sample_perf(perf_alloc(PC_ELAPSED, "pmw3901: read")),
 	_comms_errors(perf_alloc(PC_COUNT, "pmw3901: com err")),
-	_yaw_rotation(yaw_rotation)
+	_yaw_rotation(config.rotation)
 {
 }
 

--- a/src/drivers/optical_flow/pmw3901/PMW3901.hpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.hpp
@@ -65,13 +65,10 @@
 class PMW3901 : public device::SPI, public I2CSPIDriver<PMW3901>
 {
 public:
-	PMW3901(I2CSPIBusOption bus_option, int bus, int devid, enum Rotation yaw_rotation, int bus_frequency,
-		spi_mode_e spi_mode);
+	PMW3901(const I2CSPIDriverConfig &config);
 
 	virtual ~PMW3901();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	virtual int init();

--- a/src/drivers/optical_flow/pmw3901/pmw3901_main.cpp
+++ b/src/drivers/optical_flow/pmw3901/pmw3901_main.cpp
@@ -46,25 +46,6 @@ PMW3901::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *PMW3901::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	PMW3901 *instance = new PMW3901(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.rotation,
-					cli.bus_frequency, cli.spi_mode);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 int
 pmw3901_main(int argc, char *argv[])
 {

--- a/src/drivers/optical_flow/px4flow/px4flow.cpp
+++ b/src/drivers/optical_flow/px4flow/px4flow.cpp
@@ -75,12 +75,9 @@
 class PX4FLOW: public device::I2C, public I2CSPIDriver<PX4FLOW>
 {
 public:
-	PX4FLOW(I2CSPIBusOption bus_option, int bus, int address, uint8_t sonar_rotation, int bus_frequency,
-		int conversion_interval = PX4FLOW_CONVERSION_INTERVAL_DEFAULT, enum Rotation rotation = ROTATION_NONE);
+	PX4FLOW(const I2CSPIDriverConfig &config);
 	virtual ~PX4FLOW();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int init() override;
@@ -139,14 +136,13 @@ private:
 
 extern "C" __EXPORT int px4flow_main(int argc, char *argv[]);
 
-PX4FLOW::PX4FLOW(I2CSPIBusOption bus_option, int bus, int address, uint8_t sonar_rotation, int bus_frequency,
-		 int conversion_interval, enum Rotation rotation) :
-	I2C(DRV_FLOW_DEVTYPE_PX4FLOW, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address),
-	_sonar_rotation(sonar_rotation),
+PX4FLOW::PX4FLOW(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config),
+	_sonar_rotation(config.rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": read")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": com_err")),
-	_sensor_rotation(rotation)
+	_sensor_rotation(Rotation::ROTATION_NONE)
 {
 }
 
@@ -382,25 +378,6 @@ PX4FLOW::print_usage()
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *PX4FLOW::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	PX4FLOW *instance = new PX4FLOW(iterator.configuredBusOption(), iterator.bus(), cli.i2c_address, cli.orientation,
-					cli.bus_frequency);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
-
 int
 px4flow_main(int argc, char *argv[])
 {
@@ -408,13 +385,13 @@ px4flow_main(int argc, char *argv[])
 	using ThisDriver = PX4FLOW;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = PX4FLOW_I2C_MAX_BUS_SPEED;
-	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.rotation = (Rotation)distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.i2c_address = I2C_FLOW_ADDRESS_DEFAULT;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optArg());
+			cli.rotation = (Rotation)atoi(cli.optArg());
 			break;
 		}
 	}

--- a/src/drivers/osd/atxxxx/atxxxx.cpp
+++ b/src/drivers/osd/atxxxx/atxxxx.cpp
@@ -46,10 +46,10 @@ using namespace time_literals;
 
 static constexpr uint32_t OSD_UPDATE_RATE{50_ms};	// 20 Hz
 
-OSDatxxxx::OSDatxxxx(I2CSPIBusOption bus_option, int bus, int devid, int bus_frequency, spi_mode_e spi_mode) :
-	SPI(DRV_OSD_DEVTYPE_ATXXXX, MODULE_NAME, bus, devid, spi_mode, bus_frequency),
+OSDatxxxx::OSDatxxxx(const I2CSPIDriverConfig &config) :
+	SPI(config),
 	ModuleParams(nullptr),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus)
+	I2CSPIDriver(config)
 {
 }
 
@@ -82,6 +82,10 @@ OSDatxxxx::init()
 		for (int j = 0; j < num_rows; j++) {
 			add_character_to_screen(' ', i, j);
 		}
+	}
+
+	if (ret == PX4_OK) {
+		start();
 	}
 
 	return ret;
@@ -501,27 +505,6 @@ It can be enabled with the OSD_ATXXXX_CFG parameter.
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(false, true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *OSDatxxxx::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	OSDatxxxx *instance = new OSDatxxxx(iterator.configuredBusOption(), iterator.bus(), iterator.devid(),
-					cli.bus_frequency, cli.spi_mode);
-
-	if (!instance) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (OK != instance->init()) {
-		delete instance;
-		return nullptr;
-	}
-
-	instance->start();
-
-	return instance;
 }
 
 int

--- a/src/drivers/osd/atxxxx/atxxxx.h
+++ b/src/drivers/osd/atxxxx/atxxxx.h
@@ -68,11 +68,9 @@ extern "C" __EXPORT int atxxxx_main(int argc, char *argv[]);
 class OSDatxxxx : public device::SPI, public ModuleParams, public I2CSPIDriver<OSDatxxxx>
 {
 public:
-	OSDatxxxx(I2CSPIBusOption bus_option, int bus, int devid, int bus_frequency, spi_mode_e spi_mode);
+	OSDatxxxx(const I2CSPIDriverConfig &config);
 	virtual ~OSDatxxxx() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int init() override;

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -41,10 +41,10 @@
 #include "ina226.h"
 
 
-INA226::INA226(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int address, int battery_index) :
-	I2C(DRV_POWER_DEVTYPE_INA226, MODULE_NAME, bus, address, bus_frequency),
+INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
+	I2C(config),
 	ModuleParams(nullptr),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address),
+	I2CSPIDriver(config),
 	_sample_perf(perf_alloc(PC_ELAPSED, "ina226_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "ina226_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina226_collection_err")),

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -152,11 +152,10 @@ using namespace time_literals;
 class INA226 : public device::I2C, public ModuleParams, public I2CSPIDriver<INA226>
 {
 public:
-	INA226(I2CSPIBusOption bus_option, const int bus, int bus_frequency, int address, int battery_index);
+	INA226(const I2CSPIDriverConfig &config, int battery_index);
 	virtual ~INA226();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	void	RunImpl();

--- a/src/drivers/power_monitor/ina226/ina226_main.cpp
+++ b/src/drivers/power_monitor/ina226/ina226_main.cpp
@@ -35,20 +35,18 @@
 
 #include "ina226.h"
 
-I2CSPIDriverBase *INA226::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
+I2CSPIDriverBase *INA226::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
-	INA226 *instance = new INA226(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency, cli.i2c_address,
-				      cli.custom2);
+	INA226 *instance = new INA226(config, config.custom1);
 
 	if (instance == nullptr) {
 		PX4_ERR("alloc failed");
 		return nullptr;
 	}
 
-	if (cli.keep_running) {
+	if (config.keep_running) {
 		if (instance->force_init() != PX4_OK) {
-			PX4_INFO("Failed to init INA226 on bus %d, but will try again periodically.", iterator.bus());
+			PX4_INFO("Failed to init INA226 on bus %d, but will try again periodically.", config.bus);
 		}
 
 	} else if (instance->init() != PX4_OK) {
@@ -97,12 +95,12 @@ ina226_main(int argc, char *argv[])
 	cli.i2c_address = INA226_BASEADDR;
 	cli.default_i2c_frequency = 100000;
 	cli.support_keep_running = true;
-	cli.custom2 = 1;
+	cli.custom1 = 1;
 
 	while ((ch = cli.getOpt(argc, argv, "t:")) != EOF) {
 		switch (ch) {
 		case 't': // battery index
-			cli.custom2 = (int)strtol(cli.optArg(), NULL, 0);
+			cli.custom1 = (int)strtol(cli.optArg(), NULL, 0);
 			break;
 		}
 	}

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -47,13 +47,13 @@
  * Address 0x44 - measures battery voltage and current with a 0.0005 ohm sense resistor
  * Address 0x45 - measures 5VDC/12VDC ouptut voltage and current with a 0.005 ohm sense resistor
  */
-VOXLPM::VOXLPM(I2CSPIBusOption bus_option, const int bus, int bus_frequency, VOXLPM_CH_TYPE ch_type) :
-	I2C(DRV_POWER_DEVTYPE_VOXLPM, MODULE_NAME, bus, VOXLPM_INA231_ADDR_VBATT, bus_frequency),
+VOXLPM::VOXLPM(const I2CSPIDriverConfig &config) :
+	I2C(config),
 	ModuleParams(nullptr),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
+	I2CSPIDriver(config),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms_errors")),
-	_ch_type(ch_type),
+	_ch_type((VOXLPM_CH_TYPE)config.custom1),
 	_battery(1, this, _meas_interval_us)
 {
 }

--- a/src/drivers/power_monitor/voxlpm/voxlpm.hpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.hpp
@@ -225,11 +225,10 @@ enum VOXLPM_CH_TYPE {
 class VOXLPM : public device::I2C, public ModuleParams, public I2CSPIDriver<VOXLPM>
 {
 public:
-	VOXLPM(I2CSPIBusOption bus_option, const int bus, int bus_frequency, VOXLPM_CH_TYPE ch_type);
+	VOXLPM(const I2CSPIDriverConfig &config);
 	virtual ~VOXLPM();
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 	static void print_usage();
 
 	virtual int		init();

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -33,17 +33,15 @@
 
 #include "PCF8583.hpp"
 
-PCF8583::PCF8583(I2CSPIBusOption bus_option, const int bus, int bus_frequency) :
-	I2C(DRV_SENS_DEVTYPE_PCF8583, MODULE_NAME, bus, PCF8583_BASEADDR_DEFAULT, bus_frequency),
+PCF8583::PCF8583(const I2CSPIDriverConfig &config) :
+	I2C(config),
 	ModuleParams(nullptr),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus)
+	I2CSPIDriver(config)
 {
 }
 
 int PCF8583::init()
 {
-	set_device_address(_param_pcf8583_addr.get());
-
 	if (I2C::init() != PX4_OK) {
 		return PX4_ERROR;
 	}

--- a/src/drivers/rpm/pcf8583/PCF8583.hpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.hpp
@@ -57,11 +57,9 @@
 class PCF8583 : public device::I2C, public ModuleParams, public I2CSPIDriver<PCF8583>
 {
 public:
-	PCF8583(I2CSPIBusOption bus_option, const int bus, int bus_frequency);
+	PCF8583(const I2CSPIDriverConfig &config);
 	~PCF8583() override = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	void		RunImpl();
@@ -85,7 +83,6 @@ private:
 	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::PCF8583_ADDR>) _param_pcf8583_addr,
 		(ParamInt<px4::params::PCF8583_POOL>) _param_pcf8583_pool,
 		(ParamInt<px4::params::PCF8583_RESET>) _param_pcf8583_reset,
 		(ParamInt<px4::params::PCF8583_MAGNET>) _param_pcf8583_magnet

--- a/src/drivers/rpm/pcf8583/pcf8583_main.cpp
+++ b/src/drivers/rpm/pcf8583/pcf8583_main.cpp
@@ -42,31 +42,19 @@ PCF8583::print_usage()
 	PRINT_MODULE_USAGE_NAME("pcf8583", "driver");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(80);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
-I2CSPIDriverBase *PCF8583::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				       int runtime_instance)
-{
-	PCF8583 *instance = new PCF8583(iterator.configuredBusOption(), iterator.bus(), cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
-}
 extern "C" __EXPORT int pcf8583_main(int argc, char *argv[])
 {
 	using ThisDriver = PCF8583;
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = 400000;
+
+	int32_t addr{80};
+	param_get(param_find("PCF8583_ADDR"), &addr);
+	cli.i2c_address = addr;
 
 	const char *verb = cli.parseDefaultArguments(argc, argv);
 

--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -46,25 +46,14 @@
 
 extern "C" __EXPORT int batmon_main(int argc, char *argv[]);
 
-Batmon::Batmon(I2CSPIBusOption bus_option, const int bus, SMBus *interface):
-	SMBUS_SBS_BaseClass(bus_option, bus, interface)
+Batmon::Batmon(const I2CSPIDriverConfig &config, SMBus *interface):
+	SMBUS_SBS_BaseClass(config, interface)
 {
-
 }
 
-Batmon::~Batmon()
+I2CSPIDriverBase *Batmon::instantiate(const I2CSPIDriverConfig &config, int runtime_instance)
 {
-	// Needn't change the parameter since there are other modules that may use it.
-	//int battsource = 0;
-	//param_set(param_find("BAT_SOURCE"), &battsource);
-}
-
-I2CSPIDriverBase *Batmon::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				      int runtime_instance)
-
-{
-	//TODO there may be a better way to pass the driver ID, since iterator object should have it
-	SMBus *interface = new SMBus(DRV_BAT_DEVTYPE_BATMON_SMBUS, iterator.bus(), cli.i2c_address);
+	SMBus *interface = new SMBus(config.devid_driver_index, config.bus, config.i2c_address);
 
 	int32_t batmon_en_param = 0;
 	param_get(param_find("BATMON_DRIVER_EN"), &batmon_en_param);
@@ -78,7 +67,7 @@ I2CSPIDriverBase *Batmon::instantiate(const BusCLIArguments &cli, const BusInsta
 		return nullptr;
 	}
 
-	Batmon *instance = new Batmon(iterator.configuredBusOption(), iterator.bus(), interface);
+	Batmon *instance = new Batmon(config, interface);
 
 	if (instance == nullptr) {
 		PX4_ERR("alloc failed");

--- a/src/drivers/smart_battery/batmon/batmon.h
+++ b/src/drivers/smart_battery/batmon/batmon.h
@@ -54,16 +54,16 @@ class Batmon : public SMBUS_SBS_BaseClass<Batmon>
 {
 
 public:
-	Batmon(I2CSPIBusOption bus_option, const int bus, SMBus *interface);
-	~Batmon();
+	Batmon(const I2CSPIDriverConfig &config, SMBus *interface);
+	~Batmon() = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
+	static I2CSPIDriverBase *instantiate(const I2CSPIDriverConfig &config, int runtime_instance);
 
 	static void print_usage();
 
 	void RunImpl();
-	enum {
+
+	enum BATMON_REGISTERS {
 		BATT_SMBUS_TEMP_EXTERNAL_1		=	0x48,
 		BATT_SMBUS_TEMP_EXTERNAL_2		=	0x49,
 		BATT_SMBUS_CELL_1_VOLTAGE               =       0x3F,
@@ -83,7 +83,7 @@ public:
 		BATT_SMBUS_CELL_15_VOLTAGE              =       0x31,
 		BATT_SMBUS_CELL_16_VOLTAGE              =       0x30,
 		BATT_SMBUS_CELL_COUNT                   =       0x40
-	} BATMON_REGISTERS;
+	};
 
 private:
 

--- a/src/drivers/telemetry/bst/bst.cpp
+++ b/src/drivers/telemetry/bst/bst.cpp
@@ -111,11 +111,9 @@ struct BSTBattery {
 class BST : public device::I2C, public I2CSPIDriver<BST>
 {
 public:
-	BST(I2CSPIBusOption bus_option, const int bus, int address, int bus_frequency);
+	BST(const I2CSPIDriverConfig &config);
 	~BST() override = default;
 
-	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-					     int runtime_instance);
 	static void print_usage();
 
 	int		init() override;
@@ -179,9 +177,9 @@ private:
 	}
 };
 
-BST::BST(I2CSPIBusOption bus_option, const int bus, int address, int bus_frequency) :
-	I2C(DRV_TEL_DEVTYPE_BST, MODULE_NAME, bus, address, bus_frequency),
-	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus, address)
+BST::BST(const I2CSPIDriverConfig &config) :
+	I2C(config),
+	I2CSPIDriver(config)
 {
 }
 
@@ -315,24 +313,6 @@ BST::print_usage()
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
 	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x76);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
-}
-
-I2CSPIDriverBase *BST::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
-				   int runtime_instance)
-{
-	BST *instance = new BST(iterator.configuredBusOption(), iterator.bus(), cli.i2c_address, cli.bus_frequency);
-
-	if (instance == nullptr) {
-		PX4_ERR("alloc failed");
-		return nullptr;
-	}
-
-	if (instance->init() != PX4_OK) {
-		delete instance;
-		return nullptr;
-	}
-
-	return instance;
 }
 
 extern "C" __EXPORT int bst_main(int argc, char *argv[])

--- a/src/lib/drivers/device/nuttx/I2C.cpp
+++ b/src/lib/drivers/device/nuttx/I2C.cpp
@@ -42,6 +42,7 @@
 
 #include "I2C.hpp"
 
+#include <px4_platform_common/i2c_spi_buses.h>
 #include <nuttx/i2c/i2c_master.h>
 
 namespace device
@@ -62,6 +63,11 @@ I2C::I2C(uint8_t device_type, const char *name, const int bus, const uint16_t ad
 	_device_id.devid_s.bus_type = DeviceBusType_I2C;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = address;
+}
+
+I2C::I2C(const I2CSPIDriverConfig &config)
+	: I2C(config.devid_driver_index, config.module_name, config.bus, config.i2c_address, config.bus_frequency)
+{
 }
 
 I2C::~I2C()

--- a/src/lib/drivers/device/nuttx/I2C.hpp
+++ b/src/lib/drivers/device/nuttx/I2C.hpp
@@ -45,6 +45,8 @@
 
 #include <nuttx/i2c/i2c_master.h>
 
+struct I2CSPIDriverConfig;
+
 #if !defined(CONFIG_I2C)
 #  error I2C support requires CONFIG_I2C
 #endif
@@ -87,6 +89,7 @@ protected:
 	 * @param frequency	I2C bus frequency for the device (currently not used)
 	 */
 	I2C(uint8_t device_type, const char *name, const int bus, const uint16_t address, const uint32_t frequency);
+	I2C(const I2CSPIDriverConfig &config);
 	virtual ~I2C();
 
 	/**

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -47,6 +47,7 @@
 
 #include "SPI.hpp"
 
+#include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_config.h>
 #include <nuttx/arch.h>
 
@@ -67,13 +68,18 @@ SPI::SPI(uint8_t device_type, const char *name, int bus, uint32_t device, enum s
 	// fill in _device_id fields for a SPI device
 	_device_id.devid_s.bus_type = DeviceBusType_SPI;
 	_device_id.devid_s.bus = bus;
-	// Use the 2. LSB byte as SPI address. This is currently 0, but will allow to extend
-	// for multiple instances of the same device on a bus, should that ever be required.
+	// Use the 2. LSB byte as SPI address, which is non-zero for multiple instances of the same device on a bus
 	_device_id.devid_s.address = (uint8_t)(device >> 8);
 
 	if (!px4_spi_bus_requires_locking(bus)) {
 		_locking_mode = LOCK_NONE;
 	}
+}
+
+SPI::SPI(const I2CSPIDriverConfig &config)
+	: SPI(config.devid_driver_index, config.module_name, config.bus, config.spi_devid, config.spi_mode,
+	      config.bus_frequency)
+{
 }
 
 SPI::~SPI()

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -45,6 +45,8 @@
 #include <nuttx/spi/spi.h>
 #include <px4_platform_common/spi.h>
 
+struct I2CSPIDriverConfig;
+
 namespace device __EXPORT
 {
 
@@ -72,6 +74,9 @@ protected:
 	 * @param frequency	SPI clock frequency
 	 */
 	SPI(uint8_t device_type, const char *name, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency);
+
+	SPI(const I2CSPIDriverConfig &config);
+
 	virtual ~SPI();
 
 	/**

--- a/src/lib/drivers/device/posix/I2C.cpp
+++ b/src/lib/drivers/device/posix/I2C.cpp
@@ -47,6 +47,8 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
+#include <px4_platform_common/i2c_spi_buses.h>
+
 namespace device
 {
 
@@ -58,6 +60,11 @@ I2C::I2C(uint8_t device_type, const char *name, const int bus, const uint16_t ad
 	_device_id.devid_s.bus_type = DeviceBusType_I2C;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = address;
+}
+
+I2C::I2C(const I2CSPIDriverConfig &config)
+	: I2C(config.devid_driver_index, config.module_name, config.bus, config.i2c_address, config.bus_frequency)
+{
 }
 
 I2C::~I2C()

--- a/src/lib/drivers/device/posix/I2C.hpp
+++ b/src/lib/drivers/device/posix/I2C.hpp
@@ -43,6 +43,8 @@
 #include "../CDev.hpp"
 #include <px4_platform_common/i2c.h>
 
+struct I2CSPIDriverConfig;
+
 namespace device __EXPORT
 {
 
@@ -79,6 +81,7 @@ protected:
 	 * @param frequency	I2C bus frequency for the device (currently not used)
 	 */
 	I2C(uint8_t device_type, const char *name, const int bus, const uint16_t address, const uint32_t frequency);
+	I2C(const I2CSPIDriverConfig &config);
 	virtual ~I2C();
 
 	/**

--- a/src/lib/drivers/device/posix/SPI.cpp
+++ b/src/lib/drivers/device/posix/SPI.cpp
@@ -48,6 +48,7 @@
 #include <linux/types.h>
 #include <linux/spi/spidev.h>
 
+#include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_config.h>
 
 namespace device
@@ -65,6 +66,13 @@ SPI::SPI(uint8_t device_type, const char *name, int bus, uint32_t device, enum s
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = (uint8_t)device;
 }
+
+SPI::SPI(const I2CSPIDriverConfig &config)
+	: SPI(config.devid_driver_index, config.module_name, config.bus, config.spi_devid, config.spi_mode,
+	      config.bus_frequency)
+{
+}
+
 
 SPI::~SPI()
 {

--- a/src/lib/drivers/device/posix/SPI.hpp
+++ b/src/lib/drivers/device/posix/SPI.hpp
@@ -58,6 +58,8 @@ enum spi_mode_e {
 	SPIDEV_MODE3 = SPI_MODE_3  /* CPOL=1 CHPHA=1 */
 };
 
+struct I2CSPIDriverConfig;
+
 namespace device __EXPORT
 {
 
@@ -85,6 +87,9 @@ protected:
 	 * @param frequency	SPI clock frequency
 	 */
 	SPI(uint8_t device_type, const char *name, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency);
+
+	SPI(const I2CSPIDriverConfig &config);
+
 	virtual ~SPI();
 
 	/**

--- a/src/lib/drivers/device/qurt/I2C.cpp
+++ b/src/lib/drivers/device/qurt/I2C.cpp
@@ -44,6 +44,8 @@
 
 #include <dev_fs_lib_i2c.h>
 
+#include <px4_platform_common/i2c_spi_buses.h>
+
 namespace device
 {
 
@@ -56,6 +58,11 @@ I2C::I2C(uint8_t device_type, const char *name, const int bus, const uint16_t ad
 	_device_id.devid_s.bus_type = DeviceBusType_I2C;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = address;
+}
+
+I2C::I2C(const I2CSPIDriverConfig &config)
+	: I2C(config.devid_driver_index, config.module_name, config.bus, config.i2c_address, config.bus_frequency)
+{
 }
 
 I2C::~I2C()

--- a/src/lib/drivers/device/qurt/I2C.hpp
+++ b/src/lib/drivers/device/qurt/I2C.hpp
@@ -42,6 +42,8 @@
 
 #include "../CDev.hpp"
 
+struct I2CSPIDriverConfig;
+
 namespace device __EXPORT
 {
 
@@ -78,6 +80,7 @@ protected:
 	 * @param frequency	I2C bus frequency for the device (currently not used)
 	 */
 	I2C(uint8_t device_type, const char *name, const int bus, const uint16_t address, const uint32_t frequency);
+	I2C(const I2CSPIDriverConfig &config);
 	virtual ~I2C();
 
 	/**

--- a/src/lib/drivers/device/qurt/SPI.cpp
+++ b/src/lib/drivers/device/qurt/SPI.cpp
@@ -46,6 +46,7 @@
 
 #include "dev_fs_lib_spi.h"
 
+#include <px4_platform_common/i2c_spi_buses.h>
 #include <px4_platform_common/px4_config.h>
 
 namespace device
@@ -62,6 +63,12 @@ SPI::SPI(uint8_t device_type, const char *name, int bus, uint32_t device, enum s
 	_device_id.devid_s.bus_type = DeviceBusType_SPI;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = (uint8_t)device;
+}
+
+SPI::SPI(const I2CSPIDriverConfig &config)
+	: SPI(config.devid_driver_index, config.module_name, config.bus, config.spi_devid, config.spi_mode,
+	      config.bus_frequency)
+{
 }
 
 SPI::~SPI()

--- a/src/lib/drivers/device/qurt/SPI.hpp
+++ b/src/lib/drivers/device/qurt/SPI.hpp
@@ -50,6 +50,8 @@ enum spi_mode_e {
 	SPIDEV_MODE3 = 3  /* CPOL=1 CHPHA=1 */
 };
 
+struct I2CSPIDriverConfig;
+
 namespace device __EXPORT
 {
 
@@ -70,6 +72,7 @@ protected:
 	 * @param frequency	SPI clock frequency
 	 */
 	SPI(uint8_t device_type, const char *name, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency);
+	SPI(const I2CSPIDriverConfig &config);
 	virtual ~SPI();
 
 	/**

--- a/src/lib/drivers/smbus_sbs/SBS.hpp
+++ b/src/lib/drivers/smbus_sbs/SBS.hpp
@@ -58,7 +58,7 @@ template<class T>
 class SMBUS_SBS_BaseClass : public I2CSPIDriver<T>
 {
 public:
-	SMBUS_SBS_BaseClass(I2CSPIBusOption bus_option, const int bus, SMBus *interface);
+	SMBUS_SBS_BaseClass(const I2CSPIDriverConfig &config, SMBus *interface);
 	SMBUS_SBS_BaseClass();
 
 	~SMBUS_SBS_BaseClass();
@@ -170,16 +170,12 @@ protected:
 };
 
 template<class T>
-SMBUS_SBS_BaseClass<T>::SMBUS_SBS_BaseClass(I2CSPIBusOption bus_option, const int bus, SMBus *interface):
-	I2CSPIDriver<T>(MODULE_NAME, px4::device_bus_to_wq(interface->get_device_id()), bus_option, bus,
-			interface->get_device_address()),
+SMBUS_SBS_BaseClass<T>::SMBUS_SBS_BaseClass(const I2CSPIDriverConfig &config, SMBus *interface):
+	I2CSPIDriver<T>(config),
 	_interface(interface)
 {
-	static int SBS_instance_number = 0;
 	battery_status_s new_report = {};
-	SBS_instance_number++;
-	// TODO: there maybe a better way to assign instance number. This would
-	// 	 result in continuously increasing instance number and possible overflow
+	int SBS_instance_number = 0;
 	_batt_topic = orb_advertise_multi(ORB_ID(battery_status), &new_report, &SBS_instance_number);
 	_interface->init();
 }


### PR DESCRIPTION
Also simplifies the API a bit, since we anyway have to change the drivers to pass additional information (the bus device index) to the lower-level parts. There's a few drivers that are updated to see the differences.
Device ID's are preserved.

fixes https://github.com/PX4/PX4-Autopilot/issues/17247

@dakejahl @dagar 

Any other suggestions while we're at it?