### PR TITLE
ekf2: update EKF2_EV_DELAY default to 0

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -136,7 +136,7 @@ PARAM_DEFINE_FLOAT(EKF2_ASP_DELAY, 100);
  * @reboot_required true
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(EKF2_EV_DELAY, 175);
+PARAM_DEFINE_FLOAT(EKF2_EV_DELAY, 0);
 
 /**
  * Auxillary Velocity Estimate (e.g from a landing target) delay relative to IMU measurements


### PR DESCRIPTION
I could be wrong, but I suspect `EKF2_EV_DELAY 0` is a better default for most people because MAVROS and ModalAI VOXL vision are handling the timesync by default.

 - using ROVIO and with the default EKF2_EV_DELAY 175 it was exceeding the EKF internal timeouts https://github.com/PX4/PX4-Autopilot/issues/19859 
 - modal AI EV defaults https://gitlab.com/voxl-public/flight-core-px4/px4-parameters/-/blob/master/platforms/v1.12/Starling/Starling_V2_param_rev_C.params#L54 