### PR TITLE
FlightTaskAuto: don't override landing gear state for takeoff

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -146,11 +146,8 @@ bool FlightTaskAuto::update()
 		_velocity_setpoint(2) = NAN;
 		break;
 
-	case WaypointType::takeoff:
-		// Takeoff is completely defined by target position
-		_gear.landing_gear = landing_gear_s::GEAR_DOWN;
-
 	// FALLTHROUGH
+	case WaypointType::takeoff:
 	case WaypointType::loiter:
 	case WaypointType::position:
 	default:


### PR DESCRIPTION
## Describe problem solved by this pull request
The auto flight tasks supports retracting the landing gear when it considers to be "high enough above the ground".
However, during the entire takeoff navigation state (which usually persists until you reach the desired takeoff altitude) the landing gear was hardcoded to be extended and thus the mechanism described above did not work anymore.

## Describe your solution
Remove the hardcoded extension of landing gear during takeoff.
