### PR TITLE
sensors module: add 3 decimals to all the type:float params

### DIFF
--- a/src/modules/sensors/module.yaml
+++ b/src/modules/sensors/module.yaml
@@ -201,6 +201,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             #unit: Pa
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -296,6 +297,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             unit: rad/s
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -307,6 +309,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             unit: rad/s
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -318,6 +321,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             unit: rad/s
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -413,6 +417,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             unit: gauss
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -424,6 +429,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             unit: gauss
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -435,6 +441,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             unit: gauss
             volatile: true
             num_instances: *max_num_sensor_instances
@@ -446,6 +453,7 @@ parameters:
             category: System
             type: float
             default: 1.0
+            decimal: 3
             min: 0.1
             max: 3.0
             volatile: true
@@ -458,6 +466,7 @@ parameters:
             category: System
             type: float
             default: 1.0
+            decimal: 3
             min: 0.1
             max: 3.0
             volatile: true
@@ -470,6 +479,7 @@ parameters:
             category: System
             type: float
             default: 1.0
+            decimal: 3
             min: 0.1
             max: 3.0
             volatile: true
@@ -482,6 +492,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -492,6 +503,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -518,6 +530,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -534,6 +547,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0
@@ -550,6 +564,7 @@ parameters:
             category: System
             type: float
             default: 0.0
+            decimal: 3
             volatile: true
             num_instances: *max_num_sensor_instances
             instance_start: 0


### PR DESCRIPTION
### Solved Problem
All the CAL_MAG parameters were visualized with no decimals..

Fixes #{Github issue ID}

### Solution
Added decimals to the type:float

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
