### PR TITLE
Don't link sensors module to drivers__device

### DIFF
--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -51,7 +51,6 @@ px4_add_module(
 		airspeed
 		conversion
 		data_validator
-		drivers__device
 		mathlib
 		sensor_calibration
 		vehicle_acceleration


### PR DESCRIPTION
sensors module only works on uORB, it doesn't link to drivers__device

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

