### PR TITLE
ekf2: fix replay EKF2 start when CONSTRAINED_FLASH

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2233,11 +2233,11 @@ int EKF2::task_spawn(int argc, char *argv[])
 			}
 		}
 
-	}
+	} else
 
 #endif // !CONSTRAINED_FLASH
 
-	else {
+	{
 		// otherwise launch regular
 		EKF2 *ekf2_inst = new EKF2(false, px4::wq_configurations::INS0, replay_mode);
 


### PR DESCRIPTION
Before (with `CONSTRAINED_FLASH`):
```
if replay
   set replay variable
else
   start EKF instance
end
```

Now:
```
if replay
   set replay variable
end

start EKF instance
```