### PR TITLE
lib/drivers/{accelerometer,gyroscope}: ensure sane monotonically increasing timestamp_sample

### DIFF
--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -113,10 +113,11 @@ void PX4Accelerometer::update(const hrt_abstime &timestamp_sample, float x, floa
 	// Apply rotation (before scaling)
 	rotate_3f(_rotation, x, y, z);
 
-	// publish
 	sensor_accel_s report;
 
-	report.timestamp_sample = timestamp_sample;
+	// ensure monotonically increasing timestamp_sample within reasonable range
+	report.timestamp_sample = math::constrain(timestamp_sample, _timestamp_prev, hrt_absolute_time());
+
 	report.device_id = _device_id;
 	report.temperature = _temperature;
 	report.error_count = _error_count;
@@ -130,10 +131,15 @@ void PX4Accelerometer::update(const hrt_abstime &timestamp_sample, float x, floa
 	report.timestamp = hrt_absolute_time();
 
 	_sensor_pub.publish(report);
+
+	_timestamp_prev = report.timestamp;
 }
 
 void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 {
+	// ensure monotonically increasing timestamp_sample within reasonable range
+	sample.timestamp_sample = math::constrain(sample.timestamp_sample, _timestamp_prev, hrt_absolute_time());
+
 	// rotate all raw samples and publish fifo
 	const uint8_t N = sample.samples;
 
@@ -145,6 +151,8 @@ void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 	sample.scale = _scale;
 	sample.timestamp = hrt_absolute_time();
 	_sensor_fifo_pub.publish(sample);
+
+	_timestamp_prev = sample.timestamp;
 
 
 	// publish

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -70,6 +70,8 @@ private:
 	uORB::PublicationMulti<sensor_accel_s> _sensor_pub{ORB_ID(sensor_accel)};
 	uORB::PublicationMulti<sensor_accel_fifo_s>  _sensor_fifo_pub{ORB_ID(sensor_accel_fifo)};
 
+	hrt_abstime _timestamp_prev{0};
+
 	uint32_t		_device_id{0};
 	const enum Rotation	_rotation;
 

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -1,4 +1,3 @@
-
 /****************************************************************************
  *
  *   Copyright (c) 2018-2021 PX4 Development Team. All rights reserved.
@@ -67,6 +66,8 @@ public:
 private:
 	uORB::PublicationMulti<sensor_gyro_s> _sensor_pub{ORB_ID(sensor_gyro)};
 	uORB::PublicationMulti<sensor_gyro_fifo_s>  _sensor_fifo_pub{ORB_ID(sensor_gyro_fifo)};
+
+	hrt_abstime _timestamp_prev{0};
 
 	uint32_t		_device_id{0};
 	const enum Rotation	_rotation;


### PR DESCRIPTION
The timestamp_sample in raw IMU data is critical for calculating sensor rates, filtering, etc and every driver and driver source (eg mavlink, UAVCAN, etc) is free to populate it however they choose. 

This PR adds a basic sanity check and protection that the timestamp_sample is monotonically increasing sample to sample and that it never exceeds the publication timestamp.