### PR TITLE
fc-v2-bsp - Set default mag rotation on bootup for onboard mag

### DIFF
--- a/boards/modalai/fc-v2/init/rc.board_sensors
+++ b/boards/modalai/fc-v2/init/rc.board_sensors
@@ -22,7 +22,7 @@ icm42688p -s -b 1 -R 12 start
 icm42688p -s -b 2 -R 12 start
 
 # Internal I2C mag
-bmm150 -I start
+bmm150 -I -R 0 start
 
 # Internal I2C baro
 bmp388 -I start


### PR DESCRIPTION
Validated on bench top test.