### PR TITLE
flight mode manager: Define parameter names for MPC_POS_MODE

### DIFF
--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -188,20 +188,21 @@ void FlightModeManager::start_flight_task()
 		should_disable_task = false;
 		FlightTaskError error = FlightTaskError::NoError;
 
-		switch (_param_mpc_pos_mode.get()) {
-		case 0:
+		switch (Manual_Position_control_sub_mode(_param_mpc_pos_mode.get())) {
+		case Manual_Position_control_sub_mode::Simple_position_control:
 			error = switchTask(FlightTaskIndex::ManualPosition);
 			break;
 
-		case 3:
+		case Manual_Position_control_sub_mode::Smooth_position_control:
 			error = switchTask(FlightTaskIndex::ManualPositionSmoothVel);
 			break;
 
-		case 4:
+		case Manual_Position_control_sub_mode::Acceleration_based_input:
 		default:
-			if (_param_mpc_pos_mode.get() != 4) {
+			if (Manual_Position_control_sub_mode(_param_mpc_pos_mode.get()) !=
+			    Manual_Position_control_sub_mode::Acceleration_based_input) {
 				PX4_ERR("MPC_POS_MODE %" PRId32 " invalid, resetting", _param_mpc_pos_mode.get());
-				_param_mpc_pos_mode.set(4);
+				_param_mpc_pos_mode.set(int32_t(Manual_Position_control_sub_mode::Acceleration_based_input));
 				_param_mpc_pos_mode.commit();
 			}
 
@@ -217,12 +218,12 @@ void FlightModeManager::start_flight_task()
 		should_disable_task = false;
 		FlightTaskError error = FlightTaskError::NoError;
 
-		switch (_param_mpc_pos_mode.get()) {
-		case 0:
+		switch (Manual_Position_control_sub_mode(_param_mpc_pos_mode.get())) {
+		case Manual_Position_control_sub_mode::Simple_position_control:
 			error = switchTask(FlightTaskIndex::ManualAltitude);
 			break;
 
-		case 3:
+		case Manual_Position_control_sub_mode::Smooth_position_control:
 		default:
 			error = switchTask(FlightTaskIndex::ManualAltitudeSmoothVel);
 			break;

--- a/src/modules/flight_mode_manager/FlightModeManager.hpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.hpp
@@ -64,6 +64,12 @@ enum class FlightTaskError : int {
 	ActivationFailed = -2
 };
 
+enum class Manual_Position_control_sub_mode : int32_t {
+	Simple_position_control = 0,
+	Smooth_position_control = 3,
+	Acceleration_based_input = 4,
+};
+
 class FlightModeManager : public ModuleBase<FlightModeManager>, public ModuleParams, public px4::WorkItem
 {
 public:


### PR DESCRIPTION
### Solved Problem

None

### Solution

Set MPC_POS_MODE setting value to definition name.

### Alternatives

None

### Test coverage

None

### Context

None