### PR TITLE
Protected build linker scripts and px4 layer

### DIFF
--- a/boards/px4/fmu-v5/nuttx-config/scripts/kernel-space.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/kernel-space.ld
@@ -1,0 +1,146 @@
+/****************************************************************************
+ * kernel-space.ld
+ *
+ *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* NOTE:  This depends on the memory.ld script having been included prior to
+ * this script.
+ */
+
+OUTPUT_ARCH(arm)
+EXTERN(_vectors)
+ENTRY(_stext)
+
+/*
+ * Ensure that abort() is present in the final object.  The exception handling
+ * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
+ */
+EXTERN(abort)
+EXTERN(_bootdelay_signature)
+/*
+ * TODO: Fill in the signature location into TOC from user-space elf
+EXTERN(_main_toc)
+*/
+
+SECTIONS
+{
+    .text : {
+        _stext = ABSOLUTE(.);
+        *(.vectors)
+	. = ALIGN(32);
+	/*
+	This signature provides the bootloader with a way to delay booting
+	*/
+	_bootdelay_signature = ABSOLUTE(.);
+	FILL(0xffecc2925d7d05c5)
+	. += 8;
+        /*
+        *(.main_toc)
+        */
+        *(.text .text.*)
+        *(.fixup)
+        *(.gnu.warning)
+        *(.rodata .rodata.*)
+        *(.gnu.linkonce.t.*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.got)
+        *(.gcc_except_table)
+        *(.gnu.linkonce.r.*)
+        _etext = ABSOLUTE(.);
+    } > kflash
+
+    /*
+     * Init functions (static constructors and the like)
+     */
+    .init_section : {
+        _sinit = ABSOLUTE(.);
+	KEEP(*(.init_array .init_array.*))
+        _einit = ABSOLUTE(.);
+    } > kflash
+
+
+    .ARM.extab : {
+        *(.ARM.extab*)
+    } > kflash
+
+    __exidx_start = ABSOLUTE(.);
+    .ARM.exidx : {
+        *(.ARM.exidx*)
+    } > kflash
+
+    __exidx_end = ABSOLUTE(.);
+
+    _eronly = ABSOLUTE(.);
+
+    .data : {
+        _sdata = ABSOLUTE(.);
+        *(.data .data.*)
+        *(.gnu.linkonce.d.*)
+        CONSTRUCTORS
+        _edata = ABSOLUTE(.);
+    } > ksram AT > kflash
+
+    .bss : {
+        _sbss = ABSOLUTE(.);
+        *(.bss .bss.*)
+        *(.gnu.linkonce.b.*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = ABSOLUTE(.);
+    } > ksram
+
+    /* Stabs debugging sections */
+
+    .stab 0 : { *(.stab) }
+    .stabstr 0 : { *(.stabstr) }
+    .stab.excl 0 : { *(.stab.excl) }
+    .stab.exclstr 0 : { *(.stab.exclstr) }
+    .stab.index 0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 : { *(.comment) }
+    .debug_abbrev 0 : { *(.debug_abbrev) }
+    .debug_info 0 : { *(.debug_info) }
+    .debug_line 0 : { *(.debug_line) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    .debug_aranges 0 : { *(.debug_aranges) }
+
+    .ramfunc : {
+        _sramfuncs = .;
+	*(.ramfunc  .ramfunc.*)
+	. = ALIGN(4);
+	_eramfuncs = .;
+    } > ksram AT > kflash
+
+    _framfuncs = LOADADDR(.ramfunc);
+}

--- a/boards/px4/fmu-v5/nuttx-config/scripts/memory.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/memory.ld
@@ -1,0 +1,98 @@
+/****************************************************************************
+ * scripts/memory.ld
+ *
+ *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* The STM32F765IIT6 has 2048 KiB of main FLASH memory.  This FLASH memory
+ * can be accessed from either the AXIM interface at address 0x0800:0000 or
+ * from the ITCM interface at address 0x0020:0000.
+ *
+ * Additional information, including the option bytes, is available at at
+ * FLASH at address 0x1ff0:0000 (AXIM) or 0x0010:0000 (ITCM).
+ *
+ * In the STM32F765IIT6, two different boot spaces can be selected through
+ * the BOOT pin and the boot base address programmed in the BOOT_ADD0 and
+ * BOOT_ADD1 option bytes:
+ *
+ *   1) BOOT=0: Boot address defined by user option byte BOOT_ADD0[15:0].
+ *      ST programmed value: Flash on ITCM at 0x0020:0000
+ *   2) BOOT=1: Boot address defined by user option byte BOOT_ADD1[15:0].
+ *      ST programmed value: System bootloader at 0x0010:0000
+ *
+ * NuttX does not modify these option byes.  On the unmodified NUCLEO-144
+ * board, the BOOT0 pin is at ground so by default, the STM32F765IIT6 will
+ * boot from address 0x0020:0000 in ITCM FLASH.
+ *
+ * The STM32F765IIT6 also has 512 KiB of data SRAM (in addition to ITCM SRAM).
+ * SRAM is split up into three blocks:
+ *
+ *   1) 128 KiB of DTCM SRM beginning at address 0x2000:0000
+ *   2) 368 KiB of SRAM1 beginning at address 0x2002:0000
+ *   3)  16 KiB of SRAM2 beginning at address 0x2007:c000
+ *
+ * When booting from FLASH, FLASH memory is aliased to address 0x0000:0000
+ * where the code expects to begin execution by jumping to the entry point in
+ * the 0x0800:0000 address range.
+ *
+ * Bootloader reserves the first 32K bank (2 Mbytes Flash memory single bank)
+ * organization (256 bits read width)
+ */
+
+MEMORY
+{
+  /* ITCM boot address */
+
+  itcm  (rwx) : ORIGIN = 0x00208000, LENGTH = 2048K-32K
+
+  /* 2048KB FLASH, bootloader reserves the first 32kb */
+
+  kflash (rx) : ORIGIN = 0x08008000, LENGTH = 1024K-32K
+  uflash (rx) : ORIGIN = 0x08100000, LENGTH = 1024K
+
+  /* ITCM RAM */
+
+  itcm_ram  (rwx) : ORIGIN = 0x00000000, LENGTH = 16K
+
+  /* DTCM SRAM */
+
+  dtcm_ram  (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+
+  /* 368KB of contiguous SRAM1 */
+
+  ksram (rwx) : ORIGIN = 0x20020000, LENGTH = 128K
+  usram (rwx) : ORIGIN = 0x20040000, LENGTH = 368K-128K
+
+  /* 16KB of SRAM2 */
+
+  sram2 (rwx) : ORIGIN = 0x2007c000, LENGTH = 16K
+}

--- a/boards/px4/fmu-v5/nuttx-config/scripts/user-space.ld
+++ b/boards/px4/fmu-v5/nuttx-config/scripts/user-space.ld
@@ -1,0 +1,124 @@
+/****************************************************************************
+ * user-space.ld
+ *
+ *   Copyright (C) 2015 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* NOTE:  This depends on the memory.ld script having been included prior to
+ * this script.
+ */
+EXTERN(userspace)
+OUTPUT_ARCH(arm)
+SECTIONS
+{
+    .userspace : {
+        *(.userspace)
+    } > uflash
+
+    .text : {
+        _stext = ABSOLUTE(.);
+        *(.text .text.*)
+        *(.fixup)
+        *(.gnu.warning)
+        *(.rodata .rodata.*)
+        *(.gnu.linkonce.t.*)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.got)
+        *(.gcc_except_table)
+        *(.gnu.linkonce.r.*)
+        _etext = ABSOLUTE(.);
+    } > uflash
+
+    /*
+     * Init functions (static constructors and the like)
+     */
+    .init_section : {
+        _sinit = ABSOLUTE(.);
+        KEEP(*(.init_array .init_array.*))
+        _einit = ABSOLUTE(.);
+    } > uflash
+
+
+    .ARM.extab : {
+        *(.ARM.extab*)
+    } > uflash
+
+    __exidx_start = ABSOLUTE(.);
+    .ARM.exidx : {
+        *(.ARM.exidx*)
+    } > uflash
+
+    __exidx_end = ABSOLUTE(.);
+
+    _eronly = ABSOLUTE(.);
+
+    .data : {
+        _sdata = ABSOLUTE(.);
+        *(.data .data.*)
+        *(.gnu.linkonce.d.*)
+        CONSTRUCTORS
+        _edata = ABSOLUTE(.);
+    } > usram AT > uflash
+
+    .bss : {
+        _sbss = ABSOLUTE(.);
+        *(.bss .bss.*)
+        *(.gnu.linkonce.b.*)
+        *(COMMON)
+        /* Kernel heap start at _ebss, make _ebss MPU-friendly aligned */
+        . = ALIGN(0x1000);
+        _ebss = ABSOLUTE(.);
+    } > usram
+
+    /* Stabs debugging sections */
+
+    .stab 0 : { *(.stab) }
+    .stabstr 0 : { *(.stabstr) }
+    .stab.excl 0 : { *(.stab.excl) }
+    .stab.exclstr 0 : { *(.stab.exclstr) }
+    .stab.index 0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 : { *(.comment) }
+    .debug_abbrev 0 : { *(.debug_abbrev) }
+    .debug_info 0 : { *(.debug_info) }
+    .debug_line 0 : { *(.debug_line) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    .debug_aranges 0 : { *(.debug_aranges) }
+
+    /* Start of the image signature. This
+     *  has to be in the end of the image
+     */
+     .signature : {
+         _boot_signature = ALIGN(4);
+     } > uflash
+}

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -44,6 +44,14 @@ add_dependencies(px4 git_nuttx)
 
 get_property(module_libraries GLOBAL PROPERTY PX4_MODULE_LIBRARIES)
 
+if (NOT CONFIG_BUILD_FLAT)
+	add_executable(px4_kernel ${PX4_SOURCE_DIR}/platforms/common/empty.c)
+	set(KERNEL_NAME ${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_${PX4_BOARD_LABEL}_kernel.elf)
+	set_target_properties(px4_kernel PROPERTIES OUTPUT_NAME ${KERNEL_NAME})
+	add_dependencies(px4_kernel git_nuttx)
+	get_property(kernel_module_libraries GLOBAL PROPERTY PX4_KERNEL_MODULE_LIBRARIES)
+endif()
+
 # build NuttX
 add_subdirectory(NuttX ${PX4_BINARY_DIR}/NuttX)
 
@@ -81,18 +89,31 @@ else()
 endif()
 
 list(APPEND nuttx_libs
-	nuttx_apps
-	nuttx_arch
-	nuttx_binfmt
-	nuttx_c
 	nuttx_boards
-	nuttx_xx
 	nuttx_drivers
 	nuttx_fs
-	nuttx_mm
 	nuttx_sched
 	nuttx_crypto
-)
+	nuttx_binfmt
+	nuttx_xx
+	)
+
+if (NOT CONFIG_BUILD_FLAT)
+	list(APPEND nuttx_libs
+		px4_board_ctrl
+		nuttx_karch
+		nuttx_kmm
+		nuttx_stubs
+		nuttx_kc
+		)
+else()
+	list(APPEND nuttx_libs
+		nuttx_apps
+		nuttx_arch
+		nuttx_mm
+		nuttx_c
+		)
+endif()
 
 if(CONFIG_NET)
 	list(APPEND nuttx_libs nuttx_net)
@@ -104,53 +125,6 @@ file(RELATIVE_PATH PX4_BINARY_DIR_REL ${CMAKE_CURRENT_BINARY_DIR} ${PX4_BINARY_D
 # only in the cygwin environment: convert absolute linker script path to mixed windows (C:/...)
 # because even relative linker script paths are different for linux, mac and windows
 CYGPATH(NUTTX_CONFIG_DIR NUTTX_CONFIG_DIR_CYG)
-
-target_link_libraries(nuttx_c INTERFACE nuttx_sched) # nxsched_get_streams
-
-target_link_libraries(nuttx_arch
-	INTERFACE
-		drivers_board
-		arch_hrt
-		arch_board_reset
-)
-
-target_link_libraries(nuttx_c INTERFACE nuttx_drivers)
-target_link_libraries(nuttx_drivers INTERFACE nuttx_c)
-target_link_libraries(nuttx_xx INTERFACE nuttx_c)
-target_link_libraries(nuttx_fs INTERFACE nuttx_c)
-
-target_link_libraries(px4 PRIVATE
-
-	-nostartfiles
-	-nodefaultlibs
-	-nostdlib
-	-nostdinc++
-
-	-fno-exceptions
-	-fno-rtti
-	-Wl,--script=${NUTTX_CONFIG_DIR_CYG}/scripts/${SCRIPT_PREFIX}script.ld
-	-Wl,-Map=${PX4_CONFIG}.map
-	-Wl,--warn-common
-	-Wl,--gc-sections
-
-	-Wl,--start-group
-		${nuttx_libs}
-	-Wl,--end-group
-
-	m
-	gcc
-	)
-
-if(NOT USE_LD_GOLD)
-	target_link_libraries(px4 PRIVATE -Wl,--print-memory-usage)
-endif()
-
-target_link_libraries(px4 PRIVATE ${module_libraries})
-
-if(config_romfs_root)
-	add_subdirectory(${PX4_SOURCE_DIR}/ROMFS ${PX4_BINARY_DIR}/ROMFS)
-	target_link_libraries(px4 PRIVATE romfs)
-endif()
 
 if((DEFINED ENV{SIGNING_TOOL}) AND (NOT NUTTX_DIR MATCHES "external"))
 	set(PX4_BINARY_OUTPUT ${PX4_BINARY_DIR}/${PX4_CONFIG}_unsigned.bin)
@@ -164,10 +138,154 @@ else()
 	set(PX4_BINARY_OUTPUT ${PX4_BINARY_DIR_REL}/${PX4_CONFIG}.bin)
 endif()
 
-add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
-	COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_OUTPUT}
-	DEPENDS px4
-)
+if (NOT CONFIG_BUILD_FLAT)
+
+	target_link_libraries(nuttx_karch
+		INTERFACE
+			drivers_board
+			arch_hrt
+			)
+
+	target_link_libraries(px4_kernel PRIVATE
+
+		-nostartfiles
+		-nodefaultlibs
+		-nostdlib
+		-nostdinc++
+
+		-fno-exceptions
+		-fno-rtti
+
+		-Wl,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}memory.ld,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}kernel-space.ld
+
+		-Wl,-Map=${PX4_CONFIG}_kernel.map
+		-Wl,--warn-common
+		-Wl,--gc-sections
+
+		-Wl,--start-group
+			${nuttx_libs}
+			${kernel_module_libraries}
+			px4_work_queue # TODO, this shouldn't be needed here?
+		-Wl,--end-group
+
+		m
+		gcc
+		)
+
+	if (config_romfs_root)
+		add_subdirectory(${PX4_SOURCE_DIR}/ROMFS ${PX4_BINARY_DIR}/ROMFS)
+		target_link_libraries(px4_kernel PRIVATE romfs)
+	endif()
+
+	target_link_libraries(px4_kernel PRIVATE -Wl,--print-memory-usage)
+
+	set(nuttx_userspace)
+
+	list(APPEND nuttx_userspace
+		drivers_userspace
+		nuttx_arch
+		nuttx_apps
+		nuttx_mm
+		nuttx_proxies
+		nuttx_c
+		nuttx_xx
+		)
+
+	target_link_libraries(nuttx_c INTERFACE nuttx_proxies)
+
+	target_link_libraries(px4 PRIVATE
+
+		-nostartfiles
+		-nodefaultlibs
+		-nostdlib
+		-nostdinc++
+
+		-fno-exceptions
+		-fno-rtti
+
+		-Wl,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}memory.ld,--script=${NUTTX_CONFIG_DIR}/scripts/${SCRIPT_PREFIX}user-space.ld
+
+		-Wl,-Map=${PX4_CONFIG}.map
+		-Wl,--warn-common
+		-Wl,--gc-sections
+
+		-Wl,--start-group
+		${nuttx_userspace}
+		-Wl,--end-group
+
+		m
+		gcc
+		)
+
+	target_link_libraries(px4 PRIVATE -Wl,--print-memory-usage)
+
+	target_link_libraries(px4 PRIVATE
+		${module_libraries}
+	)
+
+	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
+		COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR_REL}/${PX4_BOARD}_user.bin
+		COMMAND ${CMAKE_OBJCOPY} --gap-fill 0xFF --pad-to ${CONFIG_NUTTX_USERSPACE} -O binary ${PX4_BINARY_DIR_REL}/${KERNEL_NAME} ${PX4_BINARY_OUTPUT}
+		COMMAND cat ${PX4_BINARY_DIR_REL}/${PX4_BOARD}_user.bin >> ${PX4_BINARY_OUTPUT}
+
+		DEPENDS px4 px4_kernel
+	)
+
+else()
+
+	target_link_libraries(nuttx_c INTERFACE nuttx_sched) # nxsched_get_streams
+
+	target_link_libraries(nuttx_arch
+		INTERFACE
+			drivers_board
+			arch_hrt
+			arch_board_reset
+	)
+
+	target_link_libraries(nuttx_c INTERFACE nuttx_drivers)
+	target_link_libraries(nuttx_drivers INTERFACE nuttx_c)
+	target_link_libraries(nuttx_xx INTERFACE nuttx_c)
+	target_link_libraries(nuttx_fs INTERFACE nuttx_c)
+
+	target_link_libraries(px4 PRIVATE
+
+		-nostartfiles
+		-nodefaultlibs
+		-nostdlib
+		-nostdinc++
+
+		-fno-exceptions
+		-fno-rtti
+		-Wl,--script=${NUTTX_CONFIG_DIR_CYG}/scripts/${SCRIPT_PREFIX}script.ld
+		-Wl,-Map=${PX4_CONFIG}.map
+		-Wl,--warn-common
+		-Wl,--gc-sections
+
+		-Wl,--start-group
+			${nuttx_libs}
+		-Wl,--end-group
+
+		m
+		gcc
+		)
+
+	if(NOT USE_LD_GOLD)
+		target_link_libraries(px4 PRIVATE -Wl,--print-memory-usage)
+	endif()
+
+	target_link_libraries(px4 PRIVATE ${module_libraries})
+
+	if(config_romfs_root)
+		add_subdirectory(${PX4_SOURCE_DIR}/ROMFS ${PX4_BINARY_DIR}/ROMFS)
+		target_link_libraries(px4 PRIVATE romfs)
+	endif()
+
+	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
+		COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_OUTPUT}
+		DEPENDS px4
+	)
+
+endif()
 
 # create .px4 with parameter and airframe metadata
 if (TARGET parameters_xml AND TARGET airframes_xml)

--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -33,8 +33,8 @@
 
 # skip for px4_layer support on an IO board
 if(NOT PX4_BOARD MATCHES "io-v2")
-
-	add_library(px4_layer
+	# Kernel side & nuttx flat build common sources
+	set(KERNEL_SRCS
 		board_crashdump.c
 		board_dma_alloc.c
 		board_fat_dma_alloc.c
@@ -51,32 +51,36 @@ if(NOT PX4_BOARD MATCHES "io-v2")
 		px4_24xxxx_mtd.c
 		px4_crypto.cpp
 	)
-	target_link_libraries(px4_layer
-		PRIVATE
-			arch_board_reset
-			arch_board_critmon
-			arch_version
-			nuttx_apps
-			nuttx_sched
-			nuttx_mm
-			px4_work_queue
-			uORB
+
+	# Kernel side & nuttx flat build common libraries
+	set(KERNEL_LIBS
+		arch_board_reset
+		arch_board_critmon
+		arch_version
+		nuttx_sched
 	)
+
+if (NOT DEFINED CONFIG_BUILD_FLAT AND "${PX4_PLATFORM}" MATCHES "nuttx")
+	# Build the NuttX user and kernel space px4 layers
+	include(${CMAKE_CURRENT_SOURCE_DIR}/px4_protected_layers.cmake)
+
 else()
+	# Build the flat build px4_layer
+	include(${CMAKE_CURRENT_SOURCE_DIR}/px4_layer.cmake)
+endif()
+
+else()
+	# Build the px4 layer for io_v2
 	add_library(px4_layer ${PX4_SOURCE_DIR}/platforms/common/empty.c)
 endif()
+
 add_dependencies(px4_layer prebuild_targets)
 
 add_subdirectory(gpio)
 add_subdirectory(srgbled)
 
+# Build px4_random
 if (DEFINED PX4_CRYPTO)
 	add_library(px4_random nuttx_random.c)
-	add_dependencies(px4_random nuttx_context)
 	target_link_libraries(px4_random PRIVATE nuttx_crypto)
-
-	target_link_libraries(px4_layer
-		PUBLIC
-			crypto_backend
-	)
 endif()

--- a/platforms/nuttx/src/px4/common/console_buffer_usr.cpp
+++ b/platforms/nuttx/src/px4/common/console_buffer_usr.cpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/console_buffer.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/sem.h>
+#include <pthread.h>
+#include <string.h>
+#include <fcntl.h>
+
+#ifdef BOARD_ENABLE_CONSOLE_BUFFER
+#ifndef BOARD_CONSOLE_BUFFER_SIZE
+# define BOARD_CONSOLE_BUFFER_SIZE (1024*4) // default buffer size
+#endif
+
+
+// TODO: User side implementation of px4_console_buffer
+
+int px4_console_buffer_init()
+{
+	return 0;
+}
+
+int px4_console_buffer_size()
+{
+	return 0;
+}
+
+int px4_console_buffer_read(char *buffer, int buffer_length, int *offset)
+{
+	return 0;
+}
+
+#endif /* BOARD_ENABLE_CONSOLE_BUFFER */

--- a/platforms/nuttx/src/px4/common/px4_layer.cmake
+++ b/platforms/nuttx/src/px4/common/px4_layer.cmake
@@ -1,0 +1,22 @@
+# Build the px4 layer for nuttx flat build
+
+add_library(px4_layer
+		${KERNEL_SRCS}
+		cdc_acm_check.cpp
+	)
+
+target_link_libraries(px4_layer
+	PRIVATE
+		${KERNEL_LIBS}
+		nuttx_c
+		nuttx_arch
+		nuttx_mm
+	)
+
+
+if (DEFINED PX4_CRYPTO)
+	target_link_libraries(px4_layer
+		PUBLIC
+			crypto_backend
+	)
+endif()

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -1,0 +1,41 @@
+
+# Build the user side px4_layer
+
+add_library(px4_layer
+	tasks.cpp
+	console_buffer_usr.cpp
+	usr_mcu_version.cpp
+	cdc_acm_check.cpp
+	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/print_load.cpp
+	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/cpuload.cpp
+)
+
+target_link_libraries(px4_layer
+	PRIVATE
+		m
+		nuttx_c
+		nuttx_xx
+		nuttx_mm
+)
+
+# Build the kernel side px4_kernel_layer
+
+add_library(px4_kernel_layer
+		${KERNEL_SRCS}
+)
+
+target_link_libraries(px4_kernel_layer
+	PRIVATE
+		${KERNEL_LIBS}
+		nuttx_kc
+		nuttx_karch
+		nuttx_kmm
+)
+
+if (DEFINED PX4_CRYPTO)
+	target_link_libraries(px4_kernel_layer PUBLIC crypto_backend)
+endif()
+
+target_compile_options(px4_kernel_layer PRIVATE -D__KERNEL__)
+
+add_dependencies(px4_kernel_layer prebuild_targets)

--- a/platforms/nuttx/src/px4/common/usr_mcu_version.cpp
+++ b/platforms/nuttx/src/px4/common/usr_mcu_version.cpp
@@ -1,0 +1,114 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 Technology Innovation Institute. All rights reserved.
+ *   Author: @author Jukka Laitinen <jukkax@ssrc.tii.ae>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file usr_mcu_version.c
+ * Implementation of generic user-space version API
+ */
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
+
+#include "board_config.h"
+
+static int hw_version = 0;
+static int hw_revision = 0;
+static char hw_info[] = HW_INFO_INIT;
+
+__EXPORT const char *board_get_hw_type_name(void)
+{
+	return (const char *) hw_info;
+}
+
+__EXPORT int board_get_hw_version(void)
+{
+	return  hw_version;
+}
+
+__EXPORT int board_get_hw_revision()
+{
+	return  hw_revision;
+}
+
+__EXPORT void board_get_uuid32(uuid_uint32_t uuid_words)
+{
+	/* TODO: This is a stub for userspace build. Use some proper interface
+	 * to fetch the uuid32 from the kernel
+	 */
+	uint32_t chip_uuid[PX4_CPU_UUID_WORD32_LENGTH];
+	memset((uint8_t *)chip_uuid, 0, PX4_CPU_UUID_WORD32_LENGTH * 4);
+
+	for (unsigned i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
+		uuid_words[i] = chip_uuid[i];
+	}
+}
+
+int board_mcu_version(char *rev, const char **revstr, const char **errata)
+{
+	/* TODO: This is a stub for userspace build. Use some proper interface
+	 * to fetch the version from the kernel
+	 */
+	return -1;
+}
+
+int board_get_px4_guid(px4_guid_t px4_guid)
+{
+	/* TODO: This is a stub for userspace build. Use some proper interface
+	 * to fetch the guid from the kernel
+	 */
+	uint8_t  *pb = (uint8_t *) &px4_guid[0];
+	memset(pb, 0, PX4_GUID_BYTE_LENGTH);
+
+	return PX4_GUID_BYTE_LENGTH;
+}
+
+int board_get_px4_guid_formated(char *format_buffer, int size)
+{
+	px4_guid_t px4_guid;
+	board_get_px4_guid(px4_guid);
+	int offset  = 0;
+
+	/* size should be 2 per byte + 1 for termination
+	 * So it needs to be odd
+	 */
+	size = size & 1 ? size : size - 1;
+
+	/* Discard from MSD */
+	for (unsigned i = PX4_GUID_BYTE_LENGTH - size / 2; offset < size && i < PX4_GUID_BYTE_LENGTH; i++) {
+		offset += snprintf(&format_buffer[offset], size - offset, "%02x", px4_guid[i]);
+	}
+
+	return offset;
+}
+


### PR DESCRIPTION
This PR adds the following in preparation for running PX4 in NuttX "protected build" configuration

- Linker scripts for building separate kernel and userspace blobs
- Cmake file change for building the two separate blobs and combining them into one for flashing
- px4_layer split into two: The OS specific part for kernel side linkage and the OS specific part for the user side linkage.

The px4_layer for user space contains a few stubs: 
- console_buffer_usr.cpp: we could avoid having this at all if we'd just define that the "protected" build doesn't support console buffer at all (this can be flagged in the board definition). I initially added a stub for it, so that we could have an implementation for it there in the future
- usr_mcu_version.cpp: Just give a version info of 00000 for now, as there is no interface which could be used to get the version info in userland atm. Something either using boardctl_ioctl or procfs interface would be proper implementation in the future
- cpuload code: Just picked posix files, which in practice do nothing in nuttx build. What could be done here is that we could read the load from proc/cpuload in nuttx and in proc/loadavg(?) in linux. But user side cannot link directly to nuttx internals, what is what the flat build/kernel does.

In practice, this PR alone doesn't add any functionality, since it doesn't change the normal PX4 / flat building and it doesn't work alone for protected build. Please let me know if it is sane to split the "protected build" PR into pieces like this.
