### PR TITLE
mavlink: fix forwarding to target id >= 128

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -440,11 +440,11 @@ Mavlink::forward_message(const mavlink_message_t *msg, Mavlink *self)
 	if (meta) {
 		// Extract target system and target component if set
 		if (meta->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM) {
-			target_system_id = (_MAV_PAYLOAD(msg))[meta->target_system_ofs];
+			target_system_id = static_cast<uint8_t>((_MAV_PAYLOAD(msg))[meta->target_system_ofs]);
 		}
 
 		if (meta->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT) {
-			target_component_id = (_MAV_PAYLOAD(msg))[meta->target_component_ofs];
+			target_component_id = static_cast<uint8_t>((_MAV_PAYLOAD(msg))[meta->target_component_ofs]);
 		}
 	}
 


### PR DESCRIPTION
The `_MAV_PAYLOAD` macro casts the value to a `char*`. Some compilers treat `char` as signed, so we were getting negative system and component ids if the id was >= 128. This caused later comparisons to fail which resulted in messages not being forwarded.