### PR TITLE
Small crypto cleanups

### DIFF
--- a/platforms/nuttx/src/px4/common/nuttx_random.c
+++ b/platforms/nuttx/src/px4/common/nuttx_random.c
@@ -41,6 +41,4 @@ size_t px4_get_secure_random(uint8_t *out,
 	arc4random_buf(out, outlen);
 	return outlen;
 }
-#else
-#error CONFIG_CRYPTO_RANDOM_POOL has to be defined
 #endif

--- a/src/drivers/stub_keystore/Kconfig
+++ b/src/drivers/stub_keystore/Kconfig
@@ -1,7 +1,6 @@
 menu "stub_keystore configuration"
 	menuconfig DRIVERS_STUB_KEYSTORE
 	bool "stub_keystore"
-	depends on DRIVERS_SW_CRYPTO
 	default n
 	---help---
 		Enable support for stub_keystore


### PR DESCRIPTION
These are small fixes from the TII master branch;

- It is not necessary to give a compilation error on missing CONFIG_CRYPTO_RANDOM_POOL. Some want's to define their own px4_secure_random function without using NuttX crypto support.
- Allow using stub_keystore with also other crypto backend drivers than sw_crypto