### PR TITLE
Remove unused strncpy in parameter send_untransmitted

### DIFF
--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -375,8 +375,6 @@ MavlinkParametersManager::send_untransmitted()
 			// space in the TX buffer
 			if ((param != PARAM_INVALID) && param_value_unsaved(param)) {
 				int ret = send_param(param);
-				char buf[100];
-				strncpy(&buf[0], param_name(param), MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
 				sent_one = true;
 
 				if (ret != PX4_OK) {


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
Removing (seemingly) unused char array and `strncpy` in parameter `send_untransmitted()`

**Describe your solution**
Removed lines
