### PR TITLE
Changes SDIO clock speed to 20MHz for Matek H743 Slim board

### DIFF
--- a/boards/matek/h743-slim/nuttx-config/include/board.h
+++ b/boards/matek/h743-slim/nuttx-config/include/board.h
@@ -284,17 +284,17 @@
 
 #define STM32_SDMMC_INIT_CLKDIV     (300 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
 
-/* 25 MHz Max for now, 25 mHZ = PLL1Q/(2*div), div =  PLL1Q/(2*freq)
- * div = 4.8 = 240 / 50, So round up to 5 for default speed 24 MB/s
+/* 20 MHz Max for now - more reliable on some boards than 25 MHz
+ * 20 MHz = PLL1Q/(2*div), div =  PLL1Q/(2*freq), div = 6 = 240 / 40
  */
 
 #if defined(CONFIG_STM32H7_SDMMC_XDMA) || defined(CONFIG_STM32H7_SDMMC_IDMA)
-#  define STM32_SDMMC_MMCXFR_CLKDIV   (5 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
+#  define STM32_SDMMC_MMCXFR_CLKDIV   (6 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
 #else
 #  define STM32_SDMMC_MMCXFR_CLKDIV   (100 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
 #endif
 #if defined(CONFIG_STM32H7_SDMMC_XDMA) || defined(CONFIG_STM32H7_SDMMC_IDMA)
-#  define STM32_SDMMC_SDXFR_CLKDIV    (5 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
+#  define STM32_SDMMC_MMCXFR_CLKDIV   (6 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
 #else
 #  define STM32_SDMMC_SDXFR_CLKDIV    (100 << STM32_SDMMC_CLKCR_CLKDIV_SHIFT)
 #endif


### PR DESCRIPTION
Addresses the reliability issues seen on the Matek H743 Slim board when using a Sandisk 4, 16, and 32GB Class-10 U1 A1 SD cards, as described in: https://github.com/PX4/PX4-Autopilot/issues/19155

The main approach here is to drop the max SDIO clock speed from 25MHz to 20MHz, which appears to have generally solved the problem, at least on the Matek H743 Slim (monitored over a few days of heavy SD card testing with sd_stress, sd_bench, and general parameter-based operations).

This may not be strictly necessary on all boards, and may be a function of things like temperature, the onboard oscillator components used on each physical board, or other factors. That said, a similar PR was introduced in Ardupilot which drops the clock speed to an even more conservative speed of 12.5MHz:
https://github.com/PX4/PX4-Autopilot/blob/master/boards/matek/h743-slim/nuttx-config/include/board.h#L292-L297

It would be good to have some feedback/review from those more familiar with the H7's clock tree and SDIO interface.