### PR TITLE
actuator_controls.msg: fix NUM_ACTUATOR_CONTROLS (9)

### DIFF
--- a/msg/actuator_controls.msg
+++ b/msg/actuator_controls.msg
@@ -1,5 +1,5 @@
 uint64 timestamp			# time since system start (microseconds)
-uint8 NUM_ACTUATOR_CONTROLS = 8
+uint8 NUM_ACTUATOR_CONTROLS = 9
 uint8 NUM_ACTUATOR_CONTROL_GROUPS = 4
 uint8 INDEX_ROLL = 0
 uint8 INDEX_PITCH = 1


### PR DESCRIPTION
The counter wasn't increased when the tilt index was added in https://github.com/PX4/PX4-Autopilot/pull/19329/commits/938c4c6da1d491e1e54b2d8f35ccda22c469fd89. 
Note: the actuator_controls.msg will be replaced by dedicated topics for thrust, torque and special commands (like flaps) very soon. 