### PR TITLE
drivers/gps: increase stack to handle gps dump config for RTCM output (PPK)

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -108,7 +108,7 @@ struct GPS_Sat_Info {
 	satellite_info_s _data;
 };
 
-static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(1990);
+static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(2040);
 
 
 class GPS : public ModuleBase<GPS>, public device::Device


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
GPS driver is out of stack again when using dump config for PPK.

### Solution
Increase stack 50 more bytes.

### Changelog Entry
Likely not interesting for release notes.

### Test coverage
Stack warnings were a bit sporadic, but will update from flight tests in next couple days if still not enough. Really should handle it now after this second increase.