### PR TITLE
ManualControlSelector: Enable original PX4 default behavior until QGC catches up

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -252,11 +252,12 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  *
  * @group Commander
  * @min 0
- * @max 3
+ * @max 4
  * @value 0 RC Transmitter only
  * @value 1 Joystick only
  * @value 2 RC and Joystick with fallback
  * @value 3 RC or Joystick keep first
+ * @value 4 Stick input disabled
  */
 PARAM_DEFINE_INT32(COM_RC_IN_MODE, 3);
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -252,12 +252,13 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  *
  * @group Commander
  * @min 0
- * @max 2
+ * @max 3
  * @value 0 RC Transmitter only
- * @value 1 Joystick only/No RC Checks
- * @value 2 RC and Joystick are accepted
+ * @value 1 Joystick only
+ * @value 2 RC and Joystick with fallback
+ * @value 3 RC or Joystick keep first
  */
-PARAM_DEFINE_INT32(COM_RC_IN_MODE, 0);
+PARAM_DEFINE_INT32(COM_RC_IN_MODE, 3);
 
 /**
  * RC input arm/disarm command duration

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -54,6 +54,11 @@ void ManualControlSelector::updateWithNewInputSample(uint64_t now, const manual_
 		_setpoint = input;
 		_setpoint.valid = true;
 		_instance = instance;
+
+		if (_first_valid_source == manual_control_setpoint_s::SOURCE_UNKNOWN) {
+			// initialize first valid source once
+			_first_valid_source = _setpoint.data_source;
+		}
 	}
 }
 
@@ -73,9 +78,12 @@ bool ManualControlSelector::isInputValid(const manual_control_setpoint_s &input,
 					     || input.data_source == manual_control_setpoint_s::SOURCE_MAVLINK_4
 					     || input.data_source == manual_control_setpoint_s::SOURCE_MAVLINK_5);
 	const bool source_any_matched = (_rc_in_mode == 2);
+	const bool source_first_matched = (_rc_in_mode == 3) &&
+					  (input.data_source == _first_valid_source
+					   || _first_valid_source == manual_control_setpoint_s::SOURCE_UNKNOWN);
 
 	return sample_from_the_past && sample_newer_than_timeout
-	       && (source_rc_matched || source_mavlink_matched || source_any_matched);
+	       && (source_rc_matched || source_mavlink_matched || source_any_matched || source_first_matched);
 }
 
 manual_control_setpoint_s &ManualControlSelector::setpoint()

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -53,4 +53,5 @@ private:
 	uint64_t _timeout{0};
 	int32_t _rc_in_mode{0};
 	int _instance{-1};
+	uint8_t _first_valid_source{manual_control_setpoint_s::SOURCE_UNKNOWN};
 };

--- a/src/modules/manual_control/ManualControlSelectorTest.cpp
+++ b/src/modules/manual_control/ManualControlSelectorTest.cpp
@@ -219,6 +219,34 @@ TEST(ManualControlSelector, FirstInput)
 	EXPECT_EQ(selector.instance(), 0);
 }
 
+TEST(ManualControlSelector, DisabledInput)
+{
+	ManualControlSelector selector;
+	selector.setRcInMode(4);
+	selector.setTimeout(500_ms);
+
+	uint64_t timestamp = some_time;
+
+	manual_control_setpoint_s input {};
+	// Reject MAVLink stick input
+	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.timestamp_sample = timestamp;
+	selector.updateWithNewInputSample(timestamp, input, 0);
+
+	EXPECT_FALSE(selector.setpoint().valid);
+	EXPECT_EQ(selector.instance(), -1);
+
+	timestamp += 100_ms;
+
+	// Reject RC stick input
+	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.timestamp_sample = timestamp;
+	selector.updateWithNewInputSample(timestamp, input, 1);
+
+	EXPECT_FALSE(selector.setpoint().valid);
+	EXPECT_EQ(selector.instance(), -1);
+}
+
 TEST(ManualControlSelector, RcTimeout)
 {
 	ManualControlSelector selector;

--- a/src/modules/manual_control/ManualControlSelectorTest.cpp
+++ b/src/modules/manual_control/ManualControlSelectorTest.cpp
@@ -168,6 +168,57 @@ TEST(ManualControlSelector, AutoInput)
 	EXPECT_EQ(selector.instance(), 1);
 }
 
+TEST(ManualControlSelector, FirstInput)
+{
+	ManualControlSelector selector;
+	selector.setRcInMode(3);
+	selector.setTimeout(500_ms);
+
+	uint64_t timestamp = some_time;
+
+	manual_control_setpoint_s input {};
+	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.timestamp_sample = timestamp;
+	selector.updateWithNewInputSample(timestamp, input, 0);
+
+	EXPECT_TRUE(selector.setpoint().valid);
+	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.instance(), 0);
+
+	timestamp += 100_ms;
+
+	// Now provide input from MAVLink as well which should get ignored.
+	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.timestamp_sample = timestamp;
+	selector.updateWithNewInputSample(timestamp, input, 1);
+
+	EXPECT_TRUE(selector.setpoint().valid);
+	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.instance(), 0);
+
+	timestamp += 500_ms;
+
+	// Now we'll let RC time out, but it should NOT switch to MAVLINK because RC was first
+	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.timestamp_sample = timestamp;
+	selector.updateWithNewInputSample(timestamp, input, 1);
+
+	EXPECT_FALSE(selector.setpoint().valid);
+	EXPECT_FALSE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_MAVLINK_0);
+	EXPECT_EQ(selector.instance(), -1);
+
+	timestamp += 100_ms;
+
+	// Provide input from RC again and it should get accepted because it was the first.
+	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.timestamp_sample = timestamp;
+	selector.updateWithNewInputSample(timestamp, input, 0);
+
+	EXPECT_TRUE(selector.setpoint().valid);
+	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.instance(), 0);
+}
+
 TEST(ManualControlSelector, RcTimeout)
 {
 	ManualControlSelector selector;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Since https://github.com/PX4/PX4-Autopilot/pull/17404 by default only RC is accepted and the original PX4 behavior of only accepting the first source present since boot is not supported anymore. I received somewhat obvious feedback from multiple users that were not aware that this has to be configured now.

**Describe your solution**
This PR enables the original behavior for default. Additionally I added an option to disable stick input completely which doesn't require specific implementation but should explicitly be possible and documented.

**Describe possible alternatives**
The goal is to make it mandatory for the user to configure what he's planning to use in the UI. Until this UI exists I recover the default behavior to not piss of numerous people that waste time finding the parameter. We should add the UI and then set the default to disabled such that the workflow is obvious.

**Test data / coverage**
I added unit tests for both cases and made sure they do exactly what we want.

**Additional context**
Add any other related context or media.
