### PR TITLE
Fix json board targets regression from #17100

### DIFF
--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -41,7 +41,7 @@ def process_target(px4board_file, target_name):
     platform = None
     toolchain = None
 
-    if(px4board_file.endswith("default.px4board")):
+    if px4board_file.endswith("default.px4board"):
         kconf.load_config(px4board_file, replace=True)
     else: # Merge config with default.px4board
         default_kconfig = re.sub(r'[a-zA-Z\d_]+\.px4board', 'default.px4board', px4board_file)


### PR DESCRIPTION
Changed parse code to traverse of px4board files instead of cmake files and reads out the BOARD_TOOLCHAIN & BOARD_PLATFORM to determine the container instead.

Okay looks okay but it's hard to verify

```
hovergames@hovergames:~/src/Firmware$ python3 Tools/generate_board_targets_json.py 
{
   "include":[
      {
         "target":"modalai_fc-v2_default",
         "container":"nuttx-focal"
      },
      {
         "target":"modalai_fc-v2_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"modalai_fc-v1_default",
         "container":"nuttx-focal"
      },
      {
         "target":"modalai_fc-v1_rtps",
         "container":"nuttx-focal"
      },
      {
         "target":"spracing_h7extreme_default",
         "container":"nuttx-focal"
      },
      {
         "target":"uvify_core_default",
         "container":"nuttx-focal"
      },
      {
         "target":"holybro_pix32v5_default",
         "container":"nuttx-focal"
      },
      {
         "target":"holybro_can-gps-v1_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"holybro_can-gps-v1_default",
         "container":"nuttx-focal"
      },
      {
         "target":"holybro_kakutef7_default",
         "container":"nuttx-focal"
      },
      {
         "target":"holybro_durandal-v1_default",
         "container":"nuttx-focal"
      },
      {
         "target":"holybro_durandal-v1_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"bitcraze_crazyflie_default",
         "container":"nuttx-focal"
      },
      {
         "target":"bitcraze_crazyflie21_default",
         "container":"nuttx-focal"
      },
      {
         "target":"av_x-v1_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_ctrl-zero-h7-oem_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_ctrl-zero-h7-oem_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_ctrl-zero-f7-oem_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_pixracerpro_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_pixracerpro_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_x21-777_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_ctrl-zero-f7_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_ctrl-zero-h7_default",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_ctrl-zero-h7_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"mro_x21_default",
         "container":"nuttx-focal"
      },
      {
         "target":"scumaker_pilotpi_default",
         "container":"armhf"
      },
      {
         "target":"scumaker_pilotpi_arm64",
         "container":"aarch64"
      },
      {
         "target":"nxp_fmuk66-e_default",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_fmuk66-e_socketcan",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_fmuk66-e_rtps",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_fmurt1062-v1_default",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_fmuk66-v3_default",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_fmuk66-v3_socketcan",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_fmuk66-v3_rtps",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_ucans32k146_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_ucans32k146_default",
         "container":"nuttx-focal"
      },
      {
         "target":"nxp_ucans32k146_servo",
         "container":"nuttx-focal"
      },
      {
         "target":"omnibus_f4sd_default",
         "container":"nuttx-focal"
      },
      {
         "target":"airmind_mindpx-v2_default",
         "container":"nuttx-focal"
      },
      {
         "target":"cuav_can-gps-v1_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"cuav_can-gps-v1_default",
         "container":"nuttx-focal"
      },
      {
         "target":"cuav_x7pro_default",
         "container":"nuttx-focal"
      },
      {
         "target":"cuav_x7pro_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"cuav_nora_default",
         "container":"nuttx-focal"
      },
      {
         "target":"cuav_nora_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"emlid_navio2_default",
         "container":"armhf"
      },
      {
         "target":"atl_mantis-edu_default",
         "container":"nuttx-focal"
      },
      {
         "target":"freefly_can-rtk-gps_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"freefly_can-rtk-gps_default",
         "container":"nuttx-focal"
      },
      {
         "target":"beaglebone_blue_default",
         "container":"armhf"
      },
      {
         "target":"cubepilot_io-v2_default",
         "container":"nuttx-focal"
      },
      {
         "target":"cubepilot_cubeorange_default",
         "container":"nuttx-focal"
      },
      {
         "target":"cubepilot_cubeorange_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"cubepilot_cubeyellow_default",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-flow_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-flow_default",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-gps_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-gps_default",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-rtk-gps_canbootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-rtk-gps_debug",
         "container":"nuttx-focal"
      },
      {
         "target":"ark_can-rtk-gps_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v6u_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v6u_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_raspberrypi_default",
         "container":"armhf"
      },
      {
         "target":"px4_fmu-v3_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5x_base_phy_DP83848C",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5x_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5x_rtps",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v4_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_io-v2_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v4pro_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5_debug",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5_rtps",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v5_uavcanv0periph",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v6x_default",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v6x_bootloader",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_sitl_sitl",
         "container":"base-focal"
      },
      {
         "target":"px4_sitl_default",
         "container":"base-focal"
      },
      {
         "target":"px4_sitl_rtps",
         "container":"base-focal"
      },
      {
         "target":"px4_fmu-v2_fixedwing",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v2_multicopter",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v2_rover",
         "container":"nuttx-focal"
      },
      {
         "target":"px4_fmu-v2_default",
         "container":"nuttx-focal"
      }
   ]
}
```