### PR TITLE
TIME_ESTIMATE_TO_TARGET: clarify unsupported message fields

### DIFF
--- a/src/modules/mavlink/streams/TIME_ESTIMATE_TO_TARGET.hpp
+++ b/src/modules/mavlink/streams/TIME_ESTIMATE_TO_TARGET.hpp
@@ -64,7 +64,13 @@ private:
 			_rtl_estimate_sub.copy(&rtl_estimate);
 
 			mavlink_time_estimate_to_target_t msg{};
-			msg.safe_return = rtl_estimate.safe_time_estimate;
+			msg.safe_return = static_cast<int32_t>(rtl_estimate.safe_time_estimate);
+
+			// Set to -1 explicitly because not supported (yet)
+			msg.land = -1;
+			msg.mission_next_item = -1;
+			msg.mission_end = -1;
+			msg.commanded_action = -1;
 
 			mavlink_msg_time_estimate_to_target_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
## Describe problem solved by this pull request
The [MAVLink message definition](https://mavlink.io/en/messages/common.html#TIME_ESTIMATE_TO_TARGET) says "-1 means no time estimate available." Since the original implementation from https://github.com/PX4/PX4-Autopilot/pull/20029 initializes all fields with zero they are in principle valid and available.

FYI @marcirsch

## Describe your solution
Fill unsupported fields with -1.
Also I made the cast of the estimated time for the RTL in seconds float in uORB to int32 in MAVLink explicit.

## Test data / coverage
Untested. This is purely based on code review.