### PR TITLE
vectornav: fix incorrect string-from-error function usage

### DIFF
--- a/src/drivers/ins/vectornav/libvnc/src/vn/sensors.c
+++ b/src/drivers/ins/vectornav/libvnc/src/vn/sensors.c
@@ -2689,7 +2689,7 @@ RESEND:
 	{
 		char buffer[128];
 		memset(buffer, 0, sizeof(buffer));
-		strFromSensorError(buffer, error);
+		strFromVnError(buffer, error);
 		/* printf("VnSensor_writeFirmwareUpdate: Error %d - %s", error, buffer); */
 	}
 	else


### PR DESCRIPTION
Fixed incorrect string-from-error function usage causing build failure
```
/home/jake/code/jake/PX4-Autopilot/src/drivers/ins/vectornav/libvnc/src/vn/sensors.c:2692:30: error: implicit conversion from 'VnError' to 'SensorError' [-Werror=enum-conversion]
 2692 |   strFromSensorError(buffer, error);
 ```