### PR TITLE
use more recent docker image for fixing missing python package (jsonschema)

### DIFF
--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -7,13 +7,13 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2021-05-04"
 	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]] || [[ $@ =~ .*pilotpi.default ]]; then
 		# beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default, scumaker_pilotpi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-02-04"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-08-18"
 	elif [[ $@ =~ .*pilotpi.arm64 ]]; then
 		# scumaker_pilotpi_arm64
 		PX4_DOCKER_REPO="px4io/px4-dev-aarch64:latest"
 	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-02-04"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-08-18"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"


### PR DESCRIPTION
- Get recent docker image to fix missing python jsonschema when compling linux arm based targets

slack thread : https://px4.slack.com/archives/C50RWGQMT/p1630417292050700

**Describe problem solved by this pull request**
when compiling arm 32Bits linux based targets it miss some python package (jasonschema)

**Describe your solution**
docker image that is get by Docker_run.sh is outdated (2021-02-04)
changed to px4io/px4-dev-armhf:2021-08-18

**Describe possible alternatives**
why not use latest ? may be avoiding bad commit in docker image

**Test data / coverage**
run a compile from a totally fresh checkout
```
$./Tools/docker_run.sh " export NO_NINJA_BUILD=1; make scumaker_pilotpi_default"
guessing PX4_DOCKER_REPO based on input
PX4_DOCKER_REPO: px4io/px4-dev-armhf:2021-08-18
*Unable to find image 'px4io/px4-dev-armhf:2021-08-18' locally
2021-08-18: Pulling from px4io/px4-dev-armhf
1cfaf5c6f756: Already exists 
a0b6a0944f5d: Pull complete 
61dbc6117a12: Pull complete 
d3b98973acf6: Pull complete 
7862f5841fad: Pull complete 
d6c766d36232: Pull complete 
5f88ccc293d6: Pull complete 
c4aebd75ac82: Pull complete 
e6bfeb46fc49: Pull complete 
77d7346d4ca6: Pull complete 
4b3a05f272cd: Pull complete 
Digest: sha256:40f736f8dfeb641dc9220aacef35905b26b93e061473b7233f7053a316b262fd
Status: Downloaded newer image for px4io/px4-dev-armhf:2021-08-18
*Starting with UID : 1000
-- PX4 version: v1.11.0-rc3-4959-gf856b89723
-- PX4 config file: /home/oga/devel/PX4-Autopilot/boards/scumaker/pilotpi/default.cmake
-- PX4 config: scumaker_pilotpi_default
-- PX4 platform: posix
-- PX4 lockstep: disabled
-- cmake build type: RelWithDebInfo
-- The CXX compiler identification is GNU 8.3.0
-- The C compiler identification is GNU 8.3.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/lib/ccache/arm-linux-gnueabihf-gcc
-- Check for working CXX compiler: /usr/lib/ccache/arm-linux-gnueabihf-g++
-- Check for working CXX compiler: /usr/lib/ccache/arm-linux-gnueabihf-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working C compiler: /usr/lib/ccache/arm-linux-gnueabihf-gcc
-- Check for working C compiler: /usr/lib/ccache/arm-linux-gnueabihf-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Building for code coverage
-- ccache enabled via symlink (/usr/lib/ccache/arm-linux-gnueabihf-g++ -> /usr/bin/ccache)
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.7.3", minimum required is "3") 
-- ROMFS: ROMFS/px4fmu_common
-- Configuring done
-- Generating done
-- Build files have been written to: /home/oga/devel/PX4-Autopilot/build/scumaker_pilotpi_default
Scanning dependencies of target events_header
Scanning dependencies of target flighttasks_generated
Scanning dependencies of target generate_topic_listener
Scanning dependencies of target uorb_headers
[  0%] Generating Flight Tasks
[  0%] Generating combined event json file
[  0%] Generating listener_generated.cpp
[  1%] Generating uORB topic headers
[  1%] Generating px4 event header file
[  1%] Built target flighttasks_generated
[  1%] Built target generate_topic_listener
Scanning dependencies of target drivers_board
Scanning dependencies of target parameters_xml
[  1%] Building CXX object boards/scumaker/pilotpi/src/CMakeFiles/drivers_board.dir/i2c.cpp.o
[  1%] Generating serial_params.c
[  1%] Building CXX object boards/scumaker/pilotpi/src/CMakeFiles/drivers_board.dir/spi.cpp.o
[  2%] Linking CXX static library libdrivers_board.a
[  2%] Built target drivers_board
[  2%] Built target events_header
Scanning dependencies of target ver_gen
Scanning dependencies of target mixer_gen_6dof
[  2%] Generating git version header
[  3%] Generating mixer_multirotor_6dof.generated.h
[  3%] Generating parameters.xml
[  3%] Built target mixer_gen_6dof
Scanning dependencies of target mixer_gen
[  3%] Generating mixer_multirotor.generated.h
[  3%] Built target ver_gen
[... / ...]
[ 98%] Building CXX object src/modules/commander/CMakeFiles/modules__commander.dir/worker_thread.cpp.o
Scanning dependencies of target FlightTaskManualAcceleration
[ 98%] Building CXX object src/modules/flight_mode_manager/tasks/ManualAcceleration/CMakeFiles/FlightTaskManualAcceleration.dir/FlightTaskManualAcceleration.cpp.o
Scanning dependencies of target FlightTaskManualPositionSmoothVel
[ 98%] Building CXX object src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/CMakeFiles/FlightTaskManualPositionSmoothVel.dir/FlightTaskManualPositionSmoothVel.cpp.o
[100%] Linking CXX static library libmodules__commander.a
[100%] Built target modules__commander
Scanning dependencies of target FlightTaskOrbit
[100%] Building CXX object src/modules/flight_mode_manager/tasks/Orbit/CMakeFiles/FlightTaskOrbit.dir/FlightTaskOrbit.cpp.o
[100%] Linking CXX static library libFlightTaskAutoLineSmoothVel.a
[100%] Built target FlightTaskAutoLineSmoothVel
[100%] Linking CXX static library libFlightTaskManualAcceleration.a
[100%] Built target FlightTaskManualAcceleration
[100%] Linking CXX static library libFlightTaskManualPositionSmoothVel.a
[100%] Built target FlightTaskManualPositionSmoothVel
[100%] Linking CXX static library libFlightTaskOrbit.a
[100%] Built target FlightTaskOrbit
Scanning dependencies of target modules__flight_mode_manager
[100%] Building CXX object src/modules/flight_mode_manager/CMakeFiles/modules__flight_mode_manager.dir/FlightTasks_generated.cpp.o
[100%] Building CXX object src/modules/flight_mode_manager/CMakeFiles/modules__flight_mode_manager.dir/FlightModeManager.cpp.o
[100%] Linking CXX static library libmodules__flight_mode_manager.a
[100%] Built target modules__flight_mode_manager
Scanning dependencies of target px4
[100%] Building CXX object platforms/posix/CMakeFiles/px4.dir/apps.cpp.o
[100%] Building CXX object platforms/posix/CMakeFiles/px4.dir/src/px4/common/main.cpp.o
[100%] Linking CXX executable ../../bin/px4
[100%] Built target px4
Scanning dependencies of target examples__dyn_hello
[100%] Building CXX object src/examples/dyn_hello/CMakeFiles/examples__dyn_hello.dir/hello.cpp.o
[100%] Linking CXX shared library examples__dyn_hello.px4mod
[100%] Built target examples__dyn_hello

```
