### PR TITLE
ekf2: expand accel bias stability criteria

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -548,7 +548,7 @@ union warning_event_status_u {
 		bool gps_data_stopped_using_alternate	: 1; ///< 3 - true when the gps data has stopped for a significant time period but the filter is able to use other sources of data to maintain navigation
 		bool height_sensor_timeout		: 1; ///< 4 - true when the height sensor has not been used to correct the state estimates for a significant time period
 		bool stopping_navigation		: 1; ///< 5 - true when the filter has insufficient data to estimate velocity and position and is falling back to an attitude, height and height rate mode of operation
-		bool invalid_accel_bias_cov_reset	: 1; ///< 6 - true when the filter has detected bad acceerometer bias state esitmstes and has reset the corresponding covariance matrix elements
+		bool invalid_accel_bias_cov_reset	: 1; ///< 6 - true when the filter has detected bad acceerometer bias state estimates and has reset the corresponding covariance matrix elements
 		bool bad_yaw_using_gps_course		: 1; ///< 7 - true when the fiter has detected an invalid yaw esitmate and has reset the yaw angle to the GPS ground course
 		bool stopping_mag_use			: 1; ///< 8 - true when the filter has detected bad magnetometer data and is stopping further use of the magnetomer data
 		bool vision_data_stopped		: 1; ///< 9 - true when the vision system data has stopped for a significant time period

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -244,6 +244,8 @@ public:
 	Vector3f getAccelBiasVariance() const { return Vector3f{P(13, 13), P(14, 14), P(15, 15)} / sq(_dt_ekf_avg); } // get the accelerometer bias variance in m/s**2
 	Vector3f getMagBiasVariance() const { return Vector3f{P(19, 19), P(20, 20), P(21, 21)}; }
 
+	bool accel_bias_inhibited() const { return _accel_bias_inhibit[0] || _accel_bias_inhibit[1] || _accel_bias_inhibit[2]; }
+
 	// get GPS check status
 	void get_gps_check_status(uint16_t *val) const { *val = _gps_check_fail_status.value; }
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -208,8 +208,6 @@ private:
 	struct InFlightCalibration {
 		hrt_abstime last_us{0};         ///< last time the EKF was operating a mode that estimates accelerometer biases (uSec)
 		hrt_abstime total_time_us{0};   ///< accumulated calibration time since the last save
-		Vector3f last_bias{};           ///< last valid XYZ accelerometer bias estimates (Gauss)
-		Vector3f last_bias_variance{};  ///< variances for the last valid accelerometer XYZ bias estimates (m/s**2)**2
 		bool cal_available{false};      ///< true when an unsaved valid calibration for the XYZ accelerometer bias is available
 	};
 
@@ -240,6 +238,8 @@ private:
 	Vector3f _last_accel_calibration_published{};
 	Vector3f _last_gyro_calibration_published{};
 	Vector3f _last_mag_calibration_published{};
+
+	hrt_abstime _last_sensor_bias_published{0};
 
 	float _last_baro_bias_published{};
 


### PR DESCRIPTION
The ekf2 accel "calibration" (stable estimated bias) was initially based on the mag criteria (in flight + no faults + 3d mag fusion), but there's no accel equivalent to mag_3D.

This PR attempts to collect all relevant factors to the estimated accel bias being acceptable and require that they're all satisfied continuously for 30 seconds before declaring it's stable (acceptable to update calibration). This is just a first pass of what seemed appropriate, @bresch please update accordingly.

 - vehicle not at rest
 - valid height mode
 - preflight no height failure
 - no height sensor timeout
 - no invalid_accel_bias_cov_reset
 - no vertical velocity or position fusion rejections
 - bias variance within valid min/max range continuously for entire period (not just when calibration is retrieved)