### PR TITLE
Don't allow arming outside geofence if geofence action is not NONE

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -89,6 +89,7 @@ bool high_latency_data_link_lost 			# Set to true if the high latency data link 
 
 bool engine_failure				# Set to true if an engine failure is detected
 bool mission_failure				# Set to true if mission could not continue/finish
+bool geofence_violated
 
 uint8 failure_detector_status			# Bitmask containing FailureDetector status [0, 0, 0, 0, 0, FAILURE_ALT, FAILURE_PITCH, FAILURE_ROLL]
 

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -86,6 +86,7 @@ public:
 		bool esc_check = false;
 		bool global_position = false;
 		bool mission = false;
+		bool geofence = false;
 	};
 
 	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -168,6 +168,14 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		}
 	}
 
+	if (arm_requirements.geofence && status.geofence_violated) {
+		if (report_fail) {
+			mavlink_log_critical(mavlink_log_pub, "Arming denied, vehicle outside geofence");
+		}
+
+		prearm_ok = false;
+	}
+
 	// Arm Requirements: authorization
 	// check last, and only if everything else has passed
 	if (arm_requirements.arm_authorization && prearm_ok) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1733,6 +1733,7 @@ Commander::run()
 			_arm_requirements.esc_check = _param_escs_checks_required.get();
 			_arm_requirements.global_position = !_param_arm_without_gps.get();
 			_arm_requirements.mission = _param_arm_mission_required.get();
+			_arm_requirements.geofence = _param_geofence_action.get() > geofence_result_s::GF_ACTION_NONE;
 
 			/* flight mode slots */
 			_flight_mode_slots[0] = _param_fltmode_1.get();
@@ -2114,6 +2115,7 @@ Commander::run()
 
 		/* start geofence result check */
 		_geofence_result_sub.update(&_geofence_result);
+		_status.geofence_violated = _geofence_result.geofence_violated;
 
 		const bool in_low_battery_failsafe = _battery_warning > battery_status_s::BATTERY_WARNING_LOW;
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -767,8 +767,8 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 			/* inform other apps via the mission result */
 			_geofence_result.geofence_violated = true;
 
-			/* Issue a warning about the geofence violation once */
-			if (!_geofence_violation_warning_sent) {
+			/* Issue a warning about the geofence violation once and only if we are armed */
+			if (!_geofence_violation_warning_sent && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
 				mavlink_log_critical(&_mavlink_log_pub, "Approaching on Geofence");
 
 				// we have predicted a geofence violation and if the action is to loiter then


### PR DESCRIPTION
Also avoid navigator spamming "approaching on geofence" when vehicle is not armed.