### PR TITLE
Protocol splitter: improve TX message flow

### DIFF
--- a/msg/templates/urtps/microRTPS_transport.cpp
+++ b/msg/templates/urtps/microRTPS_transport.cpp
@@ -330,6 +330,8 @@ int UART_node::init()
 
 	// If using shared UART, no need to set it up
 	if (_baudrate == 0) {
+		_poll_fd[0].fd = _uart_fd;
+		_poll_fd[0].events = POLLIN;
 		return _uart_fd;
 	}
 

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -160,9 +160,15 @@ int ReadBuffer::read(int fd)
 		PX4_DEBUG("Buffer full: %zu %zu %zu %zu", start_mavlink, end_mavlink, start_rtps, end_rtps);
 	}
 
-	int r = ::read(fd, buffer + buf_size, sizeof(buffer) - buf_size);
+	int bytes_available = 0;
+	int err = ::ioctl(fd, FIONREAD, (unsigned long)&bytes_available);
+	ssize_t r = 0;
 
-	if (r < 0) {
+	if (err != 0 || bytes_available > 0) {
+		r = ::read(fd, buffer + buf_size, sizeof(buffer) - buf_size);
+	}
+
+	if (r <= 0) {
 		return r;
 	}
 

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -358,7 +358,7 @@ pollevent_t DevCommon::poll_state(struct file *filp)
 	 * the _fd in here or by overriding some other method.
 	 */
 
-	::poll(fds, sizeof(fds) / sizeof(fds[0]), 100);
+	::poll(fds, sizeof(fds) / sizeof(fds[0]), 10);
 
 	return POLLIN;
 }

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -366,7 +366,7 @@ pollevent_t DevCommon::poll_state(struct file *filp)
 int DevCommon::try_to_copy_data(char *buffer, size_t buflen, MessageType message_type)
 {
 	if (buflen == 0) {
-		return -1;
+		return 0;
 	}
 
 	switch (message_type) {
@@ -398,7 +398,7 @@ int DevCommon::try_to_copy_data(char *buffer, size_t buflen, MessageType message
 			return len_to_copy;
 
 		} else {
-			return -1;
+			return 0;
 		}
 
 	case MessageType::Rtps:
@@ -429,14 +429,14 @@ int DevCommon::try_to_copy_data(char *buffer, size_t buflen, MessageType message
 			return len_to_copy;
 
 		} else {
-			return -1;
+			return 0;
 		}
 
 		break;
 
 
 	default:
-		return -1;
+		return 0;
 	}
 }
 


### PR DESCRIPTION
This considerably improves the message flow for outgoing data. In particular under high load conditions, like param loading or log download.

Check individual commits for details.