### PR TITLE
TECS airspeedless throttle improvement.

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -609,7 +609,12 @@ float TECSControl::_calcThrottleControlOutput(const STERateLimit &limit, const C
 		// Add the integrator feedback during closed loop operation with an airspeed sensor
 		throttle_setpoint += _throttle_integ_state;
 
+	} else {
+		/* We want to avoid reducing the throttle output when switching from airspeed enabled mode into airspeedless mode.
+		  Thus, if the throttle integrator has a positive value, add it still to the throttle setpoint. */
+		throttle_setpoint += math::max(0.0f, _throttle_integ_state);
 	}
+
 
 	// ramp in max throttle setting with underspeediness value
 	throttle_setpoint = _ratio_undersped * param.throttle_max + (1.0f - _ratio_undersped) * throttle_setpoint;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

We want to avoid going into stall, when a FW is changed from airspeed to airspeedless altitude mode. In this case, we want to avoid reducing the throttle kcommand. However, when switching into the airspeedless mode, the throttle integrator term in TECS is discarded. This could reduce the throttle command, when switching into airspeedless mode.


### Solution
If in airspeedless mode, add the throttle integrator term to the throttle setpoint, if the integrator term is positive. This should avoid reducing airspeed when switching to airspeedless mode.

### Test coverage

