### PR TITLE
Adjust lower bound for CAL_AIR_TUBED_MM to 1.5 mm

### DIFF
--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -68,7 +68,7 @@ PARAM_DEFINE_FLOAT(CAL_AIR_TUBELEN, 0.2f);
 /**
  * Airspeed sensor tube diameter. Only used for the Tube Pressure Drop Compensation.
  *
- * @min 0.1
+ * @min 1.5
  * @max 100
  * @unit mm
  *


### PR DESCRIPTION
**Describe problem solved by this pull request**
During our last testflight we noticed that the tube pressure compensation returns too high calibration factor causing our plane to stall.

**Describe your solution**
Adjust the lower bound of CAL_AIR_TUBED_MM to 1.5 mm such that the users gets warned if they want to set a value lower than 1.5 mm. This limit should be feasible since Sensirion anyway recommends a tube diameter larger than 1.8 mm.

**Describe possible alternatives**
We could also enforce a lower bound in the software but I am not fully convinced that this is the way to go.

**Test data / coverage**
Logfile: https://review.px4.io/plot_app?log=0477a18b-4aef-4996-ac17-4aa5391e6303

**Additional context**
I implemented a matlab script to visualize the scale factor and the corrected airspeed as a function of different differential pressure measurements.

Factor and airspeed for a tube diameter of 1.0 mm, length 0.2 m:
![image](https://user-images.githubusercontent.com/6713722/125046507-5fb3b700-e09e-11eb-93df-0b85e792d07c.png)
![image](https://user-images.githubusercontent.com/6713722/125046609-7823d180-e09e-11eb-8cd4-e42a8205158e.png)

Factor and airspeed for a tube diameter of 1.5 mm, length 0.2 m:
![image](https://user-images.githubusercontent.com/6713722/125046711-9093ec00-e09e-11eb-9e89-6d995632cbe0.png)
![image](https://user-images.githubusercontent.com/6713722/125046750-9984bd80-e09e-11eb-8181-4fd5f6279712.png)


