### PR TITLE
UCANS32K146 Fix CAN1 STB pin

### DIFF
--- a/boards/nxp/ucans32k146/src/bringup.c
+++ b/boards/nxp/ucans32k146/src/bringup.c
@@ -159,10 +159,12 @@ int s32k1xx_bringup(void)
 	if (s32k1xx_gpioread(BOARD_REVISION_DETECT_PIN)) {
 		/* STB high -> active CAN phy */
 		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ONE);
+		s32k1xx_pinconfig(PIN_CAN1_STB  | GPIO_OUTPUT_ONE);
 
 	} else {
 		/* STB low -> active CAN phy */
 		s32k1xx_pinconfig(PIN_CAN0_STB  | GPIO_OUTPUT_ZERO);
+		s32k1xx_pinconfig(PIN_CAN1_STB  | GPIO_OUTPUT_ZERO);
 	}
 
 #endif


### PR DESCRIPTION
For CAN1 STB wasn't set hence CAN1 wasn't working

This PR adds GPIO for STB pin