### PR TITLE
Added crosshairs to MSP OSD driver

### DIFF
--- a/src/drivers/osd/msp_osd/module.yaml
+++ b/src/drivers/osd/msp_osd/module.yaml
@@ -36,11 +36,25 @@ parameters:
                 15: (unused) ESC_TMP
                 16: (unused) PITCH_ANGLE
                 17: (unused) ROLL_ANGLE
-                18: (unused) CROSSHAIRS
+                18: CROSSHAIRS
                 19: AVG_CELL_VOLTAGE
                 20: (unused) HORIZON_SIDEBARS
                 21: POWER
             default: 16383
+
+        # OSD Crosshairs Vertical Position
+        OSD_CH_HEIGHT:
+            description:
+                short: OSD Crosshairs Height
+                long: |
+                  Controls the vertical position of the crosshair display.
+                  Resolution is limited by OSD to 15 discrete values. Negative
+                  values will display the crosshairs below the horizon
+            type: int32
+            default: 0
+            min: -8
+            max: 8
+
 
         # OSD Log Level
         OSD_LOG_LEVEL:

--- a/src/drivers/osd/msp_osd/msp_osd.cpp
+++ b/src/drivers/osd/msp_osd/msp_osd.cpp
@@ -102,6 +102,7 @@ const uint16_t osd_mah_drawn_pos = 2449;
 
 // Bottom Row 3
 const uint16_t osd_craft_name_pos = 2480;
+const uint16_t osd_crosshairs_pos = 2319;
 
 // Right
 const uint16_t osd_main_batt_voltage_pos = 2073;
@@ -170,13 +171,18 @@ void MspOsd::SendConfig()
 	msp_osd_config.osd_avg_cell_voltage_pos = enabled(SymbolIndex::AVG_CELL_VOLTAGE) ? osd_avg_cell_voltage_pos :
 			LOCATION_HIDDEN;
 
+	// the location of our crosshairs can change
+	msp_osd_config.osd_crosshairs_pos = LOCATION_HIDDEN;
+
+	if (enabled(SymbolIndex::CROSSHAIRS)) {
+		msp_osd_config.osd_crosshairs_pos = osd_crosshairs_pos - 32 * _param_osd_ch_height.get();
+	}
+
 	// possibly available, but not currently used
 	msp_osd_config.osd_flymode_pos = 			LOCATION_HIDDEN;
 	msp_osd_config.osd_esc_tmp_pos = 			LOCATION_HIDDEN;
 	msp_osd_config.osd_pitch_angle_pos = 			LOCATION_HIDDEN;
 	msp_osd_config.osd_roll_angle_pos = 			LOCATION_HIDDEN;
-	msp_osd_config.osd_crosshairs_pos = 			LOCATION_HIDDEN;
-
 	msp_osd_config.osd_horizon_sidebars_pos = 		LOCATION_HIDDEN;
 
 	// Not implemented or not available

--- a/src/drivers/osd/msp_osd/msp_osd.hpp
+++ b/src/drivers/osd/msp_osd/msp_osd.hpp
@@ -164,6 +164,7 @@ private:
 	// parameters
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::OSD_SYMBOLS>) _param_osd_symbols,
+		(ParamInt<px4::params::OSD_CH_HEIGHT>) _param_osd_ch_height,
 		(ParamInt<px4::params::OSD_SCROLL_RATE>) _param_osd_scroll_rate,
 		(ParamInt<px4::params::OSD_DWELL_TIME>) _param_osd_dwell_time,
 		(ParamInt<px4::params::OSD_LOG_LEVEL>) _param_osd_log_level


### PR DESCRIPTION
### Solved Problem
Simply adds crosshairs to the OSD display, optionally