### PR TITLE
boards: bootloader.cmake trivial whitespace cleanup

### DIFF
--- a/boards/holybro/durandal-v1/bootloader.cmake
+++ b/boards/holybro/durandal-v1/bootloader.cmake
@@ -5,16 +5,5 @@ px4_add_board(
 	MODEL durandal-v1
 	LABEL bootloader
 	TOOLCHAIN arm-none-eabi
-    ARCHITECTURE cortex-m7
-
-
-	DRIVERS
-#	bootloader
-
-	MODULES
-
-	SYSTEMCMDS
-
-	EXAMPLES
-
-	)
+	ARCHITECTURE cortex-m7
+)

--- a/boards/modalai/fc-v2/bootloader.cmake
+++ b/boards/modalai/fc-v2/bootloader.cmake
@@ -6,15 +6,4 @@ px4_add_board(
 	LABEL bootloader
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
-
-
-	DRIVERS
-#	bootloader
-
-	MODULES
-
-	SYSTEMCMDS
-
-	EXAMPLES
-
-	)
+)

--- a/boards/px4/fmu-v6u/bootloader.cmake
+++ b/boards/px4/fmu-v6u/bootloader.cmake
@@ -5,16 +5,5 @@ px4_add_board(
 	MODEL fmu-v6u
 	LABEL bootloader
 	TOOLCHAIN arm-none-eabi
-    ARCHITECTURE cortex-m7
-
-
-	DRIVERS
-#	bootloader
-
-	MODULES
-
-	SYSTEMCMDS
-
-	EXAMPLES
-
-	)
+	ARCHITECTURE cortex-m7
+)

--- a/boards/px4/fmu-v6x/bootloader.cmake
+++ b/boards/px4/fmu-v6x/bootloader.cmake
@@ -5,16 +5,5 @@ px4_add_board(
 	MODEL fmu-v6x
 	LABEL bootloader
 	TOOLCHAIN arm-none-eabi
-    ARCHITECTURE cortex-m7
-
-
-	DRIVERS
-#	bootloader
-
-	MODULES
-
-	SYSTEMCMDS
-
-	EXAMPLES
-
-	)
+	ARCHITECTURE cortex-m7
+)


### PR DESCRIPTION
Clean this up before it's copied around even more.