### PR TITLE
ROMFS: assign all 4 tilts to motors to have them all tilt

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -27,7 +27,9 @@ param set-default CA_ROTOR3_PY 0.1875
 param set-default CA_ROTOR3_KM -0.05
 
 param set-default CA_ROTOR0_TILT 1
+param set-default CA_ROTOR1_TILT 2
 param set-default CA_ROTOR2_TILT 3
+param set-default CA_ROTOR3_TILT 4
 param set-default CA_SV_CS0_TRQ_R -0.5
 param set-default CA_SV_CS0_TYPE 1
 param set-default CA_SV_CS1_TRQ_R 0.5


### PR DESCRIPTION
I originally wanted to only tilt the front motors of the SITL tiltrotor, as this is more realistic (in the model the props are mounted all on the top side of the motor which would cause collisions when tilting..). This could be done by not assigning a motor to the tilt, then it would always stay vertical and not tilt for FW. Kind of a hack that we possibly should prevent in the future, and maybe replace with exposing a setting for which motors to tilt for FW.
Forgot to set CA_SV_TL0_CT and CA_SV_TL2_CT to 1 though, so the current model is broken.
And while reconsidering it decided to for now have all 4 motors tiltable, and control yaw in hove through differential thrust and not tilt.
Let's remove the rear tilts from the simulation model and then change the config again to resemble it to the model.