### PR TITLE
Update rcS

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -81,33 +81,6 @@ then
 			hardfault_log reset
 		fi
 	fi
-
-	# Prevent MacOS and Ubuntu from creating unnecessary temporary files on the microSD card
-
-	# block MacOS Spotlight indexing (.Spotlight-V100 folder)
-	if [ ! -f "/fs/microsd/.metadata_never_index" ]; then
-		cat > /fs/microsd/.metadata_never_index
-	fi
-
-	# block MacOS trashes
-	if [ ! -f "/fs/microsd/.Trashes" ]; then
-		cat > /fs/microsd/.Trashes
-	fi
-
-	# block MacOS logging of filesystem events
-	if [ ! -d "/fs/microsd/.fseventsd" ]; then
-		mkdir /fs/microsd/.fseventsd
-	fi
-
-	if [ ! -f "/fs/microsd/.fseventsd/no_log" ]; then
-		cat > /fs/microsd/.fseventsd/no_log
-	fi
-
-	# block Ubuntu trash
-	if [ ! -f "/fs/microsd/.Trash-1000" ]; then
-		cat > /fs/microsd/.Trash-1000
-	fi
-
 else
 	# tune SD_INIT
 	set STARTUP_TUNE 14 # tune 14 = SD_INIT


### PR DESCRIPTION
remove sd index file spoofing

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
-> the code didn´t really prevent systems indexing
-> less confusion on the SD file system
-> easier ftp access to the sd volume
-> real index files that can interfere are now visible again
