### PR TITLE
Increase orbit radius limit & reject out of range radius commands

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -69,10 +69,16 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 	}
 
 	float new_velocity = signFromBool(new_is_clockwise) * new_absolute_velocity;
-	_started_clockwise = new_is_clockwise;
-	_sanitizeParams(new_radius, new_velocity);
-	_orbit_radius = new_radius;
-	_orbit_velocity = new_velocity;
+
+	if (math::isInRange(new_radius, _radius_min, _radius_max)) {
+		_started_clockwise = new_is_clockwise;
+		_sanitizeParams(new_radius, new_velocity);
+		_orbit_radius = new_radius;
+		_orbit_velocity = new_velocity;
+
+	} else {
+		ret = false;
+	}
 
 	// commanded heading behaviour
 	if (PX4_ISFINITE(command.param3)) {

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -70,7 +70,7 @@ protected:
 private:
 	/* TODO: Should be controlled by params */
 	static constexpr float _radius_min = 1.f;
-	static constexpr float _radius_max = 100.f;
+	static constexpr float _radius_max = 1e3f;
 	static constexpr float _velocity_max = 10.f;
 	static constexpr float _acceleration_max = 2.f;
 	static constexpr float _horizontal_acceptance_radius = 2.f;


### PR DESCRIPTION
**Describe problem solved by this pull request**
For certain use cases the limit is just too low and if the limit is exceeded currently there a bug where the radius is just pruned instead of not executing the out of range orbit command.

Note: Not rejecting out of range radiuses is a regression:
https://github.com/PX4/PX4-Autopilot/commit/9bd46be1242535d5ec3da04c11d274aa22a2f805#diff-89127f427c1fc4e2fb02b97822ec75dc1bc7a4690ae4cd3aba8bc4f811250717L61

**Describe your solution**
- > the orbit radius is limited to 100m. If flying in open areas this limit is too strict.

  Makes it configurable by parameter. I'm open to suggestions for the default.
  
- > When commanding a larger radius in AMC, it gets resized to 100m.

  Fixes the bug by not acknowledging the command and stopping instead of executing the Orbit.
This is already better than just changing the radius and then starting to execute but it should be further improved with e.g. an error message and possibly by switching mode.

**Test data / coverage**
SITL testing with out-of-range radiuses and hitting the limit by stick input.