### PR TITLE
microdds_client: fix -l flag and add -c for custom participant configuration

### DIFF
--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -49,7 +49,7 @@ public:
 	};
 
 	MicroddsClient(Transport transport, const char *device, int baudrate, const char *host, const char *port,
-		       bool localhost_only, const char *client_namespace);
+		       bool localhost_only, bool custom_participant, const char *client_namespace);
 
 	~MicroddsClient();
 
@@ -75,6 +75,7 @@ private:
 	int setBaudrate(int fd, unsigned baud);
 
 	const bool _localhost_only;
+	const bool _custom_participant;
 	const char *_client_namespace;
 
 	SendTopicsSubs *_subs{nullptr};


### PR DESCRIPTION
Allows to use a custom FastDDS configuration on the Agent side.
