### PR TITLE
Add Flaperons to VTOL and back transition - WIP

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -442,13 +442,13 @@ void Standard::fill_actuator_outputs()
 
 	_thrust_setpoint_0->timestamp = hrt_absolute_time();
 	_thrust_setpoint_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
-	_thrust_setpoint_0->xyz[0] = 0.f;
+	_thrust_setpoint_0->xyz[0] = fw_out[actuator_controls_s::INDEX_THROTTLE];
 	_thrust_setpoint_0->xyz[1] = 0.f;
 	_thrust_setpoint_0->xyz[2] = -mc_out[actuator_controls_s::INDEX_THROTTLE];
 
 	_thrust_setpoint_1->timestamp = hrt_absolute_time();
 	_thrust_setpoint_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
-	_thrust_setpoint_1->xyz[0] = fw_out[actuator_controls_s::INDEX_THROTTLE];
+	_thrust_setpoint_1->xyz[0] = 0.f;
 	_thrust_setpoint_1->xyz[1] = 0.f;
 	_thrust_setpoint_1->xyz[2] = 0.f;
 

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -73,6 +73,7 @@ private:
 		float pitch_setpoint_offset;
 		float reverse_output;
 		float reverse_delay;
+		float use_vtol_flaperons;
 	} _params_standard;
 
 	struct {
@@ -81,6 +82,7 @@ private:
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
 		param_t reverse_delay;
+		param_t use_vtol_flaperons;
 	} _params_handles_standard;
 
 	enum class vtol_mode {
@@ -97,6 +99,7 @@ private:
 
 	float _pusher_throttle{0.0f};
 	float _reverse_output{0.0f};
+	float _use_vtol_flaperons{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
 
 	void parameters_update() override;

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -87,10 +87,25 @@ PARAM_DEFINE_FLOAT(VT_FWD_THRUST_SC, 0.7f);
 PARAM_DEFINE_FLOAT(VT_B_TRANS_RAMP, 3.0f);
 
 /**
- * Output on airbrakes channel during back transition
+ * Option for use of Flaperons on back transition.
+ *
+ * Used for enabling Flaperons during a back transition.
+ * Flaps and Airbrakes need to be enabled for your selected model/mixer
+ *
+ * @min 0
+ * @max 1
+ * @increment 0.01
+ * @decimal 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_B_FL_USE, 1.0f);
+
+
+/**
+ * Output on spoilerons channel during back transition
  *
  * Used for airbrakes or with ESCs that have reverse thrust enabled on a seperate channel
- * Airbrakes need to be enables for your selected model/mixer
+ * Spoilerons need to be enabled for your selected model/mixer
  *
  * @min 0
  * @max 1


### PR DESCRIPTION
WIP:


This adds Flaperon functionality to VTOLs when in FW flight as well as auto deploys them during back transition.

Flaperons must be configured in your mixer (flaps and airbrakes). If only flaps are configured then it will just deploy flaps.

Flaps were added to VTOL attitude control group since that was omitted in the VTOL attitude control group.

Reverse thrust had to be moved from airbrakes to spoilerons index.

Added a parameter to control flaperon usage. It only controls the airbrake channel (ailerons up). If disabled only the ailerons will not deploy, flaps would still go down (this should be thought about and potentially changed).


To Do:

- [ ] Update mixers that use airbrakes with VTOL and reverse thrust
- [ ] New SITL model is needed for SITL testing. Flaps and ailerons need to be present.
- [ ] Test reverse thrust and flaperon deployment work at the same time (edge case but should be able to be possible)
- [x] Test flaperons work in non-auto mode during FW flight
- [ ] Check if there are control allocation implications (new mixer management)
- [ ] Ensure parameter does disable ailerons up