### PR TITLE
Preflight check: simplify messageing

### DIFF
--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
@@ -42,7 +42,7 @@ transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &s
 		const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
 		const arming_state_t new_arming_state, actuator_armed_s &armed, const bool fRunPreArmChecks,
 		orb_advert_t *mavlink_log_pub, vehicle_status_flags_s &status_flags,
-		const hrt_abstime &time_since_boot, arm_disarm_reason_t calling_reason)
+		arm_disarm_reason_t calling_reason)
 {
 	// Double check that our static arrays are still valid
 	static_assert(vehicle_status_s::ARMING_STATE_INIT == 0, "ARMING_STATE_INIT == 0");
@@ -69,7 +69,6 @@ transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &s
 
 			if (!PreFlightCheck::preflightCheck(mavlink_log_pub, status, status_flags, control_mode,
 							    true, // report_failures
-							    time_since_boot,
 							    safety_button_available, safety_off,
 							    true)) { // is_arm_attempt
 				feedback_provided = true; // Preflight checks report error messages

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.hpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.hpp
@@ -58,7 +58,7 @@ public:
 				const bool safety_button_available, const bool safety_off, const arming_state_t new_arming_state,
 				actuator_armed_s &armed, const bool fRunPreArmChecks, orb_advert_t *mavlink_log_pub,
 				vehicle_status_flags_s &status_flags,
-				const hrt_abstime &time_since_boot, arm_disarm_reason_t calling_reason);
+				arm_disarm_reason_t calling_reason);
 
 	// Getters
 	uint8_t getArmState() const { return _arm_state; }

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachineTest.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachineTest.cpp
@@ -269,7 +269,6 @@ TEST(ArmStateMachineTest, ArmingStateTransitionTest)
 						     true /* enable pre-arm checks */,
 						     nullptr /* no mavlink_log_pub */,
 						     status_flags,
-						     2e6, /* 2 seconds after boot, everything should be checked */
 						     arm_disarm_reason_t::unit_test);
 
 		// Validate result of transition

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -64,7 +64,7 @@ public:
 	**/
 	static bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				   vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
-				   bool reportFailures, const hrt_abstime &time_since_boot,
+				   bool reportFailures,
 				   const bool safety_button_available, const bool safety_off,
 				   const bool is_arm_attempt = false);
 
@@ -93,8 +93,7 @@ private:
 				  const float arming_max_airspeed_allowed);
 	static int rcCalibrationCheck(orb_advert_t *mavlink_log_pub, bool report_fail);
 	static bool powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail);
-	static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool optional,
-			      const bool report_fail);
+	static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool report_fail);
 	static bool ekf2CheckSensorBias(orb_advert_t *mavlink_log_pub, const bool report_fail);
 	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail);
 	static bool manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);

--- a/src/modules/commander/Arming/PreFlightCheck/checks/ekf2Check.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/ekf2Check.cpp
@@ -44,8 +44,7 @@
 
 using namespace time_literals;
 
-bool PreFlightCheck::ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool optional,
-			       const bool report_fail)
+bool PreFlightCheck::ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool report_fail)
 {
 	bool success = true; // start with a pass and change to a fail if any test fails
 

--- a/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/preArmCheck.cpp
@@ -47,48 +47,48 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 	// rate control mode require valid angular velocity
 	if (control_mode.flag_control_rates_enabled && !status_flags.angular_velocity_valid) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! angular velocity invalid"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Angular velocity invalid"); }
 
 		prearm_ok = false;
 	}
 
 	// attitude control mode require valid attitude
 	if (control_mode.flag_control_attitude_enabled && !status_flags.attitude_valid) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! attitude invalid"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Attitude invalid"); }
 
 		prearm_ok = false;
 	}
 
 	// velocity control mode require valid velocity
 	if (control_mode.flag_control_velocity_enabled && !status_flags.local_velocity_valid) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! velocity invalid"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Velocity invalid"); }
 
 		prearm_ok = false;
 	}
 
 	// position control mode require valid position
 	if (control_mode.flag_control_position_enabled && !status_flags.local_position_valid) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! position invalid"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Position invalid"); }
 
 		prearm_ok = false;
 	}
 
 	// manual control mode require valid manual control (rc)
 	if (control_mode.flag_control_manual_enabled && status.rc_signal_lost) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! manual control lost"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Manual control unavailable"); }
 
 		prearm_ok = false;
 	}
 
 	if (status_flags.flight_terminated) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Flight termination active"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Flight termination active"); }
 
 		prearm_ok = false;
 	}
 
 	// USB not connected
 	if (!status_flags.circuit_breaker_engaged_usb_check && status_flags.usb_connected) {
-		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Flying with USB is not safe"); }
+		if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Flying with USB is not safe"); }
 
 		prearm_ok = false;
 	}
@@ -98,7 +98,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 		// Fail transition if power is not good
 		if (!status_flags.power_input_valid) {
-			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Connect power module"); }
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Connect power module"); }
 
 			prearm_ok = false;
 		}
@@ -110,7 +110,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		// Only arm if healthy
 		if (!status_flags.battery_healthy) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Check battery"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Check battery"); }
 			}
 
 			prearm_ok = false;
@@ -125,7 +125,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 	if (mission_required) {
 		if (!status_flags.auto_mission_available) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! No valid mission"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "No valid mission"); }
 			}
 
 			prearm_ok = false;
@@ -133,7 +133,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 		if (!status_flags.global_position_valid) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Missions require a global position"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Missions require a global position"); }
 			}
 
 			prearm_ok = false;
@@ -147,7 +147,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 	if (global_position_required && !status_flags.circuit_breaker_engaged_posfailure_check) {
 		if (!status_flags.global_position_valid) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Global position required"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Global position required"); }
 			}
 
 			prearm_ok = false;
@@ -155,7 +155,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 		if (!status_flags.home_position_valid) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Home position invalid"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Home position invalid"); }
 			}
 
 			prearm_ok = false;
@@ -166,7 +166,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 	if (safety_button_available && !safety_off) {
 		// Fail transition if we need safety button press
 		if (prearm_ok) {
-			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Press safety button first"); }
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Press safety button first"); }
 		}
 
 		prearm_ok = false;
@@ -174,7 +174,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 	if (status_flags.avoidance_system_required && !status_flags.avoidance_system_valid) {
 		if (prearm_ok) {
-			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Avoidance system not ready"); }
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Avoidance system not ready"); }
 		}
 
 		prearm_ok = false;
@@ -187,7 +187,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 	if (esc_checks_required && status_flags.escs_error) {
 		if (prearm_ok) {
-			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! One or more ESCs are offline"); }
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "One or more ESCs are offline"); }
 
 			prearm_ok = false;
 		}
@@ -195,7 +195,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 	if (esc_checks_required && status_flags.escs_failure) {
 		if (prearm_ok) {
-			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! One or more ESCs have a failure"); }
+			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "One or more ESCs have a failure"); }
 
 			prearm_ok = false;
 		}
@@ -204,7 +204,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 	if (status.is_vtol) {
 		if (status.in_transition_mode) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Vehicle is in transition state"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Vehicle is in transition state"); }
 
 				prearm_ok = false;
 			}
@@ -213,7 +213,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 		if (!status_flags.circuit_breaker_vtol_fw_arming_check
 		    && status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 			if (prearm_ok) {
-				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Arming denied! Vehicle is not in multicopter mode"); }
+				if (report_fail) { mavlink_log_critical(mavlink_log_pub, "Vehicle is not in multicopter mode"); }
 
 				prearm_ok = false;
 			}
@@ -226,7 +226,7 @@ bool PreFlightCheck::preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_st
 
 	if (gefence_action_configured && status.geofence_violated) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Arming denied, vehicle outside geofence");
+			mavlink_log_critical(mavlink_log_pub, "Vehicle outside geofence");
 		}
 
 		prearm_ok = false;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -299,7 +299,6 @@ int Commander::custom_command(int argc, char *argv[])
 		bool preflight_check_res = PreFlightCheck::preflightCheck(nullptr, vehicle_status, vehicle_status_flags,
 					   vehicle_control_mode,
 					   true, // report_failures
-					   30_s,
 					   false, // safety_buttton_available not known
 					   false); // safety_off not known
 		PX4_INFO("Preflight check: %s", preflight_check_res ? "OK" : "FAILED");
@@ -496,7 +495,7 @@ bool Commander::shutdown_if_allowed()
 			_safety.isButtonAvailable(), _safety.isSafetyOff(),
 			vehicle_status_s::ARMING_STATE_SHUTDOWN,
 			_actuator_armed, false /* fRunPreArmChecks */, &_mavlink_log_pub, _vehicle_status_flags,
-			hrt_elapsed_time(&_boot_timestamp), arm_disarm_reason_t::shutdown);
+			arm_disarm_reason_t::shutdown);
 }
 
 static constexpr const char *arm_disarm_reason_str(arm_disarm_reason_t calling_reason)
@@ -748,7 +747,7 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 	transition_result_t arming_res = _arm_state_machine.arming_state_transition(_vehicle_status, _vehicle_control_mode,
 					 _safety.isButtonAvailable(), _safety.isSafetyOff(),
 					 vehicle_status_s::ARMING_STATE_ARMED, _actuator_armed, run_preflight_checks,
-					 &_mavlink_log_pub, _vehicle_status_flags, hrt_elapsed_time(&_boot_timestamp),
+					 &_mavlink_log_pub, _vehicle_status_flags,
 					 calling_reason);
 
 	if (arming_res == TRANSITION_CHANGED) {
@@ -793,7 +792,7 @@ transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool f
 					 _safety.isButtonAvailable(), _safety.isSafetyOff(),
 					 vehicle_status_s::ARMING_STATE_STANDBY, _actuator_armed, false,
 					 &_mavlink_log_pub, _vehicle_status_flags,
-					 hrt_elapsed_time(&_boot_timestamp), calling_reason);
+					 calling_reason);
 
 	if (arming_res == TRANSITION_CHANGED) {
 		mavlink_log_info(&_mavlink_log_pub, "Disarmed by %s\t", arm_disarm_reason_str(calling_reason));
@@ -853,7 +852,6 @@ Commander::Commander() :
 	// run preflight immediately to find all relevant parameters, but don't report
 	PreFlightCheck::preflightCheck(&_mavlink_log_pub, _vehicle_status, _vehicle_status_flags, _vehicle_control_mode,
 				       false, // report_failures
-				       hrt_elapsed_time(&_boot_timestamp),
 				       false, // safety_buttton_available not known
 				       false); // safety_off not known
 }
@@ -1408,7 +1406,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 						_safety.isButtonAvailable(), _safety.isSafetyOff(),
 						vehicle_status_s::ARMING_STATE_INIT, _actuator_armed,
 						false /* fRunPreArmChecks */, &_mavlink_log_pub, _vehicle_status_flags,
-						30_s, // time since boot not relevant for switching to ARMING_STATE_INIT
 						(cmd.from_external ? arm_disarm_reason_t::command_external : arm_disarm_reason_t::command_internal))
 				   ) {
 
@@ -2459,7 +2456,6 @@ Commander::run()
 					_safety.isButtonAvailable(), _safety.isSafetyOff(),
 					vehicle_status_s::ARMING_STATE_STANDBY, _actuator_armed,
 					true /* fRunPreArmChecks */, &_mavlink_log_pub, _vehicle_status_flags,
-					hrt_elapsed_time(&_boot_timestamp),
 					arm_disarm_reason_t::transition_to_standby);
 		}
 
@@ -3000,7 +2996,6 @@ Commander::run()
 						_vehicle_status_flags,
 						_vehicle_control_mode,
 						false, // report_failures
-						hrt_elapsed_time(&_boot_timestamp),
 						_safety.isButtonAvailable(), _safety.isSafetyOff());
 				perf_end(_preflight_check_perf);
 
@@ -3630,7 +3625,6 @@ void Commander::data_link_check()
 						// make sure to report preflight check failures to a connecting GCS
 						PreFlightCheck::preflightCheck(&_mavlink_log_pub, _vehicle_status, _vehicle_status_flags, _vehicle_control_mode,
 									       true, // report_failures
-									       hrt_elapsed_time(&_boot_timestamp),
 									       _safety.isButtonAvailable(), _safety.isSafetyOff());
 					}
 				}


### PR DESCRIPTION
## Describe problem solved by this pull request
1. Pre arm checks which are now preflight checks since #19807 always write "Arming denied!" before the actual reason. This will get simpler and more clear when transitioning the reporting of these checks to events.
2. The preflight checks had to be fed with a time since boot to only execute estimator checks 10 seconds later than the actual boot time. Which was a workaround see https://github.com/PX4/PX4-Autopilot/pull/17169 and https://github.com/PX4/PX4-Autopilot/pull/18204.

## Describe your solution
1. I left the prefix away.
2. I removed this passed in grace period. Like @dagar also suggested here: https://github.com/PX4/PX4-Autopilot/compare/pr-commander_consolidate_arming#diff-8dbe4602a00c6d769a55577c614b571fe8edba3147f29526187ce0a7dd24b926L196
If there's a problem with the report when connecting the ground station we might want to delay doing that report if it's too close to booting but I would avoid running certain checks differently for that reason.

## Describe possible alternatives
I can give it a shot to delay reporting if it's too quickly after boot if desired.

## Test data / coverage
I tested this in SITL SIH. Note that the timing might be different on the real vehicle. Sensors take longer but probably also the ground station takes longer to connect.