### PR TITLE
ekf2: use delayed IMU timestamp for publication's timestamp_sample

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -667,7 +667,7 @@ void EKF2::PublishEventFlags(const hrt_abstime &timestamp)
 
 	if (information_event_updated || warning_event_updated) {
 		estimator_event_flags_s event_flags{};
-		event_flags.timestamp_sample = timestamp;
+		event_flags.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 
 		event_flags.information_event_changes           = _filter_information_event_changes;
 		event_flags.gps_checks_passed                   = _ekf.information_event_flags().gps_checks_passed;
@@ -752,7 +752,7 @@ void EKF2::PublishInnovations(const hrt_abstime &timestamp, const imuSample &imu
 {
 	// publish estimator innovation data
 	estimator_innovations_s innovations{};
-	innovations.timestamp_sample = timestamp;
+	innovations.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 	_ekf.getGpsVelPosInnov(innovations.gps_hvel, innovations.gps_vvel, innovations.gps_hpos, innovations.gps_vpos);
 	_ekf.getEvVelPosInnov(innovations.ev_hvel, innovations.ev_vvel, innovations.ev_hpos, innovations.ev_vpos);
 	_ekf.getBaroHgtInnov(innovations.baro_vpos);
@@ -787,7 +787,7 @@ void EKF2::PublishInnovationTestRatios(const hrt_abstime &timestamp)
 {
 	// publish estimator innovation test ratio data
 	estimator_innovations_s test_ratios{};
-	test_ratios.timestamp_sample = timestamp;
+	test_ratios.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 	_ekf.getGpsVelPosInnovRatio(test_ratios.gps_hvel[0], test_ratios.gps_vvel, test_ratios.gps_hpos[0],
 				    test_ratios.gps_vpos);
 	_ekf.getEvVelPosInnovRatio(test_ratios.ev_hvel[0], test_ratios.ev_vvel, test_ratios.ev_hpos[0], test_ratios.ev_vpos);
@@ -812,7 +812,7 @@ void EKF2::PublishInnovationVariances(const hrt_abstime &timestamp)
 {
 	// publish estimator innovation variance data
 	estimator_innovations_s variances{};
-	variances.timestamp_sample = timestamp;
+	variances.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 	_ekf.getGpsVelPosInnovVar(variances.gps_hvel, variances.gps_vvel, variances.gps_hpos, variances.gps_vpos);
 	_ekf.getEvVelPosInnovVar(variances.ev_hvel, variances.ev_vvel, variances.ev_hpos, variances.ev_vpos);
 	_ekf.getBaroHgtInnovVar(variances.baro_vpos);
@@ -1058,7 +1058,7 @@ void EKF2::PublishSensorBias(const hrt_abstime &timestamp)
 {
 	// estimator_sensor_bias
 	estimator_sensor_bias_s bias{};
-	bias.timestamp_sample = timestamp;
+	bias.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 
 	const Vector3f gyro_bias{_ekf.getGyroBias()};
 	const Vector3f accel_bias{_ekf.getAccelBias()};
@@ -1109,7 +1109,7 @@ void EKF2::PublishStates(const hrt_abstime &timestamp)
 {
 	// publish estimator states
 	estimator_states_s states;
-	states.timestamp_sample = timestamp;
+	states.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 	states.n_states = Ekf::_k_num_states;
 	_ekf.getStateAtFusionHorizonAsVector().copyTo(states.states);
 	_ekf.covariances_diagonal().copyTo(states.covariances);
@@ -1120,7 +1120,7 @@ void EKF2::PublishStates(const hrt_abstime &timestamp)
 void EKF2::PublishStatus(const hrt_abstime &timestamp)
 {
 	estimator_status_s status{};
-	status.timestamp_sample = timestamp;
+	status.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 
 	_ekf.getOutputTrackingError().copyTo(status.output_tracking_error);
 
@@ -1199,7 +1199,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 
 	if (update) {
 		estimator_status_flags_s status_flags{};
-		status_flags.timestamp_sample = timestamp;
+		status_flags.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 
 		status_flags.control_status_changes   = _filter_control_status_changes;
 		status_flags.cs_tilt_align            = _ekf.control_status_flags().tilt_align;
@@ -1297,7 +1297,7 @@ void EKF2::PublishWindEstimate(const hrt_abstime &timestamp)
 	if (_ekf.get_wind_status()) {
 		// Publish wind estimate only if ekf declares them valid
 		wind_s wind{};
-		wind.timestamp_sample = timestamp;
+		wind.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 
 		const Vector2f wind_vel = _ekf.getWindVelocity();
 		const Vector2f wind_vel_var = _ekf.getWindVelocityVariance();

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -261,7 +261,7 @@ bool EKF2Selector::UpdateErrorScores()
 
 		if (_instance[i].estimator_status_sub.update(&status)) {
 
-			_instance[i].timestamp_sample_last = status.timestamp_sample;
+			_instance[i].timestamp_last = status.timestamp;
 
 			_instance[i].accel_device_id = status.accel_device_id;
 			_instance[i].gyro_device_id = status.gyro_device_id;
@@ -302,14 +302,14 @@ bool EKF2Selector::UpdateErrorScores()
 			_instance[i].timeout = false;
 
 			if (!_instance[i].warning) {
-				_instance[i].time_last_no_warning = status.timestamp_sample;
+				_instance[i].time_last_no_warning = status.timestamp;
 			}
 
 			if (!PX4_ISFINITE(_instance[i].relative_test_ratio)) {
 				_instance[i].relative_test_ratio = 0;
 			}
 
-		} else if (!_instance[i].timeout && (hrt_elapsed_time(&_instance[i].timestamp_sample_last) > status_timeout)) {
+		} else if (!_instance[i].timeout && (hrt_elapsed_time(&_instance[i].timestamp_last) > status_timeout)) {
 			_instance[i].healthy.set_state_and_update(false, hrt_absolute_time());
 			_instance[i].timeout = true;
 		}
@@ -395,7 +395,7 @@ void EKF2Selector::PublishVehicleAttitude()
 		// ensure monotonically increasing timestamp_sample through reset, don't publish
 		//  estimator's attitude for system (vehicle_attitude) if it's stale
 		if ((attitude.timestamp_sample <= _attitude_last.timestamp_sample)
-		    || (attitude.timestamp_sample < _instance[_selected_instance].timestamp_sample_last)) {
+		    || (hrt_elapsed_time(&attitude.timestamp) > 10_ms)) {
 
 			publish = false;
 		}
@@ -497,7 +497,7 @@ void EKF2Selector::PublishVehicleLocalPosition()
 		// ensure monotonically increasing timestamp_sample through reset, don't publish
 		//  estimator's local position for system (vehicle_local_position) if it's stale
 		if ((local_position.timestamp_sample <= _local_position_last.timestamp_sample)
-		    || (local_position.timestamp_sample < _instance[_selected_instance].timestamp_sample_last)) {
+		    || (hrt_elapsed_time(&local_position.timestamp) > 20_ms)) {
 
 			publish = false;
 		}
@@ -536,7 +536,7 @@ void EKF2Selector::PublishVehicleOdometry()
 		// ensure monotonically increasing timestamp_sample through reset, don't publish
 		//  estimator's odometry for system (vehicle_odometry) if it's stale
 		if ((odometry.timestamp_sample <= _odometry_last.timestamp_sample)
-		    || (odometry.timestamp_sample < _instance[_selected_instance].timestamp_sample_last)) {
+		    || (hrt_elapsed_time(&odometry.timestamp) > 20_ms)) {
 
 			publish = false;
 		}
@@ -602,7 +602,7 @@ void EKF2Selector::PublishVehicleGlobalPosition()
 		// ensure monotonically increasing timestamp_sample through reset, don't publish
 		//  estimator's global position for system (vehicle_global_position) if it's stale
 		if ((global_position.timestamp_sample <= _global_position_last.timestamp_sample)
-		    || (global_position.timestamp_sample < _instance[_selected_instance].timestamp_sample_last)) {
+		    || (hrt_elapsed_time(&global_position.timestamp) > 20_ms)) {
 
 			publish = false;
 		}
@@ -633,7 +633,7 @@ void EKF2Selector::PublishWindEstimate()
 		// ensure monotonically increasing timestamp_sample through reset, don't publish
 		//  estimator's wind for system (wind) if it's stale
 		if ((wind.timestamp_sample <= _wind_last.timestamp_sample)
-		    || (wind.timestamp_sample < _instance[_selected_instance].timestamp_sample_last)) {
+		    || (hrt_elapsed_time(&wind.timestamp) > 100_ms)) {
 
 			publish = false;
 		}

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -120,7 +120,7 @@ private:
 		uORB::Subscription estimator_odometry_sub;
 		uORB::Subscription estimator_wind_sub;
 
-		uint64_t timestamp_sample_last{0};
+		uint64_t timestamp_last{0};
 
 		uint32_t accel_device_id{0};
 		uint32_t gyro_device_id{0};


### PR DESCRIPTION
 - use delayed IMU timestamp for the timestamp_sample in most EKF2 publications, except those from the output predictor (attitude, local_position, global_position).

This is a convenient way to more directly see the delayed time horizon.

``` Console
nsh> listener estimator_states

TOPIC: estimator_states 3 instances

Instance 0:
 estimator_states
    timestamp: 13760866 (0.009067 seconds ago)
    timestamp_sample: 13648974 (111892 us before timestamp)
    states: [0.9310, 0.0173, 0.0062, -0.3645, 0.0008, -0.0003, -0.1048, 0.0016, 0.0000, -0.2949, 0.0000, 0.0000, 0.0000, 0.0001, -0.0001, -0.0022, 0.0911, -0.0000, 0.2883, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
    covariances: [0.0000, 0.0001, 0.0001, 0.0002, 0.0060, 0.0060, 0.0937, 0.0038, 0.0038, 0.7124, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
    n_states: 24


Instance 1:
 estimator_states
    timestamp: 13774615 (0.001781 seconds ago)
    timestamp_sample: 13660063 (114552 us before timestamp)
    states: [0.9205, 0.0100, 0.0004, -0.3905, -0.0007, 0.0001, -0.0555, -0.0001, 0.0001, -0.2031, -0.0000, 0.0000, 0.0000, 0.0000, -0.0000, -0.0011, 0.0898, -0.0000, 0.2887, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
    covariances: [0.0000, 0.0001, 0.0001, 0.0001, 0.0061, 0.0061, 0.0940, 0.0040, 0.0040, 0.7178, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
    n_states: 24


Instance 2:
 estimator_states
    timestamp: 13773872 (0.008262 seconds ago)
    timestamp_sample: 13662373 (111499 us before timestamp)
    states: [0.9281, 0.0132, 0.0096, -0.3718, 0.0012, 0.0002, -0.0519, 0.0007, 0.0001, -0.1915, -0.0000, 0.0000, 0.0000, 0.0000, -0.0000, -0.0009, 0.0953, 0.0000, 0.2869, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
    covariances: [0.0000, 0.0001, 0.0001, 0.0002, 0.0068, 0.0068, 0.0946, 0.0047, 0.0047, 0.7170, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]
    n_states: 24




nsh> listener estimator_attitude

TOPIC: estimator_attitude 3 instances

Instance 0:
 estimator_attitude
    timestamp: 21880997 (0.000574 seconds ago)
    timestamp_sample: 21880405 (592 us before timestamp)
    q: [0.9320, 0.0174, 0.0063, -0.3618] (Roll: 1.6 deg, Pitch: 1.4 deg, Yaw: -42.4 deg)
    delta_q_reset: [0.9996, 0.0000, 0.0000, 0.0259]
    quat_reset_counter: 2


Instance 1:
 estimator_attitude
    timestamp: 21885095 (0.000432 seconds ago)
    timestamp_sample: 21884678 (417 us before timestamp)
    q: [0.9212, 0.0099, 0.0003, -0.3889] (Roll: 1.0 deg, Pitch: 0.4 deg, Yaw: -45.8 deg)
    delta_q_reset: [0.9996, 0.0000, 0.0000, 0.0272]
    quat_reset_counter: 2


Instance 2:
 estimator_attitude
    timestamp: 21886987 (0.001541 seconds ago)
    timestamp_sample: 21886373 (614 us before timestamp)
    q: [0.9286, 0.0131, 0.0097, -0.3707] (Roll: 0.9 deg, Pitch: 1.6 deg, Yaw: -43.5 deg)
    delta_q_reset: [0.9996, 0.0000, -0.0000, 0.0270]
    quat_reset_counter: 2
```