### PR TITLE
cmake: Add debug symbols to the .px4 file

### DIFF
--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -51,17 +51,19 @@ import subprocess
 #
 def mkdesc():
 	proto = {}
-	proto['magic']		= "PX4FWv1"
-	proto['board_id']	= 0
-	proto['board_revision']	= 0
-	proto['version']	= ""
-	proto['summary']	= ""
-	proto['description']	= ""
-	proto['git_identity']	= "" # git tag
-	proto['git_hash']	= "" # git commit hash
-	proto['build_time']	= 0
-	proto['image']		= bytes()
-	proto['image_size']	= 0
+	proto['magic']		     = "PX4FWv1"
+	proto['board_id']	     = 0
+	proto['board_revision']	     = 0
+	proto['version']	     = ""
+	proto['summary']	     = ""
+	proto['description']	     = ""
+	proto['git_identity']	     = "" # git tag
+	proto['git_hash']	     = "" # git commit hash
+	proto['build_time']	     = 0
+	proto['image']		     = bytes()
+	proto['image_size']	     = 0
+	proto['debug_symbols']       = bytes()
+	proto['debug_symbols_size']  = bytes()
 	return proto
 
 # Parse commandline
@@ -76,6 +78,7 @@ parser.add_argument("--git_identity",	action="store", help="the working director
 parser.add_argument("--parameter_xml",	action="store", help="the parameters.xml file")
 parser.add_argument("--airframe_xml",	action="store", help="the airframes.xml file")
 parser.add_argument("--image",		action="store", help="the firmware image")
+parser.add_argument("--debug_symbols",	action="store", help="the firmware debug symbols")
 args = parser.parse_args()
 
 # Fetch the firmware descriptor prototype if specified
@@ -123,5 +126,10 @@ if args.image != None:
 	bytes = f.read()
 	desc['image_size'] = len(bytes)
 	desc['image'] = base64.b64encode(zlib.compress(bytes,9)).decode('utf-8')
+if args.debug_symbols != None:
+	f = open(args.debug_symbols, "rb")
+	bytes = f.read()
+	desc['debug_symbols_size'] = len(bytes)
+	desc['debug_symbols'] = base64.b64encode(zlib.compress(bytes,9)).decode('utf-8')
 
 print(json.dumps(desc, indent=4))

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -148,6 +148,8 @@ else()
 	set(PX4_BINARY_OUTPUT ${PX4_BINARY_DIR_REL}/${PX4_CONFIG}.bin)
 endif()
 
+set(PX4_DEBUG_SYMBOLS_OUTPUT ${PX4_BINARY_DIR_REL}/${PX4_CONFIG}.dbg)
+
 if (NOT CONFIG_BUILD_FLAT)
 
 	target_link_libraries(nuttx_karch
@@ -237,6 +239,7 @@ if (NOT CONFIG_BUILD_FLAT)
 		COMMAND ${CMAKE_OBJCOPY} --gap-fill 0xFF --pad-to ${CONFIG_NUTTX_USERSPACE} -O binary ${PX4_BINARY_DIR_REL}/${KERNEL_NAME} ${PX4_BINARY_OUTPUT}
 		COMMAND cat ${PX4_BINARY_DIR_REL}/${PX4_BOARD}_user.bin >> ${PX4_BINARY_OUTPUT}
 
+		COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_DEBUG_SYMBOLS_OUTPUT}
 		DEPENDS px4 px4_kernel
 	)
 
@@ -291,6 +294,7 @@ else()
 
 	add_custom_command(OUTPUT ${PX4_BINARY_OUTPUT}
 		COMMAND ${CMAKE_OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_OUTPUT}
+		COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_DEBUG_SYMBOLS_OUTPUT}
 		DEPENDS px4
 	)
 
@@ -309,7 +313,8 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 				--git_identity ${PX4_SOURCE_DIR}
 				--parameter_xml ${PX4_BINARY_DIR}/parameters.xml
 				--airframe_xml ${PX4_BINARY_DIR}/airframes.xml
-				--image ${PX4_BINARY_DIR}/${PX4_CONFIG}.bin > ${fw_package}
+				--image ${PX4_BINARY_DIR}/${PX4_CONFIG}.bin
+				--debug_symbols ${PX4_BINARY_DIR}/${PX4_CONFIG}.dbg > ${fw_package}
 		DEPENDS
 			${PX4_BINARY_DIR}/${PX4_CONFIG}.bin
 			airframes_xml


### PR DESCRIPTION
This keeps the correct debug symbols tightly matched to every build. This prevents losing debug symbols for a specific build for later debugging.

### Solved Problem

We observed that when building and releasing PX4 artifacts, most of the time just the `.px4` file is retained, but not the corresponding `.elf` file. Even when the `.elf` file is retained, confusion easily occurs which elf file corresponds to which binary, making debugging harder.

### Solution
This includes debug symbols into the `.px4` file. This ensures that the debug symbols are always tighly retained with the build.

### Note

This increases the `.px4` file size from ~2MB to ~22MB. It could be reduced to ~15 MB by using xz instead of zlib, at the expense of longer compression time.
