### PR TITLE
paw3902: Default to using SENS_FLOW_ROT rotation

### DIFF
--- a/src/drivers/optical_flow/paw3902/paw3902_main.cpp
+++ b/src/drivers/optical_flow/paw3902/paw3902_main.cpp
@@ -46,8 +46,14 @@ void PAW3902::print_usage()
 I2CSPIDriverBase *PAW3902::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
 				       int runtime_instance)
 {
+	float yaw_rotation_degrees = NAN;
+
+	if (cli.custom1 >= 0) {
+		yaw_rotation_degrees = cli.custom1;
+	}
+
 	PAW3902 *instance = new PAW3902(iterator.configuredBusOption(), iterator.bus(), iterator.devid(), cli.bus_frequency,
-					cli.spi_mode, iterator.DRDYGPIO(), cli.custom1);
+					cli.spi_mode, iterator.DRDYGPIO(), yaw_rotation_degrees);
 
 	if (!instance) {
 		PX4_ERR("alloc failed");
@@ -67,6 +73,7 @@ extern "C" __EXPORT int paw3902_main(int argc, char *argv[])
 	int ch = 0;
 	using ThisDriver = PAW3902;
 	BusCLIArguments cli{false, true};
+	cli.custom1 = -1;
 	cli.spi_mode = SPIDEV_MODE0;
 	cli.default_spi_frequency = SPI_SPEED;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Can't set paw3902 rotation through parameter.

**Describe your solution**
Change the default if `-Y` is not passed to use the parameter value.
This restores the behavior to what it was previous to #16338 (74083d6).

**Describe possible alternatives**
Leave it.

**Test data / coverage**
Before this change, setting the parameter doesn't change orientation (same plots every time)
![image](https://user-images.githubusercontent.com/4969631/116130185-2a472200-a688-11eb-8670-03abab4d169b.png)

After change
![image](https://user-images.githubusercontent.com/4969631/116130200-2fa46c80-a688-11eb-91f4-4bcb26f66d27.png)

**Additional context**
