### PR TITLE
make_list: check if file exists before the other operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ all: px4_sitl_default
 space := $(subst ,, )
 
 define make_list
-     $(shell cat .github/workflows/compile_${1}.yml | sed -E 's|[[:space:]]+(.*),|check_\1|g' | grep check_${2})
+     $(shell [ -f .github/workflows/compile_${1}.yml ] && cat .github/workflows/compile_${1}.yml | sed -E 's|[[:space:]]+(.*),|check_\1|g' | grep check_${2})
 endef
 
 # Parsing


### PR DESCRIPTION
**Describe problem solved by this pull request**
In cases where some GAct CI workflows were removed, the `make_list` Makefile function will through an error when trying to `cat` a file that doesn't exist (ex. `comple_linux.yml`)

**Describe your solution**
Check if the file exists first.

**Describe possible alternatives**
We could silence/suppress it, but that's not that useful.

**Test data / coverage**
Tested locally with some workflow files removed.

**Additional context**
N.A.
