### PR TITLE
Commander: avoid RC actions during calibration

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -30,7 +30,7 @@ bool circuit_breaker_vtol_fw_arming_check 	# set to true if for VTOLs arming in 
 bool offboard_control_signal_lost
 
 bool rc_signal_found_once
-bool rc_input_blocked                                # set if RC input should be ignored temporarily
+bool rc_calibration_in_progress
 bool rc_calibration_valid                            # set if RC calibration is valid
 bool vtol_transition_failure                        # Set to true if vtol transition failed
 bool usb_connected                                # status of the USB power supply


### PR DESCRIPTION
**Describe problem solved by this pull request**
Before https://github.com/PX4/PX4-Autopilot/pull/17404 special handling of RC actions namely arming, modes switching and override during RC calibration was done through the `ManualControl::setRCAllowed()` in the class within commander. Listening to the `vehicle_status_flags.rc_input_blocked` flag was kept intact for the override but not for arming and mode switching.

**Describe your solution**
I rename the flag `vehicle_status_flags.rc_input_blocked` to `rc_calibration_in_progress` to avoid any ambiguity and guard the execution of RC-initiated actions during RC calibration.

**Test data / coverage**
I bench tested this on a pixracer with TBS Crossfire SBUS concentrating on holding the already calibrated arm gesture for a long time and also moving the already configured mode switch during calibration because that's what triggered the actions before.