### PR TITLE
Sensors: use temperature data from differential pressure sensor to calculate air density

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -110,6 +110,22 @@ void VehicleAirData::SensorCorrectionsUpdate(bool force)
 	}
 }
 
+void VehicleAirData::AirTemperatureUpdate()
+{
+	differential_pressure_s differential_pressure;
+
+	static constexpr float temperature_min_celsius = -20.f;
+	static constexpr float temperature_max_celsius = 35.f;
+
+	// update air temperature if data from differential pressure sensor is finite and not exactly 0
+	// limit the range to max 35°C to limt the error due to heated up airspeed sensors prior flight
+	if (_differential_pressure_sub.update(&differential_pressure) && PX4_ISFINITE(differential_pressure.temperature)
+	    && fabsf(differential_pressure.temperature) > FLT_EPSILON) {
+		_air_temperature_celsius = math::constrain(differential_pressure.temperature, temperature_min_celsius,
+					   temperature_max_celsius);
+	}
+}
+
 void VehicleAirData::ParametersUpdate()
 {
 	// Check if parameters have changed
@@ -129,6 +145,8 @@ void VehicleAirData::Run()
 	ParametersUpdate();
 
 	SensorCorrectionsUpdate();
+
+	AirTemperatureUpdate();
 
 	bool updated[MAX_SENSOR_COUNT] {};
 
@@ -250,12 +268,8 @@ void VehicleAirData::Run()
 			out.baro_alt_meter = (((powf((p / p1), (-(a * CONSTANTS_AIR_GAS_CONST) / CONSTANTS_ONE_G))) * T1) - T1) / a;
 
 			// calculate air density
-			// estimate air density assuming typical 20degC ambient temperature
-			// TODO: use air temperature if available (differential pressure sensors)
-			static constexpr float pressure_to_density = 1.0f / (CONSTANTS_AIR_GAS_CONST * (20.0f -
-					CONSTANTS_ABSOLUTE_NULL_CELSIUS));
-
-			out.rho = pressure_to_density * out.baro_pressure_pa;
+			out.rho = out.baro_pressure_pa  / (CONSTANTS_AIR_GAS_CONST * (_air_temperature_celsius -
+							   CONSTANTS_ABSOLUTE_NULL_CELSIUS));
 
 			out.timestamp = hrt_absolute_time();
 			_vehicle_air_data_pub.publish(out);

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,6 +46,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/sensor_correction.h>
@@ -72,6 +73,7 @@ private:
 
 	void ParametersUpdate();
 	void SensorCorrectionsUpdate(bool force = false);
+	void AirTemperatureUpdate();
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
@@ -80,6 +82,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _sensor_correction_sub{ORB_ID(sensor_correction)};
+	uORB::Subscription _differential_pressure_sub{ORB_ID(differential_pressure)};
 
 	uORB::SubscriptionCallbackWorkItem _sensor_sub[MAX_SENSOR_COUNT] {
 		{this, ORB_ID(sensor_baro), 0},
@@ -109,6 +112,8 @@ private:
 	uint8_t _priority[MAX_SENSOR_COUNT] {};
 
 	int8_t _selected_sensor_sub_index{-1};
+
+	float _air_temperature_celsius{20.f}; // initialize with typical 20degC ambient temperature
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,


### PR DESCRIPTION
**Describe problem solved by this pull request**
For the air density calculation we currently assume constant 20°C temperature. As the temperature has a significant effect on air density, it would be nice to use the measurement from an airspeed sensor (differential pressure) if available.

**Describe your solution**
- subscribe to differential_pressure in Sensors/Vehicle_air_data
- use differential_pressure.temperature if that is within valid range (defined as -50..50°C)

Do we also want to handle subscriptions to multiple differential_pressure instances with fallback logic? Sounds a bit like an overkill to me atm, but it also shows that there could be a cleaner way how we handle the publication of estimated values that are not coming from the EKF atm (like mainly airspeed, but also air density in that case). 

**Test data / coverage**
SITL tested.

**Additional context**
Air density can e.g. be used for throttle scaling.
