### PR TITLE
mavlink_ftp: fix tests after implementation fix

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -165,7 +165,7 @@ MavlinkFTP::_process_request(
 	// basic sanity checks; must validate length before use
 	if (payload->size > kMaxDataLength) {
 		errorCode = kErrInvalidDataSize;
-		PX4_WARN("invalid data size");
+		PX4_WARN("invalid data size: %d", payload->size);
 		goto out;
 	}
 

--- a/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.cpp
+++ b/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.cpp
@@ -700,7 +700,11 @@ bool MavlinkFtpTest::_removedirectory_test()
 		uint8_t		error_code;
 	};
 	static const struct _testCase rgTestCases[] = {
+#ifdef __PX4_NUTTX
+		{ "/bogus",						false,	false, 1, MavlinkFTP::kErrFailFileProtected },
+#else
 		{ "/bogus",						false,	false, 1, MavlinkFTP::kErrFileNotFound },
+#endif
 		{ _unittest_microsd_dir,				false,	false, 2, MavlinkFTP::kErrFailErrno },
 		{ _unittest_microsd_file,				false,	false, 2, MavlinkFTP::kErrFailErrno },
 		{ _unittest_microsd_dir,				true,	true, 0, MavlinkFTP::kErrNone },
@@ -808,7 +812,11 @@ bool MavlinkFtpTest::_removefile_test()
 		uint8_t		error_code;
 	};
 	static const struct _testCase rgTestCases[] = {
+#ifdef __PX4_NUTTX
+		{ "/bogus",			false, 1, MavlinkFTP::kErrFailFileProtected },
+#else
 		{ "/bogus",			false, 1, MavlinkFTP::kErrFileNotFound },
+#endif
 		{ _unittest_microsd_dir,	false, 2, MavlinkFTP::kErrFailErrno },
 		{ _unittest_microsd_file,	true,  0, MavlinkFTP::kErrNone },
 		{ _unittest_microsd_file,	false, 1, MavlinkFTP::kErrFileNotFound },

--- a/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.h
+++ b/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.h
@@ -98,12 +98,13 @@ private:
 	bool _removefile_test(void);
 
 	void _receive_message_handler_generic(const mavlink_file_transfer_protocol_t *ftp_req);
-	void _setup_ftp_msg(const MavlinkFTP::PayloadHeader *payload_header, uint8_t size, const uint8_t *data,
+	bool _setup_ftp_msg(const MavlinkFTP::PayloadHeader *payload_header,
+			    const uint8_t *data, const uint8_t data_len,
 			    mavlink_message_t *msg);
 	bool _decode_message(const mavlink_file_transfer_protocol_t *ftp_msg, const MavlinkFTP::PayloadHeader **payload);
 	bool _send_receive_msg(MavlinkFTP::PayloadHeader	*payload_header,
-			       uint8_t				size,
 			       const uint8_t			*data,
+			       const size_t			data_len,
 			       const MavlinkFTP::PayloadHeader	**payload_reply);
 	void _cleanup_microsd(void);
 


### PR DESCRIPTION
In commit 462b5721721122c94bc7a3c43ae7f37c41ee625d the reading operation on the PX4 side was changed to only read as many bytes as requested rather than however many fit in the payload data.

This caused the unit tests to fail which this commit here aims to fix.

What is confusing about MAVLink FTP is that there is a size field which generally signals how many bytes of the payload data are used/set.

However, in the case of a read requst, the size field is used to indicate how many bytes should be read. The payload data is empty in that case though.

This case was, from how I understand it, not implemented/tested in the unit tests and now failed. In order to implement it I had to change a few things:
- Change _setup_ftp_msg and _send_receive_msg so that the params contain a data length rather than the size field. The size field itself needs to be set outside of these methods using payload->size.
- Since we test files smaller, equal, and bigger than one payload data length, I implemented that we send multiple read requests until we have the whole file and not just the first part.
- Additionally, I saw a lot of uninitialized warnings in valgrind, and got rid of them by adding a few zero initializations.
