### PR TITLE
ekf2 preflight: only check innovation of active height sources

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -877,6 +877,11 @@ void EKF2::PublishInnovations(const hrt_abstime &timestamp)
 		_preflt_checker.setUsingEvPosAiding(_ekf.control_status_flags().ev_pos);
 		_preflt_checker.setUsingEvVelAiding(_ekf.control_status_flags().ev_vel);
 
+		_preflt_checker.setUsingBaroHgtAiding(_ekf.control_status_flags().baro_hgt);
+		_preflt_checker.setUsingGpsHgtAiding(_ekf.control_status_flags().gps_hgt);
+		_preflt_checker.setUsingRngHgtAiding(_ekf.control_status_flags().rng_hgt);
+		_preflt_checker.setUsingEvHgtAiding(_ekf.control_status_flags().ev_hgt);
+
 		_preflt_checker.update(_ekf.get_imu_sample_delayed().delta_ang_dt, innovations);
 
 	} else if (_ekf.control_status_flags().in_air != _ekf.control_status_prev_flags().in_air) {

--- a/src/modules/ekf2/Utility/PreFlightChecker.hpp
+++ b/src/modules/ekf2/Utility/PreFlightChecker.hpp
@@ -79,6 +79,11 @@ public:
 	void setUsingEvPosAiding(bool val) { _is_using_ev_pos_aiding = val; }
 	void setUsingEvVelAiding(bool val) { _is_using_ev_vel_aiding = val; }
 
+	void setUsingBaroHgtAiding(bool val) { _is_using_baro_hgt_aiding = val; }
+	void setUsingGpsHgtAiding(bool val) { _is_using_gps_hgt_aiding = val; }
+	void setUsingRngHgtAiding(bool val) { _is_using_rng_hgt_aiding = val; }
+	void setUsingEvHgtAiding(bool val) { _is_using_ev_hgt_aiding = val; }
+
 	bool hasHeadingFailed() const { return _has_heading_failed; }
 	bool hasHorizVelFailed() const { return _has_horiz_vel_failed; }
 	bool hasVertVelFailed() const { return _has_vert_vel_failed; }
@@ -149,14 +154,24 @@ private:
 	bool _is_using_ev_pos_aiding{};
 	bool _is_using_ev_vel_aiding{};
 
+	bool _is_using_baro_hgt_aiding{};
+	bool _is_using_gps_hgt_aiding{};
+	bool _is_using_rng_hgt_aiding{};
+	bool _is_using_ev_hgt_aiding{};
+
 	// Low-pass filters for innovation pre-flight checks
 	InnovationLpf _filter_vel_n_innov;	///< Preflight low pass filter N axis velocity innovations (m/sec)
 	InnovationLpf _filter_vel_e_innov;	///< Preflight low pass filter E axis velocity innovations (m/sec)
 	InnovationLpf _filter_vel_d_innov;	///< Preflight low pass filter D axis velocity innovations (m/sec)
-	InnovationLpf _filter_hgt_innov;	///< Preflight low pass filter height innovation (m)
 	InnovationLpf _filter_heading_innov;	///< Preflight low pass filter heading innovation magntitude (rad)
 	InnovationLpf _filter_flow_x_innov;	///< Preflight low pass filter optical flow innovation (rad)
 	InnovationLpf _filter_flow_y_innov;	///< Preflight low pass filter optical flow innovation (rad)
+
+	// Preflight low pass filter height innovation (m)
+	InnovationLpf _filter_baro_hgt_innov;
+	InnovationLpf _filter_gps_hgt_innov;
+	InnovationLpf _filter_rng_hgt_innov;
+	InnovationLpf _filter_ev_hgt_innov;
 
 	// Preflight low pass filter time constant inverse (1/sec)
 	static constexpr float _innov_lpf_tau_inv = 0.2f;


### PR DESCRIPTION
fixes https://github.com/PX4/PX4-Autopilot/issues/19770

## Describe problem solved by this pull request
In https://github.com/PX4/PX4-Autopilot/commit/639222dd653c5536e16c02aff6dacf49d2d7159a#diff-b98e0cba6406890a752c8c8deb36086c8ed27442210a00a7ac02e2692245460c , the innovation for all the potential aiding sources is published. The problem is that the preflight checker in EKF2 module assumed that only the active source was non-zero (which was correct before this commit).

## Describe your solution
Only run the check on the active height source(s), similar to what we were already doing for the horizontal sources.