### PR TITLE
publish actuator topics iff allocation is done 

### DIFF
--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -429,10 +429,10 @@ ControlAllocator::Run()
 
 			_control_allocation[i]->clipActuatorSetpoint();
 		}
-	}
 
-	// Publish actuator setpoint and allocator status
-	publish_actuator_controls();
+		// Publish actuator setpoint
+		publish_actuator_controls();
+	}
 
 	// Publish status at limited rate, as it's somewhat expensive and we use it for slower dynamics
 	// (i.e. anti-integrator windup)


### PR DESCRIPTION
## Context
Currently there are no manual pass-through or rather a way in which the functions allocated to the outputs can be dynamically change during flight to listen to the `manual_control_setpoint` topic in case of an emergency(hardware failure). To fix this, we have our own module which publishes to the `actuator_servos` and `actuator_motors` based on the `manual_control_setpoint` message if we are flying in full manual mode. Once we are in a controlled mode, the `control_allocator` module is the only module publishing to those topics.

Having another module (like ours, or any other module running alongside `control_allocator`) publishing to the `actuator_servos` and `actuator_motors` topics will result in undesired behavior because the `control_allocator` module will introduce unwanted null containing setpoints to the motors and or servos even if there are no updates on the `vehicle_thrust_setpoint` and or `vehicle_torque_setpoint` topic.
