### PR TITLE
commander: fix incorrect return in set_link_loss_nav_state()

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -755,12 +755,13 @@ void set_link_loss_nav_state(vehicle_status_s &status, actuator_armed_s &armed,
 		} else {
 			if (status_flags.local_position_valid) {
 				status.nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
+				return;
 
 			} else if (status_flags.local_altitude_valid) {
 				status.nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+				return;
 			}
 
-			return;
 		}
 
 	// FALLTHROUGH


### PR DESCRIPTION
If both local position and altitude were not valid, then both RC loss and
datalink loss would not trigger any failsafe at all, independently from
the configured action.