### PR TITLE
ekf2: only set fault status bad_acc_clipping if clipping frequently

### DIFF
--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -812,6 +812,8 @@ void Ekf::checkVerticalAccelerationHealth()
 		_clip_counter--;
 	}
 
+	_fault_status.flags.bad_acc_clipping = _clip_counter > clip_count_limit / 2;
+
 	const bool is_clipping_frequently = _clip_counter > 0;
 
 	// if vertical velocity and position are independent and agree, then do not require evidence of clipping if

--- a/src/modules/ekf2/EKF/covariance.cpp
+++ b/src/modules/ekf2/EKF/covariance.cpp
@@ -237,24 +237,19 @@ void Ekf::predictCovariance()
 	dvxVar = dvyVar = dvzVar = sq(dt * accel_noise);
 
 	// Accelerometer Clipping
-	_fault_status.flags.bad_acc_clipping = false; // reset flag
-
 	// delta velocity X: increase process noise if sample contained any X axis clipping
 	if (_imu_sample_delayed.delta_vel_clipping[0]) {
 		dvxVar = sq(dt * BADACC_BIAS_PNOISE);
-		_fault_status.flags.bad_acc_clipping = true;
 	}
 
 	// delta velocity Y: increase process noise if sample contained any Y axis clipping
 	if (_imu_sample_delayed.delta_vel_clipping[1]) {
 		dvyVar = sq(dt * BADACC_BIAS_PNOISE);
-		_fault_status.flags.bad_acc_clipping = true;
 	}
 
 	// delta velocity Z: increase process noise if sample contained any Z axis clipping
 	if (_imu_sample_delayed.delta_vel_clipping[2]) {
 		dvzVar = sq(dt * BADACC_BIAS_PNOISE);
-		_fault_status.flags.bad_acc_clipping = true;
 	}
 
 	// predict the covariance


### PR DESCRIPTION
In ekf2 if there's any accel clipping at all we set `_fault_status.flags.bad_acc_clipping`. In practice this is way too sensitive as it results in unnecessary estimator switching during mundane events like setting a board with a hard mounted IMU on a table. It can also be too aggressive when there's real frequent clipping across multiple IMUs because the selector sees clipping on the current primary instance and then switches immediately to the next available instance only to see clipping on the next update.

I'm not sure if this change might be moving too far in the other direction, but it now exposes more internal state (_fault_status.flags.bad_acc_clipping = is_clipping_frequently) that we can monitor and adjust as needed.
