### PR TITLE
Ascend/pthread muorb

### DIFF
--- a/platforms/qurt/cmake/qurt_reqs.cmake
+++ b/platforms/qurt/cmake/qurt_reqs.cmake
@@ -100,7 +100,6 @@ set(ARCHCPUFLAGS
 add_definitions(
 	-D __QURT
 	-D _PROVIDE_POSIX_TIME_DECLS
-	-D _TIMER_T
 	-D _HAS_C9X
 	-D restrict=__restrict__
 	-D noreturn_function=

--- a/platforms/qurt/cmake/qurt_reqs.cmake
+++ b/platforms/qurt/cmake/qurt_reqs.cmake
@@ -35,7 +35,7 @@ set(HEXAGON_SDK_INCLUDES
 	${HEXAGON_SDK_ROOT}/incs
 	${HEXAGON_SDK_ROOT}/incs/stddef
 	${HEXAGON_SDK_ROOT}/rtos/qurt/computev66/include/qurt
-	# ${HEXAGON_SDK_ROOT}/rtos/qurt/computev66/include/posix
+	${HEXAGON_SDK_ROOT}/rtos/qurt/computev66/include/posix
 	${HEXAGON_SDK_ROOT}/tools/HEXAGON_Tools/8.4.05/Tools/target/hexagon/include
 	)
 

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -84,6 +84,9 @@
 //#pragma GCC poison exit
 #endif // !defined(__PX4_NUTTX)
 
+#ifdef __PX4_QURT
+typedef int timer_t;
+#endif
 
 /* For SITL lockstep we fake the clock, sleeping, and timedwaits
  * Therefore, we prefix these syscalls with system_. */

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -84,6 +84,7 @@
 //#pragma GCC poison exit
 #endif // !defined(__PX4_NUTTX)
 
+
 /* For SITL lockstep we fake the clock, sleeping, and timedwaits
  * Therefore, we prefix these syscalls with system_. */
 #include <time.h>

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -84,10 +84,6 @@
 //#pragma GCC poison exit
 #endif // !defined(__PX4_NUTTX)
 
-#ifdef __PX4_QURT
-typedef int timer_t;
-#endif
-
 /* For SITL lockstep we fake the clock, sleeping, and timedwaits
  * Therefore, we prefix these syscalls with system_. */
 #include <time.h>

--- a/src/modules/muorb/slpi/uORBProtobufChannel.cpp
+++ b/src/modules/muorb/slpi/uORBProtobufChannel.cpp
@@ -36,6 +36,7 @@
 
 #include <qurt.h>
 #include <qurt_thread.h>
+#include <pthread.h>
 
 // TODO: Move this out of here once we have px4-log functionality
 extern "C" void HAP_debug(const char *msg, int level, const char *filename, int line);
@@ -45,8 +46,13 @@ static MUORBTestType test_to_run;
 
 fc_func_ptrs muorb_func_ptrs;
 
-static void test_runner(void *test)
+static void *test_runner(void *test)
 {
+	uint8_t data[MUORB_TEST_DATA_LEN];
+ 	for (uint8_t i = 0; i < MUORB_TEST_DATA_LEN; i++) {
+		data[i] = i;
+	};
+
 	HAP_debug("test_runner called", 1, muorb_test_topic_name, 0);
 
 	switch (*((MUORBTestType *) test)) {
@@ -62,19 +68,15 @@ static void test_runner(void *test)
 		(void) muorb_func_ptrs.unsubscribe_func_ptr(muorb_test_topic_name);
 		break;
 
-	case TOPIC_TEST_TYPE: {
-			uint8_t data[MUORB_TEST_DATA_LEN];
-
-			for (uint8_t i = 0; i < MUORB_TEST_DATA_LEN; i++) { data[i] = i; }
-
-			(void) muorb_func_ptrs.topic_data_func_ptr(muorb_test_topic_name, data, MUORB_TEST_DATA_LEN);
-		}
+	case TOPIC_TEST_TYPE:
+		(void) muorb_func_ptrs.topic_data_func_ptr(muorb_test_topic_name, data, MUORB_TEST_DATA_LEN);
 
 	default:
 		break;
 	}
 
-	qurt_thread_exit(0);
+	pthread_exit(0);
+	return nullptr;
 }
 
 int px4muorb_orb_initialize(fc_func_ptrs *func_ptrs, int32_t clock_offset_us)
@@ -93,14 +95,13 @@ char stack[TEST_STACK_SIZE];
 
 void run_test(MUORBTestType test)
 {
-	qurt_thread_t tid;
-	qurt_thread_attr_t attr;
-
-	qurt_thread_attr_init(&attr);
-	qurt_thread_attr_set_stack_addr(&attr, stack);
-	qurt_thread_attr_set_stack_size(&attr, TEST_STACK_SIZE);
+	pthread_t tid;
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setstacksize(&attr, TEST_STACK_SIZE);
 	test_to_run = test;
-	(void) qurt_thread_create(&tid, &attr, &test_runner, (void *) &test_to_run);
+	pthread_create(&tid, &attr, &test_runner, (void *) &test_to_run);
+	pthread_attr_destroy(&attr);
 }
 
 int px4muorb_topic_advertised(const char *topic_name)
@@ -137,15 +138,10 @@ int px4muorb_send_topic_data(const char *topic_name, const uint8_t *data,
 		// Validate the test data received
 		bool test_passed = true;
 
-		if (data_len_in_bytes != MUORB_TEST_DATA_LEN) {
-			test_passed = false;
-
-		} else {
-			for (int i = 0; i < data_len_in_bytes; i++) {
-				if ((uint8_t) i != data[i]) {
-					test_passed = false;
-					break;
-				}
+		for (int i = 0; i < data_len_in_bytes; i++) {
+			if ((uint8_t) i != data[i]) {
+				test_passed = false;
+				break;
 			}
 		}
 

--- a/src/modules/muorb/slpi/uORBProtobufChannel.cpp
+++ b/src/modules/muorb/slpi/uORBProtobufChannel.cpp
@@ -75,7 +75,6 @@ static void *test_runner(void *test)
 		break;
 	}
 
-	qurt_thread_exit(0);
 	return nullptr;
 }
 

--- a/src/modules/muorb/slpi/uORBProtobufChannel.cpp
+++ b/src/modules/muorb/slpi/uORBProtobufChannel.cpp
@@ -48,11 +48,6 @@ fc_func_ptrs muorb_func_ptrs;
 
 static void *test_runner(void *test)
 {
-	uint8_t data[MUORB_TEST_DATA_LEN];
- 	for (uint8_t i = 0; i < MUORB_TEST_DATA_LEN; i++) {
-		data[i] = i;
-	};
-
 	HAP_debug("test_runner called", 1, muorb_test_topic_name, 0);
 
 	switch (*((MUORBTestType *) test)) {
@@ -68,14 +63,19 @@ static void *test_runner(void *test)
 		(void) muorb_func_ptrs.unsubscribe_func_ptr(muorb_test_topic_name);
 		break;
 
-	case TOPIC_TEST_TYPE:
-		(void) muorb_func_ptrs.topic_data_func_ptr(muorb_test_topic_name, data, MUORB_TEST_DATA_LEN);
+	case TOPIC_TEST_TYPE: {
+			uint8_t data[MUORB_TEST_DATA_LEN];
+
+			for (uint8_t i = 0; i < MUORB_TEST_DATA_LEN; i++) { data[i] = i; }
+
+			(void) muorb_func_ptrs.topic_data_func_ptr(muorb_test_topic_name, data, MUORB_TEST_DATA_LEN);
+		}
 
 	default:
 		break;
 	}
 
-	pthread_exit(0);
+	qurt_thread_exit(0);
 	return nullptr;
 }
 
@@ -138,10 +138,15 @@ int px4muorb_send_topic_data(const char *topic_name, const uint8_t *data,
 		// Validate the test data received
 		bool test_passed = true;
 
-		for (int i = 0; i < data_len_in_bytes; i++) {
-			if ((uint8_t) i != data[i]) {
-				test_passed = false;
-				break;
+		if (data_len_in_bytes != MUORB_TEST_DATA_LEN) {
+			test_passed = false;
+
+		} else {
+			for (int i = 0; i < data_len_in_bytes; i++) {
+				if ((uint8_t) i != data[i]) {
+					test_passed = false;
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

Describe problem solved by this pull request
This is a PR to add support for PTHREAD functioning on the DSP/qurt architecture (Swapping from qurt_threads to pthreads for easier builds).

Describe your solution
This is the bare minimum of code to run the muorb module on a pthread leveraging the hexagon SDK.