### PR TITLE
Remove duplicate failure detector status from vehicle status

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -58,18 +58,6 @@ uint8 NAVIGATION_STATE_ORBIT = 21               # Orbit in a circle
 uint8 NAVIGATION_STATE_AUTO_VTOL_TAKEOFF = 22   # Takeoff, transition, establish loiter
 uint8 NAVIGATION_STATE_MAX = 23
 
-# Bitmask of detected failures
-uint16 failure_detector_status
-uint16 FAILURE_NONE = 0
-uint16 FAILURE_ROLL = 1              # (1 << 0)
-uint16 FAILURE_PITCH = 2             # (1 << 1)
-uint16 FAILURE_ALT = 4               # (1 << 2)
-uint16 FAILURE_EXT = 8               # (1 << 3)
-uint16 FAILURE_ARM_ESC = 16          # (1 << 4)
-uint16 FAILURE_BATTERY = 32          # (1 << 5)
-uint16 FAILURE_IMBALANCED_PROP = 64  # (1 << 6)
-uint16 FAILURE_MOTOR = 128           # (1 << 7)
-
 uint8 hil_state
 uint8 HIL_STATE_OFF = 0
 uint8 HIL_STATE_ON = 1

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.cpp
@@ -39,7 +39,8 @@ constexpr bool
 ArmStateMachine::arming_transitions[vehicle_status_s::ARMING_STATE_MAX][vehicle_status_s::ARMING_STATE_MAX];
 
 transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &status,
-		const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
+		const vehicle_control_mode_s &control_mode, const failure_detector_status_s failure_detector_status,
+		const bool safety_button_available, const bool safety_off,
 		const arming_state_t new_arming_state, actuator_armed_s &armed, const bool fRunPreArmChecks,
 		orb_advert_t *mavlink_log_pub, vehicle_status_flags_s &status_flags,
 		arm_disarm_reason_t calling_reason)
@@ -68,6 +69,7 @@ transition_result_t ArmStateMachine::arming_state_transition(vehicle_status_s &s
 		    && (_arm_state != vehicle_status_s::ARMING_STATE_IN_AIR_RESTORE)) {
 
 			if (!PreFlightCheck::preflightCheck(mavlink_log_pub, status, status_flags, control_mode,
+							    failure_detector_status,
 							    true, // report_failures
 							    safety_button_available, safety_off,
 							    true)) { // is_arm_attempt

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.hpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachine.hpp
@@ -55,6 +55,7 @@ public:
 
 	transition_result_t
 	arming_state_transition(vehicle_status_s &status, const vehicle_control_mode_s &control_mode,
+				const failure_detector_status_s failure_detector_status,
 				const bool safety_button_available, const bool safety_off, const arming_state_t new_arming_state,
 				actuator_armed_s &armed, const bool fRunPreArmChecks, orb_advert_t *mavlink_log_pub,
 				vehicle_status_flags_s &status_flags,

--- a/src/modules/commander/Arming/ArmStateMachine/ArmStateMachineTest.cpp
+++ b/src/modules/commander/Arming/ArmStateMachine/ArmStateMachineTest.cpp
@@ -257,11 +257,13 @@ TEST(ArmStateMachineTest, ArmingStateTransitionTest)
 		status_flags.circuit_breaker_engaged_power_check = true;
 
 		vehicle_control_mode_s control_mode{};
+		failure_detector_status_s failure_detector_status{};
 
 		// Attempt transition
 		transition_result_t result = arm_state_machine.arming_state_transition(
 						     status,
 						     control_mode,
+						     failure_detector_status,
 						     test->safety_button_available,
 						     test->safety_off,
 						     test->requested_state,

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -52,6 +52,7 @@ static constexpr unsigned max_mandatory_baro_count = 1;
 
 bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				    vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
+				    const failure_detector_status_s failure_detector_status,
 				    bool report_failures,
 				    const bool safety_button_available, const bool safety_off,
 				    const bool is_arm_attempt)
@@ -206,11 +207,7 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 		}
 	}
 
-	/* ---- Failure Detector ---- */
-	if (!failureDetectorCheck(mavlink_log_pub, status, report_failures)) {
-		failed = true;
-	}
-
+	failed = failed || !failureDetectorCheck(mavlink_log_pub, failure_detector_status, report_failures);
 	failed = failed || !manualControlCheck(mavlink_log_pub, report_failures);
 	failed = failed || !modeCheck(mavlink_log_pub, report_failures, status);
 	failed = failed || !cpuResourceCheck(mavlink_log_pub, report_failures);

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -41,6 +41,7 @@
 #pragma once
 
 #include <uORB/uORB.h>
+#include <uORB/topics/failure_detector_status.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status_flags.h>
 #include <uORB/topics/vehicle_status.h>
@@ -64,6 +65,7 @@ public:
 	**/
 	static bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 				   vehicle_status_flags_s &status_flags, const vehicle_control_mode_s &control_mode,
+				   const failure_detector_status_s failure_detector_status,
 				   bool reportFailures,
 				   const bool safety_button_available, const bool safety_off,
 				   const bool is_arm_attempt = false);
@@ -95,7 +97,8 @@ private:
 	static bool powerCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail);
 	static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_status, const bool report_fail);
 	static bool ekf2CheckSensorBias(orb_advert_t *mavlink_log_pub, const bool report_fail);
-	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status, const bool report_fail);
+	static bool failureDetectorCheck(orb_advert_t *mavlink_log_pub, const failure_detector_status_s failure_detector_status,
+					 const bool report_fail);
 	static bool manualControlCheck(orb_advert_t *mavlink_log_pub, const bool report_fail);
 	static bool modeCheck(orb_advert_t *mavlink_log_pub, const bool report_fail, const vehicle_status_s &status);
 	static bool airframeCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status);

--- a/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/failureDetectorCheck.cpp
@@ -35,34 +35,35 @@
 
 #include <systemlib/mavlink_log.h>
 
-bool PreFlightCheck::failureDetectorCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
+bool PreFlightCheck::failureDetectorCheck(orb_advert_t *mavlink_log_pub,
+		const failure_detector_status_s failure_detector_status,
 		const bool report_fail)
 {
-	if (status.failure_detector_status != vehicle_status_s::FAILURE_NONE) {
-		if (report_fail) {
-			if (status.failure_detector_status & vehicle_status_s::FAILURE_ROLL) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Roll failure detected");
-			}
-
-			if (status.failure_detector_status & vehicle_status_s::FAILURE_PITCH) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Pitch failure detected");
-			}
-
-			if (status.failure_detector_status & vehicle_status_s::FAILURE_ALT) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Altitude failure detected");
-			}
-
-			if (status.failure_detector_status & vehicle_status_s::FAILURE_EXT) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Parachute failure detected");
-			}
-
-			if (status.failure_detector_status & vehicle_status_s::FAILURE_ARM_ESC) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: ESC failure detected");
-			}
+	if (report_fail) {
+		if (failure_detector_status.fd_roll) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Roll failure detected");
 		}
 
-		return false;
+		if (failure_detector_status.fd_pitch) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Pitch failure detected");
+		}
+
+		if (failure_detector_status.fd_alt) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Altitude failure detected");
+		}
+
+		if (failure_detector_status.fd_ext) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Parachute failure detected");
+		}
+
+		if (failure_detector_status.fd_arm_escs) {
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: ESC failure detected");
+		}
 	}
 
-	return true;
+	return !failure_detector_status.fd_roll
+	       && !failure_detector_status.fd_pitch
+	       && !failure_detector_status.fd_alt
+	       && !failure_detector_status.fd_ext
+	       && !failure_detector_status.fd_arm_escs;
 }

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -164,6 +164,22 @@ FailureDetector::FailureDetector(ModuleParams *parent) :
 {
 }
 
+const failure_detector_status_s FailureDetector::getFailureDetectorStatus() const
+{
+	failure_detector_status_s failure_detector_status{};
+	failure_detector_status.fd_roll = getStatusFlags().roll;
+	failure_detector_status.fd_pitch = getStatusFlags().pitch;
+	failure_detector_status.fd_alt = getStatusFlags().alt;
+	failure_detector_status.fd_ext = getStatusFlags().ext;
+	failure_detector_status.fd_arm_escs = getStatusFlags().arm_escs;
+	failure_detector_status.fd_battery = getStatusFlags().battery;
+	failure_detector_status.fd_imbalanced_prop = getStatusFlags().imbalanced_prop;
+	failure_detector_status.fd_motor = getStatusFlags().motor;
+	failure_detector_status.imbalanced_prop_metric = getImbalancedPropMetric();
+	failure_detector_status.motor_failure_mask = getMotorFailures();
+	return failure_detector_status;
+}
+
 bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode)
 {
 	_failure_injector.update();

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -53,6 +53,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_motors.h>
+#include <uORB/topics/failure_detector_status.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
@@ -103,6 +104,7 @@ public:
 	bool update(const vehicle_status_s &vehicle_status, const vehicle_control_mode_s &vehicle_control_mode);
 	const failure_detector_status_u &getStatus() const { return _status; }
 	const decltype(failure_detector_status_u::flags) &getStatusFlags() const { return _status.flags; }
+	const failure_detector_status_s getFailureDetectorStatus() const;
 	float getImbalancedPropMetric() const { return _imbalanced_prop_lpf.getState(); }
 	uint16_t getMotorFailures() const { return _motor_failure_esc_timed_out_mask | _motor_failure_esc_under_current_mask; }
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -70,11 +70,11 @@
 #include <uORB/topics/actuator_servos.h>
 #include <uORB/topics/actuator_servos_trim.h>
 #include <uORB/topics/control_allocator_status.h>
+#include <uORB/topics/failure_detector_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_torque_setpoint.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
-#include <uORB/topics/failure_detector_status.h>
 
 class ControlAllocator : public ModuleBase<ControlAllocator>, public ModuleParams, public px4::ScheduledWorkItem
 {


### PR DESCRIPTION
## Describe problem solved by this pull request
Addressing https://github.com/PX4/PX4-Autopilot/pull/19895#discussion_r918101617 without deviating the pr.

## Describe your solution
I removed the `failure_detector_status` from the `vehicle_status` message because it's duplicate to the separate `failure_detector_status` message.

## Test data / coverage
Not tested. It's a refactor with hopefully no mistakes in logic adaption.