### PR TITLE
Add 3D DShot capability

### DIFF
--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -231,6 +231,9 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::DSHOT_CONFIG>)   _param_dshot_config,
 		(ParamFloat<px4::params::DSHOT_MIN>)    _param_dshot_min,
+		(ParamBool<px4::params::DSHOT_3D_ENABLE>) _param_dshot_3d_enable,
+		(ParamInt<px4::params::DSHOT_3D_DEAD_H>) _param_dshot_3d_dead_h,
+		(ParamInt<px4::params::DSHOT_3D_DEAD_L>) _param_dshot_3d_dead_l,
 		(ParamInt<px4::params::MOT_POLE_COUNT>) _param_mot_pole_count
 	)
 };

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -44,7 +44,7 @@ parameters:
             description:
                 short: Allows for 3d mode when using DShot and suitable mixer
                 long: |
-                    WARNING: ESC must be configured for 3D mode, and DSHOT_MIN set to 0
+                    WARNING: ESC must be configured for 3D mode, and DSHOT_MIN set to 0.
                     This splits the throttle ranges in two.
                     Direction 1) 48 is the slowest, 1047 is the fastest.
                     Direction 2) 1049 is the slowest, 2047 is the fastest.
@@ -82,4 +82,3 @@ parameters:
                     Typical motors for 5 inch props have 14 poles.
             type: int32
             default: 14
-

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -14,7 +14,7 @@ parameters:
                 long: |
                     This enables/disables DShot. The different modes define different
                     speeds, for example DShot150 = 150kb/s. Not all ESCs support all modes.
-                    
+
                     Note: this enables DShot on the FMU outputs. For boards with an IO it is the
                     AUX outputs.
             type: enum
@@ -40,6 +40,36 @@ parameters:
             decimal: 2
             increment: 0.01
             default: 0.055
+        DSHOT_3D_ENABLE:
+            description:
+                short: Allows for 3d mode when using DShot and suitable mixer
+                long: |
+                    This splits the throttle ranges in two.
+                    Direction 1) 48 is the slowest, 1047 is the fastest.
+                    Direction 2) 1049 is the slowest, 2047 is the fastest.
+                    When mixer outputs 1000 or value inside DSHOT 3D deadband, DShot 0 is sent.
+            type: boolean
+            default: 0
+        DSHOT_3D_DEAD_H:
+            description:
+                short: DSHOT 3D deadband high
+                long: |
+                    When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
+                    This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
+            type: int32
+            low: 1000
+            high: 1999
+            default: 1000
+        DSHOT_3D_DEAD_L:
+            description:
+                short: DSHOT 3D deadband low
+                long: |
+                    When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
+                    This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
+            type: int32
+            low: 0
+            high: 1000
+            default: 1000
         MOT_POLE_COUNT: # only used by dshot so far, so keep it under the dshot group
             description:
                 short: Number of magnetic poles of the motors

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -44,6 +44,7 @@ parameters:
             description:
                 short: Allows for 3d mode when using DShot and suitable mixer
                 long: |
+                    WARNING: ESC must be configured for 3D mode, and DSHOT_MIN set to 0
                     This splits the throttle ranges in two.
                     Direction 1) 48 is the slowest, 1047 is the fastest.
                     Direction 2) 1049 is the slowest, 2047 is the fastest.

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -57,8 +57,8 @@ parameters:
                     When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
                     This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
             type: int32
-            low: 1000
-            high: 1999
+            min: 1000
+            max: 1999
             default: 1000
         DSHOT_3D_DEAD_L:
             description:
@@ -67,8 +67,8 @@ parameters:
                     When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
                     This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
             type: int32
-            low: 0
-            high: 1000
+            min: 0
+            max: 1000
             default: 1000
         MOT_POLE_COUNT: # only used by dshot so far, so keep it under the dshot group
             description:


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes #17364 

**Describe your solution**
Added 3 DShot parameters to enable 3D DShot.
If DSHOT_3D_ENABLE is selected, the bottom actuator_output range is reversed to comply with DShot specification.
DSHOT_3D_DEAD_H and DSHOT_3D_DEAD_L set the range where output is 0

**Describe possible alternatives**
- Use generic deadband parameters that apply to both DShot and pwm
- Fix actuator output value of 0 not being usable by DShot [see here](https://github.com/benjinne/PX4-Autopilot/blob/4f52c0b6daa93f01b3c02e9457265be107af74be/src/drivers/dshot/DShot.h#L58). 

**Test data / coverage**
Tested using a custom rover mixer and both directions worked and deadband/min and max values worked correctly.

