### PR TITLE
mavlink: make sure heartbeat reports flight termination

### DIFF
--- a/src/modules/mavlink/streams/HEARTBEAT.hpp
+++ b/src/modules/mavlink/streams/HEARTBEAT.hpp
@@ -59,6 +59,7 @@ public:
 private:
 	explicit MavlinkStreamHeartbeat(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
+	uORB::Subscription _acturator_armed_sub{ORB_ID(actuator_armed)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_status_flags_sub{ORB_ID(vehicle_status_flags)};
@@ -76,6 +77,8 @@ private:
 			vehicle_control_mode_s vehicle_control_mode{};
 			_vehicle_control_mode_sub.copy(&vehicle_control_mode);
 
+			actuator_armed_s actuator_armed{};
+			_acturator_armed_sub.copy(&actuator_armed);
 
 			// uint8_t base_mode (MAV_MODE_FLAG) - System mode bitmap.
 			uint8_t base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
@@ -123,7 +126,8 @@ private:
 			}
 
 			// system_status overrides
-			if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_TERMINATION) {
+			if (actuator_armed.force_failsafe || actuator_armed.lockdown || actuator_armed.manual_lockdown
+				|| vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_TERMINATION) {
 				system_status = MAV_STATE_FLIGHT_TERMINATION;
 
 			} else if (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
MAVLink specs define a way to report when then vehicle was terminated (thanks @julianoes):
https://mavlink.io/en/messages/common.html#MAV_STATE_FLIGHT_TERMINATION
but the issue is that the usually used ways of termination e.g. kill switch, geofence, failsafe reaction do not report this state.

That's what I originally wanted to do when I ran into #17707

**Describe your solution**
This pull request makes sure the termination state is set with the common ways a vehicle is terminated like:
`manual_lockdown`, `lockdown`, `foce_failsafe`.

**Describe possible alternatives**
I'm suggesting to generally unify the termination state such that further confusion can be avoided. There should be one terminated/killed state and everything which is not terminated in the air should be named clearly different. This would also simplify implementations of safety systems like e.g. https://github.com/PX4/PX4-Autopilot/pull/17564

**Test data / coverage**
I successfully tested this in SITL by setting a geofence radius, setting the geofence breach reaction to terminate and commanding to fly out of the geofence:
![image](https://user-images.githubusercontent.com/4668506/120812614-6efa8e80-c54d-11eb-9bd1-7b30584ebd55.png)
The `MAV_STATE` changes from `ACTIVE` to `TERMINATION` just like expected.
