### PR TITLE
Wind Estimator: remove filter reset due to beta fusion timeout

### DIFF
--- a/src/lib/wind_estimator/WindEstimator.cpp
+++ b/src/lib/wind_estimator/WindEstimator.cpp
@@ -81,10 +81,6 @@ WindEstimator::initialise(const matrix::Vector3f &velI, const float hor_vel_vari
 		_P(INDEX_W_N, INDEX_W_N) = _P(INDEX_W_E, INDEX_W_E) = sq(INITIAL_WIND_ERROR);
 	}
 
-	// reset the timestamp for measurement rejection
-	_time_rejected_tas = 0;
-	_time_rejected_beta = 0;
-
 	_wind_estimator_reset = true;
 
 	return true;
@@ -143,20 +139,14 @@ WindEstimator::fuse_airspeed(uint64_t time_now, const float true_airspeed, const
 	sym::FuseAirspeed(velI, _state, _P, true_airspeed, _tas_var, FLT_EPSILON,
 			  &H_tas, &K, &_tas_innov_var, &_tas_innov);
 
-	bool reinit_filter = false;
-	bool meas_is_rejected = false;
+	const bool meas_is_rejected = check_if_meas_is_rejected(_tas_innov, _tas_innov_var, _tas_gate);
 
-	// note: _time_rejected_tas and reinit_filter are not used anymore as filter can't get reset due to tas rejection
-	meas_is_rejected = check_if_meas_is_rejected(time_now, _tas_innov, _tas_innov_var, _tas_gate, _time_rejected_tas,
-			   reinit_filter);
+	if (_tas_innov_var < 0.0f) {
+		// re init filter in case of a negative variance, and trigger early return to not fuse measurement
+		_initialised = initialise(velI, hor_vel_variance, matrix::Eulerf(q_att).psi(), true_airspeed, _tas_var);
+		return;
 
-	if (meas_is_rejected || _tas_innov_var < 0.f) {
-		// only reset filter if _tas_innov_var gets unfeasible
-		if (_tas_innov_var < 0.0f) {
-			_initialised = initialise(velI, hor_vel_variance, matrix::Eulerf(q_att).psi(), true_airspeed, _tas_var);
-		}
-
-		// we either did a filter reset or the current measurement was rejected so do not fuse
+	} else if (meas_is_rejected) {
 		return;
 	}
 
@@ -238,20 +228,14 @@ WindEstimator::fuse_beta(uint64_t time_now, const matrix::Vector3f &velI, const 
 	_beta_innov = 0.0f - beta_pred;
 	_beta_innov_var = S(0, 0);
 
-	bool reinit_filter = false;
-	bool meas_is_rejected = false;
+	const bool meas_is_rejected = check_if_meas_is_rejected(_beta_innov, _beta_innov_var, _beta_gate);
 
-	meas_is_rejected = check_if_meas_is_rejected(time_now, _beta_innov, _beta_innov_var, _beta_gate, _time_rejected_beta,
-			   reinit_filter);
+	if (_beta_innov_var < 0.0f) {
+		// re init filter in case of a negative variance, and trigger early return to not fuse measurement
+		_initialised = initialise(velI, hor_vel_variance, matrix::Eulerf(q_att).psi());
+		return;
 
-	reinit_filter |= _beta_innov_var < 0.0f;
-
-	if (meas_is_rejected || reinit_filter) {
-		if (reinit_filter) {
-			_initialised = initialise(velI, hor_vel_variance, matrix::Eulerf(q_att).psi());
-		}
-
-		// we either did a filter reset or the current measurement was rejected so do not fuse
+	} else if (meas_is_rejected) {
 		return;
 	}
 
@@ -301,17 +285,7 @@ WindEstimator::run_sanity_checks()
 }
 
 bool
-WindEstimator::check_if_meas_is_rejected(uint64_t time_now, float innov, float innov_var, uint8_t gate_size,
-		uint64_t &time_meas_rejected, bool &reinit_filter)
+WindEstimator::check_if_meas_is_rejected(float innov, float innov_var, uint8_t gate_size)
 {
-	if (innov * innov > gate_size * gate_size * innov_var) {
-		time_meas_rejected = time_meas_rejected == 0 ? time_now : time_meas_rejected;
-
-	} else {
-		time_meas_rejected = 0;
-	}
-
-	reinit_filter = time_now - time_meas_rejected > 5_s && time_meas_rejected != 0;
-
-	return time_meas_rejected != 0;
+	return (innov * innov > gate_size * gate_size * innov_var);
 }

--- a/src/lib/wind_estimator/WindEstimator.hpp
+++ b/src/lib/wind_estimator/WindEstimator.hpp
@@ -68,8 +68,7 @@ public:
 
 	bool is_estimate_valid() { return _initialised; }
 
-	bool check_if_meas_is_rejected(uint64_t time_now, float innov, float innov_var, uint8_t gate_size,
-				       uint64_t &time_meas_rejected, bool &reinit_filter);
+	bool check_if_meas_is_rejected(float innov, float innov_var, uint8_t gate_size);
 
 	matrix::Vector2f get_wind() { return matrix::Vector2f{_state(INDEX_W_N), _state(INDEX_W_E)}; }
 
@@ -130,9 +129,6 @@ private:
 	uint64_t _time_last_airspeed_fuse = 0;	///< timestamp of last airspeed fusion
 	uint64_t _time_last_beta_fuse = 0;	///< timestamp of last sideslip fusion
 	uint64_t _time_last_update = 0;		///< timestamp of last covariance prediction
-	uint64_t _time_rejected_beta = 0;	///< timestamp of when sideslip measurements have consistently started to be rejected
-	uint64_t _time_rejected_tas =
-		0;	///< timestamp of when true airspeed measurements have consistently started to be rejected
 
 	bool _wind_estimator_reset = false; ///< wind estimator was reset in this cycle
 


### PR DESCRIPTION
## Describe problem solved by this pull request
We had a wind estimator filter reset on a VTOL with low yaw stability (causing it to side-slip quite often) that then a bit later in the flight triggered an airspeed failure because the wind estimate was then re-initialized to very wrong values (due to a high slip angle during initialization). 

The reset happened during a very dynamic flight phase where the side slip angle was high (looking at COG and yaw and the previously estimated wind), and was triggered as the beta_innovations were not fused for more than 5s (threshold for beta fusion, with gate=1 and innov_variance=0.09 is 0.3). 
![image](https://user-images.githubusercontent.com/26798987/196510939-80f585f4-92e6-4e37-81bb-52f76be03254.png)

## Describe your solution
Remove the filter re-init after 5s not fusing beta. I'm yet to see a case where the wind estimator got so out of hands that it needs to be reset because even in normal flight conditions (without a lot of side slip) it wouldn't be fused anymore. Instead, I saw it already a couple of time that a filter with totally healthy states (like here) got reset because the sensors provide bad data (that's the reason the timeout reset was already removed for the airspeed fusion before). 

## Describe possible alternatives
Increase timeout from 5s to e.g. 10s, or even parametrize it (then planes that often slip could have it very high).

The instance 0 of the wind estimates, which can e.g. be used for airspeed-sensor-less flying, only fuses beta. There a reset could maybe make sense, though with the accuracy feedback introduced with https://github.com/PX4/PX4-Autopilot/pull/19955 there is already a way to telling the controller to not use this estimate anymore. If we think this instance should keep the reset then we could certainly enable that. Just not sure on if that really makes the system more stable (see comment above).

## Test data / coverage
SITL only.

## Additional context
If we remove the beta fusion timeout as proposed here, we only do resets of the filter if:
- innovation variance gets negative
- _P has negative values
- any of the states is NAN

Do all these check make sense? Is this best practice to do so? Can we also guard against these cases without resets?
