### PR TITLE
Add vscode cmake-variant for px4_sitl_rtps

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -6,6 +6,11 @@ CONFIG:
       buildType: RelWithDebInfo
       settings:
         CONFIG: px4_sitl_default
+    px4_sitl_rtps:
+      short: px4_sitl_rtps
+      buildType: RelWithDebInfo
+      settings:
+        CONFIG: px4_sitl_rtps
     px4_sitl_asan:
       short: px4_sitl (AddressSanitizer)
       buildType: AddressSanitizer


### PR DESCRIPTION
**Describe problem solved by this pull request**
Adds px4_sitl_rtps to vscode's cmake-variants to allow debugging rtps and px4

**Test data / coverage**
Debugged px4 with vscode and rtps running
