### PR TITLE
UAVCAN servo feedback added

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -174,6 +174,8 @@ set(msg_files
 	SensorSelection.msg
 	SensorsStatus.msg
 	SensorsStatusImu.msg
+	ServoReport.msg
+	ServoStatus.msg
 	SystemPower.msg
 	TakeoffStatus.msg
 	TaskStackInfo.msg

--- a/msg/ServoReport.msg
+++ b/msg/ServoReport.msg
@@ -1,0 +1,9 @@
+uint64 timestamp					# time since system start (microseconds)
+
+float32 servo_position					# feedback position of servo. [-1;1]
+float32 servo_speed					# feedback speed of servo [deg/s]
+float32 servo_acceleration				# feedback of acceleration
+uint8 load_pct						# Load percentage
+uint8 servo_id						# id of servo
+uint8 servo_function					# servo output function (one of Servo1...ServoN)
+

--- a/msg/ServoStatus.msg
+++ b/msg/ServoStatus.msg
@@ -1,0 +1,19 @@
+uint64 timestamp					# time since system start (microseconds)
+uint8 CONNECTED_SERVO_MAX = 8				# The number of Servos supported. Current (Q2/2013) we support 8 Servos
+
+uint16 counter  					# incremented by the writing thread everytime new data is stored
+uint8 servo_count					# number of connected servo's
+uint8 servo_online_flags				# Bitmask indicating which servo is online/offline
+
+# servo_online_flags bit 0 : Set to 1 if SERVO0 is online
+# servo_online_flags bit 1 : Set to 1 if SERVO1 is online
+# servo_online_flags bit 2 : Set to 1 if SERVO2 is online
+# servo_online_flags bit 3 : Set to 1 if SERVO3 is online
+# servo_online_flags bit 4 : Set to 1 if SERVO4 is online
+# servo_online_flags bit 5 : Set to 1 if SERVO5 is online
+# servo_online_flags bit 6 : Set to 1 if SERVO6 is online
+# servo_online_flags bit 7 : Set to 1 if SERVO7 is online
+
+
+ServoReport[8] servo
+

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -39,9 +39,31 @@ using namespace time_literals;
 
 UavcanServoController::UavcanServoController(uavcan::INode &node) :
 	_node(node),
-	_uavcan_pub_array_cmd(node)
+	_uavcan_pub_array_cmd(node),
+	_uavcan_sub_status(node)
 {
 	_uavcan_pub_array_cmd.setPriority(UAVCAN_COMMAND_TRANSFER_PRIORITY);
+}
+
+
+int
+UavcanServoController::init()
+{
+	// Servo status subscription
+	int res = _uavcan_sub_status.start(StatusCbBinder(this, &UavcanServoController::servo_status_sub_cb));
+
+	if (res < 0) {
+		PX4_ERR("Servo status sub failed %i", res);
+		return res;
+	}
+
+	return res;
+}
+
+void
+UavcanServoController::set_servo_count(uint8_t count)
+{
+	_servo_count = count;
 }
 
 void
@@ -59,4 +81,49 @@ UavcanServoController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACT
 	}
 
 	_uavcan_pub_array_cmd.broadcast(msg);
+}
+
+
+void
+UavcanServoController::servo_status_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::actuator::Status>
+		&msg)
+{
+	// make sure your ID number set on your uavcan servo is between 0-8 otherwise it wont be picked up here.
+	if (msg.actuator_id < servo_status_s::CONNECTED_SERVO_MAX) {
+		auto &ref = _servo_status.servo[msg.actuator_id];
+
+		ref.timestamp       	= hrt_absolute_time();
+		ref.servo_position 	= msg.position;
+		ref.servo_acceleration  = msg.force;
+		ref.servo_speed     	= msg.speed;
+		ref.load_pct     	= msg.power_rating_pct;
+
+		_servo_status.timestamp = hrt_absolute_time();
+		_servo_status.servo_count = _servo_count;
+		_servo_status.counter += 1;
+
+		// this is only helpfull if you have more than 1 UAVCAN servo connected, since if you have only one,
+		// and it gets disconnected, this callback function will not execute, thus not updating the
+		// check_servo_status()
+		_servo_status.servo_online_flags = check_servos_status();
+		_servo_status_pub.publish(_servo_status);
+	}
+}
+
+uint8_t
+UavcanServoController::check_servos_status()
+{
+	int servo_status_flags = 0;
+	const hrt_abstime now = hrt_absolute_time();
+
+	for (int index = 0; index < servo_status_s::CONNECTED_SERVO_MAX; index++) {
+
+		// this timeout value can be too short for a given servo periodic stream rate, and may result in a servo being timeout.
+		if (_servo_status.servo[index].timestamp > 0 && now - _servo_status.servo[index].timestamp < 1200_ms) {
+			servo_status_flags |= (1 << index);
+		}
+
+	}
+
+	return servo_status_flags;
 }

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -56,6 +56,7 @@
 #include <arch/chip/chip.h>
 
 #include <uORB/topics/esc_status.h>
+#include <uORB/topics/servo_status.h>
 
 #include <drivers/drv_hrt.h>
 
@@ -492,6 +493,12 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	}
 
 	ret = _hardpoint_controller.init();
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = _servo_controller.init();
 
 	if (ret < 0) {
 		return ret;
@@ -945,10 +952,10 @@ void UavcanMixingInterfaceESC::mixerChanged()
 	_esc_controller.set_rotor_count(rotor_count);
 }
 
-bool UavcanMixingInterfaceServo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceServo::updateOutputs(bool stop_servos, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
-	_servo_controller.update_outputs(stop_motors, outputs, num_outputs);
+	_servo_controller.update_outputs(stop_servos, outputs, num_outputs);
 	return true;
 }
 
@@ -958,6 +965,22 @@ void UavcanMixingInterfaceServo::Run()
 	_mixing_output.update();
 	_mixing_output.updateSubscriptions(false);
 	pthread_mutex_unlock(&_node_mutex);
+}
+
+void UavcanMixingInterfaceServo::mixerChanged()
+{
+	int servo_count = 0;
+
+	for (unsigned i = 0; i < MAX_ACTUATORS; ++i) {
+		servo_count += _mixing_output.isFunctionSet(i);
+
+		if (i < servo_status_s::CONNECTED_SERVO_MAX) {
+			_servo_controller.servo_status().servo[i].servo_function = (uint8_t)_mixing_output.outputFunction(i);
+		}
+
+	}
+
+	_servo_controller.set_servo_count(servo_count);
 }
 
 void

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -129,8 +129,10 @@ public:
 		  _node_mutex(node_mutex),
 		  _servo_controller(servo_controller) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_servos, uint16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
+
+	void mixerChanged() override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }
 

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -63,6 +63,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("external_ins_global_position");
 	add_optional_topic("external_ins_local_position");
 	add_optional_topic("esc_status", 250);
+	add_optional_topic("servo_status", 250);
 	add_topic("failure_detector_status", 100);
 	add_topic("failsafe_flags");
 	add_optional_topic("follow_target", 500);


### PR DESCRIPTION
## Describe problem solved by this pull request
There is no feedback implemented for uavcan servo's

## Describe your solution
Follow a close implementation of that of uavcan esc's:
- Added ```servo_status``` and ```servo_report``` uorb messages and resembles that of ```esc_status``` and ```esc_report```
- Using the ```uavcan::equipment::actuator::Status``` message in the callback to fill in the feedback info

## Test data / coverage
- Tested with Hitec MD950 CAN servo. Work as excepted using the Actuator Tab in QGC when assigning the Landing Gear Function to the corresponding Servo


## Additional context
The following is also added in the code comments at the relevant places:
- The ```check_servos_status()```  function is only helpful if you have more than 1 UAVCAN servo connected, since if you have only one, and it gets disconnected, the callback function will not execute, thus not updating the ```check_servo_status()``` function
-  The timeout check in the ```check_servo_status()``` function can be too short for a given servo periodic stream rate, and may result in a servo being timeout. (untested)
-  Make sure your ID number set on your uavcan servo is between 0-8 otherwise it wont be picked up here. (untested)
- The above points is also applicable to the uavcan ESC's implementation. (untested)

- Also added a similar implementation for the ```mixerChanged()``` method as that of ```UavcanMixingInterfaceESC::mixerChangerd()``` but not too sure of the implications.
