### PR TITLE
Fixed-wing landing nudge modifications

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1774,6 +1774,11 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 		// enable direct yaw control using rudder/wheel
 		_att_sp.fw_control_yaw = true;
 
+		// XXX: hacky way to pass through manual nose-wheel incrementing. need to clean this interface.
+		if (_param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled) {
+			_att_sp.yaw_sp_move_rate = _manual_control_setpoint.r;
+		}
+
 		// idle throttle may be >0 for internal combustion engines
 		// normally set to zero for electric motors
 		_att_sp.thrust_body[0] = _param_fw_thr_idle.get();
@@ -2611,7 +2616,8 @@ Vector2f
 FixedwingPositionControl::calculateTouchdownPosition(const float control_interval, const Vector2f &local_land_position)
 {
 	if (fabsf(_manual_control_setpoint.r) > MANUAL_TOUCHDOWN_NUDGE_INPUT_DEADZONE
-	    && _param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled) {
+	    && _param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled
+	    && !_flaring) {
 		// laterally nudge touchdown location with yaw stick
 		// positive is defined in the direction of a right hand turn starting from the approach vector direction
 		const float signed_deadzone_threshold = MANUAL_TOUCHDOWN_NUDGE_INPUT_DEADZONE * math::signNoZero(

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -161,7 +161,7 @@ static constexpr float kClearanceAltitudeBuffer = 10.0f;
 static constexpr float L1_VIRTUAL_TAKEOFF_WP_DIST = 1.0e6f;
 
 // [m/s] maximum rate at which the touchdown position can be nudged
-static constexpr float MAX_TOUCHDOWN_POSITION_NUDGE_RATE = 1.0f;
+static constexpr float MAX_TOUCHDOWN_POSITION_NUDGE_RATE = 4.0f;
 
 // [.] normalized deadzone threshold for manual nudging input
 static constexpr float MANUAL_TOUCHDOWN_NUDGE_INPUT_DEADZONE = 0.15f;


### PR DESCRIPTION
## Describe problem solved by this pull request
Nudge rate on landing was a bit slow. And post flaring, not so effect when rolling out on ground (still moving the path and not directly acting with the wheel).

## Describe your solution
- Bumped the landing nudge rate.
- Once the flare has engaged, fixed the landing touchdown offset, and feed the yaw stick directly to the wheel (like in takeoff nudging) to allow direct nudging on wheels after touchdown.

## Test data / coverage
Flight test https://review.px4.io/plot_app?log=7cfc1746-df6b-4824-ab9e-ac6c2e7962bd
