### PR TITLE
EKF2: Only fuse fake yaw when really needed

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -360,7 +360,6 @@ struct parameters {
 	int32_t mag_fusion_type{0};             ///< integer used to specify the type of magnetometer fusion used
 	float mag_acc_gate{0.5f};               ///< when in auto select mode, heading fusion will be used when manoeuvre accel is lower than this (m/sec**2)
 	float mag_yaw_rate_gate{0.25f};         ///< yaw rate threshold used by mode select logic (rad/sec)
-	const float quat_max_variance{0.0001f}; ///< zero innovation yaw measurements will not be fused when the sum of quaternion variance is less than this
 
 	// GNSS heading fusion
 	float gps_heading_noise{0.1f};          ///< measurement noise standard deviation used for GNSS heading fusion (rad)

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -392,7 +392,7 @@ void Ekf::controlBetaFusion()
 void Ekf::controlDragFusion()
 {
 	if ((_params.fusion_mode & SensorFusionMask::USE_DRAG) && _drag_buffer &&
-	    !_control_status.flags.fake_pos && _control_status.flags.in_air && !_mag_inhibit_yaw_reset_req) {
+	    !_control_status.flags.fake_pos && _control_status.flags.in_air) {
 
 		if (!_control_status.flags.wind) {
 			// reset the wind states and covariances when starting drag accel fusion

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -525,11 +525,9 @@ private:
 	uint64_t _mag_use_not_inhibit_us{0};	///< last system time in usec before magnetometer use was inhibited
 	float _last_static_yaw{NAN};		///< last yaw angle recorded when on ground motion checks were passing (rad)
 
-	bool _mag_inhibit_yaw_reset_req{false};	///< true when magnetometer inhibit has been active for long enough to require a yaw reset when conditions improve.
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
-	bool _is_yaw_fusion_inhibited{false};		///< true when yaw sensor use is being inhibited
 
 	SquareMatrix24f P{};	///< state covariance matrix
 
@@ -870,7 +868,6 @@ private:
 	float getTerrainVPos() const { return isTerrainEstimateValid() ? _terrain_vpos : _last_on_ground_posD; }
 
 	void runOnGroundYawReset();
-	bool canResetMagHeading() const;
 	void runInAirYawReset();
 
 	void selectMagAuto();
@@ -880,7 +877,6 @@ private:
 	bool canUse3DMagFusion() const;
 
 	void checkMagDeclRequired();
-	void checkMagInhibition();
 	bool shouldInhibitMag() const;
 	bool magFieldStrengthDisturbed(const Vector3f &mag) const;
 	static bool isMeasuredMatchingExpected(float measured, float expected, float gate);

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -666,9 +666,9 @@ private:
 	bool fuseMag(const Vector3f &mag, estimator_aid_source3d_s &aid_src_mag, bool update_all_states = true);
 
 	// update quaternion states and covariances using an innovation, observation variance and Jacobian vector
-	// innovation : prediction - measurement
-	// variance : observaton variance
-	bool fuseYaw(const float innovation, const float variance, estimator_aid_source1d_s &aid_src_status);
+	bool fuseYaw(float innovation, float variance, estimator_aid_source1d_s &aid_src_status);
+	bool fuseYaw(float innovation, float variance, estimator_aid_source1d_s &aid_src_status, const Vector24f &H_YAW);
+	void computeYawInnovVarAndH(float variance, float &innovation_variance, Vector24f &H_YAW) const;
 
 	// fuse the yaw angle obtained from a dual antenna GPS unit
 	void fuseGpsYaw();

--- a/src/modules/ekf2/test/CMakeLists.txt
+++ b/src/modules/ekf2/test/CMakeLists.txt
@@ -51,6 +51,7 @@ px4_add_unit_gtest(SRC test_EKF_gnss_yaw_generated.cpp LINKLIBS ecl_EKF ecl_test
 px4_add_unit_gtest(SRC test_EKF_height_fusion.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)
 px4_add_unit_gtest(SRC test_EKF_imuSampling.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_initialization.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
+px4_add_unit_gtest(SRC test_EKF_mag.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_mag_3d_fusion_generated.cpp LINKLIBS ecl_EKF ecl_test_helper)
 px4_add_unit_gtest(SRC test_EKF_mag_declination_generated.cpp LINKLIBS ecl_EKF ecl_test_helper)
 px4_add_unit_gtest(SRC test_EKF_measurementSampling.cpp LINKLIBS ecl_EKF ecl_sensor_sim)

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -195,6 +195,11 @@ void EkfWrapper::setMagFuseTypeNone()
 	_ekf_params->mag_fusion_type = MagFuseType::NONE;
 }
 
+void EkfWrapper::enableMagStrengthCheck()
+{
+	_ekf_params->check_mag_strength = 1;
+}
+
 bool EkfWrapper::isWindVelocityEstimated() const
 {
 	return _ekf->control_status_flags().wind;

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -97,6 +97,7 @@ public:
 	bool isIntendingMagHeadingFusion() const;
 	bool isIntendingMag3DFusion() const;
 	void setMagFuseTypeNone();
+	void enableMagStrengthCheck();
 
 	bool isWindVelocityEstimated() const;
 

--- a/src/modules/ekf2/test/test_EKF_mag.cpp
+++ b/src/modules/ekf2/test/test_EKF_mag.cpp
@@ -1,0 +1,129 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 ECL Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Test the mag fusion
+ */
+
+#include <gtest/gtest.h>
+#include "EKF/ekf.h"
+#include "sensor_simulator/sensor_simulator.h"
+#include "sensor_simulator/ekf_wrapper.h"
+#include "test_helper/reset_logging_checker.h"
+
+class EkfMagTest : public ::testing::Test
+{
+public:
+
+	EkfMagTest(): ::testing::Test(),
+		_ekf{std::make_shared<Ekf>()},
+		_sensor_simulator(_ekf),
+		_ekf_wrapper(_ekf) {};
+
+	std::shared_ptr<Ekf> _ekf;
+	SensorSimulator _sensor_simulator;
+	EkfWrapper _ekf_wrapper;
+
+	// Setup the Ekf with synthetic measurements
+	void SetUp() override
+	{
+		// run briefly to init, then manually set in air and at rest (default for a real vehicle)
+		_ekf->init(0);
+		_sensor_simulator.runSeconds(0.1);
+		_ekf->set_in_air_status(false);
+		_ekf->set_vehicle_at_rest(true);
+	}
+
+	const uint32_t _init_duration_s{4};
+};
+
+TEST_F(EkfMagTest, fusionStartWithReset)
+{
+	// GIVEN: some meaningful mag data
+	const float mag_heading = M_PI_F / 3.f;
+	const Vector3f mag_data(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f);
+	_sensor_simulator._mag.setData(mag_data);
+
+	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	// THEN: the fusion initializes using the mag data and runs normally
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), mag_heading, radians(0.1f));
+	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
+}
+
+TEST_F(EkfMagTest, noInitLargeStrength)
+{
+	// GIVEN: a really large magnetic field
+	_ekf_wrapper.enableMagStrengthCheck();
+	const Vector3f mag_data(1.f, 1.f, 1.f);
+	_sensor_simulator._mag.setData(mag_data);
+
+	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	// THEN: the fusion shouldn't start
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+	EXPECT_EQ(0, (int) _ekf->control_status_flags().yaw_align);
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter);
+}
+
+TEST_F(EkfMagTest, suddenLargeStrength)
+{
+	_ekf_wrapper.enableMagStrengthCheck();
+
+	// GIVEN: some meaningful mag data
+	const float mag_heading = -M_PI_F / 7.f;
+	Vector3f mag_data(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f);
+	_sensor_simulator._mag.setData(mag_data);
+
+	_sensor_simulator.runSeconds(_init_duration_s);
+
+	// THEN: the fusion initializes using the mag data and runs normally
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), mag_heading, radians(0.1f));
+	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+
+	// BUT WHEN: the mag field norm is suddenly too large
+	mag_data *= 5.f;
+	_sensor_simulator._mag.setData(mag_data);
+	_sensor_simulator.runSeconds(6.f);
+
+	// THEN: the mag fusion should stop after some time
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+}


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When not using a mag (e.g.: after yaw emergency or mag type "none"), a yaw error isn't properly corrected even in presence of a large acceleration an a GNSS observation.

### Solution
Constantly fusing a zero yaw innovation makes the filter too confident about its yaw estimate and doesn't correct itself anymore. The proposed solution is to only fuse a fake yaw measurement when the yaw variance of the estimator is too large (i.e.: larger than its initialization value).

Other changes:
- do not run the mag selection/reset/fusion logic when the mag is inhibited
- stop the mag fusion when the mag is constantly inhibited, this prevents having the mag fusion flag set while the fusion is not occurring for a long time.

### Test coverage
SITL test: mag type none, takeoff in alt mode, move to init yaw. After a couple of seconds, change the gyro bias to 0.1 rad/s

before:
The gyro bias takes time to estimate and during that time, the drone makes a violent toilet bowl spiral. It ends up stopping navigation and falls back to alt mode after 2 yaw resets.
https://logs.px4.io/plot_app?log=9619a774-677a-43e3-96c7-6dc710d1828e
![DeepinScreenshot_select-area_20221229172559](https://user-images.githubusercontent.com/14822839/209981336-b4934b10-fb4b-41fa-97a1-82944e3819eb.png)

this PR:
https://logs.px4.io/plot_app?log=e8694d1e-8798-4734-89fb-fd7e663bdfd5
The gyro bias is learned rapidly and a slight toilet bowl is enough to correct the yaw estimate properly.
![DeepinScreenshot_select-area_20221229170529](https://user-images.githubusercontent.com/14822839/209981905-c5c5cdc0-7109-42d3-aaf9-4b54d37d02a0.png)


- unit tests for the mag inhibition

