### PR TITLE
Thoneflow - fix up links to docs

### DIFF
--- a/src/drivers/optical_flow/thoneflow/thoneflow.cpp
+++ b/src/drivers/optical_flow/thoneflow/thoneflow.cpp
@@ -466,7 +466,7 @@ Serial bus driver for the ThoneFlow-3901U optical flow sensor.
 
 Most boards are configured to enable/start the driver on a specified UART using the SENS_TFLOW_CFG parameter.
 
-Setup/usage information: https://docs.px4.io/en/sensor/thoneflow.html
+Setup/usage information: https://docs.px4.io/master/en/sensor/pmw3901.html#thone-thoneflow-3901u
 
 ### Examples
 


### PR DESCRIPTION
The Thoneflow driver links to a non-existent "thoneflow doc" (possibly deleted). This fixes it up to point to the correct part of the docs: https://docs.px4.io/master/en/sensor/pmw3901.html#thone-thoneflow-3901u