### PR TITLE
mavlink: add COMPONENT_METADATA message

### DIFF
--- a/src/lib/component_information/generate_crc.py
+++ b/src/lib/component_information/generate_crc.py
@@ -31,6 +31,7 @@ def crc_update(buf, crc_table, crc):
 crc_table = create_table()
 
 with open(filename, 'w') as outfile:
+    outfile.write("#pragma once\n")
     outfile.write("#include <stdint.h>\n")
     outfile.write("namespace component_information {\n")
     for filename in files:

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -69,6 +69,7 @@
 #include "streams/COLLISION.hpp"
 #include "streams/COMMAND_LONG.hpp"
 #include "streams/COMPONENT_INFORMATION.hpp"
+#include "streams/COMPONENT_METADATA.hpp"
 #include "streams/DISTANCE_SENSOR.hpp"
 #include "streams/EFI_STATUS.hpp"
 #include "streams/ESC_INFO.hpp"
@@ -548,6 +549,9 @@ static const StreamListItem streams_list[] = {
 #if defined(COMPONENT_INFORMATION_HPP)
 	create_stream_list_item<MavlinkStreamComponentInformation>(),
 #endif // COMPONENT_INFORMATION_HPP
+#if defined(COMPONENT_METADATA_HPP)
+	create_stream_list_item<MavlinkStreamComponentMetadata>(),
+#endif // COMPONENT_METADATA_HPP
 #if defined(RAW_RPM_HPP)
 	create_stream_list_item<MavlinkStreamRawRpm>(),
 #endif // RAW_RPM_HPP

--- a/src/modules/mavlink/streams/COMPONENT_METADATA.hpp
+++ b/src/modules/mavlink/streams/COMPONENT_METADATA.hpp
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef COMPONENT_METADATA_HPP
+#define COMPONENT_METADATA_HPP
+
+#include "../mavlink_stream.h"
+
+#include <component_information/checksums.h>
+
+#include <px4_platform_common/defines.h>
+
+#include <sys/stat.h>
+
+class MavlinkStreamComponentMetadata : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamComponentMetadata(mavlink); }
+
+	static constexpr const char *get_name_static() { return "COMPONENT_METADATA"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_COMPONENT_METADATA; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return 0; // never streamed
+	}
+
+	bool request_message(float param2, float param3, float param4,
+			     float param5, float param6, float param7) override
+	{
+		mavlink_component_metadata_t component_metadata{};
+		PX4_DEBUG("COMPONENT_METADATA request");
+
+		strncpy(component_metadata.uri, "mftp://etc/extras/component_general.json.xz",
+			sizeof(component_metadata.uri) - 1);
+		component_metadata.file_crc = component_information::component_general_crc;
+
+		component_metadata.time_boot_ms = hrt_absolute_time() / 1000;
+		mavlink_msg_component_metadata_send_struct(_mavlink->get_channel(), &component_metadata);
+
+		return true;
+	}
+private:
+	explicit MavlinkStreamComponentMetadata(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	bool send() override
+	{
+		return false;
+	}
+};
+
+#endif // COMPONENT_METADATA_HPP


### PR DESCRIPTION
And still support the previous message COMPONENT_INFORMATION for now.

From https://github.com/mavlink/mavlink/pull/1823