### PR TITLE
Add CANNODE_GPS_RTCM

### DIFF
--- a/boards/freefly/can-rtk-gps/init/rc.board_defaults
+++ b/boards/freefly/can-rtk-gps/init/rc.board_defaults
@@ -3,8 +3,4 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-param set-default CBRK_IO_SAFETY 0
 param set-default CANNODE_GPS_RTCM 1
-
-safety_button start
-tone_alarm start

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -304,14 +304,25 @@ int UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events
 	_publisher_list.add(new MagneticFieldStrength2(this, _node));
 	_publisher_list.add(new RangeSensorMeasurement(this, _node));
 	_publisher_list.add(new RawAirData(this, _node));
-	_publisher_list.add(new MovingBaselineDataPub(this, _node));
+
+	int32_t enable_movingbaselinedata = 0;
+	param_get(param_find("CANNODE_GPS_RTCM"), &enable_movingbaselinedata);
+
+	if (enable_movingbaselinedata != 0) {
+		_publisher_list.add(new MovingBaselineDataPub(this, _node));
+
+	}
+
 	_publisher_list.add(new SafetyButton(this, _node));
 	_publisher_list.add(new StaticPressure(this, _node));
 	_publisher_list.add(new StaticTemperature(this, _node));
 
 	_subscriber_list.add(new BeepCommand(_node));
 	_subscriber_list.add(new LightsCommand(_node));
-	_subscriber_list.add(new MovingBaselineData(_node));
+
+	if (enable_movingbaselinedata != 0) {
+		_subscriber_list.add(new MovingBaselineData(_node));
+	}
 
 	for (auto &subscriber : _subscriber_list) {
 		subscriber->init();

--- a/src/drivers/uavcannode/uavcannode_params.c
+++ b/src/drivers/uavcannode/uavcannode_params.c
@@ -80,3 +80,12 @@ PARAM_DEFINE_INT32(CANNODE_TERM, 0);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(CANNODE_FLOW_ROT, 0);
+
+/**
+ * Enable RTCM pub/sub
+ *
+ * @boolean
+ * @max 1
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CANNODE_GPS_RTCM, 0);


### PR DESCRIPTION
This PR adds a param to cannodes in order to turn on/off publishing/subscribing to RTCM data. It is set to off by default and for the ARK RTK GPS and Freefly GPS, it is set to on by default.