### PR TITLE
Add attitude and bodyrate control to RTPS

### DIFF
--- a/msg/tools/urtps_bridge_topics.yaml
+++ b/msg/tools/urtps_bridge_topics.yaml
@@ -59,6 +59,10 @@ rtps:
     send:    true
   - msg:     vehicle_local_position_setpoint
     receive: true
+  - msg:     vehicle_attitude_setpoint
+    receive: true
+  - msg:     vehicle_rates_setpoint
+    receive: true
   - msg:     trajectory_setpoint
     receive: true
   - msg:     vehicle_odometry


### PR DESCRIPTION
## Describe problem solved by this pull request
`attitude` and `body rate` control in offboard mode was previously not possible with Fast-RTPS.

## Describe your solution
Generate the corresponding RTPS message for those two channels. The PX4 build bot should automatically update the [px4_ros_com](https://github.com/PX4/px4_ros_com) repo right?

## Describe possible alternatives
None

## Test data / coverage
Does not affect the flight controller

## Additional context
None