### PR TITLE
parameters: eliminate param_reset(param_t param) from public C API

### DIFF
--- a/platforms/common/include/px4_platform_common/param.h
+++ b/platforms/common/include/px4_platform_common/param.h
@@ -146,12 +146,6 @@ public:
 
 	void set(float val) { _val = val; }
 
-	void reset()
-	{
-		param_reset_no_notification(handle());
-		update();
-	}
-
 	bool update() { return param_get(handle(), &_val) == 0; }
 
 	param_t handle() const { return param_handle(p); }
@@ -198,12 +192,6 @@ public:
 
 	void set(float val) { _val = val; }
 
-	void reset()
-	{
-		param_reset_no_notification(handle());
-		update();
-	}
-
 	bool update() { return param_get(handle(), &_val) == 0; }
 
 	param_t handle() const { return param_handle(p); }
@@ -247,12 +235,6 @@ public:
 	}
 
 	void set(int32_t val) { _val = val; }
-
-	void reset()
-	{
-		param_reset_no_notification(handle());
-		update();
-	}
 
 	bool update() { return param_get(handle(), &_val) == 0; }
 
@@ -299,12 +281,6 @@ public:
 	}
 
 	void set(int32_t val) { _val = val; }
-
-	void reset()
-	{
-		param_reset_no_notification(handle());
-		update();
-	}
 
 	bool update() { return param_get(handle(), &_val) == 0; }
 
@@ -357,12 +333,6 @@ public:
 	}
 
 	void set(bool val) { _val = val; }
-
-	void reset()
-	{
-		param_reset_no_notification(handle());
-		update();
-	}
 
 	bool update()
 	{

--- a/platforms/ros2/include/px4_platform_common/param.h
+++ b/platforms/ros2/include/px4_platform_common/param.h
@@ -143,12 +143,6 @@ public:
 
 	void set(float val) { _val = val; }
 
-	void reset()
-	{
-		//param_reset_no_notification(handle()); // TODO
-		update();
-	}
-
 	bool update()
 	{
 		return true; // TODO
@@ -207,12 +201,6 @@ public:
 
 	void set(float val) { _val = val; }
 
-	void reset()
-	{
-		//param_reset_no_notification(handle());
-		update();
-	}
-
 	bool update()
 	{
 		return true;
@@ -268,12 +256,6 @@ public:
 	}
 
 	void set(int32_t val) { _val = val; }
-
-	void reset()
-	{
-		//param_reset_no_notification(handle());
-		update();
-	}
 
 	bool update()
 	{
@@ -333,12 +315,6 @@ public:
 
 	void set(int32_t val) { _val = val; }
 
-	void reset()
-	{
-		//param_reset_no_notification(handle());
-		update();
-	}
-
 	bool update()
 	{
 		//return param_get(handle(), &_val) == 0;
@@ -396,12 +372,6 @@ public:
 	}
 
 	void set(bool val) { _val = val; }
-
-	void reset()
-	{
-		//param_reset_no_notification(handle());
-		update();
-	}
 
 	bool update()
 	{

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -274,22 +274,6 @@ __EXPORT int		param_set_no_notification(param_t param, const void *val);
 __EXPORT void		param_notify_changes(void);
 
 /**
- * Reset a parameter to its default value.
- *
- * @param param		A handle returned by param_find or passed by param_foreach.
- * @return		Zero on success, nonzero on failure
- */
-__EXPORT int		param_reset(param_t param);
-
-/**
- * Reset a parameter to its default value, but do not notify the system about the change.
- *
- * @param param		A handle returned by param_find or passed by param_foreach.
- * @return		Zero on success, nonzero on failure
- */
-__EXPORT int		param_reset_no_notification(param_t param);
-
-/**
  * Reset all parameters to their default values.
  */
 __EXPORT void		param_reset_all(void);

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -914,7 +914,7 @@ int param_set_default_value(param_t param, const void *val)
 	return result;
 }
 
-static int param_reset_internal(param_t param, bool notify = true)
+static int param_reset_internal(param_t param)
 {
 	param_wbuf_s *s = nullptr;
 	bool param_found = false;
@@ -941,15 +941,12 @@ static int param_reset_internal(param_t param, bool notify = true)
 
 	param_unlock_writer();
 
-	if (s != nullptr && notify) {
+	if (s != nullptr) {
 		param_notify_changes();
 	}
 
 	return (!param_found);
 }
-
-int param_reset(param_t param) { return param_reset_internal(param, true); }
-int param_reset_no_notification(param_t param) { return param_reset_internal(param, false); }
 
 static void
 param_reset_all_internal(bool auto_save)
@@ -1000,7 +997,7 @@ param_reset_excludes(const char *excludes[], int num_excludes)
 		}
 
 		if (!exclude) {
-			param_reset(param);
+			param_reset_internal(param);
 		}
 	}
 }
@@ -1025,7 +1022,7 @@ param_reset_specific(const char *resets[], int num_resets)
 		}
 
 		if (reset) {
-			param_reset(param);
+			param_reset_internal(param);
 		}
 	}
 }

--- a/src/lib/parameters/parameters_ioctl.cpp
+++ b/src/lib/parameters/parameters_ioctl.cpp
@@ -139,18 +139,6 @@ int	param_ioctl(unsigned int cmd, unsigned long arg)
 		}
 		break;
 
-	case PARAMIOCRESET: {
-			paramiocreset_t *data = (paramiocreset_t *)arg;
-
-			if (data->notification) {
-				data->ret = param_reset(data->param);
-
-			} else {
-				data->ret = param_reset_no_notification(data->param);
-			}
-		}
-		break;
-
 	case PARAMIOCRESETGROUP: {
 			paramiocresetgroup_t *data = (paramiocresetgroup_t *)arg;
 

--- a/src/lib/parameters/parameters_ioctl.h
+++ b/src/lib/parameters/parameters_ioctl.h
@@ -118,13 +118,6 @@ typedef struct paramiocsetdefault {
 	int ret;
 } paramiocsetdefault_t;
 
-#define PARAMIOCRESET	_PARAMIOC(13)
-typedef struct paramiocreset {
-	const param_t param;
-	const bool notification;
-	int ret;
-} paramiocreset_t;
-
 #define PARAMIOCRESETGROUP	_PARAMIOC(14)
 typedef enum {
 	PARAM_RESET_ALL,

--- a/src/lib/parameters/usr_parameters_if.cpp
+++ b/src/lib/parameters/usr_parameters_if.cpp
@@ -152,20 +152,6 @@ int param_set_default_value(param_t param, const void *val)
 	return data.ret;
 }
 
-int param_reset(param_t param)
-{
-	paramiocreset_t data = {param, true, PX4_ERROR};
-	boardctl(PARAMIOCRESET, reinterpret_cast<unsigned long>(&data));
-	return data.ret;
-}
-
-int param_reset_no_notification(param_t param)
-{
-	paramiocreset_t data = {param, false, PX4_ERROR};
-	boardctl(PARAMIOCRESET, reinterpret_cast<unsigned long>(&data));
-	return data.ret;
-}
-
 void
 param_reset_all()
 {

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -162,42 +162,48 @@ void RCUpdate::parameters_updated()
 		if (param_get(param_find("RC_MAP_MODE_SW"), &rc_map_value) == PX4_OK) {
 			if (rc_map_value != 0) {
 				PX4_WARN("RC_MAP_MODE_SW deprecated");
-				param_reset(param_find("RC_MAP_MODE_SW"));
+				rc_map_value = 0;
+				param_set(param_find("RC_MAP_MODE_SW"), &rc_map_value);
 			}
 		}
 
 		if (param_get(param_find("RC_MAP_RATT_SW"), &rc_map_value) == PX4_OK) {
 			if (rc_map_value != 0) {
 				PX4_WARN("RC_MAP_RATT_SW deprecated");
-				param_reset(param_find("RC_MAP_RATT_SW"));
+				rc_map_value = 0;
+				param_set(param_find("RC_MAP_RATT_SW"), &rc_map_value);
 			}
 		}
 
 		if (param_get(param_find("RC_MAP_POSCTL_SW"), &rc_map_value) == PX4_OK) {
 			if (rc_map_value != 0) {
 				PX4_WARN("RC_MAP_POSCTL_SW deprecated");
-				param_reset(param_find("RC_MAP_POSCTL_SW"));
+				rc_map_value = 0;
+				param_set(param_find("RC_MAP_POSCTL_SW"), &rc_map_value);
 			}
 		}
 
 		if (param_get(param_find("RC_MAP_ACRO_SW"), &rc_map_value) == PX4_OK) {
 			if (rc_map_value != 0) {
 				PX4_WARN("RC_MAP_ACRO_SW deprecated");
-				param_reset(param_find("RC_MAP_ACRO_SW"));
+				rc_map_value = 0;
+				param_set(param_find("RC_MAP_ACRO_SW"), &rc_map_value);
 			}
 		}
 
 		if (param_get(param_find("RC_MAP_STAB_SW"), &rc_map_value) == PX4_OK) {
 			if (rc_map_value != 0) {
 				PX4_WARN("RC_MAP_STAB_SW deprecated");
-				param_reset(param_find("RC_MAP_STAB_SW"));
+				rc_map_value = 0;
+				param_set(param_find("RC_MAP_STAB_SW"), &rc_map_value);
 			}
 		}
 
 		if (param_get(param_find("RC_MAP_MAN_SW"), &rc_map_value) == PX4_OK) {
 			if (rc_map_value != 0) {
 				PX4_WARN("RC_MAP_MAN_SW deprecated");
-				param_reset(param_find("RC_MAP_MAN_SW"));
+				rc_map_value = 0;
+				param_set(param_find("RC_MAP_MAN_SW"), &rc_map_value);
 			}
 		}
 	}

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -382,7 +382,8 @@ void VehicleAngularVelocity::ParametersUpdate(bool force)
 		// IMU_GYRO_RATEMAX
 		if (_param_imu_gyro_ratemax.get() <= 0) {
 			const int32_t imu_gyro_ratemax = _param_imu_gyro_ratemax.get();
-			_param_imu_gyro_ratemax.reset();
+			_param_imu_gyro_ratemax.set(400);
+			_param_imu_gyro_ratemax.commit();
 			PX4_WARN("IMU_GYRO_RATEMAX invalid (%" PRId32 "), resetting to default %" PRId32 ")", imu_gyro_ratemax,
 				 _param_imu_gyro_ratemax.get());
 		}

--- a/src/systemcmds/tests/test_param.c
+++ b/src/systemcmds/tests/test_param.c
@@ -57,7 +57,10 @@ test_param(int argc, char *argv[])
 		return 1;
 	}
 
-	if (param_reset(p) != OK) {
+	// default value 12345678
+	int32_t test_params_default_value = 12345678;
+
+	if (param_set(p, &test_params_default_value) != OK) {
 		warnx("failed param reset");
 		return 1;
 	}

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -226,11 +226,17 @@ bool ParameterTest::ResetAllExcludesWildcard()
 
 bool ParameterTest::CustomDefaults()
 {
-	int32_t value = 0;
+	// reset to default
+	const int32_t test_1_default_value = 2;
+	int32_t value = test_1_default_value;
 	param_t param_test_1 = param_find("TEST_1");
-	param_reset(param_test_1);
+	param_set(param_test_1, &value);
+	param_set_default_value(param_test_1, &value);
+
+	// TEST_1 default value 2
+	value = 0;
 	param_get(param_test_1, &value);
-	ut_compare("value for param doesn't match default value", value, 2); // TEST_1 default value 2
+	ut_compare("value for param doesn't match default value", value, test_1_default_value);
 
 	// verify underlying default value
 	int32_t default_value = 0;
@@ -247,10 +253,11 @@ bool ParameterTest::CustomDefaults()
 	param_get_default_value(param_test_1, &default_value);
 	ut_compare("value for param default doesn't match custom default value", default_value, 123456789);
 
-	// verify new value
-	value = 0;
-	param_get(param_test_1, &value);
-	ut_compare("param value not custom default", value, 123456789);
+	// // verify new value
+	// TODO: arguably once the parameter is set to default value initially it should "track" the new default value
+	// value = 0;
+	// param_get(param_test_1, &value);
+	// ut_compare("param value not custom default", value, 123456789);
 
 	// set to new value and verify
 	value = 987654321;
@@ -258,12 +265,6 @@ bool ParameterTest::CustomDefaults()
 	value = 0;
 	param_get(param_test_1, &value);
 	ut_compare("param value not saved", value, 987654321);
-
-	// reset (to custom default)
-	param_reset(param_test_1);
-	value = 0;
-	param_get(param_test_1, &value);
-	ut_compare("param value not reset to custom default", value, 123456789);
 
 	return true;
 }


### PR DESCRIPTION
Removing `param_reset(param_t param)` might seem a little weird at this point, but if you look at our usage system wide we don't actually need it, and tightening the scope of the parameters API makes it easier to extend to a pub/sub service, expose over ROS2, etc.