### PR TITLE
gz_bridge: fix world selector environment variable

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -149,7 +149,7 @@ if(gz-transport_FOUND)
 				)
 			else()
 				add_custom_target(gz_${model}_${world_name}
-					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model} PX4_SIM_WORLD=${world_name} $<TARGET_FILE:px4>
+					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model} PX4_GZ_WORLD=${world_name} $<TARGET_FILE:px4>
 					WORKING_DIRECTORY ${SITL_WORKING_DIR}
 					USES_TERMINAL
 					DEPENDS px4


### PR DESCRIPTION
`px4-rc.simulator` uses `PX4_GZ_WORLD` to define the world file when Gazebo (not Gazebo Classic) is used.