### PR TITLE
Add geofence buffer zone, (i.e. inner geofence), with associated gf action

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -9,4 +9,7 @@ uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated
 
+bool geofence_buffer_violated   # true if the geofence buffer zone is violated
+uint8 geofence_buffer_action    # action to take when geofence buffer zone is violated
+
 bool home_required              # true if the geofence requires a valid home position

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -88,6 +88,7 @@ bool high_latency_data_link_lost 			# Set to true if the high latency data link 
 bool engine_failure				# Set to true if an engine failure is detected
 bool mission_failure				# Set to true if mission could not continue/finish
 bool geofence_violated
+bool geofence_buffer_violated
 
 uint8 failure_detector_status			# Bitmask containing FailureDetector status [0, 0, 0, 0, 0, FAILURE_ALT, FAILURE_PITCH, FAILURE_ROLL]
 

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -87,6 +87,7 @@ public:
 		bool global_position = false;
 		bool mission = false;
 		bool geofence = false;
+		bool geofence_buffer = false;
 	};
 
 	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -263,6 +263,7 @@ private:
 
 		// Geofence
 		(ParamInt<px4::params::GF_ACTION>) _param_geofence_action,
+		(ParamInt<px4::params::GF_BUFFER_ACTION>) _param_geofence_buffer_action,
 
 		// Mavlink
 		(ParamInt<px4::params::MAV_COMP_ID>) _param_mav_comp_id,
@@ -319,6 +320,8 @@ private:
 	bool		_geofence_land_on{false};
 	bool		_geofence_warning_action_on{false};
 	bool		_geofence_violated_prev{false};
+	bool		_geofence_buffer_warning_action_on{false};
+	bool		_geofence_buffer_violated_prev{false};
 
 	bool		_rtl_time_actions_done{false};
 

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
@@ -46,6 +46,7 @@ union geofence_violation_type_u {
 		bool dist_to_home_exceeded: 1;	///< 0 - distance to home exceeded
 		bool max_altitude_exceeded: 1;	///< 1 - maximum altitude exceeded
 		bool fence_violation: 1;	///< 2- violation of user defined fence
+		bool buffer_violation: 1;	///< 3- violation of user defined buffer zone
 	} flags;
 	uint8_t value;
 };

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -197,7 +197,9 @@ bool Geofence::checkAll(double lat, double lon, float altitude)
 	// as they both report being inside when not enabled
 	inside_fence = inside_fence && isInsidePolygonOrCircle(lat, lon, altitude);
 
-	if (inside_fence) {
+	bool inside_buffer = isInsideBufferZone(lat, lon, altitude);
+
+	if (inside_fence && !inside_buffer) {
 		_outside_counter = 0;
 		return inside_fence;
 
@@ -453,14 +455,151 @@ bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, 
 	return dx * dx + dy * dy < circle_point.circle_radius * circle_point.circle_radius;
 }
 
-bool
-Geofence::valid()
+bool Geofence::valid()
 {
 	return true; // always valid
 }
 
-int
-Geofence::loadFromFile(const char *filename)
+bool Geofence::isInsideBufferZone(double lat, double lon, float altitude)
+{
+	// the following uses dm_read, so first we try to lock all items. If that fails, it (most likely) means
+	// the data is currently being updated (via a mavlink geofence transfer), and we do not check for a violation now
+	if (dm_trylock(DM_KEY_FENCE_POINTS) != 0) {
+		return false;
+	}
+
+	// we got the lock, now check if the fence data got updated
+	mission_stats_entry_s stats;
+	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
+
+	if (ret == sizeof(mission_stats_entry_s) && _update_counter != stats.update_counter) {
+		_updateFence();
+	}
+
+	if (isEmpty()) {
+		dm_unlock(DM_KEY_FENCE_POINTS);
+		/* Empty fence -> accept all points */
+		return false;
+	}
+
+	float buffer_distance_m = _param_gf_buffer_dist.get();
+
+	/* Vertical check */
+	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
+		if ((altitude < _altitude_max && altitude >= _altitude_max - buffer_distance_m) ||
+		    (altitude > _altitude_min && altitude <= _altitude_min + buffer_distance_m)) {
+			dm_unlock(DM_KEY_FENCE_POINTS);
+
+			PX4_INFO("Altitude check returned error!");
+			return true;
+		}
+	}
+
+	/* Horizontal check: iterate all polygons & circles */
+	bool inside_circle_buffer_zone  = false;
+	bool inside_polygon_buffer_zone = false;
+
+	for (int polygon_index = 0; polygon_index < _num_polygons; ++polygon_index) {
+
+		if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_INCLUSION ||
+		    _polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_EXCLUSION) {
+			inside_circle_buffer_zone = insideCircleBufferZone(_polygons[polygon_index], lat, lon, altitude);
+		} else {
+			inside_polygon_buffer_zone = insidePolygonBufferZone(_polygons[polygon_index], lat, lon, altitude);
+		}
+	}
+
+	dm_unlock(DM_KEY_FENCE_POINTS);
+
+	if (inside_circle_buffer_zone || inside_polygon_buffer_zone) {
+		return true;
+	}
+
+	return false;
+}
+
+bool Geofence::insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude)
+{
+	mission_fence_point_s temp_vertex_i{};
+	mission_fence_point_s temp_vertex_j{};
+	crosstrack_error_s crosstrack_error{};
+
+	for (unsigned i = 0, j = polygon.vertex_count - 1; i < polygon.vertex_count; j = i++) {
+		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + i, &temp_vertex_i,
+			    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+			break;
+		}
+
+		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + j, &temp_vertex_j,
+			    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+			break;
+		}
+
+		if (temp_vertex_i.frame != NAV_FRAME_GLOBAL && temp_vertex_i.frame != NAV_FRAME_GLOBAL_INT
+		    && temp_vertex_i.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT
+		    && temp_vertex_i.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+			// TODO: handle different frames
+			PX4_ERR("Frame type %i not supported", (int)temp_vertex_i.frame);
+			break;
+		}
+
+		get_distance_to_line(&crosstrack_error, lat, lon,
+				     temp_vertex_i.lat, temp_vertex_i.lon,
+				     temp_vertex_j.lat, temp_vertex_j.lon);
+
+		if (!crosstrack_error.past_end &&
+		    fabs(crosstrack_error.distance) <= _param_gf_buffer_dist.get()) {
+
+			PX4_INFO("inside_polygon_buffer_zone! crosstrack distance to fence: %f", (double)crosstrack_error.distance);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool Geofence::insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude)
+{
+	mission_fence_point_s circle_point{};
+	crosstrack_error_s crosstrack_error{};
+
+	if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index, &circle_point,
+		    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+		PX4_ERR("dm_read failed");
+		return false;
+	}
+
+	if (circle_point.frame != NAV_FRAME_GLOBAL && circle_point.frame != NAV_FRAME_GLOBAL_INT
+	    && circle_point.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT
+	    && circle_point.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+		// TODO: handle different frames
+		PX4_ERR("Frame type %i not supported", (int)circle_point.frame);
+		return false;
+	}
+
+	if (!_projection_reference.isInitialized()) {
+		_projection_reference.initReference(lat, lon);
+	}
+
+	get_distance_to_arc(&crosstrack_error, lat, lon,
+			    circle_point.lat,
+			    circle_point.lon,
+			    circle_point.circle_radius, 0.f, 360.f);
+
+	PX4_INFO("lat = %f", (double)lat);
+	PX4_INFO("lat = %f", (double)lon);
+
+	PX4_INFO("distance_to_arc = %f", (double)crosstrack_error.distance);
+
+	if (fabs(crosstrack_error.distance) <= _param_gf_buffer_dist.get()) {
+		PX4_INFO("inside_circle_buffer_zone! crosstrack distance to fence: %f", (double)crosstrack_error.distance);
+		return true;
+	}
+
+	return false;
+}
+
+int Geofence::loadFromFile(const char *filename)
 {
 	FILE *fp;
 	char line[120];
@@ -472,7 +611,7 @@ Geofence::loadFromFile(const char *filename)
 	/* Make sure no data is left in the datamanager */
 	clearDm();
 
-	/* open the mixer definition file */
+	/* open the geofence file */
 	fp = fopen(GEOFENCE_FILENAME, "r");
 
 	if (fp == nullptr) {

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -108,9 +108,13 @@ public:
 
 	bool isCloserThanMaxDistToHome(double lat, double lon, float altitude);
 
+	bool isCloserThanBufferDistance(double lat, double lon, float altitude);
+
 	bool isBelowMaxAltitude(float altitude);
 
 	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
+
+	virtual bool isInsideBufferZone(double lat, double lon, float altitude);
 
 	int clearDm();
 
@@ -141,7 +145,7 @@ public:
 
 	int getSource() { return _param_gf_source.get(); }
 	int getGeofenceAction() { return _param_gf_action.get(); }
-
+	int getGeofenceBufferAction() { return _param_gf_buffer_action.get(); }
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 
@@ -179,6 +183,7 @@ private:
 	uORB::SubscriptionData<vehicle_air_data_s> _sub_airdata;
 
 	int _outside_counter{0};
+
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, we polygon data was updated
 
 	/**
@@ -198,9 +203,8 @@ private:
 	 */
 	bool checkPolygons(double lat, double lon, float altitude);
 
-
-
 	bool checkAll(const vehicle_global_position_s &global_position);
+
 	bool checkAll(const vehicle_global_position_s &global_position, float baro_altitude_amsl);
 
 	/**
@@ -209,12 +213,16 @@ private:
 	 */
 	bool insidePolygon(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
+	bool insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
 	/**
 	 * Check if a single point is within a circle
 	 * @param polygon must be a circle!
 	 * @return true if within polygon the circle
 	 */
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
+	bool insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -129,3 +129,35 @@ PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, 0);
  * @group Geofence
  */
 PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
+
+/**
+ * Geofence buffer distance.
+ *
+ * Distance inside the Geofence to apply the GF_BUFFER_ACTION.
+ *
+ * @min 0.0
+ * @max 100.0
+ * @group Geofence
+ */
+PARAM_DEFINE_FLOAT(GF_BUFFER_DIST, 10.0f);
+
+/**
+ * Geofence buffer zone violation action.
+ *
+ * Note: Setting this value to 4 enables flight termination,
+ * which will kill the vehicle on violation of the fence.
+ * Due to the inherent danger of this, this function is
+ * disabled using a software circuit breaker, which needs
+ * to be reset to 0 to really shut down the system.
+ *
+ * @min 0
+ * @max 5
+ * @value 0 None
+ * @value 1 Warning
+ * @value 2 Hold mode
+ * @value 3 Return mode
+ * @value 4 Terminate
+ * @value 5 Land mode
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF_BUFFER_ACTION, 1);


### PR DESCRIPTION
**Describe problem solved by this pull request**
The geofence class has recently been improved with predictive behavior, however this alone does not allow an initial behavior such as hold or land to be followed later by a hard flight termination on a hard geofence breach.  In the event of a poor position estimate and/or attitude estimate due to vibrations the drone might still be able to be held within the fence, but for areas that require a flight termination on geofence breach the current functionality only allows that single option.

**Describe your solution**
This PR creates a buffer zone, effectively an inner fence,  with associated behavior and offset distance parameter that allow the drone to enter another mode prior to any flight termination commands if the fence is actually violated.

**Describe possible alternatives**
If there is a better manner to create a 2 geofence solution please let me know what a preferred architecture would be!

**Test data / coverage**
SITL tested using jmavsim.

**Additional context**
This PR leverages PR #17795 and functions best with that PR, but contents for that PR can be stripped out of this PR if for any reason #17795 is not able to be merged.
