### PR TITLE
Use local coordinates for FW Position Control

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -195,6 +195,7 @@ set(msg_files
 	vehicle_land_detected.msg
 	vehicle_local_position.msg
 	vehicle_local_position_setpoint.msg
+	vehicle_local_path_setpoint.msg
 	vehicle_magnetometer.msg
 	vehicle_odometry.msg
 	vehicle_optical_flow.msg

--- a/msg/vehicle_local_path_setpoint.msg
+++ b/msg/vehicle_local_path_setpoint.msg
@@ -1,0 +1,16 @@
+# Local position setpoint in NED frame
+# setting something to NaN means the state should not be controlled
+
+uint64 timestamp	# time since system start (microseconds)
+
+float32[2] prev_wp	# previous waypoint in meters NED
+float32 x		# in meters NED
+float32 y		# in meters NED
+float32 z		# in meters NED
+float32 vx		# in meters/sec
+float32 vy		# in meters/sec
+float32 vz		# in meters/sec
+float32 true_airspeed	# true air relative setpoint in meters/sec
+float32 curvature	# in meters/sec^2
+
+# TOPICS vehicle_local_path_setpoint

--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -233,22 +233,6 @@ public:
 			       const matrix::Vector2f &wind_vel);
 
 	/*
-	 * Loitering (unlimited) logic. Takes loiter center, radius, and direction and
-	 * determines the relevant parameters for evaluating the NPFG guidance law,
-	 * then updates control setpoints.
-	 *
-	 * @param[in] loiter_center The position of the center of the loiter circle [m]
-	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
-	 * @param[in] radius Loiter radius [m]
-	 * @param[in] loiter_direction_counter_clockwise Specifies loiter direction
-	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
-	 * @param[in] wind_vel Wind velocity vector [m/s]
-	 */
-	void navigateLoiter(const matrix::Vector2f &loiter_center, const matrix::Vector2f &vehicle_pos,
-			    float radius, bool loiter_direction_counter_clockwise, const matrix::Vector2f &ground_vel,
-			    const matrix::Vector2f &wind_vel);
-
-	/*
 	 * Path following logic. Takes poisiton, path tangent, curvature and
 	 * then updates control setpoints to follow a path setpoint.
 	 *


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously the L1 guidance for Fixedwing/VTOL vehicles have been using global coordinates.

- None of the other controllers that are used by multicopters work directly on global coordinates. 
- When passing position setpoints with offboard, the setpoints were converted into global coordinates just so that it can be used by L1. This results in redundant conversions(local->global->local) internally in the controller
- This prevents from using the L1 controller without the global position being initialized, such as using external vision based position estimation. Such use case is particularly useful for rovers that operate indoors

**Describe your solution**
This PR changes the input of the `ECL_L1_PosController` to use local coordinates instead of global coordinates(WGS84)

While this PR includes transition of the coordinates of L1 from global to local for the `ECL_L1_PosController`, the integration into the fixedwing position controller is still relying on projecting waypoints into the local frame. This is due to the fact that a lot of the control logic in the fw position control is using the `pos_sp_triplet` directly.

For example, 

https://github.com/PX4/PX4-Autopilot/blob/0b1402afe2a214dcfbd0d6f8f10b6a1041067ca9/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1074-L1078

I have left this PR as a draft since I am not sure what would be a good direction for the fw pos controller since the pos_sp_triplet is used throughout the controller

**Test data / coverage**
- Tested in SITL Gazebo with `plane` model
```
make px4_sitl gazebo_plane
```

**Additional context**
- Related to https://github.com/PX4/PX4-Autopilot/issues/5123
