### PR TITLE
VTOL: Quad-chute param corrections/improvements

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -91,7 +91,7 @@ PARAM_DEFINE_FLOAT(VT_F_TRANS_DUR, 5.0f);
 PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 4.0f);
 
 /**
- * Target throttle value for the transition to fixed wing flight.
+ * Target throttle value for the transition to fixed-wing flight.
  *
  * standard vtol: pusher
  *
@@ -194,10 +194,11 @@ PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);
 PARAM_DEFINE_FLOAT(VT_TRANS_MIN_TM, 2.0f);
 
 /**
- * QuadChute Altitude
+ * Quad-chute altitude
  *
- * Minimum altitude for fixed wing flight, when in fixed wing the altitude drops below this altitude
- * the vehicle will transition back to MC mode and enter failsafe RTL
+ * Minimum altitude for fixed-wing flight. When the vehicle is in fixed-wing mode
+ * and the altitude drops below this altitude (relative altitude above local origin),
+ * it will instantly switch back to MC mode and execute behavior defined in COM_QC_ACT.
  *
  * @unit m
  * @min 0.0
@@ -276,8 +277,8 @@ PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 /**
  * Quad-chute maximum height
  *
- * Maximum height above the ground (if available, otherwhise above
- * home if available, otherwise above the local origin) where triggering a quadchute is possible.
+ * Maximum height above the ground (if available, otherwise above
+ * Home if available, otherwise above the local origin) where triggering a quad-chute is possible.
  * At high altitudes there is a big risk to deplete the battery and therefore crash if quad-chuting there.
  *
  * @unit m
@@ -288,7 +289,7 @@ PARAM_DEFINE_INT32(VT_FW_QC_R, 0);
 PARAM_DEFINE_INT32(VT_FW_QC_HMAX, 0);
 
 /**
- * Airspeed less front transition time (open loop)
+ * Airspeed-less front transition time (open loop)
  *
  * The duration of the front transition when there is no airspeed feedback available.
  *

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -244,7 +244,7 @@ PARAM_DEFINE_FLOAT(VT_QC_HR_ERROR_I, 0.0f);
  * @decimal 1
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_QC_T_ALT_LOSS, 10.0f);
+PARAM_DEFINE_FLOAT(VT_QC_T_ALT_LOSS, 20.0f);
 
 /**
  * Quad-chute max pitch threshold


### PR DESCRIPTION
Stumbled on some inconsistencies and wrong/bad param descriptions for the quad-chute params while doing https://github.com/PX4/PX4-user_guide/pull/2364.
Further I propose here to increase the default of VT_QC_T_ALT_LOSS to 20m, as 10m has shown to be quite tight. 