### PR TITLE
l1 control: Removed approach angle limitation

### DIFF
--- a/src/lib/l1/ECL_L1_Pos_Controller.cpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.cpp
@@ -189,8 +189,8 @@ ECL_L1_Pos_Controller::navigate_waypoints(const Vector2f &vector_A, const Vector
 		float xtrackErr = vector_A_to_airplane % vector_AB;
 		float sine_eta1 = xtrackErr / math::max(_L1_distance, 0.1f);
 
-		/* limit output to 45 degrees */
-		sine_eta1 = math::constrain(sine_eta1, -0.7071f, 0.7071f); //sin(pi/4) = 0.7071
+		/* limit output to feasible values */
+		sine_eta1 = math::constrain(sine_eta1, -1.0f, 1.0f);
 		float eta1 = asinf(sine_eta1);
 		eta = eta1 + eta2;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
The l1 control library has an approach angle limitation when navigating to a line defined by two points. This can lead to undesired behavior in the case that the vehicle is further away than the l1 distance from the line while being close to the end point. In this case, the vehicle will fly past the endpoint without going close to it.

**Describe your solution**
Removed the 45° approach angle restriction. What was the reason for the limitation in the first place?

**Test data / coverage**
Tested with SITL simulation
