### PR TITLE
batmon: read a unique 16byte unique serial number and add to log 

### DIFF
--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2021-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,6 +86,16 @@ I2CSPIDriverBase *Batmon::instantiate(const I2CSPIDriverConfig &config, int runt
 	// Setting the BAT_SOURCE to "external"
 	int32_t battsource = 1;
 	param_set(param_find("BAT_SOURCE"), &battsource);
+	uint32_t fullSerial[4];
+	const uint8_t fullSerialLength = 16;
+	ret = interface->block_read(BATT_SMBUS_MANUFACTURER_DATA, fullSerial, fullSerialLength, true);
+
+	if (ret != PX4_OK) {
+		PX4_ERR("could not read serial");
+	}
+
+	PX4_INFO("Serial number: %08lX%08lX%08lX%08lX, %04X", fullSerial[3], fullSerial[2], fullSerial[1], fullSerial[0],
+		 instance->_serial_number);
 
 	instance->ScheduleOnInterval(SBS_MEASUREMENT_INTERVAL_US);
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Tracking individual batmon batteries to monitor its health and history requires a longer unique ID. During startup, the full serial and shorter 2byte serial is printed to the log

**Describe your solution**
A 16byte unique serial number is used to identify each batmon. A hashed 2 byte serial number is used in the uorb packets. This helps track multiple batteries connected on an aircraft

**Test data / coverage**
Tested on a pixhawk 4 connected to batmon v5 :  https://review.px4.io/plot_app?log=fa06a51f-59da-411c-ba58-fb44ae1f22bf 

**Additional context**
An example output on the log with this PR
![batmon_serial_number](https://user-images.githubusercontent.com/518314/154824398-13165247-d536-4a9c-8667-d23b25b455bf.png)

