### PR TITLE
GeofenceBreachAvoidance: vertical breach fix

### DIFF
--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -62,6 +62,7 @@ void GeofenceBreachAvoidance::updateParameters()
 	param_get(_paramHandle.param_mpc_acc_down_max, &_params.param_mpc_acc_down_max);
 
 	updateMinHorDistToFenceMultirotor();
+	updateMinVertDistToFenceMultirotor();
 }
 
 void GeofenceBreachAvoidance::setCurrentPosition(double lat, double lon, float alt)


### PR DESCRIPTION

**Describe problem solved by this pull request**
Vertical GF min distance calculation was never called, allowing for an easy breach of the GF. 

**Describe your solution**
Call updateMinVertDistToFenceMultirotor() also when updateMinHorDistToFenceMultirotor() is called. 

**Test data / coverage**
Flight tested.


