### PR TITLE
commander: allow rearming grace period for arming switch only

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -677,7 +677,8 @@ static constexpr const char *main_state_str(uint8_t main_state)
 transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_preflight_checks)
 {
 	// allow a grace period for re-arming: preflight checks don't need to pass during that time, for example for accidential in-air disarming
-	if (_param_com_rearm_grace.get() && (hrt_elapsed_time(&_last_disarmed_timestamp) < 5_s)) {
+	if (calling_reason == arm_disarm_reason_t::rc_switch
+	    && (hrt_elapsed_time(&_last_disarmed_timestamp) < 5_s)) {
 		run_preflight_checks = false;
 	}
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -247,7 +247,6 @@ private:
 		(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_arm_mission_required,
 		(ParamBool<px4::params::COM_ARM_AUTH_REQ>) _param_arm_auth_required,
 		(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required,
-		(ParamBool<px4::params::COM_REARM_GRACE>) _param_com_rearm_grace,
 
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -679,16 +679,6 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_ANG, 45);
 PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 2);
 
 /**
- * Rearming grace period
- *
- * Re-arming grace allows to rearm the drone with manual command without running prearmcheck during 5 s after disarming.
- *
- * @group Commander
- * @boolean
- */
-PARAM_DEFINE_INT32(COM_REARM_GRACE, 1);
-
-/**
  * Enable RC stick override of auto and/or offboard modes
  *
  * When RC stick override is enabled, moving the RC sticks more than COM_RC_STICK_OV


### PR DESCRIPTION
**Describe problem solved by this pull request**
Immediate rearming after landing should not bypass all checks in normal operation. For example, the drone should not rearm if the user landed after a yaw emergency reset or a loss of navigation.
The grace period introduced in https://github.com/PX4/PX4-Autopilot/pull/9622/files is intended to allow the user to rearm the drone in air in case of an unintentional disarming using the arm switch.

**Describe your solution**
Use a grace period of 5s after disarm only if the drone is armed through the arm switch.

**Test data / coverage**
SITL tested