### PR TITLE
setup/python requirements: add future module

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -3,6 +3,7 @@ argparse>=1.2
 cerberus
 coverage
 empy>=3.3
+future
 jinja2>=2.8
 jsonschema
 kconfiglib


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since https://github.com/PX4/PX4-Autopilot/pull/18238 the python module `future` seems to have become a requirement. Without it I couldn't build anymore.

**Describe your solution**
I'm adding future to the setup script requirements. After running `python3 -m pip install --user -r Tools/setup/requirements.txt` with this change it builds fine.

**Test data / coverage**
Ran into this problem on Ubuntu 20.04 with Python 3 (only) and used the change to fix it which worked.
