### PR TITLE
ekf2: use validated airspeed from airspeed sensor only

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1576,6 +1576,7 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 			if (PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
 			    && PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)
 			    && (airspeed_validated.calibrated_airspeed_m_s > 0.f)
+			    && (airspeed_validated.selected_airspeed_index > 0)
 			   ) {
 				airspeedSample airspeed_sample {
 					.time_us = airspeed_validated.timestamp,


### PR DESCRIPTION
Don't use synthetic measurements to prevent circular dependency.

https://github.com/PX4/PX4-Autopilot/blob/8080ca966a8a435ba550f4bc8dda39eab20af2fb/msg/airspeed_validated.msg#L12
