### PR TITLE
Remove DO_SET_SERVO support & comment cleanup

### DIFF
--- a/msg/vehicle_command.msg
+++ b/msg/vehicle_command.msg
@@ -36,7 +36,6 @@ uint16 VEHICLE_CMD_DO_SET_HOME = 179			# Changes the home location either to the
 uint16 VEHICLE_CMD_DO_SET_PARAMETER = 180		# Set a system parameter.  Caution!  Use of this command requires knowledge of the numeric enumeration value of the parameter. |Parameter number| Parameter value| Empty| Empty| Empty| Empty| Empty|
 uint16 VEHICLE_CMD_DO_SET_RELAY = 181			# Set a relay to a condition. |Relay number| Setting (1=on, 0=off, others possible depending on system hardware)| Empty| Empty| Empty| Empty| Empty|
 uint16 VEHICLE_CMD_DO_REPEAT_RELAY = 182		# Cycle a relay on and off for a desired number of cyles with a desired period. |Relay number| Cycle count| Cycle time (seconds, decimal)| Empty| Empty| Empty| Empty|
-uint16 VEHICLE_CMD_DO_SET_SERVO = 183			# Set a servo to a desired PWM value. |Servo number| PWM (microseconds, 1000 to 2000 typical)| Empty| Empty| Empty| Empty| Empty|
 uint16 VEHICLE_CMD_DO_REPEAT_SERVO = 184		# Cycle a between its nominal setting and a desired PWM for a desired number of cycles with a desired period. |Servo number| PWM (microseconds, 1000 to 2000 typical)| Cycle count| Cycle time (seconds)| Empty| Empty| Empty|
 uint16 VEHICLE_CMD_DO_FLIGHTTERMINATION = 185		# Terminate flight immediately |Flight termination activated if > 0.5| Empty| Empty| Empty| Empty| Empty| Empty|
 uint16 VEHICLE_CMD_DO_SET_ACTUATOR = 187		# Sets actuators (e.g. servos) to a desired value. |Actuator 1| Actuator 2| Actuator 3| Actuator 4| Actuator 5| Actuator 6| Index|

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -223,7 +223,7 @@ private:
 	void handle_mission_clear_all(const mavlink_message_t *msg);
 
 	/**
-	 * Parse mavlink MISSION_ITEM message to get mission_item_s.
+	 * Parse mavlink MISSION_ITEM message to get mission_item_s
 	 *
 	 * @param mavlink_mission_item pointer to mavlink_mission_item_t or mavlink_mission_item_int_t
 	 *			       depending on _int_mode
@@ -232,7 +232,9 @@ private:
 	int parse_mavlink_mission_item(const mavlink_mission_item_t *mavlink_mission_item, struct mission_item_s *mission_item);
 
 	/**
-	 * Format mission_item_s as mavlink MISSION_ITEM(_INT) message.
+	 * Format mission_item_s into a mavlink MISSION_ITEM(_INT)
+	 *
+	 * This is used for formatting stored mission plan into a MAVLink mission to send to the GCS
 	 *
 	 * @param mission_item:		pointer to the existing mission item
 	 * @param mavlink_mission_item: pointer to mavlink_mission_item_t or mavlink_mission_item_int_t

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -78,7 +78,6 @@ MissionBlock::is_mission_item_reached_or_completed()
 	switch (_mission_item.nav_cmd) {
 
 	// Action Commands that doesn't have timeout completes instantaneously
-	case NAV_CMD_DO_SET_SERVO:
 	case NAV_CMD_DO_SET_ACTUATOR:
 	case NAV_CMD_DO_LAND_START:
 	case NAV_CMD_DO_TRIGGER_CONTROL:
@@ -559,21 +558,8 @@ MissionBlock::issue_command(const mission_item_s &item)
 		return;
 	}
 
-	if (item.nav_cmd == NAV_CMD_DO_SET_SERVO) {
-		PX4_INFO("DO_SET_SERVO command");
-
-		// XXX: we should issue a vehicle command and handle this somewhere else
-		actuator_controls_s actuators = {};
-		actuators.timestamp = hrt_absolute_time();
-
-		// params[0] actuator number to be set 0..5 (corresponds to AUX outputs 1..6)
-		// params[1] new value for selected actuator in ms 900...2000
-		actuators.control[(int)item.params[0]] = 1.0f / 2000 * -item.params[1];
-
-		_actuator_pub.publish(actuators);
-
-	} else if (item.nav_cmd == NAV_CMD_DO_WINCH ||
-		   item.nav_cmd == NAV_CMD_DO_GRIPPER) {
+	if (item.nav_cmd == NAV_CMD_DO_WINCH ||
+	    item.nav_cmd == NAV_CMD_DO_GRIPPER) {
 		// Initiate Payload Deployment
 		vehicle_command_s vcmd = {};
 		vcmd.command = item.nav_cmd;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -211,7 +211,4 @@ protected:
 	bool _payload_deploy_ack_successful{false};	// Flag to keep track of whether we received an acknowledgement for a successful payload deployment
 	hrt_abstime _payload_deployed_time{0};		// Last payload deployment start time to handle timeouts
 	float _payload_deploy_timeout_s{0.0f};		// Timeout for payload deployment in Mission class, to prevent endless loop if successful deployment ack is never received
-
-	// Used for MAV_CMD_DO_SET_SERVO command of a Mission item
-	uORB::Publication<actuator_controls_s>	_actuator_pub{ORB_ID(actuator_controls_2)};
 };

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -255,7 +255,6 @@ MissionFeasibilityChecker::checkMissionItemValidity(const mission_s &mission)
 		    missionitem.nav_cmd != NAV_CMD_DO_JUMP &&
 		    missionitem.nav_cmd != NAV_CMD_DO_CHANGE_SPEED &&
 		    missionitem.nav_cmd != NAV_CMD_DO_SET_HOME &&
-		    missionitem.nav_cmd != NAV_CMD_DO_SET_SERVO &&
 		    missionitem.nav_cmd != NAV_CMD_DO_SET_ACTUATOR &&
 		    missionitem.nav_cmd != NAV_CMD_DO_LAND_START &&
 		    missionitem.nav_cmd != NAV_CMD_DO_TRIGGER_CONTROL &&
@@ -290,7 +289,7 @@ MissionFeasibilityChecker::checkMissionItemValidity(const mission_s &mission)
 		}
 
 		/* Check non navigation item */
-		if (missionitem.nav_cmd == NAV_CMD_DO_SET_SERVO) {
+		if (missionitem.nav_cmd == NAV_CMD_DO_SET_ACTUATOR) {
 
 			/* check actuator number */
 			if (missionitem.params[0] < 0 || missionitem.params[0] > 5) {
@@ -400,7 +399,7 @@ MissionFeasibilityChecker::checkTakeoff(const mission_s &mission, float home_alt
 					  missionitem.nav_cmd != NAV_CMD_DO_JUMP &&
 					  missionitem.nav_cmd != NAV_CMD_DO_CHANGE_SPEED &&
 					  missionitem.nav_cmd != NAV_CMD_DO_SET_HOME &&
-					  missionitem.nav_cmd != NAV_CMD_DO_SET_SERVO &&
+					  missionitem.nav_cmd != NAV_CMD_DO_SET_ACTUATOR &&
 					  missionitem.nav_cmd != NAV_CMD_DO_LAND_START &&
 					  missionitem.nav_cmd != NAV_CMD_DO_TRIGGER_CONTROL &&
 					  missionitem.nav_cmd != NAV_CMD_DO_DIGICAM_CONTROL &&

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -58,7 +58,7 @@
 
 #define NAV_EPSILON_POSITION	0.001f	/**< Anything smaller than this is considered zero */
 
-/* compatible to mavlink MAV_CMD */
+/* Compatible to mavlink MAV_CMD: https://mavlink.io/en/messages/common.html#mav_commands */
 enum NAV_CMD {
 	NAV_CMD_IDLE = 0,
 	NAV_CMD_WAYPOINT = 16,
@@ -74,7 +74,6 @@ enum NAV_CMD {
 	NAV_CMD_DO_JUMP = 177,
 	NAV_CMD_DO_CHANGE_SPEED = 178,
 	NAV_CMD_DO_SET_HOME = 179,
-	NAV_CMD_DO_SET_SERVO = 183,
 	NAV_CMD_DO_SET_ACTUATOR = 187,
 	NAV_CMD_DO_LAND_START = 189,
 	NAV_CMD_DO_SET_ROI_LOCATION = 195,


### PR DESCRIPTION
## Describe problem solved by this pull request
This removes the support for [DO_SET_SERVO](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_SERVO) MAVLink command.

Existing problems:
- DO_SET_SERVO is redundant to DO_SET_ACTUATOR
- DO_SET_SERVO was getting treated as DO_SET_ACTUATOR in `mission_feasiblity_checker.cpp` wrongly

Also, with the support of Control allocation using normalized command values, commanding PWM values is quite obsolete. This would need to be done in a better way.

## Describe your solution
- Remove DO_SET_SERVO enums from the codebase
- Unify DO_SET_SERVO handling into only DO_SET_ACTUATOR

## Describe possible alternatives
Setting Servo (as one of control allocator's function set) value directly would be the obvious alternative, but I thought that's a bad idea because:

For example, when a fixed wing is flying and you command DO_SET_SERVO, do you really want your Servo to freeze in one position?

Therefore, I think this should rather be handled in Offboard Actuators, to decouple flight control core controls / auxilary actuators, servos

## Additional context
Related PR: https://github.com/PX4/PX4-Autopilot/pull/20325
