### PR TITLE
IMU_GYRO_CUTOFF and IMU_DGYRO_CUTOFF increase default slightly

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -80,7 +80,7 @@ PARAM_DEFINE_FLOAT(IMU_GYRO_NF_BW, 20.0f);
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
+PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 40.0f);
 
 /**
 * Gyro control data maximum publication rate (inner loop rate)
@@ -122,7 +122,7 @@ PARAM_DEFINE_INT32(IMU_GYRO_RATEMAX, 400);
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 20.0f);
+PARAM_DEFINE_FLOAT(IMU_DGYRO_CUTOFF, 30.0f);
 
 /**
 * IMU gyro dynamic notch filtering


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/17006. Alternative to https://github.com/PX4/PX4-Autopilot/pull/17567.

https://logs.px4.io/plot_app?log=907f56e5-9bd6-4878-950b-ad70865c6324

Closes https://github.com/PX4/PX4-Autopilot/pull/17567