### PR TITLE
Fix gazebo_sitl_multiple_run.sh for use with uRTPS

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -69,7 +69,7 @@ num_vehicles=${NUM_VEHICLES:=3}
 world=${WORLD:=empty}
 target=${TARGET:=px4_sitl_default}
 vehicle_model=${VEHICLE_MODEL:="iris"}
-export PX4_SIM_MODEL=${vehicle_model}${LABEL}
+export PX4_SIM_MODEL=${vehicle_model}
 
 echo ${SCRIPT}
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -126,7 +126,7 @@ else
 
 		m=0
 		while [ $m -lt ${target_number} ]; do
-			export PX4_SIM_MODEL=${target_vehicle}${LABEL}
+			export PX4_SIM_MODEL=${target_vehicle}
 			spawn_model ${target_vehicle}${LABEL} $n $target_x $target_y
 			m=$(($m + 1))
 			n=$(($n + 1))


### PR DESCRIPTION
**Describe problem solved by this pull request**
Using the command `./Tools/gazebo_sitl_multiple_run.sh -t px4_sitl_rtps -l rtps -n 3` does not work on current master. The startup script will try finding the airfram `iris_rtps` which doesn't exist. 

**Describe your solution**
The exported variable PX4_SIM_MODEL is used by the rcS script as the airframe. So removing the `{LABEL}` and just using `export PX4_SIM_MODEL=${vehicle_model}` will find the correct airframe (iris instead of iris_rtps)

**Describe possible alternatives**
None

**Test data / coverage**
Before the change the log in `/home/max/autopilot/build/px4_sitl_rtps/instance_0/out.log` would report a crash. After the change, px4 startup works fine.