### PR TITLE
FlightTaskAuto: refactor reducing number of methods

### DIFF
--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -456,7 +456,7 @@ void FlightModeManager::generateTrajectorySetpoint(const float dt,
 	vehicle_local_position_setpoint_s setpoint = FlightTask::empty_setpoint;
 	vehicle_constraints_s constraints = FlightTask::empty_constraints;
 
-	if (_current_task.task->updateInitialize() && _current_task.task->update() && _current_task.task->updateFinalize()) {
+	if (_current_task.task->updateInitialize() && _current_task.task->update()) {
 		// setpoints and constraints for the position controller from flighttask
 		setpoint = _current_task.task->getPositionSetpoint();
 		constraints = _current_task.task->getConstraints();

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -214,17 +214,13 @@ bool FlightTaskAuto::update()
 	// update previous type
 	_type_previous = _type;
 
-	return ret;
-}
-
-bool FlightTaskAuto::updateFinalize()
-{
-	// All the auto FlightTasks have to comply with defined maximum yaw rate
 	// If the FlightTask generates a yaw or a yawrate setpoint that exceeds this value
 	// it will see its setpoint constrained here
 	_limitYawRate();
+
 	_constraints.want_takeoff = _checkTakeoff();
-	return true;
+
+	return ret;
 }
 
 void FlightTaskAuto::_prepareLandSetpoints()

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -110,8 +110,6 @@ protected:
 	void _ekfResetHandlerVelocityZ(float delta_vz) override;
 	void _ekfResetHandlerHeading(float delta_psi) override;
 
-	void _generateSetpoints(); /**< Generate setpoints along line. */
-	void _generateHeading();
 	void _checkEmergencyBraking();
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */
 	bool isTargetModified() const;

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -91,7 +91,6 @@ public:
 	void reActivate() override;
 	bool updateInitialize() override;
 	bool update() override;
-	bool updateFinalize() override;
 
 	/**
 	 * Sets an external yaw handler which can be used to implement a different yaw control strategy.

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -120,11 +120,7 @@ protected:
 	/** determines when to trigger a takeoff (ignored in flight) */
 	bool _checkTakeoff() override { return _want_takeoff; };
 
-	void _prepareIdleSetpoints();
 	void _prepareLandSetpoints();
-	void _prepareVelocitySetpoints();
-	void _prepareTakeoffSetpoints();
-	void _preparePositionSetpoints();
 	bool _highEnoughForLandingGear(); /**< Checks if gears can be lowered. */
 
 	void updateParams() override; /**< See ModuleParam class */

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -109,14 +109,6 @@ public:
 	virtual bool update();
 
 	/**
-	 * Call after update()
-	 * to constrain the generated setpoints in order to comply
-	 * with the constraints of the current mode
-	 * @return true on success, false on error
-	 */
-	virtual bool updateFinalize() { return true; };
-
-	/**
 	 * Get the output data
 	 * @return task output setpoints that get executed by the positon controller
 	 */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Preparation to be able to tear apart FlightTaskAuto into the different modes like Takeoff, RTL, Mission, ...

**Describe your solution**
In #18618 and #18647 I merged 3 classes together. Now that everything is together in `FlightTaskAuto` I started to simplify it. I keep the changes easy to review such that it doesn't end up in a huge pr that is hard to look at and just generates conflicts.

**Test data / coverage**
It's all pure refactoring and moving things around except for small order changes in the setpoint preparation switch case e.g. `WaypointType::velocity`.