### PR TITLE
Update current year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2012 - 2022, PX4 Development Team
+Copyright (c) 2012 - 2023, PX4 Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update year to match with the current year 2023 in LICENSE file. 2022 now is in the past.

### Solved Problem
Date in the LICENSE file was not correct.

### Solution
Now it is changed to 2023.

### Alternatives
No possible alternatives until 2024.

### Test coverage
Compared with the calendar.

### Context
Happy new year!
