### PR TITLE
Add option for UAVCAN battery to use Battery Library for filtering

### DIFF
--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -73,7 +73,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	uint8_t instance = 0;
 
 	for (instance = 0; instance < battery_status_s::MAX_INSTANCES; instance++) {
-		if (battery_status[instance].id == msg.getSrcNodeID().get() || battery_status[instance].id == 0) {
+		if (_battery_status[instance].id == msg.getSrcNodeID().get() || _battery_status[instance].id == 0) {
 			break;
 		}
 	}
@@ -82,51 +82,51 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 		return;
 	}
 
-	battery_status[instance].timestamp = hrt_absolute_time();
-	battery_status[instance].voltage_v = msg.voltage;
-	battery_status[instance].voltage_filtered_v = msg.voltage;
-	battery_status[instance].current_a = msg.current;
-	battery_status[instance].current_filtered_a = msg.current;
-	battery_status[instance].current_average_a = msg.current;
+	_battery_status[instance].timestamp = hrt_absolute_time();
+	_battery_status[instance].voltage_v = msg.voltage;
+	_battery_status[instance].voltage_filtered_v = msg.voltage;
+	_battery_status[instance].current_a = msg.current;
+	_battery_status[instance].current_filtered_a = msg.current;
+	_battery_status[instance].current_average_a = msg.current;
 
 	if (battery_aux_support[instance] == false) {
-		sumDischarged(battery_status[instance].timestamp, battery_status[instance].current_a);
-		battery_status[instance].discharged_mah = _discharged_mah;
+		sumDischarged(_battery_status[instance].timestamp, _battery_status[instance].current_a);
+		_battery_status[instance].discharged_mah = _discharged_mah;
 	}
 
-	battery_status[instance].remaining = msg.state_of_charge_pct / 100.0f; // between 0 and 1
-	// battery_status[instance].scale = msg.; // Power scaling factor, >= 1, or -1 if unknown
-	battery_status[instance].temperature = msg.temperature + CONSTANTS_ABSOLUTE_NULL_CELSIUS; // Kelvin to Celcius
-	// battery_status[instance].cell_count = msg.;
-	battery_status[instance].connected = true;
-	battery_status[instance].source = msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_IN_USE;
-	// battery_status[instance].priority = msg.;
-	battery_status[instance].capacity = msg.full_charge_capacity_wh;
-	battery_status[instance].full_charge_capacity_wh = msg.full_charge_capacity_wh;
-	battery_status[instance].remaining_capacity_wh = msg.remaining_capacity_wh;
-	// battery_status[instance].cycle_count = msg.;
-	battery_status[instance].time_remaining_s = NAN;
-	// battery_status[instance].average_time_to_empty = msg.;
-	battery_status[instance].serial_number = msg.model_instance_id;
-	battery_status[instance].id = msg.getSrcNodeID().get();
+	_battery_status[instance].remaining = msg.state_of_charge_pct / 100.0f; // between 0 and 1
+	// _battery_status[instance].scale = msg.; // Power scaling factor, >= 1, or -1 if unknown
+	_battery_status[instance].temperature = msg.temperature + CONSTANTS_ABSOLUTE_NULL_CELSIUS; // Kelvin to Celcius
+	// _battery_status[instance].cell_count = msg.;
+	_battery_status[instance].connected = true;
+	_battery_status[instance].source = msg.status_flags & uavcan::equipment::power::BatteryInfo::STATUS_FLAG_IN_USE;
+	// _battery_status[instance].priority = msg.;
+	_battery_status[instance].capacity = msg.full_charge_capacity_wh;
+	_battery_status[instance].full_charge_capacity_wh = msg.full_charge_capacity_wh;
+	_battery_status[instance].remaining_capacity_wh = msg.remaining_capacity_wh;
+	// _battery_status[instance].cycle_count = msg.;
+	_battery_status[instance].time_remaining_s = NAN;
+	// _battery_status[instance].average_time_to_empty = msg.;
+	_battery_status[instance].serial_number = msg.model_instance_id;
+	_battery_status[instance].id = msg.getSrcNodeID().get();
 
 	if (battery_aux_support[instance] == false) {
 		// Mavlink 2 needs individual cell voltages or cell[0] if cell voltages are not available.
-		battery_status[instance].voltage_cell_v[0] = msg.voltage;
+		_battery_status[instance].voltage_cell_v[0] = msg.voltage;
 
 		// Set cell count to 1 so the the battery code in mavlink_messages.cpp copies the values correctly (hack?)
-		battery_status[instance].cell_count = 1;
+		_battery_status[instance].cell_count = 1;
 	}
 
-	// battery_status[instance].max_cell_voltage_delta = msg.;
+	// _battery_status[instance].max_cell_voltage_delta = msg.;
 
-	// battery_status[instance].is_powering_off = msg.;
+	// _battery_status[instance].is_powering_off = msg.;
 
-	determineWarning(battery_status[instance].remaining);
-	battery_status[instance].warning = _warning;
+	determineWarning(_battery_status[instance].remaining);
+	_battery_status[instance].warning = _warning;
 
 	if (battery_aux_support[instance] == false) {
-		publish(msg.getSrcNodeID().get(), &battery_status[instance]);
+		publish(msg.getSrcNodeID().get(), &_battery_status[instance]);
 	}
 }
 
@@ -137,7 +137,7 @@ UavcanBatteryBridge::battery_aux_sub_cb(const uavcan::ReceivedDataStructure<ardu
 	uint8_t instance = 0;
 
 	for (instance = 0; instance < battery_status_s::MAX_INSTANCES; instance++) {
-		if (battery_status[instance].id == msg.getSrcNodeID().get()) {
+		if (_battery_status[instance].id == msg.getSrcNodeID().get()) {
 			break;
 		}
 	}
@@ -148,23 +148,23 @@ UavcanBatteryBridge::battery_aux_sub_cb(const uavcan::ReceivedDataStructure<ardu
 
 	battery_aux_support[instance] = true;
 
-	battery_status[instance].discharged_mah = (battery_status[instance].full_charge_capacity_wh -
-			battery_status[instance].remaining_capacity_wh) / msg.nominal_voltage *
+	_battery_status[instance].discharged_mah = (_battery_status[instance].full_charge_capacity_wh -
+			_battery_status[instance].remaining_capacity_wh) / msg.nominal_voltage *
 			1000;
-	battery_status[instance].cell_count = math::min((uint8_t)msg.voltage_cell.size(), (uint8_t)14);
-	battery_status[instance].cycle_count = msg.cycle_count;
-	battery_status[instance].over_discharge_count = msg.over_discharge_count;
-	battery_status[instance].nominal_voltage = msg.nominal_voltage;
-	battery_status[instance].time_remaining_s = math::isZero(battery_status[instance].current_a) ? 0 :
-			(battery_status[instance].remaining_capacity_wh /
-			 battery_status[instance].nominal_voltage / battery_status[instance].current_a * 3600);
-	battery_status[instance].is_powering_off = msg.is_powering_off;
+	_battery_status[instance].cell_count = math::min((uint8_t)msg.voltage_cell.size(), (uint8_t)14);
+	_battery_status[instance].cycle_count = msg.cycle_count;
+	_battery_status[instance].over_discharge_count = msg.over_discharge_count;
+	_battery_status[instance].nominal_voltage = msg.nominal_voltage;
+	_battery_status[instance].time_remaining_s = math::isZero(_battery_status[instance].current_a) ? 0 :
+			(_battery_status[instance].remaining_capacity_wh /
+			 _battery_status[instance].nominal_voltage / _battery_status[instance].current_a * 3600);
+	_battery_status[instance].is_powering_off = msg.is_powering_off;
 
-	for (uint8_t i = 0; i < battery_status[instance].cell_count; i++) {
-		battery_status[instance].voltage_cell_v[i] = msg.voltage_cell[i];
+	for (uint8_t i = 0; i < _battery_status[instance].cell_count; i++) {
+		_battery_status[instance].voltage_cell_v[i] = msg.voltage_cell[i];
 	}
 
-	publish(msg.getSrcNodeID().get(), &battery_status[instance]);
+	publish(msg.getSrcNodeID().get(), &_battery_status[instance]);
 }
 
 void

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -231,13 +231,13 @@ void
 UavcanBatteryBridge::filterData(const uavcan::ReceivedDataStructure<uavcan::equipment::power::BatteryInfo> &msg,
 				uint8_t instance)
 {
-	_battery.setConnected(true);
-	_battery.updateVoltage(msg.voltage);
-	_battery.updateCurrent(msg.current);
-	_battery.updateBatteryStatus(hrt_absolute_time());
+	_battery[instance]->setConnected(true);
+	_battery[instance]->updateVoltage(msg.voltage);
+	_battery[instance]->updateCurrent(msg.current);
+	_battery[instance]->updateBatteryStatus(hrt_absolute_time());
 
 	/* Override data that is expected to arrive from UAVCAN msg*/
-	_battery_status[instance] = _battery.getBatteryStatus();
+	_battery_status[instance] = _battery[instance]->getBatteryStatus();
 	_battery_status[instance].temperature = msg.temperature + CONSTANTS_ABSOLUTE_NULL_CELSIUS; // Kelvin to Celcius
 	_battery_status[instance].serial_number = msg.model_instance_id;
 	_battery_status[instance].id = msg.getSrcNodeID().get(); // overwrite zeroed index from _battery

--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -84,6 +84,6 @@ private:
 	float _discharged_mah_loop = 0.f;
 	uint8_t _warning;
 	hrt_abstime _last_timestamp;
-	battery_status_s battery_status[battery_status_s::MAX_INSTANCES] {};
+	battery_status_s _battery_status[battery_status_s::MAX_INSTANCES] {};
 	bool battery_aux_support[battery_status_s::MAX_INSTANCES] {false};
 };

--- a/src/drivers/uavcan/sensors/battery.hpp
+++ b/src/drivers/uavcan/sensors/battery.hpp
@@ -99,8 +99,18 @@ private:
 	BatteryDataType _batt_update_mod[battery_status_s::MAX_INSTANCES] {};
 
 	static constexpr int FILTER_DATA = 2;
-	static constexpr int BATTERY_INDEX = 1;
+	static constexpr int BATTERY_INDEX_1 = 1;
+	static constexpr int BATTERY_INDEX_2 = 2;
+	static constexpr int BATTERY_INDEX_3 = 3;
+	static constexpr int BATTERY_INDEX_4 = 4;
 	static constexpr int SAMPLE_INTERVAL_US = 20_ms; // assume higher frequency UAVCAN feedback than 50Hz
-	Battery _battery{BATTERY_INDEX, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_EXTERNAL};
 
+	static_assert(battery_status_s::MAX_INSTANCES <= BATTERY_INDEX_4, "Battery array too big");
+
+	Battery battery1 = {BATTERY_INDEX_1, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_EXTERNAL};
+	Battery battery2 = {BATTERY_INDEX_2, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_EXTERNAL};
+	Battery battery3 = {BATTERY_INDEX_3, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_EXTERNAL};
+	Battery battery4 = {BATTERY_INDEX_4, this, SAMPLE_INTERVAL_US, battery_status_s::BATTERY_SOURCE_EXTERNAL};
+
+	Battery *_battery[battery_status_s::MAX_INSTANCES] = { &battery1, &battery2, &battery3, &battery4 };
 };

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -228,7 +228,15 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_BARO, 0);
  *  uavcan::equipment::power::BatteryInfo
  *  ardupilot::equipment::power::BatteryInfoAux
  *
- * @boolean
+ *  0 - Disable
+ *  1 - Use raw data. Recommended for Smart battery
+ *  2 - Filter the data with internal battery library
+ *
+ * @min 0
+ * @max 2
+ * @value 0 Disable
+ * @value 1 Raw data
+ * @value 2 Filter data
  * @reboot_required true
  * @group UAVCAN
  */


### PR DESCRIPTION
## Describe the problem solved by this pull request
Some of the power modules (non-Smart battery UAVCAN batt devices) don't have an algorithm that is handling estimation like voltage drop or remaining time. 
In that case, if the user drow a lot of currents and the battery have high internal resistance user can experience low remaining flight time or voltage drop under the allowed value that can trigger a false failsafe. 

## Describe your solution
This solution is integrating internal Battery Library (src/lib/battery) for calculating all filtered voltage, like it is done at other places (ina226, voxlpm drivers, [analog battery](https://github.com/PX4/PX4-Autopilot/blob/f9d8c613b048f58eb3110e9af13cb3a89c4c866f/src/modules/battery_status/analog_battery.h#L39), [esc battery](https://github.com/PX4/PX4-Autopilot/blob/f9d8c613b048f58eb3110e9af13cb3a89c4c866f/src/modules/esc_battery/EscBattery.hpp#L79))
The battery library took only voltage and current and estimate all other battery status data. 
things like temperature and instance-id are overwritten at the end. 

## Test data / coverage
Before this PR voltage drop is visible on full throttle:
![image](https://user-images.githubusercontent.com/10188706/177520134-f44e2bd7-d333-4bae-a823-ef91719e29df.png)

After this PR it can be seen voltage drop is smothered with the filtering. 
![image](https://user-images.githubusercontent.com/10188706/177521373-68d47492-4218-4542-8617-edcc18b6cbc4.png)


