### PR TITLE
Add NAV_CMD_DO_SET_ACTUATOR to mission commands

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -280,6 +280,7 @@ bool FeasibilityChecker::checkMissionItemValidity(mission_item_s &mission_item, 
 	    mission_item.nav_cmd != NAV_CMD_DO_MOUNT_CONTROL &&
 	    mission_item.nav_cmd != NAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW &&
 	    mission_item.nav_cmd != NAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE &&
+	    mission_item.nav_cmd != NAV_CMD_DO_SET_ACTUATOR &&
 	    mission_item.nav_cmd != NAV_CMD_DO_SET_ROI &&
 	    mission_item.nav_cmd != NAV_CMD_DO_SET_ROI_LOCATION &&
 	    mission_item.nav_cmd != NAV_CMD_DO_SET_ROI_WPNEXT_OFFSET &&


### PR DESCRIPTION
### Solved Problem
When  I tried to setup offboard actuator set  (with dynamic control allocation) and enable a mission item triggered/driven offboard actuator set, I found that the mission feasibility checker rejects the commands but the mission block supports them.


### Solution
- Add the `NAV_CMD_DO_SET_ACTUATOR` to the supported commands

### Test Setup
1. Setup `offboard actuator outputs` in QGC configuration page
2. Create a mission with a "Set Servo" mission item and save it
3. Manually  edit "Set Servo" mission item to change command to 187 (NAV_CMD_DO_SET_ACTUATOR)
4. Alternatively use the development build of QGC and create "Set Actuator" mission item
5. Upload to PX4
6. Inspection of `actuator_outputs` and `vehicle_command`  uorb messages
7. Using Iris Model

### Test coverage
- SITL
  - Mission uploading working
  - Mission item working
- HITL
  - Mission uploading working
  - Mission item working

