### PR TITLE
Horizontal velocity parameter description clarifications

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -65,7 +65,6 @@ param set-default COM_SPOOLUP_TIME 1.5
 param set-default MPC_THR_HOVER 0.45
 param set-default MPC_TILTMAX_AIR 25
 param set-default MPC_TKO_RAMP_T 1.8
-param set-default MPC_VEL_MANUAL 3
 param set-default MPC_XY_CRUISE 3
 param set-default MPC_XY_VEL_MAX 3.5
 param set-default MPC_YAWRAUTO_MAX 40

--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -63,7 +63,6 @@ param set-default MPC_ACC_UP_MAX 4
 param set-default MPC_MAN_Y_MAX 120
 param set-default MPC_TILTMAX_AIR 45
 param set-default MPC_THR_HOVER 0.3
-param set-default MPC_VEL_MANUAL 5
 param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_VEL_MAX 5
 param set-default MPC_XY_VEL_P_ACC 1.58

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -64,7 +64,6 @@ param set-default MPC_MANTHR_MIN 0
 param set-default MPC_MAN_Y_MAX 120
 param set-default MPC_TILTMAX_AIR 45
 param set-default MPC_THR_HOVER 0.3
-param set-default MPC_VEL_MANUAL 5
 param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_VEL_MAX 5
 param set-default MPC_XY_VEL_P_ACC 1.58

--- a/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
@@ -53,7 +53,6 @@ param set-default MPC_XY_VEL_P_ACC 2.6
 param set-default MPC_XY_VEL_I_ACC 1.2
 param set-default MPC_XY_VEL_D_ACC 0.2
 param set-default MPC_TKO_RAMP_T 1
-param set-default MPC_VEL_MANUAL 3
 
 param set-default BAT1_SOURCE 0
 param set-default BAT1_N_CELLS 4

--- a/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
+++ b/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
@@ -62,7 +62,6 @@ param set-default MPC_XY_VEL_P_ACC 2.6
 param set-default MPC_XY_VEL_I_ACC 1.2
 param set-default MPC_XY_VEL_D_ACC 0.2
 param set-default MPC_TKO_RAMP_T 1
-param set-default MPC_VEL_MANUAL 3
 
 param set-default BAT1_SOURCE 0
 param set-default BAT1_N_CELLS 4

--- a/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
+++ b/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
@@ -51,7 +51,6 @@ param set-default MPC_XY_VEL_I_ACC 0.4
 param set-default MPC_XY_VEL_D_ACC 0.2
 # etc gains
 param set-default MPC_TKO_RAMP_T 0.4
-param set-default MPC_VEL_MANUAL 5
 
 # Filter settings
 param set-default IMU_DGYRO_CUTOFF 90

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -307,9 +307,12 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I_ACC, 0.4f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_D_ACC, 0.2f);
 
 /**
- * Default horizontal velocity in mission
+ * Default autonomous horizontal velocity
  *
- * Horizontal velocity used when flying autonomously in e.g. Missions, RTL, Goto.
+ * Default horizontal velocity used when flying autonomously in e.g. Missions, RTL, Goto.
+ * This can be overriden by e.g. mission velocity or MAV_CMD_DO_CHANGE_SPEED.
+ *
+ * Set lower than MPC_XY_VEL_MAX
  *
  * @unit m/s
  * @min 3.0
@@ -351,11 +354,10 @@ PARAM_DEFINE_FLOAT(MPC_XY_ERR_MAX, 2.0f);
 /**
  * Maximum horizontal velocity setpoint in Position mode
  *
- * If velocity setpoint larger than MPC_XY_VEL_MAX is set, then
- * the setpoint will be capped to MPC_XY_VEL_MAX
- *
  * The maximum sideways and backward speed can be set differently
  * using MPC_VEL_MAN_SIDE and MPC_VEL_MAN_BACK, respectively.
+ *
+ * Set lower than MPC_XY_VEL_MAX
  *
  * @unit m/s
  * @min 3.0
@@ -399,8 +401,10 @@ PARAM_DEFINE_FLOAT(MPC_VEL_MAN_BACK, -1.0f);
 /**
  * Maximum horizontal velocity
  *
- * Maximum horizontal velocity in AUTO mode. If higher speeds
- * are commanded in a mission they will be capped to this velocity.
+ * Absolute maximum allowed horizontal velocity in any velocity controlled mode.
+ * If higher speeds are commanded they will be capped to this maximum.
+ *
+ * Set higher than MPC_VEL_MANUAL, MPC_XY_CRUISE
  *
  * @unit m/s
  * @min 0.0


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When talking to users I found that the descriptions require additional clarification.

### Solution
- Instead of repeating myself I'd like to improve the parameter documentation.
- While at it I found that some airframes set arbitrary low speeds even though racers frames can easily reach the 10m/s default and for VTOLs there is already a spcific default of 5m/s.

### Test coverage
Please review, I cannot test this.

### Context
My answer in a chat:
> `MPC_XY_VEL_MAX` is the absolute limit where the controller just clamps. You'd like to have that at the absolute maximum the vehicle can safely fly at least by some small margin higher than the expected operation.
> `MPC_VEL_MANUAL` what speed is reached when the user fully deflects the stick in position mode and waits for the maximum speed.
> `MPC_XY_CRUISE` default autonomous speed in e.g. mission if not specified, RTL, ...

