### PR TITLE
sensors/vehicle_imu: continue integrating gyro if there's a gap in data

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -192,7 +192,7 @@ void VehicleIMU::Run()
 		}
 
 		// check for additional updates and that we're fully caught up before publishing
-		if (consume_all_gyro && _sensor_gyro_sub.updated()) {
+		if ((consume_all_gyro || _data_gap) && _sensor_gyro_sub.updated()) {
 			continue;
 		}
 


### PR DESCRIPTION
 - minor improvement that helps to determine the sensor publication rate as soon as possible
