### PR TITLE
CubeBlack: fix hardware detection

### DIFF
--- a/boards/px4/fmu-v2/src/init.c
+++ b/boards/px4/fmu-v2/src/init.c
@@ -166,7 +166,7 @@ __EXPORT void board_on_reset(int status)
 }
 
 /************************************************************************************
-  * Name: determin_hw_version
+  * Name: determine_hw_info
  *
  * Description:
  *
@@ -188,7 +188,7 @@ __EXPORT void board_on_reset(int status)
  *  10   10 - 0xA PixhawkMini
  *  10   11 - 0xB FMUv2 questionable hardware (should be treated like regular FMUv2)
  *
- *  This will return OK on success and -1 on not supported
+ *  This will return OK on success.
  *
  *  hw_type Initial state is {'V','2',0, 0}
  *   V 2    - FMUv2
@@ -198,17 +198,16 @@ __EXPORT void board_on_reset(int status)
  *
  ************************************************************************************/
 
-static int determin_hw_version(int *version, int *revision)
+static int determine_hw_info(int *revision, int *version)
 {
 	*revision = 0; /* default revision */
-	int rv = 0;
 	int pos = 0;
 	stm32_configgpio(GPIO_PULLDOWN | (HW_VER_PB4 & ~GPIO_PUPD_MASK));
 	up_udelay(10);
-	rv |= stm32_gpioread(HW_VER_PB4) << pos++;
+	*version |= stm32_gpioread(HW_VER_PB4) << pos++;
 	stm32_configgpio(HW_VER_PB4);
 	up_udelay(10);
-	rv |= stm32_gpioread(HW_VER_PB4) << pos++;
+	*version |= stm32_gpioread(HW_VER_PB4) << pos++;
 
 	int votes = 16;
 	int ones[2] = {0, 0};
@@ -224,18 +223,18 @@ static int determin_hw_version(int *version, int *revision)
 	}
 
 	if (ones[0] > zeros[0]) {
-		rv |= 1 << pos;
+		*version |= 1 << pos;
 	}
 
 	pos++;
 
 	if (ones[1] > zeros[1]) {
-		rv |= 1 << pos;
+		*version |= 1 << pos;
 	}
 
 	stm32_configgpio(HW_VER_PB4_INIT);
 	stm32_configgpio(HW_VER_PB12_INIT);
-	*version = rv;
+
 	return OK;
 }
 
@@ -366,7 +365,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	/* Ensure the power is on 1 ms before we drive the GPIO pins */
 	usleep(1000);
 
-	if (OK == determin_hw_version(&hw_version, & hw_revision)) {
+	if (OK == determine_hw_info(&hw_revision, &hw_version)) {
 		switch (hw_version) {
 		case HW_VER_FMUV2_STATE:
 			break;
@@ -514,7 +513,6 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 #endif
 
 	/* Configure the HW based on the manifest */
-
 	px4_platform_configure();
 
 	return OK;

--- a/boards/px4/fmu-v3/src/init.c
+++ b/boards/px4/fmu-v3/src/init.c
@@ -166,7 +166,7 @@ __EXPORT void board_on_reset(int status)
 }
 
 /************************************************************************************
-  * Name: determin_hw_version
+  * Name: determine_hw_info
  *
  * Description:
  *
@@ -188,7 +188,7 @@ __EXPORT void board_on_reset(int status)
  *  10   10 - 0xA PixhawkMini
  *  10   11 - 0xB FMUv2 questionable hardware (should be treated like regular FMUv2)
  *
- *  This will return OK on success and -1 on not supported
+ *  This will return OK on success.
  *
  *  hw_type Initial state is {'V','2',0, 0}
  *   V 2    - FMUv2
@@ -198,17 +198,16 @@ __EXPORT void board_on_reset(int status)
  *
  ************************************************************************************/
 
-static int determin_hw_version(int *version, int *revision)
+static int determine_hw_info(int *revision, int *version)
 {
 	*revision = 0; /* default revision */
-	int rv = 0;
 	int pos = 0;
 	stm32_configgpio(GPIO_PULLDOWN | (HW_VER_PB4 & ~GPIO_PUPD_MASK));
 	up_udelay(10);
-	rv |= stm32_gpioread(HW_VER_PB4) << pos++;
+	*version |= stm32_gpioread(HW_VER_PB4) << pos++;
 	stm32_configgpio(HW_VER_PB4);
 	up_udelay(10);
-	rv |= stm32_gpioread(HW_VER_PB4) << pos++;
+	*version |= stm32_gpioread(HW_VER_PB4) << pos++;
 
 	int votes = 16;
 	int ones[2] = {0, 0};
@@ -224,18 +223,18 @@ static int determin_hw_version(int *version, int *revision)
 	}
 
 	if (ones[0] > zeros[0]) {
-		rv |= 1 << pos;
+		*version |= 1 << pos;
 	}
 
 	pos++;
 
 	if (ones[1] > zeros[1]) {
-		rv |= 1 << pos;
+		*version |= 1 << pos;
 	}
 
 	stm32_configgpio(HW_VER_PB4_INIT);
 	stm32_configgpio(HW_VER_PB12_INIT);
-	*version = rv;
+
 	return OK;
 }
 
@@ -366,7 +365,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	/* Ensure the power is on 1 ms before we drive the GPIO pins */
 	usleep(1000);
 
-	if (OK == determin_hw_version(&hw_version, & hw_revision)) {
+	if (OK == determine_hw_info(&hw_revision, &hw_version)) {
 		switch (hw_version) {
 		case HW_VER_FMUV2_STATE:
 			break;

--- a/platforms/nuttx/src/px4/nxp/imxrt/board_hw_info/board_hw_rev_ver.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/board_hw_info/board_hw_rev_ver.c
@@ -66,19 +66,6 @@ static char hw_info[HW_INFO_SIZE] = {0};
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
-/****************************************************************************
-  * Name: determin_hw_version
- *
- * Description:
- *
- * This function fist determines if revision  and version resistors are in place.
- * if they it will read the ADC channels and decode the DN to ordinal numbers
- * that will be returned by board_get_hw_version and board_get_hw_revision API
- *
- *  This will return OK on success and -1 on not supported
-*
- *
- ****************************************************************************/
 
 static int dn_to_ordinal(uint16_t dn)
 {

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/board_hw_rev_ver.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/board_hw_rev_ver.c
@@ -71,19 +71,6 @@ static char hw_info[HW_INFO_SIZE] = {0};
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
-/****************************************************************************
-  * Name: determin_hw_version
- *
- * Description:
- *
- * This function fist determines if revision  and version resistors are in place.
- * if they it will read the ADC channels and decode the DN to ordinal numbers
- * that will be returned by board_get_hw_version and board_get_hw_revision API
- *
- *  This will return OK on success and -1 on not supported
-*
- *
- ****************************************************************************/
 
 static int dn_to_ordinal(uint16_t dn)
 {


### PR DESCRIPTION
This fixes the case where the hardware detection fails on CubeBlack when a CAN device is connected to CAN1 and talking, and therefore preventing the check from getting a clear result.

I suggest to review commit by commit as the first commit is just a refactor.

Tested on CubeBlack.

Fixes #21102.

Probably needs duplicating/copying to fmu-v2.