### PR TITLE
setup ubuntu.sh; fix legacy gazebo for Ubuntu 22.04

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -14,7 +14,6 @@ set -e
 INSTALL_NUTTX="true"
 INSTALL_SIM="true"
 INSTALL_ARCH=`uname -m`
-INSTALL_SIM_IGNITION="false"
 
 # Parse arguments
 for arg in "$@"
@@ -26,11 +25,6 @@ do
 	if [[ $arg == "--no-sim-tools" ]]; then
 		INSTALL_SIM="false"
 	fi
-
-	if [[ $arg == "--sim-ignition" ]]; then
-		INSTALL_SIM_IGNITION="true"
-	fi
-
 done
 
 # detect if running in docker
@@ -223,7 +217,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	# Set Java 11 as default
 	sudo update-alternatives --set java $(update-alternatives --list java | grep "java-$java_version")
 
-	# Gazebo
+	# Install Gazebo classic
 	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
 		gazebo_version=9
 		gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
@@ -260,16 +254,17 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		# fix VMWare 3D graphics acceleration for gazebo
 		echo "export SVGA_VGPU10=0" >> ~/.profile
 	fi
-fi
 
-if [[ $INSTALL_SIM_IGNITION == "true" ]]; then
-	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-	# Update list, since new gazebo-stable.list has been added
-	sudo apt-get update -y --quiet
-	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
-		ignition-fortress \
-		;
+	# Install Gazebo
+	if [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
+		sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+		wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+		# Update list, since new gazebo-stable.list has been added
+		sudo apt-get update -y --quiet
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+			ignition-fortress \
+			;
+	fi
 fi
 
 if [[ $INSTALL_NUTTX == "true" ]]; then

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -14,7 +14,7 @@ set -e
 INSTALL_NUTTX="true"
 INSTALL_SIM="true"
 INSTALL_ARCH=`uname -m`
-INSTALL_SIM_JAMMY="false"
+INSTALL_SIM_IGNITION="false"
 
 # Parse arguments
 for arg in "$@"
@@ -27,8 +27,8 @@ do
 		INSTALL_SIM="false"
 	fi
 
-	if [[ $arg == "--sim_jammy" ]]; then
-		INSTALL_SIM_JAMMY="true"
+	if [[ $arg == "--sim-ignition" ]]; then
+		INSTALL_SIM_IGNITION="true"
 	fi
 
 done
@@ -71,9 +71,7 @@ elif [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
 elif [[ "${UBUNTU_RELEASE}" == "20.04" ]]; then
 	echo "Ubuntu 20.04"
 elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
-	echo "Ubuntu 22.04, simulation build off by default." 
-	echo "Use --sim_jammy to enable simulation build."
-	INSTALL_SIM="false"
+	echo "Ubuntu 22.04"
 fi
 
 
@@ -230,7 +228,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		gazebo_version=9
 		gazebo_packages="gazebo$gazebo_version libgazebo$gazebo_version-dev"
 	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
-		gazebo_packages="ignition-fortress"
+		gazebo_packages="gazebo libgazebo-dev"
 	else
 		# default and Ubuntu 20.04
 		gazebo_version=11
@@ -264,7 +262,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	fi
 fi
 
-if [[ $INSTALL_SIM_JAMMY == "true" ]]; then
+if [[ $INSTALL_SIM_IGNITION == "true" ]]; then
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	# Update list, since new gazebo-stable.list has been added


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Gazebo simulation on ubuntu 22.04


### Solution
- Fall back to gazebo in version 11 (Package named gazebo) as it works on ubuntu 22.04 

### Alternatives
- Left ignition gazebo for potential future use case

### Test coverage
- Tested on ubuntu 22.04 

