### PR TITLE
Tools/check_submodules.sh: perform submodule sync again after first update to reach nested submodules

### DIFF
--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -9,6 +9,7 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 	if [ "$CI" == "true" ] || [ -n "${VSCODE_PID+set}" ]; then
 		git submodule --quiet sync --recursive -- $1
 		git submodule --quiet update --init --recursive --jobs=8 -- $1  || true
+		git submodule --quiet sync --recursive -- $1
 		git submodule --quiet update --init --recursive --jobs=8 -- $1
 		exit 0
 	fi
@@ -51,6 +52,7 @@ if [[ -f $1"/.git" || -d $1"/.git" ]]; then
 else
 	git submodule --quiet sync --recursive --quiet -- $1
 	git submodule --quiet update --init --recursive -- $1  || true
+	git submodule --quiet sync --recursive --quiet -- $1
 	git submodule --quiet update --init --recursive -- $1
 fi
 


### PR DESCRIPTION
This is an attempt to handle the failure when a submodule reference within another submodule changes.
![Screenshot from 2021-11-10 10-48-40](https://user-images.githubusercontent.com/84712/141145669-d6e03d47-86e2-4880-8194-8e8749630f6d.png)

