### PR TITLE
Levenberg-Marquardt fitting for sensor calibration

### DIFF
--- a/src/modules/commander/lm_fit.cpp
+++ b/src/modules/commander/lm_fit.cpp
@@ -32,6 +32,14 @@
  ****************************************************************************/
 
 #include "lm_fit.hpp"
+#include <lib/mathlib/mathlib.h>
+
+#define LM_MAX_SIZE 9
+enum class FIT_TYPE {
+
+	SPHERE = 0,
+	ELLIPSOID = 1
+};
 
 struct iteration_result {
 	float gradient_damping;
@@ -41,60 +49,151 @@ struct iteration_result {
 	} result = STATUS::SUCCESS;
 };
 
-void lm_sphere_fit_iteration(const float x[], const float y[], const float z[],
-			     unsigned int samples_collected, sphere_params &params, iteration_result &result)
+void compute_jacob(FIT_TYPE type, const float x, const float y, const float z,
+		   const sphere_params &p, float* jacob, float& residual) {
+
+	float x_unbiased = x - p.offset(0);
+	float y_unbiased = y - p.offset(1);
+	float z_unbiased = z - p.offset(2);
+	float A = p.diag(0)    * x_unbiased + p.offdiag(0) * y_unbiased + p.offdiag(1) * z_unbiased;
+	float B = p.offdiag(0) * x_unbiased + p.diag(1)    * y_unbiased + p.offdiag(2) * z_unbiased;
+	float C = p.offdiag(1) * x_unbiased + p.offdiag(2) * y_unbiased + p.diag(2)    * z_unbiased;
+
+	float length = sqrtf(A * A + B * B + C * C);
+	residual =  p.radius - length;
+
+	if (jacob != nullptr) {
+		switch(type) {
+		case FIT_TYPE::SPHERE:
+			jacob[0] = 1.0f;
+			// 1-3: partial derivative (offsets wrt fitness fn) fn operated on sample
+			jacob[1] = (p.diag(0)    * A + p.offdiag(0) * B + p.offdiag(1) * C) / length;
+			jacob[2] = (p.offdiag(0) * A + p.diag(1)    * B + p.offdiag(2) * C) / length;
+			jacob[3] = (p.offdiag(1) * A + p.offdiag(2) * B + p.diag(2)    * C) / length;
+			break;
+		case FIT_TYPE::ELLIPSOID:
+		default:
+			// 0-2: partial derivative (offsets wrt fitness fn) fn operated on sample
+			jacob[0] = (p.diag(0)    * A + p.offdiag(0) * B + p.offdiag(1) * C) / length;
+			jacob[1] = (p.offdiag(0) * A + p.diag(1)    * B + p.offdiag(2) * C) / length;
+			jacob[2] = (p.offdiag(1) * A + p.offdiag(2) * B + p.diag(2)    * C) / length;
+			// 3-5: partial derivative (diag offset wrt fitness fn) fn operated on sample
+			jacob[3] = -x_unbiased * A / length;
+			jacob[4] = -y_unbiased * B / length;
+			jacob[5] = -z_unbiased * C / length;
+			// 6-8: partial derivative (off-diag offset wrt fitness fn) fn operated on sample
+			jacob[6] = -(y_unbiased * A + x_unbiased * B) / length;
+			jacob[7] = -(z_unbiased * A + x_unbiased * C) / length;
+			jacob[8] = -(z_unbiased * B + y_unbiased * C) / length;
+		}
+	}
+}
+
+int lm_size(FIT_TYPE type) {
+	int size = 0;
+	switch(type) {
+	case FIT_TYPE::SPHERE:
+		size = 4;
+		break;
+	case FIT_TYPE::ELLIPSOID:
+	default:
+		size = 9;
+	}
+	return math::min(LM_MAX_SIZE,size);
+}
+
+void lm_param_to_array(FIT_TYPE type, const sphere_params &params, float param_array[]) {
+
+	switch(type) {
+	case FIT_TYPE::SPHERE:
+		param_array[0] = params.radius;
+		param_array[1] = params.offset(0);
+		param_array[2] = params.offset(1);
+		param_array[3] = params.offset(2);
+		break;
+	case FIT_TYPE::ELLIPSOID:
+	default:
+		param_array[0] = params.offset(0);
+		param_array[1] = params.offset(1);
+		param_array[2] = params.offset(2);
+		param_array[3] = params.diag(0);
+		param_array[4] = params.diag(1);
+		param_array[5] = params.diag(2);
+		param_array[6] = params.offdiag(0);
+		param_array[7] = params.offdiag(1);
+		param_array[8] = params.offdiag(2);
+	}
+}
+
+void lm_array_to_param(FIT_TYPE type, const float param_array[], sphere_params &params) {
+
+	switch(type) {
+	case FIT_TYPE::SPHERE:
+		params.radius = param_array[0];
+		params.offset(0) = param_array[1];
+		params.offset(1) = param_array[2];
+		params.offset(2) = param_array[3];
+		break;
+	case FIT_TYPE::ELLIPSOID:
+	default:
+		params.offset(0) = param_array[0];
+		params.offset(1) = param_array[1];
+		params.offset(2) = param_array[2];
+		params.diag(0) = param_array[3];
+		params.diag(1) = param_array[4];
+		params.diag(2) = param_array[5];
+		params.offdiag(0) = param_array[6];
+		params.offdiag(1) = param_array[7];
+		params.offdiag(2) = param_array[8];
+	}
+}
+
+void lm_fit_iteration(const float x[], const float y[], const float z[],
+			     unsigned int samples_collected, sphere_params &params, iteration_result &result,
+			     FIT_TYPE type)
 {
-	// Run Sphere Fit using Levenberg Marquardt LSq Fit
+	// Run fit using Levenberg Marquardt LSq Fit
 	const float lma_damping = 10.f;
 	float fitness = result.cost;
 	float fit1 = 0.f;
 	float fit2 = 0.f;
 
-	matrix::SquareMatrix<float, 4> JTJ;
-	float JTFI[4] {};
+	int max_size = lm_size(type);
+
+	matrix::SquareMatrix<float, LM_MAX_SIZE> JTJ;
+	JTJ.setIdentity();
+	float JTFI[LM_MAX_SIZE] {};
 	float residual = 0.0f;
+	float jacob[LM_MAX_SIZE]{0.f};
 
 	// Gauss Newton Part common for all kind of extensions including LM
 	for (uint16_t k = 0; k < samples_collected; k++) {
 
-		float sphere_jacob[4];
-		//Calculate Jacobian
-		float A = (params.diag(0)    * (x[k] - params.offset(0))) + (params.offdiag(0) * (y[k] - params.offset(1))) +
-			  (params.offdiag(1) * (z[k] - params.offset(2)));
-		float B = (params.offdiag(0) * (x[k] - params.offset(0))) + (params.diag(1)    * (y[k] - params.offset(1))) +
-			  (params.offdiag(2) * (z[k] - params.offset(2)));
-		float C = (params.offdiag(1) * (x[k] - params.offset(0))) + (params.offdiag(2) * (y[k] - params.offset(1))) +
-			  (params.diag(2)    * (z[k] - params.offset(2)));
-		float length = sqrtf(A * A + B * B + C * C);
+		compute_jacob(type,x[k] ,y[k] ,z[k] ,params,jacob,residual);
 
-		// 0: partial derivative (radius wrt fitness fn) fn operated on sample
-		sphere_jacob[0] = 1.0f;
-		// 1-3: partial derivative (offsets wrt fitness fn) fn operated on sample
-		sphere_jacob[1] = 1.0f * (((params.diag(0)    * A) + (params.offdiag(0) * B) + (params.offdiag(1) * C)) / length);
-		sphere_jacob[2] = 1.0f * (((params.offdiag(0) * A) + (params.diag(1)    * B) + (params.offdiag(2) * C)) / length);
-		sphere_jacob[3] = 1.0f * (((params.offdiag(1) * A) + (params.offdiag(2) * B) + (params.diag(2)    * C)) / length);
-		residual = params.radius - length;
-
-		for (uint8_t i = 0; i < 4; i++) {
+		for (uint8_t i = 0; i < max_size; i++) {
 			// compute JTJ
-			for (uint8_t j = 0; j < 4; j++) {
-				JTJ(i, j) += sphere_jacob[i] * sphere_jacob[j];
+			for (uint8_t j = 0; j < max_size; j++) {
+				JTJ(i, j) += jacob[i] * jacob[j];
 			}
 
-			JTFI[i] += sphere_jacob[i] * residual;
+			JTFI[i] += jacob[i] * residual;
 		}
 	}
 
-
 	//------------------------Levenberg-Marquardt-part-starts-here---------------------------------//
 	// refer: http://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm#Choice_of_damping_parameter
-	float fit1_params[4] = {params.radius, params.offset(0), params.offset(1), params.offset(2)};
-	float fit2_params[4];
+	sphere_params params1 = params;
+	sphere_params params2 = params;
+	float fit1_params[LM_MAX_SIZE];
+	lm_param_to_array(type, params, fit1_params);
+	float fit2_params[LM_MAX_SIZE];
 	memcpy(fit2_params, fit1_params, sizeof(fit1_params));
+
 	JTJ = (JTJ + JTJ.transpose()) * 0.5f; // fix numerical issues
-	matrix::SquareMatrix<float, 4> JTJ2 = JTJ;
+	matrix::SquareMatrix<float, LM_MAX_SIZE> JTJ2 = JTJ;
 
-	for (uint8_t i = 0; i < 4; i++) {
+	for (uint8_t i = 0; i < max_size; i++) {
 		JTJ(i, i) += result.gradient_damping;
 		JTJ2(i, i) += result.gradient_damping / lma_damping;
 	}
@@ -107,11 +206,10 @@ void lm_sphere_fit_iteration(const float x[], const float y[], const float z[],
 	if (!JTJ2.I(JTJ2)) {
 		result.result = iteration_result::STATUS::FAILURE;
 		return;
-
 	}
 
-	for (uint8_t row = 0; row < 4; row++) {
-		for (uint8_t col = 0; col < 4; col++) {
+	for (uint8_t row = 0; row < max_size; row++) {
+		for (uint8_t col = 0; col < max_size; col++) {
 			fit1_params[row] -= JTFI[col] * JTJ(row, col);
 			fit2_params[row] -= JTFI[col] * JTJ2(row, col);
 		}
@@ -119,162 +217,15 @@ void lm_sphere_fit_iteration(const float x[], const float y[], const float z[],
 
 	// Calculate mean squared residuals
 	for (uint16_t k = 0; k < samples_collected; k++) {
-		float A = (params.diag(0)    * (x[k] - fit1_params[1])) + (params.offdiag(0) * (y[k] - fit1_params[2])) +
-			  (params.offdiag(1) *
-			   (z[k] + fit1_params[3]));
-		float B = (params.offdiag(0) * (x[k] - fit1_params[1])) + (params.diag(1)    * (y[k] - fit1_params[2])) +
-			  (params.offdiag(2) *
-			   (z[k] + fit1_params[3]));
-		float C = (params.offdiag(1) * (x[k] - fit1_params[1])) + (params.offdiag(2) * (y[k] - fit1_params[2])) + (params.diag(
-					2)    *
-				(z[k] - fit1_params[3]));
-		float length = sqrtf(A * A + B * B + C * C);
-		residual = fit1_params[0] - length;
-		fit1 += residual * residual;
+		lm_array_to_param(type,fit1_params,params1);
+		float residual1;
+		compute_jacob(type,x[k] ,y[k] ,z[k], params1, nullptr, residual1);
+		fit1 += residual1 * residual1;
 
-		A = (params.diag(0)    * (x[k] - fit2_params[1])) + (params.offdiag(0) * (y[k] - fit2_params[2])) + (params.offdiag(1) *
-				(z[k] - fit2_params[3]));
-		B = (params.offdiag(0) * (x[k] - fit2_params[1])) + (params.diag(1)    * (y[k] - fit2_params[2])) + (params.offdiag(2) *
-				(z[k] - fit2_params[3]));
-		C = (params.offdiag(1) * (x[k] - fit2_params[1])) + (params.offdiag(2) * (y[k] - fit2_params[2])) + (params.diag(2)    *
-				(z[k] - fit2_params[3]));
-		length = sqrtf(A * A + B * B + C * C);
-		residual = fit2_params[0] - length;
-		fit2 += residual * residual;
-	}
-
-	fit1 = sqrtf(fit1) / samples_collected;
-	fit2 = sqrtf(fit2) / samples_collected;
-
-	if (fit1 > result.cost && fit2 > result.cost) {
-		result.gradient_damping *= lma_damping;
-
-	} else if (fit2 < result.cost && fit2 < fit1) {
-		result.gradient_damping /= lma_damping;
-		memcpy(fit1_params, fit2_params, sizeof(fit1_params));
-		fitness = fit2;
-
-	} else if (fit1 < result.cost) {
-		fitness = fit1;
-	}
-
-	//--------------------Levenberg-Marquardt-part-ends-here--------------------------------//
-
-	if (PX4_ISFINITE(fitness) && fitness <= result.cost) {
-		result.cost = fitness;
-		params.radius = fit1_params[0];
-		params.offset(0) = fit1_params[1];
-		params.offset(1) = fit1_params[2];
-		params.offset(2) = fit1_params[3];
-		result.result = iteration_result::STATUS::SUCCESS;
-
-	} else {
-		result.result = iteration_result::STATUS::FAILURE;
-	}
-}
-
-void lm_ellipsoid_fit_iteration(const float x[], const float y[], const float z[],
-				unsigned int samples_collected, sphere_params &params, iteration_result &result)
-{
-	// Run Sphere Fit using Levenberg Marquardt LSq Fit
-	const float lma_damping = 10.0f;
-	float fitness = result.cost;
-	float fit1 = 0.0f;
-	float fit2 = 0.0f;
-
-	matrix::SquareMatrix<float, 9> JTJ;
-	float JTFI[9] {};
-	float residual = 0.0f;
-	float ellipsoid_jacob[9];
-
-	// Gauss Newton Part common for all kind of extensions including LM
-	for (uint16_t k = 0; k < samples_collected; k++) {
-
-		// Calculate Jacobian
-		float A = (params.diag(0)    * (x[k] - params.offset(0))) + (params.offdiag(0) * (y[k] - params.offset(1))) +
-			  (params.offdiag(1) * (z[k] - params.offset(2)));
-		float B = (params.offdiag(0) * (x[k] - params.offset(0))) + (params.diag(1)    * (y[k] - params.offset(1))) +
-			  (params.offdiag(2) * (z[k] - params.offset(2)));
-		float C = (params.offdiag(1) * (x[k] - params.offset(0))) + (params.offdiag(2) * (y[k] - params.offset(1))) +
-			  (params.diag(2)    * (z[k] - params.offset(2)));
-		float length = sqrtf(A * A + B * B + C * C);
-		residual = params.radius - length;
-		fit1 += residual * residual;
-		// 0-2: partial derivative (offset wrt fitness fn) fn operated on sample
-		ellipsoid_jacob[0] = 1.0f * (((params.diag(0)    * A) + (params.offdiag(0) * B) + (params.offdiag(1) * C)) / length);
-		ellipsoid_jacob[1] = 1.0f * (((params.offdiag(0) * A) + (params.diag(1)    * B) + (params.offdiag(2) * C)) / length);
-		ellipsoid_jacob[2] = 1.0f * (((params.offdiag(1) * A) + (params.offdiag(2) * B) + (params.diag(2)    * C)) / length);
-		// 3-5: partial derivative (diag offset wrt fitness fn) fn operated on sample
-		ellipsoid_jacob[3] = -1.0f * ((x[k] - params.offset(0)) * A) / length;
-		ellipsoid_jacob[4] = -1.0f * ((y[k] - params.offset(1)) * B) / length;
-		ellipsoid_jacob[5] = -1.0f * ((z[k] - params.offset(2)) * C) / length;
-		// 6-8: partial derivative (off-diag offset wrt fitness fn) fn operated on sample
-		ellipsoid_jacob[6] = -1.0f * (((y[k] - params.offset(1)) * A) + ((x[k] - params.offset(0)) * B)) / length;
-		ellipsoid_jacob[7] = -1.0f * (((z[k] - params.offset(2)) * A) + ((x[k] - params.offset(0)) * C)) / length;
-		ellipsoid_jacob[8] = -1.0f * (((z[k] - params.offset(2)) * B) + ((y[k] - params.offset(1)) * C)) / length;
-
-		for (uint8_t i = 0; i < 9; i++) {
-			// compute JTJ
-			for (uint8_t j = 0; j < 9; j++) {
-				JTJ(i, j) += ellipsoid_jacob[i] * ellipsoid_jacob[j];
-			}
-
-			JTFI[i] += ellipsoid_jacob[i] * residual;
-		}
-	}
-
-
-	//------------------------Levenberg-Marquardt-part-starts-here---------------------------------//
-	// refer: http://en.wikipedia.org/wiki/Levenberg%E2%80%93Marquardt_algorithm#Choice_of_damping_parameter
-	float fit1_params[9] = {params.offset(0), params.offset(1), params.offset(2), params.diag(0), params.diag(1), params.diag(2), params.offdiag(0), params.offdiag(1), params.offdiag(2)};
-	float fit2_params[9];
-	memcpy(fit2_params, fit1_params, sizeof(fit1_params));
-	matrix::SquareMatrix<float, 9> JTJ2 = JTJ;
-
-	for (uint8_t i = 0; i < 9; i++) {
-		JTJ(i, i) += result.gradient_damping;
-		JTJ2(i, i) += result.gradient_damping / lma_damping;
-	}
-
-
-	if (!JTJ.I(JTJ)) {
-		result.result = iteration_result::STATUS::FAILURE;
-		return;
-	}
-
-	if (!JTJ2.I(JTJ2)) {
-		result.result = iteration_result::STATUS::FAILURE;
-		return;
-	}
-
-	for (uint8_t row = 0; row < 9; row++) {
-		for (uint8_t col = 0; col < 9; col++) {
-			fit1_params[row] -= JTFI[col] * JTJ(row, col);
-			fit2_params[row] -= JTFI[col] * JTJ2(row, col);
-		}
-	}
-
-	// Calculate mean squared residuals
-	for (uint16_t k = 0; k < samples_collected; k++) {
-		float A = (fit1_params[3]    * (x[k] - fit1_params[0])) + (fit1_params[6] * (y[k] - fit1_params[1])) + (fit1_params[7] *
-				(z[k] - fit1_params[2]));
-		float B = (fit1_params[6] * (x[k] - fit1_params[0])) + (fit1_params[4]   * (y[k] - fit1_params[1])) + (fit1_params[8] *
-				(z[k] - fit1_params[2]));
-		float C = (fit1_params[7] * (x[k] - fit1_params[0])) + (fit1_params[8] * (y[k] - fit1_params[1])) + (fit1_params[5]    *
-				(z[k] - fit1_params[2]));
-		float length = sqrtf(A * A + B * B + C * C);
-		residual = params.radius - length;
-		fit1 += residual * residual;
-
-		A = (fit2_params[3]    * (x[k] - fit2_params[0])) + (fit2_params[6] * (y[k] - fit2_params[1])) + (fit2_params[7] *
-				(z[k] - fit2_params[2]));
-		B = (fit2_params[6] * (x[k] - fit2_params[0])) + (fit2_params[4]   * (y[k] - fit2_params[1])) + (fit2_params[8] *
-				(z[k] - fit2_params[2]));
-		C = (fit2_params[7] * (x[k] - fit2_params[0])) + (fit2_params[8] * (y[k] - fit2_params[1])) + (fit2_params[5]    *
-				(z[k] - fit2_params[2]));
-		length = sqrtf(A * A + B * B + C * C);
-		residual = params.radius - length;
-		fit2 += residual * residual;
+		lm_array_to_param(type,fit2_params,params2);
+		float residual2;
+		compute_jacob(type,x[k] ,y[k] ,z[k], params2, nullptr, residual2);
+		fit2 += residual2 * residual2;
 	}
 
 	fit1 = sqrtf(fit1) / samples_collected;
@@ -295,23 +246,13 @@ void lm_ellipsoid_fit_iteration(const float x[], const float y[], const float z[
 	//--------------------Levenberg-Marquardt-part-ends-here--------------------------------//
 	if (PX4_ISFINITE(fitness) && fitness <= result.cost) {
 		result.cost = fitness;
-		params.offset(0) = fit1_params[0];
-		params.offset(1) = fit1_params[1];
-		params.offset(2) = fit1_params[2];
-		params.diag(0) = fit1_params[3];
-		params.diag(1) = fit1_params[4];
-		params.diag(2) = fit1_params[5];
-		params.offdiag(0) = fit1_params[6];
-		params.offdiag(1) = fit1_params[7];
-		params.offdiag(2) = fit1_params[8];
+		lm_array_to_param(type,fit1_params,params);
 		result.result = iteration_result::STATUS::SUCCESS;
 
 	} else {
 		result.result = iteration_result::STATUS::FAILURE;
 	}
 }
-
-
 
 int lm_mag_fit(const float x[], const float y[], const float z[], unsigned int samples_collected, sphere_params &params,
 	       bool full_ellipsoid)
@@ -333,10 +274,10 @@ int lm_mag_fit(const float x[], const float y[], const float z[], unsigned int s
 
 	for (int i = 0; i < max_iterations; i++) {
 		if (full_ellipsoid) {
-			lm_ellipsoid_fit_iteration(x, y, z, samples_collected, params, iter);
+			lm_fit_iteration(x, y, z, samples_collected, params, iter, FIT_TYPE::ELLIPSOID);
 
 		} else {
-			lm_sphere_fit_iteration(x, y, z, samples_collected, params, iter);
+			lm_fit_iteration(x, y, z, samples_collected, params, iter, FIT_TYPE::SPHERE);
 		}
 
 		if (iter.result == iteration_result::STATUS::SUCCESS


### PR DESCRIPTION
This PR aims to add a new Levenberg-Marquardt fitting for sensor calibration. It optimizes scales and offsets (without off-diagonals). It could be used for accel calibration as discussed here https://github.com/PX4/PX4-Autopilot/pull/18166.

As a first step, the existing code is factorized.
and then a new fitting ("ortogonal_ellipsoid") is added.

This is a draft and it can certainly be improved. I am not sure how to make it cleaner. I could define an "algorithm" class from which each specific algorithm can inherit.

Not tested much for now but I have done 3 mag calibrations: one with the actual code, one with my new implementation (should have the same results but as input data are not the same...), and one with the new orthogonal_ellipsoid method (not aimed to be used for mag calibration but just to see if it works).

  | actual | new | orthogonal_ellipsoid
-- | -- | -- | --
CAL_MAG0_XODIAG | 0.001 | -0.003 | 0.000
CAL_MAG0_XOFF | 0.017 | 0.012 | 0.014
CAL_MAG0_XSCALE | 1.011 | 0.999 | 1.003
CAL_MAG0_YODIAG | -0.014 | 0.001 | 0.000
CAL_MAG0_YOFF | -0.042 | -0.043 | -0.051
CAL_MAG0_YSCALE | 0.981 | 0.983 | 0.974
CAL_MAG0_ZODIAG | 0.088 | 0.078 | 0.000
CAL_MAG0_ZOFF | -0.179 | -0.187 | -0.178
CAL_MAG0_ZSCALE | 0.984 | 1.042 | 1.016
