### PR TITLE
mavlink: tcflush() uart before closing it

### DIFF
--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -46,6 +46,7 @@
 
 #include <sys/ioctl.h>
 #include <unistd.h>
+#include <termios.h>
 #include <cstdint>
 #include <string.h>
 
@@ -219,6 +220,8 @@ DevCommon::DevCommon(const char *device_path)
 DevCommon::~DevCommon()
 {
 	if (_fd >= 0) {
+		/* discard all pending data, as close() might block otherwise on NuttX with flow control enabled */
+		tcflush(_fd, TCIOFLUSH);
 		::close(_fd);
 	}
 }

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -324,12 +324,9 @@ Mavlink::destroy_all_instances()
 		}
 	}
 
-	//we know all threads have exited, so it's safe to manipulate the linked list and delete objects.
+	//we know all threads have exited, so it's safe to delete objects.
 	for (Mavlink *inst_to_del : mavlink_module_instances) {
-		if (inst_to_del != nullptr) {
-			delete inst_to_del;
-			inst_to_del = nullptr;
-		}
+		delete inst_to_del;
 	}
 
 	printf("\n");
@@ -2533,6 +2530,8 @@ Mavlink::task_main(int argc, char *argv[])
 	_streams.clear();
 
 	if (_uart_fd >= 0 && !_is_usb_uart) {
+		/* discard all pending data, as close() might block otherwise on NuttX with flow control enabled */
+		tcflush(_uart_fd, TCIOFLUSH);
 		/* close UART */
 		::close(_uart_fd);
 	}


### PR DESCRIPTION
On NuttX with flow control, if no one was reading from the uart, the
close() call would block indefinitely waiting for data to be sent.