### PR TITLE
Remove memory allocation ownership transfer

### DIFF
--- a/platforms/common/uORB/uORBDeviceMaster.cpp
+++ b/platforms/common/uORB/uORBDeviceMaster.cpp
@@ -99,19 +99,11 @@ int uORB::DeviceMaster::advertise(const struct orb_metadata *meta, bool is_adver
 			*instance = group_tries;
 		}
 
-		/* driver wants a permanent copy of the path, so make one here */
-		const char *devpath = strdup(nodepath);
-
-		if (devpath == nullptr) {
-			return -ENOMEM;
-		}
-
 		/* construct the new node, passing the ownership of path to it */
-		uORB::DeviceNode *node = new uORB::DeviceNode(meta, group_tries, devpath);
+		uORB::DeviceNode *node = new uORB::DeviceNode(meta, group_tries, nodepath);
 
-		/* if we didn't get a device, that's bad, free the path too */
+		/* if we didn't get a device, that's bad */
 		if (node == nullptr) {
-			free((void *)devpath);
 			return -ENOMEM;
 		}
 

--- a/src/lib/cdev/CDev.cpp
+++ b/src/lib/cdev/CDev.cpp
@@ -128,6 +128,9 @@ CDev::init()
 		if (ret == PX4_OK) {
 			_registered = true;
 		}
+
+	} else {
+		ret = -ENODEV;
 	}
 
 	return ret;
@@ -371,29 +374,6 @@ CDev::remove_poll_waiter(px4_pollfd_struct_t *fds)
 
 	PX4_DEBUG("poll: bad fd state");
 	return -EINVAL;
-}
-
-int CDev::unregister_driver_and_memory()
-{
-	int retval = PX4_OK;
-
-	if (_registered) {
-		unregister_driver(_devname);
-		_registered = false;
-
-	} else {
-		retval = -ENODEV;
-	}
-
-	if (_devname != nullptr) {
-		free((void *)_devname);
-		_devname = nullptr;
-
-	} else {
-		retval = -ENODEV;
-	}
-
-	return retval;
 }
 
 } // namespace cdev

--- a/src/lib/cdev/CDev.hpp
+++ b/src/lib/cdev/CDev.hpp
@@ -270,17 +270,6 @@ protected:
 
 	px4_sem_t	_lock; /**< lock to protect access to all class members (also for derived classes) */
 
-
-	/**
-	* First, unregisters the driver. Next, free the memory for the devname,
-	* in case it was expected to have ownership. Sets devname to nullptr.
-	*
-	* This is only needed if the ownership of the devname was passed to the CDev, otherwise ~CDev handles it.
-	*
-	* @return  PX4_OK on success, -ENODEV if the devname is already nullptr
-	*/
-	int unregister_driver_and_memory();
-
 private:
 	const char	*_devname{nullptr};		/**< device node name */
 

--- a/src/lib/cdev/CMakeLists.txt
+++ b/src/lib/cdev/CMakeLists.txt
@@ -51,6 +51,10 @@ px4_add_library(cdev
 )
 target_compile_options(cdev PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 
+if (${PX4_PLATFORM} STREQUAL "nuttx")
+	target_link_libraries(cdev PRIVATE nuttx_fs) # register/unregister driver
+endif()
+
 if(PX4_TESTING)
 	add_subdirectory(test)
 endif()


### PR DESCRIPTION

**Describe problem solved by this pull request**

This is a cherry-pick from the protected build PR. This fixes a problem in freeing allocated node name; in kernel it needs to be freed with kernel-specific function (kmm_free), as the strdup allocates it from kernel heap.

This also cleans up the managing of the node name in general. It seems unnecessary to transfer the memory allocation ownership from uORB to CDev. It is confusing and in general better practice to free the memory by the same entity who allocated it. In this case the memory allocation and de-allocation can be fully managed by uORBDeviceNode.

**Describe your solution**
Allocate the copy of the node name in uORBDeviceNode constructor, when the CDev object is being created. The success of the allocation is checked later in CDev::init. The deletion of the allocated node name is handled in uORBDeviceNode destructor.

**Describe possible alternatives**
- Always strdup the name in CDev ; would probably cause excess memory consumption, as many names are constants (e.g. in drivers)
- Add an interface into CDev costructor to conditionally strdup the name. Works fine, but needs to store the info about whether it was allocated or not, to be used in destructor. Too complex and also wastes memory

**Test data / coverage**
Tried out in pixhawk 4 and in sitl

