### PR TITLE
ulog stream message lost

### DIFF
--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -128,7 +128,15 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 		}
 	}
 
-	while ((_current_num_msgs < _max_num_messages) && _ulog_stream_sub.update()) {
+
+	while ((_current_num_msgs < _max_num_messages) && _ulog_stream_sub.updated()) {
+		const unsigned last_generation = _ulog_stream_sub.get_last_generation();
+		_ulog_stream_sub.update();
+
+		if (_ulog_stream_sub.get_last_generation() != last_generation + 1) {
+			PX4_ERR("ulog_stream lost, generation %d -> %d", last_generation, _ulog_stream_sub.get_last_generation());
+		}
+
 		const ulog_stream_s &ulog_data = _ulog_stream_sub.get();
 
 		if (ulog_data.timestamp > 0) {

--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -66,6 +66,11 @@ MavlinkULog::MavlinkULog(int datarate, float max_rate_factor, uint8_t target_sys
 	_next_rate_check = _last_sent_time + _rate_calculation_delta_t * 1.e6f;
 }
 
+MavlinkULog::~MavlinkULog()
+{
+	perf_free(_msg_missed_ulog_stream_perf);
+}
+
 void MavlinkULog::start_ack_received()
 {
 	if (_waiting_for_initial_ack) {
@@ -134,7 +139,7 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 		_ulog_stream_sub.update();
 
 		if (_ulog_stream_sub.get_last_generation() != last_generation + 1) {
-			PX4_ERR("ulog_stream lost, generation %d -> %d", last_generation, _ulog_stream_sub.get_last_generation());
+			perf_count(_msg_missed_ulog_stream_perf);
 		}
 
 		const ulog_stream_s &ulog_data = _ulog_stream_sub.get();

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -45,6 +45,7 @@
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/sem.h>
 #include <drivers/drv_hrt.h>
+#include <lib/perf/perf_counter.h>
 
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
@@ -102,7 +103,7 @@ private:
 
 	MavlinkULog(int datarate, float max_rate_factor, uint8_t target_system, uint8_t target_component);
 
-	~MavlinkULog() = default;
+	~MavlinkULog();
 
 	static void lock()
 	{
@@ -136,6 +137,8 @@ private:
 	float _current_rate_factor; ///< currently used rate percentage
 	int _current_num_msgs = 0;  ///< number of messages sent within the current time interval
 	hrt_abstime _next_rate_check; ///< next timestamp at which to update the rate
+
+	perf_counter_t _msg_missed_ulog_stream_perf{perf_alloc(PC_COUNT, MODULE_NAME": ulog_stream messages missed")};
 
 	/* do not allow copying this class */
 	MavlinkULog(const MavlinkULog &) = delete;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Helping mechanism for detecting lost ulog_stream messages

**Describe your solution**
Using perf counter for each lost message. 

**Additional context**
![image](https://user-images.githubusercontent.com/10188706/125976635-8a0f97de-68cd-461a-9dea-71dcf15f398e.png)
