### PR TITLE
lockstep_scheduler: avoid pthread_cond_destroy on at_exit

### DIFF
--- a/platforms/posix/src/px4/common/drv_hrt.cpp
+++ b/platforms/posix/src/px4/common/drv_hrt.cpp
@@ -53,7 +53,7 @@
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 #include <lockstep_scheduler/lockstep_scheduler.h>
-static LockstepScheduler lockstep_scheduler {};
+static LockstepScheduler lockstep_scheduler {true};
 #endif
 
 // Intervals in usec

--- a/platforms/posix/src/px4/common/lockstep_scheduler/include/lockstep_scheduler/lockstep_components.h
+++ b/platforms/posix/src/px4/common/lockstep_scheduler/include/lockstep_scheduler/lockstep_components.h
@@ -46,7 +46,7 @@
 class LockstepComponents
 {
 public:
-	LockstepComponents();
+	LockstepComponents(bool no_cleanup_on_destroy = false);
 	~LockstepComponents();
 
 	/**
@@ -69,6 +69,7 @@ public:
 	void wait_for_components();
 
 private:
+	const bool _no_cleanup_on_destroy;
 
 	px4_sem_t _components_sem;
 

--- a/platforms/posix/src/px4/common/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/px4/common/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -46,6 +46,7 @@
 class LockstepScheduler
 {
 public:
+	LockstepScheduler(bool no_cleanup_on_destroy = false) : _components(no_cleanup_on_destroy) {}
 	~LockstepScheduler();
 
 	void set_absolute_time(uint64_t time_us);


### PR DESCRIPTION
The static object is destroyed on at_exit while threads might still be inside a CS. This can lead to a hanging process.
Cleaner would be to gracefully stop the threads.

According to https://linux.die.net/man/3/pthread_cond_destroy: Attempting to destroy a condition variable upon which other threads are currently blocked results in undefined behavior.