### PR TITLE
px4io: allow switching to rate ctrl wq

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -708,7 +708,7 @@ void PX4IO::Run()
 		}
 	}
 
-	_mixing_output.updateSubscriptions(false, true);
+	_mixing_output.updateSubscriptions(true, true);
 
 	perf_end(_cycle_perf);
 }


### PR DESCRIPTION
No reason to run this in a separate thread at lower priority if it's keeping you in the air.


Master vs PR on px4_fmu-v5_default (SYS_AUTOSTART 4001 generic quadcopter)

#### master
``` Console
INFO  [mixer_module] Param prefix: PWM_MAIN
control latency: 2784 events, 2918925us elapsed, 1048.46us avg, min 575us max 3893us 2715.366us rms
INFO  [mixer_module] Mixer loaded: yes
INFO  [mixer_module] Driver instance: 0
```

#### PR
``` Console
INFO  [mixer_module] Param prefix: PWM_MAIN
control latency: 123540 events, 63771247us elapsed, 516.20us avg, min 385us max 1933us 102.654us rms
INFO  [mixer_module] Switched to rate_ctrl work queue
INFO  [mixer_module] Mixer loaded: yes
INFO  [mixer_module] Driver instance: 0
```