### PR TITLE
vscode: remove terminal settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -126,8 +126,6 @@
         },
         "search.showLineNumbers": true,
         "telemetry.enableTelemetry": false,
-        "terminal.integrated.copyOnSelection": true,
-        "terminal.integrated.rightClickBehavior": "paste",
         "terminal.integrated.scrollback": 5000,
         "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
         "workbench.editor.highlightModifiedTabs": true,


### PR DESCRIPTION
These terminal settings are a matter of personal preference and should not be part of the project configuration.

