### PR TITLE
add uavcan fuel tank status sensor

### DIFF
--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -168,6 +168,7 @@ px4_add_module(
 		sensors/battery.cpp
 		sensors/airspeed.cpp
 		sensors/flow.cpp
+		sensors/fuel_tank_status.cpp
 		sensors/gnss_relative.cpp
 		sensors/gnss.cpp
 		sensors/mag.cpp

--- a/src/drivers/uavcan/Kconfig
+++ b/src/drivers/uavcan/Kconfig
@@ -54,6 +54,10 @@ if DRIVERS_UAVCAN
         bool "Subscribe to Flow:                        com::hex::equipment::flow::Measurement"
         default y
 
+    config UAVCAN_SENSOR_FUEL_TANK
+        bool "Subscribe to Fuel tank:                   uavcan.equipment.ice.FuelTankStatus"
+        default y
+
     config UAVCAN_SENSOR_GNSS
         bool "Subscribe to GPS:                         uavcan::equipment::gnss::Auxiliary | uavcan::equipment::gnss::Fix | uavcan::equipment::gnss::Fix2"
         default y

--- a/src/drivers/uavcan/sensors/fuel_tank_status.cpp
+++ b/src/drivers/uavcan/sensors/fuel_tank_status.cpp
@@ -1,0 +1,95 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @author Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#include "fuel_tank_status.hpp"
+#include <uORB/topics/battery_status.h>
+
+const char *const UavcanFuelTankStatusBridge::NAME = "fuel_tank_status";
+
+UavcanFuelTankStatusBridge::UavcanFuelTankStatusBridge(uavcan::INode &node) :
+	UavcanSensorBridgeBase("uavcan_fuel_tank_status", ORB_ID(battery_status)),
+	_sub_fuel_tank_status_data(node)
+{ }
+
+int UavcanFuelTankStatusBridge::init()
+{
+	int res = _sub_fuel_tank_status_data.start(FuelTankStatusCbBinder(this,
+			&UavcanFuelTankStatusBridge::fuel_tank_status_sub_cb));
+
+	if (res < 0) {
+		DEVICE_LOG("failed to start uavcan sub: %d", res);
+		return res;
+	}
+
+	return 0;
+}
+
+void UavcanFuelTankStatusBridge::fuel_tank_status_sub_cb(const
+		uavcan::ReceivedDataStructure<uavcan::equipment::ice::FuelTankStatus> &msg)
+{
+	battery_status_s battery{};
+
+	battery.remaining = msg.available_fuel_volume_percent * 0.01;
+	battery.id = msg.getSrcNodeID().get();
+	battery.timestamp = hrt_absolute_time();
+
+	// Connected = false because it's temporary solution
+	battery.connected = false;
+
+	// Fill other fields by default
+	battery.voltage_v = 0.0;
+	battery.voltage_filtered_v = 0.0;
+	battery.current_a = 0.0;
+	battery.current_filtered_a = 0.01;
+	battery.current_average_a = 0.0;
+	battery.discharged_mah = 0.0;
+	battery.scale = 1.0;
+	battery.temperature = msg.fuel_temperature;
+	battery.cell_count = static_cast<int32_t>(1);
+	battery.source = 0;
+	battery.priority = 0;
+	battery.capacity = 0;
+	battery.warning = 0;
+	battery.voltage_cell_v[0] = 0.0;
+
+	publish(msg.getSrcNodeID().get(), &battery);
+}
+
+int UavcanFuelTankStatusBridge::init_driver(uavcan_bridge::Channel *channel)
+{
+	return PX4_OK;
+}

--- a/src/drivers/uavcan/sensors/fuel_tank_status.hpp
+++ b/src/drivers/uavcan/sensors/fuel_tank_status.hpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @author Dmitry Ponomarev <ponomarevda96@gmail.com>
+ */
+
+#pragma once
+
+#include "sensor_bridge.hpp"
+
+#include <uavcan/equipment/ice/FuelTankStatus.hpp>
+
+class UavcanFuelTankStatusBridge : public UavcanSensorBridgeBase
+{
+public:
+	static const char *const NAME;
+
+	UavcanFuelTankStatusBridge(uavcan::INode &node);
+
+	const char *get_name() const override { return NAME; }
+
+	int init() override;
+
+private:
+
+	void fuel_tank_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ice::FuelTankStatus> &msg);
+	int init_driver(uavcan_bridge::Channel *channel) override;
+
+	typedef uavcan::MethodBinder < UavcanFuelTankStatusBridge *,
+		void (UavcanFuelTankStatusBridge::*)
+		(const uavcan::ReceivedDataStructure<uavcan::equipment::ice::FuelTankStatus> &) >
+		FuelTankStatusCbBinder;
+
+	uavcan::Subscriber<uavcan::equipment::ice::FuelTankStatus, FuelTankStatusCbBinder> _sub_fuel_tank_status_data;
+
+};

--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -57,6 +57,9 @@
 #if defined(CONFIG_UAVCAN_SENSOR_FLOW)
 #include "flow.hpp"
 #endif
+#if defined(CONFIG_UAVCAN_SENSOR_FUEL_TANK)
+#include "fuel_tank_status.hpp"
+#endif
 #if defined(CONFIG_UAVCAN_SENSOR_GNSS)
 #include "gnss.hpp"
 #endif
@@ -135,6 +138,17 @@ void IUavcanSensorBridge::make_all(uavcan::INode &node, List<IUavcanSensorBridge
 
 	if (uavcan_sub_flow != 0) {
 		list.add(new UavcanFlowBridge(node));
+	}
+
+#endif
+
+	// fuel tank
+#if defined(CONFIG_UAVCAN_SENSOR_FUEL_TANK)
+	int32_t uavcan_sub_fuel = 1;
+	param_get(param_find("UAVCAN_SUB_FUEL"), &uavcan_sub_fuel);
+
+	if (uavcan_sub_fuel != 0) {
+		list.add(new UavcanFuelTankStatusBridge(node));
 	}
 
 #endif

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -293,6 +293,17 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_DPRES, 0);
 PARAM_DEFINE_INT32(UAVCAN_SUB_FLOW, 0);
 
 /**
+ * subscription fuel tank
+ *
+ * Enable UAVCAN fuel tank subscription.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_SUB_FUEL, 0);
+
+/**
  * subscription GPS
  *
  * Enable UAVCAN GPS subscriptions.


### PR DESCRIPTION
**Describe problem solved by this pull request**
According to the #17861 I've added a UAVCAN fuel tank sensor that allows at that moment just to log fuel tank data, but in future it is possible to extend it for making an internal combustion engine control.

**Describe your solution**
Here I've created a simple uavcan fuel tank status bridge that converts [uavcan.equipment.ice.FuelTankStatus](https://legacy.uavcan.org/Specification/7._List_of_standard_data_types/#fueltankstatus) message into uorb `battery_status`, so `SYS_STATUS` automatically populates a `battery_remaining` field with a fuel tank level.
I `filled battery_status.connect` as `false` because I think at that moment fuel tank should not interfere on the existing control such as `low battery failsafe trigger`. I filled other fields which are useless for fuel tank as 0 as well.

**Test data / coverage**
I've tested it in uavcan hitl simulator on cuav v5+ by sending simple fuel tank messages during the flight. It's important to notice that during the test I used [a little bit different Autopilot version than master branch](https://github.com/InnopolisAero/PX4-Autopilot/tree/px4_v1.12.1_inno_vtol_dynamics_wth_fuel_tank) because simulator needs custom airframe and turning off the internal sensors. In the test firmware I also filled `battery_status.connect` as `true` just to visualize fuel tank level. You can see [the screencast of simulated flight](https://youtu.be/002TO4F6SZ0) if it is interesting.
Actual firmware seems to be ok as well. Perhaps next week we will perform a real flight with this feature.
