### PR TITLE
kakuteh7v2/mini: use EKF2 without mag by default 

### DIFF
--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -40,11 +40,5 @@ param set-default SYS_DM_BACKEND 1
 # Ignore that there is no SD card
 param set-default COM_ARM_SDCARD 0
 
-# Store missions in RAM
-param set-default SYS_DM_BACKEND 1
-
-# Ignore that there is no SD card
-param set-default COM_ARM_SDCARD 0
-
 # Don't try to log onto SD card
 param set-default SDLOG_MODE -1

--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -22,13 +22,12 @@ param set-default CBRK_SUPPLY_CHK 894281
 # Select the Generic 250 Racer by default
 param set-default SYS_AUTOSTART 4050
 
-# use the Q attitude estimator, it works w/o mag or GPS.
-param set-default SYS_MC_EST_GROUP 3
-param set-default ATT_ACC_COMP 0
-param set-default ATT_W_ACC 0.4000
-param set-default ATT_W_GYRO_BIAS 0.0000
-
+# use EKF2
+param set-default SYS_MC_EST_GROUP 2
+# and set it without mag
 param set-default SYS_HAS_MAG 0
+# and enable gravity fusion
+param set-default EKF2_IMU_CONTROL 7
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090

--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -22,9 +22,7 @@ param set-default CBRK_SUPPLY_CHK 894281
 # Select the Generic 250 Racer by default
 param set-default SYS_AUTOSTART 4050
 
-# use EKF2
-param set-default SYS_MC_EST_GROUP 2
-# and set it without mag
+# use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion
 param set-default EKF2_IMU_CONTROL 7

--- a/boards/holybro/kakuteh7v2/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7v2/init/rc.board_defaults
@@ -22,13 +22,12 @@ param set-default CBRK_SUPPLY_CHK 894281
 # Select the Generic 250 Racer by default
 param set-default SYS_AUTOSTART 4050
 
-# use the Q attitude estimator, it works w/o mag or GPS.
-param set-default SYS_MC_EST_GROUP 3
-param set-default ATT_ACC_COMP 0
-param set-default ATT_W_ACC 0.4000
-param set-default ATT_W_GYRO_BIAS 0.0000
-
+# use EKF2
+param set-default SYS_MC_EST_GROUP 2
+# and set it without mag
 param set-default SYS_HAS_MAG 0
+# and enable gravity fusion
+param set-default EKF2_IMU_CONTROL 7
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090

--- a/boards/holybro/kakuteh7v2/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7v2/init/rc.board_defaults
@@ -22,9 +22,7 @@ param set-default CBRK_SUPPLY_CHK 894281
 # Select the Generic 250 Racer by default
 param set-default SYS_AUTOSTART 4050
 
-# use EKF2
-param set-default SYS_MC_EST_GROUP 2
-# and set it without mag
+# use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion
 param set-default EKF2_IMU_CONTROL 7


### PR DESCRIPTION
This switches from attitude_estimator_q to EKF2 which should now work without mag when the params are set to SYS_HAS_MAG = 0 and EKF2_IMU_CTRL = 7 to enable gravity fusion.

As suggested by @bresch.

@bkueng should I do the same for KakuteH7 v1 and KakuteF7?

FYI @vincentpoont2.