### PR TITLE
boards: cubepilot_cubeorange only start ADSB mavlink if console not present

### DIFF
--- a/boards/cubepilot/cubeorange/init/rc.board_mavlink
+++ b/boards/cubepilot/cubeorange/init/rc.board_mavlink
@@ -6,5 +6,8 @@
 # Start MAVLink on the USB port
 mavlink start -d /dev/ttyACM0
 
-# Start ADS-B receiver mavlink connection
-mavlink start -d /dev/ttyS4
+# Start ADS-B receiver mavlink connection if console not present
+if [ ! -e /dev/console ]
+then
+	mavlink start -d /dev/ttyS4 -b 57600 -m minimal
+fi


### PR DESCRIPTION
Attempting to fix the console/test build.