### PR TITLE
Add range fields to accel/gyro/FIFO messages and constrain multicopter attitude controller to sensor dynamic limits

### DIFF
--- a/msg/SensorAccel.msg
+++ b/msg/SensorAccel.msg
@@ -3,16 +3,20 @@ uint64 timestamp_sample
 
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
-float32 x                 # acceleration in the FRD board frame X-axis in m/s^2
-float32 y                 # acceleration in the FRD board frame Y-axis in m/s^2
-float32 z                 # acceleration in the FRD board frame Z-axis in m/s^2
-
 float32 temperature       # temperature in degrees Celsius
+
+float32 scale             # sensor resolution scale (LSB/g)
+
+float32 dynamic_range     # dynamic range of the sensor (m/s^2)
 
 uint32 error_count
 
 uint8[3] clip_counter     # clip count per axis in the sample period
 
 uint8 samples             # number of raw samples that went into this message
+
+float32 x                 # acceleration in the FRD board frame X-axis in m/s^2
+float32 y                 # acceleration in the FRD board frame Y-axis in m/s^2
+float32 z                 # acceleration in the FRD board frame Z-axis in m/s^2
 
 uint8 ORB_QUEUE_LENGTH = 8

--- a/msg/SensorAccelFifo.msg
+++ b/msg/SensorAccelFifo.msg
@@ -4,7 +4,10 @@ uint64 timestamp_sample
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
 float32 dt                # delta time between samples (microseconds)
-float32 scale
+
+float32 scale             # sensor resolution scale (LSB/g)
+
+float32 dynamic_range     # dynamic range of the sensor (m/s^2)
 
 uint8 samples             # number of valid samples
 

--- a/msg/SensorGyro.msg
+++ b/msg/SensorGyro.msg
@@ -3,16 +3,20 @@ uint64 timestamp_sample
 
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
-float32 x                 # angular velocity in the FRD board frame X-axis in rad/s
-float32 y                 # angular velocity in the FRD board frame Y-axis in rad/s
-float32 z                 # angular velocity in the FRD board frame Z-axis in rad/s
-
 float32 temperature       # temperature in degrees Celsius
+
+float32 scale             # sensor resolution scale (LSB/dps)
+
+float32 dynamic_range     # dynamic range of the gyro (degs/s)
 
 uint32 error_count
 
 uint8[3] clip_counter     # clip count per axis in the sample period
 
 uint8 samples             # number of raw samples that went into this message
+
+float32 x                 # angular velocity in the FRD board frame X-axis in rad/s
+float32 y                 # angular velocity in the FRD board frame Y-axis in rad/s
+float32 z                 # angular velocity in the FRD board frame Z-axis in rad/s
 
 uint8 ORB_QUEUE_LENGTH = 8

--- a/msg/SensorGyroFifo.msg
+++ b/msg/SensorGyroFifo.msg
@@ -4,7 +4,10 @@ uint64 timestamp_sample
 uint32 device_id          # unique device ID for the sensor that does not change between power cycles
 
 float32 dt                # delta time between samples (microseconds)
-float32 scale
+
+float32 scale             # sensor resolution scale (LSB/dps)
+
+uint16 dynamic_range      # dynamic range of the sensor (degs/s)
 
 uint8 samples             # number of valid samples
 

--- a/msg/VehicleAngularVelocity.msg
+++ b/msg/VehicleAngularVelocity.msg
@@ -6,4 +6,6 @@ float32[3] xyz		  # Bias corrected angular velocity about the FRD body frame XYZ
 
 float32[3] xyz_derivative # angular acceleration about the FRD body frame XYZ-axis in rad/s^2
 
+float32 dynamic_range    # dynamic range of the gyro (rad/s)
+
 # TOPICS vehicle_angular_velocity vehicle_angular_velocity_groundtruth

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -117,20 +117,23 @@ void PX4Accelerometer::update(const hrt_abstime &timestamp_sample, float x, floa
 	rotate_3f(_rotation, x, y, z);
 
 	// publish
-	sensor_accel_s report;
+	sensor_accel_s report{};
 
 	report.timestamp_sample = timestamp_sample;
-	report.device_id = _device_id;
-	report.temperature = _temperature;
-	report.error_count = _error_count;
-	report.x = x * _scale;
-	report.y = y * _scale;
-	report.z = z * _scale;
-	report.clip_counter[0] = (fabsf(x) >= _clip_limit);
-	report.clip_counter[1] = (fabsf(y) >= _clip_limit);
-	report.clip_counter[2] = (fabsf(z) >= _clip_limit);
-	report.samples = 1;
-	report.timestamp = hrt_absolute_time();
+	report.device_id        = _device_id;
+	report.temperature      = _temperature;
+	report.scale            = _scale;
+	report.dynamic_range    = _dynamic_range;
+	report.error_count      = _error_count;
+	report.clip_counter[0]  = (fabsf(x) >= _clip_limit);
+	report.clip_counter[1]  = (fabsf(y) >= _clip_limit);
+	report.clip_counter[2]  = (fabsf(z) >= _clip_limit);
+	report.samples          = 1;
+	report.x                = x * _scale;
+	report.y                = y * _scale;
+	report.z                = z * _scale;
+
+	report.timestamp        = hrt_absolute_time();
 
 	_sensor_pub.publish(report);
 }
@@ -145,17 +148,26 @@ void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 	}
 
 	sample.device_id = _device_id;
-	sample.scale = _scale;
+	sample.scale     = _scale;
 	sample.timestamp = hrt_absolute_time();
+
 	_sensor_fifo_pub.publish(sample);
 
-
 	// publish
-	sensor_accel_s report;
+	sensor_accel_s report{};
+
 	report.timestamp_sample = sample.timestamp_sample;
-	report.device_id = _device_id;
-	report.temperature = _temperature;
-	report.error_count = _error_count;
+	report.device_id        = _device_id;
+	report.temperature      = _temperature;
+	report.scale            = _scale;
+	report.dynamic_range    = _dynamic_range;
+	report.error_count      = _error_count;
+
+	report.clip_counter[0] = clipping(sample.x, N);
+	report.clip_counter[1] = clipping(sample.y, N);
+	report.clip_counter[2] = clipping(sample.z, N);
+
+	report.samples         = N;
 
 	// trapezoidal integration (equally spaced)
 	const float scale = _scale / (float)N;
@@ -167,10 +179,6 @@ void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 	_last_sample[1] = sample.y[N - 1];
 	_last_sample[2] = sample.z[N - 1];
 
-	report.clip_counter[0] = clipping(sample.x, N);
-	report.clip_counter[1] = clipping(sample.y, N);
-	report.clip_counter[2] = clipping(sample.z, N);
-	report.samples = N;
 	report.timestamp = hrt_absolute_time();
 
 	_sensor_pub.publish(report);
@@ -179,5 +187,5 @@ void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 void PX4Accelerometer::UpdateClipLimit()
 {
 	// 99.9% of potential max
-	_clip_limit = math::constrain((_range / _scale) * 0.999f, 0.f, (float)INT16_MAX);
+	_clip_limit = math::constrain((_dynamic_range / _scale) * 0.999f, 0.f, (float)INT16_MAX);
 }

--- a/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.hpp
@@ -53,7 +53,7 @@ public:
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);
 	void set_error_count(uint32_t error_count) { _error_count = error_count; }
-	void set_range(float range) { _range = range; UpdateClipLimit(); }
+	void set_range(float range) { _dynamic_range = range; UpdateClipLimit(); }
 	void set_scale(float scale);
 	void set_temperature(float temperature) { _temperature = temperature; }
 
@@ -74,11 +74,11 @@ private:
 
 	int32_t			_imu_gyro_rate_max{0}; // match gyro max rate
 
-	float			_range{16 * CONSTANTS_ONE_G};
+	float			_dynamic_range{16 * CONSTANTS_ONE_G};
 	float			_scale{1.f};
 	float			_temperature{NAN};
 
-	float			_clip_limit{_range / _scale};
+	float			_clip_limit{_dynamic_range / _scale};
 
 	uint32_t		_error_count{0};
 

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -52,7 +52,7 @@ public:
 	void set_device_id(uint32_t device_id) { _device_id = device_id; }
 	void set_device_type(uint8_t devtype);
 	void set_error_count(uint32_t error_count) { _error_count = error_count; }
-	void set_range(float range) { _range = range; UpdateClipLimit(); }
+	void set_range(float range) { _dynamic_range = range; UpdateClipLimit(); }
 	void set_scale(float scale);
 	void set_temperature(float temperature) { _temperature = temperature; }
 
@@ -73,11 +73,11 @@ private:
 
 	int32_t			_imu_gyro_rate_max{0};
 
-	float			_range{math::radians(2000.f)};
+	float			_dynamic_range{math::radians(2000.f)};
 	float			_scale{1.f};
 	float			_temperature{NAN};
 
-	float			_clip_limit{_range / _scale};
+	float			_clip_limit{_dynamic_range / _scale};
 
 	uint32_t		_error_count{0};
 

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -179,6 +179,14 @@ MulticopterRateControl::Run()
 				_rates_setpoint(0) = PX4_ISFINITE(vehicle_rates_setpoint.roll)  ? vehicle_rates_setpoint.roll  : rates(0);
 				_rates_setpoint(1) = PX4_ISFINITE(vehicle_rates_setpoint.pitch) ? vehicle_rates_setpoint.pitch : rates(1);
 				_rates_setpoint(2) = PX4_ISFINITE(vehicle_rates_setpoint.yaw)   ? vehicle_rates_setpoint.yaw   : rates(2);
+
+				// ensure the rate setpoint is constrained within the dynamic range of the sensor
+				const float dynamic_range{static_cast<float>(angular_velocity.dynamic_range)};
+
+				math::constrain(_rates_setpoint(0), -dynamic_range, dynamic_range);
+				math::constrain(_rates_setpoint(1), -dynamic_range, dynamic_range);
+				math::constrain(_rates_setpoint(2), -dynamic_range, dynamic_range);
+
 				_thrust_setpoint = Vector3f(vehicle_rates_setpoint.thrust_body);
 			}
 		}

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -852,7 +852,8 @@ void VehicleAngularVelocity::Run()
 				if (!_sensor_gyro_fifo_sub.updated()) {
 					if (CalibrateAndPublish(sensor_fifo_data.timestamp_sample,
 								angular_velocity_uncalibrated,
-								angular_acceleration_uncalibrated)) {
+								angular_acceleration_uncalibrated,
+								sensor_fifo_data.dynamic_range)) {
 
 						perf_end(_cycle_perf);
 						return;
@@ -894,7 +895,8 @@ void VehicleAngularVelocity::Run()
 				if (!_sensor_sub.updated()) {
 					if (CalibrateAndPublish(sensor_data.timestamp_sample,
 								angular_velocity_uncalibrated,
-								angular_acceleration_uncalibrated)) {
+								angular_acceleration_uncalibrated,
+								sensor_data.dynamic_range)) {
 
 						perf_end(_cycle_perf);
 						return;
@@ -914,7 +916,8 @@ void VehicleAngularVelocity::Run()
 
 bool VehicleAngularVelocity::CalibrateAndPublish(const hrt_abstime &timestamp_sample,
 		const Vector3f &angular_velocity_uncalibrated,
-		const Vector3f &angular_acceleration_uncalibrated)
+		const Vector3f &angular_acceleration_uncalibrated,
+		const uint16_t dynamic_range)
 {
 	if (timestamp_sample >= _last_publish + _publish_interval_min_us) {
 
@@ -929,6 +932,8 @@ bool VehicleAngularVelocity::CalibrateAndPublish(const hrt_abstime &timestamp_sa
 		// Angular acceleration: rotate sensor frame to board, scale raw data to SI, apply any additional configured rotation
 		_angular_acceleration = _calibration.rotation() * angular_acceleration_uncalibrated;
 		_angular_acceleration.copyTo(angular_velocity.xyz_derivative);
+
+		angular_velocity.dynamic_range = dynamic_range;
 
 		angular_velocity.timestamp = hrt_absolute_time();
 		_vehicle_angular_velocity_pub.publish(angular_velocity);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -76,7 +76,7 @@ private:
 	void Run() override;
 
 	bool CalibrateAndPublish(const hrt_abstime &timestamp_sample, const matrix::Vector3f &angular_velocity_uncalibrated,
-				 const matrix::Vector3f &angular_acceleration_uncalibrated);
+				 const matrix::Vector3f &angular_acceleration_uncalibrated, const uint16_t dynamic_range);
 
 	inline float FilterAngularVelocity(int axis, float data[], int N = 1);
 	inline float FilterAngularAcceleration(int axis, float inverse_dt_s, float data[], int N = 1);


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR add range fields to accel/gyro/FIFO messages and constrains attitude controller rate setpoints within gyro sensor dynamic range.

**Describe your solution**
Rates controllers should, under best circumstances, never ask for more rotational rate than the IMU sensors can measure.  This PR enforces that paradigm.

**Describe possible alternatives**
Rates setpoints are currently not forcibly held within the dynamic range of the sensor.  The status quo is obviously acceptable, however, as we know it works just fine.

**Test data / coverage**
Flight tested on a 250 racer pixhawk 4 mini: https://review.px4.io/plot_app?log=ad685f23-9aef-4d02-b696-58ade1d63938

**Additional Context**
Follows and is simplified greatly by #19673
