### PR TITLE
fw pos ctrl: fix state switching logic for takeoff and landing

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1512,7 +1512,9 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const Vec
 		if (_param_fw_use_npfg.get()) {
 			_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 			_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-			_npfg.navigateWaypoints(prev_wp_local, curr_wp_local, curr_pos_local, ground_speed, _wind_vel);
+			// NOTE: current waypoint is passed twice to trigger the "point following" logic -- TODO: create
+			// point following navigation interface instead of this hack.
+			_npfg.navigateWaypoints(curr_wp_local, curr_wp_local, curr_pos_local, ground_speed, _wind_vel);
 			_att_sp.roll_body = _runway_takeoff.getRoll(_npfg.getRollSetpoint());
 			target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2122,6 +2122,14 @@ FixedwingPositionControl::control_manual_position(const hrt_abstime &now, const 
 {
 	const float dt = update_position_control_mode_timestep(now);
 
+	// update lateral guidance timesteps for slewrates
+	if (_param_fw_use_npfg.get()) {
+		_npfg.setDt(dt);
+
+	} else {
+		_l1_control.set_dt(dt);
+	}
+
 	// if we assume that user is taking off then help by demanding altitude setpoint well above ground
 	// and set limit to pitch angle to prevent steering into ground
 	// this will only affect planes and not VTOL

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -350,6 +350,30 @@ private:
 	 * @param dt Time step
 	 */
 	void		update_desired_altitude(float dt);
+
+	/**
+	 * @brief Updates timing information for landed and in-air states.
+	 *
+	 * @param now Current system time [us]
+	 */
+	void update_in_air_states(const hrt_abstime now);
+
+	/**
+	 * @brief Updates the time since the last position control call.
+	 *
+	 * @param now Current system time [us]
+	 * @return Time since last position control call [s]
+	 */
+	float update_position_control_mode_timestep(const hrt_abstime now);
+
+	/**
+	 * @brief Moves the current position setpoint to a value far ahead of the current vehicle yaw when in  a VTOL
+	 * transition.
+	 *
+	 * @param[in,out] current_sp current position setpoint
+	 */
+	void move_position_setpoint_for_vtol_transition(position_setpoint_s &current_sp);
+
 	uint8_t		handle_setpoint_type(const uint8_t setpoint_type, const position_setpoint_s &pos_sp_curr);
 	void		control_auto(const hrt_abstime &now, const Vector2d &curr_pos, const Vector2f &ground_speed,
 				     const position_setpoint_s &pos_sp_prev,


### PR DESCRIPTION
**Describe problem solved by this pull request**
Takeoff and landing modes were separated from the `control_auto()` umbrella in #19495 in an effort to start untangling the fixed-wing position control module before some more significant refactoring to come. However, some of the internal state resets  and position setpoint handling logic was not exactly translated in a way that reproduced the previous behavior. Sorry - I missed them as well in the PR review.

Example: takeoff mode would be overridden from this logic:
https://github.com/PX4/PX4-Autopilot/blob/14a2fdfe551435638e22864437e75030abbf28eb/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L760-L766

And some TECS states and other attitude integral resets were not initialized in takeoff and landing modes as they were before. 

**Describe your solution**
This PR is a hotfix to revive the same behavior the module had prior to #19495, while keeping the takeoff and landing modes separated. There are more fundamental issues that need work in this module.. e.g. `in_takeoff_situation()` is a quite egregious one IMHO. But these can be saved for a subsequent discussion and PR. 

**Test data / coverage**
Tested that the basic functionality operates as it did before. E.g. making sure the takeoff mode is not exited until navigator sees the mission item reached, loiter down to waypoints work (the position setpoint switching), flying back to takeoff waypoints later in a mission does not re-enter takeoff logic, etc.

https://user-images.githubusercontent.com/8026163/166902577-a16f9fea-6010-46be-a9c2-f1b3434d9a48.mp4

Note the takeoff behavior is actually kind of terrible (no loiter up to takeoff point when below the takeoff point altitude) - but this has been the behavior for some time now. I'm working on a larger refactor of takeoff and landing for fixed-wing which will simplify these modes and also allow for a more general discussion on what takeoff actually *should* look like. But for now.. this PR is just to make sure the next release has the behavior that's been expected.

@sfuhrer would be great if you could check that I did not mess up any VTOL functionality.
@dagar if the current release branch has #19495 in it .. we would probably need to include this PR as well to make sure the logic isnt broken on the release.
