### PR TITLE
Swap arm-none-eabi-gdb for gdb-multiarch

### DIFF
--- a/platforms/nuttx/cmake/Toolchain-arm-none-eabi.cmake
+++ b/platforms/nuttx/cmake/Toolchain-arm-none-eabi.cmake
@@ -20,7 +20,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
 
 # compiler tools
 find_program(CMAKE_AR ${TOOLCHAIN_PREFIX}-gcc-ar)
-find_program(CMAKE_GDB ${TOOLCHAIN_PREFIX}-gdb)
+find_program(CMAKE_GDB gdb-multiarch)
 find_program(CMAKE_LD ${TOOLCHAIN_PREFIX}-ld)
 find_program(CMAKE_LINKER ${TOOLCHAIN_PREFIX}-ld)
 find_program(CMAKE_NM ${TOOLCHAIN_PREFIX}-gcc-nm)


### PR DESCRIPTION
The latest version of cortex-debug requires a GDB version 9 or higher. The version of GDB that is included with our 9.3.1 GCC toolchain is 8. Switching to gcc-multiarch appears to be more universal and robust. It is already a dependency of the setup script.