### PR TITLE
Qurt work_queue Implementation

### DIFF
--- a/platforms/qurt/cmake/px4_impl_os.cmake
+++ b/platforms/qurt/cmake/px4_impl_os.cmake
@@ -126,6 +126,7 @@ function(px4_os_add_flags)
 
 		-Wno-unknown-warning-option
 		-Wno-cast-align
+		--include=${PX4_SOURCE_DIR}/platforms/qurt/include/qurt_reqs.h
 	)
 
 	# Clear -rdynamic flag which fails for hexagon

--- a/platforms/qurt/include/px4_arch/micro_hal.h
+++ b/platforms/qurt/include/px4_arch/micro_hal.h
@@ -31,17 +31,5 @@
  *
  ****************************************************************************/
 
-// This file is meant to tackle the dependencies on IOCTL found in PX4.
-// As QURT does not have IOCTL natively, this file exists to define those
-// functions/params found throughout the code base.
+// Placeholder
 
-#pragma once
-
-#include "qurt_reqs.h"
-
-#define	IOCPARM_MASK	0x1fff		/* parameter length, at most 13 bits */
-#define	IOC_VOID	0x20000000	/* no parameters */
-
-#define	_IOC(inout,group,num,len)	((unsigned long) \
-		((inout) | (((len) & IOCPARM_MASK) << 16) | ((group) << 8) | (num)))
-#define	_IO(g,n)	_IOC(IOC_VOID,	(g), (n), 0)

--- a/platforms/qurt/include/qurt_reqs.h
+++ b/platforms/qurt/include/qurt_reqs.h
@@ -36,9 +36,13 @@
 
 #pragma once
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef unsigned long useconds_t;
 int usleep(useconds_t usec);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif

--- a/platforms/qurt/include/qurt_reqs.h
+++ b/platforms/qurt/include/qurt_reqs.h
@@ -36,5 +36,9 @@
 
 #pragma once
 
+__BEGIN_DECLS
+
 typedef unsigned long useconds_t;
 int usleep(useconds_t usec);
+
+__END_DECLS

--- a/platforms/qurt/include/qurt_reqs.h
+++ b/platforms/qurt/include/qurt_reqs.h
@@ -31,17 +31,10 @@
  *
  ****************************************************************************/
 
-// This file is meant to tackle the dependencies on IOCTL found in PX4.
-// As QURT does not have IOCTL natively, this file exists to define those
-// functions/params found throughout the code base.
+// This file is meant to tackle the dependencies found in PX4
+// that have not been implemented in the Hexagon SDK yet.
 
 #pragma once
 
-#include "qurt_reqs.h"
-
-#define	IOCPARM_MASK	0x1fff		/* parameter length, at most 13 bits */
-#define	IOC_VOID	0x20000000	/* no parameters */
-
-#define	_IOC(inout,group,num,len)	((unsigned long) \
-		((inout) | (((len) & IOCPARM_MASK) << 16) | ((group) << 8) | (num)))
-#define	_IO(g,n)	_IOC(IOC_VOID,	(g), (n), 0)
+typedef unsigned long useconds_t;
+int usleep(useconds_t usec);

--- a/platforms/qurt/include/sys/ioctl.h
+++ b/platforms/qurt/include/sys/ioctl.h
@@ -37,8 +37,6 @@
 
 #pragma once
 
-#include "qurt_reqs.h"
-
 #define	IOCPARM_MASK	0x1fff		/* parameter length, at most 13 bits */
 #define	IOC_VOID	0x20000000	/* no parameters */
 

--- a/platforms/qurt/src/px4/CMakeLists.txt
+++ b/platforms/qurt/src/px4/CMakeLists.txt
@@ -39,3 +39,5 @@ set(QURT_LAYER_SRCS
 add_library(px4_layer
         ${QURT_LAYER_SRCS}
 )
+
+target_link_libraries(px4_layer PRIVATE work_queue)


### PR DESCRIPTION
## Describe problem solved by this pull request
This PR is meant to tie in Work Queue into the qurt environment.

## Describe your solution
Firstly we created a micro_hal place holder to remove the dependency associated to it. Secondly, this usleep is not defined in the unistd.h file within the Hexagon SDK, we created a qurt_reqs file with the declarations and then made them included headers in every file during compilation via the cmake edit.

## Describe possible alternatives
There are no other alternative implementations, only thing is that as we move further in the implementation of other things, micro_hal will have to be converted from a placeholder to legitimate code.

## Test data / coverage
Tested via the muorb module with some usleeps and work_queue code to ensure proper running