### PR TITLE
Update sitl_multiple_run.sh

### DIFF
--- a/Tools/simulation/sitl_multiple_run.sh
+++ b/Tools/simulation/sitl_multiple_run.sh
@@ -10,7 +10,7 @@ sitl_num=2
 [ -n "$1" ] && sitl_num="$1"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-src_path="$SCRIPT_DIR/.."
+src_path="$SCRIPT_DIR/../../"
 
 build_path=${src_path}/build/px4_sitl_default
 


### PR DESCRIPTION
Edited line to account for the fact that the file has been moved one level deeper in the folder tree (the same edit should be made in the documentation https://docs.px4.io/main/en/simulation/multi_vehicle_jmavsim.html)

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When following the documentation for multi vehicle simulation using jmavsim I found that the file `sitl_multiple_run.sh` was moved one level deeper in the folder tree. This change was not updated in the documentation [here](https://docs.px4.io/main/en/simulation/multi_vehicle_jmavsim.html), and the script (which uses a relative path), was not updated either.

Fixes #{Github issue ID}

### Solution
- Add `../` for enabling the script to find the required file in the correct location
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarfiy page https://docs.px4.io/main/en/simulation/multi_vehicle_jmavsim.html
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
