### PR TITLE
Auto: No YAW operation

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -166,7 +166,8 @@ bool FlightTaskAuto::update()
 		waypoints[2] = _position_setpoint;
 	}
 
-	const bool should_wait_for_yaw_align = _param_mpc_yaw_mode.get() == 4 && !_yaw_sp_aligned;
+	const bool should_wait_for_yaw_align = _param_mpc_yaw_mode.get() == int32_t(yaw_mode::towards_waypoint_yaw_first)
+					       && !_yaw_sp_aligned;
 	const bool force_zero_velocity_setpoint = should_wait_for_yaw_align || _is_emergency_braking_active;
 	_updateTrajConstraints();
 	PositionSmoothing::PositionSmoothingSetpoints smoothed_setpoints;
@@ -501,31 +502,30 @@ void FlightTaskAuto::_set_heading_from_mode()
 
 	Vector2f v; // Vector that points towards desired location
 
-	switch (_param_mpc_yaw_mode.get()) {
+	switch (yaw_mode(_param_mpc_yaw_mode.get())) {
 
-	case 0: // Heading points towards the current waypoint.
-	case 4: // Same as 0 but yaw first and then go
+	case yaw_mode::towards_waypoint: // Heading points towards the current waypoint.
+	case yaw_mode::towards_waypoint_yaw_first: // Same as 0 but yaw first and then go
 		v = Vector2f(_target) - Vector2f(_position);
 		break;
 
-	case 1: // Heading points towards home.
+	case yaw_mode::towards_home: // Heading points towards home.
 		if (_sub_home_position.get().valid_lpos) {
 			v = Vector2f(&_sub_home_position.get().x) - Vector2f(_position);
 		}
 
 		break;
 
-	case 2: // Heading point away from home.
+	case yaw_mode::away_from_home: // Heading point away from home.
 		if (_sub_home_position.get().valid_lpos) {
 			v = Vector2f(_position) - Vector2f(&_sub_home_position.get().x);
 		}
 
 		break;
 
-	case 3: // Along trajectory.
+	case yaw_mode::along_trajectory: // Along trajectory.
 		// The heading depends on the kind of setpoint generation. This needs to be implemented
 		// in the subclasses where the velocity setpoints are generated.
-		v.setAll(NAN);
 		break;
 	}
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -81,6 +81,14 @@ enum class State {
 	none /**< Vehicle is in normal tracking mode from triplet previous to triplet target */
 };
 
+enum class yaw_mode : int32_t {
+	towards_waypoint = 0,
+	towards_home = 1,
+	away_from_home = 2,
+	along_trajectory = 3,
+	towards_waypoint_yaw_first = 4,
+};
+
 class FlightTaskAuto : public FlightTask
 {
 public:


### PR DESCRIPTION
### Solved Problem

None

### Solution

I set the Along trajectory to MPC_YAW_MODE.
I determined the direction of the YAW before starting the mission and started the mission.
Once I started the mission, the YAW rotated in the direction of the WP.

I found that I set NAN as a variable to enter the YAW operation.
I will change the variable to not set a value to match the other process.

### Alternatives

None

### Test coverage

### Context

AFTER

TAKEOFF->WP3: Not Change YAW
![Screenshot from 2023-01-08 12-07-24](https://user-images.githubusercontent.com/646194/211179197-65208b96-387f-4199-957e-67ab4ee31e7c.png)

WP13->WP14: Not Change YAW
![Screenshot from 2023-01-08 12-09-59](https://user-images.githubusercontent.com/646194/211179230-371171d5-5a19-447b-9519-357de4985e55.png)

WP14-> : Not Change YAW
![Screenshot from 2023-01-08 12-10-07](https://user-images.githubusercontent.com/646194/211179241-1ce2a3ac-e0e5-4ad4-abcb-3d41c33a018f.png)

BEFORE
TAKEOFF->WP17: CNANGE YAW
![Screenshot from 2023-01-08 12-02-27](https://user-images.githubusercontent.com/646194/211179257-54e773af-44d1-4eeb-8b9b-808be8cf83d7.png)

WP20->WP22: CNANGE YAW
![Screenshot from 2023-01-08 12-03-07](https://user-images.githubusercontent.com/646194/211179290-18bfa299-e289-49c9-b251-42b7f341dadf.png)