### PR TITLE
Avoid invalid setpoint message when switching to altitude controlled mode

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -223,5 +223,5 @@ private:
 	 * Used to handle transitions where no proper setpoint was generated yet and when the received setpoint is invalid.
 	 * This should only happen briefly when transitioning and never during mode operation or by design.
 	 */
-	trajectory_setpoint_s generateFailsafeSetpoint(const hrt_abstime &now, const PositionControlStates &states);
+	trajectory_setpoint_s generateFailsafeSetpoint(const hrt_abstime &now, const PositionControlStates &states, bool warn);
 };


### PR DESCRIPTION
## Describe problem solved by this pull request
Right now on main there's a high chance that if you switch from a non altitude controlled mode e.g. stabilized to an altitude controlled one e.g. altitude that you get a message for invalid setpoint. This is because https://github.com/PX4/PX4-Autopilot/pull/19162 solved the issue where no valid setpoint is present yet by just generating a failsafe setpoint. And I think originally it was supposed to not show the message but now it does.

## Describe your solution
I just don't show the message when the failsafe setpoint is generated to bridge the mode switch.

## Describe possible alternatives
I plan to change the logic as part of simplifying the entire wrapping logic for takeoff and landing but in the meantime we need a fix for the user experience on main.

## Test data / coverage
I tested this in SITL. The message doesn't show up anymore.