### PR TITLE
Add brushless RPM sensor driver

### DIFF
--- a/msg/rpm.msg
+++ b/msg/rpm.msg
@@ -1,4 +1,4 @@
 uint64 timestamp                      # time since system start (microseconds)
 
 float32 indicated_frequency_rpm       # indicated rotor Frequency in Revolution per minute
-float32 estimated_accurancy_rpm       # estimated accurancy in Revolution per minute
+float32 estimated_accurancy_rpm       # estimated accurancy in Revolution per minute (-1 indicates no accuracy information)

--- a/src/drivers/rpm/CMakeLists.txt
+++ b/src/drivers/rpm/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(pcf8583)
+add_subdirectory(brushless_rpm_sensor)

--- a/src/drivers/rpm/brushless_rpm_sensor/CMakeLists.txt
+++ b/src/drivers/rpm/brushless_rpm_sensor/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015-2019 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2015-2021 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,5 +39,6 @@ px4_add_module(
 		brushless_rpm_main.cpp
 		brushless_rpm.cpp
 	DEPENDS
+		drivers__pwm_input
 		px4_work_queue
 )

--- a/src/drivers/rpm/brushless_rpm_sensor/CMakeLists.txt
+++ b/src/drivers/rpm/brushless_rpm_sensor/CMakeLists.txt
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2015-2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE drivers__brushless_rpm
+	MAIN brushless_rpm
+	COMPILE_FLAGS
+		-Wno-cast-align # TODO: fix and enable
+	SRCS
+		brushless_rpm_main.cpp
+		brushless_rpm.cpp
+	DEPENDS
+		px4_work_queue
+)

--- a/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.cpp
+++ b/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.cpp
@@ -1,0 +1,148 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2014-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file BrushlessRPMPWM.cpp
+ * @author Jerry Mailloux <jerry@envgo.com>
+ *
+ * Driver for the brushless RPM sensor - attaches to 2 motor phase wires.
+ * (Specific one is ose-83279-011. "Brushless RPM sensor for RCMv2 Telemetry System")
+ *
+ * This driver accesses the pwm_input published by the pwm_input driver.
+ */
+#include <math.h>
+#include <px4_arch/io_timer.h>
+#include "brushless_rpm.hpp"
+
+
+BrushlessRPMPWM::BrushlessRPMPWM() :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
+{
+	// figure out the measure interval based on the minimum RPM that can be read, and the
+	// number of pole pairs. Add 5ms to account for any latency.  Don't measure
+	// any faster than 50ms.
+	_measure_interval = (uint32_t)math::max((60000000.0/(_param_rpm_pole_pairs.get()*BRUSHLESS_RPM_MIN_RPM))+5000, 50000.0);
+}
+
+BrushlessRPMPWM::~BrushlessRPMPWM()
+{
+	stop();
+	perf_free(_sample_perf);
+}
+
+int
+BrushlessRPMPWM::init()
+{
+	start();
+
+	return PX4_OK;
+}
+
+void
+BrushlessRPMPWM::start()
+{
+	ScheduleOnInterval(get_measure_interval());
+}
+
+void
+BrushlessRPMPWM::stop()
+{
+	ScheduleClear();
+}
+
+void
+BrushlessRPMPWM::Run()
+{
+	measure();
+}
+
+int
+BrushlessRPMPWM::measure()
+{
+	perf_begin(_sample_perf);
+
+	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	uint32_t rpm;
+
+	if((collect() == PX4_OK) && (_pwm.period != 0)) {
+		// when the motor isn't turning, noise on the line causes spurious readings.
+		// Get a grouping consecutive non zero readings before starting to report RPM.
+		if(_consecutive_non_zero_readings++ > 5) {
+			rpm = (60 * 1000000) / _pwm.period / _param_rpm_pole_pairs.get();
+		} else {
+			rpm = 0;
+		}
+	} else {
+		// if we aren't getting readings from pwm_input because there are no transitions
+		// or pwm period is zero (which I don't think will happen, but we should guard against
+		// anyway), set RPM to zero.
+		rpm = 0;
+		_consecutive_non_zero_readings = 0;
+	}
+
+	// publish
+	rpm_s msg{};
+	msg.indicated_frequency_rpm = (float)rpm;
+
+	// there is no accuracy information coming from this sensor, so set accuracy to 1.
+	msg.estimated_accurancy_rpm = 1;
+	msg.timestamp = timestamp_sample;
+	_rpm_pub.publish(msg);
+
+	perf_end(_sample_perf);
+	return PX4_OK;
+}
+
+int
+BrushlessRPMPWM::collect()
+{
+	pwm_input_s pwm_input;
+
+	if (_sub_pwm_input.update(&pwm_input)) {
+
+		_pwm = pwm_input;
+
+		return PX4_OK;
+	}
+
+	return EAGAIN;
+}
+
+void
+BrushlessRPMPWM::print_info()
+{
+	perf_print_counter(_sample_perf);
+	printf("poll interval: %lu \n", get_measure_interval());
+}

--- a/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.cpp
+++ b/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.cpp
@@ -95,12 +95,15 @@ BrushlessRPMPWM::measure()
 
 	const hrt_abstime timestamp_sample = hrt_absolute_time();
 	uint32_t rpm;
+	pwm_input_s pwm_input;
 
-	if((collect() == PX4_OK) && (_pwm.period != 0)) {
+
+
+	if(_sub_pwm_input.update(&pwm_input) && (pwm_input.period != 0)) {
 		// when the motor isn't turning, noise on the line causes spurious readings.
 		// Get a grouping consecutive non zero readings before starting to report RPM.
 		if(_consecutive_non_zero_readings++ > 5) {
-			rpm = (60 * 1000000) / _pwm.period / _param_rpm_pole_pairs.get();
+			rpm = (60 * 1000000) / pwm_input.period / _param_rpm_pole_pairs.get();
 		} else {
 			rpm = 0;
 		}
@@ -123,21 +126,6 @@ BrushlessRPMPWM::measure()
 
 	perf_end(_sample_perf);
 	return PX4_OK;
-}
-
-int
-BrushlessRPMPWM::collect()
-{
-	pwm_input_s pwm_input;
-
-	if (_sub_pwm_input.update(&pwm_input)) {
-
-		_pwm = pwm_input;
-
-		return PX4_OK;
-	}
-
-	return EAGAIN;
 }
 
 void

--- a/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.cpp
+++ b/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.cpp
@@ -119,8 +119,9 @@ BrushlessRPMPWM::measure()
 	rpm_s msg{};
 	msg.indicated_frequency_rpm = (float)rpm;
 
-	// there is no accuracy information coming from this sensor, so set accuracy to 1.
-	msg.estimated_accurancy_rpm = 1;
+	// there is no accuracy information coming from this sensor, so set accuracy to -1
+	// for not set.
+	msg.estimated_accurancy_rpm = -1;
 	msg.timestamp = timestamp_sample;
 	_rpm_pub.publish(msg);
 

--- a/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.hpp
+++ b/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.hpp
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2014-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file brushless_rpm.hpp
+ * @author Jerry Mailloux <jerry@envgo.com>
+ *
+ * Driver for brushless RPM sensor.
+ *
+ * This driver accesses the pwm_input published by the pwm_input driver.
+ */
+#pragma once
+
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <px4_platform_common/module_params.h>
+#include <uORB/topics/pwm_input.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/rpm.h>
+#include <board_config.h>
+#include <drivers/device/device.h>
+#include <perf/perf_counter.h>
+
+using namespace time_literals;
+
+// Device limits
+static constexpr uint32_t BRUSHLESS_RPM_MIN_RPM{1000};
+static constexpr uint32_t BRUSHLESS_RPM_MAX_RPM{20000};
+
+class BrushlessRPMPWM : public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	BrushlessRPMPWM();
+	virtual ~BrushlessRPMPWM();
+
+	int init();
+	void start();
+	void stop();
+
+	void print_info();
+
+protected:
+
+	int collect();
+	int measure();
+
+	void Run() override;
+
+private:
+	uint32_t _consecutive_non_zero_readings {0};
+	uint32_t _measure_interval {50_ms};
+
+	uint32_t get_measure_interval() const { return _measure_interval; };
+
+
+	uORB::Subscription _sub_pwm_input{ORB_ID(pwm_input)};
+
+	pwm_input_s 	_pwm{};
+
+	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};
+
+	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, "brushless_rpm: read")};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::RPM_POLE_PAIRS>) _param_rpm_pole_pairs
+	)
+};

--- a/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.hpp
+++ b/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm.hpp
@@ -71,8 +71,6 @@ public:
 	void print_info();
 
 protected:
-
-	int collect();
 	int measure();
 
 	void Run() override;
@@ -85,8 +83,6 @@ private:
 
 
 	uORB::Subscription _sub_pwm_input{ORB_ID(pwm_input)};
-
-	pwm_input_s 	_pwm{};
 
 	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};
 

--- a/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm_main.cpp
+++ b/src/drivers/rpm/brushless_rpm_sensor/brushless_rpm_main.cpp
@@ -1,0 +1,180 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2014-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file brushless_rpm_main.cpp
+ * @author Jerry Mailloux <jerry@envgo.com>
+ *
+ * Interface for the brushless RPM sensor that outputs a PWM signal corresponding
+ * to spin rate in Hz.
+ */
+
+#include <cstdlib>
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <systemlib/err.h>
+
+#include <board_config.h>
+#include <px4_platform_common/getopt.h>
+#include <px4_platform_common/module.h>
+
+#include "brushless_rpm.hpp"
+
+/**
+ * @brief Local functions in support of the shell command.
+ */
+namespace brushless_rpm
+{
+
+BrushlessRPMPWM *instance = nullptr;
+
+/**
+ * Start the pwm driver.
+ *
+ * This function only returns if the sensor is up and running
+ * or could not be detected successfully.
+ */
+int
+start_rpm_sensor(void)
+{
+	if (instance != nullptr) {
+		PX4_ERR("already started");
+		return PX4_OK;
+	}
+
+	instance = new BrushlessRPMPWM();
+
+	if (instance == nullptr) {
+		PX4_ERR("Failed to instantiate the driver");
+		return PX4_ERROR;
+	}
+
+	// Initialize the sensor.
+	if (instance->init() != PX4_OK) {
+		PX4_ERR("Failed to initialize brushless RPM pwm.");
+		delete instance;
+		instance = nullptr;
+		return PX4_ERROR;
+	}
+
+	// Start the driver.
+	instance->start();
+
+	PX4_INFO("driver started");
+	return PX4_OK;
+}
+
+/**
+ * @brief Prints status info about the driver.
+ */
+int
+status()
+{
+	if (instance == nullptr) {
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
+	}
+
+	instance->print_info();
+	return PX4_OK;
+}
+
+/**
+ * @brief Stops the driver
+ */
+int
+stop()
+{
+	if (instance != nullptr) {
+		delete instance;
+		instance = nullptr;
+	}
+
+	return PX4_OK;
+}
+
+/**
+ * @brief Displays driver usage at the console.
+ */
+int
+usage()
+{
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+PWM driver for brushless RPM sensor.
+
+Setup/usage information: https://www.offshoreelectrics.com/proddetail.php?prod=ose-83279-011
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("brushless_rpm", "driver");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("start","Start driver");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("status","Print driver status information");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("stop","Stop driver");
+	return PX4_OK;
+}
+
+} // namespace brushless_rpm
+
+
+/**
+ * @brief Driver 'main' command.
+ */
+extern "C" __EXPORT int brushless_rpm_main(int argc, char *argv[])
+{
+	int myoptind = 1;
+
+	if (myoptind >= argc) {
+		return brushless_rpm::usage();
+	}
+
+	// Start the driver.
+	if (!strcmp(argv[myoptind], "start")) {
+		return brushless_rpm::start_rpm_sensor();
+	}
+
+	// Print the driver status.
+	if (!strcmp(argv[myoptind], "status")) {
+		return brushless_rpm::status();
+	}
+
+	// Stop the driver
+	if (!strcmp(argv[myoptind], "stop")) {
+		return brushless_rpm::stop();
+	}
+
+	// Print driver usage information.
+	return brushless_rpm::usage();
+}

--- a/src/drivers/rpm/brushless_rpm_sensor/parameters.c
+++ b/src/drivers/rpm/brushless_rpm_sensor/parameters.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Brushless RPM sensor - number of pole pairs
+ *
+ * @reboot_required true
+ * @group Sensors
+ * @min 1
+ */
+PARAM_DEFINE_INT32(RPM_POLE_PAIRS, 7);


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
See write up in https://github.com/PX4/PX4-Autopilot/issues/18732

**Describe your solution**
I use the pwm_input driver with the following hardware: https://www.offshoreelectrics.com/proddetail.php?prod=ose-83279-011.  The hardware outputs a frequency equal to the spin rate measured.  The pwm_input captures the period of this signal.  The brushless_rpm driver them converts this to RPM based on the number of pole pairs the motor has (parameter)

**Describe possible alternatives**
You can get motor controllers that output RPM.  This didn't work for us because we didn't want to be limited to certain motor controllers.  You can get other RPM sensors.  This one was nice because it simply connects to 2 of the motor phases.  It is also quite cheap, and we've found very accurate (I compared the driver output to that of an optical sensor).

**Test data / coverage**
I compared the output of the driver to that of an optical sensor.  They matched quite well.  We used this driver in the field on our airframe (a hydrofoiling boat).  We haven't uploaded logs.  But I've attached a screenshot of the output.

**Additional context**
Add any other related context or media
<img width="966" alt="Screen Shot 2021-12-06 at 3 57 50 PM" src="https://user-images.githubusercontent.com/6007135/144921487-365265b5-c25b-4bbf-81f5-17b5bb4b10dc.png">
.
