### PR TITLE
Switch to async AFBR measurement calls and use schedule.

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/API/Src/irq.c
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/API/Src/irq.c
@@ -2,6 +2,7 @@
 #include <nuttx/irq.h>
 
 static volatile irqstate_t irqstate_flags;
+static volatile size_t _lock_count = 0;
 
 /*!***************************************************************************
 * @brief Enable IRQ Interrupts
@@ -10,7 +11,13 @@ static volatile irqstate_t irqstate_flags;
 *****************************************************************************/
 void IRQ_UNLOCK(void)
 {
-	leave_critical_section(irqstate_flags);
+	if (_lock_count > 0) {
+		_lock_count--;
+
+		if (_lock_count == 0) {
+			leave_critical_section(irqstate_flags);
+		}
+	}
 }
 
 /*!***************************************************************************
@@ -20,5 +27,9 @@ void IRQ_UNLOCK(void)
 *****************************************************************************/
 void IRQ_LOCK(void)
 {
-	irqstate_flags = enter_critical_section();
+	if (_lock_count == 0) {
+		irqstate_flags = enter_critical_section();
+	}
+
+	_lock_count++;
 }


### PR DESCRIPTION
This PR changes the AFBR distance sensor driver to use the trigger measurement function instead of the API's built in measurement timer.

https://review.px4.io/plot_app?log=0eb19c71-da95-4341-84da-d547436b4039