### PR TITLE
[Release 1.13 fixup] Holybro PX4Vision: Don't use IO

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -11,6 +11,10 @@
 
 . ${R}etc/init.d/rc.mc_defaults
 
+# System parameters
+# use FMU motor outputs for less delay in the rate control loop
+param set-default SYS_USE_IO 0
+
 # Commander Parameters
 param set-default COM_OBS_AVOID 1
 param set-default COM_DISARM_LAND 0.5


### PR DESCRIPTION
This is required in v1.13. As found by @vincentpoont2 in https://github.com/PX4/PX4-Autopilot/pull/20244#issuecomment-1281766937.