### PR TITLE
parameters: open export files O_TRUNC to discard previous data

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -7,7 +7,7 @@ param set-default IMU_INTEG_RATE 250
 if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0" ]; then
 
 	if ! simulator_sih start; then
-		echo "ERROR  [init] simulator_sih failed to start"
+		echo "ERROR [init] simulator_sih failed to start"
 		exit 1
 	fi
 
@@ -46,7 +46,7 @@ elif [ "$PX4_SIMULATOR" = "ignition" ]; then
 			sensor_gps_sim start
 			sensor_mag_sim start
 		else
-			echo "ERROR  [init] ign gazebo failed to start"
+			echo "ERROR [init] ign gazebo failed to start"
 			exit 1
 		fi
 	else
@@ -61,7 +61,7 @@ elif [ "$PX4_SIMULATOR" = "ignition" ]; then
 			sensor_gps_sim start
 			sensor_mag_sim start
 		else
-			echo "ERROR  [init] ign gazebo failed to start"
+			echo "ERROR [init] ign gazebo failed to start"
 			exit 1
 		fi
 

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -52,7 +52,7 @@ then
 	# shellcheck disable=SC2012
 	REQUESTED_AUTOSTART=$(ls "${R}etc/init.d-posix/airframes" | sed -n 's/^\([0-9][0-9]*\)_'${PX4_SIM_MODEL}'$/\1/p')
 	if [ -z "$REQUESTED_AUTOSTART" ]; then
-		echo "ERROR  [init] Unknown model $PX4_SIM_MODEL (not found by name on ${R}etc/init.d-posix/airframes)"
+		echo "ERROR [init] Unknown model $PX4_SIM_MODEL (not found by name on ${R}etc/init.d-posix/airframes)"
 		exit 1
 	else
 		SYS_AUTOSTART=$REQUESTED_AUTOSTART
@@ -62,17 +62,45 @@ fi
 
 # Load parameters
 set PARAM_FILE parameters.bson
-param select $PARAM_FILE
+set PARAM_BACKUP_FILE parameters_backup.bson
 
-if [ -f $PARAM_FILE ]
-then
-	if param load
+param select $PARAM_FILE
+if [ -f $PARAM_FILE ]; then
+	set +e # disable exit on error control for param import
+	if ! param import
 	then
-		echo "[param] Loaded: $PARAM_FILE"
-	else
-		echo "[param] FAILED loading $PARAM_FILE"
+		echo "ERROR [init] param import failed"
+
+		param dump $PARAM_FILE
+
+		# try to make a backup copy
+		cp $PARAM_FILE param_import_fail.bson
+
+		# try importing from backup file
+		if [ -f $PARAM_BACKUP_FILE ]
+		then
+			echo "[init] importing from parameter backup"
+
+			# dump current backup file contents for comparison
+			param dump $PARAM_BACKUP_FILE
+
+			param import $PARAM_BACKUP_FILE
+
+			# overwrite invalid $PARAM_FILE with backup
+			cp $PARAM_BACKUP_FILE $PARAM_FILE
+		fi
+
+		param status
 	fi
+	set -e # restore exit on error control
+
+elif [ -f $PARAM_BACKUP_FILE ]; then
+	echo "ERROR [init] primary param file $PARAM_FILE unavailable, using backup $PARAM_BACKUP_FILE"
+	param import $PARAM_BACKUP_FILE
 fi
+
+param select-backup $PARAM_BACKUP_FILE
+
 
 # exit early when the minimal shell is requested
 [ $RUN_MINIMAL_SHELL = yes ] && exit 0

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -28,6 +28,7 @@ set IOFW "/etc/extras/px4_io-v2_default.bin"
 set LOGGER_ARGS ""
 set LOGGER_BUF 8
 set PARAM_FILE ""
+set PARAM_BACKUP_FILE ""
 set RC_INPUT_ARGS ""
 set SDCARD_AVAILABLE no
 set SDCARD_EXT_PATH /fs/microsd/ext_autostart
@@ -93,6 +94,7 @@ then
 	fi
 
 	set PARAM_FILE /fs/microsd/params
+	set PARAM_BACKUP_FILE "/fs/microsd/parameters_backup.bson"
 fi
 
 #
@@ -132,27 +134,32 @@ else
 
 		if [ -d "/fs/microsd" ]
 		then
-			dmesg >> /fs/microsd/param_import_fail.txt &
-
 			# try to make a backup copy
-			cp $PARAM_FILE /fs/microsd/param_import_fail.bson &
-		fi
+			cp $PARAM_FILE /fs/microsd/param_import_fail.bson
 
-		# try importing from backup file
-		if [ -f "/fs/microsd/parameters_backup.bson" ]
-		then
-			echo "[init] importing from parameter backup"
+			# try importing from backup file
+			if [ -f $PARAM_BACKUP_FILE ]
+			then
+				echo "[init] importing from parameter backup"
 
-			# dump current backup file contents for comparison
-			param dump /fs/microsd/parameters_backup.bson
+				# dump current backup file contents for comparison
+				param dump $PARAM_BACKUP_FILE
 
-			param import /fs/microsd/parameters_backup.bson
+				param import $PARAM_BACKUP_FILE
+
+				# overwrite invalid $PARAM_FILE with backup
+				cp $PARAM_BACKUP_FILE $PARAM_FILE
+			fi
+
+			param status
+
+			dmesg >> /fs/microsd/param_import_fail.txt &
 		fi
 	fi
 
 	if [ $SDCARD_AVAILABLE = yes ]
 	then
-		param select-backup /fs/microsd/parameters_backup.bson
+		param select-backup $PARAM_BACKUP_FILE
 	fi
 
 	if ver hwcmp PX4_FMU_V5X PX4_FMU_V6X
@@ -534,6 +541,7 @@ unset IOFW
 unset LOGGER_ARGS
 unset LOGGER_BUF
 unset PARAM_FILE
+unset PARAM_BACKUP_FILE
 unset RC_INPUT_ARGS
 unset SDCARD_AVAILABLE
 unset SDCARD_EXT_PATH

--- a/Tools/px4airframes/rcout.py
+++ b/Tools/px4airframes/rcout.py
@@ -78,7 +78,7 @@ class RCOutput():
         result += "\t. /etc/init.d/airframes/${AIRFRAME}\n"
         if not post_start:
             result += "else\n"
-            result += "\techo \"ERROR  [init] No file matches SYS_AUTOSTART value found in : /etc/init.d/airframes\"\n"
+            result += "\techo \"ERROR [init] No file matches SYS_AUTOSTART value found in : /etc/init.d/airframes\"\n"
             # Reset the configuration
             result += "\tparam set SYS_AUTOSTART 0\n"
             result += "\ttone_alarm ${TUNE_ERR}\n"

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1116,7 +1116,7 @@ int param_save_default()
 
 		for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
 			// write parameters to file
-			int fd = ::open(filename, O_WRONLY | O_CREAT, PX4_O_MODE_666);
+			int fd = ::open(filename, O_WRONLY | O_CREAT | O_TRUNC, PX4_O_MODE_666);
 
 			if (fd > -1) {
 				perf_begin(param_export_perf);
@@ -1155,7 +1155,7 @@ int param_save_default()
 
 		// backup file
 		if (param_backup_file) {
-			int fd_backup_file = ::open(param_backup_file, O_WRONLY | O_CREAT, PX4_O_MODE_666);
+			int fd_backup_file = ::open(param_backup_file, O_WRONLY | O_CREAT | O_TRUNC, PX4_O_MODE_666);
 
 			if (fd_backup_file > -1) {
 				int backup_export_ret = param_export_internal(fd_backup_file, nullptr);
@@ -1373,6 +1373,11 @@ static int param_export_internal(int fd, param_filter_func filter)
 	param_wbuf_s *s = nullptr;
 	bson_encoder_s encoder{};
 	uint8_t bson_buffer[256];
+
+	if (lseek(fd, 0, SEEK_SET) != 0) {
+		PX4_ERR("export seek failed %d", errno);
+		return -1;
+	}
 
 	if (bson_encoder_init_buf_file(&encoder, fd, &bson_buffer, sizeof(bson_buffer)) != 0) {
 		goto out;

--- a/src/lib/parameters/tinybson/tinybson.cpp
+++ b/src/lib/parameters/tinybson/tinybson.cpp
@@ -147,7 +147,7 @@ bson_decoder_init_buf(bson_decoder_t decoder, void *buf, unsigned bufsize, bson_
 
 	if (bufsize == 0) {
 		decoder->bufsize = *(uint32_t *)buf;
-		debug("auto-detected %u byte object", decoder->bufsize);
+		debug("auto-detected %zu byte object", decoder->bufsize);
 
 	} else {
 		decoder->bufsize = bufsize;
@@ -403,7 +403,7 @@ write_x(bson_encoder_t encoder, const void *p, size_t s)
 
 	memcpy(encoder->buf + encoder->bufpos, p, s);
 	encoder->bufpos += s;
-	debug("appended %d bytes", s);
+	debug("appended %zu bytes", s);
 
 	return 0;
 }


### PR DESCRIPTION
 - rcS parameter backup try to directly restore param (FRAM) from backup (in case SD card is removed before successful export)
 - rcS parameter backup logging rearrange to capture more logging output (param_import_fail.txt)
 - posix rcS try to keep param backup and restore roughly in sync with NuttX rcS
 - tinybson fix debug printf format
 - param_export_internal ensure file descriptor positioned at 0 (precaution)