### PR TITLE
vtol_type: scale VT_TRANS_TIMEOUT with air density

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -347,9 +347,9 @@ bool VtolType::isRollExceeded()
 bool VtolType::isFrontTransitionTimeout()
 {
 	// check front transition timeout
-	if (_param_vt_trans_timeout.get()  > FLT_EPSILON && _common_vtol_mode == mode::TRANSITION_TO_FW) {
+	if (getFrontTransitionTimeout()  > FLT_EPSILON && _common_vtol_mode == mode::TRANSITION_TO_FW) {
 
-		if (_time_since_trans_start > _param_vt_trans_timeout.get()) {
+		if (_time_since_trans_start > getFrontTransitionTimeout()) {
 			// transition timeout occured, abort transition
 			return true;
 		}
@@ -580,6 +580,11 @@ float VtolType::getFrontTransitionTimeFactor() const
 float VtolType::getMinimumFrontTransitionTime() const
 {
 	return getFrontTransitionTimeFactor() * _param_vt_trans_min_tm.get();
+}
+
+float VtolType::getFrontTransitionTimeout() const
+{
+	return getFrontTransitionTimeFactor() * _param_vt_trans_timeout.get();
 }
 
 float VtolType::getOpenLoopFrontTransitionTime() const

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -228,6 +228,11 @@ public:
 	float getMinimumFrontTransitionTime() const;
 
 	/**
+	 * @return Front transition timeout scaled for air density (if available) [s]
+	*/
+	float getFrontTransitionTimeout() const;
+
+	/**
 	* @return Minimum open-loop front transition time scaled for air density (if available) [s]
 	*/
 	float getOpenLoopFrontTransitionTime() const;


### PR DESCRIPTION
VT_TRANS_MIN_TM and VT_F_TR_OL_TM are scaled with density altitude. This was not yet the case for the timeout, but should be done here as well.