### PR TITLE
MulticopterPositionControl: correct horizontal margin calculation

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -145,16 +145,17 @@ void PositionControl::_velocityControl(const float dt)
 	// Prioritize vertical control while keeping a horizontal margin
 	const Vector2f thrust_sp_xy(_thr_sp);
 	const float thrust_sp_xy_norm = thrust_sp_xy.norm();
+	const float thrust_max_squared = math::sq(_lim_thr_max);
 
 	// Determine how much vertical thrust is left keeping horizontal margin
 	const float allocated_horizontal_thrust = math::min(thrust_sp_xy_norm, _lim_thr_xy_margin);
-	const float thrust_z_max_squared = math::sq(_lim_thr_max) - math::sq(allocated_horizontal_thrust);
+	const float thrust_z_max_squared = thrust_max_squared - math::sq(allocated_horizontal_thrust);
 
 	// Saturate maximal vertical thrust
 	_thr_sp(2) = math::max(_thr_sp(2), -sqrtf(thrust_z_max_squared));
 
 	// Determine how much horizontal thrust is left after prioritizing vertical control
-	const float thrust_max_xy_squared = thrust_z_max_squared - math::sq(_thr_sp(2));
+	const float thrust_max_xy_squared = thrust_max_squared - math::sq(_thr_sp(2));
 	float thrust_max_xy = 0;
 
 	if (thrust_max_xy_squared > 0) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
The horizontal margin introduced in https://github.com/PX4/PX4-Autopilot/pull/18205 has a bug where it correctly limits the vertical thrust but then clamps again all horizontal thrust if the vertical thrust hits that lower limit that would allow the expected horizontal margin. This results in just a lower thrust limit and no margin again.

**Describe your solution**
Using the full available maximum thrust for limiting the horizontal thrust results in the expected margin.

**Test data / coverage**
I also corrected the unit test and made it more clear to make sure it can be understood by future developers.
I ran a SITL test saturating the motors and didn't just visually check the behavior but analyzed the values in the log:
![image](https://user-images.githubusercontent.com/4668506/132888368-4ad80f12-c6f0-442a-a1d0-4aa30e934f05.png)
Horizontal control is equal to the configured margin.
