### PR TITLE
CI - build on main as well

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,8 @@ pipeline {
     stage('Analysis') {
       when {
         anyOf {
-          branch 'master'
+          branch 'main'
+          branch 'master' // should be removed, but in case there is something going on...
           branch 'pr-jenkins' // for testing
         }
       }
@@ -217,7 +218,8 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              branch 'main'
+              branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }
@@ -245,7 +247,8 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              branch 'main'
+              branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }
@@ -278,7 +281,8 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              branch 'main'
+              branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }
@@ -307,7 +311,8 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              branch 'main'
+              branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }
@@ -350,7 +355,8 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              branch 'main'
+              branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }
@@ -373,7 +379,8 @@ pipeline {
           }
           when {
             anyOf {
-              branch 'master'
+              branch 'main'
+              branch 'master' // should be removed, but in case there is something going on...
               branch 'pr-jenkins' // for testing
             }
           }


### PR DESCRIPTION
CI does not appear to be working at all, and hasn't AFAIK since update to use main rather than master. As evidence I point to the jenkins page, which indicates nothing has run, and is idle (except main), which I kicked off. Also that no stuff from docs has been build for a month or so - though that co-incided with me changing docs to main, so could be multiple things going on.

I think there was no update to CI following moving to using main branch. 

As @dagar is on holiday, this change just updates jenkins to build for main as well as master. It shouldn't break anything because it is an "as well" build. Let's see if this does something useful.

![image](https://user-images.githubusercontent.com/5368500/182493777-f914b4f2-5a74-49f6-b19f-44c66c1dfd0c.png)
