### PR TITLE
(RFC) Kconfig modules dependency chain

### DIFF
--- a/src/drivers/px4io/Kconfig
+++ b/src/drivers/px4io/Kconfig
@@ -1,5 +1,6 @@
 menuconfig DRIVERS_PX4IO
 	bool "px4io"
 	default n
+	select MODULES_RC_UPDATE
 	---help---
 		Enable support for px4io

--- a/src/drivers/rc_input/Kconfig
+++ b/src/drivers/rc_input/Kconfig
@@ -1,5 +1,6 @@
 menuconfig DRIVERS_RC_INPUT
 	bool "rc_input"
 	default n
+	select MODULES_RC_UPDATE
 	---help---
 		Enable support for rc_input

--- a/src/modules/airspeed_selector/Kconfig
+++ b/src/modules/airspeed_selector/Kconfig
@@ -1,6 +1,7 @@
 menuconfig MODULES_AIRSPEED_SELECTOR
 	bool "airspeed_selector"
 	default n
+	select MODULES_FW_POS_CONTROL_L1
 	---help---
 		Enable support for airspeed_selector
 

--- a/src/modules/flight_mode_manager/Kconfig
+++ b/src/modules/flight_mode_manager/Kconfig
@@ -1,6 +1,9 @@
 menuconfig MODULES_FLIGHT_MODE_MANAGER
 	bool "flight_mode_manager"
 	default n
+	select MODULES_COMMANDER 
+	select MODULES_MC_ATT_CONTROL 
+	select MODULES_MC_POS_CONTROL
 	---help---
 		Enable support for flight_mode_manager
 

--- a/src/modules/fw_att_control/Kconfig
+++ b/src/modules/fw_att_control/Kconfig
@@ -1,6 +1,8 @@
 menuconfig MODULES_FW_ATT_CONTROL
 	bool "fw_att_control"
 	default n
+	select MODULES_COMMANDER
+	select MODULES_FW_POS_CONTROL_L1
 	---help---
 		Enable support for fw_att_control
 

--- a/src/modules/fw_autotune_attitude_control/Kconfig
+++ b/src/modules/fw_autotune_attitude_control/Kconfig
@@ -1,5 +1,6 @@
 menuconfig MODULES_FW_AUTOTUNE_ATTITUDE_CONTROL
 	bool "fw_autotune_attitude_control"
 	default n
+	select MODULES_COMMANDER
 	---help---
 		Enable support for fw_autotune_attitude_control

--- a/src/modules/fw_pos_control_l1/Kconfig
+++ b/src/modules/fw_pos_control_l1/Kconfig
@@ -1,6 +1,8 @@
 menuconfig MODULES_FW_POS_CONTROL_L1
 	bool "fw_pos_control_l1"
 	default n
+	select MODULES_COMMANDER
+	select MODULES_NAVIGATOR
 	---help---
 		Enable support for fw_pos_control_l1
 

--- a/src/modules/manual_control/Kconfig
+++ b/src/modules/manual_control/Kconfig
@@ -1,5 +1,6 @@
 menuconfig MODULES_MANUAL_CONTROL
 	bool "manual_control"
 	default n
+	select MODULES_COMMANDER
 	---help---
 		Enable support for manual_control

--- a/src/modules/mavlink/Kconfig
+++ b/src/modules/mavlink/Kconfig
@@ -1,6 +1,7 @@
 menuconfig MODULES_MAVLINK
 	bool "mavlink"
 	default n
+	depends on MODULES_DATAMAN
 	---help---
 		Enable support for mavlink
 

--- a/src/modules/mc_att_control/Kconfig
+++ b/src/modules/mc_att_control/Kconfig
@@ -1,6 +1,7 @@
 menuconfig MODULES_MC_ATT_CONTROL
 	bool "mc_att_control"
 	default n
+	select MODULES_MC_POS_CONTROL
 	---help---
 		Enable support for mc_att_control
 

--- a/src/modules/mc_autotune_attitude_control/Kconfig
+++ b/src/modules/mc_autotune_attitude_control/Kconfig
@@ -1,5 +1,6 @@
 menuconfig MODULES_MC_AUTOTUNE_ATTITUDE_CONTROL
 	bool "mc_autotune_attitude_control"
 	default n
+	select MODULES_MC_ATT_CONTROL
 	---help---
 		Enable support for mc_autotune_attitude_control

--- a/src/modules/mc_rate_control/Kconfig
+++ b/src/modules/mc_rate_control/Kconfig
@@ -1,6 +1,7 @@
 menuconfig MODULES_MC_RATE_CONTROL
 	bool "mc_rate_control"
 	default n
+	select MODULES_MC_POS_CONTROL
 	---help---
 		Enable support for mc_rate_control
 

--- a/src/modules/navigator/Kconfig
+++ b/src/modules/navigator/Kconfig
@@ -1,6 +1,7 @@
 menuconfig MODULES_NAVIGATOR
 	bool "navigator"
 	default n
+	select MODULES_DATAMAN
 	---help---
 		Enable support for navigator
 

--- a/src/modules/rover_pos_control/Kconfig
+++ b/src/modules/rover_pos_control/Kconfig
@@ -1,5 +1,6 @@
 menuconfig MODULES_ROVER_POS_CONTROL
 	bool "rover_pos_control"
+	select MODULES_NAVIGATOR
 	default n
 	---help---
 		Enable support for rover_pos_control

--- a/src/modules/sih/Kconfig
+++ b/src/modules/sih/Kconfig
@@ -1,8 +1,9 @@
 menuconfig MODULES_SIH
-	bool "sih"
+	bool "Simulator in Hardware (SIH)"
+	select MODULES_SENSORS
 	default n
 	---help---
-		Enable support for sih
+		Enable support for Simulator in Hardware (SIH)
 
 menuconfig USER_SIH
 	bool "sih running as userspace module"

--- a/src/modules/vtol_att_control/Kconfig
+++ b/src/modules/vtol_att_control/Kconfig
@@ -1,6 +1,7 @@
 menuconfig MODULES_VTOL_ATT_CONTROL
 	bool "vtol_att_control"
 	default n
+	select MODULES_COMMANDER
 	---help---
 		Enable support for vtol_att_control
 


### PR DESCRIPTION
Request for Comments (RFC)

This PR introduces a dependency chain in PX4 by using the Kconfig select keywords to enforce module selection that are tightly coupled.

Right now this has been done through some trivial trail and error, but would be nice to gain some feedback which PX4 software modules are tightly coupled what the dependencies chains are.