### PR TITLE
PilotPi: fix upload command

### DIFF
--- a/boards/scumaker/pilotpi/cmake/upload.cmake
+++ b/boards/scumaker/pilotpi/cmake/upload.cmake
@@ -46,7 +46,7 @@ endif()
 add_custom_target(upload
 	COMMAND rsync -arh --progress
 			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/pilotpi*.config ${PX4_BINARY_DIR}/etc # source
-			\$\{AUTOPILOT_USER\}@\$\{AUTOPILOT_HOST\}:/home/\$\{AUTOPILOT_USER\}/px4 # destination
+			"${AUTOPILOT_USER}@${AUTOPILOT_HOST}:/home/${AUTOPILOT_USER}/px4" # destination
 	DEPENDS px4
 	COMMENT "uploading px4"
 	USES_TERMINAL


### PR DESCRIPTION
**Describe problem solved by this pull request**
`make scumaker_pilotpi_default upload` now fails somehow... A quick fix for that.