### PR TITLE
ctrl-zero-h7-oem spi 5 fix - Update board.h

### DIFF
--- a/boards/mro/ctrl-zero-h7-oem/nuttx-config/include/board.h
+++ b/boards/mro/ctrl-zero-h7-oem/nuttx-config/include/board.h
@@ -265,7 +265,7 @@
 
 #define GPIO_SPI5_SCK    ADJ_SLEW_RATE(GPIO_SPI5_SCK_1) /* PF7  */
 #define GPIO_SPI5_MISO   GPIO_SPI5_MISO_1               /* PF8  */
-#define GPIO_SPI5_MOSI   GPIO_SPI5_MOSI_1               /* PF9  */
+#define GPIO_SPI5_MOSI   GPIO_SPI5_MOSI_2               /* PF9  */
 
 
 /* I2C */


### PR DESCRIPTION
fix spi pin missmatch PF9=GPIO_SPI5_MOSI_2

Please use PX4 Discuss or Slack to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

Describe problem solved by this pull request
BMI088 doesn't´t start cause the sensor isn´t detected on this bus

Describe your solution
BMI088 gyro and acc now starts properly

Additional context
Add any other related context or media.
Board sensors: /etc/init.d/rc.board_sensors
icm20602 #0 on SPI bus 1 rotation 8
bmi088_accel #0 on SPI bus 5 rotation 8
bmi088_gyro #0 on SPI bus 5 rotation 8
icm20948 #0 on SPI bus 1 rotation 8
dps310 #0 on SPI bus 2