### PR TITLE
ekf2: estimator aid source status (airspeed)

### DIFF
--- a/msg/estimator_aid_source_1d.msg
+++ b/msg/estimator_aid_source_1d.msg
@@ -19,4 +19,4 @@ bool innovation_rejected     # true if the observation has been rejected
 bool fused                   # true if the sample was successfully fused
 
 # TOPICS estimator_aid_source_1d
-# TOPICS estimator_aid_src_baro_hgt estimator_aid_src_rng_hgt
+# TOPICS estimator_aid_src_baro_hgt estimator_aid_src_rng_hgt estimator_aid_src_airspeed

--- a/src/modules/ekf2/EKF/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/airspeed_fusion.cpp
@@ -45,8 +45,11 @@
 #include "ekf.h"
 #include <mathlib/mathlib.h>
 
-void Ekf::fuseAirspeed()
+void Ekf::updateAirspeed(const airspeedSample &airspeed_sample, estimator_aid_source_1d_s &airspeed) const
 {
+	// reset flags
+	resetEstimatorAidStatusFlags(airspeed);
+
 	const float vn = _state.vel(0); // Velocity in north direction
 	const float ve = _state.vel(1); // Velocity in east direction
 	const float vd = _state.vel(2); // Velocity in downwards direction
@@ -55,7 +58,51 @@ void Ekf::fuseAirspeed()
 
 	// Variance for true airspeed measurement - (m/sec)^2
 	const float R_TAS = sq(math::constrain(_params.eas_noise, 0.5f, 5.0f) *
-			       math::constrain(_airspeed_sample_delayed.eas2tas, 0.9f, 10.0f));
+			       math::constrain(airspeed_sample.eas2tas, 0.9f, 10.0f));
+
+	// Intermediate variables
+	const float IV0 = ve - vwe;
+	const float IV1 = vn - vwn;
+	const float IV2 = (IV0)*(IV0) + (IV1)*(IV1) + (vd)*(vd);
+
+	const float predicted_airspeed = sqrtf(IV2);
+
+	if (fabsf(predicted_airspeed) < FLT_EPSILON) {
+		return;
+	}
+
+	const float IV3 = 1.0F/(IV2);
+	const float IV4 = IV0*P(5,23);
+	const float IV5 = IV0*IV3;
+	const float IV6 = IV1*P(4,22);
+	const float IV7 = IV1*IV3;
+
+	const float innov_var = IV3*vd*(IV0*P(5,6) - IV0*P(6,23) + IV1*P(4,6) - IV1*P(6,22) + P(6,6)*vd) - IV5*(-IV0*P(23,23) - IV1*P(22,23) + IV1*P(4,23) + IV4 + P(6,23)*vd) + IV5*(IV0*P(5,5) + IV1*P(4,5) - IV1*P(5,22) - IV4 + P(5,6)*vd) - IV7*(-IV0*P(22,23) + IV0*P(5,22) - IV1*P(22,22) + IV6 + P(6,22)*vd) + IV7*(-IV0*P(4,23) + IV0*P(4,5) + IV1*P(4,4) - IV6 + P(4,6)*vd) + R_TAS;
+
+	airspeed.observation = airspeed_sample.true_airspeed;
+	airspeed.observation_variance = R_TAS;
+	airspeed.innovation = predicted_airspeed - airspeed.observation;
+	airspeed.innovation_variance = innov_var;
+
+	airspeed.fusion_enabled = _control_status.flags.fuse_aspd;
+
+	airspeed.timestamp_sample = airspeed_sample.time_us;
+
+	const float innov_gate = fmaxf(_params.tas_innov_gate, 1.f);
+	setEstimatorAidStatusTestRatio(airspeed, innov_gate);
+}
+
+void Ekf::fuseAirspeed(estimator_aid_source_1d_s &airspeed)
+{
+	if (airspeed.innovation_rejected) {
+		return;
+	}
+
+	const float vn = _state.vel(0); // Velocity in north direction
+	const float ve = _state.vel(1); // Velocity in east direction
+	const float vd = _state.vel(2); // Velocity in downwards direction
+	const float vwn = _state.wind_vel(0); // Wind speed in north direction
+	const float vwe = _state.wind_vel(1); // Wind speed in east direction
 
 	// determine if we need the airspeed fusion to correct states other than wind
 	const bool update_wind_only = !_control_status.flags.wind_dead_reckoning;
@@ -63,34 +110,25 @@ void Ekf::fuseAirspeed()
 	// Intermediate variables
 	const float HK0 = vn - vwn;
 	const float HK1 = ve - vwe;
-	const float HK2 = ecl::powf(HK0, 2) + ecl::powf(HK1, 2) + ecl::powf(vd, 2);
-	const float v_tas_pred = sqrtf(HK2); // predicted airspeed
+	const float HK2 = sqrtf((HK0)*(HK0) + (HK1)*(HK1) + (vd)*(vd));
 
-	//const float HK3 = powf(HK2, -1.0F/2.0F);
-	if (v_tas_pred < 1.0f) {
+	const float predicted_airspeed = HK2;
+
+	if (predicted_airspeed < 1.0f) {
 		// calculation can be badly conditioned for very low airspeed values so don't fuse this time
 		return;
 	}
 
-	const float HK3 = 1.0f / v_tas_pred;
+	const float HK3 = 1.0F/(HK2);
 	const float HK4 = HK0*HK3;
 	const float HK5 = HK1*HK3;
-	const float HK6 = 1.0F/HK2;
-	const float HK7 = HK0*P(4,6) - HK0*P(6,22) + HK1*P(5,6) - HK1*P(6,23) + P(6,6)*vd;
-	const float HK8 = HK1*P(5,23);
-	const float HK9 = HK0*P(4,5) - HK0*P(5,22) + HK1*P(5,5) - HK8 + P(5,6)*vd;
-	const float HK10 = HK1*HK6;
-	const float HK11 = HK0*P(4,22);
-	const float HK12 = HK0*P(4,4) - HK1*P(4,23) + HK1*P(4,5) - HK11 + P(4,6)*vd;
-	const float HK13 = HK0*HK6;
-	const float HK14 = -HK0*P(22,23) + HK0*P(4,23) - HK1*P(23,23) + HK8 + P(6,23)*vd;
-	const float HK15 = -HK0*P(22,22) - HK1*P(22,23) + HK1*P(5,22) + HK11 + P(6,22)*vd;
-	//const float HK16 = HK3/(-HK10*HK14 + HK10*HK9 + HK12*HK13 - HK13*HK15 + HK6*HK7*vd + R_TAS);
+	const float HK6 = HK3*vd;
+	const float HK7 = -HK0*HK3;
+	const float HK8 = -HK1*HK3;
 
-	// innovation variance - check for badly conditioned calculation
-	_airspeed_innov_var = (-HK10 * HK14 + HK10 * HK9 + HK12 * HK13 - HK13 * HK15 + HK6 * HK7 * vd + R_TAS);
+	const float innov_var = airspeed.innovation_variance;
 
-	if (_airspeed_innov_var < R_TAS) { //
+	if (innov_var < airspeed.observation_variance || innov_var < FLT_EPSILON) {
 		// Reset the estimator covariance matrix
 		// if we are getting aiding from other sources, warn and reset the wind states and covariances only
 		const char *action_string = nullptr;
@@ -112,58 +150,37 @@ void Ekf::fuseAirspeed()
 		return;
 	}
 
-	const float HK16 = HK3 / _airspeed_innov_var;
+	const float HK9 = 1.0F/(innov_var);
+
 	_fault_status.flags.bad_airspeed = false;
 
 	// Observation Jacobians
 	SparseVector24f<4,5,6,22,23> Hfusion;
 	Hfusion.at<4>() = HK4;
 	Hfusion.at<5>() = HK5;
-	Hfusion.at<6>() = HK3*vd;
-	Hfusion.at<22>() = -HK4;
-	Hfusion.at<23>() = -HK5;
+	Hfusion.at<6>() = HK6;
+	Hfusion.at<22>() = HK7;
+	Hfusion.at<23>() = HK8;
 
 	Vector24f Kfusion; // Kalman gain vector
 
 	if (!update_wind_only) {
 		// we have no other source of aiding, so use airspeed measurements to correct states
-		for (unsigned row = 0; row <= 3; row++) {
-			Kfusion(row) = HK16*(HK0*P(4,row) - HK0*P(row,22) + HK1*P(5,row) - HK1*P(row,23) + P(6,row)*vd);
-		}
-
-		Kfusion(4) = HK12*HK16;
-		Kfusion(5) = HK16*HK9;
-		Kfusion(6) = HK16*HK7;
-
-		for (unsigned row = 7; row <= 21; row++) {
-			Kfusion(row) = HK16*(HK0*P(4,row) - HK0*P(row,22) + HK1*P(5,row) - HK1*P(row,23) + P(6,row)*vd);
+		for (unsigned row = 0; row <= 21; row++) {
+			Kfusion(row) = HK9*(HK4*P(row,4) + HK5*P(row,5) + HK6*P(row,6) + HK7*P(row,22) + HK8*P(row,23));
 		}
 	}
 
-	Kfusion(22) = HK15*HK16;
-	Kfusion(23) = HK14*HK16;
+	Kfusion(22) = HK9*(HK4*P(4,22) + HK5*P(5,22) + HK6*P(6,22) + HK7*P(22,22) + HK8*P(22,23));
+	Kfusion(23) = HK9*(HK4*P(4,23) + HK5*P(5,23) + HK6*P(6,23) + HK7*P(22,23) + HK8*P(23,23));
 
-	// Calculate measurement innovation
-	_airspeed_innov = v_tas_pred - _airspeed_sample_delayed.true_airspeed;
+	const bool is_fused = measurementUpdate(Kfusion, Hfusion, airspeed.innovation);
 
-	// Compute the ratio of innovation to gate size
-	_tas_test_ratio = sq(_airspeed_innov) / (sq(fmaxf(_params.tas_innov_gate, 1.0f)) * _airspeed_innov_var);
-
-	// If the innovation consistency check fails then don't fuse the sample and indicate bad airspeed health
-	if (_tas_test_ratio > 1.0f) {
-		_innov_check_fail_status.flags.reject_airspeed = true;
-		return;
-
-	} else {
-		_innov_check_fail_status.flags.reject_airspeed = false;
-	}
-
-	const bool is_fused = measurementUpdate(Kfusion, Hfusion, _airspeed_innov);
-
+	airspeed.fused = is_fused;
 	_fault_status.flags.bad_airspeed = !is_fused;
 
 	if (is_fused) {
-		_time_last_arsp_fuse = _time_last_imu;
+		airspeed.time_last_fuse = _time_last_imu;
 	}
 }
 
@@ -195,7 +212,7 @@ void Ekf::resetWindUsingAirspeed()
 
 	resetWindCovarianceUsingAirspeed();
 
-	_time_last_arsp_fuse = _time_last_imu;
+	_aid_src_airspeed.time_last_fuse = _time_last_imu;
 }
 
 void Ekf::resetWindToZero()

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -347,6 +347,8 @@ public:
 
 	const BaroBiasEstimator::status &getBaroBiasEstimatorStatus() const { return _baro_b_est.getStatus(); }
 
+	const auto &aid_src_airspeed() const { return _aid_src_airspeed; }
+
 	const auto &aid_src_baro_hgt() const { return _aid_src_baro_hgt; }
 	const auto &aid_src_rng_hgt() const { return _aid_src_rng_hgt; }
 

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -123,9 +123,9 @@ public:
 	void getDragInnovVar(float drag_innov_var[2]) const { _drag_innov_var.copyTo(drag_innov_var); }
 	void getDragInnovRatio(float drag_innov_ratio[2]) const { _drag_test_ratio.copyTo(drag_innov_ratio); }
 
-	void getAirspeedInnov(float &airspeed_innov) const { airspeed_innov = _airspeed_innov; }
-	void getAirspeedInnovVar(float &airspeed_innov_var) const { airspeed_innov_var = _airspeed_innov_var; }
-	void getAirspeedInnovRatio(float &airspeed_innov_ratio) const { airspeed_innov_ratio = _tas_test_ratio; }
+	void getAirspeedInnov(float &airspeed_innov) const { airspeed_innov = _aid_src_airspeed.innovation; }
+	void getAirspeedInnovVar(float &airspeed_innov_var) const { airspeed_innov_var = _aid_src_airspeed.innovation_variance; }
+	void getAirspeedInnovRatio(float &airspeed_innov_ratio) const { airspeed_innov_ratio = _aid_src_airspeed.test_ratio; }
 
 	void getBetaInnov(float &beta_innov) const { beta_innov = _beta_innov; }
 	void getBetaInnovVar(float &beta_innov_var) const { beta_innov_var = _beta_innov_var; }
@@ -412,7 +412,6 @@ private:
 	uint64_t _time_last_ver_vel_fuse{0};	///< time the last fusion of verticalvelocity measurements was performed (uSec)
 	uint64_t _time_last_of_fuse{0};		///< time the last fusion of optical flow measurements were performed (uSec)
 	uint64_t _time_last_flow_terrain_fuse{0}; ///< time the last fusion of optical flow measurements for terrain estimation were performed (uSec)
-	uint64_t _time_last_arsp_fuse{0};	///< time the last fusion of airspeed measurements were performed (uSec)
 	uint64_t _time_last_beta_fuse{0};	///< time the last fusion of synthetic sideslip measurements were performed (uSec)
 	uint64_t _time_last_zero_velocity_fuse{0}; ///< last time of zero velocity update (uSec)
 	uint64_t _time_last_gps_yaw_fuse{0};	///< time the last fusion of GPS yaw measurements were performed (uSec)
@@ -475,9 +474,6 @@ private:
 	Vector2f _drag_innov{};		///< multirotor drag measurement innovation (m/sec**2)
 	Vector2f _drag_innov_var{};	///< multirotor drag measurement innovation variance ((m/sec**2)**2)
 
-	float _airspeed_innov{0.0f};		///< airspeed measurement innovation (m/sec)
-	float _airspeed_innov_var{0.0f};	///< airspeed measurement innovation variance ((m/sec)**2)
-
 	float _beta_innov{0.0f};	///< synthetic sideslip measurement innovation (rad)
 	float _beta_innov_var{0.0f};	///< synthetic sideslip measurement innovation variance (rad**2)
 
@@ -500,6 +496,7 @@ private:
 
 	estimator_aid_source_1d_s _aid_src_baro_hgt{};
 	estimator_aid_source_1d_s _aid_src_rng_hgt{};
+	estimator_aid_source_1d_s _aid_src_airspeed{};
 
 	estimator_aid_source_2d_s _aid_src_fake_pos{};
 
@@ -643,8 +640,8 @@ private:
 	// apply sensible limits to the declination and length of the NE mag field states estimates
 	void limitDeclination();
 
-	// fuse airspeed measurement
-	void fuseAirspeed();
+	void updateAirspeed(const airspeedSample &airspeed_sample, estimator_aid_source_1d_s &airspeed) const;
+	void fuseAirspeed(estimator_aid_source_1d_s &airspeed);
 
 	// fuse synthetic zero sideslip measurement
 	void fuseSideslip();

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -984,7 +984,7 @@ void Ekf::get_innovation_test_status(uint16_t &status, float &mag, float &vel, f
 	}
 
 	// return the airspeed fusion innovation test ratio
-	tas = sqrtf(_tas_test_ratio);
+	tas = sqrtf(_aid_src_airspeed.test_ratio);
 
 	// return the terrain height innovation test ratio
 	hagl = sqrtf(_hagl_test_ratio);
@@ -1045,7 +1045,7 @@ void Ekf::update_deadreckoning_status()
 	const bool optFlowAiding = _control_status.flags.opt_flow && isRecent(_time_last_of_fuse, _params.no_aid_timeout_max);
 
 	const bool airDataAiding = _control_status.flags.wind &&
-				   isRecent(_time_last_arsp_fuse, _params.no_aid_timeout_max) &&
+				   isRecent(_aid_src_airspeed.time_last_fuse, _params.no_aid_timeout_max) &&
 				   isRecent(_time_last_beta_fuse, _params.no_aid_timeout_max);
 
 	_control_status.flags.wind_dead_reckoning = !velPosAiding && !optFlowAiding && airDataAiding;

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -335,7 +335,6 @@ protected:
 	Vector2f _ev_pos_test_ratio{};		// EV position innovation consistency check ratios
 	Vector2f _aux_vel_test_ratio{};		// Auxiliary horizontal velocity innovation consistency check ratio
 	float _optflow_test_ratio{};		// Optical flow innovation consistency check ratio
-	float _tas_test_ratio{};		// tas innovation consistency check ratio
 	float _hagl_test_ratio{};		// height above terrain measurement innovation consistency check ratio
 	float _beta_test_ratio{};		// sideslip innovation consistency check ratio
 	Vector2f _drag_test_ratio{};		// drag innovation consistency check ratio

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/3Dmag_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/3Dmag_generated.cpp
@@ -62,6 +62,12 @@ Kfusion(22) = HKX21*(HKX10*P(0,22) - HKX11*P(2,22) + HKX12*P(3,22) + HKX4*P(16,2
 Kfusion(23) = HKX21*(HKX10*P(0,23) - HKX11*P(2,23) + HKX12*P(3,23) + HKX4*P(16,23) + HKX7*P(17,23) - HKX8*P(18,23) + HKX9*P(1,23) + P(19,23));
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+
 // Axis 1 equations
 // Sub Expressions
 const float HKY0 = magD*q1 + magE*q0 - magN*q3;
@@ -126,6 +132,12 @@ Kfusion(22) = HKY21*(HKY10*P(0,22) + HKY11*P(1,22) - HKY12*P(3,22) + HKY5*P(17,2
 Kfusion(23) = HKY21*(HKY10*P(0,23) + HKY11*P(1,23) - HKY12*P(3,23) + HKY5*P(17,23) + HKY7*P(18,23) - HKY8*P(16,23) + HKY9*P(2,23) + P(20,23));
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+
 // Axis 2 equations
 // Sub Expressions
 const float HKZ0 = magD*q0 - magE*q1 + magN*q2;
@@ -188,5 +200,11 @@ Kfusion(20) = HKZ21*(HKZ10*P(0,20) - HKZ11*P(1,20) + HKZ12*P(2,20) + HKZ6*P(18,2
 Kfusion(21) = HKZ20*HKZ21;
 Kfusion(22) = HKZ21*(HKZ10*P(0,22) - HKZ11*P(1,22) + HKZ12*P(2,22) + HKZ6*P(18,22) + HKZ7*P(16,22) - HKZ8*P(17,22) + HKZ9*P(3,22) + P(21,22));
 Kfusion(23) = HKZ21*(HKZ10*P(0,23) - HKZ11*P(1,23) + HKZ12*P(2,23) + HKZ6*P(18,23) + HKZ7*P(16,23) - HKZ8*P(17,23) + HKZ9*P(3,23) + P(21,23));
+
+
+// Predicted observation
+
+
+// Innovation variance
 
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/acc_bf_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/acc_bf_generated.cpp
@@ -75,6 +75,12 @@ Kfusion(22) = HK33*(-HK12*P(2,22) - HK13*P(6,22) + HK29 - HK7*P(22,22));
 Kfusion(23) = HK33*(-HK12*P(2,23) - HK13*P(6,23) + HK24 - HK7*P(22,23));
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+
 // Axis 1 equations
 // Sub Expressions
 const float HK0 = ve - vwe;
@@ -150,5 +156,11 @@ Kfusion(20) = HK33*(-HK12*P(3,20) + HK13*P(20,22) - HK13*P(4,20) + HK14*P(0,20) 
 Kfusion(21) = HK33*(-HK12*P(3,21) + HK13*P(21,22) - HK13*P(4,21) + HK14*P(0,21) + HK15*P(1,21) + HK16*P(2,21) + HK17*P(6,21) - HK9*P(21,23) + HK9*P(5,21));
 Kfusion(22) = HK33*(-HK12*P(3,22) + HK24 - HK25 - HK9*P(22,23));
 Kfusion(23) = HK33*(-HK12*P(3,23) - HK13*P(4,23) + HK29 - HK9*P(23,23));
+
+
+// Predicted observation
+
+
+// Innovation variance
 
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/beta_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/beta_generated.cpp
@@ -91,3 +91,9 @@ Kfusion(22) = HK43*HK50;
 Kfusion(23) = HK40*HK50;
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/flow_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/flow_generated.cpp
@@ -81,6 +81,12 @@ Kfusion(22) = HK41*(HK22*P(4,22) + HK27*P(5,22) + HK28*P(6,22) + HK29*P(0,22) + 
 Kfusion(23) = HK41*(HK22*P(4,23) + HK27*P(5,23) + HK28*P(6,23) + HK29*P(0,23) + HK30*P(1,23) + HK31*P(2,23) + HK32*P(3,23));
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+
 // Y Axis Equations
 // Sub Expressions
 const float HK0 = -Tbs(0,0)*q2 + Tbs(0,1)*q1 + Tbs(0,2)*q0;
@@ -168,5 +174,11 @@ Kfusion(20) = -HK47*(HK32*P(0,20) + HK33*P(1,20) + HK34*P(2,20) + HK35*P(3,20) +
 Kfusion(21) = -HK47*(HK32*P(0,21) + HK33*P(1,21) + HK34*P(2,21) + HK35*P(3,21) + HK36*P(4,21) + HK37*P(5,21) + HK38*P(6,21));
 Kfusion(22) = -HK47*(HK32*P(0,22) + HK33*P(1,22) + HK34*P(2,22) + HK35*P(3,22) + HK36*P(4,22) + HK37*P(5,22) + HK38*P(6,22));
 Kfusion(23) = -HK47*(HK32*P(0,23) + HK33*P(1,23) + HK34*P(2,23) + HK35*P(3,23) + HK36*P(4,23) + HK37*P(5,23) + HK38*P(6,23));
+
+
+// Predicted observation
+
+
+// Innovation variance
 
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/gps_yaw_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/gps_yaw_generated.cpp
@@ -65,3 +65,9 @@ Kfusion(22) = HK29*(-HK14*P(0,22) - HK20*P(1,22) - HK21*P(2,22) + HK22*HK8*P(3,2
 Kfusion(23) = HK29*(-HK14*P(0,23) - HK20*P(1,23) - HK21*P(2,23) + HK22*HK8*P(3,23));
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/mag_decl_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/mag_decl_generated.cpp
@@ -43,3 +43,9 @@ Kfusion(22) = -HK9*(HK5*P(16,22) - P(17,22));
 Kfusion(23) = -HK9*(HK5*P(16,23) - P(17,23));
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/tas_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/tas_generated.cpp
@@ -53,3 +53,9 @@ Kfusion(22) = HK15*HK16;
 Kfusion(23) = HK14*HK16;
 
 
+// Predicted observation
+
+
+// Innovation variance
+
+

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/tas_hk_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/tas_hk_generated.cpp
@@ -1,0 +1,55 @@
+// Sub Expressions
+const float HK0 = vn - vwn;
+const float HK1 = ve - vwe;
+const float HK2 = sqrtf((HK0)*(HK0) + (HK1)*(HK1) + (vd)*(vd));
+const float HK3 = 1.0F/(HK2);
+const float HK4 = HK0*HK3;
+const float HK5 = HK1*HK3;
+const float HK6 = HK3*vd;
+const float HK7 = -HK0*HK3;
+const float HK8 = -HK1*HK3;
+const float HK9 = 1.0F/(innov_var);
+
+
+// Observation Jacobians
+Hfusion.at<4>() = HK4;
+Hfusion.at<5>() = HK5;
+Hfusion.at<6>() = HK6;
+Hfusion.at<22>() = HK7;
+Hfusion.at<23>() = HK8;
+
+
+// Kalman gains
+Kfusion(0) = HK9*(HK4*P(0,4) + HK5*P(0,5) + HK6*P(0,6) + HK7*P(0,22) + HK8*P(0,23));
+Kfusion(1) = HK9*(HK4*P(1,4) + HK5*P(1,5) + HK6*P(1,6) + HK7*P(1,22) + HK8*P(1,23));
+Kfusion(2) = HK9*(HK4*P(2,4) + HK5*P(2,5) + HK6*P(2,6) + HK7*P(2,22) + HK8*P(2,23));
+Kfusion(3) = HK9*(HK4*P(3,4) + HK5*P(3,5) + HK6*P(3,6) + HK7*P(3,22) + HK8*P(3,23));
+Kfusion(4) = HK9*(HK4*P(4,4) + HK5*P(4,5) + HK6*P(4,6) + HK7*P(4,22) + HK8*P(4,23));
+Kfusion(5) = HK9*(HK4*P(4,5) + HK5*P(5,5) + HK6*P(5,6) + HK7*P(5,22) + HK8*P(5,23));
+Kfusion(6) = HK9*(HK4*P(4,6) + HK5*P(5,6) + HK6*P(6,6) + HK7*P(6,22) + HK8*P(6,23));
+Kfusion(7) = HK9*(HK4*P(4,7) + HK5*P(5,7) + HK6*P(6,7) + HK7*P(7,22) + HK8*P(7,23));
+Kfusion(8) = HK9*(HK4*P(4,8) + HK5*P(5,8) + HK6*P(6,8) + HK7*P(8,22) + HK8*P(8,23));
+Kfusion(9) = HK9*(HK4*P(4,9) + HK5*P(5,9) + HK6*P(6,9) + HK7*P(9,22) + HK8*P(9,23));
+Kfusion(10) = HK9*(HK4*P(4,10) + HK5*P(5,10) + HK6*P(6,10) + HK7*P(10,22) + HK8*P(10,23));
+Kfusion(11) = HK9*(HK4*P(4,11) + HK5*P(5,11) + HK6*P(6,11) + HK7*P(11,22) + HK8*P(11,23));
+Kfusion(12) = HK9*(HK4*P(4,12) + HK5*P(5,12) + HK6*P(6,12) + HK7*P(12,22) + HK8*P(12,23));
+Kfusion(13) = HK9*(HK4*P(4,13) + HK5*P(5,13) + HK6*P(6,13) + HK7*P(13,22) + HK8*P(13,23));
+Kfusion(14) = HK9*(HK4*P(4,14) + HK5*P(5,14) + HK6*P(6,14) + HK7*P(14,22) + HK8*P(14,23));
+Kfusion(15) = HK9*(HK4*P(4,15) + HK5*P(5,15) + HK6*P(6,15) + HK7*P(15,22) + HK8*P(15,23));
+Kfusion(16) = HK9*(HK4*P(4,16) + HK5*P(5,16) + HK6*P(6,16) + HK7*P(16,22) + HK8*P(16,23));
+Kfusion(17) = HK9*(HK4*P(4,17) + HK5*P(5,17) + HK6*P(6,17) + HK7*P(17,22) + HK8*P(17,23));
+Kfusion(18) = HK9*(HK4*P(4,18) + HK5*P(5,18) + HK6*P(6,18) + HK7*P(18,22) + HK8*P(18,23));
+Kfusion(19) = HK9*(HK4*P(4,19) + HK5*P(5,19) + HK6*P(6,19) + HK7*P(19,22) + HK8*P(19,23));
+Kfusion(20) = HK9*(HK4*P(4,20) + HK5*P(5,20) + HK6*P(6,20) + HK7*P(20,22) + HK8*P(20,23));
+Kfusion(21) = HK9*(HK4*P(4,21) + HK5*P(5,21) + HK6*P(6,21) + HK7*P(21,22) + HK8*P(21,23));
+Kfusion(22) = HK9*(HK4*P(4,22) + HK5*P(5,22) + HK6*P(6,22) + HK7*P(22,22) + HK8*P(22,23));
+Kfusion(23) = HK9*(HK4*P(4,23) + HK5*P(5,23) + HK6*P(6,23) + HK7*P(22,23) + HK8*P(23,23));
+
+
+// Predicted observation
+meas_pred = HK2;
+
+
+// Innovation variance
+
+

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/tas_var_generated.cpp
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/tas_var_generated.cpp
@@ -1,0 +1,25 @@
+// Sub Expressions
+const float IV0 = ve - vwe;
+const float IV1 = vn - vwn;
+const float IV2 = (IV0)*(IV0) + (IV1)*(IV1) + (vd)*(vd);
+const float IV3 = 1.0F/(IV2);
+const float IV4 = IV0*P(5,23);
+const float IV5 = IV0*IV3;
+const float IV6 = IV1*P(4,22);
+const float IV7 = IV1*IV3;
+
+
+// Observation Jacobians
+
+
+// Kalman gains
+
+
+// Predicted observation
+meas_pred = sqrtf(IV2);
+
+
+// Innovation variance
+innov_var = IV3*vd*(IV0*P(5,6) - IV0*P(6,23) + IV1*P(4,6) - IV1*P(6,22) + P(6,6)*vd) - IV5*(-IV0*P(23,23) - IV1*P(22,23) + IV1*P(4,23) + IV4 + P(6,23)*vd) + IV5*(IV0*P(5,5) + IV1*P(4,5) - IV1*P(5,22) - IV4 + P(5,6)*vd) - IV7*(-IV0*P(22,23) + IV0*P(5,22) - IV1*P(22,22) + IV6 + P(6,22)*vd) + IV7*(-IV0*P(4,23) + IV0*P(4,5) + IV1*P(4,4) - IV6 + P(4,6)*vd) + R_TAS;
+
+

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -638,6 +638,9 @@ void EKF2::Run()
 
 void EKF2::PublishAidSourceStatus(const hrt_abstime &timestamp)
 {
+	// airspeed
+	PublishAidSourceStatus(_ekf.aid_src_airspeed(), _status_airspeed_pub_last, _estimator_aid_src_airspeed_pub);
+
 	// baro height
 	PublishAidSourceStatus(_ekf.aid_src_baro_hgt(), _status_baro_hgt_pub_last, _estimator_aid_src_baro_hgt_pub);
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -254,6 +254,8 @@ private:
 	hrt_abstime _last_sensor_bias_published{0};
 	hrt_abstime _last_gps_status_published{0};
 
+	hrt_abstime _status_airspeed_pub_last{0};
+
 	hrt_abstime _status_baro_hgt_pub_last{0};
 	hrt_abstime _status_rng_hgt_pub_last{0};
 
@@ -320,6 +322,7 @@ private:
 	uORB::PublicationMulti<vehicle_optical_flow_vel_s> _estimator_optical_flow_vel_pub{ORB_ID(estimator_optical_flow_vel)};
 	uORB::PublicationMulti<yaw_estimator_status_s>       _yaw_est_pub{ORB_ID(yaw_estimator_status)};
 
+	uORB::PublicationMulti<estimator_aid_source_1d_s> _estimator_aid_src_airspeed_pub{ORB_ID(estimator_aid_src_airspeed)};
 	uORB::PublicationMulti<estimator_aid_source_1d_s> _estimator_aid_src_baro_hgt_pub{ORB_ID(estimator_aid_src_baro_hgt)};
 	uORB::PublicationMulti<estimator_aid_source_1d_s> _estimator_aid_src_rng_hgt_pub{ORB_ID(estimator_aid_src_rng_hgt)};
 


### PR DESCRIPTION
Follows https://github.com/PX4/PX4-Autopilot/pull/19702, requires https://github.com/PX4/PX4-Autopilot/pull/19867
Since this isn't a direct observation of a state, the innovation variance and the KH computation need to be split-up in the python derivation directly.

@dagar This is required to be able to check the test ratio before trying to start the fusion.

## Test data / coverage
SITL tested