### PR TITLE
fmu-v6c: fix Telem1, Telem2 without flow control

### DIFF
--- a/boards/px4/fmu-v6c/nuttx-config/include/board.h
+++ b/boards/px4/fmu-v6c/nuttx-config/include/board.h
@@ -375,7 +375,8 @@
 #define GPIO_UART5_RX    GPIO_UART5_RX_3    /* PD2  */
 #define GPIO_UART5_TX    GPIO_UART5_TX_3    /* PC12 */
 // GPIO_UART5_RTS   no remap                /* PC8  */
-// GPIO_UART5_CTS  No remap                 /* PC9  */
+#undef GPIO_UART5_CTS
+#define GPIO_UART5_CTS   ((GPIO_ALT|GPIO_AF8|GPIO_PORTC|GPIO_PIN9) | GPIO_PULLDOWN) /* PC9  */
 
 #define GPIO_USART6_RX   GPIO_USART6_RX_1   /* PC7 */
 #define GPIO_USART6_TX   GPIO_USART6_TX_1   /* PC6  */
@@ -383,7 +384,7 @@
 #define GPIO_UART7_RX    GPIO_UART7_RX_3    /* PE7  */
 #define GPIO_UART7_TX    GPIO_UART7_TX_3    /* PE8  */
 #define GPIO_UART7_RTS   GPIO_UART7_RTS_1   /* PE9  */
-#define GPIO_UART7_CTS   GPIO_UART7_CTS_1   /* PE10 */
+#define GPIO_UART7_CTS   (GPIO_UART7_CTS_1 | GPIO_PULLDOWN) /* PE10 */
 
 #define GPIO_UART8_RX    GPIO_UART8_RX_1    /* PE0 */
 #define GPIO_UART8_TX    GPIO_UART8_TX_1    /* PE1 */


### PR DESCRIPTION
When flow control is used together with DMA, we need to add a pulldown to ~RTS and~ CTS. Without it, it assumes flow control and gets stuck when ~RTS and~ CTS ~are~ is not connected.

Same as #20974 but for 6C.