### PR TITLE
Add get*Expo() functions to the Sticks library

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -67,6 +67,10 @@ public:
 	float getRoll() const { return _positions(1); }
 	float getThrottleZeroCentered() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
 	float getYaw() const { return _positions(3); }
+	float getPitchExpo() const { return _positions_expo(0); }
+	float getRollExpo() const { return _positions_expo(1); }
+	float getThrottleZeroCenteredExpo() const { return -_positions_expo(2); } // Convert Z-axis(down) command to Up-axis frame
+	float getYawExpo() const { return _positions_expo(3); }
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle


### PR DESCRIPTION
**Describe problem solved by this pull request**
Adds a verbose function to return Expo() values of the RC stick commands, to intuitively get Roll, Pitch Yaw and Throttle stick inputs.

**Describe your solution**
Add get*Expo() functions

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Additional context**
Discussion happened in the #19260, where I had put arbitrary dead-zone threshold to the User RC adjustment for the Follow Angle, Height and Distance to make sure slight movements on the stick wouldn't affect the follow target behaviors (Since it's easy to move the stick right while moving it up, etc. which would bring undesirable effect of changing two parameters at once, when user only wants to change one)

@potaito [commented](https://github.com/PX4/PX4-Autopilot/pull/19260/files#r860689824) that using an exponential value would solve the problem of parameter adjustments being too sensitive.