### PR TITLE
AirspeedValidator: increase gate sizes

### DIFF
--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -98,7 +98,6 @@ public:
 	void set_wind_estimator_beta_noise(float beta_var) { _wind_estimator.set_beta_noise(beta_var); }
 	void set_wind_estimator_tas_gate(uint8_t gate_size)
 	{
-		_tas_gate = gate_size;
 		_wind_estimator.set_tas_gate(gate_size);
 	}
 
@@ -147,7 +146,6 @@ private:
 	static constexpr uint64_t DATA_STUCK_TIMEOUT{2_s}; ///< timeout after which data stuck check triggers when data is flat
 
 	// states of innovation check
-	float _tas_gate{1.0f}; ///< gate size of airspeed innovation (to calculate tas_test_ratio)
 	bool _innovations_check_failed{false};  ///< true when airspeed innovations have failed consistency checks
 	float _tas_innov_threshold{1.0}; ///< innovation error threshold for triggering innovation check failure
 	float _tas_innov_integ_threshold{-1.0}; ///< integrator innovation error threshold for triggering innovation check failure

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -61,7 +61,7 @@ PARAM_DEFINE_FLOAT(ASPD_BETA_NOISE, 0.3f);
  * @unit SD
  * @group Airspeed Validator
  */
-PARAM_DEFINE_INT32(ASPD_TAS_GATE, 3);
+PARAM_DEFINE_INT32(ASPD_TAS_GATE, 5);
 
 /**
  * Airspeed Selector: Gate size for sideslip angle fusion
@@ -73,7 +73,7 @@ PARAM_DEFINE_INT32(ASPD_TAS_GATE, 3);
  * @unit SD
  * @group Airspeed Validator
  */
-PARAM_DEFINE_INT32(ASPD_BETA_GATE, 1);
+PARAM_DEFINE_INT32(ASPD_BETA_GATE, 2);
 
 /**
  * Controls when to apply the new estimated airspeed scale(s)


### PR DESCRIPTION
**Describe problem solved by this pull request**
While troubleshooting this [comment](https://github.com/PX4/PX4-Autopilot/pull/18810#issuecomment-1010401914), I found that in SITL the wind estimation inside the airspeed validator breaks down for wind speeds larger than 10m/s, resulting in false-positive airspeed failure detection. Increasing the gate sizes helps. 

**Describe your solution**
Increase the gate size for airspeed (5) and beta (2) fusion. As the sole purpose of the wind estimator inside the validator is for detecting airspeed sensor issues, it doesn't make that much sense to reject its fusion, as the chance of a healthy airspeed sensor publishing data that need to be rejected is rather small.

**Describe possible alternatives**
Overall I think we can improve the wind estimator further, the EKF wind states usually look better. At least in SITL, where comparison to the ground truth is easy, but also on real vehicles the convergence usually is smoother.

**Test data / coverage**
SITL


