### PR TITLE
13004_quad+_tailsitter - outputs mixed up

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
@@ -7,8 +7,8 @@
 #
 # @output MAIN1 motor 1
 # @output MAIN2 motor 2
-# @output MAIN3 motor 4
-# @output MAIN4 motor 5
+# @output MAIN3 motor 3
+# @output MAIN4 motor 4
 # @output MAIN5 elevon left
 # @output MAIN6 elevon right
 # @output MAIN7 canard surface


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-user_guide/issues/1849

Essentially the airframe uses `R: 4+` or `R: 4x` mixers, and the motors are assigned sequentially to the next free bus slots. So it should not be possible for these to be out of order. 
This has been wrong for more than 5 years according to the docs.

Note, I don't have merge rights, so if you approve this, please also merge it.