### PR TITLE
mavlink: rate multiplier and scheduling optimizations

### DIFF
--- a/src/modules/mavlink/mavlink_events.cpp
+++ b/src/modules/mavlink/mavlink_events.cpp
@@ -138,7 +138,9 @@ void SendProtocol::update(const hrt_abstime &now)
 
 	while (_latest_sequence != buffer_sequence) {
 		// only send if enough tx buffer space available
-		if (_mavlink.get_free_tx_buf() < MAVLINK_MSG_ID_EVENT_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) {
+		if ((_mavlink.get_free_tx_buf() < MAVLINK_MSG_ID_EVENT_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES)
+		    || _mavlink.over_data_rate()) {
+
 			break;
 		}
 
@@ -218,7 +220,9 @@ void SendProtocol::on_gcs_connected()
 void SendProtocol::send_current_sequence(const hrt_abstime &now)
 {
 	// only send if enough tx buffer space available
-	if (_mavlink.get_free_tx_buf() < MAVLINK_MSG_ID_CURRENT_EVENT_SEQUENCE_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) {
+	if ((_mavlink.get_free_tx_buf() < MAVLINK_MSG_ID_CURRENT_EVENT_SEQUENCE_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES)
+	    || _mavlink.over_data_rate()) {
+
 		return;
 	}
 

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -1064,7 +1064,8 @@ void MavlinkFTP::send()
 	unsigned max_bytes_to_send = _mavlink->get_free_tx_buf();
 	PX4_DEBUG("MavlinkFTP::send max_bytes_to_send(%u) get_free_tx_buf(%u)", max_bytes_to_send, _mavlink->get_free_tx_buf());
 
-	if (max_bytes_to_send < get_size()) {
+	// Skip send if not enough room
+	if ((max_bytes_to_send < get_size()) || _mavlink->over_data_rate()) {
 		return;
 	}
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -466,12 +466,7 @@ MavlinkMissionManager::send_mission_item_reached(uint16_t seq)
 void
 MavlinkMissionManager::send()
 {
-	// do not send anything over high latency communication
-	if (_mavlink->get_mode() == Mavlink::MAVLINK_MODE_IRIDIUM) {
-		return;
-	}
-
-	mission_result_s mission_result{};
+	mission_result_s mission_result;
 
 	if (_mission_result_sub.update(&mission_result)) {
 
@@ -1744,11 +1739,6 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 
 void MavlinkMissionManager::check_active_mission()
 {
-	// do not send anything over high latency communication
-	if (_mavlink->get_mode() == Mavlink::MAVLINK_MODE_IRIDIUM) {
-		return;
-	}
-
 	if (!(_my_dataman_id == _dataman_id)) {
 		PX4_DEBUG("WPM: New mission detected (possibly over different Mavlink instance) Updating");
 

--- a/src/modules/mavlink/mavlink_stream.cpp
+++ b/src/modules/mavlink/mavlink_stream.cpp
@@ -47,7 +47,6 @@
 MavlinkStream::MavlinkStream(Mavlink *mavlink) :
 	_mavlink(mavlink)
 {
-	_last_sent = hrt_absolute_time();
 }
 
 /**
@@ -58,71 +57,38 @@ MavlinkStream::update(const hrt_abstime &t)
 {
 	update_data();
 
-	// If the message has never been sent before we want
-	// to send it immediately and can return right away
-	if (_last_sent == 0) {
-		// this will give different messages on the same run a different
-		// initial timestamp which will help spacing them out
-		// on the link scheduling
-		if (send()) {
-			_last_sent = hrt_absolute_time();
+	int sz = get_size();
 
-			if (!_first_message_sent) {
-				_first_message_sent = true;
-			}
-		}
-
+	if ((sz <= 0) || (_interval == 0)) {
+		// We don't need to send anything if the size or interval is 0.
 		return 0;
-	}
 
-	// One of the previous iterations sent the update
-	// already before the deadline
-	if (_last_sent > t) {
-		return -1;
-	}
-
-	int64_t dt = t - _last_sent;
-	int interval = _interval;
-
-	if (!const_rate()) {
-		interval /= _mavlink->get_rate_mult();
-	}
-
-	// We don't need to send anything if the inverval is 0. send() will be called manually.
-	if (interval == 0) {
-		return 0;
-	}
-
-	const bool unlimited_rate = interval < 0;
-
-	// Send the message if it is due or
-	// if it will overrun the next scheduled send interval
-	// by 30% of the interval time. This helps to avoid
-	// sending a scheduled message on average slower than
-	// scheduled. Doing this at 50% would risk sending
-	// the message too often as the loop runtime of the app
-	// needs to be accounted for as well.
-	// This method is not theoretically optimal but a suitable
-	// stopgap as it hits its deadlines well (0.5 Hz, 50 Hz and 250 Hz)
-
-	if (unlimited_rate || (dt > (interval - (_mavlink->get_main_loop_delay() / 10) * 3))) {
-		// interval expired, send message
-
-		// If the interval is non-zero and dt is smaller than 1.5 times the interval
-		// do not use the actual time but increment at a fixed rate, so that processing delays do not
-		// distort the average rate. The check of the maximum interval is done to ensure that after a
-		// long time not sending anything, sending multiple messages in a short time is avoided.
-		if (send()) {
-			_last_sent = ((interval > 0) && ((int64_t)(1.5f * interval) > dt)) ? _last_sent + interval : t;
-
-			if (!_first_message_sent) {
-				_first_message_sent = true;
+	} else if ((_interval < 0) || (_last_sent == 0)) {
+		// if unlimited rate or message has never been sent before
+		// we want to send it immediately and can return right away
+		if (_mavlink->canTransmit(sz)) {
+			if (send()) {
+				_last_sent = t;
+				return 0;
 			}
-
-			return 0;
 
 		} else {
-			return -1;
+			_mavlink->count_txerrbytes(sz);
+		}
+
+	} else {
+		int interval = const_rate() ? _interval : (_interval * _mavlink->get_rate_div());
+
+		if (t >= _last_sent + interval) {
+			if (_mavlink->canTransmit(sz)) {
+				if (send()) {
+					_last_sent = math::max(_last_sent + interval, t - interval);
+					return 0;
+				}
+
+			} else {
+				_mavlink->count_txerrbytes(sz);
+			}
 		}
 	}
 

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -114,13 +114,7 @@ public:
 	/**
 	 * @return true if the first message of this stream has been sent
 	 */
-	bool first_message_sent() const { return _first_message_sent; }
-
-	/**
-	 * Reset the time of last sent to 0. Can be used if a message over this
-	 * stream needs to be sent immediately.
-	 */
-	void reset_last_sent() { _last_sent = 0; }
+	bool first_message_sent() const { return _last_sent != 0; }
 
 protected:
 	Mavlink      *const _mavlink;
@@ -138,7 +132,6 @@ protected:
 
 private:
 	hrt_abstime _last_sent{0};
-	bool _first_message_sent{false};
 };
 
 

--- a/src/modules/mavlink/streams/ADSB_VEHICLE.hpp
+++ b/src/modules/mavlink/streams/ADSB_VEHICLE.hpp
@@ -61,14 +61,12 @@ private:
 
 	bool send() override
 	{
-		bool sent = false;
-
 		transponder_report_s pos;
 
-		while ((_mavlink->get_free_tx_buf() >= get_size()) && _transponder_report_sub.update(&pos)) {
+		if (_transponder_report_sub.update(&pos)) {
 
 			if (!(pos.flags & transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE)) {
-				continue;
+				return false;
 			}
 
 			mavlink_adsb_vehicle_t msg{};
@@ -100,10 +98,10 @@ private:
 			if (pos.flags & transponder_report_s::PX4_ADSB_FLAGS_VALID_SQUAWK) { msg.flags |= ADSB_FLAGS_VALID_SQUAWK; }
 
 			mavlink_msg_adsb_vehicle_send_struct(_mavlink->get_channel(), &msg);
-			sent = true;
+			return true;
 		}
 
-		return sent;
+		return false;
 	}
 };
 

--- a/src/modules/mavlink/streams/CAMERA_IMAGE_CAPTURED.hpp
+++ b/src/modules/mavlink/streams/CAMERA_IMAGE_CAPTURED.hpp
@@ -63,7 +63,7 @@ private:
 	{
 		camera_capture_s capture;
 
-		if ((_mavlink->get_free_tx_buf() >= get_size()) && _capture_sub.update(&capture)) {
+		if (_capture_sub.update(&capture)) {
 			mavlink_camera_image_captured_t msg{};
 
 			msg.time_boot_ms = capture.timestamp / 1000;

--- a/src/modules/mavlink/streams/CAMERA_TRIGGER.hpp
+++ b/src/modules/mavlink/streams/CAMERA_TRIGGER.hpp
@@ -76,7 +76,7 @@ private:
 	{
 		camera_trigger_s camera_trigger;
 
-		if ((_mavlink->get_free_tx_buf() >= get_size()) && _camera_trigger_sub.update(&camera_trigger)) {
+		if (_camera_trigger_sub.update(&camera_trigger)) {
 			/* ensure that only active trigger events are sent and ignore camera capture feedback messages*/
 			if (camera_trigger.timestamp > 0 && !camera_trigger.feedback) {
 				mavlink_camera_trigger_t msg{};

--- a/src/modules/mavlink/streams/COLLISION.hpp
+++ b/src/modules/mavlink/streams/COLLISION.hpp
@@ -62,7 +62,7 @@ private:
 		collision_report_s report;
 		bool sent = false;
 
-		while ((_mavlink->get_free_tx_buf() >= get_size()) && _collision_sub.update(&report)) {
+		if (_collision_sub.update(&report)) {
 			mavlink_collision_t msg = {};
 
 			msg.src = report.src;

--- a/src/modules/mavlink/streams/COMMAND_LONG.hpp
+++ b/src/modules/mavlink/streams/COMMAND_LONG.hpp
@@ -60,38 +60,32 @@ private:
 	bool send() override
 	{
 		bool sent = false;
+		const unsigned last_generation = _vehicle_command_sub.get_last_generation();
+		vehicle_command_s cmd;
 
-		static constexpr size_t COMMAND_LONG_SIZE = MAVLINK_MSG_ID_COMMAND_LONG_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+		if (_vehicle_command_sub.update(&cmd)) {
+			if (_vehicle_command_sub.get_last_generation() != last_generation + 1) {
+				PX4_ERR("COMMAND_LONG vehicle_command lost, generation %d -> %d", last_generation,
+					_vehicle_command_sub.get_last_generation());
+			}
 
-		while ((_mavlink->get_free_tx_buf() >= COMMAND_LONG_SIZE) && _vehicle_command_sub.updated()) {
+			// mavlink mavlink commands are <= UINT16_MAX
+			const bool px4_internal_cmd = (cmd.command >= vehicle_command_s::VEHICLE_CMD_PX4_INTERNAL_START);
 
-			const unsigned last_generation = _vehicle_command_sub.get_last_generation();
-			vehicle_command_s cmd;
+			// internal commands
+			const bool target_system_internal = (cmd.target_system == _mavlink->get_system_id())
+							    && (cmd.target_component == _mavlink->get_component_id())
+							    && (cmd.source_system == cmd.target_system)
+							    && (cmd.source_component == cmd.target_component);
 
-			if (_vehicle_command_sub.update(&cmd)) {
-				if (_vehicle_command_sub.get_last_generation() != last_generation + 1) {
-					PX4_ERR("COMMAND_LONG vehicle_command lost, generation %d -> %d", last_generation,
-						_vehicle_command_sub.get_last_generation());
-				}
+			if (!cmd.from_external && !px4_internal_cmd && !target_system_internal) {
+				PX4_DEBUG("sending command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
 
-				// mavlink mavlink commands are <= UINT16_MAX
-				const bool px4_internal_cmd = (cmd.command >= vehicle_command_s::VEHICLE_CMD_PX4_INTERNAL_START);
+				MavlinkCommandSender::instance().handle_vehicle_command(cmd, _mavlink->get_channel());
+				sent = true;
 
-				// internal commands
-				const bool target_system_internal = (cmd.target_system == _mavlink->get_system_id())
-								    && (cmd.target_component == _mavlink->get_component_id())
-								    && (cmd.source_system == cmd.target_system)
-								    && (cmd.source_component == cmd.target_component);
-
-				if (!cmd.from_external && !px4_internal_cmd && !target_system_internal) {
-					PX4_DEBUG("sending command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
-
-					MavlinkCommandSender::instance().handle_vehicle_command(cmd, _mavlink->get_channel());
-					sent = true;
-
-				} else {
-					PX4_DEBUG("not forwarding command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
-				}
+			} else {
+				PX4_DEBUG("not forwarding command %d to %d/%d", cmd.command, cmd.target_system, cmd.target_component);
 			}
 		}
 

--- a/src/modules/mavlink/streams/GPS_RTCM_DATA.hpp
+++ b/src/modules/mavlink/streams/GPS_RTCM_DATA.hpp
@@ -60,9 +60,8 @@ private:
 	bool send() override
 	{
 		gps_inject_data_s gps_inject_data;
-		bool sent = false;
 
-		while ((_mavlink->get_free_tx_buf() >= get_size()) && _gps_inject_data_sub.update(&gps_inject_data)) {
+		if (_gps_inject_data_sub.update(&gps_inject_data)) {
 			mavlink_gps_rtcm_data_t msg{};
 
 			msg.len = gps_inject_data.len;
@@ -71,10 +70,10 @@ private:
 
 			mavlink_msg_gps_rtcm_data_send_struct(_mavlink->get_channel(), &msg);
 
-			sent = true;
+			return true;
 		}
 
-		return sent;
+		return false;
 	}
 };
 

--- a/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
+++ b/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
@@ -87,7 +87,6 @@ private:
 		_throttle(SimpleAnalyzer::AVERAGE),
 		_windspeed(SimpleAnalyzer::AVERAGE)
 	{
-		reset_last_sent();
 	}
 
 	struct PerBatteryData {
@@ -201,6 +200,10 @@ private:
 				reset_analysers(t);
 
 				mavlink_msg_high_latency2_send_struct(_mavlink->get_channel(), &msg);
+			}
+
+			if (updated) {
+				_mavlink->set_first_heartbeat_sent();
 			}
 
 			return updated;

--- a/src/modules/mavlink/streams/LINK_NODE_STATUS.hpp
+++ b/src/modules/mavlink/streams/LINK_NODE_STATUS.hpp
@@ -55,29 +55,25 @@ private:
 
 	bool send() override
 	{
-		if (_mavlink->get_free_tx_buf() >= get_size()) {
-			mavlink_link_node_status_t link_node_status{};
+		mavlink_link_node_status_t link_node_status{};
 
-			const telemetry_status_s &tstatus = _mavlink->telemetry_status();
-			link_node_status.tx_buf = 0; // % TODO
-			link_node_status.rx_buf = 0; // % TODO
-			link_node_status.tx_rate = tstatus.tx_rate_avg;
-			link_node_status.rx_rate = tstatus.rx_rate_avg;
-			link_node_status.rx_parse_err = tstatus.rx_parse_errors;
-			link_node_status.tx_overflows = tstatus.tx_buffer_overruns;
-			link_node_status.rx_overflows = tstatus.rx_buffer_overruns;
-			link_node_status.messages_sent = tstatus.tx_message_count;
-			link_node_status.messages_received = tstatus.rx_message_count;
-			link_node_status.messages_lost = tstatus.rx_message_lost_count;
+		const telemetry_status_s &tstatus = _mavlink->telemetry_status();
+		link_node_status.tx_buf = 0; // % TODO
+		link_node_status.rx_buf = 0; // % TODO
+		link_node_status.tx_rate = tstatus.tx_rate_avg;
+		link_node_status.rx_rate = tstatus.rx_rate_avg;
+		link_node_status.rx_parse_err = tstatus.rx_parse_errors;
+		link_node_status.tx_overflows = tstatus.tx_buffer_overruns;
+		link_node_status.rx_overflows = tstatus.rx_buffer_overruns;
+		link_node_status.messages_sent = tstatus.tx_message_count;
+		link_node_status.messages_received = tstatus.rx_message_count;
+		link_node_status.messages_lost = tstatus.rx_message_lost_count;
 
-			link_node_status.timestamp = hrt_absolute_time();
+		link_node_status.timestamp = hrt_absolute_time();
 
-			mavlink_msg_link_node_status_send_struct(_mavlink->get_channel(), &link_node_status);
+		mavlink_msg_link_node_status_send_struct(_mavlink->get_channel(), &link_node_status);
 
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 };
 

--- a/src/modules/mavlink/streams/STATUSTEXT.hpp
+++ b/src/modules/mavlink/streams/STATUSTEXT.hpp
@@ -69,56 +69,53 @@ private:
 	bool send() override
 	{
 		if (_mavlink->is_connected()) {
-			while (_mavlink_log_sub.updated() && (_mavlink->get_free_tx_buf() >= get_size())) {
+			const unsigned last_generation = _mavlink_log_sub.get_last_generation();
 
-				const unsigned last_generation = _mavlink_log_sub.get_last_generation();
+			mavlink_log_s mavlink_log;
 
-				mavlink_log_s mavlink_log;
+			if (_mavlink_log_sub.update(&mavlink_log)) {
+				// don't send stale messages
+				if (hrt_elapsed_time(&mavlink_log.timestamp) < 2_s) {
 
-				if (_mavlink_log_sub.update(&mavlink_log)) {
-					// don't send stale messages
-					if (hrt_elapsed_time(&mavlink_log.timestamp) < 2_s) {
-
-						if (_mavlink_log_sub.get_last_generation() != (last_generation + 1)) {
-							perf_count(_missed_msg_count_perf);
-							PX4_DEBUG("channel %d has missed %d mavlink log messages", _mavlink->get_channel(),
-								  perf_event_count(_missed_msg_count_perf));
-						}
-
-						mavlink_statustext_t msg{};
-						const char *text = mavlink_log.text;
-						constexpr unsigned max_chunk_size = sizeof(msg.text);
-						msg.severity = mavlink_log.severity;
-						msg.chunk_seq = 0;
-						msg.id = _id++;
-						unsigned text_size;
-
-						while ((text_size = strlen(text)) > 0) {
-							unsigned chunk_size = math::min(text_size, max_chunk_size);
-
-							if (chunk_size < max_chunk_size) {
-								memcpy(&msg.text[0], &text[0], chunk_size);
-								// pad with zeros
-								memset(&msg.text[0] + chunk_size, 0, max_chunk_size - chunk_size);
-
-							} else {
-								memcpy(&msg.text[0], &text[0], chunk_size);
-							}
-
-							mavlink_msg_statustext_send_struct(_mavlink->get_channel(), &msg);
-
-							if (text_size <= max_chunk_size) {
-								break;
-
-							} else {
-								text += max_chunk_size;
-							}
-
-							msg.chunk_seq += 1;
-						}
-
-						return true;
+					if (_mavlink_log_sub.get_last_generation() != (last_generation + 1)) {
+						perf_count(_missed_msg_count_perf);
+						PX4_DEBUG("channel %d has missed %d mavlink log messages", _mavlink->get_channel(),
+							  perf_event_count(_missed_msg_count_perf));
 					}
+
+					mavlink_statustext_t msg{};
+					const char *text = mavlink_log.text;
+					constexpr unsigned max_chunk_size = sizeof(msg.text);
+					msg.severity = mavlink_log.severity;
+					msg.chunk_seq = 0;
+					msg.id = _id++;
+					unsigned text_size;
+
+					while ((text_size = strlen(text)) > 0) {
+						unsigned chunk_size = math::min(text_size, max_chunk_size);
+
+						if (chunk_size < max_chunk_size) {
+							memcpy(&msg.text[0], &text[0], chunk_size);
+							// pad with zeros
+							memset(&msg.text[0] + chunk_size, 0, max_chunk_size - chunk_size);
+
+						} else {
+							memcpy(&msg.text[0], &text[0], chunk_size);
+						}
+
+						mavlink_msg_statustext_send_struct(_mavlink->get_channel(), &msg);
+
+						if (text_size <= max_chunk_size) {
+							break;
+
+						} else {
+							text += max_chunk_size;
+						}
+
+						msg.chunk_seq += 1;
+					}
+
+					return true;
 				}
 			}
 		}


### PR DESCRIPTION
 - only update rate multipler if streams, radio status, or tx error rate has changed
 - by default schedule main loop at 3x fastest stream
 - cleanup and optimize mavlink stream update

This can significantly reduce the default cpu usage of a mavlink instance.

##### master
```` Console
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                    8224 24.700   256/  512   0 (  0)  READY  3
 903 mavlink_if0                   396  1.958  1788/ 2728 100 (100)  READY  4
 908 mavlink_rcv_if0                80  0.395  1292/ 4560 175 (175)  w:sem  4
1112 mavlink_if1                  1573  7.682  1876/ 2824 100 (100)  w:sig  4
1114 mavlink_rcv_if1               102  0.506  1316/ 4560 175 (175)  w:sem  4

Processes: 28 total, 11 running, 17 sleeping
CPU usage: 72.86% tasks, 2.44% sched, 24.70% idle
DMA Memory: 5120 total, 1536 used 1536 peak
Uptime: 30.860s total, 8.225s idle

nsh> mavlink status

instance #0:
        mavlink chan: #0
        type:           RADIO Link
          rssi:         20
          remote rssi:  0
          txbuf:        100
          noise:        19
          remote noise: 0
          rx errors:    0
          fixed:        0
        flow control: ON
        rates:
          tx: 496.0 B/s
          txerr: 0.0 B/s
          tx rate mult: 0.456
          tx rate max: 1200 B/s
          rx: 17.0 B/s
          rx loss: 0.0%
        Received Messages:
          sysid: 51, compid: 68, Total: 59 (lost: 0)
        FTP enabled: YES, TX enabled: YES
        mode: Normal
        MAVLink version: 1
        transport protocol: serial (/dev/ttyS1 @57600)

instance #1:
        GCS heartbeat valid
        mavlink chan: #1
        type:           USB CDC
        flow control: ON
        rates:
          tx: 21695.6 B/s
          txerr: 0.0 B/s
          tx rate mult: 1.000
          tx rate max: 800000 B/s
          rx: 620.8 B/s
          rx loss: 0.0%
        Received Messages:
          sysid:255, compid:190, Total: 1541 (lost: 0)
        FTP enabled: YES, TX enabled: YES
        mode: Config
        MAVLink version: 2
        transport protocol: serial (/dev/ttyACM0 @2000000)
        ping statistics:
          last: 1.63 ms
          mean: 1.11 ms
          max: 9.70 ms
          min: 0.18 ms
          dropped packets: 0
````

#### PR
``` Console
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                    6146 29.527   256/  512   0 (  0)  READY  3
 903 mavlink_if0                    73  0.861  1876/ 2728 100 (100)  w:sig  4
 908 mavlink_rcv_if0                34  0.388  1284/ 4560 175 (175)  w:sem  4
1108 mavlink_if1                   323  3.790  1852/ 2824 100 (100)  w:sig  4
1110 mavlink_rcv_if1                43  0.520  1396/ 4560 175 (175)  w:sem  4

Processes: 28 total, 9 running, 19 sleeping
CPU usage: 68.11% tasks, 2.36% sched, 29.53% idle
DMA Memory: 5120 total, 1536 used 2048 peak
Uptime: 19.769s total, 6.147s idle

nsh> mavlink status

instance #0:
        mavlink chan: #0
        type:           RADIO Link
          rssi:         24
          remote rssi:  0
          txbuf:        88
          noise:        16
          remote noise: 0
          rx errors:    0
          fixed:        0
        flow control: ON
        rates:
          tx: 1146.2 B/s
          txerr: 0.0 B/s
          tx rate mult: 0.456
          tx rate max: 1200 B/s
          rx: 33.9 B/s
          rx loss: 0.0%
        Received Messages:
          sysid: 51, compid: 68, Total: 20 (lost: 0)
        FTP enabled: YES, TX enabled: YES
        mode: Normal
        MAVLink version: 1
        transport protocol: serial (/dev/ttyS1 @57600)

instance #1:
        GCS heartbeat valid
        mavlink chan: #1
        type:           USB CDC
        flow control: ON
        rates:
          tx: 21520.5 B/s
          txerr: 0.0 B/s
          tx rate mult: 1.000
          tx rate max: 800000 B/s
          rx: 616.7 B/s
          rx loss: 0.0%
        Received Messages:
          sysid:255, compid:190, Total: 530 (lost: 0)
        FTP enabled: YES, TX enabled: YES
        mode: Config
        MAVLink version: 2
        transport protocol: serial (/dev/ttyACM0 @2000000)
        ping statistics:
          last: 1.64 ms
          mean: 1.17 ms
          max: 5.01 ms
          min: 0.25 ms
          dropped packets: 0


```
