### PR TITLE
fix commander main state reevaluation when disarmed (depending on available estimates)

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2472,13 +2472,6 @@ Commander::run()
 						_landing_gear_pub.publish(landing_gear);
 					}
 				}
-
-				// evaluate the main state machine according to mode switches
-				if (set_main_state() == TRANSITION_CHANGED) {
-					// play tune on mode change only if armed, blink LED always
-					tune_positive(_armed.armed);
-					_status_changed = true;
-				}
 			}
 
 			/* check throttle kill switch */
@@ -2512,6 +2505,15 @@ Commander::run()
 			}
 
 			/* no else case: do not change lockdown flag in unconfigured case */
+		}
+
+		/* evaluate the main state machine according to mode switches
+		 * this should be calld even if manual input is not updated as it also depends on
+		 * safety update and available estimates */
+		if (set_main_state() == TRANSITION_CHANGED) {
+			// play tune on mode change only if armed, blink LED always
+			tune_positive(_armed.armed);
+			_status_changed = true;
 		}
 
 		if (!_manual_control.isRCAvailable()) {
@@ -3083,10 +3085,8 @@ Commander::control_status_leds(bool changed, const uint8_t battery_warning)
 
 transition_result_t Commander::set_main_state()
 {
-	if ((_manual_control_switches.timestamp == 0)
-	    || (_manual_control_switches.timestamp == _last_manual_control_switches.timestamp)) {
-
-		// no manual control or no update -> nothing changed
+	if (_manual_control_switches.timestamp == 0) {
+		// no manual control -> nothing changed
 		return TRANSITION_NOT_CHANGED;
 	}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1984,9 +1984,7 @@ Commander::run()
 		}
 
 		/* update safety topic */
-		const bool safety_updated = _safety_sub.updated();
-
-		if (safety_updated) {
+		if (_safety_sub.updated()) {
 			const bool previous_safety_valid = (_safety.timestamp != 0);
 			const bool previous_safety_off = _safety.safety_off;
 
@@ -2440,7 +2438,7 @@ Commander::run()
 				_internal_state.main_state = commander_state_s::MAIN_STATE_POSCTL;
 			}
 
-			if (_manual_control_switches_sub.update(&_manual_control_switches) || safety_updated) {
+			if (_manual_control_switches_sub.update(&_manual_control_switches)) {
 
 				// handle landing gear switch if configured and in a manual mode
 				if ((_vehicle_control_mode.flag_control_manual_enabled) &&


### PR DESCRIPTION
**Describe problem solved by this pull request**
On px1.12 and later master, commander main state is not reevaluated if available estimates change when disarmed. 
After boot, this leads to stabilized mode because position and altitude estimates are not available. When estimates become available, the commander keeps going in stabilized even if RC request mode is position for example.

This issue has been seen by other users: https://px4.slack.com/archives/C0V533X4N/p1632814748388800

**Describe your solution**
Evaluate commander main state when available estimates change if disarmed