### PR TITLE
drivers/gps: add param for enabling protocols at i2c interface

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -904,6 +904,15 @@ GPS::run()
 			gpsConfig.output_mode = GPSHelper::OutputMode::GPS;
 		}
 
+		int32_t gps_ubx_cfg_intf = static_cast<int32_t>(GPSHelper::InterfaceProtocolsMask::ALL_DISABLED);
+		handle = param_find("GPS_UBX_CFG_INTF");
+
+		if (handle != PARAM_INVALID) {
+			param_get(handle, &gps_ubx_cfg_intf);
+		}
+
+		gpsConfig.interface_protocols = static_cast<GPSHelper::InterfaceProtocolsMask>(gps_ubx_cfg_intf);
+
 		if (_helper && _helper->configure(_baudrate, gpsConfig) == 0) {
 
 			/* reset report */

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -125,6 +125,22 @@ PARAM_DEFINE_INT32(GPS_UBX_MODE, 0);
  */
 PARAM_DEFINE_INT32(GPS_UBX_BAUD2, 230400);
 
+/**
+ * u-blox protocol configuration for interfaces
+ *
+ * @min 0
+ * @max 32
+ * @bit 0 Enable I2C input protocol UBX
+ * @bit 1 Enable I2C input protocol NMEA
+ * @bit 2 Enable I2C input protocol RTCM3X
+ * @bit 3 Enable I2C output protocol UBX
+ * @bit 4 Enable I2C output protocol NMEA
+ * @bit 5 Enable I2C output protocol RTCM3X
+ *
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_UBX_CFG_INTF, 0);
 
 /**
  * Heading/Yaw offset for dual antenna GPS


### PR DESCRIPTION
### Solved Problem
I2C port In/Out configuration issue https://github.com/PX4/PX4-Autopilot/issues/20599

### Solution
This solution will give support for enabling protocols at the I2C interface with the **GPS_UBX_CFG_INTF** parameter. 
In the future parameter can be extended for enabling/disabling protocols at other interfaces (UART1, UART2, USB, SPI).

Needed protocols could be enabled with the check box: 
![image](https://user-images.githubusercontent.com/10188706/208114002-c7f7ddbd-f57b-4c33-a18c-d40ac758fdb9.png)

![image](https://user-images.githubusercontent.com/10188706/208113869-4b2c186c-bbef-472e-ae15-141722bc05a4.png)
