### PR TITLE
I2CSPIDriverBase: print rotation and i2c address if set

### DIFF
--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -516,21 +516,36 @@ int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterat
 		// print some info that we are running
 		switch (iterator.busType()) {
 		case BOARD_I2C_BUS:
-			PX4_INFO_RAW("%s #%i on I2C bus %d%s\n", instance->ItemName(), runtime_instance, iterator.bus(),
-				     iterator.external() ? " (external)" : "");
+			PX4_INFO_RAW("%s #%i on I2C bus %d", instance->ItemName(), runtime_instance, iterator.bus());
+
+			if (iterator.external()) {
+				PX4_INFO_RAW(" (external)");
+			}
+
+			if (cli.i2c_address != 0) {
+				PX4_INFO_RAW(" address 0x%X", cli.i2c_address);
+			}
+
+			if (cli.rotation != 0) {
+				PX4_INFO_RAW(" rotation %d", cli.rotation);
+			}
+
+			PX4_INFO_RAW("\n");
 
 			break;
 
 		case BOARD_SPI_BUS:
-			PX4_INFO_RAW("%s #%i on SPI bus %d (devid=0x%x)",
-				     instance->ItemName(), runtime_instance, iterator.bus(), PX4_SPI_DEV_ID(iterator.devid()));
+			PX4_INFO_RAW("%s #%i on SPI bus %d", instance->ItemName(), runtime_instance, iterator.bus());
 
 			if (iterator.external()) {
-				PX4_INFO_RAW(" (external, equal to '-b %i')\n", iterator.externalBusIndex());
-
-			} else {
-				PX4_INFO_RAW("\n");
+				PX4_INFO_RAW(" (external, equal to '-b %i')", iterator.externalBusIndex());
 			}
+
+			if (cli.rotation != 0) {
+				PX4_INFO_RAW(" rotation %d", cli.rotation);
+			}
+
+			PX4_INFO_RAW("\n");
 
 			break;
 


### PR DESCRIPTION
This is sometimes helpful to see in logs, especially cases where board init script logic grows in complexity.

I'd still very much like to find a way for the rotation to become a static property in the board support.

``` Console
icm20602 #0 on SPI bus 1 rotation 2
icm20689 #0 on SPI bus 1 rotation 2
bmi055 #0 on SPI bus 1 rotation 2
bmi055 #1 on SPI bus 1 rotation 2
ms5611 #0 on SPI bus 4
ist8310 #0 on I2C bus 3 address 0xE rotation 10
ist8310 #1 on I2C bus 1 (external) address 0xE rotation 10
```