### PR TITLE
fix offboard disarm failsafe

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
@@ -119,7 +119,7 @@ void RcAndDataLinkChecks::checkAndReport(const Context &context, Report &reporte
 					    events::ID("check_rc_dl_no_dllink"),
 					    log_level, "No connection to the ground control station");
 
-		if (reporter.mavlink_log_pub()) {
+		if (gcs_connection_required && reporter.mavlink_log_pub()) {
 			mavlink_log_warning(reporter.mavlink_log_pub(), "Preflight Fail: No connection to the ground control station\t");
 		}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
@@ -119,7 +119,7 @@ void RcAndDataLinkChecks::checkAndReport(const Context &context, Report &reporte
 					    events::ID("check_rc_dl_no_dllink"),
 					    log_level, "No connection to the ground control station");
 
-		if (gcs_connection_required && reporter.mavlink_log_pub()) {
+		if (reporter.mavlink_log_pub()) {
 			mavlink_log_warning(reporter.mavlink_log_pub(), "Preflight Fail: No connection to the ground control station\t");
 		}
 

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -467,7 +467,9 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 	// offboard signal
 	if (status_flags.offboard_control_signal_lost && (status_flags.mode_req_offboard_signal & (1u << user_intended_mode))) {
 		action = fromOffboardLossActParam(_param_com_obl_rc_act.get(), user_intended_mode);
-		return action;
+
+		// for this specific case, user_intended_mode is not modified, we shouldn't check additional fallbacks
+		if (action == Action::Disarm) { return action; }
 	}
 
 	// posctrl

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -467,6 +467,7 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 	// offboard signal
 	if (status_flags.offboard_control_signal_lost && (status_flags.mode_req_offboard_signal & (1u << user_intended_mode))) {
 		action = fromOffboardLossActParam(_param_com_obl_rc_act.get(), user_intended_mode);
+		return action;
 	}
 
 	// posctrl

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -469,7 +469,9 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 		action = fromOffboardLossActParam(_param_com_obl_rc_act.get(), user_intended_mode);
 
 		// for this specific case, user_intended_mode is not modified, we shouldn't check additional fallbacks
-		if (action == Action::Disarm) { return action; }
+		if (action == Action::Disarm) {
+		     return action;
+		}
 	}
 
 	// posctrl


### PR DESCRIPTION
## Problem solved by this pull request
In checkModeFallback, if the failsafe mode selected for offboard is Action::Disarm, it will be overridden. The user_intented_mode is not set in this case so it will trigger the last modeCanRun check and so switch to Action::RTL, which is not the user-desired behavior.

## Solution
Stopping the check when the offboard fallback is decided. Other fallbacks would be decided in subsequent loops (if needed)

## Alternative solution
Set an user_intended_mode (which one??) in fromOffboardLossActParam like the other situations.

## Minor issue also solved
Avoid printing of "Preflight Fail: No connection to the ground control station" is not set as required