### PR TITLE
Add CPU Load averaging to cpuResourceCheck

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/cpuResourceCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/cpuResourceCheck.hpp
@@ -34,9 +34,18 @@
 #pragma once
 
 #include "../Common.hpp"
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/cpuload.h>
+
+using namespace math;
+using namespace time_literals;
+
+// Time constant for the alpha filter for averaging out the Cpu load over time
+// Currently, `cpu_load` message is being published at 2Hz, so assume 3-sample
+// timewindow as the alphafilter time constant
+static constexpr float CPULOAD_ALPHAFILTER_TIME_CONSTANT = 1.5f;
 
 class CpuResourceChecks : public HealthAndArmingCheckBase
 {
@@ -48,6 +57,9 @@ public:
 
 private:
 	uORB::Subscription _cpuload_sub{ORB_ID(cpuload)};
+
+	AlphaFilter<float> _cpuload_alphafilter{};
+	hrt_abstime _last_cpuload_timestamp{0}; // Last timestamp of the cpuload message
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamFloat<px4::params::COM_CPU_MAX>) _param_com_cpu_max


### PR DESCRIPTION
## Describe problem solved by this pull request
Currently in `main`, the `EKF2_MULTI_IMU` is by default set to 3, which adds ~10% of CPU load, and the base CPU load is now around 75%.

In the event of CPU load spikes: like parameter update (when all the modules come to halt for a bit to update it's internal parameters), the CPU load can breach the CPU load limit configured by the `COM_CPU_MAX` parameter (90 by default).

This was causing numerous preflight fail error messages popping up in GCS, which is a bit misleading.

## Describe your solution
Implemented an Alphafilter to filter out the CPU Load across 3 samples (roughly, determined by the time constant)

## Describe possible alternatives
Moving average filter would be a better choice, but that would come at a cost of memory

## Additional context
https://github.com/PX4/PX4-Autopilot/pull/20358 is related, but only fixes the board LED behavior based on the `COM_CPU_MAX` parameter.

Maybe it's better to unify this 'averaged CPU load' to also trigger LED changes? @dagar 

Oh I just noticed https://github.com/PX4/PX4-Autopilot/pull/20359, I think then this PR isn't necessary?