### PR TITLE
Optionally enable airspeed sim and inject failure

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
@@ -10,6 +10,8 @@ PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
 PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=rc_cessna}
 
+param set-default SENS_EN_ARSPDSIM 1
+
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -11,6 +11,8 @@ PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
 PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=standard_vtol}
 
+param set-default SENS_EN_ARSPDSIM 1
+
 # TODO: Enable motor failure detection when the
 # VTOL no longer reports 0A for all ESCs in SITL
 param set-default FD_ACT_EN 0

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -80,7 +80,10 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; th
 			sensor_baro_sim start
 			sensor_gps_sim start
 			sensor_mag_sim start
-			sensor_airspeed_sim start
+			if param compare -s SENS_EN_ARSPDSIM 1
+			then
+				sensor_airspeed_sim start
+			fi
 
 		else
 			echo "ERROR [init] gz_bridge failed to start"
@@ -94,7 +97,10 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; th
 			sensor_baro_sim start
 			sensor_gps_sim start
 			sensor_mag_sim start
-			sensor_airspeed_sim start
+			if param compare -s SENS_EN_ARSPDSIM 1
+			then
+				sensor_airspeed_sim start
+			fi
 
 		else
 			echo "ERROR [init] gz_bridge failed to start"
@@ -109,7 +115,10 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; th
 			sensor_baro_sim start
 			sensor_gps_sim start
 			sensor_mag_sim start
-			sensor_airspeed_sim start
+			if param compare -s SENS_EN_ARSPDSIM 1
+			then
+				sensor_airspeed_sim start
+			fi
 
 		else
 			echo "ERROR [init] gz_bridge failed to start"

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.cpp
@@ -106,47 +106,49 @@ void SensorAirspeedSim::Run()
 		updateParams();
 	}
 
-	if (_vehicle_local_position_sub.updated() && _vehicle_global_position_sub.updated()
-	    && _vehicle_attitude_sub.updated()) {
+	if (_sim_failure.get() == 0) {
+		if (_vehicle_local_position_sub.updated() && _vehicle_global_position_sub.updated()
+		    && _vehicle_attitude_sub.updated()) {
 
-		vehicle_local_position_s lpos{};
-		_vehicle_local_position_sub.copy(&lpos);
+			vehicle_local_position_s lpos{};
+			_vehicle_local_position_sub.copy(&lpos);
 
-		vehicle_global_position_s gpos{};
-		_vehicle_global_position_sub.copy(&gpos);
+			vehicle_global_position_s gpos{};
+			_vehicle_global_position_sub.copy(&gpos);
 
-		vehicle_attitude_s attitude{};
-		_vehicle_attitude_sub.copy(&attitude);
+			vehicle_attitude_s attitude{};
+			_vehicle_attitude_sub.copy(&attitude);
 
-		Vector3f local_velocity = Vector3f{lpos.vx, lpos.vy, lpos.vz};
-		Vector3f body_velocity = Dcmf{Quatf{attitude.q}} .transpose() * local_velocity;
+			Vector3f local_velocity = Vector3f{lpos.vx, lpos.vy, lpos.vz};
+			Vector3f body_velocity = Dcmf{Quatf{attitude.q}} .transpose() * local_velocity;
 
-		// device id
-		device::Device::DeviceId device_id;
-		device_id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
-		device_id.devid_s.bus = 0;
-		device_id.devid_s.address = 0;
-		device_id.devid_s.devtype = DRV_DIFF_PRESS_DEVTYPE_SIM;
+			// device id
+			device::Device::DeviceId device_id;
+			device_id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_SIMULATION;
+			device_id.devid_s.bus = 0;
+			device_id.devid_s.address = 0;
+			device_id.devid_s.devtype = DRV_DIFF_PRESS_DEVTYPE_SIM;
 
-		const float alt_amsl = gpos.alt;
-		const float temperature_local = TEMPERATURE_MSL - LAPSE_RATE * alt_amsl;
-		const float density_ratio = powf(TEMPERATURE_MSL / temperature_local, 4.256f);
-		const float air_density = AIR_DENSITY_MSL / density_ratio;
+			const float alt_amsl = gpos.alt;
+			const float temperature_local = TEMPERATURE_MSL - LAPSE_RATE * alt_amsl;
+			const float density_ratio = powf(TEMPERATURE_MSL / temperature_local, 4.256f);
+			const float air_density = AIR_DENSITY_MSL / density_ratio;
 
-		// calculate differential pressure + noise in hPa
-		const float diff_pressure_noise = (float)generate_wgn() * 0.01f;
-		float diff_pressure = sign(body_velocity(0)) * 0.005f * air_density  * body_velocity(0) * body_velocity(
-					      0) + diff_pressure_noise;
+			// calculate differential pressure + noise in hPa
+			const float diff_pressure_noise = (float)generate_wgn() * 0.01f;
+			float diff_pressure = sign(body_velocity(0)) * 0.005f * air_density  * body_velocity(0) * body_velocity(
+						      0) + diff_pressure_noise;
 
 
-		differential_pressure_s differential_pressure{};
-		// report.timestamp_sample = time;
-		differential_pressure.device_id = 1377548; // 1377548: DRV_DIFF_PRESS_DEVTYPE_SIM, BUS: 1, ADDR: 5, TYPE: SIMULATION
-		differential_pressure.differential_pressure_pa = (double)diff_pressure * 100.0; // hPa to Pa;
-		differential_pressure.temperature = temperature_local;
-		differential_pressure.timestamp = hrt_absolute_time();
-		_differential_pressure_pub.publish(differential_pressure);
+			differential_pressure_s differential_pressure{};
+			// report.timestamp_sample = time;
+			differential_pressure.device_id = 1377548; // 1377548: DRV_DIFF_PRESS_DEVTYPE_SIM, BUS: 1, ADDR: 5, TYPE: SIMULATION
+			differential_pressure.differential_pressure_pa = (double)diff_pressure * 100.0; // hPa to Pa;
+			differential_pressure.temperature = temperature_local;
+			differential_pressure.timestamp = hrt_absolute_time();
+			_differential_pressure_pub.publish(differential_pressure);
 
+		}
 	}
 
 	perf_end(_loop_perf);

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
+++ b/src/modules/simulation/sensor_airspeed_sim/SensorAirspeedSim.hpp
@@ -89,7 +89,7 @@ private:
 
 	perf_counter_t _loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 
-	// DEFINE_PARAMETERS(
-	// 	(ParamInt<px4::params::SIM_GPS_USED>) _sim_gps_used
-	// )
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::SIM_ARSPD_FAIL>) _sim_failure
+	)
 };

--- a/src/modules/simulation/sensor_airspeed_sim/parameters.c
+++ b/src/modules/simulation/sensor_airspeed_sim/parameters.c
@@ -32,10 +32,13 @@
  ****************************************************************************/
 
 /**
- * simulated GPS number of satellites used
+ * Enable simulated airspeed sensor instance
  *
+ * @reboot_required true
  * @min 0
- * @max  50
- * @group Simulator
- */
-// PARAM_DEFINE_INT32(SIM_GPS_USED, 10);
+ * @max 1
+ * @group Sensors
+ * @value 0 Disabled
+ * @value 1 Enabled
+  */
+PARAM_DEFINE_INT32(SENS_EN_ARSPDSIM, 0);

--- a/src/modules/simulation/sensor_airspeed_sim/parameters.c
+++ b/src/modules/simulation/sensor_airspeed_sim/parameters.c
@@ -42,3 +42,15 @@
  * @value 1 Enabled
   */
 PARAM_DEFINE_INT32(SENS_EN_ARSPDSIM, 0);
+
+/**
+ * Dynamically simulate failure of airspeed sensor instance
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 1
+ * @group Sensors
+ * @value 0 Disabled
+ * @value 1 Enabled
+  */
+PARAM_DEFINE_INT32(SIM_ARSPD_FAIL, 0);

--- a/src/modules/simulation/sensor_airspeed_sim/parameters.c
+++ b/src/modules/simulation/sensor_airspeed_sim/parameters.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This is a follow-up PR of https://github.com/PX4/PX4-Autopilot/pull/21114, where the airspeed sensor was enabled for all vehicles in gz.


### Solution
This PR adds a parameter to optionally enable the module and dynamically turn on and off the sensor publishing
- `SENS_EN_ARSPDSIM`: Enable/disable the simulated airspeed sensor module
- `SIM_ARSPD_FAIL`: Inject failure to the simulated airspeed sensor on runtime

The sensor is now only enabled for `rc_cessna` and `standard_vtol`

### Alternatives
As discussed with @dagar, we could always run the module and check whether `SENS_EN_ARSPDSIM` is true to publish the sensor data. However, I think separating the two use cases explicitly makes a more clear separation of the two use cases.

### Test coverage
Tested with the `standard_vtol`
```
make px4_sitl gz_standard_vtol
```

### Context
- This is a follow-up PR of https://github.com/PX4/PX4-Autopilot/pull/21114, where the airspeed sensor was enabled for all vehicles in gz.
