### PR TITLE
Add position_sp_triplet to the dds topics

### DIFF
--- a/src/modules/microdds_client/dds_topics.yaml
+++ b/src/modules/microdds_client/dds_topics.yaml
@@ -11,6 +11,9 @@ publications:
   - topic: /fmu/out/failsafe_flags
     type: px4_msgs::msg::FailsafeFlags
 
+  - topic: /fmu/out/position_setpoint_triplet
+    type: px4_msgs::msg::PositionSetpointTriplet
+
   - topic: /fmu/out/sensor_combined
     type: px4_msgs::msg::SensorCombined
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When trying to integrate an offboard process such as an obstacle avoidance algorithm in ROS2, there was no information of the vehicle's mission or waypoints being published

### Solution
This commit adds the position_sp_triplet to the dds topic list.
This lets you at least figure out where the vehicle is "trying" to go next for auto modes

### Alternatives
We can try to find a better way to communicate mission waypoints as a dds topic, or provide a service interface, where the offboard process can request what the mission of the vehicle should be.


### Test coverage

### Context
- Related to https://github.com/PX4/PX4-Autopilot/issues/20981