### PR TITLE
AirspeedSelector: Improve wording of sensor failure message

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -557,8 +557,7 @@ void AirspeedModule::select_airspeed_and_publish()
 	    (_number_of_airspeed_sensors > 0 || !_vehicle_land_detected.landed) &&
 	    _valid_airspeed_index != _prev_airspeed_index) {
 		if (_prev_airspeed_index > 0) {
-			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected (%i, %i)", _prev_airspeed_index,
-					     _valid_airspeed_index);
+			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Return to launch (RTL) is advised.");
 
 		} else if (_prev_airspeed_index == 0 && _valid_airspeed_index == -1) {
 			mavlink_log_info(&_mavlink_log_pub, "Airspeed estimation invalid");


### PR DESCRIPTION
**Describe problem solved by this pull request**
The message thrown at the operator after an Airspeed sensor failure used to not contain any useful information on how to proceed.

**Describe your solution**
Leonardo changed that message to a better wording