### PR TITLE
generate_msg_docs.py - fix path to messages

### DIFF
--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     if not os.path.isdir(output_dir):
         os.mkdir(output_dir)
 
-    msg_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),"..")
+    msg_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),"../../msg")
     msg_files = get_msgs_list(msg_path)
     msg_files.sort()
 


### PR DESCRIPTION
uOrb topics documentation haven't build since at least September last year. I think the path to messages must have changed, or to the tool.
In either case, this should fix it.

FYI all the names have changed from snake to camel case, so will have to delete some of the removed docs. Might be some related docs updates needed to.