### PR TITLE
Fix heater driver startup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -70,13 +70,6 @@ then
 	srf05 start
 fi
 
-
-# Heater driver for temperature regulated IMUs.
-if param compare -s SENS_EN_THERMAL 1
-then
-	heater start
-fi
-
 # Teraranger one tof sensor
 if param greater -s SENS_EN_TRANGER 0
 then

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -484,6 +484,12 @@ else
 	#
 	. ${R}etc/init.d/rc.thermal_cal
 
+	# Heater driver for temperature regulated IMUs.
+	if param compare -s SENS_EN_THERMAL 1
+	then
+		heater start
+	fi
+
 	#
 	# Start gimbal to control mounts such as gimbals, disabled by default.
 	#


### PR DESCRIPTION
This moves the startup of the heater driver further down in the startup script to make sure that all sensors are started and sensor IDs are registered by the time the heater starts.

@dagar it would be good to get your opinion whether this is still required or might have been resolved in the meantime.