### PR TITLE
px4flow allow delayed background startup

### DIFF
--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -88,7 +88,7 @@ unset BOARD_RC_SENSORS
 # Check for flow sensor
 if param compare SENS_EN_PX4FLOW 1
 then
-	px4flow start -X
+	px4flow start -X &
 fi
 
 uavcannode start

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -101,12 +101,6 @@ then
 	pmw3901 -S start
 fi
 
-# Check for px4flow sensor
-if param compare -s SENS_EN_PX4FLOW 1
-then
-	px4flow start -X
-fi
-
 # vl53l1x i2c distance sensor
 if param compare -s SENS_EN_VL53L1X 1
 then
@@ -198,9 +192,3 @@ then
 	# start last (wait for possible icm20948 passthrough mode)
 	ak09916 -X -q start
 fi
-
-###############################################################################
-#                            End Optional drivers                             #
-###############################################################################
-
-sensors start

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -405,6 +405,7 @@ else
 			battery_status start
 		fi
 
+		sensors start
 		commander start
 	fi
 
@@ -506,6 +507,12 @@ else
 	if param compare -s IMU_GYRO_CAL_EN 1
 	then
 		gyro_calibration start
+	fi
+
+	# Check for px4flow sensor
+	if param compare -s SENS_EN_PX4FLOW 1
+	then
+		px4flow start -X &
 	fi
 
 	#

--- a/src/drivers/optical_flow/px4flow/px4flow.cpp
+++ b/src/drivers/optical_flow/px4flow/px4flow.cpp
@@ -406,6 +406,14 @@ px4flow_main(int argc, char *argv[])
 	BusInstanceIterator iterator(MODULE_NAME, cli, DRV_FLOW_DEVTYPE_PX4FLOW);
 
 	if (!strcmp(verb, "start")) {
+		// px4flow can require more time to fully start and be accessible
+		static constexpr uint64_t STARTUP_MIN_TIME_US = 6'000'000;
+		const hrt_abstime time_now_us = hrt_absolute_time();
+
+		if (time_now_us < STARTUP_MIN_TIME_US) {
+			px4_usleep(STARTUP_MIN_TIME_US - time_now_us);
+		}
+
 		return ThisDriver::module_start(cli, iterator);
 	}
 


### PR DESCRIPTION
On px4_fmu-v5x the peripheral power is cycled at init and things like the px4flow need more time to be available and successfully probe.

This is a bit ugly, but works for now. 