### PR TITLE
distance_sensor: Add TF02 Pro I2C parameter

### DIFF
--- a/src/drivers/distance_sensor/tf02pro/TF02PRO.cpp
+++ b/src/drivers/distance_sensor/tf02pro/TF02PRO.cpp
@@ -47,7 +47,14 @@ TF02PRO::TF02PRO(const I2CSPIDriverConfig &config) :
 	_px4_rangefinder.set_rangefinder_type(distance_sensor_s::MAV_DISTANCE_SENSOR_LASER);
 	_px4_rangefinder.set_max_distance(TF02PRO_MAX_DISTANCE);
 	_px4_rangefinder.set_min_distance(TF02PRO_MIN_DISTANCE);
+	// get the rotation value from the parameter
+	int32_t value;
+	param_get(param_find("SENS_TF02PRO_ROT"), &value);
+	_px4_rangefinder.set_orientation(value);
 	_px4_rangefinder.set_fov(math::radians(3.0f));
+	// get the address value from the parameter
+	param_get(param_find("SENS_TF02PRO_ADD"), &value);
+	set_device_address(value);
 }
 
 /**

--- a/src/drivers/distance_sensor/tf02pro/TF02PRO.hpp
+++ b/src/drivers/distance_sensor/tf02pro/TF02PRO.hpp
@@ -45,6 +45,7 @@
 #include <drivers/device/i2c.h>
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
+#include <px4_platform_common/module_params.h>
 
 /* Configuration Constants */
 #define TF02PRO_BASEADDR			0x10 	// 7-bit address. 8-bit address is 0x20.

--- a/src/drivers/distance_sensor/tf02pro/parameters.c
+++ b/src/drivers/distance_sensor/tf02pro/parameters.c
@@ -40,3 +40,38 @@
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_EN_TF02PRO, 0);
+
+/**
+ * TF02 Pro I2C address
+ *
+ * @reboot_required true
+ *
+ * @min 0
+ * @max 255
+ * @group Sensors
+*/
+PARAM_DEFINE_INT32(SENS_TF02PRO_ADD, 16);
+
+/**
+ * TF02 Pro Sensor Rotation
+ *
+ * This parameter defines the rotation of the TF02 Pro sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 25
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * @value 24 ROTATION_DOWNWARD_FACING
+ * @value 25 ROTATION_UPWARD_FACING
+ *
+ */
+PARAM_DEFINE_INT32(SENS_TF02PRO_ROT, 25);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
None

### Solution
Thanks to the TF02 PRO I2C driver code submitted by #20857, the IIC driver of TF products can be used in the PX4 firmware.
I added SENS_TF02PRO_ROT and SENS_TF02PRO_ADD parameters to set the rotation and I2C address of the sensor.
After increasing the rotation parameter, the sensor can not only be used for height determination, but also be used for obstacle avoidance of large target objects.
The TF sensor supports setting the IIC address, so add an address setting parameter.
 Parameter setting document：
[TF02-Pro User Manual.pdf](https://github.com/PX4/PX4-Autopilot/files/11037042/TF02-Pro.User.Manual.pdf)


### Alternatives
None.

### Test coverage
Here I use the TF sensor with the I2C address 0x02, the Rotation is set to face forward, and the parameters are set as follows.
![image](https://user-images.githubusercontent.com/10082403/226819171-ffbad925-b710-4958-9961-f25074cdd14a.png)
Using  the logic analyzer capture I2C data  , it can be seen that the address of the sensor is 0x02.
![image](https://user-images.githubusercontent.com/10082403/226819678-52e55b4b-ebef-499a-aade-74233c94f5ea.png)
Connect to QGC to view rangefinder data.
![image](https://user-images.githubusercontent.com/10082403/226819720-aa8524ff-72f1-4ff4-90dc-4b9f51de5e2e.png)
![image](https://user-images.githubusercontent.com/10082403/226819731-e907462d-aeed-41c7-9381-1166c616c499.png)

### Context
None.

