### PR TITLE
CUAV Pixhawk V6X Baro & Mag won't start on stable | px4_fmu-v6x:Fix CUAV Sensor Set startup

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -70,7 +70,7 @@ else
 fi
 
 # Internal magnetometer on I2c
-if ver hwtypecmp V6X002001
+if ver hwtypecmp V6X21
 then
 	rm3100 -I -b 4 start
 else
@@ -81,7 +81,7 @@ fi
 ist8310 -X -b 1 -R 10 start
 
 # Possible internal Baro
-if ver hwtypecmp V6X002001
+if ver hwtypecmp V6X21
 then
 	icp201xx -I -a 0x64 start
 else
@@ -92,7 +92,7 @@ if ver hwtypecmp V6X00 V6X10
 then
 	bmp388 -I start
 else
-	if ver hwtypecmp V6X002001
+	if ver hwtypecmp V6X21
 	then
 		icp201xx -X start
 	else


### PR DESCRIPTION
   Reverts part of 3c10e34a49d964f85eacf186153097d102fd2578 not applicable to V1.13 VER/REV system.
```
[boot] Rev 0x1 : Ver 0x2 V6X21
reset done, 10 ms
[boot] Fault Log info File No 4 Length 3177 flags:0x01 state:1
[boot] Fault Log is Armed
sercon: Registering CDC/ACM serial driver
sercon: Successfully registered the CDC/ACM serial driver
HW arch: PX4_FMU_V6X
HW type: V6X21
HW version: 0x00000002
HW revision: 0x00000001
FW git-hash: 3cb529184ec9c715367ac1ce48cec29b17bab1b5
FW version: 1.13.2 0 (17629696)
FW git-branch: release/1.13-pr-cuav-fix
OS: NuttX
OS version: Release 12.0.0 (201326847)
OS git-hash: 78abbf36c057f2a62011d7d208134d50e95d9916
Build datetime: Mar  1 2023 06:02:10
Build uri: localhost
Build variant: default
Toolchain: GNU GCC, 9.3.1 20200408 (release)
PX4GUID: 000600000000313732373330511200480049
MCU: STM32H7[4|5]xxx, rev. V
t_log] Fault Log is Armed
INFO  [param] selected parameter default file /fs/mtd_params
INFO  [param] importing from '/fs/mtd_params'
INFO  [parameters] BSON document size 765 bytes, decoded 765 bytes (INT32:17, FLOAT:19)
INFO  [param] selected parameter backup file /fs/microsd/parameters_backup.bson
Board architecture defaults: /etc/init.d/rc.board_arch_defaults
Board defaults: /etc/init.d/rc.board_defaults
INFO  [dataman] data manager file '/fs/microsd/dataman' size is 62560 bytes
Loading airframe: /etc/init.d/airframes/4001_quad_x
WARN  [px4io] check CRC failed: -22, CRC: 1891365525
[PX4IO] using firmware from /etc/extras/px4_io-v2_default.bin
[PX4IO] bad sync 0xff,0xff
[PX4IO] found bootloader revision: 5
[PX4IO] erase...
[PX4IO] programming 39952 bytes...
[PX4IO] verify...
[PX4IO] update complete
INFO  [tune_control] Stopping playback...
INFO  [px4io] IO FW CRC match
Board sensors: /etc/init.d/rc.board_sensors
INFO  [ina226] Failed to init INA226 on bus 1, but will try again periodically.
ina226 #0 on I2C bus 1 (external) address 0x41
INFO  [ina226] Failed to init INA226 on bus 2, but will try again periodically.
ina226 #1 on I2C bus 2 (external) address 0x41
bmi088_accel #0 on SPI bus 3 rotation 4
bmi088_gyro #0 on SPI bus 3 rotation 4
icm42688p #0 on SPI bus 2 rotation 6
icm20649 #0 on SPI bus 1 rotation 14
rm3100 #0 on I2C bus 4 address 0x20
WARN  [SPI_I2C] ist8310: no instance started (no device on bus?)
icp201xx #0 on I2C bus 4 (external) address 0x64
icp201xx #1 on I2C bus 2 (external) address 0x63
WARN  [SPI_I2C] ms5611: no instance started (no device on bus?)
nsh: battery_status: command not found
INFO  [pwm_out] instance: 0, max rate: 100, default: 50, alt: 50
INFO  [init] Mixer: /etc/mixers/quad_x.main.mix on /dev/pwm_output0
INFO  [init] Mixer: /etc/mixers/pass.aux.mix on /dev/pwm_output1
ekf2 [790:237]
INFO  [pwm_out] instance: 0, max rate: 100, default: 50, alt: 50
Starting Main GPS on /dev/ttyS0
Starting MAVLink on /dev/ttyS6
INFO  [mavlink] mode: Normal, data rate: 1200 B/s on /dev/ttyS6 @ 57600B
Starting MAVLink on ethernet
INFO  [mavlink] mode: Normal, data rate: 100000 B/s on udp port 14550 remote port 14550
INFO  [logger] logger started (mode=all)
INFO  [uavcan] Node ID 1, bitrate 1000000

NuttShell (NSH) NuttX-12.0.0
nsh> WARN  [mavlink] no broadcasting address found
```