### PR TITLE
Update rc.vtol_defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -23,6 +23,7 @@ param set-default MPC_XY_ERR_MAX 5
 param set-default MPC_XY_VEL_MAX 4
 param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_JERK_MAX 4.5
+param set-default MPC_YAW_MODE 4
 
 param set-default NAV_ACC_RAD 3
 


### PR DESCRIPTION
based on our experience with VTOL it makes sense to change the yaw mode default. You always want your VTOL to yaw in transition direction before starting the transition.