### PR TITLE
HTE: relax validity condition when already valid

### DIFF
--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -172,15 +172,11 @@ void MulticopterHoverThrustEstimator::Run()
 					_hover_thrust_ekf.fuseAccZ(-local_pos.az, -local_pos_sp.thrust[2]);
 				}
 
-				bool valid;
+				bool valid = (_hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f);
 
+				// The test ratio does not need to pass all the time to have a valid estimate
 				if (!_valid) {
-					valid = (_hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f)
-						&& (_hover_thrust_ekf.getInnovationTestRatio() < 1.f);
-
-				} else {
-					// The test ratio does not need to pass all the time to have a valid estimate
-					valid = _hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f;
+					valid = valid && (_hover_thrust_ekf.getInnovationTestRatio() < 1.f);
 				}
 
 				_valid_hysteresis.set_state_and_update(valid, local_pos.timestamp);

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.cpp
@@ -172,8 +172,17 @@ void MulticopterHoverThrustEstimator::Run()
 					_hover_thrust_ekf.fuseAccZ(-local_pos.az, -local_pos_sp.thrust[2]);
 				}
 
-				const bool valid = (_hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f)
-						   && (_hover_thrust_ekf.getInnovationTestRatio() < 1.f);
+				bool valid;
+
+				if (!_valid) {
+					valid = (_hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f)
+						&& (_hover_thrust_ekf.getInnovationTestRatio() < 1.f);
+
+				} else {
+					// The test ratio does not need to pass all the time to have a valid estimate
+					valid = _hover_thrust_ekf.getHoverThrustEstimateVar() < 0.001f;
+				}
+
 				_valid_hysteresis.set_state_and_update(valid, local_pos.timestamp);
 				_valid = _valid_hysteresis.get_state();
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
On some platforms (such as VTOL planes), the test ratio sometimes jumps above 1 in case of wind gusts or thrust spikes. This isn't harmful to the Hover Thrust Estimator and the current estimate it still correct.

**Describe your solution**
The condition to get valid requires a low variance and test ratio. but
to stay valid, only the variance is required.

**Test data / coverage**
SITL test (takeoff, change of mass, landing)

![DeepinScreenshot_select-area_20210621102643](https://user-images.githubusercontent.com/14822839/122731051-3233d480-d27b-11eb-87aa-33042dee80f0.png)

https://logs.px4.io/plot_app?log=12fa674c-3d1c-480c-97b9-2d5c23ed0e14
