### PR TITLE
Tools/HIL: default to USB UART if available

### DIFF
--- a/Tools/HIL/monitor_firmware_upload.py
+++ b/Tools/HIL/monitor_firmware_upload.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 import re
 import sys
 import datetime
+import serial.tools.list_ports as list_ports
 
 COLOR_RED    = "\x1b[31m"
 COLOR_GREEN  = "\x1b[32m"
@@ -35,6 +36,7 @@ def print_line(line):
         print('[{0}] {1}'.format(current_time.isoformat(timespec='milliseconds'), line), end='')
     else:
         print('{0}'.format(line), end='')
+
 
 def monitor_firmware_upload(port, baudrate):
     ser = serial.Serial(port, baudrate, bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, timeout=1, xonxoff=False, rtscts=False, dsrdtr=False)
@@ -70,8 +72,30 @@ def monitor_firmware_upload(port, baudrate):
             ser.flush()
 
 def main():
+
+    default_device = None
+    device_required = True
+
+    # select USB UART as default if there's only 1
+    ports = list(serial.tools.list_ports.grep('USB UART'))
+
+    if (len(ports) == 1):
+        default_device = ports[0].device
+        device_required = False
+
+        print("Default USB UART port: {0}".format(ports[0].name))
+        print(" device: {0}".format(ports[0].device))
+        print(" description: \"{0}\" ".format(ports[0].description))
+        print(" hwid: {0}".format(ports[0].hwid))
+        #print(" vid: {0}, pid: {1}".format(ports[0].vid, ports[0].pid))
+        #print(" serial_number: {0}".format(ports[0].serial_number))
+        #print(" location: {0}".format(ports[0].location))
+        print(" manufacturer: {0}".format(ports[0].manufacturer))
+        #print(" product: {0}".format(ports[0].product))
+        #print(" interface: {0}".format(ports[0].interface))
+
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('--device', "-d", nargs='?', default=None, help='', required=True)
+    parser.add_argument('--device', "-d", nargs='?', default=default_device, help='', required=device_required)
     parser.add_argument("--baudrate", "-b", dest="baudrate", type=int, help="Mavlink port baud rate (default=57600)", default=57600)
     args = parser.parse_args()
 

--- a/Tools/HIL/reboot.py
+++ b/Tools/HIL/reboot.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 import re
 import sys
 import datetime
+import serial.tools.list_ports as list_ports
 
 COLOR_RED    = "\x1b[31m"
 COLOR_GREEN  = "\x1b[32m"
@@ -35,6 +36,7 @@ def print_line(line):
         print('[{0}] {1}'.format(current_time.isoformat(timespec='milliseconds'), line), end='')
     else:
         print('{0}'.format(line), end='')
+
 
 def reboot(port, baudrate):
     ser = serial.Serial(port, baudrate, bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, timeout=1, xonxoff=False, rtscts=False, dsrdtr=False)
@@ -75,8 +77,30 @@ def reboot(port, baudrate):
             sys.exit(-1)
 
 def main():
+
+    default_device = None
+    device_required = True
+
+    # select USB UART as default if there's only 1
+    ports = list(serial.tools.list_ports.grep('USB UART'))
+
+    if (len(ports) == 1):
+        default_device = ports[0].device
+        device_required = False
+
+        print("Default USB UART port: {0}".format(ports[0].name))
+        print(" device: {0}".format(ports[0].device))
+        print(" description: \"{0}\" ".format(ports[0].description))
+        print(" hwid: {0}".format(ports[0].hwid))
+        #print(" vid: {0}, pid: {1}".format(ports[0].vid, ports[0].pid))
+        #print(" serial_number: {0}".format(ports[0].serial_number))
+        #print(" location: {0}".format(ports[0].location))
+        print(" manufacturer: {0}".format(ports[0].manufacturer))
+        #print(" product: {0}".format(ports[0].product))
+        #print(" interface: {0}".format(ports[0].interface))
+
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('--device', "-d", nargs='?', default=None, help='', required=True)
+    parser.add_argument('--device', "-d", nargs='?', default=default_device, help='', required=device_required)
     parser.add_argument("--baudrate", "-b", dest="baudrate", type=int, help="Mavlink port baud rate (default=57600)", default=57600)
     args = parser.parse_args()
 

--- a/Tools/HIL/run_nsh_cmd.py
+++ b/Tools/HIL/run_nsh_cmd.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 import re
 import sys
 import datetime
+import serial.tools.list_ports as list_ports
 
 COLOR_RED    = "\x1b[31m"
 COLOR_GREEN  = "\x1b[32m"
@@ -46,6 +47,7 @@ def do_nsh_cmd(port, baudrate, cmd):
     # wait for nsh prompt
     while True:
         ser.write("\n".encode("ascii"))
+        ser.flush()
 
         serial_line = ser.readline().decode("ascii", errors='ignore')
 
@@ -126,8 +128,30 @@ def do_nsh_cmd(port, baudrate, cmd):
     ser.close()
 
 def main():
+
+    default_device = None
+    device_required = True
+
+    # select USB UART as default if there's only 1
+    ports = list(serial.tools.list_ports.grep('USB UART'))
+
+    if (len(ports) == 1):
+        default_device = ports[0].device
+        device_required = False
+
+        print("Default USB UART port: {0}".format(ports[0].name))
+        print(" device: {0}".format(ports[0].device))
+        print(" description: \"{0}\" ".format(ports[0].description))
+        print(" hwid: {0}".format(ports[0].hwid))
+        #print(" vid: {0}, pid: {1}".format(ports[0].vid, ports[0].pid))
+        #print(" serial_number: {0}".format(ports[0].serial_number))
+        #print(" location: {0}".format(ports[0].location))
+        print(" manufacturer: {0}".format(ports[0].manufacturer))
+        #print(" product: {0}".format(ports[0].product))
+        #print(" interface: {0}".format(ports[0].interface))
+
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('--device', "-d", nargs='?', default=None, help='', required=True)
+    parser.add_argument('--device', "-d", nargs='?', default=default_device, help='', required=device_required)
     parser.add_argument("--baudrate", "-b", dest="baudrate", type=int, help="Mavlink port baud rate (default=57600)", default=57600)
     parser.add_argument("--cmd", "-c", dest="cmd", help="Command to run")
     args = parser.parse_args()

--- a/Tools/HIL/run_tests.py
+++ b/Tools/HIL/run_tests.py
@@ -9,6 +9,7 @@ import unittest
 import os
 import sys
 import datetime
+import serial.tools.list_ports as list_ports
 
 COLOR_RED    = "\x1b[31m"
 COLOR_GREEN  = "\x1b[32m"
@@ -38,6 +39,7 @@ def print_line(line):
     else:
         print('{0}'.format(line), end='')
 
+
 def do_test(port, baudrate, test_name):
     ser = serial.Serial(port, baudrate, bytesize=serial.EIGHTBITS, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, timeout=1, xonxoff=False, rtscts=False, dsrdtr=False)
 
@@ -47,6 +49,7 @@ def do_test(port, baudrate, test_name):
     # wait for nsh prompt
     while True:
         ser.write("\n".encode("ascii"))
+        ser.flush()
 
         serial_line = ser.readline().decode("ascii", errors='ignore')
 
@@ -206,8 +209,30 @@ class TestHardwareMethods(unittest.TestCase):
         self.assertTrue(do_test(self.TEST_DEVICE, self.TEST_BAUDRATE, "versioning"))
 
 def main():
+
+    default_device = None
+    device_required = True
+
+    # select USB UART as default if there's only 1
+    ports = list(serial.tools.list_ports.grep('USB UART'))
+
+    if (len(ports) == 1):
+        default_device = ports[0].device
+        device_required = False
+
+        print("Default USB UART port: {0}".format(ports[0].name))
+        print(" device: {0}".format(ports[0].device))
+        print(" description: \"{0}\" ".format(ports[0].description))
+        print(" hwid: {0}".format(ports[0].hwid))
+        #print(" vid: {0}, pid: {1}".format(ports[0].vid, ports[0].pid))
+        #print(" serial_number: {0}".format(ports[0].serial_number))
+        #print(" location: {0}".format(ports[0].location))
+        print(" manufacturer: {0}".format(ports[0].manufacturer))
+        #print(" product: {0}".format(ports[0].product))
+        #print(" interface: {0}".format(ports[0].interface))
+
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('--device', "-d", nargs='?', default=None, help='', required=True)
+    parser.add_argument('--device', "-d", nargs='?', default=default_device, help='', required=device_required)
     parser.add_argument("--baudrate", "-b", dest="baudrate", type=int, help="Mavlink port baud rate (default=57600)", default=57600)
     args = parser.parse_args()
 


### PR DESCRIPTION
``` Console
$ ./Tools/HIL/run_nsh_cmd.py --cmd 'work_queue status'
Default USB UART port: ttyUSB0
 device: /dev/ttyUSB0
 description: "FT232R USB UART - FT232R USB UART"
 hwid: USB VID:PID=0403:6001 SER=AC00CKKL LOCATION=1-2.4.1
 manufacturer: FTDI
[2021-12-31T21:20:17.098]
Running command: 'work_queue status'
[2021-12-31T21:20:17.208]
[2021-12-31T21:20:17.209] Work Queue: 14 threads                          RATE        INTERVAL
[2021-12-31T21:20:17.209] |__ 1) wq:rate_ctrl
[2021-12-31T21:20:17.211] |   |__ 1) mc_rate_control                  804.7 Hz         1243 us
[2021-12-31T21:20:17.212] |   |__ 2) px4io                            398.7 Hz         2508 us
[2021-12-31T21:20:17.213] |   \__ 3) vehicle_angular_velocity         804.7 Hz         1243 us
[2021-12-31T21:20:17.214] |__ 2) wq:SPI1
[2021-12-31T21:20:17.215] |   \__ 1) icm20602                         796.1 Hz         1256 us
[2021-12-31T21:20:17.216] |__ 3) wq:SPI2
[2021-12-31T21:20:17.295] |   \__ 1) icm42688p                        807.8 Hz         1238 us
[2021-12-31T21:20:17.295] |__ 4) wq:SPI3
[2021-12-31T21:20:17.297] |   \__ 1) icm20649                         758.3 Hz         1319 us (1333 us)
[2021-12-31T21:20:17.297] |__ 5) wq:I2C1
[2021-12-31T21:20:17.299] |   |__ 1) ina226                             9.8 Hz       101552 us
[2021-12-31T21:20:17.300] |   |__ 2) ist8310                           46.7 Hz        21403 us
[2021-12-31T21:20:17.301] |   \__ 3) rgbled_ncp5623c                   38.6 Hz        25878 us
[2021-12-31T21:20:17.302] |__ 6) wq:I2C2
[2021-12-31T21:20:17.381] |   |__ 1) bmp388                            23.1 Hz        43297 us (43300 us)
[2021-12-31T21:20:17.382] |   \__ 2) ina226                             2.0 Hz       500275 us
[2021-12-31T21:20:17.383] |__ 7) wq:I2C4
[2021-12-31T21:20:17.384] |   |__ 1) bmm150                            20.0 Hz        49984 us (50000 us)
[2021-12-31T21:20:17.386] |   \__ 2) bmp388                            23.1 Hz        43298 us (43300 us)
[2021-12-31T21:20:17.386] |__ 8) wq:nav_and_controllers
[2021-12-31T21:20:17.387] |   |__ 1) ekf2_selector                    300.7 Hz         3325 us
[2021-12-31T21:20:17.389] |   |__ 2) flight_mode_manager               50.0 Hz        19999 us
[2021-12-31T21:20:17.469] |   |__ 3) land_detector                     99.9 Hz        10013 us
[2021-12-31T21:20:17.471] |   |__ 4) mc_att_control                   202.0 Hz         4952 us
[2021-12-31T21:20:17.472] |   |__ 5) mc_hover_thrust_estimator        100.0 Hz        10001 us
[2021-12-31T21:20:17.473] |   |__ 6) mc_pos_control                    99.9 Hz        10015 us
[2021-12-31T21:20:17.474] |   |__ 7) sensors                          201.9 Hz         4954 us
[2021-12-31T21:20:17.476] |   |__ 8) vehicle_acceleration             201.9 Hz         4953 us
[2021-12-31T21:20:17.477] |   |__ 9) vehicle_air_data                  23.1 Hz        43334 us
[2021-12-31T21:20:17.556] |   |__10) vehicle_gps_position               5.0 Hz       200097 us
[2021-12-31T21:20:17.557] |   \__11) vehicle_magnetometer              46.7 Hz        21418 us
[2021-12-31T21:20:17.557] |__ 9) wq:INS0
[2021-12-31T21:20:17.559] |   |__ 1) ekf2                             189.6 Hz         5273 us
[2021-12-31T21:20:17.560] |   \__ 2) vehicle_imu                      189.7 Hz         5273 us
[2021-12-31T21:20:17.560] |__ 10) wq:INS1
[2021-12-31T21:20:17.562] |   |__ 1) ekf2                             202.0 Hz         4952 us
[2021-12-31T21:20:17.563] |   \__ 2) vehicle_imu                      201.9 Hz         4953 us
[2021-12-31T21:20:17.564] |__ 11) wq:INS2
[2021-12-31T21:20:17.642] |   |__ 1) ekf2                             199.0 Hz         5024 us
[2021-12-31T21:20:17.643] |   \__ 2) vehicle_imu                      200.0 Hz         5001 us
[2021-12-31T21:20:17.644] |__ 12) wq:hp_default
[2021-12-31T21:20:17.645] |   |__ 1) board_adc                        100.0 Hz        10003 us (10000 us)
[2021-12-31T21:20:17.646] |   |__ 2) gyro_fft                         398.6 Hz         2509 us
[2021-12-31T21:20:17.648] |   |__ 3) manual_control                     5.0 Hz       200297 us
[2021-12-31T21:20:17.649] |   |__ 4) mc_autotune_attitude_control       0.0 Hz            0 us
[2021-12-31T21:20:17.650] |   |__ 5) pwm_out0                           0.0 Hz     92980096 us
[2021-12-31T21:20:17.728] |   |__ 6) pwm_out1                           1.0 Hz       998272 us
[2021-12-31T21:20:17.730] |   |__ 7) rc_update                          0.0 Hz            0 us
[2021-12-31T21:20:17.731] |   |__ 8) safety_button                     30.3 Hz        33000 us (33000 us)
[2021-12-31T21:20:17.732] |   \__ 9) tone_alarm                         0.0 Hz     20367866 us
[2021-12-31T21:20:17.733] |__ 13) wq:uavcan
[2021-12-31T21:20:17.734] |   |__ 1) uavcan                           337.1 Hz         2967 us (3000 us)
[2021-12-31T21:20:17.736] |   |__ 2) uavcan-actuators-esc              10.0 Hz        99971 us (100000 us)
[2021-12-31T21:20:17.819] |   \__ 3) uavcan-actuators-servo            10.0 Hz        99974 us (100000 us)
[2021-12-31T21:20:17.819] \__ 14) wq:lp_default
[2021-12-31T21:20:17.819]     |__ 1) gyro_calibration                  50.0 Hz        20000 us (20000 us)
[2021-12-31T21:20:17.819]     |__ 2) load_mon                           2.0 Hz       499880 us (500000 us)
[2021-12-31T21:20:17.820]     |__ 3) mag_bias_estimator                50.0 Hz        20004 us (20000 us)
[2021-12-31T21:20:17.820]     \__ 4) send_event                        30.0 Hz        33333 us (33333 us)
```