### PR TITLE
Advanced Plane Airframe for SITL Advanced Lift-Drag Plugin

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_advanced_plane
@@ -1,0 +1,70 @@
+#!/bin/sh
+#
+# @name Advanced Plane SITL
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+param set-default EKF2_MAG_ACCLIM 0
+param set-default EKF2_MAG_YAWLIM 0
+
+param set-default FW_LND_AIRSPD_SC 1
+param set-default FW_LND_ANG 8
+param set-default FW_THR_LND_MAX 0
+
+param set-default FW_L1_PERIOD 12
+
+param set-default FW_MAN_P_MAX 30
+
+param set-default FW_PSP_OFF 2
+param set-default FW_P_LIM_MAX 32
+param set-default FW_P_LIM_MIN -15
+
+param set-default FW_SPOILERS_LND 0.4
+
+param set-default FW_THR_MIN 0.05
+param set-default FW_THR_TRIM 0.25
+
+param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_SINK_MAX 2.7
+param set-default FW_T_SINK_MIN 2.2
+
+param set-default FW_W_EN 1
+
+param set-default MIS_LTRMIN_ALT 30
+param set-default MIS_TAKEOFF_ALT 30
+
+param set-default NAV_ACC_RAD 15
+param set-default NAV_DLL_ACT 2
+
+param set-default RWTO_TKOFF 1
+
+#param set-default SYS_CTRL_ALLOC 1
+param set-default CA_AIRFRAME 1
+
+param set-default CA_ROTOR_COUNT 1
+param set-default CA_ROTOR0_PX 0.3
+
+param set-default CA_SV_CS_COUNT 6
+param set-default CA_SV_CS0_TRQ_R -0.5
+param set-default CA_SV_CS0_TYPE 1
+param set-default CA_SV_CS1_TRQ_R 0.5
+param set-default CA_SV_CS1_TYPE 2
+param set-default CA_SV_CS2_TRQ_P 1.0
+param set-default CA_SV_CS2_TYPE 3
+param set-default CA_SV_CS3_TRQ_Y 1.0
+param set-default CA_SV_CS3_TYPE 4
+param set-default CA_SV_CS4_TYPE 9
+param set-default CA_SV_CS5_TYPE 10
+param set-default PWM_MAIN_FUNC3 204
+param set-default PWM_MAIN_FUNC4 205
+param set-default PWM_MAIN_FUNC5 101
+param set-default PWM_MAIN_FUNC6 201
+param set-default PWM_MAIN_FUNC7 202
+param set-default PWM_MAIN_FUNC8 203
+param set-default PWM_MAIN_FUNC9 206
+param set-default PWM_MAIN_REV 256
+
+
+set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -61,6 +61,7 @@ px4_add_romfs_files(
 	1036_malolo
 	1037_believer
 	1038_glider
+	1039_advanced_plane
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/src/modules/simulation/simulator_ignition_bridge/SimulatorIgnitionBridge.cpp
+++ b/src/modules/simulation/simulator_ignition_bridge/SimulatorIgnitionBridge.cpp
@@ -76,14 +76,14 @@ int SimulatorIgnitionBridge::init()
 	if (!_model_pose.empty()) {
 		PX4_INFO("Requested Model Position: %s", _model_pose.c_str());
 
-		std::vector<float> model_pose_v;
+		std::vector<double> model_pose_v;
 
 		std::stringstream ss(_model_pose);
 
 		while (ss.good()) {
 			std::string substr;
 			std::getline(ss, substr, ',');
-			model_pose_v.push_back(std::stof(substr));
+			model_pose_v.push_back(std::stod(substr));
 		}
 
 		while (model_pose_v.size() < 6) {

--- a/src/modules/simulation/simulator_ignition_bridge/SimulatorIgnitionBridge.cpp
+++ b/src/modules/simulation/simulator_ignition_bridge/SimulatorIgnitionBridge.cpp
@@ -76,14 +76,14 @@ int SimulatorIgnitionBridge::init()
 	if (!_model_pose.empty()) {
 		PX4_INFO("Requested Model Position: %s", _model_pose.c_str());
 
-		std::vector<double> model_pose_v;
+		std::vector<float> model_pose_v;
 
 		std::stringstream ss(_model_pose);
 
 		while (ss.good()) {
 			std::string substr;
 			std::getline(ss, substr, ',');
-			model_pose_v.push_back(std::stod(substr));
+			model_pose_v.push_back(std::stof(substr));
 		}
 
 		while (model_pose_v.size() < 6) {

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo.cmake
@@ -63,6 +63,7 @@ set(debuggers
 
 set(models
 	none
+	advanced_plane
 	believer
 	boat
 	cloudship


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
The Advanced Lift Drag plugin (https://github.com/PX4/PX4-SITL_gazebo/pull/901) needs an associated airframe to test it with. While there is a model in that pull request, PX4 does not "see" it by default, and will not compile it. 
@Jaeyoung-Lim has previously opened a pull request for this [here](https://github.com/PX4/PX4-Autopilot/pull/20136), and this pull request is quite similar to that one; the changes between the two are the different parameters for the advanced plane airframe, and the change I made to one of the simulation plugins to make sure it compiles.

## Describe your solution
This pull request links the model in the Gazebo pull request to PX4, and adds in a set of parameters that work with it. 

## Describe possible alternatives
There isn't really another solution- a model needs to be added.

## Test data / coverage
To ensure it was reasonably tuned, this model was flown in SITL. The log is here: https://review.px4.io/plot_app?log=3dd859f2-5e6a-4c51-a58f-6abb4829d711
The model is still very responsive in roll and pitch, and the controller overshoots the rates as a result. However, the oscillations @Jaeyoung-Lim observed previously are either nonexistent or much, much smaller (~1 deg/s in pitch rate).

## Additional context
Add any other related context or media.
