### PR TITLE
fix pwm_out, px4io: prevent disarm and rate param updates during boot 

### DIFF
--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -190,6 +190,7 @@ void PWMOut::Run()
 	_mixing_output.updateSubscriptions(true);
 
 	perf_end(_cycle_perf);
+	_first_update_cycle = false;
 }
 
 int PWMOut::task_spawn(int argc, char *argv[])
@@ -218,7 +219,7 @@ void PWMOut::update_params()
 	updateParams();
 
 	// Automatically set the PWM rate and disarmed value when a channel is first set to a servo
-	if (!_first_param_update) {
+	if (!_first_update_cycle) {
 		for (size_t i = 0; i < _num_outputs; i++) {
 			if ((previously_set_functions & (1u << i)) == 0 && _mixing_output.functionParamHandle(i) != PARAM_INVALID) {
 				int32_t output_function;
@@ -257,8 +258,6 @@ void PWMOut::update_params()
 			}
 		}
 	}
-
-	_first_param_update = false;
 }
 
 int PWMOut::custom_command(int argc, char *argv[])

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -187,7 +187,7 @@ void PWMOut::Run()
 	}
 
 	// check at end of cycle (updateSubscriptions() can potentially change to a different WorkQueue thread)
-	_mixing_output.updateSubscriptions(true, true);
+	_mixing_output.updateSubscriptions(true);
 
 	perf_end(_cycle_perf);
 }

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -91,7 +91,7 @@ private:
 	bool		_pwm_on{false};
 	uint32_t	_pwm_mask{0};
 	bool		_pwm_initialized{false};
-	bool		_first_param_update{true};
+	bool		_first_update_cycle{true};
 
 	perf_counter_t	_cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 	perf_counter_t	_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": interval")};

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -633,11 +633,11 @@ void PX4IO::Run()
 		}
 	}
 
-	_mixing_output.updateSubscriptions(true, true);
-
 	// minimal backup scheduling
 	ScheduleDelayed(20_ms);
 
+	// check at end of cycle (updateSubscriptions() can potentially change to a different WorkQueue thread)
+	_mixing_output.updateSubscriptions(true);
 	perf_end(_cycle_perf);
 }
 

--- a/src/drivers/tap_esc/TAP_ESC.cpp
+++ b/src/drivers/tap_esc/TAP_ESC.cpp
@@ -404,7 +404,7 @@ void TAP_ESC::Run()
 	}
 
 	// check at end of cycle (updateSubscriptions() can potentially change to a different WorkQueue thread)
-	_mixing_output.updateSubscriptions(true, true);
+	_mixing_output.updateSubscriptions(true);
 
 	perf_end(_cycle_perf);
 }

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -212,7 +212,7 @@ void MixingOutput::cleanupFunctions()
 	}
 }
 
-bool MixingOutput::updateSubscriptions(bool allow_wq_switch, bool limit_callbacks_to_primary)
+bool MixingOutput::updateSubscriptions(bool allow_wq_switch)
 {
 	if (!_need_function_update || _armed.armed) {
 		return false;

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -151,10 +151,9 @@ public:
 	 * Check for subscription updates.
 	 * Call this at the very end of Run() if allow_wq_switch
 	 * @param allow_wq_switch if true
-	 * @param limit_callbacks_to_primary set to only register callbacks for primary actuator controls (if used)
 	 * @return true if subscriptions got changed
 	 */
-	bool updateSubscriptions(bool allow_wq_switch = false, bool limit_callbacks_to_primary = false);
+	bool updateSubscriptions(bool allow_wq_switch = false);
 
 	/**
 	 * unregister uORB subscription callbacks


### PR DESCRIPTION
Before, the logic to update disarm and rate values also triggered during
bootup on the px4io, because the output functions are only set in
updateSubscriptions().
Therefore change the check to prevent updating during the first cycle.

@sfuhrer @ryanjAA 