### PR TITLE
mavlink: shell expand locking

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1333,18 +1333,20 @@ MavlinkShell *
 Mavlink::get_shell()
 {
 	if (!_mavlink_shell) {
-		_mavlink_shell = new MavlinkShell();
+		MavlinkShell *shell = new MavlinkShell();
 
-		if (!_mavlink_shell) {
+		if (!shell) {
 			PX4_ERR("Failed to allocate a shell");
 
 		} else {
-			int ret = _mavlink_shell->start();
+			int ret = shell->start();
 
-			if (ret != 0) {
+			if (ret == 0) {
+				_mavlink_shell = shell;
+
+			} else {
 				PX4_ERR("Failed to start shell (%i)", ret);
-				delete _mavlink_shell;
-				_mavlink_shell = nullptr;
+				delete shell;
 			}
 		}
 	}

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -148,13 +148,13 @@ int MavlinkShell::start()
 		close(fd_backups[i]);
 	}
 
-#ifdef __PX4_NUTTX
-	sched_unlock();
-#endif /* __PX4_NUTTX */
-
 	//close unused pipe fd's
 	close(_shell_fds[0]);
 	close(_shell_fds[1]);
+
+#ifdef __PX4_NUTTX
+	sched_unlock();
+#endif /* __PX4_NUTTX */
 
 	return ret;
 }


### PR DESCRIPTION
On some H7 boards (cuav x7pro tested)  there's an occasional hard fault when starting the mavlink shell. It stopped reproducing when I expanded the locking slightly, but I haven't identified the root cause. 