### PR TITLE
change offboard control mode check order

### DIFF
--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -115,11 +115,14 @@ void getVehicleControlMode(bool armed, uint8_t nav_state, uint8_t vehicle_type,
 	case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
 		vehicle_control_mode.flag_control_offboard_enabled = true;
 
-		if (offboard_control_mode.position) {
-			vehicle_control_mode.flag_control_position_enabled = true;
-			vehicle_control_mode.flag_control_velocity_enabled = true;
-			vehicle_control_mode.flag_control_altitude_enabled = true;
-			vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		if (offboard_control_mode.body_rate) {
+			vehicle_control_mode.flag_control_rates_enabled = true;
+
+		} else if (offboard_control_mode.attitude) {
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_attitude_enabled = true;
+
+		} else if (offboard_control_mode.acceleration) {
 			vehicle_control_mode.flag_control_acceleration_enabled = true;
 			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
@@ -132,17 +135,14 @@ void getVehicleControlMode(bool armed, uint8_t nav_state, uint8_t vehicle_type,
 			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
 
-		} else if (offboard_control_mode.acceleration) {
+		} else if (offboard_control_mode.position) {
+			vehicle_control_mode.flag_control_position_enabled = true;
+			vehicle_control_mode.flag_control_velocity_enabled = true;
+			vehicle_control_mode.flag_control_altitude_enabled = true;
+			vehicle_control_mode.flag_control_climb_rate_enabled = true;
 			vehicle_control_mode.flag_control_acceleration_enabled = true;
 			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
-
-		} else if (offboard_control_mode.attitude) {
-			vehicle_control_mode.flag_control_rates_enabled = true;
-			vehicle_control_mode.flag_control_attitude_enabled = true;
-
-		} else if (offboard_control_mode.body_rate) {
-			vehicle_control_mode.flag_control_rates_enabled = true;
 		}
 
 		break;


### PR DESCRIPTION
### Solved Problem
From control_mode.cpp, only one offboard mode is allowed at a time. However, nothing prevent to raise several flag at the same type. 
As, for example in mavlink receiver
https://github.com/PX4/PX4-Autopilot/blob/0cfe1350281579ef3d009944cc8810850a2604d9/src/modules/mavlink/mavlink_receiver.cpp#L1530-L1599

As a consequence, if several flags are raised together, the commander will select only one of them. Which is fine, apart from the fact the some flags enable more control loop than others. 

As it is done now, when a set attitude target is received from Mavlink with the default typemask, it leads to both the offboard_control_mode.attitude and offboard_control_mode.body_rate to be raised.

Then both the attitude controller and rate controller are allowed to run while the Mavlink receiver publishes on vehicle_rate_setpoint and vehicle_attitude_setpoint.
As the attitude controller also publish on vehicle_rate_setpoint. Leading to undefined behavior as two sources publish on the vehicle_rate_setpoint.

I propose to change the order of the check in the commander to choose the most restrictive case when several offboard_control_mode flags are raised.

An other solution would be to handle better malformed typemask in the Mavlink receiver but it will not avoid a similar issue from other sources.