### PR TITLE
fix UAVCAN esc_status publish conflict

### DIFF
--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -126,7 +126,7 @@ private:
 
 	struct Telemetry {
 		DShotTelemetry handler{};
-		uORB::PublicationData<esc_status_s> esc_status_pub{ORB_ID(esc_status)};
+		uORB::PublicationMultiData<esc_status_s> esc_status_pub{ORB_ID(esc_status)};
 		int last_motor_index{-1};
 	};
 

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -65,7 +65,7 @@ public:
 
 
 	UavcanEscController(uavcan::INode &node);
-	~UavcanEscController();
+	~UavcanEscController() = default;
 
 	int init();
 
@@ -85,16 +85,10 @@ private:
 	void esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::esc::Status> &msg);
 
 	/**
-	 * ESC status will be published to ORB from this callback (fixed rate).
-	 */
-	void orb_pub_timer_cb(const uavcan::TimerEvent &event);
-
-	/**
 	 * Checks all the ESCs freshness based on timestamp, if an ESC exceeds the timeout then is flagged offline.
 	 */
 	uint8_t check_escs_status();
 
-	static constexpr unsigned ESC_STATUS_UPDATE_RATE_HZ = 10;
 	static constexpr unsigned UAVCAN_COMMAND_TRANSFER_PRIORITY = 5;	///< 0..31, inclusive, 0 - highest, 31 - lowest
 
 	typedef uavcan::MethodBinder<UavcanEscController *,
@@ -116,7 +110,6 @@ private:
 	uavcan::INode								&_node;
 	uavcan::Publisher<uavcan::equipment::esc::RawCommand>			_uavcan_pub_raw_cmd;
 	uavcan::Subscriber<uavcan::equipment::esc::Status, StatusCbBinder>	_uavcan_sub_status;
-	uavcan::TimerEventForwarder<TimerCbBinder>				_orb_timer;
 
 	/*
 	 * ESC states


### PR DESCRIPTION
UAVCAN esc_status was publishing even with no ESCs attached. Additionally dshot was only publishing to the first esc_status instance.

![image](https://user-images.githubusercontent.com/84712/149009828-653dd0aa-3aa4-4a32-aa62-0830a6c4a406.png)
