### PR TITLE
[UAVCANv1] Update to use libcanard callback and param rework

### DIFF
--- a/src/drivers/uavcan_v1/ParamManager.cpp
+++ b/src/drivers/uavcan_v1/ParamManager.cpp
@@ -52,34 +52,7 @@ bool UavcanParamManager::GetParamByName(const char *param_name, uavcan_register_
 				return false;
 			}
 
-			/// TODO: What will be our approach for handling other UAVCAN data-value types?
-			switch (param_type(param_handle)) {
-			case PARAM_TYPE_INT32: {
-					int32_t out_val {};
-					param_get(param_handle, &out_val);
-
-					if (uavcan_register_Value_1_0_is_natural16_(&value)) { //FIXME param rewrite
-						value.natural16.value.elements[0] = (uint16_t)out_val;
-						uavcan_register_Value_1_0_select_natural16_(&value);
-
-					} else {
-						value.integer32.value.elements[0] = out_val;
-						uavcan_register_Value_1_0_select_integer32_(&value);
-					}
-
-					break;
-				}
-
-			case PARAM_TYPE_FLOAT: {
-					float out_val {};
-					param_get(param_handle, &out_val);
-					value.real32.value.elements[0] = out_val;
-					uavcan_register_Value_1_0_select_real32_(&value);
-					break;
-				}
-			}
-
-			return true;
+			return param.px4_param_to_register_value(param_handle, value);
 		}
 	}
 
@@ -96,34 +69,7 @@ bool UavcanParamManager::GetParamByName(const uavcan_register_Name_1_0 &name, ua
 				return false;
 			}
 
-			/// TODO: What will be our approach for handling other UAVCAN data-value types?
-			switch (param_type(param_handle)) {
-			case PARAM_TYPE_INT32: {
-					int32_t out_val {};
-					param_get(param_handle, &out_val);
-
-					if (uavcan_register_Value_1_0_is_natural16_(&value)) { //FIXME param rewrite
-						value.natural16.value.elements[0] = (uint16_t)out_val;
-						uavcan_register_Value_1_0_select_natural16_(&value);
-
-					} else {
-						value.integer32.value.elements[0] = out_val;
-						uavcan_register_Value_1_0_select_integer32_(&value);
-					}
-
-					break;
-				}
-
-			case PARAM_TYPE_FLOAT: {
-					float out_val {};
-					param_get(param_handle, &out_val);
-					value.real32.value.elements[0] = out_val;
-					uavcan_register_Value_1_0_select_real32_(&value);
-					break;
-				}
-			}
-
-			return true;
+			return param.px4_param_to_register_value(param_handle, value);
 		}
 	}
 
@@ -140,21 +86,7 @@ bool UavcanParamManager::SetParamByName(const uavcan_register_Name_1_0 &name, co
 				return false;
 			}
 
-			switch (param_type(param_handle)) {
-			case PARAM_TYPE_INT32: {
-					int32_t in_val = value.integer32.value.elements[0];
-					param_set(param_handle, &in_val);
-					break;
-				}
-
-			case PARAM_TYPE_FLOAT: {
-					float in_val = value.natural32.value.elements[0];
-					param_set(param_handle, &in_val);
-					break;
-				}
-			}
-
-			return true;
+			return param.register_value_to_px4_param(value, param_handle);
 		}
 	}
 

--- a/src/drivers/uavcan_v1/ParamManager.hpp
+++ b/src/drivers/uavcan_v1/ParamManager.hpp
@@ -47,7 +47,7 @@
 #include <uavcan/_register/Name_1_0.h>
 #include <uavcan/_register/Value_1_0.h>
 
-static auto get_uavcan_port_id = [](param_t &in, uavcan_register_Value_1_0 &out) -> bool
+static bool px4_param_to_uavcan_port_id(param_t &in, uavcan_register_Value_1_0 &out)
 {
 	if (param_type(in) == PARAM_TYPE_INT32) {
 		int32_t out_val {};
@@ -61,7 +61,7 @@ static auto get_uavcan_port_id = [](param_t &in, uavcan_register_Value_1_0 &out)
 	return false;
 };
 
-static auto set_uavcan_port_id = [](const uavcan_register_Value_1_0 &in, param_t &out) -> bool
+static bool uavcan_port_id_to_px4_param(const uavcan_register_Value_1_0 &in, param_t &out)
 {
 	if (uavcan_register_Value_1_0_is_natural16_(&in) && in.natural16.value.count == 1) {
 		if (param_type(out) == PARAM_TYPE_INT32) {
@@ -74,12 +74,15 @@ static auto set_uavcan_port_id = [](const uavcan_register_Value_1_0 &in, param_t
 	return false;
 };
 
+typedef bool (*param_2_reg_t)(param_t &in, uavcan_register_Value_1_0 &out);
+typedef bool (*reg_2_param_t)(const uavcan_register_Value_1_0 &in, param_t &out);
+
 
 typedef struct {
 	const char *uavcan_name;
 	const char *px4_name;
-	bool (*px4_param_to_register_value)(param_t &in, uavcan_register_Value_1_0 &out) {};
-	bool (*register_value_to_px4_param)(const uavcan_register_Value_1_0 &in, param_t &out) {};
+	param_2_reg_t px4_param_to_register_value;
+	reg_2_param_t register_value_to_px4_param;
 	bool is_mutable {true};
 	bool is_persistent {true};
 } UavcanParamBinder;
@@ -97,17 +100,17 @@ private:
 
 
 	const UavcanParamBinder _uavcan_params[11] {
-		{"uavcan.pub.esc.0.id",                "UCAN1_ESC_PUB",		    get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.pub.servo.0.id",              "UCAN1_SERVO_PUB",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.pub.gps.0.id",                "UCAN1_GPS_PUB",		    get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.esc.0.id",                "UCAN1_ESC0_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.gps.0.id",                "UCAN1_GPS0_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.gps.1.id",                "UCAN1_GPS1_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.energy_source.0.id",      "UCAN1_BMS_ES_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.battery_status.0.id",     "UCAN1_BMS_BS_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.battery_parameters.0.id", "UCAN1_BMS_BP_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.legacy_bms.0.id",         "UCAN1_LG_BMS_PID",		get_uavcan_port_id, set_uavcan_port_id},
-		{"uavcan.sub.uorb.sensor_gps.0.id",    "UCAN1_UORB_GPS",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.pub.esc.0.id",                "UCAN1_ESC_PUB",		    px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.pub.servo.0.id",              "UCAN1_SERVO_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.pub.gps.0.id",                "UCAN1_GPS_PUB",		    px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.esc.0.id",                "UCAN1_ESC0_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.gps.0.id",                "UCAN1_GPS0_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.gps.1.id",                "UCAN1_GPS1_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.energy_source.0.id",      "UCAN1_BMS_ES_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.battery_status.0.id",     "UCAN1_BMS_BS_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.battery_parameters.0.id", "UCAN1_BMS_BP_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.legacy_bms.0.id",         "UCAN1_LG_BMS_PID",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.uorb.sensor_gps.0.id",    "UCAN1_UORB_GPS",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		//{"uavcan.sub.bms.0.id",   "UCAN1_BMS0_PID"}, //FIXME instancing
 		//{"uavcan.sub.bms.1.id",   "UCAN1_BMS1_PID"},
 	};

--- a/src/drivers/uavcan_v1/ParamManager.hpp
+++ b/src/drivers/uavcan_v1/ParamManager.hpp
@@ -42,16 +42,48 @@
 #pragma once
 
 #include <lib/parameters/param.h>
+#include <px4_platform_common/defines.h>
 
 #include <uavcan/_register/Name_1_0.h>
 #include <uavcan/_register/Value_1_0.h>
 
+static auto get_uavcan_port_id = [](param_t &in, uavcan_register_Value_1_0 &out) -> bool
+{
+	if (param_type(in) == PARAM_TYPE_INT32) {
+		int32_t out_val {};
+		param_get(in, &out_val);
+		out.natural16.value.elements[0] = (uint16_t)out_val;
+		out.natural16.value.count = 1;
+		uavcan_register_Value_1_0_select_natural16_(&out);
+		return true;
+	}
+
+	return false;
+};
+
+static auto set_uavcan_port_id = [](const uavcan_register_Value_1_0 &in, param_t &out) -> bool
+{
+	if (uavcan_register_Value_1_0_is_natural16_(&in) && in.natural16.value.count == 1) {
+		if (param_type(out) == PARAM_TYPE_INT32) {
+			int32_t in_val = in.natural16.value.elements[0];
+			param_set(out, &in_val);
+			return true;
+		}
+	}
+
+	return false;
+};
+
+
 typedef struct {
 	const char *uavcan_name;
 	const char *px4_name;
+	bool (*px4_param_to_register_value)(param_t &in, uavcan_register_Value_1_0 &out) {};
+	bool (*register_value_to_px4_param)(const uavcan_register_Value_1_0 &in, param_t &out) {};
 	bool is_mutable {true};
 	bool is_persistent {true};
 } UavcanParamBinder;
+
 
 class UavcanParamManager
 {
@@ -63,18 +95,19 @@ public:
 
 private:
 
+
 	const UavcanParamBinder _uavcan_params[11] {
-		{"uavcan.pub.esc.0.id",              "UCAN1_ESC_PUB"},
-		{"uavcan.pub.servo.0.id",            "UCAN1_SERVO_PUB"},
-		{"uavcan.pub.gps.0.id",              "UCAN1_GPS_PUB"},
-		{"uavcan.sub.esc.0.id",              "UCAN1_ESC0_PID"},
-		{"uavcan.sub.gps.0.id",              "UCAN1_GPS0_PID"},
-		{"uavcan.sub.gps.1.id",              "UCAN1_GPS1_PID"},
-		{"uavcan.sub.energy_source.0.id",      "UCAN1_BMS_ES_PID"},
-		{"uavcan.sub.battery_status.0.id",     "UCAN1_BMS_BS_PID"},
-		{"uavcan.sub.battery_parameters.0.id", "UCAN1_BMS_BP_PID"},
-		{"uavcan.sub.legacy_bms.0.id",         "UCAN1_LG_BMS_PID"},
-		{"uavcan.sub.uorb.sensor_gps.0.id",    "UCAN1_UORB_GPS"},
+		{"uavcan.pub.esc.0.id",                "UCAN1_ESC_PUB",		    get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.pub.servo.0.id",              "UCAN1_SERVO_PUB",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.pub.gps.0.id",                "UCAN1_GPS_PUB",		    get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.esc.0.id",                "UCAN1_ESC0_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.gps.0.id",                "UCAN1_GPS0_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.gps.1.id",                "UCAN1_GPS1_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.energy_source.0.id",      "UCAN1_BMS_ES_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.battery_status.0.id",     "UCAN1_BMS_BS_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.battery_parameters.0.id", "UCAN1_BMS_BP_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.legacy_bms.0.id",         "UCAN1_LG_BMS_PID",		get_uavcan_port_id, set_uavcan_port_id},
+		{"uavcan.sub.uorb.sensor_gps.0.id",    "UCAN1_UORB_GPS",		get_uavcan_port_id, set_uavcan_port_id},
 		//{"uavcan.sub.bms.0.id",   "UCAN1_BMS0_PID"}, //FIXME instancing
 		//{"uavcan.sub.bms.1.id",   "UCAN1_BMS1_PID"},
 	};

--- a/src/drivers/uavcan_v1/Subscribers/BaseSubscriber.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/BaseSubscriber.hpp
@@ -56,6 +56,7 @@ public:
 		_canard_instance(ins), _instance(instance)
 	{
 		_subj_sub._subject_name = subject_name;
+		_subj_sub._canard_sub.user_reference = this;
 	}
 
 	virtual void subscribe() = 0;

--- a/src/drivers/uavcan_v1/Subscribers/DS-015/Battery.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/DS-015/Battery.hpp
@@ -49,7 +49,7 @@
 #include <reg/drone/service/battery/Parameters_0_3.h>
 #include <reg/drone/service/battery/Status_0_2.h>
 
-#include "DynamicPortSubscriber.hpp"
+#include "../DynamicPortSubscriber.hpp"
 
 #define KELVIN_OFFSET 273.15f
 #define WH_TO_JOULE   3600
@@ -61,9 +61,13 @@ public:
 		UavcanDynamicPortSubscriber(ins, pmgr, "energy_source", instance)
 	{
 		_subj_sub.next = &_status_sub;
+
 		_status_sub._subject_name = _status_name;
+		_status_sub._canard_sub.user_reference = this;
 		_status_sub.next = &_parameters_sub;
+
 		_parameters_sub._subject_name = _parameters_name;
+		_parameters_sub._canard_sub.user_reference = this;
 		_parameters_sub.next = NULL;
 	}
 

--- a/src/drivers/uavcan_v1/Subscribers/DS-015/Esc.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/DS-015/Esc.hpp
@@ -32,68 +32,82 @@
  ****************************************************************************/
 
 /**
- * @file Gnss.hpp
+ * @file Esc.hpp
  *
- * Defines basic functionality of UAVCAN v1 GNSS subscription
+ * Defines basic functionality of UAVCAN v1 ESC setpoint subscription
+ * (For use on a CAN-->PWM node)
  *
  * @author Jacob Crabill <jacob@flyvoly.com>
  */
 
 #pragma once
 
+/// For use with PR-16808 once merged
+// #include <uORB/topics/output_control.h>
+
 // DS-15 Specification Messages
-#include <reg/drone/physics/kinematics/geodetic/Point_0_1.h>
+#include <reg/drone/service/actuator/common/sp/Vector8_0_1.h>
+#include <reg/drone/service/common/Readiness_0_1.h>
 
-#include "DynamicPortSubscriber.hpp"
+#include "../DynamicPortSubscriber.hpp"
 
-class UavcanGnssSubscriber : public UavcanDynamicPortSubscriber
+class UavcanEscSubscriber : public UavcanDynamicPortSubscriber
 {
 public:
-	UavcanGnssSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
-		UavcanDynamicPortSubscriber(ins, pmgr, "gps", instance) { };
+	UavcanEscSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
+		UavcanDynamicPortSubscriber(ins, pmgr, "esc", instance) { };
 
 	void subscribe() override
 	{
-		// Subscribe to messages reg.drone.physics.kinematics.geodetic.Point.0.1
+		// Subscribe to messages reg.drone.service.actuator.common.sp.Vector8.0.1
 		canardRxSubscribe(&_canard_instance,
 				  CanardTransferKindMessage,
 				  _subj_sub._canard_sub._port_id,
-				  reg_drone_physics_kinematics_geodetic_Point_0_1_EXTENT_BYTES_,
+				  reg_drone_service_actuator_common_sp_Vector8_0_1_EXTENT_BYTES_,
 				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
 				  &_subj_sub._canard_sub);
 
-		/** TODO: Add additional GPS-data messages: (reg.drone.service.gnss._.0.1.uavcan):
-		 * # A compliant implementation of this service should publish the following subjects:
-		 * #
-		 * #   PUBLISHED SUBJECT NAME      SUBJECT TYPE                                            TYP. RATE [Hz]
-		 * #   point_kinematics            reg.drone.physics.kinematics.geodetic.PointStateVarTs   1...100
-		 * #   time                        reg.drone.service.gnss.Time                             1...10
-		 * #   heartbeat                   reg.drone.service.gnss.Heartbeat                        ~1
-		 * #   sensor_status               reg.drone.service.sensor.Status                         ~1
-		 *
-		 * Not mentioned, but should also be included: Dilution of Precision
-		 *   (reg.drone.service.gnss.DilutionOfPrecision.0.1.uavcan)
-		 * For PX4, only the PointStateVarTs, DilutionOfPrecision, and perhaps Time would be needed
-		 * to publish 'sensor_gps'
-		 */
+		// Subscribe to messages reg.drone.service.common.Readiness.0.1
+		canardRxSubscribe(&_canard_instance,
+				  CanardTransferKindMessage,
+				  static_cast<CanardPortID>(static_cast<uint32_t>(_subj_sub._canard_sub._port_id) + 1),
+				  reg_drone_service_common_Readiness_0_1_EXTENT_BYTES_,
+				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
+				  &_canard_sub_readiness);
 	};
 
 	void callback(const CanardTransfer &receive) override
 	{
 		// Test with Yakut:
 		// export YAKUT_TRANSPORT="pyuavcan.transport.can.CANTransport(pyuavcan.transport.can.media.slcan.SLCANMedia('/dev/serial/by-id/usb-Zubax_Robotics_Zubax_Babel_23002B000E514E413431302000000000-if00', 8, 115200), 42)"
-		// yakut pub 1500.reg.drone.physics.kinematics.geodetic.Point.0.1 '{latitude: 1.234, longitude: 2.34, altitude: {meter: 0.5}}'
-		PX4_INFO("GpsCallback");
+		// yakut pub 22.reg.drone.service.actuator.common.sp.Vector8.0.1 '{value: [1000, 2000, 3000, 4000, 0, 0, 0, 0]}'
+		PX4_INFO("EscCallback");
 
-		reg_drone_physics_kinematics_geodetic_Point_0_1 geo {};
-		size_t geo_size_in_bits = receive.payload_size;
-		reg_drone_physics_kinematics_geodetic_Point_0_1_deserialize_(&geo, (const uint8_t *)receive.payload, &geo_size_in_bits);
+		reg_drone_service_actuator_common_sp_Vector8_0_1 esc {};
+		size_t esc_size_in_bits = receive.payload_size;
+		reg_drone_service_actuator_common_sp_Vector8_0_1_deserialize_(&esc, (const uint8_t *)receive.payload,
+				&esc_size_in_bits);
 
-		double lat = geo.latitude;
-		double lon = geo.longitude;
-		double alt = geo.altitude.meter;
-		PX4_INFO("Latitude: %f, Longitude: %f, Altitude: %f", lat, lon, alt);
+		double val1 = static_cast<double>(esc.value[0]);
+		double val2 = static_cast<double>(esc.value[1]);
+		double val3 = static_cast<double>(esc.value[2]);
+		double val4 = static_cast<double>(esc.value[3]);
+		PX4_INFO("values[0-3] = {%f, %f, %f, %f}", val1, val2, val3, val4);
 		/// do something with the data
+
+		/// For use with PR-16808 once merged
+		// output_control_s outputs;
+
+		// for (uint8_t i = 0; i < 8; i++) {
+		// 	outputs.value[i] = 2.f * (esc.value[i] / 8191.f) - 1.f;
+		// }
+
+		// _output_pub.publish(outputs);
 	};
 
+private:
+	/// For use with PR-16808 once merged
+	// uORB::Publication<output_control_s> _output_pub{ORB_ID(output_control_mc)};
+
+	CanardRxSubscription _canard_sub_readiness;
 };

--- a/src/drivers/uavcan_v1/Subscribers/DS-015/Gnss.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/DS-015/Gnss.hpp
@@ -32,82 +32,68 @@
  ****************************************************************************/
 
 /**
- * @file Esc.hpp
+ * @file Gnss.hpp
  *
- * Defines basic functionality of UAVCAN v1 ESC setpoint subscription
- * (For use on a CAN-->PWM node)
+ * Defines basic functionality of UAVCAN v1 GNSS subscription
  *
  * @author Jacob Crabill <jacob@flyvoly.com>
  */
 
 #pragma once
 
-/// For use with PR-16808 once merged
-// #include <uORB/topics/output_control.h>
-
 // DS-15 Specification Messages
-#include <reg/drone/service/actuator/common/sp/Vector8_0_1.h>
-#include <reg/drone/service/common/Readiness_0_1.h>
+#include <reg/drone/physics/kinematics/geodetic/Point_0_1.h>
 
-#include "DynamicPortSubscriber.hpp"
+#include "../DynamicPortSubscriber.hpp"
 
-class UavcanEscSubscriber : public UavcanDynamicPortSubscriber
+class UavcanGnssSubscriber : public UavcanDynamicPortSubscriber
 {
 public:
-	UavcanEscSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
-		UavcanDynamicPortSubscriber(ins, pmgr, "esc", instance) { };
+	UavcanGnssSubscriber(CanardInstance &ins, UavcanParamManager &pmgr, uint8_t instance = 0) :
+		UavcanDynamicPortSubscriber(ins, pmgr, "gps", instance) { };
 
 	void subscribe() override
 	{
-		// Subscribe to messages reg.drone.service.actuator.common.sp.Vector8.0.1
+		// Subscribe to messages reg.drone.physics.kinematics.geodetic.Point.0.1
 		canardRxSubscribe(&_canard_instance,
 				  CanardTransferKindMessage,
 				  _subj_sub._canard_sub._port_id,
-				  reg_drone_service_actuator_common_sp_Vector8_0_1_EXTENT_BYTES_,
+				  reg_drone_physics_kinematics_geodetic_Point_0_1_EXTENT_BYTES_,
 				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
 				  &_subj_sub._canard_sub);
 
-		// Subscribe to messages reg.drone.service.common.Readiness.0.1
-		canardRxSubscribe(&_canard_instance,
-				  CanardTransferKindMessage,
-				  static_cast<CanardPortID>(static_cast<uint32_t>(_subj_sub._canard_sub._port_id) + 1),
-				  reg_drone_service_common_Readiness_0_1_EXTENT_BYTES_,
-				  CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
-				  &_canard_sub_readiness);
+		/** TODO: Add additional GPS-data messages: (reg.drone.service.gnss._.0.1.uavcan):
+		 * # A compliant implementation of this service should publish the following subjects:
+		 * #
+		 * #   PUBLISHED SUBJECT NAME      SUBJECT TYPE                                            TYP. RATE [Hz]
+		 * #   point_kinematics            reg.drone.physics.kinematics.geodetic.PointStateVarTs   1...100
+		 * #   time                        reg.drone.service.gnss.Time                             1...10
+		 * #   heartbeat                   reg.drone.service.gnss.Heartbeat                        ~1
+		 * #   sensor_status               reg.drone.service.sensor.Status                         ~1
+		 *
+		 * Not mentioned, but should also be included: Dilution of Precision
+		 *   (reg.drone.service.gnss.DilutionOfPrecision.0.1.uavcan)
+		 * For PX4, only the PointStateVarTs, DilutionOfPrecision, and perhaps Time would be needed
+		 * to publish 'sensor_gps'
+		 */
 	};
 
 	void callback(const CanardTransfer &receive) override
 	{
 		// Test with Yakut:
 		// export YAKUT_TRANSPORT="pyuavcan.transport.can.CANTransport(pyuavcan.transport.can.media.slcan.SLCANMedia('/dev/serial/by-id/usb-Zubax_Robotics_Zubax_Babel_23002B000E514E413431302000000000-if00', 8, 115200), 42)"
-		// yakut pub 22.reg.drone.service.actuator.common.sp.Vector8.0.1 '{value: [1000, 2000, 3000, 4000, 0, 0, 0, 0]}'
-		PX4_INFO("EscCallback");
+		// yakut pub 1500.reg.drone.physics.kinematics.geodetic.Point.0.1 '{latitude: 1.234, longitude: 2.34, altitude: {meter: 0.5}}'
+		PX4_INFO("GpsCallback");
 
-		reg_drone_service_actuator_common_sp_Vector8_0_1 esc {};
-		size_t esc_size_in_bits = receive.payload_size;
-		reg_drone_service_actuator_common_sp_Vector8_0_1_deserialize_(&esc, (const uint8_t *)receive.payload,
-				&esc_size_in_bits);
+		reg_drone_physics_kinematics_geodetic_Point_0_1 geo {};
+		size_t geo_size_in_bits = receive.payload_size;
+		reg_drone_physics_kinematics_geodetic_Point_0_1_deserialize_(&geo, (const uint8_t *)receive.payload, &geo_size_in_bits);
 
-		double val1 = static_cast<double>(esc.value[0]);
-		double val2 = static_cast<double>(esc.value[1]);
-		double val3 = static_cast<double>(esc.value[2]);
-		double val4 = static_cast<double>(esc.value[3]);
-		PX4_INFO("values[0-3] = {%f, %f, %f, %f}", val1, val2, val3, val4);
+		double lat = geo.latitude;
+		double lon = geo.longitude;
+		double alt = geo.altitude.meter;
+		PX4_INFO("Latitude: %f, Longitude: %f, Altitude: %f", lat, lon, alt);
 		/// do something with the data
-
-		/// For use with PR-16808 once merged
-		// output_control_s outputs;
-
-		// for (uint8_t i = 0; i < 8; i++) {
-		// 	outputs.value[i] = 2.f * (esc.value[i] / 8191.f) - 1.f;
-		// }
-
-		// _output_pub.publish(outputs);
 	};
 
-private:
-	/// For use with PR-16808 once merged
-	// uORB::Publication<output_control_s> _output_pub{ORB_ID(output_control_mc)};
-
-	CanardRxSubscription _canard_sub_readiness;
 };

--- a/src/drivers/uavcan_v1/Subscribers/legacy/LegacyBatteryInfo.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/legacy/LegacyBatteryInfo.hpp
@@ -47,7 +47,7 @@
 // Legacy message from UAVCANv0
 #include <legacy/equipment/power/BatteryInfo_1_0.h>
 
-#include "DynamicPortSubscriber.hpp"
+#include "../DynamicPortSubscriber.hpp"
 
 class UavcanLegacyBatteryInfoSubscriber : public UavcanDynamicPortSubscriber
 {

--- a/src/drivers/uavcan_v1/Uavcan.hpp
+++ b/src/drivers/uavcan_v1/Uavcan.hpp
@@ -72,11 +72,11 @@
 #include "Publishers/Gnss.hpp"
 
 #include "Subscribers/BaseSubscriber.hpp"
-#include "Subscribers/Battery.hpp"
-#include "Subscribers/Esc.hpp"
-#include "Subscribers/Gnss.hpp"
+#include "Subscribers/DS-015/Battery.hpp"
+#include "Subscribers/DS-015/Esc.hpp"
+#include "Subscribers/DS-015/Gnss.hpp"
 #include "Subscribers/NodeIDAllocationData.hpp"
-#include "Subscribers/LegacyBatteryInfo.hpp"
+#include "Subscribers/legacy/LegacyBatteryInfo.hpp"
 
 // uORB over UAVCAN subscribers
 #include "Subscribers/uORB/sensor_gps.hpp"


### PR DESCRIPTION
Updated to use libcanard canardRxAccept2 which allows to callback directly to the correct handler.

@pavel-kirienko Furthermore reworked ParamManager to use lambda expressions for UAVCAN register <-> PX4 Param system conversions.

Moved subscribers to their own message set folders, DS-015, Legacy, uORB in the future I want to make it compile selectable to support which message and thus we can easily extend it with new message standards.