### PR TITLE
Stick gesture to kill

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1537,9 +1537,9 @@ void Commander::executeActionRequest(const action_request_s &action_request)
 		break;
 
 	case action_request_s::ACTION_UNKILL:
-		if (arm_disarm_reason == arm_disarm_reason_t::rc_switch && _actuator_armed.manual_lockdown) {
-			mavlink_log_info(&_mavlink_log_pub, "Kill-switch disengaged\t");
-			events::send(events::ID("commander_kill_sw_disengaged"), events::Log::Info, "Kill-switch disengaged");
+		if (_actuator_armed.manual_lockdown) {
+			mavlink_log_info(&_mavlink_log_pub, "Kill disengaged\t");
+			events::send(events::ID("commander_kill_sw_disengaged"), events::Log::Info, "Kill disengaged");
 			_status_changed = true;
 			_actuator_armed.manual_lockdown = false;
 		}
@@ -1547,8 +1547,8 @@ void Commander::executeActionRequest(const action_request_s &action_request)
 		break;
 
 	case action_request_s::ACTION_KILL:
-		if (arm_disarm_reason == arm_disarm_reason_t::rc_switch && !_actuator_armed.manual_lockdown) {
-			const char kill_switch_string[] = "Kill-switch engaged\t";
+		if (!_actuator_armed.manual_lockdown) {
+			const char kill_switch_string[] = "Kill engaged\t";
 			events::LogLevels log_levels{events::Log::Info};
 
 			if (_vehicle_land_detected.landed) {
@@ -1559,7 +1559,7 @@ void Commander::executeActionRequest(const action_request_s &action_request)
 				log_levels.external = events::Log::Critical;
 			}
 
-			events::send(events::ID("commander_kill_sw_engaged"), log_levels, "Kill-switch engaged");
+			events::send(events::ID("commander_kill_sw_engaged"), log_levels, "Kill engaged");
 
 			_status_changed = true;
 			_actuator_armed.manual_lockdown = true;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -624,7 +624,7 @@ transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool f
 					     || (calling_reason == arm_disarm_reason_t::rc_switch)
 					     || (calling_reason == arm_disarm_reason_t::rc_button);
 
-		if (!landed && !(mc_manual_thrust_mode && commanded_by_rc)) {
+		if (!landed && !(mc_manual_thrust_mode && commanded_by_rc && _param_com_disarm_man.get())) {
 			if (calling_reason != arm_disarm_reason_t::rc_stick) {
 				mavlink_log_critical(&_mavlink_log_pub, "Disarming denied: not landed\t");
 				events::send(events::ID("commander_disarm_denied_not_landed"),

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -318,6 +318,7 @@ private:
 
 		(ParamFloat<px4::params::COM_DISARM_LAND>)  _param_com_disarm_land,
 		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_preflight,
+		(ParamBool<px4::params::COM_DISARM_MAN>)    _param_com_disarm_man,
 		(ParamInt<px4::params::COM_DL_LOSS_T>)      _param_com_dl_loss_t,
 		(ParamInt<px4::params::COM_HLDL_LOSS_T>)    _param_com_hldl_loss_t,
 		(ParamInt<px4::params::COM_HLDL_REG_T>)     _param_com_hldl_reg_t,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -246,6 +246,19 @@ PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
 
 /**
+ * Allow disarming via switch/stick/button on multicopters in manual thrust modes
+ *
+ * 0: Disallow disarming when not landed
+ * 1: Allow disarming in multicopter flight in modes where
+ * the thrust is directly controlled by thr throttle stick
+ * e.g. Stabilized, Acro
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_DISARM_MAN, 1);
+
+/**
  * Battery failsafe mode
  *
  * Action the system takes at critical battery. See also BAT_CRIT_THR and BAT_EMERGEN_THR

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -154,7 +154,8 @@ void ManualControl::processInput(hrt_abstime now)
 		_throttle_diff.reset();
 		_stick_arm_hysteresis.set_state_and_update(false, now);
 		_stick_disarm_hysteresis.set_state_and_update(false, now);
-		_button_hysteresis.set_state_and_update(false, now);
+		_stick_kill_hysteresis.set_state_and_update(false, now);
+		_button_arm_hysteresis.set_state_and_update(false, now);
 	}
 
 	processSwitches(now);
@@ -178,10 +179,10 @@ void ManualControl::processSwitches(hrt_abstime &now)
 
 				if (_param_com_arm_swisbtn.get()) {
 					// Arming button
-					const bool previous_button_hysteresis = _button_hysteresis.get_state();
-					_button_hysteresis.set_state_and_update(switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON, now);
+					const bool previous_button_arm_hysteresis = _button_arm_hysteresis.get_state();
+					_button_arm_hysteresis.set_state_and_update(switches.arm_switch == manual_control_switches_s::SWITCH_POS_ON, now);
 
-					if (!previous_button_hysteresis && _button_hysteresis.get_state()) {
+					if (!previous_button_arm_hysteresis && _button_arm_hysteresis.get_state()) {
 						sendActionRequest(action_request_s::ACTION_TOGGLE_ARMING, action_request_s::SOURCE_RC_BUTTON);
 					}
 
@@ -291,7 +292,8 @@ void ManualControl::updateParams()
 
 	_stick_arm_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
 	_stick_disarm_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
-	_button_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
+	_button_arm_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
+	_stick_kill_hysteresis.set_hysteresis_time_from(false, _param_man_kill_gest_t.get() * 1_s);
 
 	_selector.setRcInMode(_param_com_rc_in_mode.get());
 	_selector.setTimeout(_param_com_rc_loss_t.get() * 1_s);
@@ -365,6 +367,18 @@ void ManualControl::processStickArming(const manual_control_setpoint_s &input)
 
 	if (_param_man_arm_gesture.get() && !previous_stick_disarm_hysteresis && _stick_disarm_hysteresis.get_state()) {
 		sendActionRequest(action_request_s::ACTION_DISARM, action_request_s::SOURCE_RC_STICK_GESTURE);
+	}
+
+	// Kill gesture
+	if (_param_man_kill_gest_t.get() > 0.f) {
+		const bool right_stick_lower_right = (input.pitch < -0.9f) && (input.roll > 0.9f);
+
+		const bool previous_stick_kill_hysteresis = _stick_kill_hysteresis.get_state();
+		_stick_kill_hysteresis.set_state_and_update(left_stick_lower_left && right_stick_lower_right, input.timestamp);
+
+		if (!previous_stick_kill_hysteresis && _stick_kill_hysteresis.get_state()) {
+			sendActionRequest(action_request_s::ACTION_KILL, action_request_s::SOURCE_RC_STICK_GESTURE);
+		}
 	}
 }
 

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -122,7 +122,8 @@ private:
 
 	systemlib::Hysteresis _stick_arm_hysteresis{false};
 	systemlib::Hysteresis _stick_disarm_hysteresis{false};
-	systemlib::Hysteresis _button_hysteresis{false};
+	systemlib::Hysteresis _stick_kill_hysteresis{false};
+	systemlib::Hysteresis _button_arm_hysteresis{false};
 
 	MovingDiff _roll_diff{};
 	MovingDiff _pitch_diff{};
@@ -146,6 +147,7 @@ private:
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
 		(ParamBool<px4::params::MAN_ARM_GESTURE>) _param_man_arm_gesture,
+		(ParamFloat<px4::params::MAN_KILL_GEST_T>) _param_man_kill_gest_t,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_com_rc_arm_hyst,
 		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_com_arm_swisbtn,
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,

--- a/src/modules/manual_control/manual_control_params.c
+++ b/src/modules/manual_control/manual_control_params.c
@@ -41,3 +41,20 @@
  * @group Manual Control
  */
 PARAM_DEFINE_INT32(MAN_ARM_GESTURE, 1);
+
+/**
+ * Trigger time for kill stick gesture
+ *
+ * The timeout for holding the left stick to the lower left
+ * and the right stick to the lower right at the same time until the gesture
+ * kills the actuators one-way.
+ *
+ * A negative value disables the feature.
+ *
+ * @group Manual Control
+ * @unit s
+ * @decimal 2
+ * @min -1
+ * @max 15
+ */
+PARAM_DEFINE_FLOAT(MAN_KILL_GEST_T, -1.f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
We received the requirement to not disarm in Manual/Stabilized mode when not landed but keep an accessible way to be able to kill the vehicle. After a local solution my goal was to find something future proof and I came up with this suggestion.

**Describe your solution**
A rough solution:
- Kill if sticks are held "left stick lower left and right stick lower right" for 10 seconds
- Parameter to be able to disable disarming when not landed in manual thrust modes like Acro, Stabilized

**Describe possible alternatives**
I can confirm what Beat mentioned: We would not have this problem if the arm and disarm gesture would be using both sticks e.g. arm with left stick lower right, right stick lower left and disarming with left stick lower left and right stick lower right. I'm open to hearing more opinions on that as well but would definitely want to support this as a next step in the near future.

**Test data / coverage**
I bench tested this on top of the RC cleanup pr https://github.com/PX4/PX4-Autopilot/pull/17404