### PR TITLE
mission block: fix incorrectly calculated ccw loiter exit

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -466,7 +466,8 @@ MissionBlock::is_mission_item_reached()
 			     _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT)) {
 
 				float bearing = get_bearing_to_next_waypoint(curr_sp.lat, curr_sp.lon, next_sp.lat, next_sp.lon);
-				// We should not use asinf outside of [-1..1].
+
+				// calculate (positive) angle between current bearing vector (orbit center to next waypoint) and vector pointing to tangent exit location
 				const float ratio = math::min(fabsf(_mission_item.loiter_radius / range), 1.0f);
 				float inner_angle = acosf(ratio);
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -467,8 +467,8 @@ MissionBlock::is_mission_item_reached()
 
 				float bearing = get_bearing_to_next_waypoint(curr_sp.lat, curr_sp.lon, next_sp.lat, next_sp.lon);
 				// We should not use asinf outside of [-1..1].
-				const float ratio = math::constrain(_mission_item.loiter_radius / range, -1.0f, 1.0f);
-				float inner_angle = M_PI_2_F - asinf(ratio);
+				const float ratio = math::min(fabsf(_mission_item.loiter_radius / range), 1.0f);
+				float inner_angle = acosf(ratio);
 
 				// Compute "ideal" tangent origin
 				if (curr_sp.loiter_direction > 0) {


### PR DESCRIPTION
**Describe problem solved by this pull request**
Addresses #18595
Loiter exit for fixed-wing landing was incorrectly calculated on counter clockwise loiters causing the aircraft to fly an offset approach vector.

**Describe your solution**
Loiter radius was signed in mission item, which means we need to take it's absolute value before doing trig operations (as they were currently implemented).

**Test data / coverage**
SITL with CCW landing. Aborted and let it go around one more time just for good measure.
![screen_land_ccw](https://user-images.githubusercontent.com/8026163/163429011-4b8238d2-f3a9-4138-8e3f-29e2c12df2f9.png)
And in CW direction just to make sure nothing else changed.
![scrren_land_cw](https://user-images.githubusercontent.com/8026163/163429041-5e5a8798-a7cc-4287-9a99-99719ffdf68b.png)

@ryanjAA @thomasteisberg
