### PR TITLE
Commander: rework GPS quality thresholds for Home position setting and GPS invalid warning

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -17,7 +17,6 @@ param set-default COM_POS_FS_DELAY 5
 
 # there is a 2.5 factor applied on the _FS thresholds if for invalidation
 param set-default COM_POS_FS_EPH 50
-param set-default COM_POS_FS_EPV 30
 param set-default COM_VEL_FS_EVH 5
 
 param set-default COM_POS_LOW_EPH 50

--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -28,7 +28,6 @@ bool local_position_invalid           # Local position estimate invalid
 bool local_position_invalid_relaxed   # Local position with reduced accuracy requirements invalid (e.g. flying with optical flow)
 bool local_velocity_invalid           # Local velocity estimate invalid
 bool global_position_invalid          # Global position estimate invalid
-bool gps_position_invalid             # GPS position invalid
 bool auto_mission_missing             # No mission available
 bool offboard_control_signal_lost     # Offboard signal lost
 bool home_position_invalid            # No home position available

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ HealthAndArmingChecks::HealthAndArmingChecks(ModuleParams *parent, vehicle_statu
 	_failsafe_flags.local_position_invalid_relaxed = true;
 	_failsafe_flags.local_velocity_invalid = true;
 	_failsafe_flags.global_position_invalid = true;
-	_failsafe_flags.gps_position_invalid = true;
 	_failsafe_flags.auto_mission_missing = true;
 	_failsafe_flags.offboard_control_signal_lost = true;
 	_failsafe_flags.home_position_invalid = true;

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -297,8 +297,8 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 					mavlink_log_info(reporter.mavlink_log_pub(), "GNSS data fusion started\t");
 				}
 
-				events::send(events::ID("check_estimator_gnss_fusion_stated"), {events::Log::Info, events::LogInternal::Info},
-					     "GNSS data fusion stated");
+				events::send(events::ID("check_estimator_gnss_fusion_started"), {events::Log::Info, events::LogInternal::Info},
+					     "GNSS data fusion started");
 			}
 		}
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -66,7 +66,6 @@ private:
 				       const vehicle_local_position_s &lpos);
 
 	void checkGps(const Context &context, Report &reporter, const sensor_gps_s &vehicle_gps_position) const;
-	void gpsNoLongerValid(const Context &context, Report &reporter) const;
 	void lowPositionAccuracy(const Context &context, Report &reporter, const vehicle_local_position_s &lpos) const;
 	void setModeRequirementFlags(const Context &context, bool pre_flt_fail_innov_heading, bool pre_flt_fail_innov_vel_horiz,
 				     const vehicle_local_position_s &lpos, const sensor_gps_s &vehicle_gps_position,
@@ -100,10 +99,9 @@ private:
 	bool		_nav_test_passed{false};	///< true if the post takeoff navigation test has passed
 	bool		_nav_test_failed{false};	///< true if the post takeoff navigation test has failed
 
-	static constexpr hrt_abstime GPS_VALID_TIME{3_s};
-	systemlib::Hysteresis _vehicle_gps_position_valid{false};
-
 	bool _position_reliant_on_optical_flow{false};
+
+	bool _gps_was_fused{false};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::SYS_MC_EST_GROUP>) _param_sys_mc_est_group,

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -114,7 +114,6 @@ private:
 					(ParamBool<px4::params::COM_ARM_WO_GPS>) _param_com_arm_wo_gps,
 					(ParamBool<px4::params::SYS_HAS_GPS>) _param_sys_has_gps,
 					(ParamFloat<px4::params::COM_POS_FS_EPH>) _param_com_pos_fs_eph,
-					(ParamFloat<px4::params::COM_POS_FS_EPV>) _param_com_pos_fs_epv,
 					(ParamFloat<px4::params::COM_VEL_FS_EVH>) _param_com_vel_fs_evh,
 					(ParamInt<px4::params::COM_POS_FS_DELAY>) _param_com_pos_fs_delay,
 					(ParamFloat<px4::params::COM_POS_LOW_EPH>) _param_com_low_eph

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,6 +41,11 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/failsafe_flags.h>
 
+static constexpr int kHomePositionGPSRequiredFixType = 2;
+static constexpr float kHomePositionGPSRequiredEPH = 5.f;
+static constexpr float kHomePositionGPSRequiredEPV = 10.f;
+static constexpr float kHomePositionGPSRequiredEVH = 1.f;
+
 class HomePosition
 {
 public:
@@ -75,4 +80,5 @@ private:
 	uint8_t							_heading_reset_counter{0};
 	bool							_valid{false};
 	const failsafe_flags_s					&_failsafe_flags;
+	bool							_gps_position_for_home_valid{false};
 };

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -81,4 +81,9 @@ private:
 	bool							_valid{false};
 	const failsafe_flags_s					&_failsafe_flags;
 	bool							_gps_position_for_home_valid{false};
+	double							_gps_lat{0};
+	double							_gps_lon{0};
+	float							_gps_alt{0.f};
+	float							_gps_eph{0.f};
+	float							_gps_epv{0.f};
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -727,21 +727,6 @@ PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1);
 PARAM_DEFINE_FLOAT(COM_POS_FS_EPH, 5.f);
 
 /**
- * Vertical position error threshold.
- *
- * This is the vertical position error (EPV) threshold that will trigger a failsafe.
- * The default is appropriate for a multicopter. Can be increased for a fixed-wing.
- * If the previous position error was below this threshold, there is an additional
- * factor of 2.5 applied (threshold for invalidation 2.5 times the one for validation).
- *
- * @unit m
- * @min 0
- * @decimal 1
- * @group Commander
- */
-PARAM_DEFINE_FLOAT(COM_POS_FS_EPV, 10.f);
-
-/**
  * Horizontal velocity error threshold.
  *
  * This is the horizontal velocity error (EVH) threshold that will trigger a failsafe.

--- a/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
+++ b/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
@@ -310,6 +310,10 @@ private:
 				msg->failure_flags |= HL_FAILURE_FLAG_ESTIMATOR;
 			}
 
+			if (estimator_status.gps_check_fail_flags > 0) {
+				msg->failure_flags |= HL_FAILURE_FLAG_GPS;
+			}
+
 			return true;
 		}
 
@@ -448,10 +452,6 @@ private:
 		failsafe_flags_s failsafe_flags;
 
 		if (_failsafe_flags_sub.update(&failsafe_flags)) {
-			if (failsafe_flags.gps_position_invalid) {
-				msg->failure_flags |= HL_FAILURE_FLAG_GPS;
-			}
-
 			if (failsafe_flags.offboard_control_signal_lost) {
 				msg->failure_flags |= HL_FAILURE_FLAG_OFFBOARD_LINK;
 			}


### PR DESCRIPTION
### Solved Problem
- checks for GPS validity in Commander (used for setting Home and for triggering warning if GPS data is bad) are linked to failsafe thresholds (eg. COM_POS_FS_EPH), so don't reflect if the GPS is currently used or not by the estimator

### Solution
- decouple GPS checks for Home position setting (with hard coded thresholds)
- change "GPS invalid" warning to "GPS stopped being fused warning", that acts on real estimator feedback not separate thresholds

Previously failsafe_flags.gps_position_invalid was used for both. Beside it being two different things that really shouldn't have the same thresholds, it for me also doesn't belong into the failsafe flags as it doesn't trigger any failsafe (only losing global/local position does). 

One diff in the Home position setting is that I dropped (for now) the valid hysteresis around _vehicle_gps_position_valid, which required the checks to pass for 3s before Home position was set. Do we want that? 

### Alternatives
Certainly can be architecture differently, please advice. 

### Test coverage
SITL tested:
Triggered gps failure through failure injection, made it ok again, made it fail again, and then wait till (leave vehicle dead-reckoning) till position estimate inaccuracy grows above COM_POS_LOW_EPH and system RTLs.
https://user-images.githubusercontent.com/26798987/220408751-b46aafd2-efdb-44d6-9932-050a8592a6e3.mp4
![image](https://user-images.githubusercontent.com/26798987/220408724-0d405f60-8e3c-4b28-b060-ad51bbf7c134.png)


### Context
This came up as a follow up for https://github.com/PX4/PX4-Autopilot/pull/21018.
