### PR TITLE
Enable DO_SET_SPEED commands outside of missions in other AUTO modes

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -96,11 +96,6 @@ void Mission::mission_init()
 void
 Mission::on_inactive()
 {
-	/* We need to reset the mission cruising speed, otherwise the
-	 * mission velocity which might have been set using mission items
-	 * is used for missions such as RTL. */
-	_navigator->set_cruising_speed();
-
 	// if we were executing an landing but have been inactive for 2 seconds, then make the landing invalid
 	// this prevents RTL to just continue at the current mission index
 	if (_navigator->getMissionLandingInProgress() && (hrt_absolute_time() - _time_mission_deactivated) > 2_s) {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -498,6 +498,19 @@ Navigator::run()
 					}
 				}
 
+				if (get_vstatus()->nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER) {
+
+					// publish new reposition setpoint with updated speed/throtte when DO_CHANGE_SPEED
+					// was received in AUTO_LOITER mode
+
+					position_setpoint_triplet_s *rep = get_reposition_triplet();
+
+					// set repo setpoint to current, and only change speed and throttle fields
+					*rep = *(get_position_setpoint_triplet());
+					rep->current.cruising_speed = get_cruising_speed();
+					rep->current.cruising_throttle = get_cruising_throttle();
+				}
+
 				// TODO: handle responses for supported DO_CHANGE_SPEED options?
 				publish_vehicle_command_ack(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
@@ -1000,7 +1013,7 @@ Navigator::get_cruising_speed()
 {
 	/* there are three options: The mission-requested cruise speed, or the current hover / plane speed */
 	if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-		if (is_planned_mission() && _mission_cruising_speed_mc > 0.0f) {
+		if (_mission_cruising_speed_mc > 0.0f) {
 			return _mission_cruising_speed_mc;
 
 		} else {
@@ -1008,7 +1021,7 @@ Navigator::get_cruising_speed()
 		}
 
 	} else {
-		if (is_planned_mission() && _mission_cruising_speed_fw > 0.0f) {
+		if (_mission_cruising_speed_fw > 0.0f) {
 			return _mission_cruising_speed_fw;
 
 		} else {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -555,6 +555,17 @@ Navigator::run()
 				_vehicle_roi_pub.publish(_vroi);
 
 				publish_vehicle_command_ack(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
+
+			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
+				// reset cruise speed and throttle to default when transitioning
+				set_cruising_speed();
+				set_cruising_throttle();
+
+				// need to update current setpooint with reset cruise speed and throttle
+				position_setpoint_triplet_s *rep = get_reposition_triplet();
+				*rep = *(get_position_setpoint_triplet());
+				rep->current.cruising_speed = get_cruising_speed();
+				rep->current.cruising_throttle = get_cruising_throttle();
 			}
 		}
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -287,6 +287,10 @@ void RTL::on_activation()
 
 	setClimbAndReturnDone(_rtl_state > RTL_STATE_RETURN);
 
+	// reset cruising speed and throttle to default for RTL
+	_navigator->set_cruising_speed();
+	_navigator->set_cruising_throttle();
+
 	set_rtl_item();
 
 }


### PR DESCRIPTION
Replaces https://github.com/PX4/PX4-Autopilot/pull/18605.

**Describe problem solved by this pull request**
- no interface to change speed setpoint in auto flight if not in mission
- ~~flying in high wind with an airspeed setpoint close to stall is dangerous due to increased external disturbances, so the airspeed setpoint should ideally be increased in these situations~~

**Describe your solution**
*Speed setpoint slider:*
(Note: no PR yet for QGC side) Introduce a slider in the flyview of QGC to change the current speed setpoint. For MC this would be groundspeed, for FW/VTOLs in FW mode airspeed. After confirming the set value of the slider, QGC sends the MAVLink command [DO_CHANGE_SPEED](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED). Navigator stores the received value in _mission_cruising_speed_mc/_fw, and applies it from there on for every new AUTO action (e.g. GoTo, Loiter etc). For it to have immediate effect if vehicle is in AUTO_LOITER when receiving the change speed, apply it by doing a reposition without updating any other field than cruising_speed and cruising_throttle. 
DO_CHANGE_SPEED waypoints in mission have the same interface. They override the value set through the slider in the flyview.

When RTL is activated reset the cruising speed and throttle.
![image](https://user-images.githubusercontent.com/26798987/145605430-28c940ce-1994-4bb1-8144-cdf57916d71a.png)


~~*Wind-based adaption:* (not sure if we need this anymore with https://github.com/PX4/PX4-Autopilot/pull/18810)
There is an offset added to the minimum airspeed setpoint: setpoint += `FW_WIND_ARSP_SC` * abs(wind). So if the scale is set to 0.2, then for 10m/s there are 2m/s added to the setpoint that help making the vehicle's attitude control more robust to disturbances caused by the high wind, plus reduces the chance of a groundspeed undershoot.~~

EDIT: removed the wind-based adaption from this PR, and also split out the airspeed setpoint handling in the FW position controller: https://github.com/PX4/PX4-Autopilot/pull/18841

**Describe possible alternatives**


**Test data / coverage**
SITL tested. 

**Additional context**
