### PR TITLE
Fix VTOL takeoff loitering around home instead of loiter point

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -546,9 +546,10 @@ void Navigator::run()
 
 				publish_vehicle_command_ack(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
-			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
-				// reset cruise speed and throttle to default when transitioning
-				set_cruising_speed();
+			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION
+				   && get_vstatus()->nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF) {
+				// reset cruise speed and throttle to default when transitioning (VTOL Takeoff handles it separately)
+				reset_cruising_speed();
 				set_cruising_throttle();
 
 				// need to update current setpooint with reset cruise speed and throttle


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
VTOL takeoff navigation mode was broken. Once the vehicle was loitering and switched to loiter, it would fly back to home and loiter there.

**Describe your solution**
Don't reset cruise speed and throttle after a vtol transition as part of the VTOL takeoff navigation mode.

**Describe possible alternatives**
None

**Test data / coverage**
SITL
