### PR TITLE
Update FMuv6C rc.board_sensors

### DIFF
--- a/boards/px4/fmu-v6c/init/rc.board_sensors
+++ b/boards/px4/fmu-v6c/init/rc.board_sensors
@@ -15,7 +15,7 @@ icm42688p -R 6 -s start
 ms5611 -I -b 4 -a 0x77 start
 
 # Internal compass on IMU I2C4
-ist8310 -I -b 4 -a 0xc -R 6 start
+ist8310 -I -b 4 -a 0xc -R 4 start
 
 # External compass on GPS/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
 ist8310 -X -b 1 -R 10 start


### PR DESCRIPTION
Change internal compass IMU rotation from 6 (YAW270) to 4 (YAW180).

With the actual placement of the board, we think it should be YAW180.
We placed the IST8310 external and rotated by 270 degrees, and the quad position can be fixed. So it looks like the previous compass rotation angle was incorrect.

The rotation angle of the compass on the IMU is YAW180, and the corresponding Rotation option is 4.

![image](https://user-images.githubusercontent.com/46874772/169940461-f4b32e2e-3efe-4886-990c-a399f9f1553e.png)
![image](https://user-images.githubusercontent.com/46874772/169940472-f5cb6dc1-f739-42dd-96f6-5a99ed0d1f25.png)

