### PR TITLE
[WIP]Add secondary geofence at an outer offset distance from the primary geofence.

### DIFF
--- a/msg/GeofenceResult.msg
+++ b/msg/GeofenceResult.msg
@@ -1,14 +1,17 @@
-uint64 timestamp                        # time since system start (microseconds)
-uint8 GF_ACTION_NONE = 0                # no action on geofence violation
-uint8 GF_ACTION_WARN = 1                # critical mavlink message
-uint8 GF_ACTION_LOITER = 2              # switch to AUTO|LOITER
-uint8 GF_ACTION_RTL = 3                 # switch to AUTO|RTL
-uint8 GF_ACTION_TERMINATE = 4           # flight termination
-uint8 GF_ACTION_LAND = 5                # switch to AUTO|LAND
+uint64 timestamp                # time since system start (microseconds)
+uint8 GF_ACTION_NONE      = 0   # no action on geofence violation
+uint8 GF_ACTION_WARN      = 1   # critical mavlink message
+uint8 GF_ACTION_LOITER    = 2   # switch to AUTO|LOITER
+uint8 GF_ACTION_RTL       = 3   # switch to AUTO|RTL
+uint8 GF_ACTION_TERMINATE = 4   # flight termination
+uint8 GF_ACTION_LAND      = 5   # switch to AUTO|LAND
 
-uint8 geofence_violation_reason         # one of geofence_violation_reason_t::*
+bool max_altitude_exceeded       # true if the maximum altitude allowed is exceeded
+bool max_distance_exceeded       # true if the maximum distance from home allowed is exceeded
+bool primary_geofence_breached   # true if the primary geofence is breached
+bool secondary_geofence_breached # true if the secondary geofence is breached
 
-bool primary_geofence_breached          # true if the primary geofence is breached
-uint8 primary_geofence_action           # action to take when the primary geofence is breached
+uint8 primary_geofence_action    # action to take when the primary geofence is breached
+uint8 secondary_geofence_action  # action to take when the secondary geofence is breached
 
-bool home_required                      # true if the geofence requires a valid home position
+bool home_required               # true if the geofence requires a valid home position

--- a/src/lib/geo/geo.h
+++ b/src/lib/geo/geo.h
@@ -72,11 +72,13 @@ static constexpr float CONSTANTS_EARTH_SPIN_RATE = 7.2921150e-5f;				// radians/
 
 // XXX remove
 struct crosstrack_error_s {
-	bool past_end;		// Flag indicating we are past the end of the line/arc segment
-	float distance;		// Distance in meters to closest point on line/arc
-	float bearing;		// Bearing in radians to closest point on line/arc
+	bool before_start;	 // Flag indicating the vehicle is before the start of the line/arc segment
+	bool past_end;		 // Flag indicating the vehicle is past the end of the line/arc segment
+	float distance_to_start; // Distance in meters to closest endpoint on line/arc segment
+	float distance_to_end;	 // Distance in meters to closest endpoint on line/arc segment
+	float distance;		 // Distance in meters to closest point on line/arc
+	float bearing;		 // Bearing in radians to closest point on line/arc
 } ;
-
 
 /**
  * Returns the distance to the next waypoint in meters.
@@ -114,7 +116,8 @@ void create_waypoint_from_line_and_dist(double lat_A, double lon_A, double lat_B
  * @param lat_target latitude of target waypoint in degrees (47.1234567°, not 471234567°)
  * @param lon_target longitude of target waypoint in degrees (47.1234567°, not 471234567°)
  */
-void waypoint_from_heading_and_distance(double lat_start, double lon_start, float bearing, float dist,
+void waypoint_from_heading_and_distance(const double lat_start, const double lon_start, const float bearing,
+					const float dist,
 					double *lat_target, double *lon_target);
 
 /**

--- a/src/lib/geo/geo.h
+++ b/src/lib/geo/geo.h
@@ -116,8 +116,7 @@ void create_waypoint_from_line_and_dist(double lat_A, double lon_A, double lat_B
  * @param lat_target latitude of target waypoint in degrees (47.1234567°, not 471234567°)
  * @param lon_target longitude of target waypoint in degrees (47.1234567°, not 471234567°)
  */
-void waypoint_from_heading_and_distance(const double lat_start, const double lon_start, const float bearing,
-					const float dist,
+void waypoint_from_heading_and_distance(double lat_start, double lon_start, float bearing, float dist,
 					double *lat_target, double *lon_target);
 
 /**

--- a/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.hpp
@@ -50,10 +50,11 @@ private:
 	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::CBRK_VTOLARMING>) _param_cbrk_vtolarming,
-					(ParamInt<px4::params::CBRK_USB_CHK>) _param_cbrk_usb_chk,
-					(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_com_arm_wo_gps,
-					(ParamInt<px4::params::COM_ARM_AUTH_REQ>) _param_com_arm_auth_req,
-					(ParamInt<px4::params::GF_ACTION>) _param_gf_action
-				       )
+		(ParamInt<px4::params::CBRK_VTOLARMING>)   _param_cbrk_vtolarming,
+		(ParamInt<px4::params::CBRK_USB_CHK>)      _param_cbrk_usb_chk,
+		(ParamBool<px4::params::COM_ARM_WO_GPS>)   _param_com_arm_wo_gps,
+		(ParamInt<px4::params::COM_ARM_AUTH_REQ>)  _param_com_arm_auth_req,
+		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,
+		(ParamInt<px4::params::GF2_ACTION>)        _param_gf2_action
+	       )
 };

--- a/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
+++ b/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
@@ -339,7 +339,7 @@ private:
 		geofence_result_s geofence;
 
 		if (_geofence_sub.update(&geofence)) {
-			if (geofence.primary_geofence_breached) {
+			if (geofence.primary_geofence_breached || geofence.secondary_geofence_breached) {
 				msg->failure_flags |= HL_FAILURE_FLAG_GEOFENCE;
 			}
 

--- a/src/modules/navigator/GeofenceBreachAvoidance/fake_geofence.hpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/fake_geofence.hpp
@@ -51,7 +51,7 @@ public:
 
 	virtual ~FakeGeofence() {};
 
-	bool isInsidePolygonOrCircle(double lat, double lon, float altitude) override
+	bool isFakePrimaryGeofenceBreached(double lat, double lon, float altitude)
 	{
 		switch (_probe_function_behavior) {
 		case ProbeFunction::ALL_POINTS_OUTSIDE: {

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
@@ -33,22 +33,14 @@
 
 #include <lib/mathlib/mathlib.h>
 #include <px4_platform_common/module_params.h>
-#include "../geofence.h"
 #include <px4_platform_common/defines.h>
+#include <uORB/topics/geofence_result.h>
+#include "../geofence.h"
 
 
 class Geofence;
 
 #define GEOFENCE_CHECK_INTERVAL_US 200000
-
-union geofence_violation_type_u {
-	struct {
-		bool dist_to_home_exceeded: 1;	///< 0 - distance to home exceeded
-		bool max_altitude_exceeded: 1;	///< 1 - maximum altitude exceeded
-		bool fence_violation: 1;	///< 2- violation of user defined fence
-	} flags;
-	uint8_t value;
-};
 
 class GeofenceBreachAvoidance : public ModuleParams
 {
@@ -59,47 +51,52 @@ public:
 
 	matrix::Vector2<double> getFenceViolationTestPoint();
 
-	matrix::Vector2<double> waypointFromBearingAndDistance(matrix::Vector2<double> current_pos_lat_lon,
-			float test_point_bearing, float test_point_distance);
+	matrix::Vector2<double> waypointFromBearingAndDistance(matrix::Vector2<double> const current_pos_lat_lon,
+			const float test_point_bearing, const float test_point_distance);
 
-	matrix::Vector2<double>
-	generateLoiterPointForFixedWing(geofence_violation_type_u violation_type, Geofence *geofence);
+	matrix::Vector2<double> generateLoiterPointForFixedWing(geofence_result_s geofence_result, Geofence *geofence);
 
 	float computeBrakingDistanceMultirotor();
 
 	float computeVerticalBrakingDistanceMultirotor();
 
-	matrix::Vector2<double> generateLoiterPointForMultirotor(geofence_violation_type_u violation_type, Geofence *geofence);
+	matrix::Vector2<double> generateLoiterPointForMultirotor(geofence_result_s geofence_result, Geofence *geofence);
 
-	float generateLoiterAltitudeForFixedWing(geofence_violation_type_u violation_type);
+	float generateLoiterAltitudeForFixedWing(geofence_result_s geofence_result);
 
-	float generateLoiterAltitudeForMulticopter(geofence_violation_type_u violation_type);
+	float generateLoiterAltitudeForMulticopter(geofence_result_s geofence_result);
 
 	float getMinHorDistToFenceMulticopter() {return _min_hor_dist_to_fence_mc;}
 
 	float getMinVertDistToFenceMultirotor() {return _min_vert_dist_to_fence_mc;}
 
-	void setTestPointBearing(float test_point_bearing) { _test_point_bearing = test_point_bearing; }
+	void setTestPointBearing(const float test_point_bearing) { _test_point_bearing = test_point_bearing; }
 
-	void setHorizontalTestPointDistance(float test_point_distance) { _test_point_distance = test_point_distance; }
+	void setHorizontalTestPointDistance(const float test_point_distance) { _test_point_distance = test_point_distance; }
 
-	void setVerticalTestPointDistance(float distance) { _vertical_test_point_distance = distance; }
+	void setVerticalTestPointDistance(const float distance) { _vertical_test_point_distance = distance; }
 
-	void setHorizontalVelocity(float velocity_hor_abs) { _velocity_hor_abs = velocity_hor_abs; }
+	void setHorizontalVelocity(const float velocity_hor_abs) { _velocity_hor_abs = velocity_hor_abs; }
 
-	void setClimbRate(float climbrate) { _climbrate = climbrate; }
+	void setClimbRate(const float climbrate) { _climbrate = climbrate; }
 
-	void setCurrentPosition(double lat, double lon, float alt);
+	void setCurrentPosition(const double lat, const double lon, const float alt);
 
-	void setHomePosition(double lat, double lon, float alt);
+	void setHomePosition(const double lat, const double lon, const float alt);
 
-	void setMaxHorDistHome(float dist) { _max_hor_dist_home = dist; }
+	void setMaxHorDistHome(const float dist) { _max_hor_dist_home = dist; }
 
-	void setMaxVerDistHome(float dist) { _max_ver_dist_home = dist; }
+	void setMaxVerDistHome(const float dist) { _max_ver_dist_home = dist; }
 
 	void updateParameters();
 
 private:
+	void updateMinHorDistToFenceMultirotor();
+
+	void updateMinVertDistToFenceMultirotor();
+
+	matrix::Vector2<double> waypointFromHomeToTestPointAtDist(float distance);
+
 	struct {
 		param_t param_mpc_jerk_max;
 		param_t param_mpc_acc_hor;
@@ -120,29 +117,26 @@ private:
 
 	} _params;
 
-	float _test_point_bearing{0.0f};
-	float _test_point_distance{0.0f};
-	float _vertical_test_point_distance{0.0f};
-	float _velocity_hor_abs{0.0f};
+	matrix::Vector2<double> _current_pos_lat_lon{};
+	matrix::Vector2<double> _home_lat_lon {};
+
 	float _climbrate{0.0f};
 	float _current_alt_amsl{0.0f};
+
+	float _home_alt_amsl{0.0f};
+
+	float _max_hor_dist_home{0.0f};
+	float _max_ver_dist_home{0.0f};
+
 	float _min_hor_dist_to_fence_mc{0.0f};
 	float _min_vert_dist_to_fence_mc{0.0f};
 
 	float _multirotor_braking_distance{0.0f};
 	float _multirotor_vertical_braking_distance{0.0f};
 
-	matrix::Vector2<double> _current_pos_lat_lon{};
-	matrix::Vector2<double> _home_lat_lon {};
-	float _home_alt_amsl{0.0f};
+	float _test_point_bearing{0.0f};
+	float _test_point_distance{0.0f};
 
-	float _max_hor_dist_home{0.0f};
-	float _max_ver_dist_home{0.0f};
-
-	void updateMinHorDistToFenceMultirotor();
-
-	void updateMinVertDistToFenceMultirotor();
-
-	matrix::Vector2<double> waypointFromHomeToTestPointAtDist(float distance);
-
+	float _vertical_test_point_distance{0.0f};
+	float _velocity_hor_abs{0.0f};
 };

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -189,13 +189,13 @@ bool Geofence::checkAll(const struct vehicle_global_position_s &global_position,
 
 bool Geofence::checkAll(double lat, double lon, float altitude)
 {
-	bool inside_fence = isCloserThanMaxDistToHome(lat, lon, altitude);
+	bool inside_fence = isMaxDistanceBreached(lat, lon, altitude);
 
-	inside_fence = inside_fence && isBelowMaxAltitude(altitude);
+	inside_fence = inside_fence && isMaxAltitudeBreached(altitude);
 
 	// to be inside the geofence both fences have to report being inside
 	// as they both report being inside when not enabled
-	inside_fence = inside_fence && isInsidePolygonOrCircle(lat, lon, altitude);
+	inside_fence = inside_fence && isPrimaryGeofenceBreached(lat, lon, altitude);
 
 	if (inside_fence) {
 		_outside_counter = 0;
@@ -242,9 +242,9 @@ bool Geofence::check(const struct mission_item_s &mission_item)
 	return checkAll(mission_item.lat, mission_item.lon, mission_item.altitude);
 }
 
-bool Geofence::isCloserThanMaxDistToHome(double lat, double lon, float altitude)
+bool Geofence::isMaxDistanceBreached(const double lat, const double lon, const float altitude)
 {
-	bool inside_fence = true;
+	bool exceeds_max_dist = false;
 
 	if (isHomeRequired() && _navigator->home_global_position_valid()) {
 
@@ -269,16 +269,17 @@ bool Geofence::isCloserThanMaxDistToHome(double lat, double lon, float altitude)
 				_last_horizontal_range_warning = hrt_absolute_time();
 			}
 
-			inside_fence = false;
+			exceeds_max_dist = true;
+			PX4_INFO("Max distance geofence breached");
 		}
 	}
 
-	return inside_fence;
+	return exceeds_max_dist;
 }
 
-bool Geofence::isBelowMaxAltitude(float altitude)
+bool Geofence::isMaxAltitudeBreached(const float altitude)
 {
-	bool inside_fence = true;
+	bool exceeds_max_alt = false;
 
 	if (isHomeRequired() && _navigator->home_alt_valid()) {
 
@@ -297,22 +298,24 @@ bool Geofence::isBelowMaxAltitude(float altitude)
 				_last_vertical_range_warning = hrt_absolute_time();
 			}
 
-			inside_fence = false;
+			exceeds_max_alt = true;
+
+			PX4_INFO("Max altitude geofence breached");
 		}
 	}
 
-	return inside_fence;
+	return exceeds_max_alt;
 }
 
-bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
+bool Geofence::isPrimaryGeofenceBreached(const double lat, const double lon, const float altitude)
 {
 	// the following uses dm_read, so first we try to lock all items. If that fails, it (most likely) means
 	// the data is currently being updated (via a mavlink geofence transfer), and we do not check for a violation now
 	if (dm_trylock(DM_KEY_FENCE_POINTS) != 0) {
-		return true;
+		return false;
 	}
 
-	// we got the lock, now check if the fence data got updated
+	// dm items locked, check if the fence data was updated
 	mission_stats_entry_s stats;
 	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
 
@@ -322,27 +325,33 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 
 	if (isEmpty()) {
 		dm_unlock(DM_KEY_FENCE_POINTS);
-		/* Empty fence -> accept all points */
+		// Empty fence -> accept all points
 		return true;
 	}
 
-	/* Vertical check */
-	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
+	// Vertical check. Only perform check if configured properly.
+	if (_altitude_max > _altitude_min) {
 		if (altitude > _altitude_max || altitude < _altitude_min) {
 			dm_unlock(DM_KEY_FENCE_POINTS);
-			return false;
+			return true;
+		}
+
+		// Secondary geofence check
+		if ((altitude > _altitude_max + _param_gf2_offset.get()) ||
+		    (altitude < _altitude_min - _param_gf2_offset.get())) {
+			_secondary_geofence_breach = true;
 		}
 	}
 
-
-	/* Horizontal check: iterate all polygons & circles */
+	// Horizontal check: iterate all polygons & circles
 	bool outside_exclusion = true;
 	bool inside_inclusion = false;
 	bool had_inclusion_areas = false;
+	bool inside = false;
 
 	for (int polygon_index = 0; polygon_index < _num_polygons; ++polygon_index) {
 		if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_INCLUSION) {
-			bool inside = insideCircle(_polygons[polygon_index], lat, lon, altitude);
+			inside = insideCircle(_polygons[polygon_index], lat, lon, altitude);
 
 			if (inside) {
 				inside_inclusion = true;
@@ -351,36 +360,48 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 			had_inclusion_areas = true;
 
 		} else if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_EXCLUSION) {
-			bool inside = insideCircle(_polygons[polygon_index], lat, lon, altitude);
+			inside = insideCircle(_polygons[polygon_index], lat, lon, altitude, false);
 
 			if (inside) {
 				outside_exclusion = false;
 			}
 
-		} else { // it's a polygon
-			bool inside = insidePolygon(_polygons[polygon_index], lat, lon, altitude);
+		} else if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_POLYGON_VERTEX_INCLUSION) {
+			inside = insidePolygon(_polygons[polygon_index], lat, lon, altitude);
 
-			if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_POLYGON_VERTEX_INCLUSION) {
-				if (inside) {
-					inside_inclusion = true;
-				}
+			if (inside) {
+				inside_inclusion = true;
+			}
 
-				had_inclusion_areas = true;
+			had_inclusion_areas = true;
 
-			} else { // exclusion
-				if (inside) {
-					outside_exclusion = false;
-				}
+		}  else if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_POLYGON_VERTEX_EXCLUSION) {
+			inside = insidePolygon(_polygons[polygon_index], lat, lon, altitude, false);
+
+			if (inside) {
+				outside_exclusion = false;
 			}
 		}
 	}
 
 	dm_unlock(DM_KEY_FENCE_POINTS);
 
-	return (!had_inclusion_areas || inside_inclusion) && outside_exclusion;
+	if ((inside_inclusion && had_inclusion_areas) ||
+	    (outside_exclusion && !had_inclusion_areas)) {
+		return false;
+
+	} else {
+		return true;
+	}
 }
 
-bool Geofence::insidePolygon(const PolygonInfo &polygon, double lat, double lon, float altitude)
+bool Geofence::isSecondaryGeofenceBreached()
+{
+	return _secondary_geofence_breach;
+}
+
+bool Geofence::insidePolygon(const PolygonInfo &polygon, const double lat, const double lon, const float altitude,
+			     const bool inclusion_fence)
 {
 	/**
 	 * Adaptation of algorithm originally presented as
@@ -391,7 +412,10 @@ bool Geofence::insidePolygon(const PolygonInfo &polygon, double lat, double lon,
 
 	mission_fence_point_s temp_vertex_i{};
 	mission_fence_point_s temp_vertex_j{};
-	bool c = false;
+	crosstrack_error_s crosstrack_error{};
+
+	float distance_to_geofence{1e6f};
+	bool inside_polygon{false};
 
 	for (unsigned i = 0, j = polygon.vertex_count - 1; i < polygon.vertex_count; j = i++) {
 		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + i, &temp_vertex_i,
@@ -415,16 +439,30 @@ bool Geofence::insidePolygon(const PolygonInfo &polygon, double lat, double lon,
 		if (((double)temp_vertex_i.lon >= lon) != ((double)temp_vertex_j.lon >= lon) &&
 		    (lat <= (double)(temp_vertex_j.lat - temp_vertex_i.lat) * (lon - (double)temp_vertex_i.lon) /
 		     (double)(temp_vertex_j.lon - temp_vertex_i.lon) + (double)temp_vertex_i.lat)) {
-			c = !c;
+			inside_polygon = !inside_polygon;
+		}
+
+		get_distance_to_line(&crosstrack_error, lat, lon,
+				     temp_vertex_i.lat, temp_vertex_i.lon,
+				     temp_vertex_j.lat, temp_vertex_j.lon);
+
+		distance_to_geofence = math::min(fabs(crosstrack_error.distance), fabs(distance_to_geofence));
+	}
+
+	if ((inside_polygon && !inclusion_fence) ||
+	    (!inside_polygon && inclusion_fence)) {
+
+		if (distance_to_geofence > _param_gf2_offset.get()) {
+			_secondary_geofence_breach = true;
 		}
 	}
 
-	return c;
+	return inside_polygon;
 }
 
-bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude)
+bool Geofence::insideCircle(const PolygonInfo &polygon, const double lat, const double lon, const float altitude,
+			    const bool inclusion_fence)
 {
-
 	mission_fence_point_s circle_point{};
 
 	if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index, &circle_point,
@@ -445,21 +483,29 @@ bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, 
 		_projection_reference.initReference(lat, lon);
 	}
 
-	float x1, y1, x2, y2;
-	_projection_reference.project(lat, lon, x1, y1);
-	_projection_reference.project(circle_point.lat, circle_point.lon, x2, y2);
-	float dx = x1 - x2, dy = y1 - y2;
-	return dx * dx + dy * dy < circle_point.circle_radius * circle_point.circle_radius;
+	float distance_to_center = get_distance_to_next_waypoint(lat, lon, circle_point.lat, circle_point.lon);
+
+	bool inside_circle = false;
+
+	if (distance_to_center < circle_point.circle_radius) {
+		inside_circle = true;
+
+	} else {
+		if ((inclusion_fence == true && !inside_circle) ||
+		    (!inclusion_fence == true && inside_circle)) {
+
+			float distance_to_geofence = distance_to_center - circle_point.circle_radius;
+
+			if (distance_to_geofence > _param_gf2_offset.get()) {
+				_secondary_geofence_breach = true;
+			}
+		}
+	}
+
+	return inside_circle;
 }
 
-bool
-Geofence::valid()
-{
-	return true; // always valid
-}
-
-int
-Geofence::loadFromFile(const char *filename)
+int Geofence::loadFromFile(const char *filename)
 {
 	FILE *fp;
 	char line[120];
@@ -471,7 +517,7 @@ Geofence::loadFromFile(const char *filename)
 	/* Make sure no data is left in the datamanager */
 	clearDm();
 
-	/* open the mixer definition file */
+	/* open the geofence file */
 	fp = fopen(GEOFENCE_FILENAME, "r");
 
 	if (fp == nullptr) {
@@ -595,9 +641,10 @@ bool Geofence::isHomeRequired()
 {
 	bool max_horizontal_enabled = (_param_gf_max_hor_dist.get() > FLT_EPSILON);
 	bool max_vertical_enabled = (_param_gf_max_ver_dist.get() > FLT_EPSILON);
-	bool geofence_action_rtl = (getGeofenceAction() == geofence_result_s::GF_ACTION_RTL);
+	bool primary_geofence_action_rtl = (getPrimaryGeofenceAction() == geofence_result_s::GF_ACTION_RTL);
+	bool secondary_geofence_action_rtl = (getPrimaryGeofenceAction() == geofence_result_s::GF_ACTION_RTL);
 
-	return max_horizontal_enabled || max_vertical_enabled || geofence_action_rtl;
+	return max_horizontal_enabled || max_vertical_enabled || primary_geofence_action_rtl || secondary_geofence_action_rtl;
 }
 
 void Geofence::printStatus()

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -62,6 +62,35 @@
 PARAM_DEFINE_INT32(GF_ACTION, 2);
 
 /**
+ * Secondary Geofence violation action.
+ *
+ * Note: Setting this value to 4 enables flight termination,
+ * which will kill the vehicle on violation of the fence.
+ *
+ * @min 0
+ * @max 5
+ * @value 0 None
+ * @value 1 Warning
+ * @value 2 Hold mode
+ * @value 3 Return mode
+ * @value 4 Terminate
+ * @value 5 Land mode
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF2_ACTION, 0);
+
+/**
+ * Secondary Geofence distance offset distance from the Primary Geofence, (m).
+ *
+ * Distance offset outside of primary Geofence to apply the GF2_ACTION.
+ * *
+ * @min 0
+ * @max 100
+ * @group Geofence
+ */
+PARAM_DEFINE_FLOAT(GF2_OFFSET, 0.f);
+
+/**
  * Geofence altitude mode
  *
  * Select which altitude (AMSL) source should be used for geofence calculations.
@@ -125,7 +154,7 @@ PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, 0);
  * @increment 1
  * @group Geofence
  */
-PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
+PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0.f);
 
 /**
  * Use Pre-emptive geofence triggering

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -66,19 +66,19 @@
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
+#include <uORB/topics/mode_completed.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_controller_landing_status.h>
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
+#include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/transponder_report.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_global_position.h>
-#include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status.h>
-#include <uORB/topics/mode_completed.h>
 #include <uORB/uORB.h>
 
 using namespace time_literals;
@@ -115,9 +115,7 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	/**
-	 * Load fence from file
-	 */
+	/** Load fence from file */
 	void load_fence_from_file(const char *filename);
 
 	/**
@@ -130,25 +128,36 @@ public:
 	 */
 	void publish_vehicle_cmd(vehicle_command_s *vcmd);
 
-	/**
-	 * Check nearby traffic for potential collisions
-	 */
-	void check_traffic();
-
 	void take_traffic_conflict_action();
 
 	void run_fake_traffic();
 
-	/**
-	 * Setters
+	/*
+	 * Generate an artificial traffic indication
+	 *
+	 * @param distance Horizontal distance to this vehicle
+	 * @param direction Direction in earth frame from this vehicle in radians
+	 * @param traffic_heading Travel direction of the traffic in earth frame in radians
+	 * @param altitude_diff Altitude difference, positive is up
+	 * @param hor_velocity Horizontal velocity of traffic, in m/s
+	 * @param ver_velocity Vertical velocity of traffic, in m/s
+	 * @param emitter_type, Type of vehicle, as a number
 	 */
+	void fake_traffic(const char *callsign, float distance, float direction, float traffic_heading, float altitude_diff,
+			  float hor_velocity, float ver_velocity, int emitter_type);
+
+	/** Check nearby traffic for potential collisions */
+	void check_traffic();
+
+	/** Buffer for air traffic to control the amount of messages sent to a user. */
+	bool buffer_air_traffic(uint32_t icao_address);
+
+	/** Setters */
 	void set_can_loiter_at_sp(bool can_loiter) { _can_loiter_at_sp = can_loiter; }
 	void set_position_setpoint_triplet_updated() { _pos_sp_triplet_updated = true; }
 	void set_mission_result_updated() { _mission_result_updated = true; }
 
-	/**
-	 * Getters
-	 */
+	/** Getters */
 	home_position_s             *get_home_position() { return &_home_pos; }
 	mission_result_s            *get_mission_result() { return &_mission_result; }
 	position_setpoint_triplet_s *get_position_setpoint_triplet() { return &_pos_sp_triplet; }
@@ -182,21 +191,18 @@ public:
 
 	/**
 	 * Get the acceptance radius
-	 *
 	 * @return the distance at which the next waypoint should be used
 	 */
 	float get_acceptance_radius();
 
 	/**
 	 * Get the altitude acceptance radius
-	 *
 	 * @return the distance from the target altitude before considering the waypoint reached
 	 */
 	float get_altitude_acceptance_radius();
 
 	/**
 	 * Get the cruising speed
-	 *
 	 * @return the desired cruising speed for this mission
 	 */
 	float get_cruising_speed();
@@ -214,7 +220,6 @@ public:
 
 	/**
 	 * Reset cruising speed to default values
-	 *
 	 * For VTOL: resets both cruising speeds.
 	 */
 	void reset_cruising_speed();
@@ -231,7 +236,6 @@ public:
 
 	/**
 	 * Get the target throttle
-	 *
 	 * @return the desired throttle for this mission
 	 */
 	float get_cruising_throttle();
@@ -276,127 +280,47 @@ public:
 	double get_mission_landing_lat() { return _mission.get_landing_lat(); }
 	double get_mission_landing_lon() { return _mission.get_landing_lon(); }
 	float  get_mission_landing_alt() { return _mission.get_landing_alt(); }
-
-	float get_mission_landing_loiter_radius() { return _mission.get_landing_loiter_rad(); }
+	float  get_mission_landing_loiter_radius() { return _mission.get_landing_loiter_rad(); }
 
 	// RTL
 	bool in_rtl_state() const { return _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL; }
 
 	bool abort_landing();
 
-	void geofence_breach_check(bool &have_geofence_position_data);
-
 	// Param access
-	int get_loiter_min_alt() const { return _param_min_ltr_alt.get(); }
-	int get_landing_abort_min_alt() const { return _param_mis_lnd_abrt_alt.get(); }
-	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
-	int  get_takeoff_land_required() const { return _para_mis_takeoff_land_req.get(); }
-	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
-	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
+	int   get_landing_abort_min_alt() const { return _param_mis_lnd_abrt_alt.get(); }
+
 	float get_lndmc_alt_max() const { return _param_lndmc_alt_max.get(); }
 
+	int   get_loiter_min_alt() const { return _param_min_ltr_alt.get(); }
+
+	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
+
+	int   get_takeoff_land_required() const { return _para_mis_takeoff_land_req.get(); }
+
 	float get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss; }
+
+	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
+
+	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
 
 	bool force_vtol();
 
 	void acquire_gimbal_control();
 	void release_gimbal_control();
+	void stop_capturing_images();
 
-	void 		calculate_breaking_stop(double &lat, double &lon, float &yaw);
-	void        	stop_capturing_images();
+	void calculate_breaking_stop(double &lat, double &lon, float &yaw);
 
 	void mode_completed(uint8_t nav_state, uint8_t result = mode_completed_s::RESULT_SUCCESS);
 
 private:
 
-	int _local_pos_sub{-1};
-	int _mission_sub{-1};
-	int _vehicle_status_sub{-1};
+	struct traffic_buffer_s {
+		uint32_t    icao_address;
+		hrt_abstime timestamp;
+	};
 
-	uORB::SubscriptionData<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
-
-	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-
-	uORB::Subscription _global_pos_sub{ORB_ID(vehicle_global_position)};	/**< global position subscription */
-	uORB::Subscription _gps_pos_sub{ORB_ID(vehicle_gps_position)};		/**< gps position subscription */
-	uORB::Subscription _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
-	uORB::Subscription _land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */
-	uORB::Subscription _pos_ctrl_landing_status_sub{ORB_ID(position_controller_landing_status)};	/**< position controller landing status subscription */
-	uORB::Subscription _traffic_sub{ORB_ID(transponder_report)};		/**< traffic subscription */
-	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};	/**< vehicle commands (onboard and offboard) */
-
-	uORB::Publication<geofence_result_s>		_geofence_result_pub{ORB_ID(geofence_result)};
-	uORB::Publication<mission_result_s>		_mission_result_pub{ORB_ID(mission_result)};
-	uORB::Publication<position_setpoint_triplet_s>	_pos_sp_triplet_pub{ORB_ID(position_setpoint_triplet)};
-	uORB::Publication<vehicle_command_ack_s>	_vehicle_cmd_ack_pub{ORB_ID(vehicle_command_ack)};
-	uORB::Publication<vehicle_command_s>		_vehicle_cmd_pub{ORB_ID(vehicle_command)};
-	uORB::Publication<vehicle_roi_s>		_vehicle_roi_pub{ORB_ID(vehicle_roi)};
-	uORB::Publication<mode_completed_s> _mode_completed_pub{ORB_ID(mode_completed)};
-
-	orb_advert_t	_mavlink_log_pub{nullptr};	/**< the uORB advert to send messages over mavlink */
-
-	// Subscriptions
-	home_position_s					_home_pos{};		/**< home position for RTL */
-	mission_result_s				_mission_result{};
-	vehicle_global_position_s			_global_pos{};		/**< global vehicle position */
-	sensor_gps_s				_gps_pos{};		/**< gps position */
-	vehicle_land_detected_s				_land_detected{};	/**< vehicle land_detected */
-	vehicle_local_position_s			_local_pos{};		/**< local vehicle position */
-	vehicle_status_s				_vstatus{};		/**< vehicle status */
-
-	bool						_rtl_activated{false};
-
-	// Publications
-	geofence_result_s				_geofence_result{};
-	position_setpoint_triplet_s			_pos_sp_triplet{};	/**< triplet of position setpoints */
-	position_setpoint_triplet_s			_reposition_triplet{};	/**< triplet for non-mission direct position command */
-	position_setpoint_triplet_s			_takeoff_triplet{};	/**< triplet for non-mission direct takeoff command */
-	vehicle_roi_s					_vroi{};		/**< vehicle ROI */
-
-	perf_counter_t	_loop_perf;			/**< loop performance counter */
-
-	Geofence	_geofence;			/**< class that handles the geofence */
-	GeofenceBreachAvoidance _gf_breach_avoidance;
-	hrt_abstime _last_geofence_check = 0;
-
-	bool		_geofence_violation_warning_sent{false};	/**< prevents spaming to mavlink */
-	bool		_can_loiter_at_sp{false};			/**< flags if current position SP can be used to loiter */
-	bool		_pos_sp_triplet_updated{false};			/**< flags if position SP triplet needs to be published */
-	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
-	bool		_mission_result_updated{false};			/**< flags if mission result has seen an update */
-
-	bool		_shouldEngageMissionForLanding{false};
-
-	Mission		_mission;			/**< class that handles the missions */
-	Loiter		_loiter;			/**< class that handles loiter */
-	Takeoff		_takeoff;			/**< class for handling takeoff commands */
-	VtolTakeoff	_vtol_takeoff;			/**< class for handling VEHICLE_CMD_NAV_VTOL_TAKEOFF command */
-	Land		_land;			/**< class for handling land commands */
-	PrecLand	_precland;			/**< class for handling precision land commands */
-	RTL 		_rtl;				/**< class that handles RTL */
-	AdsbConflict 	_adsb_conflict;			/**< class that handles ADSB conflict avoidance */
-
-	NavigatorMode *_navigation_mode{nullptr};	/**< abstract pointer to current navigation mode class */
-	NavigatorMode *_navigation_mode_array[NAVIGATOR_MODE_ARRAY_SIZE] {};	/**< array of navigation modes */
-
-	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
-	param_t _handle_mpc_jerk_auto{PARAM_INVALID};
-	param_t _handle_mpc_acc_hor{PARAM_INVALID};
-
-	float _param_back_trans_dec_mss{0.f};
-	float _param_mpc_jerk_auto{4.f}; 	/**< initialized with the default jerk auto value to prevent division by 0 if the parameter is accidentally set to 0 */
-	float _param_mpc_acc_hor{3.f};		/**< initialized with the default horizontal acc value to prevent division by 0 if the parameter is accidentally set to 0 */
-
-	float _mission_cruising_speed_mc{-1.0f};
-	float _mission_cruising_speed_fw{-1.0f};
-	float _mission_throttle{NAN};
-
-	traffic_buffer_s _traffic_buffer{};
-
-	bool _is_capturing_images{false}; // keep track if we need to stop capturing images
-
-
-	// update subscriptions
 	void params_update();
 
 	/**
@@ -409,30 +333,129 @@ private:
 	 */
 	void publish_mission_result();
 
-	void publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
+	void publish_vehicle_command_ack(const vehicle_command_s &cmd, const uint8_t result);
 
 	bool geofence_allows_position(const vehicle_global_position_s &pos);
 
+	void geofence_breach_notification();
+
+	void geofence_breach_check(bool &have_geofence_position_data);
+
+	void geofence_breach_avoidance_check();
+
+	uORB::SubscriptionData<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+
+	uORB::SubscriptionData<position_controller_status_s> _position_controller_status_sub{ORB_ID(position_controller_status)};
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+
+	// Subscriptions
+	uORB::Subscription _global_pos_sub{ORB_ID(vehicle_global_position)};    /**< global position subscription */
+	uORB::Subscription _gps_pos_sub{ORB_ID(vehicle_gps_position)};          /**< gps position subscription */
+	uORB::Subscription _home_pos_sub{ORB_ID(home_position)};                /**< home position subscription */
+	uORB::Subscription _land_detected_sub{ORB_ID(vehicle_land_detected)};   /**< vehicle land detected subscription */
+	uORB::Subscription _pos_ctrl_landing_status_sub{ORB_ID(position_controller_landing_status)};    /**< position controller landing status subscription */
+	uORB::Subscription _traffic_sub{ORB_ID(transponder_report)};            /**< traffic subscription */
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};       /**< vehicle commands (onboard and offboard) */
+
+	// Publications
+	uORB::Publication<geofence_result_s>            _geofence_result_pub{ORB_ID(geofence_result)};
+	uORB::Publication<mission_result_s>             _mission_result_pub{ORB_ID(mission_result)};
+	uORB::Publication<mode_completed_s>             _mode_completed_pub{ORB_ID(mode_completed)};
+	uORB::Publication<position_setpoint_triplet_s>  _pos_sp_triplet_pub{ORB_ID(position_setpoint_triplet)};
+	uORB::Publication<vehicle_command_ack_s>        _vehicle_cmd_ack_pub{ORB_ID(vehicle_command_ack)};
+	uORB::Publication<vehicle_command_s>            _vehicle_cmd_pub{ORB_ID(vehicle_command)};
+	uORB::Publication<vehicle_roi_s>                _vehicle_roi_pub{ORB_ID(vehicle_roi)};
+
+	perf_counter_t _loop_perf{};                            /**< loop performance counter */
+	orb_advert_t   _mavlink_log_pub{nullptr};               /**< the uORB advert to send messages over mavlink */
+
+	geofence_result_s           _geofence_result{};
+	home_position_s             _home_pos{};                /**< home position for RTL */
+	mission_result_s            _mission_result{};
+	position_setpoint_triplet_s _pos_sp_triplet{};          /**< triplet of position setpoints */
+	position_setpoint_triplet_s _reposition_triplet{};      /**< triplet for non-mission direct position command */
+	position_setpoint_triplet_s _takeoff_triplet{};         /**< triplet for non-mission direct takeoff command */
+	sensor_gps_s                _gps_pos{};                 /**< gps position */
+	traffic_buffer_s            _traffic_buffer{};
+	vehicle_global_position_s   _global_pos{};              /**< global vehicle position */
+	vehicle_land_detected_s     _land_detected{};           /**< vehicle land_detected */
+	vehicle_local_position_s    _local_pos{};               /**< local vehicle position */
+	vehicle_roi_s               _vroi{};                    /**< vehicle ROI */
+	vehicle_status_s            _vstatus{};                 /**< vehicle status */
+
+	AdsbConflict            _adsb_conflict;                 /**< class that handles ADSB conflict avoidance */
+	Geofence                _geofence;                      /**< class that handles the geofence */
+	GeofenceBreachAvoidance _geofence_breach_avoidance;
+	Land                    _land;                          /**< class for handling land commands */
+	Loiter                  _loiter;                        /**< class that handles loiter */
+	Mission                 _mission;                       /**< class that handles the missions */
+	PrecLand                _precland;                      /**< class for handling precision land commands */
+	RTL                     _rtl;                           /**< class that handles RTL */
+	Takeoff                 _takeoff;                       /**< class for handling takeoff commands */
+	VtolTakeoff             _vtol_takeoff;                  /**< class for handling VEHICLE_CMD_NAV_VTOL_TAKEOFF command */
+
+	NavigatorMode *_navigation_mode{nullptr};               /**< abstract pointer to current navigation mode class */
+	NavigatorMode *_navigation_mode_array[NAVIGATOR_MODE_ARRAY_SIZE] {};    /**< array of navigation modes */
+
+	hrt_abstime _last_geofence_check_timestamp{};
+
+	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
+	param_t _handle_mpc_jerk_auto{PARAM_INVALID};
+	param_t _handle_mpc_acc_hor{PARAM_INVALID};
+	param_t _handle_reverse_delay{PARAM_INVALID};
+
+	float _param_back_trans_dec_mss{0.f};
+	float _param_mpc_jerk_auto{4.f};        /**< initialized with the default jerk auto value to prevent division by 0 if the parameter is accidentally set to 0 */
+	float _param_mpc_acc_hor{3.f};          /**< initialized with the default horizontal acc value to prevent division by 0 if the parameter is accidentally set to 0 */
+	float _param_reverse_delay{0.f};
+
+	float _mission_cruising_speed_mc{-1.0f};
+	float _mission_cruising_speed_fw{-1.0f};
+	float _mission_throttle{NAN};
+
+	int _local_pos_sub{-1};
+	int _mission_sub{-1};
+	int _vehicle_status_sub{-1};
+
+	uint8_t _previous_nav_state{};				/**< nav_state of the previous iteration*/
+
+	bool _can_loiter_at_sp{false};                          /**< flags if current position SP can be used to loiter */
+	bool _geofence_violation_warning_sent{false};           /**< prevents spaming to mavlink */
+	bool _is_capturing_images{false};                       /**< keep track if we need to stop capturing images */
+	bool _mission_result_updated{false};                    /**< flags if mission result has seen an update */
+	bool _mission_landing_in_progress{false};               /**< this flag gets set if the mission is currently executing on a landing pattern
+						                 * if mission mode is inactive, this flag will be cleared after 2 seconds */
+	bool _pos_sp_triplet_updated{false};                    /**< flags if position SP triplet needs to be published */
+	bool _pos_sp_triplet_published_invalid_once{false};     /**< flags if position SP triplet has been published once to UORB */
+	bool _rtl_activated{false};
+
+	char _geofence_violation_warning[50];
+
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::NAV_LOITER_RAD>)   _param_nav_loiter_rad,	/**< loiter radius for fixedwing */
-		(ParamFloat<px4::params::NAV_ACC_RAD>)      _param_nav_acc_rad,		/**< acceptance for takeoff */
-		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)   _param_nav_fw_alt_rad,	/**< acceptance rad for fixedwing alt */
-		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
-		_param_nav_fw_altl_rad,	/**< acceptance rad for fixedwing alt before landing*/
-		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)   _param_nav_mc_alt_rad,	/**< acceptance rad for multicopter alt */
-		(ParamInt<px4::params::NAV_FORCE_VT>)       _param_nav_force_vt,	/**< acceptance radius for multicopter alt */
-		(ParamInt<px4::params::NAV_TRAFF_AVOID>)    _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
+
+		(ParamFloat<px4::params::NAV_ACC_RAD>)      _param_nav_acc_rad,         /**< acceptance for takeoff */
+		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)   _param_nav_fw_alt_rad,      /**< acceptance rad for fixedwing alt */
+		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)  _param_nav_fw_altl_rad,     /**< acceptance rad for fw alt before landing*/
+		(ParamFloat<px4::params::NAV_LOITER_RAD>)   _param_nav_loiter_rad,      /**< loiter radius for fixedwing */
+		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)   _param_nav_mc_alt_rad,      /**< acceptance rad for multicopter alt */
+		(ParamInt<px4::params::NAV_FORCE_VT>)       _param_nav_force_vt,        /**< acceptance radius for multicopter alt */
+		(ParamInt<px4::params::NAV_TRAFF_AVOID>)    _param_nav_traff_avoid,     /**< avoiding other aircraft is enabled */
 		(ParamFloat<px4::params::NAV_TRAFF_A_HOR>)  _param_nav_traff_a_hor_ct,	/**< avoidance Distance Crosstrack*/
 		(ParamFloat<px4::params::NAV_TRAFF_A_VER>)  _param_nav_traff_a_ver,	/**< avoidance Distance Vertical*/
+		(ParamFloat<px4::params::NAV_TRAFF_A_RADU>) _param_nav_traff_a_radu,    /**< avoidance Distance Unmanned*/
+		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm,    /**< avoidance Distance Manned*/
 		(ParamInt<px4::params::NAV_TRAFF_COLL_T>)   _param_nav_traff_collision_time,
-		(ParamFloat<px4::params::NAV_MIN_LTR_ALT>)   _param_min_ltr_alt,	/**< minimum altitude in Loiter mode*/
+		(ParamFloat<px4::params::NAV_MIN_LTR_ALT>)  _param_min_ltr_alt,         /**< minimum altitude in Loiter mode*/
 
 		// non-navigator parameters: Mission (MIS_*)
+		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
 		(ParamInt<px4::params::MIS_TKO_LAND_REQ>)  _para_mis_takeoff_land_req,
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
-		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
 		(ParamFloat<px4::params::LNDMC_ALT_MAX>)   _param_lndmc_alt_max,
 		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt
 	)


### PR DESCRIPTION
## Describe problem solved by this pull request
For operations that require a hard terminate on Geofence violation, the predictive behavior helps avoid flight termination that can be avoided, however this alone does not allow an initial behavior such as hold or land to be followed later by a hard flight termination on Geofence breach. In the event of a poor position estimate and/or attitude estimate due to vibrations the drone might still be able to be held within the Geofence while ending the flight in a semi-controlled descent.

## Describe your solution
This PR creates a secondary Geofence with associated behavior via an offset distance parameter that allow the drone to enter another mode prior to any flight termination commands if the primary Geofence is actually violated, or vice versa.

## Describe possible alternatives
Ultimately it would be nice to migrate geofence vertex lookups into volatile memory, however this implementation mirrors the current architecture.

## Test data / coverage
Additional flight testing to be accomplished

## Additional context
Replaces #19112, potentially impacts #18821.  Predictive Geofence action could be deprecated in lieu of this functionality.
@RomanBapst @NAmmann
