### PR TITLE
Point to a newer version of librobotcontrol

### DIFF
--- a/boards/beaglebone/blue/cmake/init.cmake
+++ b/boards/beaglebone/blue/cmake/init.cmake
@@ -35,8 +35,8 @@ add_compile_options(-Wno-cast-align)
 
 include(ExternalProject)
 ExternalProject_Add(librobotcontrol
-	GIT_REPOSITORY https://github.com/dagar/librobotcontrol.git
-	GIT_TAG 1abcb0a # latest as of 2019-12-29
+        GIT_REPOSITORY https://github.com/beagleboard/librobotcontrol.git
+        GIT_TAG 290e14f
 	CMAKE_CACHE_ARGS -DCMAKE_TOOLCHAIN_FILE:STRING=${CMAKE_TOOLCHAIN_FILE}
 	INSTALL_COMMAND ""
 	TEST_COMMAND ""


### PR DESCRIPTION
Fixes PRU path issues found in old versions of the library by upgrading to 1.0.5