### PR TITLE
cmake: px4_parse_function_args re-enable failure on unparsed (invalid) arguments

### DIFF
--- a/cmake/px4_parse_function_args.cmake
+++ b/cmake/px4_parse_function_args.cmake
@@ -89,9 +89,8 @@ function(px4_parse_function_args)
 	cmake_parse_arguments(IN "" "NAME" "OPTIONS;ONE_VALUE;MULTI_VALUE;REQUIRED;ARGN" "${ARGN}")
 	cmake_parse_arguments(OUT "${IN_OPTIONS}" "${IN_ONE_VALUE}" "${IN_MULTI_VALUE}" "${IN_ARGN}")
 
-	if (OUT_UNPARSED_ARGUMENTS)
-		#message(FATAL_ERROR "${IN_NAME}: unparsed ${OUT_UNPARSED_ARGUMENTS}")
-		# TODO: reenable
+	if(OUT_UNPARSED_ARGUMENTS)
+		message(FATAL_ERROR "${IN_NAME}: unparsed ${OUT_UNPARSED_ARGUMENTS}")
 	endif()
 
 	foreach(arg ${IN_REQUIRED})


### PR DESCRIPTION
Better to have this enabled and catch any typos.