### PR TITLE
FlightTaskAuto: use MPC_VEL_MAX instead of MPC_XY_CRUISE for emergency braking thresholds

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -735,7 +735,7 @@ void FlightTaskAuto::_checkEmergencyBraking()
 							(factor * _param_mpc_z_vel_max_dn.get())
 							|| _position_smoothing.getCurrentVelocityZ() < -(factor * _param_mpc_z_vel_max_up.get());
 		const bool is_horizontal_speed_exceeded = _position_smoothing.getCurrentVelocityXY().longerThan(
-					factor * _param_mpc_xy_cruise.get());
+					factor * _param_mpc_xy_vel_max.get());
 
 		if (is_vertical_speed_exceeded || is_horizontal_speed_exceeded) {
 			_is_emergency_braking_active = true;


### PR DESCRIPTION

**Describe problem solved by this pull request**
The emergency braking logic prevents the vehicle from flying faster than 1.3*MPC_XY_CRUISE atm in auto modes (speed can be set through DO_CHANGE_SPEED mission items).

**Describe your solution**
Use MPC_XY_VEL_MAX instead of MPC_XY_CRUISE.

Did I miss anything, or was this unintentional?
