### PR TITLE
uavcan_v1: Fix Heartbeat scheduling

### DIFF
--- a/src/drivers/uavcan_v1/Publishers/Publisher.hpp
+++ b/src/drivers/uavcan_v1/Publishers/Publisher.hpp
@@ -60,12 +60,15 @@ class UavcanPublisher
 {
 public:
 	static constexpr uint16_t CANARD_PORT_ID_UNSET = 65535U;
+	static constexpr uint16_t CANARD_PORT_ID_MAX   = 32767U;
 
 	UavcanPublisher(CanardInstance &ins, UavcanParamManager &pmgr, const char *subject_name, uint8_t instance = 0) :
 		_canard_instance(ins), _param_manager(pmgr), _subject_name(subject_name), _instance(instance) { };
 
 	// Update the uORB Subscription and broadcast a UAVCAN message
 	virtual void update() = 0;
+
+	bool isValidPortId(int32_t id) const { return id >= 0 && id <= CANARD_PORT_ID_MAX; }
 
 	CanardPortID id() { return _port_id; };
 
@@ -79,9 +82,16 @@ public:
 		_param_manager.GetParamByName(uavcan_param, value);
 		int32_t new_id = value.integer32.value.elements[0];
 
+		// Allow, for example, a default PX4 param value of '-1' to disable publication
+		if (!isValidPortId(new_id)) {
+			// but always use the standard 'unset' value for comparison
+			new_id = CANARD_PORT_ID_UNSET;
+		}
+
 		if (_port_id != new_id) {
 			if (new_id == CANARD_PORT_ID_UNSET) {
 				PX4_INFO("Disabling publication of subject %s.%d", _subject_name, _instance);
+				_port_id = CANARD_PORT_ID_UNSET;
 
 			} else {
 				_port_id = (CanardPortID)new_id;

--- a/src/drivers/uavcan_v1/Subscribers/BaseSubscriber.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/BaseSubscriber.hpp
@@ -51,6 +51,7 @@ class UavcanBaseSubscriber
 {
 public:
 	static constexpr uint16_t CANARD_PORT_ID_UNSET = 65535U;
+	static constexpr uint16_t CANARD_PORT_ID_MAX   = 32767U;
 
 	UavcanBaseSubscriber(CanardInstance &ins, const char *subject_name, uint8_t instance = 0) :
 		_canard_instance(ins), _instance(instance)
@@ -63,6 +64,8 @@ public:
 	{
 		unsubscribe();
 	}
+
+	bool isValidPortId(int32_t id) const { return id >= 0 && id <= CANARD_PORT_ID_MAX; }
 
 	virtual void subscribe() = 0;
 	virtual void unsubscribe()
@@ -96,6 +99,10 @@ public:
 
 	bool hasPortID(CanardPortID port_id)
 	{
+		if (!isValidPortId((int32_t)port_id)) {
+			return false;
+		}
+
 		SubjectSubscription *curSubj = &_subj_sub;
 
 		while (curSubj != NULL) {

--- a/src/drivers/uavcan_v1/Subscribers/DynamicPortSubscriber.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/DynamicPortSubscriber.hpp
@@ -72,6 +72,12 @@ public:
 			if (_param_manager.GetParamByName(uavcan_param, value)) {
 				int32_t new_id = value.integer32.value.elements[0];
 
+				// Allow, for example, a default PX4 param value of '-1' to disable subscription
+				if (!isValidPortId(new_id)) {
+					// but always use the standard 'unset' value for comparison
+					new_id = CANARD_PORT_ID_UNSET;
+				}
+
 				/* FIXME how about partial subscribing */
 				if (curSubj->_canard_sub.port_id != new_id) {
 					if (new_id == CANARD_PORT_ID_UNSET) {

--- a/src/drivers/uavcan_v1/Uavcan.cpp
+++ b/src/drivers/uavcan_v1/Uavcan.cpp
@@ -423,10 +423,10 @@ void UavcanNode::sendHeartbeat()
 		heartbeat.uptime = _uavcan_node_heartbeat_transfer_id; // TODO: use real uptime
 		heartbeat.health.value = uavcan_node_Health_1_0_NOMINAL;
 		heartbeat.mode.value = uavcan_node_Mode_1_0_OPERATIONAL;
-
+		const hrt_abstime now = hrt_absolute_time();
 
 		CanardTransfer transfer = {
-			.timestamp_usec = hrt_absolute_time() + PUBLISHER_DEFAULT_TIMEOUT_USEC,
+			.timestamp_usec = now + PUBLISHER_DEFAULT_TIMEOUT_USEC,
 			.priority       = CanardPriorityNominal,
 			.transfer_kind  = CanardTransferKindMessage,
 			.port_id        = uavcan_node_Heartbeat_1_0_FIXED_PORT_ID_,
@@ -447,7 +447,7 @@ void UavcanNode::sendHeartbeat()
 			PX4_ERR("Heartbeat transmit error %d", result);
 		}
 
-		_uavcan_node_heartbeat_last = transfer.timestamp_usec;
+		_uavcan_node_heartbeat_last = now;
 	}
 }
 


### PR DESCRIPTION
The `hrt_abstime` value used to control the 1s pub rate was the value of the `timestamp_usec` of the `CanardTransfer`, which has a timeout of 100ms added to it.
    
Since `hrt_abstime` is an unsigned datatype, if the `hrt_elapsed_time()` check was called <100ms apart, the negative value between `hrt_absolute_time()` and the future time would result in a large `hrt_elapsed_time`, and the bus would be spammed with Heartbeat messages (or error messages from canardTxPush) at some rate >10Hz.

I also cleaned up the handling of "unset" / "invalid" port ID parameters; the recent changes from using 0 to using 65535 to using -1 for the "disabled" value of the PX4 params was causing unsubscribe()/subscribe() to be called on every parameter update.