### PR TITLE
removed unused code - _constrainOneSide and _constrainAbs

### DIFF
--- a/src/lib/motion_planning/PositionSmoothing.cpp
+++ b/src/lib/motion_planning/PositionSmoothing.cpp
@@ -84,26 +84,6 @@ bool PositionSmoothing::_isTurning(const Vector3f &target) const
 		&& pos_to_target.longerThan(_target_acceptance_radius));
 }
 
-
-
-/* Constrain some value vith a constrain depending on the sign of the constraint
- * Example: 	- if the constrain is -5, the value will be constrained between -5 and 0
- * 		- if the constrain is 5, the value will be constrained between 0 and 5
- */
-inline float _constrainOneSide(float val, float constraint)
-{
-	const float min = (constraint < FLT_EPSILON) ? constraint : 0.f;
-	const float max = (constraint > FLT_EPSILON) ? constraint : 0.f;
-
-	return math::constrain(val, min, max);
-}
-
-inline float _constrainAbs(float val, float max)
-{
-	return matrix::sign(val) * math::min(fabsf(val), fabsf(max));
-}
-
-
 float PositionSmoothing::_getMaxXYSpeed(const Vector3f(&waypoints)[3]) const
 {
 	Vector3f pos_traj(_trajectory[0].getCurrentPosition(),


### PR DESCRIPTION
## Description
Cleanup of unused code in `positionsmoothing.cpp`.
Removed code L#89 - 104:
`_constrainOneSide`
`_constrainAbs`

## Related link
Last usage removed:
[https://github.com/PX4/PX4-Autopilot/commit/75d7a049c1c4f7df4a522005a37cb31cd3237b20](https://github.com/PX4/PX4-Autopilot/commit/75d7a049c1c4f7df4a522005a37cb31cd3237b20#diff-3b9266c5fffe78c73d047b6ee8cf3e9ef9d9eacd7cc74db660a718a4e957b754L269-L271)

