### PR TITLE
FlightTask(Auto): Avoid SubscriptionData in unnecessary cases

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -131,8 +131,7 @@ protected:
 	float _mc_cruise_speed{0.0f}; /**< Requested cruise speed. If not valid, default cruise speed is used. */
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 
-	uORB::SubscriptionData<home_position_s>			_sub_home_position{ORB_ID(home_position)};
-	uORB::SubscriptionData<vehicle_status_s>		_sub_vehicle_status{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	State _current_state{State::none};
 	float _target_acceptance_radius{0.0f}; /**< Acceptances radius of the target */
@@ -186,7 +185,7 @@ private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
 	bool _yaw_lock{false}; /**< if within acceptance radius, lock yaw to current yaw */
 
-	uORB::SubscriptionData<position_setpoint_triplet_s> _sub_triplet_setpoint{ORB_ID(position_setpoint_triplet)};
+	uORB::Subscription _position_setpoint_triplet_sub{ORB_ID(position_setpoint_triplet)};
 
 	matrix::Vector3f
 	_triplet_target; /**< current triplet from navigator which may differ from the intenal one (_target) depending on the vehicle state. */

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.cpp
@@ -33,7 +33,6 @@ bool FlightTask::updateInitialize()
 	_time_stamp_last = _time_stamp_current;
 
 	_sub_vehicle_local_position.update();
-	_sub_home_position.update();
 
 	_evaluateVehicleLocalPosition();
 	_evaluateVehicleLocalPositionSetpoint();
@@ -191,11 +190,14 @@ void FlightTask::_evaluateDistanceToGround()
 	// Altitude above ground is local z-position or altitude above home or distance sensor altitude depending on what's available
 	_dist_to_ground = -_position(2);
 
+	home_position_s home_position{};
+	_home_position_sub.copy(&home_position);
+
 	if (PX4_ISFINITE(_dist_to_bottom)) {
 		_dist_to_ground = _dist_to_bottom;
 
-	} else if (_sub_home_position.get().valid_alt) {
-		_dist_to_ground = -(_position(2) - _sub_home_position.get().z);
+	} else if (home_position.valid_alt) {
+		_dist_to_ground = -(_position(2) - home_position.z);
 	}
 }
 

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -177,7 +177,8 @@ public:
 
 protected:
 	uORB::SubscriptionData<vehicle_local_position_s> _sub_vehicle_local_position{ORB_ID(vehicle_local_position)};
-	uORB::SubscriptionData<home_position_s> _sub_home_position{ORB_ID(home_position)};
+
+	uORB::Subscription _home_position_sub{ORB_ID(home_position)};
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	/** Reset all setpoints to NAN */


### PR DESCRIPTION
**Describe problem solved by this pull request**
Using `SubscriptionData` is keeping the uORB data struct in RAM at all time as a member even though a lot of times the evaluation is in one or two places and the scope of the raw data could be local. I'm doing a refactoring step to replace them.

**Describe your solution**
I'm removing usages of `SubscriptionData` for:
FlightTask:
- home_position [48bytes]
FlightTaskAuto:
- home_position (was duplicate)
- vehicle_status [80 bytes]
- position_setpoint_triplet [248 bytes]

Total 424 bytes

Also, I'm renaming to the _sub postfix convention we usually use.