### PR TITLE
rc.interface: also save empty ESC mask (none)

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -17,17 +17,21 @@ set OUTPUT_DEV none
 set OUTPUT_AUX_DEV /dev/pwm_output1
 set OUTPUT_EXTRA_DEV /dev/pwm_output0
 
-# set these before starting the modules
+# set ESC mask before starting the modules
+# setting the numeric parameter to "none" would make the startup script fail
 if [ $PWM_AUX_OUT != none ]
 then
-
 	param set PWM_AUX_OUT ${PWM_AUX_OUT}
+else
+	param set PWM_AUX_OUT 0
 fi
 
 
 if [ $PWM_OUT != none ]
 then
 	param set PWM_MAIN_OUT ${PWM_OUT}
+else
+	param set PWM_AUX_OUT 0
 fi
 
 #


### PR DESCRIPTION
## Describe problem solved by this pull request
Credits to @eyeam3 for pointing out to me that these ifs do not help because the ESC mask should always be saved.
If the environmental variable is any string in this case "none", then the integer parameter gets set to 0 which is exactly what we want.
![image](https://user-images.githubusercontent.com/4668506/175761282-fac899dd-7dcc-43e8-932f-25c3afb059cd.png)
Admittedly I did not find any real case in which the variables are none it could in principle still happen and in that case the mask is wrongly set after switching airframe/output configuration.

## Describe your solution
I removed the ifs again that were in my understanding experimentally added in https://github.com/PX4/PX4-Autopilot/commit/7c0165ea0c4f783c1d49a9446d5559248c0cc171 from https://github.com/PX4/PX4-Autopilot/pull/18769 to work against some CI issues.

## Test data / coverage
See screenshot of what the command does with none.

## Additional context
Related to https://github.com/PX4/PX4-Autopilot/pull/17833
