### PR TITLE
Add condition for Iridium mode to not send params change after a timeout

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3256,7 +3256,9 @@ MavlinkReceiver::run()
 			_mission_manager.check_active_mission();
 			_mission_manager.send();
 
-			_parameters_manager.send();
+			if (_mavlink->get_mode() != Mavlink::MAVLINK_MODE::MAVLINK_MODE_IRIDIUM) {
+				_parameters_manager.send();
+			}
 
 			if (_mavlink->ftp_enabled()) {
 				_mavlink_ftp.send();


### PR DESCRIPTION
In the mavlink_receiver code, after a while it will try to resend some parameter update through the MAVLink instance. But for Iridium links those are not a good idea. So this adds a condition that prevent the sending if the MAVLink instance is in Iridium mode.

Related to issue #21496

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I found that adding a condition for the MAVLink mode of the instance the MAVLink receiver is in prevent the sending of PARAM_VALUE message on the interface.

Fixes #21496 [Sporadic PARAM_VALUE message being sent through an Iridium interface
](https://github.com/PX4/PX4-Autopilot/issues/21496)

### Solution
- Add simply to add an if condition around the `_parameters_manager.send();` function in the `mavlink_receiver.cpp` file. 

### Test coverage
- Tested it only manually on my setup, and I wasn't able to reproduce the bug with this fix.

### Context
Most of the information is inside the issue :). But don't hesitate to ask for more. 
