### PR TITLE
Airspeed selector: fix condition for messaging

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -150,6 +150,7 @@ private:
 	float _ground_minus_wind_TAS{0.0f}; /**< true airspeed from groundspeed minus windspeed */
 	float _ground_minus_wind_CAS{0.0f}; /**< calibrated airspeed from groundspeed minus windspeed */
 	bool _armed_prev{false};
+	bool _armed{false};
 
 	hrt_abstime _time_last_airspeed_update[MAX_NUM_AIRSPEED_SENSORS] {};
 
@@ -317,10 +318,10 @@ AirspeedModule::Run()
 		update_params();
 	}
 
-	const bool armed = (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+	_armed = (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
 
 	// check for new connected airspeed sensors as long as we're disarmed
-	if (!armed) {
+	if (!_armed) {
 		check_for_connected_airspeed_sensors();
 	}
 
@@ -380,7 +381,7 @@ AirspeedModule::Run()
 					_in_takeoff_situation = true;
 				}
 
-				input_data.in_fixed_wing_flight = (armed && in_air_fixed_wing && !_in_takeoff_situation);
+				input_data.in_fixed_wing_flight = (_armed && in_air_fixed_wing && !_in_takeoff_situation);
 
 				// push input data into airspeed validator
 				_airspeed_validator[i].update_airspeed_validator(input_data);
@@ -394,7 +395,7 @@ AirspeedModule::Run()
 			}
 
 			// save estimated airspeed scale after disarm
-			if (!armed && _armed_prev) {
+			if (!_armed && _armed_prev) {
 				if (_param_aspd_scale_apply.get() > 0) {
 					if (fabsf(_airspeed_validator[i].get_CAS_scale_validated() - _param_airspeed_scale[i]) > 0.01f) {
 						// apply the new scale if changed more than 0.01
@@ -428,7 +429,7 @@ AirspeedModule::Run()
 
 	select_airspeed_and_publish();
 
-	_armed_prev = armed;
+	_armed_prev = _armed;
 
 	perf_end(_perf_elapsed);
 
@@ -593,8 +594,7 @@ void AirspeedModule::select_airspeed_and_publish()
 
 	// print warning or info, depending of whether airspeed got declared invalid or healthy
 	if (_valid_airspeed_index != _prev_airspeed_index &&
-	    (_number_of_airspeed_sensors > 0 || !_vehicle_land_detected.landed) &&
-	    _valid_airspeed_index != _prev_airspeed_index) {
+	    _number_of_airspeed_sensors > 0 && _armed) {
 		if (_prev_airspeed_index > 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Return to launch (RTL) is advised.\t");
 			events::send(events::ID("airspeed_selector_sensor_failure"), events::Log::Critical,

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -593,8 +593,14 @@ void AirspeedModule::select_airspeed_and_publish()
 
 	// print warning or info, depending of whether airspeed got declared invalid or healthy
 	if (_valid_airspeed_index != _prev_airspeed_index &&
-	    _number_of_airspeed_sensors > 0 && _vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
-		if (_prev_airspeed_index > 0) {
+	    _number_of_airspeed_sensors > 0) {
+		if (_vehicle_status.arming_state == !vehicle_status_s::ARMING_STATE_ARMED && _prev_airspeed_index > 0) {
+			mavlink_log_critical(&_mavlink_log_pub,
+					     "Airspeed sensor failure detected. Check connection between sensor and flight controller.\t");
+			events::send(events::ID("airspeed_selector_sensor_failure_disarmed"), events::Log::Critical,
+				     "Airspeed sensor failure detected. Check connection between sensor and flight controller");
+
+		} else if (_prev_airspeed_index > 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Return to launch (RTL) is advised.\t");
 			events::send(events::ID("airspeed_selector_sensor_failure"), events::Log::Critical,
 				     "Airspeed sensor failure detected. Return to launch (RTL) is advised");

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -597,7 +597,7 @@ void AirspeedModule::select_airspeed_and_publish()
 		if (_vehicle_status.arming_state == !vehicle_status_s::ARMING_STATE_ARMED && _prev_airspeed_index > 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Check connection and reboot.\t");
 			events::send(events::ID("airspeed_selector_sensor_failure_disarmed"), events::Log::Critical,
-				     "Airspeed sensor failure detected. Check connection and reboot.");
+				     "Airspeed sensor failure detected. Check connection and reboot");
 
 		} else if (_prev_airspeed_index > 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Return to launch (RTL) is advised.\t");

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -595,10 +595,9 @@ void AirspeedModule::select_airspeed_and_publish()
 	if (_valid_airspeed_index != _prev_airspeed_index &&
 	    _number_of_airspeed_sensors > 0) {
 		if (_vehicle_status.arming_state == !vehicle_status_s::ARMING_STATE_ARMED && _prev_airspeed_index > 0) {
-			mavlink_log_critical(&_mavlink_log_pub,
-					     "Airspeed sensor failure detected. Check connection between sensor and flight controller.\t");
+			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Check connection and reboot.\t");
 			events::send(events::ID("airspeed_selector_sensor_failure_disarmed"), events::Log::Critical,
-				     "Airspeed sensor failure detected. Check connection between sensor and flight controller");
+				     "Airspeed sensor failure detected. Check connection and reboot.");
 
 		} else if (_prev_airspeed_index > 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Return to launch (RTL) is advised.\t");


### PR DESCRIPTION
**Describe problem solved by this pull request**
Current behavior: If airspeed has been valid and gets invalid prior to arming, a warning will be spawned advising the user to RTL. This message is meant to be issued while flying. A quick investigation showed that the condition is broken.

**Describe your solution**
Fix the condition and use an armed boolean instead of the landed flag.
