### PR TITLE
move to Land WP's altitude instead of staying at current altitude

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -915,14 +915,6 @@ Mission::set_mission_items()
 					mission_item_next_position = _mission_item;
 					has_next_position_item = true;
 
-					float altitude = _navigator->get_global_position()->alt;
-
-					if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
-						altitude = pos_sp_triplet->current.alt;
-					}
-
-					_mission_item.altitude = altitude;
-					_mission_item.altitude_is_relative = false;
 					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 					_mission_item.autocontinue = true;
 					_mission_item.time_inside = 0.0f;
@@ -959,22 +951,6 @@ Mission::set_mission_items()
 					mission_item_next_position = _mission_item;
 					has_next_position_item = true;
 
-					/*
-					 * Ignoring waypoint altitude:
-					 * Set altitude to the same as we have now to prevent descending too fast into
-					 * the ground. Actual landing will descend anyway until it touches down.
-					 * XXX: We might want to change that at some point if it is clear to the user
-					 * what the altitude means on this waypoint type.
-					 */
-					float altitude = _navigator->get_global_position()->alt;
-
-					if (pos_sp_triplet->current.valid
-					    && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
-						altitude = pos_sp_triplet->current.alt;
-					}
-
-					_mission_item.altitude = altitude;
-					_mission_item.altitude_is_relative = false;
 					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 					_mission_item.autocontinue = true;
 					_mission_item.time_inside = 0.0f;


### PR DESCRIPTION
@dagar @sfuhrer @RomanBapst here's the PR from our slack conversation about moving to the altitude defined in the Land waypoint. (https://px4.slack.com/archives/C0V533X4N/p1639150436168000)

**Describe problem solved by this pull request**
For MC and VTOL drones that enforce landing in MC mode the altitude of the Land WP is ignored, which is confusing when planning a mission. For example, in the attached mission I'd expect the drone to fly diagonally from WP No. 5 at 25m to the Land WP at 5m, and then descend vertically for the last descent.
[short vtol mission ZH.zip](https://github.com/PX4/PX4-Autopilot/files/7712222/short.vtol.mission.ZH.zip)
Without this PR, the drone flies towards the landing spot at 25m altitude and then descends vertically which is not my intent when planning a mission like this.

Additionally, if the takeoff spot is higher than the landing spot with the current implementation the drone descends too slowly for too long as the slow land speed is by default set relative to home. This PR removes this false slow land speed problem.
![image](https://user-images.githubusercontent.com/48206725/146020864-82aa9e68-9214-41a8-b937-18fd41231ecd.png)


**Describe your solution**
Don't ignore the VTOL&Land and Land waypoints' altitude.

**Test data / coverage**
SITL gazebo standard VTOL with slight variations of the above mission:

VTOL in MC mode, rel alt, normal land WP: https://logs.px4.io/plot_app?log=9ab242e3-5af7-4edf-a36c-1dd01fc9e41d
mission: VTOL takeoff, 2WP at 25m rel, BT, 1 WP at 25m rel, Land WP at 5m rel.

VTOL in MC mode, abs alt, normal land WP: https://logs.px4.io/plot_app?log=04398968-2b24-4b80-9874-e6531522c8dd
mission: VTOL takeoff, 2WP at 25m rel, BT, 1 WP at 25m rel, Land WP at 533m AMSL.

VTOL in FW mode, rel alt, normal land WP: https://logs.px4.io/plot_app?log=54320484-ebfe-4348-a8ff-6307db4cc888 
mission: VTOL takeoff, 3WP at 25m rel, Land WP at 5m rel.

VTOL in FW mode, abs alt, normal land WP: https://logs.px4.io/plot_app?log=38905b9a-6431-41b8-9b7a-d8d8b1fb06bb
mission: VTOL takeoff, 3WP at 25m rel, Land WP at 533m AMSL.

VTOL in FW mode, rel alt, VTOL&Land WP: https://logs.px4.io/plot_app?log=a3cac434-e8ad-4ba8-b52b-e9945e8d06a5 
mission: VTOL takeoff, 3WP at 25m rel, VTOL&Land WP at 5m rel.

VTOL in FW mode, abs alt, VTOL&Land WP: https://logs.px4.io/plot_app?log=a49b6308-d13c-425e-a3ba-4c0380d39a47 
mission: VTOL takeoff, 3WP at 25m rel, VTOL&Land WP at 533m AMSL.

SITL gazebo Iris:
MC, rel alt: https://logs.px4.io/plot_app?log=6d029bcd-835f-4d7e-959d-38e6e62a1b06 
mission: 2 normal WPs at 25m rel, Land WP at 5m rel.

MC, abs alt: https://logs.px4.io/plot_app?log=63924e11-7c38-408b-a296-e3fc14ed95b6 
mission: 2 normal WPs at 25m rel, Land WP at 533m AMSL.


**Additional context**
- To my understanding this PR does not affect FW planes. I assume that `NAV_CMD_VTOL_LAND` is reserved for VTOLs and `do_need_move_to_land()` always returns false for FW planes, so the deleted blocks would never be activated on FW planes .

- This PR can cause hard landings if you don't plan your Land altitude correctly. If the Land WP is below ground level the drone will hit the ground at normal descent speed, same as if you had put a normal WP below ground - which is something you shouldn't do in the first place.
![image](https://user-images.githubusercontent.com/48206725/146020795-90930ae0-58be-4a21-9a12-448df43460ab.png)

- You can get around my problems by setting an additional normal WP at the desired Land position at the desired lower altitude, but I don't like having to put these "useless" waypoints.