### PR TITLE
sensors: automatically set initial accel/gyro calibration if stable bias available

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -180,7 +180,8 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate,
-		(ParamInt<px4::params::IMU_GYRO_RATEMAX>) _param_imu_gyro_ratemax
+		(ParamInt<px4::params::IMU_GYRO_RATEMAX>) _param_imu_gyro_ratemax,
+		(ParamBool<px4::params::SENS_IMU_AUTOCAL>) _param_sens_imu_autocal
 	)
 };
 

--- a/src/modules/sensors/vehicle_imu/imu_parameters.c
+++ b/src/modules/sensors/vehicle_imu/imu_parameters.c
@@ -48,3 +48,15 @@
 * @group Sensors
 */
 PARAM_DEFINE_INT32(IMU_INTEG_RATE, 200);
+
+/**
+ * IMU auto calibration
+ *
+ * Automatically initialize IMU (accel/gyro) calibration from bias estimates if available.
+ *
+ * @boolean
+ *
+ * @category system
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(SENS_IMU_AUTOCAL, 1);


### PR DESCRIPTION
Similar to https://github.com/PX4/PX4-Autopilot/pull/18421 for magnetometer this change will use an available stable estimated bias to set initial accel and gyro calibrations if the sensors are completely uncalibrated.

At the moment this is fairly conservative for accel.


 - can be enabled via SENS_IMU_AUTOCAL parameter
    - this parameter also controls saving the learned EKF2 IMU biases back to calibration parameters