### PR TITLE
Improve offboard failsafe

### DIFF
--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
@@ -45,6 +45,7 @@ import rospy
 import math
 import numpy as np
 from geometry_msgs.msg import PoseStamped, Quaternion
+from mavros_msgs.msg import ParamValue
 from mavros_test_common import MavrosTestCommon
 from pymavlink import mavutil
 from six.moves import xrange
@@ -163,6 +164,9 @@ class MavrosOffboardPosctlTest(MavrosTestCommon):
                                    10, -1)
 
         self.log_topic_vars()
+        # exempting failsafe from lost RC to allow offboard
+        rcl_except = ParamValue(1<<2, 0.0)
+        self.set_param("COM_RCL_EXCEPT", rcl_except, 5)
         self.set_mode("OFFBOARD", 5)
         self.set_arm(True, 5)
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -751,7 +751,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status_flags.offboard_control_signal_lost) {
 			if (status.rc_signal_lost) {
 				// Offboard and RC are lost
-				enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_offboard);
+				enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_offboard);
 				set_offboard_loss_nav_state(status, armed, status_flags, offb_loss_act);
 
 			} else {

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -771,7 +771,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		} else if (status.rc_signal_lost && !(param_com_rcl_except & RCLossExceptionBits::RCL_EXCEPT_OFFBOARD)) {
 			// Only RC is lost
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
-			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_rcl_act_t);
 
 		} else {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_OFFBOARD;

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -143,18 +143,18 @@ void AutopilotTester::set_height_source(AutopilotTester::HeightSource height_sou
 	}
 }
 
-void AutopilotTester::set_rcl_except(AutopilotTester::RCLExcept mask)
+void AutopilotTester::set_rc_loss_exception(AutopilotTester::RcLossException mask)
 {
 	switch (mask) {
-	case RCLExcept::Mission:
+	case RcLossException::Mission:
 		CHECK(_param->set_param_int("COM_RCL_EXCEPT", 1 << 0) == Param::Result::Success);
 		break;
 
-	case RCLExcept::Hold:
+	case RcLossException::Hold:
 		CHECK(_param->set_param_int("COM_RCL_EXCEPT", 1 << 1) == Param::Result::Success);
 		break;
 
-	case RCLExcept::Offboard:
+	case RcLossException::Offboard:
 		CHECK(_param->set_param_int("COM_RCL_EXCEPT", 1 << 2) == Param::Result::Success);
 	}
 }

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -143,6 +143,22 @@ void AutopilotTester::set_height_source(AutopilotTester::HeightSource height_sou
 	}
 }
 
+void AutopilotTester::set_rcl_except(AutopilotTester::RCLExcept mask)
+{
+	switch (mask) {
+	case RCLExcept::Mission:
+		CHECK(_param->set_param_int("COM_RCL_EXCEPT", 1 << 0) == Param::Result::Success);
+		break;
+
+	case RCLExcept::Hold:
+		CHECK(_param->set_param_int("COM_RCL_EXCEPT", 1 << 1) == Param::Result::Success);
+		break;
+
+	case RCLExcept::Offboard:
+		CHECK(_param->set_param_int("COM_RCL_EXCEPT", 1 << 2) == Param::Result::Success);
+	}
+}
+
 void AutopilotTester::arm()
 {
 	const auto result = _action->arm();

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -85,6 +85,12 @@ public:
 		Gps
 	};
 
+	enum class RCLExcept {
+		Mission,
+		Hold,
+		Offboard
+	};
+
 	AutopilotTester();
 	~AutopilotTester();
 
@@ -96,6 +102,7 @@ public:
 	void check_home_not_within(float min_distance_m);
 	void set_takeoff_altitude(const float altitude_m);
 	void set_height_source(HeightSource height_source);
+	void set_rcl_except(RCLExcept mask);
 	void arm();
 	void takeoff();
 	void land();

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -102,7 +102,7 @@ public:
 	void check_home_not_within(float min_distance_m);
 	void set_takeoff_altitude(const float altitude_m);
 	void set_height_source(HeightSource height_source);
-	void set_rcl_except(RCLExcept mask);
+	void set_rc_loss_exception(RcLossException mask);
 	void arm();
 	void takeoff();
 	void land();

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -85,10 +85,10 @@ public:
 		Gps
 	};
 
-	enum class RCLExcept {
-		Mission,
-		Hold,
-		Offboard
+	enum class RcLossException {
+		Mission = 0,
+		Hold = 1,
+		Offboard = 2
 	};
 
 	AutopilotTester();

--- a/test/mavsdk_tests/test_multicopter_offboard.cpp
+++ b/test/mavsdk_tests/test_multicopter_offboard.cpp
@@ -42,6 +42,7 @@ TEST_CASE("Offboard takeoff and land", "[multicopter][offboard]")
 	tester.connect(connection_url);
 	tester.wait_until_ready();
 	tester.store_home();
+	tester.set_rcl_except(AutopilotTester::RCLExcept::Offboard);
 	tester.arm();
 	std::chrono::seconds goto_timeout = std::chrono::seconds(90);
 	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);
@@ -60,6 +61,7 @@ TEST_CASE("Offboard position control", "[multicopter][offboard]")
 	tester.connect(connection_url);
 	tester.wait_until_ready();
 	tester.store_home();
+	tester.set_rcl_except(AutopilotTester::RCLExcept::Offboard);
 	tester.arm();
 	std::chrono::seconds goto_timeout = std::chrono::seconds(120);
 	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);

--- a/test/mavsdk_tests/test_multicopter_offboard.cpp
+++ b/test/mavsdk_tests/test_multicopter_offboard.cpp
@@ -42,7 +42,7 @@ TEST_CASE("Offboard takeoff and land", "[multicopter][offboard]")
 	tester.connect(connection_url);
 	tester.wait_until_ready();
 	tester.store_home();
-	tester.set_rcl_except(AutopilotTester::RCLExcept::Offboard);
+	tester.set_rc_loss_exception(AutopilotTester::RcLossException::Offboard);
 	tester.arm();
 	std::chrono::seconds goto_timeout = std::chrono::seconds(90);
 	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);
@@ -61,7 +61,7 @@ TEST_CASE("Offboard position control", "[multicopter][offboard]")
 	tester.connect(connection_url);
 	tester.wait_until_ready();
 	tester.store_home();
-	tester.set_rcl_except(AutopilotTester::RCLExcept::Offboard);
+	tester.set_rc_loss_exception(AutopilotTester::RcLossException::Offboard);
 	tester.arm();
 	std::chrono::seconds goto_timeout = std::chrono::seconds(120);
 	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Closes #16534 using 2nd proposal of adding a new parameter to allow for failsafe on RC only.

**Describe your solution**
Change the following:
   * When Both offboard and RC are lost, use OBL_ACT instead of OBL_RC_ACT
   * When only offboard is lost and RCL_EXCEPT is enabled use OBL_ACT instead of OBL_RC_ACT
   * When only RC is lost and RCL_EXCEPT is disabled, use NAV_RCL_ACT
![Untitled](https://user-images.githubusercontent.com/9113272/131142573-73be5e14-eb48-4301-8ad6-5c13084062a2.png)

**Describe possible alternatives**
The outcomes in the table were picked by my intuition, but can change if needed.

**Test data / coverage**
All scenarios in table tested and verified using jmavsim and offboard_control example in px4_ros_com.
