### PR TITLE
microRTPS: increase base message ID space and update protocol_splitter header

### DIFF
--- a/msg/tools/uorb_rtps_classifier.py
+++ b/msg/tools/uorb_rtps_classifier.py
@@ -49,7 +49,7 @@ class Classifier():
         self.msg_folder = msg_folder
         self.all_msgs_list = self.set_all_msgs()
         self.msg_id_map = self.parse_yaml_msg_id_file(yaml_file)
-        self.alias_space_init_id = 170
+        self.alias_space_init_id = 180
 
         # Checkers
         self.check_if_listed(yaml_file)

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -343,109 +343,109 @@ rtps:
     id: 159
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
-    id: 170
+    id: 180
     alias: actuator_controls
   - msg: actuator_controls_1
-    id: 171
+    id: 181
     alias: actuator_controls
   - msg: actuator_controls_2
-    id: 172
+    id: 182
     alias: actuator_controls
   - msg: actuator_controls_3
-    id: 173
+    id: 183
     alias: actuator_controls
   - msg: actuator_controls_virtual_fw
-    id: 174
+    id: 184
     alias: actuator_controls
   - msg: actuator_controls_virtual_mc
-    id: 175
+    id: 185
     alias: actuator_controls
   - msg: mc_virtual_attitude_setpoint
-    id: 176
+    id: 186
     alias: vehicle_attitude_setpoint
   - msg: fw_virtual_attitude_setpoint
-    id: 177
+    id: 187
     alias: vehicle_attitude_setpoint
   - msg: vehicle_attitude_groundtruth
-    id: 178
+    id: 188
     alias: vehicle_attitude
   - msg: vehicle_global_position_groundtruth
-    id: 179
+    id: 189
     alias: vehicle_global_position
   - msg: vehicle_local_position_groundtruth
-    id: 180
+    id: 190
     alias: vehicle_local_position
   - msg: vehicle_mocap_odometry
     alias: vehicle_odometry
-    id: 181
+    id: 191
     receive: true
   - msg: vehicle_visual_odometry
-    id: 182
+    id: 192
     alias: vehicle_odometry
     receive: true
   - msg: vehicle_trajectory_waypoint_desired
-    id: 183
+    id: 193
     alias: vehicle_trajectory_waypoint
     send: true
   - msg: obstacle_distance_fused
-    id: 184
+    id: 194
     alias: obstacle_distance
   - msg: vehicle_vision_attitude
-    id: 185
+    id: 195
     alias: vehicle_attitude
   - msg: trajectory_setpoint
-    id: 186
+    id: 196
     alias: vehicle_local_position_setpoint
     receive: true
   - msg: camera_trigger_secondary
-    id: 187
+    id: 197
     alias: camera_trigger
   - msg: vehicle_angular_velocity_groundtruth
-    id: 188
+    id: 198
     alias: vehicle_angular_velocity
   - msg: estimator_visual_odometry_aligned
-    id: 189
+    id: 199
     alias: vehicle_odometry
   - msg: estimator_innovation_variances
-    id: 190
+    id: 200
     alias: estimator_innovations
   - msg: estimator_innovation_test_ratios
-    id: 191
+    id: 201
     alias: estimator_innovations
   - msg: orb_multitest
-    id: 192
+    id: 202
     alias: orb_test
   - msg: orb_test_medium_multi
-    id: 193
+    id: 203
     alias: orb_test_medium
   - msg: orb_test_medium_queue
-    id: 194
+    id: 204
     alias: orb_test_medium
   - msg: orb_test_medium_queue_poll
-    id: 195
+    id: 205
     alias: orb_test_medium
   - msg: orb_test_medium_wrap_around
-    id: 196
+    id: 206
     alias: orb_test_medium
   - msg: estimator_local_position
-    id: 197
+    id: 207
     alias: vehicle_local_position
   - msg: estimator_global_position
-    id: 198
+    id: 208
     alias: vehicle_global_position
   - msg: estimator_attitude
-    id: 199
+    id: 209
     alias: vehicle_attitude
   - msg: estimator_odometry
-    id: 200
+    id: 210
     alias: vehicle_odometry
   - msg: actuator_controls_4
-    id: 201
+    id: 211
     alias: actuator_controls
   - msg: actuator_controls_5
-    id: 202
+    id: 212
     alias: actuator_controls
   - msg: estimator_wind
-    id: 203
+    id: 213
     alias: wind
   ########## multi topics: end ##########

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -86,7 +86,7 @@ typedef union __attribute__((packed))
 		uint8_t len_h:	7,         // Length MSB
 			 type:	1;         // 0=MAVLINK, 1=RTPS
 		uint8_t len_l;             // Length LSB
-		uint8_t checksum;          // XOR of two above bytes
+		uint8_t checksum;          // XOR of the three bytes above
 	} fields;
 } Sp2Header_t;
 
@@ -352,7 +352,7 @@ ssize_t Mavlink2Dev::read(struct file *filp, char *buffer, size_t buflen)
 	       (((Sp2Header_t *) &_read_buffer->buffer[i])->fields.magic != Sp2HeaderMagic
 		|| ((Sp2Header_t *) &_read_buffer->buffer[i])->fields.type != (uint8_t)MessageType::Mavlink
 		|| ((Sp2Header_t *) &_read_buffer->buffer[i])->fields.checksum !=
-		(_read_buffer->buffer[i + 1] ^ _read_buffer->buffer[i + 2])
+		(_read_buffer->buffer[i] ^ _read_buffer->buffer[i + 1] ^ _read_buffer->buffer[i + 2])
 	       )) {
 		i++;
 	}
@@ -446,7 +446,7 @@ ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
 			} else {
 				_header.fields.len_h = (buflen >> 8) & 0x7f;
 				_header.fields.len_l = buflen & 0xff;
-				_header.fields.checksum = _header.bytes[1] ^ _header.bytes[2];
+				_header.fields.checksum = _header.bytes[0] ^ _header.bytes[1] ^ _header.bytes[2];
 				::write(_fd, _header.bytes, 4);
 				ret = ::write(_fd, buffer, buflen);
 			}
@@ -519,7 +519,7 @@ ssize_t RtpsDev::read(struct file *filp, char *buffer, size_t buflen)
 	       (((Sp2Header_t *) &_read_buffer->buffer[i])->fields.magic != Sp2HeaderMagic
 		|| ((Sp2Header_t *) &_read_buffer->buffer[i])->fields.type != (uint8_t)MessageType::Rtps
 		|| ((Sp2Header_t *) &_read_buffer->buffer[i])->fields.checksum !=
-		(_read_buffer->buffer[i + 1] ^ _read_buffer->buffer[i + 2])
+		(_read_buffer->buffer[i] ^ _read_buffer->buffer[i + 1] ^ _read_buffer->buffer[i + 2])
 	       )) {
 		i++;
 	}
@@ -595,7 +595,7 @@ ssize_t RtpsDev::write(struct file *filp, const char *buffer, size_t buflen)
 			} else {
 				_header.fields.len_h = (buflen >> 8) & 0x7f;
 				_header.fields.len_l = buflen & 0xff;
-				_header.fields.checksum = _header.bytes[1] ^ _header.bytes[2];
+				_header.fields.checksum = _header.bytes[0] ^ _header.bytes[1] ^ _header.bytes[2];
 				::write(_fd, _header.bytes, 4);
 				ret = ::write(_fd, buffer, buflen);
 			}


### PR DESCRIPTION
**Describe problem solved by this pull request**
- Preventing and actively adding a bit more room to base messages RTPS IDs
- Follow the update and fix to the agent_protocol_splitter in https://github.com/Auterion/agent_protocol_splitter/pull/14.

**Describe your solution**
- Increase the base ID space to 179, and update the alias messages IDs accordingly;
- On the protocol_splitter, now we include the magic number on XOR for checksum.

**Describe possible alternatives**
N.A.

**Test data / coverage**
Tested with SITL and the Auterion Skynode.