### PR TITLE
when logger modules cant log, this is detected and new file open to log

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -187,7 +187,7 @@ int Logger::print_status()
 	PX4_INFO("Number of subscriptions: %i (%i bytes)", _num_subscriptions,
 		 (int)(_num_subscriptions * sizeof(LoggerSubscription)));
 
-	bool is_logging = false;
+	is_logging = false;
 
 	if (_writer.is_started(LogType::Full, LogWriter::BackendFile)) {
 		PX4_INFO("Full File Logging Running:");
@@ -420,6 +420,9 @@ void Logger::update_params()
 	}
 }
 
+bool Logger::check_logging(){
+	return _writer.is_started(LogType::Full, LogWriter::BackendFile);
+}
 bool Logger::request_stop_static()
 {
 	if (is_running()) {
@@ -688,6 +691,17 @@ void Logger::run()
 	while (!should_exit()) {
 		// Start/stop logging (depending on logging mode, by default when arming/disarming)
 		const bool logging_started = start_stop_logging();
+
+		if(check_logging()){
+			is_logging = true;
+		} else
+		{
+			is_logging = false;
+		}
+
+		if(!is_logging){
+			get_instance()->set_arm_override(true);
+		}
 
 		if (logging_started) {
 #ifdef DBGPRINT

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -296,6 +296,11 @@ private:
 	 */
 	bool start_stop_logging();
 
+	/**
+	 * check logger module is loging or not
+	*/
+	bool check_logging();
+
 	void handle_vehicle_command_update();
 	void ack_vehicle_command(vehicle_command_s *cmd, uint32_t result);
 
@@ -332,6 +337,7 @@ private:
 
 	bool						_prev_state{false}; ///< previous state depending on logging mode (arming or aux1 state)
 	bool						_manually_logging_override{false};
+	bool						is_logging{false};
 
 	Statistics					_statistics[(int)LogType::Count];
 	hrt_abstime					_last_sync_time{0}; ///< last time a sync msg was sent


### PR DESCRIPTION
### Solved Problem
When I fly and logger is interrupted. 

### Solution
- I add some function to control logging and if logging stop after that I open new log file and continue to log. 