### PR TITLE
params/uorb dos - mixer to control allocation

### DIFF
--- a/msg/Gripper.msg
+++ b/msg/Gripper.msg
@@ -1,4 +1,4 @@
-## Used to command an actuation in the gripper, which is mapped to a specific output in the mixer module
+## Used to command an actuation in the gripper, which is mapped to a specific output in the control allocation module
 
 uint64 timestamp
 

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -500,7 +500,6 @@ PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 30.0f);
  * Flaps setting during take-off
  *
  * Sets a fraction of full flaps during take-off.
- * Also applies to flaperons if enabled in control allocation.
  *
  * @unit norm
  * @min 0.0

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -514,7 +514,6 @@ PARAM_DEFINE_FLOAT(FW_FLAPS_TO_SCL, 0.0f);
  * Flaps setting during landing
  *
  * Sets a fraction of full flaps during landing.
- * Also applies to flaperons if enabled in control allocation.
  *
  * @unit norm
  * @min 0.0

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -500,7 +500,7 @@ PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 30.0f);
  * Flaps setting during take-off
  *
  * Sets a fraction of full flaps during take-off.
- * Also applies to flaperons if enabled in the mixer/allocation.
+ * Also applies to flaperons if enabled in control allocation.
  *
  * @unit norm
  * @min 0.0
@@ -515,7 +515,7 @@ PARAM_DEFINE_FLOAT(FW_FLAPS_TO_SCL, 0.0f);
  * Flaps setting during landing
  *
  * Sets a fraction of full flaps during landing.
- * Also applies to flaperons if enabled in the mixer/allocation.
+ * Also applies to flaperons if enabled in control allocation.
  *
  * @unit norm
  * @min 0.0

--- a/src/modules/simulation/simulator_sih/sih.cpp
+++ b/src/modules/simulation/simulator_sih/sih.cpp
@@ -682,11 +682,11 @@ int Sih::print_usage(const char *reason)
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description
-This module provide a simulator for quadrotors and fixed-wings running fully
+This module provides a simulator for quadrotors and fixed-wings running fully
 inside the hardware autopilot.
 
 This simulator subscribes to "actuator_outputs" which are the actuator pwm
-signals given by the mixer.
+signals given by the control allocation module.
 
 This simulator publishes the sensors signals corrupted with realistic noise
 in order to incorporate the state estimator in the loop.


### PR DESCRIPTION
There are params and uorb topics that refer to mixer or mixer/or allocation. I'm trying to update our docs to refer to control allocation wherever this is "no worse" in order to create a cleaner break between mixer and control allocation documentation.