### PR TITLE
Correct conversion from sec to usec

### DIFF
--- a/src/modules/mavlink/mavlink_timesync.cpp
+++ b/src/modules/mavlink/mavlink_timesync.cpp
@@ -163,7 +163,7 @@ MavlinkTimesync::handle_message(const mavlink_message_t *msg)
 
 			// date -d @1234567890: Sat Feb 14 02:31:30 MSK 2009
 			bool onb_unix_valid = (unsigned long long)tv.tv_sec > PX4_EPOCH_SECS;
-			bool ofb_unix_valid = time.time_unix_usec > PX4_EPOCH_SECS * 1000ULL;
+			bool ofb_unix_valid = time.time_unix_usec > PX4_EPOCH_SECS * 1000000ULL;
 
 			if (!onb_unix_valid && ofb_unix_valid) {
 				tv.tv_sec = time.time_unix_usec / 1000000ULL;


### PR DESCRIPTION
**Describe problem solved by this pull request**
us is compared to ms. This would cause any offboard time that is after Jan 15th, 1970 to be considered valid, instead of the intended Feb 14th 2009.

**Describe your solution**
Changed seconds * 1000 (ms) to seconds * 1000000 (us).

**Describe possible alternatives**
N/A

**Test data / coverage**
We did not test it since it is a simple logical error, but we can of course do that if you would like us to

**Additional context**
