### PR TITLE
Configure clang-format for Google code style slightly adapted

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+# Google C++ style as base
+Language: Cpp
+BasedOnStyle: Google
+
+# Indentation using tabs
+UseTab: ForContinuationAndIndentation
+TabWidth: 8
+IndentWidth: 8
+ContinuationIndentWidth: 8
+ConstructorInitializerIndentWidth: 8
+AccessModifierOffset: -8
+
+ColumnLimit: 120 # Allow more collumns

--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,10 @@ format:
 	$(call colorecho,'Formatting with astyle')
 	@"$(SRC_DIR)"/Tools/astyle/check_code_style_all.sh --fix
 
+format_clang:
+	$(call colorecho,'Formatting with clang-format')
+	@"$(SRC_DIR)"/Tools/astyle/files_to_check_code_style.sh | xargs clang-format -i -style=file
+
 # Testing
 # --------------------------------------------------------------------
 .PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard tests_avoidance

--- a/Tools/astyle/files_to_check_code_style.sh
+++ b/Tools/astyle/files_to_check_code_style.sh
@@ -8,23 +8,24 @@ if [ $# -gt 0 ]; then
 fi
 
 exec find boards msg src platforms test \
-    -path msg/templates/urtps -prune -o \
-    -path platforms/nuttx/NuttX -prune -o \
-    -path platforms/qurt/dspal -prune -o \
-    -path src/drivers/uavcan/libuavcan -prune -o \
-    -path src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis -prune -o \
-    -path src/drivers/cyphal/libcanard -prune -o \
-    -path src/lib/crypto/monocypher -prune -o \
-    -path src/lib/events/libevents -prune -o \
-    -path src/lib/parameters/uthash -prune -o \
-    -path src/modules/ekf2/EKF -prune -o \
-    -path src/modules/gyro_fft/CMSIS_5 -prune -o \
-    -path src/modules/mavlink/mavlink -prune -o \
-    -path src/modules/micrortps_bridge/micro-CDR -prune -o \
-    -path src/modules/micrortps_bridge/microRTPS_client -prune -o \
-    -path test/mavsdk_tests/catch2 -prune -o \
-    -path src/lib/crypto/monocypher -prune -o \
-    -path src/lib/crypto/libtomcrypt -prune -o \
-    -path src/lib/crypto/libtommath -prune -o \
-    -path src/modules/microdds_client/Micro-XRCE-DDS-Client -prune -o \
+    -not -path "msg/templates/urtps/*" \
+    -not -path "platforms/nuttx/NuttX/*" \
+    -not -path "platforms/qurt/dspal/*" \
+    -not -path "src/drivers/gps/devices/*" \
+    -not -path "src/drivers/uavcan/libuavcan/*" \
+    -not -path "src/drivers/uavcan/uavcan_drivers/kinetis/driver/include/uavcan_kinetis/*" \
+    -not -path "src/drivers/cyphal/libcanard/*" \
+    -not -path "src/lib/crypto/monocypher/*" \
+    -not -path "src/lib/events/libevents/*" \
+    -not -path "src/lib/parameters/uthash/*" \
+    -not -path "src/modules/ekf2/EKF/*" \
+    -not -path "src/modules/gyro_fft/CMSIS_5/*" \
+    -not -path "src/modules/mavlink/mavlink/*" \
+    -not -path "src/modules/micrortps_bridge/micro-CDR/*" \
+    -not -path "src/modules/micrortps_bridge/microRTPS_client/*" \
+    -not -path "test/mavsdk_tests/catch2/*" \
+    -not -path "src/lib/crypto/monocypher/*" \
+    -not -path "src/lib/crypto/libtomcrypt/*" \
+    -not -path "src/lib/crypto/libtommath/*" \
+    -not -path "src/modules/microdds_client/Micro-XRCE-DDS-Client/*" \
     -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) | grep $PATTERN


### PR DESCRIPTION
## Describe problem solved by this pull request
As discussed we'd like to have a more clear code style that is easy to document, adapt to, apply with tools and maintain.

## Describe your solution
As discussed with @dagar @tstastny @ThomasDebrunner we'd prefer to adopt the Google style guide with a few adaptations that are documented in the PX4 guide here: https://github.com/PX4/PX4-user_guide/pull/1918

This pr is deploying clang-format to adapt the spacing of the proposed code style. Note that for naming conventions and other context-aware tooling we need to use clang-tidy on top which I started testing with but didn't get to do what is required yet. Also note that we'll need to transition the style and not change everything at once. Also there are some things that are less expected like the spacing of DMA tables. Please chime in for feedback and suggestions on transitioning.

## Test data / coverage
It can be tested by using the make target for testing `make format_clang` and the result of running it I pushed onto this branch for your reference: https://github.com/PX4/PX4-Autopilot/compare/google-style-showcase

Missing:
- [ ] Check styling corner cases like DMA comment table
- [ ] Deal with clang-format not installed
- [ ] Integration with pre-commit hook
- [ ] Transition strategy e.g. remove/add transitioned folders