### PR TITLE
Update default.cmake

### DIFF
--- a/boards/modalai/fc-v1/default.cmake
+++ b/boards/modalai/fc-v1/default.cmake
@@ -10,6 +10,7 @@ px4_add_board(
 		TEL1:/dev/ttyS6 # UART7  / J5
 		TEL2:/dev/ttyS4 # UART5  / J1
 		TEL3:/dev/ttyS1 # USART2 / J4
+		TEL4:/dev/ttyS3 # UART4  / J09
 	DRIVERS
 		adc/ads1115
 		adc/board_adc


### PR DESCRIPTION
-makes TELEM/SERIAL-4 (VOXL-Flight J1009) work

On ModalAI's VOXL-Flight board the TELEM-/SERIAL4, broken out on J1009 wouldn't work at all and this line adds its full functionality.

