### PR TITLE
Reduce Beeepr Default volume since it's too loud in TAP_ESC devices

### DIFF
--- a/msg/tune_control.msg
+++ b/msg/tune_control.msg
@@ -33,7 +33,7 @@ uint32 silence       # in us
 uint8 volume         # value between 0-100 if supported by backend
 
 uint8 VOLUME_LEVEL_MIN = 0
-uint8 VOLUME_LEVEL_DEFAULT = 40
+uint8 VOLUME_LEVEL_DEFAULT = 20
 uint8 VOLUME_LEVEL_MAX = 100
 
 uint8 ORB_QUEUE_LENGTH = 4


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently, all devices using [TAP_ESC driver](https://github.com/PX4/PX4-Autopilot/tree/master/src/drivers/tap_esc) is too loud (e.g. Mantis drone when it starts up, it's so loud that everyone in the room stops what they are doing :flushed:), with the default volume 40.

**Describe your solution**
**This PR sets the default volume to 20, and this only affects TAP_ESC driver using devices, because on other buzzer drivers, they do not take the volume element in the "tune_control" message into account.** So it only affects the devices with the TAP_ESC, and they are all too loud due to this volume setting.

**Describe possible alternatives**
We could add a 'System wide Volume' parameter, but that would be meaningless because the only use case for this parameter would be vehicles using the TAP_ESC, which is only a small portion of the PX4 Ecosystem.
