### PR TITLE
Remove MultirotorMixer from MC Ratecontrol

### DIFF
--- a/src/modules/angular_velocity_controller/AngularVelocityControl/AngularVelocityControl.hpp
+++ b/src/modules/angular_velocity_controller/AngularVelocityControl/AngularVelocityControl.hpp
@@ -41,7 +41,7 @@
 
 #include <matrix/matrix/math.hpp>
 
-#include <lib/mixer/MultirotorMixer/MultirotorMixer.hpp>
+#include <mathlib/mathlib.h>
 
 class AngularVelocityControl
 {

--- a/src/modules/mc_rate_control/RateControl/RateControl.hpp
+++ b/src/modules/mc_rate_control/RateControl/RateControl.hpp
@@ -41,7 +41,7 @@
 
 #include <matrix/matrix/math.hpp>
 
-#include <lib/mixer/MultirotorMixer/MultirotorMixer.hpp>
+#include <mathlib/mathlib.h>
 #include <uORB/topics/rate_ctrl_status.h>
 
 class RateControl


### PR DESCRIPTION
## Describe problem solved by this pull request
I noticed that the MultirotorMixer is included from the ratecontrol library, but is actually not being used

## Describe your solution
Remove the library and use the mathlib instead!

## Test data / coverage
Tested in SITL
```
make px4_sitl gazebo
```
builds correctly :smile: