### PR TITLE
mavlink: streams fix SCALED_IMU size reporting

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -98,6 +98,8 @@
 #include "streams/RAW_RPM.hpp"
 #include "streams/RC_CHANNELS.hpp"
 #include "streams/SCALED_IMU.hpp"
+#include "streams/SCALED_IMU2.hpp"
+#include "streams/SCALED_IMU3.hpp"
 #include "streams/SCALED_PRESSURE.hpp"
 #include "streams/SERVO_OUTPUT_RAW.hpp"
 #include "streams/STATUSTEXT.hpp"
@@ -333,10 +335,14 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamHighresIMU>(),
 #endif // HIGHRES_IMU_HPP
 #if defined(SCALED_IMU_HPP)
-	create_stream_list_item<MavlinkStreamScaledIMU<0> >(),
-	create_stream_list_item<MavlinkStreamScaledIMU<1> >(),
-	create_stream_list_item<MavlinkStreamScaledIMU<2> >(),
+	create_stream_list_item<MavlinkStreamScaledIMU>(),
 #endif // SCALED_IMU_HPP
+#if defined(SCALED_IMU2_HPP)
+	create_stream_list_item<MavlinkStreamScaledIMU2>(),
+#endif // SCALED_IMU2_HPP
+#if defined(SCALED_IMU3_HPP)
+	create_stream_list_item<MavlinkStreamScaledIMU3>(),
+#endif // SCALED_IMU3_HPP
 #if defined(SCALED_PRESSURE)
 	create_stream_list_item<MavlinkStreamScaledPressure>(),
 #endif // SCALED_PRESSURE

--- a/src/modules/mavlink/streams/SCALED_IMU2.hpp
+++ b/src/modules/mavlink/streams/SCALED_IMU2.hpp
@@ -31,8 +31,8 @@
  *
  ****************************************************************************/
 
-#ifndef SCALED_IMU_HPP
-#define SCALED_IMU_HPP
+#ifndef SCALED_IMU2_HPP
+#define SCALED_IMU2_HPP
 
 #include <lib/ecl/geo/geo.h>
 #include <lib/matrix/matrix/math.hpp>
@@ -40,13 +40,13 @@
 #include <uORB/topics/sensor_mag.h>
 #include <uORB/topics/vehicle_imu.h>
 
-class MavlinkStreamScaledIMU : public MavlinkStream
+class MavlinkStreamScaledIMU2 : public MavlinkStream
 {
 public:
-	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamScaledIMU(mavlink); }
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamScaledIMU2(mavlink); }
 
-	static constexpr const char *get_name_static() { return "SCALED_IMU"; }
-	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_SCALED_IMU; }
+	static constexpr const char *get_name_static() { return "SCALED_IMU2"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_SCALED_IMU2; }
 
 	const char *get_name() const override { return get_name_static(); }
 	uint16_t get_id() override { return get_id_static(); }
@@ -54,22 +54,22 @@ public:
 	unsigned get_size() override
 	{
 		if (_vehicle_imu_sub.advertised() || _sensor_mag_sub.advertised()) {
-			return MAVLINK_MSG_ID_SCALED_IMU_LEN  + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+			return MAVLINK_MSG_ID_SCALED_IMU2_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 		}
 
 		return 0;
 	}
 
 private:
-	explicit MavlinkStreamScaledIMU(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+	explicit MavlinkStreamScaledIMU2(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
-	uORB::Subscription _vehicle_imu_sub{ORB_ID(vehicle_imu), 0};
-	uORB::Subscription _sensor_mag_sub{ORB_ID(sensor_mag), 0};
+	uORB::Subscription _vehicle_imu_sub{ORB_ID(vehicle_imu), 1};
+	uORB::Subscription _sensor_mag_sub{ORB_ID(sensor_mag), 1};
 
 	bool send() override
 	{
 		if (_vehicle_imu_sub.updated() || _sensor_mag_sub.updated()) {
-			mavlink_scaled_imu_t msg{};
+			mavlink_scaled_imu2_t msg{};
 
 			vehicle_imu_s imu;
 
@@ -104,11 +104,11 @@ private:
 				msg.temperature = sensor_mag.temperature;
 			}
 
-			mavlink_msg_scaled_imu_send_struct(_mavlink->get_channel(), &msg);
+			mavlink_msg_scaled_imu2_send_struct(_mavlink->get_channel(), &msg);
 			return true;
 		}
 
 		return false;
 	}
 };
-#endif /* SCALED_IMU_HPP */
+#endif /* SCALED_IMU2_HPP */

--- a/src/modules/mavlink/streams/SCALED_IMU3.hpp
+++ b/src/modules/mavlink/streams/SCALED_IMU3.hpp
@@ -31,8 +31,8 @@
  *
  ****************************************************************************/
 
-#ifndef SCALED_IMU_HPP
-#define SCALED_IMU_HPP
+#ifndef SCALED_IMU3_HPP
+#define SCALED_IMU3_HPP
 
 #include <lib/ecl/geo/geo.h>
 #include <lib/matrix/matrix/math.hpp>
@@ -40,13 +40,13 @@
 #include <uORB/topics/sensor_mag.h>
 #include <uORB/topics/vehicle_imu.h>
 
-class MavlinkStreamScaledIMU : public MavlinkStream
+class MavlinkStreamScaledIMU3 : public MavlinkStream
 {
 public:
-	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamScaledIMU(mavlink); }
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamScaledIMU3(mavlink); }
 
-	static constexpr const char *get_name_static() { return "SCALED_IMU"; }
-	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_SCALED_IMU; }
+	static constexpr const char *get_name_static() { return "SCALED_IMU3"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_SCALED_IMU3; }
 
 	const char *get_name() const override { return get_name_static(); }
 	uint16_t get_id() override { return get_id_static(); }
@@ -54,22 +54,22 @@ public:
 	unsigned get_size() override
 	{
 		if (_vehicle_imu_sub.advertised() || _sensor_mag_sub.advertised()) {
-			return MAVLINK_MSG_ID_SCALED_IMU_LEN  + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+			return MAVLINK_MSG_ID_SCALED_IMU3_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 		}
 
 		return 0;
 	}
 
 private:
-	explicit MavlinkStreamScaledIMU(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+	explicit MavlinkStreamScaledIMU3(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
-	uORB::Subscription _vehicle_imu_sub{ORB_ID(vehicle_imu), 0};
-	uORB::Subscription _sensor_mag_sub{ORB_ID(sensor_mag), 0};
+	uORB::Subscription _vehicle_imu_sub{ORB_ID(vehicle_imu), 2};
+	uORB::Subscription _sensor_mag_sub{ORB_ID(sensor_mag), 2};
 
 	bool send() override
 	{
 		if (_vehicle_imu_sub.updated() || _sensor_mag_sub.updated()) {
-			mavlink_scaled_imu_t msg{};
+			mavlink_scaled_imu3_t msg{};
 
 			vehicle_imu_s imu;
 
@@ -104,11 +104,11 @@ private:
 				msg.temperature = sensor_mag.temperature;
 			}
 
-			mavlink_msg_scaled_imu_send_struct(_mavlink->get_channel(), &msg);
+			mavlink_msg_scaled_imu3_send_struct(_mavlink->get_channel(), &msg);
 			return true;
 		}
 
 		return false;
 	}
 };
-#endif /* SCALED_IMU_HPP */
+#endif /* SCALED_IMU3_HPP */


### PR DESCRIPTION
These IMU streams weren't correctly reporting size when not advertised which skews the mavlink rate scaling if you don't have all 3 IMUs. This keeps it simple by treating it as 3 separate streams where it's now obvious what's missing compared to other streams.