### PR TITLE
pwm.cpp: remove the test example

### DIFF
--- a/src/systemcmds/pwm/pwm.cpp
+++ b/src/systemcmds/pwm/pwm.cpp
@@ -105,7 +105,7 @@ Set the PWM rate for all channels to 400 Hz:
 $ pwm rate -a -r 400
 
 Arm and set the outputs of channels 1 and 3 to a PWM value to 1200 us:
-$ pwm arm -c 13 -p 1200
+$ pwm min -c 13 -p 1200
 
 )DESCR_STR");
 

--- a/src/systemcmds/pwm/pwm.cpp
+++ b/src/systemcmds/pwm/pwm.cpp
@@ -100,12 +100,12 @@ The parameters `-p` and `-r` can be set to a parameter instead of specifying an 
 Note that in OneShot mode, the PWM range [1000, 2000] is automatically mapped to [125, 250].
 
 ### Examples
+
 Set the PWM rate for all channels to 400 Hz:
 $ pwm rate -a -r 400
 
-Test the outputs of eg. channels 1 and 3, and set the PWM value to 1200 us:
-$ pwm arm
-$ pwm test -c 13 -p 1200
+Arm and set the outputs of channels 1 and 3 to a PWM value to 1200 us:
+$ pwm arm -c 13 -p 1200
 
 )DESCR_STR");
 


### PR DESCRIPTION
`test` was removed as a command in https://github.com/PX4/PX4-Autopilot/pull/18944 (see https://github.com/PX4/PX4-Autopilot/pull/18944/files#diff-90857310600e7e305702c6b43a375b216ef7ead634a4c0b6f690a8289e6b746cL135) but is still used as a usage example in the docs.

This removes the command.

PLEASE check that the command I have replaced it with `$ pwm arm -c 13 -p 1200` is valid!