### PR TITLE
rtl: don't fly mission landing if we trigger rtl in hover

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -592,7 +592,7 @@ void Navigator::run()
 				case RTL::RTL_TYPE_CLOSEST:
 
 					if (!rtl_activated && _rtl.getClimbAndReturnDone()
-					    && _rtl.getDestinationTypeMissionLanding()) {
+					    && _rtl.getShouldEngageMissionForLanding()) {
 						_mission.set_execution_mode(mission_result_s::MISSION_EXECUTION_MODE_FAST_FORWARD);
 
 						if (!getMissionLandingInProgress() && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -100,7 +100,7 @@ public:
 	void get_rtl_xy_z_speed(float &xy, float &z);
 	matrix::Vector2f get_wind();
 
-	bool getDestinationTypeMissionLanding() { return _destination.type == RTL_DESTINATION_MISSION_LANDING; }
+	bool getShouldEngageMissionForLanding() const { return _should_engange_mission_for_landing; }
 
 private:
 
@@ -162,6 +162,7 @@ private:
 
 	bool _climb_and_return_done{false};	// this flag is set to true if RTL is active and we are past the climb state and return state
 	bool _rtl_alt_min{false};
+	bool _should_engange_mission_for_landing{false};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::RTL_RETURN_ALT>)  _param_rtl_return_alt,


### PR DESCRIPTION
**Describe problem solved by this pull request**
RTL in hover mode if mission landing is available would go to the mission landing point but then it would navigate to the mission loiter point and get stuck there.
The reason was that navigator switched into mission mode as soon as the return segment was completed. This should only be done for fixed wing vehicles but not when RTL is triggered during hover.

**Describe your solution**
When RTL is triggered, figure out if mission landing is needed.

**Test data / coverage**
SITL

