### PR TITLE
FlightTaskAuto: use MPC_XY_CRUISE and MPC_XY_VEL_MAX to clamp cruise speed 

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -157,7 +157,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f)) {
 		// If no speed is planned use the default cruise speed as limit
-		_mc_cruise_speed = _constraints.speed_xy;
+		_mc_cruise_speed = _param_mpc_xy_cruise.get();
 	}
 
 	// Ensure planned cruise speed is below the maximum such that the smooth trajectory doesn't get capped
@@ -407,16 +407,6 @@ bool FlightTaskAuto::_evaluateGlobalReference()
 
 	// check if everything is still finite
 	return PX4_ISFINITE(_reference_altitude) && PX4_ISFINITE(ref_lat) && PX4_ISFINITE(ref_lon);
-}
-
-void FlightTaskAuto::_setDefaultConstraints()
-{
-	FlightTask::_setDefaultConstraints();
-
-	// only adjust limits if the new limit is lower
-	if (_constraints.speed_xy >= _param_mpc_xy_cruise.get()) {
-		_constraints.speed_xy = _param_mpc_xy_cruise.get();
-	}
 }
 
 Vector2f FlightTaskAuto::_getTargetVelocityXY()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -92,7 +92,6 @@ public:
 	void setYawHandler(WeatherVane *ext_yaw_handler) override {_ext_yaw_handler = ext_yaw_handler;}
 
 protected:
-	void _setDefaultConstraints() override;
 	matrix::Vector2f _getTargetVelocityXY(); /**< only used for follow-me and only here because of legacy reason.*/
 	void _updateInternalWaypoints(); /**< Depending on state of vehicle, the internal waypoints might differ from target (for instance if offtrack). */
 	bool _compute_heading_from_2D_vector(float &heading, matrix::Vector2f v); /**< Computes and sets heading a 2D vector */

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -256,7 +256,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I_ACC, 0.4f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_D_ACC, 0.2f);
 
 /**
- * Maximum horizontal velocity in mission
+ * Default horizontal velocity in mission
  *
  * Horizontal velocity used when flying autonomously in e.g. Missions, RTL, Goto.
  *


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
In the previous state, MPC_XY_CRUISE was used as a capping value for the cruise speed in auto modes. 
This caused vehicles no not be able to fly faster than MPC_XY_CRUISE instead of MPC_XY_VEL_MAX.

**Describe your solution**
FlightTask was already defining the right constrain, so in this PR i just got rid of the method override in FlightTaskAuto and initialized the cruise speed to MPC_XY_CRUISE when the setpoint was empty

**Test data / coverage**
tested in SITL

**Additional context**
Add any other related context or media.
