### PR TITLE
[MC&VTOL] Faster blind landing (position loss failsafe)

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
+++ b/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
@@ -52,7 +52,7 @@ bool FlightTaskDescend::update()
 
 	if (PX4_ISFINITE(_velocity(2))) {
 		// land with landspeed
-		_velocity_setpoint(2) = _param_mpc_land_speed.get();
+		_velocity_setpoint(2) = _param_mpc_z_vel_max_dn.get();
 		_acceleration_setpoint(2) = NAN;
 
 	} else {

--- a/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
+++ b/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
@@ -51,9 +51,18 @@ bool FlightTaskDescend::update()
 	bool ret = FlightTask::update();
 
 	if (PX4_ISFINITE(_velocity(2))) {
-		// land with landspeed
+		// descend with maximum downspeed
 		_velocity_setpoint(2) = _param_mpc_z_vel_max_dn.get();
 		_acceleration_setpoint(2) = NAN;
+
+		// Slow down automatic descend close to ground
+		bool range_dist_available = PX4_ISFINITE(_dist_to_bottom);
+
+		if (range_dist_available) {
+			_velocity_setpoint(2) = math::gradual(_dist_to_bottom,
+							      _param_mpc_land_alt2.get(), _param_mpc_land_alt1.get(),
+							      _param_mpc_land_speed.get(), _param_mpc_z_vel_max_dn.get());
+		}
 
 	} else {
 		// descend with constant acceleration (crash landing)

--- a/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.hpp
+++ b/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.hpp
@@ -51,6 +51,8 @@ public:
 private:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
 					(ParamFloat<px4::params::MPC_THR_HOVER>) _param_mpc_thr_hover, ///< thrust at hover equilibrium
-					(ParamFloat<px4::params::MPC_LAND_SPEED>) _param_mpc_land_speed ///< velocity for controlled descend
+					(ParamFloat<px4::params::MPC_LAND_SPEED>) _param_mpc_land_speed, ///< velocity for controlled descend
+					(ParamFloat<px4::params::MPC_LAND_ALT1>) _param_mpc_land_alt1, ///< altitude at which we start ramping down speed
+					(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2 ///< altitude at which we descend at land speed
 				       )
 };


### PR DESCRIPTION
## Describe problem solved by this pull request
The global position loss failsafe is IMO one of the most poorly handled failsafes, especially for MC and VTOLs. If you fly in high wind conditions the possible position drift is currently almost without bounds. And as without a global position you most likely don't have a functioning geocage anymore, this is really problematic.

This PR reduces the potential drifts by descending faster. 

## Describe your solution
Use MPC_Z_VEL_MAX_DN to set the descent speed in DESCEND mode instead of MPC_LAND_SPEED. If there is a valid `_dist_to_bottom` measurement use this to slow down the landing before hitting the ground. 

If there is no rangefinder, the vehicle will hit the ground with MPC_Z_VEL_MAX_DN, which is IMO still much better than having enormous drifts.

## Test data / coverage
SITL on a modified standard_vtol model that includes a lidar sensor: [standard_vtol.zip](https://github.com/PX4/PX4-Autopilot/files/8918206/standard_vtol.zip) (following https://docs.px4.io/v1.12/en/sensor/rangefinders.html#simulation)

Log flying a mission, disabling GPS via `failure gps off` : https://logs.px4.io/plot_app?log=6e024336-d596-40eb-9e95-42bbafd2d625

In the following screenshot, you can see how the down speed reduces from MPC_Z_VEL_MAX_DN (1.5m/s) to MPC_LAND_SPEED (0.7m/s) when using the lidar.
![Screenshot from 2022-06-16 12-53-46](https://user-images.githubusercontent.com/48206725/174055847-3719a96a-1f3b-4f5e-9668-330a8fe513ed.png)

## Additional context
PR following a slack discussion: https://px4.slack.com/archives/C0V533X4N/p1653709401725759