### PR TITLE
Add support for UCANS32K146B board revision

### DIFF
--- a/boards/nxp/ucans32k146/nuttx-config/include/board.h
+++ b/boards/nxp/ucans32k146/nuttx-config/include/board.h
@@ -90,6 +90,12 @@
 #define BOARD_LED_G_BIT   (1 << BOARD_LED_G)
 #define BOARD_LED_B_BIT   (1 << BOARD_LED_B)
 
+/* Board revision detection pin
+ * 0 equals UCANS32K146-01
+ * 1 equals UCANS32K146B
+ */
+#define BOARD_REVISION_DETECT_PIN  (GPIO_INPUT | PIN_PORTA | PIN10 )
+
 /* If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board
  * the UCANS32K146.  The following definitions describe how NuttX
  * controls the LEDs:
@@ -152,11 +158,9 @@
 /* CAN selections ***********************************************************/
 #define PIN_CAN0_TX      PIN_CAN0_TX_4      /* PTE5 */
 #define PIN_CAN0_RX      PIN_CAN0_RX_4      /* PTE4 */
-#define PIN_CAN0_ENABLE  (GPIO_OUTPUT | PIN_PORTE | PIN11 )
-#define CAN0_ENABLE_OUT  0
+#define PIN_CAN0_STB     (GPIO_OUTPUT | PIN_PORTE | PIN11 )
 #define PIN_CAN1_TX      PIN_CAN1_TX_1      /* PTA13 */
 #define PIN_CAN1_RX      PIN_CAN1_RX_1      /* PTA12 */
-#define PIN_CAN1_ENABLE  (GPIO_OUTPUT | PIN_PORTE | PIN10 )
-#define CAN1_ENABLE_OUT  0
+#define PIN_CAN1_STB     (GPIO_OUTPUT | PIN_PORTE | PIN10 )
 
 #endif  /* __BOARDS_ARM_RDDRONE_UAVCAN146_INCLUDE_BOARD_H */

--- a/boards/nxp/ucans32k146/src/bringup.c
+++ b/boards/nxp/ucans32k146/src/bringup.c
@@ -151,5 +151,20 @@ int s32k1xx_bringup(void)
 
 #endif
 #endif
+
+#ifdef CONFIG_S32K1XX_FLEXCAN
+	s32k1xx_pinconfig(BOARD_REVISION_DETECT_PIN);
+
+	if (s32k1xx_gpioread(BOARD_REVISION_DETECT_PIN)) {
+		/* STB high -> active CAN phy */
+		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ONE);
+
+	} else {
+		/* STB low -> active CAN phy */
+		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ZERO);
+	}
+
+#endif
+
 	return ret;
 }

--- a/boards/nxp/ucans32k146/src/can_boot.c
+++ b/boards/nxp/ucans32k146/src/can_boot.c
@@ -71,7 +71,18 @@ __EXPORT void s32k1xx_board_initialize(void)
 	// Can GPIO
 	s32k1xx_pinconfig(PIN_CAN0_TX);
 	s32k1xx_pinconfig(PIN_CAN0_RX);
-	s32k1xx_pinconfig(PIN_CAN0_ENABLE  | GPIO_OUTPUT_ZERO);
+
+	s32k1xx_pinconfig(BOARD_REVISION_DETECT_PIN);
+
+	if (s32k1xx_gpioread(BOARD_REVISION_DETECT_PIN)) {
+		/* STB high -> active CAN phy */
+		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ONE);
+
+	} else {
+		/* STB low -> active CAN phy */
+		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ZERO);
+	}
+
 	//s32k1xx_gpiowrite
 #if defined(OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO)
 	s32k1xx_pinconfig(GPIO_GETNODEINFO_JUMPER);
@@ -101,7 +112,14 @@ void board_deinitialize(void)
 	} while ((regval & CAN_MCR_LPMACK) == 0);
 
 
-	s32k1xx_pinconfig(PIN_CAN0_ENABLE  | GPIO_OUTPUT_ONE);
+	if (s32k1xx_gpioread(BOARD_REVISION_DETECT_PIN)) {
+		/* STB high -> standby CAN phy */
+		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ZERO);
+
+	} else {
+		/* STB low -> standby CAN phy */
+		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ONE);
+	}
 }
 
 /****************************************************************************


### PR DESCRIPTION
The UCANS32K146B is a board revision that uses a different CAN phy.
However the behavior of the STB pin on this CAN phy is inverted.
This patch adds a runtime detector to see which revision it's and correctly set the CAN phy STB pin.