### PR TITLE
sensors/vehicle_angular_velocity: FFT & ESC RPM notch filters avoid unnecessary filter resets

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -78,8 +78,8 @@ private:
 	void CalibrateAndPublish(bool publish, const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity,
 				 const matrix::Vector3f &angular_acceleration, float scale = 1.f);
 
-	float FilterAngularVelocity(int axis, float data[], int N = 1);
-	float FilterAngularAcceleration(int axis, float dt_s, float data[], int N = 1);
+	inline float FilterAngularVelocity(int axis, float data[], int N = 1);
+	inline float FilterAngularAcceleration(int axis, float dt_s, float data[], int N = 1);
 
 	void DisableDynamicNotchEscRpm();
 	void DisableDynamicNotchFFT();
@@ -148,8 +148,8 @@ private:
 	static constexpr int MAX_NUM_FFT_PEAKS = sizeof(sensor_gyro_fft_s::peak_frequencies_x) / sizeof(
 				sensor_gyro_fft_s::peak_frequencies_x[0]);
 
-	math::NotchFilterArray<float> _dynamic_notch_filter_esc_rpm[MAX_NUM_ESC_RPM][MAX_NUM_ESC_RPM_HARMONICS][3] {};
-	math::NotchFilterArray<float> _dynamic_notch_filter_fft[MAX_NUM_FFT_PEAKS][3] {};
+	math::NotchFilterArray<float> _dynamic_notch_filter_esc_rpm[3][MAX_NUM_ESC_RPM][MAX_NUM_ESC_RPM_HARMONICS] {};
+	math::NotchFilterArray<float> _dynamic_notch_filter_fft[3][MAX_NUM_FFT_PEAKS] {};
 
 	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_fft_update_perf{nullptr};


### PR DESCRIPTION
 - using direct form 1 the internal filter state (delay elements) are still valid if the notch frequency or bandwidth is adjusted
 - during regular operation (updated ESC RPM feedback or detected FFT peaks) we only need to reset these notch filters if they were previously disabled

