### PR TITLE
Matrix inversion speedup

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -922,6 +922,7 @@ void runTests() {
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "sd_bench"'
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "sd_bench -u"'
 
+  sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "sensors stop"' // ignore irrelevant sensor timeouts during microbenchmarks
   sh './Tools/HIL/run_nsh_cmd.py --device `find /dev/serial -name *usb-*` --cmd "microbench all"'
 
   // test rebooting multiple times

--- a/boards/cubepilot/cubeorange/test.cmake
+++ b/boards/cubepilot/cubeorange/test.cmake
@@ -44,9 +44,9 @@ px4_add_board(
 		pwm_out_sim
 		pwm_out
 		px4io
-		roboclaw
+		#roboclaw
 		rpm
-		smart_battery/batmon
+		#smart_battery/batmon
 		telemetry # all available telemetry drivers
 		test_ppm
 		tone_alarm
@@ -107,7 +107,7 @@ px4_add_board(
 		perf
 		pwm
 		reboot
-		reflect
+		#reflect
 		sd_bench
 		#serial_test
 		system_time

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -23,7 +23,7 @@ px4_add_board(
 		#camera_capture
 		#camera_trigger
 		#differential_pressure # all available differential pressure drivers
-		differential_pressure/ms4525
+		#differential_pressure/ms4525
 		#distance_sensor # all available distance sensor drivers
 		distance_sensor/ll40ls
 		distance_sensor/lightware_laser_serial

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -75,7 +75,7 @@ px4_add_board(
 		logger
 		mavlink
 		mc_att_control
-		mc_hover_thrust_estimator
+		#mc_hover_thrust_estimator
 		mc_pos_control
 		mc_rate_control
 		navigator

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -20,7 +20,8 @@ px4_add_board(
 	DRIVERS
 		adc/ads1115
 		adc/board_adc
-		barometer # all available barometer drivers
+		#barometer # all available barometer drivers
+		barometer/ms5611
 		#batt_smbus
 		#camera_capture
 		camera_trigger

--- a/boards/px4/fmu-v5x/test.cmake
+++ b/boards/px4/fmu-v5x/test.cmake
@@ -27,17 +27,17 @@ px4_add_board(
 		gps
 		heater
 		#imu # all available imu drivers
-		imu/analog_devices/adis16448
+		#imu/analog_devices/adis16448
 		imu/bosch/bmi088
 		imu/invensense/icm20602
 		imu/invensense/icm20948 # required for ak09916 mag
 		imu/invensense/icm20649
 		imu/invensense/icm42688p
-		irlock
+		#irlock
 		lights # all available light drivers
 		magnetometer # all available magnetometer drivers
 		optical_flow # all available optical flow drivers
-		osd
+		#osd
 		pca9685
 		#pca9685_pwm_out
 		power_monitor/ina226

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
@@ -54,7 +54,7 @@ void
 ControlAllocationPseudoInverse::updatePseudoInverse()
 {
 	if (_mix_update_needed) {
-		_mix = matrix::geninv(_effectiveness);
+		matrix::geninv(_effectiveness, _mix);
 		_mix_update_needed = false;
 	}
 }

--- a/src/systemcmds/microbench/test_microbench_math.cpp
+++ b/src/systemcmds/microbench/test_microbench_math.cpp
@@ -71,14 +71,24 @@ void unlock()
 }
 
 #define PERF(name, op, count) do { \
-		px4_usleep(1000); \
 		reset(); \
 		perf_counter_t p = perf_alloc(PC_ELAPSED, name); \
-		for (int i = 0; i < count; i++) { \
-			px4_usleep(1); \
+		for (int rep = 0; rep < 10; rep++) { \
+			px4_usleep(1000); \
 			lock(); \
 			perf_begin(p); \
-			op; \
+			for (int i = 0; i < (count)/10; i++) { \
+				op; \
+				op; \
+				op; \
+				op; \
+				op; \
+				op; \
+				op; \
+				op; \
+				op; \
+				op; \
+			} \
 			perf_end(p); \
 			unlock(); \
 			reset(); \
@@ -180,50 +190,48 @@ ut_declare_test_c(test_microbench_math, MicroBenchMath)
 
 bool MicroBenchMath::time_single_precision_float()
 {
-	PERF("float add", f32_out += f32, 100);
-	PERF("float sub", f32_out -= f32, 100);
-	PERF("float mul", f32_out *= f32, 100);
-	PERF("float div", f32_out /= f32, 100);
-	PERF("float sqrt", f32_out = sqrtf(f32), 100);
+	PERF("float add (10k ops)", f32_out += f32, 10000);
+	PERF("float sub (10k ops)", f32_out -= f32, 10000);
+	PERF("float mul (10k ops)", f32_out *= f32, 10000);
+	PERF("float div (10k ops)", f32_out /= f32, 10000);
+	PERF("float sqrt (1k ops)", f32_out = sqrtf(f32), 1000);
 
 	return true;
 }
 
 bool MicroBenchMath::time_single_precision_float_trig()
 {
-	PERF("sinf()", f32_out = sinf(f32), 100);
-	PERF("cosf()", f32_out = cosf(f32), 100);
-	PERF("tanf()", f32_out = tanf(f32), 100);
+	PERF("sinf() (1k ops)", f32_out = sinf(f32), 1000);
+	PERF("cosf() (1k ops)", f32_out = cosf(f32), 1000);
+	PERF("tanf() (1k ops)", f32_out = tanf(f32), 1000);
 
-	PERF("acosf()", f32_out = acosf(f32), 100);
-	PERF("asinf()", f32_out = asinf(f32), 100);
-	PERF("atan2f()", f32_out = atan2f(f32, 2.0f * f32), 100);
+	PERF("acosf() (1k ops)", f32_out = acosf(f32), 1000);
+	PERF("asinf() (1k ops)", f32_out = asinf(f32), 1000);
+	PERF("atan2f() (1k ops)", f32_out = atan2f(f32, 2.0f * f32), 1000);
 
 	return true;
 }
 
 bool MicroBenchMath::time_double_precision_float()
 {
-	PERF("double add", f64_out += f64, 100);
-	PERF("double sub", f64_out -= f64, 100);
-	PERF("double mul", f64_out *= f64, 100);
-	PERF("double div", f64_out /= f64, 100);
-	PERF("double sqrt", f64_out = sqrt(f64), 100);
+	PERF("double add (1k ops)", f64_out += f64, 1000);
+	PERF("double sub (1k ops)", f64_out -= f64, 1000);
+	PERF("double mul (1k ops)", f64_out *= f64, 1000);
+	PERF("double div (100 ops)", f64_out /= f64, 100);
+	PERF("double sqrt (100 ops)", f64_out = sqrt(f64), 100);
 
 	return true;
 }
 
 bool MicroBenchMath::time_double_precision_float_trig()
 {
-	PERF("sin()", f64_out = sin(f64), 100);
-	PERF("cos()", f64_out = cos(f64), 100);
-	PERF("tan()", f64_out = tan(f64), 100);
+	PERF("sin() (100 ops)", f64_out = sin(f64), 100);
+	PERF("cos() (100 ops)", f64_out = cos(f64), 100);
+	PERF("tan() (100 ops)", f64_out = tan(f64), 100);
 
-	PERF("acos()", f64_out = acos(f64 * 0.5), 100);
-	PERF("asin()", f64_out = asin(f64 * 0.6), 100);
-	PERF("atan2()", f64_out = atan2(f64 * 0.7, f64 * 0.8), 100);
-
-	PERF("sqrt()", f64_out = sqrt(f64), 100);
+	PERF("acos() (100 ops)", f64_out = acos(f64 * 0.5), 100);
+	PERF("asin() (100 ops)", f64_out = asin(f64 * 0.6), 100);
+	PERF("atan2() (100 ops)", f64_out = atan2(f64 * 0.7, f64 * 0.8), 100);
 
 	return true;
 }
@@ -231,40 +239,40 @@ bool MicroBenchMath::time_double_precision_float_trig()
 
 bool MicroBenchMath::time_8bit_integers()
 {
-	PERF("int8 add", i_8_out += i_8, 100);
-	PERF("int8 sub", i_8_out -= i_8, 100);
-	PERF("int8 mul", i_8_out *= i_8, 100);
-	PERF("int8 div", i_8_out /= i_8, 100);
+	PERF("int8 add (10k ops)", i_8_out += i_8, 10000);
+	PERF("int8 sub (10k ops)", i_8_out -= i_8, 10000);
+	PERF("int8 mul (10k ops)", i_8_out *= i_8, 10000);
+	PERF("int8 div (10k ops)", i_8_out /= i_8, 10000);
 
 	return true;
 }
 
 bool MicroBenchMath::time_16bit_integers()
 {
-	PERF("int16 add", i_16_out += i_16, 100);
-	PERF("int16 sub", i_16_out -= i_16, 100);
-	PERF("int16 mul", i_16_out *= i_16, 100);
-	PERF("int16 div", i_16_out /= i_16, 100);
+	PERF("int16 add (10k ops)", i_16_out += i_16, 10000);
+	PERF("int16 sub (10k ops)", i_16_out -= i_16, 10000);
+	PERF("int16 mul (10k ops)", i_16_out *= i_16, 10000);
+	PERF("int16 div (10k ops)", i_16_out /= i_16, 10000);
 
 	return true;
 }
 
 bool MicroBenchMath::time_32bit_integers()
 {
-	PERF("int32 add", i_32_out += i_32, 100);
-	PERF("int32 sub", i_32_out -= i_32, 100);
-	PERF("int32 mul", i_32_out *= i_32, 100);
-	PERF("int32 div", i_32_out /= i_32, 100);
+	PERF("int32 add (10k ops)", i_32_out += i_32, 10000);
+	PERF("int32 sub (10k ops)", i_32_out -= i_32, 10000);
+	PERF("int32 mul (10k ops)", i_32_out *= i_32, 10000);
+	PERF("int32 div (10k ops)", i_32_out /= i_32, 10000);
 
 	return true;
 }
 
 bool MicroBenchMath::time_64bit_integers()
 {
-	PERF("int64 add", i_64_out += i_64, 100);
-	PERF("int64 sub", i_64_out -= i_64, 100);
-	PERF("int64 mul", i_64_out *= i_64, 100);
-	PERF("int64 div", i_64_out /= i_64, 100);
+	PERF("int64 add (1k ops)", i_64_out += i_64, 1000);
+	PERF("int64 sub (1k ops)", i_64_out -= i_64, 1000);
+	PERF("int64 mul (1k ops)", i_64_out *= i_64, 1000);
+	PERF("int64 div (1k ops)", i_64_out /= i_64, 1000);
 
 	return true;
 }

--- a/src/systemcmds/microbench/test_microbench_matrix.cpp
+++ b/src/systemcmds/microbench/test_microbench_matrix.cpp
@@ -170,8 +170,8 @@ bool MicroBenchMatrix::time_matrix_dcm()
 
 bool MicroBenchMatrix::time_matrix_pseduo_inverse()
 {
-	PERF("matrix 6x16 pseudo inverse (all non-zero columns)", A16 = matrix::geninv(B16), 100);
-	PERF("matrix 6x16 pseudo inverse (4 non-zero columns)", A16 = matrix::geninv(B16_4), 100);
+	PERF("matrix 6x16 pseudo inverse (all non-zero columns)", matrix::geninv(B16, A16), 100);
+	PERF("matrix 6x16 pseudo inverse (4 non-zero columns)", matrix::geninv(B16_4, A16), 100);
 	return true;
 }
 

--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -776,7 +776,8 @@ bool MatrixTest::pseudoInverseTests()
 				};
 
 	Matrix<float, 3, 4> A0(data0);
-	Matrix<float, 4, 3> A0_I = geninv(A0);
+	Matrix<float, 4, 3> A0_I;
+	geninv(A0, A0_I);
 	Matrix<float, 4, 3> A0_I_check(data0_check);
 
 	ut_test((A0_I - A0_I_check).abs().max() < 1e-5);
@@ -795,7 +796,8 @@ bool MatrixTest::pseudoInverseTests()
 				};
 
 	Matrix<float, 4, 3> A1(data1);
-	Matrix<float, 3, 4> A1_I = geninv(A1);
+	Matrix<float, 3, 4> A1_I;
+	geninv(A1, A1_I);
 	Matrix<float, 3, 4> A1_I_check(data1_check);
 
 	ut_test((A1_I - A1_I_check).abs().max() < 1e-5);
@@ -845,7 +847,8 @@ bool MatrixTest::pseudoInverseTests()
 		{ 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}
 	};
 	Matrix<float, 16, 6> A_check(A_quad_w);
-	Matrix<float, 16, 6> A = geninv(B);
+	Matrix<float, 16, 6> A;
+	geninv(B, A);
 	ut_test((A - A_check).abs().max() < 1e-5);
 
 	return true;


### PR DESCRIPTION
From https://github.com/PX4/PX4-Matrix/pull/165

Also fixes the math benchmark: trying to measure a single instruction with perf counters does not work (similar for atomic ops).

The results make more sense now when measuring over a number of ops (e.g. float div slower than add/sub/mul, double is at least an order of magnitude slower than float).
```
INFO  [microbench] RUNNING TEST: time_single_precision_float
float add (10k ops): 10 events, 4887us elapsed, 488.70us avg, min 488us max 489us 0.483us rms
float sub (10k ops): 10 events, 4890us elapsed, 489.00us avg, min 489us max 489us 0.005us rms
float mul (10k ops): 10 events, 4888us elapsed, 488.80us avg, min 488us max 489us 0.421us rms
float div (10k ops): 10 events, 12625us elapsed, 1262.50us avg, min 1262us max 1263us 0.532us rms
float sqrt (1k ops): 10 events, 1202us elapsed, 120.20us avg, min 120us max 121us 0.421us rms
INFO  [microbench] TEST PASSED: time_single_precision_float

INFO  [microbench] RUNNING TEST: time_single_precision_float_trig
sinf() (1k ops): 10 events, 10800us elapsed, 1080.00us avg, min 1080us max 1080us 0.068us rms
cosf() (1k ops): 10 events, 10500us elapsed, 1050.00us avg, min 1050us max 1050us 0.063us rms
tanf() (1k ops): 10 events, 19012us elapsed, 1901.20us avg, min 1901us max 1902us 0.410us rms
acosf() (1k ops): 10 events, 4901us elapsed, 490.10us avg, min 490us max 491us 0.315us rms
asinf() (1k ops): 10 events, 4605us elapsed, 460.50us avg, min 460us max 461us 0.526us rms
atan2f() (1k ops): 10 events, 13537us elapsed, 1353.70us avg, min 1353us max 1354us 0.491us rms
INFO  [microbench] TEST PASSED: time_single_precision_float_trig

INFO  [microbench] RUNNING TEST: time_double_precision_float
double add (1k ops): 10 events, 5863us elapsed, 586.30us avg, min 586us max 587us 0.483us rms
double sub (1k ops): 10 events, 5743us elapsed, 574.30us avg, min 574us max 575us 0.482us rms
double mul (1k ops): 10 events, 4589us elapsed, 458.90us avg, min 458us max 459us 0.315us rms
double div (100 ops): 10 events, 3780us elapsed, 378.00us avg, min 378us max 378us 0.009us rms
double sqrt (100 ops): 10 events, 1180us elapsed, 118.00us avg, min 118us max 118us 0.006us rms
INFO  [microbench] TEST PASSED: time_double_precision_float

INFO  [microbench] RUNNING TEST: time_double_precision_float_trig
sin() (100 ops): 10 events, 15960us elapsed, 1596.00us avg, min 1596us max 1596us   nanus rms
cos() (100 ops): 10 events, 17345us elapsed, 1734.50us avg, min 1734us max 1735us 0.517us rms
tan() (100 ops): 10 events, 23179us elapsed, 2317.90us avg, min 2317us max 2318us 0.331us rms
acos() (100 ops): 10 events, 1507us elapsed, 150.70us avg, min 150us max 151us 0.483us rms
asin() (100 ops): 10 events, 1726us elapsed, 172.60us avg, min 172us max 173us 0.516us rms
atan2() (100 ops): 10 events, 27132us elapsed, 2713.20us avg, min 2713us max 2714us 0.441us rms
sqrt() (100 ops): 10 events, 1182us elapsed, 118.20us avg, min 118us max 119us 0.421us rms
INFO  [microbench] TEST PASSED: time_double_precision_float_trig

INFO  [microbench] RUNNING TEST: time_8bit_integers
int8 add (10k ops): 10 events, 4948us elapsed, 494.80us avg, min 494us max 495us 0.422us rms
int8 sub (10k ops): 10 events, 4944us elapsed, 494.40us avg, min 494us max 495us 0.517us rms
int8 mul (10k ops): 10 events, 4945us elapsed, 494.50us avg, min 494us max 495us 0.527us rms
int8 div (10k ops): 10 events, 4888us elapsed, 488.80us avg, min 488us max 489us 0.421us rms
INFO  [microbench] TEST PASSED: time_8bit_integers

INFO  [microbench] RUNNING TEST: time_16bit_integers
int16 add (10k ops): 10 events, 4885us elapsed, 488.50us avg, min 488us max 489us 0.527us rms
int16 sub (10k ops): 10 events, 4888us elapsed, 488.80us avg, min 488us max 489us 0.421us rms
int16 mul (10k ops): 10 events, 4889us elapsed, 488.90us avg, min 488us max 489us 0.316us rms
int16 div (10k ops): 10 events, 7266us elapsed, 726.60us avg, min 726us max 727us 0.515us rms
INFO  [microbench] TEST PASSED: time_16bit_integers

INFO  [microbench] RUNNING TEST: time_32bit_integers
int32 add (10k ops): 10 events, 4290us elapsed, 429.00us avg, min 429us max 429us   nanus rms
int32 sub (10k ops): 10 events, 4291us elapsed, 429.10us avg, min 429us max 430us 0.315us rms
int32 mul (10k ops): 10 events, 4292us elapsed, 429.20us avg, min 429us max 430us 0.421us rms
int32 div (10k ops): 10 events, 4888us elapsed, 488.80us avg, min 488us max 489us 0.422us rms
INFO  [microbench] TEST PASSED: time_32bit_integers

INFO  [microbench] RUNNING TEST: time_64bit_integers
int64 add (1k ops): 10 events, 1199us elapsed, 119.90us avg, min 119us max 120us 0.316us rms
int64 sub (1k ops): 10 events, 1273us elapsed, 127.30us avg, min 127us max 128us 0.482us rms
int64 mul (1k ops): 10 events, 1008us elapsed, 100.80us avg, min 100us max 101us 0.421us rms
int64 div (1k ops): 10 events, 6864us elapsed, 686.40us avg, min 686us max 687us 0.516us rms
INFO  [microbench] TEST PASSED: time_64bit_integers
```
However there's a remaining issue: loading and storing from/to memory uses additional runtime, distorting the results (this could be fixed by using inline assembly). So I'm inclined to just remove the tests to avoid incorrect interpretation.

Out of interest I also checked cos/sin from cmsis:
```
sinf() (1k ops): 10 events, 8714us elapsed, 871.40us avg, min 871us max 872us 0.515us rms
cosf() (1k ops): 10 events, 8357us elapsed, 835.70us avg, min 835us max 836us 0.480us rms
arm_sin() (1k ops): 10 events, 2933us elapsed, 293.30us avg, min 293us max 294us 0.483us rms
arm_cos() (1k ops): 10 events, 3110us elapsed, 311.00us avg, min 311us max 311us   nanus rms
```
So we would gain something there, but the result is also less accurate.

