### PR TITLE
px4events: add @skip-file tag

### DIFF
--- a/Tools/px4events/srcscanner.py
+++ b/Tools/px4events/srcscanner.py
@@ -46,7 +46,7 @@ class SourceScanner(object):
                 print('Failed reading file: %s, skipping content.' % path)
                 pass
         try:
-            return parser.Parse(contents)
+            return parser.Parse(contents, path)
         except Exception as e:
             print("Exception while parsing file {}".format(path))
             raise

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecksTest.cpp
@@ -43,6 +43,9 @@ using namespace time_literals;
 
 // to run: make tests TESTFILTER=HealthAndArmingChecks
 
+/* EVENT
+ * @skip-file
+ */
 
 class ReporterTest : public ::testing::Test
 


### PR DESCRIPTION
And skip [HealthAndArmingChecksTest.cpp](https://github.com/PX4/PX4-Autopilot/compare/main...pr-cmake_metadata_extract_events_skip_file?expand=1#diff-0acaeaa062a8d2fb0616f25ecceb05995fb02cbc9bec0fd06231115b980911cf) to fix metadata deployment.

Replacement for https://github.com/PX4/PX4-Autopilot/pull/20189