### PR TITLE
User high resolution timer fix

### DIFF
--- a/platforms/nuttx/src/px4/common/usr_hrt.cpp
+++ b/platforms/nuttx/src/px4/common/usr_hrt.cpp
@@ -75,17 +75,6 @@ hrt_absolute_time(void)
 }
 
 /**
- * Store the absolute time in an interrupt-safe fashion
- */
-void
-hrt_store_absolute_time(volatile hrt_abstime *t)
-{
-	irqstate_t flags = px4_enter_critical_section();
-	*t = hrt_absolute_time();
-	px4_leave_critical_section(flags);
-}
-
-/**
  * Event dispatcher thread
  */
 int

--- a/platforms/nuttx/src/px4/common/usr_hrt.cpp
+++ b/platforms/nuttx/src/px4/common/usr_hrt.cpp
@@ -122,7 +122,8 @@ void
 hrt_init(void)
 {
 	px4_register_shutdown_hook(hrt_request_stop);
-	g_usr_hrt_task = px4_task_spawn_cmd("usr_hrt", SCHED_DEFAULT, SCHED_PRIORITY_MAX, 1000, event_thread, NULL);
+	g_usr_hrt_task = px4_task_spawn_cmd("usr_hrt", SCHED_DEFAULT, SCHED_PRIORITY_MAX, PX4_STACK_ADJUSTED(1024),
+					    event_thread, NULL);
 }
 
 /**


### PR DESCRIPTION
## Describe problem solved by this pull request
This fixes two crashes when using user hrt:
1. Stack underflow, which occurs randomly due to exception stack overflow
2. Crash due to illegal instruction when trying to disable global interrupts from user space.

## Describe your solution
User land code does not need to disable system interrupts, especially here, as the atomic handling of hrt is handled by the kernel side code.

## Test data / coverage
Unpublished RISC-V target for Microchip MPFS.

## Additional context
RISC-V does not allow executing global interrupt disable/enable from user space. Doing so results in an illegal instruction trap.
