### PR TITLE
keep minimal legacy battery parameters for older QGC usability

### DIFF
--- a/boards/mro/ctrl-zero-h7-oem/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-h7-oem/init/rc.board_defaults
@@ -3,10 +3,7 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-param set-default BAT_V_DIV 10.1
 param set-default BAT1_V_DIV 10.1
-
-param set-default BAT_A_PER_V 24
 param set-default BAT1_A_PER_V 24
 
 

--- a/boards/mro/ctrl-zero-h7/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-h7/init/rc.board_defaults
@@ -3,11 +3,7 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-param set-default BAT_V_DIV 10.1
 param set-default BAT1_V_DIV 10.1
-
-param set-default BAT_A_PER_V 24
 param set-default BAT1_A_PER_V 24
-
 
 safety_button start

--- a/boards/mro/pixracerpro/init/rc.board_defaults
+++ b/boards/mro/pixracerpro/init/rc.board_defaults
@@ -3,8 +3,5 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-param set-default BAT_V_DIV 10.1
 param set-default BAT1_V_DIV 10.1
-
-param set-default BAT_A_PER_V 17
 param set-default BAT1_A_PER_V 17

--- a/src/lib/battery/battery_params_deprecated.c
+++ b/src/lib/battery/battery_params_deprecated.c
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file battery_params_deprecated.c
+ *
+ * Defines the deprcated single battery configuration which are temporarily kept for backwards compatibility with QGC.
+ */
+
+/**
+ * This parameter is deprecated. Please use BAT1_V_EMPTY instead.
+ *
+ * @group Battery Calibration
+ * @category system
+ */
+PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.5f);
+
+/**
+ * This parameter is deprecated. Please use BAT1_V_CHARGED instead.
+ *
+ * @group Battery Calibration
+ * @category system
+ */
+PARAM_DEFINE_FLOAT(BAT_V_CHARGED, 4.05f);
+
+/**
+ * This parameter is deprecated. Please use BAT1_V_LOAD_DROP instead.
+ *
+ * @group Battery Calibration
+ * @category system
+ */
+PARAM_DEFINE_FLOAT(BAT_V_LOAD_DROP, 0.3f);
+
+/**
+ * This parameter is deprecated. Please use BAT1_N_CELLS instead.
+ *
+ * @group Battery Calibration
+ * @category system
+ */
+PARAM_DEFINE_INT32(BAT_N_CELLS, 3);

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -286,14 +286,13 @@ MavlinkParametersManager::send()
 {
 	if (!_first_send) {
 		// parameters QGC can't tolerate not finding (2020-11-11)
-		param_find("BAT_A_PER_V");
 		param_find("BAT_CRIT_THR");
 		param_find("BAT_EMERGEN_THR");
 		param_find("BAT_LOW_THR");
-		param_find("BAT_N_CELLS");
-		param_find("BAT_V_CHARGED");
-		param_find("BAT_V_DIV");
-		param_find("BAT_V_EMPTY");
+		param_find("BAT_N_CELLS");     // deprecated
+		param_find("BAT_V_CHARGED");   // deprecated
+		param_find("BAT_V_EMPTY");     // deprecated
+		param_find("BAT_V_LOAD_DROP"); // deprecated
 		param_find("CAL_ACC0_ID");
 		param_find("CAL_GYRO0_ID");
 		param_find("CAL_MAG0_ID");


### PR DESCRIPTION
 - BAT_V_EMPTY, BAT_V_CHARGED, BAT_V_LOAD_DROP, BAT_N_CELLS

Otherwise older QGC is nearly unusable with continuous error pop ups.