### PR TITLE
[WIP] update accelerometer calibration to use Levenberg Marquardt least squares fit

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.hpp
+++ b/src/lib/sensor_calibration/Accelerometer.hpp
@@ -76,6 +76,7 @@ public:
 	const matrix::Dcmf &rotation() const { return _rotation; }
 	const Rotation &rotation_enum() const { return _rotation_enum; }
 	const matrix::Vector3f &scale() const { return _scale; }
+	const matrix::Vector3f &thermal_offset() const { return _thermal_offset; }
 
 	// apply offsets and scale
 	// rotate corrected measurements from sensor to body frame

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,13 +130,17 @@
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/time.h>
 
+#include "lm_fit.hpp"
+
 #include <drivers/drv_hrt.h>
+#include <include/containers/Bitset.hpp>
 #include <lib/sensor_calibration/Accelerometer.hpp>
 #include <lib/sensor_calibration/Utilities.hpp>
 #include <lib/mathlib/mathlib.h>
 #include <lib/geo/geo.h>
 #include <matrix/math.hpp>
 #include <lib/conversion/rotation.h>
+#include <lib/mathlib/math/WelfordMean.hpp>
 #include <lib/parameters/param.h>
 #include <lib/systemlib/err.h>
 #include <lib/systemlib/mavlink_log.h>
@@ -150,191 +154,174 @@ using namespace matrix;
 using namespace time_literals;
 
 static constexpr char sensor_name[] {"accel"};
-static constexpr unsigned MAX_ACCEL_SENS = 4;
+static constexpr uint8_t MAX_ACCEL_SENS = 4;
 
 /// Data passed to calibration worker routine
 struct accel_worker_data_s {
-	orb_advert_t	*mavlink_log_pub{nullptr};
-	unsigned	done_count{0};
-	float		accel_ref[MAX_ACCEL_SENS][detect_orientation_side_count][3] {};
-	float		accel_temperature_ref[MAX_ACCEL_SENS] {NAN, NAN, NAN, NAN};
+	orb_advert_t *mavlink_log_pub{nullptr};
+	unsigned done_count{0};
+	matrix::Vector3f accel_ref[MAX_ACCEL_SENS][detect_orientation_side_count] {};
+	float accel_temperature_ref[MAX_ACCEL_SENS] {NAN, NAN, NAN, NAN};
+
+	unsigned calibration_sides{0}; ///< The total number of sides
+	bool side_data_collected[detect_orientation_side_count] {};
 };
 
 // Read specified number of accelerometer samples, calculate average and dispersion.
-static calibrate_return read_accelerometer_avg(float (&accel_avg)[MAX_ACCEL_SENS][detect_orientation_side_count][3],
-		float (&accel_temperature_avg)[MAX_ACCEL_SENS],	unsigned orient, unsigned samples_num)
+static calibrate_return read_accelerometer_avg(Vector3f(&accel_avg)[MAX_ACCEL_SENS][detect_orientation_side_count],
+		float (&accel_temperature_avg)[MAX_ACCEL_SENS], unsigned orient)
 {
-	Vector3f accel_sum[MAX_ACCEL_SENS] {};
+	calibration::Accelerometer calibrations[MAX_ACCEL_SENS] {};
+	uORB::SubscriptionMultiArray<sensor_accel_s, MAX_ACCEL_SENS> accel_subs{ORB_ID::sensor_accel};
+	math::WelfordMean<Vector3f> mean[MAX_ACCEL_SENS] {};
+
+	Vector3f accel_prev[MAX_ACCEL_SENS] {};
+
 	float temperature_sum[MAX_ACCEL_SENS] {NAN, NAN, NAN, NAN};
-	unsigned counts[MAX_ACCEL_SENS] {};
-
-	unsigned errcount = 0;
-
-	// sensor thermal corrections
-	uORB::Subscription sensor_correction_sub{ORB_ID(sensor_correction)};
-	sensor_correction_s sensor_correction{};
-	sensor_correction_sub.copy(&sensor_correction);
-
-	uORB::SubscriptionBlocking<sensor_accel_s> accel_sub[MAX_ACCEL_SENS] {
-		{ORB_ID(sensor_accel), 0, 0},
-		{ORB_ID(sensor_accel), 0, 1},
-		{ORB_ID(sensor_accel), 0, 2},
-		{ORB_ID(sensor_accel), 0, 3},
-	};
+	unsigned temperature_count[MAX_ACCEL_SENS] {};
 
 	/* use the first sensor to pace the readout, but do per-sensor counts */
-	while (counts[0] < samples_num) {
-		if (accel_sub[0].updatedBlocking(100000)) {
-			for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
-				sensor_accel_s arp;
+	bool done = false;
 
-				while (accel_sub[accel_index].update(&arp)) {
-					// fetch optional thermal offset corrections in sensor/board frame
-					Vector3f offset{0, 0, 0};
-					sensor_correction_sub.update(&sensor_correction);
+	const unsigned num_accels = math::min(accel_subs.advertised_count(), MAX_ACCEL_SENS);
 
-					if (sensor_correction.timestamp > 0 && arp.device_id != 0) {
-						for (uint8_t correction_index = 0; correction_index < MAX_ACCEL_SENS; correction_index++) {
-							if (sensor_correction.accel_device_ids[correction_index] == arp.device_id) {
-								switch (correction_index) {
-								case 0:
-									offset = Vector3f{sensor_correction.accel_offset_0};
-									break;
-								case 1:
-									offset = Vector3f{sensor_correction.accel_offset_1};
-									break;
-								case 2:
-									offset = Vector3f{sensor_correction.accel_offset_2};
-									break;
-								case 3:
-									offset = Vector3f{sensor_correction.accel_offset_3};
-									break;
-								}
-							}
-						}
-					}
+	const hrt_abstime timestamp_start = hrt_absolute_time();
 
-					accel_sum[accel_index] += Vector3f{arp.x, arp.y, arp.z} - offset;
+	while (!done && (hrt_elapsed_time(&timestamp_start) < 5_s)) {
+		unsigned good_count = 0;
 
-					counts[accel_index]++;
+		for (unsigned accel_index = 0; accel_index < num_accels; accel_index++) {
+			sensor_accel_s arp;
 
-					if (!PX4_ISFINITE(temperature_sum[accel_index])) {
-						// set first valid value
-						temperature_sum[accel_index] = (arp.temperature * counts[accel_index]);
+			while (accel_subs[accel_index].update(&arp)) {
+				calibrations[accel_index].set_device_id(arp.device_id);
+				calibrations[accel_index].SensorCorrectionsUpdate();
 
-					} else {
-						temperature_sum[accel_index] += arp.temperature;
-					}
+				// fetch optional thermal offset corrections in sensor/board frame
+				const Vector3f accel{Vector3f{arp.x, arp.y, arp.z} - calibrations[accel_index].thermal_offset()};
+
+				if ((accel - accel_prev[accel_index]).longerThan(0.5f)) {
+					mean[accel_index].reset();
+					accel_prev[accel_index] = accel;
+
+				} else {
+					mean[accel_index].update(accel);
+				}
+
+				if (!PX4_ISFINITE(temperature_sum[accel_index])) {
+					// set first valid value
+					temperature_sum[accel_index] = arp.temperature;
+					temperature_count[accel_index] = 1;
+
+				} else {
+					temperature_sum[accel_index] += arp.temperature;
+					temperature_count[accel_index]++;
 				}
 			}
 
+			if ((mean[accel_index].count() > 1000) && !mean[accel_index].variance().longerThan(0.01)) {
+				good_count++;
+			}
+		}
+
+		if ((good_count > 0) && (good_count == num_accels)) {
+			PX4_INFO("finished early: %d", mean[0].count());
+			done = true;
+
 		} else {
-			errcount++;
-			continue;
-		}
-
-		if (errcount > samples_num / 10) {
-			return calibrate_return_error;
+			px4_usleep(2000);
 		}
 	}
 
-	// rotate sensor measurements from sensor to body frame using board rotation matrix
-	const Dcmf board_rotation = calibration::GetBoardRotationMatrix();
+	unsigned good_count = 0;
 
-	for (unsigned s = 0; s < MAX_ACCEL_SENS; s++) {
-		accel_sum[s] = board_rotation * accel_sum[s];
+	for (unsigned s = 0; s < num_accels; s++) {
+		if (mean[s].valid()) {
+			const Vector3f avg = mean[s].mean();
+			const Vector3f var = mean[s].variance();
+
+			PX4_INFO("O: %d, Accel: %d, Mean: [%.6f, %.6f, %.6f], Variance: [%.6f, %.6f, %.6f]", orient, s,
+				 (double)avg(0), (double)avg(1), (double)avg(2),
+				 (double)var(0), (double)var(1), (double)var(2)
+				);
+
+			if (!var.longerThan(0.01f)) {
+				good_count++;
+
+			} else {
+				break;
+			}
+
+			accel_avg[s][orient] = mean[s].mean();
+
+		} else {
+			accel_avg[s][orient].zero();
+		}
 	}
 
 	for (unsigned s = 0; s < MAX_ACCEL_SENS; s++) {
-		const Vector3f avg{accel_sum[s] / counts[s]};
-		avg.copyTo(accel_avg[s][orient]);
+		if (temperature_count[s] > 0) {
+			accel_temperature_avg[s] = temperature_sum[s] / temperature_count[s];
 
-		accel_temperature_avg[s] = temperature_sum[s] /  counts[s];
+		} else {
+			accel_temperature_avg[s] = NAN;
+		}
 	}
 
-	return calibrate_return_ok;
+	return (good_count == num_accels) ? calibrate_return_ok : calibrate_return_error;
 }
 
 static calibrate_return accel_calibration_worker(detect_orientation_return orientation, void *data)
 {
-	static constexpr unsigned samples_num = 750;
 	accel_worker_data_s *worker_data = (accel_worker_data_s *)(data);
 
-	calibration_log_info(worker_data->mavlink_log_pub, "[cal] Hold still, measuring %s side",
-			     detect_orientation_str(orientation));
+	int attempt = 0;
 
-	read_accelerometer_avg(worker_data->accel_ref, worker_data->accel_temperature_ref, orientation, samples_num);
+	while (attempt < 10) {
+		calibration_log_info(worker_data->mavlink_log_pub, "[cal] Hold still, measuring %s side",
+				     detect_orientation_str(orientation));
 
-	// check accel
-	for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
-		switch (orientation) {
-		case ORIENTATION_TAIL_DOWN:    // [ g, 0, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_TAIL_DOWN][0] < 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid X-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
+		if (read_accelerometer_avg(worker_data->accel_ref, worker_data->accel_temperature_ref,
+					   orientation) == calibrate_return_ok) {
 
-			break;
+			calibration_log_info(worker_data->mavlink_log_pub, "[cal] %s side result: [%.3f %.3f %.3f]",
+					     detect_orientation_str(orientation),
+					     (double)worker_data->accel_ref[0][orientation](0),
+					     (double)worker_data->accel_ref[0][orientation](1),
+					     (double)worker_data->accel_ref[0][orientation](2));
 
-		case ORIENTATION_NOSE_DOWN:    // [ -g, 0, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_NOSE_DOWN][0] > 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid X-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
+			worker_data->done_count++;
+			calibration_log_info(worker_data->mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 17 * worker_data->done_count);
 
-			break;
-
-		case ORIENTATION_LEFT:         // [ 0, g, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_LEFT][1] < 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Y-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_RIGHT:        // [ 0, -g, 0 ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_RIGHT][1] > 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Y-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_UPSIDE_DOWN:  // [ 0, 0, g ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_UPSIDE_DOWN][2] < 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Z-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		case ORIENTATION_RIGHTSIDE_UP: // [ 0, 0, -g ]
-			if (worker_data->accel_ref[accel_index][ORIENTATION_RIGHTSIDE_UP][2] > 0.f) {
-				calibration_log_emergency(worker_data->mavlink_log_pub, "[cal] accel %d invalid Z-axis, check rotation", accel_index);
-				return calibrate_return_error;
-			}
-
-			break;
-
-		default:
-			break;
+			return calibrate_return_ok;
 		}
+
+		attempt++;
 	}
 
-	calibration_log_info(worker_data->mavlink_log_pub, "[cal] %s side result: [%.3f %.3f %.3f]",
-			     detect_orientation_str(orientation),
-			     (double)worker_data->accel_ref[0][orientation][0],
-			     (double)worker_data->accel_ref[0][orientation][1],
-			     (double)worker_data->accel_ref[0][orientation][2]);
-
-	worker_data->done_count++;
-	calibration_log_info(worker_data->mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 17 * worker_data->done_count);
-
-	return calibrate_return_ok;
+	return calibrate_return_error;
 }
 
 int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 {
+	// We should not try to subscribe if the topic doesn't actually exist and can be counted.
+	const unsigned orb_accel_count = orb_group_count(ORB_ID(sensor_accel));
+
+	// Warn that we will not calibrate more than MAX_GYROS gyroscopes
+	if (orb_accel_count > MAX_ACCEL_SENS) {
+		calibration_log_critical(mavlink_log_pub, "Detected %u accels, but will calibrate only %u", orb_accel_count,
+					 MAX_ACCEL_SENS);
+
+	} else if (orb_accel_count < 1) {
+		calibration_log_critical(mavlink_log_pub, "No accels found");
+		return PX4_ERROR;
+	}
+
+	// Collect: As defined by configuration
+	// start with a full mask, all six bits set
+	int32_t cal_mask = (1 << 6) - 1;
+	param_get(param_find("CAL_ACC_SIDES"), &cal_mask);
+
 	calibration_log_info(mavlink_log_pub, CAL_QGC_STARTED_MSG, sensor_name);
 
 	calibration::Accelerometer calibrations[MAX_ACCEL_SENS] {};
@@ -370,82 +357,221 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 	/* measure and calculate offsets & scales */
 	accel_worker_data_s worker_data{};
 	worker_data.mavlink_log_pub = mavlink_log_pub;
-	bool data_collected[detect_orientation_side_count] {};
 
-	if (calibrate_from_orientation(mavlink_log_pub, data_collected, accel_calibration_worker, &worker_data,
-				       false) == calibrate_return_ok) {
+	for (unsigned i = 0; i < (sizeof(worker_data.side_data_collected) / sizeof(worker_data.side_data_collected[0])); i++) {
+		if ((cal_mask & (1 << i)) > 0) {
+			// mark as missing
+			worker_data.side_data_collected[i] = false;
+			worker_data.calibration_sides++;
 
-		const Dcmf board_rotation = calibration::GetBoardRotationMatrix();
-		const Dcmf board_rotation_t = board_rotation.transpose();
+		} else {
+			// mark as completed from the beginning
+			worker_data.side_data_collected[i] = true;
+
+			calibration_log_info(mavlink_log_pub,
+					     "[cal] %s side done, rotate to a different side",
+					     detect_orientation_str(static_cast<enum detect_orientation_return>(i)));
+			px4_usleep(100000);
+		}
+	}
+
+	if (calibrate_from_orientation(mavlink_log_pub, worker_data.side_data_collected, accel_calibration_worker,
+				       &worker_data) == calibrate_return_ok) {
+
+		const Rotation board_rotation = calibration::GetBoardRotation();
 
 		bool param_save = false;
 		bool failed = true;
 
-		for (unsigned i = 0; i < MAX_ACCEL_SENS; i++) {
-			if (i < active_sensors) {
-				// calculate offsets
-				Vector3f offset{};
+		int internal_rotation_count{0};
+		Rotation internal_rotations[MAX_ACCEL_SENS] {};
 
-				// X offset: average X from TAIL_DOWN + NOSE_DOWN
-				const Vector3f accel_tail_down{worker_data.accel_ref[i][ORIENTATION_TAIL_DOWN]};
-				const Vector3f accel_nose_down{worker_data.accel_ref[i][ORIENTATION_NOSE_DOWN]};
-				offset(0) = (accel_tail_down(0) + accel_nose_down(0)) * 0.5f;
+		for (uint8_t cur_accel = 0; cur_accel < active_sensors; cur_accel++) {
+			int accel_data_count = 0;
 
-				// Y offset: average Y from LEFT + RIGHT
-				const Vector3f accel_left{worker_data.accel_ref[i][ORIENTATION_LEFT]};
-				const Vector3f accel_right{worker_data.accel_ref[i][ORIENTATION_RIGHT]};
-				offset(1) = (accel_left(1) + accel_right(1)) * 0.5f;
+			matrix::Vector3f accel_data[6] {};
 
-				// Z offset: average Z from UPSIDE_DOWN + RIGHTSIDE_UP
-				const Vector3f accel_upside_down{worker_data.accel_ref[i][ORIENTATION_UPSIDE_DOWN]};
-				const Vector3f accel_rightside_up{worker_data.accel_ref[i][ORIENTATION_RIGHTSIDE_UP]};
-				offset(2) = (accel_upside_down(2) + accel_rightside_up(2)) * 0.5f;
+			for (int orientation = 0; orientation < 6; orientation++) {
+				if ((cal_mask & (1 << orientation)) > 0) {
+					accel_data[accel_data_count] = worker_data.accel_ref[cur_accel][orientation];
+					accel_data_count++;
+				}
+			}
 
-				// transform matrix
-				Matrix3f mat_A;
-				mat_A.row(0) = accel_tail_down - offset;
-				mat_A.row(1) = accel_left - offset;
-				mat_A.row(2) = accel_upside_down - offset;
+			bool sphere_fit_only = false;
+			bool sphere_fit_success = false;
+			bool ellipsoid_fit_success = false;
 
-				// calculate inverse matrix for A: simplify matrices mult because b has only one non-zero element == g at index i
-				const Matrix3f accel_T = mat_A.I() * CONSTANTS_ONE_G;
+			sphere_params sphere_data{};
+			sphere_data.radius = CONSTANTS_ONE_G;
+			int ret = lm_fit(worker_data.accel_ref[cur_accel], 6, sphere_data, false);
 
-				// update calibration
-				const Vector3f accel_offs_rotated{board_rotation_t *offset};
-				calibrations[i].set_offset(accel_offs_rotated);
+			if (ret == PX4_OK) {
+				sphere_fit_success = true;
 
-				const Matrix3f accel_T_rotated{board_rotation_t *accel_T * board_rotation};
-				calibrations[i].set_scale(accel_T_rotated.diag());
+				if (!sphere_fit_only) {
+					int ellipsoid_ret = lm_fit(accel_data, accel_data_count, sphere_data, true);
 
-				calibrations[i].set_temperature(worker_data.accel_temperature_ref[i]);
+					if (ellipsoid_ret == PX4_OK) {
+						ellipsoid_fit_success  = true;
+					}
+				}
+
+				PX4_INFO("Accel: %" PRIu8 " sphere radius: %.4f", cur_accel, (double)sphere_data.radius);
+			}
+
+			static constexpr float scale_min = 0.9f;
+			static constexpr float scale_max = 1.1f;
+
+			for (int axis = 0; axis < 3; axis++) {
+				if ((sphere_data.diag(axis) < scale_min) || (sphere_data.diag(axis) > scale_max)) {
+					PX4_WARN("bad scale factor"); // TODO, abort and report failure
+				}
+			}
+
+			bool calibration_valid = sphere_fit_success || ellipsoid_fit_success; // TODO: scale range, offset range, etc
 
 #if defined(DEBUD_BUILD)
-				PX4_INFO("accel %d: offset", i);
-				offset.print();
-				PX4_INFO("accel %d: bT * offset", i);
-				accel_offs_rotated.print();
+			PX4_INFO("accel %d offset", cur_accel);
+			sphere_data.offset.print();
 
-				PX4_INFO("accel %d: mat_A", i);
-				mat_A.print();
-				PX4_INFO("accel %d: accel_T", i);
-				accel_T.print();
-				PX4_INFO("accel %d: bT * accel_T * b", i);
-				accel_T_rotated.print();
+			PX4_INFO("accel %d scale", cur_accel);
+			sphere_data.diag.print();
+
+			PX4_INFO("accel %d offdiagonal", cur_accel);
+			sphere_data.offdiag.print();
 #endif // DEBUD_BUILD
-				calibrations[i].PrintStatus();
+
+			if (!calibration_valid) {
+				failed = true;
+				break;
+			}
+
+			// determine best rotation
+			float calibration_metric[ROTATION_MAX] {};
+			float min_error = FLT_MAX;
+			Rotation best_rotation = ROTATION_NONE;
+
+			for (int r = ROTATION_NONE; r < ROTATION_MAX; r++) {
+				calibration_metric[r] = FLT_MAX;
+
+				// try all rotations
+				switch (r) {
+				case ROTATION_ROLL_90_PITCH_68_YAW_293: // skip
+				case ROTATION_PITCH_180_YAW_90:  // skip 26, same as 14 ROTATION_ROLL_180_YAW_270
+				case ROTATION_PITCH_180_YAW_270: // skip 27, same as 10 ROTATION_ROLL_180_YAW_90
+					break;
+
+				default: {
+						matrix::Matrix<float, 6, 3> Y;
+						static constexpr float g = CONSTANTS_ONE_G;
+						Y.row(0) = Vector3f{ g,  0,  0}; // ORIENTATION_TAIL_DOWN
+						Y.row(1) = Vector3f{-g,  0,  0}; // ORIENTATION_NOSE_DOWN,
+						Y.row(2) = Vector3f{ 0,  g,  0}; // ORIENTATION_LEFT,
+						Y.row(3) = Vector3f{ 0, -g,  0}; // ORIENTATION_RIGHT,
+						Y.row(4) = Vector3f{ 0,  0,  g}; // ORIENTATION_UPSIDE_DOWN,
+						Y.row(5) = Vector3f{ 0,  0, -g}; // ORIENTATION_RIGHTSIDE_UP
+
+						// apply calibration and compare data with expected direction
+						for (int orientation = 0; orientation < 6; orientation++) {
+
+							if ((cal_mask & (1 << orientation)) > 0) {
+								Vector3f calibrated_accel{sphere_data.diag.emult(worker_data.accel_ref[cur_accel][orientation] - sphere_data.offset)};
+
+								const Vector3f rotated_data{get_rot_matrix((Rotation)r) *calibrated_accel};
+
+								calibration_metric[r] += (rotated_data - Y.row(orientation)).norm();
+							}
+						}
+					}
+				}
 
 
-				if (calibrations[i].ParametersSave()) {
-					param_save = true;
-					failed = false;
+				if (calibration_metric[r] < min_error) {
+					min_error = calibration_metric[r];
+					best_rotation = (Rotation)r;
+				}
 
-				} else {
-					failed = true;
-					calibration_log_critical(mavlink_log_pub, "calibration save failed");
+			}
+
+			PX4_INFO("best rotation: %d", best_rotation);
+
+			if (!calibrations[cur_accel].external()) {
+				internal_rotations[internal_rotation_count] = best_rotation;
+				internal_rotation_count++;
+			}
+
+			bool print_all_errors = true;
+
+			if (calibrations[cur_accel].external()) {
+				switch (calibrations[cur_accel].rotation_enum()) {
+				case ROTATION_ROLL_90_PITCH_68_YAW_293:
+					PX4_INFO("[cal] External Accel: %" PRIu8 " (%" PRIu32 "), keeping manually configured rotation %" PRIu8,
+						 cur_accel, calibrations[cur_accel].device_id(), calibrations[cur_accel].rotation_enum());
+					continue;
+
+				default: {
+						if (best_rotation != calibrations[cur_accel].rotation_enum()) {
+							calibration_log_info(mavlink_log_pub, "[cal] External Accel: %" PRIu8 " (%" PRIu32 "), determined rotation: %" PRIu8,
+									     cur_accel, calibrations[cur_accel].device_id(), best_rotation);
+							calibrations[cur_accel].set_rotation(best_rotation);
+
+						} else {
+							PX4_INFO("[cal] External Accel: %" PRIu8 " (%" PRIu32 "), no rotation change: %" PRIu8,
+								 cur_accel, calibrations[cur_accel].device_id(), best_rotation);
+						}
+					}
 					break;
 				}
 			}
+
+			if (print_all_errors) {
+				for (int r = ROTATION_NONE; r < ROTATION_MAX; r++) {
+					if (calibration_metric[r] < FLT_MAX) {
+						PX4_ERR("Accel: %" PRIu8 " (%" PRIu32 "), rotation: %" PRIu32 ", error: %.3f",
+							cur_accel, calibrations[cur_accel].device_id(), (uint32_t)r, (double)calibration_metric[r]);
+					}
+				}
+			}
+
+			// update calibration
+			calibrations[cur_accel].set_offset(sphere_data.offset);
+			calibrations[cur_accel].set_scale(sphere_data.diag);
+			calibrations[cur_accel].set_temperature(worker_data.accel_temperature_ref[cur_accel]);
+
+			calibrations[cur_accel].PrintStatus();
+
+			// save all calibrations including empty slots
+			if (calibrations[cur_accel].ParametersSave()) {
+				param_save = true;
+				failed = false;
+
+			} else {
+				failed = true;
+				calibration_log_critical(mavlink_log_pub, "calibration save failed");
+				break;
+			}
 		}
+
+		// review SENS_BOARD_ROT, do all internal accels agree on SENS_BOARD_ROT?
+		if (!failed && (internal_rotation_count > 0)) {
+			Rotation best_rotation = internal_rotations[0];
+			bool same = true;
+
+			for (unsigned i = 0; i < MAX_ACCEL_SENS; i++) {
+				if (internal_rotations[0] != internal_rotations[i]) {
+					same = false;
+					break;
+				}
+			}
+
+			if (same && (best_rotation != board_rotation)) {
+				PX4_ERR("Incorrect board rotation: %d", board_rotation);
+				int32_t sens_board_rot = best_rotation;
+				param_set_no_notification(param_find("SENS_BOARD_ROT"), &sens_board_rot);
+			}
+		}
+
 
 		if (!failed && factory_storage.store() != PX4_OK) {
 			failed = true;
@@ -472,7 +598,6 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 #if !defined(CONSTRAINED_FLASH)
 	PX4_INFO("Accelerometer quick calibration");
 
-	bool param_save = false;
 	bool failed = true;
 
 	FactoryCalibrationStorage factory_storage;
@@ -482,135 +607,113 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 		return PX4_ERROR;
 	}
 
-	// sensor thermal corrections (optional)
-	uORB::Subscription sensor_correction_sub{ORB_ID(sensor_correction)};
-	sensor_correction_s sensor_correction{};
-	sensor_correction_sub.copy(&sensor_correction);
-
+	calibration::Accelerometer calibrations[MAX_ACCEL_SENS] {};
+	math::WelfordMean<Vector3f> mean[MAX_ACCEL_SENS] {};
 	uORB::SubscriptionMultiArray<sensor_accel_s, MAX_ACCEL_SENS> accel_subs{ORB_ID::sensor_accel};
+	px4::Bitset<MAX_ACCEL_SENS> valid_cal;
 
-	/* use the first sensor to pace the readout, but do per-sensor counts */
-	for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
-		sensor_accel_s arp{};
-		Vector3f accel_sum{};
-		float temperature_sum{NAN};
-		unsigned count = 0;
+	const hrt_abstime start_time = hrt_absolute_time();
 
-		while (accel_subs[accel_index].update(&arp)) {
-			// fetch optional thermal offset corrections in sensor/board frame
-			if ((arp.timestamp > 0) && (arp.device_id != 0)) {
-				Vector3f offset{0, 0, 0};
+	Vector3f accel_prev[MAX_ACCEL_SENS] {};
 
-				if (sensor_correction.timestamp > 0) {
-					for (uint8_t correction_index = 0; correction_index < MAX_ACCEL_SENS; correction_index++) {
-						if (sensor_correction.accel_device_ids[correction_index] == arp.device_id) {
-							switch (correction_index) {
-							case 0:
-								offset = Vector3f{sensor_correction.accel_offset_0};
-								break;
-							case 1:
-								offset = Vector3f{sensor_correction.accel_offset_1};
-								break;
-							case 2:
-								offset = Vector3f{sensor_correction.accel_offset_2};
-								break;
-							case 3:
-								offset = Vector3f{sensor_correction.accel_offset_3};
-								break;
-							}
-						}
-					}
-				}
+	while ((hrt_elapsed_time(&start_time) < 3_s) && (valid_cal.count() < accel_subs.advertised_count())) {
+		for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+			sensor_accel_s sensor_accel;
 
-				const Vector3f accel{Vector3f{arp.x, arp.y, arp.z} - offset};
+			while (accel_subs[accel_index].update(&sensor_accel)) {
+				if ((sensor_accel.timestamp > 0) && (sensor_accel.device_id != 0)) {
+					calibrations[accel_index].set_device_id(sensor_accel.device_id);
+					calibrations[accel_index].SensorCorrectionsUpdate();
 
-				if (count > 0) {
-					const Vector3f diff{accel - (accel_sum / count)};
+					const Vector3f accel{Vector3f{sensor_accel.x, sensor_accel.y, sensor_accel.z} - calibrations[accel_index].thermal_offset()};
 
-					if (diff.norm() < 1.f) {
-						accel_sum += Vector3f{arp.x, arp.y, arp.z} - offset;
+					if ((accel - accel_prev[accel_index]).longerThan(0.5f)) {
+						mean[accel_index].reset();
+						accel_prev[accel_index] = accel;
 
-						count++;
-
-						if (!PX4_ISFINITE(temperature_sum)) {
-							// set first valid value
-							temperature_sum = (arp.temperature * count);
-
-						} else {
-							temperature_sum += arp.temperature;
-						}
+					} else {
+						mean[accel_index].update(accel);
 					}
 
-				} else {
-					accel_sum = accel;
-					temperature_sum = arp.temperature;
-					count = 1;
+					if (mean[accel_index].count() > 300 && !mean[accel_index].variance().longerThan(0.01f)) {
+						valid_cal.set(accel_index, true);
+					}
 				}
 			}
 		}
 
-		if ((count > 0) && (arp.device_id != 0)) {
+		px4_usleep(1000);
 
-			bool calibrated = false;
-			const Vector3f accel_avg = accel_sum / count;
-			const float temperature_avg = temperature_sum / count;
+		for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+			if (mean[accel_index].count() > 0) {
+				PX4_DEBUG("accel %d/%d valid %d var: %.6f", accel_index, accel_subs.advertised_count(), mean[accel_index].count(),
+					  (double)mean[accel_index].variance().length());
+			}
+		}
+	}
+
+	bool calibration_updated = false;
+
+	px4::Bitset<MAX_ACCEL_SENS> calibrated;
+
+	static constexpr float g = CONSTANTS_ONE_G;
+	matrix::Matrix<float, 6, 3> Y;
+	Y.row(0) = Vector3f{ g,  0,  0}; // ORIENTATION_TAIL_DOWN
+	Y.row(1) = Vector3f{-g,  0,  0}; // ORIENTATION_NOSE_DOWN,
+	Y.row(2) = Vector3f{ 0,  g,  0}; // ORIENTATION_LEFT,
+	Y.row(3) = Vector3f{ 0, -g,  0}; // ORIENTATION_RIGHT,
+	Y.row(4) = Vector3f{ 0,  0,  g}; // ORIENTATION_UPSIDE_DOWN,
+	Y.row(5) = Vector3f{ 0,  0, -g}; // ORIENTATION_RIGHTSIDE_UP
+
+	for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+		if (valid_cal[accel_index]) {
+
+			const Vector3f accel_avg = mean[accel_index].mean();
+
+			int closest_orientation = -1;
+			float smallest_orientation_error = INFINITY;
+
+			for (int i = 0; i < 6; i++) {
+				// assume sensor/board is in one of these orientations
+				float accel_error = (Vector3f{Y.row(i)} - accel_avg).length();
+
+				if (accel_error < smallest_orientation_error) {
+					closest_orientation = i;
+					smallest_orientation_error = accel_error;
+				}
+			}
 
 			Vector3f offset{0.f, 0.f, 0.f};
 
-			uORB::SubscriptionData<vehicle_attitude_s> attitude_sub{ORB_ID(vehicle_attitude)};
-			attitude_sub.update();
+			if (closest_orientation != -1) {
+				PX4_INFO("assuming accel %d is orientation %s (%d)", accel_index,
+					 detect_orientation_str((enum detect_orientation_return)closest_orientation),
+					 closest_orientation);
 
-			if (attitude_sub.advertised() && attitude_sub.get().timestamp != 0) {
-				// use vehicle_attitude if available
-				const vehicle_attitude_s &att = attitude_sub.get();
-				const matrix::Quatf q{att.q};
-				const Vector3f accel_ref = q.conjugate_inversed(Vector3f{0.f, 0.f, -CONSTANTS_ONE_G});
-
-				// sanity check angle between acceleration vectors
-				const float angle = AxisAnglef(Quatf(accel_avg, accel_ref)).angle();
-
-				if (angle <= math::radians(10.f)) {
-					offset = accel_avg - accel_ref;
-					calibrated = true;
-				}
+				offset = accel_avg - (calibrations[accel_index].scale().emult(Vector3f{Y.row(closest_orientation)}));
+				calibrated.set(accel_index, true);
 			}
 
-			if (!calibrated) {
-				// otherwise simply normalize to gravity and remove offset
-				Vector3f accel{accel_avg};
-				accel.normalize();
-				accel = accel * CONSTANTS_ONE_G;
+			const Vector3f accel_avg_calibrated = calibrations[accel_index].scale().emult(accel_avg - offset);
 
-				offset = accel_avg - accel;
-				calibrated = true;
-			}
-
-			calibration::Accelerometer calibration{arp.device_id};
-
-			// reset cal index to uORB
-			calibration.set_calibration_index(accel_index);
-
-			if (!calibrated || (offset.norm() > CONSTANTS_ONE_G)
-			    || !PX4_ISFINITE(offset(0))
-			    || !PX4_ISFINITE(offset(1))
-			    || !PX4_ISFINITE(offset(2))) {
+			if (!calibrated[accel_index] || !accel_avg_calibrated.longerThan(CONSTANTS_ONE_G * 0.9f)
+			    || accel_avg_calibrated.longerThan(CONSTANTS_ONE_G * 1.1f)
+			    || !PX4_ISFINITE(offset(0)) || !PX4_ISFINITE(offset(1)) || !PX4_ISFINITE(offset(2))) {
 
 				PX4_ERR("accel %d quick calibrate failed", accel_index);
+				failed = true;
+				break;
 
 			} else {
-				calibration.set_offset(offset);
-				calibration.set_temperature(temperature_avg);
+				// reset cal index to uORB
+				calibrations[accel_index].set_calibration_index(accel_index);
 
-				if (calibration.ParametersSave()) {
-					calibration.PrintStatus();
-					param_save = true;
-					failed = false;
-
-				} else {
-					failed = true;
-					calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "calibration save failed");
-					break;
+				if (calibrations[accel_index].set_offset(offset)) {
+					calibrations[accel_index].PrintStatus();
+					calibration_updated = true;
 				}
+
+				failed = false;
 			}
 		}
 	}
@@ -619,15 +722,29 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 		failed = true;
 	}
 
-	if (param_save) {
-		param_notify_changes();
-	}
-
 	if (!failed) {
+		if (calibration_updated) {
+			bool param_save = false;
+
+			for (unsigned accel_index = 0; accel_index < MAX_ACCEL_SENS; accel_index++) {
+				if (calibrated[accel_index]) {
+					if (calibrations[accel_index].ParametersSave()) {
+						param_save = true;
+					}
+				}
+			}
+
+			if (param_save) {
+				param_notify_changes();
+			}
+		}
+
+		calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
 		return PX4_OK;
 	}
 
 #endif // !CONSTRAINED_FLASH
 
+	calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, sensor_name);
 	return PX4_ERROR;
 }

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -63,17 +63,16 @@
 
 using namespace time_literals;
 
-enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub, bool lenient_still_position)
+enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub)
 {
 	static constexpr unsigned ndim = 3;
 
 	float accel_ema[ndim] {};                       // exponential moving average of accel
 	float accel_disp[3] {};                         // max-hold dispersion of accel
 	static constexpr float ema_len = 0.5f;          // EMA time constant in seconds
-	static constexpr float normal_still_thr = 0.25; // normal still threshold
-	float still_thr2 = powf(lenient_still_position ? (normal_still_thr * 3) : normal_still_thr, 2);
+	float still_thr2 = powf(0.25f * 3, 2);
 	static constexpr float accel_err_thr = 5.0f;    // set accel error threshold to 5m/s^2
-	const hrt_abstime still_time = lenient_still_position ? 500000 : 1300000; // still time required in us
+	static constexpr hrt_abstime still_time = 500000;
 
 	/* set timeout to 90s */
 	static constexpr hrt_abstime timeout = 90_s;
@@ -219,7 +218,7 @@ const char *detect_orientation_str(enum detect_orientation_return orientation)
 
 calibrate_return calibrate_from_orientation(orb_advert_t *mavlink_log_pub,
 		bool side_data_collected[detect_orientation_side_count], calibration_from_orientation_worker_t calibration_worker,
-		void *worker_data, bool lenient_still_position)
+		void *worker_data)
 {
 	const hrt_abstime calibration_started = hrt_absolute_time();
 	calibrate_return result = calibrate_return_ok;
@@ -268,7 +267,7 @@ calibrate_return calibrate_from_orientation(orb_advert_t *mavlink_log_pub,
 		px4_usleep(20000);
 		calibration_log_info(mavlink_log_pub, "[cal] hold vehicle still on a pending side");
 		px4_usleep(20000);
-		enum detect_orientation_return orient = detect_orientation(mavlink_log_pub, lenient_still_position);
+		enum detect_orientation_return orient = detect_orientation(mavlink_log_pub);
 
 		if (orient == ORIENTATION_ERROR) {
 			orientation_failures++;

--- a/src/modules/commander/calibration_routines.h
+++ b/src/modules/commander/calibration_routines.h
@@ -54,8 +54,7 @@ static constexpr unsigned detect_orientation_side_count = 6;
 /// Wait for vehicle to become still and detect it's orientation
 ///	@return Returns detect_orientation_return according to orientation when vehicle
 ///		and ready for measurements
-enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub,	///< uORB handle to write output to
-		bool lenient_still_detection);	///< true: Use more lenient still position detection
+enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub);
 
 /// Returns the human readable string representation of the orientation
 ///	@param orientation Orientation to return string for, "error" if buffer is too small
@@ -67,17 +66,15 @@ enum calibrate_return {
 	calibrate_return_cancelled
 };
 
-typedef calibrate_return(*calibration_from_orientation_worker_t)(detect_orientation_return
-		orientation,	///< Orientation which was detected
-		void *worker_data);	///< Opaque worker data
+typedef calibrate_return(*calibration_from_orientation_worker_t)(detect_orientation_return orientation,
+		void *worker_data);
 
 /// Perform calibration sequence which require a rest orientation detection prior to calibration.
 ///	@return OK: Calibration succeeded, ERROR: Calibration failed
 calibrate_return calibrate_from_orientation(orb_advert_t *mavlink_log_pub,	///< uORB handle to write output to
 		bool side_data_collected[detect_orientation_side_count],	///< Sides for which data still needs calibration
 		calibration_from_orientation_worker_t calibration_worker,	///< Worker routine which performs the actual calibration
-		void *worker_data,						///< Opaque data passed to worker routine
-		bool lenient_still_detection);					///< true: Use more lenient still position detection
+		void *worker_data);						///< Opaque data passed to worker routine
 
 /// Used to periodically check for a cancel command
 bool calibrate_cancel_check(orb_advert_t *mavlink_log_pub, const hrt_abstime &calibration_started);

--- a/src/modules/sensors/sensor_params_acc.c
+++ b/src/modules/sensors/sensor_params_acc.c
@@ -31,32 +31,36 @@
  *
  ****************************************************************************/
 
-#pragma once
-
-#include <matrix/matrix/math.hpp>
-#include <px4_platform_common/defines.h>
-
-struct sphere_params {
-	matrix::Vector3f offset{0.f, 0.f, 0.f};
-	matrix::Vector3f diag{1.f, 1.f, 1.f};
-	matrix::Vector3f offdiag{0.f, 0.f, 0.f};
-	float radius{0.2f};
-};
-
+/**
+ * Bitfield selecting mag sides for calibration
+ *
+ * If set to two side calibration, only the offsets are estimated, the scale
+ * calibration is left unchanged. Thus an initial six side calibration is
+ * recommended.
+ *
+ * Bits:
+ * ORIENTATION_TAIL_DOWN = 1
+ * ORIENTATION_NOSE_DOWN = 2
+ * ORIENTATION_LEFT = 4
+ * ORIENTATION_RIGHT = 8
+ * ORIENTATION_UPSIDE_DOWN = 16
+ * ORIENTATION_RIGHTSIDE_UP = 32
+ *
+ * @min 34
+ * @max 63
+ * @value 34 Two side calibration
+ * @value 38 Three side calibration
+ * @value 63 Six side calibration
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(CAL_ACC_SIDES, 63);
 
 /**
- * Least-squares fit of a sphere to a set of points.
+ * Automatically set external rotations.
  *
- * Fits a sphere to a set of points on the sphere surface.
+ * During calibration attempt to automatically determine the rotation of external magnetometers.
  *
- * @param data x,y,z point coordinates
- * @param samples_collected number of points
- * @param max_iterations abort if maximum number of iterations have been reached. If unsure, set to 100.
- * @param params the values to be optimized
- * @param full_ellipsoid whether to just optimize a sphere, or do an ellipsoid optimization
- *
- * NB!! If you optimize the full ellipsoid, you must have already optimized without the full ellipsoid
- *
- * @return 0 on success, 1 on failure
+ * @boolean
+ * @group Sensors
  */
-int lm_fit(const matrix::Vector3f data[], unsigned samples_collected, sphere_params &params, bool full_ellipsoid);
+PARAM_DEFINE_INT32(CAL_CAL_ROT_AUTO, 1);


### PR DESCRIPTION
 - update accel cal to use Levenberg Marquardt least squares fit (same as magnetometer)
    - this is more robust to user positioning error as it only requires a nice distribution of points and doesn't actually depend on the user holding the vehicle in each orientation (although the calibration flow is still structured this way)
 - use online Welford mean to gather clean readings per orientation
 - reset if movement during per side data gathering
 - detect invalid rotations (and soon auto correct like mag)
 - add `CAL_ACC_SIDES` (analogous to CAL_MAG_SIDES) to limit accel calibration to a subset of orientations (when full set is difficult or impossible)
 - accel quick calibration (commander calibrate accel quick) assume vehicle is aligned with gravity and adjust offsets immediately

