### PR TITLE
removing MOUNT_ORIENTATION on udp_gcs_port_local from typhoon

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/6011_gazebo-classic_typhoon_h480.post
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/6011_gazebo-classic_typhoon_h480.post
@@ -2,7 +2,5 @@
 mavlink start -x -u 14558 -r 4000 -f -m onboard -o 14530 -p
 
 # shellcheck disable=SC2154
-mavlink stream -r 10 -s MOUNT_ORIENTATION -u $udp_gcs_port_local
-# shellcheck disable=SC2154
 mavlink stream -r 50 -s ATTITUDE_QUATERNION -u $udp_offboard_port_local
 mavlink stream -r 10 -s MOUNT_ORIENTATION -u $udp_offboard_port_local


### PR DESCRIPTION
### Solved Problem
When was running the autopilot in headless mode in docker. I found that I was receiving an error on the startup script: 
```
WARN  [mavlink] mavlink for network on port 18570 is not running
ERROR [px4] Startup script returned with return value: 256
```

### Solution
Seeing that @julianoes already removed it from other vehicles and @TSC21 told me that it was very probably deprecated, maybe it makes sense to remove it ?
I have to admit that I don t fully understand what I' m doing and I would be happy to get explained why we send this message to the "Ground Control Station" ?

### Alternatives

### Test coverage

### Context
