### PR TITLE
commander: cleanup mavlink system present and validity checks

### DIFF
--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -37,25 +37,38 @@ float32 rx_message_lost_rate
 
 uint64 HEARTBEAT_TIMEOUT_US = 1500000       # Heartbeat timeout 1.5 seconds
 
-# Heartbeats per type
-bool heartbeat_type_antenna_tracker         # MAV_TYPE_ANTENNA_TRACKER
-bool heartbeat_type_gcs                     # MAV_TYPE_GCS
-bool heartbeat_type_onboard_controller      # MAV_TYPE_ONBOARD_CONTROLLER
-bool heartbeat_type_gimbal                  # MAV_TYPE_GIMBAL
-bool heartbeat_type_adsb                    # MAV_TYPE_ADSB
-bool heartbeat_type_camera                  # MAV_TYPE_CAMERA
-bool heartbeat_type_parachute               # MAV_TYPE_PARACHUTE
+# Heartbeats
+bool heartbeat_adsb               # MAV_TYPE_ADSB
+bool heartbeat_antenna_tracker    # MAV_TYPE_ANTENNA_TRACKER
+bool heartbeat_battery            # MAV_TYPE_BATTERY
+bool heartbeat_camera             # MAV_TYPE_CAMERA
+bool heartbeat_gcs                # MAV_TYPE_GCS
+bool heartbeat_gimbal             # MAV_TYPE_GIMBAL
+bool heartbeat_log                # MAV_COMP_ID_LOG
+bool heartbeat_obstacle_avoidance # MAV_COMP_ID_OBSTACLE_AVOIDANCE
+bool heartbeat_onboard_controller # MAV_TYPE_ONBOARD_CONTROLLER
+bool heartbeat_osd                # MAV_COMP_ID_OSD
+bool heartbeat_pairing_manager    # MAV_COMP_ID_PAIRING_MANAGER
+bool heartbeat_parachute          # MAV_TYPE_PARACHUTE
+bool heartbeat_telemetry_radio    # MAV_COMP_ID_TELEMETRY_RADIO
+bool heartbeat_uart_bridge        # MAV_COMP_ID_UART_BRIDGE
+bool heartbeat_udp_bridge         # MAV_COMP_ID_UDP_BRIDGE
+bool heartbeat_vio                # MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY
 
-# Heartbeats per component
-bool heartbeat_component_telemetry_radio    # MAV_COMP_ID_TELEMETRY_RADIO
-bool heartbeat_component_log                # MAV_COMP_ID_LOG
-bool heartbeat_component_osd                # MAV_COMP_ID_OSD
-bool heartbeat_component_obstacle_avoidance # MAV_COMP_ID_OBSTACLE_AVOIDANCE
-bool heartbeat_component_vio                # MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY
-bool heartbeat_component_pairing_manager    # MAV_COMP_ID_PAIRING_MANAGER
-bool heartbeat_component_udp_bridge         # MAV_COMP_ID_UDP_BRIDGE
-bool heartbeat_component_uart_bridge        # MAV_COMP_ID_UART_BRIDGE
-
-# Misc component health
-bool avoidance_system_healthy
-bool parachute_system_healthy
+# system status healthy
+bool system_healthy_adsb
+bool system_healthy_antenna_tracker
+bool system_healthy_battery
+bool system_healthy_camera
+bool system_healthy_gcs
+bool system_healthy_gimbal
+bool system_healthy_log
+bool system_healthy_obstacle_avoidance
+bool system_healthy_onboard_controller
+bool system_healthy_osd
+bool system_healthy_pairing_manager
+bool system_healthy_parachute
+bool system_healthy_telemetry_radio
+bool system_healthy_uart_bridge
+bool system_healthy_udp_bridge
+bool system_healthy_vio

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -36,8 +36,16 @@ bool vtol_transition_failure                        # Set to true if vtol transi
 bool usb_connected                                # status of the USB power supply
 bool sd_card_detected_once                        # set to true if the SD card was detected
 
-bool avoidance_system_required					  # Set to true if avoidance system is enabled via COM_OBS_AVOID parameter
-bool avoidance_system_valid                       # Status of the obstacle avoidance system
+bool system_required_obstacle_avoidance					  # Set to true if avoidance system is enabled via COM_OBS_AVOID parameter
 
-bool parachute_system_present
-bool parachute_system_healthy
+bool system_present_gcs
+bool system_present_gimbal
+bool system_present_obstacle_avoidance
+bool system_present_onboard_controller
+bool system_present_parachute
+
+bool system_valid_gcs
+bool system_valid_gimbal
+bool system_valid_obstacle_avoidance
+bool system_valid_onboard_controller
+bool system_valid_parachute

--- a/src/modules/commander/Arming/PreFlightCheck/checks/parachuteCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/parachuteCheck.cpp
@@ -48,14 +48,14 @@ bool PreFlightCheck::parachuteCheck(orb_advert_t *mavlink_log_pub, const bool re
 	const bool parachute_required = param_com_parachute != 0;
 
 	if (parachute_required) {
-		if (!status_flags.parachute_system_present) {
+		if (!status_flags.system_present_parachute) {
 			success = false;
 
 			if (report_fail) {
 				mavlink_log_critical(mavlink_log_pub, "Fail: Parachute system missing");
 			}
 
-		} else if (!status_flags.parachute_system_healthy) {
+		} else if (!status_flags.system_valid_parachute) {
 			success = false;
 
 			if (report_fail) {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -123,7 +123,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		prearm_ok = false;
 	}
 
-	if (status_flags.avoidance_system_required && !status_flags.avoidance_system_valid) {
+	if (status_flags.system_required_obstacle_avoidance && !status_flags.system_valid_obstacle_avoidance) {
 		if (prearm_ok) {
 			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Avoidance system not ready"); }
 		}

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -327,12 +327,10 @@ private:
 
 
 	hrt_abstime	_datalink_last_heartbeat_gcs{0};
-	hrt_abstime	_datalink_last_heartbeat_avoidance_system{0};
+	hrt_abstime	_datalink_last_heartbeat_gimbal{0};
+	hrt_abstime	_datalink_last_heartbeat_obstacle_avoidance_system{0};
 	hrt_abstime	_datalink_last_heartbeat_onboard_controller{0};
 	hrt_abstime	_datalink_last_heartbeat_parachute_system{0};
-	bool		_onboard_controller_lost{false};
-	bool		_avoidance_system_lost{false};
-	bool		_parachute_system_lost{true};
 
 	hrt_abstime	_high_latency_datalink_heartbeat{0};
 	hrt_abstime	_high_latency_datalink_lost{0};

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2829,7 +2829,7 @@ Mavlink::display_status()
 	_receiver.enable_message_statistics();
 #endif // !CONSTRAINED_FLASH
 
-	if (_tstatus.heartbeat_type_gcs) {
+	if (_tstatus.heartbeat_gcs) {
 		printf("\tGCS heartbeat valid\n");
 	}
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -281,7 +281,7 @@ public:
 
 	bool			get_forwarding_on() { return _forwarding_on; }
 
-	bool			is_connected() { return _tstatus.heartbeat_type_gcs; }
+	bool			is_connected() { return _tstatus.heartbeat_gcs; }
 
 #if defined(MAVLINK_UDP)
 	static Mavlink 		*get_instance_for_network_port(unsigned long port);

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -206,7 +206,7 @@ private:
 #endif // !CONSTRAINED_FLASH
 	void handle_message_request_event(mavlink_message_t *msg);
 
-	void CheckHeartbeats(const hrt_abstime &t, bool force = false);
+	void CheckHeartbeats(const hrt_abstime &t);
 
 	/**
 	 * Set the interval at which the given message stream is published.
@@ -373,22 +373,22 @@ private:
 
 	hrt_abstime _last_heartbeat_check{0};
 
-	hrt_abstime _heartbeat_type_antenna_tracker{0};
-	hrt_abstime _heartbeat_type_gcs{0};
-	hrt_abstime _heartbeat_type_onboard_controller{0};
-	hrt_abstime _heartbeat_type_gimbal{0};
-	hrt_abstime _heartbeat_type_adsb{0};
-	hrt_abstime _heartbeat_type_camera{0};
-	hrt_abstime _heartbeat_type_parachute{0};
-
-	hrt_abstime _heartbeat_component_telemetry_radio{0};
-	hrt_abstime _heartbeat_component_log{0};
-	hrt_abstime _heartbeat_component_osd{0};
-	hrt_abstime _heartbeat_component_obstacle_avoidance{0};
-	hrt_abstime _heartbeat_component_visual_inertial_odometry{0};
-	hrt_abstime _heartbeat_component_pairing_manager{0};
-	hrt_abstime _heartbeat_component_udp_bridge{0};
-	hrt_abstime _heartbeat_component_uart_bridge{0};
+	hrt_abstime _heartbeat_adsb{0};
+	hrt_abstime _heartbeat_antenna_tracker{0};
+	hrt_abstime _heartbeat_battery{0};
+	hrt_abstime _heartbeat_camera{0};
+	hrt_abstime _heartbeat_gcs{0};
+	hrt_abstime _heartbeat_gimbal{0};
+	hrt_abstime _heartbeat_log{0};
+	hrt_abstime _heartbeat_obstacle_avoidance{0};
+	hrt_abstime _heartbeat_onboard_controller{0};
+	hrt_abstime _heartbeat_osd{0};
+	hrt_abstime _heartbeat_pairing_manager{0};
+	hrt_abstime _heartbeat_parachute{0};
+	hrt_abstime _heartbeat_telemetry_radio{0};
+	hrt_abstime _heartbeat_uart_bridge{0};
+	hrt_abstime _heartbeat_udp_bridge{0};
+	hrt_abstime _heartbeat_visual_inertial_odometry{0};
 
 	param_t _handle_sens_flow_maxhgt{PARAM_INVALID};
 	param_t _handle_sens_flow_maxr{PARAM_INVALID};


### PR DESCRIPTION
 - try to handle mavlink system validity and present checks more consistently
 - telemetry_status unify heartbeats and healthy flags across MAV_TYPE and MAV_COMPONENT (once it's outside of mavlink we don't care about the difference)
 - add gimbal

There's quite a lot of manual duplication here, it would be great to make this a bit more generic (as @MaEtUgR mentioned previously).
