### PR TITLE
optical_flow/paw3902: minor improvements

### DIFF
--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -126,10 +126,17 @@ private:
 
 	Mode		_mode{Mode::LowLight};
 
+	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_1};
+
 	int _bright_to_low_counter{0};
 	int _low_to_superlow_counter{0};
 	int _low_to_bright_counter{0};
 	int _superlow_to_low_counter{0};
 
 	int _valid_count{0};
+
+	bool _data_ready_interrupt_enabled{false};
+
+	hrt_abstime _last_good_publish{0};
+	hrt_abstime _last_reset{0};
 };

--- a/src/drivers/optical_flow/paw3902/paw3902_main.cpp
+++ b/src/drivers/optical_flow/paw3902/paw3902_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020, 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
 - configure a backup schedule when using motion interrupt otherwise the sensor will stop publishing entirely in the dark
 - as a precaution issue full reset if sensor is stuck in a bad state (no vaid data for an extended period)
 - update light mode change criteria to match datasheet exactly
