### PR TITLE
Custom irlock frame params

### DIFF
--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -136,7 +136,7 @@ void LandingTargetEstimator::update()
 		// z component of measurement unsafe, don't use this measurement
 		return;
 	}
-    
+
 	float dist = _vehicleLocalPosition.dist_bottom - _params.offset_z;
 
 	// scale the ray s.t. the z component has length of dist
@@ -144,7 +144,7 @@ void LandingTargetEstimator::update()
 	_rel_pos(1) = sensor_ray(1) / sensor_ray(2) * dist;
 
 	// Adjust relative position according to sensor offset if centered approach
-	if(_params.appr_mode == ApproachMode::Centered){
+	if (_params.appr_mode == ApproachMode::Centered) {
 		_rel_pos(0) += _params.offset_x;
 		_rel_pos(1) += _params.offset_y;
 	}
@@ -265,7 +265,7 @@ void LandingTargetEstimator::_update_params()
 
 	param_get(_paramHandle.scale_x, &_params.scale_x);
 	param_get(_paramHandle.scale_y, &_params.scale_y);
-	
+
 	int32_t appr_mode = 0;
 	param_get(_paramHandle.appr_mode, &appr_mode);
 	_params.appr_mode = (ApproachMode)appr_mode;

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -59,7 +59,6 @@ LandingTargetEstimator::LandingTargetEstimator()
 	_paramHandle.mode = param_find("LTEST_MODE");
 	_paramHandle.scale_x = param_find("LTEST_SCALE_X");
 	_paramHandle.scale_y = param_find("LTEST_SCALE_Y");
-	_paramHandle.appr_mode = param_find("LTEST_APPR_MODE");
 	_paramHandle.sensor_yaw = param_find("LTEST_SENS_ROT");
 	_paramHandle.offset_x = param_find("LTEST_SENS_POS_X");
 	_paramHandle.offset_y = param_find("LTEST_SENS_POS_Y");
@@ -143,11 +142,9 @@ void LandingTargetEstimator::update()
 	_rel_pos(0) = sensor_ray(0) / sensor_ray(2) * dist;
 	_rel_pos(1) = sensor_ray(1) / sensor_ray(2) * dist;
 
-	// Adjust relative position according to sensor offset if centered approach
-	if (_params.appr_mode == ApproachMode::Centered) {
-		_rel_pos(0) += _params.offset_x;
-		_rel_pos(1) += _params.offset_y;
-	}
+	// Adjust relative position according to sensor offset
+	_rel_pos(0) += _params.offset_x;
+	_rel_pos(1) += _params.offset_y;
 
 	if (!_estimator_initialized) {
 		PX4_INFO("Init");
@@ -265,10 +262,6 @@ void LandingTargetEstimator::_update_params()
 
 	param_get(_paramHandle.scale_x, &_params.scale_x);
 	param_get(_paramHandle.scale_y, &_params.scale_y);
-
-	int32_t appr_mode = 0;
-	param_get(_paramHandle.appr_mode, &appr_mode);
-	_params.appr_mode = (ApproachMode)appr_mode;
 
 	int32_t sensor_yaw = 0;
 	param_get(_paramHandle.sensor_yaw, &sensor_yaw);

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -47,7 +47,6 @@
 
 #define SEC2USEC 1000000.0f
 
-
 namespace landing_target_estimator
 {
 
@@ -60,7 +59,11 @@ LandingTargetEstimator::LandingTargetEstimator()
 	_paramHandle.mode = param_find("LTEST_MODE");
 	_paramHandle.scale_x = param_find("LTEST_SCALE_X");
 	_paramHandle.scale_y = param_find("LTEST_SCALE_Y");
-
+	_paramHandle.appr_mode = param_find("LTEST_APPR_MODE");
+	_paramHandle.sensor_yaw = param_find("LTEST_SENS_ROT");
+	_paramHandle.offset_x = param_find("LTEST_SENS_POS_X");
+	_paramHandle.offset_y = param_find("LTEST_SENS_POS_Y");
+	_paramHandle.offset_z = param_find("LTEST_SENS_POS_Z");
 	_check_params(true);
 }
 
@@ -115,15 +118,16 @@ void LandingTargetEstimator::update()
 		return;
 	}
 
-	// TODO account for sensor orientation as set by parameter
-	// default orientation has camera x pointing in body y, camera y in body -x
-
 	matrix::Vector<float, 3> sensor_ray; // ray pointing towards target in body frame
-	sensor_ray(0) = -_irlockReport.pos_y * _params.scale_y; // forward
-	sensor_ray(1) = _irlockReport.pos_x * _params.scale_x; // right
+	sensor_ray(0) = _irlockReport.pos_x * _params.scale_x; // forward
+	sensor_ray(1) = _irlockReport.pos_y * _params.scale_y; // right
 	sensor_ray(2) = 1.0f;
 
-	// rotate the unit ray into the navigation frame, assume sensor frame = body frame
+	// rotate unit ray according to sensor orientation
+	_S_att = get_rot_matrix(_params.sensor_yaw);
+	sensor_ray = _S_att * sensor_ray;
+
+	// rotate the unit ray into the navigation frame
 	matrix::Quaternion<float> q_att(&_vehicleAttitude.q[0]);
 	_R_att = matrix::Dcm<float>(q_att);
 	sensor_ray = _R_att * sensor_ray;
@@ -132,12 +136,18 @@ void LandingTargetEstimator::update()
 		// z component of measurement unsafe, don't use this measurement
 		return;
 	}
-
-	float dist = _vehicleLocalPosition.dist_bottom;
+    
+	float dist = _vehicleLocalPosition.dist_bottom - _params.offset_z;
 
 	// scale the ray s.t. the z component has length of dist
 	_rel_pos(0) = sensor_ray(0) / sensor_ray(2) * dist;
 	_rel_pos(1) = sensor_ray(1) / sensor_ray(2) * dist;
+
+	// Adjust relative position according to sensor offset if centered approach
+	if(_params.appr_mode == ApproachMode::Centered){
+		_rel_pos(0) += _params.offset_x;
+		_rel_pos(1) += _params.offset_y;
+	}
 
 	if (!_estimator_initialized) {
 		PX4_INFO("Init");
@@ -255,6 +265,18 @@ void LandingTargetEstimator::_update_params()
 
 	param_get(_paramHandle.scale_x, &_params.scale_x);
 	param_get(_paramHandle.scale_y, &_params.scale_y);
+	
+	int32_t appr_mode = 0;
+	param_get(_paramHandle.appr_mode, &appr_mode);
+	_params.appr_mode = (ApproachMode)appr_mode;
+
+	int32_t sensor_yaw = 0;
+	param_get(_paramHandle.sensor_yaw, &sensor_yaw);
+	_params.sensor_yaw = static_cast<enum Rotation>(sensor_yaw);
+
+	param_get(_paramHandle.offset_x, &_params.offset_x);
+	param_get(_paramHandle.offset_y, &_params.offset_y);
+	param_get(_paramHandle.offset_z, &_params.offset_z);
 }
 
 

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.h
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.h
@@ -108,11 +108,6 @@ private:
 		Stationary
 	};
 
-	enum class ApproachMode {
-		Centered = 0,
-		Aligned
-	};
-
 	/**
 	* Handles for parameters
 	**/
@@ -124,7 +119,6 @@ private:
 		param_t mode;
 		param_t scale_x;
 		param_t scale_y;
-		param_t appr_mode;
 		param_t offset_x;
 		param_t offset_y;
 		param_t offset_z;
@@ -139,7 +133,6 @@ private:
 		TargetMode mode;
 		float scale_x;
 		float scale_y;
-		ApproachMode appr_mode;
 		float offset_x;
 		float offset_y;
 		float offset_z;

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.h
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.h
@@ -58,6 +58,7 @@
 #include <matrix/math.hpp>
 #include <mathlib/mathlib.h>
 #include <matrix/Matrix.hpp>
+#include <lib/conversion/rotation.h>
 #include "KalmanFilter.h"
 
 using namespace time_literals;
@@ -107,6 +108,11 @@ private:
 		Stationary
 	};
 
+	enum class ApproachMode {
+		Centered = 0,
+		Aligned
+	};
+
 	/**
 	* Handles for parameters
 	**/
@@ -118,6 +124,11 @@ private:
 		param_t mode;
 		param_t scale_x;
 		param_t scale_y;
+		param_t appr_mode;
+		param_t offset_x;
+		param_t offset_y;
+		param_t offset_z;
+		param_t sensor_yaw;
 	} _paramHandle;
 
 	struct {
@@ -128,6 +139,11 @@ private:
 		TargetMode mode;
 		float scale_x;
 		float scale_y;
+		ApproachMode appr_mode;
+		float offset_x;
+		float offset_y;
+		float offset_z;
+		enum Rotation sensor_yaw;
 	} _params;
 
 	uORB::Subscription _vehicleLocalPositionSub{ORB_ID(vehicle_local_position)};
@@ -149,7 +165,8 @@ private:
 	// keep track of whether last measurement was rejected
 	bool _faulty{false};
 
-	matrix::Dcmf _R_att;
+	matrix::Dcmf _R_att; //Orientation of the body frame
+	matrix::Dcmf _S_att; //Orientation of the sensor relative to body frame
 	matrix::Vector2f _rel_pos;
 	KalmanFilter _kalman_filter_x;
 	KalmanFilter _kalman_filter_y;

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -133,22 +133,6 @@ PARAM_DEFINE_FLOAT(LTEST_SCALE_X, 1.0f);
  */
 PARAM_DEFINE_FLOAT(LTEST_SCALE_Y, 1.0f);
 
-/**
- * Landing Approach Mode
- *
- * Configure the mode of the landing approach. Depending on the mode, the aircraft positions itself relative to the beacon differently.
- *
- * Mode Centered: The aircraft aligns its center (body frame) with the beacon according to LTEST_SENS_POS_X and LTEST_SENS_POS_Y
- * Mode Aligned: The aircraft aligns the sensor with the beacon
- *
- * @min 0
- * @max 1
- * @value 0 Centered
- * @value 1 Aligned
- * @group Landing Target Estimator
- */
-PARAM_DEFINE_INT32(LTEST_APPR_MODE, 0);
-
 
 /**
  * Rotation of IRLOCK sensor relative to airframe

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -132,3 +132,74 @@ PARAM_DEFINE_FLOAT(LTEST_SCALE_X, 1.0f);
  * @group Landing target Estimator
  */
 PARAM_DEFINE_FLOAT(LTEST_SCALE_Y, 1.0f);
+
+/**
+ * Landing Approach Mode 
+ * 
+ * Configure the mode of the landing approach. Depending on the mode, the aircraft positions itself relative to the beacon differently.
+ * 
+ * Mode Centered: The aircraft aligns its center (body frame) with the beacon according to LTEST_SENS_POS_X and LTEST_SENS_POS_Y
+ * Mode Aligned: The aircraft aligns the sensor with the beacon
+ * 
+ * @min 0
+ * @max 1
+ * @value 0 Centered
+ * @value 1 Aligned
+ * @group Landing Target Estimator
+ */
+PARAM_DEFINE_INT32(LTEST_APPR_MODE, 1);
+
+
+/**
+ * Rotation of IRLOCK sensor relative to airframe
+ * 
+ * Default orientation of Yaw 90°
+ * 
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * 
+ * @min -1
+ * @max 40
+ * @reboot_required true
+ * @group Landing Target Estimator
+ */
+PARAM_DEFINE_INT32(LTEST_SENS_ROT, 2);
+
+/**
+ * X Position of IRLOCK in body frame (forward)
+ * 
+ * @reboot_required true
+ * @unit m
+ * @decimal 3
+ * @group Landing Target Estimator
+ * 
+ */
+PARAM_DEFINE_FLOAT(LTEST_SENS_POS_X, 0.3);
+
+/**
+ * Y Position of IRLOCK in body frame (right)
+ * 
+ * @reboot_required true
+ * @unit m
+ * @decimal 3
+ * @group Landing Target Estimator
+ * 
+ */
+PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Y, 0.3);
+
+/**
+ * Z Position of IRLOCK in body frame (downward)
+ * 
+ * @reboot_required true
+ * @unit m
+ * @decimal 3
+ * @group Landing Target Estimator
+ * 
+ */
+PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Z, 0.3);

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -134,13 +134,13 @@ PARAM_DEFINE_FLOAT(LTEST_SCALE_X, 1.0f);
 PARAM_DEFINE_FLOAT(LTEST_SCALE_Y, 1.0f);
 
 /**
- * Landing Approach Mode 
- * 
+ * Landing Approach Mode
+ *
  * Configure the mode of the landing approach. Depending on the mode, the aircraft positions itself relative to the beacon differently.
- * 
+ *
  * Mode Centered: The aircraft aligns its center (body frame) with the beacon according to LTEST_SENS_POS_X and LTEST_SENS_POS_Y
  * Mode Aligned: The aircraft aligns the sensor with the beacon
- * 
+ *
  * @min 0
  * @max 1
  * @value 0 Centered
@@ -152,9 +152,9 @@ PARAM_DEFINE_INT32(LTEST_APPR_MODE, 0);
 
 /**
  * Rotation of IRLOCK sensor relative to airframe
- * 
+ *
  * Default orientation of Yaw 90°
- * 
+ *
  * @value 0 No rotation
  * @value 1 Yaw 45°
  * @value 2 Yaw 90°
@@ -163,7 +163,7 @@ PARAM_DEFINE_INT32(LTEST_APPR_MODE, 0);
  * @value 5 Yaw 225°
  * @value 6 Yaw 270°
  * @value 7 Yaw 315°
- * 
+ *
  * @min -1
  * @max 40
  * @reboot_required true
@@ -173,33 +173,33 @@ PARAM_DEFINE_INT32(LTEST_SENS_ROT, 2);
 
 /**
  * X Position of IRLOCK in body frame (forward)
- * 
+ *
  * @reboot_required true
  * @unit m
  * @decimal 3
  * @group Landing Target Estimator
- * 
+ *
  */
 PARAM_DEFINE_FLOAT(LTEST_SENS_POS_X, 0.0f);
 
 /**
  * Y Position of IRLOCK in body frame (right)
- * 
+ *
  * @reboot_required true
  * @unit m
  * @decimal 3
  * @group Landing Target Estimator
- * 
+ *
  */
 PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Y, 0.0f);
 
 /**
  * Z Position of IRLOCK in body frame (downward)
- * 
+ *
  * @reboot_required true
  * @unit m
  * @decimal 3
  * @group Landing Target Estimator
- * 
+ *
  */
 PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Z, 0.0f);

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -147,7 +147,7 @@ PARAM_DEFINE_FLOAT(LTEST_SCALE_Y, 1.0f);
  * @value 1 Aligned
  * @group Landing Target Estimator
  */
-PARAM_DEFINE_INT32(LTEST_APPR_MODE, 1);
+PARAM_DEFINE_INT32(LTEST_APPR_MODE, 0);
 
 
 /**
@@ -180,7 +180,7 @@ PARAM_DEFINE_INT32(LTEST_SENS_ROT, 2);
  * @group Landing Target Estimator
  * 
  */
-PARAM_DEFINE_FLOAT(LTEST_SENS_POS_X, 0.3);
+PARAM_DEFINE_FLOAT(LTEST_SENS_POS_X, 0.0f);
 
 /**
  * Y Position of IRLOCK in body frame (right)
@@ -191,7 +191,7 @@ PARAM_DEFINE_FLOAT(LTEST_SENS_POS_X, 0.3);
  * @group Landing Target Estimator
  * 
  */
-PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Y, 0.3);
+PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Y, 0.0f);
 
 /**
  * Z Position of IRLOCK in body frame (downward)
@@ -202,4 +202,4 @@ PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Y, 0.3);
  * @group Landing Target Estimator
  * 
  */
-PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Z, 0.3);
+PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Z, 0.0f);


### PR DESCRIPTION
**Describe problem solved by this pull request**

Hello all, We are currently working on a drone delivery project where we are planning to use the IR-LOCK for fine tuning the cargo delivery. However, the current `landing_target_estimator` module works under the assumption that the IRLOCK's camera frame has a specific orientation and position relative to the body frame.

In our drone frame it will not be possible to position the camera like this, so it would be nice to specify the camera's orientation and position relative to the body frame as parameters (as mentioned in a "todo" comment on the aforementioned module). We thought this could be a useful feature for other users

**Describe your solution**

We have defined four additional parameters:
- **LTEST_SENS_ROT**: The yaw of the camera relative to body frame (defaults to 90º)
- **LTEST_SENS_POS_X**: X offset to body frame
- **LTEST_SENS_POS_Y**: Y offset to body frame
- **LTEST_SENS_POS_Z**: Z offset to body frame

Regarding the source code, our approach is simple and consists of:

1. Reading the rotation from the `LTEST_SENS_ROT` parameter and from it compute the rotation matrix between the camera and body frame 
2. Multiplying the rotation matrix obtained from the attitude of the drone with the one obtained in a previous step in order to compute the orientation in the reference frame and multiply it by the sensor ray coordinates.
3. Compute the coordinates of the target pose taking into account that `LTEST_SENS_POS_Z` must be subtracted fron the distance to ground `dist`.
4. `LTEST_SENS_POS_X` and `LTEST_SENS_POS_Y` offsets are added to the relative pose of the beacon

**Describe possible alternatives**

A design choice that must be considered is whether the `x/y_rel` is relative to the camera or the body frame, we have opted for it to be relative to the body frame.

It can also be desired to align the camera to the beacon instead of the body frame, we had begun implementing this in `abdff6d` but have opted to remove it for the sake of simplicity.

We are also interested in discussing alternatives as we are relatively new to the PX4 ecosystem!

**Test data / coverage**

For now,  testing consisted only of SITL simulation using the `gazebo_iris_irlock` environment with different IRLOCK poses specified in the `iris_irlock.sdf` model file. We plan to further test our approach in simulation using both stationary and moving targets.

We are currently in the process of assembling our drone so unfortunately no flight data is available atm

**Additional context**

CC @matheus-ps
