### PR TITLE
mantis: disable optical flow fusion in EKF2

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -46,7 +46,7 @@ param set-default COM_RC_LOSS_T 3
 
 
 # ekf2
-param set-default EKF2_AID_MASK 35
+param set-default EKF2_AID_MASK 33
 param set-default EKF2_BARO_DELAY 0
 param set-default EKF2_BARO_NOISE 2.0
 


### PR DESCRIPTION
Above grass fields I can frequently observe position instabilities with the mantis due to the optical flow fusion.

Let's disable flow fusion for now.

Here are two flight logs that show the issue:

![image](https://user-images.githubusercontent.com/3762382/153589879-7fa4c5ac-999d-465b-b493-c2ade8cf81f7.png)
https://logs.px4.io/plot_app?log=c698bb13-2c5b-4994-a95f-e0c6ccd014c6

![image](https://user-images.githubusercontent.com/3762382/153589919-d0a6a5fd-2beb-4ef6-8766-e6f37b641e66.png)
https://logs.px4.io/plot_app?log=97e5e699-852e-402c-bcfb-cbaeb1de218b

