### PR TITLE
Dynamic cruise throttle based on air density and wind conditions

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -415,8 +415,11 @@ private:
 	float		get_tecs_thrust();
 
 	float		get_manual_airspeed_setpoint();
-	float		get_auto_airspeed_setpoint(const hrt_abstime &now, const float pos_sp_cru_airspeed, const Vector2f &ground_speed,
-			float dt);
+	float		get_auto_airspeed_setpoint(const hrt_abstime &now, const float pos_sp_cruise_airspeed,
+			const Vector2f &ground_speed, float dt);
+	float 		getMinimumCruiseThrottleWindCompensated(float throttle_cruise);
+	void 		compensateCruiseAndMaxThrottleForAirDensityAndWind(float &throttle_cruise, float &throttle_max,
+			float throttle_min);
 
 	void		reset_takeoff_state(bool force = false);
 	void		reset_landing_state();
@@ -524,6 +527,8 @@ private:
 		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,
 
 		(ParamFloat<px4::params::FW_TKO_PITCH_MIN>) _takeoff_pitch_min,
+
+		(ParamFloat<px4::params::FW_WIND_CTHR_SC>) _param_fw_wind_cruise_throttle_scale,
 
 		(ParamFloat<px4::params::NAV_FW_ALT_RAD>) _param_nav_fw_alt_rad
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -244,12 +244,13 @@ PARAM_DEFINE_FLOAT(NPFG_PERIOD_SF, 1.5f);
 PARAM_DEFINE_FLOAT(FW_THR_CRUISE, 0.6f);
 
 /**
- * Scale throttle by pressure change
+ * Throttle air density scale
  *
- * Automatically adjust throttle to account for decreased air density at higher altitudes.
- * Start with a scale factor of 1.0 and adjust for different propulsion systems.
+ * This scale is applied to the air density compensation factor for TECS cruise and maximum throttle.
+ * E.g. cruise_throttle_compensated = cruise_throttle * eas2tas * FW_THR_ALT_SCL
+ * where eas2tas is the conversion factor from equivalent to true airspeed (calculated using estimated air density)
  *
- * When flying without airspeed sensor this will help to keep a constant performance over large altitude ranges.
+ * This compensation is most important for vehicles without airspeed sensors in order to keep a constant performance over large density altitude ranges.
  *
  * The default value of 0 will disable scaling.
  *
@@ -998,3 +999,19 @@ PARAM_DEFINE_INT32(FW_GPSF_LT, 30);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(FW_GPSF_R, 15.0f);
+
+/**
+ * Wind-based cruise throttle adaption.
+ *
+ * Scale factor from horizontal wind magnitude to cruise throttle increment.
+ * cruise_throttle_comp = cruise_throttle + wind_magnitude * FW_WIND_CTHR_SC.
+ * This parameter only has an effect if airspeed is not controlled (e.g. disabled or not valid).
+ *
+ * @unit norm
+ * @min 0
+ * @max 0.05
+ * @decimal 3
+ * @increment 0.001
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_WIND_CTHR_SC, 0.0f);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Vehicles without an airspeed sensor solely rely on an appropriate cruise throttle setting in order to fly at sufficient airspeed  above stall speed. When density altitude increases, cruise throttle also needs to increase (assuming ESCs that do duty cycle control). Currently, a similar compensation is already done, however utilizing pressure altitude instead of density altitude.

Additionally, the risk of stalling a vehicle at low airspeed increases with increasing wind speed (especially gusty conditions).
Therefore, cruise throttle should also be increased accordingly based on estimated wind conditions.


**Describe your solution**
This PR applies cruise throttle (and maximum throttle) compensation for air density and wind conditions.
The wind compensation is kept fairly simple, at the moment a parameter can be used to specify the sensitivity between wind magnitude and cruise throttle increase.
It might be necessary to apply filtering to the wind magnitude in order to avoid too high dynamics  in the cruise throttle signal.

**Describe possible alternatives**

**Test data / coverage**
SITL only

**Additional context**
Add any other related context or media.
