### PR TITLE
rc.board_param init file to specify custom board param save location

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -176,6 +176,7 @@ list(APPEND OPTIONAL_BOARD_RC
 	rc.board_sensors
 	rc.board_extras
 	rc.board_mavlink
+	rc.board_param
 )
 
 foreach(board_rc_file ${OPTIONAL_BOARD_RC})

--- a/ROMFS/cannode/init.d/rcS
+++ b/ROMFS/cannode/init.d/rcS
@@ -21,19 +21,19 @@ set R /
 #
 ver all
 
+#
+# Set the parameter file the board supports params on
+# MTD device.
+#
 if mft query -q -k MTD -s MTD_PARAMETERS -v /fs/mtd_params
 then
 	set PARAM_FILE /fs/mtd_params
-fi
-
-if mft query -q -k MTD -s MTD_PARAMETERS -v /dev/eeeprom0
-then
-	set PARAM_FILE /dev/eeeprom0
-fi
-
-if mft query -q -k MTD -s MTD_PARAMETERS -v /mnt/qspi/params
-then
-	set PARAM_FILE /mnt/qspi/params
+else
+	set BOARD_PARAM ${R}etc/init.d/rc.board_param
+	if [ -f $BOARD_PARAM ]
+	then
+		. $BOARD_PARAM
+	fi
 fi
 
 #

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -113,6 +113,12 @@ else
 	if mft query -q -k MTD -s MTD_PARAMETERS -v /fs/mtd_params
 	then
 		set PARAM_FILE /fs/mtd_params
+	else
+		set BOARD_PARAM ${R}etc/init.d/rc.board_param
+		if [ -f $BOARD_PARAM ]
+		then
+			. $BOARD_PARAM
+		fi
 	fi
 
 	#

--- a/boards/nxp/mr-canhubk3/init/rc.board_param
+++ b/boards/nxp/mr-canhubk3/init/rc.board_param
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# board specific defaults
+#------------------------------------------------------------------------------
+
+set PARAM_FILE /mnt/qspi/params

--- a/boards/nxp/mr-canhubk3/nuttx-config/scripts/script.ld
+++ b/boards/nxp/mr-canhubk3/nuttx-config/scripts/script.ld
@@ -49,6 +49,7 @@ MEMORY
 OUTPUT_ARCH(arm)
 EXTERN(_vectors)
 EXTERN(boot_header)
+EXTERN(board_get_manifest)
 ENTRY(_stext)
 
 SECTIONS

--- a/boards/nxp/mr-canhubk3/src/mtd.cpp
+++ b/boards/nxp/mr-canhubk3/src/mtd.cpp
@@ -33,37 +33,25 @@
 
 #include <nuttx/spi/spi.h>
 #include <px4_platform_common/px4_manifest.h>
-//                                                              KiB BS    nB
-static const px4_mft_device_t qspi_flash = {            // 8MB QSPI flash with NXFFS
-	.bus_type = px4_mft_device_t::ONCHIP,
-};
 
 static const px4_mft_device_t i2c0 = {             // 24LC64T on IMU   8K 32 X 256
 	.bus_type =  px4_mft_device_t::I2C,
 	.devid    =  PX4_MK_I2C_DEVID(1, 0x50)
 };
 
-
-static const px4_mtd_entry_t fmum_qspi_flash = {
-	.device = &qspi_flash,
-	.npart = 1,
-	.partd = {
-		{
-			.type = MTD_PARAMETERS,
-			.path = "/mnt/qspi/params",
-			.nblocks = 1
-		}
-	},
-};
-
 static const px4_mtd_entry_t imu_eeprom = {
 	.device = &i2c0,
-	.npart = 2,
+	.npart = 3,
 	.partd = {
 		{
 			.type = MTD_CALDATA,
 			.path = "/fs/mtd_caldata",
-			.nblocks = 248
+			.nblocks = 240
+		},
+		{
+			.type = MTD_MFT_REV,
+			.path = "/fs/mtd_mft_rev",
+			.nblocks = 8
 		},
 		{
 			.type = MTD_ID,
@@ -75,10 +63,9 @@ static const px4_mtd_entry_t imu_eeprom = {
 
 
 static const px4_mtd_manifest_t board_mtd_config = {
-	.nconfigs   = 2,
+	.nconfigs   = 1,
 	.entries = {
-		&imu_eeprom,
-		&fmum_qspi_flash
+		&imu_eeprom
 	}
 };
 

--- a/boards/nxp/ucans32k146/init/rc.board_param
+++ b/boards/nxp/ucans32k146/init/rc.board_param
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# board specific defaults
+#------------------------------------------------------------------------------
+
+set PARAM_FILE /dev/eeeprom0


### PR DESCRIPTION
MTD_PARAMETERS can be freely defined as any path in the board definition.
But the rcS startup script still has to check all paths manually for all boards.

Current status:
- /fs/mtd_params
- /dev/eeeprom0
- /mnt/qspi/params

Add board specific rc.board_param file where the board can specify the parameter save file.