### PR TITLE
Board UUID format function wrong memory access bug fix

### DIFF
--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -61,3 +61,5 @@ endif()
 
 add_subdirectory(px4_work_queue)
 add_subdirectory(work_queue)
+
+px4_add_unit_gtest(SRC board_identity_test.cpp LINKLIBS px4_platform)

--- a/platforms/common/board_identity.c
+++ b/platforms/common/board_identity.c
@@ -40,6 +40,12 @@
 #include <px4_platform_common/px4_config.h>
 #include <stdio.h>
 #include <string.h>
+
+/**
+ * For special cases, specific boards may need to override the UUID, instead of using the generic
+ * PX4 GUID (gettable via 'board_get_px4_guid_formated' function). In that case we define the cascaded
+ * UUID function getters to incorporate the overridden UUID into the GUID.
+ */
 #if defined(BOARD_OVERRIDE_UUID) || defined(BOARD_OVERRIDE_MFGUID) || defined(BOARD_OVERRIDE_PX4_GUID)
 static const uint16_t soc_arch_id = PX4_SOC_ARCH_ID;
 static const char board_uuid[17] = BOARD_OVERRIDE_UUID;
@@ -72,11 +78,11 @@ int board_get_uuid32_formated(char *format_buffer, int size,
 	int offset = 0;
 	int sep_size = seperator ? strlen(seperator) : 0;
 
-	for (unsigned i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
+	for (unsigned i = 0; (offset < size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH); i++) {
 		offset += snprintf(&format_buffer[offset], size - offset, format, uuid[i]);
 
-		if (sep_size && i < PX4_CPU_UUID_WORD32_LENGTH - 1) {
-			strcat(&format_buffer[offset], seperator);
+		if (sep_size && (offset < size - sep_size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH - 1)) {
+			strncat(&format_buffer[offset], seperator, size - offset);
 			offset += sep_size;
 		}
 	}

--- a/platforms/common/board_identity_test.cpp
+++ b/platforms/common/board_identity_test.cpp
@@ -1,0 +1,162 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <px4_platform_common/px4_config.h>
+#include <string.h>
+
+/**
+ * @file board_identity_test.cpp
+ * @author Junwoo Hwang <junwoo091400@gmail.com>
+ *
+ * Unit test for checking if board identification string retrieval function works correctly,
+ * and without any unexpected buffer overflows
+ */
+
+/**
+ * @brief Test `board_get_uuid32_formated` function for buffer overflows & correct formatting
+ *
+ * This is a deprecated function that gets used on exceptional cases where "BOARD_OVERRIDE_UUID" is defined.
+ * Which is the case in SITL target as well as few others. In that case, the generic function `board_get_px4_guid_formated`
+ * calls this function to fill out the buffer.
+ *
+ * It should write 16 bytes of UUID for SITL (PX4_CPU_UUID_BYTE_LENGTH depends on target!) in specified format, and if the
+ * buffer has size less than that, the buffer shouldn't overflow, respecting the size argument.
+ *
+ * For example, with the format "02x", which writes each byte in 2-character hexadecimal value, the 16 bytes of UUID
+ * will be written across '33' bytes of buffer, as each UUID byte will use 2 bytes, and NULL terminator will use 1 byte.
+ *
+ * If the buffer overflow occurs, the GCC compiler level will terminate the test with '*** stack smashing detected ***'
+ * message, which should cancel the test
+ *
+ * TODO: Make the test fail properly, instead of getting canceled in stack smashing case
+ */
+TEST(BoardIdentityTest, UUID32BufferOverflow)
+{
+	// Get groundtruth UUID value. Without separator, should require 33 bytes
+	char groundtruth_uuid_no_sep[50];
+	board_get_uuid32_formated(groundtruth_uuid_no_sep, sizeof(groundtruth_uuid_no_sep), "%02x", NULL); // No separator
+	EXPECT_EQ(32, strlen(groundtruth_uuid_no_sep));
+	// Get groundtruth UUID value. With separator, should be 36 bytes
+	char groundtruth_uuid_with_sep[50];
+	board_get_uuid32_formated(groundtruth_uuid_with_sep, sizeof(groundtruth_uuid_with_sep), "%02x", "-"); // With separator
+	EXPECT_EQ(35, strlen(groundtruth_uuid_with_sep));
+
+	// 12 bytes : Shouldn't be enough, but shouldn't also cause buffer overflow
+	// We check : 1. If the function causes buffer overflow | 2. If the buffer gets filled with correct data
+	// Note: Since for `char buf[N]`, the maimum string length is N-1, we give N-1 for `strncmp` function.
+	char buf_12[12];
+	board_get_uuid32_formated(buf_12, sizeof(buf_12), "%02x", NULL); // No separator
+	EXPECT_EQ(0, strncmp(groundtruth_uuid_no_sep, buf_12, sizeof(buf_12) - 1));
+	board_get_uuid32_formated(buf_12, sizeof(buf_12), "%02x", "-"); // With separator
+	EXPECT_EQ(0, strncmp(groundtruth_uuid_with_sep, buf_12, sizeof(buf_12) - 1));
+
+	// 33 bytes: Should be enough for UUID with no separator, but not enough for UUID with separator
+	char buf_33[33];
+	board_get_uuid32_formated(buf_33, sizeof(buf_33), "%02x", NULL); // No separator
+	EXPECT_EQ(0, strncmp(groundtruth_uuid_no_sep, buf_33, sizeof(buf_33) - 1));
+	board_get_uuid32_formated(buf_33, sizeof(buf_33), "%02x", "-"); // With separator
+	EXPECT_EQ(0, strncmp(groundtruth_uuid_with_sep, buf_33, sizeof(buf_33) - 1));
+
+	// 40 bytes: Should be enough for UUID for all cases
+	char buf_40[40];
+	board_get_uuid32_formated(buf_40, sizeof(buf_40), "%02x", NULL); // No separator
+	EXPECT_EQ(0, strncmp(groundtruth_uuid_no_sep, buf_40, sizeof(buf_40) - 1));
+	board_get_uuid32_formated(buf_40, sizeof(buf_40), "%02x", "-"); // With separator
+	EXPECT_EQ(0, strncmp(groundtruth_uuid_with_sep, buf_40, sizeof(buf_40) - 1));
+}
+
+/**
+ * @brief Test `board_get_mfguid_formated` function for buffer overflows & correct formatting
+ *
+ * The size that should be written is PX4_CPU_MFGUID_FORMAT_SIZE, which is usually 33 (like UUID)
+ */
+TEST(BoardIdentityTest, MFGUIDBufferOverflow)
+{
+	// Get groundtruth MFGUID value
+	char groundtruth_mfg_uid[50];
+	board_get_mfguid_formated(groundtruth_mfg_uid, sizeof(groundtruth_mfg_uid));
+
+	// Expect buffer of size PX4_CPU_MFGUID_FORMAT_SIZE, which means string length will be -1 of that.
+	EXPECT_EQ(PX4_CPU_MFGUID_FORMAT_SIZE - 1, strlen(groundtruth_mfg_uid));
+
+	// 12 bytes : Shouldn't be enough, but shouldn't also cause buffer overflow
+	// We check : 1. If the function causes buffer overflow | 2. If the buffer gets filled with correct data
+	// Note: Since for `char buf[N]`, the maimum string length is N-1, we give N-1 for `strncmp` function.
+	char buf_12[12];
+	board_get_mfguid_formated(buf_12, sizeof(buf_12));
+	EXPECT_EQ(0, strncmp(groundtruth_mfg_uid, buf_12, sizeof(buf_12) - 1));
+
+	// 33 bytes: Should be just enough for MFGUID
+	char buf_33[33];
+	board_get_mfguid_formated(buf_33, sizeof(buf_33));
+	EXPECT_EQ(0, strncmp(groundtruth_mfg_uid, buf_33, sizeof(buf_33) - 1));
+
+	// 40 bytes: Should be enough for MFGUID
+	char buf_40[40];
+	board_get_mfguid_formated(buf_40, sizeof(buf_40));
+	EXPECT_EQ(0, strncmp(groundtruth_mfg_uid, buf_40, sizeof(buf_40) - 1));
+}
+
+/**
+ * @brief Test `board_get_px4_guid_formated` function for buffer overflows & correct formatting
+ *
+ * The size that needs to be written is PX4_GUID_FORMAT_SIZE, which includes the NULL
+ * termination character into account, which is usually 33.
+ */
+TEST(BoardIdentityTest, PX4GUIDBufferOverflow)
+{
+	// Get groundtruth PX4 GUID value with enough buffer (minimum 32 + 1)
+	char groundtruth_px4_guid[50];
+	board_get_px4_guid_formated(groundtruth_px4_guid, sizeof(groundtruth_px4_guid));
+
+	// Expect buffer of size PX4_GUID_FORMAT_SIZE, which means string length will be -1 of that.
+	EXPECT_EQ(PX4_GUID_FORMAT_SIZE - 1, strlen(groundtruth_px4_guid));
+
+	// 12 bytes : Shouldn't be enough, but shouldn't also cause buffer overflow
+	// We check : 1. If the function causes buffer overflow | 2. If the buffer gets filled with correct data
+	// Note: Since for `char buf[N]`, the maimum string length is N-1, we give N-1 for `strncmp` function.
+	char buf_12[12];
+	board_get_px4_guid_formated(buf_12, sizeof(buf_12));
+	EXPECT_EQ(0, strncmp(groundtruth_px4_guid, buf_12, sizeof(buf_12) - 1));
+
+	// 33 bytes: Should be just enough for PX4 GUID
+	char buf_33[33];
+	board_get_px4_guid_formated(buf_33, sizeof(buf_33));
+	EXPECT_EQ(0, strncmp(groundtruth_px4_guid, buf_33, sizeof(buf_33) - 1));
+
+	// 40 bytes: Should be enough for PX4 GUID
+	char buf_40[40];
+	board_get_px4_guid_formated(buf_40, sizeof(buf_40));
+	EXPECT_EQ(0, strncmp(groundtruth_px4_guid, buf_40, sizeof(buf_40) - 1));
+}

--- a/platforms/common/include/px4_platform_common/board_common.h
+++ b/platforms/common/include/px4_platform_common/board_common.h
@@ -946,7 +946,7 @@ int board_get_mfguid_formated(char *format_buffer, int size); // DEPRICATED use 
 int board_get_px4_guid(px4_guid_t guid);
 
 /************************************************************************************
- * Name: board_get_mfguid_formated
+ * Name: board_get_px4_guid_formated
  *
  * Description:
  *   All boards either provide a way to retrieve a formatted string of the

--- a/platforms/nuttx/src/px4/nxp/imxrt/version/board_identity.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/version/board_identity.c
@@ -100,15 +100,14 @@ int board_get_uuid32_formated(char *format_buffer, int size,
 {
 	uuid_uint32_t uuid;
 	board_get_uuid32(uuid);
-
 	int offset = 0;
 	int sep_size = seperator ? strlen(seperator) : 0;
 
-	for (unsigned int i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
-		offset += snprintf(&format_buffer[offset], size - ((i * 2 * sizeof(uint32_t)) + 1), format, uuid[i]);
+	for (unsigned i = 0; (offset < size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH); i++) {
+		offset += snprintf(&format_buffer[offset], size - offset, format, uuid[i]);
 
-		if (sep_size && i < PX4_CPU_UUID_WORD32_LENGTH - 1) {
-			strcat(&format_buffer[offset], seperator);
+		if (sep_size && (offset < size - sep_size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH - 1)) {
+			strncat(&format_buffer[offset], seperator, size - offset);
 			offset += sep_size;
 		}
 	}

--- a/platforms/nuttx/src/px4/nxp/kinetis/version/board_identity.c
+++ b/platforms/nuttx/src/px4/nxp/kinetis/version/board_identity.c
@@ -71,15 +71,14 @@ int board_get_uuid32_formated(char *format_buffer, int size,
 {
 	uuid_uint32_t uuid;
 	board_get_uuid32(uuid);
-
 	int offset = 0;
 	int sep_size = seperator ? strlen(seperator) : 0;
 
-	for (unsigned int i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
-		offset += snprintf(&format_buffer[offset], size - ((i * 2 * sizeof(uint32_t)) + 1), format, uuid[i]);
+	for (unsigned i = 0; (offset < size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH); i++) {
+		offset += snprintf(&format_buffer[offset], size - offset, format, uuid[i]);
 
-		if (sep_size && i < PX4_CPU_UUID_WORD32_LENGTH - 1) {
-			strcat(&format_buffer[offset], seperator);
+		if (sep_size && (offset < size - sep_size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH - 1)) {
+			strncat(&format_buffer[offset], seperator, size - offset);
 			offset += sep_size;
 		}
 	}

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/version/board_identity.c
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/version/board_identity.c
@@ -71,15 +71,14 @@ int board_get_uuid32_formated(char *format_buffer, int size,
 {
 	uuid_uint32_t uuid;
 	board_get_uuid32(uuid);
-
 	int offset = 0;
 	int sep_size = seperator ? strlen(seperator) : 0;
 
-	for (unsigned int i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
-		offset += snprintf(&format_buffer[offset], size - ((i * 2 * sizeof(uint32_t)) + 1), format, uuid[i]);
+	for (unsigned i = 0; (offset < size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH); i++) {
+		offset += snprintf(&format_buffer[offset], size - offset, format, uuid[i]);
 
-		if (sep_size && i < PX4_CPU_UUID_WORD32_LENGTH - 1) {
-			strcat(&format_buffer[offset], seperator);
+		if (sep_size && (offset < size - sep_size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH - 1)) {
+			strncat(&format_buffer[offset], seperator, size - offset);
 			offset += sep_size;
 		}
 	}

--- a/platforms/nuttx/src/px4/rpi/rpi_common/version/board_identity.c
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/version/board_identity.c
@@ -65,11 +65,11 @@ int board_get_uuid32_formated(char *format_buffer, int size,
 	int offset = 0;
 	int sep_size = seperator ? strlen(seperator) : 0;
 
-	for (unsigned i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
+	for (unsigned i = 0; (offset < size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH); i++) {
 		offset += snprintf(&format_buffer[offset], size - offset, format, uuid[i]);
 
-		if (sep_size && i < PX4_CPU_UUID_WORD32_LENGTH - 1) {
-			strcat(&format_buffer[offset], seperator);
+		if (sep_size && (offset < size - sep_size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH - 1)) {
+			strncat(&format_buffer[offset], seperator, size - offset);
 			offset += sep_size;
 		}
 	}

--- a/platforms/nuttx/src/px4/stm/stm32_common/version/board_identity.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/version/board_identity.c
@@ -89,11 +89,11 @@ int board_get_uuid32_formated(char *format_buffer, int size,
 	int offset = 0;
 	int sep_size = seperator ? strlen(seperator) : 0;
 
-	for (unsigned i = 0; i < PX4_CPU_UUID_WORD32_LENGTH; i++) {
+	for (unsigned i = 0; (offset < size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH); i++) {
 		offset += snprintf(&format_buffer[offset], size - offset, format, uuid[i]);
 
-		if (sep_size && i < PX4_CPU_UUID_WORD32_LENGTH - 1) {
-			strcat(&format_buffer[offset], seperator);
+		if (sep_size && (offset < size - sep_size - 1) && (i < PX4_CPU_UUID_WORD32_LENGTH - 1)) {
+			strncat(&format_buffer[offset], seperator, size - offset);
 			offset += sep_size;
 		}
 	}


### PR DESCRIPTION
## How it was discovered
From #20036, it utilizes the `board_get_px4_guid_formated` function for filling in `uas_id` for OPEN DRONE ID MAVLink message, like [here](https://github.com/PX4/PX4-Autopilot/pull/20036/files#diff-9df698b07008acc1a7b23a558fb96d819a88ac3e378bf34602fe5f23a3efe809R163).

This led to the ['Standard VTOL w/ build type AddressSanitizer'](https://github.com/PX4/PX4-Autopilot/blob/main/.github/workflows/sitl_tests.yml#L19) SITL test to fail with Stack Buffer Overflow, as shown below in 'Cause' section.

You can reproduce this bug via:
1. Checkout your branch to the one in #20036 
2. Build SITL with AddressSanitizer enabled: `PX4_ASAN=1 make px4_sitl gazebo HEADLESS=1`
3. The stack overflow error will occur shortly after the SITL starts

### Cause
`board_get_uuid32_formated` function didn't respect the `size` argument, and called `snprintf` function at the offset bigger than the `size`, which triggered the wrong memory access error.

![SanitizerOutput](https://user-images.githubusercontent.com/23277211/188935923-94764587-a6f1-4947-a3a4-1010b48f2b46.PNG)

### Reason
Although this function is depreciated and rarely used, it does get called when the board target has "BOARD_OVERRIDE_UUID" defined in it's `board_config.h`, and the `board_get_px4_guid_formated` gets called.

![Board_UUID_MemoryWrongAccess_DebugResult](https://user-images.githubusercontent.com/23277211/188935950-486ec0d9-2ec6-45d9-85d2-46d4d685e934.PNG)

For SITL few other targets listed below, this was the case, and we then don't stick to the generic global PX4 GUID format (which can be retrieved by the same function `board_get_px4_guid_formated`, but it sticks to the 18 bytes length specification), but rather uses the cascaded function structure that triggers the ill-coded `board_get_uuid32_formated`, located inside `platforms/common/board_identity.c`.

### Affected Targets
Any targets with `BOARD_OVERRIDE_UUID` defined are affected by this bug. Calling any of the board identity ID formatter function on any of these targets would have caused the buffer overflow. 
- Beaglebone Blue
- Emlid Navio 2
- Raspbery Pi
- Scumaker Pilotpi

## Describe your solution
1. Added index sanity checks to make sure we don't go over the buffer's size
4. Added unit test to detect buffer overflow & correct formatting for size-constrained buffers

## Test data / coverage
Unit test is added in the PR

## Additional context
It would be nice to have the stack smashing error being reported as "Buffer overflow" error in the unit test itself (currently the test just aborts, as the error is coming from lower level than the testing framework. Any ideas on this? @dagar 

This should go in to `main` before #20036, to prevent the CI failure mentioned in the beginning.