### PR TITLE
ekf2: GNSS yaw only reset test ratio for new samples

### DIFF
--- a/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
+++ b/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
@@ -48,10 +48,11 @@
 
 void Ekf::updateGpsYaw(const gpsSample &gps_sample)
 {
-	auto &gnss_yaw = _aid_src_gnss_yaw;
-	resetEstimatorAidStatus(gnss_yaw);
-
 	if (PX4_ISFINITE(gps_sample.yaw)) {
+
+		auto &gnss_yaw = _aid_src_gnss_yaw;
+		resetEstimatorAidStatus(gnss_yaw);
+
 		// initially populate for estimator_aid_src_gnss_yaw logging
 
 		// calculate the observed yaw angle of antenna array, converting a from body to antenna yaw measurement


### PR DESCRIPTION
 - otherwise external test ratio monitoring could trigger a false positive