### PR TITLE
remove proto for unused function limit_thrust_during_landing()

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -108,8 +108,6 @@ private:
 
 	hrt_abstime	_time_stamp_last_loop{0};		/**< time stamp of last loop iteration */
 
-	int _task_failure_count{0};         /**< counter for task failures */
-
 	vehicle_local_position_setpoint_s _setpoint {};
 	vehicle_control_mode_s _vehicle_control_mode {};
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
seems that this function prototype is unused. 
Is there reason for it? or just leftover?