### PR TITLE
Moving average filter

### DIFF
--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -35,11 +35,13 @@ px4_add_library(mathlib
 	math/test/test.cpp
 	math/filter/LowPassFilter2p.hpp
 	math/filter/MedianFilter.hpp
+	math/filter/MovingAverage.hpp
 	math/filter/NotchFilter.hpp
 )
 
 px4_add_unit_gtest(SRC math/test/LowPassFilter2pVector3fTest.cpp LINKLIBS mathlib)
 px4_add_unit_gtest(SRC math/test/AlphaFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/MedianFilterTest.cpp)
+px4_add_unit_gtest(SRC math/test/MovingAverageTest.cpp)
 px4_add_unit_gtest(SRC math/test/NotchFilterTest.cpp)
 px4_add_unit_gtest(SRC math/FunctionsTest.cpp)

--- a/src/lib/mathlib/math/filter/MedianFilter.hpp
+++ b/src/lib/mathlib/math/filter/MedianFilter.hpp
@@ -48,7 +48,7 @@
 namespace math
 {
 
-template<typename T, int WINDOW = 3>
+template<typename T, uint32_t WINDOW = 3>
 class MedianFilter
 {
 public:
@@ -59,8 +59,8 @@ public:
 
 	void insert(const T &sample)
 	{
-		_head = (_head + 1) % WINDOW;
 		_buffer[_head] = sample;
+		_head = (_head + 1) % WINDOW;
 	}
 
 	T median()
@@ -78,6 +78,13 @@ public:
 		return median();
 	}
 
+	void reset(const T &sample)
+	{
+		for (uint32_t i = 0; i < WINDOW; i++) {
+			_buffer[i] = sample;
+		}
+	}
+
 private:
 
 	static int cmp(const void *a, const void *b)
@@ -86,7 +93,7 @@ private:
 	}
 
 	T _buffer[WINDOW] {};
-	uint8_t _head{0};
+	uint32_t _head{0};
 };
 
 } // namespace math

--- a/src/lib/mathlib/math/filter/MovingAverage.hpp
+++ b/src/lib/mathlib/math/filter/MovingAverage.hpp
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/*
+ * @file MovingAverage.hpp
+ *
+ * @brief Implementation of a moving average of fixed window size.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+template<typename T, uint32_t WINDOW = 3>
+class MovingAverage
+{
+public:
+	static_assert(WINDOW >= 2, "Window must be two or more samples");
+
+	MovingAverage() = default;
+
+	void insert(const T &sample)
+	{
+		_buffer[_head] = sample;
+		_head = (_head + 1) % WINDOW;
+	}
+
+	T getState()
+	{
+		T sum{0};
+
+		for (uint32_t i = 0; i < WINDOW; i++) {
+			sum += _buffer[i];
+		}
+
+		return sum / static_cast<T>(WINDOW);
+	}
+
+	T apply(const T &sample)
+	{
+		insert(sample);
+		return getState();
+	}
+
+	void reset(const T &sample)
+	{
+		for (uint32_t i = 0; i < WINDOW; i++) {
+			_buffer[i] = sample;
+		}
+	}
+
+private:
+	T _buffer[WINDOW] {};
+	uint32_t _head{0};
+};

--- a/src/lib/mathlib/math/test/AlphaFilterTest.cpp
+++ b/src/lib/mathlib/math/test/AlphaFilterTest.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file test_AlphaFilter.cpp
+ * @file AlphaFilterTest.cpp
  *
  * @brief Unit tests for the alpha filter class
  */

--- a/src/lib/mathlib/math/test/MovingAverageTest.cpp
+++ b/src/lib/mathlib/math/test/MovingAverageTest.cpp
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <lib/mathlib/math/filter/MovingAverage.hpp>
+
+TEST(MovingAverageTest, initializeToZero)
+{
+	MovingAverage<float> filter{};
+	EXPECT_FLOAT_EQ(filter.getState(), 0.f);
+}
+
+TEST(MovingAverageTest, simpleAverage)
+{
+	MovingAverage<float> filter{};
+	EXPECT_FLOAT_EQ(filter.apply(1.f), 1.f / 3.f);
+	EXPECT_FLOAT_EQ(filter.apply(2.f), 1.f);
+	EXPECT_FLOAT_EQ(filter.apply(3.f), 2.f);
+	EXPECT_FLOAT_EQ(filter.apply(4.f), 3.f);
+}


### PR DESCRIPTION
**Describe problem solved by this pull request**
When investigating what filtering would make the most sense in the detection for moving sticks in https://github.com/PX4/PX4-Autopilot/pull/17404 I thought about a moving average which is similar to a median filter but has a bit different use cases. So I quickly wrote up the library. I want to contribute it even if I don't use it yet since I think other places of PX4 could reuse it as well.

I also adapted the median filter a bit, please correct if I misunderstood something.

**Test data / coverage**
I added minimal unit testing to make sure the filter does what it should.
