### PR TITLE
BMS data logs missing samples

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -156,7 +156,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("yaw_estimator_status", 1000, MAX_ESTIMATOR_INSTANCES);
 
 	// log all raw sensors at minimal rate (at least 1 Hz)
-	add_topic_multi("battery_status", 300, 2);
+	add_topic_multi("battery_status", 200, 2);
 	add_topic_multi("differential_pressure", 1000, 2);
 	add_topic_multi("distance_sensor", 1000);
 	add_topic_multi("optical_flow", 1000, 1);


### PR DESCRIPTION
**Describe problem solved by this pull request**
BMS data published every 0.25Sec, but logging is at just abit lower rate of 0.3sec. 
so there are many drops of data.

**Describe your solution**
log battery status every 0.2sec instead of 0.3sec
that should help debugging BMS related issues
