### PR TITLE
vtol_type: fix set_motor_state() for motor_state::VALUE

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -381,7 +381,7 @@ void VtolType::set_all_motor_state(const motor_state target_state, const int val
 
 void VtolType::set_main_motor_state(const motor_state target_state, const int value)
 {
-	if (_main_motor_state != target_state) {
+	if (_main_motor_state != target_state || target_state == motor_state::VALUE) {
 
 		if (set_motor_state(target_state, _main_motor_channel_bitmap, value)) {
 			_main_motor_state = target_state;
@@ -391,7 +391,7 @@ void VtolType::set_main_motor_state(const motor_state target_state, const int va
 
 void VtolType::set_alternate_motor_state(const motor_state target_state, const int value)
 {
-	if (_alternate_motor_state != target_state) {
+	if (_alternate_motor_state != target_state || target_state == motor_state::VALUE) {
 
 		if (set_motor_state(target_state, _alternate_motor_channel_bitmap, value)) {
 			_alternate_motor_state = target_state;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently the PWM ramp down is only called once, as afterwards _main_motor_state = VALUE and set_motor_state() is not called anymore.


**Describe your solution**
Always call set_motor_state() if _main_motor_state = VALUE.


**Test data / coverage**
flight tested

**Additional context**
We only used it for ramping down the alternative motor(s) during front transition currently btw. 
