### PR TITLE
airspeed calibration: instruct to blow into front of pitot

### DIFF
--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -199,7 +199,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 	/* wait 500 ms to ensure parameter propagated through the system */
 	px4_usleep(500 * 1000);
 
-	calibration_log_critical(mavlink_log_pub, "[cal] Blow across front of pitot without touching");
+	calibration_log_critical(mavlink_log_pub, "[cal] Blow into front of pitot without touching");
 
 	calibration_counter = 0;
 


### PR DESCRIPTION
Current calibration message says blow across the pitot, while actually you should blow in (as the other docs say). This changes the message. This originates from Chris Anderson on Slack - image illustrates the difference.

![image](https://user-images.githubusercontent.com/5368500/117291639-99a3e980-aeb2-11eb-9613-6962a1822808.png)

