### PR TITLE
rcS-posix: improve microdds_client startup

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -129,6 +129,7 @@ fi
 # multi-instance setup
 # shellcheck disable=SC2154
 param set MAV_SYS_ID $((px4_instance+1))
+param set XRCE_DDS_KEY $((px4_instance+1))
 
 if [ $AUTOCNF = yes ]
 then
@@ -268,14 +269,20 @@ navigator start
 microdds_ns=""
 if [ "$px4_instance" -ne "0" ]
 then
-	# Assign new xrce dds key based on instance number and set default namespace
-	param set XRCE_DDS_KEY ${px4_instance}
+	# for multi intances setup, add namespace prefix
 	microdds_ns="-n px4_$px4_instance"
 fi
 if [ -n "$PX4_MICRODDS_NS" ]
 then
 	# Override namespace if environment variable is defined
 	microdds_ns="-n $PX4_MICRODDS_NS"
+fi
+if [ -n "$ROS_DOMAIN_ID" ]
+then
+	# Match XRCE_DDS_DOM_ID with ROS_DOMAIN_ID, if defined
+	param set XRCE_DDS_DOM_ID $ROS_DOMAIN_ID
+else
+	param set XRCE_DDS_DOM_ID 0
 fi
 microdds_client start -t udp -h 127.0.0.1 -p 8888 $microdds_ns
 


### PR DESCRIPTION
### Solved Problem

- In simulation, `XRCE_DDS_KEY` is equal to `1` for both PX4 instance 0 and 1 (#20466). In this way the two instances cannot connect to the same _agent_ as all session keys must be unique.

### New Feature

- Closes #21291

### Solution
- `XRCE_DDS_KEY` is now always set to `$px4_instance+1`  just like MAV_SYS_ID. Uniqueness is ensured. This modification has no other effect on the user side.
- If `ROS_DOMAIN_ID` is defined, then its value is copied in `XRCE_DDS_DOM_ID`. If it is not defined than `XRCE_DDS_DOM_ID` is forced to zero (default value).

### Additional Informations
To keep the single instance simulation as close as possible to real vehicle usage, the additional namespace prefix `/px4_$px4_instance` is still added only for instances greater than zero.