### PR TITLE
Log vehicle local position setpoints for fixedwing position control

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -860,7 +860,9 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 		_att_sp.pitch_body = get_tecs_pitch();
 	}
 
-	publishLocalPositionSetpoint(current_sp);
+	if (!_vehicle_status.in_transition_to_fw) {
+		publishLocalPositionSetpoint(current_sp);
+	}
 }
 
 void
@@ -2238,18 +2240,29 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const hrt_abstime &now, flo
 	tecs_status_publish();
 }
 
-void FixedwingPositionControl::publishLocalPositionSetpoint(const position_setpoint_s current_waypoint)
+void FixedwingPositionControl::publishLocalPositionSetpoint(const position_setpoint_s &current_waypoint)
 {
 	if (_global_local_proj_ref.isInitialized()) {
 		Vector2f current_setpoint = _global_local_proj_ref.project(current_waypoint.lat, current_waypoint.lon);
 		vehicle_local_position_setpoint_s local_position_setpoint{};
+		local_position_setpoint.timestamp = hrt_absolute_time();
 		local_position_setpoint.x = current_setpoint(0);
 		local_position_setpoint.y = current_setpoint(1);
 		local_position_setpoint.z = _global_local_alt0 - current_waypoint.alt;
+		local_position_setpoint.yaw = NAN;
+		local_position_setpoint.yawspeed = NAN;
+		local_position_setpoint.vx = NAN;
+		local_position_setpoint.vy = NAN;
+		local_position_setpoint.vz = NAN;
+		local_position_setpoint.acceleration[0] = NAN;
+		local_position_setpoint.acceleration[1] = NAN;
+		local_position_setpoint.acceleration[2] = NAN;
+		local_position_setpoint.jerk[0] = NAN;
+		local_position_setpoint.jerk[1] = NAN;
+		local_position_setpoint.jerk[2] = NAN;
 		local_position_setpoint.thrust[0] = _att_sp.thrust_body[0];
 		local_position_setpoint.thrust[1] = _att_sp.thrust_body[1];
 		local_position_setpoint.thrust[2] = _att_sp.thrust_body[2];
-		local_position_setpoint.timestamp = hrt_absolute_time();
 		_local_pos_sp_pub.publish(local_position_setpoint);
 	}
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -154,6 +154,7 @@ private:
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	uORB::Publication<vehicle_attitude_setpoint_s>		_attitude_sp_pub;
+	uORB::Publication<vehicle_local_position_setpoint_s> 	_local_pos_sp_pub{ORB_ID(vehicle_local_position_setpoint)};	///< vehicle local position setpoint publication
 	uORB::Publication<position_controller_status_s>		_pos_ctrl_status_pub{ORB_ID(position_controller_status)};			///< navigation capabilities publication
 	uORB::Publication<position_controller_landing_status_s>	_pos_ctrl_landing_status_pub{ORB_ID(position_controller_landing_status)};	///< landing status publication
 	uORB::Publication<tecs_status_s>			_tecs_status_pub{ORB_ID(tecs_status)};						///< TECS status publication
@@ -285,6 +286,7 @@ private:
 	void		status_publish();
 	void		landing_status_publish();
 	void		tecs_status_publish();
+	void 		publishLocalPositionSetpoint(const position_setpoint_s current_waypoint);
 
 	void		abort_landing(bool abort);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -286,7 +286,7 @@ private:
 	void		status_publish();
 	void		landing_status_publish();
 	void		tecs_status_publish();
-	void 		publishLocalPositionSetpoint(const position_setpoint_s current_waypoint);
+	void 		publishLocalPositionSetpoint(const position_setpoint_s &current_waypoint);
 
 	void		abort_landing(bool abort);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously it was hard to interpret what the fw position controller was doing in term of tracking performance since the position setpoints were not logged in the local frame.

- It is hard to associate waypoints switching with the vehicle behavior, given that the fw pos control overrides the setpoints internally sometimes
- This is especially a problem when passing high bandwidth setpoints from offboard or for path tracking.
- For VTOLs the position setpoints just stops logging when the vehicle transitions to FW mode, since the local_position_setpoint is only published from the MC position controller module

**Describe your solution**
This adds publication of the `vehicle_local_position_setpoint` so that it gets logged as a local setpoint.

**Describe possible alternatives**
- I think a bigger problem creeping is that all our position setpoints are in the global frame due to L1 only supporting lat/lon as a input. For offboard mode, we are converting local->global and global->local two times for this reason. I would like to move towards doing fw control in local coordinates since this would allow us to fly even in GPS denied situations. 

**Test data / coverage**
Tested in SITL Gazebo
```
make px4_sitl gazebo_plane
```
and the log correctly shows the position setpoints and how the waypoints are switching.
- Before PR: [FlightLog](https://logs.px4.io/plot_app?log=290f3041-74cf-4126-9b63-d3eeea42f058)
![image](https://user-images.githubusercontent.com/5248102/147812419-7f0abfe8-5702-4a03-9a83-d2998d1a08d2.png)

- After PR: [Flightlog](https://logs.px4.io/plot_app?log=75f1c7b7-bbf7-4228-954c-67f3c35fb1b9)
![image](https://user-images.githubusercontent.com/5248102/147812079-a3ec7ddc-4499-481c-bbfe-98dfacc66c78.png)

**Additional context**

- 
