### PR TITLE
sensor: unify accel/gyro/mag estimated bias -> cal update

### DIFF
--- a/src/lib/sensor_calibration/Accelerometer.hpp
+++ b/src/lib/sensor_calibration/Accelerometer.hpp
@@ -69,7 +69,7 @@ public:
 	uint8_t calibration_count() const { return _calibration_count; }
 	int8_t calibration_index() const { return _calibration_index; }
 	uint32_t device_id() const { return _device_id; }
-	bool enabled() const { return (_priority > 0); }
+	bool enabled() const { return (_device_id != 0) && (_priority > 0); }
 	bool external() const { return _external; }
 	const matrix::Vector3f &offset() const { return _offset; }
 	const int32_t &priority() const { return _priority; }

--- a/src/lib/sensor_calibration/Gyroscope.hpp
+++ b/src/lib/sensor_calibration/Gyroscope.hpp
@@ -68,7 +68,7 @@ public:
 	uint8_t calibration_count() const { return _calibration_count; }
 	int8_t calibration_index() const { return _calibration_index; }
 	uint32_t device_id() const { return _device_id; }
-	bool enabled() const { return (_priority > 0); }
+	bool enabled() const { return (_device_id != 0) && (_priority > 0); }
 	bool external() const { return _external; }
 	const matrix::Vector3f &offset() const { return _offset; }
 	const int32_t &priority() const { return _priority; }

--- a/src/lib/sensor_calibration/Magnetometer.hpp
+++ b/src/lib/sensor_calibration/Magnetometer.hpp
@@ -71,7 +71,7 @@ public:
 	uint8_t calibration_count() const { return _calibration_count; }
 	int8_t calibration_index() const { return _calibration_index; }
 	uint32_t device_id() const { return _device_id; }
-	bool enabled() const { return (_priority > 0); }
+	bool enabled() const { return (_device_id != 0) && (_priority > 0); }
 	bool external() const { return _external; }
 	const matrix::Vector3f &offset() const { return _offset; }
 	const int32_t &priority() const { return _priority; }

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -125,24 +125,20 @@ bool VehicleIMU::ParametersUpdate(bool force)
 		_accel_calibration.ParametersUpdate();
 		_gyro_calibration.ParametersUpdate();
 
-		if (accel_calibration_count != _accel_calibration.calibration_count()) {
+		if ((accel_calibration_count != _accel_calibration.calibration_count())
+		    || (gyro_calibration_count != _gyro_calibration.calibration_count())
+		   ) {
 			// if calibration changed reset any existing learned calibration
-			_accel_cal_available = false;
-			_in_flight_calibration_check_timestamp_last = hrt_absolute_time() + INFLIGHT_CALIBRATION_QUIET_PERIOD_US;
-
 			for (auto &learned_cal : _accel_learned_calibration) {
 				learned_cal = {};
 			}
-		}
-
-		if (gyro_calibration_count != _gyro_calibration.calibration_count()) {
-			// if calibration changed reset any existing learned calibration
-			_gyro_cal_available = false;
-			_in_flight_calibration_check_timestamp_last = hrt_absolute_time() + INFLIGHT_CALIBRATION_QUIET_PERIOD_US;
 
 			for (auto &learned_cal : _gyro_learned_calibration) {
 				learned_cal = {};
 			}
+
+			_in_flight_cal_available = false;
+			_last_calibration_update = hrt_absolute_time();
 		}
 
 		// constrain IMU integration time 1-20 milliseconds (50-1000 Hz)
@@ -165,9 +161,94 @@ bool VehicleIMU::ParametersUpdate(bool force)
 	return updated;
 }
 
+void VehicleIMU::SensorCalibrationUpdate()
+{
+	int accel_cal_index = 0;
+	int gyro_cal_index = 0;
+
+	for (int i = 0; i < _estimator_sensor_bias_subs.size(); i++) {
+		estimator_sensor_bias_s estimator_sensor_bias;
+
+		if (_estimator_sensor_bias_subs[i].update(&estimator_sensor_bias)
+		    && (hrt_elapsed_time(&estimator_sensor_bias.timestamp) < 10_s)
+		    && (estimator_sensor_bias.timestamp > _last_calibration_update)) {
+
+			// find corresponding accel bias
+			if ((estimator_sensor_bias.accel_device_id != 0)
+			    && (estimator_sensor_bias.accel_device_id == _accel_calibration.device_id())
+			    && estimator_sensor_bias.accel_bias_valid
+			    && estimator_sensor_bias.accel_bias_stable
+			   ) {
+
+				if (accel_cal_index < IN_FLIGHT_CAL_COUNT) {
+
+					const Vector3f bias{estimator_sensor_bias.accel_bias};
+					const Vector3f bias_variance{estimator_sensor_bias.accel_bias_variance};
+
+					_accel_learned_calibration[accel_cal_index].device_id = estimator_sensor_bias.accel_device_id;
+					_accel_learned_calibration[accel_cal_index].offset = _accel_calibration.BiasCorrectedSensorOffset(bias);
+					_accel_learned_calibration[accel_cal_index].variance = bias_variance;
+					_accel_learned_calibration[accel_cal_index].estimator_instance = i;
+
+					_in_flight_cal_available = true;
+				}
+
+				accel_cal_index++;
+			}
+
+			// find corresponding gyro calibration
+			if ((estimator_sensor_bias.gyro_device_id != 0)
+			    && (estimator_sensor_bias.gyro_device_id == _gyro_calibration.device_id())
+			    && estimator_sensor_bias.gyro_bias_valid
+			    && estimator_sensor_bias.gyro_bias_stable
+			   ) {
+
+				if (gyro_cal_index < IN_FLIGHT_CAL_COUNT) {
+
+					const Vector3f bias{estimator_sensor_bias.gyro_bias};
+					const Vector3f bias_variance{estimator_sensor_bias.gyro_bias_variance};
+
+					_gyro_learned_calibration[gyro_cal_index].device_id = estimator_sensor_bias.gyro_device_id;
+					_gyro_learned_calibration[gyro_cal_index].offset = _gyro_calibration.BiasCorrectedSensorOffset(bias);
+					_gyro_learned_calibration[gyro_cal_index].variance = bias_variance;
+					_gyro_learned_calibration[gyro_cal_index].estimator_instance = i;
+
+					_in_flight_cal_available = true;
+				}
+
+				gyro_cal_index++;
+			}
+		}
+	}
+}
+
+void VehicleIMU::SensorCalibrationApplyAll()
+{
+	if (_in_flight_cal_available) {
+		bool calibration_param_save_needed = false;
+
+		if (calibration::SensorCalibrationApplyLearned<calibration::Accelerometer, IN_FLIGHT_CAL_COUNT>(_accel_calibration,
+				_instance, _accel_learned_calibration)) {
+			calibration_param_save_needed = true;
+		}
+
+		if (calibration::SensorCalibrationApplyLearned<calibration::Gyroscope, IN_FLIGHT_CAL_COUNT>(_gyro_calibration,
+				_instance, _gyro_learned_calibration)) {
+			calibration_param_save_needed = true;
+		}
+
+		if (calibration_param_save_needed) {
+			_last_calibration_update = hrt_absolute_time();
+			param_notify_changes();
+		}
+
+		_in_flight_cal_available = false;
+	}
+}
+
 void VehicleIMU::Run()
 {
-	const hrt_abstime now_us = hrt_absolute_time();
+	const hrt_abstime time_now_us = hrt_absolute_time();
 
 	const bool parameters_updated = ParametersUpdate();
 
@@ -245,7 +326,7 @@ void VehicleIMU::Run()
 					_gyro_update_latency_mean.reset();
 				}
 
-				const float time_run_s = now_us * 1e-6f;
+				const float time_run_s = time_now_us * 1e-6f;
 
 				_gyro_update_latency_mean.update(Vector2f{time_run_s - _gyro_timestamp_sample_last * 1e-6f, time_run_s - _gyro_timestamp_last * 1e-6f});
 
@@ -259,16 +340,19 @@ void VehicleIMU::Run()
 		}
 	}
 
-	if (_param_sens_imu_autocal.get() && !parameters_updated) {
-		if ((_armed || !_accel_calibration.calibrated() || !_gyro_calibration.calibrated())
-		    && (now_us > _in_flight_calibration_check_timestamp_last + 1_s)) {
+	if (_param_sens_imu_autocal.get() && !parameters_updated
+	    && (time_now_us > _last_calibration_update + IN_FLIGHT_CALIBRATION_QUIET_PERIOD_US)) {
+
+		bool uncalibrated = !_accel_calibration.calibrated() || !_gyro_calibration.calibrated();
+
+		if ((_armed || uncalibrated)
+		    && (time_now_us > _in_flight_calibration_check_timestamp_last + 1_s)) {
 
 			SensorCalibrationUpdate();
-			_in_flight_calibration_check_timestamp_last = now_us;
+			_in_flight_calibration_check_timestamp_last = time_now_us;
 
 		} else if (!_armed) {
-			SensorCalibrationSaveAccel();
-			SensorCalibrationSaveGyro();
+			SensorCalibrationApplyAll();
 		}
 	}
 }
@@ -769,147 +853,6 @@ void VehicleIMU::PrintStatus()
 
 	_accel_calibration.PrintStatus();
 	_gyro_calibration.PrintStatus();
-}
-
-void VehicleIMU::SensorCalibrationUpdate()
-{
-	for (int i = 0; i < _estimator_sensor_bias_subs.size(); i++) {
-		estimator_sensor_bias_s estimator_sensor_bias;
-
-		if (_estimator_sensor_bias_subs[i].update(&estimator_sensor_bias)
-		    && (hrt_elapsed_time(&estimator_sensor_bias.timestamp) < 1_s)) {
-
-			// find corresponding accel bias
-			if (estimator_sensor_bias.accel_bias_valid && estimator_sensor_bias.accel_bias_stable
-			    && (estimator_sensor_bias.accel_device_id != 0)
-			    && (estimator_sensor_bias.accel_device_id == _accel_calibration.device_id())) {
-
-				const Vector3f bias{estimator_sensor_bias.accel_bias};
-
-				_accel_learned_calibration[i].offset = _accel_calibration.BiasCorrectedSensorOffset(bias);
-				_accel_learned_calibration[i].bias_variance = Vector3f{estimator_sensor_bias.accel_bias_variance};
-				_accel_learned_calibration[i].valid = true;
-				_accel_cal_available = true;
-			}
-
-			// find corresponding gyro calibration
-			if (estimator_sensor_bias.gyro_bias_valid && estimator_sensor_bias.gyro_bias_stable
-			    && (estimator_sensor_bias.gyro_device_id != 0)
-			    && (estimator_sensor_bias.gyro_device_id == _gyro_calibration.device_id())) {
-
-				const Vector3f bias{estimator_sensor_bias.gyro_bias};
-
-				_gyro_learned_calibration[i].offset = _gyro_calibration.BiasCorrectedSensorOffset(bias);
-				_gyro_learned_calibration[i].bias_variance = Vector3f{estimator_sensor_bias.gyro_bias_variance};
-				_gyro_learned_calibration[i].valid = true;
-				_gyro_cal_available = true;
-			}
-		}
-	}
-}
-
-void VehicleIMU::SensorCalibrationSaveAccel()
-{
-	if (_accel_cal_available) {
-		const Vector3f cal_orig{_accel_calibration.offset()};
-		bool initialised = false;
-		Vector3f offset_estimate{};
-		Vector3f bias_variance{};
-
-		// apply all valid saved offsets
-		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
-			if (_accel_learned_calibration[i].valid) {
-				if (!initialised) {
-					bias_variance = _accel_learned_calibration[i].bias_variance;
-					offset_estimate = _accel_learned_calibration[i].offset;
-					initialised = true;
-
-				} else {
-					for (int axis_index = 0; axis_index < 3; axis_index++) {
-						const float sum_of_variances = _accel_learned_calibration[i].bias_variance(axis_index) + bias_variance(axis_index);
-						const float k1 = bias_variance(axis_index) / sum_of_variances;
-						const float k2 = _accel_learned_calibration[i].bias_variance(axis_index) / sum_of_variances;
-						offset_estimate(axis_index) = k2 * offset_estimate(axis_index) + k1 * _accel_learned_calibration[i].offset(axis_index);
-						bias_variance(axis_index) *= k2;
-					}
-				}
-
-				// reset
-				_accel_learned_calibration[i] = {};
-			}
-		}
-
-		if (initialised && ((cal_orig - offset_estimate).longerThan(0.05f) || !_accel_calibration.calibrated())) {
-			if (_accel_calibration.set_offset(offset_estimate)) {
-				PX4_INFO("%s %d (%" PRIu32 ") offset committed: [%.3f %.3f %.3f]->[%.3f %.3f %.3f])",
-					 _accel_calibration.SensorString(), _instance, _accel_calibration.device_id(),
-					 (double)cal_orig(0), (double)cal_orig(1), (double)cal_orig(2),
-					 (double)offset_estimate(0), (double)offset_estimate(1), (double)offset_estimate(2));
-
-				// save parameters with preferred calibration slot to current sensor index
-				if (_accel_calibration.ParametersSave(_sensor_accel_sub.get_instance())) {
-					param_notify_changes();
-				}
-
-				_in_flight_calibration_check_timestamp_last = hrt_absolute_time() + INFLIGHT_CALIBRATION_QUIET_PERIOD_US;
-			}
-		}
-
-		// reset
-		_accel_cal_available = false;
-	}
-}
-
-void VehicleIMU::SensorCalibrationSaveGyro()
-{
-	if (_gyro_cal_available) {
-		const Vector3f cal_orig{_gyro_calibration.offset()};
-		bool initialised = false;
-		Vector3f offset_estimate{};
-		Vector3f bias_variance{};
-
-		// apply all valid saved offsets
-		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
-			if (_gyro_learned_calibration[i].valid) {
-				if (!initialised) {
-					bias_variance = _gyro_learned_calibration[i].bias_variance;
-					offset_estimate = _gyro_learned_calibration[i].offset;
-					initialised = true;
-
-				} else {
-					for (int axis_index = 0; axis_index < 3; axis_index++) {
-						const float sum_of_variances = _gyro_learned_calibration[i].bias_variance(axis_index) + bias_variance(axis_index);
-						const float k1 = bias_variance(axis_index) / sum_of_variances;
-						const float k2 = _gyro_learned_calibration[i].bias_variance(axis_index) / sum_of_variances;
-						offset_estimate(axis_index) = k2 * offset_estimate(axis_index) + k1 * _gyro_learned_calibration[i].offset(axis_index);
-						bias_variance(axis_index) *= k2;
-					}
-				}
-
-				// reset
-				_gyro_learned_calibration[i] = {};
-			}
-		}
-
-		if (initialised && ((cal_orig - offset_estimate).longerThan(0.01f) || !_gyro_calibration.calibrated())) {
-			if (_gyro_calibration.set_offset(offset_estimate)) {
-				PX4_INFO("%s %d (%" PRIu32 ") offset committed: [%.3f %.3f %.3f]->[%.3f %.3f %.3f])",
-					 _gyro_calibration.SensorString(), _instance, _gyro_calibration.device_id(),
-					 (double)cal_orig(0), (double)cal_orig(1), (double)cal_orig(2),
-					 (double)offset_estimate(0), (double)offset_estimate(1), (double)offset_estimate(2));
-
-				// save parameters with preferred calibration slot to current sensor index
-				if (_gyro_calibration.ParametersSave(_sensor_gyro_sub.get_instance())) {
-					param_notify_changes();
-				}
-
-				_in_flight_calibration_check_timestamp_last = hrt_absolute_time() + INFLIGHT_CALIBRATION_QUIET_PERIOD_US;
-			}
-		}
-
-		// reset
-		_gyro_cal_available = false;
-	}
 }
 
 } // namespace sensors

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -36,6 +36,7 @@
 #include "data_validator/DataValidatorGroup.hpp"
 
 #include <lib/sensor_calibration/Magnetometer.hpp>
+#include <lib/sensor_calibration/Utilities.hpp>
 #include <lib/conversion/rotation.h>
 #include <lib/mathlib/math/Limits.hpp>
 #include <lib/matrix/matrix/math.hpp>
@@ -91,8 +92,10 @@ private:
 	 */
 	void calcMagInconsistency();
 
+	void SensorCalibrationApplyAll();
+	void SensorCalibrationUpdate();
+
 	void UpdateMagBiasEstimate();
-	void UpdateMagCalibration();
 	void UpdatePowerCompensation();
 
 	static constexpr int MAX_SENSOR_COUNT = 4;
@@ -118,13 +121,10 @@ private:
 	// Used to check, save and use learned magnetometer biases
 	uORB::SubscriptionMultiArray<estimator_sensor_bias_s> _estimator_sensor_bias_subs{ORB_ID::estimator_sensor_bias};
 
-	bool _in_flight_mag_cal_available{false}; ///< from navigation filter
-
-	struct MagCal {
-		uint32_t device_id{0};
-		matrix::Vector3f offset{};
-		matrix::Vector3f variance{};
-	} _mag_cal[ORB_MULTI_MAX_INSTANCES] {};
+	static constexpr hrt_abstime IN_FLIGHT_CALIBRATION_QUIET_PERIOD_US{10_s};
+	calibration::InFlightCalibration _learned_calibration[ORB_MULTI_MAX_INSTANCES] {};
+	hrt_abstime _in_flight_calibration_check_timestamp_last{0};
+	bool _in_flight_cal_available{false}; ///< from navigation filter
 
 	uORB::SubscriptionCallbackWorkItem _sensor_sub[MAX_SENSOR_COUNT] {
 		{this, ORB_ID(sensor_mag), 0},


### PR DESCRIPTION
 - add bias variance reference for updating accel & gyro calibration from in flight estimated bias
 - post flight mag cal update now controlled by SENS_MAG_AUTOCAL and enabled by default
 - try to keep things consistent between mag & accel/gyro cal update from online bias