### PR TITLE
Airspeed selector: use actual airspeed_valid

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -603,7 +603,8 @@ void AirspeedModule::select_airspeed_and_publish()
 		airspeed_validated.true_airspeed_m_s = _airspeed_validator[_valid_airspeed_index - 1].get_TAS();
 		airspeed_validated.calibrated_ground_minus_wind_m_s = _ground_minus_wind_CAS;
 		airspeed_validated.true_ground_minus_wind_m_s = _ground_minus_wind_TAS;
-		airspeed_validated.airspeed_sensor_measurement_valid = true;
+		airspeed_validated.airspeed_sensor_measurement_valid =
+			_airspeed_validator[_valid_airspeed_index - 1].get_airspeed_valid();
 		break;
 	}
 


### PR DESCRIPTION
airspeed_validated.airspeed_sensor_measurement_valid is always logged as valid if an airspeed sensor is used, regardless of AirspeedValidator.get_airspeed_valid(). This doesn't seem right. If it is right, I think a comment should be added. If it is not, this change will make sure the actual value is logged.

**Test data / coverage**
Test flown (based on v1.11.3). This revealed that the airspeed validator in fact considered the airspeed invalid.