### PR TITLE
MAVlink Onboard lowbandwidth mode: send ESC_INFO data

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1819,6 +1819,8 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("GIMBAL_DEVICE_ATTITUDE_STATUS", 1.0f);
 		configure_stream_local("GIMBAL_MANAGER_STATUS", 0.5f);
 		configure_stream_local("GIMBAL_DEVICE_SET_ATTITUDE", 5.0f);
+		configure_stream_local("ESC_INFO", 1.0f);
+		configure_stream_local("ESC_STATUS", 5.0f);
 
 		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
 		configure_stream_local("ATTITUDE_TARGET", 2.0f);


### PR DESCRIPTION

**Describe problem solved by this pull request**
minor update to extend the onboard_lowbandwidth mavlink streaming mode to have ESC data. Being able to send ESC information to the other subsystems over MAVLink can indeed be useful to monitor the vehicle state.
