### PR TITLE
battery: skip charge estimation if N cells is 0

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -206,6 +206,10 @@ void Battery::sumDischarged(const hrt_abstime &timestamp, float current_a)
 
 float Battery::calculateStateOfChargeVoltageBased(const float voltage_v, const float current_a)
 {
+	if (_params.n_cells == 0) {
+		return -1.0f;
+	}
+
 	// remaining battery capacity based on voltage
 	float cell_voltage = voltage_v / _params.n_cells;
 


### PR DESCRIPTION
This triggers the undefined behavior fuzzer, so let's try to fix it.

https://github.com/PX4/PX4-Autopilot/runs/7315277790?check_suite_focus=true#step:5:51