### PR TITLE
Land amid mission

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2377,7 +2377,10 @@ Commander::run()
 			// Check for auto-disarm on landing or pre-flight
 			if (_param_com_disarm_land.get() > 0 || _param_com_disarm_preflight.get() > 0) {
 
-				if (_param_com_disarm_land.get() > 0 && _have_taken_off_since_arming) {
+				const bool landed_amid_mission = (_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION)
+								 && !_mission_result_sub.get().finished;
+
+				if (_param_com_disarm_land.get() > 0 && _have_taken_off_since_arming && !landed_amid_mission) {
 					_auto_disarm_landed.set_hysteresis_time_from(false, _param_com_disarm_land.get() * 1_s);
 					_auto_disarm_landed.set_state_and_update(_vehicle_land_detected.landed, hrt_absolute_time());
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
Goal: As part of one mission without user intervention land at a waypoint, wait a specified time without disarming and then takeoff again and continue with other mission items.

**Describe your solution**
I had these problems on the radar:
1. No easy way to plan such a mission.
  No blocking issue. In QGC I can plan a land waypoint (to zero meters above ground whatever effect that has, violates terrain collision) a "Delay until" waypoint with a specified delay time and then further waypoints.
  ![image](https://user-images.githubusercontent.com/4668506/168585754-eb595272-5b84-4d7e-9cc9-95f564cf4a6c.png)
1. Landing would not get accepted and it would not continue to the next item.
  No issue, worked out of the box. Land item is accepted upon land detection:
  https://github.com/PX4/PX4-Autopilot/blob/3fe4c6e3f56d68417918454188a3f968c1e5ccd6/src/modules/navigator/mission_block.cpp#L82-L83
1. The drone disarms upon land detection like it's usually expected.
  Solved with 514fc03412d6264250a1352a99f35d39cf60faea. Not disarming upon land detection when flying a mission and it not being finished yet (`mission_result.finished`).
1. While testing I found out that the "delay until" does not work when landed for implementation details reasons.
  Solved with afa35486e1cdb730df80980d12410663a1b85059 Implementing the delay acceptance outside of landing depedent context.

**Test data / coverage**
I tested this a lot of times in SITL jMAVSim (multicoper) and checked with debug output it's always doing the expected sequence with various timing and waypoints.

**Additional context**
![Animation](https://user-images.githubusercontent.com/4668506/168588748-6516e457-7ec5-4073-8f9c-c76534e17716.gif)

