### PR TITLE
fix mavlink radio status locking

### DIFF
--- a/Tools/serial/generate_config.py
+++ b/Tools/serial/generate_config.py
@@ -138,6 +138,12 @@ serial_ports = {
         "default_baudrate": 1, # set default to an unusable value to detect that this serial port has not been configured
         },
 
+    # Pixhawk Payload Bus
+    "PPB": {
+        "label": "Pixhawk Payload Bus",
+        "index": 401,
+        "default_baudrate": 57600,
+        },
 
     }
 

--- a/platforms/common/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/platforms/common/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -83,7 +83,7 @@ int uORBTest::UnitTest::pubsublatency_main()
 		if (fds[0].revents & POLLIN) {
 			orb_copy(ORB_ID(orb_test_medium), test_multi_sub, &t);
 
-			unsigned elt = (unsigned)hrt_elapsed_time_atomic(&t.timestamp);
+			unsigned elt = (unsigned)hrt_elapsed_time(&t.timestamp);
 			latency_integral += elt;
 			timings[i] = elt;
 

--- a/platforms/nuttx/src/px4/nxp/imxrt/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/hrt/hrt.c
@@ -587,21 +587,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time as atomic operation.
- */
-hrt_abstime
-hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
-{
-	irqstate_t flags = px4_enter_critical_section();
-
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	px4_leave_critical_section(flags);
-
-	return delta;
-}
-
-/**
  * Store the absolute time in an interrupt-safe fashion
  */
 void

--- a/platforms/nuttx/src/px4/nxp/kinetis/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/nxp/kinetis/hrt/hrt.c
@@ -599,21 +599,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time as atomic operation.
- */
-hrt_abstime
-hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
-{
-	irqstate_t flags = px4_enter_critical_section();
-
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	px4_leave_critical_section(flags);
-
-	return delta;
-}
-
-/**
  * Store the absolute time in an interrupt-safe fashion
  */
 void

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/hrt/hrt.c
@@ -635,21 +635,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time as atomic operation.
- */
-hrt_abstime
-hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
-{
-	irqstate_t flags = px4_enter_critical_section();
-
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	px4_leave_critical_section(flags);
-
-	return delta;
-}
-
-/**
  * Store the absolute time in an interrupt-safe fashion
  */
 void

--- a/platforms/nuttx/src/px4/stm/stm32_common/hrt/hrt.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/hrt/hrt.c
@@ -720,21 +720,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time as atomic operation
- */
-hrt_abstime
-hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
-{
-	irqstate_t flags = px4_enter_critical_section();
-
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	px4_leave_critical_section(flags);
-
-	return delta;
-}
-
-/**
  * Store the absolute time in an interrupt-safe fashion
  */
 void

--- a/platforms/posix/src/px4/common/drv_hrt.cpp
+++ b/platforms/posix/src/px4/common/drv_hrt.cpp
@@ -158,20 +158,6 @@ hrt_abstime ts_to_abstime(const struct timespec *ts)
 }
 
 /*
- * Compute the delta between a timestamp taken in the past
- * and now.
- *
- * This function is safe to use even if the timestamp is updated
- * by an interrupt during execution.
- */
-hrt_abstime hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
-{
-	// This is not atomic as the value on the application layer of POSIX is limited.
-	hrt_abstime delta = hrt_absolute_time() - *then;
-	return delta;
-}
-
-/*
  * Store the absolute time in an interrupt-safe fashion.
  *
  * This function ensures that the timestamp cannot be seen half-written by an interrupt handler.

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -111,15 +111,6 @@ static inline hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
 }
 
 /**
- * Compute the delta between a timestamp taken in the past
- * and now.
- *
- * This function is safe to use even if the timestamp is updated
- * by an interrupt during execution.
- */
-__EXPORT extern hrt_abstime hrt_elapsed_time_atomic(const volatile hrt_abstime *then);
-
-/**
  * Store the absolute time in an interrupt-safe fashion.
  *
  * This function ensures that the timestamp cannot be seen half-written by an interrupt handler.

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -658,6 +658,7 @@ private:
 
 	pthread_mutex_t		_message_buffer_mutex {};
 	pthread_mutex_t		_send_mutex {};
+	pthread_mutex_t         _radio_status_mutex {};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1518,7 +1518,7 @@ MavlinkReceiver::handle_message_radio_status(mavlink_message_t *msg)
 
 		radio_status_s status{};
 
-		hrt_store_absolute_time(&status.timestamp);
+		status.timestamp = hrt_absolute_time();
 		status.rssi = rstatus.rssi;
 		status.remote_rssi = rstatus.remrssi;
 		status.txbuf = rstatus.txbuf;

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -197,7 +197,6 @@ controls_init(void)
 	/* no channels */
 	r_raw_rc_count = 0;
 	system_state.rc_channels_timestamp_received = 0;
-	system_state.rc_channels_timestamp_valid = 0;
 
 	/* DSM input (USART1) */
 	_dsm_fd = dsm_init("/dev/ttyS0");
@@ -378,9 +377,6 @@ controls_tick()
 		/* update RC-received timestamp */
 		system_state.rc_channels_timestamp_received = hrt_absolute_time();
 
-		/* update RC-received timestamp */
-		system_state.rc_channels_timestamp_valid = system_state.rc_channels_timestamp_received;
-
 		/* map raw inputs to mapped inputs */
 		/* XXX mapping should be atomic relative to protocol */
 		for (unsigned i = 0; i < r_raw_rc_count; i++) {
@@ -500,7 +496,7 @@ controls_tick()
 	 * If we haven't seen any new control data in 200ms, assume we
 	 * have lost input.
 	 */
-	if (!rc_input_lost && hrt_elapsed_time_atomic(&system_state.rc_channels_timestamp_received) > 200000) {
+	if (!rc_input_lost && hrt_elapsed_time(&system_state.rc_channels_timestamp_received) > 200000) {
 		rc_input_lost = true;
 
 		/* clear the input-kind flags here */

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -136,8 +136,7 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
  */
 struct sys_state_s {
 
-	volatile uint64_t	rc_channels_timestamp_received;
-	volatile uint64_t	rc_channels_timestamp_valid;
+	uint64_t	rc_channels_timestamp_received;
 
 	/**
 	 * Last FMU receive time, in microseconds since system boot

--- a/src/systemcmds/microbench/test_microbench_hrt.cpp
+++ b/src/systemcmds/microbench/test_microbench_hrt.cpp
@@ -144,7 +144,6 @@ bool MicroBenchHRT::time_px4_hrt()
 {
 	PERF("hrt_absolute_time()", u_64_out = hrt_absolute_time(), 1000);
 	PERF("hrt_elapsed_time()", u_64_out = hrt_elapsed_time(&u_64), 1000);
-	PERF("hrt_elapsed_time_atomic()", u_64_out = hrt_elapsed_time_atomic(&u_64), 1000);
 
 	return true;
 }

--- a/src/systemcmds/tests/hrt_test/hrt_test.cpp
+++ b/src/systemcmds/tests/hrt_test/hrt_test.cpp
@@ -71,13 +71,13 @@ int HRTTest::main()
 
 	hrt_abstime t = hrt_absolute_time();
 	px4_usleep(1000000);
-	hrt_abstime elt = hrt_elapsed_time_atomic(&t);
+	hrt_abstime elt = hrt_elapsed_time(&t);
 	PX4_INFO("Elapsed time %llu in 1 sec (usleep)\n", (unsigned long long)elt);
 	PX4_INFO("Start time %llu\n", (unsigned long long)t);
 
 	t = hrt_absolute_time();
 	px4_sleep(1);
-	elt = hrt_elapsed_time_atomic(&t);
+	elt = hrt_elapsed_time(&t);
 	PX4_INFO("Elapsed time %llu in 1 sec (sleep)\n", (unsigned long long)elt);
 	PX4_INFO("Start time %llu\n", (unsigned long long)t);
 


### PR DESCRIPTION
- hrt_elapsed_time_atomic is not atomic on posix
- other fields like _radio_status_mult need protection as well

I'm also removing `hrt_elapsed_time_atomic` altogether to avoid further problems with that.