### PR TITLE
Navigator: Various fixes for camera trigger interactions

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -173,6 +173,7 @@ Mission::on_inactivation()
 	cmd.param3 = 1.0f;
 	_navigator->publish_vehicle_cmd(&cmd);
 
+	_navigator->stop_capturing_images();
 	_navigator->release_gimbal_control();
 
 	if (_navigator->get_precland()->is_activated()) {

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -320,6 +320,7 @@ public:
 	void release_gimbal_control();
 
 	void 		calculate_breaking_stop(double &lat, double &lon, float &yaw);
+	void        	stop_capturing_images();
 
 private:
 
@@ -415,6 +416,9 @@ private:
 							 * if mission mode is inactive, this flag will be cleared after 2 seconds */
 
 	traffic_buffer_s _traffic_buffer{};
+
+	bool _is_capturing_images{false}; // keep track if we need to stop capturing images
+
 
 	// update subscriptions
 	void params_update();

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1493,8 +1493,20 @@ void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
 	switch (vcmd->command) {
 	case NAV_CMD_IMAGE_START_CAPTURE:
 
-		// We are only capturing multiple if param3 is 0 or > 1.
-		if (static_cast<int>(vcmd->param3) != 1) {
+		if (static_cast<int>(vcmd->param3) == 1) {
+			// When sending a single capture we need to include the sequence number, thus camera_trigger needs to handle this cmd
+			vcmd->param1 = 0.0f;
+			vcmd->param2 = 0.0f;
+			vcmd->param3 = 0.0f;
+			vcmd->param4 = 0.0f;
+			vcmd->param5 = 1.0;
+			vcmd->param6 = 0.0;
+			vcmd->param7 = 0.0f;
+			vcmd->command = vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL;
+
+		} else {
+			// We are only capturing multiple if param3 is 0 or > 1.
+			// For multiple pictures the sequence number does not need to be included, thus there is no need to go through camera_trigger
 			_is_capturing_images = true;
 		}
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1492,7 +1492,20 @@ void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
 	// sent to the mavlink links to other components.
 	switch (vcmd->command) {
 	case NAV_CMD_IMAGE_START_CAPTURE:
+
+		// We are only capturing multiple if param3 is 0 or > 1.
+		if (static_cast<int>(vcmd->param3) != 1) {
+			_is_capturing_images = true;
+		}
+
+		vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
+		break;
+
 	case NAV_CMD_IMAGE_STOP_CAPTURE:
+		_is_capturing_images = false;
+		vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
+		break;
+
 	case NAV_CMD_VIDEO_START_CAPTURE:
 	case NAV_CMD_VIDEO_STOP_CAPTURE:
 		vcmd->target_component = 100; // MAV_COMP_ID_CAMERA
@@ -1543,6 +1556,20 @@ void Navigator::release_gimbal_control()
 	vcmd.param3 = -1.0f; // Leave unchanged.
 	vcmd.param4 = -1.0f; // Leave unchanged.
 	publish_vehicle_cmd(&vcmd);
+}
+
+
+void
+Navigator::stop_capturing_images()
+{
+	if (_is_capturing_images) {
+		vehicle_command_s vcmd = {};
+		vcmd.command = NAV_CMD_IMAGE_STOP_CAPTURE;
+		vcmd.param1 = 0.0f;
+		publish_vehicle_cmd(&vcmd);
+
+		// _is_capturing_images is reset inside publish_vehicle_cmd.
+	}
 }
 
 bool Navigator::geofence_allows_position(const vehicle_global_position_s &pos)


### PR DESCRIPTION

## Describe problem solved by this pull request
This brings in a few fixes:

- If a survey was interrupted with an RTL, the drone would have kept doing the pictures doing the RTL. As per @julianoes comment at the time we discussed it: "_When a mission starts capturing images using the MAV_CMD_IMAGE_START_CAPTURE command, it should also stop it again, in case it is stopped early, e.g. with RTL_"
- According to MAVLink specs, when triggering a single photo the Capture ID needs to be incremented the to prevent double captures when a command is re-transmitted (https://mavlink.io/en/messages/common.html#MAV_CMD_IMAGE_START_CAPTURE).
This was not happening for "Hover and capture" waypoints and in general when using TakePhoto with MAVSDK.


## Describe your solution
A clear and concise description of what you have implemented.

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
