### PR TITLE
ekf2: enable mag check by default, but commander only warn

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -648,7 +648,7 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_ANG, 45);
  *
  * @group Commander
  */
-PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 1);
+PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 2);
 
 /**
  * Rearming grace period

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1358,7 +1358,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_GPS_H, 10.0f);
  * @group EKF2
  * @boolean
  */
-PARAM_DEFINE_INT32(EKF2_MAG_CHECK, 0);
+PARAM_DEFINE_INT32(EKF2_MAG_CHECK, 1);
 
 /**
  * Enable synthetic magnetometer Z component measurement.


### PR DESCRIPTION
Other than potentially increasing preflight warnings within ekf2 this will also have an impact on inhibiting mag use and resets. 

Is this a better default than having it off entirely?