### PR TITLE
drivers/imu: ensure timestamp_sample adjustment isn't done as float

### DIFF
--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
@@ -220,7 +220,7 @@ void BMI088_Accelerometer::RunImpl()
 
 					// tolerate minor jitter, leave sample to next iteration if behind by only 1
 					if (samples == _fifo_samples + 1) {
-						timestamp_sample -= FIFO_SAMPLE_DT;
+						timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 						samples--;
 					}
 

--- a/src/drivers/imu/invensense/icm20608g/ICM20608G.cpp
+++ b/src/drivers/imu/invensense/icm20608g/ICM20608G.cpp
@@ -262,7 +262,7 @@ void ICM20608G::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 

--- a/src/drivers/imu/invensense/icm20689/ICM20689.cpp
+++ b/src/drivers/imu/invensense/icm20689/ICM20689.cpp
@@ -262,7 +262,7 @@ void ICM20689::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.cpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.cpp
@@ -225,7 +225,7 @@ void ICM40609D::RunImpl()
 
 					// tolerate minor jitter, leave sample to next iteration if behind by only 1
 					if (samples == _fifo_gyro_samples + 1) {
-						timestamp_sample -= FIFO_SAMPLE_DT;
+						timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 						samples--;
 					}
 

--- a/src/drivers/imu/invensense/icm42605/ICM42605.cpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.cpp
@@ -226,7 +226,7 @@ void ICM42605::RunImpl()
 
 					// tolerate minor jitter, leave sample to next iteration if behind by only 1
 					if (samples == _fifo_gyro_samples + 1) {
-						timestamp_sample -= FIFO_SAMPLE_DT;
+						timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 						samples--;
 					}
 

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -226,7 +226,7 @@ void ICM42688P::RunImpl()
 
 					// tolerate minor jitter, leave sample to next iteration if behind by only 1
 					if (samples == _fifo_gyro_samples + 1) {
-						timestamp_sample -= FIFO_SAMPLE_DT;
+						timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 						samples--;
 					}
 

--- a/src/drivers/imu/invensense/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.cpp
@@ -231,7 +231,7 @@ void MPU6000::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.cpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.cpp
@@ -263,7 +263,7 @@ void MPU6500::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.cpp
@@ -298,7 +298,7 @@ void MPU9250::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.cpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.cpp
@@ -231,7 +231,7 @@ void MPU9250_I2C::RunImpl()
 
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 

--- a/src/drivers/imu/st/lsm9ds1/LSM9DS1.cpp
+++ b/src/drivers/imu/st/lsm9ds1/LSM9DS1.cpp
@@ -189,7 +189,7 @@ void LSM9DS1::RunImpl()
 			} else {
 				// tolerate minor jitter, leave sample to next iteration if behind by only 1
 				if (samples == _fifo_gyro_samples + 1) {
-					timestamp_sample -= FIFO_SAMPLE_DT;
+					timestamp_sample -= static_cast<int>(FIFO_SAMPLE_DT);
 					samples--;
 				}
 


### PR DESCRIPTION
 - larger HRT timestamps can't be represented exactly when cast to float


This was presenting very unusual errors on bench tested systems left running overnight.

``` Console
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (5585511377) < timestamp_sample (5585511424)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (5585520127) < timestamp_sample (5585520128)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (5585522642) < timestamp_sample (5585522688)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (5585522653) < timestamp_sample (5585522688)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411191291) < timestamp_sample (6411191296)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411202558) < timestamp_sample (6411202560)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411205053) < timestamp_sample (6411205120)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (6411205068) < timestamp_sample (6411205120)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (6411213820) < timestamp_sample (6411213824)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411213810) < timestamp_sample (6411213824)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411216373) < timestamp_sample (6411216384)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411225071) < timestamp_sample (6411225088)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (6411225082) < timestamp_sample (6411225088)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (6411236335) < timestamp_sample (6411236352)
ERROR [vehicle_imu] 1 - gyro 3932170 timestamp (6411236324) < timestamp_sample (6411236352)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (6411247596) < timestamp_sample (6411247616)
ERROR [vehicle_imu] 1 - gyro  3932170 timestamp (6411247586) < timestamp_sample (6411247616)
ERROR [vehicle_imu] 1 - accel 3932170 timestamp (6411258860) < timestamp_sample (6411258880)
ERROR [vehicle_imu] 1 - gyro  3932170 timestamp (6411258845) < timestamp_sample (6411258880)
```