### PR TITLE
gazebo_tailsitter: disable multi-EKF for replayable logs

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -44,6 +44,12 @@ param set-default PWM_MAIN_FUNC6 201
 param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_REV 96 # invert both elevons
 
+# Single-EKF (for replay)
+param set-default EKF2_MULTI_IMU 0
+param set-default SENS_IMU_MODE 1
+param set-default EKF2_MULTI_MAG 0
+param set-default SENS_MAG_MODE 1
+
 param set-default NPFG_PERIOD 12
 param set-default FW_PR_I 0.2
 param set-default FW_PR_P 0.2


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The tailsitter CI is still sometimes failing due to a bad initial orientation (see https://logs.px4.io/plot_app?log=4682a45f-0c63-4ec6-9f86-349a237a3d45).
I didn't find what caused it and a replay log would be useful.
