### PR TITLE
mavlink: add actuator_armed header to heartbeat

### DIFF
--- a/src/modules/mavlink/streams/HEARTBEAT.hpp
+++ b/src/modules/mavlink/streams/HEARTBEAT.hpp
@@ -34,6 +34,7 @@
 #ifndef HEARTBEAT_HPP
 #define HEARTBEAT_HPP
 
+#include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_status_flags.h>


### PR DESCRIPTION
**Describe problem solved by this pull request**
I forgot to include the `actuator_armed` header in https://github.com/PX4/PX4-Autopilot/pull/17709. The necessary definitions are available through some include but I'd rather correct it to be clean.
