### PR TITLE
Fw takeoff refactor

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
@@ -38,7 +38,6 @@ param set-default NAV_DLL_ACT 2
 param set-default RWTO_TKOFF 1
 
 param set-default RWTO_MAX_PITCH 20
-param set-default RWTO_MAX_ROLL 10
 
 param set-default RWTO_PSP 8
 param set-default RWTO_AIRSPD_SCL 1.8

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
@@ -38,7 +38,6 @@ param set-default NAV_DLL_ACT 2
 param set-default RWTO_TKOFF 1
 
 param set-default RWTO_MAX_PITCH 20
-param set-default RWTO_MAX_ROLL 10
 
 param set-default RWTO_PSP 8
 param set-default RWTO_AIRSPD_SCL 1.8

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
@@ -37,7 +37,6 @@ param set-default NAV_DLL_ACT 2
 
 param set-default RWTO_TKOFF 1
 param set-default RWTO_MAX_PITCH 20
-param set-default RWTO_MAX_ROLL 10
 param set-default RWTO_PSP 8
 param set-default RWTO_AIRSPD_SCL 1.8
 

--- a/msg/vehicle_rates_setpoint.msg
+++ b/msg/vehicle_rates_setpoint.msg
@@ -1,8 +1,12 @@
 uint64 timestamp	# time since system start (microseconds)
 
-float32 roll		# body angular rates in NED frame
-float32 pitch		# body angular rates in NED frame
-float32 yaw		# body angular rates in NED frame
+# body angular rates in NED frame
+float32 roll		# [rad/s] roll rate setpoint
+float32 pitch		# [rad/s] pitch rate setpoint
+float32 yaw		# [rad/s] yaw rate setpoint
+
+# [rad/s] yaw rate setpoint the wheel attempts to track (the wheel controller has different gains than the yaw controller)
+float32 yaw_via_wheel
 
 # For clarification: For multicopters thrust_body[0] and thrust[1] are usually 0 and thrust[2] is the negative throttle demand.
 # For fixed wings thrust_x is the throttle demand and thrust_y, thrust_z will usually be zero.

--- a/msg/vehicle_rates_setpoint.msg
+++ b/msg/vehicle_rates_setpoint.msg
@@ -5,9 +5,6 @@ float32 roll		# [rad/s] roll rate setpoint
 float32 pitch		# [rad/s] pitch rate setpoint
 float32 yaw		# [rad/s] yaw rate setpoint
 
-# [rad/s] yaw rate setpoint the wheel attempts to track (the wheel controller has different gains than the yaw controller)
-float32 yaw_via_wheel
-
 # For clarification: For multicopters thrust_body[0] and thrust[1] are usually 0 and thrust[2] is the negative throttle demand.
 # For fixed wings thrust_x is the throttle demand and thrust_y, thrust_z will usually be zero.
 float32[3] thrust_body	# Normalized thrust command in body NED frame [-1,1]

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -216,8 +216,17 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-	const float tas_fully_undersped = math::max(_TAS_min - TAS_ERROR_BOUND - TAS_UNDERSPEED_SOFT_BOUND, 0.0f);
-	const float tas_starting_to_underspeed = math::max(_TAS_min - TAS_ERROR_BOUND, tas_fully_undersped);
+	// this is the expected (something like standard) deviation from the airspeed setpoint that we allow the airspeed
+	// to vary in before ramping in underspeed mitigation
+	const float tas_error_bound = kTASErrorPercentage * _equivalent_airspeed_trim;
+
+	// this is the soft boundary where underspeed mitigation is ramped in
+	// NOTE: it's currently the same as the error bound, but separated here to indicate these values do not in general
+	// need to be the same
+	const float tas_underspeed_soft_bound = kTASErrorPercentage * _equivalent_airspeed_trim;
+
+	const float tas_fully_undersped = math::max(_TAS_min - tas_error_bound - tas_underspeed_soft_bound, 0.0f);
+	const float tas_starting_to_underspeed = math::max(_TAS_min - tas_error_bound, tas_fully_undersped);
 
 	_percent_undersped = 1.0f - math::constrain((_tas_state - tas_fully_undersped) /
 			     math::max(tas_starting_to_underspeed - tas_fully_undersped, FLT_EPSILON), 0.0f, 1.0f);

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -168,9 +168,8 @@ void TECS::_update_speed_setpoint()
 
 	// Calculate limits for the demanded rate of change of speed based on physical performance limits
 	// with a 50% margin to allow the total energy controller to correct for errors.
-	// NOTE: at zero airspeed, the true airspeed rate setpoint is unbounded
-	const float max_tas_rate_sp = 0.5f * _STE_rate_max / _tas_state;
-	const float min_tas_rate_sp = 0.5f * _STE_rate_min / _tas_state;
+	const float max_tas_rate_sp = 0.5f * _STE_rate_max / math::max(_tas_state, FLT_EPSILON);
+	const float min_tas_rate_sp = 0.5f * _STE_rate_min / math::max(_tas_state, FLT_EPSILON);
 
 	_TAS_setpoint_adj = constrain(_TAS_setpoint, _TAS_min, _TAS_max);
 
@@ -548,10 +547,10 @@ void TECS::_initialize_states(float pitch, float throttle_trim, float baro_altit
 void TECS::_update_STE_rate_lim()
 {
 	// Calculate the specific total energy upper rate limits from the max throttle climb rate
-	_STE_rate_max = _max_climb_rate * CONSTANTS_ONE_G;
+	_STE_rate_max = math::max(_max_climb_rate, FLT_EPSILON) * CONSTANTS_ONE_G;
 
 	// Calculate the specific total energy lower rate limits from the min throttle sink rate
-	_STE_rate_min = - _min_sink_rate * CONSTANTS_ONE_G;
+	_STE_rate_min = - math::max(_min_sink_rate, FLT_EPSILON) * CONSTANTS_ONE_G;
 }
 
 void TECS::update_pitch_throttle(float pitch, float baro_altitude, float hgt_setpoint,

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -81,7 +81,6 @@ public:
 	 * Must be called at 50Hz or greater
 	 */
 	void update_vehicle_state_estimates(float equivalent_airspeed, const float speed_deriv_forward, bool altitude_lock,
-					    bool in_air,
 					    float altitude, float vz);
 
 	/**
@@ -98,6 +97,23 @@ public:
 	float get_throttle_trim() { return _throttle_trim; }
 
 	void reset_state() { _states_initialized = false; }
+
+	void resetIntegrals()
+	{
+		_throttle_integ_state =  0.0f;
+		_pitch_integ_state = 0.0f;
+	}
+
+	/**
+	 * @brief Resets the altitude and height rate control trajectory generators to the input altitude
+	 *
+	 * @param altitude Vehicle altitude (AMSL) [m]
+	 */
+	void resetTrajectoryGenerators(const float altitude)
+	{
+		_alt_control_traj_generator.reset(0, 0, altitude);
+		_velocity_control_traj_generator.reset(0.0f, 0.0f, altitude);
+	}
 
 	enum ECL_TECS_MODE {
 		ECL_TECS_MODE_NORMAL = 0,
@@ -307,8 +323,7 @@ private:
 	bool _uncommanded_descent_recovery{false};			///< true when a continuous descent caused by an unachievable airspeed demand has been detected
 	bool _climbout_mode_active{false};				///< true when in climbout mode
 	bool _airspeed_enabled{false};					///< true when airspeed use has been enabled
-	bool _states_initialized{false};					///< true when TECS states have been iniitalized
-	bool _in_air{false};						///< true when the vehicle is flying
+	bool _states_initialized{false};				///< true when TECS states have been iniitalized
 
 	/**
 	 * Update the airspeed internal state using a second order complementary filter

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -219,8 +219,15 @@ public:
 
 private:
 
+	// [m/s] bound on expected (safe) true airspeed tracking errors, including TAS = TAS_min - TAS_ERROR_BOUND
+	static constexpr float TAS_ERROR_BOUND = 2.0f;
+
+	// [m/s] true airspeed soft boundary region below the accepted TAS error region (below TAS_min - TAS_ERROR_BOUND)
+	// underspeed mitigation measures are ramped in from zero to full within this region
+	static constexpr float TAS_UNDERSPEED_SOFT_BOUND = 1.5f;
+
 	static constexpr float _jerk_max =
-		1000.0f;	// maximum jerk for creating height rate trajectories, we want infinite jerk so set a high value
+		1000.0f;
 
 	enum ECL_TECS_MODE _tecs_mode {ECL_TECS_MODE_NORMAL};
 
@@ -318,7 +325,7 @@ private:
 	static constexpr float DT_DEFAULT = 0.02f;			///< default value for _dt (sec)
 
 	// controller mode logic
-	bool _underspeed_detected{false};				///< true when an underspeed condition has been detected
+	float _percent_undersped{0.0f};					///< a continuous representation of how "undersped" the TAS is [0,1]
 	bool _detect_underspeed_enabled{true};				///< true when underspeed detection is enabled
 	bool _uncommanded_descent_recovery{false};			///< true when a continuous descent caused by an unachievable airspeed demand has been detected
 	bool _climbout_mode_active{false};				///< true when in climbout mode
@@ -342,7 +349,7 @@ private:
 			float alt_amsl);
 
 	/**
-	 * Detect if the system is not capable of maintaining airspeed
+	 * Detect how undersped the aircraft is
 	 */
 	void _detect_underspeed();
 

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -291,8 +291,8 @@ private:
 
 	// vehicle physical limits
 	float _pitch_setpoint_unc{0.0f};				///< pitch demand before limiting (rad)
-	float _STE_rate_max{0.0f};					///< specific total energy rate upper limit achieved when throttle is at _throttle_setpoint_max (m**2/sec**3)
-	float _STE_rate_min{0.0f};					///< specific total energy rate lower limit acheived when throttle is at _throttle_setpoint_min (m**2/sec**3)
+	float _STE_rate_max{FLT_EPSILON};				///< specific total energy rate upper limit achieved when throttle is at _throttle_setpoint_max (m**2/sec**3)
+	float _STE_rate_min{-FLT_EPSILON};				///< specific total energy rate lower limit acheived when throttle is at _throttle_setpoint_min (m**2/sec**3)
 	float _throttle_setpoint_max{0.0f};				///< normalised throttle upper limit
 	float _throttle_setpoint_min{0.0f};				///< normalised throttle lower limit
 	float _throttle_trim{0.0f};					///< throttle required to fly level at _EAS_setpoint, compensated for air density and vehicle weight

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -219,12 +219,8 @@ public:
 
 private:
 
-	// [m/s] bound on expected (safe) true airspeed tracking errors, including TAS = TAS_min - TAS_ERROR_BOUND
-	static constexpr float TAS_ERROR_BOUND = 2.0f;
-
-	// [m/s] true airspeed soft boundary region below the accepted TAS error region (below TAS_min - TAS_ERROR_BOUND)
-	// underspeed mitigation measures are ramped in from zero to full within this region
-	static constexpr float TAS_UNDERSPEED_SOFT_BOUND = 1.5f;
+	// [0,1] percentage of true airspeed trim corresponding to expected (safe) true airspeed tracking errors
+	static constexpr float kTASErrorPercentage = 0.15;
 
 	static constexpr float _jerk_max =
 		1000.0f;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -599,6 +599,7 @@ void FixedwingAttitudeControl::Run()
 				_rates_sp.roll = _roll_ctrl.get_desired_bodyrate();
 				_rates_sp.pitch = _pitch_ctrl.get_desired_bodyrate();
 				_rates_sp.yaw = _yaw_ctrl.get_desired_bodyrate();
+				_rates_sp.yaw_via_wheel = _wheel_ctrl.get_desired_rate();
 
 				_rates_sp.timestamp = hrt_absolute_time();
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -556,6 +556,9 @@ void FixedwingAttitudeControl::Run()
 					if (wheel_control) {
 						yaw_u = _wheel_ctrl.control_bodyrate(dt, control_input);
 
+						// XXX: this is an abuse -- used to ferry manual yaw inputs from position controller during auto modes
+						yaw_u += _att_sp.yaw_sp_move_rate * _param_fw_man_y_sc.get();
+
 					} else {
 						yaw_u = _yaw_ctrl.control_euler_rate(dt, control_input, bodyrate_ff(2));
 					}

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -601,8 +601,7 @@ void FixedwingAttitudeControl::Run()
 				 */
 				_rates_sp.roll = _roll_ctrl.get_desired_bodyrate();
 				_rates_sp.pitch = _pitch_ctrl.get_desired_bodyrate();
-				_rates_sp.yaw = _yaw_ctrl.get_desired_bodyrate();
-				_rates_sp.yaw_via_wheel = _wheel_ctrl.get_desired_rate();
+				_rates_sp.yaw = (wheel_control) ? _wheel_ctrl.get_desired_rate() : _yaw_ctrl.get_desired_bodyrate();
 
 				_rates_sp.timestamp = hrt_absolute_time();
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1092,15 +1092,13 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 	/* current waypoint (the one currently heading for) */
 	curr_wp = Vector2d(pos_sp_curr.lat, pos_sp_curr.lon);
 
-	if (pos_sp_prev.valid) {
+	if (pos_sp_prev.valid && pos_sp_prev.type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
 		prev_wp(0) = pos_sp_prev.lat;
 		prev_wp(1) = pos_sp_prev.lon;
 
 	} else {
-		/*
-			* No valid previous waypoint, go for the current wp.
-			* This is automatically handled by the L1 library.
-			*/
+		// No valid previous waypoint, go for the current wp.
+		// This is automatically handled by the L1/NPFG libraries.
 		prev_wp(0) = pos_sp_curr.lat;
 		prev_wp(1) = pos_sp_curr.lon;
 	}
@@ -1269,15 +1267,13 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 	/* current waypoint (the one currently heading for) */
 	curr_wp = Vector2d(pos_sp_curr.lat, pos_sp_curr.lon);
 
-	if (pos_sp_prev.valid) {
+	if (pos_sp_prev.valid && pos_sp_prev.type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
 		prev_wp(0) = pos_sp_prev.lat;
 		prev_wp(1) = pos_sp_prev.lon;
 
 	} else {
-		/*
-			* No valid previous waypoint, go for the current wp.
-			* This is automatically handled by the L1 library.
-			*/
+		// No valid previous waypoint, go for the current wp.
+		// This is automatically handled by the L1/NPFG libraries.
 		prev_wp(0) = pos_sp_curr.lat;
 		prev_wp(1) = pos_sp_curr.lon;
 	}

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -725,8 +725,9 @@ FixedwingPositionControl::updateManualTakeoffStatus()
 	if (!_completed_manual_takeoff) {
 		const bool at_controllable_airspeed = _airspeed > _param_fw_airspd_min.get()
 						      || !_airspeed_valid;
-		_completed_manual_takeoff = !_landed
-					    && at_controllable_airspeed;
+		const bool is_hovering = _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+					 && _control_mode.flag_armed;
+		_completed_manual_takeoff = (!_landed && at_controllable_airspeed) || is_hovering;
 	}
 }
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1518,10 +1518,10 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 				/* Perform launch detection */
 
 				/* Inform user that launchdetection is running every 4s */
-				if ((now - _launch_detection_notify) > 4_s) {
+				if ((now - _last_time_launch_detection_notified) > 4_s) {
 					mavlink_log_critical(&_mavlink_log_pub, "Launch detection running\t");
 					events::send(events::ID("fixedwing_position_control_launch_detection"), events::Log::Info, "Launch detection running");
-					_launch_detection_notify = now;
+					_last_time_launch_detection_notified = now;
 				}
 
 				/* Detect launch using body X (forward) acceleration */
@@ -2465,7 +2465,7 @@ FixedwingPositionControl::reset_takeoff_state()
 
 	_launchDetector.reset();
 	_launch_detection_state = LAUNCHDETECTION_RES_NONE;
-	_launch_detection_notify = 0;
+	_last_time_launch_detection_notified = 0;
 
 	_launch_detected = false;
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -738,8 +738,7 @@ FixedwingPositionControl::updateManualTakeoffStatus()
 		const bool at_controllable_airspeed = _airspeed > _param_fw_airspd_min.get()
 						      || !_airspeed_valid;
 		_completed_manual_takeoff = !_landed
-					    && at_controllable_airspeed
-					    && !_vehicle_status.is_vtol;
+					    && at_controllable_airspeed;
 	}
 }
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1424,6 +1424,11 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		// yaw control is disabled once in "taking off" state
 		_att_sp.fw_control_yaw = _runway_takeoff.controlYaw();
 
+		// XXX: hacky way to pass through manual nose-wheel incrementing. need to clean this interface.
+		if (_param_rwto_nudge.get()) {
+			_att_sp.yaw_sp_move_rate = _manual_control_setpoint.r;
+		}
+
 		// tune up the lateral position control guidance when on the ground
 		if (_att_sp.fw_control_yaw) {
 			_npfg.setPeriod(_param_rwto_l1_period.get());
@@ -2358,6 +2363,9 @@ FixedwingPositionControl::Run()
 
 		// by default we don't want yaw to be contoller directly with rudder
 		_att_sp.fw_control_yaw = false;
+
+		// default to zero - is used (IN A HACKY WAY) to pass direct nose wheel steering via yaw stick to the actuators during auto takeoff
+		_att_sp.yaw_sp_move_rate = 0.0f;
 
 		if (_control_mode_current != FW_POSCTRL_MODE_AUTO_LANDING) {
 			reset_landing_state();

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1373,7 +1373,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 	// set the altitude to something above the clearance altitude to ensure the vehicle climbs past the value
 	// (navigator will accept the takeoff as complete once crossing the clearance altitude)
-	const float altitude_setpoint_amsl = clearance_altitude_amsl + _param_nav_fw_alt_rad.get();
+	const float altitude_setpoint_amsl = clearance_altitude_amsl + kClearanceAltitudeBuffer;
 
 	Vector2f local_2D_position{_local_pos.x, _local_pos.y};
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1412,6 +1412,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		_launch_detection_notify = 0;
 	}
 
+	float terrain_alt = _takeoff_ground_alt;
+
 	if (_runway_takeoff.runwayTakeoffEnabled()) {
 		if (!_runway_takeoff.isInitialized()) {
 			_runway_takeoff.init(now, _yaw, _current_latitude, _current_longitude);
@@ -1428,7 +1430,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_runway_takeoff.forceSetFlyState();
 		}
 
-		float terrain_alt = get_terrain_altitude_takeoff(_takeoff_ground_alt);
+		terrain_alt = get_terrain_altitude_takeoff(_takeoff_ground_alt);
 
 		// update runway takeoff helper
 		_runway_takeoff.update(now, _airspeed, _current_altitude - terrain_alt,
@@ -1561,9 +1563,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 							   true,
 							   radians(_takeoff_pitch_min.get()));
 
-				/* limit roll motion to ensure enough lift */
-				_att_sp.roll_body = constrain(_att_sp.roll_body, radians(-15.0f), radians(15.0f));
-
 			} else {
 				tecs_update_pitch_throttle(control_interval,
 							   pos_sp_curr.alt,
@@ -1613,6 +1612,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 	if (!(_launch_detection_state == LAUNCHDETECTION_RES_NONE || _runway_takeoff.runwayTakeoffEnabled())) {
 		_att_sp.pitch_body = get_tecs_pitch();
 	}
+
+	_att_sp.roll_body = constrainRollNearGround(_att_sp.roll_body, _current_altitude, terrain_alt);
 
 	if (!_vehicle_status.in_transition_to_fw) {
 		publishLocalPositionSetpoint(pos_sp_curr);
@@ -1821,11 +1822,6 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 			_att_sp.roll_body = _l1_control.get_roll_setpoint();
 		}
 
-		if (_land_noreturn_horizontal) {
-			/* limit roll motion to prevent wings from touching the ground first */
-			_att_sp.roll_body = constrain(_att_sp.roll_body, radians(-10.0f), radians(10.0f));
-		}
-
 		/* enable direct yaw control using rudder/wheel */
 		if (_land_noreturn_horizontal) {
 			_att_sp.yaw_body = _target_bearing;
@@ -1953,6 +1949,8 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 	/* Copy thrust and pitch values from tecs */
 	// when we are landed state we want the motor to spin at idle speed
 	_att_sp.thrust_body[0] = (_landed) ? min(_param_fw_thr_idle.get(), 1.f) : get_tecs_thrust();
+
+	_att_sp.roll_body = constrainRollNearGround(_att_sp.roll_body, _current_altitude, terrain_alt);
 
 	// Apply flaps and spoilers for landing. Amount of deflection is handled in the FW attitdue controller
 	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_LAND;
@@ -2607,6 +2605,23 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 				    hgt_rate_sp);
 
 	tecs_status_publish();
+}
+
+float
+FixedwingPositionControl::constrainRollNearGround(const float roll_setpoint, const float altitude,
+		const float terrain_altitude) const
+{
+	// we want the wings level when at the wing height above ground
+	const float height_above_ground = math::max(altitude - (terrain_altitude + _param_fw_wing_height.get()), 0.0f);
+
+	// this is a conservative (linear) approximation of the roll angle that would cause wing tip strike
+	// roll strike = arcsin( 2 * height / span )
+	// d(roll strike)/d(height) = 2 / span / cos(2 * height / span)
+	// d(roll strike)/d(height) (@height=0) = 2 / span
+	// roll strike ~= 2 * height / span
+	const float roll_wingtip_strike = 2.0f * height_above_ground / _param_fw_wing_span.get();
+
+	return math::constrain(roll_setpoint, -roll_wingtip_strike, roll_wingtip_strike);
 }
 
 void FixedwingPositionControl::publishLocalPositionSetpoint(const position_setpoint_s &current_waypoint)

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -752,7 +752,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 		return; // do not publish the setpoint
 	}
 
-	FW_POSCTRL_MODE last_position_control_mode = _control_mode_current;
+	FW_POSCTRL_MODE commanded_position_control_mode = _control_mode_current;
 
 	_skipping_takeoff_detection = false;
 
@@ -770,7 +770,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 			} else {
 				_control_mode_current = FW_POSCTRL_MODE_AUTO_TAKEOFF;
 
-				if (last_position_control_mode != FW_POSCTRL_MODE_AUTO_TAKEOFF && !_landed) {
+				if (commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_TAKEOFF && !_landed) {
 					// skip takeoff detection when switching from any other mode, auto or manual,
 					// while already in air.
 					// TODO: find a better place for / way of doing this
@@ -796,14 +796,14 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 		   && pos_sp_curr_valid) {
 
 		// reset timer the first time we switch into this mode
-		if (last_position_control_mode != FW_POSCTRL_MODE_AUTO_ALTITUDE
-		    && last_position_control_mode != FW_POSCTRL_MODE_AUTO_CLIMBRATE) {
+		if (commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_ALTITUDE
+		    && commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_CLIMBRATE) {
 			_time_in_fixed_bank_loiter = now;
 		}
 
 		if (hrt_elapsed_time(&_time_in_fixed_bank_loiter) < (_param_nav_gpsf_lt.get() * 1_s)
 		    && !_vehicle_status.in_transition_mode) {
-			if (last_position_control_mode != FW_POSCTRL_MODE_AUTO_ALTITUDE) {
+			if (commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_ALTITUDE) {
 				// Need to init because last loop iteration was in a different mode
 				mavlink_log_critical(&_mavlink_log_pub, "Start loiter with fixed bank angle.\t");
 				events::send(events::ID("fixedwing_position_control_fb_loiter"), events::Log::Critical,
@@ -813,7 +813,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 			_control_mode_current = FW_POSCTRL_MODE_AUTO_ALTITUDE;
 
 		} else {
-			if (last_position_control_mode != FW_POSCTRL_MODE_AUTO_CLIMBRATE && !_vehicle_status.in_transition_mode) {
+			if (commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_CLIMBRATE && !_vehicle_status.in_transition_mode) {
 				mavlink_log_critical(&_mavlink_log_pub, "Start descending.\t");
 				events::send(events::ID("fixedwing_position_control_descend"), events::Log::Critical, "Start descending");
 			}
@@ -823,7 +823,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 
 
 	} else if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_position_enabled) {
-		if (last_position_control_mode != FW_POSCTRL_MODE_MANUAL_POSITION) {
+		if (commanded_position_control_mode != FW_POSCTRL_MODE_MANUAL_POSITION) {
 			/* Need to init because last loop iteration was in a different mode */
 			_hdg_hold_yaw = _yaw; // yaw is not controlled, so set setpoint to current yaw
 			_hdg_hold_enabled = false; // this makes sure the waypoints are reset below

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -272,8 +272,7 @@ private:
 
 	RunwayTakeoff _runway_takeoff;
 
-	// true if the last iteration was in manual mode (used to determine when a reset is needed)
-	bool _last_manual{false};
+	bool _skipping_takeoff_detection{false};
 
 	/* throttle and airspeed states */
 
@@ -578,7 +577,7 @@ private:
 	float get_auto_airspeed_setpoint(const float control_interval, const float pos_sp_cru_airspeed,
 					 const Vector2f &ground_speed);
 
-	void reset_takeoff_state(bool force = false);
+	void reset_takeoff_state();
 	void reset_landing_state();
 
 	bool using_npfg_with_wind_estimate() const;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -216,6 +216,12 @@ private:
 	// [m] ground altitude where the plane was launched
 	float _takeoff_ground_alt{0.0f};
 
+	// true if a launch, specifically using the launch detector, has been detected
+	bool _launch_detected{false};
+
+	// [deg] global position of the vehicle at the time launch is detected (using launch detector)
+	Vector2d _launch_global_position{0, 0};
+
 	// [rad] yaw setpoint for manual position mode heading hold
 	float _hdg_hold_yaw{0.0f};
 
@@ -525,13 +531,12 @@ private:
 	 *
 	 * @param now Current system time [us]
 	 * @param control_interval Time since last position control call [s]
-	 * @param curr_pos Current 2D local position vector of vehicle [m]
+	 * @param global_position Vechile global position [deg]
 	 * @param ground_speed Local 2D ground speed of vehicle [m/s]
-	 * @param pos_sp_prev previous position setpoint
 	 * @param pos_sp_curr current position setpoint
 	 */
-	void control_auto_takeoff(const hrt_abstime &now, const float control_interval, const Vector2d &curr_pos,
-				  const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr);
+	void control_auto_takeoff(const hrt_abstime &now, const float control_interval, const Vector2d &global_position,
+				  const Vector2f &ground_speed, const position_setpoint_s &pos_sp_curr);
 
 	/**
 	 * @brief Controls automatic landing.
@@ -656,6 +661,15 @@ private:
 	 */
 	float constrainRollNearGround(const float roll_setpoint, const float altitude, const float terrain_altitude) const;
 
+	/**
+	 * @brief Calculates the unit takeoff bearing vector from the launch position to takeoff waypont.
+	 *
+	 * @param launch_position Vehicle launch position in local coordinates (NE) [m]
+	 * @param takeoff_waypoint Takeoff waypoint position in local coordinates (NE) [m]
+	 * @return Unit takeoff bearing vector
+	 */
+	Vector2f calculateTakeoffBearingVector(const Vector2f &launch_position, const Vector2f &takeoff_waypoint) const;
+
 	DEFINE_PARAMETERS(
 
 		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
@@ -749,7 +763,9 @@ private:
 		(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
 
 		(ParamFloat<px4::params::FW_WING_SPAN>) _param_fw_wing_span,
-		(ParamFloat<px4::params::FW_WING_HEIGHT>) _param_fw_wing_height
+		(ParamFloat<px4::params::FW_WING_HEIGHT>) _param_fw_wing_height,
+
+		(ParamFloat<px4::params::RWTO_L1_PERIOD>) _param_rwto_l1_period
 	)
 
 };

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -765,7 +765,8 @@ private:
 		(ParamFloat<px4::params::FW_WING_SPAN>) _param_fw_wing_span,
 		(ParamFloat<px4::params::FW_WING_HEIGHT>) _param_fw_wing_height,
 
-		(ParamFloat<px4::params::RWTO_L1_PERIOD>) _param_rwto_l1_period
+		(ParamFloat<px4::params::RWTO_L1_PERIOD>) _param_rwto_l1_period,
+		(ParamBool<px4::params::RWTO_NUDGE>) _param_rwto_nudge
 	)
 
 };

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -148,6 +148,10 @@ static constexpr float AIR_DENSITY_STANDARD_ATMOS_5000_AMSL = 0.7363f;
 // [rad] minimum pitch while airspeed has not yet reached a controllable value in manual position controlled takeoff modes
 static constexpr float MIN_PITCH_DURING_MANUAL_TAKEOFF = 0.0f;
 
+// [m] arbitrary buffer altitude added to clearance altitude setpoint during takeoff to ensure aircraft passes the clearance
+// altitude while waiting for navigator to flag it exceeded
+static constexpr float kClearanceAltitudeBuffer = 10.0f;
+
 class FixedwingPositionControl final : public ModuleBase<FixedwingPositionControl>, public ModuleParams,
 	public px4::WorkItem
 {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -145,6 +145,9 @@ static constexpr float MAX_WEIGHT_RATIO = 2.0f;
 // air density of standard athmosphere at 5000m above mean sea level [kg/m^3]
 static constexpr float AIR_DENSITY_STANDARD_ATMOS_5000_AMSL = 0.7363f;
 
+// [rad] minimum pitch while airspeed has not yet reached a controllable value in manual position controlled takeoff modes
+static constexpr float MIN_PITCH_DURING_MANUAL_TAKEOFF = 0.0f;
+
 class FixedwingPositionControl final : public ModuleBase<FixedwingPositionControl>, public ModuleParams,
 	public px4::WorkItem
 {
@@ -264,6 +267,9 @@ private:
 
 	// [us] time at which the plane went in the air
 	hrt_abstime _time_went_in_air{0};
+
+	// indicates whether we have completed a manual takeoff in a position control mode
+	bool _completed_manual_takeoff{false};
 
 	// Takeoff launch detection and runway
 	LaunchDetector _launchDetector;
@@ -409,9 +415,11 @@ private:
 	float getManualHeightRateSetpoint();
 
 	/**
-	 * @brief Check if we are in a takeoff situation
+	 * @brief Updates a state indicating whether a manual takeoff has been completed.
+	 *
+	 * Criteria include passing an airspeed threshold and not being in a landed state. VTOL airframes always pass.
 	 */
-	bool in_takeoff_situation();
+	void updateManualTakeoffStatus();
 
 	/**
 	 * @brief Update desired altitude base on user pitch stick input

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -302,7 +302,7 @@ private:
 	matrix::Vector3f _body_velocity{};
 
 	bool _reinitialize_tecs{true};
-	bool _is_tecs_running{false};
+	bool _tecs_is_running{false};
 
 	hrt_abstime _time_last_tecs_update{0}; // [us]
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -646,6 +646,16 @@ private:
 					bool climbout_mode, float climbout_pitch_min_rad,
 					bool disable_underspeed_detection = false, float hgt_rate_sp = NAN);
 
+	/**
+	 * @brief Constrains the roll angle setpoint near ground to avoid wingtip strike.
+	 *
+	 * @param roll_setpoint Unconstrained roll angle setpoint [rad]
+	 * @param altitude Vehicle altitude (AMSL) [m]
+	 * @param terrain_altitude Terrain altitude (AMSL) [m]
+	 * @return Constrained roll angle setpoint [rad]
+	 */
+	float constrainRollNearGround(const float roll_setpoint, const float altitude, const float terrain_altitude) const;
+
 	DEFINE_PARAMETERS(
 
 		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
@@ -736,8 +746,10 @@ private:
 		(ParamFloat<px4::params::NAV_FW_ALT_RAD>) _param_nav_fw_alt_rad,
 
 		(ParamFloat<px4::params::WEIGHT_BASE>) _param_weight_base,
-		(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross
+		(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
 
+		(ParamFloat<px4::params::FW_WING_SPAN>) _param_fw_wing_span,
+		(ParamFloat<px4::params::FW_WING_HEIGHT>) _param_fw_wing_height
 	)
 
 };

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -276,7 +276,7 @@ private:
 
 	// AUTO TAKEOFF
 
-	// [m] ground altitude where the plane was launched
+	// [m] ground altitude AMSL where the plane was launched
 	float _takeoff_ground_alt{0.0f};
 
 	// class handling launch detection methods for fixed-wing takeoff

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -1007,3 +1007,32 @@ PARAM_DEFINE_FLOAT(WEIGHT_BASE, -1.0f);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(WEIGHT_GROSS, -1.0f);
+
+/**
+ * The aircraft's wing span (length from tip to tip).
+ *
+ * This is used for limiting the roll setpoint near the ground. (if multiple wings, take the longest span)
+ *
+ * @unit m
+ * @min 1.0
+ * @max 15.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW Geometry
+ */
+PARAM_DEFINE_FLOAT(FW_WING_SPAN, 6.0);
+
+/**
+ * Height (AGL) of the wings when the aircraft is on the ground.
+ *
+ * This is used to constrain a minimum altitude below which we keep wings level to avoid wing tip strike. It's prudent
+ * to give a slight margin here (> 0m)
+ *
+ * @unit m
+ * @min 0.0
+ * @max 5.0
+ * @decimal 1
+ * @increment 1
+ * @group FW Geometry
+ */
+PARAM_DEFINE_FLOAT(FW_WING_HEIGHT, 0.5);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -1014,23 +1014,21 @@ PARAM_DEFINE_FLOAT(WEIGHT_GROSS, -1.0f);
  * This is used for limiting the roll setpoint near the ground. (if multiple wings, take the longest span)
  *
  * @unit m
- * @min 1.0
- * @max 15.0
+ * @min 0.1
  * @decimal 1
  * @increment 0.1
  * @group FW Geometry
  */
-PARAM_DEFINE_FLOAT(FW_WING_SPAN, 6.0);
+PARAM_DEFINE_FLOAT(FW_WING_SPAN, 3.0);
 
 /**
  * Height (AGL) of the wings when the aircraft is on the ground.
  *
- * This is used to constrain a minimum altitude below which we keep wings level to avoid wing tip strike. It's prudent
+ * This is used to constrain a minimum altitude below which we keep wings level to avoid wing tip strike. It's safer
  * to give a slight margin here (> 0m)
  *
  * @unit m
  * @min 0.0
- * @max 5.0
  * @decimal 1
  * @increment 1
  * @group FW Geometry

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
@@ -52,75 +52,45 @@ using namespace time_literals;
 namespace runwaytakeoff
 {
 
-RunwayTakeoff::RunwayTakeoff(ModuleParams *parent) :
-	ModuleParams(parent),
-	_state(),
-	_initialized(false),
-	_initialized_time(0),
-	_init_yaw(0),
-	_climbout(false)
+void RunwayTakeoff::init(const hrt_abstime &time_now, const float initial_yaw, const matrix::Vector2d &start_pos_global)
 {
+	initial_yaw_ = initial_yaw;
+	start_pos_global_ = start_pos_global;
+	takeoff_state_ = RunwayTakeoffState::THROTTLE_RAMP;
+	climbout_ = true; // this is true until climbout is finished
+	initialized_ = true;
+	time_initialized_ = time_now;
+	takeoff_time_ = 0;
 }
 
-void RunwayTakeoff::init(const hrt_abstime &now, float yaw, double current_lat, double current_lon)
+void RunwayTakeoff::update(const hrt_abstime &time_now, const float calibrated_airspeed, const float vehicle_altitude,
+			   const float clearance_altitude, orb_advert_t *mavlink_log_pub)
 {
-	_init_yaw = yaw;
-	_initialized = true;
-	_state = RunwayTakeoffState::THROTTLE_RAMP;
-	_initialized_time = now;
-	_climbout = true; // this is true until climbout is finished
-	_start_wp(0) = current_lat;
-	_start_wp(1) = current_lon;
-}
-
-void RunwayTakeoff::update(const hrt_abstime &now, float airspeed, float alt_agl,
-			   double current_lat, double current_lon, orb_advert_t *mavlink_log_pub)
-{
-	switch (_state) {
+	switch (takeoff_state_) {
 	case RunwayTakeoffState::THROTTLE_RAMP:
-		if (((now - _initialized_time) > (_param_rwto_ramp_time.get() * 1_s))
-		    || (airspeed > (_param_fw_airspd_min.get() * _param_rwto_airspd_scl.get() * 0.9f))) {
-
-			_state = RunwayTakeoffState::CLAMPED_TO_RUNWAY;
+		if ((time_now - time_initialized_) > (param_rwto_ramp_time_.get() * 1_s)) {
+			takeoff_state_ = RunwayTakeoffState::CLAMPED_TO_RUNWAY;
 		}
 
 		break;
 
 	case RunwayTakeoffState::CLAMPED_TO_RUNWAY:
-		if (airspeed > _param_fw_airspd_min.get() * _param_rwto_airspd_scl.get()) {
-			_state = RunwayTakeoffState::TAKEOFF;
-			mavlink_log_info(mavlink_log_pub, "#Takeoff airspeed reached\t");
+		if (calibrated_airspeed > param_fw_airspd_min_.get() * param_rwto_airspd_scl_.get()) {
+			takeoff_time_ = time_now;
+			takeoff_state_ = RunwayTakeoffState::CLIMBOUT;
+			mavlink_log_info(mavlink_log_pub, "Takeoff airspeed reached, climbout\t");
 			events::send(events::ID("runway_takeoff_reached_airspeed"), events::Log::Info,
-				     "Takeoff airspeed reached");
-		}
-
-		break;
-
-	case RunwayTakeoffState::TAKEOFF:
-		if (alt_agl > _param_rwto_nav_alt.get()) {
-			_state = RunwayTakeoffState::CLIMBOUT;
-
-			/*
-			 * If we started in heading hold mode, move the navigation start WP to the current location now.
-			 * The navigator will take this as starting point to navigate towards the takeoff WP.
-			 */
-			if (_param_rwto_hdg.get() == 0) {
-				_start_wp(0) = current_lat;
-				_start_wp(1) = current_lon;
-			}
-
-			mavlink_log_info(mavlink_log_pub, "#Climbout\t");
-			events::send(events::ID("runway_takeoff_climbout"), events::Log::Info, "Climbout");
+				     "Takeoff airspeed reached, climbout");
 		}
 
 		break;
 
 	case RunwayTakeoffState::CLIMBOUT:
-		if (alt_agl > _param_fw_clmbout_diff.get()) {
-			_climbout = false;
-			_state = RunwayTakeoffState::FLY;
-			mavlink_log_info(mavlink_log_pub, "#Navigating to waypoint\t");
-			events::send(events::ID("runway_takeoff_nav_to_wp"), events::Log::Info, "Navigating to waypoint");
+		if (vehicle_altitude > clearance_altitude) {
+			climbout_ = false;
+			takeoff_state_ = RunwayTakeoffState::FLY;
+			mavlink_log_info(mavlink_log_pub, "Reached clearance altitude\t");
+			events::send(events::ID("runway_takeoff_reached_clearance_altitude"), events::Log::Info, "Reached clearance altitude");
 		}
 
 		break;
@@ -130,132 +100,96 @@ void RunwayTakeoff::update(const hrt_abstime &now, float airspeed, float alt_agl
 	}
 }
 
-/*
- * Returns true as long as we're below navigation altitude
- */
 bool RunwayTakeoff::controlYaw()
 {
 	// keep controlling yaw directly until we start navigation
-	return _state < RunwayTakeoffState::CLIMBOUT;
+	return takeoff_state_ < RunwayTakeoffState::CLIMBOUT;
 }
 
-/*
- * Returns pitch setpoint to use.
- *
- * Limited (parameter) as long as the plane is on runway. Otherwise
- * use the one from TECS
- */
-float RunwayTakeoff::getPitch(float tecsPitch)
+float RunwayTakeoff::getPitch(float external_pitch_setpoint)
 {
-	if (_state <= RunwayTakeoffState::CLAMPED_TO_RUNWAY) {
-		return math::radians(_param_rwto_psp.get());
+	if (takeoff_state_ <= RunwayTakeoffState::CLAMPED_TO_RUNWAY) {
+		return math::radians(param_rwto_psp_.get());
 	}
 
-	return tecsPitch;
+	return external_pitch_setpoint;
 }
 
-/*
- * Returns the roll setpoint to use.
- */
-float RunwayTakeoff::getRoll(float navigatorRoll)
+float RunwayTakeoff::getRoll(float external_roll_setpoint)
 {
 	// until we have enough ground clearance, set roll to 0
-	if (_state < RunwayTakeoffState::CLIMBOUT) {
+	if (takeoff_state_ < RunwayTakeoffState::CLIMBOUT) {
 		return 0.0f;
 	}
 
-	// allow some roll during climbout
-	else if (_state < RunwayTakeoffState::FLY) {
-		return math::constrain(navigatorRoll,
-				       math::radians(-_param_rwto_max_roll.get()),
-				       math::radians(_param_rwto_max_roll.get()));
-	}
-
-	return navigatorRoll;
+	return external_roll_setpoint;
 }
 
-/*
- * Returns the yaw setpoint to use.
- *
- * In heading hold mode (_heading_mode == 0), it returns initial yaw as long as it's on the
- * runway. When it has enough ground clearance we start navigation towards WP.
- */
-float RunwayTakeoff::getYaw(float navigatorYaw)
+float RunwayTakeoff::getYaw(float external_yaw_setpoint)
 {
-	if (_param_rwto_hdg.get() == 0 && _state < RunwayTakeoffState::CLIMBOUT) {
-		return _init_yaw;
+	if (param_rwto_hdg_.get() == 0 && takeoff_state_ < RunwayTakeoffState::CLIMBOUT) {
+		return initial_yaw_;
 
 	} else {
-		return navigatorYaw;
+		return external_yaw_setpoint;
 	}
 }
 
-/*
- * Returns the throttle setpoint to use.
- *
- * Ramps up in the beginning, until it lifts off the runway it is set to
- * parameter value, then it returns the TECS throttle.
- */
-float RunwayTakeoff::getThrottle(const hrt_abstime &now, float tecsThrottle)
+float RunwayTakeoff::getThrottle(const hrt_abstime &time_now, float external_throttle_setpoint)
 {
-	switch (_state) {
-	case RunwayTakeoffState::THROTTLE_RAMP: {
-			float throttle = ((now - _initialized_time) / (_param_rwto_ramp_time.get() * 1_s)) * _param_rwto_max_thr.get();
-			return math::min(throttle, _param_rwto_max_thr.get());
-		}
+	float throttle = 0.0f;
+
+	switch (takeoff_state_) {
+	case RunwayTakeoffState::THROTTLE_RAMP:
+		throttle = ((time_now - time_initialized_) / (param_rwto_ramp_time_.get() * 1_s)) * param_rwto_max_thr_.get();
+		throttle = math::constrain(throttle, 0.0f, param_rwto_max_thr_.get());
+		break;
 
 	case RunwayTakeoffState::CLAMPED_TO_RUNWAY:
-		return _param_rwto_max_thr.get();
+		throttle = param_rwto_max_thr_.get();
+		break;
 
 	default:
-		return tecsThrottle;
+		const float interpolator = math::constrain((time_now - takeoff_time_ * 1_s) / (kThrottleHysteresisTime * 1_s), 0.0f,
+					   1.0f);
+		throttle = external_throttle_setpoint * interpolator + (1.0f - interpolator) * param_rwto_max_thr_.get();
 	}
+
+	return throttle;
 }
 
 bool RunwayTakeoff::resetIntegrators()
 {
 	// reset integrators if we're still on runway
-	return _state < RunwayTakeoffState::TAKEOFF;
+	return takeoff_state_ < RunwayTakeoffState::CLIMBOUT;
 }
 
-/*
- * Returns the minimum pitch for TECS to use.
- *
- * In climbout we either want what was set on the waypoint (sp_min) but at least
- * the climbtout minimum pitch (parameter).
- * Otherwise use the minimum that is enforced generally (parameter).
- */
-float RunwayTakeoff::getMinPitch(float climbout_min, float min)
+float RunwayTakeoff::getMinPitch(float min_pitch_in_climbout, float min_pitch)
 {
-	if (_state < RunwayTakeoffState::FLY) {
-		return climbout_min;
+	if (takeoff_state_ < RunwayTakeoffState::FLY) {
+		return min_pitch_in_climbout;
 
 	} else {
-		return min;
+		return min_pitch;
 	}
 }
 
-/*
- * Returns the maximum pitch for TECS to use.
- *
- * Limited by parameter (if set) until climbout is done.
- */
-float RunwayTakeoff::getMaxPitch(float max)
+float RunwayTakeoff::getMaxPitch(const float max_pitch)
 {
-	// use max pitch from parameter if set (> 0.1)
-	if (_state < RunwayTakeoffState::FLY && _param_rwto_max_pitch.get() > 0.1f) {
-		return _param_rwto_max_pitch.get();
-	}
+	// use max pitch from parameter if set
+	if (takeoff_state_ < RunwayTakeoffState::FLY && param_rwto_max_pitch_.get() > kMinMaxPitch) {
+		return param_rwto_max_pitch_.get();
 
-	else {
-		return max;
+	} else {
+		return max_pitch;
 	}
 }
 
 void RunwayTakeoff::reset()
 {
-	_initialized = false;
-	_state = RunwayTakeoffState::THROTTLE_RAMP;
+	initialized_ = false;
+	takeoff_state_ = RunwayTakeoffState::THROTTLE_RAMP;
+	takeoff_time_ = 0;
 }
 
-}
+} // namespace runwaytakeoff

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -90,6 +90,9 @@ public:
 	float getMaxPitch(float max);
 	const matrix::Vector2d &getStartWP() const { return _start_wp; };
 
+	// NOTE: this is only to be used for mistaken mode transitions to takeoff while already in air
+	void forceSetFlyState() { _state = RunwayTakeoffState::FLY; }
+
 	void reset();
 
 private:

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -55,71 +55,204 @@ namespace runwaytakeoff
 {
 
 enum RunwayTakeoffState {
-	THROTTLE_RAMP = 0, /**< ramping up throttle */
-	CLAMPED_TO_RUNWAY = 1, /**< clamped to runway, controlling yaw directly (wheel or rudder) */
-	TAKEOFF = 2, /**< taking off, get ground clearance, roll 0 */
-	CLIMBOUT = 3, /**< climbout to safe height before navigation, roll limited */
-	FLY = 4 /**< fly towards takeoff waypoint */
+	THROTTLE_RAMP = 0, // ramping up throttle
+	CLAMPED_TO_RUNWAY, // clamped to runway, controlling yaw directly (wheel or rudder)
+	CLIMBOUT, // climbout to safe height before navigation
+	FLY // navigate freely
 };
 
 class __EXPORT RunwayTakeoff : public ModuleParams
 {
 public:
-	RunwayTakeoff(ModuleParams *parent);
+	RunwayTakeoff(ModuleParams *parent) : ModuleParams(parent) {}
 	~RunwayTakeoff() = default;
 
-	void init(const hrt_abstime &now, float yaw, double current_lat, double current_lon);
-	void update(const hrt_abstime &now, float airspeed, float alt_agl, double current_lat, double current_lon,
-		    orb_advert_t *mavlink_log_pub);
+	/**
+	 * @brief Initializes the state machine.
+	 *
+	 * @param time_now Absolute time since system boot [us]
+	 * @param initial_yaw Vehicle yaw angle at time of initialization [us]
+	 * @param start_pos_global Vehicle global (lat, lon) position at time of initialization [deg]
+	 */
+	void init(const hrt_abstime &time_now, const float initial_yaw, const matrix::Vector2d &start_pos_global);
 
-	RunwayTakeoffState getState() { return _state; }
-	bool isInitialized() { return _initialized; }
+	/**
+	 * @brief Updates the state machine based on the current vehicle condition.
+	 *
+	 * @param time_now Absolute time since system boot [us]
+	 * @param calibrated_airspeed Vehicle calibrated airspeed [m/s]
+	 * @param vehicle_altitude Vehicle altitude (AGL) [m]
+	 * @param clearance_altitude Altitude (AGL) above which we have cleared all occlusions in the runway path [m]
+	 * @param mavlink_log_pub
+	 */
+	void update(const hrt_abstime &time_now, const float calibrated_airspeed, const float vehicle_altitude,
+		    const float clearance_altitude, orb_advert_t *mavlink_log_pub);
 
-	bool runwayTakeoffEnabled() { return _param_rwto_tkoff.get(); }
-	float getMinAirspeedScaling() { return _param_rwto_airspd_scl.get(); }
-	float getInitYaw() { return _init_yaw; }
+	/**
+	 * @return Current takeoff state
+	 */
+	RunwayTakeoffState getState() { return takeoff_state_; }
 
+	/**
+	 * @return The state machine is initialized
+	 */
+	bool isInitialized() { return initialized_; }
+
+	/**
+	 * @return Runway takeoff is enabled
+	 */
+	bool runwayTakeoffEnabled() { return param_rwto_tkoff_.get(); }
+
+	/**
+	 * @return Scale factor for minimum indicated airspeed
+	 */
+	float getMinAirspeedScaling() { return param_rwto_airspd_scl_.get(); }
+
+	/**
+	 * @return Initial vehicle yaw angle [rad]
+	 */
+	float getInitYaw() { return initial_yaw_; }
+
+	/**
+	 * @return The vehicle should control yaw via rudder or nose gear
+	 */
 	bool controlYaw();
-	bool climbout() { return _climbout; }
-	float getPitch(float tecsPitch);
-	float getRoll(float navigatorRoll);
-	float getYaw(float navigatorYaw);
-	float getThrottle(const hrt_abstime &now, float tecsThrottle);
-	bool resetIntegrators();
-	float getMinPitch(float climbout_min, float min);
-	float getMaxPitch(float max);
-	const matrix::Vector2d &getStartWP() const { return _start_wp; };
+
+	/**
+	 * @return TECS should be commanded to climbout mode
+	 */
+	bool climbout() { return climbout_; }
+
+	/**
+	 * @param external_pitch_setpoint Externally commanded pitch angle setpoint (usually from TECS) [rad]
+	 * @return Pitch angle setpoint (limited while plane is on runway) [rad]
+	 */
+	float getPitch(float external_pitch_setpoint);
+
+	/**
+	 * @param external_roll_setpoint Externally commanded roll angle setpoint (usually from L1) [rad]
+	 * @return Roll angle setpoint [rad]
+	 */
+	float getRoll(float external_roll_setpoint);
+
+	/**
+	 * @brief Returns the appropriate yaw angle setpoint.
+	 *
+	 * In heading hold mode (_heading_mode == 0), it returns initial yaw as long as it's on the runway.
+	 * When it has enough ground clearance we start navigation towards WP.
+	 *
+	 * @param external_yaw_setpoint Externally commanded yaw angle setpoint [rad]
+	 * @return Yaw angle setpoint [rad]
+	 */
+	float getYaw(float external_yaw_setpoint);
+
+	/**
+	 * @brief Returns the throttle setpoint.
+	 *
+	 * Ramps up over RWTO_RAMP_TIME to RWTO_MAX_THR until the aircraft lifts off the runway, then passes
+	 * through the externally defined throttle setting.
+	 *
+	 * @param time_now Absolute time since system boot [us]
+	 * @param external_throttle_setpoint Externally commanded throttle setpoint (usually from TECS), normalized [0,1]
+	 * @return Throttle setpoint, normalized [0,1]
+	 */
+	float getThrottle(const hrt_abstime &time_now, const float external_throttle_setpoint);
+
+	/**
+	 * @param min_pitch_in_climbout Minimum pitch angle during climbout [rad]
+	 * @param min_pitch Externally commanded minimum pitch angle [rad]
+	 * @return Minimum pitch angle [rad]
+	 */
+	float getMinPitch(const float min_pitch_in_climbout, const float min_pitch);
+
+	/**
+	 * @param max_pitch Externally commanded maximum pitch angle [rad]
+	 * @return Maximum pitch angle [rad]
+	 */
+	float getMaxPitch(const float max_pitch);
+
+	/**
+	 * @return Runway takeoff starting position in global frame (lat, lon) [deg]
+	 */
+	const matrix::Vector2d &getStartPosition() const { return start_pos_global_; };
 
 	// NOTE: this is only to be used for mistaken mode transitions to takeoff while already in air
-	void forceSetFlyState() { _state = RunwayTakeoffState::FLY; }
+	void forceSetFlyState() { takeoff_state_ = RunwayTakeoffState::FLY; }
 
+	/**
+	 * @return If the attitude / rate control integrators should be continually reset.
+	 * This is the case during ground roll.
+	 */
+	bool resetIntegrators();
+
+	/**
+	 * @brief Reset the state machine.
+	 */
 	void reset();
 
 private:
-	/** state variables **/
-	RunwayTakeoffState _state{THROTTLE_RAMP};
-	bool _initialized{false};
-	hrt_abstime _initialized_time{0};
-	float _init_yaw{0.f};
-	bool _climbout{false};
-	matrix::Vector2d _start_wp;
+	/**
+	 * Minimum allowed maximum pitch constraint (from parameter) for runway takeoff. [rad]
+	 */
+	static constexpr float kMinMaxPitch = 0.1f;
+
+	/**
+	 * Time from takeoff during which the takeoff throttle is transitioned to the externally commanded throttle.
+	 * Used to avoid throttle jumps immediately on lift off when switching from the constant, parameterized, takeoff
+	 * throttle to the airspeed/altitude controller's commanded throttle [s]
+	 */
+	static constexpr float kThrottleHysteresisTime = 2.0f;
+
+	/**
+	 * Current state of runway takeoff procedure
+	 */
+	RunwayTakeoffState takeoff_state_{THROTTLE_RAMP};
+
+	/**
+	 * True if the runway state machine is initialized
+	 */
+	bool initialized_{false};
+
+	/**
+	 * The absolute time since system boot at which the state machine was intialized [us]
+	 */
+	hrt_abstime time_initialized_{0};
+
+	/**
+	 * The absolute time the takeoff state transitions from CLAMPED_TO_RUNWAY -> CLIMBOUT [us]
+	 */
+	hrt_abstime takeoff_time_{0};
+
+	/**
+	 * Initial yaw of the vehicle on first pass through the runway takeoff state machine.
+	 * used for heading hold mode. [rad]
+	 */
+	float initial_yaw_{0.f};
+
+	/**
+	 * True if TECS should be commanded to "climbout" mode.
+	 */
+	bool climbout_{false};
+
+	/**
+	 * The global (lat, lon) position of the vehicle on first pass through the runway takeoff state machine. The
+	 * takeoff path emanates from this point to correct for any GNSS uncertainty from the planned takeoff point. The
+	 * vehicle should accordingly be set on the center of the runway before engaging the mission. [deg]
+	 */
+	matrix::Vector2d start_pos_global_{};
 
 	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::RWTO_TKOFF>) _param_rwto_tkoff,
-		(ParamInt<px4::params::RWTO_HDG>) _param_rwto_hdg,
-		(ParamFloat<px4::params::RWTO_NAV_ALT>) _param_rwto_nav_alt,
-		(ParamFloat<px4::params::RWTO_MAX_THR>) _param_rwto_max_thr,
-		(ParamFloat<px4::params::RWTO_PSP>) _param_rwto_psp,
-		(ParamFloat<px4::params::RWTO_MAX_PITCH>) _param_rwto_max_pitch,
-		(ParamFloat<px4::params::RWTO_MAX_ROLL>) _param_rwto_max_roll,
-		(ParamFloat<px4::params::RWTO_AIRSPD_SCL>) _param_rwto_airspd_scl,
-		(ParamFloat<px4::params::RWTO_RAMP_TIME>) _param_rwto_ramp_time,
-		(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_fw_airspd_min,
-		(ParamFloat<px4::params::FW_CLMBOUT_DIFF>) _param_fw_clmbout_diff
+		(ParamBool<px4::params::RWTO_TKOFF>) param_rwto_tkoff_,
+		(ParamInt<px4::params::RWTO_HDG>) param_rwto_hdg_,
+		(ParamFloat<px4::params::RWTO_MAX_THR>) param_rwto_max_thr_,
+		(ParamFloat<px4::params::RWTO_PSP>) param_rwto_psp_,
+		(ParamFloat<px4::params::RWTO_MAX_PITCH>) param_rwto_max_pitch_,
+		(ParamFloat<px4::params::RWTO_AIRSPD_SCL>) param_rwto_airspd_scl_,
+		(ParamFloat<px4::params::RWTO_RAMP_TIME>) param_rwto_ramp_time_,
+		(ParamFloat<px4::params::FW_AIRSPD_MIN>) param_fw_airspd_min_
 	)
-
 };
 
-}
+} // namespace runwaytakeoff
 
 #endif // RUNWAYTAKEOFF_H

--- a/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
@@ -48,10 +48,11 @@
 PARAM_DEFINE_INT32(RWTO_TKOFF, 0);
 
 /**
- * Specifies which heading should be held during runnway takeoff.
+ * Specifies which heading should be held during the runway takeoff ground roll.
  *
- * 0: airframe heading
- * 1: position control along runway direction (defined by operator in MAV_CMD)
+ * 0: airframe heading when takeoff is initiated
+ * 1: position control along runway direction (bearing defined from vehicle position on takeoff initiation to MAV_CMD_TAKEOFF
+ *    position defined by operator)
  *
  * @value 0 Airframe
  * @value 1 Runway
@@ -147,6 +148,9 @@ PARAM_DEFINE_FLOAT(RWTO_L1_PERIOD, 5.0f);
 
 /**
  * Enable use of yaw stick for nudging the wheel during runway ground roll
+ *
+ * This is useful when map, GNSS, or yaw errors on ground are misaligned with what the operator intends for takeoff course.
+ * Particularly useful for skinny runways or if the wheel servo is a bit off trim.
  *
  * @boolean
  * @group Runway Takeoff

--- a/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
@@ -50,31 +50,16 @@ PARAM_DEFINE_INT32(RWTO_TKOFF, 0);
 /**
  * Specifies which heading should be held during runnway takeoff.
  *
- * 0: airframe heading, 1: heading towards takeoff waypoint
+ * 0: airframe heading
+ * 1: position control along runway direction (defined by operator in MAV_CMD)
  *
  * @value 0 Airframe
- * @value 1 Waypoint
+ * @value 1 Runway
  * @min 0
  * @max 1
  * @group Runway Takeoff
  */
 PARAM_DEFINE_INT32(RWTO_HDG, 0);
-
-/**
- * Altitude AGL at which we have enough ground clearance to allow some roll.
- *
- * Until RWTO_NAV_ALT is reached the plane is held level and only
- * rudder is used to keep the heading (see RWTO_HDG). This should be below
- * FW_CLMBOUT_DIFF if FW_CLMBOUT_DIFF > 0.
- *
- * @unit m
- * @min 0.0
- * @max 100.0
- * @decimal 1
- * @increment 1
- * @group Runway Takeoff
- */
-PARAM_DEFINE_FLOAT(RWTO_NAV_ALT, 5.0);
 
 /**
  * Max throttle during runway takeoff.
@@ -122,21 +107,6 @@ PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
 PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
 
 /**
- * Max roll during climbout.
- *
- * Roll is limited during climbout to ensure enough lift and prevents aggressive
- * navigation before we're on a safe height.
- *
- * @unit deg
- * @min 0.0
- * @max 60.0
- * @decimal 1
- * @increment 0.5
- * @group Runway Takeoff
- */
-PARAM_DEFINE_FLOAT(RWTO_MAX_ROLL, 25.0);
-
-/**
  * Min airspeed scaling factor for takeoff.
  *
  * Pitch up will be commanded when the following airspeed is reached:
@@ -162,3 +132,15 @@ PARAM_DEFINE_FLOAT(RWTO_AIRSPD_SCL, 1.3);
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_RAMP_TIME, 2.0f);
+
+/**
+ * L1 period while steering on runway
+ *
+ * @unit s
+ * @min 1.0
+ * @max 100.0
+ * @decimal 1
+ * @increment 0.1
+ * @group Runway Takeoff
+ */
+PARAM_DEFINE_FLOAT(RWTO_L1_PERIOD, 5.0f);

--- a/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
@@ -144,3 +144,11 @@ PARAM_DEFINE_FLOAT(RWTO_RAMP_TIME, 2.0f);
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_L1_PERIOD, 5.0f);
+
+/**
+ * Enable use of yaw stick for nudging the wheel during runway ground roll
+ *
+ * @boolean
+ * @group Runway Takeoff
+ */
+PARAM_DEFINE_INT32(RWTO_NUDGE, 0);

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -183,6 +183,13 @@ MissionBlock::is_mission_item_reached()
 			}
 
 		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
+			   && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+			/* fixed-wing takeoff is reached once the vehicle has exceeded the takeoff altitude */
+			if (_navigator->get_global_position()->alt > mission_item_altitude_amsl) {
+				_waypoint_position_reached = true;
+			}
+
+		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
 			   && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROVER) {
 			/* for takeoff mission items use the parameter for the takeoff acceptance radius */
 			if (dist_xy >= 0.0f && dist_xy <= _navigator->get_acceptance_radius()) {


### PR DESCRIPTION
## Describe problem solved by this pull request
Issues:
- takeoff is currently defined by a waypoint, but should really be seen as an action or procedure
- many entanglements with TECS and other fixed-wing modes
- many hardcoded limits (magic numbers!) and open-loop behaviors

## Describe your solution
### Summary
- takeoff behavior now defined by a **course** (ground-relative direction) to takeoff in, and **clearance altitude** to "clear" before proceeding with the mission.
- takeoff mainly just concerns getting to a specific airspeed and altitude, let TECS control this (in a constrained manner)
- some incremental work on disentangling things
- NOTE: this is mainly a runway takeoff refactor, so the launch detection method is untouched, except for also adhering to the new course-based takeoff logic.

### Commit-by-commit

[fw pos ctrl: handle takeoff detection when switching to takeoff mode while in air](https://github.com/PX4/PX4-Autopilot/commit/62c51a25247484623de95595f9f1727c14aebd34)
attempt to disentangle / consolidate reset logic a bit.

[remove in air vs landed knowledge from TECS](https://github.com/PX4/PX4-Autopilot/commit/f3cfe217877938d083e2934c49776f3b2c8fec7d)
TECS is doing too much internally. It should not need to care whether we are landed or not. That's the job of the outer loops using it. This commit shifts the responsibility of integral reset handling outside. TECS is now running in all cases except during rotary wing or transitioning flight modes (the latter still something to be discussed), and during landed state, the integrals and trajectory generator are constantly reset.

[TECS: speed (only) -based underspeed detection](https://github.com/PX4/PX4-Autopilot/commit/ba289a3403f9ebbba7c77477a6a01317abba25f2)
- underspeed condition changed to only tell us whether or not we are under the desired speed
- airspeed min is a bit conservative as an underspeed detection metric, as we can even command minimum airspeed
- instead of arbitrary scale on min airspeed, use an expected TAS error bound to mark the start of underspeed detection. Even when TECS is tuned well, we can expect up to 2m/s airspeed tracking error which should not be fully penalized. This value is hardcoded for the moment, but could be changed or parameterized if necessary.
- change underspeed condition from binary to continuous and ramp in mitigation effects to avoid jumpy setpoints within soft bound range
![underspeed_figure](https://user-images.githubusercontent.com/8026163/177128136-1535aa70-a90c-4f0d-9b29-891a87d19eaa.png)
- allow the airspeed filter to reach zero, see the following figure showing the 3m/s cap is now gone ([this script](https://colab.research.google.com/drive/1ebFC5OshLoS_vj1gjhg2FGLiVfG6LUbq?usp=sharing) was used to generate the plots)
- NOTE: this filter should ideally not be inside TECS either. But .. for another PR.
![true_airspeed_filter](https://user-images.githubusercontent.com/8026163/177128929-acbd49a3-16fd-4a86-872a-926289357266.png)
![true_airspeed_derivative_filter](https://user-images.githubusercontent.com/8026163/177128944-37d9c404-6f22-47be-92bb-9f3a8b4e00ce.png)

[fw pos ctrl: rework manual takeoff aid](https://github.com/PX4/PX4-Autopilot/commit/25e1897186c0bb52d50461d7bfee5582022b5d9c)
- takeoff situational knowledge removed from all other modes except manual (or actual takeoff mode). why? IMHO we should only allow takeoff when it has been commanded, and handle it explicitly. If we are in other modes (e.g. loiter..) the expectation should not be that we are possibly taking off. Flight condition protections should be handled independently, and near-ground states should also be handled independently. The latter especially requires a bit more consideration if already in other mission modes.
- manual takeoff is marked complete if at a **controllable airspeed** - this is a *manual* mode, so we give as much authority to the operator as possible while helping just a bit in the beginning to get the aircraft in the air, so altitude or time are not considered here.
- minimum pitch bounds TECS until manual takeoff complete
- remove individual roll constraints during manual takeoff (ground proximity constraints coming in subsequent commit)

[fw pos ctrl: encapsulate wing tip strike constraint for roll angle](https://github.com/PX4/PX4-Autopilot/commit/ce8162573caee1a3e0decfd79529af711bf41ecf)
- consolidate near ground roll limiting using a conservative approximation of aircraft geometry constraints
- two new parameters `FW_WING_SPAN` and `FW_WING_HEIGHT` for the general wing strike limiting case
$\phi_\text{strike} = \sin^{-1}\left( 2 h / b \right)$
$\frac{ \partial\phi_\text{strike} }{ \partial h } = \frac{2}{b \cos\left( 2 h / b \right)}$
$\frac{ \partial\phi_\text{strike} }{ \partial h } \left(h=0\right) = 2 / b$
$\phi_\text{strike} \approx 2  h / b$
Where $\phi_\text{strike}$ is the roll angle where a strike would occur, $h$ is the height above ground, $b$ is the wing span (tip to tip). [This script](https://colab.research.google.com/drive/1gLUxiXC8j7jMP53AgQo7isaKdTJgN1at?usp=sharing) was used to generate the plot below.
![wingstrikeprotection](https://user-images.githubusercontent.com/8026163/177132940-19d39645-f682-4669-9183-24fa30bfa8db.png)

[fw pos ctrl: refactor takeoff mode](https://github.com/PX4/PX4-Autopilot/commit/461dcbf22839b348cdd8040bb9264285efd2f6db)
This is the actual refactor of the takeoff logic after all the preliminaries in previous commits were taken care of.

New state machine:
1. **throttle ramp**: throttle is ramped from zero to `RWTO_MAX_THR` over `RWTO_RAMP_TIME`. throttle ramp must complete before switching to next state to avoid a jump in throttle setpoint just after takeoff if the takeoff airspeed is reached before the ramp is complete
2. **clamped to runway**: continue at `RWTO_MAX_THR` until the takeoff airspeed is reached
3. **climbout**: climbout until clearance altitude is reached. `RWTO_MAX_THR` is blended back into TECS commanded throttle with some small time hysteresis to avoid throttle cuts directly after lift off.
4. **fly**: once clearance altitude is reached, proceed with the mission.

Other changes:
- takeoff waypoint altitude is used as a clearance altitude, set such that once above, the aircraft has cleared all ground occlusions and may proceed with the mission. **IDEALLY** this would be a new takeoff mav cmd. But for now we can bootstrap by using the existing waypoint until we're comfortable with the approach.
- post takeoff, the aircraft follows the infinite line sourced from the launch point in the direction of the takeoff waypoint
- `RWTO_L1_PERIOD` added to allow setting a more aggressive L1 or NPFG tuning during ground roll

[fw att ctrl: log the yaw rate command controlled by the wheel](https://github.com/PX4/PX4-Autopilot/commit/c6096e99b546903c0f1b84727365b356958df41f)
Wheel and yaw rate are controlled separately (with two separate gain sets). This just logs the wheel controller output which wasnt done before. NOTE: a separate discussion to have would be changing the wheel logic in general, e.g. separating it from the rudder, but this can be left to another PR.

[fw pos/att ctrl: pass manual nose wheel increments during takeoff ground roll](https://github.com/PX4/PX4-Autopilot/commit/0a7ed345102cdc885c320ac00e8474de99185f89)
Allows "nudging" the vehicle on the runway (if `RWTO_NUDGE` enabled) by directly passing through the yaw stick input to the wheel. This is useful when map, GNSS, or yaw errors on ground are misaligned with what the operator intends for takeoff course. Particularly useful for skinny runways or if the wheel servo is a bit off trim.

[fw pos ctrl: head straight for next waypoint after takeoff](https://github.com/PX4/PX4-Autopilot/commit/6adea1d52cc2f0bf67a1acf2cc55242f011aed19)
Dont follow the line between takeoff "waypoint" and next point, just go directly to the next point. We are moving towards not having a takeoff "waypoint".

[fw pos ctrl: organize state variables](https://github.com/PX4/PX4-Autopilot/commit/5d722114781e2397fd69c0e1c443775f07b242ee)
Just organizes the header a bit to make it easier to find variable related to a specific group or mode. Also will help when we hopefully start splitting this mega class into small classes. 

## Describe possible alternatives

**Throttle max used until climbout**
Ideally.. TECS would control the airspeed even on the ground instead of hard-coding the takeoff throttle. The param itself `RWTO_THR_MAX` even specifies a maximum, so could be used only as constraint (similar for the throttle ramp). However, one concern would be that on lift-off there may still be some jump in setpoint due to the instantaneously changing conditions. This could be handled by possibly freezing (and putting some hysteresis) on the throttle setting that achieved the airspeed necessary for takeoff, but then would probably need to be filtered. Further, at the beginning of the throttle ramp, the aircraft is in a "landed" state, so the TECS integrators are getting reset constantly. If the ramp is only set as constraint, it could be that there is some weird behavior where the time based ramp constraint is satisfied, but the throttle setpoint itself does whatever it likes underneath this constraint (possibly pulsing, possibly taking a non-linear, non-gradual trajectory).

**Launch logic (e.g. catapult or hand)**
Likely we need to revisit this logic -- it is currently not regressed in this PR, but has been a bit neglected as this was primarily a runway takeoff refactor. Would leave this for another PR with input from interested parties who use this functionality.

## Test data / coverage

**Manual takeoff aid**:
- [x] make sure throttle does not spool up when "landed" and throttle stick is below deadzone in **position** mode
- [x] make sure throttle does not spool up when "landed" and throttle stick is below deadzone in **altitude** mode
![position_altitude_mode_throttle_threshold](https://user-images.githubusercontent.com/8026163/179484446-52a2cdcd-ee57-4fa9-a22e-6a098f31cda2.png)
^thanks @sfuhrer 

**Auto takeoff**:
- [x] flight test
- [x] check that nudging works
https://review.px4.io/plot_app?log=e45b9dfe-7483-4b66-80fc-2218d9bfd639
Video: https://drive.google.com/file/d/1-j2IDMTEZ5bGhBx-0-I-2tls_cLj5h5k/view?usp=sharing

**VTOL**
- [x] check nothing breaks on VTOL ops