### PR TITLE
logger: limit buffer size to available free memory (NuttX only) 

### DIFF
--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -169,7 +169,8 @@ private:
 	class LogFileBuffer
 	{
 	public:
-		LogFileBuffer(size_t log_buffer_size, perf_counter_t perf_write, perf_counter_t perf_fsync);
+		LogFileBuffer(size_t log_buffer_desired_size, size_t log_buffer_min_size,
+			      perf_counter_t perf_write, perf_counter_t perf_fsync);
 
 		~LogFileBuffer();
 
@@ -203,7 +204,8 @@ private:
 		bool _should_run = false;
 		px4::atomic_bool _had_write_error{false};
 	private:
-		const size_t _buffer_size;
+		size_t _buffer_size;
+		const size_t _buffer_size_min;
 		int	_fd = -1;
 		uint8_t *_buffer = nullptr;
 		size_t _head = 0; ///< next position to write to


### PR DESCRIPTION
This updates logger to automatically limit the buffer size at the time of allocation to available free memory and a 1 kilobyte margin.

I don't love the platform ifdef dropped in the middle of log_writer_file, but this is better than accidentally missing logging and only finding out later.
