### PR TITLE
Battery class Refactor

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -286,9 +286,6 @@ Syslink::task_main()
 	_memory = new SyslinkMemory(this);
 	_memory->init();
 
-	_battery.reset();
-
-
 	//	int ret;
 
 	/* Open serial port */

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -3,7 +3,7 @@ float32 voltage_v			# Battery voltage in volts, 0 if unknown
 float32 voltage_filtered_v	# Battery voltage in volts, filtered, 0 if unknown
 float32 current_a			# Battery current in amperes, -1 if unknown
 float32 current_filtered_a	# Battery current in amperes, filtered, 0 if unknown
-float32 average_current_a	# Battery current average in amperes, -1 if unknown
+float32 current_average_a	# Battery current average in amperes, -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -1,4 +1,5 @@
 uint64 timestamp			# time since system start (microseconds)
+bool connected				# Whether or not a battery is connected, based on a voltage threshold
 float32 voltage_v			# Battery voltage in volts, 0 if unknown
 float32 voltage_filtered_v	# Battery voltage in volts, filtered, 0 if unknown
 float32 current_a			# Battery current in amperes, -1 if unknown
@@ -9,7 +10,6 @@ float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
 int32 cell_count			# Number of cells
-bool connected				# Whether or not a battery is connected, based on a voltage threshold
 
 uint8 BATTERY_SOURCE_POWER_MODULE = 0
 uint8 BATTERY_SOURCE_EXTERNAL = 1

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -129,7 +129,7 @@ void BATT_SMBUS::RunImpl()
 
 	float average_current = (-1.0f * ((float)(*(int16_t *)&result)) / 1000.0f) * _c_mult;
 
-	new_report.average_current_a = average_current;
+	new_report.current_average_a = average_current;
 
 	// If current is high, turn under voltage protection off. This is neccessary to prevent
 	// a battery from cutting off while flying with high current near the end of the packs capacity.

--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -169,7 +169,7 @@ void Batmon::RunImpl()
 
 	float average_current = (-1.0f * ((float)(*(int16_t *)&result)) / 1000.0f);
 
-	new_report.average_current_a = average_current;
+	new_report.current_average_a = average_current;
 
 	// Read run time to empty (minutes).
 	ret |= _interface->read_word(BATT_SMBUS_RUN_TIME_TO_EMPTY, result);

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -69,7 +69,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	battery.voltage_filtered_v = msg.voltage;
 	battery.current_a = msg.current;
 	battery.current_filtered_a = msg.current;
-	// battery.average_current_a = msg.;
+	// battery.current_average_a = msg.;
 
 	sumDischarged(battery.timestamp, battery.current_a);
 	battery.discharged_mah = _discharged_mah;

--- a/src/drivers/uavcan/sensors/cbat.cpp
+++ b/src/drivers/uavcan/sensors/cbat.cpp
@@ -68,7 +68,7 @@ UavcanCBATBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<cuav::equip
 	battery.voltage_filtered_v = battery.voltage_v;
 	battery.current_a = msg.current;
 	battery.current_filtered_a = battery.current_a;
-	battery.average_current_a = msg.average_current;
+	battery.current_average_a = msg.average_current;
 	battery.discharged_mah = msg.passed_charge * 1000;
 	battery.remaining = msg.state_of_charge / 100.0f;
 	// battery.scale = msg.; // Power scaling factor, >= 1, or -1 if unknown

--- a/src/drivers/uavcan_v1/Subscribers/legacy/LegacyBatteryInfo.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/legacy/LegacyBatteryInfo.hpp
@@ -79,7 +79,7 @@ public:
 		bat_status.timestamp = hrt_absolute_time();
 		bat_status.voltage_filtered_v = bat_info.voltage;
 		bat_status.current_filtered_a = bat_info.current;
-		bat_status.average_current_a = bat_info.average_power_10sec;
+		bat_status.current_average_a = bat_info.average_power_10sec;
 		bat_status.remaining = bat_info.state_of_charge_pct / 100.0f;
 		bat_status.scale = -1;
 

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -137,8 +137,8 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	estimateStateOfCharge(_voltage_filter_v.getState(), _current_filter_a.getState(), _throttle_filter.getState());
 	computeScale();
 
-	if (_battery_initialized) {
-		determineWarning(connected);
+	if (connected && _battery_initialized) {
+		determineWarning();
 	}
 
 	if (_voltage_filter_v.getState() > 2.1f) {
@@ -239,22 +239,20 @@ void Battery::estimateStateOfCharge(const float voltage_v, const float current_a
 	}
 }
 
-void Battery::determineWarning(bool connected)
+void Battery::determineWarning()
 {
-	if (connected) {
-		// propagate warning state only if the state is higher, otherwise remain in current warning state
-		if (_state_of_charge < _params.emergen_thr) {
-			_warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
+	// propagate warning state only if the state is higher, otherwise remain in current warning state
+	if (_battery_status.remaining < _params.emergen_thr) {
+		_warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
 
-		} else if (_state_of_charge < _params.crit_thr) {
-			_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
+	} else if (_battery_status.remaining < _params.crit_thr) {
+		_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
 
-		} else if (_state_of_charge < _params.low_thr) {
-			_warning = battery_status_s::BATTERY_WARNING_LOW;
+	} else if (_battery_status.remaining < _params.low_thr) {
+		_warning = battery_status_s::BATTERY_WARNING_LOW;
 
-		} else {
-			_warning = battery_status_s::BATTERY_WARNING_NONE;
-		}
+	} else {
+		_warning = battery_status_s::BATTERY_WARNING_NONE;
 	}
 }
 

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -120,7 +120,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	computeScale();
 
 	if (connected && _battery_initialized) {
-		determineWarning();
+		_warning = determineWarning(_state_of_charge);
 	}
 
 	if (_voltage_filter_v.getState() > 2.1f) {
@@ -219,20 +219,19 @@ void Battery::estimateStateOfCharge(const float voltage_v, const float current_a
 	}
 }
 
-void Battery::determineWarning()
+uint8_t Battery::determineWarning(float state_of_charge)
 {
-	// propagate warning state only if the state is higher, otherwise remain in current warning state
-	if (_battery_status.remaining < _params.emergen_thr) {
-		_warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
+	if (state_of_charge < _params.emergen_thr) {
+		return battery_status_s::BATTERY_WARNING_EMERGENCY;
 
-	} else if (_battery_status.remaining < _params.crit_thr) {
-		_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
+	} else if (state_of_charge < _params.crit_thr) {
+		return battery_status_s::BATTERY_WARNING_CRITICAL;
 
-	} else if (_battery_status.remaining < _params.low_thr) {
-		_warning = battery_status_s::BATTERY_WARNING_LOW;
+	} else if (state_of_charge < _params.low_thr) {
+		return battery_status_s::BATTERY_WARNING_LOW;
 
 	} else {
-		_warning = battery_status_s::BATTERY_WARNING_NONE;
+		return battery_status_s::BATTERY_WARNING_NONE;
 	}
 }
 

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -167,14 +167,9 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	}
 
 	if (source == _params.source) {
-		publish();
+		_battery_status.timestamp = hrt_absolute_time();
+		_battery_status_pub.publish(_battery_status);
 	}
-}
-
-void Battery::publish()
-{
-	_battery_status.timestamp = hrt_absolute_time();
-	_battery_status_pub.publish(_battery_status);
 }
 
 void Battery::sumDischarged(const hrt_abstime &timestamp, float current_a)

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -130,37 +130,38 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 		connected = false;
 	}
 
-	_battery_status.voltage_v = voltage_v;
-	_battery_status.voltage_filtered_v = _voltage_filter_v.getState();
-	_battery_status.current_a = current_a;
-	_battery_status.current_filtered_a = _current_filter_a.getState();
-	_battery_status.current_average_a = -1.f; // support will follow
-	_battery_status.discharged_mah = _discharged_mah;
-	_battery_status.remaining = _state_of_charge;
-	_battery_status.scale = _scale;
-	_battery_status.temperature = NAN;
+	battery_status_s battery_status{};
+	battery_status.voltage_v = voltage_v;
+	battery_status.voltage_filtered_v = _voltage_filter_v.getState();
+	battery_status.current_a = current_a;
+	battery_status.current_filtered_a = _current_filter_a.getState();
+	battery_status.current_average_a = -1.f; // support will follow
+	battery_status.discharged_mah = _discharged_mah;
+	battery_status.remaining = _state_of_charge;
+	battery_status.scale = _scale;
+	battery_status.temperature = NAN;
 	// Publish at least one cell such that the total voltage gets into MAVLink BATTERY_STATUS
-	_battery_status.cell_count = math::max(_params.n_cells, static_cast<int32_t>(1));
-	_battery_status.connected = connected;
-	_battery_status.source = source;
-	_battery_status.priority = priority;
-	_battery_status.capacity = _params.capacity > 0.f ? static_cast<uint16_t>(_params.capacity) : 0;
-	_battery_status.id = static_cast<uint8_t>(_index);
-	_battery_status.warning = _warning;
+	battery_status.cell_count = math::max(_params.n_cells, static_cast<int32_t>(1));
+	battery_status.connected = connected;
+	battery_status.source = source;
+	battery_status.priority = priority;
+	battery_status.capacity = _params.capacity > 0.f ? static_cast<uint16_t>(_params.capacity) : 0;
+	battery_status.id = static_cast<uint8_t>(_index);
+	battery_status.warning = _warning;
 
-	static constexpr int32_t uorb_max_cells = sizeof(_battery_status.voltage_cell_v) / sizeof(
-				_battery_status.voltage_cell_v[0]);
+	static constexpr int32_t uorb_max_cells = sizeof(battery_status.voltage_cell_v) / sizeof(
+				battery_status.voltage_cell_v[0]);
 
-	int max_cells = math::min(_battery_status.cell_count, uorb_max_cells);
+	int max_cells = math::min(battery_status.cell_count, uorb_max_cells);
 
 	// Fill cell voltages with average values to work around MAVLink BATTERY_STATUS not allowing to report just total voltage
 	for (int i = 0; i < max_cells; i++) {
-		_battery_status.voltage_cell_v[i] = _battery_status.voltage_filtered_v / max_cells;
+		battery_status.voltage_cell_v[i] = battery_status.voltage_filtered_v / max_cells;
 	}
 
 	if (source == _params.source) {
-		_battery_status.timestamp = hrt_absolute_time();
-		_battery_status_pub.publish(_battery_status);
+		battery_status.timestamp = hrt_absolute_time();
+		_battery_status_pub.publish(battery_status);
 	}
 }
 

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -197,7 +197,7 @@ protected:
 private:
 	void sumDischarged(const hrt_abstime &timestamp, float current_a);
 	void estimateStateOfCharge(const float voltage_v, const float current_a, const float throttle);
-	void determineWarning(bool connected);
+	void determineWarning();
 	void computeScale();
 
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -156,11 +156,6 @@ protected:
 	void updateParams() override;
 
 	/**
-	 * Publishes the uORB battery_status message with the most recently-updated data.
-	 */
-	void publish();
-
-	/**
 	 * This function helps migrating and syncing from/to deprecated parameters. BAT_* BAT1_*
 	 * @tparam T Type of the parameter (int or float)
 	 * @param old_param Handle to the old deprecated parameter (for example, param_find("BAT_N_CELLS"))

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -69,11 +69,6 @@ public:
 	~Battery() = default;
 
 	/**
-	 * Reset all battery stats and report invalid/nothing.
-	 */
-	void reset();
-
-	/**
 	 * Get the battery cell count
 	 */
 	int cell_count() { return _params.n_cells; }

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -143,8 +143,6 @@ protected:
 		int32_t source_old;
 	} _params{};
 
-	battery_status_s _battery_status{};
-
 	const int _index;
 
 	bool _first_parameter_update{true};

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -187,7 +187,7 @@ protected:
 private:
 	void sumDischarged(const hrt_abstime &timestamp, float current_a);
 	void estimateStateOfCharge(const float voltage_v, const float current_a, const float throttle);
-	void determineWarning();
+	uint8_t determineWarning(float state_of_charge);
 	void computeScale();
 
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -146,7 +146,6 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _battery_status_sub{ORB_ID(battery_status)};			/**< battery status subscription */
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};				/**< airspeed subscription */
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -565,10 +565,8 @@ void FixedwingAttitudeControl::Run()
 						if (_battery_status_sub.updated()) {
 							battery_status_s battery_status{};
 
-							if (_battery_status_sub.copy(&battery_status)) {
-								if (battery_status.scale > 0.0f) {
-									_battery_scale = battery_status.scale;
-								}
+							if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
+								_battery_scale = battery_status.scale;
 							}
 						}
 

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -241,7 +241,7 @@ MulticopterRateControl::Run()
 				if (_battery_status_sub.updated()) {
 					battery_status_s battery_status;
 
-					if (_battery_status_sub.copy(&battery_status)) {
+					if (_battery_status_sub.copy(&battery_status) && battery_status.connected && battery_status.scale > 0.f) {
 						_battery_status_scale = battery_status.scale;
 					}
 				}

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -99,8 +99,7 @@ void BatterySimulator::Run()
 	float vbatt = math::gradual(_battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 	vbatt *= _battery.cell_count();
 
-	const float throttle = 0.0f; // simulate no throttle compensation to make the estimate predictable
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, throttle);
+	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0.f);
 
 	perf_end(_loop_perf);
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
The structure of the battery class annoys me for a long time now. This pr is a first stab at simplifying the structure. The final goal is to be able to reuse everything useful also for smart battery drivers but I'm trying to not change everything at once here.

**Describe your solution**
Refactoring:
- It looks like every battery field is stored in stored in the battery_status message and in a separate member field
- Reset logic is complicated ofr that
- Certain fields are set multiple times
- Publish measured values even if the battery is not connected. The connected field gives information and should be checked.
- Remove outdated comment: https://github.com/PX4/PX4-Autopilot/commit/e360dd34f91628d8d090df10d08250241dcfea7d#diff-3a5252ca9358f1005158928f25483d87347e4c7550a62eeda333baf8c66f90b0R212

**Describe possible alternatives**
Follow-ups should:
- add unit testing
- clarify connected vs too low voltage vs initialized
- enable a smart battery to fill quantities it knows and have the rest estimated

**Test data / coverage**
I did not test this yet. It pure refactoring based on the code. I think a thorough review and might be able to do some basic tests.