### PR TITLE
Fixed syntax error

### DIFF
--- a/boards/cuav/x7pro/init/rc.board_sensors
+++ b/boards/cuav/x7pro/init/rc.board_sensors
@@ -15,7 +15,7 @@ rm3100 -s -b 2 start
 
 # SPI4
 bmi088 -s -b 4 -A -R 2 start
-if !bmi088 -s -b 4 -G -R 2 start
+if ! bmi088 -s -b 4 -G -R 2 start
 then
 	icm42688p -R 2 -s start
 fi


### PR DESCRIPTION
https://github.com/PX4/PX4-Autopilot/pull/17692 
Fixed syntax errors in PR above.

The serial port outputs information:

![image](https://user-images.githubusercontent.com/69180601/121128535-20efce80-c85e-11eb-8245-6f279003a2df.png)
