### PR TITLE
MCPosControl: fix horizontal anti-reset windup algorithm

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -181,9 +181,16 @@ void PositionControl::_velocityControl(const float dt)
 
 	// Use tracking Anti-Windup for horizontal direction: during saturation, the integrator is used to unsaturate the output
 	// see Anti-Reset Windup for PID controllers, L.Rundqwist, 1990
-	const Vector2f acc_sp_xy_limited = Vector2f(_thr_sp) * (CONSTANTS_ONE_G / _hover_thrust);
+	const Vector2f acc_sp_xy_produced = Vector2f(_thr_sp) * (CONSTANTS_ONE_G / _hover_thrust);
 	const float arw_gain = 2.f / _gain_vel_p(0);
-	vel_error.xy() = Vector2f(vel_error) - (arw_gain * (Vector2f(_acc_sp) - acc_sp_xy_limited));
+
+	// The produced acceleration can be greater or smaller than the desired acceleration due to the saturations and the actual vertical thrust (computed independently).
+	// The ARW loop needs to run if the signal is saturated only.
+	const Vector2f acc_sp_xy = _acc_sp.xy();
+	const Vector2f acc_limited_xy = (acc_sp_xy.norm_squared() > acc_sp_xy_produced.norm_squared())
+					? acc_sp_xy_produced
+					: acc_sp_xy;
+	vel_error.xy() = Vector2f(vel_error) - arw_gain * (acc_sp_xy - acc_limited_xy);
 
 	// Make sure integral doesn't get NAN
 	ControlMath::setZeroIfNanVector3f(vel_error);


### PR DESCRIPTION
Since the horizontal and vertical velocity controllers are now decoupled, it can be that the horizontal acceleration produced by the controller is actually greater than the desired one (by design). This condition would actually make the ARW run "backwards", degrading the controller performance.

Current state of PX4:
We can see below that the integrator continues to increase even when the velocity overshoots the setpoint because  the anti-reset windup loop works in reverse when the produced acceleration is larger than the desired one (this was never possible in the past, with the coupled XY and Z axes).
![DeepinScreenshot_select-area_20220725163435](https://user-images.githubusercontent.com/14822839/180954042-168bedeb-9457-446a-b314-9e1d95dee14d.png)

With this PR:
The integrator now works properly; there is also less overshoot in general
![DeepinScreenshot_select-area_20220725164006](https://user-images.githubusercontent.com/14822839/180954100-8cd6a7f3-6bdc-4bbe-bff4-44e103670c85.png)

