### PR TITLE
commander: preflight check minor optimization

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019-2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,8 @@
 #include <uORB/Subscription.hpp>
 
 using namespace time_literals;
+
+static constexpr unsigned MAX_SENSORS = 4;
 
 static constexpr unsigned max_mandatory_mag_count = 1;
 static constexpr unsigned max_mandatory_gyro_count = 1;
@@ -240,7 +242,7 @@ bool PreFlightCheck::sensorAvailabilityCheck(const bool report_failure,
 	bool report_fail = report_failure;
 
 	/* check all sensors, but fail only for mandatory ones */
-	for (uint8_t i = 0u; i < ORB_MULTI_MAX_INSTANCES; i++) {
+	for (uint8_t i = 0u; i < MAX_SENSORS; i++) {
 		const bool is_mandatory = i < nb_mandatory_instances;
 
 		if (!sens_check(mavlink_log_pub, status, i, is_mandatory, report_fail)) {

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,30 +102,39 @@ private:
 	static bool sensorAvailabilityCheck(const bool report_failure,
 					    const uint8_t nb_mandatory_instances, orb_advert_t *mavlink_log_pub,
 					    vehicle_status_s &status, sens_check_func_t sens_check);
-	static bool isMagRequired(uint8_t instance);
+
+	static bool isMagRequired(uint32_t device_id);
 	static bool magnetometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				      const bool is_mandatory, bool &report_fail);
 	static bool magConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
-	static bool isAccelRequired(uint8_t instance);
+
+	static bool isAccelRequired(uint32_t device_id);
 	static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				       const bool is_mandatory, bool &report_fail);
-	static bool isGyroRequired(uint8_t instance);
+
+	static bool isGyroRequired(uint32_t device_id);
 	static bool gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 			      const bool is_mandatory, bool &report_fail);
-	static bool isBaroRequired(uint8_t instance);
+
+	static bool isBaroRequired(uint32_t device_id);
 	static bool baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 			      const bool is_mandatory, bool &report_fail);
+
 	static bool distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				  const bool is_mandatory, bool &report_fail);
+
 	static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
+
 	static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool optional,
 				  const bool report_fail, const bool prearm, const bool max_airspeed_check_en, const float arming_max_airspeed_allowed);
+
 	static int rcCalibrationCheck(orb_advert_t *mavlink_log_pub, bool report_fail);
+
 	static bool powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,
 			       const bool prearm);
+
 	static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool optional,
 			      const bool report_fail);
-
 	static bool ekf2CheckSensorBias(orb_advert_t *mavlink_log_pub, const bool report_fail);
 
 	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,

--- a/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/baroCheck.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,41 +43,46 @@
 
 using namespace time_literals;
 
-bool PreFlightCheck::isBaroRequired(const uint8_t instance)
+bool PreFlightCheck::isBaroRequired(uint32_t device_id)
 {
-	uORB::SubscriptionData<sensor_baro_s> baro{ORB_ID(sensor_baro), instance};
-	const uint32_t device_id = static_cast<uint32_t>(baro.get().device_id);
-
-	bool is_used_by_nav = false;
-
 	for (uint8_t i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		uORB::SubscriptionData<estimator_status_s> estimator_status_sub{ORB_ID(estimator_status), i};
 
-		if (device_id > 0 && estimator_status_sub.get().baro_device_id == device_id) {
-			is_used_by_nav = true;
+		if (!estimator_status_sub.advertised()) {
 			break;
+		}
+
+		if (device_id != 0 && estimator_status_sub.get().baro_device_id == device_id) {
+			return true;
 		}
 	}
 
-	return is_used_by_nav;
+	return false;
 }
 
 bool PreFlightCheck::baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 			       const bool is_mandatory, bool &report_fail)
 {
-	const bool exists = (orb_exists(ORB_ID(sensor_baro), instance) == PX4_OK);
-	const bool is_required = is_mandatory || isBaroRequired(instance);
+	uORB::SubscriptionData<sensor_baro_s> baro{ORB_ID(sensor_baro), instance};
 
-	bool valid = false;
+	const bool exists = baro.advertised();
+
+	bool is_required = is_mandatory;
+	bool is_valid = false;
 
 	if (exists) {
-		uORB::SubscriptionData<sensor_baro_s> baro{ORB_ID(sensor_baro), instance};
 
-		valid = (baro.get().device_id != 0) && (baro.get().timestamp != 0) && (hrt_elapsed_time(&baro.get().timestamp) < 1_s);
+		is_valid = (baro.get().timestamp != 0) && (hrt_elapsed_time(&baro.get().timestamp) < 1_s);
+
+		if (is_valid) {
+			if (!is_required && isBaroRequired(baro.get().device_id)) {
+				is_required = true;
+			}
+		}
 	}
 
 	if (instance == 0) {
-		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_ABSPRESSURE, exists, is_required, valid, status);
+		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_ABSPRESSURE, exists, is_required, is_valid, status);
 	}
 
 	if (report_fail && is_required) {
@@ -85,11 +90,13 @@ bool PreFlightCheck::baroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Baro Sensor %u missing", instance);
 			report_fail = false;
 
-		} else if (!valid) {
+		} else if (!is_valid) {
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from Baro %u", instance);
 			report_fail = false;
 		}
 	}
 
-	return valid || !is_required;
+	const bool is_sensor_ok = is_valid;
+
+	return is_sensor_ok || !is_required;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/checks/distanceSensorChecks.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/distanceSensorChecks.cpp
@@ -34,9 +34,9 @@
 #include "../PreFlightCheck.hpp"
 
 #include <drivers/drv_hrt.h>
+#include <HealthFlags.h>
 #include <px4_defines.h>
 #include <systemlib/mavlink_log.h>
-#include <uORB/uORB.h>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/distance_sensor.h>
 
@@ -45,27 +45,30 @@ using namespace time_literals;
 bool PreFlightCheck::distSensCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const uint8_t instance,
 				   const bool is_mandatory, bool &report_fail)
 {
-	const bool exists = (orb_exists(ORB_ID(distance_sensor), instance) == PX4_OK);
-	bool valid = false;
+	uORB::SubscriptionData<distance_sensor_s> dist_sens_sub{ORB_ID(distance_sensor), instance};
+
+	const bool exists = dist_sens_sub.advertised();
+
+	bool is_required = is_mandatory;
+	bool is_valid = false;
 
 	if (exists) {
-		uORB::SubscriptionData<distance_sensor_s> dist_sens_sub{ORB_ID(distance_sensor), instance};
-		dist_sens_sub.update();
-		const distance_sensor_s &dist_sens_data = dist_sens_sub.get();
 
-		valid = (hrt_elapsed_time(&dist_sens_data.timestamp) < 1_s);
+		is_valid = (dist_sens_sub.get().timestamp != 0) && (hrt_elapsed_time(&dist_sens_sub.get().timestamp) < 1_s);
 	}
 
-	if (report_fail && is_mandatory) {
+	if (report_fail && is_required) {
 		if (!exists) {
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: distance sensor %u missing", instance);
 			report_fail = false;
 
-		} else if (!valid) {
+		} else if (!is_valid) {
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: no valid data from distance sensor %u", instance);
 			report_fail = false;
 		}
 	}
 
-	return valid || !is_mandatory;
+	const bool is_sensor_ok = is_valid;
+
+	return is_sensor_ok || !is_required;
 }


### PR DESCRIPTION
I was contemplating moving `commander` to a work queue and noticed that the preflight checks are quite slow. It doesn't really matter right now because we run them periodically (~ 1 Hz) in a lower priority thread, but it might in the future.

 - limit to 4 sensors
 - when iterating through estimator_status subscriptions break once they're no longer advertised
 - only proceed with calibration checks (checking all calibration slots) if the device id is populated
 - minor changes to keep things roughly aligned between accel/baro/distance/gyro/mag 

#### master
``` Console
nsh> commander status
INFO  [commander] arming: STANDBY
INFO  [commander] navigation: MANUAL
commander: cycle: 1303 events, 627197us elapsed, 481.35us avg, min 82us max 16327us 21118.385us rms
commander: preflight check: 29 events, 361609us elapsed, 12469.28us avg, min 10686us max 16208us 13505.922us rms
```


#### PR
``` Console
nsh> commander status
INFO  [commander] arming: STANDBY
INFO  [commander] navigation: MANUAL
commander: cycle: 531 events, 160720us elapsed, 302.67us avg, min 82us max 7411us 1647.625us rms
commander: preflight check: 12 events, 47280us elapsed, 3940.00us avg, min 2225us max 4872us 2372.114us rms
```

