### PR TITLE
ekf2: lower fake position observation variance when at rest

### DIFF
--- a/src/modules/ekf2/EKF/fake_pos_control.cpp
+++ b/src/modules/ekf2/EKF/fake_pos_control.cpp
@@ -108,7 +108,7 @@ void Ekf::fuseFakePosition()
 	} else if (!_control_status.flags.in_air && _control_status.flags.vehicle_at_rest) {
 		// Accelerate tilt fine alignment by fusing more
 		// aggressively when the vehicle is at rest
-		fake_pos_obs_var(0) = fake_pos_obs_var(1) = sq(0.1f);
+		fake_pos_obs_var(0) = fake_pos_obs_var(1) = sq(0.01f);
 
 	} else {
 		fake_pos_obs_var(0) = fake_pos_obs_var(1) = sq(0.5f);

--- a/src/modules/ekf2/test/test_EKF_externalVision.cpp
+++ b/src/modules/ekf2/test/test_EKF_externalVision.cpp
@@ -283,7 +283,7 @@ TEST_F(EkfExternalVisionTest, velocityFrameBody)
 	// THEN: As the drone is turned 90 degrees, velocity variance
 	//       along local y axis is expected to be bigger
 	const Vector3f velVar_new = _ekf->getVelocityVariance();
-	EXPECT_NEAR(velVar_new(1) / velVar_new(0), 80.f, 15.f);
+	EXPECT_NEAR(velVar_new(1) / velVar_new(0), 40.f, 15.f);
 
 	const Vector3f vel_earth_est = _ekf->getVelocity();
 	EXPECT_NEAR(vel_earth_est(0), 0.0f, 0.1f);
@@ -319,7 +319,7 @@ TEST_F(EkfExternalVisionTest, velocityFrameLocal)
 	// THEN: Independently on drones heading, velocity variance
 	//       along local x axis is expected to be bigger
 	const Vector3f velVar_new = _ekf->getVelocityVariance();
-	EXPECT_NEAR(velVar_new(0) / velVar_new(1), 80.f, 15.f);
+	EXPECT_NEAR(velVar_new(0) / velVar_new(1), 40.f, 15.f);
 
 	const Vector3f vel_earth_est = _ekf->getVelocity();
 	EXPECT_NEAR(vel_earth_est(0), 1.0f, 0.1f);
@@ -357,7 +357,7 @@ TEST_F(EkfExternalVisionTest, positionFrameLocal)
 	// WHEN: the measurement in EV FRD frame changes
 	pos_earth = Vector3f(0.3f, 0.0f, 0.0f);
 	_sensor_simulator._vio.setPosition(pos_earth);
-	_sensor_simulator.runSeconds(4);
+	_sensor_simulator.runSeconds(8);
 
 	// THEN: the position should converge to the EV position
 	// Note that the estimate is now in the EV frame because it is


### PR DESCRIPTION
Given how sensitive the vehicle at rest detection is (you can't even touch a board without triggering) can we further reduce the ekf2 fake position observation variance so that tilt align completes even faster?

With current master on px4_fmu-v5x EKF alignment takes about 6 seconds (time from boot). This change reduces it to about 3.5 seconds.