### PR TITLE
mavlink: don't read garbage target sysid/compid

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -393,11 +393,15 @@ Mavlink::forward_message(const mavlink_message_t *msg, Mavlink *self)
 			if (meta) {
 				// Extract target system and target component if set
 				if (meta->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM) {
-					target_system_id = (_MAV_PAYLOAD(msg))[meta->target_system_ofs];
+					if (meta->target_system_ofs < msg->len) {
+						target_system_id = (_MAV_PAYLOAD(msg))[meta->target_system_ofs];
+					}
 				}
 
 				if (meta->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT) {
-					target_component_id = (_MAV_PAYLOAD(msg))[meta->target_component_ofs];
+					if (meta->target_component_ofs < msg->len) {
+						target_component_id = (_MAV_PAYLOAD(msg))[meta->target_component_ofs];
+					}
 				}
 			}
 


### PR DESCRIPTION
This fixes a tricky bug that we discovered in MAVSDK:
https://github.com/mavlink/MAVSDK/pull/1464

It turns out the target_system and target_component fields can potentially be:
1. at the end of a message payload,
2. and zero,

and therefore they get trimmed. When you then try to read it you potentially read some garbage from the CRC fields.

Found with @JonasVautherin.