### PR TITLE
sensors/vehicle_magnetometer: fix multi_mode check

### DIFF
--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -486,7 +486,7 @@ void VehicleMagnetometer::Run()
 	// Publish
 	if (_param_sens_mag_rate.get() > 0) {
 		int interval_us = 1e6f / _param_sens_mag_rate.get();
-		const bool multi_mode = (_param_sens_mag_mode.get() == 1);
+		const bool multi_mode = (_param_sens_mag_mode.get() == 0);
 
 		for (int instance = 0; instance < MAX_SENSOR_COUNT; instance++) {
 			if (updated[instance] && (_data_sum_count[instance] > 0)) {


### PR DESCRIPTION
Signed-off-by: Serhat Aksun <serhat.aksun@maxwell-innovations.com>

## Describe problem solved by this pull request
In VehicleMagnetometer, multi mode for magnetometers are enabled when sens_mag_mode parameter is set to 1 which is not correct.

## Describe your solution
multi mode for magnetometers are enabled when sens_mag_mode parameter is set to 0. This pr fixes the multi_mode check in VehicleMagnetometer

