### PR TITLE
RTL FW/VTOL doesn't accept climb for RTL altitude

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -373,6 +373,7 @@ void RTL::set_rtl_item()
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
+			_mission_item.loiter_radius = _navigator->get_loiter_radius();
 
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above destination)\t",
 					 (int)ceilf(_rtl_alt), (int)ceilf(_rtl_alt - _destination.alt));


### PR DESCRIPTION
Vehicle would never accept climb for RTL altitude, and just keep loitering for ever, because the _mission_item.loiter_radius field was not set (thus at 0m).
