### PR TITLE
EKF2: deprecate aid mask

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
@@ -30,10 +30,10 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 
 # EKF2
-param set-default EKF2_AID_MASK 2
 param set-default EKF2_GPS_CTRL 0
 param set-default EKF2_EVP_NOISE 0.05
 param set-default EKF2_EVA_NOISE 0.05
+param set-default EKF2_OF_CTRL 1
 
 # LPE: Flow-only mode
 param set-default LPE_FUSION 242

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1017_gazebo-classic_iris_opt_flow_mockup
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1017_gazebo-classic_iris_opt_flow_mockup
@@ -30,8 +30,8 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 
 # EKF2
-param set-default EKF2_AID_MASK 2
 param set-default EKF2_GPS_CTRL 0
+param set-default EKF2_OF_CTRL 1
 
 # LPE: Flow-only mode
 param set-default LPE_FUSION 242

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4006_gz_px4vision
@@ -23,11 +23,12 @@ param set-default COM_OBS_AVOID 0
 param set-default COM_DISARM_LAND 0.5
 
 # EKF2 parameters
-param set-default EKF2_AID_MASK 35
+param set-default EKF2_DRAG_CTRL 1
 param set-default EKF2_IMU_POS_X 0.02
 param set-default EKF2_GPS_POS_X 0.055
 param set-default EKF2_GPS_POS_Z -0.15
 param set-default EKF2_MIN_RNG 0.03
+param set-default EKF2_OF_CTRL 1
 param set-default EKF2_OF_POS_X 0.055
 param set-default EKF2_OF_POS_Y 0.02
 param set-default EKF2_OF_POS_Z 0.065

--- a/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
+++ b/ROMFS/px4fmu_common/init.d/airframes/4016_holybro_px4vision
@@ -16,11 +16,12 @@ param set-default COM_OBS_AVOID 1
 param set-default COM_DISARM_LAND 0.5
 
 # EKF2 parameters
-param set-default EKF2_AID_MASK 35
+param set-default EKF2_DRAG_CTRL 1
 param set-default EKF2_IMU_POS_X 0.02
 param set-default EKF2_GPS_POS_X 0.055
 param set-default EKF2_GPS_POS_Z -0.15
 param set-default EKF2_MIN_RNG 0.03
+param set-default EKF2_OF_CTRL 1
 param set-default EKF2_OF_POS_X 0.055
 param set-default EKF2_OF_POS_Y 0.02
 param set-default EKF2_OF_POS_Z 0.065

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_holybro_px4vision_v1_5
@@ -16,11 +16,12 @@ param set-default COM_OBS_AVOID 1
 param set-default COM_DISARM_LAND 0.5
 
 # EKF2 parameters
-param set-default EKF2_AID_MASK 35
+param set-default EKF2_DRAG_CTRL 1
 param set-default EKF2_IMU_POS_X 0.02
 param set-default EKF2_GPS_POS_X 0.055
 param set-default EKF2_GPS_POS_Z -0.15
 param set-default EKF2_MIN_RNG 0.03
+param set-default EKF2_OF_CTRL 1
 param set-default EKF2_OF_POS_X 0.055
 param set-default EKF2_OF_POS_Y 0.02
 param set-default EKF2_OF_POS_Z 0.065

--- a/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
+++ b/ROMFS/px4fmu_common/init.d/airframes/4061_atl_mantis_edu
@@ -37,12 +37,13 @@ param set-default COM_RC_LOSS_T 3
 
 
 # ekf2
-param set-default EKF2_AID_MASK 33
 param set-default EKF2_TERR_MASK 1
 param set-default EKF2_BARO_NOISE 2.0
 
 param set-default EKF2_BCOEF_X 31.5
 param set-default EKF2_BCOEF_Y 25.5
+
+param set-default EKF2_DRAG_CTRL 1
 
 param set-default EKF2_GPS_DELAY 100
 param set-default EKF2_GPS_POS_X 0.06

--- a/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
+++ b/ROMFS/px4fmu_common/init.d/airframes/4073_ifo-s
@@ -37,11 +37,11 @@ param set-default SENS_TFMINI_CFG 103
 param set-default SENS_EN_BATT 1
 
 # EKF2
-param set-default EKF2_AID_MASK 3
 param set-default EKF2_GND_EFF_DZ 6
 param set-default EKF2_MIN_RNG 0.3
 
 # Flow
+param set-default EKF2_OF_CTRL 1
 param set-default EKF2_OF_QMIN 70
 
 # Position control

--- a/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
@@ -24,10 +24,10 @@ param set-default CBRK_SUPPLY_CHK 894281
 param set-default COM_RC_IN_MODE 1
 
 param set-default EKF2_ABL_LIM 2
-param set-default EKF2_AID_MASK 3
 param set-default EKF2_HGT_REF 2
 param set-default EKF2_RNG_CTRL 2
 param set-default EKF2_MAG_TYPE 1
+param set-default EKF2_OF_CTRL 1
 param set-default EKF2_OF_DELAY 10
 
 param set-default IMU_GYRO_CUTOFF 100

--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -19,7 +19,7 @@
 
 param set-default SYS_MC_EST_GROUP 2
 param set-default SYS_HAS_MAG 0
-param set-default EKF2_AID_MASK 2
+param set-default EKF2_OF_CTRL 1
 param set-default EKF2_GPS_CTRL 0
 param set-default EKF2_MAG_TYPE 5
 

--- a/boards/modalai/voxl2/target/voxl-px4-set-default-parameters.config
+++ b/boards/modalai/voxl2/target/voxl-px4-set-default-parameters.config
@@ -12,8 +12,9 @@ param set IMU_GYRO_RATEMAX 800
 param set EKF2_IMU_POS_X 0.027
 param set EKF2_IMU_POS_Y 0.009
 param set EKF2_IMU_POS_Z -0.019
+param set EKF2_EV_CTRL 15
 param set EKF2_EV_DELAY 5
-param set EKF2_AID_MASK 280
+param set EKF2_GPS_CTRL 0
 param set EKF2_ABL_LIM 0.8
 param set EKF2_TAU_POS 0.25
 param set EKF2_TAU_VEL 0.25

--- a/src/modules/ekf2/EKF/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/airspeed_fusion.cpp
@@ -57,7 +57,7 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 	const bool airspeed_timed_out = isTimedOut(_aid_src_airspeed.time_last_fuse, (uint64_t)10e6);
 	const bool sideslip_timed_out = isTimedOut(_aid_src_sideslip.time_last_fuse, (uint64_t)10e6);
 
-	if (_control_status.flags.fake_pos || (airspeed_timed_out && sideslip_timed_out && !(_params.fusion_mode & SensorFusionMask::USE_DRAG))) {
+	if (_control_status.flags.fake_pos || (airspeed_timed_out && sideslip_timed_out && (_params.drag_ctrl == 0))) {
 		_control_status.flags.wind = false;
 	}
 

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -158,7 +158,7 @@ enum class EvCtrl : uint8_t {
 enum SensorFusionMask : uint16_t {
 	// Bit locations for fusion_mode
 	DEPRECATED_USE_GPS = (1<<0),    ///< set to true to use GPS data (DEPRECATED, use gnss_ctrl)
-	USE_OPT_FLOW     = (1<<1),      ///< set to true to use optical flow data
+	DEPRECATED_USE_OPT_FLOW     = (1<<1), ///< set to true to use optical flow data
 	DEPRECATED_INHIBIT_ACC_BIAS = (1<<2), ///< set to true to inhibit estimation of accelerometer delta velocity bias
 	DEPRECATED_USE_EXT_VIS_POS = (1<<3), ///< set to true to use external vision position data
 	DEPRECATED_USE_EXT_VIS_YAW = (1<<4), ///< set to true to use external vision quaternion data for yaw
@@ -423,6 +423,7 @@ struct parameters {
 	float gravity_noise{1.0f};              ///< accelerometer measurement gaussian noise (m/s**2)
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
+	int32_t flow_ctrl{0};
 	float flow_delay_ms{5.0f};              ///< optical flow measurement delay relative to the IMU (mSec) - this is to the middle of the optical flow integration interval
 
 	// optical flow fusion

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -162,7 +162,7 @@ enum SensorFusionMask : uint16_t {
 	DEPRECATED_INHIBIT_ACC_BIAS = (1<<2), ///< set to true to inhibit estimation of accelerometer delta velocity bias
 	DEPRECATED_USE_EXT_VIS_POS = (1<<3), ///< set to true to use external vision position data
 	DEPRECATED_USE_EXT_VIS_YAW = (1<<4), ///< set to true to use external vision quaternion data for yaw
-	USE_DRAG         = (1<<5),      ///< set to true to use the multi-rotor drag model to estimate wind
+	DEPRECATED_USE_DRAG         = (1<<5), ///< set to true to use the multi-rotor drag model to estimate wind
 	DEPRECATED_ROTATE_EXT_VIS  = (1<<6), ///< set to true to if the EV observations are in a non NED reference frame and need to be rotated before being used
 	DEPRECATED_USE_GPS_YAW     = (1<<7), ///< set to true to use GPS yaw data if available (DEPRECATED, use gnss_ctrl)
 	DEPRECATED_USE_EXT_VIS_VEL = (1<<8), ///< set to true to use external vision velocity data
@@ -477,6 +477,7 @@ struct parameters {
 
 #if defined(CONFIG_EKF2_DRAG_FUSION)
 	// multi-rotor drag specific force fusion
+	int32_t drag_ctrl{0};
 	float drag_noise{2.5f};                 ///< observation noise variance for drag specific force measurements (m/sec**2)**2
 	float bcoef_x{100.0f};                  ///< bluff body drag ballistic coefficient for the X-axis (kg/m**2)
 	float bcoef_y{100.0f};                  ///< bluff body drag ballistic coefficient for the Y-axis (kg/m**2)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -105,7 +105,7 @@ enum MagFuseType : uint8_t {
 	MAG_3D  = 2,   	///< Magnetometer 3-axis fusion will always be used. This is more accurate, but more affected by localised earth field distortions
 	UNUSED  = 3,    ///< Not implemented
 	INDOOR  = 4,   	///< The same as option 0, but magnetometer or yaw fusion will not be used unless earth frame external aiding (GPS or External Vision) is being used. This prevents inconsistent magnetic fields associated with indoor operation degrading state estimates.
-	NONE    = 5    	///< Do not use magnetometer under any circumstance. Other sources of yaw may be used if selected via the EKF2_AID_MASK parameter.
+	NONE    = 5    	///< Do not use magnetometer under any circumstance..
 };
 
 #if defined(CONFIG_EKF2_RANGE_FINDER)
@@ -153,19 +153,6 @@ enum class EvCtrl : uint8_t {
 	VPOS = (1<<1),
 	VEL  = (1<<2),
 	YAW  = (1<<3)
-};
-
-enum SensorFusionMask : uint16_t {
-	// Bit locations for fusion_mode
-	DEPRECATED_USE_GPS = (1<<0),    ///< set to true to use GPS data (DEPRECATED, use gnss_ctrl)
-	DEPRECATED_USE_OPT_FLOW     = (1<<1), ///< set to true to use optical flow data
-	DEPRECATED_INHIBIT_ACC_BIAS = (1<<2), ///< set to true to inhibit estimation of accelerometer delta velocity bias
-	DEPRECATED_USE_EXT_VIS_POS = (1<<3), ///< set to true to use external vision position data
-	DEPRECATED_USE_EXT_VIS_YAW = (1<<4), ///< set to true to use external vision quaternion data for yaw
-	DEPRECATED_USE_DRAG         = (1<<5), ///< set to true to use the multi-rotor drag model to estimate wind
-	DEPRECATED_ROTATE_EXT_VIS  = (1<<6), ///< set to true to if the EV observations are in a non NED reference frame and need to be rotated before being used
-	DEPRECATED_USE_GPS_YAW     = (1<<7), ///< set to true to use GPS yaw data if available (DEPRECATED, use gnss_ctrl)
-	DEPRECATED_USE_EXT_VIS_VEL = (1<<8), ///< set to true to use external vision velocity data
 };
 
 struct gpsMessage {
@@ -297,7 +284,6 @@ struct parameters {
 	int32_t imu_ctrl{static_cast<int32_t>(ImuCtrl::GyroBias) | static_cast<int32_t>(ImuCtrl::AccelBias)};
 
 	// measurement source control
-	int32_t fusion_mode{};         ///< bitmasked integer that selects some aiding sources
 	int32_t height_sensor_ref{HeightSensor::BARO};
 	int32_t position_sensor_ref{static_cast<int32_t>(PositionSensor::GNSS)};
 	int32_t baro_ctrl{1};

--- a/src/modules/ekf2/EKF/drag_fusion.cpp
+++ b/src/modules/ekf2/EKF/drag_fusion.cpp
@@ -44,7 +44,7 @@
 
 void Ekf::controlDragFusion()
 {
-	if ((_params.fusion_mode & SensorFusionMask::USE_DRAG) && _drag_buffer &&
+	if ((_params.drag_ctrl > 0) && _drag_buffer &&
 	    !_control_status.flags.fake_pos && _control_status.flags.in_air) {
 
 		if (!_control_status.flags.wind) {

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -569,7 +569,7 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 	}
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
-	if (_params.fusion_mode & SensorFusionMask::USE_OPT_FLOW) {
+	if (_params.flow_ctrl > 0) {
 		max_time_delay_ms = math::max(_params.flow_delay_ms, max_time_delay_ms);
 	}
 #endif // CONFIG_EKF2_OPTICAL_FLOW

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -480,7 +480,7 @@ void EstimatorInterface::setDragData(const imuSample &imu)
 {
 	// down-sample the drag specific force data by accumulating and calculating the mean when
 	// sufficient samples have been collected
-	if ((_params.fusion_mode & SensorFusionMask::USE_DRAG)) {
+	if (_params.drag_ctrl > 0) {
 
 		// Allocate the required buffer size if not previously done
 		if (_drag_buffer == nullptr) {

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -158,7 +158,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 
 		// Handle cases where we are using optical flow but we should not use it anymore
 		if (_control_status.flags.opt_flow) {
-			if (!(_params.fusion_mode & SensorFusionMask::USE_OPT_FLOW)
+			if (!(_params.flow_ctrl == 1)
 			    || inhibit_flow_use) {
 
 				stopFlowFusion();
@@ -167,7 +167,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 		}
 
 		// optical flow fusion mode selection logic
-		if ((_params.fusion_mode & SensorFusionMask::USE_OPT_FLOW) // optical flow has been selected by the user
+		if ((_params.flow_ctrl == 1) // optical flow has been selected by the user
 		    && !_control_status.flags.opt_flow // we are not yet using flow data
 		    && !inhibit_flow_use) {
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -110,7 +110,6 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_req_pdop(_params->req_pdop),
 	_param_ekf2_req_hdrift(_params->req_hdrift),
 	_param_ekf2_req_vdrift(_params->req_vdrift),
-	_param_ekf2_aid_mask(_params->fusion_mode),
 	_param_ekf2_hgt_ref(_params->height_sensor_ref),
 	_param_ekf2_baro_ctrl(_params->baro_ctrl),
 	_param_ekf2_gps_ctrl(_params->gnss_ctrl),

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -150,6 +150,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 	_param_ekf2_grav_noise(_params->gravity_noise),
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
+	_param_ekf2_of_ctrl(_params->flow_ctrl),
 	_param_ekf2_of_delay(_params->flow_delay_ms),
 	_param_ekf2_of_n_min(_params->flow_noise),
 	_param_ekf2_of_n_max(_params->flow_noise_qual_min),
@@ -884,6 +885,29 @@ void EKF2::VerifyParams()
 	}
 
 #endif // CONFIG_EKF2_DRAG_FUSION
+
+#if defined(CONFIG_EKF2_OPTICAL_FLOW)
+
+	// IMU EKF2_AID_MASK -> EKF2_OF_CTRL (2023-04-26)
+	if (_param_ekf2_aid_mask.get() & SensorFusionMask::DEPRECATED_USE_OPT_FLOW) {
+		// EKF2_OF_CTRL enable flow fusion
+		_param_ekf2_of_ctrl.set(1);
+
+		// EKF2_AID_MASK clear deprecated bit
+		_param_ekf2_aid_mask.set(_param_ekf2_aid_mask.get() & ~(SensorFusionMask::DEPRECATED_USE_OPT_FLOW));
+
+		_param_ekf2_of_ctrl.commit();
+		_param_ekf2_aid_mask.commit();
+
+		mavlink_log_critical(&_mavlink_log_pub, "EKF2 optical flow use EKF2_OF_CTRL instead of EKF2_AID_MASK\n");
+		/* EVENT
+		 * @description <param>EKF2_AID_MASK</param> is set to {1:.0}.
+		 */
+		events::send<float>(events::ID("ekf2_aid_mask_opt_flow"), events::Log::Warning,
+				    "Use EKF2_OF_CTRL instead", _param_ekf2_aid_mask.get());
+	}
+
+#endif // CONFIG_EKF2_OPTICAL_FLOW
 }
 
 void EKF2::PublishAidSourceStatus(const hrt_abstime &timestamp)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -640,6 +640,8 @@ private:
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
 		// optical flow fusion
+		(ParamExtInt<px4::params::EKF2_OF_CTRL>)
+		_param_ekf2_of_ctrl, ///< optical flow fusion selection
 		(ParamExtFloat<px4::params::EKF2_OF_DELAY>)
 		_param_ekf2_of_delay, ///< optical flow measurement delay relative to the IMU (mSec) - this is to the middle of the optical flow integration interval
 		(ParamExtFloat<px4::params::EKF2_OF_N_MIN>)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -144,6 +144,19 @@ public:
 	int instance() const { return _instance; }
 
 private:
+	//TODO: remove after 1.14 release
+	enum SensorFusionMask : uint16_t {
+		// Bit locations for fusion_mode
+		DEPRECATED_USE_GPS = (1 << 0),  ///< set to true to use GPS data (DEPRECATED, use gnss_ctrl)
+		DEPRECATED_USE_OPT_FLOW     = (1 << 1), ///< set to true to use optical flow data
+		DEPRECATED_INHIBIT_ACC_BIAS = (1 << 2), ///< set to true to inhibit estimation of accelerometer delta velocity bias
+		DEPRECATED_USE_EXT_VIS_POS = (1 << 3), ///< set to true to use external vision position data
+		DEPRECATED_USE_EXT_VIS_YAW = (1 << 4), ///< set to true to use external vision quaternion data for yaw
+		DEPRECATED_USE_DRAG         = (1 << 5), ///< set to true to use the multi-rotor drag model to estimate wind
+		DEPRECATED_ROTATE_EXT_VIS  = (1 << 6), ///< set to true to if the EV observations are in a non NED reference frame and need to be rotated before being used
+		DEPRECATED_USE_GPS_YAW     = (1 << 7), ///< set to true to use GPS yaw data if available (DEPRECATED, use gnss_ctrl)
+		DEPRECATED_USE_EXT_VIS_VEL = (1 << 8), ///< set to true to use external vision velocity data
+	};
 
 	static constexpr uint8_t MAX_NUM_IMUS = 4;
 	static constexpr uint8_t MAX_NUM_MAGS = 4;
@@ -561,7 +574,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_REQ_VDRIFT>) _param_ekf2_req_vdrift,	///< maximum acceptable vertical drift speed (m/s)
 
 		// measurement source control
-		(ParamExtInt<px4::params::EKF2_AID_MASK>)
+		(ParamInt<px4::params::EKF2_AID_MASK>)
 		_param_ekf2_aid_mask,		///< bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
 		(ParamExtInt<px4::params::EKF2_HGT_REF>) _param_ekf2_hgt_ref,    ///< selects the primary source for height data
 		(ParamExtInt<px4::params::EKF2_BARO_CTRL>) _param_ekf2_baro_ctrl,///< barometer control selection

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -692,6 +692,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_GYR_B_LIM>) _param_ekf2_gyr_b_lim,	///< Gyro bias learning limit (rad/s)
 
 #if defined(CONFIG_EKF2_DRAG_FUSION)
+		(ParamExtInt<px4::params::EKF2_DRAG_CTRL>) _param_ekf2_drag_ctrl,		///< drag fusion selection
 		// Multi-rotor drag specific force fusion
 		(ParamExtFloat<px4::params::EKF2_DRAG_NOISE>)
 		_param_ekf2_drag_noise,	///< observation noise variance for drag specific force measurements (m/sec**2)**2

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -659,7 +659,7 @@ PARAM_DEFINE_INT32(EKF2_HGT_REF, 1);
 /**
  * Barometric sensor height aiding
  *
- * If this parameter is enabled then the estimator will make use of the barometric height measurements to estimate it's height in addition to other
+ * If this parameter is enabled then the estimator will make use of the barometric height measurements to estimate its height in addition to other
  * height sources (if activated).
  *
  * @group EKF2
@@ -714,7 +714,7 @@ PARAM_DEFINE_INT32(EKF2_GPS_CTRL, 7);
  *
  * To en-/disable range finder for terrain height estimation, use EKF2_TERR_MASK instead.
  *
- * If this parameter is enabled then the estimator will make use of the range finder measurements to estimate it's height in addition to other
+ * If this parameter is enabled then the estimator will make use of the range finder measurements to estimate its height in addition to other
  * height sources (if activated). Range sensor aiding can be enabled (i.e.: always use) or set in "conditional" mode.
  *
  * Conditional mode: This enables the range finder to be used during low speed (< EKF2_RNG_A_VMAX) and low altitude (< EKF2_RNG_A_HMAX)
@@ -1177,7 +1177,7 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_PITCH, 0.0f);
  * Maximum horizontal velocity allowed for conditional range aid mode.
  *
  * If the vehicle horizontal speed exceeds this value then the estimator will not fuse range measurements
- * to estimate it's height. This only applies when conditional range aid mode is activated (EKF2_RNG_CTRL = 1).
+ * to estimate its height. This only applies when conditional range aid mode is activated (EKF2_RNG_CTRL = 1).
  *
  * @group EKF2
  * @min 0.1
@@ -1190,7 +1190,7 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_A_VMAX, 1.0f);
  * Maximum absolute altitude (height above ground level) allowed for conditional range aid mode.
  *
  * If the vehicle absolute altitude exceeds this value then the estimator will not fuse range measurements
- * to estimate it's height. This only applies when conditional range aid mode is activated (EKF2_RNG_CTRL = 1).
+ * to estimate its height. This only applies when conditional range aid mode is activated (EKF2_RNG_CTRL = 1).
  *
  * @group EKF2
  * @min 1.0

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -618,7 +618,7 @@ PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
  * 2 : Deprecated, use EKF2_IMU_CTRL instead
  * 3 : Deprecated, use EKF2_EV_CTRL instead
  * 4 : Deprecated, use EKF2_EV_CTRL instead
- * 5 : Set to true to enable multi-rotor drag specific force fusion
+ * 5 : Deprecated. use EKF2_DRAG_CTRL instead
  * 6 : Deprecated, use EKF2_EV_CTRL instead
  * 7 : Deprecated, use EKF2_GPS_CTRL instead
  * 8 : Deprecated, use EKF2_EV_CTRL instead
@@ -631,7 +631,7 @@ PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
  * @bit 2 unused
  * @bit 3 unused
  * @bit 4 unused
- * @bit 5 multi-rotor drag fusion
+ * @bit 5 unused
  * @bit 6 unused
  * @bit 7 unused
  * @bit 8 unused
@@ -1254,6 +1254,20 @@ PARAM_DEFINE_FLOAT(EKF2_EVV_GATE, 3.0f);
 PARAM_DEFINE_FLOAT(EKF2_EVP_GATE, 5.0f);
 
 /**
+ * Multirotor wind estimation selection
+ *
+ * Activate wind speed estimation using specific-force measurements and
+ * a drag model defined by EKF2_BCOEF_[XY] and EKF2_MCOEF.
+ *
+ * Only use on vehicles that have their thrust aligned with the Z axis and
+ * no thrust in the XY plane.
+ *
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_DRAG_CTRL, 0);
+
+/**
  * Specific drag force observation noise variance used by the multi-rotor specific drag force model.
  *
  * Increasing this makes the multi-rotor wind estimates adjust more slowly.
@@ -1269,7 +1283,7 @@ PARAM_DEFINE_FLOAT(EKF2_DRAG_NOISE, 2.5f);
 /**
  * X-axis ballistic coefficient used for multi-rotor wind estimation.
  *
- * This parameter controls the prediction of drag produced by bluff body drag along the forward/reverse axis when flying a multi-copter which enables estimation of wind drift when enabled by the EKF2_AID_MASK parameter. The drag produced by this effect scales with speed squared. The predicted drag from the rotors is specified separately by the EKF2_MCOEF parameter.
+ * This parameter controls the prediction of drag produced by bluff body drag along the forward/reverse axis when flying a multi-copter which enables estimation of wind drift when enabled by the EKF2_DRAG_CTRL parameter. The drag produced by this effect scales with speed squared. The predicted drag from the rotors is specified separately by the EKF2_MCOEF parameter.
  * Set this parameter to zero to turn off the bluff body drag model for this axis.
  *
  * @group EKF2
@@ -1283,7 +1297,7 @@ PARAM_DEFINE_FLOAT(EKF2_BCOEF_X, 100.0f);
 /**
  * Y-axis ballistic coefficient used for multi-rotor wind estimation.
  *
- * This parameter controls the prediction of drag produced by bluff body drag along the right/left axis when flying a multi-copter, which enables estimation of wind drift when enabled by the EKF2_AID_MASK parameter. The drag produced by this effect scales with speed squared. The predicted drag from the rotors is specified separately by the EKF2_MCOEF parameter.
+ * This parameter controls the prediction of drag produced by bluff body drag along the right/left axis when flying a multi-copter, which enables estimation of wind drift when enabled by the EKF2_DRAG_CTRL parameter. The drag produced by this effect scales with speed squared. The predicted drag from the rotors is specified separately by the EKF2_MCOEF parameter.
  * Set this parameter to zero to turn off the bluff body drag model for this axis.
  *
  * @group EKF2
@@ -1297,7 +1311,7 @@ PARAM_DEFINE_FLOAT(EKF2_BCOEF_Y, 100.0f);
 /**
  * Propeller momentum drag coefficient used for multi-rotor wind estimation.
  *
- * This parameter controls the prediction of drag produced by the propellers when flying a multi-copter, which enables estimation of wind drift when enabled by the EKF2_AID_MASK parameter. The drag produced by this effect scales with speed not speed squared and is produced because some of the air velocity normal to the propeller axis of rotation is lost when passing through the rotor disc. This  changes the momentum of the flow which creates a drag reaction force. When comparing un-ducted propellers of the same diameter, the effect is roughly proportional to the area of the propeller blades when viewed side on and changes with propeller selection. Momentum drag is significantly higher for ducted rotors. To account for the drag produced by the body which scales with speed squared, see documentation for the EKF2_BCOEF_X and EKF2_BCOEF_Y parameters.
+ * This parameter controls the prediction of drag produced by the propellers when flying a multi-copter, which enables estimation of wind drift when enabled by the EKF2_DRAG_CTRL parameter. The drag produced by this effect scales with speed not speed squared and is produced because some of the air velocity normal to the propeller axis of rotation is lost when passing through the rotor disc. This  changes the momentum of the flow which creates a drag reaction force. When comparing un-ducted propellers of the same diameter, the effect is roughly proportional to the area of the propeller blades when viewed side on and changes with propeller selection. Momentum drag is significantly higher for ducted rotors. To account for the drag produced by the body which scales with speed squared, see documentation for the EKF2_BCOEF_X and EKF2_BCOEF_Y parameters.
  * Set this parameter to zero to turn off the momentum drag model for both axis.
  *
  * @group EKF2

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -614,7 +614,7 @@ PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
  *
  * Set bits in the following positions to enable:
  * 0 : Deprecated, use EKF2_GPS_CTRL instead
- * 1 : Set to true to use optical flow data if available
+ * 1 : Deprecated. use EKF2_OF_CTRL instead
  * 2 : Deprecated, use EKF2_IMU_CTRL instead
  * 3 : Deprecated, use EKF2_EV_CTRL instead
  * 4 : Deprecated, use EKF2_EV_CTRL instead
@@ -627,7 +627,7 @@ PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
  * @min 0
  * @max 511
  * @bit 0 unused
- * @bit 1 use optical flow
+ * @bit 1 unused
  * @bit 2 unused
  * @bit 3 unused
  * @bit 4 unused
@@ -866,6 +866,16 @@ PARAM_DEFINE_FLOAT(EKF2_EVA_NOISE, 0.1f);
  * @decimal 2
  */
 PARAM_DEFINE_FLOAT(EKF2_GRAV_NOISE, 1.0f);
+
+/**
+ * Optical flow aiding
+ *
+ * Enable optical flow fusion.
+ *
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_OF_CTRL, 0);
 
 /**
  * Measurement noise for the optical flow sensor when it's reported quality metric is at the maximum

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -496,7 +496,7 @@ PARAM_DEFINE_INT32(EKF2_DECL_TYPE, 7);
  * If set to '3-axis' 3-axis field fusion is used at all times.
  * If set to 'VTOL custom' the behaviour is the same as 'Automatic', but if fusing airspeed, magnetometer fusion is only allowed to modify the magnetic field states. This can be used by VTOL platforms with large magnetic field disturbances to prevent incorrect bias states being learned during forward flight operation which can adversely affect estimation accuracy after transition to hovering flight.
  * If set to 'MC custom' the behaviour is the same as 'Automatic, but if there are no earth frame position or velocity observations being used, the magnetometer will not be used. This enables vehicles to operate with no GPS in environments where the magnetic field cannot be used to provide a heading reference. Prior to flight, the yaw angle is assumed to be constant if movement tests indicate that the vehicle is static. This allows the vehicle to be placed on the ground to learn the yaw gyro bias prior to flight.
- * If set to 'None' the magnetometer will not be used under any circumstance. If no external source of yaw is available, it is possible to use post-takeoff horizontal movement combined with GPS velocity measurements to align the yaw angle with the timer required (depending on the amount of movement and GPS data quality). Other external sources of yaw may be used if selected via the EKF2_AID_MASK parameter.
+ * If set to 'None' the magnetometer will not be used under any circumstance. If no external source of yaw is available, it is possible to use post-takeoff horizontal movement combined with GPS velocity measurements to align the yaw angle with the timer required (depending on the amount of movement and GPS data quality).
  * @group EKF2
  * @value 0 Automatic
  * @value 1 Magnetic heading
@@ -610,7 +610,7 @@ PARAM_DEFINE_FLOAT(EKF2_GPS_V_GATE, 5.0f);
 PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
 
 /**
- * Integer bitmask controlling data fusion and aiding methods.
+ * Will be removed after v1.14 release
  *
  * Set bits in the following positions to enable:
  * 0 : Deprecated, use EKF2_GPS_CTRL instead

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -285,12 +285,12 @@ matrix::Vector3f EkfWrapper::getDeltaVelBiasVariance() const
 
 void EkfWrapper::enableDragFusion()
 {
-	_ekf_params->fusion_mode |= SensorFusionMask::USE_DRAG;
+	_ekf_params->drag_ctrl = 1;
 }
 
 void EkfWrapper::disableDragFusion()
 {
-	_ekf_params->fusion_mode &= ~SensorFusionMask::USE_DRAG;
+	_ekf_params->drag_ctrl = 0;
 }
 
 void EkfWrapper::setDragFusionParameters(const float &bcoef_x, const float &bcoef_y, const float &mcoef)

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -132,12 +132,12 @@ bool EkfWrapper::isIntendingGpsHeadingFusion() const
 
 void EkfWrapper::enableFlowFusion()
 {
-	_ekf_params->fusion_mode |= SensorFusionMask::USE_OPT_FLOW;
+	_ekf_params->flow_ctrl = 1;
 }
 
 void EkfWrapper::disableFlowFusion()
 {
-	_ekf_params->fusion_mode &= ~SensorFusionMask::USE_OPT_FLOW;
+	_ekf_params->flow_ctrl = 0;
 }
 
 bool EkfWrapper::isIntendingFlowFusion() const


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The last bits used in the aid mask were to select optical flow and drag fusion; we should have them removed for 1.14 to be consistent and be able to remove `EKF2_AID_MASK` completely just after the release.

### Solution
Create:
- `EKF2_OF_CTRL`: en-/disable optical flow
- `EKF2_DRAG_CTRL`: en-/disable wind estimation using drag fusion

### Changelog Entry
For release notes:
```
Migrate EKF2_AID_MASK
New parameter: EKF2_OF_CTRL, EKF2_DRAG_CTRL
Documentation:
```
 https://github.com/PX4/PX4-user_guide/pull/2459

### Test coverage
Param migration tested in SITL
