### PR TITLE
Broadcom AFBR-S50 Distance Sensor Driver: Test API

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -68,6 +68,10 @@ public:
 	 */
 	void stop();
 
+	int test();
+
+	bool _testing = false;
+
 private:
 	void Run() override;
 

--- a/src/drivers/distance_sensor/broadcom/afbrs50/argus_hal_test.c
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/argus_hal_test.c
@@ -46,6 +46,9 @@
 #include "platform/argus_nvm.h"
 #include "platform/argus_irq.h"
 
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
+
 /*******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -91,63 +94,63 @@ status_t Argus_VerifyHALImplementation(s2pi_slave_t spi_slave)
 {
 	status_t status = STATUS_OK;
 
-	print("########################################################\n");
-	print("#   Running HAL Verification Test - " HAL_TEST_VERSION "\n");
-	print("########################################################\n\n");
+	PX4_INFO_RAW("########################################################\n");
+	PX4_INFO_RAW("#   Running HAL Verification Test - " HAL_TEST_VERSION "\n");
+	PX4_INFO_RAW("########################################################\n\n");
 
-	print("1 > Timer Plausibility Test\n");
+	PX4_INFO_RAW("1 > Timer Plausibility Test\n");
 	status = TimerPlausibilityTest();
 
 	if (status != STATUS_OK) { goto summary; }
 
-	print("1 > PASS\n\n");
+	PX4_INFO_RAW("1 > PASS\n\n");
 
-	print("2 > Timer Wraparound Test\n");
+	PX4_INFO_RAW("2 > Timer Wraparound Test\n");
 	status = TimerWraparoundTest();
 
 	if (status != STATUS_OK) { goto summary; }
 
-	print("2 > PASS\n\n");
+	PX4_INFO_RAW("2 > PASS\n\n");
 
-	print("3 > SPI Connection Test\n");
+	PX4_INFO_RAW("3 > SPI Connection Test\n");
 	status = SpiConnectionTest(spi_slave);
 
 	if (status != STATUS_OK) { goto summary; }
 
-	print("3 > PASS\n\n");
+	PX4_INFO_RAW("3 > PASS\n\n");
 
-	print("4 > SPI Interrupt Test\n");
+	PX4_INFO_RAW("4 > SPI Interrupt Test\n");
 	status = SpiInterruptTest(spi_slave);
 
 	if (status != STATUS_OK) { goto summary; }
 
-	print("4 > PASS\n\n");
+	PX4_INFO_RAW("4 > PASS\n\n");
 
-	print("5 > GPIO Mode Test\n");
+	PX4_INFO_RAW("5 > GPIO Mode Test\n");
 	status = GpioModeTest(spi_slave);
 
 	if (status != STATUS_OK) { goto summary; }
 
-	print("5 > PASS\n\n");
+	PX4_INFO_RAW("5 > PASS\n\n");
 
-	print("6 > Timer Test\n");
+	PX4_INFO_RAW("6 > Timer Test\n");
 	status = TimerTest(spi_slave);
 
 	if (status != STATUS_OK) { goto summary; }
 
-	print("6 > PASS\n\n");
+	PX4_INFO_RAW("6 > PASS\n\n");
 
 summary:
-	print("########################################################\n");
+	PX4_INFO_RAW("########################################################\n");
 
 	if (status != STATUS_OK) {
-		print("#   FAIL: HAL Verification Test finished with error %d!\n", status);
+		PX4_INFO_RAW("#   FAIL: HAL Verification Test finished with error %d!\n", status);
 
 	} else {
-		print("#   PASS: HAL Verification Test finished successfully!\n");
+		PX4_INFO_RAW("#   PASS: HAL Verification Test finished successfully!\n");
 	}
 
-	print("########################################################\n\n");
+	PX4_INFO_RAW("########################################################\n\n");
 	return status;
 }
 
@@ -165,10 +168,10 @@ summary:
 static status_t CheckTimerCounterValues(uint32_t hct, uint32_t lct)
 {
 	if (lct > 999999) {
-		error_log("Timer plausibility check:\n"
-			  "The parameter \"lct\" of Timer_GetCounterValue() must always "
-			  "be within 0 and 999999.\n"
-			  "Current Values: hct = %d, lct = %d", hct, lct);
+		PX4_INFO_RAW("Timer plausibility check:\n"
+			     "The parameter \"lct\" of Timer_GetCounterValue() must always "
+			     "be within 0 and 999999.\n"
+			     "Current Values: hct = %d, lct = %d", hct, lct);
 		return ERROR_FAIL;
 	}
 
@@ -225,13 +228,13 @@ static status_t TimerPlausibilityTest(void)
 	/* Either the hct value must have been increased or the lct value if the hct
 	 * value is still the same. */
 	if (!((hct1 > hct0) || ((hct1 == hct0) && (lct1 > lct0)))) {
-		error_log("Timer plausibility check: the elapsed time could not be "
-			  "measured with the Timer_GetCounterValue() function; no time "
-			  "has elapsed!\n"
-			  "The delay was induced by the following code:\n"
-			  "for (volatile uint32_t i = 0; i < 100000; ++i) __asm(\"nop\");\n",
-			  "Current Values: hct0 = %d, lct0 = %d, hct1 = %d, lct1 = %d",
-			  hct0, lct0, hct1, lct1);
+		PX4_INFO_RAW("Timer plausibility check: the elapsed time could not be "
+			     "measured with the Timer_GetCounterValue() function; no time "
+			     "has elapsed!\n"
+			     "The delay was induced by the following code:\n"
+			     "for (volatile uint32_t i = 0; i < 100000; ++i) __asm(\"nop\");\n"
+			     "Current Values: hct0 = %d, lct0 = %d, hct1 = %d, lct1 = %d",
+			     hct0, lct0, hct1, lct1);
 		return ERROR_FAIL;
 	}
 
@@ -281,6 +284,8 @@ static status_t TimerWraparoundTest(void)
 	uint32_t hct2 = hct0 + n;
 	uint32_t lct2 = lct0;
 
+	px4_usleep(20000);
+
 	/* Periodically read timer values. From previous tests we
 	 * already know the timer value is increasing. */
 	while (hct0 < hct2 || lct0 < lct2) {
@@ -300,16 +305,18 @@ static status_t TimerWraparoundTest(void)
 		 * than previous one. */
 		if (!(((hct1 == hct0 + 1) && (lct1 < lct0))
 		      || ((hct1 == hct0) && (lct1 >= lct0)))) {
-			error_log("Timer plausibility check: the wraparound of \"lct\" or "
-				  "\"hct\" parameters of the Timer_GetCounterValue() "
-				  "function was not handled correctly!\n"
-				  "Current Values: hct0 = %d, lct0 = %d, hct1 = %d, lct1 = %d",
-				  hct0, lct0, hct1, lct1);
+			PX4_INFO_RAW("Timer plausibility check: the wraparound of \"lct\" or "
+				     "\"hct\" parameters of the Timer_GetCounterValue() "
+				     "function was not handled correctly!\n"
+				     "Current Values: hct0 = %d, lct0 = %d, hct1 = %d, lct1 = %d",
+				     hct0, lct0, hct1, lct1);
 			return ERROR_FAIL;
 		}
 
 		hct0 = hct1;
 		lct0 = lct1;
+
+		px4_usleep(20000);
 	}
 
 	return STATUS_OK;
@@ -350,8 +357,8 @@ static status_t SPITransferSync(s2pi_slave_t slave, uint8_t *data, uint8_t size)
 	status_t status = S2PI_TransferFrame(slave, data, data, size, 0, 0);
 
 	if (status < STATUS_OK) {
-		error_log("SPI transfer failed! The call to S2PI_TransferFrame "
-			  "yielded error code: %d", status);
+		PX4_INFO_RAW("SPI transfer failed! The call to S2PI_TransferFrame "
+			     "yielded error code: %d", status);
 		return status;
 	}
 
@@ -365,16 +372,16 @@ static status_t SPITransferSync(s2pi_slave_t slave, uint8_t *data, uint8_t size)
 		status = S2PI_GetStatus();
 
 		if (status < STATUS_OK) {
-			error_log("SPI transfer failed! The call to S2PI_GetStatus "
-				  "yielded error code: %d", status);
+			PX4_INFO_RAW("SPI transfer failed! The call to S2PI_GetStatus "
+				     "yielded error code: %d", status);
 			S2PI_Abort();
 			return status;
 		}
 
 		if (Time_CheckTimeoutMSec(&start, timeout_ms)) {
-			error_log("SPI transfer failed! The operation did not finished "
-				  "within %d ms. This may also be caused by an invalid "
-				  "timer implementation!", timeout_ms);
+			PX4_INFO_RAW("SPI transfer failed! The operation did not finished "
+				     "within %d ms. This may also be caused by an invalid "
+				     "timer implementation!", timeout_ms);
 			return ERROR_TIMEOUT;
 		}
 	} while (status == STATUS_BUSY);
@@ -423,7 +430,7 @@ static status_t SpiConnectionTest(s2pi_slave_t slave)
 	status = SPITransferSync(slave, data, 17U);
 
 	if (status < STATUS_OK) {
-		error_log("SPI connection test failed!");
+		PX4_INFO_RAW("SPI connection test failed!");
 		return status;
 	}
 
@@ -435,17 +442,17 @@ static status_t SpiConnectionTest(s2pi_slave_t slave)
 	status = SPITransferSync(slave, data, 17U);
 
 	if (status < STATUS_OK) {
-		error_log("SPI connection test failed!");
+		PX4_INFO_RAW("SPI connection test failed!");
 		return status;
 	}
 
 	/* Verify the read pattern. */
 	for (uint8_t i = 1; i < 17U; ++i) {
 		if (data[i] != i) {
-			error_log("SPI connection test failed!\n"
-				  "Verification of read data is invalid!\n"
-				  "read_data[%d] = %d, but expected was %d",
-				  i, data[i], i);
+			PX4_INFO_RAW("SPI connection test failed!\n"
+				     "Verification of read data is invalid!\n"
+				     "read_data[%d] = %d, but expected was %d",
+				     i, data[i], i);
 			return ERROR_FAIL;
 		}
 	}
@@ -508,7 +515,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status_t status = SPITransferSync(slave, d1, sizeof(d1));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -516,7 +523,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d2, sizeof(d2));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -524,7 +531,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d3, sizeof(d3));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -532,7 +539,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d4, sizeof(d4));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -540,7 +547,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d5, sizeof(d5));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -548,7 +555,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d6, sizeof(d6));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -556,7 +563,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d7, sizeof(d7));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -564,7 +571,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d8, sizeof(d8));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -572,7 +579,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d9, sizeof(d9));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -580,7 +587,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d10, sizeof(d10));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -588,7 +595,7 @@ static status_t ConfigureDevice(s2pi_slave_t slave, int8_t rcoTrim)
 	status = SPITransferSync(slave, d11, sizeof(d11));
 
 	if (status < STATUS_OK) {
-		error_log("Device configuration failed!");
+		PX4_INFO_RAW("Device configuration failed!");
 		return status;
 	}
 
@@ -629,7 +636,7 @@ static status_t TriggerMeasurement(s2pi_slave_t slave, uint16_t samples)
 	status_t status = SPITransferSync(slave, d, sizeof(d));
 
 	if (status < STATUS_OK) {
-		error_log("Trigger measurement failed!");
+		PX4_INFO_RAW("Trigger measurement failed!");
 		return status;
 	}
 
@@ -670,8 +677,8 @@ static status_t AwaitDataReady(s2pi_slave_t slave, uint32_t timeout_ms)
 
 	while (S2PI_ReadIrqPin(slave)) {
 		if (Time_CheckTimeoutMSec(&start, timeout_ms)) {
-			error_log("SPI interrupt test failed! The S2PI_ReadIrqPin did not "
-				  "determine an pending interrupt within %d ms.", timeout_ms);
+			PX4_INFO_RAW("SPI interrupt test failed! The S2PI_ReadIrqPin did not "
+				     "determine an pending interrupt within %d ms.", timeout_ms);
 			return ERROR_TIMEOUT;
 		}
 	}
@@ -738,16 +745,16 @@ static status_t SpiInterruptTest(s2pi_slave_t slave)
 	status_t status = S2PI_SetIrqCallback(slave, DataReadyCallback, (void *)&isDataReady);
 
 	if (status < STATUS_OK) {
-		error_log("SPI interrupt test failed! The call to S2PI_SetIrqCallback "
-			  "yielded error code: %d", status);
+		PX4_INFO_RAW("SPI interrupt test failed! The call to S2PI_SetIrqCallback "
+			     "yielded error code: %d", status);
 		return status;
 	}
 
 	/* Check if IRQ is not yet pending. */
 	if (S2PI_ReadIrqPin(slave) == 0) {
-		error_log("SPI interrupt test failed! The S2PI_ReadIrqPin did "
-			  "return 0 but no interrupt is pending since no "
-			  "measurements are executed yet!");
+		PX4_INFO_RAW("SPI interrupt test failed! The S2PI_ReadIrqPin did "
+			     "return 0 but no interrupt is pending since no "
+			     "measurements are executed yet!");
 		return ERROR_FAIL;
 	};
 
@@ -755,7 +762,7 @@ static status_t SpiInterruptTest(s2pi_slave_t slave)
 	status = ConfigureDevice(slave, 0);
 
 	if (status < STATUS_OK) {
-		error_log("SPI interrupt test failed!");
+		PX4_INFO_RAW("SPI interrupt test failed!");
 		return status;
 	}
 
@@ -763,7 +770,7 @@ static status_t SpiInterruptTest(s2pi_slave_t slave)
 	status = TriggerMeasurement(slave, 0);
 
 	if (status < STATUS_OK) {
-		error_log("SPI interrupt test failed!");
+		PX4_INFO_RAW("SPI interrupt test failed!");
 		return status;
 	}
 
@@ -774,15 +781,15 @@ static status_t SpiInterruptTest(s2pi_slave_t slave)
 	status = AwaitDataReady(slave, timeout_ms);
 
 	if (status < STATUS_OK) {
-		error_log("SPI interrupt test failed!");
+		PX4_INFO_RAW("SPI interrupt test failed!");
 		return status;
 	}
 
 	/* Wait for Interrupt using the callback method. */
 	while (!isDataReady) {
 		if (Time_CheckTimeoutMSec(&start, timeout_ms)) {
-			error_log("SPI interrupt test failed! The IRQ callback was not "
-				  "invoked within %d ms.", timeout_ms);
+			PX4_INFO_RAW("SPI interrupt test failed! The IRQ callback was not "
+				     "invoked within %d ms.", timeout_ms);
 			return ERROR_TIMEOUT;
 		}
 	}
@@ -791,8 +798,8 @@ static status_t SpiInterruptTest(s2pi_slave_t slave)
 	status = S2PI_SetIrqCallback(slave, 0, 0);
 
 	if (status < STATUS_OK) {
-		error_log("SPI interrupt test failed! The call to S2PI_SetIrqCallback "
-			  "with null pointers yielded error code: %d", status);
+		PX4_INFO_RAW("SPI interrupt test failed! The call to S2PI_SetIrqCallback "
+			     "with null pointers yielded error code: %d", status);
 		return status;
 	}
 
@@ -830,8 +837,8 @@ static status_t ReadEEPROM(s2pi_slave_t slave, uint8_t *eeprom)
 	status_t status = SPITransferSync(slave, d1, sizeof(d1));
 
 	if (status < STATUS_OK) {
-		error_log("EEPROM readout failed (enable EEPROM), "
-			  "error code: %d", status);
+		PX4_INFO_RAW("EEPROM readout failed (enable EEPROM), "
+			     "error code: %d", status);
 		return status;
 	}
 
@@ -842,8 +849,8 @@ static status_t ReadEEPROM(s2pi_slave_t slave, uint8_t *eeprom)
 		status = EEPROM_Read(slave, address, &data[address]);
 
 		if (status != STATUS_OK) {
-			error_log("EEPROM readout failed @ address 0x%02x, "
-				  "error code: %d!", address, status);
+			PX4_INFO_RAW("EEPROM readout failed @ address 0x%02x, "
+				     "error code: %d!", address, status);
 			return status;
 		}
 	}
@@ -853,8 +860,8 @@ static status_t ReadEEPROM(s2pi_slave_t slave, uint8_t *eeprom)
 	status = SPITransferSync(slave, d2, sizeof(d2));
 
 	if (status < STATUS_OK) {
-		error_log("EEPROM readout failed (enable EEPROM), "
-			  "error code: %d", status);
+		PX4_INFO_RAW("EEPROM readout failed (enable EEPROM), "
+			     "error code: %d", status);
 		return status;
 	}
 
@@ -862,8 +869,8 @@ static status_t ReadEEPROM(s2pi_slave_t slave, uint8_t *eeprom)
 	uint8_t err = hamming_decode(data, eeprom);
 
 	if (err != 0) {
-		error_log("EEPROM readout failed! Failed to decoding "
-			  "Hamming weight (error: %d)!", err);
+		PX4_INFO_RAW("EEPROM readout failed! Failed to decoding "
+			     "Hamming weight (error: %d)!", err);
 		return STATUS_ARGUS_EEPROM_BIT_ERROR;
 	}
 
@@ -909,29 +916,29 @@ static status_t GpioModeTest(s2pi_slave_t slave)
 	status_t status = ReadEEPROM(slave, eeprom1);
 
 	if (status < STATUS_OK) {
-		error_log("GPIO mode test failed (1st attempt)!");
+		PX4_INFO_RAW("GPIO mode test failed (1st attempt)!");
 		return status;
 	}
 
 	status = ReadEEPROM(slave, eeprom2);
 
 	if (status < STATUS_OK) {
-		error_log("GPIO mode test failed (2nd attempt)!");
+		PX4_INFO_RAW("GPIO mode test failed (2nd attempt)!");
 		return status;
 	}
 
 	status = ReadEEPROM(slave, eeprom3);
 
 	if (status < STATUS_OK) {
-		error_log("GPIO mode test failed (3rd attempt)!");
+		PX4_INFO_RAW("GPIO mode test failed (3rd attempt)!");
 		return status;
 	}
 
 	/* Verify EEPROM data. */
 	if ((memcmp(eeprom1, eeprom2, 16) != 0) ||
 	    (memcmp(eeprom1, eeprom3, 16) != 0)) {
-		error_log("GPIO Mode test failed (data comparison)!\n"
-			  "The data from 3 distinct EEPROM readout does not match!");
+		PX4_INFO_RAW("GPIO Mode test failed (data comparison)!\n"
+			     "The data from 3 distinct EEPROM readout does not match!");
 		return ERROR_FAIL;
 	}
 
@@ -940,14 +947,14 @@ static status_t GpioModeTest(s2pi_slave_t slave)
 	argus_module_version_t module = EEPROM_ReadModule(eeprom1);
 
 	if (chipID == 0 || module == 0) {
-		error_log("GPIO Mode test failed (data verification)!\n"
-			  "Invalid EEPROM data: Module = %d; Chip ID = %d!", module, chipID);
+		PX4_INFO_RAW("GPIO Mode test failed (data verification)!\n"
+			     "Invalid EEPROM data: Module = %d; Chip ID = %d!", module, chipID);
 		return ERROR_FAIL;
 	}
 
-	print("EEPROM Readout succeeded!\n");
-	print("- Module: %d\n", module);
-	print("- Device ID: %d\n", chipID);
+	PX4_INFO_RAW("EEPROM Readout succeeded!\n");
+	PX4_INFO_RAW("- Module: %d\n", module);
+	PX4_INFO_RAW("- Device ID: %d\n", chipID);
 
 	return STATUS_OK;
 }
@@ -995,7 +1002,7 @@ static status_t ReadRcoTrim(s2pi_slave_t slave, int8_t *rcotrim)
 	case MODULE_NONE: /* Uncalibrated module; use all 0 data. */
 	default:
 
-		error_log("EEPROM Readout failed! Unknown module number: %d", module);
+		PX4_INFO_RAW("EEPROM Readout failed! Unknown module number: %d", module);
 		return ERROR_ARGUS_UNKNOWN_MODULE;
 	}
 
@@ -1034,9 +1041,9 @@ static status_t RunMeasurement(s2pi_slave_t slave, uint16_t samples)
 	status_t status = TriggerMeasurement(slave, samples);
 
 	if (status < STATUS_OK) {
-		error_log("Speed test failed!\n"
-			  "Call to TransferFrame returned code: %d",
-			  status);
+		PX4_INFO_RAW("Speed test failed!\n"
+			     "Call to TransferFrame returned code: %d",
+			     status);
 		return status;
 	}
 
@@ -1044,9 +1051,9 @@ static status_t RunMeasurement(s2pi_slave_t slave, uint16_t samples)
 	status = AwaitDataReady(slave, 300);
 
 	if (status < STATUS_OK) {
-		error_log("Speed test failed!\n"
-			  "SPI Read IRQ pin didn't raised, timeout activated at 200ms, error code: %d",
-			  status);
+		PX4_INFO_RAW("Speed test failed!\n"
+			     "SPI Read IRQ pin didn't raised, timeout activated at 200ms, error code: %d",
+			     status);
 		return status;
 	}
 
@@ -1096,19 +1103,19 @@ static status_t TimerTest(s2pi_slave_t slave)
 	status_t status = ReadRcoTrim(slave, &RcoTrim);
 
 	if (status < STATUS_OK) {
-		error_log("Timer test failed!\n"
-			  "EEPROM Read test returned code: %d", status);
+		PX4_INFO_RAW("Timer test failed!\n"
+			     "EEPROM Read test returned code: %d", status);
 		return status;
 	}
 
-	print("RCOTrim = %d\n", RcoTrim);
+	PX4_INFO_RAW("RCOTrim = %d\n", RcoTrim);
 
 	/* Configure the device with calibrated RCO to 24MHz. */
 	status = ConfigureDevice(slave, RcoTrim);
 
 	if (status < STATUS_OK) {
-		error_log("Timer test failed!\n"
-			  "Configuration test returned code: %d", status);
+		PX4_INFO_RAW("Timer test failed!\n"
+			     "Configuration test returned code: %d", status);
 		return status;
 	}
 
@@ -1120,9 +1127,9 @@ static status_t TimerTest(s2pi_slave_t slave)
 	float x2sum = 0;
 	float xysum = 0;
 
-	print("+-------+---------+------------+\n");
-	print("| count | samples | elapsed us |\n");
-	print("+-------+---------+------------+\n");
+	PX4_INFO_RAW("+-------+---------+------------+\n");
+	PX4_INFO_RAW("| count | samples | elapsed us |\n");
+	PX4_INFO_RAW("+-------+---------+------------+\n");
 
 	for (uint8_t i = 1; i <= n; ++i) {
 		ltc_t start;
@@ -1132,9 +1139,9 @@ static status_t TimerTest(s2pi_slave_t slave)
 		status = RunMeasurement(slave, samples);
 
 		if (status < STATUS_OK) {
-			error_log("Timer test failed!\n"
-				  "Run measurement returned code: %d",
-				  status);
+			PX4_INFO_RAW("Timer test failed!\n"
+				     "Run measurement returned code: %d",
+				     status);
 			return status;
 		}
 
@@ -1145,30 +1152,29 @@ static status_t TimerTest(s2pi_slave_t slave)
 		x2sum += (float) samples * samples;
 		xysum += (float) samples * elapsed_usec;
 
-		print("| %5d | %7d | %10d |\n", i, samples, elapsed_usec);
+		PX4_INFO_RAW("| %5d | %7d | %10d |\n", i, samples, elapsed_usec);
 	}
 
-	print("+-------+---------+------------+\n");
+	PX4_INFO_RAW("+-------+---------+------------+\n");
 
 
 	const float slope = (n * xysum - xsum * ysum) / (n * x2sum - xsum * xsum);
 	const float intercept = (ysum * x2sum - xsum * xysum) / (n * x2sum - xsum * xsum);
-	print("Linear Regression: y(x) = %dE-7 sec * x + %dE-7 sec\n",
-	      (int)(10 * slope), (int)(10 * intercept));
+	PX4_INFO_RAW("Linear Regression: y(x) = %dE-7 sec * x + %dE-7 sec\n",
+		     (int)(10 * slope), (int)(10 * intercept));
 
 	/* Check the error of the slope. */
 	const float max_slope = exp_slope * (1.f + rel_slope_error);
 	const float min_slope = exp_slope * (1.f - rel_slope_error);
 
 	if (slope > max_slope || slope < min_slope) {
-		error_log("Time test failed!\n"
-			  "The measured time slope does not match the expected value! "
-			  "(actual: %dE-7, expected: %dE-7, min: %dE-7, max: %dE-7)\n",
-			  (int)(10 * slope), (int)(10 * exp_slope),
-			  (int)(10 * min_slope), (int)(10 * max_slope));
+		PX4_INFO_RAW("Time test failed!\n"
+			     "The measured time slope does not match the expected value! "
+			     "(actual: %dE-7, expected: %dE-7, min: %dE-7, max: %dE-7)\n",
+			     (int)(10 * slope), (int)(10 * exp_slope),
+			     (int)(10 * min_slope), (int)(10 * max_slope));
 		return ERROR_FAIL;
 	}
 
 	return STATUS_OK;
 }
-

--- a/src/drivers/distance_sensor/broadcom/afbrs50/argus_hal_test.h
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/argus_hal_test.h
@@ -37,6 +37,10 @@
 #ifndef ARGUS_HAL_TEST_H
 #define ARGUS_HAL_TEST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 __BEGIN_DECLS
 
 /*!***************************************************************************
@@ -161,6 +165,10 @@ __BEGIN_DECLS
 status_t Argus_VerifyHALImplementation(s2pi_slave_t spi_slave);
 
 __END_DECLS
+
+#ifdef __cplusplus
+}
+#endif
 
 /*! @} */
 #endif /* ARGUS_CAL_API_H */


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR for the Broadcom AFBR-S50 Distance Sensor driver enables execution of a series of tests in order to verify the HAL implementation.

**Describe your solution**
The "test" arguement can be used within nutt shell for the afbrs50 driver in order to run the series of tests. Updates are printed out in the shell and delays were included to prevent breakpoint traps & faults.

**Test data / coverage**
The additions to the driver were tested successfully within the nutt shell on macOS and Linux.

**Additional context**
![Screen Shot 2021-06-28 at 2 33 20 PM](https://user-images.githubusercontent.com/46569551/123703747-0c31a580-d822-11eb-9e72-011d55339df1.png)
