### PR TITLE
px4_work_queue: increase UART stack

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -77,16 +77,16 @@ static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
 
 static constexpr wq_config_t uavcan{"wq:uavcan", 3624, -19};
 
-static constexpr wq_config_t UART0{"wq:UART0", 1504, -21};
-static constexpr wq_config_t UART1{"wq:UART1", 1504, -22};
-static constexpr wq_config_t UART2{"wq:UART2", 1504, -23};
-static constexpr wq_config_t UART3{"wq:UART3", 1504, -24};
-static constexpr wq_config_t UART4{"wq:UART4", 1504, -25};
-static constexpr wq_config_t UART5{"wq:UART5", 1504, -26};
-static constexpr wq_config_t UART6{"wq:UART6", 1504, -27};
-static constexpr wq_config_t UART7{"wq:UART7", 1504, -28};
-static constexpr wq_config_t UART8{"wq:UART8", 1504, -29};
-static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1504, -30};
+static constexpr wq_config_t UART0{"wq:UART0", 1536, -21};
+static constexpr wq_config_t UART1{"wq:UART1", 1536, -22};
+static constexpr wq_config_t UART2{"wq:UART2", 1536, -23};
+static constexpr wq_config_t UART3{"wq:UART3", 1536, -24};
+static constexpr wq_config_t UART4{"wq:UART4", 1536, -25};
+static constexpr wq_config_t UART5{"wq:UART5", 1536, -26};
+static constexpr wq_config_t UART6{"wq:UART6", 1536, -27};
+static constexpr wq_config_t UART7{"wq:UART7", 1536, -28};
+static constexpr wq_config_t UART8{"wq:UART8", 1536, -29};
+static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1536, -30};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1920, -50};
 


### PR DESCRIPTION
Testing master on px4_fmu-v4.

``` Console
WARN  [load_mon] wq:UART4 low on stack! (296 bytes left)
```