### PR TITLE
Support 15 servos on DroneCAN

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/24001_dodeca_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/24001_dodeca_cox
@@ -67,3 +67,22 @@ param set-default CA_ROTOR11_PY -0.25
 param set-default CA_ROTOR11_PZ -0.05
 param set-default CA_ROTOR11_KM -0.05
 
+param set-default CA_ROTOR12_PX 0.0
+param set-default CA_ROTOR12_PY 0.0
+param set-default CA_ROTOR12_PZ 0.0
+param set-default CA_ROTOR12_KM 0.0
+
+param set-default CA_ROTOR13_PX 0.0
+param set-default CA_ROTOR13_PY 0.0
+param set-default CA_ROTOR13_PZ 0.0
+param set-default CA_ROTOR13_KM 0.0
+
+param set-default CA_ROTOR14_PX -0.0
+param set-default CA_ROTOR14_PY -0.0
+param set-default CA_ROTOR14_PZ -0.0
+param set-default CA_ROTOR14_KM -0.0
+
+param set-default CA_ROTOR15_PX 0.0
+param set-default CA_ROTOR15_PY 0.0
+param set-default CA_ROTOR15_PZ 0.0
+param set-default CA_ROTOR15_KM 0.0

--- a/msg/ActuatorMotors.msg
+++ b/msg/ActuatorMotors.msg
@@ -6,7 +6,7 @@ uint16 reversible_flags     # bitset which motors are configured to be reversibl
 
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
 
-uint8 NUM_CONTROLS = 12
-float32[12] control # range: [-1, 1], where 1 means maximum positive thrust,
+uint8 NUM_CONTROLS = 20
+float32[20] control # range: [-1, 1], where 1 means maximum positive thrust,
                     # -1 maximum negative (if not supported by the output, <0 maps to NaN),
                     # and NaN maps to disarmed (stop the motors)

--- a/msg/ActuatorMotors.msg
+++ b/msg/ActuatorMotors.msg
@@ -6,7 +6,7 @@ uint16 reversible_flags     # bitset which motors are configured to be reversibl
 
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
 
-uint8 NUM_CONTROLS = 20
+uint8 NUM_CONTROLS = 16
 float32[20] control # range: [-1, 1], where 1 means maximum positive thrust,
                     # -1 maximum negative (if not supported by the output, <0 maps to NaN),
                     # and NaN maps to disarmed (stop the motors)

--- a/msg/ActuatorServos.msg
+++ b/msg/ActuatorServos.msg
@@ -2,7 +2,7 @@
 uint64 timestamp			# time since system start (microseconds)
 uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
 
-uint8 NUM_CONTROLS = 8
-float32[8] control # range: [-1, 1], where 1 means maximum positive position,
+uint8 NUM_CONTROLS = 15
+float32[15] control # range: [-1, 1], where 1 means maximum positive position,
                    # -1 maximum negative,
                    # and NaN maps to disarmed

--- a/msg/ActuatorServosTrim.msg
+++ b/msg/ActuatorServosTrim.msg
@@ -1,5 +1,5 @@
 # Servo trims, added as offset to servo outputs
 uint64 timestamp			# time since system start (microseconds)
 
-uint8 NUM_CONTROLS = 8
-float32[8] trim    # range: [-1, 1]
+uint8 NUM_CONTROLS = 15
+float32[15] trim    # range: [-1, 1]

--- a/msg/ActuatorTest.msg
+++ b/msg/ActuatorTest.msg
@@ -6,7 +6,7 @@ uint8 ACTION_RELEASE_CONTROL = 0	# exit test mode for the given function
 uint8 ACTION_DO_CONTROL = 1			# enable actuator test mode
 
 uint8 FUNCTION_MOTOR1 = 101
-uint8 MAX_NUM_MOTORS  = 12
+uint8 MAX_NUM_MOTORS  = 20
 uint8 FUNCTION_SERVO1 = 201
 uint8 MAX_NUM_SERVOS  = 15
 

--- a/msg/ActuatorTest.msg
+++ b/msg/ActuatorTest.msg
@@ -6,7 +6,7 @@ uint8 ACTION_RELEASE_CONTROL = 0	# exit test mode for the given function
 uint8 ACTION_DO_CONTROL = 1			# enable actuator test mode
 
 uint8 FUNCTION_MOTOR1 = 101
-uint8 MAX_NUM_MOTORS  = 20
+uint8 MAX_NUM_MOTORS  = 16
 uint8 FUNCTION_SERVO1 = 201
 uint8 MAX_NUM_SERVOS  = 15
 

--- a/msg/ActuatorTest.msg
+++ b/msg/ActuatorTest.msg
@@ -8,7 +8,7 @@ uint8 ACTION_DO_CONTROL = 1			# enable actuator test mode
 uint8 FUNCTION_MOTOR1 = 101
 uint8 MAX_NUM_MOTORS  = 12
 uint8 FUNCTION_SERVO1 = 201
-uint8 MAX_NUM_SERVOS  = 8
+uint8 MAX_NUM_SERVOS  = 15
 
 uint8 action					# one of ACTION_*
 uint16 function					# actuator output function

--- a/msg/EscStatus.msg
+++ b/msg/EscStatus.msg
@@ -1,5 +1,5 @@
 uint64 timestamp					# time since system start (microseconds)
-uint8 CONNECTED_ESC_MAX = 8				# The number of ESCs supported. Current (Q2/2013) we support 8 ESCs
+uint8 CONNECTED_ESC_MAX = 20				# The number of ESCs supported.
 
 uint8 ESC_CONNECTION_TYPE_PPM = 0			# Traditional PPM ESC
 uint8 ESC_CONNECTION_TYPE_SERIAL = 1			# Serial Bus connected ESC
@@ -25,4 +25,4 @@ uint8 esc_online_flags					# Bitmask indicating which ESC is online/offline
 
 uint8 esc_armed_flags					# Bitmask indicating which ESC is armed. For ESC's where the arming state is not known (returned by the ESC), the arming bits should always be set.
 
-EscReport[8] esc
+EscReport[20] esc

--- a/msg/EscStatus.msg
+++ b/msg/EscStatus.msg
@@ -1,5 +1,5 @@
 uint64 timestamp					# time since system start (microseconds)
-uint8 CONNECTED_ESC_MAX = 20				# The number of ESCs supported.
+uint8 CONNECTED_ESC_MAX = 16				# The number of ESCs supported.
 
 uint8 ESC_CONNECTION_TYPE_PPM = 0			# Traditional PPM ESC
 uint8 ESC_CONNECTION_TYPE_SERIAL = 1			# Serial Bus connected ESC
@@ -25,4 +25,4 @@ uint8 esc_online_flags					# Bitmask indicating which ESC is online/offline
 
 uint8 esc_armed_flags					# Bitmask indicating which ESC is armed. For ESC's where the arming state is not known (returned by the ESC), the arming bits should always be set.
 
-EscReport[20] esc
+EscReport[16] esc

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -48,7 +48,7 @@
 
 __BEGIN_DECLS
 
-#define PWM_OUTPUT_MAX_CHANNELS 16
+#define PWM_OUTPUT_MAX_CHANNELS 20
 
 /* Use defaults unless the board override the defaults by providing
  * PX4_PWM_ALTERNATE_RANGES and a replacement set of

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -48,7 +48,7 @@
 
 __BEGIN_DECLS
 
-#define PWM_OUTPUT_MAX_CHANNELS 20
+#define PWM_OUTPUT_MAX_CHANNELS 16
 
 /* Use defaults unless the board override the defaults by providing
  * PX4_PWM_ALTERNATE_RANGES and a replacement set of

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -45,7 +45,7 @@
 class UavcanServoController
 {
 public:
-	static constexpr int MAX_ACTUATORS = 8;
+	static constexpr int MAX_ACTUATORS = 15;
 	static constexpr unsigned MAX_RATE_HZ = 50;
 	static constexpr unsigned UAVCAN_COMMAND_TRANSFER_PRIORITY = 6;	///< 0..31, inclusive, 0 - highest, 31 - lowest
 

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -24,4 +24,4 @@ actuator_output:
         min: { min: 0, max: 1000, default: 0 }
         max: { min: 0, max: 1000, default: 1000 }
         failsafe: { min: 0, max: 1000 }
-      num_channels: 8
+      num_channels: 15

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -15,7 +15,7 @@ actuator_output:
         min: { min: 0, max: 8191, default: 1 }
         max: { min: 0, max: 8191, default: 8191 }
         failsafe: { min: 0, max: 8191 }
-      num_channels: 20
+      num_channels: 16
     - param_prefix: UAVCAN_SV
       group_label: 'Servos'
       channel_label: 'Servo'

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -15,7 +15,7 @@ actuator_output:
         min: { min: 0, max: 8191, default: 1 }
         max: { min: 0, max: 8191, default: 8191 }
         failsafe: { min: 0, max: 8191 }
-      num_channels: 8
+      num_channels: 20
     - param_prefix: UAVCAN_SV
       group_label: 'Servos'
       channel_label: 'Servo'

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -9,7 +9,7 @@ functions:
 
     Motor:
       start: 101
-      count: 12
+      count: 20
     Servo:
       start: 201
       count: 15

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -9,7 +9,7 @@ functions:
 
     Motor:
       start: 101
-      count: 20
+      count: 16
     Servo:
       start: 201
       count: 15

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -12,7 +12,7 @@ functions:
       count: 12
     Servo:
       start: 201
-      count: 8
+      count: 15
     Offboard_Actuator_Set:
       start: 301
       count: 6

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1,4 +1,4 @@
-__max_num_mc_motors: &max_num_mc_motors 20
+__max_num_mc_motors: &max_num_mc_motors 16
 __max_num_servos: &max_num_servos 15
 __max_num_tilts: &max_num_tilts 4
 
@@ -67,10 +67,6 @@ parameters:
                 13: Motor 14
                 14: Motor 15
                 15: Motor 16
-                16: Motor 17
-                17: Motor 18
-                18: Motor 19
-                19: Motor 20
             default: 0
         CA_R${i}_SLEW:
             description:
@@ -132,9 +128,6 @@ parameters:
                 14: '14'
                 15: '15'
                 16: '16'
-                17: '17'
-                18: '18'
-                19: '19'
             default: 0
         CA_ROTOR${i}_PX:
             description:

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -63,6 +63,14 @@ parameters:
                 9: Motor 10
                 10: Motor 11
                 11: Motor 12
+                12: Motor 13
+                13: Motor 14
+                14: Motor 15
+                15: Motor 16
+                16: Motor 17
+                17: Motor 18
+                18: Motor 19
+                19: Motor 20
             default: 0
         CA_R${i}_SLEW:
             description:
@@ -120,6 +128,13 @@ parameters:
                 10: '10'
                 11: '11'
                 12: '12'
+                13: '13'
+                14: '14'
+                15: '15'
+                16: '16'
+                17: '17'
+                18: '18'
+                19: '19'
             default: 0
         CA_ROTOR${i}_PX:
             description:

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1,5 +1,5 @@
-__max_num_mc_motors: &max_num_mc_motors 12
-__max_num_servos: &max_num_servos 8
+__max_num_mc_motors: &max_num_mc_motors 20
+__max_num_servos: &max_num_servos 15
 __max_num_tilts: &max_num_tilts 4
 
 module_name: Control Allocation


### PR DESCRIPTION
Currently only 8 servos can be command simultaneously over DroneCAN, but `uavcan::equipment::actuator::ArrayCommand` takes up to 15 Servo commands (`uavcan::equipment::actuator::Command`) 

This changes bring the number of servos which can be commanded simultaneously to 15.

## Testing

Using a Hitec Servo and setting its ID to 15, and by using the actuator tab on QGC it was following the slider commands as expected. 