### PR TITLE
Matrix: 2D rotation

### DIFF
--- a/src/lib/matrix/matrix/Dcm2.hpp
+++ b/src/lib/matrix/matrix/Dcm2.hpp
@@ -1,0 +1,127 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file Dcm2.hpp
+ *
+ * A givens rotation matrix 2x2.
+ * All rotations and axis systems follow the right-hand rule.
+ *
+ * This library uses the convention that premultiplying a two dimensional
+ * vector represented in coordinate system 1 will apply a rotation from coordinate system
+ * 1 to coordinate system 2 to the vector.
+ * Likewise, a matrix instance of this class also represents a coordinate transformation
+ * from frame 2 to frame 1.
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include "math.hpp"
+
+namespace matrix
+{
+
+template<typename Type>
+class Dcm2 : public SquareMatrix<Type, 2>
+{
+public:
+	/**
+	 * Standard constructor
+	 *
+	 * Initializes to identity
+	 */
+	Dcm2() : SquareMatrix<Type, 2>(eye<Type, 2>()) {}
+
+	/**
+	 * Constructor from array
+	 *
+	 * @param _data pointer to array
+	 */
+	explicit Dcm2(const Type data_[2][2]) : SquareMatrix<Type, 2>(data_)
+	{
+	}
+
+	/**
+	 * Constructor from array
+	 *
+	 * @param _data pointer to array
+	 */
+	explicit Dcm2(const Type data_[4]) : SquareMatrix<Type, 2>(data_)
+	{
+	}
+
+	/**
+	 * Copy constructor
+	 *
+	 * @param other Matrix22 to set dcm to
+	 */
+	Dcm2(const Matrix<Type, 2, 2> &other) : SquareMatrix<Type, 2>(other)
+	{
+	}
+
+	/**
+	 * Constructor from an angle
+	 *
+	 * This sets the transformation matrix from frame 2 to frame 1 where the rotation
+	 * from frame 1 to frame 2 is described by an angle in radians.
+	 *
+	 * @param angle from frame 1 to frame 2 in radians
+	 */
+	Dcm2(const Type angle)
+	{
+		Dcm2 &dcm = *this;
+		Type sin_angle = sin(angle);
+		Type cos_angle = cos(angle);
+
+		dcm(0, 0) = cos_angle;
+		dcm(0, 1) = -sin_angle;
+		dcm(1, 0) = sin_angle;
+		dcm(1, 1) = cos_angle;
+	}
+
+	void renormalize()
+	{
+		/* renormalize rows */
+		for (size_t r = 0; r < 2; r++) {
+			matrix::Vector2<Type> rvec(Matrix<Type, 1, 2>(this->Matrix<Type, 2, 2>::row(r)).transpose());
+			this->Matrix<Type, 2, 2>::row(r) = rvec.normalized();
+		}
+	}
+};
+
+using Dcm2f = Dcm2<float>;
+using Dcm2d = Dcm2<double>;
+
+} // namespace matrix

--- a/src/lib/matrix/matrix/math.hpp
+++ b/src/lib/matrix/matrix/math.hpp
@@ -14,6 +14,7 @@
 #include "Vector4.hpp"
 #include "Euler.hpp"
 #include "Dcm.hpp"
+#include "Dcm2.hpp"
 #include "Scalar.hpp"
 #include "Quaternion.hpp"
 #include "AxisAngle.hpp"

--- a/src/lib/matrix/test/CMakeLists.txt
+++ b/src/lib/matrix/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_compile_options(
 px4_add_unit_gtest(SRC MatrixAssignmentTest.cpp)
 px4_add_unit_gtest(SRC MatrixAttitudeTest.cpp)
 px4_add_unit_gtest(SRC MatrixCopyToTest.cpp)
+px4_add_unit_gtest(SRC MatrixDcm2Test.cpp)
 px4_add_unit_gtest(SRC MatrixDualTest.cpp)
 px4_add_unit_gtest(SRC MatrixFilterTest.cpp)
 px4_add_unit_gtest(SRC MatrixHatveeTest.cpp)

--- a/src/lib/matrix/test/MatrixDcm2Test.cpp
+++ b/src/lib/matrix/test/MatrixDcm2Test.cpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <matrix/Dcm.hpp>
+#include <matrix/Dcm2.hpp>
+
+using namespace matrix;
+
+TEST(MatrixDcm2Test, CompareToDcm)
+{
+	// 2D matrix and 3D matrix rotating around yaw are equivalent
+	Dcm2f R2(1.f);
+	Dcmf R3(Eulerf(0.f, 0.f, 1.f));
+	EXPECT_EQ(Dcm2f(R3.slice<2, 2>(0, 0)), R2);
+
+	// Rotating a 2D and a 3D vector respectively is equivalent
+	Vector2f v2(1.f, 2.f);
+	Vector3f v3(v2(0), v2(1), 0.f);
+	Vector2f result2 = R2 * v2;
+	Vector3f result3 = R3 * v3;
+	EXPECT_EQ(Vector2f(result2), result2);
+	EXPECT_EQ(result2, result3.xy());
+}
+
+TEST(MatrixDcm2Test, 45DegreeRotation)
+{
+	Vector2f v(1.0f, 0.0f);
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(1.f, 1.f) * (sqrt(2) / 2));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(0.f, 1.f));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(-1.f, 1.f) * (sqrt(2) / 2));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(-1.f, 0.f));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(-1.f, -1.f) * (sqrt(2) / 2));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(0.f, -1.f));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(1.f, -1.f) * (sqrt(2) / 2));
+	v = Dcm2f(M_PI / 4.f) * v;
+	EXPECT_EQ(v, Vector2f(1.f, 0.f));
+}

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -273,14 +273,6 @@ void FlightTaskManualAltitude::_respectGroundSlowdown()
 	}
 }
 
-void FlightTaskManualAltitude::_rotateIntoHeadingFrame(Vector2f &v)
-{
-	const float yaw_rotate = PX4_ISFINITE(_yaw_setpoint) ? _yaw_setpoint : _yaw;
-	Vector3f v_r = Vector3f(Dcmf(Eulerf(0.0f, 0.0f, yaw_rotate)) * Vector3f(v(0), v(1), 0.0f));
-	v(0) = v_r(0);
-	v(1) = v_r(1);
-}
-
 void FlightTaskManualAltitude::_updateHeadingSetpoints()
 {
 	if (_isYawInput() || !_is_yaw_good_for_control) {

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -64,11 +64,6 @@ protected:
 	void _updateConstraintsFromEstimator();
 
 	/**
-	 * rotates vector into local frame
-	 */
-	void _rotateIntoHeadingFrame(matrix::Vector2f &vec);
-
-	/**
 	 *  Check and sets for position lock.
 	 *  If sticks are at center position, the vehicle
 	 *  will exit velocity control and enter position control.

--- a/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -91,8 +91,8 @@ void FlightTaskManualPosition::_scaleSticks()
 	// scale velocity to its maximum limits
 	Vector2f vel_sp_xy = stick_xy * velocity_scale;
 
-	/* Rotate setpoint into local frame. */
-	_rotateIntoHeadingFrame(vel_sp_xy);
+	// Rotate setpoint into local frame
+	Sticks::rotateIntoHeadingFrameXY(vel_sp_xy, _yaw, _yaw_setpoint);
 
 	// collision prevention
 	if (_collision_prevention.is_active()) {

--- a/src/modules/flight_mode_manager/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/modules/flight_mode_manager/tasks/Transition/FlightTaskTransition.cpp
@@ -36,7 +36,8 @@
  */
 
 #include "FlightTaskTransition.hpp"
-#include "Sticks.hpp"
+
+using namespace matrix;
 
 FlightTaskTransition::FlightTaskTransition()
 {
@@ -50,7 +51,6 @@ FlightTaskTransition::FlightTaskTransition()
 
 bool FlightTaskTransition::updateInitialize()
 {
-
 	updateParameters();
 	return FlightTask::updateInitialize();
 }
@@ -110,8 +110,7 @@ bool FlightTaskTransition::update()
 
 	// calculate a horizontal acceleration vector which corresponds to an attitude composed of pitch up by _param_pitch_cruise_degrees
 	// and zero roll angle
-	matrix::Vector2f tmp(-1.0f, 0.0f);
-	Sticks::rotateIntoHeadingFrameXY(tmp, _yaw, NAN);
+	const Vector2f tmp = Dcm2f(_yaw) * Vector2f(-1.0f, 0.0f);
 	_acceleration_setpoint.xy() = tmp * tanf(math::radians(_param_pitch_cruise_degrees)) * CONSTANTS_ONE_G;
 
 	// slowly move vertical velocity setpoint to zero

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -95,7 +95,6 @@ void Sticks::limitStickUnitLengthXY(Vector2f &v)
 
 void Sticks::rotateIntoHeadingFrameXY(Vector2f &v, const float yaw, const float yaw_setpoint)
 {
-	Vector3f v3(v(0), v(1), 0.f);
 	const float yaw_rotate = PX4_ISFINITE(yaw_setpoint) ? yaw_setpoint : yaw;
-	v = Vector2f(Dcmf(Eulerf(0.0f, 0.0f, yaw_rotate)) * v3);
+	v = Dcm2f(yaw_rotate) * v;
 }

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControl.cpp
@@ -88,7 +88,7 @@ matrix::Vector3f AttitudeControl::update(const Quatf &q) const
 	const Vector3f eq = 2.f * qe.canonical().imag();
 
 	// calculate angular rates setpoint
-	matrix::Vector3f rate_setpoint = eq.emult(_proportional_gain);
+	Vector3f rate_setpoint = eq.emult(_proportional_gain);
 
 	// Feed forward the yaw setpoint rate.
 	// yawspeed_setpoint is the feed forward commanded rotation around the world z-axis,


### PR DESCRIPTION
### Solved Problem
For horizontal flight patterns, it's useful to be able to rotate a 2D vector.

### Solution
- Add a 2-dimensional rotation matrix class.

### Alternatives
We could also call the 3D rotation implementation with only a yaw rotation but I doubt that's any better.

### Test coverage
- I added unit tests to compare a rotation matrix to the 3D case and rotate a vector.

### Context
This is in preparation to enable a figure eight pattern.
