### PR TITLE
VTOL backtransition tracking improvements

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1093,9 +1093,9 @@ FixedwingPositionControl::handle_setpoint_type(const uint8_t setpoint_type, cons
 		}
 	}
 
-	// set to type loiter during VTOL transitions in Land mode (to not start FW landing logic)
+	// set to type position during VTOL transitions in Land mode (to not start FW landing logic)
 	if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_LAND && _vehicle_status.in_transition_mode) {
-		position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+		position_sp_type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 	}
 
 	return position_sp_type;

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -74,8 +74,12 @@ Land::on_active()
 	if (_navigator->get_vstatus()->is_vtol &&
 	    _navigator->get_vstatus()->in_transition_mode) {
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-		pos_sp_triplet->current.lat = _navigator->get_global_position()->lat;
-		pos_sp_triplet->current.lon = _navigator->get_global_position()->lon;
+
+		// create a virtual wp 1m in front of the vehicle to track during the backtransition
+		waypoint_from_heading_and_distance(_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
+						   _navigator->get_position_setpoint_triplet()->current.yaw, 1.f,
+						   &pos_sp_triplet->current.lat, &pos_sp_triplet->current.lon);
+
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -795,7 +795,7 @@ MissionBlock::set_vtol_transition_item(struct mission_item_s *item, const uint8_
 	item->nav_cmd = NAV_CMD_DO_VTOL_TRANSITION;
 	item->params[0] = (float) new_mode;
 	item->params[1] = 0.0f;
-	item->yaw = _navigator->get_local_position()->heading;
+	item->yaw = _navigator->get_local_position()->heading; // ideally that would be course and not heading
 	item->autocontinue = true;
 }
 


### PR DESCRIPTION
**Describe problem solved by this pull request and how I solved it**
Two partly related things:
- when triggering LAND, the VTOL started the transition immediately and was then tracking a point slightly behind the vehicle, causing it to turn during the backtransition (instead of flying straight). Instead it should be tracking a point slightly in front of the vehicle (I set it to 1m for now)
- the position setpoint during transition was set to Loiter, and that caused it to display the Orbit status circle. Setting it to Position type looks more correct to me.

current:
https://user-images.githubusercontent.com/26798987/153183183-3cb4c589-cfc7-4be2-b42e-92a020d9e741.mp4

with the fixes:
https://user-images.githubusercontent.com/26798987/153183417-93c42a56-092e-4e32-a446-73e86413dc4b.mp4






**Describe possible alternatives**
Longer term I'd like to move some logic that's currently all over that place in Navigator to the Land mode, then this one can be more sophisticated and e.g. only set the position setpoint type to Land only once the transition is over.

**Test data / coverage**
SITL tested


