### PR TITLE
component_information: merge extra component_information_header target 

### DIFF
--- a/src/lib/component_information/CMakeLists.txt
+++ b/src/lib/component_information/CMakeLists.txt
@@ -68,12 +68,16 @@ endif()
 list(APPEND comp_metadata_types "--type" "4,${PX4_BINARY_DIR}/events/all_events.json.xz,${comp_metadata_events_uri},${comp_metadata_events_uri_fallback},")
 
 set(component_general_json ${PX4_BINARY_DIR}/component_general.json)
-add_custom_command(OUTPUT ${component_general_json} ${component_general_json}.xz
+set(component_information_header ${CMAKE_CURRENT_BINARY_DIR}/checksums.h)
+add_custom_command(OUTPUT ${component_general_json} ${component_general_json}.xz ${component_information_header}
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_component_general.py
 		${component_general_json}
 		--compress
 		${comp_metadata_types}
 		--version-file ${PX4_BINARY_DIR}/src/lib/version/build_git_version.h
+	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_crc.py
+		${component_general_json}
+		--output ${component_information_header}
 	DEPENDS
 		generate_component_general.py
 		${PX4_BINARY_DIR}/parameters.json.xz
@@ -81,21 +85,10 @@ add_custom_command(OUTPUT ${component_general_json} ${component_general_json}.xz
 		${PX4_BINARY_DIR}/events/all_events.json.xz
 		events_json
 		ver_gen
-	COMMENT "Generating component_general.json"
+		generate_crc.py
+	COMMENT "Generating component_general.json and checksums.h"
 )
 add_custom_target(component_general_json DEPENDS ${component_general_json})
 
-
-set(component_information_header ${CMAKE_CURRENT_BINARY_DIR}/checksums.h)
-add_custom_command(OUTPUT ${component_information_header}
-	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_crc.py
-		${component_general_json}
-		--output ${component_information_header}
-	DEPENDS
-		generate_crc.py
-		${component_general_json}
-	COMMENT "Generating component_information/checksums.h"
-)
-add_custom_target(component_information_header DEPENDS ${component_information_header})
 
 

--- a/src/lib/component_information/generate_component_general.py
+++ b/src/lib/component_information/generate_component_general.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import lzma #to create .xz file
 import re
-import os
 
 parser = argparse.ArgumentParser(description="""Generate the COMPONENT_GENERAL json file""")
 parser.add_argument('filename', metavar='component_general.json', help='JSON output file')
@@ -76,14 +75,5 @@ component_general['metadataTypes'] = metadata_types
 with open(filename, 'w') as outfile:
     json.dump(component_general, outfile)
 
-# DEBUG: in some cases writing the compressed file fails with 'No such file or directory'
-# even though it was just written above
-if not os.path.isfile(filename):
-    print('{:} does not exist'.format(filename))
-
 if compress:
-    try:
-        save_compressed(filename)
-    except FileNotFoundError as e:
-        print(os.listdir(os.path.dirname(filename)))
-        raise
+    save_compressed(filename)

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -65,7 +65,7 @@ px4_add_module(
 		module.yaml
 	DEPENDS
 		airspeed
-		component_information_header
+		component_general_json # for checksums.h
 		drivers_accelerometer
 		drivers_barometer
 		drivers_gyroscope


### PR DESCRIPTION


With Makefile build, generate_component_general.py was called twice during
build, which did not happen with the ninja build.

This created a race condition with the following error in rare cases:
```
Traceback (most recent call last):
  File "/__w/PX4-Autopilot/PX4-Autopilot/src/lib/component_information/generate_component_general.py", line 79, in <module>
    save_compressed(filename)
  File "/__w/PX4-Autopilot/PX4-Autopilot/src/lib/component_information/generate_component_general.py", line 33, in save_compressed
    with open(filename, 'r') as content_file:
FileNotFoundError: [Errno 2] No such file or directory: '/__w/PX4-Autopilot/PX4-Autopilot/build/px4_sitl_default/component_general.json'
make[3]: *** [src/lib/component_information/CMakeFiles/component_information_header.dir/build.make:68: component_general.json] Error 1
```

Merging the targets avoids the duplicate execution.

@davids5 