### PR TITLE
Keep sending GPS_RAW_INT on gps failure

### DIFF
--- a/src/modules/mavlink/streams/GPS2_RAW.hpp
+++ b/src/modules/mavlink/streams/GPS2_RAW.hpp
@@ -36,6 +36,8 @@
 
 #include <uORB/topics/sensor_gps.h>
 
+using namespace time_literals;
+
 class MavlinkStreamGPS2Raw : public MavlinkStream
 {
 public:
@@ -56,13 +58,16 @@ private:
 	explicit MavlinkStreamGPS2Raw(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
 	uORB::Subscription _sensor_gps_sub{ORB_ID(sensor_gps), 1};
+	hrt_abstime _last_send_ts {};
+	static constexpr hrt_abstime _no_gps_send_interval {1_s};
 
 	bool send() override
 	{
 		sensor_gps_s gps;
+		mavlink_gps2_raw_t msg{};
+		hrt_abstime now{};
 
 		if (_sensor_gps_sub.update(&gps)) {
-			mavlink_gps2_raw_t msg{};
 
 			msg.time_usec = gps.timestamp;
 			msg.fix_type = gps.fix_type;
@@ -99,6 +104,19 @@ private:
 			}
 
 			mavlink_msg_gps2_raw_send_struct(_mavlink->get_channel(), &msg);
+			_last_send_ts = gps.timestamp;
+
+			return true;
+
+		} else if (_last_send_ts != 0 && (now = hrt_absolute_time()) > _last_send_ts + _no_gps_send_interval) {
+			msg.fix_type = GPS_FIX_TYPE_NO_GPS;
+			msg.eph = UINT16_MAX;
+			msg.epv = UINT16_MAX;
+			msg.vel = UINT16_MAX;
+			msg.cog = UINT16_MAX;
+			msg.satellites_visible = UINT8_MAX;
+			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
+			_last_send_ts = now;
 
 			return true;
 		}

--- a/src/modules/mavlink/streams/GPS2_RAW.hpp
+++ b/src/modules/mavlink/streams/GPS2_RAW.hpp
@@ -59,7 +59,7 @@ private:
 
 	uORB::Subscription _sensor_gps_sub{ORB_ID(sensor_gps), 1};
 	hrt_abstime _last_send_ts {};
-	static constexpr hrt_abstime _no_gps_send_interval {1_s};
+	static constexpr hrt_abstime kNoGpsSendInterval {1_s};
 
 	bool send() override
 	{
@@ -108,14 +108,14 @@ private:
 
 			return true;
 
-		} else if (_last_send_ts != 0 && (now = hrt_absolute_time()) > _last_send_ts + _no_gps_send_interval) {
+		} else if (_last_send_ts != 0 && (now = hrt_absolute_time()) > _last_send_ts + kNoGpsSendInterval) {
 			msg.fix_type = GPS_FIX_TYPE_NO_GPS;
 			msg.eph = UINT16_MAX;
 			msg.epv = UINT16_MAX;
 			msg.vel = UINT16_MAX;
 			msg.cog = UINT16_MAX;
 			msg.satellites_visible = UINT8_MAX;
-			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
+			mavlink_msg_gps2_raw_send_struct(_mavlink->get_channel(), &msg);
 			_last_send_ts = now;
 
 			return true;

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -59,7 +59,7 @@ private:
 
 	uORB::Subscription _sensor_gps_sub{ORB_ID(sensor_gps), 0};
 	hrt_abstime _last_send_ts {};
-	static constexpr hrt_abstime _no_gps_send_interval {1_s};
+	static constexpr hrt_abstime kNoGpsSendInterval {1_s};
 
 	bool send() override
 	{
@@ -108,7 +108,7 @@ private:
 
 			return true;
 
-		} else if (_last_send_ts != 0 && (now = hrt_absolute_time()) > _last_send_ts + _no_gps_send_interval) {
+		} else if (_last_send_ts != 0 && (now = hrt_absolute_time()) > _last_send_ts + kNoGpsSendInterval) {
 			msg.fix_type = GPS_FIX_TYPE_NO_GPS;
 			msg.eph = UINT16_MAX;
 			msg.epv = UINT16_MAX;

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -65,7 +65,7 @@ private:
 	{
 		sensor_gps_s gps;
 		mavlink_gps_raw_int_t msg{};
-		hrt_abstime now {};
+		hrt_abstime now{};
 
 		if (_sensor_gps_sub.update(&gps)) {
 			msg.time_usec = gps.timestamp;
@@ -108,7 +108,7 @@ private:
 
 			return true;
 
-		} else if ((now = hrt_absolute_time()) > _last_send_ts + _no_gps_send_interval) {
+		} else if (_last_send_ts != 0 && (now = hrt_absolute_time()) > _last_send_ts + _no_gps_send_interval) {
 			msg.fix_type = GPS_FIX_TYPE_NO_GPS;
 			msg.eph = UINT16_MAX;
 			msg.epv = UINT16_MAX;
@@ -117,6 +117,8 @@ private:
 			msg.satellites_visible = UINT8_MAX;
 			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
 			_last_send_ts = now;
+
+			return true;
 		}
 
 		return false;

--- a/src/modules/mavlink/streams/GPS_RAW_INT.hpp
+++ b/src/modules/mavlink/streams/GPS_RAW_INT.hpp
@@ -36,6 +36,8 @@
 
 #include <uORB/topics/sensor_gps.h>
 
+using namespace time_literals;
+
 class MavlinkStreamGPSRawInt : public MavlinkStream
 {
 public:
@@ -57,7 +59,7 @@ private:
 
 	uORB::Subscription _sensor_gps_sub{ORB_ID(sensor_gps), 0};
 	hrt_abstime _last_send_ts {};
-	hrt_abstime _no_gps_send_interval {1 * 1000000};
+	static constexpr hrt_abstime _no_gps_send_interval {1_s};
 
 	bool send() override
 	{
@@ -106,7 +108,7 @@ private:
 
 			return true;
 
-		} else if ((now = hrt_absolute_time()) - _last_send_ts > _no_gps_send_interval) {
+		} else if ((now = hrt_absolute_time()) > _last_send_ts + _no_gps_send_interval) {
 			msg.fix_type = GPS_FIX_TYPE_NO_GPS;
 			msg.eph = UINT16_MAX;
 			msg.epv = UINT16_MAX;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
If the gps process dies, the ground control will keep showing the values from the last GPS_RAW_INT message and will not detect an unhealthy state of the GPS.

### Solution
Keep sending GPS_RAW_INT message on 1Hz, with no gps available state and default values when the GPS_RAW_INT message wasn't sent for 1s. This allows the ground control to visualise that no GPS is available.

### Test coverage
Tested by stopping the gps process using `gps stop` in the MAVLink Console.

