### PR TITLE
Typo Fix: pub.advertised() -> pub.advertise()

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -202,7 +202,7 @@ bool EKF2::multi_init(int imu, int mag)
 	_estimator_states_pub.advertise();
 	_estimator_status_flags_pub.advertise();
 	_estimator_status_pub.advertise();
-	_estimator_visual_odometry_aligned_pub.advertised();
+	_estimator_visual_odometry_aligned_pub.advertise();
 	_yaw_est_pub.advertise();
 
 	bool changed_instance = _vehicle_imu_sub.ChangeInstance(imu) && _magnetometer_sub.ChangeInstance(mag);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Based on the context, `_estimator_visual_odometry_aligned_pub` should call `advertise` API here, NOT `advertised`.
https://github.com/PX4/PX4-Autopilot/blob/3e21efb72147b349d5c3a389bbe70b705ccfd20d/src/modules/ekf2/EKF2.cpp#L204-L206
API `advertise` will generate a handle for the instance, thus ensure the consistentency of uORB instance number:
https://github.com/PX4/PX4-Autopilot/blob/5dbbddb13f1730d51c33c5a90d1042ba0a714241/platforms/common/uORB/PublicationMulti.hpp#L72-L80
While `advertised` only check whether the handle is null, without generate the handle:
https://github.com/PX4/PX4-Autopilot/blob/5dbbddb13f1730d51c33c5a90d1042ba0a714241/platforms/common/uORB/Publication.hpp#L73

**Describe your solution**
Replace `advertised` with `advertise`.

**Describe possible alternatives**
If this "typo" is kept with intention, please add extra comment to describe it.

**Test data / coverage**
Tested with `make px4_sitl jmavsim`, the flight is finished without problem.
Still we need additional test to check whether the publisher number is consistent with the EKF instance.
