### PR TITLE
Split out some commits from #20707

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -184,6 +184,9 @@ param set-default SDLOG_DIRS_MAX 7
 param set-default TRIG_INTERFACE 3
 
 param set-default SYS_FAILURE_EN 1
+# Enable low-battery actions by default for (automated) testing. Battery sim
+# does not go below 50% by default, but failure injection can trigger failsafes.
+param set-default COM_LOW_BAT_ACT 2
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.
 if [ -n "$PX4_SIM_SPEED_FACTOR" ]; then

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -125,6 +125,7 @@ set(msg_files
 	Mission.msg
 	MissionResult.msg
 	MountOrientation.msg
+	ModeCompleted.msg
 	NavigatorMissionItem.msg
 	NpfgStatus.msg
 	ObstacleDistance.msg

--- a/msg/ModeCompleted.msg
+++ b/msg/ModeCompleted.msg
@@ -1,0 +1,14 @@
+# Mode completion result, published by an active mode.
+# Note that this is not always published (e.g. when a user switches modes or on
+# failsafe activation)
+uint64 timestamp				 # time since system start (microseconds)
+
+
+uint8 RESULT_SUCCESS = 0
+# [1-99]: reserved
+uint8 RESULT_FAILURE_OTHER = 100 # Mode failed (generic error)
+
+uint8 result                     # One of RESULT_*
+
+uint8 nav_state                  # Source mode
+

--- a/src/modules/commander/failsafe/emscripten.cpp
+++ b/src/modules/commander/failsafe/emscripten.cpp
@@ -167,7 +167,7 @@ void set_param_value_float(const std::string &name, float value)
 
 int failsafe_update(bool armed, bool vtol_in_transition_mode, bool mission_finished,
 		    bool user_override, uint8_t user_intended_mode, uint8_t vehicle_type,
-		    failsafe_flags_s status_flags)
+		    failsafe_flags_s status_flags, bool defer_failsafes)
 {
 	uint64_t time_ms = emscripten_date_now();
 	FailsafeBase::State state{};
@@ -177,6 +177,7 @@ int failsafe_update(bool armed, bool vtol_in_transition_mode, bool mission_finis
 	state.user_intended_mode = user_intended_mode;
 	state.vehicle_type = vehicle_type;
 	mode_util::getModeRequirements(vehicle_type, status_flags);
+	failsafe_instance.current().deferFailsafes(defer_failsafes, 0);
 	return failsafe_instance.current().update(time_ms * 1000, state, false, user_override, status_flags);
 }
 

--- a/src/modules/commander/failsafe/emscripten_template.html
+++ b/src/modules/commander/failsafe/emscripten_template.html
@@ -203,6 +203,11 @@
                                 <button onclick="moveRCSticks()">Move RC Sticks (user takeover request)</button>
                             </td>
                         </tr>
+                        <tr style="display:none;"> <!-- hide this by default -->
+                            <td><label for="defer_failsafes">Defer Failsafes:</label></td>
+                            <td><input type="checkbox" id="defer_failsafes" name="defer_failsafes"></td>
+                            <td></td>
+                        </tr>
                     </table>
                 </div>
                 <div class="box"><h3>Parameters</h3>
@@ -319,8 +324,9 @@
           var mission_finished = document.querySelector('input[id="mission_finished"]').checked;
           var intended_nav_state = document.querySelector('select[id="intended_nav_state"]').value;
           var vehicle_type = document.querySelector('select[id="vehicle_type"]').value;
+          var defer_failsafes = document.querySelector('input[id="defer_failsafes"]').checked;
           var updated_user_intended_mode = Module.failsafe_update(armed, vtol_in_transition_mode, mission_finished, user_override_requested, parseInt(intended_nav_state),
-              parseInt(vehicle_type), state);
+              parseInt(vehicle_type), state, defer_failsafes);
           user_override_requested = false;
           var action = Module.selected_action();
           action_str = Module.action_str(action);

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -70,7 +70,14 @@ uint8_t FailsafeBase::update(const hrt_abstime &time_us, const State &state, boo
 		removeActions(ClearCondition::OnModeChangeOrDisarm);
 	}
 
-	updateDelay(time_us - _last_update);
+	if (_defer_failsafes && _failsafe_defer_started != 0 && _defer_timeout > 0
+	    && time_us > _failsafe_defer_started + _defer_timeout) {
+		_defer_failsafes = false;
+	}
+
+	if (_failsafe_defer_started == 0) {
+		updateDelay(time_us - _last_update);
+	}
 
 	checkStateAndMode(time_us, state, status_flags);
 	removeNonActivatedActions();
@@ -79,7 +86,8 @@ uint8_t FailsafeBase::update(const hrt_abstime &time_us, const State &state, boo
 	SelectedActionState action_state{};
 	getSelectedAction(state, status_flags, user_intended_mode_updated, rc_sticks_takeover_request, action_state);
 
-	updateDelay(time_us - _last_update, action_state.delayed_action != Action::None);
+	updateStartDelay(time_us - _last_update, action_state.delayed_action != Action::None);
+	updateFailsafeDeferState(time_us, action_state.failsafe_deferred);
 
 	// Notify user if the action is worse than before, or a new action got added
 	if (action_state.action > _selected_action || (action_state.action != Action::None && _notification_required)) {
@@ -98,7 +106,19 @@ uint8_t FailsafeBase::update(const hrt_abstime &time_us, const State &state, boo
 	return _last_user_intended_mode;
 }
 
-void FailsafeBase::updateDelay(const hrt_abstime &dt, bool delay_active)
+void FailsafeBase::updateFailsafeDeferState(const hrt_abstime &time_us, bool defer)
+{
+	if (defer) {
+		if (_failsafe_defer_started == 0) {
+			_failsafe_defer_started = time_us;
+		}
+
+	} else {
+		_failsafe_defer_started = 0;
+	}
+}
+
+void FailsafeBase::updateStartDelay(const hrt_abstime &dt, bool delay_active)
 {
 	// Ensure that even with a toggling state the delayed action is executed at some point.
 	// This is done by increasing the delay slower than reducing it.
@@ -411,6 +431,7 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 	returned_state.action = Action::None;
 	Action &selected_action = returned_state.action;
 	UserTakeoverAllowed allow_user_takeover = UserTakeoverAllowed::Always;
+	bool allow_failsafe_to_be_deferred{true};
 
 	// Select the worst action based on the current active actions
 	for (int action_idx = 0; action_idx < max_num_actions; ++action_idx) {
@@ -426,7 +447,17 @@ void FailsafeBase::getSelectedAction(const State &state, const failsafe_flags_s 
 				selected_action = cur_action.action;
 				returned_state.cause = cur_action.cause;
 			}
+
+			if (!cur_action.can_be_deferred) {
+				allow_failsafe_to_be_deferred = false;
+			}
 		}
+	}
+
+	if (_defer_failsafes && allow_failsafe_to_be_deferred && selected_action != Action::None) {
+		returned_state.failsafe_deferred = selected_action > Action::Warn;
+		returned_state.action = Action::None;
+		return;
 	}
 
 	// Check if we should enter delayed Hold
@@ -625,4 +656,24 @@ bool FailsafeBase::modeCanRun(const failsafe_flags_s &status_flags, uint8_t mode
 		(!status_flags.offboard_control_signal_lost || ((status_flags.mode_req_offboard_signal & mode_mask) == 0)) &&
 		(!status_flags.home_position_invalid || ((status_flags.mode_req_home_position & mode_mask) == 0)) &&
 		((status_flags.mode_req_other & mode_mask) == 0);
+}
+
+bool FailsafeBase::deferFailsafes(bool enabled, int timeout_s)
+{
+	if (enabled && _selected_action > Action::Warn) {
+		return false;
+	}
+
+	if (timeout_s == 0) {
+		_defer_timeout = DEFAULT_DEFER_TIMEOUT;
+
+	} else if (timeout_s < 0) {
+		_defer_timeout = 0;
+
+	} else {
+		_defer_timeout = timeout_s * 1_s;
+	}
+
+	_defer_failsafes = enabled;
+	return true;
 }

--- a/src/modules/microdds_client/dds_topics.h.em
+++ b/src/modules/microdds_client/dds_topics.h.em
@@ -118,7 +118,10 @@ static void on_topic_update(uxrSession *session, uxrObjectId object_id, uint16_t
 bool RcvTopicsPubs::init(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId reliable_in_stream_id, uxrStreamId best_effort_in_stream_id, uxrObjectId participant_id, const char *client_namespace)
 {
 @[    for idx, sub in enumerate(subscriptions)]@
-	create_data_reader(session, reliable_out_stream_id, best_effort_in_stream_id, participant_id, @(idx), client_namespace, "@(sub['topic_simple'])", "@(sub['dds_type'])");
+	{
+			uint16_t queue_depth = uORB::DefaultQueueSize<@(sub['simple_base_type'])_s>::value * 2; // use a bit larger queue size than internal
+			create_data_reader(session, reliable_out_stream_id, best_effort_in_stream_id, participant_id, @(idx), client_namespace, "@(sub['topic_simple'])", "@(sub['dds_type'])", queue_depth);
+	}
 @[    end for]@
 
 	uxr_set_topic_callback(session, on_topic_update, this);

--- a/src/modules/microdds_client/utilities.hpp
+++ b/src/modules/microdds_client/utilities.hpp
@@ -84,7 +84,7 @@ static bool create_data_writer(uxrSession *session, uxrStreamId reliable_out_str
 
 static bool create_data_reader(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId input_stream_id,
 			       uxrObjectId participant_id, uint16_t index, const char *client_namespace, const char *topic_name_simple,
-			       const char *type_name)
+			       const char *type_name, uint16_t queue_depth)
 {
 	// topic
 	char topic_name[TOPIC_NAME_SIZE];
@@ -115,7 +115,7 @@ static bool create_data_reader(uxrSession *session, uxrStreamId reliable_out_str
 		.durability = UXR_DURABILITY_VOLATILE,
 		.reliability = UXR_RELIABILITY_BEST_EFFORT,
 		.history = UXR_HISTORY_KEEP_LAST,
-		.depth = 0,
+		.depth = queue_depth,
 	};
 
 	uint16_t datareader_req = uxr_buffer_create_datareader_bin(session, reliable_out_stream_id, datareader_id,

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -87,6 +87,7 @@ Land::on_active()
 	if (_navigator->get_land_detected()->landed) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
+		_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND);
 		set_idle_item(&_mission_item);
 
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -735,6 +735,7 @@ Mission::set_mission_items()
 		// set mission finished
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
+		_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
 
 		if (!user_feedback_done) {
 			/* only tell users that we got no mission if there has not been any

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -77,6 +77,7 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/mode_completed.h>
 #include <uORB/uORB.h>
 
 using namespace time_literals;
@@ -323,6 +324,8 @@ public:
 	void 		calculate_breaking_stop(double &lat, double &lon, float &yaw);
 	void        	stop_capturing_images();
 
+	void mode_completed(uint8_t nav_state, uint8_t result = mode_completed_s::RESULT_SUCCESS);
+
 private:
 
 	struct traffic_buffer_s {
@@ -352,6 +355,7 @@ private:
 	uORB::Publication<vehicle_command_ack_s>	_vehicle_cmd_ack_pub{ORB_ID(vehicle_command_ack)};
 	uORB::Publication<vehicle_command_s>		_vehicle_cmd_pub{ORB_ID(vehicle_command)};
 	uORB::Publication<vehicle_roi_s>		_vehicle_roi_pub{ORB_ID(vehicle_roi)};
+	uORB::Publication<mode_completed_s> _mode_completed_pub{ORB_ID(mode_completed)};
 
 	orb_advert_t	_mavlink_log_pub{nullptr};	/**< the uORB advert to send messages over mavlink */
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1620,6 +1620,15 @@ void Navigator::calculate_breaking_stop(double &lat, double &lon, float &yaw)
 	yaw = get_local_position()->heading;
 }
 
+void Navigator::mode_completed(uint8_t nav_state, uint8_t result)
+{
+	mode_completed_s mode_completed{};
+	mode_completed.timestamp = hrt_absolute_time();
+	mode_completed.result = result;
+	mode_completed.nav_state = nav_state;
+	_mode_completed_pub.publish(mode_completed);
+}
+
 int Navigator::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -668,6 +668,7 @@ void RTL::advance_rtl()
 
 	case RTL_STATE_LAND:
 		_rtl_state = RTL_STATE_LANDED;
+		_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_RTL);
 		break;
 
 	default:

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -65,6 +65,7 @@ Takeoff::on_active()
 	} else if (is_mission_item_reached_or_completed() && !_navigator->get_mission_result()->finished) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
+		_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF);
 
 		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 

--- a/src/modules/navigator/vtol_takeoff.cpp
+++ b/src/modules/navigator/vtol_takeoff.cpp
@@ -149,9 +149,10 @@ VtolTakeoff::on_active()
 				_navigator->reset_position_setpoint(reposition_triplet->current);
 				_navigator->reset_position_setpoint(reposition_triplet->next);
 
-				// the VTOL takeoff is done, proceed loitering and update the navigation state to LOITER
+				// the VTOL takeoff is done
 				_navigator->get_mission_result()->finished = true;
 				_navigator->set_mission_result_updated();
+				_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF);
 
 				break;
 			}

--- a/src/modules/simulation/battery_simulator/BatterySimulator.hpp
+++ b/src/modules/simulation/battery_simulator/BatterySimulator.hpp
@@ -45,6 +45,8 @@
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
 
 using namespace time_literals;
 
@@ -67,6 +69,7 @@ public:
 
 private:
 	void Run() override;
+	void updateCommands();
 
 	static constexpr uint32_t BATTERY_SIMLATOR_SAMPLE_FREQUENCY_HZ = 100; // Hz
 	static constexpr uint32_t BATTERY_SIMLATOR_SAMPLE_INTERVAL_US = 1_s / BATTERY_SIMLATOR_SAMPLE_FREQUENCY_HZ;
@@ -76,11 +79,16 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
+	uORB::Subscription _vehicle_command_sub{ORB_ID(vehicle_command)};
+	uORB::Publication<vehicle_command_ack_s> _command_ack_pub{ORB_ID(vehicle_command_ack)};
+
 	Battery _battery;
 
 	uint64_t _last_integration_us{0};
 	float _battery_percentage{1.f};
 	bool _armed{false};
+
+	bool _force_empty_battery{false};
 
 	perf_counter_t	_loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 


### PR DESCRIPTION
First few commits from #20707 (w/o changes):
* microdds_client: set queue depth for incoming topics according to msg definition
* commander failsafe: add API to defer failsafes
* navigator: add ModeCompleted signalling topic
* ROMFS: enable COM_LOW_BAT_ACT by default for SITL
* battery_simulator: add support for failure injection 
