### PR TITLE
boards/px4/fmu-v5/toc: The RD certificate signature points to the wro…

### DIFF
--- a/boards/px4/fmu-v5/src/toc.c
+++ b/boards/px4/fmu-v5/src/toc.c
@@ -60,7 +60,7 @@ extern const int *_boot_signature;
 /* RD certificate signature follows the certificate */
 
 #define RDCTSIG_ADDR RDCT_END
-#define RDCTSIG_END ((const void *)((const uint8_t*)RDCT_ADDR+SIGNATURE_SIZE))
+#define RDCTSIG_END ((const void *)((const uint8_t*)RDCTSIG_ADDR+SIGNATURE_SIZE))
 
 /* The table of contents */
 


### PR DESCRIPTION
…ng place

The signature end address is incorrect

## Describe problem solved by this pull request
The RD certificate signature end address points to the wrong place,this fixes it
