### PR TITLE
Jenkins attach GDB and print back trace on failure

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -21,7 +21,7 @@ pipeline {
                 sh 'make cubepilot_cubeorange_test'
                 sh 'make cubepilot_cubeorange_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'cubepilot_cubeorange_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'cubepilot_cubeorange_test'
               }
               post {
                 always {
@@ -70,6 +70,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/cubepilot_cubeorange_test/cubepilot_cubeorange_test.elf || true'
                     resetBoard()
                 }
               }
@@ -91,7 +92,7 @@ pipeline {
                 sh 'make cuav_x7pro_test'
                 sh 'make cuav_x7pro_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'cuav_x7pro_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'cuav_x7pro_test'
               }
               post {
                 always {
@@ -138,6 +139,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/cuav_x7pro_test/cuav_x7pro_test.elf || true'
                     resetBoard()
                 }
               }
@@ -159,7 +161,7 @@ pipeline {
                 sh 'make px4_fmu-v3_test'
                 sh 'make px4_fmu-v3_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'px4_fmu-v3_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'px4_fmu-v3_test'
               }
               post {
                 always {
@@ -206,6 +208,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v3_test/px4_fmu-v3_test.elf || true'
                     resetBoard()
                 }
               }
@@ -227,7 +230,7 @@ pipeline {
                 sh 'make px4_fmu-v4_test'
                 sh 'make px4_fmu-v4_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'px4_fmu-v4_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'px4_fmu-v4_test'
               }
               post {
                 always {
@@ -273,6 +276,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v4_test/px4_fmu-v4_test.elf || true'
                     resetBoard()
                 }
               }
@@ -294,7 +298,7 @@ pipeline {
                 sh 'make px4_fmu-v4pro_test'
                 sh 'make px4_fmu-v4pro_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'px4_fmu-v4pro_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'px4_fmu-v4pro_test'
               }
               post {
                 always {
@@ -341,6 +345,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v4pro_test/px4_fmu-v4pro_test.elf || true'
                     resetBoard()
                 }
               }
@@ -362,7 +367,7 @@ pipeline {
                 sh 'make px4_fmu-v5_debug'
                 sh 'make px4_fmu-v5_debug bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'px4_fmu-v5_debug'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'px4_fmu-v5_debug'
               }
               post {
                 always {
@@ -420,6 +425,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v5_debug/px4_fmu-v5_debug.elf || true'
                     resetBoard()
                 }
               }
@@ -441,7 +447,7 @@ pipeline {
                 sh 'make px4_fmu-v5_stackcheck'
                 sh 'make px4_fmu-v5_stackcheck bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'px4_fmu-v5_stackcheck'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'px4_fmu-v5_stackcheck'
               }
               post {
                 always {
@@ -498,6 +504,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v5_stackcheck/px4_fmu-v5_stackcheck.elf || true'
                     resetBoard()
                 }
               }
@@ -519,7 +526,7 @@ pipeline {
                 sh 'make px4_fmu-v5_test'
                 sh 'make px4_fmu-v5_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'px4_fmu-v5_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'px4_fmu-v5_test'
               }
               post {
                 always {
@@ -566,79 +573,13 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v5_test/px4_fmu-v5_test.elf || true'
                     resetBoard()
                 }
               }
             } // stage test
           }
         }
-
-        // stage("modalai_fc-v1_test") {
-        //   stages {
-        //     stage("build modalai_fc-v1_test") {
-        //       agent {
-        //         docker {
-        //           image 'px4io/px4-dev-nuttx-focal:2021-09-08'
-        //           args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
-        //         }
-        //       }
-        //       steps {
-        //         checkout scm
-        //         sh 'export'
-        //         sh 'make distclean'
-        //         sh 'ccache -s'
-        //         sh 'git fetch --tags'
-        //         sh 'make modalai_fc-v1_test'
-        //         sh 'make modalai_fc-v1_test bootloader_elf'
-        //         sh 'ccache -s'
-        //         stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'modalai_fc-v1_test'
-        //       }
-        //       post {
-        //         always {
-        //             sh 'make distclean'
-        //         }
-        //       }
-        //     } // stage build
-        //     stage("hardware") {
-        //       agent {
-        //         label 'modalai_fc-v1'
-        //       }
-        //       stages {
-        //         stage("flash") {
-        //           steps {
-        //             sh 'export'
-        //             sh 'find /dev/serial'
-        //             unstash 'modalai_fc-v1_test'
-        //             sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/modalai_fc-v1_test/modalai_fc-v1_bootloader.elf'
-        //             // flash board and watch bootup
-        //             sh './platforms/nuttx/Debug/upload_jlink_gdb.sh build/modalai_fc-v1_test/modalai_fc-v1_test.elf && ./Tools/HIL/monitor_firmware_upload.py --device `find /dev/serial -name *usb-*` --baudrate 57600'
-        //           }
-        //         }
-        //         stage("tests") {
-        //           steps {
-        //             runTests()
-        //           }
-        //         }
-        //         stage("status") {
-        //           steps {
-        //             // configure
-        //             resetParameters()
-        //             sh './Tools/HIL/nsh_param_set.py --device `find /dev/serial -name *usb-*` --name "SYS_AUTOSTART" --value "4001"'    // generic quadcopter
-        //             sh './Tools/HIL/nsh_param_set.py --device `find /dev/serial -name *usb-*` --name "SYS_BL_UPDATE" --value "1"'       // update bootloader
-        //             checkStatus()
-        //             quickCalibrate()
-        //           }
-        //         }
-        //         stage("print topics") {
-        //           steps {
-        //             printTopics()
-        //           }
-        //         }
-
-        //       }
-        //     } // stage test
-        //   }
-        // }
 
         stage("nxp_fmuk66-v3_test") {
           stages {
@@ -654,7 +595,7 @@ pipeline {
                 sh 'make nxp_fmuk66-v3_test'
                 //sh 'make nxp_fmuk66-v3_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/upload_jlink_gdb.sh, Tools/HIL/*.py', name: 'nxp_fmuk66-v3_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*.py', name: 'nxp_fmuk66-v3_test'
               }
               post {
                 always {
@@ -701,6 +642,7 @@ pipeline {
               }
               post {
                 always {
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/nxp_fmuk66-v3_test/nxp_fmuk66-v3_test.elf || true'
                     resetBoard()
                 }
               }

--- a/platforms/nuttx/Debug/jlink_gdb_backtrace.sh
+++ b/platforms/nuttx/Debug/jlink_gdb_backtrace.sh
@@ -1,0 +1,41 @@
+#! /bin/sh
+
+if command -v gdb-multiarch &> /dev/null
+then
+	GDB_CMD=$(command -v gdb-multiarch)
+
+elif command -v arm-none-eabi-gdb &> /dev/null
+then
+	GDB_CMD=$(command -v arm-none-eabi-gdb)
+
+else
+	echo "gdb arm-none-eabi or multi-arch not found"
+	exit 1
+fi
+
+file ${1}
+
+gdb_cmd_file=$(mktemp)
+
+cat >"${gdb_cmd_file}" <<EOL
+
+source ${WORKSPACE}/platforms/nuttx/Debug/NuttX
+source ${WORKSPACE}/platforms/nuttx/Debug/ARMv7M
+
+target remote localhost:2331
+
+monitor regs
+
+showtasks
+
+vecstate
+
+info threads
+
+backtrace
+
+bt full
+
+EOL
+
+${GDB_CMD} -silent --nh --nx --nw -batch -x ${gdb_cmd_file} ${1}

--- a/platforms/nuttx/cmake/jlink.cmake
+++ b/platforms/nuttx/cmake/jlink.cmake
@@ -48,6 +48,18 @@ if(JLinkGDBServerCLExe_PATH)
 		USES_TERMINAL
 	)
 
+	# jlink_gdb_backtrace (attach, print current tasks, back trace, exit)
+	add_custom_target(jlink_gdb_backtrace
+		COMMAND ${PX4_BINARY_DIR}/jlink_gdb_start.sh
+		COMMAND ${CMAKE_COMMAND} -E env WORKSPACE=${PX4_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_backtrace.sh $<TARGET_FILE:px4>
+		DEPENDS
+			px4
+			${PX4_BINARY_DIR}/jlink_gdb_start.sh
+			${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_backtrace.sh
+		WORKING_DIRECTORY ${PX4_BINARY_DIR}
+		USES_TERMINAL
+	)
+
 
 	# jlink_upload_bootloader
 	#   board directory supplied bootloader.bin


### PR DESCRIPTION
This is primarily intended for the test rack, but can also be used locally if you have a single jlink connected to your system on USB.

``` Console
$ make px4_fmu-v5_default jlink_gdb_backtrace

/home/dagar/git/PX4-Autopilot/build/px4_fmu-v5_default/px4_fmu-v5_default.elf: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, with debug_info, not stripped
Loading NuttX GDB macros.  Use 'help nuttx' for more information.
Loading ARMv7M GDB macros.  Use 'help armv7m' for more information.
0x08147634 in raisebasepri (basepri=128) at NuttX/nuttx/include/arch/armv7-m/irq.h:305
305	  raisebasepri(NVIC_SYSH_DISABLE_PRIORITY);
R0 = 2000EB90, R1 = 00000001, R2 = 00000080, R3 = 00000000
R4 = 00000000, R5 = 2000EB90, R6 = 081CB798, R7 = 000000F0
R8 = 0805B33F, R9 = 000000F0, R10= 0000000A, R11= 00000000
R12= FFFFFFEC, R13= 2000E558, MSP= 2000E558, PSP= 00000000
R14(LR) = 0814BDF7, R15(PC) = 08147634
XPSR 21000000, APSR 20000000, EPSR 01000000, IPSR 00000000
CFBP 0400F000, CONTROL 4000000, FAULTMASK 00, BASEPRI F000, PRIMASK 00

Security extension regs:
MSP_S  = 00000000, MSPLIM_S  = 00000000
PSP_S  = 00000000, PSPLIM_S  = 00000000
MSP_NS = 2000E558, MSPLIM_NS = 00000000
PSP_NS = 00000000, PSPLIM_NS = 00000000
CONTROL_S  00, FAULTMASK_S  00, BASEPRI_S  00, PRIMASK_S  00
CONTROL_NS 4000000, FAULTMASK_NS 00, BASEPRI_NS F000, PRIMASK_NS 00

PENDING
    <none>
RUNNABLE
    TCB        PID PRI
    0x20002ea0  348 253 wq:SPI1
    0x200255f4  00 000 Idle Task
WAITING for Semaphore
    TCB        PID PRI
    0x2007f400  04 255 wq:manager
    0x20012070  880 255 wq:rate_ctrl
    0x2000f240  366 250 wq:SPI4
    0x200024f0  90 246 wq:I2C1
    0x20010980  374 244 wq:I2C3
    0x20012930  879 242 wq:nav_and_controllers
    0x200161a0  881 241 wq:INS0
    0x2001cb70  895 240 wq:INS1
    0x20011750  901 239 wq:INS2
    0x20003e30  55 237 wq:hp_default
    0x20003100  313 236 wq:uavcan
    0x2003f1d0  1278 230 logger
    0x2002c1e0  999 205 gps
    0x20003450  53 205 wq:lp_default
    0x20031a00  1067 175 mavlink_rcv_if0
    0x200068d0  317 120 uavcan_fw_srv
    0x20042550  1202 105 navigator
    0x2007dc00  03 100 init
    0x20001530  72 090 dataman
    0x20034820  1289 060 log_writer_file
WAITING for Signal
    TCB        PID PRI
    0x2007c2a0  01 249 hpwork
    0x2007cea0  02 050 lpwork
    0x2002e9a0  1066 100 mavlink_if0
    0x20018c20  891 140 commander
INACTIVE
    <none>
(not currently in exception handler)
  Id   Target Id         Frame 



* 1    Thread 57005      0x08147634 in raisebasepri (basepri=128) at NuttX/nuttx/include/arch/armv7-m/irq.h:305
#0  0x08147634 in raisebasepri (basepri=128) at NuttX/nuttx/include/arch/armv7-m/irq.h:305
#1  up_irq_save () at NuttX/nuttx/include/arch/armv7-m/irq.h:305
#2  cdev::CDev::poll_notify (this=this@entry=0x2000eb90, events=events@entry=1 '\001') at ../../src/lib/cdev/CDev.cpp:313
#3  0x0814bdf6 in uORB::DeviceNode::write (this=0x2000eb90, filp=<optimized out>, buffer=<optimized out>, buflen=<optimized out>) at ../../platforms/common/uORB/uORBDeviceNode.cpp:267
#4  0x0814c0fc in uORB::DeviceNode::publish (meta=<optimized out>, handle=<optimized out>, data=data@entry=0x2000e5b0) at ../../platforms/common/uORB/uORBDeviceNode.cpp:332
#5  0x0814c6c2 in uORB::Manager::orb_publish (this=<optimized out>, meta=<optimized out>, handle=<optimized out>, data=data@entry=0x2000e5b0) at ../../platforms/common/uORB/uORBManager.cpp:282
#6  0x0814ab90 in orb_publish (meta=<optimized out>, handle=<optimized out>, data=data@entry=0x2000e5b0) at ../../platforms/common/uORB/uORBManager.hpp:89
#7  0x0813f9d6 in uORB::PublicationMulti<sensor_gyro_s, (unsigned char)8>::publish (data=..., this=0x2000ea88) at ../../platforms/common/uORB/Publication.hpp:77
#8  PX4Gyroscope::updateFIFO (this=this@entry=0x2000ea88, sample=...) at ../../src/lib/drivers/gyroscope/PX4Gyroscope.cpp:151
#9  0x0803faae in ICM20689::ProcessGyro (this=this@entry=0x2000e9a0, timestamp_sample=@0x2000e8a0: 1862307999, fifo=fifo@entry=0x2000e6f5, samples=samples@entry=10 '\n') at ../../src/drivers/imu/invensense/icm20689/ICM20689.cpp:620
#10 0x0803fb0e in ICM20689::FIFORead (this=this@entry=0x2000e9a0, timestamp_sample=@0x2000e8a0: 1862307999, samples=<optimized out>) at ../../src/drivers/imu/invensense/icm20689/ICM20689.cpp:513
#11 0x0803fdc4 in ICM20689::RunImpl (this=this@entry=0x2000e9a0) at ../../src/drivers/imu/invensense/icm20689/ICM20689.cpp:275
#12 0x0803fe7a in I2CSPIDriver<ICM20689>::Run (this=0x2000e9e8) at ../../platforms/common/include/px4_platform_common/i2c_spi_buses.h:280
#13 0x08146a54 in px4::WorkQueue::Run (this=this@entry=0x2000e900) at ../../platforms/common/px4_work_queue/WorkQueue.cpp:187
#14 0x08146ba0 in px4::WorkQueueRunner (context=<error reading variable: value has been optimized out>) at ../../platforms/common/px4_work_queue/WorkQueueManager.cpp:230
#15 0x080144e0 in pthread_startup (entry=<optimized out>, arg=<optimized out>) at pthread/pthread_create.c:59
#16 0x00000000 in ?? ()



Backtrace stopped: previous frame identical to this frame (corrupt stack?)
#0  0x08147634 in raisebasepri (basepri=128) at NuttX/nuttx/include/arch/armv7-m/irq.h:305
        primask = 0
#1  up_irq_save () at NuttX/nuttx/include/arch/armv7-m/irq.h:305
        basepri = 240 '\360'
        basepri = <optimized out>
#2  cdev::CDev::poll_notify (this=this@entry=0x2000eb90, events=events@entry=1 '\001') at ../../src/lib/cdev/CDev.cpp:313
        flags = <optimized out>
#3  0x0814bdf6 in uORB::DeviceNode::write (this=0x2000eb90, filp=<optimized out>, buffer=<optimized out>, buflen=<optimized out>) at ../../platforms/common/uORB/uORBDeviceNode.cpp:267
        flags = 240 '\360'
        generation = <optimized out>
#4  0x0814c0fc in uORB::DeviceNode::publish (meta=<optimized out>, handle=<optimized out>, data=data@entry=0x2000e5b0) at ../../platforms/common/uORB/uORBDeviceNode.cpp:332
        devnode = <optimized out>
        ret = <optimized out>
#5  0x0814c6c2 in uORB::Manager::orb_publish (this=<optimized out>, meta=<optimized out>, handle=<optimized out>, data=data@entry=0x2000e5b0) at ../../platforms/common/uORB/uORBManager.cpp:282
No locals.
#6  0x0814ab90 in orb_publish (meta=<optimized out>, handle=<optimized out>, data=data@entry=0x2000e5b0) at ../../platforms/common/uORB/uORBManager.hpp:89
No locals.
#7  0x0813f9d6 in uORB::PublicationMulti<sensor_gyro_s, (unsigned char)8>::publish (data=..., this=0x2000ea88) at ../../platforms/common/uORB/Publication.hpp:77
No locals.
#8  PX4Gyroscope::updateFIFO (this=this@entry=0x2000ea88, sample=...) at ../../src/lib/drivers/gyroscope/PX4Gyroscope.cpp:151
        N = 10 '\n'
        report = {timestamp = 1862308194, timestamp_sample = 1862307999, device_id = 3932170, x = 0.00484695332, y = 0.0160322301, z = -0.00218379218, temperature = 40.6181145, error_count = 34, samples = 10 '\n', _padding0 = "\251\002 y\000\000", static ORB_QUEUE_LENGTH = 8 '\b'}
        scale = <optimized out>
#9  0x0803faae in ICM20689::ProcessGyro (this=this@entry=0x2000e9a0, timestamp_sample=@0x2000e8a0: 1862307999, fifo=fifo@entry=0x2000e6f5, samples=samples@entry=10 '\n') at ../../src/drivers/imu/invensense/icm20689/ICM20689.cpp:620
        gyro = {timestamp = 1862308190, timestamp_sample = 1862307999, device_id = 3932170, dt = 125, scale = 0.00106526446, x = {18, 2, -1, 8, 5, 5, 1, 15, -1, -20, 0 <repeats 22 times>}, y = {25, 24, 20, 17, 7, 14, 4, 3, 26, -1, 0 <repeats 22 times>}, z = {1, -28, 27, -15, -27, 23, -11, -25, 31, -19, 0 <repeats 22 times>}, samples = 10 '\n', _padding0 = "\000\000", static ORB_QUEUE_LENGTH = 4 '\004'}
#10 0x0803fb0e in ICM20689::FIFORead (this=this@entry=0x2000e9a0, timestamp_sample=@0x2000e8a0: 1862307999, samples=<optimized out>) at ../../src/drivers/imu/invensense/icm20689/ICM20689.cpp:513
        buffer = {cmd = 0 '\000', f = {{ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 167 '\247', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 148 '\224', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 41 ')', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 25 '\031', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 18 '\022', GYRO_ZOUT_H = 255 '\377', GYRO_ZOUT_L = 255 '\377'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 157 '\235', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 140 '\214', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 41 ')', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 24 '\030', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 2 '\002', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 28 '\034'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 157 '\235', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 140 '\214', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 41 ')', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 20 '\024', GYRO_YOUT_H = 255 '\377', GYRO_YOUT_L = 255 '\377', GYRO_ZOUT_H = 255 '\377', GYRO_ZOUT_L = 229 '\345'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 159 '\237', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 148 '\224', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 51 '3', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 17 '\021', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 8 '\b', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 15 '\017'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 159 '\237', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 148 '\224', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 51 '3', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 7 '\a', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 5 '\005', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 27 '\033'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 165 '\245', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 145 '\221', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 45 '-', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 14 '\016', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 5 '\005', GYRO_ZOUT_H = 255 '\377', GYRO_ZOUT_L = 233 '\351'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 165 '\245', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 145 '\221', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 45 '-', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 4 '\004', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 1 '\001', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 11 '\v'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 175 '\257', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 116 't', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 45 '-', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 3 '\003', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 15 '\017', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 25 '\031'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 175 '\257', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 116 't', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 45 '-', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 26 '\032', GYRO_YOUT_H = 255 '\377', GYRO_YOUT_L = 255 '\377', GYRO_ZOUT_H = 255 '\377', GYRO_ZOUT_L = 225 '\341'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 159 '\237', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 117 'u', ACCEL_ZOUT_H = 8 '\b', ACCEL_ZOUT_L = 36 '$', GYRO_XOUT_H = 255 '\377', GYRO_XOUT_L = 255 '\377', GYRO_YOUT_H = 255 '\377', GYRO_YOUT_L = 236 '\354', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 19 '\023'}, {ACCEL_XOUT_H = 0 '\000', ACCEL_XOUT_L = 0 '\000', ACCEL_YOUT_H = 0 '\000', ACCEL_YOUT_L = 0 '\000', ACCEL_ZOUT_H = 0 '\000', ACCEL_ZOUT_L = 0 '\000', GYRO_XOUT_H = 0 '\000', GYRO_XOUT_L = 0 '\000', GYRO_YOUT_H = 0 '\000', GYRO_YOUT_L = 0 '\000', GYRO_ZOUT_H = 0 '\000', GYRO_ZOUT_L = 0 '\000'} <repeats 22 times>}}
        transfer_size = <optimized out>
#11 0x0803fdc4 in ICM20689::RunImpl (this=this@entry=0x2000e9a0) at ../../src/drivers/imu/invensense/icm20689/ICM20689.cpp:275
        samples = <optimized out>
        timestamp_sample = 1862307999
        success = false
        fifo_count = <optimized out>
        now = 1862308009
#12 0x0803fe7a in I2CSPIDriver<ICM20689>::Run (this=0x2000e9e8) at ../../platforms/common/include/px4_platform_common/i2c_spi_buses.h:280
No locals.
#13 0x08146a54 in px4::WorkQueue::Run (this=this@entry=0x2000e900) at ../../platforms/common/px4_work_queue/WorkQueue.cpp:187
        work = 0x2000e9e8
#14 0x08146ba0 in px4::WorkQueueRunner (context=<error reading variable: value has been optimized out>) at ../../platforms/common/px4_work_queue/WorkQueueManager.cpp:230
        config = <error reading variable config (value has been optimized out)>
        wq = {<IntrusiveSortedListNode<px4::WorkQueue*>> = {_sorted_list_node_sibling = 0x2000fcb0}, _flags = 240 '\360', _q = {_head = 0x2000ed18, _tail = 0x2000ed18}, _process_lock = {semcount = 1, flags = 1 '\001', holder = {{htcb = 0x0, counts = 0}, {htcb = 0x0, counts = 0}}}, _exit_lock = {semcount = 1, flags = 1 '\001', holder = {{htcb = 0x0, counts = 0}, {htcb = 0x0, counts = 0}}}, _config = @0x81b8a9c, _work_items = {<IntrusiveSortedList<px4::WorkItem*>> = {_head = 0x2000ed18}, _mutex = {flink = 0x0, sem = {semcount = 1, flags = 0 '\000', holder = {{htcb = 0x0, counts = 0}, {htcb = 0x0, counts = 0}}}, pid = -1, flags = 1 '\001'}, _cv = {sem = {semcount = 0, flags = 0 '\000', holder = {{htcb = 0x0, counts = 0}, {htcb = 0x0, counts = 0}}}, clockid = 0 '\000'}}, _should_exit = {_value = false}}
#15 0x080144e0 in pthread_startup (entry=<optimized out>, arg=<optimized out>) at pthread/pthread_create.c:59
No locals.
#16 0x00000000 in ?? ()
No symbol table info available.
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

```
