### PR TITLE
Manual control mode requirement for manual modes

### DIFF
--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -17,6 +17,7 @@ uint32 mode_req_offboard_signal
 uint32 mode_req_home_position
 uint32 mode_req_wind_and_flight_time_compliance # if set, mode cannot be entered if wind or flight time limit exceeded
 uint32 mode_req_prevent_arming    # if set, cannot arm while in this mode
+uint32 mode_req_manual_control
 uint32 mode_req_other             # other requirements, not covered above (for external modes)
 
 

--- a/src/modules/commander/HealthAndArmingChecks/Common.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/Common.hpp
@@ -246,6 +246,8 @@ public:
 	void armingCheckFailure(NavModes required_modes, HealthComponentIndex component, uint32_t event_id,
 				const events::LogLevels &log_levels, const char *message);
 
+	void clearArmingBits(NavModes modes);
+
 	/**
 	 * Clear can_run bits for certain modes. This will prevent mode switching and trigger failsafe if the
 	 * mode is being run.
@@ -301,8 +303,6 @@ private:
 			unsigned args_size);
 
 	NavModes reportedModes(NavModes required_modes);
-
-	void clearArmingBits(NavModes modes);
 
 	NavModes getModeGroup(uint8_t nav_state) const;
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
@@ -143,6 +143,21 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_home_position);
 	}
 
+	if (reporter.failsafeFlags().manual_control_signal_lost && reporter.failsafeFlags().mode_req_manual_control != 0) {
+		/* EVENT
+		 * @description
+		 * Connect and enable stick input or use autonomous mode.
+		 * <profile name="dev">
+		 * Sticks can be enabled via <param>COM_RC_IN_MODE</param> parameter.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure((NavModes)reporter.failsafeFlags().mode_req_manual_control,
+					    health_component_t::remote_control,
+					    events::ID("check_modes_manual_control"),
+					    events::Log::Critical, "No manual control input");
+		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_manual_control);
+	}
+
 	if (reporter.failsafeFlags().mode_req_other != 0) {
 		// Here we expect there is already an event reported for the failing check (this is for external modes)
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_other);

--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
@@ -144,6 +144,10 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 	}
 
 	if (reporter.failsafeFlags().manual_control_signal_lost && reporter.failsafeFlags().mode_req_manual_control != 0) {
+		const bool rc_disabled = (_param_com_rc_in_mode.get() == 4);
+		NavModes nav_modes = rc_disabled ? (NavModes)reporter.failsafeFlags().mode_req_manual_control : NavModes::None;
+		events::LogLevel log_level = rc_disabled ? events::Log::Error : events::Log::Warning;
+
 		/* EVENT
 		 * @description
 		 * Connect and enable stick input or use autonomous mode.
@@ -151,10 +155,11 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 		 * Sticks can be enabled via <param>COM_RC_IN_MODE</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure((NavModes)reporter.failsafeFlags().mode_req_manual_control,
+		reporter.armingCheckFailure(nav_modes,
 					    health_component_t::remote_control,
 					    events::ID("check_modes_manual_control"),
-					    events::Log::Critical, "No manual control input");
+					    log_level, "No manual control input");
+		reporter.clearArmingBits((NavModes)reporter.failsafeFlags().mode_req_manual_control);
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_manual_control);
 	}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.hpp
@@ -49,6 +49,7 @@ private:
 	void checkArmingRequirement(const Context &context, Report &reporter);
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_com_arm_mis_req
+					(ParamBool<px4::params::COM_ARM_MIS_REQ>) _param_com_arm_mis_req,
+					(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode
 				       );
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/rcAndDataLinkCheck.hpp
@@ -52,7 +52,6 @@ private:
 	hrt_abstime	_last_valid_manual_control_setpoint{0};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
 					(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 					(ParamInt<px4::params::NAV_DLL_ACT>) _param_nav_dll_act
 				       )

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -56,19 +56,23 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	flags.mode_req_home_position = 0;
 	flags.mode_req_wind_and_flight_time_compliance = 0;
 	flags.mode_req_prevent_arming = 0;
+	flags.mode_req_manual_control = 0;
 	flags.mode_req_other = 0;
 
 	// NAVIGATION_STATE_MANUAL
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_MANUAL, flags.mode_req_manual_control);
 
 	// NAVIGATION_STATE_ALTCTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ALTCTL, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ALTCTL, flags.mode_req_attitude);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ALTCTL, flags.mode_req_local_alt);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_ALTCTL, flags.mode_req_manual_control);
 
 	// NAVIGATION_STATE_POSCTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_attitude);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_local_position_relaxed);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_manual_control);
 
 	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
 		setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_global_position);
@@ -104,6 +108,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 
 	// NAVIGATION_STATE_ACRO
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ACRO, flags.mode_req_angular_velocity);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_ACRO, flags.mode_req_manual_control);
 
 	// NAVIGATION_STATE_DESCEND
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_DESCEND, flags.mode_req_angular_velocity);
@@ -122,6 +127,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_STAB
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_STAB, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_STAB, flags.mode_req_attitude);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_STAB, flags.mode_req_manual_control);
 
 	// NAVIGATION_STATE_AUTO_TAKEOFF
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_angular_velocity);

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -71,14 +71,13 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_POSCTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_attitude);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_local_alt);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_manual_control);
 
 	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
 		setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_global_position);
 	}
-
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_local_alt);
 
 	// NAVIGATION_STATE_AUTO_MISSION
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_angular_velocity);

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -656,6 +656,7 @@ bool FailsafeBase::modeCanRun(const failsafe_flags_s &status_flags, uint8_t mode
 		(!status_flags.auto_mission_missing || ((status_flags.mode_req_mission & mode_mask) == 0)) &&
 		(!status_flags.offboard_control_signal_lost || ((status_flags.mode_req_offboard_signal & mode_mask) == 0)) &&
 		(!status_flags.home_position_invalid || ((status_flags.mode_req_home_position & mode_mask) == 0)) &&
+		(!status_flags.manual_control_signal_lost || ((status_flags.mode_req_manual_control & mode_mask) == 0)) &&
 		((status_flags.mode_req_other & mode_mask) == 0);
 }
 


### PR DESCRIPTION
### Solved Problem
When switching to a manual mode (Manual, Acro, Stabilized, Altitude, Position) without a stick input source it is currently possible to arm and stay in the mode.

Fixes https://github.com/PX4/PX4-Autopilot/pull/20172#discussion_r988214569

### Solution
#### Requirements
1. **[untouched]** Stick input disabled and not required -> Nothing
2. **[untouched]** Stick input present but lost in flight -> Failsafe NAV_RCL_ACT (tested with RTL only!)
3. **[mandatory]** Manual mode (Manual, Acro, Stabilized, Altitude, Position) and disabled or unavailable stick input -> Error
4. **[nice to have]** Stick input enabled but not present when not required -> Warning

|  | RC required | RC not required |
|---|---|---|
| RC disabled | Error 3. | OK 1. |
| RC enabled not present | Error 3. | Warn 4. |
| RC enabled and present | OK | OK |

#### Steps/commits
- Establish manual control as mode requirement for manual modes working towards 3.
- Make sure the manual control availability flag `manual_control_signal_lost` gets updated also when manual control is disabled and remove the existing manual control check to establish 3.
- Minor reorder
- ~Add back a revised second manual control check for 4.~
- ~Suggestion to allow a check to just publish a warning (no failure) but only for certain modes. Originally that's only possible for all modes see https://github.com/PX4/PX4-Autopilot/blob/c5dc1221b68352725630cbda5c04bc0f5c3c1617/src/modules/commander/HealthAndArmingChecks/Common.hpp#L239 https://github.com/PX4/PX4-Autopilot/blob/c5dc1221b68352725630cbda5c04bc0f5c3c1617/src/modules/commander/HealthAndArmingChecks/Common.cpp#L92-L95. Alternatively the condition outside the check could look at the mode and requirement mask but that's in my eyes worse. Not sure if you have a better idea to achieve 3. and 4. without having a duplicate event with RC enabled and required but not present:~
- **EDIT:** I now replaced the above suggestion with the discussed solution of only publishing one event for "No manual control input" but making the severity and mode mask dependent on if stick input is enabled or not. The only downside to this is that if RC is enabled the severity for it being not available is always a warning (details text in orange). Still, it doesn't allow arming in manual modes (top bar red) and switching to manual modes in the air. I think that's worth the simplicity.

### Alternatives
- We can move on with just the first 3 commits and move 4. to a different pr.
- We can move on with just the first 4 commits but then there's a duplicate event in the 4. case:
  <img width="177" alt="warning and requirement" src="https://user-images.githubusercontent.com/4668506/205116148-30f40268-4654-432e-86fa-292399602add.png">

### Test coverage
I successfully tested the entire case table above in SITL with a joystick using:
- RC disabled: `COM_RC_IN_MODE` Disabled
- RC enabled not present: `COM_RC_IN_MODE` set to RC only
- RC enabled and present: `COM_RC_IN_MODE` set to Joystick only
The options mentioned under alternatives were also tested the same way.