### PR TITLE
Refactor tune control & support broken single note playing functionality

### DIFF
--- a/msg/tune_control.msg
+++ b/msg/tune_control.msg
@@ -3,7 +3,7 @@
 
 uint64 timestamp     # time since system start (microseconds)
 
-uint8 TUNE_ID_STOP                 = 0
+uint8 TUNE_ID_CUSTOM               = 0 # Plays a specified frequency / duration
 uint8 TUNE_ID_STARTUP              = 1
 uint8 TUNE_ID_ERROR                = 2
 uint8 TUNE_ID_NOTIFY_POSITIVE      = 3
@@ -24,6 +24,8 @@ uint8 TUNE_ID_PROG_PX4IO_OK        = 17
 uint8 TUNE_ID_PROG_PX4IO_ERR       = 18
 uint8 TUNE_ID_POWER_OFF            = 19
 uint8 NUMBER_OF_TUNES              = 20
+
+uint8 TUNE_ID_STOP                 = 127 # Special command to stop the tune
 
 uint8 tune_id        # tune_id corresponding to TuneID::* from the tune_defaults.h in the tunes library
 bool tune_override   # if true the tune which is playing will be stopped and the new started

--- a/src/drivers/drv_tone_alarm.h
+++ b/src/drivers/drv_tone_alarm.h
@@ -41,7 +41,6 @@
 #pragma once
 
 #include "drv_hrt.h"
-#include <lib/tunes/tune_definition.h>
 #include <uORB/topics/tune_control.h>
 
 namespace ToneAlarmInterface

--- a/src/drivers/tone_alarm/ToneAlarm.cpp
+++ b/src/drivers/tone_alarm/ToneAlarm.cpp
@@ -166,7 +166,7 @@ void ToneAlarm::Run()
 
 					break;
 
-				case Tunes::ControlResult::WouldInterrupt:
+				case Tunes::ControlResult::CantInterrupt:
 					// otherwise re-publish tune to process next
 					PX4_DEBUG("tune already playing, requeing tune: %d", tune_control.tune_id);
 					{

--- a/src/lib/tunes/CMakeLists.txt
+++ b/src/lib/tunes/CMakeLists.txt
@@ -32,8 +32,8 @@
 ############################################################################
 
 px4_add_library(tunes
-	default_tunes.cpp
-	tune_definition.h
+	tune_definitions.h
+	tune_definitions.cpp
 	tunes.cpp
 	tunes.h
 )

--- a/src/lib/tunes/tune_definitions.cpp
+++ b/src/lib/tunes/tune_definitions.cpp
@@ -74,4 +74,4 @@ const bool Tunes::_default_tunes_interruptable[] = {
 #undef PX4_DEFINE_TUNE
 
 // Set the default_tunes array size
-const unsigned int Tunes::_default_tunes_size =  sizeof(_default_tunes) / sizeof(_default_tunes[0]);
+const unsigned int Tunes::_default_tunes_count =  sizeof(_default_tunes) / sizeof(_default_tunes[0]);

--- a/src/lib/tunes/tune_definitions.cpp
+++ b/src/lib/tunes/tune_definitions.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,24 +32,46 @@
  ****************************************************************************/
 
 /**
- * @file default_tunes.h
+ * @file tune_definitions.cpp
+ *
+ * Includes definitions for the arrays defined in the scope of Tunes class library
  */
 
 #include "tunes.h"
 
+/**
+ * @brief Define default tune MML strings
+ *
+ * It will generate the list of MML strings somewhat like:
+ *
+ * const char *const Tunes::_default_tunes[] = {
+ * 	"",
+ * 	"MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc",
+ * 	...
+ * };
+ */
 #define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) tune,
-// Initialize default tunes
 const char *const Tunes::_default_tunes[] = {
-#include "tune_definition.desc"
+#include "tune_definitions.desc"
 };
 #undef PX4_DEFINE_TUNE
 
+/**
+ * @brief Define a bool list indicating if each default tunes are interruptable
+ *
+ * It will be somewhat like:
+ *
+ * const bool Tunes::_default_tunes_interruptable[] = {
+ *	true,
+ *	true,
+ * 	...
+ * };
+ */
 #define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) interruptable,
-// Initialize default tunes
 const bool Tunes::_default_tunes_interruptable[] = {
-#include "tune_definition.desc"
+#include "tune_definitions.desc"
 };
 #undef PX4_DEFINE_TUNE
 
-// set default_tunes array size
+// Set the default_tunes array size
 const unsigned int Tunes::_default_tunes_size =  sizeof(_default_tunes) / sizeof(_default_tunes[0]);

--- a/src/lib/tunes/tune_definitions.desc
+++ b/src/lib/tunes/tune_definitions.desc
@@ -32,15 +32,14 @@
  ****************************************************************************/
 
 /**
- * Driver for the PX4 audio .
+ * Definitions of settings for the default tunes inside PX4
  *
- * The tune_control supports a set of predefined "alarm" tunes and
- * one user-supplied tune.
+ * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY statement, with some exceptions and extensions.
  *
- * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY
- * statement, with some exceptions and extensions.
+ * If you are curious about the original Microsoft BASIC MML (Music Macro Language), read here:
+ * http://www.vgmpf.com/Wiki/index.php?title=Microsoft_BASIC_MML
  *
- * From Wikibooks:
+ * Syntax description:
  *
  * PLAY "[string expression]"
  *
@@ -77,9 +76,8 @@
  *
  * Extensions/variations:
  *
- * MB MF  The MF command causes the tune to play once and then stop. The MB command causes the
- *        tune to repeat when it ends.
- *
+ * MF     The MF command causes the tune to play once and then stop.
+ * MB     The MB command causes the tune to repeat when it ends.
  */
 
 

--- a/src/lib/tunes/tune_definitions.desc
+++ b/src/lib/tunes/tune_definitions.desc
@@ -80,6 +80,13 @@
  * MB     The MB command causes the tune to repeat when it ends.
  */
 
+/*
+ * NOTE : These tunes must match the TUNE_ID* constants defined in the tune_control.msg file!
+ *
+ * Since the tune_definitions.h generates the TuneID enum based on this definitions below,
+ * if the order goes out of sync, the tune_control uORB message may trigger an unexpected
+ * tune from the list below!
+ */
 
 //           ordinal name                  tune                                        interruptible*     hint
 //  * Repeated tunes should always be defined as interruptible, if not an explicit 'tone_control stop' is needed

--- a/src/lib/tunes/tune_definitions.h
+++ b/src/lib/tunes/tune_definitions.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,11 +31,32 @@
  *
  ****************************************************************************/
 
+/**
+ * @file tune_definitions.h
+ *
+ * Includes definition for the Tune related enum used in tunes.h and tunes.cpp.
+ * The enum is used in the tune.h, which is why it needs to be defined in this separated header,
+ * while other arrays are instantiated in 'tune_definitinos.cpp'
+ */
+
 #pragma once
 
+/**
+ * @brief Define TuneID enums using the 'tune_definitions.desc' file
+ *
+ * This is done by cleverly defining the 'PX4_DEFINE_TUNE' locally, using only the 'name' component,
+ * and using it inside the definition for the enum class TuneID. Therefore the line below will end up like:
+ *
+ * enum class TuneID {
+ *	CUSTOM,
+ * 	STARTUP,
+ * 	...
+ * 	NONE = -1
+ * };
+ */
 #define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) name,
 enum class TuneID {
-#include "tune_definition.desc"
+#include "tune_definitions.desc"
 	NONE = -1
 };
 #undef PX4_DEFINE_TUNE

--- a/src/lib/tunes/tune_definitions.h
+++ b/src/lib/tunes/tune_definitions.h
@@ -57,6 +57,7 @@
 #define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) name,
 enum class TuneID {
 #include "tune_definitions.desc"
-	NONE = -1
+	STOP = 127, // Special Tune ID that stops the tune
+	NONE = -1   // Undefined Tune ID
 };
 #undef PX4_DEFINE_TUNE

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -40,7 +40,8 @@
 #include <errno.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/tune_control.h>
-#include "tune_definition.h"
+
+#include "tune_definitions.h"
 
 #define TUNE_DEFAULT_NOTE_LENGTH 4
 #define TUNE_DEFAULT_OCTAVE 4

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -70,7 +70,7 @@ public:
 		Success = 0,
 		AlreadyPlaying = 1,
 		InvalidTune = -EINVAL,
-		WouldInterrupt = -EBUSY,
+		CantInterrupt = -EBUSY,
 	};
 
 	/**
@@ -93,7 +93,7 @@ public:
 	 * or the tune being already played is a repeated tune.
 	 * @param  tune_control struct containig the uORB message
 	 * @return              return ControlResult::InvalidTune if the default tune does not exist,
-	 * 			ControlResult::WouldInterrupt if tune was already playing and not interruptible,
+	 * 			ControlResult::CantInterrupt if tune was already playing and not interruptible,
 	 * 			ControlResult::AlreadyPlaying if same tune was already playing,
 	 * 			ControlResult::Success if new tune was set.
 	 */
@@ -136,7 +136,7 @@ public:
 	 *  requested via its tune ID.
 	 *  @return             Number of default tunes accessible via tune ID
 	 */
-	unsigned int get_default_tunes_size() const {return _default_tunes_size;}
+	unsigned int get_default_tunes_count() const {return _default_tunes_count;}
 
 	unsigned int get_maximum_update_interval() {return (unsigned int)TUNE_MAX_UPDATE_INTERVAL_US;}
 
@@ -206,14 +206,14 @@ private:
 
 	static const char *const  _default_tunes[];
 	static const bool         _default_tunes_interruptable[];
-	static const unsigned int _default_tunes_size;
+	static const unsigned int _default_tunes_count;
 	static const uint8_t      _note_tab[];
 
-	const char *_next_tune      = nullptr; ///< next note in the string
-	const char *_tune           = nullptr; ///< current tune string
-	const char *_tune_start_ptr = nullptr; ///< pointer to repeat tune
+	const char *_next_note_pointer      = nullptr; ///< next note in the string
+	const char *_tune_str           = nullptr; ///< current tune string
+	const char *_tune_str_start = nullptr; ///< pointer to repeat tune
 
-	int _current_tune_id = static_cast<int>(TuneID::NONE);
+	TuneID _current_tune_id = TuneID::NONE;
 
 	bool _repeat = false; ///< if true, tune restarts at end
 

--- a/src/modules/events/rc_loss_alarm.cpp
+++ b/src/modules/events/rc_loss_alarm.cpp
@@ -43,8 +43,6 @@
 #include <drivers/drv_hrt.h>
 #include <stdint.h>
 
-#include <tunes/tune_definition.h>
-
 namespace events
 {
 namespace rc_loss


### PR DESCRIPTION
**Describe problem solved by this pull request**
1. `tune_control play -f 1500 -d 500000` (Command to play a single note) was broken, so you couldn't actually use this single note play feature of `tune_control`
2. Whenever `tune_control` uORB message was getting sent with the tune id of `TUNE_ID_STOP`, it was actually making the tune library enter `CUSTOM` tune mode, which should only be used to play a custom frequency / duration.
   * The only reason nobody noticed this so far was because the CUSTOM tune has an "" (empty string) defined in the `tune_definitions.desc`.
3. Rename and add comments to ambiguous parts of the code to improve readability

**Describe your solution**
1. Support single note playing command in `tune_control` module appropriately
2. Added the STOP tune ID separately as a custom command / tune-id, and decouple it from original implementation where it mixed it up with CUSTOM tune id.
3. Rename and re-structure `tune_descriptions.h and .cpp` to make the file / code more clear to the developers.
4. Remove `libtest` command from `tune_control`, as it doesn't seem to serve much purpose :shrug: 

**Test data / coverage**
Tested on PixhawkV5X hardware (the following commands):
![image](https://user-images.githubusercontent.com/23277211/168300286-b4ae9809-ba4b-4251-b4e0-97deb311fb57.png)
- `tune_control play -t 12`
- `tune_control play note -f 1500 -d 500000`
- `tune_control play error`
- `tune_control stop`

**Additional context**
- [x] I have removed the header inclusion from files like `src/drivers/drv_tone_alarm.h`, is this ok? It seems to compile fine but wanted to make sure this isn't done accidentally.