### PR TITLE
microdds_client: add _subs reset method to allow reconnections

### DIFF
--- a/src/modules/microdds_client/dds_topics.h.em
+++ b/src/modules/microdds_client/dds_topics.h.em
@@ -37,6 +37,14 @@ struct SendTopicsSubs {
 	uint32_t num_payload_sent{};
 
 	void update(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId best_effort_stream_id, uxrObjectId participant_id, const char *client_namespace);
+	void reset();
+};
+
+void SendTopicsSubs::reset() {
+	num_payload_sent = 0;
+@[    for idx, pub in enumerate(publications)]@
+	@(pub['topic_simple'])_data_writer = uxr_object_id(0, UXR_INVALID_ID);
+@[    end for]@
 };
 
 void SendTopicsSubs::update(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId best_effort_stream_id, uxrObjectId participant_id, const char *client_namespace)

--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -371,6 +371,7 @@ void MicroddsClient::run()
 		uxr_delete_session_retries(&session, _connected ? 1 : 0);
 		_last_payload_tx_rate = 0;
 		_last_payload_tx_rate = 0;
+		_subs->reset();
 	}
 }
 


### PR DESCRIPTION
### Solved Problem
If the DDS session is closed without stooping the client (i.e. by the Agent or due to a connection issue) the `_subs` structure is not de-initialized (`data_writer.id = UXR_DATAWRITER_ID`) and therefore when a new session is established the `*_data_writers` are not recreated. 
https://github.com/PX4/PX4-Autopilot/blob/00bfd5436a6f743fe79d6c300ab37982fcf2987f/src/modules/microdds_client/dds_topics.h.em#L52-L55
Right now the only solution is to stop and restart the client.

Fixes https://github.com/PX4/px4_ros_com/issues/175

### Solution
- Added the `reset()` method to `SendTopicsSubs` which clear the structure.
- `_subs->reset()` is called right after the DDS session is deleted.

### Alternatives
The entire `_subs` struct could be deleted and then recreated in the following cycle.

### Test coverage
- Tested in SITL
