### PR TITLE
drivers/gps: increase stack

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -105,7 +105,7 @@ struct GPS_Sat_Info {
 	satellite_info_s _data;
 };
 
-static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1760);
+static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1990);
 
 
 class GPS : public ModuleBase<GPS>, public device::Device


### PR DESCRIPTION
### Solved Problem
When GPS_DUMP is used, more stuff is streamed, and the gps driver reports low on stack. Actually had stack at 1940 on a private repo and still saw the low on stack warning, hence bumping to 1990 here.

### Solution
Increase the stack.