### PR TITLE
FlightTaskAuto: Respect altitude with offtrack state

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -194,7 +194,7 @@ private:
 	_triplet_prev_wp; /**< previous triplet from navigator which may differ from the intenal one (_prev_wp) depending on the vehicle state.*/
 	matrix::Vector3f
 	_triplet_next_wp; /**< next triplet from navigator which may differ from the intenal one (_next_wp) depending on the vehicle state.*/
-	matrix::Vector2f _closest_pt; /**< closest point to the vehicle position on the line previous - target */
+	matrix::Vector3f _closest_pt; /**< closest point to the vehicle position on the line previous - target */
 
 	map_projection_reference_s _reference_position{}; /**< Structure used to project lat/lon setpoint into local frame. */
 	float _reference_altitude{NAN};  /**< Altitude relative to ground. */


### PR DESCRIPTION
**Describe problem solved by this pull request**
When sending consecutive reposition commands to a multicopter that contain different altitudes and not waiting until the previous target position was reached there's very strange behavior.

**Describe your solution**
This solves one of the issues when switching goto target mid-flight where the altitude overshoots. Only the horizontal path between waypoints was considered in the "off-track" calculations. I'm using the exact same calculations just in 3D to also consider the altitude.

**Describe possible alternatives**
Further improvements with unexpected waypoint changes require architecture changes to solve properly and are work in progress with the new mode architecture.

**Test data / coverage**
I tested this in SITL and SIH and the switching has fewer issues. It still does an overshoot but converges to the right path fairly quickly while before if the altitude didn't match it could get stuck for quite some time and start wobbling back and forth.

**Additional context**
SIH Example before:
![image](https://user-images.githubusercontent.com/4668506/148204467-47da7ed2-5a07-460c-b27e-68f0f540a0c5.png)


SIH Example after:
![image](https://user-images.githubusercontent.com/4668506/148204352-d0718056-e342-465b-a8ae-ad93cc013deb.png)

