### PR TITLE
Functions: fix corner case x_low == x_high == value resulting in NAN

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -140,7 +140,7 @@ const T expo_deadzone(const T &value, const T &e, const T &dz)
 template<typename T>
 const T gradual(const T &value, const T &x_low, const T &x_high, const T &y_low, const T &y_high)
 {
-	if (value < x_low) {
+	if (value <= x_low) {
 		return y_low;
 
 	} else if (value > x_high) {

--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -150,6 +150,12 @@ TEST(FunctionsTest, gradual)
 	EXPECT_FLOAT_EQ(gradual(1.75f, 1.f, 2.f, 4.f, 6.f), 5.5f);
 	EXPECT_FLOAT_EQ(gradual(2.f, 1.f, 2.f, 4.f, 6.f), 6.f);
 	EXPECT_FLOAT_EQ(gradual(12.f, 1.f, 2.f, 4.f, 6.f), 6.f);
+
+	// corner case when x_low == x_high == value
+	EXPECT_FLOAT_EQ(gradual(1.f, 1.f, 1.f, 4.f, 6.f), 4.f);
+
+	// corner case when x_low > x_high
+	EXPECT_FLOAT_EQ(gradual(1.05f, 1.1f, 1.f, 4.f, 6.f), 4.f);
 }
 
 TEST(FunctionsTest, gradual3)


### PR DESCRIPTION
**Describe problem solved by this pull request**
There was a rare corner case with a semi-sane airspeed parameters configuration on which @sfuhrer knows more details that lead to calling the `gradual()` function with upper and lower bound of the input range being the same value `x_low == x_high` and the `value` to evaluate the function at being exactly the same number. In that case it the evaluation did neither go into the above or below range case and the calculation for the linear slope of the range in between resulted in a division by zero.

**Describe your solution**
Simply checking one of the range limits with <= or >= results in always being above or below if `x_low == x_high` and hence there is no case anymore in which the denominator could end up being zero.

**Test data / coverage**
I added the unit test covering the corner case. It failed before with an output of NAN and passes now.
