### PR TITLE
Support headless mode for ignition gazebo

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -186,8 +186,13 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 	fi
 elif [ "$program" == "ignition" ] && [ -z "$no_sim" ]; then
 	echo "Ignition Gazebo"
+	if [[ -n "$HEADLESS" ]]; then
+		ignition_headless="-s"
+	else
+		ignition_headless=""
+	fi
 	source "$src_path/Tools/setup_ignition.bash" "${src_path}" "${build_path}"
-	ign gazebo ${verbose} -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
+	ign gazebo ${verbose} ${ignition_headless} -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
 elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	echo "FG setup"
 	cd "${src_path}/Tools/flightgear_bridge/"


### PR DESCRIPTION
**Describe problem solved by this pull request**
While `HEADLESS=1` supports other simulators such as `jsbsim`, `gazebo` this flag doesn't work for ignition gazebo

**Describe your solution**
This adds support for `HEADLESS=1` when starting ignition gazebo with headless mode

**Test data / coverage**
Headless mode can be tested with the following command
```
HEADLESS=1 make px4_sitl ignition
```

**Additional context**
- This is a follow up PR of https://github.com/PX4/PX4-Autopilot/pull/18187