### PR TITLE
commander: Add prearm check for flight termination

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -24,6 +24,7 @@ bool position_reliant_on_optical_flow
 bool position_reliant_on_vision_position
 
 bool dead_reckoning
+bool flight_terminated
 
 bool circuit_breaker_engaged_power_check
 bool circuit_breaker_engaged_airspd_check

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -79,6 +79,12 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		prearm_ok = false;
 	}
 
+	if (status_flags.flight_terminated) {
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Flight termination active"); }
+
+		prearm_ok = false;
+	}
+
 	// USB not connected
 	if (!status_flags.circuit_breaker_engaged_usb_check && status_flags.usb_connected) {
 		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Flying with USB is not safe"); }

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2823,6 +2823,8 @@ Commander::run()
 			checkWindAndWarn();
 		}
 
+		_status_flags.flight_terminated = _armed.force_failsafe || _armed.lockdown || _armed.manual_lockdown;
+
 		/* Get current timestamp */
 		const hrt_abstime now = hrt_absolute_time();
 


### PR DESCRIPTION
This adds a pre-arm check that prevents arming after a flight termination. This probably requires some discussion as it is related to the ongoing discussion in #19198.