### PR TITLE
Qshell static subscription

### DIFF
--- a/src/drivers/qshell/posix/qshell.cpp
+++ b/src/drivers/qshell/posix/qshell.cpp
@@ -47,9 +47,18 @@
 // Static variables
 px4::AppState QShell::appState;
 uint32_t QShell::_current_sequence{0};
+uORB::Subscription* QShell::_qshell_retval_sub{nullptr};
+
 
 int QShell::main(std::vector<std::string> argList)
 {
+	if (_qshell_retval_sub == nullptr) {
+		_qshell_retval_sub = new uORB::Subscription(ORB_ID(qshell_retval));
+		if (_qshell_retval_sub == nullptr) {
+			PX4_ERR("Couldn't initialilze Qshell response subscription");
+		}
+	}
+
 	int ret = _send_cmd(argList);
 
 	if (ret != 0) {
@@ -109,7 +118,7 @@ int QShell::_wait_for_retval()
 	memset(&retval, 0, sizeof(qshell_retval_s));
 
 	while (hrt_elapsed_time(&time_started_us) < QSHELL_RESPONSE_WAIT_TIME_US) {
-		if (_qshell_retval_sub.update(&retval)) {
+		if (_qshell_retval_sub->update(&retval)) {
 			if (retval.return_sequence != _current_sequence) {
 				PX4_WARN("Ignoring return value with wrong sequence");
 

--- a/src/drivers/qshell/posix/qshell.cpp
+++ b/src/drivers/qshell/posix/qshell.cpp
@@ -47,13 +47,14 @@
 // Static variables
 px4::AppState QShell::appState;
 uint32_t QShell::_current_sequence{0};
-uORB::Subscription* QShell::_qshell_retval_sub{nullptr};
+uORB::Subscription *QShell::_qshell_retval_sub{nullptr};
 
 
 int QShell::main(std::vector<std::string> argList)
 {
 	if (_qshell_retval_sub == nullptr) {
 		_qshell_retval_sub = new uORB::Subscription(ORB_ID(qshell_retval));
+
 		if (_qshell_retval_sub == nullptr) {
 			PX4_ERR("Couldn't initialilze Qshell response subscription");
 		}

--- a/src/drivers/qshell/posix/qshell.h
+++ b/src/drivers/qshell/posix/qshell.h
@@ -58,7 +58,7 @@ private:
 
 	uORB::Publication<qshell_req_s>	_qshell_req_pub{ORB_ID(qshell_req)};
 
-	uORB::Subscription		_qshell_retval_sub{ORB_ID(qshell_retval)};
+	static uORB::Subscription*	_qshell_retval_sub;
 
 	static uint32_t			_current_sequence;
 };

--- a/src/drivers/qshell/posix/qshell.h
+++ b/src/drivers/qshell/posix/qshell.h
@@ -58,7 +58,7 @@ private:
 
 	uORB::Publication<qshell_req_s>	_qshell_req_pub{ORB_ID(qshell_req)};
 
-	static uORB::Subscription*	_qshell_retval_sub;
+	static uORB::Subscription	*_qshell_retval_sub;
 
 	static uint32_t			_current_sequence;
 };


### PR DESCRIPTION

### Solved Problem
Qshell instantiates a new instance for each command with a new subscription to the return value topic. This will cause it to see any old topic data until the new one comes in. This PR changes the subscription to be static so that it will not see the old topic data and only see new updated topic information.