### PR TITLE
VTOL Quad-chute: reset failure state once operator triggeres transition to FW again

### DIFF
--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -44,7 +44,7 @@ bool battery_unhealthy                # Battery unhealthy
 # Other
 bool primary_geofence_breached        # Primary Geofence breached
 bool mission_failure                  # Mission failure
-bool vtol_transition_failure          # VTOL transition failed (quadchute)
+bool vtol_fixed_wing_system_failure   # vehicle in fixed-wing system failure failsafe mode (after quad-chute)
 bool wind_limit_exceeded              # Wind limit exceeded
 bool flight_time_limit_exceeded       # Maximum flight time exceeded
 

--- a/msg/VtolVehicleStatus.msg
+++ b/msg/VtolVehicleStatus.msg
@@ -9,4 +9,4 @@ uint64 timestamp			# time since system start (microseconds)
 
 uint8 vehicle_vtol_state		# current state of the vtol, see VEHICLE_VTOL_STATE
 
-bool vtol_transition_failsafe		# vtol in transition failsafe mode
+bool fixed_wing_system_failure		# vehicle in fixed-wing system failure failsafe mode (after quad-chute)

--- a/src/modules/commander/HealthAndArmingChecks/checks/vtolCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/vtolCheck.cpp
@@ -47,10 +47,11 @@ void VtolChecks::checkAndReport(const Context &context, Report &reporter)
 			 */
 			reporter.armingCheckFailure(NavModes::All, health_component_t::system,
 						    events::ID("check_vtol_fixed_wing_system_failure"),
-						    events::Log::Error, "VTOL transition failure");
+						    events::Log::Error,
+						    "VTOL fixed-wing system failure detected. Verify reason for failure, and reboot the vehicle once confirmed safe");
 
 			if (reporter.mavlink_log_pub()) {
-				mavlink_log_info(reporter.mavlink_log_pub(), "Preflight Fail: VTOL transition failure\t");
+				mavlink_log_info(reporter.mavlink_log_pub(), "Preflight Fail: VTOL fixed-wing system failure detected\t");
 			}
 		}
 	}

--- a/src/modules/commander/HealthAndArmingChecks/checks/vtolCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/vtolCheck.cpp
@@ -40,12 +40,13 @@ void VtolChecks::checkAndReport(const Context &context, Report &reporter)
 	vtol_vehicle_status_s vtol_vehicle_status;
 
 	if (_vtol_vehicle_status_sub.copy(&vtol_vehicle_status)) {
-		reporter.failsafeFlags().vtol_transition_failure = vtol_vehicle_status.vtol_transition_failsafe;
+		reporter.failsafeFlags().vtol_fixed_wing_system_failure = vtol_vehicle_status.fixed_wing_system_failure;
 
-		if (reporter.failsafeFlags().vtol_transition_failure) {
+		if (reporter.failsafeFlags().vtol_fixed_wing_system_failure) {
 			/* EVENT
 			 */
-			reporter.armingCheckFailure(NavModes::All, health_component_t::system, events::ID("check_vtol_transition_failure"),
+			reporter.armingCheckFailure(NavModes::All, health_component_t::system,
+						    events::ID("check_vtol_fixed_wing_system_failure"),
 						    events::Log::Error, "VTOL transition failure");
 
 			if (reporter.mavlink_log_pub()) {

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -373,7 +373,7 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 	    state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER ||
 	    state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF ||
 	    state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF) {
-		CHECK_FAILSAFE(status_flags, vtol_transition_failure, fromQuadchuteActParam(_param_com_qc_act.get()));
+		CHECK_FAILSAFE(status_flags, vtol_fixed_wing_system_failure, fromQuadchuteActParam(_param_com_qc_act.get()));
 	}
 
 	// Mission

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -78,11 +78,6 @@ void Standard::update_vtol_state()
 		_pusher_throttle = 0.0f;
 		_reverse_output = 0.0f;
 
-		//reset failsafe when FW is no longer requested
-		if (!_attc->is_fixed_wing_requested()) {
-			_vtol_vehicle_status->vtol_transition_failsafe = false;
-		}
-
 	} else if (!_attc->is_fixed_wing_requested()) {
 
 		// the transition to fw mode switch is off

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -72,7 +72,7 @@ void Standard::update_vtol_state()
 
 	float mc_weight = _mc_roll_weight;
 
-	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+	if (_vtol_vehicle_status->fixed_wing_system_failure) {
 		// Failsafe event, engage mc motors immediately
 		_vtol_mode = vtol_mode::MC_MODE;
 		_pusher_throttle = 0.0f;

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -71,7 +71,7 @@ void Tailsitter::update_vtol_state()
 
 	float pitch = Eulerf(Quatf(_v_att->q)).theta();
 
-	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+	if (_vtol_vehicle_status->fixed_wing_system_failure) {
 		// Failsafe event, switch to MC mode immediately
 		_vtol_mode = vtol_mode::MC_MODE;
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -75,11 +75,6 @@ void Tailsitter::update_vtol_state()
 		// Failsafe event, switch to MC mode immediately
 		_vtol_mode = vtol_mode::MC_MODE;
 
-		//reset failsafe when FW is no longer requested
-		if (!_attc->is_fixed_wing_requested()) {
-			_vtol_vehicle_status->vtol_transition_failsafe = false;
-		}
-
 	} else if (!_attc->is_fixed_wing_requested()) {
 
 		switch (_vtol_mode) { // user switchig to MC mode

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -75,11 +75,6 @@ void Tiltrotor::update_vtol_state()
 		// Failsafe event, switch to MC mode immediately
 		_vtol_mode = vtol_mode::MC_MODE;
 
-		//reset failsafe when FW is no longer requested
-		if (!_attc->is_fixed_wing_requested()) {
-			_vtol_vehicle_status->vtol_transition_failsafe = false;
-		}
-
 	} else 	if (!_attc->is_fixed_wing_requested()) {
 
 		// plane is in multicopter mode

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -71,7 +71,7 @@ void Tiltrotor::update_vtol_state()
 	 * forward completely. For the backtransition the motors simply rotate back.
 	*/
 
-	if (_vtol_vehicle_status->vtol_transition_failsafe) {
+	if (_vtol_vehicle_status->fixed_wing_system_failure) {
 		// Failsafe event, switch to MC mode immediately
 		_vtol_mode = vtol_mode::MC_MODE;
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -198,43 +198,43 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 		case QuadchuteReason::TransitionTimeout:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: transition timeout\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_tout"), events::Log::Critical,
-				     "Quadchute triggered, due to transition timeout");
+				     "Quad-chute triggered due to transition timeout");
 			break;
 
 		case QuadchuteReason::ExternalCommand:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: external command\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_ext_cmd"), events::Log::Critical,
-				     "Quadchute triggered, due to external command");
+				     "Quad-chute triggered due to external command");
 			break;
 
 		case QuadchuteReason::MinimumAltBreached:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: minimum altitude breached\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_min_alt"), events::Log::Critical,
-				     "Quadchute triggered, due to minimum altitude breach");
+				     "Quad-chute triggered due to minimum altitude breach");
 			break;
 
 		case QuadchuteReason::LossOfAlt:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: loss of altitude\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_alt_loss"), events::Log::Critical,
-				     "Quadchute triggered, due to loss of altitude");
+				     "Quad-chute triggered due to loss of altitude");
 			break;
 
 		case QuadchuteReason::LargeAltError:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: large altitude error\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_alt_err"), events::Log::Critical,
-				     "Quadchute triggered, due to large altitude error");
+				     "Quad-chute triggered due to large altitude error");
 			break;
 
 		case QuadchuteReason::MaximumPitchExceeded:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: maximum pitch exceeded\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_max_pitch"), events::Log::Critical,
-				     "Quadchute triggered, due to maximum pitch angle exceeded");
+				     "Quad-chute triggered due to maximum pitch angle exceeded");
 			break;
 
 		case QuadchuteReason::MaximumRollExceeded:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: maximum roll exceeded\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_max_roll"), events::Log::Critical,
-				     "Quadchute triggered, due to maximum roll angle exceeded");
+				     "Quad-chute triggered due to maximum roll angle exceeded");
 			break;
 
 		case QuadchuteReason::None:

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -134,9 +134,9 @@ void VtolAttitudeControl::action_request_poll()
 				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 				_immediate_transition = false;
 
-				// reset vtol_transition_failsafe flag when a new transition to FW is triggered
+				// reset fixed_wing_system_failure flag when a new transition to FW is triggered
 				if (_transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW) {
-					_vtol_vehicle_status.vtol_transition_failsafe = false;
+					_vtol_vehicle_status.fixed_wing_system_failure = false;
 				}
 
 				break;
@@ -169,9 +169,9 @@ void VtolAttitudeControl::vehicle_cmd_poll()
 				_transition_command = transition_command_param1;
 				_immediate_transition = (PX4_ISFINITE(vehicle_command.param2)) ? int(vehicle_command.param2 + 0.5f) : false;
 
-				// reset vtol_transition_failsafe flag when a new transition to FW is triggered
+				// reset fixed_wing_system_failure flag when a new transition to FW is triggered
 				if (_transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW) {
-					_vtol_vehicle_status.vtol_transition_failsafe = false;
+					_vtol_vehicle_status.fixed_wing_system_failure = false;
 				}
 			}
 
@@ -193,7 +193,7 @@ void VtolAttitudeControl::vehicle_cmd_poll()
 void
 VtolAttitudeControl::quadchute(QuadchuteReason reason)
 {
-	if (!_vtol_vehicle_status.vtol_transition_failsafe) {
+	if (!_vtol_vehicle_status.fixed_wing_system_failure) {
 		switch (reason) {
 		case QuadchuteReason::TransitionTimeout:
 			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: transition timeout\t");
@@ -242,7 +242,7 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 			return;
 		}
 
-		_vtol_vehicle_status.vtol_transition_failsafe = true;
+		_vtol_vehicle_status.fixed_wing_system_failure = true;
 	}
 }
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -133,6 +133,12 @@ void VtolAttitudeControl::action_request_poll()
 			case action_request_s::ACTION_VTOL_TRANSITION_TO_FIXEDWING:
 				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 				_immediate_transition = false;
+
+				// reset vtol_transition_failsafe flag when a new transition to FW is triggered
+				if (_transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW) {
+					_vtol_vehicle_status.vtol_transition_failsafe = false;
+				}
+
 				break;
 			}
 		}
@@ -162,6 +168,11 @@ void VtolAttitudeControl::vehicle_cmd_poll()
 			} else {
 				_transition_command = transition_command_param1;
 				_immediate_transition = (PX4_ISFINITE(vehicle_command.param2)) ? int(vehicle_command.param2 + 0.5f) : false;
+
+				// reset vtol_transition_failsafe flag when a new transition to FW is triggered
+				if (_transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW) {
+					_vtol_vehicle_status.vtol_transition_failsafe = false;
+				}
 			}
 
 			if (vehicle_command.from_external) {

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -249,13 +249,13 @@ PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
 PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 
 /**
- * Quadchute maximum height.
+ * Quadchute maximum height
  *
  * Maximum height above the ground (if available, otherwhise above home if available, otherwise above the local origin) where triggering a quadchute is possible.
  * Triggering a quadchute always means transitioning the vehicle to hover flight in which generally a lot of energy is consumed.
  * At high altitudes there is therefore a big risk to deplete the battery and therefore crash. Currently, there is no automated
  * re-transition to fixed wing mode implemented and therefore this parameter serves and an intermediate measure to increase safety.
- * Setting this value to 0 deactivates the behavior.
+ * Setting this value to 0 deactivates the behavior (always enable quad-chute independently of altitude).
  *
  * @unit m
  * @min 0

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -227,10 +227,13 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
 PARAM_DEFINE_FLOAT(VT_FW_ALT_ERR, 0.0f);
 
 /**
- * QuadChute Max Pitch
+ * Quad-chute max pitch threshold
  *
- * Maximum pitch angle before QuadChute engages
- * Above this the vehicle will transition back to MC mode and enter failsafe RTL
+ * Absolute pitch threshold for quad-chute triggering in FW mode.
+ * Above this the vehicle will transition back to MC mode and execute behavior defined in COM_QC_ACT.
+ * Set to 0 do disable this threshold.
+ *
+ * @unit deg
  * @min 0
  * @max 180
  * @group VTOL Attitude Control
@@ -238,10 +241,13 @@ PARAM_DEFINE_FLOAT(VT_FW_ALT_ERR, 0.0f);
 PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
 
 /**
- * QuadChute Max Roll
+ * Quad-chute max roll threshold
  *
- * Maximum roll angle before QuadChute engages
- * Above this the vehicle will transition back to MC mode and enter failsafe RTL
+ * Absolute roll threshold for quad-chute triggering in FW mode.
+ * Above this the vehicle will transition back to MC mode and execute behavior defined in COM_QC_ACT.
+ * Set to 0 do disable this threshold.
+ *
+ * @unit deg
  * @min 0
  * @max 180
  * @group VTOL Attitude Control
@@ -249,7 +255,7 @@ PARAM_DEFINE_INT32(VT_FW_QC_P, 0);
 PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 
 /**
- * Quadchute maximum height
+ * Quad-chute maximum height
  *
  * Maximum height above the ground (if available, otherwhise above home if available, otherwise above the local origin) where triggering a quadchute is possible.
  * Triggering a quadchute always means transitioning the vehicle to hover flight in which generally a lot of energy is consumed.

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -228,9 +228,12 @@ bool VtolType::isQuadchuteEnabled()
 
 	}
 
+	const bool above_quadchute_altitude_limit = _param_quadchute_max_height.get() > 0
+			&& dist_to_ground > (float)_param_quadchute_max_height.get();
+
 	return _v_control_mode->flag_armed &&
-	       !_land_detected->landed && _param_quadchute_max_height.get() > 0 &&
-	       dist_to_ground < (float)_param_quadchute_max_height.get();
+	       !_land_detected->landed && !above_quadchute_altitude_limit;
+
 }
 
 bool VtolType::isMinAltBreached()

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -471,7 +471,7 @@ float VtolType::pusher_assist()
 	}
 
 	// Do not engage pusher assist during a failsafe event (could be a problem with the fixed wing drive)
-	if (_attc->get_vtol_vehicle_status()->vtol_transition_failsafe) {
+	if (_attc->get_vtol_vehicle_status()->fixed_wing_system_failure) {
 		return 0.0f;
 	}
 


### PR DESCRIPTION
### Solved Problem
Many people complained that it is not possible for them to transition back to FW after a quad-chute. Depending on how far away from Home the QC happened, transitioning to FW is the only way to get the vehicle back home and land it safely. As the trigger of a quad-chute is not a reliable source to determine the system health (is real hardware failure or did a large external disturbance cause the QC?), I find it better to give the operator the responsibility to judge the situation and trigger a transition to FW if deemed safe.

### Solution
Reset the failure flag (`fixed_wing_system_failure`) on re-triggering of transition to FW, which then in turn allows the transition to happen int he first place. Before was only possible to reset it with a commanded transition to MC, which many ground station interfaces didn't allow as the system, after a quad-chute, already was in MC mode.

While on it found that the newly introduced max altitude for quad-chute wrongly disabled QC completely when set to 0 (default). Fixed that in the 2nd commit.

Beside that changed some variable names (fixed_wing_system_failure is more precise than transition_failure) and improved the meta data of some QC parameters.

### Test coverage
SITL tested.

