### PR TITLE
Improve Robustness of LANDING_TARGET Message

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2305,6 +2305,11 @@ MavlinkReceiver::handle_message_landing_target(mavlink_message_t *msg)
 
 		_landing_target_pose_pub.publish(landing_target_pose);
 
+	} else if (landing_target.position_valid) {
+		// We only support MAV_FRAME_LOCAL_NED. In this case, the frame was unsupported.
+		mavlink_log_critical(&_mavlink_log_pub, "landing target: coordinate frame %d unsupported",
+				     landing_target.frame);
+
 	} else {
 		irlock_report_s irlock_report{};
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -575,15 +575,20 @@ void Simulator::handle_message_landing_target(const mavlink_message_t *msg)
 	mavlink_landing_target_t landing_target_mavlink;
 	mavlink_msg_landing_target_decode(msg, &landing_target_mavlink);
 
-	irlock_report_s report{};
-	report.timestamp = hrt_absolute_time();
-	report.signature = landing_target_mavlink.target_num;
-	report.pos_x = landing_target_mavlink.angle_x;
-	report.pos_y = landing_target_mavlink.angle_y;
-	report.size_x = landing_target_mavlink.size_x;
-	report.size_y = landing_target_mavlink.size_y;
+	if (landing_target_mavlink.position_valid) {
+		PX4_WARN("Only landing targets relative to captured images are supported");
 
-	_irlock_report_pub.publish(report);
+	} else {
+		irlock_report_s report{};
+		report.timestamp = hrt_absolute_time();
+		report.signature = landing_target_mavlink.target_num;
+		report.pos_x = landing_target_mavlink.angle_x;
+		report.pos_y = landing_target_mavlink.angle_y;
+		report.size_x = landing_target_mavlink.size_x;
+		report.size_y = landing_target_mavlink.size_y;
+
+		_irlock_report_pub.publish(report);
+	}
 }
 
 void Simulator::handle_message_odometry(const mavlink_message_t *msg)


### PR DESCRIPTION
**Describe problem solved by this pull request**
In `MavlinkReceiver::handle_message_landing_target`, if `landing_target.frame != MAV_FRAME_LOCAL_NED` then the message is handled as a "Target Relative to Captured Image" message. [Per MAVLink's documentation](https://mavlink.io/en/services/landing_target.html), PX4 does not handle frames other than `MAV_FRAME_LOCAL_NED`. However, treating messages with other frames as a target relative to a captured image does not seem correct. MAVLink appears to be silent on the issue of default parameter values for this message. Users may supply values of `angle_x`, etc that cause undesirable behavior.

**Describe your solution**
Updated MavlinkReceiver::handle_message_landing_target to warn users when they provide a landing target with an unsupported coordinate frame.

Updated Simulator::handle_message_landing_target to warn users when they provide a landing target that is not relative to a captured image.

**Describe possible alternatives**
None.

**Test data / coverage**
Ran in SITL. Tested sending the previously incorrectly handled message.
<img width="646" alt="new-helpful-error-message" src="https://user-images.githubusercontent.com/4347705/113763867-31fa5300-96e8-11eb-88ac-50d67cf0aecb.png">


**Additional context**
Discussed in https://github.com/PX4/PX4-Autopilot/issues/17337. 
