### PR TITLE
ekf2: selector treat combined test ratio > 1 as a warning

### DIFF
--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -293,7 +293,8 @@ bool EKF2Selector::UpdateErrorScores()
 			float combined_test_ratio = fmaxf(0.5f * (status.vel_test_ratio + status.pos_test_ratio), status.hgt_test_ratio);
 
 			_instance[i].combined_test_ratio = combined_test_ratio;
-			_instance[i].healthy = (status.filter_fault_flags == 0) && (combined_test_ratio > 0.f) && (combined_test_ratio < 1.f);
+			_instance[i].healthy = (status.filter_fault_flags == 0) && (combined_test_ratio > 0.f);
+			_instance[i].warning = (combined_test_ratio >= 1.f);
 			_instance[i].filter_fault = (status.filter_fault_flags != 0);
 			_instance[i].timeout = false;
 
@@ -733,7 +734,9 @@ void EKF2Selector::Run()
 				SelectInstance(best_ekf);
 			}
 
-		} else if (lower_error_available && (hrt_elapsed_time(&_last_instance_change) > 10_s)) {
+		} else if (lower_error_available
+			   && ((hrt_elapsed_time(&_last_instance_change) > 10_s) || _instance[_selected_instance].warning)) {
+
 			// if this instance has a significantly lower relative error to the active primary, we consider it as a
 			// better instance and would like to switch to it even if the current primary is healthy
 			SelectInstance(best_ekf_alternate);

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -298,6 +298,10 @@ bool EKF2Selector::UpdateErrorScores()
 			_instance[i].filter_fault = (status.filter_fault_flags != 0);
 			_instance[i].timeout = false;
 
+			if (!_instance[i].warning) {
+				_instance[i].time_last_no_warning = status.timestamp_sample;
+			}
+
 			if (!PX4_ISFINITE(_instance[i].relative_test_ratio)) {
 				_instance[i].relative_test_ratio = 0;
 			}
@@ -735,7 +739,9 @@ void EKF2Selector::Run()
 			}
 
 		} else if (lower_error_available
-			   && ((hrt_elapsed_time(&_last_instance_change) > 10_s) || _instance[_selected_instance].warning)) {
+			   && ((hrt_elapsed_time(&_last_instance_change) > 10_s)
+			       || (_instance[_selected_instance].warning
+				   && (hrt_elapsed_time(&_instance[_selected_instance].time_last_no_warning) > 1_s)))) {
 
 			// if this instance has a significantly lower relative error to the active primary, we consider it as a
 			// better instance and would like to switch to it even if the current primary is healthy

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -125,6 +125,7 @@ private:
 		uint32_t mag_device_id{0};
 
 		hrt_abstime time_last_selected{0};
+		hrt_abstime time_last_no_warning{0};
 
 		float combined_test_ratio{NAN};
 		float relative_test_ratio{NAN};

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -130,6 +130,7 @@ private:
 		float relative_test_ratio{NAN};
 
 		bool healthy{false};
+		bool warning{false};
 		bool filter_fault{false};
 		bool timeout{false};
 


### PR DESCRIPTION
The EKF2 selector change in https://github.com/PX4/PX4-Autopilot/pull/18669 also prevents selection when only attitude is available. This PR is one possible solution, but I'm open to suggestions.