### PR TITLE
commander_params: shorten low battery action delay

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -296,7 +296,7 @@ PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
  * @max 25.0
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(COM_BAT_ACT_T, 10.0f);
+PARAM_DEFINE_FLOAT(COM_BAT_ACT_T, 5.f);
 
 /**
  * Imbalanced propeller failsafe mode


### PR DESCRIPTION
**Describe problem solved by this pull request**
I got multiple times the feedback now that a consistent delay is helpful and makes sense but the default delay is too long for low battery action where you're trying to come back in time and possibly the emergency reaction kicks in while the critical action is executing which leads to a longer accumulated delay.


**Describe your solution**
5 seconds are enough to understand what's going on and react if necessary. Otherwise this delay can be configured longer for specific use cases.

**Additional context**
Original introduction of the feature: https://github.com/PX4/PX4-Autopilot/pull/19033
