### PR TITLE
Better RC loss failsafe configuration options for BVLOS

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2566,15 +2566,15 @@ Commander::run()
 						       _armed,
 						       _internal_state,
 						       &_mavlink_log_pub,
-						       (link_loss_actions_t)_param_nav_dll_act.get(),
+						       static_cast<link_loss_actions_t>(_param_nav_dll_act.get()),
 						       _mission_result_sub.get().finished,
 						       _mission_result_sub.get().stay_in_failsafe,
 						       _status_flags,
 						       _land_detector.landed,
-						       (link_loss_actions_t)_param_nav_rcl_act.get(),
-						       (offboard_loss_actions_t)_param_com_obl_act.get(),
-						       (offboard_loss_rc_actions_t)_param_com_obl_rc_act.get(),
-						       (position_nav_loss_actions_t)_param_com_posctl_navl.get(),
+						       static_cast<link_loss_actions_t>(_param_nav_rcl_act.get()),
+						       static_cast<offboard_loss_actions_t>(_param_com_obl_act.get()),
+						       static_cast<offboard_loss_rc_actions_t>(_param_com_obl_rc_act.get()),
+						       static_cast<position_nav_loss_actions_t>(_param_com_posctl_navl.get()),
 						       _param_com_rcl_act_t.get());
 
 		if (nav_state_changed) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2575,7 +2575,8 @@ Commander::run()
 						       static_cast<offboard_loss_actions_t>(_param_com_obl_act.get()),
 						       static_cast<offboard_loss_rc_actions_t>(_param_com_obl_rc_act.get()),
 						       static_cast<position_nav_loss_actions_t>(_param_com_posctl_navl.get()),
-						       _param_com_rcl_act_t.get());
+						       _param_com_rcl_act_t.get(),
+						       _param_com_rcl_except.get());
 
 		if (nav_state_changed) {
 			_status.nav_state_timestamp = hrt_absolute_time();

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -198,6 +198,7 @@ private:
 
 		(ParamInt<px4::params::NAV_RCL_ACT>) _param_nav_rcl_act,
 		(ParamFloat<px4::params::COM_RCL_ACT_T>) _param_com_rcl_act_t,
+		(ParamInt<px4::params::COM_RCL_EXCEPT>) _param_com_rcl_except,
 
 		(ParamFloat<px4::params::COM_HOME_H_T>) _param_com_home_h_t,
 		(ParamFloat<px4::params::COM_HOME_V_T>) _param_com_home_v_t,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -833,7 +833,7 @@ PARAM_DEFINE_INT32(COM_FLIGHT_UUID, 0);
  *
  * @value 0 Hold
  * @value 1 Mission (if valid)
- * @group Mission
+ * @group Commander
  */
 PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);
 
@@ -851,7 +851,7 @@ PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);
  * @value 5 Terminate
  * @value 6 Lockdown
  *
- * @group Mission
+ * @group Commander
  */
 PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
 
@@ -869,7 +869,7 @@ PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
  * @value 5 Terminate
  * @value 6 Lockdown
  *
- * @group Mission
+ * @group Commander
  */
 PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 
@@ -877,7 +877,7 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
  * Flag to enable obstacle avoidance.
  *
  * @boolean
- * @group Mission
+ * @group Commander
  */
 PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -850,6 +850,8 @@ PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);
  * @value 3 Land mode
  * @value 5 Terminate
  * @value 6 Lockdown
+ * @min 0
+ * @max 6
  *
  * @group Commander
  */
@@ -862,16 +864,31 @@ PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
  * set by COM_RC_LOSS_T in seconds. If RC input checks have been disabled
  * by setting the COM_RC_IN_MODE param it will not be triggered.
  *
- * @value 0 Disabled
  * @value 1 Hold mode
  * @value 2 Return mode
  * @value 3 Land mode
  * @value 5 Terminate
  * @value 6 Lockdown
+ * @min 1
+ * @max 6
  *
  * @group Commander
  */
 PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
+
+/**
+ * RC loss exceptions
+ *
+ * Specify modes in which RC loss is ignored and the failsafe action not triggered.
+ *
+ * @min 0
+ * @max 31
+ * @bit 0 Mission
+ * @bit 1 Hold
+ * @bit 2 Offboard
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_RCL_EXCEPT, 0);
 
 /**
  * Flag to enable obstacle avoidance.

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -694,6 +694,34 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
+		} else if (status.data_link_lost && data_link_loss_act_configured && !landed && is_armed) {
+			// Data link lost, data link loss reaction configured -> do configured reaction
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, data_link_loss_act, 0);
+
+		} else if (status.rc_signal_lost && !(param_com_rcl_except & RCLossExceptionBits::RCL_EXCEPT_HOLD)
+			   && status_flags.rc_signal_found_once && is_armed && !landed) {
+			// RC link lost, rc loss not disabled in loiter, RC was used before -> RC loss reaction after delay
+			// Safety pilot expects to be able to take over by RC in case anything unexpected happens
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_rcl_act_t);
+
+		} else if (status.rc_signal_lost && !(param_com_rcl_except & RCLossExceptionBits::RCL_EXCEPT_HOLD)
+			   && status.data_link_lost && !data_link_loss_act_configured
+			   && is_armed && !landed) {
+			// All links lost, no data link loss reaction configured -> immediately do RC loss reaction
+			// Lost all communication, by default it's considered unsafe to continue the mission
+			// This is only reached when flying mission completely without RC (it was not present since boot)
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, 0);
+
+		} else if (status.rc_signal_lost && (param_com_rcl_except & RCLossExceptionBits::RCL_EXCEPT_HOLD)
+			   && status.data_link_lost && !data_link_loss_act_configured
+			   && is_armed && !landed) {
+			// All links lost, all link loss reactions disabled -> return
+			// Pilot disabled all reactions, return to avoid lost vehicle
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
 		} else {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -598,14 +598,6 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, 0);
 
-		} else if (status.rc_signal_lost && (param_com_rcl_except & RCLossExceptionBits::RCL_EXCEPT_HOLD)
-			   && status.data_link_lost && !data_link_loss_act_configured
-			   && is_armed && !landed) {
-			// All links lost, all link loss reactions disabled -> return
-			// Pilot disabled all reactions, return to avoid lost vehicle
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_datalink);
-			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
-
 		} else {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
 		}
@@ -715,14 +707,6 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			// This is only reached when flying mission completely without RC (it was not present since boot)
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, 0);
-
-		} else if (status.rc_signal_lost && (param_com_rcl_except & RCLossExceptionBits::RCL_EXCEPT_HOLD)
-			   && status.data_link_lost && !data_link_loss_act_configured
-			   && is_armed && !landed) {
-			// All links lost, all link loss reactions disabled -> return
-			// Pilot disabled all reactions, return to avoid lost vehicle
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_datalink);
-			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
 		} else {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -58,6 +58,7 @@ static constexpr const char reason_no_rc_and_no_offboard[] = "no RC and no offbo
 static constexpr const char reason_no_local_position[] = "no local position";
 static constexpr const char reason_no_global_position[] = "no global position";
 static constexpr const char reason_no_datalink[] = "no datalink";
+static constexpr const char reason_no_rc_and_no_datalink[] = "no RC and no datalink";
 
 // This array defines the arming state transitions. The rows are the new state, and the columns
 // are the current state. Using new state and current state you can index into the array which
@@ -558,7 +559,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			   && mission_finished) {
 			// All links lost, all link loss reactions disabled -> return after mission finished
 			// Pilot disabled all reactions, finish mission but then return to avoid lost vehicle
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
 		} else if (!stay_in_failsafe) {
@@ -602,7 +603,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			   && is_armed && !landed) {
 			// All links lost, all link loss reactions disabled -> return
 			// Pilot disabled all reactions, return to avoid lost vehicle
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
 		} else {
@@ -720,7 +721,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			   && is_armed && !landed) {
 			// All links lost, all link loss reactions disabled -> return
 			// Pilot disabled all reactions, return to avoid lost vehicle
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_datalink);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, link_loss_actions_t::AUTO_RTL, 0);
 
 		} else {

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -115,6 +115,12 @@ enum class arm_disarm_reason_t {
 	UNIT_TEST = 13
 };
 
+enum RCLossExceptionBits {
+	RCL_EXCEPT_MISSION = (1 << 0),
+	RCL_EXCEPT_HOLD = (1 << 1),
+	RCL_EXCEPT_OFFBOARD = (1 << 2)
+};
+
 transition_result_t
 arming_state_transition(vehicle_status_s &status, const safety_s &safety, const arming_state_t new_arming_state,
 			actuator_armed_s &armed, const bool fRunPreArmChecks, orb_advert_t *mavlink_log_pub,
@@ -133,7 +139,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		   const link_loss_actions_t rc_loss_act, const offboard_loss_actions_t offb_loss_act,
 		   const offboard_loss_rc_actions_t offb_loss_rc_act,
 		   const position_nav_loss_actions_t posctl_nav_loss_act,
-		   const float param_com_rcl_act_t);
+		   const float param_com_rcl_act_t, const int param_com_rcl_except);
 
 /*
  * Checks the validty of position data against the requirements of the current navigation


### PR DESCRIPTION
**Describe problem solved by this pull request**
Resolves https://github.com/PX4/PX4-Autopilot/pull/16864

Some Pilots in BVLOS (Beyond Visual Line Of Sight) scenarios want to be able to **fly foremost missions but presumably also loiter/offboard even when they lose the RC link that is present at boot**. To currently do that the only way is disabling the RC (Remote Control) loss reaction https://docs.px4.io/master/en/advanced_config/parameter_reference.html#NAV_RCL_ACT which is generally not safe to do if you ever fly relying on RC stick input because then the vehicle will ignore the link loss and just keep on using the last known value e.g. in stabilized mode.

I also realized that there are **no reactions in takeoff mode for link loss**. This could potentially result in a flyaway with an unreachable takeoff altitude with lost link.

**Describe your solution**
As discussed with @dagar and I think also @julianoes and others:
- I'm **not allowing to disable the RC loss action** anymore.
- Instead, I give the **option to specifically configure exceptions for certain modes such that the vehicle continues to fly even though a present RC is lost mid-flight**.
- Do link loss failsafe reactions in takeoff like in loiter/hold mode.

**Describe possible alternatives**
The reasoning is:
- By default, if a pilot connects an RC and flies whatever mode and has RC loss configured (default) he expects the failsafe to kick in. Typical use cases are flying missions or offboard with a safety pilot on-site watching the drone and expecting he can take over if something goes wrong at any point in time. In certain legislations this is even the mandatory workflow without a special permit.
- Allowing BVLOS operations in combination with RC for takeoff and landing for certain scenarios and products like @sanderux's.

Possible follow-ups:
- I'm aware that NAV_RCL_ACT can still be forced to disabled and that should be completely disallowed/ignored. It currently doesn't break backwards compatibility although I see no reason why anyone would disable the failsafe given the new options.
- A lot of the failsafe logic between autonomous modes are duplicated. I didn't go through unifying but it might be possible to simplify and make it more readable mostly in the interest of reducing error-proneness. E.g. it works correctly for mission but not some other mode that wasn't tested in the same corner case (e.g. takeoff).

**Test data / coverage**
I SITL tested the RC loss exception bits to act exactly like intended.
Failsafe in takeoff also works as expected.

The only thing I noticed which is independent of this pr is that the RC loss delay uses Hold mode to delay the vehicle's reaction but since goto (for some reason) is Hold mode the drone continues upon RC loss for the delay time towards the goto waypoint. I think we should really make goto a separate mode.

I noticed another thing: QGC seems to magically know about the parameter description that I just added without me recompiling with the adjusted reference xml. But there seems to be an off-by-one bug somewhere. The zeroth bit does not att anythign and the first bit adds one. I checked and other parameter bitfields are also defined zero based.
![image](https://user-images.githubusercontent.com/4668506/122789187-531a1b00-d2b7-11eb-9a2f-8493ec8b07b7.png)

