### PR TITLE
log irlock_report and landing_target_pose messages

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -62,7 +62,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("cpuload");
 	add_optional_topic("esc_status", 250);
 	add_topic("failure_detector_status", 100);
-	add_topic("follow_target", 500);
+	add_optional_topic("follow_target", 500);
 	add_optional_topic("generator_status");
 	add_optional_topic("gps_dump");
 	add_optional_topic("heater_status");
@@ -70,6 +70,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("hover_thrust_estimate", 100);
 	add_topic("input_rc", 500);
 	add_optional_topic("internal_combustion_engine_status", 10);
+	add_optional_topic("irlock_report", 1000);
+	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");


### PR DESCRIPTION
Currently there is no logging of the precision landing messages, and it's hard to tell if the camera is even picking up the IR beacon.

Need to log both messages, because on some systems the information will come in directly as a landing_target_pose message, and on others it's coming in as irlock_report and then filtered in PX4 to produce the landing_target_pose message.

Logging at a low rate is perfectly sufficient, since it's mostly about seeing that the system works at all and detects _something_.