### PR TITLE
Makefile: keep git clean for submodules to resolve incomplete dependency problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,8 +469,7 @@ validate_module_configs:
 
 clean:
 	@rm -rf "$(SRC_DIR)"/build
-	@git clean -df -e ".project" -e ".cproject" -e ".idea" -e ".project" -e ".settings" -e ".vscode"
-	@git submodule foreach git clean -dfX
+	@git submodule foreach git clean -df
 
 submodulesclean:
 	@git submodule foreach --quiet --recursive git clean -ff -x -d


### PR DESCRIPTION
This might solve the issue with a partial libuavcan build being interrupted, but not yet verified.

**EDIT:** seems to work, broken incomplete builds are now recoverable with `make clean`.