### PR TITLE
sensors/vehicle_angular_velocity: filter reset on scale change fixes

### DIFF
--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -93,6 +93,22 @@ void PX4Accelerometer::set_device_type(uint8_t devtype)
 	_device_id = device_id.devid;
 }
 
+void PX4Accelerometer::set_scale(float scale)
+{
+	if (fabsf(scale - _scale) > FLT_EPSILON) {
+		// rescale last sample on scale change
+		float rescale = _scale / scale;
+
+		for (auto &s : _last_sample) {
+			s = roundf(s * rescale);
+		}
+
+		_scale = scale;
+
+		UpdateClipLimit();
+	}
+}
+
 void PX4Accelerometer::update(const hrt_abstime &timestamp_sample, float x, float y, float z)
 {
 	// Apply rotation (before scaling)

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -55,7 +55,7 @@ public:
 	void set_error_count(uint32_t error_count) { _error_count = error_count; }
 	void increase_error_count() { _error_count++; }
 	void set_range(float range) { _range = range; UpdateClipLimit(); }
-	void set_scale(float scale) { _scale = scale; UpdateClipLimit(); }
+	void set_scale(float scale);
 	void set_temperature(float temperature) { _temperature = temperature; }
 
 	void update(const hrt_abstime &timestamp_sample, float x, float y, float z);

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
@@ -80,6 +80,20 @@ void PX4Gyroscope::set_device_type(uint8_t devtype)
 	_device_id = device_id.devid;
 }
 
+void PX4Gyroscope::set_scale(float scale)
+{
+	if (fabsf(scale - _scale) > FLT_EPSILON) {
+		// rescale last sample on scale change
+		float rescale = _scale / scale;
+
+		for (auto &s : _last_sample) {
+			s = roundf(s * rescale);
+		}
+
+		_scale = scale;
+	}
+}
+
 void PX4Gyroscope::update(const hrt_abstime &timestamp_sample, float x, float y, float z)
 {
 	// Apply rotation (before scaling)

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -55,7 +55,7 @@ public:
 	void set_error_count(uint32_t error_count) { _error_count = error_count; }
 	void increase_error_count() { _error_count++; }
 	void set_range(float range) { _range = range; }
-	void set_scale(float scale) { _scale = scale; }
+	void set_scale(float scale);
 	void set_temperature(float temperature) { _temperature = temperature; }
 
 	void update(const hrt_abstime &timestamp_sample, float x, float y, float z);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -75,26 +75,26 @@ public:
 private:
 	void Run() override;
 
-	void CalibrateAndPublish(const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity,
+	void CalibrateAndPublish(bool publish, const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity,
 				 const matrix::Vector3f &angular_acceleration, float scale = 1.f);
 
-	float FilterAngularVelocity(int axis, float data[], int N);
-	float FilterAngularAcceleration(int axis, float data[], int N, float dt_s);
+	float FilterAngularVelocity(int axis, float data[], int N = 1);
+	float FilterAngularAcceleration(int axis, float dt_s, float data[], int N = 1);
 
 	void DisableDynamicNotchEscRpm();
 	void DisableDynamicNotchFFT();
 	void ParametersUpdate(bool force = false);
 
-	void ResetFilters();
+	void ResetFilters(float new_scale = 1.f);
 	void SensorBiasUpdate(bool force = false);
 	bool SensorSelectionUpdate(bool force = false);
-	void UpdateDynamicNotchEscRpm(bool force = false);
-	void UpdateDynamicNotchFFT(bool force = false);
+	void UpdateDynamicNotchEscRpm(float new_scale = 1.f, bool force = false);
+	void UpdateDynamicNotchFFT(float new_scale = 1.f, bool force = false);
 	bool UpdateSampleRate();
 
 	// scaled appropriately for current FIFO mode
-	matrix::Vector3f GetResetAngularVelocity() const;
-	matrix::Vector3f GetResetAngularAcceleration() const;
+	matrix::Vector3f GetResetAngularVelocity(float new_scale = 1.f) const;
+	matrix::Vector3f GetResetAngularAcceleration(float new_scale = 1.f) const;
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
@@ -127,7 +127,7 @@ private:
 	hrt_abstime _publish_interval_min_us{0};
 	hrt_abstime _last_publish{0};
 
-	float _filter_sample_rate_hz{0.f};
+	float _filter_sample_rate_hz{NAN};
 
 	static constexpr const float kInitialRateHz{1000.f}; /**< sensor update rate used for initialization */
 


### PR DESCRIPTION
Work in progress fixes for the gyro control data pipeline needed for when the scale factor (FIFO data) changes.

For the sake of efficiency (at 8 kHz) all filtering is performed on the raw data before the calibration and rotation is applied to only the last output. As a result we have to be a bit more careful when switching between sensors or in cases where the gyro scale factor changes (eg icm42688p 20 bit data).