### PR TITLE
Decimal added for the CAL_ACC[012]* parameters

### DIFF
--- a/src/modules/sensors/module.yaml
+++ b/src/modules/sensors/module.yaml
@@ -14,6 +14,7 @@ parameters:
             category: System
             type: int32
             default: 0
+            decimal: 3
             num_instances: *max_num_sensor_instances
             instance_start: 0
 
@@ -31,6 +32,7 @@ parameters:
                 75: High
                 100: Max
             default: -1
+            decimal: 3
             num_instances: *max_num_sensor_instances
             instance_start: 0
 
@@ -97,6 +99,7 @@ parameters:
             type: float
             default: 0.0
             unit: m/s^2
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -108,6 +111,7 @@ parameters:
             type: float
             default: 0.0
             unit: m/s^2
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -119,6 +123,7 @@ parameters:
             type: float
             default: 0.0
             unit: m/s^2
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -129,6 +134,7 @@ parameters:
             category: System
             type: float
             default: 1.0
+            decimal: 3
             min: 0.1
             max: 3.0
             volatile: true
@@ -141,6 +147,7 @@ parameters:
             category: System
             type: float
             default: 1.0
+            decimal: 3
             min: 0.1
             max: 3.0
             volatile: true
@@ -153,6 +160,7 @@ parameters:
             category: System
             type: float
             default: 1.0
+            decimal: 3
             min: 0.1
             max: 3.0
             volatile: true


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Discord](https://discord.gg/dronecode) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

## Describe problem solved by this pull reques
The vehicle parameters CAL_ACC[012]* were lacking the 'decimal' field in the yaml description

## Describe your solution
The field decimal field is now added

## Describe possible alternatives
NA

## Test data / coverage
The changes were tested with QGC and SITL. Before the changes the parameters appear as integers which is NOK and after the changes they appear as floats which is correct.

## Additional context
Add any other related context or media.
![1 - before](https://user-images.githubusercontent.com/1894862/201154185-8d09a169-1273-48fc-89b9-22cda06159f3.jpg)
![2 - after](https://user-images.githubusercontent.com/1894862/201154214-27977a01-a4e0-4fcc-bd9d-d20c857a6d67.jpg)

