### PR TITLE
Fix delta angle coning metric

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1380,12 +1380,17 @@ void EKF2::UpdateImuStatus()
 			return;
 		}
 
+		const float dt = _ekf.get_dt_imu_avg();
+
 		// accel -> delta velocity
-		_ekf.setDeltaVelocityHighFrequencyVibrationMetric(imu_status.accel_vibration_metric * _ekf.get_dt_imu_avg());
+		_ekf.setDeltaVelocityHighFrequencyVibrationMetric(imu_status.accel_vibration_metric * dt);
 
 		// gyro -> delta angle
-		_ekf.setDeltaAngleHighFrequencyVibrationMetric(imu_status.gyro_vibration_metric * _ekf.get_dt_imu_avg());
-		_ekf.setDeltaAngleConingMetric(imu_status.gyro_coning_vibration * _ekf.get_dt_imu_avg());
+		_ekf.setDeltaAngleHighFrequencyVibrationMetric(imu_status.gyro_vibration_metric * dt);
+
+		// note: the coning metric uses the cross product of two consecutive angular velocities
+		// this is why the conversion to delta angle requires dt^2
+		_ekf.setDeltaAngleConingMetric(imu_status.gyro_coning_vibration * dt * dt);
 	}
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
In https://github.com/PX4/PX4-Autopilot/pull/18001 we replaced the internal computation of the vibration metric that was done by the EKF to the metric computed in the IMU module directly. However, there is a scale issue due to the conversion between delta angles and angular velocity for the coning metric:

In the past, we were computing the vibration metric in the EKF:
```coning = lpf(d_theta[k] x d_theta[k-1])``` << note the cross product
now, it is computed on the integrated IMU data from angular velocities
```coning_vel = lpf(w[k] x w[k-1])```
and then sent to the EKF as `coning = coning_vel * dt`
however, since `d_theta = w * dt`,
```coning = lpf(w[k]*dt x w[k-1]*dt)```
or
```coning = coning_vel * dt^2```