### PR TITLE
CRSF: Validate unknown packet sizes to be smaller than max packet size

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -294,6 +294,15 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 				// We don't know what this packet is, so we'll let the parser continue
 				// just so that we can dequeue it in one shot
 				working_segment_size = packet_size + PACKET_SIZE_TYPE_SIZE;
+
+				if (working_segment_size >  CRSF_MAX_PACKET_LEN) {
+					parser_statistics->invalid_unknown_packet_sizes++;
+					parser_state = PARSER_STATE_HEADER;
+					working_segment_size = HEADER_SIZE;
+					working_index = 0;
+					buffer_count = QueueBuffer_Count(&rx_queue);
+					continue;
+				}
 			}
 
 			parser_state = PARSER_STATE_PAYLOAD;

--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -295,7 +295,7 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 				// just so that we can dequeue it in one shot
 				working_segment_size = packet_size + PACKET_SIZE_TYPE_SIZE;
 
-				if (working_segment_size >  CRSF_MAX_PACKET_LEN) {
+				if (working_segment_size > CRSF_MAX_PACKET_LEN) {
 					parser_statistics->invalid_unknown_packet_sizes++;
 					parser_state = PARSER_STATE_HEADER;
 					working_segment_size = HEADER_SIZE;

--- a/src/drivers/rc/crsf_rc/CrsfParser.hpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.hpp
@@ -69,6 +69,7 @@ struct CrsfParserStatistics_t {
 	uint32_t crcs_valid_unknown_packets;
 	uint32_t crcs_invalid;
 	uint32_t invalid_known_packet_sizes;
+	uint32_t invalid_unknown_packet_sizes;
 };
 
 enum CRSF_MESSAGE_TYPE {

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -504,6 +504,7 @@ int CrsfRc::print_status()
 	PX4_INFO("Valid unknown packet CRCs: %li",  _packet_parser_statistics.crcs_valid_unknown_packets);
 	PX4_INFO("Invalid CRCs: %li",  _packet_parser_statistics.crcs_invalid);
 	PX4_INFO("Invalid known packet sizes: %li",  _packet_parser_statistics.invalid_known_packet_sizes);
+	PX4_INFO("Invalid unknown packet sizes: %li",  _packet_parser_statistics.invalid_unknown_packet_sizes);
 
 	return 0;
 }


### PR DESCRIPTION
An issue existed in the CSRF driver, where invalid serial data could result in the parser attempting to parse a packet of unknown type, with a length which is larger than the circular buffer itself. This would mean the parser would be stalled waiting for a packet larger than could ever be encountered. This PR fixes this bug to cap the possible unknown packet type size to the maximum size of a CRSF packet.