### PR TITLE
VTOL: always set min PWM, not only once on entering a new VTOL phase

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -314,11 +314,6 @@ void Standard::update_transition_state()
 		}
 
 		set_all_motor_state(motor_state::ENABLED);
-
-		// set idle speed for MC actuators
-		if (!_flag_idle_mc) {
-			_flag_idle_mc = set_idle_mc();
-		}
 	}
 
 	mc_weight = math::constrain(mc_weight, 0.0f, 1.0f);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -244,10 +244,6 @@ void Tailsitter::update_transition_state()
 
 		const float trans_pitch_rate = M_PI_2_F / _params->back_trans_duration;
 
-		if (!_flag_idle_mc) {
-			_flag_idle_mc = set_idle_mc();
-		}
-
 		if (tilt > 0.01f) {
 			_q_trans_sp = Quatf(AxisAnglef(_trans_rot_axis,
 						       time_since_trans_start * trans_pitch_rate)) * _q_trans_start;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -366,12 +366,6 @@ void Tiltrotor::update_transition_state()
 		// turn on all MC motors
 		set_all_motor_state(motor_state::ENABLED);
 
-
-		// set idle speed for rotary wing mode
-		if (!_flag_idle_mc) {
-			_flag_idle_mc = set_idle_mc();
-		}
-
 		// tilt rotors back
 		if (_tilt_control > _params_tiltrotor.tilt_mc) {
 			_tilt_control = _params_tiltrotor.tilt_fw -

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -136,9 +136,7 @@ bool VtolType::init()
 
 void VtolType::update_mc_state()
 {
-	if (!_flag_idle_mc) {
-		_flag_idle_mc = set_idle_mc();
-	}
+	set_idle_mc();
 
 	resetAccelToPitchPitchIntegrator();
 
@@ -155,9 +153,7 @@ void VtolType::update_mc_state()
 
 void VtolType::update_fw_state()
 {
-	if (_flag_idle_mc) {
-		_flag_idle_mc = !set_idle_fw();
-	}
+	set_idle_fw();
 
 	resetAccelToPitchPitchIntegrator();
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -218,8 +218,6 @@ protected:
 
 	struct Params 					*_params;
 
-	bool _flag_idle_mc = false;		//false = "idle is set for fixed wing mode"; true = "idle is set for multicopter mode"
-
 	bool _pusher_active = false;
 	float _mc_roll_weight = 1.0f;	// weight for multicopter attitude controller roll output
 	float _mc_pitch_weight = 1.0f;	// weight for multicopter attitude controller pitch output


### PR DESCRIPTION



**Describe problem solved by this pull request**
Upon a parameter change, pwm_out resets the minimum PWM, and with that can overwrite VT_IDLE_PWM_MC.

**Describe your solution**
In the VTOL module always set the PWM min values corresponding to the VTOL mode.

Downsides:
- uses up resources for nothing most of the time (haven't checked how much)
- if a param change occurs in hover, the PWM min may still get set to non-VT_IDLE_PWM_MC for a brief moment (haven't checked)

**Describe possible alternatives**
- in pwm_out, do not update the PWM settings upon a random param change
- in VTOL, check the currently set PWM min and only reset if required
- find a clean way to get rid of the current PWM settings inside the VTOL module

**Test data / coverage**
Bench tested


