### PR TITLE
hysteresis: avoid subtracting unsigned integers

### DIFF
--- a/src/lib/hysteresis/hysteresis.cpp
+++ b/src/lib/hysteresis/hysteresis.cpp
@@ -74,17 +74,15 @@ Hysteresis::update(const hrt_abstime &now_us)
 {
 	if (_requested_state != _state) {
 
-		const hrt_abstime elapsed = now_us - _last_time_to_change_state;
-
 		if (_state && !_requested_state) {
 			// true -> false
-			if (elapsed >= _time_from_true_us) {
+			if (now_us >= _last_time_to_change_state + _time_from_true_us) {
 				_state = false;
 			}
 
 		} else if (!_state && _requested_state) {
 			// false -> true
-			if (elapsed >= _time_from_false_us) {
+			if (now_us >= _last_time_to_change_state + _time_from_false_us) {
 				_state = true;
 			}
 		}


### PR DESCRIPTION
 - avoid potential errors with timestamp passed in from different sources
 - this wasn't a potential issue originally when hrt_absolute_time() was handled internally