### PR TITLE
MatrixHelperTest: correct wrap compare values

### DIFF
--- a/src/lib/matrix/test/MatrixHelperTest.cpp
+++ b/src/lib/matrix/test/MatrixHelperTest.cpp
@@ -48,11 +48,11 @@ TEST(MatrixHelperTest, Helper)
 	EXPECT_FLOAT_EQ(wrap(-1., 30., 40.), 39.);
 	EXPECT_FLOAT_EQ(wrap(-8000., -555., 1.), -216.);
 	EXPECT_FLOAT_EQ(wrap(0., 0., 360.), 0.);
-	EXPECT_FLOAT_EQ(wrap(0. - FLT_EPSILON, 0., 360.), 360.);
-	EXPECT_FLOAT_EQ(wrap(0. + FLT_EPSILON, 0., 360.), 0.);
+	EXPECT_FLOAT_EQ(wrap(0. - FLT_EPSILON, 0., 360.), 360. - FLT_EPSILON);
+	EXPECT_FLOAT_EQ(wrap(0. + FLT_EPSILON, 0., 360.), FLT_EPSILON);
 	EXPECT_FLOAT_EQ(wrap(360., 0., 360.), 0.);
-	EXPECT_FLOAT_EQ(wrap(360. - FLT_EPSILON, 0., 360.), 360.);
-	EXPECT_FLOAT_EQ(wrap(360. + FLT_EPSILON, 0., 360.), 0.);
+	EXPECT_FLOAT_EQ(wrap(360. - FLT_EPSILON, 0., 360.), 360. - FLT_EPSILON);
+	EXPECT_FLOAT_EQ(wrap(360. + FLT_EPSILON, 0., 360.), FLT_EPSILON);
 
 	// integer wraps
 	EXPECT_EQ(wrap(-10, 0, 10), 0);

--- a/src/lib/matrix/test/MatrixHelperTest.cpp
+++ b/src/lib/matrix/test/MatrixHelperTest.cpp
@@ -43,8 +43,8 @@ TEST(MatrixHelperTest, Helper)
 	EXPECT_FLOAT_EQ(wrap(4., 0., 1.), 0.);
 	EXPECT_FLOAT_EQ(wrap(-4., 0., 10.), 6.);
 	EXPECT_FLOAT_EQ(wrap(-18., 0., 10.), 2.);
-	EXPECT_FLOAT_EQ(wrap(-1.5, 3., 5.), 4.);
-	EXPECT_FLOAT_EQ(wrap(15.5, 3., 5.), 3.);
+	EXPECT_FLOAT_EQ(wrap(-1.5, 3., 5.), 4.5);
+	EXPECT_FLOAT_EQ(wrap(15.5, 3., 5.), 3.5);
 	EXPECT_FLOAT_EQ(wrap(-1., 30., 40.), 39.);
 	EXPECT_FLOAT_EQ(wrap(-8000., -555., 1.), -216.);
 	EXPECT_FLOAT_EQ(wrap(0., 0., 360.), 0.);


### PR DESCRIPTION
**Describe problem solved by this pull request**
A couple tests are failing after #19250. @dagar I'm wondering how this got past CI?

**Describe your solution**
Fixed two float compares -- just had wrong compare value for the wrapping functions, methods were calculating correctly.

TODO:
- [ ] the `+/-FLT_EPSILON` comparisons however are still failing - but maybe this is expected for a diff of `FLT_EPSILON` when using `EXPECT_FLOAT_EQ`? Could use `EXPECT_NEAR` instead?
https://github.com/PX4/PX4-Autopilot/blob/92b93811e3e67abff277491760887e155ff9935e/src/lib/matrix/test/MatrixHelperTest.cpp#L51-L52
```
[ RUN      ] MatrixHelperTest.Helper
../../src/lib/matrix/test/MatrixHelperTest.cpp:52: Failure
Expected equality of these values:
  wrap(0. + 1.19209289550781250000000000000000000e-7F, 0., 360.)
    Which is: 1.1920929e-07
  0.
    Which is: 0
../../src/lib/matrix/test/MatrixHelperTest.cpp:55: Failure
Expected equality of these values:
  wrap(360. + 1.19209289550781250000000000000000000e-7F, 0., 360.)
    Which is: 1.1920929e-07
  0.
    Which is: 0
[  FAILED  ] MatrixHelperTest.Helper (0 ms)
```

**Test data / coverage**
`make tests`
