### PR TITLE
ekf2: mag field disturbed only care about NE for heading

### DIFF
--- a/msg/EstimatorStatusFlags.msg
+++ b/msg/EstimatorStatusFlags.msg
@@ -38,6 +38,7 @@ bool cs_wind_dead_reckoning     # 30 - true if we are navigationg reliant on win
 bool cs_rng_kin_consistent      # 31 - true when the range finder kinematic consistency check is passing
 bool cs_fake_pos                # 32 - true when fake position measurements are being fused
 bool cs_fake_hgt                # 33 - true when fake height measurements are being fused
+bool cs_mag_field_ne_disturbed  # 34 - true when the NE mag field does not match the expected strength
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -535,6 +535,7 @@ union filter_control_status_u {
 		uint64_t rng_kin_consistent      : 1; ///< 31 - true when the range finder kinematic consistency check is passing
 		uint64_t fake_pos                : 1; ///< 32 - true when fake position measurements are being fused
 		uint64_t fake_hgt                : 1; ///< 33 - true when fake height measurements are being fused
+		uint64_t mag_field_ne_disturbed  : 1; ///< 34 - true when the NE mag field does not match the expected strength
 	} flags;
 	uint64_t value;
 };

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1370,7 +1370,7 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 	status.pre_flt_fail_innov_vel_horiz = _preflt_checker.hasHorizVelFailed();
 	status.pre_flt_fail_innov_vel_vert = _preflt_checker.hasVertVelFailed();
 	status.pre_flt_fail_innov_height = _preflt_checker.hasHeightFailed();
-	status.pre_flt_fail_mag_field_disturbed = _ekf.control_status_flags().mag_field_disturbed;
+	status.pre_flt_fail_mag_field_disturbed = _ekf.control_status_flags().mag_field_ne_disturbed;
 
 	status.accel_device_id = _device_id_accel;
 	status.baro_device_id = _device_id_baro;
@@ -1446,6 +1446,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_rng_kin_consistent      = _ekf.control_status_flags().rng_kin_consistent;
 		status_flags.cs_fake_pos                = _ekf.control_status_flags().fake_pos;
 		status_flags.cs_fake_hgt                = _ekf.control_status_flags().fake_hgt;
+		status_flags.cs_mag_field_ne_disturbed  = _ekf.control_status_flags().mag_field_ne_disturbed;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;


### PR DESCRIPTION
 - mag_field_disturbed look at full mag field strength (after mag bias applied)
 - mag_field_ne_disturbed (NEW) only consider north east component of mag field (what's actually used for mag heading)


Need to review specific thresholds from logs and real world testing.