### PR TITLE
Update CI files to use the main branches.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Checks
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,7 +3,7 @@ name: Clang Tidy
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -3,7 +3,7 @@ name: Linux Targets
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -3,7 +3,7 @@ name: Linux ARM64 Targets
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -3,7 +3,7 @@ name: MacOS build
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -3,7 +3,7 @@ name: Nuttx Targets
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -3,7 +3,7 @@ name: Deploy metadata for all targets
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     - 'release/*'
     - 'pr-metadata-test'
 

--- a/.github/workflows/mavros_mission_tests.yml
+++ b/.github/workflows/mavros_mission_tests.yml
@@ -3,7 +3,7 @@ name: MAVROS Mission Tests
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/mavros_offboard_tests.yml
+++ b/.github/workflows/mavros_offboard_tests.yml
@@ -3,7 +3,7 @@ name: MAVROS Offboard Tests
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -3,7 +3,7 @@ name: Metadata
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     - 'release/*'
     - 'pr-metadata-test'
 

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -3,7 +3,7 @@ name: Python CI Checks
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/sitl_tests.yml
+++ b/.github/workflows/sitl_tests.yml
@@ -3,7 +3,7 @@ name: SITL Tests
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
   pull_request:
     branches:
     - '*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       dist: xenial
       # In order to stay under the coverity rate limit, we only run this weekly
       # and not on push which is configured in travis-ci settings.
-      if: branch = master
+      if: branch = main
 
 before_install:
     - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -297,10 +297,10 @@ pipeline {
             sh('make distclean; git clean -ff -x -d .')
             withCredentials([usernamePassword(credentialsId: 'px4buildbot_github_personal_token', passwordVariable: 'GIT_PASS', usernameVariable: 'GIT_USER')]) {
               sh("git clone https://${GIT_USER}:${GIT_PASS}@github.com/PX4/px4_msgs.git")
-              // 'master' branch
+              // 'main' branch
               sh('./msg/tools/uorb_to_ros_msgs.py msg/ px4_msgs/msg/')
               sh('cd px4_msgs; git status; git add .; git commit -a -m "Update message definitions `date`" || true')
-              sh('cd px4_msgs; git push origin master || true')
+              sh('cd px4_msgs; git push origin main || true')
               // 'ros1' branch
               sh('cd px4_msgs; git checkout ros1')
               sh('./msg/tools/uorb_to_ros_msgs.py msg/ px4_msgs/msg/')


### PR DESCRIPTION
## Describe problem solved by this pull request
Some of the CI files still point to the `master` branch instead of the up-to-date `main` branch. This points the CI to the correct `main` branch. This also fixes the issues where the update to `px4_msgs` was still using the old `master` branch instead of the current `main` branch.

## Describe your solution
Replace `master` branch with `main` where appropriate.
