### PR TITLE
add time_utc_usec to gps blended state msg

### DIFF
--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -464,6 +464,8 @@ sensor_gps_s GpsBlending::gps_blend_states(float blend_weights[GPS_MAX_RECEIVERS
 		}
 	}
 
+	gps_blended_state.time_utc_usec = _gps_state[gps_best_index].time_utc_usec;
+
 	// Add the sum of weighted offsets to the reference position to obtain the blended position
 	const double lat_deg_now = (double)gps_blended_state.lat * 1.0e-7;
 	const double lon_deg_now = (double)gps_blended_state.lon * 1.0e-7;


### PR DESCRIPTION
Problem:
- When blending two gps receivers time_utc_usec is not published on vehicle_gps_position.msg
- use the clock of the best quality gps
