### PR TITLE
airframes markdownout.py - fix link to not open file for editing

### DIFF
--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -6,7 +6,7 @@ import html
 class MarkdownTablesOutput():
     def __init__(self, groups, board, image_path):
         result = ("# Airframes Reference\n"
-                  "> **Note** **This list is [auto-generated](https://github.com/PX4/Firmware/edit/master/Tools/px4airframes/markdownout.py) from the source code**.\n"
+                  "> **Note** **This list is [auto-generated](https://github.com/PX4/PX4-Autopilot/blob/master/Tools/px4airframes/markdownout.py) from the source code**.\n"
                   "> \n"
                   "> **AUX** channels may not be present on some flight controllers.\n"
                   "> If present, PWM AUX channels are commonly labelled **AUX OUT**.\n"


### PR DESCRIPTION
The airframes page in docs had an autogenerated "edit on github" link to the file used to generate it. This fixes link to moved repo, and makes it a source code not edit link. That makes sense because most people should be editing this code outside of github editor.