### PR TITLE
RTL fixes and improvements for VTOL vehicles

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -613,13 +613,7 @@ void RTL::advance_rtl()
 		break;
 
 	case RTL_STATE_RETURN:
-		if (vtol_in_fw_mode || descend_and_loiter) {
-			_rtl_state = RTL_STATE_DESCEND;
-
-		} else {
-			_rtl_state = RTL_STATE_LAND;
-		}
-
+		_rtl_state = RTL_STATE_DESCEND;
 		break;
 
 	case RTL_STATE_DESCEND:

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -639,7 +639,7 @@ void RTL::advance_rtl()
 	case RTL_STATE_LOITER:
 
 		if (vtol_in_fw_mode) {
-			_rtl_state = RTL_STATE_TRANSITION_TO_MC;
+			_rtl_state = RTL_STATE_HEAD_TO_CENTER;
 
 		} else {
 			_rtl_state = RTL_STATE_LAND;

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -501,6 +501,9 @@ void RTL::set_rtl_item()
 				_mission_item.yaw = _navigator->get_local_position()->heading;
 			}
 
+			_mission_item.vtol_back_transition = true;
+			// acceptance_radius will be overwritten since vtol_back_transition is set,
+			// set as a default value only
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -645,7 +645,6 @@ void RTL::advance_rtl()
 			_rtl_state = RTL_STATE_LAND;
 		}
 
-		_rtl_state = RTL_STATE_LAND;
 		break;
 
 	case RTL_STATE_HEAD_TO_CENTER:


### PR DESCRIPTION
**Update 2023-02-01**
This PR does not longer include the original MC descend alterations in RTL, but instead just fixes the addtional issues found int the process. This PR now:
- Fixes VTOL FW landing bug
- RTL_STATE_HEAD_TO_CENTER is not longer dependent on whether loiter is used or not.
- MC will use descend state, independent of whether loiter is used or not.
- Fix acceptance radius for mission item prior to VTOL transition by setting _mission_item.vtol_back_transition

**Describe problem solved by this pull request**
The main problem I set out to solve was that a VTOL RTL is too slow/consumes to much battery when landing at rally points with altitude different than home altitude. This is because MPC_LAND_ALT1/MPC_LAND_ALT2 do not consider rally point altitude, and it is therefor not possible to tune the land and descend speeds so that you get both a soft landing and a fast descent until you are close to the ground. For VTOLs we can not use RTL_DESCEND_ALT for this wither, since it must be set high enough for a safe FW loiter, which can be too high to do a slow MC descend from.

During this process, I found other issues with RTL that I have addressed as well:
  - If RTL_LAND_DELAY > 0, VTOLs will do a FW landing, this bug was introduces in https://github.com/PX4/PX4-Autopilot/pull/16582
  - RTL_STATE_HEAD_TO_CENTER is dependent on whether to loiter or not. It would be desired to have same functionality for  VTOL transition/movement no matter if loiter is used or not.
  - MC and VTOL in MC will skip descend state if there is no loiter. I under stand the rationale that in most cases the behavior will be almost the same if MPC_LAND_ALT1/MPC_LAND_ALT2 is set correctly, but as described above this is not possible for rally points with altitude different than home.
  - Acceptance radius for VTOL landing in RTL is different than normal VTOL landing, since state prior to VTOL transition do not set _mission_item.vtol_back_transition. This can cause some overshoot and possible unnecessarily aggressive maneuvering.

**Describe your solution**
The main issue is fixed by introducing a new parameter RTL_DESCEND_MC and a new RTL state RTL_STATE_MC_DESCEND. RTL_DESCEND_MC gives an altitude for a MC (or VTOL in MC) to descend to (at speed MPC_Z_V_AUTO_DN) before starting the landing (at a slower speed). For VTOL in FW, this state will be entered after first descending to RTL_DESCEND_ALT and loiter and transition to MC. For MC and VTOL in MC, this state will be entered after return. That means that RTL_DESCEND_ALT and RTL_LAND_DELAY will not be used at all for MC.

**Describe possible alternatives**
MPC_LAND_ALT1/MPC_LAND_ALT2 could be fixed to account for rally point altitude, which may solve some, but not all RTL VTOL issues.

**Test data / coverage**
Tested in simulator with standard VTOL.
Could use some help to test pure MC and FW behavior.

**Additional context**
RTL time prediction is not changed. The prediction seems to be fairly rough for VTOL anyway, so I consider it safe to ignore the these changes and they will not make the RTL time worse.