### PR TITLE
Fix uavcan battery causing immediate RTL time remaining low

### DIFF
--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -87,7 +87,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	battery_status[instance].voltage_filtered_v = msg.voltage;
 	battery_status[instance].current_a = msg.current;
 	battery_status[instance].current_filtered_a = msg.current;
-	// battery_status[instance].current_average_a = msg.;
+	battery_status[instance].current_average_a = msg.current;
 
 	if (battery_aux_support[instance] == false) {
 		sumDischarged(battery_status[instance].timestamp, battery_status[instance].current_a);
@@ -101,11 +101,11 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	battery_status[instance].connected = true;
 	battery_status[instance].source = msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_IN_USE;
 	// battery_status[instance].priority = msg.;
-	// battery_status[instance].capacity = msg.;
+	battery_status[instance].capacity = msg.full_charge_capacity_wh;
 	battery_status[instance].full_charge_capacity_wh = msg.full_charge_capacity_wh;
 	battery_status[instance].remaining_capacity_wh = msg.remaining_capacity_wh;
 	// battery_status[instance].cycle_count = msg.;
-	// battery_status[instance].time_remaining_s = msg.;
+	battery_status[instance].time_remaining_s = NAN;
 	// battery_status[instance].average_time_to_empty = msg.;
 	battery_status[instance].serial_number = msg.model_instance_id;
 	battery_status[instance].id = msg.getSrcNodeID().get();

--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -85,5 +85,5 @@ private:
 	uint8_t _warning;
 	hrt_abstime _last_timestamp;
 	battery_status_s battery_status[battery_status_s::MAX_INSTANCES] {};
-	bool battery_aux_support[battery_status_s::MAX_INSTANCES] {};
+	bool battery_aux_support[battery_status_s::MAX_INSTANCES] {false};
 };


### PR DESCRIPTION
This PR fixes a standard dronecan battery without the ardupilot aux message causing an immediate RTL due to time remaining low.

Fixes issue https://github.com/PX4/PX4-Autopilot/issues/19642

This PR
https://review.px4.io/plot_app?log=5b4122a9-8a57-48cc-8d0e-d8cdc8945d30

v1.13.0-beta1
https://review.px4.io/plot_app?log=761b3a20-94ae-43d9-aba3-1205751f58ce
https://review.px4.io/plot_app?log=25386252-9972-4f8f-bac0-716c54559f68