### PR TITLE
[RFC] per sensor noise defaults

### DIFF
--- a/platforms/common/include/px4_platform_common/param.h
+++ b/platforms/common/include/px4_platform_common/param.h
@@ -146,6 +146,8 @@ public:
 
 	void set(float val) { _val = val; }
 
+	bool is_default() { return param_value_is_default(handle()); }
+
 	void reset()
 	{
 		param_reset_no_notification(handle());
@@ -198,6 +200,8 @@ public:
 
 	void set(float val) { _val = val; }
 
+	bool is_default() { return param_value_is_default(handle()); }
+
 	void reset()
 	{
 		param_reset_no_notification(handle());
@@ -247,6 +251,8 @@ public:
 	}
 
 	void set(int32_t val) { _val = val; }
+
+	bool is_default() { return param_value_is_default(handle()); }
 
 	void reset()
 	{
@@ -299,6 +305,8 @@ public:
 	}
 
 	void set(int32_t val) { _val = val; }
+
+	bool is_default() { return param_value_is_default(handle()); }
 
 	void reset()
 	{
@@ -357,6 +365,8 @@ public:
 	}
 
 	void set(bool val) { _val = val; }
+
+	bool is_default() { return param_value_is_default(handle()); }
 
 	void reset()
 	{

--- a/src/lib/sensor_defaults/AccelDefaults.hpp
+++ b/src/lib/sensor_defaults/AccelDefaults.hpp
@@ -1,0 +1,97 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+#include <lib/drivers/device/Device.hpp>
+
+namespace sensors
+{
+
+struct AccelNoiseParameters {
+	float noise{0.35f};         // Accelerometer noise for covariance prediction (m/s^2)
+	float bias_noise{0.003f};   // Process noise for IMU accelerometer bias prediction (m/s^2)
+	float switch_on_bias{0.2f}; // 1-sigma IMU accelerometer switch-on bias (m/s^3)
+	uint8_t type{DRV_DEVTYPE_UNUSED};
+};
+
+AccelNoiseParameters getAccelNoise(uint32_t sensor_device_id)
+{
+	device::Device::DeviceId device_id;
+	device_id.devid = sensor_device_id;
+
+	switch (device_id.devid_s.devtype) {
+	case DRV_ACC_DEVTYPE_BMI055: return AccelNoiseParameters{};
+
+	case DRV_ACC_DEVTYPE_BMI088: return AccelNoiseParameters{};
+
+	case DRV_ACC_DEVTYPE_FXOS8701C: return AccelNoiseParameters{};
+
+	case DRV_ACC_DEVTYPE_LSM303AGR: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ADIS16448: return AccelNoiseParameters{ .noise = 0.30f, .bias_noise = 0.002f, .switch_on_bias = 0.1f};
+
+	case DRV_IMU_DEVTYPE_ADIS16470: return AccelNoiseParameters{ .noise = 0.20f, .bias_noise = 0.001f, .switch_on_bias = 0.05f};
+
+	case DRV_IMU_DEVTYPE_ADIS16477: return AccelNoiseParameters{ .noise = 0.20f, .bias_noise = 0.001f, .switch_on_bias = 0.05f};
+
+	case DRV_IMU_DEVTYPE_ADIS16497: return AccelNoiseParameters{ .noise = 0.20f, .bias_noise = 0.001f, .switch_on_bias = 0.05f};
+
+	case DRV_IMU_DEVTYPE_ICM20602: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20608G: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20649: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20689: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20948: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM40609D: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM42605: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM42688P: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_MPU6000: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_MPU6500: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_MPU9250: return AccelNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ST_LSM9DS1_AG : return AccelNoiseParameters{};
+	}
+
+	return AccelNoiseParameters{};
+}
+
+}; // namespace sensors

--- a/src/lib/sensor_defaults/GyroDefaults.hpp
+++ b/src/lib/sensor_defaults/GyroDefaults.hpp
@@ -1,0 +1,97 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+#include <lib/drivers/device/Device.hpp>
+
+namespace sensors
+{
+
+struct GyroNoiseParameters {
+	float noise{0.015f};        // Rate gyro noise for covariance prediction (rad/s)
+	float bias_noise{0.001f};   // Process noise for IMU rate gyro bias prediction (rad/s^2)
+	float switch_on_bias{0.1f}; // 1-sigma IMU gyro switch-on bias (rad/s)
+	uint8_t type{DRV_DEVTYPE_UNUSED};
+};
+
+GyroNoiseParameters getGyroNoise(uint32_t sensor_device_id)
+{
+	device::Device::DeviceId device_id;
+	device_id.devid = sensor_device_id;
+
+	switch (device_id.devid_s.devtype) {
+	case DRV_GYR_DEVTYPE_BMI055: return GyroNoiseParameters{};
+
+	case DRV_GYR_DEVTYPE_BMI088: return GyroNoiseParameters{};
+
+	case DRV_GYR_DEVTYPE_FXAS2100C: return GyroNoiseParameters{};
+
+	case DRV_GYR_DEVTYPE_L3GD20: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ADIS16448: return GyroNoiseParameters{ .noise = 0.012f, .bias_noise = 0.0005f, .switch_on_bias = 0.05f};
+
+	case DRV_IMU_DEVTYPE_ADIS16470: return GyroNoiseParameters{ .noise = 0.010f, .bias_noise = 0.0002f, .switch_on_bias = 0.02f};
+
+	case DRV_IMU_DEVTYPE_ADIS16477: return GyroNoiseParameters{ .noise = 0.010f, .bias_noise = 0.0002f, .switch_on_bias = 0.02f};
+
+	case DRV_IMU_DEVTYPE_ADIS16497: return GyroNoiseParameters{ .noise = 0.010f, .bias_noise = 0.0002f, .switch_on_bias = 0.02f};
+
+	case DRV_IMU_DEVTYPE_ICM20602: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20608G: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20649: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20689: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM20948: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM40609D: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM42605: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ICM42688P: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_MPU6000: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_MPU6500: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_MPU9250: return GyroNoiseParameters{};
+
+	case DRV_IMU_DEVTYPE_ST_LSM9DS1_AG : return GyroNoiseParameters{};
+	}
+
+	return GyroNoiseParameters{};
+}
+
+}; // namespace sensors

--- a/src/lib/sensor_defaults/MagDefaults.hpp
+++ b/src/lib/sensor_defaults/MagDefaults.hpp
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+#include <lib/drivers/device/Device.hpp>
+
+namespace sensors
+{
+
+static constexpr float DEFAULT_MAG_NOISE   = 0.005f;  // gauss
+
+float getMagNoise(uint32_t sensor_device_id)
+{
+	device::Device::DeviceId device_id;
+	device_id.devid = sensor_device_id;
+
+	switch (device_id.devid_s.devtype) {
+	case DRV_GYR_DEVTYPE_BMI055: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_HMC5883: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_AK8963: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_LIS3MDL: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_IST8310: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_RM3100: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_QMC5883L: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_AK09916: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_IST8308: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_LIS2MDL: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_BMM150: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_ST_LSM9DS1_M: return DEFAULT_MAG_NOISE;
+
+	case DRV_MAG_DEVTYPE_LSM303AGR: return DEFAULT_MAG_NOISE;
+	}
+
+	return DEFAULT_MAG_NOISE;
+}
+}; // namespace sensors


### PR DESCRIPTION
This is a quick initial idea for handling estimator sensor tuning defaults. It's just a first pass to experiment with the idea, what's actually included and how it functions can all be changed.

### Currently included
 - accel
     - noise (EKF2_ACC_NOISE)
     - bias noise (EKF2_ACC_B_NOISE)
     - switch on bias (EKF2_ABIAS_INIT)
 - gyro
     - noise (EKF2_GYR_NOISE)
     - bias noise (EKF2_GYR_B_NOISE)
     - switch on bias (EKF2_GBIAS_INIT)
 - mag
     - noise (EKF2_MAG_NOISE)

The way it currently works is that value is pulled from a table unless the user actually sets the parameter to a non-default value. This avoids expanding the EKF2 parameter tree per instance.

#### TODO
  - [ ] add GPS
  - [ ] add sensor delays (should they be aware of the source?)