### PR TITLE
fix logger: use free() instead of 'delete[]' for _buffer

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -401,7 +401,7 @@ LogWriterFile::LogFileBuffer::~LogFileBuffer()
 		close(_fd);
 	}
 
-	delete[] _buffer;
+	free(_buffer);
 
 	perf_free(_perf_write);
 	perf_free(_perf_fsync);


### PR DESCRIPTION
The allocation got changed to `px4_cache_aligned_alloc`