### PR TITLE
Allow yawing during hold

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -109,6 +109,8 @@ protected:
 	bool isTargetModified() const;
 	void _updateTrajConstraints();
 
+	void rcHelpModifyYaw(float &yaw_sp);
+
 	/** determines when to trigger a takeoff (ignored in flight) */
 	bool _checkTakeoff() override { return _want_takeoff; };
 


### PR DESCRIPTION
Allow the operator of a multirotor to yaw the vehicle in hold mode without switching to position mode if RC help is active and RC override is disabled.

### Test coverage
SITL jmavsim

### Context
Related links, screenshot before/after, video
