### PR TITLE
commander: fix hold after mission logic

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1862,17 +1862,22 @@ void Commander::checkForMissionUpdate()
 			}
 		}
 
-		// handle navigation state auto-switching based on mission_result
 		if (_arm_state_machine.isArmed() && !_vehicle_land_detected.landed
 		    && (mission_result.timestamp >= _vehicle_status.nav_state_timestamp)
 		    && mission_result.finished) {
 
-			if ((_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
-			     || _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
-			    && (_param_takeoff_finished_action.get() == 1) && auto_mission_available) {
-				_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
+			if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
+			    || _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF) {
+				// Transition mode to loiter or auto-mission after takeoff is completed.
+				if ((_param_takeoff_finished_action.get() == 1) && auto_mission_available) {
+					_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
 
-			} else {
+				} else {
+					_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
+				}
+
+			} else if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION) {
+				// Transition to loiter when the mission is cleared and/or finished, and we are still in mission mode.
 				_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
 			}
 		}


### PR DESCRIPTION
In https://github.com/PX4/PX4-Autopilot/pull/20564, the change in logic to hold after mission clear also broke RTL, as non-mission takeoff still published a mission result which allowed entering the mission finished condition and always changing state to loiter (ignoring rtl). New logic only switches navigation states if mission is finish and the nav state is explicitly in takeoff state, or in mission state.

I checked the following cases work as intended in SITL:
- takeoff command, RTL command .. RTL actually is able to finish
- takeoff command, `COM_TAKEOFF_ACT=0`, vehicle holds once done taking off
- takeoff command, `COM_TAKEOFF_ACT=1`, vehicle enters the mission once done taking off
- start mission, clear mission while it's running, vehicle holds