### PR TITLE
Fix Dshot actuator test issues

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -478,9 +478,7 @@ bool DShot::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 		_current_command.clear();
 	}
 
-	if (stop_motors || num_control_groups_updated > 0) {
-		up_dshot_trigger();
-	}
+	up_dshot_trigger();
 
 	return true;
 }

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -478,7 +478,9 @@ bool DShot::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
 		_current_command.clear();
 	}
 
-	up_dshot_trigger();
+	if (stop_motors || num_control_groups_updated > 0 || _mixing_output.useDynamicMixing()) {
+		up_dshot_trigger();
+	}
 
 	return true;
 }

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -398,16 +398,16 @@ ControlAllocator::Run()
 
 			_control_allocation[i]->clipActuatorSetpoint();
 		}
+	}
 
-		// Publish actuator setpoint and allocator status
-		publish_actuator_controls();
+	// Publish actuator setpoint and allocator status
+	publish_actuator_controls();
 
-		// Publish status at limited rate, as it's somewhat expensive and we use it for slower dynamics
-		// (i.e. anti-integrator windup)
-		if (now - _last_status_pub >= 5_ms) {
-			publish_control_allocator_status();
-			_last_status_pub = now;
-		}
+	// Publish status at limited rate, as it's somewhat expensive and we use it for slower dynamics
+	// (i.e. anti-integrator windup)
+	if (now - _last_status_pub >= 5_ms) {
+		publish_control_allocator_status();
+		_last_status_pub = now;
 	}
 
 	perf_end(_loop_perf);

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -51,7 +51,7 @@ using namespace time_literals;
 
 ControlAllocator::ControlAllocator() :
 	ModuleParams(nullptr),
-	WorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::rate_ctrl),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
 {
 	for (int i = 0; i < MAX_NUM_MOTORS; ++i) {
@@ -284,6 +284,9 @@ ControlAllocator::Run()
 	}
 
 	perf_begin(_loop_perf);
+
+	// Push backup schedule
+	ScheduleDelayed(50_ms);
 
 	// Check if parameters have changed
 	if (_parameter_update_sub.updated() && !_armed) {

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -93,6 +93,8 @@ ControlAllocator::init()
 		return false;
 	}
 
+	ScheduleDelayed(50_ms);
+
 	return true;
 }
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -74,7 +74,7 @@
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 
-class ControlAllocator : public ModuleBase<ControlAllocator>, public ModuleParams, public px4::WorkItem
+class ControlAllocator : public ModuleBase<ControlAllocator>, public ModuleParams, public px4::ScheduledWorkItem
 {
 public:
 	static constexpr int NUM_ACTUATORS = ControlAllocation::NUM_ACTUATORS;

--- a/src/systemcmds/actuator_test/actuator_test.cpp
+++ b/src/systemcmds/actuator_test/actuator_test.cpp
@@ -85,7 +85,7 @@ WARNING: remove all props before using this command.
 	PRINT_MODULE_USAGE_PARAM_INT('s', -1, 1, 8, "Servo to test (1...8)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('f', -1, 1, 8, "Specify function directly", true);
 
-	PRINT_MODULE_USAGE_PARAM_INT('v', 0, 0, 100, "value (-1...1)", false);
+	PRINT_MODULE_USAGE_PARAM_FLOAT('v', 0, -1, 1, "value (-1...1)", false);
 	PRINT_MODULE_USAGE_PARAM_INT('t', 0, 0, 100, "Timeout in seconds (run interactive if not set)", true);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("iterate-motors", "Iterate all motors starting and stopping one after the other");


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR addresses the issues described here:
https://github.com/PX4/PX4-Autopilot/issues/19190#issuecomment-1044276295

In summary, this PR addresses three problems:
1. The `actuator_test` system command does not accept the type and range of values it's usage statement describes
2. The DShot driver does not trigger commands unless the vehicle is armed and ControlAllocator is receiving torque/thrust setpoints. Because of this, the actuator_test commands have no effect.
3. Because `control_allocator` does not publish `actuator_motors` when disarmed, the FunctionMotors subscription never gets a sample containing information like the reversibility mask, which would cause issues in the interpretation of `actuator_test` commands if they did happen to be working.

**Describe your solution**
The initial solutions this PR implements (pending feedback from those more versed in the entire flow of events) are:
1. A simple fix for the value argument in the actuator test system command
2. Moving the publication of actuator commands and status out of the `do_update` check in ControlAllocator, such that the current state is always published
3. Removing the conditional check in DShot::updateOutputs around `up_dshot_trigger`, such that commands are properly issued regardless of whether there are input events being published upstream.

**Alternative solutions**
As an alternative to changing ControlAllocator to always publish current state, we could add in another topic/interface that lets ControlAllocator know that a test is happening and make `do_update` evaluate to true in that case. There are some timing considerations to be aware of here though, since the FunctionMotors instance still needs the reversibility info before the test actually begins.

**Test data / coverage**
Tested on a Matek H743 wing with a Saleae logic analyzer and both actuator_test and QGroundControl inputs.
