### PR TITLE
Add fmuv6x to vscode cmake variants

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -51,6 +51,16 @@ CONFIG:
       buildType: MinSizeRel
       settings:
         CONFIG: px4_fmu-v5x_default
+    px4_fmu-v6x_default:
+      short: px4_fmu-v6x
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_fmu-v6x_default
+    px4_fmu-v6x_bootloader:
+      short: px4_fmu-v6x_bootloader
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_fmu-v6x_bootloader
     airmind_mindpx-v2_default:
       short: airmind_mindpx-v2
       buildType: MinSizeRel


### PR DESCRIPTION
Adds fmuv6x default and bootloader to vscode cmake variants for development.