### PR TITLE
Allow overriding sitl_gazebo build_cores with an environment variable

### DIFF
--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -21,13 +21,17 @@ px4_add_git_submodule(TARGET git_jmavsim PATH "${PX4_SOURCE_DIR}/Tools/jMAVSim")
 
 # Add support for external project building
 include(ExternalProject)
-include(ProcessorCount)
 
-set(build_cores 1)
-
-ProcessorCount(N)
-if(N GREATER_EQUAL 4)
-	math(EXPR build_cores "${N} - 2")
+# Allow specifying parallelization for sitl_gazebo build
+if(DEFINED ENV{BUILD_CORES})
+	set(build_cores $ENV{BUILD_CORES})
+else()
+	set(build_cores 1)
+	include(ProcessorCount)
+	ProcessorCount(N)
+	if(N GREATER_EQUAL 4)
+		math(EXPR build_cores "${N} - 2")
+	endif()
 endif()
 
 # project to build sitl_gazebo if necessary

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -49,8 +49,8 @@ if(parallel_jobs GREATER NUMBER_OF_LOGICAL_CORES)
 	set(parallel_jobs ${NUMBER_OF_LOGICAL_CORES})
 endif()
 
-message(STATUS  "${NUMBER_OF_LOGICAL_CORES} logical cores detected and ${AVAILABLE_PHYSICAL_MEMORY} megabytes of memory available.
-		Limiting concurrent jobs to ${parallel_jobs}")
+message(DEBUG  "${NUMBER_OF_LOGICAL_CORES} logical cores detected and ${AVAILABLE_PHYSICAL_MEMORY} megabytes of memory available.
+		Limiting sitl_gazebo and simulation-ignition concurrent jobs to ${parallel_jobs}")
 
 # project to build sitl_gazebo if necessary
 px4_add_git_submodule(TARGET git_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_gazebo")

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -22,17 +22,35 @@ px4_add_git_submodule(TARGET git_jmavsim PATH "${PX4_SOURCE_DIR}/Tools/jMAVSim")
 # Add support for external project building
 include(ExternalProject)
 
-# Allow specifying parallelization for sitl_gazebo build
-if(DEFINED ENV{BUILD_CORES})
-	set(build_cores $ENV{BUILD_CORES})
-else()
-	set(build_cores 1)
+# Estimate an appropriate number of parallel jobs
+cmake_host_system_information(RESULT AVAILABLE_PHYSICAL_MEMORY QUERY AVAILABLE_PHYSICAL_MEMORY)
+cmake_host_system_information(RESULT NUMBER_OF_LOGICAL_CORES QUERY NUMBER_OF_LOGICAL_CORES)
+
+set(parallel_jobs 1)
+
+if(NOT NUMBER_OF_LOGICAL_CORES)
 	include(ProcessorCount)
-	ProcessorCount(N)
-	if(N GREATER_EQUAL 4)
-		math(EXPR build_cores "${N} - 2")
-	endif()
+	ProcessorCount(NUMBER_OF_LOGICAL_CORES)
 endif()
+
+if(NOT AVAILABLE_PHYSICAL_MEMORY AND NUMBER_OF_LOGICAL_CORES GREATER_EQUAL 4)
+	# Memory estimate unavailable, use N-2 jobs
+	math(EXPR parallel_jobs "${NUMBER_OF_LOGICAL_CORES} - 2")
+endif()
+
+if (AVAILABLE_PHYSICAL_MEMORY)
+	# Allow an additional job for every 1.5GB of available physical memory
+	math(EXPR parallel_jobs "${AVAILABLE_PHYSICAL_MEMORY}/(3*1024/2)")
+else()
+	set(AVAILABLE_PHYSICAL_MEMORY "?")
+endif()
+
+if(parallel_jobs GREATER NUMBER_OF_LOGICAL_CORES)
+	set(parallel_jobs ${NUMBER_OF_LOGICAL_CORES})
+endif()
+
+message(STATUS  "${NUMBER_OF_LOGICAL_CORES} logical cores detected and ${AVAILABLE_PHYSICAL_MEMORY} megabytes of memory available.
+		Limiting concurrent jobs to ${parallel_jobs}")
 
 # project to build sitl_gazebo if necessary
 px4_add_git_submodule(TARGET git_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_gazebo")
@@ -49,7 +67,7 @@ ExternalProject_Add(sitl_gazebo
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
 	BUILD_ALWAYS 1
-	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${build_cores}
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${parallel_jobs}
 )
 
 px4_add_git_submodule(TARGET git_ign_gazebo PATH "${PX4_SOURCE_DIR}/Tools/simulation-ignition")
@@ -63,7 +81,7 @@ ExternalProject_Add(simulation-ignition
 	USES_TERMINAL_BUILD true
 	EXCLUDE_FROM_ALL true
 	BUILD_ALWAYS 1
-	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${build_cores}
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j ${parallel_jobs}
 )
 
 ExternalProject_Add(mavsdk_tests


### PR DESCRIPTION

Closes #17691

This is far from a perfect solution, it simply tries to offer a minimum of flexibility when deploying automated builds.

This allows the possibility of overriding the parallelism when building sitl_gazebo, which is memory intensive and can result in oom ( see #17691 , other issues have been closed in the past but not actually solved: #14747 #14430  ). This is especially the case as new CPUs have more and more logical cores, but systems still generally have 16GB or less of RAM. In my 16GB system, `master` currently uses 14 parallel jobs which results in oom and with no way of resolving it since it is hardcoded to N-2 jobs in `ExternalProject_Add`.

Example of usage: `BUILD_CORES=8 DONT_RUN=1 make px4_sitl_default gazebo`

An important caveat with this solution is that it only works during configuration, not build time. Unless the CMake file is reloaded, only the first time the example above is run will affect the number of parallel jobs. Trying to set a different `BUILD_CORES` environment variable afterwards does **not** work, because `ExternalProject_Add` is already defined

I was unable to find a workaround or a better solution. I was hoping the `BUILD_COMMAND` could be given in a way that it reads an environment variable during build time, but couldn't. The problem overall seems to come from cmake + make and not passing parallelism over to external projects.

Any alternative suggestions?