### PR TITLE
Broadcom AFBR-S50LV85D Distance Sensor Driver: Publish Quality

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -93,7 +93,15 @@ void AFBRS50::ProcessMeasurement(void *data)
 		if ((evaluate_status == STATUS_OK) && (res.Status == 0)) {
 			uint32_t result_mm = res.Bin.Range / (Q9_22_ONE / 1000);
 			float result_m = static_cast<float>(result_mm) / 1000.f;
-			_px4_rangefinder.update(((res.TimeStamp.sec * 1000000ULL) + res.TimeStamp.usec), result_m);
+			int8_t quality = 100;
+
+			// distance quality check
+			if (result_m < _min_distance || result_m > _max_distance) {
+				result_m = 0.0;
+				quality = 0;
+			}
+
+			_px4_rangefinder.update(((res.TimeStamp.sec * 1000000ULL) + res.TimeStamp.usec), result_m, quality);
 		}
 	}
 }
@@ -137,36 +145,46 @@ int AFBRS50::init()
 
 		// FALLTHROUGH
 		case AFBR_S50MV85G_V3:
-			_px4_rangefinder.set_min_distance(0.08f);
-			_px4_rangefinder.set_max_distance(10.f);
+			_min_distance = 0.08f;
+			_max_distance = 10.f;
+			_px4_rangefinder.set_min_distance(_min_distance);
+			_px4_rangefinder.set_max_distance(_max_distance);
 			_px4_rangefinder.set_fov(math::radians(6.f));
 			PX4_INFO_RAW("AFBR-S50MV85G\n");
 			break;
 
 		case AFBR_S50LV85D_V1:
-			_px4_rangefinder.set_min_distance(0.08f);
-			_px4_rangefinder.set_max_distance(30.f);
+			_min_distance = 0.08f;
+			_max_distance = 30.f;	// Short range mode
+			_px4_rangefinder.set_min_distance(_min_distance);
+			_px4_rangefinder.set_max_distance(_max_distance);
 			_px4_rangefinder.set_fov(math::radians(6.f));
 			PX4_INFO_RAW("AFBR-S50LV85D (v1)\n");
 			break;
 
 		case AFBR_S50MV68B_V1:
-			_px4_rangefinder.set_min_distance(0.08f);
-			_px4_rangefinder.set_max_distance(10.f);
+			_min_distance = 0.08f;
+			_max_distance = 10.f;
+			_px4_rangefinder.set_min_distance(_min_distance);
+			_px4_rangefinder.set_max_distance(_max_distance);
 			_px4_rangefinder.set_fov(math::radians(1.f));
 			PX4_INFO_RAW("AFBR-S50MV68B (v1)\n");
 			break;
 
 		case AFBR_S50MV85I_V1:
-			_px4_rangefinder.set_min_distance(0.08f);
-			_px4_rangefinder.set_max_distance(5.f);
+			_min_distance = 0.08f;
+			_max_distance = 5.f;
+			_px4_rangefinder.set_min_distance(_min_distance);
+			_px4_rangefinder.set_max_distance(_max_distance);
 			_px4_rangefinder.set_fov(math::radians(6.f));
 			PX4_INFO_RAW("AFBR-S50MV85I (v1)\n");
 			break;
 
 		case AFBR_S50SV85K_V1:
-			_px4_rangefinder.set_min_distance(0.08f);
-			_px4_rangefinder.set_max_distance(10.f);
+			_min_distance = 0.08f;
+			_max_distance = 10.f;
+			_px4_rangefinder.set_min_distance(_min_distance);
+			_px4_rangefinder.set_max_distance(_max_distance);
 			_px4_rangefinder.set_fov(math::radians(4.f));
 			PX4_INFO_RAW("AFBR-S50SV85K (v1)\n");
 			break;

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -89,4 +89,7 @@ private:
 	hrt_abstime _measurement_time{0};
 
 	perf_counter_t _sample_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": sample interval")};
+
+	float _max_distance;
+	float _min_distance;
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR for the Broadcom AFBR-S50LV85D Distance Sensor driver prevents the sensor from publishing invalid measurements when too close or far from the surface. The issue noticed was that before lift off, the drone would measure distances on the scale of 1000's of meters. Once the sensor was an acceptable distance from the ground, measurements recording was accurate.

**Describe your solution**
Measured data is gated to ensure the value is within the sensor's minimum and maximum range before publishing. For invalid measurements, a value of zero meters is published instead with a signal quality of zero.

**Test data / coverage**
The driver was tested on an ARK Flow running as a uavcannode with a Pixhawk 4 Mini on 1.12 beta 5. The system was also running an ARK GPS on UAVCAN.

ARK Flow and ARK GPS on 1.12 beta5: https://review.px4.io/plot_app?log=9ee433a5-7694-41bb-8d96-3437803a0d54

![IMG_4234](https://user-images.githubusercontent.com/46569551/123029921-26413300-d39f-11eb-9d4c-cb003de6b02d.jpg)

![IMG_4237](https://user-images.githubusercontent.com/46569551/123029935-2e00d780-d39f-11eb-8d7b-6a5c525141af.jpg)


