### PR TITLE
CA: refactor logic for matrix updating

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
@@ -57,6 +57,12 @@ enum class ActuatorType {
 	COUNT
 };
 
+enum class EffectivenessUpdateReason {
+	NO_EXTERNAL_UPDATE = 0,
+	CONFIGURATION_UPDATE = 1,
+	MOTOR_ACTIVATION_UPDATE = 2,
+};
+
 
 class ActuatorEffectiveness
 {
@@ -147,7 +153,7 @@ public:
 	 *
 	 * @return true if updated and matrix is set
 	 */
-	virtual bool getEffectivenessMatrix(Configuration &configuration, bool force) = 0;
+	virtual bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) { return false;}
 
 	/**
 	 * Get the current flight phase

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.cpp
@@ -124,12 +124,8 @@ void ActuatorEffectivenessControlSurfaces::updateParams()
 	}
 }
 
-bool ActuatorEffectivenessControlSurfaces::getEffectivenessMatrix(Configuration &configuration, bool force)
+bool ActuatorEffectivenessControlSurfaces::addActuators(Configuration &configuration)
 {
-	if (!force) {
-		return false;
-	}
-
 	for (int i = 0; i < _count; i++) {
 		int actuator_idx = configuration.addActuator(ActuatorType::SERVOS, _params[i].torque, Vector3f{});
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessControlSurfaces.hpp
@@ -69,7 +69,7 @@ public:
 	ActuatorEffectivenessControlSurfaces(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessControlSurfaces() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool addActuators(Configuration &configuration);
 
 	const char *name() const override { return "Control Surfaces"; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessCustom.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessCustom.hpp
@@ -43,7 +43,7 @@ public:
 	ActuatorEffectivenessCustom(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessCustom() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	const char *name() const override { return "Custom"; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessFixedWing.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessFixedWing.cpp
@@ -43,21 +43,22 @@ ActuatorEffectivenessFixedWing::ActuatorEffectivenessFixedWing(ModuleParams *par
 }
 
 bool
-ActuatorEffectivenessFixedWing::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessFixedWing::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!force) {
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 
 	// Motors
 	_rotors.enableYawControl(false);
-	_rotors.getEffectivenessMatrix(configuration, true);
+	const bool rotors_added_successfully = _rotors.addActuators(configuration);
 
 	// Control Surfaces
 	_first_control_surface_idx = configuration.num_actuators_matrix[0];
-	_control_surfaces.getEffectivenessMatrix(configuration, true);
+	const bool surfaces_added_successfully = _control_surfaces.addActuators(configuration);
 
-	return true;
+	return (rotors_added_successfully && surfaces_added_successfully);
 }
 
 void ActuatorEffectivenessFixedWing::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessFixedWing.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessFixedWing.hpp
@@ -45,7 +45,7 @@ public:
 	ActuatorEffectivenessFixedWing(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessFixedWing() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	const char *name() const override { return "Fixed Wing"; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
@@ -43,20 +43,21 @@ ActuatorEffectivenessMCTilt::ActuatorEffectivenessMCTilt(ModuleParams *parent)
 }
 
 bool
-ActuatorEffectivenessMCTilt::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessMCTilt::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!force) {
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 
 	// MC motors
 	_mc_rotors.enableYawControl(!_tilts.hasYawControl());
-	_mc_rotors.getEffectivenessMatrix(configuration, true);
+	const bool rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
 	// Tilts
 	int first_tilt_idx = configuration.num_actuators_matrix[0];
 	_tilts.updateTorqueSign(_mc_rotors.geometry());
-	_tilts.getEffectivenessMatrix(configuration, true);
+	const bool tilts_added_successfully = _tilts.addActuators(configuration);
 
 	// Set offset such that tilts point upwards when control input == 0 (trim is 0 if min_angle == -max_angle).
 	// Note that we don't set configuration.trim here, because in the case of trim == +-1, yaw is always saturated
@@ -72,7 +73,7 @@ ActuatorEffectivenessMCTilt::getEffectivenessMatrix(Configuration &configuration
 		}
 	}
 
-	return true;
+	return (rotors_added_successfully && tilts_added_successfully);
 }
 
 void ActuatorEffectivenessMCTilt::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
@@ -43,7 +43,7 @@ public:
 	ActuatorEffectivenessMCTilt(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessMCTilt() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	void getDesiredAllocationMethod(AllocationMethod allocation_method_out[MAX_NUM_MATRICES]) const override
 	{

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,30 +31,26 @@
  *
  ****************************************************************************/
 
-#include "ActuatorEffectivenessCustom.hpp"
+#include "ActuatorEffectivenessMultirotor.hpp"
 
 using namespace matrix;
 
-ActuatorEffectivenessCustom::ActuatorEffectivenessCustom(ModuleParams *parent)
-	: ModuleParams(parent), _motors(this), _torque(this)
+ActuatorEffectivenessMultirotor::ActuatorEffectivenessMultirotor(ModuleParams *parent)
+	: ModuleParams(parent),
+	  _mc_rotors(this)
 {
 }
 
 bool
-ActuatorEffectivenessCustom::getEffectivenessMatrix(Configuration &configuration,
+ActuatorEffectivenessMultirotor::getEffectivenessMatrix(Configuration &configuration,
 		EffectivenessUpdateReason external_update)
 {
 	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 
-	// motors
-	_motors.enableYawControl(false);
-	const bool motors_added_successfully = _motors.addActuators(configuration);
+	// Motors
+	const bool rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
-	// Torque
-	const bool torque_added_successfully = _torque.addActuators(configuration);
-
-	return (motors_added_successfully && torque_added_successfully);
+	return rotors_added_successfully;
 }
-

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,68 +31,31 @@
  *
  ****************************************************************************/
 
-/**
- * @file ActuatorEffectivenessTiltrotorVTOL.hpp
- *
- * Actuator effectiveness for tiltrotor VTOL
- *
- * @author Julien Lecoeur <julien.lecoeur@gmail.com>
- */
-
 #pragma once
 
 #include "ActuatorEffectiveness.hpp"
 #include "ActuatorEffectivenessRotors.hpp"
-#include "ActuatorEffectivenessControlSurfaces.hpp"
-#include "ActuatorEffectivenessTilts.hpp"
 
-#include <uORB/topics/actuator_controls.h>
-#include <uORB/Subscription.hpp>
-
-class ActuatorEffectivenessTiltrotorVTOL : public ModuleParams, public ActuatorEffectiveness
+class ActuatorEffectivenessMultirotor : public ModuleParams, public ActuatorEffectiveness
 {
 public:
-	ActuatorEffectivenessTiltrotorVTOL(ModuleParams *parent);
-	virtual ~ActuatorEffectivenessTiltrotorVTOL() = default;
+	ActuatorEffectivenessMultirotor(ModuleParams *parent);
+	virtual ~ActuatorEffectivenessMultirotor() = default;
 
 	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
-	int numMatrices() const override { return 2; }
-
 	void getDesiredAllocationMethod(AllocationMethod allocation_method_out[MAX_NUM_MATRICES]) const override
 	{
-		static_assert(MAX_NUM_MATRICES >= 2, "expecting at least 2 matrices");
 		allocation_method_out[0] = AllocationMethod::SEQUENTIAL_DESATURATION;
-		allocation_method_out[1] = AllocationMethod::PSEUDO_INVERSE;
 	}
 
 	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
-		normalize[1] = false;
 	}
 
-	void setFlightPhase(const FlightPhase &flight_phase) override;
+	const char *name() const override { return "Multirotor"; }
 
-	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index,
-			    ActuatorVector &actuator_sp) override;
-
-	const char *name() const override { return "VTOL Tiltrotor"; }
-
-	uint32_t getStoppedMotors() const override { return _stopped_motors; }
 protected:
-	bool _combined_tilt_updated{true};
 	ActuatorEffectivenessRotors _mc_rotors;
-	ActuatorEffectivenessControlSurfaces _control_surfaces;
-	ActuatorEffectivenessTilts _tilts;
-
-	uint32_t _nontilted_motors{}; ///< motors that are not tiltable
-	uint32_t _stopped_motors{}; ///< currently stopped motors
-
-	int _first_control_surface_idx{0}; ///< applies to matrix 1
-	int _first_tilt_idx{0}; ///< applies to matrix 0
-
-	float _last_tilt_control{NAN};
-
-	uORB::Subscription _actuator_controls_1_sub{ORB_ID(actuator_controls_1)};
 };

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
@@ -136,24 +136,18 @@ void ActuatorEffectivenessRotors::updateParams()
 }
 
 bool
-ActuatorEffectivenessRotors::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessRotors::addActuators(Configuration &configuration)
 {
-	if (_updated || force) {
-		_updated = false;
-
-		if (configuration.num_actuators[(int)ActuatorType::SERVOS] > 0) {
-			PX4_ERR("Wrong actuator ordering: servos need to be after motors");
-			return false;
-		}
-
-		int num_actuators = computeEffectivenessMatrix(_geometry,
-				    configuration.effectiveness_matrices[configuration.selected_matrix],
-				    configuration.num_actuators_matrix[configuration.selected_matrix]);
-		configuration.actuatorsAdded(ActuatorType::MOTORS, num_actuators);
-		return true;
+	if (configuration.num_actuators[(int)ActuatorType::SERVOS] > 0) {
+		PX4_ERR("Wrong actuator ordering: servos need to be after motors");
+		return false;
 	}
 
-	return false;
+	int num_actuators = computeEffectivenessMatrix(_geometry,
+			    configuration.effectiveness_matrices[configuration.selected_matrix],
+			    configuration.num_actuators_matrix[configuration.selected_matrix]);
+	configuration.actuatorsAdded(ActuatorType::MOTORS, num_actuators);
+	return true;
 }
 
 int

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -93,7 +93,7 @@ public:
 	static int computeEffectivenessMatrix(const Geometry &geometry,
 					      EffectivenessMatrix &effectiveness, int actuator_start_index = 0);
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool addActuators(Configuration &configuration);
 
 	const char *name() const override { return "Multirotor"; }
 
@@ -117,8 +117,6 @@ public:
 
 private:
 	void updateParams() override;
-
-	bool _updated{true};
 	const AxisConfiguration _axis_config;
 	const bool _tilt_support; ///< if true, tilt servo assignment params are loaded
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverAckermann.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverAckermann.cpp
@@ -37,9 +37,10 @@
 using namespace matrix;
 
 bool
-ActuatorEffectivenessRoverAckermann::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessRoverAckermann::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!force) {
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverAckermann.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverAckermann.hpp
@@ -41,7 +41,7 @@ public:
 	ActuatorEffectivenessRoverAckermann() = default;
 	virtual ~ActuatorEffectivenessRoverAckermann() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	const char *name() const override { return "Rover (Ackermann)"; }
 private:

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverDifferential.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverDifferential.cpp
@@ -37,9 +37,10 @@
 using namespace matrix;
 
 bool
-ActuatorEffectivenessRoverDifferential::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessRoverDifferential::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!force) {
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverDifferential.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRoverDifferential.hpp
@@ -41,7 +41,7 @@ public:
 	ActuatorEffectivenessRoverDifferential() = default;
 	virtual ~ActuatorEffectivenessRoverDifferential() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	const char *name() const override { return "Rover (Differential)"; }
 private:

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
@@ -42,15 +42,16 @@ ActuatorEffectivenessStandardVTOL::ActuatorEffectivenessStandardVTOL(ModuleParam
 }
 
 bool
-ActuatorEffectivenessStandardVTOL::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessStandardVTOL::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!force) {
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 
 	// MC motors
 	configuration.selected_matrix = 0;
-	_mc_rotors.getEffectivenessMatrix(configuration, true);
+	const bool mc_rotors_added_successfully = _mc_rotors.addActuators(configuration);
 	_mc_motors_mask = (1u << _mc_rotors.geometry().num_rotors) - 1;
 
 	// Pusher/Puller
@@ -63,9 +64,9 @@ ActuatorEffectivenessStandardVTOL::getEffectivenessMatrix(Configuration &configu
 	// Control Surfaces
 	configuration.selected_matrix = 1;
 	_first_control_surface_idx = configuration.num_actuators_matrix[configuration.selected_matrix];
-	_control_surfaces.getEffectivenessMatrix(configuration, true);
+	const bool surfaces_added_successfully = _control_surfaces.addActuators(configuration);
 
-	return true;
+	return (mc_rotors_added_successfully && surfaces_added_successfully);
 }
 
 void ActuatorEffectivenessStandardVTOL::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
@@ -53,7 +53,7 @@ public:
 	ActuatorEffectivenessStandardVTOL(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessStandardVTOL() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	const char *name() const override { return "Standard VTOL"; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.cpp
@@ -47,24 +47,24 @@ ActuatorEffectivenessTailsitterVTOL::ActuatorEffectivenessTailsitterVTOL(ModuleP
 	setFlightPhase(FlightPhase::HOVER_FLIGHT);
 }
 bool
-ActuatorEffectivenessTailsitterVTOL::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessTailsitterVTOL::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!force) {
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 
 	// MC motors
 	configuration.selected_matrix = 0;
 	_mc_rotors.enableYawControl(_mc_rotors.geometry().num_rotors > 3); // enable MC yaw control if more than 3 rotors
-
-	_mc_rotors.getEffectivenessMatrix(configuration, true);
+	const bool mc_rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
 	// Control Surfaces
 	configuration.selected_matrix = 1;
 	_first_control_surface_idx = configuration.num_actuators_matrix[configuration.selected_matrix];
-	_control_surfaces.getEffectivenessMatrix(configuration, true);
+	const bool surfaces_added_successfully = _control_surfaces.addActuators(configuration);
 
-	return true;
+	return (mc_rotors_added_successfully && surfaces_added_successfully);
 }
 
 void ActuatorEffectivenessTailsitterVTOL::setFlightPhase(const FlightPhase &flight_phase)

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
@@ -52,7 +52,7 @@ public:
 	ActuatorEffectivenessTailsitterVTOL(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessTailsitterVTOL() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
 
 	int numMatrices() const override { return 2; }
 
@@ -75,7 +75,6 @@ public:
 
 	uint32_t getStoppedMotors() const override { return _stopped_motors; }
 protected:
-	bool _updated{true};
 	ActuatorEffectivenessRotors _mc_rotors;
 	ActuatorEffectivenessControlSurfaces _control_surfaces;
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -51,9 +51,10 @@ ActuatorEffectivenessTiltrotorVTOL::ActuatorEffectivenessTiltrotorVTOL(ModulePar
 	setFlightPhase(FlightPhase::HOVER_FLIGHT);
 }
 bool
-ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(Configuration &configuration, bool force)
+ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
 {
-	if (!_updated && !force) {
+	if (!_combined_tilt_updated && external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
 		return false;
 	}
 
@@ -62,30 +63,31 @@ ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(Configuration &config
 	_mc_rotors.enableYawControl(!_tilts.hasYawControl());
 
 	// Update matrix with tilts in vertical position when update is triggered by a manual
-	// configuration (parameter) change (=force update). This is to make sure the normalization
-	// scales are tilt-invariant. Note: force update only possible when disarm.
-	const float tilt_control_applied = force ? -1.f : _last_tilt_control;
+	// configuration (parameter) change. This is to make sure the normalization
+	// scales are tilt-invariant. Note: configuration updates are only possible when disarmed.
+	const float tilt_control_applied = (external_update == EffectivenessUpdateReason::CONFIGURATION_UPDATE) ? -1.f :
+					   _last_tilt_control;
 	_nontilted_motors = _mc_rotors.updateAxisFromTilts(_tilts, tilt_control_applied)
 			    << configuration.num_actuators[(int)ActuatorType::MOTORS];
 
-	_mc_rotors.getEffectivenessMatrix(configuration, true);
+	const bool mc_rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
 	// Control Surfaces
 	configuration.selected_matrix = 1;
 	_first_control_surface_idx = configuration.num_actuators_matrix[configuration.selected_matrix];
-	_control_surfaces.getEffectivenessMatrix(configuration, true);
+	const bool surfaces_added_successfully = _control_surfaces.addActuators(configuration);
 
 	// Tilts
 	configuration.selected_matrix = 0;
 	_first_tilt_idx = configuration.num_actuators_matrix[configuration.selected_matrix];
 	_tilts.updateTorqueSign(_mc_rotors.geometry(), true /* disable pitch to avoid configuration errors */);
-	_tilts.getEffectivenessMatrix(configuration, true);
+	const bool tilts_added_successfully = _tilts.addActuators(configuration);
 
-	// If it was a forced update (thus coming from a config change), then make sure to update matrix in
+	// If it was an update coming from a config change, then make sure to update matrix in
 	// the next iteration again with the correct tilt (but without updating the normalization scale).
-	_updated = force;
+	_combined_tilt_updated = (external_update == EffectivenessUpdateReason::CONFIGURATION_UPDATE);
 
-	return true;
+	return (mc_rotors_added_successfully && surfaces_added_successfully && tilts_added_successfully);
 }
 
 void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,
@@ -114,7 +116,7 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 				_last_tilt_control = control_tilt;
 
 			} else if (fabsf(control_tilt - _last_tilt_control) > 0.01f) {
-				_updated = true;
+				_combined_tilt_updated = true;
 				_last_tilt_control = control_tilt;
 			}
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTilts.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTilts.cpp
@@ -84,12 +84,8 @@ void ActuatorEffectivenessTilts::updateParams()
 	}
 }
 
-bool ActuatorEffectivenessTilts::getEffectivenessMatrix(Configuration &configuration, bool force)
+bool ActuatorEffectivenessTilts::addActuators(Configuration &configuration)
 {
-	if (!force) {
-		return false;
-	}
-
 	for (int i = 0; i < _count; i++) {
 		configuration.addActuator(ActuatorType::SERVOS, _torque[i], Vector3f{});
 	}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTilts.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTilts.hpp
@@ -67,7 +67,7 @@ public:
 	ActuatorEffectivenessTilts(ModuleParams *parent);
 	virtual ~ActuatorEffectivenessTilts() = default;
 
-	bool getEffectivenessMatrix(Configuration &configuration, bool force) override;
+	bool addActuators(Configuration &configuration);
 
 	const char *name() const override { return "Tilts"; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/CMakeLists.txt
+++ b/src/modules/control_allocator/ActuatorEffectiveness/CMakeLists.txt
@@ -42,6 +42,8 @@ px4_add_library(ActuatorEffectiveness
 	ActuatorEffectivenessFixedWing.hpp
 	ActuatorEffectivenessMCTilt.cpp
 	ActuatorEffectivenessMCTilt.hpp
+	ActuatorEffectivenessMultirotor.cpp
+	ActuatorEffectivenessMultirotor.hpp
 	ActuatorEffectivenessTilts.cpp
 	ActuatorEffectivenessTilts.hpp
 	ActuatorEffectivenessRotors.cpp

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -42,7 +42,7 @@
 #pragma once
 
 #include <ActuatorEffectiveness.hpp>
-#include <ActuatorEffectivenessRotors.hpp>
+#include <ActuatorEffectivenessMultirotor.hpp>
 #include <ActuatorEffectivenessStandardVTOL.hpp>
 #include <ActuatorEffectivenessTiltrotorVTOL.hpp>
 #include <ActuatorEffectivenessTailsitterVTOL.hpp>
@@ -125,7 +125,7 @@ private:
 	void update_allocation_method(bool force);
 	bool update_effectiveness_source();
 
-	void update_effectiveness_matrix_if_needed(bool force = false);
+	void update_effectiveness_matrix_if_needed(EffectivenessUpdateReason reason);
 
 	void publish_control_allocator_status();
 


### PR DESCRIPTION
This is mainly a refactoring of how we tell the effectiveness classes to update it's effectiveness matrices. This is required to enable motor failure handling and dynamic on/off switching of actuators in flight inside the control allocation. 

**Describe your solution**
The "force" flag is replaced by an enum that relays the reason for the matrix update to the effectiveness:
```
enum class EffectivenessUpdateReason {
	NO_EXTERNAL_UPDATE = 0,
	CONFIGURATION_UPDATE = 1,
	MOTOR_ACTIVATION_UPDATE = 2 (either motor failure or motor stopped in FW)
};
```
Then the Effectiveness knows when a matrix update is required (`!NO_EXTERNAL_UPDATE`) and if additionally the normalization scale needs an update (`CONFIGURATION_UPDATE`).
Note: the 4th reason for a matrix update, the change of combined tilt for tiltrotor, is handled inside the Effectiveness.


**Test data / coverage**
SITL tested

