### PR TITLE
fixes for i2c reset init branch

### DIFF
--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
@@ -88,10 +88,7 @@ int MPL3115A2::probe()
 	uint8_t whoami = 0;
 
 	if ((RegisterRead(MPL3115A2_REG_WHO_AM_I, &whoami) > 0) && (whoami == MPL3115A2_WHO_AM_I)) {
-		/*
-		 * Disable retries; we may enable them selectively in some cases,
-		 * but the device gets confused if we retry some of the commands.
-		 */
+
 		return PX4_OK;
 	}
 
@@ -198,10 +195,6 @@ int MPL3115A2::measure()
 	// Send the command to read the ADC for P and T.
 	unsigned addr = (MPL3115A2_CTRL_REG1 << 8) | MPL3115A2_CTRL_TRIGGER;
 
-	/*
-	 * Disable retries on this command; we can't know whether failure
-	 * means the device did or did not see the command.
-	 */
 	int ret = RegisterWrite((addr >> 8) & 0xff, addr & 0xff);
 
 	if (ret == -EIO) {

--- a/src/drivers/barometer/ms5611/ms5611_i2c.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_i2c.cpp
@@ -143,13 +143,11 @@ MS5611_I2C::probe()
 {
 	if ((PX4_OK == _probe_address(MS5611_ADDRESS_1)) ||
 	    (PX4_OK == _probe_address(MS5611_ADDRESS_2))) {
-		/*
-		 * Disable retries; we may enable them selectively in some cases,
-		 * but the device gets confused if we retry some of the commands.
-		 */
-		_retries = 1;
+
 		return PX4_OK;
 	}
+
+	_retries = 1;
 
 	return -EIO;
 }


### PR DESCRIPTION
A couple of fixes for the i2c reset init branch

Edit:
removed my commit: (ist8308: fix return PX4_ERROR if can't get device id)
It is already fixed here