### PR TITLE
trajectory-planning: Single target option for PositionSmoothing

### DIFF
--- a/src/lib/motion_planning/PositionSmoothing.hpp
+++ b/src/lib/motion_planning/PositionSmoothing.hpp
@@ -68,7 +68,7 @@ public:
 
 	/**
 	 * @brief Generates new setpoints for jerk, acceleration, velocity and position
-	 * to reach the given waypoint smoothly from current position.
+	 * to reach the given waypoint triplet smoothly from current position
 	 *
 	 * @param position Current position of the vehicle
 	 * @param waypoints 0: Past waypoint, 1: target, 2: Target after next target
@@ -77,14 +77,44 @@ public:
 	 * @param force_zero_velocity_setpoint Force vehicle to stop. Generate trajectory that ends with still vehicle.
 	 * @param out_setpoints Output of the generated setpoints
 	 */
-	void generateSetpoints(
+	inline void generateSetpoints(
 		const Vector3f &position,
 		const Vector3f(&waypoints)[3],
 		const Vector3f &feedforward_velocity,
 		float delta_time,
 		bool force_zero_velocity_setpoint,
 		PositionSmoothingSetpoints &out_setpoints
-	);
+	)
+	{
+		_generateSetpoints(position, waypoints, false, feedforward_velocity, delta_time, force_zero_velocity_setpoint,
+				   out_setpoints);
+	}
+
+	/**
+	 * @brief Generates new setpoints for jerk, acceleration, velocity and position
+	 * to reach the given waypoint smoothly from current position.
+	 *
+	 * @param position Current position of the vehicle
+	 * @param waypoint desired waypoint
+	 * @param feedforward_velocity FF velocity
+	 * @param delta_time Time since last invocation of the function
+	 * @param force_zero_velocity_setpoint Force vehicle to stop. Generate trajectory that ends with still vehicle.
+	 * @param out_setpoints Output of the generated setpoints
+	 */
+	inline void generateSetpoints(
+		const Vector3f &position,
+		const Vector3f &waypoint,
+		const Vector3f &feedforward_velocity,
+		float delta_time,
+		bool force_zero_velocity_setpoint,
+		PositionSmoothingSetpoints &out_setpoints
+	)
+	{
+		Vector3f waypoints[3] = {waypoint, waypoint, waypoint};
+		_generateSetpoints(position, waypoints, true, feedforward_velocity, delta_time, force_zero_velocity_setpoint,
+				   out_setpoints);
+	}
+
 
 	/**
 	 * @brief Reset internal state to the given values
@@ -394,7 +424,19 @@ private:
 
 	/* Internal functions */
 	bool _isTurning(const Vector3f &target) const;
+
+	void _generateSetpoints(
+		const Vector3f &position,
+		const Vector3f(&waypoints)[3],
+		bool is_single_waypoint,
+		const Vector3f &feedforward_velocity,
+		float delta_time,
+		bool force_zero_velocity_setpoint,
+		PositionSmoothingSetpoints &out_setpoints
+	);
+
 	const Vector3f _generateVelocitySetpoint(const Vector3f &position, const Vector3f(&waypoints)[3],
+			bool is_single_waypoint,
 			const Vector3f &feedforward_velocity_setpoint);
 	const Vector2f _getL1Point(const Vector3f &position, const Vector3f(&waypoints)[3]) const;
 	const Vector3f _getCrossingPoint(const Vector3f &position, const Vector3f(&waypoints)[3]) const;

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -284,9 +284,7 @@ void FlightTaskOrbit::_generate_circle_approach_setpoints()
 	const Vector3f target_circle_point{closest_point_on_circle(0), closest_point_on_circle(1), _center(2)};
 
 	PositionSmoothing::PositionSmoothingSetpoints out_setpoints;
-	_position_smoothing.generateSetpoints(_position, {
-		_circle_approach_start_position, target_circle_point, target_circle_point
-	},
+	_position_smoothing.generateSetpoints(_position, target_circle_point,
 	{0.f, 0.f, 0.f}, _deltatime, false, out_setpoints);
 
 	_yaw_setpoint = atan2f(position_to_center_xy(1), position_to_center_xy(0));


### PR DESCRIPTION
This adds a "single target" mode for the position smoothing.

**Describe problem solved by this pull request**
 For cases, when we simply want to guide the vehicle to a new position, without passing through other waypoints, knowledge of the previous waypoint as well as L1 guidance are not necessary. 

In fact, L1 guidance could potentially get consfused when setting previous waypoints to wrong values in the old API.

**Describe your solution**
This extends the PositionSmoothing library with an API that consumes only a single waypoint and then internally disables L1 guidance on turns. 
An example for such a case is the Orbit approach trajectory.

**Test data / coverage**
Tested in SITL and X500 on Skynode
