### PR TITLE
StickAccelerationXY: apply jerk limit after drag

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -14,7 +14,7 @@
  *    distribution.
  * 3. Neither the name PX4 nor the names of its contributors may be
  *    used to endorse or promote products derived from this software
- *    without spec{fic prior written permission.
+ *    without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -92,7 +92,6 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 
 	Sticks::rotateIntoHeadingFrameXY(stick_xy, yaw, yaw_sp);
 	_acceleration_setpoint = stick_xy.emult(acceleration_scale);
-	applyJerkLimit(dt);
 
 	// Add drag to limit speed and brake again
 	Vector2f drag = calculateDrag(acceleration_scale.edivide(velocity_scale), dt, stick_xy, _velocity_setpoint);
@@ -110,6 +109,7 @@ void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, 
 
 	_acceleration_setpoint -= drag;
 
+	applyJerkLimit(dt);
 	applyTiltLimit(_acceleration_setpoint);
 
 	// Generate velocity setpoint by forward integrating commanded acceleration


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When @bresch analyzed a log in which the pilot switched from Altitude mode to Position mode at high speed he found that upon FlightTaskAcceleration initialization the drag calculation can produce a big step in the acceleration setpoint and hence attitude.

### Solution
We discussed many possibilities to initialize with the exact right value e.g. by back calculating and so on but applying the jerk limit after the drag already solves the issue, makes the solution less complex and brittle and if there are no negative side effects for stick feeling and brake behavior in normal use nothing speaks against that.

I thought there is a reason for this order but can't remember or find any clue for that anymore so we should just test if we found any problem with this.

### Test coverage
- I did not test this on a real vehicle. It looks ok in simulation but I'd also just expect any side effect when the slew rate of the jerk gets loaded higher than feasible and causes delayed changes.