### PR TITLE
Use braking logic from mission to hold mode

### DIFF
--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -110,7 +110,7 @@ Loiter::set_loiter_position()
 			setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
 
 		} else {
-			setLoiterItemFromCurrentPosition(&_mission_item);
+			setLoiterItemFromCurrentPositionWithBreaking(&_mission_item);
 		}
 
 	}

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -110,7 +110,12 @@ Loiter::set_loiter_position()
 			setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
 
 		} else {
-			setLoiterItemFromCurrentPositionWithBreaking(&_mission_item);
+			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+				setLoiterItemFromCurrentPositionWithBreaking(&_mission_item);
+
+			} else {
+				setLoiterItemFromCurrentPosition(&_mission_item);
+			}
 		}
 
 	}

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -705,6 +705,17 @@ MissionBlock::setLoiterItemFromCurrentPosition(struct mission_item_s *item)
 }
 
 void
+MissionBlock::setLoiterItemFromCurrentPositionWithBreaking(struct mission_item_s *item)
+{
+	setLoiterItemCommonFields(item);
+
+	_navigator->calculate_breaking_stop(item->lat, item->lon, item->yaw);
+
+	item->altitude = _navigator->get_global_position()->alt;
+	item->loiter_radius = _navigator->get_loiter_radius();
+}
+
+void
 MissionBlock::setLoiterItemCommonFields(struct mission_item_s *item)
 {
 	item->nav_cmd = NAV_CMD_LOITER_UNLIMITED;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -111,6 +111,7 @@ protected:
 	void setLoiterItemFromCurrentPositionSetpoint(struct mission_item_s *item);
 
 	void setLoiterItemFromCurrentPosition(struct mission_item_s *item);
+	void setLoiterItemFromCurrentPositionWithBreaking(struct mission_item_s *item);
 
 	void setLoiterItemCommonFields(struct mission_item_s *item);
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -320,6 +320,8 @@ public:
 	void acquire_gimbal_control();
 	void release_gimbal_control();
 
+	void 		calculate_breaking_stop(double &lat, double &lon, float &yaw);
+
 private:
 
 	struct traffic_buffer_s {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1577,8 +1577,6 @@ void Navigator::calculate_breaking_stop(double &lat, double &lon, float &yaw)
 
 	waypoint_from_heading_and_distance(get_global_position()->lat, get_global_position()->lon, course_over_ground,
 					   multirotor_braking_distance, &lat, &lon);
-	lat = lat;
-	lon = lon;
 	yaw = get_local_position()->heading;
 }
 


### PR DESCRIPTION
This PR re-uses the breaking logic which is used when we switch from mission to Goto/reposition mode but when entering hold/loiter mode.