### PR TITLE
TECS: if height_rate_setpoint is set, only use that one to update altitude reference

### DIFF
--- a/msg/TecsStatus.msg
+++ b/msg/TecsStatus.msg
@@ -1,7 +1,7 @@
 uint64 timestamp		# time since system start (microseconds)
 
 float32 altitude_sp			# Altitude setpoint AMSL [m]
-float32 altitude_sp_filtered		# Altitude setpoint filtered AMSL [m]
+float32 altitude_sp_ref			# Altitude setpoint reference AMSL [m]
 float32 height_rate_setpoint		# Height rate setpoint [m/s]
 float32 height_rate			# Height rate [m/s]
 float32 equivalent_airspeed_sp		# Equivalent airspeed setpoint [m/s]

--- a/msg/TecsStatus.msg
+++ b/msg/TecsStatus.msg
@@ -1,7 +1,9 @@
 uint64 timestamp		# time since system start (microseconds)
 
 float32 altitude_sp			# Altitude setpoint AMSL [m]
-float32 altitude_sp_ref			# Altitude setpoint reference AMSL [m]
+float32 altitude_reference		# Altitude setpoint reference AMSL [m]
+float32 height_rate_reference		# Height rate setpoint reference [m/s]
+float32 height_rate_direct		# Direct height rate setpoint from velocity reference generator [m/s]
 float32 height_rate_setpoint		# Height rate setpoint [m/s]
 float32 height_rate			# Height rate [m/s]
 float32 equivalent_airspeed_sp		# Equivalent airspeed setpoint [m/s]

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -134,7 +134,7 @@ TECSAirspeedFilter::AirspeedFilterState TECSAirspeedFilter::getState() const
 }
 
 void TECSAltitudeReferenceModel::update(const float dt, const AltitudeReferenceState &setpoint, float altitude,
-					const Param &param)
+					float height_rate, const Param &param)
 {
 	// Input checks
 	if (!TIMESTAMP_VALID(dt)) {
@@ -143,40 +143,55 @@ void TECSAltitudeReferenceModel::update(const float dt, const AltitudeReferenceS
 		return;
 	}
 
-	if (!PX4_ISFINITE(altitude)) {
-		altitude = 0.0f;
-	}
+	const float current_alt = PX4_ISFINITE(altitude) ? altitude : 0.f;
 
-	if (PX4_ISFINITE(setpoint.alt_rate)) {
-		_alt_rate_ref = setpoint.alt_rate;
-
-	} else {
-		_alt_rate_ref = 0.0f;
-	}
+	_velocity_control_traj_generator.setMaxJerk(param.jerk_max);
+	_velocity_control_traj_generator.setMaxAccelUp(param.vert_accel_limit);
+	_velocity_control_traj_generator.setMaxAccelDown(param.vert_accel_limit);
+	_velocity_control_traj_generator.setMaxVelUp(param.max_sink_rate); // different convention for FW than for MC
+	_velocity_control_traj_generator.setMaxVelDown(param.max_climb_rate); // different convention for FW than for MC
 
 	// Altitude setpoint reference
-	const bool altitude_control_enable{PX4_ISFINITE(setpoint.alt)};
 	_alt_control_traj_generator.setMaxJerk(param.jerk_max);
 	_alt_control_traj_generator.setMaxAccel(param.vert_accel_limit);
 	_alt_control_traj_generator.setMaxVel(fmax(param.max_climb_rate, param.max_sink_rate));
 
-	if (altitude_control_enable) {
-		const float target_climbrate = math::min(param.target_climbrate, param.max_climb_rate);
-		const float target_sinkrate = math::min(param.target_sinkrate, param.max_sink_rate);
+	_velocity_control_traj_generator.setVelSpFeedback(setpoint.alt_rate);
 
-		const float delta_trajectory_to_target_m = setpoint.alt - _alt_control_traj_generator.getCurrentPosition();
+	bool control_altitude = true;
+	float altitude_setpoint = setpoint.alt;
 
-		float altitude_rate_target = math::signNoZero<float>(delta_trajectory_to_target_m) *
-					     math::trajectory::computeMaxSpeedFromDistance(
-						     param.jerk_max, param.vert_accel_limit, fabsf(delta_trajectory_to_target_m), 0.0f);
-
-		altitude_rate_target = math::constrain(altitude_rate_target, -target_sinkrate, target_climbrate);
-
-		_alt_control_traj_generator.updateDurations(altitude_rate_target);
-		_alt_control_traj_generator.updateTraj(dt);
+	if (PX4_ISFINITE(setpoint.alt_rate)) {
+		// input is height rate (not altitude)
+		_velocity_control_traj_generator.setCurrentPositionEstimate(current_alt);
+		_velocity_control_traj_generator.update(dt, setpoint.alt_rate);
+		altitude_setpoint = _velocity_control_traj_generator.getCurrentPosition();
+		control_altitude = PX4_ISFINITE(altitude_setpoint); // returns true if altitude is locked
 
 	} else {
-		_alt_control_traj_generator.reset(0.0f, 0.0f, altitude);
+		_velocity_control_traj_generator.reset(0, height_rate, altitude_setpoint);
+	}
+
+	if (control_altitude) {
+		const float target_climbrate_m_s = math::min(param.target_climbrate, param.max_climb_rate);
+		const float target_sinkrate_m_s = math::min(param.target_sinkrate, param.max_sink_rate);
+
+		const float delta_trajectory_to_target_m = altitude_setpoint - _alt_control_traj_generator.getCurrentPosition();
+
+		float height_rate_target = math::signNoZero<float>(delta_trajectory_to_target_m) *
+					   math::trajectory::computeMaxSpeedFromDistance(
+						   param.jerk_max, param.vert_accel_limit, fabsf(delta_trajectory_to_target_m), 0.f);
+
+		height_rate_target = math::constrain(height_rate_target, -target_sinkrate_m_s, target_climbrate_m_s);
+
+		_alt_control_traj_generator.updateDurations(height_rate_target);
+		_alt_control_traj_generator.updateTraj(dt);
+		_height_rate_setpoint_direct = NAN;
+
+	} else {
+		_alt_control_traj_generator.setCurrentVelocity(_velocity_control_traj_generator.getCurrentVelocity());
+		_alt_control_traj_generator.setCurrentPosition(current_alt);
+		_height_rate_setpoint_direct = _velocity_control_traj_generator.getCurrentVelocity();
 	}
 }
 
@@ -190,25 +205,12 @@ TECSAltitudeReferenceModel::AltitudeReferenceState TECSAltitudeReferenceModel::g
 	return ref;
 }
 
-float TECSAltitudeReferenceModel::getAltitudeRateReference() const
-{
-	return _alt_rate_ref;
-}
-
 void TECSAltitudeReferenceModel::initialize(const AltitudeReferenceState &state)
 {
-	float init_state_alt{state.alt};
-	_alt_rate_ref = state.alt_rate;
+	const float init_state_alt = PX4_ISFINITE(state.alt) ? state.alt : 0.f;
+	const float init_state_alt_rate = PX4_ISFINITE(state.alt_rate) ? state.alt_rate : 0.f;
 
-	if (!PX4_ISFINITE(state.alt)) {
-		init_state_alt = 0.0f;
-	}
-
-	if (!PX4_ISFINITE(state.alt_rate)) {
-		_alt_rate_ref = 0.0f;
-	}
-
-	_alt_control_traj_generator.reset(0.0f, _alt_rate_ref, init_state_alt);
+	_alt_control_traj_generator.reset(0.0f, init_state_alt_rate, init_state_alt);
 }
 
 void TECSControl::initialize(const Setpoint &setpoint, const Input &input, Param &param, const Flag &flag)
@@ -245,7 +247,6 @@ void TECSControl::initialize(const Setpoint &setpoint, const Input &input, Param
 	_debug_output.energy_balance_rate_estimate = seb_rate.estimate;
 	_debug_output.energy_balance_rate_sp = seb_rate.setpoint;
 	_debug_output.pitch_integrator = _pitch_integ_state;
-
 	_debug_output.altitude_rate_control = control_setpoint.altitude_rate_setpoint;
 	_debug_output.true_airspeed_derivative_control = control_setpoint.tas_rate_setpoint;
 }
@@ -263,7 +264,14 @@ void TECSControl::update(const float dt, const Setpoint &setpoint, const Input &
 
 	control_setpoint.tas_rate_setpoint = _calcAirspeedControlOutput(setpoint, input, param, flag);
 
-	control_setpoint.altitude_rate_setpoint = _calcAltitudeControlOutput(setpoint, input, param);
+	if (PX4_ISFINITE(setpoint.altitude_rate_setpoint_direct)) {
+		// direct height rate control
+		control_setpoint.altitude_rate_setpoint = setpoint.altitude_rate_setpoint_direct;
+
+	} else {
+		// altitude is locked, go through altitude outer loop
+		control_setpoint.altitude_rate_setpoint = _calcAltitudeControlOutput(setpoint, input, param);
+	}
 
 	SpecificEnergyRates specific_energy_rate{_calcSpecificEnergyRates(control_setpoint, input)};
 
@@ -313,8 +321,9 @@ float TECSControl::_calcAirspeedControlOutput(const Setpoint &setpoint, const In
 float TECSControl::_calcAltitudeControlOutput(const Setpoint &setpoint, const Input &input, const Param &param) const
 {
 	float altitude_rate_output;
-	altitude_rate_output = (setpoint.altitude_reference.alt - input.altitude) * param.altitude_error_gain +
-			       param.altitude_setpoint_gain_ff * setpoint.altitude_reference.alt_rate + setpoint.altitude_rate_setpoint;
+	altitude_rate_output = (setpoint.altitude_reference.alt - input.altitude) * param.altitude_error_gain
+			       + param.altitude_setpoint_gain_ff * setpoint.altitude_reference.alt_rate;
+
 	altitude_rate_output = math::constrain(altitude_rate_output, -param.max_sink_rate, param.max_climb_rate);
 
 	return altitude_rate_output;
@@ -633,14 +642,15 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 		      const float eas_to_tas)
 {
 	// Init subclasses
-	TECSAltitudeReferenceModel::AltitudeReferenceState current_state{	.alt = altitude,
+	TECSAltitudeReferenceModel::AltitudeReferenceState current_state{.alt = altitude,
 			.alt_rate = altitude_rate};
 	_altitude_reference_model.initialize(current_state);
 	_airspeed_filter.initialize(equivalent_airspeed);
 
 	TECSControl::Setpoint control_setpoint;
 	control_setpoint.altitude_reference = _altitude_reference_model.getAltitudeReference();
-	control_setpoint.altitude_rate_setpoint = _altitude_reference_model.getAltitudeRateReference();
+	control_setpoint.altitude_rate_setpoint_direct =
+		_altitude_reference_model.getAltitudeReference().alt_rate; // init to reference altitude rate
 	control_setpoint.tas_setpoint = equivalent_airspeed * eas_to_tas;
 
 	const TECSControl::Input control_input{ .altitude = altitude,
@@ -654,9 +664,9 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 	_debug_status.control = _control.getDebugOutput();
 	_debug_status.true_airspeed_filtered = eas_to_tas * _airspeed_filter.getState().speed;
 	_debug_status.true_airspeed_derivative = eas_to_tas * _airspeed_filter.getState().speed_rate;
-	_debug_status.altitude_sp_ref = _altitude_reference_model.getAltitudeReference().alt;
-	_debug_status.altitude_rate_alt_ref = _altitude_reference_model.getAltitudeReference().alt_rate;
-	_debug_status.altitude_rate_feedforward = _altitude_reference_model.getAltitudeRateReference();
+	_debug_status.altitude_reference = _altitude_reference_model.getAltitudeReference().alt;
+	_debug_status.height_rate_reference = _altitude_reference_model.getAltitudeReference().alt_rate;
+	_debug_status.height_rate_direct = _altitude_reference_model.getHeightRateSetpointDirect();
 
 	_update_timestamp = hrt_absolute_time();
 }
@@ -704,11 +714,11 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 		const TECSAltitudeReferenceModel::AltitudeReferenceState setpoint{ .alt = hgt_setpoint,
 				.alt_rate = hgt_rate_sp};
 
-		_altitude_reference_model.update(dt, setpoint, altitude, _reference_param);
+		_altitude_reference_model.update(dt, setpoint, altitude, hgt_rate, _reference_param);
 
 		TECSControl::Setpoint control_setpoint;
 		control_setpoint.altitude_reference = _altitude_reference_model.getAltitudeReference();
-		control_setpoint.altitude_rate_setpoint = _altitude_reference_model.getAltitudeRateReference();
+		control_setpoint.altitude_rate_setpoint_direct = _altitude_reference_model.getHeightRateSetpointDirect();
 
 		// Calculate the demanded true airspeed
 		// TODO this function should not be in the module. Only give feedback that the airspeed can't be achieved.
@@ -739,9 +749,9 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 		_debug_status.control = _control.getDebugOutput();
 		_debug_status.true_airspeed_filtered = eas_to_tas * eas.speed;
 		_debug_status.true_airspeed_derivative = eas_to_tas * eas.speed_rate;
-		_debug_status.altitude_sp_ref = control_setpoint.altitude_reference.alt;
-		_debug_status.altitude_rate_alt_ref = control_setpoint.altitude_reference.alt_rate;
-		_debug_status.altitude_rate_feedforward = control_setpoint.altitude_rate_setpoint;
+		_debug_status.altitude_reference = control_setpoint.altitude_reference.alt;
+		_debug_status.height_rate_reference = control_setpoint.altitude_reference.alt_rate;
+		_debug_status.height_rate_direct = _altitude_reference_model.getHeightRateSetpointDirect();
 	}
 }
 

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -652,12 +652,10 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 
 	_debug_status.tecs_mode = _tecs_mode;
 	_debug_status.control = _control.getDebugOutput();
-	const TECSAirspeedFilter::AirspeedFilterState eas = _airspeed_filter.getState();
-	_debug_status.true_airspeed_filtered = eas_to_tas * eas.speed;
-	_debug_status.true_airspeed_derivative = eas_to_tas * eas.speed_rate;
-	const TECSAltitudeReferenceModel::AltitudeReferenceState ref_alt{_altitude_reference_model.getAltitudeReference()};
-	_debug_status.altitude_sp_ref = ref_alt.alt;
-	_debug_status.altitude_rate_alt_ref = ref_alt.alt_rate;
+	_debug_status.true_airspeed_filtered = eas_to_tas * _airspeed_filter.getState().speed;
+	_debug_status.true_airspeed_derivative = eas_to_tas * _airspeed_filter.getState().speed_rate;
+	_debug_status.altitude_sp_ref = _altitude_reference_model.getAltitudeReference().alt;
+	_debug_status.altitude_rate_alt_ref = _altitude_reference_model.getAltitudeReference().alt_rate;
 	_debug_status.altitude_rate_feedforward = _altitude_reference_model.getAltitudeRateReference();
 
 	_update_timestamp = hrt_absolute_time();

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -133,8 +133,8 @@ TECSAirspeedFilter::AirspeedFilterState TECSAirspeedFilter::getState() const
 	return _airspeed_state;
 }
 
-void TECSReferenceModel::update(const float dt, const AltitudeReferenceState &setpoint, float altitude,
-				const Param &param)
+void TECSAltitudeReferenceModel::update(const float dt, const AltitudeReferenceState &setpoint, float altitude,
+					const Param &param)
 {
 	// Input checks
 	if (!TIMESTAMP_VALID(dt)) {
@@ -147,14 +147,12 @@ void TECSReferenceModel::update(const float dt, const AltitudeReferenceState &se
 		altitude = 0.0f;
 	}
 
-	// Consider the altitude rate setpoint already smooth. No need to filter further, simply hold the value for the altitude rate reference.
 	if (PX4_ISFINITE(setpoint.alt_rate)) {
 		_alt_rate_ref = setpoint.alt_rate;
 
 	} else {
 		_alt_rate_ref = 0.0f;
 	}
-
 
 	// Altitude setpoint reference
 	const bool altitude_control_enable{PX4_ISFINITE(setpoint.alt)};
@@ -182,9 +180,9 @@ void TECSReferenceModel::update(const float dt, const AltitudeReferenceState &se
 	}
 }
 
-TECSReferenceModel::AltitudeReferenceState TECSReferenceModel::getAltitudeReference() const
+TECSAltitudeReferenceModel::AltitudeReferenceState TECSAltitudeReferenceModel::getAltitudeReference() const
 {
-	TECSReferenceModel::AltitudeReferenceState ref{
+	TECSAltitudeReferenceModel::AltitudeReferenceState ref{
 		.alt = _alt_control_traj_generator.getCurrentPosition(),
 		.alt_rate = _alt_control_traj_generator.getCurrentVelocity(),
 	};
@@ -192,12 +190,12 @@ TECSReferenceModel::AltitudeReferenceState TECSReferenceModel::getAltitudeRefere
 	return ref;
 }
 
-float TECSReferenceModel::getAltitudeRateReference() const
+float TECSAltitudeReferenceModel::getAltitudeRateReference() const
 {
 	return _alt_rate_ref;
 }
 
-void TECSReferenceModel::initialize(const AltitudeReferenceState &state)
+void TECSAltitudeReferenceModel::initialize(const AltitudeReferenceState &state)
 {
 	float init_state_alt{state.alt};
 	_alt_rate_ref = state.alt_rate;
@@ -635,7 +633,7 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 		      const float eas_to_tas)
 {
 	// Init subclasses
-	TECSReferenceModel::AltitudeReferenceState current_state{	.alt = altitude,
+	TECSAltitudeReferenceModel::AltitudeReferenceState current_state{	.alt = altitude,
 			.alt_rate = altitude_rate};
 	_reference_model.initialize(current_state);
 	_airspeed_filter.initialize(equivalent_airspeed);
@@ -657,7 +655,7 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 	const TECSAirspeedFilter::AirspeedFilterState eas = _airspeed_filter.getState();
 	_debug_status.true_airspeed_filtered = eas_to_tas * eas.speed;
 	_debug_status.true_airspeed_derivative = eas_to_tas * eas.speed_rate;
-	const TECSReferenceModel::AltitudeReferenceState ref_alt{_reference_model.getAltitudeReference()};
+	const TECSAltitudeReferenceModel::AltitudeReferenceState ref_alt{_reference_model.getAltitudeReference()};
 	_debug_status.altitude_sp_ref = ref_alt.alt;
 	_debug_status.altitude_rate_alt_ref = ref_alt.alt_rate;
 	_debug_status.altitude_rate_feedforward = _reference_model.getAltitudeRateReference();
@@ -705,7 +703,7 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 		const TECSAirspeedFilter::AirspeedFilterState eas = _airspeed_filter.getState();
 
 		// Update Reference model submodule
-		const TECSReferenceModel::AltitudeReferenceState setpoint{ .alt = hgt_setpoint,
+		const TECSAltitudeReferenceModel::AltitudeReferenceState setpoint{ .alt = hgt_setpoint,
 				.alt_rate = hgt_rate_sp};
 
 		_reference_model.update(dt, setpoint, altitude, _reference_param);

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -635,12 +635,12 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 	// Init subclasses
 	TECSAltitudeReferenceModel::AltitudeReferenceState current_state{	.alt = altitude,
 			.alt_rate = altitude_rate};
-	_reference_model.initialize(current_state);
+	_altitude_reference_model.initialize(current_state);
 	_airspeed_filter.initialize(equivalent_airspeed);
 
 	TECSControl::Setpoint control_setpoint;
-	control_setpoint.altitude_reference = _reference_model.getAltitudeReference();
-	control_setpoint.altitude_rate_setpoint = _reference_model.getAltitudeRateReference();
+	control_setpoint.altitude_reference = _altitude_reference_model.getAltitudeReference();
+	control_setpoint.altitude_rate_setpoint = _altitude_reference_model.getAltitudeRateReference();
 	control_setpoint.tas_setpoint = equivalent_airspeed * eas_to_tas;
 
 	const TECSControl::Input control_input{ .altitude = altitude,
@@ -655,10 +655,10 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 	const TECSAirspeedFilter::AirspeedFilterState eas = _airspeed_filter.getState();
 	_debug_status.true_airspeed_filtered = eas_to_tas * eas.speed;
 	_debug_status.true_airspeed_derivative = eas_to_tas * eas.speed_rate;
-	const TECSAltitudeReferenceModel::AltitudeReferenceState ref_alt{_reference_model.getAltitudeReference()};
+	const TECSAltitudeReferenceModel::AltitudeReferenceState ref_alt{_altitude_reference_model.getAltitudeReference()};
 	_debug_status.altitude_sp_ref = ref_alt.alt;
 	_debug_status.altitude_rate_alt_ref = ref_alt.alt_rate;
-	_debug_status.altitude_rate_feedforward = _reference_model.getAltitudeRateReference();
+	_debug_status.altitude_rate_feedforward = _altitude_reference_model.getAltitudeRateReference();
 
 	_update_timestamp = hrt_absolute_time();
 }
@@ -706,11 +706,11 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 		const TECSAltitudeReferenceModel::AltitudeReferenceState setpoint{ .alt = hgt_setpoint,
 				.alt_rate = hgt_rate_sp};
 
-		_reference_model.update(dt, setpoint, altitude, _reference_param);
+		_altitude_reference_model.update(dt, setpoint, altitude, _reference_param);
 
 		TECSControl::Setpoint control_setpoint;
-		control_setpoint.altitude_reference = _reference_model.getAltitudeReference();
-		control_setpoint.altitude_rate_setpoint = _reference_model.getAltitudeRateReference();
+		control_setpoint.altitude_reference = _altitude_reference_model.getAltitudeReference();
+		control_setpoint.altitude_rate_setpoint = _altitude_reference_model.getAltitudeRateReference();
 
 		// Calculate the demanded true airspeed
 		// TODO this function should not be in the module. Only give feedback that the airspeed can't be achieved.

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -641,7 +641,7 @@ public:
 				.alt_rate = altitude_rate};
 
 		// reset altitude reference model.
-		_reference_model.initialize(init_state);
+		_altitude_reference_model.initialize(init_state);
 	}
 
 	float get_pitch_setpoint() {return _control.getPitchSetpoint();}
@@ -651,9 +651,9 @@ public:
 	ECL_TECS_MODE tecs_mode() { return _tecs_mode; }
 
 private:
-	TECSControl 		_control;				///< Control submodule.
-	TECSAirspeedFilter 	_airspeed_filter;			///< Airspeed filter submodule.
-	TECSAltitudeReferenceModel 	_reference_model;			///< Setpoint reference model submodule.
+	TECSControl 			_control;			///< Control submodule.
+	TECSAirspeedFilter 		_airspeed_filter;		///< Airspeed filter submodule.
+	TECSAltitudeReferenceModel 	_altitude_reference_model;	///< Setpoint reference model submodule.
 
 	enum ECL_TECS_MODE _tecs_mode {ECL_TECS_MODE_NORMAL};		///< Current activated mode.
 

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -155,9 +155,10 @@ public:
 	 * @param[in] dt is the update interval in [s].
 	 * @param[in] setpoint are the desired setpoints.
 	 * @param[in] altitude is the altitude amsl in [m].
+	 * @param[in] height_rate is the height rate setpoint in [m/s].
 	 * @param[in] param are the reference model parameters.
 	 */
-	void update(float dt, const AltitudeReferenceState &setpoint, float altitude, const Param &param);
+	void update(float dt, const AltitudeReferenceState &setpoint, float altitude, float height_rate, const Param &param);
 
 	/**
 	 * @brief Get the current altitude reference of altitude reference model.
@@ -167,17 +168,20 @@ public:
 	AltitudeReferenceState getAltitudeReference() const;
 
 	/**
-	 * @brief Get the altitude rate reference of the altitude rate reference model.
+	 * @brief Get the Height Rate Setpoint directly from the velocity trajector generator
 	 *
-	 * @return Current altitude rate reference point.
+	 * @return float direct height rate setpoint [m/s]
 	 */
-	float getAltitudeRateReference() const;
+	float getHeightRateSetpointDirect() const {return _height_rate_setpoint_direct; }
+
 
 private:
 	// State
 	VelocitySmoothing
 	_alt_control_traj_generator;		///< Generates altitude rate and altitude setpoint trajectory when altitude is commanded.
-	float _alt_rate_ref; 			///< Altitude rate reference in [m/s].
+	ManualVelocitySmoothingZ
+	_velocity_control_traj_generator;	///< generates height rate trajectory when height rate is commanded
+	float _height_rate_setpoint_direct{NAN}; ///< generated direct height rate setpoint
 };
 
 class TECSControl
@@ -249,7 +253,7 @@ public:
 	 */
 	struct Setpoint {
 		TECSAltitudeReferenceModel::AltitudeReferenceState altitude_reference;	///< Altitude/height rate reference.
-		float altitude_rate_setpoint;					///< Altitude rate setpoint.
+		float altitude_rate_setpoint_direct;					///< Direct height rate setpoint.
 		float tas_setpoint;						///< True airspeed setpoint.
 	};
 
@@ -543,9 +547,9 @@ public:
 		TECSControl::DebugOutput control;
 		float true_airspeed_filtered;
 		float true_airspeed_derivative;
-		float altitude_sp_ref;
-		float altitude_rate_alt_ref;
-		float altitude_rate_feedforward;
+		float altitude_reference;
+		float height_rate_reference;
+		float height_rate_direct;
 		enum ECL_TECS_MODE tecs_mode;
 	};
 public:

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -248,7 +248,7 @@ public:
 	 *
 	 */
 	struct Setpoint {
-		TECSAltitudeReferenceModel::AltitudeReferenceState altitude_reference;	///< Altitude reference from reference model.
+		TECSAltitudeReferenceModel::AltitudeReferenceState altitude_reference;	///< Altitude/height rate reference.
 		float altitude_rate_setpoint;					///< Altitude rate setpoint.
 		float tas_setpoint;						///< True airspeed setpoint.
 	};

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -113,7 +113,7 @@ private:
 	AirspeedFilterState _airspeed_state{.speed = 0.0f, .speed_rate = 0.0f};	///< Complimentary filter state
 };
 
-class TECSReferenceModel
+class TECSAltitudeReferenceModel
 {
 public:
 	/**
@@ -139,8 +139,8 @@ public:
 	};
 
 public:
-	TECSReferenceModel() = default;
-	~TECSReferenceModel() = default;
+	TECSAltitudeReferenceModel() = default;
+	~TECSAltitudeReferenceModel() = default;
 
 	/**
 	 * @brief Initialize reference models.
@@ -248,7 +248,7 @@ public:
 	 *
 	 */
 	struct Setpoint {
-		TECSReferenceModel::AltitudeReferenceState altitude_reference;	///< Altitude reference from reference model.
+		TECSAltitudeReferenceModel::AltitudeReferenceState altitude_reference;	///< Altitude reference from reference model.
 		float altitude_rate_setpoint;					///< Altitude rate setpoint.
 		float tas_setpoint;						///< True airspeed setpoint.
 	};
@@ -637,7 +637,7 @@ public:
 	 */
 	void handle_alt_step(float altitude, float altitude_rate)
 	{
-		TECSReferenceModel::AltitudeReferenceState init_state{ .alt = altitude,
+		TECSAltitudeReferenceModel::AltitudeReferenceState init_state{ .alt = altitude,
 				.alt_rate = altitude_rate};
 
 		// reset altitude reference model.
@@ -653,7 +653,7 @@ public:
 private:
 	TECSControl 		_control;				///< Control submodule.
 	TECSAirspeedFilter 	_airspeed_filter;			///< Airspeed filter submodule.
-	TECSReferenceModel 	_reference_model;			///< Setpoint reference model submodule.
+	TECSAltitudeReferenceModel 	_reference_model;			///< Setpoint reference model submodule.
 
 	enum ECL_TECS_MODE _tecs_mode {ECL_TECS_MODE_NORMAL};		///< Current activated mode.
 
@@ -676,7 +676,7 @@ private:
 		.airspeed_rate_noise_std_dev = 0.02f
 	};
 	/// Reference model parameters.
-	TECSReferenceModel::Param _reference_param{
+	TECSAltitudeReferenceModel::Param _reference_param{
 		.target_climbrate = 2.0f,
 		.target_sinkrate = 2.0f,
 		.jerk_max = 1000.0f,

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -483,7 +483,9 @@ FixedwingPositionControl::tecs_status_publish(float alt_sp, float equivalent_air
 	}
 
 	tecs_status.altitude_sp = alt_sp;
-	tecs_status.altitude_sp_ref = debug_output.altitude_sp_ref;
+	tecs_status.altitude_reference = debug_output.altitude_reference;
+	tecs_status.height_rate_reference = debug_output.height_rate_reference;
+	tecs_status.height_rate_direct = debug_output.height_rate_direct;
 	tecs_status.height_rate_setpoint = debug_output.control.altitude_rate_control;
 	tecs_status.height_rate = -_local_pos.vz;
 	tecs_status.equivalent_airspeed_sp = equivalent_airspeed_sp;

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -468,43 +468,43 @@ void
 FixedwingPositionControl::tecs_status_publish(float alt_sp, float equivalent_airspeed_sp,
 		float true_airspeed_derivative_raw, float throttle_trim)
 {
-	tecs_status_s t{};
+	tecs_status_s tecs_status{};
 
 	const TECS::DebugOutput &debug_output{_tecs.getStatus()};
 
 	switch (_tecs.tecs_mode()) {
 	case TECS::ECL_TECS_MODE_NORMAL:
-		t.mode = tecs_status_s::TECS_MODE_NORMAL;
+		tecs_status.mode = tecs_status_s::TECS_MODE_NORMAL;
 		break;
 
 	case TECS::ECL_TECS_MODE_UNDERSPEED:
-		t.mode = tecs_status_s::TECS_MODE_UNDERSPEED;
+		tecs_status.mode = tecs_status_s::TECS_MODE_UNDERSPEED;
 		break;
 	}
 
-	t.altitude_sp = alt_sp;
-	t.altitude_sp_filtered = debug_output.altitude_sp_ref;
-	t.height_rate_setpoint = debug_output.control.altitude_rate_control;
-	t.height_rate = -_local_pos.vz;
-	t.equivalent_airspeed_sp = equivalent_airspeed_sp;
-	t.true_airspeed_sp = _eas2tas * equivalent_airspeed_sp;
-	t.true_airspeed_filtered = debug_output.true_airspeed_filtered;
-	t.true_airspeed_derivative_sp = debug_output.control.true_airspeed_derivative_control;
-	t.true_airspeed_derivative = debug_output.true_airspeed_derivative;
-	t.true_airspeed_derivative_raw = true_airspeed_derivative_raw;
-	t.total_energy_rate = debug_output.control.total_energy_rate_estimate;
-	t.total_energy_balance_rate = debug_output.control.energy_balance_rate_estimate;
-	t.total_energy_rate_sp = debug_output.control.total_energy_rate_sp;
-	t.total_energy_balance_rate_sp = debug_output.control.energy_balance_rate_sp;
-	t.throttle_integ = debug_output.control.throttle_integrator;
-	t.pitch_integ = debug_output.control.pitch_integrator;
-	t.throttle_sp = _tecs.get_throttle_setpoint();
-	t.pitch_sp_rad = _tecs.get_pitch_setpoint();
-	t.throttle_trim = throttle_trim;
+	tecs_status.altitude_sp = alt_sp;
+	tecs_status.altitude_sp_filtered = debug_output.altitude_sp_ref;
+	tecs_status.height_rate_setpoint = debug_output.control.altitude_rate_control;
+	tecs_status.height_rate = -_local_pos.vz;
+	tecs_status.equivalent_airspeed_sp = equivalent_airspeed_sp;
+	tecs_status.true_airspeed_sp = _eas2tas * equivalent_airspeed_sp;
+	tecs_status.true_airspeed_filtered = debug_output.true_airspeed_filtered;
+	tecs_status.true_airspeed_derivative_sp = debug_output.control.true_airspeed_derivative_control;
+	tecs_status.true_airspeed_derivative = debug_output.true_airspeed_derivative;
+	tecs_status.true_airspeed_derivative_raw = true_airspeed_derivative_raw;
+	tecs_status.total_energy_rate = debug_output.control.total_energy_rate_estimate;
+	tecs_status.total_energy_balance_rate = debug_output.control.energy_balance_rate_estimate;
+	tecs_status.total_energy_rate_sp = debug_output.control.total_energy_rate_sp;
+	tecs_status.total_energy_balance_rate_sp = debug_output.control.energy_balance_rate_sp;
+	tecs_status.throttle_integ = debug_output.control.throttle_integrator;
+	tecs_status.pitch_integ = debug_output.control.pitch_integrator;
+	tecs_status.throttle_sp = _tecs.get_throttle_setpoint();
+	tecs_status.pitch_sp_rad = _tecs.get_pitch_setpoint();
+	tecs_status.throttle_trim = throttle_trim;
 
-	t.timestamp = hrt_absolute_time();
+	tecs_status.timestamp = hrt_absolute_time();
 
-	_tecs_status_pub.publish(t);
+	_tecs_status_pub.publish(tecs_status);
 }
 
 void

--- a/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
+++ b/src/modules/fw_path_navigation/FixedwingPositionControl.cpp
@@ -483,7 +483,7 @@ FixedwingPositionControl::tecs_status_publish(float alt_sp, float equivalent_air
 	}
 
 	tecs_status.altitude_sp = alt_sp;
-	tecs_status.altitude_sp_filtered = debug_output.altitude_sp_ref;
+	tecs_status.altitude_sp_ref = debug_output.altitude_sp_ref;
 	tecs_status.height_rate_setpoint = debug_output.control.altitude_rate_control;
 	tecs_status.height_rate = -_local_pos.vz;
 	tecs_status.equivalent_airspeed_sp = equivalent_airspeed_sp;


### PR DESCRIPTION
### Solved Problem
https://github.com/PX4/PX4-Autopilot/pull/21189#issuecomment-1487220075

This reverts the logic to how it was before the TECS refactoring. Not saying it has to stay that way.
