### PR TITLE
ekf2: update mag calibration requirements

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2285,7 +2285,6 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 {
 	const bool bias_valid = (_param_ekf2_mag_type.get() == static_cast<int32_t>(MagFuseType::AUTO)
 				 || _param_ekf2_mag_type.get() == static_cast<int32_t>(MagFuseType::MAG_3D))
-				&& _ekf.control_status_flags().tilt_align
 				&& _ekf.control_status_flags().yaw_align
 				&& _ekf.control_status_flags().mag_aligned_in_flight
 				&& (_ekf.fault_status().value == 0)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2290,9 +2290,7 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 				&& _ekf.control_status_flags().mag_aligned_in_flight
 				&& (_ekf.fault_status().value == 0)
 				&& !_ekf.control_status_flags().mag_fault
-				&& !_ekf.control_status_flags().mag_field_disturbed
-				&& !_ekf.warning_event_flags().stopping_mag_use
-				&& !_ekf.warning_event_flags().emergency_yaw_reset_mag_stopped;
+				&& !_ekf.control_status_flags().mag_field_disturbed;
 
 	const bool learning_valid = bias_valid && _ekf.control_status_flags().mag_3D;
 


### PR DESCRIPTION
Capture all relevant control status flags for mag bias validity checks (leading to post flight mag cal).