### PR TITLE
ROMFS: SITL Plane: reduce FW_SPOILERS_LND to 0.4 to leave ailerons enough control authority

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
@@ -25,7 +25,7 @@ param set-default FW_P_LIM_MIN -15
 param set-default FW_RR_FF 0.1
 param set-default FW_RR_P 0.3
 
-param set-default FW_SPOILERS_LND 0.8
+param set-default FW_SPOILERS_LND 0.4
 
 param set-default FW_THR_MAX 0.6
 param set-default FW_THR_MIN 0.05


### PR DESCRIPTION
Currently the ailerons are deflected 80% up during landing to simulate extra breaking. This seems to be enough, as with that high setting the roll tracking gets so worse that it effects lateral guidance. 

Came in as part of https://github.com/PX4/PX4-Autopilot/pull/19329. 

I think it is still good to have in the SITL Plane the ailerons deflect a bit during landing, just to have it as an example of what's possible. 
Propose setting them to 40% deflection.