### PR TITLE
DataValidator: fix unexpected fail-over

### DIFF
--- a/src/modules/sensors/data_validator/DataValidatorGroup.cpp
+++ b/src/modules/sensors/data_validator/DataValidatorGroup.cpp
@@ -153,13 +153,31 @@ float *DataValidatorGroup::get_best(uint64_t timestamp, int *index)
 
 	int i = 0;
 
+	// First find the current selected sensor
+	while (next != nullptr) {
+		if (i == pre_check_best) {
+			const int prio = next->priority();
+			const float confidence = next->confidence(timestamp);
+
+			pre_check_prio = prio;
+			pre_check_confidence = confidence;
+
+			max_index = i;
+			max_confidence = confidence;
+			max_priority = prio;
+			best = next;
+			break;
+		}
+
+		next = next->sibling();
+		i++;
+	}
+
+	i = 0;
+	next = _first;
+
 	while (next != nullptr) {
 		float confidence = next->confidence(timestamp);
-
-		if (i == pre_check_best) {
-			pre_check_prio = next->priority();
-			pre_check_confidence = confidence;
-		}
 
 		/*
 		 * Switch if:


### PR DESCRIPTION
### Solved Problem
A single error makes the selector switch from the primary mag to a secondary one because it is on instance 1 while the internal one is on instance 0.
This is because currently, the the best instance is selected but it is harder for an instance with a higher number to be selected because they need to be strictly better than the instance with a lower number.
IMO, the initial intent was to keep the currently selected instance until a problem is detected or if a good instance with a higher priority is available.

### Solution
Instead of always starting with instance 0 (potentially an internal mag), first take the current sensor as reference to
compare the other ones against it.

### Test coverage
tested on v5 by hacking a change of confidence when a sensor is disconnected instead of triggering a timeout

FYI: @bkueng 