### PR TITLE
Adding MAVLink message stream of GPS_RTCM_DATA to Autopilot

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -80,6 +80,7 @@
 #include "streams/GPS_GLOBAL_ORIGIN.hpp"
 #include "streams/GPS_RAW_INT.hpp"
 #include "streams/GPS_STATUS.hpp"
+#include "streams/GPS_RTCM_DATA.hpp"
 #include "streams/HEARTBEAT.hpp"
 #include "streams/HIGHRES_IMU.hpp"
 #include "streams/HIL_ACTUATOR_CONTROLS.hpp"
@@ -542,8 +543,11 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamRawRpm>(),
 #endif // RAW_RPM_HPP
 #if defined(EFI_STATUS_HPP)
-	create_stream_list_item<MavlinkStreamEfiStatus>()
+	create_stream_list_item<MavlinkStreamEfiStatus>(),
 #endif // EFI_STATUS_HPP
+#if defined(GPS_RTCM_DATA_HPP)
+	create_stream_list_item<MavlinkStreamGPSRTCMData>()
+#endif // GPS_RTCM_DATA_HPP
 };
 
 const char *get_stream_name(const uint16_t msg_id)

--- a/src/modules/mavlink/streams/GPS_RTCM_DATA.hpp
+++ b/src/modules/mavlink/streams/GPS_RTCM_DATA.hpp
@@ -1,0 +1,81 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef GPS_RTCM_DATA_HPP
+#define GPS_RTCM_DATA_HPP
+
+#include <uORB/topics/gps_inject_data.h>
+
+class MavlinkStreamGPSRTCMData : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamGPSRTCMData(mavlink); }
+
+	static constexpr const char *get_name_static() { return "GPS_RTCM_DATA"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_GPS_RTCM_DATA; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return _gps_inject_data_sub.advertised() ? (MAVLINK_MSG_ID_GPS_RTCM_DATA_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) : 0;
+	}
+
+private:
+	explicit MavlinkStreamGPSRTCMData(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _gps_inject_data_sub{ORB_ID(gps_inject_data), 0};
+
+	bool send() override
+	{
+		gps_inject_data_s gps_inject_data;
+		bool sent = false;
+
+		while ((_mavlink->get_free_tx_buf() >= get_size()) && _gps_inject_data_sub.update(&gps_inject_data)) {
+			mavlink_gps_rtcm_data_t msg{};
+
+			msg.len = gps_inject_data.len;
+			msg.flags = gps_inject_data.flags;
+			memcpy(msg.data, gps_inject_data.data, sizeof(msg.data));
+
+			mavlink_msg_gps_rtcm_data_send_struct(_mavlink->get_channel(), &msg);
+
+			sent = true;
+		}
+
+		return sent;
+	}
+};
+
+#endif // GPS_RTCM_DATA_HPP


### PR DESCRIPTION
**Describe problem solved by this pull request**
In the current code, MAVLINK message stream of GPS_RTCM_DATA is not available / cannot be seen from the autopilot, at least when tested with QGroundControl, as shown in the image below.

![No_RTK_PX4_Message_QGC](https://user-images.githubusercontent.com/34166338/141117876-34782ed4-1bb3-48f6-a275-a9c4e564d81f.png)

The GPS_RTCM_DATA is streamed via uORB from the base to the rover, under the `gps_inject_data` uORB message, as shown in the image below.

![gps_inject_data_mavlink_console_output](https://user-images.githubusercontent.com/34166338/141118097-2ba764e9-5458-46d9-b5e6-ba67ab80ee01.png)

The new addition is to stream the `gps_inject_data` uORB messages as GPS_RTCM_DATA to the autopilot, as shown in the image below.

![GPS_RTCM_DATA_PX4_QGroundControl](https://user-images.githubusercontent.com/34166338/141118270-0f3a3a74-c066-47f3-94ca-b177495d9107.png)

**Describe your solution**
The proposed implementation is adding the initial structure for the GPS_RTCM_DATA stream message for MAVLink.

**Test data / coverage**
The test was done with Pixhawk 4 running on DJI F550 Hex platform.
