### PR TITLE
WIP: Enable unit tests for navigation modes

### DIFF
--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -51,6 +51,7 @@ px4_add_module(
 		enginefailure.cpp
 		gpsfailure.cpp
 		follow_target.cpp
+		NavigatorCore.cpp
 	DEPENDS
 		git_ecl
 		ecl_geo
@@ -60,3 +61,4 @@ px4_add_module(
 	)
 
 px4_add_functional_gtest(SRC RangeRTLTest.cpp LINKLIBS modules__navigator modules__dataman)
+px4_add_functional_gtest(SRC NavigatorModeTakeoffTest.cpp LINKLIBS modules__navigator modules__dataman)

--- a/src/modules/navigator/FakeNavigator.h
+++ b/src/modules/navigator/FakeNavigator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#define MODULE_NAME "navigator"
+
+#include <navigator/navigator.h>
+
+
+class FakeNavigator : public Navigator
+{
+public:
+	FakeNavigator() :
+		Navigator() {};
+
+	virtual ~FakeNavigator() {};
+
+private:
+};

--- a/src/modules/navigator/GeofenceBreachAvoidance/GeofenceBreachAvoidanceTest.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/GeofenceBreachAvoidanceTest.cpp
@@ -34,7 +34,7 @@
 #include <gtest/gtest.h>
 #include "geofence_breach_avoidance.h"
 #include "fake_geofence.hpp"
-#include "dataman_mocks.hpp"
+#include <dataman/dataman_mocks.hpp>
 #include <parameters/param.h>
 
 using namespace matrix;

--- a/src/modules/navigator/NavigatorCore.cpp
+++ b/src/modules/navigator/NavigatorCore.cpp
@@ -1,0 +1,131 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file NavigatorCore.cpp
+ *
+ */
+
+#include "NavigatorCore.h"
+#include <px4_platform_common/defines.h>
+
+
+NavigatorCore::NavigatorCore() :
+	ModuleParams(nullptr)
+{
+
+}
+
+NavigatorCore::~NavigatorCore()
+{
+
+}
+
+bool NavigatorCore::forceVTOL()
+{
+
+	return _status.is_vtol && (isRotaryWing() || _status.in_transition_to_fw) && _param_nav_force_vt.get();
+}
+
+float NavigatorCore::getHorAcceptanceRadiusMeter()
+{
+	if (isRotaryWing()) {
+		return getDefaultHorAcceptanceRadiusMeter();
+
+	} else {
+		return math::max(_pos_ctrl_status.acceptance_radius, getDefaultHorAcceptanceRadiusMeter());
+	}
+}
+
+float NavigatorCore::getAltAcceptanceRadMeter()
+{
+	if (isFixedWing()) {
+		const position_setpoint_s &next_sp =  getCurrentTriplet().next;
+
+		if (next_sp.type == position_setpoint_s::SETPOINT_TYPE_LAND && next_sp.valid) {
+			// Use separate (tighter) altitude acceptance for clean altitude starting point before landing
+			return getFixedWingLandingAltAcceptanceRadius();
+		}
+	}
+
+	return getDefaultAltAcceptanceRadiusMeter();
+}
+
+float NavigatorCore::getDefaultAltAcceptanceRadiusMeter()
+{
+
+	if (isFixedWing()) {
+		return getFixedWingAltAcceptanceRadiusMeter();
+
+	} else if (isRover()) {
+		return INFINITY;
+
+	} else {
+		float alt_acceptance_radius = getMulticopterAltAcceptanceRadiusMeter();
+
+		if ((_pos_ctrl_status.timestamp > getCurrentTriplet().timestamp)
+		    && _pos_ctrl_status.altitude_acceptance > alt_acceptance_radius) {
+			alt_acceptance_radius = _pos_ctrl_status.altitude_acceptance;
+		}
+
+		return alt_acceptance_radius;
+	}
+}
+
+float NavigatorCore::getAcceptanceRadiusMeter()
+{
+
+	float acceptance_radius = _param_nav_acc_rad.get();
+
+	// for fixed-wing and rover, return the max of NAV_ACC_RAD and the controller acceptance radius (e.g. L1 distance)
+	if (!isRotaryWing() && PX4_ISFINITE(_pos_ctrl_status.acceptance_radius) && _pos_ctrl_status.timestamp != 0) {
+
+		acceptance_radius = math::max(acceptance_radius, _pos_ctrl_status.acceptance_radius);
+	}
+
+	return acceptance_radius;
+}
+
+float NavigatorCore::getAltAcceptanceRadiusMeter()
+{
+
+	if (isFixedWing()) {
+		const position_setpoint_s &next_sp = _triplet.next;
+
+		if (next_sp.type == position_setpoint_s::SETPOINT_TYPE_LAND && next_sp.valid) {
+			// Use separate (tighter) altitude acceptance for clean altitude starting point before landing
+			return _param_nav_fw_altl_rad.get();
+		}
+	}
+
+	return getDefaultAltAcceptanceRadiusMeter();
+}

--- a/src/modules/navigator/NavigatorCore.h
+++ b/src/modules/navigator/NavigatorCore.h
@@ -1,0 +1,157 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2013-2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <px4_platform_common/module_params.h>
+
+#include <lib/mathlib/mathlib.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/home_position.h>
+#include <uORB/topics/position_controller_status.h>
+#include <uORB/topics/position_setpoint_triplet.h>
+
+
+class NavigatorCore : public ModuleParams
+{
+
+public:
+	NavigatorCore();
+
+	~NavigatorCore();
+
+	typedef matrix::Vector3<float> Vector3f;
+	typedef matrix::Vector2<double> Vector2d;
+
+	bool getLanded() { return _landed_state.landed; }
+	bool getMaybeLanded() { return _landed_state.maybe_landed; }
+	float getLandDetectedAltMaxMeter() { return _landed_state.alt_max; }
+	double getLatRad() { return _global_pos.lat; }
+	double getLonRad() { return _global_pos.lon;}
+	float getAltitudeAMSLMeters() { return _global_pos.alt; }
+	float getTrueHeadingRad() { return _local_pos.heading; }
+	double getHomeLatRad() { return _home.lat; }
+	double getHomeLonRad() { return _home.lon; }
+	float getHomeAltAMSLMeter() { return _home.alt; }
+	float getHomeTrueHeadingRad() { return _home.yaw; }
+	home_position_s &getHomePosition() { return _home; }
+
+	bool isNotArmed() { return _status.arming_state != vehicle_status_s::ARMING_STATE_ARMED; }
+	uint8_t getArmingState() { return _status.arming_state; }
+
+
+	float getPosNorthMeter() { return _local_pos.x; }
+	float getPosEastMeter() { return _local_pos.y; }
+	float getPosDownMeter() { return _local_pos.z; }
+
+	float getVelNorthMPS() { return _local_pos.vx; }
+	float getVelEastMPS() { return _local_pos.vy; }
+	float getVelDownMPS() { return _local_pos.vz; }
+
+	float getLoiterRadiusMeter() { return _param_nav_loiter_rad.get(); }
+
+	bool getIsInTransitionMode() { return _status.in_transition_mode; }
+
+	position_setpoint_triplet_s getCurrentTriplet() { return _triplet; }
+
+	bool isHomeValid() { return (_home.timestamp > 0 && _home.valid_alt && _home.valid_hpos && _home.valid_lpos); }
+	bool isHomeAltValid() { return (_home.timestamp > 0 && _home.valid_alt);  }
+
+	bool isRotaryWing() { return _status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING; }
+	bool isFixedWing() { return _status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING; }
+	bool isRover() { return _status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER; }
+	bool isVTOL() { return _status.is_vtol; }
+	uint8_t getVehicleType() { return _status.vehicle_type; }
+
+	float getDefaultAltAcceptanceRadiusMeter();
+	float getAltAcceptanceRadMeter();
+	float getFixedWingLandingAltAcceptanceRadius() { return _param_nav_fw_altl_rad.get(); }
+	float getDefaultHorAcceptanceRadiusMeter() { return _param_nav_acc_rad.get(); }
+	float getHorAcceptanceRadiusMeter();
+	float getMulticopterAltAcceptanceRadiusMeter() { return _param_nav_mc_alt_rad.get(); }
+	float getFixedWingAltAcceptanceRadiusMeter() { return _param_nav_fw_alt_rad.get(); }
+
+	float getAcceptanceRadiusMeter();
+	float getAltAcceptanceRadiusMeter();
+
+	float getRelativeTakeoffMinAltitudeMeter() { return _param_mis_takeoff_alt.get(); }
+	float getRelativeLoiterMinAltitudeMeter() { return _param_mis_ltrmin_alt.get(); }
+	bool isTakeoffRequired() { return _param_mis_takeoff_req.get(); }
+	float getWaypointHeadingTimeoutSeconds() { return _param_mis_yaw_tmt.get(); }
+	float getWaypointHeadingAcceptanceRad() { return _param_mis_yaw_err.get(); }
+
+
+	bool forceVTOL();
+
+	void updateLocalPosition(const vehicle_local_position_s &local_pos) { _local_pos = local_pos; };
+	void updateVehicleStatus(const vehicle_status_s &status) { _status = status; }
+	void updateGlobalPosition(const vehicle_global_position_s &global_pos) { _global_pos = global_pos; }
+	void updateLandedState(const vehicle_land_detected_s &landed_state) { _landed_state = landed_state; }
+	void updateHomePosition(const home_position_s &home) { _home = home; }
+	void updatePositionControllerStatus(const position_controller_status_s &pos_ctrl_status) { _pos_ctrl_status = pos_ctrl_status; }
+
+private:
+
+	vehicle_local_position_s _local_pos{};
+	vehicle_status_s _status{};
+	vehicle_global_position_s _global_pos{};
+	vehicle_land_detected_s _landed_state{};
+	home_position_s _home{};
+	position_controller_status_s _pos_ctrl_status{};
+
+	position_setpoint_triplet_s _triplet{};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,	/**< loiter radius for fixedwing */
+		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad,	/**< acceptance for takeoff */
+		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)
+		_param_nav_fw_alt_rad,	/**< acceptance radius for fixedwing altitude */
+		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
+		_param_nav_fw_altl_rad,	/**< acceptance radius for fixedwing altitude before landing*/
+		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
+		_param_nav_mc_alt_rad,	/**< acceptance radius for multicopter altitude */
+		(ParamInt<px4::params::NAV_FORCE_VT>) _param_nav_force_vt,	/**< acceptance radius for multicopter altitude */
+		(ParamInt<px4::params::NAV_TRAFF_AVOID>) _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
+		(ParamFloat<px4::params::NAV_TRAFF_A_RADU>) _param_nav_traff_a_radu,	/**< avoidance Distance Unmanned*/
+		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm,	/**< avoidance Distance Manned*/
+
+		// non-navigator parameters
+		// Mission (MIS_*)
+		(ParamFloat<px4::params::MIS_LTRMIN_ALT>) _param_mis_ltrmin_alt,
+		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
+		(ParamBool<px4::params::MIS_TAKEOFF_REQ>) _param_mis_takeoff_req,
+		(ParamFloat<px4::params::MIS_YAW_TMT>) _param_mis_yaw_tmt,
+		(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err
+	)
+};

--- a/src/modules/navigator/NavigatorModeTakeoffTest.cpp
+++ b/src/modules/navigator/NavigatorModeTakeoffTest.cpp
@@ -1,0 +1,121 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#include <gtest/gtest.h>
+#include "FakeNavigator.h"
+#include "takeoff.h"
+#include <dataman/dataman_mocks.hpp>
+
+
+TEST(NavigatorModeTakeoffTest, TestTakeoff)
+{
+	FakeNavigator fake_navigator;
+
+	NavigatorCore &navigator_core = fake_navigator.getCore();
+	Takeoff takeoff(&fake_navigator, navigator_core);
+	fake_navigator.params_update();
+
+	vehicle_status_s status = {};
+	status.timestamp = 1e6;
+	status.is_vtol = true;
+	status.arming_state = vehicle_status_s::ARMING_STATE_ARMED;
+	status.vehicle_type = vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+
+	vehicle_global_position_s global_pos = {};
+	global_pos.timestamp = 1e6;
+	global_pos.lat = 40;
+	global_pos.lon = 3;
+	global_pos.alt = 300;
+
+	vehicle_land_detected_s landed = {};
+	landed.landed = true;
+	landed.timestamp = 1e6;
+
+	home_position_s home = {};
+	home.timestamp = 1e6;
+	home.lat = global_pos.lat;
+	home.lon = global_pos.lon;
+	home.alt = global_pos.alt;
+	home.valid_alt = true;
+	home.valid_hpos = true;
+	home.valid_lpos = true;
+
+	vehicle_local_position_s local_pos = {};
+	local_pos.timestamp = 1e6;
+	local_pos.x = -0.2f;
+	local_pos.y = 0.1f;
+	local_pos.z = 0.1f;
+
+	local_pos.vx = local_pos.vy = local_pos.vz = 0;
+	local_pos.heading = -0.54f;
+
+	navigator_core.updateGlobalPosition(global_pos);
+	navigator_core.updateHomePosition(home);
+	navigator_core.updateLandedState(landed);
+	navigator_core.updateLocalPosition(local_pos);
+	navigator_core.updateVehicleStatus(status);
+
+	takeoff.on_activation();
+
+	position_setpoint_s current = fake_navigator.get_position_setpoint_triplet()->current;
+
+	ASSERT_EQ(current.lat, navigator_core.getLatRad());
+	ASSERT_EQ(current.lon, navigator_core.getLonRad());
+	ASSERT_EQ(current.type, 3); // position_setpoint_s::TYPE_TAKEOFF
+	ASSERT_EQ(current.valid, true);
+	ASSERT_EQ(current.alt_valid, true);
+	ASSERT_EQ(current.alt, global_pos.alt + navigator_core.getRelativeTakeoffMinAltitudeMeter());
+	ASSERT_EQ(current.yaw, navigator_core.getTrueHeadingRad());
+	ASSERT_EQ(current.yaw_valid, true);
+	ASSERT_EQ(current.yawspeed_valid, false);
+	ASSERT_EQ(current.loiter_radius, navigator_core.getLoiterRadiusMeter());
+	ASSERT_EQ(current.loiter_direction, 1);
+	ASSERT_EQ(current.acceptance_radius, navigator_core.getHorAcceptanceRadiusMeter());
+	ASSERT_EQ(current.cruising_speed, -1.0f);
+
+	uint64_t t_first = current.timestamp;
+
+	landed.landed = false;
+	navigator_core.updateLandedState(landed);
+	global_pos.alt += navigator_core.getRelativeTakeoffMinAltitudeMeter();
+	navigator_core.updateGlobalPosition(global_pos);
+
+	takeoff.on_active();
+	current = fake_navigator.get_position_setpoint_triplet()->current;
+
+	ASSERT_NE(t_first, current.timestamp);
+	ASSERT_EQ(current.type, 2);
+
+
+
+
+}

--- a/src/modules/navigator/RangeRTLTest.cpp
+++ b/src/modules/navigator/RangeRTLTest.cpp
@@ -11,7 +11,8 @@
 TEST(Navigator_and_RTL, interact_correctly)
 {
 	Navigator n;
-	RTL rtl(&n);
+	NavigatorCore navigator_core;
+	RTL rtl(&n, navigator_core);
 
 
 	home_position_s home_pos{};

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -52,8 +52,8 @@
 #include "navigator.h"
 #include "enginefailure.h"
 
-EngineFailure::EngineFailure(Navigator *navigator) :
-	MissionBlock(navigator),
+EngineFailure::EngineFailure(Navigator *navigator, NavigatorCore &navigator_core) :
+	MissionBlock(navigator, navigator_core),
 	_ef_state(EF_STATE_NONE)
 {
 }
@@ -93,15 +93,15 @@ EngineFailure::set_ef_item()
 	case EF_STATE_LOITERDOWN: {
 			//XXX create mission item at ground (below?) here
 
-			_mission_item.lat = _navigator->get_global_position()->lat;
-			_mission_item.lon = _navigator->get_global_position()->lon;
+			_mission_item.lat = _navigator_core.getLatRad();
+			_mission_item.lon = _navigator_core.getLonRad();
 			_mission_item.altitude_is_relative = false;
 			//XXX setting altitude to a very low value, evaluate other options
-			_mission_item.altitude = _navigator->get_home_position()->alt - 1000.0f;
+			_mission_item.altitude = _navigator_core.getHomeAltAMSLMeter() - 1000.0f;
 			_mission_item.yaw = NAN;
-			_mission_item.loiter_radius = _navigator->get_loiter_radius();
+			_mission_item.loiter_radius = _navigator_core.getLoiterRadiusMeter();
 			_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
-			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
+			_mission_item.acceptance_radius = _navigator_core.getAcceptanceRadiusMeter();
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 

--- a/src/modules/navigator/enginefailure.h
+++ b/src/modules/navigator/enginefailure.h
@@ -47,7 +47,7 @@ class Navigator;
 class EngineFailure : public MissionBlock
 {
 public:
-	EngineFailure(Navigator *navigator);
+	EngineFailure(Navigator *navigator, NavigatorCore &navigator_core);
 	~EngineFailure() = default;
 
 	void on_inactive() override;

--- a/src/modules/navigator/follow_target.h
+++ b/src/modules/navigator/follow_target.h
@@ -54,7 +54,7 @@ class FollowTarget : public MissionBlock, public ModuleParams
 {
 
 public:
-	FollowTarget(Navigator *navigator);
+	FollowTarget(Navigator *navigator, NavigatorCore &navigator_core);
 	~FollowTarget() = default;
 
 	void on_inactive() override;

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -224,13 +224,13 @@ bool Geofence::isCloserThanMaxDistToHome(double lat, double lon, float altitude)
 {
 	bool inside_fence = true;
 
-	if (isHomeRequired() && _navigator->home_position_valid()) {
+	if (isHomeRequired() && _navigator->getCore().isHomeValid()) {
 
 		const float max_horizontal_distance = _param_gf_max_hor_dist.get();
 
-		const double home_lat = _navigator->get_home_position()->lat;
-		const double home_lon = _navigator->get_home_position()->lon;
-		const float home_alt = _navigator->get_home_position()->alt;
+		const double home_lat = _navigator->getCore().getHomeLatRad();
+		const double home_lon = _navigator->getCore().getHomeLonRad();
+		const float home_alt = _navigator->getCore().getHomeAltAMSLMeter();
 
 		float dist_xy = -1.0f;
 		float dist_z = -1.0f;
@@ -255,10 +255,10 @@ bool Geofence::isBelowMaxAltitude(float altitude)
 {
 	bool inside_fence = true;
 
-	if (isHomeRequired() && _navigator->home_position_valid()) {
+	if (isHomeRequired() && _navigator->getCore().isHomeValid()) {
 
 		const float max_vertical_distance = _param_gf_max_ver_dist.get();
-		const float home_alt = _navigator->get_home_position()->alt;
+		const float home_alt = _navigator->getCore().getHomeAltAMSLMeter();
 
 		float dist_z = altitude - home_alt;
 

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -52,8 +52,8 @@
 using matrix::Eulerf;
 using matrix::Quatf;
 
-GpsFailure::GpsFailure(Navigator *navigator) :
-	MissionBlock(navigator),
+GpsFailure::GpsFailure(Navigator *navigator, NavigatorCore &navigator_core) :
+	MissionBlock(navigator, navigator_core),
 	ModuleParams(navigator)
 {
 }
@@ -92,7 +92,7 @@ GpsFailure::on_active()
 			Quatf q(Eulerf(att_sp.roll_body, att_sp.pitch_body, 0.0f));
 			q.copyTo(att_sp.q_d);
 
-			if (_navigator->get_vstatus()->is_vtol) {
+			if (_navigator_core.isVTOL()) {
 				_fw_virtual_att_sp_pub.publish(att_sp);
 
 			} else {

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -51,7 +51,7 @@ class Navigator;
 class GpsFailure : public MissionBlock, public ModuleParams
 {
 public:
-	GpsFailure(Navigator *navigator);
+	GpsFailure(Navigator *navigator, NavigatorCore &navigator_core);
 	~GpsFailure() = default;
 
 	void on_inactive() override;

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -41,8 +41,8 @@
 #include "land.h"
 #include "navigator.h"
 
-Land::Land(Navigator *navigator) :
-	MissionBlock(navigator)
+Land::Land(Navigator *navigator, NavigatorCore &navigator_core) :
+	MissionBlock(navigator, navigator_core)
 {
 }
 
@@ -71,16 +71,16 @@ void
 Land::on_active()
 {
 	/* for VTOL update landing location during back transition */
-	if (_navigator->get_vstatus()->is_vtol &&
-	    _navigator->get_vstatus()->in_transition_mode) {
+	if (_navigator_core.isVTOL() &&
+	    _navigator_core.getIsInTransitionMode()) {
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-		pos_sp_triplet->current.lat = _navigator->get_global_position()->lat;
-		pos_sp_triplet->current.lon = _navigator->get_global_position()->lon;
+		pos_sp_triplet->current.lat = _navigator_core.getLatRad();
+		pos_sp_triplet->current.lon = _navigator_core.getLonRad();
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 
 
-	if (_navigator->get_land_detected()->landed) {
+	if (_navigator_core.getLanded()) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 		set_idle_item(&_mission_item);

--- a/src/modules/navigator/land.h
+++ b/src/modules/navigator/land.h
@@ -46,7 +46,7 @@
 class Land : public MissionBlock
 {
 public:
-	Land(Navigator *navigator);
+	Land(Navigator *navigator, NavigatorCore &navigator_core);
 	~Land() = default;
 
 	void on_activation() override;

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -48,7 +48,7 @@
 class Loiter : public MissionBlock, public ModuleParams
 {
 public:
-	Loiter(Navigator *navigator);
+	Loiter(Navigator *navigator, NavigatorCore &navigator_core);
 	~Loiter() = default;
 
 	void on_inactive() override;

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -69,7 +69,7 @@ class Navigator;
 class Mission : public MissionBlock, public ModuleParams
 {
 public:
-	Mission(Navigator *navigator);
+	Mission(Navigator *navigator, NavigatorCore &navigator_core);
 	~Mission() override = default;
 
 	void on_inactive() override;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -42,6 +42,7 @@
 
 #include "navigator_mode.h"
 #include "navigation.h"
+#include "NavigatorCore.h"
 
 #include <drivers/drv_hrt.h>
 #include <systemlib/mavlink_log.h>
@@ -61,7 +62,7 @@ public:
 	/**
 	 * Constructor
 	 */
-	MissionBlock(Navigator *navigator);
+	MissionBlock(Navigator *navigator, NavigatorCore &navigator_core);
 	virtual ~MissionBlock() = default;
 
 	MissionBlock(const MissionBlock &) = delete;
@@ -150,6 +151,8 @@ protected:
 	bool _waypoint_yaw_reached{false};
 
 	hrt_abstime _time_wp_reached{0};
+
+	NavigatorCore &_navigator_core;
 
 	uORB::Publication<actuator_controls_s>	_actuator_pub{ORB_ID(actuator_controls_2)};
 };

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -67,8 +67,8 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 	bool warned = false;
 
 	// first check if we have a valid position
-	const bool home_valid = _navigator->home_position_valid();
-	const bool home_alt_valid = _navigator->home_alt_valid();
+	const bool home_valid = _navigator->getCore().isHomeValid();
+	const bool home_alt_valid = _navigator->getCore().isHomeAltValid();
 
 	if (!home_alt_valid) {
 		failed = true;
@@ -79,7 +79,7 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 		failed = failed || !checkDistanceToFirstWaypoint(mission, max_distance_to_1st_waypoint);
 	}
 
-	const float home_alt = _navigator->get_home_position()->alt;
+	const float home_alt = _navigator->getCore().getHomeAltAMSLMeter();
 
 	// check if all mission item commands are supported
 	failed = failed || !checkMissionItemValidity(mission);
@@ -87,10 +87,10 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 	failed = failed || !checkGeofence(mission, home_alt, home_valid);
 	failed = failed || !checkHomePositionAltitude(mission, home_alt, home_alt_valid, warned);
 
-	if (_navigator->get_vstatus()->is_vtol) {
+	if (_navigator->getCore().isVTOL()) {
 		failed = failed || !checkVTOL(mission, home_alt, false);
 
-	} else if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	} else if (_navigator->getCore().isRotaryWing()) {
 		failed = failed || !checkRotarywing(mission, home_alt);
 
 	} else {
@@ -300,7 +300,7 @@ MissionFeasibilityChecker::checkMissionItemValidity(const mission_s &mission)
 		}
 
 		// check if the mission starts with a land command while the vehicle is landed
-		if ((i == 0) && missionitem.nav_cmd == NAV_CMD_LAND && _navigator->get_land_detected()->landed) {
+		if ((i == 0) && missionitem.nav_cmd == NAV_CMD_LAND && _navigator->getCore().getLanded()) {
 
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: starts with landing");
 			return false;
@@ -336,7 +336,7 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 					    : missionitem.altitude - home_alt;
 
 			// check if we should use default acceptance radius
-			float acceptance_radius = _navigator->get_default_acceptance_radius();
+			float acceptance_radius = _navigator->getCore().getDefaultHorAcceptanceRadiusMeter();
 
 			if (missionitem.acceptance_radius > NAV_EPSILON_POSITION) {
 				acceptance_radius = missionitem.acceptance_radius;
@@ -408,7 +408,7 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 		}
 	}
 
-	if (_navigator->get_takeoff_required() && _navigator->get_land_detected()->landed) {
+	if (_navigator->getCore().isTakeoffRequired() && _navigator->getCore().getLanded()) {
 		// check for a takeoff waypoint, after the above conditions have been met
 		// MIS_TAKEOFF_REQ param has to be set and the vehicle has to be landed - one can load a mission
 		// while the vehicle is flying and it does not require a takeoff waypoint
@@ -653,7 +653,7 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(const mission_s &mission
 		/* check distance from current position to item */
 		float dist_to_1wp = get_distance_to_next_waypoint(
 					    mission_item.lat, mission_item.lon,
-					    _navigator->get_home_position()->lat, _navigator->get_home_position()->lon);
+					    _navigator->getCore().getHomeLatRad(), _navigator->getCore().getHomeLonRad());
 
 		if (dist_to_1wp < max_distance) {
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -122,6 +122,8 @@ public:
 
 	void		publish_vehicle_cmd(vehicle_command_s *vcmd);
 
+	void		params_update();
+
 	/**
 	 * Generate an artificial traffic indication
 	 *
@@ -165,39 +167,39 @@ public:
 	const vehicle_roi_s &get_vroi() { return _vroi; }
 	void reset_vroi() { _vroi = {}; }
 
-	bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
-	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos && _home_pos.valid_lpos); }
+	//bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
+	//bool _navigator_core.isHomeValid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos && _home_pos.valid_lpos); }
 
 	Geofence	&get_geofence() { return _geofence; }
 
 	bool		get_can_loiter_at_sp() { return _can_loiter_at_sp; }
-	float		get_loiter_radius() { return _param_nav_loiter_rad.get(); }
+	//float		_navigator_core.getLoiterRadiusMeter() { return _param_nav_loiter_rad.get(); }
 
 	/**
 	 * Returns the default acceptance radius defined by the parameter
 	 */
-	float		get_default_acceptance_radius();
+	//float		get_default_acceptance_radius();
 
 	/**
 	 * Get the acceptance radius
 	 *
 	 * @return the distance at which the next waypoint should be used
 	 */
-	float		get_acceptance_radius();
+	//float		get_acceptance_radius();
 
 	/**
 	 * Get the default altitude acceptance radius (i.e. from parameters)
 	 *
 	 * @return the distance from the target altitude before considering the waypoint reached
 	 */
-	float		get_default_altitude_acceptance_radius();
+	//float		get_default_altitude_acceptance_radius();
 
 	/**
 	 * Get the altitude acceptance radius
 	 *
 	 * @return the distance from the target altitude before considering the waypoint reached
 	 */
-	float		get_altitude_acceptance_radius();
+	//float		get_altitude_acceptance_radius();
 
 	/**
 	 * Get the cruising speed
@@ -290,43 +292,21 @@ public:
 
 	void geofence_breach_check(bool &have_geofence_position_data);
 
-	// Param access
-	float		get_loiter_min_alt() const { return _param_mis_ltrmin_alt.get(); }
-	float		get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
-	bool		get_takeoff_required() const { return _param_mis_takeoff_req.get(); }
-	float		get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
-	float		get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
-
 	float		get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss; }
 	float		get_vtol_reverse_delay() const { return _param_reverse_delay; }
 
-	bool		force_vtol();
+	//bool		force_vtol();
 
 	void		acquire_gimbal_control();
 	void		release_gimbal_control();
 
+	NavigatorCore &getCore() { return _navigator_core; }
+
 private:
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,	/**< loiter radius for fixedwing */
-		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad,	/**< acceptance for takeoff */
-		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)
-		_param_nav_fw_alt_rad,	/**< acceptance radius for fixedwing altitude */
-		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
-		_param_nav_fw_altl_rad,	/**< acceptance radius for fixedwing altitude before landing*/
-		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
-		_param_nav_mc_alt_rad,	/**< acceptance radius for multicopter altitude */
-		(ParamInt<px4::params::NAV_FORCE_VT>) _param_nav_force_vt,	/**< acceptance radius for multicopter altitude */
 		(ParamInt<px4::params::NAV_TRAFF_AVOID>) _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
 		(ParamFloat<px4::params::NAV_TRAFF_A_RADU>) _param_nav_traff_a_radu,	/**< avoidance Distance Unmanned*/
-		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm,	/**< avoidance Distance Manned*/
-
-		// non-navigator parameters
-		// Mission (MIS_*)
-		(ParamFloat<px4::params::MIS_LTRMIN_ALT>) _param_mis_ltrmin_alt,
-		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
-		(ParamBool<px4::params::MIS_TAKEOFF_REQ>) _param_mis_takeoff_req,
-		(ParamFloat<px4::params::MIS_YAW_TMT>) _param_mis_yaw_tmt,
-		(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err
+		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm	/**< avoidance Distance Manned*/
 	)
 
 	int		_local_pos_sub{-1};
@@ -385,6 +365,8 @@ private:
 	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
 	bool		_mission_result_updated{false};		/**< flags if mission result has seen an update */
 
+	NavigatorCore _navigator_core;
+
 	NavigatorMode	*_navigation_mode{nullptr};		/**< abstract pointer to current navigation mode class */
 	Mission		_mission;			/**< class that handles the missions */
 	Loiter		_loiter;			/**< class that handles loiter */
@@ -411,7 +393,7 @@ private:
 	// if mission mode is inactive, this flag will be cleared after 2 seconds
 
 	// update subscriptions
-	void		params_update();
+
 
 	/**
 	 * Publish a new position setpoint triplet for position controllers

--- a/src/modules/navigator/precland.h
+++ b/src/modules/navigator/precland.h
@@ -67,7 +67,7 @@ enum class PrecLandMode {
 class PrecLand : public MissionBlock, public ModuleParams
 {
 public:
-	PrecLand(Navigator *navigator);
+	PrecLand(Navigator *navigator, NavigatorCore &navigator_core);
 	~PrecLand() override = default;
 
 	void on_activation() override;

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -72,7 +72,7 @@ public:
 		RTL_DESTINATION_SAFE_POINT,
 	};
 
-	RTL(Navigator *navigator);
+	RTL(Navigator *navigator, NavigatorCore &navigator_core);
 
 	~RTL() = default;
 

--- a/src/modules/navigator/takeoff.h
+++ b/src/modules/navigator/takeoff.h
@@ -46,7 +46,7 @@
 class Takeoff : public MissionBlock
 {
 public:
-	Takeoff(Navigator *navigator);
+	Takeoff(Navigator *navigator, NavigatorCore &navigator_core);
 	~Takeoff() = default;
 
 	void on_activation() override;


### PR DESCRIPTION
I'm just sharing this for general visibility.

In order to start cleaning up navigation modes it's beneficial to have the ability to write unit tests for them. Navigation modes are given a pointer to the navigator module instance from which they get ALL data they need. This makes it really hard to write unit test.
As an initial step I decided to rip out the relevant data out of Navigator module and put it into a NavigatorCore class.
I'm also taking the chance to avoid returning pointers to private members and improving names for methods which should improve readability a lot.
The final goal is to tackle monsters like "is_mission_item_reached()" which is a function that has grown to an unmaintainable size. Having unit tests in place increase chances of actually not breaking too many things while doing the refactoring.

For demonstration i wrote a unit test for the Takeoff navigation mode.

