### PR TITLE
Commander: ignore MAV_CMD_REQUEST_MSG

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1614,6 +1614,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 	case vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
 	case vehicle_command_s::VEHICLE_CMD_CONFIGURE_ACTUATOR:
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ACTUATOR:
+	case vehicle_command_s::VEHICLE_CMD_REQUEST_MESSAGE:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
When starting vmount with MAVLink gimbal v2 as the output, the blue LED on the FMU blinks irregularly, because vmount publishes a MAV_CMD_DO_REQUEST_MESSAGE, which isn't known to commander.

**Describe your solution**
This commit adds the MAV_CMD_REQUEST_MESSAGE to the list of vehicle
commands which are ignored without generating a warning sound.

**Describe possible alternatives**
I'm open to inputs, but I think this is how it's done

**Test data / coverage**
On my bench, it no longer triggers the "Command unsupported" beep & blink when starting vmount.
