### PR TITLE
px4_work_queue: adjust status formatting to accommodate longer names (eg mc_autotune_attitude_control)

### DIFF
--- a/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
+++ b/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
@@ -72,7 +72,7 @@ void ScheduledWorkItem::ScheduleClear()
 void ScheduledWorkItem::print_run_status()
 {
 	if (_call.period > 0) {
-		PX4_INFO_RAW("%-26s %8.1f Hz %12.0f us (%" PRId64 " us)\n", _item_name, (double)average_rate(),
+		PX4_INFO_RAW("%-29s %8.1f Hz %12.0f us (%" PRId64 " us)\n", _item_name, (double)average_rate(),
 			     (double)average_interval(), _call.period);
 
 	} else {

--- a/platforms/common/px4_work_queue/WorkItem.cpp
+++ b/platforms/common/px4_work_queue/WorkItem.cpp
@@ -134,7 +134,7 @@ float WorkItem::average_interval() const
 
 void WorkItem::print_run_status()
 {
-	PX4_INFO_RAW("%-26s %8.1f Hz %12.0f us\n", _item_name, (double)average_rate(), (double)average_interval());
+	PX4_INFO_RAW("%-29s %8.1f Hz %12.0f us\n", _item_name, (double)average_rate(), (double)average_interval());
 
 	// reset statistics
 	_run_count = 0;

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -407,7 +407,7 @@ WorkQueueManagerStatus()
 	if (!_wq_manager_should_exit.load() && (_wq_manager_wqs_list != nullptr)) {
 
 		const size_t num_wqs = _wq_manager_wqs_list->size();
-		PX4_INFO_RAW("\nWork Queue: %-1zu threads                        RATE        INTERVAL\n", num_wqs);
+		PX4_INFO_RAW("\nWork Queue: %-2zu threads                          RATE        INTERVAL\n", num_wqs);
 
 		LockGuard lg{_wq_manager_wqs_list->mutex()};
 		size_t i = 0;


### PR DESCRIPTION
The new `mc_autotune_attitude_control` pushed us over the edge.

![Screenshot from 2021-10-04 15-00-13](https://user-images.githubusercontent.com/84712/135908876-97b56cf3-a9eb-48d1-b09f-0bfb27ed3314.png)
