### PR TITLE
Add an ioctl interface for userspace to kernel calls

### DIFF
--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -57,7 +57,7 @@ bool uORB::Manager::initialize()
 	}
 
 #if defined(__PX4_NUTTX) && !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
-	px4_register_boardct_ioctl(_ORBIOCBASE, orb_ioctl);
+	px4_register_boardct_ioctl(_ORBIOCDEVBASE, orb_ioctl);
 #endif
 	return _Instance != nullptr;
 }

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -65,7 +65,8 @@ class SubscriptionCallback;
  * a handle
  */
 
-#define ORBIOCDEVEXISTS	_ORBIOC(30)
+#define _ORBIOCDEV(_n) (_PX4_IOC(_ORBIOCDEVBASE, _n))
+#define ORBIOCDEVEXISTS	_ORBIOCDEV(30)
 typedef struct orbiocdevexists {
 	const ORB_ID orb_id;
 	const uint8_t instance;
@@ -73,7 +74,7 @@ typedef struct orbiocdevexists {
 	int ret;
 } orbiocdevexists_t;
 
-#define ORBIOCDEVADVERTISE	_ORBIOC(31)
+#define ORBIOCDEVADVERTISE	_ORBIOCDEV(31)
 typedef struct orbiocadvertise {
 	const struct orb_metadata *meta;
 	bool is_advertiser;
@@ -81,13 +82,13 @@ typedef struct orbiocadvertise {
 	int ret;
 } orbiocdevadvertise_t;
 
-#define ORBIOCDEVUNADVERTISE	_ORBIOC(32)
+#define ORBIOCDEVUNADVERTISE	_ORBIOCDEV(32)
 typedef struct orbiocunadvertise {
 	void *handle;
 	int ret;
 } orbiocdevunadvertise_t;
 
-#define ORBIOCDEVPUBLISH	_ORBIOC(33)
+#define ORBIOCDEVPUBLISH	_ORBIOCDEV(33)
 typedef struct orbiocpublish {
 	const struct orb_metadata *meta;
 	orb_advert_t handle;
@@ -95,7 +96,7 @@ typedef struct orbiocpublish {
 	int ret;
 } orbiocdevpublish_t;
 
-#define ORBIOCDEVADDSUBSCRIBER	_ORBIOC(34)
+#define ORBIOCDEVADDSUBSCRIBER	_ORBIOCDEV(34)
 typedef struct {
 	const ORB_ID orb_id;
 	const uint8_t instance;
@@ -103,15 +104,15 @@ typedef struct {
 	void *handle;
 } orbiocdevaddsubscriber_t;
 
-#define ORBIOCDEVREMSUBSCRIBER	_ORBIOC(35)
+#define ORBIOCDEVREMSUBSCRIBER	_ORBIOCDEV(35)
 
-#define ORBIOCDEVQUEUESIZE	_ORBIOC(36)
+#define ORBIOCDEVQUEUESIZE	_ORBIOCDEV(36)
 typedef struct {
 	const void *handle;
 	uint8_t size;
 } orbiocdevqueuesize_t;
 
-#define ORBIOCDEVDATACOPY	_ORBIOC(37)
+#define ORBIOCDEVDATACOPY	_ORBIOCDEV(37)
 typedef struct {
 	void *handle;
 	void *dst;
@@ -119,33 +120,33 @@ typedef struct {
 	bool ret;
 } orbiocdevdatacopy_t;
 
-#define ORBIOCDEVREGCALLBACK	_ORBIOC(38)
+#define ORBIOCDEVREGCALLBACK	_ORBIOCDEV(38)
 typedef struct {
 	void *handle;
 	class uORB::SubscriptionCallback *callback_sub;
 	bool registered;
 } orbiocdevregcallback_t;
 
-#define ORBIOCDEVUNREGCALLBACK	_ORBIOC(39)
+#define ORBIOCDEVUNREGCALLBACK	_ORBIOCDEV(39)
 typedef struct {
 	void *handle;
 	class uORB::SubscriptionCallback *callback_sub;
 } orbiocdevunregcallback_t;
 
-#define ORBIOCDEVGETINSTANCE	_ORBIOC(40)
+#define ORBIOCDEVGETINSTANCE	_ORBIOCDEV(40)
 typedef struct {
 	const void *handle;
 	uint8_t instance;
 } orbiocdevgetinstance_t;
 
-#define ORBIOCDEVUPDATESAVAIL	_ORBIOC(41)
+#define ORBIOCDEVUPDATESAVAIL	_ORBIOCDEV(41)
 typedef struct {
 	const void *handle;
 	unsigned last_generation;
 	unsigned ret;
 } orbiocdevupdatesavail_t;
 
-#define ORBIOCDEVISADVERTISED	_ORBIOC(42)
+#define ORBIOCDEVISADVERTISED	_ORBIOCDEV(42)
 typedef struct {
 	const void *handle;
 	bool ret;
@@ -155,7 +156,7 @@ typedef enum {
 	ORB_DEVMASTER_STATUS = 0,
 	ORB_DEVMASTER_TOP = 1
 } orbiocdevmastercmd_t;
-#define ORBIOCDEVMASTERCMD	_ORBIOC(45)
+#define ORBIOCDEVMASTERCMD	_ORBIOCDEV(45)
 
 
 /**

--- a/platforms/nuttx/src/px4/common/board_ctrl.c
+++ b/platforms/nuttx/src/px4/common/board_ctrl.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file board_ctrl.c
+ *
+ * Provide a kernel-userspace boardctl_ioctl interface
+ */
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform/board_ctrl.h>
+#include "board_config.h"
+
+static struct {
+	ioctl_ptr_t ioctl_func;
+} ioctl_ptrs[MAX_IOCTL_PTRS];
+
+/************************************************************************************
+ * Name: px4_register_boardct_ioctl
+ *
+ * Description:
+ *   an interface function for kernel services to register an ioct handler for user side
+ *
+ ************************************************************************************/
+
+
+int px4_register_boardct_ioctl(unsigned base, ioctl_ptr_t func)
+{
+	unsigned i = IOCTL_BASE_TO_IDX(base);
+	int ret = PX4_ERROR;
+
+	if (i < MAX_IOCTL_PTRS) {
+		ioctl_ptrs[i].ioctl_func = func;
+		ret = PX4_OK;
+	}
+
+	return ret;
+}
+
+/************************************************************************************
+ * Name: board_ioctl
+ *
+ * Description:
+ *   implements board_ioctl for userspace-kernel interface
+ *
+ ************************************************************************************/
+
+int board_ioctl(unsigned int cmd, uintptr_t arg)
+{
+	unsigned i = IOCTL_BASE_TO_IDX(cmd);
+	int ret = -EINVAL;
+
+	if (i < MAX_IOCTL_PTRS && ioctl_ptrs[i].ioctl_func) {
+		ret = ioctl_ptrs[i].ioctl_func(cmd, arg);
+	}
+
+	return ret;
+}
+
+/************************************************************************************
+ * Name: kernel_ioctl_initialize
+ *
+ * Description:
+ *   initializes the kernel-side ioctl interface
+ *
+ ************************************************************************************/
+
+void kernel_ioctl_initialize(void)
+{
+	for (int i = 0; i < MAX_IOCTL_PTRS; i++) {
+		ioctl_ptrs[i].ioctl_func = NULL;
+	}
+}

--- a/platforms/nuttx/src/px4/common/include/px4_platform/board_ctrl.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/board_ctrl.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 Technology Innovation Institute. All rights reserved.
+ *                 Author: Jukka Laitinen <jukkax@ssrc.tii.ae>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+/* Encode the px4 boardctl ioctls in the following way:
+ * the highest 4-bits identifies the boardctl's used by this if
+ * the next 4-bits identifies the module which handles the ioctl
+ * the low byte identiefies the actual IOCTL within the module
+ */
+
+#define _BOARDCTLIOCBASE		(0x4000)
+#define IOCTL_IDX_TO_BASE(x)	((((x) & 0xF) << 8) | _BOARDCTLIOCBASE)
+#define IOCTL_BASE_TO_IDX(x)	(((x) & 0x0F00) >> 8)
+
+#define _ORBIOCDEVBASE				IOCTL_IDX_TO_BASE(0)
+#define _HRTIOCBASE				IOCTL_IDX_TO_BASE(1)
+#define _CRYPTOIOCBASE			IOCTL_IDX_TO_BASE(2)
+#define _BUILTINIOCBASE			IOCTL_IDX_TO_BASE(3)
+#define MAX_IOCTL_PTRS 4
+
+typedef int (*ioctl_ptr_t)(unsigned int, unsigned long);
+
+__BEGIN_DECLS
+
+/* Function to initialize or reset the interface */
+void kernel_ioctl_initialize(void);
+
+/* Function to register a px4 boardctl handler */
+int px4_register_boardct_ioctl(unsigned base, ioctl_ptr_t func);
+
+__END_DECLS

--- a/platforms/nuttx/src/px4/common/include/px4_platform/board_ctrl.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/board_ctrl.h
@@ -50,6 +50,18 @@
 #define _BUILTINIOCBASE			IOCTL_IDX_TO_BASE(3)
 #define MAX_IOCTL_PTRS 4
 
+/* The BUILTINIOCLAUNCH IOCTL is used to launch kernel side modules
+ * from the user side code
+ */
+
+#define BUILTINIOCLAUNCH               (_PX4_IOC(_BUILTINIOCBASE, 1))
+
+typedef struct builtinioclaunch {
+	int argc;
+	char **argv;
+	int ret;
+} builtinioclaunch_t;
+
 typedef int (*ioctl_ptr_t)(unsigned int, unsigned long);
 
 __BEGIN_DECLS

--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -56,10 +56,20 @@
 #include <px4_platform_common/crypto.h>
 #endif
 
+#if !defined(CONFIG_BUILD_FLAT)
+#include <px4_platform/board_ctrl.h>
+#endif
+
 extern void cdcacm_init(void);
 
 int px4_platform_init()
 {
+
+#if !defined(CONFIG_BUILD_FLAT)
+	/* initialize userspace-kernelspace call gate interface */
+
+	kernel_ioctl_initialize();
+#endif
 
 	int ret = px4_console_buffer_init();
 

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -18,6 +18,13 @@ target_link_libraries(px4_layer
 		nuttx_mm
 )
 
+# Build the interface library between user and kernel side
+add_library(px4_board_ctrl
+		board_ctrl.c
+)
+
+add_dependencies(px4_board_ctrl nuttx_context px4_kernel_builtin_list_target)
+
 # Build the kernel side px4_kernel_layer
 
 add_library(px4_kernel_layer


### PR DESCRIPTION
This adds an ioctl interface for NuttX protected build, allowing
system calls from user space to kernel for uORB, HRT and crypto

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

