### PR TITLE
parameters: require valid BSON document size

### DIFF
--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1355,7 +1355,13 @@ static int param_verify(int fd)
 		} while (result > 0);
 
 		if (result == 0) {
-			return 0;
+			if (decoder.total_document_size != decoder.total_decoded_size) {
+				PX4_ERR("BSON document size (%" PRId32 ") doesn't match bytes decoded (%" PRId32 ")", decoder.total_document_size,
+					decoder.total_decoded_size);
+
+			} else {
+				return 0;
+			}
 
 		} else if (result == -ENODATA) {
 			PX4_ERR("verify: no BSON data");
@@ -1613,11 +1619,17 @@ param_import_internal(int fd)
 			} while (result > 0);
 
 			if (result == 0) {
-				PX4_INFO("BSON document size %" PRId32 " bytes, decoded %" PRId32 " bytes (INT32:%" PRIu16 ", FLOAT:%" PRIu16 ")",
-					 decoder.total_document_size, decoder.total_decoded_size,
-					 decoder.count_node_int32, decoder.count_node_double);
+				if (decoder.total_document_size == decoder.total_decoded_size) {
+					PX4_INFO("BSON document size %" PRId32 " bytes, decoded %" PRId32 " bytes (INT32:%" PRIu16 ", FLOAT:%" PRIu16 ")",
+						 decoder.total_document_size, decoder.total_decoded_size,
+						 decoder.count_node_int32, decoder.count_node_double);
 
-				return 0;
+					return 0;
+
+				} else {
+					PX4_ERR("BSON document size (%" PRId32 ") doesn't match bytes decoded (%" PRId32 ")",
+						decoder.total_document_size, decoder.total_decoded_size);
+				}
 
 			} else if (result == -ENODATA) {
 				// silently retry as a precaution unless this is our last attempt


### PR DESCRIPTION
The BSON document size is the first int32 in the file. This needs to match the total number of bytes read until the end of the document to be valid.

Parameter import failure on the test rack px4_fmu-v4pro (these are rare, but do happen). http://px4-jenkins.dagar.ca:8080/blue/organizations/jenkins/PX4-Autopilot/detail/pr-update_src%2Fdrivers%2Fuavcan_v1%2Flibcanard/52/pipeline

 - parameters were set (verified via param dump)
 - `param save` issued
 - after reboot the system has 0 parameters imported
    - this could happen if reading from mtd_params returns nothing but zeros (0 document size (int32_t) followed by BSON EOO)

![Screenshot from 2021-12-30 11-13-28](https://user-images.githubusercontent.com/84712/147769048-d3b6f481-80bc-42c8-ba05-02ef5b9648fe.png)

