### PR TITLE
commander/safety: set early safety_button_available

### DIFF
--- a/src/modules/commander/Safety.cpp
+++ b/src/modules/commander/Safety.cpp
@@ -56,10 +56,13 @@ void Safety::safetyButtonHandler()
 
 	} else {
 
+		if (!_safety.safety_switch_available && _safety_button_sub.advertised()) {
+			_safety.safety_switch_available = true;
+		}
+
 		button_event_s button_event;
 
 		while (_safety_button_sub.update(&button_event)) {
-			_safety.safety_switch_available = true;
 			_safety.safety_off |= button_event.triggered; // triggered safety button activates safety off
 		}
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
This solves prearm check issue introduced after the safety_button refactoring https://github.com/PX4/PX4-Autopilot/pull/19413
The commander should be first able to know if the safety button exists before it is pressed. 

**Describe your solution**
If a safety button is advertised it means that driver that handles the safety button exists.