### PR TITLE
param import: avoid printing errors for erased flash devices

### DIFF
--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1426,6 +1426,10 @@ param_import_internal(int fd, bool mark_saved)
 					 decoder.total_decoded_size);
 				return 0;
 
+			} else if (result == -ENODATA) {
+				PX4_DEBUG("BSON: no data");
+				return 0;
+
 			} else {
 				PX4_ERR("param import failed (%d) attempt %d, retrying", result, attempt);
 			}


### PR DESCRIPTION
Errors:
```
ERROR [parameters] param import failed (-1) attempt 1, retrying
ERROR [parameters] param import failed (-1) attempt 2, retrying
ERROR [parameters] param import failed (-1) attempt 3, retrying
ERROR [parameters] param import failed (-1) attempt 4, retrying
ERROR [param] importing from '/fs/mtd_caldata' failed (-1)
```