### PR TITLE
FW Position Control: remove unnsed params

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -840,8 +840,6 @@ private:
 		(ParamInt<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,
 
 		(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off,
-		(ParamFloat<px4::params::FW_MAN_P_MAX>) _param_fw_man_p_max,
-		(ParamFloat<px4::params::FW_MAN_R_MAX>) _param_fw_man_r_max,
 
 		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,
 


### PR DESCRIPTION
The roll one is since https://github.com/PX4/PX4-Autopilot/pull/18989 not used anymore, how pitch was ever used I don't know. 