### PR TITLE
Implement Input for Spektrum SRXL2 Receivers

### DIFF
--- a/msg/input_rc.msg
+++ b/msg/input_rc.msg
@@ -16,6 +16,7 @@ uint8 RC_INPUT_SOURCE_PX4FMU_DSM = 12
 uint8 RC_INPUT_SOURCE_PX4IO_SUMD = 13
 uint8 RC_INPUT_SOURCE_PX4FMU_CRSF = 14
 uint8 RC_INPUT_SOURCE_PX4FMU_GHST = 15
+uint8 RC_INPUT_SOURCE_PX4FMU_SRXL = 16
 
 uint8 RC_INPUT_MAX_CHANNELS = 18 	# Maximum number of R/C input channels in the system. S.Bus has up to 18 channels.
 

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -31,6 +31,8 @@
  *
  ****************************************************************************/
 
+#define DEBUG_BUILD
+
 #include "RCInput.hpp"
 
 #include "crsf_telemetry.h"
@@ -73,6 +75,9 @@ RCInput::~RCInput()
 #endif
 	dsm_deinit();
 
+	// TODO: need call?
+	// SRXLCodec::~SRXLCodec();
+
 	delete _crsf_telemetry;
 	delete _ghst_telemetry;
 
@@ -91,6 +96,9 @@ RCInput::init()
 	// dsm_init sets some file static variables and returns a file descriptor
 	// it also powers on the radio if needed
 	_rcs_fd = dsm_init(_device);
+
+	// TODO: need call?
+	// _rcs_fd = SRXLCodec::init(_device);
 
 	if (_rcs_fd < 0) {
 		return -errno;
@@ -710,18 +718,52 @@ void RCInput::Run()
 
 			} else {
 				// Scan the next protocol
+				set_rc_scan_state(RC_SCAN_SRXL);
+			}
+
+			break;
+
+		case RC_SCAN_SRXL:
+			if (_rc_scan_begin == 0) {
+				// _rc_scan_begin = cycle_timestamp;
+
+				// // Configure serial port for DSM
+				// // SRXLCodec::config(_rcs_fd);
+
+				// rc_io_invert(false);
+
+			} else if ( _rc_scan_locked
+					|| ((cycle_timestamp - _rc_scan_begin) < rc_scan_max) )
+			{
+
+				//                             // parse new data
+				//                             // NYI -- this block is probably broken
+
+				//                             if (newBytes > 0) {
+				//                                     int8_t dsm_rssi = 0;
+				//                                     bool dsm_11_bit = false;
+
+				//                                     // parse new data
+				//                                     // rc_updated = SRXLCodec::Parse( cycle_timestamp, &_rcs_buf[0], newBytes, &_raw_rc_values[0], &_raw_rc_count,
+				//                                     //                              &dsm_11_bit, &frame_drops, &dsm_rssi, input_rc_s::RC_INPUT_MAX_CHANNELS);
+
+				//                                     if (rc_updated) {
+				//                                             // we have a new SRXL frame. Publish it.
+				//                                             _rc_in.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_SRXL;
+				//                                             // not sure what this call does, either
+				//                                             fill_rc_in(_raw_rc_count, _raw_rc_values, cycle_timestamp,
+				//                                                        false, false, frame_drops, dsm_rssi);
+				//                                             _rc_scan_locked = true;
+				//                                     }
+				//                             }
+				printf("RCScan: SCAN-SRXL Failed. NYI\n");
+
+			} else {
+				// Scan the next protocol
 				set_rc_scan_state(RC_SCAN_SBUS);
 			}
 
 			break;
-		}
-
-		perf_end(_cycle_perf);
-
-		if (rc_updated) {
-			perf_count(_publish_interval_perf);
-
-			_to_input_rc.publish(_rc_in);
 
 		} else if (!rc_updated && !_armed && (hrt_elapsed_time(&_rc_in.timestamp_last_signal) > 1_s)) {
 			_rc_scan_locked = false;
@@ -732,6 +774,18 @@ void RCInput::Run()
 			PX4_INFO("RC scan: %s RC input locked", RC_SCAN_STRING[_rc_scan_state]);
 		}
 	}
+
+	perf_end(_cycle_perf);
+
+	if (rc_updated) {
+		perf_count(_publish_interval_perf);
+
+		_to_input_rc.publish(_rc_in);
+
+	} else if (!rc_updated && ((hrt_absolute_time() - _rc_in.timestamp_last_signal) > 1_s)) {
+		_rc_scan_locked = false;
+	}
+}
 }
 
 #if defined(SPEKTRUM_POWER)
@@ -789,6 +843,13 @@ int RCInput::custom_command(int argc, char *argv[])
 		return 0;
 	}
 
+	// Not Yet Implemented.
+	// if (!strcmp(verb, "bind_srxl")) {
+	// 	PX4_INFO("Binding Spektrum SRXL receiver");
+	// 	SRXLDriver::bind(_rcs_fd);
+	// 	return 0;
+	// }
+
 #endif /* SPEKTRUM_POWER */
 
 	/* start the FMU if not running */
@@ -831,8 +892,9 @@ int RCInput::print_status()
 
 		case RC_SCAN_DSM:
 			// DSM status output
-#if defined(SPEKTRUM_POWER)
-#endif
+// #if defined(SPEKTRUM_POWER)
+// 			PX4_INFO("Spektrum Telemetry: %s", _dsm_telemetry ? "yes" : "no");
+// #endif
 			break;
 
 		case RC_SCAN_PPM:
@@ -846,6 +908,14 @@ int RCInput::print_status()
 		case RC_SCAN_ST24:
 			// SUMD status output
 			break;
+
+		case RC_SCAN_SRXL:
+#ifdef SPEKTRUM_POWER
+			// PX4_INFO("SBUS frame drops: %u", sbus_dropped_frames());
+			// PX4_INFO("Spektrum Telemetry: %s", _srxl_telemetry ? "yes" : "no");
+#endif
+			break;
+
 		}
 	}
 

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -325,16 +325,10 @@ void RCInput::Run()
 				if (input_rc_s::RC_INPUT_SOURCE_PX4FMU_SRXL == _rc_in.input_source) {
 					cmd_ret = vehicle_command_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
 
+					// WARNING:  SRXL uses a different bind mechanism and values than legacy receivers
+					//           It doens't require the power cycling, just sending the correct data frames
 					if (_rc_scan_locked && !_armed) {
-						// WARNING:  SRXL uses a different bind mechanism and values than legacy receivers
-						//  -- until the upstream code accomodates the difference...
-						//     Override the values here:
-						// const uint8_t srxl_bind_mode = (int)vcmd.param2;
-						const uint8_t srxl_bind_mode =
-							0xB2;  // === DSMx 11ms; some documentation claims this mode will auto-select 11ms or 22ms mode
-						// const uint8_t srxl_bind_mode = 0xA2;  // === DSMX 22ms  // desired bind-mode
-
-						if (0 < _srxl.request_bind_receiver(srxl_bind_mode)) {
+						if (0 < _srxl.request_bind_receiver(vcmd.param2)) {
 							cmd_ret = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
 						}
 					}

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -73,9 +73,6 @@ RCInput::~RCInput()
 #endif
 	dsm_deinit();
 
-	// TODO: need call?
-	// SRXLCodec::~SRXLCodec();
-
 	delete _crsf_telemetry;
 	delete _ghst_telemetry;
 

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -97,17 +97,19 @@ private:
 		RC_SCAN_SUMD,
 		RC_SCAN_ST24,
 		RC_SCAN_CRSF,
-		RC_SCAN_GHST
+		RC_SCAN_GHST,
+		RC_SCAN_SRXL,
 	} _rc_scan_state{RC_SCAN_SBUS};
 
-	static constexpr char const *RC_SCAN_STRING[7] {
+	static constexpr char const *RC_SCAN_STRING[8] {
 		"PPM",
 		"SBUS",
 		"DSM",
 		"SUMD",
 		"ST24",
 		"CRSF",
-		"GHST"
+		"GHST",
+		"SRXL",
 	};
 
 	void Run() override;
@@ -160,6 +162,10 @@ private:
 
 	CRSFTelemetry *_crsf_telemetry{nullptr};
 	GHSTTelemetry *_ghst_telemetry{nullptr};
+
+	// these are not defined in this module...  but ... should be?
+	// how is this accessed, otherwise?
+	//SRXLTelemetry * _srxl_telemetry{nullptr};
 
 	perf_counter_t	_cycle_perf;
 	perf_counter_t	_publish_interval_perf;

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -43,6 +43,7 @@
 #include <lib/rc/ghst.hpp>
 #include <lib/rc/dsm.h>
 #include <lib/rc/sbus.h>
+#include <lib/rc/srxl.hpp>
 #include <lib/rc/st24.h>
 #include <lib/rc/sumd.h>
 #include <px4_platform_common/px4_config.h>
@@ -163,9 +164,8 @@ private:
 	CRSFTelemetry *_crsf_telemetry{nullptr};
 	GHSTTelemetry *_ghst_telemetry{nullptr};
 
-	// these are not defined in this module...  but ... should be?
-	// how is this accessed, otherwise?
-	//SRXLTelemetry * _srxl_telemetry{nullptr};
+	// defined in `src/lib/rc/srxl.hpp`
+	SRXLCodec _srxl;
 
 	perf_counter_t	_cycle_perf;
 	perf_counter_t	_publish_interval_perf;

--- a/src/drivers/telemetry/CMakeLists.txt
+++ b/src/drivers/telemetry/CMakeLists.txt
@@ -34,4 +34,4 @@
 add_subdirectory(bst)
 add_subdirectory(frsky_telemetry)
 add_subdirectory(hott)
-#add_subdirectory(iridiumsbd)
+add_subdirectory(iridiumsbd)

--- a/src/lib/rc/CMakeLists.txt
+++ b/src/lib/rc/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(rc
 	sumd.cpp
 	sbus.cpp
 	dsm.cpp
+	srxl.cpp
 	common_rc.cpp
 )
 target_compile_options(rc

--- a/src/lib/rc/CMakeLists.txt
+++ b/src/lib/rc/CMakeLists.txt
@@ -32,14 +32,14 @@
 ############################################################################
 
 add_library(rc
+	common_rc.cpp
 	crsf.cpp
+	dsm.cpp
 	ghst.cpp
+	sbus.cpp
+	srxl.cpp
 	st24.cpp
 	sumd.cpp
-	sbus.cpp
-	dsm.cpp
-	srxl.cpp
-	common_rc.cpp
 )
 target_compile_options(rc
 	PRIVATE

--- a/src/lib/rc/srxl.cpp
+++ b/src/lib/rc/srxl.cpp
@@ -1,0 +1,64 @@
+#include <cstring>
+#include "crc16.h"
+#include "srxl.hpp"
+
+constexpr bool SRXLCodec::is_srxl_telemetry(srxl_frame_t &frame)
+{
+	if ((frame.header == SRXL1_FRAME_HEADER)
+	    || (frame.header != SRXL2_FRAME_HEADER)) {
+		// success -- continue
+	} else {
+		return false;
+	}
+
+	switch (frame.version) {
+	case FRAME_TYPE_HANDSHAKE:
+	case FRAME_TYPE_BIND:
+	case FRAME_TYPE_PARAMETER:
+	case FRAME_TYPE_SIGNAL_QUALITY:
+	case FRAME_TYPE_TELEMETRY:
+	case FRAME_TYPE_CONTROL:
+		// success -- continue
+		break;
+
+	default:
+		return false;
+	}
+
+	return true;
+}
+
+void SRXLCodec::set_payload(uint8_t *payload, size_t length, srxl_frame_t &frame)
+{
+	uint16_t crc = crc16((const uint8_t *)payload, length);
+
+	frame.header = SRXL2_FRAME_HEADER;
+	frame.version = FRAME_TYPE_TELEMETRY;
+	frame.length = length + sizeof(srxl_frame_t) + sizeof(uint16_t);
+
+	/* copy the completed buffer to the transmission buffer */
+	memcpy(frame.payload, payload, length);
+
+	uint8_t *crc_dest = frame.payload + length;
+	crc_dest[0] = static_cast<uint8_t>(crc >> 8);   // MSB?
+	crc_dest[1] = static_cast<uint8_t>(crc & 0xFF); // LSB?
+
+	// TODO: Fix me!
+	// _bytes_to_transmit = get_frame_length(frame);
+}
+
+constexpr uint8_t SRXLCodec::get_frame_length(srxl_frame_t &frame)
+{
+	return frame.length;
+}
+
+SRXLCodec::srxl_frame_t &SRXLCodec::get_frame()
+{
+	return _frame_buffer;
+}
+
+void SRXLCodec::get_buffer(uint8_t *&buffer, size_t &buf_size)
+{
+	buffer = _receive_buffer;
+	buf_size = _bytes_received;
+}

--- a/src/lib/rc/srxl.cpp
+++ b/src/lib/rc/srxl.cpp
@@ -1,64 +1,447 @@
 #include <cstring>
+#include <cmath>
+
+#include <termios.h>
+
 #include "crc16.h"
+
 #include "srxl.hpp"
 
-constexpr bool SRXLCodec::is_srxl_telemetry(srxl_frame_t &frame)
+#define SRXL_DEBUG_LEVEL 2
+
+// enable debugging output
+#if SRXL_DEBUG_LEVEL > 0
+#define SRXL_WARN(...) printf(__VA_ARGS__)
+#else
+#define SRXL_WARN(...)
+#endif
+
+#if SRXL_DEBUG_LEVEL > 1
+#define SRXL_DEBUG(...) printf(__VA_ARGS__)
+#else
+#define SRXL_DEBUG(...)
+#endif
+
+// verbose debugging--Careful when enabling: it leads to too much output, causing dropped bytes
+#if SRXL_DEBUG_LEVEL > 2
+#define SRXL_TRACE(...) printf(__VA_ARGS__)
+#else
+#define SRXL_TRACE(...)
+#endif
+
+void SRXLCodec::configure(const int new_file_despcriptor)
 {
-	if ((frame.header == SRXL1_FRAME_HEADER)
-	    || (frame.header != SRXL2_FRAME_HEADER)) {
-		// success -- continue
+	SRXL_TRACE(">> SRXL: initializing...\n");
+
+	_fd = new_file_despcriptor;
+
+#ifdef SPEKTRUM_POWER_CONFIG
+	// Enable power controls for Spektrum receiver
+	SPEKTRUM_POWER_CONFIG();
+#endif
+#ifdef SPEKTRUM_POWER
+	// enable power on Spektrum connector
+	SPEKTRUM_POWER(true);
+#endif
+
+	if (_fd > 0) {
+		struct termios t;
+
+		/* 115200bps, no parity, one stop bit */
+		tcgetattr(_fd, &t);
+		cfsetspeed(&t, 115200);
+		t.c_cflag &= ~(CSTOPB | PARENB);
+		tcsetattr(_fd, TCSANOW, &t);
+
+		set_single_wire(true);
+
+		reset();
+	}
+}
+
+uint16_t *SRXLCodec::channels()
+{
+	return _control_channels;
+}
+
+int SRXLCodec::channel_count() const
+{
+	return _updated_channel_count;
+}
+
+uint16_t SRXLCodec::decode_channel(const uint16_t raw_value)
+{
+	// The data for the channels is as follows:
+	//     CH 1 = 0x2AA0 = 10912     // (approx -100% on Spektrum transmitter)
+	//     CH 2 = 0x8000 = 32768     // (center position)
+	//     CH 3 = 0x8004 = 32772     // (1 tick above center at 14-bit resolution)
+	//     CH 5 = 0x7FFC = 32764     // (1 tick below center at 14-bit resolution)
+	//     CH 6 = 0xD554 = 54612     // (approx. 100% on Spektrum transmitter)
+	if (raw_value < 0x1000 || raw_value > 0xF000) {
+		// if the value is unrealistic, fail the parsing entirely
+		SRXL_DEBUG("Invalid SRXL-Channel range: %u\n", raw_value);
+		return 0;
+	}
+
+	// The channel value must be bit-shifted to the right to match the application’s accepted resolution.
+	// For example, to match DSMX 2048 data (11-bit), shift each value 5 bits to the right. -- SXRL2 Specification p15
+	auto shifted_value = raw_value >> 5;
+
+	return shifted_value;
+}
+
+uint16_t SRXLCodec::frame_drops() const
+{
+	return _frame_drops;
+}
+
+void SRXLCodec::handle_bind_frame(const uint8_t *const frame)
+{
+	// <0xA6><0x41><Length><Request><DeviceID><Type><Options><GUID><UID><CRC>
+
+	const uint8_t request_type = frame[3];
+
+	if (0xEB == request_type) {
+		printf("        ::Bind-Mode-Entered::\n");
+		// Enter Bind Mode -- for receivers; ignore.
+		return;
+
+	} else if (0xB5 == request_type) {
+		// Request Bind Status -- for receivers; ignore.
+		printf("        ::Request-Bind-Status::\n");
+		return;
+
+	} else if (0xDB == request_type) {
+		// Bind Data Report
+		print_frame("    ::Bind-Report: ", frame, FRAME_LENGTH_BIND);
+
+		const uint8_t src_id = frame[4];
+		printf("        ::Bind::  from: %02x(=?=%02x)", src_id, _receiver_id);
+
+		_receiver_bind_type = frame[5];
+		printf("  btype: %02x", _receiver_bind_type);
+
+		_receiver_options = frame[6];
+		printf("  telemetry: %s\n", (supports_telemetry() ? "enabled" : "disabled"));
+
+	} else if (0xB5 == request_type) {
+		// Set Bind Info -- for receivers; ignore.
+		printf("        ::Set-Bind-Info::\n");
+
+		const uint8_t src_id = frame[4];
+		printf("        ::Bind::  from: %02x(%02x)", src_id, _receiver_id);
+
+		_receiver_bind_type = frame[5];
+		printf("  btype: %02x", _receiver_bind_type);
+
+		_receiver_options = frame[6];
+		printf("  telemetry: %s\n", (supports_telemetry() ? "enabled" : "disabled"));
+
+		return;
+
 	} else {
+		// invalid value; ignore.
+		return;
+	}
+}
+
+void SRXLCodec::handle_control_frame(const uint8_t *const frame)
+{
+
+	const int8_t rssi_report = frame[5];
+
+	if (0 < rssi_report) {
+		// this is a percentage RSSI report:
+		_rssi_percentage = rssi_report;
+
+	} else {
+		// this is a dBm RSSI report; NYI
+	}
+
+	_frame_drops = (frame[6] << 8) | frame[7];
+
+	// channel mask is small-endian:
+	const uint32_t channel_mask = frame[8] | (frame[9] << 8) | (frame[10] << 16) | (frame[11] << 24);
+
+	if (0 == channel_mask) {
+		// common-case-optimization: if channel-mask is zero, there is no data to interpret.
+		return;
+	}
+
+	int receive_channel_index = 12;  ///< byte index in the received frame
+	int max_channel_count = 0;
+
+
+	for (int receive_channel_number = 0; receive_channel_number < max_control_channel_count; ++receive_channel_number) {
+		// only extract channels which are actually received
+		const bool channel_present = static_cast<uint32_t>(1 << receive_channel_number) & channel_mask;
+
+		if (channel_present) {
+			const uint16_t receive_channel_value = frame[receive_channel_index] | (frame[receive_channel_index + 1] << 8);
+			const uint16_t px4_channel_value = decode_channel(receive_channel_value);
+			max_channel_count = receive_channel_number + 1;
+
+			if (0 != px4_channel_value) {
+				_control_channels[receive_channel_number] = px4_channel_value;
+			}
+
+			receive_channel_index += 2;
+		}
+	}
+
+#ifdef SRXL_DEBUG_LEVEL
+	constexpr static uint64_t print_interval = 1e6;
+
+	if (print_interval < (_last_rx_time - _last_print_time)) {
+		_last_print_time = _last_rx_time;
+		printf("    >>Control-Frame::Channel-Mask:  %08x \n", channel_mask);
+
+		for (int i = 0; i < 4; ++i) {   // 4 channels are the troublesome ones-- pitch roll, throttle, yaw
+			printf("            [%2d]: %04x \n", i, _control_channels[i]);
+		}
+	}
+
+#endif
+
+	if (max_channel_count > _updated_channel_count) {
+		_updated_channel_count = max_channel_count;
+	}
+}
+
+void SRXLCodec::handle_handshake_frame(const uint8_t *const request)
+{
+	// Note: currently ignore, and assume this is an active handshake request
+	const uint8_t dest_id = request[4];
+
+	if (0xFF == dest_id) {
+		// This is a broadcast id:
+		//   - This coincides with a successful receiver handshake
+		//   - Used to set baud rate; we only support 115200 baud, so make no changes
+		SRXL_DEBUG("    >> Handshake complete: 0xFF\n");
+		return;
+
+	} else if (_fc_id == dest_id) {
+		SRXL_DEBUG("    >> Handshake Probe: %02x => %02x\n", request[3], request[4]);
+	}
+
+	const uint8_t source_id = request[3];
+
+	if (_fc_id == source_id) {
+		// we detected our own transmission packet.. ignore
+		return;
+	}
+
+	printf("    >> Handshake complete:  %d => %d\n", source_id, dest_id);
+	_receiver_id = source_id;
+
+	// ==== Construct Reply ====
+	uint8_t reply[FRAME_LENGTH_HANDSHAKE];
+	reply[0] = SRXL2_FRAME_HEADER;
+	reply[1] = FRAME_TYPE_HANDSHAKE;
+	reply[2] = FRAME_LENGTH_HANDSHAKE;
+	reply[3] = _fc_id; ///< SrcId
+	reply[4] = _receiver_id;  ///< DestID
+	reply[5] = 10;  ///< Priority; 10 == 0x0A = default
+	reply[6] = 0;   ///< BaudRate; 0 => 115200 baud
+	reply[7] = 0;   ///< Info
+
+	// store as big-endian
+	reply[8] = static_cast<uint8_t>(FLIGHT_CONTROLLER_UUID >> 24);
+	reply[9] = static_cast<uint8_t>(FLIGHT_CONTROLLER_UUID >> 16);
+	reply[10] = static_cast<uint8_t>(FLIGHT_CONTROLLER_UUID >> 8);
+	reply[11] = static_cast<uint8_t>(FLIGHT_CONTROLLER_UUID);
+
+	pack(reply, FRAME_LENGTH_HANDSHAKE);
+
+	// send reply
+	::write(_fd, &reply, FRAME_LENGTH_HANDSHAKE);
+}
+
+void SRXLCodec::handle_signal_quality(const uint8_t *const request)
+{
+}
+
+void SRXLCodec::pack(uint8_t *const frame, uint8_t frame_length)
+{
+	uint16_t crc = crc16(reinterpret_cast<const uint8_t *>(frame), frame_length - 2);
+	frame[frame_length - 2] = static_cast<uint8_t>(crc >> 8);   // MSB
+	frame[frame_length - 1] = static_cast<uint8_t>(crc & 0xFF); // LSB
+}
+
+
+bool SRXLCodec::parse(const uint64_t now, const uint8_t *source, const uint8_t source_length)
+{
+
+	// check 1: look for sync byte:
+	const uint8_t *cursor = source;   // < movable pointer to constant data
+
+	//     Note: This parser ignores SRXL version 1 messages
+	if (*cursor != SRXL2_FRAME_HEADER) {
+		// printf("        XX Not an SRXL frame.\n");
 		return false;
 	}
 
-	switch (frame.version) {
-	case FRAME_TYPE_HANDSHAKE:
-	case FRAME_TYPE_BIND:
-	case FRAME_TYPE_PARAMETER:
-	case FRAME_TYPE_SIGNAL_QUALITY:
-	case FRAME_TYPE_TELEMETRY:
-	case FRAME_TYPE_CONTROL:
-		// success -- continue
-		break;
+	// if a valid frame, start extracting fields
+	const uint8_t frame_type = cursor[1];
+	const uint8_t frame_length = cursor[2];
 
-	default:
+	// check 2: have we received enough bytes to be a frame, at all?
+	if (source_length < SRXL_MIN_FRAME_LENGTH) {
+		// printf("        XX incomplete frame: %d < %d\n", source_length, frame->length );
+		return false;
+	}
+
+	// check 3: have we received the whole frame?
+	if (source_length < frame_length) {
+		// printf("        XX incomplete frame: %d < %d\n", source_length, frame->length );
+		return false;
+	}
+
+	// check 4: verify checksum
+	if (! validate_checksum(cursor, frame_length)) {
+		return false;
+	}
+
+	_last_rx_time = now;
+
+	// check 5: is this a known frame type => route appropriately
+	// printf("    ::frame-type:  %02x: \n", frame_type );
+	switch (frame_type) {
+	case FRAME_TYPE_BIND:
+		handle_bind_frame(cursor);
+		return false;
+
+	case FRAME_TYPE_CONTROL:
+		handle_control_frame(cursor);
+		return true;
+
+	case FRAME_TYPE_HANDSHAKE:
+		handle_handshake_frame(cursor);
+		_updated_channel_count = 0;
+		return true;
+
+	case FRAME_TYPE_PARAMETER:
+		// not supported
+		return false;
+
+	case FRAME_TYPE_SIGNAL_QUALITY:
+		// NYI
+		// handle_signal_quality( *frame );
+		return false;
+
+	case FRAME_TYPE_TELEMETRY:
+		// receiving telemetry not supported; only sending telemetry
+		return false;
+
+	default:  // failure path
+		return false;
+	}
+}
+
+#if SRXL_DEBUG_LEVEL > 1
+void SRXLCodec::print_frame(const char *const preamble, const uint8_t *cursor, uint8_t frame_length)
+{
+	printf("%s %d: [", preamble, frame_length);
+
+	for (int i = 0; i < frame_length; ++i, ++cursor) {
+		printf(" %02X", *cursor);
+	}
+
+	printf("]\n");
+}
+#endif
+
+void SRXLCodec::reset()
+{
+	// _partial_frame_count = 0;
+
+	// initializes all channels to the invalid-flag-value
+	for (int i = 0; i < max_control_channel_count; ++i) {
+		_control_channels[i] = UINT16_MAX;
+	}
+
+	_last_rx_time = hrt_absolute_time();
+
+	_frame_drops = 0;
+
+	_rssi_percentage = 0;
+
+	_updated_channel_count = 0;
+
+	// reset connection state
+	_receiver_id = 0;
+	_receiver_bind_type = 0;
+	_receiver_options = 0;
+}
+
+int SRXLCodec::rssi_percentage() const
+{
+	return _rssi_percentage;
+}
+
+int SRXLCodec::request_bind_receiver(uint8_t bind_mode)
+{
+	printf("    >> Request Bind as: %02x\n", bind_mode);
+
+	// ==== Construct Reply ====
+	// <0xA6><0x41><Length> <Request><DeviceID><Type><Options><GUID><UID><CRC>
+	uint8_t reply[FRAME_LENGTH_BIND];
+	reply[0] = SRXL2_FRAME_HEADER;
+	reply[1] = FRAME_TYPE_BIND;
+	reply[2] = FRAME_LENGTH_BIND;
+	reply[3] = 0xEB;  ///< request-type
+	reply[4] = _receiver_id;  ///< DeviceId === DestID === default receiver address
+	reply[5] = bind_mode;  ///< bind-type
+	///< bind type (1==telemetry, 2==bind-reply, 3=request US power level for transmits )
+	reply[6] = 3; // = 1 & 2;
+	// bit #2 ( == 0x03) requests US Power Levels -- FCC-Compliant Power Levels)
+
+	// Zero out remaining fields
+	// // GUID field:
+	// memset(reply+7, 0, 8);
+	// // UID field:
+	// memset(reply+15, 0, 4);
+
+	pack(reply, FRAME_LENGTH_BIND);
+
+	// send reply
+	return ::write(_fd, &reply, FRAME_LENGTH_BIND);
+}
+
+bool SRXLCodec::set_single_wire(bool single_wire)
+{
+	auto flags  = single_wire ? (SER_SINGLEWIRE_ENABLED | SER_SINGLEWIRE_PUSHPULL | SER_SINGLEWIRE_PULLDOWN) : 0 ;
+
+	if (0 > ioctl(_fd, TIOCSSINGLEWIRE, flags)) {
+		perror("!! Could not set TIOCSSINGLEWIRE:");
 		return false;
 	}
 
 	return true;
 }
 
-void SRXLCodec::set_payload(uint8_t *payload, size_t length, srxl_frame_t &frame)
+bool SRXLCodec::supports_telemetry() const
 {
-	uint16_t crc = crc16((const uint8_t *)payload, length);
-
-	frame.header = SRXL2_FRAME_HEADER;
-	frame.version = FRAME_TYPE_TELEMETRY;
-	frame.length = length + sizeof(srxl_frame_t) + sizeof(uint16_t);
-
-	/* copy the completed buffer to the transmission buffer */
-	memcpy(frame.payload, payload, length);
-
-	uint8_t *crc_dest = frame.payload + length;
-	crc_dest[0] = static_cast<uint8_t>(crc >> 8);   // MSB?
-	crc_dest[1] = static_cast<uint8_t>(crc & 0xFF); // LSB?
-
-	// TODO: Fix me!
-	// _bytes_to_transmit = get_frame_length(frame);
+	return (1 & _receiver_options);
 }
 
-constexpr uint8_t SRXLCodec::get_frame_length(srxl_frame_t &frame)
+bool SRXLCodec::validate_checksum(const uint8_t *const frame, uint8_t frame_length)
 {
-	return frame.length;
-}
+	const uint16_t found_checksum = (frame[frame_length - 2] << 8) | frame[frame_length - 1];
 
-SRXLCodec::srxl_frame_t &SRXLCodec::get_frame()
-{
-	return _frame_buffer;
-}
+	if (0 == found_checksum) {
+		printf("    XX Peer has returned the frame with checksum == 0 !?\n");
+		return false;
+	}
 
-void SRXLCodec::get_buffer(uint8_t *&buffer, size_t &buf_size)
-{
-	buffer = _receive_buffer;
-	buf_size = _bytes_received;
+	const uint16_t calculated_checksum = crc16(reinterpret_cast<const uint8_t *>(frame), frame_length - 2);
+
+	if (found_checksum == calculated_checksum) {
+		return true;
+
+	} else {
+		printf("    XX invalid checksum:  %04X != %04X\n", found_checksum, calculated_checksum);
+		return false;
+	}
+
 }

--- a/src/lib/rc/srxl.cpp
+++ b/src/lib/rc/srxl.cpp
@@ -450,6 +450,9 @@ int SRXLCodec::rssi_percentage() const
 
 int SRXLCodec::request_bind_receiver(uint8_t bind_mode)
 {
+	// explicitly override bind_mode -- upstream code does not correctly populate this value
+	bind_mode = SRXLCodec::SRXL_BIND_MODE_DSMX_11MS;
+
 	printf("    >> Request Bind as: %02x\n", bind_mode);
 
 	// ==== Construct Reply ====

--- a/src/lib/rc/srxl.cpp
+++ b/src/lib/rc/srxl.cpp
@@ -110,9 +110,11 @@ uint16_t SRXLCodec::decode_channel(const uint16_t raw_value)
 
 	// The channel value must be bit-shifted to the right to match the application’s accepted resolution.
 	// For example, to match DSMX 2048 data (11-bit), shift each value 5 bits to the right. -- SXRL2 Specification p15
-	auto shifted_value = raw_value >> 5;
+	auto shifted_value = raw_value >> 6;
 
-	return shifted_value;
+	auto offset_value = shifted_value + 1000;
+
+	return offset_value;
 }
 
 uint16_t SRXLCodec::frame_drops() const

--- a/src/lib/rc/srxl.cpp
+++ b/src/lib/rc/srxl.cpp
@@ -264,7 +264,9 @@ void SRXLCodec::handle_control_frame(const uint8_t *const frame)
 
 	if (print_interval < (_last_rx_time - _last_print_time)) {
 		_last_print_time = _last_rx_time;
-		printf("    >>Control-Frame::Channel-Mask:  %08x \n", channel_mask);
+
+		// this is a useful debug printf, but any type-specifier seems to break the format checks
+		// printf("    >>Control-Frame::Channel-Mask:  %08lx \n", channel_mask);
 
 		for (int i = 0; i < 4; ++i) {   // 4 channels are the troublesome ones-- pitch roll, throttle, yaw
 			printf("            [%2d]: %04x \n", i, _control_channels[i]);

--- a/src/lib/rc/srxl.cpp
+++ b/src/lib/rc/srxl.cpp
@@ -1,3 +1,36 @@
+/****************************************************************************
+ *
+ *	Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
 #include <cstring>
 #include <cmath>
 

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -123,6 +123,8 @@ private:
 
 private:
 // ====== ====== ====== ====== Private API ====== ====== ====== ======
+	static uint16_t srxlCrc16(const uint8_t *const packet);
+
 	uint16_t decode_channel(const uint16_t raw_value);
 
 	void handle_bind_frame(const uint8_t *const frame);
@@ -133,9 +135,9 @@ private:
 
 	void handle_signal_quality(const uint8_t *const frame);
 
-	void pack(uint8_t *const frame, uint8_t frame_length);
+	void pack(uint8_t *const frame);
 
-	void print_frame(const char *const preamble, const uint8_t *frame, uint8_t frame_length);
+	void print_frame(const char *const preamble, const uint8_t *frame);
 
 	void reset();
 
@@ -144,7 +146,7 @@ private:
 
 	// void set_payload( uint8_t *payload, size_t length, srxl_frame_t* dest);
 
-	bool validate_checksum(const uint8_t *const frame, uint8_t frame_length);
+	bool validate_checksum(const uint8_t *const frame);
 
 private:
 	// size_t _bytes_received;

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -1,0 +1,122 @@
+/****************************************************************************
+ *
+ *	Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *	notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *	notice, this list of conditions and the following disclaimer in
+ *	the documentation and/or other materials provided with the
+ *	distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *	used to endorse or promote products derived from this software
+ *	without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file srxl.h
+ *
+ * RC protocol definition for Spektrum SRXL
+ *
+ * @author Kurt Kiefer <kekiefer@gmail.com>
+ * @author Daniel Williams <equipoise@gmail.com>
+ */
+
+#pragma once
+
+// "Cannot find the standard library!?"
+// #include <array>
+
+#include <cstdint>
+
+class SRXLCodec
+{
+// ====== ====== ====== ====== Public Constants ====== ====== ====== ======
+public:
+
+	// Version 1 specific
+	constexpr static const uint8_t SRXL1_FRAME_HEADER = 	0xA5;
+	constexpr static const uint8_t SRXL1_MAX_LENGTH =	64;
+
+	// Version 2 specific
+	constexpr const static uint8_t SRXL2_FRAME_HEADER = 	0xA6;
+	constexpr const static uint8_t SRXL2_MIN_LENGTH =	5;
+	constexpr const static uint8_t SRXL2_MAX_LENGTH =	80;
+
+	// Packet Types
+	enum frame_type_t {
+		FRAME_TYPE_HANDSHAKE = 0x21,
+		FRAME_TYPE_BIND = 0x41,
+		FRAME_TYPE_PARAMETER = 0x50,
+		FRAME_TYPE_SIGNAL_QUALITY = 0x55,
+		FRAME_TYPE_TELEMETRY = 0x80,
+		FRAME_TYPE_CONTROL = 0xCD,
+	};
+
+	// apply to all versions
+	constexpr static const uint8_t SRXL_FRAME_HEADER_SIZE = 3;
+	constexpr static const uint8_t SRXL_MAX_FRAME_LENGTH = SRXL2_MAX_LENGTH;
+	constexpr static const uint8_t SRXL_MAX_PAYLOAD_LENGTH = SRXL2_MAX_LENGTH - SRXL_FRAME_HEADER_SIZE;
+
+
+// ====== ====== ====== ====== Public Types ====== ====== ====== ======
+public:
+	typedef uint8_t srxl_buffer_t[SRXL_MAX_FRAME_LENGTH];
+
+#pragma pack(push,1)
+	struct srxl_frame_t {
+		uint8_t header;
+		uint8_t version;
+		uint8_t length;
+		uint8_t payload[SRXL_MAX_PAYLOAD_LENGTH];
+	};
+#pragma pack(pop)
+	static_assert(sizeof(srxl_frame_t) == SRXL_MAX_FRAME_LENGTH,
+		      "Inconsistent frame-struct size!! This is a developer error!");
+
+
+// ====== ====== ====== ====== Public API ====== ====== ====== ======
+public:
+	SRXLCodec() = default;
+	~SRXLCodec() = default;
+
+	static void set_payload(uint8_t *payload, size_t length, srxl_frame_t &frame);
+
+	srxl_frame_t &get_frame();
+
+	void get_buffer(uint8_t *&buf_ref, size_t &buf_size);
+
+	static constexpr bool is_srxl_telemetry(srxl_frame_t &frame);
+
+	static constexpr uint8_t get_frame_length(srxl_frame_t &frame);
+
+private:
+	// raw buffer; will match bytes on/to/from the wire
+	srxl_buffer_t _receive_buffer;
+
+	// maybe should overlay the byte-buffer, above?
+	srxl_frame_t _frame_buffer;
+
+	size_t _bytes_received;
+
+	size_t _bytes_to_transmit;
+
+};

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -114,6 +114,13 @@ private:
 
 	constexpr static const uint32_t FLIGHT_CONTROLLER_UUID = 0x12345678;
 
+	// for complete reference, see SRXL2 Specification, Rev K, page 10
+	//     the other bind types are not implemented in this driver
+	enum bind_type_t {
+		SRXL_BIND_NONE = 0x00,
+		SRXL_BIND_MODE_DSMX_22MS =  0xA2,   // Enforce 22ms ONLY
+		SRXL_BIND_MODE_DSMX_11MS =  0xB2,   // auto-selects 11ms or 22ms based on best available speed.
+	};
 
 private:
 // ====== ====== ====== ====== Private API ====== ====== ====== ======

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -45,8 +45,6 @@
 
 class SRXLCodec
 {
-
-// ====== ====== ====== ====== Public API ====== ====== ====== ======
 public:
 	SRXLCodec() = default;
 	~SRXLCodec() = default;
@@ -73,7 +71,7 @@ public:
 	/// \brief check if the receiver currently accepts telemetry downlink
 	bool supports_telemetry() const;
 
-// ====== ====== ====== ====== Public Types ====== ====== ====== ======
+
 private:
 	// Version 1 specific
 	constexpr static const uint8_t SRXL1_FRAME_HEADER = 	0xA5;
@@ -123,7 +121,7 @@ private:
 	};
 
 private:
-// ====== ====== ====== ====== Private API ====== ====== ====== ======
+
 	static uint16_t srxlCrc16(const uint8_t *const packet);
 
 	uint16_t decode_channel(const uint16_t raw_value);

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -32,9 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file srxl.h
- *
- * RC protocol definition for Spektrum SRXL
+ * Serial protocol definition for Spektrum SRXL
  *
  * @author Kurt Kiefer <kekiefer@gmail.com>
  * @author Daniel Williams <equipoise@gmail.com>

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *	Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *	Copyright (c) 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,12 +46,41 @@
 // #include <array>
 
 #include <cstdint>
+#include <px4_platform_common/defines.h>
+// #include <px4_platform_common/px4_config.h>
 
 class SRXLCodec
 {
-// ====== ====== ====== ====== Public Constants ====== ====== ====== ======
-public:
 
+// ====== ====== ====== ====== Public API ====== ====== ====== ======
+public:
+	SRXLCodec() = default;
+	~SRXLCodec() = default;
+
+	void configure(int fd);
+
+	/// \brief retrieve frame drops count, as reported by the receiver
+	uint16_t frame_drops() const;
+
+	/// \brief parse and process, the frame in the given buffer
+	bool parse(const uint64_t now, const uint8_t *source, const uint8_t source_length);
+
+	/// \brief retrieve control channel data
+	uint16_t *channels();
+	int channel_count() const;
+
+	/// \brief request that the currently-connected receiver place itself into bind-mode
+	int request_bind_receiver(const uint8_t bind_mode);
+
+	/// \brief get the last reported signal strength value.
+	/// \return reports signal RSSI in percentage points: 0-100
+	int rssi_percentage() const;
+
+	/// \brief check if the receiver currently accepts telemetry downlink
+	bool supports_telemetry() const;
+
+// ====== ====== ====== ====== Public Types ====== ====== ====== ======
+private:
 	// Version 1 specific
 	constexpr static const uint8_t SRXL1_FRAME_HEADER = 	0xA5;
 	constexpr static const uint8_t SRXL1_MAX_LENGTH =	64;
@@ -71,52 +100,83 @@ public:
 		FRAME_TYPE_CONTROL = 0xCD,
 	};
 
+	// Frame Sizes
+	constexpr static uint8_t FRAME_LENGTH_HANDSHAKE = 14;
+	constexpr static uint8_t FRAME_LENGTH_BIND = 21;
+	constexpr static uint8_t FRAME_LENGTH_PARAMETER = 14;
+	constexpr static uint8_t FRAME_LENGTH_SIGNAL_QUALITY = 10;
+	constexpr static uint8_t FRAME_LENGTH_TELEMETRY = 22;
+
 	// apply to all versions
 	constexpr static const uint8_t SRXL_FRAME_HEADER_SIZE = 3;
+	constexpr static const uint8_t SRXL_MIN_FRAME_LENGTH = SRXL2_MIN_LENGTH;
 	constexpr static const uint8_t SRXL_MAX_FRAME_LENGTH = SRXL2_MAX_LENGTH;
 	constexpr static const uint8_t SRXL_MAX_PAYLOAD_LENGTH = SRXL2_MAX_LENGTH - SRXL_FRAME_HEADER_SIZE;
 
+	constexpr static const uint8_t SRXL_RECIEVER_MIN_ID = 0x10;
+	constexpr static const uint8_t SRXL_RECIEVER_MAX_ID = 0x2F;
+	/// The PX4 flight controller will advertise this SRXL bus ID:
+	constexpr static const uint8_t FLIGHT_CONTROLLER_DEFAULT_ID = 0x30;
 
-// ====== ====== ====== ====== Public Types ====== ====== ====== ======
-public:
-	typedef uint8_t srxl_buffer_t[SRXL_MAX_FRAME_LENGTH];
+	constexpr static const uint32_t FLIGHT_CONTROLLER_UUID = 0x12345678;
 
-#pragma pack(push,1)
-	struct srxl_frame_t {
-		uint8_t header;
-		uint8_t version;
-		uint8_t length;
-		uint8_t payload[SRXL_MAX_PAYLOAD_LENGTH];
-	};
-#pragma pack(pop)
-	static_assert(sizeof(srxl_frame_t) == SRXL_MAX_FRAME_LENGTH,
-		      "Inconsistent frame-struct size!! This is a developer error!");
-
-
-// ====== ====== ====== ====== Public API ====== ====== ====== ======
-public:
-	SRXLCodec() = default;
-	~SRXLCodec() = default;
-
-	static void set_payload(uint8_t *payload, size_t length, srxl_frame_t &frame);
-
-	srxl_frame_t &get_frame();
-
-	void get_buffer(uint8_t *&buf_ref, size_t &buf_size);
-
-	static constexpr bool is_srxl_telemetry(srxl_frame_t &frame);
-
-	static constexpr uint8_t get_frame_length(srxl_frame_t &frame);
 
 private:
-	// raw buffer; will match bytes on/to/from the wire
-	srxl_buffer_t _receive_buffer;
+// ====== ====== ====== ====== Private API ====== ====== ====== ======
+	uint16_t decode_channel(const uint16_t raw_value);
 
-	// maybe should overlay the byte-buffer, above?
-	srxl_frame_t _frame_buffer;
+	void handle_bind_frame(const uint8_t *const frame);
 
-	size_t _bytes_received;
+	void handle_control_frame(const uint8_t *const frame);
 
-	size_t _bytes_to_transmit;
+	void handle_handshake_frame(const uint8_t *const frame);
+
+	void handle_signal_quality(const uint8_t *const frame);
+
+	void pack(uint8_t *const frame, uint8_t frame_length);
+
+	void print_frame(const char *const preamble, const uint8_t *frame, uint8_t frame_length);
+
+	void reset();
+
+	// adapted from frsky_telemetry module.  Seems to work ok.
+	bool set_single_wire(bool single_wire = true);
+
+	// void set_payload( uint8_t *payload, size_t length, srxl_frame_t* dest);
+
+	bool validate_checksum(const uint8_t *const frame, uint8_t frame_length);
+
+private:
+	// size_t _bytes_received;
+
+	// size_t _bytes_to_transmit;
+
+	// file handle for internal serial port
+	// this is singleton-enforced
+	int _fd;
+
+	hrt_abstime _last_rx_time;
+	hrt_abstime _last_print_time = 0;
+
+	uint16_t _frame_drops;
+
+	// uint32_t _partial_frame_count;
+
+	uint8_t _rssi_percentage;
+	static constexpr int max_control_channel_count = 32;
+	uint16_t _control_channels[max_control_channel_count];
+	int _updated_channel_count = 0;
+
+	// id for this px4-flight-controller  ... on the srxl bus
+	constexpr static uint8_t _fc_id = FLIGHT_CONTROLLER_DEFAULT_ID;
+
+	// id of the paired spektrum receiver
+	uint8_t _receiver_id = 0;
+	uint8_t _receiver_bind_type = 0;  // 0 == not bound
+	// Options: A byte with 3 RF enable bits:
+	//	bit 0:	enable Telemetry transmission over RF for the device
+	//	bit 1:	allow Bind reply over RF
+	//	bit 2:	request US power level for RF transmits
+	uint8_t _receiver_options = 0;
 
 };

--- a/src/lib/rc/srxl.hpp
+++ b/src/lib/rc/srxl.hpp
@@ -42,12 +42,8 @@
 
 #pragma once
 
-// "Cannot find the standard library!?"
-// #include <array>
-
 #include <cstdint>
 #include <px4_platform_common/defines.h>
-// #include <px4_platform_common/px4_config.h>
 
 class SRXLCodec
 {
@@ -175,6 +171,7 @@ private:
 	// id of the paired spektrum receiver
 	uint8_t _receiver_id = 0;
 	uint8_t _receiver_bind_type = 0;  // 0 == not bound
+
 	// Options: A byte with 3 RF enable bits:
 	//	bit 0:	enable Telemetry transmission over RF for the device
 	//	bit 1:	allow Bind reply over RF

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -432,9 +432,12 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			schedule_reboot(100000);
 			break;
 
+#if defined(SPEKTRUM_POWER)
+
 		case PX4IO_P_SETUP_DSM:
 			dsm_bind(value & 0x0f, (value >> 4) & 0xF);
 			break;
+#endif
 
 		case PX4IO_P_SETUP_FORCE_SAFETY_ON:
 			if (value == PX4IO_FORCE_SAFETY_MAGIC) {

--- a/src/systemcmds/tests/test_spektrum_telemetry.c
+++ b/src/systemcmds/tests/test_spektrum_telemetry.c
@@ -1,0 +1,252 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Author: @author Simon Wilks <sjwilks@gmail.com>
+ *   Author: @author Kurt Kiefer <kekiefer@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file test_spektrum_telemetry.c
+ *
+ * Tests the Spektrum SRXL telemetry support. Based on HoTT telemetry tests.
+ *
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <drivers/drv_gpio.h>
+#include <px4_config.h>
+#include <px4_defines.h>
+#include <px4_log.h>
+#include <sys/types.h>
+#include <systemlib/err.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include "tests_main.h"
+
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+static int open_uart(const char *device)
+{
+	/* baud rate */
+	int speed = B115200;
+
+	/* open uart */
+	int uart = open(device, O_RDWR | O_NOCTTY);
+
+	if (uart < 0) {
+		PX4_ERR("FAIL: Error opening port");
+		return ERROR;
+	}
+
+	/* Try to set baud rate */
+	struct termios uart_config;
+
+	/* Fill the struct for the new configuration */
+	tcgetattr(uart, &uart_config);
+
+	/* Clear ONLCR flag (which appends a CR for every LF) */
+	uart_config.c_oflag &= ~ONLCR;
+
+	uart_config.c_cflag &= ~(CSTOPB | PARENB);
+
+	/* Set baud rate */
+	if (cfsetispeed(&uart_config, speed) < 0 || cfsetospeed(&uart_config, speed) < 0) {
+		PX4_ERR("FAIL: Error setting baudrate / termios config for cfsetispeed, cfsetospeed");
+		return ERROR;
+	}
+
+	if (tcsetattr(uart, TCSANOW, &uart_config) < 0) {
+		PX4_ERR("FAIL: Error setting baudrate / termios config for tcsetattr");
+		return ERROR;
+	}
+
+	return uart;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: test_hott_telemetry
+ ****************************************************************************/
+
+int test_spektrum_telemetry(int argc, char *argv[])
+{
+	PX4_INFO("Spektrum Telemetry Test Requirements:");
+	PX4_INFO("- Radio on and Electric Air. Mod on (telemetry -> sensor select).");
+	PX4_INFO("- Receiver telemetry port must be in telemetry mode.");
+	PX4_INFO("- Connect telemetry wire to /dev/ttyS1 (USART2).");
+	PX4_INFO("Testing...");
+
+	const char device[] = "/dev/ttyS5";
+	int fd = open_uart(device);
+
+	if (fd < 0) {
+		close(fd);
+		return ERROR;
+	}
+
+#ifdef TIOCSSINGLEWIRE
+	/* Activate single wire mode */
+	ioctl(fd, TIOCSSINGLEWIRE, SER_SINGLEWIRE_ENABLED);
+#endif
+
+	char send = 'a';
+	//write(fd, &send, 1);
+
+	/* Since TX and RX are now connected we should be able to read in what we wrote */
+	const int timeout = 1000;
+	struct pollfd fds[] = { { .fd = fd, .events = POLLIN } };
+
+	if (poll(fds, 1, timeout) == 0) {
+		PX4_ERR("FAIL: Could not read sent data.");
+		return 1;
+	}
+
+	char receive;
+	read(fd, &receive, 1);
+	PX4_INFO("PASS: Single wire enabled. Sent %x and received %x", send, receive);
+
+	/* Attempt to read HoTT poll messages from the HoTT receiver */
+	int received_count = 0;
+	int valid_count = 0;
+	const int max_polls = 5;
+	uint8_t byte;
+
+	for (; received_count < 32; received_count++) {
+		if (poll(fds, 1, timeout) == 0) {
+			PX4_ERR("FAIL: Could not read sent data. Is your HoTT receiver plugged in on %s?", device);
+			return 1;
+
+		} else {
+			read(fd, &byte, 1);
+
+			if (byte == 0xb2) {
+				valid_count++;
+			}
+
+			/* Read the device ID being polled */
+			read(fd, &byte, 1);
+		}
+	}
+
+	if (received_count > 0 && valid_count > 0) {
+		if (received_count == max_polls && valid_count == max_polls) {
+			PX4_INFO("PASS: Received %d out of %d valid byte pairs from the HoTT receiver device.", received_count, max_polls);
+
+		} else {
+			PX4_WARN("WARN: Received %d out of %d byte pairs of which %d were valid from the HoTT receiver device.", received_count,
+				 max_polls, valid_count);
+		}
+
+	} else {
+		/* Let's work out what went wrong */
+		if (received_count == 0) {
+			PX4_ERR("FAIL: Could not read any polls from HoTT receiver device.");
+			return 1;
+		}
+
+		if (valid_count == 0) {
+			PX4_ERR("FAIL: Received unexpected values from the HoTT receiver device.");
+			return 1;
+		}
+	}
+
+
+	/* Attempt to send a HoTT response messages */
+	uint8_t response[] = {0x7c, 0x8e, 0x00, 0xe0, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, \
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf4, 0x01, 0x00, 0x00, \
+			      0x19, 0x00, 0x00, 0x00, 0x30, 0x75, 0x78, 0x00, 0x00, 0x00, \
+			      0x00, 0x00, 0x00, 0x7d, 0x12
+			     };
+
+	usleep(5000);
+
+	for (unsigned int i = 0; i < sizeof(response); i++) {
+		write(fd, &response[i], 1);
+		usleep(1000);
+	}
+
+	PX4_INFO("PASS: Response sent to the HoTT receiver device. Voltage should now show 2.5V.");
+
+
+#ifdef TIOCSSINGLEWIRE
+	/* Disable single wire */
+	ioctl(fd, TIOCSSINGLEWIRE, ~SER_SINGLEWIRE_ENABLED);
+#endif
+
+	write(fd, &send, 1);
+
+	/* We should timeout as there will be nothing to read (TX and RX no longer connected) */
+	if (poll(fds, 1, timeout) == 0) {
+		PX4_ERR("FAIL: timeout expected.");
+		return 1;
+	}
+
+	PX4_INFO("PASS: Single wire disabled.");
+
+	close(fd);
+	return 0;
+}


### PR DESCRIPTION
## Problem Description

Updated: 2021 Sep 2

A clear and concise description of the problem this proposed change will solve:

1. [X] Adds support for the Spektrum SRXL2 Protocol.
2. [X] Adds support for binding receiver through QGC
3. [X] Adds support for RC input  (uplink)
    - [x] Calibrate r/c radio in QGC -- fixed! (20210522)
4. [x] ported crc16 function from reference implementation: 
    - https://github.com/SpektrumRC/SRXL2/tree/master/Source

## Not included:
1. Telemetry Support (downlink)
    - out-of-scope; left for a future PR


## Describe your solution
Best effort has been made to work with the exist architecture.  
1. The most notable change is a srxl driver at `src/lib/rc/srxl.*`.
2. Significant changes were made to `src/drivers/rc_input/RCInput.*` to accommodate the addition parser case


## History

This patch is inherited from Kekiefer (https://github.com/kekiefer), Much thanks for the examples, and ground-work.


## Describe possible alternatives

### Trade-Off 1:  Custom vs Prexisting SRXL parser

1. Custom SRXL parser

Available as implemented in this patch. It is simple to comprehend and debug, but also lacks features.

2. Off-The-Shelf Parser:

Spektrum RC, the original equipment manufacturer of both the transmitter and receiver produces a reference library to parse this telemetry:
https://github.com/SpektrumRC/SRXL2

It is more complicated, but fully featured.   And maintained by Spektrum themselves.
Recomend bring it in as a submodule for future development.

### Trade-Off #2:  Parellel SRXL parser vs Expanding DSM parser

The rational here is very simple.  From the Spektrum Documentation:

> Previous Spektrum serial receivers were based on the Spektrum remote receiver protocol, which is not compatible with SRXL2.

In addition, parallel parsers prevent introduction of inadvertent bugs to the legacy "dsm" parser, and also allows completely code paths for the two cases.


### Documention

the list of supported receivers at:
https://docs.px4.io/master/en/getting_started/rc_transmitter_receiver.html
is just out-of-date.  It needs to be updated.
Compatible:  - PPM, satellite receivers, SRXL2/Serial Port

Note: DSM refers to over-the-air radio-wave modulation.  DSM modulated receivers may implement analog PWM, Summed PWM, or SRXL


### Development Hardware:

- FMU: Holybro Pixhawk 4 (standard)
- Receiver: Spektrum SPM 4651
- Transmitter: Spektrum DX6e
- [Debugging only]  Dronecode debug port reader -- https://kb.zubax.com/display/MAINKB/Dronecode+Probe+documentation                         
                                               

### Test Setup:

```
    Pixhawk 4 FMU                                  Spektrum 4651 Receiver
    "DSM/SBUS RC" Port
------------------------+
        Pin     Signal  |                         +----------------
        1       VDD_5V  |------\         /--------| 1 - Signal
        2       SBUS    |---------------/         | 2 -
        3       RSSI    |        \----------------| 3 - V+ (5VDC)
        4       VDD_3V3 |            /------------| 4 - GND
        5       GND     |-----------/             +----------------
------------------------+
```
- (photo): https://drive.google.com/file/d/1WEVORPKYTBK2P2txbnXX7Qj2etqOS7VA/view?usp=sharing

### Procedure:

1. plug in dronecode adapter
2. connect: `$ screen /dev/ttyACM1 57600`                                                                         
        (yes, baudrate is necessary, USB connection notwithstanding)                                                  
3. plug in mainboard (fmu) (if already plugged in, unplug, then replug -- the goal is to verify the boot sequence on the debug console.
4. Verify that we see the boot sequence through the dronecode adapter  (the boot text should scroll by, and dump you at a `nsh> ` prompt.                                      
                                     
5. Build firmware:
```
make px4_fmu-v5_multicopter upload
```

2. ensure fmu board has power 
3. wait for upload to complete.
4. start input daemon: `rc_input start`
5. [Optional] verify: `rc_input status`
6. turn on transmitter.   You should see bind messages in the debug console
7. move control sticks -- you should see a difference in the control channel values output in the debug console.
8. This setup should be ready to calibrate in QGC or your ground station of choice.

## Spektrum RC Specifications Sources
- [ Receiver Feature Matrix](  https://www.spektrumrc.com/Content/Media/PDF/64930-dot-1-air-rx-chart.pdf )
- [ Old Spektrum Serial Protocol (RevG) ]( https://github.com/SpektrumRC/SpektrumDocumentation/blob/master/Telemetry/Remote%20Receiver%20Interfacing.pdf )
- [ Old Spektrum Serial Protocol (RevA) ]( https://www.spektrumrc.com/ProdInfo/Files/Remote%20Receiver%20Interfacing%20Rev%20A.pdf )

- [New Serial Protocol: SRXL2]( https://www.spektrumrc.com/srxl2/ )
    - [ Specification Document ]( https://github.com/SpektrumRC/SRXL2/blob/master/Docs/SRXL2%20Specification.pdf )
    - [ Reference Implementation ]( https://github.com/spektrumrc/srxl2 )

## Github Links
- [ Source Issue (Resolves #16620) ]( https://github.com/PX4/PX4-Autopilot/issues/16620 )
- [ Previous issue (#8650) ]( https://github.com/PX4/PX4-Autopilot/issues/8650 )
