### PR TITLE
fix the quaternion normalization issue

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3778,7 +3778,7 @@ void Commander::estimator_check()
 						&& (fabsf(q(1)) <= 1.f)
 						&& (fabsf(q(2)) <= 1.f)
 						&& (fabsf(q(3)) <= 1.f);
-	const bool norm_in_tolerance = (fabsf(1.f - q.norm()) <= FLT_EPSILON);
+	const bool norm_in_tolerance = (fabsf(1.f - q.norm()) <= 1e-6f);
 
 	const bool condition_attitude_valid = (hrt_elapsed_time(&attitude.timestamp) < 1_s)
 					      && norm_in_tolerance && no_element_larger_than_one;


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
Be course of the numerical computing error . The normalization of the quaternion can't always equal to 1 precisely. It could occasionally trigger the error"attitude estimate no longer valid".
**Describe your solution**
enlarge the threshold from FLT_EPSILON to 1e-6f.

**Describe possible alternatives**


**Test data / coverage**
It has been tested. The solution keeps it silence.

**Additional context**
none
