### PR TITLE
commander: lockdown is not termination

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2932,7 +2932,7 @@ Commander::run()
 			checkWindSpeedThresholds();
 		}
 
-		_status_flags.flight_terminated = _armed.force_failsafe || _armed.lockdown || _armed.manual_lockdown;
+		_status_flags.flight_terminated = _armed.force_failsafe || _armed.manual_lockdown;
 
 		/* Get current timestamp */
 		const hrt_abstime now = hrt_absolute_time();


### PR DESCRIPTION
We use lockdown to prevent outputs like motors and servos from being active in HITL simulation. This means that we can't treat the lockdown flag as a flight_terminated, otherwise we can't arm in HITL at all.

I suggest to merge this for now and then revisit the termination and lockdown topic another time.

Related to: https://github.com/PX4/PX4-Autopilot/pull/19419.