### PR TITLE
FW_AT_MAN_AUX - define what an Aux input is

### DIFF
--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control_params.c
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control_params.c
@@ -105,9 +105,9 @@ PARAM_DEFINE_INT32(FW_AT_APPLY, 2);
 PARAM_DEFINE_INT32(FW_AT_AXES, 3);
 
 /**
- * Enable auto tuning enable on aux input
+ * Enable auto tuning enable on an RC AUX input channel mapped by RC_MAP_AUXn
  *
- * Defines which aux input to enable auto tuning
+ * Defines the AUXn input (mapped by RC_MAP_AUXn) on which to enable auto tuning.
  *
  * @value 0 Disable
  * @value 1 Aux1

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control_params.c
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control_params.c
@@ -105,7 +105,7 @@ PARAM_DEFINE_INT32(FW_AT_APPLY, 2);
 PARAM_DEFINE_INT32(FW_AT_AXES, 3);
 
 /**
- * Enable auto tuning enable on an RC AUX input channel mapped by RC_MAP_AUXn
+ * Enable auto tuning enable on an RC AUX input
  *
  * Defines the AUXn input (mapped by RC_MAP_AUXn) on which to enable auto tuning.
  *

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control_params.c
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control_params.c
@@ -105,9 +105,9 @@ PARAM_DEFINE_INT32(FW_AT_APPLY, 2);
 PARAM_DEFINE_INT32(FW_AT_AXES, 3);
 
 /**
- * Enable auto tuning enable on an RC AUX input
+ * Enable/disable auto tuning using an RC AUX input
  *
- * Defines the AUXn input (mapped by RC_MAP_AUXn) on which to enable auto tuning.
+ * Defines which RC_MAP_AUXn parameter maps the RC channel used to enable/disable auto tuning.
  *
  * @value 0 Disable
  * @value 1 Aux1


### PR DESCRIPTION
The name "Aux input" is opaque unless you know what it is. I've tried to make it clear that this is a map to a channel defined in RC_MAP_AUXn

Relates to #2163