### PR TITLE
gazebo-classic_iris_vision: fix airframe include and default parameters

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1013_gazebo-classic_iris_vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1013_gazebo-classic_iris_vision
@@ -5,12 +5,12 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d-posix/airframes/10016_iris
+. ${R}etc/init.d-posix/airframes/10016_gazebo-classic_iris
 
-# EKF2: Vision position and heading
-param set-default EKF2_AID_MASK 24
+# EKF2: Vision position and heading, no GPS
 param set-default EKF2_EV_DELAY 5
 param set-default EKF2_EV_CTRL 15
+param set-default EKF2_HGT_REF 3
 param set-default EKF2_GPS_CTRL 0
 
 # LPE: Vision + baro


### PR DESCRIPTION
### Solved Problem

- `ROMFS/px4fmu_common/init.d-posix/airframes/1013_gazebo-classic_iris_vision` was wrongly loading the base iris model.
- The GPS is the default source for altitude estimation (`EKF2_HGT_REF=1`) therefore `EKF2_GPS_CTRL` was never set to 0 but remained 7.

### Solution
- Fix the base iris airframe name.
- Set `EKF2_HGT_REF=3` as default values in order to use vision for altitude estimation. `EKF2_GPS_CTRL`  is now correctly set to 0.