### PR TITLE
drivers/imu/bosch: run accels at max rate rather than IMU_GYRO_RATEMAX

### DIFF
--- a/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055_Accelerometer.cpp
@@ -48,7 +48,7 @@ BMI055_Accelerometer::BMI055_Accelerometer(const I2CSPIDriverConfig &config) :
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_accel: DRDY missed");
 	}
 
-	ConfigureSampleRate(_px4_accel.get_max_rate_hz());
+	ConfigureSampleRate(RATE);
 }
 
 BMI055_Accelerometer::~BMI055_Accelerometer()

--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
@@ -48,7 +48,7 @@ BMI088_Accelerometer::BMI088_Accelerometer(const I2CSPIDriverConfig &config) :
 		_drdy_missed_perf = perf_alloc(PC_COUNT, MODULE_NAME"_accel: DRDY missed");
 	}
 
-	ConfigureSampleRate(_px4_accel.get_max_rate_hz());
+	ConfigureSampleRate(RATE);
 }
 
 BMI088_Accelerometer::~BMI088_Accelerometer()

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -35,7 +35,6 @@
 #include "PX4Accelerometer.hpp"
 
 #include <lib/drivers/device/Device.hpp>
-#include <lib/parameters/param.h>
 
 using namespace time_literals;
 
@@ -72,8 +71,6 @@ PX4Accelerometer::PX4Accelerometer(uint32_t device_id, enum Rotation rotation) :
 {
 	// advertise immediately to keep instance numbering in sync
 	_sensor_pub.advertise();
-
-	param_get(param_find("IMU_GYRO_RATEMAX"), &_imu_gyro_rate_max);
 }
 
 PX4Accelerometer::~PX4Accelerometer()

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -48,8 +48,6 @@ public:
 
 	uint32_t get_device_id() const { return _device_id; }
 
-	int32_t get_max_rate_hz() const { return math::constrain(_imu_gyro_rate_max, static_cast<int32_t>(100), static_cast<int32_t>(4000)); }
-
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);
 	void set_error_count(uint32_t error_count) { _error_count = error_count; }
@@ -72,8 +70,6 @@ private:
 
 	uint32_t		_device_id{0};
 	const enum Rotation	_rotation;
-
-	int32_t			_imu_gyro_rate_max{0}; // match gyro max rate
 
 	float			_range{16 * CONSTANTS_ONE_G};
 	float			_scale{1.f};


### PR DESCRIPTION
The BMI055 and BMI088 IMU are effectively separate accel + gyro that have different output data rates and slightly different clocks. By running the accelerometer at the max rate (BMI055 1600 Hz, BMI088 2000 Hz) it provides more granularity for the downstream IMU integration that's driven by the gyro with accel added integrated as closely as possible. 