### PR TITLE
FlightTaskAuto: apply cruise speed from position triplet also when negative to have default speed in RTL

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -342,12 +342,11 @@ bool FlightTaskAuto::_evaluateTriplets()
 	const float cruise_speed_from_triplet = _sub_triplet_setpoint.get().current.cruising_speed;
 
 	if (PX4_ISFINITE(cruise_speed_from_triplet)
-	    && (cruise_speed_from_triplet > 0.f)
 	    && (_sub_triplet_setpoint.get().current.timestamp > _time_last_cruise_speed_override)) {
 		_mc_cruise_speed = cruise_speed_from_triplet;
 	}
 
-	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f)) {
+	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < FLT_EPSILON)) {
 		// If no speed is planned use the default cruise speed as limit
 		_mc_cruise_speed = _param_mpc_xy_cruise.get();
 	}


### PR DESCRIPTION
Navigator sets the cruise_speed to -1 if the controller shouldn't listen to it and instead use the default speed (for MC: MPC_XY_CRUISE). This is for example for RTL the case, where we want to return at the default speed, independently of what the mission speed before was.

For FW the check for <0 was never there, it only checks isfinite() (like the MC controller now). 

Also added a minor cosmetic change in changing a `<0.0f` to `<FLT_EPSILON` as float comparisons against 0.0f are not recommended. 


