### PR TITLE
Add geofence buffer zone, (i.e. inner geofence), with associated gf action

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -9,4 +9,7 @@ uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated
 
+bool geofence_buffer_violated   # true if the geofence buffer zone is violated
+uint8 geofence_buffer_action    # action to take when geofence buffer zone is violated
+
 bool home_required              # true if the geofence requires a valid home position

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -85,6 +85,7 @@ bool high_latency_data_link_lost 			# Set to true if the high latency data link 
 
 bool mission_failure				# Set to true if mission could not continue/finish
 bool geofence_violated
+bool geofence_buffer_violated
 
 uint16 failure_detector_status			# Bitmask containing FailureDetector status [0, 0, 0, 0, 0, FAILURE_ALT, FAILURE_PITCH, FAILURE_ROLL]
 

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -91,6 +91,7 @@ public:
 		bool global_position = false;
 		bool mission = false;
 		bool geofence = false;
+		bool geofence_buffer = false;
 	};
 
 	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -319,6 +319,8 @@ private:
 	bool		_geofence_land_on{false};
 	bool		_geofence_warning_action_on{false};
 	bool		_geofence_violated_prev{false};
+	bool		_geofence_buffer_warning_action_on{false};
+	bool		_geofence_buffer_violated_prev{false};
 
 	bool            _collision_prevention_enabled{false};
 

--- a/src/modules/navigator/GeofenceBreachAvoidance/GeofenceBreachAvoidanceTest.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/GeofenceBreachAvoidanceTest.cpp
@@ -88,8 +88,8 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForFixedWing)
 	Vector2d home_global(42.1, 8.2);
 	MapProjection ref{home_global(0), home_global(1)};
 
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.fence_violation = true;
+	geofence_violation_type gf_violation;
+	gf_violation.fence_violation = true;
 
 	gf_avoidance.setHorizontalTestPointDistance(20.0f);
 	gf_avoidance.setTestPointBearing(0.0f);
@@ -121,7 +121,7 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForFixedWing)
 	EXPECT_FLOAT_EQ(loiter_point_lat_lon(0), loiter_point_lat_lon_expected(0));
 	EXPECT_FLOAT_EQ(loiter_point_lat_lon(1), loiter_point_lat_lon_expected(1));
 
-	gf_violation.flags.fence_violation = false;
+	gf_violation.fence_violation = false;
 	loiter_point_lat_lon = gf_avoidance.generateLoiterPointForFixedWing(gf_violation, &geo);
 
 	EXPECT_FLOAT_EQ(loiter_point_lat_lon(0), home_global(0));
@@ -148,8 +148,8 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForMultirotor)
 	value = 8;
 	param_set(param, &value);
 
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.fence_violation = true;
+	geofence_violation_type gf_violation;
+	gf_violation.fence_violation = true;
 
 	gf_avoidance.setHorizontalTestPointDistance(30.0f);
 	gf_avoidance.setTestPointBearing(0.0f);
@@ -184,7 +184,7 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForMultirotor)
 
 	EXPECT_LE(error, 0.0f);
 
-	gf_violation.flags.fence_violation = false;
+	gf_violation.fence_violation = false;
 	loiter_point = gf_avoidance.generateLoiterPointForMultirotor(gf_violation, &geo);
 
 	EXPECT_LT(Vector2d(loiter_point - home_global).norm(), 1e-4);
@@ -198,14 +198,14 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterAltitudeForFixedWing)
 
 	gf_avoidance.setVerticalTestPointDistance(vertical_test_point_dist);
 	gf_avoidance.setCurrentPosition(0, 0, current_alt_amsl); // just care about altitude
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.max_altitude_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.max_altitude_exceeded = true;
 
 	float loiter_alt = gf_avoidance.generateLoiterAltitudeForFixedWing(gf_violation);
 
 	EXPECT_EQ(loiter_alt, current_alt_amsl - 2 * vertical_test_point_dist);
 
-	gf_violation.flags.max_altitude_exceeded = false;
+	gf_violation.max_altitude_exceeded = false;
 
 	loiter_alt = gf_avoidance.generateLoiterAltitudeForFixedWing(gf_violation);
 
@@ -217,8 +217,8 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterAltitudeForMulticopter)
 	GeofenceBreachAvoidance gf_avoidance(nullptr);
 	const float climbrate = 10.0f;
 	const float current_alt_amsl = 100.0f;
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.max_altitude_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.max_altitude_exceeded = true;
 
 	gf_avoidance.setClimbRate(climbrate);
 	gf_avoidance.setCurrentPosition(0, 0, current_alt_amsl);
@@ -229,7 +229,7 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterAltitudeForMulticopter)
 	EXPECT_EQ(loiter_alt_amsl, current_alt_amsl + gf_avoidance.computeVerticalBrakingDistanceMultirotor() -
 		  gf_avoidance.getMinVertDistToFenceMultirotor());
 
-	gf_violation.flags.max_altitude_exceeded = false;
+	gf_violation.max_altitude_exceeded = false;
 
 	loiter_alt_amsl = gf_avoidance.generateLoiterAltitudeForMulticopter(gf_violation);
 
@@ -242,8 +242,8 @@ TEST_F(GeofenceBreachAvoidanceTest, maxDistToHomeViolationMulticopter)
 	FakeGeofence geo;
 	Vector2d home_global(42.1, 8.2);
 	MapProjection ref{home_global(0), home_global(1)};
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.dist_to_home_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.dist_to_home_exceeded = true;
 
 	const float hor_vel = 8.0f;
 	const float test_point_distance = 30.0f;
@@ -274,8 +274,8 @@ TEST_F(GeofenceBreachAvoidanceTest, maxDistToHomeViolationFixedWing)
 	FakeGeofence geo;
 	Vector2d home_global(42.1, 8.2);
 	MapProjection ref{home_global(0), home_global(1)};
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.dist_to_home_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.dist_to_home_exceeded = true;
 
 	const float test_point_distance = 30.0f;
 	const float max_dist_to_home = 100.0f;

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -94,16 +94,15 @@ matrix::Vector2<double> GeofenceBreachAvoidance::waypointFromBearingAndDistance(
 	return Vector2d(fence_violation_test_point_lat, fence_violation_test_point_lon);
 }
 
-Vector2d
-GeofenceBreachAvoidance::getFenceViolationTestPoint()
+Vector2d GeofenceBreachAvoidance::getFenceViolationTestPoint()
 {
 	return waypointFromBearingAndDistance(_current_pos_lat_lon, _test_point_bearing, _test_point_distance);
 }
 
-Vector2d
-GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type_u violation_type, Geofence *geofence)
+Vector2d GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type violation_type,
+		Geofence *geofence)
 {
-	if (violation_type.flags.fence_violation) {
+	if (violation_type.fence_violation) {
 		const float bearing_90_left = matrix::wrap_2pi(_test_point_bearing - M_PI_F * 0.5f);
 		const float bearing_90_right = matrix::wrap_2pi(_test_point_bearing + M_PI_F * 0.5f);
 
@@ -139,7 +138,7 @@ GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type
 
 		return Vector2d(loiter_center_lat, loiter_center_lon);
 
-	} else if (violation_type.flags.dist_to_home_exceeded) {
+	} else if (violation_type.dist_to_home_exceeded) {
 
 		return waypointFromHomeToTestPointAtDist(math::max(_max_hor_dist_home - 2 * _test_point_distance, 0.0f));
 
@@ -148,11 +147,10 @@ GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type
 	}
 }
 
-Vector2d
-GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_type_u violation_type, Geofence *geofence)
+Vector2d GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_type violation_type,
+		Geofence *geofence)
 {
-
-	if (violation_type.flags.fence_violation) {
+	if (violation_type.fence_violation) {
 		float current_distance = _test_point_distance * 0.5f;
 		float current_min = 0.0f;
 		float current_max = _test_point_distance;
@@ -181,7 +179,7 @@ GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_typ
 			return waypointFromBearingAndDistance(_current_pos_lat_lon, _test_point_bearing, _multirotor_braking_distance);
 		}
 
-	} else if (violation_type.flags.dist_to_home_exceeded) {
+	} else if (violation_type.dist_to_home_exceeded) {
 
 		return waypointFromHomeToTestPointAtDist(math::max(_max_hor_dist_home - _min_hor_dist_to_fence_mc, 0.0f));
 
@@ -195,9 +193,9 @@ GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_typ
 	}
 }
 
-float GeofenceBreachAvoidance::generateLoiterAltitudeForFixedWing(geofence_violation_type_u violation_type)
+float GeofenceBreachAvoidance::generateLoiterAltitudeForFixedWing(geofence_violation_type violation_type)
 {
-	if (violation_type.flags.max_altitude_exceeded) {
+	if (violation_type.max_altitude_exceeded) {
 		return _current_alt_amsl - 2.0f * _vertical_test_point_distance;
 
 	} else {
@@ -205,9 +203,9 @@ float GeofenceBreachAvoidance::generateLoiterAltitudeForFixedWing(geofence_viola
 	}
 }
 
-float GeofenceBreachAvoidance::generateLoiterAltitudeForMulticopter(geofence_violation_type_u violation_type)
+float GeofenceBreachAvoidance::generateLoiterAltitudeForMulticopter(geofence_violation_type violation_type)
 {
-	if (violation_type.flags.max_altitude_exceeded) {
+	if (violation_type.max_altitude_exceeded) {
 		return _current_alt_amsl + _multirotor_vertical_braking_distance - _min_vert_dist_to_fence_mc;
 
 	} else {

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
@@ -41,13 +41,11 @@ class Geofence;
 
 #define GEOFENCE_CHECK_INTERVAL_US 200000
 
-union geofence_violation_type_u {
-	struct {
-		bool dist_to_home_exceeded: 1;	///< 0 - distance to home exceeded
-		bool max_altitude_exceeded: 1;	///< 1 - maximum altitude exceeded
-		bool fence_violation: 1;	///< 2- violation of user defined fence
-	} flags;
-	uint8_t value;
+struct geofence_violation_type {
+	bool dist_to_home_exceeded{false};
+	bool max_altitude_exceeded{false};
+	bool fence_violation{false};
+	bool buffer_violation{false};
 };
 
 class GeofenceBreachAvoidance : public ModuleParams
@@ -63,17 +61,17 @@ public:
 			float test_point_bearing, float test_point_distance);
 
 	matrix::Vector2<double>
-	generateLoiterPointForFixedWing(geofence_violation_type_u violation_type, Geofence *geofence);
+	generateLoiterPointForFixedWing(geofence_violation_type violation_type, Geofence *geofence);
 
 	float computeBrakingDistanceMultirotor();
 
 	float computeVerticalBrakingDistanceMultirotor();
 
-	matrix::Vector2<double> generateLoiterPointForMultirotor(geofence_violation_type_u violation_type, Geofence *geofence);
+	matrix::Vector2<double> generateLoiterPointForMultirotor(geofence_violation_type violation_type, Geofence *geofence);
 
-	float generateLoiterAltitudeForFixedWing(geofence_violation_type_u violation_type);
+	float generateLoiterAltitudeForFixedWing(geofence_violation_type violation_type);
 
-	float generateLoiterAltitudeForMulticopter(geofence_violation_type_u violation_type);
+	float generateLoiterAltitudeForMulticopter(geofence_violation_type violation_type);
 
 	float getMinHorDistToFenceMulticopter() {return _min_hor_dist_to_fence_mc;}
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -312,7 +312,7 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 		return true;
 	}
 
-	// we got the lock, now check if the fence data got updated
+	// dm items locked, check if the fence data was updated
 	mission_stats_entry_s stats;
 	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
 
@@ -322,11 +322,11 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 
 	if (isEmpty()) {
 		dm_unlock(DM_KEY_FENCE_POINTS);
-		/* Empty fence -> accept all points */
+		// Empty fence -> accept all points
 		return true;
 	}
 
-	/* Vertical check */
+	// Vertical check
 	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
 		if (altitude > _altitude_max || altitude < _altitude_min) {
 			dm_unlock(DM_KEY_FENCE_POINTS);
@@ -335,7 +335,7 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 	}
 
 
-	/* Horizontal check: iterate all polygons & circles */
+	// Horizontal check: iterate all polygons & circles
 	bool outside_exclusion = true;
 	bool inside_inclusion = false;
 	bool had_inclusion_areas = false;
@@ -452,10 +452,137 @@ bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, 
 	return dx * dx + dy * dy < circle_point.circle_radius * circle_point.circle_radius;
 }
 
-bool
-Geofence::valid()
+bool Geofence::isInsideBufferZone(double lat, double lon, float altitude)
 {
-	return true; // always valid
+	if (getGeofenceBufferAction() == 0) {
+		return true;
+	}
+
+	// the following uses dm_read, so first we try to lock all items. If that fails, it (most likely) means
+	// the data is currently being updated (via a mavlink geofence transfer), and we do not check for a violation now
+	if (dm_trylock(DM_KEY_FENCE_POINTS) != 0) {
+		return false;
+	}
+
+	// dm items locked, check if the fence data was updated
+	mission_stats_entry_s stats;
+	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
+
+	if (ret == sizeof(mission_stats_entry_s) && _update_counter != stats.update_counter) {
+		_updateFence();
+	}
+
+	if (isEmpty()) {
+		dm_unlock(DM_KEY_FENCE_POINTS);
+		// Empty fence -> accept all points
+		return false;
+	}
+
+	float buffer_distance_m = _param_gf_buffer_dist.get();
+
+	// Vertical check
+	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
+		if ((altitude < _altitude_max && altitude >= _altitude_max - buffer_distance_m) ||
+		    (altitude > _altitude_min && altitude <= _altitude_min + buffer_distance_m)) {
+			dm_unlock(DM_KEY_FENCE_POINTS);
+
+			PX4_ERR("Altitude check returned error!");
+			return true;
+		}
+	}
+
+	// Horizontal check: iterate all polygons & circles
+	bool inside_circle_buffer_zone  = false;
+	bool inside_polygon_buffer_zone = false;
+
+	for (int polygon_index = 0; polygon_index < _num_polygons; ++polygon_index) {
+
+		if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_INCLUSION ||
+		    _polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_EXCLUSION) {
+			inside_circle_buffer_zone = insideCircleBufferZone(_polygons[polygon_index], lat, lon, altitude);
+
+		} else {
+			inside_polygon_buffer_zone = insidePolygonBufferZone(_polygons[polygon_index], lat, lon, altitude);
+		}
+	}
+
+	dm_unlock(DM_KEY_FENCE_POINTS);
+
+	return (inside_circle_buffer_zone || inside_polygon_buffer_zone);
+}
+
+bool Geofence::insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude)
+{
+	mission_fence_point_s temp_vertex_i{};
+	mission_fence_point_s temp_vertex_j{};
+	crosstrack_error_s crosstrack_error{};
+
+	for (unsigned i = 0, j = polygon.vertex_count - 1; i < polygon.vertex_count; j = i++) {
+		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + i, &temp_vertex_i,
+			    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+			break;
+		}
+
+		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + j, &temp_vertex_j,
+			    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+			break;
+		}
+
+		if (temp_vertex_i.frame != NAV_FRAME_GLOBAL && temp_vertex_i.frame != NAV_FRAME_GLOBAL_INT
+		    && temp_vertex_i.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT
+		    && temp_vertex_i.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+			// TODO: handle different frames
+			PX4_ERR("Frame type %i not supported", (int)temp_vertex_i.frame);
+			break;
+		}
+
+		get_distance_to_line(&crosstrack_error, lat, lon,
+				     temp_vertex_i.lat, temp_vertex_i.lon,
+				     temp_vertex_j.lat, temp_vertex_j.lon);
+
+		if (!crosstrack_error.past_end &&
+		    static_cast<float>(fabs(crosstrack_error.distance)) < _param_gf_buffer_dist.get()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool Geofence::insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude)
+{
+	mission_fence_point_s circle_point{};
+	crosstrack_error_s crosstrack_error{};
+
+	if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index, &circle_point,
+		    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+		PX4_ERR("dm_read failed");
+		return false;
+	}
+
+	if (circle_point.frame != NAV_FRAME_GLOBAL && circle_point.frame != NAV_FRAME_GLOBAL_INT
+	    && circle_point.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT
+	    && circle_point.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+		// TODO: handle different frames
+		PX4_ERR("Frame type %i not supported", (int)circle_point.frame);
+		return false;
+	}
+
+	if (!_projection_reference.isInitialized()) {
+		_projection_reference.initReference(lat, lon);
+	}
+
+	get_distance_to_arc(&crosstrack_error, lat, lon,
+			    circle_point.lat,
+			    circle_point.lon,
+			    circle_point.circle_radius, 0.f, 360.f);
+
+	if (static_cast<float>(fabs(crosstrack_error.distance)) <= _param_gf_buffer_dist.get()) {
+		PX4_INFO("Inside buffer zone! Crosstrack distance to fence: %f", (double)crosstrack_error.distance);
+		return true;
+	}
+
+	return false;
 }
 
 int
@@ -471,7 +598,7 @@ Geofence::loadFromFile(const char *filename)
 	/* Make sure no data is left in the datamanager */
 	clearDm();
 
-	/* open the mixer definition file */
+	/* open the geofence file */
 	fp = fopen(GEOFENCE_FILENAME, "r");
 
 	if (fp == nullptr) {

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -107,13 +107,18 @@ public:
 
 	bool isCloserThanMaxDistToHome(double lat, double lon, float altitude);
 
+
+	bool isCloserThanBufferDistance(double lat, double lon, float altitude);
+
 	bool isBelowMaxAltitude(float altitude);
 
 	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
 
+	virtual bool isInsideBufferZone(double lat, double lon, float altitude);
+
 	int clearDm();
 
-	bool valid();
+	bool valid() { return true; }	// always valid
 
 	/**
 	 * Load a single inclusion polygon, replacing any already existing polygons.
@@ -140,7 +145,7 @@ public:
 
 	int getSource() { return _param_gf_source.get(); }
 	int getGeofenceAction() { return _param_gf_action.get(); }
-
+	int getGeofenceBufferAction() { return _param_gf_buffer_action.get(); }
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
@@ -179,6 +184,7 @@ private:
 	uORB::SubscriptionData<vehicle_air_data_s> _sub_airdata;
 
 	int _outside_counter{0};
+
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, we polygon data was updated
 
 	/**
@@ -198,9 +204,8 @@ private:
 	 */
 	bool checkPolygons(double lat, double lon, float altitude);
 
-
-
 	bool checkAll(const vehicle_global_position_s &global_position);
+
 	bool checkAll(const vehicle_global_position_s &global_position, float baro_altitude_amsl);
 
 	/**
@@ -209,12 +214,16 @@ private:
 	 */
 	bool insidePolygon(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
+	bool insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
 	/**
 	 * Check if a single point is within a circle
 	 * @param polygon must be a circle!
 	 * @return true if within polygon the circle
 	 */
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
+	bool insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,
@@ -223,6 +232,8 @@ private:
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_gf_max_ver_dist,
-		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict
+		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict,
+		(ParamInt<px4::params::GF_BUFFER_ACTION>)  _param_gf_buffer_action,
+		(ParamFloat<px4::params::GF_BUFFER_DIST>)  _param_gf_buffer_dist
 	)
 };

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -138,3 +138,35 @@ PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_PREDICT, 1);
+
+/**
+ * Geofence buffer distance.
+ *
+ * Distance inside the Geofence to apply the GF_BUFFER_ACTION.
+ *
+ * @min 0.0
+ * @max 100.0
+ * @group Geofence
+ */
+PARAM_DEFINE_FLOAT(GF_BUFFER_DIST, 10.0f);
+
+/**
+ * Geofence buffer zone violation action.
+ *
+ * Note: Setting this value to 4 enables flight termination,
+ * which will kill the vehicle on violation of the fence.
+ * Due to the inherent danger of this, this function is
+ * disabled using a software circuit breaker, which needs
+ * to be reset to 0 to really shut down the system.
+ *
+ * @min 0
+ * @max 5
+ * @value 0 None
+ * @value 1 Warning
+ * @value 2 Hold mode
+ * @value 3 Return mode
+ * @value 4 Terminate
+ * @value 5 Land mode
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF_BUFFER_ACTION, 0);


### PR DESCRIPTION
Describe problem solved by this pull request
The geofence class has recently been improved with predictive behavior, however this alone does not allow an initial behavior such as hold or land to be followed later by a hard flight termination on a hard geofence breach. In the event of a poor position estimate and/or attitude estimate due to vibrations the drone might still be able to be held within the fence, but for areas that require a flight termination on geofence breach the current functionality only allows that single option.

Describe your solution
This PR creates a buffer zone, effectively an inner fence, with associated behavior and offset distance parameter that allow the drone to enter another mode prior to any flight termination commands if the fence is actually violated.

Describe possible alternatives
If there is a better manner to create a 2 geofence solution please let me know what a preferred architecture would be!

Test data / coverage
SITL tested using jmavsim.

Additional context
This PR leverages PR #17795 and functions best with that PR, but contents for that PR can be stripped out of this PR if for any reason #17795 is not able to be merged.
