### PR TITLE
mavlink: fix bug when opening /dev/null as default stdin/stdout/stderr

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1864,20 +1864,30 @@ Mavlink::task_main(int argc, char *argv[])
 	// use default /dev/null so that these numbers are not used by other other files.
 	if (fcntl(0, F_GETFD) == -1) {
 		int tmp = open("/dev/null", O_RDONLY);
-		dup2(tmp, 0);
-		close(tmp);
+
+		if (tmp != 0) {
+			dup2(tmp, 0);
+			close(tmp);
+		}
+
 	}
 
 	if (fcntl(1, F_GETFD) == -1) {
 		int tmp = open("/dev/null", O_WRONLY);
-		dup2(tmp, 1);
-		close(tmp);
+
+		if (tmp != 1) {
+			dup2(tmp, 1);
+			close(tmp);
+		}
 	}
 
 	if (fcntl(2, F_GETFD) == -1) {
 		int tmp = open("/dev/null", O_WRONLY);
-		dup2(tmp, 2);
-		close(tmp);
+
+		if (tmp != 2) {
+			dup2(tmp, 2);
+			close(tmp);
+		}
 	}
 
 	int ch;


### PR DESCRIPTION
Prior commit added opening of /dev/null as 0, 1 and/or 2 file descriptors, if they where not present. However, if the temporary file descriptor used to open /dev/null matched the target file descriptor, it would be immediately closed again. This commit fixes that, and does not duplicate and close the temporary file descriptor if it is already at the correct number.


### Solved Problem
My previous PR #21075 unfortunately have a bug.

Prior PR added opening of /dev/null as 0, 1 and/or 2 file descriptors, if they where not present. However, if the temporary file descriptor used to open /dev/null matched the target file descriptor, it would be immediately closed again.

### Solution
This PR fixes the issue with temporary fd having the target fd number, and does not duplicate and close the temporary file descriptor if it is already at the correct number.

### Alternatives
Revert the original problem and fix it elsewhere.

### Test coverage
Tested on a cube orange with USB connection and TELEM1 connection.

### Context
N/A
