### PR TITLE
second order reference model filter with optional rate feedback

### DIFF
--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -36,11 +36,13 @@ px4_add_library(mathlib
 	math/filter/LowPassFilter2p.hpp
 	math/filter/MedianFilter.hpp
 	math/filter/NotchFilter.hpp
+	math/filter/second_order_reference_model.hpp
 )
 
 px4_add_unit_gtest(SRC math/test/LowPassFilter2pVector3fTest.cpp LINKLIBS mathlib)
 px4_add_unit_gtest(SRC math/test/AlphaFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/MedianFilterTest.cpp)
 px4_add_unit_gtest(SRC math/test/NotchFilterTest.cpp)
+px4_add_unit_gtest(SRC math/test/second_order_reference_model_test.cpp)
 px4_add_unit_gtest(SRC math/FunctionsTest.cpp)
 px4_add_unit_gtest(SRC math/WelfordMeanTest.cpp)

--- a/src/lib/mathlib/math/filter/second_order_reference_model.hpp
+++ b/src/lib/mathlib/math/filter/second_order_reference_model.hpp
@@ -1,0 +1,153 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file second_order_reference_model.hpp
+ *
+ * @brief Implementation of a second order system with optional rate feed-forward.
+ *
+ * @author Thomas Stastny <thomas.stastny@auterion.com>
+ */
+
+#pragma once
+
+template <typename T>
+class SecondOrderReferenceModel
+{
+public:
+	SecondOrderReferenceModel() = default;
+
+	/**
+	 * Construct with system parameters
+	 *
+	 * @param[in] natural_freq The desired natural frequency of the system [rad/s]
+	 * @param[in] damping_ratio The desired damping ratio of the system
+	 */
+	SecondOrderReferenceModel(const float natural_freq, const float damping_ratio)
+	{
+		setParameters(natural_freq, damping_ratio);
+	}
+
+	/**
+	 * Set the system parameters
+	 *
+	 * Calculates the damping coefficient and spring stiffness
+	 *
+	 * @param[in] natural_freq The desired natural frequency of the system [rad/s]
+	 * @param[in] damping_ratio The desired damping ratio of the system
+	 * @return Whether or not the param set was successful
+	 */
+	bool setParameters(const float natural_freq, const float damping_ratio)
+	{
+		if (natural_freq < 0.0f || damping_ratio < 0.0f) {
+			return false;
+		}
+
+		// note these are "effective" coefficients, as mass coefficient is considered baked in
+		spring_constant_ = natural_freq * natural_freq;
+		damping_coefficient_ = 2.0f * damping_ratio * natural_freq;
+
+		return true;
+	}
+
+	/**
+	 * @return System state
+	 */
+	const T &getState() const { return filter_state_; }
+
+	/**
+	 * @return System rate
+	 */
+	const T &getRate() const { return filter_rate_; }
+
+	/**
+	 * @return System acceleration
+	 */
+	const T &getAccel() const { return filter_accel_; }
+
+	/**
+	 * Update the system states
+	 *
+	 * Units of rate_sample must correspond to the derivative of state_sample units.
+	 * There is currently no handling of discrete time behavior w.r.t. continuous time
+	 * system parameters. Sampling time should be sufficiently fast.
+	 *
+	 * @param[in] time_step Time since last sample [s]
+	 * @param[in] state_sample New state sample
+	 * @param[in] rate_sample New rate sample, if provided, otherwise defaults to zero(s)
+	 */
+	void update(const float time_step, const T &state_sample, const T &rate_sample = T())
+	{
+		T state_error = state_sample - filter_state_;
+		T rate_error = rate_sample - filter_rate_;
+
+		filter_accel_ = state_error * spring_constant_ + rate_error * damping_coefficient_;
+		filter_rate_ = integrate(filter_rate_, filter_accel_, time_step);
+		filter_state_ = integrate(filter_state_, filter_rate_, time_step);
+	}
+
+	/**
+	 * Reset the system states
+	 *
+	 * @param[in] state Initial state
+	 * @param[in] rate Initial rate, if provided, otherwise defaults to zero(s)
+	 */
+	void reset(const T &state, const T &rate = T())
+	{
+		filter_state_ = state;
+		filter_rate_ = rate;
+		filter_accel_ = T();
+	}
+
+protected:
+
+	float spring_constant_{0.0f};
+	float damping_coefficient_{0.0f};
+
+	T filter_state_{};
+	T filter_rate_{};
+	T filter_accel_{};
+
+	/**
+	 * Take one integration step using Euler integration
+	 *
+	 * @param[in] last_state
+	 * @param[in] rate
+	 * @param[in] time_step Time since last sample [s]
+	 * @return The next state
+	 */
+	T integrate(const T &last_state, const T &rate, const float time_step) const
+	{
+		return last_state + rate * time_step;
+	}
+};

--- a/src/lib/mathlib/math/filter/second_order_reference_model.hpp
+++ b/src/lib/mathlib/math/filter/second_order_reference_model.hpp
@@ -137,12 +137,12 @@ public:
 			return;
 		}
 
+		filter_state_ = integrate(filter_state_, filter_rate_, time_step);
+		filter_rate_ = integrate(filter_rate_, filter_accel_, time_step);
+
 		T state_error = state_sample - filter_state_;
 		T rate_error = rate_sample - filter_rate_;
-
 		filter_accel_ = state_error * spring_constant_ + rate_error * damping_coefficient_;
-		filter_rate_ = integrate(filter_rate_, filter_accel_, time_step);
-		filter_state_ = integrate(filter_state_, filter_rate_, time_step);
 	}
 
 	/**

--- a/src/lib/mathlib/math/filter/second_order_reference_model.hpp
+++ b/src/lib/mathlib/math/filter/second_order_reference_model.hpp
@@ -35,6 +35,10 @@
  * @file second_order_reference_model.hpp
  *
  * @brief Implementation of a second order system with optional rate feed-forward.
+ * Note that sample time abstraction is not done here. Users should run the filter
+ * at a sufficiently fast rate to achieve the continuous time performance described
+ * by the natural frequency and damping ratio parameters. Tuning of these parameters
+ * will only maintain a given performance for the sampled time for which it was tuned.
  *
  * @author Thomas Stastny <thomas.stastny@auterion.com>
  */
@@ -77,18 +81,18 @@ public:
 	{
 		if (natural_freq < FLT_EPSILON || damping_ratio < FLT_EPSILON) {
 
-			// deadzone the resulting constants (will result in zero filter acceleration)
+			// Deadzone the resulting constants (will result in zero filter acceleration)
 			spring_constant_ = 0.0f;
 			damping_coefficient_ = 0.0f;
 
-			// zero natural frequency means our time step is irrelevant
+			// Zero natural frequency means our time step is irrelevant
 			max_time_step_ = INFINITY;
 
-			// fail
+			// Fail
 			return false;
 		}
 
-		// note these are "effective" coefficients, as mass coefficient is considered baked in
+		// Note these are "effective" coefficients, as mass coefficient is considered baked in
 		spring_constant_ = natural_freq * natural_freq;
 		damping_coefficient_ = 2.0f * damping_ratio * natural_freq;
 

--- a/src/lib/mathlib/math/test/second_order_reference_model_test.cpp
+++ b/src/lib/mathlib/math/test/second_order_reference_model_test.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 ECL Development Team. All rights reserved.
+ *   Copyright (c) 2022 ECL Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/lib/mathlib/math/test/second_order_reference_model_test.cpp
+++ b/src/lib/mathlib/math/test/second_order_reference_model_test.cpp
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 ECL Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file second_order_reference_model_test.cpp
+ *
+ * @brief Unit tests for the second order reference model implementation
+ */
+
+#include <gtest/gtest.h>
+#include <matrix/math.hpp>
+#include <lib/mathlib/math/filter/second_order_reference_model.hpp>
+
+using matrix::Vector3f;
+
+TEST(SecondOrderReferenceModel, FloatDefaultConstructorInitializesStatesToZero)
+{
+	SecondOrderReferenceModel<float> sys_float;
+
+	// default constructor leaves states initialized to zero
+	EXPECT_FLOAT_EQ(sys_float.getState(), 0.0f);
+	EXPECT_FLOAT_EQ(sys_float.getRate(), 0.0f);
+	EXPECT_FLOAT_EQ(sys_float.getAccel(), 0.0f);
+}
+
+TEST(SecondOrderReferenceModel, FloatReset)
+{
+	SecondOrderReferenceModel<float> sys_float;
+
+	// reset the system states
+	float init_state = 3.0f;
+	float init_rate = 1.1f;
+	sys_float.reset(init_state, init_rate);
+	EXPECT_FLOAT_EQ(sys_float.getState(), init_state);
+	EXPECT_FLOAT_EQ(sys_float.getRate(), init_rate);
+	EXPECT_FLOAT_EQ(sys_float.getAccel(), 0.0f);
+
+	// reset the system without providing rate
+	init_state = 5.5f;
+	sys_float.reset(init_state);
+	EXPECT_FLOAT_EQ(sys_float.getState(), init_state);
+	EXPECT_FLOAT_EQ(sys_float.getRate(), 0.0f);
+	EXPECT_FLOAT_EQ(sys_float.getAccel(), 0.0f);
+}
+
+TEST(SecondOrderReferenceModel, Vector3DefaultConstructorInitializesStatesToZero)
+{
+	SecondOrderReferenceModel<Vector3f> sys_vector3f;
+
+	// default constructor leaves states initialized to zero
+	Vector3f state = sys_vector3f.getState();
+	EXPECT_FLOAT_EQ(state(0), 0.0f);
+	EXPECT_FLOAT_EQ(state(1), 0.0f);
+	EXPECT_FLOAT_EQ(state(2), 0.0f);
+	Vector3f rate = sys_vector3f.getRate();
+	EXPECT_FLOAT_EQ(rate(0), 0.0f);
+	EXPECT_FLOAT_EQ(rate(1), 0.0f);
+	EXPECT_FLOAT_EQ(rate(2), 0.0f);
+	Vector3f accel = sys_vector3f.getAccel();
+	EXPECT_FLOAT_EQ(accel(0), 0.0f);
+	EXPECT_FLOAT_EQ(accel(1), 0.0f);
+	EXPECT_FLOAT_EQ(accel(2), 0.0f);
+}
+
+TEST(SecondOrderReferenceModel, Vector3Reset)
+{
+	SecondOrderReferenceModel<Vector3f> sys_vector3f;
+
+	// reset the system states
+	Vector3f init_state(1.0f, 2.0f, 3.0f);
+	Vector3f init_rate(0.1f, 0.2f, 0.3f);
+	sys_vector3f.reset(init_state, init_rate);
+	Vector3f state = sys_vector3f.getState();
+	EXPECT_FLOAT_EQ(state(0), init_state(0));
+	EXPECT_FLOAT_EQ(state(1), init_state(1));
+	EXPECT_FLOAT_EQ(state(2), init_state(2));
+	Vector3f rate = sys_vector3f.getRate();
+	EXPECT_FLOAT_EQ(rate(0), init_rate(0));
+	EXPECT_FLOAT_EQ(rate(1), init_rate(1));
+	EXPECT_FLOAT_EQ(rate(2), init_rate(2));
+	Vector3f accel = sys_vector3f.getAccel();
+	EXPECT_FLOAT_EQ(accel(0), 0.0f);
+	EXPECT_FLOAT_EQ(accel(1), 0.0f);
+	EXPECT_FLOAT_EQ(accel(2), 0.0f);
+
+	// reset the system without providing rate
+	init_state = Vector3f(4.0f, 5.0f, 6.0f);
+	sys_vector3f.reset(init_state);
+	state = sys_vector3f.getState();
+	EXPECT_FLOAT_EQ(state(0), init_state(0));
+	EXPECT_FLOAT_EQ(state(1), init_state(1));
+	EXPECT_FLOAT_EQ(state(2), init_state(2));
+	rate = sys_vector3f.getRate();
+	EXPECT_FLOAT_EQ(rate(0), 0.0f);
+	EXPECT_FLOAT_EQ(rate(1), 0.0f);
+	EXPECT_FLOAT_EQ(rate(2), 0.0f);
+	accel = sys_vector3f.getAccel();
+	EXPECT_FLOAT_EQ(accel(0), 0.0f);
+	EXPECT_FLOAT_EQ(accel(1), 0.0f);
+	EXPECT_FLOAT_EQ(accel(2), 0.0f);
+}

--- a/src/lib/mathlib/math/test/second_order_reference_model_test.cpp
+++ b/src/lib/mathlib/math/test/second_order_reference_model_test.cpp
@@ -41,6 +41,7 @@
 #include <matrix/math.hpp>
 #include <lib/mathlib/math/filter/second_order_reference_model.hpp>
 
+using math::SecondOrderReferenceModel;
 using matrix::Vector3f;
 
 TEST(SecondOrderReferenceModel, FloatDefaultConstructorInitializesStatesToZero)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Reference models can be used as filters which exhibit a particular, chosen (reference) dynamic behavior. This PR implements a simple second order transfer function which can be used as such a reference model, additionally with rate feedback. The system is parameterized by explicitly set natural frequency and damping ratio. Another nice feature is that the output state and rate are kinematically consistent.

This PR doesn't use this filter in an application just yet.. but there are some future PR's in the pipeline which will benefit from this filter formulation. Example applications: Input filter for attitude / rate commands before reaching the attitude / rate controllers, respectively. Smoothing out airspeed estimates with aid from accelerometer measurements (I believe this is even happening in its own implementation in TECS currently).

Block diagram:
![second-order-reference-model drawio](https://user-images.githubusercontent.com/8026163/155315315-a85990c9-7858-4682-b1b9-91d49793f50a.png)

**Describe possible alternatives**
Why not just use a regular delayed second order filter? Using the rate feedback aids tracking if it is available. If one does not have such feedback, the filter will still work as a 2nd order system with zero-rate setpoint.

A method within the class which could be extended / improved is the integration function. ATM is a simple forward Euler step, assuming whoever uses this filter runs it fast enough for this to be ok.

**Test data / coverage**
As can be seen from the plots below, the filter running without rate feedback has noticeable delay w.r.t. the raw (noisier) inputs. These raw data here was generated by integrating some random walk accelerations twice.
![vel_plot_2nd_o_filt](https://user-images.githubusercontent.com/8026163/155226193-67cc49e7-5478-439f-b4b9-97a88cc76648.png)
![pos_plot_2nd_o_filt](https://user-images.githubusercontent.com/8026163/155226191-2200accb-0188-43b0-a66a-a942200a0c89.png)

Unit tests are also included in this PR. If there are some other specific unit test cases to add, please let me know. Further open to any alterations for generality (e.g. continuous -> discrete time considerations, naming, additional parameter inputs, etc).

TODO:
- [x] convert to discrete (bilinear transform) formulation