### PR TITLE
Control Allocation User Experience Improvement

### DIFF
--- a/src/drivers/pwm_out/module.yaml
+++ b/src/drivers/pwm_out/module.yaml
@@ -25,9 +25,9 @@ actuator_output:
             -3: DShot600
             -2: DShot1200
             -1: OneShot
-            50: PWM50
-            100: PWM100
-            200: PWM200
-            400: PWM400
+            50: PWM 50 Hz
+            100: PWM 100 Hz
+            200: PWM 200 Hz
+            400: PWM 400 Hz
         reboot_required: true
 

--- a/src/drivers/px4io/module.yaml
+++ b/src/drivers/px4io/module.yaml
@@ -22,8 +22,8 @@ actuator_output:
         default: 400
         values:
             -1: OneShot
-            50: PWM50
-            100: PWM100
-            200: PWM200
-            400: PWM400
+            50: PWM 50 Hz
+            100: PWM 100 Hz
+            200: PWM 200 Hz
+            400: PWM 400 Hz
         reboot_required: true


### PR DESCRIPTION
## Motivation
This is a Autopilot side PR for the ongoing control allocation user experience improvement (#19444).

## Changes
1. Clarify the PWM 50, 100, 200, ... setting values by adding 'Hz' in the end to avoid misunderstanding
![image](https://user-images.githubusercontent.com/23277211/167156154-65696b13-201c-412e-8077-23e7216137a9.png)
2. 
