### PR TITLE
fix replay msg ids larger than 128

### DIFF
--- a/src/modules/replay/Replay.cpp
+++ b/src/modules/replay/Replay.cpp
@@ -371,9 +371,9 @@ bool
 Replay::readAndAddSubscription(std::ifstream &file, uint16_t msg_size)
 {
 	_read_buffer.reserve(msg_size + 1);
-	char *message = (char *)_read_buffer.data();
+	uint8_t *message = _read_buffer.data();
 	streampos this_message_pos = file.tellg() - (streamoff)ULOG_MSG_HEADER_LEN;
-	file.read(message, msg_size);
+	file.read((char *)message, msg_size);
 	message[msg_size] = 0;
 
 	if (!file) {
@@ -387,8 +387,8 @@ Replay::readAndAddSubscription(std::ifstream &file, uint16_t msg_size)
 	_subscription_file_pos = file.tellg();
 
 	uint8_t multi_id = *(uint8_t *)message;
-	uint16_t msg_id = ((uint16_t) message[1]) | (((uint16_t) message[2]) << 8);
-	string topic_name(message + 3);
+	uint16_t msg_id = ((uint16_t)message[1]) | (((uint16_t)message[2]) << 8);
+	string topic_name((char *)message + 3);
 	const orb_metadata *orb_meta = findTopic(topic_name);
 
 	if (!orb_meta) {


### PR DESCRIPTION
### Solved Problem
@dagar When using replays, I found that several topics were not published at all. Digging deep I found that this happened for all uORB topics with a msg_id larger than 128. The old formula behaved weird when casting (signed) char to unsigned int16, so I made the calculation a bit more straightforward.

Before:

```
INFO  [replay] Topic estimator_optical_flow_vel got msg id 125
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96242
INFO  [replay] Topic estimator_optical_flow_vel got msg id 126
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96274
INFO  [replay] Topic estimator_optical_flow_vel got msg id 127
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96306
INFO  [replay] Topic estimator_optical_flow_vel got msg id 65408
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96338
INFO  [replay] Topic estimator_optical_flow_vel got msg id 65409
```
After:

```
INFO  [replay] Topic estimator_optical_flow_vel got msg id 125
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96242
INFO  [replay] Topic estimator_optical_flow_vel got msg id 126
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96274
INFO  [replay] Topic estimator_optical_flow_vel got msg id 127
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96306
INFO  [replay] Topic estimator_optical_flow_vel got msg id 128
ERROR [replay] estimator_optical_flow_vel nextDataMessage 96338
INFO  [replay] Topic estimator_optical_flow_vel got msg id 129
```
