### PR TITLE
ekf2: allow yaw estimator to run when disarmed (if not at rest)

### DIFF
--- a/msg/yaw_estimator_status.msg
+++ b/msg/yaw_estimator_status.msg
@@ -3,6 +3,7 @@ uint64 timestamp_sample         # the timestamp of the raw data (microseconds)
 
 float32 yaw_composite	# composite yaw from GSF (rad)
 float32 yaw_variance	# composite yaw variance from GSF (rad^2)
+bool yaw_composite_valid
 
 float32[5] yaw		# yaw estimate for each model in the filter bank (rad)
 float32[5] innov_vn	# North velocity innovation for each model in the filter bank (m/s)

--- a/src/modules/ekf2/EKF/EKFGSF_yaw.cpp
+++ b/src/modules/ekf2/EKF/EKFGSF_yaw.cpp
@@ -23,7 +23,6 @@ void EKFGSF_yaw::update(const imuSample &imu_sample,
 	_delta_vel = imu_sample.delta_vel;
 	_delta_ang_dt = imu_sample.delta_ang_dt;
 	_delta_vel_dt = imu_sample.delta_vel_dt;
-	_run_ekf_gsf = run_EKF;
 	_true_airspeed = airspeed;
 
 	// to reduce effect of vibration, filter using an LPF whose time constant is 1/10 of the AHRS tilt correction time constant
@@ -60,7 +59,7 @@ void EKFGSF_yaw::update(const imuSample &imu_sample,
 	}
 
 	// The 3-state EKF models only run when flying to avoid corrupted estimates due to operator handling and GPS interference
-	if (_run_ekf_gsf && _vel_data_updated) {
+	if (run_EKF && _vel_data_updated) {
 		if (!_ekf_gsf_vel_fuse_started) {
 			initialiseEKFGSF();
 			ahrsAlignYaw();
@@ -111,7 +110,7 @@ void EKFGSF_yaw::update(const imuSample &imu_sample,
 			}
 		}
 
-	} else if (_ekf_gsf_vel_fuse_started && !_run_ekf_gsf) {
+	} else if (_ekf_gsf_vel_fuse_started && !run_EKF) {
 		// wait to fly again
 		_ekf_gsf_vel_fuse_started = false;
 	}

--- a/src/modules/ekf2/EKF/EKFGSF_yaw.h
+++ b/src/modules/ekf2/EKF/EKFGSF_yaw.h
@@ -108,7 +108,6 @@ private:
 	} _ekf_gsf[N_MODELS_EKFGSF] {};
 
 	bool _vel_data_updated{};	// true when velocity data has been updated
-	bool _run_ekf_gsf{};		// true when operating condition is suitable for to run the GSF and EKF models and fuse velocity data
 	Vector2f _vel_NE{};        // NE velocity observations (m/s)
 	float _vel_accuracy{};     // 1-sigma accuracy of velocity observations (m/s)
 	bool _ekf_gsf_vel_fuse_started{}; // true when the EKF's have started fusing velocity data and the prediction and update processing is active

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -330,6 +330,9 @@ public:
 	bool getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF],
 			   float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]);
 
+	// Returns true if the output of the yaw emergency estimator can be used for a reset
+	bool isYawEmergencyEstimateAvailable() const;
+
 	const BaroBiasEstimator::status &getBaroBiasEstimatorStatus() const { return _baro_b_est.getStatus(); }
 
 private:
@@ -1043,9 +1046,6 @@ private:
 	// Resets the horizontal velocity and position to the default navigation sensor
 	// Returns true if the reset was successful
 	bool resetYawToEKFGSF();
-
-	// Returns true if the output of the yaw emergency estimator can be used for a reset
-	bool isYawEmergencyEstimateAvailable() const;
 
 	void resetGpsDriftCheckFilters();
 };

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1770,7 +1770,7 @@ void Ekf::runYawEKFGSF()
 {
 	float TAS = 0.f;
 
-	if (_control_status.flags.fixed_wing) {
+	if (_control_status.flags.fixed_wing && _control_status.flags.in_air) {
 		if (isTimedOut(_airspeed_sample_delayed.time_us, 1000000)) {
 			TAS = _params.EKFGSF_tas_default;
 
@@ -1779,8 +1779,10 @@ void Ekf::runYawEKFGSF()
 		}
 	}
 
+	const bool run_yaw_estimator = _control_status.flags.in_air || !_control_status.flags.vehicle_at_rest;
 	const Vector3f imu_gyro_bias = getGyroBias();
-	_yawEstimator.update(_imu_sample_delayed, _control_status.flags.in_air, TAS, imu_gyro_bias);
+
+	_yawEstimator.update(_imu_sample_delayed, run_yaw_estimator, TAS, imu_gyro_bias);
 
 	// basic sanity check on GPS velocity data
 	if (_gps_data_ready && _gps_sample_delayed.vacc > FLT_EPSILON &&

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1334,6 +1334,7 @@ void EKF2::PublishYawEstimatorStatus(const hrt_abstime &timestamp)
 			       yaw_est_test_data.innov_vn, yaw_est_test_data.innov_ve,
 			       yaw_est_test_data.weight)) {
 
+		yaw_est_test_data.yaw_composite_valid = _ekf.isYawEmergencyEstimateAvailable();
 		yaw_est_test_data.timestamp_sample = _ekf.get_imu_sample_delayed().time_us;
 		yaw_est_test_data.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 


### PR DESCRIPTION
This is to allow yaw estimator to run and potential perform yaw align before the vehicle is armed. Potentially useful for cases like https://github.com/PX4/PX4-Autopilot/issues/19393. 

https://github.com/PX4/PX4-Autopilot/blob/bc26b73c07d15527620a183abfe5c3ef21d39414/src/modules/ekf2/EKF/gps_control.cpp#L139-L147