### PR TITLE
Set Tune's Volume for Power-Off in Commander to default volume

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -96,7 +96,7 @@ static orb_advert_t tune_control_pub = nullptr;
 static void play_power_button_down_tune()
 {
 	tune_control_s tune_control{};
-	tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT - 20;
+	tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
 	tune_control.tune_id = tune_control_s::TUNE_ID_POWER_OFF;
 	tune_control.timestamp = hrt_absolute_time();
 	orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Power Off volume was set to default volume - 20, which is almost inaudible for variable-volume beeper ESCs, like ATL Mantis Edu. So whenever powering down the ATL Mantis Edu, user couldn't know if it was turning off or not!

**Describe your solution**
Restore default volume as the volume commanded