### PR TITLE
[WIP] ekf2: use autodiff to fuse optical flow observations

### DIFF
--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -47,26 +47,23 @@
 #include <float.h>
 #include "utils.hpp"
 
+using D = matrix::Dual<float, 7>;
+using matrix::Vector3;
+
 void Ekf::fuseOptFlow()
 {
 	float gndclearance = fmaxf(_params.rng_gnd_clearance, 0.1f);
-
-	// get latest estimated orientation
-	const float q0 = _state.quat_nominal(0);
-	const float q1 = _state.quat_nominal(1);
-	const float q2 = _state.quat_nominal(2);
-	const float q3 = _state.quat_nominal(3);
-
-	// get latest velocity in earth frame
-	const float vn = _state.vel(0);
-	const float ve = _state.vel(1);
-	const float vd = _state.vel(2);
 
 	// calculate the optical flow observation variance
 	const float R_LOS = calcOptFlowMeasVar();
 
 	// get rotation matrix from earth to body
 	const Dcmf earth_to_body = quatToInverseRotMat(_state.quat_nominal);
+
+	matrix::Quaternion<D> q(D(_state.quat_nominal(0), 0),
+			D(_state.quat_nominal(1), 1),
+			D(_state.quat_nominal(2), 2),
+			D(_state.quat_nominal(3), 3));
 
 	// calculate the sensor position relative to the IMU
 	const Vector3f pos_offset_body = _params.flow_pos_body - _params.imu_pos_body;
@@ -76,10 +73,10 @@ void Ekf::fuseOptFlow()
 	const Vector3f vel_rel_imu_body = Vector3f(-_flow_sample_delayed.gyro_xyz / _flow_sample_delayed.dt) % pos_offset_body;
 
 	// calculate the velocity of the sensor in the earth frame
-	const Vector3f vel_rel_earth = _state.vel + _R_to_earth * vel_rel_imu_body;
+	Vector3<D> vel_earth(D(_state.vel(0), 4), D(_state.vel(1), 5), D(_state.vel(2), 6));
 
 	// rotate into body frame
-	const Vector3f vel_body = earth_to_body * vel_rel_earth;
+	Vector3<D> vel_body = q.rotateVectorInverse(vel_earth) + Vector3<D>(D(vel_rel_imu_body(0)), D(vel_rel_imu_body(1)), D(vel_rel_imu_body(2)));
 
 	// height above ground of the IMU
 	float heightAboveGndEst = _terrain_vpos - _state.pos(2);
@@ -108,142 +105,51 @@ void Ekf::fuseOptFlow()
 	_flow_vel_body(1) = opt_flow_rate(0) * range;
 	_flow_vel_ne = Vector2f(_R_to_earth * Vector3f(_flow_vel_body(0), _flow_vel_body(1), 0.f));
 
-	_flow_innov(0) =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
-	_flow_innov(1) = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis
+	matrix::Vector2<D> predicted_flow;
+	predicted_flow(0) =  vel_body(1) / range;
+	predicted_flow(1) = -vel_body(0) / range;
+	_flow_innov(0) = predicted_flow(0).value - opt_flow_rate(0);
+	_flow_innov(1) = predicted_flow(1).value - opt_flow_rate(1);
 
-	// The derivation allows for an arbitrary body to flow sensor frame rotation which is
-	// currently not supported by the EKF, so assume sensor frame is aligned with the
-	// body frame
-	const Dcmf Tbs = matrix::eye<float, 3>();
-
-	// Sub Expressions
-	const float HK0 = -Tbs(1,0)*q2 + Tbs(1,1)*q1 + Tbs(1,2)*q0;
-	const float HK1 = Tbs(1,0)*q3 + Tbs(1,1)*q0 - Tbs(1,2)*q1;
-	const float HK2 = Tbs(1,0)*q0 - Tbs(1,1)*q3 + Tbs(1,2)*q2;
-	const float HK3 = HK0*vd + HK1*ve + HK2*vn;
-	const float HK4 = 1.0F/range;
-	const float HK5 = 2*HK4;
-	const float HK6 = Tbs(1,0)*q1 + Tbs(1,1)*q2 + Tbs(1,2)*q3;
-	const float HK7 = -HK0*ve + HK1*vd + HK6*vn;
-	const float HK8 = HK0*vn - HK2*vd + HK6*ve;
-	const float HK9 = -HK1*vn + HK2*ve + HK6*vd;
-	const float HK10 = q0*q2;
-	const float HK11 = q1*q3;
-	const float HK12 = HK10 + HK11;
-	const float HK13 = 2*Tbs(1,2);
-	const float HK14 = q0*q3;
-	const float HK15 = q1*q2;
-	const float HK16 = HK14 - HK15;
-	const float HK17 = 2*Tbs(1,1);
-	const float HK18 = ecl::powf(q1, 2);
-	const float HK19 = ecl::powf(q2, 2);
-	const float HK20 = -HK19;
-	const float HK21 = ecl::powf(q0, 2);
-	const float HK22 = ecl::powf(q3, 2);
-	const float HK23 = HK21 - HK22;
-	const float HK24 = HK18 + HK20 + HK23;
-	const float HK25 = HK12*HK13 - HK16*HK17 + HK24*Tbs(1,0);
-	const float HK26 = HK14 + HK15;
-	const float HK27 = 2*Tbs(1,0);
-	const float HK28 = q0*q1;
-	const float HK29 = q2*q3;
-	const float HK30 = HK28 - HK29;
-	const float HK31 = -HK18;
-	const float HK32 = HK19 + HK23 + HK31;
-	const float HK33 = -HK13*HK30 + HK26*HK27 + HK32*Tbs(1,1);
-	const float HK34 = HK28 + HK29;
-	const float HK35 = HK10 - HK11;
-	const float HK36 = HK20 + HK21 + HK22 + HK31;
-	const float HK37 = HK17*HK34 - HK27*HK35 + HK36*Tbs(1,2);
-	const float HK38 = 2*HK3;
-	const float HK39 = 2*HK7;
-	const float HK40 = 2*HK8;
-	const float HK41 = 2*HK9;
-	const float HK42 = HK25*P(0,4) + HK33*P(0,5) + HK37*P(0,6) + HK38*P(0,0) + HK39*P(0,1) + HK40*P(0,2) + HK41*P(0,3);
-	const float HK43 = ecl::powf(range, -2);
-	const float HK44 = HK25*P(4,6) + HK33*P(5,6) + HK37*P(6,6) + HK38*P(0,6) + HK39*P(1,6) + HK40*P(2,6) + HK41*P(3,6);
-	const float HK45 = HK25*P(4,5) + HK33*P(5,5) + HK37*P(5,6) + HK38*P(0,5) + HK39*P(1,5) + HK40*P(2,5) + HK41*P(3,5);
-	const float HK46 = HK25*P(4,4) + HK33*P(4,5) + HK37*P(4,6) + HK38*P(0,4) + HK39*P(1,4) + HK40*P(2,4) + HK41*P(3,4);
-	const float HK47 = HK25*P(2,4) + HK33*P(2,5) + HK37*P(2,6) + HK38*P(0,2) + HK39*P(1,2) + HK40*P(2,2) + HK41*P(2,3);
-	const float HK48 = HK25*P(3,4) + HK33*P(3,5) + HK37*P(3,6) + HK38*P(0,3) + HK39*P(1,3) + HK40*P(2,3) + HK41*P(3,3);
-	const float HK49 = HK25*P(1,4) + HK33*P(1,5) + HK37*P(1,6) + HK38*P(0,1) + HK39*P(1,1) + HK40*P(1,2) + HK41*P(1,3);
-	// const float HK50 = HK4/(HK25*HK43*HK46 + HK33*HK43*HK45 + HK37*HK43*HK44 + HK38*HK42*HK43 + HK39*HK43*HK49 + HK40*HK43*HK47 + HK41*HK43*HK48 + R_LOS);
-
-	// calculate innovation variance for X axis observation and protect against a badly conditioned calculation
-	_flow_innov_var(0) = (HK25*HK43*HK46 + HK33*HK43*HK45 + HK37*HK43*HK44 + HK38*HK42*HK43 + HK39*HK43*HK49 + HK40*HK43*HK47 + HK41*HK43*HK48 + R_LOS);
-
-	if (_flow_innov_var(0) < R_LOS) {
-		// we need to reinitialise the covariance matrix and abort this fusion step
-		initialiseCovariance();
-		return;
-	}
-	const float HK50 = HK4/_flow_innov_var(0);
-
-	const float HK51 = Tbs(0,1)*q1;
-	const float HK52 = Tbs(0,2)*q0;
-	const float HK53 = Tbs(0,0)*q2;
-	const float HK54 = HK51 + HK52 - HK53;
-	const float HK55 = Tbs(0,0)*q3;
-	const float HK56 = Tbs(0,1)*q0;
-	const float HK57 = Tbs(0,2)*q1;
-	const float HK58 = HK55 + HK56 - HK57;
-	const float HK59 = Tbs(0,0)*q0;
-	const float HK60 = Tbs(0,2)*q2;
-	const float HK61 = Tbs(0,1)*q3;
-	const float HK62 = HK59 + HK60 - HK61;
-	const float HK63 = HK54*vd + HK58*ve + HK62*vn;
-	const float HK64 = Tbs(0,0)*q1 + Tbs(0,1)*q2 + Tbs(0,2)*q3;
-	const float HK65 = HK58*vd + HK64*vn;
-	const float HK66 = -HK54*ve + HK65;
-	const float HK67 = HK54*vn + HK64*ve;
-	const float HK68 = -HK62*vd + HK67;
-	const float HK69 = HK62*ve + HK64*vd;
-	const float HK70 = -HK58*vn + HK69;
-	const float HK71 = 2*Tbs(0,1);
-	const float HK72 = 2*Tbs(0,2);
-	const float HK73 = HK12*HK72 + HK24*Tbs(0,0);
-	const float HK74 = -HK16*HK71 + HK73;
-	const float HK75 = 2*Tbs(0,0);
-	const float HK76 = HK26*HK75 + HK32*Tbs(0,1);
-	const float HK77 = -HK30*HK72 + HK76;
-	const float HK78 = HK34*HK71 + HK36*Tbs(0,2);
-	const float HK79 = -HK35*HK75 + HK78;
-	const float HK80 = 2*HK63;
-	const float HK81 = 2*HK65 + 2*ve*(-HK51 - HK52 + HK53);
-	const float HK82 = 2*HK67 + 2*vd*(-HK59 - HK60 + HK61);
-	const float HK83 = 2*HK69 + 2*vn*(-HK55 - HK56 + HK57);
-	const float HK84 = HK71*(-HK14 + HK15) + HK73;
-	const float HK85 = HK72*(-HK28 + HK29) + HK76;
-	const float HK86 = HK75*(-HK10 + HK11) + HK78;
-	const float HK87 = HK80*P(0,0) + HK81*P(0,1) + HK82*P(0,2) + HK83*P(0,3) + HK84*P(0,4) + HK85*P(0,5) + HK86*P(0,6);
-	const float HK88 = HK80*P(0,6) + HK81*P(1,6) + HK82*P(2,6) + HK83*P(3,6) + HK84*P(4,6) + HK85*P(5,6) + HK86*P(6,6);
-	const float HK89 = HK80*P(0,5) + HK81*P(1,5) + HK82*P(2,5) + HK83*P(3,5) + HK84*P(4,5) + HK85*P(5,5) + HK86*P(5,6);
-	const float HK90 = HK80*P(0,4) + HK81*P(1,4) + HK82*P(2,4) + HK83*P(3,4) + HK84*P(4,4) + HK85*P(4,5) + HK86*P(4,6);
-	const float HK91 = HK80*P(0,2) + HK81*P(1,2) + HK82*P(2,2) + HK83*P(2,3) + HK84*P(2,4) + HK85*P(2,5) + HK86*P(2,6);
-	const float HK92 = 2*HK43;
-	const float HK93 = HK80*P(0,3) + HK81*P(1,3) + HK82*P(2,3) + HK83*P(3,3) + HK84*P(3,4) + HK85*P(3,5) + HK86*P(3,6);
-	const float HK94 = HK80*P(0,1) + HK81*P(1,1) + HK82*P(1,2) + HK83*P(1,3) + HK84*P(1,4) + HK85*P(1,5) + HK86*P(1,6);
-	// const float HK95 = HK4/(HK43*HK74*HK90 + HK43*HK77*HK89 + HK43*HK79*HK88 + HK43*HK80*HK87 + HK66*HK92*HK94 + HK68*HK91*HK92 + HK70*HK92*HK93 + R_LOS);
-
-	// calculate innovation variance for Y axis observation and protect against a badly conditioned calculation
-	_flow_innov_var(1) = (HK43*HK74*HK90 + HK43*HK77*HK89 + HK43*HK79*HK88 + HK43*HK80*HK87 + HK66*HK92*HK94 + HK68*HK91*HK92 + HK70*HK92*HK93 + R_LOS);
-	if (_flow_innov_var(1) < R_LOS) {
-		// we need to reinitialise the covariance matrix and abort this fusion step
-		initialiseCovariance();
-		return;
-	}
-	const float HK95 = HK4/_flow_innov_var(1);
-
-
-	// run the innovation consistency check and record result
-	bool flow_fail = false;
-	float test_ratio[2];
-	test_ratio[0] = sq(_flow_innov(0)) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var(0));
-	test_ratio[1] = sq(_flow_innov(1)) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var(1));
-	_optflow_test_ratio = math::max(test_ratio[0], test_ratio[1]);
+	// fuse observation axes sequentially
+	SparseVector24f<0,1,2,3,4,5,6> Hfusion; // Optical flow observation Jacobians
+	Vector24f Kfusion; // Optical flow Kalman gains
 
 	for (uint8_t obs_index = 0; obs_index <= 1; obs_index++) {
-		if (test_ratio[obs_index] > 1.0f) {
+		// Observation Jacobians
+		Hfusion.at<0>() = predicted_flow(obs_index).derivative(0);
+		Hfusion.at<1>() = predicted_flow(obs_index).derivative(1);
+		Hfusion.at<2>() = predicted_flow(obs_index).derivative(2);
+		Hfusion.at<3>() = predicted_flow(obs_index).derivative(3);
+		Hfusion.at<4>() = predicted_flow(obs_index).derivative(4);
+		Hfusion.at<5>() = predicted_flow(obs_index).derivative(5);
+		Hfusion.at<6>() = predicted_flow(obs_index).derivative(6);
+
+		auto PHt = P * Hfusion;
+		_flow_innov_var(obs_index) = Hfusion.dot(PHt) + R_LOS;
+
+		// Kalman gains
+		Kfusion = PHt / _flow_innov_var(obs_index);
+
+		// calculate innovation variance and protect against a badly conditioned calculation
+		if (_flow_innov_var(obs_index) < R_LOS) {
+			// we need to reinitialise the covariance matrix and abort this fusion step
+			initialiseCovariance();
+			return;
+		}
+
+		// run the innovation consistency check and record result
+		float test_ratio = sq(_flow_innov(obs_index)) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var(obs_index));
+		if (obs_index == 0) {
+			_optflow_test_ratio = test_ratio;
+
+		} else {
+			_optflow_test_ratio = math::max(_optflow_test_ratio, test_ratio);
+		}
+
+		bool flow_fail = false;
+
+		if (test_ratio > 1.0f) {
 			flow_fail = true;
 			_innov_check_fail_status.value |= (1 << (obs_index + 10));
 
@@ -251,66 +157,9 @@ void Ekf::fuseOptFlow()
 			_innov_check_fail_status.value &= ~(1 << (obs_index + 10));
 
 		}
-	}
 
-	// if either axis fails we abort the fusion
-	if (flow_fail) {
-		return;
-
-	}
-
-	// fuse observation axes sequentially
-	SparseVector24f<0,1,2,3,4,5,6> Hfusion; // Optical flow observation Jacobians
-	Vector24f Kfusion; // Optical flow Kalman gains
-
-	for (uint8_t obs_index = 0; obs_index <= 1; obs_index++) {
-
-		// calculate observation Jocobians and Kalman gains
-		if (obs_index == 0) {
-			// Observation Jacobians - axis 0
-			Hfusion.at<0>() = HK3*HK5;
-			Hfusion.at<1>() = HK5*HK7;
-			Hfusion.at<2>() = HK5*HK8;
-			Hfusion.at<3>() = HK5*HK9;
-			Hfusion.at<4>() = HK25*HK4;
-			Hfusion.at<5>() = HK33*HK4;
-			Hfusion.at<6>() = HK37*HK4;
-
-			// Kalman gains - axis 0
-			Kfusion(0) = HK42*HK50;
-			Kfusion(1) = HK49*HK50;
-			Kfusion(2) = HK47*HK50;
-			Kfusion(3) = HK48*HK50;
-			Kfusion(4) = HK46*HK50;
-			Kfusion(5) = HK45*HK50;
-			Kfusion(6) = HK44*HK50;
-
-			for (unsigned row = 7; row <= 23; row++) {
-				Kfusion(row) = HK50*(HK25*P(4,row) + HK33*P(5,row) + HK37*P(6,row) + HK38*P(0,row) + HK39*P(1,row) + HK40*P(2,row) + HK41*P(3,row));
-			}
-
-		} else {
-			// Observation Jacobians - axis 1
-			Hfusion.at<0>() = -HK5*HK63;
-			Hfusion.at<1>() = -HK5*HK66;
-			Hfusion.at<2>() = -HK5*HK68;
-			Hfusion.at<3>() = -HK5*HK70;
-			Hfusion.at<4>() = -HK4*HK74;
-			Hfusion.at<5>() = -HK4*HK77;
-			Hfusion.at<6>() = -HK4*HK79;
-
-			// Kalman gains - axis 1
-			Kfusion(0) = -HK87*HK95;
-			Kfusion(1) = -HK94*HK95;
-			Kfusion(2) = -HK91*HK95;
-			Kfusion(3) = -HK93*HK95;
-			Kfusion(4) = -HK90*HK95;
-			Kfusion(5) = -HK89*HK95;
-			Kfusion(6) = -HK88*HK95;
-
-			for (unsigned row = 7; row <= 23; row++) {
-				Kfusion(row) = -HK95*(HK80*P(0,row) + HK81*P(1,row) + HK82*P(2,row) + HK83*P(3,row) + HK84*P(4,row) + HK85*P(5,row) + HK86*P(6,row));
-			}
+		if (flow_fail) {
+			continue;
 
 		}
 


### PR DESCRIPTION
NOTE: the CPU load, flash space and RAM usage needs to be evaluated

**Describe problem solved by this pull request**
The auto-generated code is noisy and hard to read. More than this, modifying an existing fusion or adding a new one requires a lot of manual work.

**Describe your solution**
Automatic differentiation can be used to generate the observation jacobian without the need of pre-computed algebraic solution, making the code cleaner and less prone to human errors.

**Test data / coverage**
Unit tests and SITL (iris_opt_flow)