### PR TITLE
ekf2: initialiseFilter() simplify mag heading init and resetQuatStateYaw

### DIFF
--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -176,13 +176,6 @@ bool Ekf::initialiseFilter()
 		}
 	}
 
-	if (_params.mag_fusion_type <= MagFuseType::MAG_3D) {
-		if (_mag_counter < _obs_buffer_length) {
-			// not enough mag samples accumulated
-			return false;
-		}
-	}
-
 	if (_baro_counter < _obs_buffer_length) {
 		// not enough baro samples accumulated
 		return false;
@@ -198,18 +191,25 @@ bool Ekf::initialiseFilter()
 	// calculate the initial magnetic field and yaw alignment
 	// but do not mark the yaw alignement complete as it needs to be
 	// reset once the leveling phase is done
-	if ((_params.mag_fusion_type <= MagFuseType::MAG_3D) && (_mag_counter != 0)) {
-		// rotate the magnetometer measurements into earth frame using a zero yaw angle
-		// the angle of the projection onto the horizontal gives the yaw angle
-		const Vector3f mag_earth_pred = updateYawInRotMat(0.f, _R_to_earth) * _mag_lpf.getState();
-		float yaw_new = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
+	if (_params.mag_fusion_type <= MagFuseType::MAG_3D) {
+		if (_mag_counter > 1) {
+			// rotate the magnetometer measurements into earth frame using a zero yaw angle
+			// the angle of the projection onto the horizontal gives the yaw angle
+			const Vector3f mag_earth_pred = updateYawInRotMat(0.f, _R_to_earth) * _mag_lpf.getState();
+			float yaw_new = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
-		// update quaternion states and corresponding covarainces
-		resetQuatStateYaw(yaw_new, 0.f, false);
+			// update the rotation matrix using the new yaw value
+			_R_to_earth = updateYawInRotMat(yaw_new, Dcmf(_state.quat_nominal));
+			_state.quat_nominal = _R_to_earth;
 
-		// set the earth magnetic field states using the updated rotation
-		_state.mag_I = _R_to_earth * _mag_lpf.getState();
-		_state.mag_B.zero();
+			// set the earth magnetic field states using the updated rotation
+			_state.mag_I = _R_to_earth * _mag_lpf.getState();
+			_state.mag_B.zero();
+
+		} else {
+			// not enough mag samples accumulated
+			return false;
+		}
 	}
 
 	// initialise the state covariance matrix now we have starting values for all the states

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -1068,8 +1068,7 @@ private:
 	// reset the quaternion states and covariances to the new yaw value, preserving the roll and pitch
 	// yaw : Euler yaw angle (rad)
 	// yaw_variance : yaw error variance (rad^2)
-	// update_buffer : true if the state change should be also applied to the output observer buffer
-	void resetQuatStateYaw(float yaw, float yaw_variance, bool update_buffer = true);
+	void resetQuatStateYaw(float yaw, float yaw_variance);
 
 	// Declarations used to control use of the EKF-GSF yaw estimator
 

--- a/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
+++ b/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
@@ -216,7 +216,7 @@ bool Ekf::resetYawToGps()
 	const float measured_yaw = _gps_sample_delayed.yaw;
 
 	const float yaw_variance = sq(fmaxf(_params.gps_heading_noise, 1.e-2f));
-	resetQuatStateYaw(measured_yaw, yaw_variance, true);
+	resetQuatStateYaw(measured_yaw, yaw_variance);
 
 	_aid_src_gnss_yaw.time_last_fuse = _time_last_imu;
 	_gnss_yaw_signed_test_ratio_lpf.reset(0.f);


### PR DESCRIPTION
 - most of resetQuatStateYaw doesn't apply to initial heading init, so removing the special case keeps it simple
 - avoid incrementing the quat reset counter and delta initially (no one even has the attitude yet)
