### PR TITLE
mavlink: receiver move geo.h include to header

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -43,7 +43,6 @@
 #include <airspeed/airspeed.h>
 #include <conversion/rotation.h>
 #include <drivers/drv_rc_input.h>
-#include <geo/geo.h>
 #include <systemlib/px4_macros.h>
 
 #include <math.h>

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -48,6 +48,7 @@
 #include "mavlink_timesync.h"
 #include "tune_publisher.h"
 
+#include <geo/geo.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/barometer/PX4Barometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>


### PR DESCRIPTION

This commit d997a8d308b132d4f7009eb6b4d04687519346b0 adds variable `map_projection_reference_s _global_local_proj_ref{}` to `mavlink_receiver.h`, so `geo.h` should be include in header.