### PR TITLE
[BACKPORT v1.13] px4_fmu-v6:Add Revision 1 to manifest to note I2C4 is only internal

### DIFF
--- a/boards/px4/fmu-v6c/src/board_config.h
+++ b/boards/px4/fmu-v6c/src/board_config.h
@@ -145,8 +145,10 @@
 
 #define BOARD_NUM_SPI_CFG_HW_VERSIONS 2 // Rev 0, 10 Sensor sets
 //                 Base/FMUM
-#define V6C00   HW_VER_REV(0x0,0x0) // FMUV6C,                 Rev 0
-#define V6C10   HW_VER_REV(0x1,0x0) // NO PX4IO,               Rev 0
+#define V6C00   HW_VER_REV(0x0,0x0) // FMUV6C,                 Rev 0  I2C4 External but with Internal devices
+#define V6C01   HW_VER_REV(0x0,0x1) // FMUV6C,                 Rev 1  I2C4 Internal I2C2 External
+#define V6C10   HW_VER_REV(0x1,0x0) // NO PX4IO,               Rev 0  I2C4 External but with Internal devices
+#define V6C11   HW_VER_REV(0x1,0x1) // NO PX4IO,               Rev 1  I2C4 Internal I2C2 External
 
 
 /* HEATER

--- a/boards/px4/fmu-v6c/src/manifest.c
+++ b/boards/px4/fmu-v6c/src/manifest.c
@@ -97,8 +97,10 @@ static const px4_hw_mft_item_t hw_mft_list_v0610[] = {
 
 static px4_hw_mft_list_entry_t mft_lists[] = {
 //  ver_rev
-	{V6C00, hw_mft_list_v0600, arraySize(hw_mft_list_v0600)},
-	{V6C10, hw_mft_list_v0610, arraySize(hw_mft_list_v0610)}, // No PX4IO
+	{V6C00, hw_mft_list_v0600, arraySize(hw_mft_list_v0600)}, // Rev 0
+	{V6C01, hw_mft_list_v0600, arraySize(hw_mft_list_v0600)}, // Rev 1
+	{V6C10, hw_mft_list_v0610, arraySize(hw_mft_list_v0610)}, // Rev 0 No PX4IO
+	{V6C11, hw_mft_list_v0610, arraySize(hw_mft_list_v0610)}, // Rev 1 No PX4IO
 };
 
 /************************************************************************************


### PR DESCRIPTION
Backport of #20391.