### PR TITLE
Fix github url for uavcan_v1/legacy_data_types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,5 +65,5 @@
 	url = https://github.com/UAVCAN/libcanard.git
 [submodule "src/drivers/uavcan_v1/legacy_data_types"]
 	path = src/drivers/uavcan_v1/legacy_data_types
-	url = https://github.com/px4/public_regulated_data_types/
+	url = https://github.com/PX4/public_regulated_data_types/
 	branch = legacy


### PR DESCRIPTION
I don't know how this works for others/CI, but I am getting continuous errors for this URL being spelled with lower-case "px4", and need to always fix it when re-basing.

I am making a PR out of this, even though I don't know how submodule fetching can work atm for everybody else :)
