### PR TITLE
ekf2: OF control logic fixes

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -236,6 +236,7 @@ struct flowSample {
 	Vector3f    gyro_xyz{};    ///< measured delta angle of the inertial frame about the body axes obtained from rate gyro measurements (rad), RH rotation is positive
 	float       dt{};          ///< amount of integration time (sec)
 	uint8_t     quality{};     ///< quality indicator between 0 and 255
+	float       ground_distance_m{NAN}; ///< optical range finder measurement (m) if available
 };
 
 struct extVisionSample {

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -236,7 +236,6 @@ struct flowSample {
 	Vector3f    gyro_xyz{};    ///< measured delta angle of the inertial frame about the body axes obtained from rate gyro measurements (rad), RH rotation is positive
 	float       dt{};          ///< amount of integration time (sec)
 	uint8_t     quality{};     ///< quality indicator between 0 and 255
-	float       ground_distance_m{NAN}; ///< optical range finder measurement (m) if available
 };
 
 struct extVisionSample {

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -200,6 +200,8 @@ void Ekf::resetVerticalPositionTo(const float new_vert_pos, float new_vert_pos_v
 	_gps_hgt_b_est.setBias(_gps_hgt_b_est.getBias() + delta_z);
 	_rng_hgt_b_est.setBias(_rng_hgt_b_est.getBias() + delta_z);
 
+	_terrain_vpos -= delta_z;
+
 	// Reset the timout timer
 	_time_last_hgt_fuse = _time_delayed_us;
 }

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -77,24 +77,12 @@ void Ekf::updateOptFlow(estimator_aid_source2d_s &aid_src)
 	const float R_LOS = calcOptFlowMeasVar(_flow_sample_delayed);
 	aid_src.observation_variance[0] = R_LOS;
 	aid_src.observation_variance[1] = R_LOS;
-
-
-	// compute innovation variance to update test ratios
-	const Vector24f state_vector = getStateAtFusionHorizonAsVector();
-	Vector2f innov_var;
-	Vector24f H;
-	sym::ComputeFlowXyInnovVarAndHx(state_vector, P, range, R_LOS, FLT_EPSILON, &innov_var, &H);
-	innov_var.copyTo(_aid_src_optical_flow.innovation_variance);
-
-	// run the innovation consistency check and record result
-	setEstimatorAidStatusTestRatio(_aid_src_optical_flow, math::max(_params.flow_innov_gate, 1.f));
-
-	_innov_check_fail_status.flags.reject_optflow_X = (_aid_src_optical_flow.test_ratio[0] > 1.f);
-	_innov_check_fail_status.flags.reject_optflow_Y = (_aid_src_optical_flow.test_ratio[1] > 1.f);
 }
 
 void Ekf::fuseOptFlow()
 {
+	_aid_src_optical_flow.fusion_enabled = true;
+
 	const float R_LOS = _aid_src_optical_flow.observation_variance[0];
 
 	// calculate the height above the ground of the optical flow camera. Since earth frame is NED

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -77,12 +77,24 @@ void Ekf::updateOptFlow(estimator_aid_source2d_s &aid_src)
 	const float R_LOS = calcOptFlowMeasVar(_flow_sample_delayed);
 	aid_src.observation_variance[0] = R_LOS;
 	aid_src.observation_variance[1] = R_LOS;
+
+
+	// compute innovation variance to update test ratios
+	const Vector24f state_vector = getStateAtFusionHorizonAsVector();
+	Vector2f innov_var;
+	Vector24f H;
+	sym::ComputeFlowXyInnovVarAndHx(state_vector, P, range, R_LOS, FLT_EPSILON, &innov_var, &H);
+	innov_var.copyTo(_aid_src_optical_flow.innovation_variance);
+
+	// run the innovation consistency check and record result
+	setEstimatorAidStatusTestRatio(_aid_src_optical_flow, math::max(_params.flow_innov_gate, 1.f));
+
+	_innov_check_fail_status.flags.reject_optflow_X = (_aid_src_optical_flow.test_ratio[0] > 1.f);
+	_innov_check_fail_status.flags.reject_optflow_Y = (_aid_src_optical_flow.test_ratio[1] > 1.f);
 }
 
 void Ekf::fuseOptFlow()
 {
-	_aid_src_optical_flow.fusion_enabled = true;
-
 	const float R_LOS = _aid_src_optical_flow.observation_variance[0];
 
 	// calculate the height above the ground of the optical flow camera. Since earth frame is NED
@@ -111,7 +123,7 @@ void Ekf::fuseOptFlow()
 	_innov_check_fail_status.flags.reject_optflow_Y = (_aid_src_optical_flow.test_ratio[1] > 1.f);
 
 	// if either axis fails we abort the fusion
-	if (_aid_src_optical_flow.innovation_rejected) {
+	if (_aid_src_optical_flow.innovation_rejected || !_aid_src_optical_flow.fusion_enabled) {
 		return;
 	}
 

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -170,6 +170,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 		    && !_control_status.flags.opt_flow // we are not yet using flow data
 		    && !inhibit_flow_use
 		    && !isRecent(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6)
+		    && isTerrainEstimateValid()
 		   ) {
 
 			// set the flag and reset the fusion timeout
@@ -215,7 +216,6 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 				// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
 				// but use a relaxed time criteria to enable it to coast through bad range finder data
 				if (isRecent(_time_last_hagl_fuse, (uint64_t)10e6)) {
-					updateOptFlow(_aid_src_optical_flow);
 					fuseOptFlow();
 					_last_known_pos.xy() = _state.pos.xy();
 				}

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -165,17 +165,26 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 			}
 		}
 
+		// Wait until the midpoint of the flow sample has fallen behind the fusion time horizon
+		const bool flow_delayed = (_time_delayed_us > (_flow_sample_delayed.time_us - uint32_t(1e6f * _flow_sample_delayed.dt) / 2));
+
+		// use a relaxed time criteria to enable it to coast through bad range finder data
+		const bool terrain_available = isTerrainEstimateValid() || isRecent(_time_last_hagl_fuse, (uint64_t)10e6);
+
 		// optical flow fusion mode selection logic
 		if ((_params.fusion_mode & SensorFusionMask::USE_OPT_FLOW) // optical flow has been selected by the user
 		    && !_control_status.flags.opt_flow // we are not yet using flow data
+		    && flow_delayed
 		    && !inhibit_flow_use
 		    && !isRecent(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6)
-		    && isTerrainEstimateValid()
+		    && terrain_available
 		   ) {
-
 			// set the flag and reset the fusion timeout
 			ECL_INFO("starting optical flow fusion");
 			updateOptFlow(_aid_src_optical_flow);
+
+			_innov_check_fail_status.flags.reject_optflow_X = false;
+			_innov_check_fail_status.flags.reject_optflow_Y = false;
 
 			// if we are not using GPS or external vision aiding, then the velocity and position states and covariances need to be set
 			if (!isHorizontalAidingActive()) {
@@ -194,59 +203,59 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 					ECL_INFO("reset position to last known (%.3f, %.3f)", (double)_last_known_pos(0), (double)_last_known_pos(1));
 					resetHorizontalPositionTo(_last_known_pos.xy(), 0.f);
 				}
+
+				_aid_src_optical_flow.fusion_enabled = true;
+				_aid_src_optical_flow.test_ratio[0] = 0.f;
+				_aid_src_optical_flow.test_ratio[1] = 0.f;
+				_aid_src_optical_flow.innovation_rejected = false;
+				_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
+
+				_control_status.flags.opt_flow = true;
+				return;
 			}
 
-			_aid_src_optical_flow.fusion_enabled = true;
-			_aid_src_optical_flow.test_ratio[0] = 0.f;
-			_aid_src_optical_flow.test_ratio[1] = 0.f;
-			_aid_src_optical_flow.innovation_rejected = false;
-			_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
-
-			_innov_check_fail_status.flags.reject_optflow_X = false;
-			_innov_check_fail_status.flags.reject_optflow_Y = false;
-
+			// otherwise enable opt_flow and continue to fusion
 			_control_status.flags.opt_flow = true;
-
-			return;
 		}
 
 		if (_control_status.flags.opt_flow) {
-			// Wait until the midpoint of the flow sample has fallen behind the fusion time horizon
-			if (_time_delayed_us > (_flow_sample_delayed.time_us - uint32_t(1e6f * _flow_sample_delayed.dt) / 2)) {
-				// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
-				// but use a relaxed time criteria to enable it to coast through bad range finder data
-				if (isRecent(_time_last_hagl_fuse, (uint64_t)10e6)) {
+
+			if (flow_delayed) {
+				if (terrain_available) {
+					// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
 					fuseOptFlow();
 					_last_known_pos.xy() = _state.pos.xy();
+
+					// handle the case when we have optical flow, are reliant on it, but have not been using it for an extended period
+					if (isTimedOut(_aid_src_optical_flow.time_last_fuse, _params.no_aid_timeout_max)
+					&& !isOtherSourceOfHorizontalAidingThan(_control_status.flags.opt_flow)
+					) {
+						ECL_INFO("reset velocity to flow");
+						_information_events.flags.reset_vel_to_flow = true;
+						resetHorizontalVelocityTo(_flow_vel_ne, calcOptFlowMeasVar(_flow_sample_delayed));
+
+						// reset position, estimate is relative to initial position in this mode, so we start with zero error
+						ECL_INFO("reset position to last known (%.3f, %.3f)", (double)_last_known_pos(0), (double)_last_known_pos(1));
+						_information_events.flags.reset_pos_to_last_known = true;
+						resetHorizontalPositionTo(_last_known_pos.xy(), 0.f);
+
+						_aid_src_optical_flow.fusion_enabled = true;
+						_aid_src_optical_flow.test_ratio[0] = 0.f;
+						_aid_src_optical_flow.test_ratio[1] = 0.f;
+						_aid_src_optical_flow.innovation_rejected = false;
+						_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
+					}
 				}
 
 				_flow_data_ready = false;
 			}
 
-			// handle the case when we have optical flow, are reliant on it, but have not been using it for an extended period
-			if (isTimedOut(_aid_src_optical_flow.time_last_fuse, _params.no_aid_timeout_max)
-			    && !isOtherSourceOfHorizontalAidingThan(_control_status.flags.opt_flow)
-			    && (_flow_sample_delayed.quality >= _params.flow_qual_min)
-			    && isTerrainEstimateValid()
-			   ) {
-
-				ECL_INFO("reset velocity to flow");
-				_information_events.flags.reset_vel_to_flow = true;
-				resetHorizontalVelocityTo(_flow_vel_ne, calcOptFlowMeasVar(_flow_sample_delayed));
-
-				// reset position, estimate is relative to initial position in this mode, so we start with zero error
-				ECL_INFO("reset position to last known (%.3f, %.3f)", (double)_last_known_pos(0), (double)_last_known_pos(1));
-				_information_events.flags.reset_pos_to_last_known = true;
-				resetHorizontalPositionTo(_last_known_pos.xy(), 0.f);
-
-				_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
+			if (!terrain_available || !isRecent(_aid_src_optical_flow.time_last_fuse, (uint64_t)5e6)) {
+				stopFlowFusion();
 			}
 		}
 
-	} else if (_control_status.flags.opt_flow
-		   && (!isRecent(_flow_sample_delayed.time_us, (uint64_t)10e6)
-		       || !isRecent(_aid_src_optical_flow.time_last_fuse, (uint64_t)10e6))
-		  ) {
+	} else if (_control_status.flags.opt_flow && !isRecent(_flow_sample_delayed.time_us, (uint64_t)10e6)) {
 
 		stopFlowFusion();
 	}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1971,8 +1971,7 @@ bool EKF2::UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps)
 			.flow_xy_rad = Vector2f{-optical_flow.pixel_flow[0], -optical_flow.pixel_flow[1]},
 			.gyro_xyz = Vector3f{-optical_flow.delta_angle[0], -optical_flow.delta_angle[1], -optical_flow.delta_angle[2]},
 			.dt = 1e-6f * (float)optical_flow.integration_timespan_us,
-			.quality = optical_flow.quality,
-			.ground_distance_m = optical_flow.distance_m,
+			.quality = optical_flow.quality
 		};
 
 		if (Vector2f(optical_flow.pixel_flow).isAllFinite() && flow.dt < 1) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1972,6 +1972,7 @@ bool EKF2::UpdateFlowSample(ekf2_timestamps_s &ekf2_timestamps)
 			.gyro_xyz = Vector3f{-optical_flow.delta_angle[0], -optical_flow.delta_angle[1], -optical_flow.delta_angle[2]},
 			.dt = 1e-6f * (float)optical_flow.integration_timespan_us,
 			.quality = optical_flow.quality,
+			.ground_distance_m = optical_flow.distance_m,
 		};
 
 		if (Vector2f(optical_flow.pixel_flow).isAllFinite() && flow.dt < 1) {

--- a/src/modules/ekf2/test/test_EKF_flow.cpp
+++ b/src/modules/ekf2/test/test_EKF_flow.cpp
@@ -168,6 +168,7 @@ TEST_F(EkfFlowTest, resetToFlowVelocityOnGround)
 	_sensor_simulator._flow.setData(flow_sample);
 	_ekf_wrapper.enableFlowFusion();
 	_sensor_simulator.startFlow();
+	_sensor_simulator.startRangeFinder();
 	_sensor_simulator.runSeconds(1.0);
 
 	// THEN: estimated velocity should match simulated velocity

--- a/src/modules/ekf2/test/test_EKF_flow.cpp
+++ b/src/modules/ekf2/test/test_EKF_flow.cpp
@@ -140,6 +140,8 @@ TEST_F(EkfFlowTest, resetToFlowVelocityInAir)
 
 	// THEN: estimated velocity should match simulated velocity
 	const Vector3f estimated_velocity = _ekf->getVelocity();
+	estimated_velocity.print();
+	simulated_velocity.print();
 	EXPECT_TRUE(isEqual(estimated_velocity, simulated_velocity))
 			<< "estimated vel = " << estimated_velocity(0) << ", "
 			<< estimated_velocity(1);

--- a/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
+++ b/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
@@ -183,7 +183,7 @@ TEST_F(EkfFusionLogicTest, fallbackFromGpsToFlow)
 	const float max_ground_distance = 50.f;
 	_ekf->set_optical_flow_limits(max_flow_rate, min_ground_distance, max_ground_distance);
 	_sensor_simulator.startFlow();
-	_sensor_simulator.startFlow();
+	_sensor_simulator.startRangeFinder();
 	_ekf_wrapper.enableFlowFusion();
 
 	_ekf->set_in_air_status(true);

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -156,6 +156,7 @@ TEST_F(EkfGpsTest, gpsHgtToBaroFallback)
 	_sensor_simulator._flow.setData(_sensor_simulator._flow.dataAtRest());
 	_ekf_wrapper.enableFlowFusion();
 	_sensor_simulator.startFlow();
+	_sensor_simulator.startRangeFinder();
 
 	_ekf_wrapper.enableGpsHeightFusion();
 


### PR DESCRIPTION
 - always compute innovation variance and test ratios (updateOptFlow())
 - if horizontal aiding active require good test ratio before starting OF
 - strict on ground (not flying) optical flow fusion workaround to when vehicle is also at rest (much more conservative)
 - add additional OF reset terrain validity and OF quality check
