### PR TITLE
MissionFeasibility: add combined takeoff/landing requirement check

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -45,6 +45,7 @@ param set-default NAV_ACC_RAD 10
 param set-default MIS_DIST_WPS 5000
 param set-default MIS_LTRMIN_ALT 25
 param set-default MIS_TAKEOFF_ALT 25
+param set-default MIS_TKO_LAND_REQ 2
 
 #
 # FW takeoff acceleration can easily exceed ublox GPS 2G default.

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -19,6 +19,7 @@ param set-default EKF2_FUSE_BETA 1
 param set-default HTE_VXY_THR 2.0
 
 param set-default MIS_DIST_WPS 5000
+param set-default MIS_TKO_LAND_REQ 2
 
 param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_VEL_MANUAL 5

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1743,8 +1743,7 @@ Mission::check_mission_valid(bool force)
 		_navigator->get_mission_result()->valid =
 			_missionFeasibilityChecker.checkMissionFeasible(_mission,
 					_param_mis_dist_1wp.get(),
-					_param_mis_dist_wps.get(),
-					_navigator->mission_landing_required());
+					_param_mis_dist_wps.get());
 
 		_navigator->get_mission_result()->seq_total = _mission.count;
 		_navigator->increment_mission_instance_count();

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2022 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,26 +56,18 @@ private:
 
 	/* Checks for all airframes */
 	bool checkGeofence(const mission_s &mission, float home_alt, bool home_valid);
-
 	bool checkHomePositionAltitude(const mission_s &mission, float home_alt, bool home_alt_valid);
-
 	bool checkMissionItemValidity(const mission_s &mission);
-
 	bool checkDistanceToFirstWaypoint(const mission_s &mission, float max_distance);
 	bool checkDistancesBetweenWaypoints(const mission_s &mission, float max_distance);
-
 	bool checkTakeoff(const mission_s &mission, float home_alt);
+	bool checkTakeoffLandAvailable();
+	bool checkRotaryWingLanding(const mission_s &mission);
+	bool checkFixedWingLanding(const mission_s &mission);
+	bool checkVTOLLanding(const mission_s &mission);
 
-	/* Checks specific to fixedwing airframes */
-	bool checkFixedwing(const mission_s &mission, float home_alt, bool land_start_req);
-	bool checkFixedWingLanding(const mission_s &mission, bool land_start_req);
-
-	/* Checks specific to rotarywing airframes */
-	bool checkRotarywing(const mission_s &mission, float home_alt);
-
-	/* Checks specific to VTOL airframes */
-	bool checkVTOL(const mission_s &mission, float home_alt, bool land_start_req);
-	bool checkVTOLLanding(const mission_s &mission, bool land_start_req);
+	bool _has_takeoff{false};
+	bool _has_landing{false};
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator) : ModuleParams(nullptr), _navigator(navigator) {}
@@ -88,6 +80,5 @@ public:
 	 * Returns true if mission is feasible and false otherwise
 	 */
 	bool checkMissionFeasible(const mission_s &mission,
-				  float max_distance_to_1st_waypoint, float max_distance_between_waypoints,
-				  bool land_start_req);
+				  float max_distance_to_1st_waypoint, float max_distance_between_waypoints);
 };

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -58,14 +58,19 @@
 PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
 
 /**
- * Take-off waypoint required
+ * Mission takeoff/landing required
  *
- * If set, the mission feasibility checker will check for a takeoff waypoint on the mission.
+ * Specifies if a mission has to contain a takeoff and/or mission landing.
+ * Validity of configured takeoffs/landings is checked independently of the setting here.
  *
- * @boolean
+ * @value 0 No requirements
+ * @value 1 Require a takeoff
+ * @value 2 Require a landing
+ * @value 3 Require a takeoff and a landing
+ * @value 4 Require a takeoff and a landing, or neither of both
  * @group Mission
  */
-PARAM_DEFINE_INT32(MIS_TAKEOFF_REQ, 0);
+PARAM_DEFINE_INT32(MIS_TKO_LAND_REQ, 0);
 
 /**
  * Minimum Loiter altitude

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -297,8 +297,6 @@ public:
 	float get_mission_landing_loiter_radius() { return _mission.get_landing_loiter_rad(); }
 
 	// RTL
-	bool mission_landing_required() { return _rtl.get_rtl_type() == RTL::RTL_TYPE_MISSION_LANDING; }
-
 	bool in_rtl_state() const { return _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL; }
 
 	bool abort_landing();
@@ -308,7 +306,7 @@ public:
 	// Param access
 	float get_loiter_min_alt() const { return _param_mis_ltrmin_alt.get(); }
 	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
-	bool  get_takeoff_required() const { return _param_mis_takeoff_req.get(); }
+	int  get_takeoff_land_required() const { return _para_mis_takeoff_land_req.get(); }
 	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
 	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
 	float get_lndmc_alt_max() const { return _param_lndmc_alt_max.get(); }
@@ -451,7 +449,7 @@ private:
 		// non-navigator parameters: Mission (MIS_*)
 		(ParamFloat<px4::params::MIS_LTRMIN_ALT>)  _param_mis_ltrmin_alt,
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
-		(ParamBool<px4::params::MIS_TAKEOFF_REQ>)  _param_mis_takeoff_req,
+		(ParamInt<px4::params::MIS_TKO_LAND_REQ>)  _para_mis_takeoff_land_req,
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
 		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,


### PR DESCRIPTION
## Describe problem solved by this pull request
Currently with RTL_TYPE=1 (default for FW and VTOL), a mission is rejected if it doesn't contain a landing (landing pattern). There is no way to disable this check without changing the RTL behavior. 


## Describe your solution
Replace the existing check for the availability of a takeoff mission item with a combined check for takeoff and landing item (or landing pattern). New param MIS_TKO_LAND_REQ can be set to require only a takeoff, only a landing, both takeoff and landing, and both or none. The latter is meant to be set if is e.g. deemed unsafe to start a flight through a Takeoff WP without though defining a Landing - as then in case of a RTL the vehicle doesn't follow a pre-defined path but instead only can do default RTL that especially for FW and VTOL isn't always safe.

The default behavior isn't changed, as MIS_TKO_LAND_REQ is set to 2 for FW and VTOL, and thus for these vehicles a mission landing is still required by default. 

This PR also contains some refactoring. 

