### PR TITLE
add SPI to stm32f1

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32f1/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/stm/stm32f1/CMakeLists.txt
@@ -32,6 +32,7 @@
 ############################################################################
 
 add_subdirectory(../stm32_common/io_pins io_pins)
+add_subdirectory(../stm32_common/spi spi)
 add_subdirectory(../stm32_common/hrt hrt)
 add_subdirectory(../stm32_common/board_critmon board_critmon)
 add_subdirectory(../stm32_common/board_reset board_reset)


### PR DESCRIPTION
The `arch_spi` library is missing for the STM32 F1 targets.

### Solved Problem
Fix linking error for STM32 F1 targets.