### PR TITLE
vtol: fix pwm max init

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -853,6 +853,9 @@ PX4IO::init()
 		_primary_pwm_device = true;
 	}
 
+	/* ensure PWM limits are applied before any other module starts */
+	update_params();
+
 	/* start the IO interface task */
 	_task = px4_task_spawn_cmd("px4io",
 				   SCHED_DEFAULT,

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -77,8 +77,6 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	for (auto &pwm_disarmed : _disarmed_pwm_values.values) {
 		pwm_disarmed = PWM_MOTOR_OFF;
 	}
-
-	_current_max_pwm_values = _max_mc_pwm_values;
 }
 
 bool VtolType::init()
@@ -93,7 +91,7 @@ bool VtolType::init()
 	}
 
 	int ret = px4_ioctl(fd, PWM_SERVO_GET_MAX_PWM, (long unsigned int)&_max_mc_pwm_values);
-
+	_current_max_pwm_values = _max_mc_pwm_values;
 
 	if (ret != PX4_OK) {
 		PX4_ERR("failed getting max values");


### PR DESCRIPTION
- px4io: ensure pwm params are loaded before any other module starts
-  fix vtol_att_control: set _current_max_pwm_values to current values on init