### PR TITLE
VTOL takeoff problem hotfix

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -623,7 +623,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 			    _navigator->get_loiter_radius();
 	sp->loiter_direction = math::signNoZero(item.loiter_radius);
 
-	if (item.acceptance_radius > 0.0f && PX4_ISFINITE(item.acceptance_radius)) {
+	if (item.acceptance_radius > 0.001f && PX4_ISFINITE(item.acceptance_radius)) {
 		// if the mission item has a specified acceptance radius, overwrite the default one from parameters
 		sp->acceptance_radius = item.acceptance_radius;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -756,6 +756,7 @@ MissionBlock::set_takeoff_item(struct mission_item_s *item, float abs_altitude)
 	item->altitude = abs_altitude;
 	item->altitude_is_relative = false;
 
+	item->acceptance_radius = _navigator->get_acceptance_radius();
 	item->loiter_radius = _navigator->get_loiter_radius();
 	item->autocontinue = false;
 	item->origin = ORIGIN_ONBOARD;


### PR DESCRIPTION
## Describe the problem solved by this pull request
VTOL takeoff depending on how the vehicle was landed before would not work properly. The tricky part is that even though the issue showed up pretty often after an update on one of our models used in its typical workflow I was never able to reproduce the root cause SITL. Also, the Symptom is flaky but most of the time it would not take off at all, get stuck during the initial ascent or even descend again somewhere in the middle of the ascent.

## Describe your solution
I was able to find the combination of all the in-between problems and two of them I'm fixing in this pr. That doesn't give us a guarantee for any related problem ever occurring again but I'm fairly confident it increases robustness.

### What I cannot explain:
- The global field `_mission_item.acceptance_radius` in navigator in some way got a value close to zero but just not zero e.g. 3e-38 after a certain mission flight/landing procedure (not directly after boot). My best guess is that the field gets reinitialized with zero in some place in navigator and for float arithmetics reason on the MCU this is interpreted as not exactly zero. I don't see how float has 10^-38 accuracy but other fields that are exactly zero show as exactly zero in the log.
![image](https://user-images.githubusercontent.com/4668506/188593120-248c3e76-d9ea-4360-a784-d6d61d6c7ba9.png)
Also in most places the acceptance radius gets set to the default value e.g. in the global `reset_position_setpoint()` function:
https://github.com/PX4/PX4-Autopilot/blob/92fbd86b463dabd4c1ff0e4cec5c4205dec402f5/src/modules/navigator/navigator_main.cpp#L1067
I was not able to reproduce this in SITL presumably because of different float arithmetic.

### What is easily reproducible:
- The `MissionBlock::set_takeoff_item()` did not overwrite the acceptance radius with the default: https://github.com/PX4/PX4-Autopilot/blob/92fbd86b463dabd4c1ff0e4cec5c4205dec402f5/src/modules/navigator/mission_block.cpp#L747
like other `set_XX_item()` do e.g. land https://github.com/PX4/PX4-Autopilot/blob/92fbd86b463dabd4c1ff0e4cec5c4205dec402f5/src/modules/navigator/mission_block.cpp#L796
so I added this in 64ffe93a6f044a5bc40ec801554d37c3c1f4ec33
- This value gets accepted as a proper custom acceptance radius because it's even just slightly positive in the check here:
https://github.com/PX4/PX4-Autopilot/blob/92fbd86b463dabd4c1ff0e4cec5c4205dec402f5/src/modules/navigator/mission_block.cpp#L626 so I increased the threshold for a minimal acceptance radius to 1mm (0.001m) in 0033384bf6bd1b1e37f3c4e944c7b876010e80fd
I'm not sure what we need custom acceptance radiuses for at all but it's defined in MAVLink message for waypoints: https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT
- This almost zero acceptance radius gets published as `position_setpoint_triplet.current.acceptance_radius` and intepreted in `FlightTaskAuto` and the biggest problem with that is the condition to check for the `previous_infront` state here: https://github.com/PX4/PX4-Autopilot/blob/92fbd86b463dabd4c1ff0e4cec5c4205dec402f5/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp#L643
We have to evalueate what this is for exactly but the result of a too small acceptance radius is that every time the previous waypoint is close to the vehicle position which often is explicitly the case when there is no previous waypoint in the triplet then the `previous_infront` state is entered in a flaky way and can cause the vehicle to not take off at all, get stuck at some altitude or even start descending again.

## Describe possible alternatives
Mid-term I'd try to get away from:
- global navigator state - that can lead to all kinds of outcomes depending on the order things are executed
- custom acceptance radiuses - we should have proper path following with a progress of execution and no need for an acceptance radius to jump to continuation
- FlightTaskAuto `offtrack`, `target_behind`, `previous_infront` internal state - those are for special case handling to find back to the path but often lead to strange flight behavior if enabled in the wrong moment

All these defects lead to problems like the one solved by this pr.

## Test data / coverage
I went through the various scenarios of small and zero acceptance radius in SITL, that's also how I found out about big part of the problem and the fixes.
This exact change was tested on the real vehicle that originally had the issues and with this it didn't happen again.