### PR TITLE
Param markdown  - fix sensor param table

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -20,6 +20,12 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
 tr > * {
     vertical-align : top;
 }
+td:nth-child(1),td:nth-child(2) {
+  text-align : left;
+  }
+table {
+  width: fit-content;
+}
 </style>
 
 """               


### PR DESCRIPTION
This fixes the CSS on the parameters output for sensors table, and generally makes the appearance better: https://docs.px4.io/master/en/advanced_config/parameter_reference.html#sensors