### PR TITLE
Pr control alloc matrix inversion robust master

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -111,6 +111,10 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 		if (_actuator_controls_1_sub.copy(&actuator_controls_1)) {
 			float control_tilt = actuator_controls_1.control[4] * 2.f - 1.f;
 
+			// set control_tilt to exactly -1 or 1 if close to these end points
+			control_tilt = control_tilt < -0.99f ? -1.f : control_tilt;
+			control_tilt = control_tilt > 0.99f ? 1.f : control_tilt;
+
 			// initialize _last_tilt_control
 			if (!PX4_ISFINITE(_last_tilt_control)) {
 				_last_tilt_control = control_tilt;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -370,9 +370,9 @@ void Tiltrotor::update_transition_state()
 
 	} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_FRONT_P2) {
 		// the plane is ready to go into fixed wing mode, tilt the rotors forward completely
-		_tilt_control = _params_tiltrotor.tilt_transition +
-				fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_transition) * time_since_trans_start /
-				_params_tiltrotor.front_trans_dur_p2;
+		_tilt_control = math::constrain(_params_tiltrotor.tilt_transition +
+						fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_transition) * time_since_trans_start /
+						_params_tiltrotor.front_trans_dur_p2, _params_tiltrotor.tilt_transition, _params_tiltrotor.tilt_fw);
 
 		_mc_roll_weight = 0.0f;
 		_mc_yaw_weight = 0.0f;


### PR DESCRIPTION


**Describe problem solved by this pull request**
Small entries in the effectiveness matrix, e.g. due to not exactly vertical/horizontal motor tilts, cause the allocation algorithm to try to control axes with only very little control authority. For example, if the motors are still slightly pointing upwards in fixed-wing configuration of a tiltrotor, it will try to achieve an allocation with a rolling moment of 0. That has effect on all the other (actually active) axes, as with the very small authority the setpoint can only be achieved by giving the weak axis a lot of control weight, somewhat neglecting the actual important axes (in the example here: collective thrust).

**Describe your solution**
- make sure that tilt doesn't exceed 1, as otherwise the motor thrust component is slightly pointing down
- set tilts to exactly -1 or 1 if close to these end points
- set all the elements of a row to 0 if that row has weak authority

Weak authority on a axis is currently defined as: none of the actuators have an effectiveness on this particular axis larger than 0.05. 

**Describe possible alternatives**
Weak authority on a axis can also be defined relative to the effectiveness of the other axis. Pro: we don't delete axis unnecessarily if the overall effectiveness is low (e.g. low ct values). Con: If one axis has a very high effectiveness, it would mean that other axis may get flagged as weak even though they actually have sufficient authority.
Given that the current way is simpler we could get this in and get serious testing in. 

**Test data / coverage**
SITL and partly flight tested on a real tiltrotor

