### PR TITLE
drivers/imu: remove timestamp_sample adjustments

### DIFF
--- a/src/drivers/imu/invensense/icm20602/ICM20602.cpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.cpp
@@ -274,7 +274,6 @@ void ICM20602::RunImpl()
 					if (samples > _fifo_gyro_samples) {
 						// grab desired number of samples, but reschedule next cycle sooner
 						int extra_samples = samples - _fifo_gyro_samples;
-						timestamp_sample -= extra_samples * static_cast<int>(FIFO_SAMPLE_DT);
 						samples = _fifo_gyro_samples;
 
 						if (_fifo_gyro_samples > extra_samples) {

--- a/src/drivers/imu/invensense/icm20649/ICM20649.cpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.cpp
@@ -229,7 +229,6 @@ void ICM20649::RunImpl()
 				if (samples > _fifo_gyro_samples) {
 					// grab desired number of samples, but reschedule next cycle sooner
 					int extra_samples = samples - _fifo_gyro_samples;
-					timestamp_sample -= extra_samples * static_cast<int>(FIFO_SAMPLE_DT);
 					samples = _fifo_gyro_samples;
 
 					if (_fifo_gyro_samples > extra_samples) {

--- a/src/drivers/imu/invensense/icm20948/ICM20948.cpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.cpp
@@ -265,7 +265,6 @@ void ICM20948::RunImpl()
 				if (samples > _fifo_gyro_samples) {
 					// grab desired number of samples, but reschedule next cycle sooner
 					int extra_samples = samples - _fifo_gyro_samples;
-					timestamp_sample -= extra_samples * static_cast<int>(FIFO_SAMPLE_DT);
 					samples = _fifo_gyro_samples;
 
 					if (_fifo_gyro_samples > extra_samples) {


### PR DESCRIPTION
This IMU driver timestamp_sample adjustments were well intentioned to improve the downstream rate calculations in the case of minor scheduling jitter that's unavoidable on some boards with a congested bus, but I don't think it's worth the risk. There are still edge cases when running at high rate without data ready interrupts that can result in the timestamp_sample not monotonically increasing.

