### PR TITLE
FW Position Controller: improve accelerated stall protection

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -633,7 +633,7 @@ private:
 	float get_manual_airspeed_setpoint();
 
 	/**
-	 * @brief Returns a calibrated airspeed setpoint for auto modes.
+	 * @brief Returns am adapted calibrated airspeed setpoint
 	 *
 	 * Adjusts the setpoint for wind, accelerated stall, and slew rates.
 	 *
@@ -643,8 +643,8 @@ private:
 	 * @param ground_speed Vehicle ground velocity vector (NE) [m/s]
 	 * @return Adjusted calibrated airspeed setpoint [m/s]
 	 */
-	float get_auto_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
-					 float calibrated_min_airspeed, const Vector2f &ground_speed);
+	float adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
+				      float calibrated_min_airspeed, const Vector2f &ground_speed);
 
 	void reset_takeoff_state();
 	void reset_landing_state();

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -633,7 +633,7 @@ private:
 	float get_manual_airspeed_setpoint();
 
 	/**
-	 * @brief Returns am adapted calibrated airspeed setpoint
+	 * @brief Returns an adapted calibrated airspeed setpoint
 	 *
 	 * Adjusts the setpoint for wind, accelerated stall, and slew rates.
 	 *

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -524,6 +524,10 @@ PARAM_DEFINE_FLOAT(FW_LND_THRTC_SC, 1.0f);
  * The minimal airspeed (calibrated airspeed) the user is able to command.
  * Further, if the airspeed falls below this value, the TECS controller will try to
  * increase airspeed more aggressively.
+ * Has to be set according to the vehicle's stall speed (which should be set in FW_AIRSPD_STALL),
+ * with some margin between the stall speed and minimum airspeed.
+ * This value corresponds to the desired minimum speed with the default load factor (level flight, default weight),
+ * and is automatically adpated to the current load factor (calculated from roll setpoint and WEIGHT_GROSS/WEIGHT_BASE).
  *
  * @unit m/s
  * @min 0.5
@@ -537,7 +541,8 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
 /**
  * Maximum Airspeed (CAS)
  *
- * If the CAS (calibrated airspeed) is above this value, the TECS controller will try to decrease
+ * The maximal airspeed (calibrated airspeed) the user is able to command.
+ * Further, if the airspeed is above this value, the TECS controller will try to decrease
  * airspeed more aggressively.
  *
  * @unit m/s


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Two separate issues related to accelerated stall (load factor dependent stall speed):
- the check was only in Auto modes, not in manual Position or Altitude
- it was using FW_AIRSPD_STALL, which, when set correctly, didn't leave the controller any room for error


### Solution
- also do it in Position and Altitude
- clearly define FW_AIRSPD_MIN as stall+margin, and use that (adjusted to the load factor), as the min airspeed setpoint into the controller

### Test coverage
SITL

### Context

