### PR TITLE
boards/mro/pixracerpro: fix voltage/current monitoring

### DIFF
--- a/boards/mro/pixracerpro/src/board_config.h
+++ b/boards/mro/pixracerpro/src/board_config.h
@@ -86,9 +86,9 @@
 #define DIRECT_PWM_OUTPUT_CHANNELS  8
 
 /* Power supply control and monitoring GPIOs */
-#define GPIO_nPOWER_IN_A                /* PB5 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN5)
+#define GPIO_POWER_IN_A                 /* PB5 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN5)
 
-#define GPIO_nVDD_BRICK1_VALID          GPIO_nPOWER_IN_A /* Brick 1 Is Chosen */
+#define GPIO_VDD_BRICK1_VALID           GPIO_POWER_IN_A /* Brick 1 Is Chosen */
 #define BOARD_NUMBER_BRICKS             1
 
 #define GPIO_VDD_3V3_SPEKTRUM_POWER_EN  /* PE4  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
@@ -143,7 +143,7 @@
  */
 #define BOARD_ADC_USB_CONNECTED (px4_arch_gpioread(GPIO_OTGFS_VBUS))
 #define BOARD_ADC_USB_VALID     BOARD_ADC_USB_CONNECTED
-#define BOARD_ADC_BRICK_VALID   (!px4_arch_gpioread(GPIO_nVDD_BRICK1_VALID))
+#define BOARD_ADC_BRICK_VALID   (px4_arch_gpioread(GPIO_VDD_BRICK1_VALID))
 
 #define BOARD_NUM_IO_TIMERS 3
 #define BOARD_DMA_ALLOC_POOL_SIZE 5120 /* This board provides a DMA pool and APIs */
@@ -160,7 +160,7 @@
 		GPIO_CAN2_SILENT_S0,              \
 		GPIO_LEVEL_SHIFTER_OE,            \
 		GPIO_PWM_VOLT_SEL,                \
-		GPIO_nPOWER_IN_A,                 \
+		GPIO_POWER_IN_A,                  \
 		GPIO_VDD_3V3_SPEKTRUM_POWER_EN,   \
 		PX4_GPIO_PIN_OFF(GPIO_SDMMC1_D0), \
 		PX4_GPIO_PIN_OFF(GPIO_SDMMC1_D1), \


### PR DESCRIPTION
## Describe problem solved by this pull request
The board definition for the Pixracer Pro's brick power valid signal has the wrong polarity.

## Describe your solution
This PR corrects the polarity for the signal allowing the battery to be used.

## Test data / coverage
Tested using the analog power input socket on a Pixracer Pro and an Mro ACSP4 power module. Verified that the battery is now properly detected, and that the voltage and current readouts can now be correctly calibrated and displayed.

## Additional context
Essentially the same fix as https://github.com/PX4/PX4-Autopilot/pull/16590
