### PR TITLE
platforms/nuttx: px4_init initialize and reset all I2C buses

### DIFF
--- a/boards/freefly/can-rtk-gps/src/led.cpp
+++ b/boards/freefly/can-rtk-gps/src/led.cpp
@@ -115,8 +115,6 @@ RGBLED_NCP5623C::init()
 int
 RGBLED_NCP5623C::probe()
 {
-	_retries = 4;
-
 	return write(NCP5623_LED_CURRENT, 0x00);
 }
 

--- a/boards/nxp/ucans32k146/src/CMakeLists.txt
+++ b/boards/nxp/ucans32k146/src/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
 		bringup.c
 		buttons.c
 		clockconfig.c
-		# i2c.cpp # TODO
+		i2c.cpp
 		init.c
 		mtd.cpp
 		periphclocks.c

--- a/platforms/nuttx/src/px4/nxp/s32k14x/include/px4_arch/i2c_hw_description.h
+++ b/platforms/nuttx/src/px4/nxp/s32k14x/include/px4_arch/i2c_hw_description.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#pragma once
+
+#include <px4_arch/hw_description.h>
+#include <px4_platform_common/i2c.h>
+
+static inline constexpr px4_i2c_bus_t initI2CBusInternal(int bus)
+{
+	px4_i2c_bus_t ret{};
+	ret.bus = bus;
+	ret.is_external = false;
+	return ret;
+}
+
+static inline constexpr px4_i2c_bus_t initI2CBusExternal(int bus)
+{
+	px4_i2c_bus_t ret{};
+	ret.bus = bus;
+	ret.is_external = true;
+	return ret;
+}

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/include/px4_arch/i2c_hw_description.h
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/include/px4_arch/i2c_hw_description.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#pragma once
+
+#include <px4_arch/hw_description.h>
+#include <px4_platform_common/i2c.h>
+
+static inline constexpr px4_i2c_bus_t initI2CBusInternal(int bus)
+{
+	px4_i2c_bus_t ret{};
+	ret.bus = bus;
+	ret.is_external = false;
+	return ret;
+}
+
+static inline constexpr px4_i2c_bus_t initI2CBusExternal(int bus)
+{
+	px4_i2c_bus_t ret{};
+	ret.bus = bus;
+	ret.is_external = true;
+	return ret;
+}

--- a/src/drivers/barometer/lps22hb/LPS22HB_I2C.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB_I2C.cpp
@@ -72,19 +72,17 @@ int LPS22HB_I2C::probe()
 {
 	uint8_t id = 0;
 
-	_retries = 10;
-
 	if (read(WHO_AM_I, &id, 1)) {
 		DEVICE_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
-	_retries = 2;
-
 	if (id != LPS22HB_ID_WHO_AM_I) {
 		DEVICE_DEBUG("ID byte mismatch (%02x != %02x)", LPS22HB_ID_WHO_AM_I, id);
 		return -EIO;
 	}
+
+	_retries = 1;
 
 	return PX4_OK;
 }

--- a/src/drivers/barometer/lps25h/lps25h_i2c.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_i2c.cpp
@@ -71,19 +71,17 @@ int LPS25H_I2C::probe()
 {
 	uint8_t id;
 
-	_retries = 10;
-
 	if (read(ADDR_WHO_AM_I, &id, 1)) {
 		DEVICE_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
-	_retries = 2;
-
 	if (id != ID_WHO_AM_I) {
 		DEVICE_DEBUG("ID byte mismatch (%02x != %02x)", ID_WHO_AM_I, id);
 		return -EIO;
 	}
+
+	_retries = 1;
 
 	return OK;
 }

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
@@ -85,17 +85,14 @@ int MPL3115A2::init()
 
 int MPL3115A2::probe()
 {
-	_retries = 10;
 	uint8_t whoami = 0;
 
 	if ((RegisterRead(MPL3115A2_REG_WHO_AM_I, &whoami) > 0) && (whoami == MPL3115A2_WHO_AM_I)) {
-		/*
-		 * Disable retries; we may enable them selectively in some cases,
-		 * but the device gets confused if we retry some of the commands.
-		 */
-		_retries = 0;
+
 		return PX4_OK;
 	}
+
+	_retries = 1;
 
 	return -EIO;
 }
@@ -198,11 +195,6 @@ int MPL3115A2::measure()
 	// Send the command to read the ADC for P and T.
 	unsigned addr = (MPL3115A2_CTRL_REG1 << 8) | MPL3115A2_CTRL_TRIGGER;
 
-	/*
-	 * Disable retries on this command; we can't know whether failure
-	 * means the device did or did not see the command.
-	 */
-	_retries = 0;
 	int ret = RegisterWrite((addr >> 8) & 0xff, addr & 0xff);
 
 	if (ret == -EIO) {

--- a/src/drivers/barometer/ms5611/ms5611_i2c.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_i2c.cpp
@@ -141,17 +141,13 @@ MS5611_I2C::ioctl(unsigned operation, unsigned &arg)
 int
 MS5611_I2C::probe()
 {
-	_retries = 10;
-
 	if ((PX4_OK == _probe_address(MS5611_ADDRESS_1)) ||
 	    (PX4_OK == _probe_address(MS5611_ADDRESS_2))) {
-		/*
-		 * Disable retries; we may enable them selectively in some cases,
-		 * but the device gets confused if we retry some of the commands.
-		 */
-		_retries = 0;
+
 		return PX4_OK;
 	}
+
+	_retries = 1;
 
 	return -EIO;
 }
@@ -183,7 +179,7 @@ MS5611_I2C::_reset()
 	int		result;
 
 	/* bump the retry count */
-	_retries = 10;
+	_retries = 3;
 	result = transfer(&cmd, 1, nullptr, 0);
 	_retries = old_retrycount;
 
@@ -193,12 +189,6 @@ MS5611_I2C::_reset()
 int
 MS5611_I2C::_measure(unsigned addr)
 {
-	/*
-	 * Disable retries on this command; we can't know whether failure
-	 * means the device did or did not see the command.
-	 */
-	_retries = 0;
-
 	uint8_t cmd = addr;
 	return transfer(&cmd, 1, nullptr, 0);
 }

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -49,8 +49,6 @@ LidarLiteI2C::LidarLiteI2C(const I2CSPIDriverConfig &config) :
 	_px4_rangefinder.set_min_distance(LL40LS_MIN_DISTANCE);
 	_px4_rangefinder.set_max_distance(LL40LS_MAX_DISTANCE);
 	_px4_rangefinder.set_fov(0.008); // Divergence 8 mRadian
-	// up the retries since the device misses the first measure attempts
-	_retries = 3;
 
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_LL40LS); /// TODO
 }
@@ -126,9 +124,6 @@ LidarLiteI2C::probe()
 	uint8_t id_high = 0;
 	uint8_t id_low = 0;
 
-	// more retries for detection
-	_retries = 10;
-
 	for (uint8_t i = 0; i < sizeof(addresses); i++) {
 
 		set_device_address(addresses[i]);
@@ -196,7 +191,7 @@ LidarLiteI2C::probe()
 				}
 			}
 
-			_retries = 3;
+			_retries = 1;
 			return OK;
 		}
 

--- a/src/drivers/distance_sensor/teraranger/TERARANGER.cpp
+++ b/src/drivers/distance_sensor/teraranger/TERARANGER.cpp
@@ -78,9 +78,6 @@ TERARANGER::TERARANGER(const I2CSPIDriverConfig &config) :
 	I2CSPIDriver(config),
 	_px4_rangefinder(get_device_id(), config.rotation)
 {
-	// up the retries since the device misses the first measure attempts
-	I2C::_retries = 3;
-
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_TERARANGER);
 	_px4_rangefinder.set_rangefinder_type(distance_sensor_s::MAV_DISTANCE_SENSOR_LASER);
 }
@@ -242,6 +239,7 @@ int TERARANGER::probe()
 	// Can't use a single transfer as Teraranger needs a bit of time for internal processing.
 	if (transfer(&cmd, 1, nullptr, 0) == OK) {
 		if (transfer(nullptr, 0, &who_am_i, 1) == OK && who_am_i == TERARANGER_WHO_AM_I_REG_VAL) {
+			_retries = 1;
 			return measure();
 		}
 	}

--- a/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
+++ b/src/drivers/distance_sensor/vl53l0x/VL53L0X.cpp
@@ -69,8 +69,8 @@ VL53L0X::VL53L0X(const I2CSPIDriverConfig &config) :
 	_px4_rangefinder.set_max_distance(2.f);
 	_px4_rangefinder.set_fov(math::radians(25.f));
 
-	// Allow 3 retries as the device typically misses the first measure attempts.
-	I2C::_retries = 3;
+	// Allow retries as the device typically misses the first measure attempts.
+	I2C::_retries = 1;
 
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_VL53L0X);
 }

--- a/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
+++ b/src/drivers/distance_sensor/vl53l1x/vl53l1x.cpp
@@ -150,9 +150,6 @@ VL53L1X::VL53L1X(const I2CSPIDriverConfig &config) :
 	_px4_rangefinder.set_max_distance(2.f);
 	_px4_rangefinder.set_fov(math::radians(25.f));
 
-	// Allow 3 retries as the device typically misses the first measure attempts.
-	I2C::_retries = 3;
-
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_VL53L1X);
 }
 
@@ -214,6 +211,8 @@ int VL53L1X::probe()
 	if ((ret != PX4_OK) | (data != _device_id.devid_s.address)) {
 		return -EIO;
 	}
+
+	_retries = 1;
 
 	return PX4_OK;
 }

--- a/src/drivers/lights/rgbled/rgbled.cpp
+++ b/src/drivers/lights/rgbled/rgbled.cpp
@@ -134,25 +134,13 @@ RGBLED::probe()
 	bool on, powersave;
 	uint8_t r, g, b;
 
-	/**
-	   this may look strange, but is needed. There is a serial
-	   EEPROM (Microchip-24aa01) that responds to a bunch of I2C
-	   addresses, including the 0x55 used by this LED device. So
-	   we need to do enough operations to be sure we are talking
-	   to the right device. These 3 operations seem to be enough,
-	   as the 3rd one consistently fails if no RGBLED is on the bus.
-	 */
-
-	unsigned prevretries = _retries;
-	_retries = 4;
-
 	if ((ret = get(on, powersave, r, g, b)) != OK ||
 	    (ret = send_led_enable(false) != OK) ||
 	    (ret = send_led_enable(false) != OK)) {
 		return ret;
 	}
 
-	_retries = prevretries;
+	_retries = 1;
 
 	return ret;
 }

--- a/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
@@ -72,7 +72,7 @@ int HMC5883_I2C::probe()
 {
 	uint8_t data[3] = {0, 0, 0};
 
-	_retries = 10;
+	_retries = 1;
 
 	if (read(ADDR_ID_A, &data[0], 1) ||
 	    read(ADDR_ID_B, &data[1], 1) ||
@@ -80,8 +80,6 @@ int HMC5883_I2C::probe()
 		DEVICE_DEBUG("read_reg fail");
 		return -EIO;
 	}
-
-	_retries = 2;
 
 	if ((data[0] != ID_A_WHO_AM_I) ||
 	    (data[1] != ID_B_WHO_AM_I) ||

--- a/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
+++ b/src/drivers/magnetometer/isentek/ist8308/IST8308.cpp
@@ -86,12 +86,11 @@ void IST8308::print_status()
 
 int IST8308::probe()
 {
-	_retries = 2;
-
 	for (int retry = 0; retry < 3; retry++) {
 		const uint8_t WAI = RegisterRead(Register::WAI);
 
 		if (WAI == Device_ID) {
+			_retries = 1;
 			return PX4_OK;
 
 		} else {

--- a/src/drivers/magnetometer/lis2mdl/lis2mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis2mdl/lis2mdl_i2c.cpp
@@ -86,14 +86,12 @@ LIS2MDL_I2C::probe()
 {
 	uint8_t data = 0;
 
-	_retries = 10;
+	_retries = 1;
 
 	if (read(ADDR_WHO_AM_I, &data, 1)) {
 		DEVICE_DEBUG("read_reg fail");
 		return -EIO;
 	}
-
-	_retries = 2;
 
 	if (data != ID_WHO_AM_I) {
 		DEVICE_DEBUG("LIS2MDL bad ID: %02x", data);

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
@@ -85,19 +85,17 @@ int LIS3MDL_I2C::probe()
 {
 	uint8_t data = 0;
 
-	_retries = 10;
-
 	if (read(ADDR_WHO_AM_I, &data, 1)) {
 		DEVICE_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
-	_retries = 2;
-
 	if (data != ID_WHO_AM_I) {
 		DEVICE_DEBUG("LIS3MDL bad ID: %02x", data);
 		return -EIO;
 	}
+
+	_retries = 1;
 
 	return OK;
 }

--- a/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
@@ -84,19 +84,17 @@ int RM3100_I2C::probe()
 {
 	uint8_t data = 0;
 
-	_retries = 10;
-
 	if (read(ADDR_REVID, &data, 1)) {
 		DEVICE_DEBUG("RM3100 read_reg fail");
 		return -EIO;
 	}
 
-	_retries = 2;
-
 	if (data != RM3100_REVID) {
 		DEVICE_DEBUG("RM3100 bad ID: %02x", data);
 		return -EIO;
 	}
+
+	_retries = 1;
 
 	return OK;
 }

--- a/src/drivers/telemetry/bst/bst.cpp
+++ b/src/drivers/telemetry/bst/bst.cpp
@@ -185,9 +185,6 @@ BST::BST(const I2CSPIDriverConfig &config) :
 
 int BST::probe()
 {
-	int retries_prev = _retries;
-	_retries = 3;
-
 	BSTPacket<BSTDeviceInfoRequest> dev_info_req = {};
 	dev_info_req.type = 0x0A;
 	dev_info_req.payload.cmd = 0x04;
@@ -213,7 +210,7 @@ int BST::probe()
 		  (int)swap_uint32(dev_info_reply.payload.hw_id), (int)swap_uint16(dev_info_reply.payload.fw_id),
 		  dev_info_reply.payload.dev_name);
 
-	_retries = retries_prev;
+	_retries = 1;
 
 	return OK;
 }

--- a/src/lib/drivers/airspeed/airspeed.cpp
+++ b/src/lib/drivers/airspeed/airspeed.cpp
@@ -104,11 +104,9 @@ Airspeed::probe()
 	   for detection. Once it is running the number of retries can
 	   be reduced
 	*/
-	_retries = 4;
+	_retries = 1;
 	int ret = measure();
 
-	// drop back to 2 retries once initialised
-	_retries = 2;
 	return ret;
 }
 


### PR DESCRIPTION
This adds a full I2C bus reset in board init, both using the low level I2C driver reset (if enabled), followed by a general call software reset. With a centralized bus reset now handled by the board on all buses we can reduce the retries scattered across most drivers. The current external I2C device probing results in a huge number of I2C reset attempts.

  - fixes init for stubborn I2C devices like the Sensirion sdp3x or the QMC588L magnetometer
  - minimize the retry count for most I2C drivers as the board now does a reset on each bus