### PR TITLE
Publish orbit status also when the waypoint is a loiter waypoint

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -872,6 +872,11 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 
 	_position_sp_type = position_sp_type;
 
+	if (position_sp_type == position_setpoint_s::SETPOINT_TYPE_LOITER
+	    || current_sp.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
+		publishOrbitStatus(current_sp);
+	}
+
 	switch (position_sp_type) {
 	case position_setpoint_s::SETPOINT_TYPE_IDLE:
 		_att_sp.thrust_body[0] = 0.0f;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -894,8 +894,6 @@ FixedwingPositionControl::control_auto(const hrt_abstime &now, const Vector2d &c
 
 	case position_setpoint_s::SETPOINT_TYPE_LOITER:
 		control_auto_loiter(now, dt, curr_pos, ground_speed, pos_sp_prev, current_sp, pos_sp_next);
-		publishOrbitStatus(current_sp);
-
 		break;
 
 	case position_setpoint_s::SETPOINT_TYPE_LAND:


### PR DESCRIPTION
**Describe problem solved by this pull request**
In https://github.com/PX4/PX4-Autopilot/pull/19042 the orbit status message publishing had been removed when the position controller was considering loiter type waypoints as a position setpoint. This PR retains this back to the current state. 

**Describe your solution**
Publish orbit status also when the waypoint is a loiter waypoint

**Test data / coverage**
Tested in SITL Gazebo
```
make px4_sitl gazebo_plane
```

**Additional context**
- This is a follow up PR of https://github.com/PX4/PX4-Autopilot/pull/19042
