### PR TITLE
ekf2: improve angular rate compensation

### DIFF
--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -388,7 +388,7 @@ void Ekf::controlOpticalFlowFusion()
 			// compensate for body motion to give a LOS rate
 			_flow_compensated_XY_rad = _flow_sample_delayed.flow_xy_rad - _flow_sample_delayed.gyro_xyz.xy();
 
-		} else if (!_control_status.flags.in_air && is_body_rate_comp_available) {
+		} else if (!_control_status.flags.in_air) {
 
 			if (!is_delta_time_good) {
 				// handle special case of SITL and PX4Flow where dt is forced to

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -340,6 +340,7 @@ bool Ekf::calcOptFlowBodyRateComp()
 		return false;
 	}
 
+	bool is_body_rate_comp_available = false;
 	const bool use_flow_sensor_gyro = PX4_ISFINITE(_flow_sample_delayed.gyro_xyz(0)) && PX4_ISFINITE(_flow_sample_delayed.gyro_xyz(1)) && PX4_ISFINITE(_flow_sample_delayed.gyro_xyz(2));
 
 	if (use_flow_sensor_gyro) {
@@ -356,6 +357,8 @@ bool Ekf::calcOptFlowBodyRateComp()
 
 			// calculate the bias estimate using  a combined LPF and spike filter
 			_flow_gyro_bias = _flow_gyro_bias * 0.99f + matrix::constrain(measured_body_rate - reference_body_rate, -0.1f, 0.1f) * 0.01f;
+
+			is_body_rate_comp_available = true;
 		}
 
 	} else {
@@ -365,13 +368,15 @@ bool Ekf::calcOptFlowBodyRateComp()
 		    && (_flow_sample_delayed.dt > FLT_EPSILON)) {
 			_flow_sample_delayed.gyro_xyz = -_imu_del_ang_of / _delta_time_of * _flow_sample_delayed.dt;
 			_flow_gyro_bias.zero();
+
+			is_body_rate_comp_available = true;
 		}
 	}
 
 	// reset the accumulators
 	_imu_del_ang_of.setZero();
 	_delta_time_of = 0.0f;
-	return true;
+	return is_body_rate_comp_available;
 }
 
 // calculate the measurement variance for the optical flow sensor (rad/sec)^2


### PR DESCRIPTION
follows https://github.com/PX4/PX4-ECL/pull/1005#issuecomment-831151462

When the optical flow sensor does not provide angular rate measurements, the EKF uses its gyro data for the compensation. The integrated gyro data needs to be properly scaled to match the optical flow integration time.

`_imu_del_ang_of` is the integrated gyro data over a period of `_delta_time_of` while `_flow_sample_delayed.gyro_xyz` is the integral over `_flow_sample_delayed.dt`. Even if the two periods are close, they aren't exactly the same and can degrade performance during fast rotations if the compensation isn't done properly.

Tested on Pixhawk4 with pmw3901 (handheld test):
https://logs.px4.io/plot_app?log=4ef0fcd4-c621-4c20-8040-864fa8660341
![DeepinScreenshot_select-area_20211011162111](https://user-images.githubusercontent.com/14822839/136806440-d6e36600-77c5-4d0b-ae69-c103632ca8a4.png)

