### PR TITLE
Navigator: remove _can_loiter_at_sp and _need_takeoff

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
@@ -31,6 +31,7 @@ param set-default PWM_MAIN_FUNC4 104
 
 # EKF2
 param set-default EKF2_GPS_CTRL 0
+param set-default EKF2_HGT_REF 0
 param set-default EKF2_EVP_NOISE 0.05
 param set-default EKF2_EVA_NOISE 0.05
 param set-default EKF2_OF_CTRL 1
@@ -38,6 +39,9 @@ param set-default EKF2_OF_CTRL 1
 # LPE: Flow-only mode
 param set-default LPE_FUSION 242
 param set-default LPE_FAKE_ORIGIN 1
+
+# Commander
+# param set-default COM_HOME_EN 0 # Disable setting of home position
 
 param set-default MPC_ALT_MODE 2
 

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -62,8 +62,6 @@ Land::on_activation()
 	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 
-	_navigator->set_can_loiter_at_sp(false);
-
 	_navigator->set_position_setpoint_triplet_updated();
 
 	// reset cruising speed to default

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -82,7 +82,6 @@ Loiter::set_loiter_position()
 		// Not setting loiter position if disarmed and landed, instead mark the current
 		// setpoint as invalid and idle (both, just to be sure).
 
-		_navigator->set_can_loiter_at_sp(false);
 		_navigator->get_position_setpoint_triplet()->current.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
 		_navigator->set_position_setpoint_triplet_updated();
 		return;
@@ -110,7 +109,6 @@ Loiter::set_loiter_position()
 	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 
-	_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
 	_navigator->set_position_setpoint_triplet_updated();
 }
 
@@ -136,7 +134,6 @@ Loiter::reposition()
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
 		pos_sp_triplet->next.valid = false;
 
-		_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
 		_navigator->set_position_setpoint_triplet_updated();
 
 		// mark this as done

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -336,7 +336,7 @@ Mission::on_active()
 		 || _mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
 		 || _mission_item.nav_cmd == NAV_CMD_LAND
 		 || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND
-		 || _work_item_type == WORK_ITEM_TYPE_ALIGN)) {
+		 || _work_item_type == WORK_ITEM_TYPE_ALIGN_HEADING)) {
 		// Mount control is disabled If the vehicle is in ROI-mode, the vehicle
 		// needs to rotate such that ROI is in the field of view.
 		// ROI only makes sense for multicopters.
@@ -960,7 +960,7 @@ Mission::set_mission_items()
 
 					_mission_item.force_heading = true;
 
-					new_work_item_type = WORK_ITEM_TYPE_ALIGN;
+					new_work_item_type = WORK_ITEM_TYPE_ALIGN_HEADING;
 
 					/* set position setpoint to current while aligning */
 					_mission_item.lat = _navigator->get_global_position()->lat;
@@ -969,7 +969,7 @@ Mission::set_mission_items()
 
 				/* heading is aligned now, prepare transition */
 				if (_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF &&
-				    _work_item_type == WORK_ITEM_TYPE_ALIGN &&
+				    _work_item_type == WORK_ITEM_TYPE_ALIGN_HEADING &&
 				    _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
 				    !_navigator->get_land_detected()->landed) {
 
@@ -1175,7 +1175,7 @@ Mission::set_mission_items()
 					/* disable weathervane before front transition for allowing yaw to align */
 					pos_sp_triplet->current.disable_weather_vane = true;
 
-					new_work_item_type = WORK_ITEM_TYPE_ALIGN;
+					new_work_item_type = WORK_ITEM_TYPE_ALIGN_HEADING;
 
 					set_align_mission_item(&_mission_item, &mission_item_next_position);
 
@@ -1185,7 +1185,7 @@ Mission::set_mission_items()
 				}
 
 				/* yaw is aligned now */
-				if (_work_item_type == WORK_ITEM_TYPE_ALIGN &&
+				if (_work_item_type == WORK_ITEM_TYPE_ALIGN_HEADING &&
 				    new_work_item_type == WORK_ITEM_TYPE_DEFAULT) {
 
 					new_work_item_type = WORK_ITEM_TYPE_DEFAULT;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1367,23 +1367,6 @@ Mission::set_align_mission_item(struct mission_item_s *mission_item, struct miss
 	mission_item->force_heading = true;
 }
 
-float
-Mission::calculate_takeoff_altitude(struct mission_item_s *mission_item)
-{
-	/* calculate takeoff altitude */
-	float takeoff_alt = get_absolute_altitude_for_item(*mission_item);
-
-	/* takeoff to at least MIS_TAKEOFF_ALT above home/ground, even if first waypoint is lower */
-	if (_navigator->get_land_detected()->landed) {
-		takeoff_alt = fmaxf(takeoff_alt, _navigator->get_global_position()->alt + _navigator->get_takeoff_min_alt());
-
-	} else {
-		takeoff_alt = fmaxf(takeoff_alt, _navigator->get_home_position()->alt + _navigator->get_takeoff_min_alt());
-	}
-
-	return takeoff_alt;
-}
-
 void
 Mission::heading_sp_update()
 {

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -310,7 +310,7 @@ Mission::on_active()
 	if (_mission_type != MISSION_TYPE_NONE && is_mission_item_reached_or_completed()) {
 		/* If we just completed a takeoff which was inserted before the right waypoint,
 		   there is no need to report that we reached it because we didn't. */
-		if (_work_item_type != WORK_ITEM_TYPE_TAKEOFF) {
+		if (_work_item_type != WORK_ITEM_TYPE_CLIMB) {
 			set_mission_item_reached();
 		}
 
@@ -887,7 +887,7 @@ Mission::set_mission_items()
 				    _work_item_type == WORK_ITEM_TYPE_DEFAULT &&
 				    new_work_item_type == WORK_ITEM_TYPE_DEFAULT) {
 
-					new_work_item_type = WORK_ITEM_TYPE_TAKEOFF;
+					new_work_item_type = WORK_ITEM_TYPE_CLIMB;
 
 					/* use current mission item as next position item */
 					mission_item_next_position = _mission_item;
@@ -926,7 +926,7 @@ Mission::set_mission_items()
 					   && new_work_item_type == WORK_ITEM_TYPE_DEFAULT) {
 					// if the vehicle is already in fixed wing mode then the current mission item
 					// will be accepted immediately and the work items will be skipped
-					_work_item_type = WORK_ITEM_TYPE_TAKEOFF;
+					_work_item_type = WORK_ITEM_TYPE_CLIMB;
 
 
 					/* ignore yaw here, otherwise it might yaw before heading_sp_update takes over */
@@ -935,7 +935,7 @@ Mission::set_mission_items()
 
 				/* if we just did a normal takeoff navigate to the actual waypoint now */
 				if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF &&
-				    _work_item_type == WORK_ITEM_TYPE_TAKEOFF &&
+				    _work_item_type == WORK_ITEM_TYPE_CLIMB &&
 				    new_work_item_type == WORK_ITEM_TYPE_DEFAULT) {
 
 					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
@@ -945,7 +945,7 @@ Mission::set_mission_items()
 
 				/* if we just did a VTOL takeoff, prepare transition */
 				if (_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF &&
-				    _work_item_type == WORK_ITEM_TYPE_TAKEOFF &&
+				    _work_item_type == WORK_ITEM_TYPE_CLIMB &&
 				    new_work_item_type == WORK_ITEM_TYPE_DEFAULT &&
 				    _navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
 				    !_navigator->get_land_detected()->landed) {

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -356,7 +356,7 @@ private:
 	// Work Item corresponds to the sub-mode set on the "MAV_CMD_DO_SET_MODE" MAVLink message
 	enum work_item_type {
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */
-		WORK_ITEM_TYPE_TAKEOFF,		/**< takeoff before moving to waypoint */
+		WORK_ITEM_TYPE_CLIMB,		/**< climb at current position before moving to waypoint */
 		WORK_ITEM_TYPE_MOVE_TO_LAND,	/**< move to land waypoint before descent */
 		WORK_ITEM_TYPE_ALIGN_HEADING,		/**< align heading for next waypoint */
 		WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF,

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -134,11 +134,6 @@ private:
 	void set_mission_items();
 
 	/**
-	 * Returns true if we need to do a takeoff at the current state
-	 */
-	bool do_need_vertical_takeoff();
-
-	/**
 	 * Returns true if we need to move to waypoint location before starting descent
 	 */
 	bool do_need_move_to_land();
@@ -347,8 +342,6 @@ private:
 	float _landing_loiter_radius{0.f};
 
 	float _mission_init_climb_altitude_amsl{NAN};	/**< altitude AMSL the vehicle will climb to when mission starts */
-
-	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
 	enum {
 		MISSION_TYPE_NONE,

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -248,7 +248,7 @@ private:
 	* @param prev_pos_index The index of the previous position item containing a position
 	* @return true if a previous position item was found
 	*/
-	bool getPreviousPositionItemIndex(const mission_s &mission, int start_index, unsigned &prev_pos_index) const;
+	bool getPreviousPositionItemIndex(const mission_s &mission, int start_index, uint16_t &prev_pos_index) const;
 
 	/**
 	 * @brief Get the next item after start_index that contains a position
@@ -310,6 +310,13 @@ private:
 	 */
 	bool cameraWasTriggering();
 
+	/**
+	 * @brief Check if a climb is necessary to align with mission altitude prior to starting the mission
+	 *
+	 * @param mission_item_index The index of the mission item to check if a climb is necessary
+	 */
+	void checkClimbRequired(uint16_t mission_item_index);
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_mis_dist_1wp,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mis_mnt_yaw_ctl
@@ -338,6 +345,8 @@ private:
 	float _landing_alt{0.0f};
 
 	float _landing_loiter_radius{0.f};
+
+	float _mission_init_climb_altitude_amsl{NAN};	/**< altitude AMSL the vehicle will climb to when mission starts */
 
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -358,7 +358,7 @@ private:
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */
 		WORK_ITEM_TYPE_TAKEOFF,		/**< takeoff before moving to waypoint */
 		WORK_ITEM_TYPE_MOVE_TO_LAND,	/**< move to land waypoint before descent */
-		WORK_ITEM_TYPE_ALIGN,		/**< align for next waypoint */
+		WORK_ITEM_TYPE_ALIGN_HEADING,		/**< align heading for next waypoint */
 		WORK_ITEM_TYPE_TRANSITION_AFTER_TAKEOFF,
 		WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION,
 		WORK_ITEM_TYPE_PRECISION_LAND

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -154,11 +154,6 @@ private:
 	void set_align_mission_item(struct mission_item_s *mission_item, struct mission_item_s *mission_item_next);
 
 	/**
-	 * Calculate takeoff height for mission item considering ground clearance
-	 */
-	float calculate_takeoff_altitude(struct mission_item_s *mission_item);
-
-	/**
 	 * Updates the heading of the vehicle. Rotary wings only.
 	 */
 	void heading_sp_update();

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -44,13 +44,13 @@
  */
 
 /**
- * Take-off altitude
+ * Default take-off altitude
  *
- * This is the minimum altitude the system will take off to.
+ * This is the relative altitude the system will take off to
+ * if not otherwise specified.
  *
  * @unit m
  * @min 0
- * @max 80
  * @decimal 1
  * @increment 0.5
  * @group Mission

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -142,7 +142,6 @@ public:
 	/**
 	 * Setters
 	 */
-	void set_can_loiter_at_sp(bool can_loiter) { _can_loiter_at_sp = can_loiter; }
 	void set_position_setpoint_triplet_updated() { _pos_sp_triplet_updated = true; }
 	void set_mission_result_updated() { _mission_result_updated = true; }
 
@@ -170,8 +169,6 @@ public:
 	bool home_global_position_valid() { return (_home_pos.valid_alt && _home_pos.valid_hpos); }
 
 	Geofence &get_geofence() { return _geofence; }
-
-	bool get_can_loiter_at_sp() { return _can_loiter_at_sp; }
 
 	float get_loiter_radius() { return _param_nav_loiter_rad.get(); }
 
@@ -358,7 +355,6 @@ private:
 	hrt_abstime _last_geofence_check = 0;
 
 	bool		_geofence_violation_warning_sent{false};	/**< prevents spaming to mavlink */
-	bool		_can_loiter_at_sp{false};			/**< flags if current position SP can be used to loiter */
 	bool		_pos_sp_triplet_updated{false};			/**< flags if position SP triplet needs to be published */
 	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
 	bool		_mission_result_updated{false};			/**< flags if mission result has seen an update */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -282,7 +282,7 @@ public:
 	// Param access
 	int get_loiter_min_alt() const { return _param_min_ltr_alt.get(); }
 	int get_landing_abort_min_alt() const { return _param_mis_lnd_abrt_alt.get(); }
-	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
+	float get_param_mis_takeoff_alt() const { return _param_mis_takeoff_alt.get(); }
 	int  get_takeoff_land_required() const { return _para_mis_takeoff_land_req.get(); }
 	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
 	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -851,7 +851,6 @@ void Navigator::run()
 		case vehicle_status_s::NAVIGATION_STATE_STAB:
 		default:
 			navigation_mode_new = nullptr;
-			_can_loiter_at_sp = false;
 			break;
 		}
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -416,8 +416,6 @@ void RTL::on_active()
 
 void RTL::set_rtl_item()
 {
-	_navigator->set_can_loiter_at_sp(false);
-
 	const vehicle_global_position_s &gpos = *_navigator->get_global_position();
 
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
@@ -576,8 +574,6 @@ void RTL::set_rtl_item()
 			_mission_item.autocontinue = autocontinue;
 			_mission_item.origin = ORIGIN_ONBOARD;
 			_mission_item.loiter_radius = landing_loiter_radius;
-
-			_navigator->set_can_loiter_at_sp(true);
 
 			break;
 		}

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -96,62 +96,48 @@ Takeoff::on_active()
 void
 Takeoff::set_takeoff_position()
 {
-	struct position_setpoint_triplet_s *rep = _navigator->get_takeoff_triplet();
+	if (!_navigator->home_alt_valid()) {
+		mavlink_log_info(_navigator->get_mavlink_log_pub(),
+				 "Home altitude not valid, abort takeoff\t");
 
-	float abs_altitude = 0.0f;
-
-	float min_abs_altitude;
-
-	// TODO: review this, comments are talking about home pos, the validity is checked but the
-	// current altitude is used instead. Also, the "else" case does not consider the current altitude at all.
-	if (_navigator->home_alt_valid()) { //only use home position if it is valid
-		min_abs_altitude = _navigator->get_global_position()->alt + _navigator->get_takeoff_min_alt();
-
-	} else { //e.g. flow
-		min_abs_altitude = _navigator->get_takeoff_min_alt();
+		events::send(events::ID("navigator_takeoff_abort_no_valid_home_alt"), {events::LogLevel::Critical, events::LogInternal::Warning},
+			     "Home altitude not valid, abort takeoff");
+		return;
 	}
 
-	// Use altitude if it has been set. If home position is invalid use min_abs_altitude
-	events::LogLevel log_level = events::LogLevel::Disabled;
+	struct position_setpoint_triplet_s *rep = _navigator->get_takeoff_triplet();
 
-	if (rep->current.valid && PX4_ISFINITE(rep->current.alt) && _navigator->home_alt_valid()) {
-		abs_altitude = rep->current.alt;
+	float takeoff_altitude_amsl = 0.f;
 
-		// If the altitude suggestion is lower than home + minimum clearance, raise it and complain.
-		if (abs_altitude < min_abs_altitude) {
-			if (abs_altitude < min_abs_altitude - 0.1f) { // don't complain if difference is smaller than 10cm
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-						     "Using minimum takeoff altitude: %.2f m\t", (double)_navigator->get_takeoff_min_alt());
-				log_level = events::LogLevel::Warning;
-			}
+	if (rep->current.valid && PX4_ISFINITE(rep->current.alt)) {
+		takeoff_altitude_amsl = rep->current.alt;
 
-			abs_altitude = min_abs_altitude;
+		// If the altitude suggestion is lower than home, notify and abort
+		if (takeoff_altitude_amsl < _navigator->get_home_position()->alt) {
+			mavlink_log_critical(_navigator->get_mavlink_log_pub(),
+					     "abort takeoff \t");
 		}
 
 	} else {
-		// Use home + minimum clearance but only notify.
-		abs_altitude = min_abs_altitude;
+		takeoff_altitude_amsl = _navigator->get_home_position()->alt + _navigator->get_param_mis_takeoff_alt();
 		mavlink_log_info(_navigator->get_mavlink_log_pub(),
-				 "Using minimum takeoff altitude: %.2f m\t", (double)_navigator->get_takeoff_min_alt());
-		log_level = events::LogLevel::Info;
+				 "Using deault takeoff altitude: %.1f m\t", (double)_navigator->get_param_mis_takeoff_alt());
+
+		events::send<float>(events::ID("navigator_takeoff_default_alt"), {events::Log::Info, events::LogInternal::Info},
+				    "Using default takeoff altitude: {1:.2m}",
+				    _navigator->get_param_mis_takeoff_alt());
 	}
 
-	if (log_level != events::LogLevel::Disabled) {
-		events::send<float>(events::ID("navigator_takeoff_min_alt"), {log_level, events::LogInternal::Info},
-				    "Using minimum takeoff altitude: {1:.2m}",
-				    _navigator->get_takeoff_min_alt());
-	}
-
-	if (abs_altitude < _navigator->get_global_position()->alt) {
+	if (takeoff_altitude_amsl < _navigator->get_global_position()->alt) {
 		// If the suggestion is lower than our current alt, let's not go down.
-		abs_altitude = _navigator->get_global_position()->alt;
+		takeoff_altitude_amsl = _navigator->get_global_position()->alt;
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Already higher than takeoff altitude\t");
 		events::send(events::ID("navigator_takeoff_already_higher"), {events::Log::Error, events::LogInternal::Info},
 			     "Already higher than takeoff altitude (not descending)");
 	}
 
 	// set current mission item to takeoff
-	set_takeoff_item(&_mission_item, abs_altitude);
+	set_takeoff_item(&_mission_item, takeoff_altitude_amsl);
 	_navigator->get_mission_result()->finished = false;
 	_navigator->set_mission_result_updated();
 	reset_mission_item_reached();

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -181,12 +181,5 @@ Takeoff::set_takeoff_position()
 		memset(rep, 0, sizeof(*rep));
 	}
 
-	if (PX4_ISFINITE(pos_sp_triplet->current.lat) && PX4_ISFINITE(pos_sp_triplet->current.lon)) {
-		_navigator->set_can_loiter_at_sp(true);
-
-	} else {
-		_navigator->set_can_loiter_at_sp(false);
-	}
-
 	_navigator->set_position_setpoint_triplet_updated();
 }


### PR DESCRIPTION
Only base decision on whether a takeoff is required prior to starting a mission on landed state and altitude below min altitude/mission altitude.

`get_can_loiter_at_sp()` was only needed for setting `_need_takeoff` (the comment says "require takeoff after non-loiter or landing"). The landing part is covered in `Mission::do_need_vertical_takeoff()` already, and I don't get how this should be linked to whether the type is loiter or not.

I originally wanted to work on syncing the behavior of what the vehicles do when starting a mission with the current WP being a takeoff while already in-air, but then instead only ended up doing this mini clean up. If somebody has an idea how to cleanly not look at Takeoff WP once already in flight let me know, but it's not necessarily linked to the changes here. 
