### PR TITLE
Handle orbit status messages for go to waypoints

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2576,7 +2576,15 @@ void FixedwingPositionControl::publishOrbitStatus(const position_setpoint_s pos_
 {
 	orbit_status_s orbit_status{};
 	orbit_status.timestamp = hrt_absolute_time();
-	orbit_status.radius = static_cast<float>(pos_sp.loiter_direction) * pos_sp.loiter_radius;
+	float loiter_radius = pos_sp.loiter_radius;
+	uint8_t loiter_direction = pos_sp.loiter_direction;
+
+	if (fabsf(loiter_radius) < FLT_EPSILON) {
+		loiter_radius = _param_nav_loiter_rad.get();
+		loiter_direction = (loiter_radius > 0) ? 1 : -1;
+	}
+
+	orbit_status.radius = static_cast<float>(loiter_direction) * loiter_radius;
 	orbit_status.frame = 0; // MAV_FRAME::MAV_FRAME_GLOBAL
 	orbit_status.x = static_cast<double>(pos_sp.lat);
 	orbit_status.y = static_cast<double>(pos_sp.lon);


### PR DESCRIPTION
**Describe problem solved by this pull request**
For Go To waypoints, the loiter radius of the position setpoint is zero, and therefore orbit status was publishing zero radius. 

This resulted in the orbit status being displayed as a point on QGC. However, the goto waypoints are handled using a default loiter radius defined by the parameter when navigating through goto waypoints

**Describe your solution**
This commit corrects this by passing the default loiter radius as the guidance logic was using

**Test data / coverage**
Tested in SITL Gazebo
```
make px4_sitl gazebo_plane
```
- Before PR
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/5248102/151759463-fb12d444-e723-4ca6-a517-3ee098ed62e6.gif)


- After PR
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/5248102/151759399-e7680dfa-7eeb-44f6-abb2-e7b0950e93bf.gif)



