### PR TITLE
FlightModeManager: only execute flight task commands when multicopter

### DIFF
--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -413,7 +413,8 @@ void FlightModeManager::handleCommand()
 		FlightTaskIndex desired_task = switchVehicleCommand(command.command);
 
 		// ignore all unkown commands
-		if (desired_task != FlightTaskIndex::None) {
+		if (desired_task != FlightTaskIndex::None
+		    && _vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 			// switch to the commanded task
 			bool switch_succeeded = (switchTask(desired_task) == FlightTaskError::NoError);
 			uint8_t cmd_result = vehicle_command_ack_s::VEHICLE_RESULT_FAILED;


### PR DESCRIPTION
## Describe problem solved by this pull request
When flying a VTOL in fixed-wing operation and sending an Orbit command with a large radius the user gets an error that the limit is exceeded even though for fixed-wing there is apparently no limit.

## Describe your solution
The issue is that for VTOLs in fixed-wing all flight tasks are stopped as part of the loop but an incoming command can still get processed and start a task that checks the parameters just to get stopped again. I'm only allowing task switching commands while the vehicle is a multicopter.

## Describe possible alternatives
Later on we need to dispatch the different modes depending on vehicle type. That's also why I just solved it this way and didn't just prohibit running any flight mode manager activity when the vehicle type is different from a multicopter.

## Test data / coverage
I verified in simulation that the problem is solved.