### PR TITLE
Tools/HIL/run_nsh_cmd.py handle missing echo, but cmd succeeded

### DIFF
--- a/Tools/HIL/run_nsh_cmd.py
+++ b/Tools/HIL/run_nsh_cmd.py
@@ -74,6 +74,10 @@ def do_nsh_cmd(port, baudrate, cmd):
 
         if cmd in serial_line:
             break
+        elif serial_line.startswith(success_cmd) and len(serial_line) <= len(success_cmd) + 2:
+            print_line(serial_line)
+            # we missed the echo, but command ran and succeeded
+            sys.exit(0)
         else:
             if len(serial_line) > 0:
                 print_line(serial_line)


### PR DESCRIPTION
For example, running the command succeeded, but the echo was interrupted by `gyro_calibration`.

http://px4-jenkins.dagar.ca:8080/blue/organizations/jenkins/PX4-Autopilot/detail/PR-17810/3/pipeline

![Screenshot from 2021-07-19 10-15-31](https://user-images.githubusercontent.com/84712/126174427-a1966133-7d9a-4c4f-9ffd-17a92b5cd12b.png)
