### PR TITLE
mavlink local_position_ned: always publish on update, not just when xy and v_xy valid

### DIFF
--- a/src/modules/mavlink/streams/LOCAL_POSITION_NED.hpp
+++ b/src/modules/mavlink/streams/LOCAL_POSITION_NED.hpp
@@ -62,21 +62,20 @@ private:
 		vehicle_local_position_s lpos;
 
 		if (_lpos_sub.update(&lpos)) {
-			if (lpos.xy_valid && lpos.v_xy_valid) {
-				mavlink_local_position_ned_t msg{};
+			mavlink_local_position_ned_t msg{};
 
-				msg.time_boot_ms = lpos.timestamp / 1000;
-				msg.x = lpos.x;
-				msg.y = lpos.y;
-				msg.z = lpos.z;
-				msg.vx = lpos.vx;
-				msg.vy = lpos.vy;
-				msg.vz = lpos.vz;
+			msg.time_boot_ms = lpos.timestamp / 1000;
+			msg.x = lpos.x;
+			msg.y = lpos.y;
+			msg.z = lpos.z;
+			msg.vx = lpos.vx;
+			msg.vy = lpos.vy;
+			msg.vz = lpos.vz;
 
-				mavlink_msg_local_position_ned_send_struct(_mavlink->get_channel(), &msg);
+			mavlink_msg_local_position_ned_send_struct(_mavlink->get_channel(), &msg);
 
-				return true;
-			}
+			return true;
+
 		}
 
 		return false;


### PR DESCRIPTION

## Describe problem solved by this pull request
There is no mavlink message `LOCAL_POSITION_NED` published when v_xy or xy of the local_position get invalid. E.g. after a GNSS failure. The vertical states (vz and z) can though still be fairly well estimated (baro), so not the whole message should be stopped from being published. 
This message can e.g. be used by the groundstation to display the current relative altitude. 

## Describe your solution
Remove validity checks, always publish the message.

## Describe possible alternatives
- Granular checks for xy, z, v_xy, v_z and only fill valid fields. Set others to NaN?
- use other mavlink message for relative altitude. E.g. could be added to VFR_HUD (currently only has AMSL). Or be calculated using AMSL-Home.alt (though what to display then when Home is not valid..)

