### PR TITLE
offboard land detection

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -379,23 +379,22 @@ void MulticopterPositionControl::Run()
 				bool want_takeoff = _vehicle_control_mode.flag_armed && _vehicle_land_detected.landed
 						    && hrt_elapsed_time(&_setpoint.timestamp) < 1_s;
 
-				if (want_takeoff && PX4_ISFINITE(_setpoint.z)
-				    && (_setpoint.z < states.position(2))) {
+				_vehicle_constraints.want_takeoff = false;
 
-					_vehicle_constraints.want_takeoff = true;
+				if (want_takeoff && PX4_ISFINITE(_setpoint.z)) {
+					if (_setpoint.z < states.position(2)) {
+						_vehicle_constraints.want_takeoff = true;
+					}
 
-				} else if (want_takeoff && PX4_ISFINITE(_setpoint.vz)
-					   && (_setpoint.vz < 0.f)) {
+				} else if (want_takeoff && PX4_ISFINITE(_setpoint.vz)) {
+					if (_setpoint.vz < 0.f) {
+						_vehicle_constraints.want_takeoff = true;
+					}
 
-					_vehicle_constraints.want_takeoff = true;
-
-				} else if (want_takeoff && PX4_ISFINITE(_setpoint.acceleration[2])
-					   && (_setpoint.acceleration[2] < 0.f)) {
-
-					_vehicle_constraints.want_takeoff = true;
-
-				} else {
-					_vehicle_constraints.want_takeoff = false;
+				} else if (want_takeoff && PX4_ISFINITE(_setpoint.acceleration[2])) {
+					if (_setpoint.acceleration[2] < 0.f) {
+						_vehicle_constraints.want_takeoff = true;
+					}
 				}
 
 				// override with defaults


### PR DESCRIPTION
**Describe problem solved by this pull request**
We use offboard mode to control our quadrotor.
We generate a trajectory in z position with consistent derivatives.
When we land, our z position increase downward, z speed converge to our target (1m/s downward) and our z acceleration converges to 0 when the speed stabilizes.

The issue is that when we hit the ground, land detector detect it but the position control detect that we want to takeoff so thrust increase and it never disarm.

The takeoff detection is due to our z acceleration been about 0 but with a very small oscillation that makes point upward  by moments.

Here is a log with one false detection : https://review.px4.io/plot_app?log=ced2541e-fd20-4fd3-88c6-2f284262bc95

**Describe your solution**
in offboard mode, if we have a valid z position setpoint superior (so more downward) than estimated, do not consider we want to take off. Same thing on z speed.

This solution will change the behavior: in offboard mode, if we have a valid z position setpoint more downward than estimated and a speed setpoint pointing upward, we will no longer consider we want to take off.