### PR TITLE
PX4 State-Estimation Bridge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "mavlink/include/mavlink/v2.0"]
 	path = mavlink/include/mavlink/v2.0
-	url = https://github.com/mavlink/c_library_v2.git
-	branch = master
+	url = https://github.com/aau-cns/mavlink_c_library_v2.git
+	branch = ext_state_est
 [submodule "src/drivers/uavcan/libuavcan"]
 	path = src/drivers/uavcan/libuavcan
 	url = https://github.com/PX4/uavcan.git

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -78,7 +78,9 @@ fi
 
 
 # Use environment variable PX4_ESTIMATOR to choose estimator.
-if [ "$PX4_ESTIMATOR" = "q" ]; then
+if [ "$PX4_ESTIMATOR" = "ext" ]; then
+	param set SYS_MC_EST_GROUP 4
+elif [ "$PX4_ESTIMATOR" = "q" ]; then
 	param set SYS_MC_EST_GROUP 3
 elif [ "$PX4_ESTIMATOR" = "ekf2" ]; then
 	param set SYS_MC_EST_GROUP 2

--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -9,38 +9,44 @@
 #                       Begin Estimator Group Selection                       #
 ###############################################################################
 
-#
-# LPE
-#
-if param compare SYS_MC_EST_GROUP 1
+if param compare SYS_MC_EST_GROUP 4
 then
-	#
-	# Try to start LPE. If it fails, start EKF2 as a default.
-	# Unfortunately we do not build it on px4_fmu-v2 due to a limited flash.
-	#
-	if attitude_estimator_q start
-	then
-		echo "WARN [init] Estimator LPE unsupported, EKF2 recommended."
-		local_position_estimator start
-	else
-		echo "ERROR [init] Estimator LPE not available. Using EKF2"
-		param set SYS_MC_EST_GROUP 2
-		param save
-		reboot
-	fi
+	echo "WARN [init] Using external estimator"
+	ext_state_est start
 else
 	#
-	# Q estimator (attitude estimation only)
+	# LPE
 	#
-	if param compare SYS_MC_EST_GROUP 3
+	if param compare SYS_MC_EST_GROUP 1
 	then
-		attitude_estimator_q start
+		#
+		# Try to start LPE. If it fails, start EKF2 as a default.
+		# Unfortunately we do not build it on px4_fmu-v2 due to a limited flash.
+		#
+		if attitude_estimator_q start
+		then
+			echo "WARN [init] Estimator LPE unsupported, EKF2 recommended."
+			local_position_estimator start
+		else
+			echo "ERROR [init] Estimator LPE not available. Using EKF2"
+			param set SYS_MC_EST_GROUP 2
+			param save
+			reboot
+		fi
 	else
 		#
-		# EKF2
+		# Q estimator (attitude estimation only)
 		#
-		param set SYS_MC_EST_GROUP 2
-		ekf2 start
+		if param compare SYS_MC_EST_GROUP 3
+		then
+			attitude_estimator_q start
+		else
+			#
+			# EKF2
+			#
+			param set SYS_MC_EST_GROUP 2
+			ekf2 start
+		fi
 	fi
 fi
 

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+                ext_state_est
 		esc_battery
 		events
 		fw_att_control

--- a/boards/px4/fmu-v5/critmonitor.cmake
+++ b/boards/px4/fmu-v5/critmonitor.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		esc_battery
 		events
 		fw_att_control

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -51,6 +51,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_ests
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5/irqmonitor.cmake
+++ b/boards/px4/fmu-v5/irqmonitor.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -57,6 +57,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		events
 		land_detector
 		landing_target_estimator

--- a/boards/px4/fmu-v5/optimized.cmake
+++ b/boards/px4/fmu-v5/optimized.cmake
@@ -62,6 +62,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -52,6 +52,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		events
 		land_detector
 		load_mon

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est
 		#esc_battery
 		events
 		fw_att_control

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -28,6 +28,7 @@ px4_add_board(
 		commander
 		dataman
 		ekf2
+		ext_state_est		
 		events
 		fw_att_control
 		fw_pos_control_l1

--- a/launch/mavros_posix_sitl.launch
+++ b/launch/mavros_posix_sitl.launch
@@ -10,7 +10,7 @@
     <arg name="P" default="0"/>
     <arg name="Y" default="0"/>
     <!-- vehicle model and world -->
-    <arg name="est" default="ekf2"/>
+    <arg name="est" default="ext"/>
     <arg name="vehicle" default="iris"/>
     <arg name="world" default="$(find mavlink_sitl_gazebo)/worlds/empty.world"/>
     <arg name="sdf" default="$(find mavlink_sitl_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf"/>

--- a/launch/posix_sitl.launch
+++ b/launch/posix_sitl.launch
@@ -10,7 +10,7 @@
     <arg name="P" default="0"/>
     <arg name="Y" default="0"/>
     <!-- vehicle model and world -->
-    <arg name="est" default="ekf2"/>
+    <arg name="est" default="ext"/>
     <arg name="vehicle" default="iris"/>
     <arg name="world" default="$(find mavlink_sitl_gazebo)/worlds/empty.world"/>
     <arg name="sdf" default="$(find mavlink_sitl_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf"/>

--- a/launch/px4.launch
+++ b/launch/px4.launch
@@ -4,7 +4,7 @@
     <!-- Launches Only PX4 SITL. This can be used by external projects -->
 
     <!-- PX4 config arguments -->
-    <arg name="est" default="ekf2"/>
+    <arg name="est" default="ext"/>
     <arg name="vehicle" default="iris"/>
     <arg name="ID" default="0"/>
     <arg name="interactive" default="true"/>

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -35,6 +35,7 @@
 cmake_policy(SET CMP0057 NEW)
 
 set(msg_files
+	ext_core_state.msg
 	actuator_armed.msg
 	actuator_controls.msg
 	actuator_outputs.msg

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -35,6 +35,7 @@
 cmake_policy(SET CMP0057 NEW)
 
 set(msg_files
+        ext_core_state_lite.msg
 	ext_core_state.msg
 	actuator_armed.msg
 	actuator_controls.msg

--- a/msg/ext_core_state.msg
+++ b/msg/ext_core_state.msg
@@ -1,0 +1,21 @@
+# this message describes the format for an external state
+
+# state timestamp (microseconds)
+uint64 timestamp		
+
+# Position of the imu frame w.r.t. the world frame
+float64 p_wi_x			
+float64 p_wi_y			
+float64 p_wi_z			
+
+# Velocity of the imu frame w.r.t. the world frame
+float64 v_wi_x			
+float64 v_wi_y			
+float64 v_wi_z			
+
+# Orientation of the imu frame w.r.t. the world frame
+float64 q_wi_w			
+float64 q_wi_x			
+float64 q_wi_y			
+float64 q_wi_z			
+

--- a/msg/ext_core_state.msg
+++ b/msg/ext_core_state.msg
@@ -1,21 +1,23 @@
 # this message describes the format for an external state
 
 # state timestamp (microseconds)
-uint64 timestamp		
+uint64 timestamp
+uint64 timestamp_sample		
 
 # Position of the imu frame w.r.t. the world frame
-float64 p_wi_x			
-float64 p_wi_y			
-float64 p_wi_z			
+float32[3] p_wi				
 
 # Velocity of the imu frame w.r.t. the world frame
-float64 v_wi_x			
-float64 v_wi_y			
-float64 v_wi_z			
+float32[3] v_wi		
 
 # Orientation of the imu frame w.r.t. the world frame
-float64 q_wi_w			
-float64 q_wi_x			
-float64 q_wi_y			
-float64 q_wi_z			
+float32[4] q_wi		
 
+# Accelerometer bias
+float32[3] b_a	
+
+# Gyroscope bias
+float32[3] b_w	
+
+# Position orientation and velocity upper triangular covariance in Row-Major order
+float32[45] cov_urt

--- a/msg/ext_core_state_lite.msg
+++ b/msg/ext_core_state_lite.msg
@@ -1,0 +1,14 @@
+# this message describes the format for an external state lite
+
+# state timestamp (microseconds)
+uint64 timestamp
+uint64 timestamp_sample		
+
+# Position of the imu frame w.r.t. the world frame
+float32[3] p_wi				
+
+# Velocity of the imu frame w.r.t. the world frame
+float32[3] v_wi		
+
+# Orientation of the imu frame w.r.t. the world frame
+float32[4] q_wi		

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -108,11 +108,12 @@ PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);
  * @value 1 local_position_estimator, attitude_estimator_q (unsupported)
  * @value 2 ekf2 (recommended)
  * @value 3 Q attitude estimator (no position)
+ * @value 4 External state estimation
  *
  * @reboot_required true
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
+PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 4);
 
 /**
  * Parameter version

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -747,8 +747,6 @@ bool Ekf2::update_mag_decl(Param &mag_decl_param)
 
 void Ekf2::Run()
 {
-  PX4_WARN("EKF2 Run");
-
 	if (should_exit()) {
 		_sensor_combined_sub.unregisterCallback();
 
@@ -877,6 +875,7 @@ void Ekf2::Run()
 		_ekf.setIMUData(imu_sample_new);
 
 		// publish attitude immediately (uses quaternion from output predictor)
+    PX4_WARN("EKF2 Run");
 		publish_attitude(now);
 
 		// read mag data
@@ -2450,6 +2449,7 @@ int Ekf2::custom_command(int argc, char *argv[])
 
 int Ekf2::task_spawn(int argc, char *argv[])
 {
+  PX4_INFO("Task spawn");
 	bool replay_mode = false;
 
 	if (argc > 1 && !strcmp(argv[1], "-r")) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -747,6 +747,8 @@ bool Ekf2::update_mag_decl(Param &mag_decl_param)
 
 void Ekf2::Run()
 {
+  PX4_WARN("EKF2 Run");
+
 	if (should_exit()) {
 		_sensor_combined_sub.unregisterCallback();
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -875,7 +875,6 @@ void Ekf2::Run()
 		_ekf.setIMUData(imu_sample_new);
 
 		// publish attitude immediately (uses quaternion from output predictor)
-    PX4_WARN("EKF2 Run");
 		publish_attitude(now);
 
 		// read mag data

--- a/src/modules/ext_state_est/CMakeLists.txt
+++ b/src/modules/ext_state_est/CMakeLists.txt
@@ -1,0 +1,43 @@
+############################################################################
+#
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE modules__ext_state_est
+	MAIN ext_state_est
+	COMPILE_FLAGS
+	STACK_MAX 2400
+	SRCS
+		ext_state_est_main.cpp
+	DEPENDS
+
+	)

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -1,0 +1,205 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ext_state_est_main.h"
+
+#include <px4_getopt.h>
+#include <px4_log.h>
+#include <px4_posix.h>
+
+#include <uORB/Publication.hpp>
+#include <uORB/topics/external_state.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_odometry.h>
+
+int ExtStateEst::print_status() {
+  PX4_INFO("Running");
+  // TODO: print additional runtime information about the state of the module
+
+  vehicle_odometry_s odom;
+
+  uORB::Publication<vehicle_odometry_s> _vehicle_odometry_pub{
+      ORB_ID(vehicle_odometry)};
+  _vehicle_odometry_pub.publish(odom);
+  return 0;
+}
+
+int ExtStateEst::custom_command(int argc, char *argv[]) {
+  /*
+  if (!is_running()) {
+          print_usage("not running");
+          return 1;
+  }
+
+  // additional custom commands can be handled like this:
+  if (!strcmp(argv[0], "do-something")) {
+          get_instance()->do_something();
+          return 0;
+  }
+   */
+
+  return print_usage("unknown command");
+}
+
+int ExtStateEst::task_spawn(int argc, char *argv[]) {
+
+  ExtStateEst *instance = new ExtStateEst();
+
+  if (instance) {
+    _object.store(instance);
+    _task_id = task_id_is_work_queue;
+
+    if (instance->init()) {
+      return PX4_OK;
+    }
+
+  } else {
+    PX4_ERR("alloc failed");
+  }
+
+  delete instance;
+  _object.store(nullptr);
+  _task_id = -1;
+
+  return PX4_ERROR;
+}
+
+bool ExtStateEst::init() {
+  if (!_ext_state_sub.registerCallback()) {
+    PX4_ERR("sensor combined callback registration failed!");
+    return false;
+  }
+
+  PX4_INFO("Init");
+  return true;
+}
+
+ExtStateEst::ExtStateEst()
+    : ModuleParams(nullptr),
+      WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
+      _ext_state_sub{this, ORB_ID(ext_state_est_odometry)},
+      _att_pub{ORB_ID(vehicle_attitude)},
+      _vehicle_global_position_pub{ORB_ID(vehicle_global_position)},
+      _vehicle_local_position_pub{ORB_ID(vehicle_local_position)} {
+  PX4_WARN("RUN..");
+  // initialise parameter cache
+  updateParams();
+}
+
+ExtStateEst::~ExtStateEst() {}
+
+void ExtStateEst::Run() {
+  PX4_WARN("RUN..");
+
+  if (should_exit()) {
+    _ext_state_sub.unregisterCallback();
+    exit_and_cleanup();
+    return;
+  }
+
+  vehicle_odometry_s ext_state_in;
+
+  if (_ext_state_sub.update(&ext_state_in)) {
+
+    PX4_WARN("Got measurement");
+
+    uint64_t timestamp = ext_state_in.timestamp;
+    // vehicle_global_position_s position;
+
+    vehicle_local_position_s &position = _vehicle_local_position_pub.get();
+    position.timestamp = timestamp;
+    position.x = ext_state_in.x;
+    position.y = ext_state_in.y;
+    position.z = ext_state_in.z;
+
+    vehicle_attitude_s attitude;
+    attitude.timestamp = timestamp;
+    attitude.q[0] = ext_state_in.q[0];
+    attitude.q[1] = ext_state_in.q[1];
+    attitude.q[2] = ext_state_in.q[2];
+    attitude.q[3] = ext_state_in.q[3];
+
+    _vehicle_local_position_pub.update();
+    _att_pub.publish(attitude);
+  }
+}
+
+void ExtStateEst::parameters_update(bool force) {
+  //	// check for parameter updates
+  //	if (_parameter_update_sub.updated() || force) {
+  //		// clear update
+  //		parameter_update_s update;
+  //		_parameter_update_sub.copy(&update);
+
+  //		// update parameters from storage
+  //		updateParams();
+  //	}
+}
+
+int ExtStateEst::print_usage(const char *reason) {
+  if (reason) {
+    PX4_WARN("%s\n", reason);
+  }
+
+  PRINT_MODULE_DESCRIPTION(
+      R"DESCR_STR(
+### Description
+Section that describes the provided module functionality.
+
+This is a template for a module running as a task in the background with start/stop/status functionality.
+
+### Implementation
+Section describing the high-level implementation of this module.
+
+### Examples
+CLI usage example:
+$ module start -f -p 42
+
+)DESCR_STR");
+
+  PRINT_MODULE_USAGE_NAME("module", "template");
+  PRINT_MODULE_USAGE_COMMAND("start");
+  PRINT_MODULE_USAGE_PARAM_FLAG('f', "Optional example flag", true);
+  PRINT_MODULE_USAGE_PARAM_INT('p', 0, 0, 1000, "Optional example parameter",
+                               true);
+  PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+  return 0;
+}
+
+int ext_state_est_main(int argc, char *argv[]) {
+  return ExtStateEst::main(argc, argv);
+}

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -33,12 +33,18 @@
 
 #include "ext_state_est_main.h"
 
-#include <px4_getopt.h>
-#include <px4_log.h>
-#include <px4_posix.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <px4_platform_common/time.h>
 
 #include <uORB/Publication.hpp>
-#include <uORB/topics/external_state.h>
+#include <uORB/SubscriptionCallback.hpp>
+
+#include <uORB/Publication.hpp>
+#include <uORB/topics/ext_core_state.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -109,8 +115,9 @@ bool ExtStateEst::init() {
 
 ExtStateEst::ExtStateEst()
     : ModuleParams(nullptr),
-      WorkItem(MODULE_NAME, px4::wq_configurations::att_pos_ctrl),
-      _ext_state_sub{this, ORB_ID(ext_state_est_odometry)},
+      ScheduledWorkItem(MODULE_NAME,
+                        px4::wq_configurations::navigation_and_controllers),
+      _ext_state_sub{this, ORB_ID(ext_core_state)},
       _att_pub{ORB_ID(vehicle_attitude)},
       _vehicle_global_position_pub{ORB_ID(vehicle_global_position)},
       _vehicle_local_position_pub{ORB_ID(vehicle_local_position)} {
@@ -122,7 +129,7 @@ ExtStateEst::ExtStateEst()
 ExtStateEst::~ExtStateEst() {}
 
 void ExtStateEst::Run() {
-  PX4_WARN("RUN..");
+  PX4_WARN("ExtState Run");
 
   if (should_exit()) {
     _ext_state_sub.unregisterCallback();

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -109,7 +109,7 @@ bool ExtStateEst::init() {
 ExtStateEst::ExtStateEst()
     : ModuleParams(nullptr),
       ScheduledWorkItem(MODULE_NAME,
-                        px4::wq_configurations::navigation_and_controllers),
+                        px4::wq_configurations::nav_and_controllers),
       _ext_state_perf(perf_alloc(PC_ELAPSED, MODULE_NAME ": update")),
       _ext_state_sub{this, ORB_ID(ext_core_state)},
       _ext_state_lite_sub{this, ORB_ID(ext_core_state_lite)},
@@ -120,7 +120,10 @@ ExtStateEst::ExtStateEst()
       _vehicle_odometry_pub{ORB_ID(vehicle_odometry)}, _unitq(matrix::Quatf()) {
 }
 
-ExtStateEst::~ExtStateEst() { perf_free(_ext_state_perf); }
+ExtStateEst::~ExtStateEst() { 
+px4_lockstep_unregister_component(_lockstep_component);
+perf_free(_ext_state_perf);
+}
 
 void ExtStateEst::Run() {
 
@@ -364,6 +367,13 @@ if (_ext_state_lite_sub.update(&ext_state_lite_in)) {
     _estimator_status_pub.publish(status);
 
     perf_end(_ext_state_perf);
+
+   if (_lockstep_component == -1)
+   {
+      _lockstep_component = px4_lockstep_register_component();
+   }
+
+   px4_lockstep_progress(_lockstep_component);
   }
 }
 

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -189,12 +189,21 @@ void ExtStateEst::Run() {
     position.hagl_min = INFINITY;
     position.hagl_max = INFINITY;
 
+    position.ax = INFINITY;
+    position.ay = INFINITY;
+    position.az = INFINITY;
+
+    const matrix::Quatf q_att(ext_state_in.q_wi);
+
+    position.heading = matrix::Eulerf(q_att).psi();
+    position.delta_heading = 0;
+    position.heading_reset_counter = 0;
+
     // Attitude for control
     vehicle_attitude_s attitude;
     attitude.timestamp = timestamp;
     attitude.quat_reset_counter = 0;
     _unitq.copyTo(attitude.delta_q_reset);
-    const matrix::Quatf q_att(ext_state_in.q_wi);
     q_att.copyTo(attitude.q);
 
     _vehicle_local_position_pub.update();

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -133,11 +133,11 @@ void ExtStateEst::Run() {
   if (_ext_state_sub.update(&ext_state_in)) {
 
     // Alessandro: wtf?? timestamps and synchronizations needs ti be tested!
-    // uint64_t timestamp = ext_state_in.timestamp;
-    uint64_t timestamp_sample = ext_state_in.timestamp_sample;
+    uint64_t timestamp = ext_state_in.timestamp;
+    //uint64_t timestamp_sample = ext_state_in.timestamp_sample;
 
     vehicle_local_position_s &position = _vehicle_local_position_pub.get();
-    position.timestamp = timestamp_sample;
+    position.timestamp = timestamp;
     position.x = ext_state_in.p_wi[0];
     position.y = ext_state_in.p_wi[1];
     position.z = ext_state_in.p_wi[2];
@@ -157,7 +157,7 @@ void ExtStateEst::Run() {
     position.v_z_valid = true;
 
     vehicle_attitude_s attitude;
-    attitude.timestamp = timestamp_sample;
+    attitude.timestamp = timestamp;
     attitude.q[0] = ext_state_in.q_wi[0];
     attitude.q[1] = ext_state_in.q_wi[1];
     attitude.q[2] = ext_state_in.q_wi[2];

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -142,6 +142,20 @@ void ExtStateEst::Run() {
     position.y = ext_state_in.p_wi[1];
     position.z = ext_state_in.p_wi[2];
 
+    position.epv = 0;
+    position.eph = 0;
+    position.xy_valid = true;
+    position.z_valid = true;
+
+    position.vx = ext_state_in.v_wi[0];
+    position.vy = ext_state_in.v_wi[1];
+    position.vz = ext_state_in.v_wi[2];
+
+    position.evv = 0;
+    position.evh = 0;
+    position.v_xy_valid = true;
+    position.v_z_valid = true;
+
     vehicle_attitude_s attitude;
     attitude.timestamp = timestamp_sample;
     attitude.q[0] = ext_state_in.q_wi[0];

--- a/src/modules/ext_state_est/ext_state_est_main.cpp
+++ b/src/modules/ext_state_est/ext_state_est_main.cpp
@@ -45,6 +45,7 @@
 #include <uORB/SubscriptionCallback.hpp>
 
 #include <uORB/Publication.hpp>
+#include <uORB/topics/estimator_status.h>
 #include <uORB/topics/ext_core_state.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_combined.h>
@@ -109,7 +110,10 @@ ExtStateEst::ExtStateEst()
       _ext_state_sub{this, ORB_ID(ext_core_state)},
       _att_pub{ORB_ID(vehicle_attitude)},
       _vehicle_global_position_pub{ORB_ID(vehicle_global_position)},
-      _vehicle_local_position_pub{ORB_ID(vehicle_local_position)} {}
+      _vehicle_local_position_pub{ORB_ID(vehicle_local_position)},
+      _estimator_status_pub{ORB_ID(estimator_status)},
+      _vehicle_odometry_pub{ORB_ID(vehicle_odometry)}, _unitq(matrix::Quatf()) {
+}
 
 ExtStateEst::~ExtStateEst() { perf_free(_ext_state_perf); }
 
@@ -128,14 +132,38 @@ void ExtStateEst::Run() {
 
   perf_begin(_ext_state_perf);
 
-  ext_core_state_s ext_state_in;
+  //  vehicle_odometry_s odom{};
+
+  ext_core_state_s ext_state_in{};
 
   if (_ext_state_sub.update(&ext_state_in)) {
 
-    // Alessandro: wtf?? timestamps and synchronizations needs ti be tested!
     uint64_t timestamp = ext_state_in.timestamp;
-    //uint64_t timestamp_sample = ext_state_in.timestamp_sample;
+    //    uint64_t timestamp_sample = ext_state_in.timestamp_sample;
 
+    //    // Odometry for PX4 -> MAVLINK -> MAVROS -> ROS
+    //    odom.timestamp = timestamp;
+    //    odom.timestamp_sample = timestamp_sample;
+    //    odom.x = ext_state_in.p_wi[0];
+    //    odom.y = ext_state_in.p_wi[1];
+    //    odom.z = ext_state_in.p_wi[2];
+
+    //    matrix::Quatf q_odom(ext_state_in.q_wi);
+    //    q_odom.copyTo(odom.q);
+
+    //    odom.local_frame = odom.LOCAL_FRAME_NED;
+
+    //    odom.vx = NAN;
+    //    odom.vy = NAN;
+    //    odom.vz = NAN;
+    //    odom.rollspeed = NAN;
+    //    odom.pitchspeed = NAN;
+    //    odom.yawspeed = NAN;
+
+    //    //TODO: add covariance
+    //    _vehicle_odometry_pub.publish(odom);
+
+    // Local position for control
     vehicle_local_position_s &position = _vehicle_local_position_pub.get();
     position.timestamp = timestamp;
     position.x = ext_state_in.p_wi[0];
@@ -156,18 +184,55 @@ void ExtStateEst::Run() {
     position.v_xy_valid = true;
     position.v_z_valid = true;
 
+    position.vxy_max = INFINITY;
+    position.vz_max = INFINITY;
+    position.hagl_min = INFINITY;
+    position.hagl_max = INFINITY;
+
+    // Attitude for control
     vehicle_attitude_s attitude;
     attitude.timestamp = timestamp;
-    attitude.q[0] = ext_state_in.q_wi[0];
-    attitude.q[1] = ext_state_in.q_wi[1];
-    attitude.q[2] = ext_state_in.q_wi[2];
-    attitude.q[3] = ext_state_in.q_wi[3];
+    attitude.quat_reset_counter = 0;
+    _unitq.copyTo(attitude.delta_q_reset);
+    const matrix::Quatf q_att(ext_state_in.q_wi);
+    q_att.copyTo(attitude.q);
 
     _vehicle_local_position_pub.update();
     _att_pub.publish(attitude);
-  }
 
-  perf_end(_ext_state_perf);
+    // Estimator Status
+    // TODO: for now we only fullfill components needed by the commander
+    estimator_status_s status;
+    status.timestamp = hrt_absolute_time();
+
+    // status.states;
+    status.n_states = 0;
+    // status.covariances;
+    status.control_mode_flags = 0;
+    status.filter_fault_flags = 0;
+    status.innovation_check_flags = 0;
+    status.mag_test_ratio = 0.1f;
+    status.vel_test_ratio = 0.1f;
+    status.pos_test_ratio = 0.1f;
+    status.hgt_test_ratio = 0.1f;
+    status.tas_test_ratio = 0.1f;
+    status.hagl_test_ratio = 0.1f;
+    status.beta_test_ratio = 0.1f;
+
+    status.pos_horiz_accuracy = _vehicle_local_position_pub.get().eph;
+    status.pos_vert_accuracy = _vehicle_local_position_pub.get().epv;
+    status.solution_status_flags = 0;
+
+    status.time_slip = 0;
+    status.pre_flt_fail_innov_heading = false;
+    status.pre_flt_fail_innov_vel_horiz = false;
+    status.pre_flt_fail_innov_vel_vert = false;
+    status.pre_flt_fail_innov_height = false;
+    status.pre_flt_fail_mag_field_disturbed = false;
+    _estimator_status_pub.publish(status);
+
+    perf_end(_ext_state_perf);
+  }
 }
 
 int ExtStateEst::print_usage(const char *reason) {

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -1,0 +1,102 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_module.h>
+#include <px4_module_params.h>
+#include <uORB/Publication.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/external_state.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_odometry.h>
+
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <px4_posix.h>
+#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_local_position.h>
+
+
+extern "C" __EXPORT int ext_state_est_main(int argc, char *argv[]);
+
+class ExtStateEst : public ModuleBase<ExtStateEst>,
+                    public ModuleParams,
+                    public px4::WorkItem {
+public:
+  ExtStateEst();
+  ~ExtStateEst() override;
+
+  /** @see ModuleBase */
+  static int task_spawn(int argc, char *argv[]);
+
+  bool init();
+
+  /** @see ModuleBase */
+  static ExtStateEst *instantiate(int argc, char *argv[]);
+
+  /** @see ModuleBase */
+  static int custom_command(int argc, char *argv[]);
+
+  /** @see ModuleBase */
+  static int print_usage(const char *reason = nullptr);
+
+  /** @see ModuleBase::run() */
+  void Run() override;
+
+  /** @see ModuleBase::print_status() */
+  int print_status() override;
+
+  uORB::SubscriptionCallbackWorkItem _ext_state_sub;
+  uORB::Publication<vehicle_attitude_s> _att_pub;
+  uORB::PublicationData<vehicle_global_position_s> _vehicle_global_position_pub;
+  uORB::PublicationData<vehicle_local_position_s> _vehicle_local_position_pub;
+
+private:
+  /**
+   * Check for parameter changes and update them if needed.
+   * @param parameter_update_sub uorb subscription to parameter_update
+   * @param force for a parameter update
+   */
+  void parameters_update(bool force = false);
+
+  //	DEFINE_PARAMETERS(
+  //		(ParamInt<px4::params::SYS_AUTOSTART>) _param_sys_autostart,   /**<
+  //example parameter */
+  //		(ParamInt<px4::params::SYS_AUTOCONFIG>) _param_sys_autoconfig  /**<
+  //another parameter */
+  //	)
+
+  //	// Subscriptions
+  //	uORB::Subscription	_parameter_update_sub{ORB_ID(parameter_update)};
+};

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -55,7 +55,6 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
-#include <uORB/topics/vehicle_odometry.h>
 
 class ExtStateEst final : public ModuleBase<ExtStateEst>,
                           public ModuleParams,
@@ -85,7 +84,6 @@ private:
   perf_counter_t _ext_state_perf;
 
   uORB::SubscriptionCallbackWorkItem _ext_state_sub;
-  uORB::SubscriptionCallbackWorkItem _mocap_odom_sub;
   uORB::Publication<vehicle_attitude_s> _att_pub;
   uORB::PublicationData<vehicle_global_position_s> _vehicle_global_position_pub;
   uORB::PublicationData<vehicle_local_position_s> _vehicle_local_position_pub;

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -33,26 +33,27 @@
 
 #pragma once
 
-#include <px4_module.h>
-#include <px4_module_params.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <px4_platform_common/time.h>
+
 #include <uORB/Publication.hpp>
 #include <uORB/SubscriptionCallback.hpp>
-#include <uORB/topics/external_state.h>
+#include <uORB/topics/ext_core_state.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_attitude.h>
-#include <uORB/topics/vehicle_odometry.h>
-
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <px4_posix.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
-
+#include <uORB/topics/vehicle_odometry.h>
 
 extern "C" __EXPORT int ext_state_est_main(int argc, char *argv[]);
 
 class ExtStateEst : public ModuleBase<ExtStateEst>,
                     public ModuleParams,
-                    public px4::WorkItem {
+                    public px4::ScheduledWorkItem {
 public:
   ExtStateEst();
   ~ExtStateEst() override;
@@ -91,10 +92,12 @@ private:
   void parameters_update(bool force = false);
 
   //	DEFINE_PARAMETERS(
-  //		(ParamInt<px4::params::SYS_AUTOSTART>) _param_sys_autostart,   /**<
-  //example parameter */
-  //		(ParamInt<px4::params::SYS_AUTOCONFIG>) _param_sys_autoconfig  /**<
-  //another parameter */
+  //		(ParamInt<px4::params::SYS_AUTOSTART>) _param_sys_autostart,
+  ///**<
+  // example parameter */
+  //		(ParamInt<px4::params::SYS_AUTOCONFIG>) _param_sys_autoconfig
+  ///**<
+  // another parameter */
   //	)
 
   //	// Subscriptions

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -52,6 +52,7 @@
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/ext_core_state.h>
+#include <uORB/topics/ext_core_state_lite.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -87,6 +88,7 @@ private:
   perf_counter_t _ext_state_perf;
 
   uORB::SubscriptionCallbackWorkItem _ext_state_sub;
+  uORB::SubscriptionCallbackWorkItem _ext_state_lite_sub;
   uORB::Publication<vehicle_attitude_s> _att_pub;
   uORB::PublicationData<vehicle_global_position_s> _vehicle_global_position_pub;
   uORB::PublicationData<vehicle_local_position_s> _vehicle_local_position_pub;

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -86,6 +86,7 @@ private:
   void Run() override;
 
   perf_counter_t _ext_state_perf;
+  int _lockstep_component{-1};
 
   uORB::SubscriptionCallbackWorkItem _ext_state_sub;
   uORB::SubscriptionCallbackWorkItem _ext_state_lite_sub;

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -50,11 +50,13 @@
 
 #include <uORB/Publication.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/estimator_status.h>
 #include <uORB/topics/ext_core_state.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/vehicle_status.h>
 
 class ExtStateEst final : public ModuleBase<ExtStateEst>,
@@ -88,8 +90,12 @@ private:
   uORB::Publication<vehicle_attitude_s> _att_pub;
   uORB::PublicationData<vehicle_global_position_s> _vehicle_global_position_pub;
   uORB::PublicationData<vehicle_local_position_s> _vehicle_local_position_pub;
+  uORB::Publication<estimator_status_s> _estimator_status_pub;
+
+  uORB::Publication<vehicle_odometry_s> _vehicle_odometry_pub;
 
   bool _callback_registered{false};
+  const matrix::Quatf _unitq;
 };
 
 extern "C" __EXPORT int ext_state_est_main(int argc, char *argv[]) {

--- a/src/modules/ext_state_est/ext_state_est_main.h
+++ b/src/modules/ext_state_est/ext_state_est_main.h
@@ -55,6 +55,7 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_status.h>
 
 class ExtStateEst final : public ModuleBase<ExtStateEst>,
                           public ModuleParams,

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -271,6 +271,10 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 		handle_message_statustext(msg);
 		break;
 
+  case MAVLINK_MSG_ID_EXT_CORE_STATE:
+    handle_message_ext_core_state(msg);
+    break;
+
 	default:
 		break;
 	}
@@ -2781,6 +2785,41 @@ void MavlinkReceiver::handle_message_statustext(mavlink_message_t *msg)
 
 		_log_message_pub.publish(log_message);
 	}
+}
+
+void
+MavlinkReceiver::handle_message_ext_core_state(mavlink_message_t *msg)
+{
+  mavlink_ext_core_state_t ml_ecs;
+  mavlink_msg_ext_core_state_decode(msg, &ml_ecs);
+
+  ext_core_state_s ecs{};
+
+  ecs.timestamp = hrt_absolute_time();
+  ecs.timestamp_sample = _mavlink_timesync.sync_stamp(ml_ecs.usec);
+
+  // Alessandro: check possible data defrag
+  memcpy(ecs.p_wi, ml_ecs.p_wi, sizeof(ml_ecs.p_wi));
+  memcpy(ecs.v_wi, ml_ecs.v_wi, sizeof(ml_ecs.v_wi));
+  memcpy(ecs.q_wi, ml_ecs.q_wi, sizeof(ml_ecs.q_wi));
+  memcpy(ecs.b_a, ml_ecs.b_a, sizeof(ml_ecs.b_a));
+  memcpy(ecs.b_w, ml_ecs.b_w, sizeof(ml_ecs.b_w));
+
+//  std::copy(std::begin(ml_ecs.p_wi), std::end(ml_ecs.p_wi), std::begin(ecs.p_wi));
+//  std::copy(std::begin(ml_ecs.v_wi), std::end(ml_ecs.v_wi), std::begin(ecs.v_wi));
+//  std::copy(std::begin(ml_ecs.q_wi), std::end(ml_ecs.q_wi), std::begin(ecs.q_wi));
+//  std::copy(std::begin(ml_ecs.b_a), std::end(ml_ecs.b_a), std::begin(ecs.b_a));
+//  std::copy(std::begin(ml_ecs.b_w), std::end(ml_ecs.b_w), std::begin(ecs.b_w));
+
+  const size_t URT_SIZE = sizeof(ecs.cov_urt) / sizeof(ecs.cov_urt[0]);
+  static_assert(URT_SIZE == (sizeof(ml_ecs.cov_urt) / sizeof(ml_ecs.cov_urt[0])),
+          "External state estimate Covariance matrix URT array size mismatch");
+
+  for (size_t i = 0; i < URT_SIZE; i++) {
+    ecs.cov_urt[i] = ml_ecs.cov_urt[i];
+  }
+
+  _ext_core_state_pub.publish(ecs);
 }
 
 /**

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2798,7 +2798,6 @@ MavlinkReceiver::handle_message_ext_core_state(mavlink_message_t *msg)
   ecs.timestamp = hrt_absolute_time();
   ecs.timestamp_sample = _mavlink_timesync.sync_stamp(ml_ecs.usec);
 
-  // Alessandro: check possible data defrag
   memcpy(ecs.p_wi, ml_ecs.p_wi, sizeof(ml_ecs.p_wi));
   memcpy(ecs.v_wi, ml_ecs.v_wi, sizeof(ml_ecs.v_wi));
   memcpy(ecs.q_wi, ml_ecs.q_wi, sizeof(ml_ecs.q_wi));

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2804,12 +2804,6 @@ MavlinkReceiver::handle_message_ext_core_state(mavlink_message_t *msg)
   memcpy(ecs.b_a, ml_ecs.b_a, sizeof(ml_ecs.b_a));
   memcpy(ecs.b_w, ml_ecs.b_w, sizeof(ml_ecs.b_w));
 
-//  std::copy(std::begin(ml_ecs.p_wi), std::end(ml_ecs.p_wi), std::begin(ecs.p_wi));
-//  std::copy(std::begin(ml_ecs.v_wi), std::end(ml_ecs.v_wi), std::begin(ecs.v_wi));
-//  std::copy(std::begin(ml_ecs.q_wi), std::end(ml_ecs.q_wi), std::begin(ecs.q_wi));
-//  std::copy(std::begin(ml_ecs.b_a), std::end(ml_ecs.b_a), std::begin(ecs.b_a));
-//  std::copy(std::begin(ml_ecs.b_w), std::end(ml_ecs.b_w), std::begin(ecs.b_w));
-
   const size_t URT_SIZE = sizeof(ecs.cov_urt) / sizeof(ecs.cov_urt[0]);
   static_assert(URT_SIZE == (sizeof(ml_ecs.cov_urt) / sizeof(ml_ecs.cov_urt[0])),
           "External state estimate Covariance matrix URT array size mismatch");

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2815,6 +2815,23 @@ MavlinkReceiver::handle_message_ext_core_state(mavlink_message_t *msg)
   _ext_core_state_pub.publish(ecs);
 }
 
+void
+MavlinkReceiver::handle_message_ext_core_state_lite(mavlink_message_t *msg)
+{
+  mavlink_ext_core_state_lite_t ml_ecs;
+  mavlink_msg_ext_core_state_lite_decode(msg, &ml_ecs);
+
+  ext_core_state_lite_s ecs{};
+
+  ecs.timestamp = hrt_absolute_time();
+  ecs.timestamp_sample = _mavlink_timesync.sync_stamp(ml_ecs.usec);
+
+  memcpy(ecs.p_wi, ml_ecs.p_wi, sizeof(ml_ecs.p_wi));
+  memcpy(ecs.v_wi, ml_ecs.v_wi, sizeof(ml_ecs.v_wi));
+  memcpy(ecs.q_wi, ml_ecs.q_wi, sizeof(ml_ecs.q_wi));
+  _ext_core_state_lite_pub.publish(ecs);
+}
+
 /**
  * Receive data from UART/UDP
  */

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -271,9 +271,12 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 		handle_message_statustext(msg);
 		break;
 
-  case MAVLINK_MSG_ID_EXT_CORE_STATE:
-    handle_message_ext_core_state(msg);
-    break;
+        case MAVLINK_MSG_ID_EXT_CORE_STATE:
+                handle_message_ext_core_state(msg);
+                break;
+        case MAVLINK_MSG_ID_EXT_CORE_STATE_LITE:
+                handle_message_ext_core_state_lite(msg);
+                break;
 
 	default:
 		break;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -102,6 +102,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_trajectory_bezier.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
+#include <uORB/topics/ext_core_state.h>
 
 class Mavlink;
 
@@ -179,6 +180,7 @@ private:
 	void handle_message_utm_global_position(mavlink_message_t *msg);
 	void handle_message_vision_position_estimate(mavlink_message_t *msg);
 	void handle_message_onboard_computer_status(mavlink_message_t *msg);
+  void handle_message_ext_core_state(mavlink_message_t *msg);
 
 
 	void Run();
@@ -260,6 +262,7 @@ private:
 	uORB::Publication<vehicle_rates_setpoint_s>		_rates_sp_pub{ORB_ID(vehicle_rates_setpoint)};
 	uORB::Publication<vehicle_trajectory_bezier_s>	_trajectory_bezier_pub{ORB_ID(vehicle_trajectory_bezier)};
 	uORB::Publication<vehicle_trajectory_waypoint_s>	_trajectory_waypoint_pub{ORB_ID(vehicle_trajectory_waypoint)};
+  uORB::Publication<ext_core_state_s>	_ext_core_state_pub{ORB_ID(ext_core_state)};
 
 	// ORB publications (multi)
 	uORB::PublicationMulti<distance_sensor_s>		_distance_sensor_pub{ORB_ID(distance_sensor), ORB_PRIO_LOW};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -264,8 +264,8 @@ private:
 	uORB::Publication<vehicle_rates_setpoint_s>		_rates_sp_pub{ORB_ID(vehicle_rates_setpoint)};
 	uORB::Publication<vehicle_trajectory_bezier_s>	_trajectory_bezier_pub{ORB_ID(vehicle_trajectory_bezier)};
 	uORB::Publication<vehicle_trajectory_waypoint_s>	_trajectory_waypoint_pub{ORB_ID(vehicle_trajectory_waypoint)};
-        uORB::Publication<ext_core_state_s>             	_ext_core_state_pub{ORB_ID(ext_core_state)};
-        uORB::Publication<ext_core_state_lite_s>        	_ext_core_state_lite_pub{ORB_ID(ext_core_state_lite)};
+        uORB::Publication<ext_core_state_s>	                 _ext_core_state_pub{ORB_ID(ext_core_state)};
+        uORB::Publication<ext_core_state_lite_s>	         _ext_core_state_lite_pub{ORB_ID(ext_core_state_lite)};
 
 	// ORB publications (multi)
 	uORB::PublicationMulti<distance_sensor_s>		_distance_sensor_pub{ORB_ID(distance_sensor), ORB_PRIO_LOW};

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -103,6 +103,7 @@
 #include <uORB/topics/vehicle_trajectory_bezier.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
 #include <uORB/topics/ext_core_state.h>
+#include <uORB/topics/ext_core_state_lite.h>
 
 class Mavlink;
 
@@ -180,7 +181,8 @@ private:
 	void handle_message_utm_global_position(mavlink_message_t *msg);
 	void handle_message_vision_position_estimate(mavlink_message_t *msg);
 	void handle_message_onboard_computer_status(mavlink_message_t *msg);
-  void handle_message_ext_core_state(mavlink_message_t *msg);
+        void handle_message_ext_core_state(mavlink_message_t *msg);
+        void handle_message_ext_core_state_lite(mavlink_message_t *msg);
 
 
 	void Run();
@@ -262,7 +264,8 @@ private:
 	uORB::Publication<vehicle_rates_setpoint_s>		_rates_sp_pub{ORB_ID(vehicle_rates_setpoint)};
 	uORB::Publication<vehicle_trajectory_bezier_s>	_trajectory_bezier_pub{ORB_ID(vehicle_trajectory_bezier)};
 	uORB::Publication<vehicle_trajectory_waypoint_s>	_trajectory_waypoint_pub{ORB_ID(vehicle_trajectory_waypoint)};
-  uORB::Publication<ext_core_state_s>	_ext_core_state_pub{ORB_ID(ext_core_state)};
+        uORB::Publication<ext_core_state_s>             	_ext_core_state_pub{ORB_ID(ext_core_state)};
+        uORB::Publication<ext_core_state_lite_s>        	_ext_core_state_lite_pub{ORB_ID(ext_core_state_lite)};
 
 	// ORB publications (multi)
 	uORB::PublicationMulti<distance_sensor_s>		_distance_sensor_pub{ORB_ID(distance_sensor), ORB_PRIO_LOW};


### PR DESCRIPTION
## Describe problem solved by this pull request
For our research on State-Estimation and multi-sensor-fusion, it was necessary to pass the estimates of an external state estimator to the controller of the PX4 to circumvent the cascade of multiple EKF (e.g. passing an external estimate to the internal EKF2). In addition, the internal EKF2 caused unforeseen rejections of valid location information, which prevented reproducible results when performing experiments.

## Describe your solution
We added an additional module called "bridge" which subscribes to the external state-estimate and passes this estimate directly to the controller. Switching between the LPE, EKF2, and the bridge is still possible through parameters.

## Describe possible alternatives
In the past, the only solution that was followed by multiple institutions was to provide the pose of en external state estimator as a vision pose measurement and set the measurement noise to the lowest value to "force" the EKF2 to follow the measurement input. The bridge module directly solves this issue and allows for reproducible results when using the PX4 in research and when reproducible results are required.

## Test data / coverage
Test data can be generated and provided if needed. 

## Additional context
Video of an exemplary usage of the bridge module with an external estimator ([MaRS](https://github.com/aau-cns/mars_lib)) https://youtu.be/sVYeHpfOjuQ

A new mavlink message and mavros plugin needed to be added to provide a [position, velocity, orientation] state to the PX4. This was done in [mavlink](https://github.com/aau-cns/mavlink) and [mavros](https://github.com/aau-cns/mavros).

At the very moment, this addition is based on v1.11.3
