### PR TITLE
serial port config include device (eg /dev/ttyS3) in label (eg TELEM/SERIAL 4 (/dev/ttyS3))

### DIFF
--- a/Tools/serial/generate_config.py
+++ b/Tools/serial/generate_config.py
@@ -311,7 +311,7 @@ for tag, device in board_ports:
     serial_devices.append({
         'tag': tag,
         'device': device,
-        'label': serial_ports[tag]["label"],
+        'label': serial_ports[tag]["label"] + ' (' + device + ')',
         'index': serial_ports[tag]["index"],
         'default_baudrate': serial_ports[tag]["default_baudrate"]
         })


### PR DESCRIPTION
Serial port configuration is still a source of frequent confusion. Would exposing the device in addition to the nice name/alias in every label/description help?

Example
![Screenshot from 2021-07-05 12-28-29](https://user-images.githubusercontent.com/84712/124499756-8a46fc80-dd8c-11eb-98bb-f13922dacfc5.png)
