### PR TITLE
ekf2: ensure minimum output buffer sizing

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -503,7 +503,7 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 	const float filter_update_period_ms = _params.filter_update_interval_us / 1000.f;
 
 	// calculate the IMU buffer length required to accomodate the maximum delay with some allowance for jitter
-	_imu_buffer_length = ceilf(max_time_delay_ms / filter_update_period_ms);
+	_imu_buffer_length = math::max(2, (int)ceilf(max_time_delay_ms / filter_update_period_ms));
 
 	// set the observation buffer length to handle the minimum time of arrival between observations in combination
 	// with the worst case delay from current time to ekf fusion time


### PR DESCRIPTION
 - buffer at least 2 samples for the IMU (and output predictor buffers) and observation buffers
 - dropping below 2 becomes problematic for the minimum observation interval calculation and the vertical output buffer trapezoidal integration

Arguably the real (potential) issue here is that the EKF delayed time horizon configuration isn't factoring in the difference between the timestamp and timestamp_sample in many of the incoming data sources. So for now we'll at least have this minimal protection.

The longer term solution will be monitoring incoming data sources and determining an appropriate delay for each that factors in the timestamp_sample delay initially. 
