### PR TITLE
NotchFilter push initialization/reset into filter

### DIFF
--- a/src/lib/mathlib/math/filter/NotchFilter.hpp
+++ b/src/lib/mathlib/math/filter/NotchFilter.hpp
@@ -128,6 +128,8 @@ public:
 		_b2 = b[2];
 	}
 
+	bool initialized() const { return _initialized; }
+
 	void reset() { _initialized = false; }
 
 	void reset(const T &sample)
@@ -150,11 +152,6 @@ public:
 		_notch_freq = 0.f;
 		_bandwidth = 0.f;
 		_sample_freq = 0.f;
-
-		_delay_element_1 = {};
-		_delay_element_2 = {};
-		_delay_element_output_1 = {};
-		_delay_element_output_2 = {};
 
 		_b0 = 1.f;
 		_b1 = 0.f;

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -171,7 +171,7 @@ void VehicleAngularVelocity::ResetFilters()
 			// angular velocity notch
 			_notch_filter_velocity[axis].setParameters(_filter_sample_rate_hz, _param_imu_gyro_nf_freq.get(),
 					_param_imu_gyro_nf_bw.get());
-			_notch_filter_velocity[axis].reset(angular_velocity_uncalibrated(axis));
+			_notch_filter_velocity[axis].reset();
 
 			// angular acceleration low pass
 			if ((_param_imu_dgyro_cutoff.get() > 0.f)
@@ -548,11 +548,9 @@ void VehicleAngularVelocity::UpdateDynamicNotchEscRpm(bool force)
 					}
 
 					if (reset) {
-						const Vector3f reset_angular_velocity{GetResetAngularVelocity()};
-
 						for (int axis = 0; axis < 3; axis++) {
 							for (int harmonic = 0; harmonic < MAX_NUM_ESC_RPM_HARMONICS; harmonic++) {
-								_dynamic_notch_filter_esc_rpm[axis][esc][harmonic].reset(reset_angular_velocity(axis));
+								_dynamic_notch_filter_esc_rpm[axis][esc][harmonic].reset();
 							}
 						}
 
@@ -633,8 +631,7 @@ void VehicleAngularVelocity::UpdateDynamicNotchFFT(bool force)
 
 						// force reset if the notch frequency jumps significantly
 						if (force || reset || (notch_freq_diff > bandwidth)) {
-							const Vector3f reset_angular_velocity{GetResetAngularVelocity()};
-							nf.reset(reset_angular_velocity(axis));
+							nf.reset();
 							perf_count(_dynamic_notch_filter_fft_reset_perf);
 						}
 

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -156,11 +156,9 @@ private:
 	hrt_abstime _last_esc_rpm_notch_update[MAX_NUM_ESC_RPM] {};
 
 	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
-	perf_counter_t _dynamic_notch_filter_esc_rpm_reset_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_disable_perf{nullptr};
 
 	perf_counter_t _dynamic_notch_filter_fft_disable_perf{nullptr};
-	perf_counter_t _dynamic_notch_filter_fft_reset_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_fft_update_perf{nullptr};
 
 	bool _dynamic_notch_esc_rpm_available{false};

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -86,11 +86,11 @@ private:
 	void DisableDynamicNotchFFT();
 	void ParametersUpdate(bool force = false);
 
-	void ResetFilters();
+	void ResetFilters(const hrt_abstime &time_now_us);
 	void SensorBiasUpdate(bool force = false);
-	bool SensorSelectionUpdate(bool force = false);
-	void UpdateDynamicNotchEscRpm(bool force = false);
-	void UpdateDynamicNotchFFT(bool force = false);
+	bool SensorSelectionUpdate(const hrt_abstime &time_now_us, bool force = false);
+	void UpdateDynamicNotchEscRpm(const hrt_abstime &time_now_us, bool force = false);
+	void UpdateDynamicNotchFFT(const hrt_abstime &time_now_us, bool force = false);
 	bool UpdateSampleRate();
 
 	// scaled appropriately for current sensor


### PR DESCRIPTION
 - this simplifies the reset by allowing a notch filter to reset as needed
 - improves cascade initialization, on reset each filter will reset properly from the output of the previous
 - reset conditions can be handled more intelligently internally (eg decide to reset if only the notch frequency moves sufficiently)

TODO:
 - [ ] test performance implications (RPM filtering, FFT filtering)