### PR TITLE
Create publish_status() method in the heater driver and add a status field to indicate if the temperature setpoint has been met within 2.5C.

### DIFF
--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -25,7 +25,7 @@ px4_add_board(
 		distance_sensor # all available distance sensor drivers
 		dshot
 		gps
-		#heater
+		heater
 		#imu # all available imu drivers
 		imu/analog_devices/adis16448
 		imu/bosch/bmi055

--- a/msg/heater_status.msg
+++ b/msg/heater_status.msg
@@ -3,6 +3,7 @@ uint64 timestamp	# time since system start (microseconds)
 uint32 device_id
 
 bool heater_on
+bool temperature_target_met
 
 float32 temperature_sensor
 float32 temperature_target

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -57,7 +57,8 @@
 
 using namespace time_literals;
 
-#define CONTROLLER_PERIOD_DEFAULT 100000
+#define CONTROLLER_PERIOD_DEFAULT    10000
+#define TEMPERATURE_TARGET_THRESHOLD 2.5f
 
 class Heater : public ModuleBase<Heater>, public ModuleParams, public px4::ScheduledWorkItem
 {
@@ -101,8 +102,24 @@ public:
 
 private:
 
+	/** Disables the heater (either by GPIO or PX4IO). */
+	void disable_heater();
+
+	/** Turns the heater on (either by GPIO or PX4IO). */
+	void heater_on();
+
+	/** Turns the heater off (either by GPIO or PX4IO). */
+	void heater_off();
+
+	void initialize();
+
+	/** Enables / configures the heater (either by GPIO or PX4IO). */
+	void initialize_heater_io();
+
 	/** @brief Called once to initialize uORB topics. */
 	bool initialize_topics();
+
+	void publish_status();
 
 	/** @brief Calculates the heater element on/off time and schedules the next cycle. */
 	void Run() override;
@@ -113,18 +130,6 @@ private:
 	 */
 	void update_params(const bool force = false);
 
-	/** Enables / configures the heater (either by GPIO or PX4IO). */
-	void heater_initialize();
-
-	/** Disnables the heater (either by GPIO or PX4IO). */
-	void heater_disable();
-
-	/** Turns the heater on (either by GPIO or PX4IO). */
-	void heater_on();
-
-	/** Turns the heater off (either by GPIO or PX4IO). */
-	void heater_off();
-
 	/** Work queue struct for the scheduler. */
 	static struct work_s _work;
 
@@ -133,7 +138,9 @@ private:
 	int _io_fd {-1};
 #endif
 
-	bool _heater_on = false;
+	bool _heater_initialized     = false;
+	bool _heater_on              = false;
+	bool _temperature_target_met = false;
 
 	int _controller_period_usec = CONTROLLER_PERIOD_DEFAULT;
 	int _controller_time_on_usec = 0;
@@ -155,7 +162,7 @@ private:
 		(ParamFloat<px4::params::SENS_IMU_TEMP_FF>) _param_sens_imu_temp_ff,
 		(ParamFloat<px4::params::SENS_IMU_TEMP_I>)  _param_sens_imu_temp_i,
 		(ParamFloat<px4::params::SENS_IMU_TEMP_P>)  _param_sens_imu_temp_p,
-		(ParamInt<px4::params::SENS_TEMP_ID>)       _param_sens_temp_id,
-		(ParamFloat<px4::params::SENS_IMU_TEMP>)    _param_sens_imu_temp
+		(ParamFloat<px4::params::SENS_IMU_TEMP>)    _param_sens_imu_temp,
+		(ParamInt<px4::params::SENS_TEMP_ID>)       _param_sens_temp_id
 	)
 };


### PR DESCRIPTION
Hello,

**Describe problem solved by this pull request**
This PR performs a minor bit of refactoring and adds a status field to the heater_status message to indicate if the temperature setpoint has been achieved within 2.5C.  It also decreases the default heater temperature setpoint to be valid for a wider range of hardware and increases the driver scheduling frequency to reduce potential influence on magnetometers. 

**Test data / coverage**
Flight tested on a CubeBlack after resetting the setpoint on the bench from 55C to 35C.  I will post another log from cold shortly.
https://review.px4.io/plot_app?log=3b68e434-421c-4072-8d5d-5385f524fee9

![image](https://user-images.githubusercontent.com/2497951/114605641-84db8980-9c57-11eb-8b62-928611f01f06.png)


Let me know if you have any questions or would like more information regarding this PR. Thanks!

-Mark
