### PR TITLE
Add separate precision landing library. 

### DIFF
--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -46,6 +46,7 @@ px4_add_module(
 		takeoff.cpp
 		land.cpp
 		precland.cpp
+		precland_mode.cpp
 		mission_feasibility_checker.cpp
 		geofence.cpp
 		vtol_takeoff.cpp

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -49,6 +49,7 @@
 #include "mission_block.h"
 #include "mission_feasibility_checker.h"
 #include "navigator_mode.h"
+#include "precland.h"
 
 #include <float.h>
 
@@ -269,6 +270,8 @@ private:
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
 	hrt_abstime _time_mission_deactivated{0};
+
+	PrecLand _precland;
 
 	enum {
 		MISSION_TYPE_NONE,

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -43,7 +43,7 @@
 
 #include "geofence.h"
 #include "land.h"
-#include "precland.h"
+#include "precland_mode.h"
 #include "loiter.h"
 #include "mission.h"
 #include "navigator_mode.h"
@@ -171,8 +171,6 @@ public:
 	vehicle_land_detected_s     *get_land_detected() { return &_land_detected; }
 	vehicle_local_position_s    *get_local_position() { return &_local_pos; }
 	vehicle_status_s            *get_vstatus() { return &_vstatus; }
-
-	PrecLand *get_precland() { return &_precland; } /**< allow others, e.g. Mission, to use the precision land block */
 
 	const vehicle_roi_s &get_vroi() { return _vroi; }
 
@@ -391,7 +389,7 @@ private:
 	Takeoff		_takeoff;			/**< class for handling takeoff commands */
 	VtolTakeoff	_vtol_takeoff;			/**< class for handling VEHICLE_CMD_NAV_VTOL_TAKEOFF command */
 	Land		_land;			/**< class for handling land commands */
-	PrecLand	_precland;			/**< class for handling precision land commands */
+	PrecLandMode	_precland;			/**< class for handling precision land commands */
 	RTL 		_rtl;				/**< class that handles RTL */
 
 	NavigatorMode *_navigation_mode{nullptr};	/**< abstract pointer to current navigation mode class */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -706,7 +706,7 @@ void Navigator::run()
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
 			_pos_sp_triplet_published_invalid_once = false;
 			navigation_mode_new = &_precland;
-			_precland.set_mode(PrecLandMode::Required);
+			_precland.set_mode(PrecLand::PrecLandMode::Required);
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_MANUAL:

--- a/src/modules/navigator/precland_mode.cpp
+++ b/src/modules/navigator/precland_mode.cpp
@@ -1,0 +1,101 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file precland_mode.cpp
+ *
+ * Helper class to do precision landing with a landing target
+ *
+ * @author Nicolas de Palezieux (Sunflower Labs) <ndepal@gmail.com>
+ */
+
+#include "precland_mode.h"
+#include "navigator.h"
+
+#include <uORB/topics/position_setpoint_triplet.h>
+
+PrecLandMode::PrecLandMode(Navigator *navigator) :
+	MissionBlock(navigator)
+{
+
+}
+
+void
+PrecLandMode::on_activation()
+{
+	_global_pos_sub.update();
+	// Get the landing position from current position_setpoint, else use the current vehicle position.
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+	PrecLand::LandingPosition2D approximate_landing_pos{ .lat = pos_sp_triplet->current.lat,
+			.lon = pos_sp_triplet->current.lon};
+
+	if (!pos_sp_triplet->current.valid) {
+		PX4_WARN("No valid landing position for precision landing. Using current position");
+		approximate_landing_pos.lat = _global_pos_sub.get().lat;
+		approximate_landing_pos.lon = _global_pos_sub.get().lon;
+	}
+
+	_prec_land.initialize(approximate_landing_pos);
+}
+
+void
+PrecLandMode::on_active()
+{
+	_local_pos_sub.update();
+
+	_prec_land.setAcceptanceRadius(_navigator->get_acceptance_radius());
+	_prec_land.update();
+
+	PrecLand::Output prec_land_output{_prec_land.getOutput()};
+
+	_mission_item.nav_cmd = prec_land_output.nav_cmd;
+	_mission_item.lat = prec_land_output.pos_hor.lat;
+	_mission_item.lon = prec_land_output.pos_hor.lon;
+	_mission_item.altitude = prec_land_output.alt;
+	_mission_item.altitude_is_relative = false;
+	_mission_item.yaw = _local_pos_sub.get().heading;
+
+
+	mission_apply_limitation(_mission_item);
+
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+	pos_sp_triplet->previous.valid = false;
+	pos_sp_triplet->next.valid = false;
+
+	if (mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current)) {
+		_navigator->set_position_setpoint_triplet_updated();
+	}
+
+}
+
+

--- a/src/modules/navigator/precland_mode.h
+++ b/src/modules/navigator/precland_mode.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file preclandMode.h
+ *
+ * Helper class to do precision landing with a landing target
+ *
+ * @author Nicolas de Palezieux (Sunflower Labs) <ndepal@gmail.com>
+ */
+
+#pragma once
+
+#include "mission_block.h"
+#include "precland.h"
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_global_position.h>
+
+class PrecLandMode : public MissionBlock
+{
+public:
+	PrecLandMode(Navigator *navigator);
+	~PrecLandMode() override = default;
+
+	void on_activation() override;
+	void on_active() override;
+
+	void set_mode(PrecLand::PrecLandMode mode) { _prec_land.setMode(mode); };
+
+	PrecLand::PrecLandMode get_mode() { return _prec_land.getMode(); };
+private:
+	PrecLand _prec_land;
+
+	uORB::SubscriptionData<vehicle_local_position_s> _local_pos_sub{ORB_ID(vehicle_local_position)};
+	uORB::SubscriptionData<vehicle_global_position_s> _global_pos_sub{ORB_ID(vehicle_global_position)};
+};
+
+

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -45,6 +45,7 @@
 
 #include "navigator_mode.h"
 #include "mission_block.h"
+#include "precland.h"
 
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/home_position.h>
@@ -118,6 +119,8 @@ private:
 
 	void set_rtl_item();
 
+	void set_prec_land_item();
+
 	void advance_rtl();
 
 	float calculate_return_alt_from_cone_half_angle(float cone_half_angle_deg);
@@ -134,6 +137,8 @@ private:
 	float getHoverLandSpeed();
 
 	RTLState _rtl_state{RTL_STATE_NONE};
+
+	PrecLand _precland;
 
 	struct RTLPosition {
 		double lat;


### PR DESCRIPTION
### Solved Problem
Rearranged handling of the precision landing in the navigator. Precision landing was implemented as a separate mode in the navigator. However, other modes (Mission/RTL) also used the Precision landing mode class if necessary. This would lead to strange behaviour in the code, when the e.g. mission mode would execute the precision landing on_active function when the mission mode was active, while the navigator in the same time would also call the on_inactive function of the precision land.

### Solution
Rearranged the precision landing logic into a separate library. Mission/RTL/recision landing mode use the precision landing library separately.

### Test coverage
- So far no teting due to lack of precision landing capabilities.

### Context
Related links, screenshot before/after, video
