### PR TITLE
Manual control loss message needs to account for full loss interval.

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
@@ -68,7 +68,7 @@ void RcAndDataLinkChecks::checkAndReport(const Context &context, Report &reporte
 			reporter.setIsPresent(health_component_t::remote_control);
 
 			if (reporter.failsafeFlags().manual_control_signal_lost && _last_valid_manual_control_setpoint > 0) {
-				float elapsed = hrt_elapsed_time(&_last_valid_manual_control_setpoint) * 1e-6f;
+				float elapsed = hrt_elapsed_time(&_last_valid_manual_control_setpoint) * 1e-6f + _param_com_rc_loss_t.get();
 				events::send<float>(events::ID("commander_rc_regained"), events::Log::Info,
 						    "Manual control regained after {1:.1} s", elapsed);
 			}


### PR DESCRIPTION
The error message did not account for the check interval and was therefore under-reporting the loss.