### PR TITLE
fix warning (mavlink): connection to gcs

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp
@@ -119,7 +119,7 @@ void RcAndDataLinkChecks::checkAndReport(const Context &context, Report &reporte
 					    events::ID("check_rc_dl_no_dllink"),
 					    log_level, "No connection to the ground control station");
 
-		if (reporter.mavlink_log_pub()) {
+		if (gcs_connection_required && reporter.mavlink_log_pub()) {
 			mavlink_log_warning(reporter.mavlink_log_pub(), "Preflight Fail: No connection to the ground control station\t");
 		}
 


### PR DESCRIPTION
A small fix to avoid GCS connexion errors sent through Mavlink log publisher when it is not required.
