### PR TITLE
ekf2_params: enable baro ground effect compensation by default

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -543,7 +543,7 @@ PARAM_DEFINE_FLOAT(EKF2_BARO_GATE, 5.0f);
  * @unit m
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(EKF2_GND_EFF_DZ, 0.0f);
+PARAM_DEFINE_FLOAT(EKF2_GND_EFF_DZ, 4.0f);
 
 /**
  * Height above ground level for ground effect zone


### PR DESCRIPTION
**Describe problem solved by this pull request**
By default people currently fly without ground effect compensation which spoils barometer-based altitude estimates close to the ground which is a problem especially on landing because the drone amplifies negative effects by decelerating vertically and giving more thrust towards the ground and the altitude estimate is crucial for a linear smooth landing approach and detection.

**Describe your solution**
I suggest enabling the compensation by default. We found in our testing that a deadzone for barometer innovations `EKF2_GND_EFF_DZ` of 4m is a conservative value that helps in most cases where vehicles suffer from landing issues. `EKF2_GND_MAX_HGT` is already set such that the compensation has an effect when less than 0.5m above ground which I think can only be detected with a distance sensor. 

**Describe possible alternatives**
In the code the parameter `EKF2_GND_EFF_DZ` is initialized with 5m:
https://github.com/PX4/PX4-ECL/blob/master/EKF/common.h#L262
Any data based reason? Better default @priseborough ?

The only upstream airframe configuring this parameter are Unify IFO and IFO S and they set it to 6m:
https://github.com/PX4/PX4-Autopilot/blame/0b50f85096553d9dcecc415fbb37d5b9b757831e/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s#L83
Any data based reason? Better default @hyonlim ?

**Test data / coverage**
This configuration was extensively tested on a platform with big propellers and low rotor disks when on ground suffering strong altitude innovations when relying on the barometer. All visible issues in landing approach and log could be fixed by enabling the compensation. Note: It was not tested on any platform without distance sensor. Do you expect any issues @priseborough?
