### PR TITLE
modalai_esc - directly using deadband param value instead of converting it to RPM

### DIFF
--- a/src/drivers/actuators/modalai_esc/modalai_esc.cpp
+++ b/src/drivers/actuators/modalai_esc/modalai_esc.cpp
@@ -966,7 +966,8 @@ void ModalaiEsc::mix_turtle_mode(uint16_t outputs[MAX_ACTUATORS])
 					     float)_parameters.turtle_motor_percent / 100.f);
 
 		// Add a little bit to the motorOutputMin so props aren't spinning when sticks are centered
-		motor_output = (motor_output < _rpm_turtle_min + _parameters.turtle_motor_deadband) ? 0.0f : (motor_output - _parameters.turtle_motor_deadband);
+		motor_output = (motor_output < _rpm_turtle_min + _parameters.turtle_motor_deadband) ? 0.0f :
+			       (motor_output - _parameters.turtle_motor_deadband);
 
 		// using the output map here for clarity as PX4 motors are 1-4
 		switch (_output_map[i].number) {

--- a/src/drivers/actuators/modalai_esc/modalai_esc.cpp
+++ b/src/drivers/actuators/modalai_esc/modalai_esc.cpp
@@ -966,8 +966,7 @@ void ModalaiEsc::mix_turtle_mode(uint16_t outputs[MAX_ACTUATORS])
 					     float)_parameters.turtle_motor_percent / 100.f);
 
 		// Add a little bit to the motorOutputMin so props aren't spinning when sticks are centered
-		float dead_band_rpm = ((float)_parameters.turtle_motor_deadband / 100.0f) * _rpm_fullscale;
-		motor_output = (motor_output < _rpm_turtle_min + dead_band_rpm) ? 0.0f : (motor_output -  dead_band_rpm);
+		motor_output = (motor_output < _rpm_turtle_min + _parameters.turtle_motor_deadband) ? 0.0f : (motor_output - _parameters.turtle_motor_deadband);
 
 		// using the output map here for clarity as PX4 motors are 1-4
 		switch (_output_map[i].number) {


### PR DESCRIPTION
Per usage feedback in the field, use the "turtle mode dead band" value instead of converting it to RPM