### PR TITLE
mavlink: increase optimization to ${MAX_CUSTOM_OPT_LEVEL}

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	MODULE modules__mavlink
 	MAIN mavlink
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 		-Wno-cast-align # TODO: fix and enable
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 		-Wno-enum-compare # ROTATION <-> MAV_SENSOR_ROTATION


### PR DESCRIPTION
 - MAX_CUSTOM_OPT_LEVEL is -O2 on boards that aren't flash constrained

Depending on the usage mavlink can be a large percentage of overall CPU. Let's see what this is worth.

