### PR TITLE
ROS2/microRTPS: Add support for ROS2 Galactic and ROS2 Rolling

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -428,7 +428,7 @@ def generate_agent(out_dir):
     # the '-typeros2' option in fastrtpsgen.
     # .. note:: This is only available in FastRTPSGen 1.0.4 and above
     gen_ros2_typename = ""
-    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic'] and fastrtpsgen_version >= version.Version("1.0.4"):
+    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic', 'rolling'] and fastrtpsgen_version >= version.Version("1.0.4"):
         gen_ros2_typename = "-typeros2 "
 
     for idl_file in glob.glob(os.path.join(idl_dir, "*.idl")):

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -428,7 +428,7 @@ def generate_agent(out_dir):
     # the '-typeros2' option in fastrtpsgen.
     # .. note:: This is only available in FastRTPSGen 1.0.4 and above
     gen_ros2_typename = ""
-    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy'] and fastrtpsgen_version >= version.Version("1.0.4"):
+    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic'] and fastrtpsgen_version >= version.Version("1.0.4"):
         gen_ros2_typename = "-typeros2 "
 
     for idl_file in glob.glob(os.path.join(idl_dir, "*.idl")):


### PR DESCRIPTION
**Describe problem solved by this pull request**
This as simple as it can be read: we want continuous support to the cutting edge ROS2 distros available.

**Describe your solution**
The quick win here is make sure that at least we can generate the required typesupport and typename for uORB RTPS counterparts. This is achieved easily on the generator scripts.

**Describe possible alternatives**
Not an alternative, but following the above, other functionalities will be made available, including localhost only comms and shared memory transport. Will follow a PR with that.

**Test data / coverage**
All tested in SITL.

**Additional context**
Support to the above was already brought in https://github.com/PX4/px4_ros_com/pull/84 and https://github.com/PX4/px4_msgs/pull/5. This PR syncs the changes in the generator code. ROS2 Rolling and Galactic containers are also already available in https://github.com/PX4/PX4-containers.

Also to note there that, eventhough that the default middleware in Galactic changed from FastDDS to CycloneDDS, we can still plug the bridge topics to the ROS2 DDS domain. One can also change the default middleware to FastDDS by setting export `RMW_IMPLEMENTATION=rmw_fastrtps_cpp`.