### PR TITLE
drivers: enable IridiumSBD telemetry again

### DIFF
--- a/src/drivers/telemetry/CMakeLists.txt
+++ b/src/drivers/telemetry/CMakeLists.txt
@@ -34,4 +34,4 @@
 add_subdirectory(bst)
 add_subdirectory(frsky_telemetry)
 add_subdirectory(hott)
-#add_subdirectory(iridiumsbd)
+add_subdirectory(iridiumsbd)

--- a/src/drivers/telemetry/Kconfig
+++ b/src/drivers/telemetry/Kconfig
@@ -5,6 +5,7 @@ menu "Telemetry"
         select DRIVERS_TELEMETRY_BST
         select DRIVERS_TELEMETRY_FRSKY_TELEMETRY
         select DRIVERS_TELEMETRY_HOTT
+        select DRIVERS_TELEMETRY_IRIDIUMSBD
         ---help---
             Enable default set of telemetry drivers
     rsource "*/Kconfig"


### PR DESCRIPTION
My reasoning is that it's very confusing if everything is just disabled because there might be more bugs. Everything in PX4 might have bugs with it but by keepign it disabled we won't surface them so they can get fixed. However, by disabling it we cause an hour or more of figering out how to enable it to anyone that does want to try it.

Therefore, my suggestion is to include it again. Of course, it still needs to be actually enabled via param.

Closes #18121.
Related to #17831.

Context #17837.