### PR TITLE
Fix broadcom afbrs50 build

### DIFF
--- a/src/drivers/distance_sensor/broadcom/CMakeLists.txt
+++ b/src/drivers/distance_sensor/broadcom/CMakeLists.txt
@@ -31,4 +31,4 @@
 #
 ############################################################################
 
-#add_subdirectory(afbrs50) # not suitable for general inclusion
+add_subdirectory(afbrs50)


### PR DESCRIPTION
This PR fixes the broadcom afbrs50 build with the new kconfig system.