### PR TITLE
flight_mode_manager: StickAccelerationXY minimize setpoint oscillations around zero

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -85,8 +85,11 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 
 	// Don't allow the drag to change the sign of the velocity, otherwise we might get into oscillations around 0, due
 	// to discretization
-	if (_acceleration_setpoint.norm_squared() < FLT_EPSILON
-	    && _velocity_setpoint.norm_squared() < drag.norm_squared() * dt * dt) {
+	if (((_acceleration_setpoint.norm_squared() < FLT_EPSILON)
+	     || (sign(_acceleration_setpoint_prev(0)) != sign(_acceleration_setpoint(0)))
+	     || (sign(_acceleration_setpoint_prev(1)) != sign(_acceleration_setpoint(1))))
+	    && (_velocity_setpoint.norm_squared() < (drag.norm_squared() * dt * dt))) {
+
 		drag.setZero();
 		_velocity_setpoint.setZero();
 	}


### PR DESCRIPTION
Attempted fix for small oscillations that occur with `FlightTaskManualAcceleration` when you start or stop moving the sticks and the velocity setpoint is nearly zero.

<img width="1311" alt="Screen Shot 2021-07-11 at 8 48 39 PM" src="https://user-images.githubusercontent.com/84712/125215407-68b4ac00-e289-11eb-8962-e71147be3a91.png">

<img width="1307" alt="Screen Shot 2021-07-11 at 8 52 47 PM" src="https://user-images.githubusercontent.com/84712/125215629-07410d00-e28a-11eb-96db-ce5c3ce7a5b1.png">

