### PR TITLE
fix qgc throttle calibration for radios with reverse sign

### DIFF
--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -203,6 +203,7 @@ void RCUpdate::parameters_updated()
 	}
 
 	// Center throttle trim when it's set to the minimum to correct for hardcoded QGC RC calibration
+	// or in the case of radios with reverse sign convention, QGC sets trim to the maximum.
 	// See https://github.com/mavlink/qgroundcontrol/commit/0577af2e944a0f53919aeb1367d580f744004b2c
 	const int8_t throttle_channel = _rc.function[rc_channels_s::FUNCTION_THROTTLE];
 
@@ -211,7 +212,7 @@ void RCUpdate::parameters_updated()
 		const uint16_t throttle_trim = _parameters.trim[throttle_channel];
 		const uint16_t throttle_max = _parameters.max[throttle_channel];
 
-		if (throttle_min == throttle_trim) {
+		if (throttle_min == throttle_trim || throttle_max == throttle_trim) {
 			const uint16_t new_throttle_trim = (throttle_min + throttle_max) / 2;
 			_parameters.trim[throttle_channel] = new_throttle_trim;
 		}


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When use a radio that has reverse sign convention on the throttle stick (e.g. Futaba), the PX4 multicopter autopilot is unresponsive to throttle stick commands. This is caused by a bug in rc_update.cpp.

In rc_update.cpp there is code to center throttle trim but it only checks the case where throttle trim is set to throttle min. If the radio has reverse sign convention, the throttle trim is set to throttle max, so the existing code fails to center throttle trim for radios with reverse sign convention.

Fixes #{Github issue ID}

### Solution
Change the logic to center throttle trim in case throttle trim == throttle min OR throttle trim == throttle max.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarfiy page ... / done, read docs.px4.io/...
```

### Alternatives
The error in the existing logic seems obvious. This is a simple direct fix.

### Test coverage
- Verified correct throttle stick response on CubeOrange with Futaba radio.

### Context
Related links, screenshot before/after, video
