### PR TITLE
Fix flaps being deployed in manual flight modes for fixedwing

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -655,7 +655,7 @@ void FixedwingAttitudeControl::control_flaps(const float dt)
 	/* map flaps by default to manual if valid */
 	if (PX4_ISFINITE(_manual_control_setpoint.flaps) && _vcontrol_mode.flag_control_manual_enabled
 	    && fabsf(_param_fw_flaps_scl.get()) > 0.01f) {
-		flap_control = 0.5f * (_manual_control_setpoint.flaps + 1.0f) * _param_fw_flaps_scl.get();
+		flap_control = _manual_control_setpoint.flaps * _param_fw_flaps_scl.get();
 
 	} else if (_vcontrol_mode.flag_control_auto_enabled
 		   && fabsf(_param_fw_flaps_scl.get()) > 0.01f) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
For fixedwings, there were different flap scalings deployed between auto modes and manual flight modes, resulting in the flaps always being deployed halfway in manual flight modes.

- In manual flight modes(stabilized, manual), zero flap input was mapped to flap command 0.5
- In auto modes(mission, hold), zero flap command was mapped to flap command 0.0

**Describe your solution**
This PR removes the special scaling in manual flight modes, so that the flap does not get deployed when switching fixed wing aircraft between manual and auto modes.

This should not influence flaps being deployed in auto modes.

**Describe possible alternatives**
By removing the scaling, we are assuming that flap commands range from [-1, 1]. This makes more sense since the mixers actually allow you to give -1 flap commands. If we want to prevent this behavior, IMO we need to add an explicit mode for it rather than secretly scaling this inside the attitude controller.

**Test data / coverage**
Tested by flying a plane model in Gazebo SITL
```
make px4_sitl gazebo_plane
```
Flown using a virtual joystick on QGroundControl. Note that the flap channels getting deployed in manual flight modes

- Before PR: https://logs.px4.io/plot_app?log=e5f35769-c0fa-4585-aab8-6478d50041aa
![bokeh_plot (1)](https://user-images.githubusercontent.com/5248102/128637127-af367e33-2924-483b-a426-e04bb21c537f.png)


- After PR: https://logs.px4.io/plot_app?log=df16c2cb-1d7e-4733-9269-ff9003b0d3b9
![bokeh_plot](https://user-images.githubusercontent.com/5248102/128637045-9cc9ced2-6fdd-4a0e-87d4-39e28f9b3e30.png)

**Additional context**
- This was not apparent before there were flaps in the SITL plane model, but this is more visible after it has been added.
