### PR TITLE
commander: relax COM_ARM_MAG_ANG default to minimize false positives

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -609,7 +609,7 @@ PARAM_DEFINE_FLOAT(COM_ARM_IMU_GYR, 0.25f);
  * @min 3
  * @max 180
  */
-PARAM_DEFINE_INT32(COM_ARM_MAG_ANG, 45);
+PARAM_DEFINE_INT32(COM_ARM_MAG_ANG, 60);
 
 /**
  * Enable mag strength preflight check


### PR DESCRIPTION
This might be controversial, but this preflight check often reports false positives that aren't actually going to be problematic in real operation.

In my mind this check is mainly for catching blatant setup problems like a magnetometer that's mounted 90 or 180 degrees off.