### PR TITLE
EKF2: Always publish global position

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -212,8 +212,6 @@ private:
 	uint32_t _device_id_gyro{0};
 	uint32_t _device_id_mag{0};
 
-	Vector3f _last_local_position_for_gpos{};
-
 	Vector3f _last_accel_bias_published{};
 	Vector3f _last_gyro_bias_published{};
 	Vector3f _last_mag_bias_published{};


### PR DESCRIPTION

**Describe problem solved by this pull request**

When using simulated or fake GPS, based on some other positioning
system, the GPS coordinate input can be very accurate due to quantization
or even for true accuracy. In this case this check bites and perfectly valid position
doesn't get published.

**Describe your solution**

For historical reasons, there is a check in EKF2 to only publish global
position if it has moved for 1mm.

This is no longer necessary, and also this if doesn't save any cpu cycles
in real conditions where GPS errors are always much bigger that this.

Just removed this if.

**Describe possible alternatives**

- The value to be compared against could be a parameter which can be set acc. to the global positioning system used.

**Test data / coverage**

**Additional context**
