### PR TITLE
Jenkins fix compile job

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -158,6 +158,8 @@ pipeline {
 def createBuildNode(Boolean archive, String docker_image, String target) {
   return {
 
+    bypass_entrypoint = ''
+
     node {
       docker.withRegistry('https://registry.hub.docker.com', 'docker_hub_dagar') {
         docker.image(docker_image).inside('-e CCACHE_BASEDIR=${WORKSPACE} -v ${CCACHE_DIR}:${CCACHE_DIR}:rw' + bypass_entrypoint) {


### PR DESCRIPTION
Broken during the Snapdragon purge (https://github.com/PX4/PX4-Autopilot/pull/17921) that happened to correspond with the primary Jenkins master (ci.px4.io) being down. 