### PR TITLE
ROMFS: add 13100_generic_tiltrotor config and remove actuator assignments from other generic vehicles

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
+++ b/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
@@ -1,22 +1,10 @@
 #!/bin/sh
 #
-# @name Generic Quadplane VTOL
+# @name Generic Standard VTOL
 #
 # @type Standard VTOL
 # @class VTOL
-#
-# @maintainer
-#
-# @output MAIN1 motor 1
-# @output MAIN2 motor 2
-# @output MAIN3 motor 3
-# @output MAIN4 motor 4
-# @output AUX1 Aileron 1
-# @output AUX2 Aileron 2
-# @output AUX3 Elevator
-# @output AUX4 Rudder
-# @output AUX5 Throttle
-#
+
 # @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
 # @board holybro_kakutef7 exclude
@@ -24,21 +12,21 @@
 
 . ${R}etc/init.d/rc.vtol_defaults
 
+param set-default SYS_CTRL_ALLOC 1
 param set-default CA_AIRFRAME 2
 param set-default CA_ROTOR_COUNT 5
-param set-default CA_ROTOR0_PX 0.15
-param set-default CA_ROTOR0_PY 0.15
-param set-default CA_ROTOR1_PX -0.15
-param set-default CA_ROTOR1_PY -0.15
-param set-default CA_ROTOR2_PX 0.15
-param set-default CA_ROTOR2_PY -0.15
+param set-default CA_ROTOR0_PX 1
+param set-default CA_ROTOR0_PY 1
+param set-default CA_ROTOR1_PX -1
+param set-default CA_ROTOR1_PY -1
+param set-default CA_ROTOR2_PX 1
+param set-default CA_ROTOR2_PY -1
 param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.15
-param set-default CA_ROTOR3_PY 0.15
+param set-default CA_ROTOR3_PX -1
+param set-default CA_ROTOR3_PY 1
 param set-default CA_ROTOR3_KM -0.05
 param set-default CA_ROTOR4_AX 1.0
 param set-default CA_ROTOR4_AZ 0.0
-param set-default CA_ROTOR4_PX 0.2
 param set-default CA_SV_CS_COUNT 4
 param set-default CA_SV_CS0_TYPE 1
 param set-default CA_SV_CS0_TRQ_R -0.5
@@ -48,16 +36,5 @@ param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS2_TRQ_P 1.0
 param set-default CA_SV_CS3_TRQ_Y 1.0
 param set-default CA_SV_CS3_TYPE 4
-
-param set-default PWM_AUX_DIS5 950
-
 param set-default VT_TYPE 2
-param set-default VT_MOT_ID 1234
-param set-default VT_FW_MOT_OFFID 1234
-
 param set-default MAV_TYPE 22
-
-set MIXER quad_x
-set MIXER_AUX vtol_AAERT
-
-set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/airframes/13100_generic_vtol_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/13100_generic_vtol_tiltrotor
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# @name Generic Tiltrotor VTOL
+#
+# @type VTOL Tiltrotor
+# @class VTOL
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. ${R}etc/init.d/rc.vtol_defaults
+
+param set-default SYS_CTRL_ALLOC 1
+
+param set-default CA_AIRFRAME 3
+param set-default CA_ROTOR_COUNT 4
+param set-default CA_ROTOR0_PX 1
+param set-default CA_ROTOR0_PY 1
+param set-default CA_ROTOR0_TILT 2
+param set-default CA_ROTOR1_PX -1
+param set-default CA_ROTOR1_PY -1
+param set-default CA_ROTOR2_PX 1
+param set-default CA_ROTOR2_PY -1
+param set-default CA_ROTOR2_TILT 1
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -1
+param set-default CA_ROTOR3_PY 1
+param set-default CA_ROTOR3_KM -0.05
+param set-default CA_SV_CS_COUNT 4
+param set-default CA_SV_CS0_TYPE 1
+param set-default CA_SV_CS0_TRQ_R -0.5
+param set-default CA_SV_CS1_TYPE 2
+param set-default CA_SV_CS1_TRQ_R 0.5
+param set-default CA_SV_CS2_TYPE 7
+param set-default CA_SV_CS2_TRQ_P 0.5
+param set-default CA_SV_CS2_TRQ_Y 0.5
+param set-default CA_SV_CS3_TYPE 8
+param set-default CA_SV_CS3_TRQ_P 0.5
+param set-default CA_SV_CS3_TRQ_Y -0.5
+param set-default CA_SV_TL_COUNT 2
+
+param set-default MAV_TYPE 21
+param set-default VT_TYPE 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
@@ -1,16 +1,9 @@
 #!/bin/sh
 #
-# @name Generic Tailsitter
+# @name Generic VTOL Tailsitter
 #
-# @type VTOL Duo Tailsitter
+# @type VTOL Tailsitter
 # @class VTOL
-#
-# @output MAIN1 motor right
-# @output MAIN2 motor left
-# @output MAIN5 elevon right
-# @output MAIN6 elevon left
-#
-# @maintainer Roman Bapst <roman@px4.io>
 #
 # @board px4_fmu-v2 exclude
 # @board bitcraze_crazyflie exclude
@@ -19,18 +12,13 @@
 
 . ${R}etc/init.d/rc.vtol_defaults
 
-param set-default MAV_TYPE 19
-
-param set-default VT_ELEV_MC_LOCK 0
-param set-default VT_MOT_COUNT 2
-param set-default VT_TYPE 0
-
+param set-default SYS_CTRL_ALLOC 1
 param set-default CA_AIRFRAME 4
 param set-default CA_ROTOR_COUNT 2
 param set-default CA_ROTOR0_KM -0.05
-param set-default CA_ROTOR0_PY 0.2
-param set-default CA_ROTOR1_KM -0.05
-param set-default CA_ROTOR1_PY -0.2
+param set-default CA_ROTOR0_PY -0.2
+param set-default CA_ROTOR1_KM 0.05
+param set-default CA_ROTOR1_PY 0.2
 param set-default CA_SV_CS_COUNT 2
 param set-default CA_SV_CS0_TRQ_P 0.5
 param set-default CA_SV_CS0_TRQ_Y 0.5
@@ -39,6 +27,6 @@ param set-default CA_SV_CS1_TRQ_P 0.5
 param set-default CA_SV_CS1_TRQ_Y -0.5
 param set-default CA_SV_CS1_TYPE 6
 
-set MIXER vtol_tailsitter_duo
-
-set PWM_OUT 1234
+param set-default MAV_TYPE 19
+param set-default VT_TYPE 0
+param set-default VT_ELEV_MC_LOCK 0

--- a/ROMFS/px4fmu_common/init.d/airframes/2100_standard_plane
+++ b/ROMFS/px4fmu_common/init.d/airframes/2100_standard_plane
@@ -1,28 +1,16 @@
 #!/bin/sh
 #
-# @name Standard Plane
+# @name Generic Standard Plane
 #
 # @type Standard Plane
 # @class Plane
-#
-# @output MAIN1 aileron
-# @output MAIN2 elevator
-# @output MAIN3 throttle
-# @output MAIN4 rudder
-# @output MAIN5 flaps
-# @output MAIN6 gear
-#
-# @output AUX1 feed-through of RC AUX1 channel
-# @output AUX2 feed-through of RC AUX2 channel
-# @output AUX3 feed-through of RC AUX3 channel
-#
-# @maintainer Lorenz Meier <lorenz@px4.io>
 #
 # @board bitcraze_crazyflie exclude
 #
 
 . ${R}etc/init.d/rc.fw_defaults
 
+param set-default SYS_CTRL_ALLOC 1
 param set-default CA_AIRFRAME 1
 param set-default CA_ROTOR_COUNT 1
 param set-default CA_ROTOR0_PX 0.3
@@ -34,11 +22,3 @@ param set-default CA_SV_CS2_TRQ_P 1.0
 param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS3_TRQ_Y 1.0
 param set-default CA_SV_CS3_TYPE 4
-
-param set-default PWM_AUX_RATE 50
-param set-default PWM_MAIN_RATE 50
-
-set MIXER AETRFG
-
-# Rate must be set by group (see pwm info).
-# Throttle is in the same group as servos.

--- a/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
@@ -5,19 +5,20 @@
 # @type Flying Wing
 # @class Plane
 #
-# @output MAIN1 left aileron
-# @output MAIN2 right aileron
-# @output MAIN4 throttle
-#
-# @output AUX1 feed-through of RC AUX1 channel
-# @output AUX2 feed-through of RC AUX2 channel
-# @output AUX3 feed-through of RC AUX3 channel
-#
-# @maintainer
-#
 # @board bitcraze_crazyflie exclude
 #
 
 . ${R}etc/init.d/rc.fw_defaults
 
-set MIXER fw_generic_wing
+param set-default SYS_CTRL_ALLOC 1
+param set-default CA_AIRFRAME 1
+
+param set-default CA_ROTOR_COUNT 1
+param set-default CA_ROTOR0_PX 0.15
+param set-default CA_SV_CS_COUNT 2
+param set-default CA_SV_CS0_TYPE 5
+param set-default CA_SV_CS0_TRQ_P 0.5
+param set-default CA_SV_CS0_TRQ_R -0.5
+param set-default CA_SV_CS1_TYPE 6
+param set-default CA_SV_CS1_TRQ_P 0.5
+param set-default CA_SV_CS1_TRQ_R 0.5

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -124,6 +124,7 @@ px4_add_romfs_files(
 	13007_vtol_AAVVT_quad
 	13008_QuadRanger
 	13009_vtol_spt_ranger
+	13100_generic_vtol_tiltrotor
 	13012_convergence
 	13013_deltaquad
 	13014_vtol_babyshark


### PR DESCRIPTION
Following up on https://github.com/PX4/PX4-Autopilot/pull/19596#issuecomment-1119658490, I created a "Generic Tiltrotor VTOL" airframe config. The purpose of it is that users with custom airframes (=not RTF models basically) can select this airframe, it sets the needed system variables that tell the system that we're dealing with a VTOL tiltrotor (yes, we should try to reduce their number, they're quite redundant) and then the user configures the actuators through the control allocation UI. 

We already have generic airframes for tailsitters(13200) and standard VTOLs (13000), though they also contain specific actuator settings that we maybe want to remove after dropping support for the legacy mixing system. IMO VTOLs (and FW btw) are too diverse to split them further up than "standard VTOL", "tiltrotor" and "tailsitter", though we can talk about this. 