### PR TITLE
Adds missing reset counter logic to EV height fusion

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -712,6 +712,7 @@ private:
 	void resetHeightToEv();
 
 	void resetVerticalVelocityToGps(const gpsSample &gps_sample);
+	void resetVerticalVelocityToEv(const extVisionSample &ev_sample);
 	void resetVerticalVelocityToZero();
 
 	// fuse optical flow line of sight rate measurements

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -259,6 +259,14 @@ void Ekf::resetVerticalVelocityToGps(const gpsSample &gps_sample)
 	P.uncorrelateCovarianceSetVariance<1>(6, sq(1.5f * gps_sample.sacc));
 }
 
+void Ekf::resetVerticalVelocityToEv(const extVisionSample &ev_sample)
+{
+	resetVerticalVelocityTo(ev_sample.vel(2));
+
+	// the state variance is the same as the observation
+	P.uncorrelateCovarianceSetVariance<1>(6, ev_sample.velVar(2));
+}
+
 void Ekf::resetVerticalVelocityToZero()
 {
 	// we don't know what the vertical velocity is, so set it to zero


### PR DESCRIPTION
EV odometry handling in the EKF is not considering the reset_counter field for EV height fusion, only horizontal position, velocity, and yaw.

This PR adds the same reset logic from the other estimates to the EV height fusion controller so that the vertical position and velocity estimates are reset upon change in the EV odom message's reset_counter field.
