### PR TITLE
vtol_type: reset accel to pitch integrator

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -140,6 +140,8 @@ void VtolType::update_mc_state()
 		_flag_idle_mc = set_idle_mc();
 	}
 
+	resetAccelToPitchPitchIntegrator();
+
 	VtolType::set_all_motor_state(motor_state::ENABLED);
 
 	// copy virtual attitude setpoint to real attitude setpoint
@@ -156,6 +158,8 @@ void VtolType::update_fw_state()
 	if (_flag_idle_mc) {
 		_flag_idle_mc = !set_idle_fw();
 	}
+
+	resetAccelToPitchPitchIntegrator();
 
 	VtolType::set_alternate_motor_state(motor_state::DISABLED);
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -313,6 +313,8 @@ private:
 
 	bool set_motor_state(const motor_state target_state, const int32_t channel_bitmap,  const int value);
 
+	void resetAccelToPitchPitchIntegrator() { _accel_to_pitch_integ = 0.f; }
+
 };
 
 #endif


### PR DESCRIPTION
**Describe problem solved by this pull request**
The accel to pitch integrator was not reset after a back-transition, causing issues when a flight included multiple backtransitions.

**Describe your solution**
Reset it when in MC or FW flight modes.

**Test data / coverage**
SITL tested. 

