### PR TITLE
drivers/accelerometer: adjust int16_t clipping threshold slightly

### DIFF
--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -55,7 +55,10 @@ static constexpr uint8_t clipping(const int16_t samples[], uint8_t len)
 	unsigned clip_count = 0;
 
 	for (int n = 0; n < len; n++) {
-		if ((samples[n] == INT16_MIN) || (samples[n] == INT16_MAX)) {
+		// - consider data clipped/saturated if it's INT16_MIN/INT16_MAX or within 1
+		// - this accommodates rotated data (|INT16_MIN| = INT16_MAX + 1)
+		//   and sensors that may re-use the lowest bit for other purposes (sync indicator, etc)
+		if ((samples[n] <= INT16_MIN + 1) || (samples[n] >= INT16_MAX - 1)) {
 			clip_count++;
 		}
 	}

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -227,7 +227,14 @@ constexpr T negate(T value)
 template<>
 constexpr int16_t negate<int16_t>(int16_t value)
 {
-	return (value == INT16_MIN) ? INT16_MAX : -value;
+	if (value == INT16_MAX) {
+		return INT16_MIN;
+
+	} else if (value == INT16_MIN) {
+		return INT16_MAX;
+	}
+
+	return -value;
 }
 
 inline bool isFinite(const float &value)


### PR DESCRIPTION
 - consider data clipped/saturated if it's INT16_MIN/INT16_MAX or within 1
 - this accommodates rotated data (|INT16_MIN| = INT16_MAX + 1) and sensors that may re-use the lowest bit for other purposes (sync indicator, etc)
