### PR TITLE
Fix bug in external Quadchute trigger (from PR 16691)

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -304,7 +304,7 @@ int Commander::custom_command(int argc, char *argv[])
 		send_vehicle_command(vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION,
 				     (float)(vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING ?
 					     vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW :
-					     vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC));
+					     vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC), 0.0f);
 
 		return 0;
 	}

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -699,6 +699,7 @@ MissionBlock::set_land_item(struct mission_item_s *item, bool at_current_locatio
 		vehicle_command_s vcmd = {};
 		vcmd.command = NAV_CMD_DO_VTOL_TRANSITION;
 		vcmd.param1 = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
+		vcmd.param2 = 0.0f;
 		_navigator->publish_vehicle_cmd(&vcmd);
 	}
 
@@ -748,6 +749,7 @@ MissionBlock::set_vtol_transition_item(struct mission_item_s *item, const uint8_
 {
 	item->nav_cmd = NAV_CMD_DO_VTOL_TRANSITION;
 	item->params[0] = (float) new_mode;
+	item->params[1] = 0.0f;
 	item->yaw = _navigator->get_local_position()->heading;
 	item->autocontinue = true;
 }

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -160,7 +160,7 @@ void VtolAttitudeControl::vehicle_cmd_poll()
 
 			} else {
 				_transition_command = int(vehicle_command.param1 + 0.5f);
-				_immediate_transition = int(vehicle_command.param2 + 0.5f);
+				_immediate_transition = (PX4_ISFINITE(vehicle_command.param2)) ? int(vehicle_command.param2 + 0.5f) : false;
 			}
 
 			if (vehicle_command.from_external) {


### PR DESCRIPTION
Fixes a bug introduced with https://github.com/PX4/PX4-Autopilot/pull/16691. (@dagar @sfuhrer @RomanBapst )

**Describe problem solved by this pull request**
Eli Vigdorchik ran into an undesired external quadchute during one of his test flights as reported on slack (https://px4.slack.com/archives/C39C4E709/p1622652580039900). Log here: https://review.px4.io/plot_app?log=26c65922-793b-4bad-88fa-86f58b97eb82 . For some reason Param2 of the command is set to 3, triggering the Quadchute instead of doing a normal back transition during RTL. I was able to reproduce in SITL on v1.12.0-beta and on master. I guess the issue is a badly initialized / old value of param2 floating around somewhere.
https://logs.px4.io/plot_app?log=efaae0f0-a8a8-494c-b32d-6e041689836f
https://logs.px4.io/plot_app?log=e177614d-a4c1-4ebf-97ca-6ed6fb8cf420

**Describe your solution**
Explicitly set Param2 to 0.0f in all occurrences where a normal BT is desired (I searched for all occurrences of *DO_VTOL_TRANSITION in the code).

I also added a check on NANs. If param2 is a NAN, then _immediate_transition is false too.

**Describe possible alternatives**
- 

**Test data / coverage**
Same procedure, i.e. Position mode flight with RTL triggered over QGC:
https://logs.px4.io/plot_app?log=7cc61dad-7145-4e81-9ee3-f7c84dd04ef9

I also tried manual transitions, transitions over QGC, missions with VTOL Land and normal Land items, `commander transition` and switching to Land mode via QGC. I couldn't provoke any external quadchutes. Did I miss another option to get into back transition?

**Additional context**
Follow up of https://github.com/PX4/PX4-Autopilot/pull/16691
