### PR TITLE
mc att: do not pass by euler angles to generate att sp from sticks

### DIFF
--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlMath.hpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlMath.hpp
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file AttitudeControlMath.hpp
+ */
+
+#pragma once
+
+#include <matrix/matrix/math.hpp>
+
+namespace AttitudeControlMath
+{
+/**
+ * Rotate a tilt quaternion (without yaw rotation) such that when rotated by a yaw setpoint
+ * the resulting tilt is the same as if it was rotated by the current yaw of the vehicle
+ * @param q_sp_tilt pure tilt quaternion (yaw = 0) that needs to be corrected
+ * @param q_att current attitude of the vehicle
+ * @param q_sp_yaw pure yaw quaternion of the desired yaw setpoint
+ */
+void inline correctTiltSetpointForYawError(matrix::Quatf &q_sp_tilt, const matrix::Quatf &q_att,
+		const matrix::Quatf &q_sp_yaw)
+{
+	const matrix::Vector3f z_unit(0.f, 0.f, 1.f);
+
+	// Extract yaw from the current attitude
+	const matrix::Vector3f att_z = q_att.dcm_z();
+	const matrix::Quatf q_tilt(z_unit, att_z);
+	const matrix::Quatf q_yaw = q_tilt.inversed() * q_att; // This is not euler yaw
+
+	// Find the quaternion that creates a tilt aligned with the body frame
+	// when rotated by the yaw setpoint
+	// To do so, solve q_yaw * q_tilt_ne = q_sp_yaw * q_sp_rp_compensated
+	const matrix::Quatf q_sp_rp_compensated = q_sp_yaw.inversed() * q_yaw * q_sp_tilt;
+
+	// Extract the corrected tilt
+	const matrix::Vector3f att_sp_z = q_sp_rp_compensated.dcm_z();
+	q_sp_tilt = matrix::Quatf(z_unit, att_sp_z);
+}
+}

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlMathTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlMathTest.cpp
@@ -1,0 +1,92 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "AttitudeControlMath.hpp"
+
+using namespace matrix;
+using namespace AttitudeControlMath;
+
+static const Vector3f z_unit(0.f, 0.f, 1.f);
+
+TEST(AttitudeControlMath, tiltCorrectionNoError)
+{
+	// GIVEN: some desired (non yaw-rotated) tilt setpoint
+	Quatf q_tilt_sp_ne(z_unit, Vector3f(-0.3, 0.1, 0.7));
+
+	// AND: a desired yaw setpoint
+	const Quatf q_sp_yaw = AxisAnglef(z_unit, -1.23f);
+
+	// WHEN: the current yaw error is zero (regardless of the tilt)
+	const Quatf q = q_sp_yaw * Quatf(z_unit, Vector3f(0.1f, -0.2f, 1.f));
+	const Quatf q_tilt_sp_ne_before = q_tilt_sp_ne;
+	correctTiltSetpointForYawError(q_tilt_sp_ne, q, q_sp_yaw);
+
+	// THEN: the tilt setpoint is unchanged
+	EXPECT_TRUE(isEqual(q_tilt_sp_ne_before, q_tilt_sp_ne));
+}
+
+TEST(AttitudeControlMath, tiltCorrectionYaw180)
+{
+	// GIVEN: some desired (non yaw-rotated) tilt setpoint and a desired yaw setpoint
+	Quatf q_tilt_sp_ne(z_unit, Vector3f(-0.3, 0.1, 0.7));
+	const Quatf q_sp_yaw = AxisAnglef(z_unit, -M_PI_F / 2.f);
+
+	// WHEN: there is a yaw error of 180 degrees
+	const Quatf q_yaw = Quatf(AxisAnglef(z_unit, M_PI_F / 2.f));
+	const Quatf q = q_yaw * Quatf(z_unit, Vector3f(0.1f, -0.2f, 1.f));
+	const Quatf q_tilt_sp_ne_before = q_tilt_sp_ne;
+	correctTiltSetpointForYawError(q_tilt_sp_ne, q, q_sp_yaw);
+
+	// THEN: the tilt is reversed (the corrected tilt angle is the same but the axis of rotation is opposite)
+	EXPECT_FLOAT_EQ(AxisAnglef(q_tilt_sp_ne_before).angle(), AxisAnglef(q_tilt_sp_ne).angle());
+	EXPECT_TRUE(isEqual(AxisAnglef(q_tilt_sp_ne_before).axis(), -AxisAnglef(q_tilt_sp_ne).axis()));
+}
+
+TEST(AttitudeControlMath, tiltCorrection)
+{
+	// GIVEN: some desired (non yaw-rotated) tilt setpoint and a desired yaw setpoint
+	Quatf q_tilt_sp_ne(z_unit, Vector3f(0.5, -0.1, 0.7));
+	const Quatf q_sp_yaw = AxisAnglef(z_unit, -1.23f);
+
+	// WHEN: there is a some yaw error
+	const Quatf q_yaw = Quatf(AxisAnglef(z_unit, 3.1f));
+	const Quatf q = q_yaw * Quatf(z_unit, Vector3f(0.1f, -0.2f, 1.f));
+	const Quatf q_tilt_sp_ne_before = q_tilt_sp_ne;
+	correctTiltSetpointForYawError(q_tilt_sp_ne, q, q_sp_yaw);
+
+	// THEN: the tilt vector obtained by rotating the corrected tilt by the yaw setpoint is the same as
+	// the one obtained by rotating the initial tilt by the current yaw of the vehicle
+	EXPECT_TRUE(isEqual((q_sp_yaw * q_tilt_sp_ne).dcm_z(), (q_yaw * q_tilt_sp_ne_before).dcm_z()));
+}

--- a/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
+++ b/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
@@ -34,6 +34,7 @@
 px4_add_library(AttitudeControl
 	AttitudeControl.cpp
 	AttitudeControl.hpp
+	AttitudeControlMath.hpp
 )
 target_compile_options(AttitudeControl PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 target_include_directories(AttitudeControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
+++ b/src/modules/mc_att_control/AttitudeControl/CMakeLists.txt
@@ -40,3 +40,4 @@ target_compile_options(AttitudeControl PRIVATE ${MAX_CUSTOM_OPT_LEVEL})
 target_include_directories(AttitudeControl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 px4_add_unit_gtest(SRC AttitudeControlTest.cpp LINKLIBS AttitudeControl)
+px4_add_unit_gtest(SRC AttitudeControlMathTest.cpp LINKLIBS AttitudeControl)

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -149,56 +149,46 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt,
 		v *= _man_tilt_max / v_norm;
 	}
 
-	Quatf q_sp_rpy = AxisAnglef(v(0), v(1), 0.f);
-	Eulerf euler_sp = q_sp_rpy;
-	attitude_setpoint.roll_body = euler_sp(0);
-	attitude_setpoint.pitch_body = euler_sp(1);
+	Quatf q_sp_rp = AxisAnglef(v(0), v(1), 0.f);
 	// The axis angle can change the yaw as well (noticeable at higher tilt angles).
 	// This is the formula by how much the yaw changes:
 	//   let a := tilt angle, b := atan(y/x) (direction of maximum tilt)
 	//   yaw = atan(-2 * sin(b) * cos(b) * sin^2(a/2) / (1 - 2 * cos^2(b) * sin^2(a/2))).
-	attitude_setpoint.yaw_body = _man_yaw_sp + euler_sp(2);
+	const Quatf q_sp_yaw(cosf(_man_yaw_sp / 2.f), 0.f, 0.f, sinf(_man_yaw_sp / 2.f));
 
-	/* modify roll/pitch only if we're a VTOL */
 	if (_vtol) {
-		// Construct attitude setpoint rotation matrix. Modify the setpoints for roll
-		// and pitch such that they reflect the user's intention even if a large yaw error
-		// (yaw_sp - yaw) is present. In the presence of a yaw error constructing a rotation matrix
-		// from the pure euler angle setpoints will lead to unexpected attitude behaviour from
-		// the user's view as the euler angle sequence uses the  yaw setpoint and not the current
-		// heading of the vehicle.
-		// However there's also a coupling effect that causes oscillations for fast roll/pitch changes
-		// at higher tilt angles, so we want to avoid using this on multicopters.
-		// The effect of that can be seen with:
-		// - roll/pitch into one direction, keep it fixed (at high angle)
-		// - apply a fast yaw rotation
-		// - look at the roll and pitch angles: they should stay pretty much the same as when not yawing
+		// Modify the setpoints for roll and pitch such that they reflect the user's intention even
+		// if a large yaw error(yaw_sp - yaw) is present. In the presence of a yaw error constructing
+		// an attitude setpoint from the yaw setpoint will lead to unexpected attitude behaviour from
+		// the user's view as the tilt will not be aligned with the heading of the vehicle.
 
-		// calculate our current yaw error
-		float yaw_error = wrap_pi(attitude_setpoint.yaw_body - yaw);
+		const Vector3f z_unit(0.f, 0.f, 1.f);
 
-		// compute the vector obtained by rotating a z unit vector by the rotation
-		// given by the roll and pitch commands of the user
-		Vector3f zB = {0.0f, 0.0f, 1.0f};
-		Dcmf R_sp_roll_pitch = Eulerf(attitude_setpoint.roll_body, attitude_setpoint.pitch_body, 0.0f);
-		Vector3f z_roll_pitch_sp = R_sp_roll_pitch * zB;
+		// Extract yaw from the current attitude
+		Vector3f att_z = q.dcm_z();
+		Quatf q_delta = Quatf(z_unit, att_z);
+		Quatf q_yaw = q_delta.inversed() * q; // This is not euler yaw
 
-		// transform the vector into a new frame which is rotated around the z axis
-		// by the current yaw error. this vector defines the desired tilt when we look
-		// into the direction of the desired heading
-		Dcmf R_yaw_correction = Eulerf(0.0f, 0.0f, -yaw_error);
-		z_roll_pitch_sp = R_yaw_correction * z_roll_pitch_sp;
+		// Find the quaternion that creates a tilt aligned with the body frame
+		// when rotated by the yaw setpoint
+		// To do so, solve q_yaw * q_sp_rp = q_sp_yaw * q_sp_rp_compensated
+		Quatf q_sp_rp_compensated = q_sp_yaw.inversed() * q_yaw * q_sp_rp;
 
-		// use the formula z_roll_pitch_sp = R_tilt * [0;0;1]
-		// R_tilt is computed from_euler; only true if cos(roll) not equal zero
-		// -> valid if roll is not +-pi/2;
-		attitude_setpoint.roll_body = -asinf(z_roll_pitch_sp(1));
-		attitude_setpoint.pitch_body = atan2f(z_roll_pitch_sp(0), z_roll_pitch_sp(2));
+		// Extract the corrected tilt as we still want to include the yaw setpoint
+		Vector3f att_sp_z = q_sp_rp_compensated.dcm_z();
+		q_sp_rp = Quatf(z_unit, att_sp_z);
 	}
 
-	/* copy quaternion setpoint to attitude setpoint topic */
-	Quatf q_sp = Eulerf(attitude_setpoint.roll_body, attitude_setpoint.pitch_body, attitude_setpoint.yaw_body);
+	// Align the desired tilt with the yaw setpoint
+	Quatf q_sp = q_sp_yaw * q_sp_rp;
+
 	q_sp.copyTo(attitude_setpoint.q_d);
+
+	// Transform to euler angles for logging only
+	const Eulerf euler_sp(q_sp);
+	attitude_setpoint.roll_body = euler_sp(0);
+	attitude_setpoint.pitch_body = euler_sp(1);
+	attitude_setpoint.yaw_body = euler_sp(2);
 
 	attitude_setpoint.thrust_body[2] = -throttle_curve((_manual_control_setpoint.throttle + 1.f) * .5f);
 	attitude_setpoint.timestamp = hrt_absolute_time();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Passing by Euler angles to adjust roll/pitch and yaw independently produces unwanted artifacts and is generally not an attitude representation we would like to use in the autopilot.

TODO:
- [x] extract and cover by unit tests

### Solution
Generate manual attitude setpoints with quaternions.

### Alternatives
We could also use rotation matrices .

### Test coverage
- sitl tests with large yaw error and `if (_vtol)` forced to true. Both implementations "feel" the same: the tilt is always aligned with the body frame 

main:
![DeepinScreenshot_select-area_20230303113845](https://user-images.githubusercontent.com/14822839/222719937-efd62cf6-bf9f-4f67-a0e0-79772d08833c.png)

PR:
![DeepinScreenshot_select-area_20230303121121](https://user-images.githubusercontent.com/14822839/222719803-7c8d2269-c317-47f0-99c0-15e3f3c5a7be.png)

Also tested at pitch = 90 deg, for the VTOL case, unlike before, applying a yaw stick input creates a pure roll rate
![DeepinScreenshot_select-area_20230306151607](https://user-images.githubusercontent.com/14822839/223463080-3e1254cb-775d-4e6f-8692-1b751b82dc67.png)
