### PR TITLE
commander: make LAND failsafe stick

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -927,6 +927,7 @@ void set_link_loss_nav_state(vehicle_status_s &status, actuator_armed_s &armed,
 	// FALLTHROUGH
 	case link_loss_actions_t::AUTO_LAND:
 		if (status_flags.condition_global_position_valid) {
+			main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LAND, status_flags, internal_state);
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
 			return;
 


### PR DESCRIPTION
By default we would leave the LAND failsafe as soon as a link comes back. With this change, we switch to the LAND failsafe like a proper mode change, immediately disabling the failsafe as such.
This is as the same that is done for RTL in fact.

This is not optimal but a workaround for the problem where we switch out of failsafe right on landing and then discover takeoff again and start looping through it again and again without ever disarming.