### PR TITLE
legacy_data_types specify legacy branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,4 @@
 [submodule "src/drivers/uavcan_v1/legacy_data_types"]
 	path = src/drivers/uavcan_v1/legacy_data_types
 	url = https://github.com/px4/public_regulated_data_types/
+	branch = legacy


### PR DESCRIPTION
Should fix the auto submodule updater by specifying correct branch see #17497