### PR TITLE
Gimbal: remove shutter and retraction handling

### DIFF
--- a/msg/GimbalControls.msg
+++ b/msg/GimbalControls.msg
@@ -5,5 +5,3 @@ uint8 INDEX_YAW = 2
 
 uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
 float32[3] control
-
-float32 retract_gimbal

--- a/src/modules/gimbal/common.h
+++ b/src/modules/gimbal/common.h
@@ -78,8 +78,6 @@ struct ControlData {
 
 	Type type = Type::Neutral;
 
-	bool gimbal_shutter_retract = false; // whether to lock the gimbal (only in RC output mode)
-
 	uint8_t sysid_primary_control = 0; // The MAVLink system ID selected to be in control, 0 for no one.
 	uint8_t compid_primary_control = 0; // The MAVLink component ID selected to be in control, 0 for no one.
 	// uint8_t sysid_secondary_control = 0; // The MAVLink system ID selected for additional input, not implemented yet.

--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -449,8 +449,6 @@ void update_params(ParameterHandles &param_handles, Parameters &params)
 	param_get(param_handles.mnt_mode_out, &params.mnt_mode_out);
 	param_get(param_handles.mnt_mav_sysid_v1, &params.mnt_mav_sysid_v1);
 	param_get(param_handles.mnt_mav_compid_v1, &params.mnt_mav_compid_v1);
-	param_get(param_handles.mnt_ob_lock_mode, &params.mnt_ob_lock_mode);
-	param_get(param_handles.mnt_ob_norm_mode, &params.mnt_ob_norm_mode);
 	param_get(param_handles.mnt_man_pitch, &params.mnt_man_pitch);
 	param_get(param_handles.mnt_man_roll, &params.mnt_man_roll);
 	param_get(param_handles.mnt_man_yaw, &params.mnt_man_yaw);
@@ -476,8 +474,6 @@ bool initialize_params(ParameterHandles &param_handles, Parameters &params)
 	param_handles.mnt_mode_out = param_find("MNT_MODE_OUT");
 	param_handles.mnt_mav_sysid_v1 = param_find("MNT_MAV_SYSID");
 	param_handles.mnt_mav_compid_v1 = param_find("MNT_MAV_COMPID");
-	param_handles.mnt_ob_lock_mode = param_find("MNT_OB_LOCK_MODE");
-	param_handles.mnt_ob_norm_mode = param_find("MNT_OB_NORM_MODE");
 	param_handles.mnt_man_pitch = param_find("MNT_MAN_PITCH");
 	param_handles.mnt_man_roll = param_find("MNT_MAN_ROLL");
 	param_handles.mnt_man_yaw = param_find("MNT_MAN_YAW");
@@ -500,8 +496,6 @@ bool initialize_params(ParameterHandles &param_handles, Parameters &params)
 	    param_handles.mnt_mode_out == PARAM_INVALID ||
 	    param_handles.mnt_mav_sysid_v1 == PARAM_INVALID ||
 	    param_handles.mnt_mav_compid_v1 == PARAM_INVALID ||
-	    param_handles.mnt_ob_lock_mode == PARAM_INVALID ||
-	    param_handles.mnt_ob_norm_mode == PARAM_INVALID ||
 	    param_handles.mnt_man_pitch == PARAM_INVALID ||
 	    param_handles.mnt_man_roll == PARAM_INVALID ||
 	    param_handles.mnt_man_yaw == PARAM_INVALID ||

--- a/src/modules/gimbal/gimbal_params.c
+++ b/src/modules/gimbal/gimbal_params.c
@@ -89,30 +89,6 @@ PARAM_DEFINE_INT32(MNT_MAV_SYSID, 1);
 PARAM_DEFINE_INT32(MNT_MAV_COMPID, 154);
 
 /**
-* Mixer value for selecting normal mode
-*
-* if required by the gimbal (only in AUX output mode)
-*
-* @min -1.0
-* @max 1.0
-* @decimal 3
-* @group Mount
-*/
-PARAM_DEFINE_FLOAT(MNT_OB_NORM_MODE, -1.0f);
-
-/**
-* Mixer value for selecting a locking mode
-*
-* if required for the gimbal (only in AUX output mode)
-*
-* @min -1.0
-* @max 1.0
-* @decimal 3
-* @group Mount
-*/
-PARAM_DEFINE_FLOAT(MNT_OB_LOCK_MODE, 0.0f);
-
-/**
 * Auxiliary channel to control roll (in AUX input or manual mode).
 *
 * @value 0 Disable

--- a/src/modules/gimbal/gimbal_params.h
+++ b/src/modules/gimbal/gimbal_params.h
@@ -45,8 +45,6 @@ struct Parameters {
 	int32_t mnt_mode_out;
 	int32_t mnt_mav_sysid_v1;
 	int32_t mnt_mav_compid_v1;
-	float mnt_ob_lock_mode;
-	float mnt_ob_norm_mode;
 	int32_t mnt_man_pitch;
 	int32_t mnt_man_roll;
 	int32_t mnt_man_yaw;
@@ -71,8 +69,6 @@ struct ParameterHandles {
 	param_t mnt_mode_out;
 	param_t mnt_mav_sysid_v1;
 	param_t mnt_mav_compid_v1;
-	param_t mnt_ob_lock_mode;
-	param_t mnt_ob_norm_mode;
 	param_t mnt_man_pitch;
 	param_t mnt_man_roll;
 	param_t mnt_man_yaw;

--- a/src/modules/gimbal/input_mavlink.cpp
+++ b/src/modules/gimbal/input_mavlink.cpp
@@ -257,7 +257,6 @@ InputMavlinkCmdMount::_process_command(ControlData &control_data, const vehicle_
 
 		switch ((int) vehicle_command.param7) {
 		case vehicle_command_s::VEHICLE_MOUNT_MODE_RETRACT:
-			control_data.gimbal_shutter_retract = true;
 
 		// fallthrough
 		case vehicle_command_s::VEHICLE_MOUNT_MODE_NEUTRAL:
@@ -606,8 +605,6 @@ InputMavlinkGimbalV2::UpdateResult InputMavlinkGimbalV2::_process_set_attitude(C
 InputMavlinkGimbalV2::UpdateResult InputMavlinkGimbalV2::_process_vehicle_roi(ControlData &control_data,
 		const vehicle_roi_s &vehicle_roi)
 {
-	control_data.gimbal_shutter_retract = false;
-
 	if (vehicle_roi.mode == vehicle_roi_s::ROI_NONE) {
 
 		control_data.type = ControlData::Type::Neutral;
@@ -679,7 +676,6 @@ InputMavlinkGimbalV2::_process_command(ControlData &control_data, const vehicle_
 
 		switch ((int) vehicle_command.param7) {
 		case vehicle_command_s::VEHICLE_MOUNT_MODE_RETRACT:
-			control_data.gimbal_shutter_retract = true;
 
 		// fallthrough
 

--- a/src/modules/gimbal/input_rc.cpp
+++ b/src/modules/gimbal/input_rc.cpp
@@ -161,8 +161,6 @@ InputRC::UpdateResult InputRC::_read_control_data_from_subscription(ControlData 
 			_last_set_aux_values[i] = new_aux_values[i];
 		}
 
-		control_data.gimbal_shutter_retract = false;
-
 		return UpdateResult::UpdatedActive;
 
 	} else {

--- a/src/modules/gimbal/input_test.cpp
+++ b/src/modules/gimbal/input_test.cpp
@@ -66,8 +66,6 @@ InputTest::UpdateResult InputTest::update(unsigned int timeout_ms, ControlData &
 
 	q.copyTo(control_data.type_data.angle.q);
 
-	control_data.gimbal_shutter_retract = false;
-
 	control_data.type_data.angle.angular_velocity[0] = NAN;
 	control_data.type_data.angle.angular_velocity[1] = NAN;
 	control_data.type_data.angle.angular_velocity[2] = NAN;

--- a/src/modules/gimbal/output_rc.cpp
+++ b/src/modules/gimbal/output_rc.cpp
@@ -51,7 +51,6 @@ OutputRC::OutputRC(const Parameters &parameters)
 void OutputRC::update(const ControlData &control_data, bool new_setpoints)
 {
 	if (new_setpoints) {
-		_retract_gimbal = control_data.gimbal_shutter_retract;
 		_set_angle_setpoints(control_data);
 	}
 
@@ -76,9 +75,6 @@ void OutputRC::update(const ControlData &control_data, bool new_setpoints)
 				(_angle_outputs[2] + math::radians(_parameters.mnt_off_yaw)) *
 				(1.0f / (math::radians(_parameters.mnt_range_yaw / 2.0f))),
 				-1.f, 1.f);
-	gimbal_controls.retract_gimbal = constrain(
-			_retract_gimbal ? _parameters.mnt_ob_lock_mode : _parameters.mnt_ob_norm_mode,
-			-1.f, 1.f);
 	gimbal_controls.timestamp = hrt_absolute_time();
 	_gimbal_controls_pub.publish(gimbal_controls);
 

--- a/src/modules/gimbal/output_rc.h
+++ b/src/modules/gimbal/output_rc.h
@@ -58,8 +58,6 @@ private:
 
 	uORB::Publication <gimbal_controls_s>	_gimbal_controls_pub{ORB_ID(gimbal_controls)};
 	uORB::Publication <gimbal_device_attitude_status_s>	_attitude_status_pub{ORB_ID(gimbal_device_attitude_status)};
-
-	bool _retract_gimbal = true;
 };
 
 } /* namespace gimbal */


### PR DESCRIPTION
The logic around automatically retract/deploy a gimbal resp. a camera shutter is currently broken (as it's not handled in the new control allocation). It's currently only possible to manually control retraction via MAVLink commands (DO_SET_ACTAUTOR or DO_SET_SERVO). 

Previously it used to work like that if I understand it correctly:
- at the beginning/by default, it would be  `gimbal_retract = false`
- if could be retracted by sending the MAVLink message [VEHICLE_CMD_DO_MOUNT_CONTROL](https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONTROL) with the last field set to VEHICLE_MOUNT_MODE_RETRACT (0), so `gimbal_retract = true` Note: VEHICLE_CMD_DO_MOUNT_CONTROL is deprecated and thus shouldn't be used anymore I guess
- if would be automatically deployed when a ROI is commanded, `gimbal_retract = false`
- if the gimbal was manually controlled the gimbal was deployed , `gimbal_retract = false`
if gimbal_retract = true, the corresponding acutator_controls was set to `MNT_OB_LOCK_MODE`, otherwise to `MNT_OB_NORM_MODE`

So it seems to me as if the only way to retract a gimbal was always with sending a MAVLink message. If that's the case then I wonder how bad it would be to completely remove this functionality, and instead purely rely on MAVLink messages to handle it. 
Otherwise I would rather link it to the current PX4 flight mode (eg retract in Takeoff and Landing). As that would be a new feature that so far nobody requested (that I'm aware of), I'm hesitant to implement the logic around it. And easy "hack" would be to link it (inverse) to the landing_gear (always deploy when landing gear is retracted). 