### PR TITLE
Fix px4vision parameters for collision prevention to work with defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -84,6 +84,8 @@ param set-default MPC_Z_VEL_P_ACC 5
 param set-default MPC_Z_VEL_I_ACC 3
 param set-default MPC_LAND_ALT1 3
 param set-default MPC_LAND_ALT2 1
+param set-default MPC_POS_MODE 3
+param set-default CP_GO_NO_DATA 1
 
 # Navigator Parameters
 param set-default NAV_ACC_RAD 2


### PR DESCRIPTION
**Describe problem solved by this pull request**
There has been reports of people struggling to get the px4vision collision prevention feature to work.

This is due to the following reasons
-  The default `MPC_POS_MODE=4` does not work for collision prevention due to the stick acceleration setpoints not being supported for collision prevention: [discussion](https://discuss.px4.io/t/px4-vision-collision-prevention-feature-seems-not-to-work/23476/25?u=jaeyoung-lim)
- The behavior of `CP_GO_NO_DATA` seems to be not intuitive and is assumed that the function is broken

**Describe your solution**
This sets the defaults for the px4vision to improve the experience on testing the px4vision.

**Describe possible alternatives**
A proper fix would be to get the collision prevention working with acceleration stick inputs. 

**Test data / coverage**
Not tested personally, but appears to work according to the [thread](https://discuss.px4.io/t/px4-vision-collision-prevention-feature-seems-not-to-work/23476/32?u=jaeyoung-lim)

