### PR TITLE
Fix afbrs50 high cpu load from switching

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -81,7 +81,7 @@ private:
 	void set_mode(argus_mode_t mode);
 
 	argus_hnd_t *_hnd{nullptr};
-	argus_mode_t _mode{ARGUS_MODE_A}; // Long-Range
+	argus_mode_t _mode{ARGUS_MODE_B}; // Short-Range
 
 	enum class STATE : uint8_t {
 		TEST,
@@ -96,7 +96,7 @@ private:
 
 	perf_counter_t _sample_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": sample interval")};
 
-	int _measure_interval{1000000 / 100}; // 100Hz
+	int _measure_interval{1000000 / 50}; // 50Hz
 	float _current_distance{0};
 	const float _short_range_threshold = 4.0; //meters
 	const float _long_range_threshold = 6.0; //meters


### PR DESCRIPTION
This PR fixes the high cpu load on the afbrs50 driver from the mode switching. There was no check to see what mode it was in.
I also added in the get mode call to the status function.

```
nsh> afbrs50 status
afbrs50: sample interval: 6114 events, 10662.56us avg, min 4269us max 648024us 16543.408us rms
distance: 2.772m
mode: 2
dfm mode: 2
rate: 50 Hz

nsh> afbrs50 status
afbrs50: sample interval: 6557 events, 10621.64us avg, min 4269us max 648024us 15976.356us rms
distance: 9.524m
mode: 1
dfm mode: 2
rate: 25 Hz
```

Whats in current master
```
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                   23957 17.683   300/  512   0 (  0)  READY  3
   1 hpwork                       1298  2.452  1812/ 2988 254 (254)  w:sig  3
   2 lpwork                          0  0.000   564/ 1620  50 ( 50)  w:sig  3
   3 init                            0  0.000  1508/ 2612 100 (100)  w:sem  3
   4 wq:manager                      0  0.000   388/ 1260 255 (255)  w:sem  3
  20 top                           204  0.409  1468/ 4084 237 (237)  RUN    3
  13 wq:SPI1                      1239  2.412  1940/ 2340 253 (253)  w:sem  3
  16 wq:hp_default               40874 73.929  1268/ 1900 237 (237)  READY  3
  19 wq:uavcan                    1348  2.659  2156/ 3628 236 (236)  READY  3

Processes: 9 total, 4 running, 5 sleeping, max FDs: 12
CPU usage: 81.86% tasks, 0.45% sched, 17.68% idle
Uptime: 134.330s total, 23.957s idle
nsh>
```

Running normally but not currently switching modes
```
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                  310410 77.822   300/  512   0 (  0)  READY  3
   1 hpwork                        184  3.468  1812/ 2988 254 (254)  w:sig  3
   2 lpwork                          0  0.000   564/ 1620  50 ( 50)  w:sig  3
   3 init                            0  0.000  1508/ 2612 100 (100)  w:sem  3
   4 wq:manager                      0  0.000   396/ 1260 255 (255)  w:sem  3
  25 top                            77  1.508  1468/ 4084 237 (237)  RUN    3
  13 wq:SPI1                       476  8.994  1812/ 2340 253 (253)  w:sem  3
  16 wq:hp_default                   1  0.019  1268/ 1900 237 (237)  READY  3
  19 wq:uavcan                     387  7.084  2148/ 3628 236 (236)  READY  3

Processes: 9 total, 4 running, 5 sleeping, max FDs: 12
CPU usage: 21.07% tasks, 1.10% sched, 77.82% idle
Uptime: 411.455s total, 310.410s idle
```

Running and switching modes
```
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                  340557 46.510   300/  512   0 (  0)  READY  3
   1 hpwork                       1549  2.579  1812/ 2988 254 (254)  w:sig  3
   2 lpwork                          0  0.000   564/ 1620  50 ( 50)  w:sig  3
   3 init                            0  0.000  1508/ 2612 100 (100)  w:sem  3
   4 wq:manager                      0  0.000   396/ 1260 255 (255)  w:sem  3
  25 top                           664  0.911  1468/ 4084 237 (237)  RUN    3
  13 wq:SPI1                      3974  5.511  1812/ 2340 253 (253)  w:sem  3
  16 wq:hp_default                1366 39.883  1268/ 1900 237 (237)  w:sem  3
  19 wq:uavcan                    3178  3.871  2148/ 3628 236 (236)  READY  3

Processes: 9 total, 3 running, 6 sleeping, max FDs: 12
CPU usage: 52.76% tasks, 0.73% sched, 46.51% idle
Uptime: 451.647s total, 340.557s idle
```

@samchamberlin Can you test fly this PR?