### PR TITLE
canbootloader clear pending systick interrupts

### DIFF
--- a/platforms/nuttx/src/canbootloader/uavcan/main.c
+++ b/platforms/nuttx/src/canbootloader/uavcan/main.c
@@ -936,6 +936,9 @@ static void application_run(size_t fw_image_size, bootloader_app_shared_t *commo
 
 		/* kill the systick interrupt */
 		putreg32(0, NVIC_SYSTICK_CTRL);
+		__asm volatile("dsb");
+		__asm volatile("isb");
+		putreg32(NVIC_INTCTRL_PENDSTCLR, NVIC_INTCTRL);
 
 		/* and set a specific LED pattern */
 		board_indicate(jump_to_app);


### PR DESCRIPTION
Issue with UCANS32K146 and the uavcan bootloader where in some circumstances we could get a hardfault from IRQ 15 the systick when booting from the bootloader

```B▒EG
irq_unexpected_isr: ERROR irq: 15
up_assert: Assertion failed at file:irq/irq_unexpectedisr.c line: 65 task: Idle Task
```

Turns out while we kill the systick interrupt the interrupt itself still might be pending 
https://github.com/PX4/PX4-Autopilot/blob/3a3cc33d69dd66735c3a4fffdc823c54c5e47e22/platforms/nuttx/src/canbootloader/uavcan/main.c#L938

This PR adds a routine to clear pending systick interrupts in the SCB.

@davids5 could it be that the USB bootloader could have the same issue?