### PR TITLE
ekf2: do not fuse ZVU if other velocity source is active

### DIFF
--- a/src/modules/ekf2/EKF/zero_velocity_update.cpp
+++ b/src/modules/ekf2/EKF/zero_velocity_update.cpp
@@ -45,15 +45,16 @@ void Ekf::controlZeroVelocityUpdate()
 
 	if (zero_velocity_update_data_ready) {
 		const bool continuing_conditions_passing = _control_status.flags.vehicle_at_rest
-				&& _control_status_prev.flags.vehicle_at_rest;
+				&& _control_status_prev.flags.vehicle_at_rest
+				&& !isVerticalVelocityAidingActive(); // otherwise the filter is "too rigid" to follow a position drift
 
 		if (continuing_conditions_passing) {
 			Vector3f vel_obs{0, 0, 0};
 			Vector3f innovation = _state.vel - vel_obs;
 
-			// Set a low variance initially for faster accel bias learning and higher
+			// Set a low variance initially for faster leveling and higher
 			// later to let the states follow the measurements
-			const float obs_var = _NED_origin_initialised ? sq(0.2f) : sq(0.001f);
+			const float obs_var = _control_status.flags.tilt_align ? sq(0.2f) : sq(0.001f);
 			Vector3f innov_var{
 				P(4, 4) + obs_var,
 				P(5, 5) + obs_var,


### PR DESCRIPTION
## Describe problem solved by this pull request
Some people are still seeing annoying "height estimate not stable" messages primarily because the GNSS altitude drifted by a couple of meters after initializing the EKF origin. The problem is that with Zero Velocity Updates in addition to GNSS velocity fusion, the variance of the velocity estimate becomes really small and makes the position estimate too rigid and it can take several tens of seconds to move by a couple of meters.

## Describe your solution
1. Do not fuse zero velocity fake measurements if another velocity aiding source is active (GNSS or VIO)
2. Use "extremely high accuracy" during fine alignment and "good accuracy" otherwise (this is to decouple from `_NED_origin_initialised` that relates to GNSS directly)

## Test data / coverage
Unit tests, SITL