### PR TITLE
mc_pos_control: filter velocity before derivative and switch to AlphaFilter

### DIFF
--- a/src/lib/controllib/controllib_test/CMakeLists.txt
+++ b/src/lib/controllib/controllib_test/CMakeLists.txt
@@ -38,6 +38,7 @@ px4_add_module(
 	SRCS
 		controllib_test_main.cpp
 	DEPENDS
+		controllib
 	)
 
 

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -290,6 +290,11 @@ inline bool isFinite(const float &value)
 	return PX4_ISFINITE(value);
 }
 
+inline bool isFinite(const matrix::Vector2f &value)
+{
+	return PX4_ISFINITE(value(0)) && PX4_ISFINITE(value(1));
+}
+
 inline bool isFinite(const matrix::Vector3f &value)
 {
 	return value.isAllFinite();

--- a/src/lib/mathlib/math/filter/AlphaFilter.hpp
+++ b/src/lib/mathlib/math/filter/AlphaFilter.hpp
@@ -48,13 +48,20 @@
 using namespace math;
 
 template <typename T>
-class AlphaFilter
+class AlphaFilter final
 {
 public:
 	AlphaFilter() = default;
 	explicit AlphaFilter(float alpha) : _alpha(alpha) {}
 
 	~AlphaFilter() = default;
+
+	// 0.01 to 10,000 Hz
+	static constexpr float MIN_FREQ_HZ = 0.01f;    // 0.01 Hz or 100s interval
+	static constexpr float MAX_FREQ_HZ = 10'000.f; // 10,000 Hz or 0.0001s interval
+
+	static constexpr float min_interval_s() { return 1.f / MAX_FREQ_HZ; }
+	static constexpr float max_interval_s() { return 1.f / MIN_FREQ_HZ; }
 
 	/**
 	 * Set filter parameters for time abstraction
@@ -64,27 +71,67 @@ public:
 	 * @param sample_interval interval between two samples
 	 * @param time_constant filter time constant determining convergence
 	 */
-	void setParameters(float sample_interval, float time_constant)
+	bool setParameters(const float sample_interval, const float time_constant)
 	{
-		const float denominator = time_constant + sample_interval;
-
-		if (denominator > FLT_EPSILON) {
-			setAlpha(sample_interval / denominator);
-		}
-	}
-
-	bool setCutoffFreq(float sample_freq, float cutoff_freq)
-	{
-		if ((sample_freq <= 0.f) || (cutoff_freq <= 0.f) || (cutoff_freq >= sample_freq / 2.f)
-		    || !isFinite(sample_freq) || !isFinite(cutoff_freq)) {
-
-			// Invalid parameters
+		if ((sample_interval <= 0.f) || !PX4_ISFINITE(sample_interval)
+		    || (time_constant <= 0.f) || !PX4_ISFINITE(time_constant)) {
+			// invalid parameters, disable filter
+			disable();
 			return false;
 		}
 
-		setParameters(1.f / sample_freq, 1.f / (2.f * M_PI_F * cutoff_freq));
-		_cutoff_freq = cutoff_freq;
-		return true;
+		_sample_interval = math::constrain(sample_interval, min_interval_s(), max_interval_s());
+		_time_constant = time_constant;
+
+		const float alpha = _sample_interval / (_sample_interval + _time_constant);
+
+		return setAlpha(alpha);
+	}
+
+	bool setCutoffFreq(const float sample_freq, const float cutoff_freq)
+	{
+		if ((sample_freq <= 0.f) || !PX4_ISFINITE(sample_freq)
+		    || (cutoff_freq <= 0.f) || !PX4_ISFINITE(cutoff_freq)) {
+			// invalid parameters, disable filter
+			disable();
+			return false;
+		}
+
+		const float sample_freq_constrained = math::constrain(sample_freq, MIN_FREQ_HZ, MAX_FREQ_HZ);
+		const float cutoff_freq_constrained = math::constrain(cutoff_freq, MIN_FREQ_HZ, sample_freq_constrained / 2.f);
+
+		_sample_interval = 1.f / sample_freq_constrained;
+		_time_constant = 1.f / (2.f * M_PI_F * cutoff_freq_constrained);
+
+		const float alpha = _sample_interval / (_sample_interval + _time_constant);
+
+		return setAlpha(alpha);
+	}
+
+	bool setCutoffFrequency(const float cutoff_freq)
+	{
+		const float time_constant = 1.f / (2.f * M_PI_F * cutoff_freq);
+		return setTimeConstant(time_constant);
+	}
+
+	bool setTimeConstant(const float time_constant)
+	{
+		if ((time_constant <= 0.f) || !PX4_ISFINITE(time_constant)) {
+			// Invalid parameters, disable filter
+			disable();
+			return false;
+		}
+
+		if ((fabsf(time_constant - _time_constant) / _time_constant) < 0.01f) {
+			// no change, do nothing
+			return true;
+		}
+
+		// time constant changed, update alpha
+		_time_constant = time_constant;
+		const float alpha = _sample_interval / (_sample_interval + _time_constant);
+
+		return setAlpha(alpha);
 	}
 
 	/**
@@ -92,14 +139,35 @@ public:
 	 *
 	 * @param alpha [0,1] filter weight for the previous state. High value - long time constant.
 	 */
-	void setAlpha(float alpha) { _alpha = alpha; }
+	bool setAlpha(const float alpha)
+	{
+		if (alpha < 0.f || alpha > 1.f || !PX4_ISFINITE(alpha)) {
+			// Invalid parameters, disable filter
+			disable();
+			return false;
+		}
+
+		_alpha = alpha;
+		return true;
+	}
 
 	/**
 	 * Set filter state to an initial value
 	 *
 	 * @param sample new initial value
 	 */
-	void reset(const T &sample) { _filter_state = sample; }
+	const T &reset(const T &sample = {})
+	{
+		_filter_state = sample;
+		return _filter_state;
+	}
+
+	void disable()
+	{
+		_alpha = 1.f;
+		_sample_interval = 1.f;
+		_time_constant = 0.f;
+	}
 
 	/**
 	 * Add a new raw value to the filter
@@ -112,13 +180,44 @@ public:
 		return _filter_state;
 	}
 
+	const T &update(const T &sample, const float dt)
+	{
+		if ((fabsf(dt - _sample_interval) / _sample_interval) > 0.01f) {
+			// update parameters if changed by more than 1%
+			if (!setParameters(dt, _time_constant)) {
+				// invalid new parameters, reset filter
+				return reset(sample);
+			}
+		}
+
+		_filter_state = updateCalculation(sample);
+		return _filter_state;
+	}
+
 	const T &getState() const { return _filter_state; }
-	float getCutoffFreq() const { return _cutoff_freq; }
 
-protected:
-	T updateCalculation(const T &sample) { return (1.f - _alpha) * _filter_state + _alpha * sample; }
+	float getCutoffFreq() const { return 1.f / (2.f * M_PI_F * _time_constant); }
 
-	float _cutoff_freq{0.f};
-	float _alpha{0.f};
+	const float &getSampleInterval() const { return _sample_interval; }
+	const float &getTimeConstant() const { return _time_constant; }
+
+private:
+
+	T updateCalculation(const T &sample)
+	{
+		// don't allow bad updates to propagate
+		const T ret = (1.f - _alpha) * _filter_state + _alpha * sample;
+
+		if (isFinite(ret)) {
+			return ret;
+		}
+
+		return {};
+	}
+
 	T _filter_state{};
+	float _alpha{1.f};
+
+	float _sample_interval{1.f};
+	float _time_constant{0.f};
 };

--- a/src/lib/mathlib/math/test/AlphaFilterTest.cpp
+++ b/src/lib/mathlib/math/test/AlphaFilterTest.cpp
@@ -247,7 +247,11 @@ TEST(AlphaFilterTest, SetFrequencyTest)
 	const float fs = .1f;
 
 	EXPECT_FALSE(_alpha_filter.setCutoffFreq(fs, 0.f));
-	EXPECT_FALSE(_alpha_filter.setCutoffFreq(fs, fs)); // Cutoff above Nyquist freq
+
+	// Cutoff above Nyquist freq
+	EXPECT_TRUE(_alpha_filter.setCutoffFreq(fs, fs));
+	EXPECT_FLOAT_EQ(_alpha_filter.getCutoffFreq(), fs / 2.f);
+
 	EXPECT_FALSE(_alpha_filter.setCutoffFreq(0.f, fs / 4.f));
 	EXPECT_FALSE(_alpha_filter.setCutoffFreq(0.f, 0.f));
 	EXPECT_FALSE(_alpha_filter.setCutoffFreq(-fs, fs / 4.f));

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -44,7 +44,6 @@ px4_add_module(
 	DEPENDS
 		PositionControl
 		Takeoff
-		controllib
 		geo
 		SlewRate
 	)

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -46,10 +46,10 @@
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 
 struct PositionControlStates {
-	matrix::Vector3f position;
-	matrix::Vector3f velocity;
-	matrix::Vector3f acceleration;
-	float yaw;
+	matrix::Vector3f position{NAN, NAN, NAN};
+	matrix::Vector3f velocity{NAN, NAN, NAN};
+	matrix::Vector3f acceleration{NAN, NAN, NAN};
+	float yaw{NAN};
 };
 
 /**

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -551,12 +551,23 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_XY, 0.8f);
 PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
 
 /**
- * Low pass filter cut freq. for numerical velocity derivative
+ * Velocity low pass filter cutoff frequency
  *
  * @unit Hz
- * @min 0.0
+ * @min 10
+ * @max 100
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_VEL_LP, 40.0f);
+
+/**
+ * Velocity derivative low pass filter cutoff frequency
+ *
+ * @unit Hz
+ * @min 1
  * @max 10
- * @decimal 2
+ * @decimal 1
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);


### PR DESCRIPTION
Investigating the root cause of small oscillations in multicopter position control modes. One possibility is the noisy velocity derivative.

https://logs.px4.io/plot_app?log=e807f10a-f1d4-4527-b59f-9a4da6ff770e

![Screenshot from 2022-04-19 12-31-30](https://user-images.githubusercontent.com/84712/164066526-c6b79e50-c60f-49aa-8564-5c310c3cc067.png)


I believe this is coming from the acceleration (velocity derivative) used by the multicopter position controller when `MPC_XY_VEL_D_ACC` is non-zero.
![Screenshot from 2022-04-19 14-04-14](https://user-images.githubusercontent.com/84712/164067478-5e618b57-542e-4311-88b2-a50da9474f00.png)
![Screenshot from 2022-04-19 14-09-30](https://user-images.githubusercontent.com/84712/164068328-c18ccf45-3fd0-4d30-a27b-d277d64420b5.png)

