### PR TITLE
Update current year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2012 - 2021, PX4 Development Team
+Copyright (c) 2012 - 2022, PX4 Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
2021 now is in the past.

**Describe problem solved by this pull request**
Date in the LICENSE file was not correct.

**Describe your solution**
Now it is changed to 2022.

**Describe possible alternatives**
No possible alternatives until 2023.

**Test data / coverage**
Compared with the calendar.

**Additional context**
Happy new year!
