### PR TITLE
AirspeedValidator: change default of ASPD_DO_CHECKS

### DIFF
--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -118,7 +118,6 @@ public:
 	void set_enable_data_stuck_check(bool enable) { _data_stuck_check_enabled = enable; }
 	void set_enable_innovation_check(bool enable) { _innovation_check_enabled = enable; }
 	void set_enable_load_factor_check(bool enable) { _load_factor_check_enabled = enable; }
-	void set_enable_data_variation_check(bool enable) { _data_variation_check_enabled = enable; }
 
 private:
 
@@ -146,13 +145,6 @@ private:
 	bool _data_stuck_test_failed{false};
 	float _IAS_prev{0.f};
 	static constexpr uint64_t DATA_STUCK_TIMEOUT{2_s}; ///< timeout after which data stuck check triggers when data is flat
-
-	// variation check
-	bool _data_variation_test_failed{false};
-	static constexpr uint64_t VARIATION_CHECK_TIMEOUT{10_s}; ///< timeout to check for data variation after first data is received
-	hrt_abstime _time_first_data{0};
-	float _data_variation_check_ias_prev{0.f};
-	bool _variation_detected{false};
 
 	// states of innovation check
 	bool _innovations_check_failed{false};  ///< true when airspeed innovations have failed consistency checks
@@ -193,7 +185,6 @@ private:
 	void update_CAS_scale_applied();
 	void update_CAS_TAS(float air_pressure_pa, float air_temperature_celsius);
 	void check_airspeed_data_stuck(uint64_t timestamp);
-	void check_airspeed_data_variation(uint64_t timestamp);
 	void check_airspeed_innovation(uint64_t timestamp, float estimator_status_vel_test_ratio,
 				       float estimator_status_mag_test_ratio, const matrix::Vector3f &vI);
 	void check_load_factor(float accel_z);

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -162,8 +162,7 @@ private:
 		CHECK_TYPE_ONLY_DATA_MISSING_BIT = (1 << 0),
 		CHECK_TYPE_DATA_STUCK_BIT = (1 << 1),
 		CHECK_TYPE_INNOVATION_BIT = (1 << 2),
-		CHECK_TYPE_LOAD_FACTOR_BIT = (1 << 3),
-		CHECK_TYPE_DATA_VARIATION_BIT = (1 << 4)
+		CHECK_TYPE_LOAD_FACTOR_BIT = (1 << 3)
 	};
 
 	DEFINE_PARAMETERS(
@@ -480,8 +479,6 @@ void AirspeedModule::update_params()
 				CheckTypeBits::CHECK_TYPE_INNOVATION_BIT);
 		_airspeed_validator[i].set_enable_load_factor_check(_param_airspeed_checks_on.get() &
 				CheckTypeBits::CHECK_TYPE_LOAD_FACTOR_BIT);
-		_airspeed_validator[i].set_enable_data_variation_check(_param_airspeed_checks_on.get() &
-				CheckTypeBits::CHECK_TYPE_DATA_VARIATION_BIT);
 	}
 }
 

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -151,15 +151,14 @@ PARAM_DEFINE_INT32(ASPD_PRIMARY, 1);
  * Note that the data missing check is enabled if any of the options is set.
  *
  * @min 0
- * @max 31
+ * @max 15
  * @bit 0 Only data missing check (triggers if more than 1s no data)
  * @bit 1 Data stuck (triggers if data is exactly constant for 2s in FW mode)
  * @bit 2 Innovation check (see ASPD_FS_INNOV)
  * @bit 3 Load factor check (triggers if measurement is below stall speed)
- * @bit 4 Check for data variation in first 10s after sensor connection
  * @group Airspeed Validator
  */
-PARAM_DEFINE_INT32(ASPD_DO_CHECKS, 23);
+PARAM_DEFINE_INT32(ASPD_DO_CHECKS, 7);
 
 /**
  * Enable fallback to sensor-less airspeed estimation


### PR DESCRIPTION
By default disable the "data stuck" and "data variation after boot" checks. Those checks were introduced to catch the (unlikely) case of the driver publishing a stale value that is not actually from a current measurement. This was done by declaring it invalid if either there is no update in the data for 2s or no update within the first 10s after boot.
Practice though has shown that around 0, many airspeed sensors have such a low resolution that the reported airspeed value is often at the exact same value for longer periods of time on totally healthy sensors, and thus we trigger some false positive failure detections.
Given that this failure mode (driver publishing stale data) is quite rare (if it doesn't receive new data it should stop publishing), I disable this checks here by default. They can still be enabled if the sensor used doesn't have a very low resolution around 0.

Original contributions:
https://github.com/PX4/PX4-Autopilot/pull/18442
https://github.com/PX4/PX4-Autopilot/pull/20074

Cases where it triggered false positives:
![image](https://user-images.githubusercontent.com/26798987/204569462-dbb6bf8b-7ad0-4638-8356-879764eb6357.png)
![image](https://user-images.githubusercontent.com/26798987/204569772-286f68b8-874c-4dbb-a13c-b2eca75f2a20.png)


