### PR TITLE
Prepare for Android NDK build

### DIFF
--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -33,7 +33,7 @@ add_executable(px4
 target_link_libraries(px4
 	PRIVATE
 		${module_libraries}
-		pthread m
+		m
 
 		# horrible circular dependencies that need to be teased apart
 		px4_layer px4_platform
@@ -41,8 +41,12 @@ target_link_libraries(px4
 		parameters
 )
 
-if(NOT APPLE)
+if((NOT APPLE) AND (NOT ANDROID))
 	target_link_libraries(px4 PRIVATE rt)
+endif()
+
+if(NOT ANDROID)
+	target_link_libraries(px4 PRIVATE pthread)
 endif()
 
 target_link_libraries(px4 PRIVATE uORB)


### PR DESCRIPTION
Modify CMakeList.txt prepare for Android NDK build

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
Errors when build the project with Android NDK
```
ld: error: unable to find library -lpthread                                                                                                                                                                                                   
ld: error: unable to find library -lrt                                                                                                                                                                                                        
```

**Describe your solution**
libpthread and librt is not necessary when build with NDK
