### PR TITLE
simulator_ignition_bridge: add simple esc_status publication

### DIFF
--- a/src/modules/simulation/simulator_ignition_bridge/SimulatorIgnitionBridge.hpp
+++ b/src/modules/simulation/simulator_ignition_bridge/SimulatorIgnitionBridge.hpp
@@ -44,6 +44,7 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/esc_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_accel.h>
 #include <uORB/topics/sensor_gyro.h>
@@ -93,10 +94,12 @@ private:
 	void clockCallback(const ignition::msgs::Clock &clock);
 	void imuCallback(const ignition::msgs::IMU &imu);
 	void poseInfoCallback(const ignition::msgs::Pose_V &pose);
+	void motorSpeedCallback(const ignition::msgs::Actuators &actuators);
 
 	// Subscriptions
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
+	uORB::Publication<esc_status_s>               _esc_status_pub{ORB_ID(esc_status)};
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
 	uORB::Publication<vehicle_attitude_s>         _attitude_ground_truth_pub{ORB_ID(vehicle_attitude_groundtruth)};
 	uORB::Publication<vehicle_global_position_s>  _gpos_ground_truth_pub{ORB_ID(vehicle_global_position_groundtruth)};


### PR DESCRIPTION
 - ideally we'd get this from the actual joint velocity, but this is good enough to start
