### PR TITLE
Hard fault on Port E config (CAN0) due to not sizing the table correctly

### DIFF
--- a/boards/nxp/ucans32k146/src/board_config.h
+++ b/boards/nxp/ucans32k146/src/board_config.h
@@ -90,7 +90,7 @@ __BEGIN_DECLS
 
 /* Count of peripheral clock user configurations */
 
-#define NUM_OF_PERIPHERAL_CLOCKS_0 18
+#define NUM_OF_PERIPHERAL_CLOCKS_0 19
 
 
 /* High-resolution timer */


### PR DESCRIPTION
@PetervdPerk-NXP  bit by the non-auto sizing table bug again!

Symptom: Hard fault on Port E config (CAN0)
