### PR TITLE
COMPONENT_INFORMATION: generally embed param metadata

### DIFF
--- a/boards/holybro/kakutef7/default.cmake
+++ b/boards/holybro/kakutef7/default.cmake
@@ -6,6 +6,7 @@ px4_add_board(
 	LABEL default
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
+	EXTERNAL_METADATA
 	ROMFSROOT px4fmu_common
 	SERIAL_PORTS
 		TEL1:/dev/ttyS0 # UART1

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -12,6 +12,7 @@ px4_add_board(
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
+	EXTERNAL_METADATA
 	TESTING
 	#UAVCAN_INTERFACES 2
 	SERIAL_PORTS

--- a/boards/px4/sitl/ctrlalloc.cmake
+++ b/boards/px4/sitl/ctrlalloc.cmake
@@ -5,7 +5,6 @@ px4_add_board(
 	MODEL sitl
 	ROMFSROOT px4fmu_common
 	LABEL ctrlalloc
-	EMBEDDED_METADATA parameters
 	TESTING
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -5,7 +5,6 @@ px4_add_board(
 	MODEL sitl
 	ROMFSROOT px4fmu_common
 	LABEL default
-	EMBEDDED_METADATA parameters
 	TESTING
 	ETHERNET
 	DRIVERS

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -5,7 +5,6 @@ px4_add_board(
 	MODEL sitl
 	ROMFSROOT px4fmu_common
 	LABEL nolockstep
-	EMBEDDED_METADATA parameters
 	TESTING
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -5,7 +5,6 @@ px4_add_board(
 	MODEL sitl
 	ROMFSROOT px4fmu_common
 	LABEL rtps
-	EMBEDDED_METADATA parameters
 	TESTING
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -5,7 +5,6 @@ px4_add_board(
 	MODEL sitl
 	ROMFSROOT px4fmu_common
 	LABEL test
-	EMBEDDED_METADATA parameters
 	TESTING
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -57,9 +57,9 @@
 #			[ SERIAL_PORTS <list> ]
 #			[ CONSTRAINED_FLASH ]
 #			[ CONSTRAINED_MEMORY ]
+#			[ EXTERNAL_METADATA ]
 #			[ TESTING ]
 #			[ LINKER_PREFIX <string> ]
-#			[ EMBEDDED_METADATA <string> ]
 #			[ ETHERNET ]
 #			)
 #
@@ -80,9 +80,9 @@
 #		SYSTEMCMDS		: list of system commands to build for this board (relative to src/systemcmds)
 #		EXAMPLES		: list of example modules to build for this board (relative to src/examples)
 #		SERIAL_PORTS		: mapping of user configurable serial ports and param facing name
-#		EMBEDDED_METADATA	: list of metadata to embed to ROMFS
 #		CONSTRAINED_FLASH	: flag to enable constrained flash options (eg limit init script status text)
 #		CONSTRAINED_MEMORY	: flag to enable constrained memory options (eg limit maximum number of uORB publications)
+#		EXTERNAL_METADATA	: flag to exclude metadata to reduce flash
 #		TESTING			: flag to enable automatic inclusion of PX4 testing modules
 #		LINKER_PREFIX	: optional to prefix on the Linker script.
 #		ETHERNET		: flag to indicate that ethernet is enabled
@@ -156,11 +156,11 @@ function(px4_add_board)
 			EXAMPLES
 			SERIAL_PORTS
 			UAVCAN_PERIPHERALS
-			EMBEDDED_METADATA
 		OPTIONS
 			BUILD_BOOTLOADER
 			CONSTRAINED_FLASH
 			CONSTRAINED_MEMORY
+			EXTERNAL_METADATA
 			TESTING
 			ETHERNET
 		REQUIRED
@@ -207,14 +207,11 @@ function(px4_add_board)
 
 	set(romfs_extra_files)
 	set(config_romfs_extra_dependencies)
-	foreach(metadata ${EMBEDDED_METADATA})
-		if(${metadata} STREQUAL "parameters")
-			list(APPEND romfs_extra_files ${PX4_BINARY_DIR}/parameters.json.xz)
-			list(APPEND romfs_extra_dependencies parameters_xml)
-		else()
-			message(FATAL_ERROR "invalid value for EMBEDDED_METADATA: ${metadata}")
-		endif()
-	endforeach()
+	# additional embedded metadata
+	if (NOT CONSTRAINED_FLASH AND NOT EXTERNAL_METADATA AND NOT ${PX4_BOARD_LABEL} STREQUAL "test")
+		list(APPEND romfs_extra_files ${PX4_BINARY_DIR}/parameters.json.xz)
+		list(APPEND romfs_extra_dependencies parameters_xml)
+	endif()
 	list(APPEND romfs_extra_files ${PX4_BINARY_DIR}/component_general.json.xz)
 	list(APPEND romfs_extra_dependencies component_general_json)
 	set(config_romfs_extra_files ${romfs_extra_files} CACHE INTERNAL "extra ROMFS files" FORCE)

--- a/src/lib/component_information/CMakeLists.txt
+++ b/src/lib/component_information/CMakeLists.txt
@@ -37,12 +37,10 @@
 # 2: COMP_METADATA_TYPE_COMMANDS
 # 3: COMP_METADATA_TYPE_PERIPHERALS
 set(comp_metadata_types)
-# We disable parameter support if the metadata is not in the ROMFS. This can be
-# removed once it is stored on a server
-list(FIND config_romfs_extra_dependencies "parameters_xml" index)
 set(comp_metadata_board "${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_${PX4_BOARD_LABEL}")
 set(s3_url "https://px4-travis.s3.amazonaws.com")
 set(comp_metadata_param_uri_board "${s3_url}/Firmware/{version}/${comp_metadata_board}/parameters.json.xz")
+list(FIND config_romfs_extra_dependencies "parameters_xml" index)
 if (${index} EQUAL -1)
 	set(comp_metadata_param_uri ${comp_metadata_param_uri_board})
 	# use generic URL as fallback


### PR DESCRIPTION
Embed param metadata if not CONSTRAINED_FLASH. The compressed file is about 60KB.

@dagar do you want to create a separate test label for the boards that exceed the limit?
