### PR TITLE
Add RTL after GNSS loss

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4261,6 +4261,15 @@ void Commander::estimator_check()
 			events::send(events::ID("commander_gps_lost"), {events::Log::Critical, events::LogInternal::Info},
 				     "GPS no longer valid");
 		}
+
+	} else if (!condition_gps_position_was_valid && _vehicle_status_flags.gps_position_valid) {
+
+		// report GPS valid if flying and global position is (still) valid
+		if (!_vehicle_land_detected.landed && _vehicle_status_flags.global_position_valid) {
+			mavlink_log_warning(&_mavlink_log_pub, "GPS valid\t");
+			events::send(events::ID("commander_gps_valid_in_flight"), {events::Log::Warning, events::LogInternal::Info},
+				     "GPS valid");
+		}
 	}
 }
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -260,7 +260,9 @@ private:
 		(ParamInt<px4::params::COM_FLT_TIME_MAX>) _param_com_flt_time_max,
 		(ParamFloat<px4::params::COM_WIND_MAX>) _param_com_wind_max,
 
-		(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time
+		(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time,
+
+		(ParamBool<px4::params::COM_GNSS_IVD_RTL>) _param_com_gnss_ivd_rtl
 	)
 
 	// optional parameters

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1090,3 +1090,16 @@ PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, -1);
  * @unit m/s
  */
 PARAM_DEFINE_FLOAT(COM_WIND_MAX, -1.f);
+
+/**
+ * Trigger RTL when GNSS gets invalid.
+ *
+ * Even after the loss of GNSS sensoring capabilities on the vehicle, its position can still be estimated
+ * by relying on the remaining sensor data. As the quality of the estimate in that case though deteriorates
+ * with time, it is recommended to start returning to launch as soon as the GNSS failure is detected. By setting
+ * this parameter to true, this is done automatically for Mission, Loiter and Position flight mode.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_GNSS_IVD_RTL, 1);


### PR DESCRIPTION

## Describe problem solved by this pull request
Currently there is just a warning when GPS is declared invalid (see https://github.com/PX4/PX4-Autopilot/pull/19875). Plus there is no info when the GNSS data is valid again. As the recommended action in case of GNSS loss is to return to home, it would be cool if the systems does so automatically. 

## Describe your solution
- Add info message when GNSS is declared valid in flight (usually that means that previously it was declared invalid, unless the user has taken off without a valid GNSS --> in that case I think it's also beneficial to get notified).
- Add functionality to automatically trigger RTL if GNSS is invalid, global position though still valid. Only applied in AUTO_MISSION, AUTO_LOITER and MANUAL_POSITION modes for now. Controllable through boolean param COM_GNSS_IVD_RTL, enabled by default. 

Note: doesn't change UX on hovering systems without alternative position estimation sensors (like optical flow), as there the global position is declared invalid instantly after a GNSS invalidation. Mainly targets systems with wings as the dead-reckoning capabilities on those platforms is allowing for a couple of minutes of flying in GNSS-less mode with reasonable position estimate error. 

We should think about the threshold for 1) GNSS-lost warning (currently 3s), and 2) RTL triggering (currently done at the same time as the warning). Maybe increasing it to 10s is reasonable? Maybe needs to be exposed as a parameter?

## Test data / coverage
SITL tested on the plane (`make px4_sitl gazebo_plane`
, GPS failure can be triggered by typing `failure gps off`)
 