### PR TITLE
Airframe configs clean up

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx
@@ -17,12 +17,9 @@ param set-default SENS_EN_BAROSIM 1
 param set-default SENS_EN_MAGSIM 1
 
 # disable some checks to allow to fly:
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set-default CA_ROTOR_COUNT 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10041_sihsim_airplane
@@ -22,7 +22,6 @@ param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set-default BAT_N_CELLS 3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -27,12 +27,9 @@ param set-default MC_PITCH_P 5
 param set-default MAV_TYPE 19
 
 # disable some checks to allow to fly:
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set-default BAT_N_CELLS 3

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1015_gazebo-classic_iris_obs_avoid
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1015_gazebo-classic_iris_obs_avoid
@@ -30,5 +30,3 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 
 param set-default COM_OBS_AVOID 1
-param set-default MPC_XY_CRUISE 5.0
-

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1021_gazebo-classic_uuv_hippocampus
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1021_gazebo-classic_uuv_hippocampus
@@ -5,9 +5,6 @@
 
 . ${R}etc/init.d/rc.uuv_defaults
 
-# disable circuit breaker for airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default CA_AIRFRAME 7
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_R_REV 255

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1022_gazebo-classic_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1022_gazebo-classic_uuv_bluerov2_heavy
@@ -5,9 +5,6 @@
 
 . ${R}etc/init.d/rc.uuv_defaults
 
-# disable circuit breaker for airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default CA_AIRFRAME 7
 
 param set-default CA_ROTOR_COUNT 8

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_gazebo-classic_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_gazebo-classic_believer
@@ -26,7 +26,6 @@ param set-default FW_THR_TRIM 0.25
 
 param set-default FW_T_ALT_TC 2
 param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 param set-default FW_T_TAS_TC 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
@@ -67,7 +67,6 @@ param set-default MC_YAW_P 1.6
 
 param set-default MIS_TAKEOFF_ALT 10
 
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_XY_P 0.8
 param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_XY_VEL_I_ACC 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
@@ -77,6 +77,5 @@ param set-default NAV_ACC_RAD 5
 
 param set-default VT_FWD_THRUST_EN 4
 param set-default VT_F_TRANS_THR 0.75
-param set-default VT_B_TRANS_DUR 8
 param set-default VT_TYPE 2
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -61,7 +61,6 @@ param set-default FW_THR_MAX 0.6
 param set-default FW_THR_MIN 0.05
 param set-default FW_T_ALT_TC 2
 param set-default FW_T_CLMB_MAX 8
-param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 param set-default FW_T_TAS_TC 2
@@ -69,7 +68,6 @@ param set-default FW_T_TAS_TC 2
 param set-default MC_AIRMODE 1
 param set-default MC_ROLLRATE_P 0.3
 
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_XY_P 0.8
 param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_XY_VEL_I_ACC 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1042_gazebo-classic_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1042_gazebo-classic_tiltrotor
@@ -70,7 +70,6 @@ param set-default MPC_XY_VEL_D_ACC 0.1
 
 param set-default MIS_TAKEOFF_ALT 10
 
-param set-default VT_B_TRANS_DUR 8
 param set-default VT_FWD_THRUST_EN 4
 param set-default VT_FWD_THRUST_SC 0.6
 param set-default VT_TILT_TRANS 0.6

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_gazebo-classic_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_gazebo-classic_standard_vtol_drop
@@ -78,7 +78,6 @@ param set-default VT_FWD_THRUST_EN 4
 param set-default VT_F_TRANS_THR 0.75
 param set-default VT_MOT_ID 1234
 param set-default VT_FW_MOT_OFFID 1234
-param set-default VT_B_TRANS_DUR 8
 param set-default VT_TYPE 2
 
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1043_gazebo-classic_standard_vtol_drop
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1043_gazebo-classic_standard_vtol_drop
@@ -66,7 +66,6 @@ param set-default MC_YAW_P 1.6
 
 param set-default MIS_TAKEOFF_ALT 10
 
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_XY_P 0.8
 param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_XY_VEL_I_ACC 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1060_gazebo-classic_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1060_gazebo-classic_rover
@@ -22,8 +22,6 @@ param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default GND_MAX_ANG 0.6
 param set-default GND_WHEEL_BASE 2.0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1060_gazebo-classic_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1060_gazebo-classic_rover
@@ -18,7 +18,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1061_gazebo-classic_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1061_gazebo-classic_r1_rover
@@ -22,8 +22,6 @@ param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default GND_MAX_ANG 0.6
 param set-default GND_WHEEL_BASE 2.0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1061_gazebo-classic_r1_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1061_gazebo-classic_r1_rover
@@ -18,7 +18,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1062_flightgear_tf-r1
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1062_flightgear_tf-r1
@@ -25,7 +25,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1062_flightgear_tf-r1
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1062_flightgear_tf-r1
@@ -29,8 +29,6 @@ param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default GND_MAX_ANG 0.6
 param set-default GND_WHEEL_BASE 3.0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1070_gazebo-classic_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1070_gazebo-classic_boat
@@ -22,8 +22,6 @@ param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default GND_MAX_ANG 0.6
 param set-default GND_WHEEL_BASE 2.0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1070_gazebo-classic_boat
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1070_gazebo-classic_boat
@@ -18,7 +18,6 @@ param set-default GND_THR_CRUISE 0.85
 param set-default GND_THR_MAX 1
 param set-default GND_THR_MIN 0
 
-param set-default MIS_TAKEOFF_ALT 0.01
 param set-default NAV_ACC_RAD 0.5
 param set-default NAV_LOITER_RAD 2
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -106,6 +106,5 @@ param set-default NAV_ACC_RAD 5
 
 param set-default VT_FWD_THRUST_EN 4
 param set-default VT_F_TRANS_THR 0.75
-param set-default VT_B_TRANS_DUR 8
 param set-default VT_TYPE 2
 param set-default FD_ESCS_EN 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -96,7 +96,6 @@ param set-default MC_YAW_P 1.6
 
 param set-default MIS_TAKEOFF_ALT 10
 
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_XY_P 0.8
 param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_XY_VEL_I_ACC 4

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
@@ -66,13 +66,10 @@ param set-default MC_YAWRATE_P 0.3
 param set-default CP_DIST 6
 param set-default MPC_ACC_DOWN_MAX 5
 param set-default MPC_ACC_HOR_MAX 10
-param set-default MPC_ACC_UP_MAX 4
 param set-default MPC_MANTHR_MIN 0
 param set-default MPC_MAN_Y_MAX 120
-param set-default MPC_TILTMAX_AIR 45
 param set-default MPC_THR_HOVER 0.3
 param set-default MPC_VEL_MANUAL 5
-param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_VEL_MAX 5
 param set-default MPC_XY_VEL_P_ACC 1.58
 param set-default MPC_XY_TRAJ_P 0.3

--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -34,10 +34,7 @@ param set-default HIL_ACT_FUNC3 103
 param set-default HIL_ACT_FUNC4 104
 
 # disable some checks to allow to fly
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -34,8 +34,6 @@ param set-default MC_ROLLRATE_P 0.3
 param set-default MIS_TAKEOFF_ALT 10
 param set-default MIS_YAW_TMT 10
 
-param set-default MPC_ACC_HOR_MAX 2
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_THR_MIN 0.1
 param set-default MPC_XY_P 0.8
 param set-default MPC_XY_VEL_D_ACC 0.1
@@ -94,12 +92,9 @@ param set SYS_HITL 1
 param set UAVCAN_ENABLE 0
 
 # disable some checks to allow to fly
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set-default MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1100_rc_quad_x_sih.hil
@@ -36,12 +36,9 @@ param set-default HIL_ACT_FUNC4 104
 param set SYS_HITL 2
 
 # disable some checks to allow to fly:
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set SIH_VEHICLE_TYPE 0

--- a/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1101_rc_plane_sih.hil
@@ -39,12 +39,9 @@ param set-default HIL_ACT_FUNC6 400
 param set-default SYS_HITL 2
 
 # disable some checks to allow to fly:
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set-default BAT_N_CELLS 3

--- a/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
@@ -56,12 +56,9 @@ param set-default MAV_TYPE 19
 param set-default SYS_HITL 2
 
 # disable some checks to allow to fly:
-# - with usb
-param set-default CBRK_USB_CHK 197848
 # - without real battery
 param set-default CBRK_SUPPLY_CHK 894281
 # - without safety switch
-param set-default COM_PREARM_MODE 0
 param set-default CBRK_IO_SAFETY 22027
 
 param set-default BAT_N_CELLS 3

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -101,7 +101,6 @@ param set-default VT_FW_QC_P 55
 param set-default VT_FW_QC_R 55
 param set-default VT_TRANS_MIN_TM 15
 param set-default VT_FWD_THRUST_SC 4
-param set-default VT_B_TRANS_THR 0.7
 param set-default VT_TRANS_TIMEOUT 22
 
 param set-default COM_RC_OVERRIDE 0

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -48,7 +48,6 @@ param set-default FW_R_LIM 35
 param set-default FW_RR_FF 0.9
 param set-default FW_RR_I 0.08
 param set-default FW_RR_P 0.18
-param set-default FW_T_HRATE_FF 0.5
 param set-default FW_T_CLMB_MAX 3
 param set-default FW_T_SINK_MAX 3
 param set-default FW_T_SINK_MIN 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -33,9 +33,6 @@ param set-default CBRK_IO_SAFETY 22027
 
 param set-default EKF2_GPS_POS_X -0.12
 param set-default EKF2_IMU_POS_X -0.12
-param set-default EKF2_TAU_VEL 0.5
-param set-default EKF2_GPS_P_GATE 10
-param set-default EKF2_GPS_V_GATE 10
 
 param set-default FW_ARSP_MODE 1
 param set-default NPFG_PERIOD 25
@@ -51,7 +48,6 @@ param set-default FW_RR_P 0.18
 param set-default FW_T_CLMB_MAX 3
 param set-default FW_T_SINK_MAX 3
 param set-default FW_T_SINK_MIN 1
-param set-default FW_T_VERT_ACC 6
 param set-default FW_THR_TRIM 0.70
 param set-default FW_THR_SLEW_MAX 1
 param set-default FW_P_LIM_MAX 15
@@ -61,18 +57,11 @@ param set-default FW_P_RMAX_POS 45
 param set-default FW_R_RMAX 50
 param set-default FW_THR_MIN 0.55
 param set-default FW_BAT_SCALE_EN 1
-param set-default FW_THR_ALT_SCL 2.7
 param set-default FW_T_RLL2THR 20
-
-param set-default LNDMC_XY_VEL_MAX 1
-param set-default LNDMC_Z_VEL_MAX 0.7
 
 param set-default MC_ROLLRATE_P 0.16
 param set-default MC_ROLLRATE_I 0.01
-param set-default MC_ROLLRATE_MAX 80
 param set-default MC_PITCHRATE_I 0.05
-param set-default MC_PITCHRATE_MAX 80
-param set-default MC_YAW_P 3.5
 
 param set-default MC_YAWRATE_MAX 20
 param set-default MC_AIRMODE 1
@@ -81,16 +70,11 @@ param set-default MIS_DIST_1WP 100
 param set-default MIS_TAKEOFF_ALT 15
 
 param set-default MPC_XY_P 0.8
-param set-default MPC_XY_VEL_P_ACC 2
 param set-default MPC_XY_VEL_MAX 5
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_LAND_SPEED 1.2
 param set-default MPC_TILTMAX_LND 35
 param set-default MPC_Z_VEL_MAX_UP 1.5
-param set-default MPC_HOLD_MAX_XY 0.5
-param set-default MPC_HOLD_MAX_Z 0.5
 param set-default MPC_TKO_RAMP_T 0.8
-param set-default MPC_XY_CRUISE 5
 param set-default MPC_TILTMAX_AIR 25
 param set-default MPC_TILTMAX_LND 25
 param set-default MPC_YAWRAUTO_MAX 20
@@ -112,16 +96,13 @@ param set-default MAV_1_FORWARD 1
 param set-default SER_TEL2_BAUD 57600
 
 param set-default VT_TYPE 2
-param set-default VT_F_TRANS_THR 1
 param set-default VT_PITCH_MIN 8
 param set-default VT_FW_QC_P 55
 param set-default VT_FW_QC_R 55
 param set-default VT_TRANS_MIN_TM 15
 param set-default VT_FWD_THRUST_SC 4
-param set-default VT_F_TRANS_DUR 1
 param set-default VT_B_TRANS_THR 0.7
 param set-default VT_TRANS_TIMEOUT 22
-param set-default VT_F_TRANS_RAMP 4
 
 param set-default COM_RC_OVERRIDE 0
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -117,7 +117,6 @@ param set-default VT_PITCH_MIN 8
 param set-default VT_FW_QC_P 55
 param set-default VT_FW_QC_R 55
 param set-default VT_TRANS_MIN_TM 15
-param set-default VT_B_TRANS_DUR 8
 param set-default VT_FWD_THRUST_SC 4
 param set-default VT_F_TRANS_DUR 1
 param set-default VT_B_TRANS_THR 0.7

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -80,7 +80,6 @@ param set-default SENS_BOARD_ROT 4
 param set-default VT_ARSP_BLEND 10
 param set-default VT_ARSP_TRANS 21
 param set-default VT_B_DEC_MSS 1.5
-param set-default VT_B_TRANS_DUR 12
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_FWD_THRUST_SC 1.2
 param set-default VT_F_TR_OL_TM 8

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -52,21 +52,12 @@ param set-default MC_YAWRATE_I 0.15
 param set-default MC_YAWRATE_MAX 40
 param set-default MC_YAWRATE_P 0.3
 
-param set-default MPC_ACC_DOWN_MAX 2
-param set-default MPC_ACC_HOR_MAX 2
-param set-default MPC_ACC_UP_MAX 3
 param set-default MC_AIRMODE 1
-param set-default MPC_JERK_AUTO 4
 param set-default MPC_LAND_SPEED 1
 param set-default MPC_MAN_TILT_MAX 25
 param set-default MPC_MAN_Y_MAX 40
-param set-default COM_SPOOLUP_TIME 1.5
 param set-default MPC_THR_HOVER 0.45
 param set-default MPC_TILTMAX_AIR 25
-param set-default MPC_TKO_RAMP_T 1.8
-param set-default MPC_VEL_MANUAL 3
-param set-default MPC_XY_CRUISE 3
-param set-default MPC_XY_VEL_MAX 3.5
 param set-default MPC_YAWRAUTO_MAX 40
 param set-default MPC_Z_VEL_MAX_UP 2
 
@@ -83,7 +74,6 @@ param set-default VT_B_DEC_MSS 1.5
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_FWD_THRUST_SC 1.2
 param set-default VT_F_TR_OL_TM 8
-param set-default VT_PSHER_RMP_DT 2
 param set-default VT_TRANS_MIN_TM 4
 param set-default VT_TYPE 2
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -41,7 +41,6 @@ param set-default FW_R_RMAX 50
 param set-default FW_THR_TRIM 0.65
 param set-default FW_THR_MIN 0.3
 param set-default FW_THR_SLEW_MAX 0.6
-param set-default FW_T_HRATE_FF 0
 param set-default FW_T_SINK_MAX 15
 param set-default FW_T_SINK_MIN 3
 param set-default FW_YR_P 0.15

--- a/ROMFS/px4fmu_common/init.d/airframes/17003_TF-G2
+++ b/ROMFS/px4fmu_common/init.d/airframes/17003_TF-G2
@@ -26,7 +26,6 @@ param set-default BAT1_N_CELLS 3
 
 param set-default SENS_BOARD_ROT 4
 
-param set-default FW_AIRSPD_MAX 20
 param set-default FW_AIRSPD_MIN 7
 param set-default FW_AIRSPD_TRIM 13
 param set-default FW_THR_TRIM 0.8

--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -59,12 +59,9 @@ param set-default MC_YAWRATE_P 0.3
 param set-default CP_DIST 6
 param set-default MPC_ACC_DOWN_MAX 5
 param set-default MPC_ACC_HOR_MAX 10
-param set-default MPC_ACC_UP_MAX 4
 param set-default MPC_MAN_Y_MAX 120
-param set-default MPC_TILTMAX_AIR 45
 param set-default MPC_THR_HOVER 0.3
 param set-default MPC_VEL_MANUAL 5
-param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_VEL_MAX 5
 param set-default MPC_XY_VEL_P_ACC 1.58
 param set-default MPC_XY_TRAJ_P 0.3

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -59,13 +59,10 @@ param set-default MC_YAWRATE_P 0.3
 param set-default CP_DIST 6
 param set-default MPC_ACC_DOWN_MAX 5
 param set-default MPC_ACC_HOR_MAX 10
-param set-default MPC_ACC_UP_MAX 4
 param set-default MPC_MANTHR_MIN 0
 param set-default MPC_MAN_Y_MAX 120
-param set-default MPC_TILTMAX_AIR 45
 param set-default MPC_THR_HOVER 0.3
 param set-default MPC_VEL_MANUAL 5
-param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_VEL_MAX 5
 param set-default MPC_XY_VEL_P_ACC 1.58
 param set-default MPC_XY_TRAJ_P 0.3

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -19,7 +19,6 @@
 . ${R}etc/init.d/rc.mc_defaults
 
 param set-default CBRK_SUPPLY_CHK 894281
-param set-default CBRK_USB_CHK 197848
 
 param set-default IMU_GYRO_CUTOFF 100
 param set-default IMU_DGYRO_CUTOFF 60

--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -39,7 +39,6 @@ param set-default COM_RC_LOSS_T 3
 # ekf2
 param set-default EKF2_AID_MASK 33
 param set-default EKF2_TERR_MASK 1
-param set-default EKF2_BARO_DELAY 0
 param set-default EKF2_BARO_NOISE 2.0
 
 param set-default EKF2_BCOEF_X 31.5
@@ -47,13 +46,10 @@ param set-default EKF2_BCOEF_Y 25.5
 
 param set-default EKF2_GPS_DELAY 100
 param set-default EKF2_GPS_POS_X 0.06
-param set-default EKF2_GPS_POS_Y 0.0
-param set-default EKF2_GPS_POS_Z 0.0
 param set-default EKF2_GPS_V_NOISE 0.5
 
 param set-default EKF2_IMU_POS_X 0.06
 
-param set-default EKF2_MAG_DELAY 0
 param set-default EKF2_MAG_NOISE 0.1
 
 param set-default EKF2_MIN_RNG 0.15
@@ -61,7 +57,6 @@ param set-default EKF2_MIN_RNG 0.15
 param set-default EKF2_OF_DELAY 38
 param set-default EKF2_OF_GATE 2.0
 param set-default EKF2_OF_POS_X -0.035
-param set-default EKF2_OF_POS_Y 0.0
 param set-default EKF2_OF_POS_Z 0.033
 param set-default EKF2_OF_MIN_RNG 0.01
 param set-default EKF2_OF_A_HMAX 7.0
@@ -119,30 +114,20 @@ param set-default MPC_ACC_HOR_MAX 10.0
 param set-default MPC_ACC_UP_MAX 3.0
 param set-default MPC_ALT_MODE 0
 param set-default MPC_LAND_SPEED 0.5
-param set-default MPC_LAND_VEL_XY 10
 param set-default MPC_MAN_TILT_MAX 20
 param set-default MPC_YAWRAUTO_MAX 80.0
-param set-default MPC_POS_MODE 4
 param set-default MPC_THR_HOVER 0.54
 param set-default MPC_THR_MAX 0.9
 param set-default MPC_THR_MIN 0.06
 param set-default MPC_TILTMAX_AIR 30
 param set-default MPC_XY_P 1.0
-param set-default MPC_XY_VEL_D 0.005
-param set-default MPC_XY_VEL_I 0.02
-param set-default MPC_XY_VEL_P 0.15
 param set-default MPC_Z_P 2.0
-param set-default MPC_Z_VEL_D 0.0
-param set-default MPC_Z_VEL_I 0.02
 param set-default MPC_Z_VEL_MAX_DN 2.0
-param set-default MPC_Z_VEL_P 0.27
-
 
 # gimbal configuration
 param set-default MNT_MODE_IN 0
 param set-default MNT_MODE_OUT 1
 param set-default MNT_MAN_PITCH 2
-param set-default MNT_RC_IN_MODE 1
 param set-default MNT_RATE_PITCH 30
 
 # RC
@@ -165,7 +150,6 @@ param set-default RC1_TRIM          1000
 param set-default SENS_FLOW_MAXR   7.4
 param set-default SENS_FLOW_MINHGT 0.15
 param set-default SENS_FLOW_MAXHGT 5.0
-param set-default SENS_FLOW_ROT 0
 
 # ignore the SD card errors and use normal startup sound
 set STARTUP_TUNE "1"

--- a/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4071_ifo
@@ -22,10 +22,7 @@
 param set-default MC_ROLLRATE_D 0.0013
 param set-default MC_PITCHRATE_D 0.0016
 
-param set-default MC_YAW_FF 0.5
-
 param set-default MPC_MANTHR_MAX 0.9
-param set-default MPC_MANTHR_MIN 0.08
 
 # Filter settings
 param set-default IMU_DGYRO_CUTOFF 90
@@ -37,11 +34,8 @@ param set-default SENS_BOARD_ROT 10
 
 # EKF2
 param set-default EKF2_GND_EFF_DZ 6
-param set-default EKF2_HGT_REF 1
 
 # Position control
-param set-default MPC_Z_P 1
-param set-default MPC_Z_VEL_P_ACC 4
 param set-default MPC_Z_VEL_I_ACC 0.4
 
 param set-default MPC_THR_MIN 0.06
@@ -51,7 +45,6 @@ param set-default MIS_TAKEOFF_ALT 1.1
 param set-default MPC_XY_P 1.7
 param set-default MPC_XY_VEL_P_ACC 2.6
 param set-default MPC_XY_VEL_I_ACC 1.2
-param set-default MPC_XY_VEL_D_ACC 0.2
 param set-default MPC_TKO_RAMP_T 1
 param set-default MPC_VEL_MANUAL 3
 
@@ -59,7 +52,6 @@ param set-default BAT1_SOURCE 0
 param set-default BAT1_N_CELLS 4
 param set-default BAT1_V_DIV 10.14
 param set-default BAT1_A_PER_V 18.18
-param set-default COM_DISARM_LAND 2
 
 # Filter settings
 param set-default IMU_GYRO_CUTOFF 90

--- a/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
+++ b/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
@@ -23,9 +23,6 @@ param set-default MC_ROLLRATE_D 0.0013
 
 param set-default MC_PITCHRATE_D 0.0016
 
-
-param set-default MPC_MANTHR_MIN 0.08
-
 # Filter settings
 param set-default IMU_GYRO_CUTOFF 100
 
@@ -42,7 +39,6 @@ param set-default SENS_EN_BATT 1
 # EKF2
 param set-default EKF2_AID_MASK 3
 param set-default EKF2_GND_EFF_DZ 6
-param set-default EKF2_HGT_REF 1
 param set-default EKF2_MIN_RNG 0.3
 
 # Flow
@@ -60,7 +56,6 @@ param set-default MIS_TAKEOFF_ALT 1.1
 param set-default MPC_XY_P 1.7
 param set-default MPC_XY_VEL_P_ACC 2.6
 param set-default MPC_XY_VEL_I_ACC 1.2
-param set-default MPC_XY_VEL_D_ACC 0.2
 param set-default MPC_TKO_RAMP_T 1
 param set-default MPC_VEL_MANUAL 3
 
@@ -68,7 +63,6 @@ param set-default BAT1_SOURCE 0
 param set-default BAT1_N_CELLS 4
 param set-default BAT1_V_DIV 10.14
 param set-default BAT1_A_PER_V 18.18
-param set-default COM_DISARM_LAND 2
 
 # Filter settings
 param set-default IMU_GYRO_CUTOFF 90

--- a/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
@@ -21,7 +21,6 @@ param set-default BAT1_CAPACITY 240
 param set-default BAT1_SOURCE 1
 
 param set-default CBRK_SUPPLY_CHK 894281
-param set-default CBRK_USB_CHK 197848
 param set-default COM_RC_IN_MODE 1
 
 param set-default EKF2_ABL_LIM 2

--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -27,7 +27,6 @@ param set-default BAT1_N_CELLS 1
 param set-default BAT1_SOURCE 1
 
 param set-default CBRK_SUPPLY_CHK 894281
-param set-default CBRK_USB_CHK 197848
 param set-default COM_RC_IN_MODE 1
 
 param set-default IMU_GYRO_CUTOFF 100

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -39,8 +39,6 @@ param set-default GND_THR_CRUISE 0.3
 param set-default GND_THR_MAX 0.5
 param set-default GND_THR_MIN 0
 
-param set-default MIS_TAKEOFF_ALT 0.01
-
 param set-default NAV_ACC_RAD 0.5
 
 param set-default CA_AIRFRAME 5

--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -48,9 +48,6 @@ param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 0.5
 
-# Enable Airspeed check circuit breaker because Rovers will have no airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
-
 # Differential drive acts like ackermann steering with a maximum turn angle of 180 degrees, or pi radians
 param set-default GND_MAX_ANG 3.1415
 

--- a/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
+++ b/ROMFS/px4fmu_common/init.d/airframes/50003_aion_robotics_r1_rover
@@ -44,8 +44,6 @@ param set-default GND_SPEED_D 0.001
 param set-default GND_SPEED_IMAX 0.125
 param set-default GND_SPEED_THR_SC 1
 
-param set-default MIS_TAKEOFF_ALT 0.01
-
 param set-default NAV_ACC_RAD 0.5
 
 # Differential drive acts like ackermann steering with a maximum turn angle of 180 degrees, or pi radians

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
@@ -49,9 +49,6 @@ param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 0.5
 
-# Enable Airspeed check circuit breaker because Rovers will have no airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default CA_AIRFRAME 5
 
 param set-default CA_R_REV 1

--- a/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
+++ b/ROMFS/px4fmu_common/init.d/airframes/50004_nxpcup_car_dfrobot_gpx
@@ -45,8 +45,6 @@ param set-default GND_SPEED_D 0.001
 param set-default GND_SPEED_IMAX 0.125
 param set-default GND_SPEED_THR_SC 1
 
-param set-default MIS_TAKEOFF_ALT 0.01
-
 param set-default NAV_ACC_RAD 0.5
 
 param set-default CA_AIRFRAME 5

--- a/ROMFS/px4fmu_common/init.d/airframes/60000_uuv_generic
+++ b/ROMFS/px4fmu_common/init.d/airframes/60000_uuv_generic
@@ -13,10 +13,6 @@
 
 . ${R}etc/init.d/rc.uuv_defaults
 
-# disable circuit breaker for airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
-
-
 param set-default CA_AIRFRAME 7
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_R_REV 255

--- a/ROMFS/px4fmu_common/init.d/airframes/60001_uuv_hippocampus
+++ b/ROMFS/px4fmu_common/init.d/airframes/60001_uuv_hippocampus
@@ -13,9 +13,6 @@
 
 . ${R}etc/init.d/rc.uuv_defaults
 
-# disable circuit breaker for airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
-
 param set-default CA_AIRFRAME 7
 param set-default CA_ROTOR_COUNT 4
 param set-default CA_R_REV 255

--- a/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
@@ -23,8 +23,6 @@
 . ${R}etc/init.d/rc.uuv_defaults
 
 
-# disable circuit breaker for airspeed sensor
-param set-default CBRK_AIRSPD_CHK 162128
 # companion computer is connected via USB permanently
 param set-default CBRK_USB_CHK 197848
 param set-default CBRK_IO_SAFETY 22027

--- a/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
+++ b/ROMFS/px4fmu_common/init.d/airframes/60002_uuv_bluerov2_heavy
@@ -24,10 +24,7 @@
 
 
 # companion computer is connected via USB permanently
-param set-default CBRK_USB_CHK 197848
 param set-default CBRK_IO_SAFETY 22027
-
-param set-default COM_PREARM_MODE 0
 
 param set-default MAV_1_CONFIG 102
 

--- a/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
+++ b/ROMFS/px4fmu_common/init.d/airframes/6002_draco_r
@@ -41,14 +41,8 @@ param set-default MPC_ACC_HOR 8
 param set-default MPC_THR_MIN 0.06
 param set-default MPC_THR_HOVER 0.3
 # altitude control gains
-param set-default MPC_Z_P 1
-param set-default MPC_Z_VEL_P_ACC 4
 param set-default MPC_Z_VEL_I_ACC 0.4
 # position control gains
-param set-default MPC_XY_P 0.9500
-param set-default MPC_XY_VEL_P_ACC 1.8
-param set-default MPC_XY_VEL_I_ACC 0.4
-param set-default MPC_XY_VEL_D_ACC 0.2
 # etc gains
 param set-default MPC_TKO_RAMP_T 0.4
 param set-default MPC_VEL_MANUAL 5
@@ -69,8 +63,6 @@ param set-default MIS_TAKEOFF_ALT 1.1
 #####################################
 # EKF
 #####################################
-# Height mode as GPS
-param set-default EKF2_HGT_REF 1
 # Enable optical flow and GPS
 param set-default EKF2_MAG_TYPE 1
 param set-default EKF2_OF_QMIN 80

--- a/ROMFS/px4fmu_common/init.d/rc.rover_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.rover_defaults
@@ -10,9 +10,9 @@ set VEHICLE_TYPE rover
 # MAV_TYPE_GROUND_ROVER 10
 param set-default MAV_TYPE 10
 
-#
-# Default parameters for UGVs.
-#
+# Enable Airspeed check circuit breaker because Rovers will have no airspeed sensor
+param set-default CBRK_AIRSPD_CHK 162128
+
 param set-default MIS_TAKEOFF_ALT 0.01
 
 param set-default NAV_ACC_RAD 2

--- a/ROMFS/px4fmu_common/init.d/rc.uuv_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.uuv_defaults
@@ -9,3 +9,6 @@ set VEHICLE_TYPE uuv
 
 # MAV_TYPE_SUBMARINE 12
 param set-default MAV_TYPE 12
+
+# UUV don't have an airspeed sensor, so disable checks around it
+param set-default CBRK_AIRSPD_CHK 162128

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -27,7 +27,6 @@ param set-default MIS_TKO_LAND_REQ 2
 
 param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_VEL_MANUAL 5
-param set-default MPC_XY_CRUISE 5
 param set-default MPC_XY_ERR_MAX 5
 param set-default MPC_XY_VEL_MAX 8
 param set-default MPC_JERK_MAX 4.5

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -77,9 +77,10 @@ PARAM_DEFINE_INT32(VT_ELEV_MC_LOCK, 1);
 PARAM_DEFINE_FLOAT(VT_F_TRANS_DUR, 5.0f);
 
 /**
- * Duration of a back transition
+ * Maximum duration of a back transition
  *
- * Time in seconds used for a back transition
+ * Time in seconds used for a back transition maximally.
+ * Transition is also declared over if the groundspeed drops below MPC_XY_CRUISE.
  *
  * @unit s
  * @min 0.1
@@ -88,7 +89,7 @@ PARAM_DEFINE_FLOAT(VT_F_TRANS_DUR, 5.0f);
  * @decimal 2
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 4.0f);
+PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 10.0f);
 
 /**
  * Target throttle value for the transition to fixed-wing flight.

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -107,22 +107,6 @@ PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 10.0f);
 PARAM_DEFINE_FLOAT(VT_F_TRANS_THR, 1.0f);
 
 /**
- * Target throttle value for the transition to hover flight.
- *
- * standard vtol: pusher
- *
- * tailsitter, tiltrotor: main throttle
- *
- *
- * @min -1
- * @max 1
- * @increment 0.01
- * @decimal 2
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_B_TRANS_THR, 0.0f);
-
-/**
  * Approximate deceleration during back transition
  *
  * The approximate deceleration during a back transition in m/s/s

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -324,7 +324,6 @@ protected:
 					(ParamFloat<px4::params::VT_B_TRANS_DUR>) _param_vt_b_trans_dur,
 					(ParamFloat<px4::params::VT_ARSP_TRANS>) _param_vt_arsp_trans,
 					(ParamFloat<px4::params::VT_F_TRANS_THR>) _param_vt_f_trans_thr,
-					(ParamFloat<px4::params::VT_B_TRANS_THR>) _param_vt_b_trans_thr,
 					(ParamFloat<px4::params::VT_ARSP_BLEND>) _param_vt_arsp_blend,
 					(ParamBool<px4::params::FW_ARSP_MODE>) _param_fw_arsp_mode,
 					(ParamFloat<px4::params::VT_TRANS_TIMEOUT>) _param_vt_trans_timeout,


### PR DESCRIPTION

### Solved Problem
Frees up 1.1KB of flash and keeps the airframe configs more maintainable by removing params from the custom configs that were simply reset to the default value already set either in the param definition or in the vehicle defaults. 
For the VTOLs I additionally removed outdated tuning that is not founded on hardware specs of the corresponding vehicles. 

On the v5x it reduces flash usage from 100.28% to 100.23%, so this alone doesn't fix the over flash issue. 

### Changelog Entry
Shouldn't affect behavior.
