### PR TITLE
astyle: restore backwards compatibility with old pre-commit hook

### DIFF
--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -eu
 
+PATTERN="-e ."
+
+if [ $# -gt 0 ]; then
+    PATTERN="$1"
+fi
+
 exec find boards msg src platforms test \
     -path msg/templates/urtps -prune -o \
     -path platforms/nuttx/NuttX -prune -o \
@@ -21,4 +27,4 @@ exec find boards msg src platforms test \
     -path src/lib/crypto/monocypher -prune -o \
     -path src/lib/crypto/libtomcrypt -prune -o \
     -path src/lib/crypto/libtommath -prune -o \
-    -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \)
+    -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) | grep $PATTERN


### PR DESCRIPTION
**Describe problem solved by this pull request**
I removed the filtering logic from the shell script in #18482 because the new pre-commit hook already takes care of it.

The problem is if you don't update the .git/hooks/pre-commit file and use the new shell script there's no filtering of files done and it checks all files for every file and takes much longer.

**Describe your solution**
This commit restores backwards compatibility by reverting the removal of filtering in the shellscript (https://github.com/PX4/PX4-Autopilot/pull/18482/files#diff-1185a8abba74e40db09c00cf2f8bddea37c86e4a0c31266c331da44830761aaaR24) because it does not hurt until I have an automatic way to update the pre-commit hook file.

**Test data / coverage**
Thanks for the report @bresch . This resolves the problem for me, could you quickly verify?
