### PR TITLE
FW Position control: do not check for validity of position setpoint for mode selection

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -737,8 +737,9 @@ FixedwingPositionControl::updateManualTakeoffStatus()
 }
 
 void
-FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool pos_sp_curr_valid)
+FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now)
 {
+
 	/* only run position controller in fixed-wing mode and during transitions for VTOL */
 	if (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING && !_vehicle_status.in_transition_mode) {
 		_control_mode_current = FW_POSCTRL_MODE_OTHER;
@@ -750,7 +751,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 	_skipping_takeoff_detection = false;
 
 	if (((_control_mode.flag_control_auto_enabled && _control_mode.flag_control_position_enabled) ||
-	     _control_mode.flag_control_offboard_enabled) && pos_sp_curr_valid) {
+	     _control_mode.flag_control_offboard_enabled)) {
 
 		if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
 
@@ -785,8 +786,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now, bool 
 			_control_mode_current = FW_POSCTRL_MODE_AUTO;
 		}
 
-	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_climb_rate_enabled
-		   && pos_sp_curr_valid) {
+	} else if (_control_mode.flag_control_auto_enabled && _control_mode.flag_control_climb_rate_enabled) {
 
 		// reset timer the first time we switch into this mode
 		if (commanded_position_control_mode != FW_POSCTRL_MODE_AUTO_ALTITUDE
@@ -2209,7 +2209,7 @@ FixedwingPositionControl::Run()
 		Vector2d curr_pos(_current_latitude, _current_longitude);
 		Vector2f ground_speed(_local_pos.vx, _local_pos.vy);
 
-		set_control_mode_current(_local_pos.timestamp, _pos_sp_triplet.current.valid);
+		set_control_mode_current(_local_pos.timestamp);
 
 		update_in_air_states(_local_pos.timestamp);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -664,9 +664,8 @@ private:
 	 * May also change the position setpoint type depending on the desired behavior.
 	 *
 	 * @param now Current system time [us]
-	 * @param pos_sp_curr_valid True if the current position setpoint is valid
 	 */
-	void set_control_mode_current(const hrt_abstime &now, bool pos_sp_curr_valid);
+	void set_control_mode_current(const hrt_abstime &now);
 
 	/**
 	 * @brief Compensate trim throttle for air density and vehicle weight.


### PR DESCRIPTION

## Describe problem solved by this pull request
The fixed-wing GPS failure mitigation mode was broken as (seemingly only since recently) `pos_sp_curr_valid` gets invalidated when local position is invalid. That made it up ending up in FW_POSCTRL_MODE_OTHER, resulting in undefined behavior basically. 

## Describe your solution
Removed the check for `pos_sp_curr_valid` and only check the `control_mode.flag_control_*` flags in the fixed-wing position controller mode selection. 
Context: https://github.com/PX4/PX4-Autopilot/issues/18573#issuecomment-962078351. If nobody exactly knows what this additional check is there for let's better remove it and keep the logic simple. Happy to learn about the need for it otherwise, and find an different solution. 

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
SITL tested on VTOL (w/ and w/o NAV_FORCE_VT, making it transition prior to descend), and plane.

