### PR TITLE
bmi088: Do not use invalid values

### DIFF
--- a/src/drivers/imu/bosch/bmi088_i2c/BMI088_Gyroscope.cpp
+++ b/src/drivers/imu/bosch/bmi088_i2c/BMI088_Gyroscope.cpp
@@ -346,6 +346,8 @@ bool BMI088_Gyroscope::FIFORead(const hrt_abstime &timestamp_sample, uint8_t sam
 	gyro.samples = samples;
 	gyro.dt = FIFO_SAMPLE_DT;
 
+	int index = 0;
+
 	for (int i = 0; i < samples; i++) {
 		const FIFO::DATA &fifo_sample = buffer.f[i];
 
@@ -355,15 +357,20 @@ bool BMI088_Gyroscope::FIFORead(const hrt_abstime &timestamp_sample, uint8_t sam
 
 		// sensor's frame is +x forward, +y left, +z up
 		//  flip y & z to publish right handed with z down (x forward, y right, z down)
-		gyro.x[i] = gyro_x;
-		gyro.y[i] = (gyro_y == INT16_MIN) ? INT16_MAX : -gyro_y;
-		gyro.z[i] = (gyro_z == INT16_MIN) ? INT16_MAX : -gyro_z;
+		if (!(gyro_x == INT16_MIN && gyro_y == INT16_MIN && gyro_z == INT16_MIN)) {
+			gyro.x[i] = gyro_x;
+			gyro.y[i] = (gyro_y == INT16_MIN) ? INT16_MAX : -gyro_y;
+			gyro.z[i] = (gyro_z == INT16_MIN) ? INT16_MAX : -gyro_z;
+			++index;
+		}
 	}
 
 	_px4_gyro.set_error_count(perf_event_count(_bad_register_perf) + perf_event_count(_bad_transfer_perf) +
 				  perf_event_count(_fifo_empty_perf) + perf_event_count(_fifo_overflow_perf));
 
-	_px4_gyro.updateFIFO(gyro);
+	if (index > 0) {
+		_px4_gyro.updateFIFO(gyro);
+	}
 
 	return true;
 }


### PR DESCRIPTION
### Solved Problem

We discovered that ArduPilot gets incorrect values from the BMI088.

### Solution

ArduPilot added a process that does not use illegal values (X, Y, Z values of -1).
Add this process to PX4-AutoPilot.

### Changelog Entry

None

### Alternatives

None

### Test coverage

None

### Context

ArduPilot PR

https://github.com/ArduPilot/ardupilot/pull/22710

https://github.com/ArduPilot/ardupilot/pull/23033