### PR TITLE
fake_imu updates for testing gyro filtering

### DIFF
--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -117,7 +117,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -114,7 +114,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/beaglebone/blue/default.cmake
+++ b/boards/beaglebone/blue/default.cmake
@@ -95,7 +95,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/cuav/nora/default.cmake
+++ b/boards/cuav/nora/default.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cuav/nora/test.cmake
+++ b/boards/cuav/nora/test.cmake
@@ -125,7 +125,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -123,7 +123,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cuav/x7pro/test.cmake
+++ b/boards/cuav/x7pro/test.cmake
@@ -126,7 +126,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cubepilot/cubeorange/default.cmake
+++ b/boards/cubepilot/cubeorange/default.cmake
@@ -120,7 +120,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cubepilot/cubeorange/test.cmake
+++ b/boards/cubepilot/cubeorange/test.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cubepilot/cubeyellow/default.cmake
+++ b/boards/cubepilot/cubeyellow/default.cmake
@@ -118,7 +118,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/cubepilot/cubeyellow/test.cmake
+++ b/boards/cubepilot/cubeyellow/test.cmake
@@ -120,7 +120,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/emlid/navio2/default.cmake
+++ b/boards/emlid/navio2/default.cmake
@@ -95,7 +95,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/holybro/durandal-v1/default.cmake
+++ b/boards/holybro/durandal-v1/default.cmake
@@ -118,7 +118,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/holybro/durandal-v1/test.cmake
+++ b/boards/holybro/durandal-v1/test.cmake
@@ -121,7 +121,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/holybro/pix32v5/default.cmake
+++ b/boards/holybro/pix32v5/default.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/holybro/pix32v5/test.cmake
+++ b/boards/holybro/pix32v5/test.cmake
@@ -125,7 +125,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -115,7 +115,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/modalai/fc-v1/rtps.cmake
+++ b/boards/modalai/fc-v1/rtps.cmake
@@ -115,7 +115,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/modalai/fc-v1/test.cmake
+++ b/boards/modalai/fc-v1/test.cmake
@@ -118,7 +118,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/mro/ctrl-zero-f7-oem/default.cmake
+++ b/boards/mro/ctrl-zero-f7-oem/default.cmake
@@ -119,7 +119,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/mro/ctrl-zero-f7/default.cmake
+++ b/boards/mro/ctrl-zero-f7/default.cmake
@@ -119,7 +119,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/mro/ctrl-zero-h7-oem/default.cmake
+++ b/boards/mro/ctrl-zero-h7-oem/default.cmake
@@ -117,7 +117,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/mro/ctrl-zero-h7/default.cmake
+++ b/boards/mro/ctrl-zero-h7/default.cmake
@@ -117,7 +117,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/mro/pixracerpro/default.cmake
+++ b/boards/mro/pixracerpro/default.cmake
@@ -118,7 +118,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/mro/x21-777/default.cmake
+++ b/boards/mro/x21-777/default.cmake
@@ -119,7 +119,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/mro/x21/default.cmake
+++ b/boards/mro/x21/default.cmake
@@ -120,7 +120,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-e/default.cmake
+++ b/boards/nxp/fmuk66-e/default.cmake
@@ -115,7 +115,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-e/rtps.cmake
+++ b/boards/nxp/fmuk66-e/rtps.cmake
@@ -116,7 +116,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-e/socketcan.cmake
+++ b/boards/nxp/fmuk66-e/socketcan.cmake
@@ -116,7 +116,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -115,7 +115,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-v3/rtps.cmake
+++ b/boards/nxp/fmuk66-v3/rtps.cmake
@@ -116,7 +116,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-v3/socketcan.cmake
+++ b/boards/nxp/fmuk66-v3/socketcan.cmake
@@ -116,7 +116,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/nxp/fmuk66-v3/test.cmake
+++ b/boards/nxp/fmuk66-v3/test.cmake
@@ -117,7 +117,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/nxp/fmurt1062-v1/default.cmake
+++ b/boards/nxp/fmurt1062-v1/default.cmake
@@ -117,7 +117,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		#fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -127,7 +127,7 @@ px4_add_board(
 		#work_queue
 	EXAMPLES
 		#fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -121,7 +121,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v3/test.cmake
+++ b/boards/px4/fmu-v3/test.cmake
@@ -124,7 +124,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -119,7 +119,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v4/test.cmake
+++ b/boards/px4/fmu-v4/test.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -119,7 +119,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v4pro/test.cmake
+++ b/boards/px4/fmu-v4pro/test.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/fmu-v5/ctrlalloc.cmake
+++ b/boards/px4/fmu-v5/ctrlalloc.cmake
@@ -123,7 +123,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/debug.cmake
+++ b/boards/px4/fmu-v5/debug.cmake
@@ -125,7 +125,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -121,7 +121,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -129,7 +129,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -114,7 +114,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -123,7 +123,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/test.cmake
+++ b/boards/px4/fmu-v5/test.cmake
@@ -124,7 +124,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/fmu-v5/uavcanv0periph.cmake
+++ b/boards/px4/fmu-v5/uavcanv0periph.cmake
@@ -124,7 +124,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5/uavcanv1.cmake
+++ b/boards/px4/fmu-v5/uavcanv1.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
+++ b/boards/px4/fmu-v5x/base_phy_DP83848C.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -123,7 +123,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v5x/test.cmake
+++ b/boards/px4/fmu-v5x/test.cmake
@@ -125,7 +125,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v6u/default.cmake
+++ b/boards/px4/fmu-v6u/default.cmake
@@ -118,7 +118,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v6u/test.cmake
+++ b/boards/px4/fmu-v6u/test.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -122,7 +122,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/fmu-v6x/test.cmake
+++ b/boards/px4/fmu-v6x/test.cmake
@@ -126,7 +126,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/boards/px4/raspberrypi/default.cmake
+++ b/boards/px4/raspberrypi/default.cmake
@@ -92,7 +92,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/ctrlalloc.cmake
+++ b/boards/px4/sitl/ctrlalloc.cmake
@@ -89,7 +89,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -88,7 +88,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -87,7 +87,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -86,7 +86,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -86,7 +86,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/scumaker/pilotpi/arm64.cmake
+++ b/boards/scumaker/pilotpi/arm64.cmake
@@ -87,7 +87,7 @@ px4_add_board(
 	EXAMPLES
 		dyn_hello # dynamically loading modules example
 		fake_gps
-		fake_gyro
+		fake_imu
 		fake_magnetometer
 		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		hello

--- a/boards/spracing/h7extreme/default.cmake
+++ b/boards/spracing/h7extreme/default.cmake
@@ -105,7 +105,7 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_gyro
+		#fake_imu
 		#fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -96,6 +96,20 @@ set_tests_properties(sitl-mavlink PROPERTIES PASS_REGULAR_EXPRESSION "ALL TESTS 
 sanitizer_fail_test_on_error(sitl-mavlink)
 
 
+# IMU filtering
+add_test(NAME sitl-imu_filtering
+	COMMAND $<TARGET_FILE:px4>
+		-s ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_imu_filtering
+		-t ${PX4_SOURCE_DIR}/test_data
+		${PX4_SOURCE_DIR}/ROMFS/px4fmu_test
+	WORKING_DIRECTORY ${SITL_WORKING_DIR}
+)
+
+set_tests_properties(sitl-imu_filtering PROPERTIES FAIL_REGULAR_EXPRESSION "FAIL")
+set_tests_properties(sitl-imu_filtering PROPERTIES PASS_REGULAR_EXPRESSION "ALL TESTS PASSED")
+sanitizer_fail_test_on_error(sitl-imu_filtering)
+
+
 
 # # Shutdown test
 # add_test(NAME sitl-shutdown

--- a/posix-configs/SITL/init/test/test_imu_filtering
+++ b/posix-configs/SITL/init/test/test_imu_filtering
@@ -1,0 +1,51 @@
+#!/bin/sh
+# PX4 commands need the 'px4-' prefix in bash.
+# (px4-alias.sh is expected to be in the PATH)
+. px4-alias.sh
+
+param load
+param set CBRK_SUPPLY_CHK 894281
+param set SYS_RESTART_TYPE 0
+
+dataman start
+
+tone_alarm start
+
+ver all
+
+param set IMU_GYRO_RATEMAX 2000
+
+param set IMU_GYRO_FFT_EN 1
+param set IMU_GYRO_FFT_MIN 1
+param set IMU_GYRO_FFT_MAX 1000
+
+# test values
+param set IMU_GYRO_CUTOFF 40
+param set IMU_DGYRO_CUTOFF 30
+#param set IMU_GYRO_NF_FREQ 60
+#param set IMU_GYRO_NF_BW 5
+
+# log nearly everything
+param set SDLOG_PROFILE 859
+
+fake_imu start
+
+sensors start
+gyro_fft start
+
+logger start -f -t -b 10000 -p sensor_gyro
+logger on
+
+echo "Running for 10 seconds"
+sleep 10
+
+logger off
+
+sensors status
+uorb top -a -1
+listener sensor_gyro
+listener sensor_gyro_fifo
+
+echo "ALL TESTS PASSED"
+
+shutdown

--- a/src/examples/fake_imu/CMakeLists.txt
+++ b/src/examples/fake_imu/CMakeLists.txt
@@ -32,14 +32,15 @@
 ############################################################################
 
 px4_add_module(
-	MODULE modules__fake_gyro
-	MAIN fake_gyro
+	MODULE modules__fake_imu
+	MAIN fake_imu
 	COMPILE_FLAGS
 		${MAX_CUSTOM_OPT_LEVEL}
 	SRCS
-		FakeGyro.cpp
-		FakeGyro.hpp
+		FakeImu.cpp
+		FakeImu.hpp
 	DEPENDS
+		drivers_accelerometer
 		drivers_gyroscope
 		px4_work_queue
 )

--- a/src/examples/fake_imu/FakeImu.hpp
+++ b/src/examples/fake_imu/FakeImu.hpp
@@ -38,16 +38,17 @@
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/sensor_gyro_fifo.h>
 
-class FakeGyro : public ModuleBase<FakeGyro>, public ModuleParams, public px4::ScheduledWorkItem
+class FakeImu : public ModuleBase<FakeImu>, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
-	FakeGyro();
-	~FakeGyro() override = default;
+	FakeImu();
+	~FakeImu() override = default;
 
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
@@ -61,12 +62,14 @@ public:
 	bool init();
 
 private:
-	static constexpr uint32_t SENSOR_RATE = 1250;
-	static constexpr float GYRO_RATE = 8000;
+	static constexpr double IMU_RATE_HZ = 8000;
 
 	void Run() override;
 
+	PX4Accelerometer _px4_accel;
 	PX4Gyroscope _px4_gyro;
 
-	float _time{0.f};
+	hrt_abstime _time_start_us{0};
+
+	uint32_t _sensor_interval_us{1250};
 };


### PR DESCRIPTION
This is a crude way to directly test/inspect the gyro filtering pipeline with data rates that are more representative of real vehicles (eg 8 kHz gyro instead of 250 Hz we have in SITL).

The `fake_imu` publishes fake FIFO gyro data with sine sweeps ramping up to different frequencies on x, y, z over 10 seconds. For convenience the fake accel is populated with the frequency.

You can run this directly in the test build directory.

``` Console
~/git/PX4-Autopilot/build/px4_sitl_test$ ctest -VV -R sitl-imu_filtering
```

#### Example: angular velocity (gyro through low pass with 40 Hz cutoff) 0 - 100 Hz

![image](https://user-images.githubusercontent.com/84712/118529479-8e05bd80-b711-11eb-8b65-86fc29b2d8ba.png)


To test different values you can modify the parameters in `posix-configs/SITL/init/test/test_imu_filtering`.