### PR TITLE
logger watchdog: also check main thread

### DIFF
--- a/src/modules/logger/watchdog.h
+++ b/src/modules/logger/watchdog.h
@@ -50,6 +50,7 @@ struct watchdog_data_t {
 	int logger_main_task_index = -1;
 	int logger_writer_task_index = -1;
 	hrt_abstime ready_to_run_timestamp = hrt_absolute_time();
+	hrt_abstime sem_counter_saturated_start = hrt_absolute_time();
 	uint8_t last_state = TSTATE_TASK_INVALID;
 #endif /* __PX4_NUTTX */
 };
@@ -70,9 +71,10 @@ void watchdog_initialize(const pid_t pid_logger_main, const pthread_t writer_thr
  * Expected to be called from IRQ context.
  *
  * @param watchdog_data
+ * @param semaphore_value_saturated if the scheduling semaphore counter is saturated
  * @return true if watchdog is triggered, false otherwise
  */
-bool watchdog_update(watchdog_data_t &watchdog_data);
+bool watchdog_update(watchdog_data_t &watchdog_data, bool semaphore_value_saturated);
 
 } //namespace logger
 } //namespace px4


### PR DESCRIPTION
There was a time window where if a task with higher priority than the main
logger thread would busy-loop, it would block both logging threads and the
watchdog would not trigger if the writer was in idle state.
This can happen for fast SD card writes.