### PR TITLE
commander: refactor home position setter

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -163,10 +163,10 @@ private:
 
 	void print_reject_mode(uint8_t main_state);
 
+	bool hasMovedFromCurrentHomeLocation();
 	bool set_home_position();
 	bool set_home_position_alt_only();
-	bool set_in_air_home_position();
-	bool isGPosGoodForInitializingHomePos(const vehicle_global_position_s &gpos) const;
+	void set_in_air_home_position();
 	void fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos) const;
 	void fillLocalHomePos(home_position_s &home, float x, float y, float z, float heading) const;
 	void fillGlobalHomePos(home_position_s &home, const vehicle_global_position_s &gpos) const;
@@ -199,8 +199,6 @@ private:
 		(ParamInt<px4::params::COM_RCL_EXCEPT>) _param_com_rcl_except,
 
 		(ParamBool<px4::params::COM_HOME_EN>) _param_com_home_en,
-		(ParamFloat<px4::params::COM_HOME_H_T>) _param_com_home_h_t,
-		(ParamFloat<px4::params::COM_HOME_V_T>) _param_com_home_v_t,
 		(ParamBool<px4::params::COM_HOME_IN_AIR>) _param_com_home_in_air,
 
 		(ParamFloat<px4::params::COM_POS_FS_EPH>) _param_com_pos_fs_eph,
@@ -386,7 +384,6 @@ private:
 	bool		_was_armed{false};
 	bool		_failsafe_old{false};	///< check which state machines for changes, clear "changed" flag
 	bool		_have_taken_off_since_arming{false};
-	bool		_should_set_home_on_takeoff{true};
 	bool		_system_power_usb_connected{false};
 
 	geofence_result_s	_geofence_result{};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -214,34 +214,6 @@ PARAM_DEFINE_FLOAT(COM_RCL_ACT_T, 15.0f);
 PARAM_DEFINE_INT32(COM_HOME_EN, 1);
 
 /**
- * Home set horizontal threshold
- *
- * The home position will be set if the estimated positioning accuracy is below the threshold.
- *
- * @group Commander
- * @unit m
- * @min 2
- * @max 15
- * @decimal 2
- * @increment 0.5
- */
-PARAM_DEFINE_FLOAT(COM_HOME_H_T, 5.0f);
-
-/**
- * Home set vertical threshold
- *
- * The home position will be set if the estimated positioning accuracy is below the threshold.
- *
- * @group Commander
- * @unit m
- * @min 5
- * @max 25
- * @decimal 2
- * @increment 0.5
- */
-PARAM_DEFINE_FLOAT(COM_HOME_V_T, 10.0f);
-
-/**
  * Allows setting the home position after takeoff
  *
  * If set to true, the autopilot is allowed to set its home position after takeoff

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -213,8 +213,7 @@ bool Geofence::checkAll(double lat, double lon, float altitude)
 	}
 }
 
-bool Geofence::check(const vehicle_global_position_s &global_position, const vehicle_gps_position_s &gps_position,
-		     const home_position_s home_pos, bool home_position_set)
+bool Geofence::check(const vehicle_global_position_s &global_position, const vehicle_gps_position_s &gps_position)
 {
 	if (_param_gf_altmode.get() == Geofence::GF_ALT_MODE_WGS84) {
 		if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -247,7 +247,7 @@ bool Geofence::isCloserThanMaxDistToHome(double lat, double lon, float altitude)
 {
 	bool inside_fence = true;
 
-	if (isHomeRequired() && _navigator->home_position_valid()) {
+	if (isHomeRequired() && _navigator->home_global_position_valid()) {
 
 		const float max_horizontal_distance = _param_gf_max_hor_dist.get();
 
@@ -281,7 +281,7 @@ bool Geofence::isBelowMaxAltitude(float altitude)
 {
 	bool inside_fence = true;
 
-	if (isHomeRequired() && _navigator->home_position_valid()) {
+	if (isHomeRequired() && _navigator->home_alt_valid()) {
 
 		const float max_vertical_distance = _param_gf_max_ver_dist.get();
 		const float home_alt = _navigator->get_home_position()->alt;

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -88,8 +88,7 @@ public:
 	 *
 	 * @return true: system is obeying fence, false: system is violating fence
 	 */
-	bool check(const vehicle_global_position_s &global_position,
-		   const vehicle_gps_position_s &gps_position, const home_position_s home_pos, bool home_position_set);
+	bool check(const vehicle_global_position_s &global_position, const vehicle_gps_position_s &gps_position);
 
 	/**
 	 * Return whether a mission item obeys the geofence.

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -103,7 +103,7 @@ Mission::on_inactive()
 	}
 
 	/* Without home a mission can't be valid yet anyway, let's wait. */
-	if (!_navigator->home_position_valid()) {
+	if (!_navigator->home_global_position_valid()) {
 		return;
 	}
 
@@ -1736,7 +1736,7 @@ Mission::set_current_mission_item()
 void
 Mission::check_mission_valid(bool force)
 {
-	if ((!_home_inited && _navigator->home_position_valid()) || force) {
+	if ((!_home_inited && _navigator->home_global_position_valid()) || force) {
 
 		MissionFeasibilityChecker _missionFeasibilityChecker(_navigator);
 
@@ -1749,7 +1749,7 @@ Mission::check_mission_valid(bool force)
 		_navigator->get_mission_result()->seq_total = _mission.count;
 		_navigator->increment_mission_instance_count();
 		_navigator->set_mission_result_updated();
-		_home_inited = _navigator->home_position_valid();
+		_home_inited = _navigator->home_global_position_valid();
 
 		// find and store landing start marker (if available)
 		find_mission_land_start();

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -70,7 +70,7 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 	bool failed = false;
 
 	// first check if we have a valid position
-	const bool home_valid = _navigator->home_position_valid();
+	const bool home_valid = _navigator->home_global_position_valid();
 	const bool home_alt_valid = _navigator->home_alt_valid();
 
 	if (!home_alt_valid) {

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -172,9 +172,9 @@ public:
 
 	void reset_vroi() { _vroi = {}; }
 
-	bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
+	bool home_alt_valid() { return (_home_pos.valid_alt); }
 
-	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos && _home_pos.valid_lpos); }
+	bool home_global_position_valid() { return (_home_pos.valid_alt && _home_pos.valid_hpos); }
 
 	Geofence &get_geofence() { return _geofence; }
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -405,7 +405,10 @@ void Navigator::run()
 				rep->current.loiter_direction = 1;
 				rep->current.type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
 
-				if (home_position_valid()) {
+				if (home_global_position_valid()) {
+					// Only set yaw if we know the true heading
+					// We assume that the heading is valid when the global position is valid because true heading
+					// is required to fuse NE (e.g.: GNSS) data. // TODO: we should be more explicit here
 					rep->current.yaw = cmd.param4;
 
 					rep->previous.valid = true;
@@ -836,7 +839,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		_gf_breach_avoidance.setMaxHorDistHome(_geofence.getMaxHorDistanceHome());
 		_gf_breach_avoidance.setMaxVerDistHome(_geofence.getMaxVerDistanceHome());
 
-		if (home_position_valid()) {
+		if (home_global_position_valid()) {
 			_gf_breach_avoidance.setHomePosition(_home_pos.lat, _home_pos.lon, _home_pos.alt);
 		}
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1555,8 +1555,7 @@ bool Navigator::geofence_allows_position(const vehicle_global_position_s &pos)
 	    (_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_WARN)) {
 
 		if (PX4_ISFINITE(pos.lat) && PX4_ISFINITE(pos.lon)) {
-			return _geofence.check(pos, _gps_pos, _home_pos,
-					       home_position_valid());
+			return _geofence.check(pos, _gps_pos);
 		}
 	}
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -83,7 +83,7 @@ void RTL::on_inactive()
 	if ((hrt_absolute_time() - _destination_check_time) > 1_s) {
 		_destination_check_time = hrt_absolute_time();
 
-		if (_navigator->home_position_valid()) {
+		if (_navigator->home_global_position_valid()) {
 			find_RTL_destination();
 		}
 
@@ -723,7 +723,7 @@ void RTL::calc_and_pub_rtl_time_estimate()
 
 	// Calculate RTL time estimate only when there is a valid home position
 	// TODO: Also check if vehicle position is valid
-	if (!_navigator->home_position_valid()) {
+	if (!_navigator->home_global_position_valid()) {
 		rtl_time_estimate.valid = false;
 
 	} else {

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -98,7 +98,9 @@ Takeoff::set_takeoff_position()
 
 	float min_abs_altitude;
 
-	if (_navigator->home_position_valid()) { //only use home position if it is valid
+	// TODO: review this, comments are talking about home pos, the validity is checked but the
+	// current altitude is used instead. Also, the "else" case does not consider the current altitude at all.
+	if (_navigator->home_alt_valid()) { //only use home position if it is valid
 		min_abs_altitude = _navigator->get_global_position()->alt + _navigator->get_takeoff_min_alt();
 
 	} else { //e.g. flow
@@ -108,7 +110,7 @@ Takeoff::set_takeoff_position()
 	// Use altitude if it has been set. If home position is invalid use min_abs_altitude
 	events::LogLevel log_level = events::LogLevel::Disabled;
 
-	if (rep->current.valid && PX4_ISFINITE(rep->current.alt) && _navigator->home_position_valid()) {
+	if (rep->current.valid && PX4_ISFINITE(rep->current.alt) && _navigator->home_alt_valid()) {
 		abs_altitude = rep->current.alt;
 
 		// If the altitude suggestion is lower than home + minimum clearance, raise it and complain.

--- a/src/modules/navigator/vtol_takeoff.cpp
+++ b/src/modules/navigator/vtol_takeoff.cpp
@@ -51,7 +51,7 @@ VtolTakeoff::VtolTakeoff(Navigator *navigator) :
 void
 VtolTakeoff::on_activation()
 {
-	if (_navigator->home_position_valid()) {
+	if (_navigator->home_global_position_valid()) {
 		set_takeoff_position();
 		_takeoff_state = vtol_takeoff_state::TAKEOFF_HOVER;
 		_navigator->reset_cruising_speed();


### PR DESCRIPTION
- always try to set local or global home position when possible
- set global home with GNSS position if global pos from EKF isn't
  available
- reset home when significantly moved from home before takeoff (checking
  lpos or gpos or GNSS)
- reset home on takeoff transition
- reset home on mavlink arm command
- remove "home required accuracy" parameters, rely on validity flags
- when allowed, use all possible data to set local and global home position in air (back-computation) 24d9254f11da07c2d8b30440103cc16388c2b2e9