### PR TITLE
add ability to disable board sensors

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -369,34 +369,32 @@ else
 	#
 	if param greater SYS_HITL 0
 	then
-		if param compare SYS_HITL 3
-		then
-			. ${R}etc/init.d/rc.sensors
-			commander start
-		else
-			set OUTPUT_MODE hil
-			sensors start -h
-			commander start -h
-			# disable GPS
-			param set GPS_1_CONFIG 0
+		set OUTPUT_MODE hil
+		sensors start -h
+		commander start -h
+		# disable GPS
+		param set GPS_1_CONFIG 0
 
-			# start the simulator in hardware if needed
-			if param compare SYS_HITL 2
-			then
-				sih start
-			fi
+		# start the simulator in hardware if needed
+		if param compare SYS_HITL 2
+		then
+			sih start
 		fi
+
 	else
 		#
 		# board sensors: rc.sensors
 		#
-		set BOARD_RC_SENSORS ${R}etc/init.d/rc.board_sensors
-		if [ -f $BOARD_RC_SENSORS ]
+		if param compare -s SYS_BOARD_SENS 1
 		then
-			echo "Board sensors: ${BOARD_RC_SENSORS}"
-			. $BOARD_RC_SENSORS
+			set BOARD_RC_SENSORS ${R}etc/init.d/rc.board_sensors
+			if [ -f $BOARD_RC_SENSORS ]
+			then
+				echo "Board sensors: ${BOARD_RC_SENSORS}"
+				. $BOARD_RC_SENSORS
+			fi
+			unset BOARD_RC_SENSORS
 		fi
-		unset BOARD_RC_SENSORS
 
 		. ${R}etc/init.d/rc.sensors
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -369,18 +369,23 @@ else
 	#
 	if param greater SYS_HITL 0
 	then
-		set OUTPUT_MODE hil
-		sensors start -h
-		commander start -h
-		# disable GPS
-		param set GPS_1_CONFIG 0
-
-		# start the simulator in hardware if needed
-		if param compare SYS_HITL 2
+		if param compare SYS_HITL 3
 		then
-			sih start
-		fi
+			. ${R}etc/init.d/rc.sensors
+			commander start
+		else
+			set OUTPUT_MODE hil
+			sensors start -h
+			commander start -h
+			# disable GPS
+			param set GPS_1_CONFIG 0
 
+			# start the simulator in hardware if needed
+			if param compare SYS_HITL 2
+			then
+				sih start
+			fi
+		fi
 	else
 		#
 		# board sensors: rc.sensors

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -84,6 +84,20 @@ PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
 PARAM_DEFINE_INT32(SYS_HITL, 0);
 
 /**
+ * Enable board sensors on next boot
+ *
+ * While enabled the system will boot with enabled board sensors.
+ * When disabled the system will boot with disabled board sensors.
+ *
+ * @value 0 board sensors disabled
+ * @value 1 board sensors enabled
+ * @reboot_required true
+ *
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_BOARD_SENS, 1);
+
+/**
  * Set multicopter estimator group
  *
  * Set the group of estimators used for multicopters and VTOLs


### PR DESCRIPTION
**Describe problem solved by this pull request**
For HITL simulators it is necessary to disable board sensors. At that moment using `SYS_HITL=1` parameter you may do it, but it will also set output mode, sensors and commander to the hitl mode that is not what we need for non mavlink based hitl simulators such as uavcan hitl in my case.
Below is how it works now:
```bash
if param greater SYS_HITL 0
then
	set OUTPUT_MODE hil
	sensors start -h
	commander start -h
	...
```
It would be nice to have some way to simply disable all board sensors without additional actions.

**Describe your solution**
By this PR I would like to start a discussion about extending `SYS_HITL` params possible states. As an example it might be `DISABLE_BOARD_SENSORS`, but `UAVCAN_HITL` is suitable as well.
Here I simply modified the rcS file by adding the new possible state handler.

**Describe possible alternatives**
I have not discussed with anybody about possible ways to disable board sensors, so it is possible that I missed more easier way to do it. If so, I would appreciate if somebody notice this way. Before adding this state I used to manually comment corresponded board file to disable all sensors, but it was clearly not the way how it may work with clean PX4. 

**Test data / coverage**
Here is an example of flight with uavcan hitl simulator: https://review.px4.io/plot_app?log=baefe706-04b8-4fca-8564-5ed1a981d5e9 with SYS_HITL=3.
