### PR TITLE
airframe fix for Standard Plane motor

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/2100_standard_plane
+++ b/ROMFS/px4fmu_common/init.d/airframes/2100_standard_plane
@@ -42,3 +42,6 @@ set MIXER AETRFG
 
 # Rate must be set by group (see pwm info).
 # Throttle is in the same group as servos.
+
+# use PWM parameters for throttle channe
+set PWM_OUT 3


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
When using the standard_plane layout MAIN3 is meant for thrust
![image](https://user-images.githubusercontent.com/16963678/172673590-0f34697a-33cc-4f13-a919-74c699c95c00.png)

However, the parameter PWM_MAIN_OUT defaults to 0. 

## Describe your solution
This change sets the PWM_MAIN_OUT to 3 so the ESC can be detected on that channel. This way, configuration accurately reflects what is in the layout

## Describe possible alternatives
Alternative would be manually setting it, but in attempting to do that, PWM_MAIN_OUT gets reset after reboot of device

## Test data / coverage
This was tested on CubeOrange. Ran through 5 cycles of reflashing and calibrating ESCs

## Additional context
Can follow conversation of how this change came to be in the PX4 slack channel [here](https://px4.slack.com/archives/C7L8W6DAL/p1654635359901679)
