### PR TITLE
commander: fixes valid mag count in HIL

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
@@ -65,6 +65,7 @@ void MagnetometerChecks::checkAndReport(const Context &context, Report &reporter
 
 			if (context.status().hil_state == vehicle_status_s::HIL_STATE_ON) {
 				is_calibration_valid = true;
+				num_enabled_and_valid_calibration++;
 
 			} else {
 				int calibration_index = calibration::FindCurrentCalibrationIndex("MAG", mag_data.device_id);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

When running in HIL simulation, the number of valid magnetometers is always 0 because of the `num_enabled_and_valid_calibration` variable in `commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp`.

The root cause is that we do not increment `num_enabled_and_valid_calibration` if we are in HIL mode.

### Solution

Increment `num_enabled_and_valid_calibration` in `magnetometerCheck.cpp`/`checkAndReport` if we are in HIL mode:

```cpp
if (context.status().hil_state == vehicle_status_s::HIL_STATE_ON) {
   is_calibration_valid = true;
   num_enabled_and_valid_calibration++;
}
```

By incrementing `num_enabled_and_valid_calibration` it allows the check to pass and not throw a false positive:

```cpp
        if (!had_failure && !context.isArmed()) {
		consistencyCheck(context, reporter);

		if (num_enabled_and_valid_calibration < _param_sys_has_mag.get()) {
			/* EVENT
			 * @description
			 * Make sure all required sensors are working, enabled and calibrated.
			 *
			 * <profile name="dev">
			 * This check can be configured via <param>SYS_HAS_MAG</param> parameter.
			 * </profile>
			 */
			reporter.armingCheckFailure<uint8_t, uint8_t>(NavModes::All, health_component_t::magnetometer,
					events::ID("check_mag_sys_has_mag_missing"),
					events::Log::Error, "Found {1} compass (required: {2})", num_enabled_and_valid_calibration, _param_sys_has_mag.get());

			if (reporter.mavlink_log_pub()) {
				mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Found %i compass (required: %" PRId32 ")",
						     num_enabled_and_valid_calibration, _param_sys_has_mag.get());
			}
		}
	}
```

### Test coverage

Working in SIH on a CubeOrange.

