### PR TITLE
Fix the repeated configuration of PWM rate after initialization

### DIFF
--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -563,7 +563,6 @@ void PWMOut::update_pwm_out_state(bool on)
 
 		// Set rate is not affecting non-masked channels, so can be called
 		// individually
-		set_pwm_rate(pwm_alt_rate_channels_new, default_rate_min, alt_rate_max);
 		_pwm_initialized = true;
 	}
 


### PR DESCRIPTION
**solved problem:** 
The PWM pulse frequency is 8 times the setting 
https://github.com/PX4/PX4-Autopilot/issues/17417
![微信图片_20210420172103](https://user-images.githubusercontent.com/30532769/115371744-d312fe80-a1fc-11eb-9463-258e92279da5.png)

After initialization, the configuration pulse frequency will enter The static inline void io_timer_set_oneshot_mode(unsigned timer) function of platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c will make the division factor 8 times smaller than the normal setting. 

**Test after modification:** 

**Test model:**
13014 vertical take-off and landing 
Parameter configuration ：
CBRK_USB_CHK = 197848
CBRK_SUPPLY_CHK = 894281
RC_MAP_AUX1 = Channel 5
RC_MAP_AUX2 = Channel 6
RC_MAP_AUX3 = Channel 7
RC_MAP_AUX4 = Channel 8
CBRK_AIRSPD_CHK=162128
RC_MAP_TRANS_SW=Channel 8
**Before unlock :**
![图片2](https://user-images.githubusercontent.com/30532769/115373766-c1caf180-a1fe-11eb-945c-802ac075347a.png)
![图片1](https://user-images.githubusercontent.com/30532769/115373777-c55e7880-a1fe-11eb-8f91-3df58cf490e9.png)


**After unlocking :**
![图片3](https://user-images.githubusercontent.com/30532769/115373786-c8596900-a1fe-11eb-89b0-48f72caed6d1.png)
![图片4](https://user-images.githubusercontent.com/30532769/115373802-cc858680-a1fe-11eb-9852-a64c39f106c9.png)


**Use the pwm info command to see that the result is consistent with the actual PWM output** 
