### PR TITLE
Sticks : Add utility functions to get pitch, roll, throttle and yaw values more intuitively

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -245,7 +245,7 @@ void FlightTaskAuto::_prepareLandSetpoints()
 	}
 
 	// User input assisted landing
-	if (_param_mpc_land_rc_help.get() && _sticks.checkAndSetStickInputs()) {
+	if (_param_mpc_land_rc_help.get() && _sticks.checkAndUpdateStickInputs()) {
 		// Stick full up -1 -> stop, stick full down 1 -> double the speed
 		vertical_speed *= (1 + _sticks.getPositionExpo()(2));
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -50,7 +50,7 @@ bool FlightTaskManualAltitude::updateInitialize()
 {
 	bool ret = FlightTask::updateInitialize();
 
-	_sticks.checkAndSetStickInputs();
+	_sticks.checkAndUpdateStickInputs();
 
 	if (_sticks_data_required) {
 		ret = ret && _sticks.isAvailable();

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -44,7 +44,7 @@ Sticks::Sticks(ModuleParams *parent) :
 	ModuleParams(parent)
 {}
 
-bool Sticks::checkAndSetStickInputs()
+bool Sticks::checkAndUpdateStickInputs()
 {
 	// Sticks are rescaled linearly and exponentially to [-1,1]
 	manual_control_setpoint_s manual_control_setpoint;

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -65,7 +65,7 @@ public:
 	// Helper functions to get stick values more intuitively
 	float getPitch() { return _positions(0); }
 	float getRoll() { return _positions(1); }
-	float getThrottle() { return _positions(2); }
+	float getThrottle() { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
 	float getYaw() { return _positions(3); }
 
 	/**

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -53,11 +53,20 @@ public:
 	Sticks(ModuleParams *parent);
 	~Sticks() = default;
 
-	bool checkAndSetStickInputs();
+	// Checks for updated manual control input & updates internal values
+	bool checkAndUpdateStickInputs();
+
 	bool isAvailable() { return _input_available; };
+
+	// Position : 0 : pitch, 1 : roll, 2 : throttle, 3 : yaw
 	const matrix::Vector<float, 4> &getPosition() { return _positions; };
 	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; };
 
+	// Helper functions to get stick values more intuitively
+	float getPitch() { return _positions(0); }
+	float getRoll() { return _positions(1); }
+	float getThrottle() { return _positions(2); }
+	float getYaw() { return _positions(3); }
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -65,7 +65,7 @@ public:
 	// Helper functions to get stick values more intuitively
 	float getPitch() const { return _positions(0); }
 	float getRoll() const { return _positions(1); }
-	float getThrottle() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
+	float getThrottleZeroCentered() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
 	float getYaw() const { return _positions(3); }
 
 	/**

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -63,10 +63,10 @@ public:
 	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; };
 
 	// Helper functions to get stick values more intuitively
-	float getPitch() { return _positions(0); }
-	float getRoll() { return _positions(1); }
-	float getThrottle() { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
-	float getYaw() { return _positions(3); }
+	float getPitch() const { return _positions(0); }
+	float getRoll() const { return _positions(1); }
+	float getThrottle() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
+	float getYaw() const { return _positions(3); }
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle


### PR DESCRIPTION
**Describe problem solved by this pull request**
'Sticks' utility library is used by Flight Tasks. While implementing a Follow-Target feature (#19260) with RC-controllable behavior, I found that **it is unclear as to which 'user input' each input vector corresponds to.**

**Describe your solution**
Added functions each returning user input values in a clear, intuitive naming.

+ Also renamed the 'checkAndSetStickInputs' function name to 'checkAndUpdateStickInputs', since 'set' doesn't imply that the stick values are update, which is the most important aspect of this function, thus avoiding possible confusions ;)