### PR TITLE
Clean up uORB subscription declarations

### DIFF
--- a/src/examples/fake_gyro/Kconfig
+++ b/src/examples/fake_gyro/Kconfig
@@ -1,5 +1,0 @@
-menuconfig EXAMPLES_FAKE_GYRO
-	bool "fake_gyro"
-	default n
-	---help---
-		Enable support for fake_gyro

--- a/src/examples/fixedwing_control/main.cpp
+++ b/src/examples/fixedwing_control/main.cpp
@@ -278,25 +278,14 @@ int fixedwing_control_thread_main(int argc, char *argv[])
 	 * These structs contain the system state and things
 	 * like attitude, position, the current waypoint, etc.
 	 */
-	struct vehicle_attitude_s att;
-	memset(&att, 0, sizeof(att));
-	struct vehicle_attitude_setpoint_s att_sp;
-	memset(&att_sp, 0, sizeof(att_sp));
-	struct vehicle_rates_setpoint_s rates_sp;
-	memset(&rates_sp, 0, sizeof(rates_sp));
-	struct vehicle_global_position_s global_pos;
-	memset(&global_pos, 0, sizeof(global_pos));
-	struct manual_control_setpoint_s manual_control_setpoint;
-	memset(&manual_control_setpoint, 0, sizeof(manual_control_setpoint));
-	struct vehicle_status_s vstatus;
-	memset(&vstatus, 0, sizeof(vstatus));
-	struct position_setpoint_s global_sp;
-	memset(&global_sp, 0, sizeof(global_sp));
+	vehicle_attitude_s att{};
+	vehicle_rates_setpoint_s rates_sp{};
+	manual_control_setpoint_s manual_control_setpoint{};
+	vehicle_status_s vstatus{};
+	position_setpoint_s global_sp{};
 
 	/* output structs - this is what is sent to the mixer */
-	struct actuator_controls_s actuators;
-	memset(&actuators, 0, sizeof(actuators));
-
+	actuator_controls_s actuators{};
 
 	/* publish actuator controls with zero values */
 	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROLS; i++) {

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -131,15 +131,15 @@ private:
 	uORB::Publication<vehicle_thrust_setpoint_s>	_vehicle_thrust_setpoint_pub{ORB_ID(vehicle_thrust_setpoint)};
 	uORB::Publication<vehicle_torque_setpoint_s>	_vehicle_torque_setpoint_pub{ORB_ID(vehicle_torque_setpoint)};
 
-	actuator_controls_s			_actuator_controls {};		/**< actuator control inputs */
-	manual_control_setpoint_s		_manual_control_setpoint {};	/**< r/c channel data */
-	vehicle_attitude_setpoint_s		_att_sp {};			/**< vehicle attitude setpoint */
-	vehicle_control_mode_s			_vcontrol_mode {};		/**< vehicle control mode */
-	vehicle_local_position_s		_local_pos {};			/**< local position */
-	vehicle_rates_setpoint_s		_rates_sp {};			/* attitude rates setpoint */
-	vehicle_status_s			_vehicle_status {};		/**< vehicle status */
+	actuator_controls_s			_actuator_controls{};
+	manual_control_setpoint_s		_manual_control_setpoint{};
+	vehicle_attitude_setpoint_s		_att_sp{};
+	vehicle_control_mode_s			_vcontrol_mode{};
+	vehicle_local_position_s		_local_pos{};
+	vehicle_rates_setpoint_s		_rates_sp{};
+	vehicle_status_s			_vehicle_status{};
 
-	perf_counter_t	_loop_perf;						/**< loop performance counter */
+	perf_counter_t _loop_perf;
 
 	hrt_abstime _last_run{0};
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -185,12 +185,12 @@ private:
 	uORB::Publication<tecs_status_s> _tecs_status_pub{ORB_ID(tecs_status)};
 	uORB::PublicationMulti<orbit_status_s> _orbit_status_pub{ORB_ID(orbit_status)};
 
-	manual_control_setpoint_s _manual_control_setpoint {}; // r/c channel data
-	position_setpoint_triplet_s _pos_sp_triplet {}; // triplet of mission items
-	vehicle_attitude_setpoint_s _att_sp {}; // vehicle attitude setpoint
-	vehicle_control_mode_s _control_mode {};
-	vehicle_local_position_s _local_pos {};	// vehicle local position
-	vehicle_status_s _vehicle_status {}; // vehicle status
+	manual_control_setpoint_s _manual_control_setpoint{};
+	position_setpoint_triplet_s _pos_sp_triplet{};
+	vehicle_attitude_setpoint_s _att_sp{};
+	vehicle_control_mode_s _control_mode{};
+	vehicle_local_position_s _local_pos{};
+	vehicle_status_s _vehicle_status{};
 
 	double _current_latitude{0};
 	double _current_longitude{0};
@@ -212,8 +212,8 @@ private:
 
 	float _min_current_sp_distance_xy{FLT_MAX};
 
-	position_setpoint_s _hdg_hold_prev_wp {}; // position where heading hold started
-	position_setpoint_s _hdg_hold_curr_wp {}; // position to which heading hold flies
+	position_setpoint_s _hdg_hold_prev_wp{}; // position where heading hold started
+	position_setpoint_s _hdg_hold_curr_wp{}; // position to which heading hold flies
 
 	// [us] Last absolute time position control has been called
 	hrt_abstime _last_time_position_control_called{0};

--- a/src/modules/uuv_att_control/uuv_att_control.hpp
+++ b/src/modules/uuv_att_control/uuv_att_control.hpp
@@ -117,13 +117,13 @@ private:
 
 	uORB::SubscriptionCallbackWorkItem _vehicle_attitude_sub{this, ORB_ID(vehicle_attitude)};
 
-	actuator_controls_s _actuators {}; /**< actuator control inputs */
-	manual_control_setpoint_s _manual_control_setpoint {}; /**< r/c channel data */
-	vehicle_attitude_setpoint_s _attitude_setpoint {}; /**< vehicle attitude setpoint */
-	vehicle_rates_setpoint_s _rates_setpoint {}; /**< vehicle bodyrates setpoint */
-	vehicle_control_mode_s _vcontrol_mode {}; /**< vehicle control mode */
+	actuator_controls_s _actuators{};
+	manual_control_setpoint_s _manual_control_setpoint{};
+	vehicle_attitude_setpoint_s _attitude_setpoint{};
+	vehicle_rates_setpoint_s _rates_setpoint{};
+	vehicle_control_mode_s _vcontrol_mode{};
 
-	perf_counter_t	_loop_perf; /**< loop performance counter */
+	perf_counter_t	_loop_perf;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::UUV_ROLL_P>) _param_roll_p,

--- a/src/modules/uuv_pos_control/uuv_pos_control.cpp
+++ b/src/modules/uuv_pos_control/uuv_pos_control.cpp
@@ -195,16 +195,6 @@ void UUVPOSControl::Run()
 		}
 	}
 
-	/* Manual Control mode (e.g. gamepad,...) - raw feedthrough no assistance */
-	if (_manual_control_setpoint_sub.update(&_manual_control_setpoint)) {
-		// This should be copied even if not in manual mode. Otherwise, the poll(...) call will keep
-		// returning immediately and this loop will eat up resources.
-		if (_vcontrol_mode.flag_control_manual_enabled && !_vcontrol_mode.flag_control_rates_enabled) {
-			/* manual/direct control */
-		}
-
-	}
-
 	/* Only publish if any of the proper modes are enabled */
 	if (_vcontrol_mode.flag_control_manual_enabled ||
 	    _vcontrol_mode.flag_control_attitude_enabled) {

--- a/src/modules/uuv_pos_control/uuv_pos_control.hpp
+++ b/src/modules/uuv_pos_control/uuv_pos_control.hpp
@@ -102,18 +102,17 @@ private:
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};	/**< current vehicle attitude */
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
-	uORB::Subscription _vcontrol_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle status subscription */
+	uORB::Subscription _vcontrol_mode_sub{ORB_ID(vehicle_control_mode)};
 
 	uORB::SubscriptionCallbackWorkItem _vehicle_local_position_sub{this, ORB_ID(vehicle_local_position)};
 
-	//actuator_controls_s _actuators {}; /**< actuator control inputs */
-	vehicle_attitude_s _vehicle_attitude {}; /**< vehicle attitude */
-	trajectory_setpoint_s _trajectory_setpoint{}; /**< vehicle position setpoint */
-	vehicle_control_mode_s _vcontrol_mode {}; /**< vehicle control mode */
+	vehicle_attitude_s _vehicle_attitude{};
+	trajectory_setpoint_s _trajectory_setpoint{};
+	vehicle_control_mode_s _vcontrol_mode{};
 
-	perf_counter_t	_loop_perf; /**< loop performance counter */
+	perf_counter_t	_loop_perf;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::UUV_GAIN_X_P>) _param_pose_gain_x,

--- a/src/modules/uuv_pos_control/uuv_pos_control.hpp
+++ b/src/modules/uuv_pos_control/uuv_pos_control.hpp
@@ -60,7 +60,6 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/Publication.hpp>
-#include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
@@ -104,14 +103,12 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};	/**< current vehicle attitude */
-	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};	/**< notification of manual control updates */
 	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
 	uORB::Subscription _vcontrol_mode_sub{ORB_ID(vehicle_control_mode)};		/**< vehicle status subscription */
 
 	uORB::SubscriptionCallbackWorkItem _vehicle_local_position_sub{this, ORB_ID(vehicle_local_position)};
 
 	//actuator_controls_s _actuators {}; /**< actuator control inputs */
-	manual_control_setpoint_s _manual_control_setpoint {}; /**< r/c channel data */
 	vehicle_attitude_s _vehicle_attitude {}; /**< vehicle attitude */
 	trajectory_setpoint_s _trajectory_setpoint{}; /**< vehicle position setpoint */
 	vehicle_control_mode_s _vcontrol_mode {}; /**< vehicle control mode */


### PR DESCRIPTION
## Describe problem solved by this pull request
I found these while rebasing #15949 and wanted to make a separate pr.

## Describe your solution
Commit messages describe the cleanup steps.

## Test data / coverage
No tests. It's pure refactoring. The fake gyro example is empty and the manual control subscription in the UUV position controller is a stub and unused.