### PR TITLE
Update rc.board_arch_defaults

### DIFF
--- a/platforms/nuttx/init/stm32/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32/rc.board_arch_defaults
@@ -14,5 +14,5 @@ set LOGGER_BUF 8
 if param greater -s UAVCAN_ENABLE 1
 then
 	# Reduce logger buffer to free up some RAM for UAVCAN servers.
-	set LOGGER_BUF 4
+	set LOGGER_BUF 6
 fi


### PR DESCRIPTION
Logger doesn´t start at all with 4k buffer

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
Tested with PixRacer and PixFalcon as soon as UAVCAN parameter is activated logging doesn´t start anymore.
This is completely independent of the quality or speed of the SD card.

**Describe your solution**
As soon as the log buffer is above 4k the logger works.
And 6k produces only a third of the dropouts with a Sandisk Extreme 32G compared to 5k.
But the logger would also start with 5k.
Of course, every bit of free ram is needed for UAVCAN, but the logger should be able to start despite this.

This change is certainly also necessary for the other F4xx platforms. 
