### PR TITLE
px4_platform_common: I2CBusIterator/SPIBusIterator return bus integer directly

### DIFF
--- a/platforms/common/i2c.cpp
+++ b/platforms/common/i2c.cpp
@@ -41,7 +41,7 @@
 bool px4_i2c_bus_external(int bus)
 {
 	for (int i = 0; i < I2C_BUS_MAX_BUS_ITEMS; ++i) {
-		if (px4_i2c_buses[i].bus == bus) {
+		if ((px4_i2c_buses[i].bus != -1) && (px4_i2c_buses[i].bus == bus)) {
 			return px4_i2c_buses[i].is_external;
 		}
 	}

--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * Copyright (C) 2020, 2021 PX4 Development Team. All rights reserved.
+ * Copyright (C) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -332,7 +332,7 @@ bool BusInstanceIterator::next()
 
 	} else if (busType() == BOARD_SPI_BUS) {
 		if (_spi_bus_iterator.next()) {
-			bus = _spi_bus_iterator.bus().bus;
+			bus = _spi_bus_iterator.bus();
 		}
 
 #endif // CONFIG_SPI
@@ -340,7 +340,7 @@ bool BusInstanceIterator::next()
 
 	} else if (busType() == BOARD_I2C_BUS) {
 		if (_i2c_bus_iterator.next()) {
-			bus = _i2c_bus_iterator.bus().bus;
+			bus = _i2c_bus_iterator.bus();
 		}
 
 #endif // CONFIG_I2C
@@ -448,14 +448,14 @@ int BusInstanceIterator::bus() const
 #if defined(CONFIG_SPI)
 
 	if (busType() == BOARD_SPI_BUS) {
-		return _spi_bus_iterator.bus().bus;
+		return _spi_bus_iterator.bus();
 	}
 
 #endif // CONFIG_SPI
 #if defined(CONFIG_I2C)
 
 	if (busType() == BOARD_I2C_BUS) {
-		return _i2c_bus_iterator.bus().bus;
+		return _i2c_bus_iterator.bus();
 	}
 
 #endif // CONFIG_I2C

--- a/platforms/common/include/px4_platform_common/i2c.h
+++ b/platforms/common/include/px4_platform_common/i2c.h
@@ -80,7 +80,7 @@ public:
 
 	bool next();
 
-	const px4_i2c_bus_t &bus() const { return px4_i2c_buses[_index]; }
+	int bus() const { return px4_i2c_buses[_index].bus; }
 
 	int externalBusIndex() const { return _external_bus_counter; }
 

--- a/platforms/common/include/px4_platform_common/spi.h
+++ b/platforms/common/include/px4_platform_common/spi.h
@@ -153,14 +153,14 @@ public:
 
 	bool next();
 
-	const px4_spi_bus_t &bus() const { return px4_spi_buses[_index]; }
+	int bus() const { return px4_spi_buses[_index].bus; }
 	spi_drdy_gpio_t DRDYGPIO() const { return px4_spi_buses[_index].devices[_bus_device_index].drdy_gpio; }
 
 	uint32_t devid() const { return px4_spi_buses[_index].devices[_bus_device_index].devid; }
 
 	int externalBusIndex() const { return _external_bus_counter; }
 
-	bool external() const { return px4_spi_bus_external(bus()); }
+	bool external() const { return px4_spi_bus_external(px4_spi_buses[_index]); }
 
 	int busDeviceIndex() const { return _bus_device_index; }
 

--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -139,7 +139,7 @@ int px4_platform_init()
 	I2CBusIterator i2c_bus_iterator {I2CBusIterator::FilterType::All};
 
 	while (i2c_bus_iterator.next()) {
-		i2c_master_s *i2c_dev = px4_i2cbus_initialize(i2c_bus_iterator.bus().bus);
+		i2c_master_s *i2c_dev = px4_i2cbus_initialize(i2c_bus_iterator.bus());
 
 #if defined(CONFIG_I2C_RESET)
 		I2C_RESET(i2c_dev);


### PR DESCRIPTION
 - don't expose full px4_i2c_bus_t/px4_spi_bus_t
