### PR TITLE
ROMFS: reduce LOGGER_BUF default to 8 kB on older boards

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -30,7 +30,7 @@ set FRC /fs/microsd/etc/rc.txt
 set IOFW "/etc/extras/px4_io-v2_default.bin"
 set IO_PRESENT no
 set LOGGER_ARGS ""
-set LOGGER_BUF  14
+set LOGGER_BUF 8
 set MAV_TYPE none
 set MIXER none
 set MIXER_AUX none

--- a/platforms/nuttx/init/kinetis/rc.board_arch_defaults
+++ b/platforms/nuttx/init/kinetis/rc.board_arch_defaults
@@ -9,7 +9,7 @@ param set-default SENS_IMU_MODE 1
 param set-default EKF2_MULTI_MAG 0
 param set-default SENS_MAG_MODE 1
 
-set LOGGER_BUF 12
+set LOGGER_BUF 8
 
 if param greater -s UAVCAN_ENABLE 1
 then

--- a/platforms/nuttx/init/s32k1xx/rc.board_arch_defaults
+++ b/platforms/nuttx/init/s32k1xx/rc.board_arch_defaults
@@ -3,7 +3,7 @@
 # S32K1XX specific defaults
 #------------------------------------------------------------------------------
 
-set LOGGER_BUF 12
+set LOGGER_BUF 8
 
 if param greater -s UAVCAN_ENABLE 1
 then

--- a/platforms/nuttx/init/stm32/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32/rc.board_arch_defaults
@@ -9,7 +9,7 @@ param set-default SENS_IMU_MODE 1
 param set-default EKF2_MULTI_MAG 0
 param set-default SENS_MAG_MODE 1
 
-set LOGGER_BUF 12
+set LOGGER_BUF 8
 
 if param greater -s UAVCAN_ENABLE 1
 then


### PR DESCRIPTION
Some of the older boards (eg cortex m4) are getting pretty tight on memory outside of the base system (extra mavlink, vmount, etc). Since estimator replay is no longer on by default I think it would be more conservative on these boards, saving memory for actual usage, rather than perfect logging.

In the future we can make `LOGGER_BUF` a parameter if this is a problem.