### PR TITLE
Don't save `CAL_MAG_SIDES` in factory calibration

### DIFF
--- a/src/modules/commander/factory_calibration_storage.cpp
+++ b/src/modules/commander/factory_calibration_storage.cpp
@@ -47,7 +47,7 @@ static bool filter_calibration_params(param_t handle)
 {
 	const char *name = param_name(handle);
 	// filter all non-calibration params
-	return strncmp(name, "CAL_", 4) == 0 || strncmp(name, "TC_", 3) == 0;
+	return (strncmp(name, "CAL_", 4) == 0 && strncmp(name, "CAL_MAG_SIDES", 13) != 0) || strncmp(name, "TC_", 3) == 0;
 }
 
 FactoryCalibrationStorage::FactoryCalibrationStorage()

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -98,8 +98,6 @@ bool VehicleMagnetometer::ParametersUpdate(bool force)
 {
 	// Check if parameters have changed
 	if (_parameter_update_sub.updated() || force) {
-		const int cal_mag_sides_prev = _param_cal_mag_sides.get();
-
 		// clear update
 		parameter_update_s param_update;
 		_parameter_update_sub.copy(&param_update);
@@ -109,11 +107,6 @@ bool VehicleMagnetometer::ParametersUpdate(bool force)
 		// Legacy QGC support: CAL_MAG_SIDES required to display the correct UI
 		// Force it to be a copy of the new SENS_MAG_SIDES
 		if (_param_cal_mag_sides.get() != _param_sens_mag_sides.get()) {
-			if (_param_cal_mag_sides.get() != cal_mag_sides_prev) {
-				// The user tried to change the deprecated parameter
-				mavlink_log_critical(&_mavlink_log_pub, "CAL_MAG_SIDES deprecated, use SENS_MAG_SIDES\t");
-			}
-
 			_param_cal_mag_sides.set(_param_sens_mag_sides.get());
 			_param_cal_mag_sides.commit();
 		}


### PR DESCRIPTION


### Solved Problem
Follow-up on https://github.com/PX4/PX4-Autopilot/pull/20723
Since I had to re-add `CAL_MAG_SIDES` for QGC purposes, it's still saved in the factory calibration.
Also, if it was already saved the warning message at every boot is just annoying.

### Solution
- Add `CAL_MAG_SIDES` to the factory cal filter to exclude it
- Remove the warning on `CAL_MAG_SIDES` change (silently override it).

### Alternatives
Filter the param loading, but thin involves more changes.