### PR TITLE
Commander: UX improvements on max wind and max flight time RTL

### DIFF
--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -15,6 +15,7 @@ uint32 mode_req_global_position
 uint32 mode_req_mission
 uint32 mode_req_offboard_signal
 uint32 mode_req_home_position
+uint32 mode_req_wind_and_flight_time_compliance # if set, mode cannot be entered if wind or flight time limit exceeded
 uint32 mode_req_prevent_arming    # if set, cannot arm while in this mode
 uint32 mode_req_other             # other requirements, not covered above (for external modes)
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1766,6 +1766,7 @@ void Commander::run()
 			_last_disarmed_timestamp = hrt_absolute_time();
 
 			_user_mode_intention.onDisarm();
+			_vehicle_status.takeoff_time = 0;
 		}
 
 		if (!_arm_state_machine.isArmed()) {
@@ -1971,7 +1972,6 @@ void Commander::landDetectorUpdate()
 			if (!was_landed && _vehicle_land_detected.landed) {
 				mavlink_log_info(&_mavlink_log_pub, "Landing detected\t");
 				events::send(events::ID("commander_landing_detected"), events::Log::Info, "Landing detected");
-				_vehicle_status.takeoff_time = 0;
 
 			} else if (was_landed && !_vehicle_land_detected.landed) {
 				mavlink_log_info(&_mavlink_log_pub, "Takeoff detected\t");

--- a/src/modules/commander/HealthAndArmingChecks/checks/flightTimeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/flightTimeCheck.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,5 +54,62 @@ void FlightTimeChecks::checkAndReport(const Context &context, Report &reporter)
 
 	} else {
 		reporter.failsafeFlags().flight_time_limit_exceeded = false;
+	}
+
+	// report warning when approaching max flight time
+	if (!reporter.failsafeFlags().flight_time_limit_exceeded
+	    && context.status().takeoff_time != 0
+	    && _param_com_flt_time_max.get() > 0) {
+
+		const float remaining_flight_time_sec = (context.status().takeoff_time < hrt_absolute_time()) ?
+							_param_com_flt_time_max.get() - 1.e-6f * (hrt_absolute_time() - context.status().takeoff_time) :
+							_param_com_flt_time_max.get();
+
+		if (remaining_flight_time_sec < 0.1f * _param_com_flt_time_max.get()) {
+			// send warnings every minute until RTL
+
+			const int floored_remaining_flight_time_sec = int(remaining_flight_time_sec);
+
+			if (floored_remaining_flight_time_sec <= 60 && _last_flight_time_warning_sec == -1) {
+				// less than or equal to a minute remaining on first pass
+
+				if (reporter.mavlink_log_pub()) {
+					mavlink_log_warning(reporter.mavlink_log_pub(), "Approaching max flight time (system will RTL in %i seconds)\t",
+							    floored_remaining_flight_time_sec);
+				}
+
+				/* EVENT
+				* @description
+				* Maximal flight time warning (less than 1min remaining)
+				*/
+				events::send<int16_t>(events::ID("commander_max_flight_time_warning_seconds"), events::Log::Warning,
+						      "Approaching max flight time (system will RTL in {1} seconds)", floored_remaining_flight_time_sec);
+
+			} else if ((floored_remaining_flight_time_sec % 60) == 0 && floored_remaining_flight_time_sec >= 60
+				   && floored_remaining_flight_time_sec != _last_flight_time_warning_sec) {
+
+				const int floored_remaining_flight_time_min = (int)(remaining_flight_time_sec * 0.016666667f);
+
+				if (reporter.mavlink_log_pub()) {
+					mavlink_log_warning(reporter.mavlink_log_pub(), "Approaching max flight time (system will RTL in %i minutes)\t",
+							    floored_remaining_flight_time_min);
+				}
+
+				/* EVENT
+				* @description
+				* Maximal flight time warning (more than 1min remaining)
+				*/
+				events::send<int16_t>(events::ID("commander_max_flight_time_warning_minutes"), events::Log::Warning,
+						      "Approaching max flight time (system will RTL in {1} minutes)", floored_remaining_flight_time_min);
+			}
+
+			_last_flight_time_warning_sec = floored_remaining_flight_time_sec;
+
+		} else {
+			_last_flight_time_warning_sec = -1; //reset if not in last 10%
+		}
+
+	} else {
+		_last_flight_time_warning_sec = -1; //reset if not enabled, landed or currently already exceeded
 	}
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/flightTimeCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/flightTimeCheck.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,8 @@ public:
 	void checkAndReport(const Context &context, Report &reporter) override;
 
 private:
+	int _last_flight_time_warning_sec{-1};
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::COM_FLT_TIME_MAX>) _param_com_flt_time_max
 				       )

--- a/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/modeCheck.cpp
@@ -147,6 +147,12 @@ void ModeChecks::checkAndReport(const Context &context, Report &reporter)
 		// Here we expect there is already an event reported for the failing check (this is for external modes)
 		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_other);
 	}
+
+	if ((reporter.failsafeFlags().flight_time_limit_exceeded || reporter.failsafeFlags().wind_limit_exceeded)
+	    && reporter.failsafeFlags().mode_req_wind_and_flight_time_compliance != 0) {
+		// Already reported
+		reporter.clearCanRunBits((NavModes)reporter.failsafeFlags().mode_req_wind_and_flight_time_compliance);
+	}
 }
 
 void ModeChecks::checkArmingRequirement(const Context &context, Report &reporter)

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -54,6 +54,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	flags.mode_req_mission = 0;
 	flags.mode_req_offboard_signal = 0;
 	flags.mode_req_home_position = 0;
+	flags.mode_req_wind_and_flight_time_compliance = 0;
 	flags.mode_req_prevent_arming = 0;
 	flags.mode_req_other = 0;
 
@@ -82,6 +83,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_global_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_local_alt);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_mission);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_wind_and_flight_time_compliance);
 
 	// NAVIGATION_STATE_AUTO_LOITER
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_angular_velocity);
@@ -89,6 +91,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_global_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_local_alt);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER, flags.mode_req_wind_and_flight_time_compliance);
 
 	// NAVIGATION_STATE_AUTO_RTL
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_RTL, flags.mode_req_angular_velocity);
@@ -139,6 +142,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET, flags.mode_req_local_alt);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET, flags.mode_req_prevent_arming);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET, flags.mode_req_wind_and_flight_time_compliance);
 
 	// NAVIGATION_STATE_AUTO_PRECLAND
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND, flags.mode_req_angular_velocity);
@@ -153,6 +157,7 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ORBIT, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ORBIT, flags.mode_req_local_alt);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_ORBIT, flags.mode_req_prevent_arming);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_ORBIT, flags.mode_req_wind_and_flight_time_compliance);
 
 	// NAVIGATION_STATE_AUTO_VTOL_TAKEOFF
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_angular_velocity);

--- a/src/modules/commander/UserModeIntention.cpp
+++ b/src/modules/commander/UserModeIntention.cpp
@@ -43,11 +43,6 @@ UserModeIntention::UserModeIntention(ModuleParams *parent, const vehicle_status_
 bool UserModeIntention::change(uint8_t user_intended_nav_state, bool allow_fallback, bool force)
 {
 	_ever_had_mode_change = true;
-	_had_mode_change = true;
-
-	if (_user_intented_nav_state == user_intended_nav_state) {
-		return true;
-	}
 
 	// Always allow mode change while disarmed
 	bool always_allow = force || !isArmed();
@@ -67,6 +62,7 @@ bool UserModeIntention::change(uint8_t user_intended_nav_state, bool allow_fallb
 	}
 
 	if (allow_change) {
+		_had_mode_change = true;
 		_user_intented_nav_state = user_intended_nav_state;
 
 		if (!_health_and_arming_checks.modePreventsArming(user_intended_nav_state)) {

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1025,12 +1025,11 @@ PARAM_DEFINE_FLOAT(COM_SPOOLUP_TIME, 1.0f);
  * Wind speed warning threshold
  *
  * A warning is triggered if the currently estimated wind speed is above this value.
- * Warning is sent periodically (every 1min).
+ * Warning is sent periodically (every 1 minute).
  *
- * A negative value disables the feature.
+ * Set to -1 to disable.
  *
  * @min -1
- * @max 30
  * @decimal 1
  * @increment 0.1
  * @group Commander
@@ -1043,29 +1042,31 @@ PARAM_DEFINE_FLOAT(COM_WIND_WARN, -1.f);
  *
  * The vehicle aborts the current operation and returns to launch when
  * the time since takeoff is above this value. It is not possible to resume the
- * mission or switch to any mode other than RTL or Land.
+ * mission or switch to any auto mode other than RTL or Land. Taking over in any manual
+ * mode is still possible.
  *
- * Set a negative value to disable.
+ * Starting from 90% of the maximum flight time, a warning message will be sent
+ * every 1 minute with the remaining time until automatic RTL.
  *
+ * Set to -1 to disable.
  *
  * @unit s
  * @min -1
- * @max 10000
- * @value 0 Disable
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, -1);
 
 /**
- * Wind speed RLT threshold
+ * Wind speed RTL threshold
  *
- * Wind speed threshold above which an automatic return to launch is triggered
- * and enforced as long as the threshold is exceeded.
+ * Wind speed threshold above which an automatic return to launch is triggered.
+ * It is not possible to resume the mission or switch to any auto mode other than
+ * RTL or Land if this threshold is exceeded. Taking over in any manual
+ * mode is still possible.
  *
- * A negative value disables the feature.
+ * Set to -1 to disable.
  *
  * @min -1
- * @max 30
  * @decimal 1
  * @increment 0.1
  * @group Commander

--- a/src/modules/commander/failsafe/emscripten_template.html
+++ b/src/modules/commander/failsafe/emscripten_template.html
@@ -32,7 +32,10 @@
       }
       .checkbox-field {
           display: flex;
+          align-items: center;
           flex-direction: row;
+          margin-bottom: 8px;
+          line-height: 100%;
       }
       .box {
           background-color: rgb(231, 233, 235);

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -393,8 +393,7 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 
 	CHECK_FAILSAFE(status_flags, wind_limit_exceeded,
 		       ActionOptions(Action::RTL).clearOn(ClearCondition::OnModeChangeOrDisarm));
-	CHECK_FAILSAFE(status_flags, flight_time_limit_exceeded,
-		       ActionOptions(Action::RTL).allowUserTakeover(UserTakeoverAllowed::Never));
+	CHECK_FAILSAFE(status_flags, flight_time_limit_exceeded, ActionOptions(Action::RTL));
 
 	CHECK_FAILSAFE(status_flags, primary_geofence_breached, fromGfActParam(_param_gf_action.get()));
 

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -614,6 +614,7 @@ uint8_t FailsafeBase::modeFromAction(const Action &action, uint8_t user_intended
 bool FailsafeBase::modeCanRun(const failsafe_flags_s &status_flags, uint8_t mode)
 {
 	uint32_t mode_mask = 1u << mode;
+	// mode_req_wind_and_flight_time_compliance: does not need to be handled here (these are separate failsafe triggers)
 	return
 		(!status_flags.angular_velocity_invalid || ((status_flags.mode_req_angular_velocity & mode_mask) == 0)) &&
 		(!status_flags.attitude_invalid || ((status_flags.mode_req_attitude & mode_mask) == 0)) &&


### PR DESCRIPTION
This is a follow up to https://github.com/PX4/PX4-Autopilot/pull/19578, where the max wind speed and flight time exceeded RTLs were introduced. 

What changed:
- improve parameter description
- add warning when approaching max flight time (every 1 min starting from 90% of the max flight time, or then if <60s)
- allow switching out of high wind or flight time exceeded RTL, but only into a manual mode. Do this by adding an extra requirement to Mission, Loiter, FollowMe and Orbit (`mode_req_wind_and_flight_time_compliance`).

It also incorporates a couple of Commander fixes by @bkueng that enable these extended checks.
