### PR TITLE
[v1.13] Fix RTK

### DIFF
--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -517,7 +517,7 @@ bool UavcanGnssBridge::PublishRTCMStream(const uint8_t *const data, const size_t
 
 		result = _pub_rtcm_stream.broadcast(msg) >= 0;
 		perf_count(_rtcm_stream_pub_perf);
-		msg.data = {};
+		msg.data.clear();
 	}
 
 	return result;


### PR DESCRIPTION
Before this fix, this function would stall and somehow never return.

This makes RTK data sent from QGC work on top of v1.13 for me.