### PR TITLE
init.d-posix/px4-rc.simulator: adds non-default LAT and LON as optional environment variables

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -8,6 +8,14 @@ if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0"
 
 	echo "INFO  [init] SIH simulator"
 
+	if [ ! -z "${PX4_HOME_LAT}" ]; then
+		param set SIH_LOC_LAT0 ${PX4_HOME_LAT}
+	fi
+
+	if [ ! -z "${PX4_HOME_LON}" ]; then
+		param set SIH_LOC_LON0 ${PX4_HOME_LON}
+	fi
+
 	if simulator_sih start; then
 
 		if param compare -s SENS_EN_BAROSIM 1


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Allows a user to specify a starting location for `sihsim` via environment variables like the `PX4_SIMULATOR` environment variable required for `sihsim`.

### Solution

- Checks to see if `PX4_HOME_LAT` and `PX4_HOME_LON` are set and then calls `param set` on `SIH_LOC_LAT0` and `SIH_LOC_LON0`, respectively.

### Alternatives

- `param set-default` might be a better option?
- we could also add an environment variable for `SIH_LOC_H0`

