### PR TITLE
uavcan: print info instead of error when no UAVCAN device  is detected

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -1200,7 +1200,8 @@ UavcanNode::param_count(uavcan::NodeID node_id)
 	req.index = 0;
 	int call_res = _param_getset_client.call(node_id, req);
 
-	if (call_res < 0) {
+	// -ErrInvalidParam is returned when no UAVCAN device is connected to the CAN bus
+	if ((call_res < 0) && (-uavcan::ErrInvalidParam != call_res)) {
 		PX4_ERR("couldn't start parameter count: %d", call_res);
 
 	} else {


### PR DESCRIPTION
## Describe the problem solved by this pull request
Users who have a `UAVCAN_ENABLE` parameter set different than Disabled and don't have any UAVCAN device connected, will get the following error:
`[uavcan] couldn't start parameter count`

To reproduce start QGC and check the parameters. 

## Describe your solution
Function `param_count` is getting ErrInvalidParam from call `_param_getset_client.call(node_id, req);  ` when there is no UAVCAN device connected on the CAN bus. 
My suggestion is to inform the user that there is no UAVCAN device connected instead of giving back the error.


If anyone has a better idea of how to solve it, please use this just as a pointer to the error and how to reproduce it. 

