### PR TITLE
Add support for quadtailsitter in SITL Gazebo

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -17,6 +17,7 @@ param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
 
+param set-default VT_B_TRANS_DUR 5
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -50,35 +50,32 @@ param set-default SENS_IMU_MODE 1
 param set-default EKF2_MULTI_MAG 0
 param set-default SENS_MAG_MODE 1
 
-param set-default NPFG_PERIOD 12
-param set-default FW_PR_I 0.2
-param set-default FW_PR_P 0.2
+param set-default FW_P_TC 0.6
+
+param set-default FW_PR_FF 0.1
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MIN -15
-param set-default FW_RR_P 0.2
-param set-default FW_THR_TRIM 0.33
-param set-default FW_THR_MAX 0.6
+param set-default FW_RR_FF 0.1
+param set-default FW_RR_I 0.2
+param set-default FW_RR_P 0.3
+param set-default FW_THR_TRIM 0.35
+param set-default FW_THR_MAX 0.8
 param set-default FW_THR_MIN 0.05
-param set-default FW_T_ALT_TC 2
-param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_SINK_MAX 2.7
-param set-default FW_T_SINK_MIN 2.2
-param set-default FW_T_TAS_TC 2
+param set-default FW_T_CLMB_MAX 6
+param set-default FW_T_HRATE_FF 0.5
+param set-default FW_T_SINK_MAX 3
+param set-default FW_T_SINK_MIN 1.6
 
 param set-default MC_AIRMODE 1
+param set-default MC_ROLL_P 3
+param set-default MC_PITCH_P 3
 param set-default MC_ROLLRATE_P 0.3
+param set-default MC_PITCHRATE_P 0.3
 
-param set-default MPC_XY_P 0.8
-param set-default MPC_XY_VEL_P_ACC 3
-param set-default MPC_XY_VEL_I_ACC 4
-param set-default MPC_XY_VEL_D_ACC 0.1
-
-param set-default NAV_ACC_RAD 5
-
+param set-default VT_ARSP_TRANS 10
+param set-default VT_B_TRANS_DUR 5
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_S_Y 0.5
+param set-default VT_FW_DIFTHR_S_Y 1
 param set-default VT_F_TRANS_DUR 1.5
-param set-default VT_F_TRANS_THR 0.7
 param set-default VT_TYPE 0
 
 param set-default WV_EN 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -65,6 +65,7 @@ param set-default MC_ROLLRATE_P 0.3
 param set-default MC_PITCHRATE_P 0.3
 
 param set-default VT_ARSP_TRANS 15
+param set-default VT_B_TRANS_DUR 5
 param set-default VT_FW_DIFTHR_EN 7
 param set-default VT_FW_DIFTHR_S_Y 1
 param set-default VT_F_TRANS_DUR 1.5

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -34,10 +34,10 @@ param set-default PWM_MAIN_FUNC4 104
 param set-default PWM_MAIN_FUNC5 0
 
 param set-default FW_PR_I 0.2
-param set-default FW_PR_P 0.2
+param set-default FW_PR_P 0.4
 param set-default FW_PSP_OFF 2
-param set-default FW_P_LIM_MIN -15
-param set-default FW_RR_P 0.2
+param set-default FW_RR_P 0.4
+param set-default FW_YR_P 0.2
 param set-default FW_THR_TRIM 0.33
 param set-default FW_THR_MAX 0.6
 param set-default FW_THR_MIN 0.05
@@ -47,10 +47,20 @@ param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 param set-default FW_T_TAS_TC 2
+param set-default FW_R_TC 0.1
+param set-default FW_P_TC 0.1
+param set-default FW_R_LIM 60.0
+param set-default FW_AIRSPD_STALL 10
+param set-default FW_AIRSPD_MIN 14
+param set-default FW_AIRSPD_TRIM 18
+param set-default FW_AIRSPD_MAX 22
 
-param set-default MC_AIRMODE 1
-param set-default MC_PITCH_P 5
+param set-default MC_AIRMODE 2
+param set-default MAN_ARM_GESTURE 0 # required for yaw airmode
+param set-default MC_ROLL_P 3
+param set-default MC_PITCH_P 3
 param set-default MC_ROLLRATE_P 0.3
+param set-default MC_PITCHRATE_P 0.3
 
 param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_XY_P 0.8
@@ -58,7 +68,8 @@ param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_D_ACC 0.1
 
-param set-default NAV_ACC_RAD 5
+param set-default NPFG_PERIOD 10
+param set-default NAV_ACC_RAD 10
 
 param set-default VT_FW_DIFTHR_EN 7
 param set-default VT_FW_DIFTHR_S_R 0.5

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -33,23 +33,25 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 param set-default PWM_MAIN_FUNC5 0
 
-param set-default FW_PR_I 0.2
-param set-default FW_PR_P 0.4
+parm set-default FD_FAIL_R 70
+
+param set-default FW_P_TC 0.6
+
+param set-default FW_PR_I 0.3
+param set-default FW_PR_P 0.5
 param set-default FW_PSP_OFF 2
-param set-default FW_RR_P 0.4
-param set-default FW_YR_P 0.2
-param set-default FW_THR_TRIM 0.33
-param set-default FW_THR_MAX 0.6
+param set-default FW_RR_FF 0.1
+param set-default FW_RR_I 0.1
+param set-default FW_RR_P 0.2
+param set-default FW_YR_FF 0 # make yaw rate controller very weak, only keep default P
+param set-default FW_YR_I 0
+param set-default FW_THR_TRIM 0.35
+param set-default FW_THR_MAX 0.8
 param set-default FW_THR_MIN 0.05
-param set-default FW_T_ALT_TC 2
-param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_CLMB_MAX 6
 param set-default FW_T_HRATE_FF 0.5
-param set-default FW_T_SINK_MAX 2.7
-param set-default FW_T_SINK_MIN 2.2
-param set-default FW_T_TAS_TC 2
-param set-default FW_R_TC 0.1
-param set-default FW_P_TC 0.1
-param set-default FW_R_LIM 60.0
+param set-default FW_T_SINK_MAX 3
+param set-default FW_T_SINK_MIN 1.6
 param set-default FW_AIRSPD_STALL 10
 param set-default FW_AIRSPD_MIN 14
 param set-default FW_AIRSPD_TRIM 18
@@ -62,21 +64,10 @@ param set-default MC_PITCH_P 3
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_PITCHRATE_P 0.3
 
-param set-default MPC_ACC_HOR_MAX 2
-param set-default MPC_XY_P 0.8
-param set-default MPC_XY_VEL_P_ACC 3
-param set-default MPC_XY_VEL_I_ACC 4
-param set-default MPC_XY_VEL_D_ACC 0.1
-
-param set-default NPFG_PERIOD 10
-param set-default NAV_ACC_RAD 10
-
+param set-default VT_ARSP_TRANS 15
 param set-default VT_FW_DIFTHR_EN 7
-param set-default VT_FW_DIFTHR_S_R 0.5
-param set-default VT_FW_DIFTHR_S_P 0.5
-param set-default VT_FW_DIFTHR_S_Y 0.5
+param set-default VT_FW_DIFTHR_S_Y 1
 param set-default VT_F_TRANS_DUR 1.5
-param set-default VT_F_TRANS_THR 0.7
 param set-default VT_TYPE 0
 
 param set-default WV_EN 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -1,0 +1,71 @@
+#!/bin/sh
+#
+# @name Quadrotor + Tailsitter
+#
+# @type VTOL Quad Tailsitter
+#
+
+. ${R}etc/init.d/rc.vtol_defaults
+
+param set-default MAV_TYPE 20
+
+param set-default CA_AIRFRAME 4
+
+param set-default CA_ROTOR_COUNT 4
+param set-default CA_ROTOR0_PX 0.15
+param set-default CA_ROTOR0_PY 0.23
+param set-default CA_ROTOR0_KM 0.05
+param set-default CA_ROTOR1_PX -0.15
+param set-default CA_ROTOR1_PY -0.23
+param set-default CA_ROTOR1_KM 0.05
+param set-default CA_ROTOR2_PX 0.15
+param set-default CA_ROTOR2_PY -0.23
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -0.15
+param set-default CA_ROTOR3_PY 0.23
+param set-default CA_ROTOR3_KM -0.05
+
+param set-default CA_SV_CS_COUNT 0
+
+param set-default PWM_MAIN_FUNC1 101
+param set-default PWM_MAIN_FUNC2 102
+param set-default PWM_MAIN_FUNC3 103
+param set-default PWM_MAIN_FUNC4 104
+param set-default PWM_MAIN_FUNC5 0
+
+param set-default FW_PR_I 0.2
+param set-default FW_PR_P 0.2
+param set-default FW_PSP_OFF 2
+param set-default FW_P_LIM_MIN -15
+param set-default FW_RR_P 0.2
+param set-default FW_THR_TRIM 0.33
+param set-default FW_THR_MAX 0.6
+param set-default FW_THR_MIN 0.05
+param set-default FW_T_ALT_TC 2
+param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_HRATE_FF 0.5
+param set-default FW_T_SINK_MAX 2.7
+param set-default FW_T_SINK_MIN 2.2
+param set-default FW_T_TAS_TC 2
+
+param set-default MC_AIRMODE 1
+param set-default MC_PITCH_P 5
+param set-default MC_ROLLRATE_P 0.3
+
+param set-default MPC_ACC_HOR_MAX 2
+param set-default MPC_XY_P 0.8
+param set-default MPC_XY_VEL_P_ACC 3
+param set-default MPC_XY_VEL_I_ACC 4
+param set-default MPC_XY_VEL_D_ACC 0.1
+
+param set-default NAV_ACC_RAD 5
+
+param set-default VT_FW_DIFTHR_EN 7
+param set-default VT_FW_DIFTHR_S_R 0.5
+param set-default VT_FW_DIFTHR_S_P 0.5
+param set-default VT_FW_DIFTHR_S_Y 0.5
+param set-default VT_F_TRANS_DUR 1.5
+param set-default VT_F_TRANS_THR 0.7
+param set-default VT_TYPE 0
+
+param set-default WV_EN 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -60,6 +60,7 @@ px4_add_romfs_files(
 	1042_gazebo-classic_tiltrotor
 	1043_gazebo-classic_standard_vtol_drop
 	1044_gazebo-classic_plane_lidar
+	1045_gazebo-classic_quadtailsitter
 	1060_gazebo-classic_rover
 	1061_gazebo-classic_r1_rover
 	1062_flightgear_tf-r1

--- a/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
@@ -20,6 +20,7 @@
 param set-default EKF2_FUSE_BETA 0 # side slip fusion is currently not supported for tailsitters
 
 param set UAVCAN_ENABLE 0
+param set-default VT_B_TRANS_DUR 5
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_MOT_COUNT 2
 param set-default VT_TYPE 0

--- a/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13200_generic_vtol_tailsitter
@@ -31,3 +31,4 @@ param set-default CA_SV_CS1_TYPE 6
 param set-default MAV_TYPE 19
 param set-default VT_TYPE 0
 param set-default VT_ELEV_MC_LOCK 0
+param set-default VT_B_TRANS_DUR 5

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
@@ -91,6 +91,7 @@ if(gazebo_FOUND)
 		plane_catapult
 		plane_lidar
 		px4vision
+		quadtailsitter
 		r1_rover
 		rover
 		standard_vtol


### PR DESCRIPTION
## Describe problem solved by this pull request
The current tailsitter model has control surfaces, and a control surface-less tailsitter was not available for testing in simulation

## Describe your solution
This PR adds support for a quadtailsitter, which models the HEQ SWAN K1.

The 3D mesh was provided by Holybro

## Test data / coverage
Tested in SITL Gazebo
```
make px4_sitl gazebo_quadtailsitter
```

## Additional context
- Depends on https://github.com/PX4/PX4-Autopilot/pull/20511