### PR TITLE
Commander: reword data link regained message 

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3396,8 +3396,8 @@ void Commander::data_link_check()
 					_status_changed = true;
 
 					if (_datalink_last_heartbeat_gcs != 0) {
-						mavlink_log_info(&_mavlink_log_pub, "Data link regained\t");
-						events::send(events::ID("commander_dl_regained"), events::Log::Info, "Data link regained");
+						mavlink_log_info(&_mavlink_log_pub, "Connection to ground station regained\t");
+						events::send(events::ID("commander_gcs_regained"), events::Log::Info, "Connection to ground station regained");
 					}
 
 					if (!_armed.armed && !_status_flags.condition_calibration_enabled) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
... to be consistent with the lost message.

The lost message is "Connection to ground station lost", see here:
https://github.com/PX4/PX4-Autopilot/blob/4a14a8bc7fb6f47c8e7be72d3de502d35a61a40e/src/modules/commander/Commander.cpp#L3448-L3450

**Describe your solution**
I'm rewording to a consistent message:
"Connection to ground station regained"

**Test data / coverage**
I ran this in SITL and the messaging seems easier to understand.
![image](https://user-images.githubusercontent.com/4668506/142252494-ea4e8795-651f-49ff-a338-502c28d74d03.png)

**Additional context**
The lost message was rephrased here: https://github.com/PX4/PX4-Autopilot/pull/15315/files#diff-e4b611e75eba3844661619867ee06befbcf230aced354a14f167f7d0ebbca8e0R3785
