### PR TITLE
Enable mpu9250 mag if other mags don’t start

### DIFF
--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -32,5 +32,5 @@ then
 	mpu6500 -s -R 0 start
 else
 	# mpu9250 internal SPI bus mpu9250
-	mpu9250 -s -R 8 start
+	mpu9250 -s -R 8 -M start
 fi


### PR DESCRIPTION
Hello!

We're producing and shipping a Pixracer compatible flight controller — [COEX Pix](https://clover.coex.tech/en/coex_pix.html). For now, we have shipped more then 2K of items. This flight controller has fewer sensors, in particular, it doesn't have the HMC5883 magnetometer.

The problem is that `fmu-v4` startup scripts doesn't start the MPU9250's magnetometer for some reason. I don't know if this intended. But in our case this results in that there no magnetometer working at all.

There might be several solutions for this, but here is a solution I came up with: if none of the separated internal magnetometers (HMC5883 or LIS3MDL) has started successfully, then use the MPU9250's magnetometer.