### PR TITLE
Typo Fix: WorkItem::ChangeWorkQeue -> WorkItem::ChangeWorkQueue

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkItem.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkItem.hpp
@@ -79,7 +79,7 @@ public:
 	 * @param config The WorkQueue configuration (see WorkQueueManager.hpp).
 	 * @return true if initialization was successful
 	 */
-	bool ChangeWorkQeue(const wq_config_t &config) { return Init(config); }
+	bool ChangeWorkQueue(const wq_config_t &config) { return Init(config); }
 
 	const char *ItemName() const { return _item_name; }
 

--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -158,7 +158,7 @@ int PCA9685Wrapper::init()
 
 	_class_instance = register_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH);
 
-	this->ChangeWorkQeue(px4::device_bus_to_wq(pca9685->get_device_id()));
+	this->ChangeWorkQueue(px4::device_bus_to_wq(pca9685->get_device_id()));
 
 	PX4_INFO("running on I2C bus %d address 0x%.2x", pca9685->get_device_bus(), pca9685->get_device_address());
 

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -269,7 +269,7 @@ bool MixingOutput::updateSubscriptionsStaticMixer(bool allow_wq_switch, bool lim
 		const bool sub_group_1 = (_groups_required & (1 << 1));
 
 		if (allow_wq_switch && !_wq_switched && (sub_group_0 || sub_group_1)) {
-			if (_interface.ChangeWorkQeue(px4::wq_configurations::rate_ctrl)) {
+			if (_interface.ChangeWorkQueue(px4::wq_configurations::rate_ctrl)) {
 				// let the new WQ handle the subscribe update
 				_wq_switched = true;
 				_interface.ScheduleNow();
@@ -374,7 +374,7 @@ bool MixingOutput::updateSubscriptionsDynamicMixer(bool allow_wq_switch, bool li
 		}
 
 		if (allow_wq_switch && !_wq_switched && switch_requested) {
-			if (_interface.ChangeWorkQeue(px4::wq_configurations::rate_ctrl)) {
+			if (_interface.ChangeWorkQueue(px4::wq_configurations::rate_ctrl)) {
 				// let the new WQ handle the subscribe update
 				_wq_switched = true;
 				_interface.ScheduleNow();


### PR DESCRIPTION
**Describe problem solved by this pull request**
A minor typo fix that change 'WorkItem::ChangeWorkQeue' to 'WorkItem::ChangeWorkQueue'.

**Test data / coverage**
Tested@release/1.12 branch with `make px4_sitl none` under `Ubuntu 18.04`, passed.