### PR TITLE
Initial Apple M1 support

### DIFF
--- a/src/modules/gyro_fft/CMakeLists.txt
+++ b/src/modules/gyro_fft/CMakeLists.txt
@@ -38,6 +38,11 @@ if(${PX4_PLATFORM} MATCHES "NuttX")
 	add_compile_options(-DARM_MATH_DSP)
 endif()
 
+# Disable 32-bit assembly warnings on apple silicon. Triggered by unused code only.
+if(${PX4_PLATFORM} MATCHES "posix" AND APPLE AND ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm64")
+	add_compile_options(-Wno-asm-operand-widths)
+endif()
+
 add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wno-nested-externs>)
 
 px4_add_module(


### PR DESCRIPTION
This PR adds initial support native compilation on apple silicon (M1) macos. 

**Describe problem solved by this pull request**
Apple is moving to their own arm64 based processor architecture. While at the moment one can run PX4 sitl perfectly fine in x86 emulation on those machines, having it running natively is more desirable. 

**Describe your solution**
Two things are addressed:
- Submodule for jmavsim set to https://github.com/PX4/jMAVSim/pull/132. This version of jmavsim contains native OpenGL binaries for arm64, this makes it run on M1

- The gyro_fft module uses CMSIS. CMSIS has a lot of functions with inline arm 32-bit assembly. When compiling on x86 or any non-dsp and non-neon arm processor (such as the M1), none of these functions ever get used. This is what allows (presumably) to compile on x86. On M1, the story is the same. Also none of those functions ever get used, but since we are compiling to an arm target, the apple compiler somehow still issues warnings for the inline arm assembly using 32-bit registers instead of native 64-bit registers. Since we treat those warnings as errors, compilation fails. Disabling this specific warning on apple silicon fixes the issue. This seems to be an apple-clang thing. GCC on linux arm64 doesn't seem to have this issue.

**Describe possible alternatives**
It would be better if all those functions would be behind preprocessor statements to actually not be in the code for targets that do not support them, especially also x86. But since we just use CMSIS code, we should not alter those files

**Test data / coverage**
SITL runs in jmavsim, after installing the environment natively with homebrew from https://github.com/PX4/homebrew-px4/pull/80

**Additional context**

To note:
- gazebo is not working yet
- When compiling for nuttx, we invoke the arm compiler binaries installed with the toolchain. Those compiler binaries are x86 and run therefore in rosetta. This is fine though and works out of the box.

Additional testing would be welcome!
