### PR TITLE
uORB: fix static orb_exists call for protected build

### DIFF
--- a/platforms/common/uORB/ORBSet.hpp
+++ b/platforms/common/uORB/ORBSet.hpp
@@ -37,14 +37,12 @@ class ORBSet
 {
 public:
 	struct Node {
-		struct Node *next;
-		const char *node_name;
+		Node *next{nullptr};
+		const char *node_name{nullptr};
 	};
 
-	ORBSet() :
-		_top(nullptr),
-		_end(nullptr)
-	{ }
+	ORBSet() = default;
+
 	~ORBSet()
 	{
 		while (_top != nullptr) {
@@ -52,11 +50,14 @@ public:
 
 			if (_top->next == nullptr) {
 				free((void *)_top->node_name);
-				free(_top);
+				_top->node_name = nullptr;
+
+				delete _top;
 				_top = nullptr;
 			}
 		}
 	}
+
 	void insert(const char *node_name)
 	{
 		Node **p;
@@ -68,7 +69,7 @@ public:
 			p = &_end->next;
 		}
 
-		*p = (Node *)malloc(sizeof(Node));
+		*p = new Node();
 
 		if (_end) {
 			_end = _end->next;
@@ -102,8 +103,13 @@ public:
 
 		if (_top && (strcmp(_top->node_name, node_name) == 0)) {
 			p = _top->next;
-			free((void *)_top->node_name);
-			free(_top);
+
+			if (_top->node_name) {
+				free((void *)_top->node_name);
+				_top->node_name = nullptr;
+			}
+
+			delete _top;
 			_top = p;
 
 			if (_top == nullptr) {
@@ -135,11 +141,17 @@ private:
 			}
 
 			a->next = b->next;
-			free((void *)b->node_name);
-			free(b);
+
+			if (b->node_name) {
+				free((void *)b->node_name);
+				b->node_name = nullptr;
+			}
+
+			delete b;
+			b = nullptr;
 		}
 	}
 
-	Node *_top;
-	Node *_end;
+	Node *_top{nullptr};
+	Node *_end{nullptr};
 };

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -41,15 +41,8 @@
 #include <uORB/topics/uORBTopics.hpp> // For ORB_ID enum
 #include <stdint.h>
 
-#ifdef __PX4_NUTTX
-#include "ORBSet.hpp"
-#else
-#include <string>
-#include <set>
-#define ORBSet std::set<std::string>
-#endif
-
 #ifdef ORB_COMMUNICATOR
+#include "ORBSet.hpp"
 #include "uORBCommunicator.hpp"
 #endif /* ORB_COMMUNICATOR */
 


### PR DESCRIPTION
In the recently merged initial VOXL2 support (https://github.com/PX4/PX4-Autopilot/pull/20274) `uORB::Manager::orb_exists()` needed to non-static so that it can check the remote subscribers. This broke the px4_fmu-v5_protected build which has a static orb_ioctl() method kernel side (https://github.com/PX4/PX4-Autopilot/commit/0b9505453d03cb586c2d6e8a927e0b5b5e1761b3).

This PR keeps orb_exists() non-static for VOXL2, but updates orb_ioctl() to call orb_exists() on the uORB::Manager instance (if available). I also updated ORBSet so it's used everywhere, rather than just being a typedef for std::string on Linux. We may want to optimize it later, but for now I think it would be better to keep it together.