### PR TITLE
Estimate remaining flight time

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -8,7 +8,7 @@ float32 current_average_a	# Battery current average in amperes, -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
-float32 time_remaining_s	# predicted time in seconds remaining until battery is empty under previous averaged load, -1 if unknown
+float32 time_remaining_s	# predicted time in seconds remaining until battery is empty under previous averaged load, NAN if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
 int32 cell_count			# Number of cells
 

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -8,6 +8,7 @@ float32 current_average_a	# Battery current average in amperes, -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
+float32 time_remaining_s	# predicted time in seconds remaining until battery is empty under previous averaged load, -1 if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
 int32 cell_count			# Number of cells
 
@@ -18,7 +19,6 @@ uint8 source				# Battery source
 uint8 priority				# Zero based priority is the connection on the Power Controller V1..Vn AKA BrickN-1
 uint16 capacity				# actual capacity of the battery
 uint16 cycle_count			# number of discharge cycles the battery has experienced
-uint16 run_time_to_empty	# predicted remaining battery capacity based on the present rate of discharge in min
 uint16 average_time_to_empty	# predicted remaining battery capacity based on the average rate of discharge in min
 uint16 serial_number		# serial number of the battery pack
 uint16 manufacture_date		# manufacture date, part of serial number of the battery pack. formated as: Day + Month×32 + (Year–1980)×512

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -136,7 +136,7 @@ void BATT_SMBUS::RunImpl()
 
 	// Read run time to empty (minutes).
 	ret |= _interface->read_word(BATT_SMBUS_RUN_TIME_TO_EMPTY, result);
-	new_report.run_time_to_empty = result;
+	new_report.time_remaining_s = result * 60;
 
 	// Read average time to empty (minutes).
 	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_TIME_TO_EMPTY, result);

--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -162,7 +162,7 @@ void Batmon::RunImpl()
 
 	// Read run time to empty (minutes).
 	ret |= _interface->read_word(BATT_SMBUS_RUN_TIME_TO_EMPTY, result);
-	new_report.run_time_to_empty = result;
+	new_report.time_remaining_s = result * 60;
 
 	// Read average time to empty (minutes).
 	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_TIME_TO_EMPTY, result);

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -83,7 +83,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	// battery.priority = msg.;
 	battery.capacity = msg.full_charge_capacity_wh;
 	// battery.cycle_count = msg.;
-	// battery.run_time_to_empty = msg.;
+	// battery.time_remaining_s = msg.;
 	// battery.average_time_to_empty = msg.;
 	battery.serial_number = msg.model_instance_id;
 	battery.id = msg.getSrcNodeID().get();

--- a/src/drivers/uavcan/sensors/cbat.cpp
+++ b/src/drivers/uavcan/sensors/cbat.cpp
@@ -79,7 +79,7 @@ UavcanCBATBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<cuav::equip
 	// battery.priority = msg.;
 	battery.capacity = msg.full_charge_capacity * 1000;
 	battery.cycle_count = msg.cycle_count;
-	battery.run_time_to_empty = msg.average_time_to_empty;
+	battery.time_remaining_s = msg.average_time_to_empty * 60;
 	battery.average_time_to_empty = msg.average_time_to_empty;
 	battery.serial_number = msg.serial_number;
 	battery.manufacture_date = msg.manufacture_date;

--- a/src/drivers/uavcan_v1/Subscribers/legacy/LegacyBatteryInfo.hpp
+++ b/src/drivers/uavcan_v1/Subscribers/legacy/LegacyBatteryInfo.hpp
@@ -107,7 +107,7 @@ public:
 		 * connected (partly)
 		 * priority
 		 * cycle_count
-		 * run_time_to_empty
+		 * time_remaining_s
 		 * average_time_to_empty
 		 * manufacture_date
 		 * max_error

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -249,7 +249,7 @@ void Battery::computeScale()
 
 float Battery::computeRemainingTime(float current_a)
 {
-	float time_remaining_s = -1.f;
+	float time_remaining_s{NAN};
 
 	// Only estimate remaining time with useful in flight current measurements
 	if (_current_filter_a.getState() > 1.f) {

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -133,17 +133,19 @@ private:
 	void estimateStateOfCharge(const float voltage_v, const float current_a, const float throttle);
 	uint8_t determineWarning(float state_of_charge);
 	void computeScale();
+	float computeRemainingTime(float current_a);
 
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
 	bool _battery_initialized{false};
 	AlphaFilter<float> _voltage_filter_v;
 	AlphaFilter<float> _current_filter_a;
+	AlphaFilter<float> _current_average_filter_a;
 	AlphaFilter<float> _throttle_filter;
 	float _discharged_mah{0.f};
 	float _discharged_mah_loop{0.f};
-	float _state_of_charge_volt_based{-1.f};	// [0,1]
-	float _state_of_charge{-1.f};				// [0,1]
+	float _state_of_charge_volt_based{-1.f}; // [0,1]
+	float _state_of_charge{-1.f}; // [0,1]
 	float _scale{1.f};
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};

--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -76,8 +76,8 @@ private:
 				bat_msg.energy_consumed = -1;
 				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
 				bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.f) : -1;
-				// MAVLink extension: 0 is unsupported, in uORB it's -1
-				bat_msg.time_remaining = (battery_status.connected && (battery_status.time_remaining_s >= 0.f)) ?
+				// MAVLink extension: 0 is unsupported, in uORB it's NAN
+				bat_msg.time_remaining = (battery_status.connected && (PX4_ISFINITE(battery_status.time_remaining_s))) ?
 							 math::max((int)battery_status.time_remaining_s, 1) : 0;
 
 				switch (battery_status.warning) {

--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -76,7 +76,9 @@ private:
 				bat_msg.energy_consumed = -1;
 				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
 				bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.f) : -1;
-				bat_msg.time_remaining = (battery_status.connected) ? battery_status.run_time_to_empty * 60 : 0;
+				// MAVLink extension: 0 is unsupported, in uORB it's -1
+				bat_msg.time_remaining = (battery_status.connected && (battery_status.time_remaining_s >= 0.f)) ?
+							 math::max((int)battery_status.time_remaining_s, 1) : 0;
 
 				switch (battery_status.warning) {
 				case (battery_status_s::BATTERY_WARNING_NONE):


### PR DESCRIPTION
**Describe problem solved by this pull request**
It's useful to show the user an estimate how much longer he can still fly until the battery is empty.
This estimate will also be required to make an informed decision when to return to home automatically to be able to land safely before the battery is empty.

**Describe your solution**
Calculate the remaining flight time based on a very heavily filtered "average" current consumption and the configured battery capacity.

**Test data / coverage**
The algorithm was tested on an old version of PX4 this port to the new version wasn't specifically tested yet. I suggest we check logs that fly with this functionality to see if the flight time is accurate.
 
**Additional context**
 This is based on the refactor https://github.com/PX4/PX4-Autopilot/pull/17827