### PR TITLE
sensors/vehicle_angular_velocity: add IMU_GYRO_DNF_HMC to configure number of ESC RPM notch filter harmonics

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -143,25 +143,28 @@ private:
 
 	static constexpr hrt_abstime DYNAMIC_NOTCH_FITLER_TIMEOUT = 1_s;
 
-	static constexpr int MAX_NUM_ESC_RPM = sizeof(esc_status_s::esc) / sizeof(esc_status_s::esc[0]);
-	static constexpr int MAX_NUM_ESC_RPM_HARMONICS = 3;
+	// ESC RPM
+	static constexpr int MAX_NUM_ESCS = sizeof(esc_status_s::esc) / sizeof(esc_status_s::esc[0]);
 
-	static constexpr int MAX_NUM_FFT_PEAKS = sizeof(sensor_gyro_fft_s::peak_frequencies_x) / sizeof(
-				sensor_gyro_fft_s::peak_frequencies_x[0]);
+	using NotchFilterHarmonic = math::NotchFilter<float>[3][MAX_NUM_ESCS];
+	NotchFilterHarmonic *_dynamic_notch_filter_esc_rpm{nullptr};
 
-	math::NotchFilter<float> _dynamic_notch_filter_esc_rpm[3][MAX_NUM_ESC_RPM][MAX_NUM_ESC_RPM_HARMONICS] {};
-	math::NotchFilter<float> _dynamic_notch_filter_fft[3][MAX_NUM_FFT_PEAKS] {};
-
-	px4::Bitset<MAX_NUM_ESC_RPM> _esc_available{};
-	hrt_abstime _last_esc_rpm_notch_update[MAX_NUM_ESC_RPM] {};
+	int _esc_rpm_harmonics{0};
+	px4::Bitset<MAX_NUM_ESCS> _esc_available{};
+	hrt_abstime _last_esc_rpm_notch_update[MAX_NUM_ESCS] {};
 
 	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_esc_rpm_disable_perf{nullptr};
 
+	// FFT
+	static constexpr int MAX_NUM_FFT_PEAKS = sizeof(sensor_gyro_fft_s::peak_frequencies_x)
+			/ sizeof(sensor_gyro_fft_s::peak_frequencies_x[0]);
+
+	math::NotchFilter<float> _dynamic_notch_filter_fft[3][MAX_NUM_FFT_PEAKS] {};
+
 	perf_counter_t _dynamic_notch_filter_fft_disable_perf{nullptr};
 	perf_counter_t _dynamic_notch_filter_fft_update_perf{nullptr};
 
-	bool _dynamic_notch_esc_rpm_available{false};
 	bool _dynamic_notch_fft_available{false};
 #endif // !CONSTRAINED_FLASH
 
@@ -181,6 +184,7 @@ private:
 	DEFINE_PARAMETERS(
 #if !defined(CONSTRAINED_FLASH)
 		(ParamInt<px4::params::IMU_GYRO_DNF_EN>) _param_imu_gyro_dnf_en,
+		(ParamInt<px4::params::IMU_GYRO_DNF_HMC>) _param_imu_gyro_dnf_hmc,
 		(ParamFloat<px4::params::IMU_GYRO_DNF_BW>) _param_imu_gyro_dnf_bw,
 #endif // !CONSTRAINED_FLASH
 		(ParamFloat<px4::params::IMU_GYRO_CUTOFF>) _param_imu_gyro_cutoff,

--- a/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
+++ b/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c
@@ -147,3 +147,14 @@ PARAM_DEFINE_INT32(IMU_GYRO_DNF_EN, 0);
 * @max 30
 */
 PARAM_DEFINE_FLOAT(IMU_GYRO_DNF_BW, 15.f);
+
+/**
+* IMU gyro dynamic notch filter harmonics
+*
+* ESC RPM number of harmonics (multiples of RPM) for ESC RPM dynamic notch filtering.
+*
+* @group Sensors
+* @min 1
+* @max 7
+*/
+PARAM_DEFINE_INT32(IMU_GYRO_DNF_HMC, 3);


### PR DESCRIPTION
Some vehicles need more than 3 harmonics of the ESC frequency to effectively filter.

### Master on a noisy quad with ESC RPM dynamic notch filtering (dshot telemetry)
![Screenshot from 2022-01-12 21-48-18](https://user-images.githubusercontent.com/84712/149267024-8a7f4190-b9fe-4046-b3f7-432c1fceaf37.png)

To filter out the remaining high frequency noise we need to increase from 3 to 6 (or 7) harmonics.

![image](https://user-images.githubusercontent.com/84712/149267305-68cefa98-f10e-4760-a730-e332494efc56.png)
