### PR TITLE
navigator: Fix WAYPOINT and LOITER commands for fixed-wing vehicle

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -393,13 +393,13 @@ MissionBlock::is_mission_item_reached()
 							  (_mission_item.force_heading || _mission_item.nav_cmd == NAV_CMD_WAYPOINT);
 
 			// can only enforce exit heading if next waypoint is not within loiter radius of current waypoint
-			const bool exit_heading_is_reachable = dist_current_next > 1.2f * curr_sp_new->loiter_radius;
+			const bool exit_heading_is_reachable = dist_current_next >= curr_sp_new->loiter_radius;
 
 			if (enforce_exit_heading && exit_heading_is_reachable) {
 
 				float yaw_err = 0.0f;
 
-				if (dist_current_next >  1.2f * _navigator->get_loiter_radius()) {
+				if (dist_current_next >= _navigator->get_loiter_radius()) {
 					// set required yaw from bearing to the next mission item
 					_mission_item.yaw = get_bearing_to_next_waypoint(_navigator->get_global_position()->lat,
 							    _navigator->get_global_position()->lon,

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -279,7 +279,8 @@ MissionBlock::is_mission_item_reached()
 
 			// We use the acceptance radius of the mission item if it has been set (not NAN)
 			// but only for multicopter.
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+			if ((_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+			    || _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)
 			    && PX4_ISFINITE(_mission_item.acceptance_radius) && _mission_item.acceptance_radius > FLT_EPSILON) {
 				acceptance_radius = _mission_item.acceptance_radius;
 			}


### PR DESCRIPTION
This fix allows precise following of path consisting of circular and straight segments only (Dubins path) for fixed-wing vehicle. Following fixes are provided:
- Acceptance radius for mission waypoints provided by  MAV_CMD_NAV_WAYPOINT commands is used even for fixed-wing vehicle
- Exit heading (from loitering) can be enforced whenever the next waypoint is not within loiter radius of current waypoint

**Why?**
Dubins path is one of the most common type of paths used in robotics and it consist simply of circular and straight segments. Therefore, a precise trajectory following can be achieved by PX4 by LOITER and WAYPOINT commands. The aircraft can simply loiter for a given time (0 s) while the exit heading is enforced. Then, aircraft follows straight segment to the next waypoint (entry point to circular segment) followed by another loiter command, see the schema.

To enforce the exit heading when loitering, next waypoint must be outside the loiter radius. Therefore, the next waypoint must be displaced outside the circular segment but if another circular segment follows, one does not want to visit the displaced waypoint exactly. Hence, a larger acceptance radius want to be used. This feature is now allowed only for rotary-wing vehicles (although it is not mentioned in PX4 documentation). 

**What?**
This PR allows using various acceptance radii for waypoints during mission. If it is not provided, the default acceptance radius is used.

Furthermore, the exit heading can be currently enforced only if the next waypoint is further than _1.2 * current loiter radius_. There is no need to extend that radius, and so this PR contains also a fix allowing exit heading enforcement whenever the next waypoint is not within the loiter radius.

Both changes has been tested in SILT with fixed-wing vehicle without issues allowing a precise trajectory following for Dubins path.
![image](https://user-images.githubusercontent.com/42158529/145193577-c2bcbe3a-e4a1-46d3-82a2-47b83f78db8c.png)
