### PR TITLE
ekf2: EKF vehicle_at_rest always require some rotation in addition to vibration metrics

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -87,9 +87,8 @@ bool EstimatorInterface::checkIfVehicleAtRest(float dt, const imuSample &imu)
 {
 	// detect if the vehicle is not moving when on ground
 	if (!_control_status.flags.in_air) {
-		if ((_vibe_metrics(1) * 4.0E4f > _params.is_moving_scaler)
-		    || (_vibe_metrics(2) * 2.1E2f > _params.is_moving_scaler)
-		    || ((imu.delta_ang.norm() / dt) > 0.05f * _params.is_moving_scaler)) {
+		if (((_vibe_metrics(1) * 4.0e4f > _params.is_moving_scaler) || (_vibe_metrics(2) * 2.1e2f > _params.is_moving_scaler))
+		    && ((imu.delta_ang.norm() / dt) > 0.05f * _params.is_moving_scaler)) {
 
 			_time_last_move_detect_us = imu.time_us;
 		}


### PR DESCRIPTION
On some IMUs like the Bosch BMI055 on px4_fmu-v5 the gyro is sufficiently noisy that the EKF never considers the vehicle to be at rest.

#### Example px4_fmu-v5 vibration metrics (vehicle_imu_status)
 - icm20602: gyro_vibration_metric: 0.001543
 - icm20689: gyro_vibration_metric: 0.001672
 - bmi055:     gyro_vibration_metric: 0.009696

#### Corresponding ekf2 vibration metrics (estimator_status)
 - icm20602: vibe: [0.000000, 0.000007, 0.000094]
 - icm20689: vibe: [0.000000, 0.000008, 0.000135]
 - bmi055:    vibe: [0.000000, 0.000043, 0.000196]


Rather than adjusting the thresholds I updated the existing logic to require that either the accel or gyro vibration metrics exceed a certain threshold AND there is a small amount of rotation.

This now reliably detects vehicle at rest across all 3 IMUs and it's still extremely sensitive (triggers if you even touch the vehicle).

Is this an acceptable solution?


