### PR TITLE
Get rtps baud rate as parameter with p: prefix 

### DIFF
--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -96,7 +96,21 @@ static int parse_options(int argc, char *argv[])
 
 		case 'w': _options.sleep_ms        = strtoul(myoptarg, nullptr, 10);    break;
 
-		case 'b': _options.baudrate        = strtoul(myoptarg, nullptr, 10);    break;
+		case 'b':
+		{
+			int baudrate = 0;
+			if (px4_get_parameter_value(myoptarg, baudrate) != 0) {
+				PX4_ERR("baudrate parsing failed");
+			}
+
+			if (baudrate < 9600 || baudrate > 3000000) {
+				PX4_ERR("invalid baud rate '%s'", myoptarg);
+			}
+
+			_options.baudrate = baudrate;
+
+			break;
+		}
 
 		case 'r': _options.recv_port       = strtoul(myoptarg, nullptr, 10);    break;
 

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -96,21 +96,21 @@ static int parse_options(int argc, char *argv[])
 
 		case 'w': _options.sleep_ms        = strtoul(myoptarg, nullptr, 10);    break;
 
-		case 'b':
-		{
-			int baudrate = 0;
-			if (px4_get_parameter_value(myoptarg, baudrate) != 0) {
-				PX4_ERR("baudrate parsing failed");
+		case 'b': {
+				int baudrate = 0;
+
+				if (px4_get_parameter_value(myoptarg, baudrate) != 0) {
+					PX4_ERR("baudrate parsing failed");
+				}
+
+				if (baudrate < 9600 || baudrate > 3000000) {
+					PX4_ERR("invalid baud rate '%s'", myoptarg);
+				}
+
+				_options.baudrate = baudrate;
+
+				break;
 			}
-
-			if (baudrate < 9600 || baudrate > 3000000) {
-				PX4_ERR("invalid baud rate '%s'", myoptarg);
-			}
-
-			_options.baudrate = baudrate;
-
-			break;
-		}
 
 		case 'r': _options.recv_port       = strtoul(myoptarg, nullptr, 10);    break;
 

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -103,10 +103,6 @@ static int parse_options(int argc, char *argv[])
 					PX4_ERR("baudrate parsing failed");
 				}
 
-				if (baudrate < 9600 || baudrate > 3000000) {
-					PX4_ERR("invalid baud rate '%s'", myoptarg);
-				}
-
 				_options.baudrate = baudrate;
 
 				break;


### PR DESCRIPTION
Fixes issue #17398 

**Describe your solution**
Use px4_get_parameter_value for the baud rate in microRTPS_client_main.cpp to fix this line in rtps_client module.yaml 
[`micrortps_client start -d ${SERIAL_DEV} -b p:${BAUD_PARAM} -l -1`](https://github.com/PX4/PX4-Autopilot/blob/96c7fe4978bab2af970a097f4898e024c2d33440/src/modules/micrortps_bridge/micrortps_client/module.yaml#L12)

**Describe possible alternatives**
This should be cleaned up to match how mavlink does parameter parsing, however the _options structure members can't easily be passed to px4_get_parameter_value. For this reason I suggest removing the _options structure completely and use local members as mavlink does.

**Test data / coverage**
Tested on modalai_fc-v1 by setting MAV_0_CONFIG to disabled and RTPS_CONFIG to TELEM1. Then after rebooting, the rtps_client start correctly as shown from the debug system console
`INFO  [micrortps_client] UART transport: device: /dev/ttyS6; baudrate: 57600; sleep: 1ms; poll: 1ms; flow_control: No`

Before this fix, the baudrate would always be set to 0 since the parameter wasn't queried.

