### PR TITLE
vtol_att_control: avoid using non-recent attitude setpoint during beg…

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -152,8 +152,6 @@ public:
 
 	mode get_mode() {return _vtol_mode;}
 
-	bool was_in_trans_mode() {return _flag_was_in_trans_mode;}
-
 	/**
 	 * @return Minimum front transition time scaled for air density (if available) [s]
 	*/


### PR DESCRIPTION
## Describe problem solved by this pull request
When a VTOL transition is triggered it can currently happen that data from non-recent publications of the virtual attitude setpoints are used in the transition code.
This change [here](https://github.com/PX4/PX4-Autopilot/pull/17310) actually forced transition code to run even if neither mc or fw virtual attitude setpoint has updated.
This issue becomes visible when using PlotJuggler to visualize the flight log, see plot below.
![image](https://user-images.githubusercontent.com/7610489/191250511-814319fe-ce7c-4592-b09a-c9e9f13e0688.png)


## Describe your solution
Make sure the we only start to run calculations involving the virtual attitude setpoints once both topics have recent data.

## Describe possible alternatives
Hopefully we can soon get rid of the virtual topics when introducing a new unified rate/attitude controller.

## Test data / coverage
Only SITL

## Additional context
Add any other related context or media.
