### PR TITLE
Commander: ensure diconnected battery is cleared from bit field

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3868,11 +3868,16 @@ void Commander::battery_status_check()
 			}
 		}
 
-		_last_battery_mode[index] = battery.mode;
-
 		if (battery.connected) {
 			_last_connected_batteries |= 1 << index;
 
+		} else {
+			_last_connected_batteries &= ~(1 << index);
+		}
+
+		_last_battery_mode[index] = battery.mode;
+
+		if (battery.connected) {
 			if (battery.warning > worst_warning) {
 				worst_warning = battery.warning;
 			}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Upon battery disconnect, the error message is spammed instead of only being sent once like it was intended.
![Screenshot from 2022-05-05 10-14-37](https://user-images.githubusercontent.com/4668506/166959992-e75d2ca4-a786-403b-8d13-b744cce95ad3.png)
Reported by @dagar over Slack.
FYI @cmic0 

**Describe your solution**
Make sure the corresponding bit for the battery in the bit field `_last_connected_batteries` is updated when the battery gets disconnected and not just when it's connected.

Bug must have been introduced here: https://github.com/PX4/PX4-Autopilot/pull/18919/files#diff-e4b611e75eba3844661619867ee06befbcf230aced354a14f167f7d0ebbca8e0R3783

**Describe possible alternatives**
I could do a bitfield class that does this such that set/reset don't have to be repeated everywhere.

**Test data / coverage**
Untested, issue was found in code inspection after the report. Please review.