### PR TITLE
Fixed transition timer not being reset

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -94,8 +94,8 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_mode == vtol_mode::FW_MODE) {
 			// Regular backtransition
+			resetTransitionTimer();
 			_vtol_mode = vtol_mode::TRANSITION_TO_MC;
-			_transition_start_timestamp = hrt_absolute_time();
 			_reverse_output = _param_vt_b_rev_out.get();
 
 		} else if (_vtol_mode == vtol_mode::TRANSITION_TO_FW) {
@@ -131,8 +131,8 @@ void Standard::update_vtol_state()
 			// start transition to fw mode
 			/* NOTE: The failsafe transition to fixed-wing was removed because it can result in an
 			 * unsafe flying state. */
+			resetTransitionTimer();
 			_vtol_mode = vtol_mode::TRANSITION_TO_FW;
-			_transition_start_timestamp = hrt_absolute_time();
 
 		} else if (_vtol_mode == vtol_mode::FW_MODE) {
 			// in fw mode

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -87,8 +87,8 @@ void Tailsitter::update_vtol_state()
 			break;
 
 		case vtol_mode::FW_MODE:
+			resetTransitionTimer();
 			_vtol_mode = vtol_mode::TRANSITION_BACK;
-			_transition_start_timestamp = hrt_absolute_time();
 			break;
 
 		case vtol_mode::TRANSITION_FRONT_P1:
@@ -112,7 +112,7 @@ void Tailsitter::update_vtol_state()
 		case vtol_mode::MC_MODE:
 			// initialise a front transition
 			_vtol_mode = vtol_mode::TRANSITION_FRONT_P1;
-			_transition_start_timestamp = hrt_absolute_time();
+			resetTransitionTimer();
 			break;
 
 		case vtol_mode::FW_MODE:

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -88,8 +88,8 @@ void Tiltrotor::update_vtol_state()
 			break;
 
 		case vtol_mode::FW_MODE:
+			resetTransitionTimer();
 			_vtol_mode = vtol_mode::TRANSITION_BACK;
-			_transition_start_timestamp = hrt_absolute_time();
 			break;
 
 		case vtol_mode::TRANSITION_FRONT_P1:
@@ -131,8 +131,8 @@ void Tiltrotor::update_vtol_state()
 		switch (_vtol_mode) {
 		case vtol_mode::MC_MODE:
 			// initialise a front transition
+			resetTransitionTimer();
 			_vtol_mode = vtol_mode::TRANSITION_FRONT_P1;
-			_transition_start_timestamp = hrt_absolute_time();
 			break;
 
 		case vtol_mode::FW_MODE:
@@ -159,7 +159,7 @@ void Tiltrotor::update_vtol_state()
 
 				if (transition_to_p2) {
 					_vtol_mode = vtol_mode::TRANSITION_FRONT_P2;
-					_transition_start_timestamp = hrt_absolute_time();
+					resetTransitionTimer();
 				}
 
 				break;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -248,6 +248,16 @@ public:
 	 */
 	void setDt(float dt) {_dt = dt; }
 
+	/**
+	 * @brief Resets the transition timer states.
+	 *
+	 */
+	void resetTransitionTimer()
+	{
+		_transition_start_timestamp = hrt_absolute_time();
+		_time_since_trans_start = 0.f;
+	}
+
 protected:
 	VtolAttitudeControl *_attc;
 	mode _common_vtol_mode;


### PR DESCRIPTION
The transition timer state was only updated in the `VtolType::update_vtol_state` method. However, the timer value was being used in methods which were called prior to that. Thus it could happen that a backtransition was accepted immediately  due to the timer not having been reset.