### PR TITLE
Fix velocity rampup based on stick while disarmed

### DIFF
--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
@@ -20,7 +20,7 @@ bool FlightTask::activate(const vehicle_local_position_setpoint_s &last_setpoint
 
 void FlightTask::reActivate()
 {
-	activate(getPositionSetpoint());
+	activate(empty_setpoint);
 }
 
 bool FlightTask::updateInitialize()

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -47,16 +47,16 @@ bool FlightTaskManualAcceleration::activate(const vehicle_local_position_setpoin
 {
 	bool ret = FlightTaskManualAltitudeSmoothVel::activate(last_setpoint);
 
-	if (PX4_ISFINITE(last_setpoint.vx)) {
+	_stick_acceleration_xy.resetPosition();
+
+	if (PX4_ISFINITE(last_setpoint.vx) && PX4_ISFINITE(last_setpoint.vy)) {
 		_stick_acceleration_xy.resetVelocity(Vector2f(last_setpoint.vx, last_setpoint.vy));
 
 	} else {
 		_stick_acceleration_xy.resetVelocity(_velocity.xy());
 	}
 
-	_stick_acceleration_xy.resetPosition();
-
-	if (PX4_ISFINITE(last_setpoint.acceleration[0])) {
+	if (PX4_ISFINITE(last_setpoint.acceleration[0]) && PX4_ISFINITE(last_setpoint.acceleration[1])) {
 		_stick_acceleration_xy.resetAcceleration(Vector2f(last_setpoint.acceleration[0], last_setpoint.acceleration[1]));
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -62,7 +62,7 @@ void StickAccelerationXY::resetVelocity(const matrix::Vector2f &velocity)
 void StickAccelerationXY::resetAcceleration(const matrix::Vector2f &acceleration)
 {
 	_acceleration_slew_rate_x.setForcedValue(acceleration(0));
-	_acceleration_slew_rate_x.setForcedValue(acceleration(1));
+	_acceleration_slew_rate_y.setForcedValue(acceleration(1));
 }
 
 void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, const float yaw_sp, const Vector3f &pos,

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -78,7 +78,7 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 	Sticks::limitStickUnitLengthXY(stick_xy);
 	Sticks::rotateIntoHeadingFrameXY(stick_xy, yaw, yaw_sp);
 	_acceleration_setpoint = stick_xy.emult(acceleration_scale);
-	applyFeasibilityLimit(dt);
+	applyJerkLimit(dt);
 
 	// Add drag to limit speed and brake again
 	Vector2f drag = calculateDrag(acceleration_scale.edivide(velocity_scale), dt, stick_xy, _velocity_setpoint);
@@ -109,7 +109,7 @@ void StickAccelerationXY::getSetpoints(Vector3f &pos_sp, Vector3f &vel_sp, Vecto
 	acc_sp.xy() = _acceleration_setpoint;
 }
 
-void StickAccelerationXY::applyFeasibilityLimit(const float dt)
+void StickAccelerationXY::applyJerkLimit(const float dt)
 {
 	// Apply jerk limit - acceleration slew rate
 	// Scale each jerk limit with the normalized projection of the acceleration

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -61,7 +61,7 @@ public:
 	void getSetpoints(matrix::Vector3f &pos_sp, matrix::Vector3f &vel_sp, matrix::Vector3f &acc_sp);
 
 private:
-	void applyFeasibilityLimit(const float dt);
+	void applyJerkLimit(const float dt);
 	matrix::Vector2f calculateDrag(matrix::Vector2f drag_coefficient, const float dt, const matrix::Vector2f &stick_xy,
 				       const matrix::Vector2f &vel_sp);
 	void applyTiltLimit(matrix::Vector2f &acceleration);


### PR DESCRIPTION
**Describe problem solved by this pull request**
In the default position mode implementation a combination of the default implementation for taking over smoothly:
https://github.com/PX4/PX4-Autopilot/pull/12389/files#diff-3372da232c5d9e1ac174e51bdbbe4d31d63547ce2459b5bbb83e15ea6e54d63eR37
and the recent improvements to take over smoothly from the last mode:
https://github.com/PX4/PX4-Autopilot/pull/17078/files#diff-8d0af4d9e531c4e5b5042aa541daa75f8c8375bfd4467096c2f186a8a501a549R51
lead to the possibility to ramp up the velocity setpoint as if the vehicle was flying because the reset considered its own setpoint from the last loop iteration for taking over smoothly.

**Describe your solution**
The main fix for this is the one line change 9e8d592
It by default reactivates tasks on ground with the empty setpoint such that they properly reset and don't try to take over smoothly from their own setpoints generated in the last loop iteration.

On the way I also found minor other things to correct:
- In the acceleration stick mapping for legacy reasons the pure jerk limit is called feasability limit: f97fdb4
- In the acceleration stick mapping the acceleration setpoint components taken over from the last task are screwed y = x: 
960c0a8
- Minor order cleanup and checking explicitly all components for NAN in FlightTaskManualAcceleration: 446539c

**Describe possible alternatives**
I could do a custom implementation for that tasks `reActivate()` but I don't see in what case it could make sense to reactivate a task with it's own setpoints from the last loop iteration.

**Test data / coverage**
I tested in SITL and the undesired rampup is gone. The velocity can only be increased by stick after the takeoff ramp was initiated which usually leads to feasible/trackable setpoints.

**Additional context**
Before. Disarmed the entire time, velocity ramps unexpectedly with stick deflection:
![image-20210421-111902](https://user-images.githubusercontent.com/4668506/115563524-ee8f0f80-a2b7-11eb-8bf8-5e56ace02e06.png)

After:
![image](https://user-images.githubusercontent.com/4668506/115563181-8dffd280-a2b7-11eb-826e-f0aaf6f6d737.png)
