### PR TITLE
[DO_NOT_MERGE] Fix gz servo angle scale to match joint angles

### DIFF
--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
@@ -65,7 +65,7 @@ bool GZMixingInterfaceServo::updateOutputs(bool stop_motors, uint16_t outputs[MA
 		if (_mixing_output.isFunctionSet(i)) {
 			gz::msgs::Double servo_output;
 			///TODO: Normalize output data
-			double output = (outputs[i] - 500) / 500.0;
+			double output = outputs[i];
 			// std::cout << "outputs[" << i << "]: " << outputs[i] << std::endl;
 			// std::cout << "  output: " << output << std::endl;
 			servo_output.set_data(output);

--- a/src/modules/simulation/gz_bridge/module.yaml
+++ b/src/modules/simulation/gz_bridge/module.yaml
@@ -20,8 +20,8 @@ actuator_output:
       group_label: 'Servos'
       channel_label: 'Servo'
       standard_params:
-        disarmed: { min: 0, max: 1000, default: 500 }
-        min: { min: 0, max: 1000, default: 0 }
-        max: { min: 0, max: 1000, default: 1000 }
-        failsafe: { min: 0, max: 1000 }
+        disarmed: { min: -1.0, max: 1.0, default: 0 }
+        min: { min: -1.0, max: 1.0, default: -1.0 }
+        max: { min: -1.0, max: 1.0, default: 1.0 }
+        failsafe: { min: 0, max: 1.0 }
       num_channels: 8


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The gzbridge servo actuators have a scaling between 0 and 1000, which are then converted to a normalized joint angle between [-1. 1] radians which are quite arbitrary. Since the GzBridge controls the joint angles directly through `ignition transport`, it would be nice if we can have the joint angles configurable directly from the `CA` interface


### Solution
This commit sets the scaling parameters for gz sim servos to match joint angle values directly

>Note: This is not a functional PR yet

The issue is that the actuator output value type is `uint16_t` and therefore cannot have negative values. 

```
Exception while parsing /home/jaeyoung/src/PX4-Autopilot/src/modules/simulation/gz_bridge/module.yaml:
Traceback (most recent call last):
  File "/home/jaeyoung/src/PX4-Autopilot/Tools/module_config/generate_params.py", line 379, in <module>
    raise e
  File "/home/jaeyoung/src/PX4-Autopilot/Tools/module_config/generate_params.py", line 375, in <module>
    actuator_output_params = get_actuator_output_params(yaml_config,
  File "/home/jaeyoung/src/PX4-Autopilot/Tools/module_config/generate_params.py", line 307, in get_actuator_output_params
    raise Exception('minimum value for {:} expected >= 0 (got {:})'.format(key, standard_params[key]['min']))
Exception: minimum value for disarmed expected >= 0 (got -1.0)
```

@bkueng @dagar Would you have any ideas on how to solve this? The interface seems to be only strictly built for an unsigned datatype

<!--
### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
-->