### PR TITLE
Pr fw pos c fix load factor airspeed main

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -428,7 +428,7 @@ FixedwingPositionControl::get_auto_airspeed_setpoint(const float control_interva
 	float load_factor = 1.0f;
 
 	if (PX4_ISFINITE(_att_sp.roll_body)) {
-		load_factor = 1.0f / sqrtf(cosf(_att_sp.roll_body));
+		load_factor = 1.0f / cosf(_att_sp.roll_body);
 	}
 
 	float weight_ratio = 1.0f;

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -189,15 +189,15 @@ FixedwingPositionControl::parameters_update()
 		check_ret = PX4_ERROR;
 	}
 
-	if (_param_fw_airspd_stall.get() > _param_fw_airspd_min.get() * 0.9f) {
-		mavlink_log_critical(&_mavlink_log_pub, "Config invalid: Stall airspeed higher than 0.9 of min\t");
+	if (_param_fw_airspd_stall.get() > _param_fw_airspd_min.get()) {
+		mavlink_log_critical(&_mavlink_log_pub, "Config invalid: FW_AIRSPD_STALL airspeed higher than FW_AIRSPD_MIN\t");
 		/* EVENT
 		 * @description
 		 * - <param>FW_AIRSPD_MIN</param>: {1:.1}
 		 * - <param>FW_AIRSPD_STALL</param>: {2:.1}
 		 */
 		events::send<float, float>(events::ID("fixedwing_position_control_conf_invalid_stall"), events::Log::Error,
-					   "Invalid configuration: Stall airspeed higher than 90% of minimum airspeed",
+					   "Invalid configuration: FW_AIRSPD_STALL higher FW_AIRSPD_MIN",
 					   _param_fw_airspd_min.get(), _param_fw_airspd_stall.get());
 		check_ret = PX4_ERROR;
 	}


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
- While flight testing I found that the airspeed setpoint increase due to bank angle is wrong.
- the 0.9 factor margin between stall vs min airspeed isn't actually necessary, it's enough to warn the user if stall>min.

### Solution
- remove the sqrt() from the load factor calculation. There is still a sqrt(load_factor) for the airspeed calculation based on load factor.
- remove the 0.9 factor

