### PR TITLE
clean remaining offboard_control_signal_found_once

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -27,7 +27,6 @@ bool circuit_breaker_engaged_usb_check
 bool circuit_breaker_engaged_posfailure_check	# set to true when the position valid checks have been disabled
 bool circuit_breaker_vtol_fw_arming_check 	# set to true if for VTOLs arming in fixed-wing mode should be allowed
 
-bool offboard_control_signal_found_once
 bool offboard_control_signal_lost
 
 bool rc_signal_found_once

--- a/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
+++ b/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
@@ -464,7 +464,7 @@ private:
 				msg->failure_flags |= HL_FAILURE_FLAG_GPS;
 			}
 
-			if (status_flags.offboard_control_signal_lost && status_flags.offboard_control_signal_found_once) {
+			if (status_flags.offboard_control_signal_lost) {
 				msg->failure_flags |= HL_FAILURE_FLAG_OFFBOARD_LINK;
 			}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
`offboard_control_signal_found_once` is not used anymore but still appears in vehicle_statusflags messages and is checked in high latency messages.

**Describe your solution**
Remove the remaining occurence of `offboard_control_signal_found_once`

**Describe possible alternatives**
Another solution could be to reimplement the "found_once" logic for offboard control