### PR TITLE
Bug Fix: non-atomic publish leads to early reset of VehicleIMU integrator.

### DIFF
--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -543,12 +543,13 @@ bool VehicleIMU::Publish()
 {
 	bool updated = false;
 
-	vehicle_imu_s imu;
-	Vector3f delta_angle;
-	Vector3f delta_velocity;
+    if (_accel_integrator.integral_ready() && _gyro_integrator.integral_ready()) {
+        vehicle_imu_s imu;
+        Vector3f delta_angle;
+        Vector3f delta_velocity;
 
-	if (_accel_integrator.reset(delta_velocity, imu.delta_velocity_dt)
-	    && _gyro_integrator.reset(delta_angle, imu.delta_angle_dt)) {
+        _accel_integrator.reset(delta_velocity, imu.delta_velocity_dt);
+        _gyro_integrator.reset(delta_angle, imu.delta_angle_dt);
 
 		if (_accel_calibration.enabled() && _gyro_calibration.enabled()) {
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -238,20 +238,18 @@ void VehicleIMU::Run()
 		}
 
 		// publish if both accel & gyro integrators are ready
-		if (_intervals_configured && _accel_integrator.integral_ready() && _gyro_integrator.integral_ready()) {
-			if (Publish()) {
-				// record gyro publication latency and integrated samples
-				if (_gyro_update_latency_mean.count() > 10000) {
-					// reset periodically to avoid numerical issues
-					_gyro_update_latency_mean.reset();
-				}
-
-				const float time_run_s = now_us * 1e-6f;
-
-				_gyro_update_latency_mean.update(Vector2f{time_run_s - _gyro_timestamp_sample_last * 1e-6f, time_run_s - _gyro_timestamp_last * 1e-6f});
-
-				break;
+		if (Publish()) {
+			// record gyro publication latency and integrated samples
+			if (_gyro_update_latency_mean.count() > 10000) {
+				// reset periodically to avoid numerical issues
+				_gyro_update_latency_mean.reset();
 			}
+
+			const float time_run_s = now_us * 1e-6f;
+
+			_gyro_update_latency_mean.update(Vector2f{time_run_s - _gyro_timestamp_sample_last * 1e-6f, time_run_s - _gyro_timestamp_last * 1e-6f});
+
+			break;
 		}
 
 		// finish if there are no more updates, but didn't publish
@@ -543,13 +541,14 @@ bool VehicleIMU::Publish()
 {
 	bool updated = false;
 
-    if (_accel_integrator.integral_ready() && _gyro_integrator.integral_ready()) {
-        vehicle_imu_s imu;
-        Vector3f delta_angle;
-        Vector3f delta_velocity;
+	// publish if both accel & gyro integrators are ready
+	if (_intervals_configured && _accel_integrator.integral_ready() && _gyro_integrator.integral_ready()) {
+		vehicle_imu_s imu;
+		Vector3f delta_angle;
+		Vector3f delta_velocity;
 
-        _accel_integrator.reset(delta_velocity, imu.delta_velocity_dt);
-        _gyro_integrator.reset(delta_angle, imu.delta_angle_dt);
+		_accel_integrator.reset(delta_velocity, imu.delta_velocity_dt);
+		_gyro_integrator.reset(delta_angle, imu.delta_angle_dt);
 
 		if (_accel_calibration.enabled() && _gyro_calibration.enabled()) {
 


### PR DESCRIPTION
Replacing `reset` with `integral_ready` as the latter call don't have any side effect.

**Describe problem solved by this pull request**
In the version between `1.12.0` and `1.13.0-alpha` (current version), the `VehicleIMU` module use the publish condition as below.
https://github.com/PX4/PX4-Autopilot/blob/0d31aadcc3438f082a90eaa13ebf4d183ecbdb15/src/modules/sensors/vehicle_imu/VehicleIMU.cpp#L542-L552
 
The `reset` API return true if the integrator is ready, just like `integral_ready` do.
The problem is, the function `reset` has additional side-effect: it will also reset the integrator.
**In case of only one integrator is ready, this condition will also DROP out the integral value instead of keep it until next successful publishment.**

**Describe your solution**
**The publishment should either done thoroughly, or do nothing at all.** Thus, this PR rollback the condition to `integral_ready` and commence `reset` when and only when both integrators are ready.

