### PR TITLE
px4_mtd: update eeprom at24c driver to initialize multiple instances

### DIFF
--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -111,6 +111,8 @@
  *
  * Note that these are unshifted addresses.
  */
+
+#define BOARD_MTD_NUM_EEPROM        2 /* MTD: base_eeprom, imu_eeprom*/
 #define PX4_I2C_OBDEV_SE050         0x48
 
 #define GPIO_I2C4_DRDY1_BMP388      /* PG5  */  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTG|GPIO_PIN5)

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -82,6 +82,10 @@
 #define BOARD_NUM_SPI_CFG_HW_VERSIONS 1
 #endif
 
+#ifndef BOARD_MTD_NUM_EEPROM
+#define BOARD_MTD_NUM_EEPROM 1
+#endif
+
 /* ADC defining tools
  * We want to normalize the V5 Sensing to V = (adc_dn) * ADC_V5_V_FULL_SCALE/(2 ^ ADC_BITS) * ADC_V5_SCALE)
  */

--- a/platforms/common/include/px4_platform_common/px4_mtd.h
+++ b/platforms/common/include/px4_platform_common/px4_mtd.h
@@ -75,7 +75,8 @@ __EXPORT int  px4_mtd_get_geometry(const mtd_instance_s *instance, unsigned long
  */
 __EXPORT ssize_t px4_mtd_get_partition_size(const mtd_instance_s *instance, const char *partname);
 
-FAR struct mtd_dev_s *px4_at24c_initialize(FAR struct i2c_master_s *dev,
-		uint8_t address);
+int px4_at24c_initialize(FAR struct i2c_master_s *dev,
+			 uint8_t address, FAR struct mtd_dev_s **mtd_dev);
+
 
 __END_DECLS

--- a/platforms/nuttx/src/px4/common/px4_mtd.cpp
+++ b/platforms/nuttx/src/px4/common/px4_mtd.cpp
@@ -147,14 +147,18 @@ static int at24xxx_attach(mtd_instance_s &instance)
 
 	/* start the MTD driver, attempt 5 times */
 	for (int i = 0; i < 5; i++) {
-		instance.mtd_dev = px4_at24c_initialize(i2c, PX4_I2C_DEVID_ADDR(instance.devid));
+		int ret_val = px4_at24c_initialize(i2c, PX4_I2C_DEVID_ADDR(instance.devid), &(instance.mtd_dev));
 
-		if (instance.mtd_dev) {
+		if (ret_val == 0) {
 			/* abort on first valid result */
 			if (i > 0) {
 				PX4_WARN("EEPROM needed %d attempts to attach", i + 1);
 			}
 
+			break;
+
+		} else if (ret_val == -2) {
+			PX4_ERR("Number of at24c EEPROM instances reached the board limit of %d", BOARD_MTD_NUM_EEPROM);
 			break;
 		}
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
When manifest has more than one defined EEPROM the only last one will be used for all definitions. 
For example here:
https://github.com/PX4/PX4-Autopilot/blob/master/boards/px4/fmu-v5x/src/mtd.cpp#L108-L109
When writing to `base_eeprom` all data will go to `imu_eeprom`

**Describe your solution**
In `driver px4_24xxxx_mtd.c` is allocated static memory for only one EEPROM. This solution is adding default  `#define BOARD_MTD_NUM_EEPROM 1`. In case the board will use more than one EEPROM `BOARD_MTD_NUM_EEPROM` should be set in `board_config.h`

