### PR TITLE
IMU_GYRO_RATEMAX: enforce reasonable constraint

### DIFF
--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -48,7 +48,7 @@ public:
 
 	uint32_t get_device_id() const { return _device_id; }
 
-	int32_t get_max_rate_hz() const { return _imu_gyro_rate_max; }
+	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, 100, 4000); }
 
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -48,7 +48,7 @@ public:
 
 	uint32_t get_device_id() const { return _device_id; }
 
-	int32_t get_max_rate_hz() const { return _imu_gyro_rate_max; }
+	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, 100, 4000); }
 
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);

--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -83,14 +83,15 @@ PARAM_DEFINE_FLOAT(IMU_GYRO_NF_BW, 20.0f);
 PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
 
 /**
-* Gyro control data maximum publication rate
+* Gyro control data maximum publication rate (inner loop rate)
 *
-* This is the maximum rate the gyro control data (sensor_gyro) will be allowed to publish at.
-* Set to 0 to disable and publish at the native sensor sample rate.
+* The maximum rate the gyro control data (vehicle_angular_velocity) will be
+* allowed to publish at. This is the loop rate for the rate controller and outputs.
 *
-* @min 0
+* Note: sensor data is always read and filtered at the full raw rate (eg commonly 8 kHz) regardless of this setting.
+*
+* @min 100
 * @max 2000
-* @value 0 0 (driver minimum)
 * @value 100 100 Hz
 * @value 250 250 Hz
 * @value 400 400 Hz


### PR DESCRIPTION
If `IMU_GYRO_RATEMAX` is set to 0 (previous default that meant use per sensor default) some sensors will now run too slow for ekf2, which would then start complaining about missing magnetometer data.