### PR TITLE
adis16470: fix accel and gyro scaling

### DIFF
--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -379,7 +379,7 @@ bool ADIS16470::Configure()
 	_px4_accel.set_range(40.f * CONSTANTS_ONE_G);
 	_px4_accel.set_scale(CONSTANTS_ONE_G / 800.f); // scaling 800 LSB/g -> m/s^2 per LSB
 
-	// gyro: ±2000, 10 LSB/°/sec (16-bit format)
+	// gyro: ±2000 °/sec, 10 LSB/°/sec (16-bit format)
 	_px4_gyro.set_range(math::radians(2000.f));
 	_px4_gyro.set_scale(math::radians(1.f / 10.f)); // scaling 10 LSB/°/sec -> rad/s per LSB
 

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.cpp
@@ -375,13 +375,13 @@ bool ADIS16470::Configure()
 		}
 	}
 
-	_px4_accel.set_scale(CONSTANTS_ONE_G / 2048.f);
+	// accel: ±40 g, 800 LSB/g (16-bit format)
 	_px4_accel.set_range(40.f * CONSTANTS_ONE_G);
-	_px4_gyro.set_scale(math::radians(1.f / 0.1f)); // 1 LSB = 0.1°/sec
-	_px4_gyro.set_range(math::radians(2000.f));
+	_px4_accel.set_scale(CONSTANTS_ONE_G / 800.f); // scaling 800 LSB/g -> m/s^2 per LSB
 
-	_px4_accel.set_scale(1.25f * CONSTANTS_ONE_G / 1000.0f); // accel 1.25 mg/LSB
-	_px4_gyro.set_scale(math::radians(0.025f)); // gyro 0.025 °/sec/LSB
+	// gyro: ±2000, 10 LSB/°/sec (16-bit format)
+	_px4_gyro.set_range(math::radians(2000.f));
+	_px4_gyro.set_scale(math::radians(1.f / 10.f)); // scaling 10 LSB/°/sec -> rad/s per LSB
 
 	return success;
 }


### PR DESCRIPTION
![Screenshot from 2022-08-15 09-04-03](https://user-images.githubusercontent.com/84712/184640171-a42ea6e2-7210-430a-bf05-d9823909cfd4.png)

Accel scaling was equivalent, but this shows how it's directly derived from the datasheet. Gyro scaling was wrong (and being overwritten). 