### PR TITLE
Preserve gimbal control when receiving updates from an input that is not active

### DIFF
--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -250,11 +250,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 					break;
 
 				case InputBase::UpdateResult::UpdatedNotActive:
-					if (already_active) {
-						// No longer active
-						thread_data.last_input_active = -1;
-					}
-
+					// Ignore, input not active
 					break;
 				}
 


### PR DESCRIPTION
### Solved Problem
The [update function of InputMavlinkGimbalV2](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L491) returns `UpdatedNotActive` when receiving control commands from a system or component that doesn't match the primary control. This can happen if a component just sends commands without being in control or when transitioning to a different primary control. If the input is marked as `already_active`, it will [reset last_input_active](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/gimbal.cpp#L252) which in turn [resets the primary control](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/gimbal.cpp#L209) in the next iteration. According to the MAVLink gimbal protocol v2, a component needs to send `MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE` to start controlling the gimbal and to remove control. However, with the current implementation there are several other messages that cause a reset of the primary control.

The issue was found when flying a survey mission where the gimbal didn't pitch down or the operator could control the gimbal during the survey. After the primary control reset, the GCS requests control again since no one else is in control and thus can interfere with the survey or mission.

The logic was changed in https://github.com/PX4/PX4-Autopilot/pull/19000 and before this PR, these commands are just ignored and don't cause a reset.

@julianoes Do you think this change is okay or would it break the gimbal logic in another scenario?

Furthermore, the `update_result` in https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/gimbal/input_mavlink.cpp#L518 might be changed multiple times if more than one topic was updated. As a result, the returned `UpdateResult` might not be correct, depending on timing and order. I just thought about this when going through the code but didn't make a change. 

### Solution
With this PR, the primary control remains with the component that requested it last if updates from a not active component are received.

### Alternatives
- Document the control reset in the gimbal protocol specification, but I don't think this is intended.
- Preserve the primary control in another way.

### Test coverage
Tested in SIH on FMU v5x with a MAVLink gimbal protocol v2 input.

### Context

