### PR TITLE
COM_ARM_WO_GPS - values round the wrong way

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -307,11 +307,11 @@ PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 25.0f);
 /**
  * Allow arming without GPS
  *
- * The default allows to arm the vehicle without GPS signal.
+ * The default allows the vehicle to arm without GPS signal.
  *
  * @group Commander
- * @value 0 Allow arming without GPS
- * @value 1 Require GPS lock to arm
+ * @value 0 Require GPS lock to arm
+ * @value 1 Allow arming without GPS
  */
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 


### PR DESCRIPTION
As per https://github.com/PX4/PX4-user_guide/issues/1177 the docs **must** be incorrect because they are self-conflicting. I think that the thing that is incorrect is the text on the values. 

Further, does this actually mean GPS lock, or does it mean "Position Lock" as defined by EKF fusion. If so, probably docs should also change to reflect that.