### PR TITLE
fix shellcheck error

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -8,11 +8,11 @@ if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0"
 
 	echo "INFO  [init] SIH simulator"
 
-	if [ ! -z "${PX4_HOME_LAT}" ]; then
+	if [ ! -n "${PX4_HOME_LAT}" ]; then
 		param set SIH_LOC_LAT0 ${PX4_HOME_LAT}
 	fi
 
-	if [ ! -z "${PX4_HOME_LON}" ]; then
+	if [ ! -n "${PX4_HOME_LON}" ]; then
 		param set SIH_LOC_LON0 ${PX4_HOME_LON}
 	fi
 

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -8,11 +8,11 @@ if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0"
 
 	echo "INFO  [init] SIH simulator"
 
-	if [ ! -n "${PX4_HOME_LAT}" ]; then
+	if [ -n "${PX4_HOME_LAT}" ]; then
 		param set SIH_LOC_LAT0 ${PX4_HOME_LAT}
 	fi
 
-	if [ ! -n "${PX4_HOME_LON}" ]; then
+	if [ -n "${PX4_HOME_LON}" ]; then
 		param set SIH_LOC_LON0 ${PX4_HOME_LON}
 	fi
 


### PR DESCRIPTION
### Solved Problem
It looks like this PR introduced a shellcheck failure

https://github.com/PX4/PX4-Autopilot/pull/21253

### Solution
changing string condition from -z to -n as spellcheck recommended 

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
