### PR TITLE
modules/dataman: Increase stack size by 100B

### DIFF
--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -58,7 +58,7 @@ __BEGIN_DECLS
 __EXPORT int dataman_main(int argc, char *argv[]);
 __END_DECLS
 
-static constexpr int TASK_STACK_SIZE = 1220;
+static constexpr int TASK_STACK_SIZE = 1320;
 
 /* Private File based Operations */
 static ssize_t _file_write(dm_item_t item, unsigned index, const void *buf, size_t count);


### PR DESCRIPTION
## Describe problem solved by this pull request
Fixes:
WARN  [load_mon] dataman low on stack! (276 bytes left)

Seen on px4_fmu-v5_protected target.

## Describe your solution
Increase the dataman stack size slightly. I assume the warning threshold is reached if a trap is taken when dataman is in execution (trap entry requires quite a large stack frame). With protected mode every syscall traps via SVC so seeing higher stack utilization with this target is more common.

## Test data / coverage
 px4_fmu-v5_protected

## Additional context
Add any other related context or media.
