### PR TITLE
fix timesync source for DDS protocol

### DIFF
--- a/src/modules/microdds_client/microdds_client.h
+++ b/src/modules/microdds_client/microdds_client.h
@@ -101,7 +101,7 @@ private:
 	int _last_payload_rx_rate{}; ///< in B/s
 	bool _connected{false};
 
-	Timesync _timesync{};
+	Timesync _timesync{timesync_status_s::SOURCE_PROTOCOL_DDS};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::XRCE_DDS_DOM_ID>) _param_xrce_dds_dom_id,


### PR DESCRIPTION
### Solved Problem
The protocol source for timesync status was not properly set for DDS protocol
