### PR TITLE
Fixed Skynode orientation

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -47,6 +47,11 @@ then
 	fi
 fi
 
+#Start Auterion Power Module selector for Skynode boards
+if ver hwtypecmp V6X009010 V6X010010
+then
+	pm_selector_auterion start
+fi
 
 if ver hwtypecmp V6X000004 V6X001004 V6X004004 V6X005004
 then

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -47,6 +47,12 @@ then
 	fi
 fi
 
+#Start Auterion Power Module selector for Skynode boards
+if ver hwtypecmp V6X009010 V6X010010
+then
+	pm_selector_auterion start
+fi
+
 if ver hwtypecmp V6X000004 V6X001004 V6X004004 V6X005004
 then
 	# Internal SPI bus ICM20649
@@ -101,7 +107,13 @@ if ver hwtypecmp V6X002001
 then
 	rm3100 -I -b 4 start
 else
-	bmm150 -I -R 6 start
+	if ver hwtypecmp V6X009010 V6X010010
+	then
+		# Internal magnetometer on I2C
+		bmm150 -I -R 0 start
+	else
+		bmm150 -I -R 6 start
+	fi
 fi
 
 # External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -47,6 +47,7 @@ then
 	fi
 fi
 
+
 if ver hwtypecmp V6X000004 V6X001004 V6X004004 V6X005004
 then
 	# Internal SPI bus ICM20649

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -47,11 +47,6 @@ then
 	fi
 fi
 
-#Start Auterion Power Module selector for Skynode boards
-if ver hwtypecmp V6X009010 V6X010010
-then
-	pm_selector_auterion start
-fi
 
 if ver hwtypecmp V6X000004 V6X001004 V6X004004 V6X005004
 then

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -47,7 +47,6 @@ then
 	fi
 fi
 
-
 if ver hwtypecmp V6X000004 V6X001004 V6X004004 V6X005004
 then
 	# Internal SPI bus ICM20649


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When I was flying V6X on Skynode I found that the values from the MAG0 were not correlated with MAG1. Only z-axis was correct. y-axis and x-axis were inverted.

Fixes #{Github issue ID}

### Solution
set orientation of bmm150 to zero.

### Alternatives
We could also ...

### Test coverage
- Tested on Skynode. Multiple test flights were performed.


### Context
before: x-axis of mag0 correlated with y-axis of mag1
![image](https://user-images.githubusercontent.com/119662383/221251504-c80ba491-fefc-4815-9f3c-686db38ca392.png)


after set rotation to zero: x-axis of mag0 correlates now with x-axis of mag1
![image](https://user-images.githubusercontent.com/119662383/221249545-dc7fbde4-d8af-48a1-b9bb-285d04f1aae2.png)

