### PR TITLE
TFMini Plus i2c Driver

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -77,6 +77,12 @@ then
 	lightware_laser_i2c start -X
 fi
 
+# Benewake TFmini Plus laser rangefinder sensor for i2c protocol
+if param greater -s SENS_EN_TFP_I2C 0
+then
+	tfmini_plus_i2c start -X
+fi
+
 # Sensor HY-SRF05 or HC-SR05 ultrasonic sensor
 if param compare -s SENS_EN_SR05 1
 then

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/CMakeLists.txt
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/CMakeLists.txt
@@ -30,22 +30,17 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-
-add_subdirectory(broadcom)
-add_subdirectory(cm8jl65)
-add_subdirectory(leddar_one)
-add_subdirectory(ll40ls)
-add_subdirectory(ll40ls_pwm)
-add_subdirectory(mappydot)
-add_subdirectory(mb12xx)
-add_subdirectory(pga460)
-add_subdirectory(lightware_laser_i2c)
-add_subdirectory(lightware_laser_serial)
-add_subdirectory(srf02)
-add_subdirectory(teraranger)
-add_subdirectory(tfmini)
-add_subdirectory(tfmini_plus_i2c)
-add_subdirectory(ulanding_radar)
-add_subdirectory(vl53l0x)
-add_subdirectory(vl53l1x)
-add_subdirectory(gy_us42)
+px4_add_module(
+	MODULE drivers__distance_sensor__tfmini_plus_i2c
+	MAIN tfmini_plus_i2c
+	SRCS
+		TFMINI_PLUS.cpp
+		TFMINI_PLUS.hpp
+		tfmini_plus_i2c_main.cpp
+		tfmini_plus_parser.cpp
+	MODULE_CONFIG
+		module.yaml
+	DEPENDS
+		drivers_rangefinder
+		px4_work_queue
+	)

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/TFMINI_PLUS.cpp
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/TFMINI_PLUS.cpp
@@ -1,0 +1,328 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file tfmini_plus_i2c.cpp
+ *
+ * @author Eren Ipek <eren.ipek@maxwell-innovations.com>
+ *
+ * I2C Driver for the Benewake TFmini Plus laser rangefinder series
+ * Default I2C address 0x10 is used.
+ */
+
+#include "TFMINI_PLUS.hpp"
+
+#include <fcntl.h>
+
+tfmini_plus::tfmini_plus(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency,
+			 int address) :
+	I2C(DRV_DIST_DEVTYPE_TFMINI_PLUS, MODULE_NAME, bus, address, bus_frequency),
+	I2CSPIDriver(MODULE_NAME, px4::device_bus_to_wq(get_device_id()), bus_option, bus),
+	_px4_rangefinder(get_device_id(), rotation)
+{
+	_px4_rangefinder.set_max_distance(TFMINI_PLUS_MAX_DISTANCE);
+	_px4_rangefinder.set_min_distance(TFMINI_PLUS_MIN_DISTANCE);
+	_px4_rangefinder.set_fov(math::radians(TFMINI_PLUS_FOV));
+
+}
+
+tfmini_plus::~tfmini_plus()
+{
+	perf_free(_sample_perf);
+	perf_free(_comms_errors);
+}
+
+void tfmini_plus::start()
+{
+	// Reset the report ring and state machine.
+	_collect_phase = false;
+
+	// Schedule a cycle to start things.
+	ScheduleDelayed(TFMINI_START_INTERVAL);
+}
+
+int tfmini_plus::init()
+{
+	// I2C init (and probe) first.
+	if (I2C::init() != OK) {
+		return PX4_ERROR;
+	}
+
+	px4_usleep(TFMINI_I2C_INIT_INTERVAL);
+
+	if (sensorInit() != PX4_OK) {
+		return PX4_ERROR;
+	}
+
+	return PX4_OK;
+}
+
+int tfmini_plus::collect()
+{
+	float distance_m = -1.0f;
+	uint16_t signal_value = 0;
+	float temperature = -273.0f;
+	int ret = 0;
+
+	ret = transfer(_tfminiplus_setup._tfminiplus_command._com_obtain_data,
+		       sizeof(_tfminiplus_setup._tfminiplus_command._com_obtain_data), nullptr, 0);
+
+	if (ret < 0) {
+		perf_count(_comms_errors);
+		return ret;
+	}
+
+	perf_begin(_sample_perf);
+	const hrt_abstime timestamp_sample = hrt_absolute_time();
+
+	//read from the sensor
+	ret = transfer(nullptr, 0, _command_response, static_cast<int>(TFMINI_COMMAND_RESPONSE_SIZE::OBTAIN_DATA_FRAME));
+
+	if (ret < 0) {
+		perf_count(_comms_errors);
+		return ret;
+	}
+
+	//parse
+	for (int i = 0; i < static_cast<int>(TFMINI_COMMAND_RESPONSE_SIZE::OBTAIN_DATA_FRAME); i++) {
+		tfmini_parse(_command_response[i], &_parse_state, &distance_m, &signal_value, &temperature);
+
+		if (_parse_state == TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC) {
+			perf_count(_comms_errors);
+		}
+	}
+
+	if (distance_m < 0.0f) {
+		perf_end(_sample_perf);
+		return -EAGAIN;
+	}
+
+	int8_t signal_quality = -1;
+
+	if (signal_value < TFMINI_PLUS_ACCEPTABLE_MIN_SIGNAL_VALUE || signal_value == TFMINI_PLUS_INVALID_MEASURE) {
+		signal_quality = 0;
+	}
+
+	signal_value = math::min(signal_value, static_cast<uint16_t>(TFMINI_PLUS_MAX_SIGNAL_VALUE));
+	signal_quality = static_cast<int8_t>(static_cast<uint32_t>(signal_value) / 200);  //in percent, ie: x*100/20000 or x/200
+
+	// publish most recent valid measurement from buffer
+	_px4_rangefinder.update(timestamp_sample, distance_m, signal_quality);
+
+	perf_end(_sample_perf);
+
+	return PX4_OK;
+}
+
+void tfmini_plus::RunImpl()
+{
+	if (_collect_phase) {
+		// Perform collection.
+		if (OK != collect()) {
+			PX4_DEBUG("collection error");
+			// If error restart the measurement state machine.
+			start();
+			return;
+		}
+
+		_collect_phase = false;
+	}
+
+	_collect_phase = true;
+
+	// Schedule delay for 100 Hz.
+	ScheduleDelayed(_interval);
+}
+
+void tfmini_plus::print_status()
+{
+	I2CSPIDriverBase::print_status();
+
+	if (_tfminiplus_setup._setup_step == TFMINIPLUS_SETUP_STEP::STEP4_SAVE_CONFIRMED) {
+		PX4_INFO("TFMINI-Plus is configured - version = %u.%u.%u\n", _tfminiplus_setup._version[0],
+			 _tfminiplus_setup._version[1],
+			 _tfminiplus_setup._version[2]);
+
+	} else {
+		PX4_INFO("TFMINI-Plus is being configured(state = %u) - version = %u.%u.%u\n",
+			 (uint8_t)_tfminiplus_setup._setup_step,
+			 _tfminiplus_setup._version[0], _tfminiplus_setup._version[1],
+			 _tfminiplus_setup._version[2]);
+		perf_print_counter(_sample_perf);
+		perf_print_counter(_comms_errors);
+	}
+}
+
+int tfmini_plus::autosetup_tfminiplus(void)
+{
+	int ret = 0;
+
+	if (_tfminiplus_setup._setup_step == TFMINIPLUS_SETUP_STEP::STEP4_SAVE_CONFIRMED) {
+		return ret;
+	}
+
+	// informations about commands and responses to/from TFMini-plus has been found in TFmini-Plus A04-Product Mannual_EN.pdf
+	switch (_tfminiplus_setup._setup_step) {
+	case TFMINIPLUS_SETUP_STEP::STEP0_UNCONFIGURED:
+		ret = transfer(_tfminiplus_setup._tfminiplus_command._com_version,
+			       sizeof(_tfminiplus_setup._tfminiplus_command._com_version), nullptr, 0);
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		px4_usleep(TFMINI_PLUS_COMMAND_WAITING_PERIOD);
+
+		ret = transfer(nullptr, 0, _command_response, static_cast<int>(TFMINI_COMMAND_RESPONSE_SIZE::OBTAIN_FW_VERSION));
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		// we have written _tfminiplus_setup._tfminiplus_command._com_version and we expect reading 5A 07 01 V1 V2 V3
+		if (_command_response[1] == 0x07 && _command_response[2] == 0x01) {
+			_tfminiplus_setup._version[0] = _command_response[3];
+			_tfminiplus_setup._version[1] = _command_response[4];
+			_tfminiplus_setup._version[2] = _command_response[5];
+			_tfminiplus_setup._setup_step = TFMINIPLUS_SETUP_STEP::STEP1_VERSION_CONFIRMED;
+		}
+
+		break;
+
+	case TFMINIPLUS_SETUP_STEP::STEP1_VERSION_CONFIRMED:
+		ret = transfer(_tfminiplus_setup._tfminiplus_command._com_mode, sizeof(_tfminiplus_setup._tfminiplus_command._com_mode),
+			       nullptr, 0);
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		px4_usleep(TFMINI_PLUS_COMMAND_WAITING_PERIOD);
+
+		ret = transfer(nullptr, 0, _command_response, static_cast<int>(TFMINI_COMMAND_RESPONSE_SIZE::IO_MODE));
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		// we have written _tfminiplus_setup._tfminiplus_command._com_mode and we expect reading 5A 05 05 01 65
+		if (_command_response[1] == 0x05 && _command_response[2] == 0x05 && _command_response[3] == 0x01) {
+			_tfminiplus_setup._setup_step = TFMINIPLUS_SETUP_STEP::STEP2_MODE_CONFIRMED;
+		}
+
+		break;
+
+	case TFMINIPLUS_SETUP_STEP::STEP2_MODE_CONFIRMED:
+		ret = transfer(_tfminiplus_setup._tfminiplus_command._com_enable,
+			       sizeof(_tfminiplus_setup._tfminiplus_command._com_enable), nullptr, 0);
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		px4_usleep(TFMINI_PLUS_COMMAND_WAITING_PERIOD);
+
+		ret = transfer(nullptr, 0, _command_response, static_cast<int>(TFMINI_COMMAND_RESPONSE_SIZE::ENABLE_DISABLE_OUTPUT));
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		// we have written _tfminiplus_setup._tfminiplus_command._com_enable and we expect reading 5A 05 07 01 67
+		if (_command_response[1] == 0x05 && _command_response[2] == 0x07 && _command_response[3] == 0x01) {
+			_tfminiplus_setup._setup_step = TFMINIPLUS_SETUP_STEP::STEP3_ENABLE_CONFIRMED;
+		}
+
+		break;
+
+	case TFMINIPLUS_SETUP_STEP::STEP3_ENABLE_CONFIRMED:
+		ret = transfer(_tfminiplus_setup._tfminiplus_command._com_save, sizeof(_tfminiplus_setup._tfminiplus_command._com_save),
+			       nullptr, 0);
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		px4_usleep(TFMINI_PLUS_COMMAND_WAITING_PERIOD);
+
+		ret = transfer(nullptr, 0, _command_response, static_cast<int>(TFMINI_COMMAND_RESPONSE_SIZE::SAVE_SETTINGS));
+
+		if (ret < 0) {
+			perf_count(_comms_errors);
+			return ret;
+		}
+
+		// we have written _tfminiplus_setup._tfminiplus_command._com_save and we expect reading 5A 05 11 00 6F
+		if (_command_response[1] == 0x05 && _command_response[2] == 0x11 && _command_response[3] == 0x00) {
+			_tfminiplus_setup._setup_step = TFMINIPLUS_SETUP_STEP::STEP4_SAVE_CONFIRMED;
+		}
+
+		break;
+
+	default:
+		break;
+	}
+
+	if (ret < 0) {
+		perf_count(_comms_errors);
+		return ret;
+	}
+
+	return ret;
+}
+
+int tfmini_plus::sensorInit()
+{
+	int ret = 0;
+
+	for (int i = 0 ; i < static_cast<int>(TFMINIPLUS_SETUP_STEP::STEP_MEMBER_COUNT); ++i) {
+
+		ret = autosetup_tfminiplus();
+
+		if (ret < 0) {
+			PX4_ERR("sensor setup err: %d", ret);
+			perf_count(_comms_errors);
+			perf_end(_sample_perf);
+			return ret;
+		}
+	}
+
+	return PX4_OK;
+}

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/TFMINI_PLUS.hpp
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/TFMINI_PLUS.hpp
@@ -1,0 +1,167 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file tfmini_plus.hpp
+ * @author Eren Ipek <eren.ipek@maxwell-innovations.com>
+ *
+ * I2C Driver for the Benewake TFmini Plus laser rangefinder series
+ * Default I2C address 0x10 is used.
+ */
+
+#pragma once
+
+#include <termios.h>
+
+#include <drivers/drv_hrt.h>
+#include <lib/parameters/param.h>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/drivers/rangefinder/PX4Rangefinder.hpp>
+#include <uORB/topics/distance_sensor.h>
+
+#include "tfmini_plus_parser.h"
+
+#include <px4_platform_common/i2c_spi_buses.h>
+#include <drivers/device/i2c.h>
+
+/* Configuration Constants */
+#define TFMINI_PLUS_BASEADDR 				0x10 	// see product mannual 5.5 i2c data communucation
+#define TFMINI_PLUS_BUS_CLOCK                           400000  // 400kHz bus clock speed
+
+/* Device limits */
+#define TFMINI_PLUS_MIN_DISTANCE 			(0.10f)
+#define TFMINI_PLUS_MAX_DISTANCE 			(12.f)
+#define	TFMINI_PLUS_FOV					(3.6f)
+#define TFMINI_PLUS_INVALID_MEASURE 			0xFFFF
+
+//according to the spec, signal is within [0-0xFFFF]
+//according to test, signal is within [0-20000]
+#define TFMINI_PLUS_MAX_SIGNAL_VALUE 			20000
+#define TFMINI_PLUS_ACCEPTABLE_MIN_SIGNAL_VALUE 	100	// see product mannual 5.4 Descriptions of default Output Data
+
+#define TFMINI_PLUS_COMMAND_WAITING_PERIOD		100000	// see product mannual 4.6 Timing sequence description of I^2^C mode
+#define TFMINI_PLUS_OBTAIN_DATA_PERIOD			10000	// 10000 us = 100 Hz
+
+#define TFMINI_I2C_INIT_INTERVAL			200000
+#define TFMINI_START_INTERVAL				5
+
+enum class TFMINIPLUS_SETUP_STEP {
+	STEP0_UNCONFIGURED = 0,
+	STEP1_VERSION_CONFIRMED = 1,
+	STEP2_MODE_CONFIRMED = 2,
+	STEP3_ENABLE_CONFIRMED = 3,
+	STEP4_SAVE_CONFIRMED = 4,
+	STEP_MEMBER_COUNT
+};
+
+enum class TFMINI_COMMAND_RESPONSE_SIZE {
+	SYSTEM_RESET = 5,
+	OUTPUT_FORMAT = 5,
+	ENABLE_DISABLE_OUTPUT = 5,
+	SET_SLAVE_ADDR = 5,
+	IO_MODE = 5,
+	RESTORE_FACTORY_SETTIGS = 5,
+	SAVE_SETTINGS = 5,
+	OBTAIN_FW_VERSION = 7,
+	BAUDRATE = 8,
+	OBTAIN_DATA_FRAME = 9,
+	TRIGGER_DETECTION = 9,
+};
+
+class TFMINIPLUS_COMMAND
+{
+public:
+	uint8_t _com_version[4] {0x5A, 0x04, 0x01, 0x5F}; //Obtain firmware version.
+	uint8_t _com_mode[5] {0x5A, 0x05, 0x05, 0x01, 0x65}; // standart 9byte (cm)
+	uint8_t _com_enable[5] {0x5A, 0x05, 0x07, 0x01, 0x67}; // enable data output
+	uint8_t _com_save[4] {0X5A, 0x04, 0x11, 0x6F}; // Save settings
+	uint8_t _com_obtain_data[5] {0x5A, 0x05, 0x00, 0x01, 0x60};
+};
+
+class TFMINIPLUS_SETUP
+{
+public:
+	TFMINIPLUS_COMMAND _tfminiplus_command;
+	TFMINIPLUS_SETUP_STEP _setup_step{TFMINIPLUS_SETUP_STEP::STEP0_UNCONFIGURED};
+	uint8_t _version[3] {0, 0, 0};
+
+};
+
+class tfmini_plus : public device::I2C, public I2CSPIDriver<tfmini_plus>
+{
+public:
+	tfmini_plus(I2CSPIBusOption bus_option, const int bus, const uint8_t rotation, int bus_frequency,
+		    int address = TFMINI_PLUS_BASEADDR);
+	~tfmini_plus() override;
+
+	static I2CSPIDriverBase *instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
+					     int runtime_instance);
+	static void print_usage();
+
+	int init() override;
+	void print_status() override;
+
+	void RunImpl();
+
+private:
+
+	void start();
+	int collect();
+
+	/**
+	 * Test whether the device supported by the driver is present at a
+	 * specific address.
+	 * @param address The I2C bus address to probe.
+	 * @return True if the device is present.
+	 */
+	int probe_address(uint8_t address);
+
+	int autosetup_tfminiplus(void);
+	int sensorInit();
+
+	PX4Rangefinder _px4_rangefinder;
+
+	TFMINI_PLUS_PARSE_STATE _parse_state {TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC};
+	int _interval{TFMINI_PLUS_OBTAIN_DATA_PERIOD};
+	uint8_t _command_response[10] {};
+
+	TFMINIPLUS_SETUP _tfminiplus_setup;
+
+	bool _collect_phase{false};
+
+	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, MODULE_NAME": com_err")};
+	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED,  MODULE_NAME": read")};
+};

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/module.yaml
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/module.yaml
@@ -1,0 +1,15 @@
+module_name: Benewake TFMini Rangefinder I2C Driver Module
+parameters:
+    - group: Sensors
+      definitions:
+        SENS_EN_TFP_I2C:
+            description:
+                short: Enable TFMini Plus I2C Driver
+                long: |
+                    Enables TFMini laser rangefinder I2C driver module
+            type: enum
+            values:
+                0: DISABLED
+                1: ENABLED
+            reboot_required: true
+            default: 0

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/tfmini_plus_i2c_main.cpp
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/tfmini_plus_i2c_main.cpp
@@ -1,0 +1,109 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "TFMINI_PLUS.hpp"
+
+#include <px4_platform_common/getopt.h>
+#include <px4_platform_common/module.h>
+
+void
+tfmini_plus::print_usage()
+{
+	PRINT_MODULE_USAGE_NAME("tfmini_plus", "driver");
+	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
+	PRINT_MODULE_USAGE_PARAM_INT('R', 25, 1, 25, "Sensor rotation - downward facing by default", true);
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+}
+
+I2CSPIDriverBase *tfmini_plus::instantiate(const BusCLIArguments &cli, const BusInstanceIterator &iterator,
+		int runtime_instance)
+{
+	tfmini_plus *instance = new tfmini_plus(iterator.configuredBusOption(), iterator.bus(), cli.orientation,
+						cli.bus_frequency);
+
+	if (instance == nullptr) {
+		PX4_ERR("alloc failed");
+		return nullptr;
+	}
+
+	if (instance->init() != PX4_OK) {
+		delete instance;
+		return nullptr;
+	}
+
+	instance->start();
+	return instance;
+}
+
+extern "C" __EXPORT int tfmini_plus_i2c_main(int argc, char *argv[])
+{
+	int ch;
+	using ThisDriver = tfmini_plus;
+	BusCLIArguments cli{true, false};
+	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	cli.default_i2c_frequency = TFMINI_PLUS_BUS_CLOCK;
+
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
+		switch (ch) {
+		case 'R':
+			cli.orientation = atoi(cli.optArg());
+			break;
+		}
+	}
+
+	const char *verb = cli.optArg();
+
+	if (!verb) {
+		ThisDriver::print_usage();
+		return -1;
+	}
+
+	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_DIST_DEVTYPE_TFMINI_PLUS);
+
+	if (!strcmp(verb, "start")) {
+		return ThisDriver::module_start(cli, iterator);
+	}
+
+	if (!strcmp(verb, "stop")) {
+		return ThisDriver::module_stop(iterator);
+	}
+
+	if (!strcmp(verb, "status")) {
+		return ThisDriver::module_status(iterator);
+	}
+
+	ThisDriver::print_usage();
+	return -1;
+}

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/tfmini_plus_parser.cpp
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/tfmini_plus_parser.cpp
@@ -1,0 +1,183 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file tfmini_plus_parser.cpp - modified from tfmini_parser.cpp
+ * @author Eren Ipek <eren.ipek@maxwell-innovations.com>
+ *
+ * Declarations of parser for the Benewake TFmini Plus laser rangefinder series
+ */
+
+#include "tfmini_plus_parser.h"
+#include <string.h>
+
+// #define TFMINI_DEBUG
+
+#ifdef TFMINI_DEBUG
+#include <stdio.h>
+
+const char *parser_state[] = {
+	"0_UNSYNC",
+	"1_SYNC_1",
+	"1_SYNC_2",
+	"2_GOT_DIST_L",
+	"2_GOT_DIST_H",
+	"3_GOT_STRENGTH_L",
+	"3_GOT_STRENGTH_H",
+	"4_GOT_TEMPERATURE_L",
+	"5_GOT_TEMPERATURE_h",
+	"6_GOT_RESPONSE_CHECKSUM"
+};
+#endif
+
+int tfmini_parse(uint8_t c, TFMINI_PLUS_PARSE_STATE *state,
+		 float *dist, uint16_t *strength, float *temperature)
+{
+	int ret = -1;
+	static uint8_t parserbuf[9];
+	static unsigned parserbuf_index = 0;
+	unsigned char cksm = 0;
+
+	switch (*state) {
+	case TFMINI_PLUS_PARSE_STATE::STATE6_GOT_CHECKSUM:
+		if (c == TFMINI_PLUS_DATA_HEADER) {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE1_SYNC_1;
+			parserbuf[parserbuf_index] = c;
+			(parserbuf_index)++;
+
+		} else {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC;
+		}
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC:
+		if (c == TFMINI_PLUS_DATA_HEADER) {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE1_SYNC_1;
+			parserbuf[parserbuf_index] = c;
+			(parserbuf_index)++;
+
+		} else {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC;
+			parserbuf_index = 0;
+		}
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE1_SYNC_1:
+		if (c == TFMINI_PLUS_DATA_HEADER) {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE1_SYNC_2;
+			parserbuf[parserbuf_index] = c;
+			(parserbuf_index)++;
+
+		} else {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC;
+			parserbuf_index = 0;
+		}
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE1_SYNC_2:
+		*state = TFMINI_PLUS_PARSE_STATE::STATE2_GOT_DIST_L;
+		parserbuf[parserbuf_index] = c;
+		(parserbuf_index)++;
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE2_GOT_DIST_L:
+		*state = TFMINI_PLUS_PARSE_STATE::STATE2_GOT_DIST_H;
+		parserbuf[parserbuf_index] = c;
+		(parserbuf_index)++;
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE2_GOT_DIST_H:
+		*state = TFMINI_PLUS_PARSE_STATE::STATE3_GOT_STRENGTH_L;
+		parserbuf[parserbuf_index] = c;
+		(parserbuf_index)++;
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE3_GOT_STRENGTH_L:
+		*state = TFMINI_PLUS_PARSE_STATE::STATE3_GOT_STRENGTH_H;
+		parserbuf[parserbuf_index] = c;
+		(parserbuf_index)++;
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE3_GOT_STRENGTH_H:
+		*state = TFMINI_PLUS_PARSE_STATE::STATE4_TEMPL;
+		parserbuf[parserbuf_index] = c;
+		(parserbuf_index)++;
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE4_TEMPL:
+		*state = TFMINI_PLUS_PARSE_STATE::STATE5_TEMPH;
+		parserbuf[parserbuf_index] = c;
+		(parserbuf_index)++;
+
+		break;
+
+	case TFMINI_PLUS_PARSE_STATE::STATE5_TEMPH:
+		// Find the checksum
+		cksm = 0;
+
+		for (int i = 0; i < 8; i++) {
+			cksm += parserbuf[i];
+		}
+
+		if (c == cksm) {
+			parserbuf[parserbuf_index] = '\0';
+			*dist = static_cast<float>(parserbuf[2] + (parserbuf[3] << 8)) / 100.f;
+			*strength = parserbuf[4] + (parserbuf[5] << 8);
+			*temperature = static_cast<float>(parserbuf[6] + (parserbuf[7] << 8)) / 8.f - 256.f;
+			*state = TFMINI_PLUS_PARSE_STATE::STATE6_GOT_CHECKSUM;
+			parserbuf_index = 0;
+			ret = 0;
+
+		} else {
+			*state = TFMINI_PLUS_PARSE_STATE::STATE0_UNSYNC;
+			parserbuf_index = 0;
+		}
+
+		break;
+
+	}
+
+#ifdef TFMINI_DEBUG
+	printf("state: TFMINI_PLUS_PARSE_STATE%s\n", parser_state[*state]);
+#endif
+
+	return ret;
+}

--- a/src/drivers/distance_sensor/tfmini_plus_i2c/tfmini_plus_parser.h
+++ b/src/drivers/distance_sensor/tfmini_plus_i2c/tfmini_plus_parser.h
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file tfmini_plus_parser.h - modified from tfmini_parser.h
+ * @author Eren Ipek <eren.ipek@maxwell-innovations.com>
+ *
+ * Declarations of parser for the Benewake TFmini Plus laser rangefinder series
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+
+// Data Format for Benewake TFmini models
+// ======================================
+// 9 bytes total per message:
+// 0) 0x59
+// 1) 0x59
+// 2) Dist_L (low 8bit)
+// 3) Dist_H (high 8bit)
+// 4) Strength_L (low 8bit)
+// 5) Strength_H (high 8bit)
+// 6) Temperature_H
+// 7) Temperature_L
+// 8) Checksum parity bit (low 8bit), Checksum = Byte1 + Byte2 +...+Byte8. This is only a low 8bit though
+
+// Command -and answers- Frame definitions for TFmini-plus model
+// =============================================================
+// 0) 0x5A
+// 1) Len: the total length of the frame（include Head and Checksum，unit: byte)
+// 2) ID: identifier code of command
+// 3;N-2) Data: data segment. Little endian format
+// N-1) Checksum: sum of all bytes from Head to payload. Lower 8 bits
+
+#define TFMINI_PLUS_DATA_HEADER 0x59
+
+#define TFMINI_PLUS_CMD_HEADER1 0x5A
+
+enum class TFMINI_PLUS_PARSE_STATE {
+	STATE0_UNSYNC = 0,
+	STATE1_SYNC_1,
+	STATE1_SYNC_2,
+	STATE2_GOT_DIST_L,
+	STATE2_GOT_DIST_H,
+	STATE3_GOT_STRENGTH_L,
+	STATE3_GOT_STRENGTH_H,
+	STATE4_TEMPL,
+	STATE5_TEMPH,
+	STATE6_GOT_CHECKSUM
+};
+
+int tfmini_parse(uint8_t c, TFMINI_PLUS_PARSE_STATE *state,
+		 float *dist, uint16_t *strength, float *temperature);


### PR DESCRIPTION
This pr is a driver for TFMini Plus via i2c bus. 

**Test data / coverage**
It tested with DJI F450 frame and Cuav v5+ FCU.
Firmware Version: v1.12.0-beta5 
Flight Mode: Altitude Mode
Flight Condition: Indoor (No GPS)
Flight log: https://review.px4.io/plot_app?log=449332d7-99a2-461f-976f-6e1c6316f81c



