### PR TITLE
Switch mode after autonomous disarm

### DIFF
--- a/src/modules/commander/Arming/PreFlightCheck/checks/modeCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/modeCheck.cpp
@@ -53,9 +53,6 @@ bool PreFlightCheck::modeCheck(orb_advert_t *mavlink_log_pub, const bool report_
 	case vehicle_status_s::NAVIGATION_STATE_STAB:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
-
-	// allow arming in land mode to prevent MAVSDK examples from failing on master until the workflow is changed
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
 		break;
 
 	default:

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2684,7 +2684,7 @@ Commander::run()
 			 * just a tablet. Since the RC will force its mode switch setting on connecting
 			 * we can as well just wait in a hold mode which enables tablet control.
 			 */
-			if (_vehicle_status.rc_signal_lost && (_commander_state.main_state == commander_state_s::MAIN_STATE_MANUAL)
+			if (_vehicle_status.rc_signal_lost && (_commander_state.main_state_changes == 0)
 			    && _vehicle_status_flags.global_position_valid) {
 
 				main_state_transition(_vehicle_status, commander_state_s::MAIN_STATE_AUTO_LOITER, _vehicle_status_flags,

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2900,22 +2900,21 @@ Commander::run()
 			}
 		}
 
-		// check for arming state change
+		// check for arming state changes
 		if (_was_armed != _arm_state_machine.isArmed()) {
 			_status_changed = true;
+		}
 
-			if (_arm_state_machine.isArmed()) {
-				if (!_vehicle_land_detected.landed) { // check if takeoff already detected upon arming
-					_have_taken_off_since_arming = true;
-				}
+		if (!_was_armed && _arm_state_machine.isArmed() && !_vehicle_land_detected.landed) {
+			_have_taken_off_since_arming = true;
+		}
 
-			} else { // increase the flight uuid upon disarming
-				const int32_t flight_uuid = _param_flight_uuid.get() + 1;
-				_param_flight_uuid.set(flight_uuid);
-				_param_flight_uuid.commit_no_notification();
+		if (_was_armed && !_arm_state_machine.isArmed()) {
+			const int32_t flight_uuid = _param_flight_uuid.get() + 1;
+			_param_flight_uuid.set(flight_uuid);
+			_param_flight_uuid.commit_no_notification();
 
-				_last_disarmed_timestamp = hrt_absolute_time();
-			}
+			_last_disarmed_timestamp = hrt_absolute_time();
 		}
 
 		if (!_arm_state_machine.isArmed()) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2915,6 +2915,12 @@ Commander::run()
 			_param_flight_uuid.commit_no_notification();
 
 			_last_disarmed_timestamp = hrt_absolute_time();
+
+			// Switch back to Hold mode after autonomous landing
+			if (_vehicle_control_mode.flag_control_auto_enabled) {
+				main_state_transition(_vehicle_status, commander_state_s::MAIN_STATE_AUTO_LOITER,
+						      _vehicle_status_flags, _commander_state);
+			}
 		}
 
 		if (!_arm_state_machine.isArmed()) {


### PR DESCRIPTION
## Describe problem solved by this pull request
1. There can be seemingly random switches to Hold mode when the vehicle has an RC loss while sitting on the ground, disarmed, in Manual mode.
2. After an RTL the vehicle stays in Return mode even though it's already done and it's not possible to take off again in that mode. Users get annoyed by this and there are corner cases with using the takeoff button in the ground station.
3. There are still MAVSDK use cases which will fail arming even after arming in Land mode was temporarily allowed again in https://github.com/PX4/PX4-Autopilot/pull/19449

## Describe your solution
1. Only automatic switch to Hold mode for a connected tablet and no stick input on initialization and not later on when having RC loss.
2. After landing in an autonomous mode (most of the time RTL, Land, Mission) switch back to Hold mode upon disarming.
3. That should be solved with 2. and arming in Land mode can be disallowed again.

## Test data / coverage
I only did a quick SITL test. More testing to be done. Please review and help me think of corner cases. MAVSDK should hopefully not fail anymore with this.