### PR TITLE
ROMFS cmake remove directory VERBATIM

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -120,6 +120,7 @@ add_custom_command(
 	COMMAND ${CMAKE_COMMAND} -E touch ${romfs_extract_stamp}
 	WORKING_DIRECTORY ${romfs_gen_root_dir}
 	DEPENDS ${romfs_tar_file}
+	VERBATIM
 	)
 
 add_custom_command(


### PR DESCRIPTION
Fixes the build in some environments.

@SalimTerryLi 