### PR TITLE
fix: use px4io/px4-dev-simulation-bionic:2021-02-04 docker container to execute "make tests" failed

### DIFF
--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -19,7 +19,7 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"
 	elif [[ $@ =~ .*tests* ]]; then
 		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2021-02-04"
+		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2021-12-11"
 	fi
 else
 	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";

--- a/src/modules/ekf2/test/CMakeLists.txt
+++ b/src/modules/ekf2/test/CMakeLists.txt
@@ -30,7 +30,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-add_compile_definitions(TEST_DATA_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
+add_definitions(-DTEST_DATA_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
 add_subdirectory(sensor_simulator)


### PR DESCRIPTION
Use px4io/px4-dev-simulation-bionic:2021-02-04 docker container to execute "make tests" failed.

The current docker image(px4-dev-simulation-bionic:2021-02-04) will cause "make tests" to fail: "kconfiglib is not installed or not in PATH", so update it's versions to 2021-12-11.

And the current basic image used by px4io/px4-dev-simulation-bionic is ubuntu18.04, the default version of cmake is 3.10, and the add_compile_definitions command is only available in cmake 3.12+(ubuntu 20.04), so use add_definitions instead of add_compile_definitions command.