### PR TITLE
Ekf2Selector: declare filter unhealthy when high test ratio

### DIFF
--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -293,7 +293,7 @@ bool EKF2Selector::UpdateErrorScores()
 			float combined_test_ratio = fmaxf(0.5f * (status.vel_test_ratio + status.pos_test_ratio), status.hgt_test_ratio);
 
 			_instance[i].combined_test_ratio = combined_test_ratio;
-			_instance[i].healthy = (status.filter_fault_flags == 0) && (combined_test_ratio > 0.f);
+			_instance[i].healthy = (status.filter_fault_flags == 0) && (combined_test_ratio > 0.f) && (combined_test_ratio < 1.f);
 			_instance[i].filter_fault = (status.filter_fault_flags != 0);
 			_instance[i].timeout = false;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
In some cases, the selected EKF instance has some fusion problems (e.g.: due to yaw errors) and another fully healthy instance is available. However, if the selected estimator does not report itself unhealthy (e.g.: when trying to recover, waiting for a reset timeout, ...), it the selector takes too long to react.

Example of log investigated with @priseborough : https://review.px4.io/plot_app?log=65558b78-35d9-4118-85a5-8ca7c9052052
Looking at the combined test ratio, that selected instance (3) was obviously bad and another one was available:
![DeepinScreenshot_select-area_20211118113252](https://user-images.githubusercontent.com/14822839/142399144-32453817-d0c8-47f5-a8b0-3e51ad271693.png)

**Describe your solution**
Inside the selector, use the combined test ratio to declare an EKF instance unhealthy to request a switch to a better instance.