### PR TITLE
Velocity control, baro noise deafults suggestions

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -372,7 +372,7 @@ PARAM_DEFINE_FLOAT(EKF2_NOAID_NOISE, 10.0f);
  * @unit m
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(EKF2_BARO_NOISE, 3.5f);
+PARAM_DEFINE_FLOAT(EKF2_BARO_NOISE, 6.f);
 
 /**
  * Measurement noise for magnetic heading fusion.

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -284,7 +284,7 @@ PARAM_DEFINE_FLOAT(EKF2_ACC_NOISE, 3.5e-1f);
  * @unit rad/s^2
  * @decimal 6
  */
-PARAM_DEFINE_FLOAT(EKF2_GYR_B_NOISE, 1.0e-3f);
+PARAM_DEFINE_FLOAT(EKF2_GYR_B_NOISE, 1e-3f);
 
 /**
  * Process noise for IMU accelerometer bias prediction.
@@ -295,7 +295,7 @@ PARAM_DEFINE_FLOAT(EKF2_GYR_B_NOISE, 1.0e-3f);
  * @unit m/s^3
  * @decimal 6
  */
-PARAM_DEFINE_FLOAT(EKF2_ACC_B_NOISE, 3.0e-3f);
+PARAM_DEFINE_FLOAT(EKF2_ACC_B_NOISE, 3e-3f);
 
 /**
  * Process noise for body magnetic field prediction.
@@ -306,7 +306,7 @@ PARAM_DEFINE_FLOAT(EKF2_ACC_B_NOISE, 3.0e-3f);
  * @unit gauss/s
  * @decimal 6
  */
-PARAM_DEFINE_FLOAT(EKF2_MAG_B_NOISE, 1.0e-4f);
+PARAM_DEFINE_FLOAT(EKF2_MAG_B_NOISE, 1e-4f);
 
 /**
  * Process noise for earth magnetic field prediction.
@@ -317,7 +317,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_B_NOISE, 1.0e-4f);
  * @unit gauss/s
  * @decimal 6
  */
-PARAM_DEFINE_FLOAT(EKF2_MAG_E_NOISE, 1.0e-3f);
+PARAM_DEFINE_FLOAT(EKF2_MAG_E_NOISE, 1e-3f);
 
 /**
  * Process noise for wind velocity prediction.
@@ -328,7 +328,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_E_NOISE, 1.0e-3f);
  * @unit m/s^2
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(EKF2_WIND_NOISE, 1.0e-1f);
+PARAM_DEFINE_FLOAT(EKF2_WIND_NOISE, 1e-1f);
 
 /**
  * Measurement noise for gps horizontal velocity.
@@ -394,7 +394,7 @@ PARAM_DEFINE_FLOAT(EKF2_HEAD_NOISE, 0.3f);
  * @unit gauss
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(EKF2_MAG_NOISE, 5.0e-2f);
+PARAM_DEFINE_FLOAT(EKF2_MAG_NOISE, 5e-2f);
 
 /**
  * Measurement noise for airspeed fusion.

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -304,7 +304,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I_ACC, 0.4f);
  * @decimal 3
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_VEL_D_ACC, 0.2f);
+PARAM_DEFINE_FLOAT(MPC_XY_VEL_D_ACC, 0.f);
 
 /**
  * Default horizontal velocity in mission


### PR DESCRIPTION
**Describe problem solved by this pull request**
During all bring-ups I was part of we sooner or later we:
- disabled the derivative term of the velocity controller because it didn't help significantly enough in real-world flying with smooth trajectories but was causing visible nervous-looking corrections during hover.
- increased the barometer noise because it dragged the altitude down way too much during fast forward flight.

**Describe your solution**
Assuming this does not only apply to bring-ups I'm part of I suggest making this configuration the default.

**Test data / coverage**
In use on all products I've recently helped to bring up and it always resulted in improved hover and fast-forward flight.
Note: Those were vehicles that are not particularly small but I don't see how it would be completely different on smaller setups.