### PR TITLE
parameters use bitset for mark_unsaved and minimize unnecessary locking where possible (param_get, etc)

### DIFF
--- a/platforms/common/include/px4_platform_common/atomic_bitset.h
+++ b/platforms/common/include/px4_platform_common/atomic_bitset.h
@@ -80,6 +80,14 @@ public:
 		}
 	}
 
+	void reset()
+	{
+		// set bits to false
+		for (auto &d : _data) {
+			d.store(0);
+		}
+	}
+
 private:
 	static constexpr uint8_t BITS_PER_ELEMENT = 32;
 	static constexpr size_t ARRAY_SIZE = ((N % BITS_PER_ELEMENT) == 0) ? (N / BITS_PER_ELEMENT) :

--- a/src/include/containers/Bitset.hpp
+++ b/src/include/containers/Bitset.hpp
@@ -76,6 +76,14 @@ public:
 		}
 	}
 
+	void reset()
+	{
+		// set bits to false
+		for (auto &d : _data) {
+			d = 0;
+		}
+	}
+
 private:
 	static constexpr uint8_t BITS_PER_ELEMENT = 8;
 	static constexpr size_t ARRAY_SIZE = (N % BITS_PER_ELEMENT == 0) ? N / BITS_PER_ELEMENT : N / BITS_PER_ELEMENT + 1;

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -72,11 +72,10 @@
 struct param_wbuf_s {
 	union param_value_u     val;
 	param_t                 param;
-	bool                    unsaved;
 };
 
 static int
-param_export_internal(bool only_unsaved, param_filter_func filter)
+param_export_internal(param_filter_func filter)
 {
 	struct param_wbuf_s *s = nullptr;
 	bson_encoder_s encoder{};
@@ -97,19 +96,9 @@ param_export_internal(bool only_unsaved, param_filter_func filter)
 		int32_t i;
 		float   f;
 
-		/*
-		 * If we are only saving values changed since last save, and this
-		 * one hasn't, then skip it
-		 */
-		if (only_unsaved && !s->unsaved) {
-			continue;
-		}
-
 		if (filter && !filter(s->param)) {
 			continue;
 		}
-
-		s->unsaved = false;
 
 		/* append the appropriate BSON type object */
 
@@ -310,9 +299,9 @@ out:
 	return result;
 }
 
-int flash_param_save(bool only_unsaved, param_filter_func filter)
+int flash_param_save(param_filter_func filter)
 {
-	return param_export_internal(only_unsaved, filter);
+	return param_export_internal(filter);
 }
 
 int flash_param_load()

--- a/src/lib/parameters/flashparams/flashparams.h
+++ b/src/lib/parameters/flashparams/flashparams.h
@@ -62,7 +62,7 @@ __EXPORT int param_set_external(param_t param, const void *val, bool mark_saved,
 __EXPORT const void *param_get_value_ptr_external(param_t param);
 
 /* The interface hooks to the Flash based storage. The caller is responsible for locking */
-__EXPORT int flash_param_save(bool only_unsaved, param_filter_func filter);
+__EXPORT int flash_param_save(param_filter_func filter);
 __EXPORT int flash_param_load();
 __EXPORT int flash_param_import();
 

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -318,12 +318,11 @@ __EXPORT void		param_reset_specific(const char *resets[], int num_resets);
  * Note: this method requires a large amount of stack size!
  *
  * @param fd		File descriptor to export to (-1 selects the FLASH storage).
- * @param only_unsaved	Only export changed parameters that have not yet been exported.
  * @param filter	Filter parameters to be exported. The method should return true if
  * 			the parameter should be exported. No filtering if nullptr is passed.
  * @return		Zero on success, nonzero on failure.
  */
-__EXPORT int		param_export(int fd, bool only_unsaved, param_filter_func filter);
+__EXPORT int		param_export(int fd, param_filter_func filter);
 
 /**
  * Import parameters from a file, discarding any unrecognized parameters.

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -330,11 +330,10 @@ __EXPORT int		param_export(int fd, param_filter_func filter);
  * This function merges the imported parameters with the current parameter set.
  *
  * @param fd		File descriptor to import from (-1 selects the FLASH storage).
- * @param mark_saved	Whether to mark imported parameters as already saved
  * @return		Zero on success, nonzero if an error occurred during import.
  *			Note that in the failure case, parameters may be inconsistent.
  */
-__EXPORT int		param_import(int fd, bool mark_saved);
+__EXPORT int		param_import(int fd);
 
 /**
  * Load parameters from a file.

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -559,9 +559,30 @@ param_get_default_value_internal(param_t param, void *default_val)
 int
 param_get_default_value(param_t param, void *default_val)
 {
-	param_lock_reader();
-	int ret = param_get_default_value_internal(param, default_val);
-	param_unlock_reader();
+	if (!handle_in_range(param)) {
+		return PX4_ERROR;
+	}
+
+	int ret = 0;
+
+	if (!params_custom_default[param]) {
+		// return static default value
+		switch (param_type(param)) {
+		case PARAM_TYPE_INT32:
+			memcpy(default_val, &px4::parameters[param].val.i, sizeof(px4::parameters[param].val.i));
+			return PX4_OK;
+
+		case PARAM_TYPE_FLOAT:
+			memcpy(default_val, &px4::parameters[param].val.f, sizeof(px4::parameters[param].val.f));
+			return PX4_OK;
+		}
+
+	} else {
+		param_lock_reader();
+		ret = param_get_default_value_internal(param, default_val);
+		param_unlock_reader();
+	}
+
 	return ret;
 }
 

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -284,7 +284,6 @@ static param_t param_find_internal(const char *name, bool notification)
 				param_set_used(middle);
 			}
 
-			perf_end(param_find_perf);
 			return middle;
 
 		} else if (middle == front) {

--- a/src/lib/parameters/tinybson/tinybson.cpp
+++ b/src/lib/parameters/tinybson/tinybson.cpp
@@ -115,11 +115,10 @@ read_double(bson_decoder_t decoder, double *d)
 }
 
 int
-bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder_callback callback, void *priv)
+bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder_callback callback)
 {
 	decoder->fd = fd;
 	decoder->callback = callback;
-	decoder->priv = priv;
 	decoder->nesting = 1;
 	decoder->node.type = BSON_UNDEFINED;
 
@@ -135,8 +134,7 @@ bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder_callback cal
 }
 
 int
-bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_decoder_callback callback,
-		      void *priv)
+bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_decoder_callback callback)
 {
 	/* argument sanity */
 	if ((buf == nullptr) || (callback == nullptr)) {
@@ -157,7 +155,6 @@ bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_
 
 	decoder->bufpos = 0;
 	decoder->callback = callback;
-	decoder->priv = priv;
 	decoder->nesting = 1;
 	decoder->pending = 0;
 	decoder->node.type = BSON_UNDEFINED;
@@ -318,7 +315,7 @@ bson_decoder_next(bson_decoder_t decoder)
 	}
 
 	/* call the callback and pass its results back */
-	return decoder->callback(decoder, decoder->priv, &decoder->node);
+	return decoder->callback(decoder, &decoder->node);
 }
 
 int

--- a/src/lib/parameters/tinybson/tinybson.h
+++ b/src/lib/parameters/tinybson/tinybson.h
@@ -101,7 +101,7 @@ typedef struct bson_decoder_s *bson_decoder_t;
  *
  * The node callback function's return value is returned by bson_decoder_next.
  */
-typedef int	(* bson_decoder_callback)(bson_decoder_t decoder, void *priv, bson_node_t node);
+typedef int	(* bson_decoder_callback)(bson_decoder_t decoder, bson_node_t node);
 
 struct bson_decoder_s {
 	/* file reader state */
@@ -114,7 +114,6 @@ struct bson_decoder_s {
 
 	bool			dead{false};
 	bson_decoder_callback	callback;
-	void			*priv{nullptr};
 	unsigned		nesting{0};
 	struct bson_node_s	node {};
 	int32_t			pending{0};
@@ -136,10 +135,9 @@ struct bson_decoder_s {
  * @param decoder		Decoder state structure to be initialised.
  * @param fd			File to read BSON data from.
  * @param callback		Callback to be invoked by bson_decoder_next
- * @param priv          Callback private data, stored in node.
  * @return			Zero on success.
  */
-__EXPORT int bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder_callback callback, void *priv);
+__EXPORT int bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder_callback callback);
 
 /**
  * Initialise the decoder to read from a buffer in memory.
@@ -150,11 +148,9 @@ __EXPORT int bson_decoder_init_file(bson_decoder_t decoder, int fd, bson_decoder
  *				passed as zero if the buffer size should be extracted from the
  *				BSON header only.
  * @param callback		Callback to be invoked by bson_decoder_next
- * @param priv		Callback private data, stored in node.
  * @return			Zero on success.
  */
-__EXPORT int bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_decoder_callback callback,
-				   void *priv);
+__EXPORT int bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_decoder_callback callback);
 
 /**
  * Process the next node from the stream and invoke the callback.

--- a/src/modules/commander/factory_calibration_storage.cpp
+++ b/src/modules/commander/factory_calibration_storage.cpp
@@ -84,7 +84,7 @@ int FactoryCalibrationStorage::store()
 		return 0;
 	}
 
-	int ret = param_export(_fd, false, filter_calibration_params);
+	int ret = param_export(_fd, filter_calibration_params);
 
 	if (ret != 0) {
 		PX4_ERR("param export failed (%i)", ret);

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -529,11 +529,8 @@ do_load(const char *param_file_name)
 static int
 do_import(const char *param_file_name)
 {
-	bool mark_saved = false;
-
 	if (param_file_name == nullptr) {
 		param_file_name = param_get_default_file();
-		mark_saved = true; // if imported from default storage, mark as saved
 	}
 
 	int fd = -1;
@@ -549,7 +546,7 @@ do_import(const char *param_file_name)
 		PX4_INFO("importing from '%s'", param_file_name);
 	}
 
-	int result = param_import(fd, mark_saved);
+	int result = param_import(fd);
 
 	if (fd >= 0) {
 		close(fd);

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -441,7 +441,7 @@ do_save(const char *param_file_name)
 		return 1;
 	}
 
-	int result = param_export(fd, false, nullptr);
+	int result = param_export(fd, nullptr);
 	close(fd);
 
 	if (result < 0) {

--- a/src/systemcmds/tests/test_bson.cpp
+++ b/src/systemcmds/tests/test_bson.cpp
@@ -96,7 +96,7 @@ encode(bson_encoder_t encoder)
 }
 
 static int
-decode_callback(bson_decoder_t decoder, void *priv, bson_node_t node)
+decode_callback(bson_decoder_t decoder, bson_node_t node)
 {
 	unsigned len;
 
@@ -287,7 +287,7 @@ test_bson(int argc, char *argv[])
 	}
 
 	/* now test-decode it */
-	if (bson_decoder_init_buf(&decoder, buf, len, decode_callback, nullptr)) {
+	if (bson_decoder_init_buf(&decoder, buf, len, decode_callback)) {
 		PX4_ERR("FAIL: bson_decoder_init_buf");
 		return 1;
 	}

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -408,7 +408,7 @@ bool ParameterTest::exportImportAll()
 		return false;
 	}
 
-	int result = param_export(fd, false, nullptr);
+	int result = param_export(fd, nullptr);
 
 	if (result != PX4_OK) {
 		PX4_ERR("param_export failed");

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -561,7 +561,7 @@ bool ParameterTest::exportImportAll()
 		return false;
 	}
 
-	result = param_import(fd, false);
+	result = param_import(fd);
 	close(fd);
 
 	if (result < 0) {


### PR DESCRIPTION
This is to avoid iterating the full parameter array on every param_value_unsaved() call, and minimize locking.

The way logger and mavlink use this unsaved mechanism to check for recently updated parameters seems a bit questionable (race condition), but I'll save that for later.