### PR TITLE
Height fusion control cleanup and range height improvements

### DIFF
--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -734,8 +734,6 @@ void Ekf::controlHeightSensorTimeouts()
 		// Reset vertical position and velocity states to the last measurement
 		if (request_height_reset) {
 			resetHeight();
-			// Reset the timout timer
-			_time_last_hgt_fuse = _time_last_imu;
 		}
 	}
 }

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -915,9 +915,14 @@ private:
 
 	void startBaroHgtFusion();
 	void startGpsHgtFusion();
+	void startRngHgtFusion();
+	void startRngAidHgtFusion();
+	void startEvHgtFusion();
 
 	void updateBaroHgtOffset();
 	void updateBaroHgtBias();
+
+	void checkGroundEffectTimeout();
 
 	// return an estimation of the GPS altitude variance
 	float getGpsHeightVariance();

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -345,6 +345,9 @@ void Ekf::resetHeight()
 		// that does not destabilise the filter
 		P.uncorrelateCovarianceSetVariance<1>(6, 10.0f);
 	}
+
+	// Reset the timout timer
+	_time_last_hgt_fuse = _time_last_imu;
 }
 
 // align output filter states to match EKF states at the fusion time horizon

--- a/src/modules/ekf2/EKF/sensor_range_finder.hpp
+++ b/src/modules/ekf2/EKF/sensor_range_finder.hpp
@@ -58,6 +58,7 @@ public:
 	void runChecks(uint64_t current_time_us, const matrix::Dcmf &R_to_earth);
 	bool isHealthy() const override { return _is_sample_valid; }
 	bool isDataHealthy() const override { return _is_sample_ready && _is_sample_valid; }
+	bool isDataReady() const { return _is_sample_ready; }
 	bool isRegularlySendingData() const override { return _is_regularly_sending_data; }
 
 	void setSample(const rangeSample &sample)

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -152,6 +152,7 @@ TEST_F(EkfGpsTest, gpsHgtToBaroFallback)
 	_sensor_simulator.runSeconds(1);
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsHeightFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingFlowFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingBaroHeightFusion());
 
 	// WHEN: stopping GPS fusion
 	_sensor_simulator.stopGps();


### PR DESCRIPTION
**Describe problem solved by this pull request**
The height fusion control logic still contains too many low-level details that should be taken care elsewhere.

**Describe your solution**
Move all the resets/adjustments that need to be done every time a height fusion is started in the corresponding starting function (`startGpsHgtFusion`, `startRngHgtFusion`, `startRngAidHgtFusion`, `startBaroHgtFusion` and `startEvHgtFusion`).

Furthermore, when flying in range height mode (`EKF2_HGT_MODE` = range, for indoor use on flat terrain), it makes sense that the origin of the local frame is at the ground level. This is often expected by users flying indoor in offboard mode and this PR makes sure this is correct.


**Test data / coverage**
Unit tests, SITL with range finder, GPS and baro

- `EKF2_HGT_MODE` = Baro with range aid enabled (`EKF2_RNG_AID`). Baro failure (stale) simulated in flight, the altitude fusion switches to GPS height aiding after timeout. The range aid still works as expected.
![DeepinScreenshot_select-area_20211209161347](https://user-images.githubusercontent.com/14822839/145422708-6645b23b-d949-43cc-9b16-99b052a872e1.png)

- `EKF2_HGT_MODE` = GPS with range aid enabled . GPS failure (stopped) simulated in flight, the altitude fusion switches to baro and the range aid is still working as expected.
![DeepinScreenshot_select-area_20211209152138](https://user-images.githubusercontent.com/14822839/145420075-07a21825-f051-40ff-975f-7209a55fd5b0.png)

- `EKF2_GHT_MODE` = Range finder, the local position Z (or negative Z) matches precisely the range finder data, without persistent or increasing offset. It also starts on ground, even if the data quality isn't good and fuses fake data on ground if needed instead of using unreliable baro data (e.g.: indoor).
![DeepinScreenshot_select-area_20211209153647](https://user-images.githubusercontent.com/14822839/145420430-ea95ce9e-617f-48e4-afe4-d8a9de2bb285.png)

