### PR TITLE
arch.sh: Syntax error fix

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -155,8 +155,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 			# fix VMWare 3D graphics acceleration for gazebo
 			exportline="export SVGA_VGPU10=0"
 
-			if grep -Fxq "$exportline" $HOME/.profile; then
-			else
+			if !grep -Fxq "$exportline" $HOME/.profile; then
 				echo $exportline >> $HOME/.profile;
 			fi
 		fi


### PR DESCRIPTION
**Describe problem solved by this pull request**
Script failed for me with following error
PX4-Autopilot/Tools/setup/arch.sh: line 159: syntax error near unexpected token `else'
PX4-Autopilot/Tools/setup/arch.sh: line 159: `			else'

**Describe your solution**
Seems like there is nothing to do in case of positive if case.
I have changed if condition logic

**Test data / coverage**
Script worked  after changes.
