### PR TITLE
Add CAN2 to uavcan fw server. Remove exit when armed

### DIFF
--- a/src/drivers/uavcan/uavcan_servers.cpp
+++ b/src/drivers/uavcan/uavcan_servers.cpp
@@ -291,7 +291,6 @@ UavcanServers::run(pthread_addr_t)
 
 	/* the subscribe call needs to happen in the same thread,
 	 * so not in the constructor */
-	uORB::Subscription armed_sub{ORB_ID(actuator_armed)};
 	uORB::Subscription vcmd_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription param_request_sub{ORB_ID(uavcan_parameter_request)};
 
@@ -564,18 +563,6 @@ UavcanServers::run(pthread_addr_t)
 				ack.target_component = cmd.source_component;
 				ack.timestamp = hrt_absolute_time();
 				_command_ack_pub.publish(ack);
-			}
-		}
-
-		// Shut down once armed
-		// TODO (elsewhere): start up again once disarmed?
-		if (armed_sub.updated()) {
-			actuator_armed_s armed;
-
-			if (armed_sub.copy(&armed)) {
-				if (armed.armed) {
-					_subnode_thread_should_exit.store(true);
-				}
 			}
 		}
 	}

--- a/src/drivers/uavcan/uavcan_servers.hpp
+++ b/src/drivers/uavcan/uavcan_servers.hpp
@@ -76,7 +76,7 @@
  */
 class __EXPORT UavcanServers
 {
-	static constexpr unsigned NumIfaces = 1;  // UAVCAN_STM32_NUM_IFACES
+	static constexpr unsigned NumIfaces = 2;  // UAVCAN_STM32_NUM_IFACES
 
 	static constexpr unsigned StackSize  = 6000;
 	static constexpr unsigned Priority  =  120;

--- a/src/drivers/uavcan/uavcan_servers.hpp
+++ b/src/drivers/uavcan/uavcan_servers.hpp
@@ -76,7 +76,7 @@
  */
 class __EXPORT UavcanServers
 {
-	static constexpr unsigned NumIfaces = 2;  // UAVCAN_STM32_NUM_IFACES
+	static constexpr unsigned NumIfaces = UAVCAN_STM32_NUM_IFACES;
 
 	static constexpr unsigned StackSize  = 6000;
 	static constexpr unsigned Priority  =  120;


### PR DESCRIPTION
This PR adds the uavcan fw server to the CAN2 interface to allow uavcannodes to boot on CAN2. Also removes the exit when armed to allow cannodes to boot and enumerate when armed. 

Bench tested on a Pixhawk 4, Pixhawk 4 Mini, and FMUV5X. 