### PR TITLE
L1: improve loiter joining logic

### DIFF
--- a/src/lib/l1/ECL_L1_Pos_Controller.cpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -276,7 +276,9 @@ ECL_L1_Pos_Controller::navigate_loiter(const Vector2d &vector_A, const Vector2d 
 	float tangent_vel = xtrack_vel_center * loiter_direction;
 
 	/* prevent PD output from turning the wrong way when in circle mode */
-	if (tangent_vel < 0.0f && _circle_mode) {
+	const float l1_op_tan_vel = 2.f; // hard coded max tangential velocity in the opposite direction
+
+	if (tangent_vel < -l1_op_tan_vel && _circle_mode) {
 		lateral_accel_sp_circle_pd = math::max(lateral_accel_sp_circle_pd, 0.0f);
 	}
 


### PR DESCRIPTION

This PR takes up https://github.com/PX4/PX4-Autopilot/pull/15847 again. The change we made there wasn't sufficient (though it helped in some cases I guess). We still had it often that the vehicle first flew through the loiter center before entering the loiter. 
It also can lead to big loiter overshoots in high winds, when the vehicle first passes through the center and then turns downwind.
![image](https://user-images.githubusercontent.com/26798987/116593842-d48da680-a921-11eb-87f6-01f117c6539f.png)



**Describe problem solved by this pull request**
There is logic in L1 that prevents the vehicle from trying to achieve an impossible loiter entry (e.g. due to wind). That check makes the vehicle track the loiter center if the tangential velocity is in the wrong direction while loitering. After the vehicle flies through the center, it can then turn the other way around to join the loiter. This check is though too sensitive if it purely checks for the wrong direction, and it can end in delayed loiter entry for no reason. 

**Describe your solution**
This commit increases the threshold to 2m/s of tangential velocity in the wrong direction to trigger the check.


**Describe possible alternatives**
Make a parameter out of it. I had that for the last half year approximately, and was running tests with various settings. If it was smaller than 2m/s, e.g. 1m/s, then it still happened from time to time, though already much less regularly. If there is concern that having it at 2m/s can lead to controller instability we can also reduce it to e.g. 1m/s.

**Test data / coverage**
Extensively flight tested.

