### PR TITLE
FW Attitude Controller: fix polling of rate setpoint for tailsitter

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -200,18 +200,6 @@ FixedwingAttitudeControl::vehicle_attitude_setpoint_poll()
 }
 
 void
-FixedwingAttitudeControl::vehicle_rates_setpoint_poll()
-{
-	if (_rates_sp_sub.update(&_rates_sp)) {
-		if (_vehicle_status.is_vtol_tailsitter) {
-			float tmp = _rates_sp.roll;
-			_rates_sp.roll = -_rates_sp.yaw;
-			_rates_sp.yaw = tmp;
-		}
-	}
-}
-
-void
 FixedwingAttitudeControl::vehicle_land_detected_poll()
 {
 	if (_vehicle_land_detected_sub.updated()) {
@@ -580,7 +568,7 @@ void FixedwingAttitudeControl::Run()
 			}
 
 			if (_vcontrol_mode.flag_control_rates_enabled) {
-				vehicle_rates_setpoint_poll();
+				_rates_sp_sub.update(&_rates_sp);
 
 				const Vector3f body_rates_setpoint = Vector3f(_rates_sp.roll, _rates_sp.pitch, _rates_sp.yaw);
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -274,7 +274,6 @@ private:
 	void		vehicle_control_mode_poll();
 	void		vehicle_manual_poll(const float yaw_body);
 	void		vehicle_attitude_setpoint_poll();
-	void		vehicle_rates_setpoint_poll();
 	void		vehicle_land_detected_poll();
 
 	float 		get_airspeed_and_update_scaling();


### PR DESCRIPTION
vehicle_rates_setpoint_poll() rotated the rate setpoint for tailsitters from hover to fixes-wing orientation. That is though not correct, as the actual rate estimates get rotated and thus the setpoints shouldn't be touched.

Fixes https://github.com/PX4/PX4-Autopilot/issues/20279

Issue arose with https://github.com/PX4/PX4-Autopilot/pull/20080. Acro was though also broken before it seems, as that one used vehicle_rates_setpoint_poll() already.