### PR TITLE
Angle unwrapping method

### DIFF
--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -124,16 +124,32 @@ Type wrap_2pi(Type x)
 }
 
 /**
- * Unwrap angles
+ * Unwrap value that was wrapped with range [low, high)
+ *
+ * @param[in] last_x Last unwrapped value
+ * @param[in] new_x New value in range
+ * @param low lower limit of the wrapping range
+ * @param high upper limit of the wrapping range
+ * @return New unwrapped value
+ */
+template<typename Type>
+Type unwrap(const Type last_x, const Type new_x, const Type low, const Type high)
+{
+	return last_x + wrap(new_x - last_x, low, high);
+}
+
+/**
+ * Unwrap value with range [-π, π)
  *
  * @param[in] last_angle Last unwrapped angle [rad]
  * @param[in] new_angle New angle in [-pi, pi] [rad]
+ * @param
  * @return New unwrapped angle [rad]
  */
 template<typename Type>
-Type unwrap(const Type last_angle, const Type new_angle)
+Type unwrap_pi(const Type last_angle, const Type new_angle)
 {
-	return last_angle + wrap_pi(new_angle - last_angle);
+	return unwrap(last_angle, new_angle, Type(-M_PI), Type(M_PI));
 }
 
 template<typename T>

--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -133,15 +133,7 @@ Type wrap_2pi(Type x)
 template<typename Type>
 Type unwrap(const Type last_angle, const Type new_angle)
 {
-	// wrap the last angle in [-pi,pi]
-	const Type last_angle_wrapped = matrix::detail::wrap_floating(last_angle, -Type(M_PI), Type(M_PI));
-
-	// use the shortest distance
-	Type delta = new_angle - last_angle_wrapped;
-	delta += ((delta < -Type(M_PI)) - (delta > Type(M_PI))) * Type(2 *
-			M_PI); // adds or subtracts 2*pi if delta out of range
-
-	return delta + last_angle;
+	return last_angle + wrap_pi(new_angle - last_angle);
 }
 
 template<typename T>

--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -123,6 +123,27 @@ Type wrap_2pi(Type x)
 	return wrap(x, Type(0), Type(M_TWOPI));
 }
 
+/**
+ * Unwrap angles
+ *
+ * @param[in] last_angle Last unwrapped angle [rad]
+ * @param[in] new_angle New angle in [-pi, pi] [rad]
+ * @return New unwrapped angle [rad]
+ */
+template<typename Type>
+Type unwrap(const Type last_angle, const Type new_angle)
+{
+	// wrap the last angle in [-pi,pi]
+	const Type last_angle_wrapped = matrix::detail::wrap_floating(last_angle, -Type(M_PI), Type(M_PI));
+
+	// use the shortest distance
+	Type delta = new_angle - last_angle_wrapped;
+	delta += ((delta < -Type(M_PI)) - (delta > Type(M_PI))) * Type(2 *
+			M_PI); // adds or subtracts 2*pi if delta out of range
+
+	return delta + last_angle;
+}
+
 template<typename T>
 int sign(T val)
 {

--- a/src/lib/matrix/test/CMakeLists.txt
+++ b/src/lib/matrix/test/CMakeLists.txt
@@ -44,3 +44,4 @@ foreach(test_name ${tests})
 endforeach()
 
 px4_add_unit_gtest(SRC sparseVector.cpp)
+px4_add_unit_gtest(SRC unwrap.cpp)

--- a/src/lib/matrix/test/unwrap.cpp
+++ b/src/lib/matrix/test/unwrap.cpp
@@ -19,7 +19,7 @@ TEST(Unwrap, UnwrapFloats)
 	float last_angle = wrapped_angles[0];
 
 	for (int i = 1; i < 6; i++) {
-		last_angle = unwrap(last_angle, wrapped_angles[i]);
+		last_angle = unwrap_pi(last_angle, wrapped_angles[i]);
 		EXPECT_FLOAT_EQ(last_angle, unwrapped_angles[i]);
 	}
 
@@ -27,7 +27,7 @@ TEST(Unwrap, UnwrapFloats)
 	last_angle = -wrapped_angles[0];
 
 	for (int i = 1; i < 6; i++) {
-		last_angle = unwrap(last_angle, -wrapped_angles[i]);
+		last_angle = unwrap_pi(last_angle, -wrapped_angles[i]);
 		EXPECT_FLOAT_EQ(last_angle, -unwrapped_angles[i]);
 	}
 }
@@ -48,7 +48,7 @@ TEST(Unwrap, UnwrapDoubles)
 	double last_angle = wrapped_angles[0];
 
 	for (int i = 1; i < 6; i++) {
-		last_angle = unwrap(last_angle, wrapped_angles[i]);
+		last_angle = unwrap_pi(last_angle, wrapped_angles[i]);
 		EXPECT_DOUBLE_EQ(last_angle, unwrapped_angles[i]);
 	}
 
@@ -56,7 +56,7 @@ TEST(Unwrap, UnwrapDoubles)
 	last_angle = -wrapped_angles[0];
 
 	for (int i = 1; i < 6; i++) {
-		last_angle = unwrap(last_angle, -wrapped_angles[i]);
+		last_angle = unwrap_pi(last_angle, -wrapped_angles[i]);
 		EXPECT_DOUBLE_EQ(last_angle, -unwrapped_angles[i]);
 	}
 }

--- a/src/lib/matrix/test/unwrap.cpp
+++ b/src/lib/matrix/test/unwrap.cpp
@@ -1,0 +1,62 @@
+#include <matrix/math.hpp>
+#include <gtest/gtest.h>
+
+using namespace matrix;
+
+TEST(Unwrap, UnwrapFloats)
+{
+	const float M_TWO_PI_F = float(M_PI * 2);
+
+	float unwrapped_angles[6] = {0.0, 0.25, 0.5, 0.75, 1.0, 1.25};
+	float wrapped_angles[6] = {0.0, 0.25, 0.5, -0.25, 0.0, 0.25};
+
+	for (int i = 0; i < 6; i++) {
+		unwrapped_angles[i] *= M_TWO_PI_F;
+		wrapped_angles[i] *= M_TWO_PI_F;
+	}
+
+	// positive unwrapping
+	float last_angle = wrapped_angles[0];
+
+	for (int i = 1; i < 6; i++) {
+		last_angle = unwrap(last_angle, wrapped_angles[i]);
+		EXPECT_FLOAT_EQ(last_angle, unwrapped_angles[i]);
+	}
+
+	// negative unwrapping
+	last_angle = -wrapped_angles[0];
+
+	for (int i = 1; i < 6; i++) {
+		last_angle = unwrap(last_angle, -wrapped_angles[i]);
+		EXPECT_FLOAT_EQ(last_angle, -unwrapped_angles[i]);
+	}
+}
+
+TEST(Unwrap, UnwrapDoubles)
+{
+	const double M_TWO_PI = M_PI * 2;
+
+	double unwrapped_angles[6] = {0.0, 0.25, 0.5, 0.75, 1.0, 1.25};
+	double wrapped_angles[6] = {0.0, 0.25, 0.5, -0.25, 0.0, 0.25};
+
+	for (int i = 0; i < 6; i++) {
+		unwrapped_angles[i] *= M_TWO_PI;
+		wrapped_angles[i] *= M_TWO_PI;
+	}
+
+	// positive unwrapping
+	double last_angle = wrapped_angles[0];
+
+	for (int i = 1; i < 6; i++) {
+		last_angle = unwrap(last_angle, wrapped_angles[i]);
+		EXPECT_DOUBLE_EQ(last_angle, unwrapped_angles[i]);
+	}
+
+	// negative unwrapping
+	last_angle = -wrapped_angles[0];
+
+	for (int i = 1; i < 6; i++) {
+		last_angle = unwrap(last_angle, -wrapped_angles[i]);
+		EXPECT_DOUBLE_EQ(last_angle, -unwrapped_angles[i]);
+	}
+}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Angles occasionally need to not only be wrapped.. but also unwrapped. But there's no common library method for this yet on PX4. This PR adds one.

**Describe possible alternatives**
The function currently only considers angles.. and specifically in [-pi,pi], could be possible to generalize it for any unwrapping bounds. Open to suggestions.

Another point I briefly discussed with @bresch was that `matrix` lib seems like a strange place to have all these wrapping functions. I added this one here only to keep it grouped with the existing ones. Not sure how tedious it would be to move them to their own library.. or to e.g. `mathlib`.

**Test data / coverage**
Unit tests.

**Additional context**
Will likely be used in #18026. Very likely that there are other places in the code base now that could consolidate unwrapping functionality with this method.