### PR TITLE
Stop terrain estimation with height estimation based on range finder

### DIFF
--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -95,13 +95,12 @@ void Ekf::runTerrainEstimator()
 	if (!_terrain_initialised || !_control_status.flags.in_air) {
 		_terrain_initialised = initHagl();
 
-		// If RF is primary source do not estimate terrain using RF
+	// If RF is primary source do not estimate terrain using RF
 	} else if (_control_status.flags.rng_hgt && shouldUseRangeFinderForHagl()) {
-		// TODO: Switch is too late; Still using RF although primary height source has not timed out yet
-		// works fine if speed in Z direction is low
+	   // TODO: Switch is too late; Continues to use RF until the timeout of the height source is detected
+	   // works fine if speed in Z direction is low during that phase
 		_time_last_hagl_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_hagl = false;
-
 	} else {
 
 		// predict the state variance growth where the state is the vertical position of the terrain underneath the vehicle

--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -95,6 +95,13 @@ void Ekf::runTerrainEstimator()
 	if (!_terrain_initialised || !_control_status.flags.in_air) {
 		_terrain_initialised = initHagl();
 
+		// If RF is primary source do not estimate terrain using RF
+	} else if (_control_status.flags.rng_hgt && shouldUseRangeFinderForHagl()) {
+		// TODO: Switch is too late; Still using RF although primary height source has not timed out yet
+		// works fine if speed in Z direction is low
+		_time_last_hagl_fuse = _time_last_imu;
+		_innov_check_fail_status.flags.reject_hagl = false;
+
 	} else {
 
 		// predict the state variance growth where the state is the vertical position of the terrain underneath the vehicle


### PR DESCRIPTION
When height estimation is based on range finder data, the terrain estimation must not use a range finder as source. Either terrain estimation needs to be stopped or use a different source. This e.g. allows a proper fallback of position estimation based on optical flow.

As a first step, terrain estimation is paused as soon as a fallback  to range finder based height estimation occurs. Terrain estimation is continued when other height sources are available again. 

Refer to https://github.com/PX4/PX4-ECL/pull/998