### PR TITLE
Increase mag calibration max_var_allowed

### DIFF
--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -254,7 +254,7 @@ void VehicleMagnetometer::UpdateMagCalibration()
 	// Larger values cause a larger fraction of the learned biases to be used.
 	static constexpr float magb_vref = 2.5e-7f;
 	static constexpr float min_var_allowed = magb_vref * 0.01f;
-	static constexpr float max_var_allowed = magb_vref * 100.f;
+	static constexpr float max_var_allowed = magb_vref * 500.f;
 
 	if (_armed) {
 		static constexpr uint8_t mag_cal_size = sizeof(_mag_cal) / sizeof(_mag_cal[0]);


### PR DESCRIPTION
I am seeing the auto mag cal not updating ever. Examine the logs, it appears that the Z bias variance is always much higher than X and Y, which will cause the valid check to fail.

Increasing the max variance to 500 allows most of these flights to be in the valid range after about 4 minutes of flying. 

Maybe we need to have different limits for XY and Z. 

![image](https://user-images.githubusercontent.com/2019539/194181381-4a8fc4f0-6013-4c0c-a734-2a57fde8464e.png)
![image](https://user-images.githubusercontent.com/2019539/194181394-6246ee53-b011-4fad-9396-364482a42889.png)
![image](https://user-images.githubusercontent.com/2019539/194181406-18553068-c3c5-4df5-ae91-66cc39b3c129.png)
![image](https://user-images.githubusercontent.com/2019539/194181417-bb06d093-ce73-47ec-a5d1-0efc3d7f5c95.png)
![image](https://user-images.githubusercontent.com/2019539/194181429-196940f7-63f1-4849-a734-20b1bff1559b.png)
![image](https://user-images.githubusercontent.com/2019539/194181450-9c5d3477-e501-4415-8236-4b03a4e964c7.png)
![image](https://user-images.githubusercontent.com/2019539/194181471-a5c0dfc1-99ce-4173-a060-7d85fbf09142.png)
![image](https://user-images.githubusercontent.com/2019539/194181483-dac91269-50c6-4d33-be0b-440849780a0f.png)
![image](https://user-images.githubusercontent.com/2019539/194181502-42d08c25-c432-4404-976e-5ad7241c839d.png)
