### PR TITLE
battery: allow for external state of charge injection

### DIFF
--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -88,6 +88,7 @@ public:
 
 	void setPriority(const uint8_t priority) { _priority = priority; }
 	void setConnected(const bool connected) { _connected = connected; }
+	void setStateOfCharge(const float soc) { _state_of_charge = soc; _external_state_of_charge = true; }
 	void updateVoltage(const float voltage_v);
 	void updateCurrent(const float current_a);
 
@@ -144,7 +145,8 @@ protected:
 
 private:
 	void sumDischarged(const hrt_abstime &timestamp, float current_a);
-	void estimateStateOfCharge(const float voltage_v, const float current_a);
+	float calculateStateOfChargeVoltageBased(const float voltage_v, const float current_a);
+	void estimateStateOfCharge();
 	uint8_t determineWarning(float state_of_charge);
 	void computeScale();
 	float computeRemainingTime(float current_a);
@@ -152,6 +154,8 @@ private:
 	uORB::Subscription _actuator_controls_0_sub{ORB_ID(actuator_controls_0)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
+
+	bool _external_state_of_charge{false}; ///< inticates that the soc is injected and not updated by this library
 
 	bool _connected{false};
 	const uint8_t _source;


### PR DESCRIPTION
### Solved Problem
When implementing a smart battery driver I found that just overwriting the state of charge in the battery message doesn't update the battery class so if I want to use that class and benefit from not duplicating things there needs to be an explicit way to externally inject the known state of charge from the smart battery.

### Solution
- Add possiblity to inject a known state of charge without interfering with the battery class internal calculations but leveraging e.g. existing battery warnings.

### Test coverage
This was tested with a very custom smart battery driver to work as expected.

### Context
This should also be used for UAVCAN power module and smart battery support 👀 
