### PR TITLE
mavlink: Add support for MISSION_CHANGED

### DIFF
--- a/msg/mission.msg
+++ b/msg/mission.msg
@@ -3,3 +3,7 @@ uint8 dataman_id	# default 0, there are two offboard storage places in the datam
 
 uint16 count		# count of the missions stored in the dataman
 int32 current_seq	# default -1, start at the one changed latest
+
+uint8 mission_changed	# True if mission changed
+uint8 origin_sysid	# Origin sysid of who uploaded mission
+uint8 origin_compid	# Origin compid of who uploaded mission

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1512,6 +1512,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("HYGROMETER_SENSOR", 0.1f);
 		configure_stream_local("SCALED_PRESSURE", 1.0f);
 		configure_stream_local("LOCAL_POSITION_NED", 1.0f);
+		configure_stream_local("MISSION_CHANGED", unlimited_rate);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.0f);
 		configure_stream_local("OBSTACLE_DISTANCE", 1.0f);
 		configure_stream_local("ORBIT_EXECUTION_STATUS", 2.0f);
@@ -1574,6 +1575,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("HOME_POSITION", 0.5f);
 		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 		configure_stream_local("SCALED_PRESSURE", 1.0f);
+		configure_stream_local("MISSION_CHANGED", unlimited_rate);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 10.0f);
 		configure_stream_local("OPTICAL_FLOW_RAD", 10.0f);
 		configure_stream_local("ORBIT_EXECUTION_STATUS", 5.0f);
@@ -1638,6 +1640,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("HOME_POSITION", 0.5f);
 		configure_stream_local("HYGROMETER_SENSOR", 1.0f);
 		configure_stream_local("SCALED_PRESSURE", 1.0f);
+		configure_stream_local("MISSION_CHANGED", unlimited_rate);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.5f);
 		configure_stream_local("OPTICAL_FLOW_RAD", 1.0f);
 		configure_stream_local("ORBIT_EXECUTION_STATUS", 5.0f);
@@ -1725,6 +1728,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SCALED_PRESSURE", 1.0f);
 		configure_stream_local("MAG_CAL_REPORT", 1.0f);
 		configure_stream_local("MANUAL_CONTROL", 5.0f);
+		configure_stream_local("MISSION_CHANGED", unlimited_rate);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 10.0f);
 		configure_stream_local("OPTICAL_FLOW_RAD", 10.0f);
 		configure_stream_local("ORBIT_EXECUTION_STATUS", 5.0f);
@@ -1804,6 +1808,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("GPS2_RAW", unlimited_rate);
 		configure_stream_local("GPS_RAW_INT", unlimited_rate);
 		configure_stream_local("HOME_POSITION", 0.5f);
+		configure_stream_local("MISSION_CHANGED", unlimited_rate);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.5f);
 		configure_stream_local("OPTICAL_FLOW_RAD", 1.0f);
 		configure_stream_local("ORBIT_EXECUTION_STATUS", 5.0f);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -92,6 +92,7 @@
 #include "streams/LOCAL_POSITION_NED.hpp"
 #include "streams/MAG_CAL_REPORT.hpp"
 #include "streams/MANUAL_CONTROL.hpp"
+#include "streams/MISSION_CHANGED.hpp"
 #include "streams/MOUNT_ORIENTATION.hpp"
 #include "streams/NAV_CONTROLLER_OUTPUT.hpp"
 #include "streams/OBSTACLE_DISTANCE.hpp"
@@ -395,6 +396,9 @@ static const StreamListItem streams_list[] = {
 #if defined(MAG_CAL_REPORT_HPP)
 	create_stream_list_item<MavlinkStreamMagCalReport>(),
 #endif // MAG_CAL_REPORT_HPP
+#if defined(MISSION_CHANGED_HPP)
+	create_stream_list_item<MavlinkStreamMissionChanged>(),
+#endif // MISSION_CHANGED_HPP
 #if defined(ODOMETRY_HPP)
 	create_stream_list_item<MavlinkStreamOdometry>(),
 #endif // ODOMETRY_HPP

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -159,7 +159,7 @@ private:
 
 	void init_offboard_mission();
 
-	int update_active_mission(dm_item_t dataman_id, uint16_t count, int32_t seq);
+	int update_active_mission(dm_item_t dataman_id, uint16_t count, int32_t seq, bool mission_changed);
 
 	/** store the geofence count to dataman */
 	int update_geofence_count(unsigned count);

--- a/src/modules/mavlink/streams/MISSION_CHANGED.hpp
+++ b/src/modules/mavlink/streams/MISSION_CHANGED.hpp
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef MISSION_CHANGED_HPP
+#define MISSION_CHANGED_HPP
+
+#include <uORB/topics/mission.h>
+
+class MavlinkStreamMissionChanged : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamMissionChanged(mavlink); }
+
+	static constexpr const char *get_name_static() { return "MISSION_CHANGED"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_MISSION_CHANGED; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		if (_mission_sub.advertised()) {
+			return MAVLINK_MSG_ID_MISSION_CHANGED_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+		}
+
+		return 0;
+	}
+
+private:
+	explicit MavlinkStreamMissionChanged(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _mission_sub{ORB_ID(mission)};
+
+	bool send() override
+	{
+		mission_s mission;
+
+		if (_mission_sub.update(&mission)) {
+
+			if (mission.mission_changed) {
+				mavlink_mission_changed_t msg{};
+				msg.start_index = -1; // All items
+				msg.end_index = -1; // Ignored
+				msg.origin_sysid = mission.origin_sysid;
+				msg.origin_compid = mission.origin_compid;
+				msg.mission_type = MAV_MISSION_TYPE_MISSION;
+
+				mavlink_msg_mission_changed_send_struct(_mavlink->get_channel(), &msg);
+				return true;
+
+			} else {
+				return false;
+			}
+		}
+
+		return false;
+	}
+};
+
+#endif // MISSION_CHANGED_HPP


### PR DESCRIPTION
This implements sending the MISSION_CHANGED message whenever a new mission has been uploaded.

This needed some extensions to the mission uORB message because it was not possible to know whether a mission has been uploaded from because the mission topic is also published when the current mission item has been changed.

Note that MISSION_CHANGED is currently defined in development.xml.

FYI @hamishwillee 