### PR TITLE
ekf2: selector remove special timeout condition

### DIFF
--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -251,12 +251,7 @@ bool EKF2Selector::UpdateErrorScores()
 	bool primary_updated = false;
 
 	// default estimator timeout
-	hrt_abstime status_timeout = 50_ms;
-
-	if (hrt_elapsed_time(&_attitude_last.timestamp) > FILTER_UPDATE_PERIOD) {
-		// much lower timeout if current primary estimator attitude isn't publishing
-		status_timeout = 2 * FILTER_UPDATE_PERIOD;
-	}
+	const hrt_abstime status_timeout = 50_ms;
 
 	// calculate individual error scores
 	for (uint8_t i = 0; i < EKF2_MAX_INSTANCES; i++) {


### PR DESCRIPTION
This additional condition was primarily intended to aggressively catch estimator failures if/when the primary attitude stops publishing, but so far it mainly produces false positives when disarmed and bench testing (parameter changes, etc).


