### PR TITLE
Navigator: set _land_start_index to first item with a position after the marker

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -433,11 +433,9 @@ Mission::find_mission_land_start()
 
 		if (missionitem.nav_cmd == NAV_CMD_DO_LAND_START) {
 			found_land_start_marker = true;
-			_land_start_index = i;
 		}
 
-		if (found_land_start_marker && !_land_start_available && i > _land_start_index
-		    && item_contains_position(missionitem)) {
+		if (found_land_start_marker && !_land_start_available && item_contains_position(missionitem)) {
 			// use the position of any waypoint after the land start marker which specifies a position.
 			_landing_start_lat = missionitem.lat;
 			_landing_start_lon = missionitem.lon;
@@ -447,6 +445,7 @@ Mission::find_mission_land_start()
 						  && fabsf(missionitem.loiter_radius) > FLT_EPSILON) ? fabsf(missionitem.loiter_radius) :
 						 _navigator->get_loiter_radius();
 			_land_start_available = true;
+			_land_start_index = i; // set it to the first item containing a position after the land start marker was found
 		}
 
 		if (((missionitem.nav_cmd == NAV_CMD_VTOL_LAND) && _navigator->get_vstatus()->is_vtol) ||

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -545,9 +545,9 @@ void Navigator::run()
 
 			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_LAND_START) {
 
-				/* find NAV_CMD_DO_LAND_START in the mission and
-				 * use MAV_CMD_MISSION_START to start the mission there
-				 */
+				// find NAV_CMD_DO_LAND_START in the mission and
+				// use MAV_CMD_MISSION_START to start the mission from the next item containing a position setpoint
+
 				if (_mission.land_start()) {
 					vehicle_command_s vcmd = {};
 					vcmd.command = vehicle_command_s::VEHICLE_CMD_MISSION_START;


### PR DESCRIPTION

### Solved Problem
At the start of a RTL using a mission landing, `position setpoint.type` is IDLE, and valid=false, thus FW position controller switch to `FW_POSCTRL_MODE_OTHER` which sets `_tecs.reset_state()`;
![image](https://user-images.githubusercontent.com/26798987/219685222-daee32dc-527b-4af0-b9ff-ea68767bc969.png)


### Solution
_land_start_index is used to to start the mission from this item index, and to avoid to publish a triplet.current.type=IDLE, we need to fill it with the actual position setpoint that the vehicle should go to at the start of a mission landing.


This was like this ever, but it only surfaced not because previously we didn't do a TECS reset on receiving IDLE setpoints in the FW Position Controller.

