### PR TITLE
nuttx/tasks.cpp: Remove direct dependency to kernel private procedures / structures

### DIFF
--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -93,11 +93,5 @@ int px4_task_delete(int pid)
 
 const char *px4_get_taskname(void)
 {
-#if CONFIG_TASK_NAME_SIZE > 0 && (defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT))
-	FAR struct tcb_s	*thisproc = nxsched_self();
-
-	return thisproc->name;
-#else
-	return "app";
-#endif
+	return getprogname();
 }

--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -88,7 +88,18 @@ int px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_
 
 int px4_task_delete(int pid)
 {
-	return task_delete(pid);
+	int ret = OK;
+
+	if (pid == getpid()) {
+		// Commit suicide
+		exit(EXIT_SUCCESS);
+
+	} else {
+		// Politely ask someone else to kill themselves
+		ret = kill(pid, SIGKILL);
+	}
+
+	return ret;
 }
 
 const char *px4_get_taskname(void)


### PR DESCRIPTION
## Describe problem solved by this pull request
Use libc procedures to exit, kill and ask for process name, instead of fiddling around with the tcb directly. The old solution works
with a flat memory model, but not if there is virtualization.

## Describe your solution
Use proper userland functions to exit/kill and acquire process name.

## Describe possible alternatives
None, if virtualization is to be supported

## Test data / coverage
Tested with CONFIG_BUILD_PROTECTED=y for mpfs/icicle target board (unpublished)

## Additional context
This is pre-work to moving towards px4 running as a set of processes with virtualization
