### PR TITLE
Fix SITL Test failure: Place PX4 instance runner after Gazebo server runner

### DIFF
--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -430,14 +430,11 @@ class Tester:
                         self.verbose)
                     self.active_runners.append(gzclient_runner)
 
-                '''
-                WARNING: DO NOT PLACE PX4 RUNNER BEFORE GAZEBO RUNNER!
                 # We must start the PX4 instance at the end, as starting
-                it in the beginning, then connecting Gazebo server freaks
-                out the PX4 (it needs to have data coming in when started),
-                and can lead to EKF to freak out, or the instance itself
-                to die unexpectedly.
-                '''
+                # it in the beginning, then connecting Gazebo server freaks
+                # out the PX4 (it needs to have data coming in when started),
+                # and can lead to EKF to freak out, or the instance itself
+                # to die unexpectedly.
                 px4_runner = ph.Px4Runner(
                     os.getcwd(),
                     log_dir,

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -401,17 +401,6 @@ class Tester:
         self.active_runners = []
 
         if self.config['mode'] == 'sitl':
-            px4_runner = ph.Px4Runner(
-                os.getcwd(),
-                log_dir,
-                test['model'],
-                case,
-                self.get_max_speed_factor(test),
-                self.debugger,
-                self.verbose,
-                self.build_dir)
-            self.active_runners.append(px4_runner)
-
             if self.config['simulator'] == 'gazebo':
                 gzserver_runner = ph.GzserverRunner(
                     os.getcwd(),
@@ -440,6 +429,21 @@ class Tester:
                         case,
                         self.verbose)
                     self.active_runners.append(gzclient_runner)
+
+                # WARNING: DO NOT PLACE PX4 RUNNER BEFORE GAZEBO RUNNER! (Keep it as is now)
+                # We must start the PX4 instance at the end, as starting it in the beginning, then connecting
+                # Gazebo server freaks out the PX4 (it needs to have data coming in when started), and can
+                # lead to EKF to freak out, or the instance itself to die unexpectedly.
+                px4_runner = ph.Px4Runner(
+                    os.getcwd(),
+                    log_dir,
+                    test['model'],
+                    case,
+                    self.get_max_speed_factor(test),
+                    self.debugger,
+                    self.verbose,
+                    self.build_dir)
+                self.active_runners.append(px4_runner)
 
         mavsdk_tests_runner = ph.TestRunner(
             os.getcwd(),

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -430,10 +430,14 @@ class Tester:
                         self.verbose)
                     self.active_runners.append(gzclient_runner)
 
-                # WARNING: DO NOT PLACE PX4 RUNNER BEFORE GAZEBO RUNNER! (Keep it as is now)
-                # We must start the PX4 instance at the end, as starting it in the beginning, then connecting
-                # Gazebo server freaks out the PX4 (it needs to have data coming in when started), and can
-                # lead to EKF to freak out, or the instance itself to die unexpectedly.
+                '''
+                WARNING: DO NOT PLACE PX4 RUNNER BEFORE GAZEBO RUNNER!
+                # We must start the PX4 instance at the end, as starting
+                it in the beginning, then connecting Gazebo server freaks
+                out the PX4 (it needs to have data coming in when started),
+                and can lead to EKF to freak out, or the instance itself
+                to die unexpectedly.
+                '''
                 px4_runner = ph.Px4Runner(
                     os.getcwd(),
                     log_dir,


### PR DESCRIPTION
## About
- This was a nasty bug where starting PX4 instance first, then starting Gazebo server was causing PX4 instance' EKF to freak out, probably because it doesn't like getting data a while after it is started
- This now guarantees that such edge case won't occur and MAVSDK test will run as it should

For detailed troubleshooting log, please read: https://github.com/PX4/PX4-Autopilot/issues/21229

### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/21229

### Solution
Start PX4 instance AFTER Gazebo server is started

### Alternatives
We could also make px4 itself robust so that it doesn't freak out when a simulated sensor data starts flowing in after it is instantiated for a while, but that's up for a discussion.

### Test coverage
All 3 out of 4 tests now always pass consistently:
![image](https://user-images.githubusercontent.com/23277211/222257427-75d4a885-c833-4cab-95ba-8322a67f8f2e.png)

NOTE: VTOL Mission Test (4/4) failure isn't related to MAVSDK Test architecture. Reason is given here: https://github.com/PX4/PX4-Autopilot/issues/21229#issuecomment-1450792550

### Comment
I think there's a high chance that this is the root cause of the https://github.com/PX4/PX4-Autopilot/issues/14835 as well.