### PR TITLE
Do not alter GPS_1_CONFIG param in the rcS script when HITL is enabled.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -338,8 +338,6 @@ else
 		set OUTPUT_MODE hil
 		sensors start -h
 		commander start -h
-		# disable GPS
-		param set GPS_1_CONFIG 0
 
 		# start the simulator in hardware if needed
 		if param compare SYS_HITL 2
@@ -372,6 +370,12 @@ else
 		fi
 
 		commander start
+
+		#
+		# Start UART/Serial device drivers.
+		# Note: rc.serial is auto-generated from Tools/serial/generate_config.py
+		#
+		. ${R}etc/init.d/rc.serial
 	fi
 
 
@@ -391,12 +395,6 @@ else
 		. $BOARD_RC_MAVLINK
 	fi
 	unset BOARD_RC_MAVLINK
-
-	#
-	# Start UART/Serial device drivers.
-	# Note: rc.serial is auto-generated from Tools/serial/generate_config.py
-	#
-	. ${R}etc/init.d/rc.serial
 
 	if [ $IO_PRESENT = no ]
 	then


### PR DESCRIPTION
**Describe problem solved by this pull request**
After configuring hardware for HITL simulation the primary GPS is disabled until it is manually reset.  This PR deletes the param set and only invokes the `rc.serial` script when HITL is not enabled.

**Describe possible alternatives**
It is possible that this solution is imperfect for corner cases, although I feel it remains an improvement over the current state.

**Test data / coverage**
Tested with cube black by enabling HITL rebooting, running HITL, disabling HITL, rebooting.

Let me know if you have any questions or feedback on this PR.  Thanks!

-Mark