### PR TITLE
commander: improve progress output

### DIFF
--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -141,8 +141,10 @@ static calibrate_return gyro_calibration_worker(gyro_worker_data_t &worker_data)
 				}
 			}
 
-			if (update_count % (CALIBRATION_COUNT / 20) == 0) {
-				calibration_log_info(worker_data.mavlink_log_pub, CAL_QGC_PROGRESS_MSG, (update_count * 100) / CALIBRATION_COUNT);
+			const unsigned progress = (update_count * 100) / CALIBRATION_COUNT;
+
+			if (progress % 10 == 0) {
+				calibration_log_info(worker_data.mavlink_log_pub, CAL_QGC_PROGRESS_MSG, progress);
 			}
 
 			// Propagate out the slowest sensor's count


### PR DESCRIPTION
Instead of outputting progress at weird percentages and dropping 100%,
this now sends the progress every 10 %.

Before:
```
INFO  [commander] [cal] progress <9>
INFO  [commander] [cal] progress <14>
INFO  [commander] [cal] progress <19>
INFO  [commander] [cal] progress <24>
INFO  [commander] [cal] progress <28>
INFO  [commander] [cal] progress <33>
INFO  [commander] [cal] progress <38>
INFO  [commander] [cal] progress <43>
INFO  [commander] [cal] progress <48>
INFO  [commander] [cal] progress <52>
INFO  [commander] [cal] progress <57>
INFO  [commander] [cal] progress <62>
INFO  [commander] [cal] progress <67>
INFO  [commander] [cal] progress <72>
INFO  [commander] [cal] progress <76>
INFO  [commander] [cal] progress <81>
INFO  [commander] [cal] progress <86>
INFO  [commander] [cal] progress <91>
INFO  [commander] [cal] progress <96>
```

After:
```
INFO  [commander] [cal] progress <0>
INFO  [commander] [cal] progress <10>
INFO  [commander] [cal] progress <10>
INFO  [commander] [cal] progress <20>
INFO  [commander] [cal] progress <30>
INFO  [commander] [cal] progress <40>
INFO  [commander] [cal] progress <50>
INFO  [commander] [cal] progress <50>
INFO  [commander] [cal] progress <60>
INFO  [commander] [cal] progress <70>
INFO  [commander] [cal] progress <80>
INFO  [commander] [cal] progress <80>
INFO  [commander] [cal] progress <90>
INFO  [commander] [cal] progress <90>
INFO  [commander] [cal] progress <100>
```

This was raised in https://px4.slack.com/archives/C68J8H32A/p1629420324026900.