### PR TITLE
[draft] drivers/pca9685_pwm_out switch to Dynamic Control Allocator

### DIFF
--- a/posix-configs/rpi/pilotpi_fw.config
+++ b/posix-configs/rpi/pilotpi_fw.config
@@ -17,6 +17,9 @@ param set SYS_AUTOCONFIG 0
 # useless but required for parameter completeness
 param set MAV_TYPE 1
 param set SYS_AUTOSTART 2100
+# always enable Dynamic Control Allocation
+param set SYS_CTRL_ALLOC 1
+param set-default CA_AIRFRAME 1
 
 dataman start
 
@@ -42,7 +45,7 @@ ads1115 start -I
 
 # PWM
 pca9685_pwm_out start
-mixer load /dev/pwm_output0 etc/mixers/AAERTWF.main.mix
+control_allocator start
 
 # external GPS & compass
 gps start -d /dev/ttySC0 -i uart -p ubx -s

--- a/posix-configs/rpi/pilotpi_fw.config
+++ b/posix-configs/rpi/pilotpi_fw.config
@@ -3,23 +3,34 @@
 # (px4-alias.sh is expected to be in the PATH)
 . px4-alias.sh
 
+if [ ! -f eeprom/parameters ]; then
+    param save eeprom/parameters
+fi
 param select eeprom/parameters
 param import
+
+param touch SYS_AUTOCONFIG
+param touch COM_FLTMODE1
+param touch COM_FLTMODE2
+param touch COM_FLTMODE3
+param touch COM_FLTMODE4
+param touch COM_FLTMODE5
+param touch COM_FLTMODE6
+param touch COM_RC_LOSS_T
+
+# always enable Dynamic Control Allocation
+param set SYS_CTRL_ALLOC 1
 
 # system_power not implemented
 param set CBRK_SUPPLY_CHK 894281
 
+# 1K + 4.7K voltage divider
 param set-default BAT1_V_DIV 5.7
 
-# broadcast to LAN
-# always keep current config
-param set SYS_AUTOCONFIG 0
-# useless but required for parameter completeness
+# manually setup airframe type
 param set MAV_TYPE 1
-param set SYS_AUTOSTART 2100
-# always enable Dynamic Control Allocation
-param set SYS_CTRL_ALLOC 1
 param set-default CA_AIRFRAME 1
+param set SYS_AUTOSTART 2100  # no effect on Linux
 
 dataman start
 

--- a/posix-configs/rpi/pilotpi_mc.config
+++ b/posix-configs/rpi/pilotpi_mc.config
@@ -3,23 +3,34 @@
 # (px4-alias.sh is expected to be in the PATH)
 . px4-alias.sh
 
+if [ ! -f eeprom/parameters ]; then
+    param save eeprom/parameters
+fi
 param select eeprom/parameters
 param import
+
+param touch SYS_AUTOCONFIG
+param touch COM_FLTMODE1
+param touch COM_FLTMODE2
+param touch COM_FLTMODE3
+param touch COM_FLTMODE4
+param touch COM_FLTMODE5
+param touch COM_FLTMODE6
+param touch COM_RC_LOSS_T
+
+# always enable Dynamic Control Allocation
+param set SYS_CTRL_ALLOC 1
 
 # system_power not implemented
 param set CBRK_SUPPLY_CHK 894281
 
+# 1K + 4.7K voltage divider
 param set-default BAT1_V_DIV 5.7
 
-# broadcast to LAN
-# always keep current config
-param set SYS_AUTOCONFIG 0
-# useless but required for parameter completeness
-param set MAV_TYPE 2
-param set SYS_AUTOSTART 4001
-# always enable Dynamic Control Allocation
-param set SYS_CTRL_ALLOC 1
+# manually setup airframe type
+param set MAV_TYPE 0
 param set-default CA_AIRFRAME 0
+param set SYS_AUTOSTART 4001  # no effect on Linux
 
 dataman start
 

--- a/posix-configs/rpi/pilotpi_mc.config
+++ b/posix-configs/rpi/pilotpi_mc.config
@@ -17,6 +17,9 @@ param set SYS_AUTOCONFIG 0
 # useless but required for parameter completeness
 param set MAV_TYPE 2
 param set SYS_AUTOSTART 4001
+# always enable Dynamic Control Allocation
+param set SYS_CTRL_ALLOC 1
+param set-default CA_AIRFRAME 0
 
 dataman start
 
@@ -42,7 +45,7 @@ ads1115 start -I
 
 # PWM
 pca9685_pwm_out start
-mixer load /dev/pwm_output0 etc/mixers/quad_x.main.mix
+control_allocator start
 
 # external GPS & compass
 gps start -d /dev/ttySC0 -i uart -p ubx -s

--- a/src/drivers/pca9685_pwm_out/PCA9685.h
+++ b/src/drivers/pca9685_pwm_out/PCA9685.h
@@ -94,7 +94,6 @@ namespace drv_pca9685_pwm
 #define PCA9685_CLOCK_FREQ PCA9685_CLOCK_EXT   // use ext clk
 #endif
 
-#define PCA9685_DEVICE_BASE_PATH	"/dev/pca9685"
 #define PWM_DEFAULT_FREQUENCY 50    // default pwm frequency
 
 //! Main class that exports features for PCA9685 chip
@@ -116,7 +115,7 @@ public:
 
 	int initReg();
 
-	inline float getFrequency() {return _Freq;}
+	inline float getFrequency() const {return _current_freq;}
 
 	/*
 	 * disable all of the output
@@ -141,14 +140,16 @@ public:
 protected:
 	int probe() override;
 
-#ifdef PCA9685_CLOCL_EXT
+private:
+
+#ifdef PCA9685_CLOCK_EXT
 	static const uint8_t DEFAULT_MODE1_CFG = 0x70;  // Auto-Increment, Sleep, EXTCLK
 #else
 	static const uint8_t DEFAULT_MODE1_CFG = 0x30;  // Auto-Increment, Sleep
 #endif
 	static const uint8_t DEFAULT_MODE2_CFG = 0x04;  // totem pole
 
-	float _Freq = PWM_DEFAULT_FREQUENCY;
+	float _current_freq = PWM_DEFAULT_FREQUENCY;
 
 	/**
 	 * set PWM value for a channel[0,15].

--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -33,8 +33,12 @@
 
 /**
  * @file pca9685/main.cpp
+ *
  * A cross-platform driver and wrapper for pca9685.
- * Designed to support all control-groups by binding to correct mixer files
+ * Only supports Dynamic Allocation. Old static mixer support is dropped
+ *
+ * Scheduling is bound to I2C bus to avoid bus collision, with increased latency
+ *
  * @author SalimTerryLi <lhf2613@gmail.com>
  */
 
@@ -43,13 +47,11 @@
 #include <lib/mixer_module/mixer_module.hpp>
 #include <px4_platform_common/module.h>
 #include <lib/perf/perf_counter.h>
-#include <drivers/drv_mixer.h>
 #include <drivers/drv_hrt.h>
 #include <px4_platform_common/getopt.h>
 
 #include "PCA9685.h"
 
-#include <px4_platform_common/sem.hpp>
 
 #define PCA9685_DEFAULT_IICBUS  1
 #define PCA9685_DEFAULT_ADDRESS (0x40)
@@ -57,24 +59,17 @@
 using namespace drv_pca9685_pwm;
 using namespace time_literals;
 
-class PCA9685Wrapper : public cdev::CDev, public ModuleBase<PCA9685Wrapper>, public OutputModuleInterface
+class PCA9685Wrapper : public ModuleBase<PCA9685Wrapper>, public OutputModuleInterface
 {
 public:
 
 	PCA9685Wrapper(int schd_rate_limit = 400);
 	~PCA9685Wrapper() override ;
 
-	int init() override;
+	int init();
 
-	int ioctl(cdev::file_t *filep, int cmd, unsigned long arg) override;
-
-	void mixerChanged() override;
-
-	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);
-	/** @see ModuleBase */
 	static int custom_command(int argc, char *argv[]);
-	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
 	bool updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
@@ -85,31 +80,26 @@ public:
 
 	int print_status() override;
 
+protected:
+	void updateParams() override;
+
 private:
 	perf_counter_t	_cycle_perf;
-
-	int		_class_instance{-1};
 
 	enum class STATE : uint8_t {
 		INIT,
 		WAIT_FOR_OSC,
 		RUNNING
-	};
-	STATE _state{STATE::INIT};
-	// used to compare and cancel unecessary scheduling changes caused by parameter update
-	int32_t _last_fetched_Freq = -1;
-	// If this value is above zero, then change freq and scheduling in running state.
-	float _targetFreq = -1.0f;
+	} _state = STATE::INIT;
 
+	// used to compare and cancel unecessary scheduling changes caused by parameter update
+	int32_t _freq_param_value = -1;
+	// If this value is above zero, then change freq and scheduling in running state.
+	float _target_frequency = -1.0f;
 
 	void Run() override;
 
-protected:
-	void updateParams() override;
-
 	void updatePWMParams();
-
-	void updatePWMParamTrim();
 
 	int _schd_rate_limit = 400;
 
@@ -117,18 +107,22 @@ protected:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	MixingOutput _mixing_output{"PCA9685", PCA9685_PWM_CHANNEL_COUNT, *this, MixingOutput::SchedulingPolicy::Disabled, true};
+	MixingOutput _mixing_output {
+		"PCA9685",
+		PCA9685_PWM_CHANNEL_COUNT,
+		*this,
+		MixingOutput::SchedulingPolicy::Disabled,
+		true
+	};
 };
 
 PCA9685Wrapper::PCA9685Wrapper(int schd_rate_limit) :
-	CDev(nullptr),
 	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default),
 	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")),
 	_schd_rate_limit(schd_rate_limit)
 {
 	if (!_mixing_output.useDynamicMixing()) {
-		_mixing_output.setAllMinValues(PWM_DEFAULT_MIN);
-		_mixing_output.setAllMaxValues(PWM_DEFAULT_MAX);
+		// do nothing
 	}
 }
 
@@ -146,20 +140,14 @@ PCA9685Wrapper::~PCA9685Wrapper()
 
 int PCA9685Wrapper::init()
 {
-	int ret = CDev::init();
+	int ret = pca9685->init();
 
 	if (ret != PX4_OK) {
+		PX4_ERR("I2C::init() returned %d", ret);
 		return ret;
 	}
 
-	ret = pca9685->init();
-
-	if (ret != PX4_OK) {
-		return ret;
-	}
-
-	_class_instance = register_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH);
-
+	// ensure PWM output not conflicting with other devices on the same bus
 	this->ChangeWorkQueue(px4::device_bus_to_wq(pca9685->get_device_id()));
 
 	PX4_INFO("running on I2C bus %d address 0x%.2x", pca9685->get_device_bus(), pca9685->get_device_address());
@@ -178,210 +166,38 @@ void PCA9685Wrapper::updateParams()
 void PCA9685Wrapper::updatePWMParams()
 {
 	if (_mixing_output.useDynamicMixing()) {
-		return;
-	}
+		// generated RATE param
+		param_t param_h = param_find("PCA9685_TIM0");
 
-	// update pwm params
-	const char *pname_format_pwm_ch_max[2] = {"PWM_MAIN_MAX%d", "PWM_AUX_MAX%d"};
-	const char *pname_format_pwm_ch_min[2] = {"PWM_MAIN_MIN%d", "PWM_AUX_MIN%d"};
-	const char *pname_format_pwm_ch_fail[2] = {"PWM_MAIN_FAIL%d", "PWM_AUX_FAIL%d"};
-	const char *pname_format_pwm_ch_dis[2] = {"PWM_MAIN_DIS%d", "PWM_AUX_DIS%d"};
-	const char *pname_format_pwm_ch_rev[2] = {"PWM_MAIN_REV%d", "PWM_AUX_REV%d"};
+		if (param_h != PARAM_INVALID) {
+			int32_t pval = 0;
+			param_get(param_h, &pval);
 
-	int32_t default_pwm_max = PWM_DEFAULT_MAX,
-		default_pwm_min = PWM_DEFAULT_MIN,
-		default_pwm_fail = PWM_DEFAULT_MIN,
-		default_pwm_dis = PWM_MOTOR_OFF;
+			if (_freq_param_value != pval) {
+				_freq_param_value = pval;
+				_target_frequency = (float)pval;  // update only if changed
+			}
 
-	param_t param_h = param_find("PWM_MAIN_MAX");
-
-	if (param_h != PARAM_INVALID) {
-		param_get(param_h, &default_pwm_max);
-
-	} else {
-		PX4_DEBUG("PARAM_INVALID: %s", "PWM_MAIN_MAX");
-	}
-
-	param_h = param_find("PWM_MAIN_MIN");
-
-	if (param_h != PARAM_INVALID) {
-		param_get(param_h, &default_pwm_min);
-
-	} else {
-		PX4_DEBUG("PARAM_INVALID: %s", "PWM_MAIN_MIN");
-	}
-
-	param_h = param_find("PWM_MAIN_RATE");
-
-	if (param_h != PARAM_INVALID) {
-		int32_t pval = 0;
-		param_get(param_h, &pval);
-
-		if (_last_fetched_Freq != pval) {
-			_last_fetched_Freq = pval;
-			_targetFreq = (float)pval;  // update only if changed
+		} else {
+			PX4_WARN("PARAM_INVALID: %s", "PCA9685_TIM0");
 		}
 
 	} else {
-		PX4_DEBUG("PARAM_INVALID: %s", "PWM_MAIN_RATE");
+		PX4_WARN("legacy mixer support is dropped");
 	}
-
-	for (int i = 0; i < PCA9685_PWM_CHANNEL_COUNT; i++) {
-		char pname[16];
-		uint8_t param_group, param_index;
-
-		if (i <= 7) {	// Main channel
-			param_group = 0;
-			param_index = i + 1;
-
-		} else {	// AUX
-			param_group = 1;
-			param_index = i - 8 + 1;
-		}
-
-		sprintf(pname, pname_format_pwm_ch_max[param_group], param_index);
-		param_h = param_find(pname);
-
-		if (param_h != PARAM_INVALID) {
-			int32_t pval = 0;
-			param_get(param_h, &pval);
-
-			if (pval != -1) {
-				_mixing_output.maxValue(i) = pval;
-
-			} else {
-				_mixing_output.maxValue(i) = default_pwm_max;
-			}
-
-		} else {
-			PX4_DEBUG("PARAM_INVALID: %s", pname);
-		}
-
-		sprintf(pname, pname_format_pwm_ch_min[param_group], param_index);
-		param_h = param_find(pname);
-
-		if (param_h != PARAM_INVALID) {
-			int32_t pval = 0;
-			param_get(param_h, &pval);
-
-			if (pval != -1) {
-				_mixing_output.minValue(i) = pval;
-
-			} else {
-				_mixing_output.minValue(i) = default_pwm_min;
-			}
-
-		} else {
-			PX4_DEBUG("PARAM_INVALID: %s", pname);
-		}
-
-		sprintf(pname, pname_format_pwm_ch_fail[param_group], param_index);
-		param_h = param_find(pname);
-
-		if (param_h != PARAM_INVALID) {
-			int32_t pval = 0;
-			param_get(param_h, &pval);
-
-			if (pval != -1) {
-				_mixing_output.failsafeValue(i) = pval;
-
-			} else {
-				_mixing_output.failsafeValue(i) = default_pwm_fail;
-			}
-
-		} else {
-			PX4_DEBUG("PARAM_INVALID: %s", pname);
-		}
-
-		sprintf(pname, pname_format_pwm_ch_dis[param_group], param_index);
-		param_h = param_find(pname);
-
-		if (param_h != PARAM_INVALID) {
-			int32_t pval = 0;
-			param_get(param_h, &pval);
-
-			if (pval != -1) {
-				_mixing_output.disarmedValue(i) = pval;
-
-			} else {
-				_mixing_output.disarmedValue(i) = default_pwm_dis;
-			}
-
-		} else {
-			PX4_DEBUG("PARAM_INVALID: %s", pname);
-		}
-
-		sprintf(pname, pname_format_pwm_ch_rev[param_group], param_index);
-		param_h = param_find(pname);
-
-		if (param_h != PARAM_INVALID) {
-			uint16_t &reverse_pwm_mask = _mixing_output.reverseOutputMask();
-			int32_t pval = 0;
-			param_get(param_h, &pval);
-			reverse_pwm_mask &= (0xfffe << i);  // clear this bit
-			reverse_pwm_mask |= (((uint16_t)(pval != 0)) << i); // set to new val
-
-		} else {
-			PX4_DEBUG("PARAM_INVALID: %s", pname);
-		}
-	}
-
-	if (_mixing_output.mixers()) { // only update trims if mixer loaded
-		updatePWMParamTrim();
-	}
-}
-
-void PCA9685Wrapper::updatePWMParamTrim()
-{
-	const char *pname_format_pwm_ch_trim[2] = {"PWM_MAIN_TRIM%d", "PWM_AUX_TRIM%d"};
-
-	int16_t trim_values[PCA9685_PWM_CHANNEL_COUNT] = {};
-
-	for (int i = 0; i < PCA9685_PWM_CHANNEL_COUNT; i++) {
-		char pname[16];
-
-		uint8_t param_group, param_index;
-
-		if (i <= 7) {	// Main channel
-			param_group = 0;
-			param_index = i + 1;
-
-		} else {	// AUX
-			param_group = 1;
-			param_index = i - 8 + 1;
-		}
-
-		sprintf(pname, pname_format_pwm_ch_trim[param_group], param_index);
-		param_t param_h = param_find(pname);
-		int32_t val;
-
-		if (param_h != PARAM_INVALID) {
-			param_get(param_h, &val);
-			trim_values[i] = (int16_t)val;
-
-		} else {
-			PX4_DEBUG("PARAM_INVALID: %s", pname);
-		}
-	}
-
-	unsigned n_out = _mixing_output.mixers()->set_trims(trim_values, PCA9685_PWM_CHANNEL_COUNT);
-	PX4_DEBUG("set %d trims", n_out);
 }
 
 bool PCA9685Wrapper::updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
 				   unsigned num_control_groups_updated)
 {
-	return pca9685->updatePWM(outputs, num_outputs) == 0 ? true : false;
+	return pca9685->updatePWM(outputs, num_outputs) == 0;
 }
 
 void PCA9685Wrapper::Run()
 {
-	SmartLock lock_guard(_lock);
-
 	if (should_exit()) {
 		ScheduleClear();
 		_mixing_output.unregister();
-		unregister_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH, _class_instance);
 
 		pca9685->Stop();
 		delete pca9685;
@@ -398,13 +214,13 @@ void PCA9685Wrapper::Run()
 		pca9685->initReg();
 		updatePWMParams();  // target frequency fetched, immediately apply it
 
-		if (_targetFreq > 0.0f) {
-			if (pca9685->setFreq(_targetFreq) != PX4_OK) {
-				PX4_ERR("failed to set pwm frequency to %.2f, fall back to 50Hz", (double)_targetFreq);
+		if (_target_frequency > 0.0f) {
+			if (pca9685->setFreq(_target_frequency) != PX4_OK) {
+				PX4_ERR("failed to set pwm frequency to %.2f, fall back to 50Hz", (double)_target_frequency);
 				pca9685->setFreq(50.0f);	// this should not fail
 			}
 
-			_targetFreq = -1.0f;
+			_target_frequency = -1.0f;
 
 		} else {
 			// should not happen
@@ -421,8 +237,8 @@ void PCA9685Wrapper::Run()
 			_state = STATE::RUNNING;
 			float schedule_rate = pca9685->getFrequency();
 
-			if (_schd_rate_limit < pca9685->getFrequency()) {
-				schedule_rate = _schd_rate_limit;
+			if (_schd_rate_limit < (int)pca9685->getFrequency()) {
+				schedule_rate = (float)_schd_rate_limit;
 			}
 
 			ScheduleOnInterval(1000000 / schedule_rate, 1000000 / schedule_rate);
@@ -435,7 +251,7 @@ void PCA9685Wrapper::Run()
 		// check for parameter updates
 		if (_parameter_update_sub.updated()) {
 			// clear update
-			parameter_update_s pupdate;
+			parameter_update_s pupdate = {};
 			_parameter_update_sub.copy(&pupdate);
 
 			// update parameters from storage
@@ -444,17 +260,17 @@ void PCA9685Wrapper::Run()
 
 		_mixing_output.updateSubscriptions(false);
 
-		if (_targetFreq > 0.0f) { // check if frequency should be changed
+		if (_target_frequency > 0.0f) { // check if frequency should be changed
 			ScheduleClear();
 			pca9685->disableAllOutput();
 			pca9685->stopOscillator();
 
-			if (pca9685->setFreq(_targetFreq) != PX4_OK) {
+			if (pca9685->setFreq(_target_frequency) != PX4_OK) {
 				PX4_ERR("failed to set pwm frequency, fall back to 50Hz");
 				pca9685->setFreq(50.0f);	// this should not fail
 			}
 
-			_targetFreq = -1.0f;
+			_target_frequency = -1.0f;
 			pca9685->startOscillator();
 			_state = STATE::WAIT_FOR_OSC;
 			ScheduleDelayed(500);
@@ -466,51 +282,6 @@ void PCA9685Wrapper::Run()
 	perf_end(_cycle_perf);
 }
 
-int PCA9685Wrapper::ioctl(cdev::file_t *filep, int cmd, unsigned long arg)
-{
-	SmartLock lock_guard(_lock);
-
-	int ret = OK;
-
-	switch (cmd) {
-	case MIXERIOCRESET:
-		_mixing_output.resetMixer();
-
-		break;
-
-	case MIXERIOCLOADBUF: {
-			const char *buf = (const char *)arg;
-			unsigned buflen = strlen(buf);
-			ret = _mixing_output.loadMixer(buf, buflen);
-
-			break;
-		}
-
-	case PWM_SERVO_GET_COUNT:
-		*(unsigned *)arg = PCA9685_PWM_CHANNEL_COUNT;
-
-		break;
-
-	case PWM_SERVO_SET_ARM_OK:
-	case PWM_SERVO_SET_FORCE_SAFETY_OFF:
-	case PWM_SERVO_CLEAR_ARM_OK:
-	case PWM_SERVO_SET_FORCE_SAFETY_ON:
-	case PWM_SERVO_ARM:
-	case PWM_SERVO_DISARM:
-		break;
-
-	default:
-		ret = -ENOTTY;
-		break;
-	}
-
-	if (ret == -ENOTTY) {
-		ret = CDev::ioctl(filep, cmd, arg);
-	}
-
-	return ret;
-}
-
 int PCA9685Wrapper::print_usage(const char *reason)
 {
 	if (reason) {
@@ -520,9 +291,7 @@ int PCA9685Wrapper::print_usage(const char *reason)
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description
-This module is responsible for generate pwm pulse with PCA9685 chip.
-
-It listens on the actuator_controls topics, does the mixing and writes the PWM outputs.
+This module is responsible for generating pwm pulse with PCA9685 chip.
 
 ### Implementation
 This module depends on ModuleBase and OutputModuleInterface.
@@ -531,11 +300,6 @@ IIC communication is based on CDev::I2C
 ### Examples
 It is typically started with:
 $ pca9685_pwm_out start -a 64 -b 1
-
-Use the `mixer` command to load mixer files.
-`mixer load /dev/pwm_outputX etc/mixers/quad_x.main.mix`
-The number X can be acquired by executing
-`pca9685_pwm_out status` when this driver is running.
 )DESCR_STR");
 
     PRINT_MODULE_USAGE_NAME("pca9685_pwm_out", "driver");
@@ -554,7 +318,6 @@ int PCA9685Wrapper::print_status() {
             pca9685->get_device_bus(),
             pca9685->get_device_address(),
              (double)(pca9685->getFrequency()));
-    PX4_INFO("CDev path: %s%d", PWM_OUTPUT_BASE_DEVICE_PATH, this->_class_instance);
 
     return ret;
 }
@@ -625,14 +388,6 @@ int PCA9685Wrapper::task_spawn(int argc, char **argv) {
     _task_id = -1;
 
     return PX4_ERROR;
-}
-
-void PCA9685Wrapper::mixerChanged() {
-    OutputModuleInterface::mixerChanged();
-    if (_mixing_output.mixers()) { // only update trims if mixer loaded
-        updatePWMParamTrim();
-    }
-    _mixing_output.updateSubscriptions(false);
 }
 
 extern "C" __EXPORT int pca9685_pwm_out_main(int argc, char *argv[]);

--- a/src/drivers/pca9685_pwm_out/module.yaml
+++ b/src/drivers/pca9685_pwm_out/module.yaml
@@ -1,11 +1,28 @@
 module_name: PCA9685 Output
 actuator_output:
   output_groups:
-    - param_prefix: PCA9685
-      channel_label: 'Channel'
+    - generator: pwm
+      param_prefix: PCA9685
+      channel_labels: ['Channel']
+      channel_label_module_name_prefix: true
+      timer_config_file: "src/drivers/pca9685_pwm_out/timer_config.cpp"
       standard_params:
         disarmed: { min: 800, max: 2200, default: 900 }
         min: { min: 800, max: 1400, default: 1000 }
         max: { min: 1600, max: 2200, default: 2000 }
         failsafe: { min: 800, max: 2200 }
       num_channels: 16
+      pwm_timer_param:
+        description:
+            short: Output Protocol Configuration for ${label}
+            long: |
+                Select which Output Protocol to use for outputs ${label}.
+
+                Custom PWM rates can be used by directly setting any value >0.
+        type: enum
+        default: 50
+        values:
+            50: PWM50
+            100: PWM100
+            200: PWM200
+            400: PWM400

--- a/src/drivers/pca9685_pwm_out/timer_config.cpp
+++ b/src/drivers/pca9685_pwm_out/timer_config.cpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *  Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/*
+ * Fake IO timers def. Not compilable
+ */
+
+constexpr io_timers_t io_timers[1] = {
+	Timer::Timer, DUMMY
+};
+
+constexpr timer_io_channels_t timer_io_channels[MAX_TIMER_IO_CHANNELS] = {
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+	Timer::Timer, DUMMY,
+};


### PR DESCRIPTION
**Describe problem solved by this pull request**

Seems that the driver is already broken for a while so that this PR completely removed legacy mixer support, and make it working with new Dynamic Control Allocator. The new architecture also brings configuration flexibility to this driver so that it should works for other boards with simple QGC side turning.

**Describe your solution**

I've made a fake `timer_config.cpp` to take advantage of QGC UI elements. Maybe a bit hacky...

Also did some modification around board startup scripts.