### PR TITLE
Fix reported FRAM issue

### DIFF
--- a/boards/mro/pixracerpro/src/init.c
+++ b/boards/mro/pixracerpro/src/init.c
@@ -195,5 +195,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio_mediachange(sdio_dev, true);
 #endif /* CONFIG_MMCSD */
 
+	px4_platform_configure();
+
 	return OK;
 }


### PR DESCRIPTION
Fixes non-working FRAM module - now you will be able to save parameters even if not inserting an SD card.

Compared folder to CZ OEM and found out a config function was missing at init.c
Tested with current revision D, however I would appreciate if you help me verify.
