### PR TITLE
thrust normalization for joystick input

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -141,7 +141,7 @@ RoverPositionControl::manual_control_setpoint_poll()
 					}
 
 					_att_sp.yaw_body = _manual_yaw_sp;
-					_att_sp.thrust_body[0] = _manual_control_setpoint.throttle;
+					_att_sp.thrust_body[0] = (_manual_control_setpoint.throttle + 1.f) * .5f;
 
 					Quatf q(Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body));
 					q.copyTo(_att_sp.q_d);
@@ -158,7 +158,7 @@ RoverPositionControl::manual_control_setpoint_poll()
 					_act_controls.control[actuator_controls_s::INDEX_YAW] =
 						_manual_control_setpoint.roll; // Nominally yaw: _manual_control_setpoint.yaw;
 					// Set throttle from the manual throttle channel
-					_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = _manual_control_setpoint.throttle;
+					_act_controls.control[actuator_controls_s::INDEX_THROTTLE] = (_manual_control_setpoint.throttle + 1.f) * .5f;
 					_reset_yaw_sp = true;
 				}
 


### PR DESCRIPTION
Log file: [link](https://review.px4.io/plot_app?log=79884cfc-ef61-4605-b31b-7f78004fd226)

So, i checked out how Multi-copters were reading inputs and they are adjusting the manual_control_setpoint
`(_manual_control_setpoint.throttle + 1.f) * .5f;`

Implemented that for rover, and it seemed to fix the rover in SITL. Have not tested in real world


### Solved Problem
I noticed that when running the differential rover in sitl: `make px4_sitl gazebo_r1_rover` in manual mode, the rover immediately starts to travel backwards. 

Fixes #{Github issue ID}
#20886 

### Solution
added
(_manual_control_setpoint.throttle + 1.f) * .5f; for thrust

### Alternatives
not sure tbh

### Test coverage
before: [link](https://review.px4.io/plot_app?log=79884cfc-ef61-4605-b31b-7f78004fd226)
after: [link](https://review.px4.io/plot_app?log=18069f38-872b-463a-9367-22e1aa35794f)

### Context
Related links, screenshot before/after, video
