### PR TITLE
Moved the bad-function-cast compiler warning option out of the common options

### DIFF
--- a/cmake/px4_add_common_flags.cmake
+++ b/cmake/px4_add_common_flags.cmake
@@ -144,7 +144,6 @@ function(px4_add_common_flags)
 	list(APPEND c_flags
 		-fno-common
 
-		-Wbad-function-cast
 		-Wnested-externs
 		-Wstrict-prototypes
 	)

--- a/platforms/nuttx/cmake/px4_impl_os.cmake
+++ b/platforms/nuttx/cmake/px4_impl_os.cmake
@@ -69,6 +69,8 @@ function(px4_os_add_flags)
 
 	add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-sized-deallocation>)
 
+	add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wbad-function-cast>)
+
 	add_definitions(
 		-D__PX4_NUTTX
 

--- a/platforms/posix/cmake/px4_impl_os.cmake
+++ b/platforms/posix/cmake/px4_impl_os.cmake
@@ -238,6 +238,8 @@ function(px4_os_add_flags)
 
 	endif()
 
+	add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wbad-function-cast>)
+
 endfunction()
 
 #=============================================================================


### PR DESCRIPTION
## Describe problem solved by this pull request
Fix for build failures on the Qurt platform.

## Describe your solution
Moved the bad-function-cast compiler warning option out of the common options and into the nuttx and posix specific options files since this option cannot be used with the qurt platform. There are header files in the hexagon sdk that fail this check.
