### PR TITLE
mavlink_shell: set target system and component id

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2427,6 +2427,8 @@ Mavlink::task_main(int argc, char *argv[])
 				msg.timeout = 0;
 				msg.device = SERIAL_CONTROL_DEV_SHELL;
 				msg.count = _mavlink_shell->read(msg.data, sizeof(msg.data));
+				msg.target_system = _mavlink_shell->targetSysid();
+				msg.target_component = _mavlink_shell->targetCompid();
 				mavlink_msg_serial_control_send_struct(get_channel(), &msg);
 			}
 		}

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1778,6 +1778,7 @@ MavlinkReceiver::handle_message_serial_control(mavlink_message_t *msg)
 	if (shell) {
 		// we ignore the timeout, EXCLUSIVE & BLOCKING flags of the SERIAL_CONTROL message
 		if (serial_control_mavlink.count > 0) {
+			shell->setTargetID(msg->sysid, msg->compid);
 			shell->write(serial_control_mavlink.data, serial_control_mavlink.count);
 		}
 

--- a/src/modules/mavlink/mavlink_shell.h
+++ b/src/modules/mavlink/mavlink_shell.h
@@ -42,6 +42,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <px4_platform_common/tasks.h>
+#include <px4_platform_common/atomic.h>
 
 #pragma once
 
@@ -77,7 +78,14 @@ public:
 	 */
 	size_t available();
 
+	void setTargetID(uint8_t sysid, uint8_t compid) { _target_sysid.store(sysid); _target_compid.store(compid); }
+
+	uint8_t targetSysid() const { return _target_sysid.load(); }
+	uint8_t targetCompid() const { return _target_compid.load(); }
 private:
+
+	px4::atomic<uint8_t> _target_sysid{};
+	px4::atomic<uint8_t> _target_compid{};
 
 	int _to_shell_fd = -1; /** fd to write to the shell */
 	int _from_shell_fd = -1; /** fd to read from the shell */


### PR DESCRIPTION
These got added in https://github.com/mavlink/mavlink/pull/1725 and need to be set for correct routing.