### PR TITLE
drivers/optical_flow/paw3902: require >= 10 valid consecutive readings before deciding mode changes

### DIFF
--- a/src/drivers/optical_flow/paw3902/CMakeLists.txt
+++ b/src/drivers/optical_flow/paw3902/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,4 +37,10 @@ px4_add_module(
 	SRCS
 		paw3902_main.cpp
 		PAW3902.cpp
+		PAW3902.hpp
+		PixArt_PAW3902JF_Registers.hpp
+	DEPENDS
+		conversion
+		drivers__device
+		px4_work_queue
 	)

--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -86,9 +86,9 @@ private:
 	bool DataReadyInterruptConfigure();
 	bool DataReadyInterruptDisable();
 
-	uint8_t	RegisterRead(uint8_t reg, int retries = 3);
+	uint8_t	RegisterRead(uint8_t reg, int retries = 2);
 	void RegisterWrite(uint8_t reg, uint8_t data);
-	bool RegisterWriteVerified(uint8_t reg, uint8_t data, int retries = 5);
+	bool RegisterWriteVerified(uint8_t reg, uint8_t data, int retries = 1);
 
 	void EnableLed();
 
@@ -128,8 +128,11 @@ private:
 	int		_flow_sum_y{0};
 
 	Mode		_mode{Mode::LowLight};
-	uint8_t 	_bright_to_low_counter{0};
-	uint8_t 	_low_to_superlow_counter{0};
-	uint8_t 	_low_to_bright_counter{0};
-	uint8_t 	_superlow_to_low_counter{0};
+
+	int _bright_to_low_counter{0};
+	int _low_to_superlow_counter{0};
+	int _low_to_bright_counter{0};
+	int _superlow_to_low_counter{0};
+
+	int _valid_count{0};
 };

--- a/src/drivers/optical_flow/paw3902/PixArt_PAW3902JF_Registers.hpp
+++ b/src/drivers/optical_flow/paw3902/PixArt_PAW3902JF_Registers.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
I believe this now correctly reflects the intent of the datasheet (valid for > 10 consecutive frames).

 - improve mode change requirements comments
 - reduce verified read/write retries (these are mostly wasting time)