### PR TITLE
Changed message "connection to GCS lost"  from critical to info

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3533,7 +3533,7 @@ void Commander::data_link_check()
 			_status.data_link_lost = true;
 			_status.data_link_lost_counter++;
 
-			mavlink_log_critical(&_mavlink_log_pub, "Connection to ground station lost");
+			mavlink_log_info(&_mavlink_log_pub, "Connection to ground station lost");
 
 			_status_changed = true;
 		}


### PR DESCRIPTION
**Describe problem solved by this pull request**
When QGC lose connection to FMU next time when connected to FMU user will see the message:
_"Connection to ground station lost"_ 
This can confuse users. 

**Describe your solution**
The solution is using **info** signaling instead of **critical**.
