### PR TITLE
land_detector: robustify land detection by using distance to ground info

### DIFF
--- a/src/modules/land_detector/AirshipLandDetector.h
+++ b/src/modules/land_detector/AirshipLandDetector.h
@@ -54,6 +54,7 @@ public:
 protected:
 	bool _get_ground_contact_state() override;
 	bool _get_landed_state() override;
+	void _set_hysteresis_factor(const int factor) override {};
 
 };
 

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -61,6 +61,7 @@ public:
 protected:
 
 	bool _get_landed_state() override;
+	void _set_hysteresis_factor(const int factor) override {};
 
 private:
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -96,6 +96,22 @@ void LandDetector::Run()
 
 	_update_topics();
 
+	if (!_dist_bottom_is_observable) {
+		// we consider the distance to the ground observable if the system is using a range sensor
+		_dist_bottom_is_observable = _vehicle_local_position.dist_bottom_sensor_bitfield &
+					     vehicle_local_position_s::DIST_BOTTOM_SENSOR_RANGE;
+
+	} else {
+		if (!_high_hysteresis_active && !_vehicle_local_position.dist_bottom_valid) {
+			_set_hysteresis_factor(3);
+			_high_hysteresis_active = true;
+
+		} else if (_high_hysteresis_active && _vehicle_local_position.dist_bottom_valid) {
+			_set_hysteresis_factor(1);
+			_high_hysteresis_active = false;
+		}
+	}
+
 	const hrt_abstime now_us = hrt_absolute_time();
 
 	_freefall_hysteresis.set_state_and_update(_get_freefall_state(), now_us);

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -136,6 +136,8 @@ protected:
 	 */
 	virtual bool _get_ground_effect_state() { return false; }
 
+	virtual void _set_hysteresis_factor(const int factor) = 0;
+
 	systemlib::Hysteresis _freefall_hysteresis{false};
 	systemlib::Hysteresis _landed_hysteresis{true};
 	systemlib::Hysteresis _maybe_landed_hysteresis{true};
@@ -149,6 +151,7 @@ protected:
 
 	bool _armed{false};
 	bool _previous_armed_state{false};	///< stores the previous actuator_armed.armed state
+	bool _dist_bottom_is_observable{false};
 
 private:
 	void Run() override;
@@ -164,6 +167,8 @@ private:
 
 	hrt_abstime _takeoff_time{0};
 	hrt_abstime _total_flight_time{0};	///< total vehicle flight time in microseconds
+
+	bool _high_hysteresis_active{false};
 
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -73,9 +73,12 @@ protected:
 	bool _get_ground_effect_state() override;
 
 	float _get_max_altitude() override;
+
+	void _set_hysteresis_factor(const int factor) override;
 private:
 
 	float _get_gnd_effect_altitude();
+	bool _is_close_to_ground();
 
 	/** Time in us that freefall has to hold before triggering freefall */
 	static constexpr hrt_abstime FREEFALL_TRIGGER_TIME_US = 300_ms;
@@ -91,6 +94,9 @@ private:
 
 	/** Time interval in us in which wider acceptance thresholds are used after landed. */
 	static constexpr hrt_abstime LAND_DETECTOR_LAND_PHASE_TIME_US = 2_s;
+
+	/** Distance above ground below which entering ground contact state is possible when distance to ground is available. */
+	static constexpr float DIST_FROM_GROUND_THRESHOLD = 1.0f;
 
 	/** Handles for interesting parameters. **/
 	struct {

--- a/src/modules/land_detector/RoverLandDetector.h
+++ b/src/modules/land_detector/RoverLandDetector.h
@@ -55,6 +55,7 @@ public:
 protected:
 	bool _get_ground_contact_state() override;
 	bool _get_landed_state() override;
+	void _set_hysteresis_factor(const int factor) override {};
 
 };
 


### PR DESCRIPTION
False ground-contact detection can happen with multi rotors during a maneuver where the vehicle decelerates horizontally while the user is demanding a sink rate. In this case the vehicle can "float" for a certain amount of time which can be registered as ground-contact by the land detector.
If the vehicle is equipped with a distance sensor we can make use of that data to increase the hysteresis used for the land detection states.
If the system knows that it can measure distance to the ground and the distance is greater than 1m, then the hysteresis values will be increased by a factor of 3 and thus should drastically reduce the chances of false ground contact detection.
Notice that the distance measurement itself is only used to determine the value of the hysteresis, however, it will not be used directly for making the ground contact decision.
In other words, a distance sensor reporting false data will either cause ground contact detection to be delayed (in case it reports > 1m) or it will cause the usual hysteresis values to be used (in case it reports < 1m). But you should never get a false positive ground detection due to a faulty lidar, which is important.

Also note, that these changes should have no impact on systems which don't have a distance to ground measurement available.
