### PR TITLE
EKF2: Improve height convergence during startup

### DIFF
--- a/src/modules/ekf2/EKF/zero_velocity_update.cpp
+++ b/src/modules/ekf2/EKF/zero_velocity_update.cpp
@@ -51,7 +51,9 @@ void Ekf::controlZeroVelocityUpdate()
 			Vector3f vel_obs{0, 0, 0};
 			Vector3f innovation = _state.vel - vel_obs;
 
-			const float obs_var = sq(0.001f);
+			// Set a low variance initially for faster accel bias learning and higher
+			// later to let the states follow the measurements
+			const float obs_var = _NED_origin_initialised ? sq(0.2f) : sq(0.001f);
 			Vector3f innov_var{
 				P(4, 4) + obs_var,
 				P(5, 5) + obs_var,

--- a/src/modules/ekf2/test/test_EKF_accelerometer.cpp
+++ b/src/modules/ekf2/test/test_EKF_accelerometer.cpp
@@ -101,7 +101,7 @@ TEST_F(EkfAccelerometerTest, biasEstimatePositive)
 
 TEST_F(EkfAccelerometerTest, biasEstimateNegative)
 {
-	const float biases[4] = {-0.14f, -0.24f, -0.31, -0.4f};
+	const float biases[4] = {-0.12f, -0.22f, -0.31, -0.4f};
 
 	for (int i = 0; i < 4; i ++) {
 		testBias(biases[i], 10, 0.03f);


### PR DESCRIPTION
## Describe problem solved by this pull request
After boot, the GPS checks are sometimes passing quite early, before the GNSS solution fully converged. The EKF needs to follow the altitude variation (re-converge), but it takes a lot of time because the "Zero Velocity Update (ZVU)" almost paralyzes the vertical velocity and position estimates.

## Describe your solution
- ~enable PDOP and EPV checks for starting GNSS fusion (GNSS height fusion is now enabled by default)~ will be in a follow-up PR
- increase the measurement noise of VZU (equivalent to a good GNSS velocity aiding) after the global position has been initialized

## Describe possible alternatives
Move the EKF global origin: the issue by doing this is that it requires more changes and is likely to create new bugs and race conditions.