### PR TITLE
gyro_calibration: add additional validity check before finalizing calibrations

### DIFF
--- a/src/modules/gyro_calibration/GyroCalibration.cpp
+++ b/src/modules/gyro_calibration/GyroCalibration.cpp
@@ -232,7 +232,7 @@ void GyroCalibration::Run()
 		bool calibration_updated = false;
 
 		for (int gyro = 0; gyro < _sensor_gyro_subs.size(); gyro++) {
-			if (_gyro_calibration[gyro].device_id() != 0) {
+			if (_gyro_calibration[gyro].device_id() != 0 && _gyro_mean[gyro].valid()) {
 
 				// check variance again before saving
 				if (_gyro_mean[gyro].variance().longerThan(0.001f)) {


### PR DESCRIPTION
 - this is an edge case that can slip through if sensors are running normally but then stop publishing valid data
