### PR TITLE
[Control Allocation] Publish saturation status

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -43,6 +43,7 @@ set(msg_files
 	actuator_motors.msg
 	actuator_outputs.msg
 	actuator_servos.msg
+	actuator_saturation_status.msg
 	adc_report.msg
 	airspeed.msg
 	airspeed_validated.msg

--- a/msg/actuator_saturation_status.msg
+++ b/msg/actuator_saturation_status.msg
@@ -1,0 +1,17 @@
+uint64 timestamp		# time since system start (microseconds)
+
+bool valid        # 0 - true when the saturation status is used
+bool act_pos      # 1 - true when any actuator has saturated in the positive direction
+bool act_neg      # 2 - true when any actuator has saturated in the negative direction
+bool roll_pos     # 3 - true when a positive roll demand change will increase saturation
+bool roll_neg     # 4 - true when a negative roll demand change will increase saturation
+bool pitch_pos    # 5 - true when a positive pitch demand change will increase saturation
+bool pitch_neg    # 6 - true when a negative pitch demand change will increase saturation
+bool yaw_pos      # 7 - true when a positive yaw demand change will increase saturation
+bool yaw_neg      # 8 - true when a negative yaw demand change will increase saturation
+bool thrust_x_pos # 9 - true when a forward thrust demand change will increase saturation
+bool thrust_x_neg #10 - true when a backward thrust demand change will increase saturation
+bool thrust_y_pos #11 - true when a right thrust demand change will increase saturation
+bool thrust_y_neg #12 - true when a left thrust demand change will increase saturation
+bool thrust_z_pos #13 - true when a downward thrust demand change will increase saturation
+bool thrust_z_neg #14 - true when a upward thrust demand change will increase saturation

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.cpp
@@ -71,10 +71,11 @@ ControlAllocation::setActuatorSetpoint(
 	// Compute achieved control
 	_control_allocated = _effectiveness * _actuator_sp;
 
+	updateSaturationStatus();
 }
 
 void
-ControlAllocation::clipActuatorSetpoint(matrix::Vector<float, ControlAllocation::NUM_ACTUATORS> &actuator) const
+ControlAllocation::clipActuatorSetpoint(matrix::Vector<float, ControlAllocation::NUM_ACTUATORS> &actuator)
 {
 	for (int i = 0; i < _num_actuators; i++) {
 		if (_actuator_max(i) < _actuator_min(i)) {
@@ -82,11 +83,33 @@ ControlAllocation::clipActuatorSetpoint(matrix::Vector<float, ControlAllocation:
 
 		} else if (actuator(i) < _actuator_min(i)) {
 			actuator(i) = _actuator_min(i);
+			_saturation_status.flags.act_neg = true;
 
 		} else if (actuator(i) > _actuator_max(i)) {
 			actuator(i) = _actuator_max(i);
+			_saturation_status.flags.act_pos = true;
 		}
 	}
+}
+
+void
+ControlAllocation::updateSaturationStatus()
+{
+	const float tolerance = FLT_EPSILON;
+
+	_saturation_status.flags.valid = true;
+	_saturation_status.flags.roll_pos = _control_sp(0) > (_control_allocated(0) + tolerance);
+	_saturation_status.flags.roll_neg = _control_sp(0) < (_control_allocated(0) - tolerance);
+	_saturation_status.flags.pitch_pos = _control_sp(1) > (_control_allocated(1) + tolerance);
+	_saturation_status.flags.pitch_neg = _control_sp(1) < (_control_allocated(1) - tolerance);
+	_saturation_status.flags.yaw_pos = _control_sp(2) > (_control_allocated(2) + tolerance);
+	_saturation_status.flags.yaw_neg = _control_sp(2) < (_control_allocated(2) - tolerance);
+	_saturation_status.flags.thrust_x_pos = _control_sp(3) > (_control_allocated(3) + tolerance);
+	_saturation_status.flags.thrust_x_neg = _control_sp(3) < (_control_allocated(3) - tolerance);
+	_saturation_status.flags.thrust_y_pos = _control_sp(4) > (_control_allocated(4) + tolerance);
+	_saturation_status.flags.thrust_y_pos = _control_sp(4) > (_control_allocated(4) + tolerance);
+	_saturation_status.flags.thrust_z_neg = _control_sp(5) < (_control_allocated(5) - tolerance);
+	_saturation_status.flags.thrust_z_neg = _control_sp(5) < (_control_allocated(5) - tolerance);
 }
 
 matrix::Vector<float, ControlAllocation::NUM_ACTUATORS>

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -92,6 +92,27 @@ public:
 		THRUST_Z
 	};
 
+	union saturation_status_u {
+		struct {
+			uint16_t valid		: 1; // 0 - true when the saturation status is used
+			uint16_t act_pos	: 1; // 1 - true when any actuator has saturated in the positive direction
+			uint16_t act_neg	: 1; // 2 - true when any actuator has saturated in the negative direction
+			uint16_t roll_pos	: 1; // 3 - true when a positive roll demand change will increase saturation
+			uint16_t roll_neg	: 1; // 4 - true when a negative roll demand change will increase saturation
+			uint16_t pitch_pos	: 1; // 5 - true when a positive pitch demand change will increase saturation
+			uint16_t pitch_neg	: 1; // 6 - true when a negative pitch demand change will increase saturation
+			uint16_t yaw_pos	: 1; // 7 - true when a positive yaw demand change will increase saturation
+			uint16_t yaw_neg	: 1; // 8 - true when a negative yaw demand change will increase saturation
+			uint16_t thrust_x_pos	: 1; // 9 - true when a forward thrust demand change will increase saturation
+			uint16_t thrust_x_neg	: 1; //10 - true when a backward thrust demand change will increase saturation
+			uint16_t thrust_y_pos	: 1; //11 - true when a right thrust demand change will increase saturation
+			uint16_t thrust_y_neg	: 1; //12 - true when a left thrust demand change will increase saturation
+			uint16_t thrust_z_pos	: 1; //13 - true when a downward thrust demand change will increase saturation
+			uint16_t thrust_z_neg	: 1; //14 - true when a upward thrust demand change will increase saturation
+		} flags;
+		uint16_t value;
+	};
+
 	/**
 	 * Allocate control setpoint to actuators
 	 *
@@ -171,6 +192,20 @@ public:
 	const matrix::Vector<float, NUM_ACTUATORS> &getActuatorMax() const { return _actuator_max; }
 
 	/**
+	 * Get the saturation status union
+	 *
+	 * @return saturation_status union
+	 */
+	const saturation_status_u &getSaturationStatus() const { return _saturation_status; }
+
+	/**
+	 * Get the saturation status flags
+	 *
+	 * @return saturation_status flags (bitmask)
+	 */
+	const decltype(saturation_status_u::flags) &getSaturationStatusFlags() const { return _saturation_status.flags; }
+
+	/**
 	 * Set the current actuator setpoint.
 	 *
 	 * Use this when a new allocation method is started to initialize it properly.
@@ -188,7 +223,13 @@ public:
 	 *
 	 * @param actuator Actuator vector to clip
 	 */
-	void clipActuatorSetpoint(matrix::Vector<float, NUM_ACTUATORS> &actuator) const;
+	void clipActuatorSetpoint(matrix::Vector<float, NUM_ACTUATORS> &actuator);
+
+	/**
+	 * Set the saturation status flags given the desired
+	 * and allocated torques and forces.
+	 */
+	void updateSaturationStatus();
 
 	/**
 	 * Normalize the actuator setpoint between minimum and maximum values.
@@ -216,4 +257,6 @@ protected:
 	matrix::Vector<float, NUM_AXES> _control_allocated;  	//< Allocated control
 	matrix::Vector<float, NUM_AXES> _control_trim;  	//< Control at trim actuator values
 	int _num_actuators{0};
+
+	saturation_status_u _saturation_status{};
 };

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
@@ -109,6 +109,8 @@ float ControlAllocationSequentialDesaturation::computeDesaturationGain(const Act
 			if (k < k_min) { k_min = k; }
 
 			if (k > k_max) { k_max = k; }
+
+			_saturation_status.flags.act_neg = true;
 		}
 
 		if (actuator_sp(i) > _actuator_max(i)) {
@@ -117,6 +119,8 @@ float ControlAllocationSequentialDesaturation::computeDesaturationGain(const Act
 			if (k < k_min) { k_min = k; }
 
 			if (k > k_max) { k_max = k; }
+
+			_saturation_status.flags.act_pos = true;
 		}
 	}
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -60,10 +60,12 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/actuator_motors.h>
+#include <uORB/topics/actuator_saturation_status.h>
 #include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
+#include <uORB/topics/multirotor_motor_limits.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_torque_setpoint.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
@@ -110,6 +112,7 @@ private:
 
 	void publish_actuator_setpoint();
 	void publish_control_allocator_status();
+	void publish_actuator_saturation_status();
 
 	void publish_legacy_actuator_controls();
 	void publish_legacy_multirotor_motor_limits();
@@ -143,6 +146,9 @@ private:
 
 	uORB::Publication<actuator_motors_s>	_actuator_motors_pub{ORB_ID(actuator_motors)};
 	uORB::Publication<actuator_servos_s>	_actuator_servos_pub{ORB_ID(actuator_servos)};
+
+	uORB::Publication<multirotor_motor_limits_s> _multirotor_motor_limits_pub{ORB_ID(multirotor_motor_limits)};
+	uORB::Publication<actuator_saturation_status_s> _actuator_saturation_status_pub{ORB_ID(actuator_saturation_status)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -51,6 +51,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("actuator_controls_2", 100);
 	add_topic("actuator_controls_3", 100);
 	add_topic("actuator_controls_status_0", 300);
+	add_topic("actuator_saturation_status", 300);
 	add_topic("airspeed", 1000);
 	add_topic("airspeed_validated", 200);
 	add_topic("autotune_attitude_control_status", 100);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Actuator saturation status is required by the rate controllers to avoid integrator windup. The legacy MC mixer is publishing this information under `multirotor_motor_limits.msg` but is missing when using the new ControlAllocator module.

**Describe your solution**
Publish the legacy `multirotor_motor_limits.msg` and a new `actuator_saturation_status.msg` (which contain all axes) from the new ControlAllocator module.

**Test data / coverage**
Quick SITL test only

**Additional context**
We might also want to send the value of the saturation.
