### PR TITLE
Increase SPI stacks by 16 bytes

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -50,13 +50,13 @@ namespace wq_configurations
 {
 static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 3150, 0}; // PX4 inner loop highest priority
 
-static constexpr wq_config_t SPI0{"wq:SPI0", 2336, -1};
-static constexpr wq_config_t SPI1{"wq:SPI1", 2336, -2};
-static constexpr wq_config_t SPI2{"wq:SPI2", 2336, -3};
-static constexpr wq_config_t SPI3{"wq:SPI3", 2336, -4};
-static constexpr wq_config_t SPI4{"wq:SPI4", 2336, -5};
-static constexpr wq_config_t SPI5{"wq:SPI5", 2336, -6};
-static constexpr wq_config_t SPI6{"wq:SPI6", 2336, -7};
+static constexpr wq_config_t SPI0{"wq:SPI0", 2352, -1};
+static constexpr wq_config_t SPI1{"wq:SPI1", 2352, -2};
+static constexpr wq_config_t SPI2{"wq:SPI2", 2352, -3};
+static constexpr wq_config_t SPI3{"wq:SPI3", 2352, -4};
+static constexpr wq_config_t SPI4{"wq:SPI4", 2352, -5};
+static constexpr wq_config_t SPI5{"wq:SPI5", 2352, -6};
+static constexpr wq_config_t SPI6{"wq:SPI6", 2352, -7};
 
 static constexpr wq_config_t I2C0{"wq:I2C0", 2336, -8};
 static constexpr wq_config_t I2C1{"wq:I2C1", 2336, -9};


### PR DESCRIPTION
On the ARKV6X, load mon is warning that SPI2 is low on stack running just the icm42688p driver. It appears to be due to the icm42688p on SPI2 using rotation ROTATION_ROLL_180_YAW_45 compared to the icm42688p on SPI3 using ROTATION_YAW_270.

It also appears that this is causing SPI2 to use twice the CPU as the same driver on SPI3 with a more simple rotation.

```
PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
489 wq:SPI2                       101  5.781  2012/ 2328 252 (252)  w:sem  4
504 wq:SPI3                        41  2.382  1848/ 2328 251 (251)  w:sem  4
```