### PR TITLE
Save significant IMU accel bias changes learned by the EKF

### DIFF
--- a/msg/vehicle_imu.msg
+++ b/msg/vehicle_imu.msg
@@ -16,4 +16,5 @@ uint8 CLIPPING_Y = 2
 uint8 CLIPPING_Z = 4
 uint8 delta_velocity_clipping   # bitfield indicating if there was any accelerometer clipping (per axis) during the integration time frame
 
-uint8 calibration_count         # Calibration changed counter. Monotonically increases whenever calibration changes.
+uint8 accel_calibration_count  	# Calibration changed counter. Monotonically increases whenever accelermeter calibration changes.
+uint8 gyro_calibration_count   	# Calibration changed counter. Monotonically increases whenever rate gyro calibration changes.

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -230,8 +230,8 @@ public:
 	Vector3f getAccelBias() const { return _state.delta_vel_bias / _dt_ekf_avg; } // get the accelerometer bias in m/s**2
 	const Vector3f &getMagBias() const { return _state.mag_B; }
 
-	Vector3f getGyroBiasVariance() const { return Vector3f{P(10, 10), P(11, 11), P(12, 12)} / _dt_ekf_avg; } // get the gyroscope bias variance in rad/s
-	Vector3f getAccelBiasVariance() const { return Vector3f{P(13, 13), P(14, 14), P(15, 15)} / _dt_ekf_avg; } // get the accelerometer bias variance in m/s**2
+	Vector3f getGyroBiasVariance() const { return Vector3f{P(10, 10), P(11, 11), P(12, 12)} / sq(_dt_ekf_avg); } // get the gyroscope bias variance in rad/s
+	Vector3f getAccelBiasVariance() const { return Vector3f{P(13, 13), P(14, 14), P(15, 15)} / sq(_dt_ekf_avg); } // get the accelerometer bias variance in m/s**2
 	Vector3f getMagBiasVariance() const { return Vector3f{P(19, 19), P(20, 20), P(21, 21)}; }
 
 	// get GPS check status

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -388,11 +388,11 @@ void EKF2::Run()
 					_device_id_accel = sensor_selection.accel_device_id;
 					SelectImuStatus();
 
-				} else if (accelerometer.calibration_count > _imu_calibration_count) {
+				} else if (imu.accel_calibration_count > _accel_calibration_count) {
 					// existing calibration has changed, reset saved mag bias
 					PX4_DEBUG("%d - accel %" PRIu32 " calibration updated, resetting bias", _instance, _device_id_mag);
 					_ekf.resetAccelBias();
-					_imu_calibration_count = accelerometer.calibration_count;
+					_accel_calibration_count = imu.accel_calibration_count;
 				}
 
 				if (_device_id_gyro != sensor_selection.gyro_device_id) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -387,6 +387,12 @@ void EKF2::Run()
 					_ekf.resetAccelBias();
 					_device_id_accel = sensor_selection.accel_device_id;
 					SelectImuStatus();
+
+				} else if (accelerometer.calibration_count > _imu_calibration_count) {
+					// existing calibration has changed, reset saved mag bias
+					PX4_DEBUG("%d - accel %" PRIu32 " calibration updated, resetting bias", _instance, _device_id_mag);
+					_ekf.resetAccelBias();
+					_imu_calibration_count = accelerometer.calibration_count;
 				}
 
 				if (_device_id_gyro != sensor_selection.gyro_device_id) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -515,6 +515,7 @@ void EKF2::Run()
 			PublishYawEstimatorStatus(now);
 
 			UpdateMagCalibration(now);
+			UpdateAccelCalibration(now);
 
 		} else {
 			// ekf no update
@@ -1035,7 +1036,7 @@ void EKF2::PublishSensorBias(const hrt_abstime &timestamp)
 			accel_bias.copyTo(bias.accel_bias);
 			bias.accel_bias_limit = _params->acc_bias_lim;
 			_ekf.getAccelBiasVariance().copyTo(bias.accel_bias_variance);
-			bias.accel_bias_valid = !_ekf.fault_status_flags().bad_acc_bias;
+			bias.accel_bias_valid = !_ekf.fault_status_flags().bad_acc_bias && _acc_cal_available;
 
 			_last_accel_bias_published = accel_bias;
 		}
@@ -1772,6 +1773,38 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 					_param_ekf2_mag_decl.commit_no_notification();
 				}
 			}
+		}
+	}
+}
+
+void EKF2::UpdateAccelCalibration(const hrt_abstime &timestamp)
+{
+	// Check if conditions are OK for learning of accelerometer bias values
+	// the EKF is operating in the correct mode and there are no filter faults
+	if (_ekf.control_status_flags().in_air && (_ekf.fault_status().value == 0)) {
+
+		if (_acc_cal_last_us != 0) {
+			_acc_cal_total_time_us += timestamp - _acc_cal_last_us;
+
+			// Start checking accel bias estimates when we have accumulated sufficient calibration time
+			if (_acc_cal_total_time_us > 30_s) {
+				_acc_cal_last_bias = _ekf.getAccelBias();
+				_acc_cal_last_bias_variance = _ekf.getAccelBiasVariance();
+				_acc_cal_available = true;
+			}
+		}
+
+		_acc_cal_last_us = timestamp;
+
+	} else {
+		// conditions are NOT OK for learning accelerometer bias, reset timestamp
+		// but keep the accumulated calibration time
+		_acc_cal_last_us = 0;
+
+		if (_ekf.fault_status().value != 0) {
+			// if a filter fault has occurred, assume previous learning was invalid and do not
+			// count it towards total learning time.
+			_acc_cal_total_time_us = 0;
 		}
 	}
 }

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -223,7 +223,8 @@ private:
 	uint64_t _gps_alttitude_ellipsoid_previous_timestamp{0}; ///< storage for previous timestamp to compute dt
 	float   _wgs84_hgt_offset = 0;  ///< height offset between AMSL and WGS84
 
-	uint8_t _imu_calibration_count{0};
+	uint8_t _accel_calibration_count{0};
+	uint8_t _gyro_calibration_count{0};
 	uint8_t _mag_calibration_count{0};
 
 	uint32_t _device_id_accel{0};

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -167,6 +167,7 @@ private:
 	void UpdateImuStatus();
 
 	void UpdateMagCalibration(const hrt_abstime &timestamp);
+	void UpdateAccelCalibration(const hrt_abstime &timestamp);
 
 	/*
 	 * Calculate filtered WGS84 height from estimated AMSL height
@@ -201,13 +202,19 @@ private:
 	// Used to check, save and use learned magnetometer biases
 	hrt_abstime _mag_cal_last_us{0};	///< last time the EKF was operating a mode that estimates magnetomer biases (uSec)
 	hrt_abstime _mag_cal_total_time_us{0};	///< accumulated calibration time since the last save
-
 	Vector3f _mag_cal_last_bias{};	///< last valid XYZ magnetometer bias estimates (Gauss)
 	Vector3f _mag_cal_last_bias_variance{};	///< variances for the last valid magnetometer XYZ bias estimates (Gauss**2)
 	bool _mag_cal_available{false};	///< true when an unsaved valid calibration for the XYZ magnetometer bias is available
 
 	// Used to control saving of mag declination to be used on next startup
 	bool _mag_decl_saved = false;	///< true when the magnetic declination has been saved
+
+	// Used to check, save and use learned accelerometer biases
+	hrt_abstime _acc_cal_last_us{0};	///< last time the EKF was operating a mode that estimates accelerometer biases (uSec)
+	hrt_abstime _acc_cal_total_time_us{0};	///< accumulated calibration time since the last save
+	Vector3f _acc_cal_last_bias{};		///< last valid XYZ accelerometer bias estimates (Gauss)
+	Vector3f _acc_cal_last_bias_variance{};	///< variances for the last valid accelerometer XYZ bias estimates (m/s**2)**2
+	bool _acc_cal_available{false};		///< true when an unsaved valid calibration for the XYZ accelerometer bias is available
 
 	bool _had_valid_terrain{false};			///< true if at any time there was a valid terrain estimate
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -665,9 +665,7 @@ void VehicleIMU::AccelCalibrationUpdate()
 	static constexpr float max_var_ratio = 1e2f;
 
 	if (_armed) {
-		static constexpr uint8_t accel_cal_size = sizeof(_accel_cal) / sizeof(_accel_cal[0]);
-
-		for (int i = 0; i < math::min(_estimator_sensor_bias_subs.size(), accel_cal_size); i++) {
+		for (int i = 0; i < math::min(_estimator_sensor_bias_subs.size(), (uint8_t)ORB_MULTI_MAX_INSTANCES); i++) {
 			estimator_sensor_bias_s estimator_sensor_bias;
 
 			if (_estimator_sensor_bias_subs[i].update(&estimator_sensor_bias)) {

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -146,6 +146,15 @@ void VehicleIMU::Run()
 
 	ParametersUpdate();
 
+	// check vehicle status for changes to armed state
+	if (_vehicle_control_mode_sub.updated()) {
+		vehicle_control_mode_s vehicle_control_mode;
+
+		if (_vehicle_control_mode_sub.copy(&vehicle_control_mode)) {
+			_armed = vehicle_control_mode.flag_armed;
+		}
+	}
+
 	if (!_accel_calibration.enabled() || !_gyro_calibration.enabled()) {
 		return;
 	}
@@ -219,11 +228,13 @@ void VehicleIMU::Run()
 			return;
 		}
 	}
+
 }
 
 bool VehicleIMU::UpdateAccel()
 {
 	bool updated = false;
+	const hrt_abstime now_us = hrt_absolute_time();
 
 	// integrate queued accel
 	sensor_accel_s accel;
@@ -360,6 +371,12 @@ bool VehicleIMU::UpdateAccel()
 					_last_clipping_notify_time = accel.timestamp_sample;
 					_last_clipping_notify_total_count = clipping_total;
 				}
+			}
+
+		} else {
+			if (updated && now_us - _accel_bias_check_timestamp_last > 1000000) {
+				_accel_bias_check_timestamp_last = now_us;
+				AccelCalibrationUpdate();
 			}
 		}
 	}
@@ -532,7 +549,8 @@ bool VehicleIMU::Publish()
 			delta_angle_corrected.copyTo(imu.delta_angle);
 			delta_velocity_corrected.copyTo(imu.delta_velocity);
 			imu.delta_velocity_clipping = _delta_velocity_clipping;
-			imu.calibration_count = _accel_calibration.calibration_count() + _gyro_calibration.calibration_count();
+			imu.accel_calibration_count = _accel_calibration.calibration_count();
+			imu.gyro_calibration_count = _gyro_calibration.calibration_count();
 			imu.timestamp = hrt_absolute_time();
 			_vehicle_imu_pub.publish(imu);
 
@@ -636,6 +654,110 @@ void VehicleIMU::PrintStatus()
 
 	_accel_calibration.PrintStatus();
 	_gyro_calibration.PrintStatus();
+}
+
+void VehicleIMU::AccelCalibrationUpdate()
+{
+	// State variance assumed for accelerometer bias storage.
+	// This is a reference variance used to calculate the fraction of learned accelerometer bias that will be used to update the stored value.
+	// Larger values cause a larger fraction of the learned biases to be used.
+	static constexpr float max_var_allowed = 1e-3f;
+	static constexpr float max_var_ratio = 1e2f;
+
+	if (_armed) {
+		static constexpr uint8_t accel_cal_size = sizeof(_accel_cal) / sizeof(_accel_cal[0]);
+
+		for (int i = 0; i < math::min(_estimator_sensor_bias_subs.size(), accel_cal_size); i++) {
+			estimator_sensor_bias_s estimator_sensor_bias;
+
+			if (_estimator_sensor_bias_subs[i].update(&estimator_sensor_bias)) {
+				// find corresponding accel calibration
+				if (_accel_calibration.device_id() == estimator_sensor_bias.accel_device_id) {
+					const Vector3f bias{estimator_sensor_bias.accel_bias};
+					const Vector3f bias_variance{estimator_sensor_bias.accel_bias_variance};
+
+					const bool valid = (hrt_elapsed_time(&estimator_sensor_bias.timestamp) < 1_s) &&
+							   (estimator_sensor_bias.accel_device_id != 0) &&
+							   estimator_sensor_bias.accel_bias_valid &&
+							   (bias_variance.max() < max_var_allowed) &&
+							   (bias_variance.max() < max_var_ratio * bias_variance.min());
+
+					if (valid) {
+						_accel_cal[i].device_id = estimator_sensor_bias.accel_device_id;
+						_accel_cal[i].accel_offset = bias;
+						_accel_cal[i].accel_bias_variance = bias_variance;
+						_accel_cal[i].valid = true;
+						_accel_cal_available = true;
+						break;
+
+					} else {
+						_accel_cal[i].valid = false;
+					}
+				}
+			}
+		}
+
+	} else if (_accel_cal_available) {
+		// not armed and accel cal available
+		bool calibration_param_save_needed = false;
+
+		bool initialised = false;
+		Vector3f bias_variance {};
+		Vector3f bias_estimate {};
+
+		// apply all valid saved offsets
+		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+			if ((_accel_calibration.device_id() != 0)
+			    && (_accel_cal[i].device_id == _accel_calibration.device_id())
+			    && _accel_cal[i].valid) {
+
+				if (!initialised) {
+					bias_variance = _accel_cal[i].accel_bias_variance;
+					bias_estimate = _accel_cal[i].accel_offset;
+					initialised = true;
+
+				} else {
+					for (int axis_index = 0; axis_index < 3; axis_index++) {
+						const float sum_of_variances = _accel_cal[i].accel_bias_variance(axis_index) + bias_variance(axis_index);
+						const float k1 = bias_variance(axis_index) / sum_of_variances;
+						const float k2 = _accel_cal[i].accel_bias_variance(axis_index) / sum_of_variances;
+						bias_estimate(axis_index) = k2 * bias_estimate(axis_index) + k1 * _accel_cal[i].accel_offset(axis_index);
+						bias_variance(axis_index) *= k2;
+					}
+				}
+			}
+		}
+
+		if (initialised && bias_estimate.longerThan(0.05f)) {
+			const Vector3f accel_cal_orig{_accel_calibration.offset()};
+			Vector3f accel_cal_offset{_accel_calibration.offset()};
+
+			for (int axis_index = 0; axis_index < 3; axis_index++) {
+				accel_cal_offset(axis_index) += bias_estimate(axis_index);
+			}
+
+			if (_accel_calibration.set_offset(accel_cal_offset)) {
+
+				PX4_INFO("(%" PRIu32 ") bias=[%.2f %.2f %.2f] offset:[%.2f %.2f %.2f]->[%.2f %.2f %.2f]",
+					 _accel_calibration.device_id(),
+					 (double)bias_estimate(0), (double)bias_estimate(1), (double)bias_estimate(2),
+					 (double)accel_cal_orig(0), (double)accel_cal_orig(1), (double)accel_cal_orig(2),
+					 (double)accel_cal_offset(0), (double)accel_cal_offset(1), (double)accel_cal_offset(2));
+
+				calibration_param_save_needed = true;
+			}
+		}
+
+		if (calibration_param_save_needed) {
+			for (int accel_index = 0; accel_index < MAX_SENSOR_COUNT; accel_index++) {
+				if (_accel_calibration.device_id() != 0) {
+					_accel_calibration.ParametersSave();
+				}
+			}
+
+			_accel_cal_available = false;
+		}
+	}
 }
 
 } // namespace sensors

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -736,7 +736,8 @@ void VehicleIMU::AccelCalibrationUpdate()
 				accel_cal_offset(axis_index) += bias_estimate(axis_index);
 			}
 
-			if (_accel_calibration.set_offset(accel_cal_offset)) {
+			// rotate offsets from body to sensor frame before setting
+			if (_accel_calibration.set_offset(_accel_calibration.rotation().transpose()*accel_cal_offset)) {
 
 				PX4_INFO("(%" PRIu32 ") bias=[%.2f %.2f %.2f] offset:[%.2f %.2f %.2f]->[%.2f %.2f %.2f]",
 					 _accel_calibration.device_id(),

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -732,9 +732,16 @@ void VehicleIMU::AccelCalibrationUpdate()
 			const Vector3f accel_cal_orig{_accel_calibration.offset()};
 			Vector3f accel_cal_offset{_accel_calibration.offset()};
 
+			const Vector3f scale_factors = _accel_calibration.scale();
+
 			for (int axis_index = 0; axis_index < 3; axis_index++) {
-				accel_cal_offset(axis_index) += bias_estimate(axis_index);
+				// Bias estimates are learned from data that is scale factor corrected whereas
+				// offsets within the driver are applied before scale factor correction
+				// so we so we need to remove the scale factor correction from the learned biases.
+				accel_cal_offset(axis_index) += bias_estimate(axis_index) / scale_factors(axis_index);
 			}
+
+
 
 			// rotate offsets from body to sensor frame before setting
 			if (_accel_calibration.set_offset(_accel_calibration.rotation().transpose()*accel_cal_offset)) {

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -47,12 +47,15 @@
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_accel.h>
 #include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/vehicle_imu.h>
 #include <uORB/topics/vehicle_imu_status.h>
+#include <uORB/topics/estimator_sensor_bias.h>
+#include <uORB/topics/vehicle_control_mode.h>
 
 using namespace time_literals;
 
@@ -84,6 +87,8 @@ private:
 	void UpdateAccelVibrationMetrics(const matrix::Vector3f &acceleration);
 	void UpdateGyroVibrationMetrics(const matrix::Vector3f &angular_velocity);
 
+	void AccelCalibrationUpdate();
+
 	uORB::PublicationMulti<vehicle_imu_s> _vehicle_imu_pub{ORB_ID(vehicle_imu)};
 	uORB::PublicationMulti<vehicle_imu_status_s> _vehicle_imu_status_pub{ORB_ID(vehicle_imu_status)};
 
@@ -91,6 +96,13 @@ private:
 
 	uORB::Subscription _sensor_accel_sub;
 	uORB::SubscriptionCallbackWorkItem _sensor_gyro_sub;
+
+	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
+
+	// Used to check, save and use learned magnetometer biases
+	uORB::SubscriptionMultiArray<estimator_sensor_bias_s> _estimator_sensor_bias_subs{ORB_ID::estimator_sensor_bias};
+
+	static constexpr int MAX_SENSOR_COUNT = 4;
 
 	calibration::Accelerometer _accel_calibration{};
 	calibration::Gyroscope _gyro_calibration{};
@@ -103,6 +115,7 @@ private:
 	hrt_abstime _accel_timestamp_sample_last{0};
 	hrt_abstime _gyro_timestamp_sample_last{0};
 	hrt_abstime _gyro_timestamp_last{0};
+	hrt_abstime _accel_bias_check_timestamp_last{0};
 
 	math::WelfordMean<matrix::Vector2f> _accel_interval_mean{};
 	math::WelfordMean<matrix::Vector2f> _gyro_interval_mean{};
@@ -145,6 +158,8 @@ private:
 
 	const uint8_t _instance;
 
+	bool _armed{false};
+
 	perf_counter_t _accel_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": accel data gap")};
 	perf_counter_t _gyro_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro data gap")};
 
@@ -152,6 +167,16 @@ private:
 		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate,
 		(ParamInt<px4::params::IMU_GYRO_RATEMAX>) _param_imu_gyro_ratemax
 	)
+
+	bool _accel_cal_available{false};
+
+	struct AcelCal {
+		uint32_t device_id{0};
+		matrix::Vector3f accel_offset{};
+		matrix::Vector3f accel_bias_variance{};
+		bool valid{false};
+	} _accel_cal[ORB_MULTI_MAX_INSTANCES] {};
+
 };
 
 } // namespace sensors

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -170,7 +170,7 @@ private:
 
 	bool _accel_cal_available{false};
 
-	struct AcelCal {
+	struct AccelCal {
 		uint32_t device_id{0};
 		matrix::Vector3f accel_offset{};
 		matrix::Vector3f accel_bias_variance{};


### PR DESCRIPTION
This is a prototype of a feature that enables accel biases learned by the EKF to be saved between flights. Testing to date has been limited to SITL using the default gazebo  and jmavsim multicopter models with accel bias parameters set to non zero values followed by a re-start and a short auto mission with land and disarm to verify the incorrect bias parameters were updated.

This feature would be useful for operation with IMU's that are not thermally calibrated where operation is performed at a significantly different temperature to the original calibration.

Open Questions:

1. Do we need a user controlled method of enabling or disabling the feature and maybe setting the sensitivity. For example with good quality IMU's that are temperature controlled or thermally calibrated, this feature would be unnecessary and could reduce IMU performance .
2. What if a flight experiences clipping  - should we then label the learned biases as invalid? It is common for  the touchdown to cause clipping so clipping when landing is expected would have to be ignored.
3. How well does this work on hardware.