### PR TITLE
Increase NAV_LOITER_RAD and RTL_LOITER_RAD to 80m each

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -71,7 +71,6 @@ param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_D_ACC 0.1
 
 param set-default NAV_ACC_RAD 5
-param set-default NAV_LOITER_RAD 80
 
 param set-default VT_FWD_THRUST_EN 4
 param set-default VT_F_TRANS_THR 0.75

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -70,7 +70,6 @@ param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_D_ACC 0.1
 
 param set-default NAV_ACC_RAD 5
-param set-default NAV_LOITER_RAD 80
 
 param set-default VT_FW_DIFTHR_EN 1
 param set-default VT_FW_DIFTHR_SC 0.5

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -82,7 +82,6 @@ param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_D_ACC 0.1
 
 param set-default NAV_ACC_RAD 5
-param set-default NAV_LOITER_RAD 80
 
 param set-default VT_B_TRANS_DUR 8
 param set-default VT_FWD_THRUST_EN 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
@@ -38,7 +38,6 @@ param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_D_ACC 0.1
 
 param set-default NAV_ACC_RAD 5
-param set-default NAV_LOITER_RAD 80
 
 param set-default VT_FWD_THRUST_EN 4
 param set-default VT_F_TRANS_THR 0.75

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -49,7 +49,6 @@ param set-default MPC_Z_VEL_MAX_DN 1.5
 
 param set-default NAV_ACC_RAD 5
 param set-default NAV_DLL_ACT 2
-param set-default NAV_LOITER_RAD 80
 
 param set-default RTL_DESCEND_ALT 10
 param set-default RTL_RETURN_ALT 30

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -52,7 +52,7 @@
  * @increment 0.5
  * @group Mission
  */
-PARAM_DEFINE_FLOAT(NAV_LOITER_RAD, 50.0f);
+PARAM_DEFINE_FLOAT(NAV_LOITER_RAD, 80.0f);
 
 /**
  * Acceptance Radius

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -161,7 +161,7 @@ PARAM_DEFINE_INT32(RTL_PLD_MD, 0);
  * @increment 0.5
  * @group Return Mode
  */
-PARAM_DEFINE_FLOAT(RTL_LOITER_RAD, 50.0f);
+PARAM_DEFINE_FLOAT(RTL_LOITER_RAD, 80.0f);
 
 /**
  * RTL heading mode


### PR DESCRIPTION
For many VTOLs/fixed-wing drones a 50m loiter radius is too tight, and
going to 80m is a better and safer default.

