### PR TITLE
Force ignition to use version 5 (edifice) in sitl run

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -192,7 +192,7 @@ elif [ "$program" == "ignition" ] && [ -z "$no_sim" ]; then
 		ignition_headless=""
 	fi
 	source "$src_path/Tools/setup_ignition.bash" "${src_path}" "${build_path}"
-	ign gazebo ${verbose} ${ignition_headless} -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
+	ign gazebo --force-version 5 ${verbose} ${ignition_headless} -r "${src_path}/Tools/simulation-ignition/worlds/${model}.world"&
 elif [ "$program" == "flightgear" ] && [ -z "$no_sim" ]; then
 	echo "FG setup"
 	cd "${src_path}/Tools/flightgear_bridge/"


### PR DESCRIPTION
Otherwise it can 

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
The ignition plugins are built for ignition edifice. If a newer version of ignition is installed alongside ignition edifice (e.g. fortress) the sitl run will use the newest version which ends up throwing a protobuf error and fails to run.

Full error [here](https://github.com/Auterion/px4-simulation-ignition/issues/21#issue-1133600298).

**Describe your solution**
This forces ignition to use version 5, which is the version it was built for. This makes sure ignition starts with edifice even if a newer version is installed. 

**Describe possible alternatives**
I'm sure there are alternatives, this just seems like the easiest solution at the current time. 

**Test data / coverage**
Ignition starts with this change when ignition fortress is installed along with ignition edifice. This was tested both locally and in a docker image. 

**Additional context**

