### PR TITLE
Holibro qav250 airframe: fix PWM_MAIN_TIM0 value

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -58,8 +58,6 @@ param set-default CA_ROTOR3_PX -0.15
 param set-default CA_ROTOR3_PY 0.15
 param set-default CA_ROTOR3_KM -0.05
 
-param set-default PWM_MAIN_TIM0 0
-
 param set-default PWM_MAIN_FUNC1 101
 param set-default PWM_MAIN_FUNC2 102
 param set-default PWM_MAIN_FUNC3 103


### PR DESCRIPTION
## Problem Solved

`PWM_MAIN_TIM0 = 0` is an invalid value:
![Screenshot from 2023-04-01 10-31-03](https://user-images.githubusercontent.com/38298699/229306997-df8004d8-00c5-4fdc-ae1c-0d147ff7bfa7.png)

## Solution

Remove that line and so that the default value `400` is used.