### PR TITLE
Add imbalanced propeller check to failure detector

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -75,6 +75,7 @@ set(msg_files
 	estimator_status_flags.msg
 	event.msg
 	follow_target.msg
+	failure_detector_status.msg
 	generator_status.msg
 	geofence_result.msg
 	gimbal_device_attitude_status.msg

--- a/msg/failure_detector_status.msg
+++ b/msg/failure_detector_status.msg
@@ -1,16 +1,13 @@
 uint64 timestamp                    # time since system start (microseconds)
 
 # FailureDetector status
-uint8 FAILURE_NONE = 0
-uint8 FAILURE_ROLL = 1              # (1 << 0)
-uint8 FAILURE_PITCH = 2             # (1 << 1)
-uint8 FAILURE_ALT = 4               # (1 << 2)
-uint8 FAILURE_EXT = 8               # (1 << 3)
-uint8 FAILURE_ARM_ESC = 16          # (1 << 4)
-uint8 FAILURE_HIGH_WIND = 32        # (1 << 5)
-uint8 FAILURE_BATTERY = 64          # (1 << 6)
-uint8 FAILURE_IMBALANCED_PROP = 128 # (1 << 7)
-
-uint8 failure_status                # Bitmask containing FailureDetector status
+bool fd_roll
+bool fd_pitch
+bool fd_alt
+bool fd_ext
+bool fd_arm_escs
+bool fd_high_wind
+bool fd_battery
+bool fd_imbalanced_prop
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)

--- a/msg/failure_detector_status.msg
+++ b/msg/failure_detector_status.msg
@@ -1,0 +1,16 @@
+uint64 timestamp                    # time since system start (microseconds)
+
+# FailureDetector status
+uint8 FAILURE_NONE = 0
+uint8 FAILURE_ROLL = 1              # (1 << 0)
+uint8 FAILURE_PITCH = 2             # (1 << 1)
+uint8 FAILURE_ALT = 4               # (1 << 2)
+uint8 FAILURE_EXT = 8               # (1 << 3)
+uint8 FAILURE_ARM_ESC = 16          # (1 << 4)
+uint8 FAILURE_HIGH_WIND = 32        # (1 << 5)
+uint8 FAILURE_BATTERY = 64          # (1 << 6)
+uint8 FAILURE_IMBALANCED_PROP = 128 # (1 << 7)
+
+uint8 failure_status                # Bitmask containing FailureDetector status
+
+float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)

--- a/msg/vehicle_imu_status.msg
+++ b/msg/vehicle_imu_status.msg
@@ -20,6 +20,7 @@ float32 gyro_coning_vibration   # Level of coning vibration in the IMU delta ang
 
 float32[3] mean_accel           # average accelerometer readings since last publication
 float32[3] mean_gyro            # average gyroscope readings since last publication
+float32[3] var_accel            # average accelerometer variance since last publication
 
 float32 temperature_accel
 float32 temperature_gyro

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -17,6 +17,9 @@ uint8 FAILURE_PITCH = 2	        # (1 << 1)
 uint8 FAILURE_ALT = 4 	        # (1 << 2)
 uint8 FAILURE_EXT = 8 	        # (1 << 3)
 uint8 FAILURE_ARM_ESC = 16      # (1 << 4)
+uint8 FAILURE_HIGH_WIND = 32        # (1 << 5)
+uint8 FAILURE_BATTERY = 64          # (1 << 6)
+uint8 FAILURE_IMBALANCED_PROP = 128 # (1 << 7)
 
 # HIL
 uint8 HIL_STATE_OFF = 0

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2607,11 +2607,12 @@ Commander::run()
 
 		/* Check for failure detector status */
 		if (_failure_detector.update(_status, _vehicle_control_mode)) {
-			_status.failure_detector_status = _failure_detector.getStatus();
+			_status.failure_detector_status = _failure_detector.getStatus().value;
+			auto fd_status_flags = _failure_detector.getStatusFlags();
 			_status_changed = true;
 
 			if (_armed.armed) {
-				if (_status.failure_detector_status & vehicle_status_s::FAILURE_ARM_ESC) {
+				if (fd_status_flags.arm_escs) {
 					// 500ms is the PWM spoolup time. Within this timeframe controllers are not affecting actuator_outputs
 					if (hrt_elapsed_time(&_status.armed_time) < 500_ms) {
 						disarm(arm_disarm_reason_t::failure_detector);
@@ -2620,8 +2621,7 @@ Commander::run()
 					}
 				}
 
-				if (_status.failure_detector_status & (vehicle_status_s::FAILURE_ROLL | vehicle_status_s::FAILURE_PITCH |
-								       vehicle_status_s::FAILURE_ALT | vehicle_status_s::FAILURE_EXT)) {
+				if (fd_status_flags.roll || fd_status_flags.pitch || fd_status_flags.alt || fd_status_flags.ext) {
 					const bool is_right_after_takeoff = hrt_elapsed_time(&_status.takeoff_time) < (1_s * _param_com_lkdown_tko.get());
 
 					if (is_right_after_takeoff && !_lockdown_triggered) {
@@ -2661,7 +2661,7 @@ Commander::run()
 					}
 				}
 
-				if ((_status.failure_detector_status & vehicle_status_s::FAILURE_IMBALANCED_PROP)
+				if (fd_status_flags.imbalanced_prop
 				    && !_imbalanced_propeller_check_triggered) {
 					_status_changed = true;
 					_imbalanced_propeller_check_triggered = true;
@@ -2843,7 +2843,14 @@ Commander::run()
 			/* publish failure_detector data */
 			failure_detector_status_s fd_status{};
 			fd_status.timestamp = hrt_absolute_time();
-			fd_status.failure_status = _failure_detector.getStatus();
+			fd_status.fd_roll = _failure_detector.getStatusFlags().roll;
+			fd_status.fd_pitch = _failure_detector.getStatusFlags().pitch;
+			fd_status.fd_alt = _failure_detector.getStatusFlags().alt;
+			fd_status.fd_ext = _failure_detector.getStatusFlags().ext;
+			fd_status.fd_arm_escs = _failure_detector.getStatusFlags().arm_escs;
+			fd_status.fd_high_wind = _failure_detector.getStatusFlags().high_wind;
+			fd_status.fd_battery = _failure_detector.getStatusFlags().battery;
+			fd_status.fd_imbalanced_prop = _failure_detector.getStatusFlags().imbalanced_prop;
 			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
 			_failure_detector_status_pub.publish(fd_status);
 		}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2776,7 +2776,7 @@ Commander::run()
 			_failsafe_old = _status.failsafe;
 		}
 
-		/* publish states (armed, control_mode, vehicle_status, commander_state, vehicle_status_flags) at 2 Hz or immediately when changed */
+		/* publish states (armed, control_mode, vehicle_status, commander_state, vehicle_status_flags, failure_detector_status) at 2 Hz or immediately when changed */
 		if (hrt_elapsed_time(&_status.timestamp) >= 500_ms || _status_changed || nav_state_changed) {
 
 			update_control_mode();
@@ -2839,6 +2839,13 @@ Commander::run()
 			/* publish vehicle_status_flags */
 			_status_flags.timestamp = hrt_absolute_time();
 			_vehicle_status_flags_pub.publish(_status_flags);
+
+			/* publish failure_detector data */
+			failure_detector_status_s fd_status{};
+			fd_status.timestamp = hrt_absolute_time();
+			fd_status.failure_status = _failure_detector.getStatus();
+			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
+			_failure_detector_status_pub.publish(fd_status);
 		}
 
 		/* play arming and battery warning tunes */

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2660,6 +2660,14 @@ Commander::run()
 						send_parachute_command();
 					}
 				}
+
+				if ((_status.failure_detector_status & vehicle_status_s::FAILURE_IMBALANCED_PROP)
+				    && !_imbalanced_propeller_check_triggered) {
+					_status_changed = true;
+					_imbalanced_propeller_check_triggered = true;
+					imbalanced_prop_failsafe(&_mavlink_log_pub, _status, _status_flags, &_internal_state,
+								 (imbalanced_propeller_action_t)_param_com_imb_prop_act.get());
+				}
 			}
 		}
 
@@ -2729,6 +2737,7 @@ Commander::run()
 		if (!_armed.armed) {
 			/* Reset the flag if disarmed. */
 			_have_taken_off_since_arming = false;
+			_imbalanced_propeller_check_triggered = false;
 		}
 
 		/* now set navigation state according to failsafe and main state */

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -211,6 +211,7 @@ private:
 		(ParamInt<px4::params::COM_POS_FS_GAIN>) _param_com_pos_fs_gain,
 
 		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _param_com_low_bat_act,
+		(ParamInt<px4::params::COM_IMB_PROP_ACT>) _param_com_imb_prop_act,
 		(ParamFloat<px4::params::COM_DISARM_LAND>) _param_com_disarm_land,
 		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_preflight,
 
@@ -322,6 +323,7 @@ private:
 	FailureDetector	_failure_detector;
 	bool		_flight_termination_triggered{false};
 	bool		_lockdown_triggered{false};
+	bool            _imbalanced_propeller_check_triggered{false};
 
 
 	hrt_abstime	_datalink_last_heartbeat_gcs{0};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -49,6 +49,7 @@
 // publications
 #include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/failure_detector_status.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/landing_gear.h>
 #include <uORB/topics/test_motor.h>
@@ -433,6 +434,7 @@ private:
 	// Publications
 	uORB::Publication<actuator_armed_s>			_armed_pub{ORB_ID(actuator_armed)};
 	uORB::Publication<commander_state_s>			_commander_state_pub{ORB_ID(commander_state)};
+	uORB::Publication<failure_detector_status_s>		_failure_detector_status_pub{ORB_ID(failure_detector_status)};
 	uORB::Publication<test_motor_s>				_test_motor_pub{ORB_ID(test_motor)};
 	uORB::Publication<vehicle_control_mode_s>		_control_mode_pub{ORB_ID(vehicle_control_mode)};
 	uORB::Publication<vehicle_status_flags_s>		_vehicle_status_flags_pub{ORB_ID(vehicle_status_flags)};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -340,6 +340,23 @@ PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
 PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
 
 /**
+ * Imbalanced propeller failsafe mode
+ *
+ * Action the system takes when an imbalanced propeller is detected by the failure detector.
+ * See also FD_IMB_PROP_THR to set the failure threshold.
+ *
+ * @group Commander
+ *
+ * @value -1 Disabled
+ * @value 0 Warning
+ * @value 1 Return
+ * @value 2 Land
+ * @decimal 0
+ * @increment 1
+ */
+PARAM_DEFINE_INT32(COM_IMB_PROP_ACT, 0);
+
+/**
  * Time-out to wait when offboard connection is lost before triggering offboard lost action.
  *
  * See COM_OBL_ACT and COM_OBL_RC_ACT to configure action.

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -141,3 +141,18 @@ PARAM_DEFINE_INT32(FD_EXT_ATS_TRIG, 1900);
  * @group Failure Detector
  */
 PARAM_DEFINE_INT32(FD_ESCS_EN, 1);
+
+/**
+ * Imbalanced propeller check threshold
+ *
+ * Value at which the imbalanced propeller metric (based on horizontal and
+ * vertical acceleration variance) triggers a failure
+ *
+ * Setting this value to 0 disables the feature.
+ *
+ * @min 0
+ * @max 1000
+ * @increment 1
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_IMB_PROP_THR, 30);

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -145,4 +145,17 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		      const vehicle_status_flags_s &status_flags, commander_state_s &internal_state, const uint8_t battery_warning,
 		      const low_battery_action_t low_bat_action);
 
+
+// COM_IMB_PROP_ACT parameter values
+enum class imbalanced_propeller_action_t {
+	DISABLED = -1,
+	WARNING = 0,
+	RETURN = 1,
+	LAND = 2
+};
+
+void imbalanced_prop_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
+			      const vehicle_status_flags_s &status_flags, commander_state_s *internal_state,
+			      const imbalanced_propeller_action_t failsafe_action);
+
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -60,6 +60,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("commander_state");
 	add_topic("cpuload");
 	add_topic("esc_status", 250);
+	add_topic("failure_detector_status", 100);
 	add_topic("follow_target", 500);
 	add_topic("generator_status");
 	add_topic("heater_status");

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -83,6 +83,7 @@ private:
 	void UpdateIntegratorConfiguration();
 	void UpdateAccelVibrationMetrics(const matrix::Vector3f &acceleration);
 	void UpdateGyroVibrationMetrics(const matrix::Vector3f &angular_velocity);
+	void UpdateAccelSquaredErrorSum(const matrix::Vector3f &acceleration);
 
 	uORB::PublicationMulti<vehicle_imu_s> _vehicle_imu_pub{ORB_ID(vehicle_imu)};
 	uORB::PublicationMulti<vehicle_imu_status_s> _vehicle_imu_status_pub{ORB_ID(vehicle_imu_status)};
@@ -118,6 +119,7 @@ private:
 	unsigned _accel_last_generation{0};
 	unsigned _gyro_last_generation{0};
 
+	matrix::Vector3f _accel_squared_error_sum{};
 	matrix::Vector3f _accel_sum{};
 	matrix::Vector3f _gyro_sum{};
 	int _accel_sum_count{0};


### PR DESCRIPTION
**Describe problem solved by this pull request**
1. A lot of new users are not aware that their system has a lot of vibrations due to imbalanced propellers
2. A drone with a damaged propeller should usually not continue its mission like if nothing happened.

**Describe your solution**
Assuming that the rotors are spinning in the xy-plane, a metric based on the variance of accelerometer readings is used to detect an imbalanced rotor using the following formula:
`Imbalanced propeller detected if (var(x) + var(x) - var(z)) > threshold`

**Describe possible alternatives**
We tried other methods using the ratio between XY and Z, but the one used in this PR gave the best results.

**Test data / coverage**
Tested on many multirotors and standard VTOL planes.

**Additional context**
The threshold should be robust enough on most frames to not trigger false positives but need to be tuned on each airframe to make the trigger more sensitive if needed.
