### PR TITLE
mixer_module: typo con(s)tructor

### DIFF
--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -103,7 +103,7 @@ public:
 	};
 
 	/**
-	 * Contructor
+	 * Constructor
 	 * @param param_prefix for min/max/etc. params, e.g. "PWM_MAIN". This needs to match 'param_prefix' in the module.yaml
 	 * @param max_num_outputs maximum number of supported outputs
 	 * @param interface Parent module for scheduling, parameter updates and callbacks


### PR DESCRIPTION
**Describe problem solved by this pull request**
Small typo I found by accident