### PR TITLE
Docker multi arch image for development

### DIFF
--- a/.github/workflows/docker_dev.yml
+++ b/.github/workflows/docker_dev.yml
@@ -1,0 +1,14 @@
+name: docker-dev
+on: [push, pull_request]
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
+      - name: test
+        run: |
+          echo '${{ steps.file_changes.outputs.files}}'
+          echo '${{ steps.file_changes.outputs.files_modified}}'
+          echo '${{ steps.file_changes.outputs.files_added}}'
+          echo '${{ steps.file_changes.outputs.files_removed}}'

--- a/Tools/docker_build.sh
+++ b/Tools/docker_build.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
 if [[ -z "${DOCKER_TAG}" ]]; then
-  TAG_NAME="latest"
+  # the default tag for docker images
+  # follows the pattern below, and we recommend
+  # that any images pushed to the registry continue
+  # to use the pattern for consistency
+  TAG_NAME="`date +"%Y-%m-%d"`"
 else
   TAG_NAME="${DOCKER_TAG}"
 fi
 
-PX4_DOCKER_REPO="px4io/px4-dev:$TAG_NAME"
-BUILD_ARGS="${@}"
+PX4_DOCKER_REPO="ghcr.io/px4/px4-dev:$TAG_NAME"
 PWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SRC_DIR=$PWD/../
 
 echo "[docker_build.sh]: Building [$PX4_DOCKER_REPO]"
-echo "[docker_build.sh]:  - with args: [$BUILD_ARGS]"
 
 docker build \
   -t ${PX4_DOCKER_REPO} \
-  -f Tools/setup/Dockerfile "${SRC_DIR}" \
-  --build-arg INSTALL_ARGS="${BUILD_ARGS}"
+  -f Tools/setup/Dockerfile "${SRC_DIR}"

--- a/Tools/docker_build.sh
+++ b/Tools/docker_build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ -z "${DOCKER_TAG}" ]]; then
+  TAG_NAME="latest"
+else
+  TAG_NAME="${DOCKER_TAG}"
+fi
+
+PX4_DOCKER_REPO="px4io/px4-dev:$TAG_NAME"
+BUILD_ARGS="${@}"
+PWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SRC_DIR=$PWD/../
+
+echo "[docker_build.sh]: Building [$PX4_DOCKER_REPO]"
+echo "[docker_build.sh]:  - with args: [$BUILD_ARGS]"
+
+docker build \
+  -t ${PX4_DOCKER_REPO} \
+  -f Tools/setup/Dockerfile "${SRC_DIR}" \
+  --build-arg INSTALL_ARGS="${BUILD_ARGS}"

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -8,7 +8,7 @@ fi
 
 PX4_DOCKER_REPO="px4io/px4-dev:$TAG_NAME"
 
-echo "docker_run.sh: Running [$PX4_DOCKER_REPO]"
+echo "[docker_run.sh]: Running '$PX4_DOCKER_REPO'"
 
 PWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SRC_DIR=$PWD/../

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -1,34 +1,4 @@
-#! /bin/bash
-
-if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	echo "guessing PX4_DOCKER_REPO based on input";
-	if [[ $@ =~ .*px4_fmu.* ]]; then
-		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2021-09-08"
-	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]] || [[ $@ =~ .*pilotpi.default ]]; then
-		# beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default, scumaker_pilotpi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-08-18"
-	elif [[ $@ =~ .*pilotpi.arm64 ]]; then
-		# scumaker_pilotpi_arm64
-		PX4_DOCKER_REPO="px4io/px4-dev-aarch64:latest"
-	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
-		# posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-08-18"
-	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
-		# clang tools
-		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"
-	elif [[ $@ =~ .*tests* ]]; then
-		# run all tests with simulation
-		PX4_DOCKER_REPO="px4io/px4-dev-simulation-bionic:2021-12-11"
-	fi
-else
-	echo "PX4_DOCKER_REPO is set to '$PX4_DOCKER_REPO'";
-fi
-
-# otherwise default to nuttx
-if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2021-09-08"
-fi
+#!/bin/bash
 
 # docker hygiene
 
@@ -38,30 +8,23 @@ fi
 #Delete all 'untagged/dangling' (<none>) images
 #docker rmi $(docker images -q -f dangling=true)
 
-echo "PX4_DOCKER_REPO: $PX4_DOCKER_REPO";
+if [[ -z "${DOCKER_TAG}" ]]; then
+  TAG_NAME=":latest"
+else
+  TAG_NAME=":${DOCKER_TAG}"
+fi
+
+PX4_DOCKER_REPO="px4io/px4-dev$TAG_NAME"
+
+echo $PX4_DOCKER_REPO
 
 PWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SRC_DIR=$PWD/../
 
-CCACHE_DIR=${HOME}/.ccache
-mkdir -p "${CCACHE_DIR}"
-
 docker run -it --rm -w "${SRC_DIR}" \
-	--env=AWS_ACCESS_KEY_ID \
-	--env=AWS_SECRET_ACCESS_KEY \
-	--env=BRANCH_NAME \
-	--env=CCACHE_DIR="${CCACHE_DIR}" \
-	--env=CI \
-	--env=CODECOV_TOKEN \
-	--env=COVERALLS_REPO_TOKEN \
-	--env=LOCAL_USER_ID="$(id -u)" \
-	--env=PX4_ASAN \
-	--env=PX4_MSAN \
-	--env=PX4_TSAN \
-	--env=PX4_UBSAN \
-	--env=TRAVIS_BRANCH \
-	--env=TRAVIS_BUILD_ID \
-	--publish 14556:14556/udp \
-	--volume=${CCACHE_DIR}:${CCACHE_DIR}:rw \
-	--volume=${SRC_DIR}:${SRC_DIR}:rw \
-	${PX4_DOCKER_REPO} /bin/bash -c "$1 $2 $3"
+  --env=LOCAL_USER_ID="$(id -u)" \
+  --publish 14556:14556/udp \
+  --volume=/tmp/.X11-unix:/tmp/.X11-unix \
+  --volume=/tmp:/tmp:rw \
+  --volume=${SRC_DIR}:${SRC_DIR}:rw \
+  ${PX4_DOCKER_REPO} /bin/bash -c "$1 $2 $3"

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 if [[ -z "${DOCKER_TAG}" ]]; then
-  TAG_NAME="latest"
+  # The default tag name should be hardcoded
+  # to whatever we are currently using in CI on this branch
+  TAG_NAME="2022-08-16"
 else
   TAG_NAME="${DOCKER_TAG}"
 fi
 
-PX4_DOCKER_REPO="px4io/px4-dev:$TAG_NAME"
+PX4_DOCKER_REPO="ghcr.io/px4/px4-dev:$TAG_NAME"
 
 echo "[docker_run.sh]: Running '$PX4_DOCKER_REPO'"
 

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
 
-# docker hygiene
-
-#Delete all stopped containers (including data-only containers)
-#docker rm $(docker ps -a -q)
-
-#Delete all 'untagged/dangling' (<none>) images
-#docker rmi $(docker images -q -f dangling=true)
-
 if [[ -z "${DOCKER_TAG}" ]]; then
-  TAG_NAME=":latest"
+  TAG_NAME="latest"
 else
-  TAG_NAME=":${DOCKER_TAG}"
+  TAG_NAME="${DOCKER_TAG}"
 fi
 
-PX4_DOCKER_REPO="px4io/px4-dev$TAG_NAME"
+PX4_DOCKER_REPO="px4io/px4-dev:$TAG_NAME"
 
-echo $PX4_DOCKER_REPO
+echo "docker_run.sh: Running [$PX4_DOCKER_REPO]"
 
 PWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SRC_DIR=$PWD/../

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -17,6 +17,11 @@ SRC_DIR=$PWD/../
 
 docker run -it --rm -w "${SRC_DIR}" \
   --env=LOCAL_USER_ID="$(id -u)" \
+  --env=AWS_ACCESS_KEY_ID \
+  --env=AWS_SECRET_ACCESS_KEY \
+  --env=BRANCH_NAME \
+  --env=CCACHE_DIR="${CCACHE_DIR}" \
+  --env=CI \
   --publish 14556:14556/udp \
   --volume=/tmp/.X11-unix:/tmp/.X11-unix \
   --volume=/tmp:/tmp:rw \

--- a/Tools/setup/Dockerfile
+++ b/Tools/setup/Dockerfile
@@ -24,21 +24,12 @@ RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 # Install PX4 Requirements
 COPY Tools/setup/requirements.txt /tmp/requirements.txt
 COPY Tools/setup/ubuntu.sh /tmp/ubuntu.sh
-# We support pre-downloading the gcc arm none eabi compiler
-# to speed up build times, if the file is not present when
-# building, the ubuntu.sh script will download it from source
-# To make this conditional, copy an extra 'dummy' file as well
-COPY Tools/setup/dummy.file gcc-arm-none-eabi-9-2020-q2-update-linux.tar.* /tmp/
 # The PATH env is set within ubuntu.sh, but given how we
 # are running the image using `gosu` to avoid read-only problems
 # with the filesystem the env variable does not persist
 ENV PATH="/opt/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"
-ENV PATH="/opt/jdk-14.0.2+12/bin:$PATH"
 
-# For a complete list of INSTALL_ARGS options run:
-# ./Tools/setup/ubuntu.sh --help
-ARG INSTALL_ARGS
-RUN bash /tmp/ubuntu.sh --from-docker $INSTALL_ARGS
+RUN bash /tmp/ubuntu.sh --from-docker
 
 ENV DISPLAY :99
 

--- a/Tools/setup/Dockerfile
+++ b/Tools/setup/Dockerfile
@@ -27,13 +27,17 @@ COPY Tools/setup/ubuntu.sh /tmp/ubuntu.sh
 # We support pre-downloading the gcc arm none eabi compiler
 # to speed up build times, if the file is not present when
 # building, the ubuntu.sh script will download it from source
-COPY *gcc-arm-none-eabi-9-2020-q2-update-linux.tar.bz2 /tmp/gcc-arm-none-eabi-9-2020-q2-update-linux.tar.bz2
+COPY gcc-arm-none-eabi-9-2020-q2-update-linux.tar.* /tmp/
 # The PATH env is set within ubuntu.sh, but given how we
 # are running the image using `gosu` to avoid read-only problems
 # with the filesystem the env variable does not persist
 ENV PATH="/opt/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"
 ENV PATH="/opt/jdk-14.0.2+12/bin:$PATH"
-RUN bash /tmp/ubuntu.sh --from-docker --with-java --with-rtps --no-sim-tools
+
+# For a complete list of INSTALL_ARGS options run:
+# ./Tools/setup/ubuntu.sh --help
+ARG INSTALL_ARGS
+RUN bash /tmp/ubuntu.sh --from-docker $INSTALL_ARGS
 
 ENV DISPLAY :99
 

--- a/Tools/setup/Dockerfile
+++ b/Tools/setup/Dockerfile
@@ -27,7 +27,8 @@ COPY Tools/setup/ubuntu.sh /tmp/ubuntu.sh
 # We support pre-downloading the gcc arm none eabi compiler
 # to speed up build times, if the file is not present when
 # building, the ubuntu.sh script will download it from source
-COPY gcc-arm-none-eabi-9-2020-q2-update-linux.tar.* /tmp/
+# To make this conditional, copy an extra 'dummy' file as well
+COPY Tools/setup/dummy.file gcc-arm-none-eabi-9-2020-q2-update-linux.tar.* /tmp/
 # The PATH env is set within ubuntu.sh, but given how we
 # are running the image using `gosu` to avoid read-only problems
 # with the filesystem the env variable does not persist

--- a/Tools/setup/Dockerfile
+++ b/Tools/setup/Dockerfile
@@ -1,0 +1,55 @@
+#
+# PX4 base development environment
+#
+
+FROM ubuntu:20.04
+LABEL maintainer="Daniel Agar <daniel@agar.ca>, Ramon Roche <mrpollo@gmail.com>"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Installing required utilities
+RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
+  ca-certificates \
+  gnupg \
+  lsb-core \
+  lsb-release \
+  sudo \
+  software-properties-common \
+  wget \
+  gosu \
+  ;
+
+# Install PX4 Requirements
+COPY Tools/setup/requirements.txt /tmp/requirements.txt
+COPY Tools/setup/ubuntu.sh /tmp/ubuntu.sh
+# We support pre-downloading the gcc arm none eabi compiler
+# to speed up build times, if the file is not present when
+# building, the ubuntu.sh script will download it from source
+COPY *gcc-arm-none-eabi-9-2020-q2-update-linux.tar.bz2 /tmp/gcc-arm-none-eabi-9-2020-q2-update-linux.tar.bz2
+# The PATH env is set within ubuntu.sh, but given how we
+# are running the image using `gosu` to avoid read-only problems
+# with the filesystem the env variable does not persist
+ENV PATH="/opt/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH"
+ENV PATH="/opt/jdk-14.0.2+12/bin:$PATH"
+RUN bash /tmp/ubuntu.sh --from-docker --with-java --with-rtps --no-sim-tools
+
+ENV DISPLAY :99
+
+ENV FASTRTPSGEN_DIR="/usr/local/bin/"
+ENV TERM=xterm
+ENV TZ=UTC
+
+# SITL UDP PORTS
+EXPOSE 14556/udp
+EXPOSE 14557/udp
+
+# create user with id 1001 (jenkins docker workflow default)
+RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
+
+# create and start as LOCAL_USER_ID
+COPY Tools/setup/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/Tools/setup/docker-entrypoint.sh
+++ b/Tools/setup/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Start virtual X server in the background
+# - DISPLAY default is :99, set in dockerfile
+# - Users can override with `-e DISPLAY=` in `docker run` command to avoid
+#   running Xvfb and attach their screen
+if [[ -x "$(command -v Xvfb)" && "$DISPLAY" == ":99" ]]; then
+	echo "Starting Xvfb"
+	Xvfb :99 -screen 0 1600x1200x24+32 &
+fi
+
+# Check if the ROS_DISTRO is passed and use it
+# to source the ROS environment
+if [ -n "${ROS_DISTRO}" ]; then
+	source "/opt/ros/$ROS_DISTRO/setup.bash"
+fi
+
+# Use the LOCAL_USER_ID if passed in at runtime
+if [ -n "${LOCAL_USER_ID}" ]; then
+	echo "Starting with UID : $LOCAL_USER_ID"
+	# modify existing user's id
+	usermod -u $LOCAL_USER_ID user
+
+	# run as user
+  exec gosu user "$@"
+else
+	exec "$@"
+fi

--- a/Tools/setup/docker-entrypoint.sh
+++ b/Tools/setup/docker-entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+echo "[docker-entrypoint.sh] Starting entrypoint"
 # Start virtual X server in the background
 # - DISPLAY default is :99, set in dockerfile
 # - Users can override with `-e DISPLAY=` in `docker run` command to avoid
 #   running Xvfb and attach their screen
 if [[ -x "$(command -v Xvfb)" && "$DISPLAY" == ":99" ]]; then
-	echo "Starting Xvfb"
+	echo "[docker-entrypoint.sh] Starting Xvfb"
 	Xvfb :99 -screen 0 1600x1200x24+32 &
 fi
 
@@ -17,7 +18,7 @@ fi
 
 # Use the LOCAL_USER_ID if passed in at runtime
 if [ -n "${LOCAL_USER_ID}" ]; then
-	echo "Starting with UID : $LOCAL_USER_ID"
+	echo "[docker-entrypoint.sh] Starting with UID : $LOCAL_USER_ID"
 	# modify existing user's id
 	usermod -u $LOCAL_USER_ID user
 

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -92,16 +92,17 @@ echo
 
 sudo apt-get update -y --quiet
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+	astyle \
 	build-essential \
+	cmake \
+	cppcheck \
 	g++ \
 	gcc \
 	gdb \
-	astyle \
-	cmake \
-	cppcheck \
-	file \
 	git \
+	file \
 	lcov \
+	libssl-dev \
 	libxml2-dev \
 	libxml2-utils \
 	make \
@@ -115,7 +116,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 	shellcheck \
 	unzip \
 	zip \
-	libssl-dev \
 	;
 
 # Python 3 dependencies

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -209,16 +209,9 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	else
 		echo "📌 The arm cross compiler was not found";
 		echo " * Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
-		# The arm cross compiler hosting provider is known to throttle download speeds
-		# for users who reach a certain limit of downloads in a given time frame
-		# for this reason we allow for using a previously downloaded file
-		# this is specially helpful when debugging this installer script
-		# from within a container COMPILER_PATH="/tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2"
 		COMPILER_NAME="gcc-arm-none-eabi-${NUTTX_GCC_VERSION}"
 		COMPILER_PATH="/tmp/$COMPILER_NAME-linux.tar.bz2"
-		if [ ! -f "$COMPILER_PATH" ]; then
-			wget -O $COMPILER_PATH https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${NUTTX_GCC_VERSION_SHORT}/${COMPILER_NAME}-${INSTALL_ARCH}-linux.tar.bz2
-		fi
+    wget -O $COMPILER_PATH https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${NUTTX_GCC_VERSION_SHORT}/${COMPILER_NAME}-${INSTALL_ARCH}-linux.tar.bz2
 		sudo tar -jxf $COMPILER_PATH -C /opt/;
 
 		# add arm-none-eabi-gcc to user's PATH

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -2,20 +2,22 @@
 
 set -e
 
-## Bash script to setup PX4 development environment on Ubuntu LTS (20.04, 18.04, 16.04).
+## Bash script to setup PX4 development environment on Ubuntu LTS (20.04, 18.04).
 ## Can also be used in docker.
 ##
 ## Installs:
-## - Common dependencies and tools for nuttx, jMAVSim, Gazebo
+## - Common dependencies and tools for NuttX, jMAVSim, Gazebo
 ## - NuttX toolchain (omit with arg: --no-nuttx)
-## - jMAVSim and Gazebo9 simulator (omit with arg: --no-sim-tools)
-##
-## Not Installs:
-## - FastRTPS and FastCDR
+## - jMAVSim and Gazebo simulator (omit with arg: --no-sim-tools)
+## Optional:
+## - FastRTPS and FastCDR (with args: --with-rtps)
 
 INSTALL_NUTTX="true"
 INSTALL_SIM="true"
 INSTALL_ARCH=`uname -m`
+INSTALL_RTPS="false"
+INSTALL_JAVA="false"
+INSIDE_DOCKER="false"
 
 # Parse arguments
 for arg in "$@"
@@ -28,19 +30,19 @@ do
 		INSTALL_SIM="false"
 	fi
 
-done
+	if [[ $arg == "--with-rtps" ]]; then
+		INSTALL_RTPS="true"
+	fi
 
-# detect if running in docker
-if [ -f /.dockerenv ]; then
-	echo "Running within docker, installing initial dependencies";
-	apt-get --quiet -y update && DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install \
-		ca-certificates \
-		gnupg \
-		lsb-core \
-		sudo \
-		wget \
-		;
-fi
+	if [[ $arg == "--with-java" ]]; then
+		INSTALL_JAVA="true"
+	fi
+
+	if [[ $arg == "--from-docker" ]]; then
+		INSIDE_DOCKER="true"
+	fi
+
+done
 
 # script directory
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
@@ -69,20 +71,35 @@ elif [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
 	echo "Ubuntu 20.04"
 fi
 
+VERBOSE_BAR="####################"
+echo
+echo $VERBOSE_BAR
+echo "#⚡️ Starting PX4 Dependency Installer for Ubuntu ${UBUNTU_RELEASE} (${INSTALL_ARCH})"
+echo "# Options:
+#
+#  - Install NuttX = ${INSTALL_NUTTX}
+#  - Install Java = ${INSTALL_JAVA}
+#  - Install Simulation = ${INSTALL_SIM}
+#  - Install RTPS = ${INSTALL_RTPS}"
+echo $VERBOSE_BAR
+echo
 
 echo
-echo "Installing PX4 general dependencies"
+echo $VERBOSE_BAR
+echo "🍻 Installing System Dependencies"
+echo $VERBOSE_BAR
+echo
 
 sudo apt-get update -y --quiet
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
-	astyle \
 	build-essential \
-	cmake \
-	cppcheck \
-	file \
 	g++ \
 	gcc \
 	gdb \
+	astyle \
+	cmake \
+	cppcheck \
+	file \
 	git \
 	lcov \
 	libxml2-dev \
@@ -98,34 +115,45 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 	shellcheck \
 	unzip \
 	zip \
+	libssl-dev \
 	;
 
-# Python3 dependencies
+# Python 3 dependencies
 echo
-echo "Installing PX4 Python3 dependencies"
+echo $VERBOSE_BAR
+echo "🍻 Installing Python dependencies"
+echo $VERBOSE_BAR
+echo
+
 if [ -n "$VIRTUAL_ENV" ]; then
 	# virtual environments don't allow --user option
 	python -m pip install -r ${DIR}/requirements.txt
 else
 	# older versions of Ubuntu require --user option
-	python3 -m pip install --user -r ${DIR}/requirements.txt
+	if [[ $INSIDE_DOCKER == "true" ]]; then
+		# when running inside a docker container we don't need to install
+		# under --user since the installer user is root
+		# its best to install packages globaly for any user to find
+		python3 -m pip install -r /tmp/requirements.txt
+	else
+		python3 -m pip install --user -r ${DIR}/requirements.txt
+	fi
 fi
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then
 
 	echo
-	echo "Installing NuttX dependencies"
+	echo $VERBOSE_BAR
+	echo "🍻 Installing NuttX dependencies"
+	echo $VERBOSE_BAR
+	echo
 
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		automake \
 		binutils-dev \
 		bison \
-		build-essential \
 		flex \
-		g++-multilib \
-		gcc-multilib \
-		gdb-multiarch \
 		genromfs \
 		gettext \
 		gperf \
@@ -145,7 +173,12 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		u-boot-tools \
 		util-linux \
 		vim-common \
+		g++-arm-linux-gnueabihf \
+		gcc-arm-linux-gnueabihf \
+		g++-aarch64-linux-gnu \
+		gcc-aarch64-linux-gnu \
 		;
+
 	if [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
 		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		kconfig-frontends \
@@ -158,78 +191,147 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		sudo usermod -a -G dialout $USER
 	fi
 
-	# arm-none-eabi-gcc
 	NUTTX_GCC_VERSION="9-2020-q2-update"
 	NUTTX_GCC_VERSION_SHORT="9-2020q2"
+	echo
+	echo $VERBOSE_BAR
+	echo "🍻 Verifying proper gcc version (${NUTTX_GCC_VERSION}), and installing if not found"
+	echo
 
 	source $HOME/.profile # load changed path for the case the script is reran before relogin
 	if [ $(which arm-none-eabi-gcc) ]; then
 		GCC_VER_STR=$(arm-none-eabi-gcc --version)
-		GCC_FOUND_VER=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}")
+		GCC_VER_FOUND=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}")
 	fi
 
-	if [[ "$GCC_FOUND_VER" == "1" ]]; then
-		echo "arm-none-eabi-gcc-${NUTTX_GCC_VERSION} found, skipping installation"
+	if [[ $(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}") == "1" ]]; then
+		echo "📌 Skipping installation, the arm cross compiler was found"
+		echo $VERBOSE_BAR
+		echo
 
 	else
-		echo "Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
-		wget -O /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${NUTTX_GCC_VERSION_SHORT}/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-${INSTALL_ARCH}-linux.tar.bz2 && \
-			sudo tar -jxf /tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2 -C /opt/;
+		echo "📌 The arm cross compiler was not found";
+		echo " * Installing arm-none-eabi-gcc-${NUTTX_GCC_VERSION}";
+		# The arm cross compiler hosting provider is known to throttle download speeds
+		# for users who reach a certain limit of downloads in a given time frame
+		# for this reason we allow for using a previously downloaded file
+		# this is specially helpful when debugging this installer script
+		# from within a container COMPILER_PATH="/tmp/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}-linux.tar.bz2"
+		COMPILER_NAME="gcc-arm-none-eabi-${NUTTX_GCC_VERSION}"
+		COMPILER_PATH="/tmp/$COMPILER_NAME-linux.tar.bz2"
+		if [ ! -f "$COMPILER_PATH" ]; then
+			wget -O $COMPILER_PATH https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/${NUTTX_GCC_VERSION_SHORT}/${COMPILER_NAME}-${INSTALL_ARCH}-linux.tar.bz2
+		fi
+		sudo tar -jxf $COMPILER_PATH -C /opt/;
 
 		# add arm-none-eabi-gcc to user's PATH
-		exportline="export PATH=/opt/gcc-arm-none-eabi-${NUTTX_GCC_VERSION}/bin:\$PATH"
-
-		if grep -Fxq "$exportline" $HOME/.profile; then
+		exportline="export PATH=\"/opt/${COMPILER_NAME}/bin:\$PATH\""
+		if [[ $INSIDE_DOCKER == "true" ]]; then
+			# when running on a docker container its best to set the environment globally
+			# since we don't know which user is going to be running commands on the container
+			touch /etc/profile.d/px4env.sh
+			echo $exportline >> /etc/profile.d/px4env.sh
+		elif grep -Fxq "$exportline" $HOME/.profile; then
 			echo "${NUTTX_GCC_VERSION} path already set.";
 		else
 			echo $exportline >> $HOME/.profile;
 		fi
+		echo " * arm-none-eabi-gcc (${NUTTX_GCC_VERSION}) Installed Succesful to /opt/${COMPILER_NAME}/bin"
+		echo $VERBOSE_BAR
+		echo
 	fi
+fi
+
+# Install JAVA
+# NOTE: The version of java below has been double checked to work
+# against all the tools and dependencies you need including FastRTPS
+# and Gazebo. If really need to update JDK, make sure you test the
+# compatibility with Gradle and the eProsima tools in the next step
+if [[ $INSTALL_JAVA == "true" ]]; then
+	JDK_VERSION="14.0.2_12"
+	echo
+	echo $VERBOSE_BAR
+	echo "🍻 Installing Java JDK
+
+	* Version: $JDK_VERSION
+	* Path: /opt/jdk-14.0.2+12"
+	echo $VERBOSE_BAR
+	echo
+
+	JDK_DOWNLOAD="/tmp/OpenJDK14U-jdk_x64_linux_hotspot_$JDK_VERSION.tar.gz"
+	wget -O $JDK_DOWNLOAD https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz
+	sudo tar -xzf $JDK_DOWNLOAD -C /opt/
+	export PATH="/opt/jdk-14.0.2+12/bin:$PATH"
+fi
+
+# Fast-RTPS
+# The version of eProsima tools we are using has a hard dependency on
+# JDK 14 because of Gradle, any new version of Gradle won't work unless
+# the eProsima tools are updated
+if [[ $INSTALL_RTPS == "true" ]]; then
+	echo
+	echo $VERBOSE_BAR
+	echo "🍻 Installing Fast-RTPS"
+	echo $VERBOSE_BAR
+	echo
+
+	GRADLE_VERSION="6.4.1"
+	wget -O "/tmp/gradle-$GRADLE_VERSION-bin.zip" "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip" \
+		&& unzip -d /opt/gradle "/tmp/gradle-$GRADLE_VERSION-bin.zip"
+	export PATH="$PATH:/opt/gradle/gradle-$GRADLE_VERSION/bin"
+
+	# Intall foonathan_memory from source as it is required to Fast-RTPS >= 1.9
+	git clone https://github.com/eProsima/foonathan_memory_vendor.git /tmp/foonathan_memory \
+		&& cd /tmp/foonathan_memory \
+		&& mkdir build && cd build \
+		&& cmake .. \
+		&& cmake --build . --target install -- -j $(nproc)
+
+	# Fast-DDS (Fast-RTPS 2.1.1)
+	git clone --recursive https://github.com/eProsima/Fast-DDS.git -b v2.1.1 /tmp/FastRTPS-2.1.1 \
+		&& cd /tmp/FastRTPS-2.1.1 \
+		&& mkdir build && cd build \
+		&& cmake -DTHIRDPARTY=ON -DSECURITY=ON .. \
+		&& cmake --build . --target install -- -j $(nproc)
+
+	# Fast-RTPS-Gen 1.0.4
+	git clone --recursive https://github.com/eProsima/Fast-DDS-Gen.git -b v1.0.4 /tmp/Fast-RTPS-Gen-1.0.4 \
+		&& cd /tmp/Fast-RTPS-Gen-1.0.4 \
+		&& gradle assemble \
+		&& gradle install
+
 fi
 
 # Simulation tools
 if [[ $INSTALL_SIM == "true" ]]; then
 
 	echo
-	echo "Installing PX4 simulation dependencies"
+	echo $VERBOSE_BAR
+	echo "🍻 Installing PX4 Simulation Tools"
+	echo
+
+	# default and Ubuntu 20.04
+	gazebo_version=11
+	gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
+	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
+		gazebo_version=9
+	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
+		gazebo_version=11
+		gazebo_packages="gazebo libgazebo-dev"
+	fi
+
+	echo "  * Gazebo Version $gazebo_version"
+	echo $VERBOSE_BAR
 
 	# General simulation dependencies
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		bc \
-		;
-
-	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
-		java_version=11
-	elif [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
-		java_version=13
-	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
-		java_version=11
-	else
-		java_version=14
-	fi
-	# Java (jmavsim or fastrtps)
-	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		ant \
-		openjdk-$java_version-jre \
-		openjdk-$java_version-jdk \
 		libvecmath-java \
 		;
 
-	# Set Java 11 as default
-	sudo update-alternatives --set java $(update-alternatives --list java | grep "java-$java_version")
-
-	# Gazebo
-	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
-		gazebo_version=9
-		gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
-	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
-		gazebo_packages="gazebo libgazebo-dev"
-	else
-		# default and Ubuntu 20.04
-		gazebo_version=11
-		gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
-	fi
-
+	# Installing Gazebo and dependencies
+	# Setup OSRF Gazebo repository
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	# Update list, since new gazebo-stable.list has been added
@@ -257,7 +359,26 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	fi
 fi
 
-if [[ $INSTALL_NUTTX == "true" ]]; then
-	echo
-	echo "Relogin or reboot computer before attempting to build NuttX targets"
+if [[ $INSIDE_DOCKER == "true" ]]; then
+	# cleanup installation
+	rm -rf /tmp/
 fi
+
+if [[ $INSIDE_DOCKER == "false" ]] && [[ $INSTALL_NUTTX == "true" ]]; then
+	echo
+	echo $VERBOSE_BAR
+	echo "💡 We recommend you relogin/reboot before attempting to build NuttX targets"
+	echo $VERBOSE_BAR
+	echo
+fi
+
+echo
+echo
+echo $VERBOSE_BAR
+echo "#⚡️ PX4 Dependency Installer Ended Succesfully
+#
+#  For more information on PX4 Autopilot check out our docs
+#  at docs.px4.io, if you find a bug please file an issue
+#  on GitHub https://github.com/px4/px4-autopilot"
+echo $VERBOSE_BAR
+echo

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -42,6 +42,18 @@ do
 		INSIDE_DOCKER="true"
 	fi
 
+  if [[ $arg == "--help" ]]; then
+    echo "#⚡️ PX4 Dependency Installer for Ubuntu"
+    echo "# Options:
+#
+#  --with-java      boolean
+#  --with-rtps      boolean
+#  --no-nuttx       boolean
+#  --no-sim-tools   boolean"
+    echo "#"
+    exit
+  fi
+
 done
 
 # script directory

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -93,11 +93,11 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 	build-essential \
 	cmake \
 	cppcheck \
+	file \
 	g++ \
 	gcc \
 	gdb \
 	git \
-	file \
 	lcov \
 	libssl-dev \
 	libxml2-dev \


### PR DESCRIPTION
My PR builds on the effort of many who have contributed to multiple docker images and setup scripts, and ultimately the credit should go to them. I created a new docker image to be used as the primary development image, and it has all the required dependencies to build any valid PX4 target. The image should be used on our CI pipeline. Technically depends on #19905, although I cherry-picked that commit on this branch

**How to build:**
There's a new docker build script that helps you get an image exactly how you want it. The script builds the image and assigns a tag by default unless one is specified. The tag is the output of: `date +"%Y-%m-%d"`

```
./Tools/docker_build.sh
````

**How to run:**

```
./Tools/docker_run.sh make all_variants_px4_fmu-v5x
./Tools/docker_run.sh make scumaker_pilotpi_arm64
./Tools/docker_run.sh make emlid_navio2_default
```

By default, it runs on a hardcoded `px4/px4-dev:YYYY-MM-DD` tag but can be configured to run on any tag with the `DOCKER_TAG` environment variable.

```
DOCKER_TAG=tag ./Tools/docker_run.sh make all_variants_px4_fmu-v5x
```

**Container images (How to pull?)** 
If you only want to test PX4 with a container and are not interested in building an image, you can pull from the GitHub container registry ([link to package](https://github.com/PX4/PX4-Autopilot/pkgs/container/px4-dev))
```
docker pull ghcr.io/px4/px4-dev:2022-08-16
```

**Container images (How to push?)**
In order to push to the container registry your user needs package:write permissions, which you should have if you are part of the PX4 Developer Team. Ultimately GitHub Actions should be the sole responsible entity pushing.

```
docker push ghcr.io/px4/px4-dev:2022-08-16
```