### PR TITLE
refactor commander: split out code into arming checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,57 +129,59 @@ else
 	BUILD_DIR_SUFFIX :=
 endif
 
+CMAKE_ARGS ?=
+
 # additional config parameters passed to cmake
 ifdef EXTERNAL_MODULES_LOCATION
-	CMAKE_ARGS += -DEXTERNAL_MODULES_LOCATION:STRING=$(EXTERNAL_MODULES_LOCATION)
+	override CMAKE_ARGS += -DEXTERNAL_MODULES_LOCATION:STRING=$(EXTERNAL_MODULES_LOCATION)
 endif
 
 ifdef PX4_CMAKE_BUILD_TYPE
-	CMAKE_ARGS += -DCMAKE_BUILD_TYPE=${PX4_CMAKE_BUILD_TYPE}
+	override CMAKE_ARGS += -DCMAKE_BUILD_TYPE=${PX4_CMAKE_BUILD_TYPE}
 else
 
 	# Address Sanitizer
 	ifdef PX4_ASAN
-		CMAKE_ARGS += -DCMAKE_BUILD_TYPE=AddressSanitizer
+		override CMAKE_ARGS += -DCMAKE_BUILD_TYPE=AddressSanitizer
 	endif
 
 	# Memory Sanitizer
 	ifdef PX4_MSAN
-		CMAKE_ARGS += -DCMAKE_BUILD_TYPE=MemorySanitizer
+		override CMAKE_ARGS += -DCMAKE_BUILD_TYPE=MemorySanitizer
 	endif
 
 	# Thread Sanitizer
 	ifdef PX4_TSAN
-		CMAKE_ARGS += -DCMAKE_BUILD_TYPE=ThreadSanitizer
+		override CMAKE_ARGS += -DCMAKE_BUILD_TYPE=ThreadSanitizer
 	endif
 
 	# Undefined Behavior Sanitizer
 	ifdef PX4_UBSAN
-		CMAKE_ARGS += -DCMAKE_BUILD_TYPE=UndefinedBehaviorSanitizer
+		override CMAKE_ARGS += -DCMAKE_BUILD_TYPE=UndefinedBehaviorSanitizer
 	endif
 
 	# Fuzz Testing
 	ifdef PX4_FUZZ
-		CMAKE_ARGS += -DCMAKE_BUILD_TYPE=FuzzTesting
+		override CMAKE_ARGS += -DCMAKE_BUILD_TYPE=FuzzTesting
 	endif
 
 endif
 
 # Pick up specific Python path if set
 ifdef PYTHON_EXECUTABLE
-	CMAKE_ARGS += -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+	override CMAKE_ARGS += -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
 endif
 
 # Check if the microRTPS agent is to be built
 ifdef BUILD_MICRORTPS_AGENT
-  CMAKE_ARGS += -DBUILD_MICRORTPS_AGENT=ON
+  override CMAKE_ARGS += -DBUILD_MICRORTPS_AGENT=ON
 endif
 
 # Functions
 # --------------------------------------------------------------------
 # describe how to build a cmake config
 define cmake-build
-	$(eval CMAKE_ARGS += -DCONFIG=$(1))
+	$(eval override CMAKE_ARGS += -DCONFIG=$(1))
 	@$(eval BUILD_DIR = "$(SRC_DIR)/build/$(1)")
 	@# check if the desired cmake configuration matches the cache then CMAKE_CACHE_CHECK stays empty
 	@$(call cmake-cache-check)
@@ -383,7 +385,7 @@ format:
 .PHONY: rostest python_coverage
 
 tests:
-	$(eval CMAKE_ARGS += -DTESTFILTER=$(TESTFILTER))
+	$(eval override CMAKE_ARGS += -DTESTFILTER=$(TESTFILTER))
 	$(eval ARGS += test_results)
 	$(eval ASAN_OPTIONS += color=always:check_initialization_order=1:detect_stack_use_after_return=1)
 	$(eval UBSAN_OPTIONS += color=always)

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -118,5 +118,4 @@ bool parachute_system_healthy
 bool avoidance_system_required                    # Set to true if avoidance system is enabled via COM_OBS_AVOID parameter
 bool avoidance_system_valid                       # Status of the obstacle avoidance system
 
-bool battery_healthy                	# set if battery is available and not low
 

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -7,6 +7,7 @@ uint64 timestamp				# time since system start (microseconds)
 uint32 mode_req_angular_velocity
 uint32 mode_req_attitude
 uint32 mode_req_local_position
+uint32 mode_req_local_position_relaxed
 uint32 mode_req_global_position
 uint32 mode_req_local_alt
 uint32 mode_req_mission
@@ -23,18 +24,13 @@ bool angular_velocity_valid
 bool attitude_valid
 bool local_altitude_valid
 bool local_position_valid		# set to true by the commander app if the quality of the local position estimate is good enough to use for navigation
+bool local_position_valid_relaxed	# Local position with reduced accuracy requirements (e.g. flying with optical flow)
 bool local_velocity_valid		# set to true by the commander app if the quality of the local horizontal velocity data is good enough to use for navigation
 bool global_position_valid		# set to true by the commander app if the quality of the global position estimate is good enough to use for navigation
 bool gps_position_valid
 bool home_position_valid		# indicates a valid home position (a valid home position is not always a valid launch)
 bool escs_error		      		# set to true if one or more ESCs reporting esc_status are offline
 bool escs_failure		      	# set to true if one or more ESCs reporting esc_status has a failure
-
-bool position_reliant_on_gps
-bool position_reliant_on_optical_flow
-bool position_reliant_on_vision_position
-
-bool dead_reckoning
 
 bool offboard_control_signal_lost
 

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -29,8 +29,6 @@ bool local_velocity_valid		# set to true by the commander app if the quality of 
 bool global_position_valid		# set to true by the commander app if the quality of the global position estimate is good enough to use for navigation
 bool gps_position_valid
 bool home_position_valid		# indicates a valid home position (a valid home position is not always a valid launch)
-bool escs_error		      		# set to true if one or more ESCs reporting esc_status are offline
-bool escs_failure		      	# set to true if one or more ESCs reporting esc_status has a failure
 
 bool offboard_control_signal_lost
 

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -42,3 +42,8 @@ bool rc_signal_found_once
 bool rc_calibration_in_progress
 bool vtol_transition_failure                        # Set to true if vtol transition failed
 
+bool battery_low_remaining_time
+bool battery_unhealthy
+
+uint8 battery_warning
+

--- a/platforms/common/include/px4_platform_common/log.h
+++ b/platforms/common/include/px4_platform_common/log.h
@@ -117,7 +117,6 @@ __END_DECLS
 
 #include <inttypes.h>
 #include <stdint.h>
-#include <sys/cdefs.h>
 #include <stdio.h>
 #include <stdarg.h>
 
@@ -376,15 +375,28 @@ __END_DECLS
 /****************************************************************************
  * Messages that should never be filtered or compiled out
  ****************************************************************************/
+#if defined(PRINTF_LOG)
+#define PX4_INFO(FMT, ...) 	printf(FMT "\n", ##__VA_ARGS__)
+#else
 #define PX4_INFO(FMT, ...) 	__px4_log_modulename(_PX4_LOG_LEVEL_INFO, FMT, ##__VA_ARGS__)
+#endif
 
-#ifdef __NUTTX
+#if defined(__NUTTX) || defined(PRINTF_LOG)
 #define PX4_INFO_RAW		printf
 #else
 #define PX4_INFO_RAW(FMT, ...) 	__px4_log_raw(_PX4_LOG_LEVEL_INFO, FMT, ##__VA_ARGS__)
 #endif
 
-#if defined(TRACE_BUILD)
+#if defined(PRINTF_LOG)
+/****************************************************************************
+ * Direct printf output for minimized dependencies
+ ****************************************************************************/
+#define PX4_PANIC(FMT, ...)	printf("Panic: " FMT "\n", ##__VA_ARGS__)
+#define PX4_ERR(FMT, ...)	printf("Error: " FMT "\n", ##__VA_ARGS__)
+#define PX4_WARN(FMT, ...) 	printf("Warn: " FMT "\n", ##__VA_ARGS__)
+#define PX4_DEBUG(FMT, ...) 	printf(FMT "\n", ##__VA_ARGS__)
+
+#elif defined(TRACE_BUILD)
 /****************************************************************************
  * Extremely Verbose settings for a Trace build
  ****************************************************************************/

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -106,8 +106,8 @@
                             "description": "Distance sensor"
                         },
                         "128": {
-                            "name": "manual_control_input",
-                            "description": "RC or virtual joystick input"
+                            "name": "remote_control",
+                            "description": "Remote Control (RC or Joystick)"
                         },
                         "256": {
                             "name": "motors_escs",
@@ -198,10 +198,6 @@
                         "536870912": {
                             "name": "gyro",
                             "description": "Gyroscope"
-                        },
-                        "1073741824": {
-                            "name": "remote_control",
-                            "description": "Remote Control"
                         }
                     }
                 },

--- a/src/lib/parameters/templates/px4_parameters.hpp.jinja
+++ b/src/lib/parameters/templates/px4_parameters.hpp.jinja
@@ -23,7 +23,7 @@ enum class params : uint16_t {
 static constexpr param_info_s parameters[] = {
 {% for param in params %}
 	{
-		"{{ param.attrib["name"] }}",
+		.name = "{{ param.attrib["name"] }}",
 	{%- if param.attrib["type"] == "FLOAT" %}
 		.val = {{ "{" }} .f = {{ param.attrib["default"] }} {{ "}" }},
 	{%- elif param.attrib["type"] == "INT32" %}

--- a/src/lib/perf/perf_counter.cpp
+++ b/src/lib/perf/perf_counter.cpp
@@ -41,7 +41,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/queue.h>
 #include <drivers/drv_hrt.h>
 #include <math.h>
 #include <pthread.h>

--- a/src/modules/commander/Arming/ArmStateMachine/CMakeLists.txt
+++ b/src/modules/commander/Arming/ArmStateMachine/CMakeLists.txt
@@ -39,6 +39,6 @@ target_include_directories(ArmStateMachine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ArmStateMachine PUBLIC health_and_arming_checks)
 
 px4_add_functional_gtest(SRC ArmStateMachineTest.cpp
-	LINKLIBS ArmStateMachine health_and_arming_checks sensor_calibration ArmAuthorization mode_util
+	LINKLIBS ArmStateMachine health_and_arming_checks hysteresis sensor_calibration ArmAuthorization mode_util
 	)
 

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -50,6 +50,7 @@ px4_add_module(
 		esc_calibration.cpp
 		factory_calibration_storage.cpp
 		gyro_calibration.cpp
+		HomePosition.cpp
 		level_calibration.cpp
 		lm_fit.cpp
 		mag_calibration.cpp

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -70,9 +70,6 @@
 #include <uORB/topics/cpuload.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/esc_status.h>
-#include <uORB/topics/estimator_selector_status.h>
-#include <uORB/topics/estimator_status.h>
-#include <uORB/topics/estimator_status_flags.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/iridiumsbd_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
@@ -84,8 +81,6 @@
 #include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/system_power.h>
 #include <uORB/topics/telemetry_status.h>
-#include <uORB/topics/vehicle_angular_velocity.h>
-#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
@@ -133,10 +128,6 @@ private:
 	transition_result_t disarm(arm_disarm_reason_t calling_reason, bool forced = false);
 
 	void battery_status_check();
-
-	bool check_posvel_validity(const bool data_valid, const float data_accuracy, const float required_accuracy,
-				   const hrt_abstime &data_timestamp_us, hrt_abstime &last_fail_time_us,
-				   const bool was_valid);
 
 	void control_status_leds(bool changed, const uint8_t battery_warning);
 
@@ -205,12 +196,7 @@ private:
 		(ParamBool<px4::params::COM_HOME_EN>) _param_com_home_en,
 		(ParamBool<px4::params::COM_HOME_IN_AIR>) _param_com_home_in_air,
 
-		(ParamFloat<px4::params::COM_POS_FS_EPH>) _param_com_pos_fs_eph,
-		(ParamFloat<px4::params::COM_POS_FS_EPV>) _param_com_pos_fs_epv, 	/*Not realy used for now*/
-		(ParamFloat<px4::params::COM_VEL_FS_EVH>) _param_com_vel_fs_evh,
 		(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl,	/* failsafe response to loss of navigation accuracy */
-
-		(ParamInt<px4::params::COM_POS_FS_DELAY>) _param_com_pos_fs_delay,
 
 		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _param_com_low_bat_act,
 		(ParamFloat<px4::params::COM_BAT_ACT_T>) _param_com_bat_act_t,
@@ -292,20 +278,6 @@ private:
 	static constexpr uint64_t INAIR_RESTART_HOLDOFF_INTERVAL{500_ms};
 
 	ArmStateMachine _arm_state_machine{};
-
-	hrt_abstime	_last_gpos_fail_time_us{0};	/**< Last time that the global position validity recovery check failed (usec) */
-	hrt_abstime	_last_lpos_fail_time_us{0};	/**< Last time that the local position validity recovery check failed (usec) */
-	hrt_abstime	_last_lvel_fail_time_us{0};	/**< Last time that the local velocity validity recovery check failed (usec) */
-
-	/* class variables used to check for navigation failure after takeoff */
-	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity and position innovations passed */
-	hrt_abstime	_time_last_innov_fail{0};	/**< last time velocity and position innovations failed */
-	bool		_nav_test_passed{false};	/**< true if the post takeoff navigation test has passed */
-	bool		_nav_test_failed{false};	/**< true if the post takeoff navigation test has failed */
-
-	static constexpr hrt_abstime GPS_VALID_TIME{3_s};
-	Hysteresis _vehicle_gps_position_valid{false};
-	hrt_abstime _vehicle_gps_position_timestamp_last{0};
 
 	bool		_geofence_loiter_on{false};
 	bool		_geofence_rtl_on{false};
@@ -392,15 +364,11 @@ private:
 	uORB::Subscription					_action_request_sub {ORB_ID(action_request)};
 	uORB::Subscription					_cpuload_sub{ORB_ID(cpuload)};
 	uORB::Subscription					_esc_status_sub{ORB_ID(esc_status)};
-	uORB::Subscription					_estimator_selector_status_sub{ORB_ID(estimator_selector_status)};
-	uORB::Subscription					_estimator_status_sub{ORB_ID(estimator_status)};
 	uORB::Subscription					_geofence_result_sub{ORB_ID(geofence_result)};
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription					_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
-	uORB::Subscription					_vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
-	uORB::Subscription					_vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 	uORB::Subscription					_vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription					_vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 	uORB::Subscription					_vtol_vehicle_status_sub{ORB_ID(vtol_vehicle_status)};
@@ -414,7 +382,6 @@ private:
 	uORB::Subscription					_power_button_state_sub {ORB_ID(power_button_state)};
 #endif // BOARD_HAS_POWER_CONTROL
 
-	uORB::SubscriptionData<estimator_status_flags_s>	_estimator_status_flags_sub{ORB_ID(estimator_status_flags)};
 	uORB::SubscriptionData<mission_result_s>		_mission_result_sub{ORB_ID(mission_result)};
 	uORB::SubscriptionData<offboard_control_mode_s>		_offboard_control_mode_sub{ORB_ID(offboard_control_mode)};
 	uORB::SubscriptionData<vehicle_global_position_s>	_global_position_sub{ORB_ID(vehicle_global_position)};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -155,6 +155,17 @@ private:
 	void send_parachute_command();
 
 	void checkWindSpeedThresholds();
+	void checkForMissionUpdate();
+	void handlePowerButtonState();
+	void systemPowerUpdate();
+	void landDetectorUpdate();
+	void safetyButtonUpdate();
+	void vtolStatusUpdate();
+	void updateTunes();
+	void checkWorkerThread();
+	bool getPrearmState() const;
+
+	void handleAutoDisarm();
 
 	void updateParameters();
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -41,7 +41,6 @@
 #include "worker_thread.hpp"
 #include "HealthAndArmingChecks/HealthAndArmingChecks.hpp"
 
-#include <containers/Bitset.hpp>
 #include <lib/controllib/blocks.hpp>
 #include <lib/hysteresis/hysteresis.h>
 #include <lib/mathlib/mathlib.h>
@@ -341,12 +340,6 @@ private:
 
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime	_battery_failsafe_timestamp{0};
-	px4::Bitset<battery_status_s::MAX_INSTANCES> _last_connected_batteries;
-	uint32_t	_last_battery_custom_fault[battery_status_s::MAX_INSTANCES] {};
-	uint16_t	_last_battery_fault[battery_status_s::MAX_INSTANCES] {};
-	uint8_t		_last_battery_mode[battery_status_s::MAX_INSTANCES] {};
-
-
 	Hysteresis	_auto_disarm_landed{false};
 	Hysteresis	_auto_disarm_killed{false};
 	Hysteresis	_offboard_available{false};
@@ -405,7 +398,6 @@ private:
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription					_manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
-	uORB::Subscription					_rtl_time_estimate_sub{ORB_ID(rtl_time_estimate)};
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
 	uORB::Subscription					_vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
 	uORB::Subscription					_vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
@@ -416,7 +408,6 @@ private:
 
 	uORB::SubscriptionInterval				_parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
-	uORB::SubscriptionMultiArray<battery_status_s, battery_status_s::MAX_INSTANCES> _battery_status_subs{ORB_ID::battery_status};
 	uORB::SubscriptionMultiArray<telemetry_status_s>        _telemetry_status_subs{ORB_ID::telemetry_status};
 
 #if defined(BOARD_HAS_POWER_CONTROL)

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -69,7 +69,6 @@
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/cpuload.h>
 #include <uORB/topics/distance_sensor.h>
-#include <uORB/topics/esc_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/iridiumsbd_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
@@ -135,8 +134,6 @@ private:
 	 * Checks the status of all available data links and handles switching between different system telemetry states.
 	 */
 	void data_link_check();
-
-	void esc_status_check();
 
 	void manual_control_check();
 
@@ -217,8 +214,6 @@ private:
 		// Engine failure
 		(ParamInt<px4::params::COM_ACT_FAIL_ACT>) _param_com_actuator_failure_act,
 
-		(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required,
-
 		(ParamInt<px4::params::COM_FLIGHT_UUID>) _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>) _param_takeoff_finished_action,
 
@@ -293,10 +288,6 @@ private:
 	hrt_abstime	_high_latency_datalink_heartbeat{0};
 	hrt_abstime	_high_latency_datalink_lost{0};
 
-	int		_last_esc_online_flags{-1};
-	int		_last_esc_failure[esc_status_s::CONNECTED_ESC_MAX] {};
-	hrt_abstime	_last_esc_status_updated{0};
-
 	uint8_t		_battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime	_battery_failsafe_timestamp{0};
 	Hysteresis	_auto_disarm_landed{false};
@@ -348,7 +339,6 @@ private:
 	// Subscriptions
 	uORB::Subscription					_action_request_sub {ORB_ID(action_request)};
 	uORB::Subscription					_cpuload_sub{ORB_ID(cpuload)};
-	uORB::Subscription					_esc_status_sub{ORB_ID(esc_status)};
 	uORB::Subscription					_geofence_result_sub{ORB_ID(geofence_result)};
 	uORB::Subscription					_iridiumsbd_status_sub{ORB_ID(iridiumsbd_status)};
 	uORB::Subscription					_vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -152,8 +152,6 @@ private:
 
 	bool shutdown_if_allowed();
 
-	bool stabilization_required();
-
 	void send_parachute_command();
 
 	void checkWindSpeedThresholds();

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -42,6 +42,7 @@ px4_add_library(health_and_arming_checks
 	checks/imuConsistencyCheck.cpp
 	checks/airspeedCheck.cpp
 	checks/distanceSensorChecks.cpp
+	checks/escCheck.cpp
 	checks/rcCalibrationCheck.cpp
 	checks/powerCheck.cpp
 	checks/estimatorCheck.cpp

--- a/src/modules/commander/HealthAndArmingChecks/Common.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.cpp
@@ -177,7 +177,7 @@ void Report::reset()
 void Report::prepare(uint8_t vehicle_type)
 {
 	// Get mode requirements before running any checks (in particular the mode checks require them)
-	getModeRequirements(vehicle_type, _status_flags);
+	mode_util::getModeRequirements(vehicle_type, _status_flags);
 }
 
 NavModes Report::getModeGroup(uint8_t nav_state) const

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -44,6 +44,7 @@
 #include "checks/baroCheck.hpp"
 #include "checks/cpuResourceCheck.hpp"
 #include "checks/distanceSensorChecks.hpp"
+#include "checks/escCheck.hpp"
 #include "checks/estimatorCheck.hpp"
 #include "checks/failureDetectorCheck.hpp"
 #include "checks/gyroCheck.hpp"
@@ -98,6 +99,7 @@ private:
 	BaroChecks _baro_checks;
 	CpuResourceChecks _cpu_resource_checks;
 	DistanceSensorChecks _distance_sensor_checks;
+	EscChecks _esc_checks;
 	EstimatorChecks _estimator_checks;
 	FailureDetectorChecks _failure_detector_checks;
 	GyroChecks _gyro_checks;
@@ -118,6 +120,7 @@ private:
 		&_baro_checks,
 		&_cpu_resource_checks,
 		&_distance_sensor_checks,
+		&_esc_checks,
 		&_estimator_checks,
 		&_failure_detector_checks,
 		&_gyro_checks,

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -124,7 +124,7 @@ private:
 		&_imu_consistency_checks,
 		&_magnetometer_checks,
 		&_manual_control_checks,
-		&_mode_checks,
+		&_mode_checks, // must be after _estimator_checks
 		&_parachute_checks,
 		&_power_checks,
 		&_rc_calibration_checks,

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
@@ -86,7 +86,7 @@ TEST_F(ReporterTest, basic_fail_all_modes)
 	// ensure arming is always denied with a NavModes::All failure
 	for (uint8_t nav_state = 0; nav_state < vehicle_status_s::NAVIGATION_STATE_MAX; ++nav_state) {
 		reporter.reset();
-		reporter.armingCheckFailure(NavModes::All, health_component_t::manual_control_input,
+		reporter.armingCheckFailure(NavModes::All, health_component_t::remote_control,
 					    events::ID("arming_test_basic_fail_all_modes_fail1"), events::Log::Info, "");
 		reporter.finalize();
 		reporter.report(false, false);
@@ -103,7 +103,7 @@ TEST_F(ReporterTest, arming_checks_mode_category)
 
 	// arming must still be possible for non-relevant failures
 	reporter.reset();
-	reporter.armingCheckFailure(NavModes::PositionControl | NavModes::Stabilized, health_component_t::manual_control_input,
+	reporter.armingCheckFailure(NavModes::PositionControl | NavModes::Stabilized, health_component_t::remote_control,
 				    events::ID("arming_test_arming_checks_mode_category_fail1"), events::Log::Warning, "");
 	reporter.clearCanRunBits(NavModes::PositionControl | NavModes::Stabilized);
 	reporter.healthFailure(NavModes::PositionControl, health_component_t::local_position_estimate,
@@ -118,7 +118,7 @@ TEST_F(ReporterTest, arming_checks_mode_category)
 
 	ASSERT_EQ((uint8_t)reporter.armingCheckResults().can_arm, (uint8_t)~(NavModes::PositionControl | NavModes::Stabilized));
 	ASSERT_EQ((uint64_t)reporter.armingCheckResults().error, 0);
-	ASSERT_EQ(reporter.armingCheckResults().warning, events::px4::enums::health_component_t::manual_control_input);
+	ASSERT_EQ(reporter.armingCheckResults().warning, events::px4::enums::health_component_t::remote_control);
 
 	ASSERT_EQ(reporter.healthResults().is_present, events::px4::enums::health_component_t::battery);
 	ASSERT_EQ((uint64_t)reporter.healthResults().error, 0);
@@ -132,7 +132,7 @@ TEST_F(ReporterTest, arming_checks_mode_category2)
 
 	// A matching mode category must deny arming
 	reporter.reset();
-	reporter.healthFailure(NavModes::Mission, health_component_t::manual_control_input,
+	reporter.healthFailure(NavModes::Mission, health_component_t::remote_control,
 			       events::ID("arming_test_arming_checks_mode_category2_fail1"), events::Log::Warning, "");
 	reporter.finalize();
 	reporter.report(false, false);
@@ -145,7 +145,7 @@ TEST_F(ReporterTest, arming_checks_mode_category2)
 
 	ASSERT_EQ((uint64_t)reporter.healthResults().is_present, 0);
 	ASSERT_EQ((uint64_t)reporter.healthResults().error, 0);
-	ASSERT_EQ(reporter.healthResults().warning, events::px4::enums::health_component_t::manual_control_input);
+	ASSERT_EQ(reporter.healthResults().warning, events::px4::enums::health_component_t::remote_control);
 }
 
 TEST_F(ReporterTest, reporting)
@@ -166,11 +166,11 @@ TEST_F(ReporterTest, reporting)
 			reporter.reset();
 
 			if (with_arg) {
-				reporter.armingCheckFailure<uint16_t>(NavModes::All, health_component_t::manual_control_input,
+				reporter.armingCheckFailure<uint16_t>(NavModes::All, health_component_t::remote_control,
 								      events::ID("arming_test_reporting_fail1"), events::Log::Warning, "", 4938);
 
 			} else {
-				reporter.armingCheckFailure(NavModes::PositionControl, health_component_t::manual_control_input,
+				reporter.armingCheckFailure(NavModes::PositionControl, health_component_t::remote_control,
 							    events::ID("arming_test_reporting_fail2"), events::Log::Warning, "");
 			}
 
@@ -207,11 +207,11 @@ TEST_F(ReporterTest, reporting)
 			reporter.reset();
 
 			if (with_arg) {
-				reporter.healthFailure<uint16_t>(NavModes::All, health_component_t::manual_control_input,
+				reporter.healthFailure<uint16_t>(NavModes::All, health_component_t::remote_control,
 								 events::ID("arming_test_reporting_fail3"), events::Log::Warning, "", 4938);
 
 			} else {
-				reporter.healthFailure(NavModes::PositionControl, health_component_t::manual_control_input,
+				reporter.healthFailure(NavModes::PositionControl, health_component_t::remote_control,
 						       events::ID("arming_test_reporting_fail4"), events::Log::Warning, "");
 			}
 
@@ -255,11 +255,11 @@ TEST_F(ReporterTest, reporting_multiple)
 
 	for (int i = 0; i < 3; ++i) {
 		reporter.reset();
-		reporter.armingCheckFailure<uint16_t>(NavModes::All, health_component_t::manual_control_input,
+		reporter.armingCheckFailure<uint16_t>(NavModes::All, health_component_t::remote_control,
 						      events::ID("arming_test_reporting_multiple_fail1"), events::Log::Warning, "", 4938);
-		reporter.armingCheckFailure<float>(NavModes::All, health_component_t::manual_control_input,
+		reporter.armingCheckFailure<float>(NavModes::All, health_component_t::remote_control,
 						   events::ID("arming_test_reporting_multiple_fail2"), events::Log::Warning, "", 123.f);
-		reporter.armingCheckFailure<uint8_t>(NavModes::All, health_component_t::manual_control_input,
+		reporter.armingCheckFailure<uint8_t>(NavModes::All, health_component_t::remote_control,
 						     events::ID("arming_test_reporting_multiple_fail3"), events::Log::Warning, "", 55);
 		reporter.finalize();
 		reporter.report(false, false);

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -33,13 +33,201 @@
 
 #include "batteryCheck.hpp"
 
+#include <px4_platform_common/events.h>
+
 using namespace time_literals;
+
+using battery_fault_reason_t = events::px4::enums::battery_fault_reason_t;
+static_assert(battery_status_s::BATTERY_FAULT_COUNT == (static_cast<uint8_t>(battery_fault_reason_t::_max) + 1)
+	      , "Battery fault flags mismatch!");
+
+static constexpr const char *battery_fault_reason_str(battery_fault_reason_t battery_fault_reason)
+{
+	switch (battery_fault_reason) {
+	case battery_fault_reason_t::deep_discharge: return "under voltage";
+
+	case battery_fault_reason_t::voltage_spikes: return "over voltage";
+
+	case battery_fault_reason_t::cell_fail: return "cell fault";
+
+	case battery_fault_reason_t::over_current: return "over current";
+
+	case battery_fault_reason_t::fault_temperature: return "critical temperature";
+
+	case battery_fault_reason_t::under_temperature: return "under temperature";
+
+	case battery_fault_reason_t::incompatible_voltage: return "voltage mismatch";
+
+	case battery_fault_reason_t::incompatible_firmware: return "incompatible firmware";
+
+	case battery_fault_reason_t::incompatible_model: return "incompatible model";
+
+	case battery_fault_reason_t::hardware_fault: return "hardware fault";
+
+	case battery_fault_reason_t::over_temperature: return "near temperature limit";
+
+	}
+
+	return "";
+};
+
+
+using battery_mode_t = events::px4::enums::battery_mode_t;
+static_assert(battery_status_s::BATTERY_MODE_COUNT == (static_cast<uint8_t>(battery_mode_t::_max) + 1)
+	      , "Battery mode flags mismatch!");
+static constexpr const char *battery_mode_str(battery_mode_t battery_mode)
+{
+	switch (battery_mode) {
+	case battery_mode_t::autodischarging: return "auto discharging";
+
+	case battery_mode_t::hotswap: return "hot-swap";
+
+	default: return "unknown";
+	}
+}
+
 
 void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 {
-	if (!context.status().battery_healthy) {
+	int battery_required_count = 0;
+	bool battery_has_fault = false;
+	// There are possibly multiple batteries, and we can't know which ones serve which purpose. So the safest
+	// option is to check if ANY of them have a warning, and specifically find which one has the most
+	// urgent warning.
+	uint8_t worst_warning = battery_status_s::BATTERY_WARNING_NONE;
+	// To make sure that all connected batteries are being regularly reported, we check which one has the
+	// oldest timestamp.
+	hrt_abstime oldest_update = hrt_absolute_time();
+	float worst_battery_time_s{NAN};
+	int num_connected_batteries{0};
 
+	for (auto &battery_sub : _battery_status_subs) {
+		int index = battery_sub.get_instance();
+		battery_status_s battery;
+
+		if (!battery_sub.copy(&battery)) {
+			continue;
+		}
+
+		if (battery.is_required) {
+			battery_required_count++;
+		}
+
+		if (context.isArmed()) {
+
+			if (!battery.connected) {
+				/* EVENT
+				 */
+				reporter.healthFailure<uint8_t>(NavModes::All, health_component_t::battery, events::ID("check_battery_disconnected"),
+								events::Log::Emergency, "Battery {1} disconnected", index + 1);
+
+				if (reporter.mavlink_log_pub()) {
+					mavlink_log_critical(reporter.mavlink_log_pub(), "Battery %i disconnected\t", index + 1);
+				}
+
+				// trigger a battery failsafe action if a battery disconnects in flight
+				worst_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
+			}
+
+			if (battery.mode != 0) {
+				/* EVENT
+				 */
+				reporter.healthFailure<uint8_t, events::px4::enums::battery_mode_t>(NavModes::All, health_component_t::battery,
+						events::ID("check_battery_mode"),
+						events::Log::Critical, "Battery {1} mode: {2}", index + 1, static_cast<battery_mode_t>(battery.mode));
+
+				if (reporter.mavlink_log_pub()) {
+					mavlink_log_critical(reporter.mavlink_log_pub(), "Battery %d is in %s mode!\t", index + 1,
+							     battery_mode_str(static_cast<battery_mode_t>(battery.mode)));
+				}
+			}
+		}
+
+		if (battery.connected) {
+			++num_connected_batteries;
+
+			if (battery.warning > worst_warning) {
+				worst_warning = battery.warning;
+			}
+
+			if (battery.timestamp < oldest_update) {
+				oldest_update = battery.timestamp;
+			}
+
+			if (battery.faults > 0) {
+				battery_has_fault = true;
+
+				for (uint8_t fault_index = 0; fault_index <= static_cast<uint8_t>(battery_fault_reason_t::_max); fault_index++) {
+					if (battery.faults & (1 << fault_index)) {
+						events::px4::enums::suggested_action_t action = context.isArmed() ?
+								events::px4::enums::suggested_action_t::land :
+								events::px4::enums::suggested_action_t::none;
+
+						/* EVENT
+						 * @description
+						 * The battery reported a failure which might be dangerous to fly with.
+						 * Manufacturer error code: {4}
+						 */
+						reporter.healthFailure<uint8_t, battery_fault_reason_t, events::px4::enums::suggested_action_t, uint32_t>
+						(NavModes::All, health_component_t::battery, events::ID("check_battery_fault"), {events::Log::Emergency, events::LogInternal::Warning},
+						 "Battery {1}: {2}. {3}", index + 1, static_cast<battery_fault_reason_t>(fault_index), action, battery.custom_faults);
+
+						if (reporter.mavlink_log_pub()) {
+							mavlink_log_emergency(reporter.mavlink_log_pub(), "Battery %d: %s. %s \t", index + 1,
+									      battery_fault_reason_str(
+										      static_cast<battery_fault_reason_t>(fault_index)),
+									      context.isArmed() ? "Land now!" : "");
+						}
+					}
+				}
+			}
+
+			if (PX4_ISFINITE(battery.time_remaining_s)
+			    && (!PX4_ISFINITE(worst_battery_time_s)
+				|| (PX4_ISFINITE(worst_battery_time_s) && (battery.time_remaining_s < worst_battery_time_s)))) {
+				worst_battery_time_s = battery.time_remaining_s;
+			}
+		}
+	}
+
+	if (context.isArmed()) {
+		if (worst_warning > reporter.failsafeFlags().battery_warning) {
+			reporter.failsafeFlags().battery_warning = worst_warning;
+		}
+
+	} else {
+		reporter.failsafeFlags().battery_warning = worst_warning;
+	}
+
+	if (reporter.failsafeFlags().battery_warning > battery_status_s::BATTERY_WARNING_NONE) {
+		bool critical_or_higher = reporter.failsafeFlags().battery_warning >= battery_status_s::BATTERY_WARNING_CRITICAL;
+		NavModes affected_modes = critical_or_higher ? NavModes::All : NavModes::None;
+		events::LogLevel log_level = critical_or_higher ? events::Log::Critical : events::Log::Warning;
 		/* EVENT
+		 */
+		reporter.armingCheckFailure(affected_modes, health_component_t::battery, events::ID("check_battery_low"), log_level,
+					    "Low battery");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_emergency(reporter.mavlink_log_pub(), "Preflight Fail: low battery\t");
+		}
+
+	}
+
+	rtlEstimateCheck(context, reporter, worst_battery_time_s);
+
+	reporter.failsafeFlags().battery_unhealthy =
+		// All connected batteries are regularly being published
+		hrt_elapsed_time(&oldest_update) > 5_s
+		// There is at least one connected battery (in any slot)
+		|| num_connected_batteries < battery_required_count
+		// No currently-connected batteries have any fault
+		|| battery_has_fault;
+
+	if (reporter.failsafeFlags().battery_unhealthy && !battery_has_fault) { // faults are reported above already
+		/* EVENT
+		 * @description
+		 * Make sure all batteries are connected.
 		 */
 		reporter.healthFailure(NavModes::All, health_component_t::battery, events::ID("check_battery_unhealthy"),
 				       events::Log::Error, "Battery unhealthy");
@@ -49,6 +237,29 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 		}
 	}
 
-	reporter.setIsPresent(health_component_t::battery); // assume it's present
+	if (num_connected_batteries > 0) {
+		reporter.setIsPresent(health_component_t::battery);
+	}
+
+}
+
+void BatteryChecks::rtlEstimateCheck(const Context &context, Report &reporter, float worst_battery_time_s)
+{
+	rtl_time_estimate_s rtl_time_estimate;
+
+	// Compare estimate of RTL time to estimate of remaining flight time
+	reporter.failsafeFlags().battery_low_remaining_time = _rtl_time_estimate_sub.copy(&rtl_time_estimate)
+			&& (hrt_absolute_time() - rtl_time_estimate.timestamp) < 2_s
+			&& rtl_time_estimate.valid
+			&& context.isArmed()
+			&& PX4_ISFINITE(worst_battery_time_s)
+			&& rtl_time_estimate.safe_time_estimate >= worst_battery_time_s;
+
+	if (reporter.failsafeFlags().battery_low_remaining_time) {
+		/* EVENT
+		 */
+		reporter.armingCheckFailure(NavModes::All, health_component_t::battery, events::ID("check_battery_rem_flight_time_low"),
+					    events::Log::Error, "Remaining flight time low");
+	}
 
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
@@ -36,6 +36,9 @@
 #include "../Common.hpp"
 
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
+#include <uORB/topics/battery_status.h>
+#include <uORB/topics/rtl_time_estimate.h>
 
 class BatteryChecks : public HealthAndArmingCheckBase
 {
@@ -46,4 +49,9 @@ public:
 	void checkAndReport(const Context &context, Report &reporter) override;
 
 private:
+	void rtlEstimateCheck(const Context &context, Report &reporter, float worst_battery_time_s);
+
+	uORB::SubscriptionMultiArray<battery_status_s, battery_status_s::MAX_INSTANCES> _battery_status_subs{ORB_ID::battery_status};
+	uORB::Subscription					_rtl_time_estimate_sub{ORB_ID(rtl_time_estimate)};
+
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -1,0 +1,186 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "escCheck.hpp"
+#include <px4_platform_common/events.h>
+#include <uORB/topics/actuator_motors.h>
+
+using namespace time_literals;
+
+using esc_fault_reason_t = events::px4::enums::esc_fault_reason_t;
+static_assert(esc_report_s::ESC_FAILURE_COUNT == (static_cast<uint8_t>(esc_fault_reason_t::_max) + 1)
+	      , "ESC fault flags mismatch!");
+static constexpr const char *esc_fault_reason_str(esc_fault_reason_t esc_fault_reason)
+{
+	switch (esc_fault_reason) {
+	case esc_fault_reason_t::over_current: return "over current";
+
+	case esc_fault_reason_t::over_voltage: return "over voltage";
+
+	case esc_fault_reason_t::motor_over_temp: return "motor critical temperature";
+
+	case esc_fault_reason_t::over_rpm: return "over RPM";
+
+	case esc_fault_reason_t::inconsistent_cmd: return "control failure";
+
+	case esc_fault_reason_t::motor_stuck: return "motor stall";
+
+	case esc_fault_reason_t::failure_generic: return "hardware failure";
+
+	case esc_fault_reason_t::motor_warn_temp: return "motor over temperature";
+
+	case esc_fault_reason_t::esc_warn_temp: return "over temperature";
+
+	case esc_fault_reason_t::esc_over_temp: return "critical temperature";
+
+	}
+
+	return "";
+};
+
+
+void EscChecks::checkAndReport(const Context &context, Report &reporter)
+{
+	const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime esc_telemetry_timeout =
+		700_ms; // Some DShot ESCs are unresponsive for ~550ms during their initialization, so we use a timeout higher than that
+
+	esc_status_s esc_status;
+
+	if (_esc_status_sub.copy(&esc_status) && now - esc_status.timestamp < esc_telemetry_timeout) {
+
+		checkEscStatus(context, reporter, esc_status);
+		reporter.setIsPresent(health_component_t::motors_escs);
+
+	} else if (_param_escs_checks_required.get()
+		   && now - _start_time > 5_s) { // Wait a bit after startup to allow esc's to init
+
+		/* EVENT
+		 * @description
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_ARM_CHK_ESCS</param> parameter.
+		 * </profile>
+		 */
+		reporter.healthFailure(NavModes::All, health_component_t::motors_escs, events::ID("check_escs_telem_missing"),
+				       events::Log::Critical, "ESC telemetry missing");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: ESC telemetry missing");
+		}
+	}
+}
+
+void EscChecks::checkEscStatus(const Context &context, Report &reporter, const esc_status_s &esc_status)
+{
+	const NavModes required_modes = _param_escs_checks_required.get() ? NavModes::All : NavModes::None;
+
+	if (esc_status.esc_count > 0) {
+
+		char esc_fail_msg[50];
+		esc_fail_msg[0] = '\0';
+
+		int online_bitmask = (1 << esc_status.esc_count) - 1;
+
+		// Check if one or more the ESCs are offline
+		if (online_bitmask != esc_status.esc_online_flags) {
+
+			for (int index = 0; index < esc_status.esc_count; index++) {
+				if ((esc_status.esc_online_flags & (1 << index)) == 0) {
+					uint8_t motor_index = esc_status.esc[index].actuator_function - actuator_motors_s::ACTUATOR_FUNCTION_MOTOR1 + 1;
+					/* EVENT
+					 * @description
+					 * <profile name="dev">
+					 * This check can be configured via <param>COM_ARM_CHK_ESCS</param> parameter.
+					 * </profile>
+					 */
+					reporter.healthFailure<uint8_t>(required_modes, health_component_t::motors_escs, events::ID("check_escs_offline"),
+									events::Log::Critical, "ESC {1} offline", motor_index);
+					snprintf(esc_fail_msg + strlen(esc_fail_msg), sizeof(esc_fail_msg) - strlen(esc_fail_msg), "ESC%d ", motor_index);
+					esc_fail_msg[sizeof(esc_fail_msg) - 1] = '\0';
+				}
+			}
+
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "%soffline. %s\t", esc_fail_msg, context.isArmed() ? "Land now!" : "");
+			}
+		}
+
+		for (int index = 0; index < esc_status.esc_count; index++) {
+
+			if (esc_status.esc[index].failures != 0) {
+
+				for (uint8_t fault_index = 0; fault_index <= static_cast<uint8_t>(esc_fault_reason_t::_max); fault_index++) {
+					if (esc_status.esc[index].failures & (1 << fault_index)) {
+
+						esc_fault_reason_t fault_reason_index = static_cast<esc_fault_reason_t>(fault_index);
+
+						const char *user_action = "";
+						events::px4::enums::suggested_action_t action = events::px4::enums::suggested_action_t::none;
+
+						if (context.isArmed()) {
+							if (fault_reason_index == esc_fault_reason_t::motor_warn_temp
+							    || fault_reason_index == esc_fault_reason_t::esc_warn_temp) {
+								user_action = "Reduce throttle";
+								action = events::px4::enums::suggested_action_t::reduce_throttle;
+
+							} else {
+								user_action = "Land now!";
+								action = events::px4::enums::suggested_action_t::land;
+							}
+						}
+
+						uint8_t motor_index = esc_status.esc[index].actuator_function - actuator_motors_s::ACTUATOR_FUNCTION_MOTOR1 + 1;
+
+						/* EVENT
+						 * @description
+						 * {3}
+						 *
+						 * <profile name="dev">
+						 * This check can be configured via <param>COM_ARM_CHK_ESCS</param> parameter.
+						 * </profile>
+						 */
+						reporter.healthFailure<uint8_t, events::px4::enums::esc_fault_reason_t, events::px4::enums::suggested_action_t>(
+							required_modes, health_component_t::motors_escs, events::ID("check_escs_fault"),
+							events::Log::Critical, "ESC {1}: {2}", motor_index, fault_reason_index, action);
+
+						if (reporter.mavlink_log_pub()) {
+							mavlink_log_emergency(reporter.mavlink_log_pub(), "ESC%d: %s. %s \t", motor_index,
+									      esc_fault_reason_str(fault_reason_index), user_action);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+

--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.hpp
@@ -36,25 +36,24 @@
 #include "../Common.hpp"
 
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/esc_status.h>
 
-class SystemChecks : public HealthAndArmingCheckBase
+class EscChecks : public HealthAndArmingCheckBase
 {
 public:
-	SystemChecks() = default;
-	~SystemChecks() = default;
+	EscChecks() = default;
+	~EscChecks() = default;
 
 	void checkAndReport(const Context &context, Report &reporter) override;
 
 private:
-	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
+	void checkEscStatus(const Context &context, Report &reporter, const esc_status_s &esc_status);
+
+	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
+
+	const hrt_abstime _start_time{hrt_absolute_time()};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::CBRK_VTOLARMING>) _param_cbrk_vtolarming,
-					(ParamInt<px4::params::CBRK_USB_CHK>) _param_cbrk_usb_chk,
-					(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_com_arm_mis_req,
-					(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_com_arm_wo_gps,
-					(ParamInt<px4::params::COM_ARM_AUTH_REQ>) _param_com_arm_auth_req,
-					(ParamInt<px4::params::GF_ACTION>) _param_gf_action
+					(ParamBool<px4::params::COM_ARM_CHK_ESCS>) _param_escs_checks_required
 				       )
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -35,21 +35,48 @@
 
 using namespace time_literals;
 
+EstimatorChecks::EstimatorChecks()
+{
+	_vehicle_gps_position_valid.set_hysteresis_time_from(false, GPS_VALID_TIME);
+	_vehicle_gps_position_valid.set_hysteresis_time_from(true, 0);
+
+	// initially set to failed
+	_last_lpos_fail_time_us = hrt_absolute_time();
+	_last_lpos_relaxed_fail_time_us = _last_lpos_fail_time_us;
+	_last_gpos_fail_time_us = _last_lpos_fail_time_us;
+	_last_lvel_fail_time_us = _last_lpos_fail_time_us;
+}
+
 void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 {
-	if (_param_sys_mc_est_group.get() != 2) {
-		return;
+	sensor_gps_s vehicle_gps_position;
+
+	if (_vehicle_gps_position_sub.copy(&vehicle_gps_position)) {
+		checkGps(context, reporter, vehicle_gps_position);
+
+	} else {
+		vehicle_gps_position = {};
 	}
 
-	const NavModes required_groups = (NavModes)reporter.failsafeFlags().mode_req_attitude;
-	bool missing_data = false;
+	vehicle_local_position_s lpos;
 
+	if (!_vehicle_local_position_sub.copy(&lpos)) {
+		lpos = {};
+	}
+
+	bool pre_flt_fail_innov_heading = false;
+	bool pre_flt_fail_innov_vel_horiz = false;
+	bool missing_data = false;
+	const NavModes required_groups = (NavModes)reporter.failsafeFlags().mode_req_attitude;
+
+	// Change topics to primary estimator instance
 	if (_param_sens_imu_mode.get() == 0) { // multi-ekf
 		estimator_selector_status_s estimator_selector_status;
 
 		if (_estimator_selector_status_sub.copy(&estimator_selector_status)) {
 			bool instance_changed = _estimator_status_sub.ChangeInstance(estimator_selector_status.primary_instance)
-						&& _estimator_sensor_bias_sub.ChangeInstance(estimator_selector_status.primary_instance);
+						&& _estimator_sensor_bias_sub.ChangeInstance(estimator_selector_status.primary_instance)
+						&& _estimator_status_flags_sub.ChangeInstance(estimator_selector_status.primary_instance);
 
 			if (!instance_changed) {
 				missing_data = true;
@@ -64,8 +91,11 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 		estimator_status_s estimator_status;
 
 		if (_estimator_status_sub.copy(&estimator_status)) {
+			pre_flt_fail_innov_heading = estimator_status.pre_flt_fail_innov_heading;
+			pre_flt_fail_innov_vel_horiz = estimator_status.pre_flt_fail_innov_vel_horiz;
 
 			checkEstimatorStatus(context, reporter, estimator_status, required_groups);
+			checkEstimatorStatusFlags(context, reporter, estimator_status, lpos);
 
 		} else {
 			missing_data = true;
@@ -86,6 +116,15 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 	} else {
 		reporter.setIsPresent(health_component_t::local_position_estimate);
 		checkSensorBias(context, reporter, required_groups);
+	}
+
+	// set mode requirements
+	const bool condition_gps_position_was_valid = reporter.failsafeFlags().gps_position_valid;
+	setModeRequirementFlags(context, pre_flt_fail_innov_heading, pre_flt_fail_innov_vel_horiz, lpos, vehicle_gps_position,
+				reporter.failsafeFlags());
+
+	if (condition_gps_position_was_valid && !reporter.failsafeFlags().gps_position_valid) {
+		gpsNoLongerValid(context, reporter);
 	}
 }
 
@@ -163,6 +202,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 	// check vertical position innovation test ratio
 	if (estimator_status.hgt_test_ratio > _param_com_arm_ekf_hgt.get()) {
 		/* EVENT
+		 * @description
 		 * <profile name="dev">
 		 * Test ratio: {1:.3}, limit: {2:.3}.
 		 *
@@ -181,6 +221,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 	// check velocity innovation test ratio
 	if (estimator_status.vel_test_ratio > _param_com_arm_ekf_vel.get()) {
 		/* EVENT
+		 * @description
 		 * <profile name="dev">
 		 * Test ratio: {1:.3}, limit: {2:.3}.
 		 *
@@ -199,6 +240,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 	// check horizontal position innovation test ratio
 	if (estimator_status.pos_test_ratio > _param_com_arm_ekf_pos.get()) {
 		/* EVENT
+		 * @description
 		 * <profile name="dev">
 		 * Test ratio: {1:.3}, limit: {2:.3}.
 		 *
@@ -217,6 +259,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 	// check magnetometer innovation test ratio
 	if (estimator_status.mag_test_ratio > _param_com_arm_ekf_yaw.get()) {
 		/* EVENT
+		 * @description
 		 * <profile name="dev">
 		 * Test ratio: {1:.3}, limit: {2:.3}.
 		 *
@@ -256,6 +299,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_GPS_FIX)) {
 				message = "Preflight%s: GPS fix too low";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -267,6 +311,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_SAT_COUNT)) {
 				message = "Preflight%s: not enough GPS Satellites";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -278,6 +323,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_PDOP)) {
 				message = "Preflight%s: GPS PDOP too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -289,6 +335,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_ERR)) {
 				message = "Preflight%s: GPS Horizontal Pos Error too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -300,6 +347,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_VERT_ERR)) {
 				message = "Preflight%s: GPS Vertical Pos Error too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -311,6 +359,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_SPD_ERR)) {
 				message = "Preflight%s: GPS Speed Accuracy too low";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -322,6 +371,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_DRIFT)) {
 				message = "Preflight%s: GPS Horizontal Pos Drift too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -333,6 +383,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_VERT_DRIFT)) {
 				message = "Preflight%s: GPS Vertical Pos Drift too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -344,6 +395,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR)) {
 				message = "Preflight%s: GPS Hor Speed Drift too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -355,6 +407,7 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 			} else if (estimator_status.gps_check_fail_flags & (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_VERT_SPD_ERR)) {
 				message = "Preflight%s: GPS Vert Speed Drift too high";
 				/* EVENT
+				 * @description
 				 * <profile name="dev">
 				 * This check can be configured via <param>EKF2_GPS_CHECK</param> parameter.
 				 * </profile>
@@ -415,10 +468,11 @@ void EstimatorChecks::checkSensorBias(const Context &context, Report &reporter, 
 
 				if (fabsf(bias.accel_bias[axis_index]) > ekf_ab_test_limit + test_uncertainty) {
 					/* EVENT
+					 * @description
 					 * An accelerometer recalibration might help.
 					 *
 					 * <profile name="dev">
-					 * Axis {1}: |{2:.8}| > {3:.8} + {4:.8}
+					 * Axis {1}: |{2:.8}| \> {3:.8} + {4:.8}
 					 *
 					 * This check can be configured via <param>EKF2_ABL_LIM</param> parameter.
 					 * </profile>
@@ -448,10 +502,11 @@ void EstimatorChecks::checkSensorBias(const Context &context, Report &reporter, 
 
 				if (fabsf(bias.gyro_bias[axis_index]) > ekf_gb_test_limit + test_uncertainty) {
 					/* EVENT
+					 * @description
 					 * A Gyro recalibration might help.
 					 *
 					 * <profile name="dev">
-					 * Axis {1}: |{2:.8}| > {3:.8} + {4:.8}
+					 * Axis {1}: |{2:.8}| \> {3:.8} + {4:.8}
 					 *
 					 * This check can be configured via <param>EKF2_ABL_GYRLIM</param> parameter.
 					 * </profile>
@@ -471,3 +526,298 @@ void EstimatorChecks::checkSensorBias(const Context &context, Report &reporter, 
 		}
 	}
 }
+
+void EstimatorChecks::checkEstimatorStatusFlags(const Context &context, Report &reporter,
+		const estimator_status_s &estimator_status, const vehicle_local_position_s &lpos)
+{
+	estimator_status_flags_s estimator_status_flags;
+
+	if (_estimator_status_flags_sub.copy(&estimator_status_flags)) {
+
+		bool dead_reckoning = estimator_status_flags.cs_wind_dead_reckoning
+				      || estimator_status_flags.cs_inertial_dead_reckoning;
+
+		if (!dead_reckoning) {
+			// position requirements (update if not dead reckoning)
+			bool gps             = estimator_status_flags.cs_gps;
+			bool optical_flow    = estimator_status_flags.cs_opt_flow;
+			bool vision_position = estimator_status_flags.cs_ev_pos;
+
+			_position_reliant_on_optical_flow = !gps && optical_flow && !vision_position;
+		}
+
+		// Check for a magnetomer fault and notify the user
+		if (estimator_status_flags.cs_mag_fault) {
+			/* EVENT
+			 * @description
+			 * Land and calibrate the compass.
+			 */
+			reporter.armingCheckFailure(NavModes::All, health_component_t::local_position_estimate,
+						    events::ID("check_estimator_mag_fault"),
+						    events::Log::Critical, "Stopping compass use");
+
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "Compass needs calibration - Land now!\t");
+			}
+		}
+
+		if (estimator_status_flags.cs_gps_yaw_fault) {
+			/* EVENT
+			 * @description
+			 * Land now
+			 */
+			reporter.armingCheckFailure(NavModes::All, health_component_t::local_position_estimate,
+						    events::ID("check_estimator_gnss_fault"),
+						    events::Log::Critical, "GNSS heading not reliable");
+
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(), "GNSS heading not reliable - Land now!\t");
+			}
+		}
+	}
+
+	const hrt_abstime now = hrt_absolute_time();
+
+	/* Check estimator status for signs of bad yaw induced post takeoff navigation failure
+	* for a short time interval after takeoff.
+	* Most of the time, the drone can recover from a bad initial yaw using GPS-inertial
+	* heading estimation (yaw emergency estimator) or GPS heading (fixed wings only), but
+	* if this does not fix the issue we need to stop using a position controlled
+	* mode to prevent flyaway crashes.
+	*/
+
+	if (context.status().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+
+		if (!context.isArmed()) {
+			_nav_test_failed = false;
+			_nav_test_passed = false;
+
+		} else {
+			if (!_nav_test_passed) {
+				// Both test ratios need to pass/fail together to change the nav test status
+				const bool innovation_pass = (estimator_status.vel_test_ratio < 1.f) && (estimator_status.pos_test_ratio < 1.f)
+							     && (estimator_status.vel_test_ratio > FLT_EPSILON) && (estimator_status.pos_test_ratio > FLT_EPSILON);
+
+				const bool innovation_fail = (estimator_status.vel_test_ratio >= 1.f) && (estimator_status.pos_test_ratio >= 1.f);
+
+				if (innovation_pass) {
+					_time_last_innov_pass = now;
+
+					// if nav status is unconfirmed, confirm yaw angle as passed after 30 seconds or achieving 5 m/s of speed
+					const bool sufficient_time = context.status().takeoff_time != 0
+								     && now - context.status().takeoff_time > 30_s;
+					const bool sufficient_speed = matrix::Vector2f(lpos.vx, lpos.vy).longerThan(5.f);
+
+					// Even if the test already failed, allow it to pass if it did not fail during the last 10 seconds
+					if (now - _time_last_innov_fail > 10_s && (sufficient_time || sufficient_speed)) {
+						_nav_test_passed = true;
+						_nav_test_failed = false;
+					}
+
+				} else if (innovation_fail) {
+					_time_last_innov_fail = now;
+
+					if (now - _time_last_innov_pass > 2_s) {
+						// if the innovation test has failed continuously, declare the nav as failed
+						_nav_test_failed = true;
+						/* EVENT
+						 * @description
+						 * Land and recalibrate the sensors.
+						 */
+						reporter.armingCheckFailure(NavModes::All, health_component_t::local_position_estimate,
+									    events::ID("check_estimator_nav_failure"),
+									    events::Log::Emergency, "Navigation failure");
+
+						if (reporter.mavlink_log_pub()) {
+							mavlink_log_critical(reporter.mavlink_log_pub(), "Navigation failure! Land and recalibrate sensors\t");
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+void EstimatorChecks::checkGps(const Context &context, Report &reporter, const sensor_gps_s &vehicle_gps_position) const
+{
+	if (vehicle_gps_position.jamming_state == sensor_gps_s::JAMMING_STATE_CRITICAL) {
+		/* EVENT
+		 */
+		reporter.armingCheckFailure(NavModes::None, health_component_t::gps,
+					    events::ID("check_estimator_gps_jamming_critical"),
+					    events::Log::Critical, "GPS reports critical jamming state");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "GPS reports critical jamming state\t");
+		}
+	}
+}
+
+void EstimatorChecks::gpsNoLongerValid(const Context &context, Report &reporter) const
+{
+	PX4_DEBUG("GPS no longer valid");
+
+	// report GPS failure if armed and the global position estimate is still valid
+	if (context.isArmed() && reporter.failsafeFlags().global_position_valid) {
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_warning(reporter.mavlink_log_pub(), "GPS no longer valid\t");
+		}
+
+		events::send(events::ID("check_estimator_gps_lost"), {events::Log::Error, events::LogInternal::Info},
+			     "GPS no longer valid");
+	}
+}
+
+void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_flt_fail_innov_heading,
+		bool pre_flt_fail_innov_vel_horiz,
+		const vehicle_local_position_s &lpos, const sensor_gps_s &vehicle_gps_position, vehicle_status_flags_s &failsafe_flags)
+{
+	// The following flags correspond to mode requirements, and are reported in the corresponding mode checks
+
+	const hrt_abstime now = hrt_absolute_time();
+
+	vehicle_global_position_s gpos;
+
+	if (!_vehicle_global_position_sub.copy(&gpos)) {
+		gpos = {};
+	}
+
+	// run position and velocity accuracy checks
+	// Check if quality checking of position accuracy and consistency is to be performed
+	float lpos_eph_threshold_relaxed = _param_com_pos_fs_eph.get();
+
+	// Set the allowable position uncertainty based on combination of flight and estimator state
+	// When we are in a operator demanded position control mode and are solely reliant on optical flow,
+	// do not check position error because it will gradually increase throughout flight and the operator will compensate for the drift
+	if (_position_reliant_on_optical_flow) {
+		lpos_eph_threshold_relaxed = INFINITY;
+	}
+
+	bool xy_valid = lpos.xy_valid && !_nav_test_failed;
+	bool v_xy_valid = lpos.v_xy_valid && !_nav_test_failed;
+
+	if (!context.isArmed()) {
+		if (pre_flt_fail_innov_heading || pre_flt_fail_innov_vel_horiz) {
+			xy_valid = false;
+		}
+
+		if (pre_flt_fail_innov_vel_horiz) {
+			v_xy_valid = false;
+		}
+	}
+
+	failsafe_flags.global_position_valid =
+		checkPosVelValidity(now, xy_valid, gpos.eph, _param_com_pos_fs_eph.get(), gpos.timestamp,
+				    _last_gpos_fail_time_us, failsafe_flags.global_position_valid);
+
+	failsafe_flags.local_position_valid =
+		checkPosVelValidity(now, xy_valid, lpos.eph, _param_com_pos_fs_eph.get(), lpos.timestamp,
+				    _last_lpos_fail_time_us, failsafe_flags.local_position_valid);
+
+	failsafe_flags.local_position_valid_relaxed =
+		checkPosVelValidity(now, xy_valid, lpos.eph, lpos_eph_threshold_relaxed, lpos.timestamp,
+				    _last_lpos_relaxed_fail_time_us, failsafe_flags.local_position_valid);
+
+	failsafe_flags.local_velocity_valid =
+		checkPosVelValidity(now, v_xy_valid, lpos.evh, _param_com_vel_fs_evh.get(), lpos.timestamp,
+				    _last_lvel_fail_time_us, failsafe_flags.local_velocity_valid);
+
+
+	// altitude
+	failsafe_flags.local_altitude_valid = lpos.z_valid
+					      && (now - lpos.timestamp < (_param_com_pos_fs_delay.get() * 1_s));
+
+
+	// attitude
+	vehicle_attitude_s attitude;
+
+	if (_vehicle_attitude_sub.copy(&attitude)) {
+		const matrix::Quatf q{attitude.q};
+		const float eps = 1e-5f;
+		const bool no_element_larger_than_one = (fabsf(q(0)) <= 1.f + eps)
+							&& (fabsf(q(1)) <= 1.f + eps)
+							&& (fabsf(q(2)) <= 1.f + eps)
+							&& (fabsf(q(3)) <= 1.f + eps);
+		const bool norm_in_tolerance = fabsf(1.f - q.norm()) <= eps;
+
+		failsafe_flags.attitude_valid = now - attitude.timestamp < 1_s && norm_in_tolerance && no_element_larger_than_one;
+
+	} else {
+		failsafe_flags.attitude_valid = false;
+	}
+
+	// angular velocity
+	vehicle_angular_velocity_s angular_velocity{};
+	_vehicle_angular_velocity_sub.copy(&angular_velocity);
+	const bool condition_angular_velocity_time_valid = angular_velocity.timestamp != 0
+			&& now - angular_velocity.timestamp < 1_s;
+	const bool condition_angular_velocity_finite = PX4_ISFINITE(angular_velocity.xyz[0])
+			&& PX4_ISFINITE(angular_velocity.xyz[1]) && PX4_ISFINITE(angular_velocity.xyz[2]);
+	const bool angular_velocity_valid = condition_angular_velocity_time_valid
+					    && condition_angular_velocity_finite;
+
+	if (failsafe_flags.angular_velocity_valid && !angular_velocity_valid) {
+		const char err_str[] {"angular velocity no longer valid"};
+
+		if (!condition_angular_velocity_time_valid) {
+			PX4_ERR("%s (timeout)", err_str);
+
+		} else if (!condition_angular_velocity_finite) {
+			PX4_ERR("%s (non-finite values)", err_str);
+		}
+	}
+
+	failsafe_flags.angular_velocity_valid = angular_velocity_valid;
+
+
+	// gps
+	if (vehicle_gps_position.timestamp != 0) {
+		bool time = now - vehicle_gps_position.timestamp < 1_s;
+
+		bool fix = vehicle_gps_position.fix_type >= 2;
+		bool eph = vehicle_gps_position.eph < _param_com_pos_fs_eph.get();
+		bool epv = vehicle_gps_position.epv < _param_com_pos_fs_epv.get();
+		bool evh = vehicle_gps_position.s_variance_m_s < _param_com_vel_fs_evh.get();
+		bool no_jamming = (vehicle_gps_position.jamming_state != sensor_gps_s::JAMMING_STATE_CRITICAL);
+
+		_vehicle_gps_position_valid.set_state_and_update(time && fix && eph && epv && evh && no_jamming, now);
+		failsafe_flags.gps_position_valid = _vehicle_gps_position_valid.get_state();
+
+	} else {
+		failsafe_flags.gps_position_valid = false;
+	}
+}
+
+bool EstimatorChecks::checkPosVelValidity(const hrt_abstime &now, const bool data_valid, const float data_accuracy,
+		const float required_accuracy,
+		const hrt_abstime &data_timestamp_us, hrt_abstime &last_fail_time_us,
+		const bool was_valid) const
+{
+	bool valid = was_valid;
+	const bool data_stale = (now - data_timestamp_us > _param_com_pos_fs_delay.get() * 1_s)
+				|| (data_timestamp_us == 0);
+	const float req_accuracy = (was_valid ? required_accuracy * 2.5f : required_accuracy);
+	const bool level_check_pass = data_valid && !data_stale && (data_accuracy < req_accuracy);
+
+	// Check accuracy with hysteresis in both test level and time
+	if (level_check_pass) {
+		if (!was_valid) {
+			// check if probation period has elapsed
+			if (now - last_fail_time_us > 1_s) {
+				valid = true;
+			}
+		}
+
+	} else {
+		// level check failed
+		if (was_valid) {
+			// FAILURE! no longer valid
+			valid = false;
+		}
+
+		last_fail_time_us = now;
+	}
+
+	return valid;
+}
+

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -39,13 +39,21 @@
 #include <uORB/topics/estimator_selector_status.h>
 #include <uORB/topics/estimator_sensor_bias.h>
 #include <uORB/topics/estimator_status.h>
-#include <uORB/topics/estimator_sensor_bias.h>
+#include <uORB/topics/estimator_status_flags.h>
+#include <uORB/topics/vehicle_angular_velocity.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/sensor_gps.h>
 
+#include <lib/hysteresis/hysteresis.h>
+
+using namespace time_literals;
 
 class EstimatorChecks : public HealthAndArmingCheckBase
 {
 public:
-	EstimatorChecks() = default;
+	EstimatorChecks();
 	~EstimatorChecks() = default;
 
 	void checkAndReport(const Context &context, Report &reporter) override;
@@ -54,13 +62,49 @@ private:
 	void checkEstimatorStatus(const Context &context, Report &reporter, const estimator_status_s &estimator_status,
 				  NavModes required_groups);
 	void checkSensorBias(const Context &context, Report &reporter, NavModes required_groups);
+	void checkEstimatorStatusFlags(const Context &context, Report &reporter, const estimator_status_s &estimator_status,
+				       const vehicle_local_position_s &lpos);
+
+	void checkGps(const Context &context, Report &reporter, const sensor_gps_s &vehicle_gps_position) const;
+	void gpsNoLongerValid(const Context &context, Report &reporter) const;
+	void setModeRequirementFlags(const Context &context, bool pre_flt_fail_innov_heading, bool pre_flt_fail_innov_vel_horiz,
+				     const vehicle_local_position_s &lpos, const sensor_gps_s &vehicle_gps_position,
+				     vehicle_status_flags_s &failsafe_flags);
+
+	bool checkPosVelValidity(const hrt_abstime &now, const bool data_valid, const float data_accuracy,
+				 const float required_accuracy,
+				 const hrt_abstime &data_timestamp_us, hrt_abstime &last_fail_time_us,
+				 const bool was_valid) const;
+
 
 	uORB::Subscription _estimator_selector_status_sub{ORB_ID(estimator_selector_status)};
 	uORB::Subscription _estimator_status_sub{ORB_ID(estimator_status)};
+	uORB::Subscription _estimator_status_flags_sub{ORB_ID(estimator_status_flags)};
 	uORB::Subscription _estimator_sensor_bias_sub{ORB_ID(estimator_sensor_bias)};
 
+	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+	uORB::Subscription _vehicle_angular_velocity_sub{ORB_ID(vehicle_angular_velocity)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
+
+	hrt_abstime	_last_gpos_fail_time_us{0};	///< Last time that the global position validity recovery check failed (usec)
+	hrt_abstime	_last_lpos_fail_time_us{0};	///< Last time that the local position validity recovery check failed (usec)
+	hrt_abstime	_last_lpos_relaxed_fail_time_us{0};	///< Last time that the relaxed local position validity recovery check failed (usec)
+	hrt_abstime	_last_lvel_fail_time_us{0};	///< Last time that the local velocity validity recovery check failed (usec)
+
+	// variables used to check for navigation failure after takeoff
+	hrt_abstime	_time_last_innov_pass{0};	///< last time velocity and position innovations passed
+	hrt_abstime	_time_last_innov_fail{0};	///< last time velocity and position innovations failed
+	bool		_nav_test_passed{false};	///< true if the post takeoff navigation test has passed
+	bool		_nav_test_failed{false};	///< true if the post takeoff navigation test has failed
+
+	static constexpr hrt_abstime GPS_VALID_TIME{3_s};
+	systemlib::Hysteresis _vehicle_gps_position_valid{false};
+
+	bool _position_reliant_on_optical_flow{false};
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::SYS_MC_EST_GROUP>) _param_sys_mc_est_group,
 					(ParamInt<px4::params::SENS_IMU_MODE>) _param_sens_imu_mode,
 					(ParamInt<px4::params::COM_ARM_MAG_STR>) _param_com_arm_mag_str,
 					(ParamFloat<px4::params::COM_ARM_EKF_HGT>) _param_com_arm_ekf_hgt,
@@ -68,6 +112,10 @@ private:
 					(ParamFloat<px4::params::COM_ARM_EKF_POS>) _param_com_arm_ekf_pos,
 					(ParamFloat<px4::params::COM_ARM_EKF_YAW>) _param_com_arm_ekf_yaw,
 					(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_com_arm_wo_gps,
-					(ParamBool<px4::params::SYS_HAS_GPS>) _param_sys_has_gps
+					(ParamBool<px4::params::SYS_HAS_GPS>) _param_sys_has_gps,
+					(ParamFloat<px4::params::COM_POS_FS_EPH>) _param_com_pos_fs_eph,
+					(ParamFloat<px4::params::COM_POS_FS_EPV>) _param_com_pos_fs_epv,
+					(ParamFloat<px4::params::COM_VEL_FS_EVH>) _param_com_vel_fs_evh,
+					(ParamInt<px4::params::COM_POS_FS_DELAY>) _param_com_pos_fs_delay
 				       )
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
@@ -64,13 +64,24 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_attitude);
 	}
 
+	NavModes local_position_modes = NavModes::None;
+
 	if (!reporter.failsafeFlags().local_position_valid && reporter.failsafeFlags().mode_req_local_position != 0) {
+		local_position_modes = (NavModes)reporter.failsafeFlags().mode_req_local_position;
+	}
+
+	if (!reporter.failsafeFlags().local_position_valid_relaxed
+	    && reporter.failsafeFlags().mode_req_local_position_relaxed != 0) {
+		local_position_modes = local_position_modes | (NavModes)reporter.failsafeFlags().mode_req_local_position_relaxed;
+	}
+
+	if (local_position_modes != NavModes::None) {
 		/* EVENT
 		 */
-		reporter.armingCheckFailure((NavModes)reporter.failsafeFlags().mode_req_local_position, health_component_t::system,
+		reporter.armingCheckFailure(local_position_modes, health_component_t::system,
 					    events::ID("check_modes_local_pos"),
 					    events::Log::Error, "No valid local position estimate");
-		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_local_position);
+		reporter.clearCanRunBits(local_position_modes);
 	}
 
 	if (!reporter.failsafeFlags().global_position_valid && reporter.failsafeFlags().mode_req_global_position != 0) {

--- a/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/systemCheck.cpp
@@ -161,39 +161,6 @@ void SystemChecks::checkAndReport(const Context &context, Report &reporter)
 		}
 	}
 
-	// ESC checks
-	if (_param_com_arm_chk_escs.get() && reporter.failsafeFlags().escs_error) {
-		/* EVENT
-		 * @description
-		 * <profile name="dev">
-		 * This check can be configured via <param>COM_ARM_CHK_ESCS</param> parameter.
-		 * </profile>
-		 */
-		reporter.healthFailure(NavModes::All, health_component_t::motors_escs, events::ID("check_system_escs_offline"),
-				       events::Log::Error, "One or more ESCs are offline");
-
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: One or more ESCs are offline");
-		}
-	}
-
-	if (_param_com_arm_chk_escs.get() && reporter.failsafeFlags().escs_failure) {
-		/* EVENT
-		 * @description
-		 * <profile name="dev">
-		 * This check can be configured via <param>COM_ARM_CHK_ESCS</param> parameter.
-		 * </profile>
-		 */
-		reporter.healthFailure(NavModes::All, health_component_t::motors_escs, events::ID("check_system_escs_failure"),
-				       events::Log::Error, "One or more ESCs have a failure");
-
-		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: One or more ESCs have a failure");
-		}
-	}
-
-	reporter.setIsPresent(health_component_t::motors_escs); // TODO: based on telemetry
-
 	// VTOL in transition
 	if (context.status().is_vtol && !context.isArmed()) {
 		if (context.status().in_transition_mode) {

--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -1,0 +1,341 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+#include "HomePosition.hpp"
+
+#include <lib/geo/geo.h>
+#include "commander_helper.h"
+
+HomePosition::HomePosition(const vehicle_status_flags_s &vehicle_status_flags)
+	: _vehicle_status_flags(vehicle_status_flags)
+{
+}
+
+bool HomePosition::hasMovedFromCurrentHomeLocation()
+{
+	float home_dist_xy = -1.f;
+	float home_dist_z = -1.f;
+	float eph = 0.f;
+	float epv = 0.f;
+
+	if (_home_position_pub.get().valid_lpos && _local_position_sub.get().xy_valid && _local_position_sub.get().z_valid) {
+		mavlink_wpm_distance_to_point_local(_home_position_pub.get().x, _home_position_pub.get().y, _home_position_pub.get().z,
+						    _local_position_sub.get().x, _local_position_sub.get().y, _local_position_sub.get().z,
+						    &home_dist_xy, &home_dist_z);
+
+		eph = _local_position_sub.get().eph;
+		epv = _local_position_sub.get().epv;
+
+	} else if (_home_position_pub.get().valid_hpos && _home_position_pub.get().valid_alt) {
+		if (_valid) {
+			const vehicle_global_position_s &gpos = _global_position_sub.get();
+
+			get_distance_to_point_global_wgs84(_home_position_pub.get().lat, _home_position_pub.get().lon,
+							   _home_position_pub.get().alt,
+							   gpos.lat, gpos.lon, gpos.alt,
+							   &home_dist_xy, &home_dist_z);
+
+			eph = gpos.eph;
+			epv = gpos.epv;
+
+		} else if (_vehicle_status_flags.gps_position_valid) {
+			sensor_gps_s gps;
+			_vehicle_gps_position_sub.copy(&gps);
+			const double lat = static_cast<double>(gps.lat) * 1e-7;
+			const double lon = static_cast<double>(gps.lon) * 1e-7;
+			const float alt = static_cast<float>(gps.alt) * 1e-3f;
+
+			get_distance_to_point_global_wgs84(_home_position_pub.get().lat, _home_position_pub.get().lon,
+							   _home_position_pub.get().alt,
+							   lat, lon, alt,
+							   &home_dist_xy, &home_dist_z);
+
+			eph = gps.eph;
+			epv = gps.epv;
+		}
+	}
+
+	return (home_dist_xy > eph * 2.f) || (home_dist_z > epv * 2.f);
+}
+
+bool HomePosition::setHomePosition(bool force)
+{
+	if (_home_position_pub.get().manual_home && !force) {
+		return false;
+	}
+
+	bool updated = false;
+	home_position_s home{};
+
+	if (_vehicle_status_flags.local_position_valid) {
+		// Set home position in local coordinates
+		const vehicle_local_position_s &lpos = _local_position_sub.get();
+		_heading_reset_counter = lpos.heading_reset_counter; // TODO: should not be here
+
+		fillLocalHomePos(home, lpos);
+		updated = true;
+	}
+
+	if (_vehicle_status_flags.global_position_valid) {
+		// Set home using the global position estimate (fused INS/GNSS)
+		const vehicle_global_position_s &gpos = _global_position_sub.get();
+		fillGlobalHomePos(home, gpos);
+		setHomePosValid();
+		updated = true;
+
+	} else if (_vehicle_status_flags.gps_position_valid) {
+		// Set home using GNSS position
+		sensor_gps_s gps_pos;
+		_vehicle_gps_position_sub.copy(&gps_pos);
+		const double lat = static_cast<double>(gps_pos.lat) * 1e-7;
+		const double lon = static_cast<double>(gps_pos.lon) * 1e-7;
+		const float alt = static_cast<float>(gps_pos.alt) * 1e-3f;
+		fillGlobalHomePos(home, lat, lon, alt);
+		setHomePosValid();
+		updated = true;
+
+	} else if (_local_position_sub.get().z_global) {
+		// handle special case where we are setting only altitude using local position reference
+		// This might be overwritten by altitude from global or GNSS altitude
+		home.alt = _local_position_sub.get().ref_alt;
+		home.valid_alt = true;
+
+		updated = true;
+	}
+
+	if (updated) {
+		home.timestamp = hrt_absolute_time();
+		home.manual_home = false;
+		updated = _home_position_pub.update(home);
+	}
+
+	return updated;
+}
+
+void HomePosition::fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos)
+{
+	fillLocalHomePos(home, lpos.x, lpos.y, lpos.z, lpos.heading);
+}
+
+void HomePosition::fillLocalHomePos(home_position_s &home, float x, float y, float z, float heading)
+{
+	home.x = x;
+	home.y = y;
+	home.z = z;
+	home.valid_lpos = true;
+
+	home.yaw = heading;
+}
+
+void HomePosition::fillGlobalHomePos(home_position_s &home, const vehicle_global_position_s &gpos)
+{
+	fillGlobalHomePos(home, gpos.lat, gpos.lon, gpos.alt);
+}
+
+void HomePosition::fillGlobalHomePos(home_position_s &home, double lat, double lon, float alt)
+{
+	home.lat = lat;
+	home.lon = lon;
+	home.valid_hpos = true;
+	home.alt = alt;
+	home.valid_alt = true;
+}
+
+void HomePosition::setInAirHomePosition()
+{
+	auto &home = _home_position_pub.get();
+
+	if (home.manual_home || (home.valid_lpos && home.valid_hpos && home.valid_alt)) {
+		return;
+	}
+
+	const bool global_home_valid = home.valid_hpos && home.valid_alt;
+	const bool local_home_valid = home.valid_lpos;
+
+	if (local_home_valid && !global_home_valid) {
+		if (_vehicle_status_flags.local_position_valid && _vehicle_status_flags.global_position_valid) {
+			// Back-compute lon, lat and alt of home position given the local home position
+			// and current positions in local and global (GNSS fused) frames
+			const vehicle_local_position_s &lpos = _local_position_sub.get();
+			const vehicle_global_position_s &gpos = _global_position_sub.get();
+
+			MapProjection ref_pos{gpos.lat, gpos.lon};
+
+			double home_lat;
+			double home_lon;
+			ref_pos.reproject(home.x - lpos.x, home.y - lpos.y, home_lat, home_lon);
+
+			const float home_alt = gpos.alt + home.z;
+			fillGlobalHomePos(home, home_lat, home_lon, home_alt);
+
+			setHomePosValid();
+			home.timestamp = hrt_absolute_time();
+			_home_position_pub.update();
+
+		} else if (_vehicle_status_flags.local_position_valid && _vehicle_status_flags.gps_position_valid) {
+			// Back-compute lon, lat and alt of home position given the local home position
+			// and current positions in local and global (GNSS raw) frames
+			const vehicle_local_position_s &lpos = _local_position_sub.get();
+			sensor_gps_s gps;
+			_vehicle_gps_position_sub.copy(&gps);
+
+			const double lat = static_cast<double>(gps.lat) * 1e-7;
+			const double lon = static_cast<double>(gps.lon) * 1e-7;
+			const float alt = static_cast<float>(gps.alt) * 1e-3f;
+
+			MapProjection ref_pos{lat, lon};
+
+			double home_lat;
+			double home_lon;
+			ref_pos.reproject(home.x - lpos.x, home.y - lpos.y, home_lat, home_lon);
+
+			const float home_alt = alt + home.z;
+			fillGlobalHomePos(home, home_lat, home_lon, home_alt);
+
+			setHomePosValid();
+			home.timestamp = hrt_absolute_time();
+			_home_position_pub.update();
+		}
+
+	} else if (!local_home_valid && global_home_valid) {
+		const vehicle_local_position_s &lpos = _local_position_sub.get();
+
+		if (_vehicle_status_flags.local_position_valid && lpos.xy_global && lpos.z_global) {
+			// Back-compute x, y and z of home position given the global home position
+			// and the global reference of the local frame
+			MapProjection ref_pos{lpos.ref_lat, lpos.ref_lon};
+
+			float home_x;
+			float home_y;
+			ref_pos.project(home.lat, home.lon, home_x, home_y);
+
+			const float home_z = -(home.alt - lpos.ref_alt);
+			fillLocalHomePos(home, home_x, home_y, home_z, NAN);
+
+			home.timestamp = hrt_absolute_time();
+			_home_position_pub.update();
+		}
+
+	} else if (!local_home_valid && !global_home_valid) {
+		// Home position is not known in any frame, set home at current position
+		setHomePosition();
+
+	} else {
+		// nothing to do
+	}
+}
+
+bool HomePosition::setManually(double lat, double lon, float alt, float yaw)
+{
+	const auto &vehicle_local_position = _local_position_sub.get();
+
+	if (!vehicle_local_position.xy_global || !vehicle_local_position.z_global) {
+		return false;
+	}
+
+	auto &home = _home_position_pub.get();
+	home.manual_home = true;
+
+	home.lat = lat;
+	home.lon = lon;
+	home.valid_hpos = true;
+	home.alt = alt;
+	home.valid_alt = true;
+
+	// update local projection reference including altitude
+	MapProjection ref_pos{vehicle_local_position.ref_lat, vehicle_local_position.ref_lon};
+	ref_pos.project(lat, lon, home.x, home.y);
+	home.z = -(alt - vehicle_local_position.ref_alt);
+	home.valid_lpos = vehicle_local_position.xy_valid && vehicle_local_position.z_valid;
+
+	home.yaw = yaw;
+
+	home.timestamp = hrt_absolute_time();
+	_home_position_pub.update();
+	setHomePosValid();
+	return true;
+}
+
+
+void HomePosition::setHomePosValid()
+{
+	// play tune first time we initialize HOME
+	if (!_valid) {
+		tune_home_set(true);
+	}
+
+	// mark home position as set
+	_valid = true;
+}
+
+void HomePosition::updateHomePositionYaw(float yaw)
+{
+	home_position_s home = _home_position_pub.get();
+
+	home.yaw = yaw;
+	home.timestamp = hrt_absolute_time();
+
+	_home_position_pub.update(home);
+}
+
+void HomePosition::update(bool set_automatically, bool check_if_changed)
+{
+	_local_position_sub.update();
+	_global_position_sub.update();
+
+	const vehicle_local_position_s &lpos = _local_position_sub.get();
+	const auto &home = _home_position_pub.get();
+
+	if (lpos.heading_reset_counter != _heading_reset_counter) {
+		if (_valid && set_automatically) {
+			updateHomePositionYaw(home.yaw + lpos.delta_heading);
+		}
+
+		_heading_reset_counter = lpos.heading_reset_counter;
+	}
+
+	if (check_if_changed && set_automatically) {
+		const bool can_set_home_lpos_first_time = !home.valid_lpos && _vehicle_status_flags.local_position_valid;
+		const bool can_set_home_gpos_first_time = ((!home.valid_hpos || !home.valid_alt)
+				&& (_vehicle_status_flags.global_position_valid || _vehicle_status_flags.gps_position_valid));
+		const bool can_set_home_alt_first_time = (!home.valid_alt && lpos.z_global);
+
+		if (can_set_home_lpos_first_time
+		    || can_set_home_gpos_first_time
+		    || can_set_home_alt_first_time
+		    || hasMovedFromCurrentHomeLocation()) {
+			setHomePosition();
+		}
+	}
+}

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -1,0 +1,78 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/home_position.h>
+#include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_status_flags.h>
+
+class HomePosition
+{
+public:
+	HomePosition(const vehicle_status_flags_s &vehicle_status_flags);
+	~HomePosition() = default;
+
+	bool setHomePosition(bool force = false);
+	void setInAirHomePosition();
+	bool setManually(double lat, double lon, float alt, float yaw);
+
+	void update(bool set_automatically, bool check_if_changed);
+
+	bool valid() const { return _valid; }
+
+private:
+	bool hasMovedFromCurrentHomeLocation();
+	void setHomePosValid();
+	void updateHomePositionYaw(float yaw);
+
+	static void fillLocalHomePos(home_position_s &home, const vehicle_local_position_s &lpos);
+	static void fillLocalHomePos(home_position_s &home, float x, float y, float z, float heading);
+	static void fillGlobalHomePos(home_position_s &home, const vehicle_global_position_s &gpos);
+	static void fillGlobalHomePos(home_position_s &home, double lat, double lon, float alt);
+
+	uORB::Subscription					_vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
+
+	uORB::SubscriptionData<vehicle_global_position_s>	_global_position_sub{ORB_ID(vehicle_global_position)};
+	uORB::SubscriptionData<vehicle_local_position_s>	_local_position_sub{ORB_ID(vehicle_local_position)};
+
+	uORB::PublicationData<home_position_s>			_home_position_pub{ORB_ID(home_position)};
+
+	uint8_t							_heading_reset_counter{0};
+	bool							_valid{false};
+	const vehicle_status_flags_s				&_vehicle_status_flags;
+};

--- a/src/modules/commander/ModeUtil/CMakeLists.txt
+++ b/src/modules/commander/ModeUtil/CMakeLists.txt
@@ -32,5 +32,6 @@
 ############################################################################
 
 px4_add_library(mode_util
+	control_mode.cpp
 	mode_requirements.cpp
 )

--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -1,0 +1,178 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "control_mode.hpp"
+#include <uORB/topics/vehicle_status.h>
+
+namespace mode_util
+{
+
+static bool stabilization_required(uint8_t vehicle_type)
+{
+	return vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+}
+
+void getVehicleControlMode(bool armed, uint8_t nav_state, uint8_t vehicle_type,
+			   const offboard_control_mode_s &offboard_control_mode,
+			   vehicle_control_mode_s &vehicle_control_mode)
+{
+	vehicle_control_mode.flag_armed = armed;
+
+	switch (nav_state) {
+	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
+		vehicle_control_mode.flag_control_manual_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = stabilization_required(vehicle_type);
+		vehicle_control_mode.flag_control_attitude_enabled = stabilization_required(vehicle_type);
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_STAB:
+		vehicle_control_mode.flag_control_manual_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
+		vehicle_control_mode.flag_control_manual_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_POSCTL:
+		vehicle_control_mode.flag_control_manual_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_position_enabled = true;
+		vehicle_control_mode.flag_control_velocity_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
+		vehicle_control_mode.flag_control_auto_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_position_enabled = true;
+		vehicle_control_mode.flag_control_velocity_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_ACRO:
+		vehicle_control_mode.flag_control_manual_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_DESCEND:
+		vehicle_control_mode.flag_control_auto_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
+		/* disable all controllers on termination */
+		vehicle_control_mode.flag_control_termination_enabled = true;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
+		vehicle_control_mode.flag_control_offboard_enabled = true;
+
+		if (offboard_control_mode.position) {
+			vehicle_control_mode.flag_control_position_enabled = true;
+			vehicle_control_mode.flag_control_velocity_enabled = true;
+			vehicle_control_mode.flag_control_altitude_enabled = true;
+			vehicle_control_mode.flag_control_climb_rate_enabled = true;
+			vehicle_control_mode.flag_control_acceleration_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_attitude_enabled = true;
+
+		} else if (offboard_control_mode.velocity) {
+			vehicle_control_mode.flag_control_velocity_enabled = true;
+			vehicle_control_mode.flag_control_altitude_enabled = true;
+			vehicle_control_mode.flag_control_climb_rate_enabled = true;
+			vehicle_control_mode.flag_control_acceleration_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_attitude_enabled = true;
+
+		} else if (offboard_control_mode.acceleration) {
+			vehicle_control_mode.flag_control_acceleration_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_attitude_enabled = true;
+
+		} else if (offboard_control_mode.attitude) {
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_attitude_enabled = true;
+
+		} else if (offboard_control_mode.body_rate) {
+			vehicle_control_mode.flag_control_rates_enabled = true;
+		}
+
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
+
+	// Follow Target supports RC adjustment, so disable auto control mode to disable
+	// the Flight Task from exiting itself when RC stick movement is detected.
+	case vehicle_status_s::NAVIGATION_STATE_ORBIT:
+		vehicle_control_mode.flag_control_manual_enabled = false;
+		vehicle_control_mode.flag_control_auto_enabled = false;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_position_enabled = true;
+		vehicle_control_mode.flag_control_velocity_enabled = true;
+		break;
+
+	default:
+		break;
+	}
+
+	vehicle_control_mode.flag_multicopter_position_control_enabled =
+		(vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
+		&& (vehicle_control_mode.flag_control_altitude_enabled
+		    || vehicle_control_mode.flag_control_climb_rate_enabled
+		    || vehicle_control_mode.flag_control_position_enabled
+		    || vehicle_control_mode.flag_control_velocity_enabled
+		    || vehicle_control_mode.flag_control_acceleration_enabled);
+}
+
+} // namespace mode_util

--- a/src/modules/commander/ModeUtil/control_mode.hpp
+++ b/src/modules/commander/ModeUtil/control_mode.hpp
@@ -33,17 +33,16 @@
 
 #pragma once
 
-#include <uORB/topics/vehicle_status_flags.h>
+#include <uORB/topics/offboard_control_mode.h>
+#include <uORB/topics/vehicle_control_mode.h>
+
+#include <stdint.h>
 
 namespace mode_util
 {
 
-/**
- * Get per-mode requirements
- * @param vehicle_type one of vehicle_status_s::VEHICLE_TYPE_*
- * @param flags output flags, all mode_req_* entries are set
- */
-void getModeRequirements(uint8_t vehicle_type, vehicle_status_flags_s &flags);
-
+void getVehicleControlMode(bool armed, uint8_t nav_state, uint8_t vehicle_type,
+			   const offboard_control_mode_s &offboard_control_mode,
+			   vehicle_control_mode_s &vehicle_control_mode);
 
 } // namespace mode_util

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -34,6 +34,9 @@
 #include "mode_requirements.hpp"
 #include <uORB/topics/vehicle_status.h>
 
+namespace mode_util
+{
+
 static inline void setRequirement(uint8_t nav_state, uint32_t &mode_requirement)
 {
 	mode_requirement |= 1u << nav_state;
@@ -159,3 +162,5 @@ void getModeRequirements(uint8_t vehicle_type, vehicle_status_flags_s &flags)
 
 	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 23, "update mode requirements");
 }
+
+} // namespace mode_util

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -45,6 +45,7 @@ void getModeRequirements(uint8_t vehicle_type, vehicle_status_flags_s &flags)
 	flags.mode_req_angular_velocity = 0;
 	flags.mode_req_attitude = 0;
 	flags.mode_req_local_position = 0;
+	flags.mode_req_local_position_relaxed = 0;
 	flags.mode_req_global_position = 0;
 	flags.mode_req_local_alt = 0;
 	flags.mode_req_mission = 0;
@@ -63,7 +64,7 @@ void getModeRequirements(uint8_t vehicle_type, vehicle_status_flags_s &flags)
 	// NAVIGATION_STATE_POSCTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_local_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_local_position_relaxed);
 
 	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
 		setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_global_position);

--- a/src/modules/commander/Safety.hpp
+++ b/src/modules/commander/Safety.hpp
@@ -49,9 +49,9 @@ public:
 
 	bool safetyButtonHandler();
 	void activateSafety();
-	bool isButtonAvailable() { return _button_available; }
-	bool isSafetyOff() { return _safety_off; }
-	bool isSafetyDisabled() { return _safety_disabled; }
+	bool isButtonAvailable() const { return _button_available; }
+	bool isSafetyOff() const { return _safety_off; }
+	bool isSafetyDisabled() const { return _safety_disabled; }
 
 private:
 	uORB::Subscription _safety_button_sub{ORB_ID::safety_button};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -674,8 +674,12 @@ PARAM_DEFINE_INT32(COM_ARM_MIS_REQ, 0);
  *
  * This sets the flight mode that will be used if navigation accuracy is no longer adequate for position control.
  *
- * @value 0 Altitude/Manual. Assume use of remote control after fallback. Switch to Altitude mode if a height estimate is available, else switch to MANUAL.
- * @value 1 Land/Terminate. Assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
+ * If Altitude/Manual is selected: assume use of remote control after fallback. Switch to Altitude mode if a height estimate is available, else switch to MANUAL.
+ *
+ * If Land/Terminate is selected: assume no use of remote control after fallback. Switch to Land mode if a height estimate is available, else switch to TERMINATION.
+ *
+ * @value 0 Altitude/Manual
+ * @value 1 Land/Terminate
  *
  * @group Commander
  */


### PR DESCRIPTION
This moves a big chunk of code out of commander.cpp:
- battery checks
- estimator checks
- home position
- esc checks

Also brings https://github.com/mavlink/libevents/pull/3

This is in preparation for #19708