### PR TITLE
Orbit approach transition improvements

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -66,7 +66,7 @@ bool FlightTaskAuto::activate(const vehicle_local_position_setpoint_s &last_setp
 	Vector3f accel_prev{last_setpoint.acceleration};
 
 	for (int i = 0; i < 3; i++) {
-		// If the position setpoint is unknown, set to the current postion
+		// If the position setpoint is unknown, set to the current position
 		if (!PX4_ISFINITE(pos_prev(i))) { pos_prev(i) = _position(i); }
 
 		// If the velocity setpoint is unknown, set to the current velocity

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -57,15 +57,14 @@ protected:
 	void _ekfResetHandlerPositionZ(float delta_z) override;
 	void _ekfResetHandlerVelocityZ(float delta_vz) override;
 
+	void _updateTrajConstraints();
+	void _setOutputState();
+
+	ManualVelocitySmoothingZ _smoothing; ///< Smoothing in z direction
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualAltitude,
 					(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max
 				       )
-
-private:
-	void _updateTrajConstraints();
-	void _setOutputState();
-
-	ManualVelocitySmoothingZ _smoothing; ///< Smoothing in z direction
 };

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -192,8 +192,8 @@ bool FlightTaskOrbit::update()
 	_updateTrajectoryBoundaries();
 
 	// stick input adjusts parameters within a fixed time frame
-	float radius = _orbit_radius - _sticks.getPositionExpo()(0) * _deltatime * (_radius_max / 8.f);
-	float velocity = _orbit_velocity - _sticks.getPositionExpo()(1) * _deltatime * (_velocity_max / 4.f);
+	float radius = _orbit_radius - _sticks.getPositionExpo()(0) * _deltatime * _param_mpc_xy_cruise.get();
+	float velocity = _orbit_velocity - _sticks.getPositionExpo()(1) * _deltatime * _param_mpc_acc_hor.get();
 	_sanitizeParams(radius, velocity);
 	_orbit_radius = radius;
 	_orbit_velocity = velocity;

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -51,25 +51,24 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 {
 	bool ret = true;
 	// save previous velocity and roatation direction
-	bool is_clockwise = _orbit_velocity > 0;
-
+	bool new_is_clockwise = _orbit_velocity > 0;
 	float new_radius = _orbit_radius;
-	float new_abs_velocity = fabsf(_orbit_velocity);
+	float new_absolute_velocity = fabsf(_orbit_velocity);
 
 	// commanded radius
 	if (PX4_ISFINITE(command.param1)) {
 		// Note: Radius sign is defined as orbit direction in MAVLINK
-		float radius = command.param1;
-		is_clockwise = radius > 0;
-		new_radius = fabsf(radius);
+		const float radius_parameter = command.param1;
+		new_is_clockwise = radius_parameter > 0;
+		new_radius = fabsf(radius_parameter);
 	}
 
 	// commanded velocity, take sign of radius as rotation direction
 	if (PX4_ISFINITE(command.param2)) {
-		new_abs_velocity = command.param2;
+		new_absolute_velocity = command.param2;
 	}
 
-	float new_velocity = (is_clockwise ? 1.f : -1.f) * new_abs_velocity;
+	float new_velocity = (new_is_clockwise ? 1.f : -1.f) * new_absolute_velocity;
 	_sanitizeParams(new_radius, new_velocity);
 	_orbit_radius = new_radius;
 	_orbit_velocity = new_velocity;

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -293,6 +293,8 @@ void FlightTaskOrbit::_generate_circle_approach_setpoints()
 
 	_position_setpoint = out_setpoints.position;
 	_velocity_setpoint = out_setpoints.velocity;
+	_acceleration_setpoint = out_setpoints.acceleration;
+	_jerk_setpoint = out_setpoints.jerk;
 }
 
 void FlightTaskOrbit::_generate_circle_setpoints()

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -152,7 +152,6 @@ bool FlightTaskOrbit::activate(const vehicle_local_position_setpoint_s &last_set
 	bool ret = FlightTaskManualAltitude::activate(last_setpoint);
 	_orbit_radius = _radius_min;
 	_orbit_velocity =  1.f;
-	_sanitizeParams(_orbit_radius, _orbit_velocity);
 	_center = _position;
 	_initial_heading = _yaw;
 	_slew_rate_yaw.setForcedValue(_yaw);

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -252,9 +252,9 @@ void FlightTaskOrbit::_updateTrajectoryBoundaries()
 	_position_smoothing.setMaxJerk({max_jerk, max_jerk, max_jerk}); // TODO : Should be computed using heading
 	_altitude_velocity_smoothing.setMaxJerk(max_jerk);
 
-	if (_unsmoothed_velocity_setpoint(2) < 0.f) { // up
 		const float z_accel_constraint = _param_mpc_acc_up_max.get();
 
+	if (_velocity_setpoint(2) < 0.f) { // up
 		_position_smoothing.setMaxVelocityZ(_param_mpc_z_v_auto_up.get());
 		_position_smoothing.setMaxAccelerationZ(z_accel_constraint);
 		_altitude_velocity_smoothing.setMaxVel(_param_mpc_z_vel_max_up.get());

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -106,7 +106,6 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 	if (!_is_position_on_circle()) {
 		_in_circle_approach = true;
 		_position_smoothing.reset({0.f, 0.f, 0.f}, _velocity, _position);
-		_circle_approach_start_position = _position;
 	}
 
 	return ret;
@@ -169,7 +168,6 @@ bool FlightTaskOrbit::activate(const vehicle_local_position_setpoint_s &last_set
 	      && PX4_ISFINITE(_velocity(2));
 
 	_position_smoothing.reset({0.f, 0.f, 0.f}, _velocity, _position);
-	_circle_approach_start_position = _position;
 
 	return ret;
 }
@@ -192,13 +190,6 @@ bool FlightTaskOrbit::update()
 		if (_in_circle_approach) {
 			_in_circle_approach = false;
 			_altitude_velocity_smoothing.reset(0, _velocity(2), _position(2));
-		}
-
-	} else {
-		if (!_in_circle_approach) {
-			_in_circle_approach = true;
-			_position_smoothing.reset({0.f, 0.f, 0.f}, _velocity, _position);
-			_circle_approach_start_position = _position;
 		}
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -118,7 +118,6 @@ private:
 	matrix::Vector3f _center; /**< local frame coordinates of the center point */
 
 	bool _in_circle_approach = false;
-	Vector3f _circle_approach_start_position;
 	PositionSmoothing _position_smoothing;
 	VelocitySmoothing _altitude_velocity_smoothing;
 	Vector3f _unsmoothed_velocity_setpoint;

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -49,7 +49,7 @@
 #include <lib/motion_planning/VelocitySmoothing.hpp>
 
 
-class FlightTaskOrbit : public FlightTaskManualAltitude
+class FlightTaskOrbit : public FlightTaskManualAltitudeSmoothVel
 {
 public:
 
@@ -119,7 +119,6 @@ private:
 
 	bool _in_circle_approach = false;
 	PositionSmoothing _position_smoothing;
-	VelocitySmoothing _altitude_velocity_smoothing;
 
 	/** yaw behaviour during the orbit flight according to MAVLink's ORBIT_YAW_BEHAVIOUR enum */
 	int _yaw_behaviour = orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER;

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -120,7 +120,6 @@ private:
 	bool _in_circle_approach = false;
 	PositionSmoothing _position_smoothing;
 	VelocitySmoothing _altitude_velocity_smoothing;
-	Vector3f _unsmoothed_velocity_setpoint;
 
 	/** yaw behaviour during the orbit flight according to MAVLink's ORBIT_YAW_BEHAVIOUR enum */
 	int _yaw_behaviour = orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TO_CIRCLE_CENTER;


### PR DESCRIPTION
**Describe problem solved by this pull request**
It's possible to have steps when entering and exiting the circle approach:
![image-20220105-120441](https://user-images.githubusercontent.com/4668506/148806756-9f3d54e3-9018-44bd-b1a0-0bb2724ff4c8.png)

**Describe your solution**
1. @ThomasDebrunner removed switching to a circle approach if the radius is just slightly adjusted using the stick.
2. I found a typo and did some variable name improvement refactoring.
3. I checked how the position smoothing is initialized and made sure it's using the previous setpoint rather than the current vehicle state. This should give better results because the resulting error should then be continuous while if the setpoint jumps to the current vehicle state the error jumps to zero.

**Describe possible alternatives**
We should further improve the interface for using the jerk trajectory library to make it easier to reuse.

**Test data / coverage**
So far only parts are tested. I still have to test the latest state of this which I'll do the day after tomorrow.