### PR TITLE
vtol_takeoff: reset reposition triplet before handing over to loiter mode

### DIFF
--- a/src/modules/navigator/vtol_takeoff.cpp
+++ b/src/modules/navigator/vtol_takeoff.cpp
@@ -142,6 +142,13 @@ VtolTakeoff::on_active()
 
 		case vtol_takeoff_state::CLIMB: {
 
+				// reset any potentially valid reposition triplet which was not handled
+				// we do this to avoid random loiter locations after switching to loiter mode after this
+				position_setpoint_triplet_s *reposition_triplet = _navigator->get_reposition_triplet();
+				_navigator->reset_position_setpoint(reposition_triplet->previous);
+				_navigator->reset_position_setpoint(reposition_triplet->current);
+				_navigator->reset_position_setpoint(reposition_triplet->next);
+
 				// the VTOL takeoff is done, proceed loitering and upate the navigation state to LOITER
 				_navigator->get_mission_result()->finished = true;
 				_navigator->set_mission_result_updated();


### PR DESCRIPTION
## Describe problem solved by this pull request
VTOL loiters above home after VTOL Takeoff. This issue can be reproduced when doing a VTOL takeoff after having landed as part of RTL mode. During the backtransition in RTL mode we publish a reposition triplet in order to reset cruise speed and throttle. This triplet is never handled anywhere and remains valid. When the VTOL takeoff completes, commander switches to loiter mode which uses this reposition triplet as setpoint.

## Describe your solution
Invalidate reposition triplet once VTOL takeoff navigation mode completes

