### PR TITLE
Fix overflows in abstime_to_ts

### DIFF
--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -149,8 +149,8 @@ static inline hrt_abstime ts_to_abstime(const struct timespec *ts)
  */
 static inline void abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 {
-	ts->tv_sec = (time_t)abstime / 1000000;
-	abstime -= (hrt_abstime)(ts->tv_sec * 1000000);
+	ts->tv_sec = (typeof(ts->tv_sec))(abstime / 1000000);
+	abstime -= (hrt_abstime)(ts->tv_sec) * 1000000;
 	ts->tv_nsec = (typeof(ts->tv_nsec))(abstime * 1000);
 }
 


### PR DESCRIPTION
Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I found that abstime_to_ts doesn't work at all, it overflows on two lines. Caused many mysterious bugs in my own development branches. Added separate comments explaining the needed changes

Fixes #{Github issue ID}

### Solution
Fix the typecasts

### Alternatives
N/A

### Test coverage
Desk-tested by printing out the calculated values

