### PR TITLE
Fix reaction to rejected orbit command

### DIFF
--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -571,7 +571,7 @@ const char *FlightModeManager::errorToString(const FlightTaskError error)
 	switch (error) {
 	case FlightTaskError::NoError: return "No Error";
 
-	case FlightTaskError::InvalidTask: return "Invalid Task ";
+	case FlightTaskError::InvalidTask: return "Invalid Task";
 
 	case FlightTaskError::ActivationFailed: return "Activation Failed";
 	}

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -428,7 +428,7 @@ void FlightModeManager::handleCommand()
 
 					// if we just switched and parameters are not accepted, go to failsafe
 					if (switch_result >= FlightTaskError::NoError) {
-						switchTask(FlightTaskIndex::ManualPosition);
+						switchTask(FlightTaskIndex::Failsafe);
 						cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
 					}
 				}

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -429,7 +429,6 @@ void FlightModeManager::handleCommand()
 					// if we just switched and parameters are not accepted, go to failsafe
 					if (switch_result >= FlightTaskError::NoError) {
 						switchTask(FlightTaskIndex::Failsafe);
-						cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
 					}
 				}
 			}

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -415,11 +415,11 @@ void FlightModeManager::handleCommand()
 		// ignore all unkown commands
 		if (desired_task != FlightTaskIndex::None) {
 			// switch to the commanded task
-			FlightTaskError switch_result = switchTask(desired_task);
+			bool switch_succeeded = (switchTask(desired_task) == FlightTaskError::NoError);
 			uint8_t cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;
 
 			// if we are in/switched to the desired task
-			if (switch_result >= FlightTaskError::NoError) {
+			if (switch_succeeded) {
 				cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED;
 
 				// if the task is running apply parameters to it and see if it rejects
@@ -427,7 +427,7 @@ void FlightModeManager::handleCommand()
 					cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_DENIED;
 
 					// if we just switched and parameters are not accepted, go to failsafe
-					if (switch_result >= FlightTaskError::NoError) {
+					if (switch_succeeded) {
 						switchTask(FlightTaskIndex::Failsafe);
 					}
 				}
@@ -437,7 +437,6 @@ void FlightModeManager::handleCommand()
 			vehicle_command_ack_s command_ack{};
 			command_ack.command = command.command;
 			command_ack.result = cmd_result;
-			command_ack.result_param1 = static_cast<int>(switch_result);
 			command_ack.target_system = command.source_system;
 			command_ack.target_component = command.source_component;
 			command_ack.timestamp = hrt_absolute_time();

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -37,6 +37,7 @@
 
 #include "FlightTaskOrbit.hpp"
 
+#include <lib/systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 #include <px4_platform_common/events.h>
 #include <lib/geo/geo.h>
@@ -78,6 +79,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 		_orbit_velocity = new_velocity;
 
 	} else {
+		mavlink_log_critical(&_mavlink_log_pub, "Orbit radius limit exceeded\t");
 		events::send(events::ID("orbit_radius_exceeded"), events::Log::Alert, "Orbit radius limit exceeded");
 		ret = false;
 	}

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -38,6 +38,7 @@
 #include "FlightTaskOrbit.hpp"
 
 #include <mathlib/mathlib.h>
+#include <px4_platform_common/events.h>
 #include <lib/geo/geo.h>
 
 using namespace matrix;
@@ -77,6 +78,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 		_orbit_velocity = new_velocity;
 
 	} else {
+		events::send(events::ID("orbit_radius_exceeded"), events::Log::Alert, "Orbit radius limit exceeded");
 		ret = false;
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -128,6 +128,7 @@ private:
 	float _initial_heading = 0.f; /**< the heading of the drone when the orbit command was issued */
 	SlewRateYaw<float> _slew_rate_yaw;
 
+	orb_advert_t _mavlink_log_pub{nullptr};
 	uORB::PublicationMulti<orbit_status_s> _orbit_status_pub{ORB_ID(orbit_status)};
 
 	DEFINE_PARAMETERS(


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is a follow-up to https://github.com/PX4/PX4-Autopilot/pull/19362 fixing an already previoulsly existing bug. Thanks to @mrivi for finding it!

When commanding a too large Orbit she got invalid setpoints. I figured out that’s because since the introduction the command handling for flight tasks (which is only used for orbit yet) switches to the most basic position mode flight task upon command parameter rejection.

**Describe your solution**
- Switch to the failsafe flight task when command parameters were not accepted.
  - This makes the drone just stop and wait for further actions.
  - This solves getting invalid setpoint messages when no RC is connected.
  - This also solves ending up in an "aggressive" position mode unexpectedly.
- Report "denied" instead of "failed" as the command result in the acknowledgment for invalid parameters because that matches the MAVLink definition see: https://mavlink.io/en/messages/common.html#MAV_RESULT 
- Inform the user directly from the Orbit command processing when the radius exceeds the limit. This needs to be backward compatible with `mavlink_log` since AMC doesn't support events yet.
- Minor refactoring.

**Test data / coverage**
This was tested in simulation to solve the issue and result in an improved user experience because of the error message and the correct command result.