### PR TITLE
Battery failsafe delay

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -791,8 +791,6 @@ Commander::Commander() :
 	ModuleParams(nullptr),
 	_failure_detector(this)
 {
-	_auto_disarm_landed.set_hysteresis_time_from(false, _param_com_disarm_preflight.get() * 1_s);
-
 	_land_detector.landed = true;
 
 	// XXX for now just set sensors as initialized
@@ -2046,6 +2044,7 @@ Commander::run()
 			_arm_requirements.geofence = _param_geofence_action.get() > geofence_result_s::GF_ACTION_NONE;
 
 			_auto_disarm_killed.set_hysteresis_time_from(false, _param_com_kill_disarm.get() * 1_s);
+			_offboard_available.set_hysteresis_time_from(true, _param_com_of_loss_t.get() * 1_s);
 
 			// disable arm gesture if an arm switch is configured
 			if (param_man_arm_gesture != PARAM_INVALID && param_rc_map_arm_sw != PARAM_INVALID) {
@@ -2082,8 +2081,6 @@ Commander::run()
 						     "Yaw Airmode requires disabling the stick arm gesture");
 				}
 			}
-
-			_offboard_available.set_hysteresis_time_from(true, _param_com_of_loss_t.get() * 1e6f);
 
 			param_init_forced = false;
 		}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3891,8 +3891,16 @@ void Commander::battery_status_check()
 		warn_user_about_battery(&_mavlink_log_pub, _battery_warning);
 		_battery_failsafe_timestamp = hrt_absolute_time();
 
-		if (get_battery_failsafe_action(_internal_state, _battery_warning,
-						(low_battery_action_t)_param_com_low_bat_act.get()) != commander_state_s::MAIN_STATE_MAX) {
+		uint8_t failsafe_action = get_battery_failsafe_action(_internal_state, _battery_warning,
+					  (low_battery_action_t)_param_com_low_bat_act.get());
+
+		if (_param_com_bat_act_t.get() > 0.f
+		    && failsafe_action != commander_state_s::MAIN_STATE_MAX) {
+			mavlink_log_critical(&_mavlink_log_pub, "Executing %s in %d seconds",
+					     main_state_str(failsafe_action), static_cast<uint16_t>(_param_com_bat_act_t.get()));
+			events::send<events::px4::enums::navigation_mode_t, uint16_t>(events::ID("commander_low_bat_action"), {events::Log::Critical, events::LogInternal::Warning},
+					"Executing {1} in {2} seconds",
+					navigation_mode(failsafe_action), static_cast<uint16_t>(_param_com_bat_act_t.get()));
 			main_state_transition(_status, commander_state_s::MAIN_STATE_AUTO_LOITER, _status_flags, _internal_state);
 		}
 	}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3907,7 +3907,8 @@ void Commander::battery_status_check()
 
 	if (_battery_failsafe_timestamp != 0
 	    && hrt_elapsed_time(&_battery_failsafe_timestamp) > _param_com_bat_act_t.get() * 1_s
-	    && _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER) {
+	    && (_internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER
+		|| _vehicle_control_mode.flag_control_auto_enabled)) {
 		_battery_failsafe_timestamp = 0;
 		uint8_t failsafe_action = get_battery_failsafe_action(_internal_state, _battery_warning,
 					  (low_battery_action_t)_param_com_low_bat_act.get());

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3879,7 +3879,6 @@ void Commander::battery_status_check()
 		_battery_warning = worst_warning;
 	}
 
-
 	_status_flags.condition_battery_healthy =
 		// All connected batteries are regularly being published
 		(hrt_elapsed_time(&oldest_update) < 5_s)
@@ -3893,6 +3892,18 @@ void Commander::battery_status_check()
 	// execute battery failsafe if the state has gotten worse while we are armed
 	if (battery_warning_level_increased_while_armed) {
 		warn_user_about_battery(&_mavlink_log_pub, _battery_warning);
+		_battery_failsafe_timestamp = hrt_absolute_time();
+
+		if (get_battery_failsafe_action(_internal_state, _battery_warning,
+						(low_battery_action_t)_param_com_low_bat_act.get()) != commander_state_s::MAIN_STATE_MAX) {
+			main_state_transition(_status, commander_state_s::MAIN_STATE_AUTO_LOITER, _status_flags, _internal_state);
+		}
+	}
+
+	if (_battery_failsafe_timestamp != 0
+	    && hrt_elapsed_time(&_battery_failsafe_timestamp) > _param_com_bat_act_t.get() * 1_s
+	    && _internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER) {
+		_battery_failsafe_timestamp = 0;
 		uint8_t failsafe_action = get_battery_failsafe_action(_internal_state, _battery_warning,
 					  (low_battery_action_t)_param_com_low_bat_act.get());
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3893,7 +3893,14 @@ void Commander::battery_status_check()
 	// execute battery failsafe if the state has gotten worse while we are armed
 	if (battery_warning_level_increased_while_armed) {
 		warn_user_about_battery(&_mavlink_log_pub, _battery_warning);
-		act_on_battery_failsafe(_internal_state, _battery_warning, (low_battery_action_t)_param_com_low_bat_act.get());
+		uint8_t failsafe_action = get_battery_failsafe_action(_internal_state, _battery_warning,
+					  (low_battery_action_t)_param_com_low_bat_act.get());
+
+		if (failsafe_action != commander_state_s::MAIN_STATE_MAX) {
+			_internal_state.main_state = failsafe_action;
+			_internal_state.main_state_changes++;
+			_internal_state.timestamp = hrt_absolute_time();
+		}
 	}
 
 	// Handle shutdown request from emergency battery action

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3892,8 +3892,8 @@ void Commander::battery_status_check()
 
 	// execute battery failsafe if the state has gotten worse while we are armed
 	if (battery_warning_level_increased_while_armed) {
-		battery_failsafe(&_mavlink_log_pub, _status, _status_flags, _internal_state, _battery_warning,
-				 (low_battery_action_t)_param_com_low_bat_act.get());
+		warn_user_about_battery(&_mavlink_log_pub, _battery_warning);
+		act_on_battery_failsafe(_internal_state, _battery_warning, (low_battery_action_t)_param_com_low_bat_act.get());
 	}
 
 	// Handle shutdown request from emergency battery action

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3888,19 +3888,17 @@ void Commander::battery_status_check()
 
 	// execute battery failsafe if the state has gotten worse while we are armed
 	if (battery_warning_level_increased_while_armed) {
-		warn_user_about_battery(&_mavlink_log_pub, _battery_warning);
-		_battery_failsafe_timestamp = hrt_absolute_time();
-
 		uint8_t failsafe_action = get_battery_failsafe_action(_internal_state, _battery_warning,
 					  (low_battery_action_t)_param_com_low_bat_act.get());
 
+		warn_user_about_battery(&_mavlink_log_pub, _battery_warning,
+					failsafe_action, _param_com_bat_act_t.get(),
+					main_state_str(failsafe_action), navigation_mode(failsafe_action));
+		_battery_failsafe_timestamp = hrt_absolute_time();
+
+		// Switch to loiter to wait for the reaction delay
 		if (_param_com_bat_act_t.get() > 0.f
 		    && failsafe_action != commander_state_s::MAIN_STATE_MAX) {
-			mavlink_log_critical(&_mavlink_log_pub, "Executing %s in %d seconds",
-					     main_state_str(failsafe_action), static_cast<uint16_t>(_param_com_bat_act_t.get()));
-			events::send<events::px4::enums::navigation_mode_t, uint16_t>(events::ID("commander_low_bat_action"), {events::Log::Critical, events::LogInternal::Warning},
-					"Executing {1} in {2} seconds",
-					navigation_mode(failsafe_action), static_cast<uint16_t>(_param_com_bat_act_t.get()));
 			main_state_transition(_status, commander_state_s::MAIN_STATE_AUTO_LOITER, _status_flags, _internal_state);
 		}
 	}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2414,14 +2414,14 @@ Commander::run()
 		_geofence_result_sub.update(&_geofence_result);
 		_status.geofence_violated = _geofence_result.geofence_violated;
 
-		const bool in_low_battery_failsafe = _battery_warning > battery_status_s::BATTERY_WARNING_LOW;
+		const bool in_low_battery_failsafe_delay = _battery_failsafe_timestamp != 0;
 
 		// Geofence actions
 		const bool geofence_action_enabled = _geofence_result.geofence_action != geofence_result_s::GF_ACTION_NONE;
 
 		if (_armed.armed
 		    && geofence_action_enabled
-		    && !in_low_battery_failsafe) {
+		    && !in_low_battery_failsafe_delay) {
 
 			// check for geofence violation transition
 			if (_geofence_result.geofence_violated && !_geofence_violated_prev) {
@@ -2602,7 +2602,7 @@ Commander::run()
 			// Abort autonomous mode and switch to position mode if sticks are moved significantly
 			// but only if actually in air.
 			if ((_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
-			    && !in_low_battery_failsafe && !_geofence_warning_action_on
+			    && !in_low_battery_failsafe_delay && !_geofence_warning_action_on
 			    && _armed.armed
 			    && !_status_flags.rc_calibration_in_progress
 			    && manual_control_setpoint.valid

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -211,6 +211,7 @@ private:
 		(ParamInt<px4::params::COM_POS_FS_GAIN>) _param_com_pos_fs_gain,
 
 		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _param_com_low_bat_act,
+		(ParamFloat<px4::params::COM_BAT_ACT_T>) _param_com_bat_act_t,
 		(ParamInt<px4::params::COM_IMB_PROP_ACT>) _param_com_imb_prop_act,
 		(ParamFloat<px4::params::COM_DISARM_LAND>) _param_com_disarm_land,
 		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_preflight,
@@ -343,6 +344,7 @@ private:
 	hrt_abstime	_last_esc_status_updated{0};
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
+	hrt_abstime	_battery_failsafe_timestamp{0};
 	float		_battery_current{0.0f};
 	uint8_t		_last_connected_batteries{0};
 	uint32_t	_last_battery_custom_fault[battery_status_s::MAX_INSTANCES] {};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -353,6 +353,22 @@ PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
 PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
 
 /**
+ * Delay between battery state change and failsafe reaction
+ *
+ * Battery state requires action -> wait COM_BAT_ACT_T seconds for the user to realize and take custom action
+ * React with failsafe action COM_LOW_BAT_ACT
+ *
+ * A zero value disables the delay.
+ *
+ * @group Commander
+ * @unit s
+ * @min 0.0
+ * @max 25.0
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(COM_BAT_ACT_T, 10.0f);
+
+/**
  * Imbalanced propeller failsafe mode
  *
  * Action the system takes when an imbalanced propeller is detected by the failure detector.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -189,7 +189,7 @@ PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
  * Delay between RC loss and configured reaction
  *
  * RC signal not updated -> still use data for COM_RC_LOSS_T seconds
- * Consider RC signal lost -> wait COM_RCL_ACT_T seconds on the spot waiting to regain signal
+ * Consider RC signal lost -> wait COM_RCL_ACT_T seconds in Hold mode to regain signal
  * React with failsafe action NAV_RCL_ACT
  *
  * A zero value disables the delay.
@@ -355,8 +355,9 @@ PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
 /**
  * Delay between battery state change and failsafe reaction
  *
- * Battery state requires action -> wait COM_BAT_ACT_T seconds for the user to realize and take custom action
- * React with failsafe action COM_LOW_BAT_ACT
+ * Battery state requires action -> wait COM_BAT_ACT_T seconds in Hold mode
+ * for the user to realize and take a custom action
+ * -> React with failsafe action COM_LOW_BAT_ACT
  *
  * A zero value disables the delay.
  *

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1106,32 +1106,43 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		      const vehicle_status_flags_s &status_flags, commander_state_s &internal_state, const uint8_t battery_warning,
 		      const low_battery_action_t low_battery_action)
 {
-	switch (battery_warning) {
-	case battery_status_s::BATTERY_WARNING_NONE:
-		break;
+	static constexpr char battery_level[] = "battery level";
 
+	// User warning
+	switch (battery_warning) {
 	case battery_status_s::BATTERY_WARNING_LOW:
-		mavlink_log_critical(mavlink_log_pub, "Low battery level! Return advised\t");
+		mavlink_log_warning(mavlink_log_pub, "Low %s, return advised\t", battery_level);
 		events::send(events::ID("commander_bat_low"), {events::Log::Warning, events::LogInternal::Info},
-			     "Low battery level! Return advised");
+			     "Low battery level, return advised");
 		break;
 
 	case battery_status_s::BATTERY_WARNING_CRITICAL:
+		mavlink_log_critical(mavlink_log_pub, "Critical %s, return encouraged\t", battery_level);
+		events::send(events::ID("commander_bat_crit"), {events::Log::Critical, events::LogInternal::Info},
+			     "Critical battery level, return encouraged");
+		break;
 
-		static constexpr char battery_critical[] = "Critical battery level!";
+	case battery_status_s::BATTERY_WARNING_EMERGENCY:
+		mavlink_log_emergency(mavlink_log_pub, "Dangerous %s, land now\t", battery_level);
+		events::send(events::ID("commander_bat_emerg"), {events::Log::Emergency, events::LogInternal::Info},
+			     "Dangerous battery level, land now");
+		break;
 
+	case battery_status_s::BATTERY_WARNING_FAILED:
+		mavlink_log_emergency(mavlink_log_pub, "Battery failure detected, land and check battery\t");
+		events::send(events::ID("commander_bat_failure"), events::Log::Emergency,
+			     "Battery failure detected, land and check battery");
+		break;
+
+	case battery_status_s::BATTERY_WARNING_NONE: break; // no warning
+	}
+
+	// Failsafe action
+	switch (battery_warning) {
+	case battery_status_s::BATTERY_WARNING_CRITICAL:
 		switch (low_battery_action) {
-		case LOW_BAT_ACTION::WARNING:
-			mavlink_log_critical(mavlink_log_pub, "%s, landing advised\t", battery_critical);
-			events::send(events::ID("commander_bat_crit"), {events::Log::Critical, events::LogInternal::Info},
-				     "Critical battery level! Landing advised");
-			break;
-
 		case LOW_BAT_ACTION::RETURN:
-
-		// FALLTHROUGH
 		case LOW_BAT_ACTION::RETURN_OR_LAND:
-
 			if (status_flags.condition_global_position_valid && status_flags.condition_home_position_valid) {
 				if (!(internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL ||
 				      internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
@@ -1139,9 +1150,6 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 
 					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
 					internal_state.timestamp = hrt_absolute_time();
-					mavlink_log_critical(mavlink_log_pub, "%s, executing RTL\t", battery_critical);
-					events::send(events::ID("commander_bat_crit_rtl"), {events::Log::Critical, events::LogInternal::Info},
-						     "Critical battery level! Executing RTL");
 				}
 
 			} else {
@@ -1149,9 +1157,6 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 				      internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND)) {
 					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 					internal_state.timestamp = hrt_absolute_time();
-					mavlink_log_emergency(mavlink_log_pub, "%s, can't execute RTL, landing instead\t", battery_critical);
-					events::send(events::ID("commander_bat_crit_no_rtl_land"), {events::Log::Emergency, events::LogInternal::Info},
-						     "Critical battery level! Cannot execute RTL, landing instead");
 				}
 			}
 
@@ -1162,27 +1167,17 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 			      internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND)) {
 				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 				internal_state.timestamp = hrt_absolute_time();
-				mavlink_log_emergency(mavlink_log_pub, "%s, landing\t", battery_critical);
-				events::send(events::ID("commander_bat_crit_land"), {events::Log::Warning, events::LogInternal::Info},
-					     "Critical battery level! Landing now");
 			}
 
 			break;
+
+		case LOW_BAT_ACTION::WARNING: break; // no action
 		}
 
 		break;
 
 	case battery_status_s::BATTERY_WARNING_EMERGENCY:
-
-		static constexpr char battery_dangerous[] = "Dangerous battery level!";
-
 		switch (low_battery_action) {
-		case LOW_BAT_ACTION::WARNING:
-			mavlink_log_emergency(mavlink_log_pub, "%s, please land!\t", battery_dangerous);
-			events::send(events::ID("commander_bat_emerg_warn"), {events::Log::Emergency, events::LogInternal::Info},
-				     "Dangerous battery level! Please land immediately");
-			break;
-
 		case LOW_BAT_ACTION::RETURN:
 			if (status_flags.condition_global_position_valid && status_flags.condition_home_position_valid) {
 				if (!(internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL ||
@@ -1190,9 +1185,6 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 				      internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND)) {
 					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
 					internal_state.timestamp = hrt_absolute_time();
-					mavlink_log_critical(mavlink_log_pub, "%s, executing RTL\t", battery_dangerous);
-					events::send(events::ID("commander_bat_emerg_rtl"), {events::Log::Emergency, events::LogInternal::Info},
-						     "Dangerous battery level! Executing RTL");
 				}
 
 			} else {
@@ -1200,35 +1192,24 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 				      internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND)) {
 					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 					internal_state.timestamp = hrt_absolute_time();
-					mavlink_log_emergency(mavlink_log_pub, "%s, can't execute RTL, landing instead\t", battery_dangerous);
-					events::send(events::ID("commander_bat_emerg_no_rtl_land"), {events::Log::Emergency, events::LogInternal::Info},
-						     "Dangerous battery level! Cannot execute RTL, landing instead");
 				}
 			}
 
 			break;
 
 		case LOW_BAT_ACTION::RETURN_OR_LAND:
-
-		// FALLTHROUGH
 		case LOW_BAT_ACTION::LAND:
 			if (!(internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
 			      internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND)) {
 				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
 				internal_state.timestamp = hrt_absolute_time();
-				mavlink_log_emergency(mavlink_log_pub, "%s, landing\t", battery_dangerous);
-				events::send(events::ID("commander_bat_emerg_land"), {events::Log::Emergency, events::LogInternal::Info},
-					     "Dangerous battery level! Landing now");
 			}
 
 			break;
+
+		case LOW_BAT_ACTION::WARNING: break; // no action
 		}
 
-		break;
-
-	case battery_status_s::BATTERY_WARNING_FAILED:
-		mavlink_log_emergency(mavlink_log_pub, "Battery failure detected\t");
-		events::send(events::ID("commander_bat_failure"), events::Log::Emergency, "Battery failure detected");
 		break;
 	}
 }

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1136,10 +1136,11 @@ void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t batter
 	}
 }
 
-void act_on_battery_failsafe(commander_state_s &internal_state, const uint8_t battery_warning,
-			     const low_battery_action_t param_com_low_bat_act)
+uint8_t get_battery_failsafe_action(const commander_state_s &internal_state, const uint8_t battery_warning,
+				    const low_battery_action_t param_com_low_bat_act)
 {
-	// Failsafe action
+	uint8_t ret = commander_state_s::MAIN_STATE_MAX;
+
 	const bool already_landing = internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND
 				     || internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND;
 	const bool already_landing_or_rtl = already_landing
@@ -1152,18 +1153,14 @@ void act_on_battery_failsafe(commander_state_s &internal_state, const uint8_t ba
 		case LOW_BAT_ACTION::RETURN:
 		case LOW_BAT_ACTION::RETURN_OR_LAND:
 			if (!already_landing_or_rtl) {
-				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
-				internal_state.main_state_changes++;
-				internal_state.timestamp = hrt_absolute_time();
+				ret = commander_state_s::MAIN_STATE_AUTO_RTL;
 			}
 
 			break;
 
 		case LOW_BAT_ACTION::LAND:
 			if (!already_landing) {
-				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
-				internal_state.main_state_changes++;
-				internal_state.timestamp = hrt_absolute_time();
+				ret = commander_state_s::MAIN_STATE_AUTO_LAND;
 			}
 
 			break;
@@ -1177,9 +1174,7 @@ void act_on_battery_failsafe(commander_state_s &internal_state, const uint8_t ba
 		switch (param_com_low_bat_act) {
 		case LOW_BAT_ACTION::RETURN:
 			if (!already_landing_or_rtl) {
-				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
-				internal_state.main_state_changes++;
-				internal_state.timestamp = hrt_absolute_time();
+				ret = commander_state_s::MAIN_STATE_AUTO_RTL;
 			}
 
 			break;
@@ -1187,9 +1182,7 @@ void act_on_battery_failsafe(commander_state_s &internal_state, const uint8_t ba
 		case LOW_BAT_ACTION::RETURN_OR_LAND:
 		case LOW_BAT_ACTION::LAND:
 			if (!already_landing) {
-				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
-				internal_state.main_state_changes++;
-				internal_state.timestamp = hrt_absolute_time();
+				ret = commander_state_s::MAIN_STATE_AUTO_LAND;
 			}
 
 			break;
@@ -1199,6 +1192,8 @@ void act_on_battery_failsafe(commander_state_s &internal_state, const uint8_t ba
 
 		break;
 	}
+
+	return ret;
 }
 
 void imbalanced_prop_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1138,28 +1138,21 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 	}
 
 	// Failsafe action
-	const bool rtl_possible = status_flags.condition_global_position_valid && status_flags.condition_home_position_valid;
 	const bool already_landing = internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND
 				     || internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND;
 	const bool already_landing_or_rtl = already_landing
 					    || internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL;
 
+	// The main state is directly changed for the action because we need the fallbacks by the navigation state.
 	switch (battery_warning) {
 	case battery_status_s::BATTERY_WARNING_CRITICAL:
 		switch (low_battery_action) {
 		case LOW_BAT_ACTION::RETURN:
 		case LOW_BAT_ACTION::RETURN_OR_LAND:
-			if (rtl_possible) {
-				if (!already_landing_or_rtl) {
-					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
-					internal_state.timestamp = hrt_absolute_time();
-				}
-
-			} else {
-				if (!already_landing) {
-					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
-					internal_state.timestamp = hrt_absolute_time();
-				}
+			if (!already_landing_or_rtl) {
+				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
+				internal_state.main_state_changes++;
+				internal_state.timestamp = hrt_absolute_time();
 			}
 
 			break;
@@ -1167,6 +1160,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		case LOW_BAT_ACTION::LAND:
 			if (!already_landing) {
 				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
+				internal_state.main_state_changes++;
 				internal_state.timestamp = hrt_absolute_time();
 			}
 
@@ -1180,17 +1174,10 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 	case battery_status_s::BATTERY_WARNING_EMERGENCY:
 		switch (low_battery_action) {
 		case LOW_BAT_ACTION::RETURN:
-			if (rtl_possible) {
-				if (!already_landing_or_rtl) {
-					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
-					internal_state.timestamp = hrt_absolute_time();
-				}
-
-			} else {
-				if (!already_landing) {
-					internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
-					internal_state.timestamp = hrt_absolute_time();
-				}
+			if (!already_landing_or_rtl) {
+				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;
+				internal_state.main_state_changes++;
+				internal_state.timestamp = hrt_absolute_time();
 			}
 
 			break;
@@ -1199,6 +1186,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		case LOW_BAT_ACTION::LAND:
 			if (!already_landing) {
 				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_LAND;
+				internal_state.main_state_changes++;
 				internal_state.timestamp = hrt_absolute_time();
 			}
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1102,9 +1102,7 @@ void reset_offboard_loss_globals(actuator_armed_s &armed, const bool old_failsaf
 	}
 }
 
-void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
-		      const vehicle_status_flags_s &status_flags, commander_state_s &internal_state, const uint8_t battery_warning,
-		      const low_battery_action_t low_battery_action)
+void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning)
 {
 	static constexpr char battery_level[] = "battery level";
 
@@ -1136,7 +1134,11 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 
 	case battery_status_s::BATTERY_WARNING_NONE: break; // no warning
 	}
+}
 
+void act_on_battery_failsafe(commander_state_s &internal_state, const uint8_t battery_warning,
+			     const low_battery_action_t param_com_low_bat_act)
+{
 	// Failsafe action
 	const bool already_landing = internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND
 				     || internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_PRECLAND;
@@ -1146,7 +1148,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 	// The main state is directly changed for the action because we need the fallbacks by the navigation state.
 	switch (battery_warning) {
 	case battery_status_s::BATTERY_WARNING_CRITICAL:
-		switch (low_battery_action) {
+		switch (param_com_low_bat_act) {
 		case LOW_BAT_ACTION::RETURN:
 		case LOW_BAT_ACTION::RETURN_OR_LAND:
 			if (!already_landing_or_rtl) {
@@ -1172,7 +1174,7 @@ void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &sta
 		break;
 
 	case battery_status_s::BATTERY_WARNING_EMERGENCY:
-		switch (low_battery_action) {
+		switch (param_com_low_bat_act) {
 		case LOW_BAT_ACTION::RETURN:
 			if (!already_landing_or_rtl) {
 				internal_state.main_state = commander_state_s::MAIN_STATE_AUTO_RTL;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1109,7 +1109,7 @@ void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t batter
 	// User warning
 	switch (battery_warning) {
 	case battery_status_s::BATTERY_WARNING_LOW:
-		mavlink_log_warning(mavlink_log_pub, "Low %s, return advised\t", battery_level);
+		mavlink_log_critical(mavlink_log_pub, "Low %s, return advised\t", battery_level);
 		events::send(events::ID("commander_bat_low"), {events::Log::Warning, events::LogInternal::Info},
 			     "Low battery level, return advised");
 		break;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1102,7 +1102,9 @@ void reset_offboard_loss_globals(actuator_armed_s &armed, const bool old_failsaf
 	}
 }
 
-void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning)
+void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning,
+			     const uint8_t failsafe_action, const float param_com_bat_act_t,
+			     const char *failsafe_action_string, const events::px4::enums::navigation_mode_t failsafe_action_navigation_mode)
 {
 	static constexpr char battery_level[] = "battery level";
 
@@ -1112,18 +1114,39 @@ void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t batter
 		mavlink_log_critical(mavlink_log_pub, "Low %s, return advised\t", battery_level);
 		events::send(events::ID("commander_bat_low"), {events::Log::Warning, events::LogInternal::Info},
 			     "Low battery level, return advised");
+
 		break;
 
 	case battery_status_s::BATTERY_WARNING_CRITICAL:
-		mavlink_log_critical(mavlink_log_pub, "Critical %s, return now\t", battery_level);
-		events::send(events::ID("commander_bat_crit"), {events::Log::Critical, events::LogInternal::Info},
-			     "Critical battery level, return now");
+		if (failsafe_action == commander_state_s::MAIN_STATE_MAX) {
+			mavlink_log_critical(mavlink_log_pub, "Critical %s, return now\t", battery_level);
+			events::send(events::ID("commander_bat_crit"), {events::Log::Critical, events::LogInternal::Info},
+				     "Critical battery level, return now");
+
+		} else {
+			mavlink_log_critical(mavlink_log_pub, "Critical %s, executing %s in %d seconds\t", battery_level,
+					     failsafe_action_string, static_cast<uint16_t>(param_com_bat_act_t));
+			events::send<events::px4::enums::navigation_mode_t, uint16_t>(events::ID("commander_bat_crit_act"), {events::Log::Critical, events::LogInternal::Info},
+					"Critical battery level, executing {1} in {2} seconds",
+					failsafe_action_navigation_mode, static_cast<uint16_t>(param_com_bat_act_t));
+		}
+
 		break;
 
 	case battery_status_s::BATTERY_WARNING_EMERGENCY:
-		mavlink_log_emergency(mavlink_log_pub, "Dangerous %s, land now\t", battery_level);
-		events::send(events::ID("commander_bat_emerg"), {events::Log::Emergency, events::LogInternal::Info},
-			     "Dangerous battery level, land now");
+		if (failsafe_action == commander_state_s::MAIN_STATE_MAX) {
+			mavlink_log_emergency(mavlink_log_pub, "Dangerous %s, land now\t", battery_level);
+			events::send(events::ID("commander_bat_emerg"), {events::Log::Emergency, events::LogInternal::Info},
+				     "Dangerous battery level, land now");
+
+		} else {
+			mavlink_log_emergency(mavlink_log_pub, "Dangerous %s, executing %s in %d seconds\t", battery_level,
+					      failsafe_action_string, static_cast<uint16_t>(param_com_bat_act_t));
+			events::send<events::px4::enums::navigation_mode_t, uint16_t>(events::ID("commander_bat_emerg_act"), {events::Log::Emergency, events::LogInternal::Info},
+					"Dangerous battery level, executing {1} in {2} seconds",
+					failsafe_action_navigation_mode, static_cast<uint16_t>(param_com_bat_act_t));
+		}
+
 		break;
 
 	case battery_status_s::BATTERY_WARNING_FAILED:
@@ -1148,6 +1171,10 @@ uint8_t get_battery_failsafe_action(const commander_state_s &internal_state, con
 
 	// The main state is directly changed for the action because we need the fallbacks by the navigation state.
 	switch (battery_warning) {
+	case battery_status_s::BATTERY_WARNING_NONE:
+	case battery_status_s::BATTERY_WARNING_LOW:
+		break;
+
 	case battery_status_s::BATTERY_WARNING_CRITICAL:
 		switch (param_com_low_bat_act) {
 		case LOW_BAT_ACTION::RETURN:

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -142,8 +142,8 @@ typedef enum LOW_BAT_ACTION {
 } low_battery_action_t;
 
 void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning);
-void act_on_battery_failsafe(commander_state_s &commander_state, const uint8_t battery_warning,
-			     const low_battery_action_t param_com_low_bat_act);
+uint8_t get_battery_failsafe_action(const commander_state_s &internal_state, const uint8_t battery_warning,
+				    const low_battery_action_t param_com_low_bat_act);
 
 // COM_IMB_PROP_ACT parameter values
 enum class imbalanced_propeller_action_t {

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -141,10 +141,9 @@ typedef enum LOW_BAT_ACTION {
 	RETURN_OR_LAND = 3	// Return mode at critically low level, Land mode at current position if reaching dangerously low levels
 } low_battery_action_t;
 
-void battery_failsafe(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
-		      const vehicle_status_flags_s &status_flags, commander_state_s &internal_state, const uint8_t battery_warning,
-		      const low_battery_action_t low_bat_action);
-
+void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning);
+void act_on_battery_failsafe(commander_state_s &commander_state, const uint8_t battery_warning,
+			     const low_battery_action_t param_com_low_bat_act);
 
 // COM_IMB_PROP_ACT parameter values
 enum class imbalanced_propeller_action_t {

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -141,7 +141,9 @@ typedef enum LOW_BAT_ACTION {
 	RETURN_OR_LAND = 3	// Return mode at critically low level, Land mode at current position if reaching dangerously low levels
 } low_battery_action_t;
 
-void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning);
+void warn_user_about_battery(orb_advert_t *mavlink_log_pub, const uint8_t battery_warning,
+			     const uint8_t failsafe_action, const float param_com_bat_act_t,
+			     const char *failsafe_action_string, const events::px4::enums::navigation_mode_t failsafe_action_navigation_mode);
 uint8_t get_battery_failsafe_action(const commander_state_s &internal_state, const uint8_t battery_warning,
 				    const low_battery_action_t param_com_low_bat_act);
 

--- a/src/modules/simulator/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulator/battery_simulator/BatterySimulator.cpp
@@ -90,6 +90,7 @@ void BatterySimulator::Run()
 		_last_integration_us = now_us;
 
 	} else {
+		_battery_percentage = 1.f;
 		_last_integration_us = 0;
 	}
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
If the low battery action is enabled (see [COM_LOW_BAT_ACT](https://docs.px4.io/master/en/advanced_config/parameter_reference.html#COM_LOW_BAT_ACT)) and the battery gets over the threshold the drone immediately does the action without any warning or time for the user to react. There were multiple cases where the unexpected ascend of the RTL which usually is the first action led to crashes because of an obstacle above the vehicle or a panic reaction. Often the pilot is already landing manually and is unpleasantly surprised about the sudden upwards acceleration.

**Describe your solution**
- Refactor battery failsafe to be able to separately warn the user and get the battery failsafe action
- Introduce a delay of by default 10s between low battery warning level changing with user warning and failsafe action if an action is configured.
  During the delay, the drone is in Hold mode (if possible) after the delay the action is executed.
- User messaging such that's it's clear what will get executed when.
![image](https://user-images.githubusercontent.com/4668506/149912482-3b9ca80b-fad8-48ff-abfa-5d29f51877e9.png)
- Fixed corner case: To determine if the user did something else in between I check for the main state to still be loiter but in case of no position it never even switches to loiter and the action never gets executed.

**Test data / coverage**
Purely SITL tested with a simulated battery and arbitrary low battery percentage configuration.
