### PR TITLE
Commander: allow disarmin not-landed boat like rover

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -685,7 +685,7 @@ transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool f
 {
 	if (!forced) {
 		const bool landed = (_vehicle_land_detected.landed || _vehicle_land_detected.maybe_landed
-				     || is_ground_rover(_vehicle_status));
+				     || is_ground_vehicle(_vehicle_status));
 		const bool mc_manual_thrust_mode = _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
 						   && _vehicle_control_mode.flag_control_manual_enabled
 						   && !_vehicle_control_mode.flag_control_climb_rate_enabled;

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -123,6 +123,16 @@ bool is_ground_rover(const vehicle_status_s &current_status)
 	return current_status.system_type == VEHICLE_TYPE_GROUND_ROVER;
 }
 
+bool is_boat(const vehicle_status_s &current_status)
+{
+	return current_status.system_type == VEHICLE_TYPE_BOAT;
+}
+
+bool is_ground_vehicle(const vehicle_status_s &current_status)
+{
+	return is_ground_rover(current_status) || is_boat(current_status);
+}
+
 // End time for currently blinking LED message, 0 if no blink message
 static hrt_abstime blink_msg_end = 0;
 static int fd_leds{-1};

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -56,6 +56,8 @@ bool is_vtol(const vehicle_status_s &current_status);
 bool is_vtol_tailsitter(const vehicle_status_s &current_status);
 bool is_fixed_wing(const vehicle_status_s &current_status);
 bool is_ground_rover(const vehicle_status_s &current_status);
+bool is_boat(const vehicle_status_s &current_status);
+bool is_ground_vehicle(const vehicle_status_s &current_status);
 
 int buzzer_init(void);
 void buzzer_deinit(void);


### PR DESCRIPTION
## Describe problem solved by this pull request

Reported via Discord by @PierceNichols:
> So, an issue I have been having with my project is that the commander module never shows a boat as landed. Therefore, it refuses to disarm in response to the arming switch mapped from the RC controller and can only be disarmed through QGC. 

> For my own project, I made a one-line change to the is_ground_rover() function in src/modules/commander/commander_helper.cpp so that it returns true for both ground rovers and boats instead of just ground rovers. Would this be an acceptable patch to submit?

https://discordapp.com/channels/1022170275984457759/1026905600241696819/1026966402378248224

## Describe your solution
I extend this hack to boats: https://github.com/PX4/PX4-Autopilot/commit/98dfa30838f78dfe74f903e26be9e0050578ee4a
We need to fix land detection and its dependencies for ground vehicles!

## Describe possible alternatives
This is a hotfix and a boat should never even detect a takeoff in normal operation.

## Test data / coverage
Untested. @PierceNichols please test in your use case.