### PR TITLE
[Proposal] Manual Control Setpoint uORB message elements renaming

### DIFF
--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -22,23 +22,23 @@ uint8 data_source
 # The range for the z variable is defined from 0 to 1. (The z field of
 # the MANUAL_CONTROL mavlink message is defined from -1000 to 1000)
 
-float32 x			 # stick position in x direction -1..1
+float32 front			 # stick position in front(x axis) direction -1..1
 				 # in general corresponds to forward/back motion or pitch of vehicle,
 				 # in general a positive value means forward or negative pitch and
 				 # a negative value means backward or positive pitch
 
-float32 y			 # stick position in y direction -1..1
+float32 right			 # stick position in right(y axis) direction -1..1
 				 # in general corresponds to right/left motion or roll of vehicle,
 				 # in general a positive value means right or positive roll and
 				 # a negative value means left or negative roll
 
-float32 z			 # throttle stick position 0..1
+float32 throttle		 # throttle stick position 0..1
 				 # in general corresponds to up/down motion or thrust of vehicle,
 				 # in general the value corresponds to the demanded throttle by the user,
 				 # if the input is used for setting the setpoint of a vertical position
 				 # controller any value > 0.5 means up and any value < 0.5 means down
 
-float32 r			 # yaw stick/twist position, -1..1
+float32 twist			 # yaw stick/twist position, -1..1
 				 # in general corresponds to the righthand rotation around the vertical
 				 # (downwards) axis of the vehicle
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
You can refer to the [link here](https://github.com/PX4/PX4-Autopilot/blob/6ed48ad0c0bea36a1f94245962b4b6721553b310/src/modules/rc_update/rc_update.cpp#L669) : the 'manual_control_setpoint' uORB message gets published, which basically contains all the information received through the receiver regarding the commanded inputs.

**But, current naming is quite confusing, as the pitch, roll, throttle and yaw are each named as "x, y, z and y" in the message.**

As this is used everywhere around PX4 where manual input needs to be considered. So I think it doesn't make sense to keep the naming like x, y, z, r, but instead it should be named intuitively accordingly.

**Describe your solution**
Since it's actually quite nice to have 'general' name (for rover, roll and pitch wouldn't make much sense, what about naming them **"front, right, throttle and twist"** (like in this PR)?

**Describe possible alternatives**
Up for a discussion!

**Additional context**
@potaito did agree that it's not intuitive, but said he thought it's the way it is for a some unknown reason :shrug: 
