### PR TITLE
component information: add translation support

### DIFF
--- a/Tools/px4events/jsonout.py
+++ b/Tools/px4events/jsonout.py
@@ -7,7 +7,7 @@ import os
 class JsonOutput():
     def __init__(self, groups):
         all_json = {}
-        all_json['version'] = 1
+        all_json['version'] = 2
         component = {}
         all_json['components'] = {1: component} #1: autopilot component
 

--- a/src/lib/component_information/CMakeLists.txt
+++ b/src/lib/component_information/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
 	set(comp_metadata_param_uri_fallback ${comp_metadata_param_uri_board})
 endif()
 # arguments: type, metadata file, uri, fallback uri, optional translation uri
-list(APPEND comp_metadata_types "--type" "1,${PX4_BINARY_DIR}/parameters.json.xz,${comp_metadata_param_uri},${comp_metadata_param_uri_fallback},")
+list(APPEND comp_metadata_types "--type" "1,${PX4_BINARY_DIR}/parameters.json.xz,${comp_metadata_param_uri},${comp_metadata_param_uri_fallback},https://raw.githubusercontent.com/PX4/PX4-Metadata-Translations/main/translated/parameters_summary.json")
 
 
 set(comp_metadata_events_uri_board "${s3_url}/Firmware/{version}/${comp_metadata_board}/all_events.json.xz")
@@ -66,7 +66,7 @@ else()
 	set(comp_metadata_events_uri "mftp://etc/extras/all_events.json.xz")
 	set(comp_metadata_events_uri_fallback ${comp_metadata_events_uri_board})
 endif()
-list(APPEND comp_metadata_types "--type" "4,${PX4_BINARY_DIR}/events/all_events.json.xz,${comp_metadata_events_uri},${comp_metadata_events_uri_fallback},")
+list(APPEND comp_metadata_types "--type" "4,${PX4_BINARY_DIR}/events/all_events.json.xz,${comp_metadata_events_uri},${comp_metadata_events_uri_fallback},https://raw.githubusercontent.com/PX4/PX4-Metadata-Translations/main/translated/events_summary.json")
 
 set(comp_metadata_actuators_uri_board "${s3_url}/Firmware/{version}/${comp_metadata_board}/actuators.json.xz")
 list(FIND config_romfs_extra_dependencies "actuators_json" index)

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -1,5 +1,47 @@
 {
-    "version": 1,
+    "version": 2,
+    "translation": {
+        "items": {
+            "components": {
+                "items": {
+                    "*": {
+                        "items": {
+                            "enums": {
+                                "items": {
+                                    "*": {
+                                        "items": {
+                                            "entries": {
+                                                "items": {
+                                                    "*": {
+                                                        "translate": [ "description" ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "event_groups": {
+                                "items": {
+                                    "*": {
+                                        "items": {
+                                            "events": {
+                                                "items": {
+                                                    "*": {
+                                                        "translate": [ "message", "description" ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
     "components": {
         "1": {
             "namespace": "px4",

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -11,6 +11,32 @@ class JsonOutput():
         all_params=[]
         all_json['parameters']=all_params
 
+        all_json["translation"] = {
+            "items": {
+                "parameters": {
+                    "list": {
+                        "key": "name",
+                        "translate": [ "shortDesc", "longDesc" ],
+                        "translate-global": ["category", "group"],
+                        "items": {
+                            "bitmask": {
+                                "list": {
+                                    "key": "index",
+                                    "translate": [ "description" ]
+                                }
+                            },
+                            "values": {
+                                "list": {
+                                    "key": "value",
+                                    "translate": [ "description" ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         schema_map = {
                         "short_desc": "shortDesc",
 			"long_desc": "longDesc",


### PR DESCRIPTION
This adds the metadata translation url's pointing to https://github.com/PX4/PX4-Metadata-Translations.

@hamishwillee fyi

QGC PR: https://github.com/mavlink/qgroundcontrol/pull/10522
MAVLink: https://github.com/mavlink/mavlink/pull/1934