### PR TITLE
AirspeedValidator: increase max update step size of tas_scale_validated from 1% to 5%

### DIFF
--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -145,9 +145,9 @@ AirspeedValidator::update_CAS_scale_validated(bool lpos_valid, const matrix::Vec
 		// check passes if the average airspeed with the scale applied is closer to groundspeed than without
 		if (fabsf(TAS_to_grounspeed_error_new) < fabsf(TAS_to_grounspeed_error_current)) {
 
-			// constrain the scale update to max 0.01 at a time
-			const float new_scale_constrained = math::constrain(_wind_estimator.get_tas_scale(), _CAS_scale_validated - 0.01f,
-							    _CAS_scale_validated + 0.01f);
+			// constrain the scale update to max 0.05 at a time
+			const float new_scale_constrained = math::constrain(_wind_estimator.get_tas_scale(), _CAS_scale_validated - 0.05f,
+							    _CAS_scale_validated + 0.05f);
 
 			_CAS_scale_validated = new_scale_constrained;
 		}


### PR DESCRIPTION

## Describe problem solved by this pull request
Currently the scale factor_validated (which is used to scale the raw airspeed data to airspeed_validated.CAS and TAS) is only allowed to increase by 1% per full circle flown. 

## Describe your solution
Increase the max step size to 5%. This should still be small enough to not create dangerous steps of the airspeed fed back into controllers.

## Test data / coverage
SITL tested. As expected leads to a 5x faster convergence of the validated scale to the raw scale.
![image](https://user-images.githubusercontent.com/26798987/181448224-4b05ae6f-3c9b-4e88-b470-a4cd0d5372c1.png)
![image](https://user-images.githubusercontent.com/26798987/181448345-58fea307-2414-4ed4-9e8e-bcfdb42aef89.png)

I btw don't understand why the valdiated scale doesn't fully converge to the raw one in SITL, on real places I have never seen that large offset (of 5% here). Example of a real flight:
![image](https://user-images.githubusercontent.com/26798987/181449389-d58cf5a2-adc9-488d-84ea-5c6d0fa9680c.png)

FYI @RomanBapst @tstastny 
