### PR TITLE
esc_calibration: Publish actuator_test with large enough queue size

### DIFF
--- a/msg/ActuatorTest.msg
+++ b/msg/ActuatorTest.msg
@@ -18,4 +18,4 @@ float32 value					# range: [-1, 1], where 1 means maximum positive output,
                    				# and NaN maps to disarmed (stop the motors)
 uint32 timeout_ms				# timeout in ms after which to exit test mode (if 0, do not time out)
 
-uint8 ORB_QUEUE_LENGTH = 8
+uint8 ORB_QUEUE_LENGTH = 12                     # same as MAX_NUM_MOTORS to support code in esc_calibration


### PR DESCRIPTION
The actuator test is published for each motor in a row. If the orb queue size is too small, messages are lost and not received in mixer_module.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

### Solved Problem

ESC calibration didn't work any more on upstream PX4 main

