### PR TITLE
Commander: change attitude quaternion check to avoid numerical issues

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3880,9 +3880,15 @@ void Commander::estimator_check()
 	vehicle_attitude_s attitude{};
 	_vehicle_attitude_sub.copy(&attitude);
 	const matrix::Quatf q{attitude.q};
-	const matrix::Quatf q_norm{q.unit()};
+	const bool no_element_larger_than_one = (fabsf(q(0)) <= 1.f)
+						&& (fabsf(q(1)) <= 1.f)
+						&& (fabsf(q(2)) <= 1.f)
+						&& (fabsf(q(3)) <= 1.f);
+	const bool norm_in_tolerance = (fabsf(1.f - q.norm()) <= FLT_EPSILON);
+
 	_status_flags.condition_attitude_valid = (hrt_elapsed_time(&attitude.timestamp) < 1_s)
-			&& (matrix::Quatf(q - q_norm).length() < FLT_EPSILON);
+			&& norm_in_tolerance
+			&& no_element_larger_than_one;
 
 	// angular velocity
 	vehicle_angular_velocity_s angular_velocity{};


### PR DESCRIPTION
**How this PR solves the problem**
The check for the attitude validity (part of the "AHRS preflight check") is quite sensitive to numerical issues as it makes a lot of computations that can lead to a loss of precision before doing the actual check.
Investigations showed that the `.normalize()` or `.unit()` functions of the quaternion class does not produce a perfect unit quaternion, but is always in the `FLT_EPSILON` tolerance. This PR then changes the attitude check to verify that the norm is in tolerance and that each element of the quaternion is strictly smaller or equal to 1 (in order to avoid NAN in trigonometric functions).

The fix is easily verified in SITL:

Before:
![DeepinScreenshot_select-area_20210804161632](https://user-images.githubusercontent.com/14822839/128199116-6f4f77cd-3ba5-4895-8ac5-927737f2fbfa.png)

With this PR:
![DeepinScreenshot_select-area_20210804161721](https://user-images.githubusercontent.com/14822839/128199127-ba708ec6-91a7-49c3-b452-ddb3b83878c5.png)