### PR TITLE
Add sitl glider model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1038_glider
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1038_glider
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# @name Plane SITL with catapult
+#
+
+. ${R}etc/init.d-posix/airframes/1030_plane
+
+param set-default FW_THR_CRUISE 0.0
+param set-default RWTO_TKOFF 0
+

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -61,6 +61,7 @@ px4_add_romfs_files(
 	1035_techpod
 	1036_malolo
 	1037_believer
+	1038_glider
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -105,6 +105,7 @@ set(models
 	believer
 	boat
 	cloudship
+	glider
 	if750a
 	iris
 	iris_ctrlalloc


### PR DESCRIPTION
**Describe problem solved by this pull request**
While gliding has been added to offboard, there were no vehicles that actually were unpowered. 
 This model can be useful for not only developing gliders, but also observing behaviors in TECS.

The model is a modified version of the `standard plane` model. The rotors are removed from the vehicle.

In order to takeoff, the simulation is equipped with a `catapult_plugin`, which throws the vehicle to up to around 30m altitude. 

**Describe your solution**
This commit adds a SITL target for a unpowered glider model

**Test data / coverage**
```
make px4_sitl gazebo_glider
```
![image](https://user-images.githubusercontent.com/5248102/126079600-94ba381b-8570-4605-9085-4f404debf135.png)

The vehicle takeoff can be triggered by typing
```
commander takeoff
```
in the mavlink shell

**Additional context**
- model files are added in the submodule https://github.com/PX4/PX4-SITL_gazebo/pull/785