### PR TITLE
GPS heading and timeout fix for uBlox ZED-F9P

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -75,7 +75,8 @@
 #include <linux/spi/spidev.h>
 #endif /* __PX4_LINUX */
 
-#define TIMEOUT_5HZ 500
+#define TIMEOUT_1HZ		1300	//!< Timeout time in mS, 1000 mS (1Hz) + 300 mS delta for error
+#define TIMEOUT_5HZ		500		//!< Timeout time in mS,  200 mS (5Hz) + 300 mS delta for error
 #define RATE_MEASUREMENT_PERIOD 5000000
 
 typedef enum {
@@ -837,8 +838,15 @@ GPS::run()
 			}
 
 			int helper_ret;
+			unsigned receive_timeout = TIMEOUT_5HZ;
 
-			while ((helper_ret = _helper->receive(TIMEOUT_5HZ)) > 0 && !should_exit()) {
+			if (ubx_mode == GPSDriverUBX::UBXMode::RoverWithMovingBase) {
+				/* The MB rover will wait as long as possible to compute a navigation solution,
+				 * possibly lowering the navigation rate all the way to 1 Hz while doing so. */
+				receive_timeout = TIMEOUT_1HZ;
+			}
+
+			while ((helper_ret = _helper->receive(receive_timeout)) > 0 && !should_exit()) {
 
 				if (helper_ret & 1) {
 					publish();


### PR DESCRIPTION
**Describe problem solved by this pull request**

- Timeout fix

  For **Rover with moving base** timeout is prolonged because calculation can take a bit longer if the GPS signal is bad.
  https://www.u-blox.com/sites/default/files/ZED-F9P_IntegrationManual_%28UBX-18010802%29.pdf
  Page: 21
    > The MB rover will wait as long as possible to compute a navigation solution, possibly lowering the navigation rate all the way to 1 Hz while doing so. If not time-matched observations are received in time, the receiver will flag the relative position as invalid.
  
  This can be observed with the `gps status` command in mavlink console:
  
  `INFO  [gps] status: NOT OK, port: /dev/ttyS6, baudrate: 0`
  
  Because of a timeout, GPS will try to reconfigure itself. 

- Heading fix
  
  This is solved as part of the GPS driver submodule. This PR point to submodule with the fix https://github.com/PX4/PX4-GPSDrivers/pull/81 
