### PR TITLE
Increase Battery level emergency shutdown time delay

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4018,8 +4018,8 @@ void Commander::battery_status_check()
 		if (_battery_warning == battery_status_s::BATTERY_WARNING_EMERGENCY) {
 #if defined(BOARD_HAS_POWER_CONTROL)
 
-			if (shutdown_if_allowed() && (px4_shutdown_request(400_ms) == 0)) {
-				mavlink_log_critical(&_mavlink_log_pub, "Dangerously low battery! Shutting system down\t");
+			if (shutdown_if_allowed() && (px4_shutdown_request(60_s) == 0)) {
+				mavlink_log_critical(&_mavlink_log_pub, "Dangerously low battery! Shutting system down in 60 seconds\t");
 				events::send(events::ID("commander_low_bat_shutdown"), {events::Log::Emergency, events::LogInternal::Warning},
 					     "Dangerously low battery! Shutting system down");
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
The Battery cell count parameter of the Mantis has been changed from 3 to 4 (which triggers the Battery emergency warning), and was rebooted. **The vehicle would power up (start-up tune plays for 300 ms), and then shut down immediately.**

This leaves the user puzzled as to what's happening (I thought it was bricked), and doesn't give enough time to assess the situation and modify the necessary changes (e.g. changing the battery cell count parameter for my example).

**Describe your solution**
I**ncrease Battery level emergency shutdown time delay from 300 ms to 60 seconds**, to give enough time for the user to configure the vehicle in the mean time. 60 second window is intended to be a reasonable time that will allow the user to figure out what's going on (via checking the battery level on QGC, etc) but also not deep discharge the battery to a dangerous level.

**Describe possible alternatives**


**Test data / coverage**
Tested on ATL Mantis Edu (after flashing this version, the bricked behavior was gone and was able to change the parameter).

**Additional context**
* It seems like the Battery warning beeper is not working for now (which would be very helpful for the user to recognize that the battery is the problem!), any reason why this could be happening?
* Currently it sends the event & mavlink message describing that it's shutting down due to battery level being low, but is there a way to send this during the 60 second period? Would that be necessary?