### PR TITLE
Fix MAV_TYPE_VTOL_RESERVED2 & 3 not declared compile issue

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1516,9 +1516,9 @@ void MavlinkReceiver::fill_thrust(float *thrust_body_array, uint8_t vehicle_type
 
 	case MAV_TYPE_VTOL_DUOROTOR:
 	case MAV_TYPE_VTOL_QUADROTOR:
+	case MAV_TYPE_VTOL_FIXEDROTOR:
+	case MAV_TYPE_VTOL_TAILSITTER:
 	case MAV_TYPE_VTOL_TILTROTOR:
-	case MAV_TYPE_VTOL_RESERVED2:
-	case MAV_TYPE_VTOL_RESERVED3:
 	case MAV_TYPE_VTOL_RESERVED4:
 	case MAV_TYPE_VTOL_RESERVED5:
 		switch (vehicle_type) {

--- a/src/modules/mavlink/streams/HIL_ACTUATOR_CONTROLS.hpp
+++ b/src/modules/mavlink/streams/HIL_ACTUATOR_CONTROLS.hpp
@@ -95,7 +95,7 @@ private:
 				    system_type == MAV_TYPE_OCTOROTOR ||
 				    system_type == MAV_TYPE_VTOL_DUOROTOR ||
 				    system_type == MAV_TYPE_VTOL_QUADROTOR ||
-				    system_type == MAV_TYPE_VTOL_RESERVED2) {
+				    system_type == MAV_TYPE_VTOL_FIXEDROTOR) {
 
 					/* multirotors: set number of rotor outputs depending on type */
 
@@ -118,7 +118,7 @@ private:
 						n = 4;
 						break;
 
-					case MAV_TYPE_VTOL_RESERVED2:
+					case MAV_TYPE_VTOL_FIXEDROTOR:
 						n = 8;
 						break;
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -132,7 +132,7 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 			is_fixed_wing = false;
 			break;
 
-		case MAV_TYPE_VTOL_RESERVED2:
+		case MAV_TYPE_VTOL_FIXEDROTOR:
 			pos_thrust_motors_count = 5;
 			is_fixed_wing = false;
 			break;
@@ -142,7 +142,7 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 			is_fixed_wing = false;
 			break;
 
-		case MAV_TYPE_VTOL_RESERVED3:
+		case MAV_TYPE_VTOL_TAILSITTER:
 			// this is the tricopter VTOL / quad plane with 3 motors and 2 servos
 			pos_thrust_motors_count = 3;
 			is_fixed_wing = false;


### PR DESCRIPTION
**Describe problem solved by this pull request**
![image](https://user-images.githubusercontent.com/23277211/159534649-cc692939-5fd1-4819-b39d-3bf8955c4a56.png)
When trying to build `atl_mantis_edu` target, I had the error as shown in image above.

**Describe your solution**
I have removed 2 & 3rd instance of VTOL RESERVED airframe from the source code. But not even sure what this actually does :)

**Describe possible alternatives**
I am honestly not sure if this is a right solution. I just did this hot fix since I wanted to flash the PX4 into the ATL Mantis I had. So would appreciate a review :)

**Additional context**
MAV_TYPE_VTOL_RESERVED2 was removed from this PR : https://github.com/mavlink/mavlink/pull/1808
