### PR TITLE
Add speed_xy constraint

### DIFF
--- a/msg/vehicle_constraints.msg
+++ b/msg/vehicle_constraints.msg
@@ -3,6 +3,7 @@
 
 uint64 timestamp # time since system start (microseconds)
 
+float32 speed_xy # in meters/sec
 float32 speed_up # in meters/sec
 float32 speed_down # in meters/sec
 

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -536,6 +536,10 @@ void MulticopterPositionControl::Run()
 				max_speed_xy = math::min(max_speed_xy, vehicle_local_position.vxy_max);
 			}
 
+			if (PX4_ISFINITE(_vehicle_constraints.speed_xy)) {
+				max_speed_xy = math::min(max_speed_xy, _vehicle_constraints.speed_xy);
+			}
+
 			_control.setVelocityLimits(
 				max_speed_xy,
 				math::min(speed_up, _param_mpc_z_vel_max_up.get()), // takeoff ramp starts with negative velocity limit


### PR DESCRIPTION
This PR adds the ability to set a max XY velocity constraint from a flight task. For instance, in a flight task where you want to set a position setpoint but not a velocity, you can set a max velocity constraint and let the position controller adjust the velocity automatically but not exceed the constraint.