### PR TITLE
Flexible battery class interface

### DIFF
--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -405,7 +405,7 @@ Syslink::handle_message(syslink_message_t *msg)
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
 		_battery.updateBatteryStatus(t, vbat, -1, true,
-					     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0);
+					     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0);
 
 
 		// Update battery charge state

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -404,7 +404,7 @@ Syslink::handle_message(syslink_message_t *msg)
 		memcpy(&vbat, &msg->data[1], sizeof(float));
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
-		_battery.updateBatteryStatus(t, vbat, -1, true, 0);
+		_battery.updateBatteryStatus(t, vbat, -1, true);
 
 		// Update battery charge state
 		if (charging) {

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -405,7 +405,8 @@ Syslink::handle_message(syslink_message_t *msg)
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
 		_battery.setConnected(true);
-		_battery.updateBatteryStatus(t, vbat, -1);
+		_battery.updateVoltage(vbat);
+		_battery.updateBatteryStatus(t);
 
 		// Update battery charge state
 		if (charging) {

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -404,7 +404,8 @@ Syslink::handle_message(syslink_message_t *msg)
 		memcpy(&vbat, &msg->data[1], sizeof(float));
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
-		_battery.updateBatteryStatus(t, vbat, -1, true);
+		_battery.setConnected(true);
+		_battery.updateBatteryStatus(t, vbat, -1);
 
 		// Update battery charge state
 		if (charging) {

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -406,7 +406,7 @@ Syslink::handle_message(syslink_message_t *msg)
 
 		_battery.setConnected(true);
 		_battery.updateVoltage(vbat);
-		_battery.updateBatteryStatus(t);
+		_battery.updateAndPublishBatteryStatus(t);
 
 		// Update battery charge state
 		if (charging) {

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.cpp
@@ -404,9 +404,7 @@ Syslink::handle_message(syslink_message_t *msg)
 		memcpy(&vbat, &msg->data[1], sizeof(float));
 		//memcpy(&iset, &msg->data[5], sizeof(float));
 
-		_battery.updateBatteryStatus(t, vbat, -1, true,
-					     battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0);
-
+		_battery.updateBatteryStatus(t, vbat, -1, true, 0);
 
 		// Update battery charge state
 		if (charging) {

--- a/boards/bitcraze/crazyflie/syslink/syslink_main.h
+++ b/boards/bitcraze/crazyflie/syslink/syslink_main.h
@@ -139,7 +139,7 @@ private:
 
 	// nrf chip schedules battery updates with SYSLINK_SEND_PERIOD_MS
 	static constexpr uint32_t SYSLINK_BATTERY_STATUS_INTERVAL_US = 10_ms;
-	Battery _battery{1, nullptr, SYSLINK_BATTERY_STATUS_INTERVAL_US};
+	Battery _battery{1, nullptr, SYSLINK_BATTERY_STATUS_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE};
 
 	int32_t _rssi;
 	battery_state _bstate;

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -10,7 +10,7 @@ float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown
 float32 time_remaining_s	# predicted time in seconds remaining until battery is empty under previous averaged load, NAN if unknown
 float32 temperature			# temperature of the battery. NaN if unknown
-int32 cell_count			# Number of cells
+uint8 cell_count			# Number of cells, 0 if unknown
 
 uint8 BATTERY_SOURCE_POWER_MODULE = 0
 uint8 BATTERY_SOURCE_EXTERNAL = 1
@@ -27,7 +27,7 @@ uint16 max_error			# max error, expected margin of error in % in the state-of-ch
 uint8 id					# ID number of a battery. Should be unique and consistent for the lifetime of a vehicle. 1-indexed.
 uint16 interface_error		# interface error counter
 
-float32[14] voltage_cell_v		# Battery individual cell voltages
+float32[14] voltage_cell_v		# Battery individual cell voltages, 0 if unknown
 float32 max_cell_voltage_delta	# Max difference between individual cell voltages
 
 bool is_powering_off			# Power off event imminent indication, false if unknown

--- a/src/drivers/imu/invensense/icm20602/ICM20602.hpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.hpp
@@ -76,7 +76,7 @@ private:
 	static constexpr float ACCEL_RATE{GYRO_RATE / SAMPLES_PER_TRANSFER}; // 4000 Hz accel
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/imu/invensense/icm20649/ICM20649.hpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.hpp
@@ -76,7 +76,7 @@ private:
 	static constexpr float ACCEL_RATE{GYRO_RATE / SAMPLES_PER_TRANSFER}; // 4500 Hz accel
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/imu/invensense/icm20948/ICM20948.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.hpp
@@ -78,7 +78,7 @@ private:
 	static constexpr float ACCEL_RATE{GYRO_RATE / SAMPLES_PER_TRANSFER}; // 4500 Hz accel
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/imu/invensense/icm42605/ICM42605.hpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.hpp
@@ -75,7 +75,7 @@ private:
 	static constexpr float ACCEL_RATE{1e6f / FIFO_SAMPLE_DT};
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -75,7 +75,7 @@ private:
 	static constexpr float ACCEL_RATE{1e6f / FIFO_SAMPLE_DT};
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
@@ -76,7 +76,7 @@ private:
 	static constexpr float ACCEL_RATE{GYRO_RATE / SAMPLES_PER_TRANSFER}; // 4000 Hz accel
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
@@ -78,7 +78,7 @@ private:
 	static constexpr float ACCEL_RATE{GYRO_RATE / SAMPLES_PER_TRANSFER}; // 4000 Hz accel
 
 	// maximum FIFO samples per transfer is limited to the size of sensor_accel_fifo/sensor_gyro_fifo
-	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0])), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
+	static constexpr int32_t FIFO_MAX_SAMPLES{math::min(FIFO::SIZE / sizeof(FIFO::DATA), sizeof(sensor_gyro_fifo_s::x) / sizeof(sensor_gyro_fifo_s::x[0]), sizeof(sensor_accel_fifo_s::x) / sizeof(sensor_accel_fifo_s::x[0]) * (int)(GYRO_RATE / ACCEL_RATE))};
 
 	// Transfer data
 	struct FIFOTransferBuffer {

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -84,11 +84,9 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
 	_battery.setConnected(false);
-	_battery.updateBatteryStatus(
-		hrt_absolute_time(),
-		0.0,
-		0.0
-	);
+	_battery.updateVoltage(0.f);
+	_battery.updateCurrent(0.f);
+	_battery.updateBatteryStatus(hrt_absolute_time());
 }
 
 INA226::~INA226()
@@ -229,11 +227,9 @@ INA226::collect()
 	}
 
 	_battery.setConnected(success);
-	_battery.updateBatteryStatus(
-		hrt_absolute_time(),
-		(float) _bus_voltage * INA226_VSCALE,
-		(float) _current * _current_lsb
-	);
+	_battery.updateVoltage(static_cast<float>(_bus_voltage * INA226_VSCALE));
+	_battery.updateCurrent(static_cast<float>(_current * _current_lsb));
+	_battery.updateBatteryStatus(hrt_absolute_time());
 
 	perf_end(_sample_perf);
 
@@ -297,11 +293,9 @@ INA226::RunImpl()
 
 	} else {
 		_battery.setConnected(false);
-		_battery.updateBatteryStatus(
-			hrt_absolute_time(),
-			0.0f,
-			0.0f
-		);
+		_battery.updateVoltage(0.f);
+		_battery.updateCurrent(0.f);
+		_battery.updateBatteryStatus(hrt_absolute_time());
 
 		if (init() != PX4_OK) {
 			ScheduleDelayed(INA226_INIT_RETRY_INTERVAL_US);

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -49,7 +49,7 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 	_comms_errors(perf_alloc(PC_COUNT, "ina226_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina226_collection_err")),
 	_measure_errors(perf_alloc(PC_COUNT, "ina226_measurement_err")),
-	_battery(battery_index, this, INA226_SAMPLE_INTERVAL_US)
+	_battery(battery_index, this, INA226_SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE)
 {
 	float fvalue = MAX_CURRENT;
 	_max_current = fvalue;
@@ -88,7 +88,6 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 		0.0,
 		0.0,
 		false,
-		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0
 	);
 }
@@ -235,7 +234,6 @@ INA226::collect()
 		(float) _bus_voltage * INA226_VSCALE,
 		(float) _current * _current_lsb,
 		success,
-		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0
 	);
 
@@ -305,7 +303,6 @@ INA226::RunImpl()
 			0.0f,
 			0.0f,
 			false,
-			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0
 		);
 

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -83,11 +83,11 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 	_power_lsb = 25 * _current_lsb;
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
+	_battery.setConnected(false);
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		0.0,
-		0.0,
-		false
+		0.0
 	);
 }
 
@@ -228,11 +228,11 @@ INA226::collect()
 		_bus_voltage = _power = _current = _shunt = 0;
 	}
 
+	_battery.setConnected(success);
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		(float) _bus_voltage * INA226_VSCALE,
-		(float) _current * _current_lsb,
-		success
+		(float) _current * _current_lsb
 	);
 
 	perf_end(_sample_perf);
@@ -296,11 +296,11 @@ INA226::RunImpl()
 		ScheduleDelayed(INA226_CONVERSION_INTERVAL);
 
 	} else {
+		_battery.setConnected(false);
 		_battery.updateBatteryStatus(
 			hrt_absolute_time(),
 			0.0f,
-			0.0f,
-			false
+			0.0f
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -89,8 +89,7 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 		0.0,
 		false,
 		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-		0,
-		0.0
+		0
 	);
 }
 
@@ -231,16 +230,13 @@ INA226::collect()
 		_bus_voltage = _power = _current = _shunt = 0;
 	}
 
-	_actuators_sub.copy(&_actuator_controls);
-
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		(float) _bus_voltage * INA226_VSCALE,
 		(float) _current * _current_lsb,
 		success,
 		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-		0,
-		_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE]
+		0
 	);
 
 	perf_end(_sample_perf);
@@ -310,8 +306,7 @@ INA226::RunImpl()
 			0.0f,
 			false,
 			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-			0,
-			0.0f
+			0
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -86,7 +86,7 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 	_battery.setConnected(false);
 	_battery.updateVoltage(0.f);
 	_battery.updateCurrent(0.f);
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 }
 
 INA226::~INA226()
@@ -229,7 +229,7 @@ INA226::collect()
 	_battery.setConnected(success);
 	_battery.updateVoltage(static_cast<float>(_bus_voltage * INA226_VSCALE));
 	_battery.updateCurrent(static_cast<float>(_current * _current_lsb));
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 
 	perf_end(_sample_perf);
 
@@ -295,7 +295,7 @@ INA226::RunImpl()
 		_battery.setConnected(false);
 		_battery.updateVoltage(0.f);
 		_battery.updateCurrent(0.f);
-		_battery.updateBatteryStatus(hrt_absolute_time());
+		_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 
 		if (init() != PX4_OK) {
 			ScheduleDelayed(INA226_INIT_RETRY_INTERVAL_US);

--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -87,8 +87,7 @@ INA226::INA226(const I2CSPIDriverConfig &config, int battery_index) :
 		hrt_absolute_time(),
 		0.0,
 		0.0,
-		false,
-		0
+		false
 	);
 }
 
@@ -233,8 +232,7 @@ INA226::collect()
 		hrt_absolute_time(),
 		(float) _bus_voltage * INA226_VSCALE,
 		(float) _current * _current_lsb,
-		success,
-		0
+		success
 	);
 
 	perf_end(_sample_perf);
@@ -302,8 +300,7 @@ INA226::RunImpl()
 			hrt_absolute_time(),
 			0.0f,
 			0.0f,
-			false,
-			0
+			false
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina226/ina226.h
+++ b/src/drivers/power_monitor/ina226/ina226.h
@@ -45,9 +45,7 @@
 #include <lib/perf/perf_counter.h>
 #include <battery/battery.h>
 #include <drivers/drv_hrt.h>
-#include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/parameter_update.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
@@ -202,10 +200,7 @@ private:
 	float             _current_lsb{_max_current / DN_MAX};
 	float             _power_lsb{25.0f * _current_lsb};
 
-	actuator_controls_s  _actuator_controls{};
-
 	Battery 		  _battery;
-	uORB::Subscription  _actuators_sub{ORB_ID(actuator_controls_0)};
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	int read(uint8_t address, int16_t &data);

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -89,8 +89,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 		hrt_absolute_time(),
 		0.0,
 		0.0,
-		false,
-		0
+		false
 	);
 }
 
@@ -314,8 +313,7 @@ INA228::collect()
 		hrt_absolute_time(),
 		(float) _bus_voltage * INA228_VSCALE,
 		(float) _current * _current_lsb,
-		success,
-		0
+		success
 	);
 
 	perf_end(_sample_perf);
@@ -383,8 +381,7 @@ INA228::RunImpl()
 			hrt_absolute_time(),
 			0.0f,
 			0.0f,
-			false,
-			0
+			false
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -86,11 +86,9 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
 	_battery.setConnected(false);
-	_battery.updateBatteryStatus(
-		hrt_absolute_time(),
-		0.0,
-		0.0
-	);
+	_battery.updateVoltage(0.f);
+	_battery.updateCurrent(0.f);
+	_battery.updateBatteryStatus(hrt_absolute_time());
 }
 
 INA228::~INA228()
@@ -310,11 +308,9 @@ INA228::collect()
 	}
 
 	_battery.setConnected(success);
-	_battery.updateBatteryStatus(
-		hrt_absolute_time(),
-		(float) _bus_voltage * INA228_VSCALE,
-		(float) _current * _current_lsb
-	);
+	_battery.updateVoltage(static_cast<float>(_bus_voltage * INA228_VSCALE));
+	_battery.updateCurrent(static_cast<float>(_current * _current_lsb));
+	_battery.updateBatteryStatus(hrt_absolute_time());
 
 	perf_end(_sample_perf);
 
@@ -378,11 +374,9 @@ INA228::RunImpl()
 
 	} else {
 		_battery.setConnected(false);
-		_battery.updateBatteryStatus(
-			hrt_absolute_time(),
-			0.0f,
-			0.0f
-		);
+		_battery.updateVoltage(0.f);
+		_battery.updateCurrent(0.f);
+		_battery.updateBatteryStatus(hrt_absolute_time());
 
 		if (init() != PX4_OK) {
 			ScheduleDelayed(INA228_INIT_RETRY_INTERVAL_US);

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -49,7 +49,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 	_comms_errors(perf_alloc(PC_COUNT, "ina228_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina228_collection_err")),
 	_measure_errors(perf_alloc(PC_COUNT, "ina228_measurement_err")),
-	_battery(battery_index, this, INA228_SAMPLE_INTERVAL_US)
+	_battery(battery_index, this, INA228_SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE)
 {
 	float fvalue = MAX_CURRENT;
 	_max_current = fvalue;
@@ -90,7 +90,6 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 		0.0,
 		0.0,
 		false,
-		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0
 	);
 }
@@ -316,7 +315,6 @@ INA228::collect()
 		(float) _bus_voltage * INA228_VSCALE,
 		(float) _current * _current_lsb,
 		success,
-		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0
 	);
 
@@ -386,7 +384,6 @@ INA228::RunImpl()
 			0.0f,
 			0.0f,
 			false,
-			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0
 		);
 

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -88,7 +88,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 	_battery.setConnected(false);
 	_battery.updateVoltage(0.f);
 	_battery.updateCurrent(0.f);
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 }
 
 INA228::~INA228()
@@ -310,7 +310,7 @@ INA228::collect()
 	_battery.setConnected(success);
 	_battery.updateVoltage(static_cast<float>(_bus_voltage * INA228_VSCALE));
 	_battery.updateCurrent(static_cast<float>(_current * _current_lsb));
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 
 	perf_end(_sample_perf);
 
@@ -376,7 +376,7 @@ INA228::RunImpl()
 		_battery.setConnected(false);
 		_battery.updateVoltage(0.f);
 		_battery.updateCurrent(0.f);
-		_battery.updateBatteryStatus(hrt_absolute_time());
+		_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 
 		if (init() != PX4_OK) {
 			ScheduleDelayed(INA228_INIT_RETRY_INTERVAL_US);

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -85,11 +85,11 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 	_power_lsb = 3.2f * _current_lsb;
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
+	_battery.setConnected(false);
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		0.0,
-		0.0,
-		false
+		0.0
 	);
 }
 
@@ -309,11 +309,11 @@ INA228::collect()
 		_bus_voltage = _power = _current = _shunt = 0;
 	}
 
+	_battery.setConnected(success);
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		(float) _bus_voltage * INA228_VSCALE,
-		(float) _current * _current_lsb,
-		success
+		(float) _current * _current_lsb
 	);
 
 	perf_end(_sample_perf);
@@ -377,11 +377,11 @@ INA228::RunImpl()
 		ScheduleDelayed(INA228_CONVERSION_INTERVAL);
 
 	} else {
+		_battery.setConnected(false);
 		_battery.updateBatteryStatus(
 			hrt_absolute_time(),
 			0.0f,
-			0.0f,
-			false
+			0.0f
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina228/ina228.cpp
+++ b/src/drivers/power_monitor/ina228/ina228.cpp
@@ -91,8 +91,7 @@ INA228::INA228(const I2CSPIDriverConfig &config, int battery_index) :
 		0.0,
 		false,
 		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-		0,
-		0.0
+		0
 	);
 }
 
@@ -312,16 +311,13 @@ INA228::collect()
 		_bus_voltage = _power = _current = _shunt = 0;
 	}
 
-	_actuators_sub.copy(&_actuator_controls);
-
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		(float) _bus_voltage * INA228_VSCALE,
 		(float) _current * _current_lsb,
 		success,
 		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-		0,
-		_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE]
+		0
 	);
 
 	perf_end(_sample_perf);
@@ -391,8 +387,7 @@ INA228::RunImpl()
 			0.0f,
 			false,
 			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-			0,
-			0.0f
+			0
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina228/ina228.h
+++ b/src/drivers/power_monitor/ina228/ina228.h
@@ -45,9 +45,7 @@
 #include <lib/perf/perf_counter.h>
 #include <battery/battery.h>
 #include <drivers/drv_hrt.h>
-#include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/parameter_update.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
@@ -352,10 +350,7 @@ private:
 	float             _current_lsb{_max_current / DN_MAX};
 	float             _power_lsb{25.0f * _current_lsb};
 
-	actuator_controls_s  _actuator_controls{};
-
 	Battery 		  _battery;
-	uORB::Subscription  _actuators_sub{ORB_ID(actuator_controls_0)};
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	int read(uint8_t address, int16_t &data);

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -68,11 +68,11 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 	_current_lsb = _max_current / INA238_DN_MAX;
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
+	_battery.setConnected(false);
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		0.0,
-		0.0,
-		false
+		0.0
 	);
 }
 
@@ -196,11 +196,11 @@ int INA238::collect()
 		bus_voltage = current = 0;
 	}
 
+	_battery.setConnected(success);
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		(float) bus_voltage * INA238_VSCALE,
-		(float) current * _current_lsb,
-		success
+		(float) current * _current_lsb
 	);
 
 	perf_end(_sample_perf);
@@ -255,11 +255,11 @@ void INA238::RunImpl()
 		ScheduleDelayed(INA238_CONVERSION_INTERVAL);
 
 	} else {
+		_battery.setConnected(false);
 		_battery.updateBatteryStatus(
 			hrt_absolute_time(),
 			0.0f,
-			0.0f,
-			false
+			0.0f
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -74,8 +74,7 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 		0.0,
 		false,
 		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-		0,
-		0.0
+		0
 	);
 }
 
@@ -199,16 +198,13 @@ int INA238::collect()
 		bus_voltage = current = 0;
 	}
 
-	_actuators_sub.copy(&_actuator_controls);
-
 	_battery.updateBatteryStatus(
 		hrt_absolute_time(),
 		(float) bus_voltage * INA238_VSCALE,
 		(float) current * _current_lsb,
 		success,
 		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-		0,
-		_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE]
+		0
 	);
 
 	perf_end(_sample_perf);
@@ -269,8 +265,7 @@ void INA238::RunImpl()
 			0.0f,
 			false,
 			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-			0,
-			0.0f
+			0
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -72,8 +72,7 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 		hrt_absolute_time(),
 		0.0,
 		0.0,
-		false,
-		0
+		false
 	);
 }
 
@@ -201,8 +200,7 @@ int INA238::collect()
 		hrt_absolute_time(),
 		(float) bus_voltage * INA238_VSCALE,
 		(float) current * _current_lsb,
-		success,
-		0
+		success
 	);
 
 	perf_end(_sample_perf);
@@ -261,8 +259,7 @@ void INA238::RunImpl()
 			hrt_absolute_time(),
 			0.0f,
 			0.0f,
-			false,
-			0
+			false
 		);
 
 		if (init() != PX4_OK) {

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -71,7 +71,7 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 	_battery.setConnected(false);
 	_battery.updateVoltage(0.f);
 	_battery.updateCurrent(0.f);
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 }
 
 INA238::~INA238()
@@ -197,7 +197,7 @@ int INA238::collect()
 	_battery.setConnected(success);
 	_battery.updateVoltage(static_cast<float>(bus_voltage * INA238_VSCALE));
 	_battery.updateCurrent(static_cast<float>(current * _current_lsb));
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 
 	perf_end(_sample_perf);
 
@@ -254,7 +254,7 @@ void INA238::RunImpl()
 		_battery.setConnected(false);
 		_battery.updateVoltage(0.f);
 		_battery.updateCurrent(0.f);
-		_battery.updateBatteryStatus(hrt_absolute_time());
+		_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 
 		if (init() != PX4_OK) {
 			ScheduleDelayed(INA238_INIT_RETRY_INTERVAL_US);

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -45,7 +45,7 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 	_sample_perf(perf_alloc(PC_ELAPSED, "ina238_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "ina238_com_err")),
 	_collection_errors(perf_alloc(PC_COUNT, "ina238_collection_err")),
-	_battery(battery_index, this, INA238_SAMPLE_INTERVAL_US)
+	_battery(battery_index, this, INA238_SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE)
 {
 	float fvalue = DEFAULT_MAX_CURRENT;
 	_max_current = fvalue;
@@ -73,7 +73,6 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 		0.0,
 		0.0,
 		false,
-		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0
 	);
 }
@@ -203,7 +202,6 @@ int INA238::collect()
 		(float) bus_voltage * INA238_VSCALE,
 		(float) current * _current_lsb,
 		success,
-		battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 		0
 	);
 
@@ -264,7 +262,6 @@ void INA238::RunImpl()
 			0.0f,
 			0.0f,
 			false,
-			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0
 		);
 

--- a/src/drivers/power_monitor/ina238/ina238.cpp
+++ b/src/drivers/power_monitor/ina238/ina238.cpp
@@ -69,11 +69,9 @@ INA238::INA238(const I2CSPIDriverConfig &config, int battery_index) :
 
 	// We need to publish immediately, to guarantee that the first instance of the driver publishes to uORB instance 0
 	_battery.setConnected(false);
-	_battery.updateBatteryStatus(
-		hrt_absolute_time(),
-		0.0,
-		0.0
-	);
+	_battery.updateVoltage(0.f);
+	_battery.updateCurrent(0.f);
+	_battery.updateBatteryStatus(hrt_absolute_time());
 }
 
 INA238::~INA238()
@@ -197,11 +195,9 @@ int INA238::collect()
 	}
 
 	_battery.setConnected(success);
-	_battery.updateBatteryStatus(
-		hrt_absolute_time(),
-		(float) bus_voltage * INA238_VSCALE,
-		(float) current * _current_lsb
-	);
+	_battery.updateVoltage(static_cast<float>(bus_voltage * INA238_VSCALE));
+	_battery.updateCurrent(static_cast<float>(current * _current_lsb));
+	_battery.updateBatteryStatus(hrt_absolute_time());
 
 	perf_end(_sample_perf);
 
@@ -256,11 +252,9 @@ void INA238::RunImpl()
 
 	} else {
 		_battery.setConnected(false);
-		_battery.updateBatteryStatus(
-			hrt_absolute_time(),
-			0.0f,
-			0.0f
-		);
+		_battery.updateVoltage(0.f);
+		_battery.updateCurrent(0.f);
+		_battery.updateBatteryStatus(hrt_absolute_time());
 
 		if (init() != PX4_OK) {
 			ScheduleDelayed(INA238_INIT_RETRY_INTERVAL_US);

--- a/src/drivers/power_monitor/ina238/ina238.h
+++ b/src/drivers/power_monitor/ina238/ina238.h
@@ -41,9 +41,7 @@
 #include <lib/perf/perf_counter.h>
 #include <battery/battery.h>
 #include <drivers/drv_hrt.h>
-#include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/parameter_update.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
@@ -338,10 +336,7 @@ private:
 	float _current_lsb;
 	int16_t _range;
 
-	actuator_controls_s _actuator_controls{};
-
 	Battery _battery;
-	uORB::Subscription _actuators_sub{ORB_ID(actuator_controls_0)};
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	int read(uint8_t address, uint16_t &data);

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -77,8 +77,7 @@ VOXLPM::init()
 			0.0,
 			false,
 			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-			0,
-			0.0
+			0
 		);
 	}
 
@@ -346,15 +345,12 @@ VOXLPM::measure()
 	if (ret == PX4_OK) {
 		switch (_ch_type) {
 		case VOXLPM_CH_TYPE_VBATT: {
-				_actuators_sub.copy(&_actuator_controls);
-
 				_battery.updateBatteryStatus(tnow,
 							     _voltage,
 							     _amperage,
 							     true,
 							     battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-							     0,
-							     _actuator_controls.control[actuator_controls_s::INDEX_THROTTLE]);
+							     0);
 			}
 
 		// fallthrough
@@ -382,8 +378,7 @@ VOXLPM::measure()
 							     0.0,
 							     true,
 							     battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-							     0,
-							     0.0);
+							     0);
 			}
 			break;
 

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -72,11 +72,9 @@ VOXLPM::init()
 
 	if (_ch_type == VOXLPM_CH_TYPE_VBATT) {
 		_battery.setConnected(false);
-		_battery.updateBatteryStatus(
-			hrt_absolute_time(),
-			0.0,
-			0.0
-		);
+		_battery.updateVoltage(0.f);
+		_battery.updateCurrent(0.f);
+		_battery.updateBatteryStatus(hrt_absolute_time());
 	}
 
 	/* do I2C init, it will probe the bus for two possible configurations, LTC2946 or INA231 */
@@ -345,9 +343,9 @@ VOXLPM::measure()
 		case VOXLPM_CH_TYPE_VBATT: {
 
 				_battery.setConnected(true);
-				_battery.updateBatteryStatus(tnow,
-							     _voltage,
-							     _amperage);
+				_battery.updateVoltage(_voltage);
+				_battery.updateCurrent(_amperage);
+				_battery.updateBatteryStatus(tnow);
 			}
 
 		// fallthrough
@@ -371,9 +369,9 @@ VOXLPM::measure()
 		switch (_ch_type) {
 		case VOXLPM_CH_TYPE_VBATT: {
 				_battery.setConnected(true);
-				_battery.updateBatteryStatus(tnow,
-							     0.0,
-							     0.0);
+				_battery.updateVoltage(0.f);
+				_battery.updateCurrent(0.f);
+				_battery.updateBatteryStatus(tnow);
 			}
 			break;
 

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -75,8 +75,7 @@ VOXLPM::init()
 			hrt_absolute_time(),
 			0.0,
 			0.0,
-			false,
-			0
+			false
 		);
 	}
 
@@ -347,8 +346,7 @@ VOXLPM::measure()
 				_battery.updateBatteryStatus(tnow,
 							     _voltage,
 							     _amperage,
-							     true,
-							     0);
+							     true);
 			}
 
 		// fallthrough
@@ -374,8 +372,7 @@ VOXLPM::measure()
 				_battery.updateBatteryStatus(tnow,
 							     0.0,
 							     0.0,
-							     true,
-							     0);
+							     true);
 			}
 			break;
 

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -54,7 +54,7 @@ VOXLPM::VOXLPM(const I2CSPIDriverConfig &config) :
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_comms_errors(perf_alloc(PC_COUNT, MODULE_NAME": comms_errors")),
 	_ch_type((VOXLPM_CH_TYPE)config.custom1),
-	_battery(1, this, _meas_interval_us)
+	_battery(1, this, _meas_interval_us, battery_status_s::BATTERY_SOURCE_POWER_MODULE)
 {
 }
 
@@ -76,7 +76,6 @@ VOXLPM::init()
 			0.0,
 			0.0,
 			false,
-			battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 			0
 		);
 	}
@@ -349,7 +348,6 @@ VOXLPM::measure()
 							     _voltage,
 							     _amperage,
 							     true,
-							     battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 							     0);
 			}
 
@@ -377,7 +375,6 @@ VOXLPM::measure()
 							     0.0,
 							     0.0,
 							     true,
-							     battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 							     0);
 			}
 			break;

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -71,11 +71,11 @@ VOXLPM::init()
 	int ret = PX4_ERROR;
 
 	if (_ch_type == VOXLPM_CH_TYPE_VBATT) {
+		_battery.setConnected(false);
 		_battery.updateBatteryStatus(
 			hrt_absolute_time(),
 			0.0,
-			0.0,
-			false
+			0.0
 		);
 	}
 
@@ -343,10 +343,11 @@ VOXLPM::measure()
 	if (ret == PX4_OK) {
 		switch (_ch_type) {
 		case VOXLPM_CH_TYPE_VBATT: {
+
+				_battery.setConnected(true);
 				_battery.updateBatteryStatus(tnow,
 							     _voltage,
-							     _amperage,
-							     true);
+							     _amperage);
 			}
 
 		// fallthrough
@@ -369,10 +370,10 @@ VOXLPM::measure()
 
 		switch (_ch_type) {
 		case VOXLPM_CH_TYPE_VBATT: {
+				_battery.setConnected(true);
 				_battery.updateBatteryStatus(tnow,
 							     0.0,
-							     0.0,
-							     true);
+							     0.0);
 			}
 			break;
 

--- a/src/drivers/power_monitor/voxlpm/voxlpm.cpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.cpp
@@ -74,7 +74,7 @@ VOXLPM::init()
 		_battery.setConnected(false);
 		_battery.updateVoltage(0.f);
 		_battery.updateCurrent(0.f);
-		_battery.updateBatteryStatus(hrt_absolute_time());
+		_battery.updateAndPublishBatteryStatus(hrt_absolute_time());
 	}
 
 	/* do I2C init, it will probe the bus for two possible configurations, LTC2946 or INA231 */
@@ -345,7 +345,7 @@ VOXLPM::measure()
 				_battery.setConnected(true);
 				_battery.updateVoltage(_voltage);
 				_battery.updateCurrent(_amperage);
-				_battery.updateBatteryStatus(tnow);
+				_battery.updateAndPublishBatteryStatus(tnow);
 			}
 
 		// fallthrough
@@ -371,7 +371,7 @@ VOXLPM::measure()
 				_battery.setConnected(true);
 				_battery.updateVoltage(0.f);
 				_battery.updateCurrent(0.f);
-				_battery.updateBatteryStatus(tnow);
+				_battery.updateAndPublishBatteryStatus(tnow);
 			}
 			break;
 

--- a/src/drivers/power_monitor/voxlpm/voxlpm.hpp
+++ b/src/drivers/power_monitor/voxlpm/voxlpm.hpp
@@ -88,9 +88,7 @@
 #include <battery/battery.h>
 
 #include <uORB/PublicationMulti.hpp>
-#include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/power_monitor.h>
 #include <uORB/topics/parameter_update.h>
@@ -267,8 +265,6 @@ private:
 	int16_t			_cal{0};
 
 	Battery 		_battery;
-	uORB::Subscription	_actuators_sub{ORB_ID(actuator_controls_0)};
-	actuator_controls_s	_actuator_controls{};
 
 	uint8_t 		read_reg(uint8_t addr);
 	int 			read_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len);

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -335,7 +335,7 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	}
 
 	if (valid_vel_cov) {
-		report.s_variance_m_s = math::max(math::max(vel_cov[0], vel_cov[4]), vel_cov[8]);
+		report.s_variance_m_s = math::max(vel_cov[0], vel_cov[4], vel_cov[8]);
 
 		/* There is a nonlinear relationship between the velocity vector and the heading.
 		 * Use Jacobian to transform velocity covariance to heading covariance

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -134,24 +134,13 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	battery_status.scale = _scale;
 	battery_status.time_remaining_s = computeRemainingTime(current_a);
 	battery_status.temperature = NAN;
-	// Publish at least one cell such that the total voltage gets into MAVLink BATTERY_STATUS
-	battery_status.cell_count = math::max(_params.n_cells, static_cast<int32_t>(1));
+	battery_status.cell_count = _params.n_cells;
 	battery_status.connected = connected;
 	battery_status.source = source;
 	battery_status.priority = priority;
 	battery_status.capacity = _params.capacity > 0.f ? static_cast<uint16_t>(_params.capacity) : 0;
 	battery_status.id = static_cast<uint8_t>(_index);
 	battery_status.warning = _warning;
-
-	static constexpr int32_t uorb_max_cells = sizeof(battery_status.voltage_cell_v) / sizeof(
-				battery_status.voltage_cell_v[0]);
-
-	int max_cells = math::min(battery_status.cell_count, uorb_max_cells);
-
-	// Fill cell voltages with average values to work around MAVLink BATTERY_STATUS not allowing to report just total voltage
-	for (int i = 0; i < max_cells; i++) {
-		battery_status.voltage_cell_v[i] = battery_status.voltage_filtered_v / max_cells;
-	}
 
 	if (source == _params.source) {
 		battery_status.timestamp = hrt_absolute_time();

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -130,7 +130,10 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 	} else {
 		_connected = false;
 	}
+}
 
+battery_status_s Battery::getBatteryStatus()
+{
 	battery_status_s battery_status{};
 	battery_status.voltage_v = _voltage_v;
 	battery_status.voltage_filtered_v = _voltage_filter_v.getState();
@@ -149,11 +152,21 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 	battery_status.capacity = _params.capacity > 0.f ? static_cast<uint16_t>(_params.capacity) : 0;
 	battery_status.id = static_cast<uint8_t>(_index);
 	battery_status.warning = _warning;
+	battery_status.timestamp = hrt_absolute_time();
+	return battery_status;
+}
 
+void Battery::publishBatteryStatus(const battery_status_s &battery_status)
+{
 	if (_source == _params.source) {
-		battery_status.timestamp = hrt_absolute_time();
 		_battery_status_pub.publish(battery_status);
 	}
+}
+
+void Battery::updateAndPublishBatteryStatus(const hrt_abstime &timestamp)
+{
+	updateBatteryStatus(timestamp);
+	publishBatteryStatus(getBatteryStatus());
 }
 
 void Battery::sumDischarged(const hrt_abstime &timestamp, float current_a)

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -97,8 +97,7 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 	updateParams();
 }
 
-void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
-				  int priority)
+void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected)
 {
 	if (!_battery_initialized) {
 		_voltage_filter_v.reset(voltage_v);
@@ -136,7 +135,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	battery_status.cell_count = _params.n_cells;
 	battery_status.connected = connected;
 	battery_status.source = _source;
-	battery_status.priority = priority;
+	battery_status.priority = _priority;
 	battery_status.capacity = _params.capacity > 0.f ? static_cast<uint16_t>(_params.capacity) : 0;
 	battery_status.id = static_cast<uint8_t>(_index);
 	battery_status.warning = _warning;

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -97,16 +97,26 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 	updateParams();
 }
 
-void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a)
+void Battery::updateVoltage(const float voltage_v)
+{
+	_voltage_v = voltage_v;
+	_voltage_filter_v.update(voltage_v);
+}
+
+void Battery::updateCurrent(const float current_a)
+{
+	_current_a = current_a;
+	_current_filter_a.update(current_a);
+}
+
+void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 {
 	if (!_battery_initialized) {
-		_voltage_filter_v.reset(voltage_v);
-		_current_filter_a.reset(current_a);
+		_voltage_filter_v.reset(_voltage_v);
+		_current_filter_a.reset(_current_a);
 	}
 
-	_voltage_filter_v.update(voltage_v);
-	_current_filter_a.update(current_a);
-	sumDischarged(timestamp, current_a);
+	sumDischarged(timestamp, _current_a);
 	estimateStateOfCharge(_voltage_filter_v.getState(), _current_filter_a.getState());
 	computeScale();
 
@@ -122,15 +132,15 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	}
 
 	battery_status_s battery_status{};
-	battery_status.voltage_v = voltage_v;
+	battery_status.voltage_v = _voltage_v;
 	battery_status.voltage_filtered_v = _voltage_filter_v.getState();
-	battery_status.current_a = current_a;
+	battery_status.current_a = _current_a;
 	battery_status.current_filtered_a = _current_filter_a.getState();
 	battery_status.current_average_a = _current_average_filter_a.getState();
 	battery_status.discharged_mah = _discharged_mah;
 	battery_status.remaining = _state_of_charge;
 	battery_status.scale = _scale;
-	battery_status.time_remaining_s = computeRemainingTime(current_a);
+	battery_status.time_remaining_s = computeRemainingTime(_current_a);
 	battery_status.temperature = NAN;
 	battery_status.cell_count = _params.n_cells;
 	battery_status.connected = _connected;

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -97,7 +97,7 @@ Battery::Battery(int index, ModuleParams *parent, const int sample_interval_us, 
 	updateParams();
 }
 
-void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected)
+void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a)
 {
 	if (!_battery_initialized) {
 		_voltage_filter_v.reset(voltage_v);
@@ -110,7 +110,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	estimateStateOfCharge(_voltage_filter_v.getState(), _current_filter_a.getState());
 	computeScale();
 
-	if (connected && _battery_initialized) {
+	if (_connected && _battery_initialized) {
 		_warning = determineWarning(_state_of_charge);
 	}
 
@@ -118,7 +118,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 		_battery_initialized = true;
 
 	} else {
-		connected = false;
+		_connected = false;
 	}
 
 	battery_status_s battery_status{};
@@ -133,7 +133,7 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v,
 	battery_status.time_remaining_s = computeRemainingTime(current_a);
 	battery_status.temperature = NAN;
 	battery_status.cell_count = _params.n_cells;
-	battery_status.connected = connected;
+	battery_status.connected = _connected;
 	battery_status.source = _source;
 	battery_status.priority = _priority;
 	battery_status.capacity = _params.capacity > 0.f ? static_cast<uint16_t>(_params.capacity) : 0;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -67,7 +67,7 @@
 class Battery : public ModuleParams
 {
 public:
-	Battery(int index, ModuleParams *parent, const int sample_interval_us);
+	Battery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source);
 	~Battery() = default;
 
 	/**
@@ -91,11 +91,10 @@ public:
 	 * @param voltage_raw: Battery voltage, in Volts
 	 * @param current_raw: Battery current, in Amps
 	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
-	 * @param source: Source type in relation to BAT%d_SOURCE param.
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 */
 	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
-				 int source, int priority);
+				 int priority);
 
 protected:
 	struct {
@@ -139,6 +138,7 @@ private:
 	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
+	const uint8_t _source{};
 	bool _battery_initialized{false};
 	AlphaFilter<float> _voltage_filter_v;
 	AlphaFilter<float> _current_filter_a;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -54,6 +54,8 @@
 #include <lib/parameters/param.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
 
 /**
@@ -91,10 +93,9 @@ public:
 	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
 	 * @param source: Source type in relation to BAT%d_SOURCE param.
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
-	 * @param throttle_normalized: Throttle of the vehicle, between 0 and 1
 	 */
 	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
-				 int source, int priority, float throttle_normalized);
+				 int source, int priority);
 
 protected:
 	struct {
@@ -130,11 +131,12 @@ protected:
 
 private:
 	void sumDischarged(const hrt_abstime &timestamp, float current_a);
-	void estimateStateOfCharge(const float voltage_v, const float current_a, const float throttle);
+	void estimateStateOfCharge(const float voltage_v, const float current_a);
 	uint8_t determineWarning(float state_of_charge);
 	void computeScale();
 	float computeRemainingTime(float current_a);
 
+	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
 	bool _battery_initialized{false};

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -97,6 +97,16 @@ public:
 	 */
 	void updateBatteryStatus(const hrt_abstime &timestamp);
 
+	battery_status_s getBatteryStatus();
+	void publishBatteryStatus(const battery_status_s &battery_status);
+
+	/**
+	 * Convenience function for combined update and publication
+	 * @see updateBatteryStatus()
+	 * @see publishBatteryStatus()
+	 */
+	void updateAndPublishBatteryStatus(const hrt_abstime &timestamp);
+
 protected:
 	struct {
 		param_t v_empty;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -85,16 +85,16 @@ public:
 	 */
 	float full_cell_voltage() { return _params.v_charged; }
 
+	void setPriority(const uint8_t priority) { _priority = priority; }
+
 	/**
 	 * Update current battery status message.
 	 *
 	 * @param voltage_raw: Battery voltage, in Volts
 	 * @param current_raw: Battery current, in Amps
 	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
-	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 */
-	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected,
-				 int priority);
+	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected);
 
 protected:
 	struct {
@@ -139,6 +139,7 @@ private:
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
 	const uint8_t _source{};
+	uint8_t _priority{0};
 	bool _battery_initialized{false};
 	AlphaFilter<float> _voltage_filter_v;
 	AlphaFilter<float> _current_filter_a;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -150,7 +150,7 @@ private:
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
 	bool _connected{false};
-	const uint8_t _source{};
+	const uint8_t _source;
 	uint8_t _priority{0};
 	bool _battery_initialized{false};
 	float _voltage_v{0.f};

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -86,6 +86,7 @@ public:
 	float full_cell_voltage() { return _params.v_charged; }
 
 	void setPriority(const uint8_t priority) { _priority = priority; }
+	void setConnected(const bool connected) { _connected = connected; }
 
 	/**
 	 * Update current battery status message.
@@ -94,7 +95,7 @@ public:
 	 * @param current_raw: Battery current, in Amps
 	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
 	 */
-	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a, bool connected);
+	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a);
 
 protected:
 	struct {
@@ -138,6 +139,7 @@ private:
 	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
+	bool _connected{false};
 	const uint8_t _source{};
 	uint8_t _priority{0};
 	bool _battery_initialized{false};

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -87,15 +87,15 @@ public:
 
 	void setPriority(const uint8_t priority) { _priority = priority; }
 	void setConnected(const bool connected) { _connected = connected; }
+	void updateVoltage(const float voltage_v);
+	void updateCurrent(const float current_a);
 
 	/**
 	 * Update current battery status message.
 	 *
-	 * @param voltage_raw: Battery voltage, in Volts
-	 * @param current_raw: Battery current, in Amps
 	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
 	 */
-	void updateBatteryStatus(const hrt_abstime &timestamp, float voltage_v, float current_a);
+	void updateBatteryStatus(const hrt_abstime &timestamp);
 
 protected:
 	struct {
@@ -143,7 +143,9 @@ private:
 	const uint8_t _source{};
 	uint8_t _priority{0};
 	bool _battery_initialized{false};
+	float _voltage_v{0.f};
 	AlphaFilter<float> _voltage_filter_v;
+	float _current_a{-1};
 	AlphaFilter<float> _current_filter_a;
 	AlphaFilter<float> _current_average_filter_a;
 	AlphaFilter<float> _throttle_filter;

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -91,9 +91,9 @@ public:
 	void updateCurrent(const float current_a);
 
 	/**
-	 * Update current battery status message.
+	 * Update state of charge calculations
 	 *
-	 * @param timestamp: Time at which the ADC was read (use hrt_absolute_time())
+	 * @param timestamp Time at which the battery data sample was measured
 	 */
 	void updateBatteryStatus(const hrt_abstime &timestamp);
 

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -86,6 +86,7 @@ parameters:
 
             type: enum
             values:
+                1: 1S Battery
                 2: 2S Battery
                 3: 3S Battery
                 4: 4S Battery

--- a/src/lib/mathlib/math/Limits.hpp
+++ b/src/lib/mathlib/math/Limits.hpp
@@ -57,6 +57,12 @@ constexpr _Tp min(_Tp a, _Tp b)
 }
 
 template<typename _Tp>
+constexpr _Tp min(_Tp a, _Tp b, _Tp c)
+{
+	return min(min(a, b), c);
+}
+
+template<typename _Tp>
 constexpr _Tp max(_Tp a, _Tp b)
 {
 	return (a > b) ? a : b;

--- a/src/lib/mathlib/math/Limits.hpp
+++ b/src/lib/mathlib/math/Limits.hpp
@@ -69,6 +69,12 @@ constexpr _Tp max(_Tp a, _Tp b)
 }
 
 template<typename _Tp>
+constexpr _Tp max(_Tp a, _Tp b, _Tp c)
+{
+	return max(max(a, b), c);
+}
+
+template<typename _Tp>
 constexpr _Tp constrain(_Tp val, _Tp min_val, _Tp max_val)
 {
 	return (val < min_val) ? min_val : ((val > max_val) ? max_val : val);

--- a/src/lib/motion_planning/TrajectoryConstraints.hpp
+++ b/src/lib/motion_planning/TrajectoryConstraints.hpp
@@ -89,7 +89,7 @@ inline float computeStartXYSpeedFromWaypoints(const Vector3f &start_position, co
 		const float safe_alpha = constrain(alpha, 0.f, M_PI_F - FLT_EPSILON);
 		float accel_tmp = config.max_acc_xy_radius_scale * config.max_acc_xy;
 		float max_speed_in_turn = computeMaxSpeedInWaypoint(safe_alpha, accel_tmp, config.xy_accept_rad);
-		speed_at_target = min(min(max_speed_in_turn, exit_speed), config.max_speed_xy);
+		speed_at_target = min(max_speed_in_turn, exit_speed, config.max_speed_xy);
 	}
 
 	float start_to_target = (start_position - target).xy().norm();

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -49,9 +49,11 @@ static constexpr int DEFAULT_V_CHANNEL[1] = {0};
 static constexpr int DEFAULT_I_CHANNEL[1] = {0};
 #endif
 
-AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source) :
+AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source,
+			     const uint8_t priority) :
 	Battery(index, parent, sample_interval_us, source)
 {
+	Battery::setPriority(priority);
 	char param_name[17];
 
 	_analog_param_handles.v_offs_cur = param_find("BAT_V_OFFS_CURR");
@@ -70,8 +72,7 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 }
 
 void
-AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				      int priority)
+AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw)
 {
 	float voltage_v = voltage_raw * _analog_params.v_div;
 	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
@@ -80,8 +81,7 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
 
-	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected,
-				     priority);
+	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -80,8 +80,8 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 	bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
 			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
-
-	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected);
+	Battery::setConnected(connected);
+	Battery::updateBatteryStatus(timestamp, voltage_v, current_a);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -71,7 +71,7 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 
 void
 AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				      int source, int priority, float throttle_normalized)
+				      int source, int priority)
 {
 	float voltage_v = voltage_raw * _analog_params.v_div;
 	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
@@ -81,7 +81,7 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 
 
 	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected,
-				     source, priority, throttle_normalized);
+				     source, priority);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -81,7 +81,9 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
 	Battery::setConnected(connected);
-	Battery::updateBatteryStatus(timestamp, voltage_v, current_a);
+	Battery::updateVoltage(voltage_v);
+	Battery::updateCurrent(current_a);
+	Battery::updateBatteryStatus(timestamp);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -83,7 +83,7 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 	Battery::setConnected(connected);
 	Battery::updateVoltage(voltage_v);
 	Battery::updateCurrent(current_a);
-	Battery::updateBatteryStatus(timestamp);
+	Battery::updateAndPublishBatteryStatus(timestamp);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -49,8 +49,8 @@ static constexpr int DEFAULT_V_CHANNEL[1] = {0};
 static constexpr int DEFAULT_I_CHANNEL[1] = {0};
 #endif
 
-AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us) :
-	Battery(index, parent, sample_interval_us)
+AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source) :
+	Battery(index, parent, sample_interval_us, source)
 {
 	char param_name[17];
 
@@ -71,7 +71,7 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 
 void
 AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				      int source, int priority)
+				      int priority)
 {
 	float voltage_v = voltage_raw * _analog_params.v_div;
 	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
@@ -81,7 +81,7 @@ AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, 
 
 
 	Battery::updateBatteryStatus(timestamp, voltage_v, current_a, connected,
-				     source, priority);
+				     priority);
 }
 
 bool AnalogBattery::is_valid()

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -74,11 +74,11 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 void
 AnalogBattery::updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw)
 {
-	float voltage_v = voltage_raw * _analog_params.v_div;
-	float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
+	const float voltage_v = voltage_raw * _analog_params.v_div;
+	const float current_a = (current_raw - _analog_params.v_offs_cur) * _analog_params.a_per_v;
 
-	bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
-			 (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
+	const bool connected = voltage_v > BOARD_ADC_OPEN_CIRCUIT_V &&
+			       (BOARD_ADC_OPEN_CIRCUIT_V <= BOARD_VALID_UV || is_valid());
 
 	Battery::setConnected(connected);
 	Battery::updateVoltage(voltage_v);

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -49,10 +49,9 @@ public:
 	 * @param timestamp Time at which the ADC was read (use hrt_absolute_time())
 	 * @param source The source as defined by param BAT%d_SOURCE
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
-	 * @param throttle_normalized Throttle of the vehicle, between 0 and 1
 	 */
 	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				    int source, int priority, float throttle_normalized);
+				    int source, int priority);
 
 	/**
 	 * Whether the ADC channel for the voltage of this battery is valid.

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -39,7 +39,7 @@
 class AnalogBattery : public Battery
 {
 public:
-	AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us);
+	AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source);
 
 	/**
 	 * Update current battery status message.
@@ -51,7 +51,7 @@ public:
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 */
 	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				    int source, int priority);
+				    int priority);
 
 	/**
 	 * Whether the ADC channel for the voltage of this battery is valid.

--- a/src/modules/battery_status/analog_battery.h
+++ b/src/modules/battery_status/analog_battery.h
@@ -39,7 +39,8 @@
 class AnalogBattery : public Battery
 {
 public:
-	AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source);
+	AnalogBattery(int index, ModuleParams *parent, const int sample_interval_us, const uint8_t source,
+		      const uint8_t priority);
 
 	/**
 	 * Update current battery status message.
@@ -50,8 +51,7 @@ public:
 	 * @param source The source as defined by param BAT%d_SOURCE
 	 * @param priority: The brick number -1. The term priority refers to the Vn connection on the LTC4417
 	 */
-	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw,
-				    int priority);
+	void updateBatteryStatusADC(hrt_abstime timestamp, float voltage_raw, float current_raw);
 
 	/**
 	 * Whether the ADC channel for the voltage of this battery is valid.

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -56,10 +56,9 @@
 #include <lib/perf/perf_counter.h>
 #include <lib/battery/battery.h>
 #include <lib/conversion/rotation.h>
-#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/adc_report.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
@@ -100,7 +99,6 @@ public:
 private:
 	void Run() override;
 
-	uORB::Subscription	_actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};		/**< attitude controls sub */
 	uORB::SubscriptionInterval	_parameter_update_sub{ORB_ID(parameter_update), 1_s};				/**< notification of parameter updates */
 	uORB::SubscriptionCallbackWorkItem _adc_report_sub{this, ORB_ID(adc_report)};
 
@@ -220,16 +218,12 @@ BatteryStatus::adc_poll()
 
 		for (int b = 0; b < BOARD_NUMBER_BRICKS; b++) {
 
-			actuator_controls_s ctrl{};
-			_actuator_ctrl_0_sub.copy(&ctrl);
-
 			_analogBatteries[b]->updateBatteryStatusADC(
 				hrt_absolute_time(),
 				bat_voltage_adc_readings[b],
 				bat_current_adc_readings[b],
 				battery_status_s::BATTERY_SOURCE_POWER_MODULE,
-				b,
-				ctrl.control[actuator_controls_s::INDEX_THROTTLE]
+				b
 			);
 		}
 	}

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -137,9 +137,9 @@ private:
 BatteryStatus::BatteryStatus() :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
-	_battery1(1, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE),
+	_battery1(1, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0),
 #if BOARD_NUMBER_BRICKS > 1
-	_battery2(2, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE),
+	_battery2(2, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 1),
 #endif
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME))
 {
@@ -221,8 +221,7 @@ BatteryStatus::adc_poll()
 			_analogBatteries[b]->updateBatteryStatusADC(
 				hrt_absolute_time(),
 				bat_voltage_adc_readings[b],
-				bat_current_adc_readings[b],
-				b
+				bat_current_adc_readings[b]
 			);
 		}
 	}

--- a/src/modules/battery_status/battery_status.cpp
+++ b/src/modules/battery_status/battery_status.cpp
@@ -137,9 +137,9 @@ private:
 BatteryStatus::BatteryStatus() :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
-	_battery1(1, this, SAMPLE_INTERVAL_US),
+	_battery1(1, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE),
 #if BOARD_NUMBER_BRICKS > 1
-	_battery2(2, this, SAMPLE_INTERVAL_US),
+	_battery2(2, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE),
 #endif
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME))
 {
@@ -222,7 +222,6 @@ BatteryStatus::adc_poll()
 				hrt_absolute_time(),
 				bat_voltage_adc_readings[b],
 				bat_current_adc_readings[b],
-				battery_status_s::BATTERY_SOURCE_POWER_MODULE,
 				b
 			);
 		}

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -953,12 +953,12 @@ void Ekf::get_innovation_test_status(uint16_t &status, float &mag, float &vel, f
 
 	if (_control_status.flags.ev_vel) {
 		float ev_vel = sqrtf(math::max(_ev_vel_test_ratio(0), _ev_vel_test_ratio(1)));
-		vel = math::max(math::max(vel, ev_vel), FLT_MIN);
+		vel = math::max(vel, ev_vel, FLT_MIN);
 	}
 
 	if (_control_status.flags.ev_pos) {
 		float ev_pos = sqrtf(_ev_pos_test_ratio(0));
-		pos = math::max(math::max(pos, ev_pos), FLT_MIN);
+		pos = math::max(pos, ev_pos, FLT_MIN);
 	}
 
 	if (isOnlyActiveSourceOfHorizontalAiding(_control_status.flags.opt_flow)) {

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -102,17 +102,13 @@ EscBattery::Run()
 		const bool connected = true;
 		const int priority = 0;
 
-		actuator_controls_s ctrl;
-		_actuator_ctrl_0_sub.copy(&ctrl);
-
 		_battery.updateBatteryStatus(
 			esc_status.timestamp,
 			average_voltage_v,
 			total_current_a,
 			connected,
 			battery_status_s::BATTERY_SOURCE_ESCS,
-			priority,
-			ctrl.control[actuator_controls_s::INDEX_THROTTLE]);
+			priority);
 	}
 }
 

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -99,13 +99,11 @@ EscBattery::Run()
 
 		average_voltage_v /= esc_status.esc_count;
 
-		const bool connected = true;
-
+		_battery.setConnected(true);
 		_battery.updateBatteryStatus(
 			esc_status.timestamp,
 			average_voltage_v,
-			total_current_a,
-			connected);
+			total_current_a);
 	}
 }
 

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -38,7 +38,7 @@ using namespace time_literals;
 EscBattery::EscBattery() :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::lp_default),
-	_battery(1, this, ESC_BATTERY_INTERVAL_US)
+	_battery(1, this, ESC_BATTERY_INTERVAL_US, battery_status_s::BATTERY_SOURCE_ESCS)
 {
 }
 
@@ -107,7 +107,6 @@ EscBattery::Run()
 			average_voltage_v,
 			total_current_a,
 			connected,
-			battery_status_s::BATTERY_SOURCE_ESCS,
 			priority);
 	}
 }

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -100,14 +100,12 @@ EscBattery::Run()
 		average_voltage_v /= esc_status.esc_count;
 
 		const bool connected = true;
-		const int priority = 0;
 
 		_battery.updateBatteryStatus(
 			esc_status.timestamp,
 			average_voltage_v,
 			total_current_a,
-			connected,
-			priority);
+			connected);
 	}
 }
 

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -100,10 +100,9 @@ EscBattery::Run()
 		average_voltage_v /= esc_status.esc_count;
 
 		_battery.setConnected(true);
-		_battery.updateBatteryStatus(
-			esc_status.timestamp,
-			average_voltage_v,
-			total_current_a);
+		_battery.updateVoltage(average_voltage_v);
+		_battery.updateCurrent(total_current_a);
+		_battery.updateBatteryStatus(esc_status.timestamp);
 	}
 }
 

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -102,7 +102,7 @@ EscBattery::Run()
 		_battery.setConnected(true);
 		_battery.updateVoltage(average_voltage_v);
 		_battery.updateCurrent(total_current_a);
-		_battery.updateBatteryStatus(esc_status.timestamp);
+		_battery.updateAndPublishBatteryStatus(esc_status.timestamp);
 	}
 }
 

--- a/src/modules/esc_battery/EscBattery.hpp
+++ b/src/modules/esc_battery/EscBattery.hpp
@@ -40,11 +40,10 @@
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/PublicationMulti.hpp>
-#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/parameter_update.h>
-#include <uORB/topics/actuator_controls.h>
 #include <battery/battery.h>
 
 using namespace time_literals;
@@ -72,7 +71,6 @@ private:
 	void parameters_updated();
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _actuator_ctrl_0_sub{ORB_ID(actuator_controls_0)};
 	uORB::SubscriptionCallbackWorkItem _esc_status_sub{this, ORB_ID(esc_status)};
 
 	static constexpr uint32_t ESC_BATTERY_INTERVAL_US = 20_ms; // assume higher frequency esc feedback than 50Hz

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1059,7 +1059,7 @@ FixedwingPositionControl::control_auto_position(const hrt_abstime &now, const Ve
 
 			// Save distance to waypoint if it is the smallest ever achieved, however make sure that
 			// _min_current_sp_distance_xy is never larger than the distance between the current and the previous wp
-			_min_current_sp_distance_xy = math::min(math::min(d_curr, _min_current_sp_distance_xy), d_curr_prev);
+			_min_current_sp_distance_xy = math::min(d_curr, _min_current_sp_distance_xy, d_curr_prev);
 
 			// if the minimal distance is smaller than the acceptance radius, we should be at waypoint alt
 			// navigator will soon switch to the next waypoint item (if there is one) as soon as we reach this altitude

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -99,7 +99,7 @@ void BatterySimulator::Run()
 	float vbatt = math::gradual(_battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 	vbatt *= _battery.cell_count();
 
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0, 0.f);
+	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0);
 
 	perf_end(_loop_perf);
 }

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -36,7 +36,7 @@
 BatterySimulator::BatterySimulator() :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
-	_battery(1, this, BATTERY_SIMLATOR_SAMPLE_INTERVAL_US)
+	_battery(1, this, BATTERY_SIMLATOR_SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_POWER_MODULE)
 {
 }
 
@@ -99,7 +99,7 @@ void BatterySimulator::Run()
 	float vbatt = math::gradual(_battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 	vbatt *= _battery.cell_count();
 
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, battery_status_s::BATTERY_SOURCE_POWER_MODULE, 0);
+	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, 0);
 
 	perf_end(_loop_perf);
 }

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -100,7 +100,9 @@ void BatterySimulator::Run()
 	vbatt *= _battery.cell_count();
 
 	_battery.setConnected(true);
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt);
+	_battery.updateVoltage(vbatt);
+	_battery.updateCurrent(ibatt);
+	_battery.updateBatteryStatus(now_us);
 
 	perf_end(_loop_perf);
 }

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -102,7 +102,7 @@ void BatterySimulator::Run()
 	_battery.setConnected(true);
 	_battery.updateVoltage(vbatt);
 	_battery.updateCurrent(ibatt);
-	_battery.updateBatteryStatus(now_us);
+	_battery.updateAndPublishBatteryStatus(now_us);
 
 	perf_end(_loop_perf);
 }

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -99,7 +99,7 @@ void BatterySimulator::Run()
 	float vbatt = math::gradual(_battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 	vbatt *= _battery.cell_count();
 
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true, 0);
+	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true);
 
 	perf_end(_loop_perf);
 }

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -99,7 +99,8 @@ void BatterySimulator::Run()
 	float vbatt = math::gradual(_battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 	vbatt *= _battery.cell_count();
 
-	_battery.updateBatteryStatus(now_us, vbatt, ibatt, true);
+	_battery.setConnected(true);
+	_battery.updateBatteryStatus(now_us, vbatt, ibatt);
 
 	perf_end(_loop_perf);
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
The battery class was originally only used for ADC, the interface with all the parameters stayed and now it's used in all kinds of drivers that benefit from the calculations it offers but want to publish additional information in the `battery_status`. I want to improve it and as a first step I want to get the interface flexible compared to every driver calling the update with all parameters filled with dummy data and copying over functions to be able to run them without publishing data directly.

**Describe your solution**
In this pull request I concentrated on pure refactoring to not break anything. I split up the parameters into constructor and setter passing and separated the update from publishing.

**Test data / coverage**
Not yet tested. I plan to do simulation testing, INA226 and ADC.