### PR TITLE
MulticopterPositionControl: remove unused return value parameters_update()

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -75,7 +75,7 @@ bool MulticopterPositionControl::init()
 	return true;
 }
 
-int MulticopterPositionControl::parameters_update(bool force)
+void MulticopterPositionControl::parameters_update(bool force)
 {
 	// check for parameter updates
 	if (_parameter_update_sub.updated() || force) {
@@ -239,8 +239,6 @@ int MulticopterPositionControl::parameters_update(bool force)
 		_takeoff.setTakeoffRampTime(_param_mpc_tko_ramp_t.get());
 		_takeoff.generateInitialRampValue(_param_mpc_z_vel_p_acc.get());
 	}
-
-	return OK;
 }
 
 PositionControlStates MulticopterPositionControl::set_vehicle_states(const vehicle_local_position_s &local_pos)

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -214,7 +214,7 @@ private:
 	 * Parameter update can be forced when argument is true.
 	 * @param force forces parameter update.
 	 */
-	int parameters_update(bool force);
+	void parameters_update(bool force);
 
 	/**
 	 * Check for validity of positon/velocity states.


### PR DESCRIPTION
**Describe problem solved by this pull request**
Just randomly saw this unused return value.

**Describe your solution**
Remove it.

**Test data / coverage**
Compiles.