### PR TITLE
Fix ARK PAB SYS_USE_IO

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -291,7 +291,7 @@ else
 	then
 		# Check for the mini using build with px4io fw file
 		# but not a px4IO
-		if ver hwtypecmp V540 V560
+		if ver hwtypecmp V540 V560 ARKV6X001000 ARKV6X001001 ARKV6X001002 ARKV6X001003 ARKV6X001004 ARKV6X001005 ARKV6X001006 ARKV6X001007
 		then
 			param set SYS_USE_IO 0
 		else


### PR DESCRIPTION
This PR fixes the PWM outputs on the ARK PAB.