### PR TITLE
VTOL: rework forward actuation assist

### DIFF
--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -186,6 +186,15 @@ bool param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2021-07-12: translate VT_DWN_PITCH_MAX to VT_PITCH_MIN
+	{
+		if (strcmp("VT_DWN_PITCH_MAX", node->name) == 0) {
+			strcpy(node->name, "VT_PITCH_MIN");
+			node->d *= -1;
+			PX4_INFO("copying and inverting sign %s -> %s", "VT_DWN_PITCH_MAX", "VT_PITCH_MIN");
+		}
+	}
+
 	// translate (SPI) calibration ID parameters. This can be removed after the next release (current release=1.10)
 
 	if (node->type != BSON_INT32) {
@@ -193,7 +202,6 @@ bool param_modify_on_import(bson_node_t node)
 	}
 
 	int64_t *ivalue = &node->i;
-
 	const char *cal_id_params[] = {
 		"CAL_ACC0_ID",
 		"CAL_GYRO0_ID",

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -62,18 +62,6 @@
 PARAM_DEFINE_INT32(VT_FWD_THRUST_EN, 0);
 
 /**
- * Maximum allowed angle the vehicle is allowed to pitch down to generate forward force
- *
- * When fixed-wing forward actuation is active (see VT_FW_TRHUST_EN).
- * If demanded down pitch exceeds this limmit, the fixed-wing forward actuators are used instead.
- *
- * @min 0.0
- * @max 45.0
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_DWN_PITCH_MAX, 5.0f);
-
-/**
  * Fixed-wing actuator thrust scale for hover forward flight.
  *
  * Scale applied to the demanded down-pitch to get the fixed-wing forward actuation in hover mode.

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -475,6 +475,6 @@ float Tiltrotor::thrust_compensation_for_tilt()
 	// only compensate for tilt angle up to 0.5 * max tilt
 	float compensated_tilt = math::constrain(_tilt_control, 0.0f, 0.5f);
 
-	// increase vertical thrust by 1/cos(tilt), limmit to [-1,0]
+	// increase vertical thrust by 1/cos(tilt), limit to [-1,0]
 	return math::constrain(_v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F), -1.0f, 0.0f);
 }

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -262,7 +262,7 @@ void Tiltrotor::update_mc_state()
 
 	} else {
 		// normal operation
-		_tilt_control = VtolType::pusher_assist();
+		_tilt_control = VtolType::pusher_assist() + _params_tiltrotor.tilt_mc;
 		_mc_yaw_weight = 1.0f;
 		_v_att_sp->thrust_body[2] = Tiltrotor::thrust_compensation_for_tilt();
 	}

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -91,8 +91,7 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_params_handles.dec_to_pitch_i = param_find("VT_B_DEC_I");
 	_params_handles.back_trans_dec_sp = param_find("VT_B_DEC_MSS");
 
-
-	_params_handles.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
+	_params_handles.pitch_min_rad = param_find("VT_PTCH_MIN");
 	_params_handles.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
 	_params_handles.vt_mc_on_fmu = param_find("VT_MC_ON_FMU");
 
@@ -100,8 +99,8 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_params_handles.mpc_land_alt1 = param_find("MPC_LAND_ALT1");
 	_params_handles.mpc_land_alt2 = param_find("MPC_LAND_ALT2");
 
-	_params_handles.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
-	_params_handles.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
+	_params_handles.land_pitch_min_rad = param_find("VT_LND_PTCH_MIN");
+
 	/* fetch initial parameter values */
 	parameters_update();
 
@@ -325,8 +324,12 @@ VtolAttitudeControl::parameters_update()
 	_params.diff_thrust_scale = math::constrain(v, -1.0f, 1.0f);
 
 	/* maximum down pitch allowed */
-	param_get(_params_handles.down_pitch_max, &v);
-	_params.down_pitch_max = math::radians(v);
+	param_get(_params_handles.pitch_min_rad, &v);
+	_params.pitch_min_rad = math::radians(v);
+
+	/* maximum down pitch allowed during landing*/
+	param_get(_params_handles.land_pitch_min_rad, &v);
+	_params.land_pitch_min_rad = math::radians(v);
 
 	/* scale for fixed wing thrust used for forward acceleration in multirotor mode */
 	param_get(_params_handles.forward_thrust_scale, &_params.forward_thrust_scale);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -217,7 +217,8 @@ private:
 		param_t fw_motors_off;
 		param_t diff_thrust;
 		param_t diff_thrust_scale;
-		param_t down_pitch_max;
+		param_t pitch_min_rad;
+		param_t land_pitch_min_rad;
 		param_t forward_thrust_scale;
 		param_t dec_to_pitch_ff;
 		param_t dec_to_pitch_i;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -358,3 +358,29 @@ PARAM_DEFINE_FLOAT(VT_B_DEC_I, 0.1f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_MC_ON_FMU, 0);
+
+/**
+ * Minimum pitch angle during hover.
+ *
+ * Minimum pitch angle during hover flight. If the desired pitch angle is is lower than this value
+ * then the fixed-wing forward actuation can be used to compensate for the missing thrust in forward direction
+ * (see VT_FW_TRHUST_EN)
+ *
+ * @min -10.0
+ * @max 45.0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_PTCH_MIN, -5.0f);
+
+/**
+ * Minimum pitch angle during hover landing.
+ *
+ * Overrides  VT_PTCH_MIN when the vehicle is in LAND mode (hovering).
+ * During landing it can be beneficial to allow lower minimum pitch angles as it can avoid the wings
+ * generating too much lift and preventing the vehicle from sinking at the desired rate.
+ *
+ * @min -10.0
+ * @max 45.0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_LND_PTCH_MIN, -5.0f);

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -70,7 +70,8 @@ struct Params {
 	int32_t fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
 	int32_t diff_thrust;
 	float diff_thrust_scale;
-	float down_pitch_max;
+	float pitch_min_rad;
+	float land_pitch_min_rad;
 	float forward_thrust_scale;
 	float dec_to_pitch_ff;
 	float dec_to_pitch_i;


### PR DESCRIPTION
- clean up logic
- allow positive pitch offsets in hover
- add params for min pitch during not-Land and Land modes

**Describe problem solved by this pull request**
Problem: For VTOLs we want a positive pitch angle while hovering to increase hover efficiency and reduce motor loads in high wind. When descending that can though end up being a problem, as in heavy wind the lift produced by the winds may be enough to not letting it descend even on minimal thrust.


**Describe your solution**
This PR first of all changes the logic behind the pitch setpoint when pusher assist (tilt-forward for tiltrotor) is enabled: Instead of allowing some pitch down via VT_DWN_PITCH_MAX, it will not pitch down at all to create a positive force in x, but use the pusher assist. VT_DWN_PITCH_MAX is removed, and two new params are added: VT_PTCH_MIN (min pitch when forward thrust support is enabled and not in Land mode) and VT_LND_PTCH_MIN (same, but in Land mode). 


**Test data / coverage**
Flight tested on several platforms. 

**Additional context**
![image](https://user-images.githubusercontent.com/26798987/135881080-0e1f8771-8745-43e9-b0ac-20db9458ec6c.png)
