### PR TITLE
Added support for takeoff and land commands in mission

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1487,6 +1487,8 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		case MAV_CMD_DO_SET_ROI_NONE:
 		case MAV_CMD_CONDITION_DELAY:
 		case MAV_CMD_CONDITION_DISTANCE:
+		case MAV_CMD_NAV_TAKEOFF:
+		case MAV_CMD_NAV_LAND:
 			mission_item->nav_cmd = (NAV_CMD)mavlink_mission_item->command;
 			break;
 


### PR DESCRIPTION
Fixed issue, to allow actions like takeoff, land or transition inside mission items. 

Based on: https://github.com/mavlink/MAVSDK/pull/1424