### PR TITLE
fix timesync for timestamp sample (including SFINAE detection)

### DIFF
--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -109,8 +109,11 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
 @[    end if]@
             // apply timestamp offset
             uint64_t timestamp = getMsgTimestamp(&st);
+            uint64_t timestamp_sample = getMsgTimestampSample(&st);
             _timesync->subtractOffset(timestamp);
             setMsgTimestamp(&st, timestamp);
+            _timesync->subtractOffset(timestamp_sample);
+            setMsgTimestampSample(&st, timestamp_sample);
             _@(topic)_pub.publish(&st);
 @[    if topic == 'Timesync' or topic == 'timesync']@
             }

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -120,10 +120,13 @@ private:
     // SFINAE
     template<typename T> struct hasTimestampSample{
     private:
-      static void detect(...);
-      template<typename U> static decltype(std::declval<U>().timestamp_sample()) detect(const U&);
+        template<typename U,
+                typename = decltype(std::declval<U>().timestamp_sample(int64_t()))>
+        static std::true_type detect(int);
+        template<typename U>
+        static std::false_type detect(...);
     public:
-      static constexpr bool value = std::is_same<uint64_t, decltype(detect(std::declval<T>()))>::value;
+        static constexpr bool value = decltype(detect<T>(0))::value;
     };
 
     template<typename T>


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
While trying the micrortps_agent with ROS2, I found some issues with the synchronization of the timestamp_samples in topics. While timestamps are well synchronized, the timestamps_samples are not. It concerns every topic with timestamp samples.

**Describe your solution**
2 issues have been solved
1- The detection of the existence of the timestamp_sample member in the topic fails (in RtpsTopics.h generated by RtpsTopic.h.em). Probably because the timestamp_sample member is overloaded in the definition of the topic, the detection using SFINAE does not work in the way it was done. I modified it in a way that the detection works.
2- Another more easy and obvious issue is the missing appropriate lines to make the synchronization of timestamp_sample in RtpsTopics.cpp.em in the template of
void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
The appropriate lines are added.

See also [this issue](https://github.com/PX4/px4_ros_com/issues/79) for more details

**Describe possible alternatives**
The solution to detection using SFINAE might not be the most appropriate. I am not completely accustomed to that. However, it works.

**Test data / coverage**
The solution was tested with PX4 sitl + Ros2 but also with PIHAWK mini + ROS2. The timestamp samples were synchronized.

