### PR TITLE
setup/ubuntu.sh modified to correctly install all required dependencies

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -217,6 +217,17 @@ if [[ $INSTALL_SIM == "true" ]]; then
 	# Set Java 11 as default
 	sudo update-alternatives --set java $(update-alternatives --list java | grep "java-$java_version")
 
+	# Install Gazebo
+	if [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
+		sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+		wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+		# Update list, since new gazebo-stable.list has been added
+		sudo apt-get update -y --quiet
+		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
+			ignition-fortress \
+			;
+	fi
+
 	# Install Gazebo classic
 	if [[ "${UBUNTU_RELEASE}" == "18.04" ]]; then
 		gazebo_version=9
@@ -255,16 +266,6 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		echo "export SVGA_VGPU10=0" >> ~/.profile
 	fi
 
-	# Install Gazebo
-	if [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
-		sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-		wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-		# Update list, since new gazebo-stable.list has been added
-		sudo apt-get update -y --quiet
-		sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
-			ignition-fortress \
-			;
-	fi
 fi
 
 if [[ $INSTALL_NUTTX == "true" ]]; then


### PR DESCRIPTION
Before this commit, just running Tools/setup/ubuntu.sh on Ubuntu 22.04 resulted in a system where px4_sitl won't build correctly because some ignition libraries were in too old version. An additional system upgrade was needed to solve the issue. 

The proposed fix moves the addition of the OSRF gazebo repository before installing gazebo, which results in the newer version of the libraries from the OSRF  being installed together with gazebo, and therefore no upgrade is needed after running the script.

More details are in the issue following issue, which this PR fixes https://github.com/PX4/PX4-Autopilot/issues/20923
