### PR TITLE
CubeOrange+: add check for SMPS support

### DIFF
--- a/boards/cubepilot/cubeorangeplus/src/board_config.h
+++ b/boards/cubepilot/cubeorangeplus/src/board_config.h
@@ -44,6 +44,16 @@
 #include <stdint.h>
 #include <stm32_gpio.h>
 
+/**
+ * If NuttX is built without support for SMPS it can brick the hardware.
+ * Therefore, we make sure the NuttX headers are correct.
+ */
+#include "hardware/stm32h7x3xx_pwr.h"
+#if STM32_PWR_CR3_SMPSEXTHP != (1 << 3)
+#  error "No SMPS support in NuttX submodule");
+#endif
+
+
 /* PX4IO connection configuration */
 #define BOARD_USES_PX4IO_VERSION       2
 #define PX4IO_SERIAL_DEVICE            "/dev/ttyS3"


### PR DESCRIPTION
If NuttX is built without support for SMPS it can brick the hardware. Therefore, I suggest that we add this additional compile-time check.

FYI @bugobliterator 