### PR TITLE
dronecan beeper: remove unneded var

### DIFF
--- a/src/drivers/uavcan/beep.cpp
+++ b/src/drivers/uavcan/beep.cpp
@@ -72,17 +72,13 @@ void UavcanBeepController::periodic_update(const uavcan::TimerEvent &)
 		_tune_control_sub.copy(&_tune);
 
 		if (_tune.timestamp > 0) {
-			Tunes::ControlResult result = _tunes.set_control(_tune);
-
-			if (result == Tunes::ControlResult::Success) {
-				_play_tone = true;
-			}
+			_tunes.set_control(_tune);
 		}
 	}
 
 	const hrt_abstime timestamp_now = hrt_absolute_time();
 
-	if ((timestamp_now - _interval_timestamp <= _duration) || !_play_tone) {
+	if ((timestamp_now - _interval_timestamp <= _duration)) {
 		return;
 	}
 
@@ -92,7 +88,7 @@ void UavcanBeepController::periodic_update(const uavcan::TimerEvent &)
 		_duration = _silence_length;
 		_silence_length = 0;
 
-	} else if (_play_tone && (_tunes.get_next_note(_frequency, _duration, _silence_length) == Tunes::Status::Continue)) {
+	} else if (_tunes.get_next_note(_frequency, _duration, _silence_length) == Tunes::Status::Continue) {
 
 		// Start playing the note.
 		// A frequency of 0 corresponds to ToneAlarmInterface::stop_note()

--- a/src/drivers/uavcan/beep.hpp
+++ b/src/drivers/uavcan/beep.hpp
@@ -87,7 +87,6 @@ private:
 	hrt_abstime _interval_timestamp{0};
 	tune_control_s _tune{};
 	Tunes _tunes{};
-	bool _play_tone{false};
 	unsigned int _silence_length{0};	///< If nonzero, silence before next note.
 	unsigned int _frequency{0};
 	unsigned int _duration{0};


### PR DESCRIPTION
After the last bugfix https://github.com/PX4/PX4-Autopilot/pull/18840 there is now a leftover variable that's not really needed anymore.

`_play_tone` can be removed. It's initialized as False, then set to True once, and then it stays True forever.

A similar fix was done in tap_esc.cpp where the same variable was also removed: https://github.com/PX4/PX4-Autopilot/commit/76920171c771539d5bb6a03593d4cfbcbea342b6

Bench-tested with a UAVCAN GPS module