### PR TITLE
Add Holybro PX4 vision v1.5 Airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name PX4 Vision Dev Kit v1
+# @name PX4 Vision Dev Kit v1.5
 #
 # @type Quadrotor x
 # @class Copter
@@ -60,6 +60,7 @@ param set-default CP_DIST 6
 param set-default MPC_ACC_DOWN_MAX 5
 param set-default MPC_ACC_HOR_MAX 10
 param set-default MPC_ACC_UP_MAX 4
+param set-default MPC_MANTHR_MIN 0
 param set-default MPC_MAN_Y_MAX 120
 param set-default MPC_TILTMAX_AIR 45
 param set-default MPC_THR_HOVER 0.3
@@ -88,11 +89,11 @@ param set-default RTL_RETURN_ALT 5
 param set-default SDLOG_PROFILE 131
 
 # Sensors Parameters
-param set-default SENS_CM8JL65_CFG 104
+param set-default SENS_CM8JL65_CFG 202
 param set-default SENS_FLOW_MAXHGT 25
 param set-default SENS_FLOW_MINHGT 0.5
 param set-default IMU_GYRO_CUTOFF 100
-param set-default SENS_EN_PMW3901 1
+param set-default SENS_TFLOW_CFG 103
 
 # Power Parameters
 param set-default BAT1_N_CELLS 4

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -57,6 +57,7 @@ px4_add_romfs_files(
 	4016_holybro_px4vision
 	4017_nxp_hovergames
 	4019_x500_v2
+	4020_holybro_px4vision_v1_5
 	4040_reaper
 	4041_beta75x
 	4050_generic_250


### PR DESCRIPTION
Add Holybro PX4 vision v1.5 Airframe so user can select it in QGC.
Holybro PX4 Vision v1.5 has some differences from the v1 would require different parameter.

![image](https://user-images.githubusercontent.com/46874772/188209995-f0ce3979-2261-4483-9430-8746af65a619.png)

[More info regarding PX4 Vision v1.5 ](https://shop.holybro.com/px4-vision-dev-kit-v15_p1342.html)