### PR TITLE
commander_params: COM_RC_IN_MODE - comment out of date

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -228,7 +228,7 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
 /**
  * RC control input mode
  *
- * The default value of 0 requires a valid RC transmitter setup.
+ * With value 0 a valid RC transmitter calibration is required.
  * Setting this to 1 allows joystick control and disables RC input handling and the associated checks.
  *
  * @group Commander

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -231,7 +231,7 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  * With value 0 a valid RC transmitter calibration is required.
  * A value of 1 allows joystick control only and disables RC input handling and the associated checks.
  * A value of 2 allows both sources and will fall back to the next valid one once the stream in use gets invalid.
- * A value of 3 allows either input from RC or joystick. The first available source is kept until reboot.
+ * A value of 3 allows either input from RC or joystick. The first available source is selected and used until reboot.
  * A value of 4 ignores any stick input.
  *
  * @group Commander

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -229,9 +229,7 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  * RC control input mode
  *
  * The default value of 0 requires a valid RC transmitter setup.
- * Setting this to 1 allows joystick control and disables RC input handling and the associated checks. A value of
- * 2 will generate RC control data from manual input received via MAVLink instead
- * of directly forwarding the manual input data.
+ * Setting this to 1 allows joystick control and disables RC input handling and the associated checks.
  *
  * @group Commander
  * @min 0

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -229,7 +229,7 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  * RC control input mode
  *
  * A value of 0 enables RC transmitter control (only). A valid RC transmitter calibration is required.
- * A value of 1 allows joystick control only and disables RC input handling and the associated checks.
+ * A value of 1 allows joystick control only. RC input handling and the associated checks are disabled.
  * A value of 2 allows both sources and will fall back to the next valid one once the stream in use gets invalid.
  * A value of 3 allows either input from RC or joystick. The first available source is selected and used until reboot.
  * A value of 4 ignores any stick input.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -229,7 +229,10 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  * RC control input mode
  *
  * With value 0 a valid RC transmitter calibration is required.
- * Setting this to 1 allows joystick control and disables RC input handling and the associated checks.
+ * A value of 1 allows joystick control only and disables RC input handling and the associated checks.
+ * A value of 2 allows both sources and will fall back to the next valid one once the stream in use gets invalid.
+ * A value of 3 allows either input from RC or joystick. The first available source is kept until reboot.
+ * A value of 4 ignores any stick input.
  *
  * @group Commander
  * @min 0

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -228,7 +228,7 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
 /**
  * RC control input mode
  *
- * With value 0 a valid RC transmitter calibration is required.
+ * A value of 0 enables RC transmitter control (only). A valid RC transmitter calibration is required.
  * A value of 1 allows joystick control only and disables RC input handling and the associated checks.
  * A value of 2 allows both sources and will fall back to the next valid one once the stream in use gets invalid.
  * A value of 3 allows either input from RC or joystick. The first available source is selected and used until reboot.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -230,7 +230,7 @@ PARAM_DEFINE_INT32(COM_HOME_IN_AIR, 0);
  *
  * A value of 0 enables RC transmitter control (only). A valid RC transmitter calibration is required.
  * A value of 1 allows joystick control only. RC input handling and the associated checks are disabled.
- * A value of 2 allows both sources and will fall back to the next valid one once the stream in use gets invalid.
+ * A value of 2 allows either RC Transmitter or Joystick input. The first valid input is used, will fallback to other sources if the input stream becomes invalid.
  * A value of 3 allows either input from RC or joystick. The first available source is selected and used until reboot.
  * A value of 4 ignores any stick input.
  *


### PR DESCRIPTION
The comment for `COM_RC_IN_MODE` does not match the current value options. 
I have removed the invalid part, but we need to update with information about the new options.

I can't do that yet because I don't know for each case what protections are enabled/disabled. 

@MaEtUgR can you clarify?

Options with questions/comments about behaviour as bullets. 
`@value 0` RC Transmitter only
* Is it true that this requires valid transmitter setup and will failsafe (unless circuit breaker) if transmitter data is lost?
* No requirements for Joystick and it will be ignored.

`@value 1` Joystick only
- Joystick is enabled and RC is disabled. 
- All the RC checks are disabled - so you don't have to set a circuit breaker on them or anything.
- Joystick checks are enabled - so either you will have to have a joystick OR a virtual joystick enabled right? 
  - What if you don't - is there a circuit breaker?
  - How do you enable virtual joysticks (i.e. why not here?)

`@value 2` RC and Joystick with fallback
- I assume this means that you have both RC and Joystick connected it will take inputs from either/both.
- Are checks enabled? I.e. if you don't have RC set, what will happen? What about if you don't have joystick set?
- What does "with fallback" mean?

`@value 3` RC or Joystick keep first
- What does "keep first" mean. My guess would be "whatever it detects first it uses". If it detects RC then it is as though 0 were set, with all the same safety checks etc. Otherwise it is Joystick - same as if 1 was set.

`@value 4` Stick input disabled
- I think this means no RC or Joystick and no safety checks - ie it won't ask for you to connect RC or Joystick or have virtual joystick. BUT this would mean you would only be able to fly auto modes. Right?

