### PR TITLE
Fixed mavlink_ftp read

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -572,7 +572,7 @@ MavlinkFTP::_workRead(PayloadHeader *payload)
 		return kErrFailErrno;
 	}
 
-	int bytes_read = ::read(_session_info.fd, &payload->data[0], kMaxDataLength);
+	int bytes_read = ::read(_session_info.fd, &payload->data[0], payload->size);
 
 	if (bytes_read < 0) {
 		// Negative return indicates error other than eof


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
When requesting a limited amount of bytes from a file via ftp over mavlink, I received the maximum amount of data bytes regardless of the amount of requested bytes.

**Describe your solution**
It now listens to the payload->size as per documentation

**Describe possible alternatives**
After a quick chat with @julianoes it was determined that the documentation was correct and that this change does not pose any security flaws.

**Test data / coverage**
Sent a read request with the size field set to anything but max allowed size. Response contained the correct amount of bytes.
Sent a read request with the size field set to too many bytes. Response was NACK with InvalidDataSize error code.