### PR TITLE
I2CSPIDriverBase: sensor start failure ERROR if internal, WARN if external

### DIFF
--- a/boards/cuav/x7pro/init/rc.board_sensors
+++ b/boards/cuav/x7pro/init/rc.board_sensors
@@ -5,7 +5,7 @@
 board_adc start
 
 # SPI1
-if ! icm20689 -s -b 1 -R 2 start
+if ! icm20689 -s -b 1 -R 2 -q start
 then
 	adis16470 -s -b 1 -R 2 start
 fi

--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -17,7 +17,7 @@ pwm_out sensor_reset 50
 ms5611 -s start
 
 # hmc5883 internal SPI bus is rotated 90 deg yaw
-if ! hmc5883 -T -s -R 2 start
+if ! hmc5883 -T -s -R 2 -q start
 then
 	# lis3mdl internal SPI bus is rotated 90 deg yaw
 	lis3mdl -s start

--- a/boards/px4/fmu-v4pro/init/rc.board_sensors
+++ b/boards/px4/fmu-v4pro/init/rc.board_sensors
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 rgbled start -I
-rgbled_ncp5623c start -I
+rgbled_ncp5623c start -I -q
 
 board_adc start
 

--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -696,7 +696,14 @@ int I2CSPIDriverBase::module_start(const BusCLIArguments &cli, BusInstanceIterat
 	}
 
 	if (!started && !cli.quiet_start) {
-		PX4_WARN("%s: no instance started (no device on bus?)", px4_get_taskname());
+		static constexpr char no_instance_started[] {"no instance started (no device on bus?)"};
+
+		if (iterator.external()) {
+			PX4_WARN("%s: %s", px4_get_taskname(), no_instance_started);
+
+		} else {
+			PX4_ERR("%s: %s", px4_get_taskname(), no_instance_started);
+		}
 
 #if defined(CONFIG_I2C)
 


### PR DESCRIPTION
We need to get to the point where the failure of a known required sensor can't slip through.