### PR TITLE
VTOL: use spoilers also in NAVIGATION_STATE_DESCEND

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -152,6 +152,7 @@ public:
 	struct vehicle_torque_setpoint_s 		*get_torque_setpoint_1() {return &_torque_setpoint_1;}
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_0() {return &_thrust_setpoint_0;}
 	struct vehicle_thrust_setpoint_s 		*get_thrust_setpoint_1() {return &_thrust_setpoint_1;}
+	struct vehicle_status_s				*get_vehicle_status() {return &_vehicle_status;}
 	struct vtol_vehicle_status_s			*get_vtol_vehicle_status() {return &_vtol_vehicle_status;}
 
 private:

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -379,8 +379,9 @@ float VtolType::pusher_assist()
 
 	float pitch_setpoint_min = math::radians(_param_vt_pitch_min.get());
 
-	if (_attc->get_pos_sp_triplet()->current.valid
-	    && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	if ((_attc->get_pos_sp_triplet()->current.valid
+	     && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND)
+	    || _attc->get_vehicle_status()->nav_state == vehicle_status_s::NAVIGATION_STATE_DESCEND) {
 		pitch_setpoint_min = math::radians(
 					     _param_vt_lnd_pitch_min.get()); // set min pitch during LAND (usually lower to generate less lift)
 	}

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -109,8 +109,9 @@ void VtolType::update_mc_state()
 
 	float spoiler_setpoint_hover = 0.f;
 
-	if (_attc->get_pos_sp_triplet()->current.valid
-	    && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	if ((_attc->get_pos_sp_triplet()->current.valid
+	     && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND)
+	    || _attc->get_vehicle_status()->nav_state == vehicle_status_s::NAVIGATION_STATE_DESCEND) {
 		spoiler_setpoint_hover = _param_vt_spoiler_mc_ld.get();
 	}
 


### PR DESCRIPTION
### Solved Problem
@sfuhrer I realised that https://github.com/PX4/PX4-Autopilot/pull/19329 only adds spoilers for VTOLs when in Land mode (or equivalent part in mission / RTL), but not in its fallback mode NAVIGATION_STATE_DESCEND in case of lost global position estimate.

As far as I'm concerned the main goal of DESCEND mode is to get the drone down as fast as possible, so I'd say anything that helps the drone descend is good.

### Solution
- use spoilers also in NAVIGATION_STATE_DESCEND

### Test coverage

I couldn't find out just yet how to add the Spoiler channel to the ailerons with the Control Allocation. I didn't manage with QGC in any case.

I did test on v1.13, however : https://logs.px4.io/plot_app?log=907d9abc-d0c3-4334-a384-02dd45c56d90


