### PR TITLE
gps: Support for Unicore HEADINGA sentence in NMEA

### DIFF
--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -50,6 +50,7 @@ px4_add_module(
 		devices/src/femtomes.cpp
 		devices/src/nmea.cpp
 		devices/src/unicore.cpp
+		devices/src/crc.cpp
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -147,10 +147,16 @@ PARAM_DEFINE_INT32(GPS_UBX_CFG_INTF, 0);
  *
  * Heading offset angle for dual antenna GPS setups that support heading estimation.
  *
- * Set this to 0 if the antennas are parallel to the forward-facing direction of the vehicle and the rover antenna is in
- * front. The offset angle increases clockwise.
+ * Set this to 0 if the antennas are parallel to the forward-facing direction
+ * of the vehicle and the rover (or Unicore primary) antenna is in front.
  *
- * Set this to 90 if the rover antenna is placed on the right side of the vehicle and the moving base antenna is on the left side.
+ * The offset angle increases clockwise.
+ *
+ * Set this to 90 if the rover (or Unicore primary) antenna is placed on the
+ * right side of the vehicle and the moving base antenna is on the left side.
+ *
+ * (Note: the Unicore primary antenna is the one connected on the right as seen
+ *        from the top).
  *
  * @min 0
  * @max 360


### PR DESCRIPTION
### Description

This adds a parser for Unicore sentences sent in-between NMEA sentences which brings support for the Unicore UM982 module which publishes heading information based on the two antennas.

Stack is raised because we allocate 200 bytes for the Unicore parser.

### Open questions

The assumption is that the "rover antenna" is considered to be the primary one and would match the Unicore master antenna.

### Status

- [x] Submodule PR (https://github.com/PX4/PX4-GPSDrivers/pull/123) merged
- [x] (Outdoor) bench tested
- [x] Yaw estimate unstable warnings fixed
- [x] Setup docs added, PR (https://github.com/PX4/PX4-user_guide/pull/2346)
- [ ] Flight tested (@vincentpoont2 ?)

FYI @vincentpoont2 