### PR TITLE
FW position controller: only allow switching to AUTO_ALTITDUE or AUTO_CLIMBRATE if  pos_sp_curr_valid

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -682,7 +682,8 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 	     _control_mode.flag_control_offboard_enabled) && pos_sp_curr_valid) {
 		_control_mode_current = FW_POSCTRL_MODE_AUTO;
 
-	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_climb_rate_enabled) {
+	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_climb_rate_enabled
+		   && pos_sp_curr_valid) {
 
 		// reset timer the first time we switch into this mode
 		if (_control_mode_current != FW_POSCTRL_MODE_AUTO_ALTITUDE && _control_mode_current != FW_POSCTRL_MODE_AUTO_CLIMBRATE) {


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/18573

