### PR TITLE
Filling accel value in SITL related topic

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -565,6 +565,8 @@ void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg
 		hil_lpos.vy = hil_state.vy / 100.0f;
 		hil_lpos.vz = hil_state.vz / 100.0f;
 		matrix::Eulerf euler = matrix::Quatf(hil_attitude.q);
+	        matrix::Vector3f acc(hil_state.xacc / 1000.f, hil_state.yacc / 1000.f, hil_state.zacc / 1000.f);
+	        acc = matrix::Quatf(hil_state.attitude_quaternion).conjugate(acc);
 		hil_lpos.ax = acc(0);
 		hil_lpos.ay = acc(1);
 		hil_lpos.az = acc(2);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -533,6 +533,9 @@ void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg
 		// always publish ground truth attitude message
 		_gpos_ground_truth_pub.publish(hil_gpos);
 	}
+	
+	matrix::Vector3f acc(hil_state.xacc / 1000.f, hil_state.yacc / 1000.f, hil_state.zacc / 1000.f);
+	acc = matrix::Quatf(hil_state.attitude_quaternion).conjugate(acc);
 
 	/* local position */
 	vehicle_local_position_s hil_lpos{};
@@ -562,9 +565,9 @@ void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg
 		hil_lpos.vy = hil_state.vy / 100.0f;
 		hil_lpos.vz = hil_state.vz / 100.0f;
 		matrix::Eulerf euler = matrix::Quatf(hil_attitude.q);
-		hil_lpos.ax = hil_state.xacc * CONSTANTS_ONE_G / 1000.0f;
-		hil_lpos.ay = hil_state.yacc * CONSTANTS_ONE_G / 1000.0f;
-		hil_lpos.az = hil_state.zacc * CONSTANTS_ONE_G / 1000.0f;
+		hil_lpos.ax = acc(0);
+		hil_lpos.ay = acc(1);
+		hil_lpos.az = acc(2);
 		hil_lpos.heading = euler.psi();
 		hil_lpos.xy_global = true;
 		hil_lpos.z_global = true;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -562,6 +562,9 @@ void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg
 		hil_lpos.vy = hil_state.vy / 100.0f;
 		hil_lpos.vz = hil_state.vz / 100.0f;
 		matrix::Eulerf euler = matrix::Quatf(hil_attitude.q);
+		hil_lpos.ax = hil_state.xacc * CONSTANTS_ONE_G / 1000.0f;
+		hil_lpos.ay = hil_state.yacc * CONSTANTS_ONE_G / 1000.0f;
+		hil_lpos.az = hil_state.zacc * CONSTANTS_ONE_G / 1000.0f;
 		hil_lpos.heading = euler.psi();
 		hil_lpos.xy_global = true;
 		hil_lpos.z_global = true;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -533,9 +533,6 @@ void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg
 		// always publish ground truth attitude message
 		_gpos_ground_truth_pub.publish(hil_gpos);
 	}
-	
-	matrix::Vector3f acc(hil_state.xacc / 1000.f, hil_state.yacc / 1000.f, hil_state.zacc / 1000.f);
-	acc = matrix::Quatf(hil_state.attitude_quaternion).conjugate(acc);
 
 	/* local position */
 	vehicle_local_position_s hil_lpos{};

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -562,8 +562,7 @@ void Simulator::handle_message_hil_state_quaternion(const mavlink_message_t *msg
 		hil_lpos.vy = hil_state.vy / 100.0f;
 		hil_lpos.vz = hil_state.vz / 100.0f;
 		matrix::Eulerf euler = matrix::Quatf(hil_attitude.q);
-	        matrix::Vector3f acc(hil_state.xacc / 1000.f, hil_state.yacc / 1000.f, hil_state.zacc / 1000.f);
-	        acc = matrix::Quatf(hil_state.attitude_quaternion).conjugate(acc);
+		matrix::Vector3f acc(hil_state.xacc / 1000.f, hil_state.yacc / 1000.f,  hil_state.zacc / 1000.f);
 		hil_lpos.ax = acc(0);
 		hil_lpos.ay = acc(1);
 		hil_lpos.az = acc(2);


### PR DESCRIPTION
**Describe problem solved by this pull request**
When running PX4 in SITL (JMAVSim, Gazebo), the logger is expected to record the vehicle's ground-truth state in topic vehicle_local_position_groundtruth.
This PR will fix the missing acceleration data in this topic by adding them to the output message.
Related issue: #18527 

**Describe your solution**
Retrieve the acceleration value, convert it to NED frame by quaternion, and feed it to output.

**Describe possible alternatives**
- Retrieve Gee by global position from simulator
- Retrieve frame convention from simulator
- Calculation adjustment

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.
I test this PR with `make px4_sitl gazebo_iris_mcmillan_airfield`
Logged data in `vehicle_local_position_groundtruth` topics seems good compared with previous full 0 output, but the default `CONSTANT_ONE_G` may slightly deviated from the actual gravity.

----Update@11.16----
Additional test on both `gazebo` and `JMAVSim`.
It seems like `gazebo` use body frame for linear acceleration, while `JMAVSim` keeps the NED convention for accel.
So I move the attitude conversion to [gazebo_mavlink_interfaces.cpp](https://github.com/PX4/PX4-SITL_gazebo/pull/827/files)
We also remove the unnecessary `CONSTANT_ONE_G`.
