### PR TITLE
simulator_mavlink: remove MAV_TYPE_VTOL_TAILSITTER case

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -148,12 +148,6 @@ void Simulator::actuator_controls_from_outputs(mavlink_hil_actuator_controls_t *
 			is_fixed_wing = false;
 			break;
 
-		case MAV_TYPE_VTOL_TAILSITTER:
-			// this is the tricopter VTOL / quad plane with 3 motors and 2 servos
-			pos_thrust_motors_count = 3;
-			is_fixed_wing = false;
-			break;
-
 		case MAV_TYPE_OCTOROTOR:
 			pos_thrust_motors_count = 8;
 			is_fixed_wing = false;


### PR DESCRIPTION
This type (23) doesn't specify a motor number, so it can't be properly handled. For sure not with 3 motors. This came in when we renamed some VTOL_RESERVED types in https://github.com/mavlink/mavlink/pull/1818.
There are duo (19) and quad (20) tailsitter types that still work in simulation.

Note: as soon as we switch to the new allocation architecture we don't need MAV_TYPE for the motor simulation anymore. 

