### PR TITLE
Set heightrate setpoint in Fixedwing offboard mode

### DIFF
--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -260,6 +260,7 @@ public:
 	struct Input {
 		float altitude;		///< Current altitude amsl of the UAS [m].
 		float altitude_rate;	///< Current altitude rate of the UAS [m/s].
+		float altitude_rate_sp; ///< Current altitude rate setpoint [m/s]
 		float tas;		///< Current true airspeed of the UAS [m/s].
 		float tas_rate;		///< Current true airspeed rate of the UAS [m/s²].
 	};

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -1119,7 +1119,9 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 				   tecs_fw_thr_min,
 				   tecs_fw_thr_max,
 				   _param_sinkrate_target.get(),
-				   _param_climbrate_target.get());
+				   _param_climbrate_target.get(),
+				   false,
+				   pos_sp_curr.vz);
 }
 
 void


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Height rate feedforward can be specified in fixedwing offboard mode through `trajectory_setpoint` messages by populating `vz`. This was broken from recent refactors in the fixed-wing position controller.(This is a regression of https://github.com/PX4/PX4-Autopilot/pull/20537)

The height rate feedforward was not being passed to TECS, and therefore being ignored

### Solution
Pass the height rate setpoint to TECS

### Test coverage
Tested on a tiltrotor vehicle in offboard mode
- Flight log: https://review.px4.io/plot_app?log=ae3d8e6c-c50d-4632-a1f7-be4549bc10d0

**Before PR**
![image](https://user-images.githubusercontent.com/5248102/221207584-f2868e47-9b3b-4785-917c-05619f07dd60.png)
The satutrated feedforward term here is due to the large altitude tracking error

**After PR**
![image](https://user-images.githubusercontent.com/5248102/221205836-8257d4bc-e7b8-44e5-a801-4474eaf3b907.png)

