### PR TITLE
VTOL control surface actuation during MC mode

### DIFF
--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -357,9 +357,22 @@ void Tailsitter::fill_actuator_outputs()
 		mc_out[actuator_controls_s::INDEX_LANDING_GEAR] = landing_gear_s::GEAR_UP;
 	}
 
+	// Control surface control
 	if (_param_vt_elev_mc_lock.get() && _vtol_mode == vtol_mode::MC_MODE) {
+		_torque_setpoint_1->xyz[1] = 0.0;
+		_torque_setpoint_1->xyz[2] = 0.0;
+
 		fw_out[actuator_controls_s::INDEX_ROLL]  = 0;
 		fw_out[actuator_controls_s::INDEX_PITCH] = 0;
+
+	} else if (!_param_vt_elev_mc_lock.get() && _vtol_mode == vtol_mode::MC_MODE) {
+		_torque_setpoint_1->xyz[0] = mc_in[actuator_controls_s::INDEX_YAW];
+		_torque_setpoint_1->xyz[1] = mc_in[actuator_controls_s::INDEX_PITCH];
+		_torque_setpoint_1->xyz[2] = -mc_in[actuator_controls_s::INDEX_ROLL];
+
+		fw_out[actuator_controls_s::INDEX_ROLL]  = mc_in[actuator_controls_s::INDEX_YAW];
+		fw_out[actuator_controls_s::INDEX_PITCH] = mc_in[actuator_controls_s::INDEX_PITCH];
+		fw_out[actuator_controls_s::INDEX_YAW] = -mc_in[actuator_controls_s::INDEX_ROLL];
 
 	} else {
 		fw_out[actuator_controls_s::INDEX_ROLL]  = fw_in[actuator_controls_s::INDEX_ROLL];


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I am trying to build a Tailsitter VTOL where attitude control is only done with control surfaces. However, when a tailsitter VTOL is in multicopter mode, the control surfaces were not being properly actuated when using control allocation, (when the control surfaces were not locked)

- FW attitude control messages were being consumed while the vehicle was in MC mode, and therefore the setpoints were wrongly controlled

### Solution
- Add case to use mc controller outputs for control surfaces when the vehicle is MC mode and the control surfaces are not locked

### Test coverage
- Tested on a 3D airplane platform, where there is one motor and ailerons, rudder, and elevator
  - [Video of control surface deflection](https://youtube.com/shorts/axqcYFl4ewQ)
- Flight log of hand-held hover: [flight log](https://review.px4.io/plot_app?log=5963fa16-16a0-4fa3-b019-1ca59882153c)

![PXL_20221025_065159926 (1)](https://user-images.githubusercontent.com/5248102/210601886-fe53a39c-8745-4a7e-9c45-8c9e078adab7.jpg)


### Additional context
- @tstastny @sfuhrer Am I right to conclude that the tailsitter was broken for control allocation? the current logic seems to control the attitude based on the fixed-wing attitude controller outputs, and not the `mc_att_control` outputs. Or is this actually correct that we want motors controlled by `mc_att_control` and control surfaces with the `fw_att_control`? (Confused whether the controller separation is based on vtol state (hover, fixed wing) or actuators)

https://github.com/PX4/PX4-Autopilot/blob/315c075e5c7550a88182b42ff2e4f4a86f5f3cb3/src/modules/vtol_att_control/tailsitter.cpp#L364-L369

