### PR TITLE
Navigator/FW Position Control: VTOL front towards specified transition heading if available

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -871,9 +871,13 @@ FixedwingPositionControl::move_position_setpoint_for_vtol_transition(position_se
 
 		if (!PX4_ISFINITE(_transition_waypoint(0))) {
 			double lat_transition, lon_transition;
-			// create a virtual waypoint HDG_HOLD_DIST_NEXT meters in front of the vehicle which the L1 controller can track
-			// during the transition
-			waypoint_from_heading_and_distance(_current_latitude, _current_longitude, _yaw, HDG_HOLD_DIST_NEXT, &lat_transition,
+
+			// Create a virtual waypoint HDG_HOLD_DIST_NEXT meters in front of the vehicle which the L1 controller can track
+			// during the transition. Use the current yaw setpoint to determine the transition heading, as that one in turn
+			// is set to the transition heading by Navigator, or current yaw if setpoint is not valid.
+			const float transition_heading = PX4_ISFINITE(current_sp.yaw) ? current_sp.yaw : _yaw;
+			waypoint_from_heading_and_distance(_current_latitude, _current_longitude, transition_heading, HDG_HOLD_DIST_NEXT,
+							   &lat_transition,
 							   &lon_transition);
 
 			_transition_waypoint(0) = lat_transition;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -887,7 +887,13 @@ MissionBlock::set_vtol_transition_item(struct mission_item_s *item, const uint8_
 	item->nav_cmd = NAV_CMD_DO_VTOL_TRANSITION;
 	item->params[0] = (float) new_mode;
 	item->params[1] = 0.0f;
-	item->yaw = _navigator->get_local_position()->heading; // ideally that would be course and not heading
+
+	// Keep yaw from previous mission item if valid, as that is containing the transition heading.
+	// If not valid use current yaw as yaw setpoint
+	if (!PX4_ISFINITE(item->yaw)) {
+		item->yaw = _navigator->get_local_position()->heading; // ideally that would be course and not heading
+	}
+
 	item->autocontinue = true;
 }
 


### PR DESCRIPTION
If the current yaw setpoint is valid we should use it to make the transition in this direction. For a VTOL_TAKEOFF the yaw_setpoint is used to specify the transition direction (the vehicle is aligned towards it and then transition is started). The current yaw can be a bit off (e.g. because `MIS_YAW_ERR` is large), and it is better to track the actual setpoint.


## Describe problem solved by this pull request
Ugly front transition when initial yaw error was large and MIS_YAW_ERR is large as well, as then the vehicle starts the transition e.g. 30° off to the desired transition direction while still yawing to achieve it, and then yaws back to track a heading 30° off to the actual desired transition direction. 

## Describe your solution
See above.

## Test data / coverage
SITL tested.

## Additional context
Add any other related context or media.
