### PR TITLE
uavcannode: schedule to run on log_message publications

### DIFF
--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -330,6 +330,8 @@ int UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events
 		subscriber->init();
 	}
 
+	_log_message_sub.registerCallback();
+
 	bus_events.registerSignalCallback(UavcanNode::busevent_signal_trampoline);
 
 	int rv = _node.start();

--- a/src/drivers/uavcannode/UavcanNode.hpp
+++ b/src/drivers/uavcannode/UavcanNode.hpp
@@ -66,6 +66,7 @@
 #include <lib/perf/perf_counter.h>
 
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/log_message.h>
 #include <uORB/topics/parameter_update.h>
@@ -171,7 +172,7 @@ private:
 	IntrusiveSortedList<UavcanSubscriberBase *> _subscriber_list;
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _log_message_sub{ORB_ID(log_message)};
+	uORB::SubscriptionCallbackWorkItem _log_message_sub{this, ORB_ID(log_message)};
 
 	UavcanNodeParamManager _param_manager;
 	uavcan::ParamServer _param_server;


### PR DESCRIPTION
 - this is a precaution to minimize log message latency and potential lost messages