### PR TITLE
Add risc v compiler

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -310,7 +310,7 @@ function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra)
 endfunction()
 
 # add_nuttx_dir(NAME DIRECTORY KERNEL EXTRA)
-add_nuttx_dir(arch arch/arm/src y -D__KERNEL__)
+add_nuttx_dir(arch arch/${CONFIG_ARCH}/src y -D__KERNEL__)
 add_nuttx_dir(binfmt binfmt y -D__KERNEL__)
 add_nuttx_dir(boards boards y -D__KERNEL__)
 add_nuttx_dir(drivers drivers y -D__KERNEL__)

--- a/platforms/nuttx/cmake/Platform/Generic-riscv64-unknown-elf-gcc-rv64gc.cmake
+++ b/platforms/nuttx/cmake/Platform/Generic-riscv64-unknown-elf-gcc-rv64gc.cmake
@@ -1,0 +1,11 @@
+
+if(CONFIG_ARCH_DPFPU)
+	message(STATUS "Enabling double FP precision hardware instructions")
+	set(cpu_flags "-march=rv64gc -mabi=lp64d -mcmodel=medany")
+else()
+	set(cpu_flags "-march=rv64imac -mabi=lp64 -mcmodel=medany")
+endif()
+
+set(CMAKE_C_FLAGS "${cpu_flags}" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "${cpu_flags}" CACHE STRING "" FORCE)
+set(CMAKE_ASM_FLAGS "${cpu_flags} -D__ASSEMBLY__" CACHE STRING "" FORCE)

--- a/platforms/nuttx/cmake/Toolchain-riscv64-unknown-elf.cmake
+++ b/platforms/nuttx/cmake/Toolchain-riscv64-unknown-elf.cmake
@@ -1,0 +1,44 @@
+# riscv64-unknown-elf toolchain
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+
+set(triple riscv64-unknown-elf)
+set(CMAKE_LIBRARY_ARCHITECTURE ${triple})
+set(TOOLCHAIN_PREFIX ${triple})
+
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_C_COMPILER_TARGET ${triple})
+
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_CXX_COMPILER_TARGET ${triple})
+
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+
+# needed for test compilation
+set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
+
+# compiler tools
+find_program(CMAKE_AR ${TOOLCHAIN_PREFIX}-gcc-ar)
+find_program(CMAKE_GDB ${TOOLCHAIN_PREFIX}-gdb)
+find_program(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
+find_program(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-ld)
+find_program(CMAKE_NM ${TOOLCHAIN_PREFIX}-gcc-nm)
+find_program(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
+find_program(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
+find_program(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}-gcc-ranlib)
+find_program(CMAKE_STRIP ${TOOLCHAIN_PREFIX}-strip)
+
+set(CMAKE_FIND_ROOT_PATH get_file_component(${CMAKE_C_COMPILER} PATH))
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# os tools
+foreach(tool grep make)
+	string(TOUPPER ${tool} TOOL)
+	find_program(${TOOL} ${tool})
+	if(NOT ${TOOL})
+		message(FATAL_ERROR "could not find ${tool}")
+	endif()
+endforeach()


### PR DESCRIPTION
This brings in support for compiling RISC-V based targets. We are building a flight controller / flight computer based on Microchip PolarFire MPFS250T chip.

Please comment if this kind of stuff is wanted in before there is not any targets using it? Or would it make sense to discuss about this kind of additions later on, at the same time if/when new full chip support for some RISC-V would be brought in?

I was thinking that this might be useful for others as well, if someone else is working on RISC-V targets for PX4.

If this is not wanted in at this time, just ignore and close this PR :)
