### PR TITLE
serial_test fix when DMA use large buffer

### DIFF
--- a/src/systemcmds/serial_test/serial_test.c
+++ b/src/systemcmds/serial_test/serial_test.c
@@ -574,7 +574,6 @@ static void process_read_data(struct g_mod_t *g_mod, struct cli_args_t *g_cl)
 static void process_write_data(struct g_mod_t *g_mod, struct cli_args_t *g_cl)
 {
 	ssize_t count = 0;
-	int loops = 10;
 	int repeat = (g_cl->_tx_bytes == 0);
 
 	do {
@@ -594,13 +593,11 @@ static void process_write_data(struct g_mod_t *g_mod, struct cli_args_t *g_cl)
 
 			c = 0;
 
-		} else {
-			loops--;
 		}
 
 		count += c;
 
-		if (loops == 0 || c < g_mod->_write_size) {
+		if (c <= g_mod->_write_size) {
 			g_mod->_write_count_value = g_mod->_write_data[c];
 			repeat = 0;
 		}

--- a/src/systemcmds/serial_test/serial_test.c
+++ b/src/systemcmds/serial_test/serial_test.c
@@ -598,7 +598,14 @@ static void process_write_data(struct g_mod_t *g_mod, struct cli_args_t *g_cl)
 		count += c;
 
 		if (c <= g_mod->_write_size) {
-			g_mod->_write_count_value = g_mod->_write_data[c];
+
+			if (c == 0) {
+				g_mod->_write_count_value = g_mod->_write_data[0];
+
+			} else {
+				g_mod->_write_count_value = next_count_value(g_mod->_write_data[c - 1], g_cl->_ascii_range);
+			}
+
 			repeat = 0;
 		}
 	} while (repeat);


### PR DESCRIPTION
## Describe the problem solved by this pull request
Two bugs are fixed:
1) Proper solution for infinity loop when DMA is used
2) Fix the value for the next write that was causing errors. That was working if a number of bytes for send was a module of 256 because data repeated itself and the empty value was 0.
reproducible with `serial_test -e -b 57600 -p /dev/ttyS6 -w 10`

## Describe your solution
1) When using DMA with a buffer larger than bytes that are written `write` function will return the given size. Fixed with including the max size of given data. 
![image](https://user-images.githubusercontent.com/10188706/180401407-406eda5a-fd38-474c-9762-e45540989fa7.png)

2) Calculating the next value before loop exit. 
![image](https://user-images.githubusercontent.com/10188706/180406283-199793a3-7e81-4b71-b8f9-13b092ccdcce.png)


## Describe possible alternatives
For better handling when data was really written, DMA tx interrupt could be implemented. 

## Additional info

If the test is used by TX and RX pin connected together with DMA enabled, take care that the TX buffer is not larger than RX buffer. If this is the case it will override the data in the RX buffer. 
The suggestion is to limit the size of TX bytes with `-w` or to slow down sending Tx data with `-a`