### PR TITLE
Enable offboard actuator setpoints

### DIFF
--- a/msg/offboard_control_mode.msg
+++ b/msg/offboard_control_mode.msg
@@ -7,3 +7,4 @@ bool velocity
 bool acceleration
 bool attitude
 bool body_rate
+bool actuator

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4066,12 +4066,13 @@ Commander::offboard_control_update()
 			    old.velocity != ocm.velocity ||
 			    old.acceleration != ocm.acceleration ||
 			    old.attitude != ocm.attitude ||
-			    old.body_rate != ocm.body_rate) {
+			    old.body_rate != ocm.body_rate ||
+			    old.actuator != ocm.actuator) {
 
 				_status_changed = true;
 			}
 
-			if (ocm.position || ocm.velocity || ocm.acceleration || ocm.attitude || ocm.body_rate) {
+			if (ocm.position || ocm.velocity || ocm.acceleration || ocm.attitude || ocm.body_rate || ocm.actuator) {
 				offboard_available = true;
 			}
 		}

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1272,6 +1272,7 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 
 		offboard_control_mode_s offboard_control_mode{};
 		offboard_control_mode.timestamp = hrt_absolute_time();
+		offboard_control_mode.actuator = true;
 		_offboard_control_mode_pub.publish(offboard_control_mode);
 
 		vehicle_status_s vehicle_status{};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1271,8 +1271,8 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 		//bool ignore_setpoints = bool(actuator_target.group_mlx != 2);
 
 		offboard_control_mode_s offboard_control_mode{};
-		offboard_control_mode.timestamp = hrt_absolute_time();
 		offboard_control_mode.actuator = true;
+		offboard_control_mode.timestamp = hrt_absolute_time();
 		_offboard_control_mode_pub.publish(offboard_control_mode);
 
 		vehicle_status_s vehicle_status{};


### PR DESCRIPTION
**Describe problem solved by this pull request**
Sending actuator setpoints directly from a onboard computer provides a useful way to execute open loop manuevers which is useful for system identification.

While previous to https://github.com/PX4/PX4-Autopilot/pull/16739  it was possible to send actuator commands using the `https://mavlink.io/en/messages/common.html#SET_ACTUATOR_CONTROL_TARGET` mavlink message, this is no longer working since it is not understood as a valid offboard mode.

**Describe your solution**
This commit adds a case for adding offboard actuator commands in the offboard mode

**Test data / coverage**
Tested with Gazebo SITL no lockstep target
```
make px4_sitl_nolockstep gazebo
```

As can be observed in the log, actuator setpoint to elevator (output 7) is increased as a ramp function
Flight log: https://logs.px4.io/plot_app?log=15a16288-d153-467e-8ab2-9303bb855d35


**Additional context**
- This is a regression from https://github.com/PX4/PX4-Autopilot/pull/16739 