### PR TITLE
px_uploader.py remove special pyserial checks that fail on some platforms

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -56,7 +56,6 @@ from __future__ import print_function
 import sys
 import argparse
 import binascii
-import serial
 import socket
 import struct
 import json
@@ -67,6 +66,16 @@ import array
 import os
 
 from sys import platform as _platform
+
+try:
+    import serial
+except ImportError as e:
+    print("Failed to import serial: " + str(e))
+    print("")
+    print("You may need to install it using:")
+    print("    pip3 install --user pyserial")
+    print("")
+    sys.exit(1)
 
 # Detect python version
 if sys.version_info[0] < 3:
@@ -725,29 +734,6 @@ def main():
         print("==========================================================================================================")
         print("WARNING: You should uninstall ModemManager as it conflicts with any non-modem serial device (like Pixhawk)")
         print("==========================================================================================================")
-
-    # We need to check for pyserial because the import itself doesn't
-    # seem to fail, at least not on macOS.
-    pyserial_installed = False
-    try:
-        if serial.__version__:
-            pyserial_installed = True
-    except:
-        pass
-
-    try:
-        if serial.VERSION:
-            pyserial_installed = True
-    except:
-        pass
-
-    if not pyserial_installed:
-        print("Error: pyserial not installed!")
-        print("")
-        print("You may need to install it using:")
-        print("    pip3 install --user pyserial")
-        print("")
-        sys.exit(1)
 
     # Load the firmware file
     fw = firmware(args.firmware)

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -15,7 +15,7 @@ pygments
 wheel>=0.31.1
 pymavlink
 pyros-genmsg
-pyserial>=3.0
+pyserial
 pyulog>=0.5.0
 pyyaml
 requests


### PR DESCRIPTION
This check is failing on Ubuntu. On either Mac or Ubuntu the standard install scripts (`./Tools/setup/ubuntu.sh` or `./Tools/setup/macos.sh`) will install these dependencies, so let's try and keep the checks simple rather than introduce more problems.

#### Example, fresh Ubuntu 20.04 system

``` Console
<module 'serial' from '/home/dagar/.local/lib/python3.8/site-packages/serial/__init__.py'>
Error: pyserial not installed!

You may need to install it using:
    pip3 install --user pyserial
```

#### installing with pip

``` Console
...
Requirement already satisfied: pyserial>=3.0 in /home/dagar/.local/lib/python3.8/site-packages (from -r /home/dagar/git/PX4-Autopilot/Tools/setup/requirements.txt (line 18)) (3.5)

```