### PR TITLE
vscode: change cubeorange build target

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -180,7 +180,7 @@ CONFIG:
       short: cubepilot_cubeorange
       buildType: MinSizeRel
       settings:
-        CONFIG: cubepilot_orange_test
+        CONFIG: cubepilot_cubeorange_test
     emlid_navio2_default:
       short: emlid_navio2
       buildType: MinSizeRel


### PR DESCRIPTION
- Fixes typo in Cube Orange build target config

Fixes #17745