### PR TITLE
drivers/uavcan: silence cmake deprecation warning for now

### DIFF
--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015-2021 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2015-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -88,6 +88,7 @@ add_compile_options(
 	-Wno-deprecated-copy # TODO: fix
 	-Wno-address-of-packed-member
 )
+set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE) # silence libuavcan deprecation warning for now (TODO: fix and remove)
 add_subdirectory(${LIBUAVCAN_DIR} libuavcan EXCLUDE_FROM_ALL)
 add_dependencies(uavcan prebuild_targets)
 
@@ -100,7 +101,7 @@ target_include_directories(uavcan_${UAVCAN_DRIVER}_driver PUBLIC
 
 
 # generated DSDL
-set(DSDLC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/dsdl")
+set(DSDLC_DIR "${PX4_SOURCE_DIR}/src/drivers/uavcan/dsdl")
 set(DSDLC_INPUTS
 	"${LIBUAVCAN_DIR}/dsdl/ardupilot"
 	"${LIBUAVCAN_DIR}/dsdl/com"
@@ -132,6 +133,8 @@ px4_add_module(
 	STACK_MAIN 4096
 	COMPILE_FLAGS
 		-Wno-format-security # logmessage.hpp
+		#-O0
+		#-DDEBUG_BUILD
 	INCLUDES
 		${DSDLC_OUTPUT}
 		${LIBUAVCAN_DIR}/libuavcan/include
@@ -170,10 +173,8 @@ px4_add_module(
 		sensors/ice_status.cpp
 		sensors/hygrometer.cpp
 		sensors/safety_button.cpp
-
 	MODULE_CONFIG
 		module.yaml
-
 	DEPENDS
 		px4_uavcan_dsdlc
 

--- a/src/drivers/uavcannode/CMakeLists.txt
+++ b/src/drivers/uavcannode/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015-2021 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2015-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -88,6 +88,7 @@ add_compile_options(
 	-Wno-deprecated-copy # TODO: fix
 	-Wno-address-of-packed-member
 )
+set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE) # silence libuavcan deprecation warning for now (TODO: fix and remove)
 add_subdirectory(${LIBUAVCAN_DIR} libuavcan EXCLUDE_FROM_ALL)
 add_dependencies(uavcan prebuild_targets)
 
@@ -129,14 +130,15 @@ add_custom_target(px4_uavcan_dsdlc DEPENDS px4_uavcan_dsdlc_run.stamp)
 px4_add_module(
 	MODULE drivers__uavcannode
 	MAIN uavcannode
+	COMPILE_FLAGS
+		#-O0
+		#-DDEBUG_BUILD
 	INCLUDES
 		${DSDLC_OUTPUT}
 		${LIBUAVCAN_DIR}/libuavcan/include
 		${LIBUAVCAN_DIR}/libuavcan/include/dsdlc_generated
 		${LIBUAVCAN_DIR}/libuavcan_drivers/posix/include
 		${LIBUAVCAN_DIR_DRIVERS}/${UAVCAN_DRIVER}/driver/include
-	COMPILE_OPTIONS
-		#-O0
 	SRCS
 		allocator.hpp
 		uavcan_driver.hpp

--- a/src/drivers/uavcannode/uavcan_driver.hpp
+++ b/src/drivers/uavcannode/uavcan_driver.hpp
@@ -42,6 +42,8 @@
 #  include <uavcan_kinetis/uavcan_kinetis.hpp>
 #elif defined(UAVCAN_STM32_NUTTX)
 #  include <uavcan_stm32/uavcan_stm32.hpp>
+#elif defined(UAVCAN_STM32H7_NUTTX)
+#  include <uavcan_stm32h7/uavcan_stm32h7.hpp>
 #else
 #  error "Unsupported driver"
 #endif


### PR DESCRIPTION
 - keep drivers/uavcannode cmake in sync with drivers/uavcan


Silence this noise for now, it's not that hard to fix properly when the time comes, but will require a submodule update.

![Screenshot from 2023-01-22 12-36-59](https://user-images.githubusercontent.com/84712/213930987-388ae5eb-3caf-454b-9242-5830478f6c2f.png)
