### PR TITLE
gyro_calibration: reset on any sensor timeout

### DIFF
--- a/src/modules/gyro_calibration/GyroCalibration.cpp
+++ b/src/modules/gyro_calibration/GyroCalibration.cpp
@@ -155,12 +155,20 @@ void GyroCalibration::Run()
 			if (_gyro_calibration[gyro].device_id() == sensor_gyro.device_id) {
 				const Vector3f val{Vector3f{sensor_gyro.x, sensor_gyro.y, sensor_gyro.z} - _gyro_calibration[gyro].thermal_offset()};
 				_gyro_mean[gyro].update(val);
+				_gyro_last_update[gyro] = sensor_gyro.timestamp;
 
 			} else {
 				// setting device id, reset all
 				_gyro_calibration[gyro].set_device_id(sensor_gyro.device_id);
 				Reset();
 			}
+		}
+
+		if ((_gyro_last_update[gyro] != 0) && (hrt_elapsed_time(&_gyro_last_update[gyro]) > 100_ms)) {
+			// reset on any timeout
+			Reset();
+			_gyro_last_update[gyro] = 0;
+			return;
 		}
 	}
 

--- a/src/modules/gyro_calibration/GyroCalibration.hpp
+++ b/src/modules/gyro_calibration/GyroCalibration.hpp
@@ -95,6 +95,7 @@ private:
 	calibration::Gyroscope _gyro_calibration[MAX_SENSORS] {};
 	math::WelfordMean<matrix::Vector3f> _gyro_mean[MAX_SENSORS] {};
 	float _temperature[MAX_SENSORS] {};
+	hrt_abstime _gyro_last_update[MAX_SENSORS] {};
 
 	matrix::Vector3f _acceleration[MAX_SENSORS] {};
 


### PR DESCRIPTION
If a sensor goes away and returns for some reason we only want to use fresh data once it's fully back online.