### PR TITLE
px4io mixing on fmu updates (2)

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -17,6 +17,10 @@ set OUTPUT_DEV none
 set OUTPUT_AUX_DEV /dev/pwm_output1
 set OUTPUT_EXTRA_DEV /dev/pwm_output0
 
+# set these before starting the modules
+param set PWM_AUX_OUT ${PWM_AUX_OUT}
+param set PWM_MAIN_OUT ${PWM_OUT}
+
 #
 # If mount (gimbal) control is enabled and output mode is AUX, set the aux
 # mixer to mount (override the airframe-specific MIXER_AUX setting).
@@ -222,8 +226,6 @@ then
 	fi
 fi
 
-param set PWM_AUX_OUT ${PWM_AUX_OUT}
-
 if [ $MIXER_AUX != none -a $AUX_MODE = none -a -e $OUTPUT_AUX_DEV ]
 then
 	#
@@ -265,8 +267,6 @@ then
 		fi
 	fi
 fi
-
-param set PWM_MAIN_OUT ${PWM_OUT}
 
 if [ $EXTRA_MIXER_MODE != none ]
 then

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -98,9 +98,9 @@ then
 	fi
 
 	#
-	# Start IO for RC input if needed.
+	# Start IO for PWM output or RC input if needed.
 	#
-	if [ $IO_PRESENT = yes -a $OUTPUT_MODE = io ]
+	if [ $IO_PRESENT = yes ]
 	then
 		if ! px4io start
 		then

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -35,10 +35,6 @@ px4_add_module(
 	MAIN px4io
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
-		-Wno-error
-		#-DDEBUG_BUILD
-	STACK_MAIN
-		10000
 	SRCS
 		px4io.cpp
 		px4io_serial.cpp

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -353,7 +353,8 @@ private:
 		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max,
 		(ParamInt<px4::params::RC_RSSI_PWM_MIN>) _param_rc_rssi_pwm_min,
 		(ParamInt<px4::params::SENS_EN_THERMAL>) _param_sens_en_themal,
-		(ParamInt<px4::params::SYS_HITL>) _param_sys_hitl
+		(ParamInt<px4::params::SYS_HITL>) _param_sys_hitl,
+		(ParamInt<px4::params::SYS_USE_IO>) _param_sys_use_io
 	)
 };
 
@@ -542,7 +543,7 @@ int PX4IO::init()
 	}
 
 	/* try to claim the generic PWM output device node as well - it's OK if we fail at this */
-	if (_param_sys_hitl.get() <= 0) {
+	if (_param_sys_hitl.get() <= 0 && _param_sys_use_io.get() == 1) {
 		_class_instance = register_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH);
 		_mixing_output.setDriverInstance(_class_instance);
 
@@ -724,8 +725,8 @@ void PX4IO::Run()
 
 void PX4IO::update_params()
 {
-	// skip update when armed
-	if (_mixing_output.armed().armed) {
+	// skip update when armed or PWM disabled
+	if (_mixing_output.armed().armed || _class_instance == -1) {
 		return;
 	}
 

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -45,12 +45,10 @@
 /**
  * Set usage of IO board
  *
- * Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.
+ * Can be used to use a configure the use of the IO board.
  *
- * @value 0 IO disabled
- * @value 1 IO default (RC & PWM output)
- * @value 2 RC only
- * @value 3 PWM output only
+ * @value 0 IO PWM disabled (RC only)
+ * @value 1 IO enabled (RC & PWM)
  * @reboot_required true
  * @group System
  */

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -68,7 +68,6 @@ static volatile bool mixer_servos_armed = false;
 static volatile bool should_arm = false;
 static volatile bool should_arm_nothrottle = false;
 static volatile bool should_always_enable_pwm = false;
-static volatile bool in_mixer = false;
 
 static bool new_fmu_data = false;
 static uint64_t last_fmu_update = 0;

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -135,12 +135,10 @@ mixer_tick()
 	 * FMU or from the mixer.
 	 *
 	 */
-	should_arm = ((r_status_flags & PX4IO_P_STATUS_FLAGS_INIT_OK)				/* IO initialised without error */
-		      && (r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)			/* and IO is armed */
-		      && ((r_setup_arming & PX4IO_P_SETUP_ARMING_FMU_ARMED)		/* and FMU is armed */
-			  || (r_status_flags & PX4IO_P_STATUS_FLAGS_RAW_PWM)		/* or direct PWM is set */
-			 )
-		     );
+	should_arm = (r_status_flags & PX4IO_P_STATUS_FLAGS_INIT_OK)				/* IO initialised without error */
+		     && (r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)			/* and IO is armed */
+		     && (r_setup_arming & PX4IO_P_SETUP_ARMING_FMU_ARMED)		/* and FMU is armed */
+		     ;
 
 	should_arm_nothrottle = ((r_status_flags & PX4IO_P_STATUS_FLAGS_INIT_OK)              /* IO initialised without error */
 				 && (r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)        /* and IO is armed */


### PR DESCRIPTION
Round 2. Commits can be squashed afterwards.

- SYS_USE_IO: made sure the existing behavior still works - this can still be extended as desired.
- see commit messages for further details

Tested:
- `pwm test`, `motor_test test`
- sbus out
- rc, rc lost
- pwm disarmed ioctl update after bootup
- SYS_USE_IO
- checked all combinations of flight termination, safety circuit breaker settings and arming vs disarming, safety on vs off states: behavior of fmu reboot, hardfaults. Verified failsafe/parachute trigger is entered in the expected conditions.
- pwm: oneshot, 50hz vs 400hz
- SYS_HITL


Oneshot doesn't look great, but it's similar to what we have now (increasing the proc prio helps)
![px4io_mixing_oneshot](https://user-images.githubusercontent.com/281593/130027352-cafb9b0d-6890-42ea-a231-61c5f9f9d0f2.png)
