### PR TITLE
Add CANNODE_FLOW_ROT

### DIFF
--- a/src/drivers/uavcannode/uavcannode_params.c
+++ b/src/drivers/uavcannode/uavcannode_params.c
@@ -59,3 +59,24 @@ PARAM_DEFINE_INT32(CANNODE_BITRATE, 1000000);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(CANNODE_TERM, 0);
+
+/**
+ * Cannode flow board rotation
+ *
+ * This parameter defines the yaw rotation of the Cannode flow board relative to the vehicle body frame.
+ * Zero rotation is defined as X on flow board pointing towards front of vehicle.
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ *
+ * @reboot_required true
+ *
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CANNODE_FLOW_ROT, 0);


### PR DESCRIPTION
This PR adds optical flow rotation to the cannode flow publisher. CANNODE_FLOW_ROT is set on the cannode and rotates the measurement before it is published.