### PR TITLE
GeofenceBreachAvoidance: Fixed vertical geofence

### DIFF
--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -62,6 +62,7 @@ void GeofenceBreachAvoidance::updateParameters()
 	param_get(_paramHandle.param_mpc_acc_down_max, &_params.param_mpc_acc_down_max);
 
 	updateMinHorDistToFenceMultirotor();
+	updateMinVertDistToFenceMultirotor();
 }
 
 void GeofenceBreachAvoidance::setCurrentPosition(double lat, double lon, float alt)


### PR DESCRIPTION
Minimum vertical distance to geofence was never calculated. This made it very easy to breach the geofence.