### PR TITLE
Rearrange npfg use path input

### DIFF
--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -574,22 +574,6 @@ void NPFG::navigatePathTangent(const matrix::Vector2f &vehicle_pos, const matrix
 	updateRollSetpoint();
 } // navigatePathTangent
 
-void NPFG::navigateHeading(float heading_ref, const Vector2f &ground_vel, const Vector2f &wind_vel)
-{
-	path_type_loiter_ = false;
-
-	Vector2f air_vel = ground_vel - wind_vel;
-	unit_path_tangent_ = Vector2f{cosf(heading_ref), sinf(heading_ref)};
-	signed_track_error_ = 0.0f;
-
-	closest_point_on_path_.setNaN();
-
-	// use the guidance law to regulate heading error - ignoring wind or inertial position
-	guideToPath(air_vel, Vector2f{0.0f, 0.0f}, unit_path_tangent_, signed_track_error_, 0.0f);
-
-	updateRollSetpoint();
-} // navigateHeading
-
 void NPFG::navigateBearing(float bearing, const Vector2f &ground_vel, const Vector2f &wind_vel)
 {
 	path_type_loiter_ = false;
@@ -604,20 +588,6 @@ void NPFG::navigateBearing(float bearing, const Vector2f &ground_vel, const Vect
 
 	updateRollSetpoint();
 } // navigateBearing
-
-void NPFG::navigateLevelFlight(const float heading)
-{
-	path_type_loiter_ = false;
-
-	airspeed_ref_ = airspeed_nom_;
-	lateral_accel_ = 0.0f;
-	feas_ = 1.0f;
-	bearing_vec_ = Vector2f{cosf(heading), sinf(heading)};
-	unit_path_tangent_ = bearing_vec_;
-	signed_track_error_ = 0.0f;
-
-	updateRollSetpoint();
-} // navigateLevelFlight
 
 float NPFG::switchDistance(float wp_radius) const
 {

--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -281,20 +281,6 @@ public:
 				 const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature);
 
 	/*
-	 * Navigate on a fixed heading.
-	 *
-	 * This only holds a certain (air mass relative) direction and does not perform
-	 * cross track correction. Helpful for semi-autonomous modes. Introduced
-	 * by in ECL_L1_Pos_Controller, augmented for use with NPFG here.
-	 *
-	 * @param[in] heading_ref Reference heading angle [rad]
-	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
-	 * @param[in] wind_vel Wind velocity vector [m/s]
-	 */
-	void navigateHeading(float heading_ref, const matrix::Vector2f &ground_vel,
-			     const matrix::Vector2f &wind_vel);
-
-	/*
 	 * Navigate on a fixed bearing.
 	 *
 	 * This only holds a certain (ground relative) direction and does not perform
@@ -305,13 +291,6 @@ public:
 	 * @param[in] wind_vel Wind velocity vector [m/s]
 	 */
 	void navigateBearing(float bearing, const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel);
-
-	/*
-	 * Keep the wings level.
-	 *
-	 * @param[in] heading Heading angle [rad]
-	 */
-	void navigateLevelFlight(const float heading);
 
 	/*
 	 * [Copied directly from ECL_L1_Pos_Controller]

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -895,9 +895,6 @@ FixedwingPositionControl::control_auto(const float control_interval, const Vecto
 		_att_sp.thrust_body[0] = 0.0f;
 		_att_sp.roll_body = 0.0f;
 		_att_sp.pitch_body = radians(_param_fw_psp_off.get());
-		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
-
 		break;
 
 	case position_setpoint_s::SETPOINT_TYPE_POSITION:
@@ -957,9 +954,6 @@ FixedwingPositionControl::control_auto_fixed_bank_alt_hold(const float control_i
 	}
 
 	_att_sp.pitch_body = get_tecs_pitch();
-
-	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 }
 
 void
@@ -986,9 +980,6 @@ FixedwingPositionControl::control_auto_descend(const float control_interval)
 
 	_att_sp.thrust_body[0] = (_landed) ? _param_fw_thr_min.get() : min(get_tecs_thrust(), _param_fw_thr_max.get());
 	_att_sp.pitch_body = get_tecs_pitch();
-
-	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 }
 
 uint8_t
@@ -1155,9 +1146,6 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 
 	_att_sp.yaw_body = _yaw; // yaw is not controlled, so set setpoint to current yaw
 
-	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
-
 	tecs_update_pitch_throttle(control_interval,
 				   position_sp_alt,
 				   target_airspeed,
@@ -1212,9 +1200,6 @@ FixedwingPositionControl::control_auto_velocity(const float control_interval, co
 	}
 
 	_att_sp.yaw_body = _yaw;
-
-	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 
 	tecs_update_pitch_throttle(control_interval,
 				   position_sp_alt,
@@ -1296,9 +1281,6 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_LAND;
 		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_LAND;
 
-	} else {
-		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 	}
 
 	float target_airspeed = adapt_airspeed_setpoint(control_interval, airspeed_sp, _param_fw_airspd_min.get(),
@@ -1487,7 +1469,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 		// apply flaps for takeoff according to the corresponding scale factor set via FW_FLAPS_TO_SCL
 		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_TAKEOFF;
-		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 
 	} else {
 		/* Perform launch detection */
@@ -1579,9 +1560,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_att_sp.thrust_body[0] = _param_fw_thr_idle.get();
 			_att_sp.pitch_body = radians(_takeoff_pitch_min.get());
 		}
-
-		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 
 		launch_detection_status_s launch_detection_status;
 		launch_detection_status.timestamp = now;
@@ -1891,11 +1869,6 @@ FixedwingPositionControl::control_manual_altitude(const float control_interval, 
 
 	_att_sp.thrust_body[0] = min(get_tecs_thrust(), throttle_max);
 	_att_sp.pitch_body = get_tecs_pitch();
-
-	// In Manual modes flaps and spoilers are directly controlled in FW Attitude controller and not passed
-	// through attitdue setpoints
-	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 }
 
 void
@@ -2014,11 +1987,6 @@ FixedwingPositionControl::control_manual_position(const float control_interval, 
 
 	_att_sp.thrust_body[0] = min(get_tecs_thrust(), throttle_max);
 	_att_sp.pitch_body = get_tecs_pitch();
-
-	// In Manual modes flaps and spoilers are directly controlled in FW Attitude controller and not passed
-	// through attitdue setpoints
-	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 }
 
 float
@@ -2234,6 +2202,8 @@ FixedwingPositionControl::Run()
 		_l1_control.set_l1_period(_param_fw_l1_period.get());
 
 		_att_sp.reset_integral = false;
+		_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
+		_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 
 		// by default we don't want yaw to be contoller directly with rudder
 		_att_sp.fw_control_yaw_wheel = false;
@@ -2289,9 +2259,6 @@ FixedwingPositionControl::Run()
 
 		case FW_POSCTRL_MODE_OTHER: {
 				_att_sp.thrust_body[0] = min(_att_sp.thrust_body[0], _param_fw_thr_max.get());
-
-				_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_OFF;
-				_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_OFF;
 
 				_tecs.initialize(_current_altitude, -_local_pos.vz, _airspeed, _eas2tas);
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -536,7 +536,7 @@ FixedwingPositionControl::status_publish()
 		const float bearing = _npfg.getBearing(); // dont repeat atan2 calc
 
 		pos_ctrl_status.nav_bearing = bearing;
-		pos_ctrl_status.target_bearing = _npfg.targetBearing();
+		pos_ctrl_status.target_bearing = _target_bearing;
 		pos_ctrl_status.xtrack_error = _npfg.getTrackError();
 		pos_ctrl_status.acceptance_radius = _npfg.switchDistance(500.0f);
 
@@ -1138,11 +1138,11 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 			matrix::Vector2f velocity_2d(pos_sp_curr.vx, pos_sp_curr.vy);
 			float curvature = PX4_ISFINITE(_pos_sp_triplet.current.loiter_radius) ? 1 / _pos_sp_triplet.current.loiter_radius :
 					  0.0f;
-			_npfg.navigatePathTangent(curr_pos_local, curr_wp_local, velocity_2d.normalized(), get_nav_speed_2d(ground_speed),
-						  _wind_vel, curvature);
+			navigatePathTangent(curr_pos_local, curr_wp_local, velocity_2d.normalized(), get_nav_speed_2d(ground_speed),
+					    _wind_vel, curvature);
 
 		} else {
-			_npfg.navigateWaypoints(prev_wp_local, curr_wp_local, curr_pos_local, get_nav_speed_2d(ground_speed), _wind_vel);
+			navigateWaypoints(prev_wp_local, curr_wp_local, curr_pos_local, get_nav_speed_2d(ground_speed), _wind_vel);
 		}
 
 		_att_sp.roll_body = _npfg.getRollSetpoint();
@@ -1199,9 +1199,10 @@ FixedwingPositionControl::control_auto_velocity(const float control_interval, co
 				_param_fw_airspd_min.get(), ground_speed);
 
 	if (_param_fw_use_npfg.get()) {
+		Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
 		_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 		_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-		_npfg.navigateBearing(_target_bearing, ground_speed, _wind_vel);
+		navigateBearing(curr_pos_local, _target_bearing, ground_speed, _wind_vel);
 		_att_sp.roll_body = _npfg.getRollSetpoint();
 		target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 
@@ -1279,10 +1280,14 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 		loiter_radius = _param_nav_loiter_rad.get();
 	}
 
-	const bool in_circle_mode = (_param_fw_use_npfg.get()) ? _npfg.circleMode() : _l1_control.circle_mode();
+	Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
+	Vector2f curr_wp_local{_global_local_proj_ref.project(curr_wp(0), curr_wp(1))};
+	Vector2f vehicle_to_loiter_center{curr_wp_local - curr_pos_local};
+
+	const bool close_to_circle = vehicle_to_loiter_center.norm() < loiter_radius + _npfg.switchDistance(500);
 
 	if (pos_sp_next.type == position_setpoint_s::SETPOINT_TYPE_LAND && _position_setpoint_next_valid
-	    && in_circle_mode && _param_fw_lnd_earlycfg.get()) {
+	    && close_to_circle && _param_fw_lnd_earlycfg.get()) {
 		// We're in a loiter directly before a landing WP. Enable our landing configuration (flaps,
 		// landing airspeed and potentially tighter altitude control) already such that we don't
 		// have to do this switch (which can cause significant altitude errors) close to the ground.
@@ -1299,15 +1304,12 @@ FixedwingPositionControl::control_auto_loiter(const float control_interval, cons
 	float target_airspeed = adapt_airspeed_setpoint(control_interval, airspeed_sp, _param_fw_airspd_min.get(),
 				ground_speed);
 
-	Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
-	Vector2f curr_wp_local = _global_local_proj_ref.project(curr_wp(0), curr_wp(1));
-
 	if (_param_fw_use_npfg.get()) {
 		_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 		_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-		_npfg.navigateLoiter(curr_wp_local, curr_pos_local, loiter_radius, pos_sp_curr.loiter_direction_counter_clockwise,
-				     get_nav_speed_2d(ground_speed),
-				     _wind_vel);
+		navigateLoiter(curr_wp_local, curr_pos_local, loiter_radius, pos_sp_curr.loiter_direction_counter_clockwise,
+			       get_nav_speed_2d(ground_speed),
+			       _wind_vel);
 		_att_sp.roll_body = _npfg.getRollSetpoint();
 		target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 
@@ -1426,8 +1428,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		if (_param_fw_use_npfg.get()) {
 			_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 			_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-			_npfg.navigatePathTangent(local_2D_position, start_pos_local, takeoff_bearing_vector, ground_speed,
-						  _wind_vel, 0.0f);
+			navigatePathTangent(local_2D_position, start_pos_local, takeoff_bearing_vector, ground_speed,
+					    _wind_vel, 0.0f);
 
 			_att_sp.roll_body = _runway_takeoff.getRoll(_npfg.getRollSetpoint());
 
@@ -1532,8 +1534,8 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			if (_param_fw_use_npfg.get()) {
 				_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 				_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-				_npfg.navigatePathTangent(local_2D_position, launch_local_position, takeoff_bearing_vector, ground_speed, _wind_vel,
-							  0.0f);
+				navigatePathTangent(local_2D_position, launch_local_position, takeoff_bearing_vector, ground_speed, _wind_vel,
+						    0.0f);
 				_att_sp.roll_body = _npfg.getRollSetpoint();
 				target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 
@@ -1688,7 +1690,7 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 		if (_param_fw_use_npfg.get()) {
 			_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 			_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-			_npfg.navigateWaypoints(local_approach_entrance, local_land_point, local_position, ground_speed, _wind_vel);
+			navigateWaypoints(local_approach_entrance, local_land_point, local_position, ground_speed, _wind_vel);
 			target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 			_att_sp.roll_body = _npfg.getRollSetpoint();
 
@@ -1785,7 +1787,7 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 		if (_param_fw_use_npfg.get()) {
 			_npfg.setAirspeedNom(target_airspeed * _eas2tas);
 			_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-			_npfg.navigateWaypoints(local_approach_entrance, local_land_point, local_position, ground_speed, _wind_vel);
+			navigateWaypoints(local_approach_entrance, local_land_point, local_position, ground_speed, _wind_vel);
 			target_airspeed = _npfg.getAirspeedRef() / _eas2tas;
 			_att_sp.roll_body = _npfg.getRollSetpoint();
 
@@ -1965,7 +1967,7 @@ FixedwingPositionControl::control_manual_position(const float control_interval, 
 			if (_param_fw_use_npfg.get()) {
 				_npfg.setAirspeedNom(calibrated_airspeed_sp * _eas2tas);
 				_npfg.setAirspeedMax(_param_fw_airspd_max.get() * _eas2tas);
-				_npfg.navigateWaypoints(prev_wp_local, curr_wp_local, curr_pos_local, ground_speed, _wind_vel);
+				navigateWaypoints(prev_wp_local, curr_wp_local, curr_pos_local, ground_speed, _wind_vel);
 				_att_sp.roll_body = _npfg.getRollSetpoint();
 				calibrated_airspeed_sp = _npfg.getAirspeedRef() / _eas2tas;
 
@@ -2720,7 +2722,7 @@ void FixedwingPositionControl::publishLocalPositionSetpoint(const position_setpo
 		}
 
 	} else {
-		current_setpoint = _npfg.getClosestPoint();
+		current_setpoint = _closest_point_on_path;
 	}
 
 	local_position_setpoint.x = current_setpoint(0);
@@ -2758,6 +2760,104 @@ void FixedwingPositionControl::publishOrbitStatus(const position_setpoint_s pos_
 	orbit_status.yaw_behaviour = orbit_status_s::ORBIT_YAW_BEHAVIOUR_HOLD_FRONT_TANGENT_TO_CIRCLE;
 	_orbit_status_pub.publish(orbit_status);
 }
+
+void FixedwingPositionControl::navigateWaypoints(const Vector2f &waypoint_A, const Vector2f &waypoint_B,
+		const Vector2f &vehicle_pos, const Vector2f &ground_vel, const Vector2f &wind_vel)
+{
+	// similar to logic found in ECL_L1_Pos_Controller method of same name
+	// BUT no arbitrary max approach angle, approach entirely determined by generated
+	// bearing vectors
+
+	Vector2f vector_A_to_B = waypoint_B - waypoint_A;
+	Vector2f vector_A_to_vehicle = vehicle_pos - waypoint_A;
+
+	if (vector_A_to_B.norm() < FLT_EPSILON) {
+		// the waypoints are on top of each other and should be considered as a
+		// single waypoint, fly directly to it
+		if (vector_A_to_vehicle.norm() > FLT_EPSILON) {
+			vector_A_to_B = -vector_A_to_vehicle;
+
+		} else {
+			// Fly to a point and on it. Stay to the current control. Do not update the npfg library to get last output.
+			return;
+		}
+
+
+	} else if ((vector_A_to_B.dot(vector_A_to_vehicle) < -FLT_EPSILON)) {
+		// we are in front of waypoint A, fly directly to it until we are within switch distance.
+
+		if (vector_A_to_vehicle.norm() > _npfg.switchDistance(500.0f)) {
+			vector_A_to_B = -vector_A_to_vehicle;
+		}
+	}
+
+	// track the line segment
+	Vector2f unit_path_tangent{vector_A_to_B.normalized()};
+	_target_bearing = atan2f(unit_path_tangent(1), unit_path_tangent(0));
+	_closest_point_on_path = waypoint_A + vector_A_to_vehicle.dot(unit_path_tangent) * unit_path_tangent;
+	_npfg.guideToPath(vehicle_pos, ground_vel, wind_vel, unit_path_tangent, waypoint_A, 0.0f);
+} // navigateWaypoints
+
+void FixedwingPositionControl::navigateLoiter(const Vector2f &loiter_center, const Vector2f &vehicle_pos,
+		float radius, bool loiter_direction_counter_clockwise, const Vector2f &ground_vel, const Vector2f &wind_vel)
+{
+	const float loiter_direction_multiplier = loiter_direction_counter_clockwise ? -1.f : 1.f;
+
+	Vector2f vector_center_to_vehicle = vehicle_pos - loiter_center;
+	const float dist_to_center = vector_center_to_vehicle.norm();
+
+	// find the direction from the circle center to the closest point on its perimeter
+	// from the vehicle position
+	Vector2f unit_vec_center_to_closest_pt;
+
+	if (dist_to_center < 0.1f) {
+		// the logic breaks down at the circle center, employ some mitigation strategies
+		// until we exit this region
+		if (ground_vel.norm() < 0.1f) {
+			// arbitrarily set the point in the northern top of the circle
+			unit_vec_center_to_closest_pt = Vector2f{1.0f, 0.0f};
+
+		} else {
+			// set the point in the direction we are moving
+			unit_vec_center_to_closest_pt = ground_vel.normalized();
+		}
+
+	} else {
+		// set the point in the direction of the aircraft
+		unit_vec_center_to_closest_pt = vector_center_to_vehicle.normalized();
+	}
+
+	// 90 deg clockwise rotation * loiter direction
+	const Vector2f unit_path_tangent = loiter_direction_multiplier * Vector2f{-unit_vec_center_to_closest_pt(1), unit_vec_center_to_closest_pt(0)};
+
+	float path_curvature = loiter_direction_multiplier / radius;
+	_target_bearing = atan2f(unit_path_tangent(1), unit_path_tangent(0));
+	_closest_point_on_path = unit_vec_center_to_closest_pt * radius + loiter_center;
+	_npfg.guideToPath(vehicle_pos, ground_vel, wind_vel, unit_path_tangent,
+			  loiter_center + unit_vec_center_to_closest_pt * radius, path_curvature);
+} // navigateLoiter
+
+
+void FixedwingPositionControl::navigatePathTangent(const matrix::Vector2f &vehicle_pos,
+		const matrix::Vector2f &position_setpoint,
+		const matrix::Vector2f &tangent_setpoint,
+		const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature)
+{
+	const Vector2f unit_path_tangent{tangent_setpoint.normalized()};
+	_target_bearing = atan2f(unit_path_tangent(1), unit_path_tangent(0));
+	_closest_point_on_path = position_setpoint;
+	_npfg.guideToPath(vehicle_pos, ground_vel, wind_vel, tangent_setpoint.normalized(), position_setpoint, curvature);
+} // navigatePathTangent
+
+void FixedwingPositionControl::navigateBearing(const matrix::Vector2f &vehicle_pos, float bearing,
+		const Vector2f &ground_vel, const Vector2f &wind_vel)
+{
+
+	const Vector2f unit_path_tangent = Vector2f{cosf(bearing), sinf(bearing)};
+	_target_bearing = atan2f(unit_path_tangent(1), unit_path_tangent(0));
+	_closest_point_on_path = vehicle_pos;
+	_npfg.guideToPath(vehicle_pos, ground_vel, wind_vel, unit_path_tangent, vehicle_pos, 0.0f);
+} // navigateBearing
 
 int FixedwingPositionControl::task_spawn(int argc, char *argv[])
 {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -412,6 +412,9 @@ private:
 
 	// LATERAL-DIRECTIONAL GUIDANCE
 
+	// CLosest point on path to track
+	matrix::Vector2f _closest_point_on_path;
+
 	// L1 guidance - lateral-directional position control
 	ECL_L1_Pos_Controller _l1_control;
 
@@ -772,6 +775,68 @@ private:
 	 */
 	void initializeAutoLanding(const hrt_abstime &now, const position_setpoint_s &pos_sp_prev,
 				   const position_setpoint_s &pos_sp_curr, const Vector2f &local_position, const Vector2f &local_land_point);
+
+	/*
+	 * Waypoint handling logic following closely to the ECL_L1_Pos_Controller
+	 * method of the same name. Takes two waypoints and determines the relevant
+	 * parameters for evaluating the NPFG guidance law, then updates control setpoints.
+	 *
+	 * @param[in] waypoint_A Waypoint A (segment start) position in WGS84 coordinates
+	 *            (lat,lon) [deg]
+	 * @param[in] waypoint_B Waypoint B (segment end) position in WGS84 coordinates
+	 *            (lat,lon) [deg]
+	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigateWaypoints(const matrix::Vector2f &waypoint_A, const matrix::Vector2f &waypoint_B,
+			       const matrix::Vector2f &vehicle_pos, const matrix::Vector2f &ground_vel,
+			       const matrix::Vector2f &wind_vel);
+
+	/*
+	 * Loitering (unlimited) logic. Takes loiter center, radius, and direction and
+	 * determines the relevant parameters for evaluating the NPFG guidance law,
+	 * then updates control setpoints.
+	 *
+	 * @param[in] loiter_center The position of the center of the loiter circle [m]
+	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] radius Loiter radius [m]
+	 * @param[in] loiter_direction_counter_clockwise Specifies loiter direction
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigateLoiter(const matrix::Vector2f &loiter_center, const matrix::Vector2f &vehicle_pos,
+			    float radius, bool loiter_direction_counter_clockwise, const matrix::Vector2f &ground_vel,
+			    const matrix::Vector2f &wind_vel);
+
+	/*
+	 * Path following logic. Takes poisiton, path tangent, curvature and
+	 * then updates control setpoints to follow a path setpoint.
+	 *
+	 * @param[in] vehicle_pos vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] position_setpoint closest point on a path in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] tangent_setpoint unit tangent vector of the path [m]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 * @param[in] curvature of the path setpoint [1/m]
+	 */
+	void navigatePathTangent(const matrix::Vector2f &vehicle_pos, const matrix::Vector2f &position_setpoint,
+				 const matrix::Vector2f &tangent_setpoint,
+				 const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature);
+
+	/*
+	 * Navigate on a fixed bearing.
+	 *
+	 * This only holds a certain (ground relative) direction and does not perform
+	 * cross track correction. Helpful for semi-autonomous modes. Similar to navigateHeading.
+	 *
+	 * @param[in] vehicle_pos vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] bearing Bearing angle [rad]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigateBearing(const matrix::Vector2f &vehicle_pos, float bearing, const matrix::Vector2f &ground_vel,
+			     const matrix::Vector2f &wind_vel);
 
 	DEFINE_PARAMETERS(
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Rearranged the interaction between the FwPosController and npfg. the guidance logic should not be concerned with the waypoint triplets directly. The FwPosController converts the triplets into a path setpoint which is fed into the npfg navigation logic. This is part of separating the npfg into smaller controllers with cleaner API.

### Solution
- Move the navigateXX function into the FwPosController. They are responsible to convert the setpoint triplets into a path setpoint.
- Update the npfg to only rely on one single navigatePath input function, which is used to navigate to the desired path.

### Test coverage
- Tested in SImulation using the standard_vtol gazebo simulation.

### Context
Related links, screenshot before/after, video
