### PR TITLE
Initialize global local  projection for rovers

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -421,17 +421,17 @@ RoverPositionControl::Run()
 
 			position_setpoint_triplet_poll();
 
+			if (!_global_local_proj_ref.isInitialized()
+			    || (_global_local_proj_ref.getProjectionReferenceTimestamp() != _local_pos.ref_timestamp)) {
+
+				_global_local_proj_ref.initReference(_local_pos.ref_lat, _local_pos.ref_lon,
+								     _local_pos.ref_timestamp);
+
+				_global_local_alt0 = _local_pos.ref_alt;
+			}
+
 			// Convert Local setpoints to global setpoints
 			if (_control_mode.flag_control_offboard_enabled) {
-				if (!_global_local_proj_ref.isInitialized()
-				    || (_global_local_proj_ref.getProjectionReferenceTimestamp() != _local_pos.ref_timestamp)) {
-
-					_global_local_proj_ref.initReference(_local_pos.ref_lat, _local_pos.ref_lon,
-									     _local_pos.ref_timestamp);
-
-					_global_local_alt0 = _local_pos.ref_alt;
-				}
-
 				_trajectory_setpoint_sub.update(&_trajectory_setpoint);
 
 				// local -> global


### PR DESCRIPTION
**Describe problem solved by this pull request**
The L1 controller now uses local coordinates after https://github.com/PX4/PX4-Autopilot/pull/19347, but for rovers the projection operator was not initialized for rovers if the rover was not in offboard mode


The mavros mission tests on rover caught the problem: 

![image](https://user-images.githubusercontent.com/5248102/159873738-243b8113-4cd5-4e92-af3e-787b7113dd26.png)


**Describe your solution**
This commit initializes the global and local projection for rovers

**Test data / coverage**


**Additional context**
- This fixes a regression introduced by https://github.com/PX4/PX4-Autopilot/pull/19347