### PR TITLE
Commander: switch battery bitflied to dedicated datatype

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -41,6 +41,7 @@
 #include "state_machine_helper.h"
 #include "worker_thread.hpp"
 
+#include <containers/Bitset.hpp>
 #include <lib/controllib/blocks.hpp>
 #include <lib/hysteresis/hysteresis.h>
 #include <lib/mathlib/mathlib.h>
@@ -347,7 +348,7 @@ private:
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime	_battery_failsafe_timestamp{0};
-	uint8_t		_last_connected_batteries{0};
+	px4::Bitset<battery_status_s::MAX_INSTANCES> _last_connected_batteries;
 	uint32_t	_last_battery_custom_fault[battery_status_s::MAX_INSTANCES] {};
 	uint16_t	_last_battery_fault[battery_status_s::MAX_INSTANCES] {};
 	uint8_t		_last_battery_mode[battery_status_s::MAX_INSTANCES] {};


### PR DESCRIPTION
## Describe problem solved by this pull request
Addressing this comment: https://github.com/PX4/PX4-Autopilot/pull/19594#issuecomment-1119689851

## Describe your solution
Hopefully i understood the dedicated `Bitset` bit field datatype correctly and am using it instead of a bitfield being implemented for batteries in commander possibly even wrong (https://github.com/PX4/PX4-Autopilot/pull/19594 was a bugfix).

Note: `math::countSetBits()` is still used in other places.

## Test data / coverage
I did not test this. @dagar could you double check I didn't misunderstand anything?