### PR TITLE
commander: add COM_DISARM_SAFE to optionally disable disarm safety protections

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -767,7 +767,7 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 
 transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool forced)
 {
-	if (!forced) {
+	if (!forced && _param_com_disarm_safe.get()) {
 		const bool landed = (_vehicle_land_detected.landed || _vehicle_land_detected.maybe_landed
 				     || is_ground_rover(_vehicle_status));
 		const bool mc_manual_thrust_mode = _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -217,6 +217,7 @@ private:
 		(ParamInt<px4::params::COM_IMB_PROP_ACT>) _param_com_imb_prop_act,
 		(ParamFloat<px4::params::COM_DISARM_LAND>) _param_com_disarm_land,
 		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_preflight,
+		(ParamBool<px4::params::COM_DISARM_SAFE>) _param_com_disarm_safe,
 
 		(ParamBool<px4::params::COM_OBS_AVOID>) _param_com_obs_avoid,
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -244,6 +244,16 @@ PARAM_DEFINE_FLOAT(COM_DISARM_LAND, 2.0f);
 PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 
 /**
+ * Disarm safety protections
+ *
+ * Prevent disarming if flying in an altitude or position control mode and not landed.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_DISARM_SAFE, 1);
+
+/**
  * Allow arming without GPS
  *
  * The default allows the vehicle to arm without GPS signal.


### PR DESCRIPTION
Some people want to be able to disarm no matter what.

TODO: exclude RC stick disarming?

https://github.com/PX4/PX4-Autopilot/blob/b1a13d88ad26d94941bb86f0ff137d128ada9843/src/modules/commander/Commander.cpp#L761