### PR TITLE
Control Allocation: Tiltrotor improvements

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -9,7 +9,7 @@
 
 param set-default MAV_TYPE 21
 
-# param set-default SYS_CTRL_ALLOC 1
+param set-default SYS_CTRL_ALLOC 1
 param set-default CA_AIRFRAME 3
 
 param set-default CA_ROTOR_COUNT 4
@@ -27,9 +27,7 @@ param set-default CA_ROTOR3_PY 0.1875
 param set-default CA_ROTOR3_KM -0.05
 
 param set-default CA_ROTOR0_TILT 1
-param set-default CA_ROTOR1_TILT 2
 param set-default CA_ROTOR2_TILT 3
-param set-default CA_ROTOR3_TILT 4
 param set-default CA_SV_CS0_TRQ_R -0.5
 param set-default CA_SV_CS0_TYPE 1
 param set-default CA_SV_CS1_TRQ_R 0.5

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
@@ -51,7 +51,7 @@ ActuatorEffectivenessMCTilt::getEffectivenessMatrix(Configuration &configuration
 	}
 
 	// MC motors
-	_mc_rotors.enablePropellerTorque(!_tilts.hasYawControl());
+	_mc_rotors.enableYawByDifferentialThrust(!_tilts.hasYawControl());
 	const bool rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
 	// Tilts

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
@@ -213,6 +213,11 @@ ActuatorEffectivenessRotors::computeEffectivenessMatrix(const Geometry &geometry
 			effectiveness(j + 3, i + actuator_start_index) = thrust(j);
 		}
 
+		if (geometry.yaw_by_differential_thrust_disabled) {
+			// set yaw effectiveness to 0 if yaw is controlled by other means (e.g. tilts)
+			effectiveness(2, i + actuator_start_index) = 0.f;
+		}
+
 		if (geometry.three_dimensional_thrust_disabled) {
 			// Special case tiltrotor: instead of passing a 3D thrust vector (that would mostly have a x-component in FW, and z in MC),
 			// pass the vector magnitude as z-component, plus the collective tilt. Passing 3D thrust plus tilt is not feasible as they

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.cpp
@@ -212,6 +212,17 @@ ActuatorEffectivenessRotors::computeEffectivenessMatrix(const Geometry &geometry
 			effectiveness(j, i + actuator_start_index) = moment(j);
 			effectiveness(j + 3, i + actuator_start_index) = thrust(j);
 		}
+
+		if (geometry.three_dimensional_thrust_disabled) {
+			// Special case tiltrotor: instead of passing a 3D thrust vector (that would mostly have a x-component in FW, and z in MC),
+			// pass the vector magnitude as z-component, plus the collective tilt. Passing 3D thrust plus tilt is not feasible as they
+			// can't be allocated independently, and with the current controller it's not possible to have collective tilt calculated
+			// by the allocator directly.
+
+			effectiveness(0 + 3, i + actuator_start_index) = 0.f;
+			effectiveness(1 + 3, i + actuator_start_index) = 0.f;
+			effectiveness(2 + 3, i + actuator_start_index) = ct;
+		}
 	}
 
 	return num_actuators;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -74,6 +74,7 @@ public:
 		RotorGeometry rotors[NUM_ROTORS_MAX];
 		int num_rotors{0};
 		bool propeller_torque_disabled{false};
+		bool yaw_by_differential_thrust_disabled{false};
 		bool propeller_torque_disabled_non_upwards{false}; ///< keeps propeller torque enabled for upward facing motors
 		bool three_dimensional_thrust_disabled{false}; ///< for handling of tiltrotor VTOL, as they pass in 1D thrust and collective tilt
 	};
@@ -118,6 +119,8 @@ public:
 	static matrix::Vector3f tiltedAxis(float tilt_angle, float tilt_direction);
 
 	void enablePropellerTorque(bool enable) { _geometry.propeller_torque_disabled = !enable; }
+
+	void enableYawByDifferentialThrust(bool enable) { _geometry.yaw_by_differential_thrust_disabled = !enable; }
 
 	void enablePropellerTorqueNonUpwards(bool enable) { _geometry.propeller_torque_disabled_non_upwards = !enable; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -75,6 +75,7 @@ public:
 		int num_rotors{0};
 		bool propeller_torque_disabled{false};
 		bool propeller_torque_disabled_non_upwards{false}; ///< keeps propeller torque enabled for upward facing motors
+		bool three_dimensional_thrust_disabled{false}; ///< for handling of tiltrotor VTOL, as they pass in 1D thrust and collective tilt
 	};
 
 	ActuatorEffectivenessRotors(ModuleParams *parent, AxisConfiguration axis_config = AxisConfiguration::Configurable,
@@ -119,6 +120,8 @@ public:
 	void enablePropellerTorque(bool enable) { _geometry.propeller_torque_disabled = !enable; }
 
 	void enablePropellerTorqueNonUpwards(bool enable) { _geometry.propeller_torque_disabled_non_upwards = !enable; }
+
+	void enableThreeDimensionalThrust(bool enable) { _geometry.three_dimensional_thrust_disabled = !enable; }
 
 	uint32_t getUpwardsMotors() const;
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.cpp
@@ -56,7 +56,8 @@ ActuatorEffectivenessTailsitterVTOL::getEffectivenessMatrix(Configuration &confi
 
 	// MC motors
 	configuration.selected_matrix = 0;
-	_mc_rotors.enablePropellerTorque(_mc_rotors.geometry().num_rotors > 3); // enable MC yaw control if more than 3 rotors
+	// enable MC yaw control if more than 3 rotors
+	_mc_rotors.enableYawByDifferentialThrust(_mc_rotors.geometry().num_rotors > 3);
 	const bool mc_rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
 	// Control Surfaces

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -60,7 +60,7 @@ ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(Configuration &config
 
 	// MC motors
 	configuration.selected_matrix = 0;
-	_mc_rotors.enablePropellerTorque(!_tilts.hasYawControl());
+	_mc_rotors.enableYawByDifferentialThrust(!_tilts.hasYawControl());
 	_mc_rotors.enableThreeDimensionalThrust(false);
 
 	// Update matrix with tilts in vertical position when update is triggered by a manual

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -61,6 +61,7 @@ ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(Configuration &config
 	// MC motors
 	configuration.selected_matrix = 0;
 	_mc_rotors.enablePropellerTorque(!_tilts.hasYawControl());
+	_mc_rotors.enableThreeDimensionalThrust(false);
 
 	// Update matrix with tilts in vertical position when update is triggered by a manual
 	// configuration (parameter) change. This is to make sure the normalization
@@ -127,6 +128,18 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 			for (int i = 0; i < _tilts.count(); ++i) {
 				if (_tilts.config(i).tilt_direction == ActuatorEffectivenessTilts::TiltDirection::TowardsFront) {
 					actuator_sp(i + _first_tilt_idx) += control_tilt;
+				}
+			}
+		}
+
+		// in FW directly use throttle sp
+		if (_flight_phase == FlightPhase::FORWARD_FLIGHT) {
+
+			actuator_controls_s actuator_controls_0;
+
+			if (_actuator_controls_0_sub.copy(&actuator_controls_0)) {
+				for (int i = 0; i < _first_tilt_idx; ++i) {
+					actuator_sp(i) = actuator_controls_0.control[actuator_controls_s::INDEX_THROTTLE];
 				}
 			}
 		}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -95,4 +95,5 @@ protected:
 	float _last_tilt_control{NAN};
 
 	uORB::Subscription _actuator_controls_1_sub{ORB_ID(actuator_controls_1)};
+	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
1) Input of dependent values into allocation
Currently the tiltrotor allocation receives the "normal" allocation inputs (3D torque and 3D thrust), plus additionally collective thrust (through actuator_controls_1[8]). This can result in infeasible inputs, as collective tilt and possible Fx/Fz ratio is closely linked. 

2) Non-zero yaw effectiveness for tiltrotor VTOLs with tilt as their primary yawing actuation
We currently set the torque coefficient to 0 in case of yaw-by-tilt, but when there is some collective tilt then also the thrust coefficient has an influence on the yaw effectiveness. The current way we handle yaw control on tiltrotors (basically simplifying the yaw effectivness of a tilt to "1" or "-1") though only works when the yaw actuation is completely decoupled from the control of the other axis/thrust (we don't quantify how much the yaw effectiveness of the tilts is, so how should the allocator be able to deal with it properly). 

3) Thrust not correctly normalized in fixed-wing mode after some motors were switched off after the transition.

**Describe your solution**
1) Pass 1D thrust (actuator_controls[3] + collective tilt into control allocator. 
Use the F_z component to carry the (unsigned) magnitude for thrust to the allocator, and in there assume the effectiveness of the motors to only be in z direction.

2) Set all mc_rotors effectiveness in yaw to 0 if the vtol doesn't do yaw-by-differential-thrust (e.g. on tiltrotors or duo tailsitters).

3) Directly publish` actuator_controls_1[3]` as thrust setpoint from allocator if in FW (e.g. if the throttle stick is at 50% then all the currently enabled motors are at 50%). That breaks the differential throttle for yaw control in FW though. Let's align if it's the desired behavior that stick setpoint=motor, and then find a solution for the differential thrust for yaw on all platforms.

Further I think it's time to at least enable control allocation by default in SITL, and I've started here by doing so for Tiltrotor SITL. To have it more realistic I've also disabled the tilt of the rear motors. From the controls perspective this is also more challenging than tilting all 4 motors. 

**Describe possible alternatives**
In general I think the allocation needs to be more flexible. Currently the only customization (e.g. to VTOL tiltrotor) happens in how the Effectiveness matrix (matrices) are set up and the algorithms used to invert them, but there is no way to cleanly implement alternative allocation methods. In this case here I think it would be worth to experiment with a two stage allocation, where in a first step all the motor tilts are determined by some inputs (F_x, F_z, M_z), and then the motor inputs by linearizing the system around these tilts and using F_z, M_x, M_y. 

**Test data / coverage**
The exact PR was SITL tested, and a slightly different version (setting also km to 0 if yaw is controlled by yaw) was tested on a tricopter tiltrotor. 

**Additional context**
