### PR TITLE
vtol_type: in FW, set min PWM to PWM_DEFAULT_MIN instead of PWM_MOTOR_OFF

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -332,7 +332,7 @@ bool VtolType::set_idle_fw()
 
 	for (int i = 0; i < num_outputs_max; i++) {
 		if (is_channel_set(i, generate_bitmap_from_channel_numbers(_params->vtol_motor_id))) {
-			pwm_values.values[i] = PWM_MOTOR_OFF;
+			pwm_values.values[i] = PWM_DEFAULT_MIN;
 
 		} else {
 			pwm_values.values[i] = _min_mc_pwm_values.values[i];


### PR DESCRIPTION

**Describe problem solved by this pull request**
In FW, the min PWM of all the motors was set to 900 (PWM_MOTOR_OFF), but it should rather be 1000 (PWM_DEFAULT_MIN). With the min set to PWM_MOTOR_OFF, it also scaled the PWM outputs to 900...2000, what isn't desired in general.

![image](https://user-images.githubusercontent.com/26798987/116283111-cf96ee80-a78b-11eb-8d73-e632a7fa81af.png)

That was leading to the weird factor between motor controls and motor outputs:
![image](https://user-images.githubusercontent.com/26798987/116283205-e8070900-a78b-11eb-8a75-dd245b5bb36d.png)


**Describe your solution**
Set the min PWM to PWM_DEFAULT_MIN.

**Test data / coverage**
Flight tested on several tiltrotor vehicles.

