### PR TITLE
Matrix: Vector4 and proper gtest failure output

### DIFF
--- a/cmake/gtest/CMakeLists.txt.in
+++ b/cmake/gtest/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-	URL https://github.com/google/googletest/archive/58d77fa8070e8cec2dc1ed015d66b454c8d78850.zip # 1.12.1
+	URL https://github.com/google/googletest/archive/b796f7d44681514f58a683a3a71ff17c94edb0c1.zip # 1.13
 	SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
 	BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
 	CONFIGURE_COMMAND ""

--- a/cmake/gtest/gtest.cmake
+++ b/cmake/gtest/gtest.cmake
@@ -46,4 +46,7 @@ add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src ${CMAKE_CURRENT_BINA
 get_target_property(GTEST_COMPILE_FLAGS gtest COMPILE_OPTIONS)
 list(REMOVE_ITEM GTEST_COMPILE_FLAGS "-include")
 list(REMOVE_ITEM GTEST_COMPILE_FLAGS "visibility.h")
+# Remove float warnings added by PX4 which trigger in gtest-printers.h
+list(REMOVE_ITEM GTEST_COMPILE_FLAGS "-Wdouble-promotion")
+list(REMOVE_ITEM GTEST_COMPILE_FLAGS "-Wfloat-equal")
 set_target_properties(gtest PROPERTIES COMPILE_OPTIONS "${GTEST_COMPILE_FLAGS}")

--- a/src/lib/matrix/matrix/Dual.hpp
+++ b/src/lib/matrix/matrix/Dual.hpp
@@ -92,6 +92,16 @@ struct Dual {
 		return (*this = *this / a);
 	}
 
+	bool operator==(const Dual<Scalar, N> &other) const
+	{
+		return isEqualF(value, other.value) && (derivative == other.derivative);
+	}
+
+	bool operator!=(const Dual<Scalar, N> &other) const
+	{
+		const Dual<Scalar, N> &self = *this;
+		return !(self == other);
+	}
 };
 
 // operators
@@ -359,23 +369,12 @@ Matrix<Scalar, M, N> collectReals(const Matrix<Dual<Scalar, D>, M, N> &input)
 	return r;
 }
 
-#if defined(SUPPORT_STDIOSTREAM)
-template<typename Type, size_t N>
-std::ostream &operator<<(std::ostream &os,
-			 const matrix::Dual<Type, N> &dual)
+template<typename OStream, typename Type, size_t N>
+OStream &operator<<(OStream &os, const matrix::Dual<Type, N> &dual)
 {
-	os << "[";
-	os << std::setw(10) << dual.value << ";";
-
-	for (size_t j = 0; j < N; ++j) {
-		os << "\t";
-		os << std::setw(10) << static_cast<double>(dual.derivative(j));
-	}
-
-	os << "]";
+	os << "\nValue: " << dual.value << "\nDerivative:" << dual.derivative;
 	return os;
 }
-#endif // defined(SUPPORT_STDIOSTREAM)
 
 }
 

--- a/src/lib/matrix/matrix/Matrix.hpp
+++ b/src/lib/matrix/matrix/Matrix.hpp
@@ -12,11 +12,6 @@
 #include <cstdio>
 #include <cstring>
 
-#if defined(SUPPORT_STDIOSTREAM)
-#include <iostream>
-#include <iomanip>
-#endif // defined(SUPPORT_STDIOSTREAM)
-
 #include "math.hpp"
 
 namespace matrix
@@ -816,24 +811,18 @@ Matrix<Type, M, N> constrain(const Matrix<Type, M, N> &x,
 	return m;
 }
 
-#if defined(SUPPORT_STDIOSTREAM)
-template<typename Type, size_t  M, size_t N>
-std::ostream &operator<<(std::ostream &os,
-			 const matrix::Matrix<Type, M, N> &matrix)
+template<typename OStream, typename Type, size_t M, size_t N>
+OStream &operator<<(OStream &os, const matrix::Matrix<Type, M, N> &matrix)
 {
-	for (size_t i = 0; i < M; ++i) {
-		os << "[";
-
-		for (size_t j = 0; j < N; ++j) {
-			os << std::setw(10) << matrix(i, j);
-			os << "\t";
-		}
-
-		os << "]" << std::endl;
-	}
+	os << "\n";
+	// element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
+	static const size_t n = 15 * N * M + M + 1;
+	char *buf = new char[n];
+	matrix.write_string(buf, n);
+	os << buf;
+	delete[] buf;
 
 	return os;
 }
-#endif // defined(SUPPORT_STDIOSTREAM)
 
 } // namespace matrix

--- a/src/lib/matrix/matrix/Matrix.hpp
+++ b/src/lib/matrix/matrix/Matrix.hpp
@@ -367,10 +367,9 @@ public:
 	{
 		// element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
 		static const size_t n = 15 * N * M + M + 1;
-		char *buf = new char[n];
-		write_string(buf, n);
-		printf("%s\n", buf);
-		delete[] buf;
+		char string[n];
+		write_string(string, n);
+		printf("%s\n", string);
 	}
 
 	Matrix<Type, N, M> transpose() const
@@ -817,11 +816,9 @@ OStream &operator<<(OStream &os, const matrix::Matrix<Type, M, N> &matrix)
 	os << "\n";
 	// element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
 	static const size_t n = 15 * N * M + M + 1;
-	char *buf = new char[n];
-	matrix.write_string(buf, n);
-	os << buf;
-	delete[] buf;
-
+	char string[n];
+	matrix.write_string(string, n);
+	os << string;
 	return os;
 }
 

--- a/src/lib/matrix/matrix/Quaternion.hpp
+++ b/src/lib/matrix/matrix/Quaternion.hpp
@@ -50,7 +50,7 @@ class AxisAngle;
  * described by this class.
  */
 template<typename Type>
-class Quaternion : public Vector<Type, 4>
+class Quaternion : public Vector4<Type>
 {
 public:
 	using Matrix41 = Matrix<Type, 4, 1>;
@@ -62,7 +62,7 @@ public:
 	 * @param data_ array
 	 */
 	explicit Quaternion(const Type data_[4]) :
-		Vector<Type, 4>(data_)
+		Vector4<Type>(data_)
 	{
 	}
 
@@ -84,7 +84,7 @@ public:
 	 * @param other Matrix41 to copy
 	 */
 	Quaternion(const Matrix41 &other) :
-		Vector<Type, 4>(other)
+		Vector4<Type>(other)
 	{
 	}
 

--- a/src/lib/matrix/matrix/Vector.hpp
+++ b/src/lib/matrix/matrix/Vector.hpp
@@ -161,11 +161,9 @@ OStream &operator<<(OStream &os, const matrix::Vector<Type, M> &vector)
 	os << "\n";
 	// element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
 	static const size_t n = 15 * M * 1 + 1 + 1;
-	char *buf = new char[n];
-	vector.transpose().write_string(buf, n);
-	os << buf;
-	delete[] buf;
-
+	char string[n];
+	vector.transpose().write_string(string, n);
+	os << string;
 	return os;
 }
 

--- a/src/lib/matrix/matrix/Vector.hpp
+++ b/src/lib/matrix/matrix/Vector.hpp
@@ -148,6 +148,25 @@ public:
 
 		return r;
 	}
+
+	void print() const
+	{
+		(*this).transpose().print();
+	}
 };
+
+template<typename OStream, typename Type, size_t M>
+OStream &operator<<(OStream &os, const matrix::Vector<Type, M> &vector)
+{
+	os << "\n";
+	// element: tab, point, 8 digits, 4 scientific notation chars; row: newline; string: \0 end
+	static const size_t n = 15 * M * 1 + 1 + 1;
+	char *buf = new char[n];
+	vector.transpose().write_string(buf, n);
+	os << buf;
+	delete[] buf;
+
+	return os;
+}
 
 } // namespace matrix

--- a/src/lib/matrix/matrix/Vector4.hpp
+++ b/src/lib/matrix/matrix/Vector4.hpp
@@ -1,0 +1,95 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file Vector4.hpp
+ *
+ * 4D vector class.
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template <typename Type, size_t M, size_t N>
+class Matrix;
+
+template <typename Type, size_t M>
+class Vector;
+
+template<typename Type>
+class Vector4 : public Vector<Type, 4>
+{
+public:
+	using Matrix41 = Matrix<Type, 4, 1>;
+
+	Vector4() = default;
+
+	Vector4(const Matrix41 &other) :
+		Vector<Type, 4>(other)
+	{
+	}
+
+	explicit Vector4(const Type data_[3]) :
+		Vector<Type, 4>(data_)
+	{
+	}
+
+	Vector4(Type x1, Type x2, Type x3, Type x4)
+	{
+		Vector4 &v(*this);
+		v(0) = x1;
+		v(1) = x2;
+		v(2) = x3;
+		v(3) = x4;
+	}
+
+	template<size_t P, size_t Q>
+	Vector4(const Slice<Type, 4, 1, P, Q> &slice_in) : Vector<Type, 4>(slice_in)
+	{
+	}
+
+	template<size_t P, size_t Q>
+	Vector4(const Slice<Type, 1, 4, P, Q> &slice_in) : Vector<Type, 4>(slice_in)
+	{
+	}
+};
+
+using Vector4f = Vector4<float>;
+
+} // namespace matrix

--- a/src/lib/matrix/matrix/math.hpp
+++ b/src/lib/matrix/matrix/math.hpp
@@ -11,6 +11,7 @@
 #include "Vector.hpp"
 #include "Vector2.hpp"
 #include "Vector3.hpp"
+#include "Vector4.hpp"
 #include "Euler.hpp"
 #include "Dcm.hpp"
 #include "Scalar.hpp"

--- a/src/lib/matrix/test/MatrixAttitudeTest.cpp
+++ b/src/lib/matrix/test/MatrixAttitudeTest.cpp
@@ -260,7 +260,7 @@ TEST(MatrixAttitudeTest, Attitude)
 
 	// quaterion copy ctors
 	float data_v4[] = {1, 2, 3, 4};
-	Vector<float, 4> v4(data_v4);
+	Vector4f v4(data_v4);
 	Quatf q_from_v(v4);
 	EXPECT_EQ(q_from_v, v4);
 
@@ -270,15 +270,13 @@ TEST(MatrixAttitudeTest, Attitude)
 
 	// quaternion derivative in frame 1
 	Quatf q1(0, 1, 0, 0);
-	Vector<float, 4> q1_dot1 = q1.derivative1(Vector3f(1, 2, 3));
-	float data_q_dot1_check[] = { -0.5f, 0.0f, -1.5f, 1.0f};
-	Vector<float, 4> q1_dot1_check(data_q_dot1_check);
+	Vector4f q1_dot1 = q1.derivative1(Vector3f(1, 2, 3));
+	Vector4f q1_dot1_check(-0.5f, 0.0f, -1.5f, 1.0f);
 	EXPECT_EQ(q1_dot1, q1_dot1_check);
 
 	// quaternion derivative in frame 2
-	Vector<float, 4> q1_dot2 = q1.derivative2(Vector3f(1, 2, 3));
-	float data_q_dot2_check[] = { -0.5f, 0.0f, 1.5f, -1.0f};
-	Vector<float, 4> q1_dot2_check(data_q_dot2_check);
+	Vector4f q1_dot2 = q1.derivative2(Vector3f(1, 2, 3));
+	Vector4f q1_dot2_check(-0.5f, 0.0f, 1.5f, -1.0f);
 	EXPECT_EQ(q1_dot2, q1_dot2_check);
 
 	// quaternion product

--- a/src/lib/matrix/test/MatrixDualTest.cpp
+++ b/src/lib/matrix/test/MatrixDualTest.cpp
@@ -39,12 +39,6 @@
 
 using namespace matrix;
 
-template <typename Scalar, size_t N>
-bool isEqualAll(Dual<Scalar, N> a, Dual<Scalar, N> b)
-{
-	return isEqualF(a.value, b.value) && a.derivative == b.derivative;
-}
-
 template <typename T>
 T testFunction(const Vector<T, 3> &point)
 {
@@ -83,9 +77,9 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_FLOAT_EQ(c.derivative(0), 2.f);
 
 		Dual<float, 1> d = +a;
-		EXPECT_TRUE(isEqualAll(d, a));
+		EXPECT_EQ(d, a);
 		d += b;
-		EXPECT_TRUE(isEqualAll(d, c));
+		EXPECT_EQ(d, c);
 
 		Dual<float, 1> e = a;
 		e += b.value;
@@ -93,7 +87,7 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_EQ(e.derivative, a.derivative);
 
 		Dual<float, 1> f = b.value + a;
-		EXPECT_TRUE(isEqualAll(f, e));
+		EXPECT_EQ(f, e);
 	}
 
 	{
@@ -103,9 +97,9 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_FLOAT_EQ(c.derivative(0), 0.f);
 
 		Dual<float, 1> d = b;
-		EXPECT_TRUE(isEqualAll(d, b));
+		EXPECT_EQ(d, b);
 		d -= a;
-		EXPECT_TRUE(isEqualAll(d, c));
+		EXPECT_EQ(d, c);
 
 		Dual<float, 1> e = b;
 		e -= a.value;
@@ -113,7 +107,7 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_EQ(e.derivative, b.derivative);
 
 		Dual<float, 1> f = a.value - b;
-		EXPECT_TRUE(isEqualAll(f, -e));
+		EXPECT_EQ(f, -e);
 	}
 
 	{
@@ -123,9 +117,9 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_FLOAT_EQ(c.derivative(0), 9.f);
 
 		Dual<float, 1> d = a;
-		EXPECT_TRUE(isEqualAll(d, a));
+		EXPECT_EQ(d, a);
 		d *= b;
-		EXPECT_TRUE(isEqualAll(d, c));
+		EXPECT_EQ(d, c);
 
 		Dual<float, 1> e = a;
 		e *= b.value;
@@ -133,7 +127,7 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_EQ(e.derivative, a.derivative * b.value);
 
 		Dual<float, 1> f = b.value * a;
-		EXPECT_TRUE(isEqualAll(f, e));
+		EXPECT_EQ(f, e);
 	}
 
 	{
@@ -143,9 +137,9 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_FLOAT_EQ(c.derivative(0), -1.f / 3.f);
 
 		Dual<float, 1> d = b;
-		EXPECT_TRUE(isEqualAll(d, b));
+		EXPECT_EQ(d, b);
 		d /= a;
-		EXPECT_TRUE(isEqualAll(d, c));
+		EXPECT_EQ(d, c);
 
 		Dual<float, 1> e = b;
 		e /= a.value;
@@ -153,7 +147,7 @@ TEST(MatrixDualTest, Dual)
 		EXPECT_EQ(e.derivative, b.derivative / a.value);
 
 		Dual<float, 1> f = a.value / b;
-		EXPECT_TRUE(isEqualAll(f, 1.f / e));
+		EXPECT_EQ(f, 1.f / e);
 	}
 
 	{
@@ -170,9 +164,9 @@ TEST(MatrixDualTest, Dual)
 
 	{
 		// abs
-		EXPECT_TRUE(isEqualAll(a, abs(-a)));
-		EXPECT_FALSE(isEqualAll(-a, abs(a)));
-		EXPECT_TRUE(isEqualAll(-a, -abs(a)));
+		EXPECT_EQ(a, abs(-a));
+		EXPECT_NE(-a, abs(a));
+		EXPECT_EQ(-a, -abs(a));
 	}
 
 	{
@@ -197,8 +191,8 @@ TEST(MatrixDualTest, Dual)
 
 	{
 		// max/min
-		EXPECT_TRUE(isEqualAll(b, max(a, b)));
-		EXPECT_TRUE(isEqualAll(a, min(a, b)));
+		EXPECT_EQ(b, max(a, b));
+		EXPECT_EQ(a, min(a, b));
 	}
 
 	{
@@ -248,7 +242,7 @@ TEST(MatrixDualTest, Dual)
 	{
 		// atan2
 		EXPECT_FLOAT_EQ(atan2(a, b).value, atan2(a.value, b.value));
-		EXPECT_TRUE(isEqualAll(atan2(a, Dual<float, 1>(b.value)), atan(a / b.value))); // atan2'(y, x) = atan'(y/x)
+		EXPECT_EQ(atan2(a, Dual<float, 1>(b.value)), atan(a / b.value)); // atan2'(y, x) = atan'(y/x)
 	}
 
 	{

--- a/src/lib/matrix/test/MatrixLeastSquaresTest.cpp
+++ b/src/lib/matrix/test/MatrixLeastSquaresTest.cpp
@@ -50,19 +50,12 @@ TEST(MatrixLeastSquaresTest, 4x3)
 			  -1.f,  -1.1f,  -1.2f
 			 };
 	Matrix<float, 4, 3> A(data);
-
-	float b_data[4] = {2.0f, 3.0f, 4.0f, 5.0f};
-	Vector<float, 4> b(b_data);
-
-	float x_check_data[3] = {-0.69168233f,
-				 -0.26227593f,
-				 -1.03767522f
-				};
-	Vector<float, 3> x_check(x_check_data);
+	Vector4f b(2.0f, 3.0f, 4.0f, 5.0f);
+	Vector3f x_check(-0.69168233f, -0.26227593f, -1.03767522f);
 
 	LeastSquaresSolver<float, 4, 3> qrd = LeastSquaresSolver<float, 4, 3>(A);
 
-	Vector<float, 3> x = qrd.solve(b);
+	Vector3f x = qrd.solve(b);
 	EXPECT_EQ(x, x_check);
 }
 
@@ -75,20 +68,12 @@ TEST(MatrixLeastSquaresTest, 4x4)
 				 -1.f,  -1.1f,  -1.2f,  -1.3f
 			       };
 	Matrix<float, 4, 4> A(data);
-
-	float b_data[4] = {2.0f, 3.0f, 4.0f, 5.0f};
-	Vector<float, 4> b(b_data);
-
-	float x_check_data[4] = { 0.97893433f,
-				  -2.80798701f,
-				  -0.03175765f,
-				  -2.19387649f
-				};
-	Vector<float, 4> x_check(x_check_data);
+	Vector4f b(2.0f, 3.0f, 4.0f, 5.0f);
+	Vector4f x_check(0.97893433f, -2.80798701f, -0.03175765f, -2.19387649f);
 
 	LeastSquaresSolver<float, 4, 4> qrd = LeastSquaresSolver<float, 4, 4>(A);
 
-	Vector<float, 4> x = qrd.solve(b);
+	Vector4f x = qrd.solve(b);
 	EXPECT_EQ(x, x_check);
 }
 

--- a/src/lib/matrix/test/MatrixSparseVectorTest.cpp
+++ b/src/lib/matrix/test/MatrixSparseVectorTest.cpp
@@ -92,11 +92,11 @@ TEST(MatrixSparseVectorTest, setZero)
 
 TEST(MatrixSparseVectorTest, additionWithDenseVector)
 {
-	Vector<float, 4> dense_vec;
+	Vector4f dense_vec;
 	dense_vec.setAll(1.f);
 	const float data[3] = {1.f, 2.f, 3.f};
 	const SparseVectorf<4, 1, 2, 3> sparse_vec(data);
-	const Vector<float, 4> res = sparse_vec + dense_vec;
+	const Vector4f res = sparse_vec + dense_vec;
 	EXPECT_FLOAT_EQ(res(0), 1.f);
 	EXPECT_FLOAT_EQ(res(1), 2.f);
 	EXPECT_FLOAT_EQ(res(2), 3.f);
@@ -115,7 +115,7 @@ TEST(MatrixSparseVectorTest, addScalar)
 
 TEST(MatrixSparseVectorTest, dotProductWithDenseVector)
 {
-	Vector<float, 4> dense_vec;
+	Vector4f dense_vec;
 	dense_vec.setAll(3.f);
 	const float data[3] = {1.f, 2.f, 3.f};
 	const SparseVectorf<4, 1, 2, 3> sparse_vec(data);

--- a/src/lib/matrix/test/MatrixVector3Test.cpp
+++ b/src/lib/matrix/test/MatrixVector3Test.cpp
@@ -71,13 +71,7 @@ TEST(MatrixVector3Test, Vector3)
 
 	Vector3f h;
 	EXPECT_EQ(h, Vector3f(0, 0, 0));
-
-	Vector<float, 4> j;
-	j(0) = 1;
-	j(1) = 2;
-	j(2) = 3;
-	j(3) = 4;
-
+	Vector4f j(1.f, 2.f, 3.f, 4.f);
 	Vector3f k = j.slice<3, 1>(0, 0);
 	Vector3f k_test(1, 2, 3);
 	EXPECT_EQ(k, k_test);

--- a/src/lib/matrix/test/MatrixVector4Test.cpp
+++ b/src/lib/matrix/test/MatrixVector4Test.cpp
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <matrix/math.hpp>
+
+using namespace matrix;
+
+TEST(MatrixVector3Test, Vector3)
+{
+	Vector4f a(1.f, 2.f, 3.f, 4.f);
+	EXPECT_EQ(a(0), 1.f);
+	EXPECT_EQ(a(1), 2.f);
+	EXPECT_EQ(a(2), 3.f);
+	EXPECT_EQ(a(3), 4.f);
+}

--- a/src/lib/system_identification/arx_rls_test.cpp
+++ b/src/lib/system_identification/arx_rls_test.cpp
@@ -61,9 +61,8 @@ TEST_F(ArxRlsTest, test211)
 	_rls.update(1, 2);
 	_rls.update(3, 4);
 	_rls.update(5, 6);
-	const Vector<float, 4> coefficients = _rls.getCoefficients();
-	float data_check[] = {-1.79f, 0.97f, 0.42f, -0.48f}; // generated from Python script
-	const Vector<float, 4> coefficients_check(data_check);
+	const Vector4f coefficients = _rls.getCoefficients();
+	const Vector4f coefficients_check(-1.79f, 0.97f, 0.42f, -0.48f); // generated from Python script
 	float eps = 1e-2;
 	EXPECT_TRUE((coefficients - coefficients_check).abs().max() < eps);
 }

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -64,7 +64,6 @@ public:
 	typedef matrix::Vector<float, _k_num_states> Vector24f;
 	typedef matrix::SquareMatrix<float, _k_num_states> SquareMatrix24f;
 	typedef matrix::SquareMatrix<float, 2> Matrix2f;
-	typedef matrix::Vector<float, 4> Vector4f;
 	template<int ... Idxs>
 
 	using SparseVector24f = matrix::SparseVectorf<24, Idxs...>;

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -250,9 +250,9 @@ float EkfWrapper::getYawAngle() const
 	return euler(2);
 }
 
-matrix::Vector<float, 4> EkfWrapper::getQuaternionVariance() const
+matrix::Vector4f EkfWrapper::getQuaternionVariance() const
 {
-	return matrix::Vector<float, 4>(_ekf->orientation_covariances().diag());
+	return matrix::Vector4f(_ekf->orientation_covariances().diag());
 }
 
 int EkfWrapper::getQuaternionResetCounter() const

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -111,7 +111,7 @@ public:
 
 	Eulerf getEulerAngles() const;
 	float getYawAngle() const;
-	matrix::Vector<float, 4> getQuaternionVariance() const;
+	matrix::Vector4f getQuaternionVariance() const;
 	int getQuaternionResetCounter() const;
 
 	matrix::Vector3f getDeltaVelBiasVariance() const;

--- a/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
@@ -331,9 +331,9 @@ TEST_F(EkfGpsHeadingTest, stopOnGround)
 	_ekf_wrapper.setMagFuseTypeNone();
 
 	// WHEN: running without yaw aiding
-	const matrix::Vector<float, 4> quat_variance_before = _ekf_wrapper.getQuaternionVariance();
+	const matrix::Vector4f quat_variance_before = _ekf_wrapper.getQuaternionVariance();
 	_sensor_simulator.runSeconds(20.0);
-	const matrix::Vector<float, 4> quat_variance_after = _ekf_wrapper.getQuaternionVariance();
+	const matrix::Vector4f quat_variance_after = _ekf_wrapper.getQuaternionVariance();
 
 	// THEN: the yaw variance is constrained by fusing constant data
 	EXPECT_LT(quat_variance_after(3), quat_variance_before(3));

--- a/src/modules/ekf2/test/test_EKF_initialization.cpp
+++ b/src/modules/ekf2/test/test_EKF_initialization.cpp
@@ -83,7 +83,7 @@ public:
 
 	void quaternionVarianceBigEnoughAfterOrientationInitialization()
 	{
-		const matrix::Vector<float, 4> quat_variance = _ekf_wrapper.getQuaternionVariance();
+		const matrix::Vector4f quat_variance = _ekf_wrapper.getQuaternionVariance();
 		const float quat_variance_limit = 0.0001f;
 		EXPECT_TRUE(quat_variance(1) > quat_variance_limit) << "quat_variance(1)" << quat_variance(1);
 		EXPECT_TRUE(quat_variance(2) > quat_variance_limit) << "quat_variance(2)" << quat_variance(2);

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -59,8 +59,8 @@ public:
 	bool isAvailable() { return _input_available; };
 
 	// Position : 0 : pitch, 1 : roll, 2 : throttle, 3 : yaw
-	const matrix::Vector<float, 4> &getPosition() { return _positions; }; // Raw stick position, no deadzone
-	const matrix::Vector<float, 4> &getPositionExpo() { return _positions_expo; }; // Deadzone and expo applied
+	const matrix::Vector4f &getPosition() { return _positions; }; // Raw stick position, no deadzone
+	const matrix::Vector4f &getPositionExpo() { return _positions_expo; }; // Deadzone and expo applied
 
 	// Helper functions to get stick values more intuitively
 	float getRoll() const { return _positions(1); }
@@ -90,8 +90,8 @@ public:
 
 private:
 	bool _input_available{false};
-	matrix::Vector<float, 4> _positions; ///< unmodified manual stick inputs
-	matrix::Vector<float, 4> _positions_expo; ///< modified manual sticks using expo function
+	matrix::Vector4f _positions; ///< unmodified manual stick inputs
+	matrix::Vector4f _positions_expo; ///< modified manual sticks using expo function
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _failsafe_flags_sub{ORB_ID(failsafe_flags)};

--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -233,7 +233,7 @@ bool MatrixTest::attitudeTests()
 
 	// quaterion copy ctors
 	float data_v4[] = {1, 2, 3, 4};
-	Vector<float, 4> v4(data_v4);
+	Vector4f v4(data_v4);
 	Quatf q_from_v(v4);
 	ut_test(isEqual(q_from_v, v4));
 
@@ -242,7 +242,7 @@ bool MatrixTest::attitudeTests()
 	ut_test(isEqual(q_from_m, m4));
 
 	// quaternion derivative
-	Vector<float, 4> q_dot = q.derivative1(Vector3f(1, 2, 3));
+	Vector4f q_dot = q.derivative1(Vector3f(1, 2, 3));
 	(void)q_dot;
 
 	// quaternion product


### PR DESCRIPTION
### Solved Problem
1. gtest 1.13 stable version was released 17. Jan 2023
2. Many places in the code used `Vector<float, 4>` with the inconvenience of not having e.g. an explicit constructor.
3. When a gtest comparing matrixes fails its output was the objects in hex instead of a human readable matrix.

### Solution
1. I updated to 1.13 but had to allow some warnings because the new version has double promotion and compares floats.
2. I added a `Vector4` class and put it in use.
3. Thanks to @jwidauer who showed me how to template the output stream such that without any "define hacks" it compiles and works as expected.

### Test coverage
1. Unit tests still work
2. I added minimal testing for Vector4 but it also passes all existing unit tests where it was put in use.
3. A failing unit test now gives much better output.