### PR TITLE
Fix invalid setpoint in most takeoffs

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -480,7 +480,7 @@ void MulticopterPositionControl::Run()
 			}
 
 			// make sure takeoff ramp is not amended by acceleration feed-forward
-			if (_takeoff.getTakeoffState() == TakeoffState::rampup) {
+			if (_takeoff.getTakeoffState() == TakeoffState::rampup && PX4_ISFINITE(_setpoint.velocity[2])) {
 				_setpoint.acceleration[2] = NAN;
 			}
 


### PR DESCRIPTION
### Solved Problem
MulticopterPositionControl: fix amending existing idle setpoint from before takeoff once the rampup starts. The rampup requires a valid vertical velocity setpoint.

The corner case is:
- We are before takeoff and amending the setpoint to be 0,0,100 acceleration in order to idle
- The rampup starts BUT the setpoint is not yet overwritten by the trajectory setpoint topic
- The idle setpoint gets amended to not contain a feed-forward vertical acceleration because the rampup is velocity based
- The result is a brief invalid 0,0,NAN acceleration setpoint
- That invalid setpoint gets overridden by a failsafe that holds zero velocity
- Zero velocity leads to applying ~hover thrust briefly

### Solution
I check if there's a valid vertical velocity setpoint which is required for the takeoff ramp and only then amend the acceleration feed-forward.

### Alternatives
Time to consolidate takeoff, landing with the context of what the moe wants to do.

### Test coverage
Easy to reproduce the issue in SITL.
Before:
![image](https://user-images.githubusercontent.com/4668506/200800613-949d6b40-cf18-41e6-8f6f-2430ddeddd9e.png)
After:
![image](https://user-images.githubusercontent.com/4668506/200800860-1301e046-0694-450d-882f-788f17252b5e.png)