### PR TITLE
fix memory leak

### DIFF
--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -1216,8 +1216,7 @@ dataman_main(int argc, char *argv[])
 				}
 
 				backend = BACKEND_FILE;
-				k_data_manager_device_path = strdup(dmoptarg);
-				PX4_INFO("dataman file set to: %s", k_data_manager_device_path);
+				PX4_INFO("dataman file set to: %s", dmoptarg);
 				break;
 
 			case 'r':


### PR DESCRIPTION
## Describe problem solved by this pull request
The copied string is not released, which causing memory leak.

## Describe your solution
Use `dmoptarg` directly in info message.

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.
