### PR TITLE
(WIP) Implementation of CANNODE rangefinder orientation

### DIFF
--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -84,6 +84,8 @@ void UavcanRangefinderBridge::range_sub_cb(const
 
 		uint8_t rangefinder_type = 0;
 		uint8_t rangefinder_orientation = 0;
+		const uint8_t coarse_orientation_upward = 14;
+		const uint8_t coarse_orientation_downward = 15;
 
 		switch (msg.sensor_type) {
 		case uavcan::equipment::range_sensor::Measurement::SENSOR_TYPE_SONAR:
@@ -102,14 +104,14 @@ void UavcanRangefinderBridge::range_sub_cb(const
 		}
 
 		if (msg.beam_orientation_in_body_frame.orientation_defined) {
-			// Yaw is the second element per DSDL
+			// Pitch is the second element per DSDL
 
 			switch (msg.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1]) {
-			case distance_sensor_s::ROTATION_UPWARD_FACING:
+			case coarse_orientation_upward:
 				rangefinder_orientation = distance_sensor_s::ROTATION_UPWARD_FACING;
 				break;
 
-			case distance_sensor_s::ROTATION_DOWNWARD_FACING:
+			case coarse_orientation_downward:
 				rangefinder_orientation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 				break;
 
@@ -117,7 +119,7 @@ void UavcanRangefinderBridge::range_sub_cb(const
 				break;
 			}
 
-			// Pitch is the third element per DSDL
+			// Yaw is the third element per DSDL
 
 			switch (msg.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2]) {
 			case distance_sensor_s::ROTATION_FORWARD_FACING:

--- a/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
+++ b/src/drivers/uavcannode/Publishers/RangeSensorMeasurement.hpp
@@ -77,7 +77,6 @@ public:
 		// distance_sensor[] -> uavcan::equipment::range_sensor::Measurement
 		distance_sensor_s dist;
 
-
 		if (uORB::SubscriptionCallbackWorkItem::update(&dist)) {
 			uavcan::equipment::range_sensor::Measurement range_sensor{};
 
@@ -86,8 +85,7 @@ public:
 			range_sensor.field_of_view = dist.h_fov;
 			range_sensor.beam_orientation_in_body_frame.orientation_defined = _is_orient_defined;
 
-
-			// sensor type
+			// sensor typeA
 			switch (dist.type) {
 			case distance_sensor_s::MAV_DISTANCE_SENSOR_LASER:
 				range_sensor.sensor_type = uavcan::equipment::range_sensor::Measurement::SENSOR_TYPE_LIDAR;
@@ -121,38 +119,38 @@ public:
 				range_sensor.reading_type = uavcan::equipment::range_sensor::Measurement::READING_TYPE_UNDEFINED;
 			}
 
-			uavcan::Publisher<uavcan::equipment::range_sensor::Measurement>::broadcast(range_sensor);
-
 			// Param Orientation
 			switch (_rng_orientation) {
 			case distance_sensor_s::ROTATION_FORWARD_FACING:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 0;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 0;
 				break;
 
 			case distance_sensor_s::ROTATION_RIGHT_FACING:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 2;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 2;
 				break;
 
 			case distance_sensor_s::ROTATION_BACKWARD_FACING:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 4;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 4;
 				break;
 
 			case distance_sensor_s::ROTATION_LEFT_FACING:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 6;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 6;
 				break;
 
 			case distance_sensor_s::ROTATION_UPWARD_FACING:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 24;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 14;
 				break;
 
 			case distance_sensor_s::ROTATION_DOWNWARD_FACING:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 25;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 15;
 				break;
 
 			default:
-				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[2] = 25;
+				range_sensor.beam_orientation_in_body_frame.fixed_axis_roll_pitch_yaw[1] = 15;
 				break;
 			}
+
+			uavcan::Publisher<uavcan::equipment::range_sensor::Measurement>::broadcast(range_sensor);
 
 			// ensure callback is registered
 			uORB::SubscriptionCallbackWorkItem::registerCallback();

--- a/src/drivers/uavcannode/uavcannode_params.c
+++ b/src/drivers/uavcannode/uavcannode_params.c
@@ -89,3 +89,15 @@ PARAM_DEFINE_INT32(CANNODE_FLOW_ROT, 0);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(CANNODE_GPS_RTCM, 0);
+
+/**
+ * Rangefinder Orientations
+ *
+ * @value 24    pitch 90°    Rotation Upward Facing
+ * @value 25    pitch 270°   Rotation Downward Facing
+ * @value 0     yaw   0°     Rotation Forward Facing
+ * @value 2     yaw   90°    Rotation Right Facing
+ * @value 4     yaw   180°   Rotation Backward Facing
+ * @value 6     yaw   270°   Rotation Left Facing
+ */
+PARAM_DEFINE_INT32(CANNODE_RNG_ORIENT, 25)


### PR DESCRIPTION
Signed-off-by: dirksavage88 <dirksavage88@gmail.com>

Support for setting Cannode rangefinder orientation using a existing uavcan data type.

Set rangefinder orientation with parameter CANNODE_RNG_ORIENT.

Use existing Coarse Orientation uavcan messages to send orientation to the uavcan drivers. If this value is set, use a boolean value assigned to finding the px4 specific parameter (this will prevent compatibility issues with existing Ardupilot AP Periph rangefinder parameters). Current solution is to just pass through the default downward facing orientation if the Px4 parameter is not found.

Alternative is to pull rotation values from the distance driver instance from the cannode, but the orientation will be hard-coded per rc board defaults. Other alternative is to align with Ardupilot AP Periph parameters.
