### PR TITLE
Reverted changes that broke Level Horizon calibration

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1447,8 +1447,9 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 					_vehicle_status_flags.calibration_enabled = true;
 					_worker_thread.startTask(WorkerThread::Request::AccelCalibration);
-					answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
-					_vehicle_status_flags.calibration_enabled = true;
+
+				} else if ((int)(cmd.param5) == 2) {
+					// board offset calibration
 					answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 					_vehicle_status_flags.calibration_enabled = true;
 					_worker_thread.startTask(WorkerThread::Request::LevelCalibration);


### PR DESCRIPTION
## Describe problem solved by this pull request
The Level Horizon button in QGC was no starting the level calibration routine after this commit: https://github.com/PX4/PX4-Autopilot/pull/19729

See issue discussion here: https://github.com/PX4/PX4-Autopilot/issues/19998

## Describe your solution
Restored else if statement that was accidentally deleted in the commit mentioned above.  

## Test data / coverage
Tested on a Pixhawk 4 that Level Horizon initiated the level calibration, and properly populated SENS_BOARD_X_OFF and SENS_BOARD_Y_OFF as expected.