### PR TITLE
Tune down solo roll rate controller

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1014_solo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1014_solo
@@ -8,6 +8,6 @@
 . ${R}etc/init.d/rc.mc_defaults
 
 param set-default MC_PITCHRATE_P 0.1
-param set-default MC_ROLLRATE_P 0.1
+param set-default MC_ROLLRATE_P 0.05
 
 set MIXER quad_x


### PR DESCRIPTION
**Describe problem solved by this pull request**
The solo model was showing oscillations while flying. 
This issue was discussed in https://discuss.px4.io/t/sitl-gazebo-3dr-solo-oscillation-issue/23557

**Describe your solution**
Tuning down the roll controller to remove the oscillations

**Test data / coverage**
Before PR: https://review.px4.io/plot_app?log=7a09b3f9-6f6f-4c5e-9d18-dbbd5c69094f
After PR: https://review.px4.io/plot_app?log=f270ad7e-6dfc-4c51-9770-50a391955789

