### PR TITLE
drivers:  Add uavcan hygrometer sensor

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -141,6 +141,7 @@ set(msg_files
 	sensor_gyro.msg
 	sensor_gyro_fft.msg
 	sensor_gyro_fifo.msg
+	sensor_hygrometer.msg
 	sensor_mag.msg
 	sensor_preflight_mag.msg
 	sensor_selection.msg

--- a/msg/sensor_hygrometer.msg
+++ b/msg/sensor_hygrometer.msg
@@ -1,0 +1,4 @@
+uint64 timestamp	# time since system start (microseconds)
+float32  temperature	# Temperature provided by sensor
+float32 humidity		# Humidity provided by sensor
+uint32 id		# ID number of a hygrometer. Should be unique and consistent for the lifetime of a vehicle. 1-indexed.

--- a/src/drivers/drv_airspeed.h
+++ b/src/drivers/drv_airspeed.h
@@ -50,6 +50,7 @@
 
 #define AIRSPEED_BASE_DEVICE_PATH "/dev/airspeed"
 #define AIRSPEED0_DEVICE_PATH	"/dev/airspeed0"
+#define AIRSPEED1_DEVICE_PATH	"/dev/airspeed1"
 
 /*
  * ioctl() definitions

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -160,6 +160,7 @@ px4_add_module(
 		sensors/gyro.cpp
 		sensors/cbat.cpp
 		sensors/ice_status.cpp
+		sensors/hygrometer.cpp
 
 	MODULE_CONFIG
 		module.yaml

--- a/src/drivers/uavcan/dsdl/cuav/equipment/hygrometer/20400.Hygrometer.uavcan
+++ b/src/drivers/uavcan/dsdl/cuav/equipment/hygrometer/20400.Hygrometer.uavcan
@@ -1,0 +1,7 @@
+#
+# support for hygrometer sensors on UAVCAN
+#
+
+float16 temperature
+float16 humidity
+uint8 id

--- a/src/drivers/uavcan/sensors/differential_pressure.hpp
+++ b/src/drivers/uavcan/sensors/differential_pressure.hpp
@@ -40,17 +40,20 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/differential_pressure.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <lib/drivers/device/device.h>
 
 #include "sensor_bridge.hpp"
 
 #include <uavcan/equipment/air_data/RawAirData.hpp>
 
-class UavcanDifferentialPressureBridge : public UavcanSensorBridgeBase
+class UavcanDifferentialPressureBridge : public UavcanSensorBridgeBase, public cdev::CDev
 {
 public:
 	static const char *const NAME;
 
 	UavcanDifferentialPressureBridge(uavcan::INode &node);
+
+	~UavcanDifferentialPressureBridge();
 
 	const char *get_name() const override { return NAME; }
 
@@ -60,6 +63,10 @@ private:
 	float _diff_pres_offset{0.f};
 
 	math::LowPassFilter2p<float> _filter{10.f, 1.1f}; /// Adapted from MS5525 driver
+
+	int _class_instance;
+
+	int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	void air_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::RawAirData> &msg);
 

--- a/src/drivers/uavcan/sensors/hygrometer.cpp
+++ b/src/drivers/uavcan/sensors/hygrometer.cpp
@@ -1,0 +1,80 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "hygrometer.hpp"
+#include <drivers/drv_hrt.h>
+#include <lib/ecl/geo/geo.h>
+#include <parameters/param.h>
+#include <systemlib/err.h>
+
+const char *const UavcanHygrometerBridge::NAME = "hygrometer_sensor";
+
+UavcanHygrometerBridge::UavcanHygrometerBridge(uavcan::INode &node) :
+	UavcanSensorBridgeBase("uavcan_hygrometer_sensor", ORB_ID(sensor_hygrometer)),
+	_sub_hygro(node)
+{
+}
+
+int UavcanHygrometerBridge::init()
+{
+
+
+	int res = _sub_hygro.start(HygroCbBinder(this, &UavcanHygrometerBridge::hygro_sub_cb));
+
+	if (res < 0) {
+		DEVICE_LOG("failed to start uavcan sub: %d", res);
+		return res;
+	}
+
+	return 0;
+}
+
+void UavcanHygrometerBridge::hygro_sub_cb(const
+		uavcan::ReceivedDataStructure<cuav::equipment::hygrometer::Hygrometer>
+		&msg)
+{
+
+
+	float humidity = msg.humidity;
+	float temperature_c = msg.temperature + CONSTANTS_ABSOLUTE_NULL_CELSIUS;
+	uint8_t id = msg.id;
+
+	sensor_hygrometer_s report = {
+		.timestamp = hrt_absolute_time(),
+		.temperature = temperature_c,
+		.humidity  = humidity,
+		.id  = id,
+	};
+
+	publish(msg.getSrcNodeID().get(), &report);
+}

--- a/src/drivers/uavcan/sensors/hygrometer.hpp
+++ b/src/drivers/uavcan/sensors/hygrometer.hpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <uORB/topics/sensor_hygrometer.h>
+#include "sensor_bridge.hpp"
+#include <cuav/equipment/hygrometer/Hygrometer.hpp>
+
+
+class UavcanHygrometerBridge : public UavcanSensorBridgeBase
+{
+public:
+	static const char *const NAME;
+
+	UavcanHygrometerBridge(uavcan::INode &node);
+
+	const char *get_name() const override { return NAME; }
+
+	int init() override;
+
+private:
+	float _temperature {0.0f};
+	float _humidity    {0.0f};
+	float _id  {0};
+
+
+	void hygro_sub_cb(const uavcan::ReceivedDataStructure<cuav::equipment::hygrometer::Hygrometer> &msg);
+
+	typedef uavcan::MethodBinder < UavcanHygrometerBridge *,
+		void (UavcanHygrometerBridge::*)
+		(const uavcan::ReceivedDataStructure<cuav::equipment::hygrometer::Hygrometer> &) >
+		HygroCbBinder;
+
+	uavcan::Subscriber<cuav::equipment::hygrometer::Hygrometer, HygroCbBinder> _sub_hygro;
+};

--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -50,6 +50,7 @@
 #include "gyro.hpp"
 #include "cbat.hpp"
 #include "ice_status.hpp"
+#include "hygrometer.hpp"
 
 /*
  * IUavcanSensorBridge
@@ -78,6 +79,7 @@ void IUavcanSensorBridge::make_all(uavcan::INode &node, List<IUavcanSensorBridge
 	list.add(new UavcanAccelBridge(node));
 	list.add(new UavcanGyroBridge(node));
 	list.add(new UavcanIceStatusBridge(node));
+	list.add(new UavcanHygrometerBridge(node));
 }
 
 /*

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -78,6 +78,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 	int diff_pres_sub = orb_subscribe(ORB_ID(differential_pressure));
 	struct differential_pressure_s diff_pres;
+	struct differential_pressure_s diff_pres_id;
 
 	float diff_pres_offset = 0.0f;
 
@@ -87,8 +88,13 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 		1.0f,
 	};
 
+	orb_copy(ORB_ID(differential_pressure), diff_pres_sub, &diff_pres_id);
+
+	const char *dev = (((diff_pres_id.device_id >> 16) & 0xFF) == DRV_DIFF_PRESS_DEVTYPE_UAVCAN) ? AIRSPEED0_DEVICE_PATH :
+			  AIRSPEED1_DEVICE_PATH;
+
 	bool paramreset_successful = false;
-	int  fd = px4_open(AIRSPEED0_DEVICE_PATH, 0);
+	int  fd = px4_open(dev, 0);
 
 	if (fd >= 0) {
 		if (PX4_OK == px4_ioctl(fd, AIRSPEEDIOCSSCALE, (long unsigned int)&airscale)) {
@@ -165,7 +171,10 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 	if (PX4_ISFINITE(diff_pres_offset)) {
 
-		int fd_scale = px4_open(AIRSPEED0_DEVICE_PATH, 0);
+		const char *dev_scale = (((diff_pres.device_id >> 16) & 0xFF) == DRV_DIFF_PRESS_DEVTYPE_UAVCAN) ?
+					AIRSPEED0_DEVICE_PATH : AIRSPEED1_DEVICE_PATH;
+
+		int fd_scale = px4_open(dev_scale, 0);
 		airscale.offset_pa = diff_pres_offset;
 
 		if (fd_scale >= 0) {

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1562,6 +1562,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("VIBRATION", 0.1f);
 		configure_stream_local("WIND_COV", 0.5f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 1.0f);
@@ -1623,6 +1624,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 10.0f);
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 10.0f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 10.0f);
@@ -1682,6 +1684,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 1.0f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 1.0f);
@@ -1710,6 +1713,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 25.0f);
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 2.0f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 		break;
 
 	case MAVLINK_MODE_MAGIC:
@@ -1768,6 +1772,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 20.0f);
 		configure_stream_local("VIBRATION", 2.5f);
 		configure_stream_local("WIND_COV", 10.0f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 50.0f);
@@ -1794,6 +1799,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("RC_CHANNELS", 0.5f);
 		configure_stream_local("SYS_STATUS", 0.1f);
 		configure_stream_local("VFR_HUD", 1.0f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("LINK_NODE_STATUS", 1.0f);
@@ -1842,6 +1848,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 1.0f);
+		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 1.0f);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -113,6 +113,7 @@
 #include "streams/VFR_HUD.hpp"
 #include "streams/VIBRATION.hpp"
 #include "streams/WIND_COV.hpp"
+#include "streams/HYGROMETER_SENSOR.hpp"
 
 #if !defined(CONSTRAINED_FLASH)
 # include "streams/ADSB_VEHICLE.hpp"
@@ -543,8 +544,11 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamRawRpm>(),
 #endif // RAW_RPM_HPP
 #if defined(EFI_STATUS_HPP)
-	create_stream_list_item<MavlinkStreamEfiStatus>()
+	create_stream_list_item<MavlinkStreamEfiStatus>(),
 #endif // EFI_STATUS_HPP
+#if defined(HYGROMETER_SENSOR_HPP)
+	create_stream_list_item<MavlinkStreamHygrometerSensor>()
+#endif // HYGROMETER_SENSOR_HPP
 };
 
 const char *get_stream_name(const uint16_t msg_id)

--- a/src/modules/mavlink/streams/HYGROMETER_SENSOR.hpp
+++ b/src/modules/mavlink/streams/HYGROMETER_SENSOR.hpp
@@ -1,0 +1,49 @@
+#ifndef HYGROMETER_SENSOR_HPP
+#define HYGROMETER_SENSOR_HPP
+
+#include <uORB/topics/sensor_hygrometer.h>
+
+class MavlinkStreamHygrometerSensor : public MavlinkStream
+{
+public:
+
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamHygrometerSensor(mavlink); }
+
+	static constexpr const char *get_name_static() { return "HYGROMETER_SENSOR"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_HYGROMETER_SENSOR; }
+
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return _hygrometer_sub.advertised() ? MAVLINK_MSG_ID_HYGROMETER_SENSOR_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+	}
+
+private:
+	explicit MavlinkStreamHygrometerSensor(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _hygrometer_sub{ORB_ID(sensor_hygrometer)};
+
+	bool send() override
+	{
+		if (_hygrometer_sub.updated()) {
+			sensor_hygrometer_s hygrometer{};
+			mavlink_hygrometer_sensor_t msg;
+			_hygrometer_sub.copy(&hygrometer);
+			msg.temperature = hygrometer.temperature;
+			msg.humidity = hygrometer.humidity;
+			msg.id = hygrometer.id;
+
+			mavlink_msg_hygrometer_sensor_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+
+#endif


### PR DESCRIPTION
The flight controller receive the hygrometer message from CAN device and flight controller send hygrometer message to the ground station.

And add calibrate function of uavcan airspeed.

background:
CUAV developed a new airspeed sensor that can be heated.The airspeed sensor heats up according to the set temperature, so as to prevent airspeed failure due to ice on the head of the airspeed sensor when the fixed-wing UAV is used in high and cold places.The temperature and humidity sensor is used to detect the temperature and humidity of the pitot tube head. If the measured temperature is lower than the set temperature, the airspeed sensor will enable heating to prevent ice.

![image](https://user-images.githubusercontent.com/69180601/138072481-dea70ce8-1460-4958-b3c1-bc95cc0be2b4.png)


![image](https://user-images.githubusercontent.com/69180601/138072506-4058cbfd-dea8-4c4d-9bdd-ff2b27313e69.png)
