### PR TITLE
add custom target for uorb_sources_microcdr_gen

### DIFF
--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -170,9 +170,12 @@ if (GENERATE_RTPS_BRIDGE)
 		COMMENT "Generating uORB microcdr topic sources"
 		VERBATIM
 	)
+	add_custom_target(uorb_sources_microcdr_gen DEPENDS ${uorb_sources_microcdr})
+
 	px4_add_library(uorb_msgs_microcdr ${uorb_sources_microcdr} ${uorb_headers_microcdr})
 	add_dependencies(uorb_msgs_microcdr
 		uorb_headers_microcdr_gen
+		uorb_sources_microcdr_gen
 		git_micro_cdr
 		microcdr
 	)


### PR DESCRIPTION
Hi,

I found some compile error when building the px4_fmu-v5x_rtps like #19323.

```
[  1%] Built target parameters_xml
make[3]: *** No rule to make target 'src/modules/micrortps_bridge/topics_microcdr_sources/collision_constraints.cpp', needed by 'events/px4.json'.  Stop.
make[2]: *** [CMakeFiles/Makefile2:17874: src/lib/events/CMakeFiles/events_json.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
[  1%] Built target git_nuttx
```

To solve this problem, I fix the cmake file  by adding the add_custom_target  for uorb_sources_microcdr_gen.

Please check the modified cmake file.

Thanks in advance.
