### PR TITLE
Follow up improvements for the manual control cleanup

### DIFF
--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -320,6 +320,11 @@ void ManualControl::evaluateModeSlot(uint8_t mode_slot)
 
 void ManualControl::sendActionRequest(int8_t action, int8_t source, int8_t mode)
 {
+	// We catch default unassigned mode slots which have value -1
+	if (action == action_request_s::ACTION_SWITCH_MODE && mode < 0) {
+		return;
+	}
+
 	action_request_s action_request{};
 	action_request.action = action;
 	action_request.source = source;

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -71,9 +71,9 @@ void ManualControl::Run()
 
 		updateParams();
 
-		_stick_arm_hysteresis.set_hysteresis_time_from(false, _param_rc_arm_hyst.get() * 1_ms);
-		_stick_disarm_hysteresis.set_hysteresis_time_from(false, _param_rc_arm_hyst.get() * 1_ms);
-		_button_hysteresis.set_hysteresis_time_from(false, _param_rc_arm_hyst.get() * 1_ms);
+		_stick_arm_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
+		_stick_disarm_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
+		_button_hysteresis.set_hysteresis_time_from(false, _param_com_rc_arm_hyst.get() * 1_ms);
 
 		_selector.setRcInMode(_param_com_rc_in_mode.get());
 		_selector.setTimeout(_param_com_rc_loss_t.get() * 1_s);

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -267,7 +267,7 @@ void ManualControl::processStickArming(const manual_control_setpoint_s &input)
 	const bool previous_stick_arm_hysteresis = _stick_arm_hysteresis.get_state();
 	_stick_arm_hysteresis.set_state_and_update(left_stick_lower_right && right_stick_centered, input.timestamp);
 
-	if (!previous_stick_arm_hysteresis && _stick_arm_hysteresis.get_state()) {
+	if (_param_man_arm_gesture.get() && !previous_stick_arm_hysteresis && _stick_arm_hysteresis.get_state()) {
 		sendActionRequest(action_request_s::ACTION_ARM, action_request_s::SOURCE_RC_STICK_GESTURE);
 	}
 
@@ -277,7 +277,7 @@ void ManualControl::processStickArming(const manual_control_setpoint_s &input)
 	const bool previous_stick_disarm_hysteresis = _stick_disarm_hysteresis.get_state();
 	_stick_disarm_hysteresis.set_state_and_update(left_stick_lower_left && right_stick_centered, input.timestamp);
 
-	if (!previous_stick_disarm_hysteresis && _stick_disarm_hysteresis.get_state()) {
+	if (_param_man_arm_gesture.get() && !previous_stick_disarm_hysteresis && _stick_disarm_hysteresis.get_state()) {
 		sendActionRequest(action_request_s::ACTION_DISARM, action_request_s::SOURCE_RC_STICK_GESTURE);
 	}
 }

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -120,7 +120,7 @@ private:
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
-		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_rc_arm_hyst,
+		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_com_rc_arm_hyst,
 		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_com_arm_swisbtn,
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,
 		(ParamInt<px4::params::COM_FLTMODE2>) _param_fltmode_2,

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -120,6 +120,7 @@ private:
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
+		(ParamBool<px4::params::MAN_ARM_GESTURE>) _param_man_arm_gesture,
 		(ParamInt<px4::params::COM_RC_ARM_HYST>) _param_com_rc_arm_hyst,
 		(ParamBool<px4::params::COM_ARM_SWISBTN>) _param_com_arm_swisbtn,
 		(ParamInt<px4::params::COM_FLTMODE1>) _param_fltmode_1,

--- a/src/modules/manual_control/manual_control_params.c
+++ b/src/modules/manual_control/manual_control_params.c
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Enable arm/disarm stick gesture
+ *
+ * This determines if moving the left stick to the lower right
+ * arms and to the lower left disarms the vehicle.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group Manual Control
+ */
+PARAM_DEFINE_INT32(MAN_ARM_GESTURE, 1);


### PR DESCRIPTION
**Describe problem solved by this pull request**
During further testing of the recent changes in #17404 I found two issues:
1. Moving the mode switch/button to an unassigned slot results in a message "Switching to Unkown is currently not available"
1. There's no way to disable the stick gesture for arming.
   This was previously implicitly (!) possible by either setting `COM_RC_IN_MODE` to joystick or mapping an arm switch.
1. It is possible to enable yaw Airmode even though the stick gesture for arming is enabled

**Describe your solution**
1. I'm not sending out an invalid/"Unkown" mode switch request with `commander_state.main_state` requested to be `-1`. This is the default value representing unassigned slots but when casted to the main_state type `uint8_t` being 255 and hence resulting in the expected error.
1. There needs to be an explicit way `MAN_ARM_GESTURE` to disable it because I've seen it more than once as a product or hobby vehicle setup requirement independent of joystick or arming switch use.
1. The new parameter from the last point cannot be enabled at the same time as yaw Airmode for safety reasons..

**Test data / coverage**
I bench tested everything to work as expected.