### PR TITLE
Wind estimator state covariance prediction fix

### DIFF
--- a/src/lib/wind_estimator/WindEstimator.cpp
+++ b/src/lib/wind_estimator/WindEstimator.cpp
@@ -113,27 +113,17 @@ WindEstimator::update(uint64_t time_now)
 	}
 
 	float dt = (float)(time_now - _time_last_update) * 1e-6f;
+	float dt2 = dt * dt;
 	_time_last_update = time_now;
 
 	float q_w = _wind_p_var;
 	float q_k_tas = _tas_scale_p_var;
 
-	float SPP0 = dt * dt;
-	float SPP1 = SPP0 * q_w;
-	float SPP2 = SPP1 + _P(0, 1);
-
-	matrix::Matrix3f P_next;
-
-	P_next(0, 0) = SPP1 + _P(0, 0);
-	P_next(0, 1) = SPP2;
-	P_next(0, 2) = _P(0, 2);
-	P_next(1, 0) = SPP2;
-	P_next(1, 1) = SPP1 + _P(1, 1);
-	P_next(1, 2) = _P(1, 2);
-	P_next(2, 0) = _P(0, 2);
-	P_next(2, 1) = _P(1, 2);
-	P_next(2, 2) = SPP0 * q_k_tas + _P(2, 2);
-	_P = P_next;
+	matrix::Matrix3f Qk;
+	Qk(0, 0) = q_w * dt2;
+	Qk(1, 1) = Qk(0, 0);
+	Qk(2, 2) = q_k_tas * dt2;
+	_P += Qk;
 }
 
 void

--- a/src/lib/wind_estimator/python/wind_est_derivation.py
+++ b/src/lib/wind_estimator/python/wind_est_derivation.py
@@ -100,10 +100,8 @@ dt = Symbol("dt", real=True)
 # process model. We only need to provide formula for covariance prediction
 
 # create process noise matrix for covariance prediction
-state_new = state + Matrix([q_w, q_w, q_k_tas]) * dt
-Q = diag(q_w, q_k_tas)
-L = state_new.jacobian([q_w, q_k_tas])
-Q = L * Q * Transpose(L)
+state_new = state
+Q = diag(q_w, q_w, q_k_tas) * dt**2
 
 # define symbolic covariance matrix
 p00 = Symbol('_P(0,0)', real=True)


### PR DESCRIPTION
I was surprised by the complexity of the process covariance prediction given that the model is composed by 3 interdependent stationary processes driven by uncorrelated noise. 
The covariance prediction should then be trivial: `P[k+1] = P[k] + Qk` where `Qk` is the discrete-time process noise -diagonal- matrix `diag((wind_noise * dt)^2, (wind_noise * dt)^2, (scale_noise * dt)^2)`

**Test data / coverage**
SITL tested with and without wind with a wind input scaled down by 0.9.
No wind (`make px4_sitl gazebo_plane`):
Master:
![DeepinScreenshot_select-area_20220504143815](https://user-images.githubusercontent.com/14822839/166694239-f1c20736-8ff6-4c2e-9284-913c0e61c6b7.png)
This PR:
![DeepinScreenshot_select-area_20220504143532](https://user-images.githubusercontent.com/14822839/166694423-6c858834-f43b-415f-b416-ee510ba27213.png)

Wind (`make px4_sitl gazebo_plane__windy`):
Master:
![DeepinScreenshot_select-area_20220504153149](https://user-images.githubusercontent.com/14822839/166694378-b2e76b3a-303f-412a-97f6-180be151c9c1.png)
This PR:
![DeepinScreenshot_select-area_20220504153210](https://user-images.githubusercontent.com/14822839/166694452-26353372-d082-4eb9-a4fb-521b1e19974e.png)