### PR TITLE
fix the problem related to the sitl multiple vehicle environment

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -127,7 +127,7 @@ else
 		m=0
 		while [ $m -lt ${target_number} ]; do
 			export PX4_SIM_MODEL=${target_vehicle}${LABEL}
-			spawn_model ${target_vehicle} $n $target_x $target_y
+			spawn_model ${target_vehicle}${LABEL} $n $target_x $target_y
 			m=$(($m + 1))
 			n=$(($n + 1))
 		done

--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -126,6 +126,7 @@ else
 
 		m=0
 		while [ $m -lt ${target_number} ]; do
+			export PX4_SIM_MODEL=${target_vehicle}${LABEL}
 			spawn_model ${target_vehicle} $n $target_x $target_y
 			m=$(($m + 1))
 			n=$(($n + 1))


### PR DESCRIPTION
Hi,  

I found a problem when multiple vehicle run using gazebo_sitl_multiple_run.sh like below.

```
Tools/gazebo_sitl_multiple_run.sh -s "rover:2"
Tools/gazebo_sitl_multiple_run.sh -s "rover:2,iris:2"
```

To solve this problem, I update the environment value (PX4_SIM_MODEL) for each vehicle. 

However, I'm not sure that the solution is optimal. 
Could you check this solution?


