### PR TITLE
GNSS yaw jump and failure handling improvements

### DIFF
--- a/msg/estimator_event_flags.msg
+++ b/msg/estimator_event_flags.msg
@@ -30,3 +30,4 @@ bool bad_yaw_using_gps_course           #  7 - true when the fiter has detected 
 bool stopping_mag_use                   #  8 - true when the filter has detected bad magnetometer data and is stopping further use of the magnetomer data
 bool vision_data_stopped                #  9 - true when the vision system data has stopped for a significant time period
 bool emergency_yaw_reset_mag_stopped    # 10 - true when the filter has detected bad magnetometer data, has reset the yaw to anothter source of data and has stopped further use of the magnetomer data
+bool emergency_yaw_reset_gps_yaw_stopped # 11 - true when the filter has detected bad GNSS yaw data, has reset the yaw to anothter source of data and has stopped further use of the GNSS yaw data

--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -46,6 +46,10 @@ uint8 CS_GND_EFFECT = 20	# 20 - true when when protection from ground effect ind
 uint8 CS_RNG_STUCK = 21		# 21 - true when a stuck range finder sensor has been detected
 uint8 CS_GPS_YAW = 22		# 22 - true when yaw (not ground course) data from a GPS receiver is being fused
 uint8 CS_MAG_ALIGNED = 23	# 23 - true when the in-flight mag field alignment has been completed
+uint8 CS_EV_VEL = 24		# 24 - true when local frame velocity data fusion from external vision measurements is intended
+uint8 CS_SYNTHETIC_MAG_Z = 25	# 25 - true when we are using a synthesized measurement for the magnetometer Z component
+uint8 CS_VEHICLE_AT_REST = 26	# 26 - true when the vehicle is at rest
+uint8 CS_GPS_YAW_FAULT = 27	# 27 - true when the GNSS heading has been declared faulty and is no longer being used
 
 uint32 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/msg/estimator_status_flags.msg
+++ b/msg/estimator_status_flags.msg
@@ -31,7 +31,7 @@ bool cs_mag_aligned_in_flight # 23 - true when the in-flight mag field alignment
 bool cs_ev_vel                # 24 - true when local frame velocity data fusion from external vision measurements is intended
 bool cs_synthetic_mag_z       # 25 - true when we are using a synthesized measurement for the magnetometer Z component
 bool cs_vehicle_at_rest       # 26 - true when the vehicle is at rest
-
+bool cs_gps_yaw_fault         # 27 - true when the GNSS heading has been declared faulty and is no longer being used
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3790,6 +3790,8 @@ void Commander::estimator_check()
 	}
 
 	const bool mag_fault_prev = (_estimator_status_sub.get().control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT));
+	const bool gnss_heading_fault_prev = (_estimator_status_sub.get().control_mode_flags &
+					      (1 << estimator_status_s::CS_GPS_YAW_FAULT));
 
 	// use primary estimator_status
 	if (_estimator_selector_status_sub.updated()) {
@@ -3807,10 +3809,16 @@ void Commander::estimator_check()
 
 		// Check for a magnetomer fault and notify the user
 		const bool mag_fault = (estimator_status.control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT));
+		const bool gnss_heading_fault = (estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS_YAW_FAULT));
 
 		if (!mag_fault_prev && mag_fault) {
 			mavlink_log_critical(&_mavlink_log_pub, "Stopping compass use! Check calibration on landing");
 			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG, true, true, false, _status);
+		}
+
+		if (!gnss_heading_fault_prev && gnss_heading_fault) {
+			mavlink_log_critical(&_mavlink_log_pub, "Stopping GNSS heading use! Check configuration on landing");
+			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_GPS, true, true, false, _status);
 		}
 
 		/* Check estimator status for signs of bad yaw induced post takeoff navigation failure

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -552,6 +552,7 @@ union warning_event_status_u {
 		bool stopping_mag_use			: 1; ///< 8 - true when the filter has detected bad magnetometer data and is stopping further use of the magnetomer data
 		bool vision_data_stopped		: 1; ///< 9 - true when the vision system data has stopped for a significant time period
 		bool emergency_yaw_reset_mag_stopped	: 1; ///< 10 - true when the filter has detected bad magnetometer data, has reset the yaw to anothter source of data and has stopped further use of the magnetomer data
+		bool emergency_yaw_reset_gps_yaw_stopped: 1; ///< 11 - true when the filter has detected bad GNSS yaw data, has reset the yaw to anothter source of data and has stopped further use of the GNSS yaw data
 	} flags;
 	uint32_t value;
 };

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -487,6 +487,7 @@ union filter_control_status_u {
 		uint32_t ev_vel      : 1; ///< 24 - true when local frame velocity data fusion from external vision measurements is intended
 		uint32_t synthetic_mag_z : 1; ///< 25 - true when we are using a synthesized measurement for the magnetometer Z component
 		uint32_t vehicle_at_rest : 1; ///< 26 - true when the vehicle is at rest
+		uint32_t gps_yaw_fault : 1; ///< 27 - true when the GNSS heading has been declared faulty and is no longer being used
 	} flags;
 	uint32_t value;
 };

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -276,6 +276,9 @@ struct parameters {
 	float mag_yaw_rate_gate{0.25f};		///< yaw rate threshold used by mode select logic (rad/sec)
 	const float quat_max_variance{0.0001f};	///< zero innovation yaw measurements will not be fused when the sum of quaternion variance is less than this
 
+	// GNSS heading fusion
+	float gps_heading_noise{0.1f};		///< measurement noise standard deviation used for GNSS heading fusion (rad)
+
 	// airspeed fusion
 	float tas_innov_gate{5.0f};		///< True Airspeed innovation consistency gate size (STD)
 	float eas_noise{1.4f};			///< EAS measurement noise standard deviation used for airspeed fusion (m/s)

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -751,7 +751,7 @@ void Ekf::controlGpsFusion()
 void Ekf::controlGpsYawFusion(bool gps_checks_passing, bool gps_checks_failing)
 {
 	if (!(_params.fusion_mode & MASK_USE_GPSYAW)
-	    || _is_gps_yaw_faulty) {
+	    || _control_status.flags.gps_yaw_fault) {
 
 		stopGpsYawFusion();
 		return;
@@ -793,7 +793,7 @@ void Ekf::controlGpsYawFusion(bool gps_checks_passing, bool gps_checks_failing)
 					} else if (starting_conditions_passing) {
 						// Data seems good, but previous reset did not fix the issue
 						// something else must be wrong, declare the sensor faulty and stop the fusion
-						_is_gps_yaw_faulty = true;
+						_control_status.flags.gps_yaw_fault = true;
 						stopGpsYawFusion();
 
 					} else {

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -784,7 +784,10 @@ void Ekf::controlGpsYawFusion(bool gps_checks_passing, bool gps_checks_failing)
 					if (_nb_gps_yaw_reset_available > 0) {
 						// Data seems good, attempt a reset
 						resetYawToGps();
-						_nb_gps_yaw_reset_available--;
+
+						if (_control_status.flags.in_air) {
+							_nb_gps_yaw_reset_available--;
+						}
 
 					} else if (starting_conditions_passing) {
 						// Data seems good, but previous reset did not fix the issue

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -566,10 +566,11 @@ void Ekf::controlGpsFusion()
 
 		// handle case where we are not currently using GPS, but need to align yaw angle using EKF-GSF before
 		// we can start using GPS
-		const bool align_yaw_using_gsf = !_control_status.flags.gps && _do_ekfgsf_yaw_reset
-						 && isTimedOut(_ekfgsf_yaw_reset_time, 5000000);
+		const bool align_yaw_using_gsf = !_control_status.flags.yaw_align
+		                                 && (_params.mag_fusion_type == MAG_FUSE_TYPE_NONE);
 
-		if (align_yaw_using_gsf) {
+		if ((align_yaw_using_gsf || _do_ekfgsf_yaw_reset)
+		    && isTimedOut(_ekfgsf_yaw_reset_time, 5000000)){
 			if (resetYawToEKFGSF()) {
 				_ekfgsf_yaw_reset_time = _time_last_imu;
 				_do_ekfgsf_yaw_reset = false;

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -535,7 +535,6 @@ private:
 	// height sensor status
 	bool _baro_hgt_faulty{false};		///< true if valid baro data is unavailable for use
 	bool _gps_hgt_intermittent{false};	///< true if gps height into the buffer is intermittent
-	bool _is_gps_yaw_faulty{false};		///< true if gps yaw data is rejected by the filter for too long
 
 	// imu fault status
 	uint64_t _time_bad_vert_accel{0};	///< last time a bad vertical accel was detected (uSec)

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1709,7 +1709,7 @@ bool Ekf::resetYawToEKFGSF()
 			_warning_events.flags.emergency_yaw_reset_mag_stopped = true;
 
 		} else if (_control_status.flags.gps_yaw) {
-			_is_gps_yaw_faulty = true;
+			_control_status.flags.gps_yaw_fault = true;
 			_warning_events.flags.emergency_yaw_reset_gps_yaw_stopped = true;
 
 		} else if (_control_status.flags.ev_yaw) {

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -328,6 +328,7 @@ protected:
 
 	// innovation consistency check monitoring ratios
 	float _yaw_test_ratio{};		// yaw innovation consistency check ratio
+	AlphaFilter<float>_yaw_signed_test_ratio_lpf{0.1f}; // average signed test ratio used to detect a bias in the state
 	Vector3f _mag_test_ratio{};		// magnetometer XYZ innovation consistency check ratios
 	Vector2f _gps_vel_test_ratio{};		// GPS velocity innovation consistency check ratios
 	Vector2f _gps_pos_test_ratio{};		// GPS position innovation consistency check ratios

--- a/src/modules/ekf2/EKF/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/gps_checks.cpp
@@ -91,15 +91,9 @@ bool Ekf::collect_gps(const gps_message &gps)
 		_mag_strength_gps = get_mag_strength_gauss(lat, lon);
 
 		// request a reset of the yaw using the new declination
-		if (_params.mag_fusion_type == MAG_FUSE_TYPE_NONE) {
-			// try to reset the yaw using the EKF-GSF yaw estimator
-			_do_ekfgsf_yaw_reset = true;
-			_ekfgsf_yaw_reset_time = 0;
-
-		} else {
-			if (!declination_was_valid) {
-				_mag_yaw_reset_req = true;
-			}
+		if ((_params.mag_fusion_type != MAG_FUSE_TYPE_NONE)
+		     && !declination_was_valid) {
+			_mag_yaw_reset_req = true;
 		}
 
 		// save the horizontal and vertical position uncertainty of the origin

--- a/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
+++ b/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
@@ -70,7 +70,7 @@ void Ekf::fuseGpsYaw()
 
 	// using magnetic heading process noise
 	// TODO extend interface to use yaw uncertainty provided by GPS if available
-	const float R_YAW = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
+	const float R_YAW = sq(fmaxf(_params.gps_heading_noise, 1.0e-2f));
 
 	// calculate intermediate variables
 	const float HK0 = sinf(_gps_yaw_offset);
@@ -209,7 +209,7 @@ bool Ekf::resetYawToGps()
 	// GPS yaw measurement is alreday compensated for antenna offset in the driver
 	const float measured_yaw = _gps_sample_delayed.yaw;
 
-	const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
+	const float yaw_variance = sq(fmaxf(_params.gps_heading_noise, 1.0e-2f));
 	resetQuatStateYaw(measured_yaw, yaw_variance, true);
 
 	_time_last_gps_yaw_fuse = _time_last_imu;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -634,6 +634,7 @@ void EKF2::PublishEventFlags(const hrt_abstime &timestamp)
 		event_flags.stopping_mag_use                    = _ekf.warning_event_flags().stopping_mag_use;
 		event_flags.vision_data_stopped                 = _ekf.warning_event_flags().vision_data_stopped;
 		event_flags.emergency_yaw_reset_mag_stopped     = _ekf.warning_event_flags().emergency_yaw_reset_mag_stopped;
+		event_flags.emergency_yaw_reset_gps_yaw_stopped = _ekf.warning_event_flags().emergency_yaw_reset_gps_yaw_stopped;
 
 		event_flags.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 		_estimator_event_flags_pub.publish(event_flags);
@@ -1165,6 +1166,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_ev_vel                = _ekf.control_status_flags().ev_vel;
 		status_flags.cs_synthetic_mag_z       = _ekf.control_status_flags().synthetic_mag_z;
 		status_flags.cs_vehicle_at_rest       = _ekf.control_status_flags().vehicle_at_rest;
+		status_flags.cs_gps_yaw_fault         = _ekf.control_status_flags().gps_yaw_fault;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;

--- a/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
@@ -213,7 +213,26 @@ TEST_F(EkfGpsHeadingTest, fallBackToMag)
 	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
 }
 
-TEST_F(EkfGpsHeadingTest, yaw_jump)
+TEST_F(EkfGpsHeadingTest, yaw_jump_on_ground)
+{
+	// GIVEN: the GPS yaw fusion activated
+	float gps_heading = _ekf_wrapper.getYawAngle();
+	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator.runSeconds(1);
+	_ekf->set_in_air_status(false);
+
+	// WHEN: the measurement suddenly changes
+	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
+	gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + math::radians(45.f));
+	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator.runSeconds(2);
+
+	// THEN: the fusion should reset
+	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeadingFusion());
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
+}
+
+TEST_F(EkfGpsHeadingTest, yaw_jump_in_air)
 {
 	// GIVEN: the GPS yaw fusion activated
 	float gps_heading = _ekf_wrapper.getYawAngle();

--- a/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
@@ -141,7 +141,7 @@ TEST_F(EkfGpsHeadingTest, yawConvergence)
 	// AND WHEN: the the measurement changes
 	gps_heading += math::radians(2.f);
 	_sensor_simulator._gps.setYaw(gps_heading);
-	_sensor_simulator.runSeconds(10);
+	_sensor_simulator.runSeconds(20);
 
 	// THEN: the estimate slowly converges to the new measurement
 	// Note that the process is slow, because the gyro did not detect any motion
@@ -225,11 +225,12 @@ TEST_F(EkfGpsHeadingTest, yaw_jump_on_ground)
 	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
 	gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + math::radians(45.f));
 	_sensor_simulator._gps.setYaw(gps_heading);
-	_sensor_simulator.runSeconds(2);
+	_sensor_simulator.runSeconds(8);
 
 	// THEN: the fusion should reset
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeadingFusion());
 	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
+	EXPECT_LT(fabsf(matrix::wrap_pi(_ekf_wrapper.getYawAngle() - gps_heading)), math::radians(1.f));
 }
 
 TEST_F(EkfGpsHeadingTest, yaw_jump_in_air)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Some GNSS receiver (providing heading information) start to output an incorrect value first and then reset a few seconds later (seen on some F9p setup). Also, until now, the yaw emergency estimator was only able to stop a bad heading induced by a faulty magnetometer but not other heading sources.

**Describe your solution**
- use dedicated observation noise instead of mag heading observation noise value
- trigger gyro bias variance reset based on "innovation sequence monitoring" (i.e.: average signed test ratio above some threshold)
- allow multiple resets to GNSS yaw before takeoff
- allow yaw emergency logic to disable GNSS yaw aiding
- added test cases for "GNSS yaw reset on ground" and "GNSS yaw wrong value to yaw emergency reset"
- monitor fault in commander and report failure to user (as for mag_fault) `WARN  [commander] Stopping GNSS heading use! Check configuration on landing`

**Test data / coverage**
To SITL test it, simply change
https://github.com/PX4/PX4-Autopilot/blob/6aa4e12b5fb9b0a8573fc8c486fab1aeb5f0cebb/src/modules/simulator/simulator_mavlink.cpp#L421-L422
to
```
		gps.heading = math::radians(-179.f);
		gps.heading_offset = 0.f;
```
or use a if/else to change the orientation based on some time-dependent metric (such as eph)


SITL tests:
GNSS yaw 15deg to 40deg and then stuck => in air yaw emergency
https://logs.px4.io/plot_app?log=ed9c2952-8cc7-4200-8bed-7b57faeebce2
![DeepinScreenshot_select-area_20210802163059](https://user-images.githubusercontent.com/14822839/127878029-19b38d72-9fc6-4366-9d76-a5a02b96982e.png)


initial large Z gyro bias (0.05rad/s = 2.86deg/s), GNSS yaw 15deg to 30deg and then stuck => in air yaw emergency
https://logs.px4.io/plot_app?log=c57b6379-4c1a-4fe6-99cb-bbb2aca27cf4
![DeepinScreenshot_select-area_20210802113056](https://user-images.githubusercontent.com/14822839/127838983-f2f488b6-1693-4cac-9556-fcfe3b2767f3.png)
