### PR TITLE
Preflight storage: Do not reset flight UUID and total flight time on request from GCS

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1531,11 +1531,15 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 				} else if (((int)(cmd.param1)) == 2) {
 					answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
-					_worker_thread.startTask(WorkerThread::Request::ParamResetAll);
+					_worker_thread.startTask(WorkerThread::Request::ParamResetAllConfig);
 
 				} else if (((int)(cmd.param1)) == 3) {
 					answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
 					_worker_thread.startTask(WorkerThread::Request::ParamResetSensorFactory);
+
+				} else if (((int)(cmd.param1)) == 4) {
+					answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
+					_worker_thread.startTask(WorkerThread::Request::ParamResetAll);
 				}
 			}
 

--- a/src/modules/commander/worker_thread.cpp
+++ b/src/modules/commander/worker_thread.cpp
@@ -174,14 +174,26 @@ void WorkerThread::threadEntry()
 		_ret_value = 0;
 		break;
 
-	case Request::ParamResetSensorFactory:
-		const char *reset_cal[] = { "CAL_ACC*", "CAL_GYRO*", "CAL_MAG*" };
-		param_reset_specific(reset_cal, sizeof(reset_cal) / sizeof(reset_cal[0]));
-		_ret_value = param_save_default();
+	case Request::ParamResetSensorFactory: {
+			const char *reset_cal[] = { "CAL_ACC*", "CAL_GYRO*", "CAL_MAG*" };
+			param_reset_specific(reset_cal, sizeof(reset_cal) / sizeof(reset_cal[0]));
+			_ret_value = param_save_default();
 #if defined(CONFIG_BOARDCTL_RESET)
-		px4_reboot_request(false, 400_ms);
+			px4_reboot_request(false, 400_ms);
 #endif // CONFIG_BOARDCTL_RESET
-		break;
+			break;
+		}
+
+	case Request::ParamResetAllConfig: {
+			const char *exclude_list[] = {
+				"LND_FLIGHT_T_HI",
+				"LND_FLIGHT_T_LO",
+				"COM_FLIGHT_UUID"
+			};
+			param_reset_excludes(exclude_list, sizeof(exclude_list) / sizeof(exclude_list[0]));
+			_ret_value = 0;
+			break;
+		}
 	}
 
 	_state.store((int)State::Finished); // set this last to signal the main thread we're done

--- a/src/modules/commander/worker_thread.hpp
+++ b/src/modules/commander/worker_thread.hpp
@@ -64,6 +64,7 @@ public:
 		ParamSaveDefault,
 		ParamResetAll,
 		ParamResetSensorFactory,
+		ParamResetAllConfig
 	};
 
 	WorkerThread() = default;


### PR DESCRIPTION
**Describe problem solved by this pull request**
Some external tools require the flight uuid and autopilot uuid combination to be unique. If a vehicle is reset from the GCS with the reset command, the uuid and flight time get reset as well, which causes "duplicate" flights. Also, the total flight time is no longer truthful.

**Describe your solution**
This PR changes the default reset behaviour to exclude these params, while also introducing a way to still reset all by setting the PREFLIGHT_STORAGE message param1 to 4. Idea is that from GCS, user generally only wants to wipe config, but not "lifetime reporting" things, such as the total flight time. 

**Test data / coverage**
Tested on Pixhawk 4

**Additional context**
I'll also do a PR to mavlink to clarify the param usage + include value 4 to the range. 
mavlink PR: https://github.com/mavlink/mavlink/pull/1826