### PR TITLE
VTOL: Improve front transition tracking

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -708,9 +708,12 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 
 			if (!PX4_ISFINITE(_transition_waypoint(0))) {
 				double lat_transition, lon_transition;
-				// create a virtual waypoint HDG_HOLD_DIST_NEXT meters in front of the vehicle which the L1 controller can track
-				// during the transition
-				waypoint_from_heading_and_distance(_current_latitude, _current_longitude, _yaw, HDG_HOLD_DIST_NEXT, &lat_transition,
+				// create a virtual waypoint HDG_HOLD_DIST_NEXT meters in front of the vehicle,
+				// aligned with the position setpoint which the L1 controller can track during the transition
+				float desired_yaw = get_bearing_to_next_waypoint(_current_latitude, _current_longitude, pos_sp_curr.lat,
+						    pos_sp_curr.lon);
+				waypoint_from_heading_and_distance(_current_latitude, _current_longitude, desired_yaw, HDG_HOLD_DIST_NEXT,
+								   &lat_transition,
 								   &lon_transition);
 
 				_transition_waypoint(0) = lat_transition;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -798,7 +798,6 @@ Mission::set_mission_items()
 								    _mission_item.lat, _mission_item.lon);
 
 					_mission_item.force_heading = true;
-
 					new_work_item_type = WORK_ITEM_TYPE_ALIGN;
 
 					/* set position setpoint to current while aligning */
@@ -821,7 +820,9 @@ Mission::set_mission_items()
 					}
 
 					set_vtol_transition_item(&_mission_item, vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
-					_mission_item.yaw = _navigator->get_local_position()->heading;
+					_mission_item.yaw = get_bearing_to_next_waypoint(
+								    _navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
+								    _mission_item.lat, _mission_item.lon);
 
 					/* set position setpoint to target during the transition */
 					generate_waypoint_from_heading(&pos_sp_triplet->current, _mission_item.yaw);


### PR DESCRIPTION
Follow-up on https://github.com/PX4/PX4-Autopilot/pull/16499, especially https://github.com/PX4/PX4-Autopilot/pull/16499#issuecomment-801701380. @sfuhrer @RomanBapst 

**Describe problem solved by this pull request**
Currently the front transition sets a "virtual" setpoint in front of the drone based on its current heading. This can lead to significant off-track when the initial yaw alignment is not very precise, e.g. due to a large value of [MIS_YAW_ERR](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#MIS_YAW_ERR). The other day we had a tracking error of ca 60m at the end of the front transition with respect to the planned mission, using default value of MIS_YAW_ERR. 
![FT not well aligned](https://user-images.githubusercontent.com/48206725/122562443-5d33e380-d043-11eb-9681-6c5fa7d0419a.png)

**Describe your solution**
The drone will calculate the "virtual" setpoint based on the desired heading towards the target waypoint. This allows for larger initial yaw alignment errors as they will be counteracted by the L1 logic during transition. On the logs below, check out the difference at 25°. On master, the final deviation is quite large with consequently quite a sharp roll setpoint change just after the transition. With this PR, most of the realignment still takes place before the vehicle actually takes up speed, and the global behaviour is an almost straight line, requiring no readjustment after the transition.

One of the biggest uncertainty I have with this approach is how solid it is to realign in the beginning of the transition. I think it's quite stable actually as you still have full MC support. What do you think? In any case the simulations with 90° and 180° still went well, and you have the advantage that you don't have to fly a full U-turn after the transition in the 180° case. But yeah, 40° roll and -5° pitch is a lot for the transition. But on master you have 50° roll for the U-turn just after transition...
 I don't suggest using such a high value of MIS_YAW_ERR, but there can be cases where you don't actively control the alignment of the drone before starting a transition. One such example would be if you use QGC to transition while flying a mission in MC mode and for some reason (WV, heading-to-home, idk) the drone is not aligned with where it's flying. Or in offboard you're free to do whatever you want, including badly aligned transitions. But to me these are corner cases in which I don't really see any real life usecase. And even then, it's unclear to me if it's better to transition into the wrong direction and do a U-turn afterwards as you might blindly fly through a geofence.

**Describe possible alternatives**
- Narrow down MIS_YAW_ERR to limit errors. Comes at the cost that the yaw control must be very precise, which in strong wind conditions can be difficult to achieve. More prone to hitting the yaw alignment timeout (MIS_YAW_TMT).
- Instead of calculating a virtual setpoint simply use the target position. I'm not sure if when the target position is too close the drone would try to U-turn / loiter during the transition or if it would just accept it and move on to the next one (potentially making a harsh turn too during transition). I think this is the reason why initially the virtual setpoint was introduced. 

**Test data / coverage**
SITL, standard vtol. For most of the logs I slowed down the transition by imposing a lower FW thrust and a higher final airspeed to see the effect of this PR better. I think the standard parameters make for an unrealistically fast front transition. On our real vehicles we always take around 10s to reach transition speed, which is 20+ m/s.
- MIS_YAW_ERR = 12° (default)
master: https://logs.px4.io/plot_app?log=e46f60a8-7159-4266-ad56-8b082e527ca7
PR: https://logs.px4.io/plot_app?log=9bf14c6a-d50e-48ef-b730-0aaa8059e733
- MIS_YAW_ERR = 25°
master: https://logs.px4.io/plot_app?log=ce1f7dd1-7e88-4741-a955-b56d7be37dfb
PR: https://logs.px4.io/plot_app?log=40c76e48-58e6-4919-a02a-3275907789a0
- MIS_YAW_ERR = 90°
master, fast transition: https://logs.px4.io/plot_app?log=4cb0156b-66f2-49c5-9b9c-7fc95dfe4696
PR, fast transition: https://logs.px4.io/plot_app?log=1ed15428-004e-4ab3-8c43-36de24e83057
master, slower transition: https://logs.px4.io/plot_app?log=d9c95fdf-7820-4bdf-b2e8-96336538880a
PR, slower transition: https://logs.px4.io/plot_app?log=7c40235d-f2c9-46f2-985f-b80034508b08
- MIS_YAW_ERR = 180°:
master: https://logs.px4.io/plot_app?log=5223769d-78af-4931-903a-7fb58d89c413
PR: https://logs.px4.io/plot_app?log=e8d0a2e8-cef5-4bc4-9880-15031039a375

**Additional context**
I did this with quadplanes in mind, is there anything that could fuck up with tailsitters or tiltwings? I tried two simulations with large MIS_YAW_ERR but I didn't really understand much. In any case doesn't look like it's affected much.
- it aligned already in MC part: https://logs.px4.io/plot_app?log=7f793d89-7696-4d45-8b52-f3c3fdc3762a
- same on master: https://logs.px4.io/plot_app?log=c8695868-a4b5-494f-9853-37478dcc7c13
- I forced it to be badly aligned by changing the mission a bit: https://logs.px4.io/plot_app?log=267faeea-5364-475c-9948-a58781da02f6
- this is how it looks on master, badly aligned: https://logs.px4.io/plot_app?log=6aa7e490-8809-4b97-a622-1319c9d2566f