### PR TITLE
PWM: Use disarmed value as default failsafe value

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -87,11 +87,6 @@ struct pwm_output_values {
 #define PWM_MOTOR_OFF	900
 
 /**
- * Default value for a servo stop
- */
-#define PWM_SERVO_STOP	1500
-
-/**
  * Default minimum PWM in us
  */
 #define PWM_DEFAULT_MIN 1000

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -600,34 +600,6 @@ void PWMOut::update_params()
 			}
 		}
 
-		// PWM_MAIN_FAILx
-		{
-			sprintf(str, "%s_FAIL%u", prefix, i + 1);
-			int32_t pwm_failsafe = -1;
-
-			if (param_get(param_find(str), &pwm_failsafe) == PX4_OK) {
-				if (pwm_failsafe >= 0) {
-					_mixing_output.failsafeValue(i) = math::constrain(pwm_failsafe, (int32_t) 0, (int32_t) PWM_HIGHEST_MAX);
-
-					if (pwm_failsafe != _mixing_output.failsafeValue(i)) {
-						int32_t pwm_fail_new = _mixing_output.failsafeValue(i);
-						param_set(param_find(str), &pwm_fail_new);
-					}
-
-				} else {
-					if (pwm_default_channel_mask & 1 << i) {
-						_mixing_output.failsafeValue(i) = PWM_MOTOR_OFF;
-
-					} else {
-						_mixing_output.failsafeValue(i) = PWM_SERVO_STOP;
-					}
-				}
-
-			} else {
-				PX4_ERR("param %s not found", str);
-			}
-		}
-
 		// PWM_MAIN_DISx
 		{
 			sprintf(str, "%s_DIS%u", prefix, i + 1);
@@ -652,6 +624,30 @@ void PWMOut::update_params()
 
 			if (_mixing_output.disarmedValue(i) > 0) {
 				num_disarmed_set++;
+			}
+		}
+
+		// PWM_MAIN_FAILx
+		{
+			sprintf(str, "%s_FAIL%u", prefix, i + 1);
+			int32_t pwm_failsafe = -1;
+
+			if (param_get(param_find(str), &pwm_failsafe) == PX4_OK) {
+				if (pwm_failsafe >= 0) {
+					_mixing_output.failsafeValue(i) = math::constrain(pwm_failsafe, (int32_t) 0, (int32_t) PWM_HIGHEST_MAX);
+
+					if (pwm_failsafe != _mixing_output.failsafeValue(i)) {
+						int32_t pwm_fail_new = _mixing_output.failsafeValue(i);
+						param_set(param_find(str), &pwm_fail_new);
+					}
+
+				} else {
+					// if no channel specific failsafe value is configured, use the disarmed value
+					_mixing_output.failsafeValue(i) = _mixing_output.disarmedValue(i);
+				}
+
+			} else {
+				PX4_ERR("param %s not found", str);
 			}
 		}
 


### PR DESCRIPTION
## Describe problem solved by this pull request
Before https://github.com/PX4/PX4-Autopilot/pull/19805 failsafe values stayed 0 which resulted in PWM signal being lost completely upon vehicle termination if not configured explicitly different per channel. The pr introduced default failsafe values of 900 for channels configured as ESCs and 1500 for servos. While this solved most cases there remain some unsafe ones where the output is not correctly masked as ESC, mistaken for a servo and even though the disarmed value is 0 or even set to 900 and the motor not turning when disarmed it can spool up upon vehicle termination. Also, it could be that an ESCs and servos are calibrated/set up for a different idle values than 900 and 1500 in which case the failsafe value is out of sync with the disarmed one and has to be set separately.

E.g. @RomanBapst reported a VTOL pusher which was presumably not masked as ESC spinning up after vehicle termination.

## Describe your solution
**My suggestion to prevent these cases is to use the channel's disarmed value as the default failsafe value.** The user has to then only change it in case he wants to have a specific PWM value other than the disarmed one for a channel upon termination e.g. to set up a PWM parachute or bring a PWM gimbal into its safest position.

## Describe possible alternatives
I know this only applies to the legacy mixing system and probably mostly benefits the 1.13 release. I'll follow up with @bkueng about the new dynamic one.

**EDIT:** I'll still check in but according to this the new mixing already follows this logic: https://github.com/PX4/PX4-Autopilot/blob/55563eba49f87624d7b73356ea3d421fee7ec081/Tools/module_config/generate_params.py#L281

## Test data / coverage
I did not test these code changes yet. I first want to get feedback on the proposed changes.

## Additional context
IO mixing to FMU: https://github.com/PX4/PX4-Autopilot/pull/16444
Default PWM configuration loading: https://github.com/PX4/PX4-Autopilot/pull/17833
Fix for failsafe defaults being 0: https://github.com/PX4/PX4-Autopilot/pull/19805