### PR TITLE
mission_block: handle SET_ROI_LOCATION with absolute altitude correctly

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -538,16 +538,18 @@ MissionBlock::issue_command(const mission_item_s &item)
 		vcmd.param2 = item.params[1];
 		vcmd.param3 = item.params[2];
 		vcmd.param4 = item.params[3];
+		vcmd.param5 = static_cast<double>(item.params[4]);
+		vcmd.param6 = static_cast<double>(item.params[5]);
+		vcmd.param7 = item.params[6];
 
-		if (item.nav_cmd == NAV_CMD_DO_SET_ROI_LOCATION && item.altitude_is_relative) {
+		if (item.nav_cmd == NAV_CMD_DO_SET_ROI_LOCATION) {
+			// We need to send out the ROI location that was parsed potentially with double precision to lat/lon because mission item parameters 5 and 6 only have float precision
 			vcmd.param5 = item.lat;
 			vcmd.param6 = item.lon;
-			vcmd.param7 = item.altitude + _navigator->get_home_position()->alt;
 
-		} else {
-			vcmd.param5 = (double)item.params[4];
-			vcmd.param6 = (double)item.params[5];
-			vcmd.param7 = item.params[6];
+			if (item.altitude_is_relative) {
+				vcmd.param7 = item.altitude + _navigator->get_home_position()->alt;
+			}
 		}
 
 		_navigator->publish_vehicle_cmd(&vcmd);


### PR DESCRIPTION
**Describe problem solved by this pull request**
The mission item parameter handling and interpretation is a mess.
One of the nasty extra cases is the `CMD_DO_SET_ROI_LOCATION` which:
- Comes from outside as either [MISSION_ITEM](https://mavlink.io/en/messages/common.html#MISSION_ITEM) or [MISSION_ITEM_INT](https://mavlink.io/en/messages/common.html#MISSION_ITEM_INT) with either double or single precision latitude, longitude (or even a different coordinate frame).
- Is parsed into an internal mission item which only has single precision parameters 5,6. But contains double-precision lat, lon fields.
- Needs to be sent out again to either vmount or and external gimbal/payload manager via vehicle command and possibly the correct MAVLink command.

Improved handling for this case was added by @potaito  in https://github.com/PX4/PX4-Autopilot/pull/9781 but it does not work for coordinates with an absolute altitude in my eyes just because of how the existing conditions were reused.

**Describe your solution**
I'm separating the conditions handling the correct horizontal coordinates and the relative altitude.

**Describe possible alternatives**
I suggest we clearly define if the content of a mission item is completely interpreted or not e.g. has either params or lat, lon and then handle all commands in a consistent way calling the same respective conversions depending on:
- command long/int
- normal parameters
- coordinates with 1e7
- coordinates with 1e4

**Test data / coverage**
Untested. Tests by @leonardosimovic will follow.