### PR TITLE
cmake/metadata.cmake: metadata_extract_events limit to PX4_SRC_FILES

### DIFF
--- a/cmake/metadata.cmake
+++ b/cmake/metadata.cmake
@@ -33,6 +33,8 @@
 
 # Metadata - helpers for generating documentation
 
+get_property(all_px4_src_files GLOBAL PROPERTY PX4_SRC_FILES)
+
 add_custom_target(metadata_airframes
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/docs
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
@@ -100,7 +102,7 @@ set(events_src_path "${PX4_SOURCE_DIR}/src/lib/events")
 add_custom_target(metadata_extract_events
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/events
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_events.py
-		--src-path ${PX4_SOURCE_DIR}/src
+		--src-path ${all_px4_src_files}
 		--json ${PX4_BINARY_DIR}/events/px4_full.json #--verbose
 	COMMAND ${PYTHON_EXECUTABLE} ${events_src_path}/libevents/scripts/combine.py
 		${PX4_BINARY_DIR}/events/px4_full.json
@@ -112,6 +114,7 @@ add_custom_target(metadata_extract_events
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/compress.py
 		${PX4_BINARY_DIR}/events/all_events_full.json
 	COMMENT "Extracting events from full source"
+	DEPENDS px4 # ensure all generated source files exist
 	USES_TERMINAL
 )
 


### PR DESCRIPTION
 - otherwise metadata_extract_events fails on events in functional tests (px4_add_functional_gtest)

``` Console

$ make extract_events 
[0/2] Extracting events from full source
Exception while parsing file /home/dagar/git/PX4-Autopilot/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
Exception in file /home/dagar/git/PX4-Autopilot/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
Traceback (most recent call last):
  File "/home/dagar/git/PX4-Autopilot/Tools/px_process_events.py", line 102, in <module>
    main()
  File "/home/dagar/git/PX4-Autopilot/Tools/px_process_events.py", line 89, in main
    if not scanner.ScanDir(src_paths, parser):
  File "/home/dagar/git/PX4-Autopilot/Tools/px4events/srcscanner.py", line 28, in ScanDir
    if not self.ScanFile(path, parser):
  File "/home/dagar/git/PX4-Autopilot/Tools/px4events/srcscanner.py", line 49, in ScanFile
    return parser.Parse(contents)
  File "/home/dagar/git/PX4-Autopilot/Tools/px4events/srcparser.py", line 170, in Parse
    assert 'events::ID(' not in line or line.startswith('//'), \
AssertionError: unmatched 'events::ID(' found in line 'events::ID("arming_test_basic_fail_all_modes_fail1"), events::Log::Info, "");'
[0/2] Generating git version header
FAILED: CMakeFiles/metadata_extract_events /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/CMakeFiles/metadata_extract_events 
cd /home/dagar/git/PX4-Autopilot/build/px4_sitl_default && /home/dagar/.local/lib/python3.8/site-packages/cmake/data/bin/cmake -E make_directory /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/events && /usr/bin/python3 /home/dagar/git/PX4-Autopilot/Tools/px_process_events.py --src-path /home/dagar/git/PX4-Autopilot/src --json /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/events/px4_full.json && /usr/bin/python3 /home/dagar/git/PX4-Autopilot/src/lib/events/libevents/scripts/combine.py /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/events/px4_full.json /home/dagar/git/PX4-Autopilot/src/lib/events/libevents/events/common.json /home/dagar/git/PX4-Autopilot/src/lib/events/enums.json --output /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/events/all_events_full.json && /usr/bin/python3 /home/dagar/git/PX4-Autopilot/src/lib/events/libevents/scripts/validate.py /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/events/all_events_full.json && /usr/bin/python3 /home/dagar/git/PX4-Autopilot/Tools/compress.py /home/dagar/git/PX4-Autopilot/build/px4_sitl_default/events/all_events_full.json
[2/2] Generating git version header
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:232: px4_sitl_default] Error 1
make: *** [Makefile:360: extract_events] Error 2
```

Is this the correct fix or do we want to include HealthAndArmingChecksTest events (eg events::ID("arming_test_basic_fail_all_modes_fail1")) in `make extract_events`?