### PR TITLE
sensors/vehicle_imu: increase threshold for clipping warning

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -332,7 +332,7 @@ void VehicleIMU::Run()
 			const uint64_t clipping_total = _status.accel_clipping[0] + _status.accel_clipping[1] + _status.accel_clipping[2];
 
 			if ((hrt_elapsed_time(&_last_clipping_notify_time) > 3_s)
-			    && (clipping_total > _last_clipping_notify_total_count + 10)) {
+			    && (clipping_total > _last_clipping_notify_total_count + 100)) {
 
 				mavlink_log_critical(&_mavlink_log_pub, "Accel %d clipping, land immediately!", _instance);
 				_last_clipping_notify_time = accel.timestamp_sample;


### PR DESCRIPTION
Trying to find a reasonable value that doesn't falsely trigger on the ground (eg handling a non-isolated flight controller on a table top).

