### PR TITLE
Ctrlalloc: refactor param update

### DIFF
--- a/platforms/common/include/px4_platform_common/module_params.h
+++ b/platforms/common/include/px4_platform_common/module_params.h
@@ -61,9 +61,14 @@ public:
 		if (parent) {
 			parent->_children.add(this);
 		}
+
+		_parent = parent;
 	}
 
-	virtual ~ModuleParams() = default;
+	virtual ~ModuleParams()
+	{
+		if (_parent) { _parent->_children.remove(this); }
+	}
 
 	// Disallow copy construction and move assignment.
 	ModuleParams(const ModuleParams &) = delete;
@@ -93,4 +98,5 @@ protected:
 private:
 	/** @list _children The module parameter list of inheriting classes. */
 	List<ModuleParams *> _children;
+	ModuleParams *_parent{nullptr};
 };

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
@@ -77,7 +77,7 @@ public:
 	 *
 	 * @return true if updated and matrix is set
 	 */
-	virtual bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix) = 0;
+	virtual bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix, bool force = false) = 0;
 
 	/**
 	 * Get the actuator trims

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.cpp
@@ -41,21 +41,16 @@
 
 #include "ActuatorEffectivenessMultirotor.hpp"
 
-ActuatorEffectivenessMultirotor::ActuatorEffectivenessMultirotor():
-	ModuleParams(nullptr)
+ActuatorEffectivenessMultirotor::ActuatorEffectivenessMultirotor(ModuleParams *parent):
+	ModuleParams(parent)
 {
 }
 
 bool
-ActuatorEffectivenessMultirotor::getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix)
+ActuatorEffectivenessMultirotor::getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix,
+		bool force)
 {
-	// Check if parameters have changed
-	if (_updated || _parameter_update_sub.updated()) {
-		// clear update
-		parameter_update_s param_update;
-		_parameter_update_sub.copy(&param_update);
-
-		updateParams();
+	if (_updated || force) {
 		_updated = false;
 
 		// Get multirotor geometry
@@ -148,6 +143,7 @@ ActuatorEffectivenessMultirotor::computeEffectivenessMatrix(const MultirotorGeom
 	effectiveness.setZero();
 
 	for (size_t i = 0; i < NUM_ROTORS_MAX; i++) {
+
 		// Get rotor axis
 		matrix::Vector3f axis(
 			geometry.rotors[i].axis_x,

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
@@ -46,14 +46,13 @@
 #include <px4_platform_common/module_params.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/parameter_update.h>
 
 using namespace time_literals;
 
 class ActuatorEffectivenessMultirotor: public ModuleParams, public ActuatorEffectiveness
 {
 public:
-	ActuatorEffectivenessMultirotor();
+	ActuatorEffectivenessMultirotor(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessMultirotor() = default;
 
 	static constexpr int NUM_ROTORS_MAX = 8;
@@ -76,12 +75,10 @@ public:
 	static int computeEffectivenessMatrix(const MultirotorGeometry &geometry,
 					      matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &effectiveness);
 
-	bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix) override;
+	bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix, bool force = false) override;
 
 	int numActuators() const override { return _num_actuators; }
 private:
-	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-
 	bool _updated{true};
 	int _num_actuators{0};
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
@@ -47,9 +47,10 @@ ActuatorEffectivenessStandardVTOL::ActuatorEffectivenessStandardVTOL()
 }
 
 bool
-ActuatorEffectivenessStandardVTOL::getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix)
+ActuatorEffectivenessStandardVTOL::getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix,
+		bool force)
 {
-	if (!_updated) {
+	if (!(_updated || force)) {
 		return false;
 	}
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
@@ -49,7 +49,7 @@ public:
 	ActuatorEffectivenessStandardVTOL();
 	virtual ~ActuatorEffectivenessStandardVTOL() = default;
 
-	bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix) override;
+	bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix, bool force = false) override;
 
 	/**
 	 * Set the current flight phase

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -46,9 +46,10 @@ ActuatorEffectivenessTiltrotorVTOL::ActuatorEffectivenessTiltrotorVTOL()
 	setFlightPhase(FlightPhase::HOVER_FLIGHT);
 }
 bool
-ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix)
+ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix,
+		bool force)
 {
-	if (!_updated) {
+	if (!(_updated || force)) {
 		return false;
 	}
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -49,7 +49,7 @@ public:
 	ActuatorEffectivenessTiltrotorVTOL();
 	virtual ~ActuatorEffectivenessTiltrotorVTOL() = default;
 
-	bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix) override;
+	bool getEffectivenessMatrix(matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &matrix, bool force = false) override;
 
 	/**
 	 * Set the current flight phase

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -245,16 +245,18 @@ ControlAllocator::Run()
 
 	// Check if parameters have changed
 	if (_parameter_update_sub.updated()) {
-		// clear update
-		parameter_update_s param_update;
-		_parameter_update_sub.copy(&param_update);
+		updateParams();
+		parameters_updated();
 
 		if (_control_allocation) {
 			_control_allocation->updateParameters();
 		}
 
-		updateParams();
-		parameters_updated();
+		update_effectiveness_matrix_if_needed();
+
+		// clear update
+		parameter_update_s param_update;
+		_parameter_update_sub.copy(&param_update);
 	}
 
 	if (_control_allocation == nullptr || _actuator_effectiveness == nullptr) {

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -105,7 +105,7 @@ private:
 	void update_allocation_method();
 	void update_effectiveness_source();
 
-	void update_effectiveness_matrix_if_needed();
+	void update_effectiveness_matrix_if_needed(bool force = false);
 
 	void publish_actuator_setpoint();
 	void publish_control_allocator_status();


### PR DESCRIPTION
**Describe problem solved by this pull request**
The parameter loading didn't work as expected when using the "ControlAllocation" module. The parameters were first loaded, then if the drone is a multirotor, the `ActuatorEffectiveness` object is changed and the information previously loaded is lost in the old object.

**Describe your solution**
- Restructure the param update handling
- Add a "force" flag to `getEffectivenessMatrix` to force a parameter reload in case of a param update trigger
- Do not subscribe to `parameter_update` uORB topic inside an `ActuatorEffectiveness` class, rely on the parent to send the force flag

**Test data / coverage**
SITL Gazebo tests: `make px4_sitl_ctrlalloc gazebo_iris_ctrlalloc`

fixes https://github.com/PX4/PX4-Autopilot/issues/17926