### PR TITLE
Matek M9N-CAN IMU orientation update

### DIFF
--- a/boards/matek/gnss-m9n-f4/init/rc.board_sensors
+++ b/boards/matek/gnss-m9n-f4/init/rc.board_sensors
@@ -3,7 +3,7 @@
 # Matek M9NF4 CAN specific board sensors init
 #------------------------------------------------------------------------------
 
-icm20602 -s start
+icm20602 -s -R 10 start
 
 rm3100 -b 2 -s start
 


### PR DESCRIPTION
The icm20602 IMU needs to be rolled 180º and yaw 90º for this board.
