### PR TITLE
fixed-wing attitude control: add option to disable manual yaw

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -549,9 +549,9 @@ void FixedwingAttitudeControl::Run()
 						}
 					}
 
-					/* add yaw rate setpoint from sticks in Stabilized mode */
+					/* add yaw rate setpoint from sticks in all attitude-controlled modes */
 					if (_vcontrol_mode.flag_control_manual_enabled) {
-						body_rates_setpoint(2) += math::constrain(_manual_control_setpoint.r * radians(_param_fw_y_rmax.get()),
+						body_rates_setpoint(2) += math::constrain(_manual_control_setpoint.r * radians(_param_fw_man_yr_max.get()),
 									  -radians(_param_fw_y_rmax.get()), radians(_param_fw_y_rmax.get()));
 					}
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -551,7 +551,6 @@ void FixedwingAttitudeControl::Run()
 
 					/* add yaw rate setpoint from sticks in Stabilized mode */
 					if (_vcontrol_mode.flag_control_manual_enabled) {
-						_actuator_controls.control[actuator_controls_s::INDEX_YAW] += _manual_control_setpoint.r;
 						body_rates_setpoint(2) += math::constrain(_manual_control_setpoint.r * radians(_param_fw_y_rmax.get()),
 									  -radians(_param_fw_y_rmax.get()), radians(_param_fw_y_rmax.get()));
 					}

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -240,7 +240,9 @@ private:
 
 		(ParamFloat<px4::params::TRIM_PITCH>) _param_trim_pitch,
 		(ParamFloat<px4::params::TRIM_ROLL>) _param_trim_roll,
-		(ParamFloat<px4::params::TRIM_YAW>) _param_trim_yaw
+		(ParamFloat<px4::params::TRIM_YAW>) _param_trim_yaw,
+
+		(ParamFloat<px4::params::FW_MAN_YR_MAX>) _param_fw_man_yr_max
 	)
 
 	ECL_RollController		_roll_ctrl;

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -805,3 +805,18 @@ PARAM_DEFINE_FLOAT(FW_SPOILERS_DESC, 0.f);
  * @group FW Attitude Control
  */
 PARAM_DEFINE_INT32(FW_SPOILERS_MAN, 0);
+
+/**
+ * Maximum manually added yaw rate
+ *
+ * This is the maximally added yaw rate setpoint from the yaw stick in any attitude controlled flight mode.
+ * The controller already generates a yaw rate setpoint to coordinate a turn, and this value is added to it.
+ * This is an absolute value, which is applied symmetrically to the negative and positive side.
+ *
+ * @unit deg/s
+ * @min 0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW Attitude Control
+ */
+PARAM_DEFINE_FLOAT(FW_MAN_YR_MAX, 30.f);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
- yaw stick still maps directly to actuator_controls[YAW] (seems to have been an oversight in https://github.com/PX4/PX4-Autopilot/pull/19912/commits/8372a78507f70a47ced64404250075f806c5aa22)
- not possible to disable manual yawing if not desired
 
### Solution
- remove direct stick-->controls, only change body_rates_setpoint(2) which is then fed into the controller. Note: body_rates_setpoint(2) is previously calculated by the attitude controller for turn coordination. 
- introduce FW_YR_MAX_ADD param and use instead of FW_Y_RMAX to set the effect of the stick to the rate setpoint. If no effect is desired, it can be set to 0. 

### Alternatives
We could also completely disable it in any attitude controlled mode?

### Test coverage
SITL tested.
