### PR TITLE
gpio.cpp: Add backticks around gpio command docs

### DIFF
--- a/src/systemcmds/gpio/gpio.cpp
+++ b/src/systemcmds/gpio/gpio.cpp
@@ -299,9 +299,10 @@ void usage(const char *reason)
 		R"DESCR_STR(
 ### Description
 This command is used to read and write GPIOs
-
+```
 gpio read <PORT><PIN>/<DEVICE> [PULLDOWN|PULLUP] [--force]
 gpio write <PORT><PIN>/<DEVICE> <VALUE> [PUSHPULL|OPENDRAIN] [--force]
+```
 
 ### Examples
 Read the value on port H pin 4 configured as pullup, and it is high


### PR DESCRIPTION
This adds backticks around the generated docs for gpio command. Without this the markup is valid tags, which don't render properly - see : http://docs.px4.io/master/en/modules/modules_command.html#description-3