### PR TITLE
px4io:Ensure proper lifecycle of registration of cdev

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -510,6 +510,14 @@ PX4IO::~PX4IO()
 		delete _interface;
 	}
 
+	/* In the case the task did not exit
+	 * clean up the alternate device node
+	 */
+	if (_primary_pwm_device) {
+		unregister_driver(PWM_OUTPUT0_DEVICE_PATH);
+		_primary_pwm_device = false;
+	}
+
 	/* deallocate perfs */
 	perf_free(_perf_update);
 	perf_free(_perf_write);
@@ -1217,6 +1225,7 @@ out:
 	/* clean up the alternate device node */
 	if (_primary_pwm_device) {
 		unregister_driver(PWM_OUTPUT0_DEVICE_PATH);
+		_primary_pwm_device = false;
 	}
 
 	/* tell the dtor that we are exiting */


### PR DESCRIPTION
There was a wicked race that is most always lost if there is no console.

The Init() registers the pwm0 device but if the task does not run it does not unregister it. (in the case of failure as well). The FS has a inode that is now pointing to a deleted and most likely reclaimed memory. 

So this 
![image](https://user-images.githubusercontent.com/1945821/134739354-31ef950a-6b2e-4c7f-b959-42eeee160fff.png)
begins a series of Fun that ends in a hardfault