### PR TITLE
Fix support for Cube Black Heater

### DIFF
--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -27,7 +27,7 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		dshot
 		gps
-		#heater
+		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
 		imu/l3gd20

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -48,7 +48,7 @@
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_io_heater.h>
 
-#if defined(BOARD_USES_PX4IO) and defined(PX4IO_HEATER_ENABLED)
+#if defined(BOARD_USES_PX4IO_VERSION) and defined(PX4IO_HEATER_ENABLED)
 // Heater on some boards is on IO MCU
 // Use ioctl calls to IO driver to turn heater on/off
 #  define HEATER_PX4IO

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -129,8 +129,8 @@ private:
 	static struct work_s _work;
 
 	/** File descriptor for PX4IO for heater ioctl's */
-#if defined(HEATER_PX4IO)
-	int _io_fd_ {-1};
+#if defined(PX4IO_HEATER_ENABLED)
+	int _io_fd {-1};
 #endif
 
 	bool _heater_on = false;


### PR DESCRIPTION
This PR adds support for the Cube Black Heater. It still needs to be tested and tuned. We will likely want to add the tuned parameters into the Cube Black's startup scripts.

@JacobCrabill I see you did the work to support the heater on an IO pin. Did you initially test it on a Cube Black or custom hardware?