### PR TITLE
Fix uncalibrated RC input being used

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -209,7 +209,7 @@ private:
 	bool			_timer_rates_configured{false};
 
 	/* advertised topics */
-	uORB::PublicationMulti<input_rc_s>	_to_input_rc{ORB_ID(input_rc)};
+	uORB::PublicationMulti<input_rc_s>	_input_rc_pub{ORB_ID(input_rc)};
 	uORB::Publication<px4io_status_s>	_px4io_status_pub{ORB_ID(px4io_status)};
 
 	ButtonPublisher	_button_publisher;
@@ -1144,7 +1144,7 @@ int PX4IO::io_publish_raw_rc()
 		input_rc.link_quality = -1;
 		input_rc.rssi_dbm = NAN;
 
-		_to_input_rc.publish(input_rc);
+		_input_rc_pub.publish(input_rc);
 	}
 
 	return ret;

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -127,6 +127,7 @@ private:
 
 	void rc_io_invert(bool invert);
 
+	input_rc_s _input_rc{};
 	hrt_abstime _rc_scan_begin{0};
 
 	bool _initialized{false};
@@ -140,15 +141,12 @@ private:
 	uORB::Subscription	_vehicle_cmd_sub{ORB_ID(vehicle_command)};
 	uORB::Subscription	_vehicle_status_sub{ORB_ID(vehicle_status)};
 
-	input_rc_s	_rc_in{};
+	uORB::PublicationMulti<input_rc_s> _input_rc_pub{ORB_ID(input_rc)};
 
 	float		_analog_rc_rssi_volt{-1.0f};
 	bool		_analog_rc_rssi_stable{false};
 
 	bool _armed{false};
-
-
-	uORB::PublicationMulti<input_rc_s>	_to_input_rc{ORB_ID(input_rc)};
 
 	int		_rcs_fd{-1};
 	char		_device[20] {};					///< device / serial port path

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -83,7 +83,7 @@ bool ManualControlSelector::isInputValid(const manual_control_setpoint_s &input,
 					  (input.data_source == _first_valid_source
 					   || _first_valid_source == manual_control_setpoint_s::SOURCE_UNKNOWN);
 
-	return sample_from_the_past && sample_newer_than_timeout
+	return sample_from_the_past && sample_newer_than_timeout && input.valid
 	       && (source_rc_matched || source_mavlink_matched || source_any_matched || source_first_matched);
 }
 

--- a/src/modules/manual_control/ManualControlSelectorTest.cpp
+++ b/src/modules/manual_control/ManualControlSelectorTest.cpp
@@ -37,7 +37,43 @@
 
 using namespace time_literals;
 
-static constexpr uint64_t some_time = 12345678;
+static constexpr uint64_t SOME_TIME = 12345678;
+static constexpr uint8_t SOURCE_RC = manual_control_setpoint_s::SOURCE_RC;
+static constexpr uint8_t SOURCE_MAVLINK_0 = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+static constexpr uint8_t SOURCE_MAVLINK_3 = manual_control_setpoint_s::SOURCE_MAVLINK_3;
+static constexpr uint8_t SOURCE_MAVLINK_4 = manual_control_setpoint_s::SOURCE_MAVLINK_4;
+
+TEST(ManualControlSelector, RcInputInvalidValid)
+{
+	ManualControlSelector selector;
+	selector.setRcInMode(0);
+	selector.setTimeout(500_ms);
+
+	uint64_t timestamp = SOME_TIME;
+
+	// Now provide input with the correct source flagged invalid
+	manual_control_setpoint_s input {};
+	input.data_source = SOURCE_RC;
+	input.valid = false;
+	input.timestamp_sample = timestamp;
+
+	for (int i = 0; i < 2; i++) {
+		selector.updateWithNewInputSample(timestamp, input, 1);
+		EXPECT_FALSE(selector.setpoint().valid);
+		EXPECT_EQ(selector.setpoint().timestamp_sample, 0);
+		EXPECT_EQ(selector.instance(), -1);
+		EXPECT_EQ(selector.setpoint().data_source, 0);
+		timestamp += 100_ms;
+		input.timestamp_sample = timestamp;
+	}
+
+	input.valid = true;
+	selector.updateWithNewInputSample(timestamp, input, 1);
+	EXPECT_TRUE(selector.setpoint().valid);
+	EXPECT_EQ(selector.setpoint().timestamp_sample, timestamp);
+	EXPECT_EQ(selector.instance(), 1);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
+}
 
 TEST(ManualControlSelector, RcInputContinuous)
 {
@@ -45,11 +81,12 @@ TEST(ManualControlSelector, RcInputContinuous)
 	selector.setRcInMode(0);
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	// Now provide input with the correct source.
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 
 	for (int i = 0; i < 5; i++) {
@@ -57,7 +94,7 @@ TEST(ManualControlSelector, RcInputContinuous)
 		EXPECT_TRUE(selector.setpoint().valid);
 		EXPECT_EQ(selector.setpoint().timestamp_sample, timestamp);
 		EXPECT_EQ(selector.instance(), 1);
-		EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+		EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 		timestamp += 100_ms;
 		input.timestamp_sample = timestamp;
 	}
@@ -66,13 +103,14 @@ TEST(ManualControlSelector, RcInputContinuous)
 TEST(ManualControlSelector, RcInputOnly)
 {
 	ManualControlSelector selector;
-	selector.setRcInMode(0);
+	selector.setRcInMode(0); // Configure RC input only
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.data_source = SOURCE_MAVLINK_0;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
@@ -81,25 +119,26 @@ TEST(ManualControlSelector, RcInputOnly)
 	timestamp += 100_ms;
 
 	// Now provide input with the correct source.
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 1);
 }
 
 TEST(ManualControlSelector, MavlinkInputOnly)
 {
 	ManualControlSelector selector;
-	selector.setRcInMode(1);
+	selector.setRcInMode(1); // Configure MAVLink input only
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
@@ -108,128 +147,131 @@ TEST(ManualControlSelector, MavlinkInputOnly)
 	timestamp += 100_ms;
 
 	// Now provide input with the correct source.
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_3;
+	input.data_source = SOURCE_MAVLINK_3;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_MAVLINK_3);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_MAVLINK_3);
 	EXPECT_EQ(selector.instance(), 1);
 
 	timestamp += 100_ms;
 
 	// But only the first MAVLink source wins, others are too late.
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_4;
+	input.data_source = SOURCE_MAVLINK_4;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_MAVLINK_3);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_MAVLINK_3);
 	EXPECT_EQ(selector.instance(), 1);
 }
 
-TEST(ManualControlSelector, AutoInput)
+TEST(ManualControlSelector, RcMavlinkInputFallback)
 {
 	ManualControlSelector selector;
-	selector.setRcInMode(2);
+	selector.setRcInMode(2); // Configure fallback
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 0);
 
 	timestamp += 100_ms;
 
 	// Now provide input from MAVLink as well which should get ignored.
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.data_source = SOURCE_MAVLINK_0;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 0);
 
 	timestamp += 500_ms;
 
 	// Now we'll let RC time out, so it should switch to MAVLINK.
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.data_source = SOURCE_MAVLINK_0;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_MAVLINK_0);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_MAVLINK_0);
 	EXPECT_EQ(selector.instance(), 1);
 }
 
-TEST(ManualControlSelector, FirstInput)
+TEST(ManualControlSelector, RcMavlinkInputKeepFirst)
 {
 	ManualControlSelector selector;
-	selector.setRcInMode(3);
+	selector.setRcInMode(3); // Configure keep first input
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 0);
 
 	timestamp += 100_ms;
 
 	// Now provide input from MAVLink as well which should get ignored.
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.data_source = SOURCE_MAVLINK_0;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 0);
 
 	timestamp += 500_ms;
 
 	// Now we'll let RC time out, but it should NOT switch to MAVLINK because RC was first
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.data_source = SOURCE_MAVLINK_0;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
 	EXPECT_FALSE(selector.setpoint().valid);
-	EXPECT_FALSE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_MAVLINK_0);
+	EXPECT_NE(selector.setpoint().data_source, SOURCE_MAVLINK_0);
 	EXPECT_EQ(selector.instance(), -1);
 
 	timestamp += 100_ms;
 
 	// Provide input from RC again and it should get accepted because it was the first.
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 0);
 }
 
 TEST(ManualControlSelector, DisabledInput)
 {
 	ManualControlSelector selector;
-	selector.setRcInMode(4);
+	selector.setRcInMode(4); // Configure disabled stick input
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
 	// Reject MAVLink stick input
-	input.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0;
+	input.data_source = SOURCE_MAVLINK_0;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
@@ -239,7 +281,7 @@ TEST(ManualControlSelector, DisabledInput)
 	timestamp += 100_ms;
 
 	// Reject RC stick input
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 1);
 
@@ -253,15 +295,16 @@ TEST(ManualControlSelector, RcTimeout)
 	selector.setRcInMode(0);
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
+	input.valid = true;
 	input.timestamp_sample = timestamp;
 	selector.updateWithNewInputSample(timestamp, input, 0);
 
 	EXPECT_TRUE(selector.setpoint().valid);
-	EXPECT_TRUE(selector.setpoint().data_source == manual_control_setpoint_s::SOURCE_RC);
+	EXPECT_EQ(selector.setpoint().data_source, SOURCE_RC);
 	EXPECT_EQ(selector.instance(), 0);
 
 	timestamp += 600_ms;
@@ -279,10 +322,11 @@ TEST(ManualControlSelector, RcOutdated)
 	selector.setRcInMode(0);
 	selector.setTimeout(500_ms);
 
-	uint64_t timestamp = some_time;
+	uint64_t timestamp = SOME_TIME;
 
 	manual_control_setpoint_s input {};
-	input.data_source = manual_control_setpoint_s::SOURCE_RC;
+	input.data_source = SOURCE_RC;
+	input.valid = true;
 	input.timestamp_sample = timestamp - 600_ms; // First sample is already outdated
 	selector.updateWithNewInputSample(timestamp, input, 0);
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2055,6 +2055,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 	manual_control_setpoint.yaw = mavlink_manual_control.r / 1000.f;
 	manual_control_setpoint.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0 + _mavlink->get_instance_id();
 	manual_control_setpoint.timestamp = manual_control_setpoint.timestamp_sample = hrt_absolute_time();
+	manual_control_setpoint.valid = true;
 	_manual_control_input_pub.publish(manual_control_setpoint);
 }
 

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -127,7 +127,6 @@ void RCUpdate::parameters_updated()
 {
 	// rc values
 	for (unsigned int i = 0; i < RC_MAX_CHAN_COUNT; i++) {
-
 		float min = 0.f;
 		param_get(_parameter_handles.min[i], &min);
 		_parameters.min[i] = min;
@@ -154,6 +153,12 @@ void RCUpdate::parameters_updated()
 	}
 
 	update_rc_functions();
+
+	_rc_calibrated = _param_rc_chan_cnt.get() > 0
+			 && (_param_rc_map_throttle.get() > 0
+			     || _param_rc_map_roll.get() > 0
+			     || _param_rc_map_pitch.get() > 0
+			     || _param_rc_map_yaw.get() > 0);
 
 	// deprecated parameters, will be removed post v1.12 once QGC is updated
 	{
@@ -687,6 +692,7 @@ void RCUpdate::UpdateManualControlInput(const hrt_abstime &timestamp_sample)
 	manual_control_input.aux4  = get_rc_value(rc_channels_s::FUNCTION_AUX_4,   -1.f, 1.f);
 	manual_control_input.aux5  = get_rc_value(rc_channels_s::FUNCTION_AUX_5,   -1.f, 1.f);
 	manual_control_input.aux6  = get_rc_value(rc_channels_s::FUNCTION_AUX_6,   -1.f, 1.f);
+	manual_control_input.valid = _rc_calibrated;
 
 	// publish manual_control_input topic
 	manual_control_input.timestamp = hrt_absolute_time();

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -170,6 +170,7 @@ public:
 	manual_control_switches_s _manual_switches_previous{};
 	manual_control_switches_s _manual_switches_last_publish{};
 	rc_channels_s _rc{};
+	bool _rc_calibrated{false};
 
 	rc_parameter_map_s _rc_parameter_map {};
 	float _param_rc_values[rc_parameter_map_s::RC_PARAM_MAP_NCHAN] {};	/**< parameter values for RC control */


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When testing for https://github.com/PX4/PX4-Autopilot/issues/21506 I often reset all parameters to go through a fresh setup and found that my RC input data from a crossfire receiver was used even though I didn't calibrate it yet. The values were all static zero because it was uncalibrated but still assuming to have pilot input even though there is none is a safety concern.

### Solution
- (Refactor topic object naming in RCInput.)
- Start using the `valid` flag in the `manual_control_input` topic to signal that the input is not actually calibrated and shouldn't be considered valid and used. The RC is considered calibrated if the channel count parameter `RC_CHAN_CNT` is set and at least one of the stick axes roll, pitch, yaw or throttle is mapped to an RC channel. Further the input is only considered valid if the number of channels in it actually matches what was calibrated (`RC_CHAN_CNT`).

### Changelog Entry
For release notes:
```
Bugfix Uncalibrated remote input is now considered invalid
```

### Alternatives
What's not ideal in my eyes is the reporting to the user. He cannot screw up anymore by accidentally using uncalibrated stick input but he's not informed about the details about why the stick input does not get used. QGC shows a red remote icon but feedback could be better. Should I duplicate all these checks into the RC calibration check here? https://github.com/PX4/PX4-Autopilot/blob/1d4b66fcbc103eb2e81eb708d863595679989884/src/modules/commander/HealthAndArmingChecks/checks/rcCalibrationCheck.cpp#L81 I considered that but then we need to change the workflow of default RC configuration because it will immediately fail and you will not be able to fly without RC without disabling it. I think this is the way to go but I don't feel comfortable introducing this change for 1.14 since we don't have UI changes and RC disabled by default to go with it yet.

### Test coverage
I did bench testing using the same setup that I found the issue with. On a fresh setup the `manual_control_input` is published with the uncalibrated values but flagged as invalid and therefore does not get selected/used.
<img src="https://user-images.githubusercontent.com/4668506/235889619-a3b5c50d-3d84-437d-a6d2-54e7c6189739.png" width="350">
Once the RC is successfully calibrated it gets flagged valid and is normally used.
<img src="https://user-images.githubusercontent.com/4668506/235889949-ac6ff101-515f-4a68-895a-1cdc77681f81.png" width="350">
