### PR TITLE
Commander: add COM_WIND_MAX_ACT param

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/windCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/windCheck.hpp
@@ -52,7 +52,7 @@ private:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamFloat<px4::params::COM_WIND_MAX>) _param_com_wind_max,
-					(ParamFloat<px4::params::COM_WIND_WARN>) _param_com_wind_warn
-
+					(ParamFloat<px4::params::COM_WIND_WARN>) _param_com_wind_warn,
+					(ParamInt<px4::params::COM_WIND_MAX_ACT>) _param_com_wind_max_act
 				       )
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1052,14 +1052,10 @@ PARAM_DEFINE_FLOAT(COM_WIND_WARN, -1.f);
 PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, -1);
 
 /**
- * Wind speed RTL threshold
+ * High wind speed failsafe threshold
  *
- * Wind speed threshold above which an automatic return to launch is triggered.
- * It is not possible to resume the mission or switch to any auto mode other than
- * RTL or Land if this threshold is exceeded. Taking over in any manual
- * mode is still possible.
- *
- * Set to -1 to disable.
+ * Wind speed threshold above which an automatic failsafe action is triggered.
+ * Failsafe action can be specified with COM_WIND_MAX_ACT.
  *
  * @min -1
  * @decimal 1
@@ -1068,6 +1064,27 @@ PARAM_DEFINE_INT32(COM_FLT_TIME_MAX, -1);
  * @unit m/s
  */
 PARAM_DEFINE_FLOAT(COM_WIND_MAX, -1.f);
+
+/**
+ * High wind failsafe mode
+ *
+ * Action the system takes when a wind speed above the specified threshold is detected.
+ * See COM_WIND_MAX to set the failsafe threshold.
+ * If enabled, it is not possible to resume the mission or switch to any auto mode other than
+ * RTL or Land if this threshold is exceeded. Taking over in any manual
+ * mode is still possible.
+ *
+ * @group Commander
+ *
+ * @value 0 None
+ * @value 1 Warning
+ * @value 2 Hold
+ * @value 3 Return
+ * @value 4 Terminate
+ * @value 5 Land
+ * @increment 1
+ */
+PARAM_DEFINE_INT32(COM_WIND_MAX_ACT, 0);
 
 /**
  * EPH threshold for RTL

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -132,6 +132,15 @@ private:
 		StickInputDisabled = 4		// input disabled
 	};
 
+	enum class command_after_high_wind_failsafe : int32_t {
+		None = 0,
+		Warning = 1,
+		Hold_mode = 2,
+		Return_mode = 3,
+		Terminate = 4,
+		Land_mode = 5
+	};
+
 	static ActionOptions fromNavDllOrRclActParam(int param_value);
 
 	static ActionOptions fromGfActParam(int param_value);
@@ -140,6 +149,7 @@ private:
 	static ActionOptions fromBatteryWarningActParam(int param_value, uint8_t battery_warning);
 	static ActionOptions fromQuadchuteActParam(int param_value);
 	static Action fromOffboardLossActParam(int param_value, uint8_t &user_intended_mode);
+	static ActionOptions fromHighWindLimitActParam(int param_value);
 
 	const int _caller_id_mode_fallback{genCallerId()};
 	bool _last_state_mode_fallback{false};
@@ -171,7 +181,8 @@ private:
 					(ParamInt<px4::params::COM_ACT_FAIL_ACT>) _param_com_actuator_failure_act,
 					(ParamInt<px4::params::COM_LOW_BAT_ACT>) _param_com_low_bat_act,
 					(ParamInt<px4::params::COM_OBL_RC_ACT>) _param_com_obl_rc_act,
-					(ParamInt<px4::params::COM_QC_ACT>) _param_com_qc_act
+					(ParamInt<px4::params::COM_QC_ACT>) _param_com_qc_act,
+					(ParamInt<px4::params::COM_WIND_MAX_ACT>) _param_com_wind_max_act
 				       );
 
 };


### PR DESCRIPTION
### Solved Problem
Currently the action after a "high wind speed detected" is hard coded to RTL. We would like to expose it to the user to easily switch on/off this failsafe, and doing that over the currently only interface COM_WIN_MAX (eg set to -1 to disable) is not as easy as setting a boolean. 
For some use cases, setting the action to Land instead of RTL is more appropriate, and even further options like Terminate could be added.

### Solution
Add new param `COM_WIND_MAX_ACT` with fields:
- None (in that case COM_WIND_MAX is not looked at at all)
- Warning ( in that case, if the wind is above COM_WIND_MAX, it publishes a warning that replaces the one for COM_WIND_WARN)
- Hold
- Return
- Terminate
- Land

<del>The issue I have with this way of implementing it is that it is not possible to disable the failsafe action after it already triggered by changing `COM_WIND_MAX_ACT`. For that we would need an action reset - or is that already possible @bkueng ?
Otherwise we could take `COM_WIND_MAX_ACT` already into account for the setting of `wind_limit_exceeded`. it's then though no longer nicely separated. 

I further wonder if we can combine `COM_WIND_WARN` and `COM_WIND_MAX` into one param and start warning at a fixed percentage of `COM_WIND_MAX`, eg 75%. For most applications that would be good enough, but for others this customization is probably required.