### PR TITLE
Decrease PAW3902 and PAA3905 backup schedule to 200ms

### DIFF
--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -234,7 +234,7 @@ void PAA3905::RunImpl()
 				}
 
 				// push backup schedule back
-				ScheduleDelayed(1_s);
+				ScheduleDelayed(kBackupScheduleIntervalUs);
 			}
 
 			struct TransferBuffer {
@@ -415,7 +415,7 @@ void PAA3905::RunImpl()
 					}
 
 					// only publish when there's motion or at least every second
-					if (motion_reported || (hrt_elapsed_time(&_last_publish) >= 1_s)) {
+					if (motion_reported || (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs)) {
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);

--- a/src/drivers/optical_flow/paa3905/PAA3905.hpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.hpp
@@ -121,6 +121,7 @@ private:
 	bool _data_ready_interrupt_enabled{false};
 
 	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_0 / 2};
+	static constexpr uint32_t kBackupScheduleIntervalUs{200_ms};
 
 	Mode _mode{Mode::LowLight};
 

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -239,7 +239,7 @@ void PAW3902::RunImpl()
 				}
 
 				// push backup schedule back
-				ScheduleDelayed(1_s);
+				ScheduleDelayed(kBackupScheduleIntervalUs);
 			}
 
 			struct TransferBuffer {
@@ -418,7 +418,7 @@ void PAW3902::RunImpl()
 					}
 
 					// only publish when there's motion or at least every second
-					if (motion_reported || (hrt_elapsed_time(&_last_publish) >= 1_s)) {
+					if (motion_reported || (hrt_elapsed_time(&_last_publish) >= kBackupScheduleIntervalUs)) {
 
 						sensor_optical_flow.timestamp = hrt_absolute_time();
 						_sensor_optical_flow_pub.publish(sensor_optical_flow);

--- a/src/drivers/optical_flow/paw3902/PAW3902.hpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.hpp
@@ -121,6 +121,7 @@ private:
 	bool _data_ready_interrupt_enabled{false};
 
 	uint32_t _scheduled_interval_us{SAMPLE_INTERVAL_MODE_0 / 2};
+	static constexpr uint32_t kBackupScheduleIntervalUs{200_ms};
 
 	Mode _mode{Mode::LowLight};
 


### PR DESCRIPTION
Ardupilot requires the optical flow data to be published at least once every 200ms. Decrease the backup schedule from 1 second to 200ms. 

https://review.px4.io/plot_app?log=d0f3ed77-24bc-4a40-af77-2cf56eca375f