### PR TITLE
ekf2: delete obsolete _bad_vert_accel_detected

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -550,7 +550,6 @@ private:
 	// imu fault status
 	uint64_t _time_bad_vert_accel{0};	///< last time a bad vertical accel was detected (uSec)
 	uint64_t _time_good_vert_accel{0};	///< last time a good vertical accel was detected (uSec)
-	bool _bad_vert_accel_detected{false};	///< true when bad vertical accelerometer data has been detected
 	uint16_t _clip_counter{0};		///< counter that increments when clipping ad decrements when not
 
 	// variables used to control range aid functionality

--- a/src/modules/ekf2/EKF/vel_pos_fusion.cpp
+++ b/src/modules/ekf2/EKF/vel_pos_fusion.cpp
@@ -86,7 +86,7 @@ bool Ekf::fuseVerticalVelocity(const Vector3f &innov, const Vector2f &innov_gate
 	// but limit innovation to prevent spikes that could destabilise the filter
 	float innovation;
 
-	if (_bad_vert_accel_detected && !innov_check_pass) {
+	if (_fault_status.flags.bad_acc_vertical && !innov_check_pass) {
 		const float innov_limit = innov_gate(1) * sqrtf(innov_var(2));
 		innovation = math::constrain(innov(2), -innov_limit, innov_limit);
 		innov_check_pass = true;
@@ -160,7 +160,7 @@ bool Ekf::fuseVerticalPosition(const Vector3f &innov, const Vector2f &innov_gate
 	// but limit innovation to prevent spikes that could destabilise the filter
 	float innovation;
 
-	if (_bad_vert_accel_detected && !innov_check_pass) {
+	if (_fault_status.flags.bad_acc_vertical && !innov_check_pass) {
 		const float innov_limit = innov_gate(1) * sqrtf(innov_var(2));
 		innovation = math::constrain(innov(2), -innov_limit, innov_limit);
 		innov_check_pass = true;


### PR DESCRIPTION
Delete unused `_bad_vert_accel_detected` and update fusion helper methods.

 - `_bad_vert_accel_detected` was replaced with `_fault_status.flags.bad_acc_vertical` here https://github.com/PX4/PX4-ECL/pull/917 (https://github.com/PX4/PX4-ECL/commit/6e99ebd9286c5b52585d1809ae3ae2a3f00e6bd5)
 - an older PR (https://github.com/PX4/PX4-ECL/pull/836) that started months before my change wasn't actually merged until several months after and it restored `_bad_vert_accel_detected`, but in an incomplete state

We really need to be more careful when dealing with old PRs that are dragged along and rebased many times. I've personally found it can be easy to lose sight of real incremental history when rebasing multiple commits. In a lot of cases I think we're safer to merge master into these long lived branches, then finally squash & merge once done.
