### PR TITLE
fix control_allocator: check if 2. thrust and torque sp topic is valid

### DIFF
--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -400,14 +400,17 @@ ControlAllocator::Run()
 		c[0](5) = _thrust_sp(2);
 
 		if (_num_control_allocation > 1) {
-			_vehicle_torque_setpoint1_sub.copy(&vehicle_torque_setpoint);
-			_vehicle_thrust_setpoint1_sub.copy(&vehicle_thrust_setpoint);
-			c[1](0) = vehicle_torque_setpoint.xyz[0];
-			c[1](1) = vehicle_torque_setpoint.xyz[1];
-			c[1](2) = vehicle_torque_setpoint.xyz[2];
-			c[1](3) = vehicle_thrust_setpoint.xyz[0];
-			c[1](4) = vehicle_thrust_setpoint.xyz[1];
-			c[1](5) = vehicle_thrust_setpoint.xyz[2];
+			if (_vehicle_torque_setpoint1_sub.copy(&vehicle_torque_setpoint)) {
+				c[1](0) = vehicle_torque_setpoint.xyz[0];
+				c[1](1) = vehicle_torque_setpoint.xyz[1];
+				c[1](2) = vehicle_torque_setpoint.xyz[2];
+			}
+
+			if (_vehicle_thrust_setpoint1_sub.copy(&vehicle_thrust_setpoint)) {
+				c[1](3) = vehicle_thrust_setpoint.xyz[0];
+				c[1](4) = vehicle_thrust_setpoint.xyz[1];
+				c[1](5) = vehicle_thrust_setpoint.xyz[2];
+			}
 		}
 
 		for (int i = 0; i < _num_control_allocation; ++i) {


### PR DESCRIPTION
Otherwise the 2. setpoint is equal to the first one. This is only an issue if the 2. instance isn't advertised.

This isn't an issue on any of the existing configs.