### PR TITLE
smbus_sbs: Define linker language for a header-only library

### DIFF
--- a/src/lib/drivers/smbus_sbs/CMakeLists.txt
+++ b/src/lib/drivers/smbus_sbs/CMakeLists.txt
@@ -32,3 +32,4 @@
 ############################################################################
 
 px4_add_library(drivers__smbus_sbs SBS.hpp)
+set_target_properties(drivers__smbus_sbs PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

**Describe problem solved by this pull request**

This is causing errors in some of my branches; I guess that in the master the linker language comes implicitly from somewhere else.

**Describe your solution**

CMake can't detect the linker language from this library as it is header-only; it should be explicitly set.

