### PR TITLE
Remove kconfig-frontends for ubuntu 18.04 in setup.sh

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -136,7 +136,6 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		genromfs \
 		gettext \
 		gperf \
-		kconfig-frontends \
 		libelf-dev \
 		libexpat-dev \
 		libgmp-dev \
@@ -154,6 +153,12 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		util-linux \
 		vim-common \
 		;
+	if [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+		kconfig-frontends \
+		;
+	fi
+
 
 	if [ -n "$USER" ]; then
 		# add user to dialout group (serial port access)


### PR DESCRIPTION
**Describe problem solved by this pull request**
After `kconfig-frontends` was added as a dependency, there were a lot of confusion with the install script and a lot of people were confusing this with the firmware being broken on Ubuntu 18.04. The setup script fails due to the fact that `kconfig-frontends` are not distributed over `apt`

For Ubuntu 18.04 and earlier, one can follow the documentation in http://nuttx.incubator.apache.org/docs/latest/quickstart/install.html to install `kconfig-frontends`

Even after `kconfig-frontends` is installed the installation script will still fail since `kconfig-frontends` is not a registered package in 18.04

Related to: 
- https://github.com/PX4/PX4-Autopilot/issues/18467
- https://github.com/PX4/homebrew-px4/issues/26#issuecomment-976163098
- https://discuss.px4.io/t/e-unable-to-locate-package-kconfig-frontends/24924


**Describe your solution**
This PR removes `kconfig-frontends` package from the `setup.sh` when setting up on 18.04

