### PR TITLE
mavlink: Check target for mavlink shell

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1768,6 +1768,14 @@ MavlinkReceiver::handle_message_serial_control(mavlink_message_t *msg)
 	mavlink_serial_control_t serial_control_mavlink;
 	mavlink_msg_serial_control_decode(msg, &serial_control_mavlink);
 
+	// Check if the message is targeted at us.
+	if ((serial_control_mavlink.target_system != 0 &&
+	     mavlink_system.sysid != serial_control_mavlink.target_system) ||
+	    (serial_control_mavlink.target_component != 0 &&
+	     mavlink_system.compid != serial_control_mavlink.target_component)) {
+		return;
+	}
+
 	// we only support shell commands
 	if (serial_control_mavlink.device != SERIAL_CONTROL_DEV_SHELL
 	    || (serial_control_mavlink.flags & SERIAL_CONTROL_FLAG_REPLY)) {


### PR DESCRIPTION
The SERIAL_CONTROL MAVLink message now contains a target_system and target_component field that we should check.

Without this we might be answering to a command on the network that is meant for another system.

Also see: https://github.com/mavlink/mavlink/pull/1725