### PR TITLE
TECS: change default for FW_T_I_GAIN_THR from 0.3 to more appropriate 0.1

### DIFF
--- a/src/modules/fw_path_navigation/fw_path_navigation_params.c
+++ b/src/modules/fw_path_navigation/fw_path_navigation_params.c
@@ -540,7 +540,7 @@ PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.1f);
  * @increment 0.05
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.3f);
+PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.1f);
 
 /**
  * Integrator gain pitch


### PR DESCRIPTION
Since with https://github.com/PX4/PX4-Autopilot/pull/20443/commits/b1cbe04694bcb85161126df641dc7ebb66e8697a the STE_rate_error gets properly filtered and not constantly reset to 0, the tuning has to be slightly adjusted. I found that the default for FW_T_I_GAIN_THR of 0.3 is now way to high on most vehicles. This PR is to basically revert to what was before the https://github.com/PX4/PX4-Autopilot/commit/3d3ff75495c2345f2d93a2fdc236b064d8b81688 and the filtering bug had been introduced.
