### PR TITLE
gyro_fft: add IMU_GYRO_FFT_SNR parameter and limit noise floor to configured range (IMU_GYRO_FFT_MIN/MAX)

### DIFF
--- a/posix-configs/SITL/init/test/test_imu_filtering
+++ b/posix-configs/SITL/init/test/test_imu_filtering
@@ -22,7 +22,7 @@ param set IMU_GYRO_FFT_LEN 512
 # dynamic notches ESC/FFT/both
 #param set IMU_GYRO_DYN_NF 1
 #param set IMU_GYRO_DYN_NF 2
-#param set IMU_GYRO_DYN_NF 3
+param set IMU_GYRO_DYN_NF 3
 
 # test values
 param set IMU_GYRO_CUTOFF 60

--- a/src/modules/gyro_fft/GyroFFT.cpp
+++ b/src/modules/gyro_fft/GyroFFT.cpp
@@ -439,18 +439,18 @@ void GyroFFT::FindPeaks(const hrt_abstime &timestamp_sample, int axis, q15_t *ff
 
 	// FFT output buffer is ordered [real[0], imag[0], real[1], imag[1], real[2], imag[2] ... real[(N/2)-1], imag[(N/2)-1]
 	for (uint16_t bucket_index = 0; bucket_index < (2 * _imu_gyro_fft_len - 1); bucket_index = bucket_index + 2) {
-		const float real = fft_outupt_buffer[bucket_index];
-		const float imag = fft_outupt_buffer[bucket_index + 1];
-
-		const float fft_magnitude_squared = real * real + imag * imag;
-		bin_mag_sum += fft_magnitude_squared;
-
 
 		const float freq_hz = (bucket_index / 2) * resolution_hz;
 
 		if ((bucket_index > 0) && (bucket_index < (_imu_gyro_fft_len - 1))
 		    && (freq_hz >= _param_imu_gyro_fft_min.get())
 		    && (freq_hz <= _param_imu_gyro_fft_max.get())) {
+
+			const float real = fft_outupt_buffer[bucket_index];
+			const float imag = fft_outupt_buffer[bucket_index + 1];
+
+			const float fft_magnitude_squared = real * real + imag * imag;
+			bin_mag_sum += fft_magnitude_squared;
 
 			for (int i = 0; i < MAX_NUM_PEAKS; i++) {
 				if (fft_magnitude_squared > peak_magnitude[i]) {

--- a/src/modules/gyro_fft/GyroFFT.cpp
+++ b/src/modules/gyro_fft/GyroFFT.cpp
@@ -465,7 +465,6 @@ void GyroFFT::FindPeaks(const hrt_abstime &timestamp_sample, int axis, q15_t *ff
 	// keep if peak has been previously seen and SNR > MIN_SNR
 	//   or
 	// peak has SNR > MIN_SNR_INITIAL
-	static constexpr float MIN_SNR_INITIAL = 15.f; // TODO: configurable?
 	static constexpr float MIN_SNR = 1.f; // TODO: configurable?
 
 	int num_peaks_found = 0;
@@ -491,7 +490,7 @@ void GyroFFT::FindPeaks(const hrt_abstime &timestamp_sample, int axis, q15_t *ff
 
 					// only keep if we're already tracking this frequency or if the SNR is significant
 					for (int peak_prev = 0; peak_prev < MAX_NUM_PEAKS; peak_prev++) {
-						if ((snr > MIN_SNR_INITIAL)
+						if ((snr > _param_imu_gyro_fft_snr.get())
 						    || (fabsf(freq_adjusted - peak_frequencies_publish[axis][peak_prev]) < (resolution_hz * 0.5f))) {
 							// keep
 							peak_frequencies[num_peaks_found] = freq_adjusted;

--- a/src/modules/gyro_fft/GyroFFT.hpp
+++ b/src/modules/gyro_fft/GyroFFT.hpp
@@ -161,7 +161,8 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::IMU_GYRO_FFT_LEN>) _param_imu_gyro_fft_len,
 		(ParamFloat<px4::params::IMU_GYRO_FFT_MIN>) _param_imu_gyro_fft_min,
-		(ParamFloat<px4::params::IMU_GYRO_FFT_MAX>) _param_imu_gyro_fft_max
+		(ParamFloat<px4::params::IMU_GYRO_FFT_MAX>) _param_imu_gyro_fft_max,
+		(ParamFloat<px4::params::IMU_GYRO_FFT_SNR>) _param_imu_gyro_fft_snr
 	)
 };
 

--- a/src/modules/gyro_fft/parameters.c
+++ b/src/modules/gyro_fft/parameters.c
@@ -74,3 +74,12 @@ PARAM_DEFINE_FLOAT(IMU_GYRO_FFT_MAX, 150.f);
 * @group Sensors
 */
 PARAM_DEFINE_INT32(IMU_GYRO_FFT_LEN, 512);
+
+/**
+* IMU gyro FFT SNR.
+*
+* @min 1
+* @max 30
+* @group Sensors
+*/
+PARAM_DEFINE_FLOAT(IMU_GYRO_FFT_SNR, 10.f);


### PR DESCRIPTION
The FFT frequency peak detection isn't great across all platforms by default, but at least this helps by giving you a bit more control to target it between potentially relevant frequencies (IMU_GYRO_FFT_MIN/MAX) .