### PR TITLE
Add check for _below_gnd_effect_hgt into _get_ground_effect_state() w…

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -326,7 +326,7 @@ bool MulticopterLandDetector::_get_landed_state()
 
 bool MulticopterLandDetector::_get_ground_effect_state()
 {
-	return (_in_descend && !_horizontal_movement) ||
+	return (_below_gnd_effect_hgt && _in_descend && !_horizontal_movement) ||
 	       (_below_gnd_effect_hgt && _takeoff_state == takeoff_status_s::TAKEOFF_STATE_FLIGHT) ||
 	       _takeoff_state == takeoff_status_s::TAKEOFF_STATE_RAMPUP;
 }


### PR DESCRIPTION
…hen _in_descend

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

I am seeing cs_gnd_effect bit triggering during descend even in high altitudes. Typically this occurs at RTL. I wonder if this check is correct. I am not sure why the altitude is not originally checked here, it is very common for me to have (_in_descend && !_horizontal_movement) true.

So here is the question; would it be more right this way? @dagar , @MaEtUgR , @bresch ?
