### PR TITLE
sih in sitl test

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -137,5 +137,6 @@
         "workbench.settings.enableNaturalLanguageSearch": false,
         "yaml.schemas": {
                 "${workspaceFolder}/validation/module_schema.yaml": "${workspaceFolder}/src/modules/*/module.yaml"
-        }
+        },
+        "C_Cpp.errorSquiggles": "Disabled"
 }

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -217,6 +217,7 @@ if ! replay tryapplyparams
 then
   #. px4-rc.simulator
   sih start
+#   param set IMU_INTEG_RATE 200
 fi
 load_mon start
 battery_simulator start

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -215,7 +215,8 @@ dataman start
 # only start the simulator if not in replay mode, as both control the lockstep time
 if ! replay tryapplyparams
 then
-  . px4-rc.simulator
+  #. px4-rc.simulator
+  sih start
 fi
 load_mon start
 battery_simulator start

--- a/boards/px4/sitl/nolockstep.cmake
+++ b/boards/px4/sitl/nolockstep.cmake
@@ -52,7 +52,7 @@ px4_add_board(
 		replay
 		rover_pos_control
 		sensors
-		#sih
+		sih
 		simulator
 		temperature_compensation
 		uuv_att_control

--- a/src/modules/sih/sih.cpp
+++ b/src/modules/sih/sih.cpp
@@ -493,6 +493,23 @@ int Sih::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
+int Sih::print_status()
+{
+	PX4_INFO("Running");
+	PX4_INFO("vehicle landed: %d",_grounded);
+	PX4_INFO("groundtruth state:");
+	PX4_INFO("inertial position NED (m)");
+	_p_I.print();
+	PX4_INFO("inertial velocity NED (m/s)");
+	_v_I.print();
+	PX4_INFO("attitude roll-pitch-yaw (deg)");
+	(Eulerf(_q)*180.0f/M_PI_F).print();
+	PX4_INFO("angular acceleration roll-pitch-yaw (deg/s)");
+	(_w_B*180.0f/M_PI_F).print();
+
+	return 0;
+}
+
 int Sih::print_usage(const char *reason)
 {
 	if (reason) {
@@ -516,7 +533,6 @@ The simulator implements the equations of motion using matrix algebra.
 Quaternion representation is used for the attitude.
 Forward Euler is used for integration.
 Most of the variables are declared global in the .hpp file to avoid stack overflow.
-
 
 )DESCR_STR");
 

--- a/src/modules/sih/sih.hpp
+++ b/src/modules/sih/sih.hpp
@@ -72,6 +72,9 @@ public:
 	/** @see ModuleBase */
 	static int custom_command(int argc, char *argv[]);
 
+	/** @see ModuleBase::print_status() */
+	int print_status() override;
+
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 


### PR DESCRIPTION
This is a draft pull request in an attempt to bring the SIH into the SITL. The benefit will be to have a quadrotor simulator coded in C++ in the PX4 flight stack (SIH) that can be run on a laptop or computer. The SIH can currently only be run on a dedicated hardware (Pixhawk for example), I'm trying to make it run in SITL.

I believe the minimal steps to start the SIH in SITL are
1. compile the SIH module. I called sih in `boards/px4/sitl/nolockstep.cmake`
2. do not start the module `simulator` (sending/receiving Mavlink messages with jMAVSim), and start the module `sih` instead. I implemented this modification in `ROMFS/px4fmu_common/init.d-posix/rcS`.

I compile and start the simulation with `make px4_sitl_nolockstep none` with QGC open to monitor the behaviour.
The SIH is running (checked with `sih status`), but the EKF does not seem to fuse the IMU. The topic `vehicle_attitude` is never published, but the topic `vehicle_gps_position` is published at regular interval.

My initial guess was that the multi-EKF does not like the SIH simulating one IMU only, but it works in SIH-HITL. So, this is not the problem.

I then realized the SIH was updated and calls the IMU, mag and baro drivers `#include <lib/drivers/accelerometer/PX4Accelerometer.hpp>` and they seem to be commented from compilation in `boards/px4/sitl/nolockstep.cmake`. Does that ring a bell?
I'm also mentioning that the topics `sensor_combined`, `sensor_accel`, `sensor_gyro`, `sensor_mag`, `sensor_baro` are being published at regular interval during SIH in SITL runtime. Yes they do, but they are somewhat not consumed by the EKF.

Interestingly, I tried to create a logfile by doing `logger on` followed by `logger off` and they EKF aligned itself! and then lost its fix soon after.
```
pxh> logger on
pxh> logger off
pxh> INFO  [ecl/EKF] reset position to last known position
INFO  [ecl/EKF] reset velocity to zero
INFO  [ecl/EKF] GPS checks passed
INFO  [logger] closed logfile, bytes written: 13640874
INFO  [ecl/EKF] 1622145937251161: EKF aligned, (baro hgt, IMU buf: 12, OBS buf: 9)
WARN  [ecl/EKF] baro hgt timeout - reset to gps
WARN  [ecl/EKF] gps hgt timeout - reset to gps
```

Any hint?