### PR TITLE
gazebo-classic/sitl_mutliple_run.sh: start spawning drones from index 1

### DIFF
--- a/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
+++ b/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
@@ -106,7 +106,7 @@ if [ -z ${SCRIPT} ]; then
 	fi
 
 	while [ $n -lt $num_vehicles ]; do
-		spawn_model ${vehicle_model} $n
+		spawn_model ${vehicle_model} $(($n + 1))
 		n=$(($n + 1))
 	done
 else
@@ -127,7 +127,7 @@ else
 		m=0
 		while [ $m -lt ${target_number} ]; do
 			export PX4_SIM_MODEL=gazebo-classic_${target_vehicle}
-			spawn_model ${target_vehicle}${LABEL} $n $target_x $target_y
+			spawn_model ${target_vehicle}${LABEL} $(($n + 1)) $target_x $target_y
 			m=$(($m + 1))
 			n=$(($n + 1))
 		done


### PR DESCRIPTION
Complementary to #21091.
The microDDS namespace logic remains unchanged. Single vehicle simulations have no additional prefix in the namespace and are adopted when `-i 0` is given to the startup script (the default value). Multi vehicle simulations are instead adopted for `-i 1` and greater.
This allows to keep the same namespace convention for single vehicle simulations and single real drone scenarios.

This PR forces `Tools/simulation/gazebo-classic/sitl_multiple_run.sh` to start assigning instance ids from index 1 fixing the previous collision.

Fixes #21085, #21069.