### PR TITLE
Speed reset when switching flight modes

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -65,6 +65,9 @@ Land::on_activation()
 	_navigator->set_can_loiter_at_sp(false);
 
 	_navigator->set_position_setpoint_triplet_updated();
+
+	// reset cruising speed to default
+	_navigator->reset_cruising_speed();
 }
 
 void

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -63,6 +63,9 @@ Loiter::on_activation()
 	} else {
 		set_loiter_position();
 	}
+
+	// reset cruising speed to default
+	_navigator->reset_cruising_speed();
 }
 
 void

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -210,6 +210,9 @@ Mission::on_activation()
 	cmd.param1 = -1.0f;
 	cmd.param3 = 0.0f;
 	_navigator->publish_vehicle_cmd(&cmd);
+
+	// reset cruise speed
+	_navigator->reset_cruising_speed();
 }
 
 void

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -106,6 +106,7 @@ PrecLand::on_activation()
 	switch_to_state_start();
 
 	_is_activated = true;
+
 }
 
 void

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -106,7 +106,6 @@ PrecLand::on_activation()
 	switch_to_state_start();
 
 	_is_activated = true;
-
 }
 
 void

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -300,7 +300,7 @@ void RTL::on_activation()
 	}
 
 	// reset cruising speed and throttle to default for RTL
-	_navigator->set_cruising_speed();
+	_navigator->reset_cruising_speed();
 	_navigator->set_cruising_throttle();
 
 	set_rtl_item();

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -51,6 +51,9 @@ void
 Takeoff::on_activation()
 {
 	set_takeoff_position();
+
+	// reset cruising speed to default
+	_navigator->reset_cruising_speed();
 }
 
 void


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When I issued a DO_CHANGE_SPEED, and then changed flight modes, that speed continued over to the new flight mode. 
For example, if I issue a DO_CHANGE_SPEED in mission mode for 1 m/s, and then switch to Loiter mode, I am still restricted to 1 m/s.

From the conversations that I have had with maintainers, this is not the behavior we want to have

The only flight mode that this **does not** happen for is RTL, which has the following line
`_navigator->reset_cruising_speed();`


### Solution
I reset the cruising speed upon entering a new navigation mode.

### Alternatives
We could also create a new module that keeps track of what mode we are in and changes speed limits from there

### Test coverage
- Create a waypoint mission with a change speed waypoint item at 1 m/s. Mid-mission flip to HOLD mode and issue a do_relocate. 
Before the change: [log](https://review.px4.io/plot_app?log=784a1777-8dff-446c-989e-8bf3cc0210ec)
![image](https://user-images.githubusercontent.com/16963678/229414814-126a9520-6e09-45c8-9e83-ca82b665525d.png)

After the change: [log](https://review.px4.io/plot_app?log=015494ff-ad95-498b-bfd3-b59632db3525)
![image](https://user-images.githubusercontent.com/16963678/229414936-f46b1814-8105-4f38-a5c5-cfbb1b980273.png)

