### PR TITLE
ekf2: run preflight check when disarmed only

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1002,7 +1002,10 @@ void EKF2::PublishInnovations(const hrt_abstime &timestamp)
 	_estimator_innovations_pub.publish(innovations);
 
 	// calculate noise filtered velocity innovations which are used for pre-flight checking
-	if (!_ekf.control_status_flags().in_air) {
+	vehicle_status_s vehicle_status;
+	_status_sub.copy(&vehicle_status);
+
+	if (vehicle_status.arming_state != vehicle_status_s::ARMING_STATE_ARMED) {
 		// TODO: move to run before publications
 		_preflt_checker.setUsingGpsAiding(_ekf.control_status_flags().gps);
 		_preflt_checker.setUsingFlowAiding(_ekf.control_status_flags().opt_flow);


### PR DESCRIPTION
## Describe problem solved by this pull request
Previously was when not in air and then started to run between landing detection and vehicle disarm. This was then sometimes making the altitude invalid, leading to land detection issues.

## Describe your solution
Run the EKF2 preflight checks when not armed