### PR TITLE
Lightware SF45 Fix path to crc lib (no longer in systemlib)

### DIFF
--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
@@ -37,7 +37,7 @@
 #include <inttypes.h>
 #include <fcntl.h>
 #include <termios.h>
-#include <lib/systemlib/crc.h>
+#include <lib/crc/crc.h>
 
 #include <float.h>
 #include <mathlib/mathlib.h>


### PR DESCRIPTION
The PR was made a while back before the crc.h file was moved out of systemlib. I believe the CI did not catch it due to the module not being enabled on any default firmware.
