### PR TITLE
ms5611: lower SPI clock 20 MHz -> 16 MHz

### DIFF
--- a/src/drivers/barometer/ms5611/CMakeLists.txt
+++ b/src/drivers/barometer/ms5611/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MODULE drivers__barometer__ms5611
 	MAIN ms5611
 	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		ms5611_spi.cpp
 		ms5611_i2c.cpp

--- a/src/drivers/barometer/ms5611/ms5611_main.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_main.cpp
@@ -107,7 +107,7 @@ extern "C" int ms5611_main(int argc, char *argv[])
 #else
 	BusCLIArguments cli {false, true};
 #endif
-	cli.default_spi_frequency = 20 * 1000 * 1000;
+	cli.default_spi_frequency = 16 * 1000 * 1000;
 	uint16_t dev_type_driver = DRV_BARO_DEVTYPE_MS5611;
 
 	while ((ch = cli.getOpt(argc, argv, "T:")) != EOF) {

--- a/src/drivers/barometer/ms5611/ms5611_spi.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_spi.cpp
@@ -115,27 +115,32 @@ MS5611_SPI::init()
 
 	if (ret != OK) {
 		PX4_DEBUG("SPI init failed");
-		goto out;
+		return PX4_ERROR;
 	}
 
-	/* send reset command */
-	ret = _reset();
+	// reset and read PROM (try up to 3 times)
+	for (int i = 0; i < 3; i++) {
+		/* send reset command */
+		ret = _reset();
 
-	if (ret != OK) {
-		PX4_DEBUG("reset failed");
-		goto out;
+		if (ret != OK) {
+			PX4_DEBUG("reset failed");
+			continue;
+		}
+
+		/* read PROM */
+		ret = _read_prom();
+
+		if (ret == OK) {
+			return PX4_OK;
+
+		} else {
+			PX4_DEBUG("prom readout failed");
+			continue;
+		}
 	}
 
-	/* read PROM */
-	ret = _read_prom();
-
-	if (ret != OK) {
-		PX4_DEBUG("prom readout failed");
-		goto out;
-	}
-
-out:
-	return ret;
+	return PX4_ERROR;
 }
 
 int


### PR DESCRIPTION
 - this was necessary to get the secondary ms5611 working reliably on a particular CubeOrange
 - the sensor is transferring very little data, so lowering the speed by default everywhere is harmless

On a particular CubeOrange the ms5611 PROM crc was invalid. After lowering the clock rate slightly the crc was valid, but upon closer inspection the only actual change was at the beginning in the manufacturer reserved portion.
![Screenshot from 2021-12-05 16-16-53](https://user-images.githubusercontent.com/84712/144764259-6db01148-eb55-4b73-b86e-dfdd034b020e.png)


#### before
``` Console
ms5611 on SPI bus 4 at 61 (20000 KHz)
DEBUG 1006413    prom[0]=0x8000
DEBUG 1006460    prom[1]=0xb7bd
DEBUG 1006505    prom[2]=0xba8c
DEBUG 1006549    prom[3]=0x7685
DEBUG 1006593    prom[4]=0x6c88
DEBUG 1006639    prom[5]=0x8876
DEBUG 1006683    prom[6]=0x7340
DEBUG 1006727    prom[7]=0x8
INFO  [ms5611] crc read: 8, crc: 0 (0)
```

#### after
``` Console
ms5611 on SPI bus 4 at 61 (16000 KHz)
DEBUG 905428     prom[0]=0x0           <--- ONLY DIFFERENCE
DEBUG 905475     prom[1]=0xb7bd
DEBUG 905521     prom[2]=0xba8c
DEBUG 905567     prom[3]=0x7685
DEBUG 905612     prom[4]=0x6c88
DEBUG 905660     prom[5]=0x8876
DEBUG 905706     prom[6]=0x7340
DEBUG 905752     prom[7]=0x8
INFO  [ms5611] crc read: 8, crc: 8 (8)
```