### PR TITLE
MC pos control: use vz<->z_deriv blending in pure vel mode only

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -404,9 +404,11 @@ void MulticopterPositionControl::Run()
 			_control.setInputSetpoint(_setpoint);
 
 			// update states
-			if (PX4_ISFINITE(_setpoint.vz) && (fabsf(_setpoint.vz) > FLT_EPSILON)
+			if (!PX4_ISFINITE(_setpoint.z)
+			    && PX4_ISFINITE(_setpoint.vz) && (fabsf(_setpoint.vz) > FLT_EPSILON)
 			    && PX4_ISFINITE(local_pos.z_deriv) && local_pos.z_valid && local_pos.v_z_valid) {
-				// A change in velocity is demanded. Set velocity to the derivative of position
+				// A change in velocity is demanded and the altitude is not controlled.
+				// Set velocity to the derivative of position
 				// because it has less bias but blend it in across the landing speed range
 				//  <  MPC_LAND_SPEED: ramp up using altitude derivative without a step
 				//  >= MPC_LAND_SPEED: use altitude derivative


### PR DESCRIPTION
This logic was introduced to avoid large altitude drifts in velocity mode (altitude not controlled) due to potential velocity estimate bias in case of IMU problems (see PR #8445). After some refactoring, the logic started to be used in altitude-controlled modes as well, which is not needed.

Original implementation in https://github.com/PX4/PX4-Autopilot/pull/8445/commits/02314f542ac899d1c6183de715134e946d6005b7 . That part of the code was only runing `if (!_run_alt_control)`.