### PR TITLE
handle line segment termination in navigator

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -994,7 +994,7 @@ FixedwingPositionControl::handle_setpoint_type(const uint8_t setpoint_type, cons
 			// POSITION: achieve position setpoint altitude via loiter
 			// close to waypoint, but altitude error greater than twice acceptance
 			if ((!_vehicle_status.in_transition_mode) && (dist >= 0.f)
-			    && (dist_z > 2.f * _param_fw_clmbout_diff.get())
+			    && (dist_z > _param_nav_fw_alt_rad.get())
 			    && (dist_xy < 2.f * math::max(acc_rad, loiter_radius_abs))) {
 				// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER
 				position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -447,7 +447,9 @@ private:
 
 		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,
 
-		(ParamFloat<px4::params::FW_TKO_PITCH_MIN>) _takeoff_pitch_min
+		(ParamFloat<px4::params::FW_TKO_PITCH_MIN>) _takeoff_pitch_min,
+
+		(ParamFloat<px4::params::NAV_FW_ALT_RAD>) _param_nav_fw_alt_rad
 
 	)
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -307,8 +307,40 @@ MissionBlock::is_mission_item_reached()
 
 			}
 
-			if (dist_xy >= 0.0f && dist_xy <= acceptance_radius
-			    && dist_z <= alt_acc_rad_m) {
+			bool passed_curr_wp = false;
+
+			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+
+				const float dist_prev_to_curr = get_distance_to_next_waypoint(_navigator->get_position_setpoint_triplet()->previous.lat,
+								_navigator->get_position_setpoint_triplet()->previous.lon, _navigator->get_position_setpoint_triplet()->current.lat,
+								_navigator->get_position_setpoint_triplet()->current.lon);
+
+				if (dist_prev_to_curr > 1.0e-6f && _navigator->get_position_setpoint_triplet()->previous.valid) {
+					// Fixed-wing guidance interprets this condition as line segment following
+
+					// vector from previous waypoint to current waypoint
+					float vector_prev_to_curr_north;
+					float vector_prev_to_curr_east;
+					get_vector_to_next_waypoint_fast(_navigator->get_position_setpoint_triplet()->previous.lat,
+									 _navigator->get_position_setpoint_triplet()->previous.lon, _navigator->get_position_setpoint_triplet()->current.lat,
+									 _navigator->get_position_setpoint_triplet()->current.lon, &vector_prev_to_curr_north,
+									 &vector_prev_to_curr_east);
+
+					// vector from next waypoint to aircraft
+					float vector_curr_to_vehicle_north;
+					float vector_curr_to_vehicle_east;
+					get_vector_to_next_waypoint_fast(_navigator->get_position_setpoint_triplet()->current.lat,
+									 _navigator->get_position_setpoint_triplet()->current.lon, _navigator->get_global_position()->lat,
+									 _navigator->get_global_position()->lon, &vector_curr_to_vehicle_north,
+									 &vector_curr_to_vehicle_east);
+
+					// if dot product of vectors is positive, we are passed the current waypoint (the terminal point on the line segment) and should switch to next mission item
+					passed_curr_wp = vector_prev_to_curr_north * vector_curr_to_vehicle_north + vector_prev_to_curr_east *
+							 vector_curr_to_vehicle_east > 0.0f;
+				}
+			}
+
+			if (dist_xy >= 0.0f && (dist_xy <= acceptance_radius || passed_curr_wp) && dist_z <= alt_acc_rad_m) {
 				_waypoint_position_reached = true;
 			}
 		}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Waypoint item reached criteria for fixed-wing behaviors currently span the navigator, fixed-wing position controller, and L1 guidance library. Each location having slightly varying handling. For the case of waypoints in sequence, current handling strategies include:
- in navigator: check on horizontal acceptance radius + acceptance altitude (```NAV_FW_ALT_RAD```)
- in fw_pos_ctrl_l1: (for the case of loitering up to alt at the terminal waypoint) check on acceptance altitude (```2 * _param_fw_clmbout_diff```)
- in ECL_L1_Pos_Controller: once the aircraft is beyond the terminal waypoint and within some cone, guidance is switched to flying back to the terminal waypoint.
https://github.com/PX4/PX4-Autopilot/blob/463513f31fedad64cfad6d2ede19ef66cf50dff0/src/lib/l1/ECL_L1_Pos_Controller.cpp#L152

The latter condition was implemented to handle the corner case where the aircraft is "passed" the second waypoint, but not within the acceptance radius, and thus not caught for mission progression by the navigator.

**Describe your solution**
This PR attempts to begin some disentanglement of logic by
1. handling the "passed the waypoint" case in the navigator mission item reached check for fixed-wing vehicles following waypoints in sequence (line following) -- i.e. the line segment is considered complete when the aircraft is either passed the second waypoint OR within the acceptance radius (see figure below)
2. using the same acceptance altitude in both navigator and the loiter to alt logic in fw_pos_ctrl_l1 to avoid discrete clunky guidance behavior

![waypoint_logic](https://user-images.githubusercontent.com/8026163/149019203-9418cd9f-e24c-4ae8-8b2f-ad01b22634bf.png)

NOTE: point (1) also offers the advantage that the specific L1 corner case handling is not necessary anymore -- which becomes relevant in #18810

**Test data / coverage**
The same logic was tested in SITL and can be seen https://github.com/PX4/PX4-Autopilot/pull/18810#issuecomment-1004485144
