### PR TITLE
Fix feedforward acceleration setpoints for fixedwing offboard position

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2161,10 +2161,13 @@ FixedwingPositionControl::Run()
 					if (PX4_ISFINITE(trajectory_setpoint.acceleration[0]) && PX4_ISFINITE(trajectory_setpoint.acceleration[1])
 					    && PX4_ISFINITE(trajectory_setpoint.acceleration[2])) {
 						Vector2f velocity_sp_2d(trajectory_setpoint.velocity[0], trajectory_setpoint.velocity[1]);
+						Vector2f normalized_velocity_sp_2d = velocity_sp_2d.normalized();
 						Vector2f acceleration_sp_2d(trajectory_setpoint.acceleration[0], trajectory_setpoint.acceleration[1]);
-						Vector2f acceleration_normal = acceleration_sp_2d - acceleration_sp_2d.dot(velocity_sp_2d) *
-									       velocity_sp_2d.normalized();
-						_pos_sp_triplet.current.loiter_radius = velocity_sp_2d.norm() * velocity_sp_2d.norm() / acceleration_normal.norm();
+						Vector2f acceleration_normal = acceleration_sp_2d - acceleration_sp_2d.dot(normalized_velocity_sp_2d) *
+									       normalized_velocity_sp_2d;
+						float direction = -normalized_velocity_sp_2d.cross(acceleration_normal.normalized());
+						_pos_sp_triplet.current.loiter_radius = direction * velocity_sp_2d.norm() * velocity_sp_2d.norm() /
+											acceleration_normal.norm();
 
 					} else {
 						_pos_sp_triplet.current.loiter_radius = NAN;


### PR DESCRIPTION
## Describe problem solved by this pull request
Offboard position setpoints (`local_ned_position_target`) allows you to send feedforward acceleration messages. For fixedwing vehicles, this gets translated into curvature (or loiter radius of position_setpoint_triplet)

Previously when acceleration feedforward inputs were sent, negative curvature accelerations were always being considered as positive curvature (loiter radius > 0.0). Therefore the tracking performance was bad when the curvature was negative.

## Describe your solution
This Fixes the loiter radius computation to also include negative radius

## Test data / coverage
Tested in SITL Gazebo
![196414036-a5f286d1-d93f-4d22-b675-bd4bffe5fa6a](https://user-images.githubusercontent.com/5248102/196459352-285e73f1-203a-4e7c-b111-29bf14aec124.gif)


## Additional context

