### PR TITLE
Allow for emergency yaw reset before stopping navigation

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -66,10 +66,11 @@ using math::Utilities::sq;
 using math::Utilities::updateYawInRotMat;
 
 // maximum sensor intervals in usec
-#define BARO_MAX_INTERVAL (uint64_t)2e5 ///< Maximum allowable time interval between pressure altitude measurements (uSec)
-#define EV_MAX_INTERVAL   (uint64_t)2e5 ///< Maximum allowable time interval between external vision system measurements (uSec)
-#define GPS_MAX_INTERVAL  (uint64_t)5e5 ///< Maximum allowable time interval between GPS measurements (uSec)
-#define RNG_MAX_INTERVAL  (uint64_t)2e5 ///< Maximum allowable time interval between range finder  measurements (uSec)
+#define BARO_MAX_INTERVAL     (uint64_t)2e5  ///< Maximum allowable time interval between pressure altitude measurements (uSec)
+#define EV_MAX_INTERVAL       (uint64_t)2e5  ///< Maximum allowable time interval between external vision system measurements (uSec)
+#define GNSS_MAX_INTERVAL     (uint64_t)5e5  ///< Maximum allowable time interval between GNSS measurements (uSec)
+#define GNSS_YAW_MAX_INTERVAL (uint64_t)15e5 ///< Maximum allowable time interval between GNSS yaw measurements (uSec)
+#define RNG_MAX_INTERVAL      (uint64_t)2e5  ///< Maximum allowable time interval between range finder  measurements (uSec)
 
 // bad accelerometer detection and mitigation
 #define BADACC_PROBATION  (uint64_t)10e6        ///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -395,11 +395,11 @@ struct parameters {
 	float acc_bias_learn_gyr_lim{3.0f};     ///< learning is disabled if the magnitude of the IMU angular rate vector is greater than this (rad/sec)
 	float acc_bias_learn_tc{0.5f};          ///< time constant used to control the decaying envelope filters applied to the accel and gyro magnitudes (sec)
 
-	const unsigned reset_timeout_max{7000000};      ///< maximum time we allow horizontal inertial dead reckoning before attempting to reset the states to the measurement or change _control_status if the data is unavailable (uSec)
-	const unsigned no_aid_timeout_max{1000000};     ///< maximum lapsed time from last fusion of a measurement that constrains horizontal velocity drift before the EKF will determine that the sensor is no longer contributing to aiding (uSec)
+	const unsigned reset_timeout_max{7'000'000};      ///< maximum time we allow horizontal inertial dead reckoning before attempting to reset the states to the measurement or change _control_status if the data is unavailable (uSec)
+	const unsigned no_aid_timeout_max{1'000'000};     ///< maximum lapsed time from last fusion of a measurement that constrains horizontal velocity drift before the EKF will determine that the sensor is no longer contributing to aiding (uSec)
 	const unsigned hgt_fusion_timeout_max{5'000'000}; ///< maximum time we allow height fusion to fail before attempting a reset or stopping the fusion aiding (uSec)
 
-	int32_t valid_timeout_max{5000000};     ///< amount of time spent inertial dead reckoning before the estimator reports the state estimates as invalid (uSec)
+	int32_t valid_timeout_max{5'000'000};     ///< amount of time spent inertial dead reckoning before the estimator reports the state estimates as invalid (uSec)
 
 	// static barometer pressure position error coefficient along body axes
 	float static_pressure_coef_xp{0.0f};    // (-)
@@ -434,7 +434,6 @@ struct parameters {
 	float EKFGSF_tas_default{15.0f};                ///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)
 	const unsigned EKFGSF_reset_delay{1000000};     ///< Number of uSec of bad innovations on main filter in immediate post-takeoff phase before yaw is reset to EKF-GSF value
 	const float EKFGSF_yaw_err_max{0.262f};         ///< Composite yaw 1-sigma uncertainty threshold used to check for convergence (rad)
-	const unsigned EKFGSF_reset_count_limit{3};     ///< Maximum number of times the yaw can be reset to the EKF-GSF yaw estimator value
 };
 
 union fault_status_u {

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -66,18 +66,18 @@ using math::Utilities::sq;
 using math::Utilities::updateYawInRotMat;
 
 // maximum sensor intervals in usec
-#define BARO_MAX_INTERVAL     (uint64_t)2e5  ///< Maximum allowable time interval between pressure altitude measurements (uSec)
-#define EV_MAX_INTERVAL       (uint64_t)2e5  ///< Maximum allowable time interval between external vision system measurements (uSec)
-#define GNSS_MAX_INTERVAL     (uint64_t)5e5  ///< Maximum allowable time interval between GNSS measurements (uSec)
-#define GNSS_YAW_MAX_INTERVAL (uint64_t)15e5 ///< Maximum allowable time interval between GNSS yaw measurements (uSec)
-#define RNG_MAX_INTERVAL      (uint64_t)2e5  ///< Maximum allowable time interval between range finder  measurements (uSec)
+static constexpr uint64_t BARO_MAX_INTERVAL     = 200e3;  ///< Maximum allowable time interval between pressure altitude measurements (uSec)
+static constexpr uint64_t EV_MAX_INTERVAL       = 200e3;  ///< Maximum allowable time interval between external vision system measurements (uSec)
+static constexpr uint64_t GNSS_MAX_INTERVAL     = 500e3;  ///< Maximum allowable time interval between GNSS measurements (uSec)
+static constexpr uint64_t GNSS_YAW_MAX_INTERVAL = 1500e3; ///< Maximum allowable time interval between GNSS yaw measurements (uSec)
+static constexpr uint64_t RNG_MAX_INTERVAL      = 200e3;  ///< Maximum allowable time interval between range finder  measurements (uSec)
 
 // bad accelerometer detection and mitigation
-#define BADACC_PROBATION  (uint64_t)10e6        ///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)
-#define BADACC_BIAS_PNOISE      4.9f    ///< The delta velocity process noise is set to this when accel data is declared bad (m/sec**2)
+static constexpr uint64_t BADACC_PROBATION = 10e6; ///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)
+static constexpr float BADACC_BIAS_PNOISE = 4.9f;  ///< The delta velocity process noise is set to this when accel data is declared bad (m/sec**2)
 
 // ground effect compensation
-#define GNDEFFECT_TIMEOUT       10E6    ///< Maximum period of time that ground effect protection will be active after it was last turned on (uSec)
+static constexpr uint64_t GNDEFFECT_TIMEOUT = 10e6; ///< Maximum period of time that ground effect protection will be active after it was last turned on (uSec)
 
 enum class VelocityFrame : uint8_t {
 	LOCAL_FRAME_FRD = 0,

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -638,10 +638,3 @@ void Ekf::controlAuxVelFusion()
 		}
 	}
 }
-
-bool Ekf::hasHorizontalAidingTimedOut() const
-{
-	return isTimedOut(_time_last_hor_pos_fuse, _params.reset_timeout_max)
-	       && isTimedOut(_time_last_hor_vel_fuse, _params.reset_timeout_max)
-	       && isTimedOut(_aid_src_optical_flow.time_last_fuse, _params.reset_timeout_max);
-}

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -86,7 +86,7 @@ void Ekf::controlFusionModes()
 	}
 
 	if (_gps_buffer) {
-		_gps_intermittent = !isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GPS_MAX_INTERVAL);
+		_gps_intermittent = !isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL);
 
 		// check for arrival of new sensor data at the fusion time horizon
 		_time_prev_gps_us = _gps_sample_delayed.time_us;
@@ -444,7 +444,7 @@ void Ekf::controlGpsYawFusion(const gpsSample &gps_sample, bool gps_checks_passi
 
 		const bool continuing_conditions_passing = !gps_checks_failing;
 
-		const bool is_gps_yaw_data_intermittent = !isNewestSampleRecent(_time_last_gps_yaw_buffer_push, 2 * GPS_MAX_INTERVAL);
+		const bool is_gps_yaw_data_intermittent = !isNewestSampleRecent(_time_last_gps_yaw_buffer_push, 2 * GNSS_YAW_MAX_INTERVAL);
 
 		const bool starting_conditions_passing = continuing_conditions_passing
 				&& _control_status.flags.tilt_align

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -881,7 +881,6 @@ private:
 	// control fusion of GPS observations
 	void controlGpsFusion();
 	bool shouldResetGpsFusion() const;
-	bool hasHorizontalAidingTimedOut() const;
 	bool isYawFailure() const;
 
 	void controlGpsYawFusion(const gpsSample &gps_sample, bool gps_checks_passing, bool gps_checks_failing);
@@ -1066,9 +1065,6 @@ private:
 	HeightBiasEstimator _gps_hgt_b_est{HeightSensor::GNSS, _height_sensor_ref};
 	HeightBiasEstimator _rng_hgt_b_est{HeightSensor::RANGE, _height_sensor_ref};
 	HeightBiasEstimator _ev_hgt_b_est{HeightSensor::EV, _height_sensor_ref};
-
-	int64_t _ekfgsf_yaw_reset_time{0};	///< timestamp of last emergency yaw reset (uSec)
-	uint8_t _ekfgsf_yaw_reset_count{0};	// number of times the yaw has been reset to the EKF-GSF estimate
 
 	void runYawEKFGSF();
 

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1508,9 +1508,6 @@ bool Ekf::resetYawToEKFGSF()
 		_inhibit_ev_yaw_use = true;
 	}
 
-	_ekfgsf_yaw_reset_time = _imu_sample_delayed.time_us;
-	_ekfgsf_yaw_reset_count++;
-
 	return true;
 }
 

--- a/src/modules/ekf2/EKF/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/gnss_height_control.cpp
@@ -92,7 +92,7 @@ void Ekf::controlGnssHeightFusion(const gpsSample &gps_sample)
 				&& _gps_checks_passed;
 
 		const bool starting_conditions_passing = continuing_conditions_passing
-				&& isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GPS_MAX_INTERVAL)
+				&& isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL)
 				&& _gps_checks_passed
 				&& gps_checks_passing
 				&& !gps_checks_failing;
@@ -158,7 +158,7 @@ void Ekf::controlGnssHeightFusion(const gpsSample &gps_sample)
 		}
 
 	} else if (_control_status.flags.gps_hgt
-		   && !isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GPS_MAX_INTERVAL)) {
+		   && !isNewestSampleRecent(_time_last_gps_buffer_push, 2 * GNSS_MAX_INTERVAL)) {
 		// No data anymore. Stop until it comes back.
 		ECL_WARN("stopping %s height fusion, no data", HGT_SRC_NAME);
 		stopGpsHgtFusion();

--- a/src/modules/ekf2/EKF/mag_control.cpp
+++ b/src/modules/ekf2/EKF/mag_control.cpp
@@ -209,7 +209,6 @@ void Ekf::runInAirYawReset()
 			resetQuatStateYaw(_yawEstimator.getYaw(), _yawEstimator.getYawVar());
 
 			_information_events.flags.yaw_aligned_to_imu_gps = true;
-			_ekfgsf_yaw_reset_time = _imu_sample_delayed.time_us;
 
 			// if world magnetic model (inclination, declination, strength) available then use it to reset mag states
 			if (PX4_ISFINITE(_mag_inclination_gps) && PX4_ISFINITE(_mag_declination_gps) && PX4_ISFINITE(_mag_strength_gps)) {


### PR DESCRIPTION
## Describe problem solved by this pull request
When a GNSS fusion due to a bad yaw (e.g.: sudden reset) occurs later than 30s after takeoff (i.e.: when the quick trigger is inactive), the loss of local position (5s) occurs before even trying a reset (7s).

## Describe your solution
- ~Try a yaw  (if needed) and local position reset just before (at 4.5s) a potential loss of navigation. Consecutive resets are still separated by a 7s interval.~
- Reset to the yaw emergency estimator more aggressively: "is the difference between the yaw from EKF2 and the yaw estimator is >25deg and that the GNSS velocity fusion is failing for more than 1s, then reset". We've seen in the last couple of years that almost all loss of navigation are caused by a bad magnetometer pulling the yaw estimate away and that in all those issues, the yaw estimator was correct and would have saved the vehicle.
- Remove the maximum number of yaw resets to the yaw emergency filter. ~The minimum interval between 2 resets is 7s but~ the filter can reset as much as needed during the whole flight. Since the filter is reset, it naturally takes time to re-diverge and a 2nd reset won't immediately occur.

## Describe possible alternatives
Just before a loss of navigation, the EKF could trigger a "panic" flag to tell all the available aiding sources to trigger a reset NOW as an attempt to recover the filter.

## Test data / coverage
SITL tested

### Current implementation (before this PR):
#### Thresholds:
- `reset_timeout_max` (7s) maximum time we allow horizontal inertial dead reckoning before attempting to reset the states to the measurement or change _control_status if the data is unavailable

- `no_aid_timeout_max` (1s) maximum lapsed time from last fusion of a measurement that constrains horizontal velocity drift before the EKF will determine that the sensor is no longer contributing to aiding

- `valid_timeout_max` (5s) amount of time spent inertial dead reckoning before the estimator reports the state estimates as invalid

- `EKFGSF_reset_delay` (1s)

- `hgt_fusion_timeout_max` (5s) maximum time we allow height fusion to fail before attempting a reset or stopping the fusion aiding


#### Aiding sources:
GPS:
- before takeoff: resets after no vel, flow and pos aiding during `reset_timeout_max` or no pos aiding during 2x`reset_timeout_max`
- if within first 30s after takeoff: reset after no vel aiding during `EKFGSF_reset_delay` (also does a yaw emergency reset if yaw error is > 25deg)
- after 30s of flight: resets after no vel and pos aiding during `reset_timeout_max` or no pos aiding during 2x`reset_timeout_max` (also does a yaw emergency reset if yaw error is > 25deg)

GPS_YAW:
- reset after no aiding during `reset_timeout_max`. 1 reset chance, otherwise stop (if starting conditions are not met) or stop and mark it as faulty

EV, EV_VEL:
- reset after no aiding during `reset_timeout_max`
- reset if vision data resets

EV_YAW:
- reset if vision data resets

Optical flow:
- reset after `no_aid_timeout_max` if no other aiding source, otherwise never reset, never stop

#### Others
- “inertial dead-reckoning” state when no measurements are fused for `no_aid_timeout_max`

- (v)xy local position becomes **invalid** when no measurements are fused for `valid_timeout_max` (`_horizontal_deadreckon_time_exceeded`). Fake position starts after that.
