### PR TITLE
cmake fix NuttX config import for 0 values

### DIFF
--- a/platforms/nuttx/cmake/init.cmake
+++ b/platforms/nuttx/cmake/init.cmake
@@ -96,13 +96,11 @@ foreach(NameAndValue ${ConfigContents})
 		# Find the value
 		string(REPLACE "${Name}=" "" Value ${NameAndValue})
 
-		if(Value)
-			# remove extra quotes
-			string(REPLACE "\"" "" Value ${Value})
+		# remove extra quotes
+		string(REPLACE "\"" "" Value ${Value})
 
-			# Set the variable
-			#message(STATUS "${Name} ${Value}")
-			set(${Name} ${Value} CACHE INTERNAL "NUTTX DEFCONFIG: ${Name}" FORCE)
-		endif()
+		# Set the variable
+		#message(STATUS "${Name} ${Value}")
+		set(${Name} ${Value} CACHE INTERNAL "NUTTX DEFCONFIG: ${Name}" FORCE)
 	endif()
 endforeach()


### PR DESCRIPTION
Any 0 value was being skipped. This only impacts the use of NuttX config variables with PX4 cmake, so we were probably getting away with it so far.

``` Console
-- CONFIG_STACK_USAGE_SAFE_PERCENT 0
-- CONFIG_STM32F7_I2CTIMEOSEC 0
-- CONFIG_BOARD_ASSERT_RESET_VALUE 0
-- CONFIG_RR_INTERVAL 0
-- CONFIG_SEM_PREALLOCHOLDERS 0
-- CONFIG_DEV_FIFO_SIZE 0
-- CONFIG_UART4_PARITY 0
-- CONFIG_UART4_2STOP 0
-- CONFIG_UART7_PARITY 0
-- CONFIG_UART7_2STOP 0
-- CONFIG_UART8_PARITY 0
-- CONFIG_UART8_2STOP 0
-- CONFIG_USART1_PARITY 0
-- CONFIG_USART1_2STOP 0
-- CONFIG_USART2_PARITY 0
-- CONFIG_USART2_2STOP 0
-- CONFIG_USART3_PARITY 0
-- CONFIG_USART3_2STOP 0
-- CONFIG_USART6_PARITY 0
-- CONFIG_USART6_2STOP 0
-- CONFIG_FAT_LFN_ALIAS_TRAILCHARS 0
-- CONFIG_NSH_MMCSDMINOR 0
-- CONFIG_NSH_MMCSDSLOTNO 0
-- CONFIG_NSH_ROMFSDEVNO 0
-- CONFIG_SYSTEM_CDCACM_DEVMINOR 0
```