### PR TITLE
Fixed pusher assist for standard vtol

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -98,7 +98,6 @@ void Standard::update_vtol_state()
 			// in mc mode
 			_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 			mc_weight = 1.0f;
-			_pusher_throttle = 0.0f;
 			_reverse_output = 0.0f;
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {


### PR DESCRIPTION
## Describe problem solved by this pull request
Pusher assist was broken for standard vtol. The signal going to the pusher motor would alternate between the desired value an 0.

## Describe your solution

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
