### PR TITLE
sensors/vehicle_angular_velocity: fallback sensor selection improvements

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -76,11 +76,11 @@ public:
 private:
 	void Run() override;
 
-	void CalibrateAndPublish(bool publish, const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity,
-				 const matrix::Vector3f &angular_acceleration);
+	bool CalibrateAndPublish(const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity_uncalibrated,
+				 const matrix::Vector3f &angular_acceleration_uncalibrated);
 
 	inline float FilterAngularVelocity(int axis, float data[], int N = 1);
-	inline float FilterAngularAcceleration(int axis, float dt_s, float data[], int N = 1);
+	inline float FilterAngularAcceleration(int axis, float inverse_dt_s, float data[], int N = 1);
 
 	void DisableDynamicNotchEscRpm();
 	void DisableDynamicNotchFFT();
@@ -120,7 +120,6 @@ private:
 	matrix::Vector3f _bias{};
 
 	matrix::Vector3f _angular_velocity{};
-	matrix::Vector3f _angular_velocity_prev{};
 	matrix::Vector3f _angular_acceleration{};
 
 	matrix::Vector3f _angular_velocity_raw_prev{};
@@ -164,7 +163,6 @@ private:
 	perf_counter_t _dynamic_notch_filter_fft_disable_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_fft_reset_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_fft_update_perf{nullptr};
-
 	perf_counter_t _dynamic_notch_filter_fft_perf{nullptr};
 
 	bool _dynamic_notch_esc_rpm_available{false};
@@ -178,6 +176,7 @@ private:
 
 	bool _reset_filters{true};
 	bool _fifo_available{false};
+	bool _update_sample_rate{true};
 
 	perf_counter_t _filter_reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro filter reset")};
 	perf_counter_t _selection_changed_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro selection changed")};


### PR DESCRIPTION
This allows `sensors/vehicle_angular_velocity` to select a working enabled gyro immediately on boot-up before the estimator selector is ready or in the event of a timeout.

Could be useful in an in air restart scenario bringing the inner loop online within milliseconds.

Other minor improvements.
 - avoid unnecessary filter reset on parameter update
 - additional minor optimizations (precomputing dt inverse, etc)
 - moving filter reset check and dynamic notch filter update checks out of the update loops
     - this were necessary previously when the scale factor wasn't applied prior to filtering the otherwise raw data