### PR TITLE
rc_update: handle negative sign of switch thresholds

### DIFF
--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -481,17 +481,14 @@ void RCUpdate::Run()
 switch_pos_t RCUpdate::get_rc_sw3pos_position(uint8_t func, float on_th, float mid_th) const
 {
 	if (_rc.function[func] >= 0) {
-		const bool on_inv = (on_th < 0.f);
-		const bool mid_inv = (mid_th < 0.f);
-		on_th = fabsf(on_th);
-		mid_th = fabsf(mid_th);
 
+		// value is between 0 and 1
 		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f;
 
-		if (on_inv ? value < on_th : value > on_th) {
+		if ((on_th < 0.f) ? value < -on_th : value > on_th) {
 			return manual_control_switches_s::SWITCH_POS_ON;
 
-		} else if (mid_inv ? value < mid_th : value > mid_th) {
+		} else if ((mid_th < 0.f) ? value < -mid_th : value > mid_th) {
 			return manual_control_switches_s::SWITCH_POS_MIDDLE;
 
 		} else {
@@ -505,12 +502,11 @@ switch_pos_t RCUpdate::get_rc_sw3pos_position(uint8_t func, float on_th, float m
 switch_pos_t RCUpdate::get_rc_sw2pos_position(uint8_t func, float on_th) const
 {
 	if (_rc.function[func] >= 0) {
-		const bool on_inv = (on_th < 0.f);
-		on_th = fabsf(on_th);
 
+		// value is between 0 and 1
 		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f;
 
-		if (on_inv ? value < on_th : value > on_th) {
+		if ((on_th < 0.f) ? value < -on_th : value > on_th) {
 			return manual_control_switches_s::SWITCH_POS_ON;
 
 		} else {

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -483,6 +483,8 @@ switch_pos_t RCUpdate::get_rc_sw3pos_position(uint8_t func, float on_th, float m
 	if (_rc.function[func] >= 0) {
 		const bool on_inv = (on_th < 0.f);
 		const bool mid_inv = (mid_th < 0.f);
+		on_th = fabsf(on_th);
+		mid_th = fabsf(mid_th);
 
 		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f;
 
@@ -504,6 +506,7 @@ switch_pos_t RCUpdate::get_rc_sw2pos_position(uint8_t func, float on_th) const
 {
 	if (_rc.function[func] >= 0) {
 		const bool on_inv = (on_th < 0.f);
+		on_th = fabsf(on_th);
 
 		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f;
 

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -118,6 +118,9 @@ private:
 
 	/**
 	 * Get switch position for specified function.
+	 *
+	 * @param on_th the threshold for the "on" position, from 0 to 1. To invert the switch, use 0 to -1.
+	 * @param mid_th the (lower) threshold for the "middle" position, from 0 to 1. To invert the switch, use 0 to -1.
 	 */
 	switch_pos_t	get_rc_sw3pos_position(uint8_t func, float on_th, float mid_th) const;
 	switch_pos_t	get_rc_sw2pos_position(uint8_t func, float on_th) const;


### PR DESCRIPTION
**Describe problem solved by this pull request**
The sign of RC switch threshold parameters is used to indicate whether the threshold is a lower or higher limit. The absolute value of the threshold needs to be used for the actual comparison.

If I'm correct, this was accidentally broken by the pull request #13672 from December 2019)

**Describe your solution**
Adding the missing fabsf() solves the problem.

**Describe possible alternatives**
Alternatively, support for reversing the switch direction by negating the threshold could be removed.

**Test data / coverage**
I initially fixed and tested this on v1.11.3. I don't have the hardware available right now to test it on master, but I guess the fix is straightforward enough.

**Additional context**
N/A
