### PR TITLE
Acquire gimbal control in case of gimbal v2 protocol 

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -589,8 +589,8 @@ MissionBlock::issue_command(const mission_item_s &item)
 
 	} else {
 
-		// This is to support legacy DO_MOUNT_CONTROL as part of a mission.
-		if (item.nav_cmd == NAV_CMD_DO_MOUNT_CONTROL) {
+		// This is to support legacy DO_MOUNT_CONTROL and mavlink gimbal protocol v2 DO_GIMBAL_MANAGER_PITCHYAW as part of a mission.
+		if (item.nav_cmd == NAV_CMD_DO_MOUNT_CONTROL || item.nav_cmd == NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW) {
 			_navigator->acquire_gimbal_control();
 		}
 


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When gimbal commands are added in the mission, PX4 needs to acquire the control of the gimbal and forward the command to the gimbal manager. This is happening only for the mavlink gimbal v1 protocol. This PRs extends the logic to work also with mavlink gimbal v2 protocol

### Solution
- Add ... for ...
- Refactor ...

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
