### PR TITLE
Add No help Option to CONSTRAINED_FLASH

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -11,6 +11,7 @@ px4_add_board(
 	IO px4_io-v2_default
 	#UAVCAN_INTERFACES 2
 	CONSTRAINED_FLASH
+	  NO_HELP
 	SERIAL_PORTS
 		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -56,6 +56,7 @@
 #			[ EXAMPLES <list> ]
 #			[ SERIAL_PORTS <list> ]
 #			[ CONSTRAINED_FLASH ]
+#			[   NO_HELP ]
 #			[ CONSTRAINED_MEMORY ]
 #			[ EXTERNAL_METADATA ]
 #			[ TESTING ]
@@ -82,7 +83,8 @@
 #		SYSTEMCMDS		: list of system commands to build for this board (relative to src/systemcmds)
 #		EXAMPLES		: list of example modules to build for this board (relative to src/examples)
 #		SERIAL_PORTS		: mapping of user configurable serial ports and param facing name
-#		CONSTRAINED_FLASH	: flag to enable constrained flash options (eg limit init script status text)
+#		CONSTRAINED_FLASH 	: flag to enable constrained flash options (eg limit init script status text)
+#		  NO_HELP 	 	: optional condition flag to disable help text on constrained flash systems
 #		CONSTRAINED_MEMORY	: flag to enable constrained memory options (eg limit maximum number of uORB publications)
 #		EXTERNAL_METADATA	: flag to exclude metadata to reduce flash
 #		TESTING			: flag to enable automatic inclusion of PX4 testing modules
@@ -165,6 +167,7 @@ function(px4_add_board)
 		OPTIONS
 			BUILD_BOOTLOADER
 			CONSTRAINED_FLASH
+			NO_HELP
 			CONSTRAINED_MEMORY
 			EXTERNAL_METADATA
 			TESTING
@@ -262,6 +265,9 @@ function(px4_add_board)
 	if(CONSTRAINED_FLASH)
 		set(px4_constrained_flash_build "1" CACHE INTERNAL "constrained flash build" FORCE)
 		add_definitions(-DCONSTRAINED_FLASH)
+		if (NO_HELP)
+			add_definitions(-DCONSTRAINED_FLASH_NO_HELP="https://docs.px4.io/master/en/modules/modules_main.html")
+		endif()
 	endif()
 
 	if(CONSTRAINED_MEMORY)

--- a/platforms/common/module.cpp
+++ b/platforms/common/module.cpp
@@ -60,8 +60,12 @@ void PRINT_MODULE_DESCRIPTION(const char *description)
 
 void PRINT_MODULE_USAGE_NAME(const char *executable_name, const char *category)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
 	PX4_INFO_RAW("Usage: %s <command> [arguments...]\n", executable_name);
 	PX4_INFO_RAW(" Commands:\n");
+#else
+	PX4_INFO_RAW("Usage: %s See:" CONSTRAINED_FLASH_NO_HELP "\n", executable_name);
+#endif
 }
 
 void PRINT_MODULE_USAGE_SUBCATEGORY(const char *subcategory)
@@ -71,26 +75,36 @@ void PRINT_MODULE_USAGE_SUBCATEGORY(const char *subcategory)
 
 void PRINT_MODULE_USAGE_NAME_SIMPLE(const char *executable_name, const char *category)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
 	PX4_INFO_RAW("Usage: %s [arguments...]\n", executable_name);
+#endif
 }
 
 void PRINT_MODULE_USAGE_COMMAND_DESCR(const char *name, const char *description)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	if (description) {
 		PX4_INFO_RAW("\n   %-13s %s\n", name, description);
 
 	} else {
 		PX4_INFO_RAW("\n   %s\n", name);
 	}
+
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAM_COMMENT(const char *comment)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
 	PX4_INFO_RAW("\n %s\n", comment);
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(bool i2c_support, bool spi_support)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	// Note: this must be kept in sync with Tools/px4moduledoc/srcparser.py
 	if (i2c_support) {
 		PRINT_MODULE_USAGE_PARAM_FLAG('I', "Internal I2C bus(es)", true);
@@ -112,21 +126,28 @@ void PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(bool i2c_support, bool spi_support
 
 	PRINT_MODULE_USAGE_PARAM_INT('f', -1, 0, 100000, "bus frequency in kHz", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('q', "quiet startup (no message if no device found)", true);
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(uint8_t default_address)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
 	PRINT_MODULE_USAGE_PARAM_INT('a', default_address, 0, 0xff, "I2C address", true);
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAMS_I2C_KEEP_RUNNING_FLAG()
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
 	PRINT_MODULE_USAGE_PARAM_FLAG('k', "if initialization (probing) fails, keep retrying periodically", true);
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAM_INT(char option_char, int default_val, int min_val, int max_val,
 				  const char *description, bool is_optional)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	if (is_optional) {
 		PX4_INFO_RAW("     [-%c <val>]  %s\n", option_char, description);
 
@@ -137,11 +158,15 @@ void PRINT_MODULE_USAGE_PARAM_INT(char option_char, int default_val, int min_val
 	} else {
 		PX4_INFO_RAW("     -%c <val>    %s\n", option_char, description);
 	}
+
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAM_FLOAT(char option_char, float default_val, float min_val, float max_val,
 				    const char *description, bool is_optional)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	if (is_optional) {
 		PX4_INFO_RAW("     [-%c <val>]  %s\n", option_char, description);
 
@@ -152,21 +177,29 @@ void PRINT_MODULE_USAGE_PARAM_FLOAT(char option_char, float default_val, float m
 	} else {
 		PX4_INFO_RAW("     -%c <val>    %s\n", option_char, description);
 	}
+
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAM_FLAG(char option_char, const char *description, bool is_optional)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	if (is_optional) {
 		PX4_INFO_RAW("     [-%c]        %s\n", option_char, description);
 
 	} else {
 		PX4_INFO_RAW("     -%c          %s\n", option_char, description);
 	}
+
+#endif
 }
 
 void PRINT_MODULE_USAGE_PARAM_STRING(char option_char, const char *default_val, const char *values,
 				     const char *description, bool is_optional)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	if (is_optional) {
 		PX4_INFO_RAW("     [-%c <val>]  %s\n", option_char, description);
 
@@ -187,16 +220,22 @@ void PRINT_MODULE_USAGE_PARAM_STRING(char option_char, const char *default_val, 
 			PX4_INFO_RAW("                 default: %s\n", default_val);
 		}
 	}
+
+#endif
 }
 
 
 void PRINT_MODULE_USAGE_ARG(const char *values, const char *description, bool is_optional)
 {
+#ifndef CONSTRAINED_FLASH_NO_HELP
+
 	if (is_optional) {
 		PX4_INFO_RAW("     [%-9s] %s\n", values, description);
 
 	} else {
 		PX4_INFO_RAW("     %-11s %s\n", values, description);
 	}
+
+#endif
 }
 


### PR DESCRIPTION
We are out of flash again on the V2. 

My recollection was there was supposed to be a tool to make the doc from the code.  

This PR replaces the help with the a URL in the defualt.cmake file or if none is provided uses  https://docs.px4.io/master. 

