### PR TITLE
Navigator::MissionFeasibilityChecks: rework min distance checks

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_jsbsim_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_jsbsim_rascal
@@ -25,7 +25,6 @@ param set-default FW_W_EN 1
 
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
-param set-default MIS_DIST_WPS 10000
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_flightgear_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_flightgear_rascal-electric
@@ -25,7 +25,6 @@ param set-default FW_W_EN 1
 
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
-param set-default MIS_DIST_WPS 10000
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_jsbsim_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_jsbsim_malolo
@@ -25,7 +25,6 @@ param set-default FW_W_EN 1
 
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
-param set-default MIS_DIST_WPS 10000
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
@@ -27,7 +27,6 @@ param set-default FW_W_EN 1
 param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 20
 param set-default MIS_DIST_1WP 2500
-param set-default MIS_DIST_WPS 10000
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -79,7 +79,6 @@ param set-default MC_YAWRATE_MAX 20
 param set-default MC_AIRMODE 1
 
 param set-default MIS_DIST_1WP 100
-param set-default MIS_DIST_WPS 100000
 param set-default MIS_TAKEOFF_ALT 15
 
 param set-default MPC_XY_P 0.8

--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -46,7 +46,6 @@ param set-default RTL_LAND_DELAY -1
 #
 param set-default NAV_ACC_RAD 10
 
-param set-default MIS_DIST_WPS 5000
 param set-default MIS_TAKEOFF_ALT 25
 param set-default MIS_TKO_LAND_REQ 2
 

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -23,7 +23,6 @@ param set-default EKF2_FUSE_BETA 1
 
 param set-default HTE_VXY_THR 2.0
 
-param set-default MIS_DIST_WPS 5000
 param set-default MIS_TKO_LAND_REQ 2
 
 param set-default MPC_ACC_HOR_MAX 2

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -131,12 +131,6 @@ void FeasibilityChecker::updateData()
 		param_get(handle, &_param_mis_dist_1wp);
 	}
 
-	handle = param_find("MIS_DIST_WPS");
-
-	if (handle != PARAM_INVALID) {
-		param_get(handle, &_param_mis_dist_wps);
-	}
-
 	handle = param_find("NAV_ACC_RAD");
 
 	if (handle != PARAM_INVALID) {
@@ -639,12 +633,6 @@ bool FeasibilityChecker::checkDistanceToFirstWaypoint(mission_item_s &mission_it
 
 bool FeasibilityChecker::checkDistancesBetweenWaypoints(const mission_item_s &mission_item)
 {
-	if (_param_mis_dist_wps <= 0.0f) {
-		/* param not set, check is ok */
-		return true;
-	}
-
-
 	/* check only items with valid lat/lon */
 	if (!MissionBlock::item_contains_position(mission_item)) {
 		return true;
@@ -658,24 +646,8 @@ bool FeasibilityChecker::checkDistancesBetweenWaypoints(const mission_item_s &mi
 				_last_lat, _last_lon);
 
 
-		if (dist_between_waypoints > _param_mis_dist_wps) {
-			/* distance between waypoints is too high */
-			mavlink_log_critical(_mavlink_log_pub,
-					     "Distance between waypoints too far: %d meters, %d max.\t",
-					     (int)dist_between_waypoints, (int)_param_mis_dist_wps);
-			events::send<uint32_t, uint32_t>(events::ID("navigator_mis_wp_dist_too_far"), {events::Log::Error, events::LogInternal::Info},
-							 "Distance between waypoints too far: {1m}, (maximum: {2m})", (uint32_t)dist_between_waypoints,
-							 (uint32_t)_param_mis_dist_wps);
-
-
-			return false;
-
-			/* do not allow waypoints that are literally on top of each other */
-
-			/* and do not allow condition gates that are at the same position as a navigation waypoint */
-
-		} else if (dist_between_waypoints < 0.05f &&
-			   (mission_item.nav_cmd == NAV_CMD_CONDITION_GATE || _last_cmd == NAV_CMD_CONDITION_GATE)) {
+		if (dist_between_waypoints < 0.05f &&
+		    (mission_item.nav_cmd == NAV_CMD_CONDITION_GATE || _last_cmd == NAV_CMD_CONDITION_GATE)) {
 
 			/* Waypoints and gate are at the exact same position, which indicates an
 			 * invalid mission and makes calculating the direction from one waypoint

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2022-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
 #include <mathlib/mathlib.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/Subscription.hpp>
 #include <px4_platform_common/module_params.h>
@@ -96,6 +97,7 @@ private:
 	uORB::Subscription _home_pos_sub{ORB_ID(home_position)};
 	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _land_detector_sub{ORB_ID(vehicle_land_detected)};
+	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
 
 	// parameters
 	float _param_fw_lnd_ang{0.f};
@@ -106,6 +108,7 @@ private:
 	bool _is_landed{false};
 	float _home_alt_msl{NAN};
 	matrix::Vector2d _home_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
+	matrix::Vector2d _current_position_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
 	VehicleType _vehicle_type{VehicleType::RotaryWing};
 
 	// internal flags to keep track of which checks failed
@@ -129,7 +132,7 @@ private:
 	int _landing_approach_index{-1};
 	mission_item_s _mission_item_previous = {};
 
-	// internal checkDistanceToFirstWaypoint variables
+	// internal checkHorizontalDistanceToFirstWaypoint variables
 	bool _first_waypoint_found{false};
 
 	// internal checkDistancesBetweenWaypoints variables
@@ -171,12 +174,13 @@ private:
 	bool checkLandPatternValidity(mission_item_s &mission_item, const int current_index, const int last_index);
 
 	/**
-	 * @brief Check distance to first waypoint.
+	 * @brief Check distance to first waypoint from current vehicle position.
+	 * 	  Use Home position instead of vehicle position if vehicle position is invalid.
 	 *
 	 * @param mission_item The current mission item
 	 * @return False if the check failed.
 	*/
-	bool checkDistanceToFirstWaypoint(mission_item_s &mission_item);
+	bool checkHorizontalDistanceToFirstWaypoint(mission_item_s &mission_item);
 
 	/**
 	 * @brief Check distances between waypoints

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -100,7 +100,6 @@ private:
 	// parameters
 	float _param_fw_lnd_ang{0.f};
 	float _param_mis_dist_1wp{0.f};
-	float _param_mis_dist_wps{0.f};
 	float _param_nav_acc_rad{0.f};
 	int32_t _param_mis_takeoff_land_req{0};
 

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -174,8 +174,7 @@ private:
 	bool checkLandPatternValidity(mission_item_s &mission_item, const int current_index, const int last_index);
 
 	/**
-	 * @brief Check distance to first waypoint from current vehicle position.
-	 * 	  Use Home position instead of vehicle position if vehicle position is invalid.
+	 * @brief Check distance to first waypoint from current vehicle position (if available).
 	 *
 	 * @param mission_item The current mission item
 	 * @return False if the check failed.

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -123,42 +123,6 @@ TEST_F(FeasibilityCheckerTest, mission_item_validity)
 	ASSERT_EQ(ret, false);
 }
 
-TEST_F(FeasibilityCheckerTest, max_dist_between_waypoints)
-{
-	TestFeasibilityChecker checker;
-	checker.publishLanded(true);
-
-	param_t param = param_handle(px4::params::MIS_DIST_WPS);
-
-	float max_dist = 1000.0f;
-	param_set(param, &max_dist);
-	checker.paramsChanged();
-
-	mission_item_s mission_item = {};
-	mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-
-	checker.processNextItem(mission_item, 0, 3);
-
-	// waypoints are within limits, check should pass
-	double lat_new, lon_new;
-	waypoint_from_heading_and_distance(mission_item.lat, mission_item.lon, 0, 999, &lat_new, &lon_new);
-	mission_item.lat = lat_new;
-	mission_item.lon = lon_new;
-	checker.processNextItem(mission_item, 1, 3);
-
-	ASSERT_EQ(checker.someCheckFailed(), false);
-
-	// waypoints are above limits, check should fail
-	waypoint_from_heading_and_distance(mission_item.lat, mission_item.lon, 0, 1001, &lat_new, &lon_new);
-
-	mission_item.lat = lat_new;
-	mission_item.lon = lon_new;
-	checker.processNextItem(mission_item, 2, 3);
-
-	ASSERT_EQ(checker.someCheckFailed(), true);
-}
-
-
 TEST_F(FeasibilityCheckerTest, check_dist_first_waypoint)
 {
 	TestFeasibilityChecker checker;

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -143,41 +143,15 @@ TEST_F(FeasibilityCheckerTest, check_dist_first_waypoint)
 	mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 	double lat_new, lon_new;
 
-	// GIVEN: no valid Current position, no valid Home
-
+	// GIVEN: no valid Current position
 
 	// THEN: always pass
 	checker.processNextItem(mission_item, 0, 1);
 	ASSERT_EQ(checker.someCheckFailed(), false);
 
-	// GIVEN: no valid current position, but valid Home. First WP 501m away from Home
+	// BUT WHEN: valid current position, first WP 501m away from current pos
 	checker.reset();
 	checker.publishLanded(true);
-	checker.publishHomePosition(0, 0, 0);
-	waypoint_from_heading_and_distance(mission_item.lat, mission_item.lon, 0, 501, &lat_new, &lon_new);
-	mission_item.lat = lat_new;
-	mission_item.lon = lon_new;
-
-	// THEN: check should fail
-	checker.processNextItem(mission_item, 0, 1);
-	ASSERT_EQ(checker.someCheckFailed(), true);
-
-	// BUT WHEN: no valid current position, but valid Home. First WP 499m away from Home
-	checker.reset();
-	checker.publishLanded(true);
-	checker.publishHomePosition(0, 0, 0);
-	waypoint_from_heading_and_distance(0, 0, 0, 499, &lat_new, &lon_new);
-	mission_item.lat = lat_new;
-	mission_item.lon = lon_new;
-
-	// THEN: pass
-	checker.processNextItem(mission_item, 0, 1);
-	ASSERT_EQ(checker.someCheckFailed(), false);
-
-	// BUT WHEN: valid current position, valid Home, first WP 501m away from current pos
-	checker.reset();
-	checker.publishLanded(true);
-	checker.publishHomePosition(0, 0, 0);
 	checker.publishCurrentPosition(0, 0);
 	waypoint_from_heading_and_distance(0, 0, 0, 501, &lat_new, &lon_new);
 	mission_item.lat = lat_new;
@@ -187,24 +161,10 @@ TEST_F(FeasibilityCheckerTest, check_dist_first_waypoint)
 	checker.processNextItem(mission_item, 0, 1);
 	ASSERT_EQ(checker.someCheckFailed(), true);
 
-	// BUT WHEN: valid current position, valid Home, fist WP 499m away from current but more from Home
+	// BUT WHEN: valid current position fist WP 499m away from current
 	checker.reset();
 	checker.publishLanded(true);
-	checker.publishHomePosition(10, 20, 0); // random position far away
 	checker.publishCurrentPosition(0, 0);
-	waypoint_from_heading_and_distance(0, 0, 0, 499, &lat_new, &lon_new);
-	mission_item.lat = lat_new;
-	mission_item.lon = lon_new;
-
-	// THEN: pass
-	checker.processNextItem(mission_item, 0, 1);
-	ASSERT_EQ(checker.someCheckFailed(), false);
-
-	// BUT WHEN: valid current position (far away), valid Home, first WP 499 away from Home
-	checker.reset();
-	checker.publishLanded(true);
-	checker.publishHomePosition(0, 0, 0); // random position far away
-	checker.publishCurrentPosition(10, 0);
 	waypoint_from_heading_and_distance(0, 0, 0, 499, &lat_new, &lon_new);
 	mission_item.lat = lat_new;
 	mission_item.lon = lon_new;

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -199,6 +199,19 @@ TEST_F(FeasibilityCheckerTest, check_dist_first_waypoint)
 	// THEN: pass
 	checker.processNextItem(mission_item, 0, 1);
 	ASSERT_EQ(checker.someCheckFailed(), false);
+
+	// BUT WHEN: valid current position (far away), valid Home, first WP 499 away from Home
+	checker.reset();
+	checker.publishLanded(true);
+	checker.publishHomePosition(0, 0, 0); // random position far away
+	checker.publishCurrentPosition(10, 0);
+	waypoint_from_heading_and_distance(0, 0, 0, 499, &lat_new, &lon_new);
+	mission_item.lat = lat_new;
+	mission_item.lon = lon_new;
+
+	// THEN: pass
+	checker.processNextItem(mission_item, 0, 1);
+	ASSERT_EQ(checker.someCheckFailed(), false);
 }
 
 TEST_F(FeasibilityCheckerTest, check_below_home)

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -242,7 +242,6 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_mis_dist_1wp,
-		(ParamFloat<px4::params::MIS_DIST_WPS>) _param_mis_dist_wps,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mis_mnt_yaw_ctl
 	)
 

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -89,22 +89,6 @@ PARAM_DEFINE_INT32(MIS_TKO_LAND_REQ, 0);
 PARAM_DEFINE_FLOAT(MIS_DIST_1WP, 900);
 
 /**
- * Maximal horizontal distance between waypoint
- *
- * Failsafe check to prevent running missions which are way too big.
- * Set a value of zero or less to disable. The mission will not be started if any distance between
- * two subsequent waypoints is greater than MIS_DIST_WPS.
- *
- * @unit m
- * @min 0
- * @max 10000
- * @decimal 1
- * @increment 100
- * @group Mission
- */
-PARAM_DEFINE_FLOAT(MIS_DIST_WPS, 900);
-
-/**
 * Enable yaw control of the mount. (Only affects multicopters and ROI mission items)
 *
 * If enabled, yaw commands will be sent to the mount and the vehicle will follow its heading towards the flight direction.

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -73,14 +73,14 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
 PARAM_DEFINE_INT32(MIS_TKO_LAND_REQ, 0);
 
 /**
- * Maximal horizontal distance from home to first waypoint
+ * Maximal horizontal distance from current position to first waypoint
  *
  * Failsafe check to prevent running mission stored from previous flight at a new takeoff location.
  * Set a value of zero or less to disable. The mission will not be started if the current
- * waypoint is more distant than MIS_DIST_1WP from the home position.
+ * waypoint is more distant than MIS_DIST_1WP from the current position.
  *
  * @unit m
- * @min 0
+ * @min -1
  * @max 10000
  * @decimal 1
  * @increment 100


### PR DESCRIPTION

### Solved Problem
- annoying parameter MIS_DIST_WPS with questionable use
- first waypoint check (around MIS_DIST_1WP) only checks distance to Home, and thus prevents uploading a mission that is some distance from home (typically because vehicle is already in air). 

### Solution
- remove MIS_DIST_WPS check completely
- rework MIS_DIST_1WP check to always take min() of Home and current position distance

That way we still catch the most important misconfiguration: starting a mission that actually is from another day of flying and thus very far away. I would argue that there is no other check then that required. Eg [estimator issues during too long straight](https://github.com/PX4/PX4-Autopilot/pull/16550#issuecomment-759831054) legs is something that no longer is a valid reason to prevent waypoints far apart. 

### Alternatives
- use Home when landed, use current_position when !landed?

### Test coverage
Extended the unit tests and SITL tested it.

