### PR TITLE
github actions remove ccache from deploy metadata and low priority builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,27 +36,6 @@ jobs:
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
 
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-    - name: ccache cache files
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{matrix.config}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-        restore-keys: ${{matrix.config}}-ccache-
-    - name: setup ccache
-      run: |
-          mkdir -p ~/.ccache
-          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-          echo "compression = true" >> ~/.ccache/ccache.conf
-          echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 20M" >> ~/.ccache/ccache.conf
-          ccache -s
-          ccache -z
     - name: check environment
       run: |
           export

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,30 +17,5 @@ jobs:
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-    - name: ccache cache files
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: clang-tidy-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-        restore-keys: clang-tidy-ccache-
-    - name: setup ccache
-      run: |
-          mkdir -p ~/.ccache
-          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-          echo "compression = true" >> ~/.ccache/ccache.conf
-          echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 20M" >> ~/.ccache/ccache.conf
-          ccache -s
-          ccache -z
-
     - name: make clang-tidy-quiet
-      run: |
-        ccache -z
-        make clang-tidy-quiet
-        ccache -s
+      run: make clang-tidy-quiet

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -29,32 +29,8 @@ jobs:
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-    - name: ccache cache files
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{matrix.target}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-        restore-keys: ${{matrix.target}}-ccache-
-    - name: setup ccache
-      run: |
-          mkdir -p ~/.ccache
-          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-          echo "compression = true" >> ~/.ccache/ccache.conf
-          echo "compression_level = 6" >> ~/.ccache/ccache.conf
-          echo "max_size = 50M" >> ~/.ccache/ccache.conf
-          ccache -s
-          ccache -z
-
     - name: make ${{matrix.target}}
       run: make ${{matrix.target}}
-    - name: ccache post-run
-      run: ccache -s
 
     - name: parameter & events metadata
       run: |


### PR DESCRIPTION
 - this is an attempt to preserve our limited amount of github actions cache storage
