### PR TITLE
events interface: chance uORB 'sequence' to 'event_sequence'

### DIFF
--- a/msg/event.msg
+++ b/msg/event.msg
@@ -2,10 +2,9 @@
 uint64 timestamp			# time since system start (microseconds)
 
 uint32 id                   # Event ID
-uint16 sequence             # Sequence number
+uint16 event_sequence       # Event sequence number
 uint8[25] arguments         # (optional) arguments, depend on event id
 
 uint8 log_levels            # Log levels: 4 bits MSB: internal, 4 bits LSB: external
 
 uint8 ORB_QUEUE_LENGTH = 8
-

--- a/platforms/common/events.cpp
+++ b/platforms/common/events.cpp
@@ -55,7 +55,7 @@ void send(EventType &event)
 	// - we need to ensure ordering of the sequence numbers: the sequence we set here
 	//   has to be the one published next.
 	pthread_mutex_lock(&publish_event_mutex);
-	event.sequence = ++event_sequence; // Set the sequence here so we're able to detect uORB queue overflows
+	event.event_sequence = ++event_sequence; // Set the sequence here so we're able to detect uORB queue overflows
 
 	if (orb_event_pub != nullptr) {
 		orb_publish(ORB_ID(event), orb_event_pub, &event);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -947,9 +947,9 @@ bool Logger::handle_event_updates(uint32_t &total_bytes)
 		} else {
 			// adjust sequence number
 			uint16_t updated_sequence;
-			memcpy(&updated_sequence, &orb_event->sequence, sizeof(updated_sequence));
+			memcpy(&updated_sequence, &orb_event->event_sequence, sizeof(updated_sequence));
 			updated_sequence -= _event_sequence_offset;
-			memcpy(&orb_event->sequence, &updated_sequence, sizeof(updated_sequence));
+			memcpy(&orb_event->event_sequence, &updated_sequence, sizeof(updated_sequence));
 
 			size_t msg_size = sizeof(ulog_message_data_header_s) + _event_subscription.get_topic()->o_size_no_padding;
 			uint16_t write_msg_size = static_cast<uint16_t>(msg_size - ULOG_MSG_HEADER_LEN);
@@ -974,9 +974,9 @@ bool Logger::handle_event_updates(uint32_t &total_bytes)
 			// mission log: only warnings or higher
 			if (events::internalLogLevel(orb_event->log_levels) <= events::LogLevelInternal::Warning) {
 				if (_writer.is_started(LogType::Mission)) {
-					memcpy(&updated_sequence, &orb_event->sequence, sizeof(updated_sequence));
+					memcpy(&updated_sequence, &orb_event->event_sequence, sizeof(updated_sequence));
 					updated_sequence -= _event_sequence_offset_mission;
-					memcpy(&orb_event->sequence, &updated_sequence, sizeof(updated_sequence));
+					memcpy(&orb_event->event_sequence, &updated_sequence, sizeof(updated_sequence));
 
 					if (write_message(LogType::Mission, _msg_buffer, msg_size)) {
 						data_written = true;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2473,7 +2473,7 @@ Mavlink::task_main(int argc, char *argv[])
 					events::Event e;
 					e.id = orb_event.id;
 					e.timestamp_ms = orb_event.timestamp / 1000;
-					e.sequence = orb_event.sequence - event_sequence_offset;
+					e.sequence = orb_event.event_sequence - event_sequence_offset;
 					e.log_levels = orb_event.log_levels;
 					static_assert(sizeof(e.arguments) == sizeof(orb_event.arguments),
 						      "uorb message event: arguments size mismatch");


### PR DESCRIPTION
**Describe problem solved by this pull request**
`sequence` is an IDL reserved keyword, which results on failure when parsing with FastRTPSGen.

**Describe your solution**
Renamed `sequence` to `event_sequence`, as aligned with @bkueng.

**Describe possible alternatives**
As a follow-up, I will also add a list of reserved keywords check to our IDL generator so to avoid that these words are used in uORB. List can be found in page 29 of the following PDF: https://www.omg.org/spec/IDL/4.2/PDF.

**Test data / coverage**
Changed it as well in `px4_msgs`, and now the bridge builds correctly. Before, this happened: https://github.com/PX4/px4_ros_com/runs/3014970272.
