### PR TITLE
Matek M9N CAN- RM3100 orientation fix

### DIFF
--- a/boards/matek/gnss-m9n-f4/init/rc.board_sensors
+++ b/boards/matek/gnss-m9n-f4/init/rc.board_sensors
@@ -5,7 +5,7 @@
 
 icm20602 -s start
 
-rm3100 -b 2 -s start
+rm3100 -b 2 -s -R 12 start
 
 dps310 -a 118 -X start
 


### PR DESCRIPTION
The RM3100 needs to be pitched 180º for the correct orientation on this board.