### PR TITLE
Dev toolchain Nuttx dependancy for arm64 

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -137,8 +137,6 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		bison \
 		build-essential \
 		flex \
-		g++-multilib \
-		gcc-multilib \
 		gdb-multiarch \
 		genromfs \
 		gettext \

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -116,7 +116,21 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 
 	echo
 	echo "Installing NuttX dependencies"
+	
+# architecture check to handle gcc multilib 
+	if [[ ${uname -m} == "aarch64" ]]; then
 
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+			g++-multilib-arm-linux-* \
+			gcc-multilib-arm-linux-* \
+			;
+	else 
+	
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+			g++-multilib \
+			gcc-multilib \
+			;	
+	fi
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		automake \
 		binutils-dev \


### PR DESCRIPTION

## problem 
To add Arm64 capability to development toolchain installation bash file to handle g++ multilib package under Nuttx dependencies. Normally, multi lib does not exist as g++-multilib under Ubuntu aarch64 packages and has alternatives for installation.

This will add capability for arm-based setups to use the toolchain installation bash script with no issues.  

## solution
Hardware check for how to handle this package installation since they have different names. 

## possible alternatives
There currently is a way to have Dev toolchain on RPi which nuttx and sim tools have to be neglected. 

## Test data / coverage
Already tested on M1 Macbook with Ubuntu 20.04 and even got a successful board build. 

## Additional context
Reviews are highly needed and appreciated. 
