### PR TITLE
Height estimation: EV fallback improvements

### DIFF
--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -1162,7 +1162,6 @@ void Ekf::controlHeightFusion()
 				} else if (_control_status.flags.in_air) {
 					_hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
 
-
 				} else {
 					_hgt_sensor_offset = _params.rng_gnd_clearance;
 				}

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -847,7 +847,7 @@ void Ekf::controlHeightSensorTimeouts()
 
 	// check if height has been inertial deadreckoning for too long
 	// in vision hgt mode check for vision data
-	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
+	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)3e5);
 
 	if (hgt_fusion_timeout || continuous_bad_accel_hgt) {
 

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -845,9 +845,16 @@ void Ekf::controlHeightSensorTimeouts()
 	// check if height is continuously failing because of accel errors
 	const bool continuous_bad_accel_hgt = isTimedOut(_time_good_vert_accel, (uint64_t)_params.bad_acc_reset_delay_us);
 
-	// check if height has been inertial deadreckoning for too long
-	// in vision hgt mode check for vision data
-	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)3e5);
+	// check if height has been inertial deadreckoning for too long depending on the height source
+	bool hgt_fusion_timeout = false;
+
+	if( _params.vdist_sensor_type == VDIST_SENSOR_BARO) {
+		hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
+
+	} else {
+		hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)3e5);
+
+	}
 
 	if (hgt_fusion_timeout || continuous_bad_accel_hgt) {
 

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -848,7 +848,7 @@ void Ekf::controlHeightSensorTimeouts()
 	// check if height has been inertial deadreckoning for too long depending on the height source
 	bool hgt_fusion_timeout = false;
 
-	if( _params.vdist_sensor_type == VDIST_SENSOR_BARO) {
+	if(_control_status.flags.baro_hgt) {
 		hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
 
 	} else {

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -1151,14 +1151,18 @@ void Ekf::controlHeightFusion()
 		if (!_control_status.flags.ev_hgt && !_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
 			setControlRangeHeight();
 			fuse_height = true;
+
 			if (_control_status_prev.flags.rng_hgt != _control_status.flags.rng_hgt) {
 			  // we have just switched to using range finder, calculate height sensor offset such that current
 			  // measurement matches our current height estimate
 			  // use the parameter rng_gnd_clearance if on ground to avoid a noisy offset initialization (e.g. sonar)
 				if (_control_status.flags.in_air && isTerrainEstimateValid()) {
 					_hgt_sensor_offset = _terrain_vpos;
+
 				} else if (_control_status.flags.in_air) {
 					_hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
+
+
 				} else {
 					_hgt_sensor_offset = _params.rng_gnd_clearance;
 				}


### PR DESCRIPTION
In mode VDIST_SENSOR_EV the height source is not switched to RF after a fallback to baro as soon as RF becomes ready:
=> The timeout fallback is covered in the current implementation (EV => RF => BARO).
=> However, the recovery is not fully covered (BARO, RF => EV works), but BARO => RF was not implemented.
This PR implements the recovery from BARO => RF. 

In addition the timeout limit for height sources is reduced to 300ms in case of VDIST_SENSOR_EV / VDIST_SENSOR_RANGE.

Refer to https://github.com/PX4/PX4-ECL/pull/998
