### PR TITLE
Initial version of log history support.

### DIFF
--- a/platforms/common/include/px4_platform_common/log.h
+++ b/platforms/common/include/px4_platform_common/log.h
@@ -131,6 +131,7 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 __attribute__((format(printf, 3, 4)));
 __EXPORT void px4_log_raw(int level, const char *fmt, ...)
 __attribute__((format(printf, 2, 3)));
+__EXPORT void px4_log_history(FILE *out);
 
 #if __GNUC__
 // Allow empty format strings.

--- a/platforms/common/include/px4_platform_common/log_history.h
+++ b/platforms/common/include/px4_platform_common/log_history.h
@@ -1,0 +1,68 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_platform_common/px4_config.h>
+
+#if defined(BOARD_ENABLE_LOG_HISTORY)
+#include <stdio.h>
+#include <px4_platform_common/sem.h>
+
+#ifndef BOARD_LOG_HISTORY_SIZE
+#define BOARD_LOG_HISTORY_SIZE (1024*4) // default buffer size
+#endif
+
+class LogHistory
+{
+public:
+	LogHistory() { px4_sem_init(&_lock, 0, 1); }
+	~LogHistory() { px4_sem_destroy(&_lock); }
+
+	void write(const char *buffer);
+	void print(FILE *out);
+
+private:
+	void lock() { do {} while (px4_sem_wait(&_lock) != 0); }
+	void unlock() { px4_sem_post(&_lock); }
+
+	int size();
+	int read(char *buffer, int buffer_length, int *offset);
+
+	char _log_history[BOARD_LOG_HISTORY_SIZE];
+	int _head{0};
+	int _tail{0};
+	px4_sem_t _lock;
+};
+
+#endif

--- a/platforms/common/px4_log.cpp
+++ b/platforms/common/px4_log.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #include <px4_platform_common/log.h>
+#include <px4_platform_common/log_history.h>
 #if defined(__PX4_POSIX)
 #include <px4_daemon/server_io.h>
 #endif
@@ -49,6 +50,10 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/log_message.h>
 #include <drivers/drv_hrt.h>
+
+#if defined(BOARD_ENABLE_LOG_HISTORY)
+static LogHistory g_log_history;
+#endif
 
 static orb_advert_t orb_log_message_pub = nullptr;
 
@@ -155,6 +160,25 @@ __EXPORT void px4_log_modulename(int level, const char *module_name, const char 
 
 		fputs(buf, out);
 
+#if defined(BOARD_ENABLE_LOG_HISTORY)
+
+#if defined(PX4_LOG_COLORIZED_OUTPUT)
+
+		// No color formatting for log history
+		if (use_color) {
+			pos = snprintf(buf, max_length, __px4__log_level_fmt, __px4_log_level_str[level]);
+			pos += snprintf(buf + pos, math::max(max_length - pos, (ssize_t)0), __px4__log_modulename_pfmt, module_name);
+			va_start(argptr, fmt);
+			pos += vsnprintf(buf + pos, math::max(max_length - pos, (ssize_t)0), fmt, argptr);
+			va_end(argptr);
+			pos += sprintf(buf + math::min(pos, max_length - (ssize_t)1), "\n");
+			buf[max_length] = 0; // ensure NULL termination
+		}
+
+#endif
+		g_log_history.write(buf);
+#endif // BOARD_ENABLE_LOG_HISTORY
+
 #if defined(CONFIG_ARCH_BOARD_PX4_SITL)
 		// Without flushing it's tricky to see stdout output when PX4 is started by
 		// a script like for the MAVSDK tests.
@@ -236,5 +260,38 @@ __EXPORT void px4_log_raw(int level, const char *fmt, ...)
 		buf[max_length] = 0;
 
 		fputs(buf, out);
+
+#if defined(BOARD_ENABLE_LOG_HISTORY)
+
+#if defined(PX4_LOG_COLORIZED_OUTPUT)
+
+		// No color formatting for log history
+		if (use_color) {
+			va_start(argptr, fmt);
+			pos = vsnprintf(buf, max_length, fmt, argptr);
+			va_end(argptr);
+
+			if (pos > max_length) {
+				// preserve newline if necessary
+				if (fmt[strlen(fmt) - 1] == '\n') {
+					buf[max_length - 1] = '\n';
+				}
+			}
+
+			buf[max_length] = 0; // ensure NULL termination
+		}
+
+#endif
+		g_log_history.write(buf);
+#endif // BOARD_ENABLE_LOG_HISTORY
 	}
+}
+
+__EXPORT void px4_log_history(FILE *out)
+{
+
+#if defined(BOARD_ENABLE_LOG_HISTORY)
+
+	g_log_history.print(out);
+#endif // BOARD_ENABLE_LOG_HISTORY
 }

--- a/platforms/common/px4_log_history.cpp
+++ b/platforms/common/px4_log_history.cpp
@@ -1,0 +1,147 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform_common/log_history.h>
+
+#if defined(BOARD_ENABLE_LOG_HISTORY)
+#include <string.h>
+
+void LogHistory::print(FILE *out)
+{
+	const int buffer_length = 512;
+	char buffer[buffer_length];
+	int offset = -1;
+
+	int total_size_read = 0;
+
+	do {
+		int read_size = read(buffer, buffer_length, &offset);
+
+		if (read_size <= 0) {
+			break;
+		}
+
+		fwrite(buffer, 1, read_size, out);
+
+		if (read_size < buffer_length) {
+			break;
+		}
+
+		total_size_read += read_size;
+	} while (total_size_read < BOARD_LOG_HISTORY_SIZE);
+}
+
+// Log a null terminated string to the circular history buffer.
+void LogHistory::write(const char *buffer)
+{
+	lock(); // same rule as for printf: this cannot be used from IRQ handlers
+
+	int i = 0;
+
+	while (buffer[i] != '\0') {
+
+		_log_history[_tail] = buffer[i++];
+		_tail = (_tail + 1) % BOARD_LOG_HISTORY_SIZE;
+
+		if (_tail == _head) {
+			_head = (_head + 1) % BOARD_LOG_HISTORY_SIZE;
+		}
+	}
+
+	unlock();
+}
+
+int LogHistory::size()
+{
+	lock();
+	int size;
+
+	if (_head <= _tail) {
+		size = _tail - _head;
+
+	} else {
+		size = BOARD_LOG_HISTORY_SIZE - (_head - _tail);
+	}
+
+	unlock();
+	return size;
+}
+
+int LogHistory::read(char *buffer, int buffer_length, int *offset)
+{
+	lock();
+
+	if (*offset == -1) {
+		*offset = _head;
+	}
+
+	int size = 0;
+
+	if (*offset < _tail) {
+		size = _tail - *offset;
+
+		if (size > buffer_length) {
+			size = buffer_length;
+		}
+
+		memcpy(buffer, _log_history + *offset, size);
+
+	} else if (_tail < *offset) {
+		size = BOARD_LOG_HISTORY_SIZE - *offset;
+
+		if (size > buffer_length) {
+			size = buffer_length;
+		}
+
+		memcpy(buffer, _log_history + *offset, size);
+		buffer += size;
+		buffer_length -= size;
+
+		int size_secondary = _tail;
+
+		if (size_secondary > buffer_length) {
+			size_secondary = buffer_length;
+		}
+
+		if (size_secondary > 0) {
+			memcpy(buffer, _log_history, size_secondary);
+			size += size_secondary;
+		}
+	}
+
+	unlock();
+	*offset = (*offset + size) % BOARD_LOG_HISTORY_SIZE;
+	return size;
+}
+
+#endif

--- a/src/systemcmds/hist/CMakeLists.txt
+++ b/src/systemcmds/hist/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2022 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,34 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-
-set(SRCS)
-
-if(NOT "${PX4_BOARD}" MATCHES "io-v2" AND NOT "${PX4_BOARD_LABEL}" MATCHES "bootloader")
-	list(APPEND SRCS
-		px4_log.cpp
-		px4_log_history.cpp
+px4_add_module(
+	MODULE systemcmds__hist
+	MAIN hist
+	SRCS
+		hist.cpp
 	)
-endif()
-
-add_library(px4_platform
-	board_identity.c
-	events.cpp
-	external_reset_lockout.cpp
-	i2c.cpp
-	i2c_spi_buses.cpp
-	module.cpp
-	px4_getopt.c
-	px4_cli.cpp
-	shutdown.cpp
-	spi.cpp
-	${SRCS}
-)
-target_link_libraries(px4_platform prebuild_targets px4_work_queue)
-
-if (NOT "${PX4_BOARD}" MATCHES "io-v2")
-	add_subdirectory(uORB)
-endif()
-
-add_subdirectory(px4_work_queue)
-add_subdirectory(work_queue)

--- a/src/systemcmds/hist/Kconfig
+++ b/src/systemcmds/hist/Kconfig
@@ -1,0 +1,5 @@
+menuconfig SYSTEMCMDS_HIST
+	bool "hist"
+	default n
+	---help---
+		Enable support for hist

--- a/src/systemcmds/hist/hist.cpp
+++ b/src/systemcmds/hist/hist.cpp
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/module.h>
+
+#ifndef BOARD_ENABLE_LOG_HISTORY
+#error "This module can only be used on boards that enable BOARD_ENABLE_LOG_HISTORY"
+#endif
+
+extern "C" {
+	__EXPORT int hist_main(int argc, char *argv[]);
+}
+
+static void usage()
+{
+	PRINT_MODULE_DESCRIPTION("Command-line tool to show the px4 message history. There are no arguments.");
+	PRINT_MODULE_USAGE_NAME_SIMPLE("hist", "command");
+}
+
+
+int hist_main(int argc, char *argv[])
+{
+	if (argc > 1) {
+		usage();
+		return 0;
+	}
+
+	px4_log_history(stdout);
+
+	return 0;
+}


### PR DESCRIPTION
## Describe problem solved by this pull request
Added a log history to allow the ability to display the px4 log messages through a new "hist" command for posix targets.  Initial version looking for feedback.  

## Describe possible alternatives
A console_buffer could achieve the same functionality.

## Test data / coverage
Tested on SITL and a posix based flight controller.  Some status and error messages throughout the code base use the printf()s and are not captured in this log history implementation.

## Additional context
This was a follow-up to pr #19851.