### PR TITLE
Support orbit commands in fw mode

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -42,7 +42,7 @@
 #pragma once
 
 #include "FlightTaskManualAltitudeSmoothVel.hpp"
-#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/orbit_status.h>
 #include "StraightLine.hpp"
 #include <lib/slew_rate/SlewRateYaw.hpp>
@@ -114,7 +114,7 @@ private:
 	float _initial_heading = 0.f; /**< the heading of the drone when the orbit command was issued */
 	SlewRateYaw<float> _slew_rate_yaw;
 
-	uORB::Publication<orbit_status_s> _orbit_status_pub{ORB_ID(orbit_status)};
+	uORB::PublicationMulti<orbit_status_s> _orbit_status_pub{ORB_ID(orbit_status)};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise, /**< cruise speed for circle approach */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -67,6 +67,7 @@
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/px4_work_queue/WorkItem.hpp>
 #include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/airspeed_validated.h>
@@ -87,6 +88,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/orbit_status.h>
 #include <uORB/uORB.h>
 #include <vtol_att_control/vtol_type.h>
 
@@ -156,6 +158,7 @@ private:
 	uORB::Publication<position_controller_status_s>		_pos_ctrl_status_pub{ORB_ID(position_controller_status)};			///< navigation capabilities publication
 	uORB::Publication<position_controller_landing_status_s>	_pos_ctrl_landing_status_pub{ORB_ID(position_controller_landing_status)};	///< landing status publication
 	uORB::Publication<tecs_status_s>			_tecs_status_pub{ORB_ID(tecs_status)};						///< TECS status publication
+	uORB::PublicationMulti<orbit_status_s>			_orbit_status_pub{ORB_ID(orbit_status)};
 
 	manual_control_setpoint_s	_manual_control_setpoint {};			///< r/c channel data
 	position_setpoint_triplet_s	_pos_sp_triplet {};		///< triplet of mission items
@@ -348,6 +351,8 @@ private:
 	void		reset_landing_state();
 	Vector2f 	get_nav_speed_2d(const Vector2f &ground_speed);
 	void		set_control_mode_current(bool pos_sp_curr_valid);
+
+	void publishOrbitStatus(const position_setpoint_s pos_sp);
 
 	/*
 	 * Call TECS : a wrapper function to call the TECS implementation

--- a/src/modules/mavlink/streams/ORBIT_EXECUTION_STATUS.hpp
+++ b/src/modules/mavlink/streams/ORBIT_EXECUTION_STATUS.hpp
@@ -49,34 +49,40 @@ public:
 
 	unsigned get_size() override
 	{
-		return _orbit_status_sub.advertised() ? MAVLINK_MSG_ID_ORBIT_EXECUTION_STATUS_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+		return _orbit_status_subs.advertised() ? MAVLINK_MSG_ID_ORBIT_EXECUTION_STATUS_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
 	}
 
 private:
 	explicit MavlinkStreamOrbitStatus(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
-	uORB::Subscription _orbit_status_sub{ORB_ID(orbit_status)};
+	uORB::SubscriptionMultiArray<orbit_status_s> _orbit_status_subs{ORB_ID::orbit_status};
 
 	bool send() override
 	{
 		orbit_status_s orbit_status;
+		bool updated = false;
 
-		if (_orbit_status_sub.update(&orbit_status)) {
-			mavlink_orbit_execution_status_t msg{};
+		for (auto &orbit_sub : _orbit_status_subs) {
 
-			msg.time_usec = orbit_status.timestamp;
-			msg.radius = orbit_status.radius;
-			msg.frame = orbit_status.frame;
-			msg.x = orbit_status.x * 1e7;
-			msg.y = orbit_status.y * 1e7;
-			msg.z = orbit_status.z;
+			if (orbit_sub.update(&orbit_status)) {
+				updated = true;
+				mavlink_orbit_execution_status_t msg_orbit_execution_status{};
 
-			mavlink_msg_orbit_execution_status_send_struct(_mavlink->get_channel(), &msg);
+				msg_orbit_execution_status.time_usec = orbit_status.timestamp;
+				msg_orbit_execution_status.radius = orbit_status.radius;
+				msg_orbit_execution_status.frame = orbit_status.frame;
+				msg_orbit_execution_status.x = orbit_status.x * 1e7;
+				msg_orbit_execution_status.y = orbit_status.y * 1e7;
+				msg_orbit_execution_status.z = orbit_status.z;
 
-			return true;
+				mavlink_msg_orbit_execution_status_send_struct(_mavlink->get_channel(), &msg_orbit_execution_status);
+
+				// only one subscription should ever be active at any time, so we can exit here
+				break;
+			}
 		}
 
-		return false;
+		return updated;
 	}
 };
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -441,4 +441,6 @@ private:
 	void		publish_mission_result();
 
 	void		publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
+
+	bool 		geofence_allows_position(const vehicle_global_position_s &pos);
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
For multirotors QGC allows to send orbit commands to the vehicle where the user can adjust radius, position and altitude.
For fixed wing vehicles we can only use GOTO commands where loiter radius and loiter direction are fixed.

**Describe your solution**
Support orbit command also for fixed wing vehicles.

**Additional context**
This needs the corresponding changes on QGC.
Additionally, this PR make the flight controller publish orbit_status messages as soon as the internal position setpoint type is of type LOITER. This can be used by the ground station to visualize the intent of the vehicle.
![orbit_fw_1](https://user-images.githubusercontent.com/7610489/136978367-e7725bfb-3992-4ed6-94e4-575888acc452.png)



![orbit_fw_2](https://user-images.githubusercontent.com/7610489/136978385-49e7d22a-975f-4199-9d4a-c06193bb4167.png)

