### PR TITLE
HTE: use automatic differentiation

### DIFF
--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
@@ -114,21 +114,7 @@ private:
 
 	float computeInnovVar(float H) const;
 	matrix::Dual<float, 1> computePredictedAccZ(const matrix::Dual<float, 1> &hover_thrust, float thrust) const;
-	float computeKalmanGain(float H, float innov_var) const;
 
-	/*
-	 * Compute the ratio between the Normalized Innovation Squared (NIS)
-	 * and its maximum gate size. Use isTestRatioPassing to know if the
-	 * measurement should be fused or not.
-	 */
-	float computeInnovTestRatio(float innov, float innov_var) const;
-	bool isTestRatioPassing(float innov_test_ratio) const;
-
-	void updateState(float K, float innov);
-	void updateStateCovariance(float K, float H);
-	bool isLargeOffsetDetected() const;
-
-	void bumpStateVariance();
 	void updateLpf(float residual, float signed_innov_test_ratio);
 	void updateMeasurementNoise(float residual, float H);
 

--- a/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
+++ b/src/modules/mc_hover_thrust_estimator/zero_order_hover_thrust_ekf.hpp
@@ -112,10 +112,8 @@ private:
 	float _residual_lpf{}; ///< used to remove the constant bias of the residual
 	float _signed_innov_test_ratio_lpf{}; ///< used as a delay to trigger the recovery logic
 
-	float computeH(float thrust) const;
 	float computeInnovVar(float H) const;
-	float computePredictedAccZ(float thrust) const;
-	float computeInnov(float acc_z, float thrust) const;
+	matrix::Dual<float, 1> computePredictedAccZ(const matrix::Dual<float, 1> &hover_thrust, float thrust) const;
 	float computeKalmanGain(float H, float innov_var) const;
 
 	/*


### PR DESCRIPTION
**Describe problem solved by this pull request**
An EKF requires jacobians to be computed in order to linearize the equations. Those matrices are usually pre-computed and then implemented in the code. The issue is that partial derivatives can be really large compared to the original function.

**Describe your solution**
Implementation of pre-computed jacobians can be nicely replaced by automatic differentiation without loss of precision. I took that simple single state estimator as a first attempt of using autodiff. The change of flash space and CPU load change is insignificant in this example, but the explicit observation jacobian (`H`) is now implicitly computed by automatic differentiation.

**Test data / coverage**
Unit test and SITL test

Thanks @jkflying for the nice implementation.