### PR TITLE
Enable arbitrary euler angle for Mag rotation

### DIFF
--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -91,8 +91,10 @@ enum Rotation : uint8_t {
 	ROTATION_ROLL_90_PITCH_68_YAW_293 = 38,
 	ROTATION_PITCH_315                = 39,
 	ROTATION_ROLL_90_PITCH_315        = 40,
+	ROTATION_MAX,
 
-	ROTATION_MAX
+	// Rotation Enum reserved for custom rotation using Euler Angles
+	ROTATION_CUSTOM                  = 100
 };
 
 struct rot_lookup_t {

--- a/src/lib/sensor_calibration/Magnetometer.hpp
+++ b/src/lib/sensor_calibration/Magnetometer.hpp
@@ -65,7 +65,20 @@ public:
 	bool set_offset(const matrix::Vector3f &offset);
 	bool set_scale(const matrix::Vector3f &scale);
 	bool set_offdiagonal(const matrix::Vector3f &offdiagonal);
+
+	/**
+	 * @brief Set the rotation enum & corresponding rotation matrix for Magnetometer
+	 *
+	 * @param rotation Rotation enum
+	 */
 	void set_rotation(Rotation rotation);
+
+	/**
+	 * @brief Set the custom rotation matrix & rotation enum to ROTATION_CUSTOM for Magnetometer
+	 *
+	 * @param rot_matrix Rotation matrix (3 x 3)
+	 */
+	void set_custom_rotation(const matrix::Dcmf &rot_matrix);
 
 	bool calibrated() const { return (_device_id != 0) && (_calibration_index >= 0); }
 	uint8_t calibration_count() const { return _calibration_count; }
@@ -103,7 +116,11 @@ public:
 private:
 	Rotation _rotation_enum{ROTATION_NONE};
 
+	/**
+	 * @brief 3 x 3 Rotation matrix that translates from sensor frame (XYZ) to vehicle body frame (FRD)
+	 */
 	matrix::Dcmf _rotation;
+
 	matrix::Vector3f _offset;
 	matrix::Matrix3f _scale;
 	matrix::Vector3f _power_compensation;

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -771,6 +771,10 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 							// FALLTHROUGH
 							case ROTATION_PITCH_180_YAW_270: // skip 27, same as 10 ROTATION_ROLL_180_YAW_90
+
+							// FALLTHROUGH
+							case ROTATION_CUSTOM: // Skip, as we currently don't support detecting arbitrary euler angle orientation
+
 								MSE[r] = FLT_MAX;
 								break;
 
@@ -830,6 +834,11 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 								PX4_INFO("[cal] External Mag: %d (%" PRIu32 "), keeping manually configured rotation %" PRIu8, cur_mag,
 									 worker_data.calibration[cur_mag].device_id(), worker_data.calibration[cur_mag].rotation_enum());
 								continue;
+
+							case ROTATION_CUSTOM:
+								PX4_INFO("[cal] External Mag: %d (%" PRIu32 "), not setting rotation enum since it's specified by Euler Angle",
+									 cur_mag, worker_data.calibration[cur_mag].device_id());
+								continue; // Continue to the next mag loop
 
 							default:
 								break;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -228,7 +228,12 @@ static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_68_YAW_293 == static_cast<MAV_SE
 static_assert(MAV_SENSOR_ROTATION_PITCH_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_PITCH_315), "Pitch: 315");
 static_assert(MAV_SENSOR_ROTATION_ROLL_90_PITCH_315 == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_ROLL_90_PITCH_315),
 	      "Roll: 90, Pitch: 315");
+
+// Note: Update the number (41, as of writing) below to the number of 'normal' rotation enums in MAVLink spec:
+// https://mavlink.io/en/messages/common.html#MAV_SENSOR_ORIENTATION
 static_assert(41 == ROTATION_MAX, "Keep MAV_SENSOR_ROTATION and PX4 Rotation in sync");
+
+static_assert(MAV_SENSOR_ROTATION_CUSTOM == static_cast<MAV_SENSOR_ORIENTATION>(ROTATION_CUSTOM), "Custom Rotation");
 
 
 static const StreamListItem streams_list[] = {

--- a/src/modules/sensors/module.yaml
+++ b/src/modules/sensors/module.yaml
@@ -393,9 +393,46 @@ parameters:
                 38: Roll 90°, Pitch 68°, Yaw 293°
                 39: Pitch 315°
                 40: Roll 90°, Pitch 315°
+                100: Custom Euler Angle
             min: -1
-            max: 40
+            max: 100
             default: -1
+            num_instances: *max_num_sensor_instances
+            instance_start: 0
+
+        CAL_MAG${i}_ROLL:
+            description:
+                short: Magnetometer ${i} Custom Euler Roll Angle
+            category: System
+            type: float
+            default: 0.0
+            min: -180
+            max: 180
+            unit: deg
+            num_instances: *max_num_sensor_instances
+            instance_start: 0
+
+        CAL_MAG${i}_PITCH:
+            description:
+                short: Magnetometer ${i} Custom Euler Pitch Angle
+            category: System
+            type: float
+            default: 0.0
+            min: -180
+            max: 180
+            unit: deg
+            num_instances: *max_num_sensor_instances
+            instance_start: 0
+
+        CAL_MAG${i}_YAW:
+            description:
+                short: Magnetometer ${i} Custom Euler Yaw Angle
+            category: System
+            type: float
+            default: 0.0
+            min: -180
+            max: 180
+            unit: deg
             num_instances: *max_num_sensor_instances
             instance_start: 0
 


### PR DESCRIPTION
## Describe problem solved by this pull request
Previously, the rotations for the magnetometer was confined to MAVLink defined [MAV_SENSOR_ORIENTATION](https://mavlink.io/en/messages/common.html#MAV_SENSOR_ORIENTATION), which doesn't allow setting non 45-degree multiple sensor orientation.

This was a limiting factor for drones with magnetometer that has Magnetometer installed in Euler angles of something like 37 degrees, 58 degrees, etc.

## Describe your solution
Enables setting arbitrary euler angle for magnetometer orientation, which would allow users to set angles like 37 degrees in yaw, which is useful for Alta X for example

### Added parameters
Parameters that defines the Euler angle for the orientation the Magnetometer is at were added:

- CAL_MAG${i}_ROLL
- CAL_MAG${i}_PITCH
- CAL_MAG${i}_YAW

## Describe possible alternatives
Quaternion?

## Test data / coverage
TODO

## TODO
- [ ] Add QGC UI to dynamically visualize this Euler angle setting for custom rotation

## Discussion
Currently, due to bringing in the MAV_SENSOR_ROTATION_CUSTOM enum, which breakes the sequence of numbers, and bumps up the value to 100, the `ROTATION_MAX` can no longer be used to calculate the number of rotations we support in PX4.

You can read more about enum members number count issue [here](https://stackoverflow.com/questions/14989274/is-it-possible-to-determine-the-number-of-elements-of-a-c-enum-class).

Would there be a good solution for this?