### PR TITLE
Follow up to RTL based on remaining flight time

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3681,10 +3681,14 @@ void Commander::battery_status_check()
 		// Try to trigger RTL
 		if (main_state_transition(_status, commander_state_s::MAIN_STATE_AUTO_RTL, _status_flags,
 					  _internal_state) == TRANSITION_CHANGED) {
-			mavlink_log_emergency(&_mavlink_log_pub, "Flight time low, returning to land");
+			mavlink_log_emergency(&_mavlink_log_pub, "Remaining flight time low, returning to land\t");
+			events::send(events::ID("commander_remaining_flight_time_rtl"), {events::Log::Critical, events::LogInternal::Info},
+				     "Remaining flight time low, returning to land");
 
 		} else {
-			mavlink_log_emergency(&_mavlink_log_pub, "Flight time low, land now!");
+			mavlink_log_emergency(&_mavlink_log_pub, "Remaining flight time low, land now!\t");
+			events::send(events::ID("commander_remaining_flight_time_land"), {events::Log::Critical, events::LogInternal::Info},
+				     "Remaining flight time low, land now!");
 		}
 
 		_rtl_time_actions_done = true;

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -197,9 +197,9 @@ PARAM_DEFINE_FLOAT(RTL_TIME_FACTOR, 1.1f);
  *
  * @unit s
  * @min 0
- * @max 300
+ * @max 3600
  * @decimal 1
  * @increment 1
  * @group Return To Land
  */
-PARAM_DEFINE_INT32(RTL_TIME_MARGIN, 110);
+PARAM_DEFINE_INT32(RTL_TIME_MARGIN, 100);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Follow up to the review here: https://github.com/PX4/PX4-Autopilot/pull/18646#pullrequestreview-813949240

**Describe your solution**
- Message for the user saying "Remaining flight time low" instead of "Flight time low"
- Add `\t` at the end of the deprecated `mavlink_log_emergency()` message to make it not show in newer ground stations that support the events interface
- Publish an appropriate event over the events interface
- Use a round number of 100s as the default safety margin for flight time still have left after the full RTL
- Increase the maximum value for the time margin parameter to 60 minutes to account for vehicles that are capable of flying multiple hours

**Test data / coverage**
I did not specifically test these changes yet.
