### PR TITLE
Broadcom AFBR-S50LV85D Distance Sensor Driver: Automatic Range Mode Switching

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -157,8 +157,7 @@ int AFBRS50::init()
 
 		case AFBR_S50LV85D_V1:
 			// Start in short range mode
-			argus_mode_t mode = ARGUS_MODE_B; // Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
-			set_mode(mode);
+			set_mode(ARGUS_MODE_B); // Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
 			_min_distance = 0.08f;
 			_max_distance = 80.f;	// Long: 80m, Short: 30m
 			_px4_rangefinder.set_min_distance(_min_distance);

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -157,8 +157,7 @@ int AFBRS50::init()
 
 		case AFBR_S50LV85D_V1:
 			// Start in short range mode
-			argus_mode_t mode; // Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
-			mode = ARGUS_MODE_B;
+			argus_mode_t mode = ARGUS_MODE_B; // Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
 			set_mode(mode);
 			_min_distance = 0.08f;
 			_max_distance = 80.f;	// Long: 80m, Short: 30m
@@ -294,7 +293,6 @@ void AFBRS50::set_mode(argus_mode_t mode)
 {
 	Argus_SetConfigurationMeasurementMode(_hnd, mode);
 	Argus_SetConfigurationDFMMode(_hnd, mode, DFM_MODE_8X);
-
 }
 
 void AFBRS50::get_mode()

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -213,7 +213,6 @@ void AFBRS50::Run()
 	ScheduleDelayed(100_ms);
 
 	UpdateMode();
-	// get_mode();
 
 	switch (_state) {
 	case STATE::TEST: {
@@ -260,20 +259,19 @@ void AFBRS50::Run()
 
 void AFBRS50::UpdateMode()
 {
-	//only update mode if _current_distance is a valid measurement
+	// only update mode if _current_distance is a valid measurement
 	if (_current_distance > 0) {
-		argus_mode_t mode;	// Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
 
 		if (_current_distance >= _long_range_threshold) {
-			//change to long range mode
-			mode = ARGUS_MODE_A;
+			// change to long range mode
+			argus_mode_t mode = ARGUS_MODE_A;
 			set_mode(mode);
 			_measure_interval = (1000000 / LONG_RANGE_MODE_HZ);
 			ScheduleDelayed(100_ms);
 
 		} else if (_current_distance <= _short_range_threshold) {
-			//change to short range mode
-			mode = ARGUS_MODE_B;
+			// change to short range mode
+			argus_mode_t mode = ARGUS_MODE_B;
 			set_mode(mode);
 			_measure_interval = (1000000 / SHORT_RANGE_MODE_HZ);
 			ScheduleDelayed(100_ms);

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.cpp
@@ -39,10 +39,11 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/module.h>
 
-#define AFBRS50_MEASURE_INTERVAL     (1000000 / 100) // 100Hz
-
 /*! Define the SPI baud rate (to be used in the SPI module). */
 #define SPI_BAUD_RATE 5000000
+
+#define LONG_RANGE_MODE_HZ 25
+#define SHORT_RANGE_MODE_HZ 50
 
 #include "s2pi.h"
 #include "timer.h"
@@ -101,6 +102,7 @@ void AFBRS50::ProcessMeasurement(void *data)
 				quality = 0;
 			}
 
+			_current_distance = result_m;
 			_px4_rangefinder.update(((res.TimeStamp.sec * 1000000ULL) + res.TimeStamp.usec), result_m, quality);
 		}
 	}
@@ -154,8 +156,12 @@ int AFBRS50::init()
 			break;
 
 		case AFBR_S50LV85D_V1:
+			// Start in short range mode
+			argus_mode_t mode; // Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
+			mode = ARGUS_MODE_B;
+			set_mode(mode);
 			_min_distance = 0.08f;
-			_max_distance = 30.f;	// Short range mode
+			_max_distance = 80.f;	// Long: 80m, Short: 30m
 			_px4_rangefinder.set_min_distance(_min_distance);
 			_px4_rangefinder.set_max_distance(_max_distance);
 			_px4_rangefinder.set_fov(math::radians(6.f));
@@ -194,7 +200,7 @@ int AFBRS50::init()
 		}
 
 		_state = STATE::CONFIGURE;
-		ScheduleDelayed(AFBRS50_MEASURE_INTERVAL);
+		ScheduleDelayed(_measure_interval);
 		return PX4_OK;
 	}
 
@@ -206,6 +212,9 @@ void AFBRS50::Run()
 	// backup schedule
 	ScheduleDelayed(100_ms);
 
+	UpdateMode();
+	// get_mode();
+
 	switch (_state) {
 	case STATE::TEST: {
 			Argus_VerifyHALImplementation(Argus_GetSPISlave(_hnd));
@@ -216,7 +225,7 @@ void AFBRS50::Run()
 		break;
 
 	case STATE::CONFIGURE: {
-			Argus_SetConfigurationFrameTime(_hnd, AFBRS50_MEASURE_INTERVAL);
+			Argus_SetConfigurationFrameTime(_hnd, _measure_interval);
 
 			status_t status = Argus_StartMeasurementTimer(_hnd, measurement_ready_callback);
 
@@ -227,7 +236,7 @@ void AFBRS50::Run()
 
 			} else {
 				_state = STATE::COLLECT;
-				ScheduleDelayed(AFBRS50_MEASURE_INTERVAL);
+				ScheduleDelayed(_measure_interval);
 			}
 		}
 		break;
@@ -249,6 +258,29 @@ void AFBRS50::Run()
 	}
 }
 
+void AFBRS50::UpdateMode()
+{
+	//only update mode if _current_distance is a valid measurement
+	if (_current_distance > 0) {
+		argus_mode_t mode;	// Long: ARGUS_MODE_A, Short: ARGUS_MODE_B
+
+		if (_current_distance >= _long_range_threshold) {
+			//change to long range mode
+			mode = ARGUS_MODE_A;
+			set_mode(mode);
+			_measure_interval = (1000000 / LONG_RANGE_MODE_HZ);
+			ScheduleDelayed(100_ms);
+
+		} else if (_current_distance <= _short_range_threshold) {
+			//change to short range mode
+			mode = ARGUS_MODE_B;
+			set_mode(mode);
+			_measure_interval = (1000000 / SHORT_RANGE_MODE_HZ);
+			ScheduleDelayed(100_ms);
+		}
+	}
+}
+
 void AFBRS50::stop()
 {
 	_state = STATE::STOP;
@@ -258,6 +290,27 @@ void AFBRS50::stop()
 void AFBRS50::print_info()
 {
 	perf_print_counter(_sample_perf);
+}
+
+void AFBRS50::set_mode(argus_mode_t mode)
+{
+	Argus_SetConfigurationMeasurementMode(_hnd, mode);
+	Argus_SetConfigurationDFMMode(_hnd, mode, DFM_MODE_8X);
+
+}
+
+void AFBRS50::get_mode()
+{
+	argus_mode_t current_mode;
+	argus_dfm_mode_t dfm_mode;
+	Argus_GetConfigurationMeasurementMode(_hnd, &current_mode);
+	Argus_GetConfigurationDFMMode(_hnd, current_mode, &dfm_mode);
+
+	int dist = _current_distance;
+	PX4_INFO_RAW("distance: %d\n", dist);
+	PX4_INFO_RAW("mode: %d\n", current_mode);
+	// PX4_INFO_RAW("dfm mode: %d\n", dfm_mode);
+	PX4_INFO_RAW("rate: %d Hz\n\n", (1000000 / _measure_interval));
 }
 
 namespace afbrs50

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -63,8 +63,6 @@ public:
 	 */
 	void print_info();
 
-	void print_mode();
-
 	/**
 	 * Stop the automatic measurement state machine.
 	 */
@@ -83,8 +81,7 @@ private:
 	void set_mode(argus_mode_t mode);
 
 	argus_hnd_t *_hnd{nullptr};
-	argus_mode_t _mode = ARGUS_MODE_A;	// Long-Range
-	// argus_mode_t _mode = ARGUS_MODE_B;	// Short-Range
+	argus_mode_t _mode{ARGUS_MODE_A}; // Long-Range
 
 	enum class STATE : uint8_t {
 		TEST,

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -96,8 +96,8 @@ private:
 
 	perf_counter_t _sample_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": sample interval")};
 
-	int _measure_interval = (1000000 / 100); // 100Hz
-	float _current_distance;
+	int _measure_interval{1000000 / 100}; // 100Hz
+	float _current_distance{0};
 	const float _short_range_threshold = 4.0; //meters
 	const float _long_range_threshold = 6.0; //meters
 	float _max_distance;

--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -63,6 +63,8 @@ public:
 	 */
 	void print_info();
 
+	void print_mode();
+
 	/**
 	 * Stop the automatic measurement state machine.
 	 */
@@ -71,11 +73,18 @@ public:
 private:
 	void Run() override;
 
+	void UpdateMode();
+
 	void ProcessMeasurement(void *data);
 
 	static status_t measurement_ready_callback(status_t status, void *data);
 
+	void get_mode();
+	void set_mode(argus_mode_t mode);
+
 	argus_hnd_t *_hnd{nullptr};
+	argus_mode_t _mode = ARGUS_MODE_A;	// Long-Range
+	// argus_mode_t _mode = ARGUS_MODE_B;	// Short-Range
 
 	enum class STATE : uint8_t {
 		TEST,
@@ -90,6 +99,10 @@ private:
 
 	perf_counter_t _sample_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": sample interval")};
 
+	int _measure_interval = (1000000 / 100); // 100Hz
+	float _current_distance;
+	const float _short_range_threshold = 4.0; //meters
+	const float _long_range_threshold = 6.0; //meters
 	float _max_distance;
 	float _min_distance;
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR for the Broadcom AFBR-S50LV85D Distance Sensor driver allows the sensor to use its long range or short range mode based on measured distance. This allows for better measurement results up to distances over 30 meters.

**Describe your solution**
The sensor starts in short range mode at 50 Hz and only transitions to long range mode at 25 Hz once measuring over 6m distance. On descent, the sensor requires distances below 4m to transition back to short range mode.

**Test data / coverage**
The driver was tested on an ARK Flow running as a uavcannode with a Pixhawk 4 Mini on 1.12 beta 5. The system was also running an ARK GPS on UAVCAN.

over grass (run 1): https://review.px4.io/plot_app?log=a9743528-3014-45f6-8e6d-b9c1f1a80b84

over grass (run 2): https://review.px4.io/plot_app?log=b604a85d-0546-4d7d-81cf-e36f523852de

over grass (run 3): https://review.px4.io/plot_app?log=f3ea73e7-ef7e-4488-aec2-5d853f395978

over concrete (run 1): https://review.px4.io/plot_app?log=8589644d-88a7-4b74-a130-1abc7afc5e12

over concrete (run 2): https://review.px4.io/plot_app?log=cba5710e-640b-4007-abf0-9a60908f8654