### PR TITLE
Robustify RTPS bridge stream parsing.

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
@@ -253,10 +253,14 @@ void micrortps_start_topics(const uint32_t &datarate, struct timespec &begin, ui
 
 	while (!_should_exit_task) {
 @[if recv_topics]@
-		while (0 < (read = transport_node->read(&topic_ID, data_buffer, BUFFER_SIZE))) {
+
+		read = transport_node->read();
+		if (read > 0) {
 			total_rcvd += read;
 			rx_last_sec_read += read;
+		}
 
+		while (transport_node->parse(&topic_ID, data_buffer, BUFFER_SIZE)) {
 			uint64_t read_time = hrt_absolute_time();
 
 			switch (topic_ID) {

--- a/msg/templates/urtps/microRTPS_agent.cpp.em
+++ b/msg/templates/urtps/microRTPS_agent.cpp.em
@@ -364,10 +364,14 @@ int main(int argc, char **argv)
 		if (!receiving) { start = std::chrono::steady_clock::now(); }
 
 		// Publish messages received from UART
-		if (0 < (length = transport_node->read(&topic_ID, data_buffer, BUFFER_SIZE))) {
+		length = transport_node->read();
+		if (length > 0) {
+			total_read += length;
+		}
+
+		while (transport_node->parse(&topic_ID, data_buffer, BUFFER_SIZE)) {
 			topics->publish(topic_ID, data_buffer, sizeof(data_buffer));
 			++received;
-			total_read += length;
 			receiving = true;
 			end = std::chrono::steady_clock::now();
 		}

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -56,7 +56,9 @@ public:
 
 	virtual int init() {return 0;}
 	virtual uint8_t close() {return 0;}
-	ssize_t read(uint8_t *topic_id, char out_buffer[], size_t buffer_len);
+
+	ssize_t read();
+	bool parse(uint8_t *topic_id, char out_buffer[], size_t buffer_len);
 
 	/**
 	 * write a buffer
@@ -76,6 +78,10 @@ public:
 	size_t get_header_length();
 
 private:
+#ifndef PX4_DEBUG
+	void print_buffer_debug();
+#endif /* PX4_DEBUG */
+
 	struct __attribute__((packed)) Header {
 		char marker[3];
 		uint8_t topic_id;


### PR DESCRIPTION
## Describe problem solved by this pull request

We had problems with the RTPS bridge when used over UART. Electrical noise might introduce a spurious character into the data stream from time to time. The existing implementation would accumulate those errors in the parsing buffer. Once the buffer is full only CRC errors would be generated and no message would be parsed successfully.


## Describe your solution

Two parts:
- Decouple the reading of the transport buffers from the parsing. The old implementation could only parse a single message per transport buffer read. However, a single read might push multiple message into the buffer leading to dropped message, if data is ingested too fast, or if corrupted messages (bad CRC) would accumulate in the buffer.
- Refactor the message detection on the stream buffer.


## Describe possible alternatives
No alternatives have been explored.

## Test data / coverage
Tested on a single system so far (Jetson + Holybro FMUv5 connected over UART via protocol_splitter). We will test the change on more drones in the near future, I'll update this PR if we detected any problems with the implementation.

