### PR TITLE
TECS: hotfix tas rate estimate input

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -240,8 +240,6 @@ void TECSControl::initialize(const Setpoint &setpoint, const Input &input, Param
 
 	_throttle_setpoint = _calcThrottleControlOutput(limit, ste_rate, param, flag);
 
-	_ste_rate = ste_rate.estimate;
-
 	// Debug output
 	_debug_output.total_energy_rate_estimate = ste_rate.estimate;
 	_debug_output.total_energy_rate_sp = ste_rate.setpoint;
@@ -502,7 +500,6 @@ void TECSControl::_calcThrottleControl(float dt, const SpecificEnergyRates &spec
 	}
 
 	_throttle_setpoint = constrain(throttle_setpoint, param.throttle_min, param.throttle_max);
-	_ste_rate = ste_rate.estimate;
 
 	// Debug output
 	_debug_output.total_energy_rate_estimate = ste_rate.estimate;

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -314,12 +314,6 @@ public:
 	 */
 	float getPitchSetpoint() const {return _pitch_setpoint;};
 	/**
-	 * @brief Get specific total energy rate.
-	 *
-	 * @return the total specific energy rate in [m²/s³].
-	 */
-	float getSteRate() const {return _ste_rate;};
-	/**
 	 * @brief Get the Debug Output
 	 *
 	 * @return the debug outpus struct.
@@ -535,7 +529,6 @@ private:
 	float _pitch_setpoint{0.0f};				///< Controlled pitch setpoint [rad].
 	float _throttle_setpoint{0.0f};				///< Controlled throttle setpoint [0,1].
 	float _ratio_undersped{0.0f};				///< A continuous representation of how "undersped" the TAS is [0,1]
-	float _ste_rate{0.0f};					///< Specific total energy rate [m²/s³].
 };
 
 class TECS

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -367,8 +367,11 @@ FixedwingPositionControl::vehicle_attitude_poll()
 		_pitch = euler_angles(1);
 		_yaw = euler_angles(2);
 
-		_body_acceleration = R.transpose() * Vector3f{_local_pos.ax, _local_pos.ay, _local_pos.az};
-		_body_velocity = R.transpose() * Vector3f{_local_pos.vx, _local_pos.vy, _local_pos.vz};
+		Vector3f body_acceleration = R.transpose() * Vector3f{_local_pos.ax, _local_pos.ay, _local_pos.az};
+		_body_acceleration_x = body_acceleration(0);
+
+		Vector3f body_velocity = R.transpose() * Vector3f{_local_pos.vx, _local_pos.vy, _local_pos.vz};
+		_body_velocity_x = body_velocity(0);
 
 		// load factor due to banking
 		const float load_factor = 1.f / cosf(euler_angles(0));
@@ -410,7 +413,7 @@ FixedwingPositionControl::adapt_airspeed_setpoint(const float control_interval, 
 		 * by wind). Not countering this would lead to a fly-away. Only non-zero in presence
 		 * of sufficient wind. "minimum ground speed undershoot".
 		 */
-		const float ground_speed_body = _body_velocity(0);
+		const float ground_speed_body = _body_velocity_x;
 
 		if (ground_speed_body < _param_fw_gnd_spd_min.get()) {
 			calibrated_airspeed_setpoint += _param_fw_gnd_spd_min.get() - ground_speed_body;
@@ -1414,7 +1417,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 				/* Perform launch detection */
 
 				/* Detect launch using body X (forward) acceleration */
-				_launchDetector.update(control_interval, _body_acceleration(0));
+				_launchDetector.update(control_interval, _body_acceleration_x);
 			}
 
 		} else	{
@@ -2563,7 +2566,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 		     pitch_max_rad - radians(_param_fw_psp_off.get()),
 		     desired_max_climbrate,
 		     desired_max_sinkrate,
-		     _body_acceleration(0),
+		     _body_acceleration_x,
 		     -_local_pos.vz,
 		     hgt_rate_sp);
 

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -2553,6 +2553,10 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 	const float throttle_trim_comp = compensateTrimThrottleForDensityAndWeight(_param_fw_thr_trim.get(), throttle_min,
 					 throttle_max);
 
+	// HOTFIX: the airspeed rate estimate using acceleration in body-forward direction has shown to lead to high biases
+	// when flying tight turns. It's in this case much safer to just set the estimated airspeed rate to 0.
+	const float airspeed_rate_estimate = 0.f;
+
 	_tecs.update(_pitch - radians(_param_fw_psp_off.get()),
 		     _current_altitude,
 		     alt_sp,
@@ -2566,11 +2570,11 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 		     pitch_max_rad - radians(_param_fw_psp_off.get()),
 		     desired_max_climbrate,
 		     desired_max_sinkrate,
-		     _body_acceleration_x,
+		     airspeed_rate_estimate,
 		     -_local_pos.vz,
 		     hgt_rate_sp);
 
-	tecs_status_publish(alt_sp, airspeed_sp, -_local_pos.vz, throttle_trim_comp);
+	tecs_status_publish(alt_sp, airspeed_sp, airspeed_rate_estimate, throttle_trim_comp);
 }
 
 float

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.hpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.hpp
@@ -263,8 +263,8 @@ private:
 	float _yaw{0.0f};
 	float _yawrate{0.0f};
 
-	matrix::Vector3f _body_acceleration{};
-	matrix::Vector3f _body_velocity{};
+	float _body_acceleration_x{0.f};
+	float _body_velocity_x{0.f};
 
 	MapProjection _global_local_proj_ref{};
 	float _global_local_alt0{NAN};


### PR DESCRIPTION
This is an alternative to https://github.com/PX4/PX4-Autopilot/pull/21266. The solution there, while it showed superior airspeed tracking performance, introduces additional estimator dependency that needs thorough investigation to handle properly. That's why I would like to bring this hotfix here in to mitigate the issue until a cleaner solution is found.

### Solved Problem
Bad airspeed tracking in tight turns.

### Solution
Disable airspeed rate estimation input into TECS (zero the input). 

### Test coverage
Flight tested once on a Tiltrotor VTOL. Comparison to current main (and the alternative way of estimating the airspeed rate) can be seen in https://github.com/PX4/PX4-Autopilot/pull/21266#issuecomment-1468632269.
