### PR TITLE
Improved stability of D-term in the rate controller

### DIFF
--- a/src/lib/mathlib/math/filter/AlphaFilter.hpp
+++ b/src/lib/mathlib/math/filter/AlphaFilter.hpp
@@ -43,6 +43,9 @@
 #pragma once
 
 #include <float.h>
+#include <mathlib/math/Functions.hpp>
+
+using namespace math;
 
 template <typename T>
 class AlphaFilter
@@ -68,6 +71,21 @@ public:
 		if (denominator > FLT_EPSILON) {
 			setAlpha(sample_interval / denominator);
 		}
+	}
+
+	void setCutoffFreq(float sample_freq, float cutoff_freq)
+	{
+		if ((sample_freq <= 0.f) || (cutoff_freq <= 0.f) || (cutoff_freq >= sample_freq / 2.f)
+		    || !isFinite(sample_freq) || !isFinite(cutoff_freq)) {
+
+			// No filtering
+			_alpha = 1.f;
+			_cutoff_freq = 0.f;
+			return;
+		}
+
+		setParameters(1.f / sample_freq, 1.f / (2.f * M_PI_F * cutoff_freq));
+		_cutoff_freq = cutoff_freq;
 	}
 
 	/**
@@ -96,10 +114,12 @@ public:
 	}
 
 	const T &getState() const { return _filter_state; }
+	float getCutoffFreq() const { return _cutoff_freq; }
 
 protected:
 	T updateCalculation(const T &sample) { return (1.f - _alpha) * _filter_state + _alpha * sample; }
 
+	float _cutoff_freq{0.f};
 	float _alpha{0.f};
 	T _filter_state{};
 };

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -162,7 +162,7 @@ void VehicleAngularVelocity::ResetFilters()
 			_notch_filter_velocity[axis].reset(angular_velocity_uncalibrated(axis));
 
 			// angular acceleration low pass
-			_lp_filter_acceleration[axis].set_cutoff_frequency(_filter_sample_rate_hz, _param_imu_dgyro_cutoff.get());
+			_lp_filter_acceleration[axis].setCutoffFreq(_filter_sample_rate_hz, _param_imu_dgyro_cutoff.get());
 			_lp_filter_acceleration[axis].reset(angular_acceleration_uncalibrated(axis));
 		}
 
@@ -305,7 +305,7 @@ void VehicleAngularVelocity::ParametersUpdate(bool force)
 
 		// gyro derivative low pass cutoff changed
 		for (auto &lp : _lp_filter_acceleration) {
-			if (fabsf(lp.get_cutoff_freq() - _param_imu_dgyro_cutoff.get()) > 0.01f) {
+			if (fabsf(lp.getCutoffFreq() - _param_imu_dgyro_cutoff.get()) > 0.01f) {
 				_reset_filters = true;
 				break;
 			}
@@ -630,7 +630,7 @@ float VehicleAngularVelocity::FilterAngularAcceleration(int axis, float dt_s, fl
 
 	for (int n = 0; n < N; n++) {
 		const float angular_acceleration = (data[n] - _angular_velocity_raw_prev(axis)) / dt_s;
-		angular_acceleration_filtered = _lp_filter_acceleration[axis].apply(angular_acceleration);
+		angular_acceleration_filtered = _lp_filter_acceleration[axis].update(angular_acceleration);
 		_angular_velocity_raw_prev(axis) = data[n];
 	}
 

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -37,6 +37,7 @@
 #include <lib/sensor_calibration/Gyroscope.hpp>
 #include <lib/mathlib/math/Limits.hpp>
 #include <lib/matrix/matrix/math.hpp>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/mathlib/math/filter/NotchFilter.hpp>
 #include <px4_platform_common/log.h>
@@ -165,7 +166,7 @@ private:
 #endif // !CONSTRAINED_FLASH
 
 	// angular acceleration filter
-	math::LowPassFilter2p<float> _lp_filter_acceleration[3] {};
+	AlphaFilter<float> _lp_filter_acceleration[3] {};
 
 	uint32_t _selected_sensor_device_id{0};
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
We realized that some drones with oscillations generated by the rate feedback loop had less problems when increasing the cutoff frequency of the d-term filter (or by removing it completely). For a 2nd order LPF, the cutoff needs to be carefully set to removing enough noise while not adding too much lag to the signal; if too much lag is added, the derivative part of the rate loop can become unstable and the drone oscillates.

**Describe your solution**
After some discussion with @priseborough it seems that a 1st order LPF is usually enough to remove the noise generated by the differentiation of the signal while (which is a 1st order hpf) without removing too much phase (i.e.: less lag). Having a maximum phase lag of 90 degrees, a 1st order LPF cannot make the derivative loop oscillate even when set to a low cutoff frequency.

**Test data / coverage**
SITL test showing that the filtering works properly:
![DeepinScreenshot_select-area_20211005150007](https://user-images.githubusercontent.com/14822839/136032676-5fe627f8-00c0-4568-8bf1-0005d04af200.png)

Also, in the literature, I've always seen 1st order low-pass filters on the derivative path of PIDs; it's probably not a coincidence even if the reason for this choice is usually not specified.