### PR TITLE
MC attitude reference model

### DIFF
--- a/src/lib/mathlib/math/filter/second_order_reference_model.hpp
+++ b/src/lib/mathlib/math/filter/second_order_reference_model.hpp
@@ -47,7 +47,7 @@
 namespace math
 {
 
-template<typename T>
+template<typename TState, typename T = TState>
 class SecondOrderReferenceModel
 {
 public:
@@ -118,7 +118,7 @@ public:
 	/**
 	 * @return System state [units]
 	 */
-	const T &getState() const { return filter_state_; }
+	const TState &getState() const { return filter_state_; }
 
 	/**
 	 * @return System rate [units/s]
@@ -139,7 +139,7 @@ public:
 	 * @param[in] state_sample New state sample [units]
 	 * @param[in] rate_sample New rate sample, if provided, otherwise defaults to zero(s) [units/s]
 	 */
-	void update(const float time_step, const T &state_sample, const T &rate_sample = T())
+	void update(const float time_step, const TState &state_sample, const T &rate_sample = T())
 	{
 		if ((time_step > max_time_step_) || (time_step < 0.0f)) {
 			// time step is too large or is negative, reset the filter
@@ -164,7 +164,7 @@ public:
 	 * @param[in] state Initial state [units]
 	 * @param[in] rate Initial rate, if provided, otherwise defaults to zero(s) [units/s]
 	 */
-	void reset(const T &state, const T &rate = T())
+	void reset(const TState &state, const T &rate = T())
 	{
 		filter_state_ = state;
 		filter_rate_ = rate;
@@ -188,7 +188,7 @@ private:
 	// cutoff frequency [rad/s]
 	float cutoff_freq_{FLT_EPSILON};
 
-	T filter_state_{}; // [units]
+	TState filter_state_{}; // [units]
 	T filter_rate_{}; // [units/s]
 	T filter_accel_{}; // [units/s^2]
 
@@ -224,7 +224,7 @@ private:
 	 * @param[in] state_sample [units]
 	 * @param[in] rate_sample [units/s]
 	 */
-	void integrateStates(const float time_step, const T &state_sample, const T &rate_sample)
+	void integrateStates(const float time_step, const TState &state_sample, const T &rate_sample)
 	{
 		switch (discretization_method_) {
 		case DiscretizationMethod::kForwardEuler: {
@@ -247,7 +247,7 @@ private:
 	 * @param[in] state_sample [units]
 	 * @param[in] rate_sample [units/s]
 	 */
-	void integrateStatesForwardEuler(const float time_step, const T &state_sample, const T &rate_sample)
+	void integrateStatesForwardEuler(const float time_step, const TState &state_sample, const T &rate_sample)
 	{
 		// general notation for what follows:
 		// c: continuous
@@ -287,7 +287,7 @@ private:
 	 * @param[in] state_sample [units]
 	 * @param[in] rate_sample [units/s]
 	 */
-	void integrateStatesBilinear(const float time_step, const T &state_sample, const T &rate_sample)
+	void integrateStatesBilinear(const float time_step, const TState &state_sample, const T &rate_sample)
 	{
 		const float time_step_squared = time_step * time_step;
 		const float inv_denominator = 1.0f / (0.25f * spring_constant_ * time_step_squared + 0.5f * damping_coefficient_ *
@@ -335,10 +335,10 @@ private:
 	 * @param[in] rate_sample [units/s]
 	 */
 	void transitionStates(const matrix::SquareMatrix<float, 2> &state_matrix,
-			      const matrix::SquareMatrix<float, 2> &input_matrix, const T &state_sample, const T &rate_sample)
+			      const matrix::SquareMatrix<float, 2> &input_matrix, const TState &state_sample, const T &rate_sample)
 	{
-		const T new_state = state_matrix(0, 0) * filter_state_ + state_matrix(0, 1) * filter_rate_ + input_matrix(0,
-				    0) * state_sample + input_matrix(0, 1) * rate_sample;
+		const TState new_state = state_matrix(0, 0) * filter_state_ + state_matrix(0, 1) * filter_rate_ + input_matrix(0,
+					 0) * state_sample + input_matrix(0, 1) * rate_sample;
 		const T new_rate = state_matrix(1, 0) * filter_state_ + state_matrix(1, 1) * filter_rate_ + input_matrix(1,
 				   0) * state_sample + input_matrix(1, 1) * rate_sample;
 		filter_state_ = new_state;
@@ -351,9 +351,9 @@ private:
 	 * @param[in] state_sample [units]
 	 * @param[in] rate_sample [units/s]
 	 */
-	T calculateInstantaneousAcceleration(const T &state_sample, const T &rate_sample) const
+	T calculateInstantaneousAcceleration(const TState &state_sample, const T &rate_sample) const
 	{
-		const T state_error = state_sample - filter_state_;
+		const TState state_error = state_sample - filter_state_;
 		const T rate_error = rate_sample - filter_rate_;
 		return state_error * spring_constant_ + rate_error * damping_coefficient_;
 	}

--- a/src/lib/matrix/matrix/AxisAngle.hpp
+++ b/src/lib/matrix/matrix/AxisAngle.hpp
@@ -71,11 +71,14 @@ public:
 		AxisAngle &v = *this;
 		Type mag = q.imag().norm();
 
+		// Avoid eventual problems due to the double cover of q by taking its canonical form
+		Quaternion<Type> q_c = q.canonical();
+
 		if (std::fabs(mag) >= Type(1e-10)) {
-			v = q.imag() * Type(Type(2) * std::atan2(mag, q(0)) / mag);
+			v = q_c.imag() * Type(Type(2) * std::atan2(mag, q_c(0)) / mag);
 
 		} else {
-			v = q.imag() * Type(Type(2) * Type(sign(q(0))));
+			v = q_c.imag() * Type(Type(2) * Type(sign(q_c(0))));
 		}
 	}
 

--- a/src/lib/matrix/matrix/AxisAngle.hpp
+++ b/src/lib/matrix/matrix/AxisAngle.hpp
@@ -155,6 +155,19 @@ public:
 	{
 		return Vector<Type, 3>::norm();
 	}
+
+	// Perform addition and subtraction on the manifold
+	AxisAngle operator+(const AxisAngle &rhs) const
+	{
+		const AxisAngle &lhs = *this;
+		return AxisAngle(Quaternion<Type>(lhs) * Quaternion<Type>(rhs));
+	}
+
+	AxisAngle operator-(const AxisAngle &rhs) const
+	{
+		const AxisAngle &lhs = *this;
+		return AxisAngle(Quaternion<Type>(rhs).inversed() * Quaternion<Type>(lhs));
+	}
 };
 
 using AxisAnglef = AxisAngle<float>;

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -53,7 +53,7 @@
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_land_detected.h>
-#include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <lib/mathlib/math/filter/second_order_reference_model.hpp>
 
 #include <AttitudeControl.hpp>
 
@@ -118,8 +118,7 @@ private:
 	float _man_yaw_sp{0.f};                 /**< current yaw setpoint in manual mode */
 	float _man_tilt_max;                    /**< maximum tilt allowed for manual flight [rad] */
 
-	AlphaFilter<float> _man_roll_input_filter;
-	AlphaFilter<float> _man_pitch_input_filter;
+	math::SecondOrderReferenceModel<matrix::AxisAnglef, matrix::Vector3f> _attitude_input_filter;
 
 	hrt_abstime _last_run{0};
 	hrt_abstime _last_attitude_setpoint{0};

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -92,7 +92,9 @@ MulticopterAttitudeControl::parameters_updated()
 
 	_man_tilt_max = math::radians(_param_mpc_man_tilt_max.get());
 
-	_attitude_input_filter.setParameters(1.f / (_param_mc_man_tilt_tau.get() * 0.707f), 0.707f);
+	constexpr float damping_ratio = 1.f;
+	const float natural_freq = 1.f / fmaxf(_param_mc_man_tilt_tau.get() * damping_ratio, FLT_EPSILON);
+	_attitude_input_filter.setParameters(natural_freq, damping_ratio);
 }
 
 float


### PR DESCRIPTION
Modify https://github.com/PX4/PX4-Autopilot/pull/19246 to perform attitude filtering.

The state of the reference model can now be an attitude represented by an AxisAngle and the rate is the body rate.
All the linear algebra and operations on the rates and accelerations are directly done in R^3 while the attitude additions and subtractions are performed on the 3-sphere S^3 (i.e.: quaternion group).

The actual final objective is to place that filter as a gate to all incoming attitude setpoints to modify the response of the drone visible from outside the attitude loop, preventing any discontinuities from reaching the attitude loop directly.

We could also imagine a less direct acro mode where the desired angular rates are driving the reference model, enabling the attitude loop to compensate for drift and disturbances.

The reference model could also be extended to have different roll and pitch responses, something that we will need when used on fixed-wings.

TODO:
- [ ] add the rate of the ref model as a feedforward
- [ ] merge https://github.com/PX4/PX4-Autopilot/pull/21240 first to be able to apply filtering on the resulting quaternion correctly