### PR TITLE
Makefile: don't delete my stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,7 +469,6 @@ validate_module_configs:
 
 clean:
 	@rm -rf "$(SRC_DIR)"/build
-	@git submodule foreach git clean -df
 
 submodulesclean:
 	@git submodule foreach --quiet --recursive git clean -ff -x -d


### PR DESCRIPTION
Please don't mess with git commands in make. This is evil in my eyes.

Do whatever you want in `distclean` or `submodulesclean` as I don't use them.