### PR TITLE
FW conditions for loitering for standard VTOLs

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1050,8 +1050,8 @@ FixedwingPositionControl::handle_setpoint_type(const position_setpoint_s &pos_sp
 			// POSITION: achieve position setpoint altitude via loiter
 			// close to waypoint, but altitude error greater than twice acceptance
 			if ((!_vehicle_status.in_transition_mode) && (dist >= 0.f)
-			    && (dist_z > _param_nav_fw_alt_rad.get())
-			    && (dist_xy < 2.f * math::max(acc_rad, loiter_radius_abs))) {
+			    && (dist_z > 2.f * _param_nav_fw_alt_rad.get())
+			    && (dist_xy < math::max(acc_rad, loiter_radius_abs))) {
 				// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER
 				position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 			}

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1059,7 +1059,7 @@ FixedwingPositionControl::handle_setpoint_type(const position_setpoint_s &pos_sp
 		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
 			// LOITER: use SETPOINT_TYPE_POSITION to get to SETPOINT_TYPE_LOITER (NPFG handles this internally)
 			if ((dist >= 0.f)
-			    && (dist_xy > 2.f * math::max(acc_rad, loiter_radius_abs))
+			    && (dist_xy > math::max(acc_rad, loiter_radius_abs))
 			    && !_param_fw_use_npfg.get()) {
 				// SETPOINT_TYPE_LOITER -> SETPOINT_TYPE_POSITION
 				position_sp_type = position_setpoint_s::SETPOINT_TYPE_POSITION;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
We found out that there was a problem with the loitering conditions of the drone in FW mode. Indeed, in the handle_setpoint_type function of the FixedWingPositionControl.cpp file, a part of the code is dedicated to check the position of the drone relative to the current waypoint and assess if it is possible to reach the target in FW mode. If not, the setpoint type is changed to LOITER and the drone climbs in spirals to the waypoint.
However, during our tests, we witnessed that the drone sometimes performed these transitions to LOITER mode even if the required climbs/descents were pretty slow.

### Solution
After looking at the code in detail, we found out that this switch into LOITER mode was supposed to happen when "close to waypoint, but altitude error greater than twice acceptance" (commentary in the code). However, in the code the conditions were inversed, that is not too close to the waypoint (inside two times the acceptance radius) and an altitude error greater that just one time the acceptance. We thus figured that there might be a mistake in the position of the multiplicator and moved it to correspond to the description.
As a result, we don't have the undesired LOITER phases anymore.

### Test coverage
This was tested in simulation but not on real drones (it shouldn't be a problem since the modification is pretty minor).
