### PR TITLE
VTOL: fix transitions in Stabilized

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_standard_vtol
@@ -61,6 +61,7 @@ param set-default FW_T_CLMB_MAX 8
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
+param set-default MC_AIRMODE 1
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_YAW_P 1.6
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -58,6 +58,7 @@ param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 param set-default FW_T_TAS_TC 2
 
+param set-default MC_AIRMODE 1
 param set-default MC_ROLLRATE_P 0.3
 
 param set-default MPC_ACC_HOR_MAX 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -34,8 +34,6 @@ param set-default CA_SV_CS1_TYPE 2
 param set-default CA_SV_CS2_TRQ_P 1.0
 param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS_COUNT 3
-param set-default CA_SV_TL0_CT 0
-param set-default CA_SV_TL1_CT 0
 param set-default CA_SV_TL_COUNT 2
 
 param set-default PWM_MAIN_FUNC1 101

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_tiltrotor
@@ -60,6 +60,7 @@ param set-default FW_T_CLMB_MAX 8
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
+param set-default MC_AIRMODE 1
 param set-default MC_YAWRATE_P 0.3
 param set-default MC_YAWRATE_I 0.3
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -203,18 +203,29 @@ void Standard::update_vtol_state()
 
 void Standard::update_transition_state()
 {
+	const hrt_abstime now = hrt_absolute_time();
 	float mc_weight = 1.0f;
-	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
+	float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
 
 	VtolType::update_transition_state();
 
-	// we get attitude setpoint from a multirotor flighttask if altitude is controlled.
+	// we get attitude setpoint from a multirotor flighttask if climbrate is controlled.
 	// in any other case the fixed wing attitude controller publishes attitude setpoint from manual stick input.
 	if (_v_control_mode->flag_control_climb_rate_enabled) {
+		// we need the incoming (virtual) attitude setpoints (both mc and fw) to be recent, otherwise return (means the previous setpoint stays active)
+		if (_mc_virtual_att_sp->timestamp < (now - 1_s) && _fw_virtual_att_sp->timestamp < (now - 1_s)) {
+			return;
+		}
+
 		memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 		_v_att_sp->roll_body = _fw_virtual_att_sp->roll_body;
 
 	} else {
+		// we need a recent incoming (fw virtual) attitude setpoint, otherwise return (means the previous setpoint stays active)
+		if (_fw_virtual_att_sp->timestamp < (now - 1_s)) {
+			return;
+		}
+
 		memcpy(_v_att_sp, _fw_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 		_v_att_sp->thrust_body[2] = -_fw_virtual_att_sp->thrust_body[0];
 	}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -205,7 +205,7 @@ void Standard::update_transition_state()
 {
 	const hrt_abstime now = hrt_absolute_time();
 	float mc_weight = 1.0f;
-	float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
+	const float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
 
 	VtolType::update_transition_state();
 
@@ -213,7 +213,7 @@ void Standard::update_transition_state()
 	// in any other case the fixed wing attitude controller publishes attitude setpoint from manual stick input.
 	if (_v_control_mode->flag_control_climb_rate_enabled) {
 		// we need the incoming (virtual) attitude setpoints (both mc and fw) to be recent, otherwise return (means the previous setpoint stays active)
-		if (_mc_virtual_att_sp->timestamp < (now - 1_s) && _fw_virtual_att_sp->timestamp < (now - 1_s)) {
+		if (_mc_virtual_att_sp->timestamp < (now - 1_s) || _fw_virtual_att_sp->timestamp < (now - 1_s)) {
 			return;
 		}
 

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -41,21 +41,23 @@
 
 
 /**
- * Enable/disable usage of fixed-wing actuators in hover to generate forward force (instead of pitching down).
+ * Enable usage of fixed-wing actuators in hover to generate forward force (instead of pitching down).
  *
- * This technique can be used to avoid the plane having to pitch down in order to move forward.
- * This prevents large, negative lift values being created when facing strong winds.
+ * This feature can be used to avoid the plane having to pitch down in order to move forward,
+ * and prevents large, negative lift values being created when facing strong winds.
  * Fixed-wing forward actuators refers to puller/pusher (standard VTOL), or forward-tilt (tiltrotor VTOL).
- * Only active if demaded down pitch is below VT_PITCH_MIN, and uses VT_FWD_THRUST_SC to get from
- * demanded down pitch to fixed-wing actuation.
+ * Only active if demanded down pitch is below VT_PITCH_MIN.
+ * Use VT_FWD_THRUST_SC to tune it.
  *
- * @value 0 Disable FW forward actuation in hover.
- * @value 1 Enable FW forward actuation in hover in altitude, position and auto modes (except LANDING).
- * @value 2 Enable FW forward actuation in hover in altitude, position and auto modes if above MPC_LAND_ALT1.
- * @value 3 Enable FW forward actuation in hover in altitude, position and auto modes if above MPC_LAND_ALT2.
- * @value 4 Enable FW forward actuation in hover in altitude, position and auto modes.
- * @value 5 Enable FW forward actuation in hover in altitude, position and auto modes if above MPC_LAND_ALT1 (except LANDING).
- * @value 6 Enable FW forward actuation in hover in altitude, position and auto modes if above MPC_LAND_ALT2 (except LANDING).
+ * Only active (if enabled) in Altitude, Position and Auto modes, not in Stabilized.
+ *
+ * @value 0 Disabled
+ * @value 1 Enabled (except LANDING)
+ * @value 2 Enabled if distance to ground above MPC_LAND_ALT1
+ * @value 3 Enabled if distance to ground above MPC_LAND_ALT2
+ * @value 4 Enabled constantly
+ * @value 5 Enabled if distance to ground above MPC_LAND_ALT1 (except LANDING)
+ * @value 6 Enabled if distance to ground above MPC_LAND_ALT2 (except LANDING)
  *
  * @group VTOL Attitude Control
  */

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -191,8 +191,8 @@ void Tailsitter::update_transition_state()
 	const hrt_abstime now = hrt_absolute_time();
 	const float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
 
-	// we need the incoming (virtual) attitude setpoints (both mc and fw) to be recent, otherwise return (means the previous setpoint stays active)
-	if (_mc_virtual_att_sp->timestamp < (now - 1_s) && _fw_virtual_att_sp->timestamp < (now - 1_s)) {
+	// we need the incoming (virtual) mc attitude setpoints to be recent, otherwise return (means the previous setpoint stays active)
+	if (_mc_virtual_att_sp->timestamp < (now - 1_s)) {
 		return;
 	}
 
@@ -209,8 +209,15 @@ void Tailsitter::update_transition_state()
 			float yaw_sp = atan2f(z(1), z(0));
 
 			// the intial attitude setpoint for a backtransition is a combination of the current fw pitch setpoint,
-			// the yaw setpoint and zero roll since we want wings level transition
-			_q_trans_start = Eulerf(0.0f, _fw_virtual_att_sp->pitch_body, yaw_sp);
+			// the yaw setpoint and zero roll since we want wings level transition.
+			// If for some reason the fw attitude setpoint is not recent then don't sue it and assume 0 pitch
+			if (_fw_virtual_att_sp->timestamp > (now - 1_s)) {
+				_q_trans_start = Eulerf(0.0f, _fw_virtual_att_sp->pitch_body, yaw_sp);
+
+			} else {
+				_q_trans_start = Eulerf(0.0f, 0.f, yaw_sp);
+			}
+
 
 			// attitude during transitions are controlled by mc attitude control so rotate the desired attitude to the
 			// multirotor frame

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -188,7 +188,13 @@ void Tailsitter::update_vtol_state()
 
 void Tailsitter::update_transition_state()
 {
-	const float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
+	const hrt_abstime now = hrt_absolute_time();
+	const float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
+
+	// we need the incoming (virtual) attitude setpoints (both mc and fw) to be recent, otherwise return (means the previous setpoint stays active)
+	if (_mc_virtual_att_sp->timestamp < (now - 1_s) && _fw_virtual_att_sp->timestamp < (now - 1_s)) {
+		return;
+	}
 
 	if (!_flag_was_in_trans_mode) {
 		_flag_was_in_trans_mode = true;

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -286,7 +286,7 @@ void Tiltrotor::update_transition_state()
 	// in any other case the fixed wing attitude controller publishes attitude setpoint from manual stick input.
 	if (_v_control_mode->flag_control_climb_rate_enabled) {
 		// we need the incoming (virtual) attitude setpoints (both mc and fw) to be recent, otherwise return (means the previous setpoint stays active)
-		if (_mc_virtual_att_sp->timestamp < (now - 1_s) && _fw_virtual_att_sp->timestamp < (now - 1_s)) {
+		if (_mc_virtual_att_sp->timestamp < (now - 1_s) || _fw_virtual_att_sp->timestamp < (now - 1_s)) {
 			return;
 		}
 
@@ -304,7 +304,7 @@ void Tiltrotor::update_transition_state()
 		_thrust_transition = _fw_virtual_att_sp->thrust_body[0];
 	}
 
-	float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
+	const float time_since_trans_start = (float)(now - _vtol_schedule.transition_start) * 1e-6f;
 
 	if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_FRONT_P1) {
 		// for the first part of the transition all rotors are enabled

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -322,11 +322,6 @@ VtolAttitudeControl::Run()
 		const bool mc_att_sp_updated = _mc_virtual_att_sp_sub.update(&_mc_virtual_att_sp);
 		const bool fw_att_sp_updated = _fw_virtual_att_sp_sub.update(&_fw_virtual_att_sp);
 
-		// for transition code to publish an attitude setpoint require both mc and fw virtual attitude setpoint to not contain data older than one second.
-		// this prevents either topic from being used with old data at the time when we switch into transition mode
-		const bool mc_and_fw_att_sp_are_recent = _mc_virtual_att_sp.timestamp > (now - 1_s)
-				&& _fw_virtual_att_sp.timestamp > (now - 1_s);
-
 		// update the vtol state machine which decides which mode we are in
 		_vtol_type->update_vtol_state();
 
@@ -336,7 +331,7 @@ VtolAttitudeControl::Run()
 			// vehicle is doing a transition to FW
 			_vtol_vehicle_status.vehicle_vtol_state = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_FW;
 
-			if (mc_and_fw_att_sp_are_recent && (mc_att_sp_updated || fw_att_sp_updated)) {
+			if (mc_att_sp_updated || fw_att_sp_updated) {
 				_vtol_type->update_transition_state();
 				_vehicle_attitude_sp_pub.publish(_vehicle_attitude_sp);
 			}
@@ -347,7 +342,7 @@ VtolAttitudeControl::Run()
 			// vehicle is doing a transition to MC
 			_vtol_vehicle_status.vehicle_vtol_state = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_MC;
 
-			if (mc_and_fw_att_sp_are_recent && (mc_att_sp_updated || fw_att_sp_updated)) {
+			if (mc_att_sp_updated || fw_att_sp_updated) {
 				_vtol_type->update_transition_state();
 				_vehicle_attitude_sp_pub.publish(_vehicle_attitude_sp);
 			}


### PR DESCRIPTION
## Describe problem solved by this pull request
VTOL transition broken in Stabilized for Tiltrotor since https://github.com/PX4/PX4-Autopilot/pull/20257. Reason: In Stabilized mode only the FW attitude controller was running during transitions, and thus there was no virtual mc attitude setpoint recently published. 

## Describe your solution
~MC Attitude controller: run and publish if vehicle is a MC or a VTOL in MC mode (which includes transitions). Before it was only run in full MC for Tiltrotor and Standard VTOL. The VTOL module does the selection on which virtual setpoint to use in the end (no changes there).~
EDIT: the above proposed doesn't work because it means that both the mc and fw attitude constantly publish rate setpoints, while it should be always only once of them.
New proposal pushed: move "is-recent" check inside the update_transition_state() implementations for the 3 vtol types, as only there you know exactly which virtual attitude setpoint is used in the end.
Note: I think it does the correct thing also for tailsitter, but transitions in Stabilized mode there are currently broken by other issues as well, see https://github.com/PX4/PX4-Autopilot/issues/20127.

## Describe possible alternatives
Change the [logic in vtol_att_control_main ](https://github.com/PX4/PX4-Autopilot/blob/70d73c86902276c15c74e4db4bcc83db6e02d057/src/modules/vtol_att_control/vtol_att_control_main.cpp#L339)on when to run the transition logic. 

## Test data / coverage
SITLed on all VTOL types. Along the way I found that the tuning for them all is in a pretty bad state and improved it along the way (enabling airmode and using the tilts for yaw control in hover made a big difference).

## Additional context
Lets get rid of the parallel controller architecture for VTOL asap. Work is currently going on in cleaning up the fw attitude controller, which enables us to merge it with the MC one.
