### PR TITLE
hardfault_log: Correctly annotate stack addresses

### DIFF
--- a/src/systemcmds/hardfault_log/hardfault_log.c
+++ b/src/systemcmds/hardfault_log/hardfault_log.c
@@ -363,7 +363,7 @@ static int  write_stack(bool inValid, int winsize, uint32_t wtopaddr,
 						ret = -EIO;
 					}
 
-					wtopaddr--;
+					wtopaddr -= sizeof(stack_word_t);
 				}
 			}
 		}
@@ -621,7 +621,7 @@ static int write_intterupt_stack(int fdin, int fdout, info_s *pi, char *buffer,
 		lseek(fdin, offsetof(fullcontext_s, istack), SEEK_SET);
 		ret = write_stack((pi->flags & eInvalidIntStackPrt) != 0,
 				  CONFIG_ISTACK_SIZE,
-				  pi->stacks.interrupt.sp + CONFIG_ISTACK_SIZE / 2,
+				  pi->stacks.interrupt.sp + (CONFIG_ISTACK_SIZE / 2) * sizeof(stack_word_t),
 				  pi->stacks.interrupt.top,
 				  pi->stacks.interrupt.sp,
 				  pi->stacks.interrupt.top - pi->stacks.interrupt.size,
@@ -644,7 +644,7 @@ static int write_user_stack(int fdin, int fdout, info_s *pi, char *buffer,
 		lseek(fdin, offsetof(fullcontext_s, ustack), SEEK_SET);
 		ret = write_stack((pi->flags & eInvalidUserStackPtr) != 0,
 				  CONFIG_USTACK_SIZE,
-				  pi->stacks.user.sp + CONFIG_USTACK_SIZE / 2,
+				  pi->stacks.user.sp + (CONFIG_USTACK_SIZE / 2) * sizeof(stack_word_t),
 				  pi->stacks.user.top,
 				  pi->stacks.user.sp,
 				  pi->stacks.user.top - pi->stacks.user.size,


### PR DESCRIPTION
## Describe problem solved by this pull request
I believe the addresses in the stack dump of the hardfault logs are wrong.

```
...
0x2003f129 0x403c5ab6
0x2003f128 0xa619da9c
0x2003f127 0x3a83126f
...
```

The addresses increment by 1, but we print a full word on each line. This is impossible, since arm is byte-addressed and the values are non-repeating. 

The addresses are generated in the `hardfault_log` code, anchored at the `sp` locations. So the line annotated with `<-- User sp` and `<-- Interrupt sp` are correct, all the other addresses wrong. 


## Describe your solution
This makes the function use an increment of 4 isntead of 1. This should fix the addresses

## Test data / coverage
Tested on pixhawk 4 

## EDIT

This bug had the effect that the `<-- Interrupt sp top` etc annotations were wrong. After the fix, they nicely align with what you'd expect:

```
...
0x200210cc 0x00000000
0x200210c8 0x00000000
0x200210c4 0x00000000
0x200210c0 0x20039f2c<-- Interrupt sp top
0x200210bc 0x080082a3
0x200210b8 0x00000002
0x200210b4 0x20039838
...
```



