### PR TITLE
fix dshot: remove setAllFailsafeValues

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -47,7 +47,6 @@ DShot::DShot() :
 	_mixing_output.setAllDisarmedValues(DSHOT_DISARM_VALUE);
 	_mixing_output.setAllMinValues(DSHOT_MIN_THROTTLE);
 	_mixing_output.setAllMaxValues(DSHOT_MAX_THROTTLE);
-	_mixing_output.setAllFailsafeValues(UINT16_MAX);
 }
 
 DShot::~DShot()


### PR DESCRIPTION
Fixes a regression from c1e5e666f083f08ddca218aef86a22338c8020cd, where with static mixers the dshot outputs would go to max instead of 0 in a failsafe case.