### PR TITLE
Enable GPS Blending by default

### DIFF
--- a/src/modules/sensors/vehicle_gps_position/params.c
+++ b/src/modules/sensors/vehicle_gps_position/params.c
@@ -46,7 +46,7 @@
  * @bit 1 use hpos accuracy
  * @bit 2 use vpos accuracy
  */
-PARAM_DEFINE_INT32(SENS_GPS_MASK, 0);
+PARAM_DEFINE_INT32(SENS_GPS_MASK, 7);
 
 /**
  * Multi GPS Blending Time Constant


### PR DESCRIPTION
## Describe problem solved by this pull request
When using multiple GPS without blending enabled, the sensors module will select one GPS to use. This can result in vehicle_gps having discontinuities if the data from each GPS isn't similar.

When using Moving Baseline using CAN RTK GPS, such as the ARK RTK GPS, this can result in the second uorb instance being the Rover that is outputting the heading. When the selected GPS is the Moving Base, the heading output from the Rover isn't used. With blending enabled, the heading is always used.

Here is an example where the selected GPS changed back and forth causing an EKF altitude error.
![image](https://user-images.githubusercontent.com/2019539/178577230-57233449-a03c-4bd2-90c4-f0fa6fb9bd99.png)
![image](https://user-images.githubusercontent.com/2019539/178577603-4d9470fa-cd5a-476d-96dc-634824a14051.png)

## Describe your solution
With GPS blending enabled, the blended output results in improved flight performance. 

Does anyone have thoughts on the default of using speed, hpos, and vpos?

![image](https://user-images.githubusercontent.com/2019539/178577743-d4a5f04f-bb86-4944-90da-83a9eb864909.png)
