### PR TITLE
standard: fixed pusher assist in hover

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -125,7 +125,6 @@ void Standard::update_vtol_state()
 			// in mc mode
 			_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 			mc_weight = 1.0f;
-			_pusher_throttle = 0.0f;
 			_reverse_output = 0.0f;
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {


### PR DESCRIPTION
Port of https://github.com/PX4/PX4-Autopilot/pull/19865 to v1.13

Got noticed about it being broken on 1.13 through https://discuss.px4.io/t/pusher-throttle-pulsing-with-vt-fwd-thrust-en/28994
