### PR TITLE
sensors/vehicle_acceleration: require sample rate before running

### DIFF
--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.hpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.hpp
@@ -94,7 +94,7 @@ private:
 	matrix::Vector3f _acceleration_prev{};
 
 	static constexpr const float kInitialRateHz{1000.f}; /**< sensor update rate used for initialization */
-	float _filter_sample_rate{kInitialRateHz};
+	float _filter_sample_rate{NAN};
 
 	math::LowPassFilter2pVector3f _lp_filter{kInitialRateHz, 30.f};
 


### PR DESCRIPTION
 - don't run until successfully getting the sensor's sample rate from vehicle_imu_status


This fixes a minor edge case when you only have a single accelerometer and haven't made any parameter changes, the sensor sample rate (used for filtering) might not have been updated from default.
