### PR TITLE
Update nunavut

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -6,7 +6,7 @@ empy>=3.3
 jinja2>=2.8
 matplotlib>=3.0.*
 numpy>=1.13
-nunavut
+nunavut>=1.1.0
 packaging
 pandas>=0.21
 pkgconfig

--- a/src/drivers/uavcan_v1/CMakeLists.txt
+++ b/src/drivers/uavcan_v1/CMakeLists.txt
@@ -41,6 +41,7 @@ px4_add_git_submodule(TARGET git_legacy_data_types PATH ${LEGACY_DSDL_DIR})
 
 find_program(NNVG_PATH nnvg)
 if(NNVG_PATH)
+	message("Generating UAVCANv1 DSDL headers using Nunavut")
 	execute_process(COMMAND ${NNVG_PATH} --outdir ${CMAKE_CURRENT_BINARY_DIR}/dsdlc_generated --target-language c -I ${DSDL_DIR}/uavcan ${DSDL_DIR}/reg)
 	execute_process(COMMAND ${NNVG_PATH} --outdir ${CMAKE_CURRENT_BINARY_DIR}/dsdlc_generated --target-language c -I ${LEGACY_DSDL_DIR}/uavcan ${LEGACY_DSDL_DIR}/legacy)
 	execute_process(COMMAND ${NNVG_PATH} --outdir ${CMAKE_CURRENT_BINARY_DIR}/dsdlc_generated --target-language c ${DSDL_DIR}/uavcan)


### PR DESCRIPTION
Bump nunavut to 1.1.0, which fixes the combinatorial explosion issue, so *in theory* CI should stop timing out after 5 hours when building uavcanv1 targets. @dagar I assume PX4-Containers needs to be rebuilt but not sure how this is triggered?

I also added a message before the DSDL types are generated, as this still takes a decent while and otherwise it appears to the user that CMake is randomly stalling.