### PR TITLE
commander: fix race condition on mission start

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -123,7 +123,7 @@ public:
 
 private:
 
-	void check_mission_result();
+	void check_mission_result(bool should_include_regular_check);
 
 	void answer_command(const vehicle_command_s &cmd, uint8_t result);
 
@@ -443,4 +443,7 @@ private:
 	uORB::Publication<vehicle_command_ack_s>		_command_ack_pub{ORB_ID(vehicle_command_ack)};
 
 	orb_advert_t _mavlink_log_pub{nullptr};
+
+	unsigned _mission_result_generation{0};
+	unsigned _previous_mission_instance_count{0};
 };

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -122,6 +122,9 @@ public:
 	void get_circuit_breaker_params();
 
 private:
+
+	void check_mission_result();
+
 	void answer_command(const vehicle_command_s &cmd, uint8_t result);
 
 	transition_result_t arm(arm_disarm_reason_t calling_reason, bool run_preflight_checks = true);


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is an attempt to fix the race condition that can happen in SITL testing where switching to mission mode happens right after mission upload. What presumably happens is that commander has not updated the mission_result yet and therefore denies to switch to mission mode.

**Describe your solution**
To fix, we now update the mission_result topic just before checking the mission validity. We still do the regular checks as before.

**Describe possible alternatives**
A workaround would be to sleep before trying to start the mission in the MAVSDK test.

**Test data / coverage**
Tested a bit in HITL. The problem only reproduces in CI every now and then, so I can't actually prove that this fixes it.
