### PR TITLE
Commander: Allow arming a rover with the throttle stick in the middle

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -576,7 +576,7 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 			}
 
 			if (!_vehicle_control_mode.flag_control_climb_rate_enabled &&
-			    !_status.rc_signal_lost && !_is_throttle_low) {
+			    !_status.rc_signal_lost && !_is_throttle_low && _status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROVER) {
 				mavlink_log_critical(&_mavlink_log_pub, "Arming denied: high throttle\t");
 				events::send(events::ID("commander_arm_denied_throttle_high"),
 				{events::Log::Critical, events::LogInternal::Info},


### PR DESCRIPTION
**Describe problem solved by this pull request**
With a rover that supports driving forward and backward the stick is usually mapped to stop in the center so it does not make sense to only allow arming in full reverse stick position.

**Describe your solution**
Do not force the stick to be in the lowest position for a rover in manual mode.

**Describe possible alternatives**
Ideally this would be decided in the rover manual mode but until we have that it needs to be allowed in commander.

**Test data / coverage**
We successfully used this change on a rover and armed it through the ground station while the stick was not in full reverse position.
