### PR TITLE
Fixed fastrtps version reading in microRTPS generation

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -212,8 +212,14 @@ else:
             "dpkg -s ros-" + ros2_distro + "-fastrtps 2>/dev/null | grep -i version", shell=True).decode("utf-8").strip()).group(1)
     except subprocess.CalledProcessError:
         # if ROS2 was installed from sources the command above fails, get the system-wide version instead
-        fastrtps_version = subprocess.check_output(
-            "ldconfig -v 2>/dev/null | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
+        try:
+            fastrtps_version = subprocess.check_output(
+                "ldconfig -v 2>/dev/null | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
+        except subprocess.CalledProcessError:
+            # if no system-wide version is found, look for the one provided by the source-installed ROS2
+            fastrtps_path = re.search(r'(?!\:)[^\:]*fastrtps\/lib(?=\:)', os.environ.get('LD_LIBRARY_PATH')).group(0)
+            fastrtps_version = subprocess.check_output(
+                "ls " + fastrtps_path, shell=True).decode("utf-8").strip().split('so.')[-1]
 
 
 # If nothing specified it's generated both


### PR DESCRIPTION
## Describe problem solved by this pull request
If ROS2 is built from source and no system-wise version of `fastrtps` is installed, then the microRTPS generation fails.

## Describe your solution
In the above situation, `LD_LIBRARY_PATH` is used to search for the version provided by ROS2.
First the exact location of the library is retrieved, then its version is extracted.

## Describe possible alternatives
Would it make sense to look first for the version provided by ROS2 and only if it fails then to look for the system-wise version?

## Test data / coverage
Tested on Ubuntu 20.04, ROS2 foxy source installed and no other versions of fastrtps available

## Additional context
This method requires the ROS2 environment to be sourced before compiling.
