### PR TITLE
Update Flight-gear bridge, Add support of TF-G2 autogyro flight-gear model 

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# @name ThunderFly TF-G2
+# ThunderFly TF-G2 autogyro airframe. Only for FlightGear simulator
+#
+# @type Autogyro
+# @class Autogyro
+#
+# @url https://github.com/ThunderFly-aerospace/TF-G2/
+#
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+param set-default FW_AIRSPD_STALL 5
+
+param set-default FW_P_RMAX_NEG 20.0
+param set-default FW_W_RMAX 10
+param set-default FW_W_EN 1
+
+param set-default FW_RR_P 0.08
+
+param set-default MIS_LTRMIN_ALT 50
+param set-default MIS_TAKEOFF_ALT 7
+
+param set-default NAV_ACC_RAD 20
+param set-default NAV_DLL_ACT 2
+param set-default NAV_LOITER_RAD 50
+
+param set-default RWTO_TKOFF 0
+param set-default AG_TKOFF 1
+param set-default AG_PROT_TYPE 1
+param set-default AG_PROT_MIN_RPM 50.0
+param set-default AG_PROT_TRG_RPM 900.0
+param set-defoult AG_ROTOR_RPM 900.0
+
+param set-default FW_ARSP_SCALE_EN 0
+
+param set-default FW_AIRSPD_MAX 35
+param set-default FW_AIRSPD_MIN 7
+
+param set-default FW_P_LIM_MAX 25
+param set-default FW_P_LIM_MIN -5
+param set-default FW_R_LIM 30
+
+param set-default FW_MAN_P_MAX 30.0
+param set-default FW_MAN_R_MAX 30.0
+
+param set-default FW_THR_CRUISE 0.8
+param set-default FW_THR_IDLE 0
+param set-default COM_DISARM_PRFLT 0
+
+set MIXER_FILE etc/mixers-sitl/autogyro_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
@@ -28,11 +28,12 @@ param set-default NAV_DLL_ACT 2
 param set-default NAV_LOITER_RAD 50
 
 param set-default RWTO_TKOFF 0
-param set-default AG_TKOFF 1
-param set-default AG_PROT_TYPE 1
-param set-default AG_PROT_MIN_RPM 50.0
-param set-default AG_PROT_TRG_RPM 900.0
-param set-defoult AG_ROTOR_RPM 900.0
+# Parameters related to autogyro takeoff PR
+#param set-default AG_TKOFF 1
+#param set-default AG_PROT_TYPE 1
+#param set-default AG_PROT_MIN_RPM 50.0
+#param set-default AG_PROT_TRG_RPM 900.0
+#param set-defoult AG_ROTOR_RPM 900.0
 
 param set-default FW_ARSP_SCALE_EN 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -78,6 +78,7 @@ px4_add_romfs_files(
 	3010_quadrotor_x
 	3011_hexarotor_x
 	17001_tf-g1
+	17002_tf-g2
 	2507_cloudship
 	6011_typhoon_h480
 	6011_typhoon_h480.post

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -394,6 +394,7 @@ if(ENABLE_LOCKSTEP_SCHEDULER STREQUAL "no")
 		rascal
 		rascal-electric
 		tf-g1
+		tf-g2
 		tf-r1
 	)
 	set(all_posix_vmd_make_targets)

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -252,8 +252,8 @@ private:
 	uORB::Publication<vehicle_local_position_s>	_lpos_ground_truth_pub{ORB_ID(vehicle_local_position_groundtruth)};
 	uORB::Publication<input_rc_s>			_input_rc_pub{ORB_ID(input_rc)};
 
-    //rpm
-    uORB::Publication<rpm_s>			_rpm_pub{ORB_ID(rpm)};
+	//rpm
+	uORB::Publication<rpm_s>			_rpm_pub{ORB_ID(rpm)};
 
 	// HIL GPS
 	static constexpr int MAX_GPS = 3;

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -76,6 +76,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_command_ack.h>
+#include <uORB/topics/rpm.h>
 
 #include <random>
 
@@ -250,6 +251,9 @@ private:
 	uORB::Publication<vehicle_global_position_s>	_gpos_ground_truth_pub{ORB_ID(vehicle_global_position_groundtruth)};
 	uORB::Publication<vehicle_local_position_s>	_lpos_ground_truth_pub{ORB_ID(vehicle_local_position_groundtruth)};
 	uORB::Publication<input_rc_s>			_input_rc_pub{ORB_ID(input_rc)};
+
+    //rpm
+    uORB::Publication<rpm_s>			_rpm_pub{ORB_ID(rpm)};
 
 	// HIL GPS
 	static constexpr int MAX_GPS = 3;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -424,6 +424,17 @@ void Simulator::handle_message(const mavlink_message_t *msg)
 	case MAVLINK_MSG_ID_HIL_STATE_QUATERNION:
 		handle_message_hil_state_quaternion(msg);
 		break;
+
+   case MAVLINK_MSG_ID_RAW_RPM:
+	    mavlink_raw_rpm_t rpm;
+	    mavlink_msg_raw_rpm_decode(msg, &rpm);
+	    rpm_s rpmmsg{};
+	    rpmmsg.timestamp = hrt_absolute_time();
+        rpmmsg.indicated_frequency_rpm=rpm.frequency;
+        rpmmsg.estimated_accurancy_rpm=0;
+
+        _rpm_pub.publish(rpmmsg);
+        break;
 	}
 }
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -425,16 +425,16 @@ void Simulator::handle_message(const mavlink_message_t *msg)
 		handle_message_hil_state_quaternion(msg);
 		break;
 
-   case MAVLINK_MSG_ID_RAW_RPM:
-	    mavlink_raw_rpm_t rpm;
-	    mavlink_msg_raw_rpm_decode(msg, &rpm);
-	    rpm_s rpmmsg{};
-	    rpmmsg.timestamp = hrt_absolute_time();
-        rpmmsg.indicated_frequency_rpm=rpm.frequency;
-        rpmmsg.estimated_accurancy_rpm=0;
+	case MAVLINK_MSG_ID_RAW_RPM:
+		mavlink_raw_rpm_t rpm;
+		mavlink_msg_raw_rpm_decode(msg, &rpm);
+		rpm_s rpmmsg{};
+		rpmmsg.timestamp = hrt_absolute_time();
+		rpmmsg.indicated_frequency_rpm = rpm.frequency;
+		rpmmsg.estimated_accurancy_rpm = 0;
 
-        _rpm_pub.publish(rpmmsg);
-        break;
+		_rpm_pub.publish(rpmmsg);
+		break;
 	}
 }
 


### PR DESCRIPTION
Hello, 

After the devcal last week (26.1.2022), we agreed to prepare a functional Flight-gear simulator with the [TF-G2](https://github.com/ThunderFly-aerospace/TF-G2/) autogyro model, where an automatic takeoff (https://github.com/PX4/PX4-Autopilot/pull/18582) should work.

This PR contains several changes: 
* Update submodule of [flight-gear bridge](https://github.com/PX4/PX4-FlightGear-Bridge), that contains TF-G2 model
* Create TF-G2 SITL airframe, and target
* Added translation of RPM messages from FG to PX4 

Before accepting this PR, it would be good to accept https://github.com/PX4/PX4-FlightGear-Bridge/pull/6 and update it to the latest fg-bridge master version. 