### PR TITLE
Multicopter Altitude/Position mode: Fix landing redetection issue

### DIFF
--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
@@ -20,7 +20,10 @@ bool FlightTask::activate(const vehicle_local_position_setpoint_s &last_setpoint
 
 void FlightTask::reActivate()
 {
-	activate(empty_setpoint);
+	// Preserve vertical velocity while on the ground to allow descending by stick for reliable land detection
+	vehicle_local_position_setpoint_s setpoint_preserve_vertical{empty_setpoint};
+	setpoint_preserve_vertical.vz = _velocity_setpoint(2);
+	activate(setpoint_preserve_vertical);
 }
 
 bool FlightTask::updateInitialize()

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -61,14 +61,6 @@ bool FlightTaskManualAltitudeSmoothVel::activate(const vehicle_local_position_se
 	return ret;
 }
 
-void FlightTaskManualAltitudeSmoothVel::reActivate()
-{
-	FlightTaskManualAltitude::reActivate();
-	// The task is reacivated while the vehicle is on the ground. To detect takeoff in mc_pos_control_main properly
-	// using the generated jerk, reset the z derivatives to zero
-	_smoothing.reset(0.f, 0.f, _position(2));
-}
-
 void FlightTaskManualAltitudeSmoothVel::_ekfResetHandlerPositionZ(float delta_z)
 {
 	_smoothing.setCurrentPosition(_position(2));

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -49,7 +49,6 @@ public:
 	virtual ~FlightTaskManualAltitudeSmoothVel() = default;
 
 	bool activate(const vehicle_local_position_setpoint_s &last_setpoint) override;
-	void reActivate() override;
 
 protected:
 	virtual void _updateSetpoints() override;

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -130,7 +130,7 @@ private:
 	hrt_abstime _min_thrust_start{0};	///< timestamp when minimum trust was applied first
 	hrt_abstime _landed_time{0};
 
-	bool _in_descend{false};		///< vehicle is desending
+	bool _in_descend{false};		///< vehicle is commanded to desend
 	bool _horizontal_movement{false};	///< vehicle is moving horizontally
 	bool _vertical_movement{false};
 	bool _has_low_throttle{false};


### PR DESCRIPTION
**Describe problem solved by this pull request**
I Position/Altitude mode when pulling the stick down close to ground for landing and the land detection flags triggering once but going false again it does not "redetect" landing anymore for the following sequence:

- It detects landing like expected but then falls out again before it can auto disarm.
- As the landed flag goes to true the takeoff state machine considers the vehicle by design ready for takeoff again which keeps the vehicle on the ground.
- While still on the ground before takeoff the velocity smoothing algorithm for the z-axis gets reinitialized with the current velocity.
- This results in no downwards velocity command and hence no new land detection.

The landed flag can get false again when the vehicle is e.g. moved and so on, the two states are not forced to be in sync. The auto disarm looks at the landed flag and not the takeoff state machine because it also works in Stabilized and/or for fixed-wing where there’s no takeoff state machine. This allows the vehicle to be parked on the ground but not disarming.

**Describe your solution**
- I'm assuming the special handling to allow a takeoff in `FlightTaskManualAltitudeSmoothVel::reActivate` is not necessary anymore since the takeoff works without it in my tests and it was added when the activation was still quite different and e.g. did not handle the previous setpoint. (https://github.com/PX4/PX4-Autopilot/commit/99fb88ce839879e35f86c199f7dc50fa361f85e4#diff-6ff32b6dc541eafb2df8dc2d25a86206e35b671c438c969377873c495df5a155R55-R57).
- As discussed with @bresch instead of resetting all setpoints as I added it in https://github.com/PX4/PX4-Autopilot/pull/17437/files#diff-3469f836cfbbb5f930c38d52a964fdba5babf46a3b35e615903653d45380d5c2R23 the vertical velocity setpoint is preserved such that in position or altitude mode the smoothing is not reset and full stick down results in a command to descend and hence the land detection flag `in_descend` being true.

**Describe possible alternatives**
We should consolidate land detection and takeoff state machine to one place that detects, ramps up and down again and has knowledge about the intention to take off and land.

**Test data / coverage**
This was tested in simulation and real-world and solves the described issue.