### PR TITLE
parameters: fix export shutdown locking

### DIFF
--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -143,12 +143,6 @@ out:
 
 		size_t buf_size = bson_encoder_buf_size(&encoder);
 
-		int shutdown_lock_ret = px4_shutdown_lock();
-
-		if (shutdown_lock_ret) {
-			PX4_ERR("px4_shutdown_lock() failed (%i)", shutdown_lock_ret);
-		}
-
 		/* Get a buffer from the flash driver with enough space */
 
 		uint8_t *buffer;
@@ -177,11 +171,6 @@ out:
 			free(enc_buff);
 			parameter_flashfs_free();
 		}
-
-		if (shutdown_lock_ret == 0) {
-			px4_shutdown_unlock();
-		}
-
 	}
 
 	return result;

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -106,7 +106,7 @@ param_export_internal(param_filter_func filter)
 		case PARAM_TYPE_INT32:
 			i = s->val.i;
 
-			if (bson_encoder_append_int(&encoder, param_name(s->param), i)) {
+			if (bson_encoder_append_int32(&encoder, param_name(s->param), i)) {
 				debug("BSON append failed for '%s'", param_name(s->param));
 				goto out;
 			}

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -317,12 +317,12 @@ __EXPORT void		param_reset_specific(const char *resets[], int num_resets);
  * Export changed parameters to a file.
  * Note: this method requires a large amount of stack size!
  *
- * @param fd		File descriptor to export to (-1 selects the FLASH storage).
+ * @param filename	Path to the default parameter file.
  * @param filter	Filter parameters to be exported. The method should return true if
  * 			the parameter should be exported. No filtering if nullptr is passed.
  * @return		Zero on success, nonzero on failure.
  */
-__EXPORT int		param_export(int fd, param_filter_func filter);
+__EXPORT int		param_export(const char *filename, param_filter_func filter);
 
 /**
  * Import parameters from a file, discarding any unrecognized parameters.

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1244,12 +1244,17 @@ int param_save_default()
 
 			if (fd_backup_file > -1) {
 				int backup_export_ret = param_export_internal(fd_backup_file, nullptr);
+				::close(fd_backup_file);
 
 				if (backup_export_ret != 0) {
 					PX4_ERR("backup parameter export to %s failed (%d)", param_backup_file, backup_export_ret);
-				}
 
-				::close(fd_backup_file);
+				} else {
+					// verify export
+					int fd_verify = ::open(param_backup_file, O_RDONLY, PX4_O_MODE_666);
+					param_verify(fd_verify);
+					::close(fd_verify);
+				}
 			}
 		}
 	}

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1503,7 +1503,7 @@ static int param_export_internal(int fd, param_filter_func filter)
 				const int32_t i = s->val.i;
 				PX4_DEBUG("exporting: %s (%d) size: %lu val: %" PRIi32, name, s->param, (long unsigned int)size, i);
 
-				if (bson_encoder_append_int(&encoder, name, i) != 0) {
+				if (bson_encoder_append_int32(&encoder, name, i) != 0) {
 					PX4_ERR("BSON append failed for '%s'", name);
 					goto out;
 				}

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1176,61 +1176,89 @@ const char *param_get_backup_file()
 	return param_backup_file;
 }
 
-static int param_save_file_internal(const char *filename)
-{
-	int res = PX4_ERROR;
-	int attempts = 5;
-
-	while (res != OK && attempts > 0) {
-		// write parameters to file
-		int fd = ::open(filename, O_RDWR | O_CREAT, PX4_O_MODE_666);
-
-		if (fd > -1) {
-			res = param_export(fd, nullptr);
-			::close(fd);
-
-			if (res == PX4_OK) {
-				return PX4_OK;
-
-			} else {
-				PX4_ERR("param_export failed, retrying %d", attempts);
-				px4_usleep(10000); // wait at least 10 milliseconds before trying again
-			}
-
-		} else {
-			PX4_ERR("failed to open param file %s, retrying %d", filename, attempts);
-		}
-
-		attempts--;
-	}
-
-	if (res != OK) {
-		PX4_ERR("failed to write parameters to file: %s", filename);
-	}
-
-	return PX4_ERROR;
-}
+static int param_export_internal(int fd, param_filter_func filter);
+static int param_verify(int fd);
 
 int param_save_default()
 {
+	PX4_DEBUG("param_save_default");
+	int shutdown_lock_ret = px4_shutdown_lock();
+
+	if (shutdown_lock_ret != 0) {
+		PX4_ERR("px4_shutdown_lock() failed (%i)", shutdown_lock_ret);
+	}
+
+	// take the file lock
+	do {} while (px4_sem_wait(&param_sem_save) != 0);
+
+	param_lock_reader();
+
 	int res = PX4_ERROR;
 	const char *filename = param_get_default_file();
 
 	if (filename) {
-		res = param_save_file_internal(filename);
+		static constexpr int MAX_ATTEMPTS = 3;
+
+		for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+			// write parameters to file
+			int fd = ::open(filename, O_WRONLY | O_CREAT, PX4_O_MODE_666);
+
+			if (fd > -1) {
+				perf_begin(param_export_perf);
+				res = param_export_internal(fd, nullptr);
+				perf_end(param_export_perf);
+				::close(fd);
+
+				if (res == PX4_OK) {
+					// reopen file to verify
+					int fd_verify = ::open(filename, O_RDONLY, PX4_O_MODE_666);
+					res = param_verify(fd_verify);
+					::close(fd_verify);
+				}
+			}
+
+			if (res == PX4_OK) {
+				break;
+
+			} else {
+				PX4_ERR("parameter export to %s failed (%d) attempt %d", filename, res, attempt);
+				px4_usleep(10000); // wait at least 10 milliseconds before trying again
+			}
+		}
 
 	} else {
-		param_lock_writer();
 		perf_begin(param_export_perf);
 		res = flash_param_save(nullptr);
-		params_unsaved.reset();
 		perf_end(param_export_perf);
-		param_unlock_writer();
 	}
 
-	// backup file
-	if (param_backup_file) {
-		param_save_file_internal(param_backup_file);
+	if (res != PX4_OK) {
+		PX4_ERR("param export failed (%d)", res);
+
+	} else {
+		params_unsaved.reset();
+
+		// backup file
+		if (param_backup_file) {
+			int fd_backup_file = ::open(param_backup_file, O_WRONLY | O_CREAT, PX4_O_MODE_666);
+
+			if (fd_backup_file > -1) {
+				int backup_export_ret = param_export_internal(fd_backup_file, nullptr);
+
+				if (backup_export_ret != 0) {
+					PX4_ERR("backup parameter export to %s failed (%d)", param_backup_file, backup_export_ret);
+				}
+
+				::close(fd_backup_file);
+			}
+		}
+	}
+
+	param_unlock_reader();
+	px4_sem_post(&param_sem_save);
+
+	if (shutdown_lock_ret == 0) {
+		px4_shutdown_unlock();
 	}
 
 	return res;
@@ -1335,6 +1363,8 @@ static int param_verify_callback(bson_decoder_t decoder, bson_node_t node)
 
 static int param_verify(int fd)
 {
+	PX4_DEBUG("param_verify");
+
 	if (fd < 0) {
 		return -1;
 	}
@@ -1375,27 +1405,13 @@ static int param_verify(int fd)
 }
 
 int
-param_export(int fd, param_filter_func filter)
+param_export(const char *filename, param_filter_func filter)
 {
-	int result = -1;
-	perf_begin(param_export_perf);
-
-	if (fd < 0) {
-		param_lock_writer();
-		// flash_param_save() will take the shutdown lock
-		result = flash_param_save(filter);
-		params_unsaved.reset();
-		param_unlock_writer();
-		perf_end(param_export_perf);
-		return result;
-	}
-
-	param_wbuf_s *s = nullptr;
-	bson_encoder_s encoder{};
+	PX4_DEBUG("param_export");
 
 	int shutdown_lock_ret = px4_shutdown_lock();
 
-	if (shutdown_lock_ret) {
+	if (shutdown_lock_ret != 0) {
 		PX4_ERR("px4_shutdown_lock() failed (%i)", shutdown_lock_ret);
 	}
 
@@ -1404,10 +1420,41 @@ param_export(int fd, param_filter_func filter)
 
 	param_lock_reader();
 
+	int fd = ::open(filename, O_RDWR | O_CREAT, PX4_O_MODE_666);
+	int result = PX4_ERROR;
+
+	perf_begin(param_export_perf);
+
+	if (fd > -1) {
+		result = param_export_internal(fd, filter);
+
+	} else {
+		result = flash_param_save(filter);
+	}
+
+	perf_end(param_export_perf);
+
+	param_unlock_reader();
+	px4_sem_post(&param_sem_save);
+
+	if (shutdown_lock_ret == 0) {
+		px4_shutdown_unlock();
+	}
+
+	return result;
+}
+
+// internal parameter export, caller is responsible for locking
+static int param_export_internal(int fd, param_filter_func filter)
+{
+	PX4_DEBUG("param_export_internal");
+
+	int result = -1;
+	param_wbuf_s *s = nullptr;
+	bson_encoder_s encoder{};
 	uint8_t bson_buffer[256];
 
 	if (bson_encoder_init_buf_file(&encoder, fd, &bson_buffer, sizeof(bson_buffer)) != 0) {
-		result = -1;
 		goto out;
 	}
 
@@ -1484,32 +1531,11 @@ param_export(int fd, param_filter_func filter)
 out:
 
 	if (result == 0) {
-		if (bson_encoder_fini(&encoder) == PX4_OK) {
-			// verify exported bson
-			if (param_verify(fd) == 0) {
-				if (!filter) {
-					params_unsaved.reset();
-				}
-
-			} else {
-				result = -1;
-			}
-
-		} else {
+		if (bson_encoder_fini(&encoder) != PX4_OK) {
 			PX4_ERR("BSON encoder finalize failed");
 			result = -1;
 		}
 	}
-
-	param_unlock_reader();
-
-	px4_sem_post(&param_sem_save);
-
-	if (shutdown_lock_ret == 0) {
-		px4_shutdown_unlock();
-	}
-
-	perf_end(param_export_perf);
 
 	return result;
 }
@@ -1542,7 +1568,7 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 			if (param_type(param) == PARAM_TYPE_INT32) {
 				int32_t i = node->i32;
 				param_set_internal(param, &i, true, true);
-				PX4_DEBUG("Imported %s with value %d", param_name(param), i);
+				PX4_DEBUG("Imported %s with value %" PRIi32, param_name(param), i);
 
 			} else {
 				PX4_WARN("unexpected type for %s", node->name);
@@ -1639,18 +1665,20 @@ param_import_internal(int fd)
 				}
 
 			} else {
-				PX4_ERR("param import failed (%d) attempt %d, retrying", result, attempt);
+				PX4_ERR("param import failed (%d) attempt %d", result, attempt);
 			}
 
 		} else {
-			PX4_ERR("param import bson decoder init failed attempt %d, retrying", attempt);
+			PX4_ERR("param import bson decoder init failed (attempt %d)", attempt);
 		}
 
-		if (lseek(fd, 0, SEEK_SET) != 0) {
-			PX4_ERR("import lseek failed (%d)", errno);
-		}
+		if (attempt != MAX_ATTEMPTS) {
+			if (lseek(fd, 0, SEEK_SET) != 0) {
+				PX4_ERR("import lseek failed (%d)", errno);
+			}
 
-		px4_usleep(10000); // wait at least 10 milliseconds before trying again
+			px4_usleep(10000); // wait at least 10 milliseconds before trying again
+		}
 	}
 
 	return -1;

--- a/src/lib/parameters/tinybson/tinybson.cpp
+++ b/src/lib/parameters/tinybson/tinybson.cpp
@@ -575,28 +575,28 @@ int bson_encoder_append_bool(bson_encoder_t encoder, const char *name, bool valu
 }
 
 int
-bson_encoder_append_int(bson_encoder_t encoder, const char *name, int64_t value)
+bson_encoder_append_int32(bson_encoder_t encoder, const char *name, int32_t value)
 {
-	bool result;
-
 	CODER_CHECK(encoder);
 
-	/* use the smallest encoding that will hold the value */
-	if (value == (int32_t)value) {
-		debug("encoding %lld as int32", value);
-		result = write_int8(encoder, BSON_INT32) ||
-			 write_name(encoder, name) ||
-			 write_int32(encoder, value);
-
-	} else {
-		debug("encoding %lld as int64", value);
-		result = write_int8(encoder, BSON_INT64) ||
-			 write_name(encoder, name) ||
-			 write_int64(encoder, value);
+	if (write_int8(encoder, BSON_INT32) ||
+	    write_name(encoder, name) ||
+	    write_int32(encoder, value)) {
+		CODER_KILL(encoder, "write error on BSON_INT32");
 	}
 
-	if (result) {
-		CODER_KILL(encoder, "write error on BSON_INT");
+	return 0;
+}
+
+int
+bson_encoder_append_int64(bson_encoder_t encoder, const char *name, int64_t value)
+{
+	CODER_CHECK(encoder);
+
+	if (write_int8(encoder, BSON_INT64) ||
+	    write_name(encoder, name) ||
+	    write_int64(encoder, value)) {
+		CODER_KILL(encoder, "write error on BSON_INT64");
 	}
 
 	return 0;
@@ -612,7 +612,6 @@ bson_encoder_append_double(bson_encoder_t encoder, const char *name, double valu
 	    write_double(encoder, value)) {
 		CODER_KILL(encoder, "write error on BSON_DOUBLE");
 	}
-
 
 	return 0;
 }

--- a/src/lib/parameters/tinybson/tinybson.cpp
+++ b/src/lib/parameters/tinybson/tinybson.cpp
@@ -381,6 +381,7 @@ write_x(bson_encoder_t encoder, const void *p, size_t s)
 				break;
 
 			} else {
+				PX4_ERR("file write error %d, errno:%d (%s)", ret, errno, strerror(errno));
 				CODER_KILL(encoder, "file write error");
 			}
 		}

--- a/src/lib/parameters/tinybson/tinybson.h
+++ b/src/lib/parameters/tinybson/tinybson.h
@@ -256,13 +256,22 @@ __EXPORT void *bson_encoder_buf_data(bson_encoder_t encoder);
 __EXPORT int bson_encoder_append_bool(bson_encoder_t encoder, const char *name, bool value);
 
 /**
- * Append an integer to the encoded stream.
+ * Append an int32 to the encoded stream.
  *
  * @param encoder		Encoder state.
  * @param name			Node name.
  * @param value			Value to be encoded.
  */
-__EXPORT int bson_encoder_append_int(bson_encoder_t encoder, const char *name, int64_t value);
+__EXPORT int bson_encoder_append_int32(bson_encoder_t encoder, const char *name, int32_t value);
+
+/**
+ * Append an int64 to the encoded stream.
+ *
+ * @param encoder		Encoder state.
+ * @param name			Node name.
+ * @param value			Value to be encoded.
+ */
+__EXPORT int bson_encoder_append_int64(bson_encoder_t encoder, const char *name, int64_t value);
 
 /**
  * Append a double to the encoded stream

--- a/src/modules/commander/factory_calibration_storage.cpp
+++ b/src/modules/commander/factory_calibration_storage.cpp
@@ -59,17 +59,13 @@ FactoryCalibrationStorage::FactoryCalibrationStorage()
 
 int FactoryCalibrationStorage::open()
 {
-	if (_fd >= 0) {
-		cleanup();
-	}
-
 	if (!_enabled) {
 		return 0;
 	}
 
-	_fd = ::open(CALIBRATION_STORAGE, O_RDWR);
+	int ret = ::access(CALIBRATION_STORAGE, R_OK | W_OK);
 
-	if (_fd == -1) {
+	if (ret != 0) {
 		return -errno;
 	}
 
@@ -84,7 +80,7 @@ int FactoryCalibrationStorage::store()
 		return 0;
 	}
 
-	int ret = param_export(_fd, filter_calibration_params);
+	int ret = param_export(CALIBRATION_STORAGE, filter_calibration_params);
 
 	if (ret != 0) {
 		PX4_ERR("param export failed (%i)", ret);
@@ -97,11 +93,6 @@ void FactoryCalibrationStorage::cleanup()
 {
 	if (_enabled) {
 		param_control_autosave(true);
-	}
-
-	if (_fd >= 0) {
-		close(_fd);
-		_fd = -1;
 	}
 }
 

--- a/src/modules/commander/factory_calibration_storage.h
+++ b/src/modules/commander/factory_calibration_storage.h
@@ -60,5 +60,4 @@ private:
 	void cleanup();
 
 	bool _enabled{false};
-	int _fd{-1};
 };

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -433,21 +433,9 @@ param_main(int argc, char *argv[])
 static int
 do_save(const char *param_file_name)
 {
-	/* create the file */
-	int fd = open(param_file_name, O_RDWR | O_CREAT, PX4_O_MODE_666);
-
-	if (fd < 0) {
-		PX4_ERR("open '%s' failed (%i)", param_file_name, errno);
-		return 1;
-	}
-
-	int result = param_export(fd, nullptr);
-	close(fd);
+	int result = param_export(param_file_name, nullptr);
 
 	if (result < 0) {
-#ifndef __PX4_QURT
-		(void)unlink(param_file_name);
-#endif
 		PX4_ERR("exporting to '%s' failed (%i)", param_file_name, result);
 		return 1;
 	}

--- a/src/systemcmds/tests/test_bson.cpp
+++ b/src/systemcmds/tests/test_bson.cpp
@@ -65,12 +65,12 @@ encode(bson_encoder_t encoder)
 		return 1;
 	}
 
-	if (bson_encoder_append_int(encoder, "int1", sample_small_int) != 0) {
+	if (bson_encoder_append_int32(encoder, "int1", sample_small_int) != 0) {
 		PX4_ERR("FAIL: encoder: append int failed");
 		return 1;
 	}
 
-	if (bson_encoder_append_int(encoder, "int2", sample_big_int) != 0) {
+	if (bson_encoder_append_int64(encoder, "int2", sample_big_int) != 0) {
 		PX4_ERR("FAIL: encoder: append int failed");
 		return 1;
 	}

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -401,22 +401,13 @@ bool ParameterTest::exportImportAll()
 
 	// backup current parameters
 	const char *param_file_name = PX4_STORAGEDIR "/param_backup";
-	int fd = open(param_file_name, O_RDWR | O_CREAT, PX4_O_MODE_666);
 
-	if (fd < 0) {
-		PX4_ERR("open '%s' failed (%i)", param_file_name, errno);
-		return false;
-	}
-
-	int result = param_export(fd, nullptr);
+	int result = param_export(param_file_name, nullptr);
 
 	if (result != PX4_OK) {
 		PX4_ERR("param_export failed");
-		close(fd);
 		return false;
 	}
-
-	close(fd);
 
 	bool ret = true;
 
@@ -554,7 +545,7 @@ bool ParameterTest::exportImportAll()
 	param_reset_all();
 
 	// restore original params
-	fd = open(param_file_name, O_RDONLY);
+	int fd = open(param_file_name, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("open '%s' failed (%i)", param_file_name, errno);


### PR DESCRIPTION
In NuttX bchlib keeps a sector sized buffer that might not be written out to ramtron until the file is closed (depending on usage). This was also interfering with the recently add parameter verification functionality that was reading back after an export. Depending on the size of the parameters the verify read was only coming from the buffer rather than the underlying ramtron storage as intended.

As a result there can be final ramtron writes that happens outside of our px4 shutdown lock.
