### PR TITLE
Pre arm to flight checks

### DIFF
--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
@@ -68,9 +68,12 @@ transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &s
 		    && !(status.hil_state == vehicle_status_s::HIL_STATE_ON)
 		    && (_arm_state != vehicle_status_s::ARMING_STATE_IN_AIR_RESTORE)) {
 
-			if (!PreFlightCheck::preflightCheck(mavlink_log_pub, status, status_flags, control_mode, true, true, time_since_boot)
-			    || !PreFlightCheck::preArmCheck(mavlink_log_pub, status_flags, control_mode, safety_button_available, safety_off,
-							    arm_requirements, status)) {
+			if (!PreFlightCheck::preflightCheck(mavlink_log_pub, status, status_flags, control_mode,
+							    true, // report_failures
+							    true, // prearm
+							    time_since_boot,
+							    safety_button_available, safety_off,
+							    arm_requirements)) {
 				feedback_provided = true; // Preflight checks report error messages
 				valid_transition = false;
 			}

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
@@ -42,7 +42,6 @@ transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &s
 		const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
 		const arming_state_t new_arming_state, actuator_armed_s &armed, const bool fRunPreArmChecks,
 		orb_advert_t *mavlink_log_pub, vehicle_status_flags_s &status_flags,
-		const PreFlightCheck::arm_requirements_t &arm_requirements,
 		const hrt_abstime &time_since_boot, arm_disarm_reason_t calling_reason)
 {
 	// Double check that our static arrays are still valid
@@ -70,10 +69,9 @@ transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &s
 
 			if (!PreFlightCheck::preflightCheck(mavlink_log_pub, status, status_flags, control_mode,
 							    true, // report_failures
-							    true, // prearm
 							    time_since_boot,
 							    safety_button_available, safety_off,
-							    arm_requirements)) {
+							    true)) { // is_arm_attempt
 				feedback_provided = true; // Preflight checks report error messages
 				valid_transition = false;
 			}

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.hpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.hpp
@@ -57,7 +57,7 @@ public:
 	arming_state_transition(vehicle_status_s &status, const vehicle_control_mode_s &control_mode,
 				const bool safety_button_available, const bool safety_off, const arming_state_t new_arming_state,
 				actuator_armed_s &armed, const bool fRunPreArmChecks, orb_advert_t *mavlink_log_pub,
-				vehicle_status_flags_s &status_flags, const PreFlightCheck::arm_requirements_t &arm_requirements,
+				vehicle_status_flags_s &status_flags,
 				const hrt_abstime &time_since_boot, arm_disarm_reason_t calling_reason);
 
 	// Getters

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachineTest.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachineTest.cpp
@@ -250,8 +250,6 @@ TEST(ArmStateMachineTest, ArmingStateTransitionTest)
 	for (size_t i = 0; i < cArmingTransitionTests; i++) {
 		const ArmingTransitionTest_t *test = &rgArmingTransitionTests[i];
 
-		PreFlightCheck::arm_requirements_t arm_req{};
-
 		// Setup initial machine state
 		arm_state_machine.forceArmState(test->current_state.arming_state);
 		status.hil_state = test->hil_state;
@@ -271,7 +269,6 @@ TEST(ArmStateMachineTest, ArmingStateTransitionTest)
 						     true /* enable pre-arm checks */,
 						     nullptr /* no mavlink_log_pub */,
 						     status_flags,
-						     arm_req,
 						     2e6, /* 2 seconds after boot, everything should be checked */
 						     arm_disarm_reason_t::unit_test);
 

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -52,7 +52,9 @@ static constexpr unsigned max_mandatory_baro_count = 1;
 
 bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				    vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
-				    bool report_failures, const bool prearm, const hrt_abstime &time_since_boot)
+				    bool report_failures, const bool prearm, const hrt_abstime &time_since_boot,
+				    const bool safety_button_available, const bool safety_off,
+				    const arm_requirements_t &arm_requirements)
 {
 	report_failures = (report_failures && !status_flags.calibration_enabled);
 
@@ -226,6 +228,8 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	failed = failed || !modeCheck(mavlink_log_pub, report_failures, status);
 	failed = failed || !cpuResourceCheck(mavlink_log_pub, report_failures);
 	failed = failed || !parachuteCheck(mavlink_log_pub, report_failures, status_flags);
+	failed = failed || !preArmCheck(mavlink_log_pub, status_flags, control_mode,
+					safety_button_available, safety_off, arm_requirements, status, report_failures);
 
 	/* Report status */
 	return !failed;

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -52,9 +52,9 @@ static constexpr unsigned max_mandatory_baro_count = 1;
 
 bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				    vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
-				    bool report_failures, const bool prearm, const hrt_abstime &time_since_boot,
+				    bool report_failures, const hrt_abstime &time_since_boot,
 				    const bool safety_button_available, const bool safety_off,
-				    const arm_requirements_t &arm_requirements)
+				    const bool is_arm_attempt)
 {
 	report_failures = (report_failures && !status_flags.calibration_enabled);
 
@@ -143,7 +143,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 
 		const float arming_max_airspeed_allowed = airspeed_trim / 2.0f; // set to half of trim airspeed
 
-		if (!airspeedCheck(mavlink_log_pub, status, optional, report_failures, prearm, (bool)max_airspeed_check_en,
+		if (!airspeedCheck(mavlink_log_pub, status, optional, report_failures, is_arm_attempt, (bool)max_airspeed_check_en,
 				   arming_max_airspeed_allowed)
 		    && !(bool)optional) {
 			failed = true;
@@ -175,7 +175,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 
 	/* ---- SYSTEM POWER ---- */
 	if (status_flags.power_input_valid && !status_flags.circuit_breaker_engaged_power_check) {
-		if (!powerCheck(mavlink_log_pub, status, report_failures, prearm)) {
+		if (!powerCheck(mavlink_log_pub, status, report_failures)) {
 			failed = true;
 		}
 	}
@@ -195,7 +195,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	if (estimator_type == 2) {
 
 		const bool in_grace_period = time_since_boot < 10_s;
-		const bool do_report_ekf2_failures = report_failures && (!in_grace_period || prearm);
+		const bool do_report_ekf2_failures = report_failures && (!in_grace_period);
 		const bool ekf_healthy = ekf2Check(mavlink_log_pub, status, false, do_report_ekf2_failures) &&
 					 ekf2CheckSensorBias(mavlink_log_pub, do_report_ekf2_failures);
 
@@ -220,7 +220,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	}
 
 	/* ---- Failure Detector ---- */
-	if (!failureDetectorCheck(mavlink_log_pub, status, report_failures, prearm)) {
+	if (!failureDetectorCheck(mavlink_log_pub, status, report_failures)) {
 		failed = true;
 	}
 
@@ -229,7 +229,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	failed = failed || !cpuResourceCheck(mavlink_log_pub, report_failures);
 	failed = failed || !parachuteCheck(mavlink_log_pub, report_failures, status_flags);
 	failed = failed || !preArmCheck(mavlink_log_pub, status_flags, control_mode,
-					safety_button_available, safety_off, arm_requirements, status, report_failures);
+					safety_button_available, safety_off, status, report_failures, is_arm_attempt);
 
 	/* Report status */
 	return !failed;

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -56,44 +56,17 @@ public:
 	PreFlightCheck() = default;
 	~PreFlightCheck() = default;
 
-	struct arm_requirements_t {
-		bool arm_authorization = false;
-		bool esc_check = false;
-		bool global_position = false;
-		bool mission = false;
-		bool geofence = false;
-	};
-
 	/**
-	* Runs a preflight check on all sensors to see if they are properly calibrated and healthy
-	*
-	* The function won't fail the test if optional sensors are not found, however,
-	* it will fail the test if optional sensors are found but not in working condition.
+	* Runs a preflight check to determine if the system is ready to be armed
 	*
 	* @param mavlink_log_pub
 	*   Mavlink output orb handle reference for feedback when a sensor fails
-	* @param checkMag
-	*   true if the magneteometer should be checked
-	* @param checkAcc
-	*   true if the accelerometers should be checked
-	* @param checkGyro
-	*   true if the gyroscopes should be checked
-	* @param checkBaro
-	*   true if the barometer should be checked
-	* @param checkAirspeed
-	*   true if the airspeed sensor should be checked
-	* @param checkRC
-	*   true if the Remote Controller should be checked
-	* @param checkGNSS
-	*   true if the GNSS receiver should be checked
-	* @param checkPower
-	*   true if the system power should be checked
 	**/
 	static bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				   vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
-				   bool reportFailures, const bool prearm, const hrt_abstime &time_since_boot,
+				   bool reportFailures, const hrt_abstime &time_since_boot,
 				   const bool safety_button_available, const bool safety_off,
-				   const arm_requirements_t &arm_requirements);
+				   const bool is_arm_attempt = false);
 
 private:
 	static bool sensorAvailabilityCheck(const bool report_failure,
@@ -116,18 +89,14 @@ private:
 				  const bool is_mandatory, bool &report_fail);
 	static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool report_status);
 	static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool optional,
-				  const bool report_fail, const bool prearm, const bool max_airspeed_check_en, const float arming_max_airspeed_allowed);
+				  const bool report_fail, const bool is_arm_attempt, const bool max_airspeed_check_en,
+				  const float arming_max_airspeed_allowed);
 	static int rcCalibrationCheck(orb_advert_t *mavlink_log_pub, bool report_fail);
-	static bool powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,
-			       const bool prearm);
+	static bool powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail);
 	static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool optional,
 			      const bool report_fail);
-
 	static bool ekf2CheckSensorBias(orb_advert_t *mavlink_log_pub, const bool report_fail);
-
-	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,
-					 const bool prearm);
-
+	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail);
 	static bool manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
 	static bool modeCheck(orb_advert_t *mavlink_log_pub, const bool report_fail, const vehicle_status_s &status);
 	static bool airframeCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status);
@@ -137,6 +106,5 @@ private:
 				   const vehicle_status_flags_s &status_flags);
 	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
 				const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
-				const arm_requirements_t &arm_requirements, vehicle_status_s &status,
-				const bool report_fail);
+				vehicle_status_s &status, const bool report_fail, const bool is_arm_attempt);
 };

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -56,6 +56,14 @@ public:
 	PreFlightCheck() = default;
 	~PreFlightCheck() = default;
 
+	struct arm_requirements_t {
+		bool arm_authorization = false;
+		bool esc_check = false;
+		bool global_position = false;
+		bool mission = false;
+		bool geofence = false;
+	};
+
 	/**
 	* Runs a preflight check on all sensors to see if they are properly calibrated and healthy
 	*
@@ -83,20 +91,9 @@ public:
 	**/
 	static bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				   vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
-				   bool reportFailures, const bool prearm, const hrt_abstime &time_since_boot);
-
-	struct arm_requirements_t {
-		bool arm_authorization = false;
-		bool esc_check = false;
-		bool global_position = false;
-		bool mission = false;
-		bool geofence = false;
-	};
-
-	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
-				const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
-				const arm_requirements_t &arm_requirements, vehicle_status_s &status,
-				bool report_fail = true);
+				   bool reportFailures, const bool prearm, const hrt_abstime &time_since_boot,
+				   const bool safety_button_available, const bool safety_off,
+				   const arm_requirements_t &arm_requirements);
 
 private:
 	static bool sensorAvailabilityCheck(const bool report_failure,
@@ -138,4 +135,8 @@ private:
 	static bool sdcardCheck(orb_advert_t *mavlink_log_pub, bool &sd_card_detected_once, const bool report_fail);
 	static bool parachuteCheck(orb_advert_t *mavlink_log_pub, const bool report_fail,
 				   const vehicle_status_flags_s &status_flags);
+	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
+				const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
+				const arm_requirements_t &arm_requirements, vehicle_status_s &status,
+				const bool report_fail);
 };

--- a/src/modules/commander/Arming/PreFlightCheck/checks/airspeedCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/airspeedCheck.cpp
@@ -43,7 +43,8 @@
 using namespace time_literals;
 
 bool PreFlightCheck::airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, const bool optional,
-				   const bool report_fail, const bool prearm, const bool max_airspeed_check_en, const float arming_max_airspeed_allowed)
+				   const bool report_fail, const bool is_arm_attempt, const bool max_airspeed_check_en,
+				   const float arming_max_airspeed_allowed)
 {
 	bool present = true;
 	bool success = true;
@@ -84,7 +85,7 @@ bool PreFlightCheck::airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status
 	 * might have been removed.
 	 */
 	if (max_airspeed_check_en && fabsf(airspeed_validated.calibrated_airspeed_m_s) > arming_max_airspeed_allowed
-	    && prearm) {
+	    && !is_arm_attempt) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: check Airspeed Cal or pitot");
 		}

--- a/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
@@ -36,13 +36,8 @@
 #include <systemlib/mavlink_log.h>
 
 bool PreFlightCheck::failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
-		const bool report_fail, const bool prearm)
+		const bool report_fail)
 {
-	// Ignore failure detector check after arming
-	if (!prearm) {
-		return true;
-	}
-
 	if (status.failure_detector_status != vehicle_status_s::FAILURE_NONE) {
 		if (report_fail) {
 			if (status.failure_detector_status & vehicle_status_s::FAILURE_ROLL) {

--- a/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/powerCheck.cpp
@@ -42,15 +42,9 @@
 
 using namespace time_literals;
 
-bool PreFlightCheck::powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail,
-				const bool prearm)
+bool PreFlightCheck::powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail)
 {
 	bool success = true;
-
-	if (!prearm) {
-		// Ignore power check after arming.
-		return true;
-	}
 
 	if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 		// Ignore power check in HITL.

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -40,7 +40,7 @@
 
 bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
 				 const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
-				 const arm_requirements_t &arm_requirements, vehicle_status_s &status, bool report_fail)
+				 const arm_requirements_t &arm_requirements, vehicle_status_s &status, const bool report_fail)
 {
 	bool prearm_ok = true;
 
@@ -226,7 +226,6 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 			prearm_ok = false;
 		}
 	}
-
 
 	return prearm_ok;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -34,13 +34,14 @@
 #include "../PreFlightCheck.hpp"
 
 #include <ArmAuthorization.h>
+#include <HealthFlags.h>
+#include <lib/parameters/param.h>
 #include <systemlib/mavlink_log.h>
 #include <uORB/topics/vehicle_command_ack.h>
-#include <HealthFlags.h>
 
 bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
 				 const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
-				 const arm_requirements_t &arm_requirements, vehicle_status_s &status, const bool report_fail)
+				 vehicle_status_s &status, const bool report_fail, const bool is_arm_attempt)
 {
 	bool prearm_ok = true;
 
@@ -117,8 +118,11 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 	}
 
 	// Arm Requirements: mission
-	if (arm_requirements.mission) {
+	int32_t _param_com_arm_mis_req = 0;
+	param_get(param_find("COM_ARM_MIS_REQ"), &_param_com_arm_mis_req);
+	const bool mission_required = (_param_com_arm_mis_req == 1);
 
+	if (mission_required) {
 		if (!status_flags.auto_mission_available) {
 			if (prearm_ok) {
 				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! No valid mission"); }
@@ -136,8 +140,11 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		}
 	}
 
-	if (arm_requirements.global_position && !status_flags.circuit_breaker_engaged_posfailure_check) {
+	int32_t _param_com_arm_wo_gps = 1;
+	param_get(param_find("COM_ARM_WO_GPS"), &_param_com_arm_wo_gps);
+	const bool global_position_required = (_param_com_arm_wo_gps == 0);
 
+	if (global_position_required && !status_flags.circuit_breaker_engaged_posfailure_check) {
 		if (!status_flags.global_position_valid) {
 			if (prearm_ok) {
 				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Global position required"); }
@@ -174,7 +181,11 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 	}
 
-	if (arm_requirements.esc_check && status_flags.escs_error) {
+	int32_t _param_com_arm_chk_escs = 1;
+	param_get(param_find("COM_ARM_CHK_ESCS"), &_param_com_arm_chk_escs);
+	const bool esc_checks_required = (_param_com_arm_chk_escs == 0);
+
+	if (esc_checks_required && status_flags.escs_error) {
 		if (prearm_ok) {
 			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! One or more ESCs are offline"); }
 
@@ -182,7 +193,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		}
 	}
 
-	if (arm_requirements.esc_check && status_flags.escs_failure) {
+	if (esc_checks_required && status_flags.escs_failure) {
 		if (prearm_ok) {
 			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! One or more ESCs have a failure"); }
 
@@ -191,7 +202,6 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 	}
 
 	if (status.is_vtol) {
-
 		if (status.in_transition_mode) {
 			if (prearm_ok) {
 				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Vehicle is in transition state"); }
@@ -210,7 +220,11 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		}
 	}
 
-	if (arm_requirements.geofence && status.geofence_violated) {
+	int32_t _param_gf_action = 0;
+	param_get(param_find("GF_ACTION"), &_param_gf_action);
+	const bool gefence_action_configured = (_param_gf_action != 0);
+
+	if (gefence_action_configured && status.geofence_violated) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "Arming denied, vehicle outside geofence");
 		}
@@ -218,9 +232,14 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		prearm_ok = false;
 	}
 
+	int32_t _param_com_arm_auth_req = 0;
+	param_get(param_find("GF_ACTION"), &_param_com_arm_auth_req);
+	const bool arm_authorization_configured = (_param_com_arm_auth_req != 0);
+
 	// Arm Requirements: authorization
 	// check last, and only if everything else has passed
-	if (arm_requirements.arm_authorization && prearm_ok) {
+	// skip arm authorization check until actual arming attempt
+	if (arm_authorization_configured && prearm_ok && is_arm_attempt) {
 		if (arm_auth_check() != vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED) {
 			// feedback provided in arm_auth_check
 			prearm_ok = false;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -244,9 +244,6 @@ private:
 		// Engine failure
 		(ParamInt<px4::params::COM_ACT_FAIL_ACT>) _param_com_actuator_failure_act,
 
-		(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_arm_without_gps,
-		(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_arm_mission_required,
-		(ParamBool<px4::params::COM_ARM_AUTH_REQ>) _param_arm_auth_required,
 		(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required,
 
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
@@ -295,7 +292,6 @@ private:
 	static constexpr uint64_t INAIR_RESTART_HOLDOFF_INTERVAL{500_ms};
 
 	ArmStateMachine _arm_state_machine{};
-	PreFlightCheck::arm_requirements_t	_arm_requirements{};
 
 	hrt_abstime	_valid_distance_sensor_time_us{0}; /**< Last time that distance sensor data arrived (usec) */
 


### PR DESCRIPTION
## Additional context
Builds on https://github.com/PX4/PX4-Autopilot/pull/19806, please review that one first.

## Describe problem solved by this pull request
Pre arm and pre flight checks are always called separately sometimes even inconsistently depending on what data is available and the results have to get merged together again even though there's no real difference between the checks.

## Describe your solution
I made the pre arm checks part of the pre-flight checks. I also replaced the arm_requirements struct because it was passed around as locally amended copies of otherwise parameter-filled data. Instead I'm specifically taking care that the arm authorization request only happens on an actual arm attempt.

## Describe possible alternatives
It's planned already that we'll support checks to be regularly run even in flight to trigger warnings and failsafe behavior with a new architecture. This pr is just cleaning up such that it gets easier to port checks.

## Test data / coverage
I did not test this yet. Looking into simulation tests.