### PR TITLE
[RFC] VTOL: Refactor PWM limit-setting

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -39,7 +39,10 @@ param set-default MC_YAWRATE_I 0.02
 param set-default MC_YAWRATE_D 0
 param set-default MC_YAWRATE_FF 0
 
-param set-default VT_IDLE_PWM_MC  1080
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+
+param set-default VT_IDLE_PWM_FW  1000
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_MOT_ID 12
 param set-default VT_TYPE 0

--- a/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
@@ -42,8 +42,15 @@ param set-default MC_YAWRATE_FF 0
 
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+param set-default PWM_MAIN_MIN5 1080
+param set-default PWM_MAIN_MIN6 1080
+
 param set-default VT_FW_MOT_OFFID 34
-param set-default VT_IDLE_PWM_MC 1080
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_MOT_ID 123456
 param set-default VT_FW_MOT_OFFID 56
 param set-default VT_TILT_MC 0.08

--- a/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
@@ -17,8 +17,13 @@
 param set-default PWM_MAIN_MAX 2000
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
 param set-default VT_MOT_ID 1234
-param set-default VT_IDLE_PWM_MC  1080
+param set-default VT_IDLE_PWM_FW  1000
 param set-default VT_TYPE 0
 param set-default VT_ELEV_MC_LOCK 1
 set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
@@ -26,7 +26,13 @@
 param set-default PWM_MAIN_MAX 2000
 param set-default PWM_MAIN_RATE 400
 
-param set-default VT_IDLE_PWM_MC  1080
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
+param set-default VT_IDLE_PWM_FW  1000
+param set-default VT_MOT_ID 1234
 param set-default VT_TYPE 0
 param set-default VT_ELEV_MC_LOCK 1
 set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -57,12 +57,17 @@ param set-default FW_RR_IMAX 0.2
 param set-default FW_RR_P 0.05
 param set-default FW_THR_CRUISE 0.75
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
 param set-default VT_ARSP_BLEND 6
 param set-default VT_ARSP_TRANS 12
 param set-default VT_F_TRANS_THR 0.75
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
-param set-default VT_IDLE_PWM_MC 1080
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_TYPE 2
 set MAV_TYPE 22
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -47,10 +47,15 @@ param set-default MPC_YAWRAUTO_MAX 20
 param set-default PWM_AUX_DIS3 950
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
 param set-default VT_F_TRANS_THR 0.75
-param set-default VT_IDLE_PWM_MC 1080
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_TYPE 2
 set MAV_TYPE 22
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -36,10 +36,15 @@ param set-default MPC_YAWRAUTO_MAX 40
 param set-default PWM_AUX_DIS5 950
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
 param set-default VT_F_TRANS_THR 0.75
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
-param set-default VT_IDLE_PWM_MC 1080
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_TYPE 2
 set MAV_TYPE 22
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -50,11 +50,16 @@ param set-default PWM_AUX_REV1 1
 param set-default PWM_AUX_REV2 1
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
 param set-default VT_ARSP_TRANS 15
 param set-default VT_ARSP_BLEND 8
 param set-default VT_B_TRANS_DUR 4
 param set-default VT_F_TRANS_THR 0.75
-param set-default VT_IDLE_PWM_MC 1080
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
 param set-default VT_TYPE 2

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -70,10 +70,15 @@ param set-default PWM_AUX_DIS5 950
 
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1180
+param set-default PWM_MAIN_MIN2 1180
+param set-default PWM_MAIN_MIN3 1180
+param set-default PWM_MAIN_MIN4 1180
+
 param set-default VT_ARSP_TRANS   15
 param set-default VT_B_TRANS_DUR  4
 param set-default VT_F_TRANS_THR    0.6
-param set-default VT_IDLE_PWM_MC 1180
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
 param set-default VT_TRANS_MIN_TM 5

--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -22,9 +22,15 @@ param set-default PWM_AUX_RATE 50
 param set-default PWM_MAIN_MAX 2000
 param set-default PWM_MAIN_RATE 400
 
+param set-default PWM_MAIN_MIN1 1080
+param set-default PWM_MAIN_MIN2 1080
+param set-default PWM_MAIN_MIN3 1080
+param set-default PWM_MAIN_MIN4 1080
+
+
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 13
-param set-default VT_IDLE_PWM_MC 1080
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_TILT_FW 0.9
 param set-default VT_TILT_MC 0.08
 param set-default VT_TILT_TRANS 0.5

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -63,6 +63,10 @@ param set-default PWM_MAIN_RATE 400
 
 param set-default SENS_BOARD_ROT 8
 
+param set-default PWM_MAIN_MIN1 1200
+param set-default PWM_MAIN_MIN2 1200
+param set-default PWM_MAIN_MIN3 1200
+
 param set-default VT_B_TRANS_DUR  1
 param set-default VT_F_TRANS_DUR  1.2
 param set-default VT_F_TR_OL_TM   4
@@ -70,7 +74,7 @@ param set-default VT_FW_DIFTHR_EN 1
 param set-default VT_FW_DIFTHR_SC 0.17
 param set-default VT_FW_MOT_OFFID 3
 param set-default VT_FW_PERM_STAB 0
-param set-default VT_IDLE_PWM_MC 1200
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_MOT_ID 123
 param set-default VT_TILT_FW  1
 param set-default VT_TILT_MC  0

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -129,6 +129,11 @@ param set-default MAV_1_RATE 5000
 param set-default MAV_1_FORWARD 1
 param set-default SER_TEL2_BAUD 57600
 
+param set-default PWM_MAIN_MIN1 1025
+param set-default PWM_MAIN_MIN2 1025
+param set-default PWM_MAIN_MIN3 1025
+param set-default PWM_MAIN_MIN4 1025
+
 param set-default VT_TYPE 2
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
@@ -142,7 +147,7 @@ param set-default VT_WV_LND_EN 1
 param set-default VT_WV_LTR_EN 1
 param set-default VT_FWD_THRUST_SC 4
 param set-default VT_F_TRANS_DUR 1
-param set-default VT_IDLE_PWM_MC 1025
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_B_REV_OUT 0.5
 param set-default VT_B_TRANS_THR 0.7
 param set-default VT_FW_PERM_STAB 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -91,6 +91,11 @@ param set-default PWM_MAIN_MIN 950
 
 param set-default SENS_BOARD_ROT 4
 
+param set-default PWM_MAIN_MIN5 1000
+param set-default PWM_MAIN_MIN6 1000
+param set-default PWM_MAIN_MIN7 1000
+param set-default PWM_MAIN_MIN8 1000
+
 param set-default VT_ARSP_BLEND 10
 param set-default VT_ARSP_TRANS 21
 param set-default VT_B_DEC_MSS 1.5
@@ -99,7 +104,7 @@ param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_FWD_THRUST_SC 1.2
 param set-default VT_FW_MOT_OFFID 5678
 param set-default VT_F_TR_OL_TM 8
-param set-default VT_IDLE_PWM_MC 1000
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_MOT_ID 5678
 param set-default VT_PSHER_RMP_DT 2
 param set-default VT_TRANS_MIN_TM 4

--- a/ROMFS/px4fmu_common/init.d/airframes/13030_generic_vtol_quad_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/13030_generic_vtol_quad_tiltrotor
@@ -29,7 +29,12 @@
 
 param set-default PWM_MAIN_RATE 400
 
-param set-default VT_IDLE_PWM_MC 1100
+param set-default PWM_MAIN_MIN1 1100
+param set-default PWM_MAIN_MIN2 1100
+param set-default PWM_MAIN_MIN3 1100
+param set-default PWM_MAIN_MIN4 1100
+
+param set-default VT_IDLE_PWM_FW 1000
 param set-default VT_TYPE 1
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 24

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -315,9 +315,9 @@ void Standard::update_transition_state()
 
 		set_all_motor_state(motor_state::ENABLED);
 
-		// set idle speed for MC actuators
+		// reset min/max PWM values for MC actuators for MC flight
 		if (!_flag_idle_mc) {
-			_flag_idle_mc = set_idle_mc();
+			_flag_idle_mc = set_limits_mc();
 		}
 	}
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -245,7 +245,7 @@ void Tailsitter::update_transition_state()
 		const float trans_pitch_rate = M_PI_2_F / _params->back_trans_duration;
 
 		if (!_flag_idle_mc) {
-			_flag_idle_mc = set_idle_mc();
+			_flag_idle_mc = set_limits_mc();
 		}
 
 		if (tilt > 0.01f) {

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -367,9 +367,9 @@ void Tiltrotor::update_transition_state()
 		set_all_motor_state(motor_state::ENABLED);
 
 
-		// set idle speed for rotary wing mode
+		// set PWM limits for rotary wing mode
 		if (!_flag_idle_mc) {
-			_flag_idle_mc = set_idle_mc();
+			_flag_idle_mc = set_limits_mc();
 		}
 
 		// tilt rotors back

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -59,10 +59,10 @@ VtolAttitudeControl::VtolAttitudeControl() :
 {
 	_vtol_vehicle_status.vtol_in_rw_mode = true;	/* start vtol in rotary wing mode*/
 
-	_params.idle_pwm_mc = PWM_DEFAULT_MIN;
+	_params.idle_pwm_fw = PWM_DEFAULT_MIN;
 	_params.vtol_motor_id = 0;
 
-	_params_handles.idle_pwm_mc = param_find("VT_IDLE_PWM_MC");
+	_params_handles.idle_pwm_fw = param_find("VT_IDLE_PWM_FW");
 	_params_handles.vtol_motor_id = param_find("VT_MOT_ID");
 	_params_handles.vtol_fw_permanent_stab = param_find("VT_FW_PERM_STAB");
 	_params_handles.vtol_type = param_find("VT_TYPE");
@@ -213,8 +213,9 @@ VtolAttitudeControl::parameters_update()
 {
 	float v;
 	int32_t l;
-	/* idle pwm for mc mode */
-	param_get(_params_handles.idle_pwm_mc, &_params.idle_pwm_mc);
+
+	/* Min VTOL motor PWM for FW mode */
+	param_get(_params_handles.idle_pwm_fw, &_params.idle_pwm_fw);
 
 	/* vtol motor count */
 	param_get(_params_handles.vtol_motor_id, &_params.vtol_motor_id);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -184,7 +184,7 @@ private:
 	Params _params{};	// struct holding the parameters
 
 	struct {
-		param_t idle_pwm_mc;
+		param_t idle_pwm_fw;
 		param_t vtol_motor_id;
 		param_t vtol_fw_permanent_stab;
 		param_t vtol_type;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -40,7 +40,7 @@
  */
 
 /**
- * Idle speed of VTOL when in multicopter mode
+ * Minimum PWM of VTOL motors when in fixed-wing mode
  *
  * @unit us
  * @min 900
@@ -49,7 +49,7 @@
  * @decimal 0
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_INT32(VT_IDLE_PWM_MC, 900);
+PARAM_DEFINE_INT32(VT_IDLE_PWM_FW, 1000);
 
 /**
  * Permanent stabilization in fw mode

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -48,7 +48,7 @@
 #include <drivers/drv_pwm_output.h>
 
 struct Params {
-	int32_t idle_pwm_mc;			// pwm value for idle in mc mode
+	int32_t idle_pwm_fw;			// pwm value for idle in fw mode
 	int32_t vtol_motor_id;
 	int32_t vtol_type;
 	bool elevons_mc_lock;		// lock elevons in multicopter mode
@@ -111,9 +111,9 @@ enum VtolForwardActuationMode {
 // we can select the target motors via VT_FW_MOT_OFFID
 enum class motor_state {
 	ENABLED = 0,		// motor max pwm will be set to the standard max pwm value
-	DISABLED,			// motor max pwm will be set to a value that shuts the motor off
-	IDLE,				// motor max pwm will be set to VT_IDLE_PWM_MC
-	VALUE 				// motor max pwm will be set to a specific value provided, see set_motor_state()
+	DISABLED,		// motor max pwm will be set to a value that shuts the motor off
+	IDLE,			// motor max pwm will be set to VT_IDLE_PWM_FW
+	VALUE 			// motor max pwm will be set to a specific value provided, see set_motor_state()
 };
 
 /**
@@ -251,20 +251,20 @@ protected:
 
 
 	/**
-	 * @brief      Sets mc motor minimum pwm to VT_IDLE_PWM_MC which ensures
-	 *             that they are spinning in mc mode.
+	 * @brief      Sets MC motor min/max PWM values the correct values for
+	 *             rotoray-wing flight.
 	 *
 	 * @return     true on success
 	 */
-	bool set_idle_mc();
+	bool set_limits_mc();
 
 	/**
-	 * @brief      Sets mc motor minimum pwm to PWM_MIN which ensures that the
-	 *             motors stop spinning on zero throttle in fw mode.
+	 * @brief      Sets MC motor min/max pwm to VT_IDLE_PWM_FW which ensures
+	 *             that the motors stop spinning but remain initialized.
 	 *
 	 * @return     true on success
 	 */
-	bool set_idle_fw();
+	bool set_limits_fw();
 
 	void set_all_motor_state(motor_state target_state, int value = 0);
 
@@ -285,6 +285,7 @@ private:
 	struct pwm_output_values _disarmed_pwm_values {};
 
 	struct pwm_output_values _current_max_pwm_values {};
+	struct pwm_output_values _current_min_pwm_values {};
 
 	int32_t _main_motor_channel_bitmap = 0;
 	int32_t _alternate_motor_channel_bitmap = 0;


### PR DESCRIPTION
**Describe problem solved by this pull request**
The PWM limit-setting of the VTOL attitude-control module was overly confusing, and was leading to some issues with setting the proper min/max values in various flight modes recently.  I think most of those issues were already fixed, but now I'm quite certain it's correct.

**Describe your solution**
Here's how it works now:

- When DISARMED: the `PWM_{MAIN,AUX}_DIS` value(s) apply (`DISABLED`); set both MIN and MIX to DIS
- When ARMED:
  - When in MR mode: `PWM_{MAIN,AUX}_{MIN,MAX}{i}` parameters should apply (`ENABLED`)
    - NOTE: If you want your motors to be spinning while armed in MC mode, you need set the parameters accordingly (same as a standard multicopter, I believe).
  - When in Transition Modes: Same as above
  - When in FW mode: 
    - "main" VTOL motors (motors also used for FW propulsion): No change from MR mode (`ENABLED`)
    - "alt" VTOL motors (pure-VTOL motors): Set both MIN and MAX to the `VT_IDLE_PWM_FW` value (`IDLE`).  This is a value chosen such that the motors remain "ready" (initialized) but below their 0% setpoint (not going to spin, may actively brake?)

NOTE: This changes how the PWM_x_MIN parameters are used (or rather, they actually get used now instead of being completely ignored).

**Describe possible alternatives**
The previous version of the module was the alternative, and I had a very hard time making heads or tails of where and how the various limits were being set, or why.  Now, I think it's much clearer (but maybe I'm biased to my own implementation 😄)

**Test data / coverage**
Bench-tested on a Pixhawk 4 using the standard VTOL airframe.  The expected min/max PWM values for all PWM outputs were observed based on the notes above.
