### PR TITLE
Direction-based speed constraints for multirotors

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -76,17 +76,12 @@ void FlightTaskManualPosition::_scaleSticks()
 	FlightTaskManualAltitude::_scaleSticks();
 
 	Vector2f stick_xy = _sticks.getPositionExpo().slice<2, 1>(0, 0);
+
+	Sticks::limitStickUnitLengthXY(stick_xy);
 	stick_xy(1) *= math::constrain(_param_mpc_vel_lat_sc.get(), 0.01f, 1.f);
 
 	if (stick_xy(0) < 0.f) {
 		stick_xy(0) *= math::constrain(_param_mpc_vel_back_sc.get(), 0.01f, 1.f);
-	}
-
-	/* Constrain length of stick inputs to 1 for xy */
-	const float mag = math::constrain(stick_xy.length(), 0.0f, 1.0f);
-
-	if (mag > 1.f) {
-		stick_xy = stick_xy / mag;
 	}
 
 	const float max_speed_from_estimator = _sub_vehicle_local_position.get().vxy_max;

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -78,6 +78,10 @@ void FlightTaskManualPosition::_scaleSticks()
 	Vector2f stick_xy = _sticks.getPositionExpo().slice<2, 1>(0, 0);
 	stick_xy(1) *= math::constrain(_param_mpc_vel_lat_sc.get(), 0.01f, 1.f);
 
+	if (stick_xy(0) < 0.f) {
+		stick_xy(0) *= math::constrain(_param_mpc_vel_back_sc.get(), 0.01f, 1.f);
+	}
+
 	/* Constrain length of stick inputs to 1 for xy */
 	const float mag = math::constrain(stick_xy.length(), 0.0f, 1.0f);
 

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -75,13 +75,14 @@ void FlightTaskManualPosition::_scaleSticks()
 	/* Use same scaling as for FlightTaskManualAltitude */
 	FlightTaskManualAltitude::_scaleSticks();
 
-	/* Constrain length of stick inputs to 1 for xy*/
 	Vector2f stick_xy = _sticks.getPositionExpo().slice<2, 1>(0, 0);
+	stick_xy(1) *= math::constrain(_param_mpc_vel_lat_sc.get(), 0.01f, 1.f);
 
+	/* Constrain length of stick inputs to 1 for xy */
 	const float mag = math::constrain(stick_xy.length(), 0.0f, 1.0f);
 
-	if (mag > FLT_EPSILON) {
-		stick_xy = stick_xy.normalized() * mag;
+	if (mag > 1.f) {
+		stick_xy = stick_xy / mag;
 	}
 
 	const float max_speed_from_estimator = _sub_vehicle_local_position.get().vxy_max;

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -66,6 +66,7 @@ protected:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualAltitude,
 					(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,
 					(ParamFloat<px4::params::MPC_VEL_LAT_SC>) _param_mpc_vel_lat_sc,
+					(ParamFloat<px4::params::MPC_VEL_BACK_SC>) _param_mpc_vel_back_sc,
 					(ParamFloat<px4::params::MPC_ACC_HOR_MAX>) _param_mpc_acc_hor_max,
 					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) _param_mpc_hold_max_xy
 				       )

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -65,6 +65,7 @@ protected:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualAltitude,
 					(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,
+					(ParamFloat<px4::params::MPC_VEL_LAT_SC>) _param_mpc_vel_lat_sc,
 					(ParamFloat<px4::params::MPC_ACC_HOR_MAX>) _param_mpc_acc_hor_max,
 					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) _param_mpc_hold_max_xy
 				       )

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -83,6 +83,10 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 	Sticks::limitStickUnitLengthXY(stick_xy);
 	stick_xy(1) *= math::constrain(_param_mpc_vel_lat_sc.get(), 0.01f, 1.f);
 
+	if (stick_xy(0) < 0.f) {
+		stick_xy(0) *= math::constrain(_param_mpc_vel_back_sc.get(), 0.01f, 1.f);
+	}
+
 	Sticks::rotateIntoHeadingFrameXY(stick_xy, yaw, yaw_sp);
 	_acceleration_setpoint = stick_xy.emult(acceleration_scale);
 	applyJerkLimit(dt);

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -81,6 +81,8 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 
 	// Map stick input to acceleration
 	Sticks::limitStickUnitLengthXY(stick_xy);
+	stick_xy(1) *= math::constrain(_param_mpc_vel_lat_sc.get(), 0.01f, 1.f);
+
 	Sticks::rotateIntoHeadingFrameXY(stick_xy, yaw, yaw_sp);
 	_acceleration_setpoint = stick_xy.emult(acceleration_scale);
 	applyJerkLimit(dt);

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -81,6 +81,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,
+		(ParamFloat<px4::params::MPC_VEL_LAT_SC>) _param_mpc_vel_lat_sc,
 		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor,
 		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
 		(ParamFloat<px4::params::MPC_TILTMAX_AIR>) _param_mpc_tiltmax_air

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -82,6 +82,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,
 		(ParamFloat<px4::params::MPC_VEL_LAT_SC>) _param_mpc_vel_lat_sc,
+		(ParamFloat<px4::params::MPC_VEL_BACK_SC>) _param_mpc_vel_back_sc,
 		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_mpc_acc_hor,
 		(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
 		(ParamFloat<px4::params::MPC_TILTMAX_AIR>) _param_mpc_tiltmax_air

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -378,6 +378,20 @@ PARAM_DEFINE_FLOAT(MPC_VEL_MANUAL, 10.0f);
 PARAM_DEFINE_FLOAT(MPC_VEL_LAT_SC, 1.0f);
 
 /**
+ * Ratio between backward and forward maximum velocity
+ *
+ * The maximum backward speed is defined by:
+ * MPC_VEL_BACK_SC * MPC_VEL_MANUAL
+ *
+ * @min 0.1
+ * @max 1.0
+ * @increment 0.1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_VEL_BACK_SC, 1.0f);
+
+/**
  * Maximum horizontal velocity
  *
  * Maximum horizontal velocity in AUTO mode. If higher speeds

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -354,6 +354,9 @@ PARAM_DEFINE_FLOAT(MPC_XY_ERR_MAX, 2.0f);
  * If velocity setpoint larger than MPC_XY_VEL_MAX is set, then
  * the setpoint will be capped to MPC_XY_VEL_MAX
  *
+ * The maximum lateral and backward speed can be set as a fraction
+ * of this parameter using MPC_VEL_LAT_SC and MPC_VEL_BACK_SC, respectively.
+ *
  * @unit m/s
  * @min 3.0
  * @max 20.0

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -364,6 +364,20 @@ PARAM_DEFINE_FLOAT(MPC_XY_ERR_MAX, 2.0f);
 PARAM_DEFINE_FLOAT(MPC_VEL_MANUAL, 10.0f);
 
 /**
+ * Ratio between lateral and forward maximum velocity
+ *
+ * The maximum lateral speed is defined by:
+ * MPC_VEL_LAT_SC * MPC_VEL_MANUAL
+ *
+ * @min 0.1
+ * @max 1.0
+ * @increment 0.1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_VEL_LAT_SC, 1.0f);
+
+/**
  * Maximum horizontal velocity
  *
  * Maximum horizontal velocity in AUTO mode. If higher speeds


### PR DESCRIPTION
**Describe problem solved by this pull request**
Some drones such as VTOL planes are not symmetric and are not designed to fly at full speed on all directions. For example, a vertical stabilizer makes difficult to fly fast laterally and wings make it really difficult to fly backward.

**Describe your solution**
This PR introduces 2 parameters defining the maximum lateral (MPC_VEL_LAT_SC) and backward (MPC_VEL_BACK_SC) speed as a function of the maximum speed (MPC_VEL_MANUAL).

**Test data / coverage**
SITL + flight tests

Example with `MPC_VEL_MANUAL` = 10m/s, `MPC_VEL_LAT_SC` = 0.5 and `MPC_VEL_BACK_SC` = 0.2:
![DeepinScreenshot_select-area_20220218172313](https://user-images.githubusercontent.com/14822839/154724221-a643b140-f612-411b-b88f-e6bc7d7f4c72.png)

