### PR TITLE
microRTPS: fix setting UART communication flags

### DIFF
--- a/msg/templates/urtps/microRTPS_transport.cpp
+++ b/msg/templates/urtps/microRTPS_transport.cpp
@@ -331,16 +331,16 @@ int UART_node::init()
 	}
 
 	// Set up the UART for non-canonical binary communication: 8 bits, 1 stop bit, no parity.
-	uart_config.c_iflag &= !(INPCK | ISTRIP | INLCR | IGNCR | ICRNL | IXON | IXANY | IXOFF);
+	uart_config.c_iflag &= ~(INPCK | ISTRIP | INLCR | IGNCR | ICRNL | IXON | IXANY | IXOFF);
 	uart_config.c_iflag |= IGNBRK | IGNPAR;
 
-	uart_config.c_oflag &= !(OPOST | ONLCR | OCRNL | ONOCR | ONLRET | OFILL | NLDLY | VTDLY);
+	uart_config.c_oflag &= ~(OPOST | ONLCR | OCRNL | ONOCR | ONLRET | OFILL | NLDLY | VTDLY);
 	uart_config.c_oflag |= NL0 | VT0;
 
-	uart_config.c_cflag &= !(CSIZE | CSTOPB | PARENB);
+	uart_config.c_cflag &= ~(CSIZE | CSTOPB | PARENB);
 	uart_config.c_cflag |= CS8 | CREAD | CLOCAL;
 
-	uart_config.c_lflag &= !(ISIG | ICANON | ECHO | TOSTOP | IEXTEN);
+	uart_config.c_lflag &= ~(ISIG | ICANON | ECHO | TOSTOP | IEXTEN);
 
 	// Flow control
 	if (hw_flow_control) {


### PR DESCRIPTION
bitwise not should be used instead of logical not

I don't use microR, just notice an issue, can't test.