### PR TITLE
ekf2: on accel clipping immediately reset to GNSS vel/pos (if data is good)

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -593,6 +593,7 @@ private:
 	float _gps_error_norm{1.0f};		///< normalised gps error
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time
 	bool _gps_checks_passed{false};		///> true when all active GPS checks have passed
+	uint64_t _last_gnss_reset_accel_clipping_us{0}; ///< last time GPS control performed an emergency reset due to accel clipping
 
 	// Variables used to publish the WGS-84 location of the EKF local NED origin
 	float _gps_alt_ref{NAN};		///< WGS-84 height (m)

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -297,6 +297,8 @@ protected:
 	float _dt_ekf_avg{0.010f}; ///< average update rate of the ekf in s
 
 	imuSample _imu_sample_delayed{};	// captures the imu sample on the delayed time horizon
+	bool _imu_accel_clipping_NE{false}; // IMU sample delayed accel clipping in earth NE axis
+	bool _imu_accel_clipping_D{false};  // IMU sample delayed accel clipping in earth D axis
 
 	// measurement samples capturing measurements on the delayed time horizon
 	gpsSample _gps_sample_delayed{};

--- a/src/modules/ekf2/EKF/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/gnss_height_control.cpp
@@ -114,15 +114,6 @@ void Ekf::controlGnssHeightFusion(const gpsSample &gps_sample)
 					resetVerticalPositionTo(-(measurement - bias_est.getBias()), measurement_var);
 					bias_est.setBias(_state.pos(2) + measurement);
 
-					// reset vertical velocity
-					if (PX4_ISFINITE(gps_sample.vel(2)) && (_params.gnss_ctrl & GnssCtrl::VEL)) {
-						// use 1.5 as a typical ratio of vacc/hacc
-						resetVerticalVelocityTo(gps_sample.vel(2), sq(1.5f * gps_sample.sacc));
-
-					} else {
-						resetVerticalVelocityToZero();
-					}
-
 					aid_src.time_last_fuse = _imu_sample_delayed.time_us;
 
 				} else if (is_fusion_failing) {

--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -136,6 +136,39 @@ void Ekf::controlGpsFusion()
 						_information_events.flags.reset_pos_to_gps = true;
 						resetVelocityTo(gps_sample.vel, vel_obs_var);
 						resetHorizontalPositionTo(gps_sample.pos, pos_obs_var);
+
+					} else if ((_imu_accel_clipping_NE || _imu_accel_clipping_D) && gps_checks_passing
+						   && isTimedOut(_last_gnss_reset_accel_clipping_us, (uint64_t)3e6)) {
+						// check for accel clipping and perform an emergency reset if GNSS is good (our last resort)
+						if (_imu_accel_clipping_NE) {
+							// accel clipping on horizontal axis
+
+							// reset velocity (if current sample speed accuracy is good)
+							if (gps_sample.sacc < _params.req_sacc) {
+								_information_events.flags.reset_vel_to_gps = true;
+								resetVelocityTo(gps_sample.vel, vel_obs_var);
+								_aid_src_gnss_vel.time_last_fuse = _imu_sample_delayed.time_us;
+
+								_last_gnss_reset_accel_clipping_us = _imu_sample_delayed.time_us;
+							}
+
+							// reset position (if current sample horizontal accuracy is good)
+							if (gps_sample.hacc < _params.req_hacc) {
+								_information_events.flags.reset_pos_to_gps = true;
+								resetHorizontalPositionTo(gps_sample.pos, pos_obs_var);
+								_aid_src_gnss_pos.time_last_fuse = _imu_sample_delayed.time_us;
+
+								_last_gnss_reset_accel_clipping_us = _imu_sample_delayed.time_us;
+							}
+
+						} else if (_imu_accel_clipping_D || isHeightResetRequired()) {
+							// accel clipping on vertical axis or height failure, reset vertical velocity
+							if (gps_sample.sacc < _params.req_sacc) {
+								resetVerticalVelocityTo(gps_sample.vel(2), vel_obs_var(2));
+
+								_last_gnss_reset_accel_clipping_us = _imu_sample_delayed.time_us;
+							}
+						}
 					}
 
 				} else {


### PR DESCRIPTION
Accel clipping can still be quite a dangerous situation. Rather than waiting I think it would be better to immediately reset to GNSS vel/pos on frames where it's available and the data is good. With the specific GNSS quality checks and relatively low GNSS frequency (5-10 Hz) I don't think immediately resetting on any clipping will be too aggressive (the alternative is much worse).

If this works it might also make sense to expand to range height and baro height. So far I specifically didn't add this for EV as it's quite likely any VIO is also suffering (with worse reporting).