### PR TITLE
Bug Fix: IMU_INTEG_RATE can greater than IMU_GYRO_RATEMAX

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -147,7 +147,7 @@ bool VehicleIMU::ParametersUpdate(bool force)
 
 		// constrain IMU integration time 1-20 milliseconds (50-1000 Hz)
 		int32_t imu_integration_rate_hz = constrain(_param_imu_integ_rate.get(),
-						  (int32_t)50, math::max(_param_imu_gyro_ratemax.get(), (int32_t) 1000));
+						  (int32_t)50, math::min(_param_imu_gyro_ratemax.get(), (int32_t) 1000));
 
 		if (imu_integration_rate_hz != _param_imu_integ_rate.get()) {
 			PX4_WARN("IMU_INTEG_RATE updated %" PRId32 " -> %" PRIu32, _param_imu_integ_rate.get(), imu_integration_rate_hz);


### PR DESCRIPTION
**Describe problem solved by this pull request**
A caveat in `VehicleIMU.cpp` that allows `IMU_INTEG_RATE > IMU_GYRO_RATEMAX`.
https://github.com/PX4/PX4-Autopilot/blob/58a4c38519498888679e3d81c7e6c85ae860dfa8/src/modules/sensors/vehicle_imu/VehicleIMU.cpp#L148-L150

Even we allow that happen, it's function still inconsistent with the comment if `IMU_GYRO_RATEMAX` is set to 2000 Hz.
(Here is a [ref](https://github.com/PX4/PX4-Autopilot/blob/5ded1aedcb0d429cce55fa9138c6acabcaa37ed7/src/modules/sensors/vehicle_angular_velocity/imu_gyro_parameters.c#L85-L105) for 'IMU_GYRO_RATEMAX')

And the line would become:
```
// constrain IMU integration time 1-20 milliseconds (50-1000 Hz)
int32_t imu_integration_rate_hz = constrain(_param_imu_integ_rate.get(), (int32_t)50, (int32_t) 2000);
```


This PR is intended to solve this problem.

**Describe your solution**
Replacing the `math::max` with `math::min`.

**Describe possible alternatives**
Use `constrain(_param_imu_integ_rate.get(), (int32_t)50, (int32_t) 1000)` instead.
If we allow `IMU_INTEG_RATE` greater than `IMU_GYRO_RATEMAX`, and want to keep it below 1000 Hz, 

**Test data / coverage**
Havn't test it yet, but I expect this minor revise won't cause any problem.
