### PR TITLE
PX4Board kconfig add dependency chain for QURT & POSIX modules

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -195,5 +195,6 @@ source "src/examples/Kconfig"
 endmenu
 
 menu "platforms"
+depends on PLATFORM_QURT || PLATFORM_POSIX
 source "platforms/common/Kconfig"
 endmenu

--- a/platforms/common/uORB/Kconfig
+++ b/platforms/common/uORB/Kconfig
@@ -1,5 +1,6 @@
 menuconfig ORB_COMMUNICATOR
 	bool "orb communicator"
 	default n
+	depends on PLATFORM_QURT
 	---help---
 		Enable support for the uorb communicator for distributed platforms

--- a/src/drivers/qshell/Kconfig
+++ b/src/drivers/qshell/Kconfig
@@ -1,3 +1,4 @@
 menu "qshell"
+depends on PLATFORM_QURT || PLATFORM_POSIX
 rsource "*/Kconfig"
 endmenu #qshell

--- a/src/drivers/qshell/posix/Kconfig
+++ b/src/drivers/qshell/posix/Kconfig
@@ -1,5 +1,6 @@
 menuconfig DRIVERS_QSHELL_POSIX
 	bool "posix"
 	default n
+	depends on PLATFORM_POSIX
 	---help---
 		Enable support for posix

--- a/src/drivers/qshell/qurt/Kconfig
+++ b/src/drivers/qshell/qurt/Kconfig
@@ -1,5 +1,6 @@
 menuconfig DRIVERS_QSHELL_QURT
 	bool "qurt"
 	default n
+	depends on PLATFORM_QURT
 	---help---
 		Enable support for qurt

--- a/src/modules/muorb/Kconfig
+++ b/src/modules/muorb/Kconfig
@@ -1,3 +1,4 @@
 menu "MUORB"
+depends on PLATFORM_QURT || PLATFORM_POSIX
 rsource "*/Kconfig"
 endmenu #MUORB

--- a/src/modules/muorb/apps/Kconfig
+++ b/src/modules/muorb/apps/Kconfig
@@ -1,5 +1,6 @@
 menuconfig MODULES_MUORB_APPS	
-        bool "apps"
-        default n
-        ---help---
-                Enable support for muorb apps
+	bool "apps"
+	default n
+	depends on PLATFORM_QURT
+	---help---
+		Enable support for muorb apps

--- a/src/modules/muorb/slpi/Kconfig
+++ b/src/modules/muorb/slpi/Kconfig
@@ -1,5 +1,6 @@
 menuconfig MODULES_MUORB_SLPI
-        bool "muorb_slpi"
-        default n
-        ---help---
-                Enable support for muorb slpi
+	bool "muorb_slpi"
+	default n
+	depends on PLATFORM_QURT
+	---help---
+		Enable support for muorb slpi


### PR DESCRIPTION
Hides MUORB and QSHELL qurt and qshell modules for non-QURT platforms in boardconfig

By adding dependencies for these kconfig symbols