### PR TITLE
Move uavcan start to end of rcS to prevent sd card read lock

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -265,23 +265,6 @@ else
 	fi
 
 	#
-	# Check if UAVCAN is enabled, default to it for ESCs.
-	#
-	if param greater -s UAVCAN_ENABLE 0
-	then
-		# Start core UAVCAN module.
-		if ! uavcan start
-		then
-			tune_control play error
-		fi
-	else
-		if param greater -s CYPHAL_ENABLE 0
-		then
-			cyphal start
-		fi
-	fi
-
-	#
 	# Start IO for PWM output or RC input if enabled
 	#
 	if param compare -s SYS_USE_IO 1
@@ -526,6 +509,23 @@ else
 		sh $BOARD_BOOTLOADER_UPGRADE
 	fi
 	unset BOARD_BOOTLOADER_UPGRADE
+
+	#
+	# Check if UAVCAN is enabled, default to it for ESCs.
+	#
+	if param greater -s UAVCAN_ENABLE 0
+	then
+		# Start core UAVCAN module.
+		if ! uavcan start
+		then
+			tune_control play error
+		fi
+	else
+		if param greater -s CYPHAL_ENABLE 0
+		then
+			cyphal start
+		fi
+	fi
 
 #
 # End of autostart.


### PR DESCRIPTION
This PR moves the uavcan startup to the end of the rcS script. I have been seeing an issue on and off on different autopilots where when on battery power, uavcannodes sometimes won't boot. It looks like it is caused by the uavcan firmware server spinning on the sd card firmware read. When this occurs, no other task can read the SD.

Moving the uavcan start call to the end of the rcS script appears to solve the problem. Could be related to logger start timing.