### PR TITLE
mpu9250: tolerate missing/mismatching FIFO samples if I2C slave mag active

### DIFF
--- a/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
@@ -123,7 +123,7 @@ private:
 	bool FIFORead(const hrt_abstime &timestamp_sample, uint8_t samples);
 	void FIFOReset();
 
-	bool ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
+	void ProcessAccel(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
 	void ProcessGyro(const hrt_abstime &timestamp_sample, const FIFO::DATA fifo[], const uint8_t samples);
 	void UpdateTemperature();
 


### PR DESCRIPTION
When the mpu9250 mag is active it disrupts IMU sampling. This change modifies the simple mpu9250 FIFO integrity checks (comparing duplicate accel samples) to tolerate these samples that don't match if the mag is active. Alternatively we could "fix" this by skipping the check entirely, but I'd rather keep it to catch instances where the data is corrupt due to setting the SPI clock too high, etc.

 - fixes https://github.com/PX4/PX4-Autopilot/issues/17615