### PR TITLE
Quadchute: Specifiy a maximum height

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -255,13 +255,14 @@ PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
  * Triggering a quadchute always means transitioning the vehicle to hover flight in which generally a lot of energy is consumed.
  * At high altitudes there is therefore a big risk to deplete the battery and therefore crash. Currently, there is no automated
  * re-transition to fixed wing mode implemented and therefore this parameter serves and an intermediate measure to increase safety.
+ * Setting this value to 0 deactivates the behavior.
  *
  * @unit m
+ * @min 0
  * @increment 1
- * @decimal 1
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_FW_QC_HMAX, 200.0f);
+PARAM_DEFINE_INT32(VT_FW_QC_HMAX, 0);
 
 /**
  * Airspeed less front transition time (open loop)

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -249,6 +249,21 @@ PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
 PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 
 /**
+ * Quadchute maximum height.
+ *
+ * Maximum height above the ground (if available, otherwhise above home if available, otherwise above the local origin) where triggering a quadchute is possible.
+ * Triggering a quadchute always means transitioning the vehicle to hover flight in which generally a lot of energy is consumed.
+ * At high altitudes there is therefore a big risk to deplete the battery and therefore crash. Currently, there is no automated
+ * re-transition to fixed wing mode implemented and therefore this parameter serves and an intermediate measure to increase safety.
+ *
+ * @unit m
+ * @increment 1
+ * @decimal 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_QC_HMAX, 200.0f);
+
+/**
  * Airspeed less front transition time (open loop)
  *
  * The duration of the front transition when there is no airspeed feedback available.

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -228,7 +228,9 @@ bool VtolType::isQuadchuteEnabled()
 
 	}
 
-	return _v_control_mode->flag_armed && !_land_detected->landed && dist_to_ground < _param_quadchute_max_height.get();
+	return _v_control_mode->flag_armed &&
+	       !_land_detected->landed && _param_quadchute_max_height.get() > 0 &&
+	       dist_to_ground < (float)_param_quadchute_max_height.get();
 }
 
 bool VtolType::isMinAltBreached()

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -214,7 +214,21 @@ bool VtolType::can_transition_on_ground()
 
 bool VtolType::isQuadchuteEnabled()
 {
-	return _v_control_mode->flag_armed && !_land_detected->landed;
+	float dist_to_ground = 0.f;
+	const float home_position_z = _attc->get_home_position_z();
+
+	if (_local_pos->dist_bottom_valid) {
+		dist_to_ground = _local_pos->dist_bottom;
+
+	} else if (PX4_ISFINITE(home_position_z)) {
+		dist_to_ground = -(_local_pos->z - home_position_z);
+
+	} else {
+		dist_to_ground = -_local_pos->z;
+
+	}
+
+	return _v_control_mode->flag_armed && !_land_detected->landed && dist_to_ground < _param_quadchute_max_height.get();
 }
 
 bool VtolType::isMinAltBreached()

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -314,7 +314,7 @@ protected:
 					(ParamFloat<px4::params::VT_FW_ALT_ERR>) _param_vt_fw_alt_err,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
-					(ParamFloat<px4::params::VT_FW_QC_HMAX>) _param_quadchute_max_height,
+					(ParamInt<px4::params::VT_FW_QC_HMAX>) _param_quadchute_max_height,
 					(ParamFloat<px4::params::VT_F_TR_OL_TM>) _param_vt_f_tr_ol_tm,
 					(ParamFloat<px4::params::VT_TRANS_MIN_TM>) _param_vt_trans_min_tm,
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -314,6 +314,7 @@ protected:
 					(ParamFloat<px4::params::VT_FW_ALT_ERR>) _param_vt_fw_alt_err,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
+					(ParamFloat<px4::params::VT_FW_QC_HMAX>) _param_quadchute_max_height,
 					(ParamFloat<px4::params::VT_F_TR_OL_TM>) _param_vt_f_tr_ol_tm,
 					(ParamFloat<px4::params::VT_TRANS_MIN_TM>) _param_vt_trans_min_tm,
 


### PR DESCRIPTION
### Solved Problem
Triggering a quadchute high up above the ground can be dangerous as batteries deplete fast in  hover.

Fixes #{Github issue ID}

### Solution
Add a parameter to specify a maximum height above ground/home/origin.
