### PR TITLE
geofence outside buffer zone

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -9,4 +9,7 @@ uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated
 
+bool geofence_buffer_violated   # true if the geofence buffer zone is violated
+uint8 geofence_buffer_action    # action to take when geofence buffer zone is violated
+
 bool home_required              # true if the geofence requires a valid home position

--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -9,7 +9,7 @@ uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated
 
-bool geofence_buffer_violated   # true if the geofence buffer zone is violated
-uint8 geofence_buffer_action    # action to take when geofence buffer zone is violated
+bool emergency_geofence_violated   # true if the geofence buffer zone is violated
+uint8 emergency_geofence_action    # action to take when geofence buffer zone is violated
 
 bool home_required              # true if the geofence requires a valid home position

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -99,6 +99,7 @@ bool in_transition_to_fw # True if VTOL is doing a transition from MC to FW
 
 bool mission_failure # Set to true if mission could not continue/finish
 bool geofence_violated
+bool geofence_buffer_violated
 
 # MAVLink identification
 uint8 system_type  # system type, contains mavlink MAV_TYPE

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -99,7 +99,7 @@ bool in_transition_to_fw # True if VTOL is doing a transition from MC to FW
 
 bool mission_failure # Set to true if mission could not continue/finish
 bool geofence_violated
-bool geofence_buffer_violated
+bool emergency_geofence_violated
 
 # MAVLink identification
 uint8 system_type  # system type, contains mavlink MAV_TYPE

--- a/src/lib/geo/geo.h
+++ b/src/lib/geo/geo.h
@@ -68,9 +68,9 @@ static constexpr float  CONSTANTS_RADIUS_OF_EARTH_F = CONSTANTS_RADIUS_OF_EARTH;
 static constexpr float CONSTANTS_EARTH_SPIN_RATE = 7.2921150e-5f;				// radians/second (rad/s)
 
 
-// XXX remove
 struct crosstrack_error_s {
 	bool past_end;		// Flag indicating we are past the end of the line/arc segment
+	bool before_start;	// Flag indicating we are before the start of the line/arc segment
 	float distance;		// Distance in meters to closest point on line/arc
 	float bearing;		// Bearing in radians to closest point on line/arc
 } ;
@@ -136,6 +136,9 @@ void add_vector_to_global_position(double lat_now, double lon_now, float v_n, fl
 
 int get_distance_to_line(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
 			 double lat_start, double lon_start, double lat_end, double lon_end);
+
+int get_distance_to_segment(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
+			    double lat_start, double lon_start, double lat_end, double lon_end);
 
 int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
 			double lat_center, double lon_center,

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1906,7 +1906,7 @@ Commander::run()
 				any_geofence_active = true;
 
 				if (_geofence_result.emergency_geofence_violated && !_emergency_geofence_violated_prev) {
-					PX4_WARN("Secondary geofence violated");
+					PX4_WARN("Emergency geofence violated");
 					handle_geofence_breach(_geofence_result.emergency_geofence_action);
 				}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -653,7 +653,8 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 			return TRANSITION_DENIED;
 		}
 
-		if ((_geofence_result.geofence_action == geofence_result_s::GF_ACTION_RTL)
+		if ((_geofence_result.geofence_action == geofence_result_s::GF_ACTION_RTL
+		     || _geofence_result.geofence_buffer_action == geofence_result_s::GF_ACTION_RTL)
 		    && !_vehicle_status_flags.home_position_valid) {
 			mavlink_log_critical(&_mavlink_log_pub, "Arming denied: Geofence RTL requires valid home\t");
 			events::send(events::ID("commander_arm_denied_geofence_rtl"),
@@ -1864,13 +1865,14 @@ Commander::run()
 
 		handleAutoDisarm();
 
-		if (_geofence_warning_action_on
+		if ((_geofence_warning_action_on || _geofence_buffer_warning_action_on)
 		    && _commander_state.main_state != commander_state_s::MAIN_STATE_AUTO_RTL
 		    && _commander_state.main_state != commander_state_s::MAIN_STATE_AUTO_LOITER
 		    && _commander_state.main_state != commander_state_s::MAIN_STATE_AUTO_LAND) {
 
 			// reset flag again when we switched out of it
 			_geofence_warning_action_on = false;
+			_geofence_buffer_warning_action_on = false;
 		}
 
 		battery_status_check();
@@ -1885,81 +1887,47 @@ Commander::run()
 
 		checkForMissionUpdate();
 
+
 		/* start geofence result check */
 		if (_geofence_result_sub.update(&_geofence_result)) {
-			_vehicle_status.geofence_violated = _geofence_result.geofence_violated;
+			_vehicle_status.geofence_violated = (_geofence_result.geofence_violated || _geofence_result.geofence_buffer_violated);
 		}
 
 		const bool in_low_battery_failsafe_delay = _battery_failsafe_timestamp != 0;
 
+		bool any_geofence_active = false;
+
 		// Geofence actions
-		if (_arm_state_machine.isArmed()
-		    && (_geofence_result.geofence_action != geofence_result_s::GF_ACTION_NONE)
-		    && !in_low_battery_failsafe_delay) {
+		if (_arm_state_machine.isArmed() && !in_low_battery_failsafe_delay) {
 
-			// check for geofence violation transition
-			if (_geofence_result.geofence_violated && !_geofence_violated_prev) {
+			if (_geofence_result.geofence_buffer_action != geofence_result_s::GF_ACTION_NONE) {
 
-				switch (_geofence_result.geofence_action) {
-				case (geofence_result_s::GF_ACTION_NONE) : {
-						// do nothing
-						break;
-					}
+				// PX4_WARN("Secondary geofence action not NONE");
+				any_geofence_active = true;
 
-				case (geofence_result_s::GF_ACTION_WARN) : {
-						// do nothing, mavlink critical messages are sent by navigator
-						break;
-					}
-
-				case (geofence_result_s::GF_ACTION_LOITER) : {
-						if (TRANSITION_CHANGED == main_state_transition(_vehicle_status, commander_state_s::MAIN_STATE_AUTO_LOITER,
-								_vehicle_status_flags,
-								_commander_state)) {
-							_geofence_loiter_on = true;
-						}
-
-						break;
-					}
-
-				case (geofence_result_s::GF_ACTION_RTL) : {
-						if (TRANSITION_CHANGED == main_state_transition(_vehicle_status, commander_state_s::MAIN_STATE_AUTO_RTL,
-								_vehicle_status_flags,
-								_commander_state)) {
-							_geofence_rtl_on = true;
-						}
-
-						break;
-					}
-
-				case (geofence_result_s::GF_ACTION_LAND) : {
-						if (TRANSITION_CHANGED == main_state_transition(_vehicle_status, commander_state_s::MAIN_STATE_AUTO_LAND,
-								_vehicle_status_flags,
-								_commander_state)) {
-							_geofence_land_on = true;
-						}
-
-						break;
-					}
-
-				case (geofence_result_s::GF_ACTION_TERMINATE) : {
-						PX4_WARN("Flight termination because of geofence");
-
-						if (!_flight_termination_triggered && !_lockdown_triggered) {
-							_flight_termination_triggered = true;
-							mavlink_log_critical(&_mavlink_log_pub, "Geofence violation! Flight terminated\t");
-							events::send(events::ID("commander_geofence_termination"), {events::Log::Alert, events::LogInternal::Warning},
-								     "Geofence violation! Flight terminated");
-							_actuator_armed.force_failsafe = true;
-							_status_changed = true;
-							send_parachute_command();
-						}
-
-						break;
-					}
+				if (_geofence_result.geofence_buffer_violated && !_geofence_buffer_violated_prev) {
+					PX4_WARN("Secondary geofence violated");
+					handle_geofence_breach(_geofence_result.geofence_buffer_action);
 				}
+
+				_geofence_buffer_violated_prev = _geofence_result.geofence_buffer_violated;
+
 			}
 
-			_geofence_violated_prev = _geofence_result.geofence_violated;
+			if (_geofence_result.geofence_action != geofence_result_s::GF_ACTION_NONE) {
+
+				// PX4_WARN("Primary geofence action not NONE");
+				any_geofence_active = true;
+
+				// check for geofence violation transition
+				if (_geofence_result.geofence_violated && !_geofence_violated_prev) {
+					PX4_WARN("Primary geofence violated");
+					handle_geofence_breach(_geofence_result.geofence_action);
+				}
+
+				_geofence_violated_prev        = _geofence_result.geofence_violated;
+
+			}
 
 			// reset if no longer in LOITER or if manually switched to LOITER
 			const bool in_loiter_mode = _commander_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER;
@@ -1967,7 +1935,6 @@ Commander::run()
 			if (!in_loiter_mode) {
 				_geofence_loiter_on = false;
 			}
-
 
 			// reset if no longer in RTL or if manually switched to RTL
 			const bool in_rtl_mode = _commander_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL;
@@ -1985,14 +1952,16 @@ Commander::run()
 
 			_geofence_warning_action_on = _geofence_warning_action_on || (_geofence_loiter_on || _geofence_rtl_on
 						      || _geofence_land_on);
+		}
 
-		} else {
+		if (!any_geofence_active) {
 			// No geofence checks, reset flags
 			_geofence_loiter_on = false;
 			_geofence_rtl_on = false;
 			_geofence_land_on = false;
 			_geofence_warning_action_on = false;
 			_geofence_violated_prev = false;
+			_geofence_buffer_violated_prev = false;
 		}
 
 		manual_control_check();
@@ -2422,6 +2391,7 @@ void Commander::checkForMissionUpdate()
 				events::send(events::ID("commander_mission_termination"), {events::Log::Alert, events::LogInternal::Warning},
 					     "GPS failure: Flight terminated");
 				_flight_termination_triggered = true;
+
 				_actuator_armed.force_failsafe = true;
 				_status_changed = true;
 				send_parachute_command();
@@ -3312,7 +3282,10 @@ void Commander::manual_control_check()
 
 				const bool in_low_battery_failsafe_delay = (_battery_failsafe_timestamp != 0);
 
-				if (override_enabled && !in_low_battery_failsafe_delay && !_geofence_warning_action_on) {
+				if (override_enabled
+				    && !in_low_battery_failsafe_delay
+				    && !_geofence_warning_action_on
+				    && !_geofence_buffer_warning_action_on) {
 
 					const transition_result_t posctl_result =
 						main_state_transition(_vehicle_status, commander_state_s::MAIN_STATE_POSCTL, _vehicle_status_flags, _commander_state);
@@ -3471,6 +3444,70 @@ void Commander::checkWindSpeedThresholds()
 			{events::Log::Warning, events::LogInternal::Info},
 			"High wind speed detected ({1:.1m/s}), landing advised", wind.norm());
 			_last_wind_warning = hrt_absolute_time();
+		}
+	}
+}
+
+void Commander::handle_geofence_breach(uint8_t geofence_action)
+{
+	switch (geofence_action) {
+	case (geofence_result_s::GF_ACTION_NONE) : {
+			// do nothing
+			break;
+		}
+
+	case (geofence_result_s::GF_ACTION_WARN) : {
+			// do nothing, mavlink critical messages are sent by navigator
+			break;
+		}
+
+	case (geofence_result_s::GF_ACTION_LOITER) : {
+			if (TRANSITION_CHANGED == main_state_transition(_vehicle_status,
+					commander_state_s::MAIN_STATE_AUTO_LOITER,
+					_vehicle_status_flags,
+					_commander_state)) {
+				_geofence_loiter_on = true;
+			}
+
+			break;
+		}
+
+	case (geofence_result_s::GF_ACTION_RTL) : {
+			if (TRANSITION_CHANGED == main_state_transition(_vehicle_status,
+					commander_state_s::MAIN_STATE_AUTO_RTL,
+					_vehicle_status_flags,
+					_commander_state)) {
+				_geofence_rtl_on = true;
+			}
+
+			break;
+		}
+
+	case (geofence_result_s::GF_ACTION_LAND) : {
+			if (TRANSITION_CHANGED == main_state_transition(_vehicle_status,
+					commander_state_s::MAIN_STATE_AUTO_LAND,
+					_vehicle_status_flags,
+					_commander_state)) {
+				_geofence_land_on = true;
+			}
+
+			break;
+		}
+
+	case (geofence_result_s::GF_ACTION_TERMINATE) : {
+			PX4_WARN("Flight termination because of geofence");
+
+			if (!_flight_termination_triggered && !_lockdown_triggered) {
+				_flight_termination_triggered = true;
+				mavlink_log_critical(&_mavlink_log_pub, "Geofence violation! Flight terminated\t");
+				events::send(events::ID("commander_geofence_termination"), {events::Log::Alert, events::LogInternal::Warning},
+					     "Geofence violation! Flight terminated");
+				_actuator_armed.force_failsafe = true;
+				_status_changed = true;
+				send_parachute_command();
+			}
+
+			break;
 		}
 	}
 }

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -284,8 +284,8 @@ private:
 	bool		_geofence_land_on{false};
 	bool		_geofence_warning_action_on{false};
 	bool		_geofence_violated_prev{false};
-	bool		_geofence_buffer_warning_action_on{false};
-	bool		_geofence_buffer_violated_prev{false};
+	bool		_emergency_geofence_warning_action_on{false};
+	bool		_emergency_geofence_violated_prev{false};
 
 	bool         _circuit_breaker_flight_termination_disabled{false};
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -129,6 +129,7 @@ private:
 	void battery_status_check();
 
 	void control_status_leds(bool changed, const uint8_t battery_warning);
+	void handle_geofence_breach(uint8_t geofence_action);
 
 	/**
 	 * Checks the status of all available data links and handles switching between different system telemetry states.
@@ -283,6 +284,8 @@ private:
 	bool		_geofence_land_on{false};
 	bool		_geofence_warning_action_on{false};
 	bool		_geofence_violated_prev{false};
+	bool		_geofence_buffer_warning_action_on{false};
+	bool		_geofence_buffer_violated_prev{false};
 
 	bool         _circuit_breaker_flight_termination_disabled{false};
 

--- a/src/modules/navigator/GeofenceBreachAvoidance/GeofenceBreachAvoidanceTest.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/GeofenceBreachAvoidanceTest.cpp
@@ -88,8 +88,8 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForFixedWing)
 	Vector2d home_global(42.1, 8.2);
 	MapProjection ref{home_global(0), home_global(1)};
 
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.fence_violation = true;
+	geofence_violation_type gf_violation;
+	gf_violation.fence_violation = true;
 
 	gf_avoidance.setHorizontalTestPointDistance(20.0f);
 	gf_avoidance.setTestPointBearing(0.0f);
@@ -121,7 +121,7 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForFixedWing)
 	EXPECT_FLOAT_EQ(loiter_point_lat_lon(0), loiter_point_lat_lon_expected(0));
 	EXPECT_FLOAT_EQ(loiter_point_lat_lon(1), loiter_point_lat_lon_expected(1));
 
-	gf_violation.flags.fence_violation = false;
+	gf_violation.fence_violation = false;
 	loiter_point_lat_lon = gf_avoidance.generateLoiterPointForFixedWing(gf_violation, &geo);
 
 	EXPECT_FLOAT_EQ(loiter_point_lat_lon(0), home_global(0));
@@ -148,8 +148,8 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForMultirotor)
 	value = 8;
 	param_set(param, &value);
 
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.fence_violation = true;
+	geofence_violation_type gf_violation;
+	gf_violation.fence_violation = true;
 
 	gf_avoidance.setHorizontalTestPointDistance(30.0f);
 	gf_avoidance.setTestPointBearing(0.0f);
@@ -184,7 +184,7 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterPointForMultirotor)
 
 	EXPECT_LE(error, 0.0f);
 
-	gf_violation.flags.fence_violation = false;
+	gf_violation.fence_violation = false;
 	loiter_point = gf_avoidance.generateLoiterPointForMultirotor(gf_violation, &geo);
 
 	EXPECT_LT(Vector2d(loiter_point - home_global).norm(), 1e-4);
@@ -198,14 +198,14 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterAltitudeForFixedWing)
 
 	gf_avoidance.setVerticalTestPointDistance(vertical_test_point_dist);
 	gf_avoidance.setCurrentPosition(0, 0, current_alt_amsl); // just care about altitude
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.max_altitude_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.max_altitude_exceeded = true;
 
 	float loiter_alt = gf_avoidance.generateLoiterAltitudeForFixedWing(gf_violation);
 
 	EXPECT_EQ(loiter_alt, current_alt_amsl - 2 * vertical_test_point_dist);
 
-	gf_violation.flags.max_altitude_exceeded = false;
+	gf_violation.max_altitude_exceeded = false;
 
 	loiter_alt = gf_avoidance.generateLoiterAltitudeForFixedWing(gf_violation);
 
@@ -217,8 +217,8 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterAltitudeForMulticopter)
 	GeofenceBreachAvoidance gf_avoidance(nullptr);
 	const float climbrate = 10.0f;
 	const float current_alt_amsl = 100.0f;
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.max_altitude_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.max_altitude_exceeded = true;
 
 	gf_avoidance.setClimbRate(climbrate);
 	gf_avoidance.setCurrentPosition(0, 0, current_alt_amsl);
@@ -229,7 +229,7 @@ TEST_F(GeofenceBreachAvoidanceTest, generateLoiterAltitudeForMulticopter)
 	EXPECT_EQ(loiter_alt_amsl, current_alt_amsl + gf_avoidance.computeVerticalBrakingDistanceMultirotor() -
 		  gf_avoidance.getMinVertDistToFenceMultirotor());
 
-	gf_violation.flags.max_altitude_exceeded = false;
+	gf_violation.max_altitude_exceeded = false;
 
 	loiter_alt_amsl = gf_avoidance.generateLoiterAltitudeForMulticopter(gf_violation);
 
@@ -242,8 +242,8 @@ TEST_F(GeofenceBreachAvoidanceTest, maxDistToHomeViolationMulticopter)
 	FakeGeofence geo;
 	Vector2d home_global(42.1, 8.2);
 	MapProjection ref{home_global(0), home_global(1)};
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.dist_to_home_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.dist_to_home_exceeded = true;
 
 	const float hor_vel = 8.0f;
 	const float test_point_distance = 30.0f;
@@ -274,8 +274,8 @@ TEST_F(GeofenceBreachAvoidanceTest, maxDistToHomeViolationFixedWing)
 	FakeGeofence geo;
 	Vector2d home_global(42.1, 8.2);
 	MapProjection ref{home_global(0), home_global(1)};
-	geofence_violation_type_u gf_violation;
-	gf_violation.flags.dist_to_home_exceeded = true;
+	geofence_violation_type gf_violation;
+	gf_violation.dist_to_home_exceeded = true;
 
 	const float test_point_distance = 30.0f;
 	const float max_dist_to_home = 100.0f;

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -94,16 +94,15 @@ matrix::Vector2<double> GeofenceBreachAvoidance::waypointFromBearingAndDistance(
 	return Vector2d(fence_violation_test_point_lat, fence_violation_test_point_lon);
 }
 
-Vector2d
-GeofenceBreachAvoidance::getFenceViolationTestPoint()
+Vector2d GeofenceBreachAvoidance::getFenceViolationTestPoint()
 {
 	return waypointFromBearingAndDistance(_current_pos_lat_lon, _test_point_bearing, _test_point_distance);
 }
 
-Vector2d
-GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type_u violation_type, Geofence *geofence)
+Vector2d GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type violation_type,
+		Geofence *geofence)
 {
-	if (violation_type.flags.fence_violation) {
+	if (violation_type.fence_violation) {
 		const float bearing_90_left = matrix::wrap_2pi(_test_point_bearing - M_PI_F * 0.5f);
 		const float bearing_90_right = matrix::wrap_2pi(_test_point_bearing + M_PI_F * 0.5f);
 
@@ -139,7 +138,7 @@ GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type
 
 		return Vector2d(loiter_center_lat, loiter_center_lon);
 
-	} else if (violation_type.flags.dist_to_home_exceeded) {
+	} else if (violation_type.dist_to_home_exceeded) {
 
 		return waypointFromHomeToTestPointAtDist(math::max(_max_hor_dist_home - 2 * _test_point_distance, 0.0f));
 
@@ -148,11 +147,10 @@ GeofenceBreachAvoidance::generateLoiterPointForFixedWing(geofence_violation_type
 	}
 }
 
-Vector2d
-GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_type_u violation_type, Geofence *geofence)
+Vector2d GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_type violation_type,
+		Geofence *geofence)
 {
-
-	if (violation_type.flags.fence_violation) {
+	if (violation_type.fence_violation) {
 		float current_distance = _test_point_distance * 0.5f;
 		float current_min = 0.0f;
 		float current_max = _test_point_distance;
@@ -181,7 +179,7 @@ GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_typ
 			return waypointFromBearingAndDistance(_current_pos_lat_lon, _test_point_bearing, _multirotor_braking_distance);
 		}
 
-	} else if (violation_type.flags.dist_to_home_exceeded) {
+	} else if (violation_type.dist_to_home_exceeded) {
 
 		return waypointFromHomeToTestPointAtDist(math::max(_max_hor_dist_home - _min_hor_dist_to_fence_mc, 0.0f));
 
@@ -195,9 +193,9 @@ GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_typ
 	}
 }
 
-float GeofenceBreachAvoidance::generateLoiterAltitudeForFixedWing(geofence_violation_type_u violation_type)
+float GeofenceBreachAvoidance::generateLoiterAltitudeForFixedWing(geofence_violation_type violation_type)
 {
-	if (violation_type.flags.max_altitude_exceeded) {
+	if (violation_type.max_altitude_exceeded) {
 		return _current_alt_amsl - 2.0f * _vertical_test_point_distance;
 
 	} else {
@@ -205,9 +203,9 @@ float GeofenceBreachAvoidance::generateLoiterAltitudeForFixedWing(geofence_viola
 	}
 }
 
-float GeofenceBreachAvoidance::generateLoiterAltitudeForMulticopter(geofence_violation_type_u violation_type)
+float GeofenceBreachAvoidance::generateLoiterAltitudeForMulticopter(geofence_violation_type violation_type)
 {
-	if (violation_type.flags.max_altitude_exceeded) {
+	if (violation_type.max_altitude_exceeded) {
 		return _current_alt_amsl + _multirotor_vertical_braking_distance - _min_vert_dist_to_fence_mc;
 
 	} else {

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
@@ -41,13 +41,11 @@ class Geofence;
 
 #define GEOFENCE_CHECK_INTERVAL_US 200000
 
-union geofence_violation_type_u {
-	struct {
-		bool dist_to_home_exceeded: 1;	///< 0 - distance to home exceeded
-		bool max_altitude_exceeded: 1;	///< 1 - maximum altitude exceeded
-		bool fence_violation: 1;	///< 2- violation of user defined fence
-	} flags;
-	uint8_t value;
+struct geofence_violation_type {
+	bool dist_to_home_exceeded{false};
+	bool max_altitude_exceeded{false};
+	bool fence_violation{false};
+	bool buffer_violation{false};
 };
 
 class GeofenceBreachAvoidance : public ModuleParams
@@ -63,17 +61,17 @@ public:
 			float test_point_bearing, float test_point_distance);
 
 	matrix::Vector2<double>
-	generateLoiterPointForFixedWing(geofence_violation_type_u violation_type, Geofence *geofence);
+	generateLoiterPointForFixedWing(geofence_violation_type violation_type, Geofence *geofence);
 
 	float computeBrakingDistanceMultirotor();
 
 	float computeVerticalBrakingDistanceMultirotor();
 
-	matrix::Vector2<double> generateLoiterPointForMultirotor(geofence_violation_type_u violation_type, Geofence *geofence);
+	matrix::Vector2<double> generateLoiterPointForMultirotor(geofence_violation_type violation_type, Geofence *geofence);
 
-	float generateLoiterAltitudeForFixedWing(geofence_violation_type_u violation_type);
+	float generateLoiterAltitudeForFixedWing(geofence_violation_type violation_type);
 
-	float generateLoiterAltitudeForMulticopter(geofence_violation_type_u violation_type);
+	float generateLoiterAltitudeForMulticopter(geofence_violation_type violation_type);
 
 	float getMinHorDistToFenceMulticopter() {return _min_hor_dist_to_fence_mc;}
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -478,7 +478,7 @@ bool Geofence::isInsideBufferZone(double lat, double lon, float altitude)
 		return false;
 	}
 
-	float buffer_distance_m = _param_gf_buffer_dist.get();
+	float buffer_distance_m = _param_gf_emergency_dist.get();
 
 	// Vertical check
 	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
@@ -543,7 +543,7 @@ bool Geofence::insidePolygonBufferZone(const PolygonInfo &polygon, double lat, d
 					temp_vertex_i.lat, temp_vertex_i.lon,
 					temp_vertex_j.lat, temp_vertex_j.lon);
 
-		if (static_cast<float>(fabs(crosstrack_error.distance)) < _param_gf_buffer_dist.get()) {
+		if (static_cast<float>(fabs(crosstrack_error.distance)) < _param_gf_emergency_dist.get()) {
 			return true;
 		}
 	}
@@ -579,7 +579,7 @@ bool Geofence::insideCircleBufferZone(const PolygonInfo &polygon, double lat, do
 			    circle_point.lon,
 			    circle_point.circle_radius, 0.f, 360.f);
 
-	if (static_cast<float>(fabs(crosstrack_error.distance)) <= _param_gf_buffer_dist.get()) {
+	if (static_cast<float>(fabs(crosstrack_error.distance)) <= _param_gf_emergency_dist.get()) {
 		PX4_INFO("Inside buffer zone! Crosstrack distance to fence: %f", (double)crosstrack_error.distance);
 		return true;
 	}

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -312,7 +312,7 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 		return true;
 	}
 
-	// we got the lock, now check if the fence data got updated
+	// dm items locked, check if the fence data was updated
 	mission_stats_entry_s stats;
 	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
 
@@ -322,11 +322,11 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 
 	if (isEmpty()) {
 		dm_unlock(DM_KEY_FENCE_POINTS);
-		/* Empty fence -> accept all points */
+		// Empty fence -> accept all points
 		return true;
 	}
 
-	/* Vertical check */
+	// Vertical check
 	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
 		if (altitude > _altitude_max || altitude < _altitude_min) {
 			dm_unlock(DM_KEY_FENCE_POINTS);
@@ -335,7 +335,7 @@ bool Geofence::isInsidePolygonOrCircle(double lat, double lon, float altitude)
 	}
 
 
-	/* Horizontal check: iterate all polygons & circles */
+	// Horizontal check: iterate all polygons & circles
 	bool outside_exclusion = true;
 	bool inside_inclusion = false;
 	bool had_inclusion_areas = false;
@@ -452,10 +452,139 @@ bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, 
 	return dx * dx + dy * dy < circle_point.circle_radius * circle_point.circle_radius;
 }
 
-bool
-Geofence::valid()
+bool Geofence::isInsideBufferZone(double lat, double lon, float altitude)
 {
-	return true; // always valid
+	if (getGeofenceBufferAction() == 0) {
+		return true;
+	}
+
+	// the following uses dm_read, so first we try to lock all items. If that fails, it (most likely) means
+	// the data is currently being updated (via a mavlink geofence transfer), and we do not check for a violation now
+	if (dm_trylock(DM_KEY_FENCE_POINTS) != 0) {
+		return false;
+	}
+
+	// dm items locked, check if the fence data was updated
+	mission_stats_entry_s stats;
+	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
+
+	if (ret == sizeof(mission_stats_entry_s) && _update_counter != stats.update_counter) {
+		_updateFence();
+	}
+
+	if (isEmpty()) {
+		dm_unlock(DM_KEY_FENCE_POINTS);
+		// Empty fence -> accept all points
+		return false;
+	}
+
+	float buffer_distance_m = _param_gf_buffer_dist.get();
+
+	// Vertical check
+	if (_altitude_max > _altitude_min) { // only enable vertical check if configured properly
+		if ((altitude > _altitude_max + buffer_distance_m) ||
+		    (altitude < _altitude_min - buffer_distance_m)) {
+			dm_unlock(DM_KEY_FENCE_POINTS);
+			return false;
+		}
+	}
+
+	// Horizontal check: iterate all polygons & circles
+	bool inside_circle_buffer_zone  = false;
+	bool inside_polygon_buffer_zone = false;
+
+	for (int polygon_index = 0; polygon_index < _num_polygons; ++polygon_index) {
+
+		if (_polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_INCLUSION ||
+		    _polygons[polygon_index].fence_type == NAV_CMD_FENCE_CIRCLE_EXCLUSION) {
+			inside_circle_buffer_zone = insideCircleBufferZone(_polygons[polygon_index], lat, lon, altitude);
+
+		} else {
+			inside_polygon_buffer_zone = insidePolygonBufferZone(_polygons[polygon_index], lat, lon, altitude);
+		}
+	}
+
+	dm_unlock(DM_KEY_FENCE_POINTS);
+
+	return (inside_circle_buffer_zone || inside_polygon_buffer_zone);
+}
+
+bool Geofence::insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude)
+{
+	mission_fence_point_s temp_vertex_i{};
+	mission_fence_point_s temp_vertex_j{};
+	crosstrack_error_s crosstrack_error{};
+
+	for (unsigned i = 0, j = polygon.vertex_count - 1; i < polygon.vertex_count; j = i++) {
+		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + i, &temp_vertex_i,
+			    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+			break;
+		}
+
+		if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index + j, &temp_vertex_j,
+			    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+			break;
+		}
+
+		if (temp_vertex_i.frame != NAV_FRAME_GLOBAL && temp_vertex_i.frame != NAV_FRAME_GLOBAL_INT
+		    && temp_vertex_i.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT
+		    && temp_vertex_i.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+			// TODO: handle different frames
+			PX4_ERR("Frame type %i not supported", (int)temp_vertex_i.frame);
+			break;
+		}
+
+		// get_distance_to_line(&crosstrack_error, lat, lon,
+		// 			temp_vertex_i.lat, temp_vertex_i.lon,
+		// 			temp_vertex_j.lat, temp_vertex_j.lon);
+
+
+		get_distance_to_segment(&crosstrack_error, lat, lon,
+					temp_vertex_i.lat, temp_vertex_i.lon,
+					temp_vertex_j.lat, temp_vertex_j.lon);
+
+		if (static_cast<float>(fabs(crosstrack_error.distance)) < _param_gf_buffer_dist.get()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool Geofence::insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude)
+{
+	mission_fence_point_s circle_point{};
+	crosstrack_error_s crosstrack_error{};
+
+	if (dm_read(DM_KEY_FENCE_POINTS, polygon.dataman_index, &circle_point,
+		    sizeof(mission_fence_point_s)) != sizeof(mission_fence_point_s)) {
+		PX4_ERR("dm_read failed");
+		return false;
+	}
+
+	if (circle_point.frame != NAV_FRAME_GLOBAL && circle_point.frame != NAV_FRAME_GLOBAL_INT
+	    && circle_point.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT
+	    && circle_point.frame != NAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
+		// TODO: handle different frames
+		PX4_ERR("Frame type %i not supported", (int)circle_point.frame);
+		return false;
+	}
+
+	if (!_projection_reference.isInitialized()) {
+		_projection_reference.initReference(lat, lon);
+	}
+
+	get_distance_to_arc(&crosstrack_error, lat, lon,
+			    circle_point.lat,
+			    circle_point.lon,
+			    circle_point.circle_radius, 0.f, 360.f);
+
+	if (static_cast<float>(fabs(crosstrack_error.distance)) <= _param_gf_buffer_dist.get()) {
+		PX4_INFO("Inside buffer zone! Crosstrack distance to fence: %f", (double)crosstrack_error.distance);
+		return true;
+	}
+
+	return false;
 }
 
 int
@@ -471,7 +600,7 @@ Geofence::loadFromFile(const char *filename)
 	/* Make sure no data is left in the datamanager */
 	clearDm();
 
-	/* open the mixer definition file */
+	/* open the geofence file */
 	fp = fopen(GEOFENCE_FILENAME, "r");
 
 	if (fp == nullptr) {

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -107,13 +107,18 @@ public:
 
 	bool isCloserThanMaxDistToHome(double lat, double lon, float altitude);
 
+
+	bool isCloserThanBufferDistance(double lat, double lon, float altitude);
+
 	bool isBelowMaxAltitude(float altitude);
 
 	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
 
+	virtual bool isInsideBufferZone(double lat, double lon, float altitude);
+
 	int clearDm();
 
-	bool valid();
+	bool valid() { return true; }	// always valid
 
 	/**
 	 * Load a single inclusion polygon, replacing any already existing polygons.
@@ -140,7 +145,7 @@ public:
 
 	int getSource() { return _param_gf_source.get(); }
 	int getGeofenceAction() { return _param_gf_action.get(); }
-
+	int getGeofenceBufferAction() { return _param_gf_buffer_action.get(); }
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
@@ -179,6 +184,7 @@ private:
 	uORB::SubscriptionData<vehicle_air_data_s> _sub_airdata;
 
 	int _outside_counter{0};
+
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, we polygon data was updated
 
 	/**
@@ -198,9 +204,8 @@ private:
 	 */
 	bool checkPolygons(double lat, double lon, float altitude);
 
-
-
 	bool checkAll(const vehicle_global_position_s &global_position);
+
 	bool checkAll(const vehicle_global_position_s &global_position, float baro_altitude_amsl);
 
 	/**
@@ -209,12 +214,16 @@ private:
 	 */
 	bool insidePolygon(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
+	bool insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
 	/**
 	 * Check if a single point is within a circle
 	 * @param polygon must be a circle!
 	 * @return true if within polygon the circle
 	 */
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
+	bool insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,
@@ -223,6 +232,8 @@ private:
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_gf_max_ver_dist,
-		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict
+		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict,
+		(ParamInt<px4::params::GF_BUFFER_ACTION>)  _param_gf_buffer_action,
+		(ParamFloat<px4::params::GF_BUFFER_DIST>)  _param_gf_buffer_dist
 	)
 };

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -145,7 +145,7 @@ public:
 
 	int getSource() { return _param_gf_source.get(); }
 	int getGeofenceAction() { return _param_gf_action.get(); }
-	int getGeofenceBufferAction() { return _param_gf_buffer_action.get(); }
+	int getGeofenceBufferAction() { return _param_gf_emergency_action.get(); }
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
@@ -233,7 +233,7 @@ private:
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_gf_max_ver_dist,
 		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict,
-		(ParamInt<px4::params::GF_BUFFER_ACTION>)  _param_gf_buffer_action,
-		(ParamFloat<px4::params::GF_BUFFER_DIST>)  _param_gf_buffer_dist
+		(ParamInt<px4::params::GF_EMERGENCY_ACT>)  _param_gf_emergency_action,
+		(ParamFloat<px4::params::GF_EMERGENCY_DST>)  _param_gf_emergency_dist
 	)
 };

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -114,7 +114,7 @@ public:
 
 	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
 
-	virtual bool isInsideBufferZone(double lat, double lon, float altitude);
+	virtual bool hasExceededEmergencyFence(double lat, double lon, float altitude);
 
 	int clearDm();
 
@@ -145,7 +145,7 @@ public:
 
 	int getSource() { return _param_gf_source.get(); }
 	int getGeofenceAction() { return _param_gf_action.get(); }
-	int getGeofenceBufferAction() { return _param_gf_emergency_action.get(); }
+	int getGeofenceEmergencyAction() { return _param_gf_emergency_action.get(); }
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
@@ -214,7 +214,7 @@ private:
 	 */
 	bool insidePolygon(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
-	bool insidePolygonBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
+	bool insidePolygonEmergencyZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	/**
 	 * Check if a single point is within a circle
@@ -223,7 +223,7 @@ private:
 	 */
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
-	bool insideCircleBufferZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
+	bool insideCircleEmergencyZone(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -138,3 +138,35 @@ PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_PREDICT, 1);
+
+/**
+ * Geofence buffer distance.
+ *
+ * Distance inside the Geofence to apply the GF_BUFFER_ACTION.
+ *
+ * @min 0.0
+ * @max 100.0
+ * @group Geofence
+ */
+PARAM_DEFINE_FLOAT(GF_BUFFER_DIST, 10.0f);
+
+/**
+ * Geofence buffer zone violation action.
+ *
+ * Note: Setting this value to 4 enables flight termination,
+ * which will kill the vehicle on violation of the fence.
+ * Due to the inherent danger of this, this function is
+ * disabled using a software circuit breaker, which needs
+ * to be reset to 0 to really shut down the system.
+ *
+ * @min 0
+ * @max 5
+ * @value 0 None
+ * @value 1 Warning
+ * @value 2 Hold mode
+ * @value 3 Return mode
+ * @value 4 Terminate
+ * @value 5 Land mode
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF_BUFFER_ACTION, 0);

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -140,18 +140,18 @@ PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
 PARAM_DEFINE_INT32(GF_PREDICT, 1);
 
 /**
- * Geofence buffer distance.
+ * Emergency geofence distance in meters.
  *
- * Distance inside the Geofence to apply the GF_BUFFER_ACTION.
+ * Distance in meters outside the Geofence to apply the GF_EMERGENCY_ACT.
  *
  * @min 0.0
  * @max 100.0
  * @group Geofence
  */
-PARAM_DEFINE_FLOAT(GF_BUFFER_DIST, 10.0f);
+PARAM_DEFINE_FLOAT(GF_EMERGENCY_DST, 10.0f);
 
 /**
- * Geofence buffer zone violation action.
+ * Emergency geofence violation action.
  *
  * Note: Setting this value to 4 enables flight termination,
  * which will kill the vehicle on violation of the fence.
@@ -169,4 +169,4 @@ PARAM_DEFINE_FLOAT(GF_BUFFER_DIST, 10.0f);
  * @value 5 Land mode
  * @group Geofence
  */
-PARAM_DEFINE_INT32(GF_BUFFER_ACTION, 0);
+PARAM_DEFINE_INT32(GF_EMERGENCY_ACT, 0);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -862,7 +862,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 						    _global_pos.alt);
 
 		if (gf_violation_type.fence_violation) {
-			gf_violation_type.buffer_violation = !_geofence.isInsideBufferZone(fence_violation_test_point(0),
+			gf_violation_type.buffer_violation = !_geofence.hasExceededEmergencyFence(fence_violation_test_point(0),
 							     fence_violation_test_point(1),
 							     _global_pos.alt);
 		}
@@ -872,7 +872,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		_geofence_result.timestamp = hrt_absolute_time();
 		_geofence_result.geofence_action = _geofence.getGeofenceAction();
-		_geofence_result.emergency_geofence_action = _geofence.getGeofenceBufferAction();
+		_geofence_result.emergency_geofence_action = _geofence.getGeofenceEmergencyAction();
 		_geofence_result.home_required = _geofence.isHomeRequired();
 
 		if (gf_violation_type.dist_to_home_exceeded ||
@@ -899,7 +899,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 				// we have predicted a geofence violation and if the action is to loiter then
 				// demand a reposition to a location which is inside the geofence
 				if (_geofence.getGeofenceAction() == geofence_result_s::GF_ACTION_LOITER ||
-				    _geofence.getGeofenceBufferAction() == geofence_result_s::GF_ACTION_LOITER) {
+				    _geofence.getGeofenceEmergencyAction() == geofence_result_s::GF_ACTION_LOITER) {
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
 
 					matrix::Vector2<double> loiter_center_lat_lon;
@@ -1570,8 +1570,8 @@ bool Navigator::geofence_allows_position(const vehicle_global_position_s &pos)
 {
 	if ((_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE &&
 	     _geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_WARN) ||
-	    (_geofence.getGeofenceBufferAction() != geofence_result_s::GF_ACTION_NONE &&
-	     _geofence.getGeofenceBufferAction() != geofence_result_s::GF_ACTION_WARN)) {
+	    (_geofence.getGeofenceEmergencyAction() != geofence_result_s::GF_ACTION_NONE &&
+	     _geofence.getGeofenceEmergencyAction() != geofence_result_s::GF_ACTION_WARN)) {
 
 		if (PX4_ISFINITE(pos.lat) && PX4_ISFINITE(pos.lon)) {
 			return _geofence.check(pos, _gps_pos);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -872,7 +872,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		_geofence_result.timestamp = hrt_absolute_time();
 		_geofence_result.geofence_action = _geofence.getGeofenceAction();
-		_geofence_result.geofence_buffer_action = _geofence.getGeofenceBufferAction();
+		_geofence_result.emergency_geofence_action = _geofence.getGeofenceBufferAction();
 		_geofence_result.home_required = _geofence.isHomeRequired();
 
 		if (gf_violation_type.dist_to_home_exceeded ||
@@ -885,10 +885,10 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		if (gf_violation_type.buffer_violation) {
 
-			_geofence_result.geofence_buffer_violated = true;
+			_geofence_result.emergency_geofence_violated = true;
 		}
 
-		if (_geofence_result.geofence_violated || _geofence_result.geofence_buffer_violated) {
+		if (_geofence_result.geofence_violated || _geofence_result.emergency_geofence_violated) {
 
 			/* Issue a warning about the geofence violation once and only if we are armed */
 			if (!_geofence_violation_warning_sent && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
@@ -944,7 +944,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		} else {
 			/* inform other apps via the mission result */
 			_geofence_result.geofence_violated = false;
-			_geofence_result.geofence_buffer_violated = false;
+			_geofence_result.emergency_geofence_violated = false;
 
 			/* Reset the _geofence_violation_warning_sent field */
 			_geofence_violation_warning_sent = false;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -803,7 +803,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
 
 		matrix::Vector2<double> fence_violation_test_point;
-		geofence_violation_type_u gf_violation_type{};
+		geofence_violation_type gf_violation_type{};
 		float test_point_bearing;
 		float test_point_distance;
 		float vertical_test_point_distance;
@@ -850,27 +850,45 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 			snprintf(geofence_violation_warning, sizeof(geofence_violation_warning), "Geofence exceeded");
 		}
 
-		gf_violation_type.flags.dist_to_home_exceeded = !_geofence.isCloserThanMaxDistToHome(fence_violation_test_point(0),
+		gf_violation_type.dist_to_home_exceeded = !_geofence.isCloserThanMaxDistToHome(fence_violation_test_point(0),
 				fence_violation_test_point(1),
 				_global_pos.alt);
 
-		gf_violation_type.flags.max_altitude_exceeded = !_geofence.isBelowMaxAltitude(_global_pos.alt +
+		gf_violation_type.max_altitude_exceeded = !_geofence.isBelowMaxAltitude(_global_pos.alt +
 				vertical_test_point_distance);
 
-		gf_violation_type.flags.fence_violation = !_geofence.isInsidePolygonOrCircle(fence_violation_test_point(0),
-				fence_violation_test_point(1),
-				_global_pos.alt);
+		gf_violation_type.fence_violation = !_geofence.isInsidePolygonOrCircle(fence_violation_test_point(0),
+						    fence_violation_test_point(1),
+						    _global_pos.alt);
+
+		if (gf_violation_type.fence_violation) {
+			gf_violation_type.buffer_violation = !_geofence.isInsideBufferZone(fence_violation_test_point(0),
+							     fence_violation_test_point(1),
+							     _global_pos.alt);
+		}
 
 		_last_geofence_check = hrt_absolute_time();
 		have_geofence_position_data = false;
 
 		_geofence_result.timestamp = hrt_absolute_time();
 		_geofence_result.geofence_action = _geofence.getGeofenceAction();
+		_geofence_result.geofence_buffer_action = _geofence.getGeofenceBufferAction();
 		_geofence_result.home_required = _geofence.isHomeRequired();
 
-		if (gf_violation_type.value) {
+		if (gf_violation_type.dist_to_home_exceeded ||
+		    gf_violation_type.max_altitude_exceeded ||
+		    gf_violation_type.fence_violation) {
+
 			/* inform other apps via the mission result */
 			_geofence_result.geofence_violated = true;
+		}
+
+		if (gf_violation_type.buffer_violation) {
+
+			_geofence_result.geofence_buffer_violated = true;
+		}
+
+		if (_geofence_result.geofence_violated || _geofence_result.geofence_buffer_violated) {
 
 			/* Issue a warning about the geofence violation once and only if we are armed */
 			if (!_geofence_violation_warning_sent && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
@@ -880,7 +898,8 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 				// we have predicted a geofence violation and if the action is to loiter then
 				// demand a reposition to a location which is inside the geofence
-				if (_geofence.getGeofenceAction() == geofence_result_s::GF_ACTION_LOITER) {
+				if (_geofence.getGeofenceAction() == geofence_result_s::GF_ACTION_LOITER ||
+				    _geofence.getGeofenceBufferAction() == geofence_result_s::GF_ACTION_LOITER) {
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
 
 					matrix::Vector2<double> loiter_center_lat_lon;
@@ -925,6 +944,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		} else {
 			/* inform other apps via the mission result */
 			_geofence_result.geofence_violated = false;
+			_geofence_result.geofence_buffer_violated = false;
 
 			/* Reset the _geofence_violation_warning_sent field */
 			_geofence_violation_warning_sent = false;
@@ -1548,8 +1568,10 @@ void Navigator::release_gimbal_control()
 
 bool Navigator::geofence_allows_position(const vehicle_global_position_s &pos)
 {
-	if ((_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE) &&
-	    (_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_WARN)) {
+	if ((_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE &&
+	     _geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_WARN) ||
+	    (_geofence.getGeofenceBufferAction() != geofence_result_s::GF_ACTION_NONE &&
+	     _geofence.getGeofenceBufferAction() != geofence_result_s::GF_ACTION_WARN)) {
 
 		if (PX4_ISFINITE(pos.lat) && PX4_ISFINITE(pos.lon)) {
 			return _geofence.check(pos, _gps_pos);


### PR DESCRIPTION
## Describe problem solved by this pull request
This PR builds on #20055 and switches to an outer geofence (the secondary geofence lies outside the primary). It also makes GF_ACTION the primary geofence enabling param, allowing it to work without a GF_BUFFER_ACTION defined (in the previous PR both must be defined for either to work), and fully disabling both fences by disabling GF_ACTION. It also includes logic to avoid sneaking out of a secondary geofence polygon's corners that was possible using the orignal distance to line calculation. 

## Describe your solution
This is the same solution as #20055 but switches the order, so that the original geofence behaves as normal, and the buffer distance creates an outer fence that can be triggered after an initial geofence breech has occurred.

## Describe possible alternatives
The previous PR #20055 implemented the fence as an inner fence. This uses the same approach to create an outer fence.

## Test data / coverage
This has been tested in SITL using QGC to manually fly a drone out of a geofence in two scenarios:
1. Primary geofence set to WARN and secondary set to LAND. This allowed testing concave geofence polygons ensuring that the secondary geofence could be triggered even after recovering from the primary.
2. Primary geofence set to LAND and secondary set to TERMINATE. This tested the use case that a drone should attempt to land if the geofence is breeched, but if the secondary is reached we need to get the drone out of the air immediately. 
3. Primary geofence set to WARN and secondary set to TERMINATE. This allowed testing that if a primary geofence was violated but recovered, the secondary could still terminate flight. This was tested on a concave geofence polygon, shown here.
![Screenshot from 2022-08-16 14-26-17](https://user-images.githubusercontent.com/45466823/185191889-2d272ad1-654e-4853-a331-bced5065cb55.png)

## Additional context
Replaces #20055 and _should_ not impact #18821 since the outer geofence behavior is only encountered if the inner geofence has been breeched. If the inner geofence has not been breeched, behavior is identical to before.




