### PR TITLE
commander: avoid timestamp implicit float conversions

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/offboardCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/offboardCheck.cpp
@@ -42,7 +42,10 @@ void OffboardChecks::checkAndReport(const Context &context, Report &reporter)
 	offboard_control_mode_s offboard_control_mode;
 
 	if (_offboard_control_mode_sub.copy(&offboard_control_mode)) {
-		bool data_is_recent = hrt_absolute_time() < offboard_control_mode.timestamp + _param_com_of_loss_t.get() * 1_s;
+
+		bool data_is_recent = hrt_absolute_time() < offboard_control_mode.timestamp
+				      + static_cast<hrt_abstime>(_param_com_of_loss_t.get() * 1_s);
+
 		bool offboard_available = (offboard_control_mode.position || offboard_control_mode.velocity
 					   || offboard_control_mode.acceleration || offboard_control_mode.attitude || offboard_control_mode.body_rate
 					   || offboard_control_mode.actuator) && data_is_recent;

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -426,11 +426,16 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 
 
 	// Failure detector
-	if (_armed_time != 0 && time_us - _armed_time < _param_com_spoolup_time.get() * 1_s) {
+	if ((_armed_time != 0)
+	    && (time_us < _armed_time + static_cast<hrt_abstime>(_param_com_spoolup_time.get() * 1_s))
+	   ) {
 		CHECK_FAILSAFE(status_flags, fd_esc_arming_failure, Action::Disarm);
 	}
 
-	if (_armed_time != 0 && time_us - _armed_time < (_param_com_lkdown_tko.get() + _param_com_spoolup_time.get()) * 1_s) {
+	if ((_armed_time != 0)
+	    && (time_us < _armed_time
+		+ static_cast<hrt_abstime>((_param_com_lkdown_tko.get() + _param_com_spoolup_time.get()) * 1_s))
+	   ) {
 		// This handles the case where something fails during the early takeoff phase
 		CHECK_FAILSAFE(status_flags, fd_critical_failure, Action::Disarm);
 


### PR DESCRIPTION
 - 64 bit time in microseconds stored in a 32 bit float quickly becomes problematic
 - fixes https://github.com/PX4/PX4-Autopilot/issues/20944

@ecmnet