### PR TITLE
Navigator: fix logic around when to switch to mission landing for RTL

### DIFF
--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -267,8 +267,6 @@ private:
 
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
-	hrt_abstime _time_mission_deactivated{0};
-
 	enum {
 		MISSION_TYPE_NONE,
 		MISSION_TYPE_MISSION

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -348,7 +348,7 @@ private:
 	vehicle_local_position_s			_local_pos{};		/**< local vehicle position */
 	vehicle_status_s				_vstatus{};		/**< vehicle status */
 
-	uint8_t						_previous_nav_state{}; /**< nav_state of the previous iteration*/
+	bool						_rtl_activated{false};
 
 	// Publications
 	geofence_result_s				_geofence_result{};

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -259,10 +259,6 @@ public:
 
 	void set_mission_failure_heading_timeout();
 
-	void setMissionLandingInProgress(bool in_progress) { _mission_landing_in_progress = in_progress; }
-
-	bool getMissionLandingInProgress() { return _mission_landing_in_progress; }
-
 	bool is_planned_mission() const { return _navigation_mode == &_mission; }
 
 	bool on_mission_landing() { return _mission.landing(); }
@@ -392,9 +388,6 @@ private:
 	float _mission_cruising_speed_mc{-1.0f};
 	float _mission_cruising_speed_fw{-1.0f};
 	float _mission_throttle{NAN};
-
-	bool _mission_landing_in_progress{false};	/**< this flag gets set if the mission is currently executing on a landing pattern
-							 * if mission mode is inactive, this flag will be cleared after 2 seconds */
 
 	traffic_buffer_s _traffic_buffer{};
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -670,11 +670,10 @@ void Navigator::run()
 				case RTL::RTL_TYPE_MISSION_LANDING:
 				case RTL::RTL_TYPE_CLOSEST:
 
-					if (!rtl_activated_now && _rtl.getRTLState() > RTL::RTLState::RTL_STATE_LOITER
-					    && _rtl.getShouldEngageMissionForLanding()) {
+					if (!rtl_activated_now && on_mission_landing() && _rtl.getShouldEngageMissionForLanding()) {
 						_mission.set_execution_mode(mission_result_s::MISSION_EXECUTION_MODE_FAST_FORWARD);
 
-						if (!getMissionLandingInProgress() && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED
+						if (!on_mission_landing() && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED
 						    && !get_land_detected()->landed) {
 							start_mission_landing();
 						}

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -669,16 +669,16 @@ void Navigator::run()
 				switch (_rtl.get_rtl_type()) {
 				case RTL::RTL_TYPE_MISSION_LANDING:
 				case RTL::RTL_TYPE_CLOSEST:
-
-					if (!rtl_activated_now && on_mission_landing() && _rtl.getShouldEngageMissionForLanding()) {
+					if (on_mission_landing() && _rtl.getShouldEngageMissionForLanding()) {
 						_mission.set_execution_mode(mission_result_s::MISSION_EXECUTION_MODE_FAST_FORWARD);
 
-						if (!on_mission_landing() && _vstatus.arming_state == vehicle_status_s::ARMING_STATE_ARMED
-						    && !get_land_detected()->landed) {
-							start_mission_landing();
-						}
-
 						navigation_mode_new = &_mission;
+
+						if (rtl_activated_now) {
+							mavlink_log_info(get_mavlink_log_pub(), "RTL to Mission landing, continue landing\t");
+							events::send(events::ID("rtl_land_at_mission_continue_landing"), events::Log::Info,
+								     "RTL to Mission landing, continue landing");
+						}
 
 					} else {
 						navigation_mode_new = &_rtl;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -664,14 +664,13 @@ void Navigator::run()
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL: {
 				_pos_sp_triplet_published_invalid_once = false;
-
-				const bool rtl_activated = _previous_nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+				const bool rtl_activated_now = !_rtl_activated;
 
 				switch (_rtl.get_rtl_type()) {
 				case RTL::RTL_TYPE_MISSION_LANDING:
 				case RTL::RTL_TYPE_CLOSEST:
 
-					if (!rtl_activated && _rtl.getRTLState() > RTL::RTLState::RTL_STATE_LOITER
+					if (!rtl_activated_now && _rtl.getRTLState() > RTL::RTLState::RTL_STATE_LOITER
 					    && _rtl.getShouldEngageMissionForLanding()) {
 						_mission.set_execution_mode(mission_result_s::MISSION_EXECUTION_MODE_FAST_FORWARD);
 
@@ -706,7 +705,7 @@ void Navigator::run()
 							}
 						}
 
-						if (rtl_activated) {
+						if (rtl_activated_now) {
 							mavlink_log_info(get_mavlink_log_pub(), "RTL Mission activated, continue mission\t");
 							events::send(events::ID("navigator_rtl_mission_activated"), events::Log::Info,
 								     "RTL Mission activated, continue mission");
@@ -726,11 +725,11 @@ void Navigator::run()
 							// The seconds condition is required so that when no mission was uploaded and one is available the closest
 							// mission item is determined and also that if the user changes the active mission index while rtl is active
 							// always that waypoint is tracked first.
-							if ((_navigation_mode != &_mission) && (rtl_activated || _mission.get_mission_waypoints_changed())) {
+							if ((_navigation_mode != &_mission) && (rtl_activated_now || _mission.get_mission_waypoints_changed())) {
 								_mission.set_closest_item_as_current();
 							}
 
-							if (rtl_activated) {
+							if (rtl_activated_now) {
 								mavlink_log_info(get_mavlink_log_pub(), "RTL Mission activated, fly mission in reverse\t");
 								events::send(events::ID("navigator_rtl_mission_activated_rev"), events::Log::Info,
 									     "RTL Mission activated, fly mission in reverse");
@@ -739,7 +738,7 @@ void Navigator::run()
 							navigation_mode_new = &_mission;
 
 						} else {
-							if (rtl_activated) {
+							if (rtl_activated_now) {
 								mavlink_log_info(get_mavlink_log_pub(), "RTL Mission activated, fly to home\t");
 								events::send(events::ID("navigator_rtl_mission_activated_home"), events::Log::Info,
 									     "RTL Mission activated, fly to home");
@@ -752,7 +751,7 @@ void Navigator::run()
 					break;
 
 				default:
-					if (rtl_activated) {
+					if (rtl_activated_now) {
 						mavlink_log_info(get_mavlink_log_pub(), "RTL HOME activated\t");
 						events::send(events::ID("navigator_rtl_home_activated"), events::Log::Info, "RTL activated");
 					}
@@ -762,6 +761,7 @@ void Navigator::run()
 
 				}
 
+				_rtl_activated = true;
 				break;
 			}
 
@@ -800,13 +800,14 @@ void Navigator::run()
 			break;
 		}
 
+		if (_vstatus.nav_state != vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
+			_rtl_activated = false;
+		}
+
 		// Do not execute any state machine while we are disarmed
 		if (_vstatus.arming_state != vehicle_status_s::ARMING_STATE_ARMED) {
 			navigation_mode_new = nullptr;
 		}
-
-		// update the vehicle status
-		_previous_nav_state = _vstatus.nav_state;
 
 		/* we have a new navigation mode: reset triplet */
 		if (_navigation_mode != navigation_mode_new) {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -152,7 +152,7 @@ void RTL::find_RTL_destination()
 		double dist_squared = coord_dist_sq(dlat, dlon);
 
 		// always find closest destination if in hover and VTOL
-		if (_param_rtl_type.get() == RTL_TYPE_CLOSEST || (vtol_in_rw_mode && !_navigator->getMissionLandingInProgress())) {
+		if (_param_rtl_type.get() == RTL_TYPE_CLOSEST || (vtol_in_rw_mode && !_navigator->on_mission_landing())) {
 
 			// compare home position to landing position to decide which is closer
 			if (dist_squared < min_dist_squared) {
@@ -281,12 +281,6 @@ void RTL::on_activation()
 	if (_navigator->get_land_detected()->landed) {
 		// For safety reasons don't go into RTL if landed.
 		_rtl_state = RTL_STATE_LANDED;
-
-	} else if ((_destination.type == RTL_DESTINATION_MISSION_LANDING) && _navigator->getMissionLandingInProgress()) {
-		// we were just on a mission landing, set _rtl_state past RTL_STATE_LOITER such that navigator will engage mission mode,
-		// which will continue executing the landing
-		_rtl_state = RTL_STATE_LAND;
-
 
 	} else if ((global_position.alt < _destination.alt + _param_rtl_return_alt.get()) || _rtl_alt_min) {
 


### PR DESCRIPTION
### Solved Problem
Vehicle climbs and follows RTL sequence when already on mission landing (on loiter down).

### Solution
Improve function` Mission::landing() `--> To find out if we're currently on a mission landing, check if we either are past the land start marker OR currently land start marker is current WP ~and vehicle is already in LOITER mode.~, type is LOITER_TO_ALT and vehicle is inside loiter circle. Then it seems to me like we don't need to additional function `Navigator::getMissionLandingInProgress() `anymore, so I removed that. 

### Alternatives
https://github.com/PX4/PX4-Autopilot/pull/20903 will hopefully help us to once and for all make the RTL behavior deterministic and predictable. 

### Test coverage
Tested triggering RTL on a VTOL in SITL in all flight phases of the Mission, and it now only does the whole RTL sequence when outside of the loiter down.

### Context
The previous logic was introduced with https://github.com/PX4/PX4-Autopilot/pull/16377/commits/9677e8486555184b19465d46a08e250dcbdcb814. I didn't find the specifc commit that broke it, maybe it was https://github.com/PX4/PX4-Autopilot/pull/21154.
