### PR TITLE
Protected build linker fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,11 @@ define_property(GLOBAL PROPERTY PX4_MODULE_LIBRARIES
                  FULL_DOCS "List of all PX4 module libraries"
                  )
 
+define_property(GLOBAL PROPERTY PX4_KERNEL_MODULE_LIBRARIES
+                 BRIEF_DOCS "PX4 kernel side module libs"
+                 FULL_DOCS "List of all PX4 kernel module libraries"
+                 )
+
 define_property(GLOBAL PROPERTY PX4_MODULE_PATHS
                  BRIEF_DOCS "PX4 module paths"
                  FULL_DOCS "List of paths to all PX4 modules"
@@ -142,6 +147,7 @@ set(CONFIG "px4_sitl_default" CACHE STRING "desired configuration")
 
 include(px4_add_module)
 set(config_module_list)
+set(config_kernel_list)
 
 # Find Python
 # If using catkin, Python 2 is found since it points

--- a/Kconfig
+++ b/Kconfig
@@ -118,6 +118,11 @@ config BOARD_CRYPTO
     help
         Enable PX4 Crypto Support. Select the implementation under drivers
 
+config BOARD_PROTECTED
+    bool "Memory protection"
+    help
+        Enable memory protection via MPU/MMU
+
 menu "Serial ports"
 
     config BOARD_SERIAL_URT6

--- a/boards/ark/can-flow/src/CMakeLists.txt
+++ b/boards/ark/can-flow/src/CMakeLists.txt
@@ -61,6 +61,5 @@ else()
 			nuttx_arch
 			nuttx_drivers
 			px4_layer
-			arch_io_pins
 	)
 endif()

--- a/boards/ark/can-gps/src/CMakeLists.txt
+++ b/boards/ark/can-gps/src/CMakeLists.txt
@@ -63,6 +63,5 @@ else()
 			nuttx_arch
 			nuttx_drivers
 			px4_layer
-			arch_io_pins
 	)
 endif()

--- a/boards/ark/can-rtk-gps/src/CMakeLists.txt
+++ b/boards/ark/can-rtk-gps/src/CMakeLists.txt
@@ -63,6 +63,5 @@ else()
 			nuttx_arch
 			nuttx_drivers
 			px4_layer
-			arch_io_pins
 	)
 endif()

--- a/boards/cuav/can-gps-v1/src/CMakeLists.txt
+++ b/boards/cuav/can-gps-v1/src/CMakeLists.txt
@@ -61,6 +61,5 @@ else()
 			nuttx_arch
 			nuttx_drivers
 			px4_layer
-			arch_io_pins
 	)
 endif()

--- a/boards/freefly/can-rtk-gps/src/CMakeLists.txt
+++ b/boards/freefly/can-rtk-gps/src/CMakeLists.txt
@@ -62,6 +62,5 @@ else()
 			nuttx_arch
 			nuttx_drivers
 			px4_layer
-			arch_io_pins
 	)
 endif()

--- a/boards/holybro/can-gps-v1/src/CMakeLists.txt
+++ b/boards/holybro/can-gps-v1/src/CMakeLists.txt
@@ -68,6 +68,5 @@ else()
 			nuttx_arch
 			nuttx_drivers
 			px4_layer
-			arch_io_pins
 	)
 endif()

--- a/boards/nxp/fmurt1062-v1/src/CMakeLists.txt
+++ b/boards/nxp/fmurt1062-v1/src/CMakeLists.txt
@@ -46,7 +46,6 @@ px4_add_library(drivers_board
 	imxrt_flexspi_nor_boot.c
 	imxrt_flexspi_nor_flash.c
 )
-add_dependencies(drivers_board arch_board_hw_info)
 
 target_link_libraries(drivers_board
 	PRIVATE

--- a/boards/nxp/ucans32k146/src/CMakeLists.txt
+++ b/boards/nxp/ucans32k146/src/CMakeLists.txt
@@ -45,7 +45,6 @@ if("${PX4_BOARD_LABEL}" STREQUAL  "canbootloader")
 			nuttx_arch
 			nuttx_drivers
 			canbootloader
-			arch_io_pins
 			arch_led_pwm
 	)
 	target_include_directories(drivers_board PRIVATE ${PX4_SOURCE_DIR}/platforms/nuttx/src/canbootloader)
@@ -73,6 +72,5 @@ else()
 			nuttx_drivers # sdio
 			drivers__led # drv_led_start
 			px4_layer
-			arch_io_pins
 		)
 endif()

--- a/boards/nxp/ucans32k146/src/CMakeLists.txt
+++ b/boards/nxp/ucans32k146/src/CMakeLists.txt
@@ -72,5 +72,6 @@ else()
 			nuttx_drivers # sdio
 			drivers__led # drv_led_start
 			px4_layer
+			px4_platform # I2CBusIterator
 		)
 endif()

--- a/boards/px4/fmu-v4/src/CMakeLists.txt
+++ b/boards/px4/fmu-v4/src/CMakeLists.txt
@@ -48,5 +48,4 @@ target_link_libraries(drivers_board
 		nuttx_arch # sdio
 		nuttx_drivers # sdio
 		px4_layer
-		arch_io_pins
 )

--- a/boards/px4/fmu-v5x/src/CMakeLists.txt
+++ b/boards/px4/fmu-v5x/src/CMakeLists.txt
@@ -43,7 +43,8 @@ add_library(drivers_board
 	timer_config.cpp
 	usb.c
 )
-add_dependencies(drivers_board arch_board_hw_info platform_gpio_mcp23009)
+
+add_dependencies(drivers_board platform_gpio_mcp23009)
 
 target_link_libraries(drivers_board
 	PRIVATE

--- a/boards/raspberrypi/pico/src/CMakeLists.txt
+++ b/boards/raspberrypi/pico/src/CMakeLists.txt
@@ -48,5 +48,4 @@ target_link_libraries(drivers_board
 		nuttx_arch # sdio
 		nuttx_drivers # sdio
 		px4_layer
-		arch_io_pins
 )

--- a/boards/uvify/core/src/CMakeLists.txt
+++ b/boards/uvify/core/src/CMakeLists.txt
@@ -48,5 +48,4 @@ target_link_libraries(drivers_board
 		nuttx_arch # sdio
 		nuttx_drivers # sdio
 		px4_layer
-		arch_io_pins
 )

--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -26,6 +26,8 @@ set(COMMON_KCONFIG_ENV_SETTINGS
 	ROMFSROOT=${config_romfs_root}
 )
 
+set(config_user_list)
+
 if(EXISTS ${BOARD_DEFCONFIG})
 
     # Depend on BOARD_DEFCONFIG so that we reconfigure on config change
@@ -77,6 +79,17 @@ if(EXISTS ${BOARD_DEFCONFIG})
                 set(${ConfigKey} ${Value})
                 message(STATUS "${ConfigKey} ${Value}")
             endif()
+        endif()
+
+        # Find variable name
+        string(REGEX MATCH "^CONFIG_USER[^=]+" Userspace ${NameAndValue})
+
+        if(Userspace)
+            # Find the value
+            string(REPLACE "${Name}=" "" Value ${NameAndValue})
+            string(REPLACE "CONFIG_USER_" "" module ${Name})
+            string(TOLOWER ${module} module)
+            list(APPEND config_user_list ${module})
         endif()
 
         # Find variable name
@@ -169,6 +182,16 @@ if(EXISTS ${BOARD_DEFCONFIG})
             list(APPEND config_module_list examples/${example})
         endif()
 
+    endforeach()
+
+    # Put every module not in userspace also to kernel list
+    foreach(modpath ${config_module_list})
+        get_filename_component(module ${modpath} NAME)
+        list(FIND config_user_list ${module} _index)
+
+        if (${_index} EQUAL -1)
+            list(APPEND config_kernel_list ${modpath})
+        endif()
     endforeach()
 
     if(PLATFORM)
@@ -336,6 +359,7 @@ if(EXISTS ${BOARD_DEFCONFIG})
 	list(APPEND config_module_list ${board_support_src_rel}/src)
 
 	set(config_module_list ${config_module_list})
+	set(config_kernel_list ${config_kernel_list})
 
 endif()
 

--- a/cmake/px4_add_library.cmake
+++ b/cmake/px4_add_library.cmake
@@ -44,8 +44,8 @@ function(px4_add_library target)
 	target_compile_definitions(${target} PRIVATE MODULE_NAME="${target}")
 
 	# all PX4 libraries have access to parameters and uORB
-	add_dependencies(${target} uorb_headers)
-	target_link_libraries(${target} PRIVATE prebuild_targets parameters_interface px4_platform)
+	add_dependencies(${target} uorb_headers parameters)
+	target_link_libraries(${target} PRIVATE prebuild_targets)
 
 	set_property(GLOBAL APPEND PROPERTY PX4_MODULE_PATHS ${CMAKE_CURRENT_SOURCE_DIR})
 	px4_list_make_absolute(ABS_SRCS ${CMAKE_CURRENT_SOURCE_DIR} ${ARGN})

--- a/cmake/px4_add_module.cmake
+++ b/cmake/px4_add_module.cmake
@@ -154,9 +154,29 @@ function(px4_add_module)
 	# all modules can potentially use parameters and uORB
 	add_dependencies(${MODULE} uorb_headers)
 
+	# Check if the modules source dir exists in config_kernel_list
+	# in this case, treat is as a kernel side component for
+	# protected build
+	get_target_property(MODULE_SOURCE_DIR ${MODULE} SOURCE_DIR)
+	file(RELATIVE_PATH module ${PROJECT_SOURCE_DIR}/src ${MODULE_SOURCE_DIR})
+
+	list (FIND config_kernel_list ${module} _index)
+	if (${_index} GREATER -1)
+		set (KERNEL TRUE)
+	endif()
+
 	if(NOT DYNAMIC)
-		target_link_libraries(${MODULE} PRIVATE prebuild_targets parameters_interface px4_layer px4_platform systemlib)
-		set_property(GLOBAL APPEND PROPERTY PX4_MODULE_LIBRARIES ${MODULE})
+		target_link_libraries(${MODULE} PRIVATE prebuild_targets parameters_interface px4_platform systemlib perf)
+		if (${PX4_PLATFORM} STREQUAL "nuttx" AND NOT CONFIG_BUILD_FLAT AND KERNEL)
+			target_link_libraries(${MODULE} PRIVATE px4_kernel_layer uORB_kernel)
+			set_property(GLOBAL APPEND PROPERTY PX4_KERNEL_MODULE_LIBRARIES ${MODULE})
+		else()
+			target_link_libraries(${MODULE} PRIVATE px4_layer uORB)
+			set_property(GLOBAL APPEND PROPERTY PX4_MODULE_LIBRARIES ${MODULE})
+		endif()
+		set_property(GLOBAL APPEND PROPERTY PX4_MODULE_PATHS ${CMAKE_CURRENT_SOURCE_DIR})
+		px4_list_make_absolute(ABS_SRCS ${CMAKE_CURRENT_SOURCE_DIR} ${SRCS})
+		set_property(GLOBAL APPEND PROPERTY PX4_SRC_FILES ${ABS_SRCS})
 	endif()
 
 	set_property(GLOBAL APPEND PROPERTY PX4_MODULE_PATHS ${CMAKE_CURRENT_SOURCE_DIR})
@@ -195,6 +215,10 @@ function(px4_add_module)
 
 	if(COMPILE_FLAGS)
 		target_compile_options(${MODULE} PRIVATE ${COMPILE_FLAGS})
+	endif()
+
+	if (KERNEL)
+		target_compile_options(${MODULE} PRIVATE -D__KERNEL__)
 	endif()
 
 	if(INCLUDES)

--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -52,11 +52,10 @@ add_library(px4_platform
 	spi.cpp
 	${SRCS}
 )
-add_dependencies(px4_platform prebuild_targets)
+target_link_libraries(px4_platform prebuild_targets px4_work_queue)
 
 if (NOT "${PX4_BOARD}" MATCHES "io-v2")
 	add_subdirectory(uORB)
-	target_link_libraries(px4_platform PRIVATE uORB)
 endif()
 
 add_subdirectory(px4_work_queue)

--- a/platforms/common/px4_work_queue/CMakeLists.txt
+++ b/platforms/common/px4_work_queue/CMakeLists.txt
@@ -44,4 +44,3 @@ if(PX4_TESTING)
 endif()
 
 target_compile_options(px4_work_queue PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
-target_link_libraries(px4_work_queue PRIVATE px4_platform)

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -105,10 +105,13 @@ file(RELATIVE_PATH PX4_BINARY_DIR_REL ${CMAKE_CURRENT_BINARY_DIR} ${PX4_BINARY_D
 # because even relative linker script paths are different for linux, mac and windows
 CYGPATH(NUTTX_CONFIG_DIR NUTTX_CONFIG_DIR_CYG)
 
+target_link_libraries(nuttx_c INTERFACE nuttx_sched) # nxsched_get_streams
+
 target_link_libraries(nuttx_arch
 	INTERFACE
 		drivers_board
 		arch_hrt
+		arch_board_reset
 )
 
 target_link_libraries(nuttx_c INTERFACE nuttx_drivers)

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -117,7 +117,13 @@ set_property(TARGET nuttx_apps PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY
 add_dependencies(nuttx_apps nuttx_apps_build)
 
 # helper for all targets
-function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra)
+function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra target)
+	if (${target} STREQUAL all)
+		set(nuttx_lib_target all)
+	else()
+		set(nuttx_lib_target lib${target}.a)
+	endif()
+
 	file(GLOB_RECURSE nuttx_lib_files LIST_DIRECTORIES false
 		${CMAKE_CURRENT_SOURCE_DIR}/nuttx/${nuttx_lib_dir}/*.c
 		${CMAKE_CURRENT_SOURCE_DIR}/nuttx/${nuttx_lib_dir}/*.h
@@ -126,7 +132,7 @@ function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra)
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/nuttx/${nuttx_lib_dir}/lib${nuttx_lib}.a
 		COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/${nuttx_lib_dir}/lib${nuttx_lib}.a
 		COMMAND find ${nuttx_lib_dir} -type f -name \*.o -delete
-		COMMAND make -C ${nuttx_lib_dir} --no-print-directory --silent all TOPDIR="${NUTTX_DIR}" KERNEL=${kernel} EXTRAFLAGS=${extra}
+		COMMAND make -C ${nuttx_lib_dir} --no-print-directory --silent ${nuttx_lib_target} TOPDIR="${NUTTX_DIR}" KERNEL=${kernel} EXTRAFLAGS=${extra}
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/${nuttx_lib_dir}/lib${nuttx_lib}.a ${CMAKE_CURRENT_BINARY_DIR}/nuttx/${nuttx_lib_dir}/lib${nuttx_lib}.a
 		DEPENDS
 			${nuttx_lib_files}
@@ -142,19 +148,35 @@ function(add_nuttx_dir nuttx_lib nuttx_lib_dir kernel extra)
 endfunction()
 
 # add_nuttx_dir(NAME DIRECTORY KERNEL EXTRA)
-add_nuttx_dir(arch arch/${CONFIG_ARCH}/src y -D__KERNEL__)
-add_nuttx_dir(binfmt binfmt y -D__KERNEL__)
-add_nuttx_dir(boards boards y -D__KERNEL__)
-add_nuttx_dir(drivers drivers y -D__KERNEL__)
-add_nuttx_dir(fs fs y -D__KERNEL__)
-add_nuttx_dir(sched sched y -D__KERNEL__)
-add_nuttx_dir(c libs/libc n "")
-add_nuttx_dir(xx libs/libxx n "")
-add_nuttx_dir(mm mm n "")
-add_nuttx_dir(crypto crypto y -D__KERNEL__)
+add_nuttx_dir(binfmt binfmt y -D__KERNEL__ all)
+add_nuttx_dir(boards boards y -D__KERNEL__ all)
+add_nuttx_dir(drivers drivers y -D__KERNEL__ all)
+add_nuttx_dir(fs fs y -D__KERNEL__ all)
+add_nuttx_dir(sched sched y -D__KERNEL__ all)
+add_nuttx_dir(xx libs/libxx n "" all)
+add_nuttx_dir(crypto crypto y -D__KERNEL__ all)
+
+if (NOT CONFIG_BUILD_FLAT)
+	add_nuttx_dir(arch arch/${CONFIG_ARCH}/src n "" arch)
+	add_dependencies(nuttx_arch_build nuttx_karch_build) # can't build these in parallel
+	add_nuttx_dir(karch arch/arm/src y -D__KERNEL__ karch)
+	add_nuttx_dir(c libs/libc n "" c)
+	add_dependencies(nuttx_c_build nuttx_kc_build) # can't build these in parallel
+	add_nuttx_dir(kc libs/libc y -D__KERNEL__ kc)
+	add_nuttx_dir(mm mm n "" mm)
+	add_dependencies(nuttx_mm_build nuttx_kmm_build) # can't build these in parallel
+	add_nuttx_dir(kmm mm y -D__KERNEL__ kmm)
+	add_nuttx_dir(proxies syscall n "" proxies)
+	add_dependencies(nuttx_proxies_build nuttx_stubs_build) # can't build these in parallel
+	add_nuttx_dir(stubs syscall y -D__KERNEL__ stubs)
+else()
+	add_nuttx_dir(arch arch/${CONFIG_ARCH}/src y -D__KERNEL__ all)
+	add_nuttx_dir(c libs/libc n "" all)
+	add_nuttx_dir(mm mm n "" mm)
+endif()
 
 if(CONFIG_NET)
-	add_nuttx_dir(net net y -D__KERNEL__)
+	add_nuttx_dir(net net y -D__KERNEL__ all)
 endif()
 
 ###############################################################################

--- a/platforms/nuttx/cmake/px4_impl_os.cmake
+++ b/platforms/nuttx/cmake/px4_impl_os.cmake
@@ -177,7 +177,7 @@ function(px4_os_prebuild_targets)
 	endif()
 
 	add_library(prebuild_targets INTERFACE)
-	target_link_libraries(prebuild_targets INTERFACE nuttx_xx nuttx_c nuttx_fs nuttx_mm nuttx_sched m gcc)
+	target_link_libraries(prebuild_targets INTERFACE nuttx_xx m gcc)
 	add_dependencies(prebuild_targets DEPENDS nuttx_context uorb_headers)
 
 endfunction()

--- a/platforms/nuttx/src/bootloader/stm/stm32_common/CMakeLists.txt
+++ b/platforms/nuttx/src/bootloader/stm/stm32_common/CMakeLists.txt
@@ -39,4 +39,5 @@ px4_add_library(arch_bootloader
 target_link_libraries(arch_bootloader
 	PRIVATE
 		bootloader_lib
+		nuttx_arch
 )

--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -58,6 +58,7 @@ if(NOT PX4_BOARD MATCHES "io-v2")
 			arch_version
 			nuttx_apps
 			nuttx_sched
+			nuttx_mm
 			px4_work_queue
 			uORB
 	)

--- a/platforms/nuttx/src/px4/nxp/imxrt/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/imxrt/board_reset/CMakeLists.txt
@@ -34,3 +34,10 @@
 px4_add_library(arch_board_reset
 	board_reset.cpp
 )
+
+# up_systemreset
+if (NOT DEFINED CONFIG_BUILD_FLAT)
+	target_link_libraries(arch_board_reset PRIVATE nuttx_karch)
+else()
+	target_link_libraries(arch_board_reset PRIVATE nuttx_arch)
+endif()

--- a/platforms/nuttx/src/px4/nxp/kinetis/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/kinetis/board_reset/CMakeLists.txt
@@ -34,3 +34,10 @@
 px4_add_library(arch_board_reset
 	board_reset.cpp
 )
+
+# up_systemreset
+if (NOT DEFINED CONFIG_BUILD_FLAT)
+	target_link_libraries(arch_board_reset PRIVATE nuttx_karch)
+else()
+	target_link_libraries(arch_board_reset PRIVATE nuttx_arch)
+endif()

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/board_reset/CMakeLists.txt
@@ -34,3 +34,10 @@
 px4_add_library(arch_board_reset
 	board_reset.cpp
 )
+
+# up_systemreset
+if (NOT DEFINED CONFIG_BUILD_FLAT)
+	target_link_libraries(arch_board_reset PRIVATE nuttx_karch)
+else()
+	target_link_libraries(arch_board_reset PRIVATE nuttx_arch)
+endif()

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/led_pwm/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/led_pwm/CMakeLists.txt
@@ -34,3 +34,5 @@
 px4_add_library(arch_led_pwm
 	led_pwm.cpp
 )
+
+target_link_libraries(arch_led_pwm PRIVATE arch_io_pins) # io_timer_init_timer

--- a/platforms/nuttx/src/px4/rpi/rpi_common/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/board_reset/CMakeLists.txt
@@ -34,3 +34,10 @@
 px4_add_library(arch_board_reset
 	board_reset.cpp
 )
+
+# up_systemreset
+if (NOT DEFINED CONFIG_BUILD_FLAT)
+	target_link_libraries(arch_board_reset PRIVATE nuttx_karch)
+else()
+	target_link_libraries(arch_board_reset PRIVATE nuttx_arch)
+endif()

--- a/platforms/nuttx/src/px4/rpi/rpi_common/io_pins/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/io_pins/CMakeLists.txt
@@ -40,3 +40,5 @@ px4_add_library(arch_io_pins
 )
 
 target_compile_options(arch_io_pins PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+
+target_link_libraries(arch_io_pins PRIVATE drivers_board)

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_reset/CMakeLists.txt
@@ -34,3 +34,10 @@
 px4_add_library(arch_board_reset
 	board_reset.cpp
 )
+
+# up_systemreset
+if (NOT DEFINED CONFIG_BUILD_FLAT)
+	target_link_libraries(arch_board_reset PRIVATE nuttx_karch)
+else()
+	target_link_libraries(arch_board_reset PRIVATE nuttx_arch)
+endif()

--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/CMakeLists.txt
@@ -38,3 +38,5 @@ px4_add_library(arch_io_pins
 	pwm_trigger.c
 )
 target_compile_options(arch_io_pins PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+
+target_link_libraries(arch_io_pins PRIVATE drivers_board) # timer_io_channels

--- a/platforms/nuttx/src/px4/stm/stm32_common/spi/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32_common/spi/CMakeLists.txt
@@ -35,3 +35,5 @@ px4_add_library(arch_spi
 	spi.cpp
 )
 target_compile_options(arch_spi PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
+
+target_link_libraries (arch_spi PRIVATE drivers_board) # px4_spi_buses

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -41,10 +41,6 @@ target_link_libraries(px4
 	PRIVATE
 		${module_libraries}
 		m
-
-		# horrible circular dependencies that need to be teased apart
-		px4_layer px4_platform
-		work_queue
 		parameters
 )
 

--- a/platforms/posix/cmake/px4_impl_os.cmake
+++ b/platforms/posix/cmake/px4_impl_os.cmake
@@ -301,6 +301,7 @@ function(px4_os_prebuild_targets)
 			ARGN ${ARGN})
 
 	add_library(prebuild_targets INTERFACE)
+	target_link_libraries(prebuild_targets INTERFACE px4_layer drivers_board)
 	add_dependencies(prebuild_targets DEPENDS uorb_headers)
 
 endfunction()

--- a/src/lib/drivers/device/CMakeLists.txt
+++ b/src/lib/drivers/device/CMakeLists.txt
@@ -53,8 +53,13 @@ px4_add_library(drivers__device
 	${SRCS_PLATFORM}
 	)
 
+# px4_spibus_initialize (stm32_spibus_initialize)
 if (${PX4_PLATFORM} STREQUAL "nuttx")
-	target_link_libraries(drivers__device PRIVATE nuttx_arch)
+	if (NOT DEFINED CONFIG_BUILD_FLAT)
+	  target_link_libraries(drivers__device PRIVATE nuttx_karch)
+	else()
+	  target_link_libraries(drivers__device PRIVATE nuttx_arch)
+	endif()
 endif()
 
-target_link_libraries(drivers__device PRIVATE cdev)
+target_link_libraries(drivers__device PRIVATE px4_work_queue)

--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -167,7 +167,8 @@ if (NOT "${PX4_BOARD}" MATCHES "px4_io")
 		px4_parameters.hpp
 	)
 
-	target_link_libraries(parameters PRIVATE perf tinybson px4_layer)
+	target_link_libraries(parameters PRIVATE perf tinybson px4_platform)
+
 	target_compile_definitions(parameters PRIVATE -DMODULE_NAME="parameters")
 	target_compile_options(parameters
 		PRIVATE
@@ -180,7 +181,7 @@ else()
 endif()
 add_dependencies(parameters prebuild_targets)
 
-if(${PX4_PLATFORM} STREQUAL "nuttx")
+if(${PX4_PLATFORM} STREQUAL "nuttx" AND CONFIG_BUILD_FLAT)
 	target_link_libraries(parameters PRIVATE flashparams tinybson)
 endif()
 

--- a/src/lib/version/CMakeLists.txt
+++ b/src/lib/version/CMakeLists.txt
@@ -85,5 +85,4 @@ target_compile_definitions(version
 	)
 
 target_link_libraries(version PRIVATE git_ver)
-target_link_libraries(version PRIVATE drivers_board)
 add_dependencies(version prebuild_targets)

--- a/src/modules/esc_battery/CMakeLists.txt
+++ b/src/modules/esc_battery/CMakeLists.txt
@@ -39,5 +39,6 @@ px4_add_module(
 		EscBattery.cpp
 		EscBattery.hpp
 	DEPENDS
+		battery
 		px4_work_queue
 	)

--- a/src/modules/fw_pos_control_l1/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/CMakeLists.txt
@@ -48,4 +48,5 @@ px4_add_module(
 		runway_takeoff
 		SlewRate
 		tecs
+		motion_planning
 	)

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -123,3 +123,7 @@ px4_add_unit_gtest(SRC MavlinkStatustextHandlerTest.cpp
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 		LINKLIBS modules__mavlink
 	)
+
+if(CONFIG_NET AND "${PX4_PLATFORM}" MATCHES "nuttx")
+	target_link_libraries(modules__mavlink PRIVATE nuttx_apps) # netlib_get_ipv4netmask
+endif()


### PR DESCRIPTION
This is a collection of cherry-picks from the "protected build" PR #16931 , in attempt to minimize that one.

This changes linking order of some of the libraries, adds some missing dependencies and removes some circular dependencies.

The linking for protected build is crucial part, since it needs to be done very carefully for kernel and user side; in user side one cannot link libraries which access HW or OS structured directly. Also libraries which are used in both sides cannot be directly linked to HW dependent ones

This is just a bunch of build script changes, it shouldn't change the functionality for any targets.
