### PR TITLE
lib/sensor_calibration: don't save uninitialized priority parameter immediately

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.cpp
+++ b/src/lib/sensor_calibration/Accelerometer.cpp
@@ -203,9 +203,10 @@ void Accelerometer::ParametersUpdate()
 			if (_priority != -1) {
 				PX4_ERR("%s %" PRIu32 " (%" PRId8 ") invalid priority %" PRId32 ", resetting to %" PRId32, SensorString(), _device_id,
 					_calibration_index, _priority, new_priority);
+
+				SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			}
 
-			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			_priority = new_priority;
 		}
 

--- a/src/lib/sensor_calibration/Gyroscope.cpp
+++ b/src/lib/sensor_calibration/Gyroscope.cpp
@@ -188,9 +188,10 @@ void Gyroscope::ParametersUpdate()
 			if (_priority != -1) {
 				PX4_ERR("%s %" PRIu32 " (%" PRId8 ") invalid priority %" PRId32 ", resetting to %" PRId32, SensorString(), _device_id,
 					_calibration_index, _priority, new_priority);
+
+				SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			}
 
-			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			_priority = new_priority;
 		}
 

--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -188,9 +188,10 @@ void Magnetometer::ParametersUpdate()
 			if (_priority != -1) {
 				PX4_ERR("%s %" PRIu32 " (%" PRId8 ") invalid priority %" PRId32 ", resetting to %" PRId32, SensorString(), _device_id,
 					_calibration_index, _priority, new_priority);
+
+				SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			}
 
-			SetCalibrationParam(SensorString(), "PRIO", _calibration_index, new_priority);
 			_priority = new_priority;
 		}
 


### PR DESCRIPTION
The sensor priority parameters underlying default value is -1 to indicate uninitialized. When a sensor calibration is first created it's then set to an appropriate default for internal vs external. This default doesn't need to be immediately written out to parameters immediately unless the value was invalid. The param save after a regular sensor calibration is when the priority will be exported.
![Screenshot from 2021-12-23 15-27-31](https://user-images.githubusercontent.com/84712/147288911-e0fe6d6a-c415-46c0-8ad3-261f612cc182.png)

