### PR TITLE
commander: fix initialization order of _failsafe_flags

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
@@ -35,8 +35,7 @@
 
 HealthAndArmingChecks::HealthAndArmingChecks(ModuleParams *parent, vehicle_status_s &status)
 	: ModuleParams(parent),
-	  _context(status),
-	  _reporter(_failsafe_flags)
+	  _context(status)
 {
 	// Initialize mode requirements to invalid
 	_failsafe_flags.angular_velocity_invalid = true;

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -103,11 +103,11 @@ public:
 protected:
 	void updateParams() override;
 private:
-	Context _context;
-	Report _reporter;
-	orb_advert_t _mavlink_log_pub{nullptr};
-
 	failsafe_flags_s _failsafe_flags{};
+
+	Context _context;
+	Report _reporter{_failsafe_flags};
+	orb_advert_t _mavlink_log_pub{nullptr};
 
 	uORB::Publication<health_report_s> _health_report_pub{ORB_ID(health_report)};
 	uORB::Publication<failsafe_flags_s> _failsafe_flags_pub{ORB_ID(failsafe_flags)};


### PR DESCRIPTION
In this case it did not cause any problems.
Fixes a compiler warning:
```
/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp:39:21: error: member ‘HealthAndArmingChecks::_failsafe_flags’ is used uninitialized [-Werror=uninitialized]
   39 |           _reporter(_failsafe_flags)
      |                     ^~~~~~~~~~~~~~~
```