### PR TITLE
Fixed-wing speed modes

### DIFF
--- a/msg/tecs_status.msg
+++ b/msg/tecs_status.msg
@@ -42,3 +42,9 @@ float32 throttle_sp
 float32 pitch_sp_rad
 
 uint8 mode
+
+uint8 flight_phase
+
+uint8 TECS_FLIGHT_PHASE_LEVEL 	= 0		# In level flight (no altitude setpoint change)
+uint8 TECS_FLIGHT_PHASE_CLIMB 	= 1		# Climb is triggered (altitude setpoint is increasing)
+uint8 TECS_FLIGHT_PHASE_DESCEND = 2		# Descend is triggered (altitude setpoint is descreasing)

--- a/msg/tecs_status.msg
+++ b/msg/tecs_status.msg
@@ -6,6 +6,7 @@ uint8 TECS_MODE_LAND = 3
 uint8 TECS_MODE_LAND_THROTTLELIM = 4
 uint8 TECS_MODE_BAD_DESCENT = 5
 uint8 TECS_MODE_CLIMBOUT = 6
+uint8 TECS_MODE_ECO = 7
 
 
 float32 altitude_sp

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -50,6 +50,12 @@ static constexpr float DT_MAX = 1.0f;	///< max value of _dt allowed before a fil
  * @author Paul Riseborough
  */
 
+
+TECS::TECS()
+{
+	_tecs_status_pub.advertise();
+}
+
 /*
  * This function implements a complementary filter to estimate the climb rate when
  * inertial nav data is not available. It also calculates a true airspeed derivative

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -586,7 +586,7 @@ void TECS::_update_STE_rate_lim()
 void TECS::update_pitch_throttle(float pitch, float baro_altitude, float hgt_setpoint,
 				 float EAS_setpoint, float equivalent_airspeed, float eas_to_tas, bool climb_out_setpoint, float pitch_min_climbout,
 				 float throttle_min, float throttle_max, float throttle_cruise, float pitch_limit_min, float pitch_limit_max,
-				 float target_climbrate, float target_sinkrate, float hgt_rate_sp, bool eco_mode_enabled)
+				 float hgt_rate_sp, bool eco_mode_enabled)
 {
 	// Calculate the time since last update (seconds)
 	uint64_t now = hrt_absolute_time();
@@ -630,7 +630,9 @@ void TECS::update_pitch_throttle(float pitch, float baro_altitude, float hgt_set
 
 	_updateFlightPhase(hgt_setpoint, hgt_rate_sp);
 
-	_calculateHeightRateSetpoint(hgt_setpoint, hgt_rate_sp, target_climbrate, target_sinkrate, baro_altitude);
+	const float target_climb_rate = _tecs_mode == ECL_TECS_MODE_ECO ? _target_climb_rate_eco : _target_climb_rate;
+
+	_calculateHeightRateSetpoint(hgt_setpoint, hgt_rate_sp, target_climb_rate, _target_sink_rate, baro_altitude);
 
 	// Calculate the specific energy values required by the control loop
 	_update_energy_estimates();

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -714,6 +714,10 @@ TECS::tecs_status_publish(const hrt_abstime &now)
 
 	case TECS::ECL_TECS_MODE_ECO:
 		tecs_status.mode = tecs_status_s::TECS_MODE_ECO;
+		break;
+
+	default:
+		tecs_status.mode = tecs_status_s::TECS_MODE_NORMAL;
 	}
 
 	tecs_status.altitude_sp = _hgt_setpoint;

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -56,7 +56,7 @@
 class TECS
 {
 public:
-	TECS() = default;
+	TECS();
 	~TECS() = default;
 
 	// no copy, assignment, move, move assignment
@@ -370,5 +370,7 @@ private:
 	_alt_control_traj_generator;	// generates height rate and altitude setpoint trajectory when altitude is commanded
 	ManualVelocitySmoothingZ
 	_velocity_control_traj_generator;	// generates height rate and altitude setpoint trajectory when height rate is commanded
+
+	uORB::Publication<tecs_status_s>	_tecs_status_pub{ORB_ID(tecs_status)};
 
 };

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -155,6 +155,7 @@ public:
 	float get_SEB_setpoint() { return _SPE_setpoint * _SPE_weighting - _SKE_setpoint * _SKE_weighting; }
 	float get_SEB_rate() { return _SPE_rate * _SPE_weighting - _SKE_rate * _SKE_weighting; }
 	float get_SEB_rate_setpoint() { return _SPE_rate_setpoint * _SPE_weighting - _SKE_rate_setpoint * _SKE_weighting; }
+	int get_flight_phase() { return _flight_phase; }
 
 	void tecs_status_publish(const hrt_abstime &now);
 
@@ -280,6 +281,9 @@ private:
 	bool _states_initialized{false};					///< true when TECS states have been iniitalized
 	bool _in_air{false};						///< true when the vehicle is flying
 
+	// flight phase
+	int _flight_phase{tecs_status_s::TECS_FLIGHT_PHASE_LEVEL};
+
 	/**
 	 * Update the airspeed internal state using a second order complementary filter
 	 */
@@ -322,6 +326,8 @@ private:
 	void _update_pitch_setpoint();
 
 	void _updateTrajectoryGenerationConstraints();
+
+	void _updateFlightPhase(float altitude_sp_amsl, float height_rate_setpoint);
 
 	void _calculateHeightRateSetpoint(float altitude_sp_amsl, float height_rate_sp, float target_climbrate,
 					  float target_sinkrate, float altitude_amsl);

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -94,7 +94,7 @@ public:
 	void update_pitch_throttle(float pitch, float baro_altitude, float hgt_setpoint,
 				   float EAS_setpoint, float equivalent_airspeed, float eas_to_tas, bool climb_out_setpoint, float pitch_min_climbout,
 				   float throttle_min, float throttle_setpoint_max, float throttle_cruise,
-				   float pitch_limit_min, float pitch_limit_max, float target_climbrate, float target_sinkrate, float hgt_rate_sp = NAN,
+				   float pitch_limit_min, float pitch_limit_max, float hgt_rate_sp = NAN,
 				   bool eco_mode_enabled = false);
 
 	void reset_state() { _states_initialized = false; }
@@ -142,9 +142,13 @@ public:
 
 	void set_seb_rate_ff_gain(float ff_gain) { _SEB_rate_ff = ff_gain; }
 
+	void set_target_climb_rate(float target_climb_rate) { _target_climb_rate = target_climb_rate; }
+	void set_target_sink_rate(float target_sink_rate) { _target_sink_rate = target_sink_rate; }
+
 	// eco mode settings
 	void set_speed_weight_eco(float weight_eco) { _pitch_speed_weight_eco = weight_eco; }
 	void set_height_error_time_constant_eco(float time_const_eco) { _height_error_gain_eco = 1.0f / math::max(time_const_eco, 0.1f); }
+	void set_target_climb_rate_eco(float target_climb_rate_eco) { _target_climb_rate_eco = target_climb_rate_eco; }
 
 	// getters
 	float get_throttle_setpoint() { return _last_throttle_setpoint; }
@@ -217,6 +221,7 @@ private:
 
 	float _height_error_gain_eco{0.2f};				///< in eco mode: height error inverse time constant [1/s]
 	float _pitch_speed_weight_eco{1.0f};				///< in eco mode: speed control weighting used by pitch demand calculation
+	float _target_climb_rate_eco{2.f};
 
 	// complimentary filter states
 	float _vert_vel_state{0.0f};					///< complimentary filter state - height rate (m/sec)
@@ -275,6 +280,9 @@ private:
 	// speed height weighting
 	float _SPE_weighting{1.0f};
 	float _SKE_weighting{1.0f};
+
+	float _target_climb_rate{3.f};
+	float _target_sink_rate{2.f};
 
 	// time steps (non-fixed)
 	float _dt{DT_DEFAULT};						///< Time since last update of main TECS loop (sec)

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -94,7 +94,8 @@ public:
 	void update_pitch_throttle(float pitch, float baro_altitude, float hgt_setpoint,
 				   float EAS_setpoint, float equivalent_airspeed, float eas_to_tas, bool climb_out_setpoint, float pitch_min_climbout,
 				   float throttle_min, float throttle_setpoint_max, float throttle_cruise,
-				   float pitch_limit_min, float pitch_limit_max, float target_climbrate, float target_sinkrate, float hgt_rate_sp = NAN);
+				   float pitch_limit_min, float pitch_limit_max, float target_climbrate, float target_sinkrate, float hgt_rate_sp = NAN,
+				   bool eco_mode_enabled = false);
 
 	void reset_state() { _states_initialized = false; }
 
@@ -102,7 +103,8 @@ public:
 		ECL_TECS_MODE_NORMAL = 0,
 		ECL_TECS_MODE_UNDERSPEED,
 		ECL_TECS_MODE_BAD_DESCENT,
-		ECL_TECS_MODE_CLIMBOUT
+		ECL_TECS_MODE_CLIMBOUT,
+		ECL_TECS_MODE_ECO
 	};
 
 	void set_detect_underspeed_enabled(bool enabled) { _detect_underspeed_enabled = enabled; }
@@ -140,6 +142,9 @@ public:
 
 	void set_seb_rate_ff_gain(float ff_gain) { _SEB_rate_ff = ff_gain; }
 
+	// eco mode settings
+	void set_speed_weight_eco(float weight_eco) { _pitch_speed_weight_eco = weight_eco; }
+	void set_height_error_time_constant_eco(float time_const_eco) { _height_error_gain_eco = 1.0f / math::max(time_const_eco, 0.1f); }
 
 	// getters
 	float get_throttle_setpoint() { return _last_throttle_setpoint; }
@@ -209,6 +214,9 @@ private:
 	float _STE_rate_time_const{0.1f};				///< filter time constant for specific total energy rate (damping path) (s)
 	float _speed_derivative_time_const{0.01f};			///< speed derivative filter time constant (s)
 	float _SEB_rate_ff{1.0f};
+
+	float _height_error_gain_eco{0.2f};				///< in eco mode: height error inverse time constant [1/s]
+	float _pitch_speed_weight_eco{1.0f};				///< in eco mode: speed control weighting used by pitch demand calculation
 
 	// complimentary filter states
 	float _vert_vel_state{0.0f};					///< complimentary filter state - height rate (m/sec)
@@ -280,6 +288,7 @@ private:
 	bool _airspeed_enabled{false};					///< true when airspeed use has been enabled
 	bool _states_initialized{false};					///< true when TECS states have been iniitalized
 	bool _in_air{false};						///< true when the vehicle is flying
+	bool _eco_mode_enabled{false};
 
 	// flight phase
 	int _flight_phase{tecs_status_s::TECS_FLIGHT_PHASE_LEVEL};

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -132,7 +132,7 @@ FixedwingPositionControl::parameters_update()
 	_tecs.set_seb_rate_ff_gain(_param_seb_rate_ff.get());
 
 	_tecs.set_speed_weight_eco(_param_fw_t_spdweight_eco.get());
-	_tecs.set_height_error_time_constant_eco(_param_fw_t_h_error_tc_eco.get());
+	_tecs.set_height_error_time_constant_eco(_param_fw_t_alt_tc_eco.get());
 
 
 	// Landing slope
@@ -443,7 +443,7 @@ FixedwingPositionControl::get_cruise_airspeed_setpoint(const hrt_abstime &now, c
 void
 FixedwingPositionControl::updateSpeedMode()
 {
-	FW_SPEED_MODE_COMMANDED new_mode = static_cast<FW_SPEED_MODE_COMMANDED>(_fw_spd_mode_set.get());
+	FW_SPEED_MODE_COMMANDED new_mode = static_cast<FW_SPEED_MODE_COMMANDED>(_param_fw_spd_mode_set.get());
 
 	switch (new_mode) {
 	case NORMAL:
@@ -495,9 +495,9 @@ FixedwingPositionControl::updateSpeedMode()
 void
 FixedwingPositionControl::check_eco_dash_allowed()
 {
-	const float altitude_amsl_min = max(_tecs.get_hgt_setpoint() - fw_alt_err_u.get(),
-					    _local_pos.ref_alt + fw_alt_min.get());
-	const float altitude_amsl_max = _tecs.get_hgt_setpoint() + fw_alt_err_o.get();
+	const float altitude_amsl_min = max(_tecs.get_hgt_setpoint() - _param_fw_spdm_alt_er_u.get(),
+					    _local_pos.ref_alt + _param_fw_alt_spdm_min.get());
+	const float altitude_amsl_max = _tecs.get_hgt_setpoint() + _param_fw_spdm_alt_er_o.get();
 
 	const bool altitdue_conditions_met = _current_altitude <= altitude_amsl_max
 					     && _current_altitude >= altitude_amsl_min;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -401,6 +401,47 @@ FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand, const
 
 
 void
+FixedwingPositionControl::update_wind_mode()
+{
+	/* If the corresponding wind threshold values are set, the wind state will change if these values are
+	 * passed for a certain amount of time. The wind state is then used to increase airspeed (high wind),
+	 * resp. decrease (low wind). It takes longer to move to a lower wind state than to a higher,
+	 * as in general higher airspeed is safer. */
+
+	wind_s wind_estimate;
+
+	if (_wind_sub.update(&wind_estimate)) {
+		const matrix::Vector2f wind(wind_estimate.windspeed_north, wind_estimate.windspeed_east);
+		FW_WIND_MODE fw_wind_mode_detected(FW_WIND_MODE_NORMAL);
+
+		if (_param_fw_wind_thld_h.get() > FLT_EPSILON && wind.length() > _param_fw_wind_thld_h.get()) {
+			fw_wind_mode_detected = FW_WIND_MODE_HIGH;
+
+		} else if (_param_fw_wind_thld_l.get() > FLT_EPSILON && wind.length() < _param_fw_wind_thld_l.get()) {
+			fw_wind_mode_detected = FW_WIND_MODE_LOW;
+		}
+
+		if (fw_wind_mode_detected != _fw_wind_mode_detected_prev) {
+			_first_time_current_mode_detected = hrt_absolute_time();
+		}
+
+		const float min_time_detection_mode_down = 60.0f; // min time to switch to lower wind state
+		const float time_since_new_mode_detected = hrt_elapsed_time(&_first_time_current_mode_detected) * 1e-6f;
+
+		// immediately switch to higher wind mode after detection, but require minimum time within lower wind to switch to lower mode
+		if (fw_wind_mode_detected > _fw_wind_mode_current) {
+			_fw_wind_mode_current = fw_wind_mode_detected;
+
+		} else if (fw_wind_mode_detected < _fw_wind_mode_current
+			   && time_since_new_mode_detected > min_time_detection_mode_down) {
+			_fw_wind_mode_current = fw_wind_mode_detected;
+		}
+
+		_fw_wind_mode_detected_prev = fw_wind_mode_detected;
+	}
+}
+
+void
 FixedwingPositionControl::status_publish()
 {
 	position_controller_status_s pos_ctrl_status = {};
@@ -668,6 +709,8 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 
 	/* get circle mode */
 	const bool was_circle_mode = _l1_control.circle_mode();
+
+	update_wind_mode();
 
 	/* restore TECS parameters, in case changed intermittently (e.g. in landing handling) */
 	_tecs.set_speed_weight(_param_fw_t_spdweight.get());

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -399,70 +399,6 @@ FixedwingPositionControl::calculate_target_airspeed(float airspeed_demand, const
 	return constrain(airspeed_demand, adjusted_min_airspeed, _param_fw_airspd_max.get());
 }
 
-void
-FixedwingPositionControl::tecs_status_publish()
-{
-	tecs_status_s t{};
-
-	switch (_tecs.tecs_mode()) {
-	case TECS::ECL_TECS_MODE_NORMAL:
-		t.mode = tecs_status_s::TECS_MODE_NORMAL;
-		break;
-
-	case TECS::ECL_TECS_MODE_UNDERSPEED:
-		t.mode = tecs_status_s::TECS_MODE_UNDERSPEED;
-		break;
-
-	case TECS::ECL_TECS_MODE_BAD_DESCENT:
-		t.mode = tecs_status_s::TECS_MODE_BAD_DESCENT;
-		break;
-
-	case TECS::ECL_TECS_MODE_CLIMBOUT:
-		t.mode = tecs_status_s::TECS_MODE_CLIMBOUT;
-		break;
-	}
-
-	t.altitude_sp = _tecs.hgt_setpoint();
-	t.altitude_filtered = _tecs.vert_pos_state();
-
-	t.true_airspeed_sp = _tecs.TAS_setpoint_adj();
-	t.true_airspeed_filtered = _tecs.tas_state();
-
-	t.height_rate_setpoint = _tecs.hgt_rate_setpoint();
-	t.height_rate = _tecs.vert_vel_state();
-
-	t.equivalent_airspeed_sp = _tecs.get_EAS_setpoint();
-	t.true_airspeed_derivative_sp = _tecs.TAS_rate_setpoint();
-	t.true_airspeed_derivative = _tecs.speed_derivative();
-	t.true_airspeed_derivative_raw = _tecs.speed_derivative_raw();
-	t.true_airspeed_innovation = _tecs.getTASInnovation();
-
-	t.total_energy_error = _tecs.STE_error();
-	t.total_energy_rate_error = _tecs.STE_rate_error();
-
-	t.energy_distribution_error = _tecs.SEB_error();
-	t.energy_distribution_rate_error = _tecs.SEB_rate_error();
-
-	t.total_energy = _tecs.STE();
-	t.total_energy_rate = _tecs.STE_rate();
-	t.total_energy_balance = _tecs.SEB();
-	t.total_energy_balance_rate = _tecs.SEB_rate();
-
-	t.total_energy_sp = _tecs.STE_setpoint();
-	t.total_energy_rate_sp = _tecs.STE_rate_setpoint();
-	t.total_energy_balance_sp = _tecs.SEB_setpoint();
-	t.total_energy_balance_rate_sp = _tecs.SEB_rate_setpoint();
-
-	t.throttle_integ = _tecs.throttle_integ_state();
-	t.pitch_integ = _tecs.pitch_integ_state();
-
-	t.throttle_sp = _tecs.get_throttle_setpoint();
-	t.pitch_sp_rad = _tecs.get_pitch_setpoint();
-
-	t.timestamp = hrt_absolute_time();
-
-	_tecs_status_pub.publish(t);
-}
 
 void
 FixedwingPositionControl::status_publish()
@@ -612,7 +548,6 @@ FixedwingPositionControl::getManualHeightRateSetpoint()
 		const float climb_rate_target = _param_climbrate_target.get();
 
 		height_rate_setpoint = pitch * climb_rate_target;
-
 	}
 
 	return height_rate_setpoint;
@@ -2226,8 +2161,6 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const hrt_abstime &now, flo
 				    pitch_min_rad - radians(_param_fw_psp_off.get()),
 				    pitch_max_rad - radians(_param_fw_psp_off.get()),
 				    _param_climbrate_target.get(), _param_sinkrate_target.get(), hgt_rate_sp);
-
-	tecs_status_publish();
 }
 
 void FixedwingPositionControl::publishOrbitStatus(const position_setpoint_s pos_sp)

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -70,8 +70,6 @@ FixedwingPositionControl::FixedwingPositionControl(bool vtol) :
 	// limit to 50 Hz
 	_local_pos_sub.set_interval_ms(20);
 
-	_tecs_status_pub.advertise();
-
 	/* fetch initial parameter values */
 	parameters_update();
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -497,6 +497,14 @@ FixedwingPositionControl::check_eco_dash_allowed()
 }
 
 void
+FixedwingPositionControl::resetAutoSpeedAdaptions()
+{
+	_conditions_for_eco_dash_met = false;
+	_time_conditions_not_met = _local_pos.timestamp;
+	_speed_mode_current = FW_SPEED_MODE::FW_SPEED_MODE_NORMAL;
+}
+
+void
 FixedwingPositionControl::update_wind_mode()
 {
 	/* If the corresponding wind threshold values are set, the wind state will change if these values are
@@ -2048,21 +2056,25 @@ FixedwingPositionControl::Run()
 
 		case FW_POSCTRL_MODE_AUTO_ALTITUDE: {
 				control_auto_fixed_bank_alt_hold(_local_pos.timestamp);
+				resetAutoSpeedAdaptions();
 				break;
 			}
 
 		case FW_POSCTRL_MODE_AUTO_CLIMBRATE: {
 				control_auto_descend(_local_pos.timestamp);
+				resetAutoSpeedAdaptions();
 				break;
 			}
 
 		case FW_POSCTRL_MODE_MANUAL_POSITION: {
 				control_manual_position(_local_pos.timestamp, curr_pos, ground_speed);
+				resetAutoSpeedAdaptions();
 				break;
 			}
 
 		case FW_POSCTRL_MODE_MANUAL_ALTITUDE: {
 				control_manual_altitude(_local_pos.timestamp, curr_pos, ground_speed);
+				resetAutoSpeedAdaptions();
 				break;
 			}
 
@@ -2072,6 +2084,8 @@ FixedwingPositionControl::Run()
 					reset_landing_state();
 					reset_takeoff_state();
 				}
+
+				resetAutoSpeedAdaptions();
 
 				_att_sp.thrust_body[0] = min(_att_sp.thrust_body[0], _param_fw_thr_max.get());
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -296,6 +296,8 @@ private:
 
 	FW_WIND_MODE _fw_wind_mode_detected_prev{FW_WIND_MODE_NORMAL};
 
+	float _last_airspeed_setpoint{NAN};
+
 	param_t _param_handle_airspeed_trans{PARAM_INVALID};
 	float _param_airspeed_trans{NAN};
 
@@ -353,15 +355,18 @@ private:
 	void		control_auto_fixed_bank_alt_hold(const hrt_abstime &now);
 	void		control_auto_descend(const hrt_abstime &now);
 
-	void		control_auto_position(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
+	void		control_auto_position(const hrt_abstime &now, const float dt, const Vector2d &curr_pos,
+					      const Vector2f &ground_speed,
 					      const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr);
-	void		control_auto_loiter(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
+	void		control_auto_loiter(const hrt_abstime &now, const float dt, const Vector2d &curr_pos,
+					    const Vector2f &ground_speed,
 					    const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr, const position_setpoint_s &pos_sp_next);
 	void		control_auto_takeoff(const hrt_abstime &now, const float dt,  const Vector2d &curr_pos,
 					     const Vector2f &ground_speed,
 					     const position_setpoint_s &pos_sp_prev,
 					     const position_setpoint_s &pos_sp_curr);
-	void		control_auto_landing(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
+	void		control_auto_landing(const hrt_abstime &now, const float dt, const Vector2d &curr_pos,
+					     const Vector2f &ground_speed,
 					     const position_setpoint_s &pos_sp_prev,
 					     const position_setpoint_s &pos_sp_curr);
 	void		control_manual_altitude(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed);
@@ -371,7 +376,8 @@ private:
 	float		get_tecs_thrust();
 
 	float		get_demanded_airspeed();
-	float		calculate_target_airspeed(float airspeed_demand, const Vector2f &ground_speed);
+	float		get_cruise_airspeed_setpoint(const hrt_abstime &now, const float pos_sp_cru_airspeed,
+			const Vector2f &ground_speed, float dt);
 
 	void		reset_takeoff_state(bool force = false);
 	void		reset_landing_state();

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -392,7 +392,7 @@ private:
 					float pitch_min_rad, float pitch_max_rad,
 					float throttle_min, float throttle_max, float throttle_cruise,
 					bool climbout_mode, float climbout_pitch_min_rad,
-					uint8_t mode = tecs_status_s::TECS_MODE_NORMAL, float hgt_rate_sp = NAN);
+					bool disable_underspeed_detection = false, float hgt_rate_sp = NAN);
 
 	DEFINE_PARAMETERS(
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -282,7 +282,7 @@ private:
 		DASH_FULL
 	};
 
-	bool _conditions_for_eco_dash_met{false};
+	// bool _conditions_for_eco_dash_met{false};
 	hrt_abstime _time_conditions_not_met{0};
 
 	float _last_airspeed_setpoint{NAN};
@@ -376,10 +376,9 @@ private:
 
 	void 		publishOrbitStatus(const position_setpoint_s pos_sp);
 
-	void		check_eco_dash_allowed();
 	FW_SPEED_MODE	getSpeedMode();
 	void		update_wind_mode();
-	void		resetAutoSpeedAdaptions();
+	void		resetEcoDashAllowed();
 
 	/*
 	 * Call TECS : a wrapper function to call the TECS implementation

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -272,7 +272,7 @@ private:
 		FW_SPEED_MODE_NORMAL,
 		FW_SPEED_MODE_ECO,
 		FW_SPEED_MODE_DASH,
-	} _speed_mode_current{FW_SPEED_MODE_NORMAL};
+	};
 
 	enum FW_SPEED_MODE_COMMANDED {
 		NORMAL,
@@ -280,7 +280,7 @@ private:
 		ECO_FULL,
 		DASH_CRUISE,
 		DASH_FULL
-	} _speed_mode_setting{NORMAL};
+	};
 
 	bool _conditions_for_eco_dash_met{false};
 	hrt_abstime _time_conditions_not_met{0};
@@ -345,11 +345,12 @@ private:
 	void		control_auto_descend(const hrt_abstime &now);
 
 	void		control_auto_position(const hrt_abstime &now, const float dt, const Vector2d &curr_pos,
-					      const Vector2f &ground_speed,
-					      const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr);
+					      const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
+					      const position_setpoint_s &pos_sp_curr, const FW_SPEED_MODE spd_mode);
 	void		control_auto_loiter(const hrt_abstime &now, const float dt, const Vector2d &curr_pos,
-					    const Vector2f &ground_speed,
-					    const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr, const position_setpoint_s &pos_sp_next);
+					    const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
+					    const position_setpoint_s &pos_sp_curr, const position_setpoint_s &pos_sp_next,
+					    const FW_SPEED_MODE spd_mode);
 	void		control_auto_takeoff(const hrt_abstime &now, const float dt,  const Vector2d &curr_pos,
 					     const Vector2f &ground_speed,
 					     const position_setpoint_s &pos_sp_prev,
@@ -366,7 +367,7 @@ private:
 
 	float		get_demanded_airspeed();
 	float		get_cruise_airspeed_setpoint(const hrt_abstime &now, const float pos_sp_cru_airspeed,
-			const Vector2f &ground_speed, float dt);
+			const Vector2f &ground_speed, float dt, const FW_SPEED_MODE spd_mode);
 
 	void		reset_takeoff_state(bool force = false);
 	void		reset_landing_state();
@@ -376,7 +377,7 @@ private:
 	void 		publishOrbitStatus(const position_setpoint_s pos_sp);
 
 	void		check_eco_dash_allowed();
-	void		updateSpeedMode();
+	FW_SPEED_MODE	getSpeedMode();
 	void		update_wind_mode();
 	void		resetAutoSpeedAdaptions();
 
@@ -387,7 +388,8 @@ private:
 					float pitch_min_rad, float pitch_max_rad,
 					float throttle_min, float throttle_max, float throttle_cruise,
 					bool climbout_mode, float climbout_pitch_min_rad,
-					bool disable_underspeed_detection = false, float hgt_rate_sp = NAN);
+					bool disable_underspeed_detection = false, float hgt_rate_sp = NAN,
+					bool enable_eco_mode = false);
 
 	DEFINE_PARAMETERS(
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -156,8 +156,7 @@ private:
 
 	uORB::Publication<vehicle_attitude_setpoint_s>		_attitude_sp_pub;
 	uORB::Publication<position_controller_status_s>		_pos_ctrl_status_pub{ORB_ID(position_controller_status)};			///< navigation capabilities publication
-	uORB::Publication<position_controller_landing_status_s>	_pos_ctrl_landing_status_pub{ORB_ID(position_controller_landing_status)};	///< landing status publication
-	uORB::Publication<tecs_status_s>			_tecs_status_pub{ORB_ID(tecs_status)};						///< TECS status publication
+	uORB::Publication<position_controller_landing_status_s>	_pos_ctrl_landing_status_pub{ORB_ID(position_controller_landing_status)};	///< landing status publication					///< TECS status publication
 	uORB::PublicationMulti<orbit_status_s>			_orbit_status_pub{ORB_ID(orbit_status)};
 
 	manual_control_setpoint_s	_manual_control_setpoint {};			///< r/c channel data
@@ -282,7 +281,6 @@ private:
 		DASH_FULL
 	};
 
-	// bool _conditions_for_eco_dash_met{false};
 	hrt_abstime _time_conditions_not_met{0};
 
 	float _last_airspeed_setpoint{NAN};

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -468,11 +468,11 @@ private:
 		//Speed mode params
 		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
 
-		(ParamInt<px4::params::FW_SPD_MODE_SET>) _fw_spd_mode_set,
-		(ParamFloat<px4::params::FW_ALT_MIN>) fw_alt_min,
-		(ParamFloat<px4::params::FW_ALT_ERR_U>) fw_alt_err_u,
-		(ParamFloat<px4::params::FW_ALT_ERR_O>) fw_alt_err_o,
-		(ParamFloat<px4::params::FW_T_ALT_TC_E>) _param_fw_t_h_error_tc_eco,
+		(ParamInt<px4::params::FW_SPD_MODE_SET>) _param_fw_spd_mode_set,
+		(ParamFloat<px4::params::FW_SPDM_ALT_MIN>) _param_fw_alt_spdm_min,
+		(ParamFloat<px4::params::FW_SPDM_ALT_ER_U>) _param_fw_spdm_alt_er_u,
+		(ParamFloat<px4::params::FW_SPDM_ALT_ER_O>) _param_fw_spdm_alt_er_o,
+		(ParamFloat<px4::params::FW_T_ALT_TC_E>) _param_fw_t_alt_tc_eco,
 		(ParamFloat<px4::params::FW_T_SPDWEIGHT_E>) _param_fw_t_spdweight_eco,
 		(ParamFloat<px4::params::FW_T_CLMB_R_SP_E>) _param_fw_t_clmb_r_sp_eco
 	)

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -268,6 +268,23 @@ private:
 		FW_POSCTRL_MODE_OTHER
 	} _control_mode_current{FW_POSCTRL_MODE_OTHER};		///< used to check the mode in the last control loop iteration. Use to check if the last iteration was in the same mode.
 
+	enum FW_SPEED_MODE {
+		FW_SPEED_MODE_NORMAL,
+		FW_SPEED_MODE_ECO,
+		FW_SPEED_MODE_DASH,
+	} _speed_mode_current{FW_SPEED_MODE_NORMAL};
+
+	enum FW_SPEED_MODE_COMMANDED {
+		NORMAL,
+		ECO_CRUISE,
+		ECO_FULL,
+		DASH_CRUISE,
+		DASH_FULL
+	} _speed_mode_setting{NORMAL};
+
+	bool _conditions_for_eco_dash_met{false};
+	hrt_abstime _time_conditions_not_met{0};
+
 	// wind state
 	hrt_abstime _first_time_current_mode_detected{0};		///< last time in normal wind mode
 
@@ -363,6 +380,8 @@ private:
 
 	void 		publishOrbitStatus(const position_setpoint_s pos_sp);
 
+	void		check_eco_dash_allowed();
+	void		updateSpeedMode();
 
 	void		update_wind_mode();
 
@@ -456,8 +475,11 @@ private:
 		(ParamFloat<px4::params::FW_WIND_THLD_L>) _param_fw_wind_thld_l,
 		(ParamFloat<px4::params::FW_WIND_ARSP_OF>) _param_fw_wind_arsp_of,
 
+		(ParamInt<px4::params::FW_SPD_MODE_SET>) _fw_spd_mode_set,
+		(ParamFloat<px4::params::FW_ALT_MIN>) fw_alt_min,
+		(ParamFloat<px4::params::FW_ALT_ERR_U>) fw_alt_err_u,
+		(ParamFloat<px4::params::FW_ALT_ERR_O>) fw_alt_err_o
 	)
-
 };
 
 #endif // FIXEDWINGPOSITIONCONTROL_HPP_

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -76,7 +76,6 @@
 #include <uORB/topics/position_controller_landing_status.h>
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
-#include <uORB/topics/tecs_status.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
@@ -284,7 +283,6 @@ private:
 
 	void		status_publish();
 	void		landing_status_publish();
-	void		tecs_status_publish();
 
 	void		abort_landing(bool abort);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -285,17 +285,6 @@ private:
 	bool _conditions_for_eco_dash_met{false};
 	hrt_abstime _time_conditions_not_met{0};
 
-	// wind state
-	hrt_abstime _first_time_current_mode_detected{0};		///< last time in normal wind mode
-
-	enum FW_WIND_MODE {
-		FW_WIND_MODE_LOW,
-		FW_WIND_MODE_NORMAL,
-		FW_WIND_MODE_HIGH,
-	} _fw_wind_mode_current{FW_WIND_MODE_NORMAL};		///< used to make wind-based airspeed setpoint adaptions
-
-	FW_WIND_MODE _fw_wind_mode_detected_prev{FW_WIND_MODE_NORMAL};
-
 	float _last_airspeed_setpoint{NAN};
 
 	param_t _param_handle_airspeed_trans{PARAM_INVALID};
@@ -477,9 +466,7 @@ private:
 		(ParamFloat<px4::params::FW_TKO_PITCH_MIN>) _takeoff_pitch_min,
 
 		//Speed mode params
-		(ParamFloat<px4::params::FW_WIND_THLD_H>) _param_fw_wind_thld_h,
-		(ParamFloat<px4::params::FW_WIND_THLD_L>) _param_fw_wind_thld_l,
-		(ParamFloat<px4::params::FW_WIND_ARSP_OF>) _param_fw_wind_arsp_of,
+		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
 
 		(ParamInt<px4::params::FW_SPD_MODE_SET>) _fw_spd_mode_set,
 		(ParamFloat<px4::params::FW_ALT_MIN>) fw_alt_min,

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -388,8 +388,8 @@ private:
 
 	void		check_eco_dash_allowed();
 	void		updateSpeedMode();
-
 	void		update_wind_mode();
+	void		resetAutoSpeedAdaptions();
 
 	/*
 	 * Call TECS : a wrapper function to call the TECS implementation

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -471,7 +471,10 @@ private:
 		(ParamInt<px4::params::FW_SPD_MODE_SET>) _fw_spd_mode_set,
 		(ParamFloat<px4::params::FW_ALT_MIN>) fw_alt_min,
 		(ParamFloat<px4::params::FW_ALT_ERR_U>) fw_alt_err_u,
-		(ParamFloat<px4::params::FW_ALT_ERR_O>) fw_alt_err_o
+		(ParamFloat<px4::params::FW_ALT_ERR_O>) fw_alt_err_o,
+		(ParamFloat<px4::params::FW_T_ALT_TC_E>) _param_fw_t_h_error_tc_eco,
+		(ParamFloat<px4::params::FW_T_SPDWEIGHT_E>) _param_fw_t_spdweight_eco,
+		(ParamFloat<px4::params::FW_T_CLMB_R_SP_E>) _param_fw_t_clmb_r_sp_eco
 	)
 };
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -859,7 +859,7 @@ PARAM_DEFINE_FLOAT(FW_GPSF_R, 15.0f);
  * Wind-based airspeed scaling factor in Eco
  *
  * Multiplying this factor with the current absolute wind estimate gives the airspeed offset
- * added to the setpoint (which is FW_AIRSPD_MIN) in Eco mode. This helps to make the
+ * added to the setpoint (which is FW_AIRSPD_MIN) in Eco mode (see FW_SPD_MODE_SET). This helps to make the
  * system more robust against disturbances in high wind.
  *
  * setpoint = FW_AIRSPD_MIN + FW_LND_AIRSPD_SC * wind
@@ -893,7 +893,7 @@ PARAM_DEFINE_INT32(FW_SPD_MODE_SET, 0);
 /**
  * Max altitude undershoot for Eco/Dash
  *
- * Eco/Dash mode is disabled if the current altitude is more than this value below the setpoint.
+ * Eco/Dash mode is disabled if the current altitude overshoots the setpoint by this value.
  *
  * @min 1.0
  * @max 50.0
@@ -906,7 +906,7 @@ PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_U, 10.f);
 /**
  * Max altitude overshoot for Eco/Dash
  *
- * Eco/Dash mode is disabled if the current altitude is more than this value above the setpoint.
+ * Eco/Dash mode is disabled if the current altitude undershoots the setpoint by this value.
  *
  * @min 1.0
  * @max 50.0
@@ -917,7 +917,7 @@ PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_U, 10.f);
 PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_O, 20.f);
 
 /**
- * Min altitude for Eco/Dash
+ * Minimum height above home for Eco/Dash
  *
  * Eco/Dash mode can be enabled if above this relative altitude to home.
  *
@@ -930,7 +930,7 @@ PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_O, 20.f);
 PARAM_DEFINE_FLOAT(FW_SPDM_ALT_MIN, 50.f);
 
 /**
- * Eco Mode: Speed <--> Altitude priority
+ * Speed <--> Altitude priority in Eco mode
  *
  * @min 0.0
  * @max 2.0

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -928,3 +928,40 @@ PARAM_DEFINE_FLOAT(FW_ALT_ERR_O, 20.f);
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_ALT_MIN, 50.f);
+
+/**
+ * Eco Mode: Speed <--> Altitude priority
+ *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 1
+ * @increment 1.0
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_T_SPDWEIGHT_E, 1.8f);
+
+/**
+ * Eco Mode: Altitude error time constant.
+ *
+ * Normally larger than FW_T_ALT_TC to have looser altitude control and in turn less throttle changes.
+ *
+ * @min 2.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_T_ALT_TC_E, 10.0f);
+
+/**
+ * Eco target climbrate.
+ *
+ * The rate at which the vehicle will climb in autonomous modes to achieve altitude setpoints in Eco mode.
+ *
+ * @unit m/s
+ * @min 0.5
+ * @max 15
+ * @decimal 2
+ * @increment 0.01
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_T_CLMB_R_SP_E, 2.0f);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -904,3 +904,59 @@ PARAM_DEFINE_FLOAT(FW_WIND_THLD_L, 0.0f);
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_WIND_ARSP_OF, 1.0f);
+
+/**
+ * FW Speed mode setting
+ *
+ * Setting
+ *
+ * @min 0
+ * @max 4
+ * @value 0 Normal
+ * @value 1 Eco cruise
+ * @value 2 Eco full
+ * @value 3 Dash cruise
+ * @value 4 Dash full
+ * @group FW TECS
+ */
+PARAM_DEFINE_INT32(FW_SPD_MODE_SET, 0);
+
+
+/**
+ * Max altitude undershoot for Eco/Dash
+ *
+ * Eco/Dash mode is disabled if the current altitude is more than this value below the setpoint.
+ *
+ * @min 1.0
+ * @max 50.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_ALT_ERR_U, 10.f);
+
+/**
+ * Max altitude overshoot for Eco/Dash
+ *
+ * Eco/Dash mode is disabled if the current altitude is more than this value above the setpoint.
+ *
+ * @min 1.0
+ * @max 50.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_ALT_ERR_O, 20.f);
+
+/**
+ * Min altitude for Eco/Dash
+ *
+ * Eco/Dash mode can be enabled if above this relative altitude to home.
+ *
+ * @min -200.0
+ * @max 200.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_ALT_MIN, 50.f);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -854,3 +854,53 @@ PARAM_DEFINE_INT32(FW_GPSF_LT, 30);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(FW_GPSF_R, 15.0f);
+
+/**
+ * High wind threshold
+ *
+ * If the current wind estimate is above this threshold,the value of FW_WIND_ARSP_OF
+ * is added to the cruise airspeed setpoint.
+ * Set to zero number to disable wind-based airspeed setpoint up-scaling.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 30
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_WIND_THLD_H, 0.0f);
+
+/**
+ * Low wind threshold
+ *
+ * If the current wind estimate is below this threshold for 60 seconds,the value of
+ * FW_WIND_ARSP_OF is subtracted from the cruise airspeed setpoint.
+ * Set to zero to disable wind-based airspeed setpoint down-scaling.
+ *
+ * @unit m/s
+ * @min 0
+ * @max 30
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_WIND_THLD_L, 0.0f);
+
+/**
+ * Wind-based airspeed setpoint offset
+ *
+ * Airspeed setpoint offset that is added/subtracted to the cruise airspeed setpoint if wind-based setpoint
+ * adaption is enabled for either or both high and low winds (FW_WIND_THLD_H and FW_WIND_THLD_L).
+ * If in high wind condition, this offset is added to the cruise airspeed setpoint.
+ * If in low wind condition, this offset is subtracted from the cruise airspeed setpoint.
+ * Note: manual airspeed setpoints via sticks must be disabled for wind-based adaption to work (see FW_POS_STK_CONF).
+ *
+ * @unit m/s
+ * @min 0
+ * @max 10
+ * @decimal 1
+ * @increment 0.01
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_WIND_ARSP_OF, 1.0f);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -896,7 +896,7 @@ PARAM_DEFINE_INT32(FW_SPD_MODE_SET, 0);
  * Eco/Dash mode is disabled if the current altitude overshoots the setpoint by this value.
  *
  * @min 1.0
- * @max 50.0
+ * @max 100.0
  * @decimal 1
  * @increment 0.1
  * @group FW TECS
@@ -909,7 +909,7 @@ PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_U, 10.f);
  * Eco/Dash mode is disabled if the current altitude undershoots the setpoint by this value.
  *
  * @min 1.0
- * @max 50.0
+ * @max 100.0
  * @decimal 1
  * @increment 0.1
  * @group FW TECS
@@ -932,6 +932,12 @@ PARAM_DEFINE_FLOAT(FW_SPDM_ALT_MIN, 50.f);
 /**
  * Speed <--> Altitude priority in Eco mode
  *
+ * Overrides FW_T_SPDWEIGHT in Eco mode.
+ *
+ * Set it close to 2 for looser altitude control.
+ * That helps increasing power efficiency by having a smoother throttle setpoint, plus
+ * it enables the vehicle to exploit favorable local uplift conditions to gain some altitude.
+ *
  * @min 0.0
  * @max 2.0
  * @decimal 1
@@ -943,7 +949,11 @@ PARAM_DEFINE_FLOAT(FW_T_SPDWEIGHT_E, 1.8f);
 /**
  * Eco Mode: Altitude error time constant.
  *
- * Normally larger than FW_T_ALT_TC to have looser altitude control and in turn less throttle changes.
+ * Overrides FW_T_ALT_TC in Eco mode.
+ *
+ * Increase it for looser altitude control.
+ * That helps increasing power efficiency by having a smoother throttle setpoint, plus
+ * it enables the vehicle to exploit favorable local uplift conditions to gain some altitude.
  *
  * @min 2.0
  * @decimal 1
@@ -954,6 +964,8 @@ PARAM_DEFINE_FLOAT(FW_T_ALT_TC_E, 10.0f);
 
 /**
  * Eco target climbrate.
+ *
+ * Overrides FW_T_CLMB_R_SP in Eco mode.
  *
  * The rate at which the vehicle will climb in autonomous modes to achieve altitude setpoints in Eco mode.
  *

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -901,7 +901,7 @@ PARAM_DEFINE_INT32(FW_SPD_MODE_SET, 0);
  * @increment 0.1
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_ALT_ERR_U, 10.f);
+PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_U, 10.f);
 
 /**
  * Max altitude overshoot for Eco/Dash
@@ -914,7 +914,7 @@ PARAM_DEFINE_FLOAT(FW_ALT_ERR_U, 10.f);
  * @increment 0.1
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_ALT_ERR_O, 20.f);
+PARAM_DEFINE_FLOAT(FW_SPDM_ALT_ER_O, 20.f);
 
 /**
  * Min altitude for Eco/Dash
@@ -927,7 +927,7 @@ PARAM_DEFINE_FLOAT(FW_ALT_ERR_O, 20.f);
  * @increment 0.1
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_ALT_MIN, 50.f);
+PARAM_DEFINE_FLOAT(FW_SPDM_ALT_MIN, 50.f);
 
 /**
  * Eco Mode: Speed <--> Altitude priority

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -856,54 +856,22 @@ PARAM_DEFINE_INT32(FW_GPSF_LT, 30);
 PARAM_DEFINE_FLOAT(FW_GPSF_R, 15.0f);
 
 /**
- * High wind threshold
+ * Wind-based airspeed scaling factor in Eco
  *
- * If the current wind estimate is above this threshold,the value of FW_WIND_ARSP_OF
- * is added to the cruise airspeed setpoint.
- * Set to zero number to disable wind-based airspeed setpoint up-scaling.
+ * Multiplying this factor with the current absolute wind estimate gives the airspeed offset
+ * added to the setpoint (which is FW_AIRSPD_MIN) in Eco mode. This helps to make the
+ * system more robust against disturbances in high wind.
  *
- * @unit m/s
- * @min 0.0
- * @max 30
- * @decimal 1
- * @increment 0.5
- * @group FW TECS
- */
-PARAM_DEFINE_FLOAT(FW_WIND_THLD_H, 0.0f);
-
-/**
- * Low wind threshold
+ * setpoint = FW_AIRSPD_MIN + FW_LND_AIRSPD_SC * wind
  *
- * If the current wind estimate is below this threshold for 60 seconds,the value of
- * FW_WIND_ARSP_OF is subtracted from the cruise airspeed setpoint.
- * Set to zero to disable wind-based airspeed setpoint down-scaling.
- *
- * @unit m/s
+ * @unit norm
  * @min 0
- * @max 30
- * @decimal 1
- * @increment 0.5
- * @group FW TECS
- */
-PARAM_DEFINE_FLOAT(FW_WIND_THLD_L, 0.0f);
-
-/**
- * Wind-based airspeed setpoint offset
- *
- * Airspeed setpoint offset that is added/subtracted to the cruise airspeed setpoint if wind-based setpoint
- * adaption is enabled for either or both high and low winds (FW_WIND_THLD_H and FW_WIND_THLD_L).
- * If in high wind condition, this offset is added to the cruise airspeed setpoint.
- * If in low wind condition, this offset is subtracted from the cruise airspeed setpoint.
- * Note: manual airspeed setpoints via sticks must be disabled for wind-based adaption to work (see FW_POS_STK_CONF).
- *
- * @unit m/s
- * @min 0
- * @max 10
- * @decimal 1
+ * @max 2
+ * @decimal 2
  * @increment 0.01
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_WIND_ARSP_OF, 1.0f);
+PARAM_DEFINE_FLOAT(FW_WIND_ARSP_SC, 0.0f);
 
 /**
  * FW Speed mode setting


### PR DESCRIPTION
**Describe problem solved by this pull request**
- no interface to change airspeed in auto flight if not in mission
- no interface at all to change climb/descend speed
- TECS can only be tuned properly for one single airspeed setpoint
- flying in high wind with an airspeed setpoint close to stall is dangerous due to increased external disturbances, so the airspeed setpoint should ideally be increased in these situations


**Describe your solution**
- add logic to enable fixed-wing speed modes (Normal, Eco, Dash)
- adapt airspeed setpoint adaption in Auto modes

*Speed modes*:
The idea is to introduce speed modes that the user can easily and without in-depth knowledge of the system trigger to fly slow and thus safe energy ("Eco"), normally or fast ("Dash"). 

Eco: Flying in Eco reduces the airspeed setpoint to `FW_AIRSPD_MIN`, the climb rate to `FW_T_CLMB_R_SP_E` and allows to change internal TECS tuning via the speed weight and the altitude time constant, such that it uses less energy trying to keep the altitude very precisely and instead can exploit thermals to climb to some extend. 

Dash: Sets the airspeed setpoint to `FW_AIRSPD_MAX`. No other settings are are changed atm, but it would be straight forward to e.g. add separate climb/descend rates.

Setting of speed mode: 
Currently enabled via parameter `FW_SPD_MODE_SET`, but should be replaced by a mavlink message as it should be easy to set in flight by the user. `FW_SPD_MODE_SET` has 5 options:
- 0: Normal
- 1: Eco when in cruise (level flight)
- 2: Eco (also when not in level flight)
- 3: Dash when in cruise 
- 4: Dash 
Additionally to the setting done by the user, there are customizable checks in place to disable Eco and Dash if flying low (below `FW_ALT_MIN`) or if the current altitude error is high (there are separate limits for below and above the setpoint, `FW_ALT_ERR_U` and `FW_ALT_ERR_O`). 

Airspeed adaption in Auto modes:
The following graph roughly shows the data flow for the airspeed setpoint. Some of it was already in place (groundspeed undershoot, load-factor based airspeed setpoint constraining). Let me know if you think the logic should be cleaned up a bit, it's currently quite patched together with the legacy setpoint adaptions.
![image](https://user-images.githubusercontent.com/26798987/140947600-765135f1-e1c4-4311-ad0f-227abe35557f.png)

Wind-based adaption: 
If flying in Eco mode (thus normally close to stall speed), there is an offset added to the airspeed setpoint: setpoint += `FW_WIND_ARSP_SC` * abs(wind). So if the scale is set to 0.2, then for 10m/s there are 2m/s added to the setpoint that help making the vehicle's attitude control more robust to disturbances caused by the high wind, plus reduces the chance of a groundspeed undershoot. 

*How could interface on ground station look like*
There could be a slider for the 5 speed options, something like this: 
![image](https://user-images.githubusercontent.com/26798987/141269714-ce106e06-b306-48e9-9fd4-886489fc9068.png)

The closes mavlink message we have for setting the flight speed is [MAV_CMD_DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED). Likely it's though cleaner to introduce a new message, e.g. DO_SET_SPEED_MODE. I guess this could also be useful for Multicopter applications? To be able to speed up the execution of a mission part, or to have it fast going to a a place. 

**Describe possible alternatives**
Currently all the airspeed setpoint adaptions are only happening in Auto flight. We should also think about enabling them (or some of them) in Manual flight modes containing an airspeed setpoint (Position, Altitude).
Are the names "Eco" and "Dash" descriptive? Or how about "Eco" and "Sport"?

**Test data / coverage**
SITL tested, and party flight tested on real vehicles.

**Additional context**
