### PR TITLE
Lidar Lite v3 distance sensor: Increase rate of the driver over I2C to 100Hz

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -94,7 +94,7 @@ static constexpr uint8_t LL40LS_UNIT_ID_3_V4	      = 0x19;
 static constexpr uint8_t LL40LS_DISTHIGH_REG_V4       = 0x10; /* High byte of distance register, auto increment */
 
 // Normal conversion wait time.
-static constexpr uint32_t LL40LS_CONVERSION_INTERVAL{50_ms};
+static constexpr uint32_t LL40LS_CONVERSION_INTERVAL{10_ms};
 
 // Maximum time to wait for a conversion to complete.
 static constexpr uint32_t LL40LS_CONVERSION_TIMEOUT{100_ms};


### PR DESCRIPTION
The data from the Lidar Lite v3 sensor (read through the pixhawk) is coming only on 20Hz. The [datasheet](http://static.garmin.com/pumac/LIDAR_Lite_v3_Operation_Manual_and_Technical_Specifications.pdf
) states that the sensor does measurement typically on 270 Hz.
![Selection_161](https://user-images.githubusercontent.com/7849128/186447089-8e1d92be-bd11-423b-bee3-dfa239dab8be.png)

