### PR TITLE
actuator outputs: always add reverse range param 

### DIFF
--- a/Tools/module_config/generate_actuators_metadata.py
+++ b/Tools/module_config/generate_actuators_metadata.py
@@ -142,7 +142,6 @@ def get_actuator_output(yaml_config, output_functions, timer_config_file, verbos
         }
     if 'show_subgroups_if' in actuator_output_yaml:
         actuator_output['show-subgroups-if'] = actuator_output_yaml['show_subgroups_if']
-    add_reverse_range_param = actuator_output_yaml.get('add_reverse_range_param', False)
 
     # config parameters
     def get_config_params(param_list):
@@ -257,14 +256,13 @@ def get_actuator_output(yaml_config, output_functions, timer_config_file, verbos
                 per_channel_params.append(param)
 
 
-        if add_reverse_range_param:
-            param = {
-                    'label': 'Rev Range\n(for Servos)',
-                    'name': param_prefix+'_REV',
-                    'index-offset': -1,
-                    'show-as': 'bitset',
-                }
-            per_channel_params.append(param)
+        param = {
+                'label': 'Rev Range\n(for Servos)',
+                'name': param_prefix+'_REV',
+                'index-offset': -1,
+                'show-as': 'bitset',
+            }
+        per_channel_params.append(param)
 
         # TODO: support non-standard per-channel parameters
 

--- a/Tools/module_config/generate_params.py
+++ b/Tools/module_config/generate_params.py
@@ -178,7 +178,6 @@ def get_actuator_output_params(yaml_config, output_functions,
     all_params = {}
     group_idx = 0
 
-    add_reverse_range_param = yaml_config['actuator_output'].get('add_reverse_range_param', False)
     all_param_prefixes = {}
 
     def add_local_param(param_name, param_def):
@@ -299,13 +298,9 @@ Note that non-motor outputs might already be active in prearm state if COM_PREAR
 '''
         minimum_description = \
 '''Minimum output value (when not disarmed).
-
-The output range can be reversed by setting Min > Max.
 '''
         maximum_description = \
 '''Maxmimum output value (when not disarmed).
-
-The output range can be reversed by setting Min > Max.
 '''
         failsafe_description = \
 '''This is the output value that is set when in failsafe mode.
@@ -346,29 +341,29 @@ When set to -1 (default), the value depends on the function (see {:}).
                     }
                 add_local_param(param_prefix+'_'+param_suffix+'${i}', param)
 
-    if add_reverse_range_param:
-        for param_prefix in all_param_prefixes:
-            groups = all_param_prefixes[param_prefix]
-            # collect the bits
-            channel_bits = {}
-            for instance_start, instance_start_label, num_instances, label in groups:
-                for instance in range(instance_start, instance_start+num_instances):
-                    instance_label = instance - instance_start + instance_start_label
-                    channel_bits[instance-1] = label + ' ' + str(instance_label)
+    # add reverse range param
+    for param_prefix in all_param_prefixes:
+        groups = all_param_prefixes[param_prefix]
+        # collect the bits
+        channel_bits = {}
+        for instance_start, instance_start_label, num_instances, label in groups:
+            for instance in range(instance_start, instance_start+num_instances):
+                instance_label = instance - instance_start + instance_start_label
+                channel_bits[instance-1] = label + ' ' + str(instance_label)
 
-            param = {
-                'description': {
-                    'short': 'Reverse Output Range for '+module_name,
-                    'long':
+        param = {
+            'description': {
+                'short': 'Reverse Output Range for '+module_name,
+                'long':
 '''Allows to reverse the output range for each channel.
 Note: this is only useful for servos.
 '''.format(channel_label),
-                    },
-                'type': 'bitmask',
-                'default': 0,
-                'bit': channel_bits
-                }
-            add_local_param(param_prefix+'_REV', param)
+                },
+            'type': 'bitmask',
+            'default': 0,
+            'bit': channel_bits
+            }
+        add_local_param(param_prefix+'_REV', param)
 
     if verbose: print('adding actuator params: {:}'.format(all_params))
     return all_params

--- a/src/drivers/linux_pwm_out/module.yaml
+++ b/src/drivers/linux_pwm_out/module.yaml
@@ -1,6 +1,5 @@
 module_name: PWM Output
 actuator_output:
-  add_reverse_range_param: true
   output_groups:
     - param_prefix: PWM_MAIN
       channel_label: 'Channel'

--- a/src/drivers/pwm_out/module.yaml
+++ b/src/drivers/pwm_out/module.yaml
@@ -1,6 +1,5 @@
 module_name: '${PWM_MAIN_OR_AUX}'
 actuator_output:
-  add_reverse_range_param: true
   output_groups:
     - generator: pwm
       param_prefix: '${PWM_MAIN_OR_AUX}'

--- a/src/drivers/pwm_out_sim/module_hil.yaml
+++ b/src/drivers/pwm_out_sim/module_hil.yaml
@@ -1,7 +1,6 @@
 
 module_name: HIL
 actuator_output:
-  add_reverse_range_param: true
   show_subgroups_if: 'SYS_HITL>0'
   output_groups:
     - param_prefix: HIL_ACT

--- a/src/drivers/pwm_out_sim/module_sim.yaml
+++ b/src/drivers/pwm_out_sim/module_sim.yaml
@@ -1,7 +1,6 @@
 
 module_name: SIM
 actuator_output:
-  add_reverse_range_param: true
   output_groups:
     - param_prefix: PWM_MAIN
       channel_label: Channel

--- a/src/drivers/px4io/module.yaml
+++ b/src/drivers/px4io/module.yaml
@@ -1,6 +1,5 @@
 module_name: PWM MAIN
 actuator_output:
-  add_reverse_range_param: true
   output_groups:
     - generator: pwm
       param_prefix: PWM_MAIN

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -1,6 +1,5 @@
 module_name: UAVCAN
 actuator_output:
-  add_reverse_range_param: true
   show_subgroups_if: 'UAVCAN_ENABLE>=3'
   config_parameters:
     - param: 'UAVCAN_ENABLE'

--- a/src/drivers/uavcan_v1/module.yaml
+++ b/src/drivers/uavcan_v1/module.yaml
@@ -1,6 +1,5 @@
 module_name: UAVCANv1
 actuator_output:
-  add_reverse_range_param: true
   output_groups:
     - param_prefix: UCAN1_ESC
       channel_label: 'ESC'

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -193,8 +193,6 @@ void MixingOutput::updateParams()
 
 		bool function_changed = false;
 
-		_reverse_output_mask = 0;
-
 		for (unsigned i = 0; i < _max_num_outputs; i++) {
 			int32_t val;
 
@@ -219,7 +217,6 @@ void MixingOutput::updateParams()
 			}
 
 			if (_min_value[i] > _max_value[i]) {
-				_reverse_output_mask |= 1 << i;
 				uint16_t tmp = _min_value[i];
 				_min_value[i] = _max_value[i];
 				_max_value[i] = tmp;
@@ -230,10 +227,11 @@ void MixingOutput::updateParams()
 			}
 		}
 
+		_reverse_output_mask = 0;
 		int32_t rev_range_param;
 
 		if (_param_handle_rev_range != PARAM_INVALID && param_get(_param_handle_rev_range, &rev_range_param) == 0) {
-			_reverse_output_mask |= rev_range_param;
+			_reverse_output_mask = rev_range_param;
 		}
 
 		if (function_changed) {

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -45,9 +45,9 @@ parameters:
         # Motor parameters
         CA_R_REV:
             description:
-                short: Reversible motors
+                short: Bidirectional/Reversible motors
                 long: |
-                  Configure motors to be reversible. Note that the output driver needs to support this as well.
+                  Configure motors to be bidirectional/reversible. Note that the output driver needs to support this as well.
             type: bitmask
             bit:
                 0: Motor 1
@@ -394,7 +394,7 @@ mixer:
                 default_is_nan: true
             per_item_parameters:
               - name: 'CA_R_REV'
-                label: 'Reversible'
+                label: 'Bidirectional'
                 show_as: 'bitset'
                 index_offset: 0
                 advanced: true

--- a/validation/module_schema.yaml
+++ b/validation/module_schema.yaml
@@ -251,9 +251,6 @@ actuator_output:
                   function:
                       type: string
                       allowed: [ enable ]
-        add_reverse_range_param:
-            # Add a separate range reversing bitmask param.
-            type: boolean
         output_groups:
             type: list
             minlength: 1


### PR DESCRIPTION
and remove the possibility to set min > max to reverse.

Initially the idea was to add the checkbox on the UI side, to avoid adding
another param, but I don't think I'll go through the extra effort on the
QGC side.