### PR TITLE
scripts: Hotfix px_uploader.py to avoid PX4BL bug

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -136,8 +136,11 @@ class firmware(object):
 
         self.image = bytearray(zlib.decompress(base64.b64decode(self.desc['image'])))
 
-        # pad image to 4-byte length
-        while ((len(self.image) % 4) != 0):
+        # PX4 bootloader in theory requires only 4-byte padding,
+        # but a bug exists with the flash block caching where if the data
+        # does not fill up the block, it will not be written (left as all 1s).
+        # So pad up to the flash block size (8 words).
+        while ((len(self.image) % (4 * 8)) != 0):
             self.image.extend(b'\xff')
 
     def property(self, propname):


### PR DESCRIPTION
## Describe problem solved by this pull request
We were experiencing a this hardfault while opening mavlink shell
```
[hardfault_log] -- 2022-05-19-22:12:56 Begin Fault Log --                                                            
System fault Occurred on: 2022-05-19-22:12:56                                                                        
 Type:Hard Fault in file:armv7-m/up_hardfault.c at line: 148 running task: mavlink_rcv_if2                           
 FW git-hash: b188bcb465002613d3a45a7cc1a3a6aff8f62ae0                                                               
 Build datetime: May 18 2022 19:59:10                                                                                
 Build url: localhost                                                                                                
 Processor registers: from 0x30012314                                                                                
 r0:0xffffffff r1:0x2400101c  r2:0x30011a90  r3:0x2400585c  r4:0xffffffff  r5:0x24001020 r6:0x30011a90 r7:0x00000002 
 r8:0x30012750 r9:0x00000021 r10:0x00000000 r11:0x00000000 r12:0x0000000a  sp:0x300123e8 lr:0x08023633 pc:0x08024608 
 xpsr:0x01000000 basepri:0x00000080 control:0x00000004                                                               
 exe return:0xffffffe9                                                                                                                                           
```
The call stack matched what @LorenzMeier found in #17063.
It appeared with a single-line change in a completely unrelated file.

This is caused by the semaphore `g_pipesem` being initialized to invalid data (all 1s) when copied from flash to sram.

Here are the last few bytes of the firmware .bin file.  `g_pipesem` is at `0x19ada4`.
```
0019ad80  00 00 00 00 00 00 00 00  00 00 00 00 01 00 00 00  |................|
0019ad90  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
0019ada0  ff ff 01 00 01 00 00 00  00 00 00 00 00 00 00 00  |................|
0019adb0  00 00 00 00 00 00 00 00  ff                       |.........|
```
Here what is actually on the device immediately after flashing in BL and before jumping to application (addresses are offset by `0x08020000` from what is above)
```
(gdb) x/32wx 0x81bad80
0x81bad80:      0x00000000      0x00000000      0x00000000      0x00000001
0x81bad90:      0x00000000      0x00000000      0x00000000      0x00000000
0x81bada0:      0xffffffff      0xffffffff      0xffffffff      0xffffffff
0x81badb0:      0xffffffff      0xffffffff      0xffffffff      0xffffffff
```

The data gets written to the [flash cache](https://github.com/PX4/PX4-Autopilot/blob/422be90140c9dee6f0e59ee4d181301b13fb11de/platforms/nuttx/src/bootloader/common/lib/flash_cache.c), but if it does not fill up the flash block, then it never actually writes the data. The [read-back verify](https://github.com/PX4/PX4-Autopilot/blob/422be90140c9dee6f0e59ee4d181301b13fb11de/platforms/nuttx/src/bootloader/common/bl.c#L838-L839) does not catch this because it only reads from the cache.

The specific hardfault occurs only happens when `g_pipesem` is placed at the end of the firmware image and the length of the image. In theory any variable in `.data` could be incorrectly initialized, and the behavior widely varies with small changes to the source code.

The flash cache was originally only required on STM32H7, but since [this commit](https://github.com/PX4/PX4-Autopilot/commit/64d264b49a072e29044fc6132113de41698152ec) (v1.12) it is used for the bootloader on all platforms. I suspect this is the root cause of #17065 and #19308.

## Describe your solution
Pad the firmware image in `px_uploader.py` up to a flash cache block so all data will be written.

## Describe possible alternatives
It would be better to fix the cache implementation in the bootloader, but this fix is easy and works with all current bootloaders.

## Test data / coverage
Bench test shows that the same firmware binary is correctly written and does not hardfault with this change.
