### PR TITLE
Generate C/C++ header to expose px4board kconfig symbols

### DIFF
--- a/cmake/kconfig.cmake
+++ b/cmake/kconfig.cmake
@@ -11,6 +11,7 @@ set(MENUCONFIG_PATH ${PYTHON_EXECUTABLE} -m menuconfig CACHE INTERNAL "menuconfi
 set(GUICONFIG_PATH ${PYTHON_EXECUTABLE} -m guiconfig CACHE INTERNAL "guiconfig program" FORCE)
 set(DEFCONFIG_PATH ${PYTHON_EXECUTABLE} -m defconfig CACHE INTERNAL "defconfig program" FORCE)
 set(SAVEDEFCONFIG_PATH ${PYTHON_EXECUTABLE} -m savedefconfig CACHE INTERNAL "savedefconfig program" FORCE)
+set(GENCONFIG_PATH ${PYTHON_EXECUTABLE} -m genconfig CACHE INTERNAL "genconfig program" FORCE)
 
 set(COMMON_KCONFIG_ENV_SETTINGS
 	PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
@@ -47,6 +48,11 @@ if(EXISTS ${BOARD_DEFCONFIG})
                         OUTPUT_VARIABLE DUMMY_RESULTS)
     endif()
 
+    # Generate header file for C/C++ preprocessor
+    execute_process(COMMAND ${CMAKE_COMMAND} -E env ${COMMON_KCONFIG_ENV_SETTINGS}
+                    ${GENCONFIG_PATH} --header-path ${PX4_BINARY_DIR}/px4_boardconfig.h
+                    WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+                    OUTPUT_VARIABLE DUMMY_RESULTS)
 
     # parse board config options for cmake
     file(STRINGS ${BOARD_CONFIG} ConfigContents)

--- a/platforms/common/include/px4_platform_common/px4_config.h
+++ b/platforms/common/include/px4_platform_common/px4_config.h
@@ -52,3 +52,6 @@
 #include <board_config.h>
 
 #endif
+
+/* PX4 board kconfig symbols */
+#include <px4_boardconfig.h>


### PR DESCRIPTION
Generate C/C++ header to expose px4board kconfig symbols to the preprocessor.

This allows to use #ifdef to check whenever a module/systemcd/driver is enabled. 