### PR TITLE
[EXPERIMENT] sensors/vehicle_angular_velocity: use linear regression to determine angular acceleration (aka slope filter)

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -173,6 +173,12 @@ private:
 	// angular acceleration filter
 	AlphaFilter<float> _lp_filter_acceleration[3] {};
 
+	float _gyro_sum[3] {};
+	float _time_sum[3] {};
+	float _gyro_time_sum[3] {};
+	float _time_squared_sum[3] {};
+	int _gyro_sum_count{0};
+
 	uint32_t _selected_sensor_device_id{0};
 
 	bool _reset_filters{true};


### PR DESCRIPTION
In many common setups we have 8 kHz raw gyro data available, but the inner loop rate controller might run at 400 or 800 Hz. Currently we determine the angular acceleration with a simple finite difference, but this is very susceptible to noise, so we then put the result through another filter before publishing as `vehicle_angular_acceleration`. 

Since we often have 10-20 raw samples available per angular velocity/acceleration publication one idea is to determine the slope (the angular acceleration) using all available points and linear regression.

##### Fake gyro (sine sweep to 100 Hz over 10 seconds)

![Screenshot from 2022-10-31 10-03-12](https://user-images.githubusercontent.com/84712/199026479-798a1a0b-89b4-44f2-8d33-f13a37fb5493.png)

The bottom plot shows the difference between the current angular acceleration filtering (pink) and this new "slope" filter (light blue). Dark blue is the derivative of the angular velocity in the log (lower rate than available internally). We can see the delay from the AlphaFilter, but the real question will be how this performs on an actual (noisy) vehicle.


![Screenshot from 2022-10-31 10-06-45](https://user-images.githubusercontent.com/84712/199027285-5527f345-5e0e-48b2-b09e-2bb51307ce55.png)

