### PR TITLE
mavlink_shell: fix stall on CubeOrange

### DIFF
--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -114,8 +114,6 @@ int MavlinkShell::start()
 #ifdef __PX4_NUTTX
 	sched_lock();
 #endif /* __PX4_NUTTX */
-	fflush(stdout);
-	fflush(stderr);
 
 #ifdef __PX4_POSIX
 	int remote_in_fd = dup(_shell_fds[0]);	// Input file descriptor for the remote shell


### PR DESCRIPTION
On CubeOrange where no console is configured by default, starting MAVLink shell just stalls, and doesn't work.

Also, logfile download has been reported not to work, and again, seems to work with this change.

@bkueng does this make any sense to you? Why are the `fflush`s required? 

Related to #19831.