### PR TITLE
FWPositionControl: trim throttle prediction improvements

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -574,12 +574,12 @@ float TECSControl::_calcThrottleControlOutput(const STERateLimit &limit, const C
 
 	if (ste_rate.setpoint >= FLT_EPSILON) {
 		// throttle is between trim and maximum
-		throttle_predicted = param.throttle_trim + ste_rate.setpoint / limit.STE_rate_max *
+		throttle_predicted = param.throttle_trim_adjusted + ste_rate.setpoint / limit.STE_rate_max *
 				     (param.throttle_max - param.throttle_trim);
 
 	} else {
 		// throttle is between trim and minimum
-		throttle_predicted = param.throttle_trim + ste_rate.setpoint / limit.STE_rate_min *
+		throttle_predicted = param.throttle_trim_adjusted + ste_rate.setpoint / limit.STE_rate_min *
 				     (param.throttle_min - param.throttle_trim);
 
 	}
@@ -667,8 +667,8 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 
 void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_setpoint, float equivalent_airspeed,
 		  float eas_to_tas, float throttle_min, float throttle_setpoint_max,
-		  float throttle_trim, float pitch_limit_min, float pitch_limit_max, float target_climbrate, float target_sinkrate,
-		  const float speed_deriv_forward, float hgt_rate, float hgt_rate_sp)
+		  float throttle_trim, float throttle_trim_adjusted, float pitch_limit_min, float pitch_limit_max, float target_climbrate,
+		  float target_sinkrate, const float speed_deriv_forward, float hgt_rate, float hgt_rate_sp)
 {
 
 	// Calculate the time since last update (seconds)
@@ -684,6 +684,7 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 	_control_param.pitch_max = pitch_limit_max;
 	_control_param.pitch_min = pitch_limit_min;
 	_control_param.throttle_trim = throttle_trim;
+	_control_param.throttle_trim_adjusted = throttle_trim_adjusted;
 	_control_param.throttle_max = throttle_setpoint_max;
 	_control_param.throttle_min = throttle_min;
 

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -570,17 +570,20 @@ float TECSControl::_calcThrottleControlOutput(const STERateLimit &limit, const C
 	// Specific total energy rate = _STE_rate_max is achieved when throttle is set to _throttle_setpoint_max
 	// Specific total energy rate = 0 at cruise throttle
 	// Specific total energy rate = _STE_rate_min is achieved when throttle is set to _throttle_setpoint_min
+
+	// assume airspeed and density-independent delta_throttle to sink/climb rate mapping:
+	const float throttle_increase_max_STE_rate = limit.STE_rate_max * (param.throttle_max - param.throttle_trim);
+	const float throttle_decrease_min_STE_rate = limit.STE_rate_min * (param.throttle_trim - param.throttle_min);
+
 	float throttle_predicted = 0.0f;
 
 	if (ste_rate.setpoint >= FLT_EPSILON) {
 		// throttle is between trim and maximum
-		throttle_predicted = param.throttle_trim_adjusted + ste_rate.setpoint / limit.STE_rate_max *
-				     (param.throttle_max - param.throttle_trim);
+		throttle_predicted = param.throttle_trim_adjusted + ste_rate.setpoint / throttle_increase_max_STE_rate;
 
 	} else {
 		// throttle is between trim and minimum
-		throttle_predicted = param.throttle_trim_adjusted + ste_rate.setpoint / limit.STE_rate_min *
-				     (param.throttle_min - param.throttle_trim);
+		throttle_predicted = param.throttle_trim_adjusted - ste_rate.setpoint / throttle_decrease_min_STE_rate;
 
 	}
 

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -571,7 +571,8 @@ float TECSControl::_calcThrottleControlOutput(const STERateLimit &limit, const C
 	// Specific total energy rate = 0 at cruise throttle
 	// Specific total energy rate = _STE_rate_min is achieved when throttle is set to _throttle_setpoint_min
 
-	// assume airspeed and density-independent delta_throttle to sink/climb rate mapping:
+	// assume airspeed and density-independent delta_throttle to sink/climb rate mapping
+	// TODO: include air density for thrust mappings
 	const float throttle_increase_max_STE_rate = limit.STE_rate_max * (param.throttle_max - param.throttle_trim);
 	const float throttle_decrease_min_STE_rate = limit.STE_rate_min * (param.throttle_trim - param.throttle_min);
 

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -197,7 +197,8 @@ public:
 		float tas_min;				///< True airpeed demand lower limit [m/s].
 		float pitch_max;			///< Maximum pitch angle allowed in [rad].
 		float pitch_min;			///< Minimal pitch angle allowed in [rad].
-		float throttle_trim;			///< Normalized throttle required to fly level at given eas.
+		float throttle_trim;			///< Normalized throttle required to fly level at trim airspeed and sea level
+		float throttle_trim_adjusted;		///< Trim throttle adjusted for airspeed, load factor and air density
 		float throttle_max;			///< Normalized throttle upper limit.
 		float throttle_min;			///< Normalized throttle lower limit.
 
@@ -578,8 +579,8 @@ public:
 	 */
 	void update(float pitch, float altitude, float hgt_setpoint, float EAS_setpoint, float equivalent_airspeed,
 		    float eas_to_tas, float throttle_min, float throttle_setpoint_max,
-		    float throttle_trim, float pitch_limit_min, float pitch_limit_max, float target_climbrate, float target_sinkrate,
-		    float speed_deriv_forward, float hgt_rate, float hgt_rate_sp = NAN);
+		    float throttle_trim, float throttle_trim_adjusted, float pitch_limit_min, float pitch_limit_max, float target_climbrate,
+		    float target_sinkrate, float speed_deriv_forward, float hgt_rate, float hgt_rate_sp = NAN);
 
 	/**
 	 * @brief Initialize the control loop
@@ -695,6 +696,7 @@ private:
 		.pitch_max = 5.0f,
 		.pitch_min = -5.0f,
 		.throttle_trim = 0.0f,
+		.throttle_trim_adjusted = 0.f,
 		.throttle_max = 1.0f,
 		.throttle_min = 0.1f,
 		.altitude_error_gain = 0.2f,

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -2582,6 +2582,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 		     _eas2tas,
 		     throttle_min,
 		     throttle_max,
+		     _param_fw_thr_trim.get(),
 		     throttle_trim_comp,
 		     pitch_min_rad - radians(_param_fw_psp_off.get()),
 		     pitch_max_rad - radians(_param_fw_psp_off.get()),

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -2461,12 +2461,11 @@ FixedwingPositionControl::reset_landing_state()
 float FixedwingPositionControl::calculateTrimThrottle(float throttle_min,
 		float throttle_max, float airspeed_sp)
 {
-
-	// drag modelling
-	float throttle_trim = _param_fw_thr_trim.get(); // throttle required at sea level during standard conditions.
+	float throttle_trim =
+		_param_fw_thr_trim.get(); // throttle required for level flight at trim airspeed, at sea level (standard atmosphere)
 
 	// Drag modelling (parasite drag): calculate mapping airspeed-->throttle, assuming a linear relation with different gradient
-	// above and blow trim. This is tunable thorugh FW_THR_ASPD_MIN and FW_THR_ASPD_MAX.
+	// above and below trim. This is tunable thorugh FW_THR_ASPD_MIN and FW_THR_ASPD_MAX.
 	if (PX4_ISFINITE(airspeed_sp) && _param_fw_thr_aspd_min.get() > FLT_EPSILON
 	    && airspeed_sp < _param_fw_airspd_trim.get()) {
 		throttle_trim = _param_fw_thr_trim.get() - (_param_fw_thr_trim.get() - _param_fw_thr_aspd_min.get()) /
@@ -2567,8 +2566,8 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 	}
 
 	/* update TECS vehicle state estimates */
-	const float throttle_trim_comp = calculateTrimThrottle(throttle_min,
-					 throttle_max, airspeed_sp);
+	const float throttle_trim_adjusted = calculateTrimThrottle(throttle_min,
+					     throttle_max, airspeed_sp);
 
 	// HOTFIX: the airspeed rate estimate using acceleration in body-forward direction has shown to lead to high biases
 	// when flying tight turns. It's in this case much safer to just set the estimated airspeed rate to 0.
@@ -2583,7 +2582,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 		     throttle_min,
 		     throttle_max,
 		     _param_fw_thr_trim.get(),
-		     throttle_trim_comp,
+		     throttle_trim_adjusted,
 		     pitch_min_rad - radians(_param_fw_psp_off.get()),
 		     pitch_max_rad - radians(_param_fw_psp_off.get()),
 		     desired_max_climbrate,
@@ -2592,7 +2591,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 		     -_local_pos.vz,
 		     hgt_rate_sp);
 
-	tecs_status_publish(alt_sp, airspeed_sp, airspeed_rate_estimate, throttle_trim_comp);
+	tecs_status_publish(alt_sp, airspeed_sp, airspeed_rate_estimate, throttle_trim_adjusted);
 }
 
 float

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -2458,9 +2458,26 @@ FixedwingPositionControl::reset_landing_state()
 	}
 }
 
-float FixedwingPositionControl::compensateTrimThrottleForDensityAndWeight(float throttle_trim, float throttle_min,
-		float throttle_max)
+float FixedwingPositionControl::calculateTrimThrottle(float throttle_min,
+		float throttle_max, float airspeed_sp)
 {
+
+	// drag modelling
+	float throttle_trim = _param_fw_thr_trim.get(); // throttle required at sea level during standard conditions.
+
+	// Drag modelling (parasite drag): calculate mapping airspeed-->throttle, assuming a linear relation with different gradient
+	// above and blow trim. This is tunable thorugh FW_THR_ASPD_MIN and FW_THR_ASPD_MAX.
+	if (PX4_ISFINITE(airspeed_sp) && _param_fw_thr_aspd_min.get() > FLT_EPSILON
+	    && airspeed_sp < _param_fw_airspd_trim.get()) {
+		throttle_trim = _param_fw_thr_trim.get() - (_param_fw_thr_trim.get() - _param_fw_thr_aspd_min.get()) /
+				(_param_fw_airspd_trim.get() - _param_fw_airspd_min.get()) * (_param_fw_airspd_trim.get() - airspeed_sp);
+
+	} else if (PX4_ISFINITE(airspeed_sp) && _param_fw_thr_aspd_max.get() > FLT_EPSILON
+		   && airspeed_sp > _param_fw_airspd_trim.get()) {
+		throttle_trim = _param_fw_thr_trim.get() + (_param_fw_thr_aspd_max.get() - _param_fw_thr_trim.get()) /
+				(_param_fw_airspd_max.get() - _param_fw_airspd_trim.get()) * (airspeed_sp - _param_fw_airspd_trim.get());
+	}
+
 	float weight_ratio = 1.0f;
 
 	if (_param_weight_base.get() > FLT_EPSILON && _param_weight_gross.get() > FLT_EPSILON) {
@@ -2550,8 +2567,8 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 	}
 
 	/* update TECS vehicle state estimates */
-	const float throttle_trim_comp = compensateTrimThrottleForDensityAndWeight(_param_fw_thr_trim.get(), throttle_min,
-					 throttle_max);
+	const float throttle_trim_comp = calculateTrimThrottle(throttle_min,
+					 throttle_max, airspeed_sp);
 
 	// HOTFIX: the airspeed rate estimate using acceleration in body-forward direction has shown to lead to high biases
 	// when flying tight turns. It's in this case much safer to just set the estimated airspeed rate to 0.

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.hpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.hpp
@@ -689,14 +689,15 @@ private:
 	void set_control_mode_current(const hrt_abstime &now);
 
 	/**
-	 * @brief Compensate trim throttle for air density and vehicle weight.
+	 * @brief Estimate trim throttle for air density, vehicle weight and current airspeed
 	 *
-	 * @param trim throttle required at sea level during standard conditions.
 	 * @param throttle_min Minimum allowed trim throttle.
 	 * @param throttle_max Maximum allowed trim throttle.
-	 * @return Trim throttle compensated for air density and vehicle weight.
+	 * @param airspeed_sp Current airspeed setpoint (CAS) [m/s]
+	 * @return Estimated trim throttle
 	 */
-	float compensateTrimThrottleForDensityAndWeight(float throttle_trim, float throttle_min, float throttle_max);
+	float calculateTrimThrottle(float throttle_min, float throttle_max,
+				    float airspeed_sp);
 
 	void publishOrbitStatus(const position_setpoint_s pos_sp);
 
@@ -905,6 +906,9 @@ private:
 		(ParamFloat<px4::params::FW_T_SPD_STD>) _param_speed_standard_dev,
 		(ParamFloat<px4::params::FW_T_SPD_DEV_STD>) _param_speed_rate_standard_dev,
 		(ParamFloat<px4::params::FW_T_SPD_PRC_STD>) _param_process_noise_standard_dev,
+
+		(ParamFloat<px4::params::FW_THR_ASPD_MIN>) _param_fw_thr_aspd_min,
+		(ParamFloat<px4::params::FW_THR_ASPD_MAX>) _param_fw_thr_aspd_max,
 
 		(ParamFloat<px4::params::FW_THR_TRIM>) _param_fw_thr_trim,
 		(ParamFloat<px4::params::FW_THR_IDLE>) _param_fw_thr_idle,

--- a/src/modules/fw_path_navigation/fw_path_navigation_params.c
+++ b/src/modules/fw_path_navigation/fw_path_navigation_params.c
@@ -1069,7 +1069,7 @@ PARAM_DEFINE_FLOAT(FW_SPOILERS_DESC, 0.f);
  *
  * Required throttle for level flight at minimum airspeed FW_AIRSPD_MIN (sea level, standard atmosphere)
  *
- * Set to 0 to disable mapping of airspeed to trim throttle.
+ * Set to 0 to disable mapping of airspeed to trim throttle below FW_AIRSPD_TRIM.
  *
  * @min 0
  * @max 1

--- a/src/modules/fw_path_navigation/fw_path_navigation_params.c
+++ b/src/modules/fw_path_navigation/fw_path_navigation_params.c
@@ -1067,6 +1067,8 @@ PARAM_DEFINE_FLOAT(FW_SPOILERS_DESC, 0.f);
 /**
  * Throttle at min airspeed
  *
+ * Required throttle for level flight at minimum airspeed FW_AIRSPD_MIN (sea level, standard atmosphere)
+ *
  * Set to 0 to disable mapping of airspeed to trim throttle.
  *
  * @min 0
@@ -1079,6 +1081,8 @@ PARAM_DEFINE_FLOAT(FW_THR_ASPD_MIN, 0.f);
 
 /**
  * Throttle at max airspeed
+ *
+ * Required throttle for level flight at maximum airspeed FW_AIRSPD_MAX (sea level, standard atmosphere)
  *
  * Set to 0 to disable mapping of airspeed to trim throttle.
  *

--- a/src/modules/fw_path_navigation/fw_path_navigation_params.c
+++ b/src/modules/fw_path_navigation/fw_path_navigation_params.c
@@ -1063,3 +1063,29 @@ PARAM_DEFINE_FLOAT(FW_SPOILERS_LND, 0.f);
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_SPOILERS_DESC, 0.f);
+
+/**
+ * Throttle at min airspeed
+ *
+ * Set to 0 to disable mapping of airspeed to trim throttle.
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @increment 0.01
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_THR_ASPD_MIN, 0.f);
+
+/**
+ * Throttle at max airspeed
+ *
+ * Set to 0 to disable mapping of airspeed to trim throttle.
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @increment 0.01
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_THR_ASPD_MAX, 0.f);


### PR DESCRIPTION
### Solved Problem
1) TECS doesn't cleanly support handling varying airspeed. 
Flying at different airspeed requires some sort of drag modelling, as the trim throttle strongly depends on current airspeed. The controller is able to compensate for some small airspeed changes manly through the throttle integrator, but this is not optimal especially if the airspeeds varies strongly within the same flight, as then the quality of the airspeed tracking on airspeed changes is directly dependent on how fast the integrator converges. 

~2) Inconsistent handling of load factor increase due to vehicle weight vs load factor increase due to banking.
The load factor determines how much lift the vehicle currently has, and that in turn how much induced drag it experiences, that then has to be taken into account for the calculation of induced drag.~ EDIT: removed.

### Solution
1) Plotting required throttle over airspeed for sustaining a certain airspeed in level flight yields a curve that can be very well approximated in a linear way (see plot below from two VTOLs with wide airspeed range). 
Thus I here propose to a linear mapping with different gradients on the "below trim airspeed" and "above trim airspeed" case: 

if $Airspeed_{setpoint} < Airspeed_{trim}$

$$Throttle_{trim} = Throttle_{trim} - \frac{(Throttle_{trim} - Throttle_{min})} { (Airspeed_{trim} - Airspeed_{min})} * (Airspeed_{trim} - Airspeed_{setpoint}) $$


if $Airspeed_{setpoint} > Airspeed_{trim}$

$$Throttle_{trim} = Throttle_{trim} + \frac{(Throttle_{max} - Throttle_{trim})} { (Airspeed_{max} - Airspeed_{trim})} * (Airspeed_{max} - Airspeed_{setpoint}) $$

Where the corresponding PX4 parameters are : `FW_THR_ASPD_MIN` (new), `FW_THR_ASPD_MAX` (new), `FW_AIRSPD_MIN`, `FW_AIRSPD_MAX`, `FW_AIRSPD_TRIM`

Note: we currently don't do any thrust-to-throttle allocation as function of environmental condition or drive train properties, but always linearly map vehicle_thrust_setpoint to throttle in the allocation. If that should change one day then also the mapping here has to be adjusted, as we with this linear mapping from airspeed to throttle implicitly model these effects along the way.
![image](https://user-images.githubusercontent.com/26798987/226567837-497eb773-fb0e-4fea-9583-6666dea30a5d.png)


~2) Do the load factor due to banking at the same place where the vehicle weight is taken into account, so outside of TECS in `FixedwingPositionControl::calculateTrimThrottle()`. Replace the old logic around `FW_T_RLL2THR` and introduce new parameter `FW_INDCD_DRG_RTO`, that has a physical meaning: It should be set to the ratio of induced drag at trim airspeed over total drag. As it is only used at this place it can be seen as a tuning knob that can be tweaked the same way as `FW_T_RLL2THR`, without negatively affecting other parts of the controller. Shortcoming of this approach: The induced drag is also dependent on airspeed, but I neglect that for now and thus for the whole load-factor-to-throttle mapping. Thus it would now over-compensate a tight turn when flying faster than trim. How visible that is hard to say, it could though be mitigated by e.g. assuming the induced drag to be linearly faded out towards FW_AIRSPD_MAX. And what about flying below trim airspeed, should the load-factor-thrust mapping then be increased (as induced drag is increased)?
![image](https://user-images.githubusercontent.com/26798987/226566084-37f1f6f0-98ad-4061-8f38-c934e42296d6.png)~ EDIT: removed

### Alternatives
We should probably look into how to support varying load factor cleanly for airspeed-less flying. The here proposed load factor to throttle mapping take care of "keeping the airspeed constant", but they are not meant to "increase the airspeed to avoid stalling". If flying with airspeed, this is taken care of at [a different point](https://github.com/PX4/PX4-Autopilot/blob/22c94f805a372783d670bcaf53ca736c86dcd7a5/src/modules/fw_path_navigation/FixedwingPositionControl.cpp#L441) , and the airspeed_min is adjusted in that case. For the airspeed-less case and extra logic should be added to the trim_throttle calculation. 

### Test coverage
Testflown multiple times on tiltrotor VTOL.T[his is the log of a flight with the throttle mapping decently tuned](https://review.px4.io/plot_app?log=d5d46327-f81f-4185-b391-8e078055807f). 
1) Large airspeed variation: 
![image](https://user-images.githubusercontent.com/26798987/226573902-d1b2b674-39bc-473b-9b02-f00130329f06.png)
In these plots you see the airspeed increasing from 13m/s to 20m/s and then to 26m/s. The trim throttle is adjusted to it via the logic proposed here, with the settings being `FW_THR_ASPD_MIN` = 0.32 (`FW_AIRSPD_MIN`=12), `FW_THR_ASPD_MAX`=0.8 (`FW_AIRSPD_MAX`=30). In steady condition the throttle integrator is always below some 2%, while being considerably higher during the airspeed changes (something that could be improved with https://github.com/PX4/PX4-Autopilot/pull/21266, but that's part of a different story). 

2) High roll angle maneuver:
![image](https://user-images.githubusercontent.com/26798987/226575716-49c1b61d-5840-4151-b33f-c1277ff265a9.png)
In these plots you see the effect on throttle when flying at low roll vs. at high roll (up to 55°), while the airspeed stays similar. 
Note that the vehicle was almost stalling at the 55° ( `FW_AIRSPD_MIN`=12 is chosen at bit too low), and because of that the roll tracking looks bad and also the other plots see the effect of that. `FW_INDCD_DRG_RTO` is set to 0.1 here, but should probably be increased to about 0.15 as the predicted trim throttle is a bit below the actual throttle. 


