### PR TITLE
Test and fix sign function

### DIFF
--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -152,6 +152,12 @@ Type unwrap_pi(const Type last_angle, const Type new_angle)
 	return unwrap(last_angle, new_angle, Type(-M_PI), Type(M_PI));
 }
 
+/**
+ * Type-safe sign/signum function
+ *
+ * @param[in] val Number to take the sign from
+ * @return -1 if val < 0, 0 if val == 0, 1 if val > 0
+ */
 template<typename T>
 int sign(T val)
 {

--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -155,7 +155,7 @@ Type unwrap_pi(const Type last_angle, const Type new_angle)
 template<typename T>
 int sign(T val)
 {
-	return (T(FLT_EPSILON) < val) - (val < T(FLT_EPSILON));
+	return (T(0) < val) - (val < T(0));
 }
 
 } // namespace matrix

--- a/src/lib/matrix/test/MatrixHelperTest.cpp
+++ b/src/lib/matrix/test/MatrixHelperTest.cpp
@@ -36,6 +36,24 @@
 
 using namespace matrix;
 
+TEST(MatrixHelperTest, SignFloat)
+{
+	EXPECT_FLOAT_EQ(sign(-100.f), -1.f);
+	EXPECT_FLOAT_EQ(sign(-FLT_EPSILON), -1.f);
+	EXPECT_FLOAT_EQ(sign(0.f), 0.f);
+	EXPECT_FLOAT_EQ(sign(FLT_EPSILON), 1.f);
+	EXPECT_FLOAT_EQ(sign(100.f), 1.f);
+}
+
+TEST(MatrixHelperTest, SignInt)
+{
+	EXPECT_FLOAT_EQ(sign(-100), -1);
+	EXPECT_FLOAT_EQ(sign(-1), -1);
+	EXPECT_FLOAT_EQ(sign(0), 0);
+	EXPECT_FLOAT_EQ(sign(1), 1);
+	EXPECT_FLOAT_EQ(sign(100), 1);
+}
+
 TEST(MatrixHelperTest, Helper)
 {
 	// general wraps


### PR DESCRIPTION
**Describe problem solved by this pull request**
Fixes #19361 thanks to @tstastny !
- The sign function has no documentation
- There are no unit tests for the sign function
- The sign function has a bug where unexpectedly sign(0) = -1 and sign(FLT_EPSILON) = 0

**Describe your solution**
Add documentation and unit tests.
For the bug, I'm really not sure why the putative deadzone was added here: https://github.com/PX4/PX4-Autopilot/pull/12905/files#diff-b76fc4ece0dac2e83a0e972fbea85372175487ed12f9146ee211252e51da3494R51
It never worked before. It would need to be `(T(FLT_EPSILON) < val) - (val < -T(FLT_EPSILON))`.

**Describe possible alternatives**
We could add another sign function that has a configurable deadzone with a default parameter value if there's the need. Also we should move it back to the PX4 math::Functions.

**Test data / coverage**
New unit tests.

**Additional context**
- The sign function was added in https://github.com/PX4/PX4-Autopilot/pull/6638/files#diff-9c4d6427fcd835e10b4d068f53389a16801aac8628578944e0e88b8747e2798fR50
- used for quaternion conjugation corner cases in https://github.com/PX4/PX4-Autopilot/commit/e81483a808ce7b0217c11d3dc0fce90685f44353#diff-1de2137691523f51e9a4a2a3f5fdaed75974729fd912cda6f0612bab751d3993R82
- duplicate in PX4 math removed in https://github.com/PX4/PX4-Autopilot/pull/14374/files#diff-b76fc4ece0dac2e83a0e972fbea85372175487ed12f9146ee211252e51da3494L49
