### PR TITLE
mavlink: fix incorrect rejection of forwarded alien commands

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -462,7 +462,11 @@ void MavlinkReceiver::handle_message_command_both(mavlink_message_t *msg, const 
 	uint8_t result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 
 	if (!target_ok) {
-		acknowledge(msg->sysid, msg->compid, cmd_mavlink.command, vehicle_command_ack_s::VEHICLE_RESULT_FAILED);
+		if (!_mavlink->get_forwarding_on()) {
+			// Reject alien commands only if there is no forwarding enabled
+			acknowledge(msg->sysid, msg->compid, cmd_mavlink.command, vehicle_command_ack_s::VEHICLE_RESULT_FAILED);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
When forwarding on MAVlink channel is used there could be other systems/components. When GCS through us send commands to them, these commands are treated as alien commands for this system (default component), and failed acknowledge is sent by us, but must not.