### PR TITLE
vscode: do not disable autocomplete on enter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,6 @@
                 "esc"
         ],
         "debug.toolBarLocation": "docked",
-        "editor.acceptSuggestionOnEnter": "off",
         "editor.defaultFormatter": "chiehyu.vscode-astyle",
         "editor.dragAndDrop": false,
         "editor.insertSpaces": false,


### PR DESCRIPTION
**Describe problem solved by this pull request**
Analogous to https://github.com/PX4/PX4-Autopilot/pull/16580 I noticed myself during usage and heard other people discuss why autocomplete doesn't work the familiar way. If there's an autocomplete suggestion by the Visual Studio Code IDE you currently need to press tab to accept it. By default you can also press enter but that is currently disabled and you always get a newline.

**Describe your solution**
It's definitely user preference and I'm not suggesting either version is better than the other but the project settings should probably keep the default in such cases. People can then customize the user settings. So I'm removing the customization of this setting on the project level.

Any objections @dagar 😇 ?