### PR TITLE
PWM: Draft implementation to respect PWM_OUT when loading defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -226,6 +226,8 @@ then
 	fi
 fi
 
+param set PWM_AUX_OUT ${PWM_AUX_OUT}
+
 if [ $MIXER_AUX != none -a $AUX_MODE = none -a -e $OUTPUT_AUX_DEV ]
 then
 	#
@@ -267,6 +269,8 @@ then
 		fi
 	fi
 fi
+
+param set PWM_MAIN_OUT ${PWM_OUT}
 
 if [ $EXTRA_MIXER_MODE != none ]
 then

--- a/src/lib/pwm/pwm_aux_params.yaml
+++ b/src/lib/pwm/pwm_aux_params.yaml
@@ -6,6 +6,17 @@ parameters:
     - group: PWM Outputs
       definitions:
 
+        PWM_AUX_OUT:
+            description:
+                short: PWM channels used as ESC outputs
+                long: |
+                    Number representing the channels e.g. 134 - Channel 1, 3 and 4.
+                    Global e.g. PWM_AUX_MIN/MAX/DISARM limits only apply to these channels.
+            type: int32
+            min: 0
+            max: 123456789
+            default: 0
+
         PWM_AUX_RATE:
             description:
                 short: PWM aux output frequency

--- a/src/lib/pwm/pwm_main_params.yaml
+++ b/src/lib/pwm/pwm_main_params.yaml
@@ -6,6 +6,17 @@ parameters:
     - group: PWM Outputs
       definitions:
 
+        PWM_MAIN_OUT:
+            description:
+                short: PWM channels used as ESC outputs
+                long: |
+                    Number representing the channels e.g. 134 - Channel 1, 3 and 4.
+                    Global e.g. PWM_MAIN_MIN/MAX/DISARM limits only apply to these channels.
+            type: int32
+            min: 0
+            max: 123456789
+            default: 0
+
         PWM_MAIN_RATE:
             description:
                 short: PWM main output frequency


### PR DESCRIPTION
**Describe problem solved by this pull request**
Like it was noted in the dev call of 16. June PWM default values for the entire output module e.g. `PWM_MAIN_MAX`, `PWM_MAIN_MIN`, `PWM_MAIN_DISARMED` get loaded now to all channels and not just to the ones masked by the `PWM_OUT` environmental variable set in the airframe which was not previously the case. `PWM_OUT` described the outputs going to ESCs that all use these same limits to have safe propeller actuator operation.

I described my first analysis in slack here: https://px4.slack.com/archives/C50RWGQMT/p1623862141134000
> I think we found the PWM disarmed default being loaded issue that was mentioned in the call (FYI @dagar):
Before it only loaded them for the outputs the airframe specified as ESCs with the very descriptive PWM_OUT environmental variable and that was done here: https://github.com/PX4/PX4-Autopilot/commit/318c7e83b33713e2080db27391636cff5ba51a24#diff-f93ed3bc532207cc23ce4274ee2636a1dfc5999b2160e3c813563ba0d673d278L334
Now the modules directly aaply the defaults indepndently of which outputs are ESCs e.g. here: https://github.com/PX4/PX4-Autopilot/blob/master/src/drivers/pwm_out/PWMOut.cpp#L777 (there's two more modules with the same logic)
So I suggest for the 1.12 release we write the content of PWM_OUT to a prameter and restore the behaviour from before in the modules. After the release we should let the user specify every output explicitly as ESC or servo and which one e.g. front right, left elevon or whatever. Then there will be one breaking change for the airframes in the next release but not 1.12 such that there are not two breaking changes and people that tested the beta will have the final release working. I see if I can do the pr.

**Describe your solution**
This draft sketches out to just load the content of:
environmental variable `PWM_OUT` to parameter `PWM_MAIN_OUT`
environmental variable `PWM_AUX_OUT` to parameter `PWM_AUX_OUT`
mainly with airframe backwards compatibility for release 1.12 in mind.

The entire output configuration will anyways change after 1.12 and this breaking change will require adjustment for the next release so this is a temporary solution and afterwards every output should default to no output and then explicitly configured by the user to be hooked up to an ESC or servo and which actuation e.g. Multirotor motor 3 or plane elevator. Then the implicit hardcoded airframe output configuration will get deprecated.

**Describe possible alternatives**
An automatic parameter transition would be nice but is not that easy because the transition logic cannot handle environmental variables. It would maybe be possible to load the environmental variable to a parameter to then transition it automatically but I don't see how that's better.

**Test data / coverage**
Untested draft to get feedback without too much effort.

**Additional Context**
I'm not sure how much it covers but it's related to the PWM issues:
https://github.com/PX4/PX4-Autopilot/issues/17485
https://github.com/PX4/PX4-Autopilot/compare/pr-pwm_defaults_per_channel
https://github.com/PX4/PX4-Autopilot/pull/17830
https://github.com/PX4/PX4-Autopilot/pull/17803