### PR TITLE
navigator_main: DO_REPOSITION: only trigger reposition setpoint update if vehicle is armed

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -234,7 +234,10 @@ void Navigator::run()
 				// TODO: move DO_GO_AROUND handling to navigator
 				publish_vehicle_command_ack(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
-			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_REPOSITION) {
+			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_REPOSITION
+				   && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+				// only update the reposition setpoint if armed, as it otherwise won't get executed until the vehicle switches to loiter,
+				// which can lead to dangerous and unexpected behaviors (see loiter.cpp, there is an if(armed) in there too)
 
 				bool reposition_valid = true;
 


### PR DESCRIPTION
## Describe problem solved by this pull request
A reposition setpoint is currently only handled when armed (https://github.com/PX4/PX4-Autopilot/blob/5df266cedcefea01404c6c31354c73104b3ca311/src/modules/navigator/loiter.cpp#L84). When disarmed the reposition_tripplet is though still updated, and then executed when next time switched to LOITER. So e.g. if one sends a DO_REPOSITION when disarmed and then takes off, the vehicle will go to the reposition setpoint once the takeoff is finished. I don't think this is desired. 

## Describe your solution
I propose to still let it switch to MAIN_STATE_AUTO_LOITER when the DO_REPOSITION is received when not armed, but not to update the reposition_triplet. The alternative (see below) would maybe even be cleaner, though may also have consequences I don't yet foresee. 

## Describe possible alternatives
Reject the DO_REPOSITION command when not armed. 

## Test data / coverage
SITL tested


