### PR TITLE
params.c - RC_FAILS_THR and RC_MAP_FAILSAFE

### DIFF
--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1976,7 +1976,7 @@ PARAM_DEFINE_INT32(RC_MAP_PARAM3, 0);
  * Set to a PWM value slightly above the PWM value for the channel (e.g. throttle) in a failsafe event,
  * but below the minimum PWM value for the channel during normal operation.
  *
- * Note: The default value of 0 disables the feature (it is below the expected range). 
+ * Note: The default value of 0 disables the feature (it is below the expected range).
  *
  * @min 0
  * @max 2200

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1202,13 +1202,12 @@ PARAM_DEFINE_INT32(RC_MAP_PITCH, 0);
 /**
  * Failsafe channel mapping.
  *
- * Configures which channel is used by the receiver to indicate the signal was lost.
- * Futaba receivers do report that way.
- * If 0, whichever channel is mapped to throttle is used
- * otherwise the value indicates the specific RC channel to use
+ * Configures which RC channel is used by the receiver to indicate the signal was lost
+ * (on receivers that use output a fixed signal value to report lost signal).
+ * If set to 0, the channel mapped to throttle is used.
  *
  * Use RC_FAILS_THR to set the threshold indicating lost signal. By default it's below
- * the expected range and hence diabled.
+ * the expected range and hence disabled.
  *
  * @min 0
  * @max 18
@@ -1971,11 +1970,13 @@ PARAM_DEFINE_INT32(RC_MAP_PARAM3, 0);
 /**
  * Failsafe channel PWM threshold.
  *
- * Set to a value slightly above the PWM value assumed by throttle in a failsafe event,
- * but ensure it is below the PWM value assumed by throttle during normal operation.
+ * Use RC_MAP_FAILSAFE to specify which channel is used to check RC loss using this theshold.
+ * By default this is the throttle channel.
  *
- * Use RC_MAP_FAILSAFE to specify which channel is used to check.
- * Note: The default value of 0 is below the epxed range and hence disables the feature.
+ * Set to a PWM value slightly above the PWM value for the channel (e.g. throttle) in a failsafe event,
+ * but below the minimum PWM value for the channel during normal operation.
+ *
+ * Note: The default value of 0 disables the feature (it is below the expected range). 
  *
  * @min 0
  * @max 2200

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1970,7 +1970,7 @@ PARAM_DEFINE_INT32(RC_MAP_PARAM3, 0);
 /**
  * Failsafe channel PWM threshold.
  *
- * Use RC_MAP_FAILSAFE to specify which channel is used to check RC loss using this theshold.
+ * Use RC_MAP_FAILSAFE to specify which channel is used to indicate RC loss via this theshold.
  * By default this is the throttle channel.
  *
  * Set to a PWM value slightly above the PWM value for the channel (e.g. throttle) in a failsafe event,


### PR DESCRIPTION
There was some confusion for a reader as to whether RC_FAILS_THR referred to "throttle" or "threshold". In fact it is a threshold value for the specified channel, which just happens to default to the throttle.

This attempts to make the relationships more clear.

Also removes specific info about Futaba not supporting this mechanism and makes it clear this "applies to anything that uses this mechanism for RC loss"