### PR TITLE
simulator_mavlink: Add basic vio failure injection

### DIFF
--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -1451,10 +1451,6 @@ void SimulatorMavlink::check_failure_injections()
 			}
 		}
 
-		if (!supported) {
-			PX4_WARN("CMD_INJECT_FAILURE, failure sensor/type combination not supported");
-		}
-
 		if (handled) {
 			vehicle_command_ack_s ack{};
 			ack.command = vehicle_command.command;

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -811,8 +811,11 @@ void SimulatorMavlink::handle_message_odometry(const mavlink_message_t *msg)
 	case MAV_ESTIMATOR_TYPE_NAIVE:
 	case MAV_ESTIMATOR_TYPE_VISION:
 	case MAV_ESTIMATOR_TYPE_VIO:
-		odom.timestamp = hrt_absolute_time();
-		_visual_odometry_pub.publish(odom);
+		if (!_vio_blocked) {
+			odom.timestamp = hrt_absolute_time();
+			_visual_odometry_pub.publish(odom);
+		}
+
 		break;
 
 	case MAV_ESTIMATOR_TYPE_MOCAP:
@@ -1432,6 +1435,24 @@ void SimulatorMavlink::check_failure_injections()
 				supported = true;
 				_airspeed_blocked = false;
 			}
+
+		} else if (failure_unit == vehicle_command_s::FAILURE_UNIT_SENSOR_VIO) {
+			handled = true;
+
+			if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
+				PX4_WARN("CMD_INJECT_FAILURE, vio off");
+				supported = true;
+				_vio_blocked = true;
+
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
+				PX4_INFO("CMD_INJECT_FAILURE, vio ok");
+				supported = true;
+				_vio_blocked = false;
+			}
+		}
+
+		if (!supported) {
+			PX4_WARN("CMD_INJECT_FAILURE, failure sensor/type combination not supported");
 		}
 
 		if (handled) {

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -295,6 +295,7 @@ private:
 
 	bool _gps_blocked{false};
 	bool _airspeed_blocked{false};
+	bool _vio_blocked{false};
 
 	float _last_magx[MAG_COUNT_MAX] {};
 	float _last_magy[MAG_COUNT_MAX] {};


### PR DESCRIPTION
## Describe problem solved by this pull request
`simulator_mavlink` didn't support vio failure injection.

## Describe your solution
Adds a `FAILURE_UNIT_SENSOR_VIO` case to `SimulatorMavlink::check_failure_injections()`, supporting the "off" failure type. 

## Test data / coverage
Tested with `make px4_sitl gazebo_iris_vision`, and using the `failure` command.
Drone swaps to altitude mode after `failure gps off` & `failure vio off`, goes back to position after `failure vio ok`
Logs: https://review.px4.io/plot_app?log=bb544f7f-6da4-490a-b5e5-d4fbb9c7c650
