### PR TITLE
(Remote ID) Fill out and publish open drone id messages, open drone ID preflight check

### DIFF
--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -60,3 +60,4 @@ bool heartbeat_component_uart_bridge        # MAV_COMP_ID_UART_BRIDGE
 # Misc component health
 bool avoidance_system_healthy
 bool parachute_system_healthy
+bool open_drone_id_system_healthy

--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -45,6 +45,7 @@ bool heartbeat_type_gimbal                  # MAV_TYPE_GIMBAL
 bool heartbeat_type_adsb                    # MAV_TYPE_ADSB
 bool heartbeat_type_camera                  # MAV_TYPE_CAMERA
 bool heartbeat_type_parachute               # MAV_TYPE_PARACHUTE
+bool heartbeat_type_open_drone_id           # MAV_TYPE_ODID
 
 # Heartbeats per component
 bool heartbeat_component_telemetry_radio    # MAV_COMP_ID_TELEMETRY_RADIO

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -47,3 +47,4 @@ bool parachute_system_present
 bool parachute_system_healthy
 
 bool open_drone_id_system_present
+bool open_drone_id_system_healthy

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -45,3 +45,5 @@ bool avoidance_system_valid                       # Status of the obstacle avoid
 
 bool parachute_system_present
 bool parachute_system_healthy
+
+bool open_drone_id_system_present

--- a/src/modules/commander/Arming/HealthFlags/HealthFlags.h
+++ b/src/modules/commander/Arming/HealthFlags/HealthFlags.h
@@ -77,6 +77,7 @@ struct subsystem_info_s {
 	static constexpr uint64_t SUBSYSTEM_TYPE_PREARM_CHECK = 1 << 28;
 	static constexpr uint64_t SUBSYSTEM_TYPE_OBSTACLE_AVOIDANCE = 1 << 29;
 	static constexpr uint64_t SUBSYSTEM_TYPE_PARACHUTE = 1ULL << 32;
+	static constexpr uint64_t SUBSYSTEM_TYPE_OPEN_DRONE_ID = 1ULL << 33;
 };
 
 void set_health_flags(uint64_t subsystem_type, bool present, bool enabled, bool ok, vehicle_status_s &status);

--- a/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
+++ b/src/modules/commander/Arming/PreFlightCheck/CMakeLists.txt
@@ -52,6 +52,7 @@ px4_add_library(PreFlightCheck
 	checks/cpuResourceCheck.cpp
 	checks/sdcardCheck.cpp
 	checks/parachuteCheck.cpp
+	checks/openDroneIDCheck.cpp
 )
 target_include_directories(PreFlightCheck PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(PreFlightCheck PUBLIC ArmAuthorization HealthFlags sensor_calibration)

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -215,9 +215,13 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	failed = failed || !modeCheck(mavlink_log_pub, report_failures, status);
 	failed = failed || !cpuResourceCheck(mavlink_log_pub, report_failures);
 	failed = failed || !parachuteCheck(mavlink_log_pub, report_failures, status_flags);
-	failed = failed || !openDroneIDCheck(mavlink_log_pub, report_failures, status_flags);
 	failed = failed || !preArmCheck(mavlink_log_pub, status_flags, control_mode,
 					safety_button_available, safety_off, status, report_failures, is_arm_attempt);
+
+	if (prearm) {
+		failed = failed || !openDroneIDCheck(mavlink_log_pub, report_failures, status_flags);
+	}
+
 	/* Report status */
 	return !failed;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.cpp
@@ -215,9 +215,9 @@ bool PreFlightCheck::preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_statu
 	failed = failed || !modeCheck(mavlink_log_pub, report_failures, status);
 	failed = failed || !cpuResourceCheck(mavlink_log_pub, report_failures);
 	failed = failed || !parachuteCheck(mavlink_log_pub, report_failures, status_flags);
+	failed = failed || !openDroneIDCheck(mavlink_log_pub, report_failures, status_flags);
 	failed = failed || !preArmCheck(mavlink_log_pub, status_flags, control_mode,
 					safety_button_available, safety_off, status, report_failures, is_arm_attempt);
-
 	/* Report status */
 	return !failed;
 }

--- a/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
+++ b/src/modules/commander/Arming/PreFlightCheck/PreFlightCheck.hpp
@@ -103,6 +103,8 @@ private:
 	static bool sdcardCheck(orb_advert_t *mavlink_log_pub, bool &sd_card_detected_once, const bool report_fail);
 	static bool parachuteCheck(orb_advert_t *mavlink_log_pub, const bool report_fail,
 				   const vehicle_status_flags_s &status_flags);
+	static bool openDroneIDCheck(orb_advert_t *mavlink_log_pub, const bool report_fail,
+				     const vehicle_status_flags_s &status_flags);
 	static bool preArmCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
 				const vehicle_control_mode_s &control_mode, const bool safety_button_available, const bool safety_off,
 				vehicle_status_s &status, const bool report_fail, const bool is_arm_attempt);

--- a/src/modules/commander/Arming/PreFlightCheck/checks/openDroneIDCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/openDroneIDCheck.cpp
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "../PreFlightCheck.hpp"
+
+#include <lib/parameters/param.h>
+#include <lib/systemlib/mavlink_log.h>
+#include <px4_platform_common/events.h>
+
+bool PreFlightCheck::openDroneIDCheck(orb_advert_t *mavlink_log_pub, const bool report_fail,
+				      const vehicle_status_flags_s &status_flags)
+{
+	bool success = true;
+
+	int32_t param_com_prearm_odid = false;
+	param_get(param_find("COM_PREARM_ODID"), &param_com_prearm_odid);
+	const bool open_drone_id_required = param_com_prearm_odid != 0;
+
+	if (open_drone_id_required) {
+		if (!status_flags.open_drone_id_system_present) {
+			success = false;
+
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Fail: OpenDroneID system missing");
+				events::send(events::ID("commander_open_drone_id_missing"), events::Log::Critical, "OpenDroneID system missing");
+			}
+		}
+	}
+
+	return success;
+}

--- a/src/modules/commander/Arming/PreFlightCheck/checks/openDroneIDCheck.cpp
+++ b/src/modules/commander/Arming/PreFlightCheck/checks/openDroneIDCheck.cpp
@@ -54,6 +54,15 @@ bool PreFlightCheck::openDroneIDCheck(orb_advert_t *mavlink_log_pub, const bool 
 				mavlink_log_critical(mavlink_log_pub, "Fail: OpenDroneID system missing");
 				events::send(events::ID("commander_open_drone_id_missing"), events::Log::Critical, "OpenDroneID system missing");
 			}
+
+		} else if (!status_flags.open_drone_id_system_healthy) {
+			success = false;
+
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "Fail: OpenDroneID system not ready");
+				events::send(events::ID("commander_open_drone_id_system_not_ready"), events::Log::Critical,
+					     "OpenDroneID system not ready");
+			}
 		}
 	}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3668,8 +3668,12 @@ void Commander::data_link_check()
 					}
 				}
 
+				bool healthy = telemetry.open_drone_id_system_healthy;
+
 				_datalink_last_heartbeat_open_drone_id_system = telemetry.timestamp;
 				_vehicle_status_flags.open_drone_id_system_present = true;
+				_vehicle_status_flags.open_drone_id_system_healthy = healthy;
+				set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_OPEN_DRONE_ID, true, true, healthy, _vehicle_status);
 			}
 
 			if (telemetry.heartbeat_component_obstacle_avoidance) {
@@ -3729,8 +3733,10 @@ void Commander::data_link_check()
 		mavlink_log_critical(&_mavlink_log_pub, "OpenDroneID system lost");
 		events::send(events::ID("commander_open_drone_id_lost"), events::Log::Critical, "OpenDroneID system lost");
 		_vehicle_status_flags.open_drone_id_system_present = false;
+		_vehicle_status_flags.open_drone_id_system_healthy = false;
 		_open_drone_id_system_lost = true;
 		_status_changed = true;
+		set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_OPEN_DRONE_ID, false, true, false, _vehicle_status);
 	}
 
 	// AVOIDANCE SYSTEM state check (only if it is enabled)

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -330,9 +330,11 @@ private:
 	hrt_abstime	_datalink_last_heartbeat_avoidance_system{0};
 	hrt_abstime	_datalink_last_heartbeat_onboard_controller{0};
 	hrt_abstime	_datalink_last_heartbeat_parachute_system{0};
+	hrt_abstime	_datalink_last_heartbeat_open_drone_id_system{0};
 	bool		_onboard_controller_lost{false};
 	bool		_avoidance_system_lost{false};
 	bool		_parachute_system_lost{true};
+	bool		_open_drone_id_system_lost{true};
 
 	hrt_abstime	_high_latency_datalink_heartbeat{0};
 	hrt_abstime	_high_latency_datalink_lost{0};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -925,6 +925,23 @@ PARAM_DEFINE_INT32(COM_ARM_CHK_ESCS, 0);
 PARAM_DEFINE_INT32(COM_PREARM_MODE, 0);
 
 /**
+ * Enable pre-arm check on OpenDroneID.
+ *
+ * If this parameter is set, the pre-arm mechanism will check for the OpenDroneID system and prevent arming if it is not present.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_PREARM_ODID, 0);
+
+/*
+ * Allow arming without onboard logger being enabled and in ready state
+ *
+ * The default allows the vehicle to arm without the onboard logger reporting as ready via it's heartbeat
+ */
+PARAM_DEFINE_INT32(COM_ARM_WO_OBLOG, 0);
+
+/**
  * Enable force safety
  *
  * Force safety when the vehicle disarms

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1524,6 +1524,8 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SYS_STATUS", 1.0f);
 		configure_stream_local("TIME_ESTIMATE_TO_TARGET", 1.0f);
 		configure_stream_local("UTM_GLOBAL_POSITION", 0.5f);
+		configure_stream_local("OPEN_DRONE_ID_BASIC_ID", 1.f);
+		configure_stream_local("OPEN_DRONE_ID_LOCATION", 1.f);
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("VIBRATION", 0.1f);
 		configure_stream_local("WIND_COV", 0.5f);
@@ -1591,6 +1593,8 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 10.0f);
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 10.0f);
+		configure_stream_local("OPEN_DRONE_ID_BASIC_ID", 1.f);
+		configure_stream_local("OPEN_DRONE_ID_LOCATION", 1.f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 10.0f);
@@ -1744,6 +1748,8 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 20.0f);
 		configure_stream_local("VIBRATION", 2.5f);
 		configure_stream_local("WIND_COV", 10.0f);
+		configure_stream_local("OPEN_DRONE_ID_BASIC_ID", 1.f);
+		configure_stream_local("OPEN_DRONE_ID_LOCATION", 1.f);
 
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 50.0f);
@@ -1819,7 +1825,9 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("VIBRATION", 0.5f);
 		configure_stream_local("WIND_COV", 1.0f);
-
+		configure_stream_local("SYSTEM_TIME", 2.0f);
+		configure_stream_local("OPEN_DRONE_ID_BASIC_ID", 1.f);
+		configure_stream_local("OPEN_DRONE_ID_LOCATION", 1.f);
 #if !defined(CONSTRAINED_FLASH)
 		configure_stream_local("DEBUG", 1.0f);
 		configure_stream_local("DEBUG_FLOAT_ARRAY", 1.0f);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -118,6 +118,8 @@
 #include "streams/VFR_HUD.hpp"
 #include "streams/VIBRATION.hpp"
 #include "streams/WIND_COV.hpp"
+#include "streams/OPEN_DRONE_ID_BASIC_ID.hpp"
+#include "streams/OPEN_DRONE_ID_LOCATION.hpp"
 
 #if !defined(CONSTRAINED_FLASH)
 # include "streams/ADSB_VEHICLE.hpp"
@@ -554,9 +556,16 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamEfiStatus>(),
 #endif // EFI_STATUS_HPP
 #if defined(GPS_RTCM_DATA_HPP)
-	create_stream_list_item<MavlinkStreamGPSRTCMData>()
+	create_stream_list_item<MavlinkStreamGPSRTCMData>(),
 #endif // GPS_RTCM_DATA_HPP
+#if defined(OPEN_DRONE_ID_BASIC_ID_HPP)
+	create_stream_list_item<MavlinkStreamOpenDroneIdBasicId>(),
+#endif // OPEN_DRONE_ID_BASIC_ID_HPP
+#if defined(OPEN_DRONE_ID_LOCATION)
+	create_stream_list_item<MavlinkStreamOpenDroneIdLocation>()
+#endif // OPEN_DRONE_ID_LOCATION
 };
+
 
 const char *get_stream_name(const uint16_t msg_id)
 {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2237,6 +2237,10 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 					(hb.system_status == MAV_STATE_STANDBY) || (hb.system_status == MAV_STATE_ACTIVE);
 				break;
 
+			case MAV_TYPE_ODID:
+				_heartbeat_type_open_drone_id = now;
+				break;
+
 			default:
 				PX4_DEBUG("unhandled HEARTBEAT MAV_TYPE: %" PRIu8 " from SYSID: %" PRIu8 ", COMPID: %" PRIu8, hb.type, msg->sysid,
 					  msg->compid);
@@ -3043,6 +3047,7 @@ void MavlinkReceiver::CheckHeartbeats(const hrt_abstime &t, bool force)
 		tstatus.heartbeat_type_adsb                    = (t <= TIMEOUT + _heartbeat_type_adsb);
 		tstatus.heartbeat_type_camera                  = (t <= TIMEOUT + _heartbeat_type_camera);
 		tstatus.heartbeat_type_parachute               = (t <= TIMEOUT + _heartbeat_type_parachute);
+		tstatus.heartbeat_type_open_drone_id           = (t <= TIMEOUT + _heartbeat_type_open_drone_id);
 
 		tstatus.heartbeat_component_telemetry_radio    = (t <= TIMEOUT + _heartbeat_component_telemetry_radio);
 		tstatus.heartbeat_component_log                = (t <= TIMEOUT + _heartbeat_component_log);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2239,6 +2239,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 
 			case MAV_TYPE_ODID:
 				_heartbeat_type_open_drone_id = now;
+				_mavlink->telemetry_status().open_drone_id_system_healthy =
+					(hb.system_status == MAV_STATE_STANDBY) || (hb.system_status == MAV_STATE_ACTIVE);
 				break;
 
 			default:

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -385,6 +385,7 @@ private:
 	hrt_abstime _heartbeat_type_adsb{0};
 	hrt_abstime _heartbeat_type_camera{0};
 	hrt_abstime _heartbeat_type_parachute{0};
+	hrt_abstime _heartbeat_type_open_drone_id{0};
 
 	hrt_abstime _heartbeat_component_telemetry_radio{0};
 	hrt_abstime _heartbeat_component_log{0};

--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_BASIC_ID.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_BASIC_ID.hpp
@@ -1,0 +1,178 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef OPEN_DRONE_ID_BASIC_ID_HPP
+#define OPEN_DRONE_ID_BASIC_ID_HPP
+
+#include <uORB/topics/vehicle_status.h>
+
+class MavlinkStreamOpenDroneIdBasicId : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamOpenDroneIdBasicId(mavlink); }
+
+	static constexpr const char *get_name_static() { return "OPEN_DRONE_ID_BASIC_ID"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_OPEN_DRONE_ID_BASIC_ID_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+private:
+	explicit MavlinkStreamOpenDroneIdBasicId(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+
+	MAV_ODID_UA_TYPE odidTypeForMavType(uint8_t system_type)
+	{
+		switch (system_type) {
+		case MAV_TYPE_GENERIC: return MAV_ODID_UA_TYPE_OTHER;
+
+		case MAV_TYPE_FIXED_WING: return MAV_ODID_UA_TYPE_AEROPLANE;
+
+		case MAV_TYPE_QUADROTOR: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_COAXIAL: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_HELICOPTER: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_ANTENNA_TRACKER: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_GCS: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_AIRSHIP: return MAV_ODID_UA_TYPE_AIRSHIP;
+
+		case MAV_TYPE_FREE_BALLOON: return MAV_ODID_UA_TYPE_FREE_BALLOON;
+
+		case MAV_TYPE_ROCKET: return MAV_ODID_UA_TYPE_ROCKET;
+
+		case MAV_TYPE_GROUND_ROVER: return MAV_ODID_UA_TYPE_GROUND_OBSTACLE;
+
+		case MAV_TYPE_SURFACE_BOAT: return MAV_ODID_UA_TYPE_OTHER;
+
+		case MAV_TYPE_SUBMARINE: return MAV_ODID_UA_TYPE_OTHER;
+
+		case MAV_TYPE_HEXAROTOR: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_OCTOROTOR: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_TRICOPTER: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_FLAPPING_WING: return MAV_ODID_UA_TYPE_ORNITHOPTER;
+
+		case MAV_TYPE_KITE: return MAV_ODID_UA_TYPE_KITE;
+
+		case MAV_TYPE_ONBOARD_CONTROLLER: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_VTOL_TAILSITTER_DUOROTOR: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_VTOL_TAILSITTER_QUADROTOR: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_VTOL_TILTROTOR: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_VTOL_FIXEDROTOR: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_VTOL_TAILSITTER: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_VTOL_RESERVED4: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_VTOL_RESERVED5: return MAV_ODID_UA_TYPE_HYBRID_LIFT;
+
+		case MAV_TYPE_GIMBAL: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_ADSB: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_PARAFOIL: return 	MAV_ODID_UA_TYPE_FREE_FALL_PARACHUTE;
+
+		case MAV_TYPE_DODECAROTOR: return MAV_ODID_UA_TYPE_HELICOPTER_OR_MULTIROTOR;
+
+		case MAV_TYPE_CAMERA: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_CHARGING_STATION: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_FLARM: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_SERVO: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_ODID: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_DECAROTOR: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_BATTERY: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_PARACHUTE: return MAV_ODID_UA_TYPE_FREE_FALL_PARACHUTE;
+
+		case MAV_TYPE_LOG: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_OSD: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_IMU: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_GPS: return MAV_ODID_UA_TYPE_NONE;
+
+		case MAV_TYPE_WINCH: return MAV_ODID_UA_TYPE_NONE;
+
+		default: return MAV_ODID_UA_TYPE_OTHER;
+		}
+	}
+
+
+	bool send() override
+	{
+		if (_vehicle_status_sub.updated()) {
+			vehicle_status_s vehicle_status{};
+			_vehicle_status_sub.copy(&vehicle_status);
+
+			mavlink_open_drone_id_basic_id_t msg;
+
+
+			board_get_px4_guid_formated((char *)(msg.uas_id), sizeof(msg.uas_id));
+			msg.id_type = MAV_ODID_ID_TYPE_SERIAL_NUMBER;
+			msg.ua_type = odidTypeForMavType(vehicle_status.system_type);
+			msg.target_component = 0;
+			msg.target_system = 0;
+
+			mavlink_msg_open_drone_id_basic_id_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // OPEN_DRONE_ID_BASIC_ID_HPP

--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_LOCATION.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_LOCATION.hpp
@@ -1,0 +1,149 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef OPEN_DRONE_ID_LOCATION
+#define OPEN_DRONE_ID_LOCATION
+
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_global_position.h>
+
+class MavlinkStreamOpenDroneIdLocation : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamOpenDroneIdLocation(mavlink); }
+
+	static constexpr const char *get_name_static() { return "OPEN_DRONE_ID_LOCATION"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_OPEN_DRONE_ID_LOCATION; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		return MAVLINK_MSG_ID_OPEN_DRONE_ID_LOCATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+private:
+	explicit MavlinkStreamOpenDroneIdLocation(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
+
+	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+
+	bool _airborne = false;
+	bool _in_failsafe = false;
+	mavlink_open_drone_id_location_t _message;
+
+	bool send() override
+	{
+		bool updated = false;
+
+		if (_vehicle_status_sub.updated()) {
+			vehicle_status_s vehicle_status{};
+			_vehicle_status_sub.copy(&vehicle_status);
+			_in_failsafe = vehicle_status.failsafe;
+		}
+
+		if (_vehicle_land_detected_sub.updated()) {
+			vehicle_land_detected_s vehicle_land_detected;
+			_vehicle_land_detected_sub.copy(&vehicle_land_detected);
+			_airborne = !vehicle_land_detected.landed;
+		}
+
+		_message.target_component = 0;
+		_message.target_system = 0;
+		_message.height_reference = MAV_ODID_HEIGHT_REF_OVER_TAKEOFF;
+		_message.horizontal_accuracy = MAV_ODID_HOR_ACC_UNKNOWN;
+		_message.vertical_accuracy = MAV_ODID_VER_ACC_UNKNOWN;
+		_message.barometer_accuracy = MAV_ODID_VER_ACC_UNKNOWN;
+		_message.speed_accuracy = MAV_ODID_SPEED_ACC_UNKNOWN;
+
+		_message.status = MAV_ODID_STATUS_GROUND;
+
+		if (_airborne) {
+			_message.status = MAV_ODID_STATUS_AIRBORNE;
+		}
+
+		if (_in_failsafe) {
+			_message.status = MAV_ODID_STATUS_EMERGENCY;
+		}
+
+		if (_vehicle_global_position_sub.updated()) {
+			vehicle_global_position_s vgp;
+			_vehicle_global_position_sub.copy(&vgp);
+			_message.latitude = static_cast<int32_t>(vgp.lat * 1e7);
+			_message.longitude = static_cast<int32_t>(vgp.lon * 1e7);
+			_message.altitude_barometric = vgp.alt;
+			_message.altitude_geodetic = vgp.alt_ellipsoid;
+			updated = true;
+		}
+
+
+		if (_vehicle_local_position_sub.updated()) {
+			vehicle_local_position_s vlp;
+			_vehicle_local_position_sub.copy(&vlp);
+			float speed_xy = sqrtf(vlp.vx * vlp.vx + vlp.vy * vlp.vy);
+			float direction_deg = (atan2f(vlp.vy, vlp.vx) + M_PI_F) * 180.f / M_PI_F;
+			_message.speed_horizontal = vlp.v_xy_valid ?
+						    static_cast<uint16_t>(math::min(25425.f, speed_xy * 100.f)) : 25500;
+			_message.speed_vertical = vlp.v_z_valid ?
+						  static_cast<int16_t>(math::min(6200.f, math::max(-6200.f, -vlp.vz * 100.f))) : 6300;
+			_message.direction = vlp.v_xy_valid ? static_cast<uint16_t>(direction_deg * 100.f) : 36100;
+			_message.height = vlp.z_valid ? -vlp.z : -1000;
+			updated = true;
+		}
+
+		struct timespec ts = {};
+
+		px4_clock_gettime(CLOCK_REALTIME, &ts);
+
+		long utc_time_msec = ts.tv_sec * 1000 + (ts.tv_nsec / 1e6);
+
+		_message.timestamp = static_cast<float>(utc_time_msec % 3600000L) / 1000.f;
+
+		_message.timestamp_accuracy = MAV_ODID_TIME_ACC_UNKNOWN;
+
+		if (updated) {
+			mavlink_msg_open_drone_id_location_send_struct(_mavlink->get_channel(), &_message);
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // OPEN_DRONE_ID_LOCATION


### PR DESCRIPTION
## Describe problem solved by this pull request
This PR adds mavlink streams for some of the Open Drone ID messages to be streamed over mavlink 
The messages can then be picked up by transceivers connected to the autopilot to be sent out.

This also adds a check for the heartbeat of the ODID system, as well as a pre-arm check to prevent arming in case the heartbeat is not received or does not indicate healthy.

## Describe your solution
Adds mavlink streams for open drone id messages and adds a pre-arm check