### PR TITLE
camera_trigger: remove camera trigger secondary

### DIFF
--- a/msg/camera_trigger.msg
+++ b/msg/camera_trigger.msg
@@ -4,4 +4,4 @@ uint64 timestamp_utc # UTC timestamp
 uint32 seq		# Image sequence number
 bool feedback	# Trigger feedback from camera
 
-# TOPICS camera_trigger camera_trigger_secondary
+# TOPICS camera_trigger

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -320,8 +320,6 @@ CameraTrigger::CameraTrigger() :
 	if (!_cam_cap_fback) {
 		_trigger_pub = orb_advertise(ORB_ID(camera_trigger), &trigger);
 
-	} else {
-		_trigger_pub = orb_advertise(ORB_ID(camera_trigger_secondary), &trigger);
 	}
 }
 
@@ -846,11 +844,10 @@ CameraTrigger::engage(void *arg)
 	trigger.feedback = false;
 	trigger.timestamp = hrt_absolute_time();
 
+	// Publish only if  _cam_cap_fback is disabled, otherwise, it is published over camera_capture driver
 	if (!trig->_cam_cap_fback) {
 		orb_publish(ORB_ID(camera_trigger), trig->_trigger_pub, &trigger);
 
-	} else {
-		orb_publish(ORB_ID(camera_trigger_secondary), trig->_trigger_pub, &trigger);
 	}
 
 	// increment frame count

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -56,7 +56,6 @@ void LoggedTopics::add_default_topics()
 	add_topic("airspeed_validated", 200);
 	add_topic("camera_capture");
 	add_topic("camera_trigger");
-	add_topic("camera_trigger_secondary");
 	add_topic("cellular_status", 200);
 	add_topic("commander_state");
 	add_topic("cpuload");


### PR DESCRIPTION
**Describe problem solved by this pull request**
When enabling the hotshoe feedback via camera capture (setting CAM_CAP_FBACK = 1), the camera trigger module publishes on `camera_trigger_secondary` instead of `camera_trigger`. Yet, MAVlink is still listening to the ‘camera_trigger’ message and as a result, the MAVLink message is never sent. 

**Describe your solution**
Removed camera_trigger_secondary since for multiple camera solutions we need a better mechanism. 
