### PR TITLE
Alphabetize flight_mode_manager CMakeLists.txt list, and group/format types in FlightTask.cpp/hpp.

### DIFF
--- a/src/modules/flight_mode_manager/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/CMakeLists.txt
@@ -52,16 +52,16 @@ endif()
 
 # add core flight tasks to list
 list(APPEND flight_tasks_all
+	AutoFollowMe
+	AutoLineSmoothVel
+	Descend
+	Failsafe
+	ManualAcceleration
 	ManualAltitude
 	ManualAltitudeSmoothVel
 	ManualPosition
 	ManualPositionSmoothVel
-	AutoLineSmoothVel
-	AutoFollowMe
-	Failsafe
-	Descend
 	Transition
-	ManualAcceleration
 	${flight_tasks_to_add}
 )
 

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
@@ -87,10 +87,11 @@ const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
 	vehicle_local_position_setpoint.vy = _velocity_setpoint(1);
 	vehicle_local_position_setpoint.vz = _velocity_setpoint(2);
 
-	_acceleration_setpoint.copyTo(vehicle_local_position_setpoint.acceleration);
-	_jerk_setpoint.copyTo(vehicle_local_position_setpoint.jerk);
 	vehicle_local_position_setpoint.yaw = _yaw_setpoint;
 	vehicle_local_position_setpoint.yawspeed = _yawspeed_setpoint;
+
+	_acceleration_setpoint.copyTo(vehicle_local_position_setpoint.acceleration);
+	_jerk_setpoint.copyTo(vehicle_local_position_setpoint.jerk);
 
 	// deprecated, only kept for output logging
 	matrix::Vector3f(NAN, NAN, NAN).copyTo(vehicle_local_position_setpoint.thrust);
@@ -104,7 +105,8 @@ void FlightTask::_resetSetpoints()
 	_velocity_setpoint.setNaN();
 	_acceleration_setpoint.setNaN();
 	_jerk_setpoint.setNaN();
-	_yaw_setpoint = _yawspeed_setpoint = NAN;
+	_yaw_setpoint = NAN;
+	_yawspeed_setpoint = NAN;
 }
 
 void FlightTask::_evaluateVehicleLocalPosition()

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -244,14 +244,13 @@ protected:
 	 */
 	matrix::Vector3f _position_setpoint;
 	matrix::Vector3f _velocity_setpoint;
+	matrix::Vector3f _velocity_setpoint_feedback;
 	matrix::Vector3f _acceleration_setpoint;
+	matrix::Vector3f _acceleration_setpoint_feedback;
 	matrix::Vector3f _jerk_setpoint;
 
 	float _yaw_setpoint{};
 	float _yawspeed_setpoint{};
-
-	matrix::Vector3f _velocity_setpoint_feedback;
-	matrix::Vector3f _acceleration_setpoint_feedback;
 
 	ekf_reset_counters_s _reset_counters{}; ///< Counters for estimator local position resets
 


### PR DESCRIPTION
Hello,

**Describe problem solved by this pull request**
This PR is a little bit of housekeeping for readability only, no functional changes are created by this PR.  The flight_mode_manager CMakeLists.txt library list is alphabetized, and a few instances in the FlightTask class definition and header file are re-grouped for readability.

Please let me know if you have any questions on this PR.

-Mark
