### PR TITLE
EscBattery: account for online ESCs when averaging voltage

### DIFF
--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -33,6 +33,8 @@
 
 #include "EscBattery.hpp"
 
+#include <math.h>
+
 using namespace time_literals;
 
 EscBattery::EscBattery() :
@@ -82,22 +84,22 @@ EscBattery::Run()
 
 	if (_esc_status_sub.copy(&esc_status)) {
 
-		int online_bitmask = (1 << esc_status.esc_count) - 1;
-
-		if (online_bitmask != esc_status.esc_online_flags || esc_status.esc_count == 0 ||
-		    esc_status.esc_count > esc_status_s::CONNECTED_ESC_MAX) {
+		if (esc_status.esc_count == 0 || esc_status.esc_count > esc_status_s::CONNECTED_ESC_MAX) {
 			return;
 		}
 
+		const uint8_t onlineEscCount = math::countSetBits(esc_status.esc_online_flags);
 		float average_voltage_v = 0.0f;
 		float total_current_a = 0.0f;
 
 		for (unsigned i = 0; i < esc_status.esc_count; ++i) {
-			average_voltage_v += esc_status.esc[i].esc_voltage;
-			total_current_a += esc_status.esc[i].esc_current;
+			if ((1 << i) & esc_status.esc_online_flags) {
+				average_voltage_v += esc_status.esc[i].esc_voltage;
+				total_current_a += esc_status.esc[i].esc_current;
+			}
 		}
 
-		average_voltage_v /= esc_status.esc_count;
+		average_voltage_v /= onlineEscCount;
 
 		_battery.setConnected(true);
 		_battery.updateVoltage(average_voltage_v);

--- a/src/modules/esc_battery/EscBattery.cpp
+++ b/src/modules/esc_battery/EscBattery.cpp
@@ -88,7 +88,7 @@ EscBattery::Run()
 			return;
 		}
 
-		const uint8_t onlineEscCount = math::countSetBits(esc_status.esc_online_flags);
+		const uint8_t online_esc_count = math::countSetBits(esc_status.esc_online_flags);
 		float average_voltage_v = 0.0f;
 		float total_current_a = 0.0f;
 
@@ -99,7 +99,7 @@ EscBattery::Run()
 			}
 		}
 
-		average_voltage_v /= onlineEscCount;
+		average_voltage_v /= online_esc_count;
 
 		_battery.setConnected(true);
 		_battery.updateVoltage(average_voltage_v);


### PR DESCRIPTION
## Describe problem solved by this pull request
Previously we were only estimating voltage if all the Escs were connected. this caused me some issues during development as i only had 1 Motor connected but still wanted to see the voltage estimation working.
This fix makes the Estimation account for the online Esc.

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
