### PR TITLE
GPS: Increase param name buffer to address warning in newer gccs

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -325,7 +325,7 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, GPSHelper::Interface interfac
 
 	if (_mode == gps_driver_mode_t::None) {
 		// use parameter to select mode if not provided via CLI
-		char protocol_param_name[16];
+		char protocol_param_name[17];
 		snprintf(protocol_param_name, sizeof(protocol_param_name), "GPS_%i_PROTOCOL", (int)_instance + 1);
 		int32_t protocol = 0;
 		param_get(param_find(protocol_param_name), &protocol);


### PR DESCRIPTION
## Describe problem solved by this pull request

On some branches, my GCC started complaining this this `snprintf` call may truncate. Looks like increasing the buffer by 1 byte silences the warning. This is also in line with the maximum param name length of 16 (+1 null terminator), and is used like this in other places.

```
/projects/PX4/src/drivers/gps/gps.cpp:329:78: error: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Werror=format-truncation=]
  329 |   snprintf(protocol_param_name, sizeof(protocol_param_name), "GPS_%i_PROTOCOL", (int)_instance + 1);
      |                                                                              ^
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors

```

## Describe your solution
Increase the buffer by 1 byte.

## Describe possible alternatives
Check snprintf return value, and do other error handling. I think that's unecessary, unless one has more than 99 GPSses
