### PR TITLE
fix typo in LeddarOne.cpp

### DIFF
--- a/src/drivers/distance_sensor/leddar_one/LeddarOne.cpp
+++ b/src/drivers/distance_sensor/leddar_one/LeddarOne.cpp
@@ -236,7 +236,7 @@ LeddarOne::open_serial_port(const speed_t speed)
 	uart_config.c_cflag |= (CS8 | CREAD | CLOCAL);
 
 	// Clear: echo, echo new line, canonical input and extended input.
-	uart_config.c_lflag &= (ECHO | ECHONL | ICANON | IEXTEN);
+	uart_config.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN);
 
 	// Clear ONLCR flag (which appends a CR for every LF).
 	uart_config.c_oflag &= ~ONLCR;


### PR DESCRIPTION
added missing "~"

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I found that missing char when i was investigating the code for something else. I am not very familiar with serial port reading but if i am not mistaken that line is useless if that char is missing. Similiar line also had that char. 

I have not actually tested the code, so maybe the correct thing to do is removing the line altogether

