### PR TITLE
boards/platform: remove confusing override

### DIFF
--- a/boards/px4/fmu-v2/src/i2c.cpp
+++ b/boards/px4/fmu-v2/src/i2c.cpp
@@ -47,14 +47,14 @@ constexpr px4_i2c_bus_t px4_i2c_buses[I2C_BUS_MAX_BUS_ITEMS] = {
 };
 
 
-bool px4_i2c_bus_external(const px4_i2c_bus_t &bus)
+bool px4_i2c_bus_external(int bus)
 {
 	if (HW_VER_FMUV3 == board_get_hw_version()) {
 		/* All FMUV3 2.1 i2c buses are external */
 		return true;
 
 	} else {
-		if (bus.bus != 2) {
+		if (bus != 2) {
 			return true;
 		}
 	}

--- a/boards/px4/fmu-v3/src/i2c.cpp
+++ b/boards/px4/fmu-v3/src/i2c.cpp
@@ -47,14 +47,14 @@ constexpr px4_i2c_bus_t px4_i2c_buses[I2C_BUS_MAX_BUS_ITEMS] = {
 };
 
 
-bool px4_i2c_bus_external(const px4_i2c_bus_t &bus)
+bool px4_i2c_bus_external(int bus)
 {
 	if (HW_VER_FMUV3 == board_get_hw_version()) {
 		/* All FMUV3 2.1 i2c buses are external */
 		return true;
 
 	} else {
-		if (bus.bus != 2) {
+		if (bus != 2) {
 			return true;
 		}
 	}

--- a/platforms/common/i2c.cpp
+++ b/platforms/common/i2c.cpp
@@ -38,9 +38,15 @@
 #if defined(CONFIG_I2C)
 
 #ifndef BOARD_OVERRIDE_I2C_BUS_EXTERNAL
-bool px4_i2c_bus_external(const px4_i2c_bus_t &bus)
+bool px4_i2c_bus_external(int bus)
 {
-	return bus.is_external;
+	for (int i = 0; i < I2C_BUS_MAX_BUS_ITEMS; ++i) {
+		if (px4_i2c_buses[i].bus == bus) {
+			return px4_i2c_buses[i].is_external;
+		}
+	}
+
+	return true;
 }
 #endif // BOARD_OVERRIDE_I2C_BUS_EXTERNAL
 
@@ -72,7 +78,7 @@ bool I2CBusIterator::next()
 			break;
 
 		case FilterType::InternalBus:
-			if (!px4_i2c_bus_external(bus_data)) {
+			if (!px4_i2c_bus_external(bus_data.bus)) {
 				if (_bus == bus_data.bus || _bus == -1) {
 					return true;
 				}
@@ -81,7 +87,7 @@ bool I2CBusIterator::next()
 			break;
 
 		case FilterType::ExternalBus:
-			if (px4_i2c_bus_external(bus_data)) {
+			if (px4_i2c_bus_external(bus_data.bus)) {
 				++_external_bus_counter;
 
 				if (_bus == bus_data.bus || _bus == -1) {

--- a/platforms/common/include/px4_platform_common/i2c.h
+++ b/platforms/common/include/px4_platform_common/i2c.h
@@ -50,21 +50,7 @@ __EXPORT extern const px4_i2c_bus_t px4_i2c_buses[I2C_BUS_MAX_BUS_ITEMS]; ///< b
  * runtime-check if a board has a specific bus as external.
  * This can be overridden by a board to add run-time checks.
  */
-__EXPORT bool px4_i2c_bus_external(const px4_i2c_bus_t &bus);
-
-/**
- * runtime-check if a board has a specific bus as external.
- */
-static inline bool px4_i2c_bus_external(int bus)
-{
-	for (int i = 0; i < I2C_BUS_MAX_BUS_ITEMS; ++i) {
-		if (px4_i2c_buses[i].bus == bus) {
-			return px4_i2c_bus_external(px4_i2c_buses[i]);
-		}
-	}
-
-	return true;
-}
+__EXPORT bool px4_i2c_bus_external(int bus);
 
 /**
  * runtime-check if a board has a specific device as external.
@@ -98,7 +84,7 @@ public:
 
 	int externalBusIndex() const { return _external_bus_counter; }
 
-	bool external() const { return px4_i2c_bus_external(bus()); }
+	bool external() const { return px4_i2c_bus_external(_bus); }
 
 private:
 	const FilterType _filter;


### PR DESCRIPTION
This removes the odd px4_i2c_bus_external override which was confusing me and lead to odd and inconsistent results.

The function is now only available with an int as the argument.