### PR TITLE
drivers/imu/invensense: adjust icm20602/icm20649/icm20948 rescheduling logic

### DIFF
--- a/src/drivers/imu/invensense/icm20602/ICM20602.cpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.cpp
@@ -277,12 +277,19 @@ void ICM20602::RunImpl()
 						timestamp_sample -= extra_samples * static_cast<int>(FIFO_SAMPLE_DT);
 						samples = _fifo_gyro_samples;
 
-						ScheduleOnInterval(_fifo_empty_interval_us,
-								   _fifo_empty_interval_us - (extra_samples * FIFO_SAMPLE_DT));
+						if (_fifo_gyro_samples > extra_samples) {
+							// reschedule to run when a total of _fifo_gyro_samples should be available in the FIFO
+							const uint32_t reschedule_delay_us = (_fifo_gyro_samples - extra_samples) * static_cast<int>(FIFO_SAMPLE_DT);
+							ScheduleOnInterval(_fifo_empty_interval_us, reschedule_delay_us);
+
+						} else {
+							// otherwise reschedule to run immediately
+							ScheduleOnInterval(_fifo_empty_interval_us);
+						}
 
 					} else if (samples < _fifo_gyro_samples) {
 						// reschedule next cycle to catch the desired number of samples
-						ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * FIFO_SAMPLE_DT);
+						ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * static_cast<int>(FIFO_SAMPLE_DT));
 					}
 				}
 			}

--- a/src/drivers/imu/invensense/icm20649/ICM20649.cpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.cpp
@@ -232,12 +232,19 @@ void ICM20649::RunImpl()
 					timestamp_sample -= extra_samples * static_cast<int>(FIFO_SAMPLE_DT);
 					samples = _fifo_gyro_samples;
 
-					ScheduleOnInterval(_fifo_empty_interval_us,
-							   _fifo_empty_interval_us - (extra_samples * FIFO_SAMPLE_DT));
+					if (_fifo_gyro_samples > extra_samples) {
+						// reschedule to run when a total of _fifo_gyro_samples should be available in the FIFO
+						const uint32_t reschedule_delay_us = (_fifo_gyro_samples - extra_samples) * static_cast<int>(FIFO_SAMPLE_DT);
+						ScheduleOnInterval(_fifo_empty_interval_us, reschedule_delay_us);
+
+					} else {
+						// otherwise reschedule to run immediately
+						ScheduleOnInterval(_fifo_empty_interval_us);
+					}
 
 				} else if (samples < _fifo_gyro_samples) {
 					// reschedule next cycle to catch the desired number of samples
-					ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * FIFO_SAMPLE_DT);
+					ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * static_cast<int>(FIFO_SAMPLE_DT));
 				}
 
 				if (samples == _fifo_gyro_samples) {

--- a/src/drivers/imu/invensense/icm20948/ICM20948.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.cpp
@@ -268,12 +268,19 @@ void ICM20948::RunImpl()
 					timestamp_sample -= extra_samples * static_cast<int>(FIFO_SAMPLE_DT);
 					samples = _fifo_gyro_samples;
 
-					ScheduleOnInterval(_fifo_empty_interval_us,
-							   _fifo_empty_interval_us - (extra_samples * FIFO_SAMPLE_DT));
+					if (_fifo_gyro_samples > extra_samples) {
+						// reschedule to run when a total of _fifo_gyro_samples should be available in the FIFO
+						const uint32_t reschedule_delay_us = (_fifo_gyro_samples - extra_samples) * static_cast<int>(FIFO_SAMPLE_DT);
+						ScheduleOnInterval(_fifo_empty_interval_us, reschedule_delay_us);
+
+					} else {
+						// otherwise reschedule to run immediately
+						ScheduleOnInterval(_fifo_empty_interval_us);
+					}
 
 				} else if (samples < _fifo_gyro_samples) {
 					// reschedule next cycle to catch the desired number of samples
-					ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * FIFO_SAMPLE_DT);
+					ScheduleOnInterval(_fifo_empty_interval_us, (_fifo_gyro_samples - samples) * static_cast<int>(FIFO_SAMPLE_DT));
 				}
 
 				if (samples == _fifo_gyro_samples) {


### PR DESCRIPTION
 - this handles the case where the driver might be more than one full transfer cycle behind (extra samples > _fifo_gyro_samples)

