### PR TITLE
Protocol_splitter: Increment i properly in scan_for_packets

### DIFF
--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -548,7 +548,7 @@ void DevCommon::scan_for_packets()
 
 		perf_set_count(header_bytes_received_count, _read_buffer->header_bytes_received);
 
-		i += payload_len;
+		i += Sp2HeaderSize + payload_len;
 
 	}
 }


### PR DESCRIPTION

**Describe problem solved by this pull request**
This also guarantees that i is increased in every loop iteration.
Before it was possible to enter a busy loop.

**Describe your solution**
Properly increase the `i` counter.

