### PR TITLE
ROMFS: tailsitter SITL and SIH: fix motor allocation geometry

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -49,7 +49,7 @@ param set-default CA_AIRFRAME 4
 
 param set-default CA_ROTOR_COUNT 2
 param set-default CA_ROTOR0_PX 0
-param set-default CA_ROTOR0_PY 2
+param set-default CA_ROTOR0_PY 1
 param set-default CA_ROTOR0_KM 0.05
 param set-default CA_ROTOR1_PX 0
 param set-default CA_ROTOR1_PY -1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -13,7 +13,7 @@ param set-default CA_AIRFRAME 4
 
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_ROTOR0_PX 1
-param set-default CA_ROTOR0_PY 2
+param set-default CA_ROTOR0_PY 1
 param set-default CA_ROTOR0_KM 0.05
 param set-default CA_ROTOR1_PX -1
 param set-default CA_ROTOR1_PY -1


### PR DESCRIPTION
The CA params for the geometry are wrong (frames are symmetric). 

Used to be part of https://github.com/PX4/PX4-Autopilot/pull/20558, but better keep unrelated stuff separated.

Tested the SITL, flies alright. 