### PR TITLE
ms5611: ignore reading 0

### DIFF
--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -253,6 +253,18 @@ MS5611::collect()
 		return ret;
 	}
 
+	// According to the sensor docs:
+	// If the conversion is not executed before the ADC read command, or the
+	// ADC read command is repeated, it will give 0 as the output result.
+	//
+	// We have seen 0 during the init phase on I2C, therefore, we add this
+	// protection in.
+	if (raw == 0) {
+		perf_count(_comms_errors);
+		perf_end(_sample_perf);
+		return ret;
+	}
+
 	/* handle a measurement */
 	if (_measure_phase == 0) {
 


### PR DESCRIPTION
This prevents publishing a negative pressure which leads to a NAN altitude estimate further down the line.

This was discovered on the Holybro Pixhawk 6C where the ms5611 is connected via I2C, and using the release/1.13 branch.

I suspect the measuring and collecting is a bit out of whack initially which leads to this from what I can see in the console right after startup:

```
ms5611 #0 on I2C bus 4 (external) address 0x77
486836: measure(), phase: 0
ist8310 #0 on I2C bus 4 (external) address 0xC
WARN  [SPI_I2C] ist8310: no instance started (no device on bus?)
507538: collect(), phase: 0
nsh: icm20948_i2c_passthrough: command not found
522745: measure(), phase: 1
546096: collect(), phase: 1
failed
551336: collect(), phase: 1
failed
557794: collect(), phase: 1
failed
565867: collect(), phase: 1
ret: 0, P: -94778, raw: 0, _SENS: 1553559751, _OFF: 3105658750
568031: measure(), phase: 2
NAN!=====================================
589313: collect(), phase: 2
ret: 0, P: 101241, raw: 8670584, _SENS: 1553559751, _OFF: 3105658750
596646: measure(), phase: 3
INFO  [init] Mixer: /etc/mixers/quad_x.main.mix on /dev/pwm_output0
619024: collect(), phase: 3
ret: 0, P: 101243, raw: 8670712, _SENS: 1553559751, _OFF: 3105658750
632461: measure(), phase: 0
INFO  [init] Mixer: /etc/mixers/pass.aux.mix on /dev/pwm_output1
654827: collect(), phase: 0
ekf2 [668:237]
661698: measure(), phase: 1
679172: collect(), phase: 1
```

@vincentpoont2 this should fix the altitude estimation problem that you discovered.
