### PR TITLE
[WIP] px4io_serial: ensure TX DMA is stopped if exiting early on stream error

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/px4io_serial.cpp
@@ -328,6 +328,8 @@ ArchPX4IOSerial::_bus_exchange(IOPacket *_packet)
 		if (ret == OK) {
 			/* check for DMA errors */
 			if (_rx_dma_status & DMA_STATUS_TEIF) {
+				// stream transfer error, ensure TX DMA is also stopped before exiting early
+				stm32_dmastop(_tx_dma);
 				perf_count(_pc_dmaerrs);
 				ret = -EIO;
 				break;

--- a/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/px4io_serial.cpp
@@ -373,6 +373,8 @@ ArchPX4IOSerial::_bus_exchange(IOPacket *_packet)
 		if (ret == OK) {
 			/* check for DMA errors */
 			if (_rx_dma_status & DMA_STATUS_TEIF) {
+				// stream transfer error, ensure TX DMA is also stopped before exiting early
+				stm32_dmastop(_tx_dma);
 				perf_count(_pc_dmaerrs);
 				ret = -EIO;
 				break;


### PR DESCRIPTION
 - otherwise the next retry can happen quickly enough that dma setup hangs waiting for the stream
 - this failure happens consistently if ardupilot is still on the px4io (eg cubeorange)