### PR TITLE
RTL cone logic small edit

### DIFF
--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -120,7 +120,14 @@ private:
 
 	void advance_rtl();
 
-	float calculate_return_alt_from_cone_half_angle(float cone_half_angle_deg);
+	/**
+	 * @brief Calculate return altitude considering the RTL cone geometry
+	 *
+	 * @param cone_half_angle_deg [deg] If set to 0 (0.0f), the cone logic won't apply
+	 * @return [m] Return altitude above Mean Sea Level
+	 */
+	float calculate_return_alt_from_cone_half_angle(const float cone_half_angle_deg);
+
 	void calc_and_pub_rtl_time_estimate(const RTLState rtl_state);
 
 	float getCruiseGroundSpeed();

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -124,15 +124,18 @@ PARAM_DEFINE_INT32(RTL_TYPE, 0);
  * Defines the half-angle of a cone centered around the destination position that
  * affects the altitude at which the vehicle returns.
  *
+ * This is only supported for multicopters, since it has the agility to track altitudes
+ * consistently. For fixed wings,
+ *
  * @unit deg
  * @min 0
  * @max 90
- * @value 0 No cone, always climb to RTL_RETURN_ALT above destination.
+ * @value 0 No cone, always climb to RTL_RETURN_ALT above destination. -> This isn't true?
  * @value 25 25 degrees half cone angle.
  * @value 45 45 degrees half cone angle.
  * @value 65 65 degrees half cone angle.
  * @value 80 80 degrees half cone angle.
- * @value 90 Only climb to at least RTL_DESCEND_ALT above destination.
+ * @value 90 Only climb to at least RTL_DESCEND_ALT above destination. -> This isn't true?
  * @group Return Mode
  */
 PARAM_DEFINE_INT32(RTL_CONE_ANG, 45);


### PR DESCRIPTION
## Describe problem solved by this pull request
So my initial interest started from [this comment](https://github.com/PX4/PX4-Autopilot/issues/9602#issuecomment-544487570) from an old issue #9602.

What was surprising to me was that I thought #12382 was supposed to be intended for fixed wings, but according to #15216, apparently it is not. However no reason is given in the PR about the reasoning behind this change.

I thought that for fixed wings, having a cone for RTL altitude limits makes sense since it can't be as versatile as a multicopter, hence setting a return altitude that is too high would be problematic, which was the reasoning I had myself when I read the description of the RTL cone logic PR.

## Describe your solution
This commit adds a small edit that makes sure the 'not a 0' comparison is made on the integer, to avoid problems like Floating points with close to epsilon values passing the condition `float > 0.0f`.

However, the actual question I am posing on this PR is, why is it that for fixed wings the cone logic doesn't make sense?
@sfuhrer @RomanBapst 
