### PR TITLE
Added RTL Switch Setting for ATL Mantis Edu

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -164,6 +164,8 @@ param set-default RC_MAP_AUX2       5
 param set-default RC_MAP_AUX3       10
 param set-default RC_MAP_AUX4       8
 param set-default RC_MAP_FLTMODE    6
+param set-default RC_MAP_RETURN_SW  7
+
 param set-default RC1_TRIM          1000
 
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously there was no setting for the RTL Switch, so the Return to Launch button wasn't working.

**Describe your solution**
Added RC_MAP_RETURN_SW param to 7 (Channel 7 of the RC controller)

**Test data / coverage**
Haven't tested yet
