### PR TITLE
Safety and button usage refactoring

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -52,6 +52,7 @@ set(msg_files
 	airspeed_wind.msg
 	autotune_attitude_control_status.msg
 	battery_status.msg
+	button_event.msg
 	camera_capture.msg
 	camera_status.msg
 	camera_trigger.msg

--- a/msg/button_event.msg
+++ b/msg/button_event.msg
@@ -1,0 +1,6 @@
+uint64 timestamp			# time since system start (microseconds)
+bool triggered				# Set to true if the event is triggered
+
+# TOPICS button_event safety_button
+
+uint8 ORB_QUEUE_LENGTH = 2

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_module(
 		module.yaml
 	DEPENDS
 		arch_px4io_serial
+		button_publisher
 		circuit_breaker
 		mixer_module
 	)

--- a/src/drivers/safety_button/CMakeLists.txt
+++ b/src/drivers/safety_button/CMakeLists.txt
@@ -37,6 +37,6 @@ px4_add_module(
 	SRCS
 		SafetyButton.cpp
 	DEPENDS
-		circuit_breaker
+		button_publisher
 		px4_work_queue
 	)

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -166,6 +166,7 @@ px4_add_module(
 		sensors/gyro.cpp
 		sensors/ice_status.cpp
 		sensors/hygrometer.cpp
+		sensors/safety_button.cpp
 
 	MODULE_CONFIG
 		module.yaml

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -174,6 +174,7 @@ px4_add_module(
 	DEPENDS
 		px4_uavcan_dsdlc
 
+		button_publisher
 		drivers_rangefinder
 		led
 		mixer

--- a/src/drivers/uavcan/sensors/safety_button.hpp
+++ b/src/drivers/uavcan/sensors/safety_button.hpp
@@ -34,7 +34,7 @@
 #pragma once
 
 #include "sensor_bridge.hpp"
-#include <uORB/topics/safety.h>
+#include "button/ButtonPublisher.hpp"
 
 #include <ardupilot/indication/Button.hpp>
 
@@ -61,6 +61,8 @@ private:
 		ButtonCbBinder;
 
 	uavcan::Subscriber<ardupilot::indication::Button, ButtonCbBinder> _sub_button;
-
-
+	ButtonPublisher _button_publisher;
+	uint8_t _pairing_button_counter{0u};
+	hrt_abstime _start_timestamp{0};
+	hrt_abstime _new_press_timestamp{0};
 };

--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -50,6 +50,7 @@
 #include "ice_status.hpp"
 #include "mag.hpp"
 #include "rangefinder.hpp"
+#include "safety_button.hpp"
 
 /*
  * IUavcanSensorBridge
@@ -143,6 +144,14 @@ void IUavcanSensorBridge::make_all(uavcan::INode &node, List<IUavcanSensorBridge
 
 	if (uavcan_sub_rng != 0) {
 		list.add(new UavcanRangefinderBridge(node));
+	}
+
+	// safety button
+	int32_t uavcan_sub_button = 1;
+	param_get(param_find("UAVCAN_SUB_BTN"), &uavcan_sub_button);
+
+	if (uavcan_sub_button != 0) {
+		list.add(new UavcanSafetyButtonBridge(node));
 	}
 }
 

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -310,7 +310,7 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_IMU, 0);
 /**
  * subscription magnetometer
  *
- * Enable UAVCAN GPS subscription.
+ * Enable UAVCAN mag subscription.
  *  uavcan::equipment::ahrs::MagneticFieldStrength
  *  uavcan::equipment::ahrs::MagneticFieldStrength2
  *
@@ -323,7 +323,7 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_MAG, 1);
 /**
  * subscription range finder
  *
- * Enable UAVCAN GPS subscription.
+ * Enable UAVCAN range finder subscription.
  *  uavcan::equipment::range_sensor::Measurement
  *
  * @boolean
@@ -331,3 +331,15 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_MAG, 1);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_SUB_RNG, 0);
+
+/**
+ * subscription button
+ *
+ * Enable UAVCAN button subscription.
+ *  ardupilot::indication::Button
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_SUB_BTN, 0);

--- a/src/lib/button/ButtonPublisher.cpp
+++ b/src/lib/button/ButtonPublisher.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,49 +31,54 @@
  *
  ****************************************************************************/
 
-#pragma once
+/**
+ * @file ButtonPublisher.cpp
+ *
+ * Library for button functionality.
+ *
+ */
 
-#include <float.h>
-
-#include <drivers/drv_hrt.h>
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <button/ButtonPublisher.hpp>
 
-class SafetyButton : public ModuleBase<SafetyButton>, public px4::ScheduledWorkItem
+using namespace time_literals;
+
+ButtonPublisher::ButtonPublisher()
 {
-public:
-	SafetyButton();
-	~SafetyButton() override;
+	_safety_button_pub.advertise();
+}
 
-	/** @see ModuleBase */
-	static int task_spawn(int argc, char *argv[]);
+void ButtonPublisher::safetyButtonTriggerEvent()
+{
 
-	/** @see ModuleBase */
-	static int custom_command(int argc, char *argv[]);
 
-	/** @see ModuleBase */
-	static int print_usage(const char *reason = nullptr);
+	button_event_s safety_button{};
+	safety_button.triggered = true;
+	safety_button.timestamp = hrt_absolute_time();
 
-	int Start();
+	_safety_button_pub.publish(safety_button);
+}
 
-private:
-	void Run() override;
+void ButtonPublisher::pairingButtonTriggerEvent()
+{
+	vehicle_command_s vcmd{};
+	vcmd.command = vehicle_command_s::VEHICLE_CMD_START_RX_PAIR;
+	vcmd.param1 = 10.f; // GCS pairing request handled by a companion.
+	vcmd.timestamp = hrt_absolute_time();
+	_vehicle_command_pub.publish(vcmd);
+	PX4_DEBUG("Sending GCS pairing request");
 
-	void CheckSafetyRequest(bool button_pressed);
-	void CheckPairingRequest(bool button_pressed);
-	void FlashButton();
+	led_control_s led_control{};
+	led_control.led_mask = 0xff;
+	led_control.mode = led_control_s::MODE_BLINK_FAST;
+	led_control.color = led_control_s::COLOR_GREEN;
+	led_control.num_blinks = 1;
+	led_control.priority = 0;
+	led_control.timestamp = hrt_absolute_time();
+	_led_control_pub.publish(led_control);
 
-	bool			_has_px4io{false};
-	ButtonPublisher	_button_publisher;
-	uint8_t			_button_counter{0};
-	uint8_t			_blink_counter{0};
-	bool			_button_prev_sate{false};	///< Previous state of the HW button
-
-	// Pairing request
-	hrt_abstime		_pairing_start{0};
-	int				_pairing_button_counter{0};
-
-	uORB::Subscription	_armed_sub{ORB_ID(actuator_armed)};
-
-};
+	tune_control_s tune_control{};
+	tune_control.tune_id = tune_control_s::TUNE_ID_NOTIFY_POSITIVE;
+	tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
+	tune_control.timestamp = hrt_absolute_time();
+	_tune_control_pub.publish(tune_control);
+}

--- a/src/lib/button/ButtonPublisher.hpp
+++ b/src/lib/button/ButtonPublisher.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,49 +31,47 @@
  *
  ****************************************************************************/
 
+/**
+ * @file ButtonPublisher.hpp
+ *
+ * Library for button functionality.
+ *
+ */
+
 #pragma once
 
-#include <float.h>
-
+#include <drivers/drv_tone_alarm.h>
 #include <drivers/drv_hrt.h>
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <button/ButtonPublisher.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/button_event.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/led_control.h>
+#include <uORB/topics/tune_control.h>
 
-class SafetyButton : public ModuleBase<SafetyButton>, public px4::ScheduledWorkItem
+class ButtonPublisher
 {
 public:
-	SafetyButton();
-	~SafetyButton() override;
+	ButtonPublisher();
+	~ButtonPublisher() = default;
 
-	/** @see ModuleBase */
-	static int task_spawn(int argc, char *argv[]);
+	/**
+	 * Function for publishing safety button trigger event
+	 */
+	void safetyButtonTriggerEvent();
 
-	/** @see ModuleBase */
-	static int custom_command(int argc, char *argv[]);
+	/**
+	 * Function for publishing pairing button trigger event
+	 */
+	void pairingButtonTriggerEvent();
 
-	/** @see ModuleBase */
-	static int print_usage(const char *reason = nullptr);
-
-	int Start();
+	static constexpr uint8_t PAIRING_BUTTON_EVENT_COUNT{3};
 
 private:
-	void Run() override;
-
-	void CheckSafetyRequest(bool button_pressed);
-	void CheckPairingRequest(bool button_pressed);
-	void FlashButton();
-
-	bool			_has_px4io{false};
-	ButtonPublisher	_button_publisher;
-	uint8_t			_button_counter{0};
-	uint8_t			_blink_counter{0};
-	bool			_button_prev_sate{false};	///< Previous state of the HW button
-
-	// Pairing request
-	hrt_abstime		_pairing_start{0};
-	int				_pairing_button_counter{0};
-
-	uORB::Subscription	_armed_sub{ORB_ID(actuator_armed)};
-
+	uORB::Publication<button_event_s>		_safety_button_pub{ORB_ID(safety_button)};
+	uORB::Publication<vehicle_command_s>	_vehicle_command_pub{ORB_ID(vehicle_command)};
+	uORB::Publication<led_control_s> 		_led_control_pub{ORB_ID(led_control)};
+	uORB::Publication<tune_control_s> 		_tune_control_pub{ORB_ID(tune_control)};
 };

--- a/src/lib/button/CMakeLists.txt
+++ b/src/lib/button/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2022 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,44 +31,4 @@
 #
 ############################################################################
 
-add_subdirectory(airspeed)
-add_subdirectory(avoidance)
-add_subdirectory(battery)
-add_subdirectory(bezier)
-add_subdirectory(button)
-add_subdirectory(cdev)
-add_subdirectory(circuit_breaker)
-add_subdirectory(collision_prevention)
-add_subdirectory(component_information)
-add_subdirectory(controllib)
-add_subdirectory(conversion)
-add_subdirectory(crypto)
-add_subdirectory(drivers)
-add_subdirectory(field_sensor_bias_estimator)
-add_subdirectory(geo)
-add_subdirectory(hysteresis)
-add_subdirectory(l1)
-add_subdirectory(landing_slope)
-add_subdirectory(led)
-add_subdirectory(matrix)
-add_subdirectory(mathlib)
-add_subdirectory(mixer)
-add_subdirectory(mixer_module)
-add_subdirectory(motion_planning)
-add_subdirectory(npfg)
-add_subdirectory(perf)
-add_subdirectory(pid)
-add_subdirectory(pid_design)
-add_subdirectory(pwm)
-add_subdirectory(rc)
-add_subdirectory(sensor_calibration)
-add_subdirectory(slew_rate)
-add_subdirectory(systemlib)
-add_subdirectory(system_identification)
-add_subdirectory(tecs)
-add_subdirectory(terrain_estimation)
-add_subdirectory(tunes)
-add_subdirectory(version)
-add_subdirectory(weather_vane)
-add_subdirectory(wind_estimator)
-add_subdirectory(world_magnetic_model)
+px4_add_library(button_publisher ButtonPublisher.cpp)

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -52,6 +52,7 @@ px4_add_module(
 		lm_fit.cpp
 		mag_calibration.cpp
 		rc_calibration.cpp
+		Safety.cpp
 		state_machine_helper.cpp
 		worker_thread.cpp
 	DEPENDS

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -784,6 +784,10 @@ transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool f
 		events::send<events::px4::enums::arm_disarm_reason_t>(events::ID("commander_disarmed_by"), events::Log::Info,
 				"Disarmed by {1}", calling_reason);
 
+		if (_param_com_force_safety.get()) {
+			_safety_handler.enableSafety();
+		}
+
 		_status_changed = true;
 
 	} else if (arming_res == TRANSITION_DENIED) {
@@ -2195,6 +2199,8 @@ Commander::run()
 				}
 			}
 		}
+
+		_safety_handler.safetyButtonHandler();
 
 		/* update safety topic */
 		const bool safety_updated = _safety_sub.updated();

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -36,6 +36,7 @@
 /*   Helper classes  */
 #include "Arming/PreFlightCheck/PreFlightCheck.hpp"
 #include "failure_detector/FailureDetector.hpp"
+#include "Safety.hpp"
 #include "state_machine_helper.h"
 #include "worker_thread.hpp"
 
@@ -234,6 +235,7 @@ private:
 		(ParamInt<px4::params::COM_OBL_RC_ACT>) _param_com_obl_rc_act,
 
 		(ParamInt<px4::params::COM_PREARM_MODE>) _param_com_prearm_mode,
+		(ParamBool<px4::params::COM_FORCE_SAFETY>) _param_com_force_safety,
 		(ParamBool<px4::params::COM_MOT_TEST_EN>) _param_com_mot_test_en,
 
 		(ParamFloat<px4::params::COM_KILL_DISARM>) _param_com_kill_disarm,
@@ -398,6 +400,8 @@ private:
 	vehicle_control_mode_s  _vehicle_control_mode{};
 	vehicle_status_s        _status{};
 	vehicle_status_flags_s  _status_flags{};
+
+	Safety _safety_handler{};
 
 	WorkerThread _worker_thread;
 

--- a/src/modules/commander/Safety.hpp
+++ b/src/modules/commander/Safety.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,49 +31,34 @@
  *
  ****************************************************************************/
 
+/**
+ * @file Safety.hpp
+ */
+
 #pragma once
 
-#include <float.h>
+#include <uORB/SubscriptionMultiArray.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/button_event.h>
+#include <uORB/topics/safety.h>
 
-#include <drivers/drv_hrt.h>
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <button/ButtonPublisher.hpp>
-
-class SafetyButton : public ModuleBase<SafetyButton>, public px4::ScheduledWorkItem
+class Safety
 {
+
 public:
-	SafetyButton();
-	~SafetyButton() override;
 
-	/** @see ModuleBase */
-	static int task_spawn(int argc, char *argv[]);
+	Safety();
+	~Safety() = default;
 
-	/** @see ModuleBase */
-	static int custom_command(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static int print_usage(const char *reason = nullptr);
-
-	int Start();
+	void safetyButtonHandler();
+	void enableSafety();
 
 private:
-	void Run() override;
 
-	void CheckSafetyRequest(bool button_pressed);
-	void CheckPairingRequest(bool button_pressed);
-	void FlashButton();
+	uORB::Subscription _safety_button_sub{ORB_ID::safety_button};
+	uORB::Publication<safety_s>	_safety_pub{ORB_ID(safety)};
 
-	bool			_has_px4io{false};
-	ButtonPublisher	_button_publisher;
-	uint8_t			_button_counter{0};
-	uint8_t			_blink_counter{0};
-	bool			_button_prev_sate{false};	///< Previous state of the HW button
-
-	// Pairing request
-	hrt_abstime		_pairing_start{0};
-	int				_pairing_button_counter{0};
-
-	uORB::Subscription	_armed_sub{ORB_ID(actuator_armed)};
-
+	safety_s _safety{};
+	bool _safety_disabled{false};
+	bool _previous_safety_off{false};
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -979,6 +979,16 @@ PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 0);
 PARAM_DEFINE_INT32(COM_PREARM_MODE, 0);
 
 /**
+ * Enable force safety
+ *
+ * Force safety when the vehicle disarms. Not supported when safety button used over PX4IO board.
+ *
+ * @boolean
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_FORCE_SAFETY, 0);
+
+/**
  * Enable Motor Testing
  *
  * If set, enables the motor test interface via MAVLink (DO_MOTOR_TEST), that


### PR DESCRIPTION
This is the new architectural approach for **button** usage as a **safety button** and **pairing button**. 
This is a continuation of the work from this  PR: https://github.com/PX4/PX4-Autopilot/pull/19255

**What is new?**
- added new `button_event.msg` with TOPIC: `safety_button`.

- added new library `ButtonPublisher`. The library is used at SafetyButton Driver, PX4IO, and UAVCAN. 

- ButtonPublisher for now has two functionality: 
1) publish the SafetyButton event if the button is pressed for 1 second
2) publish the PairingButton event if the button is pressed 3 times in a row under 2 second period. 
The logic of detecting what event was triggered must be done in the driver part as it currently is for **Gpio SafetyButton** and for **UAVCAN SafetyButton**. 
The library could also be expanded with other button functionality. 

- UAVCAN (DroneCAN) Safety Button can be used as **SafetyButton** and as **PairingButton**

- added option "**Force Safety**". With new architecture was easy to implement new parameters that if enabled can force safety after each disarms.   New parameter: `COM_FORCE_SAFETY`

**What this PR doesn't do?**
- It doesn't go into the current `safety.msg` logic. There is maybe room to clean it if `safety_switch_available` flag is not needed. That means all safety logic inside Commander is almost intact. 
- Force safety after disarm is not implemented for PX4IO. This needs to be done afterward. 

**Size**
Changes require **2868** additional bytes.


**New Architecture diagram**
![image](https://user-images.githubusercontent.com/10188706/161426969-f9030f00-686d-4382-a626-0d33826d7f45.png)

Developed and tested with:
- Skynode (fmu-v5x) and Pixracer (fmu-v4)
- Freefly GPS with GPIO button 
- CUAV NEO3 CAN GNSS with UAVCAN button

