### PR TITLE
FlightTaskAuto: remove _land_heading and instead directly set _yaw_setpoint (fixes weather vane landings)

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -483,7 +483,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	// set heading
 	if (_ext_yaw_handler != nullptr && _ext_yaw_handler->is_active()) {
-		_yaw_setpoint = _yaw;
+		_yaw_setpoint = NAN;
 		// use the yawrate setpoint from WV only if not moving lateral (velocity setpoint below half of _param_mpc_xy_cruise)
 		// otherwise, keep heading constant (as output from WV is not according to wind in this case)
 		bool vehicle_is_moving_lateral = _velocity_setpoint.xy().longerThan(_param_mpc_xy_cruise.get() / 2.0f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
When weather vane is enabled, we don't want to set any heading setpoint during Land, only yawspeed. Unless land help (nudging) is enabled and the yaw stick deflected, then both the yawspeed and yaw setpoint are set by that.
This functionality was already working correctly and acting on the `_yawspeed_setpoint`, but not yet on the `_yaw_setpoint`, as that one got overwritten by the `_land_heading`, that in turn was set during the init and only overwritten by the nudging (but not WV). 

**Describe your solution**
~Remove `_land_heading` and instead set `_yaw_setpoint` directly.~
EDIT:  Weather vane should only set a yawrate setpoint, but no yaw setpoint. Setting it to NAN when WV is active makes sure that whatever _yaw_setpoint is set previously (e.g. through Waypoint) is not used.

**Test data / coverage**
SITL tested with a standard VTOL.

