### PR TITLE
logger: Add 1st arm to shutdown

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -23,6 +23,12 @@ then
 	set LOGGER_ARGS "${LOGGER_ARGS} -x"
 fi
 
+if param compare SDLOG_MODE 4
+then
+	set LOGGER_ARGS "${LOGGER_ARGS} -a"
+fi
+
+
 if ! param compare SDLOG_MODE -1
 then
 	logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -257,7 +257,7 @@ Logger *Logger::instantiate(int argc, char *argv[])
 	int ch;
 	const char *myoptarg = nullptr;
 
-	while ((ch = px4_getopt(argc, argv, "r:b:etfm:p:xc:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "r:b:aetfm:p:xc:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'r': {
 				unsigned long r = strtoul(myoptarg, nullptr, 10);
@@ -289,6 +289,10 @@ Logger *Logger::instantiate(int argc, char *argv[])
 
 		case 'f':
 			log_mode = Logger::LogMode::boot_until_shutdown;
+			break;
+
+		case 'a':
+			log_mode = Logger::LogMode::arm_until_shutdown;
 			break;
 
 		case 'b': {
@@ -1113,7 +1117,8 @@ bool Logger::start_stop_logging()
 
 		if (_vehicle_status_sub.update(&vehicle_status)) {
 
-			desired_state = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+			desired_state = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) || (_prev_state
+					&& _log_mode == LogMode::arm_until_shutdown);
 			updated = true;
 		}
 	}
@@ -2405,6 +2410,7 @@ $ logger on
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAM_STRING('m', "all", "file|mavlink|all", "Backend mode", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('x', "Enable/disable logging via Aux1 RC channel", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Log 1st armed until shutdown", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('e', "Enable logging right after start until disarm (otherwise only when armed)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('f', "Log until shutdown (implies -e)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('t', "Use date/time for naming log directories and files", true);

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -87,7 +87,8 @@ public:
 		while_armed = 0,
 		boot_until_disarm,
 		boot_until_shutdown,
-		rc_aux1
+		rc_aux1,
+		arm_until_shutdown,
 	};
 
 	Logger(LogWriter::Backend backend, size_t buffer_size, uint32_t log_interval, const char *poll_topic_name,

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -60,6 +60,7 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
  * @value 1 from boot until disarm
  * @value 2 from boot until shutdown
  * @value 3 depending on AUX1 RC channel
+ * @value 4 from 1st armed until shutdown
  *
  * @reboot_required true
  * @group SD Logging


### PR DESCRIPTION
### Solved Problem

None

### Solution

I would like to automatically create a flight logbook by getting the flight time, flight start time, flight end time, flight start location, etc. from ULOG.
I want one ULOG file from first arm to power off.
I live in Japan.
The flight time of the drone in Japan country is assumed to be from "first takeoff to power off".
The drone in Japan country may move without turning off the power in the state of arm release.
PX4-Autopilot logs from boot to power off.
I may only power on and not arm.
I can create a valid ULOG file.

### Alternatives

None

### Test coverage

None

### Context

Logger menu
![Screenshot from 2023-01-15 19-17-37](https://user-images.githubusercontent.com/646194/212536956-66c14970-1500-4d34-b8c7-27233a849ab9.png)

Command start
![Screenshot from 2023-01-15 19-27-09](https://user-images.githubusercontent.com/646194/212536980-96d52b69-9033-4884-ab65-717d3c65a521.png)

Description
![Screenshot from 2023-01-15 19-27-23](https://user-images.githubusercontent.com/646194/212537023-82fb3527-75d3-4bf1-b56a-a31f22393621.png)

Parameter selection
![Screenshot from 2023-01-15 19-28-39](https://user-images.githubusercontent.com/646194/212537077-3a2432ce-9c95-4120-81dd-f3363f559f47.png)
![Screenshot from 2023-01-15 19-31-22](https://user-images.githubusercontent.com/646194/212537090-67cdb141-aaf4-4a59-98f2-72514315d4ff.png)

ULOG: start Armed!! and meny armed, disarmed..
![Screenshot from 2023-01-15 19-36-31](https://user-images.githubusercontent.com/646194/212537154-3b8369fb-9c17-4035-b2f3-f1c7f8bea0be.png)