### PR TITLE
Navigator: remove update of reposition setpoint at Transition command

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -552,12 +552,6 @@ void Navigator::run()
 				// reset cruise speed and throttle to default when transitioning (VTOL Takeoff handles it separately)
 				reset_cruising_speed();
 				set_cruising_throttle();
-
-				// need to update current setpooint with reset cruise speed and throttle
-				position_setpoint_triplet_s *rep = get_reposition_triplet();
-				*rep = *(get_position_setpoint_triplet());
-				rep->current.cruising_speed = get_cruising_speed();
-				rep->current.cruising_throttle = get_cruising_throttle();
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/20477

## Describe problem solved by this pull request
See https://github.com/PX4/PX4-Autopilot/issues/20477

## Describe your solution
Remove reposition hacks from logic handling of DO_TRANSITION. This was previously required to reset the flight speed after a VTOL transition, but is now no longer required as the DO_CHANGE_SPEED commands are handles directly in the controllers.

## Test data / coverage
SITL testing (standard vtol)

## Additional context
Originally introduced here: https://github.com/PX4/PX4-Autopilot/pull/18834#issuecomment-996595040, then the DO_CHANGE_SPEED handling was changed with https://github.com/PX4/PX4-Autopilot/pull/19407 but it looks to me like this specific part was overseen and is not required anymore.

BTW I think DO_SPEED_CHANGE is currently broken for MC in AUTO modes (at least for Goto). For FW it works. FYI @MaEtUgR 

FYI @ThomasRigi 