### PR TITLE
Move VTOL Quadchute logic to Commander (failure detector)

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -78,6 +78,7 @@ bool is_vtol_tailsitter                 # True if the system performs a 90° pit
 bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
+bool vtol_fw_actuation_failure          # True if an issue with fixed-wing actuation was detected
 
 bool rc_signal_lost				# true if RC reception lost
 

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -38,7 +38,6 @@ bool offboard_control_signal_lost
 bool rc_signal_found_once
 bool rc_calibration_in_progress
 bool rc_calibration_valid                            # set if RC calibration is valid
-bool vtol_transition_failure                        # Set to true if vtol transition failed
 bool usb_connected                                # status of the USB power supply
 bool sd_card_detected_once                        # set to true if the SD card was detected
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -322,7 +322,7 @@ private:
 	bool		_flight_termination_triggered{false};
 	bool		_lockdown_triggered{false};
 	bool            _imbalanced_propeller_check_triggered{false};
-
+	bool		_quadchute_triggered{false};
 
 	hrt_abstime	_datalink_last_heartbeat_gcs{0};
 	hrt_abstime	_datalink_last_heartbeat_avoidance_system{0};

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,7 +52,7 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 	failure_detector_status_u status_prev = _status;
 
 	if (vehicle_control_mode.flag_control_attitude_enabled) {
-		updateAttitudeStatus();
+		updateAttitudeStatus(vehicle_status);
 
 		if (_param_fd_ext_ats_en.get()) {
 			updateExternalAtsStatus();
@@ -73,10 +73,81 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 		updateImbalancedPropStatus();
 	}
 
+
+	if (vehicle_status.is_vtol) {
+		updateMinHeightStatus(vehicle_status);
+		updateAdaptiveQC(vehicle_status, vehicle_control_mode);
+		updateTransitionTimeout();
+	}
+
 	return _status.value != status_prev.value;
 }
 
-void FailureDetector::updateAttitudeStatus()
+void FailureDetector::updateMinHeightStatus(const vehicle_status_s &vehicle_status)
+{
+	vehicle_local_position_s vehicle_local_position;
+
+	if (_vehicle_local_position_sub.update(&vehicle_local_position)) {
+		if (vehicle_status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+		    && _param_vt_fw_min_alt.get() > 0
+		    && -(vehicle_local_position.z) < _param_vt_fw_min_alt.get()) {
+			_status.flags.qc_min_alt = true;
+
+		} else {
+			_status.flags.qc_min_alt = false;
+		}
+	}
+}
+
+void FailureDetector::updateAdaptiveQC(const vehicle_status_s &vehicle_status,
+				       const vehicle_control_mode_s &vehicle_control_mode)
+{
+	// adaptive quadchute, only enabled when TECS is running (so pure FW mode)
+	if (_param_vt_fw_alt_err.get() > 0 && vehicle_control_mode.flag_control_climb_rate_enabled
+	    && vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		tecs_status_s tecs_status;
+
+		if (_tecs_status_sub.update(&tecs_status)) {
+			// 1 second rolling average
+			_ra_hrate = (49 * _ra_hrate + tecs_status.height_rate) / 50;
+			_ra_hrate_sp = (49 * _ra_hrate_sp + tecs_status.height_rate_setpoint) / 50;
+
+			// are we dropping while requesting significant ascend?
+			if (((tecs_status.altitude_sp - tecs_status.altitude_filtered) > _param_vt_fw_alt_err.get()) &&
+			    (_ra_hrate < -1.0f) && (_ra_hrate_sp > 1.0f)) {
+
+				_status.flags.qc_alt_err = true;
+			}
+		}
+
+	} else {
+		// reset the filtered height rate and heigh rate setpoint if TECS is not running
+		_ra_hrate = 0.0f;
+		_ra_hrate_sp = 0.0f;
+	}
+}
+
+void FailureDetector::updateTransitionTimeout()
+{
+	vtol_vehicle_status_s vtol_vehicle_status;
+	_vtol_vehicle_status_sub.update(&vtol_vehicle_status);
+
+	const bool transitioning_to_FW = vtol_vehicle_status.in_transition_to_fw;
+
+	if (!_was_in_transition_FW_prev && transitioning_to_FW) {
+		_transition_start_timestamp = hrt_absolute_time();
+		_was_in_transition_FW_prev = true;
+	}
+
+	if (transitioning_to_FW && _param_vt_trans_timeout.get() > FLT_EPSILON) {
+		if (hrt_elapsed_time(&_transition_start_timestamp) > _param_vt_trans_timeout.get() * 1_s) {
+			// transition timeout occured, abort transition
+			_status.flags.qc_trans_tmt = true;
+		}
+	}
+}
+
+void FailureDetector::updateAttitudeStatus(const vehicle_status_s &vehicle_status)
 {
 	vehicle_attitude_s attitude;
 
@@ -105,6 +176,31 @@ void FailureDetector::updateAttitudeStatus()
 		// Update status
 		_status.flags.roll = _roll_failure_hysteresis.get_state();
 		_status.flags.pitch = _pitch_failure_hysteresis.get_state();
+
+		const bool enable_quadchte = vehicle_status.is_vtol
+					     && vehicle_status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+
+		if (enable_quadchte) {
+
+			// fixed-wing maximum roll angle
+			if (_param_vt_fw_qc_r.get() > 0) {
+				if (fabsf(roll) > fabsf(math::radians(_param_vt_fw_qc_r.get()))) {
+					_status.flags.qc_roll = true;
+				}
+			}
+
+			// fixed-wing maximum pitch angle
+			if (_param_vt_fw_qc_p.get() > 0) {
+				if (fabsf(pitch) > fabsf(math::radians(_param_vt_fw_qc_p.get()))) {
+					_status.flags.qc_pitch = true;
+				}
+			}
+
+		} else {
+			// reset if not in transition or FW
+			_status.flags.qc_roll = true;
+			_status.flags.qc_pitch = true;
+		}
 	}
 }
 

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -156,3 +156,63 @@ PARAM_DEFINE_INT32(FD_ESCS_EN, 1);
  * @group Failure Detector
  */
 PARAM_DEFINE_INT32(FD_IMB_PROP_THR, 30);
+
+/**
+ * QuadChute minimum height threshold
+ *
+ * If the current height (relative to takeoff point) drops below this value in fixed-wing mode, a "QuadChute" is triggered,
+ * which immediately switches the vehicle to hover flight and executes the action defined in COM_QC_ACT.
+ * Only enabled for VTOL vehicles.
+ * Set to 0 to disable the check.
+ *
+ * @min 0
+ * @max 500
+ * @unit m
+ * @increment 1
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(VT_FW_MIN_ALT, 0);
+
+/**
+ * QuadChute altitude error thershold
+ *
+ * If the current altitude is more than this amount below the setpoint, a "QuadChute" is triggered,
+ * which immediately switches the vehicle to hover flight and executes the action defined in COM_QC_ACT.
+ * Only enabled for VTOL vehicles.
+ * Set to 0 to disable the check.
+ *
+ * @min 0
+ * @max 200
+ * @unit m
+ * @increment 1
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(VT_FW_ALT_ERR, 0);
+
+/**
+ * QuadChute pitch threshold
+ *
+ * If the current pitch angle estimate is above this value, a "QuadChute" is triggered,
+ * which immediately switches the vehicle to hover flight and executes the action defined in COM_QC_ACT.
+ * Set to 0 to disable the check.
+ *
+ * @min 0
+ * @max 180
+ * @unit deg
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
+
+/**
+ * QuadChute roll threshold
+ *
+ * If the current roll angle estimate is above this value, a "QuadChute" is triggered,
+ * which immediately switches the vehicle to hover flight and executes the action defined in COM_QC_ACT.
+ * Set to 0 to disable the check.
+ *
+ * @min 0
+ * @max 180
+ * @unit deg
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(VT_FW_QC_R, 0);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -592,7 +592,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		} else if (status.engine_failure) {
 			status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (status_flags.vtol_transition_failure) {
+		} else if (status.vtol_fw_actuation_failure) {
 
 			set_quadchute_nav_state(status, armed, status_flags, quadchute_act);
 
@@ -646,7 +646,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
-		} else if (status_flags.vtol_transition_failure) {
+		} else if (status.vtol_fw_actuation_failure) {
 
 			set_quadchute_nav_state(status, armed, status_flags, quadchute_act);
 
@@ -762,7 +762,7 @@ bool set_nav_state(vehicle_status_s &status, actuator_armed_s &armed, commander_
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
 
-		} else if (status_flags.vtol_transition_failure) {
+		} else if (status.vtol_fw_actuation_failure) {
 
 			set_quadchute_nav_state(status, armed, status_flags, quadchute_act);
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -107,16 +107,11 @@ void Standard::update_vtol_state()
 	float mc_weight = _mc_roll_weight;
 	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
-	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+	if (_attc->get_vehicle_status()->vtol_fw_actuation_failure) {
 		// Failsafe event, engage mc motors immediately
 		_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 		_pusher_throttle = 0.0f;
 		_reverse_output = 0.0f;
-
-		//reset failsafe when FW is no longer requested
-		if (!_attc->is_fixed_wing_requested()) {
-			_vtol_vehicle_status->vtol_transition_failsafe = false;
-		}
 
 	} else if (!_attc->is_fixed_wing_requested()) {
 
@@ -279,14 +274,6 @@ void Standard::update_transition_state()
 
 		const Quatf q_sp(Eulerf(_v_att_sp->roll_body, _v_att_sp->pitch_body, _v_att_sp->yaw_body));
 		q_sp.copyTo(_v_att_sp->q_d);
-
-		// check front transition timeout
-		if (_params->front_trans_timeout > FLT_EPSILON) {
-			if (time_since_trans_start > _params->front_trans_timeout) {
-				// transition timeout occured, abort transition
-				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::TransitionTimeout);
-			}
-		}
 
 	} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_MC) {
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -105,14 +105,9 @@ void Tiltrotor::update_vtol_state()
 	 * forward completely. For the backtransition the motors simply rotate back.
 	*/
 
-	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+	if (_attc->get_vehicle_status()->vtol_fw_actuation_failure) {
 		// Failsafe event, switch to MC mode immediately
 		_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
-
-		//reset failsafe when FW is no longer requested
-		if (!_attc->is_fixed_wing_requested()) {
-			_vtol_vehicle_status->vtol_transition_failsafe = false;
-		}
 
 	} else 	if (!_attc->is_fixed_wing_requested()) {
 
@@ -197,14 +192,6 @@ void Tiltrotor::update_vtol_state()
 				if (transition_to_p2) {
 					_vtol_schedule.flight_mode = vtol_mode::TRANSITION_FRONT_P2;
 					_vtol_schedule.transition_start = hrt_absolute_time();
-				}
-
-				// check front transition timeout
-				if (_params->front_trans_timeout > FLT_EPSILON) {
-					if (time_since_trans_start > _params->front_trans_timeout) {
-						// transition timeout occured, abort transition
-						_attc->quadchute(VtolAttitudeControl::QuadchuteReason::TransitionTimeout);
-					}
 				}
 
 				break;

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -96,16 +96,6 @@ class VtolAttitudeControl : public ModuleBase<VtolAttitudeControl>, public px4::
 {
 public:
 
-	enum class QuadchuteReason {
-		TransitionTimeout = 0,
-		ExternalCommand,
-		MinimumAltBreached,
-		LossOfAlt,
-		LargeAltError,
-		MaximumPitchExceeded,
-		MaximumRollExceeded,
-	};
-
 	VtolAttitudeControl();
 	~VtolAttitudeControl() override;
 
@@ -121,10 +111,8 @@ public:
 	bool init();
 
 	bool is_fixed_wing_requested() { return _transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW; };
-	void quadchute(QuadchuteReason reason);
 	int get_transition_command() {return _transition_command;}
 	bool get_immediate_transition() {return _immediate_transition;}
-	void reset_immediate_transition() {_immediate_transition = false;}
 
 	float getAirDensity() const { return _air_density; }
 
@@ -144,6 +132,7 @@ public:
 	struct vehicle_local_position_s 		*get_local_pos() {return &_local_pos;}
 	struct vehicle_local_position_setpoint_s	*get_local_pos_sp() {return &_local_pos_sp;}
 	struct vtol_vehicle_status_s			*get_vtol_vehicle_status() {return &_vtol_vehicle_status;}
+	struct vehicle_status_s				*get_vehicle_status() {return &_vehicle_status;}
 
 	struct vehicle_torque_setpoint_s 		*get_torque_setpoint_0() {return &_torque_setpoint_0;}
 	struct vehicle_torque_setpoint_s 		*get_torque_setpoint_1() {return &_torque_setpoint_1;}
@@ -209,6 +198,7 @@ private:
 	vehicle_local_position_s		_local_pos{};
 	vehicle_local_position_setpoint_s	_local_pos_sp{};
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
+	vehicle_status_s			_vehicle_status{};
 
 	float _air_density{CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C};	// [kg/m^3]
 
@@ -220,10 +210,6 @@ private:
 		param_t vtol_fw_permanent_stab;
 		param_t vtol_type;
 		param_t elevons_mc_lock;
-		param_t fw_min_alt;
-		param_t fw_alt_err;
-		param_t fw_qc_max_pitch;
-		param_t fw_qc_max_roll;
 		param_t front_trans_time_openloop;
 		param_t front_trans_time_min;
 		param_t front_trans_duration;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -219,50 +219,6 @@ PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);
 PARAM_DEFINE_FLOAT(VT_TRANS_MIN_TM, 2.0f);
 
 /**
- * QuadChute Altitude
- *
- * Minimum altitude for fixed wing flight, when in fixed wing the altitude drops below this altitude
- * the vehicle will transition back to MC mode and enter failsafe RTL
- * @min 0.0
- * @max 200.0
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
-
-/**
- * Adaptive QuadChute
- *
- * Maximum negative altitude error for fixed wing flight. If the altitude drops below this value below the altitude setpoint
- * the vehicle will transition back to MC mode and enter failsafe RTL.
- * @min 0.0
- * @max 200.0
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_FW_ALT_ERR, 0.0f);
-
-/**
- * QuadChute Max Pitch
- *
- * Maximum pitch angle before QuadChute engages
- * Above this the vehicle will transition back to MC mode and enter failsafe RTL
- * @min 0
- * @max 180
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
-
-/**
- * QuadChute Max Roll
- *
- * Maximum roll angle before QuadChute engages
- * Above this the vehicle will transition back to MC mode and enter failsafe RTL
- * @min 0
- * @max 180
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
-
-/**
  * Airspeed less front transition time (open loop)
  *
  * The duration of the front transition when there is no airspeed feedback available.

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -203,8 +203,6 @@ void VtolType::update_fw_state()
 			blendThrottleAfterFrontTransition(progress);
 		}
 	}
-
-	check_quadchute_condition();
 }
 
 void VtolType::update_transition_state()
@@ -214,10 +212,6 @@ void VtolType::update_transition_state()
 	_transition_dt = math::constrain(_transition_dt, 0.0001f, 0.02f);
 	_last_loop_ts = t_now;
 	_throttle_blend_start_ts = t_now;
-
-
-
-	check_quadchute_condition();
 }
 
 float VtolType::update_and_get_backtransition_pitch_sp()
@@ -250,80 +244,6 @@ float VtolType::update_and_get_backtransition_pitch_sp()
 bool VtolType::can_transition_on_ground()
 {
 	return !_v_control_mode->flag_armed || _land_detected->landed;
-}
-
-void VtolType::check_quadchute_condition()
-{
-	if (_attc->get_transition_command() == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC && _attc->get_immediate_transition()
-	    && !_quadchute_command_treated) {
-		_attc->quadchute(VtolAttitudeControl::QuadchuteReason::ExternalCommand);
-		_quadchute_command_treated = true;
-		_attc->reset_immediate_transition();
-
-	} else {
-		_quadchute_command_treated = false;
-	}
-
-	if (!_tecs_running) {
-		// reset the filtered height rate and heigh rate setpoint if TECS is not running
-		_ra_hrate = 0.0f;
-		_ra_hrate_sp = 0.0f;
-	}
-
-	if (_v_control_mode->flag_armed && !_land_detected->landed) {
-		Eulerf euler = Quatf(_v_att->q);
-
-		// fixed-wing minimum altitude
-		if (_params->fw_min_alt > FLT_EPSILON) {
-
-			if (-(_local_pos->z) < _params->fw_min_alt) {
-				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MinimumAltBreached);
-			}
-		}
-
-		// adaptive quadchute
-		if (_params->fw_alt_err > FLT_EPSILON && _v_control_mode->flag_control_altitude_enabled) {
-
-			// We use tecs for tracking in FW and local_pos_sp during transitions
-			if (_tecs_running) {
-				// 1 second rolling average
-				_ra_hrate = (49 * _ra_hrate + _tecs_status->height_rate) / 50;
-				_ra_hrate_sp = (49 * _ra_hrate_sp + _tecs_status->height_rate_setpoint) / 50;
-
-				// are we dropping while requesting significant ascend?
-				if (((_tecs_status->altitude_sp - _tecs_status->altitude_filtered) > _params->fw_alt_err) &&
-				    (_ra_hrate < -1.0f) &&
-				    (_ra_hrate_sp > 1.0f)) {
-
-					_attc->quadchute(VtolAttitudeControl::QuadchuteReason::LossOfAlt);
-				}
-
-			} else {
-				const bool height_error = _local_pos->z_valid && ((-_local_pos_sp->z - -_local_pos->z) > _params->fw_alt_err);
-				const bool height_rate_error = _local_pos->v_z_valid && (_local_pos->vz > 1.0f) && (_local_pos->z_deriv > 1.0f);
-
-				if (height_error && height_rate_error) {
-					_attc->quadchute(VtolAttitudeControl::QuadchuteReason::LargeAltError);
-				}
-			}
-		}
-
-		// fixed-wing maximum pitch angle
-		if (_params->fw_qc_max_pitch > 0) {
-
-			if (fabsf(euler.theta()) > fabsf(math::radians(_params->fw_qc_max_pitch))) {
-				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumPitchExceeded);
-			}
-		}
-
-		// fixed-wing maximum roll angle
-		if (_params->fw_qc_max_roll > 0) {
-
-			if (fabsf(euler.phi()) > fabsf(math::radians(_params->fw_qc_max_roll))) {
-				_attc->quadchute(VtolAttitudeControl::QuadchuteReason::MaximumRollExceeded);
-			}
-		}
-	}
 }
 
 bool VtolType::set_idle_mc()
@@ -580,7 +500,7 @@ float VtolType::pusher_assist()
 	}
 
 	// Do not engage pusher assist during a failsafe event (could be a problem with the fixed wing drive)
-	if (_attc->get_vtol_vehicle_status()->vtol_transition_failsafe) {
+	if (_attc->get_vehicle_status()->vtol_fw_actuation_failure) {
 		return 0.0f;
 	}
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -53,10 +53,6 @@ struct Params {
 	int32_t vtol_motor_id;
 	int32_t vtol_type;
 	bool elevons_mc_lock;		// lock elevons in multicopter mode
-	float fw_min_alt;			// minimum relative altitude for FW mode (QuadChute)
-	float fw_alt_err;			// maximum negative altitude error for FW mode (Adaptive QuadChute)
-	float fw_qc_max_pitch;		// maximum pitch angle FW mode (QuadChute)
-	float fw_qc_max_roll;		// maximum roll angle FW mode (QuadChute)
 	float front_trans_time_openloop;
 	float front_trans_time_min;
 	float front_trans_duration;
@@ -175,11 +171,6 @@ public:
 	virtual void waiting_on_tecs() {}
 
 	/**
-	 * Checks for fixed-wing failsafe condition and issues abort request if needed.
-	 */
-	void check_quadchute_condition();
-
-	/**
 	 * Returns true if we're allowed to do a mode transition on the ground.
 	 */
 	bool can_transition_on_ground();
@@ -227,6 +218,7 @@ public:
 	struct airspeed_validated_s 				*_airspeed_validated;					// airspeed
 	struct tecs_status_s				*_tecs_status;
 	struct vehicle_land_detected_s			*_land_detected;
+	struct vehicle_status_s				*_vehicle_status;
 
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_0;
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_1;
@@ -247,9 +239,6 @@ public:
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)
 	float _last_thr_in_fw_mode = 0.0f;
 
-	float _ra_hrate = 0.0f;			// rolling average on height rate for quadchute condition
-	float _ra_hrate_sp = 0.0f;		// rolling average on height rate setpoint for quadchute condition
-
 	bool _flag_was_in_trans_mode = false;	// true if mode has just switched to transition
 
 	hrt_abstime _trans_finished_ts = 0;
@@ -264,9 +253,6 @@ public:
 	float _transition_dt = 0;
 
 	float _accel_to_pitch_integ = 0;
-
-	bool _quadchute_command_treated{false};
-
 
 	/**
 	 * @brief      Sets mc motor minimum pwm to VT_IDLE_PWM_MC which ensures


### PR DESCRIPTION
Moves the VTOL Quadchute logic from the VTOL module to the Failure Detector in Commander. "Quadchute" is what we call when the system automatically switches to hover mode if a failure in fixed-wing flight is detected (e.g. a stuck aileron causing roll deviation). 

I originally had this together with the other refactoring proposal I made in https://github.com/PX4/PX4-Autopilot/pull/19412, but then decided to split it up. I also had the option to set the Quadchute action through a param, that has by now been addressed in https://github.com/PX4/PX4-Autopilot/pull/19351. 

I'm by now not anymore 100% if this is the right way to go, so reaching out for feedback before proceeding (the basic logic as proposed in this PR is working, but not in a merge-able state).

Pro's of moving it to Commander:
- could reuse functions for failure detector for other systems beside VTOLs, that then could trigger a parachute
- VTOL transition triggering should in my view only be triggered by Commander, with the VTOL controller only executing it. And it then is probably cleanest to also do the failure checks in Commander, instead of doing it in the VTOL module and fetching the info
- having it in failure detector would allow us to extend it with other checks like FW actuator health (directly fed back from the actuator, so e.g. a servo health message)

Cons:
- cluttering the code and settings with VTOL specific stuff on non-VTOL vehicles
- not clear how to handle the Quadchute action and tuning beside the failure detector ones, see below

Unclear:
- should one be able to tune the limits for the Quadchute (max roll, pitch, altitude error) separately from the existing failure detector ones? Or in general, how do we combine the Quadchute action (transition to hover and RTL, Land, Hold) with the failure detector (RTL, lockdown)? Should it be a cascaded thing, so a VTOL is only able to Quadchute in FW, and then when the failure detector triggers again in hover mode it would deploy the parachute? 
- what if one wants to have check in fixed-wing mode, but never actually Quadchute but rather directly deploy a parachute?
- should we allow for another transition to fixed-wing after the Quadchute has been triggered? Maybe only on a developer setup with an RC with transition switch (it's currently like this)

Maybe it's a good moment to in the first place think about the primary responsibilities of the failure detector, and how the faults should be handled. Is it just meant to contain various checks that then set (independently) flags, which are then interpreted by Commander to change flight modes depending on configuration? How does this "configuration" happen (currently it's not really configurable, at least not in a generic manner). Should the flags be persistent after triggering or only as long as the failure is actually happening?

