### PR TITLE
battery_params: increase default empty cellvoltage to 3.6v

### DIFF
--- a/src/lib/battery/battery_params_deprecated.c
+++ b/src/lib/battery/battery_params_deprecated.c
@@ -43,7 +43,7 @@
  * @group Battery Calibration
  * @category system
  */
-PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.5f);
+PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.6f);
 
 /**
  * This parameter is deprecated. Please use BAT1_V_CHARGED instead.

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -21,7 +21,7 @@ parameters:
             reboot_required: true
             num_instances: *max_num_config_instances
             instance_start: 1
-            default: [3.5, 3.5]
+            default: [3.6, 3.6]
 
         BAT${i}_V_CHARGED:
             description:


### PR DESCRIPTION
## Describe problem solved by this pull request
Based on multiple reports the battery is used down too low with the default parameters. I analyzed logs and observed this happens consistently when the cell voltage is properly load compensated using the current measurement. The default load compensation before #19429 was very inaccurate and resulted in an unpredictable estimate. After that pr enabling current based load compensation by default if there is a usable current measurement and the battery is within expected tolerances of the default internal resistance the compensation is pretty good and 3.5V is clearly too low for an empty compensated cell voltage (the value is good for an uncompensated empty voltage under load). That was seen in various logs where the compensated cell voltage was already dropping fast after 3.6V.

Example:
![image](https://user-images.githubusercontent.com/4668506/169849056-1a1dc316-c31a-43f3-bdc9-d481a72431fc.png)

## Describe your solution
Increasing the default low cell voltage to the useful linear range of a healthy LiPo battery with current-based load compensated cell voltage readings. Since #19429 is enabled by default with a valid current reading.

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
This value was found based on calculations from existing logs where the pilot relied on the voltage based battery estimation with a healthy battery and useful current measurments. The default always lead to a quick drop in battery estimate leading to RTL and then Land without much time to react. Also the vehicle was not able to land before 0% battery. See for example:
![image](https://user-images.githubusercontent.com/4668506/169850759-c6c9199b-6ab3-44c8-9202-dccbfd4bd249.png)

With the higher empty voltage in this pr the load compensated cell voltage is much more on point to harvest the linear range of a LiPo battery. This was also tested and checking how empty the battery was after the flight by recharging it again and comparing with the labeled capacity that estimate was pretty accurate compared to before:
![image](https://user-images.githubusercontent.com/4668506/169851120-e691db05-9ab2-4edc-a1e1-40e9c4f27508.png)

## Additional context
In case the voltage is not load compensated the vehicle estimates the state of charge a bit too low which is safer than to high especially for a default configuration. We are currently rather on the limit side even if with an uncompensated voltage and that results in fast non-linear drop of state of charge at the end of the battery life. Hence we also need high percentage thresholds for low, critical and emergency battery levels.