### PR TITLE
GPS only warn if jamming state is critical

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1208,7 +1208,7 @@ GPS::publish()
 
 		if (_report_gps_pos.jamming_state != _jamming_state) {
 
-			if (_report_gps_pos.jamming_state > sensor_gps_s::JAMMING_STATE_OK) {
+			if (_report_gps_pos.jamming_state > sensor_gps_s::JAMMING_STATE_WARNING) {
 				PX4_WARN("GPS jamming detected! (state: %d) (indicator: %d)", _report_gps_pos.jamming_state,
 					 (uint8_t)_report_gps_pos.jamming_indicator);
 			}


### PR DESCRIPTION
It appears that the F9P GPS ends up reporting JAMMING_STATE_WARNING more often than not. This updates the warning to only report when the jamming state is critical.

https://github.com/PX4/PX4-Autopilot/pull/21244#issuecomment-1474269102