### PR TITLE
ROMFS: rcS dump parameter backup contents before using

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -179,6 +179,11 @@ else
 		# try importing from backup file
 		if [ -f "/fs/microsd/parameters_backup.bson" ]
 		then
+			echo "[init] importing from parameter backup"
+
+			# dump current backup file contents for comparison
+			param dump /fs/microsd/parameters_backup.bson
+
 			param import /fs/microsd/parameters_backup.bson
 		fi
 	fi

--- a/Tools/HIL/test_airframes.sh
+++ b/Tools/HIL/test_airframes.sh
@@ -29,6 +29,8 @@ do
 	${DIR}/nsh_param_set.py --device ${SERIAL_DEVICE} --name SYS_AUTOSTART  --value $airframe
 	${DIR}/nsh_param_set.py --device ${SERIAL_DEVICE} --name CBRK_BUZZER    --value 782097
 	${DIR}/run_nsh_cmd.py --device ${SERIAL_DEVICE} --cmd 'param reset SYS_HITL'
+	${DIR}/run_nsh_cmd.py --device ${SERIAL_DEVICE} --cmd 'param dump'
+	${DIR}/run_nsh_cmd.py --device ${SERIAL_DEVICE} --cmd 'param status'
 	${DIR}/run_nsh_cmd.py --device ${SERIAL_DEVICE} --cmd 'param save'
 
 	${DIR}/reboot.py --device ${SERIAL_DEVICE}

--- a/src/lib/parameters/tinybson/tinybson.cpp
+++ b/src/lib/parameters/tinybson/tinybson.cpp
@@ -239,6 +239,7 @@ bson_decoder_next(bson_decoder_t decoder)
 
 		for (;;) {
 			if (nlen >= BSON_MAXNAME) {
+				PX4_ERR("node name overflow, type:0x%02x, name:%.32s", decoder->node.type, decoder->node.name);
 				CODER_KILL(decoder, "node name overflow");
 			}
 


### PR DESCRIPTION
 - this is mainly for debug comparison

Parameter import failure on the test rack. http://px4-jenkins.dagar.ca:8080/blue/organizations/jenkins/PX4-Autopilot/detail/pr-update_platforms%2Fnuttx%2FNuttX%2Fnuttx/15/pipeline/1951/
![Screenshot from 2021-12-23 14-25-41](https://user-images.githubusercontent.com/84712/147284096-390c527f-13f5-4176-9168-efdeb7006755.png)

