### PR TITLE
Mission: don't do anything in set_current_mission_index() when index=current already

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -307,8 +307,10 @@ Mission::on_active()
 bool
 Mission::set_current_mission_index(uint16_t index)
 {
-	if (_navigator->get_mission_result()->valid &&
-	    (index != _current_mission_index) && (index < _mission.count)) {
+	if (index == _current_mission_index) {
+		return true; // nothing to do, so return true
+
+	} else if (_navigator->get_mission_result()->valid && (index < _mission.count)) {
 
 		_current_mission_index = index;
 


### PR DESCRIPTION

**Describe problem solved by this pull request**
When using MAV_CMD_MISSION_START to start a Mission on the ground, one gets the following sequence (including printfs here for context):
```

INFO  [commander] Armed by mission start	
_navigator->get_mission_result()->valid: 1
index: 0, _current_mission_index: 0, _mission.count: 11
WARN  [navigator] CMD_MISSION_START failed
INFO  [navigator] Takeoff to 20.0 meters above home
```
So it complains about that the mission start failed, but then it takes off still and flies perfectly fine.

**Describe your solution**
Don't do anything in set_current_mission_index() when index=current already, and return true.


**Test data / coverage**
SITL - with a groundstation that sends CMD_MISSION_START when starting the Mission while still disarmed.

