### PR TITLE
Fix uORB update logic in Follow-target mode

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -61,6 +61,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("commander_state");
 	add_topic("cpuload");
 	add_topic("esc_status", 250);
+	add_topic("follow_target", 500);
 	add_topic("generator_status");
 	add_topic("heater_status");
 	add_topic("home_position");

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -97,8 +97,8 @@ void FollowTarget::on_active()
 	struct map_projection_reference_s target_ref;
 	follow_target_s target_motion_with_offset = {};
 	uint64_t current_time = hrt_absolute_time();
-	bool _radius_entered = false;
-	bool _radius_exited = false;
+	bool radius_entered = false;
+	bool radius_exited = false;
 	bool updated = false;
 	float dt_ms = 0;
 
@@ -166,8 +166,8 @@ void FollowTarget::on_active()
 			// give a buffer to exit/enter the radius to give the velocity controller
 			// a chance to catch up
 
-			_radius_exited = ((_target_position_offset + _target_distance).length() > (float) TARGET_ACCEPTANCE_RADIUS_M * 1.5f);
-			_radius_entered = ((_target_position_offset + _target_distance).length() < (float) TARGET_ACCEPTANCE_RADIUS_M);
+			radius_exited = ((_target_position_offset + _target_distance).length() > (float) TARGET_ACCEPTANCE_RADIUS_M * 1.5f);
+			radius_entered = ((_target_position_offset + _target_distance).length() < (float) TARGET_ACCEPTANCE_RADIUS_M);
 
 			// to keep the velocity increase/decrease smooth
 			// calculate how many velocity increments/decrements
@@ -240,7 +240,7 @@ void FollowTarget::on_active()
 
 	case TRACK_POSITION: {
 
-			if (_radius_entered) {
+			if (radius_entered) {
 				_follow_target_state = TRACK_VELOCITY;
 
 			} else if (target_velocity_valid()) {
@@ -259,7 +259,7 @@ void FollowTarget::on_active()
 
 	case TRACK_VELOCITY: {
 
-			if (_radius_exited) {
+			if (radius_exited) {
 				_follow_target_state = TRACK_POSITION;
 
 			} else if (target_velocity_valid()) {

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -156,7 +156,14 @@ void FollowTarget::on_active()
 					       &(_target_position_delta(0)), &(_target_position_delta(1)));
 
 			// update the average velocity of the target based on the position
-			_est_target_vel = _target_position_delta / (dt_ms / 1000.0f);
+			if (PX4_ISFINITE(_current_target_motion.vx) && PX4_ISFINITE(_current_target_motion.vy)) {
+				// No need to estimate target velocity if we can take it from the target
+				_est_target_vel(0) = _current_target_motion.vx;
+				_est_target_vel(1) = _current_target_motion.vy;
+				_est_target_vel(2) = 0.0f;
+			} else {
+				_est_target_vel = _target_position_delta / (dt_ms / 1000.0f);
+			}
 
 			// if the target is moving add an offset and rotation
 			if (_est_target_vel.length() > .5F) {

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -103,11 +103,12 @@ void FollowTarget::on_active()
 	float dt_ms = 0;
 
 	if (_follow_target_sub.updated()) {
+		updated = true;
 		follow_target_s target_motion;
 
 		_target_updates++;
 
-		// save last known motion topic
+		// save last known motion topic for interpolation later
 
 		_previous_target_motion = _current_target_motion;
 

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -161,6 +161,7 @@ void FollowTarget::on_active()
 				_est_target_vel(0) = _current_target_motion.vx;
 				_est_target_vel(1) = _current_target_motion.vy;
 				_est_target_vel(2) = 0.0f;
+
 			} else {
 				_est_target_vel = _target_position_delta / (dt_ms / 1000.0f);
 			}

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -118,7 +118,7 @@ void FollowTarget::on_active()
 			_current_target_motion = target_motion;
 		}
 
-		_current_target_motion.timestamp = target_motion.timestamp;
+		_current_target_motion = target_motion;
 		_current_target_motion.lat = (_current_target_motion.lat * (double)_responsiveness) + target_motion.lat * (double)(
 						     1 - _responsiveness);
 		_current_target_motion.lon = (_current_target_motion.lon * (double)_responsiveness) + target_motion.lon * (double)(


### PR DESCRIPTION
This fixes an issue described in https://github.com/PX4/PX4-Autopilot/issues/17473. The message update flag was accidentally deleted.

**Describe problem solved by this pull request**
The update logic of the follow-target flight mode is currently broken and it won't work correctly.

**Describe your solution**
Correctly set `update` flag. As a bonus also parse the velocity fields from the target if it provides these values (Android and iOS do afaik).

**Test data / coverage**
Not tested outside of simulation at all.

**Additional context**
I'm working on a general rework of the follow-target flight-mode at which point it will also become a flight task. Don't invest too much effort into fixing the existing follow-target now.
