### PR TITLE
syscmds/param: For -a flag (show all), show also the unused parameters

### DIFF
--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -86,9 +86,8 @@ static int	do_save_default();
 static int 	do_dump(const char *param_file_name);
 static int 	do_load(const char *param_file_name);
 static int	do_import(const char *param_file_name = nullptr);
-static int	do_show(const char *search_string, bool only_changed);
+static int	do_show(const char *search_string, bool only_changed, bool only_used);
 static int	do_show_for_airframe();
-static int	do_show_all();
 static int	do_show_quiet(const char *param_name);
 static int	do_show_index(const char *index, bool used_index);
 static void	do_show_print(void *arg, param_t param);
@@ -146,8 +145,8 @@ $ reboot
 	PRINT_MODULE_USAGE_ARG("<file>", "File name", true);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("show", "Show parameter values");
-	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Show all parameters (not just used)", true);
-	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Show only changed params (unused too)", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Show all parameters (used & unused)", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Show only changed params (used & unused)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('q', "quiet mode, print only param value (name needs to be exact)", true);
 	PRINT_MODULE_USAGE_ARG("<filter>", "Filter by param name (wildcard at end allowed, eg. sys_*)", true);
 
@@ -275,29 +274,37 @@ param_main(int argc, char *argv[])
 
 		if (!strcmp(argv[1], "show")) {
 			if (argc >= 3) {
-				// optional argument -c to show only non-default params
+				// optional argument -c to show only non-default params (used & unused)
 				if (!strcmp(argv[2], "-c")) {
 					if (argc >= 4) {
-						return do_show(argv[3], true);
+						return do_show(argv[3], true, false);
 
 					} else {
-						return do_show(nullptr, true);
+						return do_show(nullptr, true, false);
 					}
 
+				// optional argument -a to show all params (used & unused)
 				} else if (!strcmp(argv[2], "-a")) {
-					return do_show_all();
+					if (argc >= 4) {
+						return do_show(argv[3], false, false);
+
+					} else {
+						return do_show(nullptr, false, false);
+					}
 
 				} else if (!strcmp(argv[2], "-q")) {
 					if (argc >= 4) {
 						return do_show_quiet(argv[3]);
 					}
 
+				// show params (only used) matching search pattern
 				} else {
-					return do_show(argv[2], false);
+					return do_show(argv[2], false, true);
 				}
 
+			// Default: show all params (only used)
 			} else {
-				return do_show(nullptr, false);
+				return do_show(nullptr, false, true);
 			}
 		}
 
@@ -561,11 +568,13 @@ do_save_default()
 }
 
 static int
-do_show(const char *search_string, bool only_changed)
+do_show(const char *search_string, bool only_changed, bool only_used)
 {
+	if (only_used) {
+		PARAM_PRINT("Warning! Only parameters used during runtime will be shown\n");
+	}
 	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
-	// also show unused params if we show non-default values only
-	param_foreach(do_show_print, (char *)search_string, only_changed, !only_changed);
+	param_foreach(do_show_print, (char *)search_string, only_changed, only_used);
 	PARAM_PRINT("\n %u/%u parameters used.\n", param_count_used(), param_count());
 
 	return 0;
@@ -580,16 +589,6 @@ do_show_for_airframe()
 	if (sys_autostart != 0) {
 		PARAM_PRINT("# Make sure to add all params from the current airframe (ID=%" PRId32 ") as well\n", sys_autostart);
 	}
-	return 0;
-}
-
-static int
-do_show_all()
-{
-	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
-	param_foreach(do_show_print, nullptr, false, false);
-	PARAM_PRINT("\n %u parameters total, %u used.\n", param_count(), param_count_used());
-
 	return 0;
 }
 


### PR DESCRIPTION
## Describe problem solved by this pull request

![image](https://user-images.githubusercontent.com/23277211/199119537-fa9b5f93-c4ec-442b-bc29-6bb56cfe5906.png)

PX4 by default was not showing the 'unused' parameters (e.g. Rover control parameters, when running quadcopter modules) that were not provoked / read / set by any module through the `param` systemcmd interface, unless we were showing the 'non-default' parameter values.

This creates a confusion to the user who isn't aware of this `param` systemcmd behavior, to think that the parameter doesn't exist (as it can't be found with the `param show <NAME>` command, but in fact it is only not being shown because we have been specifying to only show the 'used' parameters.

## Describe your solution
- Added pattern wildcard search support for `-a` flag (which was not possible before)
- Show a warning when we are only showing `used` parameters, to inform the user
- Still support legacy behavior of only showing used parameters when doing a default `param show <PARAM_NAME>` command, with no flags (makes sense, as long as we have a warning to the user that we are only showing the subset)

## Test data / coverage
Before the change
![image](https://user-images.githubusercontent.com/23277211/199119537-fa9b5f93-c4ec-442b-bc29-6bb56cfe5906.png)

After the change
![image](https://user-images.githubusercontent.com/23277211/199119306-55b57ef6-509e-4569-b336-6efaf0eea41d.png)

## Additional context
@potaito this should solve your mystery 😉 