### PR TITLE
ROMFS: disable UAVCAN in HITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/1000_rc_fw_easystar.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1000_rc_fw_easystar.hil
@@ -61,6 +61,8 @@ param set-default HIL_ACT_FUNC6 400
 
 param set SYS_HITL 1
 
+param set UAVCAN_ENABLE 0
+
 # disable some checks to allow to fly
 # - with usb
 param set-default CBRK_USB_CHK 197848

--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -15,6 +15,8 @@ set MIXER quad_x
 
 param set SYS_HITL 1
 
+param set UAVCAN_ENABLE 0
+
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_ROTOR0_PX 0.15
 param set-default CA_ROTOR0_PY 0.15

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -94,6 +94,8 @@ param set-default HIL_ACT_FUNC8 203
 
 param set SYS_HITL 1
 
+param set UAVCAN_ENABLE 0
+
 # disable some checks to allow to fly
 # - with usb
 param set-default CBRK_USB_CHK 197848


### PR DESCRIPTION
Without this, uavcan creates MixingOutput classes which then create empty actuator_outputs publications. This then prevents the motor output in HITL to be forwarded to the simulator via mavlink.

As suggested by @NicolasM0 in https://github.com/PX4/PX4-Autopilot/issues/18668

Closes https://github.com/PX4/PX4-Autopilot/issues/19667.