### PR TITLE
Make power off tune uninterruptable

### DIFF
--- a/src/lib/tunes/tune_definition.desc
+++ b/src/lib/tunes/tune_definition.desc
@@ -104,4 +104,4 @@ PX4_DEFINE_TUNE(15, SD_ERROR,              "MNBG",                              
 PX4_DEFINE_TUNE(16, PROG_PX4IO,            "MLL32CP8MB",                                    false /*  Program PX4IO */)
 PX4_DEFINE_TUNE(17, PROG_PX4IO_OK,         "MLL8CDE",                                       false /*  Program PX4IO success */)
 PX4_DEFINE_TUNE(18, PROG_PX4IO_ERR,        "ML<<CP4CP4CP4CP4CP4",                           true  /*  Program PX4IO fail */)
-PX4_DEFINE_TUNE(19, POWER_OFF,             "MFT255a8g8f8e8c8<b8a8g4",                       true  /*  When pressing off button */)
+PX4_DEFINE_TUNE(19, POWER_OFF,             "MFT255a8g8f8e8c8<b8a8g4",                       false  /*  When pressing off button */)

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -93,13 +93,11 @@ typedef enum VEHICLE_MODE_FLAG {
 
 #if defined(BOARD_HAS_POWER_CONTROL)
 static orb_advert_t tune_control_pub = nullptr;
+
 static void play_power_button_down_tune()
 {
-	tune_control_s tune_control{};
-	tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
-	tune_control.tune_id = tune_control_s::TUNE_ID_POWER_OFF;
-	tune_control.timestamp = hrt_absolute_time();
-	orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);
+	// Override any other tunes because power-off sound should have the priority
+	set_tune_override(tune_control_s::TUNE_ID_POWER_OFF);
 }
 
 static void stop_tune()

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -177,8 +177,8 @@ void set_tune(const int tune_id)
 {
 	const hrt_abstime current_time = hrt_absolute_time();
 	const unsigned int new_tune_duration = tune_durations[tune_id];
-	const bool current_tune_is_repeating = (tune_end == 0) ? true : false;
-	const bool new_tune_is_repeating = (new_tune_duration == 0) ? true : false;
+	const bool current_tune_is_repeating = (tune_end == 0);
+	const bool new_tune_is_repeating = (new_tune_duration == 0);
 
 	bool set_new_tune = false;
 

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -123,17 +123,25 @@ bool is_ground_rover(const vehicle_status_s &current_status)
 	return current_status.system_type == VEHICLE_TYPE_GROUND_ROVER;
 }
 
-static hrt_abstime blink_msg_end = 0; // end time for currently blinking LED message, 0 if no blink message
-static hrt_abstime tune_end = 0; // end time of currently played tune, 0 for repeating tunes or silence
-static uint8_t tune_current = tune_control_s::TUNE_ID_STOP; // currently playing tune, can be interrupted after tune_end
-static unsigned int tune_durations[tune_control_s::NUMBER_OF_TUNES] {};
-
+// End time for currently blinking LED message, 0 if no blink message
+static hrt_abstime blink_msg_end = 0;
 static int fd_leds{-1};
 
 static led_control_s led_control {};
 static orb_advert_t led_control_pub = nullptr;
+
+// Static array that defines the duration of each tune, 0 if it's a repeating tune (therefore no fixed duration)
+static unsigned int tune_durations[tune_control_s::NUMBER_OF_TUNES] {};
+
+// End time of currently played tune, 0 for repeating tunes or silence
+static hrt_abstime tune_end = 0;
+
+// currently playing tune, can be interrupted after tune_end
+static uint8_t tune_current = tune_control_s::TUNE_ID_STOP;
+
 static tune_control_s tune_control {};
 static orb_advert_t tune_control_pub = nullptr;
+
 
 int buzzer_init()
 {
@@ -156,36 +164,57 @@ void buzzer_deinit()
 	orb_unadvertise(tune_control_pub);
 }
 
-void set_tune_override(int tune)
+void set_tune_override(const int tune_id)
 {
-	tune_control.tune_id = tune;
+	tune_control.tune_id = tune_id;
 	tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
 	tune_control.tune_override = true;
 	tune_control.timestamp = hrt_absolute_time();
 	orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);
 }
 
-void set_tune(int tune)
+void set_tune(const int tune_id)
 {
-	unsigned int new_tune_duration = tune_durations[tune];
+	const hrt_abstime current_time = hrt_absolute_time();
+	const unsigned int new_tune_duration = tune_durations[tune_id];
+	const bool current_tune_is_repeating = (tune_end == 0) ? true : false;
+	const bool new_tune_is_repeating = (new_tune_duration == 0) ? true : false;
 
-	/* don't interrupt currently playing non-repeating tune by repeating */
-	if (tune_end == 0 || new_tune_duration != 0 || hrt_absolute_time() > tune_end) {
-		/* allow interrupting current non-repeating tune by the same tune */
-		if (tune != tune_current || new_tune_duration != 0) {
-			tune_control.tune_id = tune;
-			tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
-			tune_control.tune_override = false;
-			tune_control.timestamp = hrt_absolute_time();
-			orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);
+	bool set_new_tune = false;
+
+	if (!current_tune_is_repeating) {
+		// Current non repeating tune has ended
+		if (current_time > tune_end) {
+			set_new_tune = true;
 		}
 
-		tune_current = tune;
+		// Allow non repeating tune to interrupt current non repeating tune, if it's different
+		if (!new_tune_is_repeating && (tune_id != tune_current)) {
+			set_new_tune = true;
+		}
+
+	} else {
+		// Allow interrupting repeating tune as long as it's a different tune
+		if (tune_id != tune_current) {
+			set_new_tune = true;
+		}
+	}
+
+	if (set_new_tune) {
+		tune_control.tune_id = tune_id;
+		tune_control.volume = tune_control_s::VOLUME_LEVEL_DEFAULT;
+		tune_control.tune_override = false;
+		tune_control.timestamp = current_time;
+		orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);
+
+		tune_current = tune_id;
 
 		if (new_tune_duration != 0) {
-			tune_end = hrt_absolute_time() + new_tune_duration;
+			// Set tune ending time for a finite duration tunes
+			tune_end = current_time + new_tune_duration;
 
 		} else {
+			// Set tune ending time as 0 to indicate it's a repeating tune
 			tune_end = 0;
 		}
 	}

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -72,7 +72,7 @@ void set_tune_override(const int tune_id);
  *
  * 1. Current playing tune is non-repeating and has ended
  * 2. Current playing tune is non-repeating, but the requested tune is also non-repeating, and they are different tunes
- * 3. Current playing tune is repeating, and the requested tune is different from teh current tune
+ * 3. Current playing tune is repeating, and the requested tune is different from the current tune
  *
  * This is to prevent repeating tunes from overriding single-play tunes.
  */

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -60,8 +60,24 @@ bool is_ground_rover(const vehicle_status_s &current_status);
 int buzzer_init(void);
 void buzzer_deinit(void);
 
-void set_tune_override(int tune);
-void set_tune(int tune);
+/**
+ * @brief Override tune control and play the given tune
+ */
+void set_tune_override(const int tune_id);
+
+/**
+ * @brief Set the new tune to play under predefined conditions
+ *
+ * Setting a new tune will only be possible for the following 3 cases:
+ *
+ * 1. Current playing tune is non-repeating and has ended
+ * 2. Current playing tune is non-repeating, but the requested tune is also non-repeating, and they are different tunes
+ * 3. Current playing tune is repeating, and the requested tune is different from teh current tune
+ *
+ * This is to prevent repeating tunes from overriding single-play tunes.
+ */
+void set_tune(const int tune_id);
+
 void tune_home_set(bool use_buzzer);
 void tune_mission_ok(bool use_buzzer);
 void tune_mission_warn(bool use_buzzer);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently when you have a low battery warning, pressing down the power button (e.g. on ATL Mantis Edu) doesn't play the power-off tune, because it gets overridden by the low battery warning tune request published by the Commander
1. Commander was sending the "low battery warning" tune request on every single loop, thus filling up the uORB queue of the `tune_control` message.

**Describe your solution**
1. Fix the commander's `set_tune` function to only allow transmitting the tune_control uORB message request for a tune only after it has finished playing, so that it wouldn't fill up the queue excessively
2. Allow 'override' when requesting the Power button down tune in Commander

**Describe possible alternatives**
I think that a 'priority' should exist that allows override on certain tones over others, etc.

Or, the `Tunes` library that all the module / drivers actually playing the tune should integrate this prioritization in a smarter level, so that an already-playing tune wouldn't get overridden in cases like this. :thinking: 

## Discussion
I think that having this knowledge of "tune duration" in the `commander_helper` level, and limiting the rate of sending out the `tune_control` message with it's own logic is quite weird.

But since it's all connected to the uORB, it's quite tricky to liimit it's rate of publishing without the knowledge of the tune duration as well :shrug:
