### PR TITLE
SPI: use official HW_VER_REV function

### DIFF
--- a/platforms/common/spi.cpp
+++ b/platforms/common/spi.cpp
@@ -47,7 +47,7 @@ void px4_set_spi_buses_from_hw_version()
 #if defined(BOARD_HAS_SIMPLE_HW_VERSIONING)
 	int hw_version_revision = board_get_hw_version();
 #else
-	int hw_version_revision = (board_get_hw_version() << 16) | board_get_hw_revision();
+	int hw_version_revision = HW_VER_REV(board_get_hw_version(), board_get_hw_revision());
 #endif
 
 


### PR DESCRIPTION
This was temporarily broken as the HW_VER_REV changed from 8  to 16 bit. To avoid such issues if the function is ever changed again, we should use the actual function here instead of hardcoding it.