### PR TITLE
vehicle_magnetometer: fix standalone mag bias est factored into in flight mag cal

### DIFF
--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -280,9 +280,8 @@ void VehicleMagnetometer::UpdateMagCalibration()
 
 							_mag_cal[i].device_id = estimator_sensor_bias.mag_device_id;
 
-							// readd estimated bias that was removed before publishing vehicle_magnetometer
-							_mag_cal[i].offset = _calibration[mag_index].BiasCorrectedSensorOffset(bias) +
-									     _calibration_estimator_bias[mag_index];
+							// readd estimated bias that was removed before publishing vehicle_magnetometer (_calibration_estimator_bias)
+							_mag_cal[i].offset = _calibration[mag_index].BiasCorrectedSensorOffset(bias + _calibration_estimator_bias[mag_index]);
 
 							_mag_cal[i].variance = bias_variance;
 


### PR DESCRIPTION
The preflight mag bias estimate is in the vehicle body frame and removed from the raw mag data after it's rotated, calibrated, etc.

The in flight mag bias (from ekf2) is in the vehicle body frame, but stored as a sensor frame offset immediately.