### PR TITLE
drivers/uavcan_v1: fix Kconfig trailing whitespace

### DIFF
--- a/src/drivers/uavcan_v1/Kconfig
+++ b/src/drivers/uavcan_v1/Kconfig
@@ -73,7 +73,7 @@ if DRIVERS_UAVCAN_V1
             default n
 
         config UAVCAN_V1_GNSS_SUBSCRIBER_0
-            bool "GNSS Subscriber 0 "
+            bool "GNSS Subscriber 0"
             default n
 
         config UAVCAN_V1_GNSS_SUBSCRIBER_1


### PR DESCRIPTION
![Screenshot from 2021-10-22 13-49-17](https://user-images.githubusercontent.com/84712/138500511-481bc485-f14e-4394-b087-8cc848395ccd.png)
