### PR TITLE
gyro_fft: track closest FFT peaks over time and median filter frequency

### DIFF
--- a/msg/sensor_gyro_fft.msg
+++ b/msg/sensor_gyro_fft.msg
@@ -10,8 +10,6 @@ float32[4] peak_frequencies_x # x axis peak frequencies
 float32[4] peak_frequencies_y # y axis peak frequencies
 float32[4] peak_frequencies_z # z axis peak frequencies
 
-float32[4] peak_magnitude_x   # x axis peak frequencies magnitude
-float32[4] peak_magnitude_y   # y axis peak frequencies magnitude
-float32[4] peak_magnitude_z   # z axis peak frequencies magnitude
-
-float32[3] total_energy
+float32[4] peak_snr_x # x axis peak SNR
+float32[4] peak_snr_y # y axis peak SNR
+float32[4] peak_snr_z # z axis peak SNR

--- a/src/lib/mathlib/math/filter/MedianFilter.hpp
+++ b/src/lib/mathlib/math/filter/MedianFilter.hpp
@@ -42,6 +42,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 namespace math

--- a/src/modules/gyro_fft/GyroFFT.hpp
+++ b/src/modules/gyro_fft/GyroFFT.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/defines.h>
@@ -77,7 +78,7 @@ public:
 	bool init();
 
 private:
-	float EstimatePeakFrequency(q15_t fft[], int peak_index);
+	float EstimatePeakFrequencyBin(q15_t fft[], int peak_index);
 	void Run() override;
 	bool SensorSelectionUpdate(bool force = false);
 	void Update(const hrt_abstime &timestamp_sample, int16_t *input[], uint8_t N);
@@ -141,7 +142,12 @@ private:
 
 	unsigned _gyro_last_generation{0};
 
+	float _peak_frequencies_prev[3][MAX_NUM_PEAKS] {};
+	math::MedianFilter<float, 3> _median_filter[3][MAX_NUM_PEAKS] {};
+
 	sensor_gyro_fft_s _sensor_gyro_fft{};
+
+	hrt_abstime _last_update[3][MAX_NUM_PEAKS] {};
 
 	int32_t _imu_gyro_fft_len{256};
 


### PR DESCRIPTION
On real vehicles the detected peaks tend to jump around quite a bit. This PR is an attempt to track each detected peak primarily to minimize unnecessary notch filter resets, but also make things easier to view.

### Example with current master

<img width="1377" alt="Screen Shot 2021-07-04 at 11 43 30 PM" src="https://user-images.githubusercontent.com/84712/124414915-a82b4780-dd21-11eb-86fb-a825eeb9490f.png">
