### PR TITLE
commander: hold after mission clear

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1862,14 +1862,14 @@ void Commander::checkForMissionUpdate()
 			}
 		}
 
-		// Transition mode to loiter or auto-mission after takeoff is completed.
+		// handle navigation state auto-switching based on mission_result
 		if (_arm_state_machine.isArmed() && !_vehicle_land_detected.landed
-		    && (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF ||
-			_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
 		    && (mission_result.timestamp >= _vehicle_status.nav_state_timestamp)
 		    && mission_result.finished) {
 
-			if ((_param_takeoff_finished_action.get() == 1) && auto_mission_available) {
+			if ((_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
+			     || _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
+			    && (_param_takeoff_finished_action.get() == 1) && auto_mission_available) {
 				_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
 
 			} else {


### PR DESCRIPTION
## Describe problem solved by this pull request
Sets the vehicle to hold after a mission is finished (or cleared). -- before would stay in mission.

## Describe possible alternatives
leave it in mission.. with no mission item, however, this is somewhat uncommanded behavior.

## Test data / coverage

https://user-images.githubusercontent.com/8026163/200412752-d9db89ff-4781-4f92-abe9-e5b2565eb861.mp4


