### PR TITLE
check_code_style_all.sh: remove ignored xargs parameter

### DIFF
--- a/Tools/astyle/check_code_style_all.sh
+++ b/Tools/astyle/check_code_style_all.sh
@@ -59,7 +59,7 @@ if [ ! -f $HOOK_FILE ] && [ "$CI" != "true" ]; then
 	fi
 fi
 
-${DIR}/files_to_check_code_style.sh | xargs -n 1 -P 8 -I % ${DIR}/check_code_style.sh %
+${DIR}/files_to_check_code_style.sh | xargs -P 8 -I % ${DIR}/check_code_style.sh %
 
 if [ $? -eq 0 ]; then
     echo "Format checks passed"


### PR DESCRIPTION
**Describe problem solved by this pull request**
For quite some time now I get this annoying warning message:
`xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value`
when each time when running `make format`.

**Describe your solution**
Looked up the man page: https://man7.org/linux/man-pages/man1/xargs.1.html
> -I replace-str
.... Implies -x and -L 1.
> -L max-lines
Use at most max-lines nonblank input lines per command line. ...
> -n max-args, --max-args=max-args
Use at most max-args arguments per command line. ...

So my interpretation is that `-n 1` is superfluous because `-I string` implies that `-n` cannot be used separately but is implicitly set to one.

**Test data / coverage**
I tested and the executed commands of `make format` are exactly the same.

I'm using `xargs (GNU findutils) 4.8.0` but am assuming it doesn't make any difference.