### PR TITLE
Use signNoZero() where possible

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1349,7 +1349,7 @@ FixedwingPositionControl::control_auto_loiter(const hrt_abstime &now, const floa
 
 	if (fabsf(pos_sp_curr.loiter_radius) < FLT_EPSILON) {
 		loiter_radius = _param_nav_loiter_rad.get();
-		loiter_direction = (loiter_radius > 0) ? 1 : -1;
+		loiter_direction = signNoZero(loiter_radius);
 	}
 
 	const bool in_circle_mode = (_param_fw_use_npfg.get()) ? _npfg.circleMode() : _l1_control.circle_mode();
@@ -2751,7 +2751,7 @@ void FixedwingPositionControl::publishOrbitStatus(const position_setpoint_s pos_
 
 	if (fabsf(loiter_radius) < FLT_EPSILON) {
 		loiter_radius = _param_nav_loiter_rad.get();
-		loiter_direction = (loiter_radius > 0) ? 1 : -1;
+		loiter_direction = signNoZero(loiter_radius);
 	}
 
 	orbit_status.radius = static_cast<float>(loiter_direction) * loiter_radius;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -608,7 +608,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->yaw_valid = PX4_ISFINITE(item.yaw);
 	sp->loiter_radius = (fabsf(item.loiter_radius) > NAV_EPSILON_POSITION) ? fabsf(item.loiter_radius) :
 			    _navigator->get_loiter_radius();
-	sp->loiter_direction = (item.loiter_radius > 0) ? 1 : -1;
+	sp->loiter_direction = math::signNoZero(item.loiter_radius);
 
 	if (item.acceptance_radius > 0.0f && PX4_ISFINITE(item.acceptance_radius)) {
 		// if the mission item has a specified acceptance radius, overwrite the default one from parameters


### PR DESCRIPTION
## Describe problem solved by this pull request
We have a function doing what is used in a lot of places even though it's not complicated.

## Describe your solution
Use the existing unit tested function. I know that 0 is now considered positive while before it was negative but a zero loiter radius does not produce any movement and is in my eyes not supported. And even if it was a positive turn direction would not make any difference.

## Test data / coverage
I did not test this other than comparing the function interface to what the code did before.