### PR TITLE
commander: prevent uninitialized warning

### DIFF
--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -71,7 +71,7 @@ union failure_detector_status_u {
 		uint16_t battery : 1;
 		uint16_t imbalanced_prop : 1;
 	} flags;
-	uint16_t value;
+	uint16_t value {0};
 };
 
 using uORB::SubscriptionData;


### PR DESCRIPTION
This prevents a memory sanitizer/valgrind warning:

```
Conditional jump or move depends on uninitialised value(s)
   at 0x2DA536: __sanitizer_cov_trace_cmp4 (in build/px4_sitl_default-clang/bin/px4)
   by 0x6590D8: FailureDetector::update(vehicle_status_s const&, vehicle_control_mode_s const&) (src/modules/commander/failure_detector/FailureDetector.cpp:76) by 0x3817DF: Commander::run() (src/modules/commander/Commander.cpp:2605)
   by 0x38B10B: ModuleBase<Commander>::run_trampoline(int, char**) (platforms/common/include/px4_platform_common/module.h:180)
```