### PR TITLE
Without hardfault logging: Avoid "ERROR:Failed to register ULog file to the hardfault handler"

### DIFF
--- a/platforms/nuttx/src/px4/nxp/k66/include/px4_arch/micro_hal.h
+++ b/platforms/nuttx/src/px4/nxp/k66/include/px4_arch/micro_hal.h
@@ -87,10 +87,6 @@ __BEGIN_DECLS
 #define PX4_CPU_UUID_WORD32_FORMAT_SIZE         (PX4_CPU_UUID_WORD32_LENGTH-1+(2*PX4_CPU_UUID_BYTE_LENGTH)+1)
 #define PX4_CPU_MFGUID_FORMAT_SIZE              ((2*PX4_CPU_MFGUID_BYTE_LENGTH)+1)
 
-#define kinetis_bbsram_savepanic(fileno, context, length) (0) // todo:Not implemented yet
-
-#define px4_savepanic(fileno, context, length)   kinetis_bbsram_savepanic(fileno, context, length)
-
 /* bus_num is zero based on kinetis and must be translated from the legacy one based */
 
 #define PX4_BUS_OFFSET       1                  /* Kinetis buses are 0 based and adjustment is needed */

--- a/platforms/nuttx/src/px4/nxp/rt106x/include/px4_arch/micro_hal.h
+++ b/platforms/nuttx/src/px4/nxp/rt106x/include/px4_arch/micro_hal.h
@@ -82,10 +82,6 @@ __BEGIN_DECLS
 #define PX4_CPU_UUID_WORD32_FORMAT_SIZE         (PX4_CPU_UUID_WORD32_LENGTH-1+(2*PX4_CPU_UUID_BYTE_LENGTH)+1)
 #define PX4_CPU_MFGUID_FORMAT_SIZE              ((2*PX4_CPU_MFGUID_BYTE_LENGTH)+1)
 
-#define imxrt_bbsram_savepanic(fileno, context, length) (0) // todo:Not implemented yet
-
-#define px4_savepanic(fileno, context, length)   imxrt_bbsram_savepanic(fileno, context, length)
-
 /* bus_num is 1 based on imx and must be translated from the legacy one based */
 
 #define PX4_BUS_OFFSET       0                  /* imxrt buses are 1 based no adjustment needed */

--- a/platforms/nuttx/src/px4/nxp/s32k14x/include/px4_arch/micro_hal.h
+++ b/platforms/nuttx/src/px4/nxp/s32k14x/include/px4_arch/micro_hal.h
@@ -89,10 +89,6 @@ __BEGIN_DECLS
 #define PX4_CPU_UUID_WORD32_FORMAT_SIZE         (PX4_CPU_UUID_WORD32_LENGTH-1+(2*PX4_CPU_UUID_BYTE_LENGTH)+1)
 #define PX4_CPU_MFGUID_FORMAT_SIZE              ((2*PX4_CPU_MFGUID_BYTE_LENGTH)+1)
 
-#define s32k1xx_bbsram_savepanic(fileno, context, length) (0) // todo:Not implemented yet
-
-#define px4_savepanic(fileno, context, length)   s32k1xx_bbsram_savepanic(fileno, context, length)
-
 /* bus_num is zero based on s32k1xx and must be translated from the legacy one based */
 
 #define PX4_BUS_OFFSET       1                  /* s32k1xx buses are 0 based and adjustment is needed */

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -254,7 +254,7 @@ void LogWriterFile::start_log(LogType type, const char *filename)
 
 int LogWriterFile::hardfault_store_filename(const char *log_file)
 {
-#ifdef __PX4_NUTTX
+#if defined(__PX4_NUTTX) && defined(px4_savepanic)
 	int fd = open(HARDFAULT_ULOG_PATH, O_TRUNC | O_WRONLY | O_CREAT);
 
 	if (fd < 0) {


### PR DESCRIPTION
This prevents the logger from reporting and ERROR on systems without hardfault logging 