### PR TITLE
ci: build and deploy kakuteh7v2 & Kakuteh7mini

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -62,6 +62,8 @@ pipeline {
                      "holybro_durandal-v1_default",
                      "holybro_kakutef7_default",
                      "holybro_kakuteh7_default",
+                     "holybro_kakuteh7v2_default",
+                     "holybro_kakuteh7mini_default",
                      "holybro_pix32v5_default",
                      "matek_gnss-m9n-f4_canbootloader",
                      "matek_gnss-m9n-f4_default",


### PR DESCRIPTION
Adds Holybro kakuteh7v2 & Kakuteh7mini to Travis CI for building and deployment to S3 for QGC

Both Board ID was added in QGC here: https://github.com/mavlink/qgroundcontrol/pull/10554