### PR TITLE
lightware dist sensor: set min range based on datasheet

### DIFF
--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -175,21 +175,21 @@ int LightwareLaser::init()
 
 	case 4:
 		/* SF11/c (120m 20Hz) */
-		_px4_rangefinder.set_min_distance(0.01f);
+		_px4_rangefinder.set_min_distance(0.2f);
 		_px4_rangefinder.set_max_distance(120.0f);
 		_conversion_interval = 50000;
 		break;
 
 	case 5:
 		/* SF/LW20/b (50m 48-388Hz) */
-		_px4_rangefinder.set_min_distance(0.001f);
+		_px4_rangefinder.set_min_distance(0.2f);
 		_px4_rangefinder.set_max_distance(50.0f);
 		_conversion_interval = 20834;
 		break;
 
 	case 6:
 		/* SF/LW20/c (100m 48-388Hz) */
-		_px4_rangefinder.set_min_distance(0.001f);
+		_px4_rangefinder.set_min_distance(0.2f);
 		_px4_rangefinder.set_max_distance(100.0f);
 		_conversion_interval = 20834;
 		_type = Type::LW20c;

--- a/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
@@ -106,7 +106,7 @@ LightwareLaserSerial::init()
 
 	case 5:
 		/* SF11/c (120m 20Hz) */
-		_px4_rangefinder.set_min_distance(0.01f);
+		_px4_rangefinder.set_min_distance(0.2f);
 		_px4_rangefinder.set_max_distance(120.0f);
 		_interval = 50000;
 		break;


### PR DESCRIPTION
SF11: https://www.documents.lightware.co.za/SF11%20-%20Laser%20Altimeter%20Manual%20-%20Rev%209.pdf
![DeepinScreenshot_select-area_20220808144536](https://user-images.githubusercontent.com/14822839/183421158-790c41f4-0493-4f91-92ab-35b12747bd8c.png)

SF/LW20: https://www.documents.lightware.co.za/SF11%20-%20Laser%20Altimeter%20Manual%20-%20Rev%209.pdf
![DeepinScreenshot_select-area_20220808144506](https://user-images.githubusercontent.com/14822839/183421072-0666034d-7b0f-4f30-bdeb-20b3ef4f1b86.png)

