### PR TITLE
boards: px4 fmu-v2/v3 swap external SPI chip select order

### DIFF
--- a/boards/px4/fmu-v2/src/spi.cpp
+++ b/boards/px4/fmu-v2/src/spi.cpp
@@ -159,8 +159,8 @@ constexpr px4_spi_bus_all_hw_t px4_spi_buses_all_hw[BOARD_NUM_SPI_CFG_HW_VERSION
 			initSPIDevice(SPIDEV_FLASH(0), SPI::CS{GPIO::PortD, GPIO::Pin10})
 		}),
 		initSPIBusExternal(SPI::Bus::SPI4, {
-			initSPIConfigExternal(SPI::CS{GPIO::PortC, GPIO::Pin14}),
 			initSPIConfigExternal(SPI::CS{GPIO::PortE, GPIO::Pin4}),
+			initSPIConfigExternal(SPI::CS{GPIO::PortC, GPIO::Pin14}),
 		}),
 	}),
 

--- a/boards/px4/fmu-v3/src/spi.cpp
+++ b/boards/px4/fmu-v3/src/spi.cpp
@@ -159,8 +159,8 @@ constexpr px4_spi_bus_all_hw_t px4_spi_buses_all_hw[BOARD_NUM_SPI_CFG_HW_VERSION
 			initSPIDevice(SPIDEV_FLASH(0), SPI::CS{GPIO::PortD, GPIO::Pin10})
 		}),
 		initSPIBusExternal(SPI::Bus::SPI4, {
-			initSPIConfigExternal(SPI::CS{GPIO::PortC, GPIO::Pin14}),
 			initSPIConfigExternal(SPI::CS{GPIO::PortE, GPIO::Pin4}),
+			initSPIConfigExternal(SPI::CS{GPIO::PortC, GPIO::Pin14}),
 		}),
 	}),
 


### PR DESCRIPTION
 - fixes https://github.com/PX4/PX4-Autopilot/issues/17858


Historically it was only PE4 used as the chip select for external SPI.

https://github.com/PX4/PX4-Autopilot/blob/ea48cd4970977f4d189c1a9ba82483ac03852299/boards/px4/fmu-v2/src/board_config.h#L183-L184