### PR TITLE
Enable motor controls for tailsitter VTOLs in fixed wing mode (enable Quad Tailsitters)

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_xvert
@@ -14,7 +14,7 @@ PX4_SIM_MODEL=${PX4_SIM_MODEL:=xvert}
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_SC 0.3
+param set-default VT_FW_DIFTHR_S_Y 0.3
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_tailsitter
@@ -70,7 +70,7 @@ param set-default MPC_XY_VEL_D_ACC 0.1
 param set-default NAV_ACC_RAD 5
 
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_SC 0.5
+param set-default VT_FW_DIFTHR_S_Y 0.5
 param set-default VT_F_TRANS_DUR 1.5
 param set-default VT_F_TRANS_THR 0.7
 param set-default VT_TYPE 0

--- a/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
@@ -22,7 +22,7 @@ param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_MOT_COUNT 2
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_SC 0.3
+param set-default VT_FW_DIFTHR_S_Y 0.3
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
 

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -250,5 +250,14 @@ bool param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2022-07-18: translate VT_FW_DIFTHR_SC->VT_FW_DIFTHR_S_Y
+	{
+		if (strcmp("VT_FW_DIFTHR_SC", node->name) == 0) {
+			strcpy(node->name, "VT_FW_DIFTHR_S_Y");
+			PX4_INFO("copying %s -> %s", "VT_FW_DIFTHR_SC", "VT_FW_DIFTHR_S_Y");
+			return true;
+		}
+	}
+
 	return false;
 }

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -343,14 +343,22 @@ void Tailsitter::fill_actuator_outputs()
 		_thrust_setpoint_0->xyz[2] = -fw_in[actuator_controls_s::INDEX_THROTTLE];
 
 		/* allow differential thrust if enabled */
-		if (_param_vt_fw_difthr_en.get()) {
-			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get() ;
-			mc_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
-			mc_out[actuator_controls_s::INDEX_YAW] = -fw_in[actuator_controls_s::INDEX_ROLL];
+		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::YAW_BIT)) {
+			float yaw_control = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get();
+			mc_out[actuator_controls_s::INDEX_ROLL] = yaw_control;
+			_torque_setpoint_0->xyz[0] = yaw_control;
+		}
 
-			_torque_setpoint_0->xyz[0] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get() ;
-			_torque_setpoint_0->xyz[1] = fw_in[actuator_controls_s::INDEX_PITCH];
-			_torque_setpoint_0->xyz[2] = -fw_in[actuator_controls_s::INDEX_ROLL];
+		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::PITCH_BIT)) {
+			float pitch_control = fw_in[actuator_controls_s::INDEX_PITCH] * _param_vt_fw_difthr_s_p.get();
+			mc_out[actuator_controls_s::INDEX_PITCH] = pitch_control;
+			_torque_setpoint_0->xyz[1] = pitch_control;
+		}
+
+		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::ROLL_BIT)) {
+			float roll_control = -fw_in[actuator_controls_s::INDEX_ROLL] * _param_vt_fw_difthr_s_r.get();
+			mc_out[actuator_controls_s::INDEX_YAW] = roll_control;
+			_torque_setpoint_0->xyz[2] = roll_control;
 		}
 
 	} else {

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -344,11 +344,11 @@ void Tailsitter::fill_actuator_outputs()
 
 		/* allow differential thrust if enabled */
 		if (_param_vt_fw_difthr_en.get()) {
-			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_sc.get() ;
+			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get() ;
 			mc_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
 			mc_out[actuator_controls_s::INDEX_YAW] = -fw_in[actuator_controls_s::INDEX_ROLL];
 
-			_torque_setpoint_0->xyz[0] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_sc.get() ;
+			_torque_setpoint_0->xyz[0] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get() ;
 			_torque_setpoint_0->xyz[1] = fw_in[actuator_controls_s::INDEX_PITCH];
 			_torque_setpoint_0->xyz[2] = -fw_in[actuator_controls_s::INDEX_ROLL];
 		}

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -345,7 +345,12 @@ void Tailsitter::fill_actuator_outputs()
 		/* allow differential thrust if enabled */
 		if (_param_vt_fw_difthr_en.get()) {
 			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_sc.get() ;
+			mc_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
+			mc_out[actuator_controls_s::INDEX_YAW] = -fw_in[actuator_controls_s::INDEX_ROLL];
+
 			_torque_setpoint_0->xyz[0] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_sc.get() ;
+			_torque_setpoint_0->xyz[1] = fw_in[actuator_controls_s::INDEX_PITCH];
+			_torque_setpoint_0->xyz[2] = -fw_in[actuator_controls_s::INDEX_ROLL];
 		}
 
 	} else {

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -481,9 +481,9 @@ void Tiltrotor::fill_actuator_outputs()
 		_thrust_setpoint_0->xyz[2] = fw_in[actuator_controls_s::INDEX_THROTTLE];
 
 		/* allow differential thrust if enabled */
-		if (_param_vt_fw_difthr_en.get()) {
-			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_sc.get() ;
-			_torque_setpoint_0->xyz[2] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_sc.get() ;
+		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::YAW_BIT)) {
+			mc_out[actuator_controls_s::INDEX_ROLL] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get() ;
+			_torque_setpoint_0->xyz[2] = fw_in[actuator_controls_s::INDEX_YAW] * _param_vt_fw_difthr_s_y.get() ;
 		}
 
 	} else {

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -254,27 +254,63 @@ PARAM_DEFINE_FLOAT(VT_F_TR_OL_TM, 6.0f);
 /**
  * Differential thrust in forwards flight.
  *
- * Set to 1 to enable differential thrust in fixed-wing flight.
+ * Enable differential thrust seperately for roll, pitch, yaw in forward (fixed-wing) mode.
+ * The effectiveness of differential thrust around the corresponding axis can be
+ * tuned by setting VT_FW_DIFTHR_S_R / VT_FW_DIFTHR_S_P / VT_FW_DIFTHR_S_Y.
  *
  * @min 0
- * @max 1
- * @decimal 0
+ * @max 7
+ * @bit 0 Yaw
+ * @bit 1 Roll
+ * @bit 2 Pitch
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_FW_DIFTHR_EN, 0);
 
 /**
- * Differential thrust scaling factor
+ * Roll differential thrust factor in forward flight
  *
- * This factor specifies how the yaw input gets mapped to differential thrust in forwards flight.
+ * Maps the roll control output in forward flight to the actuator differential thrust output.
+ *
+ * Differential thrust in forward flight is enabled via VT_FW_DIFTHR_EN.
  *
  * @min 0.0
- * @max 1.0
+ * @max 2.0
  * @decimal 2
  * @increment 0.1
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_SC, 0.1f);
+PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_R, 1.f);
+
+/**
+ * Pitch differential thrust factor in forward flight
+ *
+ * Maps the pitch control output in forward flight to the actuator differential thrust output.
+ *
+ * Differential thrust in forward flight is enabled via VT_FW_DIFTHR_EN.
+ *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_P, 1.f);
+
+/**
+ * Yaw differential thrust factor in forward flight
+ *
+ * Maps the yaw control output in forward flight to the actuator differential thrust output.
+ *
+ * Differential thrust in forward flight is enabled via VT_FW_DIFTHR_EN.
+ *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_Y, 0.1f);
 
 /**
  * Backtransition deceleration setpoint to pitch feedforward gain.

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -77,6 +77,13 @@ enum VtolForwardActuationMode {
 	ENABLE_ABOVE_MPC_LAND_ALT2_WITHOUT_LAND
 };
 
+// enum for bitmask of VT_FW_DIFTHR_EN parameter options
+enum class VtFwDifthrEnBits : int32_t {
+	YAW_BIT = (1 << 0),
+	ROLL_BIT = (1 << 1),
+	PITCH_BIT = (1 << 2),
+};
+
 class VtolAttitudeControl;
 
 class VtolType : public ModuleParams
@@ -239,8 +246,8 @@ protected:
 					(ParamBool<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,
 					(ParamFloat<px4::params::VT_TRANS_TIMEOUT>) _param_vt_trans_timeout,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise,
-					(ParamBool<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en,
-					(ParamFloat<px4::params::VT_FW_DIFTHR_SC>) _param_vt_fw_difthr_sc,
+					(ParamInt<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en,
+					(ParamFloat<px4::params::VT_FW_DIFTHR_S_Y>) _param_vt_fw_difthr_s_y,
 					(ParamFloat<px4::params::VT_B_DEC_FF>) _param_vt_b_dec_ff,
 					(ParamFloat<px4::params::VT_B_DEC_I>) _param_vt_b_dec_i,
 					(ParamFloat<px4::params::VT_B_DEC_MSS>) _param_vt_b_dec_mss,

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -248,6 +248,8 @@ protected:
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise,
 					(ParamInt<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en,
 					(ParamFloat<px4::params::VT_FW_DIFTHR_S_Y>) _param_vt_fw_difthr_s_y,
+					(ParamFloat<px4::params::VT_FW_DIFTHR_S_P>) _param_vt_fw_difthr_s_p,
+					(ParamFloat<px4::params::VT_FW_DIFTHR_S_R>) _param_vt_fw_difthr_s_r,
 					(ParamFloat<px4::params::VT_B_DEC_FF>) _param_vt_b_dec_ff,
 					(ParamFloat<px4::params::VT_B_DEC_I>) _param_vt_b_dec_i,
 					(ParamFloat<px4::params::VT_B_DEC_MSS>) _param_vt_b_dec_mss,


### PR DESCRIPTION
## Describe problem solved by this pull request
For tailsitter VTOLs, motors are not used for attitude control in fixedwing mode. This is because of the distinction between control surfaces and motor controls being enabled / disabled depending on whether the vehicle is in fixed wing or multicopter mode.

## Describe your solution
This commit enables motor controls in fixed-wing mode for tailsitters. This is enabled when `VT_FW_DIFTHR_EN` is enabled on a tailsitter. This is needed for enabling control surface-less quad tailsitters (https://github.com/PX4/PX4-Autopilot/issues/19747)

## Describe possible alternatives
This feels like a hack and would be great if we can discuss how bad this hack is :sweat_smile:  @sfuhrer @tstastny 

IMHO, it would be better if this comes implicitly from the geometry of the control allocation framework. However, vehicle geomtetry doesnt seem to propagate back to vtol_att_control. We could probably do something like "Lock motor attitude control in fixedwing mode" as we do for control surfaces in fixedwing mode. However not sure how control surfaces and motors should be allocated if they are both available. 

## Test data / coverage
Tested in SITL Gazebo, with the control surfaces disabled for the quadtailsitter
```
make px4_sitl gazebo_tailsitter
```
- Flight log: [log](https://review.px4.io/plot_app?log=a616da7f-0020-4533-b983-10229f3dcb4a)
  - Note that the position and attitude controllers were not retuned, and therefore the tracking performance is quite bad. If this PR seems to be a good way to support quad tailsitters, I will add a gazebo model dedicated for quad tailsitters and retune the vehicle

## Additional context
- Fixes https://github.com/PX4/PX4-Autopilot/issues/19747