### PR TITLE
RTL: some small fixes for fixed-wing/VTOL

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2734,7 +2734,7 @@ void FixedwingPositionControl::publishOrbitStatus(const position_setpoint_s pos_
 	orbit_status_s orbit_status{};
 	orbit_status.timestamp = hrt_absolute_time();
 	float loiter_radius = pos_sp.loiter_radius;
-	uint8_t loiter_direction = pos_sp.loiter_direction;
+	int8_t loiter_direction = pos_sp.loiter_direction;
 
 	if (fabsf(loiter_radius) < FLT_EPSILON) {
 		loiter_radius = _param_nav_loiter_rad.get();

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -442,6 +442,7 @@ Mission::find_mission_land_start()
 			_landing_start_lon = missionitem.lon;
 			_landing_start_alt = missionitem.altitude_is_relative ?	missionitem.altitude +
 					     _navigator->get_home_position()->alt : missionitem.altitude;
+			_landing_loiter_radius = missionitem.loiter_radius;
 			_land_start_available = true;
 		}
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -96,6 +96,7 @@ public:
 	double get_landing_lat() { return _landing_lat; }
 	double get_landing_lon() { return _landing_lon; }
 	float get_landing_alt() { return _landing_alt; }
+	float get_landing_loiter_rad() { return _landing_loiter_radius; }
 
 	void set_closest_item_as_current();
 
@@ -262,6 +263,8 @@ private:
 	double _landing_lat{0.0};
 	double _landing_lon{0.0};
 	float _landing_alt{0.0f};
+
+	float _landing_loiter_radius{0.f};
 
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -301,6 +301,8 @@ public:
 	double get_mission_landing_lon() { return _mission.get_landing_lon(); }
 	float  get_mission_landing_alt() { return _mission.get_landing_alt(); }
 
+	float get_mission_landing_loiter_radius() { return _mission.get_landing_loiter_rad(); }
+
 	// RTL
 	bool mission_landing_required() { return _rtl.get_rtl_type() == RTL::RTL_TYPE_MISSION_LANDING; }
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -371,11 +371,20 @@ void RTL::set_rtl_item()
 		}
 
 	case RTL_STATE_RETURN: {
-			// Don't change altitude.
-			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+
+			// For FW flight:set to LOITER_TIME (with 0s loiter time), such that the loiter (orbit) status
+			// can be displayed on groundstation and the WP is accepted once within loiter radius
+			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+				_mission_item.nav_cmd = NAV_CMD_LOITER_TIME_LIMIT;
+				_mission_item.loiter_radius = landing_loiter_radius;
+
+			} else {
+				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			}
+
 			_mission_item.lat = _destination.lat;
 			_mission_item.lon = _destination.lon;
-			_mission_item.altitude = _rtl_alt;
+			_mission_item.altitude = _rtl_alt; // Don't change altitude
 			_mission_item.altitude_is_relative = false;
 
 			if (rtl_heading_mode == RTLHeadingMode::RTL_NAVIGATION_HEADING &&

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -376,7 +376,7 @@ void RTL::set_rtl_item()
 			// can be displayed on groundstation and the WP is accepted once within loiter radius
 			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
 				_mission_item.nav_cmd = NAV_CMD_LOITER_TIME_LIMIT;
-				_mission_item.loiter_radius = landing_loiter_radius;
+
 
 			} else {
 				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
@@ -404,6 +404,7 @@ void RTL::set_rtl_item()
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
+			_mission_item.loiter_radius = landing_loiter_radius;
 
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above destination)\t",
 					 (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - _destination.alt));
@@ -434,14 +435,11 @@ void RTL::set_rtl_item()
 				_mission_item.yaw = _destination.yaw;
 			}
 
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-				_mission_item.loiter_radius = landing_loiter_radius;
-			}
-
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
+			_mission_item.loiter_radius = landing_loiter_radius;
 
 			// Disable previous setpoint to prevent drift.
 			pos_sp_triplet->previous.valid = false;
@@ -481,14 +479,11 @@ void RTL::set_rtl_item()
 				_mission_item.yaw = _destination.yaw;
 			}
 
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-				_mission_item.loiter_radius = landing_loiter_radius;
-			}
-
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = max(_param_rtl_land_delay.get(), 0.0f);
 			_mission_item.autocontinue = autocontinue;
 			_mission_item.origin = ORIGIN_ONBOARD;
+			_mission_item.loiter_radius = landing_loiter_radius;
 
 			_navigator->set_can_loiter_at_sp(true);
 

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -159,7 +159,6 @@ private:
 	hrt_abstime _destination_check_time{0};
 
 	float _rtl_alt{0.0f};	// AMSL altitude at which the vehicle should return to the home position
-	float _rtl_loiter_rad{50.0f};		// radius at which a fixed wing would loiter while descending
 
 	bool _rtl_alt_min{false};
 	bool _should_engange_mission_for_landing{false};


### PR DESCRIPTION
## Describe problem solved by this pull request
- loiter radius and direction of the loiter down in a RTL during a mission landing could differate from loiter radius and direction before mission landing was engaged. 
![image](https://user-images.githubusercontent.com/26798987/190207969-98c85393-fa78-4c3f-a94b-0d68a107fe1f.png)
- loiter (orbits) with negative loiter directions (CCW) were not correctly displayed on the GS
- Orbit status of loiter before landing was not shown until on loiter (as WP wasn't of type Loiter) and vehicle flew through center of loiter down instead of joining it smoothly:
![image](https://user-images.githubusercontent.com/26798987/190206759-fa5d4086-a120-4ee2-ade8-e26cd1f0223b.png)

## Describe your solution
- if RTL is of type RTL_DESTINATION_MISSION_LANDING, then set loiter radius and direction of Descend loiter (where it will descend to RTL_DESCEND_ALT and wait there for RTL_DELAY seconds) to what was set in the mission.
- uint8_t -->int8_t
- for FW flight: already set WP type to LOITER_TO_ALT for state RTL_STATE_RETURN.
![image](https://user-images.githubusercontent.com/26798987/190204502-d76ef7c1-e5ce-4a40-a8fb-c6d358b154ec.png)

## Test data / coverage
SITL (standard VTOL and Plane)

