### PR TITLE
ekf2: update EV height state machine (small piece of EV overhaul)

### DIFF
--- a/src/modules/ekf2/EKF/bias_estimator.hpp
+++ b/src/modules/ekf2/EKF/bias_estimator.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,11 +57,11 @@ class BiasEstimator
 {
 public:
 	struct status {
-		float bias;
-		float bias_var;
-		float innov;
-		float innov_var;
-		float innov_test_ratio;
+		float bias{0.f};
+		float bias_var{0.f};
+		float innov{0.f};
+		float innov_var{0.f};
+		float innov_test_ratio{INFINITY};
 	};
 
 	BiasEstimator(float state_init, float state_var_init): _state{state_init}, _state_var{state_var_init} {};
@@ -107,7 +107,7 @@ private:
 	float _time_since_last_negative_innov{0.f};
 	float _time_since_last_positive_innov{0.f};
 
-	status _status;
+	status _status{};
 
 	void constrainStateVar();
 	float computeKalmanGain(float innov_var) const;

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -379,6 +379,7 @@ struct parameters {
 
 	// vision position fusion
 	float ev_vel_noise{0.1f};               ///< minimum allowed observation noise for EV velocity fusion (m/sec)
+	float ev_pos_noise{0.1f};               ///< minimum allowed observation noise for EV position fusion (m)
 	float ev_att_noise{0.1f};               ///< minimum allowed observation noise for EV attitude fusion (rad/sec)
 	int32_t ev_quality_minimum{0};          ///< vision minimum acceptable quality integer
 	float ev_vel_innov_gate{3.0f};          ///< vision velocity fusion innovation consistency gate size (STD)

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -400,7 +400,7 @@ void Ekf::controlExternalVisionFusion()
 		// determine if we should use the horizontal position observations
 		bool quality_sufficient = (_params.ev_quality_minimum <= 0) || (_ev_sample_delayed.quality >= _params.ev_quality_minimum);
 
-		bool starting_conditions_passing = quality_sufficient
+		const bool starting_conditions_passing = quality_sufficient
 						   && ((_ev_sample_delayed.time_us - _ev_sample_delayed_prev.time_us) < EV_MAX_INTERVAL)
 						   && ((_params.ev_quality_minimum <= 0) || (_ev_sample_delayed_prev.quality >= _params.ev_quality_minimum)) // previous quality sufficient
 						   && ((_params.ev_quality_minimum <= 0) || (_ext_vision_buffer->get_newest().quality >= _params.ev_quality_minimum)) // newest quality sufficient
@@ -409,13 +409,16 @@ void Ekf::controlExternalVisionFusion()
 		// EV velocity
 		controlEvVelFusion(_ev_sample_delayed, starting_conditions_passing, ev_reset, quality_sufficient, _aid_src_ev_vel);
 
+		// EV height
+		controlEvHeightFusion(_ev_sample_delayed, starting_conditions_passing, ev_reset, quality_sufficient, _aid_src_ev_hgt);
+
 
 		// record observation and estimate for use next time
 		_ev_sample_delayed_prev = _ev_sample_delayed;
 		_hpos_pred_prev = _state.pos.xy();
 		_yaw_pred_prev = getEulerYaw(_state.quat_nominal);
 
-	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.ev_yaw)
+	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.ev_yaw || _control_status.flags.ev_hgt)
 		   && !isRecent(_ev_sample_delayed.time_us, (uint64_t)_params.reset_timeout_max)) {
 
 		// Turn off EV fusion mode if no data has been received

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -855,7 +855,8 @@ private:
 
 	// control fusion of external vision observations
 	void controlExternalVisionFusion();
-	void controlEvVelFusion(const extVisionSample &ev_sample, bool starting_conditions_passing, bool ev_reset, bool quality_sufficient, estimator_aid_source3d_s& aid_src);
+	void controlEvHeightFusion(const extVisionSample &ev_sample, const bool common_starting_conditions_passing, const bool ev_reset, const bool quality_sufficient, estimator_aid_source1d_s& aid_src);
+	void controlEvVelFusion(const extVisionSample &ev_sample, const bool common_starting_conditions_passing, const bool ev_reset, const bool quality_sufficient, estimator_aid_source3d_s& aid_src);
 
 	// control fusion of optical flow observations
 	void controlOpticalFlowFusion();
@@ -926,7 +927,6 @@ private:
 	void controlBaroHeightFusion();
 	void controlGnssHeightFusion(const gpsSample &gps_sample);
 	void controlRangeHeightFusion();
-	void controlEvHeightFusion(const extVisionSample &ev_sample);
 
 	bool isConditionalRangeAidSuitable();
 

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1364,6 +1364,7 @@ void Ekf::stopEvFusion()
 	stopEvPosFusion();
 	stopEvVelFusion();
 	stopEvYawFusion();
+	stopEvHgtFusion();
 }
 
 void Ekf::stopEvPosFusion()

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -542,7 +542,7 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 		max_time_delay_ms = math::max(_params.flow_delay_ms, max_time_delay_ms);
 	}
 
-	if ((_params.fusion_mode & (SensorFusionMask::USE_EXT_VIS_POS | SensorFusionMask::USE_EXT_VIS_YAW)) || (_params.ev_ctrl & static_cast<int32_t>(EvCtrl::VEL))) {
+	if ((_params.fusion_mode & (SensorFusionMask::USE_EXT_VIS_POS | SensorFusionMask::USE_EXT_VIS_YAW)) || (_params.ev_ctrl > 0)) {
 		max_time_delay_ms = math::max(_params.ev_delay_ms, max_time_delay_ms);
 	}
 

--- a/src/modules/ekf2/EKF/ev_vel_control.cpp
+++ b/src/modules/ekf2/EKF/ev_vel_control.cpp
@@ -38,8 +38,8 @@
 
 #include "ekf.h"
 
-void Ekf::controlEvVelFusion(const extVisionSample &ev_sample, bool starting_conditions_passing, bool ev_reset,
-			     bool quality_sufficient, estimator_aid_source3d_s &aid_src)
+void Ekf::controlEvVelFusion(const extVisionSample &ev_sample, const bool common_starting_conditions_passing,
+			     const bool ev_reset, const bool quality_sufficient, estimator_aid_source3d_s &aid_src)
 {
 	static constexpr const char *AID_SRC_NAME = "EV velocity";
 
@@ -134,8 +134,8 @@ void Ekf::controlEvVelFusion(const extVisionSample &ev_sample, bool starting_con
 		continuing_conditions_passing = false;
 	}
 
-	starting_conditions_passing &= continuing_conditions_passing
-				       && ((Vector3f(aid_src.test_ratio).max() < 0.1f) || !isHorizontalAidingActive());
+	const bool starting_conditions_passing = common_starting_conditions_passing && continuing_conditions_passing
+			&& ((Vector3f(aid_src.test_ratio).max() < 0.1f) || !isHorizontalAidingActive());
 
 	if (_control_status.flags.ev_vel) {
 		aid_src.fusion_enabled = true;

--- a/src/modules/ekf2/EKF/height_control.cpp
+++ b/src/modules/ekf2/EKF/height_control.cpp
@@ -46,7 +46,6 @@ void Ekf::controlHeightFusion()
 	controlBaroHeightFusion();
 	controlGnssHeightFusion(_gps_sample_delayed);
 	controlRangeHeightFusion();
-	controlEvHeightFusion(_ev_sample_delayed);
 
 	checkHeightSensorRefFallback();
 }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -125,6 +125,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_rng_k_gate(_params->range_kin_consistency_gate),
 	_param_ekf2_ev_ctrl(_params->ev_ctrl),
 	_param_ekf2_ev_qmin(_params->ev_quality_minimum),
+	_param_ekf2_evp_noise(_params->ev_pos_noise),
 	_param_ekf2_evv_noise(_params->ev_vel_noise),
 	_param_ekf2_eva_noise(_params->ev_att_noise),
 	_param_ekf2_evv_gate(_params->ev_vel_innov_gate),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -525,7 +525,7 @@ private:
 		(ParamInt<px4::params::EKF2_EV_NOISE_MD>)
 		_param_ekf2_ev_noise_md,	///< determine source of vision observation noise
 		(ParamExtInt<px4::params::EKF2_EV_QMIN>) _param_ekf2_ev_qmin,
-		(ParamFloat<px4::params::EKF2_EVP_NOISE>)
+		(ParamExtFloat<px4::params::EKF2_EVP_NOISE>)
 		_param_ekf2_evp_noise,	///< default position observation noise for exernal vision measurements (m)
 		(ParamExtFloat<px4::params::EKF2_EVV_NOISE>)
 		_param_ekf2_evv_noise,	///< default velocity observation noise for exernal vision measurements (m/s)

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -77,7 +77,7 @@ void EkfWrapper::setExternalVisionHeightRef()
 
 void EkfWrapper::enableExternalVisionHeightFusion()
 {
-	setExternalVisionHeightRef(); // TODO: replace by EV control parameter
+	_ekf_params->ev_ctrl |= static_cast<int32_t>(EvCtrl::VPOS);
 }
 
 bool EkfWrapper::isIntendingExternalVisionHeightFusion() const


### PR DESCRIPTION
  - respect new EKF2_EV_CTRL parameter for VPOS usage
  - EV hgt rotate EV position before usage (there's often a small offset in frames)
  - EV hgt reset use proper EV velocity body frame
  - try to keep EV hgt and EV vel state machines consistent
  - small incremental piece of https://github.com/PX4/PX4-Autopilot/pull/19128
  - requires https://github.com/PX4/PX4-Autopilot/pull/20497 to come in first
