### PR TITLE
Disable rear motors tilt

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -27,9 +27,7 @@ param set-default CA_ROTOR3_PY 0.1875
 param set-default CA_ROTOR3_KM -0.05
 
 param set-default CA_ROTOR0_TILT 1
-param set-default CA_ROTOR1_TILT 2
 param set-default CA_ROTOR2_TILT 3
-param set-default CA_ROTOR3_TILT 4
 param set-default CA_SV_CS0_TRQ_R -0.5
 param set-default CA_SV_CS0_TYPE 1
 param set-default CA_SV_CS1_TRQ_R 0.5


### PR DESCRIPTION
## Describe problem solved by this pull request
The tiltrotor model had all four motors tilting. However the most common quad tiltrotor configuration is the front two motors rotating, and the two rear motors fixed.

## Describe your solution
This PR modifies the current tiltrotor model to have only the front motors rotate in fixed wing mode


## Test data / coverage
Flight log: https://review.px4.io/plot_app?log=80077dd9-fb35-498e-8f5e-3d6711ac0add

[![Hovering drone](https://img.youtube.com/vi/Q9iYKR3eimo/0.jpg)](https://youtu.be/Q9iYKR3eimo)

## Additional context
- Submodule PR: https://github.com/PX4/PX4-SITL_gazebo/pull/890