### PR TITLE
tiltrotor: only allow increasing tilt during first part of transition

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -299,11 +299,13 @@ void Tiltrotor::update_transition_state()
 
 		// tilt rotors forward up to certain angle
 		if (_tilt_control <= _params_tiltrotor.tilt_transition) {
-			_tilt_control = _params_tiltrotor.tilt_mc +
-					fabsf(_params_tiltrotor.tilt_transition - _params_tiltrotor.tilt_mc) * time_since_trans_start /
-					_params->front_trans_duration;
-		}
+			const float ramped_up_tilt = _params_tiltrotor.tilt_mc +
+						     fabsf(_params_tiltrotor.tilt_transition - _params_tiltrotor.tilt_mc) *
+						     time_since_trans_start / _params->front_trans_duration;
 
+			// only allow increasing tilt (tilt in hover can already be non-zero)
+			_tilt_control = math::max(_tilt_control, ramped_up_tilt);
+		}
 
 		// at low speeds give full weight to MC
 		_mc_roll_weight = 1.0f;


### PR DESCRIPTION

**Describe problem solved by this pull request**
To prevent tilt dents like that on initiating a front transition (when there already is some tilt in hover to compensate for wind).
![image](https://user-images.githubusercontent.com/26798987/115836428-c1f20980-a417-11eb-9862-4a9694fdaa80.png)

**Describe your solution**
Only allow increasing tilt during the first phase of a transition to FW.


**Test data / coverage**
SITL and flight tested. 


