### PR TITLE
tune_control: Set the effective range of frequency from 0 to 22000

### DIFF
--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -82,7 +82,7 @@ extern "C" __EXPORT int tune_control_main(int argc, char *argv[])
 		case 'f':
 			value = (uint16_t)(strtol(myoptarg, nullptr, 0));
 
-			if (value > 0 && value < 22000) {
+			if (value <= 22000) {
 				tune_control.frequency = value;
 
 			} else {


### PR DESCRIPTION
## Describe problem solved by this pull request

The frequency specification will be 0 to 22000.

## Describe your solution

Set the decision condition to 22000 or lower.

## Describe possible alternatives

None

## Test data / coverage

Set frequencies to 0, 22000, 22001 and verified that USAGE is not displayed.

![Screenshot from 2022-11-05 08-30-45](https://user-images.githubusercontent.com/646194/200089676-3ae0656b-2369-44ca-ab55-73ecd7ac4a9e.png)

## Additional context

None