### PR TITLE
ekf2: robustify wind init using airspeed

### DIFF
--- a/src/modules/ekf2/EKF/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/airspeed_fusion.cpp
@@ -114,7 +114,10 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 			ECL_INFO("starting airspeed fusion");
 
 			// If starting wind state estimation, reset the wind states and covariances before fusing any data
-			if (!_control_status.flags.wind) {
+			// Also catch the case where sideslip fusion enabled wind estimation recently and didn't converge yet.
+			const Vector2f wind_var_xy = getWindVelocityVariance();
+
+			if (!_control_status.flags.wind || (wind_var_xy(0) + wind_var_xy(1) > sq(_params.initial_wind_uncertainty))) {
 				// activate the wind states
 				_control_status.flags.wind = true;
 				// reset the wind speed states and corresponding covariances

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -85,6 +85,21 @@ bool EkfWrapper::isIntendingExternalVisionHeightFusion() const
 	return _ekf->control_status_flags().ev_hgt;
 }
 
+void EkfWrapper::enableBetaFusion()
+{
+	_ekf_params->beta_fusion_enabled = true;
+}
+
+void EkfWrapper::disableBetaFusion()
+{
+	_ekf_params->beta_fusion_enabled = false;
+}
+
+bool EkfWrapper::isIntendingBetaFusion() const
+{
+	return _ekf->control_status_flags().fuse_beta;
+}
+
 void EkfWrapper::enableGpsFusion()
 {
 	_ekf_params->gnss_ctrl |= GnssCtrl::HPOS | GnssCtrl::VEL;

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -69,6 +69,10 @@ public:
 	/* void disableExternalVisionHeightFusion(); */
 	bool isIntendingExternalVisionHeightFusion() const;
 
+	void enableBetaFusion();
+	void disableBetaFusion();
+	bool isIntendingBetaFusion() const;
+
 	void enableGpsFusion();
 	void disableGpsFusion();
 	bool isIntendingGpsFusion() const;


### PR DESCRIPTION
### Solved Problem
Tests showed that sideslip fusion often starts just before airspeed fusion, resetting the wind states to 0 instead of using the airspeed data.

### Solution
 A quick look at the wind uncertainty allows to know if the current wind estimate is meaningful or if we should rather reset it using the airspeed data.

### Test coverage
- added unit test that covers that case
