### PR TITLE
mission: only run update_mission() if mission is updated, not when reset due to landing

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -115,6 +115,8 @@ Mission::on_inactive()
 			reset_mission(_mission);
 			_navigator->reset_cruising_speed();
 			_current_mission_index = 0;
+			_navigator->reset_vroi();
+			set_current_mission_item();
 		}
 
 	} else {

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -113,8 +113,8 @@ Mission::on_inactive()
 		/* reset the current mission if needed */
 		if (need_to_reset_mission()) {
 			reset_mission(_mission);
-			update_mission();
 			_navigator->reset_cruising_speed();
+			_current_mission_index = 0;
 		}
 
 	} else {


### PR DESCRIPTION

### Solved Problem
When landing with a mission stored on the vehicle, that has not been updated since power cycling, these errors appear:
```
ERROR [navigator] mission update failed
WARN  [mavlink] ERROR: wp index out of bounds
```

### Solution
The errors come from the fact that when the mission is not updated, the [_mission_sub.copy(_mission) ](https://github.com/PX4/PX4-Autopilot/blob/202e2770da50caff0ed00c06a574e3c39933df52/src/modules/navigator/mission.cpp#L524)returns false, and thus the code below is not run, which would [reset _current_mission_index to 0 over current_seq](https://github.com/PX4/PX4-Autopilot/blob/202e2770da50caff0ed00c06a574e3c39933df52/src/modules/navigator/mission.cpp#L527), that was previously set to 0 in reset_mission. 
I thus here propose to only run `update_mission()` when the mission was actually updated, and otherwise, when we need to reset the mission on landing, only reset `_current_mission_index` to 0. 

What I'm not very sure yet: do we want to run the mission feasibility checks also on the reset? 

### Changelog Entry
Not relevant.

### Alternatives
Remove the whole auto-reset logic on landing? It's not given that a mission should always start from 0. Though then the option in QGC should be there to reset the mission on landing/on vehicle boot.

### Test coverage
SITL tested. 


