### PR TITLE
1011_iris_irlock: require precland

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1011_iris_irlock
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1011_iris_irlock
@@ -10,6 +10,7 @@
 # enable fusion of landing target velocity
 param set-default LTEST_MODE 1
 param set-default PLD_HACC_RAD 0.1
+param set-default RTL_PLD_MD 2
 
 # Start up Landing Target Estimator module
 landing_target_estimator start


### PR DESCRIPTION
For testing precision landing, we can use the simulated world with an IR beacon

```
make px4_sitl gazebo_iris_irlock
```

Precision landing can either be done by switching into the precland flight mode, or by switching to RTL with the parameter `RTL_PLD_MD` set to either 1 (opportunistic) or 2 (required). For the IRlock simulation it makes sense to have `RTL_PLD_MD` enabled.

@julianoes you suggested elsewhere, that we start the `landing_target_estimator` when `RTL_PLD_MD != 0`. I'm not sure if this is enough, or of precision landing also works with `RTL_PLD_MD=0` when switching to the precision landing flight mode rather than using RTL. I have not yet dug into how the flight mode works, but wanted to drop this message before forgetting about it.