### PR TITLE
VTOL: Rework altitude-loss quad-chute

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -89,7 +89,7 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_mode == vtol_mode::FW_MODE) {
 			// Regular backtransition
-			resetTransitionTimer();
+			resetTransitionStates();
 			_vtol_mode = vtol_mode::TRANSITION_TO_MC;
 			_reverse_output = _param_vt_b_rev_out.get();
 
@@ -126,7 +126,7 @@ void Standard::update_vtol_state()
 			// start transition to fw mode
 			/* NOTE: The failsafe transition to fixed-wing was removed because it can result in an
 			 * unsafe flying state. */
-			resetTransitionTimer();
+			resetTransitionStates();
 			_vtol_mode = vtol_mode::TRANSITION_TO_FW;
 
 		} else if (_vtol_mode == vtol_mode::FW_MODE) {

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -82,7 +82,7 @@ void Tailsitter::update_vtol_state()
 			break;
 
 		case vtol_mode::FW_MODE:
-			resetTransitionTimer();
+			resetTransitionStates();
 			_vtol_mode = vtol_mode::TRANSITION_BACK;
 			break;
 
@@ -107,7 +107,7 @@ void Tailsitter::update_vtol_state()
 		case vtol_mode::MC_MODE:
 			// initialise a front transition
 			_vtol_mode = vtol_mode::TRANSITION_FRONT_P1;
-			resetTransitionTimer();
+			resetTransitionStates();
 			break;
 
 		case vtol_mode::FW_MODE:

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -83,7 +83,7 @@ void Tiltrotor::update_vtol_state()
 			break;
 
 		case vtol_mode::FW_MODE:
-			resetTransitionTimer();
+			resetTransitionStates();
 			_vtol_mode = vtol_mode::TRANSITION_BACK;
 			break;
 
@@ -126,7 +126,7 @@ void Tiltrotor::update_vtol_state()
 		switch (_vtol_mode) {
 		case vtol_mode::MC_MODE:
 			// initialise a front transition
-			resetTransitionTimer();
+			resetTransitionStates();
 			_vtol_mode = vtol_mode::TRANSITION_FRONT_P1;
 			break;
 
@@ -154,7 +154,7 @@ void Tiltrotor::update_vtol_state()
 
 				if (transition_to_p2) {
 					_vtol_mode = vtol_mode::TRANSITION_FRONT_P2;
-					resetTransitionTimer();
+					resetTransitionStates();
 				}
 
 				break;

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -213,10 +213,10 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 				     "Quad-chute triggered due to minimum altitude breach");
 			break;
 
-		case QuadchuteReason::LossOfAlt:
-			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: loss of altitude\t");
+		case QuadchuteReason::UncommandedDescent:
+			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: Uncommanded descent detected\t");
 			events::send(events::ID("vtol_att_ctrl_quadchute_alt_loss"), events::Log::Critical,
-				     "Quad-chute triggered due to loss of altitude");
+				     "Quad-chute triggered due to uncommanded descent detection");
 			break;
 
 		case QuadchuteReason::TransitionAltitudeLoss:

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -219,10 +219,10 @@ VtolAttitudeControl::quadchute(QuadchuteReason reason)
 				     "Quad-chute triggered due to loss of altitude");
 			break;
 
-		case QuadchuteReason::LargeAltError:
-			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: large altitude error\t");
-			events::send(events::ID("vtol_att_ctrl_quadchute_alt_err"), events::Log::Critical,
-				     "Quad-chute triggered due to large altitude error");
+		case QuadchuteReason::TransitionAltitudeLoss:
+			mavlink_log_critical(&_mavlink_log_pub, "Quadchute: loss of altitude during transition\t");
+			events::send(events::ID("vtol_att_ctrl_quadchute_trans_alt_err"), events::Log::Critical,
+				     "Quad-chute triggered due to loss of altitude during transition");
 			break;
 
 		case QuadchuteReason::MaximumPitchExceeded:

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -212,10 +212,14 @@ PARAM_DEFINE_FLOAT(VT_TRANS_MIN_TM, 2.0f);
 PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
 
 /**
- * Adaptive QuadChute
+ * Quad-chute uncommanded descent threshold
  *
- * Maximum negative altitude error for fixed wing flight. If the altitude drops below this value below the altitude setpoint
- * the vehicle will transition back to MC mode and enter failsafe RTL.
+ * Threshold for integrated height rate error to trigger a uncommanded-descent quad-chute.
+ * Only checked in altitude-controlled fixed-wing flight.
+ * Additional conditions that have to be met for uncommanded descent detection are a positive (climbing) height
+ * rate setpoint and a negative (sinking) current height rate estimate.
+ *
+ * Set to 0 do disable this threshold.
  *
  * @unit m
  * @min 0.0
@@ -224,7 +228,7 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
  * @decimal 1
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_FW_ALT_ERR, 0.0f);
+PARAM_DEFINE_FLOAT(VT_QC_HR_ERROR_I, 0.0f);
 
 /**
  * Quad-chute transition altitude loss threshold

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -227,6 +227,24 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
 PARAM_DEFINE_FLOAT(VT_FW_ALT_ERR, 0.0f);
 
 /**
+ * Quad-chute transition altitude loss threshold
+ *
+ * Altitude loss threshold for quad-chute triggering during VTOL transition to fixed-wing flight.
+ * If the current altitude is more than this value below the altitude at the beginning of the
+ * transition, it will instantly switch back to MC mode and execute behavior defined in COM_QC_ACT.
+ *
+ * Set to 0 do disable this threshold.
+ *
+ * @unit m
+ * @min 0
+ * @max 50
+ * @increment 1
+ * @decimal 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_QC_T_ALT_LOSS, 10.0f);
+
+/**
  * Quad-chute max pitch threshold
  *
  * Absolute pitch threshold for quad-chute triggering in FW mode.

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -90,7 +90,7 @@ enum class QuadchuteReason {
 	ExternalCommand,
 	MinimumAltBreached,
 	LossOfAlt,
-	LargeAltError,
+	TransitionAltitudeLoss,
 	MaximumPitchExceeded,
 	MaximumRollExceeded,
 };
@@ -173,11 +173,11 @@ public:
 	bool largeAltitudeLoss();
 
 	/**
-	 *  @brief Indicates if the vehicle has an altitude error larger than VT_FW_ALT_ERR. This only applied when TECS is not running.
+	 * @brief Indicates if there is an altitude loss higher than specified threshold during a VTOL transition to FW
 	 *
-	 * @return     true if error larger than threshold
+	 * @return true if error larger than threshold
 	 */
-	bool largeAltitudeError();
+	bool isFrontTransitionAltitudeLoss();
 
 	/**
 	 *  @brief Indicates if the absolute value of the vehicle pitch angle exceeds the threshold defined by VT_FW_QC_P
@@ -252,11 +252,7 @@ public:
 	 * @brief Resets the transition timer states.
 	 *
 	 */
-	void resetTransitionTimer()
-	{
-		_transition_start_timestamp = hrt_absolute_time();
-		_time_since_trans_start = 0.f;
-	}
+	void resetTransitionStates();
 
 protected:
 	VtolAttitudeControl *_attc;
@@ -318,12 +314,15 @@ protected:
 
 	float _dt{0.0025f}; // time step [s]
 
+	float _local_position_z_start_of_transition{0.f}; // altitude at start of transition
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(ModuleParams,
 					(ParamBool<px4::params::VT_ELEV_MC_LOCK>) _param_vt_elev_mc_lock,
 					(ParamFloat<px4::params::VT_FW_MIN_ALT>) _param_vt_fw_min_alt,
 					(ParamFloat<px4::params::VT_FW_ALT_ERR>) _param_vt_fw_alt_err,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
+					(ParamFloat<px4::params::VT_QC_T_ALT_LOSS>) _param_vt_qc_t_alt_loss,
 					(ParamInt<px4::params::VT_FW_QC_HMAX>) _param_quadchute_max_height,
 					(ParamFloat<px4::params::VT_F_TR_OL_TM>) _param_vt_f_tr_ol_tm,
 					(ParamFloat<px4::params::VT_TRANS_MIN_TM>) _param_vt_trans_min_tm,

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -89,7 +89,7 @@ enum class QuadchuteReason {
 	TransitionTimeout,
 	ExternalCommand,
 	MinimumAltBreached,
-	LossOfAlt,
+	UncommandedDescent,
 	TransitionAltitudeLoss,
 	MaximumPitchExceeded,
 	MaximumRollExceeded,
@@ -165,12 +165,11 @@ public:
 	bool isMinAltBreached();
 
 	/**
-	 *  @brief Indicates if the vehicle has an altitude error larger than VT_FW_ALT_ERR and is losing altitude quickly.
-	 * 		This only applies when TECS is running.
+	 * @brief Indicates if conditions are met for uncommanded-descent quad-chute.
 	 *
-	 * @return     true if error larger than threshold
+	 * @return true if integrated height rate error larger than threshold
 	 */
-	bool largeAltitudeLoss();
+	bool isUncommandedDescent();
 
 	/**
 	 * @brief Indicates if there is an altitude loss higher than specified threshold during a VTOL transition to FW
@@ -199,11 +198,6 @@ public:
 	 * @return     true if exeeded
 	 */
 	bool isFrontTransitionTimeout();
-
-	/**
-	 *  @brief Applied a first order low pass filte to TECS height rate and heigh rate setpoint.
-	 */
-	void filterTecsHeightRates();
 
 	/**
 	 *  @brief Special handling of QuadchuteReason::ReasonExternal
@@ -290,8 +284,8 @@ protected:
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)
 	float _last_thr_in_fw_mode = 0.0f;
 
-	float _ra_hrate = 0.0f;			// rolling average on height rate for quadchute condition
-	float _ra_hrate_sp = 0.0f;		// rolling average on height rate setpoint for quadchute condition
+	float _height_rate_error_integral{0.f};
+
 
 	hrt_abstime _trans_finished_ts = 0;
 	hrt_abstime _transition_start_timestamp{0};
@@ -302,6 +296,7 @@ protected:
 
 	hrt_abstime _last_loop_ts = 0;
 	float _transition_dt = 0;
+	hrt_abstime _last_loop_quadchute_timestamp = 0;
 
 	float _accel_to_pitch_integ = 0;
 
@@ -319,7 +314,7 @@ protected:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(ModuleParams,
 					(ParamBool<px4::params::VT_ELEV_MC_LOCK>) _param_vt_elev_mc_lock,
 					(ParamFloat<px4::params::VT_FW_MIN_ALT>) _param_vt_fw_min_alt,
-					(ParamFloat<px4::params::VT_FW_ALT_ERR>) _param_vt_fw_alt_err,
+					(ParamFloat<px4::params::VT_QC_HR_ERROR_I>) _param_vt_qc_hr_error_i,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
 					(ParamFloat<px4::params::VT_QC_T_ALT_LOSS>) _param_vt_qc_t_alt_loss,


### PR DESCRIPTION
Based on https://github.com/PX4/PX4-Autopilot/pull/20913 (but basically separate). 

### Solved Problem
Previously the condition was based on hard coded height rate estimate and setpoint values and an altitude error threshold. That showed to be leading to false positives when the vehicle doesn't tightly follow the altitude ramp given by TECS to achieve a new altitude setpoint, and has become completely infeasible with the latest TECS rework that leads to non-ramped altitude setpoint changes in the tecs_status message.

For example this flight triggered a quadchute due to altitude loss (VT_FW_ALT_ERR was set to 15m, and vehicle was not able to follow TECS altitude ramp and then briefly had an uncommanded descent due to strong crosswind). 
![image](https://user-images.githubusercontent.com/26798987/212124788-646ac740-f105-45f6-b356-894073bc9006.png)

An additional issue was that during a front transition the VT_FW_ALT_ERR usually is desired to be set smaller than in FW flight, as a 10m altitude loss in transitions are more severe than in FW flight (due to the lower altitude). 

### Solution
I split up the "loss of altitude" aka "adaptive" QC into two: 
- TransitionAltitudeLoss QC (configurable through new param VT_QC_T_ALT_LOSS, 10 by default).
- UncommandedDescend QC (only in FW flight, configurable through VT_QC_HR_ERROR_I)

The new check (UncommandedDescend) no longer checks the altitude error but only the height rate instead. It begins to integrate the height rate error once it detects an uncommanded descent condition (height rate negative while setpoint is positive). Integral threshold can be tuned by user (VT_QC_HR_ERROR_I). The integral is reset once out of the uncommanded descent.
I changed parameter name from VT_FW_ALT_ERR to VT_QC_HR_ERROR_I as it needs to be re-tuned should we go for this proposed solution here.

### Test coverage
SITL tested by disabling FW throttle (FW_THR_MAX=0) and having VT_QC_HR_ERROR_I = 50m. Uncommanded descent QC is triggered 14s after the failure here, with an altitude loss of 25m (could be configured to trigger much earlier). 
![image](https://user-images.githubusercontent.com/26798987/212125622-294071ca-07c5-4315-8192-488c20bbfb00.png)
(btw, no there seems to be an issue with the tecs_status/altitude_filtered here, it always follows the setpoint without error).

### Context
Fixes https://github.com/PX4/PX4-Autopilot/issues/14947?
