### PR TITLE
ADS1115 ADC: start internal ADC as well

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -12,6 +12,7 @@ fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
+	board_adc start -n
 else
 	board_adc start
 fi

--- a/src/drivers/adc/board_adc/ADC.cpp
+++ b/src/drivers/adc/board_adc/ADC.cpp
@@ -39,8 +39,9 @@
 #include <nuttx/ioexpander/gpio.h>
 #endif
 
-ADC::ADC(uint32_t base_address, uint32_t channels) :
+ADC::ADC(uint32_t base_address, uint32_t channels, bool publish_adc_report) :
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default),
+	_publish_adc_report(publish_adc_report),
 	_sample_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": sample")),
 	_base_address(base_address)
 {
@@ -116,7 +117,10 @@ void ADC::Run()
 		_samples[i].am_data = sample(_samples[i].am_channel);
 	}
 
-	update_adc_report(now);
+	if (_publish_adc_report) {
+		update_adc_report(now);
+	}
+
 	update_system_power(now);
 }
 
@@ -352,7 +356,8 @@ int ADC::custom_command(int argc, char *argv[])
 
 int ADC::task_spawn(int argc, char *argv[])
 {
-	ADC *instance = new ADC(SYSTEM_ADC_BASE, ADC_CHANNELS);
+	bool publish_adc_report = !(argc >= 2 && strcmp(argv[1], "-n") == 0);
+	ADC *instance = new ADC(SYSTEM_ADC_BASE, ADC_CHANNELS, publish_adc_report);
 
 	if (instance) {
 		_object.store(instance);
@@ -389,6 +394,7 @@ ADC driver.
 	PRINT_MODULE_USAGE_NAME("adc", "driver");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_COMMAND("test");
+	PRINT_MODULE_USAGE_PARAM_FLAG('n', "Do not publish ADC report, only system power", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;

--- a/src/drivers/adc/board_adc/ADC.hpp
+++ b/src/drivers/adc/board_adc/ADC.hpp
@@ -102,7 +102,7 @@ private:
 
 	static const hrt_abstime	kINTERVAL{10_ms};	/**< 100Hz base rate */
 
-	bool 				_publish_adc_report;
+	const bool 			_publish_adc_report;
 
 	perf_counter_t			_sample_perf;
 

--- a/src/drivers/adc/board_adc/ADC.hpp
+++ b/src/drivers/adc/board_adc/ADC.hpp
@@ -64,7 +64,7 @@ using namespace time_literals;
 class ADC : public ModuleBase<ADC>, public px4::ScheduledWorkItem
 {
 public:
-	ADC(uint32_t base_address = SYSTEM_ADC_BASE, uint32_t channels = ADC_CHANNELS);
+	ADC(uint32_t base_address = SYSTEM_ADC_BASE, uint32_t channels = ADC_CHANNELS, bool publish_adc_report = true);
 
 	~ADC() override;
 
@@ -102,6 +102,8 @@ private:
 
 	static const hrt_abstime	kINTERVAL{10_ms};	/**< 100Hz base rate */
 
+	bool 				_publish_adc_report;
+
 	perf_counter_t			_sample_perf;
 
 	unsigned			_channel_count{0};
@@ -110,6 +112,7 @@ private:
 
 	uORB::Publication<adc_report_s>		_to_adc_report{ORB_ID(adc_report)};
 	uORB::Publication<system_power_s>	_to_system_power{ORB_ID(system_power)};
+
 #ifdef BOARD_GPIO_VDD_5V_COMP_VALID
 	int _5v_comp_valid_fd {-1};
 #endif


### PR DESCRIPTION
## Describe problem solved by this pull request
ADS1115 wasn't working as a power monitor for the FMU

## Describe your solution
This commit starts both the ADS1115 and the internal ADC so that both battery_status and system_power topics are published.
This is how to enable the ADS1115 as power monitor:
BAT1_SOURCE = Power Module (default)
ADC_ADS1115_EN = 1
reboot (and restart AMC or QGC to reload the parameters list)
BAT1_I_CHANNEL = The channel where you connected the analog current reference (either 0 or 1)
BAT1_V_CHANNEL = The channel where you connected the analog voltage reference (either 1 or 0)
BAT1_V_DIV = Given by the manufacturer of the power module
BAT1_A_PER_V = Given by the manufacturer of the power module

## Test data / coverage
Not tested yet. I'll add more context once it's tested