### PR TITLE
UCANS32K146-01 Add CAN tranceiver self test

### DIFF
--- a/boards/nxp/ucans32k146/nuttx-config/include/board.h
+++ b/boards/nxp/ucans32k146/nuttx-config/include/board.h
@@ -159,8 +159,12 @@
 #define PIN_CAN0_TX      PIN_CAN0_TX_4      /* PTE5 */
 #define PIN_CAN0_RX      PIN_CAN0_RX_4      /* PTE4 */
 #define PIN_CAN0_STB     (GPIO_OUTPUT | PIN_PORTE | PIN11 )
+#define PIN_CAN0_ERRN    (GPIO_INPUT  | PIN_PORTA | PIN11 )
+#define PIN_CAN0_EN      (GPIO_HIGHDRIVE  | PIN_PORTA | PIN10 )
 #define PIN_CAN1_TX      PIN_CAN1_TX_1      /* PTA13 */
 #define PIN_CAN1_RX      PIN_CAN1_RX_1      /* PTA12 */
 #define PIN_CAN1_STB     (GPIO_OUTPUT | PIN_PORTE | PIN10 )
+#define PIN_CAN1_ERRN    (GPIO_PULLDOWN  | PIN_PORTE | PIN6 )
+#define PIN_CAN1_EN      (GPIO_OUTPUT  | PIN_PORTE | PIN2 )
 
 #endif  /* __BOARDS_ARM_RDDRONE_UAVCAN146_INCLUDE_BOARD_H */

--- a/platforms/nuttx/src/canbootloader/include/board.h
+++ b/platforms/nuttx/src/canbootloader/include/board.h
@@ -57,6 +57,7 @@ typedef enum {
 	fw_update_timeout,
 	fw_update_invalid_crc,
 	jump_to_app,
+	hardware_failure,
 } uiindication_t;
 
 #ifndef __ASSEMBLY__


### PR DESCRIPTION
**Describe problem solved by this pull request**
UCANS32K146-01 uses a CAN tranceiver with ERR pin indicating, CAN tranceiver HW failure e.g. short to ground

**Describe your solution**
This PR adds the functionality of the ERR pin to the UCANS32K146 bootloader and does a HW self test. If an error occurs it indicates an error by the new `hardware_failure` led state


**Test data / coverage**
Tested on new UCANS32K146-01 revision, older revisions of this board are detected automatically and do not run this self-test.
