### PR TITLE
mavlink: properly initialize vehicle_command queue

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -118,7 +118,7 @@ Mavlink::Mavlink() :
 	}
 
 	// ensure topic exists, otherwise we might lose first queued commands
-	if (!orb_exists(ORB_ID(vehicle_command), 0)) {
+	if (orb_exists(ORB_ID(vehicle_command), 0) == PX4_ERROR) {
 		orb_advertise_queue(ORB_ID(vehicle_command), nullptr, vehicle_command_s::ORB_QUEUE_LENGTH);
 	}
 


### PR DESCRIPTION
This makes sure that the vehicle_command topic is properly initialized from the beginning.

orb_exists returns -1 or 0 and not a bool as one would expect.