### PR TITLE
Fix uorb_to_msg isnan floating-point check

### DIFF
--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -344,7 +344,7 @@ msp_raw_gps_t construct_RAW_GPS(const sensor_gps_s &vehicle_gps_position,
 	raw_gps.numSat = vehicle_gps_position.satellites_used;
 
 	if (airspeed_validated.airspeed_sensor_measurement_valid
-	    && !std::isnan(airspeed_validated.indicated_airspeed_m_s)
+	    && PX4_ISFINITE(airspeed_validated.indicated_airspeed_m_s)
 	    && airspeed_validated.indicated_airspeed_m_s > 0) {
 		raw_gps.groundSpeed = airspeed_validated.indicated_airspeed_m_s * 100;
 

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -344,7 +344,7 @@ msp_raw_gps_t construct_RAW_GPS(const sensor_gps_s &vehicle_gps_position,
 	raw_gps.numSat = vehicle_gps_position.satellites_used;
 
 	if (airspeed_validated.airspeed_sensor_measurement_valid
-	    && airspeed_validated.indicated_airspeed_m_s != NAN
+	    && !std::isnan(airspeed_validated.indicated_airspeed_m_s)
 	    && airspeed_validated.indicated_airspeed_m_s > 0) {
 		raw_gps.groundSpeed = airspeed_validated.indicated_airspeed_m_s * 100;
 


### PR DESCRIPTION
## Describe problem solved by this pull request
When building the ignition SITL on Ubuntu 22.04, the following error occurs:
```
uorb_to_msp.cpp:347:58: error: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Werror=float-equal]
```

## Describe your solution
Use `std::isnan` instead.

## Describe possible alternatives


## Test data / coverage
Local SITL build is now successful:
```make px4_sitl ign_x500```
