### PR TITLE
aion robotic frame - fix broken link to R1 UGV docs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -2,7 +2,7 @@
 #
 # @name Aion Robotics R1 UGV
 #
-# @url http://docs.aionrobotics.com/en/latest/r1-ugv.html
+# @url https://www.aionrobotics.com/r1
 #
 # @type Rover
 # @class Rover


### PR DESCRIPTION
The docs URL is broken. Docs have moved to https://docs.aionrobotics.com/ but that no longer includes vehicle links, so not useful. 
This is product link from main website.

@ItsTimmy Long time no see. You touched this so FYI :-)