### PR TITLE
Add watchdog_init to ARK boards to ensure watchdog pauses during debugging

### DIFF
--- a/boards/ark/can-flow/src/init.c
+++ b/boards/ark/can-flow/src/init.c
@@ -60,6 +60,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_board_led.h>
+#include <drivers/drv_watchdog.h>
 
 #include <systemlib/px4_macros.h>
 
@@ -87,6 +88,8 @@ __END_DECLS
 
 __EXPORT void stm32_boardinitialize(void)
 {
+	watchdog_init();
+
 	// Configure CAN interface
 	stm32_configgpio(GPIO_CAN1_RX);
 	stm32_configgpio(GPIO_CAN1_TX);

--- a/boards/ark/can-gps/src/init.c
+++ b/boards/ark/can-gps/src/init.c
@@ -60,6 +60,7 @@
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_board_led.h>
+#include <drivers/drv_watchdog.h>
 
 #include <systemlib/px4_macros.h>
 
@@ -82,6 +83,8 @@
 
 __EXPORT void stm32_boardinitialize(void)
 {
+	watchdog_init();
+
 	/* configure pins */
 	const uint32_t gpio[] = PX4_GPIO_INIT_LIST;
 	px4_gpio_init(gpio, arraySize(gpio));


### PR DESCRIPTION
This PR adds a call to watchdog_init on ARK boards to ensure the watchdog timer will be paused when debugging with SWD.