### PR TITLE
airspeed_selector_main: plug in numbers in switch event message

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -623,7 +623,7 @@ void AirspeedModule::select_airspeed_and_publish()
 			 * @description Previously selected sensor index: {1}, current sensor index: {2}.
 			 */
 			events::send<uint8_t, uint8_t>(events::ID("airspeed_selector_estimation_regain"), events::Log::Info,
-						       "Airspeed sensor healthy, start using again", _prev_airspeed_index,
+						       "Airspeed sensor healthy, start using again ({1}, {2})", _prev_airspeed_index,
 						       _valid_airspeed_index);
 		}
 	}


### PR DESCRIPTION
**Describe problem solved by this pull request**
I was checking on an example on how to send numbers in an event and found that the numbers in the airspeed selector are not plugged into the message. Is this just not necessary, they get appended to the message anyways and I'm being extra verbose here? Or was this just forgotten? I'm also not sure how they would be appended e.g. without space between them and so on?

**Describe your solution**
I'm plugging in the numbers like it's done in the legacy `mavlink_log_info()` message just above.

**Test data / coverage**
I did not test this. Just changed according to my observation of how it works.