### PR TITLE
README: update slack invite and badge

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 
 ---
 
-For general questions please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/).
+For general questions please use [PX4 Discuss](http://discuss.px4.io/) or Slack (you can find an invite link on this project README).
 
 **Describe problem solved by the proposed feature**
 A clear and concise description of the problem, if any, this feature will solve. E.g. I'm always frustrated when ...

--- a/.github/slack.svg
+++ b/.github/slack.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="90" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="round">
+    <rect width="90" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#round)">
+    <rect width="42" height="20" fill="#555"/>
+    <rect x="42" width="48" height="20" fill="#E01563"/>
+    <rect width="90" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="22" y="15" fill="#010101" fill-opacity=".3">slack</text>
+    <text x="22" y="14">slack</text>
+    <text x="65" y="15" fill="#010101" fill-opacity=".3">Join us!</text>
+    <text x="65" y="14">Join us!</text>
+  </g>
+</svg>
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Nuttx Targets](https://github.com/PX4/PX4-Autopilot/workflows/Nuttx%20Targets/badge.svg)](https://github.com/PX4/PX4-Autopilot/actions?query=workflow%3A%22Nuttx+Targets%22?branch=master) [![SITL Tests](https://github.com/PX4/PX4-Autopilot/workflows/SITL%20Tests/badge.svg?branch=master)](https://github.com/PX4/PX4-Autopilot/actions?query=workflow%3A%22SITL+Tests%22)
 
-[![Slack](https://px4-slack.herokuapp.com/badge.svg)](http://slack.px4.io)
+[![Slack](/.github/slack.svg)](https://join.slack.com/t/px4/shared_invite/zt-si4xo5qs-R4baYFmMjlrT4rQK5yUnaA)
 
 This repository holds the [PX4](http://px4.io) flight control solution for drones, with the main applications located in the [src/modules](https://github.com/PX4/PX4-Autopilot/tree/master/src/modules) directory. It also contains the PX4 Drone Middleware Platform, which provides drivers and middleware to run drones.
 


### PR DESCRIPTION
Our previous slack bot has been deprecated. While we move to a new platform (replacing Slack), we should still invite users to join our community on Slack.