### PR TITLE
Add I2C retries in INA226 to prevent publishing 0's on a single read …

### DIFF
--- a/src/drivers/power_monitor/ina226/ina226.cpp
+++ b/src/drivers/power_monitor/ina226/ina226.cpp
@@ -102,14 +102,19 @@ int INA226::read(uint8_t address, int16_t &data)
 {
 	// read desired little-endian value via I2C
 	uint16_t received_bytes;
-	const int ret = transfer(&address, 1, (uint8_t *)&received_bytes, sizeof(received_bytes));
+	int ret = PX4_ERROR;
 
-	if (ret == PX4_OK) {
-		data = swap16(received_bytes);
+	for (size_t i = 0; i < 3; i++) {
+		ret = transfer(&address, 1, (uint8_t *)&received_bytes, sizeof(received_bytes));
 
-	} else {
-		perf_count(_comms_errors);
-		PX4_DEBUG("i2c::transfer returned %d", ret);
+		if (ret == PX4_OK) {
+			data = swap16(received_bytes);
+			break;
+
+		} else {
+			perf_count(_comms_errors);
+			PX4_DEBUG("i2c::transfer returned %d", ret);
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
This PR adds retries to the I2C read function in the INA226 driver. Retries were added here to prevent a full bus level reset.

If either voltage or current read fails, the driver publishes 0's. 

See below log screenshots for the behavior this fixes. All of these are on different vehicles.

![image](https://user-images.githubusercontent.com/2019539/160888868-21160527-02f8-4ef1-b215-815632defe9e.png)
![image](https://user-images.githubusercontent.com/2019539/160888897-60923bca-4d20-46b6-afa0-a102283b350b.png)
![image](https://user-images.githubusercontent.com/2019539/160888922-26915c2e-e915-4d2a-951e-74d251b6ab5f.png)
![image](https://user-images.githubusercontent.com/2019539/160888951-3f773237-bf52-4ec4-991f-f5f8dbed867e.png)
![image](https://user-images.githubusercontent.com/2019539/160888990-abbea892-0639-4367-b984-79e7c5b1bc4d.png)
![image](https://user-images.githubusercontent.com/2019539/160889005-b17c36f8-678c-4db1-9e12-fd6d550a0f85.png)
![image](https://user-images.githubusercontent.com/2019539/160889026-f8b14593-706d-44ff-8ebc-358ecc49b044.png)
