### PR TITLE
[RFC] multicopter position controller protection during active accelerometer clipping

### DIFF
--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -68,5 +68,7 @@ float32 vz_max				# maximum vertical speed - set to 0 when limiting not required
 float32 hagl_min			# minimum height above ground level - set to 0 when limiting not required (meters)
 float32 hagl_max			# maximum height above ground level - set to 0 when limiting not required (meters)
 
+bool accelerometer_clipping
+
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth
 # TOPICS estimator_local_position

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -848,6 +848,8 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 		lpos.hagl_max = INFINITY;
 	}
 
+	lpos.accelerometer_clipping = _ekf.fault_status_flags().bad_acc_clipping;
+
 	// publish vehicle local position data
 	lpos.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_local_position_pub.publish(lpos);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -44,6 +44,7 @@
 #include <lib/controllib/blocks.hpp>
 #include <lib/hysteresis/hysteresis.h>
 #include <lib/perf/perf_counter.h>
+#include <lib/slew_rate/SlewRate.hpp>
 #include <lib/slew_rate/SlewRateYaw.hpp>
 #include <lib/systemlib/mavlink_log.h>
 #include <px4_platform_common/px4_config.h>
@@ -181,6 +182,8 @@ private:
 	control::BlockDerivative _vel_z_deriv; /**< velocity derivative in z */
 
 	PositionControl _control; /**< class for core PID position control */
+
+	SlewRate<float> _maximum_thrust_slew;
 
 	hrt_abstime _last_warn{0}; /**< timer when the last warn message was sent out */
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -118,6 +118,7 @@ public:
 	 * @param thrust [0.1, 0.9] with which the vehicle hovers not acelerating down or up with level orientation
 	 */
 	void setHoverThrust(const float hover_thrust) { _hover_thrust = math::constrain(hover_thrust, 0.1f, 0.9f); }
+	float getHoverThrust() const { return _hover_thrust; }
 
 	/**
 	 * Update the hover thrust without immediately affecting the output


### PR DESCRIPTION
 - during accelerometer clipping slew multicopter thrust limit (MPC_THR_MAX) down to hover thrust (+ margin)
 - the goal is to reduce or possibly prevent additionally clipping exacerbating the situation and leading to a flyaway

As a result of the clipping the velocity estimate (usually z) jumps quite quickly. The idea is to limit the throttle extreme which leads to more clipping and possibly a flyaway.

<img width="797" alt="Screen Shot 2021-05-24 at 4 40 55 PM" src="https://user-images.githubusercontent.com/84712/119405159-d4799000-bcae-11eb-8062-3283def44196.png">


<img width="783" alt="Screen Shot 2021-05-24 at 4 40 11 PM" src="https://user-images.githubusercontent.com/84712/119405080-ba3fb200-bcae-11eb-9efd-3441a79aa7f8.png">


This will be tested in the near future on a problematic vehicle.
