### PR TITLE
Add vertical emergency braking in auto mode

### DIFF
--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -66,6 +66,7 @@ bool FlightTaskAutoLineSmoothVel::activate(const vehicle_local_position_setpoint
 
 	_yaw_sp_prev = PX4_ISFINITE(last_setpoint.yaw) ? last_setpoint.yaw : _yaw;
 	_updateTrajConstraints();
+	_is_emergency_braking_active = false;
 
 	return ret;
 }
@@ -116,6 +117,7 @@ void FlightTaskAutoLineSmoothVel::_ekfResetHandlerHeading(float delta_psi)
 
 void FlightTaskAutoLineSmoothVel::_generateSetpoints()
 {
+	_checkEmergencyBraking();
 	_updateTurningCheck();
 	_prepareSetpoints();
 	_generateTrajectory();
@@ -123,6 +125,20 @@ void FlightTaskAutoLineSmoothVel::_generateSetpoints()
 	if (!PX4_ISFINITE(_yaw_setpoint) && !PX4_ISFINITE(_yawspeed_setpoint)) {
 		// no valid heading -> generate heading in this flight task
 		_generateHeading();
+	}
+}
+
+void FlightTaskAutoLineSmoothVel::_checkEmergencyBraking()
+{
+	if (!_is_emergency_braking_active) {
+		if (_trajectory[2].getCurrentVelocity() > (2.f * _param_mpc_z_vel_max_dn.get())) {
+			_is_emergency_braking_active = true;
+		}
+
+	} else {
+		if (fabsf(_trajectory[2].getCurrentVelocity()) < 0.01f) {
+			_is_emergency_braking_active = false;
+		}
 	}
 }
 
@@ -309,8 +325,9 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 
 	_want_takeoff = false;
 
-	if (_param_mpc_yaw_mode.get() == 4 && !_yaw_sp_aligned) {
-		// Wait for the yaw setpoint to be aligned
+	const bool should_wait_for_yaw_align = _param_mpc_yaw_mode.get() == 4 && !_yaw_sp_aligned;
+
+	if (should_wait_for_yaw_align || _is_emergency_braking_active) {
 		_velocity_setpoint.setAll(0.f);
 		return;
 	}
@@ -412,7 +429,13 @@ void FlightTaskAutoLineSmoothVel::_updateTrajConstraints()
 	_trajectory[1].setMaxJerk(_param_mpc_jerk_auto.get());
 	_trajectory[2].setMaxJerk(_param_mpc_jerk_auto.get());
 
-	if (_velocity_setpoint(2) < 0.f) { // up
+	if (_is_emergency_braking_active) {
+		// When initializing with large downward velocity, allow 1g of vertical
+		// acceleration for fast braking
+		_trajectory[2].setMaxAccel(9.81f);
+		_trajectory[2].setMaxJerk(9.81f);
+
+	} else if (_velocity_setpoint(2) < 0.f) { // up
 		float z_accel_constraint = _param_mpc_acc_up_max.get();
 		float z_vel_constraint = _param_mpc_z_vel_max_up.get();
 

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -435,6 +435,11 @@ void FlightTaskAutoLineSmoothVel::_updateTrajConstraints()
 		_trajectory[2].setMaxAccel(9.81f);
 		_trajectory[2].setMaxJerk(9.81f);
 
+		// If the current velocity is beyond the usual constraints, tell
+		// the controller to exceptionally increase its saturations to avoid
+		// cutting out the feedforward
+		_constraints.speed_down = math::max(fabsf(_trajectory[2].getCurrentVelocity()), _param_mpc_z_vel_max_dn.get());
+
 	} else if (_velocity_setpoint(2) < 0.f) { // up
 		float z_accel_constraint = _param_mpc_acc_up_max.get();
 		float z_vel_constraint = _param_mpc_z_vel_max_up.get();

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -63,6 +63,7 @@ protected:
 
 	void _generateSetpoints() override; /**< Generate setpoints along line. */
 	void _generateHeading();
+	void _checkEmergencyBraking();
 	void _updateTurningCheck();
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
 
@@ -79,6 +80,8 @@ protected:
 
 	float _max_speed_prev{};
 	bool _is_turning{false};
+
+	bool _is_emergency_braking_active{false};
 
 	void _prepareSetpoints(); /**< Generate velocity target points for the trajectory generator. */
 	void _updateTrajConstraints();

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -429,7 +429,7 @@ void MulticopterPositionControl::Run()
 			_control.setVelocityLimits(
 				math::constrain(speed_horizontal, 0.f, _param_mpc_xy_vel_max.get()),
 				math::min(speed_up, _param_mpc_z_vel_max_up.get()), // takeoff ramp starts with negative velocity limit
-				math::constrain(speed_down, 0.f, _param_mpc_z_vel_max_dn.get()));
+				math::max(speed_down, 0.f));
 
 			_control.setInputSetpoint(_setpoint);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
If the drone is sinking really fast (i.e: well above usual maximum descent speed) and if the user switches to an auto mode to recover (RTL or other), the trajectory generator will generate a smooth (from design parameters) that usually creates a too long braking distance. Furthermore, the setpoints are clipped by the velocity controller, creating a hard stop followed by a controlled descent (that looks like an overshoot).

**Describe your solution**
If the drone is falling at a speed above twice the maximum downward speed, the trajectory generator enters an "emergency braking mode" that sets higher acceleration and jerk parameters (9.81m/s2 and 9.81m/s3) until the vertical velocity trajectory reaches 0m/s. After this, it goes back to normal and uses the usual parameters to continue the mission.
![emergency braking](https://user-images.githubusercontent.com/14822839/120500249-ff579880-c3c0-11eb-930d-93d721745e54.png)

**Test data / coverage**
SITL:
https://logs.px4.io/plot_app?log=c47a8da3-6bc5-4d9f-88d6-3643465b0c42

And real flight tests. We use that on our vehicles for ~3 months