### PR TITLE
Qurt px4_info_raw send to apps for display

### DIFF
--- a/platforms/common/include/px4_platform_common/log.h
+++ b/platforms/common/include/px4_platform_common/log.h
@@ -71,7 +71,7 @@ __END_DECLS
  * Messages that should never be filtered or compiled out
  ****************************************************************************/
 #define PX4_INFO(FMT, ...) 	qurt_log(_PX4_LOG_LEVEL_INFO, __FILE__, __LINE__, FMT, ##__VA_ARGS__)
-#define PX4_INFO_RAW(FMT, ...) 	__px4_log_omit(_PX4_LOG_LEVEL_INFO, FMT, ##__VA_ARGS__)
+#define PX4_INFO_RAW(FMT, ...) 	qurt_log_raw(FMT, ##__VA_ARGS__)
 
 #if defined(TRACE_BUILD)
 /****************************************************************************

--- a/platforms/qurt/include/qurt_log.h
+++ b/platforms/qurt/include/qurt_log.h
@@ -57,4 +57,14 @@ static __inline void qurt_log(int level, const char *file, int line,
 	qurt_log_to_apps(level, buf);
 }
 
+static __inline void qurt_log_raw(const char *format, ...)
+{
+	char buf[256];
+	va_list args;
+	va_start(args, format);
+	vsnprintf(buf, sizeof(buf), format, args);
+	va_end(args);
+	qurt_log_to_apps(1, buf);
+}
+
 __END_DECLS


### PR DESCRIPTION

### Solved Problem
Qurt drops PX4_INFO_RAW logs currently. This PR sends them over to the Linux side for display.