### PR TITLE
Add jlink-nuttx build command for gdb helper for multi-task debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ GTAGS
 *.files
 *.includes
 
+Tools/jlink-nuttx.so
+
 # CLion ignores
 .idea
 cmake-build-*/

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,10 @@ px4io_update:
 	cp build/cubepilot_io-v2_default/cubepilot_io-v2_default.bin boards/cubepilot/cubeyellow/extras/cubepilot_io-v2_default.bin
 	git status
 
+jlink-nuttx:
+	$(CC) -shared -fPIC platforms/nuttx/NuttX/nuttx/tools/jlink-nuttx.c -o Tools/jlink-nuttx.so
+
+
 bootloaders_update: ark_fmu-v6x_bootloader cuav_nora_bootloader cuav_x7pro_bootloader cubepilot_cubeorange_bootloader holybro_durandal-v1_bootloader holybro_kakuteh7_bootloader matek_h743_bootloader matek_h743-mini_bootloader matek_h743-slim_bootloader modalai_fc-v2_bootloader mro_ctrl-zero-classic_bootloader mro_ctrl-zero-h7_bootloader mro_ctrl-zero-h7-oem_bootloader mro_pixracerpro_bootloader px4_fmu-v6c_bootloader px4_fmu-v6u_bootloader px4_fmu-v6x_bootloader
 	git status
 


### PR DESCRIPTION
Adds make jlink-nuttx command that builds GDB Segger jlink-nuttx.so plugin for task-aware debugging.

To enable multi-task debugging you've enable `CONFIG_DEBUG_TCBINFO` in your NuttX config to expose the TCB offsets.

To enable multi-task debugging in your segger debugger you've add the following line to the SEGGER GDB commandline options
`-rtos /home/peter/src/Firmware/Tools/jlink-nuttx.so`