### PR TITLE
fix legacy data types again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,5 +65,5 @@
 	url = https://github.com/UAVCAN/libcanard.git
 [submodule "src/drivers/uavcan_v1/legacy_data_types"]
 	path = src/drivers/uavcan_v1/legacy_data_types
-	url = https://github.com/PX4/public_regulated_data_types/
+	url = https://github.com/PX4/public_regulated_data_types.git
 	branch = legacy


### PR DESCRIPTION
I just realized that the previous fix was incomplete. It did fix the cloning for me, but the urls should actually end with .git.
