### PR TITLE
Add compile option for export compliant build and rework max flight time check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,13 @@ if(${PX4_PLATFORM} STREQUAL "posix")
 	endif()
 endif()
 
+
+option(PX4_EXPORT_RESTRICTION_BUILD "Enable export compliant build of PX4. This adds some flight time and wind restrictions." OFF)
+if(PX4_EXPORT_RESTRICTION_BUILD)
+	add_definitions(-DPX4_EXPORT_RESTRICTION_BUILD)
+	message(STATUS "Enabling export compliant build")
+endif()
+
 # external modules
 set(EXTERNAL_MODULES_LOCATION "" CACHE STRING "External modules source location")
 

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,11 @@ else
 	BUILD_DIR_SUFFIX :=
 endif
 
+ifdef PX4_EXPORT_RESTRICTION_BUILD
+	CMAKE_ARGS += -DPX4_EXPORT_RESTRICTION_BUILD=ON
+	BUILD_DIR_SUFFIX := $(BUILD_DIR_SUFFIX)_export_compliant
+endif
+
 CMAKE_ARGS ?=
 
 # additional config parameters passed to cmake

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -30,7 +30,8 @@ bool global_position_valid		# set to true by the commander app if the quality of
 bool gps_position_valid
 bool home_position_valid		# indicates a valid home position (a valid home position is not always a valid launch)
 
-bool flight_time_or_wind_rtl_triggered # indicates whether there was a RTL due to flight time limit reached or max wind threshold breached in the current flight
+bool max_flight_time_exceeded		# set to true if the flight time (time since last arming) is above limit
+bool max_wind_speed_exceeded		# set to true if the currently measured wind speed is above limit
 
 bool offboard_control_signal_lost
 

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -30,6 +30,8 @@ bool global_position_valid		# set to true by the commander app if the quality of
 bool gps_position_valid
 bool home_position_valid		# indicates a valid home position (a valid home position is not always a valid launch)
 
+bool flight_time_or_wind_rtl_triggered
+
 bool offboard_control_signal_lost
 
 bool rc_signal_found_once

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -30,7 +30,7 @@ bool global_position_valid		# set to true by the commander app if the quality of
 bool gps_position_valid
 bool home_position_valid		# indicates a valid home position (a valid home position is not always a valid launch)
 
-bool flight_time_or_wind_rtl_triggered
+bool flight_time_or_wind_rtl_triggered # indicates whether there was a RTL due to flight time limit reached or max wind threshold breached in the current flight
 
 bool offboard_control_signal_lost
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -161,6 +161,7 @@ private:
 	void send_parachute_command();
 
 	void checkWindSpeedThresholds();
+	void checkFlightTimeThresholds();
 	void checkForMissionUpdate();
 	void handlePowerButtonState();
 	void systemPowerUpdate();
@@ -339,6 +340,7 @@ private:
 	vtol_vehicle_status_s	_vtol_vehicle_status{};
 
 	hrt_abstime _last_wind_warning{0};
+	hrt_abstime _last_flight_time_warning{0};
 
 	// commander publications
 	actuator_armed_s        _actuator_armed{};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -275,6 +275,10 @@ private:
 	static constexpr uint64_t COMMANDER_MONITORING_INTERVAL{10_ms};
 	static constexpr uint64_t INAIR_RESTART_HOLDOFF_INTERVAL{500_ms};
 
+	// export restriction parameter limits (only active if PX4_EXPORT_RESTRICTION_BUILD)
+	static constexpr int EXPORT_RESTRICTED_MAX_FLIGHT_TIME{3540}; //59 min
+	static constexpr float EXPORT_RESTRICTED_MAX_WIND{12.f}; //12 m/s
+
 	ArmStateMachine _arm_state_machine{};
 
 	bool		_geofence_loiter_on{false};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1067,6 +1067,9 @@ PARAM_DEFINE_FLOAT(COM_WIND_WARN, -1.f);
  * the time since takeoff is above this value. It is not possible to resume the
  * mission or switch to any mode other than RTL or Land.
  *
+ * There will be a warning message sent every 1 minute with updated
+ * remaining time till RTL once passed the 90% threshold and until RTL is triggered.
+ *
  * Set a negative value to disable.
  *
  *

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1081,8 +1081,10 @@ PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, 0);
 /**
  * Wind speed RLT threshold
  *
- * Wind speed threshold above which an automatic return to launch is triggered
- * and enforced as long as the threshold is exceeded.
+ * Wind speed threshold above which an automatic return to launch is triggered.
+ * It is not possible to resume the mission or switch to any auto mode other than
+ * RTL or Land once exceeded once. Taking over in any manual
+ * mode is though still possible.
  *
  * Set to 0 to disable.
  *

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1049,16 +1049,15 @@ PARAM_DEFINE_FLOAT(COM_SPOOLUP_TIME, 1.0f);
  * A warning is triggered if the currently estimated wind speed is above this value.
  * Warning is sent periodically (every 1min).
  *
- * A negative value disables the feature.
+ * Set to 0 to disable.
  *
- * @min -1
- * @max 30
+ * @min 0
  * @decimal 1
  * @increment 0.1
  * @group Commander
  * @unit m/s
  */
-PARAM_DEFINE_FLOAT(COM_WIND_WARN, -1.f);
+PARAM_DEFINE_FLOAT(COM_WIND_WARN, 0.f);
 
 /**
  * Maximum allowed flight time
@@ -1071,16 +1070,13 @@ PARAM_DEFINE_FLOAT(COM_WIND_WARN, -1.f);
  * There will be a warning message sent every 1 minute with updated
  * remaining time till RTL once passed the 90% threshold and until RTL is triggered.
  *
- * Set a negative value to disable.
- *
+ * Set to 0 to disable.
  *
  * @unit s
- * @min -1
- * @max 10000
- * @value 0 Disable
+ * @min 0
  * @group Commander
  */
-PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, -1);
+PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, 0);
 
 /**
  * Wind speed RLT threshold
@@ -1088,13 +1084,12 @@ PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, -1);
  * Wind speed threshold above which an automatic return to launch is triggered
  * and enforced as long as the threshold is exceeded.
  *
- * A negative value disables the feature.
+ * Set to 0 to disable.
  *
- * @min -1
- * @max 30
+ * @min 0
  * @decimal 1
  * @increment 0.1
  * @group Commander
  * @unit m/s
  */
-PARAM_DEFINE_FLOAT(COM_WIND_MAX, -1.f);
+PARAM_DEFINE_FLOAT(COM_WIND_MAX, 0.f);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1065,7 +1065,8 @@ PARAM_DEFINE_FLOAT(COM_WIND_WARN, -1.f);
  *
  * The vehicle aborts the current operation and returns to launch when
  * the time since takeoff is above this value. It is not possible to resume the
- * mission or switch to any mode other than RTL or Land.
+ * mission or switch to any auto mode other than RTL or Land. Taking over in any manual
+ * mode is though still possible.
  *
  * There will be a warning message sent every 1 minute with updated
  * remaining time till RTL once passed the 90% threshold and until RTL is triggered.

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -153,8 +153,13 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		/* need global position estimate
 		 * and there was not a previously triggered flight time or max
 		 * wind speed rtl in the current flight */
-		if (status_flags.global_position_valid &&
-		    !status_flags.flight_time_or_wind_rtl_triggered) {
+
+		if (status_flags.flight_time_or_wind_rtl_triggered) {
+			events::send(events::ID("state_machine_loiter_rejected_flight_time_wind"),
+			{events::Log::Warning, events::LogInternal::Info},
+			"Mode rejected due to flight time or wind limit");
+
+		} else if (status_flags.global_position_valid) {
 			ret = TRANSITION_CHANGED;
 		}
 
@@ -166,8 +171,13 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		/* Follow and orbit only implemented for multicopter,
 		 * and only allow if there was not a previously triggered flight time or max
 		 * wind speed rtl in the current flight */
-		if (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
-		    !status_flags.flight_time_or_wind_rtl_triggered) {
+
+		if (status_flags.flight_time_or_wind_rtl_triggered) {
+			events::send(events::ID("state_machine_orbit_rejected_flight_time_wind"),
+			{events::Log::Warning, events::LogInternal::Info},
+			"Mode rejected due to flight time or wind limit");
+
+		} else if (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 			ret = TRANSITION_CHANGED;
 		}
 
@@ -185,10 +195,14 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		/* need global position, home position, and a valid mission
 		 * and there was not a previously triggered flight time or max
 		 * wind speed rtl in the current flight */
-		if (status_flags.global_position_valid &&
-		    status_flags.auto_mission_available &&
-		    !status_flags.flight_time_or_wind_rtl_triggered) {
 
+		if (status_flags.flight_time_or_wind_rtl_triggered) {
+			events::send(events::ID("state_machine_mission_rejected_flight_time_wind"),
+			{events::Log::Warning, events::LogInternal::Info},
+			"Mode rejected due to flight time or wind limit");
+
+		} else if (status_flags.global_position_valid &&
+			   status_flags.auto_mission_available) {
 			ret = TRANSITION_CHANGED;
 		}
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -150,8 +150,11 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 
 	case commander_state_s::MAIN_STATE_AUTO_LOITER:
 
-		/* need global position estimate */
-		if (status_flags.global_position_valid) {
+		/* need global position estimate
+		 * and there was not a previously triggered flight time or max
+		 * wind speed rtl in the current flight */
+		if (status_flags.global_position_valid &&
+		    !status_flags.flight_time_or_wind_rtl_triggered) {
 			ret = TRANSITION_CHANGED;
 		}
 
@@ -160,8 +163,11 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 	case commander_state_s::MAIN_STATE_AUTO_FOLLOW_TARGET:
 	case commander_state_s::MAIN_STATE_ORBIT:
 
-		/* Follow and orbit only implemented for multicopter */
-		if (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+		/* Follow and orbit only implemented for multicopter,
+		 * and only allow if there was not a previously triggered flight time or max
+		 * wind speed rtl in the current flight */
+		if (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
+		    !status_flags.flight_time_or_wind_rtl_triggered) {
 			ret = TRANSITION_CHANGED;
 		}
 
@@ -176,9 +182,12 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 
 	case commander_state_s::MAIN_STATE_AUTO_MISSION:
 
-		/* need global position, home position, and a valid mission */
+		/* need global position, home position, and a valid mission
+		 * and there was not a previously triggered flight time or max
+		 * wind speed rtl in the current flight */
 		if (status_flags.global_position_valid &&
-		    status_flags.auto_mission_available) {
+		    status_flags.auto_mission_available &&
+		    !status_flags.flight_time_or_wind_rtl_triggered) {
 
 			ret = TRANSITION_CHANGED;
 		}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -154,10 +154,15 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		 * and there was not a previously triggered flight time or max
 		 * wind speed rtl in the current flight */
 
-		if (status_flags.flight_time_or_wind_rtl_triggered) {
-			events::send(events::ID("state_machine_loiter_rejected_flight_time_wind"),
+		if (status_flags.max_flight_time_exceeded) {
+			events::send(events::ID("state_machine_loiter_rejected_flight_time"),
 			{events::Log::Warning, events::LogInternal::Info},
-			"Mode rejected due to flight time or wind limit");
+			"Mode rejected due to flight time above limit");
+
+		} else if (status_flags.max_wind_speed_exceeded) {
+			events::send(events::ID("state_machine_loiter_rejected_wind"),
+			{events::Log::Warning, events::LogInternal::Info},
+			"Mode rejected due to wind speed above limit");
 
 		} else if (status_flags.global_position_valid) {
 			ret = TRANSITION_CHANGED;
@@ -172,10 +177,15 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		 * and only allow if there was not a previously triggered flight time or max
 		 * wind speed rtl in the current flight */
 
-		if (status_flags.flight_time_or_wind_rtl_triggered) {
-			events::send(events::ID("state_machine_orbit_rejected_flight_time_wind"),
+		if (status_flags.max_flight_time_exceeded) {
+			events::send(events::ID("state_machine_orbit_rejected_flight_time"),
 			{events::Log::Warning, events::LogInternal::Info},
-			"Mode rejected due to flight time or wind limit");
+			"Mode rejected due to flight time above limit");
+
+		} else if (status_flags.max_wind_speed_exceeded) {
+			events::send(events::ID("state_machine_orbit_rejected_wind"),
+			{events::Log::Warning, events::LogInternal::Info},
+			"Mode rejected due to wind speed above limit");
 
 		} else if (status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 			ret = TRANSITION_CHANGED;
@@ -196,10 +206,15 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		 * and there was not a previously triggered flight time or max
 		 * wind speed rtl in the current flight */
 
-		if (status_flags.flight_time_or_wind_rtl_triggered) {
-			events::send(events::ID("state_machine_mission_rejected_flight_time_wind"),
+		if (status_flags.max_flight_time_exceeded) {
+			events::send(events::ID("state_machine_mission_rejected_flight_time"),
 			{events::Log::Warning, events::LogInternal::Info},
-			"Mode rejected due to flight time or wind limit");
+			"Mission rejected due to flight time above limit");
+
+		} else if (status_flags.max_wind_speed_exceeded) {
+			events::send(events::ID("state_machine_mission_rejected_wind"),
+			{events::Log::Warning, events::LogInternal::Info},
+			"Mission rejected due to wind speed above limit");
 
 		} else if (status_flags.global_position_valid &&
 			   status_flags.auto_mission_available) {

--- a/src/systemcmds/ver/ver.cpp
+++ b/src/systemcmds/ver/ver.cpp
@@ -259,6 +259,14 @@ extern "C" __EXPORT int ver_main(int argc, char *argv[])
 				ret = 0;
 			}
 
+#ifdef PX4_EXPORT_RESTRICTION_BUILD
+
+			if (show_all) {
+				printf("Export restricted build: on\n");
+			}
+
+#endif /* PX4_EXPORT_RESTRICTION_BUILD */
+
 			if (ret == 1) {
 				PX4_ERR("unknown command");
 				return 1;


### PR DESCRIPTION

## Describe problem solved by this pull request
Some countries impose constraints on the maximum flight time and maximum wind robustness of a drone resp. of it's auto pilot software. 

## Describe your solution
- Adds a compile time option to enforce the export compliance at build time, without the user being able to override it by param. By default this is disabled, an to enable add set `PX4_EXPORT_RESTRICTION_BUILD`. 

- reworked the max flight time check. It's now contained in a separate function in commander.cpp, plus also contains a warning message that's sent out to the groundstation when 90% of the max flight time (COM_FLT_TIME_MAX) is reached, and will then send a warning every 1minute with the remaining time till RTL. Notification will then look something like: 
```
WARN  [commander] Approaching max flight time (system will RTL in 122 seconds)
WARN  [commander] Approaching max flight time (system will RTL in 62 seconds)
WARN  [commander] Approaching max flight time (system will RTL in 2 seconds)
WARN  [commander] Maximum flight time reached, abort operation and RTL
```
A similar warning scheme exists already for the max wind speed warning (warning every 1min with updated wind norm if passed COM_WIND_WARN). 

- only trigger the max flight time and max wind speed RTLs once --> added `flight_time_or_wind_rtl_triggered` in `vehicle_status_flags`. Once `flight_time_or_wind_rtl_triggered` is set, mode transitions to the auto flights (mission, loiter and orbit) are rejected. There should probably be the reasoning sent in a message to the ground station, though we currently don't do this consistently (e.g. transitions to any auto flight without valid position estimate are also silently rejected). 

## Describe possible alternatives
- instead of every 1min publish the flight time warning only once, or once at 90% and once at 99% (or other thresholds)
- inform user about why mode changes to the auto modes are rejected (or wait till we have the Commander rewrite in for that https://github.com/PX4/PX4-Autopilot/pull/20172)

## Test data / coverage
SITL tested.

