### PR TITLE
UAVCAN F9P Moving Baseline

### DIFF
--- a/msg/gps_inject_data.msg
+++ b/msg/gps_inject_data.msg
@@ -1,6 +1,9 @@
 uint64 timestamp		# time since system start (microseconds)
-uint8 len			# length of data
-uint8 flags         		# LSB: 1=fragmented
-uint8[182] data		# data to write to GPS device (RTCM message)
+
+uint32 device_id                # unique device ID for the sensor that does not change between power cycles
+
+uint8 len                       # length of data
+uint8 flags                     # LSB: 1=fragmented
+uint8[300] data                 # data to write to GPS device (RTCM message)
 
 uint8 ORB_QUEUE_LENGTH = 8

--- a/msg/sensor_gps.msg
+++ b/msg/sensor_gps.msg
@@ -38,3 +38,4 @@ uint8 satellites_used		# Number of satellites used
 
 float32 heading			# heading angle of XYZ body frame rel to NED. Set to NaN if not available and updated (used for dual antenna GPS), (rad, [-PI, PI])
 float32 heading_offset		# heading offset of dual antenna array in body frame. Set to NaN if not applicable. (rad, [-PI, PI])
+float32 heading_accuracy	# heading accuracy (rad, [0, 2PI])

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -76,14 +76,19 @@ PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
  * dual GPS without heading.
  *
  * The Heading mode requires 2 F9P devices to be attached. The main GPS will act as rover and output
- * heading information, whereas the secondary will act as moving base, sending RTCM on UART2 to
- * the rover GPS.
+ * heading information, whereas the secondary will act as moving base.
+ * Modes 1 and 2 require each F9P UART1 to be connected to the Autopilot. In addition, UART2 on the
+ * F9P units are connected to each other.
+ * Modes 3 and 4 only require UART1 on each F9P connected to the Autopilot or Can Node. UART RX DMA is required.
  * RTK is still possible with this setup.
  *
  * @min 0
  * @max 1
  * @value 0 Default
- * @value 1 Heading
+ * @value 1 Heading (Rover With Moving Base UART1 Connected To Autopilot, UART2 Connected To Moving Base)
+ * @value 2 Moving Base (UART1 Connected To Autopilot, UART2 Connected To Rover)
+ * @value 3 Heading (Rover With Moving Base UART1 Connected to Autopilot Or Can Node At 921600)
+ * @value 4 Moving Base (Moving Base UART1 Connected to Autopilot Or Can Node At 921600)
  *
  * @reboot_required true
  * @group GPS
@@ -95,7 +100,6 @@ PARAM_DEFINE_INT32(GPS_UBX_MODE, 0);
  * Heading/Yaw offset for dual antenna GPS
  *
  * Heading offset angle for dual antenna GPS setups that support heading estimation.
- * (currently only for the Trimble MB-Two).
  *
  * Set this to 0 if the antennas are parallel to the forward-facing direction of the vehicle and the first antenna is in
  * front. The offset angle increases clockwise.

--- a/src/drivers/uavcan/beep.cpp
+++ b/src/drivers/uavcan/beep.cpp
@@ -45,6 +45,7 @@ UavcanBeep::UavcanBeep(uavcan::INode &node) :
 	_beep_pub(node),
 	_timer(node)
 {
+	_beep_pub.setPriority(uavcan::TransferPriority::Default);
 }
 
 int UavcanBeep::init()

--- a/src/drivers/uavcan/safety_state.cpp
+++ b/src/drivers/uavcan/safety_state.cpp
@@ -43,6 +43,7 @@ UavcanSafetyState::UavcanSafetyState(uavcan::INode &node) :
 	_safety_state_pub(node),
 	_timer(node)
 {
+	_safety_state_pub.setPriority(uavcan::TransferPriority::Default);
 }
 
 int UavcanSafetyState::init()

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -98,7 +98,7 @@ UavcanGnssBridge::init()
 		return res;
 	}
 
-	_pub_rtcm.setPriority(uavcan::TransferPriority::OneHigherThanLowest);
+	_pub_rtcm.setPriority(uavcan::TransferPriority::NumericallyMax);
 
 	return res;
 }
@@ -134,7 +134,7 @@ UavcanGnssBridge::gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 	float vel_cov[9];
 	msg.velocity_covariance.unpackSquareMatrix(vel_cov);
 
-	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_pos_cov, valid_vel_cov);
+	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_pos_cov, valid_vel_cov, NAN, NAN, NAN);
 }
 
 void
@@ -274,14 +274,34 @@ UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 		}
 	}
 
-	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_covariances, valid_covariances);
+	float heading = NAN;
+	float heading_offset = NAN;
+	float heading_accuracy = NAN;
+
+	// Use ecef_position_velocity for now... There is no heading field
+	if (!msg.ecef_position_velocity.empty()) {
+		heading = msg.ecef_position_velocity[0].velocity_xyz[0];
+
+		if (!isnan(msg.ecef_position_velocity[0].velocity_xyz[1])) {
+			heading_offset = msg.ecef_position_velocity[0].velocity_xyz[1];
+		}
+
+		if (!isnan(msg.ecef_position_velocity[0].velocity_xyz[2])) {
+			heading_accuracy = msg.ecef_position_velocity[0].velocity_xyz[2];
+		}
+	}
+
+	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_covariances, valid_covariances, heading, heading_offset,
+		     heading_accuracy);
 }
 
 template <typename FixType>
 void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType> &msg,
 				    uint8_t fix_type,
 				    const float (&pos_cov)[9], const float (&vel_cov)[9],
-				    const bool valid_pos_cov, const bool valid_vel_cov)
+				    const bool valid_pos_cov, const bool valid_vel_cov,
+				    const float heading, const float heading_offset,
+				    const float heading_accuracy)
 {
 	sensor_gps_s report{};
 	report.device_id = get_device_id();
@@ -407,8 +427,9 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 		report.vdop = msg.pdop;
 	}
 
-	report.heading = NAN;
-	report.heading_offset = NAN;
+	report.heading = heading;
+	report.heading_offset = heading_offset;
+	report.heading_accuracy = heading_accuracy;
 
 	publish(msg.getSrcNodeID().get(), &report);
 }
@@ -455,12 +476,11 @@ void UavcanGnssBridge::handleInjectDataTopic()
 
 bool UavcanGnssBridge::injectData(const uint8_t *const data, const size_t data_len)
 {
-	using uavcan::equipment::gnss::RTCMStream;
+	using ardupilot::gnss::MovingBaselineData;
 
 	perf_count(_rtcm_perf);
 
-	RTCMStream msg;
-	msg.protocol_id = RTCMStream::PROTOCOL_ID_RTCM3;
+	MovingBaselineData msg;
 
 	const size_t capacity = msg.data.capacity();
 	size_t written = 0;

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -53,7 +53,7 @@
 #include <uavcan/equipment/gnss/Auxiliary.hpp>
 #include <uavcan/equipment/gnss/Fix.hpp>
 #include <uavcan/equipment/gnss/Fix2.hpp>
-#include <uavcan/equipment/gnss/RTCMStream.hpp>
+#include <ardupilot/gnss/MovingBaselineData.hpp>
 
 #include <lib/perf/perf_counter.h>
 
@@ -87,7 +87,9 @@ private:
 	void process_fixx(const uavcan::ReceivedDataStructure<FixType> &msg,
 			  uint8_t fix_type,
 			  const float (&pos_cov)[9], const float (&vel_cov)[9],
-			  const bool valid_pos_cov, const bool valid_vel_cov);
+			  const bool valid_pos_cov, const bool valid_vel_cov,
+			  const float heading, const float heading_offset,
+			  const float heading_accuracy);
 
 	void handleInjectDataTopic();
 	bool injectData(const uint8_t *data, size_t data_len);
@@ -113,7 +115,7 @@ private:
 	uavcan::Subscriber<uavcan::equipment::gnss::Auxiliary, AuxiliaryCbBinder> _sub_auxiliary;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix, FixCbBinder> _sub_fix;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix2, Fix2CbBinder> _sub_fix2;
-	uavcan::Publisher<uavcan::equipment::gnss::RTCMStream> _pub_rtcm;
+	uavcan::Publisher<ardupilot::gnss::MovingBaselineData> _pub_rtcm;
 
 	uint64_t	_last_gnss_auxiliary_timestamp{0};
 	float		_last_gnss_auxiliary_hdop{0.0f};

--- a/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
+++ b/src/drivers/uavcannode/Publishers/BatteryInfo.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(uavcan::equipment::power::BatteryInfo::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(battery_status)),
 		uavcan::Publisher<uavcan::equipment::power::BatteryInfo>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::MiddleLower);
+	}
 
 	void PrintInfo() override
 	{

--- a/src/drivers/uavcannode/Publishers/FlowMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/FlowMeasurement.hpp
@@ -63,6 +63,8 @@ public:
 		if (param_get(rot, &val) == PX4_OK) {
 			_rotation = get_rot_matrix((enum Rotation)val);
 		}
+
+		this->setPriority(uavcan::TransferPriority::Default);
 	}
 
 	void PrintInfo() override

--- a/src/drivers/uavcannode/Publishers/GnssFix2.hpp
+++ b/src/drivers/uavcannode/Publishers/GnssFix2.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(uavcan::equipment::gnss::Fix2::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(sensor_gps)),
 		uavcan::Publisher<uavcan::equipment::gnss::Fix2>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
+	}
 
 	void PrintInfo() override
 	{
@@ -117,6 +119,26 @@ public:
 			fix2.covariance.push_back(gps.s_variance_m_s);
 			fix2.covariance.push_back(gps.s_variance_m_s);
 			fix2.covariance.push_back(gps.s_variance_m_s);
+
+			uavcan::equipment::gnss::ECEFPositionVelocity ecefpositionvelocity{};
+			ecefpositionvelocity.velocity_xyz[0] = NAN;
+			ecefpositionvelocity.velocity_xyz[1] = NAN;
+			ecefpositionvelocity.velocity_xyz[2] = NAN;
+
+			// Use ecef_position_velocity for now... There is no heading field
+			if (!isnan(gps.heading)) {
+				ecefpositionvelocity.velocity_xyz[0] = gps.heading;
+
+				if (!isnan(gps.heading_offset)) {
+					ecefpositionvelocity.velocity_xyz[1] = gps.heading_offset;
+				}
+
+				if (!isnan(gps.heading_accuracy)) {
+					ecefpositionvelocity.velocity_xyz[2] = gps.heading_accuracy;
+				}
+
+				fix2.ecef_position_velocity.push_back(ecefpositionvelocity);
+			}
 
 			uavcan::Publisher<uavcan::equipment::gnss::Fix2>::broadcast(fix2);
 

--- a/src/drivers/uavcannode/Publishers/MagneticFieldStrength2.hpp
+++ b/src/drivers/uavcannode/Publishers/MagneticFieldStrength2.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(uavcan::equipment::ahrs::MagneticFieldStrength2::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(sensor_mag)),
 		uavcan::Publisher<uavcan::equipment::ahrs::MagneticFieldStrength2>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::Default);
+	}
 
 	void PrintInfo() override
 	{

--- a/src/drivers/uavcannode/Publishers/MovingBaselineData.hpp
+++ b/src/drivers/uavcannode/Publishers/MovingBaselineData.hpp
@@ -35,26 +35,26 @@
 
 #include "UavcanPublisherBase.hpp"
 
-#include <uavcan/equipment/air_data/StaticTemperature.hpp>
+#include <ardupilot/gnss/MovingBaselineData.hpp>
 
 #include <uORB/SubscriptionCallback.hpp>
-#include <uORB/topics/sensor_baro.h>
+#include <uORB/topics/gps_inject_data.h>
 
 namespace uavcannode
 {
 
-class StaticTemperature :
+class MovingBaselineDataPub :
 	public UavcanPublisherBase,
 	public uORB::SubscriptionCallbackWorkItem,
-	private uavcan::Publisher<uavcan::equipment::air_data::StaticTemperature>
+	private uavcan::Publisher<ardupilot::gnss::MovingBaselineData>
 {
 public:
-	StaticTemperature(px4::WorkItem *work_item, uavcan::INode &node) :
-		UavcanPublisherBase(uavcan::equipment::air_data::StaticTemperature::DefaultDataTypeID),
-		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(sensor_baro)),
-		uavcan::Publisher<uavcan::equipment::air_data::StaticTemperature>(node)
+	MovingBaselineDataPub(px4::WorkItem *work_item, uavcan::INode &node) :
+		UavcanPublisherBase(ardupilot::gnss::MovingBaselineData::DefaultDataTypeID),
+		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(gps_inject_data)),
+		uavcan::Publisher<ardupilot::gnss::MovingBaselineData>(node)
 	{
-		this->setPriority(uavcan::TransferPriority::MiddleLower);
+		this->setPriority(uavcan::TransferPriority::NumericallyMax);
 	}
 
 	void PrintInfo() override
@@ -62,28 +62,48 @@ public:
 		if (uORB::SubscriptionCallbackWorkItem::advertised()) {
 			printf("\t%s -> %s:%d\n",
 			       uORB::SubscriptionCallbackWorkItem::get_topic()->o_name,
-			       uavcan::equipment::air_data::StaticTemperature::getDataTypeFullName(),
-			       uavcan::equipment::air_data::StaticTemperature::DefaultDataTypeID);
+			       ardupilot::gnss::MovingBaselineData::getDataTypeFullName(),
+			       id());
 		}
 	}
 
 	void BroadcastAnyUpdates() override
 	{
-		// sensor_baro -> uavcan::equipment::air_data::StaticTemperature
-		sensor_baro_s baro;
+		using ardupilot::gnss::MovingBaselineData;
 
-		if ((hrt_elapsed_time(&_last_static_temperature_publish) > 1_s) && uORB::SubscriptionCallbackWorkItem::update(&baro)) {
-			uavcan::equipment::air_data::StaticTemperature static_temperature{};
-			static_temperature.static_temperature = baro.temperature + CONSTANTS_ABSOLUTE_NULL_CELSIUS;
-			uavcan::Publisher<uavcan::equipment::air_data::StaticTemperature>::broadcast(static_temperature);
+		// gps_inject_data -> ardupilot::gnss::MovingBaselineData
+		gps_inject_data_s inject_data;
 
-			// ensure callback is registered
-			uORB::SubscriptionCallbackWorkItem::registerCallback();
+		if (uORB::SubscriptionCallbackWorkItem::update(&inject_data)) {
+			// Prevent republishing rtcm data we received from uavcan
+			if (inject_data.device_id > uavcan::NodeID::Max) {
+				ardupilot::gnss::MovingBaselineData movingbaselinedata{};
 
-			_last_static_temperature_publish = hrt_absolute_time();
+				const size_t capacity = movingbaselinedata.data.capacity();
+				size_t written = 0;
+				int result = 0;
+
+				while ((result >= 0) && written < inject_data.len) {
+					size_t chunk_size = inject_data.len - written;
+
+					if (chunk_size > capacity) {
+						chunk_size = capacity;
+					}
+
+					for (size_t i = 0; i < chunk_size; ++i) {
+						movingbaselinedata.data.push_back(inject_data.data[written]);
+						written += 1;
+					}
+
+					result = uavcan::Publisher<ardupilot::gnss::MovingBaselineData>::broadcast(movingbaselinedata);
+
+					// ensure callback is registered
+					uORB::SubscriptionCallbackWorkItem::registerCallback();
+
+					movingbaselinedata.data.clear();
+				}
+			}
 		}
 	}
-private:
-	hrt_abstime _last_static_temperature_publish{0};
 };
 } // namespace uavcannode

--- a/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(uavcan::equipment::range_sensor::Measurement::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(distance_sensor), instance),
 		uavcan::Publisher<uavcan::equipment::range_sensor::Measurement>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::Default);
+	}
 
 	void PrintInfo() override
 	{

--- a/src/drivers/uavcannode/Publishers/RawAirData.hpp
+++ b/src/drivers/uavcannode/Publishers/RawAirData.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(uavcan::equipment::air_data::RawAirData::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(differential_pressure)),
 		uavcan::Publisher<uavcan::equipment::air_data::RawAirData>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::Default);
+	}
 
 	void PrintInfo() override
 	{

--- a/src/drivers/uavcannode/Publishers/SafetyButton.hpp
+++ b/src/drivers/uavcannode/Publishers/SafetyButton.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(ardupilot::indication::Button::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(safety)),
 		uavcan::Publisher<ardupilot::indication::Button>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::Default);
+	}
 
 	void PrintInfo() override
 	{

--- a/src/drivers/uavcannode/Publishers/StaticPressure.hpp
+++ b/src/drivers/uavcannode/Publishers/StaticPressure.hpp
@@ -53,7 +53,9 @@ public:
 		UavcanPublisherBase(uavcan::equipment::air_data::StaticPressure::DefaultDataTypeID),
 		uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(sensor_baro)),
 		uavcan::Publisher<uavcan::equipment::air_data::StaticPressure>(node)
-	{}
+	{
+		this->setPriority(uavcan::TransferPriority::Default);
+	}
 
 	void PrintInfo() override
 	{

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -46,13 +46,14 @@
 #include "Publishers/MagneticFieldStrength2.hpp"
 #include "Publishers/RangeSensorMeasurement.hpp"
 #include "Publishers/RawAirData.hpp"
+#include "Publishers/MovingBaselineData.hpp"
 #include "Publishers/SafetyButton.hpp"
 #include "Publishers/StaticPressure.hpp"
 #include "Publishers/StaticTemperature.hpp"
 
 #include "Subscribers/BeepCommand.hpp"
 #include "Subscribers/LightsCommand.hpp"
-#include "Subscribers/RTCMStream.hpp"
+#include "Subscribers/MovingBaselineData.hpp"
 
 using namespace time_literals;
 
@@ -303,13 +304,14 @@ int UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events
 	_publisher_list.add(new MagneticFieldStrength2(this, _node));
 	_publisher_list.add(new RangeSensorMeasurement(this, _node));
 	_publisher_list.add(new RawAirData(this, _node));
+	_publisher_list.add(new MovingBaselineDataPub(this, _node));
 	_publisher_list.add(new SafetyButton(this, _node));
 	_publisher_list.add(new StaticPressure(this, _node));
 	_publisher_list.add(new StaticTemperature(this, _node));
 
 	_subscriber_list.add(new BeepCommand(_node));
 	_subscriber_list.add(new LightsCommand(_node));
-	_subscriber_list.add(new RTCMStream(_node));
+	_subscriber_list.add(new MovingBaselineData(_node));
 
 	for (auto &subscriber : _subscriber_list) {
 		subscriber->init();

--- a/src/modules/mavlink/streams/GPS2_RAW.hpp
+++ b/src/modules/mavlink/streams/GPS2_RAW.hpp
@@ -90,7 +90,11 @@ private:
 					msg.yaw = 36000; // Use 36000 for north.
 
 				} else {
-					msg.yaw = math::degrees(gps.heading) * 100.f; // centidegrees
+					msg.yaw = math::degrees(matrix::wrap_2pi(gps.heading)) * 100.0f; // centidegrees
+				}
+
+				if (PX4_ISFINITE(gps.heading_accuracy)) {
+					msg.hdg_acc = math::degrees(gps.heading_accuracy) * 1e5f; // Heading / track uncertainty in degE5
 				}
 			}
 

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -85,14 +85,17 @@ private:
 			msg.h_acc = gps.eph * 1e3f;              // position uncertainty in mm
 			msg.v_acc = gps.epv * 1e3f;              // altitude uncertainty in mm
 			msg.vel_acc = gps.s_variance_m_s * 1e3f; // speed uncertainty in mm
-			msg.hdg_acc = math::degrees(gps.c_variance_rad) * 1e5f; // Heading / track uncertainty in degE5
 
 			if (PX4_ISFINITE(gps.heading)) {
 				if (fabsf(gps.heading) < FLT_EPSILON) {
 					msg.yaw = 36000; // Use 36000 for north.
 
 				} else {
-					msg.yaw = math::degrees(gps.heading) * 100.f; // centidegrees
+					msg.yaw = math::degrees(matrix::wrap_2pi(gps.heading)) * 100.0f; // centidegrees
+				}
+
+				if (PX4_ISFINITE(gps.heading_accuracy)) {
+					msg.hdg_acc = math::degrees(gps.heading_accuracy) * 1e5f; // Heading / track uncertainty in degE5
 				}
 			}
 


### PR DESCRIPTION
This PR adds moving baseline functionality on the ARK RTK GPS using the U-Blox F9P.

Requires https://github.com/PX4/PX4-GPSDrivers/pull/91

![PXL_20211011_203619308](https://user-images.githubusercontent.com/2019539/136866899-fd0fe3bf-4e76-4f65-a582-ec100dfe4286.jpg)
