### PR TITLE
README: Project governance and trademarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,11 @@ Additional information about supported hardware can be found in [PX4 user Guide 
 ## Project Roadmap
 
 A high level project roadmap is available [here](https://github.com/orgs/PX4/projects/25).
+
+## Project Governance
+
+The PX4 Autopilot project including all of its trademarks is hosted under [Dronecode](https://www.dronecode.org/), part of the Linux Foundation.
+
+<a href="https://www.dronecode.org/" style="padding:20px" ><img src="https://mavlink.io/assets/site/logo_dronecode.png" alt="Dronecode Logo" width="110px"/></a>
+<a href="https://www.linuxfoundation.org/projects" style="padding:20px;"><img src="https://mavlink.io/assets/site/logo_linux_foundation.png" alt="Linux Foundation Logo" width="80px" /></a>
+<div style="padding:10px">&nbsp;</div>


### PR DESCRIPTION
We need to ensure the Dronecode logo is prominently displayed
and linked to the PX4 brand for trademark protection of PX4 and Dronecode.
If you have any questions about this, please feel free to reach out directly to me.