### PR TITLE
test_dataman:Set SEM_PRIO_NONE on all semaphores

### DIFF
--- a/src/systemcmds/tests/test_dataman.c
+++ b/src/systemcmds/tests/test_dataman.c
@@ -179,7 +179,7 @@ int test_dataman(int argc, char *argv[])
 
 		px4_sem_init(sems + i, 1, 0);
 		/* sems use case is a signal */
-		px4_sem_setprotocol(sems, SEM_PRIO_NONE);
+		px4_sem_setprotocol(sems + i, SEM_PRIO_NONE);
 
 		/* start the task */
 		if ((task = px4_task_spawn_cmd("dataman", SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT, 2048, task_main, av)) <= 0) {


### PR DESCRIPTION
The index was not applied to all the semaphores.