### PR TITLE
Mavsdk test: Make `wait_until_ready` also wait until vehicle can arm

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -95,8 +95,12 @@ public:
 	~AutopilotTester();
 
 	void connect(const std::string uri);
+
+	/**
+	 * @brief Wait until vehicle's system status is healthy & is able to arm
+	 */
 	void wait_until_ready();
-	void wait_until_ready_local_position_only();
+
 	void store_home();
 	void check_home_within(float acceptance_radius_m);
 	void check_home_not_within(float min_distance_m);
@@ -204,6 +208,12 @@ private:
 
 	void report_speed_factor();
 
+	/**
+	 * @brief Continue polling until condition returns true or we have a timeout
+	 *
+	 * @param fun Boolean returning function. When true, the polling terminates.
+	 * @param duration Timeout for polling in `std::chrono::` time unit
+	 */
 	template<typename Rep, typename Period>
 	bool poll_condition_with_timeout(
 		std::function<bool()> fun, std::chrono::duration<Rep, Period> duration)


### PR DESCRIPTION
## Describe problem solved by this pull request
Previously, due to the way MAVSDK's `health_all_ok` was implemented, vehicle often didn't have a valid global position estimate (although function returned true), and it wouldn't arm, and the SITL would fail. This was originally reported here: https://github.com/mavlink/MAVSDK/issues/1852#issue-1302090147

Also sometimes as vehicle didn't have manual control, it entered weird states where it wasn't able to arm as well.

## Describe your solution
In `wait_until_ready()`, wait until we are able to arm, after checking system health. This ensures that `tester.arm()` in mavsdk tests will succeed, since we know we will be able to arm, and SITL tests will not fail just because it can't arm.

## Test data / coverage
![image](https://user-images.githubusercontent.com/23277211/198042182-3dd2d6a6-2f0d-4e1e-8860-07a09e11fa94.png)

Standard VTOL mavsdk tests succeeded in local environment (wow it is slow when we don't have time factor!).

## Additional context
Related: https://github.com/mavlink/MAVSDK/issues/1852
