### PR TITLE
microdds: use UXR_DURABILITY_VOLATILE for data reader

### DIFF
--- a/src/modules/microdds_client/utilities.hpp
+++ b/src/modules/microdds_client/utilities.hpp
@@ -112,7 +112,7 @@ static bool create_data_reader(uxrSession *session, uxrStreamId reliable_out_str
 	uxrObjectId datareader_id = uxr_object_id(id, UXR_DATAREADER_ID);
 
 	uxrQoS_t qos = {
-		.durability = UXR_DURABILITY_TRANSIENT_LOCAL,
+		.durability = UXR_DURABILITY_VOLATILE,
 		.reliability = UXR_RELIABILITY_BEST_EFFORT,
 		.history = UXR_HISTORY_KEEP_LAST,
 		.depth = 0,


### PR DESCRIPTION
This corresponds to the ROS2 default. Using reader=TRANSIENT_LOCAL and writer=VOLATILE (=default) is incompatible according to https://docs.ros.org/en/rolling/Concepts/About-Quality-of-Service-Settings.html

@dagar did you use non-default QOS in your testing?