### PR TITLE
msg/position_controller_landing_status.msg: fix constant name convent…

### DIFF
--- a/msg/position_controller_landing_status.msg
+++ b/msg/position_controller_landing_status.msg
@@ -9,8 +9,8 @@ uint8 abort_status
 
 # abort reasons
 # after the manual operator abort, corresponds to individual bits of param FW_LND_ABORT
-uint8 kNotAborted = 0
-uint8 kAbortedByOperator = 1
-uint8 kTerrainNotFound = 2 # FW_LND_ABORT (1 << 0)
-uint8 kTerrainTimeout = 3 # FW_LND_ABORT (1 << 1)
-uint8 kUnknownAbortCriterion = 4
+uint8 NOT_ABORTED = 0
+uint8 ABORTED_BY_OPERATOR = 1
+uint8 TERRAIN_NOT_FOUND = 2 # FW_LND_ABORT (1 << 0)
+uint8 TERRAIN_TIMEOUT = 3 # FW_LND_ABORT (1 << 1)
+uint8 UNKNOWN_ABORT_CRITERION = 4

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -338,7 +338,7 @@ private:
 	// [m] relative height above land point
 	float _landing_approach_entrance_rel_alt{0.0f};
 
-	uint8_t _landing_abort_status{position_controller_landing_status_s::kNotAborted};
+	uint8_t _landing_abort_status{position_controller_landing_status_s::NOT_ABORTED};
 
 	bool _flaring{false};
 	hrt_abstime _time_started_flaring{0}; // [us]
@@ -436,7 +436,7 @@ private:
 	 *
 	 * @param new_abort_status Either 0 (not aborted) or the singular bit >0 which triggered the abort
 	 */
-	void updateLandingAbortStatus(const uint8_t new_abort_status = position_controller_landing_status_s::kNotAborted);
+	void updateLandingAbortStatus(const uint8_t new_abort_status = position_controller_landing_status_s::NOT_ABORTED);
 
 	/**
 	 * @brief Checks if the automatic abort bitmask (from FW_LND_ABORT) contains the given abort criterion.


### PR DESCRIPTION
…ions

- msg constant names now comply with ROS conventions:
uppercase alphanumeric characters with underscores for separating words

partially fix #19917

## Describe problem solved by this pull request
`msg/position_controller_landing_status.msg` was using wrong ROS naming [conventions](http://design.ros2.org/articles/interface_definition.html#naming-of-messages-and-services) for its constant names which prevented a successful compilation of [px4_msgs](https://github.com/PX4/px4_msgs).

## Describe your solution
The constant name definitions and all their occurrences have been fixed.
