### PR TITLE
ARK CAN Flow Add ICM-42688-P

### DIFF
--- a/boards/ark/can-flow/debug.cmake
+++ b/boards/ark/can-flow/debug.cmake
@@ -14,6 +14,7 @@ px4_add_board(
 		bootloaders
 		distance_sensor/broadcom/afbrs50
 		imu/bosch/bmi088
+		imu/invensense/icm42688p
 		optical_flow/paw3902
 		uavcannode
 	MODULES

--- a/boards/ark/can-flow/default.cmake
+++ b/boards/ark/can-flow/default.cmake
@@ -15,6 +15,7 @@ px4_add_board(
 		bootloaders
 		distance_sensor/broadcom/afbrs50
 		imu/bosch/bmi088
+		imu/invensense/icm42688p
 		optical_flow/paw3902
 		uavcannode
 	MODULES

--- a/boards/ark/can-flow/init/rc.board_sensors
+++ b/boards/ark/can-flow/init/rc.board_sensors
@@ -5,7 +5,11 @@
 
 # Internal SPI
 paw3902 -s start -Y 180
-bmi088 -A -s -R 4 start
-bmi088 -G -s -R 4 start
+
+if ! icm42688p -R 0 -s start
+then
+	bmi088 -A -s -R 4 start
+	bmi088 -G -s -R 4 start
+fi
 
 afbrs50 start

--- a/boards/ark/can-flow/src/spi.cpp
+++ b/boards/ark/can-flow/src/spi.cpp
@@ -39,6 +39,7 @@ constexpr px4_spi_bus_t px4_spi_buses[SPI_BUS_MAX_BUS_ITEMS] = {
 	initSPIBus(SPI::Bus::SPI1, {
 		initSPIDevice(DRV_GYR_DEVTYPE_BMI088, SPI::CS{GPIO::PortA, GPIO::Pin15}, SPI::DRDY{GPIO::PortA, GPIO::Pin10}),
 		initSPIDevice(DRV_ACC_DEVTYPE_BMI088, SPI::CS{GPIO::PortA, GPIO::Pin4}, SPI::DRDY{GPIO::PortB, GPIO::Pin0}),
+		initSPIDevice(DRV_IMU_DEVTYPE_ICM42688P, SPI::CS{GPIO::PortA, GPIO::Pin4}, SPI::DRDY{GPIO::PortB, GPIO::Pin0}),
 		initSPIDevice(DRV_FLOW_DEVTYPE_PAW3902, SPI::CS{GPIO::PortB, GPIO::Pin5}, SPI::DRDY{GPIO::PortB, GPIO::Pin2}),
 	}),
 	initSPIBus(SPI::Bus::SPI2, {


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds support for the ARK CAN Flow Rev 2 that swaps out the BMI088 for the ICM-42688-P due to lack of availability of the BMI088.

**Describe your solution**
Add the ICM-42688-P in the build. Check if the ICM-42688-P driver doesn't start, then start the BMI088 driver.

![image](https://user-images.githubusercontent.com/2019539/123330434-3ec66000-d4fb-11eb-8f5c-c5e3fe74d433.png)
![image](https://user-images.githubusercontent.com/2019539/123331435-8699b700-d4fc-11eb-97e9-f99c15f484bd.png)

