### PR TITLE
microdds_client: Fix check for length of participant XML

### DIFF
--- a/src/modules/microdds_client/microdds_client.cpp
+++ b/src/modules/microdds_client/microdds_client.cpp
@@ -265,7 +265,7 @@ void MicroddsClient::run()
 				   "</dds>"
 				  );
 
-		if (ret < 0 || ret >= TOPIC_NAME_SIZE) {
+		if (ret < 0 || ret >= PARTICIPANT_XML_SIZE) {
 			PX4_ERR("create entities failed: namespace too long");
 			return;
 		}


### PR DESCRIPTION
### Solved Problem
When starting the `microdds_client` with the `-l` flag, it gave an error that the client namespace was too long, even when no namespace was given.

This was because the length of the resulting participant XML was being compared to the incorrect variable and thus always appeared too long.


### Solution
Compare XML length to `PARTICIPANT_XML_SIZE`.

### Alternatives
We could also directly query the allocated size of `participant_xml` and compare `ret` to that.

### Test coverage
Tested on a v5x device and successfully started the client with the `-l` flag.

### Context
N/A
