### PR TITLE
Consider all sensors used by EKF in pre-flight checks

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -246,9 +246,8 @@ bool PreFlightCheck::sensorAvailabilityCheck(const bool report_failure, const ui
 	/* check all sensors, but fail only for mandatory ones */
 	for (uint8_t i = 0u; i < max_optional_count; i++) {
 		const bool required = (i < max_mandatory_count) || isSensorRequired(i);
-		int32_t device_id = -1;
 
-		if (!sens_check(mavlink_log_pub, status, i, !required, device_id, report_fail)) {
+		if (!sens_check(mavlink_log_pub, status, i, !required, report_fail)) {
 			if (required) {
 				pass_check = false;
 			}

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -49,6 +49,7 @@
 
 typedef bool (*sens_check_func_t)(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				  const bool optional, int32_t &device_id, const bool report_fail);
+typedef bool (*is_sens_req_func_t)(uint8_t instance);
 
 class PreFlightCheck
 {
@@ -101,16 +102,21 @@ public:
 private:
 	static bool sensorAvailabilityCheck(const bool report_failure, const uint8_t max_mandatory_count,
 					    const uint8_t max_optional_count, orb_advert_t *mavlink_log_pub,
-					    vehicle_status_s &status, sens_check_func_t sens_check);
+					    vehicle_status_s &status, sens_check_func_t sens_check, is_sens_req_func_t isSensorRequired);
+	static bool isMagRequired(uint8_t instance);
 	static bool magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				      const bool optional, int32_t &device_id, const bool report_fail);
 	static bool magConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
+	static bool isAccelRequired(uint8_t instance);
 	static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				       const bool optional, int32_t &device_id, const bool report_fail);
+	static bool isGyroRequired(uint8_t instance);
 	static bool gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 			      const bool optional, int32_t &device_id, const bool report_fail);
+	static bool isBaroRequired(uint8_t instance);
 	static bool baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 			      const bool optional, int32_t &device_id, const bool report_fail);
+	static bool isDistSensRequired(uint8_t instance);
 	static bool distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				  const bool optional, int32_t &device_id, const bool report_fail);
 	static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -48,8 +48,7 @@
 #include <drivers/drv_hrt.h>
 
 typedef bool (*sens_check_func_t)(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				  const bool optional, const bool report_fail);
-typedef bool (*is_sens_req_func_t)(uint8_t instance);
+				  const bool is_mandatory, bool &report_fail);
 
 class PreFlightCheck
 {
@@ -100,25 +99,24 @@ public:
 				bool report_fail = true);
 
 private:
-	static bool sensorAvailabilityCheck(const bool report_failure, const uint8_t max_mandatory_count,
-					    const uint8_t max_optional_count, orb_advert_t *mavlink_log_pub,
-					    vehicle_status_s &status, sens_check_func_t sens_check, is_sens_req_func_t isSensorRequired);
+	static bool sensorAvailabilityCheck(const bool report_failure,
+					    const uint8_t nb_mandatory_instances, orb_advert_t *mavlink_log_pub,
+					    vehicle_status_s &status, sens_check_func_t sens_check);
 	static bool isMagRequired(uint8_t instance);
 	static bool magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				      const bool optional, const bool report_fail);
+				      const bool is_mandatory, bool &report_fail);
 	static bool magConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
 	static bool isAccelRequired(uint8_t instance);
 	static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				       const bool optional, const bool report_fail);
+				       const bool is_mandatory, bool &report_fail);
 	static bool isGyroRequired(uint8_t instance);
 	static bool gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			      const bool optional, const bool report_fail);
+			      const bool is_mandatory, bool &report_fail);
 	static bool isBaroRequired(uint8_t instance);
 	static bool baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			      const bool optional, const bool report_fail);
-	static bool isDistSensRequired(uint8_t instance);
+			      const bool is_mandatory, bool &report_fail);
 	static bool distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				  const bool optional, const bool report_fail);
+				  const bool is_mandatory, bool &report_fail);
 	static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
 	static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool optional,
 				  const bool report_fail, const bool prearm, const bool max_airspeed_check_en, const float arming_max_airspeed_allowed);

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -48,7 +48,7 @@
 #include <drivers/drv_hrt.h>
 
 typedef bool (*sens_check_func_t)(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				  const bool optional, int32_t &device_id, const bool report_fail);
+				  const bool optional, const bool report_fail);
 typedef bool (*is_sens_req_func_t)(uint8_t instance);
 
 class PreFlightCheck
@@ -105,20 +105,20 @@ private:
 					    vehicle_status_s &status, sens_check_func_t sens_check, is_sens_req_func_t isSensorRequired);
 	static bool isMagRequired(uint8_t instance);
 	static bool magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				      const bool optional, int32_t &device_id, const bool report_fail);
+				      const bool optional, const bool report_fail);
 	static bool magConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
 	static bool isAccelRequired(uint8_t instance);
 	static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				       const bool optional, int32_t &device_id, const bool report_fail);
+				       const bool optional, const bool report_fail);
 	static bool isGyroRequired(uint8_t instance);
 	static bool gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			      const bool optional, int32_t &device_id, const bool report_fail);
+			      const bool optional, const bool report_fail);
 	static bool isBaroRequired(uint8_t instance);
 	static bool baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			      const bool optional, int32_t &device_id, const bool report_fail);
+			      const bool optional, const bool report_fail);
 	static bool isDistSensRequired(uint8_t instance);
 	static bool distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				  const bool optional, int32_t &device_id, const bool report_fail);
+				  const bool optional, const bool report_fail);
 	static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
 	static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool optional,
 				  const bool report_fail, const bool prearm, const bool max_airspeed_check_en, const float arming_max_airspeed_allowed);

--- a/src/modules/commander/Arming/PreFlightCheck/checks/accelerometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/accelerometerCheck.cpp
@@ -62,7 +62,7 @@ bool PreFlightCheck::isAccelRequired(const uint8_t instance)
 }
 
 bool PreFlightCheck::accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-					const bool optional, int32_t &device_id, const bool report_fail)
+					const bool optional, const bool report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_accel), instance) == PX4_OK);
 	bool calibration_valid = false;
@@ -80,13 +80,11 @@ bool PreFlightCheck::accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_s
 			}
 		}
 
-		device_id = accel.get().device_id;
-
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 			calibration_valid = true;
 
 		} else {
-			calibration_valid = (calibration::FindCurrentCalibrationIndex("ACC", device_id) >= 0);
+			calibration_valid = (calibration::FindCurrentCalibrationIndex("ACC", accel.get().device_id) >= 0);
 		}
 
 		if (!calibration_valid) {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/accelerometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/accelerometerCheck.cpp
@@ -50,70 +50,71 @@ bool PreFlightCheck::isAccelRequired(const uint8_t instance)
 	uORB::SubscriptionData<sensor_accel_s> accel{ORB_ID(sensor_accel), instance};
 	const uint32_t device_id = static_cast<uint32_t>(accel.get().device_id);
 
+	bool is_used_by_nav = false;
+
 	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
 
 		if (device_id > 0 && estimator_status_sub.get().accel_device_id == device_id) {
-			return true;
+			is_used_by_nav = true;
+			break;
 		}
 	}
 
-	return false;
+	return is_used_by_nav;
 }
 
 bool PreFlightCheck::accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-					const bool optional, const bool report_fail)
+					const bool is_mandatory, bool &report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_accel), instance) == PX4_OK);
-	bool calibration_valid = false;
-	bool valid = true;
+	const bool is_required = is_mandatory || isAccelRequired(instance);
+
+	bool is_valid = false;
+	bool is_calibration_valid = false;
+	bool is_value_valid = false;
 
 	if (exists) {
-
 		uORB::SubscriptionData<sensor_accel_s> accel{ORB_ID(sensor_accel), instance};
 
-		valid = (accel.get().device_id != 0) && (accel.get().timestamp != 0);
-
-		if (!valid) {
-			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Accel %u", instance);
-			}
-		}
+		is_valid = (accel.get().device_id != 0) && (accel.get().timestamp != 0);
 
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
-			calibration_valid = true;
+			is_calibration_valid = true;
 
 		} else {
-			calibration_valid = (calibration::FindCurrentCalibrationIndex("ACC", accel.get().device_id) >= 0);
+			is_calibration_valid = (calibration::FindCurrentCalibrationIndex("ACC", accel.get().device_id) >= 0);
 		}
 
-		if (!calibration_valid) {
-			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Accel %u uncalibrated", instance);
-			}
+		const float accel_magnitude = sqrtf(accel.get().x * accel.get().x
+						    + accel.get().y * accel.get().y
+						    + accel.get().z * accel.get().z);
 
-		} else {
-			const float accel_magnitude = sqrtf(accel.get().x * accel.get().x
-							    + accel.get().y * accel.get().y
-							    + accel.get().z * accel.get().z);
-
-			if (accel_magnitude < 4.0f || accel_magnitude > 15.0f /* m/s^2 */) {
-				if (report_fail) {
-					mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Accel Range, hold still on arming");
-				}
-
-				// this is fatal
-				valid = false;
-			}
-		}
-
-	} else {
-		if (!optional && report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Accel Sensor %u missing", instance);
+		if (accel_magnitude > 4.0f && accel_magnitude < 15.0f /* m/s^2 */) {
+			is_value_valid = true;
 		}
 	}
 
-	const bool success = calibration_valid && valid;
+	if (report_fail && is_required) {
+		if (!exists) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Accel Sensor %u missing", instance);
+			report_fail = false;
 
-	return success;
+		} else if (!is_valid) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Accel %u", instance);
+			report_fail = false;
+
+		} else if (!is_calibration_valid) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Accel %u uncalibrated", instance);
+			report_fail = false;
+
+		} else if (!is_value_valid) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Accel Range, hold still on arming");
+			report_fail = false;
+		}
+	}
+
+	const bool is_sensor_ok = is_valid && is_calibration_valid && is_value_valid;
+
+	return is_sensor_ok || !is_required;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/checks/accelerometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/accelerometerCheck.cpp
@@ -77,7 +77,8 @@ bool PreFlightCheck::accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_s
 	if (exists) {
 		uORB::SubscriptionData<sensor_accel_s> accel{ORB_ID(sensor_accel), instance};
 
-		is_valid = (accel.get().device_id != 0) && (accel.get().timestamp != 0);
+		is_valid = (accel.get().device_id != 0) && (accel.get().timestamp != 0)
+			   && (hrt_elapsed_time(&accel.get().timestamp) < 1_s);
 
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 			is_calibration_valid = true;

--- a/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
@@ -73,7 +73,7 @@ bool PreFlightCheck::baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 	if (exists) {
 		uORB::SubscriptionData<sensor_baro_s> baro{ORB_ID(sensor_baro), instance};
 
-		valid = (baro.get().device_id != 0) && (baro.get().timestamp != 0);
+		valid = (baro.get().device_id != 0) && (baro.get().timestamp != 0) && (hrt_elapsed_time(&baro.get().timestamp) < 1_s);
 	}
 
 	if (instance == 0) {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
@@ -60,7 +60,7 @@ bool PreFlightCheck::isBaroRequired(const uint8_t instance)
 }
 
 bool PreFlightCheck::baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			       const bool optional, int32_t &device_id, const bool report_fail)
+			       const bool optional, const bool report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_baro), instance) == PX4_OK);
 	bool valid = false;

--- a/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
@@ -48,43 +48,48 @@ bool PreFlightCheck::isBaroRequired(const uint8_t instance)
 	uORB::SubscriptionData<sensor_baro_s> baro{ORB_ID(sensor_baro), instance};
 	const uint32_t device_id = static_cast<uint32_t>(baro.get().device_id);
 
+	bool is_used_by_nav = false;
+
 	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
 
 		if (device_id > 0 && estimator_status_sub.get().baro_device_id == device_id) {
-			return true;
+			is_used_by_nav = true;
+			break;
 		}
 	}
 
-	return false;
+	return is_used_by_nav;
 }
 
 bool PreFlightCheck::baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			       const bool optional, const bool report_fail)
+			       const bool is_mandatory, bool &report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_baro), instance) == PX4_OK);
+	const bool is_required = is_mandatory || isBaroRequired(instance);
+
 	bool valid = false;
 
 	if (exists) {
 		uORB::SubscriptionData<sensor_baro_s> baro{ORB_ID(sensor_baro), instance};
 
 		valid = (baro.get().device_id != 0) && (baro.get().timestamp != 0);
-
-		if (!valid) {
-			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Baro %u", instance);
-			}
-		}
-
-	} else {
-		if (!optional && report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Baro Sensor %u missing", instance);
-		}
 	}
 
 	if (instance == 0) {
-		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_ABSPRESSURE, exists, !optional, valid, status);
+		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_ABSPRESSURE, exists, is_required, valid, status);
 	}
 
-	return valid;
+	if (report_fail && is_required) {
+		if (!exists) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Baro Sensor %u missing", instance);
+			report_fail = false;
+
+		} else if (!valid) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Baro %u", instance);
+			report_fail = false;
+		}
+	}
+
+	return valid || !is_required;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/checks/distanceSensorChecks.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/distanceSensorChecks.cpp
@@ -42,6 +42,11 @@
 
 using namespace time_literals;
 
+bool PreFlightCheck::isDistSensRequired(const uint8_t instance)
+{
+	return false;
+}
+
 bool PreFlightCheck::distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				   const bool optional, int32_t &device_id, const bool report_fail)
 {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/distanceSensorChecks.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/distanceSensorChecks.cpp
@@ -48,7 +48,7 @@ bool PreFlightCheck::isDistSensRequired(const uint8_t instance)
 }
 
 bool PreFlightCheck::distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				   const bool optional, int32_t &device_id, const bool report_fail)
+				   const bool optional, const bool report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(distance_sensor), instance) == PX4_OK);
 	bool check_valid = false;

--- a/src/modules/commander/Arming/PreFlightCheck/checks/gyroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/gyroCheck.cpp
@@ -75,7 +75,8 @@ bool PreFlightCheck::gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 	if (exists) {
 		uORB::SubscriptionData<sensor_gyro_s> gyro{ORB_ID(sensor_gyro), instance};
 
-		is_valid = (gyro.get().device_id != 0) && (gyro.get().timestamp != 0);
+		is_valid = (gyro.get().device_id != 0) && (gyro.get().timestamp != 0)
+			   && (hrt_elapsed_time(&gyro.get().timestamp) < 1_s);
 
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 			is_calibration_valid = true;

--- a/src/modules/commander/Arming/PreFlightCheck/checks/gyroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/gyroCheck.cpp
@@ -39,9 +39,26 @@
 #include <lib/sensor_calibration/Utilities.hpp>
 #include <lib/systemlib/mavlink_log.h>
 #include <uORB/Subscription.hpp>
+#include <uORB/topics/estimator_status.h>
 #include <uORB/topics/sensor_gyro.h>
 
 using namespace time_literals;
+
+bool PreFlightCheck::isGyroRequired(const uint8_t instance)
+{
+	uORB::SubscriptionData<sensor_gyro_s> gyro{ORB_ID(sensor_gyro), instance};
+	const uint32_t device_id = static_cast<uint32_t>(gyro.get().device_id);
+
+	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+		uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
+
+		if (device_id > 0 && estimator_status_sub.get().gyro_device_id == device_id) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 bool PreFlightCheck::gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 			       const bool optional, int32_t &device_id, const bool report_fail)

--- a/src/modules/commander/Arming/PreFlightCheck/checks/gyroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/gyroCheck.cpp
@@ -61,7 +61,7 @@ bool PreFlightCheck::isGyroRequired(const uint8_t instance)
 }
 
 bool PreFlightCheck::gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-			       const bool optional, int32_t &device_id, const bool report_fail)
+			       const bool optional, const bool report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_gyro), instance) == PX4_OK);
 	bool calibration_valid = false;
@@ -79,13 +79,11 @@ bool PreFlightCheck::gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 			}
 		}
 
-		device_id = gyro.get().device_id;
-
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 			calibration_valid = true;
 
 		} else {
-			calibration_valid = (calibration::FindCurrentCalibrationIndex("GYRO", device_id) >= 0);
+			calibration_valid = (calibration::FindCurrentCalibrationIndex("GYRO", gyro.get().device_id) >= 0);
 		}
 
 		if (!calibration_valid) {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
@@ -61,7 +61,7 @@ bool PreFlightCheck::isMagRequired(const uint8_t instance)
 }
 
 bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				       const bool optional, int32_t &device_id, const bool report_fail)
+				       const bool optional, const bool report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_mag), instance) == PX4_OK);
 	bool calibration_valid = false;
@@ -80,13 +80,11 @@ bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_st
 			}
 		}
 
-		device_id = magnetometer.get().device_id;
-
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 			calibration_valid = true;
 
 		} else {
-			calibration_valid = (calibration::FindCurrentCalibrationIndex("MAG", device_id) >= 0);
+			calibration_valid = (calibration::FindCurrentCalibrationIndex("MAG", magnetometer.get().device_id) >= 0);
 		}
 
 		if (!calibration_valid) {
@@ -98,7 +96,7 @@ bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_st
 		for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 			uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
 
-			if (estimator_status_sub.get().mag_device_id == static_cast<uint32_t>(device_id)) {
+			if (estimator_status_sub.get().mag_device_id == static_cast<uint32_t>(magnetometer.get().device_id)) {
 				if (estimator_status_sub.get().control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT)) {
 					is_mag_fault = true;
 					break;

--- a/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
@@ -44,6 +44,22 @@
 
 using namespace time_literals;
 
+bool PreFlightCheck::isMagRequired(const uint8_t instance)
+{
+	uORB::SubscriptionData<sensor_mag_s> magnetometer{ORB_ID(sensor_mag), instance};
+	const uint32_t device_id = static_cast<uint32_t>(magnetometer.get().device_id);
+
+	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+		uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
+
+		if (device_id > 0 && estimator_status_sub.get().mag_device_id == device_id) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				       const bool optional, int32_t &device_id, const bool report_fail)
 {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/magnetometerCheck.cpp
@@ -49,48 +49,40 @@ bool PreFlightCheck::isMagRequired(const uint8_t instance)
 	uORB::SubscriptionData<sensor_mag_s> magnetometer{ORB_ID(sensor_mag), instance};
 	const uint32_t device_id = static_cast<uint32_t>(magnetometer.get().device_id);
 
+	bool is_used_by_nav = false;
+
 	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
 
 		if (device_id > 0 && estimator_status_sub.get().mag_device_id == device_id) {
-			return true;
+			is_used_by_nav = true;;
+			break;
 		}
 	}
 
-	return false;
+	return is_used_by_nav;
 }
 
 bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
-				       const bool optional, const bool report_fail)
+				       const bool is_mandatory, bool &report_fail)
 {
 	const bool exists = (orb_exists(ORB_ID(sensor_mag), instance) == PX4_OK);
-	bool calibration_valid = false;
-	bool valid = false;
+	const bool is_required = is_mandatory || isMagRequired(instance);
+
+	bool is_valid = false;
+	bool is_calibration_valid = false;
 	bool is_mag_fault = false;
 
 	if (exists) {
-
 		uORB::SubscriptionData<sensor_mag_s> magnetometer{ORB_ID(sensor_mag), instance};
 
-		valid = (magnetometer.get().device_id != 0) && (magnetometer.get().timestamp != 0);
-
-		if (!valid) {
-			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Compass %u", instance);
-			}
-		}
+		is_valid = (magnetometer.get().device_id != 0) && (magnetometer.get().timestamp != 0);
 
 		if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
-			calibration_valid = true;
+			is_calibration_valid = true;
 
 		} else {
-			calibration_valid = (calibration::FindCurrentCalibrationIndex("MAG", magnetometer.get().device_id) >= 0);
-		}
-
-		if (!calibration_valid) {
-			if (report_fail) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass %u uncalibrated", instance);
-			}
+			is_calibration_valid = (calibration::FindCurrentCalibrationIndex("MAG", magnetometer.get().device_id) >= 0);
 		}
 
 		for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
@@ -103,25 +95,35 @@ bool PreFlightCheck::magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_st
 				}
 			}
 		}
-
-		if (is_mag_fault && report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass #%u fault", instance);
-		}
-
-	} else {
-		if (!optional && report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass Sensor %u missing", instance);
-		}
 	}
 
-	const bool success = calibration_valid && valid && !is_mag_fault;
+	const bool is_sensor_ok = is_valid && is_calibration_valid && !is_mag_fault;
 
 	if (instance == 0) {
-		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG, exists, !optional, success, status);
+		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG, exists, is_required, is_sensor_ok, status);
 
 	} else if (instance == 1) {
-		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG2, exists, !optional, success, status);
+		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG2, exists, is_required, is_sensor_ok, status);
 	}
 
-	return success;
+	if (report_fail && is_required) {
+		if (!exists) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass Sensor %u missing", instance);
+			report_fail = false;
+
+		} else if (!is_valid) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Compass %u", instance);
+			report_fail = false;
+
+		} else if (!is_calibration_valid) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass %u uncalibrated", instance);
+			report_fail = false;
+
+		} else if (is_mag_fault) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Compass #%u fault", instance);
+			report_fail = false;
+		}
+	}
+
+	return is_sensor_ok || !is_required;
 }


### PR DESCRIPTION
requires https://github.com/PX4/PX4-Autopilot/pull/19313

**Describe problem solved by this pull request**
Until now, only the first sensor instance was considered mandatory. For example, an issue with the external mag (instance 1, the primary one used by EKF2) did not trigger a pre-flight check failure.

**Describe your solution**
With this PR, all the sensors used by all the EKF2 instances are considered mandatory and would prevent arming in case of a pre-flight failure. In addition to this, the first instance is always mandatory.

Additional changes:
- the pre-flight check also fails if the sensor was disconnected after boot by checking the freshness of the measurement (1s data timeout)
- remove `maximum_optional_...` that are all the same and hardcode the number in the loop to reduce the number of arguments in sensorAvailabilityCheck
- split failure detection from message print for more clarity in each `<sensor>Check` function

**Test data / coverage**
SITL tested