### PR TITLE
Factor in stricter tilt limit during takeoff for acceleration setpoint feasibility check

### DIFF
--- a/msg/takeoff_status.msg
+++ b/msg/takeoff_status.msg
@@ -10,3 +10,5 @@ uint8 TAKEOFF_STATE_RAMPUP            = 4
 uint8 TAKEOFF_STATE_FLIGHT            = 5
 
 uint8 takeoff_state
+
+float32 tilt_limit # limited tilt feasability during takeoff, contains maximum tilt otherwise

--- a/src/lib/slew_rate/SlewRate.hpp
+++ b/src/lib/slew_rate/SlewRate.hpp
@@ -64,6 +64,12 @@ public:
 	void setForcedValue(const Type value) { _value = value; }
 
 	/**
+	 * Get value from last update of the slew rate
+	 * @return current value the slew rate is at
+	 */
+	Type getState() const { return _value; }
+
+	/**
 	 * Update slewrate
 	 * @param new_value desired new value
 	 * @param deltatime time in seconds since last update

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -239,8 +239,8 @@ protected:
 	 * Setpoints that are set to NAN are not controlled. Not all setpoints can be set at the same time.
 	 * If more than one type of setpoint is set, then order of control is a as follow: position, velocity,
 	 * acceleration, thrust. The exception is _position_setpoint together with _velocity_setpoint, where the
-	 * _velocity_setpoint is used as feedforward.
-	 * _acceleration_setpoint and _jerk_setpoint are currently not supported.
+	 * _velocity_setpoint and _acceleration_setpoint are used as feedforward.
+	 * _jerk_setpoint does not executed but just serves as internal state.
 	 */
 	matrix::Vector3f _position_setpoint;
 	matrix::Vector3f _velocity_setpoint;

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -72,7 +72,7 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 	Vector2f acceleration_scale(_param_mpc_acc_hor.get(), _param_mpc_acc_hor.get());
 	Vector2f velocity_scale(_param_mpc_vel_manual.get(), _param_mpc_vel_manual.get());
 
-	acceleration_scale *= 2.f; // because of drag the average aceleration is half
+	acceleration_scale *= 2.f; // because of drag the average acceleration is half
 
 	// Map stick input to acceleration
 	Sticks::limitStickUnitLengthXY(stick_xy);
@@ -144,9 +144,13 @@ Vector2f StickAccelerationXY::calculateDrag(Vector2f drag_coefficient, const flo
 
 void StickAccelerationXY::applyTiltLimit(Vector2f &acceleration)
 {
+	// fetch the tilt limit which is lower than the maximum during takeoff
+	takeoff_status_s takeoff_status{};
+	_takeoff_status_sub.copy(&takeoff_status);
+
 	// Check if acceleration would exceed the tilt limit
 	const float acc = acceleration.length();
-	const float acc_tilt_max = tanf(M_DEG_TO_RAD_F * _param_mpc_tiltmax_air.get()) * CONSTANTS_ONE_G;
+	const float acc_tilt_max = tanf(takeoff_status.tilt_limit) * CONSTANTS_ONE_G;
 
 	if (acc > acc_tilt_max) {
 		acceleration *= acc_tilt_max / acc;

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -40,9 +40,10 @@
 #pragma once
 
 #include <px4_platform_common/module_params.h>
-#include <float.h> // TODO add this include to AlphaFilter since it's used there
 #include <lib/ecl/AlphaFilter/AlphaFilter.hpp>
 #include <matrix/math.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/takeoff_status.h>
 
 #include "SlewRate.hpp"
 
@@ -65,6 +66,8 @@ private:
 				       const matrix::Vector2f &vel_sp);
 	void applyTiltLimit(matrix::Vector2f &acceleration);
 	void lockPosition(const matrix::Vector3f &pos, const matrix::Vector2f &vel_sp_feedback, const float dt);
+
+	uORB::Subscription _takeoff_status_sub{ORB_ID(takeoff_status)};
 
 	SlewRate<float> _acceleration_slew_rate_x;
 	SlewRate<float> _acceleration_slew_rate_y;

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -349,7 +349,6 @@ float MulticopterLandDetector::_get_gnd_effect_altitude()
 
 bool MulticopterLandDetector::_get_ground_effect_state()
 {
-
 	return (_in_descend && !_horizontal_movement) ||
 	       (_below_gnd_effect_hgt && _takeoff_state == takeoff_status_s::TAKEOFF_STATE_FLIGHT) ||
 	       _takeoff_state == takeoff_status_s::TAKEOFF_STATE_RAMPUP;

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -461,13 +461,12 @@ void MulticopterPositionControl::Run()
 		// Publish takeoff status
 		const uint8_t takeoff_state = static_cast<uint8_t>(_takeoff.getTakeoffState());
 
-		if (takeoff_state != _old_takeoff_state) {
-			takeoff_status_s takeoff_status{};
-			takeoff_status.takeoff_state = takeoff_state;
-			takeoff_status.timestamp = hrt_absolute_time();
-			_takeoff_status_pub.publish(takeoff_status);
-
-			_old_takeoff_state = takeoff_state;
+		if (takeoff_state != _takeoff_status_pub.get().takeoff_state
+		    || !isEqualF(_tilt_limit_slew_rate.getState(), _takeoff_status_pub.get().tilt_limit)) {
+			_takeoff_status_pub.get().takeoff_state = takeoff_state;
+			_takeoff_status_pub.get().tilt_limit = _tilt_limit_slew_rate.getState();
+			_takeoff_status_pub.get().timestamp = hrt_absolute_time();
+			_takeoff_status_pub.update();
 		}
 
 		// save latest reset counters

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -92,7 +92,7 @@ private:
 
 	orb_advert_t _mavlink_log_pub{nullptr};
 
-	uORB::Publication<takeoff_status_s> _takeoff_status_pub{ORB_ID(takeoff_status)};
+	uORB::PublicationData<takeoff_status_s> _takeoff_status_pub{ORB_ID(takeoff_status)};
 	uORB::Publication<vehicle_attitude_setpoint_s>	_vehicle_attitude_setpoint_pub;
 	uORB::Publication<vehicle_local_position_setpoint_s> _local_pos_sp_pub{ORB_ID(vehicle_local_position_setpoint)};	/**< vehicle local position setpoint publication */
 
@@ -199,8 +199,6 @@ private:
 
 	systemlib::Hysteresis _failsafe_land_hysteresis{false}; /**< becomes true if task did not update correctly for LOITER_TIME_BEFORE_DESCEND */
 	SlewRate<float> _tilt_limit_slew_rate;
-
-	uint8_t _old_takeoff_state{};
 
 	uint8_t _vxy_reset_counter{0};
 	uint8_t _vz_reset_counter{0};


### PR DESCRIPTION
**Describe problem solved by this pull request**
The acceleration stick mapping checks for setpoint feasibility given the tilt limit. But the tilt is more strictly constrained just during takeoff to ensure the vehicle cannot tip over when leaving the ground. So we got the report that if you go full up full forward input directly off the ground the setpoints are actually unfeasible because of the stricter limit. This results in sluggish bounce back after takeoff because the velocity setpoint is already higher than what was actually achievable.

This issue was there before but got more obvious through the smooth ramp off from the stricter tilt limit:
https://github.com/PX4/PX4-Autopilot/pull/17066

Note: Integrating the velocity setpoint is necessary to allow for straight fast forward flight without drift. That was already found quite early in development: https://github.com/PX4/PX4-Autopilot/pull/16052/files#diff-b38bc7b91169ede6eaadc5a46f8f8f80365dd92ede68bfbba8f349553eb142d3R89

**Describe your solution**
I made the stricter limit during takeoff part of the takeoff state and it only gets updated during that time. This ensures the log is not spammed with unnecessary information but allows the stick mapping to not build up a velocity setpoint even though the acceleration was not feasible.

During my work I found some small improvements:
- obsolete include: https://github.com/PX4/PX4-Autopilot/commit/4350b8a72be28c339782eae7c1afe23bfe6ad65f#diff-ff297129cc9130d5ee5cdbd7dbb11e95f9eea943a19a25b439ed836c380e7b2dL43
- unnecessary newline: https://github.com/PX4/PX4-Autopilot/commit/f3e13c5788e91aa48ee1e7ed3687eb423d74f9e5
- outdated setpoint comment: https://github.com/PX4/PX4-Autopilot/commit/d2dd1340579646b2a669a0c217cf36694084281f (Thanks to @potaito for pointing this one out)

**Describe possible alternatives**
I looked into publishing a general position control status which we want to have anyways. It could report the controller is running over the tilt limit but reacting to that in the right way is much harder than. And constantly publishing the tilt limit which is a constant value except for the short time period during takeoff is just a waste.

**Test data / coverage**
I successfully tested this in SITL and to make it more obvious I made the tilt limit on takeoff overly strict.

Before:
![image-20210412-170852](https://user-images.githubusercontent.com/4668506/114583339-c84aed80-9c81-11eb-90f9-0990742fc0a4.png)

After:
![image](https://user-images.githubusercontent.com/4668506/114583295-bf5a1c00-9c81-11eb-9602-d9505558e47d.png)

