### PR TITLE
sensors: prefix mag config param SENS instead of CAL

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -106,7 +106,7 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 	// Collect: As defined by configuration
 	// start with a full mask, all six bits set
 	int32_t cal_mask = (1 << 6) - 1;
-	param_get(param_find("CAL_MAG_SIDES"), &cal_mask);
+	param_get(param_find("SENS_MAG_SIDES"), &cal_mask);
 
 	// Calibrate all mags at the same time
 	if (result == PX4_OK) {
@@ -696,10 +696,10 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 
 	// Attempt to automatically determine external mag rotations
 	if (result == calibrate_return_ok) {
-		int32_t param_cal_mag_rot_auto = 0;
-		param_get(param_find("CAL_MAG_ROT_AUTO"), &param_cal_mag_rot_auto);
+		int32_t param_sens_mag_autorot = 0;
+		param_get(param_find("SENS_MAG_AUTOROT"), &param_sens_mag_autorot);
 
-		if ((worker_data.calibration_sides >= 3) && (param_cal_mag_rot_auto == 1)) {
+		if ((worker_data.calibration_sides >= 3) && (param_sens_mag_autorot == 1)) {
 
 			// find first internal mag to use as reference
 			int internal_index = -1;

--- a/src/modules/sensors/sensor_params_mag.c
+++ b/src/modules/sensors/sensor_params_mag.c
@@ -53,7 +53,7 @@
  * @value 63 Six side calibration
  * @group Sensors
  */
-PARAM_DEFINE_INT32(CAL_MAG_SIDES, 63);
+PARAM_DEFINE_INT32(SENS_MAG_SIDES, 63);
 
 /**
  * Type of magnetometer compensation
@@ -76,7 +76,7 @@ PARAM_DEFINE_INT32(CAL_MAG_COMP_TYP, 0);
  * @boolean
  * @group Sensors
  */
-PARAM_DEFINE_INT32(CAL_MAG_ROT_AUTO, 1);
+PARAM_DEFINE_INT32(SENS_MAG_AUTOROT, 1);
 
 /**
  * Magnetometer max rate.

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -49,8 +49,8 @@ VehicleMagnetometer::VehicleMagnetometer() :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers)
 {
-	param_find("CAL_MAG_SIDES");
-	param_find("CAL_MAG_ROT_AUTO");
+	param_find("SENS_MAG_SIDES");
+	param_find("SENS_MAG_AUTOROT");
 
 	_voter.set_timeout(SENSOR_TIMEOUT);
 	_voter.set_equal_value_threshold(1000);


### PR DESCRIPTION
### Solved Problem
`CAL_MAG_SIDES` and `CAL_MAG_ROT_AUTO` are not calibration calibrations values of the mag sensor, they are config parameters and shouldn't be saved as part of a factory calibration.

### Solution
Change the prefix to `SENS_`