### PR TITLE
setup: fix installing in virtual env on Ubuntu

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -108,7 +108,13 @@ fi
 # Python3 dependencies
 echo
 echo "Installing PX4 Python3 dependencies"
-python3 -m pip install --user -r ${DIR}/requirements.txt
+if [ -n "$VIRTUAL_ENV" ]; then
+	# virtual envrionments don't allow --user option
+	python -m pip install -r ${DIR}/requirements.txt
+else
+	# older versions of Ubuntu require --user option
+	python3 -m pip install --user -r ${DIR}/requirements.txt
+fi
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then


### PR DESCRIPTION
This fixes running the Ubuntu setup script in a Python virtual environment. This was failing because `pip` doesn't allow the `--user` option in virtual environments.
