### PR TITLE
FW Position control: add roll slewrate also in manual Position flight mode

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1106,7 +1106,17 @@ FixedwingPositionControl::control_position(const hrt_abstime &now, const Vector2
 
 			_hdg_hold_enabled = false;
 			_yaw_lock_engaged = false;
-			_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());
+
+			// do slew rate limiting on roll if enabled
+			float roll_sp_new = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());
+			const float roll_rate_slew_rad = radians(_param_fw_l1_r_slew_max.get());
+
+			if (dt > 0.f && roll_rate_slew_rad > 0.f) {
+				roll_sp_new = constrain(roll_sp_new, _att_sp.roll_body - roll_rate_slew_rad * dt,
+							_att_sp.roll_body + roll_rate_slew_rad * dt);
+			}
+
+			_att_sp.roll_body = roll_sp_new;
 			_att_sp.yaw_body = 0;
 		}
 


### PR DESCRIPTION

**Describe problem solved by this pull request**
Currently, in manual Position flight mode the roll setpoint is the unfiltered stick input. I think it would be nice to limit the rate of change, and would actually expect that the same slew rate is used as in Auto flight mode (FW_L1_R_SLEW_MAX)

**Describe your solution**
Use FW_L1_R_SLEW_MAX also in Position mode.

**Describe possible alternatives**
Are we fine to have the roll slew rate in all modes of the FW Position controller? Because then we could add it instead just before the attitdue setpoint is published (https://github.com/PX4/PX4-Autopilot/blob/fef2c4339577c1bccd33c649d63a4a31c8005ef7/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1793). It would e.g. also be in Altitude flight mode then.

**Test data / coverage**
Flight tested on several vehicle. The default of 90° for FW_L1_R_SLEW_MAX is pretty high, thus by default it doesn't change the feeling significantly. 


