### PR TITLE
Commander: add comment in COM_RC_OVERRIDE that it's always enabled in Descend mode

### DIFF
--- a/src/modules/commander/ManualControl.cpp
+++ b/src/modules/commander/ManualControl.cpp
@@ -69,6 +69,7 @@ bool ManualControl::wantsOverride(const vehicle_control_mode_s &vehicle_control_
 	const bool override_offboard_mode = (_param_rc_override.get() & OverrideBits::OVERRIDE_OFFBOARD_MODE_BIT)
 					    && vehicle_control_mode.flag_control_offboard_enabled;
 
+	// in Descend and LandGPSFail manual override is enbaled independently of COM_RC_OVERRIDE
 	const bool override_landing = (vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LANDGPSFAIL
 				       || vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_DESCEND);
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -645,6 +645,9 @@ PARAM_DEFINE_INT32(COM_REARM_GRACE, 1);
  * their center position immediately gives control back to the pilot by switching to Position mode.
  * Note: Only has an effect on multicopters, and VTOLs in multicopter mode.
  *
+ * This parameter is not considered in case of a GPS failure (Descend flight mode), where stick
+ * override is always enabled.
+ *
  * @min 0
  * @max 7
  * @bit 0 Enable override during auto modes (except for in critical battery reaction)


### PR DESCRIPTION
This is just adding a comment and extends the parameter description.

I think the logic is fine (rc override always enabled in GPS failure modes of Descend and LandGPSFail). 
