### PR TITLE
protocol_splitter: delete non rtps or mavlink data from buffer

### DIFF
--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -568,8 +568,8 @@ void DevCommon::cleanup()
 
 	size_t garbage_end = 0;
 
-	if (!mavlink_available && !rtps_available) {
-		garbage_end = math::max(_read_buffer->start_mavlink, _read_buffer->start_rtps);
+	if (!mavlink_available && !rtps_available && (_read_buffer->buf_size > 0)) {
+		garbage_end = _read_buffer->buf_size - 1;
 
 	} else {
 		garbage_end = math::min(_read_buffer->start_mavlink, _read_buffer->start_rtps);


### PR DESCRIPTION
**Describe problem solved by this pull request**
If there is no **rtps** or **mavlink** header `DevCommon::cleanup()` will never clean the buffer because `garbage_end` was always `0`.
This was causing the buffer to go up to 1024 bytes resulting in a high CPU load.

![image](https://user-images.githubusercontent.com/10188706/136335731-5840c19a-0c75-4e2f-ab79-ee12ffbfd8c0.png)

**Describe your solution**
This solution will use buffer size if there is no rtps or mavlink data inside buffer as `garbage_end` value
