### PR TITLE
VehicleCommandAck typo on module docs

### DIFF
--- a/src/modules/payload_deliverer/module.yaml
+++ b/src/modules/payload_deliverer/module.yaml
@@ -30,7 +30,7 @@ parameters:
                   Maximum time Gripper will wait while the successful griper actuation isn't recognised.
                   If the gripper has no feedback sensor, it will simply wait for
                   this time before considering gripper actuation successful and publish a
-                  'vehicle_command_ack' signaling successful gripper action
+                  'VehicleCommandAck' signaling successful gripper action
             type: float
             unit: s
             min: 0


### PR DESCRIPTION
Fixing typos in uorb names, as I find them