### PR TITLE
boards: cubeorange enable pwm_input

### DIFF
--- a/boards/cubepilot/cubeorange/console.cmake
+++ b/boards/cubepilot/cubeorange/console.cmake
@@ -43,6 +43,7 @@ px4_add_board(
 		#pca9685_pwm_out
 		power_monitor/ina226
 		#protocol_splitter
+		pwm_input
 		pwm_out_sim
 		pwm_out
 		px4io

--- a/boards/cubepilot/cubeorange/default.cmake
+++ b/boards/cubepilot/cubeorange/default.cmake
@@ -44,6 +44,7 @@ px4_add_board(
 		pca9685_pwm_out
 		power_monitor/ina226
 		#protocol_splitter
+		pwm_input
 		pwm_out_sim
 		pwm_out
 		px4io

--- a/boards/cubepilot/cubeorange/src/board_config.h
+++ b/boards/cubepilot/cubeorange/src/board_config.h
@@ -115,6 +115,11 @@
 #define GPIO_TONE_ALARM_IDLE    GPIO_BUZZER_1
 #define GPIO_TONE_ALARM         GPIO_TIM2_CH1OUT_2
 
+/* PWM input driver. Use FMU AUX5 pins attached to timer4 channel 2 */
+#define PWMIN_TIMER                       4
+#define PWMIN_TIMER_CHANNEL    /* T4C2 */ 2
+#define GPIO_PWM_IN            /* PD13 */ GPIO_TIM4_CH2IN_2
+
 /* USB
  *  OTG FS: PA9  OTG_FS_VBUS VBUS sensing
  */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Can't use `pwm_input` on CubeOrange.

**Describe your solution**
Enable `pwm_input`. Use same timer/channel/pin as FMU V6X (AUX5)

**Describe possible alternatives**
N/A

**Test data / coverage**
Connected main 5 to aux 5:
![image](https://user-images.githubusercontent.com/4969631/113945484-9dfdb980-97c3-11eb-993c-008bf68ae05e.png)
