### PR TITLE
ekf: add option to rotate the sideslip fusion direction

### DIFF
--- a/msg/EstimatorStatusFlags.msg
+++ b/msg/EstimatorStatusFlags.msg
@@ -39,6 +39,7 @@ bool cs_rng_kin_consistent      # 31 - true when the range finder kinematic cons
 bool cs_fake_pos                # 32 - true when fake position measurements are being fused
 bool cs_fake_hgt                # 33 - true when fake height measurements are being fused
 bool cs_gravity_vector          # 34 - true when gravity vector measurements are being fused
+bool cs_tailsitter              # 35 - true when the vehicle is a tailsitter and the sideslip fusion is rotated by 90 degrees
 
 # fault status
 uint32 fault_status_changes   # number of filter fault status (fs) changes

--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -54,7 +54,7 @@ AirspeedValidator::update_airspeed_validator(const airspeed_validator_update_dat
 	update_CAS_scale_applied();
 	update_CAS_TAS(input_data.air_pressure_pa, input_data.air_temperature_celsius);
 	update_wind_estimator(input_data.timestamp, input_data.airspeed_true_raw, input_data.lpos_valid,
-			      input_data.ground_velocity, input_data.lpos_evh, input_data.lpos_evv, input_data.att_q);
+			      input_data.ground_velocity, input_data.lpos_evh, input_data.lpos_evv, input_data.q_att);
 	update_in_fixed_wing_flight(input_data.in_fixed_wing_flight);
 	check_airspeed_data_stuck(input_data.timestamp);
 	check_load_factor(input_data.accel_z);
@@ -72,20 +72,18 @@ AirspeedValidator::reset_airspeed_to_invalid(const uint64_t timestamp)
 
 void
 AirspeedValidator::update_wind_estimator(const uint64_t time_now_usec, float airspeed_true_raw, bool lpos_valid,
-		const matrix::Vector3f &vI, float lpos_evh, float lpos_evv, const float att_q[4])
+		const matrix::Vector3f &vI, float lpos_evh, float lpos_evv, const Quatf &q_att)
 {
 	_wind_estimator.update(time_now_usec);
 
 	if (lpos_valid && _in_fixed_wing_flight) {
 
-		Quatf q(att_q);
-
 		// airspeed fusion (with raw TAS)
 		const float hor_vel_variance =  lpos_evh * lpos_evh;
-		_wind_estimator.fuse_airspeed(time_now_usec, airspeed_true_raw, vI, hor_vel_variance, q);
+		_wind_estimator.fuse_airspeed(time_now_usec, airspeed_true_raw, vI, hor_vel_variance, q_att);
 
 		// sideslip fusion
-		_wind_estimator.fuse_beta(time_now_usec, vI, hor_vel_variance, q);
+		_wind_estimator.fuse_beta(time_now_usec, vI, hor_vel_variance, q_att);
 	}
 }
 

--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -59,7 +59,7 @@ struct airspeed_validator_update_data {
 	bool lpos_valid;
 	float lpos_evh;
 	float lpos_evv;
-	float att_q[4];
+	matrix::Quatf q_att;
 	float air_pressure_pa;
 	float air_temperature_celsius;
 	float accel_z;
@@ -179,7 +179,7 @@ private:
 
 	void update_wind_estimator(const uint64_t timestamp, float airspeed_true_raw, bool lpos_valid,
 				   const matrix::Vector3f &vI,
-				   float lpos_evh, float lpos_evv, const float att_q[4]);
+				   float lpos_evh, float lpos_evv, const Quatf &q_att);
 	void update_CAS_scale_validated(bool lpos_valid, const matrix::Vector3f &vI, float airspeed_true_raw);
 	void update_CAS_scale_applied();
 	void update_CAS_TAS(float air_pressure_pa, float air_temperature_celsius);

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -107,7 +107,7 @@ public:
 	uint16_t getMotorFailures() const { return _motor_failure_esc_timed_out_mask | _motor_failure_esc_under_current_mask; }
 
 private:
-	void updateAttitudeStatus();
+	void updateAttitudeStatus(const vehicle_status_s &vehicle_status);
 	void updateExternalAtsStatus();
 	void updateEscsStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
 	void updateMotorStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -268,6 +268,7 @@ struct systemFlagUpdate {
 	bool at_rest{false};
 	bool in_air{true};
 	bool is_fixed_wing{false};
+	bool is_tailsitter{false};
 	bool gnd_effect{false};
 };
 
@@ -570,6 +571,7 @@ union filter_control_status_u {
 		uint64_t fake_pos                : 1; ///< 32 - true when fake position measurements are being fused
 		uint64_t fake_hgt                : 1; ///< 33 - true when fake height measurements are being fused
 		uint64_t gravity_vector          : 1; ///< 34 - true when gravity vector measurements are being fused
+		uint64_t tailsitter             : 1; ///< 35 - true when the vehicle is a tailsitter and the sideslip fusion is rotated by 90 degrees
 	} flags;
 	uint64_t value;
 };

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -135,6 +135,8 @@ public:
 	// set vehicle is fixed wing status
 	void set_is_fixed_wing(bool is_fixed_wing) { _control_status.flags.fixed_wing = is_fixed_wing; }
 
+	void set_is_tailsitter(bool is_tailsitter) { _control_status.flags.tailsitter = is_tailsitter; }
+
 	// set flag if static pressure rise due to ground effect is expected
 	// use _params.gnd_effect_deadzone to adjust for expected rise in static pressure
 	// flag will clear after GNDEFFECT_TIMEOUT uSec

--- a/src/modules/ekf2/EKF/python/ekf_derivation/derivation.py
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/derivation.py
@@ -151,12 +151,14 @@ def compute_airspeed_h_and_k(
 
 def predict_sideslip(
         state: VState,
+        pitch_offset: sf.Scalar,
         epsilon: sf.Scalar
 ) -> (sf.Scalar):
 
     vel_rel = sf.V3(state[State.vx] - state[State.wx], state[State.vy] - state[State.wy], state[State.vz])
     q_att = sf.V4(state[State.qw], state[State.qx], state[State.qy], state[State.qz])
-    relative_wind_body = quat_to_rot(q_att).T * vel_rel
+    q_offset = sf.V4(sf.cos(pitch_offset / 2.0), 0.0, sf.sin(pitch_offset / 2.0), 0.0)
+    relative_wind_body = quat_to_rot(quat_mult(q_att, q_offset)).T * vel_rel
 
     # Small angle approximation of side slip model
     # Protect division by zero using epsilon
@@ -166,12 +168,13 @@ def predict_sideslip(
 
 def compute_sideslip_innov_and_innov_var(
         state: VState,
+        pitch_offset: sf.Scalar,
         P: MState,
         R: sf.Scalar,
         epsilon: sf.Scalar
 ) -> (sf.Scalar, sf.Scalar, sf.Scalar):
 
-    sideslip_pred = predict_sideslip(state, epsilon);
+    sideslip_pred = predict_sideslip(state, pitch_offset, epsilon);
 
     innov = sideslip_pred - 0.0
 
@@ -182,12 +185,13 @@ def compute_sideslip_innov_and_innov_var(
 
 def compute_sideslip_h_and_k(
         state: VState,
+        pitch_offset: sf.Scalar,
         P: MState,
         innov_var: sf.Scalar,
         epsilon: sf.Scalar
 ) -> (VState, VState):
 
-    sideslip_pred = predict_sideslip(state, epsilon);
+    sideslip_pred = predict_sideslip(state, pitch_offset, epsilon);
 
     H = sf.V1(sideslip_pred).jacobian(state)
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_h_and_k.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_h_and_k.h
@@ -17,6 +17,7 @@ namespace sym {
  *
  * Args:
  *     state: Matrix24_1
+ *     pitch_offset: Scalar
  *     P: Matrix24_24
  *     innov_var: Scalar
  *     epsilon: Scalar
@@ -26,61 +27,97 @@ namespace sym {
  *     K: Matrix24_1
  */
 template <typename Scalar>
-void ComputeSideslipHAndK(const matrix::Matrix<Scalar, 24, 1>& state,
+void ComputeSideslipHAndK(const matrix::Matrix<Scalar, 24, 1>& state, const Scalar pitch_offset,
                           const matrix::Matrix<Scalar, 24, 24>& P, const Scalar innov_var,
                           const Scalar epsilon, matrix::Matrix<Scalar, 24, 1>* const H = nullptr,
                           matrix::Matrix<Scalar, 24, 1>* const K = nullptr) {
-  // Total ops: 539
+  // Total ops: 649
 
   // Input arrays
 
-  // Intermediate terms (44)
-  const Scalar _tmp0 = std::pow(state(2, 0), Scalar(2));
-  const Scalar _tmp1 = std::pow(state(1, 0), Scalar(2));
-  const Scalar _tmp2 = std::pow(state(0, 0), Scalar(2)) - std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp3 = -_tmp0 + _tmp1 + _tmp2;
-  const Scalar _tmp4 = -state(22, 0) + state(4, 0);
-  const Scalar _tmp5 = state(0, 0) * state(3, 0);
-  const Scalar _tmp6 = state(1, 0) * state(2, 0);
-  const Scalar _tmp7 = _tmp5 + _tmp6;
-  const Scalar _tmp8 = -state(23, 0) + state(5, 0);
-  const Scalar _tmp9 = 2 * _tmp8;
-  const Scalar _tmp10 = state(0, 0) * state(2, 0);
-  const Scalar _tmp11 = state(1, 0) * state(3, 0);
-  const Scalar _tmp12 = 2 * state(6, 0);
-  const Scalar _tmp13 = _tmp12 * (-_tmp10 + _tmp11) + _tmp3 * _tmp4 + _tmp7 * _tmp9;
-  const Scalar _tmp14 =
-      _tmp13 + epsilon * (2 * math::min<Scalar>(0, (((_tmp13) > 0) - ((_tmp13) < 0))) + 1);
-  const Scalar _tmp15 = Scalar(1.0) / (_tmp14);
-  const Scalar _tmp16 = 2 * _tmp4;
-  const Scalar _tmp17 = _tmp12 * state(1, 0) - _tmp16 * state(3, 0) + _tmp9 * state(0, 0);
-  const Scalar _tmp18 = _tmp16 * state(0, 0);
-  const Scalar _tmp19 = _tmp9 * state(3, 0);
-  const Scalar _tmp20 = _tmp12 * state(2, 0);
-  const Scalar _tmp21 = _tmp0 - _tmp1 + _tmp2;
-  const Scalar _tmp22 = -2 * _tmp5 + 2 * _tmp6;
-  const Scalar _tmp23 = state(2, 0) * state(3, 0);
-  const Scalar _tmp24 = state(0, 0) * state(1, 0);
-  const Scalar _tmp25 =
-      (_tmp12 * (_tmp23 + _tmp24) + _tmp21 * _tmp8 + _tmp22 * _tmp4) / std::pow(_tmp14, Scalar(2));
-  const Scalar _tmp26 = _tmp15 * _tmp17 - _tmp25 * (_tmp18 + _tmp19 - _tmp20);
-  const Scalar _tmp27 = _tmp9 * state(1, 0);
-  const Scalar _tmp28 = _tmp16 * state(2, 0);
-  const Scalar _tmp29 = _tmp12 * state(0, 0);
-  const Scalar _tmp30 = _tmp12 * state(3, 0) + _tmp16 * state(1, 0) + _tmp9 * state(2, 0);
-  const Scalar _tmp31 = _tmp15 * (-_tmp27 + _tmp28 + _tmp29) - _tmp25 * _tmp30;
-  const Scalar _tmp32 = _tmp15 * _tmp30 - _tmp25 * (_tmp27 - _tmp28 - _tmp29);
-  const Scalar _tmp33 = _tmp15 * (-_tmp18 - _tmp19 + _tmp20) - _tmp17 * _tmp25;
-  const Scalar _tmp34 = _tmp25 * _tmp3;
-  const Scalar _tmp35 = 2 * _tmp5;
-  const Scalar _tmp36 = 2 * _tmp6;
-  const Scalar _tmp37 = _tmp15 * (-_tmp35 + _tmp36) - _tmp34;
-  const Scalar _tmp38 = _tmp15 * _tmp21;
-  const Scalar _tmp39 = -_tmp25 * (_tmp35 + _tmp36) + _tmp38;
-  const Scalar _tmp40 = _tmp15 * (2 * _tmp23 + 2 * _tmp24) - _tmp25 * (-2 * _tmp10 + 2 * _tmp11);
-  const Scalar _tmp41 = -_tmp15 * _tmp22 + _tmp34;
-  const Scalar _tmp42 = 2 * _tmp25 * _tmp7 - _tmp38;
-  const Scalar _tmp43 = Scalar(1.0) / (math::max<Scalar>(epsilon, innov_var));
+  // Intermediate terms (67)
+  const Scalar _tmp0 = Scalar(0.5) * pitch_offset;
+  const Scalar _tmp1 = std::cos(_tmp0);
+  const Scalar _tmp2 = std::sin(_tmp0);
+  const Scalar _tmp3 = _tmp1 * state(3, 0) + _tmp2 * state(1, 0);
+  const Scalar _tmp4 = _tmp1 * state(1, 0) - _tmp2 * state(3, 0);
+  const Scalar _tmp5 = _tmp1 * state(0, 0) - _tmp2 * state(2, 0);
+  const Scalar _tmp6 = _tmp1 * state(2, 0) + _tmp2 * state(0, 0);
+  const Scalar _tmp7 = -std::pow(_tmp3, Scalar(2)) + std::pow(_tmp4, Scalar(2)) +
+                       std::pow(_tmp5, Scalar(2)) - std::pow(_tmp6, Scalar(2));
+  const Scalar _tmp8 = -state(22, 0) + state(4, 0);
+  const Scalar _tmp9 = _tmp4 * _tmp6;
+  const Scalar _tmp10 = _tmp3 * _tmp5;
+  const Scalar _tmp11 = _tmp10 + _tmp9;
+  const Scalar _tmp12 = -state(23, 0) + state(5, 0);
+  const Scalar _tmp13 = 2 * _tmp12;
+  const Scalar _tmp14 = _tmp3 * _tmp4;
+  const Scalar _tmp15 = _tmp5 * _tmp6;
+  const Scalar _tmp16 = 2 * state(6, 0);
+  const Scalar _tmp17 = _tmp11 * _tmp13 + _tmp16 * (_tmp14 - _tmp15) + _tmp7 * _tmp8;
+  const Scalar _tmp18 =
+      _tmp17 + epsilon * (2 * math::min<Scalar>(0, (((_tmp17) > 0) - ((_tmp17) < 0))) + 1);
+  const Scalar _tmp19 = Scalar(1.0) / (_tmp18);
+  const Scalar _tmp20 = _tmp0;
+  const Scalar _tmp21 = std::sin(_tmp20);
+  const Scalar _tmp22 = std::cos(_tmp20);
+  const Scalar _tmp23 = _tmp21 * state(1, 0) + _tmp22 * state(3, 0);
+  const Scalar _tmp24 = _tmp21 * _tmp23;
+  const Scalar _tmp25 = -_tmp21 * state(3, 0) + _tmp22 * state(1, 0);
+  const Scalar _tmp26 = _tmp22 * _tmp25;
+  const Scalar _tmp27 = _tmp24 + _tmp26;
+  const Scalar _tmp28 = _tmp21 * state(0, 0) + _tmp22 * state(2, 0);
+  const Scalar _tmp29 = _tmp21 * _tmp28;
+  const Scalar _tmp30 = -_tmp21 * state(2, 0) + _tmp22 * state(0, 0);
+  const Scalar _tmp31 = _tmp22 * _tmp30;
+  const Scalar _tmp32 = _tmp22 * _tmp23;
+  const Scalar _tmp33 = _tmp21 * _tmp25;
+  const Scalar _tmp34 = 2 * _tmp8;
+  const Scalar _tmp35 = _tmp1 * _tmp3;
+  const Scalar _tmp36 = _tmp2 * _tmp4;
+  const Scalar _tmp37 = _tmp35 + _tmp36;
+  const Scalar _tmp38 = _tmp2 * _tmp5;
+  const Scalar _tmp39 = _tmp1 * _tmp6;
+  const Scalar _tmp40 = _tmp1 * _tmp5;
+  const Scalar _tmp41 = _tmp2 * _tmp6;
+  const Scalar _tmp42 = -std::pow(_tmp23, Scalar(2)) - std::pow(_tmp25, Scalar(2)) +
+                        std::pow(_tmp28, Scalar(2)) + std::pow(_tmp30, Scalar(2));
+  const Scalar _tmp43 = _tmp23 * _tmp30;
+  const Scalar _tmp44 = _tmp25 * _tmp28;
+  const Scalar _tmp45 = -_tmp43 + _tmp44;
+  const Scalar _tmp46 = _tmp23 * _tmp28;
+  const Scalar _tmp47 = _tmp25 * _tmp30;
+  const Scalar _tmp48 = (_tmp12 * _tmp42 + _tmp16 * (_tmp46 + _tmp47) + _tmp34 * _tmp45) /
+                        std::pow(_tmp18, Scalar(2));
+  const Scalar _tmp49 =
+      _tmp19 *
+          (_tmp12 * (2 * _tmp29 + 2 * _tmp31) + _tmp16 * _tmp27 + _tmp34 * (-_tmp32 + _tmp33)) -
+      _tmp48 * (_tmp13 * _tmp37 + _tmp16 * (-_tmp38 - _tmp39) + _tmp8 * (2 * _tmp40 - 2 * _tmp41));
+  const Scalar _tmp50 = _tmp2 * _tmp3;
+  const Scalar _tmp51 = _tmp1 * _tmp4;
+  const Scalar _tmp52 = _tmp22 * _tmp28;
+  const Scalar _tmp53 = _tmp21 * _tmp30;
+  const Scalar _tmp54 = _tmp52 - _tmp53;
+  const Scalar _tmp55 =
+      _tmp19 *
+          (_tmp12 * (-2 * _tmp24 - 2 * _tmp26) + _tmp16 * (_tmp29 + _tmp31) + _tmp34 * _tmp54) -
+      _tmp48 * (_tmp13 * (_tmp38 + _tmp39) + _tmp16 * _tmp37 + _tmp8 * (-2 * _tmp50 + 2 * _tmp51));
+  const Scalar _tmp56 = -_tmp50 + _tmp51;
+  const Scalar _tmp57 =
+      _tmp19 * (_tmp12 * (2 * _tmp52 - 2 * _tmp53) + _tmp16 * (_tmp32 - _tmp33) + _tmp27 * _tmp34) -
+      _tmp48 * (_tmp13 * _tmp56 + _tmp16 * (-_tmp40 + _tmp41) + _tmp8 * (-2 * _tmp38 - 2 * _tmp39));
+  const Scalar _tmp58 =
+      _tmp19 *
+          (_tmp12 * (-2 * _tmp32 + 2 * _tmp33) + _tmp16 * _tmp54 + _tmp34 * (-_tmp29 - _tmp31)) -
+      _tmp48 * (_tmp13 * (_tmp40 - _tmp41) + _tmp16 * _tmp56 + _tmp8 * (-2 * _tmp35 - 2 * _tmp36));
+  const Scalar _tmp59 = _tmp48 * _tmp7;
+  const Scalar _tmp60 = _tmp19 * (-2 * _tmp43 + 2 * _tmp44) - _tmp59;
+  const Scalar _tmp61 = _tmp19 * _tmp42;
+  const Scalar _tmp62 = -_tmp48 * (2 * _tmp10 + 2 * _tmp9) + _tmp61;
+  const Scalar _tmp63 = _tmp19 * (2 * _tmp46 + 2 * _tmp47) - _tmp48 * (2 * _tmp14 - 2 * _tmp15);
+  const Scalar _tmp64 = -2 * _tmp19 * _tmp45 + _tmp59;
+  const Scalar _tmp65 = 2 * _tmp11 * _tmp48 - _tmp61;
+  const Scalar _tmp66 = Scalar(1.0) / (math::max<Scalar>(epsilon, innov_var));
 
   // Output terms (2)
   if (H != nullptr) {
@@ -88,92 +125,92 @@ void ComputeSideslipHAndK(const matrix::Matrix<Scalar, 24, 1>& state,
 
     _h.setZero();
 
-    _h(0, 0) = _tmp26;
-    _h(1, 0) = _tmp31;
-    _h(2, 0) = _tmp32;
-    _h(3, 0) = _tmp33;
-    _h(4, 0) = _tmp37;
-    _h(5, 0) = _tmp39;
-    _h(6, 0) = _tmp40;
-    _h(22, 0) = _tmp41;
-    _h(23, 0) = _tmp42;
+    _h(0, 0) = _tmp49;
+    _h(1, 0) = _tmp55;
+    _h(2, 0) = _tmp57;
+    _h(3, 0) = _tmp58;
+    _h(4, 0) = _tmp60;
+    _h(5, 0) = _tmp62;
+    _h(6, 0) = _tmp63;
+    _h(22, 0) = _tmp64;
+    _h(23, 0) = _tmp65;
   }
 
   if (K != nullptr) {
     matrix::Matrix<Scalar, 24, 1>& _k = (*K);
 
-    _k(0, 0) = _tmp43 * (P(0, 0) * _tmp26 + P(0, 1) * _tmp31 + P(0, 2) * _tmp32 +
-                         P(0, 22) * _tmp41 + P(0, 23) * _tmp42 + P(0, 3) * _tmp33 +
-                         P(0, 4) * _tmp37 + P(0, 5) * _tmp39 + P(0, 6) * _tmp40);
-    _k(1, 0) = _tmp43 * (P(1, 0) * _tmp26 + P(1, 1) * _tmp31 + P(1, 2) * _tmp32 +
-                         P(1, 22) * _tmp41 + P(1, 23) * _tmp42 + P(1, 3) * _tmp33 +
-                         P(1, 4) * _tmp37 + P(1, 5) * _tmp39 + P(1, 6) * _tmp40);
-    _k(2, 0) = _tmp43 * (P(2, 0) * _tmp26 + P(2, 1) * _tmp31 + P(2, 2) * _tmp32 +
-                         P(2, 22) * _tmp41 + P(2, 23) * _tmp42 + P(2, 3) * _tmp33 +
-                         P(2, 4) * _tmp37 + P(2, 5) * _tmp39 + P(2, 6) * _tmp40);
-    _k(3, 0) = _tmp43 * (P(3, 0) * _tmp26 + P(3, 1) * _tmp31 + P(3, 2) * _tmp32 +
-                         P(3, 22) * _tmp41 + P(3, 23) * _tmp42 + P(3, 3) * _tmp33 +
-                         P(3, 4) * _tmp37 + P(3, 5) * _tmp39 + P(3, 6) * _tmp40);
-    _k(4, 0) = _tmp43 * (P(4, 0) * _tmp26 + P(4, 1) * _tmp31 + P(4, 2) * _tmp32 +
-                         P(4, 22) * _tmp41 + P(4, 23) * _tmp42 + P(4, 3) * _tmp33 +
-                         P(4, 4) * _tmp37 + P(4, 5) * _tmp39 + P(4, 6) * _tmp40);
-    _k(5, 0) = _tmp43 * (P(5, 0) * _tmp26 + P(5, 1) * _tmp31 + P(5, 2) * _tmp32 +
-                         P(5, 22) * _tmp41 + P(5, 23) * _tmp42 + P(5, 3) * _tmp33 +
-                         P(5, 4) * _tmp37 + P(5, 5) * _tmp39 + P(5, 6) * _tmp40);
-    _k(6, 0) = _tmp43 * (P(6, 0) * _tmp26 + P(6, 1) * _tmp31 + P(6, 2) * _tmp32 +
-                         P(6, 22) * _tmp41 + P(6, 23) * _tmp42 + P(6, 3) * _tmp33 +
-                         P(6, 4) * _tmp37 + P(6, 5) * _tmp39 + P(6, 6) * _tmp40);
-    _k(7, 0) = _tmp43 * (P(7, 0) * _tmp26 + P(7, 1) * _tmp31 + P(7, 2) * _tmp32 +
-                         P(7, 22) * _tmp41 + P(7, 23) * _tmp42 + P(7, 3) * _tmp33 +
-                         P(7, 4) * _tmp37 + P(7, 5) * _tmp39 + P(7, 6) * _tmp40);
-    _k(8, 0) = _tmp43 * (P(8, 0) * _tmp26 + P(8, 1) * _tmp31 + P(8, 2) * _tmp32 +
-                         P(8, 22) * _tmp41 + P(8, 23) * _tmp42 + P(8, 3) * _tmp33 +
-                         P(8, 4) * _tmp37 + P(8, 5) * _tmp39 + P(8, 6) * _tmp40);
-    _k(9, 0) = _tmp43 * (P(9, 0) * _tmp26 + P(9, 1) * _tmp31 + P(9, 2) * _tmp32 +
-                         P(9, 22) * _tmp41 + P(9, 23) * _tmp42 + P(9, 3) * _tmp33 +
-                         P(9, 4) * _tmp37 + P(9, 5) * _tmp39 + P(9, 6) * _tmp40);
-    _k(10, 0) = _tmp43 * (P(10, 0) * _tmp26 + P(10, 1) * _tmp31 + P(10, 2) * _tmp32 +
-                          P(10, 22) * _tmp41 + P(10, 23) * _tmp42 + P(10, 3) * _tmp33 +
-                          P(10, 4) * _tmp37 + P(10, 5) * _tmp39 + P(10, 6) * _tmp40);
-    _k(11, 0) = _tmp43 * (P(11, 0) * _tmp26 + P(11, 1) * _tmp31 + P(11, 2) * _tmp32 +
-                          P(11, 22) * _tmp41 + P(11, 23) * _tmp42 + P(11, 3) * _tmp33 +
-                          P(11, 4) * _tmp37 + P(11, 5) * _tmp39 + P(11, 6) * _tmp40);
-    _k(12, 0) = _tmp43 * (P(12, 0) * _tmp26 + P(12, 1) * _tmp31 + P(12, 2) * _tmp32 +
-                          P(12, 22) * _tmp41 + P(12, 23) * _tmp42 + P(12, 3) * _tmp33 +
-                          P(12, 4) * _tmp37 + P(12, 5) * _tmp39 + P(12, 6) * _tmp40);
-    _k(13, 0) = _tmp43 * (P(13, 0) * _tmp26 + P(13, 1) * _tmp31 + P(13, 2) * _tmp32 +
-                          P(13, 22) * _tmp41 + P(13, 23) * _tmp42 + P(13, 3) * _tmp33 +
-                          P(13, 4) * _tmp37 + P(13, 5) * _tmp39 + P(13, 6) * _tmp40);
-    _k(14, 0) = _tmp43 * (P(14, 0) * _tmp26 + P(14, 1) * _tmp31 + P(14, 2) * _tmp32 +
-                          P(14, 22) * _tmp41 + P(14, 23) * _tmp42 + P(14, 3) * _tmp33 +
-                          P(14, 4) * _tmp37 + P(14, 5) * _tmp39 + P(14, 6) * _tmp40);
-    _k(15, 0) = _tmp43 * (P(15, 0) * _tmp26 + P(15, 1) * _tmp31 + P(15, 2) * _tmp32 +
-                          P(15, 22) * _tmp41 + P(15, 23) * _tmp42 + P(15, 3) * _tmp33 +
-                          P(15, 4) * _tmp37 + P(15, 5) * _tmp39 + P(15, 6) * _tmp40);
-    _k(16, 0) = _tmp43 * (P(16, 0) * _tmp26 + P(16, 1) * _tmp31 + P(16, 2) * _tmp32 +
-                          P(16, 22) * _tmp41 + P(16, 23) * _tmp42 + P(16, 3) * _tmp33 +
-                          P(16, 4) * _tmp37 + P(16, 5) * _tmp39 + P(16, 6) * _tmp40);
-    _k(17, 0) = _tmp43 * (P(17, 0) * _tmp26 + P(17, 1) * _tmp31 + P(17, 2) * _tmp32 +
-                          P(17, 22) * _tmp41 + P(17, 23) * _tmp42 + P(17, 3) * _tmp33 +
-                          P(17, 4) * _tmp37 + P(17, 5) * _tmp39 + P(17, 6) * _tmp40);
-    _k(18, 0) = _tmp43 * (P(18, 0) * _tmp26 + P(18, 1) * _tmp31 + P(18, 2) * _tmp32 +
-                          P(18, 22) * _tmp41 + P(18, 23) * _tmp42 + P(18, 3) * _tmp33 +
-                          P(18, 4) * _tmp37 + P(18, 5) * _tmp39 + P(18, 6) * _tmp40);
-    _k(19, 0) = _tmp43 * (P(19, 0) * _tmp26 + P(19, 1) * _tmp31 + P(19, 2) * _tmp32 +
-                          P(19, 22) * _tmp41 + P(19, 23) * _tmp42 + P(19, 3) * _tmp33 +
-                          P(19, 4) * _tmp37 + P(19, 5) * _tmp39 + P(19, 6) * _tmp40);
-    _k(20, 0) = _tmp43 * (P(20, 0) * _tmp26 + P(20, 1) * _tmp31 + P(20, 2) * _tmp32 +
-                          P(20, 22) * _tmp41 + P(20, 23) * _tmp42 + P(20, 3) * _tmp33 +
-                          P(20, 4) * _tmp37 + P(20, 5) * _tmp39 + P(20, 6) * _tmp40);
-    _k(21, 0) = _tmp43 * (P(21, 0) * _tmp26 + P(21, 1) * _tmp31 + P(21, 2) * _tmp32 +
-                          P(21, 22) * _tmp41 + P(21, 23) * _tmp42 + P(21, 3) * _tmp33 +
-                          P(21, 4) * _tmp37 + P(21, 5) * _tmp39 + P(21, 6) * _tmp40);
-    _k(22, 0) = _tmp43 * (P(22, 0) * _tmp26 + P(22, 1) * _tmp31 + P(22, 2) * _tmp32 +
-                          P(22, 22) * _tmp41 + P(22, 23) * _tmp42 + P(22, 3) * _tmp33 +
-                          P(22, 4) * _tmp37 + P(22, 5) * _tmp39 + P(22, 6) * _tmp40);
-    _k(23, 0) = _tmp43 * (P(23, 0) * _tmp26 + P(23, 1) * _tmp31 + P(23, 2) * _tmp32 +
-                          P(23, 22) * _tmp41 + P(23, 23) * _tmp42 + P(23, 3) * _tmp33 +
-                          P(23, 4) * _tmp37 + P(23, 5) * _tmp39 + P(23, 6) * _tmp40);
+    _k(0, 0) = _tmp66 * (P(0, 0) * _tmp49 + P(0, 1) * _tmp55 + P(0, 2) * _tmp57 +
+                         P(0, 22) * _tmp64 + P(0, 23) * _tmp65 + P(0, 3) * _tmp58 +
+                         P(0, 4) * _tmp60 + P(0, 5) * _tmp62 + P(0, 6) * _tmp63);
+    _k(1, 0) = _tmp66 * (P(1, 0) * _tmp49 + P(1, 1) * _tmp55 + P(1, 2) * _tmp57 +
+                         P(1, 22) * _tmp64 + P(1, 23) * _tmp65 + P(1, 3) * _tmp58 +
+                         P(1, 4) * _tmp60 + P(1, 5) * _tmp62 + P(1, 6) * _tmp63);
+    _k(2, 0) = _tmp66 * (P(2, 0) * _tmp49 + P(2, 1) * _tmp55 + P(2, 2) * _tmp57 +
+                         P(2, 22) * _tmp64 + P(2, 23) * _tmp65 + P(2, 3) * _tmp58 +
+                         P(2, 4) * _tmp60 + P(2, 5) * _tmp62 + P(2, 6) * _tmp63);
+    _k(3, 0) = _tmp66 * (P(3, 0) * _tmp49 + P(3, 1) * _tmp55 + P(3, 2) * _tmp57 +
+                         P(3, 22) * _tmp64 + P(3, 23) * _tmp65 + P(3, 3) * _tmp58 +
+                         P(3, 4) * _tmp60 + P(3, 5) * _tmp62 + P(3, 6) * _tmp63);
+    _k(4, 0) = _tmp66 * (P(4, 0) * _tmp49 + P(4, 1) * _tmp55 + P(4, 2) * _tmp57 +
+                         P(4, 22) * _tmp64 + P(4, 23) * _tmp65 + P(4, 3) * _tmp58 +
+                         P(4, 4) * _tmp60 + P(4, 5) * _tmp62 + P(4, 6) * _tmp63);
+    _k(5, 0) = _tmp66 * (P(5, 0) * _tmp49 + P(5, 1) * _tmp55 + P(5, 2) * _tmp57 +
+                         P(5, 22) * _tmp64 + P(5, 23) * _tmp65 + P(5, 3) * _tmp58 +
+                         P(5, 4) * _tmp60 + P(5, 5) * _tmp62 + P(5, 6) * _tmp63);
+    _k(6, 0) = _tmp66 * (P(6, 0) * _tmp49 + P(6, 1) * _tmp55 + P(6, 2) * _tmp57 +
+                         P(6, 22) * _tmp64 + P(6, 23) * _tmp65 + P(6, 3) * _tmp58 +
+                         P(6, 4) * _tmp60 + P(6, 5) * _tmp62 + P(6, 6) * _tmp63);
+    _k(7, 0) = _tmp66 * (P(7, 0) * _tmp49 + P(7, 1) * _tmp55 + P(7, 2) * _tmp57 +
+                         P(7, 22) * _tmp64 + P(7, 23) * _tmp65 + P(7, 3) * _tmp58 +
+                         P(7, 4) * _tmp60 + P(7, 5) * _tmp62 + P(7, 6) * _tmp63);
+    _k(8, 0) = _tmp66 * (P(8, 0) * _tmp49 + P(8, 1) * _tmp55 + P(8, 2) * _tmp57 +
+                         P(8, 22) * _tmp64 + P(8, 23) * _tmp65 + P(8, 3) * _tmp58 +
+                         P(8, 4) * _tmp60 + P(8, 5) * _tmp62 + P(8, 6) * _tmp63);
+    _k(9, 0) = _tmp66 * (P(9, 0) * _tmp49 + P(9, 1) * _tmp55 + P(9, 2) * _tmp57 +
+                         P(9, 22) * _tmp64 + P(9, 23) * _tmp65 + P(9, 3) * _tmp58 +
+                         P(9, 4) * _tmp60 + P(9, 5) * _tmp62 + P(9, 6) * _tmp63);
+    _k(10, 0) = _tmp66 * (P(10, 0) * _tmp49 + P(10, 1) * _tmp55 + P(10, 2) * _tmp57 +
+                          P(10, 22) * _tmp64 + P(10, 23) * _tmp65 + P(10, 3) * _tmp58 +
+                          P(10, 4) * _tmp60 + P(10, 5) * _tmp62 + P(10, 6) * _tmp63);
+    _k(11, 0) = _tmp66 * (P(11, 0) * _tmp49 + P(11, 1) * _tmp55 + P(11, 2) * _tmp57 +
+                          P(11, 22) * _tmp64 + P(11, 23) * _tmp65 + P(11, 3) * _tmp58 +
+                          P(11, 4) * _tmp60 + P(11, 5) * _tmp62 + P(11, 6) * _tmp63);
+    _k(12, 0) = _tmp66 * (P(12, 0) * _tmp49 + P(12, 1) * _tmp55 + P(12, 2) * _tmp57 +
+                          P(12, 22) * _tmp64 + P(12, 23) * _tmp65 + P(12, 3) * _tmp58 +
+                          P(12, 4) * _tmp60 + P(12, 5) * _tmp62 + P(12, 6) * _tmp63);
+    _k(13, 0) = _tmp66 * (P(13, 0) * _tmp49 + P(13, 1) * _tmp55 + P(13, 2) * _tmp57 +
+                          P(13, 22) * _tmp64 + P(13, 23) * _tmp65 + P(13, 3) * _tmp58 +
+                          P(13, 4) * _tmp60 + P(13, 5) * _tmp62 + P(13, 6) * _tmp63);
+    _k(14, 0) = _tmp66 * (P(14, 0) * _tmp49 + P(14, 1) * _tmp55 + P(14, 2) * _tmp57 +
+                          P(14, 22) * _tmp64 + P(14, 23) * _tmp65 + P(14, 3) * _tmp58 +
+                          P(14, 4) * _tmp60 + P(14, 5) * _tmp62 + P(14, 6) * _tmp63);
+    _k(15, 0) = _tmp66 * (P(15, 0) * _tmp49 + P(15, 1) * _tmp55 + P(15, 2) * _tmp57 +
+                          P(15, 22) * _tmp64 + P(15, 23) * _tmp65 + P(15, 3) * _tmp58 +
+                          P(15, 4) * _tmp60 + P(15, 5) * _tmp62 + P(15, 6) * _tmp63);
+    _k(16, 0) = _tmp66 * (P(16, 0) * _tmp49 + P(16, 1) * _tmp55 + P(16, 2) * _tmp57 +
+                          P(16, 22) * _tmp64 + P(16, 23) * _tmp65 + P(16, 3) * _tmp58 +
+                          P(16, 4) * _tmp60 + P(16, 5) * _tmp62 + P(16, 6) * _tmp63);
+    _k(17, 0) = _tmp66 * (P(17, 0) * _tmp49 + P(17, 1) * _tmp55 + P(17, 2) * _tmp57 +
+                          P(17, 22) * _tmp64 + P(17, 23) * _tmp65 + P(17, 3) * _tmp58 +
+                          P(17, 4) * _tmp60 + P(17, 5) * _tmp62 + P(17, 6) * _tmp63);
+    _k(18, 0) = _tmp66 * (P(18, 0) * _tmp49 + P(18, 1) * _tmp55 + P(18, 2) * _tmp57 +
+                          P(18, 22) * _tmp64 + P(18, 23) * _tmp65 + P(18, 3) * _tmp58 +
+                          P(18, 4) * _tmp60 + P(18, 5) * _tmp62 + P(18, 6) * _tmp63);
+    _k(19, 0) = _tmp66 * (P(19, 0) * _tmp49 + P(19, 1) * _tmp55 + P(19, 2) * _tmp57 +
+                          P(19, 22) * _tmp64 + P(19, 23) * _tmp65 + P(19, 3) * _tmp58 +
+                          P(19, 4) * _tmp60 + P(19, 5) * _tmp62 + P(19, 6) * _tmp63);
+    _k(20, 0) = _tmp66 * (P(20, 0) * _tmp49 + P(20, 1) * _tmp55 + P(20, 2) * _tmp57 +
+                          P(20, 22) * _tmp64 + P(20, 23) * _tmp65 + P(20, 3) * _tmp58 +
+                          P(20, 4) * _tmp60 + P(20, 5) * _tmp62 + P(20, 6) * _tmp63);
+    _k(21, 0) = _tmp66 * (P(21, 0) * _tmp49 + P(21, 1) * _tmp55 + P(21, 2) * _tmp57 +
+                          P(21, 22) * _tmp64 + P(21, 23) * _tmp65 + P(21, 3) * _tmp58 +
+                          P(21, 4) * _tmp60 + P(21, 5) * _tmp62 + P(21, 6) * _tmp63);
+    _k(22, 0) = _tmp66 * (P(22, 0) * _tmp49 + P(22, 1) * _tmp55 + P(22, 2) * _tmp57 +
+                          P(22, 22) * _tmp64 + P(22, 23) * _tmp65 + P(22, 3) * _tmp58 +
+                          P(22, 4) * _tmp60 + P(22, 5) * _tmp62 + P(22, 6) * _tmp63);
+    _k(23, 0) = _tmp66 * (P(23, 0) * _tmp49 + P(23, 1) * _tmp55 + P(23, 2) * _tmp57 +
+                          P(23, 22) * _tmp64 + P(23, 23) * _tmp65 + P(23, 3) * _tmp58 +
+                          P(23, 4) * _tmp60 + P(23, 5) * _tmp62 + P(23, 6) * _tmp63);
   }
 }  // NOLINT(readability/fn_size)
 

--- a/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_innov_and_innov_var.h
+++ b/src/modules/ekf2/EKF/python/ekf_derivation/generated/compute_sideslip_innov_and_innov_var.h
@@ -17,6 +17,7 @@ namespace sym {
  *
  * Args:
  *     state: Matrix24_1
+ *     pitch_offset: Scalar
  *     P: Matrix24_24
  *     R: Scalar
  *     epsilon: Scalar
@@ -27,98 +28,134 @@ namespace sym {
  */
 template <typename Scalar>
 void ComputeSideslipInnovAndInnovVar(const matrix::Matrix<Scalar, 24, 1>& state,
+                                     const Scalar pitch_offset,
                                      const matrix::Matrix<Scalar, 24, 24>& P, const Scalar R,
                                      const Scalar epsilon, Scalar* const innov = nullptr,
                                      Scalar* const innov_var = nullptr) {
-  // Total ops: 276
+  // Total ops: 387
 
   // Input arrays
 
-  // Intermediate terms (44)
-  const Scalar _tmp0 = std::pow(state(2, 0), Scalar(2));
-  const Scalar _tmp1 = std::pow(state(1, 0), Scalar(2));
-  const Scalar _tmp2 = std::pow(state(0, 0), Scalar(2)) - std::pow(state(3, 0), Scalar(2));
-  const Scalar _tmp3 = -_tmp0 + _tmp1 + _tmp2;
-  const Scalar _tmp4 = -state(22, 0) + state(4, 0);
-  const Scalar _tmp5 = state(0, 0) * state(3, 0);
-  const Scalar _tmp6 = state(1, 0) * state(2, 0);
-  const Scalar _tmp7 = _tmp5 + _tmp6;
-  const Scalar _tmp8 = -state(23, 0) + state(5, 0);
-  const Scalar _tmp9 = 2 * _tmp8;
-  const Scalar _tmp10 = state(0, 0) * state(2, 0);
-  const Scalar _tmp11 = state(1, 0) * state(3, 0);
-  const Scalar _tmp12 = 2 * state(6, 0);
-  const Scalar _tmp13 = _tmp12 * (-_tmp10 + _tmp11) + _tmp3 * _tmp4 + _tmp7 * _tmp9;
-  const Scalar _tmp14 =
-      _tmp13 + epsilon * (2 * math::min<Scalar>(0, (((_tmp13) > 0) - ((_tmp13) < 0))) + 1);
-  const Scalar _tmp15 = Scalar(1.0) / (_tmp14);
-  const Scalar _tmp16 = _tmp0 - _tmp1 + _tmp2;
-  const Scalar _tmp17 = -_tmp5 + _tmp6;
-  const Scalar _tmp18 = 2 * _tmp4;
-  const Scalar _tmp19 = state(2, 0) * state(3, 0);
-  const Scalar _tmp20 = state(0, 0) * state(1, 0);
-  const Scalar _tmp21 = _tmp12 * (_tmp19 + _tmp20) + _tmp16 * _tmp8 + _tmp17 * _tmp18;
-  const Scalar _tmp22 = _tmp9 * state(1, 0);
-  const Scalar _tmp23 = _tmp18 * state(2, 0);
-  const Scalar _tmp24 = _tmp12 * state(0, 0);
-  const Scalar _tmp25 = _tmp12 * state(3, 0) + _tmp18 * state(1, 0) + _tmp9 * state(2, 0);
-  const Scalar _tmp26 = _tmp21 / std::pow(_tmp14, Scalar(2));
-  const Scalar _tmp27 = _tmp15 * (-_tmp22 + _tmp23 + _tmp24) - _tmp25 * _tmp26;
-  const Scalar _tmp28 = _tmp15 * _tmp16;
-  const Scalar _tmp29 = 2 * _tmp5;
-  const Scalar _tmp30 = 2 * _tmp6;
-  const Scalar _tmp31 = -_tmp26 * (_tmp29 + _tmp30) + _tmp28;
-  const Scalar _tmp32 = _tmp12 * state(1, 0) - _tmp18 * state(3, 0) + _tmp9 * state(0, 0);
-  const Scalar _tmp33 = _tmp18 * state(0, 0);
-  const Scalar _tmp34 = _tmp9 * state(3, 0);
-  const Scalar _tmp35 = _tmp12 * state(2, 0);
-  const Scalar _tmp36 = _tmp15 * _tmp32 - _tmp26 * (_tmp33 + _tmp34 - _tmp35);
-  const Scalar _tmp37 = 2 * _tmp26 * _tmp7 - _tmp28;
-  const Scalar _tmp38 = _tmp26 * _tmp3;
-  const Scalar _tmp39 = -2 * _tmp15 * _tmp17 + _tmp38;
-  const Scalar _tmp40 = _tmp15 * _tmp25 - _tmp26 * (_tmp22 - _tmp23 - _tmp24);
-  const Scalar _tmp41 = _tmp15 * (-_tmp33 - _tmp34 + _tmp35) - _tmp26 * _tmp32;
-  const Scalar _tmp42 = _tmp15 * (2 * _tmp19 + 2 * _tmp20) - _tmp26 * (-2 * _tmp10 + 2 * _tmp11);
-  const Scalar _tmp43 = _tmp15 * (-_tmp29 + _tmp30) - _tmp38;
+  // Intermediate terms (67)
+  const Scalar _tmp0 = Scalar(0.5) * pitch_offset;
+  const Scalar _tmp1 = _tmp0;
+  const Scalar _tmp2 = std::sin(_tmp1);
+  const Scalar _tmp3 = std::cos(_tmp1);
+  const Scalar _tmp4 = _tmp2 * state(1, 0) + _tmp3 * state(3, 0);
+  const Scalar _tmp5 = -_tmp2 * state(3, 0) + _tmp3 * state(1, 0);
+  const Scalar _tmp6 = -_tmp2 * state(2, 0) + _tmp3 * state(0, 0);
+  const Scalar _tmp7 = _tmp2 * state(0, 0) + _tmp3 * state(2, 0);
+  const Scalar _tmp8 = -std::pow(_tmp4, Scalar(2)) - std::pow(_tmp5, Scalar(2)) +
+                       std::pow(_tmp6, Scalar(2)) + std::pow(_tmp7, Scalar(2));
+  const Scalar _tmp9 = -state(23, 0) + state(5, 0);
+  const Scalar _tmp10 = _tmp4 * _tmp6;
+  const Scalar _tmp11 = _tmp5 * _tmp7;
+  const Scalar _tmp12 = -_tmp10 + _tmp11;
+  const Scalar _tmp13 = -state(22, 0) + state(4, 0);
+  const Scalar _tmp14 = 2 * _tmp13;
+  const Scalar _tmp15 = _tmp4 * _tmp7;
+  const Scalar _tmp16 = _tmp5 * _tmp6;
+  const Scalar _tmp17 = 2 * state(6, 0);
+  const Scalar _tmp18 = _tmp12 * _tmp14 + _tmp17 * (_tmp15 + _tmp16) + _tmp8 * _tmp9;
+  const Scalar _tmp19 = std::cos(_tmp0);
+  const Scalar _tmp20 = std::sin(_tmp0);
+  const Scalar _tmp21 = _tmp19 * state(3, 0) + _tmp20 * state(1, 0);
+  const Scalar _tmp22 = _tmp19 * state(1, 0) - _tmp20 * state(3, 0);
+  const Scalar _tmp23 = _tmp19 * state(0, 0) - _tmp20 * state(2, 0);
+  const Scalar _tmp24 = _tmp19 * state(2, 0) + _tmp20 * state(0, 0);
+  const Scalar _tmp25 = -std::pow(_tmp21, Scalar(2)) + std::pow(_tmp22, Scalar(2)) +
+                        std::pow(_tmp23, Scalar(2)) - std::pow(_tmp24, Scalar(2));
+  const Scalar _tmp26 = _tmp22 * _tmp24;
+  const Scalar _tmp27 = _tmp21 * _tmp23;
+  const Scalar _tmp28 = _tmp26 + _tmp27;
+  const Scalar _tmp29 = 2 * _tmp9;
+  const Scalar _tmp30 = _tmp21 * _tmp22;
+  const Scalar _tmp31 = _tmp23 * _tmp24;
+  const Scalar _tmp32 = _tmp13 * _tmp25 + _tmp17 * (_tmp30 - _tmp31) + _tmp28 * _tmp29;
+  const Scalar _tmp33 =
+      _tmp32 + epsilon * (2 * math::min<Scalar>(0, (((_tmp32) > 0) - ((_tmp32) < 0))) + 1);
+  const Scalar _tmp34 = Scalar(1.0) / (_tmp33);
+  const Scalar _tmp35 = _tmp18 / std::pow(_tmp33, Scalar(2));
+  const Scalar _tmp36 = _tmp25 * _tmp35;
+  const Scalar _tmp37 = -2 * _tmp12 * _tmp34 + _tmp36;
+  const Scalar _tmp38 = _tmp2 * _tmp4;
+  const Scalar _tmp39 = _tmp3 * _tmp5;
+  const Scalar _tmp40 = _tmp38 + _tmp39;
+  const Scalar _tmp41 = _tmp2 * _tmp7;
+  const Scalar _tmp42 = _tmp3 * _tmp6;
+  const Scalar _tmp43 = _tmp3 * _tmp4;
+  const Scalar _tmp44 = _tmp2 * _tmp5;
+  const Scalar _tmp45 = _tmp19 * _tmp21;
+  const Scalar _tmp46 = _tmp20 * _tmp22;
+  const Scalar _tmp47 = _tmp45 + _tmp46;
+  const Scalar _tmp48 = _tmp20 * _tmp23;
+  const Scalar _tmp49 = _tmp19 * _tmp24;
+  const Scalar _tmp50 = _tmp19 * _tmp23;
+  const Scalar _tmp51 = _tmp20 * _tmp24;
+  const Scalar _tmp52 =
+      _tmp34 * (_tmp14 * (-_tmp43 + _tmp44) + _tmp17 * _tmp40 + _tmp9 * (2 * _tmp41 + 2 * _tmp42)) -
+      _tmp35 * (_tmp13 * (2 * _tmp50 - 2 * _tmp51) + _tmp17 * (-_tmp48 - _tmp49) + _tmp29 * _tmp47);
+  const Scalar _tmp53 = _tmp34 * (-2 * _tmp10 + 2 * _tmp11) - _tmp36;
+  const Scalar _tmp54 = _tmp20 * _tmp21;
+  const Scalar _tmp55 = _tmp19 * _tmp22;
+  const Scalar _tmp56 = -_tmp54 + _tmp55;
+  const Scalar _tmp57 = _tmp3 * _tmp7;
+  const Scalar _tmp58 = _tmp2 * _tmp6;
+  const Scalar _tmp59 = _tmp57 - _tmp58;
+  const Scalar _tmp60 =
+      _tmp34 *
+          (_tmp14 * (-_tmp41 - _tmp42) + _tmp17 * _tmp59 + _tmp9 * (-2 * _tmp43 + 2 * _tmp44)) -
+      _tmp35 * (_tmp13 * (-2 * _tmp45 - 2 * _tmp46) + _tmp17 * _tmp56 + _tmp29 * (_tmp50 - _tmp51));
+  const Scalar _tmp61 = _tmp34 * (2 * _tmp15 + 2 * _tmp16) - _tmp35 * (2 * _tmp30 - 2 * _tmp31);
+  const Scalar _tmp62 =
+      _tmp34 * (_tmp14 * _tmp59 + _tmp17 * (_tmp41 + _tmp42) + _tmp9 * (-2 * _tmp38 - 2 * _tmp39)) -
+      _tmp35 * (_tmp13 * (-2 * _tmp54 + 2 * _tmp55) + _tmp17 * _tmp47 + _tmp29 * (_tmp48 + _tmp49));
+  const Scalar _tmp63 = _tmp34 * _tmp8;
+  const Scalar _tmp64 = -_tmp35 * (2 * _tmp26 + 2 * _tmp27) + _tmp63;
+  const Scalar _tmp65 =
+      _tmp34 * (_tmp14 * _tmp40 + _tmp17 * (_tmp43 - _tmp44) + _tmp9 * (2 * _tmp57 - 2 * _tmp58)) -
+      _tmp35 *
+          (_tmp13 * (-2 * _tmp48 - 2 * _tmp49) + _tmp17 * (-_tmp50 + _tmp51) + _tmp29 * _tmp56);
+  const Scalar _tmp66 = 2 * _tmp28 * _tmp35 - _tmp63;
 
   // Output terms (2)
   if (innov != nullptr) {
     Scalar& _innov = (*innov);
 
-    _innov = _tmp15 * _tmp21;
+    _innov = _tmp18 * _tmp34;
   }
 
   if (innov_var != nullptr) {
     Scalar& _innov_var = (*innov_var);
 
     _innov_var = R +
-                 _tmp27 * (P(0, 1) * _tmp36 + P(1, 1) * _tmp27 + P(2, 1) * _tmp40 +
-                           P(22, 1) * _tmp39 + P(23, 1) * _tmp37 + P(3, 1) * _tmp41 +
-                           P(4, 1) * _tmp43 + P(5, 1) * _tmp31 + P(6, 1) * _tmp42) +
-                 _tmp31 * (P(0, 5) * _tmp36 + P(1, 5) * _tmp27 + P(2, 5) * _tmp40 +
-                           P(22, 5) * _tmp39 + P(23, 5) * _tmp37 + P(3, 5) * _tmp41 +
-                           P(4, 5) * _tmp43 + P(5, 5) * _tmp31 + P(6, 5) * _tmp42) +
-                 _tmp36 * (P(0, 0) * _tmp36 + P(1, 0) * _tmp27 + P(2, 0) * _tmp40 +
-                           P(22, 0) * _tmp39 + P(23, 0) * _tmp37 + P(3, 0) * _tmp41 +
-                           P(4, 0) * _tmp43 + P(5, 0) * _tmp31 + P(6, 0) * _tmp42) +
-                 _tmp37 * (P(0, 23) * _tmp36 + P(1, 23) * _tmp27 + P(2, 23) * _tmp40 +
-                           P(22, 23) * _tmp39 + P(23, 23) * _tmp37 + P(3, 23) * _tmp41 +
-                           P(4, 23) * _tmp43 + P(5, 23) * _tmp31 + P(6, 23) * _tmp42) +
-                 _tmp39 * (P(0, 22) * _tmp36 + P(1, 22) * _tmp27 + P(2, 22) * _tmp40 +
-                           P(22, 22) * _tmp39 + P(23, 22) * _tmp37 + P(3, 22) * _tmp41 +
-                           P(4, 22) * _tmp43 + P(5, 22) * _tmp31 + P(6, 22) * _tmp42) +
-                 _tmp40 * (P(0, 2) * _tmp36 + P(1, 2) * _tmp27 + P(2, 2) * _tmp40 +
-                           P(22, 2) * _tmp39 + P(23, 2) * _tmp37 + P(3, 2) * _tmp41 +
-                           P(4, 2) * _tmp43 + P(5, 2) * _tmp31 + P(6, 2) * _tmp42) +
-                 _tmp41 * (P(0, 3) * _tmp36 + P(1, 3) * _tmp27 + P(2, 3) * _tmp40 +
-                           P(22, 3) * _tmp39 + P(23, 3) * _tmp37 + P(3, 3) * _tmp41 +
-                           P(4, 3) * _tmp43 + P(5, 3) * _tmp31 + P(6, 3) * _tmp42) +
-                 _tmp42 * (P(0, 6) * _tmp36 + P(1, 6) * _tmp27 + P(2, 6) * _tmp40 +
-                           P(22, 6) * _tmp39 + P(23, 6) * _tmp37 + P(3, 6) * _tmp41 +
-                           P(4, 6) * _tmp43 + P(5, 6) * _tmp31 + P(6, 6) * _tmp42) +
-                 _tmp43 * (P(0, 4) * _tmp36 + P(1, 4) * _tmp27 + P(2, 4) * _tmp40 +
-                           P(22, 4) * _tmp39 + P(23, 4) * _tmp37 + P(3, 4) * _tmp41 +
-                           P(4, 4) * _tmp43 + P(5, 4) * _tmp31 + P(6, 4) * _tmp42);
+                 _tmp37 * (P(0, 22) * _tmp52 + P(1, 22) * _tmp62 + P(2, 22) * _tmp65 +
+                           P(22, 22) * _tmp37 + P(23, 22) * _tmp66 + P(3, 22) * _tmp60 +
+                           P(4, 22) * _tmp53 + P(5, 22) * _tmp64 + P(6, 22) * _tmp61) +
+                 _tmp52 * (P(0, 0) * _tmp52 + P(1, 0) * _tmp62 + P(2, 0) * _tmp65 +
+                           P(22, 0) * _tmp37 + P(23, 0) * _tmp66 + P(3, 0) * _tmp60 +
+                           P(4, 0) * _tmp53 + P(5, 0) * _tmp64 + P(6, 0) * _tmp61) +
+                 _tmp53 * (P(0, 4) * _tmp52 + P(1, 4) * _tmp62 + P(2, 4) * _tmp65 +
+                           P(22, 4) * _tmp37 + P(23, 4) * _tmp66 + P(3, 4) * _tmp60 +
+                           P(4, 4) * _tmp53 + P(5, 4) * _tmp64 + P(6, 4) * _tmp61) +
+                 _tmp60 * (P(0, 3) * _tmp52 + P(1, 3) * _tmp62 + P(2, 3) * _tmp65 +
+                           P(22, 3) * _tmp37 + P(23, 3) * _tmp66 + P(3, 3) * _tmp60 +
+                           P(4, 3) * _tmp53 + P(5, 3) * _tmp64 + P(6, 3) * _tmp61) +
+                 _tmp61 * (P(0, 6) * _tmp52 + P(1, 6) * _tmp62 + P(2, 6) * _tmp65 +
+                           P(22, 6) * _tmp37 + P(23, 6) * _tmp66 + P(3, 6) * _tmp60 +
+                           P(4, 6) * _tmp53 + P(5, 6) * _tmp64 + P(6, 6) * _tmp61) +
+                 _tmp62 * (P(0, 1) * _tmp52 + P(1, 1) * _tmp62 + P(2, 1) * _tmp65 +
+                           P(22, 1) * _tmp37 + P(23, 1) * _tmp66 + P(3, 1) * _tmp60 +
+                           P(4, 1) * _tmp53 + P(5, 1) * _tmp64 + P(6, 1) * _tmp61) +
+                 _tmp64 * (P(0, 5) * _tmp52 + P(1, 5) * _tmp62 + P(2, 5) * _tmp65 +
+                           P(22, 5) * _tmp37 + P(23, 5) * _tmp66 + P(3, 5) * _tmp60 +
+                           P(4, 5) * _tmp53 + P(5, 5) * _tmp64 + P(6, 5) * _tmp61) +
+                 _tmp65 * (P(0, 2) * _tmp52 + P(1, 2) * _tmp62 + P(2, 2) * _tmp65 +
+                           P(22, 2) * _tmp37 + P(23, 2) * _tmp66 + P(3, 2) * _tmp60 +
+                           P(4, 2) * _tmp53 + P(5, 2) * _tmp64 + P(6, 2) * _tmp61) +
+                 _tmp66 * (P(0, 23) * _tmp52 + P(1, 23) * _tmp62 + P(2, 23) * _tmp65 +
+                           P(22, 23) * _tmp37 + P(23, 23) * _tmp66 + P(3, 23) * _tmp60 +
+                           P(4, 23) * _tmp53 + P(5, 23) * _tmp64 + P(6, 23) * _tmp61);
   }
 }  // NOLINT(readability/fn_size)
 

--- a/src/modules/ekf2/EKF/sideslip_fusion.cpp
+++ b/src/modules/ekf2/EKF/sideslip_fusion.cpp
@@ -87,7 +87,10 @@ void Ekf::updateSideslip(estimator_aid_source1d_s &sideslip) const
 
 	float innov = 0.f;
 	float innov_var = 0.f;
-	sym::ComputeSideslipInnovAndInnovVar(getStateAtFusionHorizonAsVector(), P, R, FLT_EPSILON, &innov, &innov_var);
+
+	const float pitch_offset = _control_status.flags.tailsitter ? M_PI_2_F : 0.f;
+
+	sym::ComputeSideslipInnovAndInnovVar(getStateAtFusionHorizonAsVector(), pitch_offset, P, R, FLT_EPSILON, &innov, &innov_var);
 
 	sideslip.observation = 0.f;
 	sideslip.observation_variance = R;
@@ -138,7 +141,9 @@ void Ekf::fuseSideslip(estimator_aid_source1d_s &sideslip)
 	Vector24f H; // Observation jacobian
 	Vector24f K; // Kalman gain vector
 
-	sym::ComputeSideslipHAndK(getStateAtFusionHorizonAsVector(), P, sideslip.innovation_variance, FLT_EPSILON, &H, &K);
+	const float pitch_offset = _control_status.flags.tailsitter ? M_PI_2_F : 0.f;
+
+	sym::ComputeSideslipHAndK(getStateAtFusionHorizonAsVector(), pitch_offset, P, sideslip.innovation_variance, FLT_EPSILON, &H, &K);
 
 	if (update_wind_only) {
 		for (unsigned row = 0; row <= 21; row++) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1537,6 +1537,7 @@ void EKF2::PublishStatusFlags(const hrt_abstime &timestamp)
 		status_flags.cs_fake_pos                = _ekf.control_status_flags().fake_pos;
 		status_flags.cs_fake_hgt                = _ekf.control_status_flags().fake_hgt;
 		status_flags.cs_gravity_vector          = _ekf.control_status_flags().gravity_vector;
+		status_flags.cs_tailsitter              = _ekf.control_status_flags().tailsitter;
 
 		status_flags.fault_status_changes     = _filter_fault_status_changes;
 		status_flags.fs_bad_mag_x             = _ekf.fault_status_flags().bad_mag_x;
@@ -2195,6 +2196,9 @@ void EKF2::UpdateSystemFlagsSample(ekf2_timestamps_s &ekf2_timestamps)
 
 			// let the EKF know if the vehicle motion is that of a fixed wing (forward flight only relative to wind)
 			flags.is_fixed_wing = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
+
+			// let the EKF know about the fixed-wing flight direction for sideslip fusion
+			flags.is_tailsitter = vehicle_status.is_vtol_tailsitter;
 		}
 
 		// vehicle_land_detected

--- a/src/modules/ekf2/test/test_EKF_sideslip_fusion_generated.cpp
+++ b/src/modules/ekf2/test/test_EKF_sideslip_fusion_generated.cpp
@@ -204,8 +204,8 @@ TEST(SideslipFusionGenerated, SympyVsSymforce)
 		float innov;
 		float innov_var;
 
-		sym::ComputeSideslipInnovAndInnovVar(state_vector, P, R_BETA, FLT_EPSILON, &innov, &innov_var);
-		sym::ComputeSideslipHAndK(state_vector, P, innov_var, FLT_EPSILON, &Hfusion_symforce, &Kfusion_symforce);
+		sym::ComputeSideslipInnovAndInnovVar(state_vector, 0.f, P, R_BETA, FLT_EPSILON, &innov, &innov_var);
+		sym::ComputeSideslipHAndK(state_vector, 0.f, P, innov_var, FLT_EPSILON, &Hfusion_symforce, &Kfusion_symforce);
 	}
 
 	DiffRatioReport report = computeDiffRatioVector24f(Hfusion_sympy, Hfusion_symforce);


### PR DESCRIPTION
This is required for tailsitters flying with -90deg pitch in fixed-wing flight

context: https://github.com/PX4/PX4-Autopilot/pull/21319

