### PR TITLE
mc_pos_control: omit initial warning

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -422,7 +422,7 @@ void MulticopterPositionControl::Run()
 
 			} else {
 				// Failsafe
-				if ((time_stamp_now - _last_warn) > 2_s) {
+				if ((time_stamp_now - _last_warn) > 2_s && _last_warn > 0) {
 					PX4_WARN("invalid setpoints");
 					_last_warn = time_stamp_now;
 				}


### PR DESCRIPTION
I think we often thought this was always a race condition but I think it's often just the initial change.