### PR TITLE
px4_fmu-v6x_bootloader:Ensure PWM pins are low from boot

### DIFF
--- a/boards/px4/fmu-v6x/src/CMakeLists.txt
+++ b/boards/px4/fmu-v6x/src/CMakeLists.txt
@@ -31,14 +31,19 @@
 #
 ############################################################################
 if("${PX4_BOARD_LABEL}" STREQUAL  "bootloader")
+	add_compile_definitions(BOOTLOADER)
 	add_library(drivers_board
 		bootloader_main.c
+		init.c
 		usb.c
+		timer_config.cpp
 	)
 	target_link_libraries(drivers_board
 		PRIVATE
 			nuttx_arch # sdio
 			nuttx_drivers # sdio
+			px4_layer #gpio
+			arch_io_pins # iotimer
 			bootloader
 	)
 	target_include_directories(drivers_board PRIVATE ${PX4_SOURCE_DIR}/platforms/nuttx/src/bootloader/common)

--- a/boards/px4/fmu-v6x/src/bootloader_main.c
+++ b/boards/px4/fmu-v6x/src/bootloader_main.c
@@ -50,19 +50,6 @@
 
 extern int sercon_main(int c, char **argv);
 
-__EXPORT void board_on_reset(int status) {}
-
-__EXPORT void stm32_boardinitialize(void)
-{
-	/* configure USB interfaces */
-	stm32_usbinitialize();
-}
-
-__EXPORT int board_app_initialize(uintptr_t arg)
-{
-	return 0;
-}
-
 void board_late_initialize(void)
 {
 	sercon_main(0, NULL);

--- a/boards/px4/fmu-v6x/src/init.c
+++ b/boards/px4/fmu-v6x/src/init.c
@@ -141,7 +141,7 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void board_on_reset(int status)
 {
 	for (int i = 0; i < DIRECT_PWM_OUTPUT_CHANNELS; ++i) {
-		px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
+		px4_arch_configgpio(io_timer_channel_get_gpio_output(i));
 	}
 
 	if (status >= 0) {
@@ -208,6 +208,8 @@ stm32_boardinitialize(void)
 
 __EXPORT int board_app_initialize(uintptr_t arg)
 {
+#if !defined(BOOTLOADER)
+
 	/* Power on Interfaces */
 	VDD_3V3_SD_CARD_EN(true);
 	VDD_5V_PERIPH_EN(true);
@@ -247,11 +249,11 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		syslog(LOG_ERR, "[boot] DMA alloc FAILED\n");
 	}
 
-#if defined(SERIAL_HAVE_RXDMA)
+#  if defined(SERIAL_HAVE_RXDMA)
 	// set up the serial DMA polling at 1ms intervals for received bytes that have not triggered a DMA event.
 	static struct hrt_call serial_dma_call;
 	hrt_call_every(&serial_dma_call, 1000, 1000, (hrt_callout)stm32_serial_dma_poll, NULL);
-#endif
+#  endif
 
 	/* initial LED state */
 	drv_led_start();
@@ -268,7 +270,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	VDD_3V3_SD_CARD_EN(true);
 	usleep(500 * 1000);
 
-#ifdef CONFIG_MMCSD
+#  ifdef CONFIG_MMCSD
 	int ret = stm32_sdio_initialize();
 
 	if (ret != OK) {
@@ -276,7 +278,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		return ret;
 	}
 
-#endif /* CONFIG_MMCSD */
+#  endif /* CONFIG_MMCSD */
+
+#endif /* !defined(BOOTLOADER) */
 
 	return OK;
 }


### PR DESCRIPTION
The PR ensures the PWM pins stay low from power on (in bootloader) until driven

N.B. the PX4IO has a 880 ns pulse on it.

Channels are PX4IO 0-7, FMU 8-15

Master
From power on battery
![image](https://user-images.githubusercontent.com/1945821/165141273-863bbbf7-c7d8-43dd-987f-8c87bfc9d8e1.png)

From power on USB
![image](https://user-images.githubusercontent.com/1945821/165141004-b7938c51-77db-40a4-997e-389b27e4a914.png)



This PR
From power on battery
![image](https://user-images.githubusercontent.com/1945821/165139973-10236ada-e077-4647-8506-ac41cbe15863.png)
From power on USB
![image](https://user-images.githubusercontent.com/1945821/165140124-9c5d0c03-a3e0-4b28-bec9-306f0254c408.png)
