### PR TITLE
drivers/rc_input: RC_INPUT_PROTO parameter minimal implementation

### DIFF
--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2019, 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,21 +91,23 @@ public:
 private:
 
 	enum RC_SCAN {
-		RC_SCAN_PPM = 0,
-		RC_SCAN_SBUS,
-		RC_SCAN_DSM,
-		RC_SCAN_SUMD,
-		RC_SCAN_ST24,
-		RC_SCAN_CRSF,
-		RC_SCAN_GHST
+		RC_SCAN_NONE = 0,
+		RC_SCAN_PPM  = 1,
+		RC_SCAN_SBUS = 2,
+		RC_SCAN_DSM  = 3,
+		RC_SCAN_ST24 = 5,
+		RC_SCAN_SUMD = 4,
+		RC_SCAN_CRSF = 6,
+		RC_SCAN_GHST = 7,
 	} _rc_scan_state{RC_SCAN_SBUS};
 
-	static constexpr char const *RC_SCAN_STRING[7] {
+	static constexpr char const *RC_SCAN_STRING[] {
+		"None",
 		"PPM",
 		"SBUS",
 		"DSM",
-		"SUMD",
 		"ST24",
+		"SUMD",
 		"CRSF",
 		"GHST"
 	};
@@ -168,6 +170,7 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::RC_RSSI_PWM_CHAN>) _param_rc_rssi_pwm_chan,
 		(ParamInt<px4::params::RC_RSSI_PWM_MIN>) _param_rc_rssi_pwm_min,
-		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max
+		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max,
+		(ParamInt<px4::params::RC_INPUT_PROTO>) _param_rc_input_proto
 	)
 };

--- a/src/drivers/rc_input/module.yaml
+++ b/src/drivers/rc_input/module.yaml
@@ -1,4 +1,28 @@
 module_name: RC Input Driver
+parameters:
+    - group: RC Input
+      definitions:
+        RC_INPUT_PROTO:
+            description:
+                short: RC input protocol
+                long: |
+                    Select your RC input protocol or auto to scan.
+            category: System
+            type: enum
+            values:
+                -1: Auto
+                0: None
+                1: PPM
+                2: SBUS
+                3: DSM
+                4: ST24
+                5: SUMD
+                6: CRSF
+                7: GHST
+            min: -1
+            max: 7
+            default: -1
+
 serial_config:
     - command: set RC_INPUT_ARGS "-d ${SERIAL_DEV}"
       port_config_param:


### PR DESCRIPTION
This is a minimal version of https://github.com/PX4/PX4-Autopilot/pull/19285 that fixes the `drivers/rc_input` problem where CRSF and GHST protocols can be falsely detected due to a nearly identical wire format. Following the next release the common `drivers/rc_input` module will be split into dedicated drivers per protocol.

By default the existing `drivers/rc_input` behavior is maintained, but with a new parameter`RC_INPUT_PROTO` that always manually specifying the protocol. Additionally the parameter is set to the RC protocol on the first successful decode, so future sessions will skip the scanning entirely.

Co-authored-by: chris1seto <chris12892@gmail.com>
