### PR TITLE
change fmu-v5's uavcan timer5 to timer6

### DIFF
--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -9,6 +9,7 @@ px4_add_board(
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
 	UAVCAN_INTERFACES 2
+	UAVCAN_TIMER_OVERRIDE 6
 	SERIAL_PORTS
 		GPS1:/dev/ttyS0
 		TEL1:/dev/ttyS1

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -52,6 +52,9 @@ if(CONFIG_ARCH_CHIP)
 	elseif(${CONFIG_ARCH_CHIP} MATCHES "stm32")
 		set(UAVCAN_DRIVER "stm32")
 		set(UAVCAN_TIMER 5) # The default timer is TIM5
+		if (DEFINED config_uavcan_timer_override)
+			set (UAVCAN_TIMER  ${config_uavcan_timer_override})
+		endif()
 	endif()
 endif()
 


### PR DESCRIPTION

Problem:
        In CUAV v5+：the uavcan timer5 takes up the led_pwm_timers on the board, that makes board's LED  PWM does't work.
        
This PR makes board's led pwm works correct.