### PR TITLE
boards: link missing arch_io_pins lib

### DIFF
--- a/boards/av/x-v1/src/CMakeLists.txt
+++ b/boards/av/x-v1/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/cuav/nora/src/CMakeLists.txt
+++ b/boards/cuav/nora/src/CMakeLists.txt
@@ -56,6 +56,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led

--- a/boards/cuav/x7pro/src/CMakeLists.txt
+++ b/boards/cuav/x7pro/src/CMakeLists.txt
@@ -56,6 +56,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led

--- a/boards/cubepilot/cubeorange/src/CMakeLists.txt
+++ b/boards/cubepilot/cubeorange/src/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			drivers__led
 			nuttx_arch

--- a/boards/cubepilot/cubeyellow/src/CMakeLists.txt
+++ b/boards/cubepilot/cubeyellow/src/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/holybro/durandal-v1/src/CMakeLists.txt
+++ b/boards/holybro/durandal-v1/src/CMakeLists.txt
@@ -59,6 +59,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led # drv_led_start

--- a/boards/holybro/kakutef7/src/CMakeLists.txt
+++ b/boards/holybro/kakutef7/src/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/holybro/kakuteh7/src/CMakeLists.txt
+++ b/boards/holybro/kakuteh7/src/CMakeLists.txt
@@ -56,6 +56,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led # drv_led_start

--- a/boards/holybro/pix32v5/src/CMakeLists.txt
+++ b/boards/holybro/pix32v5/src/CMakeLists.txt
@@ -47,6 +47,7 @@ add_dependencies(drivers_board arch_board_hw_info)
 target_link_libraries(drivers_board
 	PRIVATE
 		arch_board_hw_info
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/matek/h743-mini/src/CMakeLists.txt
+++ b/boards/matek/h743-mini/src/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led

--- a/boards/matek/h743-slim/src/CMakeLists.txt
+++ b/boards/matek/h743-slim/src/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led

--- a/boards/matek/h743/src/CMakeLists.txt
+++ b/boards/matek/h743/src/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led

--- a/boards/modalai/fc-v1/src/CMakeLists.txt
+++ b/boards/modalai/fc-v1/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_dependencies(drivers_board arch_board_hw_info)
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		arch_board_hw_info
 		drivers__led # drv_led_start

--- a/boards/modalai/fc-v2/src/CMakeLists.txt
+++ b/boards/modalai/fc-v2/src/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led # drv_led_start

--- a/boards/mro/ctrl-zero-f7-oem/src/CMakeLists.txt
+++ b/boards/mro/ctrl-zero-f7-oem/src/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/mro/ctrl-zero-f7/src/CMakeLists.txt
+++ b/boards/mro/ctrl-zero-f7/src/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/mro/ctrl-zero-h7-oem/src/CMakeLists.txt
+++ b/boards/mro/ctrl-zero-h7-oem/src/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			drivers__led
 			nuttx_arch

--- a/boards/mro/ctrl-zero-h7/src/CMakeLists.txt
+++ b/boards/mro/ctrl-zero-h7/src/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			drivers__led
 			nuttx_arch

--- a/boards/mro/pixracerpro/src/CMakeLists.txt
+++ b/boards/mro/pixracerpro/src/CMakeLists.txt
@@ -55,6 +55,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			drivers__led
 			nuttx_arch

--- a/boards/nxp/fmuk66-e/src/CMakeLists.txt
+++ b/boards/nxp/fmuk66-e/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		nuttx_arch # sdio
 		nuttx_drivers # sdio
 		drivers__led # drv_led_start

--- a/boards/nxp/fmuk66-v3/src/CMakeLists.txt
+++ b/boards/nxp/fmuk66-v3/src/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		nuttx_arch # sdio
 		nuttx_drivers # sdio
 		drivers__led # drv_led_start

--- a/boards/px4/fmu-v5/src/CMakeLists.txt
+++ b/boards/px4/fmu-v5/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_dependencies(drivers_board nuttx_context)
 target_link_libraries(drivers_board
 	PRIVATE
 		arch_board_hw_info
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio

--- a/boards/px4/fmu-v6u/src/CMakeLists.txt
+++ b/boards/px4/fmu-v6u/src/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led # drv_led_start

--- a/boards/px4/fmu-v6x/src/CMakeLists.txt
+++ b/boards/px4/fmu-v6x/src/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
 
 	target_link_libraries(drivers_board
 		PRIVATE
+			arch_io_pins
 			arch_spi
 			arch_board_hw_info
 			drivers__led # drv_led_start

--- a/boards/spracing/h7extreme/src/CMakeLists.txt
+++ b/boards/spracing/h7extreme/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(drivers_board
 
 target_link_libraries(drivers_board
 	PRIVATE
+		arch_io_pins
 		arch_spi
 		drivers__led # drv_led_start
 		nuttx_arch # sdio


### PR DESCRIPTION
## Describe the problem solved by this pull request
Linking issue for PX4 minimal build (reduced .px4board, useful for board recovery variant)  
`/GIT/PX4/Firmware/build/px4_fmu-v6x_recovery/../../boards/px4/fmu-v6x/src/init.c:144: undefined reference to 'io_timer_channel_get_as_pwm_input'`

To reproduce remove all modules that contain **arch_io_pins** px4board config 

## Describe your solution
Add missing link to **arch_io_pins** lib for `boards/init.c` where `io_timer_channel_get_as_pwm_input` is used. 

```
> grep -nr io_timer_channel_get_as_pwm_input boards

boards/holybro/durandal-v1/src/init.c:144:              px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/holybro/kakuteh7/src/init.c:129:         px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/holybro/pix32v5/src/init.c:143:          px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/holybro/kakutef7/src/init.c:124:         px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/nxp/fmuk66-e/src/init.c:120:             px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/nxp/fmuk66-v3/src/init.c:120:            px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/sky-drones/smartap-airlink/src/init.cpp:142:             px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/spracing/h7extreme/src/init.c:125:               px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/av/x-v1/src/init.c:94:           px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/modalai/fc-v1/src/init.c:141:            px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/modalai/fc-v2/src/init.c:139:            px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/cubepilot/cubeyellow/src/init.c:102:             px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/cubepilot/cubeorange/src/init.c:104:             px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/px4/fmu-v5x/src/init.cpp:145:            px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/px4/fmu-v6x/src/init.c:144:              px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/px4/fmu-v5/src/init.c:143:               px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/px4/fmu-v6u/src/init.c:144:              px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/cuav/x7pro/src/init.c:113:               px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/cuav/nora/src/init.c:113:                px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/matek/h743/src/init.c:94:                px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/matek/h743-mini/src/init.c:94:           px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/matek/h743-slim/src/init.c:98:           px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/mro/ctrl-zero-f7/src/init.c:132:         px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/mro/ctrl-zero-h7/src/init.c:107:         px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/mro/ctrl-zero-f7-oem/src/init.c:132:             px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/mro/ctrl-zero-h7-oem/src/init.c:107:             px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/mro/ctrl-zero-classic/src/init.c:107:            px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
boards/mro/pixracerpro/src/init.c:107:          px4_arch_configgpio(PX4_MAKE_GPIO_INPUT(io_timer_channel_get_as_pwm_input(i)));
```

