### PR TITLE
Battery: default to electrical current based load compensation

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -196,7 +196,7 @@ void Battery::estimateStateOfCharge(const float voltage_v, const float current_a
 	float cell_voltage = voltage_v / _params.n_cells;
 
 	// correct battery voltage locally for load drop to avoid estimation fluctuations
-	if (_params.r_internal >= 0.f) {
+	if (_params.r_internal >= 0.f && current_a > FLT_EPSILON) {
 		cell_voltage += _params.r_internal * current_a;
 
 	} else {

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -71,8 +71,8 @@ parameters:
             unit: Ohm
             min: -1.0
             max: 0.2
-            decimal: 2
-            increment: 0.01
+            decimal: 4
+            increment: 0.0005
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -76,7 +76,7 @@ parameters:
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1
-            default: [-1.0, -1.0]
+            default: [0.005, 0.005]
 
         BAT${i}_N_CELLS:
             description:

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -58,7 +58,7 @@ parameters:
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1
-            default: [0.3, 0.3]
+            default: [0.1, 0.1]
 
         BAT${i}_R_INTERNAL:
             description:


### PR DESCRIPTION
**Describe problem solved by this pull request**
A lot of users get to the conclusion that the default compensation based on the normalized throttle is very unprecise to not say completely wrong in most cases. The default value also often overcompensates and makes the battery look more charged than it actually is already in hover conditions. As a result batteries get deeply discharged and degrade quickly.

**Describe your solution**
I'm suggesting to already by default compensate using electrical current if it's available. As a default value for the internal resistance of a battery I took a conservatively low value of 5mOhm which will be correct for a good healthy battery and needs to be adjusted for an older or less efficient battery.

**Test data / coverage**
Based on feedback from our testing team the lower load compensation based on throttle is pretty important because the overcompensation leads to most deep-discharged battery cases. The current based compensation we know it works but it wasn't enabled by default because some users don't calibrate their current sensing and the internal resistance wasn't even accurately configurable.