### PR TITLE
Pr skip vtol takeoff when in fw mode

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -424,7 +424,7 @@ Mission::find_mission_land_start_and_first_fw_waypoint()
 
 	bool found_land_start_marker = false;
 
-	for (size_t i = 1; i < _mission.count; i++) {
+	for (size_t i = 0; i < _mission.count; i++) {
 		const ssize_t len = sizeof(missionitem);
 		missionitem_prev = missionitem; // store the last mission item before reading a new one
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -208,6 +208,15 @@ Mission::on_activation()
 	cmd.param1 = -1.0f;
 	cmd.param3 = 0.0f;
 	_navigator->publish_vehicle_cmd(&cmd);
+
+	if (_navigator->get_vstatus()->is_vtol
+	    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		// if we are already in fixed wing flight then make sure that the current active waypoint
+		// is after the transition to forward flight waypoint
+		if (_first_fixed_wing_waypoint_index > 0 && _current_mission_index < _first_fixed_wing_waypoint_index) {
+			set_current_mission_index(_first_fixed_wing_waypoint_index);
+		}
+	}
 }
 
 void
@@ -585,8 +594,8 @@ Mission::update_mission()
 		// if we are already in fixed wing flight then make sure that the current active waypoint
 		// is after the transition to forward flight waypoint
 
-		if (_current_mission_index < _first_fixed_wing_waypoint_index) {
-			_current_mission_index = _first_fixed_wing_waypoint_index;
+		if (_first_fixed_wing_waypoint_index > 0 && _current_mission_index < _first_fixed_wing_waypoint_index) {
+			set_current_mission_index(_first_fixed_wing_waypoint_index);
 		}
 
 	}

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -221,9 +221,9 @@ private:
 	bool need_to_reset_mission();
 
 	/**
-	 * Find and store the index of the landing sequence (DO_LAND_START)
+	 * Find and store the index of the landing sequence (DO_LAND_START) and the index of the first fixed wing waypoint after vtol transition.
 	 */
-	bool find_mission_land_start();
+	void find_mission_land_start_and_first_fw_waypoint();
 
 	/**
 	 * Return the index of the closest mission item to the current global position.
@@ -253,6 +253,8 @@ private:
 	double _landing_start_lat{0.0};
 	double _landing_start_lon{0.0};
 	float _landing_start_alt{0.0f};
+
+	int _first_fixed_wing_waypoint_index{-1};	// index of the first position waypoint after a transition to forward flight, < 0 is invalid
 
 	double _landing_lat{0.0};
 	double _landing_lon{0.0};


### PR DESCRIPTION
**Describe problem solved by this pull request**
When activating or uploading a new mission containing a VTOL takeoff while the vehicle is already in fixed wing mode, the current mission index is usually pointing to the VTOL Takeoff. This causes the vehicle to fly to the VTOL takeoff waypoint at the transition altitude which might be very low.

**Describe your solution**
When activating a VTOL mission while already in FW mode make sure that the mission index is >= the first position item after the vtol takeoff waypoint.

**Test data / coverage**
Mainly tested in SITL. We are going to conduct outdoor flying this afternoon.

