### PR TITLE
sitl config: put model name first

### DIFF
--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo",   model: "iris"          } # Alaska
-          - {latitude: "-38.071235", longitude:  "145.281220", altitude:  "31", build_type: "AddressSanitizer", model: "standard_vtol" } # Australia
-          - {latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo",   model: "tailsitter"    } # Florida
-          - {latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage",         model: "standard_vtol" } # Zurich
+          - {model: "iris",          latitude:  "59.617693", longitude: "-151.145316", altitude:  "48", build_type: "RelWithDebInfo" } # Alaska
+          - {model: "standard_vtol", latitude: "-38.071235", longitude:  "145.281220", altitude:  "31", build_type: "AddressSanitizer" } # Australia
+          - {model: "tailsitter" ,   latitude:  "29.660316", longitude:  "-82.316658", altitude:  "30", build_type: "RelWithDebInfo" } # Florida
+          - {model: "standard_vtol", latitude:  "47.397742", longitude:    "8.545594", altitude: "488", build_type: "Coverage" } # Zurich
 
     container:
       image: px4io/px4-dev-simulation-focal:2021-09-08


### PR DESCRIPTION
Github constructs the workflow names from the matrix configurations. Having latitude and longitude in the fist columns makes these names rather cryptic.

This is what the workflow looks like now in the github actions tab:
![image](https://user-images.githubusercontent.com/3762382/147054658-59a1852d-1afb-4ec4-8213-962b19dd3355.png)
