### PR TITLE
ekf2: selector increase status rate before potential instance change

### DIFF
--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -78,6 +78,7 @@ private:
 	static constexpr uint64_t FILTER_UPDATE_PERIOD{10_ms};
 
 	void Run() override;
+	void PublishEstimatorSelectorStatus();
 	void PublishVehicleAttitude();
 	void PublishVehicleLocalPosition();
 	void PublishVehicleGlobalPosition();


### PR DESCRIPTION
Increase `estimator_selector_status` publication (and logging) rate if the relative test ratios are changing towards a potential change of primary estimator instance.

