### PR TITLE
Improve Ignition Gazebo Startup scripts

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -187,7 +187,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 elif [ "$program" == "ignition" ] && [ -z "$no_sim" ]; then
 	echo "Ignition Gazebo"
 	source "$src_path/Tools/setup_ignition.bash" "${src_path}" "${build_path}"
-	ign gazebo -r "${src_path}/Tools/simulation-ignition/worlds/ignition.world"&
+	ign gazebo -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
 elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	echo "FG setup"
 	cd "${src_path}/Tools/flightgear_bridge/"

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -187,7 +187,7 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 elif [ "$program" == "ignition" ] && [ -z "$no_sim" ]; then
 	echo "Ignition Gazebo"
 	source "$src_path/Tools/setup_ignition.bash" "${src_path}" "${build_path}"
-	ign gazebo -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
+	ign gazebo ${verbose} -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
 elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	echo "FG setup"
 	cd "${src_path}/Tools/flightgear_bridge/"


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the ignition startup script was not using the model name, effectively limiting it to start only one world (`ignition.world`)


**Describe your solution**
This PR extends the script so that multiple models can be added to ignition gazebo

As an addition, this PR, also enables verbose from the `VERBOSE_SIM=1` for ignition gazebo (also available for classical gazebo)

**Test data / coverage**
```
VERBOSE_SIM=1 make px4_sitl ignition
```

**Additional context**
- Includes submodule update of https://github.com/Auterion/px4-simulation-ignition/pull/14