### PR TITLE
ROMFS: fix incremental build for airframe processing

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -112,23 +112,17 @@ add_custom_command(
 		${PX4_SOURCE_DIR}/Tools/px4airframes/xmlout.py
 		${PX4_SOURCE_DIR}/Tools/serial/generate_config.py
 	)
-set(romfs_extract_stamp ${CMAKE_CURRENT_BINARY_DIR}/romfs_extract.stamp)
-add_custom_command(
-	OUTPUT ${romfs_extract_stamp}
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/*
-	COMMAND ${CMAKE_COMMAND} -E tar xf ${romfs_tar_file}
-	COMMAND ${CMAKE_COMMAND} -E touch ${romfs_extract_stamp}
-	WORKING_DIRECTORY ${romfs_gen_root_dir}
-	DEPENDS ${romfs_tar_file}
-	VERBATIM
-	)
 
+
+set(romfs_copy_stamp ${CMAKE_CURRENT_BINARY_DIR}/romfs_copy.stamp)
 add_custom_command(
 	OUTPUT
 		${romfs_gen_root_dir}/init.d/rc.serial
 		${romfs_gen_root_dir}/init.d/rc.autostart
 		${romfs_gen_root_dir}/init.d/rc.autostart.post
-		romfs_copy.stamp
+		${romfs_copy_stamp}
+	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/*
+	COMMAND ${CMAKE_COMMAND} -E tar xf ${romfs_tar_file}
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 		--airframes-path ${romfs_gen_root_dir}/init.d
 		--start-script ${romfs_gen_root_dir}/init.d/rc.autostart
@@ -137,9 +131,9 @@ add_custom_command(
 		--rc-dir ${romfs_gen_root_dir}/init.d
 		--serial-ports ${board_serial_ports} ${added_arguments}
 		--config-files ${module_config_files} #--verbose
-	COMMAND ${CMAKE_COMMAND} -E touch romfs_copy.stamp
-	DEPENDS
-		${romfs_extract_stamp}
+	COMMAND ${CMAKE_COMMAND} -E touch ${romfs_copy_stamp}
+	WORKING_DIRECTORY ${romfs_gen_root_dir}
+	DEPENDS ${romfs_tar_file}
 	COMMENT "ROMFS: copying, generating airframes"
 	)
 
@@ -311,7 +305,7 @@ add_custom_command(OUTPUT romfs_extras.stamp
 
 add_custom_target(romfs_gen_files_target
 	DEPENDS
-		${romfs_extract_stamp}
+		${romfs_copy_stamp}
 		${romfs_gen_root_dir}/init.d/rc.serial
 		romfs_extras.stamp
 	)

--- a/platforms/nuttx/src/px4/common/gpio/mcp23009/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/gpio/mcp23009/CMakeLists.txt
@@ -33,3 +33,5 @@
 px4_add_library(platform_gpio_mcp23009
 		mcp23009.cpp
 	)
+target_link_libraries(platform_gpio_mcp23009 PRIVATE drivers__device) # device::I2C
+


### PR DESCRIPTION
Fixes the error:
`Aborting due to missing @type tag in file: 'build/px4_fmu-v5_test/etc/init.d/airframes/11001_hexa_cox'`

This can happen due to a change to e.g. board_serial_ports, which changes
the CLI command and triggers a re-execution of the airframe processing.