### PR TITLE
FW pos control: fix airspeed input constraining

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -254,7 +254,7 @@ FixedwingPositionControl::manual_control_setpoint_poll()
 		 * demanding up/down with the throttle stick, and move faster/break with the pitch one.
 		 */
 		_manual_control_setpoint_altitude = -(math::constrain(_manual_control_setpoint.z, 0.0f, 1.0f) * 2.f - 1.f);
-		_manual_control_setpoint_airspeed = math::constrain(_manual_control_setpoint.x, 0.0f, 1.0f) / 2.f + 0.5f;
+		_manual_control_setpoint_airspeed = math::constrain(_manual_control_setpoint.x, -1.0f, 1.0f) / 2.f + 0.5f;
 	}
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When using FW_POSCTL_INV_ST, the airspeed cannot be lowered below the trim airspeed.

**Describe your solution**
PR #16847 accidentally over-constrains `_manual_control_setpoint.x` to 0:1. This causes `_manual_control_setpoint_airspeed` to be constrained to 0.5:1, instead of 0:1. The constrain limits have been changed to allow -1:1 input.

**Describe possible alternatives**
N/A

**Test data / coverage**
Problem found and fix tested in SITL

**Additional context**
Add any other related context or media.
