### PR TITLE
Adding namespace option to microDDS client

### DIFF
--- a/msg/templates/uorb_microcdr/dds_topics.h.em
+++ b/msg/templates/uorb_microcdr/dds_topics.h.em
@@ -48,11 +48,11 @@ struct SendTopicsSubs {
 
 	uint32_t num_payload_sent{};
 
-	bool init(uxrSession* session_, uxrStreamId stream_id, uxrObjectId participant_id);
+	bool init(uxrSession* session_, uxrStreamId stream_id, uxrObjectId participant_id, const std::string &client_namespace);
 	void update(uxrStreamId stream_id);
 };
 
-bool SendTopicsSubs::init(uxrSession* session_, uxrStreamId stream_id, uxrObjectId participant_id)
+bool SendTopicsSubs::init(uxrSession* session_, uxrStreamId stream_id, uxrObjectId participant_id, const std::string &client_namespace)
 {
 	session = session_;
 
@@ -63,14 +63,14 @@ topic_pascal = topic.replace("_", " ").title().replace(" ", "")
 	{
 
 		uxrObjectId topic_id = uxr_object_id(@(idx)+1, UXR_TOPIC_ID);
-		const char* topic_xml = "<dds>"
+		std::string topic_xml = "<dds>"
 				"<topic>"
-				"<name>rt/fmu/out/@(topic_pascal)</name>"
+				"<name>rt/" + client_namespace + "fmu/out/@(topic_pascal)</name>"
 				"<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
 				"</topic>"
 				"</dds>";
-		uint16_t topic_req = uxr_buffer_create_topic_xml(session, stream_id, topic_id, participant_id, topic_xml,
-						UXR_REPLACE);
+		uint16_t topic_req = uxr_buffer_create_topic_xml(session, stream_id, topic_id, participant_id,
+		                topic_xml.c_str(), UXR_REPLACE);
 
 		uxrObjectId publisher_id = uxr_object_id(@(idx)+1, UXR_PUBLISHER_ID);
 		const char* publisher_xml = "";
@@ -79,17 +79,17 @@ topic_pascal = topic.replace("_", " ").title().replace(" ", "")
 
 		uxrObjectId datawriter_id = uxr_object_id(@(idx)+1, UXR_DATAWRITER_ID);
 		@(topic)_data_writer = datawriter_id;
-		const char* datawriter_xml = "<dds>"
+		std::string datawriter_xml = "<dds>"
 				"<data_writer>"
 				"<topic>"
 				"<kind>NO_KEY</kind>"
-				"<name>rt/fmu/out/@(topic_pascal)</name>"
+				"<name>rt/" + client_namespace + "fmu/out/@(topic_pascal)</name>"
 				"<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
 				"</topic>"
 				"</data_writer>"
 				"</dds>";
 		uint16_t datawriter_req = uxr_buffer_create_datawriter_xml(session, stream_id, datawriter_id, publisher_id,
-						datawriter_xml, UXR_REPLACE);
+						datawriter_xml.c_str(), UXR_REPLACE);
 
 		// Send create entities message and wait its status
 		uint8_t status[3];
@@ -141,10 +141,10 @@ struct RcvTopicsPubs {
 
 	uint32_t num_payload_received{};
 
-	bool init(uxrSession* session_, uxrStreamId stream_id, uxrStreamId input_stream, uxrObjectId participant_id);
+	bool init(uxrSession* session_, uxrStreamId stream_id, uxrStreamId input_stream, uxrObjectId participant_id, const std::string& client_namespace);
 };
 
-bool RcvTopicsPubs::init(uxrSession* session_, uxrStreamId stream_id, uxrStreamId input_stream, uxrObjectId participant_id)
+bool RcvTopicsPubs::init(uxrSession* session_, uxrStreamId stream_id, uxrStreamId input_stream, uxrObjectId participant_id, const std::string& client_namespace)
 {
 	session = session_;
     uxr_set_topic_callback(session, on_topic_update, this);
@@ -161,25 +161,25 @@ topic_pascal = topic.replace("_", " ").title().replace(" ", "")
 		uint16_t subscriber_req = uxr_buffer_create_subscriber_xml(session, stream_id, subscriber_id, participant_id, subscriber_xml, UXR_REPLACE);
 
 		uxrObjectId topic_id = uxr_object_id(1000+@(idx), UXR_TOPIC_ID);
-		const char* topic_xml = "<dds>"
+		std::string topic_xml = "<dds>"
 				"<topic>"
-				"<name>rt/fmu/in/@(topic_pascal)</name>"
+				"<name>rt/" + client_namespace + "fmu/in/@(topic_pascal)</name>"
 				"<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
 				"</topic>"
 				"</dds>";
-		uint16_t topic_req = uxr_buffer_create_topic_xml(session, stream_id, topic_id, participant_id, topic_xml, UXR_REPLACE);
+		uint16_t topic_req = uxr_buffer_create_topic_xml(session, stream_id, topic_id, participant_id, topic_xml.c_str(), UXR_REPLACE);
 
 		uxrObjectId datareader_id = uxr_object_id(@(idx)+1, UXR_DATAREADER_ID);
-		const char* datareader_xml = "<dds>"
+		std::string datareader_xml = "<dds>"
 										 "<data_reader>"
 											 "<topic>"
 												 "<kind>NO_KEY</kind>"
-												 "<name>rt/fmu/in/@(topic_pascal)</name>"
+												 "<name>rt/" + client_namespace + "fmu/in/@(topic_pascal)</name>"
 												 "<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
 											 "</topic>"
 										 "</data_reader>"
 									 "</dds>";
-		uint16_t datareader_req = uxr_buffer_create_datareader_xml(session, stream_id, datareader_id, subscriber_id, datareader_xml, UXR_REPLACE);
+		uint16_t datareader_req = uxr_buffer_create_datareader_xml(session, stream_id, datareader_id, subscriber_id, datareader_xml.c_str(), UXR_REPLACE);
 
 		uint8_t status[3];
 		uint16_t requests[3] = {topic_req, subscriber_req, datareader_req };

--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -563,7 +563,7 @@ $ microdds_client start -t udp -h 127.0.0.1 -p 15555
 	PRINT_MODULE_USAGE_PARAM_STRING('h', "127.0.0.1", "<IP>", "Host IP", true);
 	PRINT_MODULE_USAGE_PARAM_INT('p', 15555, 0, 3000000, "Remote Port", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('l', "Restrict to localhost (use in combination with ROS_LOCALHOST_ONLY=1)", true);
-    PRINT_MODULE_USAGE_PARAM_STRING('n', "", "" ,"Client DDS namespace", true);
+    PRINT_MODULE_USAGE_PARAM_STRING('n', nullptr, nullptr ,"Client DDS namespace", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;

--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -49,7 +49,7 @@ public:
 	};
 
 	MicroddsClient(Transport transport, const char *device, int baudrate, const char *host, const char *port,
-		       bool localhost_only, const char* client_namespace);
+		       bool localhost_only, const char *client_namespace);
 
 	~MicroddsClient();
 
@@ -75,7 +75,7 @@ private:
 	int setBaudrate(int fd, unsigned baud);
 
 	const bool _localhost_only;
-    std::string _client_namespace;
+	char *_client_namespace;
 
 	SendTopicsSubs *_subs{nullptr};
 	RcvTopicsPubs *_pubs{nullptr};

--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -49,7 +49,7 @@ public:
 	};
 
 	MicroddsClient(Transport transport, const char *device, int baudrate, const char *host, const char *port,
-		       bool localhost_only);
+		       bool localhost_only, const char* client_namespace);
 
 	~MicroddsClient();
 
@@ -75,6 +75,7 @@ private:
 	int setBaudrate(int fd, unsigned baud);
 
 	const bool _localhost_only;
+    std::string _client_namespace;
 
 	SendTopicsSubs *_subs{nullptr};
 	RcvTopicsPubs *_pubs{nullptr};


### PR DESCRIPTION
This pr allows adding a **namespace** to the microDDS client.
The participant will be named /**namespace**/px4_xrce_participant while the topics will appear as **/namespace**/fmu/...
This allows having multiple instances of the PX4 Autopilot on the same network.
The namespace can be set as an optional argument of the microdds client. 
The default namespace is empty and does not affect the current topic names.