### PR TITLE
Fix template_module header

### DIFF
--- a/src/templates/template_module/template_module.h
+++ b/src/templates/template_module/template_module.h
@@ -35,8 +35,10 @@
 
 #include <px4_platform_common/module.h>
 #include <px4_platform_common/module_params.h>
-#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/parameter_update.h>
+
+using namespace time_literals;
 
 extern "C" __EXPORT int template_module_main(int argc, char *argv[]);
 


### PR DESCRIPTION
I have not tried compiling the template module itself, but when using it as a template, the following where the additions that I had to make in order for it to compile.

- **SubscriptionInterval.hpp** includes **Subscription.hpp**, but not vice versa. So I swapped the two.
- The time literal `1_s` is defined in the namespace **time_literals**