### PR TITLE
Added yaw tracking to LandingTargetEstimator and precland

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1011_gazebo-classic_iris_irlock
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1011_gazebo-classic_iris_irlock
@@ -34,5 +34,10 @@ param set-default LTEST_MODE 1
 param set-default PLD_HACC_RAD 0.1
 param set-default RTL_PLD_MD 2
 
+# Orientation parameters for Gazebo irislock sim
+param set-default LTEST_EULR_PHI 0      	# ENU -> NED already done in gazeebo
+param set-default LTEST_EULR_THETA -1.57	# Camera tilt, which is facing 90 degrees down
+param set-default LTEST_EULR_PSI 0.0
+
 # Start up Landing Target Estimator module
 landing_target_estimator start

--- a/msg/IrlockReport.msg
+++ b/msg/IrlockReport.msg
@@ -9,3 +9,5 @@ float32 pos_x # tan(theta), where theta is the angle between the target and the 
 float32 pos_y # tan(theta), where theta is the angle between the target and the camera center of projection in camera y-axis
 float32 size_x #/** size of target along camera x-axis in units of tan(theta) **/
 float32 size_y #/** size of target along camera y-axis in units of tan(theta) **/
+
+float32[4] q   # Quaternion as recorded by the camera (w, x, y, z order, zero-rotation is 1, 0, 0, 0)

--- a/msg/LandingTargetPose.msg
+++ b/msg/LandingTargetPose.msg
@@ -24,3 +24,7 @@ bool abs_pos_valid		# Flag showing whether absolute position is valid
 float32 x_abs			# X/north position of target, relative to origin (navigation frame) [meters]
 float32 y_abs			# Y/east position of target, relative to origin (navigation frame) [meters]
 float32 z_abs			# Z/down position of target, relative to origin (navigation frame) [meters]
+float32[4] q		 	# Quaternion of landing target orientation (w, x, y, z order, zero-rotation is 1, 0, 0, 0)
+
+float32 target_yaw
+float32 target_yaw_filtered

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.h
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.h
@@ -62,6 +62,7 @@
 #include <mathlib/mathlib.h>
 #include <matrix/Matrix.hpp>
 #include <lib/conversion/rotation.h>
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include "KalmanFilter.h"
 
 using namespace time_literals;
@@ -126,6 +127,10 @@ private:
 		param_t offset_y;
 		param_t offset_z;
 		param_t sensor_yaw;
+		param_t eulr_phi;
+		param_t eulr_theta;
+		param_t eulr_psi;
+		param_t yaw_alpha;
 	} _paramHandle;
 
 	struct {
@@ -140,6 +145,10 @@ private:
 		float offset_y;
 		float offset_z;
 		enum Rotation sensor_yaw;
+		float eulr_phi;
+		float eulr_theta;
+		float eulr_psi;
+		float yaw_alpha;
 	} _params;
 
 	struct {
@@ -147,6 +156,7 @@ private:
 		float rel_pos_x;
 		float rel_pos_y;
 		float rel_pos_z;
+		float quaternion[4];
 	} _target_position_report;
 
 	uORB::Subscription _vehicleLocalPositionSub{ORB_ID(vehicle_local_position)};
@@ -177,6 +187,8 @@ private:
 	matrix::Vector2f _rel_pos;
 	KalmanFilter _kalman_filter_x;
 	KalmanFilter _kalman_filter_y;
+	AlphaFilter<float> _alpha_filter_yaw; // poor man's orientation estimator
+	float _last_unwrapped_yaw{0.0f};
 	hrt_abstime _last_predict{0}; // timestamp of last filter prediction
 	hrt_abstime _last_update{0}; // timestamp of last filter update (used to check timeout)
 	float _dist_z{1.0f};

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -187,3 +187,51 @@ PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Y, 0.0f);
  *
  */
 PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Z, 0.0f);
+
+/**
+ * Euler Angle Rotation (3-2-1 intrinsic Tait-Bryan) Phi (X)
+ *
+ * Orientation transformation from camera frame that detected
+ * the landing_target to drone's NED frame
+ *
+ * @unit rad
+ * @decimal 2
+ *
+ * @group Landing target Estimator
+ */
+PARAM_DEFINE_FLOAT(LTEST_EULR_PHI, 0.0f);
+
+/**
+ * Euler Angle Rotation (3-2-1 intrinsic Tait-Bryan) Theta (Y)
+ *
+ * Orientation transformation from camera frame that detected
+ * the landing_target to drone's NED frame
+ *
+ * @unit rad
+ * @decimal 2
+ *
+ * @group Landing target Estimator
+ */
+PARAM_DEFINE_FLOAT(LTEST_EULR_THETA, 0.0f);
+
+/**
+ * Euler Angle Rotation (3-2-1 intrinsic Tait-Bryan) Psi (Z)
+ *
+ * Orientation transformation from camera frame that detected
+ * the landing_target to drone's NED frame
+ *
+ * @unit rad
+ * @decimal 2
+ *
+ * @group Landing target Estimator
+ */
+PARAM_DEFINE_FLOAT(LTEST_EULR_PSI, -1.57f);
+
+/**
+ * Target yaw filter alpha value
+ *
+ * @min 0
+ * @max 100
+ * @group Landing target Estimator
+ */
+PARAM_DEFINE_FLOAT(LTEST_YAW_ALPHA, 0.05);

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -192,7 +192,7 @@ PARAM_DEFINE_FLOAT(LTEST_SENS_POS_Z, 0.0f);
  * Euler Angle Rotation (3-2-1 intrinsic Tait-Bryan) Phi (X)
  *
  * Orientation transformation from camera frame that detected
- * the landing_target to drone's NED frame
+ * the landing_target to drone's FRD frame
  *
  * @unit rad
  * @decimal 2

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -268,6 +268,10 @@ PrecLand::run_state_horizontal_approach()
 	pos_sp_triplet->current.alt = _approach_alt;
 	pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 
+	// note: abs_pos_valid was already checked as a condition to enter this state
+	pos_sp_triplet->current.yaw = matrix::Eulerf(matrix::Quaternionf(_target_pose.q)).psi();
+	pos_sp_triplet->current.yaw_valid = true;
+
 	_navigator->set_position_setpoint_triplet_updated();
 }
 
@@ -298,6 +302,9 @@ PrecLand::run_state_descend_above_target()
 	_map_ref.reproject(_target_pose.x_abs, _target_pose.y_abs, pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
 
 	pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_LAND;
+
+	pos_sp_triplet->current.yaw = matrix::Eulerf(matrix::Quaternionf(_target_pose.q)).psi();
+	pos_sp_triplet->current.yaw_valid = true;
 
 	_navigator->set_position_setpoint_triplet_updated();
 }

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -619,6 +619,9 @@ void SimulatorMavlink::handle_message_landing_target(const mavlink_message_t *ms
 		report.size_x = landing_target_mavlink.size_x;
 		report.size_y = landing_target_mavlink.size_y;
 
+		matrix::Quatf q(landing_target_mavlink.q);
+		q.copyTo(report.q);
+
 		_irlock_report_pub.publish(report);
 	}
 }


### PR DESCRIPTION
## Describe problem solved by this pull request
PX4 precision landing does currently not track the orientation of the target and lands with whatever its current yaw angle is when precision landing is used.

### More detail
The existing LandingTargetEstimator.cpp currently only estimates the position of a target, not the orientation. The system was designed with the following two scenarios in mind:
1. IR camera used onboard, in which case the camera sends the relative position of the IR beacon to LandingTargetEstimator.cpp in PX4
2. An offboard vision-based detector is run, **which is expected to also estimate the 3D pose and orientation** of the target.

This is limiting, because as it turns out there is a third very intuitive use case not covered by the two above: 
- Only run the vision-based detector offboard, and then send the relative pose of the detected target to PX4 and run it through PX4's estimator LandingTargetEstimator.cpp. This is more intuitive because the offboard app does not need to know anything about drones and does not require to fetch the vehicle position and attitude. The PX4 estimator takes care of this.

I plan a wider refactor of precision landing. For now I'd like to bring in this temporary solution that at least allows people to use offboard detectors with the PX4 estimator. In a next step we can do the refactoring.

## Describe your solution
- This PR extends LandingTargetEstimator.cpp with a simple alpha filter for tracking the orientation of the target.
- It also adds the tracking of the orientation to precland.cpp in navigator

Again, as written above, this can later be refactored into a better solution. In the future we should not use two separate estimators for tracking the target position and orientation as this PR now does. Ideally we reuse the follow-me estimator also for precision landing, which would automatically enable the drone to land on a moving target, and we can get rid of LandingTargetEstimator.cpp almost entirely.

## Test data / coverage
Needs this gazebo PR for testing in simulation: https://github.com/PX4/PX4-SITL_gazebo/pull/919 (merged into main)

Run the IRlock world in Gazebo, takeoff and then use precision land. The drone will orient itself with the tag.
```
make px4_sitl gazebo_iris_irlock
```

## Additional context
We need to generally refactor the precision landing code and get rid of the notion of an IR beacon. There is a previous PR that extended the capabilities of LandingTargetEstimator.cpp to also incorporate UWB data: https://github.com/PX4/PX4-Autopilot/pull/14474

In my opinion this can be abstracted further and we also need to refactor the interface between PX4 and external systems. For example, there is a code path that has been added to hide IRLockReport uORB messages inside landing_target mavlink message, which was needed for simulation. This should be reworked into the "standard" way of sending precland tracking information from offboard to PX4:
https://github.com/PX4/PX4-Autopilot/blob/740d2fccb14c6ae6461f6de542c3b837e1f07376/src/modules/mavlink/mavlink_receiver.cpp#L2516-L2527

As mentioned above, we should at some point also re-use the follow-me estimator for precision landing, and not have separate estimators in the code base for tracking precland targets and follow-me targets. These should be interchangeable. 