### PR TITLE
metadata.cmake: enable ethernet parameters

### DIFF
--- a/cmake/metadata.cmake
+++ b/cmake/metadata.cmake
@@ -65,6 +65,7 @@ add_custom_target(metadata_parameters
 		--params-file ${generated_params_dir}/module_params.c
 		--timer-config ${PX4_SOURCE_DIR}/boards/px4/fmu-v5/src/timer_config.cpp # select a typical board
 		--board-with-io
+		--ethernet
 		--config-files ${yaml_config_files} #--verbose
 
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py


### PR DESCRIPTION
@hamishwillee this adds the ethernet params (`MAV_${i}_BROADCAST` etc) to the docs.

At some point we'll need handle this per-board, but this still works for now.