### PR TITLE
ekf2: initialize GPS drift metrics to NAN rather than 0

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -349,9 +349,9 @@ protected:
 
 	bool _deadreckon_time_exceeded{true};	// true if the horizontal nav solution has been deadreckoning for too long and is invalid
 
-	float _gps_horizontal_position_drift_rate_m_s{0}; // Horizontal position drift rate (m/s)
-	float _gps_vertical_position_drift_rate_m_s{0};   // Vertical position drift rate (m/s)
-	float _gps_filtered_horizontal_velocity_m_s{0};   // Filtered horizontal velocity (m/s)
+	float _gps_horizontal_position_drift_rate_m_s{NAN}; // Horizontal position drift rate (m/s)
+	float _gps_vertical_position_drift_rate_m_s{NAN};   // Vertical position drift rate (m/s)
+	float _gps_filtered_horizontal_velocity_m_s{NAN};   // Filtered horizontal velocity (m/s)
 
 	uint64_t _time_last_on_ground_us{0};	///< last time we were on the ground (uSec)
 	uint64_t _time_last_in_air{0};		///< last time we were in air (uSec)


### PR DESCRIPTION
This makes it consistent with the reset helper and prevents ambiguity in the field interpretation where 0 would be an impossibly good drift metric. 

https://github.com/PX4/PX4-Autopilot/blob/3d54d258674ea45391caed8138cfdbfb33e516a4/src/modules/ekf2/EKF/ekf_helper.cpp#L1777-L1784