### PR TITLE
ekf2: do not use gnss data when no fix

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -151,7 +151,7 @@ void EstimatorInterface::setGpsData(const gpsMessage &gps)
 
 	if (time_us >= static_cast<int64_t>(_gps_buffer->get_newest().time_us + _min_obs_interval_us)) {
 
-		if (!gps.vel_ned_valid) {
+		if (!gps.vel_ned_valid || (gps.fix_type == 0)) {
 			return;
 		}
 


### PR DESCRIPTION
https://github.com/PX4/PX4-Autopilot/pull/20679 wasn't enough so this PR prevents from pushing a gnss sample to the buffer when there is no fix at all.