### PR TITLE
Increase stacks for 64 bit

### DIFF
--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -266,7 +266,7 @@ WorkQueueManagerRun(int, char **)
 #if defined(__PX4_QURT)
 			const size_t stacksize = math::max(8 * 1024, PX4_STACK_ADJUSTED(wq->stacksize));
 #elif defined(__PX4_NUTTX)
-			const size_t stacksize = math::max((uint16_t)PTHREAD_STACK_MIN, wq->stacksize);
+			const size_t stacksize = math::max(PTHREAD_STACK_MIN, PX4_STACK_ADJUSTED(wq->stacksize));
 #elif defined(__PX4_POSIX)
 			// On posix system , the desired stacksize round to the nearest multiplier of the system pagesize
 			// It is a requirement of the  pthread_attr_setstacksize* function
@@ -332,7 +332,7 @@ WorkQueueManagerStart()
 		int task_id = px4_task_spawn_cmd("wq:manager",
 						 SCHED_DEFAULT,
 						 SCHED_PRIORITY_MAX,
-						 1280,
+						 PX4_STACK_ADJUSTED(1280),
 						 (px4_main_t)&WorkQueueManagerRun,
 						 nullptr);
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -102,7 +102,7 @@ struct GPS_Sat_Info {
 	satellite_info_s _data;
 };
 
-static constexpr int TASK_STACK_SIZE = 1760;
+static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1760);
 
 
 class GPS : public ModuleBase<GPS>, public device::Device

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -1229,7 +1229,8 @@ start()
 	px4_sem_setprotocol(&g_init_sema, SEM_PRIO_NONE);
 
 	/* start the worker thread with low priority for disk IO */
-	if ((task = px4_task_spawn_cmd("dataman", SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT - 10, TASK_STACK_SIZE, task_main,
+	if ((task = px4_task_spawn_cmd("dataman", SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT - 10,
+				       PX4_STACK_ADJUSTED(TASK_STACK_SIZE), task_main,
 				       nullptr)) < 0) {
 		px4_sem_destroy(&g_init_sema);
 		PX4_ERR("task start failed");

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -163,7 +163,7 @@ int Logger::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("logger",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_LOG_CAPTURE,
-				      3700,
+				      PX4_STACK_ADJUSTED(3700),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -69,7 +69,7 @@
 #endif
 
 #ifdef CONFIG_NET
-#define MAVLINK_NET_ADDED_STACK 350
+#define MAVLINK_NET_ADDED_STACK PX4_STACK_ADJUSTED(350)
 #else
 #define MAVLINK_NET_ADDED_STACK 0
 #endif
@@ -2824,7 +2824,7 @@ Mavlink::start(int argc, char *argv[])
 	px4_task_spawn_cmd(buf,
 			   SCHED_DEFAULT,
 			   SCHED_PRIORITY_DEFAULT,
-			   2896 + MAVLINK_NET_ADDED_STACK,
+			   PX4_STACK_ADJUSTED(2896) + MAVLINK_NET_ADDED_STACK,
 			   (px4_main_t)&Mavlink::start_helper,
 			   (char *const *)argv);
 

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -256,7 +256,7 @@ int micrortps_client_main(int argc, char *argv[])
 		_rtps_task = px4_task_spawn_cmd("micrortps_client",
 						SCHED_DEFAULT,
 						SCHED_PRIORITY_DEFAULT,
-						2900,
+						PX4_STACK_ADJUSTED(2900),
 						(px4_main_t) micrortps_start,
 						(char *const *)argv);
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -857,7 +857,7 @@ int Navigator::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("navigator",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_NAVIGATION,
-				      1800,
+				      PX4_STACK_ADJUSTED(1800),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 


### PR DESCRIPTION
This uses PX4_STACK_ADJUSTED macro for various modules, to increase stack for 64-bit NuttX targets (RISC-V RV64GC)

This is just a set of modules which we have used so far with MPFS board, I didn't add the macro everywhere.

Also, it may be that some of the systemcmd stacks, defined by build environment (STACK_MAIN etc.), should be increased as well, but so far we didn't see problems with those.

