### PR TITLE
Remove src/lib/drivers/accelerometer and gyroscope linking to drivers…

### DIFF
--- a/src/lib/drivers/accelerometer/CMakeLists.txt
+++ b/src/lib/drivers/accelerometer/CMakeLists.txt
@@ -36,4 +36,4 @@ px4_add_library(drivers_accelerometer
 	PX4Accelerometer.hpp
 )
 target_compile_options(drivers_accelerometer PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
-target_link_libraries(drivers_accelerometer PRIVATE conversion drivers__device)
+target_link_libraries(drivers_accelerometer PRIVATE conversion)

--- a/src/lib/drivers/gyroscope/CMakeLists.txt
+++ b/src/lib/drivers/gyroscope/CMakeLists.txt
@@ -36,4 +36,4 @@ px4_add_library(drivers_gyroscope
 	PX4Gyroscope.hpp
 )
 target_compile_options(drivers_gyroscope PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
-target_link_libraries(drivers_gyroscope PRIVATE conversion drivers__device)
+target_link_libraries(drivers_gyroscope PRIVATE conversion)


### PR DESCRIPTION
…__device

These are pure uORB publishers, they don't link to drivers__device.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

