### PR TITLE
Update fmu-v6c rc.board_sensors

### DIFF
--- a/boards/px4/fmu-v6c/init/rc.board_sensors
+++ b/boards/px4/fmu-v6c/init/rc.board_sensors
@@ -11,11 +11,11 @@ bmi055 -G -R 4 -s start
 # Internal SPI bus ICM42688p
 icm42688p -R 6 -s start
 
-# Internal barometer on I2C4
-ms5611 -I -b 4 -a 0x77 start
+# Internal barometer on External I2C4 Bus
+ms5611 -X -b 4 -a 0x77 start
 
 # Internal compass on IMU I2C4
-ist8310 -I -b 4 -a 0xc  start
+ist8310 -X -b 4 -a 0xc  start
 
 # External compass on GPS/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
 ist8310 -X -b 1 -R 10 start

--- a/boards/px4/fmu-v6c/init/rc.board_sensors
+++ b/boards/px4/fmu-v6c/init/rc.board_sensors
@@ -14,7 +14,7 @@ icm42688p -R 6 -s start
 # Internal barometer on External I2C4 Bus
 ms5611 -X -b 4 -a 0x77 start
 
-# Internal compass on IMU I2C4
+# Internal compass on External I2C4 Bus
 ist8310 -X -b 4 -a 0xc  start
 
 # External compass on GPS/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)


### PR DESCRIPTION
Change so it will start MS5611 &  IST8310 properly.
fmuv6c I2C4 was changed to external here https://github.com/PX4/PX4-Autopilot/pull/19949
