### PR TITLE
platforms/nuttx: px4io_serial always cleanup DMA before next bus exchange

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32f4/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32f4/px4io_serial/px4io_serial.cpp
@@ -225,6 +225,9 @@ ArchPX4IOSerial::ioctl(unsigned operation, unsigned &arg)
 int
 ArchPX4IOSerial::_bus_exchange(IOPacket *_packet)
 {
+	// to be paranoid ensure all previous DMA transfers are cleared
+	_abort_dma();
+
 	_current_packet = _packet;
 
 	/* clear any lingering error status */

--- a/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32f7/px4io_serial/px4io_serial.cpp
@@ -237,6 +237,9 @@ ArchPX4IOSerial::ioctl(unsigned operation, unsigned &arg)
 int
 ArchPX4IOSerial::_bus_exchange(IOPacket *_packet)
 {
+	// to be paranoid ensure all previous DMA transfers are cleared
+	_abort_dma();
+
 	_current_packet = _packet;
 
 	/* clear data that may be in the RDR and clear overrun error: */

--- a/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/px4io_serial.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32h7/px4io_serial/px4io_serial.cpp
@@ -275,6 +275,9 @@ ArchPX4IOSerial::ioctl(unsigned operation, unsigned &arg)
 int
 ArchPX4IOSerial::_bus_exchange(IOPacket *_packet)
 {
+	// to be paranoid ensure all previous DMA transfers are cleared
+	_abort_dma();
+
 	_current_packet = _packet;
 
 	/* clear data that may be in the RDR and clear overrun error: */


### PR DESCRIPTION
 - this really shouldn't be necessary, but worst case it's harmless and much better than potentially falling out of the sky


https://github.com/PX4/PX4-Autopilot/pull/18893

@JohnSnowball 