### PR TITLE
 mavlink ATTITUDE_TARGET: send also if vehicle_attitude_setpoint is not updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ validate_module_configs:
 .PHONY: clean submodulesclean submodulesupdate gazeboclean distclean
 
 clean:
-	@find "$(SRC_DIR)/build" -mindepth 1 -maxdepth 1 -type d -exec sh -c "echo {}; cmake --build {} -- clean || rm -rf {}" \; # use generated build system to clean, wipe build directory if it fails
+	@[ ! -d "$(SRC_DIR)/build" ] || find "$(SRC_DIR)/build" -mindepth 1 -maxdepth 1 -type d -exec sh -c "echo {}; cmake --build {} -- clean || rm -rf {}" \; # use generated build system to clean, wipe build directory if it fails
 	@git submodule foreach git clean -dX --force # some submodules generate build artifacts in source
 
 submodulesclean:

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -93,7 +93,6 @@ px4_add_board(
 	SYSTEMCMDS
 		bl_update
 		dmesg
-		dumpfile
 		esc_calib
 		gpio
 		hardfault_log

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1213,9 +1213,12 @@ Mavlink::configure_stream(const char *stream_name, const float rate)
 	}
 
 	/* if we reach here, the stream list does not contain the stream */
+#if defined(CONSTRAINED_FLASH) // flash constrained target's don't include all streams
+	return PX4_OK;
+#else
 	PX4_WARN("stream %s not found", stream_name);
-
 	return PX4_ERROR;
+#endif
 }
 
 void


### PR DESCRIPTION
This is the case in MC acro

And avoid 'stream xy not found' warnings on CONSTRAINED_FLASH targets

e.g.:
```
WARN  [mavlink] stream ADSB_VEHICLE not found
WARN  [mavlink] stream GIMBAL_DEVICE_ATTITUDE_STATUS not found
WARN  [mavlink] stream GIMBAL_MANAGER_STATUS not found
WARN  [mavlink] stream GIMBAL_DEVICE_SET_ATTITUDE not found
WARN  [mavlink] stream GPS2_RAW not found
WARN  [mavlink] stream UTM_GLOBAL_POSITION not found
ERROR [mavlink] configure_streams_to_default() failed
```