### PR TITLE
FlightTaskAuto: hotfix POI yawspeed feed-forward spikes

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -110,8 +110,10 @@ void FlightTaskAuto::_limitYawRate()
 		_yaw_sp_prev = _yaw_setpoint;
 
 		if (!PX4_ISFINITE(_yawspeed_setpoint) && (_deltatime > FLT_EPSILON)) {
-			// Create a feedforward
-			_yawspeed_setpoint = dyaw / _deltatime;
+			// Create a feedforward using the filtered derivative
+			_yawspeed_filter.setParameters(_deltatime, .2f);
+			_yawspeed_filter.update(dyaw);
+			_yawspeed_setpoint = _yawspeed_filter.getState() / _deltatime;
 		}
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -46,6 +46,7 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <lib/geo/geo.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 
 // TODO: make this switchable in the board config, like a module
 #if CONSTRAINED_FLASH
@@ -114,6 +115,7 @@ protected:
 	int _mission_gear{landing_gear_s::GEAR_KEEP};
 
 	float _yaw_sp_prev{NAN};
+	AlphaFilter<float> _yawspeed_filter;
 	bool _yaw_sp_aligned{false};
 
 	ObstacleAvoidance _obstacle_avoidance; /**< class adjusting setpoints according to external avoidance module's input */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Get rid of derivative spikes when navigator is continuously updating the yaw setpoint in the triplet for a POI but is running at a lower rate.

**Describe your solution**
I added a filter for the derivative but for the feed-forward only.

**Describe possible alternatives**
I considered:
- filtering the derivative `dyaw` also for the absolute yaw setpoint generation
- filtering the absolute yaw

but both lead to inherent oscillations that have adverse effects on normal mission flying.

The proper solution is to generate that yaw setpoint with high rate in the flight task and have the triplet just guide to the next waypoint at low rate.

**Test data / coverage**
SITL testing with a mission that contains a POI. It's easily reproducable.

**Additional context**
Before:
![image-20200715-144152](https://user-images.githubusercontent.com/4668506/90523718-835fcd00-e16d-11ea-9caf-d45c31404269.png)

After:
![image](https://user-images.githubusercontent.com/4668506/90523791-95417000-e16d-11ea-92df-da90a253a4bd.png)
