### PR TITLE
Fix invalid offboard setpoints for fw pos control

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -2216,13 +2216,12 @@ FixedwingPositionControl::Run()
 					}
 				}
 
+				_position_setpoint_current_valid = valid_setpoint;
+
 				if (!valid_setpoint) {
 					mavlink_log_critical(&_mavlink_log_pub, "Invalid offboard setpoint\t");
 					events::send(events::ID("fixedwing_position_control_invalid_offboard_sp"), events::Log::Error,
 						     "Invalid offboard setpoint");
-
-				} else {
-					_pos_sp_triplet.current.valid = valid_setpoint;
 				}
 			}
 


### PR DESCRIPTION
### Solved Problem
This commit fixes a regression that caused problems when trying to use offboard control with fixedwings (or VTOLs in fixedwing mode)

The problem was that all offboard setpoints were considered invalid in offboard mode:
![image](https://user-images.githubusercontent.com/5248102/203829851-55e1195d-9498-44be-aa6e-1e67db5f7ae5.png)
![image](https://user-images.githubusercontent.com/5248102/203829872-ccfb20a0-c004-4592-bbfe-f7160d51c7bd.png)

### Solution
This was a regression introduced by https://github.com/PX4/PX4-Autopilot/pull/19942, where the valid flag in position_setpoint_triplet was no longer being used and the offboard logic was left out.

### Test coverage
Tested in SITL Gazebo and publishing offboard setpoints
- Flight logs before PR: https://review.px4.io/plot_app?log=b46b490c-69f8-4fe1-a47f-b16fc6ab8b54
- Flight logs after PR: https://review.px4.io/plot_app?log=ced912ac-1b8d-427e-8829-90337d208482
