### PR TITLE
Qurt Logger Implementation

### DIFF
--- a/platforms/qurt/include/qurt_log.h
+++ b/platforms/qurt/include/qurt_log.h
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2022 ModalAI, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+#pragma once
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+
+__BEGIN_DECLS
+
+//Defining hap_debug
+void HAP_debug(const char *msg, int level, const char *filename, int line);
+
+static __inline void qurt_log(int level, const char *file, int line,
+			      const char *format, ...)
+{
+	char buf[256];
+	va_list args;
+	va_start(args, format);
+	vsnprintf(buf, sizeof(buf), format, args);
+	va_end(args);
+	HAP_debug(buf, level, file, line);
+}
+
+__END_DECLS

--- a/src/modules/muorb/slpi/uORBProtobufChannel.cpp
+++ b/src/modules/muorb/slpi/uORBProtobufChannel.cpp
@@ -38,8 +38,7 @@
 #include <qurt_thread.h>
 #include <pthread.h>
 
-// TODO: Move this out of here once we have px4-log functionality
-extern "C" void HAP_debug(const char *msg, int level, const char *filename, int line);
+#include <px4_platform_common/log.h>
 
 // Definition of test to run when in muorb test mode
 static MUORBTestType test_to_run;
@@ -48,7 +47,7 @@ fc_func_ptrs muorb_func_ptrs;
 
 static void *test_runner(void *test)
 {
-	HAP_debug("test_runner called", 1, muorb_test_topic_name, 0);
+	PX4_INFO("test_runner called");
 
 	switch (*((MUORBTestType *) test)) {
 	case ADVERTISE_TEST_TYPE:
@@ -84,7 +83,7 @@ int px4muorb_orb_initialize(fc_func_ptrs *func_ptrs, int32_t clock_offset_us)
 	// so they must be saved off here
 	if (func_ptrs != nullptr) { muorb_func_ptrs = *func_ptrs; }
 
-	HAP_debug("px4muorb_orb_initialize called", 1, "init", 0);
+	PX4_INFO("px4muorb_orb_initialize called");
 
 	return 0;
 }
@@ -107,7 +106,7 @@ int px4muorb_topic_advertised(const char *topic_name)
 {
 	if (IS_MUORB_TEST(topic_name)) { run_test(ADVERTISE_TEST_TYPE); }
 
-	HAP_debug("px4muorb_topic_advertised called", 1, topic_name, 0);
+	PX4_INFO("px4muorb_topic_advertised called");
 
 	return 0;
 }
@@ -116,7 +115,7 @@ int px4muorb_add_subscriber(const char *topic_name)
 {
 	if (IS_MUORB_TEST(topic_name)) { run_test(SUBSCRIBE_TEST_TYPE); }
 
-	HAP_debug("px4muorb_add_subscriber called", 1, topic_name, 0);
+	PX4_INFO("px4muorb_add_subscriber called");
 
 	return 0;
 }
@@ -125,7 +124,7 @@ int px4muorb_remove_subscriber(const char *topic_name)
 {
 	if (IS_MUORB_TEST(topic_name)) { run_test(UNSUBSCRIBE_TEST_TYPE); }
 
-	HAP_debug("px4muorb_remove_subscriber called", 1, topic_name, 0);
+	PX4_INFO("px4muorb_remove_subscriber called");
 
 	return 0;
 }
@@ -152,7 +151,7 @@ int px4muorb_send_topic_data(const char *topic_name, const uint8_t *data,
 		if (test_passed) { run_test(TOPIC_TEST_TYPE); }
 	}
 
-	HAP_debug("px4muorb_send_topic_data called", 1, topic_name, 0);
+	PX4_INFO("px4muorb_send_topic_data called");
 
 	return 0;
 }


### PR DESCRIPTION
## Describe problem solved by this pull request
This PR is meant to allow for PX4_INFO and other logging functions (err, warn, etc.) to be used by qurt and to be outputted onto mini-dm -- FUTURE will require string being passed into PX4_INFO to be sent over to apps side to be printed out by px4 shell.

## Describe your solution
Implemented a qurt_logger that leverages a hex function called HAP_debug - this function is in charge of printing out strings on mini-dm. This was then abstracted out to a function called qurt_log which was then leveraged in log.h.

## Describe possible alternatives
Currently this is the best possible route. Only other implementation that needs to happen is for these strings to be sent over to the apps side via a uorb communicator which would then be printed out on PX4 shell.

## Test data / coverage
This was tested using mini-dm and the muorb protobuf code base that runs on the slpi.

