### PR TITLE
sagetech_mxs: don't run by default

### DIFF
--- a/src/drivers/transponder/sagetech_mxs/module.yaml
+++ b/src/drivers/transponder/sagetech_mxs/module.yaml
@@ -4,5 +4,5 @@ serial_config:
       port_config_param:
         name: MXS_SER_CFG
         group: Transponder
-        default: TEL2
+        default: 0
       label: Sagetech MXS Serial Port


### PR DESCRIPTION
I noticed the sagetech mxs was running by default in https://github.com/PX4/PX4-Autopilot/issues/19831#issuecomment-1183327062.

FYI @faberc

