### PR TITLE
Extend the PCF8583 driver to support multiple instances 

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -155,6 +155,13 @@ then
 	irlock start -X
 fi
 
+# PCF8583 counter (RPM sensor)
+if param compare -s SENS_EN_PCF8583 1
+then
+	pcf8583 start -X
+	pcf8583 start -X -a 0x51
+fi
+
 # probe for optional external I2C devices
 if param compare SENS_EXT_I2C_PRB 1
 then

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -66,7 +66,8 @@ int PCF8583::init()
 int PCF8583::probe()
 {
     uint8_t s = readRegister(0x00);
-    if(_tranfer_fail_count!=0 || s!=0) //extremly poor detection :-(
+    PX4_INFO("status register: %" PRId8 " fail_count: %" PRId32, s,_tranfer_fail_count);
+    if(_tranfer_fail_count!=0 || (s!=0 && s!=32)) //extremly poor detection :-(
         return PX4_ERROR;
 
     return PX4_OK;
@@ -144,7 +145,7 @@ void PCF8583::RunImpl()
     uint8_t s=readRegister(0x00);
     if(_tranfer_fail_count>0 || s!=0b00100000 || diffCount<0)
     {
-        PX4_ERR("pcf8583 RPM sensor restart");
+        PX4_ERR("pcf8583 RPM sensor restart: fail count %" PRId32 ", status: %" PRId8 ", diffCount: %" PRId32,_tranfer_fail_count,s,diffCount );
         initCounter();
         return;
     } 

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -34,27 +34,27 @@
 #include "PCF8583.hpp"
 
 PCF8583::PCF8583(const I2CSPIDriverConfig &config) :
-    I2C(config),
-    ModuleParams(nullptr),
-    I2CSPIDriver(config)
+	I2C(config),
+	ModuleParams(nullptr),
+	I2CSPIDriver(config)
 {
 }
 
 int PCF8583::init()
 {
-    if (I2C::init() != PX4_OK) {
-        return PX4_ERROR;
-    }
+	if (I2C::init() != PX4_OK) {
+		return PX4_ERROR;
+	}
 
-    PX4_DEBUG("addr: %" PRId8 ", pool: %" PRId32 ", reset: %" PRId32 ", magenet: %" PRId32, get_device_address(),
-          _param_pcf8583_pool.get(),
-          _param_pcf8583_reset.get(),
-          _param_pcf8583_magnet.get());
+	PX4_DEBUG("addr: %" PRId8 ", pool: %" PRId32 ", reset: %" PRId32 ", magenet: %" PRId32, get_device_address(),
+		  _param_pcf8583_pool.get(),
+		  _param_pcf8583_reset.get(),
+		  _param_pcf8583_magnet.get());
 
-    
-    initCounter();
 
-    ScheduleOnInterval(_param_pcf8583_pool.get());
+	initCounter();
+
+	ScheduleOnInterval(_param_pcf8583_pool.get());
 
 	_rpm_pub.advertise();
 
@@ -65,109 +65,112 @@ int PCF8583::init()
 
 int PCF8583::probe()
 {
-    uint8_t s = readRegister(0x00);
-    PX4_INFO("status register: %" PRId8 " fail_count: %" PRId32, s,_tranfer_fail_count);
-    if(_tranfer_fail_count!=0 || (s!=0 && s!=32)) //extremly poor detection :-(
-        return PX4_ERROR;
+	uint8_t s = readRegister(0x00);
+	PX4_INFO("status register: %" PRId8 " fail_count: %" PRId8, s, _tranfer_fail_count);
 
-    return PX4_OK;
+	if (_tranfer_fail_count != 0 || (s != 0 && s != 32)) { //extremly poor detection :-(
+		return PX4_ERROR;
+	}
+
+	return PX4_OK;
 }
 
 void PCF8583::initCounter()
 {
-    // set counter mode
-    _tranfer_fail_count=0;
-    setRegister(0x00, 0b00100000);
-    resetCounter();
+	// set counter mode
+	_tranfer_fail_count = 0;
+	setRegister(0x00, 0b00100000);
+	resetCounter();
 
 }
 
 uint32_t PCF8583::getCounter()
 {
-    uint8_t a = readRegister(0x01);
-    uint8_t b = readRegister(0x02);
-    uint8_t c = readRegister(0x03);
+	uint8_t a = readRegister(0x01);
+	uint8_t b = readRegister(0x02);
+	uint8_t c = readRegister(0x03);
 
-    return uint32_t(
-           loWord(a) * 1u + hiWord(a) * 10u 
-         + loWord(b) * 100u + hiWord(b) * 1000u
-         + loWord(c) * 10000u + hiWord(c) * 1000000u);
+	return uint32_t(
+		       loWord(a) * 1u + hiWord(a) * 10u
+		       + loWord(b) * 100u + hiWord(b) * 1000u
+		       + loWord(c) * 10000u + hiWord(c) * 1000000u);
 }
 
 void PCF8583::resetCounter()
 {
-    setRegister(0x01, 0x00);
-    setRegister(0x02, 0x00);
-    setRegister(0x03, 0x00);
-    _count = 0;
-    _last_measurement_time = hrt_absolute_time();
+	setRegister(0x01, 0x00);
+	setRegister(0x02, 0x00);
+	setRegister(0x03, 0x00);
+	_count = 0;
+	_last_measurement_time = hrt_absolute_time();
 }
 
 void PCF8583::setRegister(uint8_t reg, uint8_t value)
 {
-    uint8_t buff[2];
-    buff[0] = reg;
-    buff[1] = value;
-    int ret = transfer(buff, 2, nullptr, 0);
+	uint8_t buff[2];
+	buff[0] = reg;
+	buff[1] = value;
+	int ret = transfer(buff, 2, nullptr, 0);
 
-    if (PX4_OK != ret) {
-        PX4_DEBUG("setRegister : i2c::transfer returned %d", ret);
-        _tranfer_fail_count++;
-    }
+	if (PX4_OK != ret) {
+		PX4_DEBUG("setRegister : i2c::transfer returned %d", ret);
+		_tranfer_fail_count++;
+	}
 }
 
 uint8_t PCF8583::readRegister(uint8_t reg)
 {
-    uint8_t rcv{};
-    int ret = transfer(&reg, 1, &rcv, 1);
+	uint8_t rcv{};
+	int ret = transfer(&reg, 1, &rcv, 1);
 
-    if (PX4_OK != ret) {
-        PX4_DEBUG("readRegister : i2c::transfer returned %d", ret);
-        _tranfer_fail_count++;
-    }
+	if (PX4_OK != ret) {
+		PX4_DEBUG("readRegister : i2c::transfer returned %d", ret);
+		_tranfer_fail_count++;
+	}
 
-    return rcv;
+	return rcv;
 }
 
 void PCF8583::RunImpl()
 {
-    // read sensor and compute frequency
-    uint32_t oldcount = _count;
-    uint64_t oldtime = _last_measurement_time;
+	// read sensor and compute frequency
+	uint32_t oldcount = _count;
+	uint64_t oldtime = _last_measurement_time;
 
-    _count = getCounter();
-    _last_measurement_time = hrt_absolute_time();
+	_count = getCounter();
+	_last_measurement_time = hrt_absolute_time();
 
-    int diffCount = _count - oldcount;    
-    uint64_t diffTime = _last_measurement_time - oldtime;
+	int diffCount = _count - oldcount;
+	uint64_t diffTime = _last_measurement_time - oldtime;
 
-    //check if device failed or reset
-    uint8_t s=readRegister(0x00);
-    if(_tranfer_fail_count>0 || s!=0b00100000 || diffCount<0)
-    {
-        PX4_ERR("pcf8583 RPM sensor restart: fail count %" PRId32 ", status: %" PRId8 ", diffCount: %" PRId32,_tranfer_fail_count,s,diffCount );
-        initCounter();
-        return;
-    } 
+	//check if device failed or reset
+	uint8_t s = readRegister(0x00);
 
-    //check counter range
-    if (_param_pcf8583_reset.get() < diffCount + (int)_count ) {
-        resetCounter();        
-    }
+	if (_tranfer_fail_count > 0 || s != 0b00100000 || diffCount < 0) {
+		PX4_ERR("pcf8583 RPM sensor restart: fail count %" PRId8 ", status: %" PRId8 ", diffCount: %" PRId8,
+			_tranfer_fail_count, s, diffCount);
+		initCounter();
+		return;
+	}
 
-    float indicated_rpm = (float)diffCount / _param_pcf8583_magnet.get() / ((float)diffTime / 1000000) * 60.f;
-    float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1000000) * 60.f;
+	//check counter range
+	if (_param_pcf8583_reset.get() < diffCount + (int)_count) {
+		resetCounter();
+	}
 
-    // publish
-    rpm_s msg{};
-    msg.indicated_frequency_rpm = indicated_rpm;
-    msg.estimated_accurancy_rpm = estimated_accurancy;
-    msg.timestamp = hrt_absolute_time();
-    _rpm_pub.publish(msg);
+	float indicated_rpm = (float)diffCount / _param_pcf8583_magnet.get() / ((float)diffTime / 1000000) * 60.f;
+	float estimated_accurancy = 1 / (float)_param_pcf8583_magnet.get() / ((float)diffTime / 1000000) * 60.f;
+
+	// publish
+	rpm_s msg{};
+	msg.indicated_frequency_rpm = indicated_rpm;
+	msg.estimated_accurancy_rpm = estimated_accurancy;
+	msg.timestamp = hrt_absolute_time();
+	_rpm_pub.publish(msg);
 }
 
 void PCF8583::print_status()
 {
-    I2CSPIDriverBase::print_status();
-    PX4_INFO("poll interval:  %" PRId32 " us", _param_pcf8583_pool.get());
+	I2CSPIDriverBase::print_status();
+	PX4_INFO("poll interval:  %" PRId32 " us", _param_pcf8583_pool.get());
 }

--- a/src/drivers/rpm/pcf8583/PCF8583.cpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.cpp
@@ -63,7 +63,7 @@ int PCF8583::probe()
 	setRegister(0x00, 0b00100000);
 
 	uint8_t s = readRegister(0x00);
-	PX4_INFO("status register: %" PRId8 " fail_count: %" PRId8, s, _tranfer_fail_count);
+	PX4_DEBUG("status register: %" PRId8 " fail_count: %" PRId8, s, _tranfer_fail_count);
 
 	setRegister(0x04, 10);
 	setRegister(0x05, 10);

--- a/src/drivers/rpm/pcf8583/PCF8583.hpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.hpp
@@ -71,14 +71,19 @@ private:
 
 	int  probe() override;
 
-	int            getCounter();
-	void           resetCounter();
+    void           initCounter();
+	uint32_t       getCounter();
+	void           resetCounter();    
 
 	uint8_t        readRegister(uint8_t reg);
 	void           setRegister(uint8_t reg, uint8_t value);
 
-	int            _count{0};
+    uint8_t        hiWord(uint8_t in) { return (in & 0x0fu); }
+    uint8_t        loWord(uint8_t in) { return ((in & 0xf0u) >> 4); }
+
+	uint32_t       _count{0};
 	hrt_abstime    _last_measurement_time{0};
+    int            _tranfer_fail_count{0};
 
 	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};
 

--- a/src/drivers/rpm/pcf8583/PCF8583.hpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.hpp
@@ -71,19 +71,19 @@ private:
 
 	int  probe() override;
 
-    void           initCounter();
+	void           initCounter();
 	uint32_t       getCounter();
-	void           resetCounter();    
+	void           resetCounter();
 
 	uint8_t        readRegister(uint8_t reg);
 	void           setRegister(uint8_t reg, uint8_t value);
 
-    uint8_t        hiWord(uint8_t in) { return (in & 0x0fu); }
-    uint8_t        loWord(uint8_t in) { return ((in & 0xf0u) >> 4); }
+	uint8_t        hiWord(uint8_t in) { return (in & 0x0fu); }
+	uint8_t        loWord(uint8_t in) { return ((in & 0xf0u) >> 4); }
 
 	uint32_t       _count{0};
 	hrt_abstime    _last_measurement_time{0};
-    int            _tranfer_fail_count{0};
+	int            _tranfer_fail_count{0};
 
 	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};
 

--- a/src/drivers/rpm/pcf8583/PCF8583.hpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.hpp
@@ -48,6 +48,7 @@
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <drivers/device/i2c.h>
 #include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/rpm.h>
 #include <drivers/drv_hrt.h>
 
@@ -86,8 +87,9 @@ private:
 	hrt_abstime    _last_measurement_time{0};
 	hrt_abstime    _last_reset_time{0};
 	int            _tranfer_fail_count{0};
+	uint8_t        _last_config_register_content{0x00};
 
-	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};
+	uORB::PublicationMulti<rpm_s> _rpm_pub{ORB_ID(rpm)};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::PCF8583_POOL>) _param_pcf8583_pool,

--- a/src/drivers/rpm/pcf8583/PCF8583.hpp
+++ b/src/drivers/rpm/pcf8583/PCF8583.hpp
@@ -82,7 +82,9 @@ private:
 	uint8_t        loWord(uint8_t in) { return ((in & 0xf0u) >> 4); }
 
 	uint32_t       _count{0};
+	uint16_t       _reset_count{0};
 	hrt_abstime    _last_measurement_time{0};
+	hrt_abstime    _last_reset_time{0};
 	int            _tranfer_fail_count{0};
 
 	uORB::Publication<rpm_s> _rpm_pub{ORB_ID(rpm)};

--- a/src/drivers/rpm/pcf8583/parameters.c
+++ b/src/drivers/rpm/pcf8583/parameters.c
@@ -32,6 +32,21 @@
  ****************************************************************************/
 
 /**
+* PCF8583 eneable driver
+*
+* Run PCF8583 driver automatically
+*
+* @reboot_required true
+* @min 0
+* @max 1
+* @group Sensors
+* @value 0 Disabled
+* @value 1 Eneabled
+*/
+PARAM_DEFINE_INT32(SENS_EN_PCF8583, 0);
+
+
+/**
  * PCF8583 rotorfreq (i2c) pool interval
  *
  * Determines how often the sensor is read out.
@@ -41,16 +56,6 @@
  * @unit us
  */
 PARAM_DEFINE_INT32(PCF8583_POOL, 1000000);
-
-/**
- * PCF8583 rotorfreq (i2c) i2c address
- *
- * @reboot_required true
- * @group Sensors
- * @value 80 Address 0x50 (80)
- * @value 81 Address 0x51 (81)
- */
-PARAM_DEFINE_INT32(PCF8583_ADDR, 80);
 
 /**
  * PCF8583 rotorfreq (i2c) pulse reset value

--- a/src/drivers/rpm/pcf8583/pcf8583_main.cpp
+++ b/src/drivers/rpm/pcf8583/pcf8583_main.cpp
@@ -40,9 +40,11 @@ void
 PCF8583::print_usage()
 {
 	PRINT_MODULE_USAGE_NAME("pcf8583", "driver");
+	PRINT_MODULE_USAGE_SUBCATEGORY("rpm_sensor");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);
-	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(80);
+	PRINT_MODULE_USAGE_PARAMS_I2C_ADDRESS(0x50);
+	PRINT_MODULE_USAGE_PARAMS_I2C_KEEP_RUNNING_FLAG();
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 }
 
@@ -50,11 +52,11 @@ extern "C" __EXPORT int pcf8583_main(int argc, char *argv[])
 {
 	using ThisDriver = PCF8583;
 	BusCLIArguments cli{true, false};
-	cli.default_i2c_frequency = 400000;
+	cli.default_i2c_frequency = 100000;
 
-	int32_t addr{80};
-	param_get(param_find("PCF8583_ADDR"), &addr);
-	cli.i2c_address = addr;
+	//int32_t addr{0x50};
+	cli.i2c_address = 0x50;
+	cli.support_keep_running = true;
 
 	const char *verb = cli.parseDefaultArguments(argc, argv);
 

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -122,7 +122,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("control_allocator_status", 200, 2);
 	add_optional_topic_multi("rate_ctrl_status", 200, 2);
 	add_topic_multi("sensor_hygrometer", 500, 4);
-	add_topic_multi("rpm", 200, 8);
+	add_topic_multi("rpm", 200);
 	add_optional_topic_multi("telemetry_status", 1000, 4);
 
 	// EKF multi topics (currently max 9 estimators)

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -122,7 +122,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("control_allocator_status", 200, 2);
 	add_optional_topic_multi("rate_ctrl_status", 200, 2);
 	add_topic_multi("sensor_hygrometer", 500, 4);
-	add_topic_multi("rpm", 200);
+	add_optional_topic_multi("rpm", 200);
 	add_optional_topic_multi("telemetry_status", 1000, 4);
 
 	// EKF multi topics (currently max 9 estimators)

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -83,7 +83,6 @@ void LoggedTopics::add_default_topics()
 	add_topic("position_setpoint_triplet", 200);
 	add_optional_topic("px4io_status");
 	add_topic("radio_status");
-	add_optional_topic("rpm", 500);
 	add_topic("rtl_time_estimate", 1000);
 	add_topic("safety");
 	add_topic("sensor_combined");
@@ -123,6 +122,7 @@ void LoggedTopics::add_default_topics()
 	add_topic_multi("control_allocator_status", 200, 2);
 	add_optional_topic_multi("rate_ctrl_status", 200, 2);
 	add_topic_multi("sensor_hygrometer", 500, 4);
+	add_topic_multi("rpm", 200, 8);
 	add_optional_topic_multi("telemetry_status", 1000, 4);
 
 	// EKF multi topics (currently max 9 estimators)

--- a/src/modules/mavlink/streams/RAW_RPM.hpp
+++ b/src/modules/mavlink/streams/RAW_RPM.hpp
@@ -49,29 +49,33 @@ public:
 
 	unsigned get_size() override
 	{
-		return _rpm_sub.advertised() ? (MAVLINK_MSG_ID_RAW_RPM_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) : 0;
+		return _rpm_subs.advertised() ? (MAVLINK_MSG_ID_RAW_RPM_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) : 0;
 	}
 
 private:
 	explicit MavlinkStreamRawRpm(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
-	uORB::Subscription _rpm_sub{ORB_ID(rpm)};
+	uORB::SubscriptionMultiArray<rpm_s, 8> _rpm_subs{ORB_ID::rpm};
 
 	bool send() override
 	{
-		rpm_s rpm;
+		bool updated = false;
 
-		if (_rpm_sub.update(&rpm)) {
-			mavlink_raw_rpm_t msg{};
+		for (int i = 0; i < _rpm_subs.size(); i++) {
+			rpm_s rpm;
 
-			msg.frequency = rpm.indicated_frequency_rpm;
+			if (_rpm_subs[i].update(&rpm)) {
+				mavlink_raw_rpm_t msg{};
 
-			mavlink_msg_raw_rpm_send_struct(_mavlink->get_channel(), &msg);
+				msg.index = i;
+				msg.frequency = rpm.indicated_frequency_rpm;
 
-			return true;
+				mavlink_msg_raw_rpm_send_struct(_mavlink->get_channel(), &msg);
+				updated = true;
+			}
 		}
 
-		return false;
+		return updated;
 	}
 };
 

--- a/src/modules/mavlink/streams/RAW_RPM.hpp
+++ b/src/modules/mavlink/streams/RAW_RPM.hpp
@@ -55,7 +55,7 @@ public:
 private:
 	explicit MavlinkStreamRawRpm(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
-	uORB::SubscriptionMultiArray<rpm_s, 8> _rpm_subs{ORB_ID::rpm};
+	uORB::SubscriptionMultiArray<rpm_s> _rpm_subs{ORB_ID::rpm};
 
 	bool send() override
 	{

--- a/src/modules/mavlink/streams/RAW_RPM.hpp
+++ b/src/modules/mavlink/streams/RAW_RPM.hpp
@@ -49,7 +49,7 @@ public:
 
 	unsigned get_size() override
 	{
-		return _rpm_subs.advertised() ? (MAVLINK_MSG_ID_RAW_RPM_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES) : 0;
+		return _rpm_subs.advertised_count() * (MAVLINK_MSG_ID_RAW_RPM_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES);
 	}
 
 private:


### PR DESCRIPTION
A common requirement of PX4 users is to be able to connect multiple revolution sensors (counters, eg. PCF8583 used in TFRPM) to one autopilot. This PR tries to solve it. 

This modification extends the existing counter driver to support multiple instances at the same time. And produce multi-instance RPM uORB message. 

PR includes increased robustness to sensor failures and better recognition of the connected sensor.

The sensor driver is started by the parameter. 
