### PR TITLE
param jsonout: handle boolean flag

### DIFF
--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -93,6 +93,11 @@ class JsonOutput():
                         code_dict['description']=param.GetEnumValue(item)
                         codes_list.append(code_dict)
                     curr_param['values'] = codes_list
+                elif param.GetBoolean():
+                    curr_param['values'] = [
+                        { 'value': 0, 'description': 'Disabled' },
+                        { 'value': 1, 'description': 'Enabled' }
+                    ]
 
 
                 if len(param.GetBitmaskList()) > 0:


### PR DESCRIPTION
This got lost when switching from xml to json metadata.

reboot_required was missing as welll: https://github.com/mavlink/qgroundcontrol/pull/9903