### PR TITLE
Commander: VTOL quadchuate also triggers a RTL in Loiter and VTOL_Takeoff modes, not just in Mission

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -629,6 +629,10 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
+
+		} else if (status_flags.vtol_transition_failure) {
+			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+
 		} else if (status.data_link_lost && data_link_loss_act_configured && !landed && is_armed) {
 			// Data link lost, data link loss reaction configured -> do configured reaction
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, event_failsafe_reason_t::no_datalink);
@@ -739,6 +743,10 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
+
+		} else if (status_flags.vtol_transition_failure) {
+			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+
 		} else if (status.data_link_lost && data_link_loss_act_configured && !landed && is_armed) {
 			// Data link lost, data link loss reaction configured -> do configured reaction
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, event_failsafe_reason_t::no_datalink);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently Quadchutes are handled differently for Mission and non-mission flight modes. In Mission it RTLs, in the other Auto modes it goes to the currently active wp (e.g. center of loiter) and just waits there.

**Describe your solution**
It also triggers RTL in Loiter and VTOL_Takeoff modes.

**Describe possible alternatives**
Add option to customize action after quadchute.

**Test data / coverage**
SITL tested.


