### PR TITLE
Crypto fixes

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -298,12 +298,8 @@ if(EXISTS ${BOARD_DEFCONFIG})
 	endif()
 
 	if(CRYPTO)
-		set(PX4_CRYPTO ${CRYPTO} CACHE STRING "PX4 crypto implementation" FORCE)
+		set(PX4_CRYPTO "1" CACHE INTERNAL "PX4 crypto implementation" FORCE)
 		add_definitions(-DPX4_CRYPTO)
-	endif()
-
-	if(KEYSTORE)
-		set(PX4_KEYSTORE ${KEYSTORE} CACHE STRING "PX4 keystore implementation" FORCE)
 	endif()
 
 	if(LINKER_PREFIX)

--- a/src/drivers/sw_crypto/crypto.c
+++ b/src/drivers/sw_crypto/crypto.c
@@ -410,7 +410,7 @@ size_t crypto_get_min_blocksize(crypto_session_handle_t handle, uint8_t key_idx)
 
 	case CRYPTO_RSA_OAEP: {
 			rsa_key enc_key;
-			unsigned pub_key_sz;
+			size_t pub_key_sz;
 			uint8_t *pub_key = (uint8_t *)crypto_get_key_ptr(handle.keystore_handle, key_idx, &pub_key_sz);
 
 			if (pub_key &&

--- a/src/drivers/sw_crypto/crypto.c
+++ b/src/drivers/sw_crypto/crypto.c
@@ -52,11 +52,11 @@ extern void libtomcrypt_init(void);
 #define KEY_CACHE_LEN 16
 
 #ifndef SECMEM_ALLOC
-#define SECMEM_ALLOC malloc
+#define SECMEM_ALLOC XMALLOC
 #endif
 
 #ifndef SECMEM_FREE
-#define SECMEM_FREE free
+#define SECMEM_FREE XFREE
 #endif
 
 /*
@@ -156,7 +156,7 @@ crypto_session_handle_t crypto_open(px4_crypto_algorithm_t algorithm)
 
 	switch (algorithm) {
 	case CRYPTO_XCHACHA20: {
-			chacha20_context_t *context = malloc(sizeof(chacha20_context_t));
+			chacha20_context_t *context = XMALLOC(sizeof(chacha20_context_t));
 
 			if (!context) {
 				ret.handle = 0;
@@ -188,7 +188,7 @@ void crypto_close(crypto_session_handle_t *handle)
 	crypto_open_count--;
 	handle->handle = 0;
 	keystore_close(&handle->keystore_handle);
-	free(handle->context);
+	XFREE(handle->context);
 	handle->context = NULL;
 }
 

--- a/src/lib/crypto/CMakeLists.txt
+++ b/src/lib/crypto/CMakeLists.txt
@@ -99,4 +99,14 @@ target_link_libraries(libtomcrypt
 # "der_encode_asn1_identifier.c:39:18: error: comparison is always false due to limited range of data type"
 target_compile_options(libtomcrypt PRIVATE -Wno-type-limits)
 
+# Re-define memory allocation macros if we are building for
+# memory protected build in nuttx. All allocations happen in
+# kernel heap there
+
+if (NOT DEFINED CONFIG_BUILD_FLAT AND "${PX4_PLATFORM}" MATCHES "nuttx")
+	target_compile_options(libtomcrypt PUBLIC -DXMALLOC=kmm_malloc -DXFREE=kmm_free -DXREALLOC=kmm_realloc -DXCALLOC=kmm_calloc)
+	target_compile_options(libtommath PUBLIC -DMP_MALLOC=kmm_malloc -DMP_FREE\(p,s\)=kmm_free\(p\) -DMP_REALLOC\(p,o,n\)=kmm_realloc\(p,n\) -DMP_CALLOC=kmm_calloc)
+	target_link_libraries(libtommath PRIVATE nuttx_kmm)
+endif()
+
 endif()


### PR DESCRIPTION
This PR contains a set of small fixes for current SW crypto implementation, picked from my other branches:
- Always use the same allocation functions for both src/lib/crypto libraries and sw_crypto driver/wrapper
- Fix cmake caching error when building variants with and without crypto enabled
- a type mismatch in crypto_get_min_blocksize function, which triggers a warning on some compilers, but not all
- a cleanup in cmake/kconfig.cmake to remove BOARD_KEYSTORE flag; it is no longer needed when the keystore (if needed as a separate module at all) is just another driver