### PR TITLE
ICM20649 on SPI6 bus will be replaced by ICM20689

### DIFF
--- a/boards/cuav/nora/init/rc.board_sensors
+++ b/boards/cuav/nora/init/rc.board_sensors
@@ -16,7 +16,10 @@ bmi088 -s -b 4 -G -R 2 start
 ms5611 -s -b 4 start
 
 # SPI6
-icm20649 -s -b 6 -R 2 start
+if ! icm20649 -s -b 6 -R 2 start
+then
+	icm20689 -s -b 6 -R 2 start
+fi
 ms5611 -s -b 6 start
 
 # External compass on GPS1/I2C1: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)

--- a/boards/cuav/nora/src/spi.cpp
+++ b/boards/cuav/nora/src/spi.cpp
@@ -55,6 +55,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	}),
 	initSPIBus(SPI::Bus::SPI6, {
 		initSPIDevice(DRV_IMU_DEVTYPE_ICM20649, SPI::CS{GPIO::PortI, GPIO::Pin12}, SPI::DRDY{GPIO::PortH, GPIO::Pin5}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM20689, SPI::CS{GPIO::PortE, GPIO::Pin15}, SPI::DRDY{GPIO::PortH, GPIO::Pin5}),
 		initSPIDevice(DRV_BARO_DEVTYPE_MS5611, SPI::CS{GPIO::PortI, GPIO::Pin8}),
 	}),
 };

--- a/boards/cuav/x7pro/init/rc.board_sensors
+++ b/boards/cuav/x7pro/init/rc.board_sensors
@@ -19,7 +19,10 @@ bmi088 -s -b 4 -G -R 2 start
 ms5611 -s -b 4 start
 
 # SPI6
-icm20649 -s -b 6 -R 2 start
+if ! icm20649 -s -b 6 -R 2 start
+then
+	icm20689 -s -b 6 -R 2 start
+fi
 ms5611 -s -b 6 start
 
 # External compass on GPS1/I2C1: standard CUAV GPS/compass puck (with lights, safety button, and buzzer)

--- a/boards/cuav/x7pro/src/spi.cpp
+++ b/boards/cuav/x7pro/src/spi.cpp
@@ -56,6 +56,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	}),
 	initSPIBus(SPI::Bus::SPI6, {
 		initSPIDevice(DRV_IMU_DEVTYPE_ICM20649, SPI::CS{GPIO::PortI, GPIO::Pin12}, SPI::DRDY{GPIO::PortH, GPIO::Pin5}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM20689, SPI::CS{GPIO::PortE, GPIO::Pin15}, SPI::DRDY{GPIO::PortH, GPIO::Pin5}),
 		initSPIDevice(DRV_BARO_DEVTYPE_MS5611, SPI::CS{GPIO::PortI, GPIO::Pin8}),
 	}),
 };


### PR DESCRIPTION
Because of the chip, ICM20649 on the new version X7\Nora SPI6 bus will be replaced by ICM20689