### PR TITLE
Rover publish actuator controls with rate of gyro

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -72,8 +72,8 @@ RoverPositionControl::~RoverPositionControl()
 bool
 RoverPositionControl::init()
 {
-	if (!_vehicle_attitude_sub.registerCallback()) {
-		PX4_ERR("vehicle attitude callback registration failed!");
+	if (!_vehicle_angular_velocity_sub.registerCallback()) {
+		PX4_ERR("vehicle angular velocity callback registration failed!");
 		return false;
 	}
 
@@ -385,7 +385,10 @@ RoverPositionControl::Run()
 {
 	parameters_update(true);
 
-	if (_vehicle_attitude_sub.update(&_vehicle_att)) {
+	/* run controller on gyro changes */
+	vehicle_angular_velocity_s angular_velocity;
+
+	if (_vehicle_angular_velocity_sub.update(&angular_velocity)) {
 
 		/* check vehicle control mode for changes to publication state */
 		vehicle_control_mode_poll();
@@ -527,7 +530,7 @@ int RoverPositionControl::print_usage(const char *reason)
 ### Description
 Controls the position of a ground rover using an L1 controller.
 
-Publishes `actuator_controls_0` messages at a constant 250Hz.
+Publishes `actuator_controls_0` messages at IMU_GYRO_RATEMAX.
 
 ### Implementation
 Currently, this implementation supports only a few modes:

--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -187,6 +187,14 @@ RoverPositionControl::attitude_setpoint_poll()
 	}
 }
 
+void
+RoverPositionControl::vehicle_attitude_poll()
+{
+	if (_att_sub.updated()) {
+		_att_sub.copy(&_vehicle_att);
+	}
+}
+
 bool
 RoverPositionControl::control_position(const matrix::Vector2d &current_position,
 				       const matrix::Vector3f &ground_speed, const position_setpoint_triplet_s &pos_sp_triplet)
@@ -393,6 +401,7 @@ RoverPositionControl::Run()
 		/* check vehicle control mode for changes to publication state */
 		vehicle_control_mode_poll();
 		attitude_setpoint_poll();
+		vehicle_attitude_poll();
 		manual_control_setpoint_poll();
 
 		_vehicle_acceleration_sub.update();

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -66,6 +66,7 @@
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_global_position.h>

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -113,6 +113,7 @@ private:
 	uORB::Subscription _local_pos_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)}; /**< notification of manual control updates */
 	uORB::Subscription _pos_sp_triplet_sub{ORB_ID(position_setpoint_triplet)};
+	uORB::Subscription _att_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _att_sp_sub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
 

--- a/src/modules/rover_pos_control/RoverPositionControl.hpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.hpp
@@ -66,7 +66,7 @@
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_attitude.h>
-#include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -99,7 +99,7 @@ public:
 private:
 	void Run() override;
 
-	uORB::SubscriptionCallbackWorkItem _vehicle_attitude_sub{this, ORB_ID(vehicle_attitude)};
+	uORB::SubscriptionCallbackWorkItem _vehicle_angular_velocity_sub{this, ORB_ID(vehicle_angular_velocity)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes #17381 
Fix Dshot not initializing on certain ESCs requiring update rate faster than 250Hz, by making the actuator update configurable by adjusting the IMU_GYRO_RATEMAX parameter. 

**Describe your solution**
Make Rover update on `vehicle_angular_velocity` instead of `vehicle_attitude`

**Describe possible alternatives**
Increase the rate of `vehicle_attitude`

**Test data / coverage**
Tested on the modalai/fc_v1 board by selecting rover and measuring update rate with oscilloscope and `uorb top actuator` to confirm the actuator_output rate increased.   
