### PR TITLE
mavlink camera ack - print error only if the mavlink command fails

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -780,7 +780,7 @@ MavlinkReceiver::handle_message_command_ack(mavlink_message_t *msg)
 	_cmd_ack_pub.publish(command_ack);
 
 	// TODO: move it to the same place that sent the command
-	if (ack.result != MAV_RESULT_ACCEPTED && ack.result != MAV_RESULT_IN_PROGRESS) {
+	if (ack.result == MAV_RESULT_FAILED) {
 		if (msg->compid == MAV_COMP_ID_CAMERA) {
 			PX4_WARN("Got unsuccessful result %" PRIu8 " from camera", ack.result);
 		}


### PR DESCRIPTION
**Describe problem solved by this pull request**
In some cases we print also the mavlink commands that replied to be unsupported or temporarily unavailable. This is not an error to show in the log. For example if a trigger fails because the camera is not ready and then the retry succeeds then we don't need this to spam the log.

Mavlink error codes for reference: https://mavlink.io/en/messages/common.html#MAV_RESULT

**Describe your solution**
Print only if the command fails and not for other conditions as before.

**Describe possible alternatives**
I cannot really think of an alternative other than leaving it as it is. This is also fine although it can spam the log in certain specific situations.

**Test data / coverage**
This has been in our internal branch for a few months now and we have not seen any issues with it so far.

**Additional context**
Add any other related context or media.
