### PR TITLE
Airspeed params: change default for ASPD_SCALE_APPLY to 2

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -83,7 +83,7 @@ PARAM_DEFINE_INT32(ASPD_BETA_GATE, 1);
  * @value 2 Apply the estimated scale in air
  * @group Airspeed Validator
  */
-PARAM_DEFINE_INT32(ASPD_SCALE_APPLY, 1);
+PARAM_DEFINE_INT32(ASPD_SCALE_APPLY, 2);
 
 /**
  * Scale of airspeed sensor 1


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
The airspeed scale estimator is a nice tool and has proven reliability in many cases already. We should have it apply the estimated scale in air by default.  

## Test data / coverage
Tested on many different VTOL platforms.
