### PR TITLE
Add call-gates to px4_crypto for protected build

### DIFF
--- a/platforms/common/include/px4_platform_common/crypto.h
+++ b/platforms/common/include/px4_platform_common/crypto.h
@@ -208,6 +208,8 @@ public:
 
 	size_t get_min_blocksize(uint8_t key_idx);
 
+	static int crypto_ioctl(unsigned int cmd, unsigned long arg);
+
 private:
 	crypto_session_handle_t _crypto_handle;
 	static px4_sem_t _lock;

--- a/platforms/common/include/px4_platform_common/crypto_backend.h
+++ b/platforms/common/include/px4_platform_common/crypto_backend.h
@@ -39,6 +39,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <sys/ioctl.h>
 #include <px4_platform_common/crypto_algorithms.h>
 #include "crypto_backend_definitions.h"
 
@@ -180,6 +181,63 @@ bool crypto_encrypt_data(crypto_session_handle_t handle,
  */
 
 size_t crypto_get_min_blocksize(crypto_session_handle_t handle, uint8_t key_idx);
+
+
+/* Crypto IOCTLs, to access backend from user space */
+
+#define _CRYPTOIOC(_n)		(_IOC(_CRYPTOIOCBASE, _n))
+
+#define CRYPTOIOCOPEN _CRYPTOIOC(1)
+typedef struct cryptoiocopen {
+	px4_crypto_algorithm_t algorithm;
+	crypto_session_handle_t *handle;
+} cryptoiocopen_t;
+
+#define CRYPTOIOCCLOSE _CRYPTOIOC(2)
+
+#define CRYPTOIOCENCRYPT _CRYPTOIOC(3)
+typedef struct cryptoiocencrypt {
+	crypto_session_handle_t *handle;
+	uint8_t  key_index;
+	const uint8_t *message;
+	size_t message_size;
+	uint8_t *cipher;
+	size_t *cipher_size;
+	bool ret;
+} cryptoiocencrypt_t;
+
+#define CRYPTOIOCGENKEY _CRYPTOIOC(4)
+typedef struct cryptoiocgenkey {
+	crypto_session_handle_t *handle;
+	uint8_t idx;
+	bool persistent;
+	bool ret;
+} cryptoiocgenkey_t;
+
+#define CRYPTOIOCGETNONCE _CRYPTOIOC(5)
+typedef struct cryptoiocgetnonce {
+	crypto_session_handle_t *handle;
+	uint8_t *nonce;
+	size_t *nonce_len;
+	bool ret;
+} cryptoiocgetnonce_t;
+
+#define CRYPTOIOCGETKEY _CRYPTOIOC(6)
+typedef struct cryptoiocgetkey {
+	crypto_session_handle_t *handle;
+	uint8_t key_idx;
+	uint8_t *key;
+	size_t *max_len;
+	uint8_t encryption_key_idx;
+	bool ret;
+} cryptoiocgetkey_t;
+
+#define CRYPTOIOCGETBLOCKSZ _CRYPTOIOC(7)
+typedef struct cryptoiocgetblocksz {
+	crypto_session_handle_t *handle;
+	uint8_t key_idx;
+	size_t ret;
+} cryptoiocgetblocksz_t;
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -12,6 +12,7 @@ add_library(px4_layer
 	${PX4_SOURCE_DIR}/platforms/posix/src/px4/common/cpuload.cpp
 	usr_hrt.cpp
 	px4_userspace_init.cpp
+	px4_usr_crypto.cpp
 )
 
 target_link_libraries(px4_layer
@@ -55,6 +56,7 @@ target_link_libraries(px4_kernel_layer
 
 if (DEFINED PX4_CRYPTO)
 	target_link_libraries(px4_kernel_layer PUBLIC crypto_backend)
+	target_link_libraries(px4_layer PUBLIC crypto_backend_interface)
 endif()
 
 target_compile_options(px4_kernel_layer PRIVATE -D__KERNEL__)


### PR DESCRIPTION
This adds kernel-userspace interfaces to crypto layer

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Describe problem solved by this pull request

Crypto interfaces are not usable in protected build, unless there is an interface to use it also from the user-side modules. This patch adds the necessary IOCTL:s to use the crypto api also in protected build.

## Test data / coverage

This has been tested on fmu-v5 (pixhawk4) platform as well as one one custom HW.
