### PR TITLE
state_machine_helper: add place holder in array  nav_state_names for removed LANDGPSFAIL mode

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -119,6 +119,7 @@ const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
 	"6: unallocated",
 	"7: unallocated",
 	"AUTO_LANDENGFAIL",
+	"9: unallocated",
 	"ACRO",
 	"11: UNUSED",
 	"DESCEND",


### PR DESCRIPTION
This was missed in https://github.com/PX4/PX4-Autopilot/pull/17547.