### PR TITLE
Add Euler 3-1-2 rotation for gimbal v1 output #19933

### DIFF
--- a/src/lib/matrix/matrix/Euler.hpp
+++ b/src/lib/matrix/matrix/Euler.hpp
@@ -141,7 +141,127 @@ public:
 
 };
 
+
+template<typename Type>
+class Euler312 : public Vector<Type, 3>
+{
+public:
+	/**
+	 * Standard constructor
+	 */
+	Euler312() = default;
+
+	/**
+	 * Copy constructor
+	 *
+	 * @param other vector to copy
+	 */
+	Euler312(const Vector<Type, 3> &other) :
+		Vector<Type, 3>(other)
+	{
+	}
+
+	/**
+	 * Constructor from Matrix31
+	 *
+	 * @param other Matrix31 to copy
+	 */
+	Euler312(const Matrix<Type, 3, 1> &other) :
+		Vector<Type, 3>(other)
+	{
+	}
+
+	/**
+	 * Constructor from euler angles
+	 *
+	 * Instance is initialized from an 3-1-2 intrinsic Tait-Bryan
+	 * rotation sequence representing transformation from frame 1
+	 * to frame 2.
+	 *
+	 * @param phi_ rotation angle about X axis
+	 * @param theta_ rotation angle about Y axis
+	 * @param psi_ rotation angle about Z axis
+	 */
+	Euler312(Type phi_, Type theta_, Type psi_) : Vector<Type, 3>()
+	{
+		phi() = phi_;
+		theta() = theta_;
+		psi() = psi_;
+	}
+
+	/**
+	 * Constructor from DCM matrix
+	 *
+	 * Instance is set from Dcm representing transformation from
+	 * frame 2 to frame 1.
+	 * This instance will hold the angles defining the 3-1-2 intrinsic
+	 * Tait-Bryan rotation sequence from frame 1 to frame 2.
+	 *
+	 * @param dcm Direction cosine matrix
+	*/
+
+	Euler312(const Dcm<Type> &dcm)
+	{
+		phi() = std::asin(dcm(2, 1));
+
+		if ((std::fabs(phi() - Type(M_PI / 2))) < Type(1.0e-3)) {
+			theta() = 0;
+			psi() = std::atan2(dcm(0, 2), -dcm(1, 2));
+
+		} else if ((std::fabs(phi() + Type(M_PI / 2))) < Type(1.0e-3)) {
+			theta() = 0;
+			psi() = std::atan2(-dcm(0, 2), dcm(1, 2));
+
+		} else {
+			theta() = std::atan2(-dcm(2, 0), dcm(2, 2));
+			psi() = std::atan2(-dcm(0, 1), dcm(1, 1));
+		}
+	}
+
+	/**
+	 * Constructor from quaternion instance.
+	 *
+	 * Instance is set from a quaternion representing transformation
+	 * from frame 2 to frame 1.
+	 * This instance will hold the angles defining the 3-1-2 intrinsic
+	 * Tait-Bryan rotation sequence from frame 1 to frame 2.
+	 *
+	 * @param q quaternion
+	*/
+	Euler312(const Quaternion<Type> &q) : Vector<Type, 3>(Euler312(Dcm<Type>(q)))
+	{
+	}
+
+	inline Type phi() const
+	{
+		return (*this)(0);
+	}
+	inline Type theta() const
+	{
+		return (*this)(1);
+	}
+	inline Type psi() const
+	{
+		return (*this)(2);
+	}
+
+	inline Type &phi()
+	{
+		return (*this)(0);
+	}
+	inline Type &theta()
+	{
+		return (*this)(1);
+	}
+	inline Type &psi()
+	{
+		return (*this)(2);
+	}
+
+};
+
 using Eulerf = Euler<float>;
+using Euler312f = Euler312<float>;
 using Eulerd = Euler<double>;
 
 } // namespace matrix

--- a/src/lib/matrix/test/MatrixAttitudeTest.cpp
+++ b/src/lib/matrix/test/MatrixAttitudeTest.cpp
@@ -493,4 +493,21 @@ TEST(MatrixAttitudeTest, Attitude)
 	q = Quatf(0, 0, 0, 1); // 180 degree rotation around the z axis
 	R = Dcmf(q);
 	EXPECT_EQ(q, Quatf(R));
+
+	// Check for Euler 3-1-2
+
+	Eulerf euler_test(0, -90 * deg2rad, -110.0 * deg2rad);
+	Quatf quat_test{euler_test};
+	Euler312f euler312{quat_test};
+	Eulerf euler321{quat_test};
+
+	// 3-2-1 should fail
+	EXPECT_FLOAT_EQ(euler321(0), 0);
+	EXPECT_EQ(std::isnan(euler321(1)), 1);
+	EXPECT_FLOAT_EQ(euler321(2), 0);
+
+	// 3-1-2 should pass
+	EXPECT_FLOAT_EQ(euler312(0), euler_test(0));
+	EXPECT_FLOAT_EQ(euler312(1), euler_test(1));
+	EXPECT_FLOAT_EQ(euler312(2), euler_test(2));
 }

--- a/src/lib/matrix/test/MatrixAttitudeTest.cpp
+++ b/src/lib/matrix/test/MatrixAttitudeTest.cpp
@@ -502,9 +502,11 @@ TEST(MatrixAttitudeTest, Attitude)
 	Eulerf euler321{quat_test};
 
 	// 3-2-1 should fail
-	EXPECT_FLOAT_EQ(euler321(0), 0);
+	// test that floats are not equal
+	// exact result is undefined - can be 0 or pi
+	EXPECT_GT(fabsf(euler321(0) - euler_test(0)), 1e-5);
 	EXPECT_EQ(std::isnan(euler321(1)), 1);
-	EXPECT_FLOAT_EQ(euler321(2), 0);
+	EXPECT_GT(fabsf(euler321(2) - euler_test(2)), 1e-5);
 
 	// 3-1-2 should pass
 	EXPECT_FLOAT_EQ(euler312(0), euler_test(0));

--- a/src/modules/gimbal/output.cpp
+++ b/src/modules/gimbal/output.cpp
@@ -215,7 +215,7 @@ void OutputBase::_calculate_angle_output(const hrt_abstime &t)
 
 	const matrix::Quatf q_setpoint(_q_setpoint);
 	const bool q_setpoint_valid = q_setpoint.isAllFinite();
-	matrix::Eulerf euler_gimbal{};
+	matrix::Euler312f euler_gimbal{};
 
 	if (q_setpoint_valid) {
 		euler_gimbal = q_setpoint;


### PR DESCRIPTION
## Describe problem solved by this pull request
PX4 use ROLL - PITCH - YAW Euler rotation sequence for gimbal v1 output, so there is a singularity when gimbal towards to ground (pitch -90 degrees). With PITCH - ROLL - YAW Euler rotations PX4 will issue correct gimbal angles.

## Describe your solution
I've implemented quaternion to Euler angles conversion using 3-1-2 sequence instead of standard 3-2-1.

## Test data / coverage
Set gimbal output to V1 and run command: `gimbal test pitch -90 yaw -110`. Without patch px4 will issue mavlink packets with all zero angles. With patch it will issue right angles: `-90 0 -110`

## Additional context
Fixes #19933
