### PR TITLE
VScode: fix tasks.json and launch_sitl.json after ign -> gazebo renaming

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -170,7 +170,7 @@
             ]
         },
         {
-            "label": "ign gazebo",
+            "label": "gazebo",
             "type": "shell",
             "options": {
                 "cwd": "${workspaceFolder}",
@@ -178,7 +178,7 @@
                     "IGN_GAZEBO_RESOURCE_PATH": "${workspaceFolder}/Tools/simulation/gz/models",
                 }
             },
-            "command": "ign gazebo -v 4 -r ${workspaceFolder}/Tools/simulation/gz/worlds/${input:gzWorld}.sdf",
+            "command": "gz sim -v 4 -r ${workspaceFolder}/Tools/simulation/gz/worlds/${input:gzWorld}.sdf",
             "isBackground": true,
             "presentation": {
                 "echo": true,
@@ -191,7 +191,7 @@
                 "close": false
             },
             "problemMatcher": [],
-            "dependsOn":["ign gazebo kill"]
+            "dependsOn":["gazebo kill"]
         },
         {
             "label": "gazebo-classic kill",
@@ -211,9 +211,9 @@
             "dependsOn":["px4_sitl_cleanup"]
         },
         {
-            "label": "ign gazebo kill",
+            "label": "gazebo kill",
             "type": "shell",
-            "command": "pkill -9 -f 'ign gazebo' || true",
+            "command": "pkill -9 -f 'gz sim' || true",
             "presentation": {
                 "echo": true,
                 "reveal": "never",

--- a/platforms/posix/Debug/launch_sitl.json.in
+++ b/platforms/posix/Debug/launch_sitl.json.in
@@ -14,11 +14,11 @@
             "environment": [
                 {
                     "name": "PX4_SIM_MODEL",
-                    "value": "${input:PX4_GZ_MODEL}"
+                    "value": "gz_${input:PX4_GZ_MODEL}"
                 }
             ],
             "externalConsole": false,
-            "postDebugTask": "ign gazebo kill",
+            "postDebugTask": "gazebo kill",
             "linux": {
                 "MIMode": "gdb",
                 "externalConsole": false,
@@ -222,6 +222,9 @@
             "description": "GZ vehicle model",
             "options": [
               "x500",
+              "x500_depth",
+              "rc_cessna",
+              "standard_vtol",
             ],
             "default": "x500"
         }


### PR DESCRIPTION
### Solved Problem 1
Since posix airframe are simulator specific, `PX4_SIM_MODEL` and `GZ_SIM_MODEL` are not the same: `PX4_SIM_MODEL=gz_${GZ_SIM_MODEL}`.

`PX4_SIM_MODEL` has two different usages during the startup of the simulation:

1. It is used to look for the right airframe unless `PX4_SYS_AUTOSTART` is defined. In this scenario `PX4_SIM_MODEL` **must** contain the `gz_` prefix.
2. It is used to look for the right gz model unless `GZ_SIM_MODEL` or `GZ_SIM_MODEL_NAME` are defined. In this scenario the prefix is not needed: if it is present it is automatically removed.

In `launch_sitl.json` the prefix was missing and no `PX4_SYS_AUTOSTART` was defined.

### Solution
- Add prefix

### Solved Problem 2
The post debug task was referencing to Ignition Fortress syntax

### Solution
- Update to Gazebo Garden syntax