### PR TITLE
Fixed-wing takeoff and landing revisions

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
@@ -41,7 +41,6 @@ param set-default FW_T_SINK_MIN 2.2
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 30
 
 param set-default NAV_ACC_RAD 15

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_plane
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default FW_L1_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
@@ -24,7 +24,6 @@ param set-default FW_RR_P 0.085
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
 param set-default MIS_DIST_WPS 10000

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
@@ -5,7 +5,6 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default FW_LND_AIRSPD_SC 1.1
 param set-default FW_LND_ANG 5
 param set-default FW_LND_FL_PMIN 9.5
 param set-default FW_LND_FL_PMAX 20

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_rascal
@@ -31,11 +31,7 @@ param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
 param set-default RWTO_TKOFF 1
-
-param set-default RWTO_MAX_PITCH 20
-
 param set-default RWTO_PSP 8
-param set-default RWTO_AIRSPD_SCL 1.8
 
 param set-default CA_AIRFRAME 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
@@ -24,7 +24,6 @@ param set-default FW_RR_P 0.085
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
 param set-default MIS_DIST_WPS 10000

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
@@ -5,7 +5,6 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default FW_LND_AIRSPD_SC 1.1
 param set-default FW_LND_ANG 5
 param set-default FW_LND_FL_PMIN 9.5
 param set-default FW_LND_FL_PMAX 20

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_rascal-electric
@@ -31,11 +31,7 @@ param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
 param set-default RWTO_TKOFF 1
-
-param set-default RWTO_MAX_PITCH 20
-
 param set-default RWTO_PSP 8
-param set-default RWTO_AIRSPD_SCL 1.8
 
 param set-default CA_AIRFRAME 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1035_techpod
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1035_techpod
@@ -27,7 +27,6 @@ param set-default FW_L1_PERIOD 12
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 30
 
 param set-default NAV_ACC_RAD 15

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1035_techpod
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1035_techpod
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default FW_L1_PERIOD 15

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
@@ -24,7 +24,6 @@ param set-default FW_RR_P 0.085
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
 param set-default MIS_DIST_WPS 10000

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
@@ -5,7 +5,6 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default FW_LND_AIRSPD_SC 1.1
 param set-default FW_LND_ANG 5
 param set-default FW_LND_FL_PMIN 9.5
 param set-default FW_LND_FL_PMAX 20

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_malolo
@@ -31,9 +31,7 @@ param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
 param set-default RWTO_TKOFF 1
-param set-default RWTO_MAX_PITCH 20
 param set-default RWTO_PSP 8
-param set-default RWTO_AIRSPD_SCL 1.8
 
 param set-default CA_AIRFRAME 1
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default FW_L1_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -34,7 +34,6 @@ param set-default FW_T_TAS_TC 2
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 30
 
 param set-default NAV_ACC_RAD 15

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_advanced_plane
@@ -31,7 +31,6 @@ param set-default FW_T_SINK_MIN 2.2
 
 param set-default FW_W_EN 1
 
-param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 30
 
 param set-default NAV_ACC_RAD 15

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_advanced_plane
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 param set-default FW_THR_LND_MAX 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1060_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1060_rover
@@ -18,7 +18,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1061_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1061_r1_rover
@@ -18,7 +18,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1062_tf-r1
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1062_tf-r1
@@ -25,7 +25,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1070_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1070_boat
@@ -18,7 +18,6 @@ param set-default GND_THR_CRUISE 0.85
 param set-default GND_THR_MAX 1
 param set-default GND_THR_MIN 0
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17001_tf-g1
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17001_tf-g1
@@ -20,7 +20,6 @@ param set-default FW_W_EN 1
 
 param set-default FW_RR_P 0.08
 
-param set-default MIS_LTRMIN_ALT 50
 param set-default MIS_TAKEOFF_ALT 3
 
 param set-default NAV_ACC_RAD 20

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17002_tf-g2
@@ -20,7 +20,6 @@ param set-default FW_W_EN 1
 
 param set-default FW_RR_P 0.08
 
-param set-default MIS_LTRMIN_ALT 50
 param set-default MIS_TAKEOFF_ALT 7
 
 param set-default NAV_ACC_RAD 20

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -31,7 +31,6 @@ param set-default MC_PITCH_P 6
 param set-default MC_PITCHRATE_P 0.2
 param set-default MC_ROLL_P 6
 param set-default MC_ROLLRATE_P 0.3
-param set-default MIS_LTRMIN_ALT 10
 param set-default MIS_TAKEOFF_ALT 10
 param set-default MIS_YAW_TMT 10
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -39,7 +39,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 0.5

--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -44,7 +44,6 @@ param set-default GND_SPEED_D 0.001
 param set-default GND_SPEED_IMAX 0.125
 param set-default GND_SPEED_THR_SC 1
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 0.5

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
@@ -45,7 +45,6 @@ param set-default GND_SPEED_D 0.001
 param set-default GND_SPEED_IMAX 0.125
 param set-default GND_SPEED_THR_SC 1
 
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 0.5

--- a/ROMFS/px4fmu_common/init.d/rc.boat_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.boat_defaults
@@ -13,7 +13,6 @@ param set-default MAV_TYPE 11
 #
 # Default parameters for UGVs.
 #
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 2

--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -43,7 +43,6 @@ param set-default RTL_LAND_DELAY -1
 param set-default NAV_ACC_RAD 10
 
 param set-default MIS_DIST_WPS 5000
-param set-default MIS_LTRMIN_ALT 25
 param set-default MIS_TAKEOFF_ALT 25
 
 #

--- a/ROMFS/px4fmu_common/init.d/rc.rover_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_defaults
@@ -13,7 +13,6 @@ param set-default MAV_TYPE 10
 #
 # Default parameters for UGVs.
 #
-param set-default MIS_LTRMIN_ALT 0.01
 param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 2

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -109,6 +109,7 @@ set(msg_files
 	IridiumsbdStatus.msg
 	IrlockReport.msg
 	LandingGear.msg
+	LandingGearWheel.msg
 	LandingTargetInnovations.msg
 	LandingTargetPose.msg
 	LedControl.msg

--- a/msg/LandingGearWheel.msg
+++ b/msg/LandingGearWheel.msg
@@ -1,0 +1,3 @@
+uint64 timestamp # time since system start (microseconds)
+
+float32 normalized_wheel_setpoint	# negative is turning left, positive turning right [-1, 1]

--- a/msg/VehicleAttitudeSetpoint.msg
+++ b/msg/VehicleAttitudeSetpoint.msg
@@ -15,7 +15,7 @@ float32[3] thrust_body		# Normalized thrust command in body NED frame [-1,1]
 
 bool reset_integral	# Reset roll/pitch/yaw integrals (navigation logic change)
 
-bool fw_control_yaw		# control heading with rudder (used for auto takeoff on runway)
+bool fw_control_yaw_wheel	# control heading with steering wheel (used for auto takeoff on runway)
 
 uint8 apply_flaps       	# flap config specifier
 uint8 FLAPS_OFF = 0     	# no flaps

--- a/src/lib/mixer_module/functions/FunctionLandingGearWheel.hpp
+++ b/src/lib/mixer_module/functions/FunctionLandingGearWheel.hpp
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FunctionProviderBase.hpp"
+
+#include <uORB/topics/landing_gear_wheel.h>
+
+/**
+ * Functions: Landing_Gear_Wheel
+ */
+class FunctionLandingGearWheel : public FunctionProviderBase
+{
+public:
+	FunctionLandingGearWheel() = default;
+	static FunctionProviderBase *allocate(const Context &context) { return new FunctionLandingGearWheel(); }
+
+	void update() override
+	{
+		landing_gear_wheel_s landing_gear_wheel;
+
+		if (_topic.update(&landing_gear_wheel)) {
+			_data = landing_gear_wheel.normalized_wheel_setpoint;
+		}
+	}
+
+	float value(OutputFunction func) override { return _data; }
+
+private:
+	uORB::Subscription _topic{ORB_ID(landing_gear_wheel)};
+	float _data{0.f};
+};

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -59,6 +59,7 @@ static const FunctionProvider all_function_providers[] = {
 	{OutputFunction::Servo1, OutputFunction::ServoMax, &FunctionServos::allocate},
 	{OutputFunction::Offboard_Actuator_Set1, OutputFunction::Offboard_Actuator_Set6, &FunctionActuatorSet::allocate},
 	{OutputFunction::Landing_Gear, &FunctionLandingGear::allocate},
+	{OutputFunction::Landing_Gear_Wheel, &FunctionLandingGearWheel::allocate},
 	{OutputFunction::Parachute, &FunctionParachute::allocate},
 	{OutputFunction::Gripper, &FunctionGripper::allocate},
 	{OutputFunction::RC_Roll, OutputFunction::RC_AUXMax, &FunctionManualRC::allocate},

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -41,6 +41,7 @@
 #include "functions/FunctionGimbal.hpp"
 #include "functions/FunctionGripper.hpp"
 #include "functions/FunctionLandingGear.hpp"
+#include "functions/FunctionLandingGearWheel.hpp"
 #include "functions/FunctionManualRC.hpp"
 #include "functions/FunctionMotors.hpp"
 #include "functions/FunctionParachute.hpp"

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -36,6 +36,8 @@ functions:
 
     Gripper: 430
 
+    Landing_Gear_Wheel: 440
+
     # Add your own here:
     #MyCustomFunction: 10000
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -364,12 +364,11 @@ void FixedwingAttitudeControl::Run()
 
 		// the position controller will not emit attitude setpoints in some modes
 		// we need to make sure that this flag is reset
-		_att_sp.fw_control_yaw = _att_sp.fw_control_yaw && _vcontrol_mode.flag_control_auto_enabled;
+		_att_sp.fw_control_yaw_wheel = _att_sp.fw_control_yaw_wheel && _vcontrol_mode.flag_control_auto_enabled;
 
 		bool wheel_control = false;
 
-		// TODO: manual wheel_control on ground?
-		if (_param_fw_w_en.get() && _att_sp.fw_control_yaw) {
+		if (_param_fw_w_en.get() && _att_sp.fw_control_yaw_wheel) {
 			wheel_control = true;
 		}
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -185,6 +185,7 @@ FixedwingAttitudeControl::vehicle_manual_poll(const float yaw_body)
 						_manual_control_setpoint.r * _param_fw_man_y_sc.get() + _param_trim_yaw.get();
 					_actuator_controls.control[actuator_controls_s::INDEX_THROTTLE] = math::constrain(_manual_control_setpoint.z, 0.0f,
 							1.0f);
+					_landing_gear_wheel.normalized_wheel_setpoint = _manual_control_setpoint.r;
 				}
 			}
 		}
@@ -518,13 +519,12 @@ void FixedwingAttitudeControl::Run()
 				if (PX4_ISFINITE(_att_sp.roll_body) && PX4_ISFINITE(_att_sp.pitch_body)) {
 					_roll_ctrl.control_attitude(dt, control_input);
 					_pitch_ctrl.control_attitude(dt, control_input);
+					_yaw_ctrl.control_attitude(dt, control_input);
 
 					if (wheel_control) {
 						_wheel_ctrl.control_attitude(dt, control_input);
 
 					} else {
-						// runs last, because is depending on output of roll and pitch attitude
-						_yaw_ctrl.control_attitude(dt, control_input);
 						_wheel_ctrl.reset_integrator();
 					}
 
@@ -558,7 +558,7 @@ void FixedwingAttitudeControl::Run()
 					/* Publish the rate setpoint for analysis once available */
 					_rates_sp.roll = body_rates_setpoint(0);
 					_rates_sp.pitch = body_rates_setpoint(1);
-					_rates_sp.yaw = (wheel_control) ? _wheel_ctrl.get_body_rate_setpoint() : body_rates_setpoint(2);
+					_rates_sp.yaw = body_rates_setpoint(2);
 
 					_rates_sp.timestamp = hrt_absolute_time();
 
@@ -585,24 +585,35 @@ void FixedwingAttitudeControl::Run()
 				_actuator_controls.control[actuator_controls_s::INDEX_PITCH] =
 					(PX4_ISFINITE(pitch_u)) ? math::constrain(pitch_u + trim_pitch, -1.f, 1.f) : trim_pitch;
 
-				float yaw_u = 0.0f;
+				const float yaw_feedforward = _param_fw_yr_ff.get() * _airspeed_scaling * body_rates_setpoint(2);
+				const float yaw_u = angular_acceleration_setpoint(2) * _airspeed_scaling * _airspeed_scaling + yaw_feedforward;
 
-				if (wheel_control) {
-					yaw_u = _wheel_ctrl.control_bodyrate(dt, control_input);
+				// wheel control
+				float wheel_u = 0.f;
 
-					// XXX: this is an abuse -- used to ferry manual yaw inputs from position controller during auto modes
-					yaw_u += _att_sp.yaw_sp_move_rate * _param_fw_man_y_sc.get();
+				if (_vcontrol_mode.flag_control_manual_enabled) {
+					// always direct control of steering wheel with yaw stick in manual modes
+					wheel_u = _manual_control_setpoint.r;
 
 				} else {
-					const float yaw_feedforward = _param_fw_yr_ff.get() * _airspeed_scaling * body_rates_setpoint(2);
-					yaw_u = angular_acceleration_setpoint(2) * _airspeed_scaling * _airspeed_scaling + yaw_feedforward;
+					// XXX: yaw_sp_move_rate here is an abuse -- used to ferry manual yaw inputs from
+					// position controller during auto modes _manual_control_setpoint.r gets passed
+					// whenever nudging is enabled, otherwise zero
+					wheel_u = wheel_control ? _wheel_ctrl.control_bodyrate(dt, control_input)
+						  + _att_sp.yaw_sp_move_rate : 0.f;
 				}
+
+				_landing_gear_wheel.normalized_wheel_setpoint = PX4_ISFINITE(wheel_u) ? wheel_u : 0.f;
 
 				_actuator_controls.control[actuator_controls_s::INDEX_YAW] = (PX4_ISFINITE(yaw_u)) ? math::constrain(yaw_u + trim_yaw,
 						-1.f, 1.f) : trim_yaw;
 
 				if (!PX4_ISFINITE(roll_u) || !PX4_ISFINITE(pitch_u) || !PX4_ISFINITE(yaw_u) || _rates_sp.reset_integral) {
 					_rate_control.resetIntegral();
+				}
+
+				if (!PX4_ISFINITE(wheel_u)) {
+					_wheel_ctrl.reset_integrator();
 				}
 
 				/* throttle passed through if it is finite */
@@ -668,6 +679,9 @@ void FixedwingAttitudeControl::Run()
 				publishThrustSetpoint(angular_velocity.timestamp_sample);
 			}
 		}
+
+		_landing_gear_wheel.timestamp = hrt_absolute_time();
+		_landing_gear_wheel_pub.publish(_landing_gear_wheel);
 
 		updateActuatorControlsStatus(dt);
 	}

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -64,6 +64,7 @@
 #include <uORB/topics/autotune_attitude_control_status.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/control_allocator_status.h>
+#include <uORB/topics/landing_gear_wheel.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/rate_ctrl_status.h>
@@ -138,6 +139,7 @@ private:
 	uORB::PublicationMulti<rate_ctrl_status_s>	_rate_ctrl_status_pub{ORB_ID(rate_ctrl_status)};
 	uORB::Publication<vehicle_thrust_setpoint_s>	_vehicle_thrust_setpoint_pub{ORB_ID(vehicle_thrust_setpoint)};
 	uORB::Publication<vehicle_torque_setpoint_s>	_vehicle_torque_setpoint_pub{ORB_ID(vehicle_torque_setpoint)};
+	uORB::Publication<landing_gear_wheel_s>		_landing_gear_wheel_pub{ORB_ID(landing_gear_wheel)};
 
 	actuator_controls_s			_actuator_controls{};
 	manual_control_setpoint_s		_manual_control_setpoint{};
@@ -146,6 +148,7 @@ private:
 	vehicle_local_position_s		_local_pos{};
 	vehicle_rates_setpoint_s		_rates_sp{};
 	vehicle_status_s			_vehicle_status{};
+	landing_gear_wheel_s			_landing_gear_wheel{};
 
 	matrix::Dcmf _R{matrix::eye<float, 3>()};
 

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -329,6 +329,9 @@ PARAM_DEFINE_FLOAT(FW_RLL_TO_YAW_FF, 0.0f);
 /**
  * Enable wheel steering controller
  *
+ * Only enabled during automatic runway takeoff and landing.
+ * In all manual modes the wheel is directly controlled with yaw stick.
+ *
  * @boolean
  * @group FW Attitude Control
  */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1412,11 +1412,13 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_runway_takeoff.forceSetFlyState();
 		}
 
-		_runway_takeoff.update(now, _airspeed, _current_altitude - _takeoff_ground_alt,
+		const float takeoff_airspeed = (_param_fw_tko_airspd.get() > FLT_EPSILON) ? _param_fw_tko_airspd.get() :
+					       _param_fw_airspd_min.get();
+
+		_runway_takeoff.update(now, takeoff_airspeed, _airspeed, _current_altitude - _takeoff_ground_alt,
 				       clearance_altitude_amsl - _takeoff_ground_alt,
 				       &_mavlink_log_pub);
 
-		const float takeoff_airspeed = _runway_takeoff.getMinAirspeedScaling() * _param_fw_airspd_min.get();
 		float adjusted_min_airspeed = _param_fw_airspd_min.get();
 
 		if (takeoff_airspeed < _param_fw_airspd_min.get()) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -617,7 +617,8 @@ FixedwingPositionControl::landing_status_publish()
 void
 FixedwingPositionControl::updateLandingAbortStatus(const uint8_t new_abort_status)
 {
-	if (!_flare_states.flaring) {
+	// prevent automatic aborts if already flaring, but allow manual aborts
+	if (!_flare_states.flaring || new_abort_status == position_controller_landing_status_s::ABORTED_BY_OPERATOR) {
 
 		// only announce changes
 		if (new_abort_status > 0 && _landing_abort_status != new_abort_status) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1777,17 +1777,20 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 
 		/* longitudinal guidance */
 
-		const float height_rate_setpoint = flare_ramp_interpolator * (-_param_fw_lnd_fl_sink.get()) +
-						   (1.0f - flare_ramp_interpolator) * _flare_states.initial_height_rate_setpoint;
+		const float flare_ramp_interpolator_sqrt = sqrtf(flare_ramp_interpolator);
 
-		const float pitch_min_rad = flare_ramp_interpolator * radians(_param_fw_lnd_fl_pmin.get()) +
-					    (1.0f - flare_ramp_interpolator) * radians(_param_fw_p_lim_min.get());
-		const float pitch_max_rad = flare_ramp_interpolator * radians(_param_fw_lnd_fl_pmax.get()) +
-					    (1.0f - flare_ramp_interpolator) * radians(_param_fw_p_lim_max.get());
+		const float height_rate_setpoint = flare_ramp_interpolator_sqrt * (-_param_fw_lnd_fl_sink.get()) +
+						   (1.0f - flare_ramp_interpolator_sqrt) * _flare_states.initial_height_rate_setpoint;
+
+		const float pitch_min_rad = flare_ramp_interpolator_sqrt * radians(_param_fw_lnd_fl_pmin.get()) +
+					    (1.0f - flare_ramp_interpolator_sqrt) * radians(_param_fw_p_lim_min.get());
+		const float pitch_max_rad = flare_ramp_interpolator_sqrt * radians(_param_fw_lnd_fl_pmax.get()) +
+					    (1.0f - flare_ramp_interpolator_sqrt) * radians(_param_fw_p_lim_max.get());
 
 		// idle throttle may be >0 for internal combustion engines
 		// normally set to zero for electric motors
-		const float throttle_max = flare_ramp_interpolator * _param_fw_thr_idle.get() + (1.0f - flare_ramp_interpolator) *
+		const float throttle_max = flare_ramp_interpolator_sqrt * _param_fw_thr_idle.get() +
+					   (1.0f - flare_ramp_interpolator_sqrt) *
 					   _param_fw_thr_max.get();
 
 		tecs_update_pitch_throttle(control_interval,

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1328,7 +1328,7 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 		// landing airspeed and potentially tighter altitude control) already such that we don't
 		// have to do this switch (which can cause significant altitude errors) close to the ground.
 		_tecs.set_height_error_time_constant(_param_fw_thrtc_sc.get() * _param_fw_t_h_error_tc.get());
-		airspeed_sp = _param_fw_lnd_airspd_sc.get() * _param_fw_airspd_min.get();
+		airspeed_sp = (_param_fw_lnd_airspd.get() > FLT_EPSILON) ? _param_fw_lnd_airspd.get() : _param_fw_airspd_min.get();
 		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_LAND;
 		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_LAND;
 
@@ -1655,7 +1655,8 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 	local_land_point = calculateTouchdownPosition(control_interval, local_land_point);
 	const Vector2f landing_approach_vector = calculateLandingApproachVector();
 
-	const float airspeed_land = _param_fw_lnd_airspd_sc.get() * _param_fw_airspd_min.get();
+	const float airspeed_land = (_param_fw_lnd_airspd.get() > FLT_EPSILON) ? _param_fw_lnd_airspd.get() :
+				    _param_fw_airspd_min.get();
 	float adjusted_min_airspeed = _param_fw_airspd_min.get();
 
 	if (airspeed_land < _param_fw_airspd_min.get()) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1363,7 +1363,7 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 	float alt_sp = pos_sp_curr.alt;
 
 	if (_landing_abort_status) {
-		if (pos_sp_curr.alt - _current_altitude  < _param_fw_clmbout_diff.get()) {
+		if (pos_sp_curr.alt - _current_altitude  < kClearanceAltitudeBuffer) {
 			// aborted landing complete, normal loiter over landing point
 			updateLandingAbortStatus(position_controller_landing_status_s::NOT_ABORTED);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -617,42 +617,45 @@ FixedwingPositionControl::landing_status_publish()
 void
 FixedwingPositionControl::updateLandingAbortStatus(const uint8_t new_abort_status)
 {
-	// only announce changes
-	if (new_abort_status > 0 && _landing_abort_status != new_abort_status) {
+	if (!_flare_states.flaring) {
 
-		switch (new_abort_status) {
-		case (position_controller_landing_status_s::ABORTED_BY_OPERATOR): {
-				mavlink_log_critical(&_mavlink_log_pub, "Landing aborted by operator\t");
-				events::send(events::ID("fixedwing_position_control_landing_abort_status_operator_abort"), events::Log::Critical,
-					     "Landing aborted by operator");
-				break;
-			}
+		// only announce changes
+		if (new_abort_status > 0 && _landing_abort_status != new_abort_status) {
 
-		case (position_controller_landing_status_s::TERRAIN_NOT_FOUND): {
-				mavlink_log_critical(&_mavlink_log_pub, "Landing aborted: terrain estimate not found\t");
-				events::send(events::ID("fixedwing_position_control_landing_abort_status_terrain_not_found"), events::Log::Critical,
-					     "Landing aborted: terrain measurement not found");
-				break;
-			}
+			switch (new_abort_status) {
+			case (position_controller_landing_status_s::ABORTED_BY_OPERATOR): {
+					mavlink_log_critical(&_mavlink_log_pub, "Landing aborted by operator\t");
+					events::send(events::ID("fixedwing_position_control_landing_abort_status_operator_abort"), events::Log::Critical,
+						     "Landing aborted by operator");
+					break;
+				}
 
-		case (position_controller_landing_status_s::TERRAIN_TIMEOUT): {
-				mavlink_log_critical(&_mavlink_log_pub, "Landing aborted: terrain estimate timed out\t");
-				events::send(events::ID("fixedwing_position_control_landing_abort_status_terrain_timeout"), events::Log::Critical,
-					     "Landing aborted: terrain estimate timed out");
-				break;
-			}
+			case (position_controller_landing_status_s::TERRAIN_NOT_FOUND): {
+					mavlink_log_critical(&_mavlink_log_pub, "Landing aborted: terrain estimate not found\t");
+					events::send(events::ID("fixedwing_position_control_landing_abort_status_terrain_not_found"), events::Log::Critical,
+						     "Landing aborted: terrain measurement not found");
+					break;
+				}
 
-		default: {
-				mavlink_log_critical(&_mavlink_log_pub, "Landing aborted: unknown criterion\t");
-				events::send(events::ID("fixedwing_position_control_landing_abort_status_unknown_criterion"), events::Log::Critical,
-					     "Landing aborted: unknown criterion");
+			case (position_controller_landing_status_s::TERRAIN_TIMEOUT): {
+					mavlink_log_critical(&_mavlink_log_pub, "Landing aborted: terrain estimate timed out\t");
+					events::send(events::ID("fixedwing_position_control_landing_abort_status_terrain_timeout"), events::Log::Critical,
+						     "Landing aborted: terrain estimate timed out");
+					break;
+				}
+
+			default: {
+					mavlink_log_critical(&_mavlink_log_pub, "Landing aborted: unknown criterion\t");
+					events::send(events::ID("fixedwing_position_control_landing_abort_status_unknown_criterion"), events::Log::Critical,
+						     "Landing aborted: unknown criterion");
+				}
 			}
 		}
-	}
 
-	_landing_abort_status = (new_abort_status >= position_controller_landing_status_s::UNKNOWN_ABORT_CRITERION) ?
-				position_controller_landing_status_s::UNKNOWN_ABORT_CRITERION : new_abort_status;
-	landing_status_publish();
+		_landing_abort_status = (new_abort_status >= position_controller_landing_status_s::UNKNOWN_ABORT_CRITERION) ?
+					position_controller_landing_status_s::UNKNOWN_ABORT_CRITERION : new_abort_status;
+		landing_status_publish();
+	}
 }
 
 void

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1439,7 +1439,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 					ground_speed);
 
 		// yaw control is disabled once in "taking off" state
-		_att_sp.fw_control_yaw = _runway_takeoff.controlYaw();
+		_att_sp.fw_control_yaw_wheel = _runway_takeoff.controlYaw();
 
 		// XXX: hacky way to pass through manual nose-wheel incrementing. need to clean this interface.
 		if (_param_rwto_nudge.get()) {
@@ -1447,7 +1447,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		}
 
 		// tune up the lateral position control guidance when on the ground
-		if (_att_sp.fw_control_yaw) {
+		if (_att_sp.fw_control_yaw_wheel) {
 			_npfg.setPeriod(_param_rwto_l1_period.get());
 			_l1_control.set_l1_period(_param_rwto_l1_period.get());
 
@@ -1827,7 +1827,7 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 		_att_sp.pitch_body = get_tecs_pitch();
 
 		// enable direct yaw control using rudder/wheel
-		_att_sp.fw_control_yaw = true;
+		_att_sp.fw_control_yaw_wheel = true;
 
 		// XXX: hacky way to pass through manual nose-wheel incrementing. need to clean this interface.
 		if (_param_fw_lnd_nudge.get() > LandingNudgingOption::kNudgingDisabled) {
@@ -1900,7 +1900,7 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 		_att_sp.yaw_body = _yaw;
 
 		// enable direct yaw control using rudder/wheel
-		_att_sp.fw_control_yaw = false;
+		_att_sp.fw_control_yaw_wheel = false;
 
 		_att_sp.thrust_body[0] = (_landed) ? _param_fw_thr_idle.get() : get_tecs_thrust();
 	}
@@ -2315,7 +2315,7 @@ FixedwingPositionControl::Run()
 		_att_sp.reset_integral = false;
 
 		// by default we don't want yaw to be contoller directly with rudder
-		_att_sp.fw_control_yaw = false;
+		_att_sp.fw_control_yaw_wheel = false;
 
 		// default to zero - is used (IN A HACKY WAY) to pass direct nose wheel steering via yaw stick to the actuators during auto takeoff
 		_att_sp.yaw_sp_move_rate = 0.0f;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -977,7 +977,8 @@ FixedwingPositionControl::control_auto_fixed_bank_alt_hold(const float control_i
 				   _param_fw_thr_max.get(),
 				   false,
 				   _param_fw_p_lim_min.get(),
-				   _param_sinkrate_target.get());
+				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get());
 
 	_att_sp.roll_body = math::radians(_param_nav_gpsf_r.get()); // open loop loiter bank angle
 	_att_sp.yaw_body = 0.f;
@@ -1012,6 +1013,7 @@ FixedwingPositionControl::control_auto_descend(const float control_interval)
 				   false,
 				   _param_fw_p_lim_min.get(),
 				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get(),
 				   false,
 				   descend_rate);
 
@@ -1198,7 +1200,8 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 				   tecs_fw_thr_max,
 				   false,
 				   radians(_param_fw_p_lim_min.get()),
-				   _param_sinkrate_target.get());
+				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get());
 }
 
 void
@@ -1257,6 +1260,7 @@ FixedwingPositionControl::control_auto_velocity(const float control_interval, co
 				   false,
 				   radians(_param_fw_p_lim_min.get()),
 				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get(),
 				   tecs_status_s::TECS_MODE_NORMAL,
 				   pos_sp_curr.vz);
 }
@@ -1377,7 +1381,8 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 				   tecs_fw_thr_max,
 				   false,
 				   radians(_param_fw_p_lim_min.get()),
-				   _param_sinkrate_target.get());
+				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get());
 }
 
 void
@@ -1486,8 +1491,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 		// update tecs
 		const float takeoff_pitch_max_deg = _runway_takeoff.getMaxPitch(_param_fw_p_lim_max.get());
-		const float takeoff_pitch_min_climbout_deg = _runway_takeoff.getMinPitch(_takeoff_pitch_min.get(),
-				_param_fw_p_lim_min.get());
+		const float takeoff_pitch_min_deg = _runway_takeoff.getMinPitch(_takeoff_pitch_min.get(),
+						    _param_fw_p_lim_min.get());
 
 		if (_runway_takeoff.resetIntegrators()) {
 			// reset integrals except yaw (which also counts for the wheel controller)
@@ -1500,13 +1505,14 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		tecs_update_pitch_throttle(control_interval,
 					   altitude_setpoint_amsl,
 					   target_airspeed,
-					   radians(_param_fw_p_lim_min.get()),
+					   radians(takeoff_pitch_min_deg),
 					   radians(takeoff_pitch_max_deg),
 					   _param_fw_thr_min.get(),
 					   _param_fw_thr_max.get(),
-					   _runway_takeoff.climbout(),
-					   radians(takeoff_pitch_min_climbout_deg),
-					   _param_sinkrate_target.get());
+					   false,
+					   radians(takeoff_pitch_min_deg),
+					   _param_sinkrate_target.get(),
+					   _param_fw_t_clmb_max.get());
 
 		_tecs.set_equivalent_airspeed_min(_param_fw_airspd_min.get()); // reset after TECS calculation
 
@@ -1603,7 +1609,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 							   takeoff_throttle,
 							   true,
 							   radians(_takeoff_pitch_min.get()),
-							   _param_sinkrate_target.get());
+							   _param_sinkrate_target.get(),
+							   _param_climbrate_target.get());
 
 			} else {
 				tecs_update_pitch_throttle(control_interval,
@@ -1615,7 +1622,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 							   takeoff_throttle,
 							   false,
 							   radians(_param_fw_p_lim_min.get()),
-							   _param_sinkrate_target.get());
+							   _param_sinkrate_target.get(),
+							   _param_climbrate_target.get());
 			}
 
 			if (_launch_detection_state != LAUNCHDETECTION_RES_DETECTED_ENABLEMOTORS) {
@@ -1765,6 +1773,7 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 					   false,
 					   pitch_min_rad,
 					   _param_sinkrate_target.get(),
+					   _param_climbrate_target.get(),
 					   true,
 					   height_rate_setpoint);
 
@@ -1834,7 +1843,8 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 					   _param_fw_thr_max.get(),
 					   false,
 					   radians(_param_fw_p_lim_min.get()),
-					   desired_max_sinkrate);
+					   desired_max_sinkrate,
+					   _param_climbrate_target.get());
 
 		/* set the attitude and throttle commands */
 
@@ -1897,6 +1907,7 @@ FixedwingPositionControl::control_manual_altitude(const float control_interval, 
 				   false,
 				   min_pitch,
 				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get(),
 				   false,
 				   height_rate_sp);
 
@@ -2005,6 +2016,7 @@ FixedwingPositionControl::control_manual_position(const float control_interval, 
 				   false,
 				   min_pitch,
 				   _param_sinkrate_target.get(),
+				   _param_climbrate_target.get(),
 				   false,
 				   height_rate_sp);
 
@@ -2447,7 +2459,8 @@ float FixedwingPositionControl::compensateTrimThrottleForDensityAndWeight(float 
 void
 FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interval, float alt_sp, float airspeed_sp,
 		float pitch_min_rad, float pitch_max_rad, float throttle_min, float throttle_max, bool climbout_mode,
-		float climbout_pitch_min_rad, const float desired_max_sinkrate, bool disable_underspeed_detection, float hgt_rate_sp)
+		float climbout_pitch_min_rad, const float desired_max_sinkrate, const float desired_max_climbrate,
+		bool disable_underspeed_detection, float hgt_rate_sp)
 {
 	_tecs_is_running = true;
 
@@ -2527,7 +2540,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 				    throttle_trim_comp,
 				    pitch_min_rad - radians(_param_fw_psp_off.get()),
 				    pitch_max_rad - radians(_param_fw_psp_off.get()),
-				    _param_climbrate_target.get(),
+				    desired_max_climbrate,
 				    desired_max_sinkrate,
 				    hgt_rate_sp);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1490,9 +1490,9 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		}
 
 		// update tecs
-		const float takeoff_pitch_max_deg = _runway_takeoff.getMaxPitch(_param_fw_p_lim_max.get());
-		const float takeoff_pitch_min_deg = _runway_takeoff.getMinPitch(_takeoff_pitch_min.get(),
-						    _param_fw_p_lim_min.get());
+		const float pitch_max = _runway_takeoff.getMaxPitch(math::radians(_param_fw_p_lim_max.get()));
+		const float pitch_min = _runway_takeoff.getMinPitch(math::radians(_takeoff_pitch_min.get()),
+					math::radians(_param_fw_p_lim_min.get()));
 
 		if (_runway_takeoff.resetIntegrators()) {
 			// reset integrals except yaw (which also counts for the wheel controller)
@@ -1505,19 +1505,19 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		tecs_update_pitch_throttle(control_interval,
 					   altitude_setpoint_amsl,
 					   target_airspeed,
-					   radians(takeoff_pitch_min_deg),
-					   radians(takeoff_pitch_max_deg),
+					   pitch_min,
+					   pitch_max,
 					   _param_fw_thr_min.get(),
 					   _param_fw_thr_max.get(),
 					   false,
-					   radians(takeoff_pitch_min_deg),
+					   pitch_min,
 					   _param_sinkrate_target.get(),
 					   _param_fw_t_clmb_max.get());
 
 		_tecs.set_equivalent_airspeed_min(_param_fw_airspd_min.get()); // reset after TECS calculation
 
 		_att_sp.pitch_body = _runway_takeoff.getPitch(get_tecs_pitch());
-		_att_sp.thrust_body[0] = _runway_takeoff.getThrottle(now, get_tecs_thrust());
+		_att_sp.thrust_body[0] = _runway_takeoff.getThrottle(_param_fw_thr_idle.get(), get_tecs_thrust());
 
 		// apply flaps for takeoff according to the corresponding scale factor set via FW_FLAPS_TO_SCL
 		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_TAKEOFF;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -344,9 +344,13 @@ private:
 
 	uint8_t _landing_abort_status{position_controller_landing_status_s::NOT_ABORTED};
 
-	bool _flaring{false};
-	hrt_abstime _time_started_flaring{0}; // [us]
-	float _heightrate_setpoint_at_flare_start{0.0f}; // [m/s]
+	// organize flare states XXX: need to split into a separate class at some point!
+	struct FlareStates {
+		bool flaring{false};
+		hrt_abstime start_time{0}; // [us]
+		float initial_height_rate_setpoint{0.0f}; // [m/s]
+		float initial_throttle_setpoint{0.0f};
+	} _flare_states;
 
 	// [m] last terrain estimate which was valid
 	float _last_valid_terrain_alt_estimate{0.0f};

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -865,7 +865,9 @@ private:
 		(ParamInt<px4::params::FW_LND_NUDGE>) _param_fw_lnd_nudge,
 		(ParamInt<px4::params::FW_LND_ABORT>) _param_fw_lnd_abort,
 
-		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc
+		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
+
+		(ParamFloat<px4::params::FW_TKO_AIRSPD>) _param_fw_tko_airspd
 	)
 
 };

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -783,8 +783,6 @@ private:
 		(ParamFloat<px4::params::FW_AIRSPD_TRIM>) _param_fw_airspd_trim,
 		(ParamFloat<px4::params::FW_AIRSPD_STALL>) _param_fw_airspd_stall,
 
-		(ParamFloat<px4::params::FW_CLMBOUT_DIFF>) _param_fw_clmbout_diff,
-
 		(ParamFloat<px4::params::FW_GND_SPD_MIN>) _param_fw_gnd_spd_min,
 
 		(ParamFloat<px4::params::FW_L1_DAMPING>) _param_fw_l1_damping,

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -803,7 +803,7 @@ private:
 		(ParamFloat<px4::params::NPFG_SW_DST_MLT>) _param_npfg_switch_distance_multiplier,
 		(ParamFloat<px4::params::NPFG_PERIOD_SF>) _param_npfg_period_safety_factor,
 
-		(ParamFloat<px4::params::FW_LND_AIRSPD_SC>) _param_fw_lnd_airspd_sc,
+		(ParamFloat<px4::params::FW_LND_AIRSPD>) _param_fw_lnd_airspd,
 		(ParamFloat<px4::params::FW_LND_ANG>) _param_fw_lnd_ang,
 		(ParamFloat<px4::params::FW_LND_FL_PMAX>) _param_fw_lnd_fl_pmax,
 		(ParamFloat<px4::params::FW_LND_FL_PMIN>) _param_fw_lnd_fl_pmin,

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -166,6 +166,9 @@ static constexpr float MAX_TOUCHDOWN_POSITION_NUDGE_RATE = 4.0f;
 // [.] normalized deadzone threshold for manual nudging input
 static constexpr float MANUAL_TOUCHDOWN_NUDGE_INPUT_DEADZONE = 0.15f;
 
+// [s] time interval after touchdown for ramping in runway clamping constraints (touchdown is assumed at FW_LND_TD_TIME after start of flare)
+static constexpr float POST_TOUCHDOWN_CLAMP_TIME = 0.5f;
+
 class FixedwingPositionControl final : public ModuleBase<FixedwingPositionControl>, public ModuleParams,
 	public px4::WorkItem
 {
@@ -867,13 +870,16 @@ private:
 
 		(ParamFloat<px4::params::FW_LND_FL_TIME>) _param_fw_lnd_fl_time,
 		(ParamFloat<px4::params::FW_LND_FL_SINK>) _param_fw_lnd_fl_sink,
+		(ParamFloat<px4::params::FW_LND_TD_TIME>) _param_fw_lnd_td_time,
 		(ParamFloat<px4::params::FW_LND_TD_OFF>) _param_fw_lnd_td_off,
 		(ParamInt<px4::params::FW_LND_NUDGE>) _param_fw_lnd_nudge,
 		(ParamInt<px4::params::FW_LND_ABORT>) _param_fw_lnd_abort,
 
 		(ParamFloat<px4::params::FW_WIND_ARSP_SC>) _param_fw_wind_arsp_sc,
 
-		(ParamFloat<px4::params::FW_TKO_AIRSPD>) _param_fw_tko_airspd
+		(ParamFloat<px4::params::FW_TKO_AIRSPD>) _param_fw_tko_airspd,
+
+		(ParamFloat<px4::params::RWTO_PSP>) _param_rwto_psp
 	)
 
 };

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -698,12 +698,14 @@ private:
 	 * @param climbout_mode True if TECS should engage climbout mode
 	 * @param climbout_pitch_min_rad Minimum pitch angle command in climbout mode [rad]
 	 * @param desired_max_sink_rate The desired max sink rate commandable when altitude errors are large [m/s]
+	 * @param desired_max_climb_rate The desired max climb rate commandable when altitude errors are large [m/s]
 	 * @param disable_underspeed_detection True if underspeed detection should be disabled
 	 * @param hgt_rate_sp Height rate setpoint [m/s]
 	 */
 	void tecs_update_pitch_throttle(const float control_interval, float alt_sp, float airspeed_sp, float pitch_min_rad,
-					float pitch_max_rad, float throttle_min, float throttle_max, bool climbout_mode, float climbout_pitch_min_rad,
-					const float desired_max_sink_rate, bool disable_underspeed_detection = false, float hgt_rate_sp = NAN);
+					float pitch_max_rad, float throttle_min, float throttle_max, bool climbout_mode,
+					float climbout_pitch_min_rad, const float desired_max_sink_rate, const float desired_max_climb_rate,
+					bool disable_underspeed_detection = false, float hgt_rate_sp = NAN);
 
 	/**
 	 * @brief Constrains the roll angle setpoint near ground to avoid wingtip strike.

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -477,20 +477,19 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
 PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
 
 /**
- * Min. airspeed scaling factor for landing
+ * Landing airspeed
  *
- * Multiplying this factor with the minimum airspeed of the plane
- * gives the target airspeed the landing approach.
- * FW_AIRSPD_MIN * FW_LND_AIRSPD_SC
+ * The calibrated airspeed setpoint during landing.
  *
- * @unit norm
- * @min 1.0
- * @max 1.5
- * @decimal 2
- * @increment 0.01
+ * If set <= 0.0, landing airspeed = FW_AIRSPD_MIN by default.
+ *
+ * @unit m/s
+ * @min -1.0
+ * @decimal 1
+ * @increment 0.1
  * @group FW Auto Landing
  */
-PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
+PARAM_DEFINE_FLOAT(FW_LND_AIRSPD, -1.f);
 
 /**
  * Altitude time constant factor for landing

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -1026,7 +1026,7 @@ PARAM_DEFINE_FLOAT(FW_WING_HEIGHT, 0.5);
  * NOTE: max(FW_LND_FLALT, FW_LND_FL_TIME * descent rate) is taken as the flare altitude
  *
  * @unit s
- * @min 0.0
+ * @min 0.1
  * @max 5.0
  * @decimal 1
  * @increment 0.1

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -357,23 +357,6 @@ PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
 PARAM_DEFINE_FLOAT(FW_THR_IDLE, 0.0f);
 
 /**
- * Climbout Altitude difference
- *
- * If the altitude error exceeds this parameter, the system will climb out
- * with maximum throttle and minimum airspeed until it is closer than this
- * distance to the desired altitude. Mostly used for takeoff waypoints / modes.
- * Set to 0 to disable climbout mode (not recommended).
- *
- * @unit m
- * @min 0.0
- * @max 150.0
- * @decimal 1
- * @increment 0.5
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_CLMBOUT_DIFF, 10.0f);
-
-/**
  * Maximum landing slope angle
  *
  * Typically the desired landing slope angle when landing configuration (flaps, airspeed) is enabled.

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -401,6 +401,21 @@ PARAM_DEFINE_FLOAT(FW_LND_ANG, 5.0f);
 PARAM_DEFINE_FLOAT(FW_TKO_PITCH_MIN, 10.0f);
 
 /**
+ * Takeoff Airspeed
+ *
+ * The calibrated airspeed setpoint TECS will stabilize to during the takeoff climbout.
+ *
+ * If set <= 0.0, FW_AIRSPD_MIN will be set by default.
+ *
+ * @unit m/s
+ * @min -1.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_TKO_AIRSPD, -1.0f);
+
+/**
  * Landing flare altitude (relative to landing altitude)
  *
  * NOTE: max(FW_LND_FLALT, FW_LND_FL_TIME * |z-velocity|) is taken as the flare altitude

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -1035,6 +1035,26 @@ PARAM_DEFINE_FLOAT(FW_WING_HEIGHT, 0.5);
 PARAM_DEFINE_FLOAT(FW_LND_FL_TIME, 1.0f);
 
 /**
+ * Landing touchdown time (since flare start)
+ *
+ * This is the time after the start of flaring that we expect the vehicle to touch the runway.
+ * At this time, a 0.5s clamp down ramp will engage, constraining the pitch setpoint to RWTO_PSP.
+ * If enabled, ensure that RWTO_PSP is configured appropriately for full gear contact on ground roll.
+ *
+ * Set to -1.0 to disable touchdown clamping. E.g. it may not be desirable to clamp on belly landings.
+ *
+ * The touchdown time will be constrained to be greater than or equal to the flare time (FW_LND_FL_TIME).
+ *
+ * @unit s
+ * @min -1.0
+ * @max 5.0
+ * @decimal 1
+ * @increment 0.1
+ * @group FW Auto Landing
+ */
+PARAM_DEFINE_FLOAT(FW_LND_TD_TIME, -1.0f);
+
+/**
  * Landing flare sink rate
  *
  * TECS will attempt to control the aircraft to this sink rate via pitch angle (throttle killed during flare)

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
@@ -57,7 +57,6 @@ void RunwayTakeoff::init(const hrt_abstime &time_now, const float initial_yaw, c
 	initial_yaw_ = initial_yaw;
 	start_pos_global_ = start_pos_global;
 	takeoff_state_ = RunwayTakeoffState::THROTTLE_RAMP;
-	climbout_ = true; // this is true until climbout is finished
 	initialized_ = true;
 	time_initialized_ = time_now;
 	takeoff_time_ = 0;
@@ -91,7 +90,6 @@ void RunwayTakeoff::update(const hrt_abstime &time_now, const float takeoff_airs
 
 	case RunwayTakeoffState::CLIMBOUT:
 		if (vehicle_altitude > clearance_altitude) {
-			climbout_ = false;
 			takeoff_state_ = RunwayTakeoffState::FLY;
 			mavlink_log_info(mavlink_log_pub, "Reached clearance altitude\t");
 			events::send(events::ID("runway_takeoff_reached_clearance_altitude"), events::Log::Info, "Reached clearance altitude");

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.cpp
@@ -137,24 +137,32 @@ float RunwayTakeoff::getYaw(float external_yaw_setpoint)
 	}
 }
 
-float RunwayTakeoff::getThrottle(const hrt_abstime &time_now, float external_throttle_setpoint)
+float RunwayTakeoff::getThrottle(const float idle_throttle, const float external_throttle_setpoint) const
 {
-	float throttle = 0.0f;
+	float throttle = idle_throttle;
 
 	switch (takeoff_state_) {
 	case RunwayTakeoffState::THROTTLE_RAMP:
-		throttle = ((time_now - time_initialized_) / (param_rwto_ramp_time_.get() * 1_s)) * param_rwto_max_thr_.get();
-		throttle = math::constrain(throttle, 0.0f, param_rwto_max_thr_.get());
+
+		throttle = interpolateValuesOverAbsoluteTime(idle_throttle, param_rwto_max_thr_.get(), time_initialized_,
+				param_rwto_ramp_time_.get());
+
 		break;
 
 	case RunwayTakeoffState::CLAMPED_TO_RUNWAY:
 		throttle = param_rwto_max_thr_.get();
+
 		break;
 
-	default:
-		const float interpolator = math::constrain((time_now - takeoff_time_ * 1_s) / (kThrottleHysteresisTime * 1_s), 0.0f,
-					   1.0f);
-		throttle = external_throttle_setpoint * interpolator + (1.0f - interpolator) * param_rwto_max_thr_.get();
+	case RunwayTakeoffState::CLIMBOUT:
+		// ramp in throttle setpoint over takeoff rotation transition time
+		throttle = interpolateValuesOverAbsoluteTime(param_rwto_max_thr_.get(), external_throttle_setpoint, takeoff_time_,
+				param_rwto_rot_time_.get());
+
+		break;
+
+	case RunwayTakeoffState::FLY:
+		throttle = external_throttle_setpoint;
 	}
 
 	return throttle;
@@ -166,21 +174,33 @@ bool RunwayTakeoff::resetIntegrators()
 	return takeoff_state_ < RunwayTakeoffState::CLIMBOUT;
 }
 
-float RunwayTakeoff::getMinPitch(float min_pitch_in_climbout, float min_pitch)
+float RunwayTakeoff::getMinPitch(float min_pitch_in_climbout, float min_pitch) const
 {
-	if (takeoff_state_ < RunwayTakeoffState::FLY) {
-		return min_pitch_in_climbout;
+	if (takeoff_state_ < RunwayTakeoffState::CLIMBOUT) {
+		// constrain to the taxi pitch setpoint
+		return math::radians(param_rwto_psp_.get() - 0.01f);
+
+	} else if (takeoff_state_ < RunwayTakeoffState::FLY) {
+		// ramp in the climbout pitch constraint over the rotation transition time
+		const float taxi_pitch_min = math::radians(param_rwto_psp_.get() - 0.01f);
+		return interpolateValuesOverAbsoluteTime(taxi_pitch_min, min_pitch_in_climbout, takeoff_time_,
+				param_rwto_rot_time_.get());
 
 	} else {
 		return min_pitch;
 	}
 }
 
-float RunwayTakeoff::getMaxPitch(const float max_pitch)
+float RunwayTakeoff::getMaxPitch(const float max_pitch) const
 {
-	// use max pitch from parameter if set
-	if (takeoff_state_ < RunwayTakeoffState::FLY && param_rwto_max_pitch_.get() > kMinMaxPitch) {
-		return param_rwto_max_pitch_.get();
+	if (takeoff_state_ < RunwayTakeoffState::CLIMBOUT) {
+		// constrain to the taxi pitch setpoint
+		return math::radians(param_rwto_psp_.get() + 0.01f);
+
+	} else if (takeoff_state_ < RunwayTakeoffState::FLY) {
+		// ramp in the climbout pitch constraint over the rotation transition time
+		const float taxi_pitch_max = math::radians(param_rwto_psp_.get() + 0.01f);
+		return interpolateValuesOverAbsoluteTime(taxi_pitch_max, max_pitch, takeoff_time_, param_rwto_rot_time_.get());
 
 	} else {
 		return max_pitch;
@@ -192,6 +212,15 @@ void RunwayTakeoff::reset()
 	initialized_ = false;
 	takeoff_state_ = RunwayTakeoffState::THROTTLE_RAMP;
 	takeoff_time_ = 0;
+}
+
+float RunwayTakeoff::interpolateValuesOverAbsoluteTime(const float start_value, const float end_value,
+		const hrt_abstime &start_time, const float interpolation_time) const
+{
+	const float seconds_since_start = hrt_elapsed_time(&start_time) / float(1_s);
+	const float interpolator = math::constrain(seconds_since_start / interpolation_time, 0.0f, 1.0f);
+
+	return interpolator * end_value + (1.0f - interpolator) * start_value;
 }
 
 } // namespace runwaytakeoff

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -140,27 +140,27 @@ public:
 	/**
 	 * @brief Returns the throttle setpoint.
 	 *
-	 * Ramps up over RWTO_RAMP_TIME to RWTO_MAX_THR until the aircraft lifts off the runway, then passes
-	 * through the externally defined throttle setting.
+	 * Ramps up over RWTO_RAMP_TIME to RWTO_MAX_THR until the aircraft lifts off the runway and then
+	 * ramps from RWTO_MAX_THR to the externally defined throttle setting over the takeoff rotation time
 	 *
-	 * @param time_now Absolute time since system boot [us]
+	 * @param idle_throttle normalized [0,1]
 	 * @param external_throttle_setpoint Externally commanded throttle setpoint (usually from TECS), normalized [0,1]
 	 * @return Throttle setpoint, normalized [0,1]
 	 */
-	float getThrottle(const hrt_abstime &time_now, const float external_throttle_setpoint);
+	float getThrottle(const float idle_throttle, const float external_throttle_setpoint) const;
 
 	/**
 	 * @param min_pitch_in_climbout Minimum pitch angle during climbout [rad]
 	 * @param min_pitch Externally commanded minimum pitch angle [rad]
 	 * @return Minimum pitch angle [rad]
 	 */
-	float getMinPitch(const float min_pitch_in_climbout, const float min_pitch);
+	float getMinPitch(const float min_pitch_in_climbout, const float min_pitch) const;
 
 	/**
 	 * @param max_pitch Externally commanded maximum pitch angle [rad]
 	 * @return Maximum pitch angle [rad]
 	 */
-	float getMaxPitch(const float max_pitch);
+	float getMaxPitch(const float max_pitch) const;
 
 	/**
 	 * @return Runway takeoff starting position in global frame (lat, lon) [deg]
@@ -181,19 +181,19 @@ public:
 	 */
 	void reset();
 
+	/**
+	 * @brief Linearly interpolates between a start and end value over an absolute time span.
+	 *
+	 * @param start_value
+	 * @param end_value
+	 * @param start_time Absolute start time [us]
+	 * @param interpolation_time The time span to interpolate over [s]
+	 * @return interpolated value
+	 */
+	float interpolateValuesOverAbsoluteTime(const float start_value, const float end_value, const hrt_abstime &start_time,
+						const float interpolation_time) const;
+
 private:
-	/**
-	 * Minimum allowed maximum pitch constraint (from parameter) for runway takeoff. [rad]
-	 */
-	static constexpr float kMinMaxPitch = 0.1f;
-
-	/**
-	 * Time from takeoff during which the takeoff throttle is transitioned to the externally commanded throttle.
-	 * Used to avoid throttle jumps immediately on lift off when switching from the constant, parameterized, takeoff
-	 * throttle to the airspeed/altitude controller's commanded throttle [s]
-	 */
-	static constexpr float kThrottleHysteresisTime = 2.0f;
-
 	/**
 	 * Current state of runway takeoff procedure
 	 */
@@ -232,9 +232,9 @@ private:
 		(ParamInt<px4::params::RWTO_HDG>) param_rwto_hdg_,
 		(ParamFloat<px4::params::RWTO_MAX_THR>) param_rwto_max_thr_,
 		(ParamFloat<px4::params::RWTO_PSP>) param_rwto_psp_,
-		(ParamFloat<px4::params::RWTO_MAX_PITCH>) param_rwto_max_pitch_,
 		(ParamFloat<px4::params::RWTO_RAMP_TIME>) param_rwto_ramp_time_,
-		(ParamFloat<px4::params::RWTO_ROT_AIRSPD>) param_rwto_rot_airspd_
+		(ParamFloat<px4::params::RWTO_ROT_AIRSPD>) param_rwto_rot_airspd_,
+		(ParamFloat<px4::params::RWTO_ROT_TIME>) param_rwto_rot_time_
 	)
 };
 

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -80,13 +80,14 @@ public:
 	 * @brief Updates the state machine based on the current vehicle condition.
 	 *
 	 * @param time_now Absolute time since system boot [us]
+	 * @param takeoff_airspeed Calibrated airspeed setpoint for the takeoff climbout [m/s]
 	 * @param calibrated_airspeed Vehicle calibrated airspeed [m/s]
 	 * @param vehicle_altitude Vehicle altitude (AGL) [m]
 	 * @param clearance_altitude Altitude (AGL) above which we have cleared all occlusions in the runway path [m]
 	 * @param mavlink_log_pub
 	 */
-	void update(const hrt_abstime &time_now, const float calibrated_airspeed, const float vehicle_altitude,
-		    const float clearance_altitude, orb_advert_t *mavlink_log_pub);
+	void update(const hrt_abstime &time_now, const float takeoff_airspeed, const float calibrated_airspeed,
+		    const float vehicle_altitude, const float clearance_altitude, orb_advert_t *mavlink_log_pub);
 
 	/**
 	 * @return Current takeoff state
@@ -102,11 +103,6 @@ public:
 	 * @return Runway takeoff is enabled
 	 */
 	bool runwayTakeoffEnabled() { return param_rwto_tkoff_.get(); }
-
-	/**
-	 * @return Scale factor for minimum indicated airspeed
-	 */
-	float getMinAirspeedScaling() { return param_rwto_airspd_scl_.get(); }
 
 	/**
 	 * @return Initial vehicle yaw angle [rad]
@@ -247,9 +243,8 @@ private:
 		(ParamFloat<px4::params::RWTO_MAX_THR>) param_rwto_max_thr_,
 		(ParamFloat<px4::params::RWTO_PSP>) param_rwto_psp_,
 		(ParamFloat<px4::params::RWTO_MAX_PITCH>) param_rwto_max_pitch_,
-		(ParamFloat<px4::params::RWTO_AIRSPD_SCL>) param_rwto_airspd_scl_,
 		(ParamFloat<px4::params::RWTO_RAMP_TIME>) param_rwto_ramp_time_,
-		(ParamFloat<px4::params::FW_AIRSPD_MIN>) param_fw_airspd_min_
+		(ParamFloat<px4::params::RWTO_ROT_AIRSPD>) param_rwto_rot_airspd_
 	)
 };
 

--- a/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/RunwayTakeoff.h
@@ -115,11 +115,6 @@ public:
 	bool controlYaw();
 
 	/**
-	 * @return TECS should be commanded to climbout mode
-	 */
-	bool climbout() { return climbout_; }
-
-	/**
 	 * @param external_pitch_setpoint Externally commanded pitch angle setpoint (usually from TECS) [rad]
 	 * @return Pitch angle setpoint (limited while plane is on runway) [rad]
 	 */
@@ -224,11 +219,6 @@ private:
 	 * used for heading hold mode. [rad]
 	 */
 	float initial_yaw_{0.f};
-
-	/**
-	 * True if TECS should be commanded to "climbout" mode.
-	 */
-	bool climbout_{false};
 
 	/**
 	 * The global (lat, lon) position of the vehicle on first pass through the runway takeoff state machine. The

--- a/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
@@ -108,21 +108,6 @@ PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
 PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
 
 /**
- * Min airspeed scaling factor for takeoff.
- *
- * Pitch up will be commanded when the following airspeed is reached:
- * FW_AIRSPD_MIN * RWTO_AIRSPD_SCL
- *
- * @unit norm
- * @min 0.0
- * @max 2.0
- * @decimal 2
- * @increment 0.01
- * @group Runway Takeoff
- */
-PARAM_DEFINE_FLOAT(RWTO_AIRSPD_SCL, 1.3);
-
-/**
  * Throttle ramp up time for runway takeoff
  *
  * @unit s
@@ -156,3 +141,19 @@ PARAM_DEFINE_FLOAT(RWTO_L1_PERIOD, 5.0f);
  * @group Runway Takeoff
  */
 PARAM_DEFINE_INT32(RWTO_NUDGE, 1);
+
+/**
+ * Takeoff rotation airspeed
+ *
+ * The calibrated airspeed threshold during the takeoff ground roll when the plane should start rotating (pitching up).
+ * Must be less than the takeoff airspeed, will otherwise be capped at the takeoff airpeed (see FW_TKO_AIRSPD).
+ *
+ * If set <= 0.0, defaults to 0.9 * takeoff airspeed (see FW_TKO_AIRSPD)
+ *
+ * @unit m/s
+ * @min -1.0
+ * @decimal 1
+ * @increment 0.1
+ * @group Runway Takeoff
+ */
+PARAM_DEFINE_FLOAT(RWTO_ROT_AIRSPD, -1.0f);

--- a/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
+++ b/src/modules/fw_pos_control_l1/runway_takeoff/runway_takeoff_params.c
@@ -77,7 +77,7 @@ PARAM_DEFINE_INT32(RWTO_HDG, 0);
 PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
 
 /**
- * Pitch setpoint during taxi / before takeoff airspeed is reached.
+ * Pitch setpoint during taxi / before takeoff rotation airspeed is reached.
  *
  * A taildragger with steerable wheel might need to pitch up
  * a little to keep its wheel on the ground before airspeed
@@ -91,21 +91,6 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
-
-/**
- * Max pitch during takeoff.
- *
- * Fixed-wing settings are used if set to 0. Note that there is also a minimum
- * pitch of 10 degrees during takeoff, so this must be larger if set.
- *
- * @unit deg
- * @min 0.0
- * @max 60.0
- * @decimal 1
- * @increment 0.5
- * @group Runway Takeoff
- */
-PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
 
 /**
  * Throttle ramp up time for runway takeoff
@@ -157,3 +142,16 @@ PARAM_DEFINE_INT32(RWTO_NUDGE, 1);
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_ROT_AIRSPD, -1.0f);
+
+/**
+ * Takeoff rotation time
+ *
+ * This is the time desired to linearly ramp in takeoff pitch constraints during the takeoff rotation
+ *
+ * @unit s
+ * @min 0.1
+ * @decimal 1
+ * @increment 0.1
+ * @group Runway Takeoff
+ */
+PARAM_DEFINE_FLOAT(RWTO_ROT_TIME, 1.0f);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -75,6 +75,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("input_rc", 500);
 	add_optional_topic("internal_combustion_engine_status", 10);
 	add_optional_topic("irlock_report", 1000);
+	add_topic("landing_gear_wheel", 10);
 	add_optional_topic("landing_target_pose", 1000);
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -63,7 +63,7 @@ TEST(PositionControlTest, EmptySetpoint)
 	EXPECT_EQ(Quatf(attitude.q_d), Quatf(1.f, 0.f, 0.f, 0.f));
 	EXPECT_EQ(Vector3f(attitude.thrust_body), Vector3f(0.f, 0.f, 0.f));
 	EXPECT_EQ(attitude.reset_integral, false);
-	EXPECT_EQ(attitude.fw_control_yaw, false);
+	EXPECT_EQ(attitude.fw_control_yaw_wheel, false);
 	EXPECT_FLOAT_EQ(attitude.apply_flaps, 0.f);//vehicle_attitude_setpoint_s::FLAPS_OFF); // TODO why no reference?
 }
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1436,15 +1436,14 @@ Mission::cruising_speed_sp_update()
 void
 Mission::do_abort_landing()
 {
-	// Abort FW landing
-	//  first climb out then loiter over intended landing location
+	// Abort FW landing, loiter above landing site in at least MIS_LND_ABRT_ALT
 
 	if (_mission_item.nav_cmd != NAV_CMD_LAND) {
 		return;
 	}
 
 	const float alt_landing = get_absolute_altitude_for_item(_mission_item);
-	const float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(),
+	const float alt_sp = math::max(alt_landing + _navigator->get_landing_abort_min_alt(),
 				       _navigator->get_global_position()->alt);
 
 	// turn current landing waypoint into an indefinite loiter
@@ -1469,10 +1468,10 @@ Mission::do_abort_landing()
 	publish_navigator_mission_item(); // for logging
 	_navigator->set_position_setpoint_triplet_updated();
 
-	mavlink_log_info(_navigator->get_mavlink_log_pub(), "Holding at %d m above landing.\t",
+	mavlink_log_info(_navigator->get_mavlink_log_pub(), "Holding at %d m above landing waypoint.\t",
 			 (int)(alt_sp - alt_landing));
 	events::send<float>(events::ID("mission_holding_above_landing"), events::Log::Info,
-			    "Holding at {1:.0m_v} above landing", alt_sp - alt_landing);
+			    "Holding at {1:.0m_v} above landing waypoint", alt_sp - alt_landing);
 
 	// reset mission index to start of landing
 	if (_land_start_available) {

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1443,11 +1443,9 @@ Mission::do_abort_landing()
 		return;
 	}
 
-	// loiter at the larger of MIS_LTRMIN_ALT above the landing point
-	//  or 2 * FW_CLMBOUT_DIFF above the current altitude
 	const float alt_landing = get_absolute_altitude_for_item(_mission_item);
 	const float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(),
-				       _navigator->get_global_position()->alt + 20.0f);
+				       _navigator->get_global_position()->alt);
 
 	// turn current landing waypoint into an indefinite loiter
 	_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1461,8 +1461,8 @@ Mission::do_abort_landing()
 	// XXX: this is a hack to invalidate the "next" position setpoint for the fixed-wing position controller during
 	// the landing abort hold. otherwise, the "next" setpoint would still register as a "LAND" point, and trigger
 	// the early landing configuration (flaps and landing airspeed) during the hold.
-	_navigator->get_position_setpoint_triplet()->next.lat = NAN;
-	_navigator->get_position_setpoint_triplet()->next.lon = NAN;
+	_navigator->get_position_setpoint_triplet()->next.lat = (double)NAN;
+	_navigator->get_position_setpoint_triplet()->next.lon = (double)NAN;
 	_navigator->get_position_setpoint_triplet()->next.alt = NAN;
 
 	publish_navigator_mission_item(); // for logging

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1460,6 +1460,14 @@ Mission::do_abort_landing()
 
 	mission_apply_limitation(_mission_item);
 	mission_item_to_position_setpoint(_mission_item, &_navigator->get_position_setpoint_triplet()->current);
+
+	// XXX: this is a hack to invalidate the "next" position setpoint for the fixed-wing position controller during
+	// the landing abort hold. otherwise, the "next" setpoint would still register as a "LAND" point, and trigger
+	// the early landing configuration (flaps and landing airspeed) during the hold.
+	_navigator->get_position_setpoint_triplet()->next.lat = NAN;
+	_navigator->get_position_setpoint_triplet()->next.lon = NAN;
+	_navigator->get_position_setpoint_triplet()->next.alt = NAN;
+
 	publish_navigator_mission_item(); // for logging
 	_navigator->set_position_setpoint_triplet_updated();
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -772,7 +772,17 @@ MissionBlock::setLoiterItemFromCurrentPosition(struct mission_item_s *item)
 
 	item->lat = _navigator->get_global_position()->lat;
 	item->lon = _navigator->get_global_position()->lon;
-	item->altitude = _navigator->get_global_position()->alt;
+
+	// check if minimum loiter altitude is specified, and enforce it if so
+	float loiter_altitude_amsl = _navigator->get_global_position()->alt;
+
+	if (_navigator->get_loiter_min_alt() > FLT_EPSILON) {
+		loiter_altitude_amsl = math::max(loiter_altitude_amsl,
+						 _navigator->get_home_position()->alt + _navigator->get_loiter_min_alt());
+	}
+
+	item->altitude = loiter_altitude_amsl;
+
 	item->loiter_radius = _navigator->get_loiter_radius();
 }
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -732,15 +732,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 		break;
 
 	case NAV_CMD_LOITER_TO_ALT:
-
-		// initially use current altitude, and switch to mission item altitude once in loiter position
-		if (_navigator->get_loiter_min_alt() > 0.f) { // ignore _param_loiter_min_alt if smaller than 0
-			sp->alt = math::max(_navigator->get_global_position()->alt,
-					    _navigator->get_home_position()->alt + _navigator->get_loiter_min_alt());
-
-		} else {
-			sp->alt = _navigator->get_global_position()->alt;
-		}
+		sp->alt = _navigator->get_global_position()->alt;
 
 	// FALLTHROUGH
 	case NAV_CMD_LOITER_TIME_LIMIT:

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -68,21 +68,6 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
 PARAM_DEFINE_INT32(MIS_TAKEOFF_REQ, 0);
 
 /**
- * Minimum Loiter altitude
- *
- * This is the minimum altitude the system will always obey. The intent is to stay out of ground effect.
- * set to -1, if there shouldn't be a minimum loiter altitude
- *
- * @unit m
- * @min -1
- * @max 80
- * @decimal 1
- * @increment 0.5
- * @group Mission
- */
-PARAM_DEFINE_FLOAT(MIS_LTRMIN_ALT, -1.0f);
-
-/**
  * Maximal horizontal distance from home to first waypoint
  *
  * Failsafe check to prevent running mission stored from previous flight at a new takeoff location.
@@ -167,3 +152,16 @@ PARAM_DEFINE_FLOAT(MIS_YAW_ERR, 12.0f);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(MIS_PD_TO, 5.0f);
+
+/**
+ * Landing abort min altitude
+ *
+ * Minimum altitude above landing point that the vehicle will climb to after an aborted landing.
+ * Then vehicle will loiter in this altitude until further command is received.
+ * Only applies to fixed-wing vehicles.
+ *
+ * @unit m
+ * @min 0
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(MIS_LND_ABRT_ALT, 30);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -306,7 +306,7 @@ public:
 	void geofence_breach_check(bool &have_geofence_position_data);
 
 	// Param access
-	float get_loiter_min_alt() const { return _param_mis_ltrmin_alt.get(); }
+	int get_landing_abort_min_alt() const { return _param_mis_lnd_abrt_alt.get(); }
 	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
 	bool  get_takeoff_required() const { return _param_mis_takeoff_req.get(); }
 	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
@@ -449,12 +449,12 @@ private:
 		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm,	/**< avoidance Distance Manned*/
 
 		// non-navigator parameters: Mission (MIS_*)
-		(ParamFloat<px4::params::MIS_LTRMIN_ALT>)  _param_mis_ltrmin_alt,
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
 		(ParamBool<px4::params::MIS_TAKEOFF_REQ>)  _param_mis_takeoff_req,
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
 		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
-		(ParamFloat<px4::params::LNDMC_ALT_MAX>)   _param_lndmc_alt_max
+		(ParamFloat<px4::params::LNDMC_ALT_MAX>)   _param_lndmc_alt_max,
+		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt
 	)
 };

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -306,6 +306,7 @@ public:
 	void geofence_breach_check(bool &have_geofence_position_data);
 
 	// Param access
+	int get_loiter_min_alt() const { return _param_min_ltr_alt.get(); }
 	int get_landing_abort_min_alt() const { return _param_mis_lnd_abrt_alt.get(); }
 	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
 	bool  get_takeoff_required() const { return _param_mis_takeoff_req.get(); }
@@ -447,6 +448,7 @@ private:
 		(ParamInt<px4::params::NAV_TRAFF_AVOID>)    _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
 		(ParamFloat<px4::params::NAV_TRAFF_A_RADU>) _param_nav_traff_a_radu,	/**< avoidance Distance Unmanned*/
 		(ParamFloat<px4::params::NAV_TRAFF_A_RADM>) _param_nav_traff_a_radm,	/**< avoidance Distance Manned*/
+		(ParamFloat<px4::params::NAV_MIN_LTR_ALT>)   _param_min_ltr_alt,	/**< minimum altitude in Loiter mode*/
 
 		// non-navigator parameters: Mission (MIS_*)
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -161,3 +161,19 @@ PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADU, 10);
  * @group Mission
  */
 PARAM_DEFINE_INT32(NAV_FORCE_VT, 1);
+
+/**
+ * Minimum Loiter altitude
+ *
+ * This is the minimum altitude above Home the system will always obey in Loiter (Hold) mode if switched into this
+ * mode without specifying an altitude (e.g. through Loiter switch on RC).
+ * Doesn't affect Loiters that are part of Missions or that are entered through a reposition setpoint ("Go to").
+ * Set to a negative value to disable.
+ *
+ * @unit m
+ * @min -1
+ * @decimal 1
+ * @increment 0.5
+ * @group Mission
+ */
+PARAM_DEFINE_FLOAT(NAV_MIN_LTR_ALT, -1.f);

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -336,14 +336,7 @@ void RTL::set_rtl_item()
 	switch (_rtl_state) {
 	case RTL_STATE_CLIMB: {
 
-			// do not use LOITER_TO_ALT for rotary wing mode as it would then always climb to at least MIS_LTRMIN_ALT,
-			// even if current climb altitude is below (e.g. RTL immediately after take off)
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-				_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-
-			} else {
-				_mission_item.nav_cmd = NAV_CMD_LOITER_TO_ALT;
-			}
+			_mission_item.nav_cmd = NAV_CMD_LOITER_TO_ALT;
 
 			_mission_item.lat = gpos.lat;
 			_mission_item.lon = gpos.lon;


### PR DESCRIPTION
General improvements to the fixed-wing auto takeoff/landing logic and controller done by @tstastny and me in the last weeks.

## New things (more info contained in the commit messages)
### Runway takeoff
Procedure:
- ramp in throttle
- hold throttle and clamp to runway until reaching rotation speed
- rotate (ramp in relaxed pitch and throttle constraints, TECS controls, takeoff airspeed setpoint)
- control aircraft to max climb and prescribed takeoff airspeed until reaching clearance altitude

Details:
- explicit runway takeoff rotation and climbout airspeed setpoints (new params `FW_TKO_AIRSPD` and `RWTO_ROT_AIRSPD`, deleted param `RWTO_AIRSPD_SCL`)
- don't use climbout mode for runway takeoff climbout
- ramping in of constraints and setpoints on all transitions (avoid jumps) --> remove param `RWTO_MAX_PITCH`, introduce `RWTO_ROT_TIME`

### Landing flare
Procedure:
- once range finder detects imminent impact (see `FW_LND_FL_TIME`), start flare
- TECS is switched to height rate control at `FW_LND_FL_SINK` m/s
- pitch min/max constraints, throttle max constraint, and height rate setpoint are ramped in using a *square root* function of the time since flare start (over `FW_LND_FL_TIME`) - square root to be more aggressive in the flaring action for these states
- throttle setpoint and L1/NPFG periods for ground roll are ramped in linearly
- if enabled, `FW_LND_TD_TIME` determines the time after flare start that touchdown is expected. after this time, touchdown clamping (for runway ground roll out) will be ramped in over a hardcoded 0.5 seconds. I.e. pitch constraint for runway. if disabled - the flare constraints will be held throughout until land is detected.

More details:
- use path following throughout flare (instead of changing to heading hold mode)

### Landing abort
- don't allow automatic landing aborts after flare has started (manual aborts are still always possible)
- disable early landing config during a landing abort
- rename `MIS_LTRMIN_ALT` param to `NAV_MIN_LTR_ALT` and only consider on loiters which are *not part of a mission
- use new specific param `MIS_LND_ABRT_ALT` for landing abort altitude
- remove param `FW_CLMBOUT_DIFF`

### General changes
- explicit landing airspeed (new param `FW_LND_AIRSPD`, replaced param `FW_LND_AIRSPD_SC`)
- vehicle_attitude_setpoint: rename fw_control_yaw to fw_control_yaw_wheel to make more explicit
- splitting wheel and yaw control and enable steering wheel in control allocation (allows wheel control in stabilized via yaw stick independent of attitude controller)

## Test data / coverage
Most of it has been test-flown on both hand-launched and runway-takeoff vehicles.

Auto take-off:
https://user-images.githubusercontent.com/8026163/201090349-9300a150-b1d3-4794-aa49-d9e279bf641b.mp4

Auto land. Note in this video, just before reaching the ground, you can see the flare start, and the touchdown time initiated nose down action.
https://user-images.githubusercontent.com/8026163/201090378-8dded870-6082-45c4-ac2c-c699bbe7eeaf.mp4

## TODO:
- [x] provide videos
- [x] param translation 
- in follow up doc pr ... update documentation!
