### PR TITLE
UCANS32K146 STB fix for 2nd CAN

### DIFF
--- a/boards/nxp/ucans32k146/init/rc.board_defaults
+++ b/boards/nxp/ucans32k146/init/rc.board_defaults
@@ -6,4 +6,5 @@
 pwm_out mode_pwm1 start
 
 ifup can0
+param set UAVCAN_V1_ID -1
 uavcan_v1 start

--- a/boards/nxp/ucans32k146/src/bringup.c
+++ b/boards/nxp/ucans32k146/src/bringup.c
@@ -159,10 +159,12 @@ int s32k1xx_bringup(void)
 	if (s32k1xx_gpioread(BOARD_REVISION_DETECT_PIN)) {
 		/* STB high -> active CAN phy */
 		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ONE);
+		s32k1xx_pinconfig(PIN_CAN1_STB  | GPIO_OUTPUT_ONE);
 
 	} else {
 		/* STB low -> active CAN phy */
 		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ZERO);
+		s32k1xx_pinconfig(PIN_CAN1_STB  | GPIO_OUTPUT_ZERO);
 	}
 
 #endif


### PR DESCRIPTION
Fixes incorrectly setting STB for 2nd CAN

Furthermore for UAVCAN UCANS32K146 is always a node thus we set it to -1 to enforce PNP protocol
UAVCAN_v1 set default id to -1 for auto PNP
