### PR TITLE
add missing baro_bias_estimate to RTPS list

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -343,6 +343,8 @@ rtps:
     id: 159
   - msg: event
     id: 160
+  - msg: baro_bias_estimate
+    id: 161
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 180


### PR DESCRIPTION
**Describe problem solved by this pull request**
I honestly don't understand why https://github.com/PX4/PX4-Autopilot/pull/17944 was merged, considering that CI was complaining. But anyway, here's the fix.

**Describe your solution**
On the PR description.

**Describe possible alternatives**
N.A.

**Test data / coverage**
N.A.

**Additional context**
N.A.
