### PR TITLE
ekf2: don't add invalid GNSS samples to the buffer

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -151,13 +151,16 @@ void EstimatorInterface::setGpsData(const gpsMessage &gps)
 
 	if (time_us >= static_cast<int64_t>(_gps_buffer->get_newest().time_us + _min_obs_interval_us)) {
 
+		if (!gps.vel_ned_valid) {
+			return;
+		}
+
 		gpsSample gps_sample_new;
 
 		gps_sample_new.time_us = time_us;
 
 		gps_sample_new.vel = gps.vel_ned;
 
-		_gps_speed_valid = gps.vel_ned_valid;
 		gps_sample_new.sacc = gps.sacc;
 		gps_sample_new.hacc = gps.eph;
 		gps_sample_new.vacc = gps.epv;

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -330,7 +330,6 @@ protected:
 	bool _initialised{false};      // true if the ekf interface instance (data buffering) is initialized
 
 	bool _NED_origin_initialised{false};
-	bool _gps_speed_valid{false};
 	float _gps_origin_eph{0.0f}; // horizontal position uncertainty of the GPS origin
 	float _gps_origin_epv{0.0f}; // vertical position uncertainty of the GPS origin
 	MapProjection _pos_ref{}; // Contains WGS-84 position latitude and longitude of the EKF origin


### PR DESCRIPTION
### Solved Problem
EKF2 never gives up on fusing GNSS data once the fusion started if there is no other horizontal aiding source available. The issue is that even if the receiver reports an invalid fix, the data is still used and the vehicle never goes into failsafe.

### Solution
Do not add an invalid GNSS sample to the buffer.

### Alternatives
Store this flag in the buffer and add it to the mandatory conditions in GPS_control

### Context
In SIH, when the GNSS fails, the eph and epv are increased, and the `vel_ned_valid` flag is set to `false` but the drone continues to fly in position or auto mode and drifts away.
