### PR TITLE
SF30/d lidar support

### DIFF
--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -194,6 +194,13 @@ int LightwareLaser::init()
 		_conversion_interval = 20834;
 		_type = Type::LW20c;
 		break;
+			
+	case 7:
+		/* SF30/D (200m 20-20000Hz) */
+		_px4_rangefinder.set_min_distance(0.2f);
+		_px4_rangefinder.set_max_distance(200.0f);
+		_conversion_interval = 25588;
+		break;
 
 	default:
 		PX4_ERR("invalid HW model %" PRId32 ".", hw_model);

--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -422,7 +422,7 @@ void LightwareLaser::print_usage()
 		R"DESCR_STR(
 ### Description
 
-I2C bus driver for Lightware SFxx series LIDAR rangefinders: SF10/a, SF10/b, SF10/c, SF11/c, SF/LW20.
+I2C bus driver for Lightware SFxx series LIDAR rangefinders: SF10/a, SF10/b, SF10/c, SF11/c, SF/LW20, SF30/d.
 
 Setup/usage information: https://docs.px4.io/main/en/sensor/sfxx_lidar.html
 )DESCR_STR");

--- a/src/drivers/distance_sensor/lightware_laser_i2c/parameters.c
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/parameters.c
@@ -45,5 +45,6 @@
  * @value 4 SF11/c
  * @value 5 SF/LW20/b
  * @value 6 SF/LW20/c
+ * @value 7 SF30/d
  */
 PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);


### PR DESCRIPTION
This adds support for the lightware SF30/d lidar (laser altimeter) with 200m range.

Bench tested and works as intended.

It outputs 250m when out of range (and the SF11/c outputs 650m) so we may want to filter those exact numbers out by anything that is consuming this lidar data.

Also, I have this set at 39hz but it can go up to 20k hz with little to no range degradation. Is there a reason to not increase the this (ie is it useful to have faster refresh rate and can that fast data data even be consumed? Concerns here would be overloading the i2c bus, if relevant). 

https://www.documents.lightware.co.za/SF30%20D%20-%20LiDAR%20Datasheet%20-%20Rev%200.pdf
