### PR TITLE
Orbit fixes for MC

### DIFF
--- a/src/modules/flight_mode_manager/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/CMakeLists.txt
@@ -71,13 +71,6 @@ set(python_args
 	-f ${files_to_generate}
 )
 
-# add the additional tasks for the python script (if there are any)
-if(flight_tasks_to_add)
-	list(APPEND python_args
-		-s ${flight_tasks_to_add}
-	)
-endif()
-
 # generate the files using the python script and template
 add_custom_command(
 	OUTPUT

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -296,14 +296,6 @@ void FlightModeManager::handleCommand()
 				}
 			}
 
-			// send back acknowledgment
-			vehicle_command_ack_s command_ack{};
-			command_ack.command = command.command;
-			command_ack.result = cmd_result;
-			command_ack.target_system = command.source_system;
-			command_ack.target_component = command.source_component;
-			command_ack.timestamp = hrt_absolute_time();
-			_vehicle_command_ack_pub.publish(command_ack);
 
 		} else if (_current_task.task) {
 			// check for other commands not related to task switching

--- a/src/modules/flight_mode_manager/FlightModeManager.hpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.hpp
@@ -50,7 +50,6 @@
 #include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
-#include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -150,7 +149,6 @@ private:
 
 	uORB::Publication<landing_gear_s> _landing_gear_pub{ORB_ID(landing_gear)};
 	uORB::Publication<trajectory_setpoint_s> _trajectory_setpoint_pub{ORB_ID(trajectory_setpoint)};
-	uORB::Publication<vehicle_command_ack_s> _vehicle_command_ack_pub{ORB_ID(vehicle_command_ack)};
 	uORB::Publication<vehicle_constraints_s> _vehicle_constraints_pub{ORB_ID(vehicle_constraints)};
 
 	DEFINE_PARAMETERS(

--- a/src/modules/flight_mode_manager/FlightModeManager.hpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.hpp
@@ -111,9 +111,10 @@ private:
 	 */
 	bool isAnyTaskActive() const { return _current_task.task; }
 
+	void tryApplyCommandIfAny();
+
 	// generated
 	int _initTask(FlightTaskIndex task_index);
-	FlightTaskIndex switchVehicleCommand(const int command);
 
 	/**
 	 * Union with all existing tasks: we use it to make sure that only the memory of the largest existing
@@ -134,6 +135,9 @@ private:
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")}; ///< loop duration performance counter
 	hrt_abstime _time_stamp_last_loop{0}; ///< time stamp of last loop iteration
+
+	vehicle_command_s _current_command{};
+	bool _command_failed{false};
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 

--- a/src/modules/flight_mode_manager/Templates/FlightTasks_generated.cpp.em
+++ b/src/modules/flight_mode_manager/Templates/FlightTasks_generated.cpp.em
@@ -75,23 +75,3 @@ int FlightModeManager::_initTask(FlightTaskIndex task_index)
 	_current_task.index = task_index;
 	return 0;
 }
-
-FlightTaskIndex FlightModeManager::switchVehicleCommand(const int command)
-{
-    switch (command) {
-@# loop through all additional tasks
-@[if tasks_add]@
-@[for task in tasks_add]@
-@{
-upperCase = lambda s: s[:].upper() if s else ''
-}@
-	case vehicle_command_s::VEHICLE_CMD_DO_@(upperCase(task)) :
-		return FlightTaskIndex::@(task);
-		break;
-
-@[end for]@
-@[end if]@
-	// ignore all unknown commands
-	default : return FlightTaskIndex::None;
-	}
-}

--- a/src/modules/flight_mode_manager/generate_flight_tasks.py
+++ b/src/modules/flight_mode_manager/generate_flight_tasks.py
@@ -6,7 +6,6 @@ import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-t", "--tasks", dest='tasks_all', nargs='+', required=True, help="All tasks to be generated")
-parser.add_argument("-s", "--tasks_additional", dest='tasks_add', nargs='+', help="Additional tasks to be generated (on top of the core)")
 parser.add_argument("-i", "--input_directory", dest='directory_in', required=True, help="Output directory")
 parser.add_argument("-o", "--output_directory", dest='directory_out', required=True, help="Input directory")
 parser.add_argument("-f", "--files", dest='gen_files', nargs='+', required=True, help="Files to generate")
@@ -20,7 +19,6 @@ for gen_file in args.gen_files:
     # need to specify the em_globals inside the loop -> em.Error: interpreter globals collision
     em_globals = {
         "tasks": args.tasks_all,
-        "tasks_add": args.tasks_add,
     }
     interpreter = em.Interpreter(output=output_file, globals=em_globals)
     interpreter.file(open(args.directory_in + "/" + gen_file + ".em"))

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -91,9 +91,10 @@ public:
 	/**
 	 * To be called to adopt parameters from an arrived vehicle command
 	 * @param command received command message containing the parameters
-	 * @return true if accepted, false if declined
+	 * @param success set to true if it was successfully applied, false on error
+	 * @return true if handled
 	 */
-	virtual bool applyCommandParameters(const vehicle_command_s &command) { return false; }
+	virtual bool applyCommandParameters(const vehicle_command_s &command, bool &success) { return false; }
 
 	/**
 	 * Call before activate() or update()

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.cpp
@@ -49,9 +49,13 @@ FlightTaskOrbit::FlightTaskOrbit()
 	_sticks_data_required = false;
 }
 
-bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
+bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command, bool &success)
 {
-	bool ret = true;
+	if (command.command != vehicle_command_s::VEHICLE_CMD_DO_ORBIT) {
+		return false;
+	}
+
+	success = true;
 	// save previous velocity and rotation direction
 	bool new_is_clockwise = _orbit_velocity > 0;
 	float new_radius = _orbit_radius;
@@ -81,7 +85,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 	} else {
 		mavlink_log_critical(&_mavlink_log_pub, "Orbit radius limit exceeded\t");
 		events::send(events::ID("orbit_radius_exceeded"), events::Log::Alert, "Orbit radius limit exceeded");
-		ret = false;
+		success = false;
 	}
 
 	// commanded heading behaviour
@@ -98,7 +102,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 			_center.xy() = _geo_projection.project(command.param5, command.param6);
 
 		} else {
-			ret = false;
+			success = false;
 		}
 	}
 
@@ -108,7 +112,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 			_center(2) = _global_local_alt0 - command.param7;
 
 		} else {
-			ret = false;
+			success = false;
 		}
 	}
 
@@ -118,7 +122,7 @@ bool FlightTaskOrbit::applyCommandParameters(const vehicle_command_s &command)
 		_position_smoothing.reset(_acceleration_setpoint, _velocity_setpoint, _position);
 	}
 
-	return ret;
+	return true;
 }
 
 bool FlightTaskOrbit::sendTelemetry()

--- a/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/modules/flight_mode_manager/tasks/Orbit/FlightTaskOrbit.hpp
@@ -56,7 +56,7 @@ public:
 	FlightTaskOrbit();
 	virtual ~FlightTaskOrbit() = default;
 
-	bool applyCommandParameters(const vehicle_command_s &command) override;
+	bool applyCommandParameters(const vehicle_command_s &command, bool &success) override;
 	bool activate(const trajectory_setpoint_s &last_setpoint) override;
 	bool update() override;
 


### PR DESCRIPTION
This fixes a few problems for orbit:
remove command ack for VEHICLE_CMD_DO_ORBIT. Already acked in commander

Fixes a regression from https://github.com/PX4/PX4-Autopilot/commit/8bae4e5c0e29f70d5d1d2427ffdef97092be939c, where
the orbit flight task wasn't an extra task (flight_tasks_to_add) anymore
and therefore the command handling wasn't generated.

There was a race condition that could cause several outcomes. The most severe
was that flight_mode_manager gets the command, switches to orbit and then
in the next iteration switches back because commander did not change
nav_state yet. When commander then switches, flight_mode_manager would still
be in the old mode.
This is prevented by storing the command (allowing it to arrive before or
after mode switch), and then apply it after the switch happens.
