### PR TITLE
input rc RSSI cleanups

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -96,7 +96,7 @@ Syslink::Syslink() :
 	_fd(0),
 	_queue(2, sizeof(syslink_message_t)),
 	_writebuffer(16, sizeof(crtp_message_t)),
-	_rssi(RC_INPUT_RSSI_MAX),
+	_rssi(input_rc_s::RC_RSSI_MAX),
 	_bstate(BAT_DISCHARGING)
 {
 	px4_sem_init(&memory_sem, 0, 0);
@@ -526,30 +526,30 @@ Syslink::handle_raw(syslink_message_t *sys)
 
 		crtp_commander *cmd = (crtp_commander *) &c->data[0];
 
-		input_rc_s rc = {};
+		input_rc_s input_rc = {};
 
-		rc.timestamp = hrt_absolute_time();
-		rc.timestamp_last_signal = rc.timestamp;
-		rc.channel_count = 5;
-		rc.rc_failsafe = false;
-		rc.rc_lost = false;
-		rc.rc_lost_frame_count = 0;
-		rc.rc_total_frame_count = 1;
-		rc.rc_ppm_frame_length = 0;
-		rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
-		rc.rssi = _rssi;
+		input_rc.timestamp = hrt_absolute_time();
+		input_rc.timestamp_last_signal = input_rc.timestamp;
+		input_rc.channel_count = 5;
+		input_rc.rc_failsafe = false;
+		input_rc.rc_lost = false;
+		input_rc.rc_lost_frame_count = 0;
+		input_rc.rc_total_frame_count = 1;
+		input_rc.rc_ppm_frame_length = 0;
+		input_rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
+		input_rc.rssi = _rssi;
 
 
 		double pitch = cmd->pitch, roll = cmd->roll, yaw = cmd->yaw;
 
 		/* channels (scaled to rc limits) */
-		rc.values[0] = pitch * 500 / 20 + 1500;
-		rc.values[1] = roll * 500 / 20 + 1500;
-		rc.values[2] = yaw * 500 / 150 + 1500;
-		rc.values[3] = cmd->thrust * 1000 / USHRT_MAX + 1000;
-		rc.values[4] = 1000; // Dummy channel as px4 needs at least 5
+		input_rc.values[0] = pitch * 500 / 20 + 1500;
+		input_rc.values[1] = roll * 500 / 20 + 1500;
+		input_rc.values[2] = yaw * 500 / 150 + 1500;
+		input_rc.values[3] = cmd->thrust * 1000 / USHRT_MAX + 1000;
+		input_rc.values[4] = 1000; // Dummy channel as px4 needs at least 5
 
-		_rc_pub.publish(rc);
+		_input_rc_pub.publish(input_rc);
 
 	} else if (c->port == CRTP_PORT_MAVLINK) {
 		_count_in++;

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.h
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.h
@@ -135,7 +135,7 @@ private:
 	hrt_abstime _params_update[3]; // Time at which the parameters were updated
 	hrt_abstime _params_ack[3]; // Time at which the parameters were acknowledged by the nrf module
 
-	uORB::PublicationMulti<input_rc_s>		_rc_pub{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>		_input_rc_pub{ORB_ID(input_rc)};
 
 	// nrf chip schedules battery updates with SYSLINK_SEND_PERIOD_MS
 	static constexpr uint32_t SYSLINK_BATTERY_STATUS_INTERVAL_US = 10_ms;

--- a/boards/emlid/navio2/navio_sysfs_rc_in/NavioSysRCInput.cpp
+++ b/boards/emlid/navio2/navio_sysfs_rc_in/NavioSysRCInput.cpp
@@ -114,12 +114,12 @@ void NavioSysRCInput::Run()
 		return;
 	}
 
-	input_rc_s data{};
+	input_rc_s input_rc{};
 
 	connected_buf[sizeof(connected_buf) - 1] = '\0';
 	_connected = (atoi(connected_buf) == 1);
 
-	data.rc_lost = !_connected;
+	input_rc.rc_lost = !_connected;
 
 	uint64_t timestamp_sample = hrt_absolute_time();
 
@@ -133,14 +133,14 @@ void NavioSysRCInput::Run()
 
 		buf[sizeof(buf) - 1] = '\0';
 
-		data.values[i] = atoi(buf);
+		input_rc.values[i] = atoi(buf);
 	}
 
 	// check if all channels are 0
 	bool all_zero = true;
 
 	for (int i = 0; i < CHANNELS; ++i) {
-		if (data.values[i] != 0) {
+		if (input_rc.values[i] != 0) {
 			all_zero = false;
 		}
 	}
@@ -149,12 +149,13 @@ void NavioSysRCInput::Run()
 		return;
 	}
 
-	data.timestamp_last_signal = timestamp_sample;
-	data.channel_count = CHANNELS;
-	data.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_PPM;
-	data.timestamp = hrt_absolute_time();
+	input_rc.timestamp_last_signal = timestamp_sample;
+	input_rc.channel_count = CHANNELS;
+	input_rc.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_PPM;
+	input_rc.rssi = input_rc_s::RC_RSSI_UNDEFINED;
+	input_rc.timestamp = hrt_absolute_time();
 
-	_input_rc_pub.publish(data);
+	_input_rc_pub.publish(input_rc);
 	perf_count(_publish_interval_perf);
 }
 

--- a/msg/input_rc.msg
+++ b/msg/input_rc.msg
@@ -23,7 +23,11 @@ uint64 timestamp_last_signal		# last valid reception time
 
 uint8 channel_count			# number of channels actually being seen
 
-int32 rssi				# receive signal strength indicator (RSSI): < 0: Undefined, 0: no signal, 100: full reception
+uint8 RC_RSSI_NO_SIGNAL = 0		# no signal
+uint8 RC_RSSI_MAX = 100			# full reception
+uint8 RC_RSSI_UNDEFINED = 255		# no indication of rssi strength
+
+uint8 rssi				# receive signal strength indicator (RSSI)
 
 bool rc_failsafe			# explicit failsafe flag: true on TX failure or TX out of range , false otherwise. Only the true state is reliable, as there are some (PPM) receivers on the market going into failsafe without telling us explicitly.
 bool rc_lost				# RC receiver connection status: True,if no frame has arrived in the expected time, false otherwise. True usually means that the receiver has been disconnected, but can also indicate a radio link loss on "stupid" systems. Will remain false, if a RX with failsafe option continues to transmit frames after a link loss.

--- a/src/drivers/drv_rc_input.h
+++ b/src/drivers/drv_rc_input.h
@@ -59,11 +59,6 @@
 #define RC_INPUT0_DEVICE_PATH	"/dev/input_rc0"
 
 /**
- * Maximum RSSI value
- */
-#define RC_INPUT_RSSI_MAX	100
-
-/**
  * Input signal type, value is a control position from zero to 100
  * percent.
  */

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -120,7 +120,7 @@ private:
 	void fill_rc_in(uint16_t raw_rc_count_local,
 			uint16_t raw_rc_values_local[input_rc_s::RC_INPUT_MAX_CHANNELS],
 			hrt_abstime now, bool frame_drop, bool failsafe,
-			unsigned frame_drops, int rssi);
+			unsigned frame_drops, uint8_t rssi);
 
 	void set_rc_scan_state(RC_SCAN _rc_scan_state);
 
@@ -136,19 +136,20 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription	_adc_report_sub{ORB_ID(adc_report)};
 	uORB::Subscription	_vehicle_cmd_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription	_vehicle_status_sub{ORB_ID(vehicle_status)};
+	bool _armed{false};
 
-	input_rc_s	_rc_in{};
+#if defined(ADC_RC_RSSI_CHANNEL)
+	uORB::Subscription	_adc_report_sub {ORB_ID(adc_report)};
 
 	float		_analog_rc_rssi_volt{-1.0f};
 	bool		_analog_rc_rssi_stable{false};
+#endif
 
-	bool _armed{false};
+	input_rc_s	_input_rc{};
 
-
-	uORB::PublicationMulti<input_rc_s>	_to_input_rc{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>	_input_rc_pub{ORB_ID(input_rc)};
 
 	int		_rcs_fd{-1};
 	char		_device[20] {};					///< device / serial port path

--- a/src/drivers/rpi_rc_in/rpi_rc_in.cpp
+++ b/src/drivers/rpi_rc_in/rpi_rc_in.cpp
@@ -117,7 +117,7 @@ void RcInput::_measure(void)
 	_data.timestamp = ts;
 	_data.timestamp_last_signal = ts;
 	_data.channel_count = _channels;
-	_data.rssi = 100;
+	_data.rssi = input_rc_s::RC_RSSI_MAX;
 	_data.rc_lost_frame_count = 0;
 	_data.rc_total_frame_count = 1;
 	_data.rc_ppm_frame_length = 100;

--- a/src/lib/rc/common_rc.h
+++ b/src/lib/rc/common_rc.h
@@ -9,6 +9,7 @@
 #include "sbus.h"
 #include "st24.h"
 #include "sumd.h"
+#include <uORB/topics/input_rc.h>
 
 #pragma pack(push, 1)
 typedef  struct rc_decode_buf_ {
@@ -27,7 +28,3 @@ extern rc_decode_buf_t rc_decode_buf;
 
 uint8_t crc8_dvb_s2(uint8_t crc, uint8_t a);
 uint8_t crc8_dvb_s2_buf(uint8_t *buf, int len);
-
-#define RC_INPUT_RSSI_MAX		100		//should be same as  input_rc_s::RC_RSSI_MAX
-#define RC_INPUT_RSSI_NO_SIGNAL		0	//should be same as  input_rc_s::RC_RSSI_NO_SIGNAL
-#define RC_INPUT_RSSI_UNDEFINED	255		//should be same as  input_rc_s::RC_RSSI_UNDEFINED

--- a/src/lib/rc/common_rc.h
+++ b/src/lib/rc/common_rc.h
@@ -27,3 +27,7 @@ extern rc_decode_buf_t rc_decode_buf;
 
 uint8_t crc8_dvb_s2(uint8_t crc, uint8_t a);
 uint8_t crc8_dvb_s2_buf(uint8_t *buf, int len);
+
+#define RC_INPUT_RSSI_MAX		100		//should be same as  input_rc_s::RC_RSSI_MAX
+#define RC_INPUT_RSSI_NO_SIGNAL		0	//should be same as  input_rc_s::RC_RSSI_NO_SIGNAL
+#define RC_INPUT_RSSI_UNDEFINED	255		//should be same as  input_rc_s::RC_RSSI_UNDEFINED

--- a/src/lib/rc/dsm.cpp
+++ b/src/lib/rc/dsm.cpp
@@ -551,15 +551,15 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
 			int8_t dbm = (int8_t)dsm_frame[0];
 
 			if (dbm == -128) {
-				*rssi_percent = RC_INPUT_RSSI_NO_SIGNAL;
+				*rssi_percent = input_rc_s::RC_RSSI_NO_SIGNAL;
 
 			} else {
 				*rssi_percent = spek_dbm_to_percent(dbm);
 			}
 
 		} else {
-			/* if we don't know the rssi, anything over 100 will invalidate it */
-			*rssi_percent = RC_INPUT_RSSI_UNDEFINED;
+			/* if we don't know the rssi*/
+			*rssi_percent = input_rc_s::RC_RSSI_UNDEFINED;
 		}
 	}
 

--- a/src/lib/rc/dsm.cpp
+++ b/src/lib/rc/dsm.cpp
@@ -512,7 +512,7 @@ void dsm_bind(uint16_t cmd, int pulses)
  * @return true=DSM frame successfully decoded, false=no update
  */
 bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, unsigned max_values,
-		int8_t *rssi_percent)
+		uint8_t *rssi_percent)
 {
 	/*
 	debug("DSM dsm_frame %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x",
@@ -551,7 +551,7 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
 			int8_t dbm = (int8_t)dsm_frame[0];
 
 			if (dbm == -128) {
-				*rssi_percent = 0;
+				*rssi_percent = RC_INPUT_RSSI_NO_SIGNAL;
 
 			} else {
 				*rssi_percent = spek_dbm_to_percent(dbm);
@@ -559,7 +559,7 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
 
 		} else {
 			/* if we don't know the rssi, anything over 100 will invalidate it */
-			*rssi_percent = 127;
+			*rssi_percent = RC_INPUT_RSSI_UNDEFINED;
 		}
 	}
 
@@ -700,13 +700,13 @@ bool dsm_decode(hrt_abstime frame_time, uint16_t *values, uint16_t *num_values, 
  * @param[out] num_values pointer to number of raw channel values returned, high order bit 0:10 bit data, 1:11 bit data
  * @param[out] n_butes number of bytes read
  * @param[out] bytes pointer to the buffer of read bytes
- * @param[out] rssi value in percent, if supported, or 127
+ * @param[out] rssi value in percent, if supported, or RC_RSSI_UNDEFINED
  * @param[out] frame_drops dropped frames (indication of an unstable link)
  * @param[in] max_values maximum number of channels the receiver can process
  * @return true=decoded raw channel values updated, false=no update
  */
 bool dsm_input(int fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes, uint8_t **bytes,
-	       int8_t *rssi, unsigned *frame_drops, unsigned max_values)
+	       uint8_t *rssi, unsigned *frame_drops, unsigned max_values)
 {
 	/*
 	 * The S.BUS protocol doesn't provide reliable framing,
@@ -748,7 +748,7 @@ bool dsm_input(int fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit,
 }
 
 bool dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
-	       uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, int8_t *rssi_percent, uint16_t max_channels)
+	       uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint8_t *rssi_percent, uint16_t max_channels)
 {
 	/* this is set by the decoding state machine and will default to false
 	 * once everything that was decodable has been decoded.

--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -70,10 +70,10 @@ __EXPORT void	dsm_deinit(void);
 __EXPORT void	dsm_proto_init(void);
 __EXPORT int	dsm_config(int dsm_fd);
 __EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes,
-			  uint8_t **bytes, int8_t *rssi, unsigned *frame_drops, unsigned max_values);
+			  uint8_t **bytes, uint8_t *rssi, unsigned *frame_drops, unsigned max_values);
 
 __EXPORT bool	dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
-			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, int8_t *rssi_percent, uint16_t max_channels);
+			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint8_t *rssi_percent, uint16_t max_channels);
 
 #ifdef SPEKTRUM_POWER
 __EXPORT void	dsm_bind(uint16_t cmd, int pulses);

--- a/src/lib/rc/sumd.cpp
+++ b/src/lib/rc/sumd.cpp
@@ -308,7 +308,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			uint8_t _cnt = *rx_count + 1;
 			*rx_count = _cnt;
 
-			*rssi = 100;
+			*rssi = RC_INPUT_RSSI_MAX;
 
 			/* failsafe flag */
 			*failsafe = (_rxpacket.status == SUMD_ID_FAILSAFE);

--- a/src/lib/rc/sumd.cpp
+++ b/src/lib/rc/sumd.cpp
@@ -308,7 +308,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			uint8_t _cnt = *rx_count + 1;
 			*rx_count = _cnt;
 
-			*rssi = RC_INPUT_RSSI_MAX;
+			*rssi = input_rc_s::RC_RSSI_MAX;
 
 			/* failsafe flag */
 			*failsafe = (_rxpacket.status == SUMD_ID_FAILSAFE);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1871,57 +1871,57 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	}
 
 	// fill uORB message
-	input_rc_s rc{};
+	input_rc_s input_rc{};
 
 	// metadata
-	rc.timestamp = hrt_absolute_time();
-	rc.timestamp_last_signal = rc.timestamp;
-	rc.rssi = RC_INPUT_RSSI_MAX;
-	rc.rc_failsafe = false;
-	rc.rc_lost = false;
-	rc.rc_lost_frame_count = 0;
-	rc.rc_total_frame_count = 1;
-	rc.rc_ppm_frame_length = 0;
-	rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
+	input_rc.timestamp = hrt_absolute_time();
+	input_rc.timestamp_last_signal = input_rc.timestamp;
+	input_rc.rssi = input_rc_s::RC_RSSI_UNDEFINED;
+	input_rc.rc_failsafe = false;
+	input_rc.rc_lost = false;
+	input_rc.rc_lost_frame_count = 0;
+	input_rc.rc_total_frame_count = 1;
+	input_rc.rc_ppm_frame_length = 0;
+	input_rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
 
 	// channels
-	rc.values[0] = man.chan1_raw;
-	rc.values[1] = man.chan2_raw;
-	rc.values[2] = man.chan3_raw;
-	rc.values[3] = man.chan4_raw;
-	rc.values[4] = man.chan5_raw;
-	rc.values[5] = man.chan6_raw;
-	rc.values[6] = man.chan7_raw;
-	rc.values[7] = man.chan8_raw;
-	rc.values[8] = man.chan9_raw;
-	rc.values[9] = man.chan10_raw;
-	rc.values[10] = man.chan11_raw;
-	rc.values[11] = man.chan12_raw;
-	rc.values[12] = man.chan13_raw;
-	rc.values[13] = man.chan14_raw;
-	rc.values[14] = man.chan15_raw;
-	rc.values[15] = man.chan16_raw;
-	rc.values[16] = man.chan17_raw;
-	rc.values[17] = man.chan18_raw;
+	input_rc.values[0] = man.chan1_raw;
+	input_rc.values[1] = man.chan2_raw;
+	input_rc.values[2] = man.chan3_raw;
+	input_rc.values[3] = man.chan4_raw;
+	input_rc.values[4] = man.chan5_raw;
+	input_rc.values[5] = man.chan6_raw;
+	input_rc.values[6] = man.chan7_raw;
+	input_rc.values[7] = man.chan8_raw;
+	input_rc.values[8] = man.chan9_raw;
+	input_rc.values[9] = man.chan10_raw;
+	input_rc.values[10] = man.chan11_raw;
+	input_rc.values[11] = man.chan12_raw;
+	input_rc.values[12] = man.chan13_raw;
+	input_rc.values[13] = man.chan14_raw;
+	input_rc.values[14] = man.chan15_raw;
+	input_rc.values[15] = man.chan16_raw;
+	input_rc.values[16] = man.chan17_raw;
+	input_rc.values[17] = man.chan18_raw;
 
 	// check how many channels are valid
 	for (int i = 17; i >= 0; i--) {
-		const bool ignore_max = rc.values[i] == UINT16_MAX; // ignore any channel with value UINT16_MAX
-		const bool ignore_zero = (i > 7) && (rc.values[i] == 0); // ignore channel 8-18 if value is 0
+		const bool ignore_max = input_rc.values[i] == UINT16_MAX; // ignore any channel with value UINT16_MAX
+		const bool ignore_zero = (i > 7) && (input_rc.values[i] == 0); // ignore channel 8-18 if value is 0
 
 		if (ignore_max || ignore_zero) {
 			// set all ignored values to zero
-			rc.values[i] = 0;
+			input_rc.values[i] = 0;
 
 		} else {
 			// first channel to not ignore -> set count considering zero-based index
-			rc.channel_count = i + 1;
+			input_rc.channel_count = i + 1;
 			break;
 		}
 	}
 
 	// publish uORB message
-	_rc_pub.publish(rc);
+	_input_rc_pub.publish(input_rc);
 }
 
 void
@@ -1937,27 +1937,27 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 
 	if (_mavlink->should_generate_virtual_rc_input()) {
 
-		input_rc_s rc{};
-		rc.timestamp = hrt_absolute_time();
-		rc.timestamp_last_signal = rc.timestamp;
+		input_rc_s input_rc{};
+		input_rc.timestamp = hrt_absolute_time();
+		input_rc.timestamp_last_signal = input_rc.timestamp;
 
-		rc.channel_count = 8;
-		rc.rc_failsafe = false;
-		rc.rc_lost = false;
-		rc.rc_lost_frame_count = 0;
-		rc.rc_total_frame_count = 1;
-		rc.rc_ppm_frame_length = 0;
-		rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
-		rc.rssi = RC_INPUT_RSSI_MAX;
+		input_rc.channel_count = 8;
+		input_rc.rc_failsafe = false;
+		input_rc.rc_lost = false;
+		input_rc.rc_lost_frame_count = 0;
+		input_rc.rc_total_frame_count = 1;
+		input_rc.rc_ppm_frame_length = 0;
+		input_rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
+		input_rc.rssi = input_rc_s::RC_RSSI_UNDEFINED;
 
-		rc.values[0] = man.x / 2 + 1500;	// roll
-		rc.values[1] = man.y / 2 + 1500;	// pitch
-		rc.values[2] = man.r / 2 + 1500;	// yaw
-		rc.values[3] = math::constrain(man.z / 0.9f + 800.0f, 1000.0f, 2000.0f);	// throttle
+		input_rc.values[0] = man.x / 2 + 1500;	// roll
+		input_rc.values[1] = man.y / 2 + 1500;	// pitch
+		input_rc.values[2] = man.r / 2 + 1500;	// yaw
+		input_rc.values[3] = math::constrain(man.z / 0.9f + 800.0f, 1000.0f, 2000.0f);	// throttle
 
 		/* decode all switches which fit into the channel mask */
 		unsigned max_switch = (sizeof(man.buttons) * 8);
-		unsigned max_channels = (sizeof(rc.values) / sizeof(rc.values[0]));
+		unsigned max_channels = (sizeof(input_rc.values) / sizeof(input_rc.values[0]));
 
 		if (max_switch > (max_channels - 4)) {
 			max_switch = (max_channels - 4);
@@ -1965,12 +1965,12 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 
 		/* fill all channels */
 		for (unsigned i = 0; i < max_switch; i++) {
-			rc.values[i + 4] = decode_switch_pos_n(man.buttons, i);
+			input_rc.values[i + 4] = decode_switch_pos_n(man.buttons, i);
 		}
 
 		_mom_switch_state = man.buttons;
 
-		_rc_pub.publish(rc);
+		_input_rc_pub.publish(input_rc);
 
 	} else {
 		manual_control_setpoint_s manual{};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -306,7 +306,7 @@ private:
 	// ORB publications (multi)
 	uORB::PublicationMulti<distance_sensor_s>		_distance_sensor_pub{ORB_ID(distance_sensor)};
 	uORB::PublicationMulti<distance_sensor_s>		_flow_distance_sensor_pub{ORB_ID(distance_sensor)};
-	uORB::PublicationMulti<input_rc_s>			_rc_pub{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>			_input_rc_pub{ORB_ID(input_rc)};
 	uORB::PublicationMulti<manual_control_setpoint_s>	_manual_control_setpoint_pub{ORB_ID(manual_control_setpoint)};
 	uORB::PublicationMulti<ping_s>				_ping_pub{ORB_ID(ping)};
 	uORB::PublicationMulti<radio_status_s>			_radio_status_pub{ORB_ID(radio_status)};

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -230,10 +230,6 @@ extern uint16_t	adc_measure(unsigned channel);
 extern void	controls_init(void);
 extern void	controls_tick(void);
 
-#define RC_INPUT_RSSI_MAX			100	//should be same as  input_rc_s::RC_RSSI_MAX
-#define RC_INPUT_RSSI_NO_SIGNAL		0	//should be same as  input_rc_s::RC_RSSI_NO_SIGNAL
-#define RC_INPUT_RSSI_UNDEFINED		255	//should be same as  input_rc_s::RC_RSSI_UNDEFINED
-
 /** global debug level for isr_debug() */
 extern volatile uint8_t debug_level;
 

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -230,6 +230,10 @@ extern uint16_t	adc_measure(unsigned channel);
 extern void	controls_init(void);
 extern void	controls_tick(void);
 
+#define RC_INPUT_RSSI_MAX			100	//should be same as  input_rc_s::RC_RSSI_MAX
+#define RC_INPUT_RSSI_NO_SIGNAL		0	//should be same as  input_rc_s::RC_RSSI_NO_SIGNAL
+#define RC_INPUT_RSSI_UNDEFINED		255	//should be same as  input_rc_s::RC_RSSI_UNDEFINED
+
 /** global debug level for isr_debug() */
 extern volatile uint8_t debug_level;
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -617,33 +617,33 @@ void Simulator::handle_message_rc_channels(const mavlink_message_t *msg)
 	mavlink_rc_channels_t rc_channels;
 	mavlink_msg_rc_channels_decode(msg, &rc_channels);
 
-	input_rc_s rc_input{};
-	rc_input.timestamp_last_signal = hrt_absolute_time();
-	rc_input.channel_count = rc_channels.chancount;
-	rc_input.rssi = rc_channels.rssi;
-	rc_input.values[0] = rc_channels.chan1_raw;
-	rc_input.values[1] = rc_channels.chan2_raw;
-	rc_input.values[2] = rc_channels.chan3_raw;
-	rc_input.values[3] = rc_channels.chan4_raw;
-	rc_input.values[4] = rc_channels.chan5_raw;
-	rc_input.values[5] = rc_channels.chan6_raw;
-	rc_input.values[6] = rc_channels.chan7_raw;
-	rc_input.values[7] = rc_channels.chan8_raw;
-	rc_input.values[8] = rc_channels.chan9_raw;
-	rc_input.values[9] = rc_channels.chan10_raw;
-	rc_input.values[10] = rc_channels.chan11_raw;
-	rc_input.values[11] = rc_channels.chan12_raw;
-	rc_input.values[12] = rc_channels.chan13_raw;
-	rc_input.values[13] = rc_channels.chan14_raw;
-	rc_input.values[14] = rc_channels.chan15_raw;
-	rc_input.values[15] = rc_channels.chan16_raw;
-	rc_input.values[16] = rc_channels.chan17_raw;
-	rc_input.values[17] = rc_channels.chan18_raw;
+	input_rc_s input_rc{};
+	input_rc.timestamp_last_signal = hrt_absolute_time();
+	input_rc.channel_count = rc_channels.chancount;
+	input_rc.rssi = rc_channels.rssi;
+	input_rc.values[0] = rc_channels.chan1_raw;
+	input_rc.values[1] = rc_channels.chan2_raw;
+	input_rc.values[2] = rc_channels.chan3_raw;
+	input_rc.values[3] = rc_channels.chan4_raw;
+	input_rc.values[4] = rc_channels.chan5_raw;
+	input_rc.values[5] = rc_channels.chan6_raw;
+	input_rc.values[6] = rc_channels.chan7_raw;
+	input_rc.values[7] = rc_channels.chan8_raw;
+	input_rc.values[8] = rc_channels.chan9_raw;
+	input_rc.values[9] = rc_channels.chan10_raw;
+	input_rc.values[10] = rc_channels.chan11_raw;
+	input_rc.values[11] = rc_channels.chan12_raw;
+	input_rc.values[12] = rc_channels.chan13_raw;
+	input_rc.values[13] = rc_channels.chan14_raw;
+	input_rc.values[14] = rc_channels.chan15_raw;
+	input_rc.values[15] = rc_channels.chan16_raw;
+	input_rc.values[16] = rc_channels.chan17_raw;
+	input_rc.values[17] = rc_channels.chan18_raw;
 
-	rc_input.timestamp = hrt_absolute_time();
+	input_rc.timestamp = hrt_absolute_time();
 
 	// publish message
-	_input_rc_pub.publish(rc_input);
+	_input_rc_pub.publish(input_rc);
 }
 
 void Simulator::handle_message_vision_position_estimate(const mavlink_message_t *msg)

--- a/src/systemcmds/tests/test_ppm_loopback.c
+++ b/src/systemcmds/tests/test_ppm_loopback.c
@@ -60,7 +60,7 @@
 int test_ppm_loopback(int argc, char *argv[])
 {
 
-	int _rc_sub = orb_subscribe(ORB_ID(input_rc));
+	int input_rc_sub = orb_subscribe(ORB_ID(input_rc));
 
 	int servo_fd, result;
 	servo_position_t pos;
@@ -134,17 +134,17 @@ int test_ppm_loopback(int argc, char *argv[])
 
 	/* read low-level values from FMU or IO RC inputs (PPM, Spektrum, S.Bus) */
 	struct input_rc_s rc_input;
-	orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
+	orb_copy(ORB_ID(input_rc), input_rc_sub, &rc_input);
 	px4_usleep(100000);
 
 	/* open PPM input and expect values close to the output values */
 
 	bool rc_updated;
-	orb_check(_rc_sub, &rc_updated);
+	orb_check(input_rc_sub, &rc_updated);
 
 	if (rc_updated) {
 
-		orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
+		orb_copy(ORB_ID(input_rc), input_rc_sub, &rc_input);
 
 		// int ppm_fd = open(RC_INPUT_DEVICE_PATH, O_RDONLY);
 


### PR DESCRIPTION
replaces 'RCinput: removed subscption to adc_report if not needed, and unify rssi type #16042'

few things done
•	removed subscption to adc_report if not needed Here. (only 4 boards defines ADC_RC_RSSI_CHANNEL…)
•	unify rssi type on all functions to uint8, where 255 is undefined. (as in mavlink)
•	set RSSI to be undefined where it undefined (mavlink)
•	rename publishers and subscribers to be input_rc trough the code
•	and more minurs cleanups (constrains, instead of ifs)

