### PR TITLE
logger: increase optimization to ${MAX_CUSTOM_OPT_LEVEL}

### DIFF
--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -36,6 +36,7 @@ px4_add_module(
 	MAIN logger
 	PRIORITY "SCHED_PRIORITY_MAX-30"
 	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
 		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		logged_topics.cpp


### PR DESCRIPTION
 - ${MAX_CUSTOM_OPT_LEVEL} is -O2 on boards that aren't flash constrained


On px4_fmu-v5 this saves roughly 1.4% CPU in exchange for about 7 kB of flash.

#### px4_fmu-v5 SDLOG_PROFILE 19
``` Console
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
1101 logger                        404  4.867  2676/ 3648 230 (230)  w:sem  4    # master
1101 logger                       2276  3.481  2772/ 3648 230 (230)  w:sem  4    # PR
```