### PR TITLE
Add indicated airspeed to uavcannode

### DIFF
--- a/src/drivers/uavcannode/Kconfig
+++ b/src/drivers/uavcannode/Kconfig
@@ -37,6 +37,10 @@ if DRIVERS_UAVCANNODE
         bool "Include hygrometer measurement"
         default n
 
+    config UAVCANNODE_INDICATED_AIR_SPEED
+        bool "Include Indicated Airspeed"
+        default n
+
     config UAVCANNODE_LIGHTS_COMMAND
         bool "Include lights command"
         default n

--- a/src/drivers/uavcannode/Publishers/IndicatedAirspeed.hpp
+++ b/src/drivers/uavcannode/Publishers/IndicatedAirspeed.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/uavcannode/Publishers/IndicatedAirspeed.hpp
+++ b/src/drivers/uavcannode/Publishers/IndicatedAirspeed.hpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "UavcanPublisherBase.hpp"
+
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/airspeed.h>
+#include <uavcan/equipment/air_data/IndicatedAirspeed.hpp>
+
+namespace uavcannode
+{
+
+class IndicatedAirspeed : public UavcanPublisherBase,
+	public uORB::SubscriptionCallbackWorkItem,
+	private uavcan::Publisher <
+	uavcan::equipment::air_data::IndicatedAirspeed >
+{
+public:
+	IndicatedAirspeed(px4::WorkItem *work_item, uavcan::INode &node)
+		: UavcanPublisherBase(
+			  uavcan::equipment::air_data::IndicatedAirspeed::DefaultDataTypeID),
+		  uORB::SubscriptionCallbackWorkItem(work_item, ORB_ID(airspeed)),
+		  uavcan::Publisher<uavcan::equipment::air_data::IndicatedAirspeed>(
+			  node)
+	{
+		this->setPriority(uavcan::TransferPriority::OneLowerThanHighest);
+	}
+
+	void PrintInfo() override
+	{
+		if (uORB::SubscriptionCallbackWorkItem::advertised()) {
+			printf(
+				"\t%s -> %s:%d\n",
+				uORB::SubscriptionCallbackWorkItem::get_topic()->o_name,
+				uavcan::equipment::air_data::IndicatedAirspeed::getDataTypeFullName(),
+				uavcan::equipment::air_data::IndicatedAirspeed::DefaultDataTypeID);
+		}
+	}
+
+	void BroadcastAnyUpdates() override
+	{
+
+		// airspeed -> uavcan::equipment::air_data::IndicatedAirspeed
+
+		airspeed_s airspeed_m;
+
+		if (uORB::SubscriptionCallbackWorkItem::update(&airspeed_m)) {
+			uavcan::equipment::air_data::IndicatedAirspeed indicated_as{};
+
+			indicated_as.indicated_airspeed = airspeed_m.indicated_airspeed_m_s;
+			uavcan::Publisher<uavcan::equipment::air_data::IndicatedAirspeed>::
+			broadcast(indicated_as);
+
+			// ensure callback is registered
+			uORB::SubscriptionCallbackWorkItem::registerCallback();
+		}
+	}
+};
+} // namespace uavcannode

--- a/src/drivers/uavcannode/UavcanNode.cpp
+++ b/src/drivers/uavcannode/UavcanNode.cpp
@@ -33,8 +33,8 @@
 
 #include "UavcanNode.hpp"
 
-#include "boot_alt_app_shared.h"
 #include "boot_app_shared.h"
+#include "boot_alt_app_shared.h"
 
 #include <drivers/drv_watchdog.h>
 #include <lib/geo/geo.h>
@@ -61,13 +61,13 @@
 #include "Publishers/GnssAuxiliary.hpp"
 #endif // CONFIG_UAVCANNODE_GNSS_FIX
 
-#if defined(CONFIG_UAVCANNODE_MAGNETIC_FIELD_STRENGTH)
-#include "Publishers/MagneticFieldStrength2.hpp"
-#endif // CONFIG_UAVCANNODE_MAGNETIC_FIELD_STRENGTH
-
 #if defined(CONFIG_UAVCANNODE_INDICATED_AIR_SPEED)
 #include "Publishers/IndicatedAirspeed.hpp"
 #endif // CONFIG_UAVCANNODE_INDICATED_AIR_SPEED
+
+#if defined(CONFIG_UAVCANNODE_MAGNETIC_FIELD_STRENGTH)
+#include "Publishers/MagneticFieldStrength2.hpp"
+#endif // CONFIG_UAVCANNODE_MAGNETIC_FIELD_STRENGTH
 
 #if defined(CONFIG_UAVCANNODE_RANGE_SENSOR_MEASUREMENT)
 #include "Publishers/RangeSensorMeasurement.hpp"
@@ -122,6 +122,8 @@ using namespace time_literals;
 namespace uavcannode
 {
 
+
+
 /**
  * @file uavcan_main.cpp
  *
@@ -137,18 +139,18 @@ namespace uavcannode
  * the application image's descriptor so that the
  * uavcan bootloader has the ability to validate the
  * image crc, size etc of this application
- */
+*/
 boot_app_shared_section app_descriptor_t AppDescriptor = {
 	.signature = APP_DESCRIPTOR_SIGNATURE,
 	{
 		0,
 	},
 	.image_size = 0,
-	.git_hash = 0,
+	.git_hash  = 0,
 	.major_version = APP_VERSION_MAJOR,
 	.minor_version = APP_VERSION_MINOR,
 	.board_id = HW_VERSION_MAJOR << 8 | HW_VERSION_MINOR,
-	.reserved = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	.reserved = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff }
 };
 
 UavcanNode *UavcanNode::_instance;
@@ -234,24 +236,21 @@ int UavcanNode::start(uavcan::NodeID node_id, uint32_t bitrate)
 
 		_can = new CanInitHelper();
 
-		if (_can ==
-		    nullptr) { // We don't have exceptions so bad_alloc cannot be thrown
+		if (_can == nullptr) {                    // We don't have exceptions so bad_alloc cannot be thrown
 			PX4_ERR("Out of memory");
 			return -1;
 		}
 	}
 
 	// Node init
-	_instance = new UavcanNode(_can, bitrate, _can->driver,
-				   UAVCAN_DRIVER::SystemClock::instance());
+	_instance = new UavcanNode(_can, bitrate, _can->driver, UAVCAN_DRIVER::SystemClock::instance());
 
 	if (_instance == nullptr) {
 		PX4_ERR("Out of memory");
 		return -1;
 	}
 
-	const int node_init_res =
-		_instance->init(node_id, _can->driver.updateEvent());
+	const int node_init_res = _instance->init(node_id, _can->driver.updateEvent());
 
 	if (node_init_res < 0) {
 		delete _instance;
@@ -273,8 +272,7 @@ void UavcanNode::fill_node_info()
 	// software version
 	uavcan::protocol::SoftwareVersion swver;
 
-	// Extracting the first 8 hex digits of the git hash and converting them to
-	// int
+	// Extracting the first 8 hex digits of the git hash and converting them to int
 	char fw_git_short[9] = {};
 	std::memmove(fw_git_short, px4_firmware_version_string(), 8);
 	char *end = nullptr;
@@ -306,11 +304,8 @@ static void cb_reboot(const uavcan::TimerEvent &)
 	board_reset(0);
 }
 
-void UavcanNode::cb_beginfirmware_update(
-	const uavcan::ReceivedDataStructure <
-	UavcanNode::BeginFirmwareUpdate::Request > &req,
-	uavcan::ServiceResponseDataStructure <
-	UavcanNode::BeginFirmwareUpdate::Response > &rsp)
+void UavcanNode::cb_beginfirmware_update(const uavcan::ReceivedDataStructure<UavcanNode::BeginFirmwareUpdate::Request>
+		&req, uavcan::ServiceResponseDataStructure<UavcanNode::BeginFirmwareUpdate::Response> &rsp)
 {
 	static bool inprogress = false;
 
@@ -327,9 +322,7 @@ void UavcanNode::cb_beginfirmware_update(
 				bootloader_alt_app_shared_t shared_alt{0};
 				shared_alt.fw_server_node_id = req.source_node_id;
 				shared_alt.node_id = _node.getNodeID().get();
-				strncat((char *)shared_alt.path,
-					(const char *)req.image_file_remote_path.path.c_str(),
-					sizeof(shared_alt.path) - 1);
+				strncat((char *)shared_alt.path, (const char *)req.image_file_remote_path.path.c_str(), sizeof(shared_alt.path) - 1);
 				bootloader_alt_app_shared_write(&shared_alt);
 				board_configure_reset(BOARD_RESET_MODE_CAN_BL, shared_alt.node_id);
 			}
@@ -340,17 +333,15 @@ void UavcanNode::cb_beginfirmware_update(
 			shared.bus_speed = active_bitrate;
 			shared.node_id = _node.getNodeID().get();
 			bootloader_app_shared_write(&shared, App);
-			// rgb_led(255, 128, 0, 5);
+			//rgb_led(255, 128, 0, 5);
 			_reset_timer.setCallback(cb_reboot);
-			_reset_timer.startOneShotWithDelay(
-				uavcan::MonotonicDuration::fromMSec(1000));
+			_reset_timer.startOneShotWithDelay(uavcan::MonotonicDuration::fromMSec(1000));
 			rsp.error = rsp.ERROR_OK;
 		}
 	}
 }
 
-int UavcanNode::init(uavcan::NodeID node_id,
-		     UAVCAN_DRIVER::BusEvent &bus_events)
+int UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 {
 	_node.setName(HW_UAVCAN_NAME);
 
@@ -362,8 +353,7 @@ int UavcanNode::init(uavcan::NodeID node_id,
 
 	fill_node_info();
 
-	if (_fw_update_listner.start(BeginFirmwareUpdateCallBack(
-					     this, &UavcanNode::cb_beginfirmware_update)) < 0) {
+	if (_fw_update_listner.start(BeginFirmwareUpdateCallBack(this, &UavcanNode::cb_beginfirmware_update)) < 0) {
 		PX4_ERR("firmware update listener start failed");
 		return PX4_ERROR;
 	}
@@ -393,10 +383,6 @@ int UavcanNode::init(uavcan::NodeID node_id,
 	_publisher_list.add(new MagneticFieldStrength2(this, _node));
 #endif // CONFIG_UAVCANNODE_MAGNETIC_FIELD_STRENGTH
 
-#if defined(CONFIG_UAVCANNODE_INDICATED_AIR_SPEED)
-	_publisher_list.add(new IndicatedAirspeed(this, _node));
-#endif // CONFIG_UAVCANNODE_INDICATED_AIR_SPEED
-	//
 #if defined(CONFIG_UAVCANNODE_RANGE_SENSOR_MEASUREMENT)
 	_publisher_list.add(new RangeSensorMeasurement(this, _node));
 #endif // CONFIG_UAVCANNODE_RANGE_SENSOR_MEASUREMENT
@@ -477,12 +463,11 @@ int UavcanNode::init(uavcan::NodeID node_id,
 }
 
 // Restart handler
-class RestartRequestHandler : public uavcan::IRestartRequestHandler
+class RestartRequestHandler: public uavcan::IRestartRequestHandler
 {
 	bool handleRestartRequest(uavcan::NodeID request_source) override
 	{
-		PX4_INFO("UAVCAN: Restarting by request from %i\n",
-			 int(request_source.get()));
+		PX4_INFO("UAVCAN: Restarting by request from %i\n", int(request_source.get()));
 		usleep(20 * 1000 * 1000);
 		board_reset(0);
 		return true; // Will never be executed BTW
@@ -491,7 +476,7 @@ class RestartRequestHandler : public uavcan::IRestartRequestHandler
 
 void UavcanNode::Run()
 {
-	static hrt_abstime up_time{0};
+	static  hrt_abstime up_time{0};
 	pthread_mutex_lock(&_node_mutex);
 
 	// Bootloader started it.
@@ -543,6 +528,7 @@ void UavcanNode::Run()
 
 		if (_dyn_node_id_client.isAllocationComplete()) {
 			PX4_INFO("Got node ID %d", _dyn_node_id_client.getAllocatedNodeID().get());
+
 			_node.setNodeID(_dyn_node_id_client.getAllocatedNodeID());
 			_init_state = Allocated;
 		}
@@ -609,8 +595,7 @@ void UavcanNode::Run()
 						// copy [MODULE_NAME] to source
 						memcpy(source, &log_message.text[1], i - 1);
 						// copy remaining text (skipping space after [])
-						memcpy(text, &log_message.text[i + 2],
-						       math::min(sizeof(log_message.text) - (i + 2), sizeof(text)));
+						memcpy(text, &log_message.text[i + 2], math::min(sizeof(log_message.text) - (i + 2), sizeof(text)));
 
 						text_copied = true;
 					}
@@ -688,8 +673,7 @@ void UavcanNode::PrintInfo()
 	// Memory status
 	printf("Pool allocator status:\n");
 	printf("\tCapacity hard/soft: %u/%u blocks\n",
-	       _pool_allocator.getBlockCapacityHardLimit(),
-	       _pool_allocator.getBlockCapacity());
+	       _pool_allocator.getBlockCapacityHardLimit(), _pool_allocator.getBlockCapacity());
 	printf("\tReserved:  %u blocks\n", _pool_allocator.getNumReservedBlocks());
 	printf("\tAllocated: %u blocks\n", _pool_allocator.getNumAllocatedBlocks());
 
@@ -698,28 +682,20 @@ void UavcanNode::PrintInfo()
 	// UAVCAN node perfcounters
 	printf("UAVCAN node status:\n");
 	printf("\tInternal failures: %llu\n", _node.getInternalFailureCount());
-	printf("\tTransfer errors:   %llu\n",
-	       _node.getDispatcher().getTransferPerfCounter().getErrorCount());
-	printf("\tRX transfers:      %llu\n",
-	       _node.getDispatcher().getTransferPerfCounter().getRxTransferCount());
-	printf("\tTX transfers:      %llu\n",
-	       _node.getDispatcher().getTransferPerfCounter().getTxTransferCount());
+	printf("\tTransfer errors:   %llu\n", _node.getDispatcher().getTransferPerfCounter().getErrorCount());
+	printf("\tRX transfers:      %llu\n", _node.getDispatcher().getTransferPerfCounter().getRxTransferCount());
+	printf("\tTX transfers:      %llu\n", _node.getDispatcher().getTransferPerfCounter().getTxTransferCount());
 
 	printf("\n");
 
 	// CAN driver status
-	for (unsigned i = 0;
-	     i <
-	     _node.getDispatcher().getCanIOManager().getCanDriver().getNumIfaces();
-	     i++) {
+	for (unsigned i = 0; i < _node.getDispatcher().getCanIOManager().getCanDriver().getNumIfaces(); i++) {
 		printf("CAN%u status:\n", unsigned(i + 1));
 
-		auto iface =
-			_node.getDispatcher().getCanIOManager().getCanDriver().getIface(i);
+		auto iface = _node.getDispatcher().getCanIOManager().getCanDriver().getIface(i);
 		printf("\tHW errors: %llu\n", iface->getErrorCount());
 
-		auto iface_perf_cnt =
-			_node.getDispatcher().getCanIOManager().getIfacePerfCounters(i);
+		auto iface_perf_cnt = _node.getDispatcher().getCanIOManager().getIfacePerfCounters(i);
 		printf("\tIO errors: %llu\n", iface_perf_cnt.errors);
 		printf("\tRX frames: %llu\n", iface_perf_cnt.frames_rx);
 		printf("\tTX frames: %llu\n", iface_perf_cnt.frames_tx);
@@ -764,7 +740,7 @@ static void print_usage()
 
 extern "C" int uavcannode_start(int argc, char *argv[])
 {
-	// board_app_initialize(nullptr);
+	//board_app_initialize(nullptr);
 
 	// Sarted byt the bootloader, we must pet it
 	watchdog_pet();


### PR DESCRIPTION
Signed-off-by: dirksavage88 <dirksavage88@gmail.com>

Add indicated airspeed in order to use dronecan airspeed sensors in uavcannode. 

Sensors by default only publish to raw air data (differential pressure, static press., static temp). Adding indicated airspeed and thus having the sensors module on a dronecan node allows distributed airspeed sensor measurements. 

Existing solutions: problematic i2c cable runs, comm errors plagued these sensors in the past: #6314 
 Uavcannode support can help pave a path towards #12237

True airspeed, sideslip, and AoA can also be brought in as they are in the dsdl, however I'm not sure if they should be under separate publishers, as indicated AS publisher is required to calibrate and use the airspeed sensor at a minimum. 

