### PR TITLE
Configure FRAM for PixracerPro

### DIFF
--- a/boards/mro/pixracerpro/src/init.c
+++ b/boards/mro/pixracerpro/src/init.c
@@ -195,5 +195,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	sdio_mediachange(sdio_dev, true);
 #endif /* CONFIG_MMCSD */
 
+	px4_platform_configure();
+
 	return OK;
 }


### PR DESCRIPTION
Corresponding PR to v1.13.x branch
Enable FRAM for mRo PixracerPro.