### PR TITLE
Only publish orbit status when vehicle is in loiter

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -843,10 +843,6 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 	_att_sp.pitch_reset_integral = false;
 	_att_sp.yaw_reset_integral = false;
 
-	if (pos_sp_curr.valid && pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
-		publishOrbitStatus(pos_sp_curr);
-	}
-
 	position_setpoint_s current_sp = pos_sp_curr;
 
 	if (_vehicle_status.in_transition_to_fw) {
@@ -893,6 +889,8 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 
 	case position_setpoint_s::SETPOINT_TYPE_LOITER:
 		control_auto_loiter(now, dt, curr_pos, ground_speed, pos_sp_prev, current_sp, pos_sp_next);
+		publishOrbitStatus(pos_sp_curr);
+
 		break;
 
 	case position_setpoint_s::SETPOINT_TYPE_LAND:

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -884,12 +884,12 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 		break;
 
 	case position_setpoint_s::SETPOINT_TYPE_VELOCITY:
-		control_auto_velocity(now, dt, curr_pos, ground_speed, pos_sp_prev, pos_sp_curr);
+		control_auto_velocity(now, dt, curr_pos, ground_speed, pos_sp_prev, current_sp);
 		break;
 
 	case position_setpoint_s::SETPOINT_TYPE_LOITER:
 		control_auto_loiter(now, dt, curr_pos, ground_speed, pos_sp_prev, current_sp, pos_sp_next);
-		publishOrbitStatus(pos_sp_curr);
+		publishOrbitStatus(current_sp);
 
 		break;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the orbit status was published only when the mission item was a loiter waypoint.

However, the fixedwing position controller goes into a loiter not only when the waypoint is a loiter, but also when other conditions are met as shown below.

https://github.com/PX4/PX4-Autopilot/blob/632dfa55e6f231f1b62fb2e9bfb048d391ebafc9/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1077-L1082

Therefore when the fixedwing position controller internally switches waypoint types, there is no feedback to the user other than the vehicle deviating off course. From experience, this can be very dangerous when flying a survey mission on steep terrain, while the vehicle does not give any feedback.

**Describe your solution**
This PR makes the vehicle publish the orbit status message whenever the vehicle is actually handling the waypoint as a loiter waypoint.

**Describe possible alternatives**
- After this PR, the orbit status message is not published when the vehicle is considering the loiter waypoint as a normal position waypoint.

**Test data / coverage**
Below shows the fixedwing vehicle mission flown with waypoints that are varying in altitude.
- Before PR
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/5248102/150119352-63aff453-c393-4d21-9e8e-d32a95b1c6da.gif)


- After PR
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/5248102/150119356-88c97218-4f43-45a5-96ca-59022b47ba5b.gif)

**Additional context**
- Follow up from the discussion we had yesterday @tstastny 