### PR TITLE
Pixhawk 6C Ethernet init stuff clean up. 

### DIFF
--- a/boards/px4/fmu-v6c/init/rc.board_defaults
+++ b/boards/px4/fmu-v6c/init/rc.board_defaults
@@ -9,12 +9,3 @@ param set-default BAT2_V_DIV 18.1
 
 param set-default BAT1_A_PER_V 36.367515152
 param set-default BAT2_A_PER_V 36.367515152
-
-# Mavlink ethernet (CFG 1000)
-param set-default MAV_2_CONFIG 1000
-param set-default MAV_2_BROADCAST 1
-param set-default MAV_2_MODE 0
-param set-default MAV_2_RADIO_CTL 0
-param set-default MAV_2_RATE 100000
-param set-default MAV_2_REMOTE_PRT 14550
-param set-default MAV_2_UDP_PRT 14550


### PR DESCRIPTION


## Problem:  
On the boot the Ethernet params are being initiated which are non-sense on 6C
<img width="462" alt="image" src="https://user-images.githubusercontent.com/46557204/182252968-c8ed6c92-7f38-417d-a8e6-d0394a18dd3b.png">

## solution
Cleaned up the init file. 



