### PR TITLE
Double the allocated stack size of 64-bit NuttX built-in modules

### DIFF
--- a/cmake/px4_add_module.cmake
+++ b/cmake/px4_add_module.cmake
@@ -202,6 +202,9 @@ function(px4_add_module)
 	set_target_properties(${MODULE} PROPERTIES STACK_MAX ${STACK_MAX})
 
 	if(${PX4_PLATFORM} STREQUAL "nuttx")
+		# double the allocated stacks for 64 bit nuttx targets
+		set(STACK_MAIN "${STACK_MAIN} * (__SIZEOF_POINTER__ >> 2)")
+
 		target_compile_options(${MODULE} PRIVATE -Wframe-larger-than=${STACK_MAX})
 	endif()
 


### PR DESCRIPTION
Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Describe problem solved by this pull request

We are running PX4&NuttX on 64-bit RISC-V targets. The need for stack is larger on 64 bits, and this is taken care in many places already with PX4_STACK_ADJUSTED() macro.

However, with built-in modules "main" functions this is not yet handled. The stack size comes from STACK_MAIN CMake variable, which has got either a default value, or it can be set per-module.

Just recently I figured out that we are getting some instability & random crashes due to some of these modules crashing / corrupting memory at startup (especially sensors module, maybe some others as well). This was due to stack overflows.

Just adjust the STACK_MAIN directly in px4_add_module, using the same mechanism as what PX4_STACK_ADJUSTED macro does. Since STACK_MAX is directly given to linker, it needs to be a plain number; so it is not adjusted. However, I feel that it is fine to have the maximum frame size half of the allocated stack anyways.

## Describe possible alternatives
1) Adjust the stack sizes later in generation of builtin_list.h in platforms/nuttx/NuttX/CMakeLists.txt
2) Directly use PX4_STACK_ADJUSTED in either px4_add_module or in platforms/nuttx/NuttX/CMakeLists.txt

For 1), I felt it simpler to handle the variable in the same place where also the default & max are handled.
For 2) it gets complicated since the nuttx builtins are being compiled in-place in platforms/nuttx/NuttX/apps and you'd need to include the px4-specific header (posix.h) containing the PX4_STACK_ADJUSTED() macro in builtin_list.h. Also the posix.h contains things which are not needed there.

## Test data / coverage
It was tested on Microchip PolarFire SoC based FC research platform, and monitored that the stacks are now large enough. On 32-bit platforms it was just reviewed that it should not change anything

