### PR TITLE
update correct airsp scale param string in ekf2

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -267,7 +267,7 @@ void EKF2::Run()
 		_ekf.set_min_required_gps_health_time(_param_ekf2_req_gps_h.get() * 1_s);
 
 		// The airspeed scale factor correcton is only available via parameter as used by the airspeed module
-		param_t param_aspd_scale = param_find("ASPD_SCALE");
+		param_t param_aspd_scale = param_find("ASPD_SCALE_1");
 
 		if (param_aspd_scale != PARAM_INVALID) {
 			param_get(param_aspd_scale, &_airspeed_scale_factor);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Appears when multiple scale factors were introduced in #18442, this line was never updated (still on old scale factor param name). Results that no param is found, and thus no scale is applied to the airspeed in EKF2.

**Describe your solution**
Update the param search for ``ASPD_SCALE_1``.

**Describe possible alternatives**
This is a quick fix.. but I imagine @sfuhrer you will want to advise on how selection of 1st, 2nd, or 3rd scales should be chosen here if someone is using the airspeed selector with multiple sensors.

**Test data / coverage**
I ran in SITL - confirmed that the wind estimate is stable after this. Can provide a log if requested.. but so far the fix is quite trivial.
