### PR TITLE
WorkQueueManager: explicitly convert PTHREAD_STACK_MIN to int 

### DIFF
--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -268,7 +268,7 @@ WorkQueueManagerRun(int, char **)
 			// On posix system , the desired stacksize round to the nearest multiplier of the system pagesize
 			// It is a requirement of the  pthread_attr_setstacksize* function
 			const unsigned int page_size = sysconf(_SC_PAGESIZE);
-			const size_t stacksize_adj = math::max(PTHREAD_STACK_MIN, PX4_STACK_ADJUSTED(wq->stacksize));
+			const size_t stacksize_adj = math::max((int)PTHREAD_STACK_MIN, PX4_STACK_ADJUSTED(wq->stacksize));
 			const size_t stacksize = (stacksize_adj + page_size - (stacksize_adj % page_size));
 #endif
 

--- a/src/modules/mavlink/streams/ACTUATOR_CONTROL_TARGET.hpp
+++ b/src/modules/mavlink/streams/ACTUATOR_CONTROL_TARGET.hpp
@@ -57,6 +57,8 @@ public:
 		case 3:
 			return "ACTUATOR_CONTROL_TARGET3";
 		}
+
+		return "ACTUATOR_CONTROL_TARGET";
 	}
 
 	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_ACTUATOR_CONTROL_TARGET; }

--- a/src/modules/mavlink/streams/SERVO_OUTPUT_RAW.hpp
+++ b/src/modules/mavlink/streams/SERVO_OUTPUT_RAW.hpp
@@ -51,6 +51,8 @@ public:
 		case 1:
 			return "SERVO_OUTPUT_RAW_1";
 		}
+
+		return "SERVO_OUTPUT_RAW";
 	}
 
 	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_SERVO_OUTPUT_RAW; }


### PR DESCRIPTION
- fixes a compiler error on GCC 11.2.1: `error: no matching function for call to ‘max(long int, int)’`
- mavlink streams: add return in all cases 