### PR TITLE
Fixedwing reset rate integral in acromode

### DIFF
--- a/src/lib/rate_control/rate_control.hpp
+++ b/src/lib/rate_control/rate_control.hpp
@@ -95,6 +95,18 @@ public:
 	void resetIntegral() { _rate_int.zero(); }
 
 	/**
+	 * Set the integral term to 0 to prevent windup for each axis
+	 * @param  axis axis: roll 0 / pitch 1 / yaw 2
+	 * @see _rate_int
+	 */
+	void resetIntegral(size_t axis)
+	{
+		if (axis < 3) {
+			_rate_int(axis) = 0.0f;
+		}
+	}
+
+	/**
 	 * Get status message of controller for logging/debugging
 	 * @param rate_ctrl_status status message to fill with internal states
 	 */

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -118,6 +118,10 @@ FixedwingRateControl::vehicle_manual_poll()
 
 				_rate_sp_pub.publish(_rates_sp);
 
+				if (_param_fw_acro_yaw_int_reset.get()) {
+					_rate_control.resetIntegral(2);
+				}
+
 			} else {
 				/* manual/direct control */
 

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -152,6 +152,7 @@ private:
 		(ParamFloat<px4::params::FW_ACRO_X_MAX>) _param_fw_acro_x_max,
 		(ParamFloat<px4::params::FW_ACRO_Y_MAX>) _param_fw_acro_y_max,
 		(ParamFloat<px4::params::FW_ACRO_Z_MAX>) _param_fw_acro_z_max,
+		(ParamInt<px4::params::FW_ACRO_Z_IRESET>) _param_fw_acro_yaw_int_reset,
 
 		(ParamFloat<px4::params::FW_AIRSPD_MAX>) _param_fw_airspd_max,
 		(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_fw_airspd_min,

--- a/src/modules/fw_rate_control/fw_rate_control_params.c
+++ b/src/modules/fw_rate_control/fw_rate_control_params.c
@@ -366,6 +366,16 @@ PARAM_DEFINE_FLOAT(FW_ACRO_Y_MAX, 90);
 PARAM_DEFINE_FLOAT(FW_ACRO_Z_MAX, 45);
 
 /**
+ * Reset for integral of the z axis while rate controller in acro mode.
+ *
+ * This configures the integral of each axis of the rate controller in acro mode
+ *
+ * @boolean
+ * @group FW Rate Control
+ */
+PARAM_DEFINE_INT32(FW_ACRO_Z_IRESET, 1);
+
+/**
  * Enable throttle scale by battery level
  *
  * This compensates for voltage drop of the battery over time by attempting to


### PR DESCRIPTION
## Describe problem solved by this pull request
In acromode, the yaw integral can become large since the vehicle have aero dynamic forces that try to stabilize the vehicle

## Describe your solution
Discussed in the FW dev call, resetting integrals in acro mode

@chris1seto FYI

## Describe possible alternatives
- we could also try to only reset the yaw integral and keep the integral of other axis such as roll and pitch

## Test data / coverage
- Tested in SITL
```
make px4_sitl gazebo_plane
```
- Flight log: https://review.px4.io/plot_app?log=f2fd0b16-92fc-4308-b19f-a9d6a789e1a4

The integrals are reset in acro mode
![bokeh_plot (1)](https://user-images.githubusercontent.com/5248102/197974360-e5a5cf07-9150-45da-8fee-bc7eff80d229.png)


## Additional context
- This topic was discussed in the fw dev call: https://discuss.px4.io/t/fw-vtol-call-october-25-2022/29505