### PR TITLE
Update status leds every time when prearm check status changes

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1713,9 +1713,14 @@ void Commander::run()
 
 			perf_begin(_preflight_check_perf);
 			_health_and_arming_checks.update();
-			_vehicle_status.pre_flight_checks_pass = _health_and_arming_checks.canArm(_vehicle_status.nav_state);
-			perf_end(_preflight_check_perf);
+			bool pre_flight_checks_pass = _health_and_arming_checks.canArm(_vehicle_status.nav_state);
 
+			if (_vehicle_status.pre_flight_checks_pass != pre_flight_checks_pass) {
+				_vehicle_status.pre_flight_checks_pass = pre_flight_checks_pass;
+				_status_changed = true;
+			}
+
+			perf_end(_preflight_check_perf);
 			checkAndInformReadyForTakeoff();
 		}
 


### PR DESCRIPTION
Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

### Solved Problem

We have had problems with status leds not properly updating when pre-arm checks are done. Basically, the blinking status leds often show some wrong/previous value (e.g. fast blinking red light even if the previous preflight checks passed).

### Solution

Always update the status leds when the result from prearm checks change; set "_status_changed = true;", which is then later passed to rgbled_set_color_and_mode

### Alternatives

### Test coverage

Tested on Pixhawk 5x

