### PR TITLE
commander: fix COM_HOME_EN missing case

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1656,7 +1656,7 @@ Commander::set_home_position()
 	// Need global and local position fix to be able to set home
 	// but already set the home position in local coordinates if available
 	// in case the global position is only valid after takeoff
-	if (_status_flags.condition_local_position_valid) {
+	if (_param_com_home_en.get() && _status_flags.condition_local_position_valid) {
 
 		// Set home position in local coordinates
 		const vehicle_local_position_s &lpos = _local_position_sub.get();


### PR DESCRIPTION
 - VEHICLE_CMD_COMPONENT_ARM_DISARM is yet another path that calls set_home_position()

There are quite a few paths through commander that set and update home_position.