### PR TITLE
Current message template file does not correctly handle float constant expresssions.

### DIFF
--- a/msg/templates/uorb/msg.h.em
+++ b/msg/templates/uorb/msg.h.em
@@ -82,9 +82,13 @@ for field in spec.parsed_fields():
 
 @# Constants c style
 #ifndef __cplusplus
-@[for constant in spec.constants]@
-#define @(uorb_struct_upper)_@(constant.name) @(int(constant.val))
-@[end for]
+@{
+for constant in spec.constants:
+    if "float" in constant.type:
+        print('#define %s_%s %s'%(spec.short_name.upper(), constant.name, float(constant.val)))
+    else:
+        print('#define %s_%s %s'%(spec.short_name.upper(), constant.name, int(constant.val)))
+}@
 #endif
 
 @##############################
@@ -122,7 +126,10 @@ for constant in spec.constants:
     else:
         raise Exception("Type {0} not supported, add to to template file!".format(type_name))
 
-    print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, int(constant.val)))
+    if "float" in type_name:
+        print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, float(constant.val)))
+    else:
+        print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, int(constant.val)))
 }
 #endif
 };


### PR DESCRIPTION
Changing msg.h.em template to properly handle const references of type float. Without this float values will be interpreted as int's and loose decimal resolution.

## Describe problem solved by this pull request
The current message template interprets all constant reference variables as int's regardless of what type is actually defined in the .msg file.

Example .msg file showing how a float might be used.

Ex: custom_actuator_test.msg
`float32 CUSTOM_ACTUATOR_MIN = 3.141592653589793238`

With the original template file 'msg.h.em' the value of CUSTOM_ACTUATOR_MIN would become 3 instead of the intended value of 3.141592653589793238

## Describe your solution
To properly handle floats the 'msg.h.em' file was augmented.

To handle the creation of accurate `#define` values the following changes were made at line 85.
`@{
for constant in spec.constants:
    if "float" in constant.type:
        print('#define %s_%s %s'%(spec.short_name.upper(), constant.name, float(constant.val)))
    else:
        print('#define %s_%s %s'%(spec.short_name.upper(), constant.name, int(constant.val)))
}@`

Finally to handle the accurate creation of `static constexp` variables the following changes were made at line 125.
`    if "float" in type_name:
        print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, float(constant.val)))
    else:
        print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, int(constant.val)))`

## Describe possible alternatives
I do not see any other alternative if someone wants to have a 'const expression' of type float32/64 inside there uORB message, and they don't want to loose decimal accuracy.

## Test data / coverage
Tested on the bench with a custom message and a custom module that prints the const expression value of the message endlessly.

## Additional context
NA
