### PR TITLE
airspeed_selector: update wind estimator (w/o airspeed fusion) always if in FW mode

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -522,7 +522,7 @@ void AirspeedModule::update_wind_estimator_sideslip()
 
 	if (_vehicle_local_position_valid
 	    && _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING
-	    && _vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+	    && !_vehicle_land_detected.landed) {
 		Vector3f vI(_vehicle_local_position.vx, _vehicle_local_position.vy, _vehicle_local_position.vz);
 		Quatf q(_vehicle_attitude.q);
 

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -521,8 +521,8 @@ void AirspeedModule::update_wind_estimator_sideslip()
 	_wind_estimator_sideslip.update(_time_now_usec);
 
 	if (_vehicle_local_position_valid
-	    && _vtol_vehicle_status.vehicle_vtol_state == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW &&
-	    _vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+	    && _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING
+	    && _vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
 		Vector3f vI(_vehicle_local_position.vx, _vehicle_local_position.vy, _vehicle_local_position.vz);
 		Quatf q(_vehicle_attitude.q);
 

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -385,7 +385,7 @@ AirspeedModule::Run()
 					_in_takeoff_situation = true;
 				}
 
-				input_data.in_fixed_wing_flight = (armed && in_air_fixed_wing && !_in_takeoff_situation);
+				input_data.in_fixed_wing_flight = (in_air_fixed_wing && !_in_takeoff_situation);
 
 				// push input data into airspeed validator
 				_airspeed_validator[i].update_airspeed_validator(input_data);


### PR DESCRIPTION
Thanks for raising @bresch 

## Describe problem solved by this pull request
No wind sideslip-only-wind estimate on planes.
![image](https://user-images.githubusercontent.com/26798987/194543214-66e31a09-07e0-4bdb-8d8a-4b45d24d3c7f.png)


## Describe your solution
`_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING` instead of `vtol_status`. 

While on it I also removed a redundant check for armed (check for landed is enough) and in another check swapped the check for if(armed) to if(!landed). 

## Describe possible alternatives
I briefly tried to further clean up/simplify the current if(landed), if(fixed-wing-flight), if(in-takeoff-condition) mess, but it's not that easy. I feel like most efficiently we should try to improve the fixed-wing land detector. If we centrally are good in land detection we can use it system wide without all these extra checks. Currently it though detects takeoff way too early and landing too late. Maybe we could use the "groundcontact" flag (isn't implemented for FW) and harden the land detection with that, plus use it in places where we ultimately just care about whether there is physical contact to the ground, and don't care about it being fully landed. That flag would then be a cleaner condition to start/stop updating the airspeed-less wind instance. 

## Test data / coverage
SITL tested.

## Additional context
