### PR TITLE
Horizontal emergency braking

### DIFF
--- a/src/lib/motion_planning/PositionSmoothing.hpp
+++ b/src/lib/motion_planning/PositionSmoothing.hpp
@@ -131,6 +131,13 @@ public:
 	{
 		return {getCurrentAccelerationX(), getCurrentAccelerationY(), getCurrentAccelerationZ()};
 	}
+	/**
+	 * @return float Current trajectory acceleration in X and Y
+	 */
+	inline Vector2f getCurrentAccelerationXY() const
+	{
+		return {getCurrentAccelerationX(), getCurrentAccelerationY()};
+	}
 
 	/**
 	 * @return float Current trajectory velocity in X
@@ -162,6 +169,14 @@ public:
 	inline Vector3f getCurrentVelocity() const
 	{
 		return {getCurrentVelocityX(), getCurrentVelocityY(), getCurrentVelocityZ()};
+	}
+
+	/**
+	 * @return float Current trajectory velocity in X and Y
+	 */
+	inline Vector2f getCurrentVelocityXY() const
+	{
+		return {getCurrentVelocityX(), getCurrentVelocityY()};
 	}
 
 	/**

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -77,8 +77,7 @@ protected:
 
 	bool isTargetModified() const;
 
-	bool _is_vert_emergency_braking_active{false};
-	bool _is_hor_emergency_braking_active{false};
+	bool _is_emergency_braking_active{false};
 
 	void _prepareSetpoints(); /**< Generate velocity target points for the trajectory generator. */
 	void _updateTrajConstraints();

--- a/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -77,7 +77,8 @@ protected:
 
 	bool isTargetModified() const;
 
-	bool _is_emergency_braking_active{false};
+	bool _is_vert_emergency_braking_active{false};
+	bool _is_hor_emergency_braking_active{false};
 
 	void _prepareSetpoints(); /**< Generate velocity target points for the trajectory generator. */
 	void _updateTrajConstraints();


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes (most of the aspects discussed in) https://github.com/PX4/PX4-Autopilot/issues/18440. 

**Describe your solution**
Extend the vertical emergency braking mode introduced in https://github.com/PX4/PX4-Autopilot/pull/18277:
- if the current trajectory setpoint's velocity is significantly outside of the velocity constraints, momentarily increase the maximum jerk and acceleration values to allow for faster recovery.
- exit the emergency braking mode once all velocity and acceleration constraints are satisfied

I chose these conditions because I think in general you don't want a drone that flies in an auto mode faster than the maximum specified velocity. I find it the lesser evil to momentarily increase jerk and accel limits to get faster back into normal conditions. Also, I think they are an easily understandable set of conditions that can apply to both vertical and horizontal components.

Clearly for me the main focus was to limit the horizontal drifts after a Quadchute, but I think the above reasoning is something that applies in general. 

**Describe possible alternatives**
- Different thresholds could be chosen. My feeling told me that a third above max speed is reasonable, but there is no strict reason for not choosing 1.2 or 1.5 times for example. But I think that the previous twice the constraints was too large.
- If there is some reason why it wasn't a good idea to merge the handling of horizontal and vertical emergency braking modes I can split them.

**Test data / coverage**
For now, SITL tested with `gazebo_standard_vtol`. I increased FW_AIRSPD_TRIM to 20m/s, MPC_THR_MIN to 20% to have enough control authority to brake hard and MPC_XY_ERR_MAX to 10m to allow for larger offsets between trajectory and current position.
Log 1: https://logs.px4.io/plot_app?log=6b4363f7-6597-4ca3-943e-f647e37b185e
Log 2: https://logs.px4.io/plot_app?log=ee4ce75a-f7ad-4c56-8742-1c5a4d490c57
![image](https://user-images.githubusercontent.com/48206725/141131448-82fb1616-68b4-4fec-855f-842f012cdaae.png)
![image](https://user-images.githubusercontent.com/48206725/141131584-0010eb45-f2ef-4fd9-8fa8-e11a3ccdd489.png)
You can see that indeed the accelerations and constraints are momentarily increased. 

I'm planning to flight test it on a real VTOL either this or next week. I will update this section with the logs when I have them available.

**Additional context**
I think this is already a big improvement as it is right now, but there are still two aspects that could be improved, either as part of this PR or as a follow-up PR.

1. I don't like how `trajectory_setpoint/z` remains frozen at 20m even though the vehicle is higher and the goal altitude is 60m for the RTL. So the drone first goes down again before moving up. I couldn't figure out what exactly causes this nuisance. If you spot the root cause I'm happy to tackle it in this PR, but I wouldn't want it blocking this PR as is.
2. The position controller still cuts local velocity setpoints, so the final behaviour isn't as smooth as planned. I think if you modify https://github.com/ThomasRigi/Firmware/blob/hor-emergency-braking/src/modules/mc_pos_control/MulticopterPositionControl.cpp#L432 you could improve this ~~, but it has implications beyond my tests conducted so far, and I would prefer not to overload this PR. But it's something I'm motivated to investigate as a follow-up PR.~~ On second thought it really seems like the sensible thing to do, so I'm going to look into it for this PR.
