### PR TITLE
CUAV X7pro and Nora: use icm42688p instead of bmi088

### DIFF
--- a/boards/cuav/nora/default.cmake
+++ b/boards/cuav/nora/default.cmake
@@ -35,6 +35,7 @@ px4_add_board(
 		imu/invensense/icm20649
 		imu/invensense/icm20689
 		imu/invensense/icm20948 # required for ak09916 mag
+		imu/invensense/icm42688p
 		irlock
 		lights # all available light drivers
 		lights/rgbled_pwm

--- a/boards/cuav/nora/init/rc.board_sensors
+++ b/boards/cuav/nora/init/rc.board_sensors
@@ -12,7 +12,10 @@ rm3100 -s -b 2 start
 
 # SPI4
 bmi088 -s -b 4 -A -R 2 start
-bmi088 -s -b 4 -G -R 2 start
+if !bmi088 -s -b 4 -G -R 2 start
+then
+	icm42688p -R 2 -s start
+fi
 ms5611 -s -b 4 start
 
 # SPI6

--- a/boards/cuav/nora/src/spi.cpp
+++ b/boards/cuav/nora/src/spi.cpp
@@ -46,6 +46,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	initSPIBus(SPI::Bus::SPI4, {
 		initSPIDevice(DRV_ACC_DEVTYPE_BMI088, SPI::CS{GPIO::PortF, GPIO::Pin3}, SPI::DRDY{GPIO::PortB, GPIO::Pin15}),
 		initSPIDevice(DRV_GYR_DEVTYPE_BMI088, SPI::CS{GPIO::PortF, GPIO::Pin4}, SPI::DRDY{GPIO::PortB, GPIO::Pin14}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM42688P, SPI::CS{GPIO::PortA, GPIO::Pin15}, SPI::DRDY{GPIO::PortB, GPIO::Pin15}),
 		initSPIDevice(DRV_BARO_DEVTYPE_MS5611, SPI::CS{GPIO::PortG, GPIO::Pin10}),
 	}),
 	initSPIBusExternal(SPI::Bus::SPI5, {

--- a/boards/cuav/x7pro/default.cmake
+++ b/boards/cuav/x7pro/default.cmake
@@ -36,6 +36,7 @@ px4_add_board(
 		imu/invensense/icm20649
 		imu/invensense/icm20689
 		imu/invensense/icm20948 # required for ak09916 mag
+		imu/invensense/icm42688p
 		irlock
 		lights # all available light drivers
 		lights/rgbled_pwm

--- a/boards/cuav/x7pro/init/rc.board_sensors
+++ b/boards/cuav/x7pro/init/rc.board_sensors
@@ -15,7 +15,10 @@ rm3100 -s -b 2 start
 
 # SPI4
 bmi088 -s -b 4 -A -R 2 start
-bmi088 -s -b 4 -G -R 2 start
+if !bmi088 -s -b 4 -G -R 2 start
+then
+	icm42688p -R 2 -s start
+fi
 ms5611 -s -b 4 start
 
 # SPI6

--- a/boards/cuav/x7pro/src/spi.cpp
+++ b/boards/cuav/x7pro/src/spi.cpp
@@ -47,6 +47,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	initSPIBus(SPI::Bus::SPI4, {
 		initSPIDevice(DRV_ACC_DEVTYPE_BMI088, SPI::CS{GPIO::PortF, GPIO::Pin3}, SPI::DRDY{GPIO::PortB, GPIO::Pin15}),
 		initSPIDevice(DRV_GYR_DEVTYPE_BMI088, SPI::CS{GPIO::PortF, GPIO::Pin4}, SPI::DRDY{GPIO::PortB, GPIO::Pin14}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM42688P, SPI::CS{GPIO::PortA, GPIO::Pin15}, SPI::DRDY{GPIO::PortB, GPIO::Pin15}),
 		initSPIDevice(DRV_BARO_DEVTYPE_MS5611, SPI::CS{GPIO::PortG, GPIO::Pin10}),
 	}),
 	initSPIBusExternal(SPI::Bus::SPI5, {


### PR DESCRIPTION
Because of the lack of chips, bmi088 on the new version X7\Nora SPI4 bus will be replaced by ICM42688P.This have done a simple test.