### PR TITLE
drivers/adc/board_adc: count number of times USB has been connected (disconnected -> connected)

### DIFF
--- a/msg/SystemPower.msg
+++ b/msg/SystemPower.msg
@@ -1,15 +1,20 @@
-uint64 timestamp		# time since system start (microseconds)
-float32 voltage5v_v		# peripheral 5V rail voltage
-float32[4] sensors3v3		# Sensors 3V3 rail voltage
-uint8 sensors3v3_valid		# Sensors 3V3 rail voltage was read (bitfield).
-uint8 usb_connected		# USB is connected when 1
-uint8 brick_valid		# brick bits power is good when bit 1
-uint8 usb_valid 		# USB is valid when 1
-uint8 servo_valid		# servo power is good when 1
-uint8 periph_5v_oc		# peripheral overcurrent when 1
-uint8 hipower_5v_oc		# high power peripheral overcurrent when 1
-uint8 comp_5v_valid		# 5V to companion valid
-uint8 can1_gps1_5v_valid	# 5V for CAN1/GPS1 valid
+uint64 timestamp                # time since system start (microseconds)
+
+float32 voltage5v_v             # peripheral 5V rail voltage
+float32[4] sensors3v3           # Sensors 3V3 rail voltage
+uint8 sensors3v3_valid          # Sensors 3V3 rail voltage was read (bitfield).
+
+bool usb_connected		# USB is connected when true
+uint8 usb_connected_count       # number of times USB has been connected
+
+uint8 brick_valid		# brick bits power is good (bitfield).
+bool usb_valid                  # USB is valid when true
+
+bool servo_valid                # servo power is good when true
+bool periph_5v_oc               # peripheral overcurrent when true
+bool hipower_5v_oc              # high power peripheral overcurrent when true
+bool comp_5v_valid              # 5V to companion valid
+bool can1_gps1_5v_valid         # 5V for CAN1/GPS1 valid
 
 uint8 BRICK1_VALID_SHIFTS=0
 uint8 BRICK1_VALID_MASK=1

--- a/src/drivers/adc/board_adc/ADC.cpp
+++ b/src/drivers/adc/board_adc/ADC.cpp
@@ -244,7 +244,17 @@ void ADC::update_system_power(hrt_abstime now)
 	// these are not ADC related, but it is convenient to
 	// publish these to the same topic
 
-	system_power.usb_connected = BOARD_ADC_USB_CONNECTED;
+	const bool usb_connected = BOARD_ADC_USB_CONNECTED;
+
+	if (!_usb_connected && usb_connected) {
+		_usb_connected_count++;
+	}
+
+	_usb_connected = usb_connected;
+
+	system_power.usb_connected = _usb_connected;
+	system_power.usb_connected_count = _usb_connected_count;
+
 	/* If provided used the Valid signal from HW*/
 #if defined(BOARD_ADC_USB_VALID)
 	system_power.usb_valid = BOARD_ADC_USB_VALID;

--- a/src/drivers/adc/board_adc/ADC.hpp
+++ b/src/drivers/adc/board_adc/ADC.hpp
@@ -113,6 +113,9 @@ private:
 	uORB::Publication<adc_report_s>		_to_adc_report{ORB_ID(adc_report)};
 	uORB::Publication<system_power_s>	_to_system_power{ORB_ID(system_power)};
 
+	uint8_t _usb_connected_count{0};
+	bool _usb_connected{false};
+
 #ifdef BOARD_GPIO_VDD_5V_COMP_VALID
 	int _5v_comp_valid_fd {-1};
 #endif


### PR DESCRIPTION
This was requested for monitoring and potentially catching certain problems.

``` Console
nsh> listener system_power

TOPIC: system_power
 system_power
    timestamp: 58858285 (0.006544 seconds ago)
    voltage5v_v: 4.98223
    sensors3v3: [3.32417, 3.30967, 3.27583, 3.25972]
    sensors3v3_valid: 15
    usb_connected: True
    usb_connected_count: 5
    brick_valid: 2
    usb_valid: True
    servo_valid: True
    periph_5v_oc: False
    hipower_5v_oc: False
    comp_5v_valid: True
    can1_gps1_5v_valid: True

```