### PR TITLE
sensors: move IMU integration to same thread as sensors in non multi-EKF mode

### DIFF
--- a/src/modules/sensors/data_validator/DataValidator.hpp
+++ b/src/modules/sensors/data_validator/DataValidator.hpp
@@ -166,7 +166,7 @@ public:
 private:
 	uint32_t _error_mask{ERROR_FLAG_NO_ERROR}; /**< sensor error state */
 
-	uint32_t _timeout_interval{40000}; /**< interval in which the datastream times out in us */
+	uint32_t _timeout_interval{50000}; /**< interval in which the datastream times out in us */
 
 	uint64_t _time_last{0};   /**< last timestamp */
 	uint64_t _event_count{0}; /**< total data counter */

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -576,7 +576,8 @@ void Sensors::InitializeVehicleIMU()
 				// if the sensors module is responsible for voting (SENS_IMU_MODE 1) then run every VehicleIMU in the same WQ
 				//   otherwise each VehicleIMU runs in a corresponding INSx WQ
 				const bool multi_mode = (_param_sens_imu_mode.get() == 0);
-				const px4::wq_config_t &wq_config = multi_mode ? px4::ins_instance_to_wq(i) : px4::wq_configurations::INS0;
+				const px4::wq_config_t &wq_config = multi_mode ? px4::ins_instance_to_wq(i) :
+								    px4::wq_configurations::nav_and_controllers;
 
 				VehicleIMU *imu = new VehicleIMU(i, i, i, wq_config);
 

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -176,10 +176,10 @@ void VotedSensorsUpdate::imuPoll(struct sensor_combined_s &raw)
 
 			_last_accel_timestamp[uorb_index] = imu_report.timestamp_sample;
 
-			_accel.voter.put(uorb_index, imu_report.timestamp_sample, _last_sensor_data[uorb_index].accelerometer_m_s2,
+			_accel.voter.put(uorb_index, imu_report.timestamp, _last_sensor_data[uorb_index].accelerometer_m_s2,
 					 imu_status.accel_error_count, _accel.priority[uorb_index]);
 
-			_gyro.voter.put(uorb_index, imu_report.timestamp_sample, _last_sensor_data[uorb_index].gyro_rad,
+			_gyro.voter.put(uorb_index, imu_report.timestamp, _last_sensor_data[uorb_index].gyro_rad,
 					imu_status.gyro_error_count, _gyro.priority[uorb_index]);
 		}
 	}


### PR DESCRIPTION
 - this is to ensure the wq:nav_and_controllers thread doesn't starve IMU integration