### PR TITLE
ObstacleAvoidance: fix condition for target wp skipping

### DIFF
--- a/src/lib/avoidance/ObstacleAvoidance.cpp
+++ b/src/lib/avoidance/ObstacleAvoidance.cpp
@@ -220,12 +220,13 @@ void ObstacleAvoidance::checkAvoidanceProgress(const Vector3f &pos, const Vector
 	Vector2f prev_to_target = Vector2f(_curr_wp - prev_wp);
 	// vector from previous triplet to the vehicle projected position on the line previous-target triplet
 	Vector2f prev_to_closest_pt = closest_pt - Vector2f(prev_wp);
-	// fraction of the previous-tagerget line that has been flown
-	const float prev_curr_travelled = prev_to_closest_pt.length() / prev_to_target.length();
+	// check if vehicle overpassed target waypoint
+	const bool should_skip_target_wp = prev_to_closest_pt.length() / prev_to_target.length() > 1.0f
+					   && prev_to_closest_pt.dot(prev_to_target) > 0.f;
 
 	Vector2f pos_to_target = Vector2f(_curr_wp - _position);
 
-	if (prev_curr_travelled > 1.0f) {
+	if (should_skip_target_wp) {
 		// if the vehicle projected position on the line previous-target is past the target waypoint,
 		// increase the target acceptance radius such that navigator will update the triplets
 		pos_control_status.acceptance_radius = pos_to_target.length() + 0.5f;


### PR DESCRIPTION
## Describe problem solved by this pull request
Condition for skipping current target waypoint is wrong. 
```
// if the vehicle projected position on the line previous-target is past the target waypoint,
// increase the target acceptance radius such that navigator will update the triplets
```
The idea here is to skip the target waypoint if it's already overpassed. (e.g. due to obstacle avoidance)
The distance from the closest point on track to the previous waypoint is compared to the distance from the target waypoint to the previous waypoint. If the former is greater than the latter, current target waypoint is skipped. The problem occurs if the distance between previous and target waypoint is shorter than previous waypoint's acceptance radius. 

Example: previous waypoint acceptance radius is 2 meters, all waypoints are colinear:
`vehicle_pos <-- 1.9 meters --> prev_wp <-- 1 meter --> target_wp <-- 10 meters --> next_wp`

It's obvious that the target waypoint will be skipped, but so will the next_wp and every that comes after, as long as they are in the same direction and the condition is met.

This is dangerous, especially if the mission is planned to avoid obstacles.

## Describe your solution
Condition should require vectors `prev_wp -> target_wp` and `prev_wp -> closest` to have the same direction. It is easily checked if the dot product is greater than 0.