### PR TITLE
microdds-client: fix namespace convention for multi vehicle simulations

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -265,13 +265,10 @@ fi
 navigator start
 
 # Try to start the microdds_client with UDP transport if module exists
-microdds_ns=""
-if [ "$px4_instance" -ne "0" ]
-then
-	# Assign new xrce dds key based on instance number and set default namespace
-	param set XRCE_DDS_KEY ${px4_instance}
-	microdds_ns="-n px4_$px4_instance"
-fi
+# Assign new xrce dds key based on instance number and set default namespace
+# px4_instance must be different form -1 as XRCE_DDS_KEY cannot be zero
+param set XRCE_DDS_KEY $((px4_instance+1))
+microdds_ns="-n px4_$px4_instance"
 if [ -n "$PX4_MICRODDS_NS" ]
 then
 	# Override namespace if environment variable is defined


### PR DESCRIPTION
### Solved Problem
When using [sitl_multiple_run.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gazebo-classic/sitl_multiple_run.sh) to run multi vehicle simulations in gazebo-classic it is not possible to use the microdds bridge as

1. By default, all drones get the same `XRCE_DDS_UDP_PRT=8888` and connect to the same Agent.
2. The first spawned vehicle (`-i 0`) gets `XRCE_DDS_KEY=1` and no additional namespace so its topics are available at `/fmu/*`.
3. The second spawned vehicle (`-i 1`) gets `XRCE_DDS_KEY=1` and the additional namespace `/px4_1/` so its topics are available at `/px4_1/fmu/*`.

But all the `XRCE_DDS_KEY` associated to the same Agent must be different.

Fixes #21085 and #21069.

### Solution
- Adds `/px4_$(px4_instance)/` namespace to all simulation instances.
- Sets `XRCE_DDS_KEY` to `$((px4_instance+1))`.

By doing so

1. The first spawned vehicle (`-i 0`) gets `XRCE_DDS_KEY=1` and and the additional namespace `/px4_0/` so its topics are available at `/px4_0/fmu/*`
2. The second spawned vehicle (`-i 1`) gets `XRCE_DDS_KEY=2` and the additional namespace `/px4_1/` so its topics are available at `/px4_1/fmu/*`
3. And so on


### Alternatives
As
1. This solution requires to change **all ROS2 publishers and subscribers** in the codes that interact with px4 through the microdds bridge as _even for a single vehicle simulation the ros topics names must be updated to the new namespace_.
2. This solution introduces a discrepancy between the default behavior of silt and hardware implementations (hardware implementation still uses the `/fmu/*` namespace convention).

The problem could be solved by **just changing** [sitl_multiple_run.sh](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/simulation/gazebo-classic/sitl_multiple_run.sh) by having the first vehicle with id 1 instead of 0, which would be reserved to single agent simulations.

### Test coverage
- Tested on ubuntu20, gazebo-classic with `sitl_multiple_run.sh`.
- Tested on ubuntu22, gazebo-garden manually spawing the drones as in https://docs.px4.io/main/en/simulation/multi_vehicle_simulation_ignition_gazebo.html .