### PR TITLE
MC Land Detector: try to make simpler to tune and less likely to detect early takeoffs, plus improve logging

### DIFF
--- a/msg/VehicleLandDetected.msg
+++ b/msg/VehicleLandDetected.msg
@@ -12,6 +12,7 @@ bool has_low_throttle
 
 bool vertical_movement
 bool horizontal_movement
+bool rotational_movement
 
 bool close_to_ground_or_skipped_check
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -57,6 +57,7 @@ LandDetector::LandDetector() :
 	_land_detected.has_low_throttle = false;
 	_land_detected.vertical_movement = false;
 	_land_detected.horizontal_movement = false;
+	_land_detected.rotational_movement = false;
 	_land_detected.close_to_ground_or_skipped_check = true;
 	_land_detected.at_rest = true;
 }
@@ -174,6 +175,7 @@ void LandDetector::Run()
 		_land_detected.has_low_throttle = _get_has_low_throttle();
 		_land_detected.horizontal_movement = _get_horizontal_movement();
 		_land_detected.vertical_movement = _get_vertical_movement();
+		_land_detected.rotational_movement = _get_rotational_movement();
 		_land_detected.close_to_ground_or_skipped_check = _get_close_to_ground_or_skipped_check();
 		_land_detected.at_rest = at_rest;
 		_land_detected.timestamp = hrt_absolute_time();

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -138,6 +138,7 @@ protected:
 	virtual bool _get_has_low_throttle() { return false; }
 	virtual bool _get_horizontal_movement() { return false; }
 	virtual bool _get_vertical_movement() { return false; }
+	virtual bool _get_rotational_movement() { return false; }
 	virtual bool _get_close_to_ground_or_skipped_check() {  return false; }
 	virtual void _set_hysteresis_factor(const int factor) = 0;
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -278,21 +278,22 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 		return false;
 	}
 
+	// Next look if vehicle is not rotating (do not consider yaw)
+	float max_rotation_threshold = math::radians(_param_lndmc_rot_max.get());
 
-	float landThresholdFactor = 1.f;
-
-	// Widen acceptance thresholds for landed state right after landed
+	// Widen max rotation thresholds for landed state right after landed
 	if ((time_now_us - _landed_time) < LAND_DETECTOR_LAND_PHASE_TIME_US) {
-		landThresholdFactor = 2.5f;
+		max_rotation_threshold *= 2.5f;
 	}
-
-	// Next look if all rotation angles are not moving.
-	const float max_rotation_scaled = math::radians(_param_lndmc_rot_max.get()) * landThresholdFactor;
 
 	matrix::Vector2f angular_velocity{_angular_velocity(0), _angular_velocity(1)};
 
-	if (angular_velocity.norm() > max_rotation_scaled) {
+	if (angular_velocity.norm() > max_rotation_threshold) {
+		_rotational_movement = true;
 		return false;
+
+	} else {
+		_rotational_movement = false;
 	}
 
 	// If vertical velocity is available: ground contact, no thrust, no movement -> landed

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -154,7 +154,7 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 
 		float vertical_velocity_threshold = _param_lndmc_z_vel_max.get();
 
-		if (_maybe_landed_hysteresis.get_state()) {
+		if (_landed_hysteresis.get_state()) {
 			vertical_velocity_threshold *= 2.5f;
 		}
 
@@ -266,9 +266,9 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 	// Next look if vehicle is not rotating (do not consider yaw)
 	float max_rotation_threshold = math::radians(_param_lndmc_rot_max.get());
 
-	// Widen max rotation thresholds if either in maybe landed state, thus making it harder
-	// to trigger a false positive !maybe_landed e.g. due to propeller throttling up/down.
-	if (_maybe_landed_hysteresis.get_state()) {
+	// Widen max rotation thresholds if either in landed state, thus making it harder
+	// to trigger a false positive !landed e.g. due to propeller throttling up/down.
+	if (_landed_hysteresis.get_state()) {
 		max_rotation_threshold *= 2.5f;
 	}
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -272,9 +272,7 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 		max_rotation_threshold *= 2.5f;
 	}
 
-	matrix::Vector2f angular_velocity{_angular_velocity(0), _angular_velocity(1)};
-
-	if (angular_velocity.norm() > max_rotation_threshold) {
+	if (_angular_velocity.xy().norm() > max_rotation_threshold) {
 		_rotational_movement = true;
 		return false;
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -152,13 +152,13 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 		// vertical speed is often deteriorated when on the ground or due to propeller
 		// up/down throttling.
 
-		float max_vertical_velocity = _param_lndmc_z_vel_max.get();
+		float vertical_velocity_threshold = _param_lndmc_z_vel_max.get();
 
 		if (_maybe_landed_hysteresis.get_state()) {
-			max_vertical_velocity *= 2.5f;
+			vertical_velocity_threshold *= 2.5f;
 		}
 
-		_vertical_movement = (fabsf(_vehicle_local_position.vz) > max_vertical_velocity);
+		_vertical_movement = (fabsf(_vehicle_local_position.vz) > vertical_velocity_threshold);
 
 	} else {
 		_vertical_movement = true;

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -202,7 +202,7 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 		if (_trajectory_setpoint_sub.update(&trajectory_setpoint)) {
 			// Setpoints can be NAN
 			_in_descend = PX4_ISFINITE(trajectory_setpoint.velocity[2])
-				      && (trajectory_setpoint.velocity[2] > FLT_EPSILON);
+				      && (trajectory_setpoint.velocity[2] > DESCENT_TRAJECTORY_VZ_THRESHOLD);
 		}
 
 		// ground contact requires commanded descent until landed

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -202,7 +202,7 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 		if (_trajectory_setpoint_sub.update(&trajectory_setpoint)) {
 			// Setpoints can be NAN
 			_in_descend = PX4_ISFINITE(trajectory_setpoint.velocity[2])
-				      && (trajectory_setpoint.velocity[2] > DESCENT_TRAJECTORY_VZ_THRESHOLD);
+				      && (trajectory_setpoint.velocity[2] >= 1.1f * _param_lndmc_z_vel_max.get());
 		}
 
 		// ground contact requires commanded descent until landed

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -87,9 +87,6 @@ private:
 	/** Distance above ground below which entering ground contact state is possible when distance to ground is available. */
 	static constexpr float DIST_FROM_GROUND_THRESHOLD = 1.0f;
 
-	/** Down velocity threshold for setting "in_descend" flag */
-	static constexpr float DESCENT_TRAJECTORY_VZ_THRESHOLD = 0.3f;
-
 	/** Handles for interesting parameters. **/
 	struct {
 		param_t minThrottle;

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,8 +95,6 @@ private:
 		param_t minThrottle;
 		param_t hoverThrottle;
 		param_t minManThrottle;
-		param_t landSpeed;
-		param_t crawlSpeed;
 		param_t useHoverThrustEstimate;
 	} _paramHandle{};
 
@@ -104,8 +102,6 @@ private:
 		float minThrottle;
 		float hoverThrottle;
 		float minManThrottle;
-		float landSpeed;
-		float crawlSpeed;
 		bool useHoverThrustEstimate;
 	} _params{};
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -74,6 +74,7 @@ protected:
 	bool _get_has_low_throttle() override { return _has_low_throttle; }
 	bool _get_horizontal_movement() override { return _horizontal_movement; }
 	bool _get_vertical_movement() override { return _vertical_movement; }
+	bool _get_rotational_movement() override { return _rotational_movement; }
 	bool _get_close_to_ground_or_skipped_check() override { return _close_to_ground_or_skipped_check; }
 
 	void _set_hysteresis_factor(const int factor) override;
@@ -131,6 +132,7 @@ private:
 	bool _in_descend{false};		///< vehicle is commanded to desend
 	bool _horizontal_movement{false};	///< vehicle is moving horizontally
 	bool _vertical_movement{false};
+	bool _rotational_movement{false};
 	bool _has_low_throttle{false};
 	bool _close_to_ground_or_skipped_check{false};
 	bool _below_gnd_effect_hgt{false};	///< vehicle height above ground is below height where ground effect occurs

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -84,8 +84,8 @@ private:
 	/** Time in us that freefall has to hold before triggering freefall */
 	static constexpr hrt_abstime FREEFALL_TRIGGER_TIME_US = 300_ms;
 
-	/** Time interval in us in which wider acceptance thresholds are used after landed. */
-	static constexpr hrt_abstime LAND_DETECTOR_LAND_PHASE_TIME_US = 2_s;
+	/** Time interval in us in which wider acceptance thresholds are used after the "maybe landed" is cleared before takeoff. */
+	static constexpr hrt_abstime LAND_DETECTOR_TAKEOFF_PHASE_TIME_US = 2_s;
 
 	/** Distance above ground below which entering ground contact state is possible when distance to ground is available. */
 	static constexpr float DIST_FROM_GROUND_THRESHOLD = 1.0f;
@@ -123,7 +123,6 @@ private:
 	uint8_t _takeoff_state{takeoff_status_s::TAKEOFF_STATE_DISARMED};
 
 	hrt_abstime _min_thrust_start{0};	///< timestamp when minimum trust was applied first
-	hrt_abstime _landed_time{0};
 
 	bool _in_descend{false};		///< vehicle is commanded to desend
 	bool _horizontal_movement{false};	///< vehicle is moving horizontally

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -87,6 +87,9 @@ private:
 	/** Distance above ground below which entering ground contact state is possible when distance to ground is available. */
 	static constexpr float DIST_FROM_GROUND_THRESHOLD = 1.0f;
 
+	/** Down velocity threshold for setting "in_descend" flag */
+	static constexpr float DESCENT_TRAJECTORY_VZ_THRESHOLD = 0.3f;
+
 	/** Handles for interesting parameters. **/
 	struct {
 		param_t minThrottle;

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -84,9 +84,6 @@ private:
 	/** Time in us that freefall has to hold before triggering freefall */
 	static constexpr hrt_abstime FREEFALL_TRIGGER_TIME_US = 300_ms;
 
-	/** Time interval in us in which wider acceptance thresholds are used after the "maybe landed" is cleared before takeoff. */
-	static constexpr hrt_abstime LAND_DETECTOR_TAKEOFF_PHASE_TIME_US = 2_s;
-
 	/** Distance above ground below which entering ground contact state is possible when distance to ground is available. */
 	static constexpr float DIST_FROM_GROUND_THRESHOLD = 1.0f;
 

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -50,14 +50,16 @@ PARAM_DEFINE_FLOAT(LNDMC_TRIG_TIME, 1.0f);
 /**
  * Multicopter max climb rate
  *
- * Maximum vertical velocity allowed in the landed state
+ * Maximum vertical velocity allowed in the landed state.
+ * Should be set lower than MPC_LAND_SPEED (and MPC_LAND_CRWL
+ * if distance sensor is present).
  *
  * @unit m/s
  * @decimal 1
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.50f);
+PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.25f);
 
 /**
  * Multicopter max horizontal velocity

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -48,11 +48,12 @@
 PARAM_DEFINE_FLOAT(LNDMC_TRIG_TIME, 1.0f);
 
 /**
- * Multicopter max climb rate
+ * Multicopter vertical velocity threshold
  *
- * Maximum vertical velocity allowed in the landed state.
- * Should be set lower than MPC_LAND_SPEED (and MPC_LAND_CRWL
- * if distance sensor is present).
+ * Vertical velocity threshold to detect landing.
+ * Should be set lower than the expected minimal speed for landing
+ * so MPC_LAND_SPEED for autonomous landing and MPC_LAND_CRWL
+ * if distance sensor is present and slowing down close to ground.
  *
  * @unit m/s
  * @decimal 1

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -448,8 +448,9 @@ PARAM_DEFINE_FLOAT(MPC_TILTMAX_LND, 12.0f);
 PARAM_DEFINE_FLOAT(MPC_LAND_SPEED, 0.7f);
 
 /**
- * Land crawl descend rate. Used below MPC_LAND_ALT3 if distance
- * sensor data is availabe.
+ * Land crawl descend rate
+ *
+ * Used below MPC_LAND_ALT3 if distance sensor data is availabe.
  *
  * @unit m/s
  * @min 0.1

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -448,10 +448,11 @@ PARAM_DEFINE_FLOAT(MPC_TILTMAX_LND, 12.0f);
 PARAM_DEFINE_FLOAT(MPC_LAND_SPEED, 0.7f);
 
 /**
- * Land crawl descend rate. Used below
+ * Land crawl descend rate. Used below MPC_LAND_ALT3 if distance
+ * sensor data is availabe.
  *
  * @unit m/s
- * @min 0.3
+ * @min 0.1
  * @decimal 1
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
## Describe problem solved by this pull request
1) vertical speed threshold for land detection very low, plus complex to tune. The threshold is currently:
`min(0.9 * max (MPC_LAND_CRWL, 0.1) * 0.5, LNDMC_Z_VEL_MAX)`, which with the default values is 0.9x0.5x0.3m/s = 0.135m/s, so about 4 times lower than `LNDMC_Z_VEL_MAX and means that `LNDMC_Z_VEL_MAX` is not at all considered (breaking [the documentation of the land detector](https://docs.px4.io/main/en/advanced_config/land_detector.html#ground-contact) .
![image](https://user-images.githubusercontent.com/26798987/196163699-8f834c81-1bbc-4439-9264-092b8712ec88.png)

2) rotational movement (that is checked for land detection) not logged
3) pre-emptive "takeoff" detection during auto takeoff due to motor spool up triggering rotational movement to be above threshold
![image](https://user-images.githubusercontent.com/26798987/196166516-0ade71cd-013e-4cd8-af49-beb8cb035ee1.png)


## Describe your solution
1) MC LandDetector: remove dependency on `MPC_LAND_SPEED` and `MPC_LAND_CRWL`
Don't consider these params for vertical speed threshold, and instead increase the default for `LNDMC_Z_VEL_MAX` and use solely that one. Makes the land detector outcome more predictable and its internal logic simpler, while the new default tuning is increasing the `vz` threshold from 0.135m/s to 0.25m/s. 
For setting the in_descend flag I added a constant (0.3m/s) instead of using the crawl speed for that.

2) add a `rotational_movement` to `land_detector_status` message.

3) Increase threshold for rotational and vertical movement not only during the first 2s after a landing, but always if `maybe_landed` is true (so during takeoff as well as after a landing was detected. That makes it harder to trigger a "not maybe landed" due to rotational or vertical movement during propeller spool up, as well as it keeps it consistent after landing, not just in the first 2s. Also makes the land detector logic a bit simpler and more predictable by removing this extra internal state. 

## Describe possible alternatives
- Instead of https://github.com/PX4/PX4-Autopilot/pull/20425/commits/7b6e2d4ae88abdaa47add4dcd45ebdfd7a7420e2 we could just keep https://github.com/PX4/PX4-Autopilot/pull/20425/commits/d687fcb2cd36446bb044884649f66c7fdc101599 (this keeps the 2s window after takeoff for higher thresholds, but I don't think it's needed).


## Test data / coverage
Minimal SITL testing. 

## Additional context
It used to be that the threshold widening was done after arming instead of after landing, but this was changed in https://github.com/PX4/PX4-Autopilot/pull/7772. Don't fully understand why. 
The `vz` threshold was changed (linked to crawl speed) in https://github.com/PX4/PX4-Autopilot/pull/19126, it used to be considerably higher before as not the crawl speed but the land speed setpoint was taken into account. 

In SITL I sometimes see a thrust spike during an auto takeoff just before the thrust ramp start. This then triggers a pre-emtptive takeoff detection, but I didn't get to the root cause yet. Not sure if reproducible on real vehicles. 
![image](https://user-images.githubusercontent.com/26798987/196167455-47b536a3-ddce-4d11-8db3-2f3f84d641cc.png)

