### PR TITLE
FlightTaskAuto: get landing altitude from mission

### DIFF
--- a/msg/PositionSetpoint.msg
+++ b/msg/PositionSetpoint.msg
@@ -6,7 +6,7 @@ uint8 SETPOINT_TYPE_POSITION=0	# position setpoint
 uint8 SETPOINT_TYPE_VELOCITY=1	# velocity setpoint
 uint8 SETPOINT_TYPE_LOITER=2	# loiter setpoint
 uint8 SETPOINT_TYPE_TAKEOFF=3	# takeoff setpoint
-uint8 SETPOINT_TYPE_LAND=4	# land setpoint, altitude must be ignored, descend until landing
+uint8 SETPOINT_TYPE_LAND=4	# land setpoint, altitude must be set to ground level if known, NAN if not, descend until landing
 uint8 SETPOINT_TYPE_IDLE=5	# do nothing, switch off motors or keep at idle speed (MC)
 
 bool valid			# true if setpoint is valid

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -175,6 +175,7 @@ protected:
 					_param_mpc_land_alt2, // altitude at which we descend at land speed
 					(ParamFloat<px4::params::MPC_LAND_ALT3>)
 					_param_mpc_land_alt3, // altitude where we switch to crawl speed, if LIDAR available
+					(ParamInt<px4::params::MPC_LAND_MODE>) _param_mpc_land_mode,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_UP>) _param_mpc_z_v_auto_up,
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn,
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -804,6 +804,27 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_LAND_ALT3, 1.0f);
 
 /**
+ * Land speed when ground level is unknown.
+ *
+ * If the land altitude is not explicitly given,
+ * choose between assuming that the land altitude is the
+ * same as home altitude (default), or descend with either
+ * MPC_LAND_SPEED (to ensure soft landing) or
+ * MPC_Z_V_AUTO_DN (to ensure fast landing)
+ * the entire descent.
+ *
+ * Only valid for auto mode.
+ *
+ * @min 0
+ * @max 2
+ * @value 0 assume home ground level
+ * @value 1 descend with MPC_LAND_SPEED
+ * @value 2 descend with MPC_Z_V_AUTO_DN
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_LAND_MODE, 0);
+
+/**
  * Position control smooth takeoff ramp time constant
  *
  * Increasing this value will make automatic and manual takeoff slower.

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -835,7 +835,7 @@ MissionBlock::set_land_item(struct mission_item_s *item)
 	item->lon = _navigator->get_global_position()->lon;
 	item->yaw = _navigator->get_local_position()->heading;
 
-	item->altitude = 0;
+	item->altitude = NAN;  // Unknown land altitude
 	item->altitude_is_relative = false;
 	item->loiter_radius = _navigator->get_loiter_radius();
 	item->acceptance_radius = _navigator->get_acceptance_radius();


### PR DESCRIPTION
### Solved Problem
RTL and mission landing assumes that ground level is the same as home, even though the correct ground level is given as altitude in the mission item.

Fixes #21086

### Solution
~~Override _evaluateDistanceToGround in FlightTaskAuto, and use mission altitude (in landing mission item only).~~
FlightTaskAuto::_prepareLandSetpoints() will use altitude base one (in prioritised order):
1. Range sensor measurement
2. Altitude from mission item or RP
3. Home altitude*

*In addition, if range sensor or mission/RP altitude is not available, a new parameter `MPC_LAND_MODE` selects if home altitude should be assumed, or if velocity should be set to `MPC_Z_V_AUTO_DN` or `MPC_LAND_SPEED`.

### Alternatives
Probably a few other places to correct for this, at least in _evaluateDistanceToGround in FlightTask, or in FlightTaskAuto.

### Test coverage
Briefly tested in simulator for mission landing, RP landing and commanded landing.
Atm poor coverage, much TODO.

### Context
N/A
