### PR TITLE
Remove needless parameter definitions

### DIFF
--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -155,43 +155,6 @@ PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADM, 500);
 PARAM_DEFINE_FLOAT(NAV_TRAFF_A_RADU, 10);
 
 /**
- * Airfield home Lat
- *
- * Latitude of airfield home waypoint
- *
- * @unit deg*1e7
- * @min -900000000
- * @max 900000000
- * @group Data Link Loss
- */
-PARAM_DEFINE_INT32(NAV_AH_LAT, -265847810);
-
-/**
- * Airfield home Lon
- *
- * Longitude of airfield home waypoint
- *
- * @unit deg*1e7
- * @min -1800000000
- * @max 1800000000
- * @group Data Link Loss
- */
-PARAM_DEFINE_INT32(NAV_AH_LON, 1518423250);
-
-/**
- * Airfield home alt
- *
- * Altitude of airfield home waypoint
- *
- * @unit m
- * @min -50
- * @decimal 1
- * @increment 0.5
- * @group Data Link Loss
- */
-PARAM_DEFINE_FLOAT(NAV_AH_ALT, 600.0f);
-
-/**
  * Force VTOL mode takeoff and land
  *
  * @boolean


### PR DESCRIPTION
## Problem
@bigworldsmall statically analyzed parameter use in PX4 and found quite some unused parameter definitions.

## Solution
I'm removing deprecated or otherwise needless parameters. See the table in:

closes #20593