### PR TITLE
cmake fix micrortps build dependencies

### DIFF
--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -48,6 +48,10 @@ else()
 	message(STATUS "${FASTRTPSGEN_VERSION}")
 endif()
 
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+	${PX4_SOURCE_DIR}/msg/tools/urtps_bridge_topics.yaml
+)
+
 if (EXISTS "${PX4_SOURCE_DIR}/msg/tools/urtps_bridge_topics.yaml")
 	set(config_rtps_send_topics)
 	execute_process(
@@ -142,6 +146,7 @@ if (GENERATE_RTPS_BRIDGE)
 			${receive_topic_files}
 			${send_topic_files}
 			${PX4_SOURCE_DIR}/msg/tools/px_generate_uorb_topic_files.py
+			${PX4_SOURCE_DIR}/msg/tools/urtps_bridge_topics.yaml
 		COMMENT "Generating uORB microcdr topic headers"
 		VERBATIM
 	)
@@ -161,10 +166,11 @@ if (GENERATE_RTPS_BRIDGE)
 			${receive_topic_files}
 			${send_topic_files}
 			${PX4_SOURCE_DIR}/msg/tools/px_generate_uorb_topic_files.py
+			${PX4_SOURCE_DIR}/msg/tools/urtps_bridge_topics.yaml
 		COMMENT "Generating uORB microcdr topic sources"
 		VERBATIM
 	)
-	px4_add_library(uorb_msgs_microcdr ${uorb_sources_microcdr})
+	px4_add_library(uorb_msgs_microcdr ${uorb_sources_microcdr} ${uorb_headers_microcdr})
 	add_dependencies(uorb_msgs_microcdr
 		uorb_headers_microcdr_gen
 		git_micro_cdr

--- a/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
@@ -56,13 +56,13 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 	endif()
 
 	foreach(topic ${config_rtps_send_topics})
-		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Publisher.cpp)
-		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Publisher.h)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/src/${topic}_Publisher.cpp)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/src/${topic}_Publisher.h)
 	endforeach()
 
 	foreach(topic ${config_rtps_receive_topics})
-		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Subscriber.cpp)
-		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/${topic}_Subscriber.h)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/src/${topic}_Subscriber.cpp)
+		list(APPEND topic_bridge_files_out ${micrortps_bridge_path}/micrortps_agent/src/${topic}_Subscriber.h)
 	endforeach()
 
 	list(APPEND topic_bridge_files_out
@@ -84,7 +84,7 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 			--client-outdir ${micrortps_bridge_path}/micrortps_client
 			--idl-dir ${micrortps_bridge_path}/micrortps_agent/idl
 			>micrortps_bridge.log 2>&1 || cat micrortps_bridge.log
-		DEPENDS ${send_topic_files} ${receive_topic_files}
+		DEPENDS ${send_topic_files} ${receive_topic_files} ${PX4_SOURCE_DIR}/msg/tools/urtps_bridge_topics.yaml
 		COMMENT "Generating RTPS topic bridge"
 	)
 	add_custom_target(topic_bridge_files DEPENDS ${topic_bridge_files_out})


### PR DESCRIPTION
I believe this should address the build dependency issue reported in https://github.com/PX4/px4_ros_com/issues/108.

The main issue is that `msg/tools/urtps_bridge_topics.yaml` needs to be a cmake configure time dependency (CMAKE_CONFIGURE_DEPENDS) because it's processed by `execute_process` in a couple places. https://github.com/PX4/PX4-Autopilot/blob/c0efbe1f9cba86bf112f8b62cc2e35956f30ac1a/src/modules/micrortps_bridge/CMakeLists.txt#L53-L55