### PR TITLE
Increase icm20948 I2C passthrough speed to 400KHz

### DIFF
--- a/src/drivers/imu/invensense/icm20948/InvenSense_ICM20948_registers.hpp
+++ b/src/drivers/imu/invensense/icm20948/InvenSense_ICM20948_registers.hpp
@@ -55,7 +55,7 @@ static constexpr uint8_t Bit5 = (1 << 5);
 static constexpr uint8_t Bit6 = (1 << 6);
 static constexpr uint8_t Bit7 = (1 << 7);
 
-static constexpr uint32_t I2C_SPEED = 100 * 1000; // 100 kHz I2C serial interface
+static constexpr uint32_t I2C_SPEED = 400 * 1000; // 400 kHz I2C serial interface
 static constexpr uint8_t I2C_ADDRESS_DEFAULT = 0x69; // 0b1101001
 
 static constexpr uint32_t SPI_SPEED = 7 * 1000 * 1000; // 7 MHz SPI


### PR DESCRIPTION
On the Cube Orange, I have been seeing the icm20948 internal mag randomly stop outputting data. The only differences I can spot from 1.11 to 1.13 is switching to the new I2CSPI driver, or the reduction in the I2C bus speed from 400KHz to 100KHz.

Over 50+ units, it occurs randomly on about 5% of the Cube Oranges. 

https://github.com/PX4/PX4-Autopilot/commit/ab0e3b6001a04481280770f3db24b41675f52b60