### PR TITLE
boards: mro pixracerpro set BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT instead of RC_SERIAL_SINGLEWIRE

### DIFF
--- a/boards/mro/pixracerpro/src/board_config.h
+++ b/boards/mro/pixracerpro/src/board_config.h
@@ -119,7 +119,7 @@
 
 /* RC Serial port */
 #define RC_SERIAL_PORT          "/dev/ttyS4"
-#define RC_SERIAL_SINGLEWIRE
+#define BOARD_SUPPORTS_RC_SERIAL_PORT_OUTPUT
 
 #define GPIO_RSSI_IN            /* PC1  */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN1)
 


### PR DESCRIPTION
This fixes DSM decoding on the mRo Pixracer Pro.

We should review this across other new H7 boards.

@berndpfrommer