### PR TITLE
FWPositionController: remove factor of 2 for switching to LOITER to achieve altitude setpoint

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1030,11 +1030,14 @@ FixedwingPositionControl::handle_setpoint_type(const position_setpoint_s &pos_sp
 		}
 
 		if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
-			// POSITION: achieve position setpoint altitude via loiter
-			// close to waypoint, but altitude error greater than twice acceptance
+			// Achieve position setpoint altitude via loiter when laterally close to WP.
+			// Detect if system has switchted into a Loiter before (check _position_sp_type), and in that
+			// case remove the dist_xy check (not switch out of Loiter until altitude is reached).
 			if ((!_vehicle_status.in_transition_mode) && (dist >= 0.f)
 			    && (dist_z > _param_nav_fw_alt_rad.get())
-			    && (dist_xy < 2.f * math::max(acc_rad, loiter_radius_abs))) {
+			    && (dist_xy < math::max(acc_rad, loiter_radius_abs)
+				|| _position_sp_type == position_setpoint_s::SETPOINT_TYPE_LOITER)) {
+
 				// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER
 				position_sp_type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 			}


### PR DESCRIPTION

### Solved Problem
Sudden altitude increase due to vehicle switching out of first-order-hold (FOH) climb. 
Eg reported here: 
https://discord.com/channels/1022170275984457759/1064965130472927294/1065009827228700733
![image](https://user-images.githubusercontent.com/26798987/214896796-5efcbd10-7a40-49c5-8915-e9cdf2e964c0.png)

### Solution
Remove factor of 2.0 to determine distance to a POSITION WP where FOH is deactivated and the vehicle achieves altitude through LOITER mode. Instead check if the switch from POSITION to LOITER has already happened, and in that case never again switch out of LOITER until altitude is reached (at which point Navigator anyway accepts the WP). 

### Alternatives
Keep some factor, but maybe reduce it. Here is how it could look (with the SITL standard VTOL), for factors of 1, 1,2  and 1.5:

![image](https://user-images.githubusercontent.com/26798987/214894683-61fd000f-1d52-4b41-86e6-263a82db3231.png)
![image](https://user-images.githubusercontent.com/26798987/214895279-f0a862c6-ab8b-43b1-9118-839e07ca3a43.png)
![image](https://user-images.githubusercontent.com/26798987/214895877-d21fd999-9169-466f-ae08-9163e8224fc8.png)

The 1.5 factor has the nicest looking outcome, but with the downside of increasing the chance to of switching out of the first-order-hold behavior even though it could actually have made it . 

### Test coverage
SITL tested.

### Context
Original PR that added the 2.0 factor: https://github.com/PX4/PX4-Autopilot/pull/5085
