### PR TITLE
commander_params: lower COM_DISARM_PRFLT but disable for fixed-wing

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -16,6 +16,8 @@ param set-default COM_POS_FS_EPV 30
 param set-default COM_POS_FS_GAIN 0
 param set-default COM_POS_FS_PROB 1
 param set-default COM_VEL_FS_EVH 5
+# Disable preflight disarm to not interfere with external launching
+param set-default COM_DISARM_PRFLT -1
 
 param set-default EKF2_ARSP_THR 8
 param set-default EKF2_FUSE_BETA 1

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -287,21 +287,19 @@ PARAM_DEFINE_INT32(COM_RC_ARM_HYST, 1000);
 PARAM_DEFINE_FLOAT(COM_DISARM_LAND, 2.0f);
 
 /**
- * Time-out for auto disarm if too slow to takeoff
+ * Time-out for auto disarm if not taking off
  *
- * A non-zero, positive value specifies the time after arming, in seconds, within which the
- * vehicle must take off (after which it will automatically disarm).
+ * A non-zero, positive value specifies the time in seconds, within which the
+ * vehicle is expected to take off after arming. In case the vehicle didn't takeoff
+ * within the timout it disamrs again.
  *
- * This is set to 25 seconds to ensure a system will not disarm if the pilot is not immediately
- * taking off, but not so long that a system is completely forgotten about.
- *
- * A zero or negative value means that automatic disarming triggered by a pre-takeoff timeout is disabled.
+ * A negative value disables autmoatic disarming triggered by a pre-takeoff timeout.
  *
  * @group Commander
  * @unit s
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 25.0f);
+PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 
 
 /**


### PR DESCRIPTION
**Describe problem solved by this pull request**
Following up on https://discuss.px4.io/t/px4-v1-12-release-coordination/21516/21

**Describe possible alternatives**
I saw that https://github.com/PX4/PX4-Autopilot/commit/1ec8ce58c7e544e96cbda711d85c7f3b21731b9b already directly commited a compromise to master but I'm still suggesting to adjust depending on the vehicle type because the feature clearly interferes with any non-runway fixed wing takeoff and generally makes less sense on fixed-wing.

**Describe your solution**
I suggest to keep the automatic disarm time for multirotors because it proved to be a good value for multirotors. The feature was developed for multirotors and I'd disable it completely for fixed wing. I would honestly did that on my plane and it gets confirmed by the feedback.

**Test data / coverage**
I tested these parameters before but not this pr in particular.
