### PR TITLE
commander: Handle overload detection timestamp reset correctly

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2262,10 +2262,12 @@ void Commander::control_status_leds(bool changed, const uint8_t battery_warning)
 
 			bool overload = (cpuload_percent > _param_com_cpu_max.get()) || (cpuload.ram_usage > 0.99f);
 
-			if (_overload_start == 0 && overload) {
-				_overload_start = time_now_us;
+			if (overload) {
+				if (_overload_start == 0) {
+					_overload_start = time_now_us;
+				}
 
-			} else if (!overload) {
+			} else {
 				_overload_start = 0;
 			}
 		}


### PR DESCRIPTION
### Solved Problem

None

### Solution

When overloading is the primary concern, no new decisions are needed.

### Alternatives

None

### Test coverage

[18/20] Linking CXX executable holybro_durandal-v1_default.elf
Memory region Used Size Region Size %age Used
        ITCM_RAM: 0 GB 64 KB 0.00% 0.00
           FLASH: 1893456 B 1920 KB 96.31% (0.00%)
       DTCM1_RAM: 0 GB 64 KB 0.00
       DTCM2_RAM: 0 GB 64 KB 0.00
        AXI_SRAM: 44804 B 512 KB 8.55
           SRAM1: 0 GB 128 KB 0.00
           SRAM2: 0 GB 128 KB 0.00
           SRAM3: 0 GB 32 KB 0.00
           SRAM4: 2 KB 64 KB 3.12%
          BKPRAM: 0 GB 4 KB 0.00% BKPRAM: 0 GB 4 KB 0.00

### Context

None