### PR TITLE
rcS: Allow airframe configuration autostart to be on SD-Card

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.autostart_ext
+++ b/ROMFS/px4fmu_common/init.d/rc.autostart_ext
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# External airframe startup script (on SD card)
+#
+set SDCARD_MIXERS_PATH ${SDCARD_EXT_PATH}/mixers
+
+if [ -e ${SDCARD_EXT_PATH}/rc.autostart ]
+then
+	. ${SDCARD_EXT_PATH}/rc.autostart
+else
+	echo "Error: ${SDCARD_EXT_PATH}/rc.autostart does not exist"
+fi

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -44,6 +44,8 @@ set PWM_EXTRA_OUT none
 set PWM_EXTRA_RATE p:PWM_EXTRA_RATE
 set EXTRA_MIXER_MODE none
 set RC_INPUT_ARGS ""
+set SDCARD_AVAILABLE no
+set SDCARD_EXT_PATH /fs/microsd/ext_autostart
 set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
 set STARTUP_TUNE 1
 set USE_IO no
@@ -57,7 +59,6 @@ ver all
 #
 # Try to mount the microSD card.
 #
-set SDCARD_AVAILABLE no
 # REBOOTWORK this needs to start after the flight control loop.
 if mount -t vfat /dev/mmcsd0 /fs/microsd
 then
@@ -105,7 +106,6 @@ then
 		fi
 	fi
 fi
-unset SDCARD_AVAILABLE
 
 #
 # Look for an init script on the microSD card.
@@ -216,10 +216,22 @@ else
 	#
 	# Set parameters and env variables for selected AUTOSTART.
 	#
+	set AUTOSTART_PATH etc/init.d/rc.autostart
 	if ! param compare SYS_AUTOSTART 0
 	then
-		. ${R}etc/init.d/rc.autostart
+		if param greater SYS_AUTOSTART 1000000
+		then
+			# Use external startup file
+			if [ $SDCARD_AVAILABLE = yes ]
+			then
+				set AUTOSTART_PATH etc/init.d/rc.autostart_ext
+			else
+				echo "ERROR [init] SD card not mounted - trying to load airframe from ROMFS"
+			fi
+		fi
+		. ${R}$AUTOSTART_PATH
 	fi
+	unset AUTOSTART_PATH
 
 	#
 	# Override parameters from user configuration file.
@@ -539,6 +551,8 @@ unset PWM_OUT
 unset PWM_EXTRA_OUT
 unset PWM_EXTRA_RATE
 unset RC_INPUT_ARGS
+unset SDCARD_AVAILABLE
+unset SDCARD_EXT_PATH
 unset SDCARD_MIXERS_PATH
 unset STARTUP_TUNE
 unset USE_IO


### PR DESCRIPTION
This PR adds the possibility to put the airframe configuration files onto the SD-card instead of having them in the ROMFS. Only enabled for param `SYS_AUTOSTART > 1000000`. 

**Describe problem solved by this pull request**
This allows separating the airframe configuration from the build / flashing. Firmware can be flashed, airframe configuration can then later be uploaded onto the SD-card.

**Describe your solution**
For `SYS_AUTOSTART > 1000000`, the startup script checks if an SD-card is available, if so, it tries to run `rc.autostart` from the SD-card.

**Test data / coverage**
Tested on skynode
