### PR TITLE
Add bmm150 retries to fix driver start

### DIFF
--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.cpp
@@ -54,12 +54,16 @@ BMM150::~BMM150()
 
 int BMM150::init()
 {
+	I2C::_retries = 3;
+
 	int ret = I2C::init();
 
 	if (ret != PX4_OK) {
 		DEVICE_DEBUG("I2C::init failed (%i)", ret);
 		return ret;
 	}
+
+	I2C::_retries = 0;
 
 	return Reset() ? 0 : -1;
 }


### PR DESCRIPTION
This PR fixes https://github.com/PX4/PX4-Autopilot/issues/18237 by adding retries to the I2C transfers.