### PR TITLE
Avoidance interface: timeout and initialisation fixes

### DIFF
--- a/src/lib/avoidance/ObstacleAvoidance.hpp
+++ b/src/lib/avoidance/ObstacleAvoidance.hpp
@@ -130,6 +130,8 @@ protected:
 	matrix::Vector3f _position = {}; /**< current vehicle position */
 	matrix::Vector3f _failsafe_position = {}; /**< vehicle position when entered in failsafe */
 
+	bool _avoidance_activated{false}; /**< true after the first avoidance setpoint is received */
+
 	systemlib::Hysteresis _avoidance_point_not_valid_hysteresis{false}; /**< becomes true if the companion doesn't start sending valid setpoints */
 	systemlib::Hysteresis _no_progress_z_hysteresis{false}; /**< becomes true if the vehicle is not making progress towards the z component of the goal */
 


### PR DESCRIPTION
## Problem solved by this pull request

1. If the obstacle avoidance input _from the mission computer_ switches from waypoints to bezier points, `if (avoidance_point_valid)` stays true and the interface _in PX4_ never switches to bezier points.
2. The OA interface is set to fail if it does not receive a waypoint message for more than 500ms. This means it fails _as soon as the flight mode changes_ from a manual mode to an auto mode. In this case it would arm, but then switch to Loiter and out of the desired auto mode (e.g. Mission or Take-off).

## Solution

1. The interface switches to handling bezier points of the waypoint stream times out.
2. The interface can only fail if there's a timeout _and_ it has already received at least one waypoint message. It will be in a 'waiting' state until the first message is received.

## Test data / coverage

Tested in simulation and many flights.
