### PR TITLE
Log local position setpoint reference for fixedwings when running NPFG

### DIFF
--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -535,7 +535,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 		// single waypoint, fly directly to it
 		unit_path_tangent_ = -vector_A_to_vehicle.normalized();
 		signed_track_error_ = vector_A_to_vehicle.norm();
-		position_setpoint_ = waypoint_A;
+		closest_point_on_path_ = waypoint_A;
 		guideToPoint(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_);
 
 	} else if (vector_A_to_B.dot(vector_A_to_vehicle) < 0.0f) {
@@ -546,7 +546,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 		// guidance to the line through A and B
 		unit_path_tangent_ = vector_A_to_B.normalized();
 		signed_track_error_ = unit_path_tangent_.cross(vector_A_to_vehicle);
-		position_setpoint_ = waypoint_A;
+		closest_point_on_path_ = waypoint_A + vector_A_to_vehicle.dot(unit_path_tangent_) * unit_path_tangent_;
 		guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, 0.0f);
 
 		const Vector2f bearing_vec_to_point = -vector_A_to_vehicle.normalized();
@@ -562,7 +562,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 
 			unit_path_tangent_ = bearing_vec_to_point;
 			signed_track_error_ = vector_A_to_vehicle.norm();
-			position_setpoint_ = waypoint_A;
+			closest_point_on_path_ = waypoint_A;
 			guideToPoint(ground_vel, wind_vel, bearing_vec_to_point, signed_track_error_);
 		}
 
@@ -570,7 +570,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 		// track the line segment between A and B
 		unit_path_tangent_ = vector_A_to_B.normalized();
 		signed_track_error_ = unit_path_tangent_.cross(vector_A_to_vehicle);
-		position_setpoint_ = waypoint_A + vector_A_to_vehicle - vector_A_to_vehicle.dot(unit_path_tangent_);
+		closest_point_on_path_ = waypoint_A + vector_A_to_vehicle.dot(unit_path_tangent_) * unit_path_tangent_;
 		guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, 0.0f);
 	}
 
@@ -616,7 +616,7 @@ void NPFG::navigateLoiter(const Vector2f &loiter_center, const Vector2f &vehicle
 	// positive in direction of path normal
 	signed_track_error_ = -loiter_direction_multiplier * (dist_to_center - radius);
 
-	position_setpoint_ = unit_vec_center_to_closest_pt * radius + loiter_center;
+	closest_point_on_path_ = unit_vec_center_to_closest_pt * radius + loiter_center;
 
 	float path_curvature = loiter_direction_multiplier / radius;
 
@@ -637,7 +637,7 @@ void NPFG::navigatePathTangent(const matrix::Vector2f &vehicle_pos, const matrix
 
 	// closest point to vehicle
 	matrix::Vector2f error_vector = vehicle_pos - position_setpoint;
-	position_setpoint_ = position_setpoint;
+	closest_point_on_path_ = position_setpoint;
 	signed_track_error_ = unit_path_tangent_.cross(error_vector);
 
 	guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, curvature);
@@ -653,7 +653,7 @@ void NPFG::navigateHeading(float heading_ref, const Vector2f &ground_vel, const 
 	unit_path_tangent_ = Vector2f{cosf(heading_ref), sinf(heading_ref)};
 	signed_track_error_ = 0.0f;
 
-	position_setpoint_.setNaN();
+	closest_point_on_path_.setNaN();
 
 	// use the guidance law to regulate heading error - ignoring wind or inertial position
 	guideToPath(air_vel, Vector2f{0.0f, 0.0f}, unit_path_tangent_, signed_track_error_, 0.0f);

--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -535,6 +535,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 		// single waypoint, fly directly to it
 		unit_path_tangent_ = -vector_A_to_vehicle.normalized();
 		signed_track_error_ = vector_A_to_vehicle.norm();
+		position_setpoint_ = waypoint_A;
 		guideToPoint(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_);
 
 	} else if (vector_A_to_B.dot(vector_A_to_vehicle) < 0.0f) {
@@ -545,6 +546,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 		// guidance to the line through A and B
 		unit_path_tangent_ = vector_A_to_B.normalized();
 		signed_track_error_ = unit_path_tangent_.cross(vector_A_to_vehicle);
+		position_setpoint_ = waypoint_A;
 		guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, 0.0f);
 
 		const Vector2f bearing_vec_to_point = -vector_A_to_vehicle.normalized();
@@ -560,6 +562,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 
 			unit_path_tangent_ = bearing_vec_to_point;
 			signed_track_error_ = vector_A_to_vehicle.norm();
+			position_setpoint_ = waypoint_A;
 			guideToPoint(ground_vel, wind_vel, bearing_vec_to_point, signed_track_error_);
 		}
 
@@ -567,6 +570,7 @@ void NPFG::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoin
 		// track the line segment between A and B
 		unit_path_tangent_ = vector_A_to_B.normalized();
 		signed_track_error_ = unit_path_tangent_.cross(vector_A_to_vehicle);
+		position_setpoint_ = waypoint_A + vector_A_to_vehicle - vector_A_to_vehicle.dot(unit_path_tangent_);
 		guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, 0.0f);
 	}
 
@@ -612,6 +616,8 @@ void NPFG::navigateLoiter(const Vector2f &loiter_center, const Vector2f &vehicle
 	// positive in direction of path normal
 	signed_track_error_ = -loiter_direction_multiplier * (dist_to_center - radius);
 
+	position_setpoint_ = unit_vec_center_to_closest_pt * radius + loiter_center;
+
 	float path_curvature = loiter_direction_multiplier / radius;
 
 	guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, path_curvature);
@@ -631,6 +637,7 @@ void NPFG::navigatePathTangent(const matrix::Vector2f &vehicle_pos, const matrix
 
 	// closest point to vehicle
 	matrix::Vector2f error_vector = vehicle_pos - position_setpoint;
+	position_setpoint_ = position_setpoint;
 	signed_track_error_ = unit_path_tangent_.cross(error_vector);
 
 	guideToPath(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, curvature);
@@ -645,6 +652,8 @@ void NPFG::navigateHeading(float heading_ref, const Vector2f &ground_vel, const 
 	Vector2f air_vel = ground_vel - wind_vel;
 	unit_path_tangent_ = Vector2f{cosf(heading_ref), sinf(heading_ref)};
 	signed_track_error_ = 0.0f;
+
+	position_setpoint_.setNaN();
 
 	// use the guidance law to regulate heading error - ignoring wind or inertial position
 	guideToPath(air_vel, Vector2f{0.0f, 0.0f}, unit_path_tangent_, signed_track_error_, 0.0f);

--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -180,6 +180,8 @@ public:
 	 */
 	float getHeadingRef() const { return atan2f(air_vel_ref_(1), air_vel_ref_(0)); }
 
+	matrix::Vector2f getPositionReference() const { return position_setpoint_;}
+
 	/*
 	 * @return Bearing angle [rad]
 	 */
@@ -422,6 +424,7 @@ private:
 	matrix::Vector2f unit_path_tangent_{matrix::Vector2f{1.0f, 0.0f}}; // unit path tangent vector
 	float signed_track_error_{0.0f}; // signed track error [m]
 	matrix::Vector2f bearing_vec_{matrix::Vector2f{1.0f, 0.0f}}; // bearing unit vector
+	matrix::Vector2f position_setpoint_{matrix::Vector2f{NAN, NAN}};
 
 	/*
 	 * guidance outputs

--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -180,7 +180,7 @@ public:
 	 */
 	float getHeadingRef() const { return atan2f(air_vel_ref_(1), air_vel_ref_(0)); }
 
-	matrix::Vector2f getPositionReference() const { return position_setpoint_;}
+	matrix::Vector2f getClosestPoint() const { return closest_point_on_path_;}
 
 	/*
 	 * @return Bearing angle [rad]
@@ -424,7 +424,7 @@ private:
 	matrix::Vector2f unit_path_tangent_{matrix::Vector2f{1.0f, 0.0f}}; // unit path tangent vector
 	float signed_track_error_{0.0f}; // signed track error [m]
 	matrix::Vector2f bearing_vec_{matrix::Vector2f{1.0f, 0.0f}}; // bearing unit vector
-	matrix::Vector2f position_setpoint_{matrix::Vector2f{NAN, NAN}};
+	matrix::Vector2f closest_point_on_path_{matrix::Vector2f{NAN, NAN}}; // instantaneous position setpoint [m]
 
 	/*
 	 * guidance outputs

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2729,26 +2729,35 @@ bool FixedwingPositionControl::checkLandingAbortBitMask(const uint8_t automatic_
 
 void FixedwingPositionControl::publishLocalPositionSetpoint(const position_setpoint_s &current_waypoint)
 {
-	if (_global_local_proj_ref.isInitialized()) {
-		Vector2f current_setpoint = _global_local_proj_ref.project(current_waypoint.lat, current_waypoint.lon);
-		vehicle_local_position_setpoint_s local_position_setpoint{};
-		local_position_setpoint.timestamp = hrt_absolute_time();
-		local_position_setpoint.x = current_setpoint(0);
-		local_position_setpoint.y = current_setpoint(1);
-		local_position_setpoint.z = _global_local_alt0 - current_waypoint.alt;
-		local_position_setpoint.yaw = NAN;
-		local_position_setpoint.yawspeed = NAN;
-		local_position_setpoint.vx = NAN;
-		local_position_setpoint.vy = NAN;
-		local_position_setpoint.vz = NAN;
-		local_position_setpoint.acceleration[0] = NAN;
-		local_position_setpoint.acceleration[1] = NAN;
-		local_position_setpoint.acceleration[2] = NAN;
-		local_position_setpoint.thrust[0] = _att_sp.thrust_body[0];
-		local_position_setpoint.thrust[1] = _att_sp.thrust_body[1];
-		local_position_setpoint.thrust[2] = _att_sp.thrust_body[2];
-		_local_pos_sp_pub.publish(local_position_setpoint);
+	vehicle_local_position_setpoint_s local_position_setpoint{};
+	local_position_setpoint.timestamp = hrt_absolute_time();
+
+	Vector2f current_setpoint;
+
+	if (!_param_fw_use_npfg.get()) {
+		if (_global_local_proj_ref.isInitialized()) {
+			current_setpoint = _global_local_proj_ref.project(current_waypoint.lat, current_waypoint.lon);
+		}
+
+	} else {
+		current_setpoint = _npfg.getPositionReference();
 	}
+
+	local_position_setpoint.x = current_setpoint(0);
+	local_position_setpoint.y = current_setpoint(1);
+	local_position_setpoint.z = _global_local_alt0 - current_waypoint.alt;
+	local_position_setpoint.yaw = NAN;
+	local_position_setpoint.yawspeed = NAN;
+	local_position_setpoint.vx = NAN;
+	local_position_setpoint.vy = NAN;
+	local_position_setpoint.vz = NAN;
+	local_position_setpoint.acceleration[0] = NAN;
+	local_position_setpoint.acceleration[1] = NAN;
+	local_position_setpoint.acceleration[2] = NAN;
+	local_position_setpoint.thrust[0] = _att_sp.thrust_body[0];
+	local_position_setpoint.thrust[1] = _att_sp.thrust_body[1];
+	local_position_setpoint.thrust[2] = _att_sp.thrust_body[2];
+	_local_pos_sp_pub.publish(local_position_setpoint);
 }
 
 void FixedwingPositionControl::publishOrbitStatus(const position_setpoint_s pos_sp)

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2740,7 +2740,7 @@ void FixedwingPositionControl::publishLocalPositionSetpoint(const position_setpo
 		}
 
 	} else {
-		current_setpoint = _npfg.getPositionReference();
+		current_setpoint = _npfg.getClosestPoint();
 	}
 
 	local_position_setpoint.x = current_setpoint(0);


### PR DESCRIPTION
## Describe problem solved by this pull request
For fixedwing position control, waypoint coordinates projected on to the local frame are logged as local position setpoints. While this makes sense for waypoints, NPFG is capable of tracking paths, and logging what position reference the vehicle is trying to track would be much more informative. For example, when the vehicle is flying on a loiter path, we want to know how close the vehicle is to the closest point on the circle, rather than the center of the loiter circle.

## Describe your solution
This commit adds a state in the NPFG library which keeps the position setpoint reference so that it can be published as part of the `vehicle_local_position_setpoint` message.

When passing arbitrary references with a path in offboard mode, comparing the position reference and the current position provides better insights into how well the vehicle is tracking the path. 

## Test data / coverage
Tested in SITL Gazebo
```
make px4_sitl gazebo_plane
```

**Before PR**
- Flight log: [log](https://review.px4.io/plot_app?log=1f580ba6-8e1a-4c79-886a-76215c045744)
![bokeh_plot (6)](https://user-images.githubusercontent.com/5248102/198900676-df52f6ff-2eb5-4d3e-a6f8-07de6519aa48.png)
![bokeh_plot (7)](https://user-images.githubusercontent.com/5248102/198900674-908f0dc3-d888-4ad7-aa77-3fa0452c9f53.png)

**After PR**
- Flight log: [log](https://review.px4.io/plot_app?log=c1b856a9-3240-432e-bac8-0570388a6c95)
- Part of the log shows a continuous position references from a loiter waypoint
![bokeh_plot (4)](https://user-images.githubusercontent.com/5248102/198900586-69efd7a6-e3ba-416d-9e70-3794f21ade0e.png)
![bokeh_plot (5)](https://user-images.githubusercontent.com/5248102/198900582-8c695568-fb9f-40ff-964c-222ec6221ffe.png)



## Additional context
Add any other related context or media.
