### PR TITLE
Constently use same roll/pitch limits in Fixed Wing Position Controller

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -432,7 +432,7 @@ PARAM_DEFINE_FLOAT(FW_PSP_OFF, 0.0f);
 /**
  * Maximum manual roll angle
  *
- * Maximum manual roll angle setpoint in manual attitude-only stabilized mode
+ * Maximum manual roll angle setpoint (positive & negative) in manual attitude-only stabilized mode
  *
  * @unit deg
  * @min 0.0

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -430,9 +430,9 @@ PARAM_DEFINE_FLOAT(FW_WR_FF, 0.2f);
 PARAM_DEFINE_FLOAT(FW_PSP_OFF, 0.0f);
 
 /**
- * Max manual roll
+ * Maximum manual roll angle
  *
- * Max roll for manual control in attitude stabilized mode
+ * Maximum manual roll angle setpoint in manual attitude-only stabilized mode
  *
  * @unit deg
  * @min 0.0
@@ -444,9 +444,9 @@ PARAM_DEFINE_FLOAT(FW_PSP_OFF, 0.0f);
 PARAM_DEFINE_FLOAT(FW_MAN_R_MAX, 45.0f);
 
 /**
- * Max manual pitch
+ * Maximum manual pitch angle
  *
- * Max pitch for manual control in attitude stabilized mode
+ * Maximum manual pitch angle setpoint (positive & negative) in manual attitude-only stabilized mode
  *
  * @unit deg
  * @min 0.0

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -701,7 +701,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 
 			/* reset setpoints from other modes (auto) otherwise we won't
 			 * level out without new manual input */
-			_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());
+			_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_r_lim.get());
 			_att_sp.yaw_body = _yaw; // yaw is not controlled, so set setpoint to current yaw
 		}
 
@@ -1774,7 +1774,7 @@ FixedwingPositionControl::control_manual_altitude(const hrt_abstime &now, const 
 				   false,
 				   height_rate_sp);
 
-	_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());
+	_att_sp.roll_body = _manual_control_setpoint.y * radians(_param_fw_r_lim.get());
 	_att_sp.yaw_body = _yaw; // yaw is not controlled, so set setpoint to current yaw
 
 	/* Copy thrust and pitch values from tecs */
@@ -1892,7 +1892,7 @@ FixedwingPositionControl::control_manual_position(const hrt_abstime &now, const 
 		_yaw_lock_engaged = false;
 
 		// do slew rate limiting on roll if enabled
-		float roll_sp_new = _manual_control_setpoint.y * radians(_param_fw_man_r_max.get());
+		float roll_sp_new = _manual_control_setpoint.y * radians(_param_fw_r_lim.get());
 		const float roll_rate_slew_rad = radians(_param_fw_l1_r_slew_max.get());
 
 		if (dt > 0.f && roll_rate_slew_rad > 0.f) {
@@ -2118,10 +2118,10 @@ FixedwingPositionControl::Run()
 		if (_control_mode_current != FW_POSCTRL_MODE_OTHER) {
 
 			if (_control_mode.flag_control_manual_enabled) {
-				_att_sp.roll_body = constrain(_att_sp.roll_body, -radians(_param_fw_man_r_max.get()),
-							      radians(_param_fw_man_r_max.get()));
-				_att_sp.pitch_body = constrain(_att_sp.pitch_body, -radians(_param_fw_man_p_max.get()),
-							       radians(_param_fw_man_p_max.get()));
+				_att_sp.roll_body = constrain(_att_sp.roll_body, -radians(_param_fw_r_lim.get()),
+							      radians(_param_fw_r_lim.get()));
+				_att_sp.pitch_body = constrain(_att_sp.pitch_body, radians(_param_fw_p_lim_min.get()),
+							       radians(_param_fw_p_lim_max.get()));
 			}
 
 			if (_control_mode.flag_control_position_enabled ||

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -129,9 +129,9 @@ PARAM_DEFINE_FLOAT(FW_THR_ALT_SCL, 0.0f);
 PARAM_DEFINE_FLOAT(FW_THR_SLEW_MAX, 0.0f);
 
 /**
- * Negative pitch limit
+ * Minimum pitch angle
  *
- * The minimum negative pitch the controller will output.
+ * The minimum pitch angle setpoint for autonomous modes including altitude and position control.
  *
  * @unit deg
  * @min -60.0
@@ -143,9 +143,9 @@ PARAM_DEFINE_FLOAT(FW_THR_SLEW_MAX, 0.0f);
 PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -45.0f);
 
 /**
- * Positive pitch limit
+ * Maximum pitch angle
  *
- * The maximum positive pitch the controller will output.
+ * The maximum pitch angle setpoint for autonomous modes including altitude and position control.
  *
  * @unit deg
  * @min 0.0
@@ -157,9 +157,9 @@ PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -45.0f);
 PARAM_DEFINE_FLOAT(FW_P_LIM_MAX, 45.0f);
 
 /**
- * Controller roll limit
+ * Maximum roll angle
  *
- * The maximum roll the controller will output.
+ * The maximum roll angle setpoint for autonomous modes including altitude and position control.
  *
  * @unit deg
  * @min 35.0


### PR DESCRIPTION
**Describe problem solved by this pull request**
In position and altitude control the roll angle was constrained using the same limits as for stabilized mode.
Additionally, the parameter description of both manual and autonomous limits was not very clear I found.

People might have different opinions on this, please raise concerns if you have any.

**Describe your solution**
Use the same roll constraints as for autonomous modes. Even thought the roll angle is directly controlled by the user, in the context of the modes it makes sense to consistently use the same roll limit. E.g. in altitude and position control altitude and airspeed are both regulated by the controller and excessive roll angle setpoints by the user can cause bad performance and in the worst case a stall.

**Describe possible alternatives**

**Test data / coverage**
Tested in SITL.

**Additional context**
Especially for airspeed-less setups this change can help to avoid overbanking in altitude and position control mode.
