### PR TITLE
mavlink: adds gps injection

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -230,6 +230,10 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 		handle_message_gps_rtcm_data(msg);
 		break;
 
+	case MAVLINK_MSG_ID_GPS_INJECT_DATA:
+		handle_message_gps_inject_data(msg);
+		break;
+
 	case MAVLINK_MSG_ID_BATTERY_STATUS:
 		handle_message_battery_status(msg);
 		break;
@@ -2693,6 +2697,21 @@ MavlinkReceiver::handle_message_collision(mavlink_message_t *msg)
 	collision_report.horizontal_minimum_delta = collision.horizontal_minimum_delta;
 
 	_collision_report_pub.publish(collision_report);
+}
+
+void
+MavlinkReceiver::handle_message_gps_inject_data(mavlink_message_t *msg)
+{
+	mavlink_gps_inject_data_t gps_inject_msg = {};
+	mavlink_msg_gps_inject_data_decode(msg, &gps_inject_msg);
+
+	gps_inject_data_s gps_inject_data_topic = {};
+	gps_inject_data_topic.len = gps_inject_msg.len;
+	gps_inject_data_topic.flags = 0;
+	memcpy(gps_inject_data_topic.data, gps_inject_msg.data, gps_inject_msg.len);
+
+	gps_inject_data_topic.timestamp = hrt_absolute_time();
+	_gps_inject_data_pub.publish(gps_inject_data_topic);
 }
 
 void

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -169,6 +169,7 @@ private:
 	void handle_message_generator_status(mavlink_message_t *msg);
 	void handle_message_set_gps_global_origin(mavlink_message_t *msg);
 	void handle_message_gps_rtcm_data(mavlink_message_t *msg);
+	void handle_message_gps_inject_data(mavlink_message_t *msg);
 	void handle_message_heartbeat(mavlink_message_t *msg);
 	void handle_message_hil_gps(mavlink_message_t *msg);
 	void handle_message_hil_optical_flow(mavlink_message_t *msg);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Adds support for `GPS_INJECT_DATA` mavlink message (id=`123`) in `common.xml` dialect in `mavlink_receiver.cpp`.

### Solution

- adds `handle_message_gps_inject_data` method
- parses `mavlink_gps_inject_data_t` and publishes data to `_gps_inject_data_pub`

### Test coverage

- I've used this in production for a little more than 2 years on v1.11 through v1.13
