### PR TITLE
bmm150: minor changes to match reference driver

### DIFF
--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.hpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.hpp
@@ -128,7 +128,7 @@ private:
 	register_config_t _register_cfg[size_register_cfg] {
 		// Register                | Set bits, Clear bits
 		{ Register::POWER_CONTROL, POWER_CONTROL_BIT::PowerControl, POWER_CONTROL_BIT::SoftReset },
-		{ Register::OP_MODE,       OP_MODE_BIT::ODR_20Hz, OP_MODE_BIT::Opmode_Sleep | OP_MODE_BIT::Self_Test },
+		{ Register::OP_MODE,       OP_MODE_BIT::ODR_20HZ_SET, OP_MODE_BIT::ODR_20HZ_CLEAR | OP_MODE_BIT::Opmode_Sleep | OP_MODE_BIT::Self_Test },
 		{ Register::REPXY,         REPXY_BIT::XY_HA_SET, REPXY_BIT::XY_HA_CLEAR },
 		{ Register::REPZ,          REPZ_BIT::Z_HA_SET, REPZ_BIT::Z_HA_CLEAR },
 	};

--- a/src/drivers/magnetometer/bosch/bmm150/Bosch_BMM150_registers.hpp
+++ b/src/drivers/magnetometer/bosch/bmm150/Bosch_BMM150_registers.hpp
@@ -96,11 +96,12 @@ enum POWER_CONTROL_BIT : uint8_t {
 // OP_MODE
 enum OP_MODE_BIT : uint8_t {
 	// 5:3 Data rate control
-	ODR_20Hz     = Bit5 | Bit3, // ODR 20 Hz
+	ODR_20HZ_SET   = Bit5 | Bit3,
+	ODR_20HZ_CLEAR = Bit4,
 
 	// 2:1 Operation mode control
-	Opmode_Sleep = Bit2 | Bit1, // Sleep mode
-	Self_Test    = Bit0,
+	Opmode_Sleep   = Bit2 | Bit1, // Sleep mode
+	Self_Test      = Bit0,
 };
 
 // STATUS


### PR DESCRIPTION
I noticed some weird data output on a Bosch BMM150 mag so I did a paranoid review of the PX4 driver vs the Bosch reference code (https://github.com/BoschSensortec/BMM150-Sensor-API/).

The only differences I found were in the least significant bit of our XY data (shouldn't matter), and a few checks around RHALL usage and trim data values. I'm not sure if this accounts for the bogus data I saw, but it also shouldn't hurt.