### PR TITLE
Airspeed validator: load factor check: Use acceleration in vertical b…

### DIFF
--- a/src/lib/airspeed_validator/AirspeedValidator.cpp
+++ b/src/lib/airspeed_validator/AirspeedValidator.cpp
@@ -53,7 +53,7 @@ AirspeedValidator::update_airspeed_validator(const airspeed_validator_update_dat
 			      input_data.lpos_vz, input_data.lpos_evh, input_data.lpos_evv, input_data.att_q);
 	update_in_fixed_wing_flight(input_data.in_fixed_wing_flight);
 	check_airspeed_innovation(input_data.timestamp, input_data.vel_test_ratio, input_data.mag_test_ratio);
-	check_load_factor(input_data.accel_z);
+	check_load_factor(input_data.accel);
 	update_airspeed_valid_status(input_data.timestamp);
 }
 
@@ -183,7 +183,7 @@ AirspeedValidator::check_airspeed_innovation(uint64_t time_now, float estimator_
 
 
 void
-AirspeedValidator::check_load_factor(float accel_z)
+AirspeedValidator::check_load_factor(const float accel[3])
 {
 	// Check if the airpeed reading is lower than physically possible given the load factor
 
@@ -191,7 +191,8 @@ AirspeedValidator::check_load_factor(float accel_z)
 
 		float max_lift_ratio = fmaxf(_CAS, 0.7f) / fmaxf(_airspeed_stall, 1.0f);
 		max_lift_ratio *= max_lift_ratio;
-		_load_factor_ratio = 0.95f * _load_factor_ratio + 0.05f * (fabsf(accel_z) / 9.81f) / max_lift_ratio;
+		float accel_xz = sqrtf(accel[0] * accel[0] + accel[2] * accel[2]);
+		_load_factor_ratio = 0.95f * _load_factor_ratio + 0.05f * (accel_xz / 9.81f) / max_lift_ratio;
 		_load_factor_ratio = math::constrain(_load_factor_ratio, 0.25f, 2.0f);
 		_load_factor_check_failed = (_load_factor_ratio > 1.1f);
 

--- a/src/lib/airspeed_validator/AirspeedValidator.hpp
+++ b/src/lib/airspeed_validator/AirspeedValidator.hpp
@@ -64,7 +64,7 @@ struct airspeed_validator_update_data {
 	float att_q[4];
 	float air_pressure_pa;
 	float air_temperature_celsius;
-	float accel_z;
+	float accel[3];
 	float vel_test_ratio;
 	float mag_test_ratio;
 	bool in_fixed_wing_flight;
@@ -160,7 +160,7 @@ private:
 	void update_CAS_TAS(float air_pressure_pa, float air_temperature_celsius);
 	void check_airspeed_innovation(uint64_t timestamp, float estimator_status_vel_test_ratio,
 				       float estimator_status_mag_test_ratio);
-	void check_load_factor(float accel_z);
+	void check_load_factor(const float accel[3]);
 	void update_airspeed_valid_status(const uint64_t timestamp);
 	void reset();
 

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -330,7 +330,9 @@ AirspeedModule::Run()
 		input_data.att_q[2] = _vehicle_attitude.q[2];
 		input_data.att_q[3] = _vehicle_attitude.q[3];
 		input_data.air_pressure_pa = _vehicle_air_data.baro_pressure_pa;
-		input_data.accel_z = _accel.xyz[2];
+		input_data.accel[0] = _accel.xyz[0];
+		input_data.accel[1] = _accel.xyz[1];
+		input_data.accel[2] = _accel.xyz[2];
 		input_data.vel_test_ratio = _estimator_status.vel_test_ratio;
 		input_data.mag_test_ratio = _estimator_status.mag_test_ratio;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
The airspeed validator load factor check uses the acceleration in body Z axis to estimate the lift force. As a result:

- (Minor problem) For airplanes and regular VTOLs: the angle of attack (difference between body frame and flight path) is not taken into account. Therefore, the acceleration used corresponds to a combination of a (large) part of the lift and a (small) part of the drag and thrust, where the fractions depend on the angle of attack.
- (Main problem) For tailsitters: the acceleration used is along the body and therefore almost aligned with the airstream instead of perpendicular to the airstream. It is always very small compared to gravity, therefore making the check always pass.

**Describe your solution**
Instead of the acceleration in body Z axis, the acceleration in the vertical (XZ) body plane can be taken. This is the acceleration resulting from lift, drag and thrust. Since drag and thrust are approximately equal when compared to the lift, they cancel out effectively resulting in an acceleration that corresponds to lift.

As a bonus, this solution works out-of-the-box for tailsitters.

**Describe possible alternatives**
Ideally the lift is estimated by taking the acceleration component perpendicular to the (air) flight path. This would would require using an estimate of the wind. That approach seems way to fragile and complicated.

**Test data / coverage**
The problem was confirmed by using Gazebo:
- Fly with tailsitter in forward flight
- In the PX4 code: Airspeed validator check_airspeed_innovation (the other check) was disabled and validator outcome was logged
- In Gazebo: Airspeed sensor was sabotaged after 100 seconds

Master: https://review.px4.io/plot_app?log=f875d2c0-0a9d-4f84-9fcc-61c3735b6a9f
This PR: https://review.px4.io/plot_app?log=c433a897-d4bb-42f6-90b5-b130255fe2ef

![image](https://user-images.githubusercontent.com/57276/123387122-b944bd80-d597-11eb-9779-57bcb424e28d.png)

With master, when the airspeed sensor was sabotaged, the airspeed was still considered valid and the aircraft crashed.

With this pull request, the airspeed was declared invalid soon after it was sabotaged, and the aircraft continued flying.

**Additional context**
N/A
