### PR TITLE
Ekf terrain estimator refactoring

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -45,6 +45,7 @@ uint8 CS_EV_VEL = 24		# 24 - true when local frame velocity data fusion from ext
 uint8 CS_SYNTHETIC_MAG_Z = 25	# 25 - true when we are using a synthesized measurement for the magnetometer Z component
 uint8 CS_VEHICLE_AT_REST = 26	# 26 - true when the vehicle is at rest
 uint8 CS_GPS_YAW_FAULT = 27	# 27 - true when the GNSS heading has been declared faulty and is no longer being used
+uint8 CS_RNG_FAULT = 28		# 28 - true when the range finder has been declared faulty and is no longer being used
 
 uint32 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/msg/estimator_status_flags.msg
+++ b/msg/estimator_status_flags.msg
@@ -32,6 +32,7 @@ bool cs_ev_vel                # 24 - true when local frame velocity data fusion 
 bool cs_synthetic_mag_z       # 25 - true when we are using a synthesized measurement for the magnetometer Z component
 bool cs_vehicle_at_rest       # 26 - true when the vehicle is at rest
 bool cs_gps_yaw_fault         # 27 - true when the GNSS heading has been declared faulty and is no longer being used
+bool cs_rng_fault             # 28 - true when the range finder has been declared faulty and is no longer being used
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -490,6 +490,7 @@ union filter_control_status_u {
 		uint32_t synthetic_mag_z : 1; ///< 25 - true when we are using a synthesized measurement for the magnetometer Z component
 		uint32_t vehicle_at_rest : 1; ///< 26 - true when the vehicle is at rest
 		uint32_t gps_yaw_fault : 1; ///< 27 - true when the GNSS heading has been declared faulty and is no longer being used
+		uint32_t rng_fault : 1; ///< 28 - true when the range finder has been declared faulty and is no longer being used
 	} flags;
 	uint32_t value;
 };

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -209,8 +209,8 @@ bool Ekf::initialiseFilter()
 		increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 	}
 
-	// try to initialise the terrain estimator
-	_terrain_initialised = initHagl();
+	// Initialise the terrain estimator
+	initHagl();
 
 	// reset the essential fusion timeout counters
 	_time_last_hgt_fuse = _time_last_imu;

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -680,8 +680,6 @@ private:
 	// initialise the terrain vertical position estimator
 	void initHagl();
 
-	bool shouldUseOpticalFlowForHagl() const { return (_params.terrain_fusion_mode & TerrainFusionMask::TerrainFuseOpticalFlow); }
-
 	void runTerrainEstimator();
 	void predictHagl();
 
@@ -695,8 +693,11 @@ private:
 	float getRngVar();
 
 	// update the terrain vertical position estimate using an optical flow measurement
-	void fuseFlowForTerrain();
+	void controlHaglFlowFusion();
+	void startHaglFlowFusion();
 	void resetHaglFlow();
+	void stopHaglFlowFusion();
+	void fuseFlowForTerrain();
 
 	void controlHaglFakeFusion();
 	void resetHaglFake();

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -386,6 +386,7 @@ private:
 	uint64_t _time_last_fake_pos_fuse{0};	///< last time we faked position measurements to constrain tilt errors during operation without external aiding (uSec)
 	uint64_t _time_last_gps_yaw_fuse{0};	///< time the last fusion of GPS yaw measurements were performed (uSec)
 	uint64_t _time_last_gps_yaw_data{0};	///< time the last GPS yaw measurement was available (uSec)
+	uint64_t _time_last_healthy_rng_data{0};
 	uint8_t _nb_gps_yaw_reset_available{0}; ///< remaining number of resets allowed before switching to another aiding source
 
 	Vector2f _last_known_posNE{};		///< last known local NE position vector (m)
@@ -535,8 +536,6 @@ private:
 	float _terrain_var{1e4f};		///< variance of terrain position estimate (m**2)
 	uint8_t _terrain_vpos_reset_counter{0};	///< number of times _terrain_vpos has been reset
 	uint64_t _time_last_hagl_fuse{0};		///< last system time that a range sample was fused by the terrain estimator
-	uint64_t _time_last_fake_hagl_fuse{0};	///< last system time that a fake range sample was fused by the terrain estimator
-	bool _terrain_initialised{false};	///< true when the terrain estimator has been initialized
 	bool _hagl_valid{false};		///< true when the height above ground estimate is valid
 	terrain_fusion_status_u _hagl_sensor_status{}; ///< Struct indicating type of sensor used to estimate height above ground
 
@@ -679,20 +678,28 @@ private:
 	bool calcOptFlowBodyRateComp();
 
 	// initialise the terrain vertical position estimator
-	// return true if the initialisation is successful
-	bool initHagl();
+	void initHagl();
 
-	bool shouldUseRangeFinderForHagl() const { return (_params.terrain_fusion_mode & TerrainFusionMask::TerrainFuseRangeFinder); }
 	bool shouldUseOpticalFlowForHagl() const { return (_params.terrain_fusion_mode & TerrainFusionMask::TerrainFuseOpticalFlow); }
 
-	// run the terrain estimator
 	void runTerrainEstimator();
+	void predictHagl();
 
 	// update the terrain vertical position estimate using a height above ground measurement from the range finder
-	void fuseHagl();
+	void controlHaglRngFusion();
+	void fuseHaglRng();
+	void startHaglRngFusion();
+	void resetHaglRngIfNeeded();
+	void resetHaglRng();
+	void stopHaglRngFusion();
+	float getRngVar();
 
 	// update the terrain vertical position estimate using an optical flow measurement
 	void fuseFlowForTerrain();
+	void resetHaglFlow();
+
+	void controlHaglFakeFusion();
+	void resetHaglFake();
 
 	// reset the heading and magnetic field states using the declination and magnetometer measurements
 	// return true if successful

--- a/src/modules/ekf2/EKF/sensor_range_finder.cpp
+++ b/src/modules/ekf2/EKF/sensor_range_finder.cpp
@@ -62,7 +62,7 @@ void SensorRangeFinder::updateValidity(uint64_t current_time_us)
 {
 	updateDtDataLpf(current_time_us);
 
-	if (isSampleOutOfDate(current_time_us) || !isDataContinuous()) {
+	if (_is_faulty || isSampleOutOfDate(current_time_us) || !isDataContinuous()) {
 		_is_sample_valid = false;
 		_is_regularly_sending_data = false;
 		return;

--- a/src/modules/ekf2/EKF/sensor_range_finder.hpp
+++ b/src/modules/ekf2/EKF/sensor_range_finder.hpp
@@ -106,6 +106,8 @@ public:
 	float getValidMinVal() const { return _rng_valid_min_val; }
 	float getValidMaxVal() const { return _rng_valid_max_val; }
 
+	void setFaulty() { _is_faulty = true; }
+
 private:
 	void updateSensorToEarthRotation(const matrix::Dcmf &R_to_earth);
 
@@ -123,6 +125,7 @@ private:
 	bool _is_sample_valid{};	///< true if range finder sample retrieved from buffer is valid
 	bool _is_regularly_sending_data{false}; ///< true if the interval between two samples is less than the maximum expected interval
 	uint64_t _time_last_valid_us{};	///< time the last range finder measurement was ready (uSec)
+	bool _is_faulty{false};         ///< the sensor should not be used anymore
 
 	/*
 	 * Stuck check

--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -53,6 +53,7 @@ void Ekf::runTerrainEstimator()
 	// If we are on ground, store the local position and time to use as a reference
 	if (!_control_status.flags.in_air) {
 		_last_on_ground_posD = _state.pos(2);
+		_control_status.flags.rng_fault = false;
 	}
 
 	predictHagl();

--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -43,44 +43,9 @@
 
 #include <mathlib/mathlib.h>
 
-bool Ekf::initHagl()
+void Ekf::initHagl()
 {
-	bool initialized = false;
-
-	if (!_control_status.flags.in_air) {
-		// if on ground, do not trust the range sensor, but assume a ground clearance
-		_terrain_vpos = _state.pos(2) + _params.rng_gnd_clearance;
-		// use the ground clearance value as our uncertainty
-		_terrain_var = sq(_params.rng_gnd_clearance);
-		_time_last_fake_hagl_fuse = _time_last_imu;
-		initialized = true;
-
-	} else if (shouldUseRangeFinderForHagl()
-		   && _range_sensor.isDataHealthy()) {
-		// if we have a fresh measurement, use it to initialise the terrain estimator
-		_terrain_vpos = _state.pos(2) + _range_sensor.getDistBottom();
-		// initialise state variance to variance of measurement
-		_terrain_var = sq(_params.range_noise);
-		// success
-		initialized = true;
-
-	} else if (shouldUseOpticalFlowForHagl()
-		   && _flow_for_terrain_data_ready) {
-		// initialise terrain vertical position to origin as this is the best guess we have
-		_terrain_vpos = fmaxf(0.0f,  _state.pos(2));
-		_terrain_var = 100.0f;
-		initialized = true;
-
-	} else {
-		// no information - cannot initialise
-	}
-
-	if (initialized) {
-		// has initialized with valid data
-		_time_last_hagl_fuse = _time_last_imu;
-	}
-
-	return initialized;
+	resetHaglFake();
 }
 
 void Ekf::runTerrainEstimator()
@@ -90,47 +55,154 @@ void Ekf::runTerrainEstimator()
 		_last_on_ground_posD = _state.pos(2);
 	}
 
-	// Perform initialisation check and
-	// on ground, continuously reset the terrain estimator
-	if (!_terrain_initialised || !_control_status.flags.in_air) {
-		_terrain_initialised = initHagl();
+	predictHagl();
 
-	} else {
+	// Fuse range finder data if available
+	controlHaglRngFusion();
 
-		// predict the state variance growth where the state is the vertical position of the terrain underneath the vehicle
+	if (shouldUseOpticalFlowForHagl()
+	    && _flow_for_terrain_data_ready) {
+		fuseFlowForTerrain();
+		_flow_for_terrain_data_ready = false;
+	}
 
-		// process noise due to errors in vehicle height estimate
-		_terrain_var += sq(_imu_sample_delayed.delta_vel_dt * _params.terrain_p_noise);
+	controlHaglFakeFusion();
 
-		// process noise due to terrain gradient
-		_terrain_var += sq(_imu_sample_delayed.delta_vel_dt * _params.terrain_gradient)
-				* (sq(_state.vel(0)) + sq(_state.vel(1)));
-
-		// limit the variance to prevent it becoming badly conditioned
-		_terrain_var = math::constrain(_terrain_var, 0.0f, 1e4f);
-
-		// Fuse range finder data if available
-		if (shouldUseRangeFinderForHagl()
-		    && _range_sensor.isDataHealthy()) {
-			fuseHagl();
-		}
-
-		if (shouldUseOpticalFlowForHagl()
-		    && _flow_for_terrain_data_ready) {
-			fuseFlowForTerrain();
-			_flow_for_terrain_data_ready = false;
-		}
-
-		// constrain _terrain_vpos to be a minimum of _params.rng_gnd_clearance larger than _state.pos(2)
-		if (_terrain_vpos - _state.pos(2) < _params.rng_gnd_clearance) {
-			_terrain_vpos = _params.rng_gnd_clearance + _state.pos(2);
-		}
+	// constrain _terrain_vpos to be a minimum of _params.rng_gnd_clearance larger than _state.pos(2)
+	if (_terrain_vpos - _state.pos(2) < _params.rng_gnd_clearance) {
+		_terrain_vpos = _params.rng_gnd_clearance + _state.pos(2);
 	}
 
 	updateTerrainValidity();
 }
 
-void Ekf::fuseHagl()
+void Ekf::predictHagl()
+{
+	// predict the state variance growth where the state is the vertical position of the terrain underneath the vehicle
+
+	// process noise due to errors in vehicle height estimate
+	_terrain_var += sq(_imu_sample_delayed.delta_vel_dt * _params.terrain_p_noise);
+
+	// process noise due to terrain gradient
+	_terrain_var += sq(_imu_sample_delayed.delta_vel_dt * _params.terrain_gradient)
+			* (sq(_state.vel(0)) + sq(_state.vel(1)));
+
+	// limit the variance to prevent it becoming badly conditioned
+	_terrain_var = math::constrain(_terrain_var, 0.0f, 1e4f);
+}
+
+void Ekf::controlHaglRngFusion()
+{
+	if (!(_params.terrain_fusion_mode & TerrainFusionMask::TerrainFuseRangeFinder)
+	    || _control_status.flags.rng_fault) {
+
+		stopHaglRngFusion();
+		return;
+	}
+
+	if (_range_sensor.isDataHealthy()) {
+		const bool continuing_conditions_passing = _control_status.flags.in_air;
+		//const bool continuing_conditions_passing = _control_status.flags.in_air && !_control_status.flags.rng_hgt; // TODO: should not be fused when using range height
+		const bool starting_conditions_passing = continuing_conditions_passing && _range_sensor.isRegularlySendingData();
+
+		_time_last_healthy_rng_data = _time_last_imu;
+
+		if (_hagl_sensor_status.flags.range_finder) {
+			if (continuing_conditions_passing) {
+				fuseHaglRng();
+
+				// We have been rejecting range data for too long
+				const uint64_t timeout = static_cast<uint64_t>(_params.terrain_timeout * 1e6f);
+				const bool is_fusion_failing = isTimedOut(_time_last_hagl_fuse, timeout);
+
+				if (is_fusion_failing) {
+					if (_range_sensor.getDistBottom() > 2.f * _params.rng_gnd_clearance) {
+						// Data seems good, attempt a reset
+						resetHaglRng();
+
+					} else if (starting_conditions_passing) {
+						// The sensor can probably not detect the ground properly
+						// declare the sensor faulty and stop the fusion
+						_control_status.flags.rng_fault = true;
+						_range_sensor.setFaulty();
+						stopHaglRngFusion();
+
+					} else {
+						// This could be a temporary issue, stop the fusion without declaring the sensor faulty
+						stopHaglRngFusion();
+					}
+				}
+
+			} else {
+				stopHaglRngFusion();
+			}
+
+		} else {
+			if (starting_conditions_passing) {
+				startHaglRngFusion();
+			}
+		}
+
+	} else if (_hagl_sensor_status.flags.range_finder && isTimedOut(_time_last_healthy_rng_data, _params.reset_timeout_max)) {
+		// No data anymore. Stop until it comes back.
+		stopHaglRngFusion();
+	}
+}
+
+void Ekf::startHaglRngFusion()
+{
+	_hagl_sensor_status.flags.range_finder = true;
+	resetHaglRngIfNeeded();
+}
+
+void Ekf::resetHaglRngIfNeeded()
+{
+	if (_hagl_sensor_status.flags.flow) {
+		const float meas_hagl = _range_sensor.getDistBottom();
+		const float pred_hagl = _terrain_vpos - _state.pos(2);
+		const float hagl_innov = pred_hagl - meas_hagl;
+		const float obs_variance = getRngVar();
+
+		const float hagl_innov_var = fmaxf(_terrain_var + obs_variance, obs_variance);
+
+		const float gate_size = fmaxf(_params.range_innov_gate, 1.0f);
+		const float hagl_test_ratio = sq(hagl_innov) / (sq(gate_size) * hagl_innov_var);
+
+		// Reset the state to the measurement only if the test ratio is large,
+		// otherwise let it converge through the fusion
+		if (hagl_test_ratio > 0.2f) {
+			resetHaglRng();
+
+		} else {
+			fuseHaglRng();
+		}
+
+	} else {
+		resetHaglRng();
+	}
+}
+
+float Ekf::getRngVar()
+{
+	return fmaxf(P(9, 9) * _params.vehicle_variance_scaler, 0.0f)
+	       + sq(_params.range_noise)
+	       + sq(_params.range_noise_scaler * _range_sensor.getRange());
+}
+
+void Ekf::resetHaglRng()
+{
+	_terrain_vpos = _state.pos(2) + _range_sensor.getDistBottom();
+	_terrain_var = getRngVar();
+	_terrain_vpos_reset_counter++;
+	_time_last_hagl_fuse = _time_last_imu;
+}
+
+void Ekf::stopHaglRngFusion()
+{
+	_hagl_sensor_status.flags.range_finder = false;
+}
+
+void Ekf::fuseHaglRng()
 {
 	// get a height above ground measurement from the range finder assuming a flat earth
 	const float meas_hagl = _range_sensor.getDistBottom();
@@ -142,9 +214,7 @@ void Ekf::fuseHagl()
 	_hagl_innov = pred_hagl - meas_hagl;
 
 	// calculate the observation variance adding the variance of the vehicles own height uncertainty
-	const float obs_variance = fmaxf(P(9, 9) * _params.vehicle_variance_scaler, 0.0f)
-				   + sq(_params.range_noise)
-				   + sq(_params.range_noise_scaler * _range_sensor.getRange());
+	const float obs_variance = getRngVar();
 
 	// calculate the innovation variance - limiting it to prevent a badly conditioned fusion
 	_hagl_innov_var = fmaxf(_terrain_var + obs_variance, obs_variance);
@@ -165,18 +235,15 @@ void Ekf::fuseHagl()
 		_innov_check_fail_status.flags.reject_hagl = false;
 
 	} else {
-		// If we have been rejecting range data for too long, reset to measurement
-		const uint64_t timeout = static_cast<uint64_t>(_params.terrain_timeout * 1e6f);
-
-		if (isTimedOut(_time_last_hagl_fuse, timeout)) {
-			_terrain_vpos = _state.pos(2) + meas_hagl;
-			_terrain_var = obs_variance;
-			_terrain_vpos_reset_counter++;
-
-		} else {
-			_innov_check_fail_status.flags.reject_hagl = true;
-		}
+		_innov_check_fail_status.flags.reject_hagl = true;
 	}
+}
+
+void Ekf::resetHaglFlow()
+{
+	_terrain_vpos = fmaxf(0.0f,  _state.pos(2));
+	_terrain_var = 100.0f;
+	_terrain_vpos_reset_counter++;
 }
 
 void Ekf::fuseFlowForTerrain()
@@ -279,6 +346,24 @@ void Ekf::fuseFlowForTerrain()
 	}
 }
 
+void Ekf::controlHaglFakeFusion()
+{
+	if (!_control_status.flags.in_air
+	    && !_hagl_sensor_status.flags.range_finder
+	    && !_hagl_sensor_status.flags.flow) {
+		resetHaglFake();
+	}
+}
+
+void Ekf::resetHaglFake()
+{
+	// assume a ground clearance
+	_terrain_vpos = _state.pos(2) + _params.rng_gnd_clearance;
+	// use the ground clearance value as our uncertainty
+	_terrain_var = sq(_params.rng_gnd_clearance);
+	_time_last_hagl_fuse = _time_last_imu;
+}
+
 void Ekf::updateTerrainValidity()
 {
 	// we have been fusing range finder measurements in the last 5 seconds
@@ -288,10 +373,7 @@ void Ekf::updateTerrainValidity()
 	// this can only be the case if the main filter does not fuse optical flow
 	const bool recent_flow_for_terrain_fusion = isRecent(_time_last_flow_terrain_fuse, (uint64_t)5e6);
 
-	_hagl_valid = (_terrain_initialised && (recent_range_fusion || recent_flow_for_terrain_fusion));
-
-	_hagl_sensor_status.flags.range_finder = shouldUseRangeFinderForHagl()
-			&& recent_range_fusion && (_time_last_fake_hagl_fuse != _time_last_hagl_fuse);
+	_hagl_valid = (recent_range_fusion || recent_flow_for_terrain_fusion);
 
 	_hagl_sensor_status.flags.flow = shouldUseOpticalFlowForHagl() && recent_flow_for_terrain_fusion;
 }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1262,6 +1262,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_synthetic_mag_z       = _ekf.control_status_flags().synthetic_mag_z;
 		status_flags.cs_vehicle_at_rest       = _ekf.control_status_flags().vehicle_at_rest;
 		status_flags.cs_gps_yaw_fault         = _ekf.control_status_flags().gps_yaw_fault;
+		status_flags.cs_rng_fault             = _ekf.control_status_flags().rng_fault;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;

--- a/src/modules/ekf2/test/test_EKF_terrain_estimator.cpp
+++ b/src/modules/ekf2/test/test_EKF_terrain_estimator.cpp
@@ -107,25 +107,20 @@ public:
 TEST_F(EkfTerrainTest, setFlowAndRangeTerrainFusion)
 {
 	// WHEN: simulate being 5m above ground
-	// By default, both rng and flow aiding are active
 	const float simulated_distance_to_ground = 1.f;
-	_sensor_simulator._rng.setData(simulated_distance_to_ground, 100);
-	_sensor_simulator._rng.setLimits(0.1f, 9.f);
-	_sensor_simulator.startRangeFinder();
-	_ekf->set_in_air_status(true);
-	_sensor_simulator.runSeconds(1.5f);
+	runFlowAndRngScenario(simulated_distance_to_ground, simulated_distance_to_ground);
 
 	// THEN: By default, both rng and flow aiding are active
 	EXPECT_TRUE(_ekf_wrapper.isIntendingTerrainRngFusion());
-	EXPECT_TRUE(_ekf_wrapper.isIntendingTerrainFlowFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingTerrainFlowFusion());
 	const float estimated_distance_to_ground = _ekf->getTerrainVertPos();
-	EXPECT_FLOAT_EQ(estimated_distance_to_ground, simulated_distance_to_ground);
+	EXPECT_NEAR(estimated_distance_to_ground, simulated_distance_to_ground, 1e-4);
 
 	// WHEN: rng fusion is disabled
 	_ekf_wrapper.disableTerrainRngFusion();
-	_sensor_simulator.runSeconds(0.2);
+	_sensor_simulator.runSeconds(5.);
 
-	// THEN: only rng fusion should be disabled
+	// THEN: rng fusion should be disabled and flow fusion should take over
 	EXPECT_FALSE(_ekf_wrapper.isIntendingTerrainRngFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingTerrainFlowFusion());
 


### PR DESCRIPTION
Mostly a pure refactoring.

- The terrain estimator checks if the aiding source (range and flow) can be used instead of having `control.cpp` doing it at various places
- Range terrain aiding has priority over flow terrain
- Flow terrain cannot start when flow is fused into the main EKF for velocity aiding

Added a range finder failure detection when the measurement has been rejected for some time and that the measured distance is smalle (< 2x the minimum distance from sensor to terrain). This is mostly to detect when the range finder is looking at some payload under the drone instead of the terrain.

- Thing to fix later: when using range aid, the range sensor is also used in the terrain estimator because fusing optical flow into the main EKF requires a valid terrain estimate...