### PR TITLE
Preflight checks: allow arming in land mode for MAVSDK compatibility

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/modeCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/modeCheck.cpp
@@ -53,6 +53,9 @@ bool PreFlightCheck::modeCheck(orb_advert_t *mavlink_log_pub, const bool report_
 	case vehicle_status_s::NAVIGATION_STATE_STAB:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
+
+	// allow arming in land mode to prevent MAVSDK examples from failing on master until the workflow is changed
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
 		break;
 
 	default:


### PR DESCRIPTION
**Describe problem solved by this pull request**
As stated by @julianoes in https://github.com/PX4/PX4-Autopilot/pull/19291#issuecomment-1076694121 the linked pr breaks compatibility to some MAVSDK tests and examples.

**Describe your solution**
To fix that I'm allowing arming in land mode even though it was the purpose of #19291 .

**Describe possible alternatives**
The suggested solution was to automatically change to a suitable mode to take off again after disarming. Until that's hashed out and implemented I suggest this in-between fix to make sure MAVSDK is unblocked.

**Test data / coverage**
I did not test this separately, please review.