### PR TITLE
ekf2: start airspeed fusion when test ratio is passing only

### DIFF
--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -1028,7 +1028,9 @@ void Ekf::controlAirDataFusion()
 
 		const bool continuing_conditions_passing = _control_status.flags.in_air && _control_status.flags.fixed_wing && !_using_synthetic_position;
 		const bool is_airspeed_significant = _airspeed_sample_delayed.true_airspeed > _params.arsp_thr;
-		const bool starting_conditions_passing = continuing_conditions_passing && is_airspeed_significant;
+		const bool is_airspeed_consistent = (_aid_src_airspeed.test_ratio > 0.f && _aid_src_airspeed.test_ratio < 1.f);
+		const bool starting_conditions_passing = continuing_conditions_passing && is_airspeed_significant
+		                                         && (is_airspeed_consistent || !_control_status.flags.wind); // if wind isn't already estimated, the states are reset when starting airspeed fusion
 
 		if (_control_status.flags.fuse_aspd) {
 			if (continuing_conditions_passing) {


### PR DESCRIPTION
requires https://github.com/PX4/PX4-Autopilot/pull/19868

## Describe problem solved by this pull request
When wind is already estimated, we don't reset the states using airspeed data, so it could be that the fusion fails if the airspeed isn't consistent with the filter (test ratio > 1). At the moment, this makes the airspeed control logic start and stop the fusion at every loop.
![DeepinScreenshot_select-area_20220704162436](https://user-images.githubusercontent.com/14822839/177284456-ec07ac26-1a5c-43cb-a79a-a92f76e8f915.png)


## Describe your solution
If the wind states are already estimated, don't start the fusion if the test ratio would fail.

When wind isn't already estimated, the wind states are reset using airspeed so the fusion can start regardless of the current test ratio.

## Test data / coverage
SITL using `make px4_sitl gazebo_standard_vtol__windy`

With an artificial high constant value in the airspeed data.
![DeepinScreenshot_select-area_20220704162909](https://user-images.githubusercontent.com/14822839/177284726-ac944360-d373-4b13-a165-59a787928da8.png)

