### PR TITLE
Payload Deliverer bug fix + status output improvements

### DIFF
--- a/src/modules/payload_deliverer/gripper.cpp
+++ b/src/modules/payload_deliverer/gripper.cpp
@@ -127,3 +127,26 @@ void Gripper::publish_gripper_command(const int8_t gripper_command)
 	gripper.command = gripper_command;
 	_gripper_pub.publish(gripper);
 }
+
+const char *Gripper::get_state_str() const
+{
+	switch (_state) {
+	case GripperState::GRABBING:
+		return "GRABBING";
+
+	case GripperState::GRABBED:
+		return "GRABBED";
+
+	case GripperState::RELEASING:
+		return "RELEASING";
+
+	case GripperState::RELEASED:
+		return "RELEASED";
+
+	case GripperState::IDLE:
+		return "IDLE";
+
+	default:
+		return "UNKNOWN";
+	}
+}

--- a/src/modules/payload_deliverer/gripper.h
+++ b/src/modules/payload_deliverer/gripper.h
@@ -87,8 +87,13 @@ public:
 	// Update gripper state
 	void update();
 
+	// Return griper's state in string format
+	const char *get_state_str() const;
+
 	// Returns true if in grabbed position either sensed or timeout based
 	bool grabbed() { return _state == GripperState::GRABBED; }
+
+	// Returns true if in grabbing position either sensed or timeout based
 	bool grabbing() { return _state == GripperState::GRABBING; }
 
 	// Returns true if in released position either sensed or timeout based

--- a/src/modules/payload_deliverer/payload_deliverer.cpp
+++ b/src/modules/payload_deliverer/payload_deliverer.cpp
@@ -216,6 +216,18 @@ void PayloadDeliverer::gripper_close()
 	send_gripper_vehicle_command(vehicle_command_s::GRIPPER_ACTION_GRAB);
 }
 
+int PayloadDeliverer::print_status()
+{
+	// Gripper status
+	PX4_INFO("Gripper valid: %s", _gripper.is_valid() ? "True" : "False");
+
+	if (_gripper.is_valid()) {
+		PX4_INFO("Gripper state: %s", _gripper.get_state_str());
+	}
+
+	return 0;
+}
+
 int PayloadDeliverer::custom_command(int argc, char *argv[])
 {
 	if (argc >= 1) {

--- a/src/modules/payload_deliverer/payload_deliverer.h
+++ b/src/modules/payload_deliverer/payload_deliverer.h
@@ -102,6 +102,16 @@ private:
 	bool initialize_gripper();
 
 	/**
+	 * @brief Update gipper instance's state and send vehicle command ack
+	 *
+	 * This updates the gripper instance to check if the gripper has reached the desired state.
+	 * And if so, it sends a vehicle command ack to the navigator.
+	 *
+	 * If the gripper instance isn't valid (i.e. not initialized), it doesn't do anything
+	 */
+	void gripper_update(const hrt_abstime &now);
+
+	/**
 	 * @brief Commands the payload delivery mechanism based on the received vehicle command
 	 *
 	 * Also handle vehicle command acknowledgement once the delivery is confirmed from the mechanism

--- a/src/modules/payload_deliverer/payload_deliverer.h
+++ b/src/modules/payload_deliverer/payload_deliverer.h
@@ -77,6 +77,9 @@ public:
 	static int custom_command(int argc, char *argv[]);
 	static int print_usage(const char *reason = nullptr);
 
+	/** @see ModuleBase. Override "status" output when invoked via Commandline, to give detailed status **/
+	int print_status() override;
+
 	// Initializes the module
 	bool init();
 


### PR DESCRIPTION
## Describe problem solved by this pull request
![PayloadDelivererSpammingOutput](https://user-images.githubusercontent.com/23277211/191497802-a9bb8654-4c58-449e-a465-996c61480468.PNG)

**Bug**: When the payload_deliverer's gripper wasn't configured correctly, the error message was spammed to the user for *any vehicle command received.

**Room for Improvement**: Also, it was hard to check what the status of the payload_deliverer module was (especially the gripper instance)

## Describe your solution
1. First commit splits out the gripper state update function and only prints out info message when we did indeed receive the `DO_GRIPPER` vehicle command
2. Second commit adds a status output function to show gripper state

## Test data / coverage
![PayloadDelivererImprovedStatus](https://user-images.githubusercontent.com/23277211/191497852-249432d4-5caf-43d8-a771-96fea3ad513c.PNG)

Here, with the changes in this PR, the spamming doesn't occur anymore unless an actual DO_GRIPPER command is received, and the status output through the px4 shell gives a verbose status of the gripper, which is very useful for the operator!