### PR TITLE
Always publish GPS heading in vehicle_gps_position if available

### DIFF
--- a/msg/vehicle_gps_position.msg
+++ b/msg/vehicle_gps_position.msg
@@ -35,5 +35,6 @@ uint8 satellites_used		# Number of satellites used
 
 float32 heading			# heading angle of XYZ body frame rel to NED. Set to NaN if not available and updated (used for dual antenna GPS), (rad, [-PI, PI])
 float32 heading_offset		# heading offset of dual antenna array in body frame. Set to NaN if not applicable. (rad, [-PI, PI])
+float32 heading_accuracy	# heading accuracy (rad, [0, 2PI])
 
 uint8 selected			# GPS selection: 0: GPS1, 1: GPS2. 2: GPS3. 3. Blending multiple receivers

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -487,6 +487,7 @@ sensor_gps_s GpsBlending::gps_blend_states(float blend_weights[GPS_MAX_RECEIVERS
 
 	gps_blended_state.heading = _gps_state[gps_best_yaw_index].heading;
 	gps_blended_state.heading_offset = _gps_state[gps_best_yaw_index].heading_offset;
+	gps_blended_state.heading_accuracy = _gps_state[gps_best_yaw_index].heading_accuracy;
 
 	return gps_blended_state;
 }

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
@@ -91,6 +91,7 @@ public:
 			return _gps_blended_state;
 		}
 	}
+	const sensor_gps_s &getOutputBlendedGpsData() const { return _gps_blended_state; }
 	int getSelectedGps() const { return _selected_gps; }
 
 private:


### PR DESCRIPTION
This PR fixes an issue with UAVCAN RTK GPS publishing heading in moving base mode. If the rover is not the _selected_gps, then the heading will not be used. 

There is a separate but related issue when the rover is not the first uorb instance to publish. The mavlink GPS_RAW_INT message will be using the moving base data and the user in QGC will not see RTK Fix in the GPS status.