### PR TITLE
logger: new optional start delay time (SDLOG_DELAY_S)

### DIFF
--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -61,6 +61,8 @@ __BEGIN_DECLS
  */
 typedef uint64_t	hrt_abstime;
 
+#define HRT_ABSTIME_INVALID UINT64_MAX
+
 /**
  * Callout function type.
  *

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -332,6 +332,8 @@ private:
 	bool						_manually_logging_override{false};
 	bool						_start_immediately{false};
 
+	hrt_abstime                                     _start_requested_time{HRT_ABSTIME_INVALID};
+
 	Statistics					_statistics[(int)LogType::Count];
 	hrt_abstime					_last_sync_time{0}; ///< last time a sync msg was sent
 
@@ -381,7 +383,8 @@ private:
 		(ParamInt<px4::params::SDLOG_PROFILE>) _param_sdlog_profile,
 		(ParamInt<px4::params::SDLOG_MISSION>) _param_sdlog_mission,
 		(ParamBool<px4::params::SDLOG_BOOT_BAT>) _param_sdlog_boot_bat,
-		(ParamBool<px4::params::SDLOG_UUID>) _param_sdlog_uuid
+		(ParamBool<px4::params::SDLOG_UUID>) _param_sdlog_uuid,
+		(ParamInt<px4::params::SDLOG_DELAY_S>) _param_sdlog_delay_s
 #if defined(PX4_CRYPTO)
 		, (ParamInt<px4::params::SDLOG_ALGORITHM>) _param_sdlog_crypto_algorithm,
 		(ParamInt<px4::params::SDLOG_KEY>) _param_sdlog_crypto_key,

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -177,6 +177,17 @@ PARAM_DEFINE_INT32(SDLOG_DIRS_MAX, 0);
 PARAM_DEFINE_INT32(SDLOG_UUID, 1);
 
 /**
+ * Start delay
+ *
+ * Start delay in seconds, only enabled if > 0.
+ *
+ * @unit s
+ * @min 0
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_DELAY_S, 0);
+
+/**
  * Logfile Encryption algorithm
  *
  * Selects the algorithm used for logfile encryption


### PR DESCRIPTION
 - this can be useful when using PX4 as a standalone data logger

Requires https://github.com/PX4/PX4-Autopilot/pull/20193.
