### PR TITLE
 esc_report: change esc_temperature field to allow negative values [needs mavlink submodule update]

### DIFF
--- a/msg/esc_report.msg
+++ b/msg/esc_report.msg
@@ -3,7 +3,7 @@ uint32 esc_errorcount					# Number of reported errors by ESC - if supported
 int32 esc_rpm						# Motor RPM, negative for reverse rotation [RPM] - if supported
 float32 esc_voltage					# Voltage measured from current ESC [V] - if supported
 float32 esc_current					# Current measured from current ESC [A] - if supported
-uint8 esc_temperature					# Temperature measured from current ESC [degC] - if supported
+float32 esc_temperature					# Temperature measured from current ESC [degC] - if supported
 uint8 esc_address					# Address of current ESC (in most cases 1-8 / must be set by driver)
 
 uint8 esc_state					# State of ESC - depend on Vendor

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -395,7 +395,7 @@ void DShot::handle_new_telemetry_data(const int motor_index, const DShotTelemetr
 		esc_status.esc[motor_index].esc_rpm         = (static_cast<int>(data.erpm) * 100) / (_param_mot_pole_count.get() / 2);
 		esc_status.esc[motor_index].esc_voltage     = static_cast<float>(data.voltage) * 0.01f;
 		esc_status.esc[motor_index].esc_current     = static_cast<float>(data.current) * 0.01f;
-		esc_status.esc[motor_index].esc_temperature = data.temperature;
+		esc_status.esc[motor_index].esc_temperature = static_cast<float>(data.temperature);
 		// TODO: accumulate consumption and use for battery estimation
 	}
 

--- a/src/drivers/tap_esc/TAP_ESC.cpp
+++ b/src/drivers/tap_esc/TAP_ESC.cpp
@@ -297,7 +297,7 @@ bool TAP_ESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], u
 					_esc_feedback.esc[feed_back_data.channelID].esc_current = feed_back_data.current;
 #endif // ESC_HAVE_CURRENT_SENSOR
 #if defined(ESC_HAVE_TEMPERATURE_SENSOR)
-					_esc_feedback.esc[feed_back_data.channelID].esc_temperature = feed_back_data.temperature;
+					_esc_feedback.esc[feed_back_data.channelID].esc_temperature = static_cast<float>(feed_back_data.temperature);
 #endif // ESC_HAVE_TEMPERATURE_SENSOR
 					_esc_feedback.esc[feed_back_data.channelID].esc_state = feed_back_data.ESCStatus;
 					_esc_feedback.esc[feed_back_data.channelID].failures = 0;

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -115,7 +115,7 @@ publish_gam_message(const uint8_t *buffer)
 	esc.esc_connectiontype = esc_status_s::ESC_CONNECTION_TYPE_PPM;
 
 	esc.esc[0].esc_rpm = (uint16_t)((msg.rpm_H << 8) | (msg.rpm_L & 0xff)) * 10;
-	esc.esc[0].esc_temperature = msg.temperature1 - 20;
+	esc.esc[0].esc_temperature = static_cast<float>(msg.temperature1 - 20);
 	esc.esc[0].esc_voltage = static_cast<float>((msg.main_voltage_H << 8) | (msg.main_voltage_L & 0xff)) * 0.1F;
 	esc.esc[0].esc_current = static_cast<float>((msg.current_H << 8) | (msg.current_L & 0xff)) * 0.1F;
 
@@ -186,7 +186,9 @@ build_gam_response(uint8_t *buffer, size_t *size)
 	msg.gam_sensor_id = GAM_SENSOR_ID;
 	msg.sensor_text_id = GAM_SENSOR_TEXT_ID;
 
-	msg.temperature1 = esc.esc[0].esc_temperature + 20;
+	const int16_t esc_temp_offset_degC = (esc.esc[0].esc_temperature + 20) > UINT8_MAX ? UINT8_MAX :
+					     (esc.esc[0].esc_temperature + 20);
+	msg.temperature1 = (esc_temp_offset_degC < 0) ? 0 : esc_temp_offset_degC;
 	msg.temperature2 = 20;  // 0 deg. C.
 
 	const uint16_t voltage = (uint16_t)(esc.esc[0].esc_voltage * 10.0F);

--- a/src/modules/mavlink/streams/ESC_INFO.hpp
+++ b/src/modules/mavlink/streams/ESC_INFO.hpp
@@ -82,7 +82,8 @@ private:
 				for (int esc_index = 0; esc_index < batch_size ; esc_index++) {
 					msg.failure_flags[esc_index] = esc_status.esc[esc_index].failures;
 					msg.error_count[esc_index] = esc_status.esc[esc_index].esc_errorcount;
-					msg.temperature[esc_index] = esc_status.esc[esc_index].esc_temperature;
+					msg.temperature[esc_index] = static_cast<int16_t>(esc_status.esc[esc_index].esc_temperature *
+								     100.f); // convert to centiDegrees
 				}
 
 				mavlink_msg_esc_info_send_struct(_mavlink->get_channel(), &msg);


### PR DESCRIPTION
Title is self explanatory. This PR needs to go in after the relative mavlink message is updated, https://github.com/mavlink/mavlink/pull/1663.

@dagar i've also noticed that the UAVCAN spec defines the temperature in Kelvin for `uavcan.equipment.esc.Status` (https://legacy.uavcan.org/Specification/7._List_of_standard_data_types/), looking at the code we've always filled the esc_temperature directly from the UAVCAN message.. not sure who to trust there :|