### PR TITLE
holybro/kakuteh7: fix BOARD_FLASH_SIZE

### DIFF
--- a/boards/holybro/kakuteh7/src/hw_config.h
+++ b/boards/holybro/kakuteh7/src/hw_config.h
@@ -71,7 +71,8 @@
 #define BOOT_DELAY_ADDRESS             0x000001a0
 #define BOARD_TYPE                     1048
 #define BOARD_FLASH_SECTORS            (14)
-#define BOARD_FLASH_SIZE               ((16-2) * 128 * 1024)
+#define BOARD_FLASH_SIZE               (16 * 128 * 1024)
+#define APP_RESERVATION_SIZE           (1 * 128 * 1024)
 
 #define OSC_FREQ                       8
 


### PR DESCRIPTION
The BL was reporting a flash size of 1703936, whereas it should be 1835008.