### PR TITLE
sensors: populate sensors_status_imu healthy flags even in multi-EKF mode

### DIFF
--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -187,6 +187,8 @@ void VotedSensorsUpdate::imuPoll(struct sensor_combined_s &raw)
 	// find the best sensor
 	int accel_best_index = -1;
 	int gyro_best_index = -1;
+	_accel.voter.get_best(hrt_absolute_time(), &accel_best_index);
+	_gyro.voter.get_best(hrt_absolute_time(), &gyro_best_index);
 
 	if (!_param_sens_imu_mode.get() && ((_selection.timestamp != 0) || (_sensor_selection_sub.updated()))) {
 		// use sensor_selection to find best
@@ -213,9 +215,6 @@ void VotedSensorsUpdate::imuPoll(struct sensor_combined_s &raw)
 
 	} else {
 		// use sensor voter to find best if SENS_IMU_MODE is enabled or ORB_ID(sensor_selection) has never published
-		_accel.voter.get_best(hrt_absolute_time(), &accel_best_index);
-		_gyro.voter.get_best(hrt_absolute_time(), &gyro_best_index);
-
 		checkFailover(_accel, "Accel", events::px4::enums::sensor_type_t::accel);
 		checkFailover(_gyro, "Gyro", events::px4::enums::sensor_type_t::gyro);
 	}


### PR DESCRIPTION
With multi-EKF enabled the sensors module doesn't decide on the primary IMU, but we can still populate the basic healthy flags in the `sensors_status_imu` message.

 - fixes https://github.com/PX4/PX4-Autopilot/issues/17927

![Screenshot from 2021-07-19 10-26-23](https://user-images.githubusercontent.com/84712/126176155-33fc2476-3321-4e83-b839-55bdcf2245af.png)


@ThomasRigi can you give this a try?

Note that the "full" sensor health should be decided at a higher level combining both these low level checks (timeouts, etc) with estimator status.


![Screenshot from 2021-07-19 10-29-01](https://user-images.githubusercontent.com/84712/126176601-37773c24-fa1a-4571-a228-3f662f428593.png)
