### PR TITLE
Commander: always update parameters, not just if disarmed

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1644,12 +1644,9 @@ void Commander::run()
 			parameter_update_s update;
 			_parameter_update_sub.copy(&update);
 
-			/* update parameters */
-			if (!_arm_state_machine.isArmed()) {
-				updateParameters();
+			updateParameters();
 
-				_status_changed = true;
-			}
+			_status_changed = true;
 		}
 
 		/* Update OA parameter */


### PR DESCRIPTION

### Solved Problem
In Commander, the local copies of PX4 parameters are only updated if disarmed, and not if armed. This makes it impossible to change any COM_* parameter if in air (well, you can change it but it doesn't have any effect until you land and takeoff again). The user is not notified about params not having an effect immediately (as opposed to the ones that require a reboot).

### Solution
Remove check for if (disarmed). 

Are you aware of any COM_* params that really should not be updated in air?



