### PR TITLE
setup: don't install ccache

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -48,7 +48,6 @@ echo "Installing PX4 general dependencies"
 sudo pacman -Sy --noconfirm --needed \
 	astyle \
 	base-devel \
-	ccache \
 	clang \
 	cmake \
 	cppcheck \

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -77,7 +77,6 @@ sudo apt-get update -y --quiet
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 	astyle \
 	build-essential \
-	ccache \
 	cmake \
 	cppcheck \
 	file \
@@ -100,12 +99,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 	unzip \
 	zip \
 	;
-
-if [[ "${UBUNTU_RELEASE}" == "16.04" ]]; then
-	echo "Installing Ubuntu 16.04 PX4-compatible ccache version"
-	wget -O /tmp/ccache_3.4.1-1_amd64.deb http://launchpadlibrarian.net/356662933/ccache_3.4.1-1_amd64.deb
-	sudo dpkg -i /tmp/ccache_3.4.1-1_amd64.deb
-fi
 
 # Python3 dependencies
 echo


### PR DESCRIPTION
I don't think the PX4 setup script should decide whether a user is to use ccache or not. Anecdotally, I've heard from some in the dev team that they are not using it themselves, so I don't think there is a good basis to push it onto others.

That being said, we can of course still use ccache as part of the CI builds nevertheless.