### PR TITLE
ubuntu.sh: new gazebo package in 22.04

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -200,13 +200,12 @@ if [[ $INSTALL_SIM == "true" ]]; then
 
 	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
 		java_version=11
-		gazebo_version=9
 	elif [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
 		java_version=13
-		gazebo_version=11
+	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
+		java_version=11
 	else
 		java_version=14
-		gazebo_version=11
 	fi
 	# Java (jmavsim or fastrtps)
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
@@ -220,20 +219,30 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	sudo update-alternatives --set java $(update-alternatives --list java | grep "java-$java_version")
 
 	# Gazebo
+	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
+		gazebo_version=9
+		gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
+	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
+		gazebo_packages="gazebo libgazebo-dev"
+	else
+		# default and Ubuntu 20.04
+		gazebo_version=11
+		gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
+	fi
+
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	# Update list, since new gazebo-stable.list has been added
 	sudo apt-get update -y --quiet
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		dmidecode \
-		gazebo$gazebo_version \
+		$gazebo_packages \
 		gstreamer1.0-plugins-bad \
 		gstreamer1.0-plugins-base \
 		gstreamer1.0-plugins-good \
 		gstreamer1.0-plugins-ugly \
 		gstreamer1.0-libav \
 		libeigen3-dev \
-		libgazebo$gazebo_version-dev \
 		libgstreamer-plugins-base1.0-dev \
 		libimage-exiftool-perl \
 		libopencv-dev \


### PR DESCRIPTION
Fixes gazebo and openjdk versions in installation script for ubuntu 22.04.

On Ubuntu 22.04 the packages `gazebo11` and `libgazebo11-dev` do not exist. The packages `gazebo` and `libgazebo-dev` (without a version number) seem to be at the correct version though:

```
apt show gazebo
Package: gazebo
Version: 11.10.2+dfsg-1
...
```

```
apt show libgazebo-dev
Package: libgazebo-dev
Version: 11.10.2+dfsg-1
```

I verified the installation with 
```
make px4_sitl gaebo
```
It compiles fine and the drone is flying :sweat_smile: 

As for openJDK, Ubuntu 22.04 dropped openjdk13 specifically. Using openjdk17 doesn't work with jMAVSim, so I opted for the older openjdk11 that is still available and also used on 18.04. Alternatively we could download openjdk13 from https://download.java.net/openjdk/, but I don't think it's worth the hassle if version 11 works just as well.

----- 
Tested on a fresh PopOS installation as well as inside an ubuntu:22.04 docker image.