### PR TITLE
en-/disable mc position controller using explicit control mode flag

### DIFF
--- a/msg/vehicle_control_mode.msg
+++ b/msg/vehicle_control_mode.msg
@@ -2,6 +2,7 @@ uint64 timestamp		# time since system start (microseconds)
 bool flag_armed			# synonym for actuator_armed.armed
 
 bool flag_external_manual_override_ok		# external override non-fatal for system. Only true for fixed wing
+bool flag_multicopter_position_control_enabled
 
 bool flag_control_manual_enabled		# true if manual input is mixed in
 bool flag_control_auto_enabled			# true if onboard autopilot should act

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3328,6 +3328,14 @@ Commander::update_control_mode()
 		break;
 	}
 
+	_vehicle_control_mode.flag_multicopter_position_control_enabled =
+		(_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
+		&& (_vehicle_control_mode.flag_control_altitude_enabled
+		    || _vehicle_control_mode.flag_control_climb_rate_enabled
+		    || _vehicle_control_mode.flag_control_position_enabled
+		    || _vehicle_control_mode.flag_control_velocity_enabled
+		    || _vehicle_control_mode.flag_control_acceleration_enabled);
+
 	_vehicle_control_mode.timestamp = hrt_absolute_time();
 	_control_mode_pub.publish(_vehicle_control_mode);
 }

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -289,7 +289,7 @@ void MulticopterPositionControl::Run()
 
 		PositionControlStates states{set_vehicle_states(local_pos)};
 
-		if (_control_mode.flag_control_acceleration_enabled || _control_mode.flag_control_climb_rate_enabled) {
+		if (_control_mode.flag_multicopter_position_control_enabled) {
 
 			_trajectory_setpoint_sub.update(&_setpoint);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Now that FlightTask is in the flight mode manager module and that the MC position controller runs on local_position updates, the multicopter position controller also runs when a VTOL plane is in fixedwing mode (using 0 velocity as a reference because trajectory_setpoint is all NAN).

**Describe your solution**
Adding a clear control mode flag to tell when the multicopter position controller should run or not.

**Describe possible alternatives**
Updating based on the `trajectory_setpoint` update was an option but it would slow down the loop if the estimate comes faster than the setpoint. Also, since "flight mode manager" will soon be used for all kind of vehicles (fixedwings, rovers, ...) the `trajectory_setpoint` might also be filled with valid values when the multicopter position controller should not run.

**Test data / coverage**
SITL gazebo standard VTOL.
Before (`vehicle_local_position_setpoint` is also published from the MC pos controller in FW):
![DeepinScreenshot_select-area_20210609145311](https://user-images.githubusercontent.com/14822839/121376437-d2b3fb80-c941-11eb-82ea-c990a1058f32.png)

With this PR (`vehicle_local_position_setpoint` publication stops in FW flight):
![DeepinScreenshot_select-area_20210609160951](https://user-images.githubusercontent.com/14822839/121376466-d8a9dc80-c941-11eb-9867-e592a65b32d6.png)

**Additional context**
Add any other related context or media.
