### PR TITLE
drivers/rc_input: always provide RC_PORT_CONFIG parameter

### DIFF
--- a/Tools/serial/generate_config.py
+++ b/Tools/serial/generate_config.py
@@ -268,10 +268,14 @@ for serial_command in serial_commands:
                 default_port_str = port_config['default'][i]
             else:
                 default_port_str = port_config['default']
+
             if default_port_str != "":
                 if default_port_str not in serial_ports:
                     raise Exception("Default Port {:} not found for {:}".format(default_port_str, serial_command['label']))
-                default_port = serial_ports[default_port_str]['index']
+
+                if default_port_str in dict(board_ports).keys():
+                    default_port = serial_ports[default_port_str]['index']
+
 
         commands.append({
             'command': serial_command['command'],

--- a/src/drivers/rc_input/module.yaml
+++ b/src/drivers/rc_input/module.yaml
@@ -5,7 +5,6 @@ serial_config:
         name: RC_PORT_CONFIG
         group: Serial
         default: RC
-        depends_on_port: RC
         description_extended: |
             Setting this to 'Disabled' will use a board-specific default port
             for RC input.


### PR DESCRIPTION
The goal is to allow users to manually configure RC on any serial port if desired. On boards with the px4io present starting the `rc_input` driver will be skipped. The deconfliction isn't perfect (eg fully respecting SYS_USE_IO 0), but I think it's good enough for users with something like a Holybro v5x that want to use Crossfire directly on a different serial port.

 - RC_PORT_CONFIG is disabled by default if the board doesn't have CONFIG_BOARD_SERIAL_RC set
 - allows user facing custom RC configuration that overrides board defaults

@bkueng I'm not sure if I've captured things properly in this change, happy to discuss. 