### PR TITLE
Changed M_PI to M_PI_F in the matrix library since M_PI is non-standard.

### DIFF
--- a/src/lib/matrix/matrix/Euler.hpp
+++ b/src/lib/matrix/matrix/Euler.hpp
@@ -93,11 +93,11 @@ public:
 	{
 		theta() = std::asin(-dcm(2, 0));
 
-		if ((std::fabs(theta() - Type(M_PI / 2))) < Type(1.0e-3)) {
+		if ((std::fabs(theta() - Type(M_PI_F / 2))) < Type(1.0e-3)) {
 			phi() = 0;
 			psi() = std::atan2(dcm(1, 2), dcm(0, 2));
 
-		} else if ((std::fabs(theta() + Type(M_PI / 2))) < Type(1.0e-3)) {
+		} else if ((std::fabs(theta() + Type(M_PI_F / 2))) < Type(1.0e-3)) {
 			phi() = 0;
 			psi() = std::atan2(-dcm(1, 2), -dcm(0, 2));
 

--- a/src/lib/matrix/matrix/helper_functions.hpp
+++ b/src/lib/matrix/matrix/helper_functions.hpp
@@ -95,7 +95,7 @@ Integer wrap(Integer x, Integer low, Integer high)
 template<typename Type>
 Type wrap_pi(Type x)
 {
-	return wrap(x, Type(-M_PI), Type(M_PI));
+	return wrap(x, Type(-M_PI_F), Type(M_PI_F));
 }
 
 /**
@@ -104,7 +104,7 @@ Type wrap_pi(Type x)
 template<typename Type>
 Type wrap_2pi(Type x)
 {
-	return wrap(x, Type(0), Type((2 * M_PI)));
+	return wrap(x, Type(0), Type((2 * M_PI_F)));
 }
 
 /**
@@ -132,7 +132,7 @@ Type unwrap(const Type last_x, const Type new_x, const Type low, const Type high
 template<typename Type>
 Type unwrap_pi(const Type last_angle, const Type new_angle)
 {
-	return unwrap(last_angle, new_angle, Type(-M_PI), Type(M_PI));
+	return unwrap(last_angle, new_angle, Type(-M_PI_F), Type(M_PI_F));
 }
 
 /**


### PR DESCRIPTION
## Describe problem solved by this pull request
A couple of the header file in the matrix library use the constant M_PI. M_PI is not part of the C standard but is often added to the math.h header file. But in some cases it is not in math.h. M_PI_F is defined in px4_platform_common/defines.h and so it can be used in place of M_PI

## Describe your solution
Replace M_PI with M_PI_F in the matrix library header files

## Describe possible alternatives
Could define M_PI at the top of those header files if it hasn't been defined by math.h but then this code would have to be copied to all files that use M_PI

