### PR TITLE
vtol_att_control: Add parameter for VTOL PWM value in FW mode

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -416,7 +416,7 @@ bool VtolType::set_motor_state(const motor_state target_state, const int32_t cha
 	case motor_state::DISABLED:
 		for (int i = 0; i < num_outputs_max; i++) {
 			if (is_channel_set(i, channel_bitmap)) {
-				_current_max_pwm_values.values[i] = _disarmed_pwm_values.values[i];
+				_current_max_pwm_values.values[i] = PWM_DEFAULT_MIN;
 			}
 		}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Setting the PWM value for the VTOL motors too low during fixed-wing mode may cause some ESCs to disarm. During back transition, the ESCs may not properly rearm.

**Describe your solution**
Instead of hard-coding the PWM value for VTOL motors during fixed-wing flight, make the value configurable by adding the parameter `VT_DIS_PWM_FW`. During fixed-wing flight, set both the minimum and maximum PWM values for the VTOL motors to the value of the parameter.

**Test data / coverage**
Tested in SITL using `make px4_sitl gazebo_standard_vtol`. The following output is during fixed-wing flight.

### Before Fix

> pxh> pwm_out_sim status
> control latency: 10891 events, 36000us elapsed, 3.31us avg, min 0us max 4000us 114.944us rms
> INFO  [mixer_module] Switched to rate_ctrl work queue: 1
> INFO  [mixer_module] Mixer loaded: yes
> INFO  [mixer_module] Driver instance: 0
> INFO  [mixer_module] Channel Configuration:
> INFO  [mixer_module] Channel 0: value: 900, failsafe: 600, disarmed: 900, min: 1000, max: 900
> INFO  [mixer_module] Channel 1: value: 900, failsafe: 600, disarmed: 900, min: 1000, max: 900
> INFO  [mixer_module] Channel 2: value: 900, failsafe: 600, disarmed: 900, min: 1000, max: 900
> INFO  [mixer_module] Channel 3: value: 900, failsafe: 600, disarmed: 900, min: 1000, max: 900
> INFO  [mixer_module] Channel 4: value: 1276, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 5: value: 1503, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 6: value: 1496, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 7: value: 1629, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 8: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 9: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 10: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 11: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 12: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 13: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 14: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 15: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000

### After Fix

> pxh> pwm_out_sim status
> control latency: 13692 events, 68000us elapsed, 4.97us avg, min 0us max 4000us 140.863us rms
> INFO  [mixer_module] Switched to rate_ctrl work queue: 1
> INFO  [mixer_module] Mixer loaded: yes
> INFO  [mixer_module] Driver instance: 0
> INFO  [mixer_module] Channel Configuration:
> INFO  [mixer_module] Channel 0: value: 1000, failsafe: 600, disarmed: 900, min: 1000, max: 1000
> INFO  [mixer_module] Channel 1: value: 1000, failsafe: 600, disarmed: 900, min: 1000, max: 1000
> INFO  [mixer_module] Channel 2: value: 1000, failsafe: 600, disarmed: 900, min: 1000, max: 1000
> INFO  [mixer_module] Channel 3: value: 1000, failsafe: 600, disarmed: 900, min: 1000, max: 1000
> INFO  [mixer_module] Channel 4: value: 1268, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 5: value: 1501, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 6: value: 1498, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 7: value: 1635, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 8: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 9: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 10: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 11: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 12: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 13: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 14: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
> INFO  [mixer_module] Channel 15: value: 0, failsafe: 600, disarmed: 900, min: 1000, max: 2000
