### PR TITLE
Fix missing return in actionStr function

### DIFF
--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -112,7 +112,8 @@ public:
 
 		case Action::Terminate: return "Terminate";
 
-		case Action::Count: return "(invalid)";
+		case Action::Count:
+		default: return "(invalid)";
 		}
 	}
 


### PR DESCRIPTION
There needs to be a default statement for the compiler to work when this function is called. Apparently it is never called in the codebase.
