### PR TITLE
Improve altitude control during transitions for standard VTOLs

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/modules/flight_mode_manager/tasks/Transition/FlightTaskTransition.hpp
@@ -41,12 +41,10 @@
 
 #include "FlightTask.hpp"
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
-#include <uORB/SubscriptionInterval.hpp>
-#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/position_setpoint.h>
 #include <drivers/drv_hrt.h>
 
 using namespace time_literals;
-
 
 class FlightTaskTransition : public FlightTask
 {
@@ -55,19 +53,14 @@ public:
 
 	virtual ~FlightTaskTransition() = default;
 	bool activate(const trajectory_setpoint_s &last_setpoint) override;
+	void reActivate() override;
 	bool updateInitialize() override;
 	bool update() override;
 
 private:
-
 	static constexpr float _vel_z_filter_time_const = 2.0f;
 
-	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	param_t _param_handle_pitch_cruise_degrees{PARAM_INVALID};
-	float _param_pitch_cruise_degrees{0.f};
+	float _start_alt{0.0f};
 
 	AlphaFilter<float> _vel_z_filter;
-
-	void updateParameters();
-
 };

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -944,7 +944,7 @@ FixedwingPositionControl::control_auto(const float control_interval, const Vecto
 	/* Copy thrust and pitch values from tecs */
 	_att_sp.pitch_body = get_tecs_pitch();
 
-	if (!_vehicle_status.in_transition_to_fw) {
+	if (!_vehicle_status.in_transition_mode) {
 		publishLocalPositionSetpoint(current_sp);
 	}
 }
@@ -1618,7 +1618,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 
 	_att_sp.roll_body = constrainRollNearGround(_att_sp.roll_body, _current_altitude, _takeoff_ground_alt);
 
-	if (!_vehicle_status.in_transition_to_fw) {
+	if (!_vehicle_status.in_transition_mode) {
 		publishLocalPositionSetpoint(pos_sp_curr);
 	}
 }
@@ -1876,7 +1876,7 @@ FixedwingPositionControl::control_auto_landing(const hrt_abstime &now, const flo
 	_att_sp.apply_flaps = vehicle_attitude_setpoint_s::FLAPS_LAND;
 	_att_sp.apply_spoilers = vehicle_attitude_setpoint_s::SPOILERS_LAND;
 
-	if (!_vehicle_status.in_transition_to_fw) {
+	if (!_vehicle_status.in_transition_mode) {
 		publishLocalPositionSetpoint(pos_sp_curr);
 	}
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
During transitions (front and back), the altitude tracking is pretty bad and the drone climbs a few meters which can be problematic in some situations. After looking into the code, I realized that during these transitions no more position/velocity setpoint were generated in the FlightTaskTransition module leading to a weaker control of the altitude. Indeed, the MC position controller (used during transitions) can be decomposed into three parts: position (P controller), velocity (PID) and acceleration. If the setpoint for one of these components is NaN, the corresponding part isn't used for the computation of the thrust setpoint.

Fixes #{Github issue ID}

### Solution
An easy solution to this problem would be to generate simple yet meaningful position and velocity setpoints for the controller to be more powerful and better manage the altitude of the drone. What I implemented was:
- just keep in memory the altitude of the drone at the beginning of the transition and set it as the z-position setpoint during the whole event for the altitude to be as constant as possible (the other two dimensions of the setpoint are set to the actual position of the drone since we don't want to influence that part of the control).
- bring slowly the vertical velocity setpoint to 0 using an Alpha filter (also keeping the x and y dimensions equal to the current velocity of the drone for them not to change the control).
I also had to change a part of FixedWingPositionControl to avoid publishing the position setpoint calculated in the module (not used for control) during back transitions since we already had the MC ones that were actually the one used to move the drone (otherwise the setpoints were overwritten and the logs were bad).

### Alternatives
This is a very basic way to improve the control, a possible and more sophisticated one would use the next waypoint to calculate the altitude and vertical velocity setpoints to enable different trajectories (for example diagonal transitions).

### Test coverage
Tested on simulation and on real drones, improved the behavior.

@ThomasRigi 
