### PR TITLE
fix incorrect L1 period param documentation

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -52,7 +52,7 @@
  * slowly during tuning until response is sharp without oscillation.
  *
  * @unit s
- * @min 12.0
+ * @min 7.0
  * @max 50.0
  * @decimal 1
  * @increment 0.5

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -46,12 +46,12 @@
 /**
  * L1 period
  *
- * This is the L1 distance and defines the tracking
- * point ahead of the aircraft its following.
- * A value of 18-25 meters works for most aircraft. Shorten
+ * Used to determine the L1 gain and controller time constant. This parameter is
+ * proportional to the L1 distance (which points ahead of the aircraft on the path
+ * it is following). A value of 18-25 seconds works for most aircraft. Shorten
  * slowly during tuning until response is sharp without oscillation.
  *
- * @unit m
+ * @unit s
  * @min 12.0
  * @max 50.0
  * @decimal 1


### PR DESCRIPTION
Minor bug - small PR.

I noticed while working on #18810 that the L1 period param has been incorrectly documented for some time now (wrong units -- should be seconds):
https://github.com/PX4/PX4-Autopilot/blob/08b0ac9654d0041a78c61025a4114a59b0045f4d/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c#L46-L61

It is correct in the L1 library:
https://github.com/PX4/PX4-Autopilot/blob/08b0ac9654d0041a78c61025a4114a59b0045f4d/src/lib/l1/ECL_L1_Pos_Controller.hpp#L220

I guess this is just left over documentation from when the L1 distance was still not dynamic with ground speed (some time ago) and this param was literally the L1 distance.

My suggested changes:
- documentation fix (correct units, etc)
- lower the minimum period and period recommendations to what an L1 distance at ground speed 15 m/s would translate to

^The latter point here open for debate if anyone has opinions (I didnt change the default).

Derivation of "5-10" seconds comes from the following equation:
```
l1_distance = ground_speed * damping * period /  pi
```
Solve for period with the previously suggested 18-25 meters (L1 distance) and you get 5-7s.

Will keep as draft until anyone else chimes in.