### PR TITLE
SITL configs VTOL/plane: improve SITL tuning a bit

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
@@ -29,12 +29,9 @@ param set-default FW_THR_MAX 0.6
 param set-default FW_THR_MIN 0.05
 param set-default FW_THR_CRUISE 0.25
 
-param set-default FW_T_ALT_TC 2
 param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
-param set-default FW_T_TAS_TC 2
 
 param set-default FW_W_EN 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -19,12 +19,9 @@ param set-default FW_RR_P 0.3
 param set-default FW_THR_CRUISE 0.25
 param set-default FW_THR_MAX 0.6
 param set-default FW_THR_MIN 0.05
-param set-default FW_T_ALT_TC 2
 param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
-param set-default FW_T_TAS_TC 2
 
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_YAW_P 1.6

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -19,12 +19,9 @@ param set-default FW_RR_P 0.3
 param set-default FW_THR_CRUISE 0.38
 param set-default FW_THR_MAX 0.6
 param set-default FW_THR_MIN 0.05
-param set-default FW_T_ALT_TC 2
 param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
-param set-default FW_T_TAS_TC 2
 
 param set-default MC_YAW_P 1.6
 


### PR DESCRIPTION
Remove some tecs params from configs that actually lead to worse performance than defaults.

Mainly checked airspeed and altitude/height rate tracking. Not a huge difference with / without these params, but I think in general we should try to keep the SITL airframe configs as light weight as possible, so use the default tuning gains where possible. 