### PR TITLE
mixer_module: Fix linking of mixer_module

### DIFF
--- a/src/lib/mixer_module/CMakeLists.txt
+++ b/src/lib/mixer_module/CMakeLists.txt
@@ -63,6 +63,6 @@ px4_add_library(mixer_module
 add_dependencies(mixer_module output_functions_header)
 target_compile_options(mixer_module PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 target_include_directories(mixer_module PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(mixer_module PRIVATE mixer)
 
 px4_add_functional_gtest(SRC mixer_module_tests.cpp LINKLIBS mixer_module mixer)
-


### PR DESCRIPTION
The module has a hard dependency on mixer library, so link them together

## Describe problem solved by this pull request
Fixes build error when mixer_module cannot find definitions for Mixer::Xxx()

## Describe your solution
The mixer module has a hard dependency on mixer, so they should be linked together

## Describe possible alternatives
Find every module / library that depends on mixer_module and add the linkage with mixer there

## Test data / coverage
fmu-v5 protected mode
