### PR TITLE
navigator_main: orbit in FW: get_cruising_speed()

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -468,6 +468,7 @@ void Navigator::run()
 					rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 					rep->current.loiter_radius = get_loiter_radius();
 					rep->current.loiter_direction_counter_clockwise = false;
+					rep->current.cruising_speed = get_cruising_speed();
 					rep->current.cruising_throttle = get_cruising_throttle();
 
 					if (PX4_ISFINITE(cmd.param1)) {


### PR DESCRIPTION
`rep->current.cruising_speed = get_cruising_speed();` was missing on entry of a FW Orbit, thus always resetting the speed to the vehicle default. 