### PR TITLE
uavcan: add UAVCAN_SUB_LOG param to enable/disable uavcan::protocol::debug::LogMessage subscription handling

### DIFF
--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -508,6 +508,18 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 
 	fill_node_info();
 
+	// log message subscription
+	int32_t uavcan_sub_log = 1;
+	param_get(param_find("UAVCAN_SUB_LOG"), &uavcan_sub_log);
+
+	if (uavcan_sub_log != 0) {
+		ret = _log_message_controller.init();
+
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
 	ret = _beep_controller.init();
 
 	if (ret < 0) {
@@ -528,12 +540,6 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	}
 
 	ret = _safety_state_controller.init();
-
-	if (ret < 0) {
-		return ret;
-	}
-
-	ret = _log_message_controller.init();
 
 	if (ret < 0) {
 		return ret;

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -308,6 +308,18 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_ICE, 0);
 PARAM_DEFINE_INT32(UAVCAN_SUB_IMU, 0);
 
 /**
+ * subscription log message
+ *
+ * Enable UAVCAN log message subscription.
+ *  uavcan::protocol::debug::LogMessage
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_SUB_LOG, 1);
+
+/**
  * subscription magnetometer
  *
  * Enable UAVCAN mag subscription.


### PR DESCRIPTION
 - fixes https://github.com/PX4/PX4-Autopilot/issues/19847

@ecmnet does this work for you? Alternatively we could make the log levels configurable (eg ignore info).