### PR TITLE
[WIP] Break apart Pixhawk Autopilot Bus Startup Logic

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -39,6 +39,7 @@ px4_add_romfs_files(
 	rc.balloon_apps
 	rc.balloon_defaults
 	rc.boat_defaults
+	rc.baseboard
 	rc.fw_apps
 	rc.fw_defaults
 	rc.heli_defaults

--- a/ROMFS/px4fmu_common/init.d/rc.baseboard
+++ b/ROMFS/px4fmu_common/init.d/rc.baseboard
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Standard startup script for baseboard sensor drivers.
+#
+###############################################################################
+#                           Begin Baseboard drivers                           #
+###############################################################################
+
+set HAVE_PM2 yes
+
+if ver hwtypecmp V6X005000 V6X005001 V6X005003 V6X005004
+then
+	set HAVE_PM2 no
+fi
+
+if param compare SENS_EN_INA226 1
+then
+	# Start Digital power monitors
+	ina226 -X -b 1 -t 1 -k start
+
+	if [ $HAVE_PM2 = yes ]
+	then
+		ina226 -X -b 2 -t 2 -k start
+	fi
+fi
+
+if param compare SENS_EN_INA228 1
+then
+	# Start Digital power monitors
+	ina228 -X -b 1 -t 1 -k start
+	if [ $HAVE_PM2 = yes ]
+	then
+		ina228 -X -b 2 -t 2 -k start
+	fi
+fi
+
+if param compare SENS_EN_INA238 1
+then
+	# Start Digital power monitors
+	ina238 -X -b 1 -t 1 -k start
+	if [ $HAVE_PM2 = yes ]
+	then
+		ina238 -X -b 2 -t 2 -k start
+	fi
+fi
+
+# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
+ist8310 -X -b 1 -R 10 start
+
+if ver hwtypecmp V6X000000 V6X001000
+then
+	bmp388 -I start
+else
+	if ver hwtypecmp V6X002001
+	then
+		icp201xx -X start
+	else
+		bmp388 -X start
+	fi
+fi
+
+# Baro on I2C3
+ms5611 -X start
+
+unset HAVE_PM2

--- a/boards/ark/fmu-v6x/init/rc.board_sensors
+++ b/boards/ark/fmu-v6x/init/rc.board_sensors
@@ -2,49 +2,12 @@
 #
 # ARK FMUARKV6X specific board sensors init
 #------------------------------------------------------------------------------
-set HAVE_PM2 yes
 
-if ver hwtypecmp ARKV6X005000 ARKV6X005001 ARKV6X005002 ARKV6X005003 ARKV6X005004
-then
-	set HAVE_PM2 no
-fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
 else
 	board_adc start
-fi
-
-
-if param compare SENS_EN_INA226 1
-then
-	# Start Digital power monitors
-	ina226 -X -b 1 -t 1 -k start
-
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina226 -X -b 2 -t 2 -k start
-	fi
-fi
-
-if param compare SENS_EN_INA228 1
-then
-	# Start Digital power monitors
-	ina228 -X -b 1 -t 1 -k start
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina228 -X -b 2 -t 2 -k start
-	fi
-fi
-
-if param compare SENS_EN_INA238 1
-then
-	# Start Digital power monitors
-	ina238 -X -b 1 -t 1 -k start
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina238 -X -b 2 -t 2 -k start
-	fi
 fi
 
 # Internal SPI bus IIM42652
@@ -59,13 +22,18 @@ icm42688p -R 6 -s -b 3 start
 # Internal magnetometer on I2c
 bmm150 -I start
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
-
 # Possible internal Baro
 bmp388 -I start
 
-# Baro on I2C3
-ms5611 -X start
+#
+# baseboard sensors: rc.baseboard
+#
+set BASEBOARD_SENSORS ${R}etc/init.d/rc.baseboard
+if [ -f $BASEBOARD_SENSORS ]
+then
+	echo "Baseboard sensors: ${BASEBOARD_SENSORS}"
+	. $BASEBOARD_SENSORS
+fi
+unset BASEBOARD_SENSORS
 
-unset HAVE_PM2
+. ${R}etc/init.d/rc.baseboard

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -3,50 +3,12 @@
 # PX4 FMUv5X specific board sensors init
 #------------------------------------------------------------------------------
 
-set HAVE_PM2 yes
-
-if ver hwtypecmp V5X005000 V5X005001 V5X005002
-then
-	set HAVE_PM2 no
-fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
 	board_adc start -n
 else
 	board_adc start
-fi
-
-
-if param compare SENS_EN_INA226 1
-then
-	# Start Digital power monitors
-	ina226 -X -b 1 -t 1 -k start
-
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina226 -X -b 2 -t 2 -k start
-	fi
-fi
-
-if param compare SENS_EN_INA228 1
-then
-	# Start Digital power monitors
-	ina228 -X -b 1 -t 1 -k start
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina228 -X -b 2 -t 2 -k start
-	fi
-fi
-
-if param compare SENS_EN_INA238 1
-then
-	# Start Digital power monitors
-	ina238 -X -b 1 -t 1 -k start
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina238 -X -b 2 -t 2 -k start
-	fi
 fi
 
 if ver hwtypecmp V5X000000 V5X000001 V5X000002 V5X001000 V5X004000 V5X004001 V5X004002 V5X005001 V5X005002
@@ -96,9 +58,6 @@ else
 
 fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
-
 # Possible internal Baro
 
 # Disable startup of internal baros if param is set to false
@@ -113,4 +72,16 @@ then
 	fi
 
 fi
-unset HAVE_PM2
+
+#
+# baseboard sensors: rc.baseboard
+#
+set BASEBOARD_SENSORS ${R}etc/init.d/rc.baseboard
+if [ -f $BASEBOARD_SENSORS ]
+then
+	echo "Baseboard sensors: ${BASEBOARD_SENSORS}"
+	. $BASEBOARD_SENSORS
+fi
+unset BASEBOARD_SENSORS
+
+. ${R}etc/init.d/rc.baseboard

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -2,49 +2,12 @@
 #
 # PX4 FMUv6X specific board sensors init
 #------------------------------------------------------------------------------
-set HAVE_PM2 yes
 
-if ver hwtypecmp V6X005000 V6X005001 V6X005003 V6X005004
-then
-	set HAVE_PM2 no
-fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
 else
 	board_adc start
-fi
-
-
-if param compare SENS_EN_INA226 1
-then
-	# Start Digital power monitors
-	ina226 -X -b 1 -t 1 -k start
-
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina226 -X -b 2 -t 2 -k start
-	fi
-fi
-
-if param compare SENS_EN_INA228 1
-then
-	# Start Digital power monitors
-	ina228 -X -b 1 -t 1 -k start
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina228 -X -b 2 -t 2 -k start
-	fi
-fi
-
-if param compare SENS_EN_INA238 1
-then
-	# Start Digital power monitors
-	ina238 -X -b 1 -t 1 -k start
-	if [ $HAVE_PM2 = yes ]
-	then
-		ina238 -X -b 2 -t 2 -k start
-	fi
 fi
 
 if ver hwtypecmp V6X000004 V6X001004 V6X004004 V6X005004
@@ -77,9 +40,6 @@ else
 	bmm150 -I start
 fi
 
-# External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)
-ist8310 -X -b 1 -R 10 start
-
 # Possible internal Baro
 if ver hwtypecmp V6X002001
 then
@@ -100,7 +60,15 @@ else
 	fi
 fi
 
-# Baro on I2C3
-ms5611 -X start
+#
+# baseboard sensors: rc.baseboard
+#
+set BASEBOARD_SENSORS ${R}etc/init.d/rc.baseboard
+if [ -f $BASEBOARD_SENSORS ]
+then
+	echo "Baseboard sensors: ${BASEBOARD_SENSORS}"
+	. $BASEBOARD_SENSORS
+fi
+unset BASEBOARD_SENSORS
 
-unset HAVE_PM2
+. ${R}etc/init.d/rc.baseboard


### PR DESCRIPTION
This PR intends to separate the logic for the Pixhawk Autopilot Bus baseboards into a common location. Currently, all PAB flight controllers (currently the fmuv5x, fmuv6x, and arkv6x) have to carry a combined flight controller and baseboard version for starting all the sensors. So each autopilot needs to be aware of every possible combination.

I propose we break apart the HW VER REV versioning. The rc.board_sensors in each board config will use HW REV for starting its internal sensors. Then call a common rc.baseboard startup script that will use HW REV for starting baseboard sensors.

This will be much more maintainable as more PAB flight controllers and baseboards are created.

From discussions with @dagar 
```
 - GPIO_HW_REV_SENSE -> GPIO_HW_VER_SENSE
 - GPIO_HW_VER_SENSE -> GPIO_HW_BASEBOARD_VER_SENSE
 - new src/drivers/pab_baseboard thing dependant on GPIO_HW_BASEBOARD_VER_SENSE for querying baseboard version and coordinating specific startup logic
```