### PR TITLE
Generate Board Information metadata in CI

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -6,6 +6,8 @@ on:
     - 'master'
     - 'release/*'
     - 'pr-metadata-test'
+  pull_request:
+    # Temporarily enable the execution on PR to test if the Board Information generation works
 
 jobs:
   enumerate_targets:
@@ -18,7 +20,22 @@ jobs:
       with:
         token: ${{secrets.ACCESS_TOKEN}}
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(./Tools/generate_board_targets_json.py)"
+      run: echo "::set-output name=matrix::$(./Tools/generate_board_targets_json.py -e)"
+
+  board_information:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-focal:2021-09-08
+    steps:
+    - uses: actions/checkout@v2
+    - name: Construct Board ID JSON File
+      run: ./Tools/generate_board_targets_json.py -b > board_information.json
+    #- name: Compress the JSON
+    #  run:
+    - uses: actions/upload-artifact@v3
+      with:
+        name: board-information-json
+        path: board_information.json
+
   build:
     runs-on: ubuntu-latest
     needs: enumerate_targets
@@ -46,9 +63,8 @@ jobs:
         args: --acl public-read
       env:
         AWS_S3_BUCKET: 'px4-travis'
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        #AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        #AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-west-1'
         SOURCE_DIR: 'build/${{ matrix.target }}/_metadata/'
         DEST_DIR: 'Firmware/${{ env.version }}/${{ matrix.target }}/'
-

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         token: ${{secrets.ACCESS_TOKEN}}
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(./Tools/generate_board_targets_json.py -e)"
+      run: echo "::set-output name=matrix::$(./Tools/generate_board_targets_json.py)"
 
   board_information:
     runs-on: ubuntu-latest
@@ -28,9 +28,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Construct Board ID JSON File
-      run: ./Tools/generate_board_targets_json.py -b > board_information.json
-    #- name: Compress the JSON
-    #  run:
+      run: ./Tools/generate_board_info_manifest.py > board_information.json
+
     - uses: actions/upload-artifact@v3
       with:
         name: board-information-json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -134,5 +134,8 @@
         "yaml.schemas": {
                 "${workspaceFolder}/validation/module_schema.yaml": "${workspaceFolder}/src/modules/*/module.yaml"
         },
-        "cortex-debug.openocdPath": "${env:PICO_SDK_PATH}/../openocd/src/openocd"       // Added for rp2040
+        "cortex-debug.openocdPath": "${env:PICO_SDK_PATH}/../openocd/src/openocd", // Added for rp2040
+        "[json]": {
+                "editor.defaultFormatter": "vscode.json-language-features"
+        }
 }

--- a/Tools/generate_board_info_manifest.py
+++ b/Tools/generate_board_info_manifest.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Script to print out the board information JSON manifest
+
+Example:
+{
+    "include":
+        [
+            {
+                "target": "px4_fmu-v5x_default",
+                "board_id": "51"
+            },
+        ...
+        ]
+}
+"""
+
+import argparse
+import os
+import json
+import re
+from kconfiglib import Kconfig
+
+parser = argparse.ArgumentParser(description='Generate build targets')
+
+parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
+                    help='Verbose Output')
+parser.add_argument('-p', '--pretty', dest='pretty', action='store_true',
+                    help='Pretty output instead of a single line')
+args = parser.parse_args()
+
+# GLOBAL VARIABLES
+verbose = args.verbose
+build_configs = []
+excluded_manufacturers = ['atlflight']
+excluded_platforms = ['qurt']
+excluded_labels = [
+    'stackcheck',
+    'nolockstep', 'replay', 'test',
+    'uavcanv1' # TODO: fix and enable
+    ]
+
+# Supress warning output while parsing KConfig
+kconf = Kconfig()
+kconf.warn_assign_undef = False
+kconf.warn_assign_override = False
+kconf.warn_assign_redun = False
+
+''' Turn given firmware.prototype into a dictionary with board information '''
+def process_target_firmware_prototype_file(manufacturer, board, file):
+    if not (file.is_file() and file.name == 'firmware.prototype'):
+        return None
+
+    global verbose, excluded_labels
+    target_name = manufacturer.name + '_' + board.name
+
+    with open(file.path, 'r') as f:
+        data = json.load(f)
+        board_info_dict = dict()
+        board_info_dict['board_name'] = data['summary']
+        board_info_dict['target_name'] = target_name
+        board_info_dict['description'] = data['description']
+        board_info_dict['board_id'] = data['board_id']
+        board_info_dict['image_max_size'] = data['image_maxsize']
+        board_info_dict['build_variants'] = []
+
+        return board_info_dict
+
+'''
+Process the firmware.prototype files and create board information Json file
+
+In this following format:
+
+{
+    "board_name"        = "HUMAN_READABLE_BOARD_NAME",      (summary)
+    "target_name"       = "TARGET_NAME_FOR_BUILD",          (manufacturer_board_label)
+    "description"       = "DESCRIPTION",                    (description)
+    "board_id"          = "BOOTLOADER_ID",
+    "image_maxsize"     = "FLASH_SIZE",
+    "build_variants"    = [ {"name": "VARIANT_1"}, ... ]    (labels)
+}
+'''
+def print_board_information(board_list: list):
+    global args, verbose
+    board_info_list = []        # Board information list
+
+    for board in board_list:
+        board_info = dict()     # Board information that will be extracted from firmware.prototype
+        board_variants = []     # Save different board variants (labels)
+
+        for file in board['files']:
+
+            # Process all the board variants
+            if file.name.endswith(".px4board"):
+                label = file.name.split(".px4board")[0]
+                board_variants.append({"name": label}) # For now we only have the 'name' attribute (e.g. default, rtps, etc.)
+
+            # Process the firwmare.prototype
+            elif file.name == "firmware.prototype":
+                board_info = process_target_firmware_prototype_file(board['manufacturer'], board['board'], file)
+
+        if board_info is None and verbose:
+            print("Error, didn't detect valid firmware.prototype for the board. This board won't be added to the Board information JSON file! : {} - {}".format(board['manufacturer'], board['file']))
+
+        if board_info is not None:
+            board_info['build_variants'] = board_variants
+            board_info_list.append(board_info)
+
+    # Final dictionary that will be turned into the JSON file
+    board_info_dict = { 'board_info' : board_info_list }
+
+    extra_args = dict()         # Extra arg that will be added to the JSON
+    if args.pretty:
+        extra_args['indent'] = 2
+
+    print(json.dumps(board_info_dict, **extra_args))
+
+
+def main():
+    global verbose, build_configs
+    source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+
+    board_list = []
+    for manufacturer in os.scandir(os.path.join(source_dir, 'boards')):
+        if not manufacturer.is_dir():
+            continue
+        if manufacturer.name in excluded_manufacturers:
+            if verbose: print(f'excluding manufacturer {manufacturer.name}')
+            continue
+
+        for board in os.scandir(manufacturer.path):
+            if not board.is_dir():
+                continue
+
+            file_list = [] # Group the files under same board together
+            for file in os.scandir(board.path):
+                if not file.is_dir():
+                    file_list.append(file)
+
+            board_list.append({'manufacturer': manufacturer, 'board' : board, 'files' : file_list})
+
+    print_board_information(board_list)
+
+if __name__ == '__main__':
+    main()

--- a/Tools/generate_board_info_manifest.py
+++ b/Tools/generate_board_info_manifest.py
@@ -117,6 +117,7 @@ def process_target_defconfig_file(file_path):
 ''' Function that receives board list and goes through the files to create the final Board Information metadata JSON '''
 def print_board_information(board_list: list):
     global args, verbose, excluded_labels
+    # Objects that we will be using to create the JSON at the end of this function
     board_info_list = []
 
     for board in board_list:
@@ -153,14 +154,21 @@ def print_board_information(board_list: list):
 
         board_info_list.append(board_info)
 
+    # Include binary URL information
+    binary_urls_dict = {"stable" : {"url" : "http://px4-travis.s3.amazonaws.com/Firmware/stable/${target_name}_${build_variant}.px4"},
+                        "beta" : {"url" : "http://px4-travis.s3.amazonaws.com/Firmware/beta/${target_name}_${build_variant}.px4"},
+                        "main" : {"url" : "http://px4-travis.s3.amazonaws.com/Firmware/main/${target_name}_${build_variant}.px4"},
+                        }
+
     # Final dictionary that will be turned into the JSON file
-    board_info_dict = { 'board_info' : board_info_list }
+    final_json_dict = { 'board_info' : board_info_list,
+                        'binary_urls' : binary_urls_dict}
 
     extra_args = dict()         # Extra arg that will be added to the JSON
     if args.pretty:
         extra_args['indent'] = 2
 
-    print(json.dumps(board_info_dict, **extra_args))
+    print(json.dumps(final_json_dict, **extra_args))
 
 ''' Go through the boards/* to get list of boards and it's directory '''
 def main():

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -1,45 +1,31 @@
 #!/usr/bin/env python3
-"""
-Script to generate a JSON config with all build targets (for CI), in 2 different versions:
-
-1. For enumerating targets: {"include":[{"target": "px4_fmu-v5x_default", "container": "nuttx-focal"}, ...]}
-
-Called by : Tools/generate_board_targets_json.py -e
-
----
-
-2. For board information: {"include":[{"target": "px4_fmu-v5x_default", "board_id": "51"}, ...]}
-
-Called by : Tools/generate_board_targets_json.py -b
-
-"""
+""" Script to generate a JSON config with all build targets (for CI) """
 
 import argparse
 import os
+import sys
 import json
 import re
 from kconfiglib import Kconfig
 
+kconf = Kconfig()
+
+# Supress warning output
+kconf.warn_assign_undef = False
+kconf.warn_assign_override = False
+kconf.warn_assign_redun = False
+
+source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+
 parser = argparse.ArgumentParser(description='Generate build targets')
 
-parser.add_argument('-e', '--enumerate', dest='enumerate', action='store_true',
-                    help='Output enumerated targets')
-parser.add_argument('-b', '--boardinfo', dest='boardinfo', action='store_true',
-                    help='Output target board information')
 parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                     help='Verbose Output')
 parser.add_argument('-p', '--pretty', dest='pretty', action='store_true',
                     help='Pretty output instead of a single line')
+
 args = parser.parse_args()
-
-if not args.enumerate and not args.boardinfo:
-    print("Please either specify -e or -v flag to indicate which format to output!")
-    exit()
-
-# GLOBAL VARIABLES
 verbose = args.verbose
-enumerate_mode = args.enumerate
-boardinfo_mode = args.boardinfo
 
 build_configs = []
 excluded_manufacturers = ['atlflight']
@@ -50,40 +36,15 @@ excluded_labels = [
     'uavcanv1' # TODO: fix and enable
     ]
 
-
-kconf = Kconfig()
-
-# Supress warning output
-kconf.warn_assign_undef = False
-kconf.warn_assign_override = False
-kconf.warn_assign_redun = False
-
-
-''' Turn given file (.px4board) into a dictionary with board and toolchain information'''
-def process_target_px4board_file(manufacturer, board, file):
-    global verbose, excluded_labels
-
+def process_target(px4board_file, target_name):
     ret = None
     platform = None
     toolchain = None
-
-    if not(file.is_file() and file.name.endswith('.px4board')):
-        return None
-
-    label = file.name.split(".px4board")[0]
-    target_name = manufacturer.name + '_' + board.name + '_' + label
-
-    if label in excluded_labels:
-        if verbose: print(f'excluding label {label} ({target_name})')
-        return None
-
-    px4board_file = file.path
 
     if px4board_file.endswith("default.px4board") or \
         px4board_file.endswith("recovery.px4board") or \
         px4board_file.endswith("bootloader.px4board"):
         kconf.load_config(px4board_file, replace=True)
-
     else: # Merge config with default.px4board
         default_kconfig = re.sub(r'[a-zA-Z\d_]+\.px4board', 'default.px4board', px4board_file)
         kconf.load_config(default_kconfig, replace=True)
@@ -116,132 +77,30 @@ def process_target_px4board_file(manufacturer, board, file):
 
     return ret
 
-'''
-Process the given board files list and print boards list Json file
-'''
-def print_board_enumeration(board_list: list):
-    global args
-    extra_args = dict()
+for manufacturer in os.scandir(os.path.join(source_dir, 'boards')):
+    if not manufacturer.is_dir():
+        continue
+    if manufacturer.name in excluded_manufacturers:
+        if verbose: print(f'excluding manufacturer {manufacturer.name}')
+        continue
 
-    json_list = []
-    for board in board_list:
-        for file in board['files']:
-            target = process_target_px4board_file(board['manufacturer'], board['board'], file)
-            if target is not None:
-                json_list.append(target)
-
-    github_action_config = { 'include' : json_list }
-
-    if args.pretty:
-        extra_args['indent'] = 2
-    print(json.dumps(github_action_config, **extra_args))
-
-
-
-''' Turn given firmware.prototype into a dictionary with board information'''
-def process_target_firmware_prototype_file(manufacturer, board, file):
-    global verbose, excluded_labels
-
-    if not (file.is_file() and file.name == 'firmware.prototype'):
-        return None
-
-    target_name = manufacturer.name + '_' + board.name
-
-    with open(file.path, 'r') as f:
-        data = json.load(f)
-        board_info_dict = dict()
-        board_info_dict['board_name'] = data['summary']
-        board_info_dict['target_name'] = target_name
-        board_info_dict['description'] = data['description']
-        board_info_dict['board_id'] = data['board_id']
-        board_info_dict['image_max_size'] = data['image_maxsize']
-        board_info_dict['build_variants'] = []
-
-        return board_info_dict
-
-'''
-Process the firmware.prototype files and create board information Json file
-
-In this following format:
-
-{
-    "board_name"        = "HUMAN_READABLE_BOARD_NAME",      (summary)
-    "target_name"       = "TARGET_NAME_FOR_BUILD",          (manufacturer_board_label)
-    "description"       = "DESCRIPTION",                    (description)
-    "board_id"          = "BOOTLOADER_ID",
-    "image_maxsize"     = "FLASH_SIZE",
-    "build_variants"    = {"VARIANT_1", "VARIANT_2", ... }, (labels)
-}
-'''
-def print_board_information(board_list: list):
-    global args, verbose
-    extra_args = dict()
-    json_list = []
-
-    for board in board_list:
-        board_variants = [] # Save different board variants (labels)
-        board_info = None
-
-        for file in board['files']:
-            target = process_target_firmware_prototype_file(board['manufacturer'], board['board'], file)
-            if target is None:
-                # .px4board files
-                if file.name.endswith(".px4board"):
-                    label = file.name.split(".px4board")[0]
-                    board_variants.append(label)
-
-            if target is not None:
-                # firmware.prototype file that defines board information
-                board_info = target
-
-        if board_info is None and verbose:
-            print('Board info is NONE!')
-            print(board)
-
-        if board_info is not None:
-            board_info['build_variants'] = board_variants
-            json_list.append(board_info)
-
-    board_info_dict = { 'board_info' : json_list }
-
-    if args.pretty:
-        extra_args['indent'] = 2
-
-    print(json.dumps(board_info_dict, **extra_args))
-
-
-'''
-Go through the board related files and process them depending on the output mode
-'''
-def main():
-    global verbose, build_configs
-    source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
-
-    board_list = []
-    for manufacturer in os.scandir(os.path.join(source_dir, 'boards')):
-        if not manufacturer.is_dir():
+    for board in os.scandir(manufacturer.path):
+        if not board.is_dir():
             continue
-        if manufacturer.name in excluded_manufacturers:
-            if verbose: print(f'excluding manufacturer {manufacturer.name}')
-            continue
-
-        for board in os.scandir(manufacturer.path):
-            if not board.is_dir():
-                continue
-
-            file_list = [] # Group the files under same board together
-            for file in os.scandir(board.path):
-                if not file.is_dir():
-                    file_list.append(file)
-
-            board_list.append({'manufacturer': manufacturer, 'board' : board, 'files' : file_list})
-
-    if enumerate_mode:
-        print_board_enumeration(board_list)
-
-    elif boardinfo_mode:
-        print_board_information(board_list)
+        for files in os.scandir(board.path):
+            if files.is_file() and files.name.endswith('.px4board'):
+                label = files.name[:-9]
+                target_name = manufacturer.name + '_' + board.name + '_' + label
+                if label in excluded_labels:
+                    if verbose: print(f'excluding label {label} ({target_name})')
+                    continue
+                target = process_target(files.path, target_name)
+                if target is not None:
+                    build_configs.append(target)
 
 
-if __name__ == '__main__':
-    main()
+github_action_config = { 'include': build_configs }
+extra_args = {}
+if args.pretty:
+    extra_args['indent'] = 2
+print(json.dumps(github_action_config, **extra_args))

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -149,7 +149,6 @@ def process_target_firmware_prototype_file(manufacturer, board, file):
 
     with open(file.path, 'r') as f:
         data = json.load(f)
-        print(data)
         board_info_dict = dict()
         board_info_dict['board_name'] = data['summary']
         board_info_dict['target_name'] = target_name
@@ -175,7 +174,7 @@ In this following format:
 }
 '''
 def print_board_information(board_list: list):
-    global args
+    global args, verbose
     extra_args = dict()
     json_list = []
 
@@ -195,7 +194,7 @@ def print_board_information(board_list: list):
                 # firmware.prototype file that defines board information
                 board_info = target
 
-        if board_info is None:
+        if board_info is None and verbose:
             print('Board info is NONE!')
             print(board)
 

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -1,31 +1,45 @@
 #!/usr/bin/env python3
-""" Script to generate a JSON config with all build targets (for CI) """
+"""
+Script to generate a JSON config with all build targets (for CI), in 2 different versions:
+
+1. For enumerating targets: {"include":[{"target": "px4_fmu-v5x_default", "container": "nuttx-focal"}, ...]}
+
+Called by : Tools/generate_board_targets_json.py -e
+
+---
+
+2. For board information: {"include":[{"target": "px4_fmu-v5x_default", "board_id": "51"}, ...]}
+
+Called by : Tools/generate_board_targets_json.py -b
+
+"""
 
 import argparse
 import os
-import sys
 import json
 import re
 from kconfiglib import Kconfig
 
-kconf = Kconfig()
-
-# Supress warning output
-kconf.warn_assign_undef = False
-kconf.warn_assign_override = False
-kconf.warn_assign_redun = False
-
-source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
-
 parser = argparse.ArgumentParser(description='Generate build targets')
 
+parser.add_argument('-e', '--enumerate', dest='enumerate', action='store_true',
+                    help='Output enumerated targets')
+parser.add_argument('-b', '--boardinfo', dest='boardinfo', action='store_true',
+                    help='Output target board information')
 parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
                     help='Verbose Output')
 parser.add_argument('-p', '--pretty', dest='pretty', action='store_true',
                     help='Pretty output instead of a single line')
-
 args = parser.parse_args()
+
+if not args.enumerate and not args.boardinfo:
+    print("Please either specify -e or -v flag to indicate which format to output!")
+    exit()
+
+# GLOBAL VARIABLES
 verbose = args.verbose
+enumerate_mode = args.enumerate
+boardinfo_mode = args.boardinfo
 
 build_configs = []
 excluded_manufacturers = ['atlflight']
@@ -36,15 +50,40 @@ excluded_labels = [
     'uavcanv1' # TODO: fix and enable
     ]
 
-def process_target(px4board_file, target_name):
+
+kconf = Kconfig()
+
+# Supress warning output
+kconf.warn_assign_undef = False
+kconf.warn_assign_override = False
+kconf.warn_assign_redun = False
+
+
+''' Turn given file (.px4board) into a dictionary with board and toolchain information'''
+def process_target_px4board_file(manufacturer, board, file):
+    global verbose, excluded_labels
+
     ret = None
     platform = None
     toolchain = None
+
+    if not(file.is_file() and file.name.endswith('.px4board')):
+        return None
+
+    label = file.name.split(".px4board")[0]
+    target_name = manufacturer.name + '_' + board.name + '_' + label
+
+    if label in excluded_labels:
+        if verbose: print(f'excluding label {label} ({target_name})')
+        return None
+
+    px4board_file = file.path
 
     if px4board_file.endswith("default.px4board") or \
         px4board_file.endswith("recovery.px4board") or \
         px4board_file.endswith("bootloader.px4board"):
         kconf.load_config(px4board_file, replace=True)
+
     else: # Merge config with default.px4board
         default_kconfig = re.sub(r'[a-zA-Z\d_]+\.px4board', 'default.px4board', px4board_file)
         kconf.load_config(default_kconfig, replace=True)
@@ -77,31 +116,133 @@ def process_target(px4board_file, target_name):
 
     return ret
 
-for manufacturer in os.scandir(os.path.join(source_dir, 'boards')):
-    if not manufacturer.is_dir():
-        continue
-    if manufacturer.name in excluded_manufacturers:
-        if verbose: print(f'excluding manufacturer {manufacturer.name}')
-        continue
+'''
+Process the given board files list and print boards list Json file
+'''
+def print_board_enumeration(board_list: list):
+    global args
+    extra_args = dict()
 
-    for board in os.scandir(manufacturer.path):
-        if not board.is_dir():
+    json_list = []
+    for board in board_list:
+        for file in board['files']:
+            target = process_target_px4board_file(board['manufacturer'], board['board'], file)
+            if target is not None:
+                json_list.append(target)
+
+    github_action_config = { 'include' : json_list }
+
+    if args.pretty:
+        extra_args['indent'] = 2
+    print(json.dumps(github_action_config, **extra_args))
+
+
+
+''' Turn given firmware.prototype into a dictionary with board information'''
+def process_target_firmware_prototype_file(manufacturer, board, file):
+    global verbose, excluded_labels
+
+    if not (file.is_file() and file.name == 'firmware.prototype'):
+        return None
+
+    target_name = manufacturer.name + '_' + board.name
+
+    with open(file.path, 'r') as f:
+        data = json.load(f)
+        print(data)
+        board_info_dict = dict()
+        board_info_dict['board_name'] = data['summary']
+        board_info_dict['target_name'] = target_name
+        board_info_dict['description'] = data['description']
+        board_info_dict['board_id'] = data['board_id']
+        board_info_dict['image_max_size'] = data['image_maxsize']
+        board_info_dict['build_variants'] = []
+
+        return board_info_dict
+
+'''
+Process the firmware.prototype files and create board information Json file
+
+In this following format:
+
+{
+    "board_name"        = "HUMAN_READABLE_BOARD_NAME",      (summary)
+    "target_name"       = "TARGET_NAME_FOR_BUILD",          (manufacturer_board_label)
+    "description"       = "DESCRIPTION",                    (description)
+    "board_id"          = "BOOTLOADER_ID",
+    "image_maxsize"     = "FLASH_SIZE",
+    "build_variants"    = {"VARIANT_1", "VARIANT_2", ... }, (labels)
+}
+'''
+def print_board_information(board_list: list):
+    global args
+    extra_args = dict()
+    json_list = []
+
+    for board in board_list:
+        board_variants = [] # Save different board variants (labels)
+        board_info = None
+
+        for file in board['files']:
+            target = process_target_firmware_prototype_file(board['manufacturer'], board['board'], file)
+            if target is None:
+                # .px4board files
+                if file.name.endswith(".px4board"):
+                    label = file.name.split(".px4board")[0]
+                    board_variants.append(label)
+
+            if target is not None:
+                # firmware.prototype file that defines board information
+                board_info = target
+
+        if board_info is None:
+            print('Board info is NONE!')
+            print(board)
+
+        if board_info is not None:
+            board_info['build_variants'] = board_variants
+            json_list.append(board_info)
+
+    board_info_dict = { 'board_info' : json_list }
+
+    if args.pretty:
+        extra_args['indent'] = 2
+
+    print(json.dumps(board_info_dict, **extra_args))
+
+
+'''
+Go through the board related files and process them depending on the output mode
+'''
+def main():
+    global verbose, build_configs
+    source_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+
+    board_list = []
+    for manufacturer in os.scandir(os.path.join(source_dir, 'boards')):
+        if not manufacturer.is_dir():
             continue
-        for files in os.scandir(board.path):
-            if files.is_file() and files.name.endswith('.px4board'):
-                label = files.name[:-9]
-                target_name = manufacturer.name + '_' + board.name + '_' + label
-                if label in excluded_labels:
-                    if verbose: print(f'excluding label {label} ({target_name})')
-                    continue
-                target = process_target(files.path, target_name)
-                if target is not None:
-                    build_configs.append(target)
+        if manufacturer.name in excluded_manufacturers:
+            if verbose: print(f'excluding manufacturer {manufacturer.name}')
+            continue
+
+        for board in os.scandir(manufacturer.path):
+            if not board.is_dir():
+                continue
+
+            file_list = [] # Group the files under same board together
+            for file in os.scandir(board.path):
+                if not file.is_dir():
+                    file_list.append(file)
+
+            board_list.append({'manufacturer': manufacturer, 'board' : board, 'files' : file_list})
+
+    if enumerate_mode:
+        print_board_enumeration(board_list)
+
+    elif boardinfo_mode:
+        print_board_information(board_list)
 
 
-github_action_config = { 'include': build_configs }
-extra_args = {}
-if args.pretty:
-    extra_args['indent'] = 2
-print(json.dumps(github_action_config, **extra_args))
-
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Describe problem solved by this pull request
There were multiple instances where the QGC didn't have the fully updated list of bootloader IDs for the boards supported by PX4, which led to **users not being able to flash their boards as QGC didn't recognize them** (and didn't know which firmware was needed to be flashed)

For example, a user reported problem here: https://github.com/PX4/PX4-Autopilot/issues/19432 and it was manually fixed in QGC side here: https://github.com/mavlink/qgroundcontrol/pull/10252. **This is not scalable**, and is a lot of manual labor of copying the data from the PX4's side to QGC side (although it's not too intensive).

### Key Improvements
1. QGC being able to automatically detect new boards by it's board ID, when the board is added in PX4 side
2. QGC being able to auto-connect new boards by it's vendor & product ID (and name), when a new board is added in PX4 side

## Describe your solution
![PX4_Board_Information_Json](https://user-images.githubusercontent.com/23277211/176460048-1e7a2e4e-8f80-4004-b12b-441a266d98cb.png)

The aim of this PR is to automatically generate the **board information JSON file** that includes all the information needed to flash / build / download target builds, which QGC can then download and update the supported boards list to the latest data.

### Update to QGC Repository
First, the JSON file will get updated to the QGC Repository as a Pull Request or a direct commit like [how the Parameter / Airframe Metadata is getting synced](https://github.com/mavlink/qgroundcontrol/commit/1fa8485f7fa12eb19b3fc07f2cffe4bc2d3bb8c4) via Jenkins CI. This will make sure that QGC will have the latest Board information and will always fully support all the boards for flashing :+1: 

### Update to Local QGC
Second, the JSON file will be uploaded to a S3 server, for example to a place like: https://px4-travis.s3.amazonaws.com/Firmware/master/_general/board_info.json. This will then get pulled to local QGC installations so that the QGCs with the internet connection will have the latest board information Json file as well.

### Existing Use-Case
Ardupilot already does that (and QGC supports this Server-fetch based board information update) by this manifest link: https://firmware.ardupilot.org/manifest.json

### Information inside board_information.json
This file should include generic information about the board targets, and not be limited to bootloader ID itself (which is crucial for QGC), so that we can utilize the file in many different applications.

```
{
    "board_name"        = "HUMAN_READABLE_BOARD_NAME",      (summary)
    "target_name"       = "TARGET_NAME_FOR_BUILD",          (manufacturer_board_label)
    "description"       = "DESCRIPTION",                    (description)
    "board_id"          = "BOOTLOADER_ID",
    "image_maxsize"     = "FLASH_SIZE",
    "build_variants"    = {"VARIANT_1", "VARIANT_2", ... }, (labels)
}
```
:exclamation:  If any critical information is missing, please let me know!

## Describe possible alternatives
The Board information JSON file can be loaded into board's Flash as a [component information](https://github.com/PX4/PX4-Autopilot/pull/16039) as well, but that would mean that a PX4_FMU-V5 board would need to hold all the information about ATL_MANTIS-EDU, PX4_FMU-V3, and so on, which doesn't make sense especially since we are constrained in Flash memory.

## QGC PR
https://github.com/mavlink/qgroundcontrol/pull/10343

## Additional context
Related discussion / PRs in the past
- https://github.com/PX4/PX4-Autopilot/issues/16351
- https://github.com/mavlink/qgroundcontrol/pull/9221
- Related discussion in QGC for this feature: https://github.com/mavlink/qgroundcontrol/issues/2797