### PR TITLE
px4_work_queue: rename serial port WQs

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -76,16 +76,18 @@ static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
 
 static constexpr wq_config_t uavcan{"wq:uavcan", 3624, -19};
 
-static constexpr wq_config_t UART0{"wq:UART0", 1632, -21};
-static constexpr wq_config_t UART1{"wq:UART1", 1632, -22};
-static constexpr wq_config_t UART2{"wq:UART2", 1632, -23};
-static constexpr wq_config_t UART3{"wq:UART3", 1632, -24};
-static constexpr wq_config_t UART4{"wq:UART4", 1632, -25};
-static constexpr wq_config_t UART5{"wq:UART5", 1632, -26};
-static constexpr wq_config_t UART6{"wq:UART6", 1632, -27};
-static constexpr wq_config_t UART7{"wq:UART7", 1632, -28};
-static constexpr wq_config_t UART8{"wq:UART8", 1632, -29};
-static constexpr wq_config_t UART_UNKNOWN{"wq:UART_UNKNOWN", 1632, -30};
+static constexpr wq_config_t ttyS0{"wq:ttyS0", 1632, -21};
+static constexpr wq_config_t ttyS1{"wq:ttyS1", 1632, -22};
+static constexpr wq_config_t ttyS2{"wq:ttyS2", 1632, -23};
+static constexpr wq_config_t ttyS3{"wq:ttyS3", 1632, -24};
+static constexpr wq_config_t ttyS4{"wq:ttyS4", 1632, -25};
+static constexpr wq_config_t ttyS5{"wq:ttyS5", 1632, -26};
+static constexpr wq_config_t ttyS6{"wq:ttyS6", 1632, -27};
+static constexpr wq_config_t ttyS7{"wq:ttyS7", 1632, -28};
+static constexpr wq_config_t ttyS8{"wq:ttyS8", 1632, -29};
+static constexpr wq_config_t ttyS9{"wq:ttyS9", 1632, -30};
+static constexpr wq_config_t ttyACM0{"wq:ttyACM0", 1632, -31};
+static constexpr wq_config_t ttyUnknown{"wq:ttyUnknown", 1632, -32};
 
 static constexpr wq_config_t lp_default{"wq:lp_default", 1920, -50};
 

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -166,39 +166,45 @@ const wq_config_t &
 serial_port_to_wq(const char *serial)
 {
 	if (serial == nullptr) {
-		return wq_configurations::hp_default;
+		return wq_configurations::ttyUnknown;
 
 	} else if (strstr(serial, "ttyS0")) {
-		return wq_configurations::UART0;
+		return wq_configurations::ttyS0;
 
 	} else if (strstr(serial, "ttyS1")) {
-		return wq_configurations::UART1;
+		return wq_configurations::ttyS1;
 
 	} else if (strstr(serial, "ttyS2")) {
-		return wq_configurations::UART2;
+		return wq_configurations::ttyS2;
 
 	} else if (strstr(serial, "ttyS3")) {
-		return wq_configurations::UART3;
+		return wq_configurations::ttyS3;
 
 	} else if (strstr(serial, "ttyS4")) {
-		return wq_configurations::UART4;
+		return wq_configurations::ttyS4;
 
 	} else if (strstr(serial, "ttyS5")) {
-		return wq_configurations::UART5;
+		return wq_configurations::ttyS5;
 
 	} else if (strstr(serial, "ttyS6")) {
-		return wq_configurations::UART6;
+		return wq_configurations::ttyS6;
 
 	} else if (strstr(serial, "ttyS7")) {
-		return wq_configurations::UART7;
+		return wq_configurations::ttyS7;
 
 	} else if (strstr(serial, "ttyS8")) {
-		return wq_configurations::UART8;
+		return wq_configurations::ttyS8;
+
+	} else if (strstr(serial, "ttyS9")) {
+		return wq_configurations::ttyS9;
+
+	} else if (strstr(serial, "ttyACM0")) {
+		return wq_configurations::ttyACM0;
 	}
 
 	PX4_DEBUG("unknown serial port: %s", serial);
 
-	return wq_configurations::UART_UNKNOWN;
+	return wq_configurations::ttyUnknown;
 }
 
 const wq_config_t &ins_instance_to_wq(uint8_t instance)


### PR DESCRIPTION
Naming these wq:UARTx is unnecessarily confusing because it usually doesn't match up with the actual hardware.
![Screenshot from 2022-01-18 12-43-45](https://user-images.githubusercontent.com/84712/149990332-226cce91-21a0-446a-b6f4-21b2a9b97788.png)

