### PR TITLE
commander/mavlink: use home attitude, not only yaw

### DIFF
--- a/msg/versioned/HomePosition.msg
+++ b/msg/versioned/HomePosition.msg
@@ -12,6 +12,8 @@ float32 x				# X coordinate in meters
 float32 y				# Y coordinate in meters
 float32 z				# Z coordinate in meters
 
+float32 roll				# Pitch angle in radians
+float32 pitch				# Roll angle in radians
 float32 yaw				# Yaw angle in radians
 
 bool valid_alt		# true when the altitude has been set

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -999,6 +999,10 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					}
 
 				} else {
+					float roll = matrix::wrap_2pi(math::radians(cmd.param2));
+					roll = PX4_ISFINITE(roll) ? roll : 0.0f;
+					float pitch = matrix::wrap_2pi(math::radians(cmd.param3));
+					pitch = PX4_ISFINITE(pitch) ? pitch : 0.0f;
 					float yaw = matrix::wrap_2pi(math::radians(cmd.param4));
 					yaw = PX4_ISFINITE(yaw) ? yaw : (float)NAN;
 					const double lat = cmd.param5;
@@ -1007,7 +1011,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 					if (PX4_ISFINITE(lat) && PX4_ISFINITE(lon) && PX4_ISFINITE(alt)) {
 
-						if (_home_position.setManually(lat, lon, alt, yaw)) {
+						if (_home_position.setManually(lat, lon, alt, roll, pitch, yaw)) {
 
 							cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022-2025 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/failsafe_flags.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
@@ -64,7 +65,7 @@ public:
 
 	bool setHomePosition(bool force = false);
 	void setInAirHomePosition();
-	bool setManually(double lat, double lon, float alt, float yaw);
+	bool setManually(double lat, double lon, float alt, float roll, float pitch, float yaw);
 	void setTakeoffTime(uint64_t takeoff_time) { _takeoff_time = takeoff_time; }
 
 	void update(bool set_automatically, bool check_if_changed);
@@ -76,8 +77,9 @@ private:
 	void setHomePosValid();
 	void updateHomePositionYaw(float yaw);
 
-	static void fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos);
-	static void fillLocalHomePos(home_position_s &home, float x, float y, float z, float heading);
+	static void fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos,
+				     const vehicle_attitude_s &attitude);
+	static void fillLocalHomePos(home_position_s &home, float x, float y, float z, float roll, float pitch, float yaw);
 	static void fillGlobalHomePos(home_position_s &home, const vehicle_global_position_s &gpos);
 	static void fillGlobalHomePos(home_position_s &home, double lat, double lon, double alt);
 
@@ -85,6 +87,7 @@ private:
 
 	uORB::SubscriptionData<vehicle_global_position_s>	_global_position_sub{ORB_ID(vehicle_global_position)};
 	uORB::SubscriptionData<vehicle_local_position_s>	_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::SubscriptionData<vehicle_attitude_s>	_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _vehicle_air_data_sub{ORB_ID(vehicle_air_data)};
 
 	uint64_t _last_gps_timestamp{0};

--- a/src/modules/mavlink/streams/HOME_POSITION.hpp
+++ b/src/modules/mavlink/streams/HOME_POSITION.hpp
@@ -75,7 +75,7 @@ private:
 				msg.y = home.y;
 				msg.z = home.z;
 
-				matrix::Quatf q(matrix::Eulerf(0.f, 0.f, home.yaw));
+				matrix::Quatf q(matrix::Eulerf(home.roll, home.pitch, home.yaw));
 				q.copyTo(msg.q);
 
 				msg.approach_x = 0.f;


### PR DESCRIPTION
According to the mavlink spec we should be publishing the home attitude as a quaternion rather than just the yaw/heading.

Additionally, this allows setting the landing roll and pitch angle using DO_SET_HOME (this yet needs to go into the MAVLink spec though).

This is marked as draft for now because it depends on the outcome of the discussion of the MAVLink spec change: https://github.com/mavlink/mavlink/pull/1843