### PR TITLE
boards: board_app_initialize() don't return early on failure

### DIFF
--- a/boards/airmind/mindpx-v2/src/init.c
+++ b/boards/airmind/mindpx-v2/src/init.c
@@ -239,7 +239,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi4) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 4\n");
 		board_autoled_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI4 to 10MHz and de-assert the known chip selects. */
@@ -255,7 +254,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 1\n");
 		board_autoled_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI1 to 37.5 MHz (40 MHz rounded to nearest valid divider, F4 max)
@@ -279,9 +277,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio = sdio_initialize(CONFIG_NSH_MMCSDSLOTNO);
 
 	if (!sdio) {
-		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n",
-		       CONFIG_NSH_MMCSDSLOTNO);
-		return -ENODEV;
+		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
 	}
 
 	/* Now bind the SDIO interface to the MMC/SD driver */
@@ -289,7 +285,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
-		return ret;
 	}
 
 	/* Then let's guess and say that there is a card in the slot. There is no card detect GPIO. */

--- a/boards/ark/can-flow/src/init.c
+++ b/boards/ark/can-flow/src/init.c
@@ -146,7 +146,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
-		return -ENODEV;
 	}
 
 #endif // FLASH_BASED_PARAMS

--- a/boards/ark/can-gps/src/init.c
+++ b/boards/ark/can-gps/src/init.c
@@ -151,7 +151,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
-		return -ENODEV;
 	}
 
 #endif // FLASH_BASED_PARAMS

--- a/boards/ark/can-rtk-gps/src/init.c
+++ b/boards/ark/can-rtk-gps/src/init.c
@@ -157,7 +157,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
-		return -ENODEV;
 	}
 
 #endif // FLASH_BASED_PARAMS

--- a/boards/atl/mantis-edu/src/init.c
+++ b/boards/atl/mantis-edu/src/init.c
@@ -240,7 +240,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/av/x-v1/src/init.c
+++ b/boards/av/x-v1/src/init.c
@@ -175,7 +175,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		syslog(LOG_ERR, "[boot] SDIO init failed\n");
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/bitcraze/crazyflie/src/init.c
+++ b/boards/bitcraze/crazyflie/src/init.c
@@ -150,12 +150,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	}
 
 #ifdef CONFIG_SPI
-	int ret = stm32_spi_bus_initialize();
-
-	if (ret != OK) {
-		return ret;
-	}
-
+	stm32_spi_bus_initialize();
 #endif
 
 	/* Configure the HW based on the manifest */

--- a/boards/bitcraze/crazyflie21/src/init.c
+++ b/boards/bitcraze/crazyflie21/src/init.c
@@ -150,12 +150,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	}
 
 #ifdef CONFIG_SPI
-	int ret = stm32_spi_bus_initialize();
-
-	if (ret != OK) {
-		return ret;
-	}
-
+	stm32_spi_bus_initialize();
 #endif
 
 	return OK;

--- a/boards/cuav/can-gps-v1/src/init.c
+++ b/boards/cuav/can-gps-v1/src/init.c
@@ -145,7 +145,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
-		return -ENODEV;
 	}
 
 #endif // FLASH_BASED_PARAMS

--- a/boards/cuav/nora/src/init.c
+++ b/boards/cuav/nora/src/init.c
@@ -201,12 +201,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/cuav/x7pro/src/init.c
+++ b/boards/cuav/x7pro/src/init.c
@@ -201,12 +201,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/cubepilot/cubeorange/src/init.c
+++ b/boards/cubepilot/cubeorange/src/init.c
@@ -181,12 +181,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/cubepilot/cubeyellow/src/init.c
+++ b/boards/cubepilot/cubeyellow/src/init.c
@@ -185,12 +185,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/freefly/can-rtk-gps/src/init.c
+++ b/boards/freefly/can-rtk-gps/src/init.c
@@ -138,7 +138,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
-		return -ENODEV;
 	}
 
 #endif // FLASH_BASED_PARAMS

--- a/boards/holybro/can-gps-v1/src/init.c
+++ b/boards/holybro/can-gps-v1/src/init.c
@@ -162,7 +162,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
-		return -ENODEV;
 	}
 
 #endif // FLASH_BASED_PARAMS

--- a/boards/holybro/durandal-v1/src/init.c
+++ b/boards/holybro/durandal-v1/src/init.c
@@ -264,7 +264,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/holybro/kakutef7/src/init.c
+++ b/boards/holybro/kakutef7/src/init.c
@@ -222,7 +222,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi_dev) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", CONFIG_NSH_MMCSDSPIPORTNO);
 		led_on(LED_BLUE);
-		return -ENODEV;
 	}
 
 	/* Now bind the SPI interface to the MMCSD driver */
@@ -231,7 +230,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (result != OK) {
 		led_on(LED_BLUE);
 		syslog(LOG_ERR, "[boot] FAILED to bind SPI port 1 to the MMCSD driver\n");
-		return -ENODEV;
 	}
 
 	up_udelay(20);
@@ -250,7 +248,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 #endif

--- a/boards/holybro/pix32v5/src/init.c
+++ b/boards/holybro/pix32v5/src/init.c
@@ -272,7 +272,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/matek/h743-slim/src/init.c
+++ b/boards/matek/h743-slim/src/init.c
@@ -170,7 +170,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_BLUE);
-		return ret;
 	}
 
 #endif

--- a/boards/modalai/fc-v1/src/init.c
+++ b/boards/modalai/fc-v1/src/init.c
@@ -277,7 +277,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/modalai/fc-v2/src/init.c
+++ b/boards/modalai/fc-v2/src/init.c
@@ -252,7 +252,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/mro/ctrl-zero-f7-oem/src/init.c
+++ b/boards/mro/ctrl-zero-f7-oem/src/init.c
@@ -226,7 +226,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/mro/ctrl-zero-f7/src/init.c
+++ b/boards/mro/ctrl-zero-f7/src/init.c
@@ -226,7 +226,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/mro/ctrl-zero-h7-oem/src/init.c
+++ b/boards/mro/ctrl-zero-h7-oem/src/init.c
@@ -186,12 +186,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/mro/ctrl-zero-h7/src/init.c
+++ b/boards/mro/ctrl-zero-h7/src/init.c
@@ -186,12 +186,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/mro/pixracerpro/src/init.c
+++ b/boards/mro/pixracerpro/src/init.c
@@ -185,12 +185,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio_dev) {
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", 0);
-		return ERROR;
 	}
 
 	if (mmcsd_slotinitialize(0, sdio_dev) != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver\n");
-		return ERROR;
 	}
 
 	/* Assume that the SD card is inserted.  What choice do we have? */

--- a/boards/mro/x21-777/src/init.c
+++ b/boards/mro/x21-777/src/init.c
@@ -213,7 +213,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/mro/x21/src/init.c
+++ b/boards/mro/x21/src/init.c
@@ -262,7 +262,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 1\n");
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
@@ -278,7 +277,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 2\n");
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI2 to 37.5 MHz (40 MHz rounded to nearest valid divider, F4 max)
@@ -293,14 +291,11 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #ifdef CONFIG_MMCSD
 	/* First, get an instance of the SDIO interface */
-
 	sdio = sdio_initialize(CONFIG_NSH_MMCSDSLOTNO);
 
 	if (!sdio) {
-		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n",
-		       CONFIG_NSH_MMCSDSLOTNO);
+		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Now bind the SDIO interface to the MMC/SD driver */
@@ -309,7 +304,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (ret != OK) {
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
 		led_on(LED_AMBER);
-		return ret;
 	}
 
 	/* Then let's guess and say that there is a card in the slot. There is no card detect GPIO. */
@@ -318,7 +312,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 #endif
 
 	/* Configure the HW based on the manifest */
-
 	px4_platform_configure();
 
 	return OK;

--- a/boards/nxp/fmuk66-e/src/init.c
+++ b/boards/nxp/fmuk66-e/src/init.c
@@ -270,7 +270,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		board_autoled_on(LED_RED);
-		return ret;
 	}
 
 #ifdef HAVE_AUTOMOUNTER
@@ -286,7 +285,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		board_autoled_on(LED_RED);
-		return ret;
 	}
 
 #endif

--- a/boards/nxp/fmuk66-v3/src/init.c
+++ b/boards/nxp/fmuk66-v3/src/init.c
@@ -270,7 +270,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		board_autoled_on(LED_RED);
-		return ret;
 	}
 
 #ifdef HAVE_AUTOMOUNTER
@@ -286,7 +285,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		board_autoled_on(LED_RED);
-		return ret;
 	}
 
 #endif

--- a/boards/nxp/fmurt1062-v1/src/init.c
+++ b/boards/nxp/fmurt1062-v1/src/init.c
@@ -295,7 +295,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif
@@ -306,7 +305,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 	/* Configure the HW based on the manifest */

--- a/boards/omnibus/f4sd/src/init.c
+++ b/boards/omnibus/f4sd/src/init.c
@@ -267,7 +267,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 1\n");
 		led_on(LED_BLUE);
-		return -ENODEV;
 	}
 
 	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
@@ -283,7 +282,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", CONFIG_NSH_MMCSDSPIPORTNO);
 		led_on(LED_BLUE);
-		return -ENODEV;
 	}
 
 	/* Now bind the SPI interface to the MMCSD driver */
@@ -292,7 +290,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (result != OK) {
 		led_on(LED_BLUE);
 		syslog(LOG_ERR, "[boot] FAILED to bind SPI port 2 to the MMCSD driver\n");
-		return -ENODEV;
 	}
 
 	up_udelay(20);
@@ -304,7 +301,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi3) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 3\n");
 		led_on(LED_BLUE);
-		return -ENODEV;
 	}
 
 	/* Copied from fmu-v4
@@ -330,7 +326,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 #endif

--- a/boards/px4/fmu-v2/src/init.c
+++ b/boards/px4/fmu-v2/src/init.c
@@ -453,7 +453,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 1);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
@@ -469,7 +468,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 2);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI2 to 37.5 MHz (40 MHz rounded to nearest valid divider, F4 max)
@@ -485,7 +483,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi4) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 4);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI4 to 1MHz and de-assert the known chip selects. */
@@ -501,7 +498,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!sdio) {
 		led_on(LED_AMBER);
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
-		return -ENODEV;
 	}
 
 	/* Now bind the SDIO interface to the MMC/SD driver */
@@ -510,7 +506,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (ret != OK) {
 		led_on(LED_AMBER);
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
-		return ret;
 	}
 
 	/* Then let's guess and say that there is a card in the slot. There is no card detect GPIO. */

--- a/boards/px4/fmu-v3/src/init.c
+++ b/boards/px4/fmu-v3/src/init.c
@@ -453,7 +453,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 1);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
@@ -469,7 +468,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 2);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI2 to 37.5 MHz (40 MHz rounded to nearest valid divider, F4 max)
@@ -485,7 +483,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi4) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 4);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 	/* Default SPI4 to 1MHz and de-assert the known chip selects. */
@@ -501,7 +498,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!sdio) {
 		led_on(LED_AMBER);
 		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
-		return -ENODEV;
 	}
 
 	/* Now bind the SDIO interface to the MMC/SD driver */
@@ -510,7 +506,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (ret != OK) {
 		led_on(LED_AMBER);
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
-		return ret;
 	}
 
 	/* Then let's guess and say that there is a card in the slot. There is no card detect GPIO. */
@@ -519,7 +514,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 #endif
 
 	/* Configure the HW based on the manifest */
-
 	px4_platform_configure();
 
 	return OK;

--- a/boards/px4/fmu-v4/src/init.c
+++ b/boards/px4/fmu-v4/src/init.c
@@ -292,7 +292,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 1\n");
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 
@@ -308,7 +307,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 2\n");
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 	/**
@@ -350,9 +348,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio) {
 		led_on(LED_RED);
-		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n",
-		       CONFIG_NSH_MMCSDSLOTNO);
-		return -ENODEV;
+		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
 	}
 
 	// Now bind the SDIO interface to the MMC/SD driver.
@@ -361,7 +357,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (ret != OK) {
 		led_on(LED_RED);
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
-		return ret;
 	}
 
 	// Then let's guess and say that there is a card in the slot. There is no card detect GPIO.

--- a/boards/px4/fmu-v4pro/src/init.c
+++ b/boards/px4/fmu-v4pro/src/init.c
@@ -311,7 +311,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 1);
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
@@ -327,7 +326,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 2);
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 	/* Default SPI2 to 12MHz and de-assert the known chip selects.
@@ -345,7 +343,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi5) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 5);
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 	/* Default SPI5 to 1MHz and de-assert the known chip selects. */
@@ -360,7 +357,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi6) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", 6);
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 	/* Default SPI6 to 1MHz and de-assert the known chip selects. */
@@ -375,9 +371,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio) {
 		led_on(LED_RED);
-		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n",
-		       CONFIG_NSH_MMCSDSLOTNO);
-		return -ENODEV;
+		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
 	}
 
 	/* Now bind the SDIO interface to the MMC/SD driver */
@@ -386,7 +380,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (ret != OK) {
 		led_on(LED_RED);
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
-		return ret;
 	}
 
 	/* Then let's guess and say that there is a card in the slot. There is no card detect GPIO. */

--- a/boards/px4/fmu-v5/src/init.c
+++ b/boards/px4/fmu-v5/src/init.c
@@ -275,7 +275,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/px4/fmu-v6u/src/init.c
+++ b/boards/px4/fmu-v6u/src/init.c
@@ -266,7 +266,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/px4/fmu-v6x/src/init.c
+++ b/boards/px4/fmu-v6x/src/init.c
@@ -268,7 +268,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif /* CONFIG_MMCSD */

--- a/boards/raspberrypi/pico/src/init.c
+++ b/boards/raspberrypi/pico/src/init.c
@@ -345,7 +345,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	// if (!spi1) {
 	// 	syslog(LOG_ERR, "[boot] FAILED to initialize SPI port %d\n", CONFIG_NSH_MMCSDSPIPORTNO);
 	// 	led_off(LED_BLUE);
-	// 	return -ENODEV;
 	// }
 
 	// /* Now bind the SPI interface to the MMCSD driver */
@@ -354,7 +353,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	// if (result != OK) {
 	// 	led_off(LED_BLUE);
 	// 	syslog(LOG_ERR, "[boot] FAILED to bind SPI port 1 to the MMCSD driver\n");
-	// 	return -ENODEV;
 	// }
 
 	// up_udelay(20);
@@ -365,7 +363,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 2\n");
 		led_off(LED_BLUE);
-		return -ENODEV;
 	}
 
 	/* Default SPI2 to 1MHz and de-assert the known chip selects. */
@@ -386,7 +383,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 // 	if (result != OK) {
 // 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
 // 		led_off(LED_AMBER);
-// 		return -ENODEV;
 // 	}
 
 // #endif

--- a/boards/spracing/h7extreme/src/init.c
+++ b/boards/spracing/h7extreme/src/init.c
@@ -225,7 +225,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (ret != OK) {
 		led_on(LED_RED);
-		return ret;
 	}
 
 #endif
@@ -273,7 +272,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (result != OK) {
 		syslog(LOG_ERR, "[boot] FAILED to init params in FLASH %d\n", result);
 		led_on(LED_AMBER);
-		return -ENODEV;
 	}
 
 #endif

--- a/boards/uvify/core/src/init.c
+++ b/boards/uvify/core/src/init.c
@@ -292,7 +292,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi1) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 1\n");
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 
@@ -308,7 +307,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (!spi2) {
 		syslog(LOG_ERR, "[boot] FAILED to initialize SPI port 2\n");
 		led_on(LED_RED);
-		return -ENODEV;
 	}
 
 	/**
@@ -350,9 +348,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (!sdio) {
 		led_on(LED_RED);
-		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n",
-		       CONFIG_NSH_MMCSDSLOTNO);
-		return -ENODEV;
+		syslog(LOG_ERR, "[boot] Failed to initialize SDIO slot %d\n", CONFIG_NSH_MMCSDSLOTNO);
 	}
 
 	// Now bind the SDIO interface to the MMC/SD driver.
@@ -361,7 +357,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	if (ret != OK) {
 		led_on(LED_RED);
 		syslog(LOG_ERR, "[boot] Failed to bind SDIO to the MMC/SD driver: %d\n", ret);
-		return ret;
 	}
 
 	// Then let's guess and say that there is a card in the slot. There is no card detect GPIO.


### PR DESCRIPTION
 - depending on the situation we're more likely to get actionable user feedback by allowing boot to complete rather than silently failing with the system in a crippled state
