### PR TITLE
FW Position control: switch from L1 to NPFG guidance by default

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -44,8 +44,6 @@ param set-default MIS_TAKEOFF_ALT 30
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
-param set-default FW_USE_NPFG 1
-
 param set-default RWTO_TKOFF 1
 
 set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -93,7 +93,7 @@ PARAM_DEFINE_FLOAT(FW_L1_R_SLEW_MAX, 90.0f);
  * @boolean
  * @group FW NPFG Control
  */
-PARAM_DEFINE_INT32(FW_USE_NPFG, 0);
+PARAM_DEFINE_INT32(FW_USE_NPFG, 1);
 
 /**
  * NPFG period


### PR DESCRIPTION
Now with the next release branched off I think it would be a good moment to start transitioning from L1 to the [NPFG fixed-wing guidance. ](https://github.com/PX4/PX4-Autopilot/pull/18810). 
It will give us more robustness in wind, deterministic flight paths and cleaner interfaces.
As a first step I would propose to make it default but keep the L1 option, and get more testing feedback in prior to removing the legacy L1 controller. 