### PR TITLE
Fix Navigation failure during calibration

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3912,8 +3912,7 @@ void Commander::estimator_check()
 
 		if (run_quality_checks && _status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 
-			if (_status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY
-			    || _status.arming_state == vehicle_status_s::ARMING_STATE_INIT) {
+			if (_status.arming_state != vehicle_status_s::ARMING_STATE_ARMED) {
 				_nav_test_failed = false;
 				_nav_test_passed = false;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
During calibration, the user could get a "Navigation failure! Land and recalibrate the sensors". This comes from the EKF check in commander. These checks are only supposed to run when in the air (or at least armed). 

**Describe your solution**
So far, the check to enable this only looked if arming state was `ARMING_STATE_STANDBY`. But during calibration, the arming state is `ARMING_STATE_INIT`. 

**Test data / coverage**
Bench tested on PIXHAWK 4 and skynode

