### PR TITLE
Fix Github workflows to work on PRs against any branch

### DIFF
--- a/.github/workflows/build_metadata.yml
+++ b/.github/workflows/build_metadata.yml
@@ -1,4 +1,4 @@
-name: Metadata
+name: Build Metadata
 
 on:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,3 +1,4 @@
+# General Checks for building metadata, format, tests, coverage, etc.
 name: Checks
 
 on:
@@ -5,8 +6,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/deploy_metadata.yml
+++ b/.github/workflows/deploy_metadata.yml
@@ -1,3 +1,4 @@
+# Deploys parameters & events metadata files of each target to a S3 server
 name: Deploy metadata for all targets
 
 on:
@@ -51,4 +52,3 @@ jobs:
         AWS_REGION: 'us-west-1'
         SOURCE_DIR: 'build/${{ matrix.target }}/_metadata/'
         DEST_DIR: 'Firmware/${{ env.version }}/${{ matrix.target }}/'
-

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -1,12 +1,11 @@
-name: Python CI Checks
+name: Python Checks
 
 on:
   push:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -5,8 +5,7 @@ on:
     branches:
     - 'master'
   pull_request:
-    branches:
-    - '*'
+    # Trigger for PRs to any branch
 
 jobs:
   build:


### PR DESCRIPTION
## Describe problem solved by this pull request
- Previous '*' filter prohibited the PR agains branches like 'release/1.13' from executing the workflows, as it excludes branches with '/'.
- Rename Workflow names to make the functionality clearer

Example commit that was in the PR against `release/1.13` that didn't get NuttX Targets, etc : other workflows executed: https://github.com/PX4/PX4-Autopilot/pull/19844/commits/2145aca58eaaf43961bf7f055b15c3f008f1e7ea

## Test data / coverage
- The CI run in this PR will show the commit in action :smile: 

## Additional context
- [ ] Does `ekf_update_change_indicator` workflow need to be run on every single push (currently it does)?
