### PR TITLE
Navigator: VTOL: remove generate_waypoint_from_heading()

### DIFF
--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -219,11 +219,6 @@ private:
 	bool need_to_reset_mission();
 
 	/**
-	 * Project current location with heading to far away location and fill setpoint.
-	 */
-	void generate_waypoint_from_heading(struct position_setpoint_s *setpoint, float yaw);
-
-	/**
 	 * Find and store the index of the landing sequence (DO_LAND_START)
 	 */
 	bool find_mission_land_start();


### PR DESCRIPTION

**Describe problem solved by this pull request**
There isn't an actual problem with how it was previously, though it is annoying to have position setpoints 1000km away from the current flight location, that raised questions by users..and having the "set wp far ahead of the vehicle" duplicated doesn't look right. 

**Describe your solution**
Remove generate_waypoint_from_heading() from Navigator, and keep the current position sp coordinates when the transition is started. 
The FW Position controller sets the wp to be tracked during a VTOL front transition, the coordinates sp set here weren't used.
https://github.com/PX4/PX4-Autopilot/blob/4ba84d56c9388f41e9ff366a7f4c73a2c4b5e4b8/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L758

**Describe possible alternatives**
Instead of having to set a wp indefinitely far ahead of the vehicle, we could make use of l1.navigate_heading() to keep the VTOL transitions straight.
If for some reason we need to keep generate_waypoint_from_heading() in Navigator then let's at least reduce the distance to 500m or something.

**Test data / coverage**
SITL tested with VTOL takeoffs and transitions.

