### PR TITLE
force ekf  to have the same global origin

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -360,6 +360,29 @@ void EKF2::Run()
 				}
 			}
 		}
+
+	} else if (_multi_mode) {
+		estimator_selector_status_s ekf_selection;
+		vehicle_local_position_s lpos;
+
+		if (_estimator_selector_status_sub.update(&ekf_selection)
+		    && ekf_selection.primary_instance != _instance
+		    && _vehicle_local_position_sub.update(&lpos)
+		    && lpos.ref_timestamp > 0
+		    && PX4_ISFINITE(lpos.ref_lat) && PX4_ISFINITE(lpos.ref_lon) && PX4_ISFINITE(lpos.ref_alt)
+		    && (abs(lpos.ref_lat - _ekf.global_origin().getProjectionReferenceLat()) > 1e-9
+			|| abs(lpos.ref_lon - _ekf.global_origin().getProjectionReferenceLon()) > 1e-9
+			|| abs(lpos.ref_alt - _ekf.getEkfGlobalOriginAltitude()) > 1e-3f)) {
+
+			_ekf.setEkfGlobalOrigin(lpos.ref_lat, lpos.ref_lon, lpos.ref_alt);
+
+			// Validate the ekf origin status.
+			PX4_INFO("%d - New NED origin (LLA): %3.10f, %3.10f, %4.3f", _instance,
+				 _ekf.global_origin().getProjectionReferenceLat(),
+				 _ekf.global_origin().getProjectionReferenceLon(),
+				 static_cast<double>(_ekf.getEkfGlobalOriginAltitude()));
+
+		}
 	}
 
 	bool imu_updated = false;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -349,13 +349,13 @@ void EKF2::Run()
 
 				if (_ekf.setEkfGlobalOrigin(latitude, longitude, altitude)) {
 					// Validate the ekf origin status.
-					uint64_t origin_time {};
-					_ekf.getEkfGlobalOrigin(origin_time, latitude, longitude, altitude);
-					PX4_INFO("%d - New NED origin (LLA): %3.10f, %3.10f, %4.3f\n",
-						 _instance, latitude, longitude, static_cast<double>(altitude));
+					PX4_INFO("%d - New NED origin (LLA): %3.10f, %3.10f, %4.3f", _instance,
+						 _ekf.global_origin().getProjectionReferenceLat(),
+						 _ekf.global_origin().getProjectionReferenceLon(),
+						 static_cast<double>(_ekf.getEkfGlobalOriginAltitude()));
 
 				} else {
-					PX4_ERR("%d - Failed to set new NED origin (LLA): %3.10f, %3.10f, %4.3f\n",
+					PX4_ERR("%d - Failed to set new NED origin (LLA): %3.10f, %3.10f, %4.3f",
 						_instance, latitude, longitude, static_cast<double>(altitude));
 				}
 			}

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -282,6 +282,9 @@ private:
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription _vehicle_optical_flow_sub{ORB_ID(vehicle_optical_flow)};
 
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _estimator_selector_status_sub{ORB_ID(estimator_selector_status)};
+
 	uORB::SubscriptionCallbackWorkItem _sensor_combined_sub{this, ORB_ID(sensor_combined)};
 	uORB::SubscriptionCallbackWorkItem _vehicle_imu_sub{this, ORB_ID(vehicle_imu)};
 


### PR DESCRIPTION
## Describe problem solved by this pull request
We often have issues with reference coordinates not being the same in all ekfs. We use offboard position control with setpoint in local frame. 
When ekf selection changes in flight, local frame jump and our commands in the previous local frame make big errors in the trajectory. In particular, when we have to keep a constant position, the drone can move quickly.

I have seen differences of more than 7 m in one case with the drone initialization not moving on the ground.

This is due to EKF initializing at different moments and GPS positions converging in between.
I am not sure why there is so much difference in initialization (1 min in one of the logs below). I suppose it can be due to the vehicle_at_rest not being detected on the ekf instance 2 (it is never detected on this instance...). If this is the case, it should not be reproduced on master (as the rest detection is common) but I think that making sure all ekfs have the same reference is a good thing.

logs:
https://review.px4.io/plot_app?log=fc7710a2-b5cf-4394-863f-e6b98ad5dbb0
https://review.px4.io/plot_app?log=5e8e64de-3c2e-45c6-a2a7-5022e236b565


## Describe your solution
I propose to force the ekf global origin to the frame of the selected instance.

## Test data / coverage
Not really tested yet (just initialization in SITL)...

## another remark
This show that the gps checks hdrift, vdrif, hspeed always pass until the vehicle is detected at rest. This is a good thing to be able to init in some moving cases but maybe a minimal check of coherence between gps speed and position drift can be added



