### PR TITLE
fw rate control: initialize rate control resets to false in stabilized mode

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -157,6 +157,8 @@ FixedwingAttitudeControl::vehicle_manual_poll(const float yaw_body)
 					Quatf q(Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body));
 					q.copyTo(_att_sp.q_d);
 
+					_att_sp.reset_rate_integrals = false;
+
 					_att_sp.timestamp = hrt_absolute_time();
 
 					_attitude_sp_pub.publish(_att_sp);


### PR DESCRIPTION
There is a corner case where, if in an auto mode that sets a reset command on the attitude setpoint message (e.g. auto takeoff), if the mode was then switched stabilized, this reset bool would never be changed back to false and the integrators would reset every cycle.

this commit initializes them to false on the manual setpoint poll where they otherwise weren't explicitly set
