### PR TITLE
Spawn at different height for multivehicle simulation

### DIFF
--- a/Tools/gazebo_sitl_multiple_run.sh
+++ b/Tools/gazebo_sitl_multiple_run.sh
@@ -39,7 +39,7 @@ function spawn_model() {
 
 	echo "Spawning ${MODEL}_${N} at ${X} ${Y}"
 
-	gz model --spawn-file=/tmp/${MODEL}_${N}.sdf --model-name=${MODEL}_${N} -x ${X} -y ${Y} -z 0.0
+	gz model --spawn-file=/tmp/${MODEL}_${N}.sdf --model-name=${MODEL}_${N} -x ${X} -y ${Y} -z 0.83
 
 	popd &>/dev/null
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
It was reported(https://discuss.px4.io/t/multi-standard-vtol-are-unstable-in-gazebo/25850) that the mutlivehicle script(`Tools/gazebo_sitl_multiple_run.sh) fails for the `standard_vtol`

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/5248102/150705828-ee0bedf8-5090-46f3-bf0e-4d4c2b4bdb7a.gif)


**Describe your solution**
This commit fixes the spawn location of the multivehicle gazebo sitl script. This is consistent with the default sitl script: https://github.com/PX4/PX4-Autopilot/blob/ed28b216c7f904c2e2f95cd494fa1b0c82e6f4e0/Tools/sitl_run.sh#L169

**Test data / coverage**
Tested with
```
Tools/gazebo_sitl_multiple_run.sh -m standard_vtol
```
