### PR TITLE
uORB: Add subscription with single field selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ endif()
 
 set(package-contact "px4users@googlegroups.com")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/platforms/common/uORB/Subscription.hpp
+++ b/platforms/common/uORB/Subscription.hpp
@@ -245,4 +245,71 @@ private:
 	T _data{};
 };
 
+template<auto member>
+class SubscriptionSelection;
+
+template <class T, class R, R T::*member>
+class SubscriptionSelection<member>: public Subscription
+{
+public:
+	/**
+	 * Constructor
+	 *
+	 * @param id The uORB metadata ORB_ID enum for the topic.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionSelection(ORB_ID id, uint8_t instance = 0) :
+		Subscription(id, instance)
+	{
+		_copySelection();
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionSelection(const orb_metadata *meta, uint8_t instance = 0) :
+		Subscription(meta, instance)
+	{
+		_copySelection();
+	}
+
+	~SubscriptionSelection() = default;
+
+	// no copy, assignment, move, move assignment
+	SubscriptionSelection(const SubscriptionSelection &) = delete;
+	SubscriptionSelection &operator=(const SubscriptionSelection &) = delete;
+	SubscriptionSelection(SubscriptionSelection &&) = delete;
+	SubscriptionSelection &operator=(SubscriptionSelection &&) = delete;
+
+	// update the embedded struct.
+	bool update()
+	{
+		bool updated = Subscription::updated();
+
+		if (updated) {
+			_copySelection();
+		}
+
+		return updated;
+	}
+
+	const R &get() const { return _data; }
+
+private:
+	void _copySelection()
+	{
+		T full_data;
+
+		if (copy(&full_data)) {
+			_data = full_data.*member;
+		}
+	}
+
+	R _data{};
+};
+
+
 } // namespace uORB

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -138,15 +138,12 @@ private:
 
 	uORB::Subscription	_adc_report_sub{ORB_ID(adc_report)};
 	uORB::Subscription	_vehicle_cmd_sub{ORB_ID(vehicle_command)};
-	uORB::Subscription	_vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionSelection<&vehicle_status_s::arming_state>	_vehicle_status_arming_state_sub{ORB_ID(vehicle_status)};
 
 	input_rc_s	_rc_in{};
 
 	float		_analog_rc_rssi_volt{-1.0f};
 	bool		_analog_rc_rssi_stable{false};
-
-	bool _armed{false};
-
 
 	uORB::PublicationMulti<input_rc_s>	_to_input_rc{ORB_ID(input_rc)};
 

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.hpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.hpp
@@ -114,7 +114,8 @@ private:
 	uORB::Subscription _actuator_controls_status_sub;
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
-	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionSelection<&vehicle_status_s::arming_state> _vehicle_status_armed_state_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionSelection<&vehicle_status_s::nav_state> _vehicle_status_nav_state_sub{ORB_ID(vehicle_status)};
 
 	uORB::PublicationData<autotune_attitude_control_status_s> _autotune_attitude_control_status_pub{ORB_ID(autotune_attitude_control_status)};
 
@@ -142,8 +143,6 @@ private:
 	uint8_t _max_steps{5};
 	int8_t _signal_sign{0};
 
-	bool _armed{false};
-	uint8_t _nav_state{0};
 	uint8_t _start_flight_mode{0};
 	bool _aux_switch_en{false};
 

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -96,13 +96,7 @@ void McAutotuneAttitudeControl::Run()
 		return;
 	}
 
-	if (_vehicle_status_sub.updated()) {
-		vehicle_status_s vehicle_status;
-
-		if (_vehicle_status_sub.copy(&vehicle_status)) {
-			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
-		}
-	}
+	_vehicle_status_arming_state_sub.update();
 
 	if (_actuator_controls_status_sub.updated()) {
 		actuator_controls_status_s controls_status;
@@ -399,7 +393,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		break;
 
 	case state::wait_for_disarm:
-		if (!_armed) {
+		if (!(_vehicle_status_arming_state_sub.get() == vehicle_status_s::ARMING_STATE_ARMED)) {
 			saveGainsToParams();
 			_state = state::complete;
 			_state_start_time = now;

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -108,7 +108,7 @@ private:
 	uORB::Subscription _actuator_controls_status_sub{ORB_ID(actuator_controls_status_0)};
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
-	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionSelection<&vehicle_status_s::arming_state> _vehicle_status_arming_state_sub{ORB_ID(vehicle_status)};
 
 	uORB::PublicationData<autotune_attitude_control_status_s> _autotune_attitude_control_status_pub{ORB_ID(autotune_attitude_control_status)};
 
@@ -135,8 +135,6 @@ private:
 	uint8_t _steps_counter{0};
 	uint8_t _max_steps{5};
 	int8_t _signal_sign{0};
-
-	bool _armed{false};
 
 	matrix::Vector3f _kid{};
 	matrix::Vector3f _rate_k{};

--- a/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.hpp
+++ b/src/modules/mc_hover_thrust_estimator/MulticopterHoverThrustEstimator.hpp
@@ -102,12 +102,11 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
-	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionSelection<&vehicle_status_s::arming_state> _vehicle_status_arming_state_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	hrt_abstime _timestamp_last{0};
 
-	bool _armed{false};
 	bool _landed{false};
 	bool _in_air{false};
 

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -181,13 +181,7 @@ void VehicleIMU::Run()
 	ScheduleDelayed(_backup_schedule_timeout_us);
 
 	// check vehicle status for changes to armed state
-	if (_vehicle_control_mode_sub.updated()) {
-		vehicle_control_mode_s vehicle_control_mode;
-
-		if (_vehicle_control_mode_sub.copy(&vehicle_control_mode)) {
-			_armed = vehicle_control_mode.flag_armed;
-		}
-	}
+	_vehicle_control_mode_armed_sub.update();
 
 	// reset data gap monitor
 	_data_gap = false;
@@ -254,7 +248,7 @@ void VehicleIMU::Run()
 	}
 
 	if (_param_sens_imu_autocal.get() && !parameters_updated) {
-		if ((_armed || !_accel_calibration.calibrated() || !_gyro_calibration.calibrated())
+		if ((_vehicle_control_mode_armed_sub.get() || !_accel_calibration.calibrated() || !_gyro_calibration.calibrated())
 		    && (now_us > _in_flight_calibration_check_timestamp_last + 1_s)) {
 
 			SensorCalibrationUpdate();

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -109,7 +109,8 @@ private:
 	uORB::Subscription _sensor_accel_sub;
 	uORB::SubscriptionCallbackWorkItem _sensor_gyro_sub;
 
-	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
+	uORB::SubscriptionSelection<&vehicle_control_mode_s::flag_armed>
+	_vehicle_control_mode_armed_sub{ORB_ID(vehicle_control_mode)};
 
 	calibration::Accelerometer _accel_calibration{};
 	calibration::Gyroscope _gyro_calibration{};

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.hpp
@@ -113,7 +113,8 @@ private:
 	uORB::Subscription _vehicle_thrust_setpoint_0_sub{ORB_ID(vehicle_thrust_setpoint), 0};
 	uORB::Subscription _battery_status_sub{ORB_ID(battery_status), 0};
 	uORB::Subscription _magnetometer_bias_estimate_sub{ORB_ID(magnetometer_bias_estimate)};
-	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
+	uORB::SubscriptionSelection<&vehicle_control_mode_s::flag_armed>
+	_vehicle_control_mode_armed_sub{ORB_ID(vehicle_control_mode)};
 
 	// Used to check, save and use learned magnetometer biases
 	uORB::SubscriptionMultiArray<estimator_sensor_bias_s> _estimator_sensor_bias_subs{ORB_ID::estimator_sensor_bias};
@@ -170,8 +171,6 @@ private:
 	uint8_t _priority[MAX_SENSOR_COUNT] {};
 
 	int8_t _selected_sensor_sub_index{-1};
-
-	bool _armed{false};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CAL_MAG_COMP_TYP>) _param_mag_comp_typ,

--- a/src/modules/simulation/battery_simulator/BatterySimulator.cpp
+++ b/src/modules/simulation/battery_simulator/BatterySimulator.cpp
@@ -72,19 +72,13 @@ void BatterySimulator::Run()
 
 	updateCommands();
 
-	if (_vehicle_status_sub.updated()) {
-		vehicle_status_s vehicle_status;
-
-		if (_vehicle_status_sub.copy(&vehicle_status)) {
-			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
-		}
-	}
-
 	const hrt_abstime now_us = hrt_absolute_time();
 
 	const float discharge_interval_us = _param_sim_bat_drain.get() * 1000 * 1000;
 
-	if (_armed) {
+	_vehicle_status_arming_state_sub.update();
+
+	if (_vehicle_status_arming_state_sub.get() == vehicle_status_s::ARMING_STATE_ARMED) {
 		if (_last_integration_us != 0) {
 			_battery_percentage -= (now_us - _last_integration_us) / discharge_interval_us;
 		}

--- a/src/modules/simulation/battery_simulator/BatterySimulator.hpp
+++ b/src/modules/simulation/battery_simulator/BatterySimulator.hpp
@@ -77,7 +77,7 @@ private:
 	uORB::Publication<battery_status_s> _battery_pub{ORB_ID(battery_status)};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionSelection<&vehicle_status_s::arming_state> _vehicle_status_arming_state_sub{ORB_ID(vehicle_status)};
 
 	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
@@ -86,7 +86,6 @@ private:
 
 	uint64_t _last_integration_us{0};
 	float _battery_percentage{1.f};
-	bool _armed{false};
 
 	bool _force_empty_battery{false};
 


### PR DESCRIPTION
## Describe problem solved by this pull request

We seem to do this pattern quite a lot:
```
     if (_vehicle_control_mode_sub.updated()) {
		vehicle_control_mode_s vehicle_control_mode;

		if (_vehicle_control_mode_sub.copy(&vehicle_control_mode)) {
			_armed = vehicle_control_mode.flag_armed;
		}
	}
```
This introduces a local state `_armed`, which is just a copy of the data in uORB. Duplicated state carries the risk of getting out of sync. The  `SubscriptionData` class would solve this, as it keeps a copy of the latest data in memory. However, this introduces a burden on memory, as the full `vehicle_control_mode_s` struct has to be kept in memory. 

This PR allows you to introduce a subscription directly onto the armed field of vehicle_control_mode:

~EDIT: With some more template magic, I managed to get it to this:~

```
uORB::SubscriptionSelection<vehicle_control_mode_s, bool, &vehicle_control_mode_s::flag_armed>
	_armed_sub{ORB_ID(vehicle_control_mode)};
```

EDIT:
If we increase language level to CPP 17, this becomes even nicer:

```
uORB::SubscriptionSelection<&vehicle_control_mode_s::flag_armed> _armed_sub{ORB_ID(vehicle_control_mode)};
```


You can then check if armed using:
```
if (_armed_sub.get()) {
...
}
```

## Describe your solution
This PR adds an option of a subscription which takes a selector lambda (without capture, decays to a function pointer). This basically generates the same logic as above, but generalized. 


## Test data / coverage
Untested for now. Draft

## Additional context
I just replaced the usage in `VehicleIMU` for now, more opportunities to replace this. 

Note: For the update, in case of change, this still needs memory for the full object copy, as did the old version. This is just syntactic sugar.
