### PR TITLE
microdds_client: add namespace to partecipant name

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -260,7 +260,13 @@ fi
 navigator start
 
 # Try to start the microdds_client with UDP transport if module exists
-microdds_client start -t udp -p "$((px4_instance+8888))" -n "px4_${px4_instance}"
+if [ $px4_instance -eq 0 ]
+then
+	microdds_client start -t udp -p 8888
+else
+	param set XRCE_DDS_KEY ${px4_instance}
+	microdds_client start -t udp -p 8888 -n "px4_$px4_instance"
+fi
 
 if param greater -s MNT_MODE_IN -1
 then

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -260,7 +260,7 @@ fi
 navigator start
 
 # Try to start the microdds_client with UDP transport if module exists
-microdds_client start -t udp -p 8888
+microdds_client start -t udp -p "$((px4_instance+8888))" -n "px4_${px4_instance}"
 
 if param greater -s MNT_MODE_IN -1
 then

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -260,13 +260,19 @@ fi
 navigator start
 
 # Try to start the microdds_client with UDP transport if module exists
-if [ $px4_instance -eq 0 ]
+microdds_ns=""
+if [ "$px4_instance" -ne "0" ]
 then
-	microdds_client start -t udp -p 8888
-else
+	# Assign new xrce dds key based on instance number and set default namespace
 	param set XRCE_DDS_KEY ${px4_instance}
-	microdds_client start -t udp -p 8888 -n "px4_$px4_instance"
+	microdds_ns="-n px4_$px4_instance"
 fi
+if [ -n "$PX4_MICRODDS_NS" ]
+then
+	# Override namespace if environment variable is defined
+	microdds_ns="-n $PX4_MICRODDS_NS"
+fi
+microdds_client start -t udp -p 8888 $microdds_ns
 
 if param greater -s MNT_MODE_IN -1
 then

--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -183,7 +183,13 @@ void MicroddsClient::run()
 
 		// Session
 		// The key identifier of the Client. All Clients connected to an Agent must have a different key.
-		const uint32_t key = 0xAAAABBBB;
+		const uint32_t key = (uint32_t)_param_xrce_key.get();
+
+		if (key == 0) {
+			PX4_ERR("session key must be different from zero");
+			return;
+		}
+
 		uxrSession session;
 		uxr_init_session(&session, _comm, key);
 

--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -52,6 +52,8 @@
 #define STREAM_HISTORY  4
 #define BUFFER_SIZE (UXR_CONFIG_SERIAL_TRANSPORT_MTU * STREAM_HISTORY) // MTU==512 by default
 
+#define PARTICIPANT_XML_SIZE 512
+
 using namespace time_literals;
 
 void on_time(uxrSession *session, int64_t current_time, int64_t received_timestamp, int64_t transmit_timestamp,
@@ -221,34 +223,46 @@ void MicroddsClient::run()
 		// uint16_t participant_req = uxr_buffer_create_participant_bin(&session, reliable_out, participant_id, domain_id,
 		// 			   participant_name, UXR_REPLACE);
 
-		// TODO: configurable participant name with client namespace?
-		const char *participant_xml = _localhost_only ?
-					      "<dds>"
-					      "<profiles>"
-					      "<transport_descriptors>"
-					      "<transport_descriptor>"
-					      "<transport_id>udp_localhost</transport_id>"
-					      "<type>UDPv4</type>"
-					      "<interfaceWhiteList><address>127.0.0.1</address></interfaceWhiteList>"
-					      "</transport_descriptor>"
-					      "</transport_descriptors>"
-					      "</profiles>"
-					      "<participant>"
-					      "<rtps>"
-					      "<name>px4_micro_xrce_dds</name>"
-					      "<useBuiltinTransports>false</useBuiltinTransports>"
-					      "<userTransports><transport_id>udp_localhost</transport_id></userTransports>"
-					      "</rtps>"
-					      "</participant>"
-					      "</dds>"
-					      :
-					      "<dds>"
-					      "<participant>"
-					      "<rtps>"
-					      "<name>px4_micro_xrce_dds</name>"
-					      "</rtps>"
-					      "</participant>"
-					      "</dds>" ;
+		char participant_xml[PARTICIPANT_XML_SIZE];
+		int ret = snprintf(participant_xml, PARTICIPANT_XML_SIZE, "%s<name>%s/px4_micro_xrce_dds</name>%s",
+				   _localhost_only ?
+				   "<dds>"
+				   "<profiles>"
+				   "<transport_descriptors>"
+				   "<transport_descriptor>"
+				   "<transport_id>udp_localhost</transport_id>"
+				   "<type>UDPv4</type>"
+				   "<interfaceWhiteList><address>127.0.0.1</address></interfaceWhiteList>"
+				   "</transport_descriptor>"
+				   "</transport_descriptors>"
+				   "</profiles>"
+				   "<participant>"
+				   "<rtps>"
+				   :
+				   "<dds>"
+				   "<participant>"
+				   "<rtps>",
+				   _client_namespace != nullptr ?
+				   _client_namespace
+				   :
+				   "",
+				   _localhost_only ?
+				   "<useBuiltinTransports>false</useBuiltinTransports>"
+				   "<userTransports><transport_id>udp_localhost</transport_id></userTransports>"
+				   "</rtps>"
+				   "</participant>"
+				   "</dds>"
+				   :
+				   "</rtps>"
+				   "</participant>"
+				   "</dds>"
+				  );
+
+		if (ret < 0 || ret >= TOPIC_NAME_SIZE) {
+			PX4_ERR("create entities failed: namespace too long");
+			return;
+		}
+
 		uint16_t participant_req = uxr_buffer_create_participant_xml(&session, reliable_out, participant_id, domain_id,
 					   participant_xml, UXR_REPLACE);
 

--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -92,7 +92,8 @@ private:
 	Timesync _timesync{};
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::XRCE_DDS_DOM_ID>) _param_xrce_dds_dom_id
+		(ParamInt<px4::params::XRCE_DDS_DOM_ID>) _param_xrce_dds_dom_id,
+		(ParamInt<px4::params::XRCE_DDS_KEY>) _param_xrce_key
 	)
 };
 

--- a/src/modules/microdds_client/module.yaml
+++ b/src/modules/microdds_client/module.yaml
@@ -44,6 +44,18 @@ parameters:
             reboot_required: true
             default: 0
 
+        XRCE_DDS_KEY:
+            description:
+                short: XRCE DDS key
+                long: |
+                    XRCE DDS key, must be different from zero.
+                    In a single agent - multi client configuration, each client
+                    must have a unique session key.
+            category: System
+            type: int32
+            reboot_required: true
+            default: 1
+
         XRCE_DDS_UDP_PRT:
             description:
                 short: Micro DDS UDP Port


### PR DESCRIPTION
## Describe problem solved by this pull request

1. The `microdds_client` did not add the namespace to the participant name. As a result when working with multiple vehicles and ROS2 all microdds_agent had the same name.
2. in `sitl` the `microdds_client` was automatically started on `udp` and port `8888`. With multiple vehicles this caused having all the clients connected to the same agent with the same key identifier, breaking the bridge regardless the presence of the namespace.

## Describe your solution

1. The `participant_xml` is created taking into account the desired namespace.
2. The parameter `XRCE_DDS_KEY` is added and used to specify the session key.
3. In `sitl` the `microdds_client` is automatically started on `udp`. ~~Depending on the `px4_instance` variable the port and the namespace are selected:
`microdds_client start -t udp -p "$((px4_instance+8888))" -n "px4_${px4_instance}"`~~
If `px4_instance` is zero, no multiple clients are expected: `XRCE_DDS_KEY` is untouched and no namespace is defined.
If `px4_instance` is greater than zero, multiple clients are expected: `XRCE_DDS_KEY` is set equal to `px4_instance` and the namespace follow the convention `px4_${px4_instance}`.
4. Regardless the value of `px4_instance`, if the environment variable `PX4_MICRODDS_NS` is set, then it is used as namespace.

## Describe possible alternatives
Have the namespace in the form of a parameter (requires string parameters)

## Test data / coverage

### Single client scenario
This solution has been tested in ingnition simulation. For two vehicles:
**terminal 1**
`make px4_sitl gz_x500`
**terminal 2**
`ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888`

#### Expected Output on terminal 3:
```
$ ros2 node list
/px4_micro_xrce_dds
$ ros2 topic list
/fmu/in/obstacle_distance
/fmu/in/offboard_control_mode
/fmu/in/onboard_computer_status
/fmu/in/sensor_optical_flow
/fmu/in/telemetry_status
/fmu/in/trajectory_setpoint
/fmu/in/vehicle_attitude_setpoint
/fmu/in/vehicle_command
/fmu/in/vehicle_mocap_odometry
/fmu/in/vehicle_rates_setpoint
/fmu/in/vehicle_trajectory_bezier
/fmu/in/vehicle_trajectory_waypoint
/fmu/in/vehicle_visual_odometry
/fmu/out/failsafe_flags
/fmu/out/sensor_combined
/fmu/out/timesync_status
/fmu/out/vehicle_attitude
/fmu/out/vehicle_control_mode
/fmu/out/vehicle_global_position
/fmu/out/vehicle_gps_position
/fmu/out/vehicle_local_position
/fmu/out/vehicle_odometry
/fmu/out/vehicle_status
/parameter_events
/rosout
```

### Multi-client scenario
This solution has been tested in ingnition simulation:
**terminal 1**
```
make px4_sitl
PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,0"  PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4 -i 1
```
**terminal 2**
`PX4_SYS_AUTOSTART=4001 PX4_GZ_MODEL_POSE="0,1"  PX4_GZ_MODEL=x500 ./build/px4_sitl_default/bin/px4 -i 2`
**terminal 3**
`ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888`

#### Expected Output on terminal 4:
```
$ ros2 node list
/px4_1/px4_micro_xrce_dds
/px4_2/px4_micro_xrce_dds
$ ros2 topic list
/parameter_events
/px4_1/fmu/in/obstacle_distance
/px4_1/fmu/in/offboard_control_mode
/px4_1/fmu/in/onboard_computer_status
/px4_1/fmu/in/sensor_optical_flow
/px4_1/fmu/in/telemetry_status
/px4_1/fmu/in/trajectory_setpoint
/px4_1/fmu/in/vehicle_attitude_setpoint
/px4_1/fmu/in/vehicle_command
/px4_1/fmu/in/vehicle_mocap_odometry
/px4_1/fmu/in/vehicle_rates_setpoint
/px4_1/fmu/in/vehicle_trajectory_bezier
/px4_1/fmu/in/vehicle_trajectory_waypoint
/px4_1/fmu/in/vehicle_visual_odometry
/px4_1/fmu/out/failsafe_flags
/px4_1/fmu/out/sensor_combined
/px4_1/fmu/out/timesync_status
/px4_1/fmu/out/vehicle_attitude
/px4_1/fmu/out/vehicle_control_mode
/px4_1/fmu/out/vehicle_global_position
/px4_1/fmu/out/vehicle_gps_position
/px4_1/fmu/out/vehicle_local_position
/px4_1/fmu/out/vehicle_odometry
/px4_1/fmu/out/vehicle_status
/px4_2/fmu/in/obstacle_distance
/px4_2/fmu/in/offboard_control_mode
/px4_2/fmu/in/onboard_computer_status
/px4_2/fmu/in/sensor_optical_flow
/px4_2/fmu/in/telemetry_status
/px4_2/fmu/in/trajectory_setpoint
/px4_2/fmu/in/vehicle_attitude_setpoint
/px4_2/fmu/in/vehicle_command
/px4_2/fmu/in/vehicle_mocap_odometry
/px4_2/fmu/in/vehicle_rates_setpoint
/px4_2/fmu/in/vehicle_trajectory_bezier
/px4_2/fmu/in/vehicle_trajectory_waypoint
/px4_2/fmu/in/vehicle_visual_odometry
/px4_2/fmu/out/failsafe_flags
/px4_2/fmu/out/sensor_combined
/px4_2/fmu/out/timesync_status
/px4_2/fmu/out/vehicle_attitude
/px4_2/fmu/out/vehicle_control_mode
/px4_2/fmu/out/vehicle_global_position
/px4_2/fmu/out/vehicle_gps_position
/px4_2/fmu/out/vehicle_local_position
/px4_2/fmu/out/vehicle_odometry
/px4_2/fmu/out/vehicle_status
/rosout
```

## Additional context
I used ignition fortress source compiled for this test. And even if #20319 is fully functional, as the associated PR in gz has been merged, I had to manually modify the gazebo version to overcome #20342.