### PR TITLE
cmake: remove romfs content before tar extraction

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -115,6 +115,7 @@ add_custom_command(
 set(romfs_extract_stamp ${CMAKE_CURRENT_BINARY_DIR}/romfs_extract.stamp)
 add_custom_command(
 	OUTPUT ${romfs_extract_stamp}
+	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/*
 	COMMAND ${CMAKE_COMMAND} -E tar xf ${romfs_tar_file}
 	COMMAND ${CMAKE_COMMAND} -E touch ${romfs_extract_stamp}
 	WORKING_DIRECTORY ${romfs_gen_root_dir}


### PR DESCRIPTION
This avoids incremental build errors when switching between branches with a different set of airframes.

E.g:
Aborting due to missing @type tag in file: 'Firmware/build/px4_fmu-v5_default/etc/init.d/airframes/13030_generic_vtol_quad_tiltrotor'