### PR TITLE
Safety disabled startup tune

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -117,5 +117,5 @@ uint64 armed_time       # Arming timestamp (microseconds)
 
 uint64 takeoff_time     # Takeoff timestamp (microseconds)
 
-bool safety_button_available	# Set to true if a safety button is connected
-bool safety_off					# Set to true if safety is off
+bool safety_button_available # Set to true if a safety button is connected
+bool safety_off # Set to true if safety is off

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2298,12 +2298,11 @@ Commander::run()
 		}
 
 		/* safety button */
-		bool safety_updated = _safety.safetyButtonHandler();
+		const bool safety_changed = _safety.safetyButtonHandler();
 		_vehicle_status.safety_button_available = _safety.isButtonAvailable();
 		_vehicle_status.safety_off = _safety.isSafetyOff();
 
-		if (safety_updated) {
-
+		if (safety_changed) {
 			set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MOTORCONTROL, _safety.isButtonAvailable(), _safety.isSafetyOff(),
 					 _safety.isButtonAvailable(), _vehicle_status);
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2307,11 +2307,13 @@ Commander::run()
 					 _safety.isButtonAvailable(), _vehicle_status);
 
 			// Notify the user if the status of the safety button changes
-			if (_safety.isSafetyOff()) {
-				set_tune(tune_control_s::TUNE_ID_NOTIFY_POSITIVE);
+			if (!_safety.isSafetyDisabled()) {
+				if (_safety.isSafetyOff()) {
+					set_tune(tune_control_s::TUNE_ID_NOTIFY_POSITIVE);
 
-			} else {
-				tune_neutral(true);
+				} else {
+					tune_neutral(true);
+				}
 			}
 
 			_status_changed = true;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -402,7 +402,7 @@ private:
 	vehicle_status_s        _vehicle_status{};
 	vehicle_status_flags_s  _vehicle_status_flags{};
 
-	Safety _safety{};
+	Safety _safety;
 
 	WorkerThread _worker_thread;
 

--- a/src/modules/commander/Safety.cpp
+++ b/src/modules/commander/Safety.cpp
@@ -44,16 +44,16 @@ Safety::Safety()
 {
 	// Safety can be turned off with the CBRK_IO_SAFETY parameter.
 	_safety_disabled = circuit_breaker_enabled("CBRK_IO_SAFETY", CBRK_IO_SAFETY_KEY);
+
+	if (_safety_disabled) {
+		_button_available = true;
+		_safety_off = true;
+	}
 }
 
 bool Safety::safetyButtonHandler()
 {
-	if (_safety_disabled) {
-		_button_available = true;
-		_safety_off = true;
-
-	} else {
-
+	if (!_safety_disabled) {
 		if (!_button_available && _safety_button_sub.advertised()) {
 			_button_available = true;
 		}

--- a/src/modules/commander/Safety.cpp
+++ b/src/modules/commander/Safety.cpp
@@ -42,9 +42,7 @@ using namespace time_literals;
 
 Safety::Safety()
 {
-	/*
-	 * Safety can be turned off with the CBRK_IO_SAFETY parameter.
-	 */
+	// Safety can be turned off with the CBRK_IO_SAFETY parameter.
 	_safety_disabled = circuit_breaker_enabled("CBRK_IO_SAFETY", CBRK_IO_SAFETY_KEY);
 }
 
@@ -67,10 +65,8 @@ bool Safety::safetyButtonHandler()
 		}
 	}
 
-	bool safety_changed = _previous_safety_off != _safety_off;
-
+	const bool safety_changed = _previous_safety_off != _safety_off;
 	_previous_safety_off = _safety_off;
-
 	return safety_changed;
 }
 

--- a/src/modules/commander/Safety.hpp
+++ b/src/modules/commander/Safety.hpp
@@ -51,6 +51,7 @@ public:
 	void activateSafety();
 	bool isButtonAvailable() { return _button_available; }
 	bool isSafetyOff() { return _safety_off; }
+	bool isSafetyDisabled() { return _safety_disabled; }
 
 private:
 	uORB::Subscription _safety_button_sub{ORB_ID::safety_button};

--- a/src/modules/commander/Safety.hpp
+++ b/src/modules/commander/Safety.hpp
@@ -43,23 +43,20 @@
 
 class Safety
 {
-
 public:
-
 	Safety();
 	~Safety() = default;
 
 	bool safetyButtonHandler();
 	void activateSafety();
-	bool isButtonAvailable() { return _button_available;}
-	bool isSafetyOff() { return _safety_off;}
+	bool isButtonAvailable() { return _button_available; }
+	bool isSafetyOff() { return _safety_off; }
 
 private:
-
 	uORB::Subscription _safety_button_sub{ORB_ID::safety_button};
 
-	bool _button_available{false};		//<! Set to true if a safety button is connected
-	bool _safety_off{false};			//<! Set to true if safety is off
-	bool _previous_safety_off{false};	//<! Previous safety value
-	bool _safety_disabled{false};		//<! Set to true if safety is disabled
+	bool _button_available{false};///< Set to true if a safety button is connected
+	bool _safety_off{false}; ///< Set to true if safety is off
+	bool _previous_safety_off{false}; ///< Previous safety value
+	bool _safety_disabled{false}; ///< Set to true if safety is disabled
 };

--- a/src/modules/manual_control/manual_control_params.c
+++ b/src/modules/manual_control/manual_control_params.c
@@ -38,7 +38,6 @@
  * arms and to the lower left disarms the vehicle.
  *
  * @boolean
- * @reboot_required true
  * @group Manual Control
  */
 PARAM_DEFINE_INT32(MAN_ARM_GESTURE, 1);


### PR DESCRIPTION
## Describe problem solved by this pull request
It was reported that the startup tune doesn't play fully anymore on master. It was reproducible all the time on my setup. I found the breaking commit to be https://github.com/PX4/PX4-Autopilot/commit/08dcc72e1fea75d2609234cecd7588ecb37492d1. Looking into more detail the safety handling can be and is by default disabled by circuit breaker parameter `CBRK_IO_SAFETY`. In that case the safety status changes once at boot and for that change with mentioned commit there is a tune output for the user that interrupts the startup tune.  

## Describe your solution
I don't output any tunes for safety if it's disabled (3rd commit [1310dde](https://github.com/PX4/PX4-Autopilot/pull/19777/commits/1310dde035d4196ec5844992ede6b1260f5231fe)) the rest is just refactoring.

## Test data / coverage
I tested that the startup tune is not interrupted anymore and disabling safety still works with tune notification when the circuit breaker is not set (safety enabled).

## Additional context
Related to https://github.com/PX4/PX4-Autopilot/pull/19558
