### PR TITLE
Revert "px4_fmu-v6c Move I2C 4 to External"

### DIFF
--- a/boards/px4/fmu-v6c/src/i2c.cpp
+++ b/boards/px4/fmu-v6c/src/i2c.cpp
@@ -36,5 +36,5 @@
 constexpr px4_i2c_bus_t px4_i2c_buses[I2C_BUS_MAX_BUS_ITEMS] = {
 	initI2CBusExternal(1),
 	initI2CBusExternal(2),
-	initI2CBusExternal(4),
+	initI2CBusInternal(4),
 };


### PR DESCRIPTION
Reverts PX4/PX4-Autopilot#19949

This is causing issues with the internal mag marked as external. For not it is better to fail starting devices on the connector marked I2C

FYI: @dagar @julianoes @vincentpoont2 