### PR TITLE
commander_params: remove deprecated COM_RCL_ACT_T

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -143,23 +143,6 @@ PARAM_DEFINE_INT32(COM_HLDL_REG_T, 0);
 PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5f);
 
 /**
- * Delay between RC loss and configured reaction
- *
- * RC signal not updated -> still use data for COM_RC_LOSS_T seconds
- * Consider RC signal lost -> wait COM_RCL_ACT_T seconds in Hold mode to regain signal
- * React with failsafe action NAV_RCL_ACT
- *
- * A zero value disables the delay.
- *
- * @group Commander
- * @unit s
- * @min 0.0
- * @max 25.0
- * @decimal 3
- */
-PARAM_DEFINE_FLOAT(COM_RCL_ACT_T, 15.0f);
-
-/**
  * Home position enabled
  *
  * Set home position automatically if possible.


### PR DESCRIPTION
## Describe problem solved by this pull request
@Curry reported on Discord some results of running static analysis and to my surprise `COM_RCL_ACT_T` was in the list of unused parameters: https://discord.com/channels/1022170275984457759/1040487659560239184/1040487670377349150

And duplicate here: fixes #20593

## Describe your solution
I remove the definition of `COM_RCL_ACT_T` because https://github.com/PX4/PX4-Autopilot/commit/455b885f86754985fb07726b7975f0f028537204 deprecated the parameter and failsafe delays got consolidated to `COM_FAIL_ACT_T`.

## Additional context
This parameter was originally introduced in: https://github.com/PX4/PX4-Autopilot/pull/16406