### PR TITLE
mavlink_ftp: disallow writes outside of /fs/microsd under NuttX

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -155,6 +155,8 @@ private:
 	uint8_t _getServerComponentId(void);
 	uint8_t _getServerChannel(void);
 
+	bool _validatePathIsWritable(const char *path);
+
 	/**
 	 * make sure that the working buffers _work_buffer* are allocated
 	 * @return true if buffers exist, false if allocation failed


### PR DESCRIPTION
As these files are kept in RAM, it could just fill up the RAM.

Fixes https://github.com/PX4/PX4-Autopilot/issues/18651