### PR TITLE
add low pass filtering on roll, pitch, and yaw mc rate control

### DIFF
--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -217,32 +217,33 @@ MulticopterRateControl::Run()
 			Vector3f att_control = _rate_control.update(rates, _rates_setpoint, angular_accel, dt, _maybe_landed || _landed);
 
 			// low pass filter the roll, pitch, and yaw actuator controls just before publishing
-			if(_param_mc_roll_cutoff.get() > 0.01f) {
-				_act_control_roll_filter.setParameters(dt, 1.f/(_param_mc_roll_cutoff.get() * M_TWOPI_F));
+			if (_param_mc_roll_cutoff.get() > 0.01f) {
+				_act_control_roll_filter.setParameters(dt, 1.f / (_param_mc_roll_cutoff.get() * M_TWOPI_F));
 
 				att_control(0) = _act_control_roll_filter.update(att_control(0));
-			}
-			else {
+
+			} else {
 				_act_control_roll_filter.reset(att_control(0));
 			}
 
-			if(_param_mc_pitch_cutoff.get() > 0.01f) {
-				_act_control_pitch_filter.setParameters(dt, 1.f/(_param_mc_pitch_cutoff.get() * M_TWOPI_F));
+			if (_param_mc_pitch_cutoff.get() > 0.01f) {
+				_act_control_pitch_filter.setParameters(dt, 1.f / (_param_mc_pitch_cutoff.get() * M_TWOPI_F));
 
 				att_control(1) = _act_control_pitch_filter.update(att_control(1));
-			}
-			else {
+
+			} else {
 				_act_control_pitch_filter.reset(att_control(1));
 			}
 
-			if(_param_mc_yaw_cutoff.get() > 0.01f) {
-				_act_control_yaw_filter.setParameters(dt, 1.f/(_param_mc_yaw_cutoff.get() * M_TWOPI_F));
+			if (_param_mc_yaw_cutoff.get() > 0.01f) {
+				_act_control_yaw_filter.setParameters(dt, 1.f / (_param_mc_yaw_cutoff.get() * M_TWOPI_F));
 
 				att_control(2) = _act_control_yaw_filter.update(att_control(2));
-			}
-			else {
+
+			} else {
 				_act_control_yaw_filter.reset(att_control(2));
 			}
+
 			// End low pass filtering of actuator controls
 
 

--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -214,7 +214,37 @@ MulticopterRateControl::Run()
 			}
 
 			// run rate controller
-			const Vector3f att_control = _rate_control.update(rates, _rates_setpoint, angular_accel, dt, _maybe_landed || _landed);
+			Vector3f att_control = _rate_control.update(rates, _rates_setpoint, angular_accel, dt, _maybe_landed || _landed);
+
+			// low pass filter the roll, pitch, and yaw actuator controls just before publishing
+			if(_param_mc_roll_cutoff.get() > 0.01f) {
+				_act_control_roll_filter.setParameters(dt, 1.f/(_param_mc_roll_cutoff.get() * M_TWOPI_F));
+
+				att_control(0) = _act_control_roll_filter.update(att_control(0));
+			}
+			else {
+				_act_control_roll_filter.reset(att_control(0));
+			}
+
+			if(_param_mc_pitch_cutoff.get() > 0.01f) {
+				_act_control_pitch_filter.setParameters(dt, 1.f/(_param_mc_pitch_cutoff.get() * M_TWOPI_F));
+
+				att_control(1) = _act_control_pitch_filter.update(att_control(1));
+			}
+			else {
+				_act_control_pitch_filter.reset(att_control(1));
+			}
+
+			if(_param_mc_yaw_cutoff.get() > 0.01f) {
+				_act_control_yaw_filter.setParameters(dt, 1.f/(_param_mc_yaw_cutoff.get() * M_TWOPI_F));
+
+				att_control(2) = _act_control_yaw_filter.update(att_control(2));
+			}
+			else {
+				_act_control_yaw_filter.reset(att_control(2));
+			}
+			// End low pass filtering of actuator controls
+
 
 			// publish rate controller status
 			rate_ctrl_status_s rate_ctrl_status{};

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -34,6 +34,8 @@
 #pragma once
 
 #include <lib/rate_control/rate_control.hpp>
+
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/defines.h>
@@ -59,6 +61,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/vehicle_torque_setpoint.h>
+
 
 using namespace time_literals;
 
@@ -129,6 +132,10 @@ private:
 	float _energy_integration_time{0.0f};
 	float _control_energy[4] {};
 
+	AlphaFilter<float> _act_control_roll_filter;
+	AlphaFilter<float> _act_control_pitch_filter;
+	AlphaFilter<float> _act_control_yaw_filter;
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MC_ROLLRATE_P>) _param_mc_rollrate_p,
 		(ParamFloat<px4::params::MC_ROLLRATE_I>) _param_mc_rollrate_i,
@@ -159,6 +166,10 @@ private:
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _param_mc_acro_supexpo,		/**< superexpo stick curve shape (roll & pitch) */
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
 
-		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en
+		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en,
+
+		(ParamFloat<px4::params::MC_ROLL_CUTOFF>) _param_mc_roll_cutoff,
+		(ParamFloat<px4::params::MC_PITCH_CUTOFF>) _param_mc_pitch_cutoff,
+		(ParamFloat<px4::params::MC_YAW_CUTOFF>) _param_mc_yaw_cutoff
 	)
 };

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -398,3 +398,39 @@ PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
+
+/**
+ * First order low pass filter cutoff frequency for roll rate control
+ *
+ * 0 disables the filter
+ *
+ * @min 0
+ * @unit Hz
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ROLL_CUTOFF, 0.f);
+
+/**
+ * First order low pass filter cutoff frequency for pitch rate control
+ *
+ * 0 disables the filter
+ *
+ * @min 0
+ * @unit Hz
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_PITCH_CUTOFF, 0.f);
+
+/**
+ * First order low pass filter cutoff frequency for yaw rate control
+ *
+ * 0 disables the filter
+ *
+ * @min 0
+ * @unit Hz
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_YAW_CUTOFF, 0.f);


### PR DESCRIPTION
### Solved Problem
Enables better tuning of roll, pitch, and yaw rate control by adding option to add first order low pass filters to the outputs of these controllers.

### Solution
Three first order low pass filters with cutoff frequencies controlled by parameters. Feature is disabled by default.

### Alternatives
Option did not exist to filter roll, pitch, and yaw controllers independently.

### Test coverage
Uploaded and flew on modalai drone to test.

### Context
None
