### PR TITLE
mavlink receiver fixes

### DIFF
--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -28,7 +28,6 @@ uint32 tx_buffer_overruns               # number of TX buffer overruns
 
 float32 rx_rate_avg                     # transmit rate average (Bytes/s)
 uint32 rx_message_count                 # count of total messages received
-uint32 rx_message_count_supported       # count of total messages received from supported systems and components (for loss statistics)
 uint32 rx_message_lost_count
 uint32 rx_buffer_overruns               # number of RX buffer overruns
 uint32 rx_parse_errors                  # number of parse errors

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2814,6 +2814,7 @@ Mavlink::display_status()
 	printf("\t  tx rate max: %i B/s\n", _datarate);
 	printf("\t  rx: %.1f B/s\n", (double)_tstatus.rx_rate_avg);
 	printf("\t  rx loss: %.1f%%\n", (double)_tstatus.rx_message_lost_rate);
+	_receiver.print_detailed_rx_stats();
 
 	if (_mavlink_ulog) {
 		printf("\tULog rate: %.1f%% of max %.1f%%\n", (double)_mavlink_ulog->current_data_rate() * 100.,

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -94,7 +94,8 @@ hrt_abstime Mavlink::_first_start_time = {0};
 bool Mavlink::_boot_complete = false;
 
 Mavlink::Mavlink() :
-	ModuleParams(nullptr)
+	ModuleParams(nullptr),
+	_receiver(this)
 {
 	// initialise parameter cache
 	mavlink_update_parameters();
@@ -2229,8 +2230,7 @@ Mavlink::task_main(int argc, char *argv[])
 		send_autopilot_capabilities();
 	}
 
-	/* start the MAVLink receiver last to avoid a race */
-	MavlinkReceiver::receive_start(&_receive_thread, this);
+	_receiver.start();
 
 	_mavlink_start_time = hrt_absolute_time();
 
@@ -2513,8 +2513,7 @@ Mavlink::task_main(int argc, char *argv[])
 		perf_end(_loop_perf);
 	}
 
-	/* first wait for threads to complete before tearing down anything */
-	pthread_join(_receive_thread, nullptr);
+	_receiver.stop();
 
 	delete _subscribe_to_stream;
 	_subscribe_to_stream = nullptr;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2417,10 +2417,10 @@ Mavlink::task_main(int argc, char *argv[])
 
 		/* check for ulog streaming messages */
 		if (_mavlink_ulog) {
-			if (_mavlink_ulog_stop_requested) {
+			if (_mavlink_ulog_stop_requested.load()) {
 				_mavlink_ulog->stop();
 				_mavlink_ulog = nullptr;
-				_mavlink_ulog_stop_requested = false;
+				_mavlink_ulog_stop_requested.store(false);
 
 			} else {
 				if (cmd_logging_start_acknowledgement) {

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -497,7 +497,7 @@ public:
 	}
 	void			request_stop_ulog_streaming()
 	{
-		if (_mavlink_ulog) { _mavlink_ulog_stop_requested = true; }
+		if (_mavlink_ulog) { _mavlink_ulog_stop_requested.store(true); }
 	}
 
 	bool ftp_enabled() const { return _ftp_on; }
@@ -569,7 +569,7 @@ private:
 	MavlinkShell		*_mavlink_shell{nullptr};
 	MavlinkULog		*_mavlink_ulog{nullptr};
 
-	volatile bool		_mavlink_ulog_stop_requested{false};
+	px4::atomic_bool	_mavlink_ulog_stop_requested{false};
 
 	MAVLINK_MODE 		_mode{MAVLINK_MODE_NORMAL};
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -80,6 +80,7 @@
 
 #include "mavlink_command_sender.h"
 #include "mavlink_messages.h"
+#include "mavlink_receiver.h"
 #include "mavlink_shell.h"
 #include "mavlink_ulog.h"
 
@@ -527,6 +528,7 @@ public:
 	bool radio_status_critical() const { return _radio_status_critical; }
 
 private:
+	MavlinkReceiver 	_receiver;
 	int			_instance_id{0};
 
 	bool			_transmitting_enabled{true};
@@ -572,8 +574,6 @@ private:
 	MAVLINK_MODE 		_mode{MAVLINK_MODE_NORMAL};
 
 	mavlink_channel_t	_channel{MAVLINK_COMM_0};
-
-	pthread_t		_receive_thread {};
 
 	bool			_forwarding_on{false};
 	bool			_ftp_on{false};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3158,7 +3158,7 @@ void MavlinkReceiver::print_detailed_rx_stats() const
 	// TODO: add mutex around shared data.
 	for (unsigned i = 0; i < MAX_REMOTE_COMPONENTS; ++i) {
 		if (_component_states[i].received_messages > 0) {
-			printf("\t  received from %u/%u: %lu, lost: %u, last %u ms ago\n",
+			printf("\t  received from sysid: %u compid: %u: %u, lost: %u, last %u ms ago\n",
 			       _component_states[i].system_id,
 			       _component_states[i].component_id,
 			       _component_states[i].received_messages,

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2178,8 +2178,8 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		battery_status_s hil_battery_status{};
 
 		hil_battery_status.timestamp = timestamp;
-		hil_battery_status.voltage_v = 12.0f;
-		hil_battery_status.voltage_filtered_v = 12.0f;
+		hil_battery_status.voltage_v = 16.0f;
+		hil_battery_status.voltage_filtered_v = 16.0f;
 		hil_battery_status.current_a = 10.0f;
 		hil_battery_status.discharged_mah = -1.0f;
 		hil_battery_status.connected = true;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3158,7 +3158,7 @@ void MavlinkReceiver::print_detailed_rx_stats() const
 	// TODO: add mutex around shared data.
 	for (unsigned i = 0; i < MAX_REMOTE_COMPONENTS; ++i) {
 		if (_component_states[i].received_messages > 0) {
-			printf("\t  received from %u/%u: %lu, lost: %lu, last %lu ms ago\n",
+			printf("\t  received from %u/%u: %lu, lost: %u, last %u ms ago\n",
 			       _component_states[i].system_id,
 			       _component_states[i].component_id,
 			       _component_states[i].received_messages,

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2215,10 +2215,12 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		battery_status_s hil_battery_status{};
 
 		hil_battery_status.timestamp = timestamp;
-		hil_battery_status.voltage_v = 11.5f;
-		hil_battery_status.voltage_filtered_v = 11.5f;
+		hil_battery_status.voltage_v = 12.0f;
+		hil_battery_status.voltage_filtered_v = 12.0f;
 		hil_battery_status.current_a = 10.0f;
 		hil_battery_status.discharged_mah = -1.0f;
+		hil_battery_status.connected = true;
+		hil_battery_status.remaining = 0.70;
 
 		_battery_pub.publish(hil_battery_status);
 	}

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3184,7 +3184,7 @@ void MavlinkReceiver::start()
 	pthread_attr_setstacksize(&receiveloop_attr,
 				  PX4_STACK_ADJUSTED(sizeof(MavlinkReceiver) + 2840 + MAVLINK_RECEIVER_NET_ADDED_STACK));
 
-	pthread_create(_thread, &receiveloop_attr, MavlinkReceiver::start_trampoline, this);
+	pthread_create(&_thread, &receiveloop_attr, MavlinkReceiver::start_trampoline, (void *)this);
 
 	pthread_attr_destroy(&receiveloop_attr);
 }
@@ -3199,5 +3199,5 @@ void *MavlinkReceiver::start_trampoline(void *context)
 void MavlinkReceiver::stop()
 {
 	_should_exit.store(true);
-	pthread_join(*_thread, nullptr);
+	pthread_join(_thread, nullptr);
 }

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3151,6 +3151,26 @@ void MavlinkReceiver::update_rx_stats(const mavlink_message_t &message)
 	}
 }
 
+void MavlinkReceiver::print_detailed_rx_stats() const
+{
+	const uint32_t now_ms = hrt_absolute_time() / 1000;
+
+	// TODO: add mutex around shared data.
+	for (unsigned i = 0; i < MAX_REMOTE_COMPONENTS; ++i) {
+		if (_component_states[i].received_messages > 0) {
+			printf("\t  received from %u/%u: %lu, lost: %lu, last %lu ms ago\n",
+			       _component_states[i].system_id,
+			       _component_states[i].component_id,
+			       _component_states[i].received_messages,
+			       _component_states[i].missed_messages,
+			       now_ms - _component_states[i].last_time_received_ms);
+
+		} else {
+			break;
+		}
+	}
+}
+
 void MavlinkReceiver::start()
 {
 	pthread_attr_t receiveloop_attr;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -124,6 +124,8 @@ public:
 	void start();
 	void stop();
 
+	void print_detailed_rx_stats() const;
+
 private:
 	static void *start_trampoline(void *context);
 	void run();

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -226,7 +226,7 @@ private:
 	void update_rx_stats(const mavlink_message_t &message);
 
 	px4::atomic_bool 	_should_exit{false};
-	pthread_t		*_thread {};
+	pthread_t		_thread {};
 
 	Mavlink				*_mavlink;
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -121,14 +121,12 @@ public:
 	MavlinkReceiver(Mavlink *parent);
 	~MavlinkReceiver() override;
 
-	/**
-	 * Start the receiver thread
-	 */
-	static void receive_start(pthread_t *thread, Mavlink *parent);
-
-	static void *start_helper(void *context);
+	void start();
+	void stop();
 
 private:
+	static void *start_trampoline(void *context);
+	void run();
 
 	void acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, uint8_t result);
 
@@ -199,8 +197,6 @@ private:
 
 	void CheckHeartbeats(const hrt_abstime &t, bool force = false);
 
-	void Run();
-
 	/**
 	 * Set the interval at which the given message stream is published.
 	 * The rate is the number of messages per second.
@@ -226,6 +222,9 @@ private:
 	void schedule_tune(const char *tune);
 
 	void update_rx_stats(const mavlink_message_t &message);
+
+	px4::atomic_bool 	_should_exit{false};
+	pthread_t		*_thread {};
 
 	Mavlink				*_mavlink;
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -128,17 +128,6 @@ public:
 
 	static void *start_helper(void *context);
 
-	/**
-	 * Set the cruising speed in offboard control
-	 *
-	 * Passing a negative value or leaving the parameter away will reset the cruising speed
-	 * to its default value.
-	 *
-	 * Sets cruising speed for current flight mode only (resets on mode changes).
-	 *
-	 */
-	void set_offb_cruising_speed(float speed = -1.0f);
-
 private:
 
 	void acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, uint8_t result);
@@ -236,10 +225,6 @@ private:
 
 	void schedule_tune(const char *tune);
 
-	/**
-	 * @brief Updates the battery, optical flow, and flight ID subscribed parameters.
-	 */
-	void update_params();
 
 	Mavlink				*_mavlink;
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -225,6 +225,7 @@ private:
 
 	void schedule_tune(const char *tune);
 
+	void update_rx_stats(const mavlink_message_t &message);
 
 	Mavlink				*_mavlink;
 
@@ -238,60 +239,20 @@ private:
 
 	orb_advert_t _mavlink_log_pub{nullptr};
 
-	// subset of MAV_COMPONENTs we support
-	enum SUPPORTED_COMPONENTS : uint8_t {
-		COMP_ID_ALL,
-		COMP_ID_AUTOPILOT1,
-
-		COMP_ID_TELEMETRY_RADIO,
-
-		COMP_ID_CAMERA,
-		COMP_ID_CAMERA2,
-
-		COMP_ID_GIMBAL,
-		COMP_ID_LOG,
-		COMP_ID_ADSB,
-		COMP_ID_OSD,
-		COMP_ID_PERIPHERAL,
-
-		COMP_ID_FLARM,
-
-		COMP_ID_GIMBAL2,
-
-		COMP_ID_MISSIONPLANNER,
-		COMP_ID_ONBOARD_COMPUTER,
-
-		COMP_ID_PATHPLANNER,
-		COMP_ID_OBSTACLE_AVOIDANCE,
-		COMP_ID_VISUAL_INERTIAL_ODOMETRY,
-		COMP_ID_PAIRING_MANAGER,
-
-		COMP_ID_IMU,
-
-		COMP_ID_GPS,
-		COMP_ID_GPS2,
-
-		COMP_ID_UDP_BRIDGE,
-		COMP_ID_UART_BRIDGE,
-		COMP_ID_TUNNEL_NODE,
-
-		COMP_ID_MAX
+	static constexpr int MAX_REMOTE_COMPONENTS{8};
+	struct ComponentState {
+		uint32_t last_time_received_ms{0};
+		uint32_t received_messages{0};
+		uint32_t missed_messages{0};
+		uint8_t system_id{0};
+		uint8_t component_id{0};
+		uint8_t last_sequence{0};
 	};
+	ComponentState _component_states[MAX_REMOTE_COMPONENTS] {};
+	bool _warned_component_states_full_once{false};
 
-	// map of supported component IDs to MAV_COMP value
-	static const uint8_t supported_component_map[COMP_ID_MAX];
-
-	bool _reported_unsupported_comp_id{false};
-
-	static constexpr int MAX_REMOTE_SYSTEM_IDS{8};
-	uint8_t _system_id_map[MAX_REMOTE_SYSTEM_IDS] {};
-
-	uint8_t  _last_index[MAX_REMOTE_SYSTEM_IDS][COMP_ID_MAX] {};    ///< Store the last received sequence ID for each system/componenet pair
-	uint8_t  _sys_comp_present[MAX_REMOTE_SYSTEM_IDS][COMP_ID_MAX] {}; ///< First message flag
 	uint64_t _total_received_counter{0};                            ///< The total number of successfully received messages
-	uint64_t _total_received_supported_counter{0};                  ///< The total number of successfully received messages
 	uint64_t _total_lost_counter{0};                                ///< Total messages lost during transmission.
-	float    _running_loss_percent{0};                              ///< Loss rate
 
 	uint8_t _mavlink_status_last_buffer_overrun{0};
 	uint8_t _mavlink_status_last_parse_error{0};


### PR DESCRIPTION
This contains various cleanup in mavlink and mavlink receiver the most notable being a different handling of how to keep track of sequence numbers for various components.

Extraced out of https://github.com/PX4/PX4-Autopilot/pull/17404.