### PR TITLE
Revert "mantis: disable optical flow fusion in EKF2"

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -46,7 +46,7 @@ param set-default COM_RC_LOSS_T 3
 
 
 # ekf2
-param set-default EKF2_AID_MASK 33
+param set-default EKF2_AID_MASK 35
 param set-default EKF2_BARO_DELAY 0
 param set-default EKF2_BARO_NOISE 2.0
 


### PR DESCRIPTION
This reverts commit 1febba315af93d20eff748c246106bfa47081538.
