### PR TITLE
Assorted fixes for the 1.12 release

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -111,5 +111,6 @@ set MAV_TYPE 22
 set MIXER babyshark
 set MIXER_AUX pass
 
+# Mark outputs for the alternate rate
+# or D-Shot
 set PWM_OUT 5678
-set PWM_AUX_OUT 1234

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -159,6 +159,10 @@ public:
 
 	int		set_mode(Mode mode);
 	Mode		get_mode() { return _mode; }
+	uint32_t	get_pwm_mask() { return _pwm_mask; }
+	uint32_t	get_alt_rate_channels() { return _pwm_alt_rate_channels; }
+	unsigned	get_alt_rate() { return _pwm_alt_rate; }
+	unsigned	get_default_rate() { return _pwm_default_rate; }
 	void		request_mode(Mode new_mode);
 
 	static int	set_i2c_bus_clock(unsigned bus, unsigned clock_hz);


### PR DESCRIPTION
These fixes are in no particular order, but are all sensitive for the release. Expected additions:

- Checking if we can make the safety switch non-latching (might require the PX4 IO changes - again)
- Set up home location for RTL with relaxed constraints