### PR TITLE
Remove contradicting geofence parameter description

### DIFF
--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -48,9 +48,6 @@
  *
  * Note: Setting this value to 4 enables flight termination,
  * which will kill the vehicle on violation of the fence.
- * Due to the inherent danger of this, this function is
- * disabled using a software circuit breaker, which needs
- * to be reset to 0 to really shut down the system.
  *
  * @min 0
  * @max 5


### PR DESCRIPTION
**Describe problem solved by this pull request**
The flight termination action on geofence violation is described as only trigger, when the corresponding circuit breaker is not disabled. However, the description of the circuit breaker states, that the geofence action is not depedning on this circuit breaker. The implementation follows the description of the circuit breaker.

**Describe your solution**
The GF_ACTION description is adapted. From my perspective, it is fine to have the geofence flight termination not dependent on the circuit breaker, as it has to be explicitly selected.

**Describe possible alternatives**
Make geofence flight termination dependent on the circuit breaker, and adapt the description on the circuit breaker.

**Test data / coverage**
No code was changes, only comment.
