### PR TITLE
Correct transmission deadline check & fix SocketCAN tx deadline

### DIFF
--- a/src/drivers/uavcan_v1/CanardSocketCAN.cpp
+++ b/src/drivers/uavcan_v1/CanardSocketCAN.cpp
@@ -43,8 +43,6 @@ uint64_t getMonotonicTimestampUSec(void)
 {
 	struct timespec ts {};
 
-	memset(&ts, 0, sizeof(ts));
-
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
 	return ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;

--- a/src/drivers/uavcan_v1/Uavcan.cpp
+++ b/src/drivers/uavcan_v1/Uavcan.cpp
@@ -271,7 +271,7 @@ void UavcanNode::transmit()
 	for (const CanardFrame *txf = nullptr; (txf = canardTxPeek(&_canard_instance)) != nullptr;) {
 		// Attempt transmission only if the frame is not yet timed out while waiting in the TX queue.
 		// Otherwise just drop it and move on to the next one.
-		if (txf->timestamp_usec == 0 || hrt_absolute_time() > txf->timestamp_usec) {
+		if (txf->timestamp_usec == 0 || txf->timestamp_usec > hrt_absolute_time()) {
 			// Send the frame. Redundant interfaces may be used here.
 			const int tx_res = _can_interface->transmit(*txf);
 


### PR DESCRIPTION
The UAVCANv1 transmit() function was checking deadline the wrong way around and thus only sending timed out frames.

Furthermore fixes the timing conversion in the SocketCAN driver.