### PR TITLE
platforms/posix: cleanup obsolete MacOS legacy

### DIFF
--- a/platforms/common/include/px4_platform_common/time.h
+++ b/platforms/common/include/px4_platform_common/time.h
@@ -5,10 +5,6 @@
 #include <time.h>
 #include <pthread.h>
 
-#if defined(__PX4_APPLE_LEGACY)
-#define clockid_t int
-#endif
-
 #if defined(__PX4_POSIX) || defined(__PX4_QURT)
 __BEGIN_DECLS
 __EXPORT int px4_clock_gettime(clockid_t clk_id, struct timespec *tp);

--- a/platforms/posix/cmake/px4_impl_os.cmake
+++ b/platforms/posix/cmake/px4_impl_os.cmake
@@ -225,21 +225,6 @@ function(px4_os_add_flags)
 		if(UNIX AND APPLE)
 			add_definitions(-D__PX4_DARWIN)
 
-			if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0)
-				message(FATAL_ERROR "PX4 Firmware requires XCode 8 or newer on Mac OS. Version installed on this system: ${CMAKE_CXX_COMPILER_VERSION}")
-			endif()
-
-			execute_process(COMMAND uname -v OUTPUT_VARIABLE DARWIN_VERSION)
-			string(REGEX MATCH "[0-9]+" DARWIN_VERSION ${DARWIN_VERSION})
-			# message(STATUS "PX4 Darwin Version: ${DARWIN_VERSION}")
-			if (DARWIN_VERSION LESS 16)
-				add_definitions(
-					-DCLOCK_MONOTONIC=1
-					-DCLOCK_REALTIME=0
-					-D__PX4_APPLE_LEGACY
-					)
-			endif()
-
 		elseif(CYGWIN)
 			add_definitions(
 				-D__PX4_CYGWIN


### PR DESCRIPTION
I believe since Sierra CLOCK_MONOTONIC has been available, but I'll verify.