### PR TITLE
Revert "protocol_splitter: delete non rtps or mavlink data from buffer"

### DIFF
--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -568,8 +568,8 @@ void DevCommon::cleanup()
 
 	size_t garbage_end = 0;
 
-	if (!mavlink_available && !rtps_available && (_read_buffer->buf_size > 0)) {
-		garbage_end = _read_buffer->buf_size - 1;
+	if (!mavlink_available && !rtps_available) {
+		garbage_end = math::max(_read_buffer->start_mavlink, _read_buffer->start_rtps);
 
 	} else {
 		garbage_end = math::min(_read_buffer->start_mavlink, _read_buffer->start_rtps);


### PR DESCRIPTION
Reverting: https://github.com/PX4/PX4-Autopilot/pull/18377

It seems we can't just delete all the data from the buffer. This causes bad communication between companion computer and FMU,
