### PR TITLE
srcparser support for  vectored 6 dof uuv airframe added

### DIFF
--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -98,6 +98,8 @@ class ParameterGroup(object):
             return "Boat"
         elif (self.name == "Balloon"):
             return "Balloon"
+        elif (self.name == "Vectored 6 DOF UUV"):
+            return "Vectored6DofUUV"
         return "AirframeUnknown"
 
     def GetParams(self):


### PR DESCRIPTION
Followed the [user guide](https://docs.px4.io/master/en/dev_airframes/adding_a_new_frame.html#adding-a-new-airframe-group) to complete the "new" airframe group for the vectored 6 DOF UUV airframe.

Related PRs:
-  PX4/PX4-user_guide#1213
- mavlink/qgroundcontrol#9604