### PR TITLE
linux_pwm_out must link mixer_module

### DIFF
--- a/src/drivers/linux_pwm_out/CMakeLists.txt
+++ b/src/drivers/linux_pwm_out/CMakeLists.txt
@@ -40,5 +40,5 @@ px4_add_module(
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS
+		mixer_module
 	)
-


### PR DESCRIPTION
### Solved Problem

When compiling `linux_pwm_out` I got linking errors related to `MixingOutput`:

```
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:348: error: undefined reference to 'MixingOutput::printStatus() const'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:47: error: undefined reference to 'MixingOutput::MixingOutput(char const*, unsigned char, OutputModuleInterface&, MixingOutput::SchedulingPolicy, bool, bool)'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:50: error: undefined reference to 'MixingOutput::setAllMinValues(unsigned short)'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:51: error: undefined reference to 'MixingOutput::setAllMaxValues(unsigned short)'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:322: error: undefined reference to 'MixingOutput::loadMixer(char const*, unsigned int)'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:316: error: undefined reference to 'MixingOutput::resetMixer()'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:142: error: undefined reference to 'MixingOutput::update()'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:154: error: undefined reference to 'MixingOutput::updateSubscriptions(bool, bool)'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:131: error: undefined reference to 'MixingOutput::unregister()'
../../src/drivers/linux_pwm_out/linux_pwm_out.cpp:55: error: undefined reference to 'MixingOutput::~MixingOutput()'
collect2: error: ld returned 1 exit status
```

### Solution

Add `mixer_module` to `DEPENDS`.