### PR TITLE
mtd: add support for extended HW revision

### DIFF
--- a/boards/ark/fmu-v6x/src/mtd.cpp
+++ b/boards/ark/fmu-v6x/src/mtd.cpp
@@ -71,8 +71,8 @@ static const px4_mtd_entry_t base_eeprom = {
 	.npart = 2,
 	.partd = {
 		{
-			.type = MTD_MFT,
-			.path = "/fs/mtd_mft",
+			.type = MTD_MFT_VER,
+			.path = "/fs/mtd_mft_ver",
 			.nblocks = 248
 		},
 		{
@@ -86,12 +86,17 @@ static const px4_mtd_entry_t base_eeprom = {
 
 static const px4_mtd_entry_t imu_eeprom = {
 	.device = &i2c4,
-	.npart = 2,
+	.npart = 3,
 	.partd = {
 		{
 			.type = MTD_CALDATA,
 			.path = "/fs/mtd_caldata",
-			.nblocks = 248
+			.nblocks = 240
+		},
+		{
+			.type = MTD_MFT_REV,
+			.path = "/fs/mtd_mft_rev",
+			.nblocks = 8
 		},
 		{
 			.type = MTD_ID,

--- a/boards/px4/fmu-v5x/src/mtd.cpp
+++ b/boards/px4/fmu-v5x/src/mtd.cpp
@@ -71,8 +71,8 @@ static const px4_mtd_entry_t base_eeprom = {
 	.npart = 2,
 	.partd = {
 		{
-			.type = MTD_MFT,
-			.path = "/fs/mtd_mft",
+			.type = MTD_MFT_VER,
+			.path = "/fs/mtd_mft_ver",
 			.nblocks = 248
 		},
 		{
@@ -86,12 +86,17 @@ static const px4_mtd_entry_t base_eeprom = {
 
 static const px4_mtd_entry_t imu_eeprom = {
 	.device = &i2c4,
-	.npart = 2,
+	.npart = 3,
 	.partd = {
 		{
 			.type = MTD_CALDATA,
 			.path = "/fs/mtd_caldata",
-			.nblocks = 248
+			.nblocks = 240
+		},
+		{
+			.type = MTD_MFT_REV,
+			.path = "/fs/mtd_mft_rev",
+			.nblocks = 8
 		},
 		{
 			.type = MTD_ID,

--- a/boards/px4/fmu-v6c/src/mtd.cpp
+++ b/boards/px4/fmu-v6c/src/mtd.cpp
@@ -65,12 +65,17 @@ static const px4_mtd_entry_t fmum_fram = {
 
 static const px4_mtd_entry_t imu_eeprom = {
 	.device = &i2c4,
-	.npart = 2,
+	.npart = 3,
 	.partd = {
 		{
 			.type = MTD_CALDATA,
 			.path = "/fs/mtd_caldata",
-			.nblocks = 248
+			.nblocks = 240
+		},
+		{
+			.type = MTD_MFT_REV,
+			.path = "/fs/mtd_mft_rev",
+			.nblocks = 8
 		},
 		{
 			.type = MTD_ID,

--- a/boards/px4/fmu-v6x/src/mtd.cpp
+++ b/boards/px4/fmu-v6x/src/mtd.cpp
@@ -71,8 +71,8 @@ static const px4_mtd_entry_t base_eeprom = {
 	.npart = 2,
 	.partd = {
 		{
-			.type = MTD_MFT,
-			.path = "/fs/mtd_mft",
+			.type = MTD_MFT_VER,
+			.path = "/fs/mtd_mft_ver",
 			.nblocks = 248
 		},
 		{
@@ -86,12 +86,17 @@ static const px4_mtd_entry_t base_eeprom = {
 
 static const px4_mtd_entry_t imu_eeprom = {
 	.device = &i2c4,
-	.npart = 2,
+	.npart = 3,
 	.partd = {
 		{
 			.type = MTD_CALDATA,
 			.path = "/fs/mtd_caldata",
-			.nblocks = 248
+			.nblocks = 240
+		},
+		{
+			.type = MTD_MFT_REV,
+			.path = "/fs/mtd_mft_rev",
+			.nblocks = 8
 		},
 		{
 			.type = MTD_ID,

--- a/boards/sky-drones/smartap-airlink/src/mtd.cpp
+++ b/boards/sky-drones/smartap-airlink/src/mtd.cpp
@@ -66,8 +66,8 @@ static const px4_mtd_entry_t base_eeprom = {
 	.npart = 2,
 	.partd = {
 		{
-			.type = MTD_MFT,
-			.path = "/fs/mtd_mft",
+			.type = MTD_MFT_VER,
+			.path = "/fs/mtd_mft_ver",
 			.nblocks = 248
 		},
 		{

--- a/platforms/common/include/px4_platform_common/mtd_manifest.h
+++ b/platforms/common/include/px4_platform_common/mtd_manifest.h
@@ -37,12 +37,13 @@ typedef enum  {
 	MTD_PARAMETERS  = 1,
 	MTD_WAYPOINTS   = 2,
 	MTD_CALDATA     = 3,
-	MTD_MFT         = 4,
-	MTD_ID          = 5,
-	MTD_NET         = 6,
+	MTD_MFT_VER     = 4,
+	MTD_MFT_REV     = 5,
+	MTD_ID          = 6,
+	MTD_NET         = 7
 } px4_mtd_types_t;
-#define PX4_MFT_MTD_TYPES  {MTD_PARAMETERS, MTD_WAYPOINTS, MTD_CALDATA, MTD_MFT, MTD_ID, MTD_NET}
-#define PX4_MFT_MTD_STR_TYPES  {"MTD_PARAMETERS", "MTD_WAYPOINTS", "MTD_CALDATA", "MTD_MFT", "MTD_ID", "MTD_NET"}
+#define PX4_MFT_MTD_TYPES  {MTD_PARAMETERS, MTD_WAYPOINTS, MTD_CALDATA, MTD_MFT_VER, MTD_MFT_REV, MTD_ID, MTD_NET}
+#define PX4_MFT_MTD_STR_TYPES  {"MTD_PARAMETERS", "MTD_WAYPOINTS", "MTD_CALDATA", "MTD_MFT_VER", "MTD_MFT_REV", "MTD_ID", "MTD_NET"}
 
 typedef struct  {
 	const px4_mtd_types_t   type;

--- a/platforms/nuttx/src/px4/common/include/px4_platform/board_hw_eeprom_rev_ver.h
+++ b/platforms/nuttx/src/px4/common/include/px4_platform/board_hw_eeprom_rev_ver.h
@@ -32,8 +32,10 @@
  ****************************************************************************/
 #pragma once
 
-#define HW_VERSION_EEPROM 		0x7		//!< Get hw_info from EEPROM
-#define HW_EEPROM_VERSION_MIN	0x10	//!< Minimum supported version
+#include <errno.h>
+
+#define HW_ID_EEPROM 			0x7		//!< Get hw_info from EEPROM
+#define HW_EEPROM_ID_MIN		0x10	//!< Minimum supported id (version/revision)
 
 #pragma pack(push, 1)
 
@@ -43,13 +45,13 @@ typedef struct {
 
 typedef struct {
 	mtd_mft_t version;
-	uint16_t hw_extended_ver;
+	uint16_t hw_extended_id; //<! HW version for MTD_MFT_VER, HW revision for MTD_MFT_REV
 	uint16_t crc;
 } mtd_mft_v0_t;
 
 typedef struct {
-	mtd_mft_t  version;
-	uint16_t hw_extended_ver;
+	mtd_mft_t version;
+	uint16_t hw_extended_id;
 	//{device tree overlay}
 	uint16_t crc;
 } mtd_mft_v1_t;


### PR DESCRIPTION
## Describe the problem solved by this pull request
This PR adds support that Manifest (MFT) could be read out from FMUM's IMU's EEPROM. Inside MFT is `hw_extended_id` that carries HW Revision. 

Some background:
![image](https://user-images.githubusercontent.com/10188706/200600821-4c7d439a-7069-4195-8fa4-1d64ea0c7747.png)

Credits for architecture and requirements go to @davids5  

## Describe your solution
In this solution, it is added additional partition at `imu_eeprom ` that will serve to store data for MTD_MFT_REV. 

## Tests
It is tested with fmu-v5x and fmu-v6x. 
