### PR TITLE
gps: fix compiling on mac

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -559,6 +559,10 @@ int GPS::setBaudrate(unsigned baud)
 
 	case 460800: speed = B460800; break;
 
+#ifndef B921600
+#define B921600 921600
+#endif
+
 	case 921600: speed = B921600; break;
 
 	default:


### PR DESCRIPTION
This fixes the following compile error on Mac:

    src/drivers/gps/gps.cpp:562:23: fatal error: use of undeclared identifier 'B921600'
            case 921600: speed = B921600; break;
                                ^
