### PR TITLE
Mavlink: bump MAX_REMOTE_COMPONENTS to 16

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -253,7 +253,7 @@ private:
 
 	orb_advert_t _mavlink_log_pub{nullptr};
 
-	static constexpr unsigned MAX_REMOTE_COMPONENTS{8};
+	static constexpr unsigned MAX_REMOTE_COMPONENTS{16};
 	struct ComponentState {
 		uint32_t received_messages{0};
 		uint32_t missed_messages{0};


### PR DESCRIPTION
To avoid `[mavlink] Max remote components of 8 used up` warnings when multiple payloads and/or a mission computer with various component IDs are used. 