### PR TITLE
Removed old ulanding driver

### DIFF
--- a/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.cpp
+++ b/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.cpp
@@ -101,24 +101,13 @@ int AerotennaULanding::collect()
 				bytes_processed = index;
 
 				while (bytes_processed < bytes_read && !checksum_passed) {
-					if (ULANDING_VERSION == 1) {
-						uint8_t checksum_value = (_buffer[index + 1] + _buffer[index + 2] + _buffer[index + 3] + _buffer[index + 4]) & 0xFF;
-						uint8_t checksum_byte = _buffer[index + 5];
-
-						if (checksum_value == checksum_byte) {
-							checksum_passed = true;
-							distance_cm = (_buffer[index + 3] << 8) | _buffer[index + 2];
-							distance_m = static_cast<float>(distance_cm) / 100.f;
-						}
-
-					} else {
+					uint8_t checksum_value = (_buffer[index + 1] + _buffer[index + 2] + _buffer[index + 3] + _buffer[index + 4]) & 0xFF;
+					uint8_t checksum_byte = _buffer[index + 5];
+					if (checksum_value == checksum_byte) {
 						checksum_passed = true;
-						distance_cm = (_buffer[index + 1] & 0x7F);
-						distance_cm += ((_buffer[index + 2] & 0x7F) << 7);
-						distance_m = static_cast<float>(distance_cm) * 0.045f;
-						break;
+						distance_cm = (_buffer[index + 3] << 8) | _buffer[index + 2];
+						distance_m = static_cast<float>(distance_cm) / 100.f;
 					}
-
 					bytes_processed++;
 				}
 			}

--- a/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.hpp
+++ b/src/drivers/distance_sensor/ulanding_radar/AerotennaULanding.hpp
@@ -59,15 +59,9 @@ using namespace time_literals;
 #define ULANDING_MEASURE_INTERVAL       10_ms
 #define ULANDING_MAX_DISTANCE	        50.0f
 #define ULANDING_MIN_DISTANCE	        0.315f
-#define ULANDING_VERSION	        1
 
-#if ULANDING_VERSION == 1
 #define ULANDING_PACKET_HDR     254
 #define ULANDING_BUFFER_LENGTH  18
-#else
-#define ULANDING_PACKET_HDR     72
-#define ULANDING_BUFFER_LENGTH  9
-#endif
 
 /**
  * Assume standard deviation to be equal to sensor resolution.


### PR DESCRIPTION
There was an old ulanding driver, which could be enabled by defining the `ULANDING_VERSION` symbol. I propose we remove this old code. I did some `git blame` sleuthing, and it appears that PX4 never supported users configuring `ULANDING_VERSION`. Today, the symbol is undocumented. I came across this because the I noticed the old driver has strange code that I can't reconcile with [ulanding's current documentation](https://aerotenna.readme.io/docs/%CE%BClanding-integration-references).