### PR TITLE
Various parameter default/vehicle default/meta-data changes 

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
@@ -13,8 +13,6 @@ param set-default FW_LND_ANG 8
 
 param set-default FW_L1_PERIOD 12
 
-param set-default FW_MAN_P_MAX 30
-
 param set-default FW_PR_P 0.9
 param set-default FW_PR_FF 0.2
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
@@ -16,7 +16,6 @@ param set-default FW_L1_PERIOD 12
 param set-default FW_PR_P 0.9
 param set-default FW_PR_FF 0.2
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
 
 param set-default FW_RR_FF 0.1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -13,8 +13,6 @@ param set-default FW_LND_ANG 8
 
 param set-default FW_L1_PERIOD 12
 
-param set-default FW_MAN_P_MAX 30
-
 param set-default FW_PR_P 0.9
 param set-default FW_PR_FF 0.2
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -16,7 +16,6 @@ param set-default FW_L1_PERIOD 12
 param set-default FW_PR_P 0.9
 param set-default FW_PR_FF 0.2
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
 
 param set-default FW_RR_FF 0.1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -49,7 +49,6 @@ param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_FUNC8 203
 
 param set-default FW_L1_PERIOD 12
-param set-default FW_MAN_P_MAX 30
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -52,7 +52,6 @@ param set-default FW_L1_PERIOD 12
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
 param set-default FW_RR_FF 0.1
 param set-default FW_RR_P 0.3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -44,7 +44,6 @@ param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_REV 96 # invert both elevons
 
 param set-default FW_L1_PERIOD 12
-param set-default FW_MAN_P_MAX 30
 param set-default FW_PR_I 0.2
 param set-default FW_PR_P 0.2
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -47,7 +47,6 @@ param set-default FW_L1_PERIOD 12
 param set-default FW_PR_I 0.2
 param set-default FW_PR_P 0.2
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
 param set-default FW_RR_P 0.2
 param set-default FW_THR_TRIM 0.33

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -59,7 +59,6 @@ param set-default FW_L1_PERIOD 12
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
 param set-default FW_RR_FF 0.1
 param set-default FW_RR_P 0.3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -56,7 +56,6 @@ param set-default PWM_MAIN_FUNC10 202
 param set-default PWM_MAIN_FUNC11 203
 
 param set-default FW_L1_PERIOD 12
-param set-default FW_MAN_P_MAX 30
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
@@ -8,7 +8,6 @@
 . ${R}etc/init.d/rc.vtol_defaults
 
 param set-default FW_L1_PERIOD 12
-param set-default FW_MAN_P_MAX 30
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
@@ -11,7 +11,6 @@ param set-default FW_L1_PERIOD 12
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MAX 32
 param set-default FW_P_LIM_MIN -15
 param set-default FW_RR_FF 0.1
 param set-default FW_RR_P 0.3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17001_tf-g1
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17001_tf-g1
@@ -38,7 +38,6 @@ param set-default FW_P_LIM_MAX 25
 param set-default FW_P_LIM_MIN -5
 param set-default FW_R_LIM 30
 
-param set-default FW_MAN_P_MAX 30.0
 param set-default FW_MAN_R_MAX 30.0
 
 param set-default FW_THR_TRIM 0.8

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
@@ -44,7 +44,6 @@ param set-default FW_P_LIM_MAX 25
 param set-default FW_P_LIM_MIN -5
 param set-default FW_R_LIM 30
 
-param set-default FW_MAN_P_MAX 30.0
 param set-default FW_MAN_R_MAX 30.0
 
 param set-default FW_THR_CRUISE 0.8

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -45,7 +45,6 @@ param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_Z_VEL_P_ACC 12
 param set-default MPC_Z_VEL_I_ACC 3
-param set-default MPC_Z_VEL_MAX_DN 1.5
 
 param set-default NAV_ACC_RAD 5
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -31,7 +31,6 @@ param set-default MC_YAWRATE_I 0.04
 param set-default MC_YAWRATE_MAX 40
 
 param set-default MPC_ACC_HOR_MAX 2
-param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_LAND_SPEED 0.8
 param set-default MPC_YAWRAUTO_MAX 40
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -34,8 +34,6 @@ param set-default FW_ACRO_X_MAX   270
 param set-default FW_ACRO_Y_MAX   270
 param set-default FW_ACRO_Z_MAX   180
 param set-default FW_PSP_OFF  5
-param set-default FW_P_LIM_MAX    30
-param set-default FW_P_LIM_MIN    -30
 param set-default FW_RR_FF    0.33
 param set-default FW_RR_P 0.11
 
@@ -74,4 +72,4 @@ then
 	set PWM_OUT 1234
 else
 	set PWM_OUT 3456
-fi	
+fi

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -55,7 +55,6 @@ param set-default FW_T_SINK_MIN 1
 param set-default FW_T_VERT_ACC 6
 param set-default FW_THR_TRIM 0.70
 param set-default FW_THR_SLEW_MAX 1
-param set-default FW_MAN_P_MAX 30
 param set-default FW_P_LIM_MAX 15
 param set-default FW_P_LIM_MIN -25
 param set-default FW_P_RMAX_NEG 45

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -90,7 +90,6 @@ param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_LAND_SPEED 1.2
 param set-default MPC_TILTMAX_LND 35
 param set-default MPC_Z_VEL_MAX_UP 1.5
-param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_HOLD_MAX_XY 0.5
 param set-default MPC_HOLD_MAX_Z 0.5
 param set-default MPC_TKO_RAMP_T 0.8

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -31,7 +31,6 @@ param set-default FW_AIRSPD_MAX 30
 param set-default FW_AIRSPD_MIN 19
 param set-default FW_AIRSPD_TRIM 23
 param set-default FW_L1_R_SLEW_MAX 40
-param set-default FW_MAN_P_MAX 30
 param set-default FW_PSP_OFF 3
 param set-default FW_P_LIM_MAX 18
 param set-default FW_P_LIM_MIN -25

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -71,7 +71,6 @@ param set-default MPC_VEL_MANUAL 3
 param set-default MPC_XY_CRUISE 3
 param set-default MPC_XY_VEL_MAX 3.5
 param set-default MPC_YAWRAUTO_MAX 40
-param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_Z_VEL_MAX_UP 2
 
 param set-default NAV_ACC_RAD 3

--- a/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
@@ -28,7 +28,6 @@ param set-default FW_L1_PERIOD 15
 param set-default FW_LND_ANG 15
 param set-default FW_LND_FLALT 8
 param set-default FW_P_LIM_MAX 20
-param set-default FW_P_LIM_MIN -30
 param set-default FW_R_LIM 45
 param set-default FW_PR_FF 0.45
 param set-default FW_PR_P 0.005

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -21,7 +21,6 @@ param set-default HTE_VXY_THR 2.0
 param set-default MIS_DIST_WPS 5000
 
 param set-default MPC_ACC_HOR_MAX 2
-param set-default MPC_TKO_SPEED 1
 param set-default MPC_VEL_MANUAL 3
 param set-default MPC_XY_CRUISE 3
 param set-default MPC_XY_ERR_MAX 5

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -29,8 +29,6 @@ param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_JERK_MAX 4.5
 param set-default MPC_YAW_MODE 4
 
-param set-default NAV_ACC_RAD 3
-
 param set-default PWM_AUX_RATE 50
 param set-default PWM_MAIN_RATE 400
 

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -28,6 +28,14 @@ param set-default MPC_XY_VEL_MAX 8
 param set-default MPC_JERK_MAX 4.5
 param set-default MPC_YAW_MODE 4
 
+# reduce aggressiveness around roll and yaw axis,
+# as VTOLs usually have high intertia and lot af drag due to wings
+param set-default MC_ROLL_P 5
+param set-default MC_ROLLRATE_MAX 120
+param set-default MC_YAW_P 2
+param set-default MC_YAWRATE_MAX 120
+param set-default MPC_MAN_Y_MAX 90
+
 param set-default PWM_AUX_RATE 50
 param set-default PWM_MAIN_RATE 400
 

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -21,10 +21,10 @@ param set-default HTE_VXY_THR 2.0
 param set-default MIS_DIST_WPS 5000
 
 param set-default MPC_ACC_HOR_MAX 2
-param set-default MPC_VEL_MANUAL 3
-param set-default MPC_XY_CRUISE 3
+param set-default MPC_VEL_MANUAL 5
+param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_ERR_MAX 5
-param set-default MPC_XY_VEL_MAX 4
+param set-default MPC_XY_VEL_MAX 8
 param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_JERK_MAX 4.5
 param set-default MPC_YAW_MODE 4

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -25,7 +25,6 @@ param set-default MPC_VEL_MANUAL 5
 param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_ERR_MAX 5
 param set-default MPC_XY_VEL_MAX 8
-param set-default MPC_Z_VEL_MAX_DN 1.5
 param set-default MPC_JERK_MAX 4.5
 param set-default MPC_YAW_MODE 4
 

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -455,7 +455,7 @@ PARAM_DEFINE_FLOAT(FW_MAN_R_MAX, 45.0f);
  * @increment 0.5
  * @group FW Attitude Control
  */
-PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 45.0f);
+PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 30.0f);
 
 /**
  * Flaps setting during take-off

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -239,7 +239,7 @@ PARAM_DEFINE_FLOAT(NPFG_PERIOD_SF, 1.5f);
  * @max 1.0
  * @decimal 2
  * @increment 0.01
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_THR_TRIM, 0.6f);
 
@@ -250,7 +250,7 @@ PARAM_DEFINE_FLOAT(FW_THR_TRIM, 0.6f);
  *
  * @min 0.0
  * @max 1.0
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_THR_SLEW_MAX, 0.0f);
 
@@ -264,7 +264,7 @@ PARAM_DEFINE_FLOAT(FW_THR_SLEW_MAX, 0.0f);
  * @max 0.0
  * @decimal 1
  * @increment 0.5
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -30.0f);
 
@@ -278,7 +278,7 @@ PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -30.0f);
  * @max 60.0
  * @decimal 1
  * @increment 0.5
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_P_LIM_MAX, 30.0f);
 
@@ -308,7 +308,7 @@ PARAM_DEFINE_FLOAT(FW_R_LIM, 50.0f);
  * @max 1.0
  * @decimal 2
  * @increment 0.01
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_THR_MAX, 1.0f);
 
@@ -329,7 +329,7 @@ PARAM_DEFINE_FLOAT(FW_THR_MAX, 1.0f);
  * @max 1.0
  * @decimal 2
  * @increment 0.01
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
 
@@ -349,7 +349,7 @@ PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
  * @max 0.4
  * @decimal 2
  * @increment 0.01
- * @group FW L1 Control
+ * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_THR_IDLE, 0.0f);
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -381,7 +381,7 @@ PARAM_DEFINE_FLOAT(FW_CLMBOUT_DIFF, 10.0f);
  * @max 15.0
  * @decimal 1
  * @increment 0.5
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_ANG, 5.0f);
 
@@ -406,7 +406,7 @@ PARAM_DEFINE_FLOAT(FW_TKO_PITCH_MIN, 10.0f);
  * @min 0.0
  * @decimal 1
  * @increment 0.5
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_FLALT, 0.5f);
 
@@ -425,7 +425,7 @@ PARAM_DEFINE_FLOAT(FW_LND_FLALT, 0.5f);
  * @value 0 Disable the terrain estimate
  * @value 1 Use the terrain estimate to trigger the flare (only)
  * @value 2 Calculate landing glide slope relative to the terrain estimate
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_INT32(FW_LND_USETER, 1);
 
@@ -441,7 +441,7 @@ PARAM_DEFINE_INT32(FW_LND_USETER, 1);
  *
  * @boolean
  *
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_INT32(FW_LND_EARLYCFG, 0);
 
@@ -456,7 +456,7 @@ PARAM_DEFINE_INT32(FW_LND_EARLYCFG, 0);
  * @max 15.0
  * @decimal 1
  * @increment 0.5
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
 
@@ -471,7 +471,7 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
  * @max 45.0
  * @decimal 1
  * @increment 0.5
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
 
@@ -487,7 +487,7 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
  * @max 1.5
  * @decimal 2
  * @increment 0.01
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
 
@@ -503,7 +503,7 @@ PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
  * @min 0.2
  * @max 1.0
  * @increment 0.1
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_THRTC_SC, 1.0f);
 
@@ -1007,7 +1007,7 @@ PARAM_DEFINE_FLOAT(FW_WING_HEIGHT, 0.5);
  * @max 5.0
  * @decimal 1
  * @increment 0.1
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_FL_TIME, 1.0f);
 
@@ -1021,7 +1021,7 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_TIME, 1.0f);
  * @max 1.0
  * @decimal 1
  * @increment 0.1
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_FL_SINK, 0.25f);
 
@@ -1033,7 +1033,7 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_SINK, 0.25f);
  * @max 10.0
  * @decimal 1
  * @increment 1
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_FLOAT(FW_LND_TD_OFF, 3.0);
 
@@ -1052,7 +1052,7 @@ PARAM_DEFINE_FLOAT(FW_LND_TD_OFF, 3.0);
  * @value 0 Disable nudging
  * @value 1 Nudge approach angle
  * @value 2 Nudge approach path
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_INT32(FW_LND_NUDGE, 2);
 
@@ -1073,6 +1073,6 @@ PARAM_DEFINE_INT32(FW_LND_NUDGE, 2);
  * @max 3
  * @bit 0 Abort if terrain is not found
  * @bit 1 Abort if terrain times out (after a first successful measurement)
- * @group FW L1 Control
+ * @group FW Auto Landing
  */
 PARAM_DEFINE_INT32(FW_LND_ABORT, 3);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -266,7 +266,7 @@ PARAM_DEFINE_FLOAT(FW_THR_SLEW_MAX, 0.0f);
  * @increment 0.5
  * @group FW L1 Control
  */
-PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -45.0f);
+PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -30.0f);
 
 /**
  * Maximum pitch angle
@@ -280,7 +280,7 @@ PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -45.0f);
  * @increment 0.5
  * @group FW L1 Control
  */
-PARAM_DEFINE_FLOAT(FW_P_LIM_MAX, 45.0f);
+PARAM_DEFINE_FLOAT(FW_P_LIM_MAX, 30.0f);
 
 /**
  * Maximum roll angle

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -242,7 +242,7 @@ PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_UP, 3.f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_Z_V_AUTO_DN, 1.f);
+PARAM_DEFINE_FLOAT(MPC_Z_V_AUTO_DN, 1.5f);
 
 /**
  * Maximum descent velocity
@@ -257,7 +257,7 @@ PARAM_DEFINE_FLOAT(MPC_Z_V_AUTO_DN, 1.f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_DN, 1.f);
+PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_DN, 1.5f);
 
 /**
  * Proportional gain for horizontal position error


### PR DESCRIPTION
With this PR I try to improve the setup UX though:
- set more reasonable parameter defaults where the case is valid for all vehicle types that use it
- change/add params in the vehicle defaults (only in vtol_default in this case)
- improve parameter meta data 

Most of the param defaults that I touch are params that I change on every single VTOL that I set up, and the annoyance of having to do that was the largest motivation for this PR.

See commit messages for details. I expect the biggest controversy around https://github.com/PX4/PX4-Autopilot/commit/d16270ffb4046fdb6dc9fd7b7430499608c6a422 (@bresch @MaEtUgR ). For MC we had a default of 1m/s descend speed, for VTOL 1.5. My proposal is to globally have it at 1.5m/s.


