### PR TITLE
fixed ulanding_radar autostart command

### DIFF
--- a/src/drivers/distance_sensor/ulanding_radar/module.yaml
+++ b/src/drivers/distance_sensor/ulanding_radar/module.yaml
@@ -1,6 +1,6 @@
 module_name: uLanding Radar
 serial_config:
-    - command: ulanding_radar start ${SERIAL_DEV}
+    - command: ulanding_radar start -d ${SERIAL_DEV}
       port_config_param:
         name: SENS_ULAND_CFG
         group: Sensors


### PR DESCRIPTION
The previous command was incorrect; calling without `-d` returns an error.

**Test data / coverage**
This was tested on a Cube Orange with an Ainstein radar connected.