### PR TITLE
Support a new board specific rc file "rc.board_paths"

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -201,6 +201,7 @@ endif()
 
 set(OPTIONAL_BOARD_RC)
 list(APPEND OPTIONAL_BOARD_RC
+	rc.board_paths
 	rc.board_defaults
 	rc.board_sensors
 	rc.board_extras

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -48,6 +48,18 @@ set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
 set STARTUP_TUNE 1
 set USE_IO no
 set VEHICLE_TYPE none
+set DATAMAN_BACKEND ""
+
+#
+# Optional board path defaults: rc.board_paths
+#
+set BOARD_RC_PATHS ${R}etc/init.d/rc.board_paths
+if [ -f $BOARD_RC_PATHS ]
+then
+	echo "Board path defaults: ${BOARD_RC_PATHS}"
+	. $BOARD_RC_PATHS
+fi
+unset BOARD_RC_PATHS
 
 #
 # Start CDC/ACM serial driver.
@@ -200,7 +212,7 @@ else
 	# Waypoint storage.
 	# REBOOTWORK this needs to start in parallel.
 	#
-	dataman start
+	dataman start $DATAMAN_BACKEND
 
 	#
 	# Start the socket communication send_event handler.
@@ -543,6 +555,7 @@ unset SDCARD_MIXERS_PATH
 unset STARTUP_TUNE
 unset USE_IO
 unset VEHICLE_TYPE
+unset DATAMAN_BACKEND
 
 #
 # Boot is complete, inform MAVLink app(s) that the system is now fully up and running.


### PR DESCRIPTION
**Describe problem solved by this pull request**

I wanted to use the existing rcS scripts, but with more control over some variables. In particular, I wanted to define the params file location and dataman backend. Also in the future for some devices I would like to replace the most of the functionality of the rcS script with my own script, located under board definition, and this could be done with the existing FRC variable in rcS.

As an example, I can now use these in my rc.board_paths, to set PARAM_FILE to another fs in /fs/lfs/ and DATAMAN_BACKEND to switch to RAM backend:
set PARAM_FILE /fs/lfs/params
set DATAMAN_BACKEND "-r"

I don't know if this is interesting, or makes sense for others, but decided to offer this to upstream anyhow. I know that these things are done differently by using raw mtd partitions and handling those separately in px4, for fmuv5x for example.

If this is not wanted, feel free to just ignore/close this one

-----------

This board specific rc file is executed very early in rcS, and can
be used to set rcS variables only.

This allows:
- Redefining $FRC to replace rest of rcS with an own script from any mountpoint
OR
- Redefining dataman backend
- Redefining params file location, can be stored as a file in other mountpoints

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

