### PR TITLE
Fix raw_dt and present_dt calculation in gps_blending

### DIFF
--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -105,8 +105,8 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 	_np_gps_suitable_for_blending = 0;
 
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS_BLEND; i++) {
-		const float raw_dt = 1e-6f * (float)(_gps_state[i].timestamp - _time_prev_us[i]);
-		const float present_dt = 1e-6f * (float)(hrt_now_us - _gps_state[i].timestamp);
+		const float raw_dt = 1e-6f * ((float)_gps_state[i].timestamp - (float)_time_prev_us[i]);
+		const float present_dt = 1e-6f * ((float)hrt_now_us - (float)_gps_state[i].timestamp);
 
 		if (raw_dt > 0.0f && raw_dt < GPS_TIMEOUT_S) {
 			_gps_dt[i] = 0.1f * raw_dt + 0.9f * _gps_dt[i];


### PR DESCRIPTION
If the GPS data is passed from companion computer, there may be inaccuracies
with timesync. This may cause time deltas to overflow.

Make the time delta calculation using floats directly, wich results in negative
numbers in case there are such inaccuracies.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**

We are currently using an indoor positioning system, based on HTC Vive trackers, and passing "GPS" coordinates over RTSP from ROS2 (as SensorGps). The latency from the trackers is very low, and timestamps for the samples are close to the current time. Inaccuracies in the timesync cause the sample times to be sligthly in the future sometimes.

This doesn't harm anything else ( for the ekf, the samples will fall into the fusion time horizon soon enough), but the overflow in the blending code calculation will make the samples disappear for good.

**Describe your solution**

Correct the time delta calculation so that it doesn't overflow. If the dt is negative, let it be, instead of letting it roll over.

**Describe possible alternatives**

Improvements for the PX4-ROS2 timesync would make sense in addition, it assumes currently that the time delay from px4->ros is equivalent to ros->px4, which is typically not the case, when there is lots of data flow from px4->ros but not the other way.

**Test data / coverage**

Tested by passing sensor data over micrortps from companion computer to px4, observed that the timesync inaccuracy doesn't any more cause loss of data
