### PR TITLE
microdds_client: support Agent IP address as PX4 parameter

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -277,7 +277,7 @@ then
 	# Override namespace if environment variable is defined
 	microdds_ns="-n $PX4_MICRODDS_NS"
 fi
-microdds_client start -t udp -p 8888 $microdds_ns
+microdds_client start -t udp -h 127.0.0.1 -p 8888 $microdds_ns
 
 if param greater -s MNT_MODE_IN -1
 then

--- a/Tools/convert_ip.py
+++ b/Tools/convert_ip.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""
+Converts IP address given in decimal dot notation to int32 to be used in XRCE_DDS_0_CFG parameter
+and vice-versa
+
+@author: Beniamino Pozzan (beniamino.pozzan@phd.unipd.it)
+"""
+
+
+import argparse
+
+parser = argparse.ArgumentParser(
+    prog = 'convert_ip',
+    description = 'converts IP to int32 and viceversa'
+    )
+parser.add_argument('input',
+                    type=str,
+                    help='IP address to convert')
+parser.add_argument('-r','--reverse',
+                    action='store_true',
+                    help='converts from int32 to dot decimal')
+
+args = parser.parse_args()
+
+if( args.reverse == False ):
+
+    try:
+        ip_parts = [int(x) for x in args.input.split('.')]
+    except:
+        raise ValueError("Not a valid IP")
+    if( len(ip_parts)!=4 ):
+        raise ValueError("Not a valid IP")
+    if( not all(x>=0 and x<255 for x in ip_parts) ):
+        raise ValueError("Not a valid IP")
+
+    ip = (ip_parts[0]<<24) + (ip_parts[1]<<16) + (ip_parts[2]<<8) + ip_parts[3]
+
+    if(ip & 0x80000000):
+        ip = -0x100000000 + ip
+
+    print("the int32 conversion of", args.input, "is")
+    print(ip)
+
+else:
+    try:
+        ip = int(args.input)
+    except:
+        raise ValueError("Not a valid IP")
+    if(ip < 0):
+        ip = ip + 0x100000000
+    print("the decimal dot conversion of", args.input, "is")
+    print('{}.{}.{}.{}'.format(ip>>24, (ip>>16)&0xff, (ip>>8)&0xff, ip&0xff))

--- a/Tools/convert_ip.py
+++ b/Tools/convert_ip.py
@@ -39,7 +39,6 @@ if( args.reverse == False ):
     if(ip & 0x80000000):
         ip = -0x100000000 + ip
 
-    print("the int32 conversion of", args.input, "is")
     print(ip)
 
 else:
@@ -49,5 +48,4 @@ else:
         raise ValueError("Not a valid IP")
     if(ip < 0):
         ip = ip + 0x100000000
-    print("the decimal dot conversion of", args.input, "is")
     print('{}.{}.{}.{}'.format(ip>>24, (ip>>16)&0xff, (ip>>8)&0xff, ip&0xff))

--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -78,6 +78,17 @@ private:
 	const bool _custom_participant;
 	const char *_client_namespace;
 
+
+	// max port characters (5+'\0')
+	static const uint8_t PORT_MAX_LENGTH = 6;
+	// max agent ip characters (15+'\0')
+	static const uint8_t AGENT_IP_MAX_LENGTH = 16;
+
+#if defined(CONFIG_NET) || defined(__PX4_POSIX)
+	char _port[PORT_MAX_LENGTH];
+	char _agent_ip[AGENT_IP_MAX_LENGTH];
+#endif
+
 	SendTopicsSubs *_subs{nullptr};
 	RcvTopicsPubs *_pubs{nullptr};
 

--- a/src/modules/microdds_client/module.yaml
+++ b/src/modules/microdds_client/module.yaml
@@ -1,16 +1,3 @@
-
-
-# parameters to auto start
-#  mode (normal, minimal)
-#  UDP port
-#  max rate
-#  DDS DOMAIN ID
-#
-
-
-# multiple instances?
-
-
 module_name: Micro XRCE-DDS
 serial_config:
     - command: |
@@ -22,13 +9,8 @@ serial_config:
         microdds_client start ${XRCE_DDS_ARGS}
 
       port_config_param:
-        name: XRCE_DDS_${i}_CFG
+        name: XRCE_DDS_CFG
         group: Micro XRCE-DDS
-        # MAVLink instances:
-        # 0: Telem1 Port (Telemetry Link)
-        # 1: Telem2 Port (Companion Link). Disabled by default to reduce RAM usage
-        # 2: Board-specific / no fixed function or port
-        #default: [TEL1, "", ""]
       supports_networking: true
 
 parameters:
@@ -46,7 +28,7 @@ parameters:
 
         XRCE_DDS_KEY:
             description:
-                short: XRCE DDS key
+                short: XRCE DDS Session key
                 long: |
                     XRCE DDS key, must be different from zero.
                     In a single agent - multi client configuration, each client
@@ -56,13 +38,29 @@ parameters:
             reboot_required: true
             default: 1
 
-        XRCE_DDS_UDP_PRT:
+        XRCE_DDS_PRT:
             description:
                 short: Micro DDS UDP Port
                 long: |
                     If ethernet enabled and selected as configuration for micro DDS,
                     selected udp port will be set and used.
             type: int32
+            min: 0
+            max: 65535
             reboot_required: true
             default: 8888
+            requires_ethernet: true
+
+        XRCE_DDS_AG_IP:
+            description:
+                short: Micro DDS Agent IP address
+                long: |
+                    If ethernet enabled and selected as configuration for micro DDS,
+                    selected Agent IP address will be set and used.
+                    Decimal dot notation is not supported. IP address must be provided
+                    in int32 format. For example, 192.168.1.2 is mapped to -1062731518;
+                    127.0.0.1 is mapped to 2130706433.
+            type: int32
+            reboot_required: true
+            default: 2130706433
             requires_ethernet: true


### PR DESCRIPTION
### Features Implemented

1. Removed incomplete multi instance capability for microdds_client.
2. Added new parameter `XRCE_DDS_AG_IP` that encodes the micro XRCE-DDS Agent IP. Its default value corresponds to `127.0.0.1`.
3. When the client is started without specifying the udp port (missing `-p` argument) then the parameter `XRCE_DDS_PRT` is used.
4. When the client is started without specifying the Agent IP (missing `-h` argument) then the parameter `XRCE_DDS_AG_IP` is used.
5. Increased verbosity of `microdds_client status`.
6. To make the conversion from IP addresses in decimal-dot notation to int32 and vice-versa `Tools/convert_ip.py` is added.

Fixes #21179

### About formatting the IP address as int32
Taking the IP address in decimal-dot notation, converting it in HEX dot notation and the stacking together the 4 bytes is not enough. The parameters in PX4 are **int32**, not **u**int32. Therefore, the resulting 4 byte variable must be written as "the decimal number whose 2-complement representation in 32 bit is my variable". This number can be negative.
Examples:
|IP | IP in hex dot notation | complete HEX number | associated `uint32` | `int32` to write in `XRCE_DDS_${i}_AG_IP`|
|---|---|---|---|---|
|`127.0.0.1` | `7f.00.00.01` | `0x7f000001` | `2130706433` | `2130706433`|
|`192.168.1.2` | `c0.a8.01.02` | `0xc0a80102` | `3232235778` | `-1062731518`|

#### Make the conversions with `Tools/convert_ip.py`
- From decimal-dot notation to int32
   ```sh
  python3 Tools/convert_ip.py xxx.xxx.xxx.xxx
   ```
- From int32 to decimal-dot notation
   ```sh
  python3 Tools/convert_ip.py -r xxxxxx
   ```
![Screenshot from 2023-03-07 23-30-39](https://user-images.githubusercontent.com/38298699/223649398-9a516580-f23b-4818-86cc-cc7a7241c47f.png)


### Test coverage
- **Tested in SITL** starting the client with different combination of parameters. In SITL the agent responds to `127.0.0.1` and `192.168.1.3` (my local IP address, change it accordingly to the tester setup). During the test, the auto-startup of the client on the [startup script](https://github.com/PX4/PX4-Autopilot/blob/6e21e96b50cce8695b65c017ad0f67924b571cf8/ROMFS/px4fmu_common/init.d-posix/rcS#L267-L280) has been disabled
   1. Agent started with `MicroXRCEAgent udp4 -p 9999`. microdds_client started with udp port and IP passed as explicit parameters.
      ```
      microdds_client start -t udp -p 9999 -h 192.168.1.3
      ```      
      ![Screenshot from 2023-03-07 23-49-37](https://user-images.githubusercontent.com/38298699/223653102-6a649410-659f-41fd-979d-045274d7b6bc.png)

   1. Agent started with `MicroXRCEAgent udp4 -p 7777`. microdds_client started with no explicit udp port, `XRCE_DDS_PRT` is used.
      ```
      param set XRCE_DDS_PRT 7777
      microdds_client start -t udp -h 127.0.0.1
      ```
      ![Screenshot from 2023-03-07 23-52-09](https://user-images.githubusercontent.com/38298699/223653626-17f57079-cd1b-4530-8bd1-e98e236fad6d.png)

   1. Agent started with `MicroXRCEAgent udp4 -p 8888`. microdds_client started with no explicit IP address, `XRCE_DDS_AG_IP` is used.
      ```
      param set XRCE_DDS_AG_IP -1062731517
      microdds_client start -t udp -p 8888
      ```
      ![Screenshot from 2023-03-07 23-54-06](https://user-images.githubusercontent.com/38298699/223653996-70448b4e-b2b8-45ff-9991-04647bed73a1.png)
      to replicate, use the matching IP on the tester machine.
   1. Agent started with `MicroXRCEAgent udp4 -p 7777`. microdds_client started with no explicit references to port or IP address, `XRCE_DDS_PRT` and `XRCE_DDS_AG_IP` are used. _This is the default command that autostarts the client when_ `XRCE_DDS_CFG=ETH`.
      ```
      param set XRCE_DDS_PRT 7777
      param set XRCE_DDS_AG_IP -1062731517
      microdds_client start -t udp
      ```
      ![Screenshot from 2023-03-07 23-55-53](https://user-images.githubusercontent.com/38298699/223654371-c815f463-3058-4dce-b2f4-5b50b6e412de.png)
      To replicate, use the matching IP on the tester machine.
 - **Test on real hardware**. I don't have a physical board therefore I cannot set `XRCE_DDS_CFG='ETH'` and test the auto-startup. The testing procedure can be the following:
    1. Configure the [Ethernet connection](https://docs.px4.io/main/en/advanced_config/ethernet_setup.html) of the board and test it.
    7. Set `XRCE_DDS_AG_IP` and `XRCE_DDS_PRT` to the desired values matching the agent configuration.
    8. Set `XRCE_DDS_CFG='ETH'` and reboot the board. It should automatically connect to the running agent. If the parameter is set using mavlink console then the the value must be `1000`.
 
   `XRCE_DDS_AG_IP` and `XRCE_DDS_PRT` may not show up in QGC as they initially result _unused_. In that case swap the order of point 2 and 3 and reboot at the end.