### PR TITLE
drivers/gps support ublox basic spectrum analyzer (UBX-MON-SPAN)

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -156,6 +156,7 @@ set(msg_files
 	SensorCombined.msg
 	SensorCorrection.msg
 	SensorGnssRelative.msg
+	SensorGnssSpectrum.msg
 	SensorGps.msg
 	SensorGyro.msg
 	SensorGyroFft.msg

--- a/msg/SensorGnssSpectrum.msg
+++ b/msg/SensorGnssSpectrum.msg
@@ -1,0 +1,16 @@
+# GNSS spectrum
+
+uint64 timestamp                  # time since system start (microseconds)
+uint64 timestamp_sample           # time since system start (microseconds)
+
+uint32 device_id                  # unique device ID for the sensor that does not change between power cycles
+
+# The center frequency at each bin: f(i) = center + span * (i - 127) / 256
+uint8[256] spectrum # dB Spectrum data (number of points = span/res)
+uint32 spectrum_span_hz    # Hz Spectrum span
+uint32 resolution_hz       # Hz Resolution of the spectrum
+uint32 center_frequency_hz # Hz Center of spectrum span
+
+uint8 programmable_gain_amplifier_db # dB Programmable gain amplifier
+
+uint8 ORB_QUEUE_LENGTH = 2

--- a/src/drivers/gps/definitions.h
+++ b/src/drivers/gps/definitions.h
@@ -45,6 +45,7 @@
 #include <uORB/topics/satellite_info.h>
 #include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/sensor_gnss_relative.h>
+#include <uORB/topics/sensor_gnss_spectrum.h>
 
 #define GPS_INFO(...) PX4_INFO(__VA_ARGS__)
 #define GPS_WARN(...) PX4_WARN(__VA_ARGS__)

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -82,6 +82,18 @@ PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
 PARAM_DEFINE_INT32(GPS_SAT_INFO, 0);
 
 /**
+ * Enable spectrum analyzer (if available)
+ *
+ * Enable publication of basic spectrum analyzer, (ORB_ID(sensor_gnss_spectrum)) if possible.
+ * Only available on newer u-blox modules.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_UBX_SPECTRUM, 0);
+
+/**
  * u-blox GPS Mode
  *
  * Select the u-blox configuration setup. Most setups will use the default, including RTK and

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -202,6 +202,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("sensor_baro", 1000, 4);
 	add_topic_multi("sensor_gps", 1000, 2);
 	add_topic_multi("sensor_gnss_relative", 1000, 1);
+	add_optional_topic("sensor_gnss_spectrum", 1000);
 	add_optional_topic_multi("sensor_gyro", 1000, 4);
 	add_topic_multi("sensor_mag", 1000, 4);
 	add_topic_multi("sensor_optical_flow", 1000, 2);


### PR DESCRIPTION
 - enable UBX-MON-SPAN with new parameter GPS_UBX_SPECTRUM
    - available on m9n and ZED f9p
 - GPS drivers update https://github.com/PX4/PX4-GPSDrivers/pull/115


![Screenshot from 2022-10-24 21-02-12](https://user-images.githubusercontent.com/84712/197658059-ccc00a67-a4c0-464e-bf56-b7ce0a0495bc.png)
