### PR TITLE
Reflect dynamically allocate block pointers instead of using heap

### DIFF
--- a/src/systemcmds/reflect/reflect.c
+++ b/src/systemcmds/reflect/reflect.c
@@ -52,16 +52,16 @@ __EXPORT int reflect_main(int argc, char *argv[]);
 
 // memory corruption checking
 #define MAX_BLOCKS 1000
-static uint32_t nblocks;
 struct block {
 	uint32_t v[256];
 };
-static struct block *blocks[MAX_BLOCKS];
 
 #define VALUE(i) ((i*7) ^ 0xDEADBEEF)
 
-static void allocate_blocks(void)
+static uint32_t allocate_blocks(struct block **blocks)
 {
+	uint32_t nblocks = 0;
+
 	while (nblocks < MAX_BLOCKS) {
 		blocks[nblocks] = calloc(1, sizeof(struct block));
 
@@ -77,9 +77,11 @@ static void allocate_blocks(void)
 	}
 
 	printf("Allocated %u blocks\n", nblocks);
+
+	return nblocks;
 }
 
-static void check_blocks(void)
+static void check_blocks(struct block **blocks, uint32_t nblocks)
 {
 	for (uint32_t n = 0; n < nblocks; n++) {
 		for (uint32_t i = 0; i < sizeof(blocks[nblocks]->v) / sizeof(uint32_t); i++) {
@@ -92,9 +94,22 @@ int
 reflect_main(int argc, char *argv[])
 {
 	uint32_t total = 0;
+	uint32_t nblocks = 0;
 	printf("Starting reflector\n");
 
-	allocate_blocks();
+	struct block **blocks = NULL;
+	blocks = malloc(sizeof(struct block *) * MAX_BLOCKS);
+
+	if (blocks == NULL) {
+		return -1;
+	}
+
+	while (nblocks < MAX_BLOCKS) {
+		blocks[nblocks] = NULL;
+		nblocks++;
+	}
+
+	nblocks = allocate_blocks(blocks);
 
 	while (true) {
 		char buf[128];
@@ -111,7 +126,7 @@ reflect_main(int argc, char *argv[])
 		total += n;
 
 		if (total > 1024000) {
-			check_blocks();
+			check_blocks(blocks, nblocks);
 			total = 0;
 		}
 	}


### PR DESCRIPTION
As shown in the CI log here https://github.com/PX4/PX4-Autopilot/pull/17100/checks?check_run_id=2492898789#step:13:12
The reflect systemcmd is pre-allocating 4KB on the HEAP to store the block pointers.

This patch dynamically allocates the the pointer array when running reflect saving some RAM.