### PR TITLE
RTCM injection fixes

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -540,6 +540,9 @@ void GPS::handleInjectDataTopic()
 		}
 	}
 
+	// Reset instance in case we didn't actually want to switch
+	_orb_inject_data_sub.ChangeInstance(_selected_rtcm_instance);
+
 	bool updated = false;
 
 	// Limit maximum number of GPS injections to 8 since usually

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -526,7 +526,6 @@ void GPS::handleInjectDataTopic()
 
 	// If there has not been a valid RTCM message for a while, try to switch to a different RTCM link
 	if ((hrt_absolute_time() - _last_rtcm_injection_time) > 5_s) {
-		_last_rtcm_injection_time = hrt_absolute_time();
 
 		for (uint8_t i = 0; i < gps_inject_data_s::MAX_INSTANCES; i++) {
 			if (_orb_inject_data_sub.ChangeInstance(i)) {


### PR DESCRIPTION
This fixes 3 small issues in the RTCM injection instance failover logic:

- Properly reset and thus log RTCM instance.
- Check instances all the time instead of every 5s when the current instance stopped publishing.
- Don't swallow one instance right after instance switching.

More info is in the commit messages.

This work is sponsored by [Firefly Drone Shows](https://www.fireflydroneshows.com/).