### PR TITLE
Navigator: accept yaw immedietaly if the flag heading_good_for_contro…

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -414,7 +414,8 @@ MissionBlock::is_mission_item_reached_or_completed()
 	if (_waypoint_position_reached && !_waypoint_yaw_reached) {
 
 		if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING
-		    && PX4_ISFINITE(_navigator->get_yaw_acceptance(_mission_item.yaw))) {
+		    && PX4_ISFINITE(_navigator->get_yaw_acceptance(_mission_item.yaw))
+		    && _navigator->get_local_position()->heading_good_for_control) {
 
 			const float yaw_err = wrap_pi(_mission_item.yaw - _navigator->get_local_position()->heading);
 


### PR DESCRIPTION

### Solved Problem
Vehicle is stuck at a mission item (eg during RTL) when `local_position.heading_good_for_control` is set to false. MPC in that case sets the vehicle heading setpoint to NAN, which then gets set to current yaw in turn (as NaN would blow up the quaternion). Navigator doesn't know about that, and thus assumes the position not reached until the current yaw is close to the mission_item yaw.

### Solution
Set `_waypoint_yaw_reached` to true immediately if `local_position.heading_good_for_control` is set to false.
 