### PR TITLE
backtransition when taking over manual control

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -105,6 +105,18 @@ VtolAttitudeControl::init()
 	return true;
 }
 
+void VtolAttitudeControl::vehicle_control_mode_poll()
+{
+	_vehicle_control_mode_sub.update(&_vehicle_control_mode);
+
+	// enforce back transition when switching to manual control
+	if (!flag_control_manual_enabled_prev && _vehicle_control_mode.flag_control_manual_enabled) {
+		_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
+	}
+
+	flag_control_manual_enabled_prev = _vehicle_control_mode.flag_control_manual_enabled;
+}
+
 void VtolAttitudeControl::vehicle_status_poll()
 {
 	_vehicle_status_sub.copy(&_vehicle_status);
@@ -312,7 +324,6 @@ VtolAttitudeControl::Run()
 	if (should_run) {
 		parameters_update();
 
-		_vehicle_control_mode_sub.update(&_vehicle_control_mode);
 		_vehicle_attitude_sub.update(&_vehicle_attitude);
 		_local_pos_sub.update(&_local_pos);
 		_local_pos_sp_sub.update(&_local_pos_sp);
@@ -320,6 +331,7 @@ VtolAttitudeControl::Run()
 		_airspeed_validated_sub.update(&_airspeed_validated);
 		_tecs_status_sub.update(&_tecs_status);
 		_land_detected_sub.update(&_land_detected);
+		vehicle_control_mode_poll();
 		vehicle_status_poll();
 		action_request_poll();
 		vehicle_cmd_poll();

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -224,12 +224,15 @@ private:
 	bool		_immediate_transition{false};
 
 	uint8_t _nav_state_prev;
+	bool flag_control_manual_enabled_prev{false};
 
 	VtolType	*_vtol_type{nullptr};	// base class for different vtol types
 
 	bool		_initialized{false};
 
 	perf_counter_t	_loop_perf;		// loop performance counter
+
+	void            vehicle_control_mode_poll();
 
 	void		vehicle_status_poll();
 


### PR DESCRIPTION
From https://discord.com/channels/1022170275984457759/1039594203149238332 @MaEtUgR @sfuhrer 

## Describe problem solved by this pull request
With #17404, a change was introduced in what happens when you take over manually with the RC from an automatic flight mode. Previously, the transition switch would be checked and the drone would transition accordingly if needed. Now the transition switch is ignored. Meaning for example that if the drone is flying in FW mission mode and you take over in Position mode with the transition switch already in MC mode, the drone will continue to fly in FW mode, and not according to the switches on the RC.

For some use cases (including ours, obviously), this is undesired. If we have to take over manually, it's because of a emergency situation, in which we want to switch to MC asap. (Though for most use cases the new functioning is arguably better.)

## Describe your solution
When a switch to a manual flight mode is detected, a back transition is started immediately.

## Describe possible alternatives
Don't merge this if it's not deemed better.

## Test data / coverage
I forgot to activate permanent logging when bench testing. I will update the descriptions with logs once I get back to my test bench.
