### PR TITLE
motor_ramp ram cleanup

### DIFF
--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -364,9 +364,9 @@ int motor_ramp_thread_main(int argc, char *argv[])
 	_thread_running = true;
 
 	unsigned long max_channels = 0;
-	static struct pwm_output_values last_spos;
-	static struct pwm_output_values last_min;
-	static unsigned servo_count;
+	struct pwm_output_values last_spos;
+	struct pwm_output_values last_min;
+	unsigned servo_count;
 
 	int fd = px4_open(_pwm_output_dev, 0);
 


### PR DESCRIPTION
Move pwm_output_values and servo count from bss to local stack of the motor_ramp task.

Saves 64 bytes of RAM when not running motor_ramp

**Testing**
Basic testing on board, but don't have working real HW available to fully verify