### PR TITLE
standard vtol: fix discontinuous attitude setpoint after backtransition

### DIFF
--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -12,3 +12,7 @@ bool vtol_in_trans_mode
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 bool vtol_transition_failsafe		# vtol in transition failsafe mode
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode
+float32 mc_roll_weight
+float32 mc_pitch_weight
+float32 mc_yaw_weight
+float32 mc_throttle_weight

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -122,10 +122,7 @@ void Standard::update_vtol_state()
 		// the transition to fw mode switch is off
 		if (_vtol_schedule.flight_mode == vtol_mode::MC_MODE) {
 			// in mc mode
-			_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
-			mc_weight = 1.0f;
-			_pusher_throttle = 0.0f;
-			_reverse_output = 0.0f;
+			set_mc_state();
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {
 			// Regular backtransition
@@ -135,10 +132,7 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_FW) {
 			// failsafe back to mc mode
-			_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
-			mc_weight = 1.0f;
-			_pusher_throttle = 0.0f;
-			_reverse_output = 0.0f;
+			set_mc_state();
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_MC) {
 			// transition to MC mode if transition time has passed or forward velocity drops below MPC cruise speed
@@ -151,7 +145,7 @@ void Standard::update_vtol_state()
 			if (time_since_trans_start > _params->back_trans_duration ||
 			    (_local_pos->v_xy_valid && x_vel <= _params->mpc_xy_cruise) ||
 			    can_transition_on_ground()) {
-				_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
+				set_mc_state();
 			}
 		}
 
@@ -196,6 +190,10 @@ void Standard::update_vtol_state()
 				_trans_finished_ts = hrt_absolute_time();
 			}
 		}
+	}
+
+	if (_vtol_schedule.flight_mode == vtol_mode::MC_MODE) {
+		mc_weight = 1.0f;
 	}
 
 	_mc_roll_weight = mc_weight;
@@ -425,4 +423,12 @@ Standard::waiting_on_tecs()
 {
 	// keep thrust from transition
 	_v_att_sp->thrust_body[0] = _pusher_throttle;
-};
+}
+
+void
+Standard::set_mc_state()
+{
+	_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
+	_pusher_throttle = 0.0f;
+	_reverse_output = 0.0f;
+}

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -64,6 +64,8 @@ public:
 	void fill_actuator_outputs() override;
 	void waiting_on_tecs() override;
 
+	void set_mc_state();
+
 private:
 
 	struct {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -511,6 +511,7 @@ VtolAttitudeControl::Run()
 
 		// Advertise/Publish vtol vehicle status
 		_vtol_vehicle_status.timestamp = hrt_absolute_time();
+		_vtol_type->fill_vtol_status_mc_weight(_vtol_vehicle_status);
 		_vtol_vehicle_status_pub.publish(_vtol_vehicle_status);
 	}
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -47,6 +47,8 @@
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_pwm_output.h>
 
+#include <uORB/topics/vtol_vehicle_status.h>
+
 struct Params {
 	int32_t idle_pwm_mc;			// pwm value for idle in mc mode
 	int32_t vtol_motor_id;
@@ -193,6 +195,14 @@ public:
 	bool was_in_trans_mode() {return _flag_was_in_trans_mode;}
 
 	virtual void parameters_update() = 0;
+
+	void fill_vtol_status_mc_weight(struct vtol_vehicle_status_s &vtol_vehicle_status)
+	{
+		vtol_vehicle_status.mc_roll_weight = _mc_roll_weight;
+		vtol_vehicle_status.mc_pitch_weight = _mc_pitch_weight;
+		vtol_vehicle_status.mc_yaw_weight = _mc_yaw_weight;
+		vtol_vehicle_status.mc_throttle_weight = _mc_throttle_weight;
+	}
 
 protected:
 	VtolAttitudeControl *_attc;


### PR DESCRIPTION
I noticed some discontinuity of the attitude setpoints after finishing the backtransition on a standard vtol. Reproduced in the simulation:

![Screenshot from 2021-09-30 09-52-01](https://user-images.githubusercontent.com/164396/135413717-0809a655-c33f-4908-b4d6-43c3e1d6f6f2.png)

Notice how the pitch body setpoint reaches zero for a single iteration. On a real drone flight, this (probably) caused some oscillations in the aftermath:

![image](https://user-images.githubusercontent.com/164396/135414228-d1a333cf-11ad-49eb-aa42-41b00758c007.png)

This PR fixes the discontinuity. New testflight in simulation with the expected smooth attitude curve:

![Screenshot from 2021-09-30 09-54-28](https://user-images.githubusercontent.com/164396/135414429-e2112af8-6fe6-4513-a593-42bdc884a75b.png)

I sneaked in some report of the mc weights via the uORB topic. Not really related to the issue, so let me know if that's unwanted.
