### PR TITLE
[WIP] commander: accel calibration updates

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.hpp
+++ b/src/lib/sensor_calibration/Accelerometer.hpp
@@ -64,6 +64,7 @@ public:
 	void set_external(bool external = true);
 	bool set_offset(const matrix::Vector3f &offset);
 	bool set_scale(const matrix::Vector3f &scale);
+	bool set_offdiagonal(const matrix::Vector3f &offdiagonal);
 	void set_rotation(Rotation rotation);
 
 	uint8_t calibration_count() const { return _calibration_count; }
@@ -74,13 +75,14 @@ public:
 	const int32_t &priority() const { return _priority; }
 	const matrix::Dcmf &rotation() const { return _rotation; }
 	const Rotation &rotation_enum() const { return _rotation_enum; }
-	const matrix::Vector3f &scale() const { return _scale; }
+	const matrix::SquareMatrix3f &scale() const { return _scale; }
+	const matrix::Vector3f &thermal_offset() const { return _thermal_offset; }
 
 	// apply offsets and scale
 	// rotate corrected measurements from sensor to body frame
 	inline matrix::Vector3f Correct(const matrix::Vector3f &data) const
 	{
-		return _rotation * matrix::Vector3f{(data - _thermal_offset - _offset).emult(_scale)};
+		return _rotation * _scale * (data - _thermal_offset - _offset);
 	}
 
 	bool ParametersSave();
@@ -97,7 +99,7 @@ private:
 
 	matrix::Dcmf _rotation;
 	matrix::Vector3f _offset;
-	matrix::Vector3f _scale;
+	matrix::SquareMatrix3f _scale;
 	matrix::Vector3f _thermal_offset;
 
 	int8_t _calibration_index{-1};

--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -167,7 +167,7 @@ void Magnetometer::ParametersUpdate()
 			set_rotation(static_cast<Rotation>(rotation_value));
 
 		} else {
-			// internal mag, CAL_MAGx_ROT -1
+			// internal, CAL_MAGx_ROT -1
 			if (rotation_value != -1) {
 				PX4_ERR("Internal %s %" PRIu32 " (%" PRId8 ") invalid rotation %" PRId32 " resetting",
 					SensorString(), _device_id, _calibration_index, rotation_value);

--- a/src/lib/sensor_calibration/Magnetometer.hpp
+++ b/src/lib/sensor_calibration/Magnetometer.hpp
@@ -82,7 +82,7 @@ public:
 	// rotate corrected measurements from sensor to body frame
 	inline matrix::Vector3f Correct(const matrix::Vector3f &data) const
 	{
-		return _rotation * (_scale * ((data + _power * _power_compensation) - _offset));
+		return _rotation * _scale * ((data + _power * _power_compensation) - _offset);
 	}
 
 	// Compute sensor offset from bias (board frame)

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -131,12 +131,14 @@
 #include <px4_platform_common/time.h>
 
 #include <drivers/drv_hrt.h>
+#include <include/containers/Bitset.hpp>
 #include <lib/sensor_calibration/Accelerometer.hpp>
 #include <lib/sensor_calibration/Utilities.hpp>
 #include <lib/mathlib/mathlib.h>
 #include <lib/geo/geo.h>
 #include <matrix/math.hpp>
 #include <lib/conversion/rotation.h>
+#include <lib/mathlib/math/WelfordMean.hpp>
 #include <lib/parameters/param.h>
 #include <lib/systemlib/err.h>
 #include <lib/systemlib/mavlink_log.h>
@@ -156,168 +158,206 @@ static constexpr unsigned MAX_ACCEL_SENS = 4;
 struct accel_worker_data_s {
 	orb_advert_t	*mavlink_log_pub{nullptr};
 	unsigned	done_count{0};
-	float		accel_ref[MAX_ACCEL_SENS][detect_orientation_side_count][3] {};
+	matrix::Vector3f accel_ref[MAX_ACCEL_SENS][detect_orientation_side_count] {};
 };
 
 // Read specified number of accelerometer samples, calculate average and dispersion.
-static calibrate_return read_accelerometer_avg(float (&accel_avg)[MAX_ACCEL_SENS][detect_orientation_side_count][3],
-		unsigned orient, unsigned samples_num)
+static calibrate_return read_accelerometer_avg(Vector3f(&accel_avg)[MAX_ACCEL_SENS][detect_orientation_side_count],
+		unsigned orient)
 {
-	Vector3f accel_sum[MAX_ACCEL_SENS] {};
-	unsigned counts[MAX_ACCEL_SENS] {};
+	calibration::Accelerometer calibrations[MAX_ACCEL_SENS] {};
+	uORB::SubscriptionMultiArray<sensor_accel_s, MAX_ACCEL_SENS> accel_subs{ORB_ID::sensor_accel};
+	math::WelfordMean<Vector3f> mean[MAX_ACCEL_SENS] {};
 
-	unsigned errcount = 0;
-
-	// sensor thermal corrections
-	uORB::Subscription sensor_correction_sub{ORB_ID(sensor_correction)};
-	sensor_correction_s sensor_correction{};
-	sensor_correction_sub.copy(&sensor_correction);
-
-	uORB::SubscriptionBlocking<sensor_accel_s> accel_sub[MAX_ACCEL_SENS] {
-		{ORB_ID(sensor_accel), 0, 0},
-		{ORB_ID(sensor_accel), 0, 1},
-		{ORB_ID(sensor_accel), 0, 2},
-		{ORB_ID(sensor_accel), 0, 3},
-	};
+	Vector3f accel_prev[MAX_ACCEL_SENS] {};
 
 	/* use the first sensor to pace the readout, but do per-sensor counts */
-	while (counts[0] < samples_num) {
-		if (accel_sub[0].updatedBlocking(100000)) {
-			for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
-				sensor_accel_s arp;
+	bool done = false;
 
-				while (accel_sub[accel_index].update(&arp)) {
-					// fetch optional thermal offset corrections in sensor/board frame
-					Vector3f offset{0, 0, 0};
-					sensor_correction_sub.update(&sensor_correction);
+	const hrt_abstime timestamp_start = hrt_absolute_time();
 
-					if (sensor_correction.timestamp > 0 && arp.device_id != 0) {
-						for (uint8_t correction_index = 0; correction_index < MAX_ACCEL_SENS; correction_index++) {
-							if (sensor_correction.accel_device_ids[correction_index] == arp.device_id) {
-								switch (correction_index) {
-								case 0:
-									offset = Vector3f{sensor_correction.accel_offset_0};
-									break;
-								case 1:
-									offset = Vector3f{sensor_correction.accel_offset_1};
-									break;
-								case 2:
-									offset = Vector3f{sensor_correction.accel_offset_2};
-									break;
-								case 3:
-									offset = Vector3f{sensor_correction.accel_offset_3};
-									break;
-								}
-							}
-						}
-					}
+	while (!done && (hrt_elapsed_time(&timestamp_start) < 3_s)) {
+		int good_count = 0;
 
-					accel_sum[accel_index] += Vector3f{arp.x, arp.y, arp.z} - offset;
-					counts[accel_index]++;
+		for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+			sensor_accel_s arp;
+
+			while (accel_subs[accel_index].update(&arp)) {
+				calibrations[accel_index].set_device_id(arp.device_id);
+				calibrations[accel_index].SensorCorrectionsUpdate();
+
+				// fetch optional thermal offset corrections in sensor/board frame
+				const Vector3f accel{Vector3f{arp.x, arp.y, arp.z} - calibrations[accel_index].thermal_offset()};
+
+				if ((accel - accel_prev[accel_index]).longerThan(0.5f)) {
+					mean[accel_index].reset();
+					accel_prev[accel_index] = accel;
+
+				} else {
+					mean[accel_index].update(accel);
 				}
 			}
 
+			if ((mean[accel_index].count() > 2000) && !mean[accel_index].variance().longerThan(0.005)) {
+				good_count++;
+			}
+		}
+
+		if ((good_count > 0) && (good_count == accel_subs.advertised_count())) {
+			PX4_INFO("finished early: %d", mean[0].count());
+			done = true;
+
 		} else {
-			errcount++;
-			continue;
-		}
-
-		if (errcount > samples_num / 10) {
-			return calibrate_return_error;
+			px4_usleep(2000);
 		}
 	}
 
-	// rotate sensor measurements from sensor to body frame using board rotation matrix
-	const Dcmf board_rotation = calibration::GetBoardRotationMatrix();
+	bool all_good = false;
 
 	for (unsigned s = 0; s < MAX_ACCEL_SENS; s++) {
-		accel_sum[s] = board_rotation * accel_sum[s];
+		if (mean[s].valid()) {
+			const Vector3f avg = mean[s].mean();
+			const Vector3f var = mean[s].variance();
+
+			PX4_INFO("O: %d, Accel: %d, Mean: [%.6f, %.6f, %.6f], Variance: [%.6f, %.6f, %.6f]", orient, s,
+				 (double)avg(0), (double)avg(1), (double)avg(2),
+				 (double)var(0), (double)var(1), (double)var(2)
+				);
+
+			if (!var.longerThan(0.005f)) {
+				all_good = true;
+
+			} else {
+				break;
+			}
+
+			accel_avg[s][orient] = mean[s].mean();
+
+		} else {
+			accel_avg[s][orient].zero();
+		}
 	}
 
-	for (unsigned s = 0; s < MAX_ACCEL_SENS; s++) {
-		const Vector3f avg{accel_sum[s] / counts[s]};
-		avg.copyTo(accel_avg[s][orient]);
-	}
-
-	return calibrate_return_ok;
+	return all_good ? calibrate_return_ok : calibrate_return_error;
 }
 
 static calibrate_return accel_calibration_worker(detect_orientation_return orientation, void *data)
 {
-	static constexpr unsigned samples_num = 750;
 	accel_worker_data_s *worker_data = (accel_worker_data_s *)(data);
 
-	calibration_log_info(worker_data->mavlink_log_pub, "[cal] Hold still, measuring %s side",
-			     detect_orientation_str(orientation));
+	int attempt = 0;
 
-	read_accelerometer_avg(worker_data->accel_ref, orientation, samples_num);
+	while (attempt < 5) {
+		calibration_log_info(worker_data->mavlink_log_pub, "[cal] Hold still, measuring %s side",
+				     detect_orientation_str(orientation));
 
-	// check accel
-	for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
-		switch (orientation) {
-		case ORIENTATION_TAIL_DOWN:    // [ g, 0, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_TAIL_DOWN][0] < 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid X-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
+		if (read_accelerometer_avg(worker_data->accel_ref, orientation) == calibrate_return_ok) {
+			calibration_log_info(worker_data->mavlink_log_pub, "[cal] %s side result: [%.3f %.3f %.3f]",
+					     detect_orientation_str(orientation),
+					     (double)worker_data->accel_ref[0][orientation](0),
+					     (double)worker_data->accel_ref[0][orientation](1),
+					     (double)worker_data->accel_ref[0][orientation](2));
 
-			break;
+			worker_data->done_count++;
+			calibration_log_info(worker_data->mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 17 * worker_data->done_count);
 
-		case ORIENTATION_NOSE_DOWN:    // [ -g, 0, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_NOSE_DOWN][0] > 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid X-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_LEFT:         // [ 0, g, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_LEFT][1] < 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Y-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_RIGHT:        // [ 0, -g, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_RIGHT][1] > 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Y-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_UPSIDE_DOWN:  // [ 0, 0, g ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_UPSIDE_DOWN][2] < 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Z-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_RIGHTSIDE_UP: // [ 0, 0, -g ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_RIGHTSIDE_UP][2] > 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Z-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		default:
-			break;
+			return calibrate_return_ok;
 		}
+
+		attempt++;
 	}
 
-	calibration_log_info(worker_data->mavlink_log_pub, "[cal] %s side result: [%.3f %.3f %.3f]",
-			     detect_orientation_str(orientation),
-			     (double)worker_data->accel_ref[0][orientation][0],
-			     (double)worker_data->accel_ref[0][orientation][1],
-			     (double)worker_data->accel_ref[0][orientation][2]);
+	return calibrate_return_error;
+}
 
-	worker_data->done_count++;
-	calibration_log_info(worker_data->mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 17 * worker_data->done_count);
+struct CalibrationResult {
+	Matrix3f scale{};
+	Vector3f offsets{};
+	bool valid{false};
+};
 
-	return calibrate_return_ok;
+static CalibrationResult CalculateCalibration(const Vector3f(&accel_data)[6], const Dcmf &rotation, bool print = false)
+{
+	// rotate calibration data into vehicle body frame
+	Vector3f data[6];
+
+	for (int i = 0; i < 6; i++) {
+		data[i] = rotation * accel_data[i];
+	}
+
+	static constexpr float g = CONSTANTS_ONE_G;
+
+	// Y = w * X
+	//  Matrix X is the 12 calibration parameters that need to be determined
+	//  Matrix w is sensor raw data LSBs collected at 6 stationary positions
+	//  Matrix Y is the known normalized Earth gravity vector
+
+	// X = (wT * w)^-1 * wT * Y
+	matrix::Matrix<float, 6, 4> w;
+
+	for (int i = 0; i < 6; i++) {
+		Vector3f tmp = rotation * accel_data[i];
+
+		w(i, 0) = tmp(0);
+		w(i, 1) = tmp(1);
+		w(i, 2) = tmp(2);
+		w(i, 3) = 1.f;
+	}
+
+	matrix::Matrix<float, 6, 3> Y;
+	Y.row(0) = Vector3f{ g,  0,  0}; // ORIENTATION_TAIL_DOWN
+	Y.row(1) = Vector3f{-g,  0,  0}; // ORIENTATION_NOSE_DOWN,
+	Y.row(2) = Vector3f{ 0,  g,  0}; // ORIENTATION_LEFT,
+	Y.row(3) = Vector3f{ 0, -g,  0}; // ORIENTATION_RIGHT,
+	Y.row(4) = Vector3f{ 0,  0,  g}; // ORIENTATION_UPSIDE_DOWN,
+	Y.row(5) = Vector3f{ 0,  0, -g}; // ORIENTATION_RIGHTSIDE_UP
+
+	const auto wT = w.transpose();
+	const auto X = matrix::SquareMatrix<float, 4>(wT * w).I() * wT * Y;
+
+	matrix::SquareMatrix3f scale = X.slice<3, 3>(0, 0);
+	Vector3f b{X.row(3)};
+
+	Vector3f offset = -scale.I() * b;
+
+	if (print) {
+		PX4_INFO("W");
+		w.print();
+		PX4_INFO("Y");
+		Y.print();
+		PX4_INFO("X");
+		X.print();
+		PX4_INFO("scale");
+		scale.print();
+		PX4_INFO("b");
+		b.print();
+		PX4_INFO("offset");
+		offset.print();
+
+
+		matrix::Matrix<float, 6, 3> Wcalibrated = w.slice<6, 3>(0, 0);
+
+		for (int i = 0; i < 6; i++) {
+			Wcalibrated.row(i) = scale * (Vector3f{Wcalibrated.row(i)} - offset);
+		}
+
+		PX4_INFO("W calibrated");
+		Wcalibrated.print();
+	}
+
+	// rotate offsets back to sensor frame
+	const Vector3f accel_offsets{rotation.transpose() *offset};
+
+	// rotate scale back to sensor frame
+	const Matrix3f accel_scale{rotation.transpose() *scale * rotation};
+
+	CalibrationResult result;
+	result.scale = accel_scale;
+	result.offsets = accel_offsets;
+	result.valid = (accel_scale(0, 0) > 0) && (accel_scale(1, 1) > 0)
+		       && (accel_scale(2, 2) > 0); // valid if all scale factors positive
+
+	return result;
 }
 
 int do_accel_calibration(orb_advert_t *mavlink_log_pub)
@@ -362,64 +402,114 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 	if (calibrate_from_orientation(mavlink_log_pub, data_collected, accel_calibration_worker, &worker_data,
 				       false) == calibrate_return_ok) {
 
-		const Dcmf board_rotation = calibration::GetBoardRotationMatrix();
-		const Dcmf board_rotation_t = board_rotation.transpose();
+		const Rotation board_rotation = calibration::GetBoardRotation();
 
 		bool param_save = false;
 		bool failed = true;
 
+		int internal_rotation_count{0};
+		Rotation internal_rotations[MAX_ACCEL_SENS] {};
+
 		for (unsigned i = 0; i < MAX_ACCEL_SENS; i++) {
 			if (i < active_sensors) {
-				// calculate offsets
-				Vector3f offset{};
+				float calibration_metric[ROTATION_MAX] {};
+				float min_error = FLT_MAX;
+				Rotation best_rotation = ROTATION_NONE;
 
-				// X offset: average X from TAIL_DOWN + NOSE_DOWN
-				const Vector3f accel_tail_down{worker_data.accel_ref[i][ORIENTATION_TAIL_DOWN]};
-				const Vector3f accel_nose_down{worker_data.accel_ref[i][ORIENTATION_NOSE_DOWN]};
-				offset(0) = (accel_tail_down(0) + accel_nose_down(0)) * 0.5f;
+				for (int r = ROTATION_NONE; r < ROTATION_MAX; r++) {
+					calibration_metric[r] = FLT_MAX;
 
-				// Y offset: average Y from LEFT + RIGHT
-				const Vector3f accel_left{worker_data.accel_ref[i][ORIENTATION_LEFT]};
-				const Vector3f accel_right{worker_data.accel_ref[i][ORIENTATION_RIGHT]};
-				offset(1) = (accel_left(1) + accel_right(1)) * 0.5f;
+					// try all rotations
+					switch (r) {
+					case ROTATION_ROLL_90_PITCH_68_YAW_293: // skip
+					case ROTATION_PITCH_180_YAW_90:  // skip 26, same as 14 ROTATION_ROLL_180_YAW_270
+					case ROTATION_PITCH_180_YAW_270: // skip 27, same as 10 ROTATION_ROLL_180_YAW_90
+						break;
 
-				// Z offset: average Z from UPSIDE_DOWN + RIGHTSIDE_UP
-				const Vector3f accel_upside_down{worker_data.accel_ref[i][ORIENTATION_UPSIDE_DOWN]};
-				const Vector3f accel_rightside_up{worker_data.accel_ref[i][ORIENTATION_RIGHTSIDE_UP]};
-				offset(2) = (accel_upside_down(2) + accel_rightside_up(2)) * 0.5f;
+					default: {
+							const CalibrationResult result = CalculateCalibration(worker_data.accel_ref[i], get_rot_matrix((Rotation)r));
 
-				// transform matrix
-				Matrix3f mat_A;
-				mat_A.row(0) = accel_tail_down - offset;
-				mat_A.row(1) = accel_left - offset;
-				mat_A.row(2) = accel_upside_down - offset;
+							if (result.valid) {
+								// crude calibration metric (difference from correct scale and no offsets)
+								const float scale_error = Vector3f(result.scale.diag() - Vector3f{1.f, 1.f, 1.f}).norm();
+								const float offset_error = result.offsets.norm();
+								// TODO: offdiagonal close to zero?
+								calibration_metric[r] = scale_error + offset_error;
 
-				// calculate inverse matrix for A: simplify matrices mult because b has only one non-zero element == g at index i
-				const Matrix3f accel_T = mat_A.I() * CONSTANTS_ONE_G;
+								if (calibration_metric[r] < min_error) {
+									min_error = calibration_metric[r];
+									best_rotation = (Rotation)r;
+								}
+							}
+						}
+					}
+				}
+
+				PX4_INFO("best rotation: %d", best_rotation);
+
+				if (!calibrations[i].external()) {
+					internal_rotations[internal_rotation_count] = best_rotation;
+					internal_rotation_count++;
+				}
+
+				const CalibrationResult result = CalculateCalibration(worker_data.accel_ref[i],
+								 get_rot_matrix((Rotation)best_rotation), true);
+
+#if 1//defined(DEBUD_BUILD)
+				PX4_INFO("accel %d offset", i);
+				result.offsets.print();
+
+				PX4_INFO("accel %d scale", i);
+				result.scale.print();
+
+				Vector3f offdiagonal{
+					(result.scale(0, 1) + result.scale(1, 0)) * 0.5f,
+					(result.scale(0, 2) + result.scale(2, 0)) * 0.5f,
+					(result.scale(1, 2) + result.scale(2, 1)) * 0.5f,
+				};
+
+				PX4_INFO("accel %d offdiagonal", i);
+				offdiagonal.print();
+#endif // DEBUD_BUILD
+
+				bool print_all_errors = true;
+
+				if (calibrations[i].external()) {
+					switch (calibrations[i].rotation_enum()) {
+					case ROTATION_ROLL_90_PITCH_68_YAW_293:
+						PX4_INFO("[cal] External Accel: %d (%d), keeping manually configured rotation %d", i,
+							 calibrations[i].device_id(), calibrations[i].rotation_enum());
+						continue;
+
+					default: {
+							if (best_rotation != calibrations[i].rotation_enum()) {
+								calibration_log_info(mavlink_log_pub, "[cal] External Accel: %d (%d), determined rotation: %d", i,
+										     calibrations[i].device_id(), best_rotation);
+								calibrations[i].set_rotation(best_rotation);
+
+							} else {
+								PX4_INFO("[cal] External Accel: %d (%d), no rotation change: %d", i, calibrations[i].device_id(), best_rotation);
+							}
+						}
+						break;
+					}
+				}
+
+				if (print_all_errors) {
+					for (int r = ROTATION_NONE; r < ROTATION_MAX; r++) {
+						if (calibration_metric[r] < FLT_MAX) {
+							PX4_ERR("Accel: %d (%d), rotation: %d, error: %.3f", i, calibrations[i].device_id(), r, (double)calibration_metric[r]);
+						}
+					}
+				}
 
 				// update calibration
-				const Vector3f accel_offs_rotated{board_rotation_t *offset};
-				calibrations[i].set_offset(accel_offs_rotated);
-
-				const Matrix3f accel_T_rotated{board_rotation_t *accel_T * board_rotation};
-				calibrations[i].set_scale(accel_T_rotated.diag());
-
-#if defined(DEBUD_BUILD)
-				PX4_INFO("accel %d: offset", i);
-				offset.print();
-				PX4_INFO("accel %d: bT * offset", i);
-				accel_offs_rotated.print();
-
-				PX4_INFO("accel %d: mat_A", i);
-				mat_A.print();
-				PX4_INFO("accel %d: accel_T", i);
-				accel_T.print();
-				PX4_INFO("accel %d: bT * accel_T * b", i);
-				accel_T_rotated.print();
-#endif // DEBUD_BUILD
+				calibrations[i].set_offset(result.offsets);
+				calibrations[i].set_scale(result.scale.diag());
+				calibrations[i].set_offdiagonal(offdiagonal);
 				calibrations[i].PrintStatus();
 
-
+				// save all calibrations including empty slots
 				if (calibrations[i].ParametersSave()) {
 					param_save = true;
 					failed = false;
@@ -431,6 +521,26 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 				}
 			}
 		}
+
+		// review SENS_BOARD_ROT, do all internal accels agree on SENS_BOARD_ROT?
+		if (!failed && (internal_rotation_count > 0)) {
+			Rotation best_rotation = internal_rotations[0];
+			bool same = true;
+
+			for (unsigned i = 0; i < MAX_ACCEL_SENS; i++) {
+				if (internal_rotations[0] != internal_rotations[i]) {
+					same = false;
+					break;
+				}
+			}
+
+			if (same && (best_rotation != board_rotation)) {
+				PX4_ERR("Incorrect board rotation: %d", board_rotation);
+				int32_t sens_board_rot = best_rotation;
+				param_set_no_notification(param_find("SENS_BOARD_ROT"), &sens_board_rot);
+			}
+		}
+
 
 		if (!failed && factory_storage.store() != PX4_OK) {
 			failed = true;
@@ -457,7 +567,6 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 #if !defined(CONSTRAINED_FLASH)
 	PX4_INFO("Accelerometer quick calibration");
 
-	bool param_save = false;
 	bool failed = true;
 
 	FactoryCalibrationStorage factory_storage;
@@ -467,122 +576,113 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 		return PX4_ERROR;
 	}
 
-	// sensor thermal corrections (optional)
-	uORB::Subscription sensor_correction_sub{ORB_ID(sensor_correction)};
-	sensor_correction_s sensor_correction{};
-	sensor_correction_sub.copy(&sensor_correction);
-
+	calibration::Accelerometer calibrations[MAX_ACCEL_SENS] {};
+	math::WelfordMean<Vector3f> mean[MAX_ACCEL_SENS] {};
 	uORB::SubscriptionMultiArray<sensor_accel_s, MAX_ACCEL_SENS> accel_subs{ORB_ID::sensor_accel};
+	px4::Bitset<MAX_ACCEL_SENS> valid_cal;
 
-	/* use the first sensor to pace the readout, but do per-sensor counts */
-	for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
-		sensor_accel_s arp{};
-		Vector3f accel_sum{};
-		unsigned count = 0;
+	const hrt_abstime start_time = hrt_absolute_time();
 
-		while (accel_subs[accel_index].update(&arp)) {
-			// fetch optional thermal offset corrections in sensor/board frame
-			if ((arp.timestamp > 0) && (arp.device_id != 0)) {
-				Vector3f offset{0, 0, 0};
+	Vector3f accel_prev[MAX_ACCEL_SENS] {};
 
-				if (sensor_correction.timestamp > 0) {
-					for (uint8_t correction_index = 0; correction_index < MAX_ACCEL_SENS; correction_index++) {
-						if (sensor_correction.accel_device_ids[correction_index] == arp.device_id) {
-							switch (correction_index) {
-							case 0:
-								offset = Vector3f{sensor_correction.accel_offset_0};
-								break;
-							case 1:
-								offset = Vector3f{sensor_correction.accel_offset_1};
-								break;
-							case 2:
-								offset = Vector3f{sensor_correction.accel_offset_2};
-								break;
-							case 3:
-								offset = Vector3f{sensor_correction.accel_offset_3};
-								break;
-							}
-						}
-					}
-				}
+	while ((hrt_elapsed_time(&start_time) < 3_s) && (valid_cal.count() < accel_subs.advertised_count())) {
+		for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+			sensor_accel_s sensor_accel;
 
-				const Vector3f accel{Vector3f{arp.x, arp.y, arp.z} - offset};
+			while (accel_subs[accel_index].update(&sensor_accel)) {
+				if ((sensor_accel.timestamp > 0) && (sensor_accel.device_id != 0)) {
+					calibrations[accel_index].set_device_id(sensor_accel.device_id);
+					calibrations[accel_index].SensorCorrectionsUpdate();
 
-				if (count > 0) {
-					const Vector3f diff{accel - (accel_sum / count)};
+					const Vector3f accel{Vector3f{sensor_accel.x, sensor_accel.y, sensor_accel.z} - calibrations[accel_index].thermal_offset()};
 
-					if (diff.norm() < 1.f) {
-						accel_sum += Vector3f{arp.x, arp.y, arp.z} - offset;
-						count++;
+					if ((accel - accel_prev[accel_index]).longerThan(0.5f)) {
+						mean[accel_index].reset();
+						accel_prev[accel_index] = accel;
+
+					} else {
+						mean[accel_index].update(accel);
 					}
 
-				} else {
-					accel_sum = accel;
-					count = 1;
+					if (mean[accel_index].count() > 300 && !mean[accel_index].variance().longerThan(0.01f)) {
+						valid_cal.set(accel_index, true);
+					}
 				}
 			}
 		}
 
-		if ((count > 0) && (arp.device_id != 0)) {
+		px4_usleep(1000);
 
-			bool calibrated = false;
-			const Vector3f accel_avg = accel_sum / count;
+		for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+			if (mean[accel_index].count() > 0) {
+				PX4_DEBUG("accel %d/%d valid %d var: %.6f", accel_index, accel_subs.advertised_count(), mean[accel_index].count(),
+					  (double)mean[accel_index].variance().length());
+			}
+		}
+	}
+
+	bool calibration_updated = false;
+
+	px4::Bitset<MAX_ACCEL_SENS> calibrated;
+
+	static constexpr float g = CONSTANTS_ONE_G;
+	matrix::Matrix<float, 6, 3> Y;
+	Y.row(0) = Vector3f{ g,  0,  0}; // ORIENTATION_TAIL_DOWN
+	Y.row(1) = Vector3f{-g,  0,  0}; // ORIENTATION_NOSE_DOWN,
+	Y.row(2) = Vector3f{ 0,  g,  0}; // ORIENTATION_LEFT,
+	Y.row(3) = Vector3f{ 0, -g,  0}; // ORIENTATION_RIGHT,
+	Y.row(4) = Vector3f{ 0,  0,  g}; // ORIENTATION_UPSIDE_DOWN,
+	Y.row(5) = Vector3f{ 0,  0, -g}; // ORIENTATION_RIGHTSIDE_UP
+
+	for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+		if (valid_cal[accel_index]) {
+
+			const Vector3f accel_avg = mean[accel_index].mean();
+
+			int closest_orientation = -1;
+			float smallest_orientation_error = INFINITY;
+
+			for (int i = 0; i < 6; i++) {
+				// assume sensor/board is in one of these orientations
+				float accel_error = (Vector3f{Y.row(i)} - accel_avg).length();
+
+				if (accel_error < smallest_orientation_error) {
+					closest_orientation = i;
+					smallest_orientation_error = accel_error;
+				}
+			}
 
 			Vector3f offset{0.f, 0.f, 0.f};
 
-			uORB::SubscriptionData<vehicle_attitude_s> attitude_sub{ORB_ID(vehicle_attitude)};
-			attitude_sub.update();
+			if (closest_orientation != -1) {
+				PX4_INFO("assuming accel %d is orientation %s (%d)", accel_index,
+					 detect_orientation_str((enum detect_orientation_return)closest_orientation),
+					 closest_orientation);
 
-			if (attitude_sub.advertised() && attitude_sub.get().timestamp != 0) {
-				// use vehicle_attitude if available
-				const vehicle_attitude_s &att = attitude_sub.get();
-				const matrix::Quatf q{att.q};
-				const Vector3f accel_ref = q.conjugate_inversed(Vector3f{0.f, 0.f, -CONSTANTS_ONE_G});
-
-				// sanity check angle between acceleration vectors
-				const float angle = AxisAnglef(Quatf(accel_avg, accel_ref)).angle();
-
-				if (angle <= math::radians(10.f)) {
-					offset = accel_avg - accel_ref;
-					calibrated = true;
-				}
+				offset = accel_avg - (calibrations[accel_index].scale().I() * Vector3f{Y.row(closest_orientation)});
+				calibrated.set(accel_index, true);
 			}
 
-			if (!calibrated) {
-				// otherwise simply normalize to gravity and remove offset
-				Vector3f accel{accel_avg};
-				accel.normalize();
-				accel = accel * CONSTANTS_ONE_G;
+			const Vector3f accel_avg_calibrated = calibrations[accel_index].scale() * (accel_avg - offset);
 
-				offset = accel_avg - accel;
-				calibrated = true;
-			}
-
-			calibration::Accelerometer calibration{arp.device_id};
-
-			// reset cal index to uORB
-			calibration.set_calibration_index(accel_index);
-
-			if (!calibrated || (offset.norm() > CONSTANTS_ONE_G)
-			    || !PX4_ISFINITE(offset(0))
-			    || !PX4_ISFINITE(offset(1))
-			    || !PX4_ISFINITE(offset(2))) {
+			if (!calibrated[accel_index] || !accel_avg_calibrated.longerThan(CONSTANTS_ONE_G * 0.9f)
+			    || accel_avg_calibrated.longerThan(CONSTANTS_ONE_G * 1.1f)
+			    || !PX4_ISFINITE(offset(0)) || !PX4_ISFINITE(offset(1)) || !PX4_ISFINITE(offset(2))) {
 
 				PX4_ERR("accel %d quick calibrate failed", accel_index);
+				failed = true;
+				break;
 
 			} else {
-				calibration.set_offset(offset);
+				// reset cal index to uORB
+				calibrations[accel_index].set_calibration_index(accel_index);
 
-				if (calibration.ParametersSave()) {
-					calibration.PrintStatus();
-					param_save = true;
-					failed = false;
-
-				} else {
-					failed = true;
-					calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "calibration save failed");
-					break;
+				if (calibrations[accel_index].set_offset(offset)) {
+					calibrations[accel_index].PrintStatus();
+					calibration_updated = true;
 				}
+
+				failed = false;
 			}
 		}
 	}
@@ -591,15 +691,29 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 		failed = true;
 	}
 
-	if (param_save) {
-		param_notify_changes();
-	}
-
 	if (!failed) {
+		if (calibration_updated) {
+			bool param_save = false;
+
+			for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+				if (calibrated[accel_index]) {
+					if (calibrations[accel_index].ParametersSave()) {
+						param_save = true;
+					}
+				}
+			}
+
+			if (param_save) {
+				param_notify_changes();
+			}
+		}
+
+		calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
 		return PX4_OK;
 	}
 
 #endif // !CONSTRAINED_FLASH
 
+	calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, sensor_name);
 	return PX4_ERROR;
 }

--- a/src/modules/sensors/sensor_params_acc0.c
+++ b/src/modules/sensors/sensor_params_acc0.c
@@ -166,3 +166,31 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_YSCALE, 1.0f);
  * @volatile
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_ZSCALE, 1.0f);
+
+/**
+ * Accelerometer X-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_XODIAG, 0.0f);
+
+/**
+ * Accelerometer Y-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_YODIAG, 0.0f);
+
+/**
+ * Accelerometer Z-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_ZODIAG, 0.0f);
+

--- a/src/modules/sensors/sensor_params_acc1.c
+++ b/src/modules/sensors/sensor_params_acc1.c
@@ -166,3 +166,30 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_YSCALE, 1.0f);
  * @volatile
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_ZSCALE, 1.0f);
+
+/**
+ * Accelerometer X-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_XODIAG, 0.0f);
+
+/**
+ * Accelerometer Y-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_YODIAG, 0.0f);
+
+/**
+ * Accelerometer Z-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_ZODIAG, 0.0f);

--- a/src/modules/sensors/sensor_params_acc2.c
+++ b/src/modules/sensors/sensor_params_acc2.c
@@ -166,3 +166,31 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
  * @volatile
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_ZSCALE, 1.0f);
+
+/**
+ * Accelerometer X-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_XODIAG, 0.0f);
+
+/**
+ * Accelerometer Y-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_YODIAG, 0.0f);
+
+/**
+ * Accelerometer Z-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_ZODIAG, 0.0f);
+

--- a/src/modules/sensors/sensor_params_acc3.c
+++ b/src/modules/sensors/sensor_params_acc3.c
@@ -166,3 +166,31 @@ PARAM_DEFINE_FLOAT(CAL_ACC3_YSCALE, 1.0f);
  * @volatile
  */
 PARAM_DEFINE_FLOAT(CAL_ACC3_ZSCALE, 1.0f);
+
+/**
+ * Accelerometer X-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC3_XODIAG, 0.0f);
+
+/**
+ * Accelerometer Y-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC3_YODIAG, 0.0f);
+
+/**
+ * Accelerometer Z-axis off diagonal factor
+ *
+ * @category system
+ * @group Sensor Calibration
+ * @volatile
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC3_ZODIAG, 0.0f);
+


### PR DESCRIPTION
 - use online Welford mean to gather clean readings per orientation
 - reset if movement during per side data gathering 
 - invert full matrix to determine calibration
 - store and use off diagonal calibration scale factors (undecided if this is worth keeping)
 - detect invalid rotations (and soon auto correct like mag)
 - accel quick calibration (commander calibrate accel quick) assume vehicle is aligned with gravity and adjust offsets immediately