### PR TITLE
Kconfig generate px4_kconf.h defines and include in px4_config.h

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -10,11 +10,13 @@ endif()
 set(MENUCONFIG_PATH ${PYTHON_EXECUTABLE} -m menuconfig CACHE INTERNAL "menuconfig program" FORCE)
 set(GUICONFIG_PATH ${PYTHON_EXECUTABLE} -m guiconfig CACHE INTERNAL "guiconfig program" FORCE)
 set(DEFCONFIG_PATH ${PYTHON_EXECUTABLE} -m defconfig CACHE INTERNAL "defconfig program" FORCE)
+set(GENCONFIG_PATH ${PYTHON_EXECUTABLE} -m genconfig CACHE INTERNAL "genconfig program" FORCE)
 set(SAVEDEFCONFIG_PATH ${PYTHON_EXECUTABLE} -m savedefconfig CACHE INTERNAL "savedefconfig program" FORCE)
 
 set(COMMON_KCONFIG_ENV_SETTINGS
 	PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 	KCONFIG_CONFIG=${BOARD_CONFIG}
+	KCONFIG_AUTOHEADER=${PX4_BINARY_DIR}/px4_kconf.h
 	# Set environment variables so that Kconfig can prune Kconfig source
 	# files for other architectures
 	PLATFORM=${PX4_PLATFORM}
@@ -45,6 +47,11 @@ if(EXISTS ${BOARD_DEFCONFIG})
                         OUTPUT_VARIABLE DUMMY_RESULTS)
     endif()
 
+    # Generate px4_kconf.h header from saved defconfig
+    execute_process(COMMAND ${CMAKE_COMMAND} -E env ${COMMON_KCONFIG_ENV_SETTINGS}
+                    ${GENCONFIG_PATH}
+                    WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+                    OUTPUT_VARIABLE DUMMY_RESULTS)
 
     # parse board config options for cmake
     file(STRINGS ${BOARD_CONFIG} ConfigContents)

--- a/platforms/common/include/px4_platform_common/px4_config.h
+++ b/platforms/common/include/px4_platform_common/px4_config.h
@@ -39,6 +39,8 @@
 
 #pragma once
 
+#include <px4_kconf.h>
+
 #if defined(__PX4_NUTTX)
 
 #include <nuttx/config.h>


### PR DESCRIPTION
To use the Kconfig in the C/C++ preprocessor directly we generate the px4_kconf.h based on our boardconfig and include this by default in px4_config.h.

Any application that wants to make #ifdef can you simple include the px4_config.h header and get the Kconfig defines as well.

This will avoid that people have to make their own kconfig parsers #18387, @jlaitine I think this PR should make your work easier to implement.
