### PR TITLE
Fix velocity smoothing functional test

### DIFF
--- a/src/lib/motion_planning/VelocitySmoothingTest.cpp
+++ b/src/lib/motion_planning/VelocitySmoothingTest.cpp
@@ -168,7 +168,7 @@ TEST_F(VelocitySmoothingTest, testConstantSetpoint)
 	const float dt = 0.01;
 	updateTrajectories(0.f, velocity_setpoints);
 	float t123 = _trajectories[0].getTotalTime();
-	int nb_steps = ceil(t123 / dt);
+	int nb_steps = ceilf(t123 / dt);
 
 	for (int i = 0; i < nb_steps; i++) {
 		updateTrajectories(dt, velocity_setpoints);


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
Bug fix on compilation error when running functional tests. Specifically, the test failing was in the velocity smoothing. Root cause was in line 171 of VelocitySmoothingTest.cpp, which was using `ceil`. The compiler threw a fatal error for implicit casting as the ceil function accepts arguments of the double type. 

![image](https://user-images.githubusercontent.com/26198479/185996432-04a987df-baaa-4517-bbfc-90e2175da528.png)


## Describe your solution
Minor amendment to use `ceilf` which accepts floating point arguments. 

## Describe possible alternatives
Casting arguments to double in `ceil`. 

## Test data / coverage
Ran `make tests TESTFILTER=function` with all tests passing.
![image](https://user-images.githubusercontent.com/26198479/185996172-647dc431-b3f3-45cc-ae49-e123b78c1631.png)

## Additional context
Add any other related context or media.
