### PR TITLE
PositionControl: log individual portions of PID velocity control

### DIFF
--- a/msg/vehicle_local_position_setpoint.msg
+++ b/msg/vehicle_local_position_setpoint.msg
@@ -17,3 +17,7 @@ float32[3] thrust	# normalized thrust vector in NED
 
 float32 yaw		# in radians NED -PI..+PI
 float32 yawspeed	# in radians/sec
+
+float32[3] velocity_proportional_portion
+float32[3] velocity_integral_potion
+float32[3] velocity_derivative_portion

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -141,7 +141,10 @@ void PositionControl::_velocityControl(const float dt)
 {
 	// PID velocity control
 	Vector3f vel_error = _vel_sp - _vel;
-	Vector3f acc_sp_velocity = vel_error.emult(_gain_vel_p) + _vel_int - _vel_dot.emult(_gain_vel_d);
+	_velocity_proportional_portion = vel_error.emult(_gain_vel_p);
+	_velocity_integral_potion = _vel_int;
+	_velocity_derivative_portion = - _vel_dot.emult(_gain_vel_d);
+	Vector3f acc_sp_velocity = _velocity_proportional_portion + _velocity_integral_potion + _velocity_derivative_portion;
 
 	// No control input from setpoints or corresponding states which are NAN
 	ControlMath::addIfNotNanVector3f(_acc_sp, acc_sp_velocity);
@@ -240,13 +243,17 @@ void PositionControl::getLocalPositionSetpoint(vehicle_local_position_setpoint_s
 	local_position_setpoint.x = _pos_sp(0);
 	local_position_setpoint.y = _pos_sp(1);
 	local_position_setpoint.z = _pos_sp(2);
-	local_position_setpoint.yaw = _yaw_sp;
-	local_position_setpoint.yawspeed = _yawspeed_sp;
 	local_position_setpoint.vx = _vel_sp(0);
 	local_position_setpoint.vy = _vel_sp(1);
 	local_position_setpoint.vz = _vel_sp(2);
 	_acc_sp.copyTo(local_position_setpoint.acceleration);
 	_thr_sp.copyTo(local_position_setpoint.thrust);
+	local_position_setpoint.yaw = _yaw_sp;
+	local_position_setpoint.yawspeed = _yawspeed_sp;
+
+	_velocity_proportional_portion.copyTo(local_position_setpoint.velocity_proportional_portion);
+	_velocity_integral_potion.copyTo(local_position_setpoint.velocity_integral_potion);
+	_velocity_derivative_portion.copyTo(local_position_setpoint.velocity_derivative_portion);
 }
 
 void PositionControl::getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint) const

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -216,4 +216,9 @@ private:
 	matrix::Vector3f _thr_sp; /**< desired thrust */
 	float _yaw_sp{}; /**< desired heading */
 	float _yawspeed_sp{}; /** desired yaw-speed */
+
+	// Velocity PID portions for logging
+	matrix::Vector3f _velocity_proportional_portion;
+	matrix::Vector3f _velocity_integral_potion;
+	matrix::Vector3f _velocity_derivative_portion;
 };


### PR DESCRIPTION
**Describe problem solved by this pull request**
In #19592 I suggested disabling the velocity control derivative by default because in my latest real-world bring-ups at least on larger size drones it caused more harm in steady hover than helping with tracking. We discussed first adding some instrumentation to figure out why that could be before just disabling it.

**Describe your solution**
I added logging for the individual portions of the proportional, integral and derivative term of the controller. It's 9 additional floats per position control telemetry (`vehicle_local_position_setpoint`).

**Describe possible alternatives**
We could add a separate message that's only logged in a certain profile.

**Test data / coverage**
I tested it in a quick SITL flight with `MPC_POS_MODE` set to 0 such that I can generate some steps for the velocity controller.  Here's the plot of some back-and-forth steps where I also compare against the numerical derivative of the proportional part calculated by Plotjuggler.
![image](https://user-images.githubusercontent.com/4668506/168111493-64e3be3b-c071-4d22-9e14-d68dbd15aef2.png)
When flying with the modern jerk optimized auto/mission implementation there are by design no velocity setpoint steps and the acceleration feed-forward already reduces the velocity error the controller ever sees significantly.