### PR TITLE
uORB : Don't add message name as default in topics list if not specified

### DIFF
--- a/msg/templates/uorb/uORBTopics.cpp.em
+++ b/msg/templates/uorb/uORBTopics.cpp.em
@@ -8,7 +8,7 @@
 @#
 @# Context:
 @#  - msgs (List) list of all msg files
-@#  - multi_topics (List) list of all multi-topic names
+@#  - topics (List) list of all topic names
 @###############################################
 /****************************************************************************
  *
@@ -48,17 +48,17 @@
 @{
 msg_names = [mn.replace(".msg", "") for mn in msgs]
 msgs_count = len(msg_names)
-msg_names_all = list(set(msg_names + multi_topics)) # set() filters duplicates
-msg_names_all.sort()
-msgs_count_all = len(msg_names_all)
+topics_all = topics
+topics_all.sort()
+topics_count_all = len(topics_all)
 }@
 @[for msg_name in msg_names]@
 #include <uORB/topics/@(msg_name).h>
 @[end for]
 
 const constexpr struct orb_metadata *const uorb_topics_list[ORB_TOPICS_COUNT] = {
-@[for idx, msg_name in enumerate(msg_names_all, 1)]@
-	ORB_ID(@(msg_name))@[if idx != msgs_count_all], @[end if]
+@[for idx, topic_name in enumerate(topics_all, 1)]@
+	ORB_ID(@(topic_name))@[if idx != topics_count_all], @[end if]
 @[end for]
 };
 

--- a/msg/templates/uorb/uORBTopics.hpp.em
+++ b/msg/templates/uorb/uORBTopics.hpp.em
@@ -8,7 +8,7 @@
 @#
 @# Context:
 @#  - msgs (List) list of all msg files
-@#  - multi_topics (List) list of all multi-topic names
+@#  - topics (List) list of all topic names
 @###############################################
 /****************************************************************************
  *
@@ -46,9 +46,9 @@
 @{
 msg_names = [mn.replace(".msg", "") for mn in msgs]
 msgs_count = len(msg_names)
-msg_names_all = list(set(msg_names + multi_topics)) # set() filters duplicates
-msg_names_all.sort()
-msgs_count_all = len(msg_names_all)
+topics_all = topics
+topics_all.sort()
+topics_count_all = len(topics_all)
 }@
 
 #pragma once
@@ -57,7 +57,7 @@ msgs_count_all = len(msg_names_all)
 
 #include <uORB/uORB.h>
 
-static constexpr size_t ORB_TOPICS_COUNT{@(msgs_count_all)};
+static constexpr size_t ORB_TOPICS_COUNT{@(topics_count_all)};
 static constexpr size_t orb_topics_count() { return ORB_TOPICS_COUNT; }
 
 /*
@@ -66,7 +66,7 @@ static constexpr size_t orb_topics_count() { return ORB_TOPICS_COUNT; }
 extern const struct orb_metadata *const *orb_get_topics() __EXPORT;
 
 enum class ORB_ID : uint8_t {
-@[for idx, msg_name in enumerate(msg_names_all)]@
+@[for idx, msg_name in enumerate(topics_all)]@
 	@(msg_name) = @(idx),
 @[end for]
 	INVALID

--- a/msg/templates/uorb_microcdr/dds_topics.h.em
+++ b/msg/templates/uorb_microcdr/dds_topics.h.em
@@ -7,7 +7,7 @@
 @#
 @# Context:
 @#  - msgs (List) list of all RTPS messages
-@#  - multi_topics (List) list of all multi-topic names
+@#  - topics (List) list of all topic names
 @#  - spec (msggen.MsgSpec) Parsed specification of the .msg file
 @###############################################
 @{
@@ -43,11 +43,11 @@ struct SendTopicsSubs {
 	uORB::Subscription @(topic)_sub{ORB_ID(@(topic))};
 	uxrObjectId @(topic)_data_writer;
 @[    end for]@
-	
+
 	uxrSession* session;
 
 	uint32_t num_payload_sent{};
-	
+
 	bool init(uxrSession* session_, uxrStreamId stream_id, uxrObjectId participant_id);
 	void update(uxrStreamId stream_id);
 };
@@ -140,7 +140,7 @@ struct RcvTopicsPubs {
 	uxrSession* session;
 
 	uint32_t num_payload_received{};
-	
+
 	bool init(uxrSession* session_, uxrStreamId stream_id, uxrStreamId input_stream, uxrObjectId participant_id);
 };
 

--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
@@ -7,7 +7,7 @@
 @#
 @# Context:
 @#  - msgs (List) list of all RTPS messages
-@#  - multi_topics (List) list of all multi-topic names
+@#  - topics (List) list of all topic names
 @#  - spec (msggen.MsgSpec) Parsed specification of the .msg file
 @###############################################
 @{


### PR DESCRIPTION
**Describe problem solved by this pull request**

Let's say you had an uORB message definition in "pasta_information.msg", and you didn't include the message name (pasta_information) in the multi topics comment section for registering custom topics (pasta_cook, pasta_order)

![Screenshot from 2022-04-12 16-00-47](https://user-images.githubusercontent.com/23277211/162981671-78e43bf6-e50e-4640-bba7-98c87df69b69.png)

The message name wouldn't be included in the uorb declaration in the message source file, which is **expected since if you specify a custom topic it means that you want to specify which topics to declare.**

![Screenshot from 2022-04-12 16-05-55](https://user-images.githubusercontent.com/23277211/162981719-7afe67b2-988f-4e19-8cff-97ad60f93b41.png)

**However, the message name was always added as a default topic name in uORBTopics source file by default**
![Screenshot from 2022-04-12 16-05-04](https://user-images.githubusercontent.com/23277211/162981747-ef0a63e2-1e86-4b31-8cc8-ba32e14a382a.png)

Which was causing an build error since that uorb topic isn't declared from message source, but is used in the list of uORBTopics.

![Screenshot from 2022-04-12 16-07-41](https://user-images.githubusercontent.com/23277211/162981775-12b5f583-6924-4e8e-aa47-972ee399e07d.png)

**Describe your solution**
This PR refactors the handling of the multi topics name function in uorb source generation script to only include the default message name as one of the topic names, only if the user didn't specify any custom multi topics.

And this function gets used generically for uORBTopics source generation as well as the message sources, which removes the discrepancy that existed before.

**Describe possible alternatives**
We **could** always include the message name as one of the default topic names, I am up for a discussion.

But since in PX4 there are no cases where the multi topic definition doesn't include the message name as one of it's topics (since there was never a case like pasta_information.msg, which would've caused the build error), it would be a bit of a waste in ORB_ID enum & orb_metadata struct instance in memory :thinking: 

**Test data / coverage**

**Additional context**
I am not sure how this affects the dds and microTPS (since multi topics part isn't used at all in the codebase right now), input on that front would be appreciated!