### PR TITLE
Global: Append units to time values

### DIFF
--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -45,6 +45,8 @@
 
 #include <pthread.h>
 
+using namespace time_literals;
+
 static List<I2CSPIInstance *> i2c_spi_module_instances; ///< list of currently running instances
 static pthread_mutex_t i2c_spi_module_instances_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -820,7 +822,7 @@ void I2CSPIDriverBase::request_stop_and_wait()
 	unsigned int i = 0;
 
 	do {
-		px4_usleep(20000); // 20 ms
+		px4_usleep(20_ms); // 20 ms
 		// wait at most 2 sec
 	} while (++i < 100 && !_task_exited.load());
 

--- a/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -418,7 +418,7 @@ WorkQueueManagerStop()
 
 			// wait until they're all stopped (empty list)
 			while (_wq_manager_wqs_list->size() > 0) {
-				px4_usleep(1000);
+				px4_usleep(1_ms);
 			}
 
 			delete _wq_manager_wqs_list;
@@ -430,7 +430,7 @@ WorkQueueManagerStop()
 			// push nullptr to wake the wq manager task
 			_wq_manager_create_queue->push(nullptr);
 
-			px4_usleep(10000);
+			px4_usleep(10_ms);
 
 			delete _wq_manager_create_queue;
 		}

--- a/platforms/common/px4_work_queue/test/wqueue_test.cpp
+++ b/platforms/common/px4_work_queue/test/wqueue_test.cpp
@@ -70,7 +70,7 @@ int WQueueTest::main()
 
 	// Wait for work to finsh
 	while (!appState.exitRequested()) {
-		px4_usleep(5000);
+		px4_usleep(5_ms);
 	}
 
 	PX4_INFO("WQueueTest finished");

--- a/platforms/common/px4_work_queue/test/wqueue_test.h
+++ b/platforms/common/px4_work_queue/test/wqueue_test.h
@@ -37,6 +37,8 @@
 #include <px4_platform_common/px4_work_queue/WorkItem.hpp>
 #include <string.h>
 
+using namespace time_literals;
+
 using namespace px4;
 
 class WQueueTest : public px4::WorkItem

--- a/platforms/common/uORB/uORBDeviceMaster.cpp
+++ b/platforms/common/uORB/uORBDeviceMaster.cpp
@@ -45,6 +45,8 @@
 #include <poll.h>
 #endif // PX4_QURT
 
+using namespace time_literals;
+
 uORB::DeviceMaster::DeviceMaster()
 {
 	px4_sem_init(&_lock, 0, 1);
@@ -346,11 +348,11 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 					}
 				}
 
-				px4_usleep(200000);
+				px4_usleep(200_ms);
 			}
 
 		} else {
-			px4_usleep(2000000); // 2 seconds
+			px4_usleep(2_s); // 2 seconds
 		}
 
 #endif

--- a/platforms/nuttx/src/px4/common/px4_mtd.cpp
+++ b/platforms/nuttx/src/px4/common/px4_mtd.cpp
@@ -58,6 +58,8 @@
 #include <nuttx/spi/spi.h>
 #include <nuttx/mtd/mtd.h>
 
+using namespace time_literals;
+
 extern "C" {
 	struct mtd_dev_s *ramtron_initialize(FAR struct spi_dev_s *dev);
 	struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
@@ -109,7 +111,7 @@ static int ramtron_attach(mtd_instance_s &instance)
 
 		// try reducing speed for next attempt
 		spi_speed_mhz--;
-		px4_usleep(10000);
+		px4_usleep(10_ms);
 	}
 
 	/* if last attempt is still unsuccessful, abort */

--- a/src/drivers/actuators/modal_io/modal_io.cpp
+++ b/src/drivers/actuators/modal_io/modal_io.cpp
@@ -488,7 +488,7 @@ int ModalIo::send_cmd_thread_safe(Command *cmd)
 
 	/* wait until main thread processed it */
 	while (_pending_cmd.load()) {
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 	}
 
 	return 0;
@@ -1311,13 +1311,13 @@ void ModalIo::Run()
 								int bootloader_baud_rate = 230400;
 
 								if (_uart_port->uart_get_baud() != bootloader_baud_rate) {
-									px4_usleep(5000);
+									px4_usleep(5_ms);
 									_uart_port->uart_set_baud(bootloader_baud_rate);
 								}
 
 							} else {
 								if (_uart_port->uart_get_baud() != _parameters.baud_rate) {
-									px4_usleep(5000);
+									px4_usleep(5_ms);
 									_uart_port->uart_set_baud(_parameters.baud_rate);  //restore normal baud rate
 								}
 							}
@@ -1331,7 +1331,7 @@ void ModalIo::Run()
 					_uart_port_bridge->uart_write(uart_buf, bytes_read);
 				}
 
-				px4_usleep(10000);
+				px4_usleep(10_ms);
 			}
 		}
 

--- a/src/drivers/adc/board_adc/ADC.cpp
+++ b/src/drivers/adc/board_adc/ADC.cpp
@@ -308,7 +308,7 @@ int ADC::test()
 	uORB::Subscription	adc_sub_test{ORB_ID(adc_report)};
 	adc_report_s adc;
 
-	px4_usleep(20000);	// sleep 20ms and wait for adc report
+	px4_usleep(20_ms);	// sleep 20ms and wait for adc report
 
 	if (adc_sub_test.update(&adc)) {
 		PX4_INFO_RAW("DeviceID: %" PRId32 "\n", adc.device_id);
@@ -323,7 +323,7 @@ int ADC::test()
 			}
 
 			PX4_INFO_RAW("\n");
-			px4_usleep(500000);
+			px4_usleep(500_ms);
 
 			if (!adc_sub_test.update(&adc)) {
 				PX4_INFO_RAW("\t ADC test failed.\n");

--- a/src/drivers/barometer/ms5611/ms5611_i2c.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_i2c.cpp
@@ -39,6 +39,8 @@
 
 #include <drivers/device/i2c.h>
 
+using namespace time_literals;
+
 #if defined(CONFIG_I2C)
 
 #include "ms5611.h"
@@ -208,7 +210,7 @@ MS5611_I2C::_read_prom()
 	 * Wait for PROM contents to be in the device (2.8 ms) in the case we are
 	 * called immediately after reset.
 	 */
-	px4_usleep(3000);
+	px4_usleep(3_ms);
 
 	uint8_t last_val = 0;
 	bool bits_stuck = true;

--- a/src/drivers/barometer/ms5611/ms5611_spi.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_spi.cpp
@@ -40,6 +40,8 @@
 #include <drivers/device/spi.h>
 #include "ms5611.h"
 
+using namespace time_literals;
+
 /* SPI protocol address bits */
 #define DIR_READ			(1<<7)
 #define DIR_WRITE			(0<<7)
@@ -218,7 +220,7 @@ MS5611_SPI::_read_prom()
 	 * Wait for PROM contents to be in the device (2.8 ms) in the case we are
 	 * called immediately after reset.
 	 */
-	px4_usleep(3000);
+	px4_usleep(3_ms);
 
 	/* read and convert PROM words */
 	bool all_zero = true;

--- a/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
+++ b/src/drivers/differential_pressure/ms4525do/MS4525DO.cpp
@@ -79,7 +79,7 @@ int MS4525DO::probe()
 			}
 
 		} else {
-			px4_usleep(1000); // TODO
+			px4_usleep(1_ms);
 		}
 	}
 

--- a/src/drivers/distance_sensor/leddar_one/LeddarOne.cpp
+++ b/src/drivers/distance_sensor/leddar_one/LeddarOne.cpp
@@ -173,7 +173,7 @@ LeddarOne::init()
 			}
 		}
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 		time_now = hrt_absolute_time();
 	}
 

--- a/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/lightware_laser_i2c.cpp
@@ -275,7 +275,7 @@ int LightwareLaser::enableI2CBinaryProtocol()
 		}
 
 		// Occasionally the previous transfer returns ret == value[0] == value[1] == 0. If so, wait a bit and retry
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 	}
 
 	return -1;

--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -120,13 +120,13 @@ int PGA460::initialize_device_settings()
 		return PX4_ERROR;
 	}
 
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	// Read to see if eeprom saved data matches desired data, otherwise overwrite eeprom.
 	if (read_eeprom() != PX4_OK) {
 		write_eeprom();
 		// Allow sufficient time for the device to complete writing to registers.
-		px4_usleep(10000);
+		px4_usleep(10_ms);
 	}
 
 	// Verify the device is alive.
@@ -159,7 +159,7 @@ int PGA460::initialize_thresholds()
 	}
 
 	// Must wait >50us per datasheet.
-	px4_usleep(100);
+	px4_usleep(100_us);
 
 	if (read_threshold_registers() == PX4_OK) {
 		return PX4_OK;
@@ -190,7 +190,7 @@ uint32_t PGA460::collect_results()
 
 		bytes_available -= ret;
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 
 	} while (bytes_available > 0);
 
@@ -257,7 +257,7 @@ float PGA460::get_temperature()
 	}
 
 	// The pga460 requires a 2ms delay per the datasheet.
-	px4_usleep(5000);
+	px4_usleep(5_ms);
 
 	buf_tx[1] = TNLR;
 	ret = ::write(_fd, &buf_tx[0], sizeof(buf_tx) - 2);
@@ -266,7 +266,7 @@ float PGA460::get_temperature()
 		return PX4_ERROR;
 	}
 
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	uint8_t buf_rx[4] = {};
 	int bytes_available = sizeof(buf_rx);
@@ -285,7 +285,7 @@ float PGA460::get_temperature()
 
 		bytes_available -= ret;
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 
 	} while (bytes_available > 0);
 
@@ -531,7 +531,7 @@ int PGA460::read_eeprom()
 		return PX4_ERROR;
 	}
 
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	int bytes_available = sizeof(buf_rx);
 	int total_bytes = 0;
@@ -549,7 +549,7 @@ int PGA460::read_eeprom()
 
 		bytes_available -= ret;
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 
 	} while (bytes_available > 0);
 
@@ -583,7 +583,7 @@ uint8_t PGA460::read_register(const uint8_t reg)
 		return PX4_ERROR;
 	}
 
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	uint8_t buf_rx[3] = {};
 	int bytes_available = sizeof(buf_rx);
@@ -602,7 +602,7 @@ uint8_t PGA460::read_register(const uint8_t reg)
 
 		bytes_available -= ret;
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 
 	} while (bytes_available > 0);
 
@@ -631,7 +631,7 @@ int PGA460::read_threshold_registers()
 		return PX4_ERROR;
 	}
 
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	uint8_t buf_rx[array_size + 2] = {};
 	int bytes_available = sizeof(buf_rx);
@@ -650,7 +650,7 @@ int PGA460::read_threshold_registers()
 
 		bytes_available -= ret;
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 
 	} while (bytes_available > 0);
 
@@ -672,7 +672,7 @@ int PGA460::request_results()
 {
 	uint8_t buf_tx[2] = {SYNCBYTE, UMR};
 	int ret = ::write(_fd, &buf_tx[0], sizeof(buf_tx));
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	if(!ret) {
 		return PX4_ERROR;
@@ -860,17 +860,17 @@ int PGA460::write_eeprom()
 	}
 
 	// Needs time, see datasheet timing requirements.
-	px4_usleep(5000);
+	px4_usleep(5_ms);
 	unlock_eeprom();
 	flash_eeprom();
-	px4_usleep(5000);
+	px4_usleep(5_ms);
 
 	uint8_t result = 0;
 
 	// Give up to 100ms for ee_cntrl register to reflect a successful eeprom write.
 	for (int i = 0; i < 100; i++) {
 		result = read_register(EE_CNTRL_ADDR);
-		px4_usleep(5000);
+		px4_usleep(5_ms);
 
 		if (result & 1 << 2) {
 			PX4_INFO("EEPROM write successful");

--- a/src/drivers/distance_sensor/pga460/pga460.h
+++ b/src/drivers/distance_sensor/pga460/pga460.h
@@ -53,6 +53,7 @@
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/tasks.h>
 
+using namespace time_literals;
 
 #define PGA460_DEFAULT_PORT "/dev/ttyS6"
 #define MAX_DETECTABLE_DISTANCE          3.0f

--- a/src/drivers/distance_sensor/srf02/SRF02.cpp
+++ b/src/drivers/distance_sensor/srf02/SRF02.cpp
@@ -67,7 +67,7 @@ int SRF02::init()
 	}
 
 	// XXX we should find out why we need to wait 200 ms here
-	px4_usleep(200000);
+	px4_usleep(200_ms);
 
 	int ret = measure();
 

--- a/src/drivers/distance_sensor/srf02/SRF02.hpp
+++ b/src/drivers/distance_sensor/srf02/SRF02.hpp
@@ -46,6 +46,8 @@
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
 
+using namespace time_literals;
+
 /* Configuration Constants */
 #define SRF02_BASEADDR 				0x70 	// 7-bit address. 8-bit address is 0xE0.
 

--- a/src/drivers/distance_sensor/tf02pro/TF02PRO.cpp
+++ b/src/drivers/distance_sensor/tf02pro/TF02PRO.cpp
@@ -82,7 +82,7 @@ int TF02PRO::init()
 		return PX4_ERROR;
 	}
 
-	px4_usleep(100000);
+	px4_usleep(100_ms);
 
 	int ret = measure();
 

--- a/src/drivers/distance_sensor/tf02pro/TF02PRO.hpp
+++ b/src/drivers/distance_sensor/tf02pro/TF02PRO.hpp
@@ -46,6 +46,8 @@
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
 
+using namespace time_literals;
+
 /* Configuration Constants */
 #define TF02PRO_BASEADDR			0x10 	// 7-bit address. 8-bit address is 0x20.
 

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -274,7 +274,7 @@ int DShot::send_command_thread_safe(const dshot_command_t command, const int num
 	while (_new_command.load()) {
 
 		if (hrt_elapsed_time(&timestamp_for_timeout) < 2_s) {
-			px4_usleep(1000);
+			px4_usleep(1_ms);
 
 		} else {
 			_new_command.store(nullptr);
@@ -302,7 +302,7 @@ void DShot::retrieve_and_print_esc_info_thread_safe(const int motor_index)
 	int max_time = 1000;
 
 	while (_request_esc_info.load() != nullptr && max_time-- > 0) {
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 	}
 
 	_request_esc_info.store(nullptr); // just in case we time out...

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -365,7 +365,7 @@ GPS::~GPS()
 		unsigned int i = 0;
 
 		do {
-			px4_usleep(20000); // 20 ms
+			px4_usleep(20_ms); // 20 ms
 			++i;
 		} while (_secondary_instance.load() && i < 100);
 	}
@@ -504,7 +504,7 @@ int GPS::pollOrRead(uint8_t *buf, size_t buf_length, int timeout)
 #else
 	/* For QURT, just use read for now, since this doesn't block, we need to slow it down
 	 * just a bit. */
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 	return ::read(_serial_fd, buf, buf_length);
 #endif
 }
@@ -1060,7 +1060,7 @@ GPS::run()
 			case gps_driver_mode_t::NMEA: // skip NMEA for auto-detection to avoid false positive matching
 #endif // CONSTRAINED_FLASH
 				_mode = gps_driver_mode_t::UBX;
-				px4_usleep(500000); // tried all possible drivers. Wait a bit before next round
+				px4_usleep(500_ms); // tried all possible drivers. Wait a bit before next round
 				break;
 
 			default:
@@ -1068,7 +1068,7 @@ GPS::run()
 			}
 
 		} else {
-			px4_usleep(500000);
+			px4_usleep(500_ms);
 		}
 	}
 
@@ -1508,7 +1508,7 @@ GPS *GPS::instantiate(int argc, char *argv[], Instance instance)
 
 			do {
 				/* wait up to 1s */
-				px4_usleep(2500);
+				px4_usleep(2500_us);
 
 			} while (!_secondary_instance.load() && ++i < 400);
 

--- a/src/drivers/hygrometer/sht3x/sht3x.cpp
+++ b/src/drivers/hygrometer/sht3x/sht3x.cpp
@@ -178,7 +178,7 @@ int SHT3X::init()
 int SHT3X::init_sensor()
 {
 	set_pointer(SHT3X_CMD_CLEAR_STATUS);
-	px4_usleep(2000);
+	px4_usleep(2_ms);
 
 	// Get sensor serial number
 	uint8_t serial[4];
@@ -190,7 +190,7 @@ int SHT3X::init_sensor()
 				   | (uint32_t)serial[3]);
 
 	set_pointer(SHT3x_CMD_PERIODIC_2HZ_MEDIUM);
-	px4_usleep(2000);
+	px4_usleep(2_ms);
 	probe();
 
 	PX4_INFO("Connected to SHT3x sensor, SN: %ld", _sht_info.serial_number);

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -391,7 +391,7 @@ int PX4IO::init()
 	hrt_abstime start_try_time = hrt_absolute_time();
 
 	do {
-		px4_usleep(2000);
+		px4_usleep(2_ms);
 		protocol = io_reg_get(PX4IO_PAGE_CONFIG, PX4IO_P_CONFIG_PROTOCOL_VERSION);
 	} while (protocol == _io_reg_get_error && (hrt_elapsed_time(&start_try_time) < 700U * 1000U));
 
@@ -898,12 +898,12 @@ int PX4IO::dsm_bind_ioctl(int dsmMode)
 
 	int ret = OK;
 	ret |= io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_DSM, dsm_bind_power_down);
-	px4_usleep(500000);
+	px4_usleep(500_ms);
 	ret |= io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_DSM, dsm_bind_set_rx_out);
 	ret |= io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_DSM, dsm_bind_power_up);
-	px4_usleep(72000);
+	px4_usleep(72_ms);
 	ret |= io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_DSM, dsm_bind_send_pulses | (dsmMode << 4));
-	px4_usleep(50000);
+	px4_usleep(50_ms);
 	ret |= io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_DSM, dsm_bind_reinit_uart);
 
 	if (ret != OK) {

--- a/src/drivers/qshell/posix/qshell.cpp
+++ b/src/drivers/qshell/posix/qshell.cpp
@@ -124,7 +124,7 @@ int QShell::_wait_for_retval()
 			}
 		}
 
-		px4_usleep(1000);
+		px4_usleep(1_ms);
 	}
 
 	PX4_ERR("command timed out");

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -99,7 +99,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 	uORB::Publication<actuator_test_s> actuator_test_pub{ORB_ID(actuator_test)};
 	// since we publish multiple at once, make sure the output driver subscribes before we publish
 	actuator_test_pub.advertise();
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	// set motors to high
 	set_motor_actuators(actuator_test_pub, 1.f, false);
@@ -140,13 +140,13 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 			}
 		}
 
-		px4_usleep(50000);
+		px4_usleep(50_ms);
 	}
 
 	if (return_code == PX4_OK) {
 		// set motors to low
 		set_motor_actuators(actuator_test_pub, 0.f, false);
-		px4_usleep(4000000);
+		px4_usleep(4_s);
 
 		// release control
 		set_motor_actuators(actuator_test_pub, 0.f, true);

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -59,6 +59,8 @@
 #include <uORB/SubscriptionBlocking.hpp>
 #include <uORB/topics/sensor_gyro.h>
 
+using namespace time_literals;
+
 static constexpr char sensor_name[] {"gyro"};
 static constexpr unsigned MAX_GYROS = 4;
 
@@ -281,13 +283,13 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 
 		if (!failed) {
 			calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
-			px4_usleep(600000); // give this message enough time to propagate
+			px4_usleep(600_ms); // give this message enough time to propagate
 			return PX4_OK;
 		}
 	}
 
 	calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, sensor_name);
-	px4_usleep(600000); // give this message enough time to propagate
+	px4_usleep(600_ms); // give this message enough time to propagate
 
 	return PX4_ERROR;
 }

--- a/src/modules/commander/level_calibration.cpp
+++ b/src/modules/commander/level_calibration.cpp
@@ -175,12 +175,12 @@ out:
 
 	if (success) {
 		calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, "level");
-		px4_usleep(600000); // give this message enough time to propagate
+		px4_usleep(600_ms); // give this message enough time to propagate
 		return 0;
 
 	} else {
 		calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "level");
-		px4_usleep(600000); // give this message enough time to propagate
+		px4_usleep(600_ms); // give this message enough time to propagate
 		return 1;
 	}
 }

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -118,23 +118,23 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 
 		case calibrate_return_ok:
 			/* if there is a any preflight-check system response, let the barrage of messages through */
-			px4_usleep(200000);
+			px4_usleep(200_ms);
 
 			calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 100);
-			px4_usleep(20000);
+			px4_usleep(20_ms);
 			calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
-			px4_usleep(20000);
+			px4_usleep(20_ms);
 			break;
 
 		default:
 			calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, sensor_name);
-			px4_usleep(20000);
+			px4_usleep(20_ms);
 			break;
 		}
 	}
 
 	/* give this message enough time to propagate */
-	px4_usleep(600000);
+	px4_usleep(600_ms);
 
 	return result;
 }
@@ -435,7 +435,7 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 					calibration_log_info(worker_data->mavlink_log_pub,
 							     "[cal] %s side calibration: progress <%u>",
 							     detect_orientation_str(orientation), new_progress);
-					px4_usleep(10000);
+					px4_usleep(10_ms);
 
 					worker_data->last_mag_progress = new_progress;
 				}
@@ -459,7 +459,7 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 				     detect_orientation_str(orientation));
 
 		worker_data->done_count++;
-		px4_usleep(20000);
+		px4_usleep(20_ms);
 		calibration_log_info(worker_data->mavlink_log_pub, CAL_QGC_PROGRESS_MSG, progress_percentage(worker_data));
 	}
 
@@ -509,7 +509,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub, int32_t cal_ma
 			calibration_log_info(mavlink_log_pub,
 					     "[cal] %s side done, rotate to a different side",
 					     detect_orientation_str(static_cast<enum detect_orientation_return>(i)));
-			px4_usleep(100000);
+			px4_usleep(100_ms);
 		}
 	}
 

--- a/src/modules/commander/rc_calibration.cpp
+++ b/src/modules/commander/rc_calibration.cpp
@@ -50,10 +50,12 @@
 #include <parameters/param.h>
 #include <systemlib/err.h>
 
+using namespace time_literals;
+
 int do_trim_calibration(orb_advert_t *mavlink_log_pub)
 {
 	uORB::Subscription manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
-	px4_usleep(400000);
+	px4_usleep(400_ms);
 	manual_control_setpoint_s manual_control_setpoint{};
 	bool changed = manual_control_setpoint_sub.updated();
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2425,20 +2425,20 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 							} else {
 								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
-								px4_usleep(100000);
+								px4_usleep(100_ms);
 								break;
 							}
 						}
 
 					} else {
-						px4_usleep(1000); // give the sensors extra time to start
+						px4_usleep(1_ms); // give the sensors extra time to start
 						break;
 					}
 				}
 			}
 
 			if (multi_instances_allocated < multi_instances) {
-				px4_usleep(10000);
+				px4_usleep(10_ms);
 			}
 		}
 
@@ -2568,7 +2568,7 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 
 				if (inst) {
 					inst->request_stop();
-					px4_usleep(20000); // 20 ms
+					px4_usleep(20_ms); // 20 ms
 					delete inst;
 					_objects[instance].store(nullptr);
 				}
@@ -2597,7 +2597,7 @@ extern "C" __EXPORT int ekf2_main(int argc, char *argv[])
 					PX4_INFO("stopping ekf2 instance %d", i);
 					was_running = true;
 					inst->request_stop();
-					px4_usleep(20000); // 20 ms
+					px4_usleep(20_ms); // 20 ms
 					delete inst;
 					_objects[i].store(nullptr);
 				}

--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -282,7 +282,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 
 		} else {
 			// We still need to wake up regularly to check for thread exit requests
-			px4_usleep(1e6);
+			px4_usleep(1_s);
 		}
 	}
 
@@ -333,7 +333,7 @@ int gimbal_main(int argc, char *argv[])
 		int counter = 0;
 
 		while (!thread_running.load() && gimbal_task >= 0) {
-			px4_usleep(5000);
+			px4_usleep(5_ms);
 
 			if (++counter >= 100) {
 				break;
@@ -358,7 +358,7 @@ int gimbal_main(int argc, char *argv[])
 		thread_should_exit.store(true);
 
 		while (thread_running.load()) {
-			px4_usleep(100000);
+			px4_usleep(100_ms);
 		}
 
 		return 0;

--- a/src/modules/landing_target_estimator/landing_target_estimator_main.cpp
+++ b/src/modules/landing_target_estimator/landing_target_estimator_main.cpp
@@ -140,7 +140,7 @@ int landing_target_estimator_thread_main(int argc, char *argv[])
 
 	while (!thread_should_exit) {
 		est.update();
-		px4_usleep(1000000 / landing_target_estimator_UPDATE_RATE_HZ);
+		px4_usleep(1_s / landing_target_estimator_UPDATE_RATE_HZ);
 	}
 
 	PX4_DEBUG("exiting");

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -430,7 +430,7 @@ void LogWriterFile::run()
 					if (written < 0) {
 						// retry once
 						PX4_ERR("write failed errno:%i (%s), retrying", errno, strerror(errno));
-						px4_usleep(10000); // 10 milliseconds
+						px4_usleep(10_ms); // 10 milliseconds
 						written = buffer.write_to_file(read_ptr, available, call_fsync);
 					}
 
@@ -505,7 +505,7 @@ int LogWriterFile::write_message(LogType type, void *ptr, size_t size, uint64_t 
 			while ((ret = write(type, ptr, 0, dropout_start)) == -1) {
 				unlock();
 				notify();
-				px4_usleep(3000);
+				px4_usleep(3_ms);
 				lock();
 			}
 		}
@@ -519,7 +519,7 @@ int LogWriterFile::write_message(LogType type, void *ptr, size_t size, uint64_t 
 			while ((ret = write(type, uptr, write_size, 0)) == -1) {
 				unlock();
 				notify();
-				px4_usleep(3000);
+				px4_usleep(3_ms);
 				lock();
 			}
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -147,7 +147,7 @@ Mavlink::~Mavlink()
 
 		do {
 			/* wait at least 1 second (10ms * 10) */
-			px4_usleep(10000);
+			px4_usleep(10_ms);
 
 			/* if we have given up, kill it */
 			if (++i > 100) {
@@ -371,7 +371,7 @@ Mavlink::destroy_all_instances()
 			iterations++;
 			printf(".");
 			fflush(stdout);
-			px4_usleep(10000);
+			px4_usleep(10_ms);
 		}
 	}
 
@@ -2753,29 +2753,29 @@ void Mavlink::configure_sik_radio()
 
 		if (fs) {
 			/* switch to AT command mode */
-			px4_usleep(1200000);
+			px4_usleep(1200_ms);
 			fprintf(fs, "+++");
 			fflush(fs);
-			px4_usleep(1200000);
+			px4_usleep(1200_ms);
 
 			if (_param_sik_radio_id.get() > 0) {
 				/* set channel */
 				fprintf(fs, "ATS3=%" PRIu32 "\r\n", _param_sik_radio_id.get());
-				px4_usleep(200000);
+				px4_usleep(200_ms);
 
 			} else {
 				/* reset to factory defaults */
 				fprintf(fs, "AT&F\r\n");
-				px4_usleep(200000);
+				px4_usleep(200_ms);
 			}
 
 			/* write config */
 			fprintf(fs, "AT&W\r\n");
-			px4_usleep(200000);
+			px4_usleep(200_ms);
 
 			/* reboot */
 			fprintf(fs, "ATZ\r\n");
-			px4_usleep(200000);
+			px4_usleep(200_ms);
 
 			// XXX NuttX suffers from a bug where
 			// fclose() also closes the fd, not just
@@ -3110,7 +3110,7 @@ Mavlink::stop_command(int argc, char *argv[])
 				while ((iterations < 1000) && inst->running()) {
 					inst->request_stop();
 					iterations++;
-					px4_usleep(1000);
+					px4_usleep(1_ms);
 				}
 
 				if (inst->running()) {

--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -365,7 +365,7 @@ void MicroddsClient::run()
 				_connected = false;
 			}
 
-			px4_usleep(1000);
+			px4_usleep(1_ms);
 		}
 
 		uxr_delete_session_retries(&session, _connected ? 1 : 0);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -182,7 +182,7 @@ void Navigator::run()
 		} else if (pret < 0) {
 			/* this is undesirable but not much we can do - might want to flag unhappy status */
 			PX4_ERR("poll error %d, %d", pret, errno);
-			px4_usleep(10000);
+			px4_usleep(10_ms);
 			continue;
 		}
 

--- a/src/modules/temperature_compensation/temperature_calibration/task.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/task.cpp
@@ -57,6 +57,8 @@
 #include "baro.h"
 #include "gyro.h"
 
+using namespace time_literals;
+
 class TemperatureCalibration;
 
 namespace temperature_calibration
@@ -185,7 +187,7 @@ void TemperatureCalibration::task_main()
 
 		if (ret < 0) {
 			// Poll error, sleep and try again
-			px4_usleep(10000);
+			px4_usleep(10_ms);
 			continue;
 
 		} else if (ret == 0) {

--- a/src/systemcmds/bl_update/bl_update.cpp
+++ b/src/systemcmds/bl_update/bl_update.cpp
@@ -54,6 +54,8 @@
 
 #include <nuttx/progmem.h>
 
+using namespace time_literals;
+
 #if defined(CONFIG_ARCH_CHIP_STM32H7)
 #  define BL_FILE_SIZE_LIMIT	128*1024
 #  define STM_RAM_BASE        STM32_AXISRAM_BASE
@@ -175,7 +177,7 @@ extern "C" __EXPORT int bl_update_main(int argc, char *argv[])
 	}
 
 	PX4_INFO("image validated, erasing bootloader...");
-	px4_usleep(10000);
+	px4_usleep(10_ms);
 
 	/* prevent other tasks from running while we do this */
 	sched_lock();
@@ -253,7 +255,7 @@ setopt(void)
 	/* program the new option value */
 	*optcr = (*optcr & ~opt_mask) | opt_bits | (1 << 1);
 
-	px4_usleep(1000);
+	px4_usleep(1_ms);
 
 	if ((*optcr & opt_mask) == opt_bits) {
 		PX4_INFO("option bits set");

--- a/src/systemcmds/led_control/led_control.cpp
+++ b/src/systemcmds/led_control/led_control.cpp
@@ -48,6 +48,8 @@
 #include <uORB/Publication.hpp>
 #include <uORB/topics/led_control.h>
 
+using namespace time_literals;
+
 static void	usage();
 
 extern "C" {
@@ -72,7 +74,7 @@ static void run_led_test1()
 	led_control.priority = led_control_s::MAX_PRIORITY;
 	publish_led_control(led_control);
 
-	px4_usleep(200 * 1000);
+	px4_usleep(200_us * 1000);
 
 	// generate some pattern
 	for (int round = led_control_s::COLOR_RED; round <= led_control_s::COLOR_WHITE; ++round) {
@@ -81,25 +83,25 @@ static void run_led_test1()
 			led_control.mode = led_control_s::MODE_ON;
 			led_control.color = round;
 			publish_led_control(led_control);
-			px4_usleep(80 * 1000);
+			px4_usleep(80_us * 1000);
 		}
 
-		px4_usleep(100 * 1000);
+		px4_usleep(100_us * 1000);
 		led_control.led_mask = 0xff;
 
 		for (int i = 0; i < 3; ++i) {
 			led_control.mode = led_control_s::MODE_ON;
 			publish_led_control(led_control);
-			px4_usleep(100 * 1000);
+			px4_usleep(100_us * 1000);
 			led_control.mode = led_control_s::MODE_OFF;
 			publish_led_control(led_control);
-			px4_usleep(100 * 1000);
+			px4_usleep(100_us * 1000);
 		}
 
-		px4_usleep(200 * 1000);
+		px4_usleep(200_us * 1000);
 	}
 
-	px4_usleep(500 * 1000);
+	px4_usleep(500_us * 1000);
 
 	// reset
 	led_control.led_mask = 0xff;

--- a/src/systemcmds/reboot/reboot.cpp
+++ b/src/systemcmds/reboot/reboot.cpp
@@ -45,6 +45,8 @@
 #include <px4_platform_common/shutdown.h>
 #include <string.h>
 
+using namespace time_literals;
+
 static void print_usage()
 {
 	PRINT_MODULE_DESCRIPTION("Reboot the system");
@@ -105,7 +107,7 @@ extern "C" __EXPORT int reboot_main(int argc, char *argv[])
 		return -1;
 	}
 
-	while (1) { px4_usleep(1); } // this command should not return on success
+	while (1) { px4_usleep(1_us); } // this command should not return on success
 
 	return 0;
 }

--- a/src/systemcmds/top/top.cpp
+++ b/src/systemcmds/top/top.cpp
@@ -52,6 +52,8 @@
 #include <drivers/drv_hrt.h>
 #include <px4_platform_common/module.h>
 
+using namespace time_literals;
+
 static void print_usage()
 {
 	PRINT_MODULE_DESCRIPTION("Monitor running processes and their CPU, stack usage, priority and state");
@@ -64,7 +66,7 @@ extern "C" __EXPORT int top_main(int argc, char *argv[])
 {
 	print_load_s load{};
 	init_print_load(&load);
-	px4_usleep(200000);
+	px4_usleep(200_ms);
 
 	/* clear screen */
 	dprintf(1, "\033[2J\n");
@@ -115,7 +117,7 @@ extern "C" __EXPORT int top_main(int argc, char *argv[])
 				}
 			}
 
-			px4_usleep(200000);
+			px4_usleep(200_ms);
 		}
 	}
 

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -54,6 +54,8 @@
 
 #include <drivers/drv_hrt.h>
 
+using namespace time_literals;
+
 #define MAX_NOTE_ITERATION 50
 
 static void usage();
@@ -202,7 +204,7 @@ extern "C" __EXPORT int tune_control_main(int argc, char *argv[])
 			PX4_INFO("frequency: %d, duration %d, silence %d, volume %d",
 				 frequency, duration, silence, volume);
 
-			px4_usleep(500000);
+			px4_usleep(500_ms);
 			exit_counter++;
 
 			// exit if the loop is doing too many iterations


### PR DESCRIPTION
### Solved Problem

Time values are in microseconds, making it difficult to understand millisecond and second settings.

### Solution

Add a unit to the time value to make it easier to recognize.

### Alternatives

None


### Test coverage

None

### Context

None