### PR TITLE
ZED-F9P UART2 Baudrate Configurability and New UBX Mode.

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -792,6 +792,7 @@ GPS::run()
 
 	handle = param_find("GPS_UBX_BAUD2");
 	int32_t f9p_uart2_baudrate = 57600;
+
 	if (handle != PARAM_INVALID) {
 		param_get(handle, &f9p_uart2_baudrate);
 	}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -783,7 +783,17 @@ GPS::run()
 
 		} else if (gps_ubx_mode == 4) {
 			ubx_mode = GPSDriverUBX::UBXMode::MovingBaseUART1;
+
+		} else if (gps_ubx_mode == 5) { // rover with static base on Uart2
+			ubx_mode = GPSDriverUBX::UBXMode::RoverWithStaticBaseUart2;
+
 		}
+	}
+
+	handle = param_find("GPS_UBX_BAUD2");
+	int32_t f9p_uart2_baudrate = 57600;
+	if (handle != PARAM_INVALID) {
+		param_get(handle, &f9p_uart2_baudrate);
 	}
 
 	int32_t gnssSystemsParam = static_cast<int32_t>(GPSHelper::GNSSSystemsMask::RECEIVER_DEFAULTS);
@@ -846,7 +856,7 @@ GPS::run()
 		/* FALLTHROUGH */
 		case gps_driver_mode_t::UBX:
 			_helper = new GPSDriverUBX(_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info,
-						   gps_ubx_dynmodel, heading_offset, ubx_mode);
+						   gps_ubx_dynmodel, heading_offset, f9p_uart2_baudrate, ubx_mode);
 			set_device_type(DRV_GPS_DEVTYPE_UBX);
 			break;
 #ifndef CONSTRAINED_FLASH

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -87,6 +87,7 @@ PARAM_DEFINE_INT32(GPS_SAT_INFO, 0);
  * Select the u-blox configuration setup. Most setups will use the default, including RTK and
  * dual GPS without heading.
  *
+ * If rover has RTCM corrections from a static base (or other static correction source) coming in on UART2, then select Mode 5.
  * The Heading mode requires 2 F9P devices to be attached. The main GPS will act as rover and output
  * heading information, whereas the secondary will act as moving base.
  * Modes 1 and 2 require each F9P UART1 to be connected to the Autopilot. In addition, UART2 on the
@@ -101,11 +102,28 @@ PARAM_DEFINE_INT32(GPS_SAT_INFO, 0);
  * @value 2 Moving Base (UART1 Connected To Autopilot, UART2 Connected To Rover)
  * @value 3 Heading (Rover With Moving Base UART1 Connected to Autopilot Or Can Node At 921600)
  * @value 4 Moving Base (Moving Base UART1 Connected to Autopilot Or Can Node At 921600)
+ * @value 5 Rover with Static Base on UART2 (similar to Default, except coming in on UART2)
  *
  * @reboot_required true
  * @group GPS
  */
 PARAM_DEFINE_INT32(GPS_UBX_MODE, 0);
+
+
+/**
+ * u-blox F9P UART2 Baudrate
+ *
+ * Select a baudrate for the F9P's UART2 port.
+ * In GPS_UBX_MODE 1, 2, and 3, the F9P's UART2 port is configured to send/receive RTCM corrections.
+ * Default is set to 57600 for easy use with a Telem Radio on this port to send/receive corrections.
+ *
+ * @min 0
+ * @unit B/s
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_UBX_BAUD2, 230400);
 
 
 /**

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -115,7 +115,7 @@ PARAM_DEFINE_INT32(GPS_UBX_MODE, 0);
  *
  * Select a baudrate for the F9P's UART2 port.
  * In GPS_UBX_MODE 1, 2, and 3, the F9P's UART2 port is configured to send/receive RTCM corrections.
- * Default is set to 57600 for easy use with a Telem Radio on this port to send/receive corrections.
+ * Set this to 57600 if you want to attach a telemetry radio on UART2.
  *
  * @min 0
  * @unit B/s


### PR DESCRIPTION
## Describe problem solved by this pull request
When using the U-blox ZED-F9P GPS module, users may want to use the GPS module's UART2 port to send or receive RTCM corrections using a Telemetry Radio, rather than hard wiring this port to another module. These radios commonly operate at 57600 baud out of the box. But the UART2 baudrate is hard coded to 230400 baud. This PR allows us to configure the Baud Rate of the ZED-F9P's UART2 port through a QGC param.

Additionally, the existing modes that the **GPS_UBX_MODE** param covers misses one potential mode -- when a user is sending RTCM corrections from a _static_ base, or other _static_ correction source, directly to UART2. The wording and documentation of the existing modes that enable UART2 assume a moving base configuration. I've called this new mode **Rover With Static Base on UART2**. This mode is functionally equivalent to Rover with moving base on UART2 (Heading mode).

## Describe your solution
Added a new param called **GPS_F9P_BAUD2**. Added a new mode to **GPS_UBX_MODE** called **Rover With Static Base on UART2**. This new mode is mapped to value 1. Other modes have been incremented.

## Describe possible alternatives
Hard code a different baud rate.

## Test data / coverage

## Additional context
This PR must be merged alongside the corresponding PR to PX4-GPSDrivers: https://github.com/PX4/PX4-GPSDrivers/pull/112