### PR TITLE
BAT_ADC_CHANNEL should point to BAT1_I_CHANNEL

### DIFF
--- a/src/modules/battery_status/analog_battery_params_deprecated.c
+++ b/src/modules/battery_status/analog_battery_params_deprecated.c
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * This parameter is deprecated. Please use BAT1_ADC_CHANNEL.
+ * This parameter is deprecated. Please use BAT1_I_CHANNEL.
  *
  * @group Battery Calibration
  */


### PR DESCRIPTION
The BAT_ADC_CHANNEL  deprecated param points to BAT1_ADC_CHANNEL in docs, but it looks like it should point to BAT1_I_CHANNEL