### PR TITLE
Non-Version Specific changes for Future NuttX upgades

### DIFF
--- a/boards/airmind/mindpx-v2/src/init.c
+++ b/boards/airmind/mindpx-v2/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/ark/can-flow/src/init.c
+++ b/boards/ark/can-flow/src/init.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 

--- a/boards/ark/can-gps/src/init.c
+++ b/boards/ark/can-gps/src/init.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 

--- a/boards/av/x-v1/src/init.c
+++ b/boards/av/x-v1/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/bitcraze/crazyflie/src/init.c
+++ b/boards/bitcraze/crazyflie/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/analog/adc.h>

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -441,7 +441,7 @@ Syslink::handle_message(syslink_message_t *msg)
 		px4_sem_post(&memory_sem);
 
 	} else {
-		PX4_INFO("GOT %d", msg->type);
+		PX4_INFO("GOT %" PRIu8, msg->type);
 	}
 
 	//Send queued messages
@@ -609,7 +609,7 @@ Syslink::handle_raw_other(syslink_message_t *sys)
 
 	if (c->port == CRTP_PORT_LOG) {
 
-		PX4_INFO("Log: %d %d", c->channel, c->data[0]);
+		PX4_INFO("Log: %" PRIu8 " %" PRIu8, c->channel, c->data[0]);
 
 		if (c->channel == 0) { // Table of Contents Access
 
@@ -632,7 +632,7 @@ Syslink::handle_raw_other(syslink_message_t *sys)
 
 			uint8_t cmd = c->data[0];
 
-			PX4_INFO("Responding to cmd: %d", cmd);
+			PX4_INFO("Responding to cmd: %" PRIu8, cmd);
 			c->data[2] = 0; // Success
 			c->size = 3 + 1;
 
@@ -673,7 +673,7 @@ Syslink::handle_raw_other(syslink_message_t *sys)
 		}
 
 	} else {
-		PX4_INFO("Got raw: %d", c->port);
+		PX4_INFO("Got raw: %" PRIu8, c->port);
 	}
 }
 
@@ -772,13 +772,13 @@ void status()
 		printf("%i: ROM ID: ", i);
 
 		for (int idi = 0; idi < idlen; idi++) {
-			printf("%02X", id[idi]);
+			printf("%02" PRIX8, id[idi]);
 		}
 
 		deck_descriptor_t desc;
 		read(deckfd, &desc, sizeof(desc));
 
-		printf(", VID: %02X , PID: %02X\n", desc.header, desc.vendorId, desc.productId);
+		printf("HDR:%02" PRIx8 ", VID: %02" PRIx8 " , PID: %02" PRIx8 "\n", desc.header, desc.vendorId, desc.productId);
 
 		// Print pages of memory
 		for (size_t di = 0; di < sizeof(desc); di++) {
@@ -786,7 +786,7 @@ void status()
 				printf("\n");
 			}
 
-			printf("%02X ", ((uint8_t *)&desc)[di]);
+			printf("%02" PRIX8 " ", ((uint8_t *)&desc)[di]);
 
 		}
 

--- a/boards/bitcraze/crazyflie21/src/init.c
+++ b/boards/bitcraze/crazyflie21/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/analog/adc.h>

--- a/boards/cuav/can-gps-v1/src/init.c
+++ b/boards/cuav/can-gps-v1/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/i2c/i2c_master.h>

--- a/boards/cuav/nora/src/init.c
+++ b/boards/cuav/nora/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/cuav/nora/src/usb.c
+++ b/boards/cuav/nora/src/usb.c
@@ -41,6 +41,7 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 #include <stm32_otg.h>
+#include <debug.h>
 
 /************************************************************************************
  * Name:  stm32_usbsuspend

--- a/boards/cuav/x7pro/src/init.c
+++ b/boards/cuav/x7pro/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/cuav/x7pro/src/usb.c
+++ b/boards/cuav/x7pro/src/usb.c
@@ -41,6 +41,7 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 #include <stm32_otg.h>
+#include <debug.h>
 
 /************************************************************************************
  * Name:  stm32_usbsuspend

--- a/boards/cubepilot/cubeorange/src/init.c
+++ b/boards/cubepilot/cubeorange/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/cubepilot/cubeorange/src/usb.c
+++ b/boards/cubepilot/cubeorange/src/usb.c
@@ -41,6 +41,8 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 #include <stm32_otg.h>
+#include <debug.h>
+#include <syslog.h>
 
 /************************************************************************************
  * Name:  stm32_usbsuspend

--- a/boards/cubepilot/cubeyellow/src/init.c
+++ b/boards/cubepilot/cubeyellow/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/cubepilot/cubeyellow/src/usb.c
+++ b/boards/cubepilot/cubeyellow/src/usb.c
@@ -41,6 +41,9 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 #include <stm32_otg.h>
+#include <debug.h>
+#include <syslog.h>
+
 
 /************************************************************************************
  * Name:  stm32_usbsuspend

--- a/boards/cubepilot/io-v2/src/init.c
+++ b/boards/cubepilot/io-v2/src/init.c
@@ -51,6 +51,7 @@
 #include <stdio.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 

--- a/boards/freefly/can-rtk-gps/src/init.c
+++ b/boards/freefly/can-rtk-gps/src/init.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/holybro/can-gps-v1/src/init.c
+++ b/boards/holybro/can-gps-v1/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/i2c/i2c_master.h>

--- a/boards/holybro/can-gps-v1/src/manifest.c
+++ b/boards/holybro/can-gps-v1/src/manifest.c
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -136,7 +137,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/holybro/can-gps-v1/src/manifest.c
+++ b/boards/holybro/can-gps-v1/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/holybro/durandal-v1/src/init.c
+++ b/boards/holybro/durandal-v1/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/holybro/durandal-v1/src/manifest.c
+++ b/boards/holybro/durandal-v1/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -114,7 +115,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/holybro/durandal-v1/src/manifest.c
+++ b/boards/holybro/durandal-v1/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/holybro/kakutef7/src/init.c
+++ b/boards/holybro/kakutef7/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/holybro/pix32v5/src/init.c
+++ b/boards/holybro/pix32v5/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/holybro/pix32v5/src/manifest.c
+++ b/boards/holybro/pix32v5/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/holybro/pix32v5/src/manifest.c
+++ b/boards/holybro/pix32v5/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -162,7 +163,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/modalai/fc-v1/src/init.c
+++ b/boards/modalai/fc-v1/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/modalai/fc-v1/src/manifest.c
+++ b/boards/modalai/fc-v1/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/modalai/fc-v1/src/manifest.c
+++ b/boards/modalai/fc-v1/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -123,7 +124,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/modalai/fc-v2/src/init.c
+++ b/boards/modalai/fc-v2/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/modalai/fc-v2/src/manifest.c
+++ b/boards/modalai/fc-v2/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/modalai/fc-v2/src/manifest.c
+++ b/boards/modalai/fc-v2/src/manifest.c
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -115,7 +116,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/mro/ctrl-zero-f7-oem/src/init.c
+++ b/boards/mro/ctrl-zero-f7-oem/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/mro/ctrl-zero-f7/src/init.c
+++ b/boards/mro/ctrl-zero-f7/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/mro/ctrl-zero-h7-oem/src/init.c
+++ b/boards/mro/ctrl-zero-h7-oem/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/mro/ctrl-zero-h7/src/init.c
+++ b/boards/mro/ctrl-zero-h7/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/mro/pixracerpro/src/init.c
+++ b/boards/mro/pixracerpro/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/mro/pixracerpro/src/usb.c
+++ b/boards/mro/pixracerpro/src/usb.c
@@ -41,6 +41,7 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 #include <stm32_otg.h>
+#include <debug.h>
 
 /************************************************************************************
  * Name:  stm32_usbsuspend

--- a/boards/mro/x21-777/src/init.c
+++ b/boards/mro/x21-777/src/init.c
@@ -43,6 +43,8 @@
 
 #include "board_config.h"
 
+#include <syslog.h>
+
 #include <nuttx/config.h>
 #include <nuttx/board.h>
 #include <nuttx/sdio.h>

--- a/boards/mro/x21/src/init.c
+++ b/boards/mro/x21/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/nxp/fmuk66-e/src/init.c
+++ b/boards/nxp/fmuk66-e/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/nxp/fmuk66-v3/src/init.c
+++ b/boards/nxp/fmuk66-v3/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/nxp/fmurt1062-v1/src/init.c
+++ b/boards/nxp/fmurt1062-v1/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/nxp/fmurt1062-v1/src/manifest.c
+++ b/boards/nxp/fmurt1062-v1/src/manifest.c
@@ -48,6 +48,8 @@
 
 #include <px4_platform_common/px4_config.h>
 #include <stdbool.h>
+#include <syslog.h>
+
 #include "systemlib/px4_macros.h"
 #include "px4_log.h"
 

--- a/boards/nxp/fmurt1062-v1/src/manifest.c
+++ b/boards/nxp/fmurt1062-v1/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,7 +121,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			PX4_ERR("Board %4x is not supported!", ver_rev);
+			PX4_ERR("Board %4" PRIx32 " is not supported!", ver_rev);
 		}
 	}
 

--- a/boards/nxp/ucans32k146/src/bringup.c
+++ b/boards/nxp/ucans32k146/src/bringup.c
@@ -138,13 +138,13 @@ int s32k1xx_bringup(void)
 	i2c = s32k1xx_i2cbus_initialize(0);
 
 	if (i2c == NULL) {
-		serr("ERROR: Failed to get I2C%d interface\n", bus);
+		serr("ERROR: Failed to get I2C0 interface\n");
 
 	} else {
 		ret = i2c_register(i2c, 0);
 
 		if (ret < 0) {
-			serr("ERROR: Failed to register I2C%d driver: %d\n", bus, ret);
+			serr("ERROR: Failed to register I2C0 driver: %d\n", ret);
 			s32k1xx_i2cbus_uninitialize(i2c);
 		}
 	}

--- a/boards/omnibus/f4sd/src/init.c
+++ b/boards/omnibus/f4sd/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/px4/fmu-v2/src/init.c
+++ b/boards/px4/fmu-v2/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/px4/fmu-v2/src/manifest.c
+++ b/boards/px4/fmu-v2/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,6 +50,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -136,7 +137,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v2/src/manifest.c
+++ b/boards/px4/fmu-v2/src/manifest.c
@@ -52,6 +52,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/px4/fmu-v3/src/init.c
+++ b/boards/px4/fmu-v3/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/px4/fmu-v3/src/manifest.c
+++ b/boards/px4/fmu-v3/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,6 +50,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -136,7 +137,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v3/src/manifest.c
+++ b/boards/px4/fmu-v3/src/manifest.c
@@ -52,6 +52,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/px4/fmu-v4/src/init.c
+++ b/boards/px4/fmu-v4/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/px4/fmu-v4pro/src/init.c
+++ b/boards/px4/fmu-v4pro/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/boards/px4/fmu-v5/src/init.c
+++ b/boards/px4/fmu-v5/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/px4/fmu-v5/src/manifest.c
+++ b/boards/px4/fmu-v5/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/px4/fmu-v5/src/manifest.c
+++ b/boards/px4/fmu-v5/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -193,7 +194,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v5x/src/manifest.c
+++ b/boards/px4/fmu-v5x/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/px4/fmu-v5x/src/manifest.c
+++ b/boards/px4/fmu-v5x/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -155,7 +156,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v6u/src/init.c
+++ b/boards/px4/fmu-v6u/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/px4/fmu-v6u/src/manifest.c
+++ b/boards/px4/fmu-v6u/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -114,7 +115,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4"  PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/fmu-v6u/src/manifest.c
+++ b/boards/px4/fmu-v6u/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/px4/fmu-v6x/src/init.c
+++ b/boards/px4/fmu-v6x/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/px4/fmu-v6x/src/manifest.c
+++ b/boards/px4/fmu-v6x/src/manifest.c
@@ -51,6 +51,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "systemlib/px4_macros.h"
 

--- a/boards/px4/fmu-v6x/src/manifest.c
+++ b/boards/px4/fmu-v6x/src/manifest.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <nuttx/config.h>
 #include <board_config.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 
 #include "systemlib/px4_macros.h"
@@ -116,7 +117,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id)
 		}
 
 		if (boards_manifest == px4_hw_mft_list_uninitialized) {
-			syslog(LOG_ERR, "[boot] Board %4x is not supported!\n", ver_rev);
+			syslog(LOG_ERR, "[boot] Board %4" PRIx32 " is not supported!\n", ver_rev);
 		}
 	}
 

--- a/boards/px4/io-v2/src/init.c
+++ b/boards/px4/io-v2/src/init.c
@@ -51,6 +51,7 @@
 #include <stdio.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 

--- a/boards/spracing/h7extreme/src/flash_w25q128.c
+++ b/boards/spracing/h7extreme/src/flash_w25q128.c
@@ -41,6 +41,7 @@
 #include "board_config.h"
 #include "qspi.h"
 #include "arm_internal.h"
+#include <debug.h>
 
 
 /************************************************************************************

--- a/boards/spracing/h7extreme/src/flash_w25q128.c
+++ b/boards/spracing/h7extreme/src/flash_w25q128.c
@@ -212,7 +212,7 @@ __ramfunc__ int n25qxxx_command(FAR struct qspi_dev_s *qspi, uint8_t cmd)
 {
 	struct qspi_cmdinfo_s cmdinfo;
 
-	finfo("CMD: %02x\n", cmd);
+	finfo("CMD: %02" PRIx8 "\n", cmd);
 
 	cmdinfo.flags   = 0;
 	cmdinfo.addrlen = 0;
@@ -246,7 +246,7 @@ __ramfunc__ int n25qxxx_command_read(FAR struct qspi_dev_s *qspi, uint8_t cmd,
 {
 	struct qspi_cmdinfo_s cmdinfo;
 
-	finfo("CMD: %02x buflen: %lu\n", cmd, (unsigned long)buflen);
+	finfo("CMD: %02" PRIx8 " buflen: %zu\n", cmd, buflen);
 
 	cmdinfo.flags   = QSPICMD_READDATA;
 	cmdinfo.addrlen = 0;
@@ -303,7 +303,7 @@ __ramfunc__ int n25qxxx_write_page(struct n25qxxx_dev_s *priv, FAR const uint8_t
 	int ret = OK;
 	unsigned int i;
 
-	finfo("address: %08lx buflen: %u\n", (unsigned long)address, (unsigned)buflen);
+	finfo("address: %08jx buflen: %zu\n", (intmax_t)address, buflen);
 
 	pagesize = (1 << priv->pageshift);
 
@@ -378,7 +378,7 @@ __ramfunc__ int n25qxxx_write_one_page(struct n25qxxx_dev_s *priv, struct qspi_m
 	n25qxxx_write_disable(priv);
 
 	if (ret < 0) {
-		ferr("ERROR: QSPI_MEMORY failed writing address=%06x\n",
+		ferr("ERROR: QSPI_MEMORY failed writing address=%06" PRIx32 "\n",
 		     meminfo->addr);
 	}
 
@@ -394,14 +394,14 @@ __ramfunc__ int n25qxxx_erase_sector(struct n25qxxx_dev_s *priv, off_t sector)
 	off_t address;
 	uint8_t status;
 
-	finfo("sector: %08lx\n", (unsigned long)sector);
+	finfo("sector: %08jx\n", (intmax_t) sector);
 
 	/* Check that the flash is ready and unprotected */
 
 	status = n25qxxx_read_status(priv);
 
 	if ((status & STATUS_BUSY_MASK) != STATUS_READY) {
-		ferr("ERROR: Flash busy: %02x", status);
+		ferr("ERROR: Flash busy: %02" PRIx8, status);
 		return -EBUSY;
 	}
 
@@ -411,7 +411,7 @@ __ramfunc__ int n25qxxx_erase_sector(struct n25qxxx_dev_s *priv, off_t sector)
 
 	if ((status & (STATUS_BP3_MASK | STATUS_BP_MASK)) != 0 &&
 	    n25qxxx_isprotected(priv, status, address)) {
-		ferr("ERROR: Flash protected: %02x", status);
+		ferr("ERROR: Flash protected: %02" PRIx8, status);
 		return -EACCES;
 	}
 
@@ -488,7 +488,7 @@ __ramfunc__  int n25qxxx_command_address(FAR struct qspi_dev_s *qspi, uint8_t cm
 {
 	struct qspi_cmdinfo_s cmdinfo;
 
-	finfo("CMD: %02x Address: %04lx addrlen=%d\n", cmd, (unsigned long)addr, addrlen);
+	finfo("CMD: %02" PRIx8 " Address: %04jx addrlen=%" PRIx8 "\n", cmd, (intmax_t) addr, addrlen);
 
 	cmdinfo.flags   = QSPICMD_ADDRESS;
 	cmdinfo.addrlen = addrlen;

--- a/boards/spracing/h7extreme/src/flash_w25q128.c
+++ b/boards/spracing/h7extreme/src/flash_w25q128.c
@@ -41,6 +41,7 @@
 #include "board_config.h"
 #include "qspi.h"
 #include "arm_internal.h"
+#include <assert.h>
 #include <debug.h>
 
 

--- a/boards/spracing/h7extreme/src/init.c
+++ b/boards/spracing/h7extreme/src/init.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/config.h>
 #include <nuttx/board.h>

--- a/boards/spracing/h7extreme/src/qspi.c
+++ b/boards/spracing/h7extreme/src/qspi.c
@@ -457,7 +457,7 @@ inline uint32_t qspi_getreg(struct stm32h7_qspidev_s *priv, unsigned int offset)
 #ifdef CONFIG_STM32H7_QSPI_REGDEBUG
 
 	if (qspi_checkreg(priv, false, value, address)) {
-		spiinfo("%08x->%08x\n", address, value);
+		spiinfo("%08" PRIx32 "->%08" PRIx32 "\n", address, value);
 	}
 
 #endif
@@ -481,7 +481,7 @@ static inline void qspi_putreg(struct stm32h7_qspidev_s *priv, uint32_t value,
 #ifdef CONFIG_STM32H7_QSPI_REGDEBUG
 
 	if (qspi_checkreg(priv, true, value, address)) {
-		spiinfo("%08x<-%08x\n", address, value);
+		spiinfo("%08" PRIx32 "<-%08" PRIx32 "\n", address, value);
 	}
 
 #endif
@@ -516,11 +516,11 @@ QUADSPI_RAMFUNC void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *m
 	 */
 
 	regval = getreg32(priv->base + STM32_QUADSPI_CR_OFFSET); /* Control Register */
-	spiinfo("CR:%08x\n", regval);
+	spiinfo("CR:%08" PRIx32 "\n", regval);
 	spiinfo("  EN:%1d ABORT:%1d DMAEN:%1d TCEN:%1d SSHIFT:%1d\n"
 		"  FTHRES: %d\n"
 		"  TEIE:%1d TCIE:%1d FTIE:%1d SMIE:%1d TOIE:%1d APMS:%1d PMM:%1d\n"
-		"  PRESCALER: %d\n",
+		"  PRESCALER: %" PRId32 "\n",
 		(regval & QSPI_CR_EN) ? 1 : 0,
 		(regval & QSPI_CR_ABORT) ? 1 : 0,
 		(regval & QSPI_CR_DMAEN) ? 1 : 0,
@@ -537,16 +537,16 @@ QUADSPI_RAMFUNC void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *m
 		(regval & QSPI_CR_PRESCALER_MASK) >> QSPI_CR_PRESCALER_SHIFT);
 
 	regval = getreg32(priv->base + STM32_QUADSPI_DCR_OFFSET); /* Device Configuration Register */
-	spiinfo("DCR:%08x\n", regval);
-	spiinfo("  CKMODE:%1d CSHT:%d FSIZE:%d\n",
+	spiinfo("DCR:%08" PRIx32 "\n", regval);
+	spiinfo("  CKMODE:%1d CSHT:%" PRId32 " FSIZE:%" PRId32 "\n",
 		(regval & QSPI_DCR_CKMODE) ? 1 : 0,
 		(regval & QSPI_DCR_CSHT_MASK) >> QSPI_DCR_CSHT_SHIFT,
 		(regval & QSPI_DCR_FSIZE_MASK) >> QSPI_DCR_FSIZE_SHIFT);
 
 	regval = getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET); /* Communication Configuration Register */
-	spiinfo("CCR:%08x\n", regval);
-	spiinfo("   INST:%02x IMODE:%d ADMODE:%d ADSIZE:%d ABMODE:%d\n"
-		"   ABSIZE:%d DCYC:%d DMODE:%d FMODE:%d\n"
+	spiinfo("CCR:%08" PRIx32 "\n", regval);
+	spiinfo("   INST:%02" PRId32 " IMODE:%" PRId32 " ADMODE:%" PRId32 " ADSIZE:%" PRId32 " ABMODE:%" PRId32 "\n"
+		"   ABSIZE:%" PRId32 " DCYC:%" PRId32 " DMODE:%" PRId32 " FMODE:%" PRId32 "\n"
 		"   SIOO:%1d DDRM:%1d\n",
 		(regval & QSPI_CCR_INSTRUCTION_MASK) >> QSPI_CCR_INSTRUCTION_SHIFT,
 		(regval & QSPI_CCR_IMODE_MASK) >> QSPI_CCR_IMODE_SHIFT,
@@ -561,8 +561,8 @@ QUADSPI_RAMFUNC void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *m
 		(regval & QSPI_CCR_DDRM) ? 1 : 0);
 
 	regval = getreg32(priv->base + STM32_QUADSPI_SR_OFFSET); /* Status Register */
-	spiinfo("SR:%08x\n", regval);
-	spiinfo("  TEF:%1d TCF:%1d FTF:%1d SMF:%1d TOF:%1d BUSY:%1d FLEVEL:%d\n",
+	spiinfo("SR:%08" PRIx32 "\n", regval);
+	spiinfo("  TEF:%1d TCF:%1d FTF:%1d SMF:%1d TOF:%1d BUSY:%1d FLEVEL:%" PRId32 "\n",
 		(regval & QSPI_SR_TEF) ? 1 : 0,
 		(regval & QSPI_SR_TCF) ? 1 : 0,
 		(regval & QSPI_SR_FTF) ? 1 : 0,
@@ -572,17 +572,17 @@ QUADSPI_RAMFUNC void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *m
 		(regval & QSPI_SR_FLEVEL_MASK) >> QSPI_SR_FLEVEL_SHIFT);
 
 #else
-	spiinfo("    CR:%08x   DCR:%08x   CCR:%08x    SR:%08x\n",
+	spiinfo("    CR:%08" PRIx32 "   DCR:%08" PRIx32 "   CCR:%08" PRIx32 "    SR:%08" PRIx32 "\n",
 		getreg32(priv->base + STM32_QUADSPI_CR_OFFSET), /* Control Register */
 		getreg32(priv->base + STM32_QUADSPI_DCR_OFFSET), /* Device Configuration Register */
 		getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET), /* Communication Configuration Register */
 		getreg32(priv->base + STM32_QUADSPI_SR_OFFSET)); /* Status Register */
-	spiinfo("   DLR:%08x   ABR:%08x PSMKR:%08x PSMAR:%08x\n",
+	spiinfo("   DLR:%08" PRIx32 "   ABR:%08" PRIx32 " PSMKR:%08" PRIx32 " PSMAR:%08" PRIx32 "\n",
 		getreg32(priv->base + STM32_QUADSPI_DLR_OFFSET), /* Data Length Register */
 		getreg32(priv->base + STM32_QUADSPI_ABR_OFFSET), /* Alternate Bytes Register */
 		getreg32(priv->base + STM32_QUADSPI_PSMKR_OFFSET), /* Polling Status mask Register */
 		getreg32(priv->base + STM32_QUADSPI_PSMAR_OFFSET)); /* Polling Status match Register */
-	spiinfo("   PIR:%08x  LPTR:%08x\n",
+	spiinfo("   PIR:%08" PRIx32 "  LPTR:%08" PRIx32 "\n",
 		getreg32(priv->base + STM32_QUADSPI_PIR_OFFSET), /* Polling Interval Register */
 		getreg32(priv->base + STM32_QUADSPI_LPTR_OFFSET)); /* Low-Power Timeout Register */
 	(void)regval;
@@ -599,62 +599,62 @@ QUADSPI_RAMFUNC void qspi_dumpgpioconfig(const char *msg)
 	/* Port B */
 
 	regval = getreg32(STM32_GPIOB_MODER);
-	spiinfo("B_MODER:%08x\n", regval);
+	spiinfo("B_MODER:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOB_OTYPER);
-	spiinfo("B_OTYPER:%08x\n", regval);
+	spiinfo("B_OTYPER:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOB_OSPEED);
-	spiinfo("B_OSPEED:%08x\n", regval);
+	spiinfo("B_OSPEED:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOB_PUPDR);
-	spiinfo("B_PUPDR:%08x\n", regval);
+	spiinfo("B_PUPDR:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOB_AFRL);
-	spiinfo("B_AFRL:%08x\n", regval);
+	spiinfo("B_AFRL:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOB_AFRH);
-	spiinfo("B_AFRH:%08x\n", regval);
+	spiinfo("B_AFRH:%" PRIx32 "\n", regval);
 
 	/* Port D */
 
 	regval = getreg32(STM32_GPIOD_MODER);
-	spiinfo("D_MODER:%08x\n", regval);
+	spiinfo("D_MODER:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOD_OTYPER);
-	spiinfo("D_OTYPER:%08x\n", regval);
+	spiinfo("D_OTYPER:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOD_OSPEED);
-	spiinfo("D_OSPEED:%08x\n", regval);
+	spiinfo("D_OSPEED:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOD_PUPDR);
-	spiinfo("D_PUPDR:%08x\n", regval);
+	spiinfo("D_PUPDR:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOD_AFRL);
-	spiinfo("D_AFRL:%08x\n", regval);
+	spiinfo("D_AFRL:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOD_AFRH);
-	spiinfo("D_AFRH:%08x\n", regval);
+	spiinfo("D_AFRH:%" PRIx32 "\n", regval);
 
 	/* Port E */
 
 	regval = getreg32(STM32_GPIOE_MODER);
-	spiinfo("E_MODER:%08x\n", regval);
+	spiinfo("E_MODER:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOE_OTYPER);
-	spiinfo("E_OTYPER:%08x\n", regval);
+	spiinfo("E_OTYPER:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOE_OSPEED);
-	spiinfo("E_OSPEED:%08x\n", regval);
+	spiinfo("E_OSPEED:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOE_PUPDR);
-	spiinfo("E_PUPDR:%08x\n", regval);
+	spiinfo("E_PUPDR:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOE_AFRL);
-	spiinfo("E_AFRL:%08x\n", regval);
+	spiinfo("E_AFRL:%" PRIx32 "\n", regval);
 
 	regval = getreg32(STM32_GPIOE_AFRH);
-	spiinfo("E_AFRH:%08x\n", regval);
+	spiinfo("E_AFRH:%" PRIx32 "\n", regval);
 }
 #endif
 
@@ -766,18 +766,18 @@ QUADSPI_RAMFUNC int qspi_setupxctnfromcmd(struct qspi_xctnspec_s *xctn,
 
 #ifdef CONFIG_DEBUG_SPI_INFO
 	spiinfo("Transfer:\n");
-	spiinfo("  flags: %02x\n", cmdinfo->flags);
-	spiinfo("  cmd: %04x\n", cmdinfo->cmd);
+	spiinfo("  flags: %02" PRIx8 "\n", cmdinfo->flags);
+	spiinfo("  cmd: %04" PRIx16 "\n", cmdinfo->cmd);
 
 	if (QSPICMD_ISADDRESS(cmdinfo->flags)) {
-		spiinfo("  address/length: %08lx/%d\n",
-			(unsigned long)cmdinfo->addr, cmdinfo->addrlen);
+		spiinfo("  address/length: %08" PRIx32 "/%" PRId8 "\n",
+			cmdinfo->addr, cmdinfo->addrlen);
 	}
 
 	if (QSPICMD_ISDATA(cmdinfo->flags)) {
 		spiinfo("  %s Data:\n",
 			QSPICMD_ISWRITE(cmdinfo->flags) ? "Write" : "Read");
-		spiinfo("    buffer/length: %p/%d\n",
+		spiinfo("    buffer/length: %p/%" PRId16 "\n",
 			cmdinfo->buffer, cmdinfo->buflen);
 	}
 
@@ -895,13 +895,13 @@ QUADSPI_RAMFUNC int qspi_setupxctnfrommem(struct qspi_xctnspec_s *xctn,
 
 #ifdef CONFIG_DEBUG_SPI_INFO
 	spiinfo("Transfer:\n");
-	spiinfo("  flags: %02x\n", meminfo->flags);
-	spiinfo("  cmd: %04x\n", meminfo->cmd);
-	spiinfo("  address/length: %08lx/%d\n",
-		(unsigned long)meminfo->addr, meminfo->addrlen);
+	spiinfo("  flags: %02" PRIx32 "\n", meminfo->flags);
+	spiinfo("  cmd: %04" PRIx16 "\n", meminfo->cmd);
+	spiinfo("  address/length: %08" PRIx32 "/%" PRId8 "\n",
+		meminfo->addr, meminfo->addrlen);
 	spiinfo("  %s Data:\n", QSPIMEM_ISWRITE(meminfo->flags) ?
 		"Write" : "Read");
-	spiinfo("    buffer/length: %p/%d\n", meminfo->buffer, meminfo->buflen);
+	spiinfo("    buffer/length: %p/%" PRId32 "\n", meminfo->buffer, meminfo->buflen);
 #endif
 
 	DEBUGASSERT(meminfo->cmd < 256);
@@ -1789,7 +1789,7 @@ QUADSPI_RAMFUNC uint32_t qspi_setfrequency(struct qspi_dev_s *dev,
 		return 0;
 	}
 
-	spiinfo("frequency=%d\n", frequency);
+	spiinfo("frequency=%" PRId32 "\n", frequency);
 	DEBUGASSERT(priv);
 
 	/* Wait till BUSY flag reset */
@@ -1840,14 +1840,14 @@ QUADSPI_RAMFUNC uint32_t qspi_setfrequency(struct qspi_dev_s *dev,
 	/* Calculate the new actual frequency */
 
 	actual = QSPI_CLK_FREQUENCY / prescaler;
-	spiinfo("prescaler=%d actual=%d\n", prescaler, actual);
+	spiinfo("prescaler=%" PRId32 " actual=%" PRId32 "\n", prescaler, actual);
 
 	/* Save the frequency setting */
 
 	priv->frequency = frequency;
 	priv->actual = actual;
 
-	spiinfo("Frequency %d->%d\n", frequency, actual);
+	spiinfo("Frequency %" PRId32 "->%" PRId32 "\n", frequency, actual);
 	return actual;
 }
 
@@ -1916,7 +1916,7 @@ QUADSPI_RAMFUNC void qspi_setmode(struct qspi_dev_s *dev, enum qspi_mode_e mode)
 		}
 
 		qspi_putreg(priv, regval, STM32_QUADSPI_DCR_OFFSET);
-		spiinfo("DCR=%08x\n", regval);
+		spiinfo("DCR=%" PRIx32 "\n", regval);
 
 		/* Save the mode so that subsequent re-configurations will be faster */
 
@@ -2587,7 +2587,7 @@ struct qspi_dev_s *stm32h7_qspi_initialize(int intf)
 		ret = irq_attach(priv->irq, priv->handler, NULL);
 
 		if (ret < 0) {
-			spierr("ERROR: Failed to attach irq %d\n", priv->irq);
+			spierr("ERROR: Failed to attach irq %" PRId8 "\n", priv->irq);
 			goto errout_with_dmadog;
 		}
 

--- a/boards/spracing/h7extreme/src/qspi.h
+++ b/boards/spracing/h7extreme/src/qspi.h
@@ -43,6 +43,7 @@
 #include <nuttx/config.h>
 #include <nuttx/spi/qspi.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/boards/uvify/core/src/init.c
+++ b/boards/uvify/core/src/init.c
@@ -53,6 +53,7 @@
 #include <string.h>
 #include <debug.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include <nuttx/board.h>
 #include <nuttx/spi/spi.h>

--- a/msg/templates/urtps/microRTPS_transport.cpp
+++ b/msg/templates/urtps/microRTPS_transport.cpp
@@ -150,9 +150,9 @@ ssize_t Transport_node::read(uint8_t *topic_ID, char out_buffer[], size_t buffer
 	// Start not found
 	if (msg_start_pos > (rx_buff_pos - header_size)) {
 #ifndef PX4_DEBUG
-		if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓↓ %u)\033[0m\n", msg_start_pos);
+		if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓↓ %" PRIu32 ")\033[0m\n", msg_start_pos);
 #else
-		if (debug) PX4_DEBUG("                               (↓↓ %u)", msg_start_pos);
+		if (debug) PX4_DEBUG("                               (↓↓ %" PRIu32 ")", msg_start_pos);
 #endif /* PX4_DEBUG */
 
 		// All we've checked so far is garbage, drop it - but save unchecked bytes
@@ -178,9 +178,9 @@ ssize_t Transport_node::read(uint8_t *topic_ID, char out_buffer[], size_t buffer
 		// If there's garbage at the beginning, drop it
 		if (msg_start_pos > 0) {
 #ifndef PX4_DEBUG
-			if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓ %u)\033[0m\n", msg_start_pos);
+			if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓ %" PRIu32 ")\033[0m\n", msg_start_pos);
 #else
-			if (debug) PX4_DEBUG("                             (↓ %u)", msg_start_pos);
+			if (debug) PX4_DEBUG("                             (↓ %" PRIu32 ")", msg_start_pos);
 #endif /* PX4_DEBUG */
 			memmove(rx_buffer, rx_buffer + msg_start_pos, rx_buff_pos - msg_start_pos);
 			rx_buff_pos -= msg_start_pos;
@@ -194,7 +194,7 @@ ssize_t Transport_node::read(uint8_t *topic_ID, char out_buffer[], size_t buffer
 
 	if (read_crc != calc_crc) {
 #ifndef PX4_DEBUG
-		if (debug) printf("\033[0;31m[ micrortps_transport ]\tBad CRC %u != %u\t\t(↓ %lu)\033[0m\n", read_crc, calc_crc, (unsigned long)(header_size + payload_len));
+		if (debug) printf("\033[0;31m[ micrortps_transport ]\tBad CRC %" PRIu16 " != %" PRIu16 "\t\t(↓ %lu)\033[0m\n", read_crc, calc_crc, (unsigned long)(header_size + payload_len));
 #else
 		if (debug) PX4_DEBUG("Bad CRC %u != %u\t\t(↓ %lu)", read_crc, calc_crc, (unsigned long)(header_size + payload_len));
 #endif /* PX4_DEBUG */
@@ -339,7 +339,7 @@ int UART_node::init()
 		printf("\033[0;31m[ micrortps_transport ]\tUART transport: ERR SET BAUD %s: Unsupported baudrate: %d\n\tsupported examples:\n\t9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 921600, 1000000\033[0m\n",
 			uart_name, baudrate);
 #else
-		PX4_ERR("UART transport: ERR SET BAUD %s: Unsupported baudrate: %d\n\tsupported examples:\n\t9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 921600, 1000000\n",
+		PX4_ERR("UART transport: ERR SET BAUD %s: Unsupported baudrate: %" PRIu32 "\n\tsupported examples:\n\t9600, 19200, 38400, 57600, 115200, 230400, 460800, 500000, 921600, 1000000\n",
 			uart_name, baudrate);
 #endif /* PX4_ERR */
 		close();

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -302,23 +302,23 @@ def print_field(field):
     elif field.name == 'device_id':
         print("char device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(device_id_buffer, sizeof(device_id_buffer), message.device_id);")
-        print("PX4_INFO_RAW(\"\\tdevice_id: %d (%s) \\n\", message.device_id, device_id_buffer);")
+        print("PX4_INFO_RAW(\"\\tdevice_id: %\" PRId32 \" (%s) \\n\", message.device_id, device_id_buffer);")
     elif field.name == 'accel_device_id':
         print("char accel_device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(accel_device_id_buffer, sizeof(accel_device_id_buffer), message.accel_device_id);")
-        print("PX4_INFO_RAW(\"\\taccel_device_id: %d (%s) \\n\", message.accel_device_id, accel_device_id_buffer);")
+        print("PX4_INFO_RAW(\"\\taccel_device_id: %\" PRId32 \" (%s) \\n\", message.accel_device_id, accel_device_id_buffer);")
     elif field.name == 'gyro_device_id':
         print("char gyro_device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(gyro_device_id_buffer, sizeof(gyro_device_id_buffer), message.gyro_device_id);")
-        print("PX4_INFO_RAW(\"\\tgyro_device_id: %d (%s) \\n\", message.gyro_device_id, gyro_device_id_buffer);")
+        print("PX4_INFO_RAW(\"\\tgyro_device_id: %\" PRId32 \" (%s) \\n\", message.gyro_device_id, gyro_device_id_buffer);")
     elif field.name == 'baro_device_id':
         print("char baro_device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(baro_device_id_buffer, sizeof(baro_device_id_buffer), message.baro_device_id);")
-        print("PX4_INFO_RAW(\"\\tbaro_device_id: %d (%s) \\n\", message.baro_device_id, baro_device_id_buffer);")
+        print("PX4_INFO_RAW(\"\\tbaro_device_id: %\" PRId32 \" (%s) \\n\", message.baro_device_id, baro_device_id_buffer);")
     elif field.name == 'mag_device_id':
         print("char mag_device_id_buffer[80];")
         print("device::Device::device_id_print_buffer(mag_device_id_buffer, sizeof(mag_device_id_buffer), message.mag_device_id);")
-        print("PX4_INFO_RAW(\"\\tmag_device_id: %d (%s) \\n\", message.mag_device_id, mag_device_id_buffer);")
+        print("PX4_INFO_RAW(\"\\tmag_device_id: %\" PRId32 \" (%s) \\n\", message.mag_device_id, mag_device_id_buffer);")
     elif (field.name == 'q' or 'q_' in field.name) and field.type == 'float32[4]':
         # float32[4] q/q_d/q_reset/delta_q_reset
         print("{")
@@ -329,7 +329,7 @@ def print_field(field):
     elif ("flags" in field.name or "bits" in field.name) and "uint" in field.type:
         # print bits of fixed width unsigned integers (uint8, uint16, uint32) if name contains flags or bits
         print("PX4_INFO_RAW(\"\\t" + field.name + ": " + c_type + " (0b\", " + field_name + ");")
-        print("\tfor (int i = (sizeof(" + field_name + ") * 8) - 1; i >= 0; i--) { PX4_INFO_RAW(\"%u%s\", " + field_name + " >> i & 1, ((unsigned)i < (sizeof(" + field_name + ") * 8) - 1 && i % 4 == 0 && i > 0) ? \"'\" : \"\"); }")
+        print("\tfor (int i = (sizeof(" + field_name + ") * 8) - 1; i >= 0; i--) { PX4_INFO_RAW(\"%lu%s\", (unsigned long) " + field_name + " >> i & 1, ((unsigned)i < (sizeof(" + field_name + ") * 8) - 1 && i % 4 == 0 && i > 0) ? \"'\" : \"\"); }")
         print("\tPX4_INFO_RAW(\")\\n\");")
     elif is_array and 'char' in field.type:
         print(("PX4_INFO_RAW(\"\\t" + field.name + ": \\\"%." + str(array_length) + "s\\\" \\n\", message." + field.name + ");"))

--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ * Copyright (C) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,15 +51,15 @@ static pthread_mutex_t i2c_spi_module_instances_mutex = PTHREAD_MUTEX_INITIALIZE
 
 const char *BusCLIArguments::parseDefaultArguments(int argc, char *argv[])
 {
-	if (getopt(argc, argv, "") == EOF) {
-		return optarg();
+	if (getOpt(argc, argv, "") == EOF) {
+		return optArg();
 	}
 
 	// unexpected arguments
 	return nullptr;
 }
 
-int BusCLIArguments::getopt(int argc, char *argv[], const char *options)
+int BusCLIArguments::getOpt(int argc, char *argv[], const char *options)
 {
 	if (_options[0] == 0) { // need to initialize
 		if (!validateConfiguration()) {

--- a/platforms/common/include/px4_platform_common/i2c_spi_buses.h
+++ b/platforms/common/include/px4_platform_common/i2c_spi_buses.h
@@ -92,13 +92,13 @@ public:
 	/**
 	 * Like px4_getopt(), but adds and handles i2c/spi driver-specific arguments
 	 */
-	int getopt(int argc, char *argv[], const char *options);
+	int getOpt(int argc, char *argv[], const char *options);
 
 	/**
 	 * returns the current optional argument (for options like 'T:'), or the command (e.g. "start")
 	 * @return nullptr or argument/command
 	 */
-	const char *optarg() const { return _optarg; }
+	const char *optArg() const { return _optarg; }
 
 
 	I2CSPIBusOption bus_option{I2CSPIBusOption::All};

--- a/platforms/nuttx/src/canbootloader/util/cxx_init.c
+++ b/platforms/nuttx/src/canbootloader/util/cxx_init.c
@@ -41,6 +41,8 @@
 #include <sched.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <debug.h>
+#include <syslog.h>
 
 #ifdef CONFIG_HAVE_CXXINITIALIZE
 #include "cxx_init.h"

--- a/platforms/nuttx/src/px4/common/board_crashdump.c
+++ b/platforms/nuttx/src/px4/common/board_crashdump.c
@@ -54,6 +54,7 @@
 #include "arm_internal.h"
 #include <systemlib/hardfault_log.h>
 #include "nvic.h"
+#include <syslog.h>
 
 #if defined(CONFIG_STM32F7_BBSRAM) && defined(CONFIG_STM32F7_SAVE_CRASHDUMP)
 #  define HAS_BBSRAM CONFIG_STM32F7_BBSRAM

--- a/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
+++ b/platforms/nuttx/src/px4/common/px4_24xxxx_mtd.c
@@ -14,7 +14,7 @@
  *
  * Derived from drivers/mtd/m25px.c
  *
- *   Copyright (C) 2009-2011 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2009-2011, 2021 Gregory Nutt. All rights reserved.
  *   Author: Gregory Nutt <gnutt@nuttx.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,6 +55,7 @@
 #include <px4_platform_common/time.h>
 
 #include <sys/types.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -270,7 +271,7 @@ void at24c_test(void)
 			}
 
 		} else if (result != 1) {
-			syslog(LOG_INFO, "unexpected %u\n", result);
+			syslog(LOG_INFO, "unexpected %zu\n", result);
 		}
 
 		if ((count % 100) == 0) {
@@ -314,7 +315,7 @@ static ssize_t at24c_bread(FAR struct mtd_dev_s *dev, off_t startblock,
 #endif
 	blocksleft  = nblocks;
 
-	finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+	finfo("startblock: %08jx nblocks: %zu\n", (intmax_t)startblock, nblocks);
 
 	if (startblock >= priv->npages) {
 		return 0;
@@ -409,7 +410,7 @@ static ssize_t at24c_bwrite(FAR struct mtd_dev_s *dev, off_t startblock, size_t 
 		nblocks = priv->npages - startblock;
 	}
 
-	finfo("startblock: %08lx nblocks: %d\n", (long)startblock, (int)nblocks);
+	finfo("startblock: %08jx nblocks: %zu\n", (intmax_t)startblock, nblocks);
 
 	BOARD_EEPROM_WP_CTRL(false);
 
@@ -505,7 +506,7 @@ static int at24c_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
 #endif
 				ret               = OK;
 
-				finfo("blocksize: %d erasesize: %d neraseblocks: %d\n",
+				finfo("blocksize: %" PRId32 " erasesize: %" PRId32 " neraseblocks: %" PRId32 "\n",
 				      geo->blocksize, geo->erasesize, geo->neraseblocks);
 			}
 		}

--- a/platforms/nuttx/src/px4/common/px4_mtd.cpp
+++ b/platforms/nuttx/src/px4/common/px4_mtd.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/spi.h>
 
+#include <inttypes.h>
 #include <errno.h>
 #include <stdbool.h>
 #include "systemlib/px4_macros.h"
@@ -363,7 +364,7 @@ memoryout:
 
 		char blockname[32];
 
-		unsigned offset;
+		unsigned long offset;
 		unsigned part;
 
 		for (offset = 0, part = 0; rv == 0 && part < nparts; offset += instances[i].partition_block_counts[part], part++) {
@@ -373,8 +374,8 @@ memoryout:
 			instances[i].part_dev[part] = mtd_partition(instances[i].mtd_dev, offset, instances[i].partition_block_counts[part]);
 
 			if (instances[i].part_dev[part] == nullptr) {
-				PX4_ERR("mtd_partition failed. offset=%lu nblocks=%lu",
-					(unsigned long)offset, (unsigned long)nblocks);
+				PX4_ERR("mtd_partition failed. offset=%lu nblocks=%u",
+					offset, nblocks);
 				rv = -ENOSPC;
 				goto errout;
 			}
@@ -407,7 +408,7 @@ memoryout:
 errout:
 
 		if (rv < 0) {
-			PX4_ERR("mtd failure: %d bus %d address %d class %d",
+			PX4_ERR("mtd failure: %d bus %" PRId32 " address %" PRId32 " class %d",
 				rv,
 				PX4_I2C_DEVID_BUS(instances[i].devid),
 				PX4_I2C_DEVID_ADDR(instances[i].devid),

--- a/platforms/nuttx/src/px4/nxp/kinetis/io_pins/kinetis_pinirq.c
+++ b/platforms/nuttx/src/px4/nxp/kinetis/io_pins/kinetis_pinirq.c
@@ -71,8 +71,7 @@ int kinetis_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
 	} else {
 		ret = kinetis_pinirqattach(pinset, func, arg);
-		pinset &= ~_PIN_INT_MASK
-			  DEBUGASSERT(port < KINETIS_NPORTS);
+		pinset &= ~_PIN_INT_MASK;
 
 		if (risingedge) {
 			pinset |= PIN_INT_RISING;

--- a/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/dshot/dshot.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright (C) 2019 PX4 Development Team. All rights reserved.
+ * Copyright (C) 2019, 2021 PX4 Development Team. All rights reserved.
  * Author: Igor Misic <igy1000mb@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -234,7 +234,7 @@ static void dshot_motor_data_set(uint32_t motor_number, uint16_t throttle, bool 
 	motor_buffer[motor_number * ONE_MOTOR_BUFF_SIZE + DSHOT_END_OF_STREAM] = 0;
 }
 
-void up_dshot_motor_data_set(uint32_t motor_number, uint16_t throttle, bool telemetry)
+void up_dshot_motor_data_set(unsigned motor_number, uint16_t throttle, bool telemetry)
 {
 	dshot_motor_data_set(motor_number, throttle + DShot_cmd_MIN_throttle, telemetry);
 }

--- a/platforms/nuttx/src/px4/stm/stm32_common/srgbled_dma/srgbled_dma.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32_common/srgbled_dma/srgbled_dma.cpp
@@ -233,9 +233,9 @@
 // Was the N complementary timer output was used
 
 #if defined(S_RGB_LED_CHANNELN)
-#  define CCER_CCnxE GTIM_CCER_CC1NE
+#  define CCER_CCnxE ATIM_CCER_CC1NE
 #else
-#  define CCER_CCnxE GTIM_CCER_CC1E
+#  define CCER_CCnxE ATIM_CCER_CC1E
 #endif
 
 #if S_RGB_LED_CHANNEL == 1

--- a/platforms/nuttx/src/px4/stm/stm32f4/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32f4/px4io_serial/px4io_serial.cpp
@@ -36,6 +36,7 @@
  *
  * Serial interface for PX4IO on STM32F4
  */
+#include <syslog.h>
 
 #include <px4_arch/px4io_serial.h>
 

--- a/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/px4io_serial.cpp
@@ -37,6 +37,8 @@
  * Serial interface for PX4IO on STM32F7
  */
 
+#include <syslog.h>
+
 #include <px4_arch/px4io_serial.h>
 
 #include "stm32_uart.h"

--- a/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/px4io_serial.cpp
@@ -37,8 +37,9 @@
  * Serial interface for PX4IO on STM32F7
  */
 
-#include <px4_arch/px4io_serial.h>
+#include <syslog.h>
 
+#include <px4_arch/px4io_serial.h>
 #include "stm32_uart.h"
 #include <nuttx/cache.h>
 

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -182,11 +182,11 @@ extern "C" int ads1115_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.i2c_address = 0x48;
 
-	while ((ch = cli.getopt(argc, argv, "")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "")) != EOF) {
 
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/adc/board_adc/ADC.cpp
+++ b/src/drivers/adc/board_adc/ADC.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,7 +55,7 @@ ADC::ADC(uint32_t base_address, uint32_t channels) :
 	}
 
 	if (_channel_count > PX4_MAX_ADC_CHANNELS) {
-		PX4_ERR("PX4_MAX_ADC_CHANNELS is too small (%d, %d)", (unsigned)PX4_MAX_ADC_CHANNELS, _channel_count);
+		PX4_ERR("PX4_MAX_ADC_CHANNELS is too small (%u, %u)", PX4_MAX_ADC_CHANNELS, _channel_count);
 	}
 
 	_samples = new px4_adc_msg_t[_channel_count];
@@ -307,14 +307,14 @@ int ADC::test()
 	px4_usleep(20000);	// sleep 20ms and wait for adc report
 
 	if (adc_sub_test.update(&adc)) {
-		PX4_INFO_RAW("DeviceID: %d\n", adc.device_id);
-		PX4_INFO_RAW("Resolution: %d\n", adc.resolution);
+		PX4_INFO_RAW("DeviceID: %" PRId32 "\n", adc.device_id);
+		PX4_INFO_RAW("Resolution: %" PRId32 "\n", adc.resolution);
 		PX4_INFO_RAW("Voltage Reference: %f\n", (double)adc.v_ref);
 
 		for (unsigned l = 0; l < 20; ++l) {
 			for (unsigned i = 0; i < PX4_MAX_ADC_CHANNELS; ++i) {
 				if (adc.channel_id[i] >= 0) {
-					PX4_INFO_RAW("% 2d:% 6d", adc.channel_id[i], adc.raw_data[i]);
+					PX4_INFO_RAW("% 2" PRId16 " :% 6" PRId32, adc.channel_id[i], adc.raw_data[i]);
 				}
 			}
 

--- a/src/drivers/adc/board_adc/ADC.hpp
+++ b/src/drivers/adc/board_adc/ADC.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
  * Driver for an ADC.
  *
  */
+#include <inttypes.h>
 #include <stdint.h>
 
 #include <drivers/drv_adc.h>

--- a/src/drivers/barometer/bmp280/bmp280.h
+++ b/src/drivers/barometer/bmp280/bmp280.h
@@ -39,7 +39,6 @@
 #pragma once
 
 #include <drivers/device/spi.h>
-#include <inttypes.h>
 
 #define BMP280_ADDR_CAL		0x88	/* address of 12x 2 bytes calibration data */
 #define BMP280_ADDR_DATA	0xF7	/* address of 2x 3 bytes p-t data */

--- a/src/drivers/barometer/bmp280/bmp280_main.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,13 +63,13 @@ I2CSPIDriverBase *BMP280::instantiate(const BusCLIArguments &cli, const BusInsta
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 

--- a/src/drivers/barometer/bmp388/bmp388_main.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,13 +61,13 @@ I2CSPIDriverBase *BMP388::instantiate(const BusCLIArguments &cli, const BusInsta
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 

--- a/src/drivers/barometer/dps310/DPS310.hpp
+++ b/src/drivers/barometer/dps310/DPS310.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/barometer/dps310/dps310_main.cpp
+++ b/src/drivers/barometer/dps310/dps310_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,13 +68,13 @@ I2CSPIDriverBase *DPS310::instantiate(const BusCLIArguments &cli, const BusInsta
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 

--- a/src/drivers/barometer/lps22hb/lps22hb_main.cpp
+++ b/src/drivers/barometer/lps22hb/lps22hb_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,13 +56,13 @@ I2CSPIDriverBase *LPS22HB::instantiate(const BusCLIArguments &cli, const BusInst
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 

--- a/src/drivers/barometer/lps25h/lps25h.h
+++ b/src/drivers/barometer/lps25h/lps25h.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/barometer/lps25h/lps25h_main.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,13 +60,13 @@ I2CSPIDriverBase *LPS25H::instantiate(const BusCLIArguments &cli, const BusInsta
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 

--- a/src/drivers/barometer/lps33hw/lps33hw.hpp
+++ b/src/drivers/barometer/lps33hw/lps33hw.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/barometer/lps33hw/lps33hw_main.cpp
+++ b/src/drivers/barometer/lps33hw/lps33hw_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -69,13 +69,13 @@ I2CSPIDriverBase *LPS33HW::instantiate(const BusCLIArguments &cli, const BusInst
 	}
 
 	if (interface == nullptr) {
-		PX4_ERR("failed creating interface for bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_ERR("failed creating interface for bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 
 	if (interface->init() != OK) {
 		delete interface;
-		PX4_DEBUG("no device on bus %i (devid 0x%x)", iterator.bus(), iterator.devid());
+		PX4_DEBUG("no device on bus %i (devid 0x%" PRIx32 ")", iterator.bus(), iterator.devid());
 		return nullptr;
 	}
 

--- a/src/drivers/barometer/ms5611/ms5611_main.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -100,10 +100,10 @@ extern "C" int ms5611_main(int argc, char *argv[])
 	cli.default_spi_frequency = 20 * 1000 * 1000;
 	uint16_t dev_type_driver = DRV_BARO_DEVTYPE_MS5611;
 
-	while ((ch = cli.getopt(argc, argv, "T:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "T:")) != EOF) {
 		switch (ch) {
 		case 'T': {
-				int val = atoi(cli.optarg());
+				int val = atoi(cli.optArg());
 
 				if (val == 5611) {
 					cli.type = MS5611_DEVICE;
@@ -118,7 +118,7 @@ extern "C" int ms5611_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -52,8 +52,8 @@ BATT_SMBUS::BATT_SMBUS(I2CSPIBusOption bus_option, const int bus, SMBus *interfa
 		     interface->get_device_address()),
 	_interface(interface)
 {
-	int battsource = 1;
-	int batt_device_type = (int)SMBUS_DEVICE_TYPE::UNDEFINED;
+	int32_t battsource = 1;
+	int32_t batt_device_type = static_cast<int32_t>(SMBUS_DEVICE_TYPE::UNDEFINED);
 
 	param_set(param_find("BAT_SOURCE"), &battsource);
 	param_get(param_find("BAT_SMBUS_MODEL"), &batt_device_type);
@@ -84,7 +84,7 @@ BATT_SMBUS::~BATT_SMBUS()
 		delete _interface;
 	}
 
-	int battsource = 0;
+	int32_t battsource = 0;
 	param_set(param_find("BAT_SOURCE"), &battsource);
 }
 
@@ -567,8 +567,8 @@ BATT_SMBUS::custom_method(const BusCLIArguments &cli)
 	switch(cli.custom1) {
 		case 1: {
 			PX4_INFO("The manufacturer name: %s", _manufacturer_name);
-			PX4_INFO("The manufacturer date: %d", _manufacture_date);
-			PX4_INFO("The serial number: %d", _serial_number);
+			PX4_INFO("The manufacturer date: %" PRId16, _manufacture_date);
+			PX4_INFO("The serial number: %d" PRId16, _serial_number);
 		}
 			break;
 		case 2:
@@ -590,7 +590,7 @@ BATT_SMBUS::custom_method(const BusCLIArguments &cli)
 				unsigned length = tx_buf[0];
 
 				if (PX4_OK != dataflash_write(address, tx_buf+1, length)) {
-					PX4_ERR("Dataflash write failed: %d", address);
+					PX4_ERR("Dataflash write failed: %u", address);
 				}
 				px4_usleep(100_ms);
 			}

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -264,7 +264,7 @@ CameraCapture::set_capture_control(bool enabled)
 		_gpio_capture = false;
 
 	} else {
-		PX4_ERR("Unable to set capture callback for chan %u\n", conf.channel);
+		PX4_ERR("Unable to set capture callback for chan %" PRIu8 "\n", conf.channel);
 		_capture_enabled = false;
 		goto err_out;
 	}
@@ -314,7 +314,7 @@ void
 CameraCapture::status()
 {
 	PX4_INFO("Capture enabled : %s", _capture_enabled ? "YES" : "NO");
-	PX4_INFO("Frame sequence : %u", _capture_seq);
+	PX4_INFO("Frame sequence : %" PRIu32, _capture_seq);
 
 	if (_last_trig_time != 0) {
 		PX4_INFO("Last trigger timestamp : %" PRIu64 " (%i ms ago)", _last_trig_time,
@@ -328,7 +328,7 @@ CameraCapture::status()
 		PX4_INFO("Last exposure time : %0.2f ms", double(_last_exposure_time) / 1000.0);
 	}
 
-	PX4_INFO("Number of overflows : %u", _capture_overflows);
+	PX4_INFO("Number of overflows : %" PRIu32, _capture_overflows);
 }
 
 static int usage()

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -43,6 +43,7 @@
  * @author Lorenz Meier <lorenz@px4.io>
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -295,7 +296,7 @@ CameraTrigger::CameraTrigger() :
 		break;
 
 	default:
-		PX4_ERR("unknown camera interface mode: %i", (int)_camera_interface_mode);
+		PX4_ERR("unknown camera interface mode: %d", static_cast<int>(_camera_interface_mode));
 		break;
 	}
 
@@ -769,7 +770,7 @@ unknown_cmd:
 
 	// Command ACK handling
 	if (updated && need_ack) {
-		PX4_DEBUG("acknowledging command %d, result=%d", cmd.command, cmd_result);
+		PX4_DEBUG("acknowledging command %" PRId32 ", result=%u", cmd.command, cmd_result);
 		vehicle_command_ack_s command_ack{};
 		command_ack.command = cmd.command;
 		command_ack.result = (uint8_t)cmd_result;
@@ -897,7 +898,7 @@ CameraTrigger::status()
 {
 	PX4_INFO("main state : %s", _trigger_enabled ? "enabled" : "disabled");
 	PX4_INFO("pause state : %s", _trigger_paused ? "paused" : "active");
-	PX4_INFO("mode : %i", _trigger_mode);
+	PX4_INFO("mode : %d", static_cast<int>(_trigger_mode));
 
 	if (_trigger_mode == TRIGGER_MODE_INTERVAL_ALWAYS_ON ||
 	    _trigger_mode == TRIGGER_MODE_INTERVAL_ON_CMD) {

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -52,8 +52,8 @@ void CameraInterface::get_pins()
 		_pins[i] = -1;
 	}
 
-	int pin_list = 0;
-	int pin_list_ex = 0;
+	int32_t pin_list = 0;
+	int32_t pin_list_ex = 0;
 
 	if (_p_pin_ex != PARAM_INVALID) {
 		param_get(_p_pin_ex, &pin_list_ex);

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -73,7 +73,7 @@ void CameraInterfacePWM::setup()
 	// Set neutral pulsewidths
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
-			up_pwm_trigger_set(_pins[i], math::constrain(_pwm_camera_neutral, 0, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(_pwm_camera_neutral, (int32_t) 0, (int32_t) 2000));
 		}
 	}
 
@@ -84,7 +84,8 @@ void CameraInterfacePWM::trigger(bool trigger_on_true)
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
 			// Set all valid pins to shoot or neutral levels
-			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? _pwm_camera_shoot : _pwm_camera_neutral, 0, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? _pwm_camera_shoot : _pwm_camera_neutral, (int32_t) 0,
+					   (int32_t) 2000));
 		}
 	}
 }

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013, 2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013, 2014, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -307,15 +307,15 @@ ms4525_airspeed_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 100000;
 	int device_type = DEVICE_TYPE_MS4525;
 
-	while ((ch = cli.getopt(argc, argv, "T:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "T:")) != EOF) {
 		switch (ch) {
 		case 'T':
-			device_type = atoi(cli.optarg());
+			device_type = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/gy_us42/GY_US42_main.cpp
+++ b/src/drivers/distance_sensor/gy_us42/GY_US42_main.cpp
@@ -73,15 +73,15 @@ extern "C" __EXPORT int gy_us42_main(int argc, char *argv[])
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -200,7 +200,7 @@ int LightwareLaser::init()
 		break;
 
 	default:
-		PX4_ERR("invalid HW model %d.", hw_model);
+		PX4_ERR("invalid HW model %" PRId32 ".", hw_model);
 		return ret;
 	}
 
@@ -265,7 +265,7 @@ int LightwareLaser::enableI2CBinaryProtocol()
 		return ret;
 	}
 
-	PX4_DEBUG("protocol values: 0x%x 0x%x", value[0], value[1]);
+	PX4_DEBUG("protocol values: 0x%" PRIx8 " 0x%" PRIx8, value[0], value[1]);
 
 	return (value[0] == 0xcc && value[1] == 0x00) ? 0 : -1;
 }
@@ -348,7 +348,7 @@ int LightwareLaser::collect()
 		perf_end(_sample_perf);
 
 		// compare different outputs (median filter adds about 25ms delay)
-		PX4_DEBUG("fm: %4i, fs: %2i%%, lm: %4i, lr: %4i, fs: %2i%%, n: %i",
+		PX4_DEBUG("fm: %4" PRIi16 ", fs: %2" PRIi16 "%%, lm: %4" PRIi16 ", lr: %4" PRIi16 ", fs: %2" PRIi16 "%%, n: %" PRIi16,
 			  data.first_return_median, data.first_return_strength, data.last_return_median, data.last_return_raw,
 			  data.last_return_strength, data.background_noise);
 

--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2016, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -453,15 +453,15 @@ extern "C" __EXPORT int lightware_laser_i2c_main(int argc, char *argv[])
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 400000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 
 #include "lightware_laser_serial.hpp"
 
+#include <inttypes.h>
 #include <fcntl.h>
 #include <termios.h>
 
@@ -127,7 +128,7 @@ LightwareLaserSerial::init()
 		break;
 
 	default:
-		PX4_ERR("invalid HW model %d.", hw_model);
+		PX4_ERR("invalid HW model %" PRIi32 ".", hw_model);
 		return -1;
 	}
 

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,7 @@ LidarLiteI2C::print_status()
 	perf_print_counter(_comms_errors);
 	perf_print_counter(_sensor_resets);
 	perf_print_counter(_sensor_zero_resets);
-	printf("poll interval:  %u \n", get_measure_interval());
+	printf("poll interval:  %" PRIu32 "\n", get_measure_interval());
 }
 
 int
@@ -152,12 +152,12 @@ LidarLiteI2C::probe()
 
 				if (_unit_id > 0) {
 					// v2
-					PX4_INFO("probe success - hw: %u, sw:%u, id: %u", _hw_version, _sw_version, _unit_id);
+					PX4_INFO("probe success - hw: %" PRIu8 ", sw:%" PRIu8 ", id: %" PRIu16, _hw_version, _sw_version, _unit_id);
 					_px4_rangefinder.set_max_distance(LL40LS_MAX_DISTANCE_V2);
 
 				} else {
 					// v1 and v3
-					PX4_INFO("probe success - hw: %u, sw:%u", _hw_version, _sw_version);
+					PX4_INFO("probe success - hw: %" PRIu8 ", sw:%" PRIu8, _hw_version, _sw_version);
 				}
 
 			} else {
@@ -165,7 +165,7 @@ LidarLiteI2C::probe()
 				if (_unit_id > 0) {
 					// v3hp
 					_is_v3hp = true;
-					PX4_INFO("probe success - id: %u", _unit_id);
+					PX4_INFO("probe success - id: %" PRIu16, _unit_id);
 				}
 			}
 
@@ -173,10 +173,8 @@ LidarLiteI2C::probe()
 			return OK;
 		}
 
-		PX4_DEBUG("probe failed unit_id=0x%02x hw_version=0x%02x sw_version=0x%02x",
-			  (unsigned)_unit_id,
-			  (unsigned)_hw_version,
-			  (unsigned)_sw_version);
+		PX4_DEBUG("probe failed unit_id=0x%02" PRIx16 " hw_version=0x%02" PRIu8 " sw_version=0x%02" PRIu8,
+			  _unit_id,  _hw_version, _sw_version);
 
 	}
 
@@ -273,10 +271,10 @@ LidarLiteI2C::print_registers()
 		int ret = lidar_transfer(&reg, 1, &val, 1);
 
 		if (ret != OK) {
-			printf("%02x:XX ", (unsigned)reg);
+			printf("%02" PRIx8 ":XX ", reg);
 
 		} else {
-			printf("%02x:%02x ", (unsigned)reg, (unsigned)val);
+			printf("%02" PRIx8 ":%02" PRIu8, reg, val);
 		}
 
 		if (reg % 16 == 15) {

--- a/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
@@ -102,15 +102,15 @@ extern "C" __EXPORT int ll40ls_main(int argc, char *argv[])
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = (enum Rotation)atoi(cli.optarg());
+			cli.orientation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/ll40ls_pwm/LidarLitePWM.cpp
+++ b/src/drivers/distance_sensor/ll40ls_pwm/LidarLitePWM.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -145,7 +145,7 @@ LidarLitePWM::print_info()
 	perf_print_counter(_comms_errors);
 	perf_print_counter(_sensor_resets);
 	perf_print_counter(_sensor_zero_resets);
-	printf("poll interval:  %u \n", get_measure_interval());
+	printf("poll interval:  %" PRIu32 " \n", get_measure_interval());
 }
 
 #endif

--- a/src/drivers/distance_sensor/ll40ls_pwm/LidarLitePWM.h
+++ b/src/drivers/distance_sensor/ll40ls_pwm/LidarLitePWM.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/distance_sensor/srf02/srf02_main.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,15 +74,15 @@ extern "C" __EXPORT int srf02_main(int argc, char *argv[])
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/srf05/SRF05.cpp
+++ b/src/drivers/distance_sensor/srf05/SRF05.cpp
@@ -245,7 +245,7 @@ SRF05::print_status()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	perf_print_counter(_sensor_resets);
-	printf("poll interval:  %u \n", get_measure_interval());
+	printf("poll interval:  %" PRIu32 " \n", get_measure_interval());
 	return 0;
 }
 

--- a/src/drivers/distance_sensor/teraranger/TERARANGER.cpp
+++ b/src/drivers/distance_sensor/teraranger/TERARANGER.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -208,7 +208,7 @@ int TERARANGER::init()
 		break;
 
 	default:
-		PX4_ERR("invalid HW model %d.", hw_model);
+		PX4_ERR("invalid HW model %" PRId32 ".", hw_model);
 		return PX4_ERROR;
 	}
 
@@ -244,9 +244,8 @@ int TERARANGER::probe()
 		}
 	}
 
-	PX4_DEBUG("WHO_AM_I byte mismatch 0x%02x should be 0x%02x\n",
-		  (unsigned)who_am_i,
-		  TERARANGER_WHO_AM_I_REG_VAL);
+	PX4_DEBUG("WHO_AM_I byte mismatch 0x%02" PRIx8 " should be 0x%02" PRIx8 "\n",
+		  who_am_i, TERARANGER_WHO_AM_I_REG_VAL);
 
 	// Not found on any address.
 	return -EIO;

--- a/src/drivers/distance_sensor/teraranger/TERARANGER.hpp
+++ b/src/drivers/distance_sensor/teraranger/TERARANGER.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/distance_sensor/teraranger/teraranger_main.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,15 +84,15 @@ extern "C" __EXPORT int teraranger_main(int argc, char *argv[])
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.default_i2c_frequency = 100000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/tfmini/TFMINI.cpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,7 +88,7 @@ TFMINI::init()
 		break;
 
 	default:
-		PX4_ERR("invalid HW model %d.", hw_model);
+		PX4_ERR("invalid HW model %" PRId32 ".", hw_model);
 		return -1;
 	}
 

--- a/src/drivers/distance_sensor/tfmini/TFMINI.hpp
+++ b/src/drivers/distance_sensor/tfmini/TFMINI.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
+++ b/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
@@ -568,15 +568,15 @@ extern "C" __EXPORT int vl53l0x_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
@@ -685,15 +685,15 @@ extern "C" __EXPORT int vl53l1x_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -299,7 +299,8 @@ void DShot::capture_trampoline(void *context, const uint32_t channel_index, cons
 void DShot::capture_callback(const uint32_t channel_index, const hrt_abstime edge_time,
 			     const uint32_t edge_state, const uint32_t overflow)
 {
-	fprintf(stdout, "DShot: Capture chan:%d time:%lld state:%d overflow:%d\n", channel_index, edge_time, edge_state,
+	fprintf(stdout, "DShot: Capture chan:%" PRId32 " time:%" PRId64 " state:%" PRId32 " overflow:%" PRId32 "\n",
+		channel_index, edge_time, edge_state,
 		overflow);
 }
 

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/imu/adis16477/adis16477_main.cpp
+++ b/src/drivers/imu/adis16477/adis16477_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,15 +73,15 @@ extern "C" int adis16477_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = 1000000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/adis16497/adis16497_main.cpp
+++ b/src/drivers/imu/adis16497/adis16497_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,15 +73,15 @@ extern "C" int adis16497_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = 5000000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/analog_devices/adis16448/adis16448_main.cpp
+++ b/src/drivers/imu/analog_devices/adis16448/adis16448_main.cpp
@@ -72,15 +72,15 @@ extern "C" int adis16448_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/analog_devices/adis16470/adis16470_main.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/adis16470_main.cpp
@@ -72,15 +72,15 @@ extern "C" int adis16470_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/bosch/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bosch/bmi055/bmi055_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +56,7 @@ extern "C" int bmi055_main(int argc, char *argv[])
 	cli.type = 0;
 	cli.default_spi_frequency = 10000000;
 
-	while ((ch = cli.getopt(argc, argv, "AGR:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "AGR:")) != EOF) {
 		switch (ch) {
 		case 'A':
 			cli.type = DRV_ACC_DEVTYPE_BMI055;
@@ -67,12 +67,12 @@ extern "C" int bmi055_main(int argc, char *argv[])
 			break;
 
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/bosch/bmi088/bmi088_i2c/bmi088_i2c_main.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_i2c/bmi088_i2c_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,7 +60,7 @@ extern "C" int bmi088_i2c_main(int argc, char *argv[])
 	cli.default_spi_frequency = 400 * 1000;
 
 
-	while ((ch = cli.getopt(argc, argv, "AGR:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "AGR:")) != EOF) {
 		switch (ch) {
 		case 'A':
 			cli.type = DRV_ACC_DEVTYPE_BMI088;
@@ -73,12 +73,12 @@ extern "C" int bmi088_i2c_main(int argc, char *argv[])
 			break;
 
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/bosch/bmi088/bmi088_main.cpp
+++ b/src/drivers/imu/bosch/bmi088/bmi088_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,7 +56,7 @@ extern "C" int bmi088_main(int argc, char *argv[])
 	cli.type = 0;
 	cli.default_spi_frequency = 10000000;
 
-	while ((ch = cli.getopt(argc, argv, "AGR:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "AGR:")) != EOF) {
 		switch (ch) {
 		case 'A':
 			cli.type = DRV_ACC_DEVTYPE_BMI088;
@@ -67,12 +67,12 @@ extern "C" int bmi088_main(int argc, char *argv[])
 			break;
 
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/fxas21002c/fxas21002c_main.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,15 +103,15 @@ extern "C" int fxas21002c_main(int argc, char *argv[])
 	cli.spi_mode = SPIDEV_MODE0;
 	cli.i2c_address = 0x20;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/fxos8701cq/fxos8701cq_main.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -109,15 +109,15 @@ extern "C" int fxos8701cq_main(int argc, char *argv[])
 	cli.spi_mode = SPIDEV_MODE0;
 	cli.i2c_address = 0x1E;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20602/icm20602_main.cpp
+++ b/src/drivers/imu/invensense/icm20602/icm20602_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm20602_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20608g/icm20608g_main.cpp
+++ b/src/drivers/imu/invensense/icm20608g/icm20608g_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm20608g_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20649/icm20649_main.cpp
+++ b/src/drivers/imu/invensense/icm20649/icm20649_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm20649_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20689/icm20689_main.cpp
+++ b/src/drivers/imu/invensense/icm20689/icm20689_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm20689_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm20948/icm20948_main.cpp
+++ b/src/drivers/imu/invensense/icm20948/icm20948_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,19 +74,19 @@ extern "C" int icm20948_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "MR:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "MR:")) != EOF) {
 		switch (ch) {
 		case 'M':
 			cli.custom1 = 1;
 			break;
 
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm40609d/icm40609d_main.cpp
+++ b/src/drivers/imu/invensense/icm40609d/icm40609d_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm40609d_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm42605/icm42605_main.cpp
+++ b/src/drivers/imu/invensense/icm42605/icm42605_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm42605_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
+++ b/src/drivers/imu/invensense/icm42688p/icm42688p_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int icm42688p_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu6000/mpu6000_main.cpp
+++ b/src/drivers/imu/invensense/mpu6000/mpu6000_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int mpu6000_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu6500/mpu6500_main.cpp
+++ b/src/drivers/imu/invensense/mpu6500/mpu6500_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int mpu6500_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu9250/mpu9250_i2c_main.cpp
+++ b/src/drivers/imu/invensense/mpu9250/mpu9250_i2c_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,15 +74,15 @@ extern "C" int mpu9250_i2c_main(int argc, char *argv[])
 	cli.default_i2c_frequency = I2C_SPEED;
 	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/invensense/mpu9250/mpu9250_main.cpp
+++ b/src/drivers/imu/invensense/mpu9250/mpu9250_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,19 +74,19 @@ extern "C" int mpu9250_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "MR:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "MR:")) != EOF) {
 		switch (ch) {
 		case 'M':
 			cli.custom1 = 1;
 			break;
 
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/l3gd20/l3gd20_main.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -84,15 +84,15 @@ extern "C" int l3gd20_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = 11 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/lsm303d/lsm303d_main.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -78,15 +78,15 @@ extern "C" int lsm303d_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = 11 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/imu/st/lsm9ds1/lsm9ds1_main.cpp
+++ b/src/drivers/imu/st/lsm9ds1/lsm9ds1_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int lsm9ds1_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/akm/ak09916/ak09916_main.cpp
+++ b/src/drivers/magnetometer/akm/ak09916/ak09916_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" __EXPORT int ak09916_main(int argc, char *argv[])
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/akm/ak8963/ak8963_main.cpp
+++ b/src/drivers/magnetometer/akm/ak8963/ak8963_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" __EXPORT int ak8963_main(int argc, char *argv[])
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/bosch/bmm150/bmm150_main.cpp
+++ b/src/drivers/magnetometer/bosch/bmm150/bmm150_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int bmm150_main(int argc, char *argv[])
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/hmc5883/hmc5883_main.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2015, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -108,10 +108,10 @@ extern "C" int hmc5883_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.default_spi_frequency = 11 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:T")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:T")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 
 		case 'T':
@@ -120,7 +120,7 @@ extern "C" int hmc5883_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/isentek/ist8308/ist8308_main.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/ist8308_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int ist8308_main(int argc, char *argv[])
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/isentek/ist8310/ist8310_main.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/ist8310_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,15 +75,15 @@ extern "C" int ist8310_main(int argc, char *argv[])
 	cli.i2c_address = I2C_ADDRESS_DEFAULT;
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/lis2mdl/lis2mdl_main.cpp
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -97,15 +97,15 @@ extern "C" int lis2mdl_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.default_spi_frequency = 11 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2015, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -104,15 +104,15 @@ extern "C" int lis3mdl_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.default_spi_frequency = 11 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
+++ b/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int lsm303agr_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = 8 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/lsm9ds1_mag/lsm9ds1_mag_main.cpp
+++ b/src/drivers/magnetometer/lsm9ds1_mag/lsm9ds1_mag_main.cpp
@@ -73,15 +73,15 @@ extern "C" __EXPORT int lsm9ds1_mag_main(int argc, char *argv[])
 	BusCLIArguments cli{false, true};
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/qmc5883l/qmc5883l_main.cpp
+++ b/src/drivers/magnetometer/qmc5883l/qmc5883l_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -72,15 +72,15 @@ extern "C" int qmc5883l_main(int argc, char *argv[])
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/rm3100/rm3100_main.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -104,15 +104,15 @@ extern "C" int rm3100_main(int argc, char *argv[])
 	cli.default_i2c_frequency = 400000;
 	cli.default_spi_frequency = 1 * 1000 * 1000;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/magnetometer/vtrantech/vcm1193l/vcm1193l_main.cpp
+++ b/src/drivers/magnetometer/vtrantech/vcm1193l/vcm1193l_main.cpp
@@ -71,15 +71,15 @@ extern "C" int vcm1193l_main(int argc, char *argv[])
 	BusCLIArguments cli{true, false};
 	cli.default_i2c_frequency = I2C_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/optical_flow/paw3902/paw3902_main.cpp
+++ b/src/drivers/optical_flow/paw3902/paw3902_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,15 +77,15 @@ extern "C" __EXPORT int paw3902_main(int argc, char *argv[])
 	cli.spi_mode = SPIDEV_MODE0;
 	cli.default_spi_frequency = SPI_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "Y:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "Y:")) != EOF) {
 		switch (ch) {
 		case 'Y':
-			cli.custom1 = atoi(cli.optarg());
+			cli.custom1 = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/optical_flow/pmw3901/pmw3901_main.cpp
+++ b/src/drivers/optical_flow/pmw3901/pmw3901_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -74,15 +74,15 @@ pmw3901_main(int argc, char *argv[])
 	cli.spi_mode = SPIDEV_MODE0;
 	cli.default_spi_frequency = PMW3901_SPI_BUS_SPEED;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.rotation = (enum Rotation)atoi(cli.optarg());
+			cli.rotation = (enum Rotation)atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/optical_flow/px4flow/px4flow.cpp
+++ b/src/drivers/optical_flow/px4flow/px4flow.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -411,15 +411,15 @@ px4flow_main(int argc, char *argv[])
 	cli.orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	cli.i2c_address = I2C_FLOW_ADDRESS_DEFAULT;
 
-	while ((ch = cli.getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {
 		switch (ch) {
 		case 'R':
-			cli.orientation = atoi(cli.optarg());
+			cli.orientation = atoi(cli.optArg());
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/power_monitor/ina226/ina226_main.cpp
+++ b/src/drivers/power_monitor/ina226/ina226_main.cpp
@@ -1,4 +1,35 @@
-
+/****************************************************************************
+ *
+ *   Copyright (C) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
@@ -68,15 +99,15 @@ ina226_main(int argc, char *argv[])
 	cli.support_keep_running = true;
 	cli.custom2 = 1;
 
-	while ((ch = cli.getopt(argc, argv, "t:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "t:")) != EOF) {
 		switch (ch) {
 		case 't': // battery index
-			cli.custom2 = (int)strtol(cli.optarg(), NULL, 0);
+			cli.custom2 = (int)strtol(cli.optArg(), NULL, 0);
 			break;
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 	if (!verb) {
 		ThisDriver::print_usage();
 		return -1;

--- a/src/drivers/power_monitor/voxlpm/voxlpm_main.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,16 +83,16 @@ voxlpm_main(int argc, char *argv[])
 	cli.type = VOXLPM_CH_TYPE_VBATT;
 	cli.support_keep_running = true;
 
-	while ((ch = cli.getopt(argc, argv, "T:")) != EOF) {
+	while ((ch = cli.getOpt(argc, argv, "T:")) != EOF) {
 		switch (ch) {
 		case 'T':
-			if (strcmp(cli.optarg(), "VBATT") == 0) {
+			if (strcmp(cli.optArg(), "VBATT") == 0) {
 				cli.type = VOXLPM_CH_TYPE_VBATT;
 
-			} else if (strcmp(cli.optarg(), "P5VDC") == 0) {
+			} else if (strcmp(cli.optArg(), "P5VDC") == 0) {
 				cli.type = VOXLPM_CH_TYPE_P5VDC;
 
-			} else if (strcmp(cli.optarg(), "P12VDC") == 0) {
+			} else if (strcmp(cli.optArg(), "P12VDC") == 0) {
 				cli.type = VOXLPM_CH_TYPE_P12VDC; //  same as P5VDC
 
 			} else {
@@ -104,7 +104,7 @@ voxlpm_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = cli.optarg();
+	const char *verb = cli.optArg();
 
 	if (!verb) {
 		ThisDriver::print_usage();

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -45,6 +45,7 @@
 #include <px4_platform_common/log.h>
 
 #include <sys/ioctl.h>
+#include <assert.h>
 #include <unistd.h>
 #include <cstdint>
 #include <string.h>

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -381,7 +381,7 @@ int PWMOut::set_mode(Mode mode)
  *                                    For Oneshot there is no rate, 0 is therefore used
  *                                    to  select Oneshot mode
  */
-int PWMOut::set_pwm_rate(uint32_t rate_map, unsigned default_rate, unsigned alt_rate)
+int PWMOut::set_pwm_rate(unsigned rate_map, unsigned default_rate, unsigned alt_rate)
 {
 	PX4_DEBUG("pwm_out%u set_pwm_rate %x %u %u", _instance, rate_map, default_rate, alt_rate);
 
@@ -416,7 +416,7 @@ int PWMOut::set_pwm_rate(uint32_t rate_map, unsigned default_rate, unsigned alt_
 			if (pass == 0) {
 				// preflight
 				if ((alt != 0) && (alt != mask)) {
-					PX4_WARN("rate group %u mask %x bad overlap %x", group, mask, alt);
+					PX4_WARN("rate group %u mask %" PRIx32 " bad overlap %" PRIx32, group, mask, alt);
 					// not a legal map, bail
 					return -EINVAL;
 				}
@@ -540,7 +540,9 @@ void PWMOut::capture_trampoline(void *context, uint32_t chan_index,
 void PWMOut::capture_callback(uint32_t chan_index,
 			      hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow)
 {
-	fprintf(stdout, "FMU: Capture chan:%d time:%lld state:%d overflow:%d\n", chan_index, edge_time, edge_state, overflow);
+	fprintf(stdout, "FMU: Capture chan:%" PRId32 " time:%" PRId64 " state:%" PRId32 " overflow:%" PRId32 "\n", chan_index,
+		edge_time, edge_state,
+		overflow);
 }
 
 bool PWMOut::update_pwm_out_state(bool on)
@@ -707,7 +709,7 @@ void PWMOut::update_params()
 
 			if (param_get(param_find(str), &pwm_min) == PX4_OK) {
 				if (pwm_min >= 0) {
-					_mixing_output.minValue(i) = math::constrain(pwm_min, PWM_LOWEST_MIN, PWM_HIGHEST_MIN);
+					_mixing_output.minValue(i) = math::constrain(pwm_min, (int32_t) PWM_LOWEST_MIN, (int32_t) PWM_HIGHEST_MIN);
 
 					if (pwm_min != _mixing_output.minValue(i)) {
 						int32_t pwm_min_new = _mixing_output.minValue(i);
@@ -727,7 +729,7 @@ void PWMOut::update_params()
 
 			if (param_get(param_find(str), &pwm_max) == PX4_OK) {
 				if (pwm_max >= 0) {
-					_mixing_output.maxValue(i) = math::constrain(pwm_max, PWM_LOWEST_MAX, PWM_HIGHEST_MAX);
+					_mixing_output.maxValue(i) = math::constrain(pwm_max, (int32_t) PWM_LOWEST_MAX, (int32_t) PWM_HIGHEST_MAX);
 
 					if (pwm_max != _mixing_output.maxValue(i)) {
 						int32_t pwm_max_new = _mixing_output.maxValue(i);
@@ -747,7 +749,7 @@ void PWMOut::update_params()
 
 			if (param_get(param_find(str), &pwm_failsafe) == PX4_OK) {
 				if (pwm_failsafe >= 0) {
-					_mixing_output.failsafeValue(i) = math::constrain(pwm_failsafe, 0, PWM_HIGHEST_MAX);
+					_mixing_output.failsafeValue(i) = math::constrain(pwm_failsafe, (int32_t) 0, (int32_t) PWM_HIGHEST_MAX);
 
 					if (pwm_failsafe != _mixing_output.failsafeValue(i)) {
 						int32_t pwm_fail_new = _mixing_output.failsafeValue(i);
@@ -764,7 +766,7 @@ void PWMOut::update_params()
 
 			if (param_get(param_find(str), &pwm_dis) == PX4_OK) {
 				if (pwm_dis >= 0) {
-					_mixing_output.disarmedValue(i) = math::constrain(pwm_dis, 0, PWM_HIGHEST_MAX);
+					_mixing_output.disarmedValue(i) = math::constrain(pwm_dis, (int32_t) 0, (int32_t) PWM_HIGHEST_MAX);
 
 					if (pwm_dis != _mixing_output.disarmedValue(i)) {
 						int32_t pwm_dis_new = _mixing_output.disarmedValue(i);
@@ -1863,7 +1865,7 @@ int PWMOut::test(const char *dev)
 		PX4_INFO("Not in a capture mode");
 	}
 
-	PX4_INFO("Testing %u servos and %u input captures", (unsigned)servo_count, capture_count);
+	PX4_INFO("Testing %u servos and %u input captures", servo_count, capture_count);
 	memset(capture_conf, 0, sizeof(capture_conf));
 
 	if (capture_count != 0) {
@@ -1873,7 +1875,7 @@ int PWMOut::test(const char *dev)
 
 			/* Save handler */
 			if (::ioctl(fd, INPUT_CAP_GET_CALLBACK, (unsigned long)&capture_conf[i].chan.channel) != 0) {
-				PX4_ERR("Unable to get capture callback for chan %u\n", capture_conf[i].chan.channel);
+				PX4_ERR("Unable to get capture callback for chan %" PRIu8 "\n", capture_conf[i].chan.channel);
 				goto err_out;
 
 			} else {
@@ -1885,7 +1887,7 @@ int PWMOut::test(const char *dev)
 					capture_conf[i].valid = true;
 
 				} else {
-					PX4_ERR("Unable to set capture callback for chan %u\n", capture_conf[i].chan.channel);
+					PX4_ERR("Unable to set capture callback for chan %" PRIu8 "\n", capture_conf[i].chan.channel);
 					goto err_out;
 				}
 			}
@@ -1938,12 +1940,12 @@ int PWMOut::test(const char *dev)
 			servo_position_t value;
 
 			if (::ioctl(fd, PWM_SERVO_GET(i), (unsigned long)&value)) {
-				PX4_ERR("error reading PWM servo %d", i);
+				PX4_ERR("error reading PWM servo %u", i);
 				goto err_out;
 			}
 
 			if (value != servos[i]) {
-				PX4_ERR("servo %d readback error, got %u expected %u", i, value, servos[i]);
+				PX4_ERR("servo %u readback error, got %" PRIu16 " expected %" PRIu16, i, value, servos[i]);
 				goto err_out;
 			}
 		}
@@ -1955,11 +1957,12 @@ int PWMOut::test(const char *dev)
 					stats.chan_in_edges_out = capture_conf[i].chan.channel;
 
 					if (::ioctl(fd, INPUT_CAP_GET_STATS, (unsigned long)&stats) != 0) {
-						PX4_ERR("Unable to get stats for chan %u\n", capture_conf[i].chan.channel);
+						PX4_ERR("Unable to get stats for chan %" PRIu8 "\n", capture_conf[i].chan.channel);
 						goto err_out;
 
 					} else {
-						fprintf(stdout, "FMU: Status chan:%u edges: %d last time:%lld last state:%d overflows:%d lantency:%u\n",
+						fprintf(stdout, "FMU: Status chan:%" PRIu8 " edges: %" PRIu32 " last time:%" PRIu64 " last state:%" PRIu32
+							" overflows:%" PRIu32 " lantency:%" PRIu16 "\n",
 							capture_conf[i].chan.channel,
 							stats.chan_in_edges_out,
 							stats.last_time,
@@ -1993,7 +1996,7 @@ int PWMOut::test(const char *dev)
 			if (capture_conf[i].valid) {
 				/* Save handler */
 				if (::ioctl(fd, INPUT_CAP_SET_CALLBACK, (unsigned long)&capture_conf[i].chan) != 0) {
-					PX4_ERR("Unable to set capture callback for chan %u\n", capture_conf[i].chan.channel);
+					PX4_ERR("Unable to set capture callback for chan %" PRIu8 "\n", capture_conf[i].chan.channel);
 					goto err_out;
 				}
 			}
@@ -2194,13 +2197,13 @@ int PWMOut::custom_command(int argc, char *argv[])
 int PWMOut::print_status()
 {
 	if (_class_instance == CLASS_DEVICE_PRIMARY) {
-		PX4_INFO("%d - PWM_MAIN 0x%04X", _instance, _pwm_mask);
+		PX4_INFO("%d - PWM_MAIN 0x%04" PRIx32, _instance, _pwm_mask);
 
 	} else if (_class_instance == CLASS_DEVICE_SECONDARY) {
-		PX4_INFO("%d - PWM_AUX 0x%04X", _instance, _pwm_mask);
+		PX4_INFO("%d - PWM_AUX 0x%04" PRIx32, _instance, _pwm_mask);
 
 	} else if (_class_instance == CLASS_DEVICE_TERTIARY) {
-		PX4_INFO("%d - PWM_EXTRA 0x%04X", _instance, _pwm_mask);
+		PX4_INFO("%d - PWM_EXTRA 0x%04" PRIx32, _instance, _pwm_mask);
 	}
 
 	PX4_INFO("%d - Max update rate: %i Hz", _instance, _current_update_rate);

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1129,7 +1129,7 @@ PX4IO::task_main()
 				}
 
 				/* S.BUS output */
-				int sbus_mode;
+				long sbus_mode;
 				parm_handle = param_find("PWM_SBUS_MODE");
 
 				if (parm_handle != PARAM_INVALID) {
@@ -1231,7 +1231,7 @@ void PX4IO::update_params()
 
 			if (param_get(param_find(str), &pwm_min) == PX4_OK) {
 				if (pwm_min >= 0) {
-					pwm.values[i] = math::constrain(pwm_min, PWM_LOWEST_MIN, PWM_HIGHEST_MIN);
+					pwm.values[i] = math::constrain(pwm_min, static_cast<int32_t>(PWM_LOWEST_MIN), static_cast<int32_t>(PWM_HIGHEST_MIN));
 
 					if (pwm_min != pwm.values[i]) {
 						int32_t pwm_min_new = pwm.values[i];
@@ -1260,7 +1260,7 @@ void PX4IO::update_params()
 
 			if (param_get(param_find(str), &pwm_max) == PX4_OK) {
 				if (pwm_max >= 0) {
-					pwm.values[i] = math::constrain(pwm_max, PWM_LOWEST_MAX, PWM_HIGHEST_MAX);
+					pwm.values[i] = math::constrain(pwm_max, static_cast<int32_t>(PWM_LOWEST_MAX), static_cast<int32_t>(PWM_HIGHEST_MAX));
 
 					if (pwm_max != pwm.values[i]) {
 						int32_t pwm_max_new = pwm.values[i];
@@ -1289,7 +1289,7 @@ void PX4IO::update_params()
 
 			if (param_get(param_find(str), &pwm_fail) == PX4_OK) {
 				if (pwm_fail >= 0) {
-					pwm.values[i] = math::constrain(pwm_fail, 0, PWM_HIGHEST_MAX);
+					pwm.values[i] = math::constrain(pwm_fail, static_cast<int32_t>(0), static_cast<int32_t>(PWM_HIGHEST_MAX));
 
 					if (pwm_fail != pwm.values[i]) {
 						int32_t pwm_fail_new = pwm.values[i];
@@ -1315,7 +1315,7 @@ void PX4IO::update_params()
 
 			if (param_get(param_find(str), &pwm_dis) == PX4_OK) {
 				if (pwm_dis >= 0) {
-					pwm.values[i] = math::constrain(pwm_dis, 0, PWM_HIGHEST_MAX);
+					pwm.values[i] = math::constrain(pwm_dis, static_cast<int32_t>(0), static_cast<int32_t>(PWM_HIGHEST_MAX));
 
 					if (pwm_dis != pwm.values[i]) {
 						int32_t pwm_dis_new = pwm.values[i];
@@ -1511,7 +1511,7 @@ PX4IO::handle_motor_test()
 					    io_reg_get(PX4IO_PAGE_CONTROL_MAX_PWM, 0, pwm_max.values, _max_actuators) == 0) {
 
 						uint16_t value = math::constrain<uint16_t>(pwm_min.values[idx] +
-								 (uint16_t)((pwm_max.values[idx] - pwm_min.values[idx]) * test_motor.value),
+								 static_cast<uint16_t>(((pwm_max.values[idx] - pwm_min.values[idx]) * test_motor.value)),
 								 pwm_min.values[idx], pwm_max.values[idx]);
 						io_reg_set(PX4IO_PAGE_DIRECT_PWM, idx, value);
 					}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1129,7 +1129,7 @@ PX4IO::task_main()
 				}
 
 				/* S.BUS output */
-				long sbus_mode;
+				int32_t sbus_mode;
 				parm_handle = param_find("PWM_SBUS_MODE");
 
 				if (parm_handle != PARAM_INVALID) {

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1040,7 +1040,7 @@ PX4IO::task_main()
 						int pret = io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_RC_THR_FAILSAFE_US, &failsafe_thr, 1);
 
 						if (pret != OK) {
-							mavlink_log_critical(&_mavlink_log_pub, "failsafe upload failed, FS: %d us", (int)failsafe_thr);
+							mavlink_log_critical(&_mavlink_log_pub, "failsafe upload failed, FS: %" PRId16 " us", failsafe_thr);
 						}
 					}
 				}
@@ -2224,7 +2224,7 @@ PX4IO::io_reg_set(uint8_t page, uint8_t offset, const uint16_t *values, unsigned
 	int ret =  _interface->write((page << 8) | offset, (void *)values, num_values);
 
 	if (ret != (int)num_values) {
-		PX4_DEBUG("io_reg_set(%hhu,%hhu,%u): error %d", page, offset, num_values, ret);
+		PX4_DEBUG("io_reg_set(%" PRIu8 ",%" PRIu8 ",%u): error %d", page, offset, num_values, ret);
 		return -1;
 	}
 
@@ -2249,7 +2249,7 @@ PX4IO::io_reg_get(uint8_t page, uint8_t offset, uint16_t *values, unsigned num_v
 	int ret = _interface->read((page << 8) | offset, reinterpret_cast<void *>(values), num_values);
 
 	if (ret != (int)num_values) {
-		PX4_DEBUG("io_reg_get(%hhu,%hhu,%u): data error %d", page, offset, num_values, ret);
+		PX4_DEBUG("io_reg_get(%" PRIu8 ",%" PRIu8 ",%u): data error %d", page, offset, num_values, ret);
 		return -1;
 	}
 
@@ -2450,14 +2450,16 @@ void
 PX4IO::print_status(bool extended_status)
 {
 	/* basic configuration */
-	printf("protocol %u hardware %u bootloader %u buffer %uB crc 0x%04x%04x\n",
+	printf("protocol %" PRIu32 " hardware %" PRIu32 " bootloader %" PRIu32 " buffer %" PRIu32 "B crc 0x%04" PRIu32 "%04"
+	       PRIu32 "\n",
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_PROTOCOL_VERSION),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_HARDWARE_VERSION),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_BOOTLOADER_VERSION),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_MAX_TRANSFER),
 	       io_reg_get(PX4IO_PAGE_SETUP,  PX4IO_P_SETUP_CRC),
 	       io_reg_get(PX4IO_PAGE_SETUP,  PX4IO_P_SETUP_CRC + 1));
-	printf("%u controls %u actuators %u R/C inputs %u analog inputs %u relays\n",
+	printf("%" PRIu32 " controls %" PRIu32 " actuators %" PRIu32 " R/C inputs %" PRIu32 " analog inputs %" PRIu32
+	       " relays\n",
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_CONTROL_COUNT),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_ACTUATOR_COUNT),
 	       io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_RC_INPUT_COUNT),
@@ -2492,17 +2494,17 @@ PX4IO::print_status(bool extended_status)
 	       (double)trim_roll, (double)trim_pitch, (double)trim_yaw);
 
 	uint16_t raw_inputs = io_reg_get(PX4IO_PAGE_RAW_RC_INPUT, PX4IO_P_RAW_RC_COUNT);
-	printf("%hu raw R/C inputs", raw_inputs);
+	printf("%" PRIu16 " raw R/C inputs", raw_inputs);
 
 	for (unsigned i = 0; i < raw_inputs; i++) {
-		printf(" %u", io_reg_get(PX4IO_PAGE_RAW_RC_INPUT, PX4IO_P_RAW_RC_BASE + i));
+		printf(" %" PRIu32, io_reg_get(PX4IO_PAGE_RAW_RC_INPUT, PX4IO_P_RAW_RC_BASE + i));
 	}
 
 	printf("\n");
 
 	uint16_t io_status_flags = io_reg_get(PX4IO_PAGE_STATUS, PX4IO_P_STATUS_FLAGS);
 	uint16_t flags = io_reg_get(PX4IO_PAGE_RAW_RC_INPUT, PX4IO_P_RAW_RC_FLAGS);
-	printf("R/C flags: 0x%04hx%s%s%s%s%s\n", flags,
+	printf("R/C flags: 0x%04" PRIx16 "%s%s%s%s%s\n", flags,
 	       (((io_status_flags & PX4IO_P_STATUS_FLAGS_RC_DSM) && (!(flags & PX4IO_P_RAW_RC_FLAGS_RC_DSM11))) ? " DSM10" : ""),
 	       (((io_status_flags & PX4IO_P_STATUS_FLAGS_RC_DSM) && (flags & PX4IO_P_RAW_RC_FLAGS_RC_DSM11)) ? " DSM11" : ""),
 	       ((flags & PX4IO_P_RAW_RC_FLAGS_FRAME_DROP) ? " FRAME_DROP" : ""),
@@ -2520,11 +2522,11 @@ PX4IO::print_status(bool extended_status)
 	}
 
 	uint16_t mapped_inputs = io_reg_get(PX4IO_PAGE_RC_INPUT, PX4IO_P_RC_VALID);
-	printf("mapped R/C inputs 0x%04hx", mapped_inputs);
+	printf("mapped R/C inputs 0x%04" PRIx16, mapped_inputs);
 
 	for (unsigned i = 0; i < _max_rc_input; i++) {
 		if (mapped_inputs & (1 << i)) {
-			printf(" %u:%hd", i, REG_TO_SIGNED(io_reg_get(PX4IO_PAGE_RC_INPUT, PX4IO_P_RC_BASE + i)));
+			printf(" %u:%" PRId16, i, REG_TO_SIGNED(io_reg_get(PX4IO_PAGE_RC_INPUT, PX4IO_P_RC_BASE + i)));
 		}
 	}
 
@@ -2533,32 +2535,32 @@ PX4IO::print_status(bool extended_status)
 	printf("ADC inputs");
 
 	for (unsigned i = 0; i < adc_inputs; i++) {
-		printf(" %u", io_reg_get(PX4IO_PAGE_RAW_ADC_INPUT, i));
+		printf(" %" PRIu32, io_reg_get(PX4IO_PAGE_RAW_ADC_INPUT, i));
 	}
 
 	printf("\n");
 
 	/* setup and state */
 	uint16_t features = io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_FEATURES);
-	printf("features 0x%04hx%s%s%s%s\n", features,
+	printf("features 0x%04" PRIx16 "%s%s%s%s\n", features,
 	       ((features & PX4IO_P_SETUP_FEATURES_SBUS1_OUT) ? " S.BUS1_OUT" : ""),
 	       ((features & PX4IO_P_SETUP_FEATURES_SBUS2_OUT) ? " S.BUS2_OUT" : ""),
 	       ((features & PX4IO_P_SETUP_FEATURES_PWM_RSSI) ? " RSSI_PWM" : ""),
 	       ((features & PX4IO_P_SETUP_FEATURES_ADC_RSSI) ? " RSSI_ADC" : "")
 	      );
 
-	printf("rates 0x%04x default %u alt %u sbus %u\n",
+	printf("rates 0x%04" PRIx32 " default %" PRIu32 " alt %" PRIu32 " sbus %" PRIu32 "\n",
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_RATES),
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_DEFAULTRATE),
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_ALTRATE),
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SBUS_RATE));
-	printf("debuglevel %u\n", io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SET_DEBUG));
+	printf("debuglevel %" PRIu32 "\n", io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SET_DEBUG));
 
 	for (unsigned group = 0; group < 4; group++) {
 		printf("controls %u:", group);
 
 		for (unsigned i = 0; i < _max_controls; i++) {
-			printf(" %hd", (int16_t) io_reg_get(PX4IO_PAGE_CONTROLS, group * PX4IO_PROTOCOL_MAX_CONTROL_COUNT + i));
+			printf(" %" PRIu16, (int16_t) io_reg_get(PX4IO_PAGE_CONTROLS, group * PX4IO_PROTOCOL_MAX_CONTROL_COUNT + i));
 		}
 
 		printf("\n");
@@ -2568,7 +2570,8 @@ PX4IO::print_status(bool extended_status)
 		for (unsigned i = 0; i < _max_rc_input; i++) {
 			unsigned base = PX4IO_P_RC_CONFIG_STRIDE * i;
 			uint16_t options = io_reg_get(PX4IO_PAGE_RC_CONFIG, base + PX4IO_P_RC_CONFIG_OPTIONS);
-			printf("input %u min %u center %u max %u deadzone %u assigned %u options 0x%04hx%s%s\n",
+			printf("input %u min %" PRIu32 " center %" PRIu32 " max %" PRIu32 " deadzone %" PRIu32 " assigned %" PRIu32
+			       " options 0x%04" PRIx16 "%s%s\n",
 			       i,
 			       io_reg_get(PX4IO_PAGE_RC_CONFIG, base + PX4IO_P_RC_CONFIG_MIN),
 			       io_reg_get(PX4IO_PAGE_RC_CONFIG, base + PX4IO_P_RC_CONFIG_CENTER),
@@ -2584,13 +2587,13 @@ PX4IO::print_status(bool extended_status)
 	printf("failsafe");
 
 	for (unsigned i = 0; i < _max_actuators; i++) {
-		printf(" %u", io_reg_get(PX4IO_PAGE_FAILSAFE_PWM, i));
+		printf(" %" PRIu32, io_reg_get(PX4IO_PAGE_FAILSAFE_PWM, i));
 	}
 
 	printf("\ndisarmed values");
 
 	for (unsigned i = 0; i < _max_actuators; i++) {
-		printf(" %u", io_reg_get(PX4IO_PAGE_DISARMED_PWM, i));
+		printf(" %" PRIu32, io_reg_get(PX4IO_PAGE_DISARMED_PWM, i));
 	}
 
 	/* IMU heater (Pixhawk 2.1) */
@@ -3001,7 +3004,7 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 			}
 
 			if (io_crc != arg) {
-				PX4_DEBUG("Firmware CRC mismatch 0x%08x 0x%08lx", io_crc, arg);
+				PX4_DEBUG("Firmware CRC mismatch 0x%08" PRIx32 " 0x%08lx", io_crc, arg);
 				return -EINVAL;
 			}
 
@@ -3251,7 +3254,7 @@ checkcrc(int argc, char *argv[])
 	}
 
 	if (ret != OK) {
-		PX4_ERR("check CRC failed: %d, CRC: %u", ret, fw_crc);
+		PX4_ERR("check CRC failed: %d, CRC: %" PRIu32, ret, fw_crc);
 		exit(1);
 
 	} else {
@@ -3584,7 +3587,7 @@ px4io_main(int argc, char *argv[])
 			exit(1);
 		}
 
-		warnx("SET_DEBUG %hhu OK", level);
+		warnx("SET_DEBUG %" PRIu8 " OK", level);
 		exit(0);
 	}
 

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -778,11 +778,11 @@ int RCInput::custom_command(int argc, char *argv[])
 
 int RCInput::print_status()
 {
-	PX4_INFO("Max update rate: %i Hz", 1000000 / _current_update_interval);
+	PX4_INFO("Max update rate: %u Hz", 1000000 / _current_update_interval);
 
 	if (_device[0] != '\0') {
 		PX4_INFO("UART device: %s", _device);
-		PX4_INFO("UART RX bytes: %u", _bytes_rx);
+		PX4_INFO("UART RX bytes: %"  PRIu32, _bytes_rx);
 	}
 
 	PX4_INFO("RC state: %s: %s", _rc_scan_locked ? "found" : "searching for signal", RC_SCAN_STRING[_rc_scan_state]);

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/roboclaw/RoboClaw.cpp
+++ b/src/drivers/roboclaw/RoboClaw.cpp
@@ -568,7 +568,7 @@ void RoboClaw::_parameters_update()
 		orb_set_interval(_actuatorsSub, _parameters.actuator_write_period_ms);
 	}
 
-	long baudRate;
+	int32_t baudRate;
 	param_get(_param_handles.serial_baud_rate, &baudRate);
 
 	switch (baudRate) {

--- a/src/drivers/roboclaw/RoboClaw.cpp
+++ b/src/drivers/roboclaw/RoboClaw.cpp
@@ -491,7 +491,7 @@ int RoboClaw::_transaction(e_command cmd, uint8_t *wbuff, size_t wbytes,
 	int count = write(_uart, buf, wbytes);
 
 	if (count < (int) wbytes) { // Did not successfully send all bytes.
-		PX4_ERR("Only wrote %d out of %d bytes", count, (int) wbytes);
+		PX4_ERR("Only wrote %d out of %zu bytes", count, wbytes);
 		return -1;
 	}
 
@@ -568,7 +568,7 @@ void RoboClaw::_parameters_update()
 		orb_set_interval(_actuatorsSub, _parameters.actuator_write_period_ms);
 	}
 
-	int baudRate;
+	long baudRate;
 	param_get(_param_handles.serial_baud_rate, &baudRate);
 
 	switch (baudRate) {

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +48,8 @@ int PCF8583::init()
 		return PX4_ERROR;
 	}
 
-	PX4_DEBUG("addr: %d, pool: %d, reset: %d, magenet: %d", get_device_address(), _param_pcf8583_pool.get(),
+	PX4_DEBUG("addr: %" PRId8 ", pool: %" PRId32 ", reset: %" PRId32 ", magenet: %" PRId32, get_device_address(),
+		  _param_pcf8583_pool.get(),
 		  _param_pcf8583_reset.get(),
 		  _param_pcf8583_magnet.get());
 
@@ -141,5 +142,5 @@ void PCF8583::RunImpl()
 void PCF8583::print_status()
 {
 	I2CSPIDriverBase::print_status();
-	PX4_INFO("poll interval:  %d us", _param_pcf8583_pool.get());
+	PX4_INFO("poll interval:  %" PRId32 " us", _param_pcf8583_pool.get());
 }

--- a/src/drivers/rpm/pcf8583/PCF8583.hpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2018, 2021, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2017, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,6 +45,7 @@
 #include <px4_platform_common/px4_config.h>
 #include <px4_platform_common/tasks.h>
 
+#include <inttypes.h>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
@@ -167,7 +168,7 @@ int
 UavcanNode::print_params(uavcan::protocol::param::GetSet::Response &resp)
 {
 	if (resp.value.is(uavcan::protocol::param::Value::Tag::integer_value)) {
-		return std::printf("name: %s %lld\n", resp.name.c_str(),
+		return std::printf("name: %s %" PRId64 "\n", resp.name.c_str(),
 				   resp.value.to<uavcan::protocol::param::Value::Tag::integer_value>());
 
 	} else if (resp.value.is(uavcan::protocol::param::Value::Tag::real_value)) {
@@ -342,7 +343,7 @@ UavcanNode::set_param(int remote_node_id, const char *name, char *value)
 				req.value.to<uavcan::protocol::param::Value::Tag::integer_value>() = i;
 
 			} else {
-				std::printf("Invalid value for: %s must be between %lld and %lld\n", name, min, max);
+				std::printf("Invalid value for: %s must be between %" PRId64 " and %" PRId64 "\n", name, min, max);
 				rv = -1;
 			}
 
@@ -940,19 +941,19 @@ UavcanNode::print_info()
 
 	// Memory status
 	printf("Pool allocator status:\n");
-	printf("\tCapacity hard/soft: %u/%u blocks\n",
+	printf("\tCapacity hard/soft: %" PRIu16 "/%" PRIu16 " blocks\n",
 	       _pool_allocator.getBlockCapacityHardLimit(), _pool_allocator.getBlockCapacity());
-	printf("\tReserved:  %u blocks\n", _pool_allocator.getNumReservedBlocks());
-	printf("\tAllocated: %u blocks\n", _pool_allocator.getNumAllocatedBlocks());
+	printf("\tReserved:  %" PRIu16 " blocks\n", _pool_allocator.getNumReservedBlocks());
+	printf("\tAllocated: %" PRIu16 " blocks\n", _pool_allocator.getNumAllocatedBlocks());
 
 	printf("\n");
 
 	// UAVCAN node perfcounters
 	printf("UAVCAN node status:\n");
-	printf("\tInternal failures: %llu\n", _node.getInternalFailureCount());
-	printf("\tTransfer errors:   %llu\n", _node.getDispatcher().getTransferPerfCounter().getErrorCount());
-	printf("\tRX transfers:      %llu\n", _node.getDispatcher().getTransferPerfCounter().getRxTransferCount());
-	printf("\tTX transfers:      %llu\n", _node.getDispatcher().getTransferPerfCounter().getTxTransferCount());
+	printf("\tInternal failures: %" PRIu64 "\n", _node.getInternalFailureCount());
+	printf("\tTransfer errors:   %" PRIu64 "\n", _node.getDispatcher().getTransferPerfCounter().getErrorCount());
+	printf("\tRX transfers:      %" PRIu64 "\n", _node.getDispatcher().getTransferPerfCounter().getRxTransferCount());
+	printf("\tTX transfers:      %" PRIu64 "\n", _node.getDispatcher().getTransferPerfCounter().getTxTransferCount());
 
 	printf("\n");
 
@@ -963,12 +964,12 @@ UavcanNode::print_info()
 		auto iface = _node.getDispatcher().getCanIOManager().getCanDriver().getIface(i);
 
 		if (iface) {
-			printf("\tHW errors: %llu\n", iface->getErrorCount());
+			printf("\tHW errors: %" PRIu64 "\n", iface->getErrorCount());
 
 			auto iface_perf_cnt = _node.getDispatcher().getCanIOManager().getIfacePerfCounters(i);
-			printf("\tIO errors: %llu\n", iface_perf_cnt.errors);
-			printf("\tRX frames: %llu\n", iface_perf_cnt.frames_rx);
-			printf("\tTX frames: %llu\n", iface_perf_cnt.frames_tx);
+			printf("\tIO errors: %" PRIu64 "\n", iface_perf_cnt.errors);
+			printf("\tRX frames: %" PRIu64 "\n", iface_perf_cnt.frames_rx);
+			printf("\tTX frames: %" PRIu64 "\n", iface_perf_cnt.frames_tx);
 		}
 	}
 
@@ -1063,7 +1064,7 @@ int uavcan_main(int argc, char *argv[])
 		(void)param_get(param_find("UAVCAN_NODE_ID"), &node_id);
 
 		if (node_id < 0 || node_id > uavcan::NodeID::Max || !uavcan::NodeID(node_id).isUnicast()) {
-			PX4_ERR("Invalid Node ID %i", node_id);
+			PX4_ERR("Invalid Node ID %" PRId32, node_id);
 			::exit(1);
 		}
 
@@ -1072,7 +1073,7 @@ int uavcan_main(int argc, char *argv[])
 		(void)param_get(param_find("UAVCAN_BITRATE"), &bitrate);
 
 		// Start
-		PX4_INFO("Node ID %u, bitrate %u", node_id, bitrate);
+		PX4_INFO("Node ID %" PRIu32 ", bitrate %" PRIu32, node_id, bitrate);
 		return UavcanNode::start(node_id, bitrate);
 	}
 

--- a/src/drivers/uavcan_v1/Uavcan.cpp
+++ b/src/drivers/uavcan_v1/Uavcan.cpp
@@ -64,7 +64,7 @@ UavcanNode::UavcanNode(CanardInterface *interface, uint32_t node_id) :
 	uavcan_allocator = o1heapInit(_uavcan_heap, HeapSize, nullptr, nullptr);
 
 	if (uavcan_allocator == nullptr) {
-		PX4_ERR("o1heapInit failed with size %d", HeapSize);
+		PX4_ERR("o1heapInit failed with size %u", HeapSize);
 	}
 
 	_canard_instance = canardInit(&memAllocate, &memFree);
@@ -228,7 +228,7 @@ void UavcanNode::Run()
 			// It is possible to statically prove that an out-of-memory will never occur for a given application if
 			// the heap is sized correctly; for background, refer to the Robson's Proof and the documentation for O1Heap.
 			// Reception of an invalid frame is NOT an error.
-			PX4_ERR("Receive error %d\n", result);
+			PX4_ERR("Receive error %" PRId32" \n", result);
 
 		} else if (result == 1) {
 			// A transfer has been received, process it.
@@ -389,7 +389,7 @@ extern "C" __EXPORT int uavcan_v1_main(int argc, char *argv[])
 		param_get(param_find("UAVCAN_V1_ID"), &node_id);
 
 		// Start
-		PX4_INFO("Node ID %u, bitrate %u", node_id, bitrate);
+		PX4_INFO("Node ID %" PRIu32 ", bitrate %" PRIu32, node_id, bitrate);
 		return UavcanNode::start(node_id, bitrate);
 	}
 
@@ -444,7 +444,7 @@ void UavcanNode::sendHeartbeat()
 			// An error has occurred: either an argument is invalid or we've ran out of memory.
 			// It is possible to statically prove that an out-of-memory will never occur for a given application if the
 			// heap is sized correctly; for background, refer to the Robson's Proof and the documentation for O1Heap.
-			PX4_ERR("Heartbeat transmit error %d", result);
+			PX4_ERR("Heartbeat transmit error %" PRId32 "", result);
 		}
 
 		_uavcan_node_heartbeat_last = now;

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -549,12 +549,12 @@ extern "C" int uavcannode_start(int argc, char *argv[])
 		board_booted_by_px4() &&
 #endif
 		(node_id < 0 || node_id > uavcan::NodeID::Max || !uavcan::NodeID(node_id).isUnicast())) {
-		PX4_ERR("Invalid Node ID %i", node_id);
+		PX4_ERR("Invalid Node ID %" PRId32, node_id);
 		return 1;
 	}
 
 	// Start
-	PX4_INFO("Node ID %u, bitrate %u", node_id, bitrate);
+	PX4_INFO("Node ID %" PRId32 ", bitrate %" PRId32, node_id, bitrate);
 	int rv = uavcannode::UavcanNode::start(node_id, bitrate);
 
 	return rv;

--- a/src/drivers/uavcannode_gps_demo/canard_main.c
+++ b/src/drivers/uavcannode_gps_demo/canard_main.c
@@ -42,6 +42,7 @@
 
 #include <sched.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -299,7 +300,7 @@ void processTxRxOnce(CanardInstance *ins, CanardSocketInstance *sock_ins, int ti
 		// It is possible to statically prove that an out-of-memory will never occur for a given application if
 		// the heap is sized correctly; for background, refer to the Robson's Proof and the documentation for O1Heap.
 		// Reception of an invalid frame is NOT an error.
-		fprintf(stderr, "Receive error %d\n", result);
+		fprintf(stderr, "Receive error %" PRId32 "\n", result);
 
 	} else if (result == 1) {
 		printf("Receive portId %i\n", receive.port_id);

--- a/src/drivers/uavcannode_gps_demo/socketcan.c
+++ b/src/drivers/uavcannode_gps_demo/socketcan.c
@@ -1,5 +1,6 @@
 #include "socketcan.h"
 
+#include <stdio.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <string.h>

--- a/src/drivers/uavcannode_gps_demo/uorb_converter.c
+++ b/src/drivers/uavcannode_gps_demo/uorb_converter.c
@@ -5,6 +5,7 @@
  *      Author: hovergames
  */
 
+#include <inttypes.h>
 #include <string.h>
 
 #include "uorb_converter.h"
@@ -95,7 +96,7 @@ void uorbProcessSub(int timeout_msec)
 					// An error has occurred: either an argument is invalid or we've ran out of memory.
 					// It is possible to statically prove that an out-of-memory will never occur for a given application if the
 					// heap is sized correctly; for background, refer to the Robson's Proof and the documentation for O1Heap.
-					PX4_ERR("canardTxPush error %d", result);
+					PX4_ERR("canardTxPush error %" PRId32, result);
 				}
 			}
 

--- a/src/examples/fake_imu/FakeImu.cpp
+++ b/src/examples/fake_imu/FakeImu.cpp
@@ -43,7 +43,7 @@ FakeImu::FakeImu() :
 {
 	_sensor_interval_us = roundf(1.e6f / _px4_gyro.get_max_rate_hz());
 
-	PX4_INFO("Rate %.3f, Interval: %d us", (double)_px4_gyro.get_max_rate_hz(), _sensor_interval_us);
+	PX4_INFO("Rate %.3f, Interval: %" PRId32 " us", (double)_px4_gyro.get_max_rate_hz(), _sensor_interval_us);
 
 	_px4_accel.set_range(2000.f); // don't care
 

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -110,7 +110,7 @@ void Battery::reset()
 	_battery_status.remaining = 1.f;
 	_battery_status.scale = 1.f;
 	// Publish at least one cell such that the total voltage gets into MAVLink BATTERY_STATUS
-	_battery_status.cell_count = math::max(_params.n_cells, 1);
+	_battery_status.cell_count = math::max(_params.n_cells, static_cast<int32_t>(1));
 	// TODO: check if it is sane to reset warning to NONE
 	_battery_status.warning = battery_status_s::BATTERY_WARNING_NONE;
 	_battery_status.connected = false;
@@ -155,8 +155,8 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 		_battery_status.source = source;
 		_battery_status.priority = priority;
 
-		static constexpr int uorb_max_cells = sizeof(_battery_status.voltage_cell_v) / sizeof(
-				_battery_status.voltage_cell_v[0]);
+		static constexpr int32_t uorb_max_cells = sizeof(_battery_status.voltage_cell_v) / sizeof(
+					_battery_status.voltage_cell_v[0]);
 
 		int max_cells = math::min(_battery_status.cell_count, uorb_max_cells);
 
@@ -282,16 +282,16 @@ void Battery::updateParams()
 				    _first_parameter_update);
 		migrateParam<float>(_param_handles.v_charged_old, _param_handles.v_charged, &_params.v_charged_old, &_params.v_charged,
 				    _first_parameter_update);
-		migrateParam<int>(_param_handles.n_cells_old, _param_handles.n_cells, &_params.n_cells_old, &_params.n_cells,
-				  _first_parameter_update);
+		migrateParam<int32_t>(_param_handles.n_cells_old, _param_handles.n_cells, &_params.n_cells_old, &_params.n_cells,
+				      _first_parameter_update);
 		migrateParam<float>(_param_handles.capacity_old, _param_handles.capacity, &_params.capacity_old, &_params.capacity,
 				    _first_parameter_update);
 		migrateParam<float>(_param_handles.v_load_drop_old, _param_handles.v_load_drop, &_params.v_load_drop_old,
 				    &_params.v_load_drop, _first_parameter_update);
 		migrateParam<float>(_param_handles.r_internal_old, _param_handles.r_internal, &_params.r_internal_old,
 				    &_params.r_internal, _first_parameter_update);
-		migrateParam<int>(_param_handles.source_old, _param_handles.source, &_params.source_old, &_params.source,
-				  _first_parameter_update);
+		migrateParam<int32_t>(_param_handles.source_old, _param_handles.source, &_params.source_old, &_params.source,
+				      _first_parameter_update);
 
 	} else {
 		param_get(_param_handles.v_empty, &_params.v_empty);

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,24 +128,24 @@ protected:
 	struct {
 		float v_empty;
 		float v_charged;
-		int n_cells;
+		int32_t  n_cells;
 		float capacity;
 		float v_load_drop;
 		float r_internal;
 		float low_thr;
 		float crit_thr;
 		float emergen_thr;
-		int source;
+		int32_t source;
 
 		// TODO: These parameters are depracated. They can be removed entirely once the
 		//  new version of Firmware has been around for long enough.
 		float v_empty_old;
 		float v_charged_old;
-		int n_cells_old;
+		int32_t  n_cells_old;
 		float capacity_old;
 		float v_load_drop_old;
 		float r_internal_old;
-		int source_old;
+		int32_t source_old;
 	} _params{};
 
 	battery_status_s _battery_status{};

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -48,7 +48,7 @@ public:
 
 	uint32_t get_device_id() const { return _device_id; }
 
-	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, 100, 4000); }
+	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, static_cast<int32_t>(100), static_cast<int32_t>(4000)); }
 
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);

--- a/src/lib/drivers/device/nuttx/I2C.cpp
+++ b/src/lib/drivers/device/nuttx/I2C.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -114,7 +114,7 @@ I2C::init()
 	if (_bus_clocks[bus_index] > _frequency) {
 		(void)px4_i2cbus_uninitialize(_dev);
 		_dev = nullptr;
-		DEVICE_LOG("FAIL: too slow for bus #%u: %u KHz, device max: %u KHz)",
+		DEVICE_LOG("FAIL: too slow for bus #%u: %u KHz, device max: %" PRIu32 " KHz)",
 			   get_device_bus(), _bus_clocks[bus_index] / 1000, _frequency / 1000);
 		ret = -EINVAL;
 		goto out;
@@ -153,7 +153,7 @@ I2C::init()
 	}
 
 	// tell the world where we are
-	DEVICE_DEBUG("on I2C bus %d at 0x%02x (bus: %u KHz, max: %u KHz)",
+	DEVICE_DEBUG("on I2C bus %d at 0x%02x (bus: %u KHz, max: %" PRIu32 " KHz)",
 		     get_device_bus(), get_device_address(), _bus_clocks[bus_index] / 1000, _frequency / 1000);
 
 out:

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2012-2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,7 +120,8 @@ SPI::init()
 	}
 
 	/* tell the world where we are */
-	DEVICE_DEBUG("on SPI bus %d at %d (%u KHz)", get_device_bus(), PX4_SPI_DEV_ID(_device), _frequency / 1000);
+	DEVICE_DEBUG("on SPI bus %d at %"  PRId32 " (%"  PRId32 " KHz)", get_device_bus(), PX4_SPI_DEV_ID(_device),
+		     _frequency / 1000);
 
 	return PX4_OK;
 }

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -48,7 +48,7 @@ public:
 
 	uint32_t get_device_id() const { return _device_id; }
 
-	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, 100, 4000); }
+	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, static_cast<int32_t>(100), static_cast<int32_t>(4000)); }
 
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +63,8 @@ bool param_modify_on_import(bson_node_t node)
 			strcpy(node->name, "COM_ARM_AUTH_ID");
 			node->i = old_param.struct_value.authorizer_system_id;
 
-			PX4_INFO("migrating COM_ARM_AUTH: %d -> COM_ARM_AUTH_ID:%d, COM_ARM_AUTH_MET: %d and COM_ARM_AUTH_TO: %f",
+			PX4_INFO("migrating COM_ARM_AUTH: %" PRId32 " -> COM_ARM_AUTH_ID:%" PRId8 ", COM_ARM_AUTH_MET: %" PRId32
+				 " and COM_ARM_AUTH_TO: %f",
 				 old_param.param_value,
 				 old_param.struct_value.authorizer_system_id,
 				 method,
@@ -258,7 +259,7 @@ bool param_modify_on_import(bson_node_t node)
 	int32_t new_value = (int32_t)device_id.devid;
 
 	if (new_value != *ivalue) {
-		PX4_INFO("param modify: %s, value=0x%x (old=0x%x)", node->name, new_value, (int32_t)*ivalue);
+		PX4_INFO("param modify: %s, value=0x%" PRId32 " (old=0x%" PRId32 ")", node->name, new_value, (int32_t)*ivalue);
 		*ivalue = new_value;
 		return true;
 	}

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -497,12 +497,12 @@ param_get(param_t param, void *val)
 	perf_count(param_get_perf);
 
 	if (!handle_in_range(param)) {
-		PX4_ERR("get: param %d invalid", param);
+		PX4_ERR("get: param %" PRId16 " invalid", param);
 		return PX4_ERROR;
 	}
 
 	if (!params_active[param]) {
-		PX4_DEBUG("get: param %d (%s) not active", param, param_name(param));
+		PX4_DEBUG("get: param %" PRId16 " (%s) not active", param, param_name(param));
 	}
 
 	int result = PX4_ERROR;
@@ -1430,7 +1430,8 @@ param_import_internal(int fd, bool mark_saved)
 			} while (result > 0);
 
 			if (result == 0) {
-				PX4_INFO("BSON document size %d bytes, decoded %d bytes", decoder.total_document_size, decoder.total_decoded_size);
+				PX4_INFO("BSON document size %" PRId32 " bytes, decoded %" PRId32 " bytes", decoder.total_document_size,
+					 decoder.total_decoded_size);
 				return 0;
 
 			} else {

--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2016, 2021, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
  * @brief Performance measuring tools.
  */
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -436,21 +437,22 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 
 	switch (handle->type) {
 	case PC_COUNT:
-		dprintf(fd, "%s: %llu events\n",
+		dprintf(fd, "%s: %" PRIu64 " events\n",
 			handle->name,
-			(unsigned long long)((struct perf_ctr_count *)handle)->event_count);
+			((struct perf_ctr_count *)handle)->event_count);
 		break;
 
 	case PC_ELAPSED: {
 			struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;
 			float rms = sqrtf(pce->M2 / (pce->event_count - 1));
-			dprintf(fd, "%s: %llu events, %lluus elapsed, %.2fus avg, min %lluus max %lluus %5.3fus rms\n",
+			dprintf(fd, "%s: %" PRIu64 " events, %" PRIu64 "us elapsed, %.2fus avg, min %" PRIu32 "us max %" PRIu32
+				"us %5.3fus rms\n",
 				handle->name,
-				(unsigned long long)pce->event_count,
-				(unsigned long long)pce->time_total,
+				pce->event_count,
+				pce->time_total,
 				(pce->event_count == 0) ? 0 : (double)pce->time_total / (double)pce->event_count,
-				(unsigned long long)pce->time_least,
-				(unsigned long long)pce->time_most,
+				pce->time_least,
+				pce->time_most,
 				(double)(1e6f * rms));
 			break;
 		}
@@ -459,12 +461,12 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 			struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;
 			float rms = sqrtf(pci->M2 / (pci->event_count - 1));
 
-			dprintf(fd, "%s: %llu events, %.2fus avg, min %lluus max %lluus %5.3fus rms\n",
+			dprintf(fd, "%s: %" PRIu64 " events, %.2fus avg, min %" PRIu32 "us max %" PRIu32 "us %5.3fus rms\n",
 				handle->name,
-				(unsigned long long)pci->event_count,
+				pci->event_count,
 				(pci->event_count == 0) ? 0 : (double)(pci->time_last - pci->time_first) / (double)pci->event_count,
-				(unsigned long long)pci->time_least,
-				(unsigned long long)pci->time_most,
+				pci->time_least,
+				pci->time_most,
 				(double)(1e6f * rms));
 			break;
 		}
@@ -486,21 +488,22 @@ perf_print_counter_buffer(char *buffer, int length, perf_counter_t handle)
 
 	switch (handle->type) {
 	case PC_COUNT:
-		num_written = snprintf(buffer, length, "%s: %llu events",
+		num_written = snprintf(buffer, length, "%s: %" PRIu64 " events",
 				       handle->name,
-				       (unsigned long long)((struct perf_ctr_count *)handle)->event_count);
+				       ((struct perf_ctr_count *)handle)->event_count);
 		break;
 
 	case PC_ELAPSED: {
 			struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;
 			float rms = sqrtf(pce->M2 / (pce->event_count - 1));
-			num_written = snprintf(buffer, length, "%s: %llu events, %lluus elapsed, %.2fus avg, min %lluus max %lluus %5.3fus rms",
+			num_written = snprintf(buffer, length,
+					       "%s: %" PRIu64 " events, %" PRIu64 "us elapsed, %.2fus avg, min %" PRIu32 "us max %" PRIu32 "us %5.3fus rms",
 					       handle->name,
-					       (unsigned long long)pce->event_count,
-					       (unsigned long long)pce->time_total,
+					       pce->event_count,
+					       pce->time_total,
 					       (pce->event_count == 0) ? 0 : (double)pce->time_total / (double)pce->event_count,
-					       (unsigned long long)pce->time_least,
-					       (unsigned long long)pce->time_most,
+					       pce->time_least,
+					       pce->time_most,
 					       (double)(1e6f * rms));
 			break;
 		}
@@ -509,12 +512,13 @@ perf_print_counter_buffer(char *buffer, int length, perf_counter_t handle)
 			struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;
 			float rms = sqrtf(pci->M2 / (pci->event_count - 1));
 
-			num_written = snprintf(buffer, length, "%s: %llu events, %.2f avg, min %lluus max %lluus %5.3fus rms",
+			num_written = snprintf(buffer, length,
+					       "%s: %" PRIu64 " events, %.2f avg, min %" PRIu32 "us max %" PRIu32 "us %5.3fus rms",
 					       handle->name,
-					       (unsigned long long)pci->event_count,
+					       pci->event_count,
 					       (pci->event_count == 0) ? 0 : (double)(pci->time_last - pci->time_first) / (double)pci->event_count,
-					       (unsigned long long)pci->time_least,
-					       (unsigned long long)pci->time_most,
+					       pci->time_least,
+					       pci->time_most,
 					       (double)(1e6f * rms));
 			break;
 		}
@@ -618,7 +622,8 @@ perf_print_latency(int fd)
 	}
 
 	// print the overflow bucket value
-	dprintf(fd, " >%4i : %i\n", latency_buckets[latency_bucket_count - 1], latency_counters[latency_bucket_count]);
+	dprintf(fd, " >%4" PRIu16 " : %" PRIu32 "\n", latency_buckets[latency_bucket_count - 1],
+		latency_counters[latency_bucket_count]);
 }
 
 void

--- a/src/lib/sensor_calibration/Accelerometer.cpp
+++ b/src/lib/sensor_calibration/Accelerometer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -173,7 +173,7 @@ void Accelerometer::ParametersUpdate()
 
 		if (_external) {
 			if ((rotation_value >= ROTATION_MAX) || (rotation_value < 0)) {
-				PX4_ERR("External %s %d (%d) invalid rotation %d, resetting to rotation none",
+				PX4_ERR("External %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 ", resetting to rotation none",
 					SensorString(), _device_id, _calibration_index, rotation_value);
 				rotation_value = ROTATION_NONE;
 				SetCalibrationParam(SensorString(), "ROT", _calibration_index, rotation_value);
@@ -184,7 +184,7 @@ void Accelerometer::ParametersUpdate()
 		} else {
 			// internal, CAL_ACCx_ROT -1
 			if (rotation_value != -1) {
-				PX4_ERR("Internal %s %d (%d) invalid rotation %d, resetting",
+				PX4_ERR("Internal %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 " resetting",
 					SensorString(), _device_id, _calibration_index, rotation_value);
 				SetCalibrationParam(SensorString(), "ROT", _calibration_index, -1);
 			}
@@ -201,8 +201,8 @@ void Accelerometer::ParametersUpdate()
 			int32_t new_priority = _external ? DEFAULT_EXTERNAL_PRIORITY : DEFAULT_PRIORITY;
 
 			if (_priority != -1) {
-				PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d", SensorString(), _device_id, _calibration_index, _priority,
-					new_priority);
+				PX4_ERR("%s %" PRIu32 " (%" PRId8 ") invalid priority %" PRId32 ", resetting to %" PRId32, SensorString(), _device_id,
+					_calibration_index, _priority, new_priority);
 			}
 
 			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
@@ -267,11 +267,12 @@ bool Accelerometer::ParametersSave()
 
 void Accelerometer::PrintStatus()
 {
-	PX4_INFO("%s %d EN: %d, offset: [%.4f %.4f %.4f] scale: [%.4f %.4f %.4f]", SensorString(), device_id(), enabled(),
+	PX4_INFO("%s %" PRIu32 " EN: %d, offset: [%.4f %.4f %.4f] scale: [%.4f %.4f %.4f]", SensorString(), device_id(),
+		 enabled(),
 		 (double)_offset(0), (double)_offset(1), (double)_offset(2), (double)_scale(0), (double)_scale(1), (double)_scale(2));
 
 	if (_thermal_offset.norm() > 0.f) {
-		PX4_INFO("%s %d temperature offset: [%.4f %.4f %.4f]", SensorString(), _device_id,
+		PX4_INFO("%s %" PRIu32 " temperature offset: [%.4f %.4f %.4f]", SensorString(), _device_id,
 			 (double)_thermal_offset(0), (double)_thermal_offset(1), (double)_thermal_offset(2));
 	}
 }

--- a/src/lib/sensor_calibration/Gyroscope.cpp
+++ b/src/lib/sensor_calibration/Gyroscope.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -158,7 +158,7 @@ void Gyroscope::ParametersUpdate()
 
 		if (_external) {
 			if ((rotation_value >= ROTATION_MAX) || (rotation_value < 0)) {
-				PX4_ERR("External %s %d (%d) invalid rotation %d, resetting to rotation none",
+				PX4_ERR("External %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 ", resetting to rotation none",
 					SensorString(), _device_id, _calibration_index, rotation_value);
 				rotation_value = ROTATION_NONE;
 				SetCalibrationParam(SensorString(), "ROT", _calibration_index, rotation_value);
@@ -169,7 +169,7 @@ void Gyroscope::ParametersUpdate()
 		} else {
 			// internal, CAL_GYROx_ROT -1
 			if (rotation_value != -1) {
-				PX4_ERR("Internal %s %d (%d) invalid rotation %d, resetting",
+				PX4_ERR("Internal %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 " resetting",
 					SensorString(), _device_id, _calibration_index, rotation_value);
 				SetCalibrationParam(SensorString(), "ROT", _calibration_index, -1);
 			}
@@ -186,8 +186,8 @@ void Gyroscope::ParametersUpdate()
 			int32_t new_priority = _external ? DEFAULT_EXTERNAL_PRIORITY : DEFAULT_PRIORITY;
 
 			if (_priority != -1) {
-				PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d", SensorString(), _device_id, _calibration_index, _priority,
-					new_priority);
+				PX4_ERR("%s %" PRIu32 " (%" PRId8 ") invalid priority %" PRId32 ", resetting to %" PRId32, SensorString(), _device_id,
+					_calibration_index, _priority, new_priority);
 			}
 
 			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
@@ -247,11 +247,11 @@ bool Gyroscope::ParametersSave()
 
 void Gyroscope::PrintStatus()
 {
-	PX4_INFO("%s %d EN: %d, offset: [%.4f %.4f %.4f]", SensorString(), device_id(), enabled(),
+	PX4_INFO("%s %" PRIu32 " EN: %d, offset: [%.4f %.4f %.4f]", SensorString(), device_id(), enabled(),
 		 (double)_offset(0), (double)_offset(1), (double)_offset(2));
 
 	if (_thermal_offset.norm() > 0.f) {
-		PX4_INFO("%s %d temperature offset: [%.4f %.4f %.4f]", SensorString(), _device_id,
+		PX4_INFO("%s %" PRIu32 " temperature offset: [%.4f %.4f %.4f]", SensorString(), _device_id,
 			 (double)_thermal_offset(0), (double)_thermal_offset(1), (double)_thermal_offset(2));
 	}
 }

--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -158,7 +158,7 @@ void Magnetometer::ParametersUpdate()
 
 		if (_external) {
 			if ((rotation_value >= ROTATION_MAX) || (rotation_value < 0)) {
-				PX4_ERR("External %s %d (%d) invalid rotation %d, resetting to rotation none",
+				PX4_ERR("External %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 ", resetting to rotation none",
 					SensorString(), _device_id, _calibration_index, rotation_value);
 				rotation_value = ROTATION_NONE;
 				SetCalibrationParam(SensorString(), "ROT", _calibration_index, rotation_value);
@@ -169,7 +169,7 @@ void Magnetometer::ParametersUpdate()
 		} else {
 			// internal mag, CAL_MAGx_ROT -1
 			if (rotation_value != -1) {
-				PX4_ERR("Internal %s %d (%d) invalid rotation %d, resetting",
+				PX4_ERR("Internal %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 " resetting",
 					SensorString(), _device_id, _calibration_index, rotation_value);
 				SetCalibrationParam(SensorString(), "ROT", _calibration_index, -1);
 			}
@@ -186,8 +186,8 @@ void Magnetometer::ParametersUpdate()
 			int32_t new_priority = _external ? DEFAULT_EXTERNAL_PRIORITY : DEFAULT_PRIORITY;
 
 			if (_priority != -1) {
-				PX4_ERR("%s %d (%d) invalid priority %d, resetting to %d", SensorString(), _device_id, _calibration_index, _priority,
-					new_priority);
+				PX4_ERR("%s %" PRIu32 " (%" PRId8 ") invalid priority %" PRId32 ", resetting to %" PRId32, SensorString(), _device_id,
+					_calibration_index, _priority, new_priority);
 			}
 
 			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
@@ -267,14 +267,14 @@ bool Magnetometer::ParametersSave()
 void Magnetometer::PrintStatus()
 {
 	if (external()) {
-		PX4_INFO("%s %d EN: %d, offset: [% 05.3f % 05.3f % 05.3f], scale: [% 05.3f % 05.3f % 05.3f], External ROT: %d",
+		PX4_INFO("%s %" PRIu32 " EN: %d, offset: [% 05.3f % 05.3f % 05.3f], scale: [% 05.3f % 05.3f % 05.3f], External ROT: %d",
 			 SensorString(), device_id(), enabled(),
 			 (double)_offset(0), (double)_offset(1), (double)_offset(2),
 			 (double)_scale(0, 0), (double)_scale(1, 1), (double)_scale(2, 2),
 			 rotation_enum());
 
 	} else {
-		PX4_INFO("%s %d EN: %d, offset: [% 05.3f % 05.3f % 05.3f], scale: [% 05.3f % 05.3f % 05.3f], Internal",
+		PX4_INFO("%s %" PRIu32 " EN: %d, offset: [% 05.3f % 05.3f % 05.3f], scale: [% 05.3f % 05.3f % 05.3f], Internal",
 			 SensorString(), device_id(), enabled(),
 			 (double)_offset(0), (double)_offset(1), (double)_offset(2),
 			 (double)_scale(0, 0), (double)_scale(1, 1), (double)_scale(2, 2));

--- a/src/lib/sensor_calibration/Utilities.cpp
+++ b/src/lib/sensor_calibration/Utilities.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020,2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,7 +80,7 @@ int32_t GetCalibrationParam(const char *sensor_type, const char *cal_type, uint8
 {
 	// eg CAL_MAGn_ID/CAL_MAGn_ROT
 	char str[20] {};
-	sprintf(str, "CAL_%s%u_%s", sensor_type, instance, cal_type);
+	sprintf(str, "CAL_%s%" PRIu8 "_%s", sensor_type, instance, cal_type);
 
 	int32_t value = 0;
 
@@ -96,12 +96,12 @@ bool SetCalibrationParam(const char *sensor_type, const char *cal_type, uint8_t 
 	char str[20] {};
 
 	// eg CAL_MAGn_ID/CAL_MAGn_ROT
-	sprintf(str, "CAL_%s%u_%s", sensor_type, instance, cal_type);
+	sprintf(str, "CAL_%s%" PRIu8 "_%s", sensor_type, instance, cal_type);
 
 	int ret = param_set_no_notification(param_find(str), &value);
 
 	if (ret != PX4_OK) {
-		PX4_ERR("failed to set %s = %d", str, value);
+		PX4_ERR("failed to set %s = %" PRId32, str, value);
 	}
 
 	return ret == PX4_OK;
@@ -117,7 +117,7 @@ Vector3f GetCalibrationParamsVector3f(const char *sensor_type, const char *cal_t
 		char axis_char = 'X' + axis;
 
 		// eg CAL_MAGn_{X,Y,Z}OFF
-		sprintf(str, "CAL_%s%u_%c%s", sensor_type, instance, axis_char, cal_type);
+		sprintf(str, "CAL_%s%" PRIu8 "_%c%s", sensor_type, instance, axis_char, cal_type);
 
 		if (param_get(param_find(str), &values(axis)) != 0) {
 			PX4_ERR("failed to get %s", str);
@@ -136,7 +136,7 @@ bool SetCalibrationParamsVector3f(const char *sensor_type, const char *cal_type,
 		char axis_char = 'X' + axis;
 
 		// eg CAL_MAGn_{X,Y,Z}OFF
-		sprintf(str, "CAL_%s%u_%c%s", sensor_type, instance, axis_char, cal_type);
+		sprintf(str, "CAL_%s%" PRIu8 "_%c%s", sensor_type, instance, axis_char, cal_type);
 
 		if (param_set_no_notification(param_find(str), &values(axis)) != 0) {
 			PX4_ERR("failed to set %s = %.4f", str, (double)values(axis));
@@ -169,7 +169,7 @@ enum Rotation GetBoardRotation()
 		return static_cast<enum Rotation>(board_rot);
 
 	} else {
-		PX4_ERR("invalid SENS_BOARD_ROT: %d", board_rot);
+		PX4_ERR("invalid SENS_BOARD_ROT: %" PRId32, board_rot);
 	}
 
 	return Rotation::ROTATION_NONE;

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -119,6 +119,7 @@ int AnalogBattery::get_current_channel()
 	}
 }
 
+
 void
 AnalogBattery::updateParams()
 {
@@ -127,8 +128,8 @@ AnalogBattery::updateParams()
 				    &_analog_params.v_div, _first_parameter_update);
 		migrateParam<float>(_analog_param_handles.a_per_v_old, _analog_param_handles.a_per_v, &_analog_params.a_per_v_old,
 				    &_analog_params.a_per_v, _first_parameter_update);
-		migrateParam<int>(_analog_param_handles.adc_channel_old, _analog_param_handles.v_channel,
-				  &_analog_params.adc_channel_old, &_analog_params.v_channel, _first_parameter_update);
+		migrateParam<int32_t>(_analog_param_handles.adc_channel_old, _analog_param_handles.v_channel,
+				      &_analog_params.adc_channel_old, &_analog_params.v_channel, _first_parameter_update);
 
 	} else {
 		param_get(_analog_param_handles.v_div, &_analog_params.v_div);

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,12 +88,12 @@ protected:
 		float v_offs_cur;
 		float v_div;
 		float a_per_v;
-		int v_channel;
-		int i_channel;
+		int32_t v_channel;
+		int32_t i_channel;
 
 		float v_div_old;
 		float a_per_v_old;
-		int adc_channel_old;
+		int32_t adc_channel_old;
 	} _analog_params;
 
 	virtual void updateParams() override;

--- a/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
+++ b/src/modules/commander/Arming/ArmAuthorization/ArmAuthorization.cpp
@@ -238,7 +238,7 @@ void arm_auth_update(hrt_abstime now, bool param_update)
 
 		case vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED:
 			mavlink_log_info(mavlink_log_pub,
-					 "Arm auth: Authorized for the next %u seconds",
+					 "Arm auth: Authorized for the next %" PRId32 " seconds",
 					 command_ack.result_param2);
 			state = ARM_AUTH_MISSION_APPROVED;
 			auth_timeout = command_ack.timestamp + (command_ack.result_param2 * 1000000);
@@ -257,7 +257,8 @@ void arm_auth_update(hrt_abstime now, bool param_update)
 				break;
 
 			case vehicle_command_ack_s::ARM_AUTH_DENIED_REASON_INVALID_WAYPOINT:
-				mavlink_log_critical(mavlink_log_pub, "Arm auth: Denied, waypoint %i have a invalid value", command_ack.result_param2);
+				mavlink_log_critical(mavlink_log_pub, "Arm auth: Denied, waypoint %" PRId32 " have a invalid value",
+						     command_ack.result_param2);
 				break;
 
 			case vehicle_command_ack_s::ARM_AUTH_DENIED_REASON_TIMEOUT:

--- a/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
@@ -106,7 +106,7 @@ bool PreFlightCheck::powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_sta
 				success = false;
 
 				if (report_fail) {
-					mavlink_log_critical(mavlink_log_pub, "Power redundancy not met: %d instead of %d",
+					mavlink_log_critical(mavlink_log_pub, "Power redundancy not met: %d instead of %" PRId32,
 							     power_module_count, required_power_module_count);
 				}
 			}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2453,7 +2453,7 @@ Commander::run()
 
 			if (_cmd_sub.copy(&cmd)) {
 				if (_cmd_sub.get_last_generation() != last_generation + 1) {
-					PX4_ERR("vehicle_command lost, generation %d -> %d", last_generation, _cmd_sub.get_last_generation());
+					PX4_ERR("vehicle_command lost, generation %u -> %u", last_generation, _cmd_sub.get_last_generation());
 				}
 
 				if (handle_command(cmd)) {
@@ -3460,7 +3460,8 @@ void Commander::mission_init()
 	if (dm_read(DM_KEY_MISSION_STATE, 0, &mission, sizeof(mission_s)) == sizeof(mission_s)) {
 		if (mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 || mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) {
 			if (mission.count > 0) {
-				PX4_INFO("Mission #%d loaded, %u WPs, curr: %d", mission.dataman_id, mission.count, mission.current_seq);
+				PX4_INFO("Mission #%" PRIu8 " loaded, %" PRIu16 " WPs, curr: %" PRId32, mission.dataman_id, mission.count,
+					 mission.current_seq);
 			}
 
 		} else {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,6 @@
  ****************************************************************************/
 
 #pragma once
-
 
 /*   Helper classes  */
 #include "Arming/PreFlightCheck/PreFlightCheck.hpp"

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012, 2021  PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -345,7 +345,7 @@ bool calibrate_cancel_check(orb_advert_t *mavlink_log_pub, const hrt_abstime &ca
 
 				} else {
 					command_ack.result = vehicle_command_s::VEHICLE_CMD_RESULT_DENIED;
-					mavlink_log_critical(mavlink_log_pub, "command denied during calibration: %u", cmd.command);
+					mavlink_log_critical(mavlink_log_pub, "command denied during calibration: %" PRIu32, cmd.command);
 					tune_negative(true);
 					ret = false;
 				}

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -151,7 +151,7 @@ static bool reject_sample(float sx, float sy, float sz, float x[], float y[], fl
 		float dist = sqrtf(dx * dx + dy * dy + dz * dz);
 
 		if (dist < min_sample_dist) {
-			PX4_DEBUG("rejected X: %.3f Y: %.3f Z: %.3f (%.3f < %.3f) (%d/%d) ", (double)sx, (double)sy, (double)sz, (double)dist,
+			PX4_DEBUG("rejected X: %.3f Y: %.3f Z: %.3f (%.3f < %.3f) (%u/%u) ", (double)sx, (double)sy, (double)sz, (double)dist,
 				  (double)min_sample_dist, count, max_count);
 
 			return true;
@@ -188,14 +188,14 @@ static calibrate_return check_calibration_result(float offset_x, float offset_y,
 
 	for (unsigned i = 0; i < num_finite; ++i) {
 		if (!PX4_ISFINITE(must_be_finite[i])) {
-			calibration_log_emergency(mavlink_log_pub, "Retry calibration (sphere NaN, %u)", cur_mag);
+			calibration_log_emergency(mavlink_log_pub, "Retry calibration (sphere NaN, %" PRIu8 ")", cur_mag);
 			return calibrate_return_error;
 		}
 	}
 
 	// earth field between 0.25 and 0.65 Gauss
 	if (sphere_radius < 0.2f || sphere_radius >= 0.7f) {
-		calibration_log_emergency(mavlink_log_pub, "Retry calibration (mag %u sphere radius invalid %.3f)", cur_mag,
+		calibration_log_emergency(mavlink_log_pub, "Retry calibration (mag %" PRIu8 " sphere radius invalid %.3f)", cur_mag,
 					  (double)sphere_radius);
 		return calibrate_return_error;
 	}
@@ -205,7 +205,7 @@ static calibrate_return check_calibration_result(float offset_x, float offset_y,
 
 	for (unsigned i = 0; i < num_positive; ++i) {
 		if (should_be_positive[i] <= 0.0f) {
-			calibration_log_emergency(mavlink_log_pub, "Retry calibration (mag %u with non-positive scale)", cur_mag);
+			calibration_log_emergency(mavlink_log_pub, "Retry calibration (mag %" PRIu8 " with non-positive scale)", cur_mag);
 			return calibrate_return_error;
 		}
 	}
@@ -219,7 +219,7 @@ static calibrate_return check_calibration_result(float offset_x, float offset_y,
 		static constexpr float MAG_MAX_OFFSET_LEN = 1.3f;
 
 		if (fabsf(should_be_not_huge[i]) > MAG_MAX_OFFSET_LEN) {
-			calibration_log_critical(mavlink_log_pub, "Warning: mag %u with large offsets", cur_mag);
+			calibration_log_critical(mavlink_log_pub, "Warning: mag %" PRIu8 " with large offsets", cur_mag);
 			break;
 		}
 	}
@@ -440,7 +440,7 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 				}
 			}
 
-			PX4_DEBUG("side counter %d / %d", calibration_counter_side, worker_data->calibration_points_perside);
+			PX4_DEBUG("side counter %u / %u", calibration_counter_side, worker_data->calibration_points_perside);
 
 		} else {
 			poll_errcount++;
@@ -596,7 +596,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 				if (ret == PX4_OK) {
 					sphere_fit_success = true;
-					PX4_INFO("Mag: %d sphere radius: %.4f", cur_mag, (double)sphere_data.radius);
+					PX4_INFO("Mag: %" PRIu8 " sphere radius: %.4f", cur_mag, (double)sphere_data.radius);
 
 					if (!sphere_fit_only) {
 						int ellipsoid_ret = lm_mag_fit(worker_data.x[cur_mag], worker_data.y[cur_mag], worker_data.z[cur_mag],
@@ -617,7 +617,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 				}
 
 				if (!sphere_fit_success && !ellipsoid_fit_success) {
-					calibration_log_emergency(mavlink_log_pub, "Retry calibration (unable to fit mag %u)", cur_mag);
+					calibration_log_emergency(mavlink_log_pub, "Retry calibration (unable to fit mag %" PRIu8 ")", cur_mag);
 					result = calibrate_return_error;
 					break;
 				}
@@ -646,7 +646,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 				continue;
 			}
 
-			printf("MAG %u with %u samples:\n", cur_mag, worker_data.calibration_counter_total[cur_mag]);
+			printf("MAG %" PRIu8 " with %u samples:\n", cur_mag, worker_data.calibration_counter_total[cur_mag]);
 			printf("RAW -> CALIBRATED\n");
 
 			float scale_data[9] {
@@ -811,7 +811,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 							switch (worker_data.calibration[cur_mag].rotation_enum()) {
 							case ROTATION_ROLL_90_PITCH_68_YAW_293:
-								PX4_INFO("[cal] External Mag: %d (%d), keeping manually configured rotation %d", cur_mag,
+								PX4_INFO("[cal] External Mag: %d (%" PRIu32 "), keeping manually configured rotation %" PRIu8, cur_mag,
 									 worker_data.calibration[cur_mag].device_id(), worker_data.calibration[cur_mag].rotation_enum());
 								continue;
 
@@ -821,25 +821,27 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 							if (smallest_check_passed && total_error_check_passed) {
 								if (best_rotation != worker_data.calibration[cur_mag].rotation_enum()) {
-									calibration_log_info(mavlink_log_pub, "[cal] External Mag: %d (%d), determined rotation: %d", cur_mag,
+									calibration_log_info(mavlink_log_pub, "[cal] External Mag: %d (%" PRIu32 ")), determined rotation: %" PRIu8, cur_mag,
 											     worker_data.calibration[cur_mag].device_id(), best_rotation);
 
 									worker_data.calibration[cur_mag].set_rotation(best_rotation);
 
 								} else {
-									PX4_INFO("[cal] External Mag: %d (%d), no rotation change: %d", cur_mag,
+									PX4_INFO("[cal] External Mag: %d (%" PRIu32 ")), no rotation change: %d", cur_mag,
 										 worker_data.calibration[cur_mag].device_id(), best_rotation);
 								}
 
 							} else {
-								PX4_ERR("External Mag: %d (%d), determining rotation failed", cur_mag, worker_data.calibration[cur_mag].device_id());
+								PX4_ERR("External Mag: %d (%" PRIu32 ")), determining rotation failed", cur_mag,
+									worker_data.calibration[cur_mag].device_id());
 								print_all_mse = true;
 							}
 
 						} else {
 							// non-primary internal mags, warn if there seems to be a rotation relative to the first primary (internal_index)
 							if (best_rotation != ROTATION_NONE) {
-								calibration_log_critical(mavlink_log_pub, "[cal] Internal Mag: %d (%d) rotation %d relative to primary %d (%d)",
+								calibration_log_critical(mavlink_log_pub,
+											 "[cal] Internal Mag: %d (%" PRIu32 ") rotation %d relative to primary %d (%" PRIu32 ")",
 											 cur_mag, worker_data.calibration[cur_mag].device_id(), best_rotation,
 											 internal_index, worker_data.calibration[internal_index].device_id());
 
@@ -849,7 +851,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 						if (print_all_mse) {
 							for (int r = ROTATION_NONE; r < ROTATION_MAX; r++) {
-								PX4_ERR("%s Mag: %d (%d), rotation: %d, MSE: %.3f",
+								PX4_ERR("%s Mag: %d (%" PRIu32 "), rotation: %d, MSE: %.3f",
 									worker_data.calibration[cur_mag].external() ? "External" : "Internal",
 									cur_mag, worker_data.calibration[cur_mag].device_id(), r, (double)MSE[r]);
 							}

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2016, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -834,7 +834,7 @@ _ram_initialize(unsigned max_offset)
 	dm_operations_data.ram.data = (uint8_t *)malloc(max_offset);
 
 	if (dm_operations_data.ram.data == nullptr) {
-		PX4_WARN("Could not allocate %d bytes of memory", max_offset);
+		PX4_WARN("Could not allocate %u bytes of memory", max_offset);
 		px4_sem_post(&g_init_sema); /* Don't want to hang startup */
 		return -1;
 	}
@@ -1091,7 +1091,7 @@ task_main(int argc, char *argv[])
 	_dm_write_perf = perf_alloc(PC_ELAPSED, MODULE_NAME": write");
 
 	/* see if we need to erase any items based on restart type */
-	int sys_restart_val;
+	int32_t sys_restart_val;
 
 	const char *restart_type_str = "Unknown restart";
 
@@ -1116,14 +1116,14 @@ task_main(int argc, char *argv[])
 	switch (backend) {
 	case BACKEND_FILE:
 		if (sys_restart_val != DM_INIT_REASON_POWER_ON) {
-			PX4_INFO("%s, data manager file '%s' size is %d bytes",
+			PX4_INFO("%s, data manager file '%s' size is %u bytes",
 				 restart_type_str, k_data_manager_device_path, max_offset);
 		}
 
 		break;
 
 	case BACKEND_RAM:
-		PX4_INFO("%s, data manager RAM size is %d bytes",
+		PX4_INFO("%s, data manager RAM size is %u bytes",
 			 restart_type_str, max_offset);
 		break;
 
@@ -1247,11 +1247,11 @@ static void
 status()
 {
 	/* display usage statistics */
-	PX4_INFO("Writes   %d", g_func_counts[dm_write_func]);
-	PX4_INFO("Reads    %d", g_func_counts[dm_read_func]);
-	PX4_INFO("Clears   %d", g_func_counts[dm_clear_func]);
-	PX4_INFO("Restarts %d", g_func_counts[dm_restart_func]);
-	PX4_INFO("Max Q lengths work %d, free %d", g_work_q.max_size, g_free_q.max_size);
+	PX4_INFO("Writes   %u", g_func_counts[dm_write_func]);
+	PX4_INFO("Reads    %u", g_func_counts[dm_read_func]);
+	PX4_INFO("Clears   %u", g_func_counts[dm_clear_func]);
+	PX4_INFO("Restarts %u", g_func_counts[dm_restart_func]);
+	PX4_INFO("Max Q lengths work %u, free %u", g_work_q.max_size, g_free_q.max_size);
 	perf_print_counter(_dm_read_perf);
 	perf_print_counter(_dm_write_perf);
 }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1562,14 +1562,14 @@ void EKF2::UpdateMagSample(ekf2_timestamps_s &ekf2_timestamps)
 		// check if magnetometer has changed
 		if (magnetometer.device_id != _device_id_mag) {
 			if (_device_id_mag != 0) {
-				PX4_WARN("%d - mag sensor ID changed %d -> %d", _instance, _device_id_mag, magnetometer.device_id);
+				PX4_WARN("%d - mag sensor ID changed %" PRIu32 " -> %" PRIu32, _instance, _device_id_mag, magnetometer.device_id);
 			}
 
 			reset = true;
 
 		} else if (magnetometer.calibration_count > _mag_calibration_count) {
 			// existing calibration has changed, reset saved mag bias
-			PX4_DEBUG("%d - mag %d calibration updated, resetting bias", _instance, _device_id_mag);
+			PX4_DEBUG("%d - mag %" PRIu32 " calibration updated, resetting bias", _instance, _device_id_mag);
 			reset = true;
 		}
 
@@ -1732,8 +1732,8 @@ int EKF2::task_spawn(int argc, char *argv[])
 		param_get(param_find("EKF2_MULTI_IMU"), &imu_instances);
 
 		if (imu_instances < 1 || imu_instances > 4) {
-			const int32_t imu_instances_limited = math::constrain(imu_instances, 1, 4);
-			PX4_WARN("EKF2_MULTI_IMU limited %d -> %d", imu_instances, imu_instances_limited);
+			const int32_t imu_instances_limited = math::constrain(imu_instances, static_cast<int32_t>(1), static_cast<int32_t>(4));
+			PX4_WARN("EKF2_MULTI_IMU limited %" PRId32 " -> %" PRId32, imu_instances, imu_instances_limited);
 			param_set_no_notification(param_find("EKF2_MULTI_IMU"), &imu_instances_limited);
 			imu_instances = imu_instances_limited;
 		}
@@ -1746,8 +1746,8 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 			// Mags (1 - 4 supported)
 			if (mag_instances < 1 || mag_instances > 4) {
-				const int32_t mag_instances_limited = math::constrain(mag_instances, 1, 4);
-				PX4_WARN("EKF2_MULTI_MAG limited %d -> %d", mag_instances, mag_instances_limited);
+				const int32_t mag_instances_limited = math::constrain(mag_instances, static_cast<int32_t>(1), static_cast<int32_t>(4));
+				PX4_WARN("EKF2_MULTI_MAG limited %" PRId32 " -> %" PRId32, mag_instances, mag_instances_limited);
 				param_set_no_notification(param_find("EKF2_MULTI_MAG"), &mag_instances_limited);
 				mag_instances = mag_instances_limited;
 			}
@@ -1772,7 +1772,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 		}
 
 		const hrt_abstime time_started = hrt_absolute_time();
-		const int multi_instances = math::min(imu_instances * mag_instances, (int)EKF2_MAX_INSTANCES);
+		const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
 		int multi_instances_allocated = 0;
 
 		// allocate EKF2 instances until all found or arming
@@ -1817,7 +1817,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 										_ekf2_selector.load()->ScheduleNow();
 									}
 
-									PX4_INFO("starting instance %d, IMU:%d (%d), MAG:%d (%d)", actual_instance,
+									PX4_INFO("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
 										 imu, vehicle_imu_sub.get().accel_device_id,
 										 mag, vehicle_mag_sub.get().device_id);
 
@@ -1831,7 +1831,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 								}
 
 							} else {
-								PX4_ERR("alloc and init failed imu: %d mag:%d", imu, mag);
+								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
 								px4_usleep(1000000);
 								break;
 							}

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2015-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2015-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -102,7 +102,7 @@ void EKF2Selector::PrintInstanceChange(const uint8_t old_instance, uint8_t new_i
 			new_reason = "";
 		}
 
-		PX4_WARN("primary EKF changed %d%s -> %d%s", old_instance, old_reason, new_instance, new_reason);
+		PX4_WARN("primary EKF changed %" PRIu8 "%s -> %" PRIu8 "%s", old_instance, old_reason, new_instance, new_reason);
 	}
 }
 
@@ -809,7 +809,7 @@ void EKF2Selector::PublishEstimatorSelectorStatus()
 
 void EKF2Selector::PrintStatus()
 {
-	PX4_INFO("available instances: %d", _available_instances);
+	PX4_INFO("available instances: %" PRIu8, _available_instances);
 
 	if (_selected_instance == INVALID_INSTANCE) {
 		PX4_WARN("selected instance: None");
@@ -818,7 +818,7 @@ void EKF2Selector::PrintStatus()
 	for (int i = 0; i < _available_instances; i++) {
 		const EstimatorInstance &inst = _instance[i];
 
-		PX4_INFO("%d: ACC: %d, GYRO: %d, MAG: %d, %s, test ratio: %.7f (%.5f) %s",
+		PX4_INFO("%" PRIu8 ": ACC: %" PRIu32 ", GYRO: %" PRIu32 ", MAG: %" PRIu32 ", %s, test ratio: %.7f (%.5f) %s",
 			 inst.instance, inst.accel_device_id, inst.gyro_device_id, inst.mag_device_id,
 			 inst.healthy ? "healthy" : "unhealthy",
 			 (double)inst.combined_test_ratio, (double)inst.relative_test_ratio,

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -275,7 +275,7 @@ void FlightModeManager::start_flight_task()
 		case 4:
 		default:
 			if (_param_mpc_pos_mode.get() != 4) {
-				PX4_ERR("MPC_POS_MODE %d invalid, resetting", _param_mpc_pos_mode.get());
+				PX4_ERR("MPC_POS_MODE %" PRId32 " invalid, resetting", _param_mpc_pos_mode.get());
 				_param_mpc_pos_mode.set(4);
 				_param_mpc_pos_mode.commit();
 			}
@@ -359,7 +359,7 @@ void FlightModeManager::check_failure(bool task_failure, uint8_t nav_state)
 
 	} else if (_task_failure_count > NUM_FAILURE_TRIES) {
 		// tell commander to switch mode
-		PX4_WARN("Previous flight task failed, switching to mode %d", nav_state);
+		PX4_WARN("Previous flight task failed, switching to mode %" PRIu8, nav_state);
 		send_vehicle_cmd_do(nav_state);
 		_task_failure_count = 0; // avoid immediate resending of a vehicle command in the next iteration
 	}
@@ -612,7 +612,7 @@ int FlightModeManager::custom_command(int argc, char *argv[])
 int FlightModeManager::print_status()
 {
 	if (isAnyTaskActive()) {
-		PX4_INFO("Running, active flight task: %i", static_cast<uint32_t>(_current_task.index));
+		PX4_INFO("Running, active flight task: %" PRIu32, static_cast<uint32_t>(_current_task.index));
 
 	} else {
 		PX4_INFO("Running, no flight task active");

--- a/src/modules/gyro_calibration/GyroCalibration.cpp
+++ b/src/modules/gyro_calibration/GyroCalibration.cpp
@@ -189,7 +189,7 @@ void GyroCalibration::Run()
 		if (_gyro_calibration[gyro].device_id() != 0) {
 			// periodically check variance
 			if ((_gyro_mean[gyro].count() % 100 == 0)) {
-				PX4_DEBUG("gyro %d (%d) variance, [%.9f, %.9f, %.9f] %.9f", gyro, _gyro_calibration[gyro].device_id(),
+				PX4_DEBUG("gyro %d (%" PRIu32 ") variance, [%.9f, %.9f, %.9f] %.9f", gyro, _gyro_calibration[gyro].device_id(),
 					  (double)_gyro_mean[gyro].variance()(0), (double)_gyro_mean[gyro].variance()(1), (double)_gyro_mean[gyro].variance()(2),
 					  (double)_gyro_mean[gyro].variance().length());
 
@@ -224,7 +224,7 @@ void GyroCalibration::Run()
 				if (_gyro_calibration[gyro].set_offset(_gyro_mean[gyro].mean())) {
 					calibration_updated = true;
 
-					PX4_INFO("gyro %d (%d) updating calibration, [%.4f, %.4f, %.4f] -> [%.4f, %.4f, %.4f] %.1f°C",
+					PX4_INFO("gyro %d (%" PRIu32 ") updating calibration, [%.4f, %.4f, %.4f] -> [%.4f, %.4f, %.4f] %.1f°C",
 						 gyro, _gyro_calibration[gyro].device_id(),
 						 (double)old_offset(0), (double)old_offset(1), (double)old_offset(2),
 						 (double)_gyro_mean[gyro].mean()(0), (double)_gyro_mean[gyro].mean()(1), (double)_gyro_mean[gyro].mean()(2),
@@ -284,7 +284,7 @@ int GyroCalibration::print_status()
 {
 	for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
 		if (_gyro_calibration[gyro].device_id() != 0) {
-			PX4_INFO_RAW("gyro %d (%d), [%.5f, %.5f, %.5f] var: [%.9f, %.9f, %.9f] %.1f°C (count %d)\n",
+			PX4_INFO_RAW("gyro %d (%" PRIu32 "), [%.5f, %.5f, %.5f] var: [%.9f, %.9f, %.9f] %.1f°C (count %d)\n",
 				     gyro, _gyro_calibration[gyro].device_id(),
 				     (double)_gyro_mean[gyro].mean()(0), (double)_gyro_mean[gyro].mean()(1), (double)_gyro_mean[gyro].mean()(2),
 				     (double)_gyro_mean[gyro].variance()(0), (double)_gyro_mean[gyro].variance()(1), (double)_gyro_mean[gyro].variance()(2),

--- a/src/modules/gyro_fft/GyroFFT.cpp
+++ b/src/modules/gyro_fft/GyroFFT.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -128,7 +128,7 @@ bool GyroFFT::init()
 
 	default:
 		// otherwise default to 256
-		PX4_ERR("Invalid IMU_GYRO_FFT_LEN=%d, resetting", _param_imu_gyro_fft_len.get());
+		PX4_ERR("Invalid IMU_GYRO_FFT_LEN=%" PRId32 ", resetting", _param_imu_gyro_fft_len.get());
 		AllocateBuffers<256>();
 		_param_imu_gyro_fft_len.set(256);
 		_param_imu_gyro_fft_len.commit();
@@ -199,7 +199,7 @@ bool GyroFFT::SensorSelectionUpdate(bool force)
 				}
 			}
 
-			PX4_ERR("unable to find or subscribe to selected sensor (%d)", sensor_selection.gyro_device_id);
+			PX4_ERR("unable to find or subscribe to selected sensor (%" PRIu32 ")", sensor_selection.gyro_device_id);
 		}
 	}
 

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -310,7 +310,7 @@ int LoggedTopics::add_topics_from_file(const char *fname)
 		char topic_name[80];
 		uint32_t interval_ms = 0;
 		uint32_t instance = 0;
-		int nfields = sscanf(line, "%s %u %u", topic_name, &interval_ms, &instance);
+		int nfields = sscanf(line, "%s %" PRIu32 " %" PRIu32, topic_name, &interval_ms, &instance);
 
 		if (nfields > 0) {
 			int name_len = strlen(topic_name);
@@ -366,7 +366,7 @@ bool LoggedTopics::add_topic(const orb_metadata *topic, uint16_t interval_ms, ui
 	}
 
 	if (_subscriptions.count >= MAX_TOPICS_NUM) {
-		PX4_WARN("Too many subscriptions, failed to add: %s %d", topic->o_name, instance);
+		PX4_WARN("Too many subscriptions, failed to add: %s %" PRIu8, topic->o_name, instance);
 		return false;
 	}
 
@@ -391,7 +391,7 @@ bool LoggedTopics::add_topic(const char *name, uint16_t interval_ms, uint8_t ins
 				if (_subscriptions.sub[j].id == static_cast<ORB_ID>(topics[i]->o_id) &&
 				    _subscriptions.sub[j].instance == instance) {
 
-					PX4_DEBUG("logging topic %s(%d), interval: %i, already added, only setting interval",
+					PX4_DEBUG("logging topic %s(%" PRUu8 "), interval: %" PRUu16 ", already added, only setting interval",
 						  topics[i]->o_name, instance, interval_ms);
 
 					_subscriptions.sub[j].interval_ms = interval_ms;
@@ -403,7 +403,7 @@ bool LoggedTopics::add_topic(const char *name, uint16_t interval_ms, uint8_t ins
 
 			if (!already_added) {
 				success = add_topic(topics[i], interval_ms, instance);
-				PX4_DEBUG("logging topic: %s(%d), interval: %i", topics[i]->o_name, instance, interval_ms);
+				PX4_DEBUG("logging topic: %s(%" PRUu8 "), interval: %" PRUu16, topics[i]->o_name, instance, interval_ms);
 				break;
 			}
 		}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1121,7 +1121,7 @@ int Logger::create_log_dir(LogType type, tm *tt, char *log_dir, int log_dir_len)
 		/* look for the next dir that does not exist */
 		while (!file_name.has_log_dir) {
 			/* format log dir: e.g. /fs/microsd/log/sess001 */
-			int n2 = snprintf(file_name.log_dir, sizeof(LogFileName::log_dir), "sess%03u", dir_number);
+			int n2 = snprintf(file_name.log_dir, sizeof(LogFileName::log_dir), "sess%03" PRIu16, dir_number);
 
 			if (n2 >= (int)sizeof(LogFileName::log_dir)) {
 				PX4_ERR("log path too long (%i)", n);
@@ -1192,7 +1192,7 @@ int Logger::get_log_file_name(LogType type, char *file_name, size_t file_name_si
 		/* look for the next file that does not exist */
 		while (file_number <= MAX_NO_LOGFILE) {
 			/* format log file path: e.g. /fs/microsd/log/sess001/log001.ulg */
-			snprintf(log_file_name, sizeof(LogFileName::log_file_name), "log%03u%s.ulg", file_number, replay_suffix);
+			snprintf(log_file_name, sizeof(LogFileName::log_file_name), "log%03" PRIu16 "%s.ulg", file_number, replay_suffix);
 			snprintf(file_name + n, file_name_size - n, "/%s", log_file_name);
 
 			if (!util::file_exist(file_name)) {
@@ -1682,7 +1682,7 @@ void Logger::write_info_multiple(LogType type, const char *name, const char *val
 		write_message(type, buffer, msg_size);
 
 	} else {
-		PX4_ERR("info_multiple str too long (%i), key=%s", msg.key_len, msg.key);
+		PX4_ERR("info_multiple str too long (%" PRIu8 "), key=%s", msg.key_len, msg.key);
 	}
 
 	_writer.unlock();
@@ -1809,7 +1809,7 @@ void Logger::write_version(LogType type)
 
 	// data versioning: increase this on every larger data change (format/semantic)
 	// 1: switch to FIFO drivers (disabled on-chip DLPF)
-	write_info(type, "ver_data_format", 1);
+	write_info(type, "ver_data_format", static_cast<uint32_t>(1));
 
 #ifndef BOARD_HAS_NO_UUID
 

--- a/src/modules/logger/watchdog.h
+++ b/src/modules/logger/watchdog.h
@@ -36,7 +36,7 @@
 #include <drivers/drv_hrt.h>
 
 #ifdef __PX4_NUTTX
-#include <sched.h>
+#include <nuttx/sched.h>
 #include <px4_platform/cpuload.h>
 #endif /* __PX4_NUTTX */
 

--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +73,7 @@ int MavlinkCommandSender::handle_vehicle_command(const vehicle_command_s &comman
 	}
 
 	lock();
-	CMD_DEBUG("new command: %d (channel: %d)", command.command, channel);
+	CMD_DEBUG("new command: %" PRIu32 " (channel: %d)", command.command, channel);
 
 	mavlink_command_long_t msg = {};
 	msg.target_system = command.target_system;
@@ -119,7 +119,7 @@ int MavlinkCommandSender::handle_vehicle_command(const vehicle_command_s &comman
 void MavlinkCommandSender::handle_mavlink_command_ack(const mavlink_command_ack_t &ack,
 		uint8_t from_sysid, uint8_t from_compid, uint8_t channel)
 {
-	CMD_DEBUG("handling result %d for command %d (from %d:%d)",
+	CMD_DEBUG("handling result %" PRIu8 " for command %" PRIu16 " (from %" PRIu8 ":%" PRIu8 ")",
 		  ack.result, ack.command, from_sysid, from_compid);
 	lock();
 
@@ -197,7 +197,7 @@ void MavlinkCommandSender::check_timeout(mavlink_channel_t channel)
 			item->command.confirmation = ++item->num_sent_per_channel[channel];
 			mavlink_msg_command_long_send_struct(channel, &item->command);
 
-			CMD_DEBUG("command %d sent (not first, retries: %d/%d, channel: %d)",
+			CMD_DEBUG("command %" PRIu16 " sent (not first, retries: %" PRIu8 "/%" PRIi8 ", channel: %d)",
 				  item->command.command,
 				  item->num_sent_per_channel[channel],
 				  max_sent,
@@ -209,7 +209,7 @@ void MavlinkCommandSender::check_timeout(mavlink_channel_t channel)
 			// If the next retry would be above the needed retries anyway, we can
 			// drop the item, and continue with other items.
 			if (item->num_sent_per_channel[channel] + 1 > RETRIES) {
-				CMD_DEBUG("command %d dropped", item->command.command);
+				CMD_DEBUG("command %" PRIu16 " dropped", item->command.command);
 				_commands.drop_current();
 				continue;
 			}
@@ -220,7 +220,7 @@ void MavlinkCommandSender::check_timeout(mavlink_channel_t channel)
 			// Therefore, we are the ones setting the timestamp of this retry round.
 			item->last_time_sent_us = hrt_absolute_time();
 
-			CMD_DEBUG("command %d sent (first, retries: %d/%d, channel: %d)",
+			CMD_DEBUG("command %" PRIu16 " sent (first, retries: %" PRId8 "/%" PRId8 ", channel: %d)",
 				  item->command.command,
 				  item->num_sent_per_channel[channel],
 				  max_sent,

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -190,7 +190,8 @@ MavlinkFTP::_process_request(
 
 
 #ifdef MAVLINK_FTP_DEBUG
-	PX4_INFO("ftp: channel %u opc %u size %u offset %u", _getServerChannel(), payload->opcode, payload->size,
+	PX4_INFO("ftp: channel %" PRIu8 " opc %" PRIu8 " size %" PRIu8 " offset %" PRIu32, _getServerChannel(), payload->opcode,
+		 payload->size,
 		 payload->offset);
 #endif
 
@@ -336,7 +337,7 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 	}
 
 #ifdef MAVLINK_FTP_DEBUG
-	PX4_INFO("FTP: %s seq_number: %d", payload->opcode == kRspAck ? "Ack" : "Nak", payload->seq_number);
+	PX4_INFO("FTP: %s seq_number: %" PRIu16, payload->opcode == kRspAck ? "Ack" : "Nak", payload->seq_number);
 #endif
 
 #ifdef MAVLINK_FTP_UNIT_TEST
@@ -368,7 +369,7 @@ MavlinkFTP::_workList(PayloadHeader *payload)
 	}
 
 #ifdef MAVLINK_FTP_DEBUG
-	PX4_INFO("FTP: list %s offset %d", _work_buffer1, payload->offset);
+	PX4_INFO("FTP: list %s offset %" PRIu32, _work_buffer1, payload->offset);
 #endif
 
 	struct dirent *result = nullptr;
@@ -461,7 +462,7 @@ MavlinkFTP::_workList(PayloadHeader *payload)
 
 		} else if (direntType == kDirentFile) {
 			// Files send filename and file length
-			int ret = snprintf(_work_buffer2, _work_buffer2_len, "%s\t%d", result->d_name, fileSize);
+			int ret = snprintf(_work_buffer2, _work_buffer2_len, "%s\t%" PRIu32, result->d_name, fileSize);
 			bool buf_is_ok = ((ret > 0) && (ret < _work_buffer2_len));
 
 			if (!buf_is_ok) {
@@ -554,7 +555,7 @@ MavlinkFTP::_workRead(PayloadHeader *payload)
 	}
 
 #ifdef MAVLINK_FTP_DEBUG
-	PX4_INFO("FTP: read offset:%d", payload->offset);
+	PX4_INFO("FTP: read offset:%" PRIu32, payload->offset);
 #endif
 
 	// We have to test seek past EOF ourselves, lseek will allow seek past EOF
@@ -590,7 +591,7 @@ MavlinkFTP::_workBurst(PayloadHeader *payload, uint8_t target_system_id, uint8_t
 	}
 
 #ifdef MAVLINK_FTP_DEBUG
-	PX4_INFO("FTP: burst offset:%d", payload->offset);
+	PX4_INFO("FTP: burst offset:%" PRIu32, payload->offset);
 #endif
 	// Setup for streaming sends
 	_session_info.stream_download = true;
@@ -993,7 +994,7 @@ void MavlinkFTP::send()
 	// Skip send if not enough room
 	unsigned max_bytes_to_send = _mavlink->get_free_tx_buf();
 #ifdef MAVLINK_FTP_DEBUG
-	PX4_INFO("MavlinkFTP::send max_bytes_to_send(%d) get_free_tx_buf(%d)", max_bytes_to_send, _mavlink->get_free_tx_buf());
+	PX4_INFO("MavlinkFTP::send max_bytes_to_send(%u) get_free_tx_buf(%u)", max_bytes_to_send, _mavlink->get_free_tx_buf());
 #endif
 
 	if (max_bytes_to_send < get_size()) {
@@ -1022,7 +1023,7 @@ void MavlinkFTP::send()
 		_session_info.stream_seq_number++;
 
 #ifdef MAVLINK_FTP_DEBUG
-		PX4_INFO("stream send: offset %d", _session_info.stream_offset);
+		PX4_INFO("stream send: offset %" PRIu32, _session_info.stream_offset);
 #endif
 
 		// We have to test seek past EOF ourselves, lseek will allow seek past EOF

--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -172,7 +172,7 @@ MavlinkLogHandler::_log_request_list(const mavlink_message_t *msg)
 			      _log_count - 1;
 	}
 
-	PX4LOG_WARN("\nMavlinkLogHandler::_log_request_list: start: %u last: %u count: %u",
+	PX4LOG_WARN("\nMavlinkLogHandler::_log_request_list: start: %d last: %d count: %d",
 		    _next_entry,
 		    _last_entry,
 		    _log_count);
@@ -195,7 +195,7 @@ MavlinkLogHandler::_log_request_data(const mavlink_message_t *msg)
 
 	//-- Does the requested log exist?
 	if (request.id >= _log_count) {
-		PX4LOG_WARN("MavlinkLogHandler::_log_request_data Requested log %u but we only have %u.", request.id,
+		PX4LOG_WARN("MavlinkLogHandler::_log_request_data Requested log %" PRIu16 " but we only have %u.", request.id,
 			    _log_count);
 		return;
 	}
@@ -282,7 +282,8 @@ MavlinkLogHandler::_log_send_listing()
 		_next_entry++;
 	}
 
-	PX4LOG_WARN("MavlinkLogHandler::_log_send_listing id: %u count: %u last: %u size: %u date: %u status: %d",
+	PX4LOG_WARN("MavlinkLogHandler::_log_send_listing id: %" PRIu16 " count: %" PRIu16 " last: %" PRIu16 " size: %" PRIu32
+		    " date: %" PRIu32 " status: %" PRIu32,
 		    response.id,
 		    response.num_logs,
 		    response.last_log_num,
@@ -353,7 +354,7 @@ MavlinkLogHandler::_get_entry(int idx, uint32_t &size, uint32_t &date, char *fil
 			if (count++ == idx) {
 				char file[160];
 
-				if (sscanf(line, "%u %u %s", &date, &size, file) == 3) {
+				if (sscanf(line, "%" PRIu32 " %" PRIu32 " %s", &date, &size, file) == 3) {
 					if (filename && filename_len > 0) {
 						strncpy(filename, file, filename_len);
 						filename[filename_len - 1] = 0; // ensure null-termination

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1024,7 +1024,7 @@ Mavlink::compute_broadcast_addr(const in_addr &host_addr, const in_addr &netmask
 void
 Mavlink::init_udp()
 {
-	PX4_DEBUG("Setting up UDP with port %d", _network_port);
+	PX4_DEBUG("Setting up UDP with port %hu", _network_port);
 
 	_myaddr.sin_family = AF_INET;
 	_myaddr.sin_addr.s_addr = htonl(INADDR_ANY);
@@ -2139,7 +2139,7 @@ Mavlink::task_main(int argc, char *argv[])
 
 	else if (get_protocol() == Protocol::UDP) {
 		if (Mavlink::get_instance_for_network_port(_network_port) != nullptr) {
-			PX4_ERR("port %d already occupied", _network_port);
+			PX4_ERR("port %hu already occupied", _network_port);
 			return PX4_ERROR;
 		}
 
@@ -2315,7 +2315,7 @@ Mavlink::task_main(int argc, char *argv[])
 
 				if (_vehicle_command_sub.update(&vehicle_cmd)) {
 					if (_vehicle_command_sub.get_last_generation() != last_generation + 1) {
-						PX4_ERR("vehicle_command lost, generation %d -> %d", last_generation, _vehicle_command_sub.get_last_generation());
+						PX4_ERR("vehicle_command lost, generation %u -> %u", last_generation, _vehicle_command_sub.get_last_generation());
 					}
 
 					if ((vehicle_cmd.command == vehicle_command_s::VEHICLE_CMD_CONTROL_HIGH_LATENCY) &&
@@ -2366,7 +2366,7 @@ Mavlink::task_main(int argc, char *argv[])
 
 				if (_vehicle_command_ack_sub.update(&command_ack)) {
 					if (_vehicle_command_ack_sub.get_last_generation() != last_generation + 1) {
-						PX4_ERR("vehicle_command_ack lost, generation %d -> %d", last_generation,
+						PX4_ERR("vehicle_command_ack lost, generation %u -> %u", last_generation,
 							_vehicle_command_ack_sub.get_last_generation());
 					}
 
@@ -2573,7 +2573,7 @@ void Mavlink::check_requested_subscriptions()
 #if defined(MAVLINK_UDP)
 
 				else if (get_protocol() == Protocol::UDP) {
-					PX4_DEBUG("stream %s on UDP port %d set to default rate", _subscribe_to_stream, _network_port);
+					PX4_DEBUG("stream %s on UDP port %hu set to default rate", _subscribe_to_stream, _network_port);
 				}
 
 #endif // MAVLINK_UDP
@@ -2593,7 +2593,7 @@ void Mavlink::check_requested_subscriptions()
 #if defined(MAVLINK_UDP)
 
 				else if (get_protocol() == Protocol::UDP) {
-					PX4_DEBUG("stream %s on UDP port %d enabled with rate %.1f Hz", _subscribe_to_stream, _network_port,
+					PX4_DEBUG("stream %s on UDP port %hu enabled with rate %.1f Hz", _subscribe_to_stream, _network_port,
 						  (double)_subscribe_to_stream_rate);
 				}
 
@@ -2608,7 +2608,7 @@ void Mavlink::check_requested_subscriptions()
 #if defined(MAVLINK_UDP)
 
 				else if (get_protocol() == Protocol::UDP) {
-					PX4_DEBUG("stream %s on UDP port %d disabled", _subscribe_to_stream, _network_port);
+					PX4_DEBUG("stream %s on UDP port %hu disabled", _subscribe_to_stream, _network_port);
 				}
 
 #endif // MAVLINK_UDP
@@ -2623,7 +2623,7 @@ void Mavlink::check_requested_subscriptions()
 #if defined(MAVLINK_UDP)
 
 			else if (get_protocol() == Protocol::UDP) {
-				PX4_ERR("stream %s on UDP port %d not found", _subscribe_to_stream, _network_port);
+				PX4_ERR("stream %s on UDP port %hu not found", _subscribe_to_stream, _network_port);
 			}
 
 #endif // MAVLINK_UDP
@@ -2668,7 +2668,7 @@ void Mavlink::configure_sik_radio()
 
 			if (_param_sik_radio_id.get() > 0) {
 				/* set channel */
-				fprintf(fs, "ATS3=%u\n", _param_sik_radio_id.get());
+				fprintf(fs, "ATS3=%" PRIu32 "\n", _param_sik_radio_id.get());
 				px4_usleep(200000);
 
 			} else {
@@ -2792,7 +2792,7 @@ Mavlink::display_status()
 		printf("\tGCS heartbeat valid\n");
 	}
 
-	printf("\tmavlink chan: #%u\n", _channel);
+	printf("\tmavlink chan: #%u\n", static_cast<unsigned>(_channel));
 
 	if (_tstatus.timestamp > 0) {
 
@@ -2800,13 +2800,13 @@ Mavlink::display_status()
 
 		if (_radio_status_available) {
 			printf("RADIO Link\n");
-			printf("\t  rssi:\t\t%d\n", _rstatus.rssi);
-			printf("\t  remote rssi:\t%u\n", _rstatus.remote_rssi);
-			printf("\t  txbuf:\t%u\n", _rstatus.txbuf);
-			printf("\t  noise:\t%d\n", _rstatus.noise);
-			printf("\t  remote noise:\t%u\n", _rstatus.remote_noise);
-			printf("\t  rx errors:\t%u\n", _rstatus.rxerrors);
-			printf("\t  fixed:\t%u\n", _rstatus.fix);
+			printf("\t  rssi:\t\t%" PRIu8 "\n", _rstatus.rssi);
+			printf("\t  remote rssi:\t%" PRIu8 "\n", _rstatus.remote_rssi);
+			printf("\t  txbuf:\t%" PRIu8 "\n", _rstatus.txbuf);
+			printf("\t  noise:\t%" PRIu8 "\n", _rstatus.noise);
+			printf("\t  remote noise:\t%" PRIu8 "\n", _rstatus.remote_noise);
+			printf("\t  rx errors:\t%" PRIu16 "\n", _rstatus.rxerrors);
+			printf("\t  fixed:\t%" PRIu16 "\n", _rstatus.fix);
 
 		} else if (_is_usb_uart) {
 			printf("USB CDC\n");
@@ -2838,7 +2838,7 @@ Mavlink::display_status()
 	       _ftp_on ? "YES" : "NO",
 	       _transmitting_enabled ? "YES" : "NO");
 	printf("\tmode: %s\n", mavlink_mode_str(_mode));
-	printf("\tMAVLink version: %i\n", _protocol_version);
+	printf("\tMAVLink version: %" PRId32 "\n", _protocol_version);
 
 	printf("\ttransport protocol: ");
 
@@ -2846,7 +2846,7 @@ Mavlink::display_status()
 #if defined(MAVLINK_UDP)
 
 	case Protocol::UDP:
-		printf("UDP (%i, remote port: %i)\n", _network_port, _remote_port);
+		printf("UDP (%hu, remote port: %hu)\n", _network_port, _remote_port);
 		printf("\tBroadcast enabled: %s\n",
 		       broadcast_enabled() ? "YES" : "NO");
 #if defined(CONFIG_NET_IGMP) && defined(CONFIG_NET_ROUTE)
@@ -2874,7 +2874,7 @@ Mavlink::display_status()
 		printf("\t  mean: %0.2f ms\n", (double)_ping_stats.mean_rtt);
 		printf("\t  max: %0.2f ms\n", (double)_ping_stats.max_rtt);
 		printf("\t  min: %0.2f ms\n", (double)_ping_stats.min_rtt);
-		printf("\t  dropped packets: %u\n", _ping_stats.dropped_packets);
+		printf("\t  dropped packets: %" PRIi32 "\n", _ping_stats.dropped_packets);
 	}
 }
 
@@ -2904,7 +2904,7 @@ Mavlink::display_status_streams()
 		printf("\t%-30s%-16s", stream->get_name(), rate_str);
 
 		if (size > 0) {
-			printf(" %3i\n", size);
+			printf(" %3u\n", size);
 
 		} else {
 			printf("\n");

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -562,7 +562,7 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 		send_ack = false;
 
 		if (msg->sysid == mavlink_system.sysid && msg->compid == mavlink_system.compid) {
-			PX4_WARN("ignoring CMD with same SYS/COMP (%d/%d) ID", mavlink_system.sysid, mavlink_system.compid);
+			PX4_WARN("ignoring CMD with same SYS/COMP (%" PRIu8 "/%" PRIu8 ") ID", mavlink_system.sysid, mavlink_system.compid);
 			return;
 		}
 
@@ -656,7 +656,7 @@ MavlinkReceiver::handle_message_command_ack(mavlink_message_t *msg)
 	// TODO: move it to the same place that sent the command
 	if (ack.result != MAV_RESULT_ACCEPTED && ack.result != MAV_RESULT_IN_PROGRESS) {
 		if (msg->compid == MAV_COMP_ID_CAMERA) {
-			PX4_WARN("Got unsuccessful result %d from camera", ack.result);
+			PX4_WARN("Got unsuccessful result %" PRIu8 " from camera", ack.result);
 		}
 	}
 }
@@ -946,7 +946,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 			setpoint.z = NAN;
 
 		} else {
-			mavlink_log_critical(&_mavlink_log_pub, "SET_POSITION_TARGET_LOCAL_NED coordinate frame %d unsupported",
+			mavlink_log_critical(&_mavlink_log_pub, "SET_POSITION_TARGET_LOCAL_NED coordinate frame %" PRIu8 " unsupported",
 					     target_local_ned.coordinate_frame);
 			return;
 		}
@@ -1054,7 +1054,7 @@ MavlinkReceiver::handle_message_set_position_target_global_int(mavlink_message_t
 				}
 
 			} else {
-				mavlink_log_critical(&_mavlink_log_pub, "SET_POSITION_TARGET_GLOBAL_INT invalid coordinate frame %d",
+				mavlink_log_critical(&_mavlink_log_pub, "SET_POSITION_TARGET_GLOBAL_INT invalid coordinate frame %" PRIu8,
 						     target_global_int.coordinate_frame);
 				return;
 			}
@@ -1299,7 +1299,7 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 		}
 
 	} else {
-		PX4_ERR("Body frame %u not supported. Unable to publish velocity", odom.child_frame_id);
+		PX4_ERR("Body frame %" PRIu8 " not supported. Unable to publish velocity", odom.child_frame_id);
 	}
 
 	/**
@@ -1330,11 +1330,11 @@ MavlinkReceiver::handle_message_odometry(mavlink_message_t *msg)
 			_mocap_odometry_pub.publish(odometry);
 
 		} else {
-			PX4_ERR("Estimator source %u not supported. Unable to publish pose and velocity", odom.estimator_type);
+			PX4_ERR("Estimator source %" PRIu8 " not supported. Unable to publish pose and velocity", odom.estimator_type);
 		}
 
 	} else {
-		PX4_ERR("Local frame %u not supported. Unable to publish pose and velocity", odom.frame_id);
+		PX4_ERR("Local frame %" PRIu8 " not supported. Unable to publish pose and velocity", odom.frame_id);
 	}
 }
 
@@ -1690,7 +1690,7 @@ MavlinkReceiver::handle_message_play_tune_v2(mavlink_message_t *msg)
 	    (mavlink_system.compid == play_tune_v2.target_component || play_tune_v2.target_component == 0)) {
 
 		if (play_tune_v2.format != TUNE_FORMAT_QBASIC1_1) {
-			PX4_ERR("Tune format %d not supported", play_tune_v2.format);
+			PX4_ERR("Tune format %" PRIu32 " not supported", play_tune_v2.format);
 			return;
 		}
 
@@ -2016,7 +2016,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 				break;
 
 			default:
-				PX4_DEBUG("unhandled HEARTBEAT MAV_TYPE: %d from SYSID: %d, COMPID: %d", hb.type, msg->sysid, msg->compid);
+				PX4_DEBUG("unhandled HEARTBEAT MAV_TYPE: %" PRIu8 " from SYSID: %" PRIu8 ", COMPID: %" PRIu8, hb.type, msg->sysid,
+					  msg->compid);
 			}
 
 
@@ -2055,7 +2056,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 				break;
 
 			default:
-				PX4_DEBUG("unhandled HEARTBEAT MAV_TYPE: %d from SYSID: %d, COMPID: %d", hb.type, msg->sysid, msg->compid);
+				PX4_DEBUG("unhandled HEARTBEAT MAV_TYPE: %" PRIu8 " from SYSID: %" PRIu8 ", COMPID: %" PRIu8, hb.type, msg->sysid,
+					  msg->compid);
 			}
 
 			CheckHeartbeats(now, true);
@@ -2313,7 +2315,7 @@ MavlinkReceiver::handle_message_landing_target(mavlink_message_t *msg)
 
 	} else if (landing_target.position_valid) {
 		// We only support MAV_FRAME_LOCAL_NED. In this case, the frame was unsupported.
-		mavlink_log_critical(&_mavlink_log_pub, "landing target: coordinate frame %d unsupported",
+		mavlink_log_critical(&_mavlink_log_pub, "landing target: coordinate frame %" PRIu8 " unsupported",
 				     landing_target.frame);
 
 	} else {
@@ -2792,7 +2794,8 @@ void MavlinkReceiver::handle_message_statustext(mavlink_message_t *msg)
 		log_message.timestamp = hrt_absolute_time();
 
 		snprintf(log_message.text, sizeof(log_message.text),
-			 "[mavlink: component %d] %." STRINGIFY(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN) "s", msg->compid, statustext.text);
+			 "[mavlink: component %" PRIu8 "] %." STRINGIFY(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN) "s", msg->compid,
+			 statustext.text);
 
 		_log_message_pub.publish(log_message);
 	}
@@ -3190,7 +3193,8 @@ void MavlinkReceiver::print_detailed_rx_stats() const
 	// TODO: add mutex around shared data.
 	for (unsigned i = 0; i < MAX_REMOTE_COMPONENTS; ++i) {
 		if (_component_states[i].received_messages > 0) {
-			printf("\t  received from sysid: %u compid: %u: %u, lost: %u, last %u ms ago\n",
+			printf("\t  received from sysid: %" PRIu8 " compid: %" PRIu8 ": %" PRIu32 ", lost: %" PRIu32 ", last %" PRIu32
+			       " ms ago\n",
 			       _component_states[i].system_id,
 			       _component_states[i].component_id,
 			       _component_states[i].received_messages,

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -151,7 +151,8 @@ static int micrortps_start(int argc, char *argv[])
 	case options::eTransports::UART: {
 			transport_node = new UART_node(_options.device, _options.baudrate, _options.poll_ms,
 						       _options.sw_flow_control, _options.hw_flow_control, _options.verbose_debug);
-			PX4_INFO("UART transport: device: %s; baudrate: %d; sleep: %dms; poll: %dms; flow_control: %s",
+			PX4_INFO("UART transport: device: %s; baudrate: %" PRIu32 "; sleep: %" PRIu32 "ms; poll: %" PRIu32
+				 "ms; flow_control: %s",
 				 _options.device, _options.baudrate, _options.sleep_ms, _options.poll_ms,
 				 _options.sw_flow_control ? "SW enabled" : (_options.hw_flow_control ? "HW enabled" : "No"));
 		}
@@ -160,7 +161,7 @@ static int micrortps_start(int argc, char *argv[])
 	case options::eTransports::UDP: {
 			transport_node = new UDP_node(_options.ip, _options.recv_port, _options.send_port,
 						      _options.verbose_debug);
-			PX4_INFO("UDP transport: ip address: %s; recv port: %u; send port: %u; sleep: %dms",
+			PX4_INFO("UDP transport: ip address: %s; recv port: %" PRIu16 "; send port: %" PRIu16 "; sleep: %" PRIu32 "ms",
 				 _options.ip, _options.recv_port, _options.send_port, _options.sleep_ms);
 
 		}

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2018, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1481,7 +1481,7 @@ Mission::read_mission_item(int offset, struct mission_item_s *mission_item)
 	const int current_index = _current_mission_index;
 	int index_to_read = current_index + offset;
 
-	int *mission_index_ptr = (offset == 0) ? &_current_mission_index : &index_to_read;
+	int *mission_index_ptr = (offset == 0) ? (int *) &_current_mission_index : &index_to_read;
 	const dm_item_t dm_item = (dm_item_t)_mission.dataman_id;
 
 	/* do not work on empty missions */
@@ -1495,7 +1495,7 @@ Mission::read_mission_item(int offset, struct mission_item_s *mission_item)
 		if (*mission_index_ptr < 0 || *mission_index_ptr >= (int)_mission.count) {
 			/* mission item index out of bounds - if they are equal, we just reached the end */
 			if ((*mission_index_ptr != (int)_mission.count) && (*mission_index_ptr != -1)) {
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission item index out of bound, index: %d, max: %d.",
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission item index out of bound, index: %d, max: %" PRIu16 ".",
 						     *mission_index_ptr, _mission.count);
 			}
 

--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -164,7 +164,7 @@ bool VehicleAcceleration::SensorSelectionUpdate(bool force)
 				if ((device_id != 0) && (device_id == sensor_selection.accel_device_id)) {
 
 					if (_sensor_sub.ChangeInstance(i) && _sensor_sub.registerCallback()) {
-						PX4_DEBUG("selected sensor changed %d -> %d", _calibration.device_id(), device_id);
+						PX4_DEBUG("selected sensor changed %" PRIu32 " -> %" PRIu32 "", _calibration.device_id(), device_id);
 
 						// clear bias and corrections
 						_bias.zero();
@@ -178,7 +178,7 @@ bool VehicleAcceleration::SensorSelectionUpdate(bool force)
 				}
 			}
 
-			PX4_ERR("unable to find or subscribe to selected sensor (%d)", sensor_selection.accel_device_id);
+			PX4_ERR("unable to find or subscribe to selected sensor (%" PRIu32 ")", sensor_selection.accel_device_id);
 			_calibration.set_device_id(0);
 		}
 	}
@@ -256,7 +256,7 @@ void VehicleAcceleration::Run()
 
 void VehicleAcceleration::PrintStatus()
 {
-	PX4_INFO("selected sensor: %d, rate: %.1f Hz, estimated bias: [%.4f %.4f %.4f]",
+	PX4_INFO("selected sensor: %" PRIu32 ", rate: %.1f Hz, estimated bias: [%.4f %.4f %.4f]",
 		 _calibration.device_id(), (double)_filter_sample_rate,
 		 (double)_bias(0), (double)_bias(1), (double)_bias(2));
 

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -207,7 +207,7 @@ void VehicleAirData::Run()
 			}
 
 			if (_selected_sensor_sub_index >= 0) {
-				PX4_INFO("%s switch from #%u -> #%d", "BARO", _selected_sensor_sub_index, best_index);
+				PX4_INFO("%s switch from #%" PRIu8 " -> #%d", "BARO", _selected_sensor_sub_index, best_index);
 			}
 
 			_selected_sensor_sub_index = best_index;
@@ -316,10 +316,11 @@ void VehicleAirData::Run()
 void VehicleAirData::PrintStatus()
 {
 	if (_selected_sensor_sub_index >= 0) {
-		PX4_INFO("selected barometer: %d (%d)", _last_data[_selected_sensor_sub_index].device_id, _selected_sensor_sub_index);
+		PX4_INFO("selected barometer: %" PRIu32 " (%" PRId8 ")", _last_data[_selected_sensor_sub_index].device_id,
+			 _selected_sensor_sub_index);
 
 		if (fabsf(_thermal_offset[_selected_sensor_sub_index]) > 0.f) {
-			PX4_INFO("%d temperature offset: %.4f", _last_data[_selected_sensor_sub_index].device_id,
+			PX4_INFO("%" PRIu32 " temperature offset: %.4f", _last_data[_selected_sensor_sub_index].device_id,
 				 (double)_thermal_offset[_selected_sensor_sub_index]);
 		}
 	}

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -265,7 +265,7 @@ bool VehicleAngularVelocity::SensorSelectionUpdate(bool force)
 				}
 			}
 
-			PX4_ERR("unable to find or subscribe to selected sensor (%d)", sensor_selection.gyro_device_id);
+			PX4_ERR("unable to find or subscribe to selected sensor (%" PRIu32 ")", sensor_selection.gyro_device_id);
 			_selected_sensor_device_id = 0;
 		}
 	}
@@ -784,7 +784,7 @@ void VehicleAngularVelocity::CalibrateAndPublish(bool publish, const hrt_abstime
 
 void VehicleAngularVelocity::PrintStatus()
 {
-	PX4_INFO("selected sensor: %d, rate: %.1f Hz %s",
+	PX4_INFO("selected sensor: %" PRIu32 ", rate: %.1f Hz %s",
 		 _selected_sensor_device_id, (double)_filter_sample_rate_hz, _fifo_available ? "FIFO" : "");
 	PX4_INFO("estimated bias: [%.4f %.4f %.4f]", (double)_bias(0), (double)_bias(1), (double)_bias(2));
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -119,10 +119,10 @@ void VehicleIMU::ParametersUpdate(bool force)
 
 		// constrain IMU integration time 1-10 milliseconds (100-1000 Hz)
 		int32_t imu_integration_rate_hz = constrain(_param_imu_integ_rate.get(),
-						  100, math::max(_param_imu_gyro_ratemax.get(), 1000));
+						  (int32_t)100, math::max(_param_imu_gyro_ratemax.get(), (int32_t) 1000));
 
 		if (imu_integration_rate_hz != _param_imu_integ_rate.get()) {
-			PX4_WARN("IMU_INTEG_RATE updated %d -> %d", _param_imu_integ_rate.get(), imu_integration_rate_hz);
+			PX4_WARN("IMU_INTEG_RATE updated %" PRId32 " -> %" PRIu32, _param_imu_integ_rate.get(), imu_integration_rate_hz);
 			_param_imu_integ_rate.set(imu_integration_rate_hz);
 			_param_imu_integ_rate.commit_no_notification();
 		}
@@ -322,7 +322,7 @@ bool VehicleIMU::UpdateAccel()
 				const uint64_t clipping_total = _status.accel_clipping[0] + _status.accel_clipping[1] + _status.accel_clipping[2];
 
 				if (clipping_total > _last_clipping_notify_total_count + 1000) {
-					mavlink_log_critical(&_mavlink_log_pub, "Accel %d clipping, not safe to fly!", _instance);
+					mavlink_log_critical(&_mavlink_log_pub, "Accel %" PRIu8 " clipping, not safe to fly!", _instance);
 					_last_clipping_notify_time = accel.timestamp_sample;
 					_last_clipping_notify_total_count = clipping_total;
 				}
@@ -530,7 +530,8 @@ void VehicleIMU::UpdateIntegratorConfiguration()
 				_intervals_configured = true;
 				_update_integrator_config = false;
 
-				PX4_DEBUG("accel (%d), gyro (%d), accel samples: %d, gyro samples: %d, accel interval: %.1f, gyro interval: %.1f sub samples: %d",
+				PX4_DEBUG("accel (%" PRIu32 "), gyro (%" PRIu32 "), accel samples: %" PRIu8 ", gyro samples: %" PRIu8
+					  ", accel interval: %.1f, gyro interval: %.1f sub samples: %d",
 					  _accel_calibration.device_id(), _gyro_calibration.device_id(), accel_integral_samples, gyro_integral_samples,
 					  (double)_accel_interval_us, (double)_gyro_interval_us, n);
 
@@ -564,8 +565,10 @@ void VehicleIMU::UpdateGyroVibrationMetrics(const Vector3f &delta_angle)
 
 void VehicleIMU::PrintStatus()
 {
-	PX4_INFO("%d - Accel ID: %d, interval: %.1f us (SD %.1f us), Gyro ID: %d, interval: %.1f us (SD %.1f us)", _instance,
-		 _accel_calibration.device_id(), (double)_accel_interval_us, (double)sqrtf(_accel_interval_best_variance),
+
+	PX4_INFO("%" PRIu8 " - Accel ID: %" PRIu32 ", interval: %.1f us (SD %.1f us), Gyro ID: %" PRIu32
+		 ", interval: %.1f us (SD %.1f us)",
+		 _instance, _accel_calibration.device_id(), (double)_accel_interval_us, (double)sqrtf(_accel_interval_best_variance),
 		 _gyro_calibration.device_id(), (double)_gyro_interval_us, (double)sqrtf(_gyro_interval_best_variance));
 
 	perf_print_counter(_accel_generation_gap_perf);

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020, 2001 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -217,7 +217,7 @@ void VehicleMagnetometer::MagCalibrationUpdate()
 
 					if (_calibration[mag_index].set_offset(mag_cal_offset)) {
 
-						PX4_INFO("%d (%d) EST:%d offset committed: [%.2f %.2f %.2f]->[%.2f %.2f %.2f] (full [%.2f %.2f %.2f])",
+						PX4_INFO("%d (%" PRIu32 ") EST:%d offset committed: [%.2f %.2f %.2f]->[%.2f %.2f %.2f] (full [%.2f %.2f %.2f])",
 							 mag_index, _calibration[mag_index].device_id(), i,
 							 (double)mag_cal_orig(0), (double)mag_cal_orig(1), (double)mag_cal_orig(2),
 							 (double)mag_cal_offset(0), (double)mag_cal_offset(1), (double)mag_cal_offset(2),
@@ -375,7 +375,7 @@ void VehicleMagnetometer::Run()
 
 			if (_param_sens_mag_mode.get()) {
 				if (_selected_sensor_sub_index >= 0) {
-					PX4_INFO("%s switch from #%u -> #%d", "MAG", _selected_sensor_sub_index, best_index);
+					PX4_INFO("%s switch from #%" PRId8 " -> #%d", "MAG", _selected_sensor_sub_index, best_index);
 				}
 			}
 
@@ -530,7 +530,7 @@ void VehicleMagnetometer::calcMagInconsistency()
 void VehicleMagnetometer::PrintStatus()
 {
 	if (_selected_sensor_sub_index >= 0) {
-		PX4_INFO("selected magnetometer: %d (%d)", _last_data[_selected_sensor_sub_index].device_id,
+		PX4_INFO("selected magnetometer: %" PRIu32 " (%" PRId8 ")", _last_data[_selected_sensor_sub_index].device_id,
 			 _selected_sensor_sub_index);
 	}
 

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,7 +106,8 @@ void VotedSensorsUpdate::parametersUpdate()
 					} else {
 						// change relative priority to incorporate any sensor faults
 						int priority_change = _accel.priority_configured[uorb_index] - accel_priority_old;
-						_accel.priority[uorb_index] = math::constrain(_accel.priority[uorb_index] + priority_change, 1, 100);
+						_accel.priority[uorb_index] = math::constrain(_accel.priority[uorb_index] + priority_change, static_cast<int32_t>(1),
+									      static_cast<int32_t>(100));
 					}
 				}
 			}
@@ -128,7 +129,8 @@ void VotedSensorsUpdate::parametersUpdate()
 					} else {
 						// change relative priority to incorporate any sensor faults
 						int priority_change = _gyro.priority_configured[uorb_index] - gyro_priority_old;
-						_gyro.priority[uorb_index] = math::constrain(_gyro.priority[uorb_index] + priority_change, 1, 100);
+						_gyro.priority[uorb_index] = math::constrain(_gyro.priority[uorb_index] + priority_change, static_cast<int32_t>(1),
+									     static_cast<int32_t>(100));
 					}
 				}
 			}
@@ -355,11 +357,11 @@ void VotedSensorsUpdate::initSensorClass(SensorData &sensor_data, uint8_t sensor
 
 void VotedSensorsUpdate::printStatus()
 {
-	PX4_INFO("selected gyro: %d (%d)", _selection.gyro_device_id, _gyro.last_best_vote);
+	PX4_INFO("selected gyro: %" PRIu32 " (%" PRIu8 ")", _selection.gyro_device_id, _gyro.last_best_vote);
 	_gyro.voter.print();
 
 	PX4_INFO_RAW("\n");
-	PX4_INFO("selected accel: %d (%d)", _selection.accel_device_id, _accel.last_best_vote);
+	PX4_INFO("selected accel: %" PRIu32 " (%" PRIu8 ")", _selection.accel_device_id, _accel.last_best_vote);
 	_accel.voter.print();
 }
 

--- a/src/modules/temperature_compensation/TemperatureCompensation.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensation.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -433,38 +433,38 @@ int TemperatureCompensation::update_offsets_baro(int topic_instance, float tempe
 void TemperatureCompensation::print_status()
 {
 	PX4_INFO("Temperature Compensation:");
-	PX4_INFO(" gyro: enabled: %i", _parameters.gyro_tc_enable);
+	PX4_INFO(" gyro: enabled: %" PRId32, _parameters.gyro_tc_enable);
 
 	if (_parameters.gyro_tc_enable == 1) {
 		for (int i = 0; i < GYRO_COUNT_MAX; ++i) {
 			uint8_t mapping = _gyro_data.device_mapping[i];
 
 			if (_gyro_data.device_mapping[i] != 255) {
-				PX4_INFO("  using device ID %i for topic instance %i", _parameters.gyro_cal_data[mapping].ID, i);
+				PX4_INFO("  using device ID %" PRId32 " for topic instance %i", _parameters.gyro_cal_data[mapping].ID, i);
 			}
 		}
 	}
 
-	PX4_INFO(" accel: enabled: %i", _parameters.accel_tc_enable);
+	PX4_INFO(" accel: enabled: %" PRId32, _parameters.accel_tc_enable);
 
 	if (_parameters.accel_tc_enable == 1) {
 		for (int i = 0; i < ACCEL_COUNT_MAX; ++i) {
 			uint8_t mapping = _accel_data.device_mapping[i];
 
 			if (_accel_data.device_mapping[i] != 255) {
-				PX4_INFO("  using device ID %i for topic instance %i", _parameters.accel_cal_data[mapping].ID, i);
+				PX4_INFO("  using device ID %" PRId32 " for topic instance %i", _parameters.accel_cal_data[mapping].ID, i);
 			}
 		}
 	}
 
-	PX4_INFO(" baro: enabled: %i", _parameters.baro_tc_enable);
+	PX4_INFO(" baro: enabled: %" PRId32, _parameters.baro_tc_enable);
 
 	if (_parameters.baro_tc_enable == 1) {
 		for (int i = 0; i < BARO_COUNT_MAX; ++i) {
 			uint8_t mapping = _baro_data.device_mapping[i];
 
 			if (_baro_data.device_mapping[i] != 255) {
-				PX4_INFO("  using device ID %i for topic instance %i", _parameters.baro_cal_data[mapping].ID, i);
+				PX4_INFO("  using device ID %" PRId32 " for topic instance %i", _parameters.baro_cal_data[mapping].ID, i);
 			}
 		}
 	}

--- a/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
+++ b/src/modules/temperature_compensation/TemperatureCompensationModule.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,7 +66,8 @@ void TemperatureCompensationModule::parameters_update()
 			int temp = _temperature_compensation.set_sensor_id_gyro(report.device_id, uorb_index);
 
 			if (temp < 0) {
-				PX4_INFO("No temperature calibration available for gyro %i (device id %u)", uorb_index, report.device_id);
+				PX4_INFO("No temperature calibration available for gyro %" PRIu8 " (device id %" PRIu32 ")", uorb_index,
+					 report.device_id);
 				_corrections.gyro_device_ids[uorb_index] = 0;
 
 			} else {
@@ -83,7 +84,8 @@ void TemperatureCompensationModule::parameters_update()
 			int temp = _temperature_compensation.set_sensor_id_accel(report.device_id, uorb_index);
 
 			if (temp < 0) {
-				PX4_INFO("No temperature calibration available for accel %i (device id %u)", uorb_index, report.device_id);
+				PX4_INFO("No temperature calibration available for accel %" PRIu8 " (device id %" PRIu32 ")", uorb_index,
+					 report.device_id);
 				_corrections.accel_device_ids[uorb_index] = 0;
 
 			} else {
@@ -100,7 +102,8 @@ void TemperatureCompensationModule::parameters_update()
 			int temp = _temperature_compensation.set_sensor_id_baro(report.device_id, uorb_index);
 
 			if (temp < 0) {
-				PX4_INFO("No temperature calibration available for baro %i (device id %u)", uorb_index, report.device_id);
+				PX4_INFO("No temperature calibration available for baro %" PRIu8 " (device id %" PRIu32 ")", uorb_index,
+					 report.device_id);
 				_corrections.baro_device_ids[uorb_index] = 0;
 
 			} else {

--- a/src/modules/temperature_compensation/temperature_calibration/task.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/task.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2017, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -116,7 +116,7 @@ void TemperatureCalibration::task_main()
 
 	int32_t min_temp_rise = 24;
 	param_get(param_find("SYS_CAL_TDEL"), &min_temp_rise);
-	PX4_INFO("Waiting for %i degrees difference in sensor temperature", min_temp_rise);
+	PX4_INFO("Waiting for %" PRId32 " degrees difference in sensor temperature", min_temp_rise);
 
 	int32_t min_start_temp = 5;
 	param_get(param_find("SYS_CAL_TMIN"), &min_start_temp);

--- a/src/modules/vmount/vmount.cpp
+++ b/src/modules/vmount/vmount.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2020, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -289,7 +289,7 @@ static int vmount_thread_main(int argc, char *argv[])
 					break;
 
 				default:
-					PX4_ERR("invalid input mode %i", params.mnt_mode_in);
+					PX4_ERR("invalid input mode %" PRId32, params.mnt_mode_in);
 					break;
 				}
 			}
@@ -323,7 +323,7 @@ static int vmount_thread_main(int argc, char *argv[])
 				break;
 
 			default:
-				PX4_ERR("invalid output mode %i", params.mnt_mode_out);
+				PX4_ERR("invalid output mode %" PRId32, params.mnt_mode_out);
 				thread_should_exit = true;
 				break;
 			}

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2015, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ struct Params {
 	float dec_to_pitch_i;
 	float back_trans_dec_sp;
 	bool vt_mc_on_fmu;
-	int vt_forward_thrust_enable_mode;
+	int32_t vt_forward_thrust_enable_mode;
 	float mpc_land_alt1;
 	float mpc_land_alt2;
 };

--- a/src/systemcmds/bl_update/bl_update.c
+++ b/src/systemcmds/bl_update/bl_update.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012, 2013 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012, 2013, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,7 @@
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/module.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -127,7 +128,7 @@ bl_update_main(int argc, char *argv[])
 	/* sanity-check file size */
 	if (s.st_size > BL_FILE_SIZE_LIMIT)
 	{
-		PX4_ERR("%s: file too large (limit: %u, actual: %d)", argv[1], BL_FILE_SIZE_LIMIT, s.st_size);
+		PX4_ERR("%s: file too large (limit: %u, actual: %jd)", argv[1], BL_FILE_SIZE_LIMIT, (intmax_t) s.st_size);
 		close(fd);
 		return 1;
 	}
@@ -145,7 +146,7 @@ bl_update_main(int argc, char *argv[])
 
 	if (buf == NULL)
 	{
-		PX4_ERR("failed to allocate %u bytes for firmware buffer", file_size);
+		PX4_ERR("failed to allocate %jd bytes for firmware buffer", (intmax_t) file_size);
 		close(fd);
 		return 1;
 	}

--- a/src/systemcmds/hardfault_log/hardfault_log.c
+++ b/src/systemcmds/hardfault_log/hardfault_log.c
@@ -44,6 +44,7 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -254,16 +255,16 @@ static int write_stack_detail(bool inValid, _stack_s *si, char *sp_name,
 	int n = 0;
 	uint32_t sbot = si->top - si->size;
 	n =   snprintf(&buffer[n], max - n, " %s stack: \n", sp_name);
-	n +=  snprintf(&buffer[n], max - n, "  top:    0x%08x\n", si->top);
-	n +=  snprintf(&buffer[n], max - n, "  sp:     0x%08x %s\n", si->sp, (inValid ? "Invalid" : "Valid"));
+	n +=  snprintf(&buffer[n], max - n, "  top:    0x%08" PRIu32 "\n", si->top);
+	n +=  snprintf(&buffer[n], max - n, "  sp:     0x%08" PRIu32 " %s\n", si->sp, (inValid ? "Invalid" : "Valid"));
 
 	if (n != write(fd, buffer, n)) {
 		return -EIO;
 	}
 
 	n = 0;
-	n +=  snprintf(&buffer[n], max - n, "  bottom: 0x%08x\n", sbot);
-	n +=  snprintf(&buffer[n], max - n, "  size:   0x%08x\n",  si->size);
+	n +=  snprintf(&buffer[n], max - n, "  bottom: 0x%08" PRIu32 "\n", sbot);
+	n +=  snprintf(&buffer[n], max - n, "  size:   0x%08" PRIu32 "\n",  si->size);
 
 	if (n != write(fd, buffer, n)) {
 		return -EIO;
@@ -275,10 +276,11 @@ static int write_stack_detail(bool inValid, _stack_s *si, char *sp_name,
 	tcb.adj_stack_size = si->size;
 
 	if (verify_ram_address(sbot, si->size)) {
-		n = snprintf(buffer, max,         "  used:   %08x\n", up_check_tcbstack(&tcb));
+		n = snprintf(buffer, max,         "  used:   %08zu\n", up_check_tcbstack(&tcb));
 
 	} else {
-		n = snprintf(buffer, max,         "Invalid Stack! (Corrupted TCB)  Stack base:  %08x Stack size:  %08x\n", sbot,
+		n = snprintf(buffer, max,         "Invalid Stack! (Corrupted TCB)  Stack base:  %08" PRIu32 " Stack size:  %08" PRIu32
+			     "\n", sbot,
 			     si->size);
 	}
 
@@ -348,7 +350,7 @@ static int  write_stack(bool inValid, int winsize, uint32_t wtopaddr,
 						marker[0] = '\0';
 					}
 
-					n = snprintf(buffer, max, "0x%08x 0x%08x%s\n", wtopaddr, stack[i], marker);
+					n = snprintf(buffer, max, "0x%08" PRIu32 " 0x%08" PRIu32 "%s\n", wtopaddr, stack[i], marker);
 
 					if (n != write(outfd, buffer, n)) {
 						ret = -EIO;
@@ -368,7 +370,9 @@ static int  write_stack(bool inValid, int winsize, uint32_t wtopaddr,
  ****************************************************************************/
 static int write_registers(uint32_t regs[], char *buffer, int max, int fd)
 {
-	int n = snprintf(buffer, max, " r0:0x%08x r1:0x%08x  r2:0x%08x  r3:0x%08x  r4:0x%08x  r5:0x%08x r6:0x%08x r7:0x%08x\n",
+	int n = snprintf(buffer, max,
+			 " r0:0x%08" PRIu32 " r1:0x%08" PRIu32 "  r2:0x%08" PRIu32 "  r3:0x%08" PRIu32 "  r4:0x%08" PRIu32 "  r5:0x%08" PRIu32
+			 " r6:0x%08" PRIu32 " r7:0x%08" PRIu32 "\n",
 			 regs[REG_R0],  regs[REG_R1],
 			 regs[REG_R2],  regs[REG_R3],
 			 regs[REG_R4],  regs[REG_R5],
@@ -378,7 +382,9 @@ static int write_registers(uint32_t regs[], char *buffer, int max, int fd)
 		return -EIO;
 	}
 
-	n  = snprintf(buffer, max, " r8:0x%08x r9:0x%08x r10:0x%08x r11:0x%08x r12:0x%08x  sp:0x%08x lr:0x%08x pc:0x%08x\n",
+	n  = snprintf(buffer, max,
+		      " r8:0x%08" PRIu32 " r9:0x%08" PRIu32 " r10:0x%08" PRIu32 " r11:0x%08" PRIu32 " r12:0x%08" PRIu32 "  sp:0x%08" PRIu32
+		      " lr:0x%08" PRIu32 " pc:0x%08" PRIu32 "\n",
 		      regs[REG_R8],  regs[REG_R9],
 		      regs[REG_R10], regs[REG_R11],
 		      regs[REG_R12], regs[REG_R13],
@@ -389,11 +395,11 @@ static int write_registers(uint32_t regs[], char *buffer, int max, int fd)
 	}
 
 #ifdef CONFIG_ARMV7M_USEBASEPRI
-	n = snprintf(buffer, max, " xpsr:0x%08x basepri:0x%08x control:0x%08x\n",
+	n = snprintf(buffer, max, " xpsr:0x%08" PRIu32 " basepri:0x%08" PRIu32 " control:0x%08" PRIu32 "\n",
 		     regs[REG_XPSR],  regs[REG_BASEPRI],
 		     getcontrol());
 #else
-	n = snprintf(buffer, max, " xpsr:0x%08x primask:0x%08x control:0x%08x\n",
+	n = snprintf(buffer, max, " xpsr:0x%08" PRIu32 " primask:0x%08" PRIu32 " control:0x%08" PRIu32 "\n",
 		     regs[REG_XPSR],  regs[REG_PRIMASK],
 		     getcontrol());
 #endif
@@ -403,7 +409,7 @@ static int write_registers(uint32_t regs[], char *buffer, int max, int fd)
 	}
 
 #ifdef REG_EXC_RETURN
-	n = snprintf(buffer, max, " exe return:0x%08x\n", regs[REG_EXC_RETURN]);
+	n = snprintf(buffer, max, " exe return:0x%08" PRIu32 "\n", regs[REG_EXC_RETURN]);
 
 	if (n != write(fd, buffer, n)) {
 		return -EIO;
@@ -419,9 +425,12 @@ static int write_registers(uint32_t regs[], char *buffer, int max, int fd)
 static int write_fault_registers(fault_regs_s *fault_regs, char *buffer, int max, int fd)
 {
 #if defined(CONFIG_ARCH_CORTEXM7)
-	const char fmt[] =  " cfsr:0x%08x hfsr:0x%08x  dfsr:0x%08x  mmfsr:0x%08x  bfsr:0x%08x afsr:0x%08x abfsr:0x%08x \n";
+	const char fmt[] =
+		" cfsr:0x%08" PRIu32 " hfsr:0x%08" PRIu32 "  dfsr:0x%08" PRIu32 "  mmfsr:0x%08" PRIu32 "  bfsr:0x%08" PRIu32
+		" afsr:0x%08" PRIu32 " abfsr:0x%08" PRIu32 " \n";
 #else
-	const char fmt[] =  " cfsr:0x%08x hfsr:0x%08x  dfsr:0x%08x  mmfsr:0x%08x  bfsr:0x%08x afsr:0x%08x\n";
+	const char fmt[] =  " cfsr:0x%08" PRIu32 " hfsr:0x%08" PRIu32 "  dfsr:0x%08" PRIu32 "  mmfsr:0x%08" PRIu32
+			    "  bfsr:0x%08" PRIu32 " afsr:0x%08" PRIu32 "\n";
 #endif
 	int n = snprintf(buffer, max, fmt,
 			 fault_regs->cfsr, fault_regs->hfsr, fault_regs->dfsr,
@@ -861,7 +870,7 @@ static int hardfault_commit(char *caller)
 
 			if (state != OK) {
 				identify(caller);
-				syslog(LOG_INFO, "Nothing to save\n", path);
+				syslog(LOG_INFO, "Nothing to save\n");
 				ret = -ENOENT;
 
 			} else {
@@ -1065,8 +1074,8 @@ __EXPORT int hardfault_check_status(char *caller)
 		} else {
 			ret = state;
 			identify(caller);
-			syslog(LOG_INFO, "Fault Log info File No %d Length %d flags:0x%02x state:%d\n",
-			       (unsigned int)desc.fileno, (unsigned int) desc.len, (unsigned int)desc.flags, state);
+			syslog(LOG_INFO, "Fault Log info File No %" PRIu8 " Length %" PRIu8 " flags:0x%02" PRIu16 " state:%d\n",
+			       desc.fileno, desc.len, desc.flags, state);
 
 			if (state == OK) {
 				char buf[TIME_FMT_LEN + 1];

--- a/src/systemcmds/mtd/mtd.cpp
+++ b/src/systemcmds/mtd/mtd.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2014, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,6 +46,7 @@
 #include <px4_platform_common/px4_mtd.h>
 #include <px4_platform_common/getopt.h>
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -112,7 +113,7 @@ static int mtd_status(void)
 						ret = instances[i].part_dev[p]->ioctl(instances[i].part_dev[p], MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
 						printf("    partition: %u:\n", p);
 						printf("     name:   %s\n", instances[i].partition_names[p]);
-						printf("     blocks: %u (%u bytes)\n", geo.neraseblocks, erasesize * geo.neraseblocks);
+						printf("     blocks: %" PRIu32 " (%lu bytes)\n", geo.neraseblocks, erasesize * geo.neraseblocks);
 						totalnblocks += geo.neraseblocks;
 						totalpartsize += erasesize * geo.neraseblocks;
 					}
@@ -175,7 +176,7 @@ int mtd_erase(mtd_instance_s &instance)
 			count += sizeof(v);
 		}
 
-		printf("Erased %lu bytes\n", (unsigned long)count);
+		printf("Erased %" PRIu32 " bytes\n", count);
 		close(fd);
 	}
 
@@ -203,7 +204,7 @@ int mtd_readtest(const mtd_instance_s &instance)
 			return 1;
 		}
 
-		printf("reading %s expecting %u bytes\n", instance.partition_names[i], expected_size);
+		printf("reading %s expecting %zd bytes\n", instance.partition_names[i], expected_size);
 		int fd = open(instance.partition_names[i], O_RDONLY);
 
 		if (fd == -1) {
@@ -216,7 +217,7 @@ int mtd_readtest(const mtd_instance_s &instance)
 		}
 
 		if (count != expected_size) {
-			PX4_ERR("Failed to read partition - got %u/%u bytes", count, expected_size);
+			PX4_ERR("Failed to read partition - got %zd/%zd bytes", count, expected_size);
 			return 1;
 		}
 
@@ -248,7 +249,7 @@ int mtd_rwtest(const mtd_instance_s &instance)
 			return 1;
 		}
 
-		printf("rwtest %s testing %u bytes\n", instance.partition_names[i], expected_size);
+		printf("rwtest %s testing %zd bytes\n", instance.partition_names[i], expected_size);
 		int fd = open(instance.partition_names[i], O_RDWR);
 
 		if (fd == -1) {
@@ -288,7 +289,7 @@ int mtd_rwtest(const mtd_instance_s &instance)
 		}
 
 		if (count != expected_size) {
-			PX4_ERR("Failed to read partition - got %u/%u bytes", count, expected_size);
+			PX4_ERR("Failed to read partition - got %zd/%zd bytes", count, expected_size);
 			return 1;
 		}
 

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -518,7 +518,7 @@ do_show_for_airframe()
 	int32_t sys_autostart = 0;
 	param_get(param_find("SYS_AUTOSTART"), &sys_autostart);
 	if (sys_autostart != 0) {
-		PARAM_PRINT("# Make sure to add all params from the current airframe (ID=%i) as well\n", sys_autostart);
+		PARAM_PRINT("# Make sure to add all params from the current airframe (ID=%" PRId32 ") as well\n", sys_autostart);
 	}
 	return 0;
 }

--- a/src/systemcmds/pwm/pwm.cpp
+++ b/src/systemcmds/pwm/pwm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013, 2014, 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013, 2014, 2017, 2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,7 @@
 #include <px4_platform_common/cli.h>
 
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
@@ -279,7 +280,7 @@ pwm_main(int argc, char *argv[])
 
 		for (unsigned i = 0; i < PWM_OUTPUT_MAX_CHANNELS; i++) {
 			if (set_mask & 1 << i) {
-				printf("%d ", i + 1);
+				printf("%u ", i + 1);
 			}
 		}
 
@@ -924,17 +925,17 @@ err_out_no_test:
 			ret = px4_ioctl(fd, PWM_SERVO_GET(i), (unsigned long)&spos);
 
 			if (ret == OK) {
-				printf("channel %u: %u us", i + 1, spos);
+				printf("channel %u: %" PRIu16 " us", i + 1, spos);
 
 				if (info_alt_rate_mask & (1 << i)) {
-					printf(" (alternative rate: %d Hz", info_alt_rate);
+					printf(" (alternative rate: %" PRIu32 " Hz", info_alt_rate);
 
 				} else {
-					printf(" (default rate: %d Hz", info_default_rate);
+					printf(" (default rate: %" PRIu32 " Hz", info_default_rate);
 				}
 
 
-				printf(" failsafe: %d, disarmed: %d us, min: %d us, max: %d us, trim: %5.2f)",
+				printf(" failsafe: %d, disarmed: %" PRIu16 " us, min: %" PRIu16 " us, max: %" PRIu16 " us, trim: %5.2f)",
 				       failsafe_pwm.values[i], disarmed_pwm.values[i], min_pwm.values[i], max_pwm.values[i],
 				       (double)((int16_t)(trim_pwm.values[i]) / 10000.0f));
 				printf("\n");

--- a/src/systemcmds/reflect/reflect.c
+++ b/src/systemcmds/reflect/reflect.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014 Andrew Tridgell. All rights reserved.
+ *   Copyright (c) 2014, 2021 Andrew Tridgell. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,6 +40,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <inttypes.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
@@ -76,7 +77,7 @@ static uint32_t allocate_blocks(struct block **blocks)
 		nblocks++;
 	}
 
-	printf("Allocated %u blocks\n", nblocks);
+	printf("Allocated %" PRIu32 " blocks\n", nblocks);
 
 	return nblocks;
 }

--- a/src/systemcmds/tests/test_adc.cpp
+++ b/src/systemcmds/tests/test_adc.cpp
@@ -52,12 +52,12 @@ int test_adc(int argc, char *argv[])
 	px4_usleep(50000);	// sleep 50ms and wait for adc report
 
 	if (_adc_sub.update(&adc)) {
-		PX4_INFO_RAW("DeviceID: %d\n", adc.device_id);
-		PX4_INFO_RAW("Resolution: %d\n", adc.resolution);
+		PX4_INFO_RAW("DeviceID: %" PRIu32 "\n", adc.device_id);
+		PX4_INFO_RAW("Resolution: %" PRIu32 "\n", adc.resolution);
 		PX4_INFO_RAW("Voltage Reference: %f\n", adc.v_ref);
 
 		for (int i = 0; i < PX4_MAX_ADC_CHANNELS; ++i) {
-			PX4_INFO_RAW("%d: %d  ", adc.channel_id[i], adc.raw_data[i]);
+			PX4_INFO_RAW("%" PRIu16 ": %" PRIi32 "  ", adc.channel_id[i], adc.raw_data[i]);
 		}
 
 		PX4_INFO_RAW("\n");

--- a/src/systemcmds/tests/test_bson.cpp
+++ b/src/systemcmds/tests/test_bson.cpp
@@ -36,9 +36,8 @@
  * Tests for the bson en/decoder
  */
 
-#include <inttypes.h>
-
 #include <px4_platform_common/defines.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/systemcmds/tests/test_bson.cpp
+++ b/src/systemcmds/tests/test_bson.cpp
@@ -124,7 +124,7 @@ decode_callback(bson_decoder_t decoder, void *priv, bson_node_t node)
 		}
 
 		if (node->i != sample_small_int) {
-			PX4_ERR("FAIL: decoder: int1 value %" PRIu64 ", expected %d", node->i, sample_small_int);
+			PX4_ERR("FAIL: decoder: int1 value %" PRIu64 ", expected %" PRIi32 "", node->i, sample_small_int);
 			return 1;
 		}
 

--- a/src/systemcmds/tests/test_file2.c
+++ b/src/systemcmds/tests/test_file2.c
@@ -39,6 +39,7 @@
 #include <px4_platform_common/defines.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <unistd.h>
@@ -70,8 +71,8 @@ static uint8_t get_value(uint32_t ofs)
 
 static int test_corruption(const char *filename, uint32_t write_chunk, uint32_t write_size, uint16_t flags)
 {
-	printf("Testing on %s with write_chunk=%u write_size=%u\n",
-	       filename, (unsigned)write_chunk, (unsigned)write_size);
+	printf("Testing on %s with write_chunk=%" PRIu32 " write_size=%" PRIu32 "\n",
+	       filename, write_chunk, write_size);
 
 	uint32_t ofs = 0;
 	int fd = open(filename, O_CREAT | O_RDWR | O_TRUNC, PX4_O_MODE_666);
@@ -93,7 +94,7 @@ static int test_corruption(const char *filename, uint32_t write_chunk, uint32_t 
 		}
 
 		if (write(fd, buffer, sizeof(buffer)) != (int)sizeof(buffer)) {
-			printf("write failed at offset %u\n", ofs);
+			printf("write failed at offset %" PRIu32 "\n", ofs);
 			return 1;
 		}
 
@@ -102,7 +103,7 @@ static int test_corruption(const char *filename, uint32_t write_chunk, uint32_t 
 		}
 
 		if (counter % 100 == 0) {
-			printf("write ofs=%u\r", ofs);
+			printf("write ofs=%" PRIu32 "\r", ofs);
 		}
 
 		counter++;
@@ -110,7 +111,7 @@ static int test_corruption(const char *filename, uint32_t write_chunk, uint32_t 
 
 	close(fd);
 
-	printf("write ofs=%u\n", ofs);
+	printf("write ofs=%" PRIu32 "\n", ofs);
 
 	// read and check
 	fd = open(filename, O_RDONLY);
@@ -127,20 +128,20 @@ static int test_corruption(const char *filename, uint32_t write_chunk, uint32_t 
 		uint8_t buffer[write_chunk];
 
 		if (counter % 100 == 0) {
-			printf("read ofs=%u\r", ofs);
+			printf("read ofs=%" PRIu32 "\r", ofs);
 		}
 
 		counter++;
 
 		if (read(fd, buffer, sizeof(buffer)) != (int)sizeof(buffer)) {
-			printf("read failed at offset %u\n", ofs);
+			printf("read failed at offset %" PRIu32 "\n", ofs);
 			close(fd);
 			return 1;
 		}
 
 		for (uint16_t j = 0; j < write_chunk; j++) {
 			if (buffer[j] != get_value(ofs)) {
-				printf("corruption at ofs=%u got %u\n", ofs, buffer[j]);
+				printf("corruption at ofs=%" PRIu32 " got %" PRIu8 "\n", ofs, buffer[j]);
 				close(fd);
 				return 1;
 			}
@@ -153,7 +154,7 @@ static int test_corruption(const char *filename, uint32_t write_chunk, uint32_t 
 		}
 	}
 
-	printf("read ofs=%u\n", ofs);
+	printf("read ofs=%" PRIu32 "\n", ofs);
 	close(fd);
 	unlink(filename);
 	printf("All OK\n");

--- a/src/systemcmds/tests/test_i2c_spi_cli.cpp
+++ b/src/systemcmds/tests/test_i2c_spi_cli.cpp
@@ -196,17 +196,17 @@ bool I2CSPICLITest::test_custom()
 		int T = 0;
 		int a = 0;
 
-		while ((ch = cli.getopt(cli_args.argc, cli_args.argv, "T:a:")) != EOF) {
+		while ((ch = cli.getOpt(cli_args.argc, cli_args.argv, "T:a:")) != EOF) {
 			switch (ch) {
-			case 'T': T = atoi(cli.optarg());
+			case 'T': T = atoi(cli.optArg());
 				break;
 
-			case 'a': a = atoi(cli.optarg());
+			case 'a': a = atoi(cli.optArg());
 				break;
 			}
 		}
 
-		const char *verb = cli.optarg();
+		const char *verb = cli.optArg();
 		ut_assert_true(verb != nullptr);
 		ut_assert_true(strcmp(verb, "start") == 0);
 		ut_assert_true(T == 432);
@@ -222,14 +222,14 @@ bool I2CSPICLITest::test_custom()
 		CLIArgsHelper cli_args(argv, 1);
 		int ch;
 
-		while ((ch = cli.getopt(cli_args.argc, cli_args.argv, "I:")) != EOF) {
+		while ((ch = cli.getOpt(cli_args.argc, cli_args.argv, "I:")) != EOF) {
 			switch (ch) {
 			case 'I': ut_assert_true(false); // must not get here, because 'I' is already used
 				break;
 			}
 		}
 
-		const char *verb = cli.optarg();
+		const char *verb = cli.optArg();
 		ut_assert_true(verb == nullptr);
 	}
 	return true;

--- a/src/systemcmds/tests/test_jig_voltages.cpp
+++ b/src/systemcmds/tests/test_jig_voltages.cpp
@@ -52,14 +52,14 @@ int test_jig_voltages(int argc, char *argv[])
 	px4_usleep(50000);	// sleep 50ms and wait for adc report
 
 	if (_adc_sub.update(&adc)) {
-		PX4_INFO_RAW("DeviceID: %d\n", adc.device_id);
-		PX4_INFO_RAW("Resolution: %d\n", adc.resolution);
+		PX4_INFO_RAW("DeviceID: %" PRIu32 "\n", adc.device_id);
+		PX4_INFO_RAW("Resolution: %" PRIu32 "\n", adc.resolution);
 		PX4_INFO_RAW("Voltage Reference: %f\n", adc.v_ref);
 
 		unsigned channels = 0;
 
 		for (int i = 0; i < PX4_MAX_ADC_CHANNELS; ++i) {
-			PX4_INFO_RAW("%d: %d  ", adc.channel_id[i], adc.raw_data[i]);
+			PX4_INFO_RAW("%" PRIu16 ": %" PRIi32 "  ", adc.channel_id[i], adc.raw_data[i]);
 
 			if (adc.channel_id[i] != -1) {
 				++channels;

--- a/src/systemcmds/tests/test_time.c
+++ b/src/systemcmds/tests/test_time.c
@@ -123,7 +123,7 @@ int test_time(int argc, char *argv[])
 		}
 	}
 
-	printf("Maximum jitter %" PRId64 "us\n", maxdelta);
+	printf("Maximum jitter %dus\n", maxdelta);
 
 	return 0;
 }

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -60,13 +60,15 @@ bool VersioningTest::_test_tag_to_version_number(const char *version_tag, uint32
 			return true;
 
 		} else {
-			PX4_ERR("Wrong vendor version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, vendor_version_result,
+			PX4_ERR("Wrong vendor version: tag: %s, got: 0x%" PRIx32 ", expected: 0x%" PRIx32 "", version_tag,
+				vendor_version_result,
 				vendor_version_target);
 			return false;
 		}
 
 	} else {
-		PX4_ERR("Wrong flight version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, flight_version_result,
+		PX4_ERR("Wrong flight version: tag: %s, got: 0x%" PRIx32 ", expected: 0x%" PRIx32 "", version_tag,
+			flight_version_result,
 			flight_version_target);
 		return false;
 	}


### PR DESCRIPTION
In the 10.1.0 Of Nuttx this changes will be needed. This PR preps the current PX4 code base for theses structural changes. 

Using inttypes - will be enforced in 10.1.0 as will type checking.

getops interface will be Thread safe and accesors will be macros that collide the cli.getops interface. The change here in uses mixed case to avoid the collisions, 

STM32 Timers will be based on the Basic timer defines and advanced

Includes for debug/syslog/assert/schedule  will only be public API and not layerd. 