### PR TITLE
Fix vehicle not exiting loiter

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -430,22 +430,14 @@ MissionBlock::is_mission_item_reached()
 
 				float yaw_err = 0.0f;
 
-				if (dist_current_next >  1.2f * _navigator->get_loiter_radius()) {
-					// set required yaw from bearing to the next mission item
-					_mission_item.yaw = get_bearing_to_next_waypoint(_navigator->get_global_position()->lat,
-							    _navigator->get_global_position()->lon,
-							    next_sp.lat, next_sp.lon);
-					const float cog = atan2f(_navigator->get_local_position()->vy, _navigator->get_local_position()->vx);
-					yaw_err = wrap_pi(_mission_item.yaw - cog);
+				// set required yaw from bearing to the next mission item
+				_mission_item.yaw = get_bearing_to_next_waypoint(_navigator->get_global_position()->lat,
+						    _navigator->get_global_position()->lon,
+						    next_sp.lat, next_sp.lon);
+				const float cog = atan2f(_navigator->get_local_position()->vy, _navigator->get_local_position()->vx);
+				yaw_err = wrap_pi(_mission_item.yaw - cog);
 
-
-
-				}
-
-
-				if (fabsf(yaw_err) < _navigator->get_yaw_threshold()) {
-					exit_heading_reached = true;
-				}
+				exit_heading_reached = fabsf(yaw_err) < _navigator->get_yaw_threshold();
 
 			} else {
 				exit_heading_reached = true;


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
The calculation of the boolean **exit_heading_reached** was using the default loiter radius and not the loiter radius of the current waypoint. This resulted in the logic breaking down when the two values where different.

**Describe your solution**
Fixed and simplified the logic.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
