### PR TITLE
Logger: watchdog updates

### DIFF
--- a/platforms/common/include/px4_platform_common/tasks.h
+++ b/platforms/common/include/px4_platform_common/tasks.h
@@ -124,6 +124,13 @@ typedef struct {
 // wait for the sensor hub if its data is coming from it.
 #define SCHED_PRIORITY_ESTIMATOR		(PX4_WQ_HP_BASE - 5)
 
+// Logger watchdog priority, triggered when a task busy-loops (and
+// restored after a short time).
+// The priority is a trade-off between:
+// - ability to capture any busy-looping task below this priority
+// - not having a negative impact on the system itself
+#define SCHED_PRIORITY_LOG_WATCHDOG		(PX4_WQ_HP_BASE - 6)
+
 // Position controllers typically are in a blocking wait on estimator data
 // so when new sensor data is available they will run last. Keeping them
 // on a high priority ensures that they are the first process to be run

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -150,11 +150,11 @@ public:
 	 * Indicate to the underlying backend whether future write_message() calls need a reliable
 	 * transfer. Needed for header integrity.
 	 */
-	void set_need_reliable_transfer(bool need_reliable)
+	void set_need_reliable_transfer(bool need_reliable, bool mavlink_backed_too = true)
 	{
 		if (_log_writer_file) { _log_writer_file->set_need_reliable_transfer(need_reliable); }
 
-		if (_log_writer_mavlink) { _log_writer_mavlink->set_need_reliable_transfer(need_reliable); }
+		if (_log_writer_mavlink) { _log_writer_mavlink->set_need_reliable_transfer(need_reliable && mavlink_backed_too); }
 	}
 
 	bool need_reliable_transfer() const

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -369,7 +369,8 @@ void LogWriterFile::run()
 			const hrt_abstime now = hrt_absolute_time();
 
 			/* call fsync periodically to minimize potential loss of data */
-			const bool call_fsync = ++poll_count >= 100 || now - last_fsync > 1_s;
+			const bool call_fsync = ++poll_count >= 100 || now - last_fsync > 1_s || _want_fsync.load();
+			_want_fsync.store(false);
 
 			if (call_fsync) {
 				last_fsync = now;

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -171,6 +171,8 @@ private:
 
 		void close_file();
 
+		void reset();
+
 		size_t get_read_ptr(void **ptr, bool *is_part);
 
 		/**

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -120,6 +120,10 @@ public:
 
 	void set_need_reliable_transfer(bool need_reliable)
 	{
+		if (!need_reliable && _need_reliable_transfer) {
+			_want_fsync.store(true);
+		}
+
 		_need_reliable_transfer = need_reliable;
 	}
 
@@ -210,6 +214,7 @@ private:
 
 	px4::atomic_bool	_exit_thread{false};
 	bool			_need_reliable_transfer{false};
+	px4::atomic_bool	_want_fsync{false};
 	pthread_mutex_t		_mtx;
 	pthread_cond_t		_cv;
 	pthread_t _thread = 0;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1601,6 +1601,8 @@ void Logger::initialize_load_output(PrintLoadReason reason)
 
 void Logger::write_load_output()
 {
+	_writer.set_need_reliable_transfer(true, _print_load_reason != PrintLoadReason::Watchdog);
+
 	if (_print_load_reason == PrintLoadReason::Watchdog) {
 		PX4_ERR("Writing watchdog data"); // this is just that we see it easily in the log
 		write_perf_data(PrintLoadReason::Watchdog);
@@ -1611,7 +1613,6 @@ void Logger::write_load_output()
 	callback_data.logger = this;
 	callback_data.counter = 0;
 	callback_data.buffer = buffer;
-	_writer.set_need_reliable_transfer(true);
 	// TODO: maybe we should restrict the output to a selected backend (eg. when file logging is running
 	// and mavlink log is started, this will be added to the file as well)
 	print_load_buffer(buffer, sizeof(buffer), print_load_callback, &callback_data, &_load);

--- a/src/modules/logger/watchdog.h
+++ b/src/modules/logger/watchdog.h
@@ -52,6 +52,10 @@ struct watchdog_data_t {
 	hrt_abstime ready_to_run_timestamp = hrt_absolute_time();
 	hrt_abstime sem_counter_saturated_start = hrt_absolute_time();
 	uint8_t last_state = TSTATE_TASK_INVALID;
+	int log_writer_priority = 0;
+	int logger_main_priority = 0;
+	hrt_abstime trigger_time = 0; ///< timestamp when it was triggered
+	bool manual_watchdog_trigger = false;
 #endif /* __PX4_NUTTX */
 };
 


### PR DESCRIPTION
- log_writer_file: do not call close() with mutex held 
- reduce boost priority to PX4_WQ_HP_BASE - 6. @dagar we can adjust this after your prio changes.
- add cli command 'trigger_watchdog' to manually trigger watchdog
- add perf counters when triggering watchdog
- reduce top measurement to 300ms
- restore priorities after 1.5s

There are precautions in case the SD card code itself has a busy-loop.

