### PR TITLE
FW Attitdue controller: fix throttle in acro (use _rate_sp.throttle_body)

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -353,13 +353,14 @@ void FixedwingAttitudeControl::Run()
 
 		const matrix::Eulerf euler_angles(_R);
 
+		vehicle_manual_poll(euler_angles.psi());
+
 		vehicle_attitude_setpoint_poll();
 
 		// vehicle status update must be before the vehicle_control_mode_poll(), otherwise rate sp are not published during whole transition
 		_vehicle_status_sub.update(&_vehicle_status);
 
 		vehicle_control_mode_poll();
-		vehicle_manual_poll(euler_angles.psi());
 		vehicle_land_detected_poll();
 
 		// the position controller will not emit attitude setpoints in some modes

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -608,7 +608,7 @@ void FixedwingAttitudeControl::Run()
 
 				/* throttle passed through if it is finite */
 				_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE] =
-					(PX4_ISFINITE(_att_sp.thrust_body[0])) ? _att_sp.thrust_body[0] : 0.0f;
+					(PX4_ISFINITE(_rates_sp.thrust_body[0])) ? _rates_sp.thrust_body[0] : 0.0f;
 
 				/* scale effort by battery status */
 				if (_param_fw_bat_scale_en.get() &&


### PR DESCRIPTION

## Describe problem solved by this pull request
Something we didn't consider in https://github.com/PX4/PX4-Autopilot/pull/20080: In Acro the` att_sp.thrust_body `obviously isn't updated, but is still listened to for filling `_actuator_controls` with.

## Describe your solution
Fill `_actuator_controls` always with rate_sp.throttle_body, which in turn is set to` att_sp.thrust_body` if in a mode with an attitude setpoint. 


## Test data / coverage
SITL tested.


