### PR TITLE
add system id - adding sine injection on roll, pitch, or yaw

### DIFF
--- a/src/modules/mc_rate_control/MulticopterRateControl.cpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.cpp
@@ -222,6 +222,7 @@ MulticopterRateControl::Run()
 				if (!_takeoff_time_set && _thrust_setpoint(2) < -0.2f) {
 					_takeoff_time_set = true;
 					_takeoff_time = hrt_absolute_time();
+
 				} else if (_takeoff_time_set) {
 					float rel_time_now = (float)(hrt_absolute_time() - _takeoff_time) / 1.e6f;
 
@@ -243,8 +244,10 @@ MulticopterRateControl::Run()
 
 								if (_param_mc_inject_rpy.get() == 0) {
 									att_control(0) += injection;
+
 								} else if (_param_mc_inject_rpy.get() == 1) {
 									att_control(1) += injection;
+
 								} else if (_param_mc_inject_rpy.get() == 2) {
 									att_control(2) += injection;
 								}
@@ -253,6 +256,7 @@ MulticopterRateControl::Run()
 					}
 				}
 			}
+
 			// END addition of sine injection
 
 			// publish rate controller status
@@ -288,15 +292,9 @@ MulticopterRateControl::Run()
 				}
 			}
 
-<<<<<<< HEAD
 			vehicle_thrust_setpoint.timestamp_sample = angular_velocity.timestamp_sample;
 			vehicle_thrust_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_thrust_setpoint_pub.publish(vehicle_thrust_setpoint);
-=======
-
-			actuators.timestamp = hrt_absolute_time();
-			_actuator_controls_0_pub.publish(actuators);
->>>>>>> ba69569534... add system id - adding sine injection on roll, pitch, or yaw
 
 			vehicle_torque_setpoint.timestamp_sample = angular_velocity.timestamp_sample;
 			vehicle_torque_setpoint.timestamp = hrt_absolute_time();

--- a/src/modules/mc_rate_control/MulticopterRateControl.hpp
+++ b/src/modules/mc_rate_control/MulticopterRateControl.hpp
@@ -126,6 +126,9 @@ private:
 	float _battery_status_scale{0.0f};
 	matrix::Vector3f _thrust_setpoint{};
 
+	bool _takeoff_time_set;
+	hrt_abstime _takeoff_time;
+
 	float _energy_integration_time{0.0f};
 	float _control_energy[4] {};
 
@@ -159,6 +162,13 @@ private:
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _param_mc_acro_supexpo,		/**< superexpo stick curve shape (roll & pitch) */
 		(ParamFloat<px4::params::MC_ACRO_SUPEXPOY>) _param_mc_acro_supexpoy,		/**< superexpo stick curve shape (yaw) */
 
-		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en
+		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _param_mc_bat_scale_en,
+
+		(ParamBool<px4::params::MC_INJECT_EN>) _param_mc_inject_en,
+		(ParamInt<px4::params::MC_INJECT_RPY>) _param_mc_inject_rpy,
+		(ParamInt<px4::params::MC_INJECT_CNT>) _param_mc_inject_cnt,
+		(ParamFloat<px4::params::MC_INJECT_START>) _param_mc_inject_start,
+		(ParamFloat<px4::params::MC_INJECT_INC>) _param_mc_inject_inc,
+		(ParamFloat<px4::params::MC_INJECT_AMP>) _param_mc_inject_amp
 	)
 };

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -398,3 +398,51 @@ PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);
+
+/**
+ * Enable sine injection in rate controller
+ *
+ * @boolean
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_INT32(MC_INJECT_EN, 0);
+
+/**
+ * Specify roll, pitch, or yaw sine injection with 0, 1, or 2
+ *
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_INT32(MC_INJECT_RPY, 2);
+
+/**
+ * Number of frequencies to inject
+ *
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_INT32(MC_INJECT_CNT, 12);
+
+/**
+ * Starting frequency
+ *
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_INJECT_START, 3.0f);
+
+/**
+ * Frequency increment
+ *
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_INJECT_INC, 1.0f);
+
+/**
+ * Amplitude of sine injection
+ *
+ * @min 0
+ * @max 0.3
+ * @decimal 3
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_INJECT_AMP, 0.05f);


### PR DESCRIPTION
### Solved Problem
Add system id test capability. Adds sine injection on roll, pitch, or yaw.