### PR TITLE
Pixhawk 6C external I2C bus hack

### DIFF
--- a/boards/px4/fmu-v6c/init/rc.board_sensors
+++ b/boards/px4/fmu-v6c/init/rc.board_sensors
@@ -11,11 +11,11 @@ bmi055 -G -R 4 -s start
 # Internal SPI bus ICM42688p
 icm42688p -R 6 -s start
 
-# Internal barometer on I2C4
-ms5611 -I -b 4 -a 0x77 start
+# Internal barometer on I2C4 (The same bus is also exposed externally, and therefore marked as external)
+ms5611 -X -b 4 -a 0x77 start
 
-# Internal compass on IMU I2C4
-ist8310 -I -b 4 -a 0xc  start
+# Internal compass on IMU I2C4 (The same bus is also exposed externally, and therefore marked as external)
+ist8310 -X -b 4 -a 0xc  start
 
 # External compass on GPS/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
 ist8310 -X -b 1 -R 10 start

--- a/boards/px4/fmu-v6c/src/board_config.h
+++ b/boards/px4/fmu-v6c/src/board_config.h
@@ -269,6 +269,8 @@
 
 #define PX4_I2C_BUS_MTD      4,5
 
+#define BOARD_OVERRIDE_I2C_DEVICE_EXTERNAL
+
 
 #define BOARD_NUM_IO_TIMERS 5
 

--- a/boards/px4/fmu-v6c/src/i2c.cpp
+++ b/boards/px4/fmu-v6c/src/i2c.cpp
@@ -36,5 +36,5 @@
 constexpr px4_i2c_bus_t px4_i2c_buses[I2C_BUS_MAX_BUS_ITEMS] = {
 	initI2CBusExternal(1),
 	initI2CBusExternal(2),
-	initI2CBusInternal(4),
+	initI2CBusExternal(4),
 };

--- a/boards/px4/fmu-v6c/src/i2c.cpp
+++ b/boards/px4/fmu-v6c/src/i2c.cpp
@@ -33,8 +33,47 @@
 
 #include <px4_arch/i2c_hw_description.h>
 
+#include <lib/drivers/device/Device.hpp>
+#include <px4_platform_common/i2c.h>
+
 constexpr px4_i2c_bus_t px4_i2c_buses[I2C_BUS_MAX_BUS_ITEMS] = {
 	initI2CBusExternal(1),
 	initI2CBusExternal(2),
 	initI2CBusExternal(4),
 };
+
+bool px4_i2c_device_external(const uint32_t device_id)
+{
+	{
+		// The internal baro and mag on Pixhawk 6C are on an external
+		// bus. On rev 0, the bus is actually exposed externally, on
+		// rev 1+, it is properly internal, however, still marked as
+		// external for compatibility.
+
+		// device_id: 4028193
+		device::Device::DeviceId device_id_baro{};
+		device_id_baro.devid_s.bus_type = device::Device::DeviceBusType_I2C;
+		device_id_baro.devid_s.bus = 4;
+		device_id_baro.devid_s.address = 0x77;
+		device_id_baro.devid_s.devtype = DRV_BARO_DEVTYPE_MS5611;
+
+		if (device_id_baro.devid == device_id) {
+			return false;
+		}
+
+		// device_id: 396321
+		device::Device::DeviceId device_id_mag{};
+		device_id_mag.devid_s.bus_type = device::Device::DeviceBusType_I2C;
+		device_id_mag.devid_s.bus = 4;
+		device_id_mag.devid_s.address = 0xc;
+		device_id_mag.devid_s.devtype = DRV_MAG_DEVTYPE_IST8310;
+
+		if (device_id_mag.devid == device_id) {
+			return false;
+		}
+	}
+
+	device::Device::DeviceId dev_id{};
+	dev_id.devid = device_id;
+	return px4_i2c_bus_external(dev_id.devid_s.bus);
+}

--- a/platforms/common/i2c.cpp
+++ b/platforms/common/i2c.cpp
@@ -42,7 +42,17 @@ bool px4_i2c_bus_external(const px4_i2c_bus_t &bus)
 {
 	return bus.is_external;
 }
-#endif
+#endif // BOARD_OVERRIDE_I2C_BUS_EXTERNAL
+
+#ifndef BOARD_OVERRIDE_I2C_DEVICE_EXTERNAL
+#include <drivers/device/Device.hpp>
+bool px4_i2c_device_external(const uint32_t device_id)
+{
+	device::Device::DeviceId dev_id{};
+	dev_id.devid = device_id;
+	return px4_i2c_bus_external(dev_id.devid_s.bus);
+}
+#endif // BOARD_OVERRIDE_I2C_DEVICE_EXTERNAL
 
 bool I2CBusIterator::next()
 {

--- a/platforms/common/include/px4_platform_common/i2c.h
+++ b/platforms/common/include/px4_platform_common/i2c.h
@@ -66,6 +66,11 @@ static inline bool px4_i2c_bus_external(int bus)
 	return true;
 }
 
+/**
+ * runtime-check if a board has a specific device as external.
+ * This can be overridden by a board to add run-time checks.
+ */
+__EXPORT bool px4_i2c_device_external(const uint32_t device_id);
 
 /**
  * @class I2CBusIterator

--- a/src/lib/drivers/device/nuttx/I2C.hpp
+++ b/src/lib/drivers/device/nuttx/I2C.hpp
@@ -108,7 +108,7 @@ protected:
 	 */
 	int		transfer(const uint8_t *send, const unsigned send_len, uint8_t *recv, const unsigned recv_len);
 
-	bool	external() const override { return px4_i2c_bus_external(_device_id.devid_s.bus); }
+	bool	external() const override { return px4_i2c_device_external(_device_id.devid); }
 
 private:
 	static unsigned	int	_bus_clocks[PX4_NUMBER_I2C_BUSES];

--- a/src/lib/drivers/device/posix/I2C.hpp
+++ b/src/lib/drivers/device/posix/I2C.hpp
@@ -104,7 +104,7 @@ protected:
 	 */
 	int		transfer(const uint8_t *send, const unsigned send_len, uint8_t *recv, const unsigned recv_len);
 
-	virtual bool	external() const override { return px4_i2c_bus_external(_device_id.devid_s.bus); }
+	virtual bool	external() const override { return px4_i2c_device_external(_device_id.devid); }
 
 private:
 	int			_fd{-1};

--- a/src/lib/sensor_calibration/Utilities.cpp
+++ b/src/lib/sensor_calibration/Utilities.cpp
@@ -250,7 +250,7 @@ bool DeviceExternal(uint32_t device_id)
 	switch (bus_type) {
 	case device::Device::DeviceBusType_I2C:
 #if defined(CONFIG_I2C)
-		external = px4_i2c_bus_external(id.devid_s.bus);
+		external = px4_i2c_device_external(device_id);
 #endif // CONFIG_I2C
 		break;
 


### PR DESCRIPTION
**This contains two changes:**

1. This swaps the internal baro and mag back to the bus which is both internal an external but configured as external for this case, in the same way as #20151.

2. Also, it adds a hack for fmu-v6c regarding mag calibration: In order for the mag calibration to treat the mag as an internal one, as well as sensors_status_mag and sensors_status_baro to be correct, we need to insert this override to change these two sensors specifically to internal.

FYI @vincentpoont2 

**Tests:**

Mag calibration:
```
...
MAG 396321 EN: 1, offset: [-0.039 -0.009 -0.025], scale: [0.991 1.069 0.981], Internal
```

sensor status topics:
```
nsh> listener sensors_status_mag

TOPIC: sensors_status_mag
 sensors_status_mag
    timestamp: 233004294 (0.008210 seconds ago)
    device_id_primary: 396321 (Type: 0x06, I2C:4 (0x0C))
    device_ids: [396321, 0, 0, 0]
    inconsistency: [0.0000, nan, nan, nan]
    healthy: [True, False, False, False]
    priority: [50, 0, 0, 0]
    enabled: [True, False, False, False]
    external: [False, False, False, False]

nsh> listener sensors_status_baro

TOPIC: sensors_status_baro
 sensors_status_baro
    timestamp: 241376486 (0.003908 seconds ago)
    device_id_primary: 4028193 (Type: 0x3D, I2C:4 (0x77))
    device_ids: [4028193, 0, 0, 0]
    inconsistency: [0.0000, nan, nan, nan]
    healthy: [True, False, False, False]
    priority: [50, 0, 0, 0]
    enabled: [True, False, False, False]
    external: [False, False, False, False]
```