### PR TITLE
Add offboard path tracking for fixedwing vehicles using NPFG

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -44,6 +44,8 @@ param set-default MIS_TAKEOFF_ALT 30
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
+param set-default FW_USE_NPFG 1
+
 param set-default RWTO_TKOFF 1
 
 set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix

--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -617,6 +617,25 @@ void NPFG::navigateLoiter(const Vector2d &loiter_center, const Vector2d &vehicle
 	updateRollSetpoint();
 } // navigateLoiter
 
+
+void NPFG::navigatePathTangent(const matrix::Vector2d &vehicle_pos, const matrix::Vector2d &position_setpoint,
+			       const matrix::Vector2f &tangent_setpoint,
+			       const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature)
+{
+	path_type_loiter_ = false;
+
+	// set unit tangent directly
+	unit_path_tangent_ = tangent_setpoint.normalized();
+
+	// closest point to vehicle
+	matrix::Vector2f error_vector = getLocalPlanarVector(position_setpoint, vehicle_pos);
+	signed_track_error_ = cross2D(unit_path_tangent_, error_vector);
+
+	guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, curvature);
+
+	updateRollSetpoint();
+} // navigatePathTangent
+
 void NPFG::navigateHeading(float heading_ref, const Vector2f &ground_vel, const Vector2f &wind_vel)
 {
 	path_type_loiter_ = false;

--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -249,6 +249,21 @@ public:
 			    const matrix::Vector2f &wind_vel);
 
 	/*
+	 * Path following logic. Takes poisiton, path tangent, curvature and
+	 * then updates control setpoints to follow a path setpoint.
+	 *
+	 * @param[in] vehicle_pos vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] position_setpoint closest point on a path in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] tangent_setpoint unit tangent vector of the path [m]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 * @param[in] curvature of the path setpoint [1/m]
+	 */
+	void navigatePathTangent(const matrix::Vector2d &vehicle_pos, const matrix::Vector2d &position_setpoint,
+				 const matrix::Vector2f &tangent_setpoint,
+				 const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature);
+
+	/*
 	 * Navigate on a fixed heading.
 	 *
 	 * This only holds a certain (air mass relative) direction and does not perform

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1197,13 +1197,13 @@ FixedwingPositionControl::control_auto_position(const hrt_abstime &now, const fl
 			matrix::Vector2f velocity_2d(pos_sp_curr.vx, pos_sp_curr.vy);
 			float curvature = PX4_ISFINITE(_pos_sp_triplet.current.loiter_radius) ? 1 / _pos_sp_triplet.current.loiter_radius :
 					  0.0f;
-			_npfg.navigatePathTangent(curr_pos, curr_wp, velocity_2d.normalized(), ground_speed, _wind_vel, curvature);
+			_npfg.navigatePathTangent(curr_pos, curr_wp, velocity_2d.normalized(), get_nav_speed_2d(ground_speed), _wind_vel,
+						  curvature);
 
 		} else {
-			_npfg.navigateWaypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_vel);
+			_npfg.navigateWaypoints(prev_wp, curr_wp, curr_pos, get_nav_speed_2d(ground_speed), _wind_vel);
 		}
 
-		_npfg.navigateWaypoints(prev_wp, curr_wp, curr_pos, get_nav_speed_2d(ground_speed), _wind_vel);
 		_att_sp.roll_body = _npfg.getRollSetpoint();
 		target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixedwing vehicles have mainly been controlled using waypoints. However, this makes it challenging to operate fixedwing vehicles close to obstacles/terrain since it is hard to predict the trajectory of the vehicle without executing the mission. 

Given that Fixedwing vehicles are more influenced by wind compared to multirotors, it is better for the vehicle to track a given **path** rather than a time stamped **trajectory**. With NPFG available in PX4, we can now precisely track arbitrary paths.

**Describe your solution**
This PR adds a path tracking interface using offboard mode for fixedwing vehicles. The vehicle can follow arbitrary paths by passing a. a position setpoint, which should be the closest point on the path b. a velocity vector, which should be the path tangent of the desired path. c. The curvature of the path. 

- Enabled NPFG by default for the believer SITL Gazebo model
- The image below shows this interface integrated into a motion primitive planner ( yellow lines are the reference path and blue is the vehicle trajectory) 

![142743574-9aaa952b-c162-4655-808f-a0dbd4776376](https://user-images.githubusercontent.com/5248102/149933092-871c03c4-0acd-49b8-b251-e2e212d465f8.png)


**Test data / coverage**
- WIP testing with upstream


**Additional context**
- NPFG needs to be enabled for this usecase https://github.com/PX4/PX4-Autopilot/pull/18810
