### PR TITLE
Tailsitters need ATTITUDE_QUATERNION  to display properly the horizon

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1509,6 +1509,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("ALTITUDE", 1.0f);
 		configure_stream_local("ATTITUDE", 15.0f);
 		configure_stream_local("ATTITUDE_TARGET", 2.0f);
+		configure_stream_local("ATTITUDE_QUATERNION", 10.0f)
 		configure_stream_local("BATTERY_STATUS", 0.5f);
 		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
 		configure_stream_local("COLLISION", unlimited_rate);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1509,7 +1509,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("ALTITUDE", 1.0f);
 		configure_stream_local("ATTITUDE", 15.0f);
 		configure_stream_local("ATTITUDE_TARGET", 2.0f);
-		configure_stream_local("ATTITUDE_QUATERNION", 10.0f)
+		configure_stream_local("ATTITUDE_QUATERNION", 10.0f);
 		configure_stream_local("BATTERY_STATUS", 0.5f);
 		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
 		configure_stream_local("COLLISION", unlimited_rate);


### PR DESCRIPTION
Tailsitters need Mavlink message ATTITUDE_QUATERNION  to display properly the horizon in FW mode.

**Describe problem solved by this pull request**
Artificial horizon not pitching down 90º in FW mode because ATTITUDE_QUATERNION message is not being send in Mavlink normal mode.

**Describe your solution**
Add this message to the normal mode at 10Hz
