### PR TITLE
VTOL Fix back transition devaitions

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -842,7 +842,7 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 			if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
 				// POSITION: achieve position setpoint altitude via loiter
 				// close to waypoint, but altitude error greater than twice acceptance
-				if ((dist >= 0.f)
+				if ((!_vehicle_status.in_transition_mode) && (dist >= 0.f)
 				    && (dist_z > 2.f * _param_fw_clmbout_diff.get())
 				    && (dist_xy < 2.f * math::max(acc_rad, fabsf(pos_sp_curr.loiter_radius)))) {
 					// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER


### PR DESCRIPTION
**Describe problem solved by this pull request**
I found a bug with back transitions that was introduced with I think https://github.com/PX4/PX4-Autopilot/pull/16499. 

If you set the next WP after the back transition to a different altitude the drone can enter a "spiralling down" mode (set here: https://github.com/PX4/PX4-Autopilot/blob/master/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L842-L850). This can lead to unexpected deviations during back transitions. And as the altitude is ultimately controlled (fix) by the MC module the spiralling down doesn't actually spiral down anyway... Also note that if you have a small value on FW_CLMBOUT_DIFF you can be affected even when the next WP is at the same altitude if the drone gets a lot of altitude during back transition due to pitching up.

**Describe your solution**
Deactivate the loitering logic during transitions. 

**Describe possible alternatives**
\-

**Test data / coverage**
Found on two different real quadplanes, and I was able to reproduce it on SITL.

Real flight on v1.12.1: https://logs.px4.io/plot_app?log=2f6a1c96-eabb-4576-abb1-a99b716f6c67

SITL tests with attached mission file [test BT deviations.zip](https://github.com/PX4/PX4-Autopilot/files/7279541/test.BT.deviations.zip):

master, FW_AIRSPD_TRIM = 19, FW_L1_PERIOD = 25 and NAV_LOITER_RAD = 50: https://logs.px4.io/plot_app?log=79cadeb1-27bc-4c4c-88c4-7ded26c0a430

master, default parameters: https://logs.px4.io/plot_app?log=6c1b368b-a435-4868-a856-159d68da926c
Interestingly there is no deviation even though the logic still triggers. I don't understand why the deviation doesn't happen on default parameters, must be something particular with the FW loitering logic. Check `position_controller_status.type`, it goes to 2, showing that the loitering logic is triggered.

This PR: https://logs.px4.io/plot_app?log=ef558a1a-2c2c-461f-a781-645a3ad2e121 
`position_controller_status.type` = 0 throughout, no deviation.

**Additional context**
Unfortunately _not_ linked to https://github.com/PX4/PX4-Autopilot/issues/18240