### PR TITLE
Enable mixer error messages to avoid silent failure

### DIFF
--- a/src/lib/mixer/AllocatedActuatorMixer/AllocatedActuatorMixer.cpp
+++ b/src/lib/mixer/AllocatedActuatorMixer/AllocatedActuatorMixer.cpp
@@ -44,9 +44,11 @@
 #include <mathlib/mathlib.h>
 #include <cstdio>
 #include <px4_platform_common/defines.h>
+#include <px4_platform_common/log.h>
 
-// #define debug(fmt, args...)	do { } while(0)
-#define debug(fmt, args...)	do { printf("[mixer] " fmt "\n", ##args); } while(0)
+#ifndef MODULE_NAME
+#define MODULE_NAME "mixer"
+#endif
 
 AllocatedActuatorMixer::AllocatedActuatorMixer(ControlCallback control_cb,
 		uintptr_t cb_handle,
@@ -62,7 +64,7 @@ AllocatedActuatorMixer::AllocatedActuatorMixer(ControlCallback control_cb,
 		_control_index = index - 8;
 
 	} else {
-		debug("'A:' invalid index");
+		PX4_ERR("'A:' invalid index");
 	}
 }
 
@@ -90,14 +92,14 @@ AllocatedActuatorMixer::parse(const char *buf, unsigned &buflen, uint8_t &index)
 
 	// parse line
 	if ((ret = sscanf(buf, "A: %d", &i)) != 1) {
-		debug("'A:' parser: failed on '%s'", buf);
+		PX4_ERR("'A:' parser: failed on '%s'", buf);
 		return -1;
 	}
 
 	buf = skipline(buf, buflen);
 
 	if (buf == nullptr) {
-		debug("'A:' parser: no line ending, line is incomplete");
+		PX4_ERR("'A:' parser: no line ending, line is incomplete");
 		return -1;
 	}
 
@@ -106,7 +108,7 @@ AllocatedActuatorMixer::parse(const char *buf, unsigned &buflen, uint8_t &index)
 		index = i;
 
 	} else {
-		debug("'A:' parser: invalid index");
+		PX4_ERR("'A:' parser: invalid index");
 		return -1;
 	}
 

--- a/src/lib/mixer/HelicopterMixer/HelicopterMixer.cpp
+++ b/src/lib/mixer/HelicopterMixer/HelicopterMixer.cpp
@@ -42,11 +42,11 @@
 #include <mathlib/mathlib.h>
 #include <cstdio>
 #include <px4_platform_common/defines.h>
+#include <px4_platform_common/log.h>
 
-#define debug(fmt, args...)	do { } while(0)
-//#define debug(fmt, args...)	do { printf("[mixer] " fmt "\n", ##args); } while(0)
-//#include <debug.h>
-//#define debug(fmt, args...)	lowsyslog(fmt "\n", ##args)
+#ifndef MODULE_NAME
+#define MODULE_NAME "mixer"
+#endif
 
 using math::constrain;
 
@@ -71,37 +71,37 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	}
 
 	if (sscanf(buf, "H: %u%n", &swash_plate_servo_count, &used) != 1) {
-		debug("helicopter parse failed on '%s'", buf);
+		PX4_ERR("helicopter parse failed on '%s'", buf);
 		return nullptr;
 	}
 
 	if (swash_plate_servo_count < 3 || swash_plate_servo_count > 4) {
-		debug("only supporting swash plate with 3 or 4 servos");
+		PX4_ERR("only supporting swash plate with 3 or 4 servos");
 		return nullptr;
 	}
 
 	if (used > (int)buflen) {
-		debug("OVERFLOW: helicopter spec used %d of %u", used, buflen);
+		PX4_ERR("OVERFLOW: helicopter spec used %d of %u", used, buflen);
 		return nullptr;
 	}
 
 	buf = skipline(buf, buflen);
 
 	if (buf == nullptr) {
-		debug("no line ending, line is incomplete");
+		PX4_ERR("no line ending, line is incomplete");
 		return nullptr;
 	}
 
 	buf = findtag(buf, buflen, 'T');
 
 	if ((buf == nullptr) || (buflen < 12)) {
-		debug("control parser failed finding tag, ret: '%s'", buf);
+		PX4_ERR("control parser failed finding tag, ret: '%s'", buf);
 		return nullptr;
 	}
 
 	if (sscanf(buf, "T: %u %u %u %u %u",
 		   &u[0], &u[1], &u[2], &u[3], &u[4]) != 5) {
-		debug("control parse failed on '%s'", buf);
+		PX4_ERR("control parse failed on '%s'", buf);
 		return nullptr;
 	}
 
@@ -112,20 +112,20 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	buf = skipline(buf, buflen);
 
 	if (buf == nullptr) {
-		debug("no line ending, line is incomplete");
+		PX4_ERR("no line ending, line is incomplete");
 		return nullptr;
 	}
 
 	buf = findtag(buf, buflen, 'P');
 
 	if ((buf == nullptr) || (buflen < 12)) {
-		debug("control parser failed finding tag, ret: '%s'", buf);
+		PX4_ERR("control parser failed finding tag, ret: '%s'", buf);
 		return nullptr;
 	}
 
 	if (sscanf(buf, "P: %d %d %d %d %d",
 		   &s[0], &s[1], &s[2], &s[3], &s[4]) != 5) {
-		debug("control parse failed on '%s'", buf);
+		PX4_ERR("control parse failed on '%s'", buf);
 		return nullptr;
 	}
 
@@ -136,7 +136,7 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	buf = skipline(buf, buflen);
 
 	if (buf == nullptr) {
-		debug("no line ending, line is incomplete");
+		PX4_ERR("no line ending, line is incomplete");
 		return nullptr;
 	}
 
@@ -148,7 +148,7 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 		buf = findtag(buf, buflen, 'S');
 
 		if ((buf == nullptr) || (buflen < 12)) {
-			debug("control parser failed finding tag, ret: '%s'", buf);
+			PX4_ERR("control parser failed finding tag, ret: '%s'", buf);
 			return nullptr;
 		}
 
@@ -159,7 +159,7 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 			   &s[1],
 			   &s[2],
 			   &s[3]) != 6) {
-			debug("control parse failed on '%s'", buf);
+			PX4_ERR("control parse failed on '%s'", buf);
 			return nullptr;
 		}
 
@@ -173,20 +173,20 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 		buf = skipline(buf, buflen);
 
 		if (buf == nullptr) {
-			debug("no line ending, line is incomplete");
+			PX4_ERR("no line ending, line is incomplete");
 			return nullptr;
 		}
 	}
 
-	debug("remaining in buf: %d, first char: %c", buflen, buf[0]);
+	PX4_DEBUG("remaining in buf: %d, first char: %c", buflen, buf[0]);
 
 	HelicopterMixer *hm = new HelicopterMixer(control_cb, cb_handle, mixer_info);
 
 	if (hm != nullptr) {
-		debug("loaded heli mixer with %d swash plate input(s)", mixer_info.control_count);
+		PX4_INFO("loaded heli mixer with %d swash plate input(s)", mixer_info.control_count);
 
 	} else {
-		debug("could not allocate memory for mixer");
+		PX4_ERR("could not allocate memory for mixer");
 	}
 
 	return hm;

--- a/src/lib/mixer/MixerBase/Mixer.cpp
+++ b/src/lib/mixer/MixerBase/Mixer.cpp
@@ -42,9 +42,11 @@
 #include <math.h>
 #include <cstring>
 #include <ctype.h>
+#include <px4_platform_common/log.h>
 
-#define debug(fmt, args...)	do { } while(0)
-//#define debug(fmt, args...)	do { printf("[mixer] " fmt "\n", ##args); } while(0)
+#ifndef MODULE_NAME
+#define MODULE_NAME "mixer"
+#endif
 
 float
 Mixer::get_control(uint8_t group, uint8_t index)
@@ -118,7 +120,7 @@ Mixer::string_well_formed(const char *buf, unsigned &buflen)
 
 	}
 
-	debug("pre-parser rejected: No newline in buf");
+	PX4_ERR("pre-parser rejected: No newline in buf");
 
 	return false;
 }

--- a/src/lib/mixer/MixerGroup.cpp
+++ b/src/lib/mixer/MixerGroup.cpp
@@ -44,11 +44,11 @@
 #include "MultirotorMixer/MultirotorMixer.hpp"
 #include "NullMixer/NullMixer.hpp"
 #include "SimpleMixer/SimpleMixer.hpp"
+#include <px4_platform_common/log.h>
 
-#define debug(fmt, args...)	do { } while(0)
-//#define debug(fmt, args...)	do { printf("[mixer] " fmt "\n", ##args); } while(0)
-//#include <debug.h>
-//#define debug(fmt, args...)	syslog(fmt "\n", ##args)
+#ifndef MODULE_NAME
+#define MODULE_NAME "mixer"
+#endif
 
 unsigned
 MixerGroup::mix(float *outputs, unsigned space)
@@ -82,7 +82,7 @@ MixerGroup::set_trims(int16_t *values, unsigned n)
 		// to be safe, clamp offset to range of [-500, 500] usec
 		float offset = math::constrain((float)values[index] / 10000, -1.0f, 1.0f);
 
-		debug("set trim: %d, offset: %5.3f", values[index], (double)offset);
+		PX4_DEBUG("set trim: %d, offset: %5.3f", values[index], (double)offset);
 		index += mixer->set_trim(offset);
 
 		if (index >= n) {
@@ -226,7 +226,7 @@ MixerGroup::load_from_buf(Mixer::ControlCallback control_cb, uintptr_t cb_handle
 
 			/* only adjust buflen if parsing was successful */
 			buflen = resid;
-			debug("SUCCESS - buflen: %d", buflen);
+			PX4_DEBUG("SUCCESS - buflen: %d", buflen);
 
 		} else {
 

--- a/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
+++ b/src/lib/mixer/MultirotorMixer/MultirotorMixer.cpp
@@ -44,6 +44,11 @@
 #include <cstdio>
 
 #include <mathlib/mathlib.h>
+#include <px4_platform_common/log.h>
+
+#ifndef MODULE_NAME
+#define MODULE_NAME "mixer"
+#endif
 
 #ifdef MIXER_MULTIROTOR_USE_MOCK_GEOMETRY
 enum class MultirotorGeometry : MultirotorGeometryUnderlyingType {
@@ -72,12 +77,6 @@ const char *_config_key[] = {"4x"};
 #include "mixer_multirotor_normalized.generated.h"
 
 #endif /* MIXER_MULTIROTOR_USE_MOCK_GEOMETRY */
-
-
-#define debug(fmt, args...)	do { } while(0)
-//#define debug(fmt, args...)	do { printf("[mixer] " fmt "\n", ##args); } while(0)
-//#include <debug.h>
-//#define debug(fmt, args...)	syslog(fmt "\n", ##args)
 
 MultirotorMixer::MultirotorMixer(ControlCallback control_cb, uintptr_t cb_handle, MultirotorGeometry geometry) :
 	MultirotorMixer(control_cb, cb_handle, _config_index[(int)geometry], _config_rotor_count[(int)geometry])
@@ -115,18 +114,18 @@ MultirotorMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	}
 
 	if (sscanf(buf, "R: %15s", geomname) != 1) {
-		debug("multirotor parse failed on '%s'", buf);
+		PX4_ERR("multirotor parse failed on '%s'", buf);
 		return nullptr;
 	}
 
 	buf = skipline(buf, buflen);
 
 	if (buf == nullptr) {
-		debug("no line ending, line is incomplete");
+		PX4_ERR("no line ending, line is incomplete");
 		return nullptr;
 	}
 
-	debug("remaining in buf: %d, first char: %c", buflen, buf[0]);
+	PX4_DEBUG("remaining in buf: %d, first char: %c", buflen, buf[0]);
 
 	for (MultirotorGeometryUnderlyingType i = 0; i < (MultirotorGeometryUnderlyingType)MultirotorGeometry::MAX_GEOMETRY;
 	     i++) {
@@ -137,11 +136,11 @@ MultirotorMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	}
 
 	if (geometry == MultirotorGeometry::MAX_GEOMETRY) {
-		debug("unrecognised geometry '%s'", geomname);
+		PX4_ERR("unrecognised geometry '%s'", geomname);
 		return nullptr;
 	}
 
-	debug("adding multirotor mixer '%s'", geomname);
+	PX4_DEBUG("adding multirotor mixer '%s'", geomname);
 
 	return new MultirotorMixer(control_cb, cb_handle, geometry);
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
I spent quite some time debugging and help debugging mixer loading errors and the error message in `dmesg` is usually `failed to load mixer` or `failed to load mixers from ...` which tells you why the motors aren't working but not what the cause for the failure could be. I discovered the parser already handles and reports different kind of errors but we just mute them. Even though it's a waste to add so many duplicate strings I consider it still better than having people spend hours trying to test all possibilities it could have failed when the error could literally tell you and the fix and clean build takes 3 minutes.

**Describe your solution**
Enable mixer error output for non flash constrained boards.

**Describe possible alternatives**
Depending on the amount of time we'll still use the static mixer infrastructure it might be worth to improve and flash optimize the error reports but I'd rather have them in the way they already exist than just muting the feedback.

**Test data / coverage**
We used this method to quickly find a multicopter mixer issue yesterday but didn't test all possible combinations of mixer errors if they show correctly.
