### PR TITLE
fmu-v3: make optional sensor startup quiet

### DIFF
--- a/boards/px4/fmu-v3/init/rc.board_sensors
+++ b/boards/px4/fmu-v3/init/rc.board_sensors
@@ -12,7 +12,7 @@ board_adc start
 hmc5883 -T -I -R 4 start
 
 # Internal SPI (auto detect ms5611 or ms5607)
-if ! ms5611 -T 5607 -s -b 1 start
+if ! ms5611 -T 5607 -s -b 1 -q start
 then
 	ms5611 -s -b 1 start
 fi
@@ -24,13 +24,13 @@ if ver hwtypecmp V30
 then
 	# Check for Pixhawk 2.0 cube (isolated IMU on SPI4)
 	#  mpu6000 on v2.0, mpu9250 on v2.1
-	if mpu6000 -s -b 4 -R 10 start
+	if mpu6000 -s -b 4 -R 10 -q start
 	then
 		set BOARD_FMUV3 20
 	else
 		# Check for Pixhawk 2.1 cube
 		# isolated/external mpu9250 (SPI4)
-		if mpu9250 -s -b 4 -R 10 start
+		if mpu9250 -s -b 4 -R 10 -q start
 		then
 			set BOARD_FMUV3 21
 		fi


### PR DESCRIPTION
This fixes the errors showing up at startup for me with a Black Cube.

Should fix http://px4-jenkins.dagar.ca:8080/blue/organizations/jenkins/PX4-Autopilot/detail/pr-backport-20086/4/pipeline/

Backport of #20281