### PR TITLE
use termios2 in linux to fix the customer buadrate issue

### DIFF
--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -661,7 +661,6 @@ void RCInput::Run()
 				if (newBytes > 0) {
 					rc_updated = crsf_parse(cycle_timestamp, &_rcs_buf[0], newBytes, &_raw_rc_values[0], &_raw_rc_count,
 								input_rc_s::RC_INPUT_MAX_CHANNELS);
-
 					if (rc_updated) {
 						// we have a new CRSF frame. Publish it.
 						_rc_in.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_CRSF;


### PR DESCRIPTION
Signed-off-by: ncer <huangzzk@bupt.edu.cn>

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**

To this issue:
https://github.com/PX4/PX4-Autopilot/issues/19613

changed CRSF/SBUS/DSM which is using `cfsetspeed ` directly in linux.


**Test data / coverage**
![20220508152408](https://user-images.githubusercontent.com/9284611/167286263-0c8e27cf-60c4-408b-830f-e9d7ad52fc01.png)

I only have the crsf devices, so I tested CRSF module. If some one could test sbus/dsm in linux, it would be very nice.

**Additional context**
Add any other related context or media.
