### PR TITLE
mission_block: always accept yaw in MC takeoff

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -343,6 +343,14 @@ MissionBlock::is_mission_item_reached()
 				_waypoint_yaw_reached = true;
 			}
 
+			// Always accept yaw during takeoff
+			// TODO: Ideally Navigator would handle a yaw reset and adjust its yaw setpoint, making the
+			// following no longer necessary.
+			// FlightTaskAuto is currently also ignoring the yaw setpoint during takeoff and thus "handling" it.
+			if (_mission_item.nav_cmd == vehicle_command_s::VEHICLE_CMD_NAV_TAKEOFF) {
+				_waypoint_yaw_reached = true;
+			}
+
 			/* if heading needs to be reached, the timeout is enabled and we don't make it, abort mission */
 			if (!_waypoint_yaw_reached && _mission_item.force_heading &&
 			    (_navigator->get_yaw_timeout() >= FLT_EPSILON) &&


### PR DESCRIPTION
Navigator sets a 3D waypoint for takeoffs that includes a heading setpoint. When EKF resets the yaw / heading during takeoff, the existing yaw setpoint is outdated and wrong and will never be reached. For this reason the flight task `FlightTaskAuto` is currently not even trying to track yaw during takeoff: https://github.com/PX4/PX4-Autopilot/blob/4a66c8c4c479a1780cbbff45a5e0c400b2cb3517/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp#L303-L310

This PR implements a similar workaround for mission_block.cpp, allowing it to ignore the yaw setpoints during takeoffs of Multicopters. The "proper" fix would be to modify Navigator such that a heading reset is handled correctly and the waypoint as well as the resulting yaw setpoint are updated.