### PR TITLE
Support custom per-channel parameters in actuator driver

### DIFF
--- a/Tools/module_config/generate_actuators_metadata.py
+++ b/Tools/module_config/generate_actuators_metadata.py
@@ -264,7 +264,18 @@ def get_actuator_output(yaml_config, output_functions, timer_config_file, verbos
             }
         per_channel_params.append(param)
 
-        # TODO: support non-standard per-channel parameters
+        custom_params = group.get('custom_params', [])
+        for custom_param in custom_params:
+            # Simply pulls all custom params, assuming they are valid ones
+            param = {
+                'name': param_prefix+'_'+custom_param['name'],
+            }
+            # TODO: check and match the custom params in output_groups with module-level parameters
+            del custom_param['name']
+            for param_key in custom_param:
+                # '-' is used in actuators.schema.json, while '_' is used in module_schema.yml
+                param[param_key.replace('_', '-')] = custom_param[param_key]
+            per_channel_params.append(param)
 
         subgroup['per-channel-parameters'] = per_channel_params
 

--- a/validation/module_schema.yaml
+++ b/validation/module_schema.yaml
@@ -369,6 +369,33 @@ actuator_output:
                                         # ui only shows the param if this condition is true
                                         type: string
                                         regex: *condition_regex
+                    custom_params:
+                        type: list
+                        schema: &mixer_parameter
+                            type: dict
+                            schema:
+                                label:
+                                    type: string
+                                name:
+                                    # param name
+                                    type: string
+                                    required: true
+                                show_as:
+                                    type: string
+                                    allowed: [ 'bitset', 'true-if-positive' ]
+                                show_if:
+                                    # condition
+                                    type: string
+                                    regex: *condition_regex
+                                index_offset:
+                                    type: integer
+                                advanced:
+                                    type: integer
+                                function:
+                                    type: string
+                                identifier:
+                                    # for rules
+                                    type: string
                     extra_function_groups:
                         # Additional function groups to add, defined in output_functions.yaml
                         type: list
@@ -477,31 +504,7 @@ mixer:
                     per_item_parameters:
                         type: list
                         minlength: 1
-                        schema: &mixer_parameter
-                            type: dict
-                            schema:
-                                label:
-                                    type: string
-                                name:
-                                    # param name
-                                    type: string
-                                    required: true
-                                show_as:
-                                    type: string
-                                    allowed: [ 'bitset', 'true-if-positive' ]
-                                show_if:
-                                    # condition
-                                    type: string
-                                    regex: *condition_regex
-                                index_offset:
-                                    type: integer
-                                advanced:
-                                    type: integer
-                                function:
-                                    type: string
-                                identifier:
-                                    # for rules
-                                    type: string
+                        schema: *mixer_parameter
         rules:
             # mixer rules, validated by the mavlink actuator component information schema
             type: list


### PR DESCRIPTION
## Describe problem solved by this pull request

I'm now doing the rewrite of `pca9685_pwm_out` driver and want to make it able to output duty cycle information(aka PWM mode) instead of typical 1ms~2ms pulse signal.

This PR will let actuator drivers be able to do runtime configuration of its output, based on Dynamic Allocator in a more flexible way than before.

## Describe your solution

Both param and meta generator are affected. 

## Test data / coverage

This is the part of my current `module.yml`:

```
  output_groups:
    - param_prefix: PCA9685
      group_label: 'PCA9685'
      channel_label: 'Channel'
      standard_params:
        disarmed: { min: 0, max: 4095, default: 900 }
        min: { min: 0, max: 4095, default: 1000 }
        max: { min: 0, max: 4095, default: 2000 }
        failsafe: { min: 0, max: 4095 }
      custom_params:
        pwm:
          label: PWM Mode
          prefix: PWM
          description: |
            Enable PWM mode will make PCA9685 output duty cycle instead of PPM pulse.
            Using MIN value different from 0 will lead to output (MIN/4096)% instead of 0%.
            Same applies to MAX and other fields.

          advanced: true
          param:
            type: boolean
            default: false
      num_channels: 16
```

After touching some of params by

```
pxh> param touch PCA9685_PWM1
pxh> param touch PCA9685_PWM2
pxh> param touch PCA9685_PWM3
```

Here are some screenshots of the working demo:

![image](https://user-images.githubusercontent.com/10492472/201332671-7a21e663-f97c-41c1-a834-0135ef79a7d6.png)

![image](https://user-images.githubusercontent.com/10492472/201337716-c515bda2-8f2e-42b8-a4aa-76ad9f9a29b2.png)

