### PR TITLE
mc_pos_control_params: correct MPC_POS_MODE docs since 1 is depracated

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -71,7 +71,6 @@ param set-default MPC_JERK_AUTO 4
 param set-default MPC_LAND_SPEED 1
 param set-default MPC_MAN_TILT_MAX 25
 param set-default MPC_MAN_Y_MAX 40
-param set-default MPC_POS_MODE 3
 param set-default MPC_SPOOLUP_TIME 1.5
 param set-default MPC_THR_HOVER 0.45
 param set-default MPC_TILTMAX_AIR 25

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -499,7 +499,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
 /**
  * Acceleration for auto and for manual
  *
- * Note: In manual, this parameter is only used in MPC_POS_MODE 1.
+ * Note: In manual, this parameter is only used in MPC_POS_MODE 4.
  *
  * @unit m/s^2
  * @min 2.0
@@ -544,7 +544,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 3.0f);
  *
  * Setting this to the maximum value essentially disables the limit.
  *
- * Note: This is only used when MPC_POS_MODE is set to a smoothing mode 1, 3 or 4.
+ * Note: This is only used when MPC_POS_MODE is set to a smoothing mode 3 or 4.
  *
  * @unit m/s^3
  * @min 0.5


### PR DESCRIPTION
**Describe problem solved by this pull request**
Related to https://github.com/PX4/PX4-user_guide/pull/1305/ and https://github.com/PX4/PX4-user_guide/pull/1310 we should correct the docs to reflect that MPC_POS_MODE 1 was deprecated a long time now and removed in https://github.com/PX4/PX4-Autopilot/pull/16052

**Describe your solution**
Corrected the parameter descriptions.
