### PR TITLE
Fix Geofence_breach_check to rely on GF_SOURCE

### DIFF
--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -152,6 +152,13 @@ public:
 	 */
 	void printStatus();
 
+	/**
+	 * Get the position of a vehicle as a global position structure depending on GF_SOURCE and GF_ALTMODE parameters
+	 *
+	 * @return global position
+	 */
+	const vehicle_global_position_s get_position_by_source(const vehicle_global_position_s &global_position, const sensor_gps_s &gps_position);
+
 private:
 
 	struct PolygonInfo {

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -359,7 +359,7 @@ private:
 	home_position_s					_home_pos{};		/**< home position for RTL */
 	mission_result_s				_mission_result{};
 	vehicle_global_position_s			_global_pos{};		/**< global vehicle position */
-	sensor_gps_s				_gps_pos{};		/**< gps position */
+	sensor_gps_s					_gps_pos{};		/**< gps position */
 	vehicle_land_detected_s				_land_detected{};	/**< vehicle land_detected */
 	vehicle_local_position_s			_local_pos{};		/**< local vehicle position */
 	vehicle_status_s				_vstatus{};		/**< vehicle status */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -813,6 +813,8 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		float test_point_distance;
 		float vertical_test_point_distance;
 
+		const vehicle_global_position_s pos = _geofence.get_position_by_source(_global_pos, _gps_pos);
+
 		if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
 			test_point_bearing = atan2f(_local_pos.vy, _local_pos.vx);
 			const float velocity_hor_abs = sqrtf(_local_pos.vx * _local_pos.vx + _local_pos.vy * _local_pos.vy);
@@ -836,7 +838,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		_gf_breach_avoidance.setHorizontalTestPointDistance(test_point_distance);
 		_gf_breach_avoidance.setVerticalTestPointDistance(vertical_test_point_distance);
 		_gf_breach_avoidance.setTestPointBearing(test_point_bearing);
-		_gf_breach_avoidance.setCurrentPosition(_global_pos.lat, _global_pos.lon, _global_pos.alt);
+		_gf_breach_avoidance.setCurrentPosition(pos.lat, pos.lon, pos.alt);
 		_gf_breach_avoidance.setMaxHorDistHome(_geofence.getMaxHorDistanceHome());
 		_gf_breach_avoidance.setMaxVerDistHome(_geofence.getMaxVerDistanceHome());
 
@@ -848,20 +850,20 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 			fence_violation_test_point = _gf_breach_avoidance.getFenceViolationTestPoint();
 
 		} else {
-			fence_violation_test_point = matrix::Vector2d(_global_pos.lat, _global_pos.lon);
+			fence_violation_test_point = matrix::Vector2d(pos.lat, pos.lon);
 			vertical_test_point_distance = 0;
 		}
 
 		gf_violation_type.flags.dist_to_home_exceeded = !_geofence.isCloserThanMaxDistToHome(fence_violation_test_point(0),
 				fence_violation_test_point(1),
-				_global_pos.alt);
+				pos.alt);
 
-		gf_violation_type.flags.max_altitude_exceeded = !_geofence.isBelowMaxAltitude(_global_pos.alt +
+		gf_violation_type.flags.max_altitude_exceeded = !_geofence.isBelowMaxAltitude(pos.alt +
 				vertical_test_point_distance);
 
 		gf_violation_type.flags.fence_violation = !_geofence.isInsidePolygonOrCircle(fence_violation_test_point(0),
 				fence_violation_test_point(1),
-				_global_pos.alt);
+				pos.alt);
 
 		_last_geofence_check = hrt_absolute_time();
 		have_geofence_position_data = false;
@@ -896,8 +898,8 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 					position_setpoint_triplet_s *rep = get_reposition_triplet();
 
 					matrix::Vector2<double> loiter_center_lat_lon;
-					matrix::Vector2<double> current_pos_lat_lon(_global_pos.lat, _global_pos.lon);
-					float loiter_altitude_amsl = _global_pos.alt;
+					matrix::Vector2<double> current_pos_lat_lon(pos.lat, pos.lon);
+					float loiter_altitude_amsl = pos.alt;
 
 
 					if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Vehicle may fly outside the fence if it has lost its global position, even if its parameter set to  GF_SOURCE = GPS

Fixes #{20677}

### Context
Related links, screenshot before/after, video
