### PR TITLE
Corrected DShot motor spin direction command - fixes #19756

### DIFF
--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -752,8 +752,8 @@ int DShot::custom_command(int argc, char *argv[])
 	};
 
 	constexpr VerbCommand commands[] = {
-		{"reverse", DShot_cmd_spin_direction_reversed, 10},
-		{"normal", DShot_cmd_spin_direction_normal, 10},
+		{"reverse", DShot_cmd_spin_direction_2, 10},
+		{"normal", DShot_cmd_spin_direction_1, 10},
 		{"save", DShot_cmd_save_settings, 10},
 		{"3d_on", DShot_cmd_3d_mode_on, 10},
 		{"3d_off", DShot_cmd_3d_mode_off, 10},


### PR DESCRIPTION
## Describe problem solved by this pull request
Fixes #19756 - where motor direction command is incorrect (temporary direction change instead of saveable direction change)

## Describe your solution
Replaced temporary direction change DShot commands with saveable DShot commands

## Describe possible alternatives
N/A

## Test data / coverage
Tested on custom flight controller board connected to AM32 ESC

## Additional context
See original issue