### PR TITLE
boards: modalai_fc-v2 fix bootloader board type

### DIFF
--- a/boards/modalai/fc-v2/src/hw_config.h
+++ b/boards/modalai/fc-v2/src/hw_config.h
@@ -71,7 +71,7 @@
 #define INTERFACE_USART                1
 #define INTERFACE_USART_CONFIG         "/dev/ttyS0,115200"
 #define BOOT_DELAY_ADDRESS             0x000001a0
-#define BOARD_TYPE                     53
+#define BOARD_TYPE                     41776
 #define _FLASH_KBYTES                  (*(uint32_t *)0x1FF1E880)
 #define BOARD_FLASH_SECTORS            (15)
 #define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)


### PR DESCRIPTION
https://github.com/PX4/PX4-Bootloader/blob/dce800bc455703e7132680eff45d5401eec945c3/board_types.txt#L34

@modaltb 