### PR TITLE
Add typhoon h480 SITL target for running SITL Gazebo with Airsim

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6013_typhoon_h480_airsim
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6013_typhoon_h480_airsim
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# @name Typhoon H480 SITL
+#
+# @type Hexarotor x
+#
+
+. ${R}etc/init.d/rc.mc_defaults
+
+param set-default MC_PITCHRATE_P 0.0800
+param set-default MC_PITCHRATE_I 0.0400
+param set-default MC_PITCHRATE_D 0.0010
+param set-default MC_PITCH_P 9.0
+param set-default MC_ROLLRATE_P 0.0800
+param set-default MC_ROLLRATE_I 0.0400
+param set-default MC_ROLLRATE_D 0.0010
+param set-default MC_ROLL_P 9.0
+param set-default MPC_XY_VEL_I_ACC 4
+param set-default MPC_XY_VEL_P_ACC 3
+
+param set-default RTL_DESCEND_ALT 10
+
+param set-default TRIG_INTERFACE 3
+param set-default TRIG_MODE 4
+param set-default MNT_MODE_IN 4
+param set-default MNT_MODE_OUT 2
+param set-default MAV_PROTO_VER 2
+
+set MAV_TYPE 13
+
+set MIXER hexa_x

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6013_typhoon_h480_airsim.post
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6013_typhoon_h480_airsim.post
@@ -1,0 +1,10 @@
+
+mixer append /dev/pwm_output0 etc/mixers/mount_legs.aux.mix
+
+mavlink start -x -u 14558 -r 4000 -f -m onboard -o 14530 -p
+
+# shellcheck disable=SC2154
+mavlink stream -r 10 -s MOUNT_ORIENTATION -u $udp_gcs_port_local
+# shellcheck disable=SC2154
+mavlink stream -r 50 -s ATTITUDE_QUATERNION -u $udp_offboard_port_local
+mavlink stream -r 10 -s MOUNT_ORIENTATION -u $udp_offboard_port_local

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -79,4 +79,6 @@ px4_add_romfs_files(
 	6011_typhoon_h480.post
 	6012_typhoon_h480_ctrlalloc
 	6012_typhoon_h480_ctrlalloc.post
+	6013_typhoon_h480_airsim
+	6013_typhoon_h480_airsim.post
 )

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -149,6 +149,7 @@ set(models
 	tiltrotor
 	typhoon_h480
 	typhoon_h480_ctrlalloc
+	typhoon_h480_airsim
 	uuv_bluerov2_heavy
 	uuv_hippocampus
 )


### PR DESCRIPTION
**Describe problem solved by this pull request**
While the Gazebo environment is the most widely used environments for PX4 SITL simulation, the rendering quality of gazebo makes it hard to test vision based applications.

While [Microsoft/Airsim](https://github.com/microsoft/AirSim) solves this problem by using advanced game engines such as the Unreal Engine or Unity the physics Airsim can simulate are limited.
- Only multirotors are available, and none of the vehicles have gimbals
- Aerodynamic effects such as Fixedwing/VTOL vehicles are not available for PX4 SITL-Airsim

**Describe your solution**
We can use the rendering capabilities through airlib-unreal to render physical properties, while still using the physics modeled in Gazebo. 

Therefore, a `gazebo_airsim_plugin` is implemented. The plugin can be attached to a specific link that orients the camera in Airsim. The specific link can be defined in the sdf flile as the following.
```
    <plugin name='airsim_plugin' filename='libgazebo_airsim_plugin.so'>
      <robotNamespace/>
      <link_name>typhoon_h480::cgo3_camera_link</link_name>
    </plugin>
```
This plugin assumes that Airsim is running in "Computer Vision Mode". The configuration file of Airsim is as the following.
```
{
  "SeeDocsAt": "https://github.com/Microsoft/AirSim/blob/master/docs/settings.md",
  "SettingsVersion": 1.2,
  "SimMode": "ComputerVision"
}
```

A special model of a `typhoon_h480` is created to run the plugin. The plugin orients the camera in airsim to the same pose of the camera attached to the gimbal. 

**Test data / coverage**
One alternative solution is to add this plugin inside airsim, and keep the `typhoon_h480_airsim` model in this repository. One step required for this would be to add `GAZEBO_PLUGIN_PATH` to where the `gazebo_airsim_plugin` is built inside airsim.

**Testing**
```
make px4_sitl gazebo_typhoon_h480_airsim
```
[![GazeboAirsim](https://img.youtube.com/vi/dwvVRZZmTX0/0.jpg)](https://youtu.be/dwvVRZZmTX0 "Circular trajectory tracking")

[![GazeboAirsim](https://img.youtube.com/vi/eoL4pxmz0Bc/0.jpg)](https://youtu.be/eoL4pxmz0Bc "Circular trajectory tracking")


**Additional context**
- Depends on https://github.com/PX4/PX4-SITL_gazebo/pull/791