### PR TITLE
setEkfGlobalOrigin fixes

### DIFF
--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -733,9 +733,9 @@ bool Ekf::setEkfGlobalOrigin(const double latitude, const double longitude, cons
 
 			resetVerticalPositionTo(_gps_alt_ref - current_alt);
 
-			_baro_hgt_offset -= _state_reset_status.posD_change;
+			_baro_hgt_offset += _state_reset_status.posD_change;
 
-			_rng_hgt_offset -= _state_reset_status.posD_change;
+			_rng_hgt_offset += _state_reset_status.posD_change;
 			_ev_hgt_offset -= _state_reset_status.posD_change;
 		}
 

--- a/src/modules/ekf2/test/test_EKF_basics.cpp
+++ b/src/modules/ekf2/test/test_EKF_basics.cpp
@@ -223,7 +223,7 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_initialized)
 	_sensor_simulator.setGpsLatitude(_latitude_new);
 	_sensor_simulator.setGpsLongitude(_longitude_new);
 	_sensor_simulator.setGpsAltitude(_altitude_new);
-	_sensor_simulator.runSeconds(2);
+	_sensor_simulator.runSeconds(5);
 
 	_ekf->getEkfGlobalOrigin(_origin_time, _latitude, _longitude, _altitude);
 
@@ -231,8 +231,9 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_initialized)
 	EXPECT_DOUBLE_EQ(_longitude, _longitude_new);
 	EXPECT_NEAR(_altitude, _altitude_new, 0.01f);
 
-	_latitude_new  = -15.0000005;
-	_longitude_new = -115.0000005;
+	// Note: we cannot reset too far since the local position is limited to 1e6m
+	_latitude_new  = 14.0000005;
+	_longitude_new = 109.0000005;
 	_altitude_new  = 1500.0;
 
 	_ekf->setEkfGlobalOrigin(_latitude_new, _longitude_new, _altitude_new);
@@ -241,6 +242,8 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_initialized)
 	EXPECT_DOUBLE_EQ(_latitude, _latitude_new);
 	EXPECT_DOUBLE_EQ(_longitude, _longitude_new);
 	EXPECT_FLOAT_EQ(_altitude, _altitude_new);
+
+	_sensor_simulator.runSeconds(1);
 
 	float hpos = 0.f;
 	float vpos = 0.f;
@@ -275,6 +278,8 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_uninitialized)
 	EXPECT_DOUBLE_EQ(_latitude, _latitude_new);
 	EXPECT_DOUBLE_EQ(_longitude, _longitude_new);
 	EXPECT_FLOAT_EQ(_altitude, _altitude_new);
+
+	_sensor_simulator.runSeconds(1);
 
 	float hpos = 0.f;
 	float vpos = 0.f;

--- a/src/modules/ekf2/test/test_EKF_basics.cpp
+++ b/src/modules/ekf2/test/test_EKF_basics.cpp
@@ -249,12 +249,15 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_initialized)
 	float vpos = 0.f;
 	float hvel = 0.f;
 	float vvel = 0.f;
+	float baro_vpos = 0.f;
 
 	// After the change of origin, the pos and vel innovations should stay small
 	_ekf->getGpsVelPosInnovRatio(hvel, vvel, hpos, vpos);
+	_ekf->getBaroHgtInnovRatio(baro_vpos);
 
 	EXPECT_NEAR(hpos, 0.f, 0.05f);
 	EXPECT_NEAR(vpos, 0.f, 0.05f);
+	EXPECT_NEAR(baro_vpos, 0.f, 0.05f);
 
 	EXPECT_NEAR(hvel, 0.f, 0.02f);
 	EXPECT_NEAR(vvel, 0.f, 0.02f);


### PR DESCRIPTION
1. the test wasn't running properly because if the ekf doesn't run, the test ratio isn't populated, so the test ratio is 0
1. the maximum size of the local position origin is a cube of 1e6m. If the origin is moved further than this, the state is clipped to that maximum value. 
1. baro and range height offsets are "positive up" while `posD_change` is "positive down" so we need to add the `posD_change`