### PR TITLE
Add mavlink support for GIMBAL_DEVICE_INFORMATION

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1022,6 +1022,9 @@ Mavlink::handle_message(const mavlink_message_t *msg)
 	// Special case for gimbals that need to forward GIMBAL_DEVICE_ATTITUDE_STATUS.
 	else if (msg->msgid == MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS) {
 		Mavlink::forward_message(msg, this);
+
+	} else if (msg->msgid == MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION) {
+		Mavlink::forward_message(msg, this);
 	}
 }
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -129,6 +129,7 @@
 # include "streams/GIMBAL_DEVICE_SET_ATTITUDE.hpp"
 # include "streams/GIMBAL_MANAGER_INFORMATION.hpp"
 # include "streams/GIMBAL_MANAGER_STATUS.hpp"
+# include "streams/GIMBAL_DEVICE_INFORMATION.hpp"
 # include "streams/GPS2_RAW.hpp"
 # include "streams/HIGH_LATENCY2.hpp"
 # include "streams/LINK_NODE_STATUS.hpp"
@@ -413,6 +414,9 @@ static const StreamListItem streams_list[] = {
 #if defined(GIMBAL_MANAGER_INFORMATION_HPP)
 	create_stream_list_item<MavlinkStreamGimbalManagerInformation>(),
 #endif // GIMBAL_MANAGER_INFORMATION_HPP
+#if defined(GIMBAL_DEVICE_INFORMATION_HPP)
+	create_stream_list_item<MavlinkStreamGimbalDeviceInformation>(),
+#endif // GIMBAL_DEVICE_INFORMATION_HPP
 #if defined(GIMBAL_MANAGER_STATUS_HPP)
 	create_stream_list_item<MavlinkStreamGimbalManagerStatus>(),
 #endif // GIMBAL_MANAGER_STATUS_HPP

--- a/src/modules/mavlink/streams/GIMBAL_DEVICE_INFORMATION.hpp
+++ b/src/modules/mavlink/streams/GIMBAL_DEVICE_INFORMATION.hpp
@@ -1,0 +1,96 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef GIMBAL_DEVICE_INFORMATION_HPP
+#define GIMBAL_DEVICE_INFORMATION_HPP
+
+#include <uORB/topics/gimbal_device_information.h>
+
+class MavlinkStreamGimbalDeviceInformation : public MavlinkStream
+{
+public:
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamGimbalDeviceInformation(mavlink); }
+
+	static constexpr const char *get_name_static() { return "GIMBAL_DEVICE_INFORMATION"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION; }
+
+	const char *get_name() const override { return get_name_static(); }
+	uint16_t get_id() override { return get_id_static(); }
+
+	unsigned get_size() override
+	{
+		if (_gimbal_device_information_sub.advertised()) {
+			return MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+		}
+
+		return 0;
+	}
+
+private:
+	explicit MavlinkStreamGimbalDeviceInformation(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+
+	uORB::Subscription _gimbal_device_information_sub{ORB_ID(gimbal_device_information)};
+
+	bool send() override
+	{
+		gimbal_device_information_s gimbal_device_information;
+
+		if (_gimbal_device_information_sub.advertised() && _gimbal_device_information_sub.copy(&gimbal_device_information)) {
+			// send out gimbal_device_info with info from gimbal_device_information
+			mavlink_gimbal_device_information_t msg{};
+
+			msg.time_boot_ms = gimbal_device_information.timestamp / 1000;
+			memcpy(msg.vendor_name, gimbal_device_information.vendor_name, sizeof(gimbal_device_information.vendor_name));
+			memcpy(msg.model_name, gimbal_device_information.model_name, sizeof(gimbal_device_information.model_name));
+			memcpy(msg.custom_name, gimbal_device_information.custom_name, sizeof(gimbal_device_information.custom_name));
+			msg.firmware_version = gimbal_device_information.firmware_version;
+			msg.hardware_version = gimbal_device_information.hardware_version;
+			msg.uid = gimbal_device_information.uid;
+			msg.cap_flags = gimbal_device_information.cap_flags;
+			msg.roll_min = gimbal_device_information.roll_min;
+			msg.roll_max = gimbal_device_information.roll_max;
+			msg.pitch_min = gimbal_device_information.pitch_min;
+			msg.pitch_max = gimbal_device_information.pitch_max;
+			msg.yaw_min = gimbal_device_information.yaw_min;
+			msg.yaw_max = gimbal_device_information.yaw_max;
+
+			mavlink_msg_gimbal_device_information_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+#endif // GIMBAL_DEVICE_INFORMATION_HPP


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Discord](https://discord.gg/dronecode) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull request
gimbal_device_information message has quite some fields like gimbal vendor, model and firmware version that become very important when operators need to check which firmware version/model is currently installed on the gimbal. 
The only way to propagate this information to the GCS is by requesting the message when the GCS connects to the autopilot, however in the current implementation PX4 would not forward the message.

Looking at the protocol (https://mavlink.io/en/services/gimbal_v2.html) seems that this case was not taken into consideration, but on the other hand the message definition states that  "This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE (https://mavlink.io/en/messages/common.html#GIMBAL_DEVICE_INFORMATION).

another option would be to include the GIMBAL_DEVICE_INFORMATION into the GIMBAL_MANAGER_INFORMATION. 
@julianoes, what do you think about the above?

## Describe your solution
Allow forwarding GIMBAL_DEVICE_INFORMATION when requested

## Describe possible alternatives
A clear and concise description of alternative solutions or features you've considered.

## Test data / coverage
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

## Additional context
Add any other related context or media.
