### PR TITLE
[BACKPORT v1.13] boards: px4_fmu-v6x add pulldowns to GPIO pins UART7 RTS and UART7 CTS

### DIFF
--- a/boards/px4/fmu-v6x/nuttx-config/include/board.h
+++ b/boards/px4/fmu-v6x/nuttx-config/include/board.h
@@ -387,8 +387,8 @@
 
 #define GPIO_UART7_RX    GPIO_UART7_RX_4    /* PF6  */
 #define GPIO_UART7_TX    GPIO_UART7_TX_3    /* PE8  */
-#define GPIO_UART7_RTS   GPIO_UART7_RTS_2   /* PF8  */
-#define GPIO_UART7_CTS   GPIO_UART7_CTS_1   /* PE10 */
+#define GPIO_UART7_RTS   (GPIO_UART7_RTS_2 | GPIO_PULLDOWN)   /* PF8  */
+#define GPIO_UART7_CTS   (GPIO_UART7_CTS_1 | GPIO_PULLDOWN)   /* PE10 */
 
 #define GPIO_UART8_RX    GPIO_UART8_RX_1    /* PE0 */
 #define GPIO_UART8_TX    GPIO_UART8_TX_1    /* PE1 */


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/pull/20974.