### PR TITLE
mavlink: enable forwarding messages over USB

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2943,6 +2943,7 @@ Mavlink::display_status()
 	       _ftp_on ? "YES" : "NO",
 	       _transmitting_enabled ? "YES" : "NO");
 	printf("\tmode: %s\n", mavlink_mode_str(_mode));
+	printf("\tForwarding: %s\n", get_forwarding_on() ? "On" : "Off");
 	printf("\tMAVLink version: %" PRId32 "\n", _protocol_version);
 
 	printf("\ttransport protocol: ");

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -166,3 +166,15 @@ PARAM_DEFINE_INT32(MAV_ODOM_LP, 0);
  * @max 250
  */
 PARAM_DEFINE_INT32(MAV_RADIO_TOUT, 5);
+
+/**
+ * Message forwarding for USB MAVLink instance.
+ *
+ * When set, messages are forwarded to the USB MAVLink instance.
+ * This is equivalent to e.g. the MAV_0_FORWARD, for MAVLink instance 0.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_S_FORWARD, 0);


### PR DESCRIPTION
This adds the param MAV_S_FORWARD to set forwarding on or off for the MAVLink instance connected over USB (/dev/ttyACM0).

Also, in order to test this, I added the forwarding state to the mavlink status command.

This is not tested yet, except using the `mavlink status` command.