### PR TITLE
Payload deliverer improvements: Gripper intermediate state & Vehicle command Ack & Parameter Updates

### DIFF
--- a/src/modules/payload_deliverer/gripper.h
+++ b/src/modules/payload_deliverer/gripper.h
@@ -78,6 +78,9 @@ public:
 	// Initialize the gripper
 	void init(const GripperConfig &config);
 
+	// De-initialize the gripper
+	void deinit();
+
 	// Actuate the gripper to the grab position
 	void grab();
 
@@ -99,13 +102,35 @@ public:
 	// Returns true if in released position either sensed or timeout based
 	bool released() { return _state == GripperState::RELEASED; }
 
-	// Returns true only once after the state transitioned into released
-	// Used for sending vehicle command ack only when the gripper actually releases
-	// in payload deliverer
+	/**
+	 * @brief Returns true once after gripper succeededs in releasing the payload
+	 *
+	 * Note, that this is a single-read for a one successful release operation. Meaning that
+	 * if you command `release()` and then call this function multiple times in the future,
+	 * it will only return `true` only once, and then it will return `false` after it returns
+	 * `true` once.
+	 *
+	 * This is used to detect a single event of successful releasing of a gripper in `payload_deliverer`
+	 * module, which then would send `vehicle_command_ack` message, indicating the successful release.
+	 */
 	bool released_read_once()
 	{
 		if (_released_state_cache) {
 			_released_state_cache = false;
+			return true;
+
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * @brief Returns true once after gripper succeededs in grabbing the payload
+	 */
+	bool grabbed_read_once()
+	{
+		if (_grabbed_state_cache) {
+			_grabbed_state_cache = false;
 			return true;
 
 		} else {
@@ -128,7 +153,10 @@ private:
 	// Internal state
 	GripperState _state{GripperState::IDLE};
 	hrt_abstime _last_command_time{0};
-	bool _released_state_cache{false}; // Cached flag that is set once gripper release was successful, gets reset once read
+
+	// Cached flag that is set once gripper release/grab was successful, it must get reset when read.
+	bool _released_state_cache{false};
+	bool _grabbed_state_cache{false};
 
 	uORB::Publication<gripper_s> _gripper_pub{ORB_ID(gripper)};
 };

--- a/src/modules/payload_deliverer/module.yaml
+++ b/src/modules/payload_deliverer/module.yaml
@@ -10,6 +10,7 @@ parameters:
                 short: Enable Gripper actuation in Payload Deliverer
             type: boolean
             default: 0
+            reboot_required: true
 
         PD_GRIPPER_TYPE:
             description:

--- a/src/modules/payload_deliverer/payload_deliverer.h
+++ b/src/modules/payload_deliverer/payload_deliverer.h
@@ -100,9 +100,12 @@ private:
 	void parameter_update();
 
 	/**
-	 * @brief Initialize gripper with current parameter settings
+	 * @brief Initialize or deinitialize gripper instance based on parameter settings
+	 *
+	 * Depending on `PD_GRIPPER_EN` and the state of `_gripper` instance, this function will
+	 * either try to initialize or de-initialize the gripper appropriately.
 	 */
-	bool initialize_gripper();
+	void configure_gripper();
 
 	/**
 	 * @brief Update gipper instance's state and send vehicle command ack


### PR DESCRIPTION
## Describe problem solved by this pull request
This fixes multiple problems found when integrating the interface with the Ground Control Station (abbreviated below as **GCS**) on directly commanding the gripper via [Joysticks](https://docs.qgroundcontrol.com/master/en/SetupView/Joystick.html) Button assignment.

- [GRIPPER_ACTION](https://mavlink.io/en/messages/common.html#GRIPPER_ACTIONS) Enum being sent by GCS was being encoded in the `param2` in `MAV_CMD` in floating point, so the value `1` (ACTION_GRAB) was not being converted correctly into the `int32_t` type
- Gripper instance was publishing `gripper` message every-time user was commanding Gripper command via GCS, this was spamming the Gripper Control Allocator
- Payload deliverer was not sending the 'IN_PROGRESS' ack to GCS, so GCS was detecting a link failure in vehicle command, and was re-sending it every 3 seconds
- Only gripper 'release' event, when successful, was being sent out as acknowledgement. The 'grab' was not handled.
- Cases where conflicting vehicle commands were coming in were not considered (Same command / Different command / From different entities, etc)
- Target system & component IDs were not filled out correctly

## Describe your solution
- Added a direct conversion from floating point to integer
- Added a check to not command `gripper` control allocator topic if we are already in the state commanded / in intermediate state
- Added IN_PROGRESS vehicle command ack to let GCS know that the command is in progress
- Added GRAB event vehicle command ack
- Handle different vehicle command conflicts
- Cache the currently executing vehicle command & the source system/component ID to send ack to

## Test data / coverage
Test needs to be done with QGC PR: https://github.com/mavlink/qgroundcontrol/pull/10446

## Additional context
Follow up of #20270, now making it more feature complete :wink: (at least aspiring to be!)

### Discussion
As indicated in [this comment](https://github.com/PX4/PX4-Autopilot/pull/20331/commits/5b94731f3535070b43512cd60293649e21c87aac#diff-4b68d4e28ee1da23b2842156f4d47c1d06583685fee16ef75d2a5dfc1196a705R150-R151), currently I haven't found a clear solution on setting the `target_system` and `target_component` for a successful action acknowledgement, since we need to keep track of the old vehicle command & make sure that this acknowledgement comes from that specific vehicle command.

This is crucial in a sense that we should be clear who sent the command / who we are responding to.

The ideal case I think would be to tie this with the Gripper somehow, and keep track of exactly which vehicle command triggered the gripper's action, but I am worrying that there may be cached data issue, where we cache a wrong vehicle command and end up not setting the correct target IDs :thinking: 

Any idea on this? @dagar @bkueng 