### PR TITLE
fix hardpoint hardfault

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1205,7 +1205,7 @@ int uavcan_main(int argc, char *argv[])
 	}
 
 	if (!std::strcmp(argv[1], "hardpoint")) {
-		if (!std::strcmp(argv[2], "set") && argc > 4) {
+		if (argc > 4 && !std::strcmp(argv[2], "set")) {
 			const int hardpoint_id = atoi(argv[3]);
 			const int command = atoi(argv[4]);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
I caught a hardfault after typing `uavcan hardpoint` in mavlink console. In code it is expected to have at least 1 additional argument after `uavcan hardpoint` to avoid this problem. Example of correct command is `uavcan hardpoint set 0 0`. The problem appears because it calls `std::strcmp(argv[2], "set")` before checking argc, but std::srtcmp expected null-terminated strings.

**Describe your solution**
The solution is just swap argc check and std::strcmp call. After fixing it is ok.

**Test data / coverage**
Here is a [short video illustration](https://youtu.be/-k2RaQSmVoc) and corresponded [log file](https://review.px4.io/plot_app?log=e0e5093a-26b1-41b3-af64-f59d42a22853). I use cuav v5+.

**Additional context**
By the way, is hardpoint control via mavlink console is what really preferred? Is not it is better to control it via uorb topics and mavlink stream or even during a mision, let's say MAV_CMD_DO_GRIPPER?