### PR TITLE
Add configurable RTPS rate parameter

### DIFF
--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -122,7 +122,17 @@ static int parse_options(int argc, char *argv[])
 				break;
 			}
 
-		case 'm': _options.datarate        = strtoul(myoptarg, nullptr, 10);    break;
+		case 'm': {
+				int datarate = 0;
+
+				if (px4_get_parameter_value(myoptarg, datarate) != 0) {
+					PX4_ERR("datarate parsing failed");
+				}
+
+				_options.datarate = datarate;
+
+				break;
+			}
 
 		case 'p': _options.poll_ms         = strtoul(myoptarg, nullptr, 10);    break;
 

--- a/src/modules/micrortps_bridge/micrortps_client/module.yaml
+++ b/src/modules/micrortps_bridge/micrortps_client/module.yaml
@@ -3,15 +3,36 @@ serial_config:
     - command: |
         protocol_splitter start ${SERIAL_DEV}
         mavlink start -d /dev/mavlink -b p:${BAUD_PARAM} -m onboard -r 5000 -x
-        micrortps_client start -d /dev/rtps -b p:${BAUD_PARAM} -l -1
+        micrortps_client start -d /dev/rtps -b p:${BAUD_PARAM} -m p:RTPS_RATE -l -1
       port_config_param:
         name: RTPS_MAV_CONFIG
         group: RTPS
       label: MAVLink + FastRTPS
     - command: |
-        micrortps_client start -d ${SERIAL_DEV} -b p:${BAUD_PARAM} -l -1
+        micrortps_client start -d ${SERIAL_DEV} -b p:${BAUD_PARAM} -m p:RTPS_RATE -l -1
       port_config_param:
         name: RTPS_CONFIG
         group: RTPS
       label: FastRTPS
+
+parameters:
+    - group: RTPS
+      definitions:
+        RTPS_RATE: 
+            description:
+                short: Maximum RTPS data rate
+                long: |
+                    Configure the maximum sending rate for the RTPS streams in Bytes/sec.
+                    If the configured streams exceed the maximum rate, the sending rate of
+                    each stream is automatically decreased.
+
+                    0 is unlimited. Note this can cause reliability issues
+                    if enough RTPS topics are selected that exceed the
+                    serial bus limit.
+
+            type: int32
+            min: 0
+            unit: B/s
+            reboot_required: true
+            default: 0
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
It doesn't take too many RTPS topics to exceed the bandwidth of a serial connection. In my case RTPS data was using >70 KB/s on a 921600 baud connection, and the connected computer could not reliably establish an RTPS connection.

**Describe your solution**
This parameter allows an easy way for users to specify the appropriate data rate. It defaults to unlimited data.

**Test data / coverage**
After configuring RTPS, I verified that `micrortps_client status` correctly reports back the transmit limit.
