### PR TITLE
GyroCalibration: consider updated temperature compensation offset

### DIFF
--- a/src/modules/gyro_calibration/GyroCalibration.cpp
+++ b/src/modules/gyro_calibration/GyroCalibration.cpp
@@ -147,6 +147,7 @@ void GyroCalibration::Run()
 			}
 
 			if (_gyro_calibration[gyro].device_id() == sensor_gyro.device_id) {
+				_gyro_calibration[gyro].SensorCorrectionsUpdate();
 				const Vector3f val{Vector3f{sensor_gyro.x, sensor_gyro.y, sensor_gyro.z} - _gyro_calibration[gyro].thermal_offset()};
 				_gyro_mean[gyro].update(val);
 				_gyro_last_update[gyro] = sensor_gyro.timestamp;

--- a/src/modules/temperature_compensation/temperature_calibration/accel.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/accel.cpp
@@ -225,5 +225,16 @@ int TemperatureCalibrationAccel::finish_sensor_instance(PerSensorData &data, int
 	set_parameter("TC_A%d_TMAX", sensor_index, &data.high_temp);
 	set_parameter("TC_A%d_TMIN", sensor_index, &data.low_temp);
 	set_parameter("TC_A%d_TREF", sensor_index, &data.ref_temp);
+
+	// reset current calibration (covered by TC parameters)
+	float offset = 0.0f;
+	float scale = 1.0f;
+	set_parameter("CAL_ACC%u_XOFF", sensor_index, &offset);
+	set_parameter("CAL_ACC%u_YOFF", sensor_index, &offset);
+	set_parameter("CAL_ACC%u_ZOFF", sensor_index, &offset);
+	set_parameter("CAL_ACC%u_XSCALE", sensor_index, &scale);
+	set_parameter("CAL_ACC%u_YSCALE", sensor_index, &scale);
+	set_parameter("CAL_ACC%u_ZSCALE", sensor_index, &scale);
+
 	return 0;
 }

--- a/src/modules/temperature_compensation/temperature_calibration/baro.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/baro.cpp
@@ -209,5 +209,10 @@ int TemperatureCalibrationBaro::finish_sensor_instance(PerSensorData &data, int 
 	set_parameter("TC_B%d_TMAX", sensor_index, &data.high_temp);
 	set_parameter("TC_B%d_TMIN", sensor_index, &data.low_temp);
 	set_parameter("TC_B%d_TREF", sensor_index, &data.ref_temp);
+
+	// reset current calibration (covered by TC parameters)
+	float offset = 0.0f;
+	set_parameter("CAL_BARO%u_OFF", sensor_index, &offset);
+
 	return 0;
 }

--- a/src/modules/temperature_compensation/temperature_calibration/gyro.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/gyro.cpp
@@ -211,5 +211,11 @@ int TemperatureCalibrationGyro::finish_sensor_instance(PerSensorData &data, int 
 	set_parameter("TC_G%d_TMIN", sensor_index, &data.low_temp);
 	set_parameter("TC_G%d_TREF", sensor_index, &data.ref_temp);
 
+	// reset current calibration (covered by TC parameters)
+	float offset = 0.0f;
+	set_parameter("CAL_GYRO%u_XOFF", sensor_index, &offset);
+	set_parameter("CAL_GYRO%u_YOFF", sensor_index, &offset);
+	set_parameter("CAL_GYRO%u_ZOFF", sensor_index, &offset);
+
 	return 0;
 }


### PR DESCRIPTION
### Solved Problem
When temperature compensation is active, it happened that the sensor offset was compensated twice because the `GyroCalibration` "auto-calibration" was not considering the new thermal offset when updating the calibration.

Also reset the offset and scale parameters as the thermal calibration does not consider those values when gathering data.

### Test coverage
bench tests on Pixhawk5