### PR TITLE
NuttX debug helper improvements

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -21,7 +21,7 @@ pipeline {
                 sh 'make cubepilot_cubeorange_bootloader'
                 sh 'make cubepilot_cubeorange_test'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*, build/cubepilot_cubeorange_test/etc/init.d/airframes/*', name: 'cubepilot_cubeorange_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*, build/cubepilot_cubeorange_test/etc/init.d/airframes/*', name: 'cubepilot_cubeorange_test'
               }
               post {
                 always {
@@ -75,7 +75,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/cubepilot_cubeorange_test/cubepilot_cubeorange_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/cubepilot_cubeorange_test/cubepilot_cubeorange_test.elf || true'
                 }
               }
             } // stage test
@@ -96,7 +96,7 @@ pipeline {
                 sh 'make cuav_x7pro_bootloader'
                 sh 'make cuav_x7pro_test'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'cuav_x7pro_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'cuav_x7pro_test'
               }
               post {
                 always {
@@ -144,7 +144,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/cuav_x7pro_test/cuav_x7pro_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/cuav_x7pro_test/cuav_x7pro_test.elf || true'
                 }
               }
             } // stage test
@@ -165,7 +165,7 @@ pipeline {
                 sh 'make px4_fmu-v3_test'
                 sh 'make px4_fmu-v3_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'px4_fmu-v3_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'px4_fmu-v3_test'
               }
               post {
                 always {
@@ -213,7 +213,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v3_test/px4_fmu-v3_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/px4_fmu-v3_test/px4_fmu-v3_test.elf || true'
                 }
               }
             } // stage test
@@ -234,7 +234,7 @@ pipeline {
                 sh 'make px4_fmu-v4_test'
                 sh 'make px4_fmu-v4_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'px4_fmu-v4_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'px4_fmu-v4_test'
               }
               post {
                 always {
@@ -281,7 +281,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v4_test/px4_fmu-v4_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/px4_fmu-v4_test/px4_fmu-v4_test.elf || true'
                 }
               }
             } // stage test
@@ -302,7 +302,7 @@ pipeline {
                 sh 'make px4_fmu-v4pro_test'
                 sh 'make px4_fmu-v4pro_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'px4_fmu-v4pro_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'px4_fmu-v4pro_test'
               }
               post {
                 always {
@@ -350,7 +350,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v4pro_test/px4_fmu-v4pro_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/px4_fmu-v4pro_test/px4_fmu-v4pro_test.elf || true'
                 }
               }
             } // stage test
@@ -371,7 +371,7 @@ pipeline {
                 sh 'make px4_fmu-v5_debug'
                 sh 'make px4_fmu-v5_debug bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'px4_fmu-v5_debug'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'px4_fmu-v5_debug'
               }
               post {
                 always {
@@ -437,7 +437,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v5_debug/px4_fmu-v5_debug.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/px4_fmu-v5_debug/px4_fmu-v5_debug.elf || true'
                 }
               }
             } // stage test
@@ -458,7 +458,7 @@ pipeline {
                 sh 'make px4_fmu-v5_stackcheck'
                 sh 'make px4_fmu-v5_stackcheck bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'px4_fmu-v5_stackcheck'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'px4_fmu-v5_stackcheck'
               }
               post {
                 always {
@@ -516,7 +516,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v5_stackcheck/px4_fmu-v5_stackcheck.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/px4_fmu-v5_stackcheck/px4_fmu-v5_stackcheck.elf || true'
                 }
               }
             } // stage test
@@ -537,7 +537,7 @@ pipeline {
                 sh 'make px4_fmu-v5_test'
                 sh 'make px4_fmu-v5_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'px4_fmu-v5_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'px4_fmu-v5_test'
               }
               post {
                 always {
@@ -585,7 +585,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/px4_fmu-v5_test/px4_fmu-v5_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/px4_fmu-v5_test/px4_fmu-v5_test.elf || true'
                 }
               }
             } // stage test
@@ -606,7 +606,7 @@ pipeline {
                 sh 'make nxp_fmuk66-v3_test'
                 //sh 'make nxp_fmuk66-v3_test bootloader_elf'
                 sh 'ccache -s'
-                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, Tools/HIL/*', name: 'nxp_fmuk66-v3_test'
+                stash includes: 'build/*/*.elf, platforms/nuttx/Debug/*, platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit, Tools/HIL/*', name: 'nxp_fmuk66-v3_test'
               }
               post {
                 always {
@@ -654,7 +654,7 @@ pipeline {
               }
               post {
                 always {
-                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace.sh build/nxp_fmuk66-v3_test/nxp_fmuk66-v3_test.elf || true'
+                    sh './platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh build/nxp_fmuk66-v3_test/nxp_fmuk66-v3_test.elf || true'
                 }
               }
             } // stage test

--- a/platforms/nuttx/Debug/PX4
+++ b/platforms/nuttx/Debug/PX4
@@ -11,10 +11,29 @@ end
 document px4
 . Various macros for working with the PX4 firmware.
 .
+.    dmesg
+.        Prints the dmesg output (if available).
+.
 .    perf
 .        Prints the state of all performance counters.
 .
 . Use 'help <macro>' for more specific help.
+end
+
+
+define dmesg
+	if g_console_buffer
+		printf "PX4 dmesg:\n"
+		# TODO: respect head and tail
+		printf "%s\n", g_console_buffer._buffer
+	else
+		printf "PX4 dmesg unavailable\n"
+	end
+end
+
+document dmesg
+.    dmesg
+.        Prints dmesg (if available).
 end
 
 
@@ -35,7 +54,11 @@ define _perf_print
 	# PC_INTERVAL
 	if $hdr->type == 2
 		set $interval = (struct perf_ctr_interval *)$hdr
-		printf "%llu events, %llu avg, min %lluus max %lluus\n", $interval->event_count, ($interval->time_last - $interval->time_first) / $interval->event_count, $interval->time_least, $interval->time_most
+		if $interval->event_count == 0
+			printf "%llu events, %llu avg, min %lluus max %lluus\n", $interval->event_count, 0, $interval->time_least, $interval->time_most
+		else
+			printf "%llu events, %llu avg, min %lluus max %lluus\n", $interval->event_count, ($interval->time_last - $interval->time_first) / $interval->event_count, $interval->time_least, $interval->time_most
+		end
 	end
 end
 

--- a/platforms/nuttx/Debug/jlink_debug_gdb.sh.in
+++ b/platforms/nuttx/Debug/jlink_debug_gdb.sh.in
@@ -1,9 +1,23 @@
 #! /bin/sh
 
+if command -v gdb-multiarch &> /dev/null
+then
+	GDB_CMD=$(command -v gdb-multiarch)
+
+elif command -v arm-none-eabi-gdb &> /dev/null
+then
+	GDB_CMD=$(command -v arm-none-eabi-gdb)
+
+else
+	echo "gdb arm-none-eabi or multi-arch not found"
+	exit 1
+fi
+
 @JLinkGDBServerExe_PATH@ -device @DEBUG_DEVICE@ -select usb -endian little -if SWD -speed auto -ir -LocalhostOnly 1 -strict -vd -singlerun &
 
-cd @PX4_BINARY_DIR@ && @CMAKE_GDB@ -silent -nh \
+cd @PX4_BINARY_DIR@ && ${GDB_CMD} -silent -nh \
 	-iex "set auto-load safe-path @PX4_BINARY_DIR@" \
+	-ix=@PX4_SOURCE_DIR@/platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit \
 	-ex "target remote localhost:2331" \
 	-ex "monitor reset 0" \
 	-ex "load" \

--- a/platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh
+++ b/platforms/nuttx/Debug/jlink_gdb_backtrace_simple.sh
@@ -40,10 +40,10 @@ backtrace
 
 vecstate
 
-info_nxthreads
+info threads
 
-nxthread_all_bt
+bt full
 
 EOL
 
-${GDB_CMD} -silent --nh --nx --nw -batch -ix=${WORKSPACE}/platforms/nuttx/NuttX/nuttx/tools/nuttx-gdbinit -x ${gdb_cmd_file} ${1}
+${GDB_CMD} -silent --nh --nx --nw -batch -x ${gdb_cmd_file} ${1}

--- a/platforms/nuttx/cmake/jlink.cmake
+++ b/platforms/nuttx/cmake/jlink.cmake
@@ -60,6 +60,18 @@ if(JLinkGDBServerCLExe_PATH)
 		USES_TERMINAL
 	)
 
+	# jlink_gdb_backtrace_simple (attach, print current tasks, back trace, exit)
+	add_custom_target(jlink_gdb_backtrace_simple
+		COMMAND ${PX4_BINARY_DIR}/jlink_gdb_start.sh
+		COMMAND ${CMAKE_COMMAND} -E env WORKSPACE=${PX4_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_backtrace_simple.sh $<TARGET_FILE:px4>
+		DEPENDS
+			px4
+			${PX4_BINARY_DIR}/jlink_gdb_start.sh
+			${CMAKE_CURRENT_SOURCE_DIR}/Debug/jlink_gdb_backtrace_simple.sh
+		WORKING_DIRECTORY ${PX4_BINARY_DIR}
+		USES_TERMINAL
+	)
+
 
 	# jlink_upload_bootloader
 	#   board directory supplied bootloader.bin


### PR DESCRIPTION
 - use NuttX gdb script for nxthreads and thread backtrace
 - update jlink_gdb_backtrace and jlink_debug_gdb helper targets to use
NuttX gdb script
 - Debug/PX4 fix "perf" divide by zero
 - Debug/PX4 add "dmesg"

### Examples

``` Console
$ make px4_fmu-v5x_default jlink_debug_gdb
```

![Screenshot from 2021-11-26 13-18-30](https://user-images.githubusercontent.com/84712/143618979-1a03ab33-eb11-4aee-99fb-521f30ec35c3.png)


![Screenshot from 2021-11-26 13-18-56](https://user-images.githubusercontent.com/84712/143619005-9dde6924-5a6e-495a-95ca-4c96faa6c1f9.png)

![Screenshot from 2021-11-26 13-19-20](https://user-images.githubusercontent.com/84712/143619041-bec97897-c424-4297-aa42-c507babb3fd7.png)

![Screenshot from 2021-11-26 13-19-47](https://user-images.githubusercontent.com/84712/143619075-25a5de11-d1de-4376-9001-49193e9af285.png)


