### PR TITLE
px4io: discover `PWM_MAIN_TRIMx` parameters right away

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -916,7 +916,7 @@ void PX4IO::update_params()
 	}
 
 	// PWM_MAIN_TRIMx
-	if (_mixing_output.mixers()) {
+	{
 		int16_t values[8] {};
 
 		for (unsigned i = 0; i < _max_actuators; i++) {
@@ -928,8 +928,10 @@ void PX4IO::update_params()
 			}
 		}
 
-		// copy the trim values to the mixer offsets
-		_mixing_output.mixers()->set_trims(values, _max_actuators);
+		if (_mixing_output.mixers()) {
+			// copy the trim values to the mixer offsets
+			_mixing_output.mixers()->set_trims(values, _max_actuators);
+		}
 	}
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Possibly closes #18750 

**Describe your solution**
Remove the condition that was added in https://github.com/PX4/PX4-Autopilot/commit/089c962d9208b3616ba505ab927fa399554035d4#diff-ff52cb1224c92cc672316dab2f93a98e7db09fb08ccdfbb9fb0015e8d86f1387R859 not knowing why it was added. @dagar please tell me about the side effects.

**Test data / coverage**
~I did not test this but based on the description in https://github.com/PX4/PX4-Autopilot/issues/18750 it should solve the issue.~ Tested the fixed version, see comment below.
