### PR TITLE
Improve forwarding of mavlink messages.

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -479,7 +479,7 @@ Mavlink::forward_message(const mavlink_message_t *msg, Mavlink *self)
 		if (inst && (inst != self) && (inst->_forwarding_on)) {
 			// Pass message only if target component was seen before
 			if (inst->_receiver.component_was_seen(target_system_id, target_component_id)) {
-				inst->pass_message(msg);
+				inst->resend_message(msg);
 			}
 		}
 	}

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -345,7 +345,7 @@ public:
 	/**
 	 * Resend message as is, don't change sequence number and CRC.
 	 */
-	void			resend_message(mavlink_message_t *msg) { _mavlink_resend_uart(_channel, msg); }
+	void			resend_message(const mavlink_message_t *msg) { _mavlink_resend_uart(_channel, msg); }
 
 	void			handle_message(const mavlink_message_t *msg);
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When connecting a Phase One P3 Payload for MAVLink (https://geospatial.phaseone.com/drone-payload/p3-payload-for-drones) to PX4, the MAVLink interface does not forward messages consistently between the GCS and the payload.

### Solution
- Replace `pass_message` by `resend_message` in `Mavlink::forward_message` (`mavlink_main.cpp`)

### Test coverage
- Simulation: `HEADLESS=1 make px4_sitl jmavsim` with `px4-rc.mavlink` from the attachment (forwarding enabled on mavlink for gimbal)

### Context

We monitor the MAVLink traffic using a Python script based on Pymavlink (see `cfwd.py` in the attachment):
* between PX4 SITL and the payload
* between PX4 SITL and QGroundControl

See full logs in the attachment.

#### Before (v1.14.0-beta1)

The camera sends all its 142 parameters to PX4:

**PX4 - Payload**
``` 
...
[2023-02-06 15:58:08,608] > PARAM_REQUEST_LIST {target_system : 1, target_component : 0}
[2023-02-06 15:58:08,613] < PARAM_VALUE {param_id : ACC_OFFSETX, param_value : 0.0, param_type : 9, param_count : 142, param_index : 0}
[2023-02-06 15:58:08,635] < PARAM_VALUE {param_id : ACC_OFFSETY, param_value : 0.0, param_type : 9, param_count : 142, param_index : 1}
[2023-02-06 15:58:08,654] < PARAM_VALUE {param_id : ACC_OFFSETZ, param_value : 0.0, param_type : 9, param_count : 142, param_index : 2}
...
[2023-02-06 15:58:11,434] < PARAM_VALUE {param_id : VERSION_Y, param_value : 7.0, param_type : 9, param_count : 142, param_index : 139}
[2023-02-06 15:58:11,454] < PARAM_VALUE {param_id : VERSION_Z, param_value : 0.0, param_type : 9, param_count : 142, param_index : 140}
...
```

But PX4 skips forwarding some of them:

**PX4 - QGroundControl**
```
...
[2023-02-06 15:58:08,799] > PARAM_VALUE {param_id : AE_SH_SPD_MIN, param_value : 0.0010000000474974513, param_type : 9, param_count : 142, param_index : 9}
[2023-02-06 15:58:08,839] > PARAM_VALUE {param_id : AF_MIN_DIST, param_value : 9.721271514892578, param_type : 9, param_count : 142, param_index : 11}
[2023-02-06 15:58:08,843] > STATUSTEXT {severity : 6, text : Preflight Fail: No manual control input    , id : 2, chunk_seq : 0}
[2023-02-06 15:58:08,860] > PARAM_VALUE {param_id : AF_STRATEGY, param_value : 0.0, param_type : 5, param_count : 142, param_index : 12}
[2023-02-06 15:58:08,879] > PARAM_VALUE {param_id : AF_STRATEGY_THR, param_value : 5.0, param_type : 9, param_count : 142, param_index : 13}
...
```

Then QGroundControl makes some read requests:

**PX4 - QGroundControl**
```
...
[2023-02-06 15:58:11,459] > PARAM_VALUE {param_id : VERSION_Z, param_value : 0.0, param_type : 9, param_count : 142, param_index : 140}
[2023-02-06 15:58:11,478] > PARAM_VALUE {param_id : WHITE_BALANCE, param_value : 0.0, param_type : 1, param_count : 142, param_index : 141}
[2023-02-06 15:58:14,497] < PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 10}
[2023-02-06 15:58:14,497] < PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 60}
[2023-02-06 15:58:14,497] < PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 110}
[2023-02-06 15:58:14,509] > PARAM_VALUE {param_id : AF_MAX_DIST, param_value : 180.0, param_type : 9, param_count : 142, param_index : 10}
[2023-02-06 15:58:17,506] < PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 60}
[2023-02-06 15:58:17,507] < PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 110}
[2023-02-06 15:58:17,523] > PARAM_VALUE {param_id : GMB_PARAM_RFRSH, param_value : 0.0, param_type : 1, param_count : 142, param_index : 60}
[2023-02-06 15:58:20,525] < PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 110}
[2023-02-06 15:58:20,538] > PARAM_VALUE {param_id : RC_LIM_MAX_ROLL, param_value : 40.0, param_type : 9, param_count : 142, param_index : 110}
...
```
But again, PX4 skips forwarding some of them:

**PX4 - Payload**
```
...
[2023-02-06 15:58:11,434] < PARAM_VALUE {param_id : VERSION_Y, param_value : 7.0, param_type : 9, param_count : 142, param_index : 139}
[2023-02-06 15:58:11,454] < PARAM_VALUE {param_id : VERSION_Z, param_value : 0.0, param_type : 9, param_count : 142, param_index : 140}
[2023-02-06 15:58:11,474] < PARAM_VALUE {param_id : WHITE_BALANCE, param_value : 0.0, param_type : 1, param_count : 142, param_index : 141}
[2023-02-06 15:58:14,499] > PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 10}
[2023-02-06 15:58:14,506] < PARAM_VALUE {param_id : AF_MAX_DIST, param_value : 180.0, param_type : 9, param_count : 142, param_index : 10}
[2023-02-06 15:58:17,512] > PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 60}
[2023-02-06 15:58:17,522] < PARAM_VALUE {param_id : GMB_PARAM_RFRSH, param_value : 0.0, param_type : 1, param_count : 142, param_index : 60}
[2023-02-06 15:58:20,528] > PARAM_REQUEST_READ {target_system : 1, target_component : 100, param_id : , param_index : 110}
[2023-02-06 15:58:20,534] < PARAM_VALUE {param_id : RC_LIM_MAX_ROLL, param_value : 40.0, param_type : 9, param_count : 142, param_index : 110}
...
```

Additionally, the camera protocol is not initiated and the Camera UI does not get displayed in QGroundControl:

![qgc](https://user-images.githubusercontent.com/8792838/217014277-b1b82160-61e9-4f78-800d-5450d865c14d.png)

#### After (pr-improve-mavlink-msg-forwarding)

The camera sends all its 142 parameters to PX4:

**PX4 - Payload**
```
...
[2023-02-06 16:08:45,937] > PARAM_REQUEST_LIST {target_system : 1, target_component : 0}
[2023-02-06 16:08:45,956] < PARAM_VALUE {param_id : ACC_OFFSETX, param_value : 0.0, param_type : 9, param_count : 142, param_index : 0}
[2023-02-06 16:08:45,976] < PARAM_VALUE {param_id : ACC_OFFSETY, param_value : 0.0, param_type : 9, param_count : 142, param_index : 1}
...
[2023-02-06 16:08:48,798] < PARAM_VALUE {param_id : VERSION_Z, param_value : 0.0, param_type : 9, param_count : 142, param_index : 140}
[2023-02-06 16:08:48,819] < PARAM_VALUE {param_id : WHITE_BALANCE, param_value : 0.0, param_type : 1, param_count : 142, param_index : 141}
...
```

And PX4 forwards them all to QGroundControl:

**PX4 - QGroundControl**
```
...
[2023-02-06 16:08:45,936] < PARAM_REQUEST_LIST {target_system : 1, target_component : 0}
...
[2023-02-06 16:08:45,972] > PARAM_VALUE {param_id : ACC_OFFSETX, param_value : 0.0, param_type : 9, param_count : 142, param_index : 0}
[2023-02-06 16:08:46,026] > PARAM_VALUE {param_id : ACC_OFFSETY, param_value : 0.0, param_type : 9, param_count : 142, param_index : 1}
...
[2023-02-06 16:08:48,799] > PARAM_VALUE {param_id : VERSION_Z, param_value : 0.0, param_type : 9, param_count : 142, param_index : 140}
[2023-02-06 16:08:48,823] > PARAM_VALUE {param_id : WHITE_BALANCE, param_value : 0.0, param_type : 1, param_count : 142, param_index : 141}
...
```

Additionally, the camera protocol is initiated:

**PX4 - QGroundControl**
```
...
[2023-02-06 16:08:46,608] > CAMERA_INFORMATION {time_boot_ms : 20209, vendor_name : [80, 104, 97, 115, 101, 79, 110, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,0, 0, 0], model_name : [105, 88, 77, 45, 49, 48, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], firmware_version : 352322821, focal_length : 35.0, sensor_size_h : 43856.640625, sensor_size_v : 32900.0, resolution_h : 11664, resolution_v : 8750, lens_id : 0, flags : 195, cam_definition_version : 25, cam_definition_uri : https://raw.githubusercontent.com/PhaseOnePhoto/MavlinkCameraDefinitionFiles/V25/CameraDefinition_iXM100.xml}
[2023-02-06 16:08:46,609] > PARAM_VALUE {param_id : FLW_SP_PAN, param_value : 100.0, param_type : 9, param_count : 142, param_index : 32}
[2023-02-06 16:08:46,626] > PARAM_VALUE {param_id : FLW_SP_TILT, param_value : 100.0, param_type : 9, param_count : 142, param_index : 33}
[2023-02-06 16:08:46,626] < PARAM_EXT_REQUEST_LIST {target_system : 1, target_component : 100}
[2023-02-06 16:08:46,646] > PARAM_VALUE {param_id : FLW_WD_PAN, param_value : 2.0, param_type : 9, param_count : 142, param_index : 34}
[2023-02-06 16:08:46,647] > PARAM_EXT_VALUE {param_id : CAM_EXPMODE, param_value : , param_type : 5, param_count : 46, param_index : 0}
[2023-02-06 16:08:46,666] > PARAM_VALUE {param_id : FLW_WD_TILT, param_value : 2.0, param_type : 9, param_count : 142, param_index : 35}
[2023-02-06 16:08:46,667] > PARAM_EXT_VALUE {param_id : CAM_ISO, param_value : , param_type : 5, param_count : 46, param_index : 1}
...
[2023-02-06 16:08:47,544] > PARAM_EXT_VALUE {param_id : MASS_STORAGE, param_value : , param_type : 1, param_count : 46, param_index : 44}
[2023-02-06 16:08:47,564] > PARAM_VALUE {param_id : MASS_STORAGE, param_value : 0.0, param_type : 1, param_count : 142, param_index : 79}
[2023-02-06 16:08:47,565] > PARAM_EXT_VALUE {param_id : CUSTOM_INFO, param_value : , param_type : 1, param_count : 46, param_index : 45
...
```

and the Camera UI gets displayed in QGround Control:

![qgc](https://user-images.githubusercontent.com/8792838/217019950-1aa92b0a-1557-4c40-8596-2df38a3dcc63.png)




[pr-improve-mavlink-msg-forwarding.zip](https://github.com/PX4/PX4-Autopilot/files/10673375/pr-improve-mavlink-msg-forwarding.zip)
