### PR TITLE
invensense/icm42688p: add extra time for between FIFO Reset command

### DIFF
--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -171,21 +171,9 @@ void ICM42688P::RunImpl()
 
 	case STATE::CONFIGURE:
 		if (Configure()) {
-			// if configure succeeded then start reading from FIFO
-			_state = STATE::FIFO_READ;
-
-			if (DataReadyInterruptConfigure()) {
-				_data_ready_interrupt_enabled = true;
-
-				// backup schedule as a watchdog timeout
-				ScheduleDelayed(100_ms);
-
-			} else {
-				_data_ready_interrupt_enabled = false;
-				ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
-			}
-
-			FIFOReset();
+			// if configure succeeded then reset the FIFO
+			_state = STATE::FIFO_RESET;
+			ScheduleDelayed(1_ms);
 
 		} else {
 			// CONFIGURE not complete
@@ -198,6 +186,24 @@ void ICM42688P::RunImpl()
 			}
 
 			ScheduleDelayed(100_ms);
+		}
+
+		break;
+
+	case STATE::FIFO_RESET:
+
+		_state = STATE::FIFO_READ;
+		FIFOReset();
+
+		if (DataReadyInterruptConfigure()) {
+			_data_ready_interrupt_enabled = true;
+
+			// backup schedule as a watchdog timeout
+			ScheduleDelayed(100_ms);
+
+		} else {
+			_data_ready_interrupt_enabled = false;
+			ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
 		}
 
 		break;

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -165,6 +165,7 @@ private:
 		RESET,
 		WAIT_FOR_RESET,
 		CONFIGURE,
+		FIFO_RESET,
 		FIFO_READ,
 	} _state{STATE::RESET};
 


### PR DESCRIPTION
## Describe the problem solved by this pull request

In roughly 5% of ICM-42688-P we have seen the issue `bad transfer: 1 events` after PX4 reboot. 

After investigating it is discovered that bits **HEADER_ODR_ACCEL** and **HEADER_ODR_GYRO** in the first FIFO Header are set to value 1. 

In the image, it can be seen the value of the first FIFO header is **0x7B** while the second one is 0x78
![Bad FIFO Header](https://user-images.githubusercontent.com/10188706/189126702-0f36d92b-9b27-4dfe-8a32-c75ce5449572.png)

0x7B -> first 2 bits are set to 1 (HEADER_ODR_ACCEL and HEADER_ODR_GYRO)
0x78 -> first 2 bits are set to 0 (HEADER_ODR_ACCEL and HEADER_ODR_GYRO)

## Describe your solution
After adding sleep before `FifoReset()` result was `FIFO empty: 1 events` 
That means FIFO was actually getting restarted but didn't have enough time to finish it, so another sleep was needed for `FifoRestart()`.

The conclusion is that about 5% of IMUs are not fast enough to immediately do config and FIFO flush. 
Unfortunately, there is nothing in the ICM-42688-P datasheet about wait time after config and FIFO reset, but there is something about it in the older generation of IMU. 

For Invensense MPU-6000 it says this:
![image](https://user-images.githubusercontent.com/10188706/189128783-12477f36-5c35-489f-a2dc-b1a32ddb2398.png)

SIGNAL_PATH_RESET -> is the same register we use for the FIFO reset. 

After adding **1ms sleep** ICM-42688-P started responding properly with no errors after reboot. 

Some more illustrations:
![fifo_flush_issue](https://user-images.githubusercontent.com/10188706/189129372-0a53f06a-0496-4362-9bdd-1dd49c1bd8a2.png)


