### PR TITLE
PreFltCheck: do not force to report ekf2 failures on GCS connection

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3528,7 +3528,7 @@ void Commander::data_link_check()
 
 					if (!_armed.armed && !_status_flags.condition_calibration_enabled) {
 						// make sure to report preflight check failures to a connecting GCS
-						PreFlightCheck::preflightCheck(&_mavlink_log_pub, _status, _status_flags, true, true,
+						PreFlightCheck::preflightCheck(&_mavlink_log_pub, _status, _status_flags, true, false,
 									       hrt_elapsed_time(&_boot_timestamp));
 					}
 				}


### PR DESCRIPTION
**Describe problem solved by this pull request**
EKF2 has a grace period of 10 seconds after boot where it doesn't need to warn the user while the sensors (especially GNSS) are still converging.
A connection to a GCS shouldn't skip this grace period but an arming request should.

**Test data / coverage**
SITL test: _Set `EKF2_REQ_EPH` to 0.1 to make the GNSS check fail_
- connecting QGC less than 10s after start does not trigger the ekf2 warnings
- connecting after those 10s does trigger the warnings
- arming withing those 10s triggers the warnings