### PR TITLE
Skip VTOL_TAKEOFF mission item when in fixed wing mode

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -820,9 +820,8 @@ Mission::set_mission_items()
 				} else if (_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF
 					   && _work_item_type == WORK_ITEM_TYPE_DEFAULT
 					   && new_work_item_type == WORK_ITEM_TYPE_DEFAULT) {
-
-
-					/* haven't transitioned yet, trigger vtol takeoff logic below */
+					// if the vehicle is already in fixed wing mode then the current mission item
+					// will be accepted immediately and the work items will be skipped
 					_work_item_type = WORK_ITEM_TYPE_TAKEOFF;
 
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -821,14 +821,10 @@ Mission::set_mission_items()
 					   && _work_item_type == WORK_ITEM_TYPE_DEFAULT
 					   && new_work_item_type == WORK_ITEM_TYPE_DEFAULT) {
 
-					if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-						/* haven't transitioned yet, trigger vtol takeoff logic below */
-						_work_item_type = WORK_ITEM_TYPE_TAKEOFF;
 
-					} else {
-						/* already in fixed-wing, go to waypoint */
-						_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-					}
+					/* haven't transitioned yet, trigger vtol takeoff logic below */
+					_work_item_type = WORK_ITEM_TYPE_TAKEOFF;
+
 
 					/* ignore yaw here, otherwise it might yaw before heading_sp_update takes over */
 					_mission_item.yaw = NAN;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -129,6 +129,13 @@ MissionBlock::is_mission_item_reached()
 			return false;
 		}
 
+	case NAV_CMD_VTOL_TAKEOFF:
+		if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+			return true;
+		}
+
+		break;
+
 	case NAV_CMD_DELAY:
 		// Set reached flags directly such that only the delay time is considered
 		_waypoint_position_reached = true;


### PR DESCRIPTION

## Describe problem solved by this pull request
When updating a mission while the vehicle is already flying in fixed wing mode the mission index is reset. If the mission contains a VTOL_TAKEOFF item then the vehicle will navigate to it. This does not make sense as the vehicle has already transitioned.

## Describe your solution
Skip VTOL_TAKEOFF item when already in fixed wing mode.
