### PR TITLE
CUAVX7pro:enables camera triggering causing no other PWM output

### DIFF
--- a/boards/cuav/x7pro/init/rc.board_mavlink
+++ b/boards/cuav/x7pro/init/rc.board_mavlink
@@ -5,3 +5,17 @@
 
 # Start MAVLink on the USB port
 mavlink start -d /dev/ttyACM0
+
+if param greater -s TRIG_MODE 0
+    then
+        # We ONLY support trigger on pins 5+6 when simultanously using AUX for actuator output.
+        if param compare TRIG_PINS 56
+        then
+            # clear pins 5 and 6
+            set FMU_MODE pwm12
+            set AUX_MODE pwm12
+        else
+            set FMU_MODE none
+            set AUX_MODE none
+        fi
+    fi

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -33,6 +33,7 @@
 
 #include "camera_interface.h"
 #include <px4_platform_common/log.h>
+#include <px4_platform_common/px4_config.h>
 
 void CameraInterface::get_pins()
 {
@@ -59,6 +60,14 @@ void CameraInterface::get_pins()
 	while ((single_pin = pin_list % 10)) {
 
 		_pins[i] = single_pin - 1;
+
+#if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM == 14
+
+		if (!PX4_MFT_HW_SUPPORTED(PX4_MFT_PX4IO)) {
+			_pins[i] += 8;
+		}
+
+#endif
 
 		if (_pins[i] < 0) {
 			_pins[i] = -1;


### PR DESCRIPTION
https://github.com/PX4/PX4-Autopilot/issues/17726
This fixed  the issue above.
Here is some debugging information

`pwm_out status
 
 INFO  [pwm_out] 0 - PWM_MAIN 0x00FF
 INFO  [pwm_out] 0 - Max update rate: 0 Hz
 INFO  [pwm_out] 0 - PWM Mode: pwm8
 pwm_out: cycle: 5 events, 613us elapsed, 122.60us avg, min 2us max 394us 161.030us rms
 pwm_out: interval: 6 events, 4684.67us avg, min 50us max 27708us 11043.268us rms
 control latency: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
 INFO  [mixer_module] Switched to rate_ctrl work queue: 1
 INFO  [mixer_module] Mixer loaded: yes
 INFO  [mixer_module] Driver instance: 0
 INFO  [mixer_module] Channel Configuration:
 INFO  [mixer_module] Channel 0: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 1: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 2: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 3: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 4: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 5: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 6: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 INFO  [mixer_module] Channel 7: value: 900, failsafe: 0, disarmed: 900, min: 1075, max: 1950
 
 INFO  [pwm_out] 1 - PWM_AUX 0x0F00
 INFO  [pwm_out] 1 - Max update rate: 0 Hz
 INFO  [pwm_out] 1 - PWM Mode: pwm4
 pwm_out: cycle: 5 events, 855us elapsed, 171.00us avg, min 2us max 525us 223.383us rms
 pwm_out: interval: 5 events, 11016.00us avg, min 10us max 54304us 23402.896us rms
 control latency: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
 INFO  [mixer_module] Switched to rate_ctrl work queue: 0
 INFO  [mixer_module] Mixer loaded: yes
 INFO  [mixer_module] Driver instance: 1
 INFO  [mixer_module] Channel Configuration:
 INFO  [mixer_module] Channel 0: value: 0, failsafe: 0, disarmed: 1500, min: 1000, max: 2000
 INFO  [mixer_module] Channel 1: value: 0, failsafe: 0, disarmed: 1500, min: 1000, max: 2000
 INFO  [mixer_module] Channel 2: value: 0, failsafe: 0, disarmed: 1500, min: 1000, max: 2000
 INFO  [mixer_module] Channel 3: value: 0, failsafe: 0, disarmed: 1500, min: 1000, max: 2000


pwm info -d /dev/pwm_output0
device: /dev/pwm_output0
channel 1: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 2: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 3: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 4: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 5: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 6: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 7: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 8: 900 us (alternative rate: 400 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel group 0: channels 1 2 3 4
channel group 1: channels 5 6 7 8

pwm info -d /dev/pwm_output1
 device: /dev/pwm_output1
 channel 1: 0 us (alternative rate: 50 Hz failsafe: 0, disarmed: 1500 us, min: 1000 us, max: 2000 us, trim:  0.00)
 channel 2: 0 us (alternative rate: 50 Hz failsafe: 0, disarmed: 1500 us, min: 1000 us, max: 2000 us, trim:  0.00)
 channel 3: 0 us (alternative rate: 50 Hz failsafe: 0, disarmed: 1500 us, min: 1000 us, max: 2000 us, trim:  0.00)
 channel 4: 0 us (alternative rate: 50 Hz failsafe: 0, disarmed: 1500 us, min: 1000 us, max: 2000 us, trim:  0.00)
 channel group 2: channels 9 10 11 12


camera_trigger status
 INFO  [camera_trigger] main state : disabled
 INFO  [camera_trigger] pause state : active
 INFO  [camera_trigger] mode : 4
 INFO  [camera_trigger] distance : 25.00 [m]
 INFO  [camera_trigger] activation time : 200.00 [ms]
 INFO  [camera_trigger] PWM trigger mode (generic), pins enabled : [-1][-1][-1][-1][12][13]`
