### PR TITLE
drivers/imu/bosch/bmi088: add more time between configure and FIFO_READ

### DIFF
--- a/src/drivers/imu/bosch/bmi088/BMI088.hpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088.hpp
@@ -73,6 +73,7 @@ protected:
 		RESET,
 		WAIT_FOR_RESET,
 		CONFIGURE,
+		FIFO_RESET,
 		FIFO_READ,
 	} _state{STATE::RESET};
 

--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -120,6 +120,7 @@ void BMI088_Accelerometer::RunImpl()
 	case STATE::RESET:
 		// ACC_SOFTRESET: Writing a value of 0xB6 to this register resets the sensor
 		RegisterWrite(Register::ACC_SOFTRESET, 0xB6);
+		DataReadyInterruptDisable();
 		_reset_timestamp = now;
 		_failure_count = 0;
 		_state = STATE::WAIT_FOR_RESET;
@@ -152,21 +153,9 @@ void BMI088_Accelerometer::RunImpl()
 
 	case STATE::CONFIGURE:
 		if (Configure()) {
-			// if configure succeeded then start reading from FIFO
-			_state = STATE::FIFO_READ;
-
-			if (DataReadyInterruptConfigure()) {
-				_data_ready_interrupt_enabled = true;
-
-				// backup schedule as a watchdog timeout
-				ScheduleDelayed(100_ms);
-
-			} else {
-				_data_ready_interrupt_enabled = false;
-				ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
-			}
-
-			FIFOReset();
+			// if configure succeeded then reset the FIFO
+			_state = STATE::FIFO_RESET;
+			ScheduleDelayed(1_ms);
 
 		} else {
 			// CONFIGURE not complete
@@ -179,6 +168,25 @@ void BMI088_Accelerometer::RunImpl()
 			}
 
 			ScheduleDelayed(100_ms);
+		}
+
+		break;
+
+	case STATE::FIFO_RESET:
+		// if configure succeeded then start reading from FIFO
+		_state = STATE::FIFO_READ;
+
+		FIFOReset();
+
+		if (DataReadyInterruptConfigure()) {
+			_data_ready_interrupt_enabled = true;
+
+			// backup schedule as a watchdog timeout
+			ScheduleDelayed(100_ms);
+
+		} else {
+			_data_ready_interrupt_enabled = false;
+			ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
 		}
 
 		break;

--- a/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Accelerometer.cpp
@@ -155,7 +155,7 @@ void BMI088_Accelerometer::RunImpl()
 		if (Configure()) {
 			// if configure succeeded then reset the FIFO
 			_state = STATE::FIFO_RESET;
-			ScheduleDelayed(1_ms);
+			ScheduleDelayed(10_ms);
 
 		} else {
 			// CONFIGURE not complete

--- a/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020-2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,6 +102,7 @@ void BMI088_Gyroscope::RunImpl()
 		// GYRO_SOFTRESET: Writing a value of 0xB6 to this register resets the sensor.
 		// Following a delay of 30 ms, all configuration settings are overwritten with their reset value.
 		RegisterWrite(Register::GYRO_SOFTRESET, 0xB6);
+		DataReadyInterruptDisable();
 		_reset_timestamp = now;
 		_failure_count = 0;
 		_state = STATE::WAIT_FOR_RESET;
@@ -112,7 +113,7 @@ void BMI088_Gyroscope::RunImpl()
 		if ((RegisterRead(Register::GYRO_CHIP_ID) == ID)) {
 			// if reset succeeded then configure
 			_state = STATE::CONFIGURE;
-			ScheduleDelayed(1_ms);
+			ScheduleDelayed(10_ms);
 
 		} else {
 			// RESET not complete
@@ -131,21 +132,9 @@ void BMI088_Gyroscope::RunImpl()
 
 	case STATE::CONFIGURE:
 		if (Configure()) {
-			// if configure succeeded then start reading from FIFO
-			_state = STATE::FIFO_READ;
-
-			if (DataReadyInterruptConfigure()) {
-				_data_ready_interrupt_enabled = true;
-
-				// backup schedule as a watchdog timeout
-				ScheduleDelayed(100_ms);
-
-			} else {
-				_data_ready_interrupt_enabled = false;
-				ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
-			}
-
-			FIFOReset();
+			// if configure succeeded then reset the FIFO
+			_state = STATE::FIFO_RESET;
+			ScheduleDelayed(1_ms);
 
 		} else {
 			// CONFIGURE not complete
@@ -158,6 +147,25 @@ void BMI088_Gyroscope::RunImpl()
 			}
 
 			ScheduleDelayed(100_ms);
+		}
+
+		break;
+
+	case STATE::FIFO_RESET:
+		// if configure succeeded then start reading from FIFO
+		_state = STATE::FIFO_READ;
+
+		FIFOReset();
+
+		if (DataReadyInterruptConfigure()) {
+			_data_ready_interrupt_enabled = true;
+
+			// backup schedule as a watchdog timeout
+			ScheduleDelayed(100_ms);
+
+		} else {
+			_data_ready_interrupt_enabled = false;
+			ScheduleOnInterval(_fifo_empty_interval_us, _fifo_empty_interval_us);
 		}
 
 		break;

--- a/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.cpp
+++ b/src/drivers/imu/bosch/bmi088/BMI088_Gyroscope.cpp
@@ -134,7 +134,7 @@ void BMI088_Gyroscope::RunImpl()
 		if (Configure()) {
 			// if configure succeeded then reset the FIFO
 			_state = STATE::FIFO_RESET;
-			ScheduleDelayed(1_ms);
+			ScheduleDelayed(10_ms);
 
 		} else {
 			// CONFIGURE not complete


### PR DESCRIPTION
 - new FIFO_RESET state used to give the sensor more time after successful configuration before sampling begins

