### PR TITLE
modalai_esc_params: remove unused parameter

### DIFF
--- a/src/drivers/actuators/modalai_esc/modalai_esc_params.c
+++ b/src/drivers/actuators/modalai_esc/modalai_esc_params.c
@@ -181,16 +181,6 @@ PARAM_DEFINE_FLOAT(UART_ESC_T_MINF, 0.15);
 PARAM_DEFINE_INT32(UART_ESC_T_EXPO, 35);
 
 /**
- * UART ESC Turtle Mode Yaw Reversal
- *
- * @group UART ESC
- * @min 0
- * @max 1
- * @decimal 10
- * @increment 1
- */
-PARAM_DEFINE_INT32(UART_ESC_T_YAWR, 0);
-/**
  * UART ESC Turtle Mode Cosphi
  *
  * @group UART ESC


### PR DESCRIPTION
## Describe problem solved by this pull request
@bigworldsmall statically analyzed parameter use in PX4 and found quite some unused parameter definitions.
One of them being `UART_ESC_T_YAWR` which I do not see where it is used and my previous pr https://github.com/PX4/PX4-Autopilot/pull/20616 already got merged 🚀 

See https://github.com/PX4/PX4-Autopilot/issues/20593#issuecomment-1316781201