### PR TITLE
Prevent lockup when avoidance mode fails

### DIFF
--- a/src/lib/avoidance/ObstacleAvoidance.cpp
+++ b/src/lib/avoidance/ObstacleAvoidance.cpp
@@ -87,7 +87,10 @@ void ObstacleAvoidance::injectAvoidanceSetpoints(Vector3f &pos_sp, Vector3f &vel
 
 	if (avoidance_invalid) {
 		PX4_WARN("Obstacle Avoidance system failed, loitering");
-		_publishVehicleCmdDoLoiter();
+		if (_avoidance_failure_mode_change_flag == false){
+			_publishVehicleCmdDoLoiter();
+			_avoidance_failure_mode_change_flag = true;
+		}
 
 		if (!PX4_ISFINITE(_failsafe_position(0)) || !PX4_ISFINITE(_failsafe_position(1))
 		    || !PX4_ISFINITE(_failsafe_position(2))) {

--- a/src/lib/avoidance/ObstacleAvoidance.hpp
+++ b/src/lib/avoidance/ObstacleAvoidance.hpp
@@ -136,7 +136,7 @@ protected:
 	float _prev_pos_to_target_z = -1.f; /**< z distance to the goal */
 
 	bool _ext_yaw_active = false; /**< true, if external yaw handling is active */
-
+	bool _avoidance_failure_mode_change_flag = false; /**< true, when mode changes to loiter when avoidance goes to invalid state. prevent lock of manaual mode change */
 	/**
 	 * Publishes vehicle command.
 	 */


### PR DESCRIPTION
This pull request is a naive solution to the mode change lock-up that occurs when the avoidance system fails and goes into loiter mode. The original code prevented the user from manual override to the flight mode.
