### PR TITLE
platforms/common:SPI - fix hang on bords supporting BOARD_HAS_BUS_MAN…

### DIFF
--- a/platforms/common/spi.cpp
+++ b/platforms/common/spi.cpp
@@ -112,49 +112,48 @@ bool SPIBusIterator::next()
 	while (_index < SPI_BUS_MAX_BUS_ITEMS && px4_spi_buses[_index].bus != -1) {
 		const px4_spi_bus_t &bus_data = px4_spi_buses[_index];
 
-		if (!board_has_bus(BOARD_SPI_BUS, bus_data.bus)) {
-			continue;
-		}
+		if (board_has_bus(BOARD_SPI_BUS, bus_data.bus)) {
 
-		// Note: we use bus_data.is_external here instead of px4_spi_bus_external(),
-		// otherwise the chip-select matching does not work if a bus is configured as
-		// external/internal, but at runtime the other way around.
-		// (On boards where a bus can be internal/external at runtime, it should be
-		// configured as external.)
-		switch (_filter) {
-		case FilterType::InternalBus:
-			if (!bus_data.is_external) {
-				if (_bus == bus_data.bus || _bus == -1) {
-					// find device id
-					for (int i = _bus_device_index + 1; i < SPI_BUS_MAX_DEVICES; ++i) {
-						if (PX4_SPI_DEVICE_ID == PX4_SPIDEVID_TYPE(bus_data.devices[i].devid) &&
-						    _devid_driver_index == bus_data.devices[i].devtype_driver) {
-							_bus_device_index = i;
-							return true;
+			// Note: we use bus_data.is_external here instead of px4_spi_bus_external(),
+			// otherwise the chip-select matching does not work if a bus is configured as
+			// external/internal, but at runtime the other way around.
+			// (On boards where a bus can be internal/external at runtime, it should be
+			// configured as external.)
+			switch (_filter) {
+			case FilterType::InternalBus:
+				if (!bus_data.is_external) {
+					if (_bus == bus_data.bus || _bus == -1) {
+						// find device id
+						for (int i = _bus_device_index + 1; i < SPI_BUS_MAX_DEVICES; ++i) {
+							if (PX4_SPI_DEVICE_ID == PX4_SPIDEVID_TYPE(bus_data.devices[i].devid) &&
+							    _devid_driver_index == bus_data.devices[i].devtype_driver) {
+								_bus_device_index = i;
+								return true;
+							}
 						}
 					}
 				}
-			}
 
-			break;
+				break;
 
-		case FilterType::ExternalBus:
-			if (bus_data.is_external) {
-				uint16_t cs_index = _devid_driver_index - 1;
+			case FilterType::ExternalBus:
+				if (bus_data.is_external) {
+					uint16_t cs_index = _devid_driver_index - 1;
 
-				if (_bus == _external_bus_counter && cs_index < SPI_BUS_MAX_DEVICES &&
-				    bus_data.devices[cs_index].cs_gpio != 0 && cs_index != _bus_device_index) {
-					// we know that bus_data.devices[cs_index].devtype_driver == cs_index
-					_bus_device_index = cs_index;
-					return true;
+					if (_bus == _external_bus_counter && cs_index < SPI_BUS_MAX_DEVICES &&
+					    bus_data.devices[cs_index].cs_gpio != 0 && cs_index != _bus_device_index) {
+						// we know that bus_data.devices[cs_index].devtype_driver == cs_index
+						_bus_device_index = cs_index;
+						return true;
+					}
 				}
+
+				break;
 			}
 
-			break;
-		}
-
-		if (bus_data.is_external) {
-			++_external_bus_counter;
+			if (bus_data.is_external) {
+				++_external_bus_counter;
+			}
 		}
 
 		++_index;


### PR DESCRIPTION

I was testing V4 HW on upstream nuttx and it did not boot.

When BOARD_HAS_BUS_MANIFEST is lit the `!board_has_bus(BOARD_SPI_BUS, bus_data.bus)` can take the continue.

The continue bypassed the index increment as of c5aef9d5127c006ffdc95789feae32f33b129de4 