### PR TITLE
print_load: Removed unused variable to fix compilation on macos

### DIFF
--- a/platforms/posix/src/px4/common/print_load.cpp
+++ b/platforms/posix/src/px4/common/print_load.cpp
@@ -116,7 +116,6 @@ void print_load(int fd, struct print_load_s *print_state)
 	mach_msg_type_number_t thread_info_count;
 
 	thread_basic_info_t basic_info_th;
-	uint32_t stat_thread = 0;
 
 	// get all threads of the PX4 main task
 	kr = task_threads(task_handle, &thread_list, &th_cnt);
@@ -124,10 +123,6 @@ void print_load(int fd, struct print_load_s *print_state)
 	if (kr != KERN_SUCCESS) {
 		PX4_WARN("ERROR getting thread list");
 		return;
-	}
-
-	if (th_cnt > 0) {
-		stat_thread += th_cnt;
 	}
 
 	long tot_sec = 0;


### PR DESCRIPTION

**Describe problem solved by this pull request**
On newer macOS (12.2+) the clang version that is shipped with the OS is more strict in detecting unused variables. This triggers 

```
/Users/thomas/auterion/PX4/platforms/posix/src/px4/common/print_load.cpp:119:11: fatal error: variable 'stat_thread' set but not used [-Wunused-but-set-variable]
        uint32_t stat_thread = 0;
```

This variable is indeed only set and never read. 

**Describe your solution**
This PR removes that variable.

**Describe possible alternatives**
`top` on POSIX sitl target is not available anyways, is this code even still used?

