### PR TITLE
Geofence: add GF_ENFORCE

### DIFF
--- a/msg/geofence_result.msg
+++ b/msg/geofence_result.msg
@@ -8,5 +8,5 @@ uint8 GF_ACTION_LAND = 5        # switch to AUTO|LAND
 
 bool geofence_violated          # true if the geofence is violated
 uint8 geofence_action           # action to take when geofence is violated
-
+bool enforce                    # true if geofence_action is enforced until geofence_violated is false
 bool home_required              # true if the geofence requires a valid home position

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -99,6 +99,7 @@ bool in_transition_to_fw # True if VTOL is doing a transition from MC to FW
 
 bool mission_failure # Set to true if mission could not continue/finish
 bool geofence_violated
+bool geofence_enforced
 
 # MAVLink identification
 uint8 system_type  # system type, contains mavlink MAV_TYPE

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -120,6 +120,10 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 
 	transition_result_t ret = TRANSITION_DENIED;
 
+	if (status.geofence_enforced) {
+		return ret;
+	}
+
 	/* transition may be denied even if the same state is requested because conditions may have changed */
 	switch (new_main_state) {
 	case commander_state_s::MAIN_STATE_MANUAL:

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -140,6 +140,7 @@ public:
 
 	int getSource() { return _param_gf_source.get(); }
 	int getGeofenceAction() { return _param_gf_action.get(); }
+	int getGeofenceEnforce() { return _param_gf_enforce.get(); }
 
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
 	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
@@ -223,6 +224,7 @@ private:
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_gf_max_ver_dist,
-		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict
+		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict,
+		(ParamBool<px4::params::GF_ENFORCE>)       _param_gf_enforce
 	)
 };

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -138,3 +138,13 @@ PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
  * @group Geofence
  */
 PARAM_DEFINE_INT32(GF_PREDICT, 1);
+
+/**
+ * Prevent pilot takeover outside of geofence, and enforce GF_ACTION
+ *
+ * true if geofence_action is enforced until geofence_violated is false
+ *
+ * @boolean
+ * @group Geofence
+ */
+PARAM_DEFINE_INT32(GF_ENFORCE, 0);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -860,6 +860,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		_geofence_result.timestamp = hrt_absolute_time();
 		_geofence_result.geofence_action = _geofence.getGeofenceAction();
 		_geofence_result.home_required = _geofence.isHomeRequired();
+		_geofence_result.enforce = _geofence.getGeofenceEnforce();
 
 		if (gf_violation_type.value) {
 			/* inform other apps via the mission result */


### PR DESCRIPTION
## Describe problem solved by this pull request
This adds the GF_ENFORCE parameter to prevent operators from overriding GF_ACTION outside the geofence.

## Describe your solution
This passes the GF_ENFORCE param accessible in the navigator via the geofence_result to the commander. 
This also adds a field to vehicle_status to indicate when the geofence_enforce is enabled to prevent the commander from switching modes. This is accomplished by preventing the the commander's main_state_transition from switching modes when gf_enforced is set in the vehicle_status

## Describe possible alternatives
This will need to be adapted to https://github.com/PX4/PX4-Autopilot/pull/20172
or I can update that PR to add these changes

## Test data / coverage
Tested with sitl setting  hold and return modes and attempting to switch modes outside the geofence rejects flight mode changes. 
