### PR TITLE
ControlAllocation: mixer matrix normalization fixes

### DIFF
--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.cpp
@@ -51,7 +51,8 @@ ControlAllocation::ControlAllocation()
 void
 ControlAllocation::setEffectivenessMatrix(
 	const matrix::Matrix<float, ControlAllocation::NUM_AXES, ControlAllocation::NUM_ACTUATORS> &effectiveness,
-	const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators)
+	const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators,
+	bool update_normalization_scale)
 {
 	_effectiveness = effectiveness;
 	ActuatorVector linearization_point_clipped = linearization_point;

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -104,7 +104,8 @@ public:
 	 * @param B Effectiveness matrix
 	 */
 	virtual void setEffectivenessMatrix(const matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &effectiveness,
-					    const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators);
+					    const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators,
+					    bool update_normalization_scale);
 
 	/**
 	 * Get the allocated actuator vector

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
@@ -44,10 +44,13 @@
 void
 ControlAllocationPseudoInverse::setEffectivenessMatrix(
 	const matrix::Matrix<float, ControlAllocation::NUM_AXES, ControlAllocation::NUM_ACTUATORS> &effectiveness,
-	const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators)
+	const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators,
+	bool update_normalization_scale)
 {
-	ControlAllocation::setEffectivenessMatrix(effectiveness, actuator_trim, linearization_point, num_actuators);
+	ControlAllocation::setEffectivenessMatrix(effectiveness, actuator_trim, linearization_point, num_actuators,
+			update_normalization_scale);
 	_mix_update_needed = true;
+	_normalization_needs_update = update_normalization_scale;
 }
 
 void
@@ -55,32 +58,30 @@ ControlAllocationPseudoInverse::updatePseudoInverse()
 {
 	if (_mix_update_needed) {
 		matrix::geninv(_effectiveness, _mix);
+
+		if (_normalization_needs_update) {
+			updateControlAllocationMatrixScale();
+			_normalization_needs_update = false;
+		}
+
 		normalizeControlAllocationMatrix();
 		_mix_update_needed = false;
 	}
 }
 
 void
-ControlAllocationPseudoInverse::normalizeControlAllocationMatrix()
+ControlAllocationPseudoInverse::updateControlAllocationMatrixScale()
 {
+	// Same scale on roll and pitch
 	if (_normalize_rpy) {
-		// Same scale on roll and pitch
 		const float roll_norm_sq = _mix.col(0).norm_squared();
 		const float pitch_norm_sq = _mix.col(1).norm_squared();
+
 		_control_allocation_scale(0) = sqrtf(fmaxf(roll_norm_sq, pitch_norm_sq) / (_num_actuators / 2.f));
 		_control_allocation_scale(1) = _control_allocation_scale(0);
 
-		if (_control_allocation_scale(0) > FLT_EPSILON) {
-			_mix.col(0) /= _control_allocation_scale(0);
-			_mix.col(1) /= _control_allocation_scale(1);
-		}
-
 		// Scale yaw separately
 		_control_allocation_scale(2) = _mix.col(2).max();
-
-		if (_control_allocation_scale(2) > FLT_EPSILON) {
-			_mix.col(2) /= _control_allocation_scale(2);
-		}
 
 	} else {
 		_control_allocation_scale(0) = 1.f;
@@ -106,16 +107,31 @@ ControlAllocationPseudoInverse::normalizeControlAllocationMatrix()
 		_control_allocation_scale(3) = norm_sum;
 		_control_allocation_scale(4) = norm_sum;
 		_control_allocation_scale(5) = norm_sum;
-		_mix.col(3) /= _control_allocation_scale(3);
-		_mix.col(4) /= _control_allocation_scale(4);
-		_mix.col(5) /= _control_allocation_scale(5);
 
 	} else {
 		_control_allocation_scale(3) = 1.f;
 		_control_allocation_scale(4) = 1.f;
 		_control_allocation_scale(5) = 1.f;
 	}
+}
 
+void
+ControlAllocationPseudoInverse::normalizeControlAllocationMatrix()
+{
+	if (_control_allocation_scale(0) > FLT_EPSILON) {
+		_mix.col(0) /= _control_allocation_scale(0);
+		_mix.col(1) /= _control_allocation_scale(1);
+	}
+
+	if (_control_allocation_scale(2) > FLT_EPSILON) {
+		_mix.col(2) /= _control_allocation_scale(2);
+	}
+
+	if (_control_allocation_scale(3) > FLT_EPSILON) {
+		_mix.col(3) /= _control_allocation_scale(3);
+		_mix.col(4) /= _control_allocation_scale(4);
+		_mix.col(5) /= _control_allocation_scale(5);
+	}
 
 	// Set all the small elements to 0 to avoid issues
 	// in the control allocation algorithms

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.hpp
@@ -55,7 +55,8 @@ public:
 
 	void allocate() override;
 	void setEffectivenessMatrix(const matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &effectiveness,
-				    const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators) override;
+				    const ActuatorVector &actuator_trim, const ActuatorVector &linearization_point, int num_actuators,
+				    bool update_normalization_scale) override;
 
 protected:
 	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _mix;
@@ -70,4 +71,6 @@ protected:
 
 private:
 	void normalizeControlAllocationMatrix();
+	void updateControlAllocationMatrixScale();
+	bool _normalization_needs_update{false};
 };

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverseTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverseTest.cpp
@@ -57,7 +57,7 @@ TEST(ControlAllocationTest, AllZeroCase)
 	matrix::Vector<float, 16> linearization_point;
 	matrix::Vector<float, 16> actuator_sp_expected;
 
-	method.setEffectivenessMatrix(effectiveness, actuator_trim, linearization_point, 16);
+	method.setEffectivenessMatrix(effectiveness, actuator_trim, linearization_point, 16, false);
 	method.setControlSetpoint(control_sp);
 	method.allocate();
 	method.clipActuatorSetpoint();

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -496,7 +496,7 @@ ControlAllocator::update_effectiveness_matrix_if_needed(bool force)
 			// Assign control effectiveness matrix
 			int total_num_actuators = config.num_actuators_matrix[i];
 			_control_allocation[i]->setEffectivenessMatrix(config.effectiveness_matrices[i], config.trim[i],
-					config.linearization_point[i], total_num_actuators);
+					config.linearization_point[i], total_num_actuators, force);
 		}
 
 		trims.timestamp = hrt_absolute_time();


### PR DESCRIPTION
**Describe problem solved by this pull request**
2 Issues:
1) The scale for the normalization should not be updated when the tilt of the motor changes in air (or if an actuator is switched off in air due to a detected failure in the future), but only when the configuration changes before flying. 
2) For tiltrotor the calculation of the average roll/pitch effect was wrong, as using the /`_num_actuators` is wrong in this case because e.g. actuators 5-8 are tilts that don't have an entry in the roll or pitch column.

**Describe your solution**
1) The `forced` flag is used to distinguish when the matrix is updated because the user changes the configuration (only enabled when disarmed), and when the matrix is updated because the geometry changes due to motors being tilted.
In the future another reason for updating the matrix can be detection an actuator failure.

2) Divide the norm_squared of the roll and pitch column by the number of contributing actuators. 

**Describe possible alternatives**
It can most likely be done nicer than using the "forced" argument for it. It anyway seems like "forced" translates to "configuration has changed", so maybe we can come up with a better naming in the first place. 

**Test data / coverage**
SITL.

**Additional context**
That's how the inversion followed by the normalization looks like:
`roll_norm_scale = sqrtf(_mix.col(0).norm_squared() / (num_non_zero_roll_torque / 2.f)):`
![image](https://user-images.githubusercontent.com/26798987/148792823-7582f55c-93b1-42fa-a6bb-c785b33252c0.png)


