### PR TITLE
Logger: fix corner case when mission log is enabled

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -484,7 +484,7 @@ void LogWriterFile::run()
 			 * not an issue because notify() is called regularly.
 			 * If the logger was switched off in the meantime, do not wait for data, instead run this loop
 			 * once more to write remaining data and close the file. */
-			if (_buffers[0]._should_run) {
+			if (_buffers[0]._should_run || _buffers[1]._should_run) {
 				pthread_cond_wait(&_cv, &_mtx);
 			}
 		}

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -287,7 +287,9 @@ int LogWriterFile::hardfault_store_filename(const char *log_file)
 
 void LogWriterFile::stop_log(LogType type)
 {
+	lock();
 	_buffers[(int)type]._should_run = false;
+	unlock();
 	notify();
 }
 
@@ -312,8 +314,10 @@ int LogWriterFile::thread_start()
 void LogWriterFile::thread_stop()
 {
 	// this will terminate the main loop of the writer thread
-	_exit_thread = true;
+	lock();
+	_exit_thread.store(true);
 	_buffers[0]._should_run = _buffers[1]._should_run = false;
+	unlock();
 
 	notify();
 
@@ -335,10 +339,10 @@ void *LogWriterFile::run_helper(void *context)
 
 void LogWriterFile::run()
 {
-	while (!_exit_thread) {
+	while (!_exit_thread.load()) {
 		// Outer endless loop
 		// Wait for _should_run flag
-		while (!_exit_thread) {
+		while (!_exit_thread.load()) {
 			bool start = false;
 			pthread_mutex_lock(&_mtx);
 			pthread_cond_wait(&_cv, &_mtx);
@@ -350,7 +354,7 @@ void LogWriterFile::run()
 			}
 		}
 
-		if (_exit_thread) {
+		if (_exit_thread.load()) {
 			break;
 		}
 

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <px4_platform_common/defines.h>
+#include <px4_platform_common/atomic.h>
 #include <stdint.h>
 #include <pthread.h>
 #include <drivers/drv_hrt.h>
@@ -205,8 +206,8 @@ private:
 
 	LogFileBuffer _buffers[(int)LogType::Count];
 
-	bool 		_exit_thread = false;
-	bool		_need_reliable_transfer = false;
+	px4::atomic_bool	_exit_thread{false};
+	bool			_need_reliable_transfer{false};
 	pthread_mutex_t		_mtx;
 	pthread_cond_t		_cv;
 	pthread_t _thread = 0;


### PR DESCRIPTION
Normally _should_run for mission is only ever true if _should_run for the normal log is. There are exceptions though:
- the log buffer fails to allocate
- there was a write failure (e.g. due to SD card removal)

In that situation, the writer would not wait anymore but busy-loop.