### PR TITLE
sensors: skip selection and failover checks during parameter update

### DIFF
--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,7 @@ public:
 private:
 	void Run() override;
 
-	void ParametersUpdate();
+	bool ParametersUpdate();
 	void SensorCorrectionsUpdate(bool force = false);
 	void AirTemperatureUpdate();
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,7 +79,7 @@ void VehicleMagnetometer::Stop()
 	}
 }
 
-void VehicleMagnetometer::ParametersUpdate(bool force)
+bool VehicleMagnetometer::ParametersUpdate(bool force)
 {
 	// Check if parameters have changed
 	if (_parameter_update_sub.updated() || force) {
@@ -161,7 +161,11 @@ void VehicleMagnetometer::ParametersUpdate(bool force)
 			}
 
 		}
+
+		return true;
 	}
+
+	return false;
 }
 
 void VehicleMagnetometer::UpdateMagBiasEstimate()
@@ -360,7 +364,7 @@ void VehicleMagnetometer::Run()
 
 	const hrt_abstime time_now_us = hrt_absolute_time();
 
-	ParametersUpdate();
+	const bool parameter_update = ParametersUpdate();
 
 	// check vehicle status for changes to armed state
 	if (_vehicle_control_mode_sub.updated()) {
@@ -450,7 +454,8 @@ void VehicleMagnetometer::Run()
 	_voter.get_best(time_now_us, &best_index);
 
 	if (best_index >= 0) {
-		if (_selected_sensor_sub_index != best_index) {
+		// handle selection change (don't process on same iteration as parameter update)
+		if ((_selected_sensor_sub_index != best_index) && !parameter_update) {
 			// clear all registered callbacks
 			for (auto &sub : _sensor_sub) {
 				sub.unregisterCallback();
@@ -488,9 +493,9 @@ void VehicleMagnetometer::Run()
 	}
 
 
-	// check failover and report
 	if (_param_sens_mag_mode.get()) {
-		if (_last_failover_count != _voter.failover_count()) {
+		// check failover and report (save failover report for a cycle where parameters didn't update)
+		if (_last_failover_count != _voter.failover_count() && !parameter_update) {
 			uint32_t flags = _voter.failover_state();
 			int failover_index = _voter.failover_index();
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,7 +79,7 @@ public:
 private:
 	void Run() override;
 
-	void ParametersUpdate(bool force = false);
+	bool ParametersUpdate(bool force = false);
 
 	void Publish(uint8_t instance, bool multi = false);
 

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -181,6 +181,8 @@ private:
 	uint64_t _last_accel_timestamp[MAX_SENSOR_COUNT] {};	/**< latest full timestamp */
 
 	sensor_selection_s _selection {};		/**< struct containing the sensor selection to be published to the uORB */
+
+	bool _parameter_update{false};
 
 	DEFINE_PARAMETERS(
 		(ParamBool<px4::params::SENS_IMU_MODE>) _param_sens_imu_mode


### PR DESCRIPTION
Parameter changes can be relatively expensive to the point where they can trigger false positives in sensor timeouts on older boards. In the `sensors` module during a cycle where the parameters update we can temporarily bypass the voting re-selection to avoid false positives. These modules throttle parameter updates (1 Hz), so worst case the detection of a perfectly timed legitimate failure would only be delayed until the next iteration (eg 5 ms later for an IMU).