### PR TITLE
Fix gps global origin stream

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1507,7 +1507,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("GIMBAL_MANAGER_STATUS", 0.5f);
 		configure_stream_local("GLOBAL_POSITION_INT", 5.0f);
 		configure_stream_local("GPS2_RAW", 1.0f);
-		configure_stream_local("GPS_GLOBAL_ORIGIN", 0.1f);
+		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS_RAW_INT", 1.0f);
 		configure_stream_local("GPS_STATUS", 1.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
@@ -1809,6 +1809,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
 		configure_stream_local("GLOBAL_POSITION_INT", 10.0f);
+		configure_stream_local("GPS_GLOBAL_ORIGIN", 1.0f);
 		configure_stream_local("GPS2_RAW", unlimited_rate);
 		configure_stream_local("GPS_RAW_INT", unlimited_rate);
 		configure_stream_local("HOME_POSITION", 0.5f);

--- a/src/modules/mavlink/streams/GPS_GLOBAL_ORIGIN.hpp
+++ b/src/modules/mavlink/streams/GPS_GLOBAL_ORIGIN.hpp
@@ -77,7 +77,8 @@ private:
 	{
 		vehicle_local_position_s vehicle_local_position{};
 
-		if (_force_next_send || _vehicle_local_position_sub.update(&vehicle_local_position)) {
+		if ((_vehicle_local_position_sub.updated() || _force_next_send)
+		    && _vehicle_local_position_sub.copy(&vehicle_local_position)) {
 			if (vehicle_local_position.xy_global && vehicle_local_position.z_global) {
 
 				static constexpr double LLA_MIN_DIFF = 0.0000001; // ~11.132 mm at the equator

--- a/src/modules/mavlink/streams/GPS_GLOBAL_ORIGIN.hpp
+++ b/src/modules/mavlink/streams/GPS_GLOBAL_ORIGIN.hpp
@@ -58,12 +58,8 @@ public:
 
 	bool request_message(float param2, float param3, float param4, float param5, float param6, float param7) override
 	{
-		if (_valid) {
-			_force_next_send = true;
-			return true;
-		}
-
-		return false;
+		_force_next_send = true;
+		return send();
 	}
 
 private:
@@ -75,15 +71,13 @@ private:
 	double _ref_lat{static_cast<double>(NAN)};
 	double _ref_lon{static_cast<double>(NAN)};
 	float _ref_alt{NAN};
-
-	bool _valid{false};
 	bool _force_next_send{true};
 
 	bool send() override
 	{
-		vehicle_local_position_s vehicle_local_position;
+		vehicle_local_position_s vehicle_local_position{};
 
-		if (_vehicle_local_position_sub.update(&vehicle_local_position)) {
+		if (_force_next_send || _vehicle_local_position_sub.update(&vehicle_local_position)) {
 			if (vehicle_local_position.xy_global && vehicle_local_position.z_global) {
 
 				static constexpr double LLA_MIN_DIFF = 0.0000001; // ~11.132 mm at the equator
@@ -107,7 +101,6 @@ private:
 					_ref_alt       = vehicle_local_position.ref_alt;
 
 					_force_next_send = false;
-					_valid = true;
 
 					return true;
 				}


### PR DESCRIPTION
When requesting a message from a stream that is not active we start the
stream with interval=0 and call the request method once. For all streams
this works fine except the gps_global_origin. For this one the request method
is actually overidden to throttle down the rate and not just send out the message.
This will cause this message to never being sent on request if the stream
is not active by default.

@DanielePettenuzzo fyi