### PR TITLE
mixers: exclude FX79.main.mix from px4_fmu-v2

### DIFF
--- a/ROMFS/px4fmu_common/mixers/FX79.main.mix
+++ b/ROMFS/px4fmu_common/mixers/FX79.main.mix
@@ -1,6 +1,8 @@
 FX-79 Delta-wing mixer for PX4FMU
 =================================
 
+# @board px4_fmu-v2 exclude
+
 Designed for FX-79.
 
 TODO (sjwilks): Add mixers for flaps.


### PR DESCRIPTION
flash overflow on master
```
/opt/gcc/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: region `flash' overflowed by 9 bytes
```