### PR TITLE
Descend nudging

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/tasks/Auto/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -240,7 +240,7 @@ void FlightTaskAuto::_prepareLandSetpoints()
 	// User input assisted landing
 	if (_param_mpc_land_rc_help.get() && _sticks.checkAndUpdateStickInputs()) {
 		// Stick full up -1 -> stop, stick full down 1 -> double the speed
-		vertical_speed *= (1 + _sticks.getPositionExpo()(2));
+		vertical_speed *= (1 - _sticks.getThrottleZeroCenteredExpo());
 
 		// Only set a yawrate setpoint if weather vane is not active or the yaw stick is out of its dead-zone
 		if (!_weathervane.isActive() || fabsf(_sticks.getYawExpo()) > FLT_EPSILON) {
@@ -248,7 +248,7 @@ void FlightTaskAuto::_prepareLandSetpoints()
 						       _deltatime);
 		}
 
-		_stick_acceleration_xy.generateSetpoints(_sticks.getPositionExpo().slice<2, 1>(0, 0), _yaw, _land_heading, _position,
+		_stick_acceleration_xy.generateSetpoints(_sticks.getPitchRollExpo(), _yaw, _land_heading, _position,
 				_velocity_setpoint_feedback.xy(), _deltatime);
 		_stick_acceleration_xy.getSetpoints(_land_position, _velocity_setpoint, _acceleration_setpoint);
 

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -243,9 +243,9 @@ void FlightTaskAuto::_prepareLandSetpoints()
 		vertical_speed *= (1 + _sticks.getPositionExpo()(2));
 
 		// Only set a yawrate setpoint if weather vane is not active or the yaw stick is out of its dead-zone
-		if (!_weathervane.isActive() || fabsf(_sticks.getPositionExpo()(3)) > FLT_EPSILON) {
-			_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _land_heading,
-						       _sticks.getPositionExpo()(3) * math::radians(_param_mpc_man_y_max.get()), _yaw, _is_yaw_good_for_control, _deltatime);
+		if (!_weathervane.isActive() || fabsf(_sticks.getYawExpo()) > FLT_EPSILON) {
+			_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _land_heading, _sticks.getYawExpo(), _yaw, _is_yaw_good_for_control,
+						       _deltatime);
 		}
 
 		_stick_acceleration_xy.generateSetpoints(_sticks.getPositionExpo().slice<2, 1>(0, 0), _yaw, _land_heading, _position,

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -142,7 +142,7 @@ protected:
 	Vector3f _unsmoothed_velocity_setpoint;
 	Sticks _sticks{this};
 	StickAccelerationXY _stick_acceleration_xy{this};
-	StickYaw _stick_yaw;
+	StickYaw _stick_yaw{this};
 	matrix::Vector3f _land_position;
 	float _land_heading;
 	WaypointType _type_previous{WaypointType::idle}; /**< Previous type of current target triplet. */
@@ -176,8 +176,7 @@ protected:
 					(ParamFloat<px4::params::MPC_Z_V_AUTO_DN>) _param_mpc_z_v_auto_dn,
 					(ParamFloat<px4::params::MPC_TKO_SPEED>) _param_mpc_tko_speed,
 					(ParamFloat<px4::params::MPC_TKO_RAMP_T>)
-					_param_mpc_tko_ramp_t, // time constant for smooth takeoff ramp
-					(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max
+					_param_mpc_tko_ramp_t // time constant for smooth takeoff ramp
 				       );
 
 private:

--- a/src/modules/flight_mode_manager/tasks/Descend/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/tasks/Descend/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,5 +35,5 @@ px4_add_library(FlightTaskDescend
 	FlightTaskDescend.cpp
 )
 
-target_link_libraries(FlightTaskDescend PUBLIC FlightTask)
+target_link_libraries(FlightTaskDescend PUBLIC FlightTask FlightTaskUtility)
 target_include_directories(FlightTaskDescend PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
+++ b/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,16 +36,6 @@
 
 #include "FlightTaskDescend.hpp"
 
-bool FlightTaskDescend::activate(const trajectory_setpoint_s &last_setpoint)
-{
-	bool ret = FlightTask::activate(last_setpoint);
-	// stay level to minimize horizontal drift
-	_acceleration_setpoint = matrix::Vector3f(0.f, 0.f, NAN);
-	// keep heading
-	_yaw_setpoint = _yaw;
-	return ret;
-}
-
 bool FlightTaskDescend::update()
 {
 	bool ret = FlightTask::update();
@@ -58,7 +48,28 @@ bool FlightTaskDescend::update()
 	} else {
 		// descend with constant acceleration (crash landing)
 		_velocity_setpoint(2) = NAN;
-		_acceleration_setpoint(2) = .3f;
+		_acceleration_setpoint(2) = .15f;
+	}
+
+	// Nudging
+	if (_param_mpc_land_rc_help.get() && _sticks.checkAndUpdateStickInputs()) {
+		_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _yaw_setpoint, _sticks.getYawExpo(), _yaw,
+					       _is_yaw_good_for_control, _deltatime);
+		_acceleration_setpoint.xy() = _stick_tilt_xy.generateAccelerationSetpoints(_sticks.getPitchRoll(), _deltatime, _yaw,
+					      _yaw_setpoint);
+
+		// Stick full up -1 -> stop, stick full down 1 -> double the value
+		_velocity_setpoint(2) *= (1 - _sticks.getThrottleZeroCenteredExpo());
+		_acceleration_setpoint(2) -= _sticks.getThrottleZeroCentered() * 10.f;
+
+	} else {
+		_acceleration_setpoint = matrix::Vector3f(0.f, 0.f, NAN); // stay level to minimize horizontal drift
+		_yawspeed_setpoint = NAN;
+
+		// keep heading
+		if (!PX4_ISFINITE(_yaw_setpoint)) {
+			_yaw_setpoint = _yaw;
+		}
 	}
 
 	return ret;

--- a/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.hpp
+++ b/src/modules/flight_mode_manager/tasks/Descend/FlightTaskDescend.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,6 +38,9 @@
 #pragma once
 
 #include "FlightTask.hpp"
+#include "Sticks.hpp"
+#include "StickTiltXY.hpp"
+#include "StickYaw.hpp"
 
 class FlightTaskDescend : public FlightTask
 {
@@ -46,11 +49,15 @@ public:
 	virtual ~FlightTaskDescend() = default;
 
 	bool update() override;
-	bool activate(const trajectory_setpoint_s &last_setpoint) override;
 
 private:
+	Sticks _sticks{this};
+	StickTiltXY _stick_tilt_xy{this};
+	StickYaw _stick_yaw{this};
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
-					(ParamFloat<px4::params::MPC_THR_HOVER>) _param_mpc_thr_hover, ///< thrust at hover equilibrium
-					(ParamFloat<px4::params::MPC_LAND_SPEED>) _param_mpc_land_speed ///< velocity for controlled descend
+					(ParamInt<px4::params::MPC_LAND_RC_HELP>) _param_mpc_land_rc_help,
+					(ParamFloat<px4::params::MPC_LAND_SPEED>) _param_mpc_land_speed, ///< velocity for controlled descend
+					(ParamFloat<px4::params::MPC_THR_HOVER>) _param_mpc_thr_hover ///< thrust at hover equilibrium
 				       )
 };

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -66,8 +66,7 @@ bool FlightTaskManualAcceleration::update()
 	_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _yaw_setpoint, _sticks.getYawExpo(), _yaw, _is_yaw_good_for_control,
 				       _deltatime);
 
-	_stick_acceleration_xy.generateSetpoints(_sticks.getPositionExpo().slice<2, 1>(0, 0), _yaw, _yaw_setpoint,
-			_position,
+	_stick_acceleration_xy.generateSetpoints(_sticks.getPitchRollExpo(), _yaw, _yaw_setpoint, _position,
 			_velocity_setpoint_feedback.xy(), _deltatime);
 	_stick_acceleration_xy.getSetpoints(_position_setpoint, _velocity_setpoint, _acceleration_setpoint);
 

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,8 +63,8 @@ bool FlightTaskManualAcceleration::update()
 {
 	bool ret = FlightTaskManualAltitudeSmoothVel::update();
 
-	_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _yaw_setpoint,
-				       _sticks.getPositionExpo()(3) * math::radians(_param_mpc_man_y_max.get()), _yaw, _is_yaw_good_for_control, _deltatime);
+	_stick_yaw.generateYawSetpoint(_yawspeed_setpoint, _yaw_setpoint, _sticks.getYawExpo(), _yaw, _is_yaw_good_for_control,
+				       _deltatime);
 
 	_stick_acceleration_xy.generateSetpoints(_sticks.getPositionExpo().slice<2, 1>(0, 0), _yaw, _yaw_setpoint,
 			_position,

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,7 +58,7 @@ private:
 	void _ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vxy) override;
 
 	StickAccelerationXY _stick_acceleration_xy{this};
-	StickYaw _stick_yaw;
+	StickYaw _stick_yaw{this};
 
 	WeatherVane _weathervane{this}; /**< weathervane library, used to implement a yaw control law that turns the vehicle nose into the wind */
 };

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -42,6 +42,7 @@
 #include "FlightTask.hpp"
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include "Sticks.hpp"
+#include "StickTiltXY.hpp"
 #include "StickYaw.hpp"
 #include <uORB/Subscription.hpp>
 
@@ -75,7 +76,9 @@ protected:
 	void _updateAltitudeLock();
 
 	Sticks _sticks{this};
+	StickTiltXY _stick_tilt_xy{this};
 	StickYaw _stick_yaw{this};
+
 	bool _sticks_data_required = true; ///< let inherited task-class define if it depends on stick data
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
@@ -89,8 +92,7 @@ protected:
 					(ParamFloat<px4::params::MPC_LAND_SPEED>)
 					_param_mpc_land_speed, /**< desired downwards speed when approaching the ground */
 					(ParamFloat<px4::params::MPC_TKO_SPEED>)
-					_param_mpc_tko_speed, /**< desired upwards speed when still close to the ground */
-					(ParamFloat<px4::params::MC_MAN_TILT_TAU>) _param_mc_man_tilt_tau
+					_param_mpc_tko_speed /**< desired upwards speed when still close to the ground */
 				       )
 private:
 	bool _isYawInput();
@@ -138,6 +140,4 @@ private:
 	 * _dist_to_ground_lock.
 	 */
 	float _dist_to_ground_lock = NAN;
-
-	AlphaFilter<matrix::Vector2f> _man_input_filter;
 };

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,14 +40,15 @@
 #pragma once
 
 #include "FlightTask.hpp"
-#include "Sticks.hpp"
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include "Sticks.hpp"
+#include "StickYaw.hpp"
 #include <uORB/Subscription.hpp>
 
 class FlightTaskManualAltitude : public FlightTask
 {
 public:
-	FlightTaskManualAltitude();
+	FlightTaskManualAltitude() = default;
 	virtual ~FlightTaskManualAltitude() = default;
 	bool activate(const trajectory_setpoint_s &last_setpoint) override;
 	bool updateInitialize() override;
@@ -73,7 +74,8 @@ protected:
 	 */
 	void _updateAltitudeLock();
 
-	Sticks _sticks;
+	Sticks _sticks{this};
+	StickYaw _stick_yaw{this};
 	bool _sticks_data_required = true; ///< let inherited task-class define if it depends on stick data
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
@@ -81,8 +83,6 @@ protected:
 					(ParamInt<px4::params::MPC_ALT_MODE>) _param_mpc_alt_mode,
 					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) _param_mpc_hold_max_xy,
 					(ParamFloat<px4::params::MPC_Z_P>) _param_mpc_z_p, /**< position controller altitude propotional gain */
-					(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max, /**< scaling factor from stick to yaw rate */
-					(ParamFloat<px4::params::MPC_MAN_Y_TAU>) _param_mpc_man_y_tau,
 					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _param_mpc_man_tilt_max, /**< maximum tilt allowed for manual flight */
 					(ParamFloat<px4::params::MPC_LAND_ALT1>) _param_mpc_land_alt1, /**< altitude at which to start downwards slowdown */
 					(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2, /**< altitude below which to land with land speed */
@@ -96,14 +96,6 @@ private:
 	bool _isYawInput();
 	void _unlockYaw();
 	void _lockYaw();
-
-	/**
-	 * Filter between stick input and yaw setpoint
-	 *
-	 * @param yawspeed_target yaw setpoint desired by the stick
-	 * @return filtered value from independent filter state
-	 */
-	float _applyYawspeedFilter(float yawspeed_target);
 
 	/**
 	 * Terrain following.
@@ -132,7 +124,6 @@ private:
 
 	void setGearAccordingToSwitch();
 
-	float _yawspeed_filter_state{}; /**< state of low-pass filter in rad/s */
 	uint8_t _reset_counter = 0; /**< counter for estimator resets in z-direction */
 	bool _terrain_follow{false}; /**< true when the vehicle is following the terrain height */
 	bool _terrain_hold{false}; /**< true when vehicle is controlling height above a static ground position */

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -67,7 +67,7 @@ void FlightTaskManualPosition::_scaleSticks()
 	/* Use same scaling as for FlightTaskManualAltitude */
 	FlightTaskManualAltitude::_scaleSticks();
 
-	Vector2f stick_xy = _sticks.getPositionExpo().slice<2, 1>(0, 0);
+	Vector2f stick_xy = _sticks.getPitchRollExpo();
 
 	Sticks::limitStickUnitLengthXY(stick_xy);
 

--- a/src/modules/flight_mode_manager/tasks/Utility/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/tasks/Utility/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2018 - 2020 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 px4_add_library(FlightTaskUtility
 	Sticks.cpp
 	StickAccelerationXY.cpp
+	StickTiltXY.cpp
 	StickYaw.cpp
 )
 

--- a/src/modules/flight_mode_manager/tasks/Utility/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/tasks/Utility/CMakeLists.txt
@@ -38,5 +38,5 @@ px4_add_library(FlightTaskUtility
 	StickYaw.cpp
 )
 
-target_link_libraries(FlightTaskUtility PUBLIC FlightTask hysteresis bezier SlewRate motion_planning)
+target_link_libraries(FlightTaskUtility PUBLIC FlightTask hysteresis bezier SlewRate motion_planning mathlib)
 target_include_directories(FlightTaskUtility PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,10 +30,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
-
-/**
- * @file StickAccelerationXY.cpp
- */
 
 #include "StickAccelerationXY.hpp"
 

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@
 
 /**
  * @file StickAccelerationXY.hpp
- * @brief Generate horizontal position, velocity and acceleration from stick input
+ * @brief Generate horizontal position, velocity and acceleration setpoints from stick input
  * @author Matthias Grob <maetugr@gmail.com>
  */
 

--- a/src/modules/flight_mode_manager/tasks/Utility/StickTiltXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickTiltXY.cpp
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "StickTiltXY.hpp"
+
+#include <geo/geo.h>
+#include "Sticks.hpp"
+
+using namespace matrix;
+
+StickTiltXY::StickTiltXY(ModuleParams *parent) :
+	ModuleParams(parent)
+{}
+
+Vector2f StickTiltXY::generateAccelerationSetpoints(Vector2f stick_xy, const float dt, const float yaw,
+		const float yaw_setpoint)
+{
+	Sticks::limitStickUnitLengthXY(stick_xy);
+	_man_input_filter.setParameters(dt, _param_mc_man_tilt_tau.get());
+	stick_xy = _man_input_filter.update(stick_xy);
+	Sticks::rotateIntoHeadingFrameXY(stick_xy, yaw, yaw_setpoint);
+	return stick_xy * tanf(math::radians(_param_mpc_man_tilt_max.get())) * CONSTANTS_ONE_G;
+}

--- a/src/modules/flight_mode_manager/tasks/Utility/StickTiltXY.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickTiltXY.hpp
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file StickTiltXY.hpp
+ * @brief Generate only horizontal acceleration setpoint from stick input
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <matrix/math.hpp>
+#include <px4_platform_common/module_params.h>
+
+class StickTiltXY : public ModuleParams
+{
+public:
+	StickTiltXY(ModuleParams *parent);
+	~StickTiltXY() = default;
+
+	/**
+	 * Produce acceleration setpoint to tilt a multicopter based on stick input
+	 *
+	 * Forward pitch stick input pitches the vehicle's pitch e.g. accelerates the vehicle in its nose direction.
+	 *
+	 * @param stick_xy the raw pitch and roll stick positions as input
+	 * @param dt time in seconds since the last execution
+	 * @param yaw the current yaw estimate for frame rotation
+	 * @param yaw_setpoint the current heading setpoint used instead of the estimate if absolute yaw is locked
+	 * @return NED frame horizontal x, y axis acceleration setpoint
+	 */
+	matrix::Vector2f generateAccelerationSetpoints(matrix::Vector2f stick_xy, const float dt, const float yaw,
+			const float yaw_setpoint);
+private:
+	AlphaFilter<matrix::Vector2f> _man_input_filter;
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _param_mpc_man_tilt_max, ///< maximum tilt allowed for manual flight
+		(ParamFloat<px4::params::MC_MAN_TILT_TAU>) _param_mc_man_tilt_tau ///< time constant for stick filter
+	)
+};

--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,23 +31,19 @@
  *
  ****************************************************************************/
 
-/**
- * @file StickYaw.cpp
- */
-
 #include "StickYaw.hpp"
 
 #include <px4_platform_common/defines.h>
 
-StickYaw::StickYaw()
-{
-	_yawspeed_slew_rate.setSlewRate(2.f * M_PI_F);
-}
+StickYaw::StickYaw(ModuleParams *parent) :
+	ModuleParams(parent)
+{}
 
-void StickYaw::generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, const float desired_yawspeed,
+void StickYaw::generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, const float stick_yaw,
 				   const float yaw, const bool is_yaw_good_for_control, const float deltatime)
 {
-	yawspeed_setpoint = _yawspeed_slew_rate.update(desired_yawspeed, deltatime);
+	_yawspeed_filter.setParameters(deltatime, _param_mpc_man_y_tau.get());
+	yawspeed_setpoint = _yawspeed_filter.update(stick_yaw * math::radians(_param_mpc_man_y_max.get()));
 	yaw_setpoint = updateYawLock(yaw, yawspeed_setpoint, yaw_setpoint, is_yaw_good_for_control);
 }
 

--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,19 +39,20 @@
 
 #pragma once
 
-#include "SlewRate.hpp"
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <px4_platform_common/module_params.h>
 
-class StickYaw
+class StickYaw : public ModuleParams
 {
 public:
-	StickYaw();
+	StickYaw(ModuleParams *parent);
 	~StickYaw() = default;
 
-	void generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, float desired_yawspeed, float yaw,
+	void generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, float stick_yaw, float yaw,
 				 bool is_yaw_good_for_control, float deltatime);
 
 private:
-	SlewRate<float> _yawspeed_slew_rate;
+	AlphaFilter<float> _yawspeed_filter;
 
 	/**
 	 * Lock yaw when not currently turning
@@ -65,4 +66,9 @@ private:
 	 * @return yaw setpoint to execute to have a yaw lock at the correct moment in time
 	 */
 	static float updateYawLock(float yaw, float yawspeed_setpoint, float yaw_setpoint, bool is_yaw_good_for_control);
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max, ///< Maximum yaw speed with full stick deflection
+		(ParamFloat<px4::params::MPC_MAN_Y_TAU>) _param_mpc_man_y_tau ///< time constant for yaw speed filtering
+	)
 };

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ bool Sticks::checkAndUpdateStickInputs()
 		_positions_expo(3) = math::expo_deadzone(_positions(3), _param_mpc_yaw_expo.get(),    _param_mpc_hold_dz.get());
 
 		// valid stick inputs are required
-		_input_available = _positions.isAllFinite();
+		_input_available = manual_control_setpoint.valid && _positions.isAllFinite();
 
 	} else {
 		failsafe_flags_s failsafe_flags;

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,18 +59,20 @@ public:
 	bool isAvailable() { return _input_available; };
 
 	// Position : 0 : pitch, 1 : roll, 2 : throttle, 3 : yaw
-	const matrix::Vector<float, 4> &getPosition() { return _positions; };
-	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; };
+	const matrix::Vector<float, 4> &getPosition() { return _positions; }; // Raw stick position, no deadzone
+	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; }; // Deadzone and expo applied
 
 	// Helper functions to get stick values more intuitively
-	float getPitch() const { return _positions(0); }
 	float getRoll() const { return _positions(1); }
-	float getThrottleZeroCentered() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
-	float getYaw() const { return _positions(3); }
-	float getPitchExpo() const { return _positions_expo(0); }
 	float getRollExpo() const { return _positions_expo(1); }
-	float getThrottleZeroCenteredExpo() const { return -_positions_expo(2); } // Convert Z-axis(down) command to Up-axis frame
+	float getPitch() const { return _positions(0); }
+	float getPitchExpo() const { return _positions_expo(0); }
+	float getYaw() const { return _positions(3); }
 	float getYawExpo() const { return _positions_expo(3); }
+	float getThrottleZeroCentered() const { return -_positions(2); } // Convert Z-axis(down) command to Up-axis frame
+	float getThrottleZeroCenteredExpo() const { return -_positions_expo(2); }
+	const matrix::Vector2f getPitchRoll() { return _positions.slice<2, 1>(0, 0); }
+	const matrix::Vector2f getPitchRollExpo() { return _positions_expo.slice<2, 1>(0, 0); }
 
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -162,8 +162,6 @@ private:
 		(ParamFloat<px4::params::MC_YAWRATE_FF>) _param_mc_yawrate_ff,
 		(ParamFloat<px4::params::MC_YAWRATE_K>) _param_mc_yawrate_k,
 
-		(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max,			/**< scaling factor from stick to yaw rate */
-
 		(ParamFloat<px4::params::MC_ACRO_R_MAX>) _param_mc_acro_r_max,
 		(ParamFloat<px4::params::MC_ACRO_P_MAX>) _param_mc_acro_p_max,
 		(ParamFloat<px4::params::MC_ACRO_Y_MAX>) _param_mc_acro_y_max,


### PR DESCRIPTION
### Solved Problem
Being able to nudge the descent in the failsafe mode called Descend using stick input was requested for the following use cases:
- Tethered vehicle
- VTOL with limited hover time
which are both not allowed to manually be switched to Altitude mode e.g. by RC override

### Solution
- Put the horizontal stick mapping of Altitude mode in the `StickTiltXY` flight task utility class and reused it in Descend mode.
- Unify the blocks for the same stick-mapping strategies. E.g. before the yaw mapping had different filtering and locking logic in Altitude compared to Position mode.

### Test coverage
- Simulation/hardware testing logs: Manual testing of the functionality with SITL gazebo iris of the cases losing GPS without RC override enabled and also losing the altitude estimate on top.