### PR TITLE
px4_userspace_init: Fix NULL dereference for px4_spi_buses in user space

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_userspace_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_userspace_init.cpp
@@ -40,6 +40,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/parameters/param.h>
 #include <px4_platform_common/px4_work_queue/WorkQueueManager.hpp>
+#include <px4_platform_common/spi.h>
 #include <uORB/uORB.h>
 #include <sys/boardctl.h>
 
@@ -48,6 +49,8 @@ extern void cdcacm_init(void);
 extern "C" void px4_userspace_init(void)
 {
 	hrt_init();
+
+	px4_set_spi_buses_from_hw_version();
 
 	px4::WorkQueueManagerStart();
 


### PR DESCRIPTION
For targets that define the SPI buses via px4_spi_buses_all_hw, a call to px4_set_spi_buses_from_hw_version() is needed. Otherwise a NULL de-reference will occur when trying to access px4_spi_buses.

## Describe problem solved by this pull request
Fixes a system crash in px4_fmu-v5_protected:
up_assert: Assertion failed at file:armv7-m/arm_memfault.c line: 101 task: wq:lp_default

## Test data / coverage
px4_fmu-v5_protected
