### PR TITLE
lib/wind_estimator: pass q_att as const reference

### DIFF
--- a/src/lib/wind_estimator/WindEstimator.cpp
+++ b/src/lib/wind_estimator/WindEstimator.cpp
@@ -40,7 +40,7 @@
 
 bool
 WindEstimator::initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas,
-			  const matrix::Quatf q_att)
+			  const matrix::Quatf &q_att)
 {
 	// do no initialise if ground velocity is low
 	// this should prevent the filter from initialising on the ground

--- a/src/lib/wind_estimator/WindEstimator.hpp
+++ b/src/lib/wind_estimator/WindEstimator.hpp
@@ -124,7 +124,7 @@ private:
 
 	// initialise state and state covariance matrix
 	bool initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas,
-			const matrix::Quatf q_att);
+			const matrix::Quatf &q_att);
 
 	void run_sanity_checks();
 };


### PR DESCRIPTION
Trivial clang-tidy complaint introduced in https://github.com/PX4/PX4-Autopilot/pull/19013. 

FYI @sfuhrer 