### PR TITLE
drivers/dshot: allow min throttle 0

### DIFF
--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -55,7 +55,7 @@ static constexpr unsigned int DSHOT600  =  600000u;
 static constexpr unsigned int DSHOT1200 = 1200000u;
 
 static constexpr int DSHOT_DISARM_VALUE = 0;
-static constexpr int DSHOT_MIN_THROTTLE = 1;
+static constexpr int DSHOT_MIN_THROTTLE = 0;
 static constexpr int DSHOT_MAX_THROTTLE = 1999;
 
 class DShot final : public ModuleBase<DShot>, public OutputModuleInterface


### PR DESCRIPTION
Typically not what you want for a multicopter, but it should still be legal to go all the way to 0.