### PR TITLE
Add ignition gazebo support for PX4 Software-In-The-Loop simulations 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,6 +74,6 @@
 [submodule "src/lib/events/libevents"]
 	path = src/lib/events/libevents
 	url = https://github.com/mavlink/libevents.git
-[submodule "Tools/sitl_ign_gazebo"]
-	path = Tools/sitl_ign_gazebo
+[submodule "Tools/simulation-ignition"]
+	path = Tools/simulation-ignition
 	url = https://github.com/Auterion/px4-simulation-ignition.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -74,3 +74,6 @@
 [submodule "src/lib/events/libevents"]
 	path = src/lib/events/libevents
 	url = https://github.com/mavlink/libevents.git
+[submodule "Tools/sitl_ign_gazebo"]
+	path = Tools/sitl_ign_gazebo
+	url = https://github.com/Auterion/px4-simulation-ignition.git

--- a/Tools/setup_ignition.bash
+++ b/Tools/setup_ignition.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Setup environment to make PX4 visible to Gazebo.
+#
+# Note, this is not necessary if using a ROS catkin workspace with the px4
+# package as the paths are exported.
+#
+# License: according to LICENSE.md in the root directory of the PX4 Firmware repository
+
+if [ "$#" != 2 ]; then
+    echo -e "usage: source setup_gazebo.bash src_dir build_dir\n"
+    return 1
+fi
+
+SRC_DIR=$1
+BUILD_DIR=$2
+
+# setup Gazebo env and update package path
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${SRC_DIR}/build/px4_sitl_default/build_ign_gazebo
+export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=$IGN_GAZEBO_SYSTEM_PLUGIN_PATH:${SRC_DIR}/build/px4_sitl_default/build_ign_gazebo
+export IGN_GAZEBO_RESOURCE_PATH=$IGN_GAZEBO_RESOURCE_PATH:${SRC_DIR}/Tools/sitl_ign_gazebo/models
+
+echo -e "LD_LIBRARY_PATH $LD_LIBRARY_PATH"

--- a/Tools/setup_ignition.bash
+++ b/Tools/setup_ignition.bash
@@ -18,6 +18,6 @@ BUILD_DIR=$2
 # setup Gazebo env and update package path
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${SRC_DIR}/build/px4_sitl_default/build_ign_gazebo
 export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=$IGN_GAZEBO_SYSTEM_PLUGIN_PATH:${SRC_DIR}/build/px4_sitl_default/build_ign_gazebo
-export IGN_GAZEBO_RESOURCE_PATH=$IGN_GAZEBO_RESOURCE_PATH:${SRC_DIR}/Tools/sitl_ign_gazebo/models
+export IGN_GAZEBO_RESOURCE_PATH=$IGN_GAZEBO_RESOURCE_PATH:${SRC_DIR}/Tools/simulation-ignition/models
 
 echo -e "LD_LIBRARY_PATH $LD_LIBRARY_PATH"

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -180,7 +180,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 elif [ "$program" == "ignition" ] && [ -z "$no_sim" ]; then
 	echo "Ignition Gazebo"
 	source "$src_path/Tools/setup_ignition.bash" "${src_path}" "${build_path}"
-	ign gazebo -r "${src_path}/Tools/sitl_ign_gazebo/worlds/ignition.world"&
+	ign gazebo -r "${src_path}/Tools/simulation-ignition/worlds/ignition.world"&
 elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	echo "FG setup"
 	cd "${src_path}/Tools/flightgear_bridge/"

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -177,6 +177,10 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 		echo "You need to have gazebo simulator installed!"
 		exit 1
 	fi
+elif [ "$program" == "ignition" ] && [ -z "$no_sim" ]; then
+	echo "Ignition Gazebo"
+	source "$src_path/Tools/setup_ignition.bash" "${src_path}" "${build_path}"
+	ign gazebo -r "${src_path}/Tools/sitl_ign_gazebo/worlds/ignition.world"&
 elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	echo "FG setup"
 	cd "${src_path}/Tools/flightgear_bridge/"

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -48,9 +48,9 @@ ExternalProject_Add(sitl_gazebo
 	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${build_cores}
 )
 
-px4_add_git_submodule(TARGET git_ign_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_ign_gazebo")
-ExternalProject_Add(sitl_ign_gazebo
-	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/sitl_ign_gazebo
+px4_add_git_submodule(TARGET git_ign_gazebo PATH "${PX4_SOURCE_DIR}/Tools/simulation-ignition")
+ExternalProject_Add(simulation-ignition
+	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/simulation-ignition
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
 	BINARY_DIR ${PX4_BINARY_DIR}/build_ign_gazebo
 	INSTALL_COMMAND ""
@@ -194,7 +194,7 @@ foreach(viewer ${viewers})
 					elseif(viewer STREQUAL "jmavsim")
 						add_dependencies(${_targ_name} px4 git_jmavsim)
 					elseif(viewer STREQUAL "ignition")
-						add_dependencies(${_targ_name} px4 sitl_ign_gazebo)
+						add_dependencies(${_targ_name} px4 simulation-ignition)
 					endif()
 				else()
 					if(viewer STREQUAL "gazebo")

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -48,6 +48,20 @@ ExternalProject_Add(sitl_gazebo
 	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${build_cores}
 )
 
+px4_add_git_submodule(TARGET git_ign_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_ign_gazebo")
+ExternalProject_Add(sitl_ign_gazebo
+	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/sitl_ign_gazebo
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+	BINARY_DIR ${PX4_BINARY_DIR}/build_ign_gazebo
+	INSTALL_COMMAND ""
+	DEPENDS git_ign_gazebo
+	USES_TERMINAL_CONFIGURE true
+	USES_TERMINAL_BUILD true
+	EXCLUDE_FROM_ALL true
+	BUILD_ALWAYS 1
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${build_cores}
+)
+
 ExternalProject_Add(mavsdk_tests
 	SOURCE_DIR ${PX4_SOURCE_DIR}/test/mavsdk_tests
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
@@ -90,6 +104,7 @@ set(viewers
 	none
 	jmavsim
 	gazebo
+	ignition
 )
 
 set(debuggers
@@ -178,6 +193,8 @@ foreach(viewer ${viewers})
 						add_dependencies(${_targ_name} px4 sitl_gazebo)
 					elseif(viewer STREQUAL "jmavsim")
 						add_dependencies(${_targ_name} px4 git_jmavsim)
+					elseif(viewer STREQUAL "ignition")
+						add_dependencies(${_targ_name} px4 sitl_ign_gazebo)
 					endif()
 				else()
 					if(viewer STREQUAL "gazebo")


### PR DESCRIPTION
**Describe problem solved by this pull request**
This commit adds SITL support for [ignition gazebo](https://ignitionrobotics.org/home). Ignition gazebo is a replacement for the "classic" gazebo for future applications.

Since PX4 uses gazebo for a lot of integration testing and simulated environments, it makes a lot of sense to integrate into the new ignition gazebo.

**Describe your solution**
This implementation is a first iteration supporting SITL in the ignition environment.
- a `mavlink_interface_plugin` was implemented as an interface for `HIL_*` mavlink messages between px4 and `ignition gazebo`
- Only a quadrotor is supported in the current implementation

A demonstration of the package is shown in the video below:
[![ignition gazebo sitl](https://img.youtube.com/vi/38UJqrNQChg/0.jpg)](https://youtu.be/38UJqrNQChg "Circular trajectory tracking")


**Test data / coverage**
The dependency that is only needed in the regular environment is ignition edifice. This is the latest LTS release of ignition gazebo. Supported environments include Ubuntu Focal / Ubuntu Bionic
```
sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
apt update
apt install ignition-edifice
```
The simulation can be run as the following
```
make px4_sitl ignition
```

**Additional context**
- The submodule that was added can be found in https://github.com/Auterion/px4-simulation-ignition
- Added ignition gazebo to px4 container: https://github.com/PX4/PX4-containers/pull/303