### PR TITLE
uORB: Subscription check if uORB::Manager instance is valid

### DIFF
--- a/platforms/common/uORB/Subscription.cpp
+++ b/platforms/common/uORB/Subscription.cpp
@@ -49,8 +49,7 @@ bool Subscription::subscribe()
 		return true;
 	}
 
-	if (_orb_id != ORB_ID::INVALID) {
-
+	if ((_orb_id != ORB_ID::INVALID) && uORB::Manager::get_instance()) {
 		DeviceMaster *device_master = uORB::Manager::get_instance()->get_device_master();
 
 		if (device_master != nullptr) {


### PR DESCRIPTION
 - this is necessary if uORB::Subscription is used with static storage duration