### PR TITLE
Don't declare synthetic airspeed valid if filter is not initialised

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -547,7 +547,7 @@ void AirspeedModule::update_ground_minus_wind_airspeed()
 {
 	const float wind_uncertainty = sqrtf(_wind_estimate_sideslip.variance_north + _wind_estimate_sideslip.variance_east);
 
-	if (wind_uncertainty < _param_wind_sigma_max_synth_tas.get()) {
+	if (_wind_estimator_sideslip.is_estimate_valid() && wind_uncertainty < _param_wind_sigma_max_synth_tas.get()) {
 		// calculate airspeed estimate based on groundspeed-windspeed
 		const float TAS_north = _vehicle_local_position.vx - _wind_estimate_sideslip.windspeed_north;
 		const float TAS_east = _vehicle_local_position.vy - _wind_estimate_sideslip.windspeed_east;


### PR DESCRIPTION
## Describe problem solved by this pull request
Synthetic airspeed was declared valid if filter was not initialized.

## Describe your solution
Check if filter is initialized.

## Describe possible alternatives
None

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
