### PR TITLE
Fix busy loop in gps module when using RTCM

### DIFF
--- a/msg/gps_inject_data.msg
+++ b/msg/gps_inject_data.msg
@@ -2,7 +2,7 @@ uint64 timestamp		# time since system start (microseconds)
 
 uint32 device_id                # unique device ID for the sensor that does not change between power cycles
 
-uint8 len                       # length of data
+uint16 len                       # length of data
 uint8 flags                     # LSB: 1=fragmented
 uint8[300] data                 # data to write to GPS device (RTCM message)
 


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
RTCM data message length was increased to 300 bytes without changing data type of integer holding the length.
This caused an overflow which lead to a busy loop in the gps driver.

## Describe your solution
Use a uint16.

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
