### PR TITLE
Micro-XRCE use bin interface over xml to save flash space

### DIFF
--- a/msg/templates/uorb_microcdr/dds_topics.h.em
+++ b/msg/templates/uorb_microcdr/dds_topics.h.em
@@ -63,14 +63,9 @@ topic_pascal = topic.replace("_", " ").title().replace(" ", "")
 	{
 
 		uxrObjectId topic_id = uxr_object_id(@(idx)+1, UXR_TOPIC_ID);
-		const char* topic_xml = "<dds>"
-				"<topic>"
-				"<name>rt/fmu/out/@(topic_pascal)</name>"
-				"<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
-				"</topic>"
-				"</dds>";
-		uint16_t topic_req = uxr_buffer_create_topic_xml(session, stream_id, topic_id, participant_id, topic_xml,
-						UXR_REPLACE);
+
+		uint16_t topic_req = uxr_buffer_create_topic_bin(session, stream_id, topic_id, participant_id, "rt/fmu/out/@(topic_pascal)",
+                    "px4_msgs::msg::dds_::@(topic_pascal)_", UXR_REPLACE);
 
 		uxrObjectId publisher_id = uxr_object_id(@(idx)+1, UXR_PUBLISHER_ID);
 		const char* publisher_xml = "";
@@ -79,17 +74,14 @@ topic_pascal = topic.replace("_", " ").title().replace(" ", "")
 
 		uxrObjectId datawriter_id = uxr_object_id(@(idx)+1, UXR_DATAWRITER_ID);
 		@(topic)_data_writer = datawriter_id;
-		const char* datawriter_xml = "<dds>"
-				"<data_writer>"
-				"<topic>"
-				"<kind>NO_KEY</kind>"
-				"<name>rt/fmu/out/@(topic_pascal)</name>"
-				"<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
-				"</topic>"
-				"</data_writer>"
-				"</dds>";
-		uint16_t datawriter_req = uxr_buffer_create_datawriter_xml(session, stream_id, datawriter_id, publisher_id,
-						datawriter_xml, UXR_REPLACE);
+
+		uxrQoS_t qos = {
+			.durability = UXR_DURABILITY_TRANSIENT_LOCAL, .reliability = UXR_RELIABILITY_RELIABLE,
+			.history = UXR_HISTORY_KEEP_LAST, .depth = 0
+		};
+
+		uint16_t datawriter_req = uxr_buffer_create_datawriter_bin(session, stream_id, datawriter_id, publisher_id,
+                    topic_id, qos, UXR_REPLACE);
 
 		// Send create entities message and wait its status
 		uint8_t status[3];
@@ -161,25 +153,18 @@ topic_pascal = topic.replace("_", " ").title().replace(" ", "")
 		uint16_t subscriber_req = uxr_buffer_create_subscriber_xml(session, stream_id, subscriber_id, participant_id, subscriber_xml, UXR_REPLACE);
 
 		uxrObjectId topic_id = uxr_object_id(1000+@(idx), UXR_TOPIC_ID);
-		const char* topic_xml = "<dds>"
-				"<topic>"
-				"<name>rt/fmu/in/@(topic_pascal)</name>"
-				"<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
-				"</topic>"
-				"</dds>";
-		uint16_t topic_req = uxr_buffer_create_topic_xml(session, stream_id, topic_id, participant_id, topic_xml, UXR_REPLACE);
+		uint16_t topic_req = uxr_buffer_create_topic_bin(session, stream_id, topic_id, participant_id, "rt/fmu/in/@(topic_pascal)",
+                    "px4_msgs::msg::dds_::@(topic_pascal)_", UXR_REPLACE);
 
 		uxrObjectId datareader_id = uxr_object_id(@(idx)+1, UXR_DATAREADER_ID);
-		const char* datareader_xml = "<dds>"
-										 "<data_reader>"
-											 "<topic>"
-												 "<kind>NO_KEY</kind>"
-												 "<name>rt/fmu/in/@(topic_pascal)</name>"
-												 "<dataType>px4_msgs::msg::dds_::@(topic_pascal)_</dataType>"
-											 "</topic>"
-										 "</data_reader>"
-									 "</dds>";
-		uint16_t datareader_req = uxr_buffer_create_datareader_xml(session, stream_id, datareader_id, subscriber_id, datareader_xml, UXR_REPLACE);
+
+		uxrQoS_t qos = {
+			.durability = UXR_DURABILITY_TRANSIENT_LOCAL, .reliability = UXR_RELIABILITY_RELIABLE,
+			.history = UXR_HISTORY_KEEP_LAST, .depth = 0
+		};
+
+		uint16_t datareader_req = uxr_buffer_create_datareader_bin(session, stream_id, datareader_id, subscriber_id,
+                    topic_id, qos, UXR_REPLACE);
 
 		uint8_t status[3];
 		uint16_t requests[3] = {topic_req, subscriber_req, datareader_req };

--- a/msg/templates/uorb_microcdr/dds_topics.h.em
+++ b/msg/templates/uorb_microcdr/dds_topics.h.em
@@ -40,12 +40,15 @@ receive_base_types = [s.short_name for idx, s in enumerate(spec) if scope[idx] =
 #define TOPIC_NAME_SIZE 128
 
 static bool generate_topic_name(char* topic, const char* client_namespace, const char* direction, const char* name) {
+	int ret;
 	if(client_namespace == nullptr) {
-		return snprintf(topic, TOPIC_NAME_SIZE, "rt/fmu/%s/%s",
-						direction, name) > 0;
+		ret = snprintf(topic, TOPIC_NAME_SIZE, "rt/fmu/%s/%s",
+						direction, name);
+		return (ret > 0 && ret < TOPIC_NAME_SIZE);
 	} else {
-		return snprintf(topic, TOPIC_NAME_SIZE, "rt/%s/fmu/%s/%s",
-						client_namespace, direction, name) > 0;
+		ret = snprintf(topic, TOPIC_NAME_SIZE, "rt/%s/fmu/%s/%s",
+						client_namespace, direction, name);
+		return (ret > 0 && ret < TOPIC_NAME_SIZE);
 	}
 }
 

--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -49,7 +49,7 @@ public:
 	};
 
 	MicroddsClient(Transport transport, const char *device, int baudrate, const char *host, const char *port,
-		       bool localhost_only);
+		       bool localhost_only, const char *client_namespace);
 
 	~MicroddsClient();
 
@@ -75,6 +75,7 @@ private:
 	int setBaudrate(int fd, unsigned baud);
 
 	const bool _localhost_only;
+	const char *_client_namespace;
 
 	SendTopicsSubs *_subs{nullptr};
 	RcvTopicsPubs *_pubs{nullptr};


### PR DESCRIPTION
Reduces the amount XML used in the generated Micro XRCE DDS code

On PX4 FMUv5 RTPS it saves around 5KB of flash.

Needs some proper testing since I can't due that my ROS setup is currently migrating to Humble.

FYI @bperseghetti 

Before
```
Memory region         Used Size  Region Size  %age Used
      FLASH_ITCM:          0 GB      2016 KB      0.00%
      FLASH_AXIM:     1905757 B      2016 KB     92.32%
        ITCM_RAM:          0 GB        16 KB      0.00%
        DTCM_RAM:          0 GB       128 KB      0.00%
           SRAM1:       44712 B       368 KB     11.87%
           SRAM2:          0 GB        16 KB      0.00%
```
After
```
Memory region         Used Size  Region Size  %age Used
      FLASH_ITCM:          0 GB      2016 KB      0.00%
      FLASH_AXIM:     1900661 B      2016 KB     92.07%
        ITCM_RAM:          0 GB        16 KB      0.00%
        DTCM_RAM:          0 GB       128 KB      0.00%
           SRAM1:       44712 B       368 KB     11.87%
           SRAM2:          0 GB        16 KB      0.00%
```