### PR TITLE
mavlink_ftp: fix to correctly trim reply messages

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -331,6 +331,9 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 		memcpy(_last_reply, ftp_req, sizeof(_last_reply));
 	}
 
+	// clear any not used payload data to correctly trim mavlink ftp message reply
+	memset(&payload->data[payload->size], 0, kMaxDataLength - payload->size);
+
 	PX4_DEBUG("FTP: %s seq_number: %" PRIu16, payload->opcode == kRspAck ? "Ack" : "Nak", payload->seq_number);
 
 #ifdef MAVLINK_FTP_UNIT_TEST


### PR DESCRIPTION
Clear any not used payload data to correctly trim mavlink ftp message reply to avoid sending long ACK and NACK messages.

File upload before patch:
![изображение](https://user-images.githubusercontent.com/3624285/184106853-bdc2983b-0ed2-4a40-afc8-6537e66406a5.png)
Full size 308 bytes acknowledgments that replicate requested packet disregarding that `payload->size` is set for 4 bytes (bytes written).

After patch:
![изображение](https://user-images.githubusercontent.com/3624285/184108349-5380a2d4-c54c-48a1-857f-5878c82624c7.png)
Correctly trimmed acknowledgments.

I supposed same thing have to be done in QGC.

It would be more efficient instead of `memset` to pass somehow payload size to `mavlink_msg_file_transfer_protocol_send_struct()` but as I understand it is not convenient by mavlink architecture.

I've tested this with file upload and a little with file download with custom board and custom fork based on older px4. Please feel free to edit if needed.

This should speed up mavlink ftp transfer a little especially if also applied to GSC side.