### PR TITLE
throw launch

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -174,6 +174,8 @@ private:
 
 	void safetyButtonUpdate();
 
+	bool isThrowLaunchInProgress() const;
+
 	void throwLaunchUpdate();
 
 	void vtolStatusUpdate();

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -174,6 +174,8 @@ private:
 
 	void safetyButtonUpdate();
 
+	void throwLaunchUpdate();
+
 	void vtolStatusUpdate();
 
 	void updateTunes();
@@ -199,6 +201,14 @@ private:
 	enum class RcOverrideBits : int32_t {
 		AUTO_MODE_BIT = (1 << 0),
 		OFFBOARD_MODE_BIT = (1 << 1),
+	};
+
+	enum class ThrowLaunchState {
+		DISABLED = 0,
+		IDLE = 1,
+		ARMED = 2,
+		UNSAFE = 3,
+		FLYING = 4
 	};
 
 	/* Decouple update interval and hysteresis counters, all depends on intervals */
@@ -261,7 +271,9 @@ private:
 	bool _arm_tune_played{false};
 	bool _have_taken_off_since_arming{false};
 	bool _status_changed{true};
+	ThrowLaunchState _throw_launch_state{ThrowLaunchState::DISABLED};
 
+	vehicle_local_position_s	_vehicle_local_position{};
 	vehicle_land_detected_s	_vehicle_land_detected{};
 
 	// commander publications
@@ -277,6 +289,7 @@ private:
 	uORB::Subscription					_system_power_sub{ORB_ID(system_power)};
 	uORB::Subscription					_vehicle_command_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription					_vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
+	uORB::Subscription					_vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription					_vtol_vehicle_status_sub{ORB_ID(vtol_vehicle_status)};
 
 	uORB::SubscriptionInterval				_parameter_update_sub{ORB_ID(parameter_update), 1_s};
@@ -328,6 +341,8 @@ private:
 		(ParamInt<px4::params::COM_RC_OVERRIDE>)    _param_com_rc_override,
 		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_takeoff_finished_action,
-		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max
+		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
+		(ParamBool<px4::params::COM_THROW_EN>)      _param_com_throw_en,
+		(ParamFloat<px4::params::COM_THROW_SPEED>)  _param_com_throw_min_speed
 	)
 };

--- a/src/modules/commander/MulticopterThrowLaunch/CMakeLists.txt
+++ b/src/modules/commander/MulticopterThrowLaunch/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015-2023 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,47 +31,6 @@
 #
 ############################################################################
 
-add_subdirectory(Arming)
-add_subdirectory(failsafe)
-add_subdirectory(failure_detector)
-add_subdirectory(HealthAndArmingChecks)
-add_subdirectory(ModeUtil)
-add_subdirectory(MulticopterThrowLaunch)
-
-px4_add_module(
-	MODULE modules__commander
-	MAIN commander
-	COMPILE_FLAGS
-	SRCS
-		accelerometer_calibration.cpp
-		airspeed_calibration.cpp
-		baro_calibration.cpp
-		calibration_routines.cpp
-		Commander.cpp
-		commander_helper.cpp
-		esc_calibration.cpp
-		factory_calibration_storage.cpp
-		gyro_calibration.cpp
-		HomePosition.cpp
-		level_calibration.cpp
-		lm_fit.cpp
-		mag_calibration.cpp
-		rc_calibration.cpp
-		Safety.cpp
-		UserModeIntention.cpp
-		worker_thread.cpp
-	DEPENDS
-		ArmAuthorization
-		circuit_breaker
-		failsafe
-		failure_detector
-		geo
-		health_and_arming_checks
-		hysteresis
-		mode_util
-		MulticopterThrowLaunch
-		sensor_calibration
-		world_magnetic_model
-	)
-
-px4_add_unit_gtest(SRC mag_calibration_test.cpp LINKLIBS modules__commander)
+px4_add_library(MulticopterThrowLaunch
+	MulticopterThrowLaunch.cpp
+)

--- a/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.cpp
+++ b/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.cpp
@@ -43,6 +43,7 @@ void MulticopterThrowLaunch::update(const bool armed)
 	if (_param_com_throw_en.get()) {
 		if (_vehicle_local_position_sub.updated()) {
 			vehicle_local_position_s vehicle_local_position{};
+
 			if (_vehicle_local_position_sub.copy(&vehicle_local_position)) {
 				_last_velocity = matrix::Vector3f(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
 			}

--- a/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.cpp
+++ b/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "MulticopterThrowLaunch.hpp"
+#include <px4_platform_common/events.h>
+
+MulticopterThrowLaunch::MulticopterThrowLaunch(ModuleParams *parent) :
+	ModuleParams(parent)
+{}
+
+void MulticopterThrowLaunch::update(const bool armed)
+{
+	if (_param_com_throw_en.get()) {
+		if (_vehicle_local_position_sub.updated()) {
+			vehicle_local_position_s vehicle_local_position{};
+			if (_vehicle_local_position_sub.copy(&vehicle_local_position)) {
+				_last_velocity = matrix::Vector3f(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
+			}
+		}
+
+		if (!armed && _throw_launch_state != ThrowLaunchState::IDLE) {
+			events::send(events::ID("mc_throw_launch_not_ready"), events::Log::Critical, "Disarmed, don't throw");
+			_throw_launch_state = ThrowLaunchState::IDLE;
+		}
+
+		switch (_throw_launch_state) {
+		case ThrowLaunchState::IDLE:
+			if (armed) {
+				events::send(events::ID("mc_throw_launch_ready"), events::Log::Critical, "Ready for throw launch");
+				_throw_launch_state = ThrowLaunchState::ARMED;
+			}
+
+			break;
+
+		case ThrowLaunchState::ARMED:
+			if (_last_velocity.longerThan(_param_com_throw_min_speed.get())) {
+				PX4_INFO("Throw detected, motors will start once falling");
+				_throw_launch_state = ThrowLaunchState::UNSAFE;
+			}
+
+			break;
+
+		case ThrowLaunchState::UNSAFE:
+			if (_last_velocity(2) > 0.f) {
+				PX4_INFO("Throw and fall detected, starting motors");
+				_throw_launch_state = ThrowLaunchState::FLYING;
+			}
+
+			break;
+
+		case ThrowLaunchState::DISABLED:
+		case ThrowLaunchState::FLYING:
+			// Nothing to do
+			break;
+		}
+
+	} else if (_throw_launch_state != ThrowLaunchState::DISABLED) {
+		// make sure everything is reset when the throw launch is disabled
+		_throw_launch_state = ThrowLaunchState::DISABLED;
+	}
+}

--- a/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.hpp
+++ b/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.hpp
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file MulticopterThrowLaunch.hpp
+ *
+ * Changes to manage a takeoff of a multicopter by manually throwing it into the air.
+ *
+ * @author Michał Barciś <mbarcis@mbarcis.net>
+ */
+
+#pragma once
+
+#include <lib/matrix/matrix/math.hpp>
+#include <px4_platform_common/module_params.h>
+
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/vehicle_local_position.h>
+
+class MulticopterThrowLaunch : public ModuleParams
+{
+public:
+	explicit MulticopterThrowLaunch(ModuleParams *parent);
+	~MulticopterThrowLaunch() override = default;
+
+	/**
+	 * @return false if feature disabled or already flying
+	 */
+	bool isThrowLaunchInProgress() const {
+		return _throw_launch_state != ThrowLaunchState::DISABLED
+			&& _throw_launch_state != ThrowLaunchState::FLYING;
+	}
+
+	bool isReadyToThrow() const { return _throw_launch_state == ThrowLaunchState::ARMED; }
+
+	/**
+	 * Main update of the state
+	 * @param armed true if vehicle is armed
+	 */
+	void update(const bool armed);
+
+	enum class ThrowLaunchState {
+		DISABLED = 0,
+		IDLE = 1,
+		ARMED = 2,
+		UNSAFE = 3,
+		FLYING = 4
+	};
+
+private:
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+
+	ThrowLaunchState _throw_launch_state{ThrowLaunchState::DISABLED};
+	matrix::Vector3f _last_velocity{};
+
+	DEFINE_PARAMETERS(
+		(ParamBool<px4::params::COM_THROW_EN>) _param_com_throw_en,
+		(ParamFloat<px4::params::COM_THROW_SPEED>) _param_com_throw_min_speed
+	);
+};

--- a/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.hpp
+++ b/src/modules/commander/MulticopterThrowLaunch/MulticopterThrowLaunch.hpp
@@ -56,9 +56,10 @@ public:
 	/**
 	 * @return false if feature disabled or already flying
 	 */
-	bool isThrowLaunchInProgress() const {
+	bool isThrowLaunchInProgress() const
+	{
 		return _throw_launch_state != ThrowLaunchState::DISABLED
-			&& _throw_launch_state != ThrowLaunchState::FLYING;
+		       && _throw_launch_state != ThrowLaunchState::FLYING;
 	}
 
 	bool isReadyToThrow() const { return _throw_launch_state == ThrowLaunchState::ARMED; }

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1134,3 +1134,30 @@ PARAM_DEFINE_INT32(COM_ARMABLE, 1);
  * @group Commander
  */
 PARAM_DEFINE_FLOAT(COM_ARM_BAT_MIN, 0.f);
+
+/**
+ * Enable throw-start
+ *
+ * Allows to start the vehicle by throwing it into the air.
+ *
+ * @group Commander
+ * @boolean
+ */
+PARAM_DEFINE_INT32(COM_THROW_EN, 0);
+
+/**
+ * Minimum speed for the throw start
+ *
+ * When the throw launch is enabled, the drone will only arm after this speed is exceeded before detecting
+ * the freefall. This is a safety feature to ensure the drone does not turn on after accidental drop or
+ * a rapid movement before the throw.
+ *
+ * Set to 0 to disable.
+ *
+ * @group Commander
+ * @min 0
+ * @decimal 1
+ * @increment 0.1
+ * @unit m/s
+ */
+PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -466,10 +466,11 @@ void MulticopterPositionControl::Run()
 				_vehicle_constraints.speed_down = _param_mpc_z_vel_max_dn.get();
 			}
 
+			bool skip_takeoff = _param_com_throw_en.get();
 			// handle smooth takeoff
 			_takeoff.updateTakeoffState(_vehicle_control_mode.flag_armed, _vehicle_land_detected.landed,
 						    _vehicle_constraints.want_takeoff,
-						    _vehicle_constraints.speed_up, false, vehicle_local_position.timestamp_sample);
+						    _vehicle_constraints.speed_up, skip_takeoff, vehicle_local_position.timestamp_sample);
 
 			const bool not_taken_off             = (_takeoff.getTakeoffState() < TakeoffState::rampup);
 			const bool flying                    = (_takeoff.getTakeoffState() >= TakeoffState::flight);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -148,6 +148,7 @@ private:
 
 		// Takeoff / Land
 		(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time, /**< time to let motors spool up after arming */
+		(ParamBool<px4::params::COM_THROW_EN>)      _param_com_throw_en, /**< throw launch enabled  */
 		(ParamFloat<px4::params::MPC_TKO_RAMP_T>)   _param_mpc_tko_ramp_t,   /**< time constant for smooth takeoff ramp */
 		(ParamFloat<px4::params::MPC_TKO_SPEED>)    _param_mpc_tko_speed,
 		(ParamFloat<px4::params::MPC_LAND_SPEED>)   _param_mpc_land_speed,

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -39,7 +39,6 @@
 #include <mathlib/mathlib.h>
 #include <lib/geo/geo.h>
 
-
 void TakeoffHandling::generateInitialRampValue(float velocity_p_gain)
 {
 	velocity_p_gain = math::max(velocity_p_gain, 0.01f);

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -74,9 +74,6 @@ void TakeoffHandling::updateTakeoffState(const bool armed, const bool landed, co
 			_takeoff_state = TakeoffState::rampup;
 			_takeoff_ramp_progress = 0.f;
 
-		} else if (!landed) {
-			_takeoff_state = TakeoffState::flight;
-
 		} else {
 			break;
 		}
@@ -106,6 +103,7 @@ void TakeoffHandling::updateTakeoffState(const bool armed, const bool landed, co
 		_takeoff_state = TakeoffState::flight;
 	}
 
+	// TODO: need to consider free fall here
 	if (!armed) {
 		_takeoff_state = TakeoffState::disarmed;
 	}

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -39,6 +39,7 @@
 #include <mathlib/mathlib.h>
 #include <lib/geo/geo.h>
 
+
 void TakeoffHandling::generateInitialRampValue(float velocity_p_gain)
 {
 	velocity_p_gain = math::max(velocity_p_gain, 0.01f);
@@ -74,6 +75,9 @@ void TakeoffHandling::updateTakeoffState(const bool armed, const bool landed, co
 			_takeoff_state = TakeoffState::rampup;
 			_takeoff_ramp_progress = 0.f;
 
+		} else if (!landed) {
+			_takeoff_state = TakeoffState::flight;
+
 		} else {
 			break;
 		}
@@ -103,7 +107,6 @@ void TakeoffHandling::updateTakeoffState(const bool armed, const bool landed, co
 		_takeoff_state = TakeoffState::flight;
 	}
 
-	// TODO: need to consider free fall here
 	if (!armed) {
 		_takeoff_state = TakeoffState::disarmed;
 	}

--- a/src/modules/mc_pos_control/Takeoff/TakeoffTest.cpp
+++ b/src/modules/mc_pos_control/Takeoff/TakeoffTest.cpp
@@ -53,15 +53,15 @@ TEST(TakeoffTest, RegularTakeoffRamp)
 	takeoff.updateTakeoffState(false, true, false, 1.f, false, 0);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::disarmed);
 
-	// armed, landed, don't want takeoff
-	takeoff.updateTakeoffState(true, true, false, 1.f, false, 500_ms);
+	// armed, not landed anymore, don't want takeoff
+	takeoff.updateTakeoffState(true, false, false, 1.f, false, 500_ms);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::spoolup);
 
-	// armed, landed, don't want takeoff yet, spoolup time passed
-	takeoff.updateTakeoffState(true, true, false, 1.f, false, 2_s);
+	// armed, not landed, don't want takeoff yet, spoolup time passed
+	takeoff.updateTakeoffState(true, false, false, 1.f, false, 2_s);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::ready_for_takeoff);
 
-	// armed, not landed anymore, want takeoff
+	// armed, not landed, want takeoff
 	takeoff.updateTakeoffState(true, false, true, 1.f, false, 3_s);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::rampup);
 

--- a/src/modules/mc_pos_control/Takeoff/TakeoffTest.cpp
+++ b/src/modules/mc_pos_control/Takeoff/TakeoffTest.cpp
@@ -53,15 +53,15 @@ TEST(TakeoffTest, RegularTakeoffRamp)
 	takeoff.updateTakeoffState(false, true, false, 1.f, false, 0);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::disarmed);
 
-	// armed, not landed anymore, don't want takeoff
-	takeoff.updateTakeoffState(true, false, false, 1.f, false, 500_ms);
+	// armed, landed, don't want takeoff
+	takeoff.updateTakeoffState(true, true, false, 1.f, false, 500_ms);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::spoolup);
 
-	// armed, not landed, don't want takeoff yet, spoolup time passed
-	takeoff.updateTakeoffState(true, false, false, 1.f, false, 2_s);
+	// armed, landed, don't want takeoff yet, spoolup time passed
+	takeoff.updateTakeoffState(true, true, false, 1.f, false, 2_s);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::ready_for_takeoff);
 
-	// armed, not landed, want takeoff
+	// armed, not landed anymore, want takeoff
 	takeoff.updateTakeoffState(true, false, true, 1.f, false, 3_s);
 	EXPECT_EQ(takeoff.getTakeoffState(), TakeoffState::rampup);
 


### PR DESCRIPTION
This PR implements a throw-launch feature for multicopters: the ability to start the drone by throwing it into the air. The drone should not spin the propellers while held in hand and only do that when airborne.

It is based on the discussions here: https://discuss.px4.io/t/quadrotor-launch-control-throw-launches/212

Technically, the feature is realized by locking the motors (i.e., preventing them from spinning) after the drone is armed and releasing the lock only when a fall down is detected. Then, the drone stabilizes according to the mode it is in.

The feature was tested both in simulation and real flight, an example flight log is available here: 
https://logs.px4.io/plot_app?log=184b1c7f-e875-4937-a12d-c7dfca8e70aa (bad throw with lots of rolling, but the drone still recovers)
https://logs.px4.io/plot_app?log=c15d061c-538f-4134-85f8-83058882073e

The documentation is available here:
https://github.com/zeroos/PX4-user_guide/blob/f31812a7ac233697c24bd8223b7b3c7ba4914ab0/en/advanced_features/throw_launch.md?plain=1#L23

### Changelog 

#### 20 Feb 2023
A first working version was tested both in simulation and reality.

#### 24 Feb 2023 
The code was refined and more tests were conducted, sometimes the propellers slightly spin while arming. It's probably due to the fact that the locking of motors happens after arming and there might be a slight delay. Would be nice to modify the solution to take care of this.

#### 18 Apr 2023

I was slightly delayed due to some platform changes, but on the bright side, the feature was tested using two different drones (albeit very similar, as both are based on an X250 racer platform, one with Pixhawk 6 and the other one with Pixhawk 4).

Another factor that delayed the work was me trying to make "hold" mode work during the throw and change the setpoint while in flight. In the end, I concluded it's better to throw the drone in the "position" mode as it behaves more predictably even when the position estimate is imperfect due to the throw.

There were also some changes done during this iteration, they revolved mainly around suppressing automatic disarming during the throw. I also needed to allow the position controller to skip the "takeoff" phase when freefall is detected after arming.

Added flight log from a successful flight.

#### 24 Apr 2023

I've added the documentation and tested everything once more. Looking forward for feedback!

Squashed all commits; the full history is here: https://github.com/zeroos/PX4-Autopilot/tree/throw-mode-history

#### 25 Apr 2023

I've realized some automated tests were not passing. Now, they should be fine.

I also rebased the branch to be on top of the current main branch and performed another flight test to make sure everything is still good. The flight log is attached to this message.

#### 15 Aug 2023

Rebased the code on top of the most recent PX4 version and provided new logs. The old logs are here: 
https://logs.px4.io/plot_app?log=5583e2c8-ec95-41aa-abdd-873a09df5477 (before rebase to main, 18th of April),
https://logs.px4.io/plot_app?log=484e9ee6-751d-4bd4-a123-6b8d33d46652 (after rebase on the 25th of April).

### TODO:

- [x] add parameter to enable/disable the feature
- [x] replace throw_mode to throw_launch across the code
- [x] come up with a way to keep the "auto disarm" feature still working
- [x] replace debug prints with some useful information
- [x] consider adding some beeps when the drone is armed, but motors are locked
- [x] try to find someone experienced who can confirm this way of locking motors (and unlocking) is okay
- [x] propose a safety mechanism to make sure the drone does not start if accidentally dropped
- [x] modify the code to prevent the slight movement of the motors after arming
- [x] provide documentation
- [x] modify the PR to work with the main version of PX4
- [x] provide new flight logs