### PR TITLE
FW land detector: tighten thresholds in airspeed-less case

### DIFF
--- a/src/modules/land_detector/land_detector_params_fw.c
+++ b/src/modules/land_detector/land_detector_params_fw.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014-2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2021 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,9 +32,11 @@
  ****************************************************************************/
 
 /**
- * Fixedwing max horizontal velocity
+ * Fixed-wing land detector: Max horizontal velocity threshold
  *
- * Maximum horizontal velocity allowed in the landed state
+ * Maximum horizontal velocity allowed in the landed state.
+ * A factor of 0.7 is applied in case of airspeed-less flying
+ * (either because no sensor is present or sensor data got invalid in flight).
  *
  * @unit m/s
  * @min 0.5
@@ -46,9 +48,11 @@
 PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 5.0f);
 
 /**
- * Fixedwing max climb rate
+ * Fixed-wing land detector: Max vertiacal velocity threshold
  *
- * Maximum vertical velocity allowed in the landed state
+ * Maximum vertical velocity allowed in the landed state.
+ * A factor of 0.7 is applied in case of airspeed-less flying
+ * (either because no sensor is present or sensor data got invalid in flight).
  *
  * @unit m/s
  * @min 0.1
@@ -57,10 +61,10 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 5.0f);
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 3.0f);
+PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 2.0f);
 
 /**
- * Fixedwing max horizontal acceleration
+ * Fixed-wing land detector: Max horizontal acceleration
  *
  * Maximum horizontal (x,y body axes) acceleration allowed in the landed state
  *
@@ -74,12 +78,12 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 3.0f);
 PARAM_DEFINE_FLOAT(LNDFW_XYACC_MAX, 8.0f);
 
 /**
- * Airspeed max
+ * Fixed-wing land detector: Max airspeed
  *
  * Maximum airspeed allowed in the landed state
  *
  * @unit m/s
- * @min 4
+ * @min 2
  * @max 20
  * @decimal 1
  *


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/18799

**Describe problem solved by this pull request**
The fixed-wing land detector relies on airspeed, groundspeed and acceleration to detect landings. The groundspeed thresholds (separate for vertical and horizontal) are rather relaxed, and are thus possible to trigger false positive land detections in-air if the airspeed is invalid. 

**Describe your solution**
Tighten the thresholds in the airspeed-less case. I've so far added a 0.7 factor for horizontal and vertical speed limits, happy for other recommendations. 

**Describe possible alternatives**
Fuse the FW with the MC land detector? Not sure if that's worth it, given that land detection for FW should be much easier (at least if one has an airspeed sensor, what most vehicles have). The logic can thus be kept very minimal and intuitive, opposed to the MC case. 

**Test data / coverage**


**Additional context**
