### PR TITLE
Range finder kinematic consistency check

### DIFF
--- a/src/modules/ekf2/CMakeLists.txt
+++ b/src/modules/ekf2/CMakeLists.txt
@@ -64,6 +64,7 @@ px4_add_module(
 		EKF/mag_control.cpp
 		EKF/mag_fusion.cpp
 		EKF/optflow_fusion.cpp
+		EKF/range_finder_consistency_check.cpp
 		EKF/sensor_range_finder.cpp
 		EKF/sideslip_fusion.cpp
 		EKF/terrain_estimator.cpp

--- a/src/modules/ekf2/EKF/CMakeLists.txt
+++ b/src/modules/ekf2/EKF/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(ecl_EKF
 	mag_control.cpp
 	mag_fusion.cpp
 	optflow_fusion.cpp
+	range_finder_consistency_check.cpp
 	sensor_range_finder.cpp
 	sideslip_fusion.cpp
 	terrain_estimator.cpp

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -828,7 +828,7 @@ void Ekf::checkVerticalAccelerationHealth()
 void Ekf::controlHeightFusion()
 {
 	checkRangeAidSuitability();
-	const bool do_range_aid = (_params.range_aid == 1) && isRangeAidSuitable();
+	const bool do_range_aid = (_params.range_aid == 1) && _is_range_aid_suitable;
 
 	switch (_params.vdist_sensor_type) {
 	default:

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -140,6 +140,7 @@ void Ekf::controlFusionModes()
 			const Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
 			const Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
 			_range_sensor.setRange(_range_sensor.getRange() + pos_offset_earth(2) / _range_sensor.getCosTilt());
+			_rng_consistency_check.update(_range_sensor.getDistBottom(), getRngHeightVariance(), _state.vel(2), P(6, 6), static_cast<float>(_time_last_imu) * 1e-6f);
 		}
 	}
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -930,8 +930,9 @@ private:
 
 	void updateGroundEffect();
 
-	// return an estimation of the GPS altitude variance
+	// return an estimation of the sensor altitude variance
 	float getGpsHeightVariance();
+	float getRngHeightVariance() const;
 
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -899,7 +899,6 @@ private:
 
 	// determine if flight condition is suitable to use range finder instead of the primary height sensor
 	void checkRangeAidSuitability();
-	bool isRangeAidSuitable() const { return _is_range_aid_suitable; }
 
 	// set control flags to use baro height
 	void setControlBaroHeight();

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1361,6 +1361,14 @@ void Ekf::updateBaroHgtBias()
 	}
 }
 
+float Ekf::getRngHeightVariance() const
+{
+	const float dist_dependant_var = sq(_params.range_noise_scaler * _range_sensor.getDistBottom());
+	const float var = sq(_params.range_noise) + dist_dependant_var;
+	const float var_sat = fmaxf(var, 0.01f);
+	return var_sat;
+}
+
 void Ekf::updateGroundEffect()
 {
 	if (_control_status.flags.in_air && !_control_status.flags.fixed_wing) {

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -63,6 +63,7 @@
 #include "common.h"
 #include "RingBuffer.h"
 #include "imu_down_sampler.hpp"
+#include "range_finder_consistency_check.hpp"
 #include "sensor_range_finder.hpp"
 #include "utils.hpp"
 
@@ -296,6 +297,8 @@ protected:
 	extVisionSample _ev_sample_delayed{};
 	extVisionSample _ev_sample_delayed_prev{};
 	dragSample _drag_down_sampled{};	// down sampled drag specific force data (filter prediction rate -> observation rate)
+
+	RangeFinderConsistencyCheck _rng_consistency_check;
 
 	float _air_density{CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C};		// air density (kg/m**3)
 

--- a/src/modules/ekf2/EKF/range_finder_consistency_check.cpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.cpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file range_finder_consistency_check.cpp
+ */
+
+#include "range_finder_consistency_check.hpp"
+
+void RangeFinderConsistencyCheck::update(float dist_bottom, float dist_bottom_var, float vz, float vz_var, float time_s)
+{
+	const float dt = time_s - _time_last_update_s;
+
+	if ((_time_last_update_s < FLT_EPSILON)
+	    || (dt < 0.001f) || (dt > 0.5f)) {
+		_time_last_update_s = time_s;
+		_dist_bottom_prev = dist_bottom;
+		return;
+	}
+
+	const float vel_bottom = (dist_bottom - _dist_bottom_prev) / dt;
+	const float innov = -vel_bottom - vz; // vel_bottom is +up while vz is +down
+	const float vel_bottom_var = 2.f * dist_bottom_var / (dt * dt);
+	const float innov_var = vel_bottom_var + vz_var;
+	const float normalized_innov_sq = (innov * innov) / innov_var;
+	_vel_bottom_test_ratio = normalized_innov_sq / (_vel_bottom_gate * _vel_bottom_gate);
+
+	_vel_bottom_signed_test_ratio_lpf.setParameters(dt, _vel_bottom_signed_test_ratio_tau);
+	const float signed_test_ratio = matrix::sign(innov) * normalized_innov_sq / (_vel_bottom_signed_gate * _vel_bottom_signed_gate);
+	_vel_bottom_signed_test_ratio_lpf.update(signed_test_ratio);
+
+	_time_last_update_s = time_s;
+	_dist_bottom_prev = dist_bottom;
+}

--- a/src/modules/ekf2/EKF/range_finder_consistency_check.cpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.cpp
@@ -59,6 +59,21 @@ void RangeFinderConsistencyCheck::update(float dist_bottom, float dist_bottom_va
 	const float signed_test_ratio = matrix::sign(innov) * _vel_bottom_test_ratio;
 	_vel_bottom_signed_test_ratio_lpf.update(signed_test_ratio);
 
+	updateConsistency(vz, time_s);
+
 	_time_last_update_s = time_s;
 	_dist_bottom_prev = dist_bottom;
+}
+
+void RangeFinderConsistencyCheck::updateConsistency(float vz, float time_s)
+{
+	if (fabsf(_vel_bottom_signed_test_ratio_lpf.getState()) >= 1.f) {
+		_is_kinematically_consistent = false;
+		_time_last_inconsistent = time_s;
+
+	} else {
+		if (fabsf(vz) > _min_vz_for_valid_consistency && _vel_bottom_test_ratio < 1.f && ((time_s - _time_last_inconsistent) > _consistency_hyst_time)) {
+			_is_kinematically_consistent = true;
+		}
+	}
 }

--- a/src/modules/ekf2/EKF/range_finder_consistency_check.cpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.cpp
@@ -50,13 +50,13 @@ void RangeFinderConsistencyCheck::update(float dist_bottom, float dist_bottom_va
 
 	const float vel_bottom = (dist_bottom - _dist_bottom_prev) / dt;
 	const float innov = -vel_bottom - vz; // vel_bottom is +up while vz is +down
-	const float vel_bottom_var = 2.f * dist_bottom_var / (dt * dt);
+	const float vel_bottom_var = 2.f * dist_bottom_var / (dt * dt); // Variance of the time derivative of a random variable: var(dz/dt) = 2*var(z) / dt^2
 	const float innov_var = vel_bottom_var + vz_var;
 	const float normalized_innov_sq = (innov * innov) / innov_var;
 	_vel_bottom_test_ratio = normalized_innov_sq / (_vel_bottom_gate * _vel_bottom_gate);
 
 	_vel_bottom_signed_test_ratio_lpf.setParameters(dt, _vel_bottom_signed_test_ratio_tau);
-	const float signed_test_ratio = matrix::sign(innov) * normalized_innov_sq / (_vel_bottom_signed_gate * _vel_bottom_signed_gate);
+	const float signed_test_ratio = matrix::sign(innov) * _vel_bottom_test_ratio;
 	_vel_bottom_signed_test_ratio_lpf.update(signed_test_ratio);
 
 	_time_last_update_s = time_s;

--- a/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file range_finder_consistency_check.hpp
+ * @brief Compute statistical tests of the range finder data
+ * using the estimated velocity as a reference in order to detect sensor faults
+ */
+
+#pragma once
+
+#include <mathlib/math/filter/AlphaFilter.hpp>
+
+class RangeFinderConsistencyCheck final
+{
+public:
+	RangeFinderConsistencyCheck() = default;
+	~RangeFinderConsistencyCheck() = default;
+
+	void update(float dist_bottom, float dist_bottom_var, float vz, float vz_var, float time_s);
+
+	float getTestRatio() const { return _vel_bottom_test_ratio; }
+	float getSignedTestRatioLpf() const { return _vel_bottom_signed_test_ratio_lpf.getState(); }
+	bool isKinematicallyConsistent() const { return _vel_bottom_signed_test_ratio_lpf.getState() < 1.f; }
+
+private:
+	float _time_last_update_s{};
+	float _dist_bottom_prev{};
+
+	float _vel_bottom_test_ratio{};
+	AlphaFilter<float> _vel_bottom_signed_test_ratio_lpf{}; // average signed test ratio used to detect a bias in the data
+
+	static constexpr float _vel_bottom_signed_test_ratio_tau = 2.f;
+	static constexpr float _vel_bottom_gate = 3.f;
+	static constexpr float _vel_bottom_signed_gate = 0.1f;
+};

--- a/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
@@ -51,15 +51,23 @@ public:
 
 	float getTestRatio() const { return _vel_bottom_test_ratio; }
 	float getSignedTestRatioLpf() const { return _vel_bottom_signed_test_ratio_lpf.getState(); }
-	bool isKinematicallyConsistent() const { return _vel_bottom_signed_test_ratio_lpf.getState() < 1.f; }
+	bool isKinematicallyConsistent() const { return _is_kinematically_consistent; }
 
 private:
+	void updateConsistency(float vz, float time_s);
+
 	float _time_last_update_s{};
 	float _dist_bottom_prev{};
 
 	float _vel_bottom_test_ratio{};
 	AlphaFilter<float> _vel_bottom_signed_test_ratio_lpf{}; // average signed test ratio used to detect a bias in the data
 
+	bool _is_kinematically_consistent{true};
+	float _time_last_inconsistent{};
+
 	static constexpr float _vel_bottom_signed_test_ratio_tau = 2.f;
 	static constexpr float _vel_bottom_gate = 0.1f;
+
+	static constexpr float _min_vz_for_valid_consistency = 0.5f;
+	static constexpr float _consistency_hyst_time = 1.f;
 };

--- a/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
@@ -61,6 +61,5 @@ private:
 	AlphaFilter<float> _vel_bottom_signed_test_ratio_lpf{}; // average signed test ratio used to detect a bias in the data
 
 	static constexpr float _vel_bottom_signed_test_ratio_tau = 2.f;
-	static constexpr float _vel_bottom_gate = 3.f;
-	static constexpr float _vel_bottom_signed_gate = 0.1f;
+	static constexpr float _vel_bottom_gate = 0.1f;
 };

--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -95,9 +95,9 @@ void Ekf::controlHaglRngFusion()
 	}
 
 	if (_range_sensor.isDataHealthy()) {
-		const bool continuing_conditions_passing = _control_status.flags.in_air;
+		const bool continuing_conditions_passing = _control_status.flags.in_air && _rng_consistency_check.isKinematicallyConsistent();
 		//const bool continuing_conditions_passing = _control_status.flags.in_air && !_control_status.flags.rng_hgt; // TODO: should not be fused when using range height
-		const bool starting_conditions_passing = continuing_conditions_passing && _range_sensor.isRegularlySendingData();
+		const bool starting_conditions_passing = continuing_conditions_passing && _range_sensor.isRegularlySendingData() && (_rng_consistency_check.getTestRatio() < 1.f);
 
 		_time_last_healthy_rng_data = _time_last_imu;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
It is quite common that range finders are reporting incorrect data due to clouds, water, LOS blockage (e.g.: when attaching a payload) or other malfunction of the sensor itself. In most of those issues, the sensor quality metric is not a reliable source of truth.

**Describe your solution**
A kinematic consistency check is done by comparing the time derivative of the vertical distance measurement ("vel_bottom") and the vertical velocity estimate of EKF2. An inconsistency is detected when the normalized innovation squared (NIS) is on average greater than a defined threshold.

When the data is said "inconsistent" it requires several conditions to be valid again:
1. low averaged NIS for more than 1s
2. low NIS
3. significant vertical velocity

**Test data / coverage**
SITL testing for now

TODO:
- [ ] logging