### PR TITLE
Data link loss reaction also in manual modes if enabled

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -63,6 +63,7 @@ uint8 arming_state			# current arming state
 uint8 hil_state				# current hil state
 bool failsafe				# true if system is in failsafe state (e.g.:RTL, Hover, Terminate, ...)
 uint64 failsafe_timestamp               # time when failsafe was activated
+bool failsafe_but_user_took_over
 
 uint8 system_type			# system type, contains mavlink MAV_TYPE
 uint8 system_id			# system id, contains MAVLink's system ID field

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2290,6 +2290,7 @@ Commander::run()
 		_status.geofence_violated = _geofence_result.geofence_violated;
 
 		const bool in_low_battery_failsafe = _battery_warning > battery_status_s::BATTERY_WARNING_LOW;
+		const bool in_data_link_loss_failsafe = _status.failsafe && _status.data_link_lost;
 
 		// Geofence actions
 		const bool geofence_action_enabled = _geofence_result.geofence_action != geofence_result_s::GF_ACTION_NONE;
@@ -2478,7 +2479,7 @@ Commander::run()
 			// Abort autonomous mode and switch to position mode if sticks are moved significantly
 			// but only if actually in air.
 			if ((_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
-			    && !in_low_battery_failsafe && !_geofence_warning_action_on
+			    && !in_low_battery_failsafe && !_geofence_warning_action_on && !in_data_link_loss_failsafe
 			    && _armed.armed
 			    && !_status_flags.rc_input_blocked
 			    && manual_control_setpoint.valid

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -854,6 +854,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 			if (main_ret != TRANSITION_DENIED) {
 				cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
+				_status.failsafe_but_user_took_over = true;
 
 			} else {
 				cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
@@ -1621,6 +1622,8 @@ void Commander::executeActionRequest(const action_request_s &action_request)
 			_internal_state.main_state = action_request.mode;
 			_internal_state.main_state_changes++;
 		}
+
+		_status.failsafe_but_user_took_over = true;
 
 		int ret = main_state_transition(_status, action_request.mode, _status_flags, _internal_state);
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -514,6 +514,11 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, event_failsafe_reason_t::no_rc);
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act, param_com_rcl_act_t);
 
+		} else if (status.data_link_lost && data_link_loss_act_configured && is_armed) {
+			// Data link lost, data link loss reaction configured -> do configured reaction
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, event_failsafe_reason_t::no_datalink);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, data_link_loss_act, 0);
+
 		} else {
 			switch (internal_state.main_state) {
 			case commander_state_s::MAIN_STATE_ACRO:
@@ -552,6 +557,11 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 				/* A local position estimate is enough for POSCTL for multirotors,
 				 * this enables POSCTL using e.g. flow.
 				 * For fixedwing, a global position is needed. */
+
+			} else if (status.data_link_lost && data_link_loss_act_configured && is_armed) {
+				// Data link lost, data link loss reaction configured -> do configured reaction
+				enable_failsafe(status, old_failsafe, mavlink_log_pub, event_failsafe_reason_t::no_datalink);
+				set_link_loss_nav_state(status, armed, status_flags, internal_state, data_link_loss_act, 0);
 
 			} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags,
 							       rc_fallback_allowed, status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)) {

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -673,6 +673,11 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
+		} else if (status.data_link_lost && data_link_loss_act_configured && is_armed) {
+			// Data link lost, data link loss reaction configured -> do configured reaction
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, event_failsafe_reason_t::no_datalink);
+			set_link_loss_nav_state(status, armed, status_flags, internal_state, data_link_loss_act, 0);
+
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else {


### PR DESCRIPTION
**Describe problem solved by this pull request**
When a pilot flies:
- manually in position mode
- BVLOS
- conventional remote e.g. SBUS receiver
- tablet to running QGC and relies on either QGC telemetry or even a video feed

and then he loses the data link he's basically flying blind but there's no failsafe reaction even if he enables the data link loss failsafe using `NAV_DLL_ACT` because the data link is not considered a strict requirement.

**Describe your solution**
I enable executing the data link loss failsafe also in manual modes if it's enabled.
For the use case where the pilot takes over in a manual mode during the data link loss reaction I had to introduce a flag at least temporarily. I want to solve this by allowing an event based reaction in the state machine where in this case only if you lose data link a reaction gets triggered and not all the time while you're in a mode and have no data link.

**Describe possible alternatives**
See last sentense above. It definitely needs improvements.

**Test data / coverage**
This was tested in simulation, in SIH with a lot of cases and flown in real world.