### PR TITLE
Prevent GPIO interrupt burst

### DIFF
--- a/msg/pps_capture.msg
+++ b/msg/pps_capture.msg
@@ -1,2 +1,3 @@
 uint64 timestamp			  # time since system start (microseconds) at PPS capture event
 uint64 rtc_timestamp		# Corrected GPS UTC timestamp at PPS capture event
+uint8  pps_rate_exceeded_counter # Increments when PPS dt < 50ms

--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -40,10 +40,14 @@
  */
 
 #include "camera_capture.hpp"
+#include <px4_platform_common/events.h>
+#include <systemlib/mavlink_log.h>
 
 #include <board_config.h>
 
 #define commandParamToInt(n) static_cast<int>(n >= 0 ? n + 0.5f : n - 0.5f)
+
+using namespace time_literals;
 
 namespace camera_capture
 {
@@ -104,6 +108,21 @@ CameraCapture::~CameraCapture()
 void
 CameraCapture::capture_callback(uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow)
 {
+	// Maximum acceptable rate is 5kHz
+	if ((edge_time - _trigger.hrt_edge_time) < 200_us) {
+		++_trigger_rate_exceeded_counter;
+
+		if (_trigger_rate_exceeded_counter > 100) {
+
+			// Trigger rate too high, stop future interrupts
+			up_input_capture_set(_capture_channel, Disabled, 0, nullptr, nullptr);
+			_trigger_rate_failure.store(true);
+		}
+
+	} else if (_trigger_rate_exceeded_counter > 0) {
+		--_trigger_rate_exceeded_counter;
+	}
+
 	_trigger.chan_index = chan_index;
 	_trigger.hrt_edge_time = edge_time;
 	_trigger.edge_state = edge_state;
@@ -139,6 +158,13 @@ void
 CameraCapture::publish_trigger()
 {
 	bool publish = false;
+
+	if (_trigger_rate_failure.load()) {
+		mavlink_log_warning(&_mavlink_log_pub, "Hardware fault: Camera capture disabled\t");
+		events::send(events::ID("camera_capture_trigger_rate_exceeded"),
+			     events::Log::Error, "Hardware fault: Camera capture disabled");
+		_trigger_rate_failure.store(false);
+	}
 
 	camera_trigger_s trigger{};
 

--- a/src/drivers/camera_capture/camera_capture.hpp
+++ b/src/drivers/camera_capture/camera_capture.hpp
@@ -134,6 +134,10 @@ private:
 
 	hrt_abstime	_pps_hrt_timestamp{0};
 	uint64_t		_pps_rtc_timestamp{0};
+	uint8_t			_trigger_rate_exceeded_counter{0};
+	px4::atomic<bool> _trigger_rate_failure{false};
+
+	orb_advert_t _mavlink_log_pub{nullptr};
 
 	// Signal capture callback
 	void			capture_callback(uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow);

--- a/src/drivers/pps_capture/PPSCapture.hpp
+++ b/src/drivers/pps_capture/PPSCapture.hpp
@@ -73,10 +73,12 @@ private:
 	uint32_t _pps_capture_gpio{0};
 	uORB::Publication<pps_capture_s>	_pps_capture_pub{ORB_ID(pps_capture)};
 	uORB::Subscription								_sensor_gps_sub{ORB_ID(sensor_gps)};
+	orb_advert_t											_mavlink_log_pub{nullptr};
 
 	hrt_abstime _hrt_timestamp{0};
 
 	hrt_abstime	_last_gps_timestamp{0};
 	uint64_t		_last_gps_utc_timestamp{0};
-
+	uint8_t			_pps_rate_exceeded_counter{0};
+	px4::atomic<bool>			_pps_rate_failure{false};
 };

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -178,7 +178,6 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("sensor_baro", 1000, 4);
 	add_topic_multi("sensor_gps", 1000, 2);
 	add_topic_multi("sensor_gnss_relative", 1000, 1);
-	add_optional_topic("pps_capture", 1000);
 	add_optional_topic_multi("sensor_gyro", 1000, 4);
 	add_optional_topic_multi("sensor_mag", 1000, 4);
 	add_optional_topic_multi("sensor_optical_flow", 1000, 2);
@@ -188,6 +187,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("vehicle_magnetometer", 500, 4);
 	add_optional_topic("vehicle_optical_flow", 500);
 	//add_optional_topic("vehicle_optical_flow_vel", 100);
+	add_optional_topic("pps_capture");
 
 	// SYS_CTRL_ALLOC: additional dynamic control allocation logging when enabled
 	int32_t sys_ctrl_alloc = 0;


### PR DESCRIPTION
## Describe the problem solved by this pull request

- Both, PPS and camera capture, are GPIOs with an interrupt on rising edges which schedule a call to process the event. Since neither of them is flight critical, the interrupt is removed when the interrupt is called at a too high rate. For PPS the limit is 20Hz for 10 interrupts, for camera capture it is 5kHz for 100 interrupts. In addition, the camera capture counter decreases again when the dt between interrupts is > 200us. 
- The watchdog improvements make sure the log doesn't end.
