### PR TITLE
simulator: add standalone sensor_mag_sim module

### DIFF
--- a/src/modules/simulator/sensor_baro_sim/CMakeLists.txt
+++ b/src/modules/simulator/sensor_baro_sim/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,46 +31,15 @@
 #
 ############################################################################
 
-option(ENABLE_UART_RC_INPUT "Enable RC Input from UART mavlink connection" OFF)
-
-if(ENABLE_UART_RC_INPUT)
-	if (APPLE)
-		set(PIXHAWK_DEVICE "/dev/cu.usbmodem1")
-	elseif (UNIX AND NOT APPLE)
-		set(PIXHAWK_DEVICE "/dev/ttyACM0")
-	elseif (WIN32)
-		set(PIXHAWK_DEVICE "COM3")
-	endif()
-
-	set(PIXHAWK_DEVICE_BAUD 115200)
-endif()
-configure_file(simulator_config.h.in simulator_config.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 px4_add_module(
-	MODULE modules__simulator
-	MAIN simulator
+	MODULE modules__simulator__sensor_baro_sim
+	MAIN sensor_baro_sim
 	COMPILE_FLAGS
-		-Wno-double-promotion
-		-Wno-cast-align
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
-	INCLUDES
-		${CMAKE_BINARY_DIR}/mavlink
-		${CMAKE_BINARY_DIR}/mavlink/development
 	SRCS
-		simulator.cpp
-		simulator_mavlink.cpp
+		SensorBaroSim.cpp
+		SensorBaroSim.hpp
 	DEPENDS
-		mavlink_c_generate
-		conversion
-		geo
-		drivers_accelerometer
 		drivers_barometer
-		drivers_gyroscope
-		drivers_magnetometer
+		geo
+		px4_work_queue
 	)
-target_include_directories(modules__simulator INTERFACE ${CMAKE_BINARY_DIR}/mavlink)
-
-add_subdirectory(battery_simulator)
-add_subdirectory(sensor_baro_sim)
-add_subdirectory(sensor_mag_sim)

--- a/src/modules/simulator/sensor_baro_sim/SensorBaroSim.cpp
+++ b/src/modules/simulator/sensor_baro_sim/SensorBaroSim.cpp
@@ -1,0 +1,225 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "SensorBaroSim.hpp"
+
+#include <drivers/drv_sensor.h>
+
+using namespace matrix;
+
+SensorBaroSim::SensorBaroSim() :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
+{
+	srand(1234); // initialize the random seed once before calling generate_wgn()
+}
+
+SensorBaroSim::~SensorBaroSim()
+{
+	perf_free(_loop_perf);
+}
+
+bool SensorBaroSim::init()
+{
+	ScheduleOnInterval(50_ms); // 20 Hz
+	return true;
+}
+
+float SensorBaroSim::generate_wgn()
+{
+	// generate white Gaussian noise sample with std=1
+
+	// algorithm 1:
+	// float temp=((float)(rand()+1))/(((float)RAND_MAX+1.0f));
+	// return sqrtf(-2.0f*logf(temp))*cosf(2.0f*M_PI_F*rand()/RAND_MAX);
+	// algorithm 2: from BlockRandGauss.hpp
+	static float V1, V2, S;
+	static bool phase = true;
+	float X;
+
+	if (phase) {
+		do {
+			float U1 = (float)rand() / RAND_MAX;
+			float U2 = (float)rand() / RAND_MAX;
+			V1 = 2.0f * U1 - 1.0f;
+			V2 = 2.0f * U2 - 1.0f;
+			S = V1 * V1 + V2 * V2;
+		} while (S >= 1.0f || fabsf(S) < 1e-8f);
+
+		X = V1 * float(sqrtf(-2.0f * float(logf(S)) / S));
+
+	} else {
+		X = V2 * float(sqrtf(-2.0f * float(logf(S)) / S));
+	}
+
+	phase = !phase;
+	return X;
+}
+
+void SensorBaroSim::Run()
+{
+	if (should_exit()) {
+		ScheduleClear();
+		exit_and_cleanup();
+		return;
+	}
+
+	perf_begin(_loop_perf);
+
+	// Check if parameters have changed
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s param_update;
+		_parameter_update_sub.copy(&param_update);
+
+		updateParams();
+	}
+
+	if (_vehicle_global_position_sub.updated()) {
+		vehicle_global_position_s gpos;
+
+		if (_vehicle_global_position_sub.copy(&gpos)) {
+
+			const float dt = math::constrain((gpos.timestamp - _last_update_time) * 1e-6f, 0.001f, 0.1f);
+
+			const float alt_msl = gpos.alt;
+
+			// calculate abs_pressure using an ISA model for the tropsphere (valid up to 11km above MSL)
+			const float lapse_rate = 0.0065f; // reduction in temperature with altitude (Kelvin/m)
+			const float temperature_msl = 288.0f; // temperature at MSL (Kelvin)
+
+			const float temperature_local = temperature_msl - lapse_rate * alt_msl;
+			const float pressure_ratio = powf(temperature_msl / temperature_local, 5.256f);
+			const float pressure_msl = 101325.0f; // pressure at MSL
+			const float absolute_pressure = pressure_msl / pressure_ratio;
+
+			// generate Gaussian noise sequence using polar form of Box-Muller transformation
+			double y1;
+			{
+				double x1;
+				double x2;
+				double w;
+
+				if (!_baro_rnd_use_last) {
+					do {
+						x1 = 2. * (double)generate_wgn() - 1.;
+						x2 = 2. * (double)generate_wgn() - 1.;
+						w = x1 * x1 + x2 * x2;
+					} while (w >= 1.0);
+
+					w = sqrt((-2.0 * log(w)) / w);
+					// calculate two values - the second value can be used next time because it is uncorrelated
+					y1 = x1 * w;
+					_baro_rnd_y2 = x2 * w;
+					_baro_rnd_use_last = true;
+
+				} else {
+					// no need to repeat the calculation - use the second value from last update
+					y1 = _baro_rnd_y2;
+					_baro_rnd_use_last = false;
+				}
+			}
+
+			// Apply noise and drift
+			const float abs_pressure_noise = 1.f * (float)y1;  // 1 Pa RMS noise
+			_baro_drift_pa += _baro_drift_pa_per_sec * dt;
+			const float absolute_pressure_noisy = absolute_pressure + abs_pressure_noise + _baro_drift_pa;
+
+			// convert to hPa
+			float pressure = absolute_pressure_noisy * 0.01f + _sim_baro_off_p.get();
+
+			// calculate temperature in Celsius
+			float temperature = temperature_local - 273.0f + _sim_baro_off_t.get();
+
+			_px4_baro.set_temperature(temperature);
+			_px4_baro.update(gpos.timestamp, pressure);
+
+			_last_update_time = gpos.timestamp;
+		}
+	}
+
+	perf_end(_loop_perf);
+}
+
+int SensorBaroSim::task_spawn(int argc, char *argv[])
+{
+	SensorBaroSim *instance = new SensorBaroSim();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int SensorBaroSim::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int SensorBaroSim::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("sensor_baro_sim", "system");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int sensor_baro_sim_main(int argc, char *argv[])
+{
+	return SensorBaroSim::main(argc, argv);
+}

--- a/src/modules/simulator/sensor_baro_sim/SensorBaroSim.hpp
+++ b/src/modules/simulator/sensor_baro_sim/SensorBaroSim.hpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <lib/drivers/barometer/PX4Barometer.hpp>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_global_position.h>
+
+using namespace time_literals;
+
+class SensorBaroSim : public ModuleBase<SensorBaroSim>, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	SensorBaroSim();
+	~SensorBaroSim() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+private:
+	void Run() override;
+
+	// generate white Gaussian noise sample with std=1
+	static float generate_wgn();
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
+
+	bool _baro_rnd_use_last{false};
+	double _baro_rnd_y2{0.0};
+	float _baro_drift_pa_per_sec{0.0};
+	float _baro_drift_pa{0.0};
+
+	hrt_abstime _last_update_time{0};
+
+	PX4Barometer _px4_baro{6620172}; // 6620172: DRV_BARO_DEVTYPE_BAROSIM, BUS: 1, ADDR: 4, TYPE: SIMULATION
+
+	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::SIM_BARO_OFF_P>) _sim_baro_off_p,
+		(ParamFloat<px4::params::SIM_BARO_OFF_P>) _sim_baro_off_t
+	)
+};

--- a/src/modules/simulator/sensor_baro_sim/parameters.c
+++ b/src/modules/simulator/sensor_baro_sim/parameters.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * simulated barometer pressure offset
+ *
+ * @group Simulator
+ */
+PARAM_DEFINE_FLOAT(SIM_BARO_OFF_P, 0.0f);
+
+/**
+ * simulated barometer temperature offset
+ *
+ * @group Simulator
+ */
+PARAM_DEFINE_FLOAT(SIM_BARO_OFF_T, 0.0f);

--- a/src/modules/simulator/sensor_gps_sim/CMakeLists.txt
+++ b/src/modules/simulator/sensor_gps_sim/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,47 +31,13 @@
 #
 ############################################################################
 
-option(ENABLE_UART_RC_INPUT "Enable RC Input from UART mavlink connection" OFF)
-
-if(ENABLE_UART_RC_INPUT)
-	if (APPLE)
-		set(PIXHAWK_DEVICE "/dev/cu.usbmodem1")
-	elseif (UNIX AND NOT APPLE)
-		set(PIXHAWK_DEVICE "/dev/ttyACM0")
-	elseif (WIN32)
-		set(PIXHAWK_DEVICE "COM3")
-	endif()
-
-	set(PIXHAWK_DEVICE_BAUD 115200)
-endif()
-configure_file(simulator_config.h.in simulator_config.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 px4_add_module(
-	MODULE modules__simulator
-	MAIN simulator
+	MODULE modules__simulator__sensor_gps_sim
+	MAIN sensor_gps_sim
 	COMPILE_FLAGS
-		-Wno-double-promotion
-		-Wno-cast-align
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
-	INCLUDES
-		${CMAKE_BINARY_DIR}/mavlink
-		${CMAKE_BINARY_DIR}/mavlink/development
 	SRCS
-		simulator.cpp
-		simulator_mavlink.cpp
+		SensorGpsSim.cpp
+		SensorGpsSim.hpp
 	DEPENDS
-		mavlink_c_generate
-		conversion
-		geo
-		drivers_accelerometer
-		drivers_barometer
-		drivers_gyroscope
-		drivers_magnetometer
+		px4_work_queue
 	)
-target_include_directories(modules__simulator INTERFACE ${CMAKE_BINARY_DIR}/mavlink)
-
-add_subdirectory(battery_simulator)
-add_subdirectory(sensor_baro_sim)
-add_subdirectory(sensor_gps_sim)
-add_subdirectory(sensor_mag_sim)

--- a/src/modules/simulator/sensor_gps_sim/SensorGpsSim.hpp
+++ b/src/modules/simulator/sensor_gps_sim/SensorGpsSim.hpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_local_position.h>
+
+using namespace time_literals;
+
+class SensorGpsSim : public ModuleBase<SensorGpsSim>, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	SensorGpsSim();
+	~SensorGpsSim() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+private:
+	void Run() override;
+
+	// generate white Gaussian noise sample with std=1
+	static float generate_wgn();
+
+	// generate white Gaussian noise sample as a 3D vector with specified std
+	matrix::Vector3f noiseGauss3f(float stdx, float stdy, float stdz) { return matrix::Vector3f(generate_wgn() * stdx, generate_wgn() * stdy, generate_wgn() * stdz); }
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position_groundtruth)};
+
+	uORB::PublicationMulti<sensor_gps_s> _sensor_gps_pub{ORB_ID(sensor_gps)};
+
+	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::SIM_GPS_USED>) _sim_gps_used
+	)
+};

--- a/src/modules/simulator/sensor_gps_sim/parameters.c
+++ b/src/modules/simulator/sensor_gps_sim/parameters.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * simulated GPS number of satellites used
+ *
+ * @min 0
+ * @max  50
+ * @group Simulator
+ */
+PARAM_DEFINE_INT32(SIM_GPS_USED, 10);

--- a/src/modules/simulator/sensor_mag_sim/CMakeLists.txt
+++ b/src/modules/simulator/sensor_mag_sim/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2021 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,45 +31,15 @@
 #
 ############################################################################
 
-option(ENABLE_UART_RC_INPUT "Enable RC Input from UART mavlink connection" OFF)
-
-if(ENABLE_UART_RC_INPUT)
-	if (APPLE)
-		set(PIXHAWK_DEVICE "/dev/cu.usbmodem1")
-	elseif (UNIX AND NOT APPLE)
-		set(PIXHAWK_DEVICE "/dev/ttyACM0")
-	elseif (WIN32)
-		set(PIXHAWK_DEVICE "COM3")
-	endif()
-
-	set(PIXHAWK_DEVICE_BAUD 115200)
-endif()
-configure_file(simulator_config.h.in simulator_config.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 px4_add_module(
-	MODULE modules__simulator
-	MAIN simulator
+	MODULE modules__simulator__sensor_mag_sim
+	MAIN sensor_mag_sim
 	COMPILE_FLAGS
-		-Wno-double-promotion
-		-Wno-cast-align
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
-	INCLUDES
-		${CMAKE_BINARY_DIR}/mavlink
-		${CMAKE_BINARY_DIR}/mavlink/development
 	SRCS
-		simulator.cpp
-		simulator_mavlink.cpp
+		SensorMagSim.cpp
+		SensorMagSim.hpp
 	DEPENDS
-		mavlink_c_generate
-		conversion
-		geo
-		drivers_accelerometer
-		drivers_barometer
-		drivers_gyroscope
 		drivers_magnetometer
+		geo
+		px4_work_queue
 	)
-target_include_directories(modules__simulator INTERFACE ${CMAKE_BINARY_DIR}/mavlink)
-
-add_subdirectory(battery_simulator)
-add_subdirectory(sensor_mag_sim)

--- a/src/modules/simulator/sensor_mag_sim/SensorMagSim.cpp
+++ b/src/modules/simulator/sensor_mag_sim/SensorMagSim.cpp
@@ -1,0 +1,195 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "SensorMagSim.hpp"
+
+#include <drivers/drv_sensor.h>
+#include <lib/world_magnetic_model/geo_mag_declination.h>
+
+using namespace matrix;
+
+SensorMagSim::SensorMagSim() :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
+{
+	_px4_mag.set_device_type(DRV_MAG_DEVTYPE_MAGSIM);
+	_px4_mag.set_external(false);
+}
+
+SensorMagSim::~SensorMagSim()
+{
+	perf_free(_loop_perf);
+}
+
+bool SensorMagSim::init()
+{
+	ScheduleOnInterval(20_ms); // 50 Hz
+	return true;
+}
+
+float SensorMagSim::generate_wgn()
+{
+	// generate white Gaussian noise sample with std=1
+
+	// algorithm 1:
+	// float temp=((float)(rand()+1))/(((float)RAND_MAX+1.0f));
+	// return sqrtf(-2.0f*logf(temp))*cosf(2.0f*M_PI_F*rand()/RAND_MAX);
+	// algorithm 2: from BlockRandGauss.hpp
+	static float V1, V2, S;
+	static bool phase = true;
+	float X;
+
+	if (phase) {
+		do {
+			float U1 = (float)rand() / RAND_MAX;
+			float U2 = (float)rand() / RAND_MAX;
+			V1 = 2.0f * U1 - 1.0f;
+			V2 = 2.0f * U2 - 1.0f;
+			S = V1 * V1 + V2 * V2;
+		} while (S >= 1.0f || fabsf(S) < 1e-8f);
+
+		X = V1 * float(sqrtf(-2.0f * float(logf(S)) / S));
+
+	} else {
+		X = V2 * float(sqrtf(-2.0f * float(logf(S)) / S));
+	}
+
+	phase = !phase;
+	return X;
+}
+
+void SensorMagSim::Run()
+{
+	if (should_exit()) {
+		ScheduleClear();
+		exit_and_cleanup();
+		return;
+	}
+
+	perf_begin(_loop_perf);
+
+	// Check if parameters have changed
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s param_update;
+		_parameter_update_sub.copy(&param_update);
+
+		updateParams();
+	}
+
+	if (_vehicle_global_position_sub.updated()) {
+		vehicle_global_position_s gpos;
+
+		if (_vehicle_global_position_sub.copy(&gpos)) {
+			if (gpos.eph < 1000) {
+
+				// magnetic field data returned by the geo library using the current GPS position
+				const float mag_declination_gps = get_mag_declination_radians(gpos.lat, gpos.lon);
+				const float mag_inclination_gps = get_mag_inclination_radians(gpos.lat, gpos.lon);
+				const float mag_strength_gps = get_mag_strength_gauss(gpos.lat, gpos.lon);
+
+				_mag_earth_pred = Dcmf(Eulerf(0, -mag_inclination_gps, mag_declination_gps)) * Vector3f(mag_strength_gps, 0, 0);
+
+				_mag_earth_available = true;
+			}
+		}
+	}
+
+	if (_mag_earth_available) {
+		vehicle_attitude_s attitude;
+
+		if (_vehicle_attitude_sub.update(&attitude)) {
+			Vector3f expected_field = Dcmf{Quatf{attitude.q}} .transpose() * _mag_earth_pred;
+
+			expected_field += noiseGauss3f(0.02f, 0.02f, 0.03f);
+
+			_px4_mag.update(attitude.timestamp,
+					expected_field(0) + _sim_mag_offset_x.get(),
+					expected_field(1) + _sim_mag_offset_y.get(),
+					expected_field(2) + _sim_mag_offset_z.get());
+		}
+	}
+}
+
+int SensorMagSim::task_spawn(int argc, char *argv[])
+{
+	SensorMagSim *instance = new SensorMagSim();
+
+	if (instance) {
+		_object.store(instance);
+		_task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	_object.store(nullptr);
+	_task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int SensorMagSim::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int SensorMagSim::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("sensor_mag_sim", "system");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int sensor_mag_sim_main(int argc, char *argv[])
+{
+	return SensorMagSim::main(argc, argv);
+}

--- a/src/modules/simulator/sensor_mag_sim/SensorMagSim.hpp
+++ b/src/modules/simulator/sensor_mag_sim/SensorMagSim.hpp
@@ -1,0 +1,94 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <lib/drivers/magnetometer/PX4Magnetometer.hpp>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_global_position.h>
+
+using namespace time_literals;
+
+class SensorMagSim : public ModuleBase<SensorMagSim>, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	SensorMagSim();
+	~SensorMagSim() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+
+private:
+	void Run() override;
+
+	// generate white Gaussian noise sample with std=1
+	static float generate_wgn();
+
+	// generate white Gaussian noise sample as a 3D vector with specified std
+	matrix::Vector3f noiseGauss3f(float stdx, float stdy, float stdz) { return matrix::Vector3f(generate_wgn() * stdx, generate_wgn() * stdy, generate_wgn() * stdz); }
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude_groundtruth)};
+	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position_groundtruth)};
+
+	PX4Magnetometer _px4_mag{197388, ROTATION_NONE}; // 197388: DRV_MAG_DEVTYPE_MAGSIM, BUS: 1, ADDR: 1, TYPE: SIMULATION
+
+	bool _mag_earth_available{false};
+
+	matrix::Vector3f _mag_earth_pred{};
+
+	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::SIM_MAG_OFFSET_X>) _sim_mag_offset_x,
+		(ParamFloat<px4::params::SIM_MAG_OFFSET_Y>) _sim_mag_offset_y,
+		(ParamFloat<px4::params::SIM_MAG_OFFSET_Z>) _sim_mag_offset_z
+	)
+};

--- a/src/modules/simulator/sensor_mag_sim/parameters.c
+++ b/src/modules/simulator/sensor_mag_sim/parameters.c
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * simulated magnetometer X offset
+ *
+ * @unit gauss
+ * @group Simulator
+ */
+PARAM_DEFINE_FLOAT(SIM_MAG_OFFSET_X, 0.0f);
+
+/**
+ * simulated magnetometer Y offset
+ *
+ * @unit gauss
+ * @group Simulator
+ */
+PARAM_DEFINE_FLOAT(SIM_MAG_OFFSET_Y, 0.0f);
+
+/**
+ * simulated magnetometer Z offset
+ *
+ * @unit gauss
+ * @group Simulator
+ */
+PARAM_DEFINE_FLOAT(SIM_MAG_OFFSET_Z,  0.0f);


### PR DESCRIPTION
This is a new standalone mag simulator "driver" that creates an appropriate magnetic field from simulator ground truth (attitude + global position).

We can use this pattern to start consolidating things across all the different simulators. As far as I know none of them actually get the magnetic field from the simulation, so it's quite a lot of duplicated code/effort.

TODO:
 - ~~add noise~~
 - configurable
 - update SIH, sitl_gazebo, ignition, etc, etc