### PR TITLE
Battery: delay initialization of SoC

### DIFF
--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -175,4 +175,6 @@ private:
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 	bool _armed{false};
+	hrt_abstime _start_timestamp{0};
+	bool _state_of_charge_delay = false;
 };

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -175,6 +175,5 @@ private:
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 	bool _armed{false};
-	hrt_abstime _start_timestamp{0};
-	bool _state_of_charge_delay = false;
+	hrt_abstime _last_unconnected_timestamp{0};
 };


### PR DESCRIPTION
### Solved Problem
@sanderux found during testing with v5x and INA238 that the computed state of charge can be off (e. g. 50%) even though the voltage seems to be measured correctly. It turned out that the issue is caused by the usage of anti-spark connectors; the pre-resistor causes a lowered initial voltage reading. This combined with bad timing (essentially how fast you're plugging the connector) causes a faulty initialization of the state of charge.

### Solution
- adding a delay of 2 seconds before initializing the state of charge solves the given issue

### Alternatives
The alternative would be to adjust the weight factor for faster convergence and make it independent of the charge level of the battery: https://github.com/PX4/PX4-Autopilot/blob/cfb670fbb37b18e1d145d86caa9244cfa7373869/src/lib/battery/battery.cpp#L233
However, this would also cause fluctuations based on changing load in flight which is undesired.

### Test coverage
- I tested this on the system where I reproduced the issue reliably. The 2 seconds delay solves it for all tests I have done
