### PR TITLE
fix the wrong flags expression in getopt

### DIFF
--- a/Tools/simulation/jmavsim/jmavsim_run.sh
+++ b/Tools/simulation/jmavsim/jmavsim_run.sh
@@ -12,7 +12,7 @@ baudrate=921600
 device=
 ip="127.0.0.1"
 protocol="tcp"
-while getopts ":b:d:u:p:qsr:f:i:loat" opt; do
+while getopts "b:d:ui:p:qsr:loat" opt; do
 	case $opt in
 		b)
 			baudrate=$OPTARG


### PR DESCRIPTION
I found that the wrong flags expressions when using getopt function.
I update the expression,  
```
":b:d:u:p:qsr:f:i:loat" => "b:d:ui:p:qsr:loat" 
```

