### PR TITLE
AirspeedSelector: fix condition for warning if not armed

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -594,7 +594,7 @@ void AirspeedModule::select_airspeed_and_publish()
 	// print warning or info, depending of whether airspeed got declared invalid or healthy
 	if (_valid_airspeed_index != _prev_airspeed_index &&
 	    _number_of_airspeed_sensors > 0) {
-		if (_vehicle_status.arming_state == !vehicle_status_s::ARMING_STATE_ARMED && _prev_airspeed_index > 0) {
+		if (_vehicle_status.arming_state != vehicle_status_s::ARMING_STATE_ARMED && _prev_airspeed_index > 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Airspeed sensor failure detected. Check connection and reboot.\t");
 			events::send(events::ID("airspeed_selector_sensor_failure_disarmed"), events::Log::Critical,
 				     "Airspeed sensor failure detected. Check connection and reboot");


### PR DESCRIPTION
#19173  introduced a new warning for a sensor failure while disarmed. However, a mistake in the condition for executing that caused it to never happen but still deploying the wrong message. Here's the fix.