### PR TITLE
iridiumsbd:  discard all pending data for flow control enabled

### DIFF
--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -60,7 +60,7 @@ IridiumSBD::IridiumSBD()
 
 IridiumSBD::~IridiumSBD()
 {
-	::close(_uart_fd);
+	deinit();
 }
 
 int IridiumSBD::task_spawn(int argc, char *argv[])
@@ -212,6 +212,16 @@ int IridiumSBD::init(int argc, char *argv[])
 	VERBOSE_INFO("SBD session timeout: %" PRId32 " s", _param_session_timeout_s);
 	VERBOSE_INFO("SBD stack time: %" PRId32 " ms", _param_stacking_time_ms);
 	return PX4_OK;
+}
+
+void IridiumSBD::deinit()
+{
+	if (_uart_fd >= 0) {
+		/* discard all pending data, as close() might block otherwise on NuttX with flow control enabled */
+		tcflush(_uart_fd, TCIOFLUSH);
+		::close(_uart_fd);
+		_uart_fd = -1;
+	}
 }
 
 int IridiumSBD::print_status()

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -141,6 +141,7 @@ public:
 
 private:
 	int init(int argc, char *argv[]);
+	void deinit();
 
 	/*
 	 * Loop executed while in SATCOM_STATE_STANDBY


### PR DESCRIPTION
Iridiumsbd driver can't be started if the modem is connected after PX4 boot.  
This solution discards all pending data, as close() is blocked otherwise. 