### PR TITLE
Multicopter position control: Invalid setpoint can windup integrator

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -321,8 +321,6 @@ void MulticopterPositionControl::Run()
 
 		// set _dt in controllib Block for BlockDerivative
 		setDt(dt);
-
-		const bool was_in_failsafe = _in_failsafe;
 		_in_failsafe = false;
 
 		_vehicle_control_mode_sub.update(&_vehicle_control_mode);
@@ -478,14 +476,16 @@ void MulticopterPositionControl::Run()
 
 			} else {
 				// Failsafe
-				if ((time_stamp_now - _last_warn) > 2_s) {
+				const bool warn_failsafe = (time_stamp_now - _last_warn) > 2_s;
+
+				if (warn_failsafe) {
 					PX4_WARN("invalid setpoints");
 					_last_warn = time_stamp_now;
 				}
 
 				vehicle_local_position_setpoint_s failsafe_setpoint{};
 
-				failsafe(time_stamp_now, failsafe_setpoint, states, !was_in_failsafe);
+				failsafe(time_stamp_now, failsafe_setpoint, states, warn_failsafe);
 
 				// reset constraints
 				_vehicle_constraints = {0, NAN, NAN, false, {}};

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -179,7 +179,7 @@ public:
 	void getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint) const;
 
 private:
-	bool _updateSuccessful();
+	bool _inputValid();
 
 	void _positionControl(); ///< Position proportional control
 	void _velocityControl(const float dt); ///< Velocity PID control

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -399,3 +399,23 @@ TEST_F(PositionControlBasicTest, UpdateHoverThrust)
 	// the output is still the same
 	EXPECT_EQ(_output_setpoint.thrust[2], -hover_thrust);
 }
+
+TEST_F(PositionControlBasicTest, IntegratorWindupWithInvalidSetpoint)
+{
+	// GIVEN: the controller was ran with an invalid setpoint containing some valid values
+	_input_setpoint.x = .1f;
+	_input_setpoint.y = .2f;
+	// all z-axis setpoints stay NAN
+	EXPECT_FALSE(runController());
+
+	// WHEN: we run the controller with a valid setpoint
+	resetInputSetpoint();
+	_input_setpoint.vx = 0.f;
+	_input_setpoint.vy = 0.f;
+	_input_setpoint.vz = 0.f;
+	EXPECT_TRUE(runController());
+
+	// THEN: the integral did not wind up and produce unexpected deviation
+	EXPECT_FLOAT_EQ(_attitude.roll_body, 0.f);
+	EXPECT_FLOAT_EQ(_attitude.pitch_body, 0.f);
+}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Settings a specific combination of invalid `trajectory_setpoint` can lead to a flyaway.
![image](https://user-images.githubusercontent.com/4668506/150109782-b53df2ad-689a-47d3-8b85-bacd199a2402.png)
This was found during simulation debugging for #18988 

I found that depending on the setpoint combination the velocity integrator can wind up because the calculations are ran with the invalid setpoint. Even though the results of the "invalid calculation" are not use the integrator state inside the controller is updated and leads to the problem.

**Describe your solution**
1. I added a minimal unit test to reproduce the error case.
2.  I made the checks for valid inputs and combinations very explicit at the beginning and don't run any calculations if they do not pass the check.
3. The existing tests and the new one pass.

**Test data / coverage**
Added unit test and manual test case in SITL with which I originally found the issue work as expected with this pr.
