### PR TITLE
Specify orientaiton of external imu ADIS16448 through parameters

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -117,7 +117,14 @@ fi
 # ADIS16448 spi external IMU
 if param compare -s SENS_EN_ADIS164X 1
 then
-	adis16448 -S start
+	if param compare -s SENS_OR_ADIS164X 0
+	then
+		adis16448 -S start
+	fi
+	if param compare -s SENS_OR_ADIS164X 4
+	then
+		adis16448 -S start -R 4
+	fi
 fi
 
 # probe for optional external I2C devices

--- a/src/drivers/imu/analog_devices/adis16448/parameters.c
+++ b/src/drivers/imu/analog_devices/adis16448/parameters.c
@@ -42,3 +42,15 @@
  * @value 1 Enabled
   */
 PARAM_DEFINE_INT32(SENS_EN_ADIS164X, 0);
+
+/**
+ * Analog Devices ADIS16448 IMU Orientation(external SPI)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 101
+ * @group Sensors
+ * @value 0 ROTATION_NONE
+ * @value 4 ROTATION_YAW_180
+  */
+PARAM_DEFINE_INT32(SENS_OR_ADIS164X, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
The orientation of external IMUs such as the ADIS16448 IMU needs to be configurable through parameters, since the imu can be mounted independent to the board orientation.

**Describe your solution**
This PR adds a parameter to specify the board orientation and passes the orientation when starting the driver.

Currently it is only handled for one orientation, just to get it working, since I don't think having a if else definition for all the parameters make sense.

**Describe possible alternatives**
The orientation parameter can be read directly from the driver. However not sure how it should work relative to the command line argument being passed

**Test data / coverage**
- Tested with a Pixhawk4 and a ADIS16448AMLZ attached on the external SPI port

**Additional context**
