### PR TITLE
Makefile: clean use git clean to delete all gitignore files recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,6 +469,8 @@ validate_module_configs:
 
 clean:
 	@rm -rf "$(SRC_DIR)"/build
+	@git clean -dfX -e ".project" -e ".cproject" -e ".idea" -e ".settings" -e ".vscode"
+	@git submodule foreach git clean -dfX -e ".project" -e ".cproject" -e ".idea" -e ".settings" -e ".vscode"
 
 submodulesclean:
 	@git submodule foreach --quiet --recursive git clean -ff -x -d


### PR DESCRIPTION
This is helpful for submodule dependencies that get into a dirty build state and will otherwise need to be completely reinitialized before the build will succeed again.