### PR TITLE
Fix multicopter stabilized mode throttle scale jump during takeoff

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -96,17 +96,15 @@ MulticopterAttitudeControl::parameters_updated()
 float
 MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 {
-	const float throttle_min = _landed ? 0.0f : _param_mpc_manthr_min.get();
-
 	// throttle_stick_input is in range [0, 1]
 	switch (_param_mpc_thr_curve.get()) {
 	case 1: // no rescaling to hover throttle
-		return math::gradual(throttle_stick_input, 0.f, 1.f, throttle_min, _param_mpc_thr_max.get());
+		return math::gradual(throttle_stick_input, 0.f, 1.f, _param_mpc_manthr_min.get(), _param_mpc_thr_max.get());
 
 	default: // 0 or other: rescale to hover throttle at 0.5 stick
 		return math::gradual3(throttle_stick_input,
 				      0.f, .5f, 1.f,
-				      throttle_min, _param_mpc_thr_hover.get(), _param_mpc_thr_max.get());
+				      _param_mpc_manthr_min.get(), _param_mpc_thr_hover.get(), _param_mpc_thr_max.get());
 	}
 }
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -101,7 +101,7 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 	// throttle_stick_input is in range [0, 1]
 	switch (_param_mpc_thr_curve.get()) {
 	case 1: // no rescaling to hover throttle
-		return throttle_min + throttle_stick_input * (_param_mpc_thr_max.get() - throttle_min);
+		return math::gradual(throttle_stick_input, 0.f, 1.f, throttle_min, _param_mpc_thr_max.get());
 
 	default: // 0 or other: rescale to hover throttle at 0.5 stick
 		return math::gradual3(throttle_stick_input,


### PR DESCRIPTION
## Describe problem solved by this pull request
https://github.com/PX4/PX4-Autopilot/pull/12542 made the lowest possible throttle value commanded by stick in Stabilized mode before taking off 0. The real world problem with this is that when takeoff is detected then the entire throttle scaling range jumps from
[0, MPC_MANTHR_MIN] to [MPC_MANTHR_MIN, MPC_MANTHR_MIN].
As a result whenever MPC_MANTHR_MIN is not set to 0 there is a thrust jump on every takeoff just at the moment takeoff is detected even when the stick is moved continuously.

## Describe your solution
Because of this, I suggest reverting to having a higher throttle value from the beginning on because it's less complicated and there's no obvious value in starting out with zero thrust if it's anyways not possible to go back to zero for safety once takeoff is detected.

## Test data / coverage
I tested this in simulation:
![image](https://user-images.githubusercontent.com/4668506/183868438-46f0b42d-7473-4524-a6e8-41215b813432.png)

## Additional context
I found this problem while working on a helicopter that is really sensitive to thrust setpoint jumps. It twitched frightening on every takeoff in Stabilized mode because of this bug:
![image](https://user-images.githubusercontent.com/4668506/183869784-b6f908b9-7fe4-4941-9723-3df64a8e5691.png)