### PR TITLE
magnetometer calibration handle internal mags that are disabled (still used for mag auto rotation)

### DIFF
--- a/src/drivers/imu/lsm303d/LSM303D.cpp
+++ b/src/drivers/imu/lsm303d/LSM303D.cpp
@@ -558,7 +558,6 @@ LSM303D::measureMagnetometer()
 	_px4_mag.set_temperature(_last_temperature);
 
 	_px4_mag.set_error_count(perf_event_count(_bad_registers) + perf_event_count(_bad_values));
-	_px4_mag.set_external(external());
 	_px4_mag.update(timestamp_sample, raw_mag_report.x, raw_mag_report.y, raw_mag_report.z);
 
 	_mag_last_measure = timestamp_sample;

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -337,7 +337,7 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 			break;
 		}
 
-		if (mag_sub[0].updatedBlocking(1000_ms)) {
+		if (mag_sub[0].updatedBlocking(100_ms)) {
 			bool rejected = false;
 			Vector3f new_samples[MAX_MAGS] {};
 
@@ -347,6 +347,8 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 					sensor_mag_s mag;
 
 					while (mag_sub[cur_mag].update(&mag)) {
+						worker_data->calibration[cur_mag].set_device_id(mag.device_id, mag.is_external);
+
 						if (worker_data->append_to_existing_calibration) {
 							// keep and update the existing calibration when we are not doing a full 6-axis calibration
 							const Matrix3f &scale = worker_data->calibration[cur_mag].scale();
@@ -525,6 +527,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 	for (uint8_t cur_mag = 0; cur_mag < MAX_MAGS; cur_mag++) {
 
 		uORB::SubscriptionData<sensor_mag_s> mag_sub{ORB_ID(sensor_mag), cur_mag};
+		mag_sub.update();
 
 		if (mag_sub.advertised() && (mag_sub.get().device_id != 0) && (mag_sub.get().timestamp > 0)) {
 			worker_data.calibration[cur_mag].set_device_id(mag_sub.get().device_id, mag_sub.get().is_external);

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -296,54 +296,53 @@ void VehicleMagnetometer::Run()
 
 	for (int uorb_index = 0; uorb_index < MAX_SENSOR_COUNT; uorb_index++) {
 
-		if (!_calibration[uorb_index].enabled()) {
-			continue;
-		}
+		const bool was_advertised = _advertised[uorb_index];
 
 		if (!_advertised[uorb_index]) {
 			// use data's timestamp to throttle advertisement checks
 			if ((_last_data[uorb_index].timestamp == 0) || (hrt_elapsed_time(&_last_data[uorb_index].timestamp) > 1_s)) {
 				if (_sensor_sub[uorb_index].advertised()) {
-					if (uorb_index > 0) {
-						/* the first always exists, but for each further sensor, add a new validator */
-						if (!_voter.add_new_validator()) {
-							PX4_ERR("failed to add validator for %s %i", "MAG", uorb_index);
-						}
-					}
-
 					_advertised[uorb_index] = true;
-
-					// advertise outputs in order if publishing all
-					if (!_param_sens_mag_mode.get()) {
-						for (int instance = 0; instance < uorb_index; instance++) {
-							_vehicle_magnetometer_pub[instance].advertise();
-						}
-					}
-
-					if (_selected_sensor_sub_index < 0) {
-						_sensor_sub[uorb_index].registerCallback();
-					}
 
 				} else {
 					_last_data[uorb_index].timestamp = hrt_absolute_time();
 				}
 			}
-
 		}
 
 		if (_advertised[uorb_index]) {
 			sensor_mag_s report;
 
 			while (_sensor_sub[uorb_index].update(&report)) {
-				updated[uorb_index] = true;
 
 				if (_calibration[uorb_index].device_id() != report.device_id) {
-					_calibration[uorb_index].set_device_id(report.device_id, report.is_external);
 					_priority[uorb_index] = _calibration[uorb_index].priority();
 				}
 
+				_calibration[uorb_index].set_device_id(report.device_id, report.is_external);
+
 				if (_calibration[uorb_index].enabled()) {
-					const Vector3f vect = _calibration[uorb_index].Correct(Vector3f{report.x, report.y, report.z});
+					if (!was_advertised) {
+						if (uorb_index > 0) {
+							/* the first always exists, but for each further sensor, add a new validator */
+							if (!_voter.add_new_validator()) {
+								PX4_ERR("failed to add validator for %s %i", "MAG", uorb_index);
+							}
+						}
+
+						// advertise outputs in order if publishing all
+						if (!_param_sens_mag_mode.get()) {
+							for (int instance = 0; instance < uorb_index; instance++) {
+								_vehicle_magnetometer_pub[instance].advertise();
+							}
+						}
+
+						if (_selected_sensor_sub_index < 0) {
+							_sensor_sub[uorb_index].registerCallback();
+						}
+					}
+
+					const Vector3f vect{_calibration[uorb_index].Correct(Vector3f{report.x, report.y, report.z})};
 
 					float mag_array[3] {vect(0), vect(1), vect(2)};
 					_voter.put(uorb_index, report.timestamp, mag_array, report.error_count, _priority[uorb_index]);
@@ -357,6 +356,8 @@ void VehicleMagnetometer::Run()
 					_last_data[uorb_index].x = vect(0);
 					_last_data[uorb_index].y = vect(1);
 					_last_data[uorb_index].z = vect(2);
+
+					updated[uorb_index] = true;
 				}
 			}
 		}


### PR DESCRIPTION
Possible fix for https://github.com/PX4/PX4-Autopilot/issues/18041.

Once addressed needs backporting for v1.12.2.