### PR TITLE
Smarter pusher ramp up during front transtitions for standard VTOLS

### DIFF
--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -256,6 +256,14 @@ bool param_modify_on_import(bson_node_t node)
 			strcpy(node->name, "VT_FW_DIFTHR_S_Y");
 			PX4_INFO("copying %s -> %s", "VT_FW_DIFTHR_SC", "VT_FW_DIFTHR_S_Y");
 			return true;
+	}
+
+	// 2022-11-08 (stable release v1.13.1): translate VT_F_TRANS_THR/VT_PSHER_RMP_DT -> VT_PSHER_SLEW)
+	{
+		if (strcmp("VT_PSHER_RMP_DT", node->name) == 0) {
+			strcpy(node->name, "VT_PSHER_SLEW");
+			PX4_INFO("copying %s -> %s", "VT_PSHER_RMP_DT", "VT_PSHER_SLEW");
+			return true;
 		}
 	}
 

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -256,9 +256,10 @@ bool param_modify_on_import(bson_node_t node)
 			strcpy(node->name, "VT_FW_DIFTHR_S_Y");
 			PX4_INFO("copying %s -> %s", "VT_FW_DIFTHR_SC", "VT_FW_DIFTHR_S_Y");
 			return true;
+		}
 	}
 
-	// 2022-11-11: translate VT_F_TRANS_THR/VT_PSHER_RMP_DT -> VT_PSHER_SLEW)
+	// 2022-11-11: translate VT_F_TRANS_THR/VT_PSHER_RMP_DT -> VT_PSHER_SLEW
 	{
 		if (strcmp("VT_PSHER_RMP_DT", node->name) == 0) {
 			strcpy(node->name, "VT_PSHER_SLEW");

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -258,7 +258,7 @@ bool param_modify_on_import(bson_node_t node)
 			return true;
 	}
 
-	// 2022-11-08 (stable release v1.13.1): translate VT_F_TRANS_THR/VT_PSHER_RMP_DT -> VT_PSHER_SLEW)
+	// 2022-11-11: translate VT_F_TRANS_THR/VT_PSHER_RMP_DT -> VT_PSHER_SLEW)
 	{
 		if (strcmp("VT_PSHER_RMP_DT", node->name) == 0) {
 			strcpy(node->name, "VT_PSHER_SLEW");

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -262,7 +262,7 @@ bool param_modify_on_import(bson_node_t node)
 	{
 		if (strcmp("VT_PSHER_RMP_DT", node->name) == 0) {
 			strcpy(node->name, "VT_PSHER_SLEW");
-			float _param_vt_f_trans_thr = param_find("VT_F_TRANS_THR");
+			double _param_vt_f_trans_thr = param_find("VT_F_TRANS_THR");
 			node->d = _param_vt_f_trans_thr / node->d;
 			PX4_INFO("copying %s -> %s", "VT_PSHER_RMP_DT", "VT_PSHER_SLEW");
 			return true;

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -262,6 +262,8 @@ bool param_modify_on_import(bson_node_t node)
 	{
 		if (strcmp("VT_PSHER_RMP_DT", node->name) == 0) {
 			strcpy(node->name, "VT_PSHER_SLEW");
+			float _param_vt_f_trans_thr = param_find("VT_F_TRANS_THR");
+			node->d = _param_vt_f_trans_thr / node->d;
 			PX4_INFO("copying %s -> %s", "VT_PSHER_RMP_DT", "VT_PSHER_SLEW");
 			return true;
 		}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -142,7 +142,6 @@ void Standard::update_vtol_state()
 			_vtol_schedule.flight_mode = vtol_mode::TRANSITION_TO_FW;
 			_vtol_schedule.transition_start = hrt_absolute_time();
 
-
 		} else if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {
 			// in fw mode
 			_vtol_schedule.flight_mode = vtol_mode::FW_MODE;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -141,7 +141,6 @@ void Standard::update_vtol_state()
 			 * unsafe flying state. */
 			_vtol_schedule.flight_mode = vtol_mode::TRANSITION_TO_FW;
 			_vtol_schedule.transition_start = hrt_absolute_time();
-			_pusher_start_trans = _pusher_throttle;
 
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {
@@ -174,7 +173,6 @@ void Standard::update_vtol_state()
 
 				// don't set pusher throttle here as it's being ramped up elsewhere
 				_trans_finished_ts = hrt_absolute_time();
-				_pusher_start_trans = 0.0f;
 			}
 		}
 	}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -240,8 +240,6 @@ void Standard::update_transition_state()
 
 		} else if (_pusher_throttle < _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
-			PX4_WARN("Timestamp %f", (double)_transition_dt);
-			//float ramped_pusher_throttle = _pusher_throttle + _param_vt_f_trans_thr.get() /_param_vt_psher_rmp_dt.get();
 			_pusher_throttle = _pusher_start_trans + _param_vt_f_trans_thr.get()
 					   * time_since_trans_start / _param_vt_psher_rmp_dt.get();
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -238,9 +238,7 @@ void Standard::update_transition_state()
 		} else if (_pusher_throttle <= _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
 			_pusher_throttle = math::min(_pusher_throttle +
-			_param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
-
-
+						     _param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
 		}
 
 		_airspeed_trans_blend_margin = _param_vt_arsp_trans.get() - _param_vt_arsp_blend.get();
@@ -295,7 +293,7 @@ void Standard::update_transition_state()
 		if (time_since_trans_start >= _param_vt_b_rev_del.get()) {
 			// Handle throttle reversal for active breaking
 			_pusher_throttle = math::constrain((time_since_trans_start - _param_vt_b_rev_del.get())
-					       * _param_vt_psher_slew.get(), 0.0f, _param_vt_b_trans_thr.get())
+							   * _param_vt_psher_slew.get(), 0.0f, _param_vt_b_trans_thr.get());
 		}
 
 		// continually increase mc attitude control as we transition back to mc mode

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -238,7 +238,7 @@ void Standard::update_transition_state()
 		} else if (_pusher_throttle <= _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
 			_pusher_throttle = math::min(_pusher_throttle +
-						     _param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
+			_param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
 
 
 		}
@@ -294,10 +294,8 @@ void Standard::update_transition_state()
 
 		if (time_since_trans_start >= _param_vt_b_rev_del.get()) {
 			// Handle throttle reversal for active breaking
-			float thrscale = (time_since_trans_start - _param_vt_b_rev_del.get()) * _param_vt_psher_slew.get() /
-					 _param_vt_f_trans_thr.get();
-			thrscale = math::constrain(thrscale, 0.0f, 1.0f);
-			_pusher_throttle = thrscale * _param_vt_b_trans_thr.get();
+			_pusher_throttle = math::constrain((time_since_trans_start - _param_vt_b_rev_del.get())
+					       * _param_vt_psher_slew.get(), 0.0f, _param_vt_b_trans_thr.get())
 		}
 
 		// continually increase mc attitude control as we transition back to mc mode

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -240,7 +240,7 @@ void Standard::update_transition_state()
 
 		} else if (_pusher_throttle < _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
-			PX4_WARN("Timestamp %d last %d ", now, _last_loop_ts);
+			PX4_WARN("Timestamp %f", (double)_transition_dt);
 			//float ramped_pusher_throttle = _pusher_throttle + _param_vt_f_trans_thr.get() /_param_vt_psher_rmp_dt.get();
 			_pusher_throttle = _pusher_start_trans + _param_vt_f_trans_thr.get()
 					   * time_since_trans_start / _param_vt_psher_rmp_dt.get();

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -234,14 +234,14 @@ void Standard::update_transition_state()
 	}
 
 	if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_FW) {
-		if (_param_vt_psher_rmp_dt.get() <= 0.0f) {
+		if (_param_vt_psher_slew.get() <= 0.0f) {
 			// just set the final target throttle value
 			_pusher_throttle = _param_vt_f_trans_thr.get();
 
 		} else if (_pusher_throttle < _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
-			_pusher_throttle = _pusher_start_trans + _param_vt_f_trans_thr.get()
-					   * time_since_trans_start / _param_vt_psher_rmp_dt.get();
+			_pusher_throttle += _param_vt_psher_slew.get() * _dt;
+
 
 		}
 
@@ -296,7 +296,8 @@ void Standard::update_transition_state()
 
 		if (time_since_trans_start >= _param_vt_b_rev_del.get()) {
 			// Handle throttle reversal for active breaking
-			float thrscale = (time_since_trans_start - _param_vt_b_rev_del.get()) / (_param_vt_psher_rmp_dt.get());
+			float thrscale = (time_since_trans_start - _param_vt_b_rev_del.get()) * _param_vt_psher_slew.get() /
+					 _param_vt_f_trans_thr.get();
 			thrscale = math::constrain(thrscale, 0.0f, 1.0f);
 			_pusher_throttle = thrscale * _param_vt_b_trans_thr.get();
 		}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -231,13 +231,14 @@ void Standard::update_transition_state()
 	}
 
 	if (_vtol_schedule.flight_mode == vtol_mode::TRANSITION_TO_FW) {
-		if (_param_vt_psher_slew.get() <= 0.0f) {
+		if (_param_vt_psher_slew.get() <= FLT_EPSILON) {
 			// just set the final target throttle value
 			_pusher_throttle = _param_vt_f_trans_thr.get();
 
-		} else if (_pusher_throttle < _param_vt_f_trans_thr.get()) {
+		} else if (_pusher_throttle <= _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
-			_pusher_throttle += _param_vt_psher_slew.get() * _dt;
+			_pusher_throttle = math::min(_pusher_throttle +
+						     _param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
 
 
 		}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -141,6 +141,8 @@ void Standard::update_vtol_state()
 			 * unsafe flying state. */
 			_vtol_schedule.flight_mode = vtol_mode::TRANSITION_TO_FW;
 			_vtol_schedule.transition_start = hrt_absolute_time();
+			_pusher_start_trans = _pusher_throttle;
+
 
 		} else if (_vtol_schedule.flight_mode == vtol_mode::FW_MODE) {
 			// in fw mode
@@ -172,6 +174,7 @@ void Standard::update_vtol_state()
 
 				// don't set pusher throttle here as it's being ramped up elsewhere
 				_trans_finished_ts = hrt_absolute_time();
+				_pusher_start_trans = 0.0f;
 			}
 		}
 	}
@@ -237,7 +240,9 @@ void Standard::update_transition_state()
 
 		} else if (_pusher_throttle <= _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
-			_pusher_throttle = _param_vt_f_trans_thr.get() * time_since_trans_start / _param_vt_psher_rmp_dt.get();
+			_pusher_throttle = _pusher_start_trans + _param_vt_f_trans_thr.get()
+					   * time_since_trans_start / _param_vt_psher_rmp_dt.get();
+
 		}
 
 		_airspeed_trans_blend_margin = _param_vt_arsp_trans.get() - _param_vt_arsp_blend.get();

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -238,8 +238,10 @@ void Standard::update_transition_state()
 			// just set the final target throttle value
 			_pusher_throttle = _param_vt_f_trans_thr.get();
 
-		} else if (_pusher_throttle <= _param_vt_f_trans_thr.get()) {
+		} else if (_pusher_throttle < _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
+			PX4_WARN("Timestamp %d last %d ", now, _last_loop_ts);
+			//float ramped_pusher_throttle = _pusher_throttle + _param_vt_f_trans_thr.get() /_param_vt_psher_rmp_dt.get();
 			_pusher_throttle = _pusher_start_trans + _param_vt_f_trans_thr.get()
 					   * time_since_trans_start / _param_vt_psher_rmp_dt.get();
 

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -85,7 +85,7 @@ private:
 	void parameters_update() override;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(VtolType,
-					(ParamFloat<px4::params::VT_PSHER_RMP_DT>) _param_vt_psher_rmp_dt,
+					(ParamFloat<px4::params::VT_PSHER_SLEW>) _param_vt_psher_slew,
 					(ParamFloat<px4::params::VT_B_TRANS_RAMP>) _param_vt_b_trans_ramp,
 					(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off,
 					(ParamFloat<px4::params::VT_B_REV_OUT>) _param_vt_b_rev_out,

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -78,6 +78,7 @@ private:
 	} _vtol_schedule;
 
 	float _pusher_throttle{0.0f};
+	float _pusher_start_trans{0.0f};
 	float _reverse_output{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
 

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -78,7 +78,6 @@ private:
 	} _vtol_schedule;
 
 	float _pusher_throttle{0.0f};
-	float _pusher_start_trans{0.0f};
 	float _reverse_output{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
 

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -118,14 +118,14 @@ PARAM_DEFINE_FLOAT(VT_B_REV_OUT, 0.0f);
 PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
 
 /**
- * Pusher throttle ramp up window
+ * Pusher throttle ramp up slew rate
  *
- * Defines the time window during which the pusher throttle will be ramped up linearly to VT_F_TRANS_THR during a transition
- * to fixed wing mode. Zero or negative values will produce an instant throttle rise to VT_F_TRANS_THR.
+ * Defines the slew rate of the throttle during transitions.
+ * Zero or negative values will produce an instant throttle rise to VT_F_TRANS_THR.
  *
  * @max 20
  * @increment 0.01
  * @decimal 2
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_PSHER_RMP_DT, 3.0f);
+PARAM_DEFINE_FLOAT(VT_PSHER_SLEW, 0.33f);

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -120,10 +120,11 @@ PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
 /**
  * Pusher throttle ramp up slew rate
  *
- * Defines the slew rate of the throttle during transitions.
- * Zero or negative values will produce an instant throttle rise to VT_F_TRANS_THR.
+ * Defines the slew rate of the puller/pusher throttle during transitions.
+ * Zero will deactivate the slew rate limiting and thus produce an instant throttle
+ * rise to the transition throttle VT_F_TRANS_THR.
  *
- * @max 20
+ * @min 0
  * @increment 0.01
  * @decimal 2
  * @group VTOL Attitude Control

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -108,7 +108,7 @@ PARAM_DEFINE_FLOAT(VT_B_REV_OUT, 0.0f);
  *
  * Set this to a value greater than 0 to give the motor time to spin down.
  *
- * unit s
+ * @unit s
  * @min 0
  * @max 10
  * @increment 1
@@ -124,6 +124,7 @@ PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
  * Zero will deactivate the slew rate limiting and thus produce an instant throttle
  * rise to the transition throttle VT_F_TRANS_THR.
  *
+ * @unit 1/s
  * @min 0
  * @increment 0.01
  * @decimal 2


### PR DESCRIPTION
## Describe problem solved by this pull request
Before, for standard VTOLs, no matter what pusher throttle was used before, it was reset to zero at the beginning of a front transition and then linearly increased to reach the desired value for fixed wing mode: it was useless, slower and resulted in a waste of energy. 

## Describe your solution
The solution that we implemented is just to make the ramp up start at the previous value assigned to the pusher instead of resetting it to zero, while keeping the same rate of increase: that way, the drone can just accelerate to get to fixed wing mode without having to slow down before.

## Describe possible alternatives
What we implemented was an easy and simple way to improve the behavior of the drone, so we didn't really consider any other solution. There could be smarter ways to do it, maybe using a nonlinear ramp up but we didn't take the time to focus about it.

## Test data / coverage
It was tested on simulation multiple times and worked fine, and since it is just the way that the pusher throttle is computed during front transitions there aren't any corner cases that could cause problems. 

## Additional context
Before modification:
![image](https://user-images.githubusercontent.com/115625131/195345268-c34f7d63-fb9e-4fe5-8037-a67fa04d5c38.png)
After modification (the front transition is at the end of the plot, from around 43s to 50s) :
![Capture d’écran du 2022-10-06 16-44-06](https://user-images.githubusercontent.com/115625131/195345287-ad9d2d2b-4dfc-4887-9886-5be2ec012fb3.png)
