### PR TITLE
UAVCAN: Delay transmission until other nodes have booted

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/stm32/driver/src/uc_stm32_can.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32/driver/src/uc_stm32_can.cpp
@@ -301,6 +301,19 @@ uavcan::int16_t CanIface::send(const uavcan::CanFrame &frame, uavcan::MonotonicT
 		return -ErrUnsupportedFrame;
 	}
 
+	// brick end time 2225ms
+	// brick start time 1187ms
+	static bool check_for_delay = false;
+	if (!check_for_delay) {
+		struct timespec ts;
+		clock_systime_timespec(&ts);
+		const uint32_t msec = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+		if (msec < 2225) {
+			return 0;
+		}
+		check_for_delay = true;
+	}
+
 	/*
 	 * Normally we should perform the same check as in @ref canAcceptNewTxFrame(), because
 	 * it is possible that the highest-priority frame between select() and send() could have been

--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
@@ -399,6 +399,19 @@ uavcan::int16_t CanIface::send(const uavcan::CanFrame &frame, uavcan::MonotonicT
 		return -ErrUnsupportedFrame;
 	}
 
+	// brick end time 2225ms
+	// brick start time 1187ms
+	static bool check_for_delay = false;
+	if (!check_for_delay) {
+		struct timespec ts;
+		clock_systime_timespec(&ts);
+		const uint32_t msec = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+		if (msec < 2225) {
+			return 0;
+		}
+		check_for_delay = true;
+	}
+
 	/*
 	 * Normally we should perform the same check as in @ref canAcceptNewTxFrame(), because
 	 * it is possible that the highest-priority frame between select() and send() could have been


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

When powering the FMUv6x on with one or multiple ProfiCNC CANflow v4 nodes attached, enumeration fails. If the CANflow nodes are hot plugged, enumeration works fine. On the FMUv5x, enumeration works in both cases. Adding another UAVCAN node onto the bus (a NEO V2 pro), enumerates that node on the v6x too.

Attaching a logic analyzer shows that both the FMU v6x/v5x flood the CAN bus with unacknowledged messages when the uavcan service starts, since the CANflow nodes are not yet configured and thus the unacked messages are automatically retransmitted by the CAN peripheral of the FMU.
Disabling automatic retransmits breaks the UAVCAN protocol, since transmission failures are no longer reported (the peripheral turns off the error flags).

![FMU flooding the bus with unacked messages](https://user-images.githubusercontent.com/121870655/212704672-acc76996-b0e2-4ba5-a009-890bc847956c.png)

The theory is that the FMUv6x boots faster than the FMUv5x and is therefore able to send more unacked messages to the CANflow node (running a STM32F3), which overflows the receive error counter (see RM0365 p982ff) and places the CANflow CAN peripheral into ERROR PASSIVE mode, perhaps even into BUS OFF state, if its transmit error counter overflows.

![CAN error states](https://user-images.githubusercontent.com/121870655/212699223-30aaae48-12b6-4fda-9359-689d53781c09.png)

I did not find any open source code for the CANflow node, so I cannot confirm it, however, simply delaying the transmission on the CAN bus prevents this situation by giving the CANflow node enough time to setup it's CAN peripheral without unacked message reception.

### Solution

I currently check that the uptime is at least 3 seconds after power up (determined experimentally) before allowing any transmissions on the bus.
This is a bit crude and should probably be done in another way, like sleeping in the thread that runs the UAVCAN node, but I don't understand the code fully yet.

### Alternatives

I think that the FMU should not flood the bus with unacked messages, however, adding some kind of bus probing mechanism that checks if the bus is even connected (ie. there is another node that can ACK) to prevent a NACK storm, seemed to complex for me to implement.

### Test coverage

Tested in hardware with logging and one or two CANflow node on FMU v5x and v6x.

### Context

- STM32F3 Reference Manual Chapter 31 [RM0365](https://www.st.com/resource/en/reference_manual/rm0365-stm32f302xbcde-and-stm32f302x68-advanced-armbased-32bit-mcus-stmicroelectronics.pdf)
