### PR TITLE
dshot: avoid using pwm failsafe params when dynamic mixing is enabled

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -47,6 +47,11 @@ DShot::DShot() :
 	_mixing_output.setAllDisarmedValues(DSHOT_DISARM_VALUE);
 	_mixing_output.setAllMinValues(DSHOT_MIN_THROTTLE);
 	_mixing_output.setAllMaxValues(DSHOT_MAX_THROTTLE);
+
+	if (_mixing_output.useDynamicMixing()) {
+		// Avoid using the PWM failsafe params
+		_mixing_output.setAllFailsafeValues(UINT16_MAX);
+	}
 }
 
 DShot::~DShot()


### PR DESCRIPTION
I remembered why I added `setAllFailsafeValues` in the first place - to avoid using pwm params.

Follow-up to https://github.com/PX4/PX4-Autopilot/pull/19553.