### PR TITLE
Add isFinite() function to Vector class

### DIFF
--- a/src/lib/matrix/matrix/Vector.hpp
+++ b/src/lib/matrix/matrix/Vector.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "math.hpp"
+#include <px4_platform_common/defines.h>
 
 namespace matrix
 {
@@ -147,6 +148,18 @@ public:
 		}
 
 		return r;
+	}
+
+	bool isFinite() const
+	{
+		const Vector &a(*this);
+		for (size_t i = 0; i < M; i++) {
+			if(!PX4_ISFINITE(a(i)))
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 };
 

--- a/src/lib/matrix/test/MatrixVectorTest.cpp
+++ b/src/lib/matrix/test/MatrixVectorTest.cpp
@@ -73,4 +73,17 @@ TEST(MatrixVectorTest, Vector)
 	v5(1) = 4;
 	EXPECT_TRUE(v5.longerThan(4.99f));
 	EXPECT_FALSE(v5.longerThan(5.f));
+
+	// isFinite
+	Vector<float, 3> v6;
+	v6(0) = 0.5f;
+	v6(1) = NAN;
+	v6(2) = 0.3f;
+	EXPECT_FALSE(v6.isFinite());
+
+	v6(1) = INFINITY;
+	EXPECT_FALSE(v6.isFinite());
+
+	v6(1) = 0.6f;
+	EXPECT_TRUE(v6.isFinite());
 }

--- a/src/lib/sensor_calibration/Accelerometer.cpp
+++ b/src/lib/sensor_calibration/Accelerometer.cpp
@@ -111,7 +111,7 @@ void Accelerometer::SensorCorrectionsUpdate(bool force)
 bool Accelerometer::set_offset(const Vector3f &offset)
 {
 	if (Vector3f(_offset - offset).longerThan(0.01f)) {
-		if (PX4_ISFINITE(offset(0)) && PX4_ISFINITE(offset(1)) && PX4_ISFINITE(offset(2))) {
+		if (offset.isFinite()) {
 			_offset = offset;
 			_calibration_count++;
 			return true;
@@ -124,9 +124,7 @@ bool Accelerometer::set_offset(const Vector3f &offset)
 bool Accelerometer::set_scale(const Vector3f &scale)
 {
 	if (Vector3f(_scale - scale).longerThan(0.01f)) {
-		if ((scale(0) > 0.f) && (scale(1) > 0.f) && (scale(2) > 0.f) &&
-		    PX4_ISFINITE(scale(0)) && PX4_ISFINITE(scale(1)) && PX4_ISFINITE(scale(2))) {
-
+		if ((scale(0) > 0.f) && (scale(1) > 0.f) && (scale(2) > 0.f) && scale.isFinite()) {
 			_scale = scale;
 			_calibration_count++;
 			return true;

--- a/src/lib/sensor_calibration/Gyroscope.cpp
+++ b/src/lib/sensor_calibration/Gyroscope.cpp
@@ -111,7 +111,7 @@ void Gyroscope::SensorCorrectionsUpdate(bool force)
 bool Gyroscope::set_offset(const Vector3f &offset)
 {
 	if (Vector3f(_offset - offset).longerThan(0.01f)) {
-		if (PX4_ISFINITE(offset(0)) && PX4_ISFINITE(offset(1)) && PX4_ISFINITE(offset(2))) {
+		if (offset.isFinite()) {
 			_offset = offset;
 			_calibration_count++;
 			return true;

--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -71,7 +71,7 @@ void Magnetometer::set_device_id(uint32_t device_id)
 bool Magnetometer::set_offset(const Vector3f &offset)
 {
 	if (Vector3f(_offset - offset).longerThan(0.01f)) {
-		if (PX4_ISFINITE(offset(0)) && PX4_ISFINITE(offset(1)) && PX4_ISFINITE(offset(2))) {
+		if (offset.isFinite()) {
 			_offset = offset;
 			_calibration_count++;
 			return true;

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -558,11 +558,7 @@ int do_accel_calibration_quick(orb_advert_t *mavlink_log_pub)
 
 			calibration::Accelerometer calibration{arp.device_id};
 
-			if (!calibrated || (offset.norm() > CONSTANTS_ONE_G)
-			    || !PX4_ISFINITE(offset(0))
-			    || !PX4_ISFINITE(offset(1))
-			    || !PX4_ISFINITE(offset(2))) {
-
+			if (!calibrated || (offset.norm() > CONSTANTS_ONE_G) || !offset.isFinite()) {
 				PX4_ERR("accel %d quick calibrate failed", accel_index);
 
 			} else {

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -105,12 +105,7 @@ bool FlightTaskAuto::updateInitialize()
 	// require valid reference and valid target
 	ret = ret && _evaluateGlobalReference() && _evaluateTriplets();
 	// require valid position
-	ret = ret && PX4_ISFINITE(_position(0))
-	      && PX4_ISFINITE(_position(1))
-	      && PX4_ISFINITE(_position(2))
-	      && PX4_ISFINITE(_velocity(0))
-	      && PX4_ISFINITE(_velocity(1))
-	      && PX4_ISFINITE(_velocity(2));
+	ret = ret && _position.isFinite() && _velocity.isFinite();
 
 	return ret;
 }
@@ -402,9 +397,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 	const bool prev_next_validity_changed = (_prev_was_valid != _sub_triplet_setpoint.get().previous.valid)
 						|| (_next_was_valid != _sub_triplet_setpoint.get().next.valid);
 
-	if (PX4_ISFINITE(_triplet_target(0))
-	    && PX4_ISFINITE(_triplet_target(1))
-	    && PX4_ISFINITE(_triplet_target(2))
+	if (_triplet_target.isFinite()
 	    && fabsf(_triplet_target(0) - tmp_target(0)) < 0.001f
 	    && fabsf(_triplet_target(1) - tmp_target(1)) < 0.001f
 	    && fabsf(_triplet_target(2) - tmp_target(2)) < 0.001f

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -169,12 +169,7 @@ bool FlightTaskOrbit::activate(const vehicle_local_position_setpoint_s &last_set
 	_slew_rate_yaw.setSlewRate(math::radians(_param_mpc_yawrauto_max.get()));
 
 	// need a valid position and velocity
-	ret = ret && PX4_ISFINITE(_position(0))
-	      && PX4_ISFINITE(_position(1))
-	      && PX4_ISFINITE(_position(2))
-	      && PX4_ISFINITE(_velocity(0))
-	      && PX4_ISFINITE(_velocity(1))
-	      && PX4_ISFINITE(_velocity(2));
+	ret = ret && _position.isFinite() && _velocity.isFinite();
 
 	Vector3f vel_prev{last_setpoint.vx, last_setpoint.vy, last_setpoint.vz};
 	Vector3f pos_prev{last_setpoint.x, last_setpoint.y, last_setpoint.z};

--- a/src/modules/mag_bias_estimator/MagBiasEstimator.cpp
+++ b/src/modules/mag_bias_estimator/MagBiasEstimator.cpp
@@ -200,7 +200,7 @@ void MagBiasEstimator::Run()
 					const Vector3f &bias = _bias_estimator[mag_index].getBias();
 					const Vector3f bias_rate = (bias - bias_prev) / dt;
 
-					if (!PX4_ISFINITE(bias(0)) || !PX4_ISFINITE(bias(1)) || !PX4_ISFINITE(bias(2)) || bias.longerThan(5.f)) {
+					if (!bias.isFinite() || bias.longerThan(5.f)) {
 						_reset_field_estimator[mag_index] = true;
 						_valid[mag_index] = false;
 						_time_valid[mag_index] = 0;

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -115,8 +115,8 @@ bool PositionControl::update(const float dt)
 	}
 
 	// There has to be a valid output accleration and thrust setpoint otherwise something went wrong
-	valid = valid && PX4_ISFINITE(_acc_sp(0)) && PX4_ISFINITE(_acc_sp(1)) && PX4_ISFINITE(_acc_sp(2));
-	valid = valid && PX4_ISFINITE(_thr_sp(0)) && PX4_ISFINITE(_thr_sp(1)) && PX4_ISFINITE(_thr_sp(2));
+	valid = valid && _acc_sp.isFinite();
+	valid = valid && _thr_sp.isFinite();
 
 	return valid;
 }
@@ -212,9 +212,7 @@ bool PositionControl::_inputValid()
 	bool valid = true;
 
 	// Every axis x, y, z needs to have some setpoint
-	for (int i = 0; i <= 2; i++) {
-		valid = valid && (PX4_ISFINITE(_pos_sp(i)) || PX4_ISFINITE(_vel_sp(i)) || PX4_ISFINITE(_acc_sp(i)));
-	}
+	valid = valid && _pos_sp.isFinite() && _vel_sp.isFinite() && _acc_sp.isFinite();
 
 	// x and y input setpoints always have to come in pairs
 	valid = valid && (PX4_ISFINITE(_pos_sp(0)) == PX4_ISFINITE(_pos_sp(1)));

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -480,10 +480,7 @@ Vector3f VehicleAngularVelocity::GetResetAngularVelocity() const
 		//  start with last valid vehicle body frame angular velocity and compute equivalent raw data (for current sensor selection)
 		Vector3f angular_velocity_uncalibrated{_calibration.Uncorrect(_angular_velocity + _bias)};
 
-		if (PX4_ISFINITE(angular_velocity_uncalibrated(0))
-		    && PX4_ISFINITE(angular_velocity_uncalibrated(1))
-		    && PX4_ISFINITE(angular_velocity_uncalibrated(2))) {
-
+		if (angular_velocity_uncalibrated.isFinite()) {
 			return angular_velocity_uncalibrated;
 		}
 	}
@@ -497,11 +494,7 @@ Vector3f VehicleAngularVelocity::GetResetAngularAcceleration() const
 		// angular acceleration filtering is performed on unscaled angular velocity data
 		//  start with last valid vehicle body frame angular acceleration and compute equivalent raw data (for current sensor selection)
 		Vector3f angular_acceleration{_calibration.rotation().I() *_angular_acceleration};
-
-		if (PX4_ISFINITE(angular_acceleration(0))
-		    && PX4_ISFINITE(angular_acceleration(1))
-		    && PX4_ISFINITE(angular_acceleration(2))) {
-
+		if (angular_acceleration.isFinite()) {
 			return angular_acceleration;
 		}
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**

Until now, to check if a Vector has finite values, codes used the PX4_ISFINITE function for every single element in the vector. This is quite chunky and unnecessary, if we have a singular function that can do the same job.

**Describe your solution**

This PR adds 'isFinite' function which transforms **this**
```
ret = ret && PX4_ISFINITE(_position(0))
	      && PX4_ISFINITE(_position(1))
	      && PX4_ISFINITE(_position(2))
	      && PX4_ISFINITE(_velocity(0))
	      && PX4_ISFINITE(_velocity(1))
	      && PX4_ISFINITE(_velocity(2));
```
**into this**

`ret = ret && _position.isFinite() && _velocity.isFinite();`

**Describe possible alternatives**
Adding this into Matrix class stage will allow even .xy() (Slice objects) to be able to use this function as well. There are couple of cases where this can be useful in the code like:
https://github.com/PX4/PX4-Autopilot/blob/4a14a8bc7fb6f47c8e7be72d3de502d35a61a40e/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp#L85

**Test data / coverage**
Unit test was added to check the functionality.

**Additional context**
Need for this function was discovered during the development of the [improved Follow-Me](https://github.com/PX4/PX4-Autopilot/pull/19260), for example for parts like this:
https://github.com/PX4/PX4-Autopilot/blob/80dfce1e394c15e74bf64d966cf16c4f915a2a94/src/modules/flight_mode_manager/tasks/AutoFollowTarget/FlightTaskAutoFollowTarget.cpp#L128-L130

**Questions**
* Should this be in the Matrix class to be more generic?
* Does it make sense to include `#include <px4_platform_common/defines.h>` in the matrix library?