### PR TITLE
Wind Estimator: use vehicle heading instead of course for initialisation

### DIFF
--- a/src/lib/wind_estimator/WindEstimator.hpp
+++ b/src/lib/wind_estimator/WindEstimator.hpp
@@ -58,7 +58,7 @@ public:
 	void update(uint64_t time_now);
 
 	void fuse_airspeed(uint64_t time_now, float true_airspeed, const matrix::Vector3f &velI,
-			   const matrix::Vector2f &velIvar);
+			   const matrix::Vector2f &velIvar, const matrix::Quatf &q_att);
 	void fuse_beta(uint64_t time_now, const matrix::Vector3f &velI, const matrix::Quatf &q_att);
 
 	bool is_estimate_valid() { return _initialised; }
@@ -123,7 +123,8 @@ private:
 	bool _wind_estimator_reset = false; ///< wind estimator was reset in this cycle
 
 	// initialise state and state covariance matrix
-	bool initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas);
+	bool initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas,
+			const matrix::Quatf q_att);
 
 	void run_sanity_checks();
 };

--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -82,7 +82,7 @@ AirspeedValidator::update_wind_estimator(const uint64_t time_now_usec, float air
 
 		// airspeed fusion (with raw TAS)
 		const Vector3f vel_var{Dcmf(q) *Vector3f{lpos_evh, lpos_evh, lpos_evv}};
-		_wind_estimator.fuse_airspeed(time_now_usec, airspeed_true_raw, vI, Vector2f{vel_var(0), vel_var(1)});
+		_wind_estimator.fuse_airspeed(time_now_usec, airspeed_true_raw, vI, Vector2f{vel_var(0), vel_var(1)}, q);
 
 		// sideslip fusion
 		_wind_estimator.fuse_beta(time_now_usec, vI, q);

--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -98,7 +98,6 @@ public:
 	void set_wind_estimator_beta_noise(float beta_var) { _wind_estimator.set_beta_noise(beta_var); }
 	void set_wind_estimator_tas_gate(uint8_t gate_size)
 	{
-		_tas_gate = gate_size;
 		_wind_estimator.set_tas_gate(gate_size);
 	}
 
@@ -147,7 +146,6 @@ private:
 	static constexpr uint64_t DATA_STUCK_TIMEOUT{2_s}; ///< timeout after which data stuck check triggers when data is flat
 
 	// states of innovation check
-	float _tas_gate{1.0f}; ///< gate size of airspeed innovation (to calculate tas_test_ratio)
 	bool _innovations_check_failed{false};  ///< true when airspeed innovations have failed consistency checks
 	float _tas_innov_threshold{1.0}; ///< innovation error threshold for triggering innovation check failure
 	float _tas_innov_integ_threshold{-1.0}; ///< integrator innovation error threshold for triggering innovation check failure


### PR DESCRIPTION
Replaces https://github.com/PX4/PX4-Autopilot/pull/19011

**Describe problem solved by this pull request**
Currently the ground course is used to map the airspeed measurement to a airspeed vector during the wind speed initialization (wind = ground - airspeed), as the airspeed sensor always points into the direction of the vehicle.

**Describe your solution**
Use vehicle heading. 

**Test data / coverage**
SITL
New:
![image](https://user-images.githubusercontent.com/26798987/149557712-75f75d6b-5610-4fde-b611-594d092df35c.png)
Old:
![image](https://user-images.githubusercontent.com/26798987/149557787-9ab06421-7513-48ad-a2d8-2bbb0d970e54.png)


**Additional context**

