### PR TITLE
gazebo airframes: cleanup and fix missing parameters

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4002_gz_x500_depth
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4002_gz_x500_depth
@@ -5,50 +5,6 @@
 # @type Quadrotor
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
-PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_depth}
 
-param set-default SIM_GZ_EN 1
-
-param set-default SENS_EN_GPSSIM 1
-param set-default SENS_EN_BAROSIM 0
-param set-default SENS_EN_MAGSIM 1
-
-param set-default CA_AIRFRAME 0
-param set-default CA_ROTOR_COUNT 4
-
-param set-default CA_ROTOR0_PX 0.13
-param set-default CA_ROTOR0_PY 0.22
-param set-default CA_ROTOR0_KM  0.05
-
-param set-default CA_ROTOR1_PX -0.13
-param set-default CA_ROTOR1_PY -0.20
-param set-default CA_ROTOR1_KM  0.05
-
-param set-default CA_ROTOR2_PX 0.13
-param set-default CA_ROTOR2_PY -0.22
-param set-default CA_ROTOR2_KM -0.05
-
-param set-default CA_ROTOR3_PX -0.13
-param set-default CA_ROTOR3_PY 0.20
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default SIM_GZ_EC_FUNC1 101
-param set-default SIM_GZ_EC_FUNC2 102
-param set-default SIM_GZ_EC_FUNC3 103
-param set-default SIM_GZ_EC_FUNC4 104
-
-param set-default SIM_GZ_EC_MIN1 150
-param set-default SIM_GZ_EC_MIN2 150
-param set-default SIM_GZ_EC_MIN3 150
-param set-default SIM_GZ_EC_MIN4 150
-
-param set-default SIM_GZ_EC_MAX1 1000
-param set-default SIM_GZ_EC_MAX2 1000
-param set-default SIM_GZ_EC_MAX3 1000
-param set-default SIM_GZ_EC_MAX4 1000
-
-param set-default MPC_THR_HOVER 0.60
+. ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
@@ -10,6 +10,8 @@ PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
 PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=rc_cessna}
 
+param set-default SIM_GZ_EN 1
+
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -11,6 +11,8 @@ PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
 PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=standard_vtol}
 
+param set-default SIM_GZ_EN 1
+
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4005_gz_x500_vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4005_gz_x500_vision
@@ -5,8 +5,6 @@
 # @type Quadrotor
 #
 
-. ${R}etc/init.d-posix/airframes/4001_gz_x500
-
-PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
-PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_vision}
+
+. ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/Tools/simulation/gz/models/x500_depth/model.sdf
+++ b/Tools/simulation/gz/models/x500_depth/model.sdf
@@ -2,7 +2,7 @@
 <sdf version='1.9'>
   <model name='x500-Depth'>
     <include merge='true'>
-      <uri>https://fuel.gazebosim.org/1.0/RudisLaboratories/models/x500-Base</uri>
+      <uri>x500</uri>
     </include>
     <include merge='true'>
       <uri>https://fuel.gazebosim.org/1.0/RudisLaboratories/models/OakD-Lite</uri>


### PR DESCRIPTION
## Problems solved

1. The Gazebo model `x500_depth` uses `https://fuel.gazebosim.org/1.0/RudisLaboratories/models/x500-Base` as base model and attaches to it the depth camera.
   1. This is not consisten with #21285.
   2. More importantly, that base model does not include the `air_pressure` sensor which leads to `Preflight Fail: barometer 0 missing` warnings.
2. The sitl airframe `4002_gz_x500_depth` is entirely coping `4001_gz_x500` with just `PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_depth}` (the SIM_MODEL name) as difference.
3. The sitl airframe `4005_gz_x500_vision` first includes `4001_gz_x500` and then set (only if they are not already set) the simulator/model specific environment variables:

   ```sh
   PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
   PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
   PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_vision}
   ```
   However `PX4_SIM_MODEL` is already defined in `4001_gz_x500` and therefore it's final value remains `x500` instead of `x500_vision`.
4. In both `4003_gz_rc_cessna` and `4004_gz_standard_vtol` the default value fo `SIM_GZ_EN` is not set to `1`.

## Proposed solutions

1. Similarly to `x500_vision`, now `x500_depth` uses the PX4 version of `x500` which includes the `air_pressure` sensor.
2. Similarly to `4005_gz_x500_vision`, now `4002_gz_x500_depth` just includes `4001_gz_x500`.
3. Move the environment variable assignment before the inclusion of `4001_gz_x500`. As cleanup, remove setting the world and simulator as they are taken care by `4001_gz_x500`.
4. Add `param set-default SIM_GZ_EN 1`.

## To reproduce the problems

1. From the `main` branch, just launch the Gazebo simulation

   ```sh
   make px4_sitl gz_x500_depth
   ```
   the PX4 console will show the warnings:
   ![Screenshot from 2023-03-31 14-41-40](https://user-images.githubusercontent.com/38298699/229248509-e165e03e-4ccb-4847-a965-ed23499ed63d.png)

2. Item 2 is just cleanup.
3. The issue can be seen when the simulation is manualy started using only the autostart id as parameter:

   ```sh
   PX4_SYS_AUTOSTART=4005 ./build/px4_sitl_default/bin/px4
   ```
   Instead of spawning `x500_vision_0` it will spawn a normal `x500_0`:   
   ![Screenshot from 2023-03-31 15-16-56](https://user-images.githubusercontent.com/38298699/229248601-f790d376-85e4-4fbc-8a7d-8d0f4c03c2ec.png)

4. From the `main` branch, just launch the Gazebo simulation

   ```sh
   make px4_sitl gz_rc_cessna # gz_standard_vtol works too
   ```
   Then open QGC and navigate to the Actuator menu, it won't show the GZ_SIM outputs   
   ![Screenshot from 2023-03-31 15-46-20](https://user-images.githubusercontent.com/38298699/229248643-c22c5564-9b59-4865-8828-0e442d740703.png)

## Expected results after the PR

1. Launching `4001_gz_x500` should not issue any warning.
2. Item 2 is just cleanup.
3. `x500_vision_0` is spawn.
4. The Actuator menu shows the GZ_SIM outputs:
   ![Screenshot from 2023-03-31 15-48-54](https://user-images.githubusercontent.com/38298699/229248672-afa2278d-c690-428f-9141-0ba41c70841c.png)
