### PR TITLE
[WIP] BMM150 forced mode >300Hz output

### DIFF
--- a/src/drivers/magnetometer/bosch/bmm150/BMM150.hpp
+++ b/src/drivers/magnetometer/bosch/bmm150/BMM150.hpp
@@ -127,6 +127,7 @@ private:
 	static constexpr uint8_t size_register_cfg{4};
 	register_config_t _register_cfg[size_register_cfg] {
 		// Register                | Set bits, Clear bits
+		// Sees.ai to modify here for forced mode
 		{ Register::POWER_CONTROL, POWER_CONTROL_BIT::PowerControl, POWER_CONTROL_BIT::SoftReset },
 		{ Register::OP_MODE,       OP_MODE_BIT::ODR_20HZ_SET, OP_MODE_BIT::ODR_20HZ_CLEAR | OP_MODE_BIT::Opmode_Sleep | OP_MODE_BIT::Self_Test },
 		{ Register::REPXY,         REPXY_BIT::XY_HA_SET, REPXY_BIT::XY_HA_CLEAR },


### PR DESCRIPTION
When attempting to sample the BMM150 magnetometer (on the Ark RTK GPS rev 3) at a higher rate, I found that it required modifying the driver to enter "Forced Mode".
This proved more difficult than initially anticipated, so following my emails with @AlexKlimaj this PR is being opened to work on it.

Fixes #{Github issue ID}

### Solution
- Explore and possibly add configuration for Forced mode (allows for higher sampling rate >300Hz)

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

