### PR TITLE
Makefile: add target for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if(BUILD_TESTING)
 	include(gtest)
 
 	add_custom_target(test_results
-			COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test -R ${TESTFILTER} USES_TERMINAL
+			COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test -R \"${TESTFILTER}\" USES_TERMINAL
 			DEPENDS
 				px4
 				examples__dyn_hello

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,8 @@ tests_coverage:
 	@mkdir -p coverage
 	@lcov --directory build/px4_sitl_test --base-directory build/px4_sitl_test --gcov-tool gcov --capture -o coverage/lcov.info
 
+test_unit:
+	@$(MAKE) tests TESTFILTER="unit\|functional"
 
 rostest: px4_sitl_default
 	@$(MAKE) --no-print-directory px4_sitl_default sitl_gazebo


### PR DESCRIPTION
## Describe problem solved by this pull request
As discussed with @dagar our coverage tool https://app.codecov.io/gh/PX4/PX4-Autopilot/tree/master/ shows coverage of the tests but as soon as you run a full SITL instance in the test you get a lot of coverage e.g. of all main loops even though there is no specific tests for them that explicitly checks they are doing the right thing. I personally would like to have a unit test coverage captured such that I can easily see which parts are explicitly tested with unit tests and which not particularly if there are unit tests if they cover the all the class cases or not.

## Describe your solution
We discussed that I would add the target that I'm interested in and @dagar would be able to somehow send it from CI to codecov in a way that the coverage of this target is visible.

## Test data / coverage
I ran `make test_unit` and it goes through all the 96 unit tests ("functional" and the ones without parameter and uORB) within 2.85 seconds on my laptop.