### PR TITLE
Remove a couple of unnecessary reboot_required from parameter meta data

### DIFF
--- a/src/lib/battery/battery_params_common.c
+++ b/src/lib/battery/battery_params_common.c
@@ -51,7 +51,6 @@
  * @max 0.5
  * @decimal 2
  * @increment 0.01
- * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
 
@@ -68,7 +67,6 @@ PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
  * @max 0.25
  * @decimal 2
  * @increment 0.01
- * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
 
@@ -85,6 +83,5 @@ PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
  * @max 0.1
  * @decimal 2
  * @increment 0.01
- * @reboot_required true
  */
 PARAM_DEFINE_FLOAT(BAT_EMERGEN_THR, 0.05f);

--- a/src/lib/circuit_breaker/circuit_breaker_params.c
+++ b/src/lib/circuit_breaker/circuit_breaker_params.c
@@ -49,7 +49,6 @@
  * checks in the commander.
  * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
  *
- * @reboot_required true
  * @min 0
  * @max 894281
  * @category Developer
@@ -78,7 +77,6 @@ PARAM_DEFINE_INT32(CBRK_RATE_CTRL, 0);
  * Setting this parameter to 22027 will disable IO safety.
  * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
  *
- * @reboot_required true
  * @min 0
  * @max 22027
  * @category Developer
@@ -160,7 +158,6 @@ PARAM_DEFINE_INT32(CBRK_BUZZER, 0);
  * zero to prevent users from flying USB powered. However, for R&D purposes
  * it has proven over the years to work just fine.
  *
- * @reboot_required true
  * @min 0
  * @max 197848
  * @category Developer
@@ -175,7 +172,6 @@ PARAM_DEFINE_INT32(CBRK_USB_CHK, 197848);
  * accuracy checks in the commander.
  * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
  *
- * @reboot_required true
  * @min 0
  * @max 201607
  * @category Developer
@@ -190,7 +186,6 @@ PARAM_DEFINE_INT32(CBRK_VELPOSERR, 0);
  * mode for VTOLs.
  * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
  *
- * @reboot_required true
  * @min 0
  * @max 159753
  * @category Developer

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -747,7 +747,6 @@ PARAM_DEFINE_FLOAT(COM_ARM_AUTH_TO, 1);
  * The default value has been optimised for rotary wing applications. For fixed wing applications, a larger value between 5 and 10 should be used.
  *
  * @unit s
- * @reboot_required true
  * @group Commander
  * @min 1
  * @max 100
@@ -764,7 +763,6 @@ PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1);
  * The default value has been optimised for rotary wing applications. For fixed wing applications, a value of 1 should be used.
  *
  * @unit s
- * @reboot_required true
  * @group Commander
  * @min 1
  * @max 100

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -137,7 +137,6 @@ PARAM_DEFINE_INT32(FD_EXT_ATS_TRIG, 1900);
  * Timeout for receiving an acknowledgement from the ESCs is 0.3s, if no feedback is received the failure detector will auto disarm the vehicle.
  *
  * @boolean
- * @reboot_required true
  *
  * @group Failure Detector
  */


### PR DESCRIPTION
**Describe problem solved by this pull request**
It was annoying me since a while that for some parameters, after you change it in QGC, the "reboot required" message pops up, though the change already has an effect. 

**Describe your solution**
Remove the "reboot_required" from couple of parameters that I think don't require it. There probably are more.



