### PR TITLE
jmavsim_run.sh: add module exports to avoid access errors

### DIFF
--- a/Tools/simulation/jmavsim/jmavsim_run.sh
+++ b/Tools/simulation/jmavsim/jmavsim_run.sh
@@ -73,4 +73,5 @@ fi
 ant create_run_jar copy_res
 cd out/production
 
-java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+java --add-exports java.base/java.lang=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/sun.java2d=ALL-UNNAMED \
+	-XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args


### PR DESCRIPTION
With openjdk 17.0.5 2022-10-18, jmavsim fails to start due to missing exports. This was previously a warning and turned into an error now.

```
Caught AppContextInfo(Bug 1004) InaccessibleObjectException: Unable to make public static sun.awt.AppContext sun.awt.AppContext.getAppContext() accessible: module java.desktop does not "exports sun.awt" to unnamed module @2c767a52 on thread J3D-Renderer-1
    [0]: java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
    [1]: java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
    [2]: java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
    [3]: java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
    [4]: com.jogamp.nativewindow.awt.AppContextInfo$1$1.run(AppContextInfo.java:40)
    [5]: com.jogamp.common.util.UnsafeUtil.doWithoutIllegalAccessLogger(UnsafeUtil.java:219)
    [6]: com.jogamp.nativewindow.awt.AppContextInfo$1.run(AppContextInfo.java:34)
    [7]: java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
    [8]: com.jogamp.nativewindow.awt.AppContextInfo.<clinit>(AppContextInfo.java:31)
    [9]: com.jogamp.nativewindow.awt.JAWTWindow.<init>(JAWTWindow.java:128)
    [10]: jogamp.nativewindow.jawt.x11.X11JAWTWindow.<init>(X11JAWTWindow.java:60)
    [11]: java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    [12]: java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
    [13]: java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    [14]: java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
    [15]: java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
    [16]: jogamp.nativewindow.NativeWindowFactoryImpl.getAWTNativeWindow(NativeWindowFactoryImpl.java:105)
    [17]: jogamp.nativewindow.NativeWindowFactoryImpl.getNativeWindowImpl(NativeWindowFactoryImpl.java:66)
    [18]: com.jogamp.nativewindow.NativeWindowFactory.getNativeWindow(NativeWindowFactory.java:654)
    [19]: javax.media.j3d.JoglPipeline$QueryCanvas.addNotify(JoglPipeline.java:8604)
    [20]: java.desktop/java.awt.Container.addNotify(Container.java:2804)
    [21]: java.desktop/java.awt.Window.addNotify(Window.java:791)
    [22]: java.desktop/java.awt.Frame.addNotify(Frame.java:495)
    [23]: java.desktop/java.awt.Window.show(Window.java:1053)
    [24]: java.desktop/java.awt.Component.show(Component.java:1728)
    [25]: java.desktop/java.awt.Component.setVisible(Component.java:1675)
    [26]: java.desktop/java.awt.Window.setVisible(Window.java:1036)
    [27]: javax.media.j3d.JoglPipeline.getBestConfiguration(JoglPipeline.java:8379)
    [28]: javax.media.j3d.Renderer.doWork(Renderer.java:496)
    [29]: javax.media.j3d.J3dThread.run(J3dThread.java:271)
Caught AppContextInfo(Bug 1004) IllegalAccessException: class com.jogamp.nativewindow.awt.AppContextInfo cannot access class sun.awt.AppContext (in module java.desktop) because module java.desktop does not export sun.awt to unnamed module @2c767a52 on thread J3D-Renderer-1
    [0]: java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
    [1]: java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
    [2]: java.base/java.lang.reflect.Method.invoke(Method.java:560)
    [3]: com.jogamp.nativewindow.awt.AppContextInfo.fetchAppContext(AppContextInfo.java:191)
    [4]: com.jogamp.nativewindow.awt.AppContextInfo.update(AppContextInfo.java:135)
    [5]: com.jogamp.nativewindow.awt.AppContextInfo.<init>(AppContextInfo.java:50)
    [6]: com.jogamp.nativewindow.awt.JAWTWindow.<init>(JAWTWindow.java:128)
    [7]: jogamp.nativewindow.jawt.x11.X11JAWTWindow.<init>(X11JAWTWindow.java:60)
    [8]: java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    [9]: java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
    [10]: java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    [11]: java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
    [12]: java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
    [13]: jogamp.nativewindow.NativeWindowFactoryImpl.getAWTNativeWindow(NativeWindowFactoryImpl.java:105)
    [14]: jogamp.nativewindow.NativeWindowFactoryImpl.getNativeWindowImpl(NativeWindowFactoryImpl.java:66)
    [15]: com.jogamp.nativewindow.NativeWindowFactory.getNativeWindow(NativeWindowFactory.java:654)
    [16]: javax.media.j3d.JoglPipeline$QueryCanvas.addNotify(JoglPipeline.java:8604)
    [17]: java.desktop/java.awt.Container.addNotify(Container.java:2804)
    [18]: java.desktop/java.awt.Window.addNotify(Window.java:791)
    [19]: java.desktop/java.awt.Frame.addNotify(Frame.java:495)
    [20]: java.desktop/java.awt.Window.show(Window.java:1053)
    [21]: java.desktop/java.awt.Component.show(Component.java:1728)
    [22]: java.desktop/java.awt.Component.setVisible(Component.java:1675)
    [23]: java.desktop/java.awt.Window.setVisible(Window.java:1036)
    [24]: javax.media.j3d.JoglPipeline.getBestConfiguration(JoglPipeline.java:8379)
    [25]: javax.media.j3d.Renderer.doWork(Renderer.java:496)
    [26]: javax.media.j3d.J3dThread.run(J3dThread.java:271)
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.eclipse.jdt.internal.jarinjarloader.JarRsrcLoader.main(JarRsrcLoader.java:61)
Caused by: java.lang.RuntimeException: java.lang.IllegalAccessException: class javax.media.j3d.JoglPipeline cannot access class sun.awt.X11GraphicsDevice (in module java.desktop) because module java.desktop does not export sun.awt to unnamed module @2c767a52
        at javax.media.j3d.JoglPipeline.getScreen(JoglPipeline.java:8553)
        at javax.media.j3d.Screen3D.<init>(Screen3D.java:354)
        at javax.media.j3d.Canvas3D.<init>(Canvas3D.java:1124)
        at javax.media.j3d.Canvas3D.<init>(Canvas3D.java:1026)
        at javax.media.j3d.Canvas3D.<init>(Canvas3D.java:990)
        at me.drton.jmavsim.Visualizer3D$CustomCanvas3D.<init>(Visualizer3D.java:909)
        at me.drton.jmavsim.Visualizer3D.<init>(Visualizer3D.java:196)
        at me.drton.jmavsim.Simulator.<init>(Simulator.java:193)
        at me.drton.jmavsim.Simulator.main(Simulator.java:944)
        ... 5 more
Caused by: java.lang.IllegalAccessException: class javax.media.j3d.JoglPipeline cannot access class sun.awt.X11GraphicsDevice (in module java.desktop) because module java.desktop does not export sun.awt to unnamed module @2c767a52
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
        at java.base/java.lang.reflect.Method.invoke(Method.java:560)
        at javax.media.j3d.JoglPipeline.getScreen(JoglPipeline.java:8551)
        ... 13 more
```