### PR TITLE
For linux: add a checker before inserting a schedule node into the queue.

### DIFF
--- a/platforms/posix/src/px4/common/drv_hrt.cpp
+++ b/platforms/posix/src/px4/common/drv_hrt.cpp
@@ -253,11 +253,6 @@ hrt_call_enter(struct hrt_call *entry)
 			next = (struct hrt_call *)sq_next(&call->link);
 
 			if ((next == nullptr) || (entry->deadline < next->deadline)) {
-				if (&call->link == &entry->link) {
-					PX4_ERR("Warning: cycle apear!");
-
-					while (1);
-				}
 				//lldbg("call enter after head\n");
 				sq_addafter(&call->link, &entry->link, &callout_queue);
 				break;

--- a/platforms/posix/src/px4/common/drv_hrt.cpp
+++ b/platforms/posix/src/px4/common/drv_hrt.cpp
@@ -253,6 +253,11 @@ hrt_call_enter(struct hrt_call *entry)
 			next = (struct hrt_call *)sq_next(&call->link);
 
 			if ((next == nullptr) || (entry->deadline < next->deadline)) {
+				if (&call->link == &entry->link) {
+					PX4_ERR("Warning: cycle apear!");
+
+					while (1);
+				}
 				//lldbg("call enter after head\n");
 				sq_addafter(&call->link, &entry->link, &callout_queue);
 				break;
@@ -434,14 +439,10 @@ hrt_call_invoke()
 			break;
 		}
 
-		sq_rem(&call->link, &callout_queue);
 		//PX4_INFO("call pop");
 
 		/* save the intended deadline for periodic calls */
 		deadline = call->deadline;
-
-		/* zero the deadline, as the call has occurred */
-		call->deadline = 0;
 
 		/* invoke the callout (if there is one) */
 		if (call->callout) {
@@ -453,6 +454,11 @@ hrt_call_invoke()
 
 			hrt_lock();
 		}
+
+		/* zero the deadline, as the call has occurred */
+		call->deadline = 0;
+
+		sq_rem(&call->link, &callout_queue);
 
 		/* if the callout has a non-zero period, it has to be re-entered */
 		if (call->period != 0) {


### PR DESCRIPTION
Signed-off-by: ncer <huangzzk@bupt.edu.cn>

**Describe problem solved by this pull request**
To issue:  #19358 
https://github.com/PX4/PX4-Autopilot/issues/19358

There are chances to produce a cycle in schedule queue (`node-> flink == node`)on  linux. In such case, if we traverse the queue, we will trap in the loop.


**Describe your solution**
Add a checker before insert the node into queue, to make sure the cycle would not be produced.

**Test data / coverage**
try to restart px4 for sometimes(for weak cpu, just restarting PX4 can reproduce the issue. For stronger cpu, need to execute some commands like ` sudo i2cdetect -y -a 0` to cause schedule jitter )

![20220321210455](https://user-images.githubusercontent.com/9284611/159266824-7d342be3-70e4-4121-a257-475a073b5331.jpg)
（The Debug Info: "Warning: cycle apear!"  has been removed in the commit,  just to clearly show the issue reproduced)

and because we have add the checker, we don't insert the node to produce a cycle. so the threads work normally:
![20220321210512](https://user-images.githubusercontent.com/9284611/159266815-c2cda311-fcd1-484f-8066-82c5bf5dff06.jpg)


**Additional context**
Please let me know if you have a batter ways to resolve this issue or advices.
