### PR TITLE
Makefile: remove update_ros2_bridge make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -550,21 +550,6 @@ check_px4: $(call make_list,nuttx,"px4") \
 check_nxp: $(call make_list,nuttx,"nxp") \
 	sizes
 
-ifneq ($(ROS2_WS_DIR),)
-  ROS2_WS_DIR := $(basename ${ROS2_WS_DIR})
-else
-  ROS2_WS_DIR := ~/colcon_ws
-endif
-
-update_ros2_bridge:
-	@Tools/update_px4_ros2_bridge.sh --ws_dir ${ROS2_WS_DIR} --all
-
-update_px4_ros_com:
-	@Tools/update_px4_ros2_bridge.sh --ws_dir ${ROS2_WS_DIR} --px4_ros_com
-
-update_px4_msgs:
-	@Tools/update_px4_ros2_bridge.sh --ws_dir ${ROS2_WS_DIR} --px4_msgs
-
 .PHONY: failsafe_web run_failsafe_web_server
 failsafe_web:
 	@if ! command -v emcc; then echo -e "Install emscripten first: https://emscripten.org/docs/getting_started/downloads.html\nAnd source the env: source <path>/emsdk_env.sh"; exit 1; fi


### PR DESCRIPTION
As `Tools/update_px4_ros2_bridge.sh` as been deleted `update_ros2_bridge`, `update_px4_ros_com` and `update_px4_msgs` are no more needed

Signed-off-by: Beniamino Pozzan <beniamino.pozzan@phd.unipd.it>