### PR TITLE
ekf2: increase stack size to 3600

### DIFF
--- a/src/modules/ekf2/CMakeLists.txt
+++ b/src/modules/ekf2/CMakeLists.txt
@@ -42,7 +42,7 @@ px4_add_module(
 	INCLUDES
 		EKF
 	STACK_MAX
-		3500
+		3600
 	SRCS
 		EKF/airspeed_fusion.cpp
 		EKF/baro_bias_estimator.cpp


### PR DESCRIPTION
Fixing the error 

```
error: the frame size of 3536 bytes is larger than 3500 bytes [-Werror=frame-larger-than=]
```

@dagar Or should we keep the stack size here as low as possible? On fmu-v3 the required frame size was 3544. Not sure what causes these fluctuations.