### PR TITLE
Makefile: validate_module_configs skips src/lib/events/libevents/*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -484,6 +484,7 @@ validate_module_configs:
 	@find "$(SRC_DIR)"/src/modules "$(SRC_DIR)"/src/drivers "$(SRC_DIR)"/src/lib -name *.yaml -type f \
 	-not -path "$(SRC_DIR)/src/lib/mixer_module/*" \
 	-not -path "$(SRC_DIR)/src/modules/microdds_client/dds_topics.yaml" \
+	-not -path "$(SRC_DIR)/src/lib/events/libevents/*" \
 	-not -path "$(SRC_DIR)/src/lib/crypto/libtommath/*" -print0 | \
 	xargs -0 "$(SRC_DIR)"/Tools/validate_yaml.py --schema-file "$(SRC_DIR)"/validation/module_schema.yaml
 


### PR DESCRIPTION
### Solved Problem

`validate_module_configs` target is checking against unrelated yaml file

```sh
(venv) salimterryli@stl-laptop:/media/dev-linux/px4/Firmware$ make validate_module_configs
Validation Errors:
{'body': ['unknown field'], 'description': ['unknown field'], 'labels': ['unknown field'], 'module_name': ['required field'], 'name': ['unknown field']}

Traceback (most recent call last):
  File "/media/dev-linux/px4/Firmware/Tools/validate_yaml.py", line 67, in <module>
    raise Exception("Validation of {:} failed".format(yaml_file))
Exception: Validation of /media/dev-linux/px4/Firmware/src/lib/events/libevents/libs/cpp/parse/nlohmann_json/.github/ISSUE_TEMPLATE/bug.yaml failed
make: *** [Makefile:484: validate_module_configs] Error 123
```