### PR TITLE
nuttx/atomic: Don't call enter-/exit_critical_section() from user code

### DIFF
--- a/platforms/common/include/px4_platform_common/atomic_from_isr.h
+++ b/platforms/common/include/px4_platform_common/atomic_from_isr.h
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file atomic.h
+ * @file atomic_from_isr.h
  *
  * Provides atomic integers and counters. Each method is executed atomically and thus
  * can be used to prevent data races and add memory synchronization between threads.
@@ -58,33 +58,35 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <px4_platform_common/sem.h>
+
+#if !defined(__PX4_NUTTX)
+
+/* For non-NuttX targets forward this to the generic atomic implementation */
+#include "atomic.h"
 
 namespace px4
 {
 
 template <typename T>
-class atomic
+using atomic_from_isr = atomic<T>;
+
+}
+
+#else
+
+/* For NuttX targets, implement an IRQ safe way for atomic data */
+#include <nuttx/irq.h>
+
+namespace px4
+{
+
+template <typename T>
+class atomic_from_isr
 {
 public:
 
-#if defined(__PX4_POSIX)
-	// Ensure that all operations are lock-free, so that 'atomic' can be used from
-	// IRQ handlers. This might not be required everywhere though.
-	static_assert(__atomic_always_lock_free(sizeof(T), 0), "atomic is not lock-free for the given type T");
-#endif // __PX4_POSIX
-	atomic()
-	{
-		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			px4_sem_init(&_lock, 0, 1);
-		}
-	}
-	explicit atomic(T value) : _value(value)
-	{
-		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			px4_sem_init(&_lock, 0, 1);
-		}
-	}
+	atomic_from_isr() = default;
+	explicit atomic_from_isr(T value) : _value(value) {}
 
 	/**
 	 * Atomically read the current value
@@ -92,9 +94,9 @@ public:
 	inline T load() const
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T val = _value;
-			release_lock();
+			leave_critical_section(flags);
 			return val;
 
 		} else {
@@ -108,9 +110,9 @@ public:
 	inline void store(T value)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			_value = value;
-			release_lock();
+			leave_critical_section(flags);
 
 		} else {
 			__atomic_store(&_value, &value, __ATOMIC_SEQ_CST);
@@ -124,10 +126,10 @@ public:
 	inline T fetch_add(T num)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T ret = _value;
 			_value += num;
-			release_lock();
+			leave_critical_section(flags);
 			return ret;
 
 		} else {
@@ -142,10 +144,10 @@ public:
 	inline T fetch_sub(T num)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T ret = _value;
 			_value -= num;
-			release_lock();
+			leave_critical_section(flags);
 			return ret;
 
 		} else {
@@ -160,10 +162,10 @@ public:
 	inline T fetch_and(T num)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T val = _value;
 			_value &= num;
-			release_lock();
+			leave_critical_section(flags);
 			return val;
 
 		} else {
@@ -178,10 +180,10 @@ public:
 	inline T fetch_xor(T num)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T val = _value;
 			_value ^= num;
-			release_lock();
+			leave_critical_section(flags);
 			return val;
 
 		} else {
@@ -196,10 +198,10 @@ public:
 	inline T fetch_or(T num)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T val = _value;
 			_value |= num;
-			release_lock();
+			leave_critical_section(flags);
 			return val;
 
 		} else {
@@ -214,10 +216,10 @@ public:
 	inline T fetch_nand(T num)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 			T ret = _value;
 			_value = ~(_value & num);
-			release_lock();
+			leave_critical_section(flags);
 			return ret;
 
 		} else {
@@ -236,16 +238,16 @@ public:
 	inline bool compare_exchange(T *expected, T desired)
 	{
 		if (!__atomic_always_lock_free(sizeof(T), 0)) {
-			take_lock();
+			irqstate_t flags = enter_critical_section();
 
 			if (_value == *expected) {
 				_value = desired;
-				release_lock();
+				leave_critical_section(flags);
 				return true;
 
 			} else {
 				*expected = _value;
-				release_lock();
+				leave_critical_section(flags);
 				return false;
 			}
 
@@ -256,17 +258,9 @@ public:
 
 private:
 	T _value {};
-
-	inline void take_lock() const { do {} while (px4_sem_wait(&_lock) != 0); }
-	inline void release_lock() const { px4_sem_post(&_lock); }
-	mutable px4_sem_t _lock;
 };
-
-using atomic_int = atomic<int>;
-using atomic_int32_t = atomic<int32_t>;
-using atomic_bool = atomic<bool>;
 
 } /* namespace px4 */
 
+#endif /* __PX4_NUTTX */
 #endif /* __cplusplus */
-

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueue.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueue.hpp
@@ -43,6 +43,10 @@
 #include <px4_platform_common/sem.h>
 #include <px4_platform_common/tasks.h>
 
+#ifdef __PX4_NUTTX
+#  include <px4_platform/atomic_block.h>
+#endif
+
 namespace px4
 {
 
@@ -84,9 +88,16 @@ private:
 
 #ifdef __PX4_NUTTX
 	// In NuttX work can be enqueued from an ISR
+#ifdef CONFIG_BUILD_FLAT
 	void work_lock() { _flags = enter_critical_section(); }
 	void work_unlock() { leave_critical_section(_flags); }
 	irqstate_t _flags;
+#else
+	// For non-flat targets, work is enqueued by user threads as well
+	void work_lock() { _atomic.start(); }
+	void work_unlock() { _atomic.finish(); }
+	atomic_block _atomic;
+#endif
 #else
 	// loop as the wait may be interrupted by a signal
 	void work_lock() { do {} while (px4_sem_wait(&_qlock) != 0); }

--- a/platforms/nuttx/src/px4/common/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/common/CMakeLists.txt
@@ -44,6 +44,7 @@ if(NOT PX4_BOARD MATCHES "io-v2")
 		gpio.c
 		print_load.cpp
 		tasks.cpp
+		px4_atomic.cpp
 		px4_nuttx_impl.cpp
 		px4_init.cpp
 		px4_manifest.cpp

--- a/platforms/nuttx/src/px4/common/include/px4_platform/atomic_block.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/atomic_block.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+#include <nuttx/irq.h>
+
+#include <px4_platform_common/sem.h>
+
+namespace px4
+{
+
+class atomic_block
+{
+public:
+	atomic_block();
+	~atomic_block();
+	void start();
+	void finish();
+private:
+	union {
+		px4_sem_t _lock;
+		irqstate_t _irqlock;
+	};
+};
+
+}

--- a/platforms/nuttx/src/px4/common/px4_atomic.cpp
+++ b/platforms/nuttx/src/px4/common/px4_atomic.cpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform/atomic_block.h>
+
+namespace px4
+{
+
+atomic_block::atomic_block(void)
+{
+	_irqlock = 0;
+}
+
+atomic_block::~atomic_block(void)
+{
+
+}
+
+void atomic_block::start(void)
+{
+	_irqlock = enter_critical_section();
+}
+
+void atomic_block::finish(void)
+{
+	leave_critical_section(_irqlock);
+}
+
+}

--- a/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
+++ b/platforms/nuttx/src/px4/common/px4_protected_layers.cmake
@@ -12,6 +12,7 @@ add_library(px4_layer
 	px4_userspace_init.cpp
 	px4_usr_crypto.cpp
 	px4_mtd.cpp
+	usr_atomic.cpp
 	usr_board_ctrl.c
 	usr_hrt.cpp
 	usr_mcu_version.cpp

--- a/platforms/nuttx/src/px4/common/usr_atomic.cpp
+++ b/platforms/nuttx/src/px4/common/usr_atomic.cpp
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 Technology Innovation Institute. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <px4_platform/atomic_block.h>
+
+namespace px4
+{
+
+atomic_block::atomic_block(void)
+{
+	px4_sem_init(&_lock, 0, 1);
+}
+
+atomic_block::~atomic_block(void)
+{
+	px4_sem_destroy(&_lock);
+}
+
+void atomic_block::start(void)
+{
+	do {} while (px4_sem_wait(&_lock) != 0);
+}
+
+void atomic_block::finish(void)
+{
+	px4_sem_post(&_lock);
+}
+
+}

--- a/src/drivers/imu/analog_devices/adis16448/ADIS16448.hpp
+++ b/src/drivers/imu/analog_devices/adis16448/ADIS16448.hpp
@@ -51,7 +51,7 @@
 #include <uORB/topics/sensor_baro.h>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace Analog_Devices_ADIS16448;
@@ -114,7 +114,7 @@ private:
 	hrt_abstime _last_config_check_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	bool _check_crc{false}; // CRC-16 not supported on earlier models (eg ADIS16448AMLZ)

--- a/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
+++ b/src/drivers/imu/analog_devices/adis16470/ADIS16470.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace Analog_Devices_ADIS16470;
@@ -107,7 +107,7 @@ private:
 	hrt_abstime _last_config_check_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	bool _self_test_passed{false};

--- a/src/drivers/imu/bosch/bmi055/BMI055.hpp
+++ b/src/drivers/imu/bosch/bmi055/BMI055.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/spi.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -66,7 +67,7 @@ protected:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/bosch/bmi085/BMI085.hpp
+++ b/src/drivers/imu/bosch/bmi085/BMI085.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/spi.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -66,7 +67,7 @@ protected:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/bosch/bmi088/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/spi.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -66,7 +67,7 @@ protected:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/bosch/bmi088_i2c/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088_i2c/BMI088.hpp
@@ -36,6 +36,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/drivers/device/i2c.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 static constexpr int16_t combine(uint8_t msb, uint8_t lsb) { return (msb << 8u) | lsb; }
@@ -72,7 +73,7 @@ protected:
 	int _total_failure_count{0};
 
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm20602/ICM20602.hpp
+++ b/src/drivers/imu/invensense/icm20602/ICM20602.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20602;
@@ -140,7 +140,7 @@ private:
 	hrt_abstime _last_config_check_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
+++ b/src/drivers/imu/invensense/icm20608g/ICM20608G.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20608G;
@@ -138,7 +138,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm20649/ICM20649.hpp
+++ b/src/drivers/imu/invensense/icm20649/ICM20649.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20649;
@@ -152,7 +152,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm20689/ICM20689.hpp
+++ b/src/drivers/imu/invensense/icm20689/ICM20689.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM20689;
@@ -138,7 +138,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm20948/ICM20948.hpp
+++ b/src/drivers/imu/invensense/icm20948/ICM20948.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 #include "ICM20948_AK09916.hpp"
@@ -169,7 +169,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
+++ b/src/drivers/imu/invensense/icm40609d/ICM40609D.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM40609D;
@@ -146,7 +146,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm42605/ICM42605.hpp
+++ b/src/drivers/imu/invensense/icm42605/ICM42605.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM42605;
@@ -146,7 +146,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm42670p/ICM42670P.hpp
+++ b/src/drivers/imu/invensense/icm42670p/ICM42670P.hpp
@@ -47,7 +47,7 @@
 #include <lib/drivers/device/spi.h>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM42670P;
@@ -150,7 +150,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_ICM42688P;
@@ -158,7 +158,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/iim42652/IIM42652.hpp
+++ b/src/drivers/imu/invensense/iim42652/IIM42652.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_IIM42652;
@@ -158,7 +158,7 @@ private:
 
 	enum REG_BANK_SEL_BIT _last_register_bank {REG_BANK_SEL_BIT::USER_BANK_0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	enum class STATE : uint8_t {

--- a/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/invensense/mpu6000/MPU6000.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_MPU6000;
@@ -140,7 +140,7 @@ private:
 	FIFO::DATA _fifo_sample_last_new_accel{};
 	uint32_t _fifo_accel_samples_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
+++ b/src/drivers/imu/invensense/mpu6500/MPU6500.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_MPU6500;
@@ -138,7 +138,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 #include "MPU9250_AK8963.hpp"
@@ -150,7 +150,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.hpp
+++ b/src/drivers/imu/invensense/mpu9250/MPU9250_I2C.hpp
@@ -48,7 +48,7 @@
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 #include <lib/geo/geo.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
 using namespace InvenSense_MPU9250;
@@ -136,7 +136,7 @@ private:
 	hrt_abstime _temperature_update_timestamp{0};
 	int _failure_count{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	int32_t _drdy_count{0};
 	bool _data_ready_interrupt_enabled{false};
 

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -45,7 +45,7 @@
 #include <drivers/device/spi.h>
 #include <lib/conversion/rotation.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_optical_flow.h>
@@ -117,7 +117,7 @@ private:
 	int _failure_count{0};
 	int _discard_reading{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_0 / 2};

--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -45,7 +45,7 @@
 #include <drivers/device/spi.h>
 #include <lib/conversion/rotation.h>
 #include <lib/perf/perf_counter.h>
-#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/atomic_from_isr.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_optical_flow.h>
@@ -117,7 +117,7 @@ private:
 	int _failure_count{0};
 	int _discard_reading{0};
 
-	px4::atomic<hrt_abstime> _drdy_timestamp_sample{0};
+	px4::atomic_from_isr<hrt_abstime> _drdy_timestamp_sample{0};
 	bool _data_ready_interrupt_enabled{false};
 
 	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_0 / 2};


### PR DESCRIPTION
Only use enter-/exit_critical_section() from kernel modules

## Describe problem solved by this pull request
Fixes a system crash for RISC-V when user code tries to execute global interrupt disable/enable

## Describe your solution
User space code does not require interrupt masking -> get rid of it.

For atomic.h, implement a wrapper "atomic_from_isr" which is intended to be used by drivers/modules that really do need IRQ level protection. Otherwise, do not use the IRQ locks.

For px4_work_queue the solution needs to be a bit more complex, as the same px4_work_queue.a library is linked to both kernel-/user space, so it really does need two separate implementations for handling atomic sections.

## Describe possible alternatives
A clear split between kernel-/user space, most of the things that are no placed into kernel space do not really need to be there.
However doing the split is an order of magnitude (at least) more work to do, so this patch fixes the crashes, nothing more.

## Test data / coverage
fmuv5 protected + mpfs protected targets (unpublished)

## Additional context
The problem description can be read from here:
https://discuss.px4.io/t/atomic-sections-via-masking-global-interrupts/28072
