### PR TITLE
ekf2: use explicit flags instead of bitmask position

### DIFF
--- a/src/modules/ekf2/EKF/mag_fusion.cpp
+++ b/src/modules/ekf2/EKF/mag_fusion.cpp
@@ -174,12 +174,20 @@ void Ekf::fuseMag(const Vector3f &mag)
 	for (uint8_t index = 0; index <= 2; index++) {
 		_mag_test_ratio(index) = sq(_mag_innov(index)) / (sq(math::max(_params.mag_innov_gate, 1.0f)) * _mag_innov_var(index));
 
-		if (_mag_test_ratio(index) > 1.0f) {
+		const bool innov_check_fail = (_mag_test_ratio(index) > 1.0f);
+
+		if (innov_check_fail) {
 			all_innovation_checks_passed = false;
-			_innov_check_fail_status.value |= (1 << (index + 3));
+		}
+
+		if (index == 0) {
+			_innov_check_fail_status.flags.reject_mag_x = innov_check_fail;
+
+		} else if (index == 1) {
+			_innov_check_fail_status.flags.reject_mag_y = innov_check_fail;
 
 		} else {
-			_innov_check_fail_status.value &= ~(1 << (index + 3));
+			_innov_check_fail_status.flags.reject_mag_z = innov_check_fail;
 		}
 	}
 


### PR DESCRIPTION
This prevents bitmask mismatch when a new flag is inserted

Offsets of 3 for mag and 10 for flow was in the "old" bitmask; now it's 4 and 11 but it's even better to use the name directly.