### PR TITLE
Landing position updates for precision landing.

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -245,12 +245,12 @@ void FlightTaskAuto::_prepareLandSetpoints()
 	}
 
 	if (_type_previous != WaypointType::land) {
-		// initialize xy-position and yaw to waypoint such that home is reached exactly without user input
-		_land_position = Vector3f(_target(0), _target(1), NAN);
+		// initialize yaw
 		_land_heading = _yaw_setpoint;
 		_stick_acceleration_xy.resetPosition(Vector2f(_target(0), _target(1)));
 	}
-
+	// Update xy-position in case of landing position changes (etc. precision landing)
+	_land_position = Vector3f(_target(0), _target(1), NAN);
 	// User input assisted landing
 	if (_param_mpc_land_rc_help.get() && _sticks.checkAndUpdateStickInputs()) {
 		// Stick full up -1 -> stop, stick full down 1 -> double the speed


### PR DESCRIPTION
## Problem

Precision landing works incorrectly - Target position is not updated during the descent above target.

## Solution
`_prepareLandSetpoints` needs to update `_land_position` continuously.

## Test coverage
Tests were performed on quadcopters with and without a fix.

### Log without fix
<img width="693" alt="WithoutFix" src="https://user-images.githubusercontent.com/186350/177326007-654a6cc2-364c-4c6c-a144-08f3e91afd47.png">

### Log with fix
<img width="693" alt="WithFix" src="https://user-images.githubusercontent.com/186350/177326010-aeb1c73c-ba12-408e-972c-1acb47af53aa.png">