### PR TITLE
tfmini: If the distance is 0xFFFF, a negative value is returned

### DIFF
--- a/src/drivers/distance_sensor/tfmini/tfmini_parser.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini_parser.cpp
@@ -159,7 +159,11 @@ int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, TFMINI_PARS
 			unsigned int t2 = parserbuf[3];
 			t2 <<= 8;
 			t2 += t1;
-			*dist = ((float)t2) / 100;
+
+			if (t2 < 0xFFFFu) {
+				*dist = ((float)t2) / 100;
+			}
+
 			*state = TFMINI_PARSE_STATE::STATE6_GOT_CHECKSUM;
 			*parserbuf_index = 0;
 			ret = 0;


### PR DESCRIPTION
**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

When TFmini is Strength<20, it returns a value of 65535.

SPEC
Dist: Represents the output of the distance value detected by TFmini, with the unit in cm by default. This
value is interpreted into the decimal value in the range of 0-1200.In the practice, if the signal strength valueStrength<20 (which is settable), the value of Dist will be deemed as unreliable and FFFF will be output by
default (-1 in case of Pixhawk data format). If Strength≥20 and actual distance >12m, the default output
value of Dist will be 1,200(cm).

**Describe your solution**
A clear and concise description of what you have implemented.

I did not set the distance when the distance is 65535.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

none

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

I have confirmed that when I set the debug value 65535, it goes to -EAGAIN.

**Additional context**
Add any other related context or media.

none

