### PR TITLE
VTOL: remove some remaining pwm stuff

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -289,11 +289,6 @@ void Standard::update_transition_state()
 		if (_param_vt_b_trans_ramp.get() > FLT_EPSILON) {
 			mc_weight = time_since_trans_start / _param_vt_b_trans_ramp.get();
 		}
-
-		// set idle speed for MC actuators
-		if (!_flag_idle_mc) {
-			_flag_idle_mc = true;
-		}
 	}
 
 	mc_weight = math::constrain(mc_weight, 0.0f, 1.0f);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -255,10 +255,6 @@ void Tailsitter::update_transition_state()
 		// calculate pitching rate - and constrain to at least 0.1s transition time
 		const float trans_pitch_rate = M_PI_2_F / math::max(_param_vt_b_trans_dur.get(), 0.1f);
 
-		if (!_flag_idle_mc) {
-			_flag_idle_mc = true;
-		}
-
 		if (tilt > 0.01f) {
 			_q_trans_sp = Quatf(AxisAnglef(_trans_rot_axis,
 						       time_since_trans_start * trans_pitch_rate)) * _q_trans_start;

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -54,8 +54,6 @@ Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 {
 	_vtol_schedule.flight_mode = vtol_mode::MC_MODE;
 	_vtol_schedule.transition_start = 0;
-
-	_flag_was_in_trans_mode = false;
 }
 
 void

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -74,6 +74,8 @@ private:
 		hrt_abstime transition_start;	/**< absoulte time at which front transition started */
 	} _vtol_schedule;
 
+	bool _flag_was_in_trans_mode = false;	// true if mode has just switched to transition
+
 	matrix::Quatf _q_trans_start;
 	matrix::Quatf _q_trans_sp;
 	matrix::Vector3f _trans_rot_axis;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -61,8 +61,6 @@ Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	_mc_roll_weight = 1.0f;
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
-
-	_flag_was_in_trans_mode = false;
 }
 
 void
@@ -295,11 +293,6 @@ void Tiltrotor::update_transition_state()
 	}
 
 	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
-
-	if (!_flag_was_in_trans_mode) {
-		// save desired heading for transition and last thrust value
-		_flag_was_in_trans_mode = true;
-	}
 
 	if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_FRONT_P1) {
 		// for the first part of the transition all rotors are enabled

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -363,11 +363,6 @@ void Tiltrotor::update_transition_state()
 
 	} else if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_BACK) {
 
-		// set idle speed for rotary wing mode
-		if (!_flag_idle_mc) {
-			_flag_idle_mc = true;
-		}
-
 		// tilt rotors back once motors are idle
 		if (time_since_trans_start > BACKTRANS_THROTTLE_DOWNRAMP_DUR_S) {
 
@@ -528,19 +523,6 @@ void Tiltrotor::fill_actuator_outputs()
 	_actuators_out_0->timestamp = _actuators_out_1->timestamp = hrt_absolute_time();
 }
 
-/*
- * Increase combined thrust of MC propellers if motors are tilted. Assumes that all MC motors are tilted equally.
- */
-
-float Tiltrotor::thrust_compensation_for_tilt()
-{
-	// only compensate for tilt angle up to 0.5 * max tilt
-	float compensated_tilt = math::constrain(_tilt_control, 0.0f, 0.5f);
-
-	// increase vertical thrust by 1/cos(tilt), limit to [-1,0]
-	return math::constrain(_v_att_sp->thrust_body[2] / cosf(compensated_tilt * M_PI_2_F), -1.0f, 0.0f);
-}
-
 void Tiltrotor::blendThrottleAfterFrontTransition(float scale)
 {
 	const float tecs_throttle = _v_att_sp->thrust_body[0];
@@ -552,7 +534,6 @@ void Tiltrotor::blendThrottleDuringBacktransition(float scale, float target_thro
 {
 	_thrust_transition = scale * target_throttle + (1.0f - scale) * _last_thr_in_fw_mode;
 }
-
 
 float Tiltrotor::timeUntilMotorsAreUp()
 {

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -58,7 +58,6 @@ public:
 	void update_mc_state() override;
 	void update_fw_state() override;
 	void waiting_on_tecs() override;
-	float thrust_compensation_for_tilt();
 	void blendThrottleAfterFrontTransition(float scale) override;
 
 private:

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -97,10 +97,6 @@ void VtolType::parameters_update()
 
 void VtolType::update_mc_state()
 {
-	if (!_flag_idle_mc) {
-		_flag_idle_mc = true;
-	}
-
 	resetAccelToPitchPitchIntegrator();
 
 	// copy virtual attitude setpoint to real attitude setpoint
@@ -124,10 +120,6 @@ void VtolType::update_mc_state()
 
 void VtolType::update_fw_state()
 {
-	if (_flag_idle_mc) {
-		_flag_idle_mc = false;
-	}
-
 	resetAccelToPitchPitchIntegrator();
 	_last_thr_in_fw_mode =  _actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -202,8 +202,6 @@ protected:
 	float _ra_hrate = 0.0f;			// rolling average on height rate for quadchute condition
 	float _ra_hrate_sp = 0.0f;		// rolling average on height rate setpoint for quadchute condition
 
-	bool _flag_was_in_trans_mode = false;	// true if mode has just switched to transition
-
 	hrt_abstime _trans_finished_ts = 0;
 
 	bool _tecs_running = false;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -77,14 +77,6 @@ enum VtolForwardActuationMode {
 	ENABLE_ABOVE_MPC_LAND_ALT2_WITHOUT_LAND
 };
 
-/**
- * @brief      Used to specify if min or max pwm values should be altered
- */
-enum class pwm_limit_type {
-	TYPE_MINIMUM = 0,
-	TYPE_MAXIMUM
-};
-
 class VtolAttitudeControl;
 
 class VtolType : public ModuleParams
@@ -197,8 +189,6 @@ protected:
 	struct vehicle_torque_setpoint_s 		*_torque_setpoint_1;
 	struct vehicle_thrust_setpoint_s 		*_thrust_setpoint_0;
 	struct vehicle_thrust_setpoint_s 		*_thrust_setpoint_1;
-
-	bool _flag_idle_mc = false;		//false = "idle is set for fixed wing mode"; true = "idle is set for multicopter mode"
 
 	float _mc_roll_weight = 1.0f;	// weight for multicopter attitude controller roll output
 	float _mc_pitch_weight = 1.0f;	// weight for multicopter attitude controller pitch output


### PR DESCRIPTION
Just a couple of leftovers that escaped their doom with [the old mixer purging](https://github.com/PX4/PX4-Autopilot/pull/20108).

Plus I noticed that _flag_was_in_trans_mode is defined for all vtol types, but only used for tailsitter, so made it a tailsitter-only member. 