### PR TITLE
MC_Pos_Control: takeoff bug constrain hover_thrust_estimate consistently

### DIFF
--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -227,7 +227,7 @@ void MulticopterPositionControl::parameters_update(bool force)
 		}
 
 		if (!_param_mpc_use_hte.get() || !_hover_thrust_initialized) {
-			_control.setHoverThrust(_param_mpc_thr_hover.get());
+			_control.setHoverThrust(_param_mpc_thr_hover.get(), false);
 			_hover_thrust_initialized = true;
 		}
 
@@ -329,7 +329,7 @@ void MulticopterPositionControl::Run()
 
 			if (_hover_thrust_estimate_sub.update(&hte)) {
 				if (hte.valid) {
-					_control.updateHoverThrust(hte.hover_thrust);
+					_control.setHoverThrust(hte.hover_thrust, true);
 				}
 			}
 		}
@@ -415,7 +415,7 @@ void MulticopterPositionControl::Run()
 				if (!flying) {
 					_setpoint.acceleration[2] = NAN;
 					// hover_thrust maybe reset on takeoff
-					_control.setHoverThrust(_param_mpc_thr_hover.get());
+					_control.setHoverThrust(_param_mpc_thr_hover.get(), false);
 				}
 
 				const bool not_taken_off             = (_takeoff.getTakeoffState() < TakeoffState::rampup);

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -79,10 +79,14 @@ void PositionControl::updateHoverThrust(const float hover_thrust_new)
 	// T' = T => a_sp' * Th' / g - Th' = a_sp * Th / g - Th
 	// so a_sp' = (a_sp - g) * Th / Th' + g
 	// we can then add a_sp' - a_sp to the current integrator to absorb the effect of changing Th by Th'
-	if (hover_thrust_new > FLT_EPSILON) {
-		_vel_int(2) += (_acc_sp(2) - CONSTANTS_ONE_G) * _hover_thrust / hover_thrust_new + CONSTANTS_ONE_G - _acc_sp(2);
-		setHoverThrust(hover_thrust_new);
-	}
+	// hover_thrust_new:  needs to be constrained to match the constraint in setHoverThrust()
+	_vel_int(2) += (_acc_sp(2) - CONSTANTS_ONE_G) * _hover_thrust / _constrainHoverThrust(hover_thrust_new)
+		       + CONSTANTS_ONE_G - _acc_sp(2);
+
+	// limit thrust integral
+	_constrainVelIntegral_Z();
+
+	setHoverThrust(hover_thrust_new);
 }
 
 void PositionControl::setState(const PositionControlStates &states)
@@ -191,7 +195,7 @@ void PositionControl::_velocityControl(const float dt)
 	_vel_int += vel_error.emult(_gain_vel_i) * dt;
 
 	// limit thrust integral
-	_vel_int(2) = math::min(fabsf(_vel_int(2)), CONSTANTS_ONE_G) * sign(_vel_int(2));
+	_constrainVelIntegral_Z();
 }
 
 void PositionControl::_accelerationControl()
@@ -205,6 +209,16 @@ void PositionControl::_accelerationControl()
 	collective_thrust /= (Vector3f(0, 0, 1).dot(body_z));
 	collective_thrust = math::min(collective_thrust, -_lim_thr_min);
 	_thr_sp = body_z * collective_thrust;
+}
+
+float PositionControl::_constrainHoverThrust(float hover_thrust)
+{
+	return math::constrain(hover_thrust, kHoverThrustMin, kHoverThrustMax);
+}
+
+void PositionControl::_constrainVelIntegral_Z()
+{
+	_vel_int(2) = math::constrain(_vel_int(2), -CONSTANTS_ONE_G, CONSTANTS_ONE_G);
 }
 
 bool PositionControl::_inputValid()

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -121,9 +121,9 @@ public:
 
 	/**
 	 * Set the normalized hover thrust
-	 * @param thrust [0.1, 0.9] with which the vehicle hovers not acelerating down or up with level orientation
+	 * @param hover_thrust [kHoverThrustMin, kHoverThrustMax] with which the vehicle hovers not accelerating down or up with level orientation
 	 */
-	void setHoverThrust(const float hover_thrust) { _hover_thrust = math::constrain(hover_thrust, 0.1f, 0.9f); }
+	void setHoverThrust(const float hover_thrust) { _hover_thrust = _constrainHoverThrust(hover_thrust); }
 
 	/**
 	 * Update the hover thrust without immediately affecting the output
@@ -179,11 +179,18 @@ public:
 	void getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint) const;
 
 private:
+	// The minimum and maximum levels of hover thrust for constraining the hover thrust estimate
+	static constexpr float kHoverThrustMin = 0.01f;
+	static constexpr float kHoverThrustMax = 0.9f;
+
 	bool _inputValid();
 
 	void _positionControl(); ///< Position proportional control
 	void _velocityControl(const float dt); ///< Velocity PID control
 	void _accelerationControl(); ///< Acceleration setpoint processing
+
+	float _constrainHoverThrust(float hover_thrust);
+	void _constrainVelIntegral_Z();
 
 	// Gains
 	matrix::Vector3f _gain_pos_p; ///< Position control proportional gain
@@ -200,7 +207,7 @@ private:
 	float _lim_thr_xy_margin{}; ///< Margin to keep for horizontal control when saturating prioritized vertical thrust
 	float _lim_tilt{}; ///< Maximum tilt from level the output attitude is allowed to have
 
-	float _hover_thrust{}; ///< Thrust [0.1, 0.9] with which the vehicle hovers not accelerating down or up with level orientation
+	float _hover_thrust{}; ///< Thrust [kHoverThrustMin, kHoverThrustMax] with which the vehicle hovers not accelerating down or up with level orientation
 
 	// States
 	matrix::Vector3f _pos; /**< current position */

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -122,15 +122,11 @@ public:
 	/**
 	 * Set the normalized hover thrust
 	 * @param hover_thrust [kHoverThrustMin, kHoverThrustMax] with which the vehicle hovers not accelerating down or up with level orientation
+	 * @param adjust_vel_int If true, update the hover thrust without immediately affecting the output
+	 * 				by adjusting the integrator. This prevents propagating the dynamics
+	 * 				of the hover thrust signal directly to the output of the controller.
 	 */
-	void setHoverThrust(const float hover_thrust) { _hover_thrust = _constrainHoverThrust(hover_thrust); }
-
-	/**
-	 * Update the hover thrust without immediately affecting the output
-	 * by adjusting the integrator. This prevents propagating the dynamics
-	 * of the hover thrust signal directly to the output of the controller.
-	 */
-	void updateHoverThrust(const float hover_thrust_new);
+	void setHoverThrust(const float hover_thrust, bool adjust_vel_int);
 
 	/**
 	 * Pass the current vehicle state to the controller

--- a/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControlTest.cpp
@@ -81,7 +81,7 @@ public:
 		_position_control.setThrustLimits(0.1f, MAXIMUM_THRUST);
 		_position_control.setHorizontalThrustMargin(HORIZONTAL_THRUST_MARGIN);
 		_position_control.setTiltLimit(1.f);
-		_position_control.setHoverThrust(.5f);
+		_position_control.setHoverThrust(.5f, false);
 
 		resetInputSetpoint();
 	}
@@ -374,11 +374,11 @@ TEST_F(PositionControlBasicTest, InvalidState)
 }
 
 
-TEST_F(PositionControlBasicTest, UpdateHoverThrust)
+TEST_F(PositionControlBasicTest, setHoverThrust)
 {
 	// GIVEN: some hover thrust and 0 velocity change
 	const float hover_thrust = 0.6f;
-	_position_control.setHoverThrust(hover_thrust);
+	_position_control.setHoverThrust(hover_thrust, false);
 
 	_input_setpoint.vx = 0.f;
 	_input_setpoint.vy = 0.f;
@@ -392,7 +392,7 @@ TEST_F(PositionControlBasicTest, UpdateHoverThrust)
 
 	// HOWEVER WHEN: we set a new hover thrust through the update function
 	const float hover_thrust_new = 0.7f;
-	_position_control.updateHoverThrust(hover_thrust_new);
+	_position_control.setHoverThrust(hover_thrust_new, true);
 	EXPECT_TRUE(runController());
 
 	// THEN: the integral is updated to avoid discontinuities and


### PR DESCRIPTION
Fixes #20275

This in response to a shoot to the sky event we had that we could reproduce quite readily. I was also able to reproduce it in gazebo. See comment  https://github.com/PX4/PX4-Autopilot/issues/20275#issuecomment-1474465513

### Issue

The branch is on a custom 1.13 with last merged in commits from main (6823cbc4140e29568f00e1211ae60e057adb1a1f) and no changes to PosControl.
(Note of all my vehicles with this same firmware only one exhibits it to the extreme of shooting to the sky. Though you can audibly hear what may be this issue on others.)

![Screenshot from 2023-03-17 17-05-33](https://user-images.githubusercontent.com/69225461/226062543-2b2dcb42-03fd-4ad8-9c70-9b3dccf81c31.png)

### Likely Cause

In `PositionControl::updateHoverThrust(const float hover_thrust)`, `_hover_thrust_new` is not constrained by the same amount as  the stored `_hover thrust` because we are pulling down  on throttle and keeping ourselves stuck to the ground the estimate for hover thrust is much smaller than the 0.1 default constraint. 

This then leads to a build up [here](https://github.com/PX4/PX4-Autopilot/blob/1c8ab2a0d7db2d14a6f320ebd8766b5ffaea28fa/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L144)

I threw in the other constraint as well to `_vel_int(2)` here just be more consistent as there are a lot of steps that use it before it eventually gets constrained here [link](https://github.com/PX4/PX4-Autopilot/blob/1c8ab2a0d7db2d14a6f320ebd8766b5ffaea28fa/src/modules/mc_pos_control/PositionControl/PositionControl.cpp#L194)

### Future Items

Really what "i think" should be done is some sort of smoothing on the acceleration or jerk in the poscontrol file. Partly as some "defensive" coding and partly so that these changes are less abrupt when `hover_estimate.valid is true`
