### PR TITLE
improve cyphal esc

### DIFF
--- a/src/drivers/cyphal/Actuators/EscClient.hpp
+++ b/src/drivers/cyphal/Actuators/EscClient.hpp
@@ -105,7 +105,7 @@ public:
 
 			for (uint8_t i = 0; i < MAX_ACTUATORS; i++) {
 				if (i < num_outputs) {
-					msg_sp.value[i] = static_cast<float>(outputs[i]);
+					msg_sp.value[i] = static_cast<float>(outputs[i] / 8192.0);
 
 				} else {
 					// "unset" values published as NaN

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -125,7 +125,7 @@ int CyphalNode::start(uint32_t node_id, uint32_t bitrate)
 		_instance = new CyphalNode(node_id, 8, CANARD_MTU_CAN_FD);
 
 	} else {
-		_instance = new CyphalNode(node_id, 64, CANARD_MTU_CAN_CLASSIC);
+		_instance = new CyphalNode(node_id, 512, CANARD_MTU_CAN_CLASSIC);
 	}
 
 	if (_instance == nullptr) {
@@ -187,6 +187,8 @@ void CyphalNode::Run()
 	if (_canard_handle.node_id() != CANARD_NODE_ID_UNSET) {
 		// send uavcan::node::Heartbeat_1_0 @ 1 Hz
 		sendHeartbeat();
+
+		sendPortList();
 
 		// Check all publishers
 		_pub_manager.update();
@@ -390,6 +392,45 @@ void CyphalNode::sendHeartbeat()
 
 		_uavcan_node_heartbeat_last = now;
 	}
+}
+
+void CyphalNode::sendPortList()
+{
+	static hrt_abstime _uavcan_node_port_List_last{0};
+
+	if (hrt_elapsed_time(&_uavcan_node_port_List_last) < 3_s) {
+		return;
+	}
+
+	static uavcan_node_port_List_0_1 msg{};
+	static uint8_t uavcan_node_port_List_0_1_buffer[uavcan_node_port_List_0_1_EXTENT_BYTES_];
+	static CanardTransferID _uavcan_node_port_List_transfer_id{0};
+	size_t payload_size = uavcan_node_port_List_0_1_EXTENT_BYTES_;
+	const hrt_abstime now = hrt_absolute_time();
+
+	const CanardTransferMetadata transfer_metadata = {
+		.priority       = CanardPriorityNominal,
+		.transfer_kind  = CanardTransferKindMessage,
+		.port_id        = uavcan_node_port_List_0_1_FIXED_PORT_ID_,
+		.remote_node_id = CANARD_NODE_ID_UNSET,
+		.transfer_id    = _uavcan_node_port_List_transfer_id++
+	};
+
+	// memset(uavcan_node_port_List_0_1_buffer, 0x00, uavcan_node_port_List_0_1_EXTENT_BYTES_);
+	uavcan_node_port_List_0_1_initialize_(&msg);
+
+	_pub_manager.fillSubjectIdList(msg.publishers);
+	_sub_manager.fillSubjectIdList(msg.subscribers);
+
+	uavcan_node_port_List_0_1_serialize_(&msg, uavcan_node_port_List_0_1_buffer, &payload_size);
+
+	_canard_handle.TxPush(now + PUBLISHER_DEFAULT_TIMEOUT_USEC,
+			      &transfer_metadata,
+			      payload_size,
+			      &uavcan_node_port_List_0_1_buffer
+			     );
+
+	_uavcan_node_port_List_last = now;
 }
 
 bool UavcanMixingInterface::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -361,10 +361,10 @@ void CyphalNode::sendHeartbeat()
 	if (hrt_elapsed_time(&_uavcan_node_heartbeat_last) >= 1_s) {
 
 		uavcan_node_Heartbeat_1_0 heartbeat{};
-		heartbeat.uptime = _uavcan_node_heartbeat_transfer_id; // TODO: use real uptime
+		const hrt_abstime now = hrt_absolute_time();
+		heartbeat.uptime = now / 1000000;
 		heartbeat.health.value = uavcan_node_Health_1_0_NOMINAL;
 		heartbeat.mode.value = uavcan_node_Mode_1_0_OPERATIONAL;
-		const hrt_abstime now = hrt_absolute_time();
 		size_t payload_size = uavcan_node_Heartbeat_1_0_SERIALIZATION_BUFFER_SIZE_BYTES_;
 
 		const CanardTransferMetadata transfer_metadata = {

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -62,6 +62,8 @@ using namespace time_literals;
 
 CyphalNode *CyphalNode::_instance;
 
+esc_status_s UavcanEscFeedbackSubscriber::_esc_status;
+
 CyphalNode::CyphalNode(uint32_t node_id, size_t capacity, size_t mtu_bytes) :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::uavcan),

--- a/src/drivers/cyphal/Cyphal.hpp
+++ b/src/drivers/cyphal/Cyphal.hpp
@@ -137,6 +137,9 @@ private:
 	// Sends a heartbeat at 1s intervals
 	void sendHeartbeat();
 
+	// Sends a port.List at 3s intervals
+	void sendPortList();
+
 	px4::atomic_bool _task_should_exit{false};	///< flag to indicate to tear down the CAN driver
 
 	bool _initialized{false};		///< number of actuators currently available

--- a/src/drivers/cyphal/ParamManager.cpp
+++ b/src/drivers/cyphal/ParamManager.cpp
@@ -56,6 +56,15 @@ bool UavcanParamManager::GetParamByName(const char *param_name, uavcan_register_
 		}
 	}
 
+	for (auto &param : _type_registers) {
+		if (strcmp(param_name, param.name) == 0) {
+			uavcan_register_Value_1_0_select_string_(&value);
+			value._string.value.count = strlen(param.value);
+			memcpy(&value._string, param.value, value._string.value.count);
+			return true;
+		}
+	}
+
 	return false;
 }
 
@@ -73,18 +82,32 @@ bool UavcanParamManager::GetParamByName(const uavcan_register_Name_1_0 &name, ua
 		}
 	}
 
+	for (auto &param : _type_registers) {
+		if (strncmp((char *)name.name.elements, param.name, name.name.count) == 0) {
+			uavcan_register_Value_1_0_select_string_(&value);
+			value._string.value.count = strlen(param.value);
+			memcpy(&value._string, param.value, value._string.value.count);
+			return true;
+		}
+	}
+
 	return false;
 }
 
 bool UavcanParamManager::GetParamName(uint32_t id, uavcan_register_Name_1_0 &name)
 {
-	if (id >= sizeof(_uavcan_params) / sizeof(UavcanParamBinder)) {
+	size_t number_of_integer_registers = sizeof(_uavcan_params) / sizeof(UavcanParamBinder);
+	size_t number_of_type_registers = sizeof(_type_registers) / sizeof(CyphalTypeRegister);
+	if (id < sizeof(_uavcan_params) / sizeof(UavcanParamBinder)) {
+		strncpy((char *)name.name.elements, _uavcan_params[id].uavcan_name, uavcan_register_Name_1_0_name_ARRAY_CAPACITY_);
+		name.name.count = strlen(_uavcan_params[id].uavcan_name);
+	} else if (id < number_of_integer_registers + number_of_type_registers) {
+		id -= number_of_integer_registers;
+		strncpy((char *)name.name.elements, _type_registers[id].name, strlen(_type_registers[id].name));
+		name.name.count = strlen(_type_registers[id].name);
+	} else {
 		return false;
 	}
-
-	strncpy((char *)name.name.elements, _uavcan_params[id].uavcan_name, uavcan_register_Name_1_0_name_ARRAY_CAPACITY_);
-
-	name.name.count = strlen(_uavcan_params[id].uavcan_name);
 
 	return true;
 }

--- a/src/drivers/cyphal/ParamManager.cpp
+++ b/src/drivers/cyphal/ParamManager.cpp
@@ -98,13 +98,16 @@ bool UavcanParamManager::GetParamName(uint32_t id, uavcan_register_Name_1_0 &nam
 {
 	size_t number_of_integer_registers = sizeof(_uavcan_params) / sizeof(UavcanParamBinder);
 	size_t number_of_type_registers = sizeof(_type_registers) / sizeof(CyphalTypeRegister);
+
 	if (id < sizeof(_uavcan_params) / sizeof(UavcanParamBinder)) {
 		strncpy((char *)name.name.elements, _uavcan_params[id].uavcan_name, uavcan_register_Name_1_0_name_ARRAY_CAPACITY_);
 		name.name.count = strlen(_uavcan_params[id].uavcan_name);
+
 	} else if (id < number_of_integer_registers + number_of_type_registers) {
 		id -= number_of_integer_registers;
 		strncpy((char *)name.name.elements, _type_registers[id].name, strlen(_type_registers[id].name));
 		name.name.count = strlen(_type_registers[id].name);
+
 	} else {
 		return false;
 	}

--- a/src/drivers/cyphal/ParamManager.hpp
+++ b/src/drivers/cyphal/ParamManager.hpp
@@ -116,8 +116,9 @@ public:
 private:
 
 
-	const UavcanParamBinder _uavcan_params[13] {
+	const UavcanParamBinder _uavcan_params[14] {
 		{"uavcan.pub.udral.esc.0.id",                	"UCAN1_ESC_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.pub.udral.readiness.0.id",            	"UCAN1_READ_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.servo.0.id",              	"UCAN1_SERVO_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.gps.0.id",                	"UCAN1_GPS_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.actuator_outputs.0.id",   	"UCAN1_ACTR_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},

--- a/src/drivers/cyphal/ParamManager.hpp
+++ b/src/drivers/cyphal/ParamManager.hpp
@@ -103,6 +103,10 @@ typedef struct {
 	bool is_persistent {true};
 } UavcanParamBinder;
 
+typedef struct {
+	const char *name;
+	const char *value;
+} CyphalTypeRegister;
 
 class UavcanParamManager
 {
@@ -134,5 +138,11 @@ private:
 		{"uavcan.sub.zubax.feedback.0.id",            	"UCAN1_FB_SUB",			px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		//{"uavcan.sub.bms.0.id",   "UCAN1_BMS0_SUB"}, //FIXME instancing
 		//{"uavcan.sub.bms.1.id",   "UCAN1_BMS1_SUB"},
+	};
+
+	CyphalTypeRegister _type_registers[3] {
+		{"uavcan.pub.udral.esc.0.type", 		"reg.udral.service.actuator.common.sp.Vector31"},
+		{"uavcan.pub.udral.readiness.0.type", 		"reg.udral.service.common.Readiness.0.1"},
+		{"uavcan.sub.zubax.feedback.0.type", 		"zubax.telega.CompactFeedback.0.1"},
 	};
 };

--- a/src/drivers/cyphal/ParamManager.hpp
+++ b/src/drivers/cyphal/ParamManager.hpp
@@ -120,7 +120,7 @@ public:
 private:
 
 
-	const UavcanParamBinder _uavcan_params[15] {
+	const UavcanParamBinder _uavcan_params[22] {
 		{"uavcan.pub.udral.esc.0.id",                	"UCAN1_ESC_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.readiness.0.id",            	"UCAN1_READ_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.servo.0.id",              	"UCAN1_SERVO_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
@@ -135,14 +135,28 @@ private:
 		{"uavcan.sub.udral.legacy_bms.0.id",         	"UCAN1_LG_BMS_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.sub.uorb.sensor_gps.0.id",    		"UCAN1_UORB_GPS",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.uorb.sensor_gps.0.id",    		"UCAN1_UORB_GPS_P",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
-		{"uavcan.sub.zubax.feedback.0.id",            	"UCAN1_FB_SUB",			px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.0.id",            	"UCAN1_FB0_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.1.id",            	"UCAN1_FB1_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.2.id",            	"UCAN1_FB2_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.3.id",            	"UCAN1_FB3_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.4.id",            	"UCAN1_FB4_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.5.id",            	"UCAN1_FB5_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.6.id",            	"UCAN1_FB6_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.7.id",            	"UCAN1_FB7_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		//{"uavcan.sub.bms.0.id",   "UCAN1_BMS0_SUB"}, //FIXME instancing
 		//{"uavcan.sub.bms.1.id",   "UCAN1_BMS1_SUB"},
 	};
 
-	CyphalTypeRegister _type_registers[3] {
+	CyphalTypeRegister _type_registers[10] {
 		{"uavcan.pub.udral.esc.0.type", 		"reg.udral.service.actuator.common.sp.Vector31"},
 		{"uavcan.pub.udral.readiness.0.type", 		"reg.udral.service.common.Readiness.0.1"},
 		{"uavcan.sub.zubax.feedback.0.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.1.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.2.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.3.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.4.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.5.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.6.type", 		"zubax.telega.CompactFeedback.0.1"},
+		{"uavcan.sub.zubax.feedback.7.type", 		"zubax.telega.CompactFeedback.0.1"},
 	};
 };

--- a/src/drivers/cyphal/ParamManager.hpp
+++ b/src/drivers/cyphal/ParamManager.hpp
@@ -116,7 +116,7 @@ public:
 private:
 
 
-	const UavcanParamBinder _uavcan_params[14] {
+	const UavcanParamBinder _uavcan_params[15] {
 		{"uavcan.pub.udral.esc.0.id",                	"UCAN1_ESC_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.readiness.0.id",            	"UCAN1_READ_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.udral.servo.0.id",              	"UCAN1_SERVO_PUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
@@ -131,6 +131,7 @@ private:
 		{"uavcan.sub.udral.legacy_bms.0.id",         	"UCAN1_LG_BMS_SUB",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.sub.uorb.sensor_gps.0.id",    		"UCAN1_UORB_GPS",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		{"uavcan.pub.uorb.sensor_gps.0.id",    		"UCAN1_UORB_GPS_P",		px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
+		{"uavcan.sub.zubax.feedback.0.id",            	"UCAN1_FB_SUB",			px4_param_to_uavcan_port_id, uavcan_port_id_to_px4_param},
 		//{"uavcan.sub.bms.0.id",   "UCAN1_BMS0_SUB"}, //FIXME instancing
 		//{"uavcan.sub.bms.1.id",   "UCAN1_BMS1_SUB"},
 	};

--- a/src/drivers/cyphal/PublicationManager.cpp
+++ b/src/drivers/cyphal/PublicationManager.cpp
@@ -125,6 +125,15 @@ UavcanPublisher *PublicationManager::getPublisher(const char *subject_name)
 	return NULL;
 }
 
+void PublicationManager::fillSubjectIdList(uavcan_node_port_SubjectIDList_0_1 &publishers_list)
+{
+	uavcan_node_port_SubjectIDList_0_1_select_sparse_list_(&publishers_list);
+
+	for (auto &dynpub : _dynpublishers) {
+		publishers_list.sparse_list.elements[publishers_list.sparse_list.count].value = dynpub->id();
+		publishers_list.sparse_list.count++;
+	}
+}
 
 void PublicationManager::update()
 {

--- a/src/drivers/cyphal/PublicationManager.hpp
+++ b/src/drivers/cyphal/PublicationManager.hpp
@@ -79,6 +79,7 @@
 
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/sensor_gps.h>
+#include <uavcan/node/port/List_0_1.h>
 
 #include "Actuators/EscClient.hpp"
 #include "Publishers/udral/Readiness.hpp"
@@ -103,6 +104,7 @@ public:
 
 	UavcanPublisher *getPublisher(const char *subject_name);
 
+	void fillSubjectIdList(uavcan_node_port_SubjectIDList_0_1 &publishers_list);
 private:
 	void updateDynamicPublications();
 

--- a/src/drivers/cyphal/PublicationManager.hpp
+++ b/src/drivers/cyphal/PublicationManager.hpp
@@ -67,7 +67,7 @@
 /* Preprocessor calculation of publisher count */
 
 #define UAVCAN_PUB_COUNT CONFIG_CYPHAL_GNSS_PUBLISHER + \
-	CONFIG_CYPHAL_ESC_CONTROLLER + \
+	2 * CONFIG_CYPHAL_ESC_CONTROLLER + \
 	CONFIG_CYPHAL_READINESS_PUBLISHER + \
 	CONFIG_CYPHAL_UORB_ACTUATOR_OUTPUTS_PUBLISHER + \
 	CONFIG_CYPHAL_UORB_SENSOR_GPS_PUBLISHER
@@ -131,6 +131,14 @@ private:
 				return new UavcanEscController(handle, pmgr);
 			},
 			"udral.esc",
+			0
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanPublisher *
+			{
+				return new ReadinessPublisher(handle, pmgr);
+			},
+			"udral.readiness",
 			0
 		},
 #endif

--- a/src/drivers/cyphal/SubscriptionManager.cpp
+++ b/src/drivers/cyphal/SubscriptionManager.cpp
@@ -158,3 +158,24 @@ void SubscriptionManager::updateParams()
 	// Check for any newly-enabled subscriptions
 	updateDynamicSubscriptions();
 }
+
+void SubscriptionManager::fillSubjectIdList(uavcan_node_port_SubjectIDList_0_1 &subscribers_list)
+{
+	uavcan_node_port_SubjectIDList_0_1_select_sparse_list_(&subscribers_list);
+
+	UavcanDynamicPortSubscriber *dynsub = _dynsubscribers;
+
+	auto &sparse_list = subscribers_list.sparse_list;
+
+	while (dynsub != nullptr) {
+		int32_t instance_idx = 0;
+
+		while (dynsub->isValidPortId(dynsub->id(instance_idx))) {
+			sparse_list.elements[sparse_list.count].value = dynsub->id(instance_idx);
+			sparse_list.count++;
+			instance_idx++;
+		}
+
+		dynsub = dynsub->next();
+	}
+}

--- a/src/drivers/cyphal/SubscriptionManager.hpp
+++ b/src/drivers/cyphal/SubscriptionManager.hpp
@@ -69,7 +69,7 @@
 
 #define UAVCAN_SUB_COUNT CONFIG_CYPHAL_ESC_SUBSCRIBER + \
 	CONFIG_CYPHAL_GNSS_SUBSCRIBER_0 + \
-	CONFIG_CYPHAL_ESC_CONTROLLER + \
+	8 * CONFIG_CYPHAL_ESC_CONTROLLER + \
 	CONFIG_CYPHAL_GNSS_SUBSCRIBER_1 + \
 	CONFIG_CYPHAL_BMS_SUBSCRIBER + \
 	CONFIG_CYPHAL_UORB_SENSOR_GPS_SUBSCRIBER
@@ -146,6 +146,62 @@ private:
 			},
 			"zubax.feedback",
 			0
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 1);
+			},
+			"zubax.feedback",
+			1
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 2);
+			},
+			"zubax.feedback",
+			2
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 3);
+			},
+			"zubax.feedback",
+			3
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 4);
+			},
+			"zubax.feedback",
+			4
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 5);
+			},
+			"zubax.feedback",
+			5
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 6);
+			},
+			"zubax.feedback",
+			6
+		},
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 7);
+			},
+			"zubax.feedback",
+			7
 		},
 #endif
 #if CONFIG_CYPHAL_GNSS_SUBSCRIBER_0

--- a/src/drivers/cyphal/SubscriptionManager.hpp
+++ b/src/drivers/cyphal/SubscriptionManager.hpp
@@ -45,6 +45,10 @@
 #define CONFIG_CYPHAL_ESC_SUBSCRIBER 0
 #endif
 
+#ifndef CONFIG_CYPHAL_ESC_CONTROLLER
+#define CONFIG_CYPHAL_ESC_CONTROLLER 0
+#endif
+
 #ifndef CONFIG_CYPHAL_GNSS_SUBSCRIBER_0
 #define CONFIG_CYPHAL_GNSS_SUBSCRIBER_0 0
 #endif
@@ -65,6 +69,7 @@
 
 #define UAVCAN_SUB_COUNT CONFIG_CYPHAL_ESC_SUBSCRIBER + \
 	CONFIG_CYPHAL_GNSS_SUBSCRIBER_0 + \
+	CONFIG_CYPHAL_ESC_CONTROLLER + \
 	CONFIG_CYPHAL_GNSS_SUBSCRIBER_1 + \
 	CONFIG_CYPHAL_BMS_SUBSCRIBER + \
 	CONFIG_CYPHAL_UORB_SENSOR_GPS_SUBSCRIBER
@@ -72,6 +77,7 @@
 #include <px4_platform_common/defines.h>
 #include <drivers/drv_hrt.h>
 #include <uavcan/node/port/List_0_1.h>
+#include "Actuators/EscClient.hpp"
 #include "Subscribers/DynamicPortSubscriber.hpp"
 #include "CanardInterface.hpp"
 
@@ -129,6 +135,16 @@ private:
 				return new UavcanEscSubscriber(handle, pmgr, 0);
 			},
 			"udral.esc",
+			0
+		},
+#endif
+#if CONFIG_CYPHAL_ESC_CONTROLLER
+		{
+			[](CanardHandle & handle, UavcanParamManager & pmgr) -> UavcanDynamicPortSubscriber *
+			{
+				return new UavcanEscFeedbackSubscriber(handle, pmgr, 0);
+			},
+			"zubax.feedback",
 			0
 		},
 #endif

--- a/src/drivers/cyphal/SubscriptionManager.hpp
+++ b/src/drivers/cyphal/SubscriptionManager.hpp
@@ -71,6 +71,7 @@
 
 #include <px4_platform_common/defines.h>
 #include <drivers/drv_hrt.h>
+#include <uavcan/node/port/List_0_1.h>
 #include "Subscribers/DynamicPortSubscriber.hpp"
 #include "CanardInterface.hpp"
 
@@ -100,6 +101,7 @@ public:
 	void subscribe();
 	void printInfo();
 	void updateParams();
+	void fillSubjectIdList(uavcan_node_port_SubjectIDList_0_1 &subscribers_list);
 
 private:
 	void updateDynamicSubscriptions();

--- a/src/drivers/cyphal/parameters.c
+++ b/src/drivers/cyphal/parameters.c
@@ -172,13 +172,76 @@ PARAM_DEFINE_INT32(UCAN1_ESC_PUB, -1);
 PARAM_DEFINE_INT32(UCAN1_READ_PUB, -1);
 
 /**
- * Cyphal ESC zubax feedback port ID.
+ * Cyphal ESC 0 zubax feedback port ID.
  *
  * @min -1
  * @max 6143
  * @group Cyphal
  */
-PARAM_DEFINE_INT32(UCAN1_FB_SUB, -1);
+PARAM_DEFINE_INT32(UCAN1_FB0_SUB, -1);
+
+/**
+ * Cyphal ESC 1 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB1_SUB, -1);
+
+/**
+ * Cyphal ESC 2 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB2_SUB, -1);
+
+/**
+ * Cyphal ESC 3 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB3_SUB, -1);
+
+/**
+ * Cyphal ESC 4 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB4_SUB, -1);
+
+/**
+ * Cyphal ESC 5 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB5_SUB, -1);
+
+/**
+ * Cyphal ESC 6 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB6_SUB, -1);
+
+/**
+ * Cyphal ESC 7 zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB7_SUB, -1);
 
 /**
  * Cyphal GPS publication port ID.

--- a/src/drivers/cyphal/parameters.c
+++ b/src/drivers/cyphal/parameters.c
@@ -163,6 +163,15 @@ PARAM_DEFINE_INT32(UCAN1_UORB_GPS_P, -1);
 PARAM_DEFINE_INT32(UCAN1_ESC_PUB, -1);
 
 /**
+ * Cyphal ESC readiness port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_READ_PUB, -1);
+
+/**
  * Cyphal GPS publication port ID.
  *
  * @min -1

--- a/src/drivers/cyphal/parameters.c
+++ b/src/drivers/cyphal/parameters.c
@@ -172,6 +172,15 @@ PARAM_DEFINE_INT32(UCAN1_ESC_PUB, -1);
 PARAM_DEFINE_INT32(UCAN1_READ_PUB, -1);
 
 /**
+ * Cyphal ESC zubax feedback port ID.
+ *
+ * @min -1
+ * @max 6143
+ * @group Cyphal
+ */
+PARAM_DEFINE_INT32(UCAN1_FB_SUB, -1);
+
+/**
  * Cyphal GPS publication port ID.
  *
  * @min -1


### PR DESCRIPTION
### Solved Problem

This PR includes Cyphal ESC improvements and some fixes to simplify configuration with Yukon. It is based on notes mentioned [in the forum](https://discuss.px4.io/t/zubax-myxa-and-cyphal-integration/31404/1) and in the previous Cyphal PR. 

I've started with a draft PR, so you can track the progress and give a earlier feedback.

- [x] Fix setpoint wrong scale. it is from 0 to 8192, but it should be from 0 to 1.0.
- [x] Use actual time instead of transfer id in uptime field of heartbeat. Now the time is reset every 256 seconds.
- [x] Add port.list.
- [x] Add *type registers.
- [x] Add ESC feedback. I am thinking of starting with zubax.telega.CompactFeedback.0.1.
- [x] Separate setpoint and readiness (now these 2 topics are related to a single register, which is not what we expect on the Yukon side).
- [x] Optimize the setpoint. Now we always send 31 commands, which is not efficient for a simple quadcopter case. We should only send as many commands as we actually use, because the zero implicit rule allows that. I'm currently looking at [the hack in RawCommand](https://github.com/PX4/PX4-Autopilot/blob/da519573d49bb2909e2b111ff7b353f97323e13d/src/drivers/uavcan/actuators/esc.cpp#L100).

### Test coverage

I will attach it when it is ready.