### PR TITLE
ver: print PX4_BOARD_LABEL for 'ver all'

### DIFF
--- a/src/lib/version/CMakeLists.txt
+++ b/src/lib/version/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(version version.c)
 target_compile_definitions(version
 	PUBLIC
 		PX4_BOARD_NAME="${PX4_BOARD_NAME}"
+		PX4_BOARD_LABEL="${PX4_BOARD_LABEL}"
 	PRIVATE
 		BUILD_URI=${BUILD_URI}
 	)

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -57,6 +57,14 @@ static inline const char *px4_board_name(void)
 }
 
 /**
+ * get the board build target variant
+ */
+static inline const char *px4_board_target_label(void)
+{
+	return PX4_BOARD_LABEL;
+}
+
+/**
  * get the board sub type
  */
 static inline const char *px4_board_sub_type(void)

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -217,6 +217,9 @@ int ver_main(int argc, char *argv[])
 
 			}
 
+			if (show_all) {
+				printf("Build variant: %s\n", px4_board_target_label());
+			}
 
 			if (show_all || !strncmp(argv[1], sz_ver_gcc_str, sizeof(sz_ver_gcc_str))) {
 				printf("Toolchain: %s, %s\n", px4_toolchain_name(), px4_toolchain_version());


### PR DESCRIPTION
```
 ver all
HW arch: PX4_FMU_V5
HW type: V500
HW version: 0x00000000
HW revision: 0x00000000
FW git-hash: fc19d173bfcbe0ae81077f7d8df403e246c7a99b
FW version: 1.12.3 0 (17564416)
FW git-branch: board_label_ver
OS: NuttX
OS version: Release 10.0.0 (167772415)
OS git-hash: 80b730cdb35570b3aa8b0062b3fe12acc37e9bf2
Build datetime: Nov 11 2021 10:42:18
Build uri: localhost
Build variant: default
Toolchain: GNU GCC, 9.3.1 20200408 (release)
PX4GUID: 000200000000353436333138511900240029
MCU: STM32F76xxx, rev. Z
```