### PR TITLE
mixer_module: check for motor test after topic update

### DIFF
--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -351,21 +351,6 @@ bool MixingOutput::update()
 		}
 	}
 
-	// check for motor test
-	if (!_armed.armed && !_armed.manual_lockdown) {
-		unsigned num_motor_test = motorTest();
-
-		if (num_motor_test > 0) {
-			if (_interface.updateOutputs(false, _current_output_value, num_motor_test, 1)) {
-				actuator_outputs_s actuator_outputs{};
-				setAndPublishActuatorOutputs(num_motor_test, actuator_outputs);
-			}
-
-			handleCommands();
-			return true;
-		}
-	}
-
 	if (_param_mot_slew_max.get() > FLT_EPSILON) {
 		updateOutputSlewrateMultirotorMixer();
 	}
@@ -393,6 +378,21 @@ bool MixingOutput::update()
 				/* Switch off the output limit ramp for the calibration. */
 				_output_limit.state = OUTPUT_LIMIT_STATE_ON;
 			}
+		}
+	}
+
+	// check for motor test (after topic updates)
+	if (!_armed.armed && !_armed.manual_lockdown) {
+		unsigned num_motor_test = motorTest();
+
+		if (num_motor_test > 0) {
+			if (_interface.updateOutputs(false, _current_output_value, num_motor_test, 1)) {
+				actuator_outputs_s actuator_outputs{};
+				setAndPublishActuatorOutputs(num_motor_test, actuator_outputs);
+			}
+
+			handleCommands();
+			return true;
 		}
 	}
 


### PR DESCRIPTION
Otherwise if a module restricts the update rate via `setMaxTopicUpdateRate()`
and then motor_test is used, the module might run faster than expected.