### PR TITLE
[VTOL] Abort front transition if RTL is activated during transition

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -228,7 +228,9 @@ void RTL::find_RTL_destination()
 		}
 	}
 
-	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+	if (_param_rtl_cone_half_angle_deg.get() > 0.0
+	    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
+	    && !_navigator->get_vstatus()->in_transition_to_fw) {
 		_rtl_alt = calculate_return_alt_from_cone_half_angle((float)_param_rtl_cone_half_angle_deg.get());
 
 	} else {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -240,6 +240,15 @@ void RTL::on_activation()
 {
 	_rtl_state = RTL_STATE_NONE;
 
+	// send a back transition command in case we're doing a front transition to abort the FT
+	if (_navigator->get_vstatus()->in_transition_to_fw) {
+		vehicle_command_s cmd {};
+		cmd.command = vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION;
+		cmd.param1 = (float)(vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC);
+		cmd.param2 = 0.0f;
+		_navigator->publish_vehicle_cmd(&cmd);
+	}
+
 	// if a mission landing is desired we should only execute mission navigation mode if we currently are in fw mode
 	// In multirotor mode no landing pattern is required so we can just navigate to the land point directly and don't need to run mission
 	_should_engange_mission_for_landing = (_destination.type == RTL_DESTINATION_MISSION_LANDING)

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -229,8 +229,7 @@ void RTL::find_RTL_destination()
 	}
 
 	if (_param_rtl_cone_half_angle_deg.get() > 0
-	    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-	    && !_navigator->get_vstatus()->in_transition_to_fw) {
+	    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 		_rtl_alt = calculate_return_alt_from_cone_half_angle((float)_param_rtl_cone_half_angle_deg.get());
 
 	} else {
@@ -241,15 +240,6 @@ void RTL::find_RTL_destination()
 void RTL::on_activation()
 {
 	_rtl_state = RTL_STATE_NONE;
-
-	// send a back transition command in case we're doing a front transition to abort the FT
-	if (_navigator->get_vstatus()->in_transition_to_fw) {
-		vehicle_command_s cmd {};
-		cmd.command = vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION;
-		cmd.param1 = (float)(vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC);
-		cmd.param2 = 0.0f;
-		_navigator->publish_vehicle_cmd(&cmd);
-	}
 
 	// if a mission landing is desired we should only execute mission navigation mode if we currently are in fw mode
 	// In multirotor mode no landing pattern is required so we can just navigate to the land point directly and don't need to run mission

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -228,7 +228,7 @@ void RTL::find_RTL_destination()
 		}
 	}
 
-	if (_param_rtl_cone_half_angle_deg.get() > 0.0
+	if (_param_rtl_cone_half_angle_deg.get() > 0
 	    && _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 	    && !_navigator->get_vstatus()->in_transition_to_fw) {
 		_rtl_alt = calculate_return_alt_from_cone_half_angle((float)_param_rtl_cone_half_angle_deg.get());
@@ -712,7 +712,7 @@ float RTL::calculate_return_alt_from_cone_half_angle(float cone_half_angle_deg)
 
 	} else {
 
-		if (cone_half_angle_deg > 0.0f && destination_dist <= _param_rtl_min_dist.get()) {
+		if (destination_dist <= _param_rtl_min_dist.get()) {
 
 			// constrain cone half angle to meaningful values. All other cases are already handled above.
 			const float cone_half_angle_rad = radians(constrain(cone_half_angle_deg, 1.0f, 89.0f));

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -210,6 +210,7 @@ private:
 	vehicle_land_detected_s			_land_detected{};
 	vehicle_local_position_s		_local_pos{};
 	vehicle_local_position_setpoint_s	_local_pos_sp{};
+	vehicle_status_s 			_vehicle_status{};
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
 
 	float _air_density{CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C};	// [kg/m^3]
@@ -222,11 +223,15 @@ private:
 	int		_transition_command{vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC};
 	bool		_immediate_transition{false};
 
+	uint8_t _nav_state_prev;
+
 	VtolType	*_vtol_type{nullptr};	// base class for different vtol types
 
 	bool		_initialized{false};
 
 	perf_counter_t	_loop_perf;		// loop performance counter
+
+	void		vehicle_status_poll();
 
 	void		action_request_poll();
 


### PR DESCRIPTION
## Describe problem solved by this pull request
When experimenting on an improved front transition tracking (for which I hope to be able to present a PR soon), I realised that it would make more sense to abort the front transition when an RTL is triggered during the transition. Like this you switch back to MC mode immediately and fly back to the RTL point directly instead of finishing the transition then U-turning to finally do the back transition again before landing.

## Describe your solution
Send a back transition command if RTL is activated during a front transition.

## Describe possible alternatives
\-
## Test data / coverage
SITL gazebo_standard_vtol: https://logs.px4.io/plot_app?log=5126b6cf-6e74-4e82-ae1e-74513e057027

To compare, this is how it behaves on current main: https://logs.px4.io/plot_app?log=cd083ce8-4b1e-4bde-b4a8-91d87266ec83

## Additional context
I also modified slightly how the return altitude is calculated. If the transition cone is 0° it doesn't make sense to call the function which calculates the altitude based on it.