### PR TITLE
Battery: address two comments from #2242

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -118,8 +118,8 @@ void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 		_current_filter_a.reset(_current_a);
 	}
 
-	// Require minimum voltage toherwise override connected status
-	if (_voltage_filter_v.getState() < 2.1f) {
+	// Require minimum voltage otherwise override connected status
+	if (_voltage_filter_v.getState() < LITHIUM_BATTERY_RECOGNITION_VOLTAGE) {
 		_connected = false;
 	}
 

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -110,6 +110,8 @@ public:
 	void updateAndPublishBatteryStatus(const hrt_abstime &timestamp);
 
 protected:
+	static constexpr float LITHIUM_BATTERY_RECOGNITION_VOLTAGE = 2.1f;
+
 	struct {
 		param_t v_empty;
 		param_t v_charged;


### PR DESCRIPTION
### Solved Problem
When looking back at https://github.com/PX4/PX4-Autopilot/pull/20729 I found that there were some additional comments:
- use a constant instead of a magic number
  addresses https://github.com/PX4/PX4-Autopilot/pull/20729#discussion_r1057367977
- fix code comment typo
   addresses https://github.com/PX4/PX4-Autopilot/pull/20729#discussion_r1057368047

### Test coverage
Should not change functionality.