### PR TITLE
ROMFS: fix typo in convergence and claire configs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -13,7 +13,7 @@
 
 . ${R}etc/init.d/rc.vtol_defaults
 
-param set-defualt MAV_TYPE 21
+param set-default MAV_TYPE 21
 
 param set-default PWM_AUX_DISARM 1000
 param set-default PWM_AUX_MAX 2000

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -22,7 +22,7 @@
 
 . ${R}etc/init.d/rc.vtol_defaults
 
-param set-defualt MAV_TYPE 21
+param set-default MAV_TYPE 21
 
 param set-default CBRK_AIRSPD_CHK 162128
 


### PR DESCRIPTION
Caused the MAV_TYPE to not be set correctly (I noticed though only by chance when doing `dmesg` on a Convergence).