### PR TITLE
Update UCANS32K146 clocking to use XTAL and support higher pheriphal …

### DIFF
--- a/boards/nxp/ucans32k146/src/clockconfig.c
+++ b/boards/nxp/ucans32k146/src/clockconfig.c
@@ -110,7 +110,7 @@ const struct clock_configuration_s g_initial_clkconfig = {
 		{
 			.mode        = SCG_SPLL_MONITOR_DISABLE,         /* SPLLCM */
 			.div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV1 */
-			.div2        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV2 */
+			.div2        = SCG_ASYNC_CLOCK_DIV_BY_2,         /* SPLLDIV2 */
 			.prediv      = 1,                                /* PREDIV */
 			.mult        = 40,                               /* MULT */
 			.src         = 0,                                /* SOURCE */

--- a/boards/nxp/ucans32k146/src/periphclocks.c
+++ b/boards/nxp/ucans32k146/src/periphclocks.c
@@ -101,7 +101,7 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] = {
 #else
 		.clkgate = false,
 #endif
-		.clksrc  = CLK_SRC_SIRC_DIV2,
+		.clksrc  = CLK_SRC_SPLL_DIV2,
 	},
 	{
 		.clkname = LPSPI0_CLK,
@@ -110,7 +110,7 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] = {
 #else
 		.clkgate = false,
 #endif
-		.clksrc  = CLK_SRC_SIRC_DIV2,
+		.clksrc  = CLK_SRC_SPLL_DIV2,
 	},
 	{
 		.clkname = LPUART0_CLK,
@@ -119,7 +119,7 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] = {
 #else
 		.clkgate = false,
 #endif
-		.clksrc  = CLK_SRC_SIRC_DIV2,
+		.clksrc  = CLK_SRC_SPLL_DIV2,
 	},
 	{
 		.clkname = LPUART1_CLK,
@@ -128,7 +128,7 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] = {
 #else
 		.clkgate = false,
 #endif
-		.clksrc  = CLK_SRC_SIRC_DIV2,
+		.clksrc  = CLK_SRC_SPLL_DIV2,
 	},
 	{
 		.clkname    = RTC0_CLK,


### PR DESCRIPTION
Use XTAL/SPLL instead of SIRC to have a higher peripheral frequencies to support higher data rates.

Should fix #19612 which caused that the UCANS32K146 UART driver would fail when requested a high baud rate.