### PR TITLE
mavlink: fix path for mavlink_types.h include

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -118,6 +118,7 @@ endif()
 
 px4_add_unit_gtest(SRC MavlinkStatustextHandlerTest.cpp
 	INCLUDES
+		${MAVLINK_LIBRARY_DIR}
 		${MAVLINK_LIBRARY_DIR}/${MAVLINK_DIALECT}
 	COMPILE_FLAGS
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2

--- a/src/modules/mavlink/mavlink_bridge_header.h
+++ b/src/modules/mavlink/mavlink_bridge_header.h
@@ -61,7 +61,7 @@
 # define MAVLINK_COMM_5 static_cast<mavlink_channel_t>(5)
 #endif
 
-#include <mavlink/mavlink_types.h>
+#include <mavlink_types.h>
 #include <unistd.h>
 
 __BEGIN_DECLS


### PR DESCRIPTION
From v1.13.0 PX4 stopped building from a Catkin workspace (with `catkin_make px4`). And we are using such a setup for our simulation environment.

The error:

```
In file included from /home/oleg/catkin_ws/src/PX4-Autopilot/src/modules/mavlink/mavlink.c:46:
/home/oleg/catkin_ws/src/PX4-Autopilot/src/modules/mavlink/mavlink_bridge_header.h:64:10: fatal error: mavlink/mavlink_types.h: No such file or directory
   64 | #include <mavlink/mavlink_types.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
```

Seemingly, the include directory is already `~/catkin_ws/build/mavlink`, so `mavlink/` prefix is not needed. And all the other `mavlink_types.h` inclusions in other modules don't prefix it with `mavlink/` directory.

This patch fixes building in a Catkin workspace and doesn't break the normal building (with `make px4_sitl`, `make px4_fmu-v4_default`, ...).