### PR TITLE
boards: px4_fmu-v6{u,x} fix test variant flash overflow and sync defaults

### DIFF
--- a/boards/px4/fmu-v6u/default.cmake
+++ b/boards/px4/fmu-v6u/default.cmake
@@ -50,7 +50,7 @@ px4_add_board(
 		uavcan
 	MODULES
 		airspeed_selector
-		attitude_estimator_q
+		#attitude_estimator_q
 		battery_status
 		camera_feedback
 		commander
@@ -66,7 +66,7 @@ px4_add_board(
 		land_detector
 		landing_target_estimator
 		load_mon
-		local_position_estimator
+		#local_position_estimator
 		logger
 		mavlink
 		mc_att_control
@@ -103,15 +103,15 @@ px4_add_board(
 		perf
 		pwm
 		reboot
-		reflect
+		#reflect
 		sd_bench
-		serial_test
+		#serial_test
 		system_time
 		top
 		topic_listener
 		tune_control
 		uorb
-		usb_connected
+		#usb_connected
 		ver
 		work_queue
 	EXAMPLES

--- a/boards/px4/fmu-v6u/test.cmake
+++ b/boards/px4/fmu-v6u/test.cmake
@@ -14,14 +14,15 @@ px4_add_board(
 		TEL3:/dev/ttyS1
 		GPS2:/dev/ttyS7
 	DRIVERS
-		adc/ads1115
+		#adc/ads1115
 		adc/board_adc
-		barometer # all available barometer drivers
-		batt_smbus
-		camera_capture
+		#barometer # all available barometer drivers
+		barometer/bmp388
+		#batt_smbus
+		#camera_capture
 		camera_trigger
 		differential_pressure # all available differential pressure drivers
-		distance_sensor # all available distance sensor drivers
+		#distance_sensor # all available distance sensor drivers
 		dshot
 		gps
 		heater
@@ -34,19 +35,19 @@ px4_add_board(
 		lights # all available light drivers
 		magnetometer # all available magnetometer drivers
 		optical_flow # all available optical flow drivers
-		osd
-		pca9685
-		pca9685_pwm_out
+		#osd
+		#pca9685
+		#pca9685_pwm_out
 		power_monitor/ina226
 		#protocol_splitter
 		#pwm_input  - Need to create arch/stm32 arch/stm32h7
 		pwm_out_sim
 		pwm_out
 		rc_input
-		roboclaw
-		rpm
+		#roboclaw
+		#rpm
 		safety_button
-		telemetry # all available telemetry drivers
+		#telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
 		uavcan
@@ -58,7 +59,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
-		esc_battery
+		#esc_battery
 		events
 		flight_mode_manager
 		fw_att_control
@@ -78,7 +79,7 @@ px4_add_board(
 		#micrortps_bridge
 		navigator
 		rc_update
-		rover_pos_control
+		#rover_pos_control
 		sensors
 		sih
 		temperature_compensation

--- a/boards/px4/fmu-v6x/default.cmake
+++ b/boards/px4/fmu-v6x/default.cmake
@@ -91,6 +91,7 @@ px4_add_board(
 	SYSTEMCMDS
 		bl_update
 		dmesg
+		dumpfile
 		esc_calib
 		gpio
 		hardfault_log

--- a/boards/px4/fmu-v6x/test.cmake
+++ b/boards/px4/fmu-v6x/test.cmake
@@ -17,14 +17,15 @@ px4_add_board(
 		TEL3:/dev/ttyS1
 		GPS2:/dev/ttyS7
 	DRIVERS
-		adc/ads1115
+		#adc/ads1115
 		adc/board_adc
-		barometer # all available barometer drivers
-		batt_smbus
-		camera_capture
+		#barometer # all available barometer drivers
+		barometer/bmp388
+		#batt_smbus
+		#camera_capture
 		camera_trigger
 		differential_pressure # all available differential pressure drivers
-		distance_sensor # all available distance sensor drivers
+		#distance_sensor # all available distance sensor drivers
 		dshot
 		gps
 		heater
@@ -34,22 +35,25 @@ px4_add_board(
 		imu/invensense/icm20649
 		imu/invensense/icm20948 # required for ak09916 mag
 		imu/invensense/icm42688p
-		irlock
+		#irlock
 		lights # all available light drivers
-		magnetometer # all available magnetometer drivers
-		optical_flow # all available optical flow drivers
-		osd
-		pca9685
-		pca9685_pwm_out
+		#magnetometer # all available magnetometer drivers
+		magnetometer/bosch/bmm150
+		magnetometer/isentek/ist8310
+		#optical_flow # all available optical flow drivers
+		#osd
+		#pca9685
+		#pca9685_pwm_out
 		power_monitor/ina226
 		#protocol_splitter
 		pwm_out_sim
 		pwm_out
 		px4io
 		rc_input
-		rpm
+		#roboclaw
+		#rpm
 		safety_button
-		telemetry # all available telemetry drivers
+		#telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
 		uavcan
@@ -60,7 +64,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
-		esc_battery
+		#esc_battery
 		events
 		flight_mode_manager
 		fw_att_control
@@ -80,7 +84,7 @@ px4_add_board(
 		#micrortps_bridge
 		navigator
 		rc_update
-		rover_pos_control
+		#rover_pos_control
 		sensors
 		sih
 		temperature_compensation
@@ -91,6 +95,7 @@ px4_add_board(
 	SYSTEMCMDS
 		bl_update
 		dmesg
+		dumpfile
 		esc_calib
 		gpio
 		hardfault_log
@@ -99,6 +104,7 @@ px4_add_board(
 		mft
 		microbench
 		mixer
+		motor_ramp
 		motor_test
 		mtd
 		nshterm
@@ -107,10 +113,11 @@ px4_add_board(
 		perf
 		pwm
 		reboot
+		#reflect
 		sd_bench
 		serial_test
 		system_time
-#		tests # tests and test runner
+		tests # tests and test runner
 		top
 		topic_listener
 		tune_control
@@ -120,8 +127,8 @@ px4_add_board(
 		work_queue
 	EXAMPLES
 		fake_gps
-		#fake_imu
-		#fake_magnetometer
+		fake_imu
+		fake_magnetometer
 		#fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
 		#hello
 		#hwtest # Hardware test

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -163,6 +163,7 @@ px4_add_module(
 	DEPENDS
 		px4_uavcan_dsdlc
 
+		drivers_rangefinder
 		led
 		mixer
 		mixer_module


### PR DESCRIPTION
More flash overflows that slipped into master during the few days that px4_fmu-v2_default was out of flash.

This updates the test variants to actually include the test material and attempts to keep the defaults in sync other than the core board differences (on board sensors, etc).