### PR TITLE
Fix invalid setpoint on takeoff

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -290,7 +290,7 @@ void MulticopterPositionControl::Run()
 
 		if (_vehicle_control_mode.flag_multicopter_position_control_enabled) {
 
-			_trajectory_setpoint_sub.update(&_setpoint);
+			const bool is_trajectory_setpoint_updated = _trajectory_setpoint_sub.update(&_setpoint);
 
 			// adjust existing (or older) setpoint with any EKF reset deltas
 			if (_setpoint.timestamp < local_pos.timestamp) {
@@ -361,22 +361,25 @@ void MulticopterPositionControl::Run()
 						    _vehicle_constraints.want_takeoff,
 						    _vehicle_constraints.speed_up, false, time_stamp_now);
 
-			const bool not_taken_off             = (_takeoff.getTakeoffState() < TakeoffState::rampup);
-			const bool flying                    = (_takeoff.getTakeoffState() >= TakeoffState::flight);
-			const bool flying_but_ground_contact = (flying && _vehicle_land_detected.ground_contact);
+			const bool flying = (_takeoff.getTakeoffState() >= TakeoffState::flight);
 
-			// make sure takeoff ramp is not amended by acceleration feed-forward
-			if (!flying) {
-				_setpoint.acceleration[2] = NAN;
-			}
+			if (is_trajectory_setpoint_updated) {
+				// make sure takeoff ramp is not amended by acceleration feed-forward
+				if (!flying) {
+					_setpoint.acceleration[2] = NAN;
+				}
 
-			if (not_taken_off || flying_but_ground_contact) {
-				// we are not flying yet and need to avoid any corrections
-				reset_setpoint_to_nan(_setpoint);
-				Vector3f(0.f, 0.f, 100.f).copyTo(_setpoint.acceleration); // High downwards acceleration to make sure there's no thrust
+				const bool not_taken_off             = (_takeoff.getTakeoffState() < TakeoffState::rampup);
+				const bool flying_but_ground_contact = (flying && _vehicle_land_detected.ground_contact);
 
-				// prevent any integrator windup
-				_control.resetIntegral();
+				if (not_taken_off || flying_but_ground_contact) {
+					// we are not flying yet and need to avoid any corrections
+					reset_setpoint_to_nan(_setpoint);
+					Vector3f(0.f, 0.f, 100.f).copyTo(_setpoint.acceleration); // High downwards acceleration to make sure there's no thrust
+
+					// prevent any integrator windup
+					_control.resetIntegral();
+				}
 			}
 
 			// limit tilt during takeoff ramupup

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -427,7 +427,7 @@ void MulticopterPositionControl::Run()
 
 			} else {
 				// Failsafe
-				if ((time_stamp_now - _last_warn) > 2_s && _last_warn > 0) {
+				if ((time_stamp_now - _last_warn) > 2_s) {
 					PX4_WARN("invalid setpoints");
 					_last_warn = time_stamp_now;
 				}


### PR DESCRIPTION
**Describe problem solved by this pull request**
- Before the rampup state and when `!flying`, `_setpoint.acceleration[2]` is set to NAN, `_setpoint` is overwritten by NAN and `_setpoint.acceleration` is set to (0,0,100) 
- When reaching rampup, `_setpoint.acceleration[2]` is still set to NAN, `_setpoint` isn’t overwritten anymore and `_setpoint.acceleration[2]` isn’t set (to 100) anymore
- Since the loop is scheduled on local_pos estimate and not the setpoint, it can be that the `_setpoint` is still NAN (overwritten state) from the previous iteration
- At that exact point in time, `_setpoint.vz(2)` and `_setpoint.acceleration[2]` are NAN, so the output is invalid: triggering `WARN [mc_pos_control] invalid setpoints`

**Describe your solution**
Only apply the overriding logic when there is a new `trajectory_setpoint` message (i.e.: `_setpoint` update).

**Describe possible alternatives**
Copy the original `trajectory_setpoint` message and only apply the changes locally

**Test data / coverage**
SITL tests

**Additional context**
I also reverted https://github.com/PX4/PX4-Autopilot/pull/17725 because the warning is now fixed so we don't want to hide it anymore.