### PR TITLE
CMake Bloaty add static ram usage breakout

### DIFF
--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -123,6 +123,8 @@ jobs:
       run: make ${{matrix.config}} bloaty_symbols || true
     - name: make ${{matrix.config}} bloaty_templates
       run: make ${{matrix.config}} bloaty_templates || true
+    - name: make ${{matrix.config}} bloaty_ram
+      run: make ${{matrix.config}} bloaty_ram || true
     - name: make ${{matrix.config}} bloaty_compare_master
       run: make ${{matrix.config}} bloaty_compare_master || true
     - name: ccache post-run

--- a/Tools/bloaty_static_ram.bloaty
+++ b/Tools/bloaty_static_ram.bloaty
@@ -1,0 +1,13 @@
+custom_data_source: {
+  name: "bloaty_static_ram"
+  base_data_source: "sections"
+
+  rewrite: {
+    pattern: "^\\.bss"
+    replacement: "ram"
+  }
+  rewrite: {
+    pattern: "^\\.data"
+    replacement: "ram"
+  }
+}

--- a/cmake/bloaty.cmake
+++ b/cmake/bloaty.cmake
@@ -71,6 +71,13 @@ if (BLOATY_PROGRAM)
 		USES_TERMINAL
 		)
 
+	# bloaty statically allocated RAM
+	add_custom_target(bloaty_ram
+		COMMAND ${BLOATY_PROGRAM} -c ${PX4_SOURCE_DIR}/Tools/bloaty_static_ram.bloaty -d bloaty_static_ram,compileunits --source-filter ^ram$ ${BLOATY_OPTS} $<TARGET_FILE:px4>
+		DEPENDS px4
+		USES_TERMINAL
+		)
+
 	# bloaty compare with last master build
 	add_custom_target(bloaty_compare_master
 		COMMAND wget -c -N --no-verbose https://s3.amazonaws.com/px4-travis/Firmware/master/${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_${PX4_BOARD_LABEL}.elf -O master.elf


### PR DESCRIPTION
Adds make <target> bloaty_ram command that creates a breakdown of statically allocated memory (.data & .bss)

Example
```
[5/6] Linking CXX executable nxp_fmuk66-v3_socketcan.elf
Memory region         Used Size  Region Size  %age Used
       vectflash:         464 B         1 KB     45.31%
      cfmprotect:          16 B         16 B    100.00%
       progflash:     1874040 B    2071536 B     90.47%
        datasram:       43800 B       256 KB     16.71%
[5/6] cd /home/hovergames/src/Firmware/build/nxp_fmuk66-v3_socketcan && /usr/local/bin/bloaty -c /home/hovergames/src/Fi...full --domain=vm -s vm -n 200 -w /home/hovergames/src/Firmware/build/nxp_fmuk66-v3_socketcan/nxp_fmuk66-v3_socketcan.elf
     VM SIZE    
 -------------- 
  99.1%  42.2Ki    ram
    23.1%  9.74Ki    iob/iob_initialize.c
    12.6%  5.32Ki    chip/kinetis_serial.c
    11.9%  5.01Ki    ../../platforms/nuttx/src/px4/common/board_dma_alloc.c
    11.6%  4.90Ki    chip/kinetis_enet.c
     3.8%  1.62Ki    chip/kinetis_usbdev.c
     3.2%  1.35Ki    [section .bss]
     3.0%  1.25Ki    chip/kinetis_pinirq.c
     2.3%    1001    src/modules/mavlink/modules__mavlink_unity.cpp
     2.1%     928    irq/irq_initialize.c
     1.8%     796    ../../platforms/nuttx/src/px4/common/cpuload.cpp
     1.7%     724    chip/kinetis_lpserial.c
     1.6%     708    ../../src/lib/parameters/parameters.cpp
     1.6%     695    init/nx_start.c

```