### PR TITLE
[WIP] Payload delivery MAVSDK SITL Test

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_standard_vtol_drop
@@ -7,12 +7,21 @@
 
 . ${R}etc/init.d-posix/airframes/1040_standard_vtol
 
+# Package delivery feature setup
+param set-default PD_GRIPPER_EN 1 # Enable Gripper
+param set-default COM_PREARM_MODE 2 # Always enable prearm (allows Servo outputs even when disarmed)
+
+# Channel 9 is used for package delivery release mechanism
+param set-default PWM_MAIN_FUNC9 430
+
+# Disable Airspeed check (since it's unreliable, and prevents from starting a mission)
+param set CBRK_AIRSPD_CHK 162128
+
 # Gimbal
-param set-default PWM_MAIN_FUNC9 420
-param set-default PWM_MAIN_FUNC10 421
-param set-default PWM_MAIN_FUNC11 422
+# param set-default PWM_MAIN_FUNC9 420
+# param set-default PWM_MAIN_FUNC10 421
+# param set-default PWM_MAIN_FUNC11 422
 
-param set-default RC_MAP_AUX1 8
-param set-default RC_MAP_AUX2 9
-param set-default RC_MAP_AUX3 10
-
+# param set-default RC_MAP_AUX1 8
+# param set-default RC_MAP_AUX2 9
+# param set-default RC_MAP_AUX3 10

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -239,6 +239,21 @@ void AutopilotTester::prepare_square_mission(MissionOptions mission_options)
 	REQUIRE(_mission->upload_mission(mission_plan) == Mission::Result::Success);
 }
 
+void AutopilotTester::prepare_triangular_mission_with_gripper_item(MissionOptions mission_options)
+{
+	const auto ct = get_coordinate_transformation();
+
+	Mission::MissionPlan mission_plan {};
+	mission_plan.mission_items.push_back(create_mission_item({mission_options.leg_length_m, 0.}, mission_options, ct));
+	mission_plan.mission_items.push_back(create_mission_item({mission_options.leg_length_m, mission_options.leg_length_m},
+					     mission_options, ct));
+	mission_plan.mission_items.push_back(create_mission_item({0., mission_options.leg_length_m}, mission_options, ct));
+
+	_mission->set_return_to_launch_after_mission(mission_options.rtl_at_end);
+
+	REQUIRE(_mission->upload_mission(mission_plan) == Mission::Result::Success);
+}
+
 void AutopilotTester::prepare_straight_mission(MissionOptions mission_options)
 {
 	const auto ct = get_coordinate_transformation();

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -114,6 +114,14 @@ public:
 	void wait_until_altitude(float rel_altitude_m, std::chrono::seconds timeout);
 	void wait_until_speed_lower_than(float speed, std::chrono::seconds timeout);
 	void prepare_square_mission(MissionOptions mission_options);
+
+	/**
+	 * @brief Prepares a Wp 1, Wp 2, Land, DO_GRIPPER, Wp 3 mission to test package delivery via Gripper
+	 *
+	 * The drone should land below Waypoint 2, open the gripper, then take-off again for Waypoint 3
+	 */
+	void prepare_triangular_mission_with_gripper_item(MissionOptions mission_options);
+
 	void prepare_straight_mission(MissionOptions mission_options);
 	void execute_mission();
 	void execute_mission_and_lose_gps();

--- a/test/mavsdk_tests/mission_plans/triangle_gripper_package_delivery.plan
+++ b/test/mavsdk_tests/mission_plans/triangle_gripper_package_delivery.plan
@@ -1,0 +1,105 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": 30,
+                "Altitude": 5,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39791045720388,
+                    8.545593277092053,
+                    5
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 0,
+                "Altitude": 0,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 21,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39775272773859,
+                    8.545153480649049,
+                    0
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 211,
+                "doJumpId": 3,
+                "frame": 2,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 30,
+                "Altitude": 10,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 4,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39757902988248,
+                    8.545586262687607,
+                    10
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            47.398538996176875,
+            8.54554255,
+            483.37876752649856
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}

--- a/test/mavsdk_tests/test_multicopter_mission.cpp
+++ b/test/mavsdk_tests/test_multicopter_mission.cpp
@@ -100,3 +100,23 @@ TEST_CASE("Fly straight Multicopter Mission", "[multicopter]")
 	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);
 }
+
+TEST_CASE("Package delivery during Mission using gripper", "[multicopter]")
+{
+	AutopilotTester tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+
+	AutopilotTester::MissionOptions mission_options;
+	mission_options.rtl_at_end = false;
+	mission_options.fly_through = true;
+	tester.prepare_square_mission(mission_options);
+	tester.check_mission_item_speed_above(2, 4.0);
+	tester.check_tracks_mission(5.f);
+	tester.arm();
+	tester.execute_mission();
+	tester.wait_until_hovering();
+	tester.execute_rtl();
+	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
+	tester.wait_until_disarmed(until_disarmed_timeout);
+}


### PR DESCRIPTION
## Describe problem solved by this pull request
The payload delivery PR #19963 was not testable unless the SITL was executed & proper QGC mission was uploaded & specific `payload_deliverer` module related parameters were set. This PR aims to add the SITL test to automate that process.

## Describe your solution
I am using the raw QGC mission plan to execute the mission. This is because in the MAVSDK Mission interface, DO_GRIPPER type of waypoint isn't supported.

## Describe possible alternatives
It would be nice to actually not have a static mission file, as the PX4 home position may get set to a different value in the future, and then the SITL test would behave irradically (e.g. having home position in Australia when the first waypoint is now at University of Zurich, Irchel campus :rofl:).

But for that I would need to use MAVSDK Mission Raw Interface, which is a bit too raw/complicated. But it would be able to generate a mission around the home position reliably.

## Additional context
There's still an unresolved question on how to setup the parameter for the `payload_deliverer` before the vehicle boots-up, in order to start the module properly. This is addressed in the MAVSDK Issue here: https://github.com/mavlink/MAVSDK/issues/1899