### PR TITLE
ControlAllocation: remove actuator trim value from actuator_sp to calculate allocated control

### DIFF
--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -143,7 +143,7 @@ public:
 	 * @return Control vector
 	 */
 	matrix::Vector<float, NUM_AXES> getAllocatedControl() const
-	{ return (_effectiveness * _actuator_sp).emult(_control_allocation_scale); }
+	{ return (_effectiveness * (_actuator_sp - _actuator_trim)).emult(_control_allocation_scale); }
 
 	/**
 	 * Get the control effectiveness matrix


### PR DESCRIPTION

## Describe problem solved by this pull request
Setting a non-zero control surface trim on vehicles with control allocation leads to non-working Integral part of the PID controller of the FW rate controller.
Reason: the fed back "allocated_torque" contains the torque generated by the trim as well, which means that "unallocated torque" is never 0, which then prevents the I-part from growing (in the corresponding direction, so either + or -).

![image](https://user-images.githubusercontent.com/26798987/193631320-9486ad08-9a54-4df7-8c2f-9f7f36da3eb0.png)

Only happens since https://github.com/PX4/PX4-Autopilot/pull/19912 is in, as from then on we listen to the unallocated torque info for disabling the integrator to avoid integrator windup due to actuator saturation.  

## Describe your solution
Subtract the trim value from the actuator setpoint to get to the "net" actuator setpoint. 

## Describe possible alternatives
Can we move the trim setting from the allocation to the output part? So e.g. for PWM servos add option to set trim PWM? Feels more natural anyway to set it there where you also set the PWM min/max corresponding to the desired min/max deflections. 

Maybe part of a larger discussion, as currently also _control_trim is not used (always 0 because `config.linearization_point` is always 0).
`_actuator_sp = _actuator_trim + _mix * (_control_sp - _control_trim)`

## Test data / coverage
Light SITL testing with VTOLs and non-zero servo trims. Checked that `control_allocator_status.unallcoated_torque` was 0 when actuators aren't saturated. 

