### PR TITLE
MC Flip Detection

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -123,6 +123,7 @@ set(msg_files
 	ManualControlSwitches.msg
 	MavlinkLog.msg
 	MavlinkTunnel.msg
+	McVelCtrlStatus.msg
 	Mission.msg
 	MissionResult.msg
 	MountOrientation.msg

--- a/msg/FailureDetectorStatus.msg
+++ b/msg/FailureDetectorStatus.msg
@@ -9,6 +9,7 @@ bool fd_arm_escs
 bool fd_battery
 bool fd_imbalanced_prop
 bool fd_motor
+bool fd_flip
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)
 uint16 motor_failure_mask           # Bit-mask with motor indices, indicating critical motor failures

--- a/msg/McVelCtrlStatus.msg
+++ b/msg/McVelCtrlStatus.msg
@@ -1,0 +1,6 @@
+uint64 timestamp		# time since system start (microseconds)
+
+# mc velocity controller integrator status
+float32 vx_integ
+float32 vy_integ
+float32 vz_integ

--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -70,6 +70,7 @@ uint16 FAILURE_ARM_ESC = 16          # (1 << 4)
 uint16 FAILURE_BATTERY = 32          # (1 << 5)
 uint16 FAILURE_IMBALANCED_PROP = 64  # (1 << 6)
 uint16 FAILURE_MOTOR = 128           # (1 << 7)
+uint16 FAILURE_FLIP = 128            # (1 << 8)
 
 uint8 hil_state
 uint8 HIL_STATE_OFF = 0

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1808,6 +1808,7 @@ void Commander::run()
 			fd_status.fd_arm_escs = _failure_detector.getStatusFlags().arm_escs;
 			fd_status.fd_battery = _failure_detector.getStatusFlags().battery;
 			fd_status.fd_imbalanced_prop = _failure_detector.getStatusFlags().imbalanced_prop;
+			fd_status.fd_flip =  _failure_detector.getStatusFlags().flip;
 			fd_status.fd_motor = _failure_detector.getStatusFlags().motor;
 			fd_status.imbalanced_prop_metric = _failure_detector.getImbalancedPropMetric();
 			fd_status.motor_failure_mask = _failure_detector.getMotorFailures();

--- a/src/modules/commander/failure_detector/FailureDetector.cpp
+++ b/src/modules/commander/failure_detector/FailureDetector.cpp
@@ -203,6 +203,46 @@ bool FailureDetector::update(const vehicle_status_s &vehicle_status, const vehic
 		updateImbalancedPropStatus();
 	}
 
+	if (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
+
+		vehicle_local_position_s vehicle_local_position;
+
+
+		if (!got_home_position) {
+			home_position_s home_position;
+
+			if (_sub_home_position.update(&home_position)) {
+				home_z = home_position.z;
+				got_home_position = true;
+			}
+		}
+
+		if (_sub_vehicle_local_position.update(&vehicle_local_position) && !escaped_z_threshold && got_home_position) {
+
+			escaped_z_threshold = (-_param_fd_escape_z.get() > (vehicle_local_position.z - home_z));
+
+			if (escaped_z_threshold) {
+				PX4_INFO("Lift Off Detected!");
+			}
+		}
+
+		position_setpoint_triplet_s pos_sp_triplet;
+
+		if (_sub_pos_sp_triplet.update(&pos_sp_triplet)) {
+			in_takeoff = pos_sp_triplet.current.valid && pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
+		}
+
+		bool detect_flip = !escaped_z_threshold && in_takeoff;
+
+		if (_param_flip_en.get() &&
+		    detect_flip) {
+
+			updateFlipStatus();
+
+		}
+
+	}
+
 	return _status.value != status_prev.value;
 }
 
@@ -235,6 +275,26 @@ void FailureDetector::updateAttitudeStatus()
 		// Update status
 		_status.flags.roll = _roll_failure_hysteresis.get_state();
 		_status.flags.pitch = _pitch_failure_hysteresis.get_state();
+	}
+}
+
+void FailureDetector::updateFlipStatus()
+{
+
+	rate_ctrl_status_s rate_ctrl_status;
+	//mc_vel_ctrl_status_s mc_vel_ctrl_status;
+	//_sub_mc_vel_ctrl_status.update(&mc_vel_ctrl_status);
+
+	if (_sub_rate_ctrl_status.update(&rate_ctrl_status) && !escaped_z_threshold) {
+
+		bool pr_speed_integ_saturating = (abs(rate_ctrl_status.pitchspeed_integ) >= _param_fd_fail_pri.get()
+						  or abs(rate_ctrl_status.rollspeed_integ) >= _param_fd_fail_pri.get());
+
+		if (pr_speed_integ_saturating && !_status.flags.flip) {
+			_status.flags.flip = true;
+			PX4_INFO("Flip Detected!");
+		}
+
 	}
 }
 

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -212,3 +212,39 @@ PARAM_DEFINE_FLOAT(FD_ACT_MOT_C2T, 2.0f);
  * @increment 100
  */
 PARAM_DEFINE_INT32(FD_ACT_MOT_TOUT, 100);
+
+/**
+ * Enable checks on flip during vertical lift off (early takeoff phase)
+ *
+ * @boolean
+ * @reboot_required true
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_FLIP_EN, 1);
+
+/**
+ * Threshold MC Pitch rate integrator before considering as flipping
+ *
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_FLIP_PR_I_THR, 0.1);
+
+/**
+ * Threshold MC Roll rate integrator before considering as flipping
+ *
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_FLIP_RR_I_THR, 0.1);
+
+/**
+ * A z velocity threshold that must be reached once during takeoff to disable the flip checks
+ *
+ * @min 0.02
+ * @max 5
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_ESCAPE_Z, 0.5);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -87,6 +87,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("magnetometer_bias_estimate", 200);
 	add_topic("manual_control_setpoint", 200);
 	add_topic("manual_control_switches");
+	add_topic("mc_vel_ctrl_status");
 	add_topic("mission_result");
 	add_topic("navigator_mission_item");
 	add_topic("npfg_status", 100);
@@ -123,8 +124,8 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_global_position", 200);
 	add_topic("vehicle_gps_position", 500);
 	add_topic("vehicle_land_detected");
-	add_topic("vehicle_local_position", 100);
-	add_topic("vehicle_local_position_setpoint", 100);
+	add_topic("vehicle_local_position");
+	add_topic("vehicle_local_position_setpoint");
 	add_topic("vehicle_magnetometer", 200);
 	add_topic("vehicle_rates_setpoint", 20);
 	add_topic("vehicle_roi", 1000);

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -484,6 +484,7 @@ void MulticopterPositionControl::Run()
 				_setpoint.acceleration[2] = NAN;
 			}
 
+
 			if (not_taken_off || flying_but_ground_contact) {
 				// we are not flying yet and need to avoid any corrections
 				_setpoint = PositionControl::empty_trajectory_setpoint;
@@ -560,6 +561,12 @@ void MulticopterPositionControl::Run()
 			_control.getAttitudeSetpoint(attitude_setpoint);
 			attitude_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
+
+			// publish velocity controller status
+			mc_vel_ctrl_status_s mc_vel_ctrl_status{};
+			_control.getVelControlStatus(mc_vel_ctrl_status);
+			mc_vel_ctrl_status.timestamp = hrt_absolute_time();
+			_vel_controller_status_pub.publish(mc_vel_ctrl_status);
 
 		} else {
 			// an update is necessary here because otherwise the takeoff state doesn't get skipped with non-altitude-controlled modes

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -64,6 +64,8 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/mc_vel_ctrl_status.h>
+#include <uORB/topics/actuator_armed.h>
 
 using namespace time_literals;
 
@@ -95,11 +97,13 @@ private:
 	uORB::PublicationData<takeoff_status_s>              _takeoff_status_pub{ORB_ID(takeoff_status)};
 	uORB::Publication<vehicle_attitude_setpoint_s>	     _vehicle_attitude_setpoint_pub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Publication<vehicle_local_position_setpoint_s> _local_pos_sp_pub{ORB_ID(vehicle_local_position_setpoint)};	/**< vehicle local position setpoint publication */
+	uORB::Publication<mc_vel_ctrl_status_s> _vel_controller_status_pub{ORB_ID(mc_vel_ctrl_status)};
 
 	uORB::SubscriptionCallbackWorkItem _local_pos_sub{this, ORB_ID(vehicle_local_position)};	/**< vehicle local position */
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
+	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
 	uORB::Subscription _hover_thrust_estimate_sub{ORB_ID(hover_thrust_estimate)};
 	uORB::Subscription _trajectory_setpoint_sub{ORB_ID(trajectory_setpoint)};
 	uORB::Subscription _vehicle_constraints_sub{ORB_ID(vehicle_constraints)};

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -200,6 +200,13 @@ void PositionControl::_velocityControl(const float dt)
 	_vel_int(2) = math::min(fabsf(_vel_int(2)), CONSTANTS_ONE_G) * sign(_vel_int(2));
 }
 
+void PositionControl::getVelControlStatus(mc_vel_ctrl_status_s &mc_vel_ctrl_status)
+{
+	mc_vel_ctrl_status.vx_integ = _vel_int(0);
+	mc_vel_ctrl_status.vy_integ = _vel_int(1);
+	mc_vel_ctrl_status.vz_integ = _vel_int(2);
+}
+
 void PositionControl::_accelerationControl()
 {
 	// Assume standard acceleration due to gravity in vertical direction for attitude generation

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -44,6 +44,7 @@
 #include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/mc_vel_ctrl_status.h>
 
 struct PositionControlStates {
 	matrix::Vector3f position;
@@ -183,6 +184,8 @@ public:
 	 * All setpoints are set to NAN (uncontrolled). Timestampt zero.
 	 */
 	static const trajectory_setpoint_s empty_trajectory_setpoint;
+
+	void getVelControlStatus(mc_vel_ctrl_status_s &mc_vel_ctrl_status);
 
 private:
 	bool _inputValid();


### PR DESCRIPTION
Checks the build up of MC pitch rate and MC roll rate integrators during takeoff to detect if landing gear is stuck or esc/motors have failed. Disarms on detection. 
 
- To test in sitl set  the maxRotVelocity of two motors to 0 in sdf 

Somewhat out of date diagram:

![image](https://user-images.githubusercontent.com/50725049/224247351-5da156ef-93d0-48ec-91f6-89094119922a.png)
