### PR TITLE
Fix errors from PR 19080

### DIFF
--- a/src/lib/drivers/device/CMakeLists.txt
+++ b/src/lib/drivers/device/CMakeLists.txt
@@ -56,10 +56,10 @@ px4_add_library(drivers__device
 # px4_spibus_initialize (stm32_spibus_initialize)
 if (${PX4_PLATFORM} STREQUAL "nuttx")
 	if (NOT DEFINED CONFIG_BUILD_FLAT)
-	  target_link_libraries(drivers__device PRIVATE nuttx_karch)
+		target_link_libraries(drivers__device PRIVATE nuttx_karch)
 	else()
-	  target_link_libraries(drivers__device PRIVATE nuttx_arch)
+		target_link_libraries(drivers__device PRIVATE nuttx_arch)
 	endif()
 endif()
 
-target_link_libraries(drivers__device PRIVATE px4_work_queue)
+target_link_libraries(drivers__device PRIVATE cdev)

--- a/src/lib/rc/CMakeLists.txt
+++ b/src/lib/rc/CMakeLists.txt
@@ -50,3 +50,7 @@ target_link_libraries(rc PRIVATE prebuild_targets)
 if(PX4_TESTING AND (${PX4_PLATFORM} MATCHES "posix"))
 	add_subdirectory(rc_tests)
 endif()
+
+if(${PX4_PLATFORM} MATCHES "nuttx")
+	target_link_libraries(rc PRIVATE nuttx_fs)
+endif()

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(px4iofirmware
 		nuttx_apps
 		nuttx_arch
 		nuttx_c
+		nuttx_mm
 		rc
 )
 


### PR DESCRIPTION
This were a few unnoticed mistakes in PR #19080

Something picked up erroneously when re-basing commits

- The one line in drivers__device CMakeLists.txt didn't make sense
- Building px4_io-v2 broke

This fixes those issues

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

