### PR TITLE
Apply RC calibration using using the interpolate function

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -160,8 +160,8 @@ const T interpolate(const T &value, const T &x_low, const T &x_high, const T &y_
 	} else {
 		/* linear function between the two points */
 		T a = (y_high - y_low) / (x_high - x_low);
-		T b = y_low - a * x_low;
-		return  a * value + b;
+		T b = y_low - (a * x_low);
+		return (a * value) + b;
 	}
 }
 

--- a/src/lib/mathlib/math/FunctionsTest.cpp
+++ b/src/lib/mathlib/math/FunctionsTest.cpp
@@ -172,7 +172,7 @@ TEST(FunctionsTest, interpolate)
 	// corner case when y_low > y_high
 	EXPECT_FLOAT_EQ(interpolate(1.5f, 1.f, 2.f, 6.f, 4.f), 5.f);
 
-	// corner case when x_low == x_high ==  y_low == y_high == 0.f
+	// corner case when x_low == x_high == y_low == y_high == 0.f
 	EXPECT_FLOAT_EQ(interpolate(0.f, 0.f, 0.f, 0.f, 0.f), 0.f);
 }
 


### PR DESCRIPTION
### Solved Problem
When working on https://github.com/PX4/PX4-Autopilot/pull/15949 I found that the RC scaling is pretty hard to go through in detail and I recently extended the interpolate function to arbitrary many support points including unit tests for exactly these piece-wise linear cases in various places in the code.

### Solution
- Some explicit bracketing in the function
- Refactor `rc_update` to use the `interpolateNXY()` function

### Test coverage
- Unit/integration test: The interpolate function has unit tests for a normal use case and the `interpolate()` function which is used for all the pieces has tests for all the corner cases where support point have no distance between them.
- Simulation/hardware testing logs: I tested this on a pixhawk 4 mini with Crossfire coming in as SBUS and the calibration values including deadzone do exactly what they are supposed to do even when setting the dezone bigger than the value range.