### PR TITLE
boards: px4_fmu-v2_default disable gyro_calibration module to save flash

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -72,7 +72,7 @@ px4_add_board(
 		flight_mode_manager
 		fw_att_control
 		fw_pos_control_l1
-		gyro_calibration
+		#gyro_calibration
 		#gyro_fft
 		land_detector
 		#landing_target_estimator


### PR DESCRIPTION
 - this doesn't impact regular gyro calibration

Master slipped over the limit slightly after back to back merges.
