### PR TITLE
RM3100 self-test procedure revision

### DIFF
--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -82,17 +82,20 @@ int RM3100::self_test()
 	/* Configure sensor to execute BIST upon receipt of a POLL command */
 	cmd = BIST_SELFTEST;
 	ret = _interface->write(ADDR_BIST, &cmd, 1);
+
 	if (ret != PX4_OK) {
 		return ret;
 	}
 
 	/* Perform test procedure until a valid result is obtained or test times out */
 	const hrt_abstime t_start = hrt_absolute_time();
+
 	while ((hrt_absolute_time() - t_start) < BIST_DUR_USEC) {
 
 		/* Poll for a measurement */
 		cmd = POLL_XYZ;
 		ret = _interface->write(ADDR_POLL, &cmd, 1);
+
 		if (ret != PX4_OK) {
 			return ret;
 		}
@@ -101,6 +104,7 @@ int RM3100::self_test()
 		if (!check_measurement()) {
 			/* Check BIST register to evaluate the test result*/
 			ret = _interface->read(ADDR_BIST, &cmd, 1);
+
 			if (ret != PX4_OK) {
 				return ret;
 			}
@@ -111,15 +115,18 @@ int RM3100::self_test()
 
 				/* If the test passed, disable self-test mode by clearing the STE bit */
 				ret = !(cmd & BIST_XYZ_OK);
+
 				if (!ret) {
 					cmd = 0;
 					ret = _interface->write(ADDR_BIST, &cmd, 1);
+
 					if (ret != PX4_OK) {
 						PX4_ERR("Failed to disable BIST");
 					}
 
 					pass = PX4_OK;
 					break;
+
 				} else {
 					PX4_ERR("BIST failed");
 				}

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -128,6 +128,14 @@ int RM3100::self_test()
 						PX4_ERR("Failed to disable BIST");
 					}
 
+					/* Re-enable DRDY clear upon register writes and measurements */
+					cmd = 0x0B;
+					ret = _interface->write(ADDR_HSHAKE, &cmd, 1);
+
+					if (ret != PX4_OK) {
+						return ret;
+					}
+
 					pass = PX4_OK;
 					break;
 

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -89,7 +89,7 @@ int RM3100::self_test()
 	while ((hrt_absolute_time() - t_start) < BIST_DUR_USEC) {
 
 		/* Re-disable DRDY clear */
-		cmd = 0x08;
+		cmd = HSHAKE_NO_DRDY_CLEAR;
 		ret = _interface->write(ADDR_HSHAKE, &cmd, 1);
 
 		if (ret != PX4_OK) {
@@ -129,7 +129,7 @@ int RM3100::self_test()
 					}
 
 					/* Re-enable DRDY clear upon register writes and measurements */
-					cmd = 0x0B;
+					cmd = HSHAKE_DEFAULT;
 					ret = _interface->write(ADDR_HSHAKE, &cmd, 1);
 
 					if (ret != PX4_OK) {

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -75,14 +75,6 @@ int RM3100::self_test()
 	bool complete = false;
 	int pass = PX4_ERROR;
 
-	/* Disable DRDY clear upon register writes and measurements */
-	cmd = 0x08;
-	ret = _interface->write(ADDR_HSHAKE, &cmd, 1);
-
-	if (ret != PX4_OK) {
-		return ret;
-	}
-
 	/* Configure sensor to execute BIST upon receipt of a POLL command */
 	cmd = BIST_SELFTEST;
 	ret = _interface->write(ADDR_BIST, &cmd, 1);

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -128,8 +128,6 @@ int RM3100::self_test()
 				}
 			}
 		}
-
-		usleep(500);
 	}
 
 	if (!complete) {

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -70,10 +70,6 @@ RM3100::~RM3100()
 
 int RM3100::self_test()
 {
-	/* A poll event may have been triggered earlier; wait for conversion and read registers to clear DRDY bit */
-	usleep(RM3100_CONVERSION_INTERVAL);
-	collect();
-
 	int ret = 0;
 	uint8_t cmd = 0;
 	bool complete = false;
@@ -133,7 +129,7 @@ int RM3100::self_test()
 			}
 		}
 
-		usleep(RM3100_CONVERSION_INTERVAL);
+		usleep(500);
 	}
 
 	if (!complete) {

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -75,6 +75,14 @@ int RM3100::self_test()
 	bool complete = false;
 	int pass = PX4_ERROR;
 
+	/* Disable DRDY clear upon register writes and measurements */
+	cmd = 0x08;
+	ret = _interface->write(ADDR_HSHAKE, &cmd, 1);
+
+	if (ret != PX4_OK) {
+		return ret;
+	}
+
 	/* Configure sensor to execute BIST upon receipt of a POLL command */
 	cmd = BIST_SELFTEST;
 	ret = _interface->write(ADDR_BIST, &cmd, 1);
@@ -87,6 +95,14 @@ int RM3100::self_test()
 	const hrt_abstime t_start = hrt_absolute_time();
 
 	while ((hrt_absolute_time() - t_start) < BIST_DUR_USEC) {
+
+		/* Re-disable DRDY clear */
+		cmd = 0x08;
+		ret = _interface->write(ADDR_HSHAKE, &cmd, 1);
+
+		if (ret != PX4_OK) {
+			return ret;
+		}
 
 		/* Poll for a measurement */
 		cmd = POLL_XYZ;

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -70,47 +70,70 @@ RM3100::~RM3100()
 
 int RM3100::self_test()
 {
-	/* Chances are that a poll event was triggered, so wait for conversion and read registers in order to clear DRDY bit */
+	/* A poll event may have been triggered earlier; wait for conversion and read registers to clear DRDY bit */
 	usleep(RM3100_CONVERSION_INTERVAL);
 	collect();
 
-	/* Fail if calibration is not good */
 	int ret = 0;
 	uint8_t cmd = 0;
+	bool complete = false;
+	int pass = PX4_ERROR;
 
-	/* Configure mag into self test mode */
+	/* Configure sensor to execute BIST upon receipt of a POLL command */
 	cmd = BIST_SELFTEST;
 	ret = _interface->write(ADDR_BIST, &cmd, 1);
-
 	if (ret != PX4_OK) {
 		return ret;
 	}
 
-	/* Now we need to write to POLL to launch self test */
-	cmd = POLL_XYZ;
-	ret = _interface->write(ADDR_POLL, &cmd, 1);
+	/* Perform test procedure until a valid result is obtained or test times out */
+	const hrt_abstime t_start = hrt_absolute_time();
+	while ((hrt_absolute_time() - t_start) < BIST_DUR_USEC) {
 
-	if (ret != PX4_OK) {
-		return ret;
+		/* Poll for a measurement */
+		cmd = POLL_XYZ;
+		ret = _interface->write(ADDR_POLL, &cmd, 1);
+		if (ret != PX4_OK) {
+			return ret;
+		}
+
+		/* If the DRDY bit in the status register is set, BIST should be complete */
+		if (!check_measurement()) {
+			/* Check BIST register to evaluate the test result*/
+			ret = _interface->read(ADDR_BIST, &cmd, 1);
+			if (ret != PX4_OK) {
+				return ret;
+			}
+
+			/* The test results are not valid if STE is not set. In this case, we try again */
+			if (cmd & BIST_STE) {
+				complete = true;
+
+				/* If the test passed, disable self-test mode by clearing the STE bit */
+				ret = !(cmd & BIST_XYZ_OK);
+				if (!ret) {
+					cmd = 0;
+					ret = _interface->write(ADDR_BIST, &cmd, 1);
+					if (ret != PX4_OK) {
+						PX4_ERR("Failed to disable BIST");
+					}
+
+					pass = PX4_OK;
+					break;
+				} else {
+					PX4_ERR("BIST failed");
+				}
+			}
+		}
+
+		usleep(RM3100_CONVERSION_INTERVAL);
 	}
 
-	/* Now wait for status register */
-	usleep(RM3100_CONVERSION_INTERVAL);
-
-	if (check_measurement() != PX4_OK) {
-		return -1;;
+	if (!complete) {
+		PX4_ERR("BIST incomplete");
 	}
 
-	/* Now check BIST register to see whether self test is ok or not*/
-	ret = _interface->read(ADDR_BIST, &cmd, 1);
-
-	if (ret != PX4_OK) {
-		return ret;
-	}
-
-	ret = !((cmd & BIST_XYZ_OK) == BIST_XYZ_OK);
-
-	return ret;
+	return pass;
 }
 
 int RM3100::check_measurement()
@@ -122,7 +145,7 @@ int RM3100::check_measurement()
 		return ret;
 	}
 
-	return !((status & STATUS_DRDY) == STATUS_DRDY) ;
+	return !(status & STATUS_DRDY);
 }
 
 int RM3100::collect()

--- a/src/drivers/magnetometer/rm3100/rm3100.h
+++ b/src/drivers/magnetometer/rm3100/rm3100.h
@@ -82,6 +82,8 @@
 #define BIST_SELFTEST		0x8F
 #define BIST_DEFAULT		0x00
 #define BIST_XYZ_OK		((1 << 4) | (1 << 5) | (1 << 6))
+#define BIST_STE		(1 << 7)
+#define BIST_DUR_USEC		(5*RM3100_CONVERSION_INTERVAL)
 #define STATUS_DRDY		(1 << 7)
 #define POLL_XYZ		0x70
 #define RM3100_REVID		0x22

--- a/src/drivers/magnetometer/rm3100/rm3100.h
+++ b/src/drivers/magnetometer/rm3100/rm3100.h
@@ -84,6 +84,8 @@
 #define BIST_XYZ_OK		((1 << 4) | (1 << 5) | (1 << 6))
 #define BIST_STE		(1 << 7)
 #define BIST_DUR_USEC		(2*RM3100_CONVERSION_INTERVAL)
+#define HSHAKE_DEFAULT		(0x0B)
+#define HSHAKE_NO_DRDY_CLEAR	(0x08)
 #define STATUS_DRDY		(1 << 7)
 #define POLL_XYZ		0x70
 #define RM3100_REVID		0x22

--- a/src/drivers/magnetometer/rm3100/rm3100.h
+++ b/src/drivers/magnetometer/rm3100/rm3100.h
@@ -83,7 +83,7 @@
 #define BIST_DEFAULT		0x00
 #define BIST_XYZ_OK		((1 << 4) | (1 << 5) | (1 << 6))
 #define BIST_STE		(1 << 7)
-#define BIST_DUR_USEC		(5*RM3100_CONVERSION_INTERVAL)
+#define BIST_DUR_USEC		(2*RM3100_CONVERSION_INTERVAL)
 #define STATUS_DRDY		(1 << 7)
 #define POLL_XYZ		0x70
 #define RM3100_REVID		0x22


### PR DESCRIPTION
**Describe problem solved by this pull request**
We have been experiencing intermittent failures with RM3100 initialization, wherein the BIST sometimes fails due to the STATUS register's DRDY bit not being set after firing off the POLL command. In this event, the current code fails the BIST outright. Beyond that, after reading through the BIST section of the datasheet, there are a few additional checks/actions that need to be taken to ensure that the results of the self-test are valid and that the BIST mode is exited upon completion.

**Describe your solution**
This PR addresses these issues in the following ways:
1. Adding some basic retry logic in the event that the DRDY bit was not upon checking the first time.
2. The results of the test are only valid if STE is set in the results, so this check is performed.
3. After the test is complete, BISTmode should be exited. It is unclear from the datasheet if there is any explicit automatic exit of BIST mode, so this takes the precautionary action of explicitly clearing STE, such that future POLL commands do not unintentionally trigger additional self-tests. I've seen this done in some reference drivers elsewhere, as well as seen it not done at all. There shouldn't be any harm, so I felt it was worth adding in.

**Test data / coverage**
I've tested this on a Matek H743 Wing. Since adding the logic, I have not failed any BIST tests, and with some temporary logging, I have observed instances where the check_measurement() method indicates the POLL result is not ready, which then triggered the retry logic and led to a successful test. Subscribing to the sensor_mag uorb topic, the output of the sensor appears reasonable.
