### PR TITLE
ekf2: decrease EKF2_MAG_YAWLIM default 0.25 -> 0.2 rad/s 

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -355,7 +355,7 @@ struct parameters {
 	int32_t mag_declination_source{7};      ///< bitmask used to control the handling of declination data
 	int32_t mag_fusion_type{0};             ///< integer used to specify the type of magnetometer fusion used
 	float mag_acc_gate{0.5f};               ///< when in auto select mode, heading fusion will be used when manoeuvre accel is lower than this (m/sec**2)
-	float mag_yaw_rate_gate{0.25f};         ///< yaw rate threshold used by mode select logic (rad/sec)
+	float mag_yaw_rate_gate{0.20f};         ///< yaw rate threshold used by mode select logic (rad/sec)
 
 	// GNSS heading fusion
 	float gps_heading_noise{0.1f};          ///< measurement noise standard deviation used for GNSS heading fusion (rad)

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -532,7 +532,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_ACCLIM, 0.5f);
  * @unit rad/s
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(EKF2_MAG_YAWLIM, 0.25f);
+PARAM_DEFINE_FLOAT(EKF2_MAG_YAWLIM, 0.20f);
 
 /**
  * Gate size for barometric and GPS height fusion


### PR DESCRIPTION
Currently in ekf2 starting mag_3d requires mag_aligned_in_flight and either the yaw > EKF2_MAG_YAWLIM or horizontal acceleration (filtered) > EKF2_MAG_ACCLIM. 

I think the default yaw rate gate (EKF2_MAG_YAWLIM) could be lowered a bit to get the mag states initialized earlier on. 

![image](https://user-images.githubusercontent.com/84712/223745992-3257a7ac-0ef8-4c62-a03c-1654362cc0fe.png)
