### PR TITLE
failure_detector: Determine the angle of the aircraft from arm release to takeoff

### DIFF
--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -52,6 +52,7 @@
 // subscriptions
 #include <uORB/Subscription.hpp>
 #include <uORB/Publication.hpp>
+#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/actuator_motors.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
@@ -60,6 +61,7 @@
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_imu_status.h>
+#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/pwm_input.h>
@@ -113,6 +115,8 @@ private:
 	void updateMotorStatus(const vehicle_status_s &vehicle_status, const esc_status_s &esc_status);
 	void updateImbalancedPropStatus();
 
+	uORB::SubscriptionInterval _vehicle_local_position_sub{ORB_ID(vehicle_local_position), 100}; // Update interval: 100 ms
+
 	failure_detector_status_u _status{};
 
 	systemlib::Hysteresis _roll_failure_hysteresis{false};
@@ -146,6 +150,11 @@ private:
 		(ParamInt<px4::params::FD_FAIL_R>) _param_fd_fail_r,
 		(ParamFloat<px4::params::FD_FAIL_R_TTRI>) _param_fd_fail_r_ttri,
 		(ParamFloat<px4::params::FD_FAIL_P_TTRI>) _param_fd_fail_p_ttri,
+		(ParamInt<px4::params::FD_FAIL_LOW_P>) _param_fd_fail_low_p,
+		(ParamInt<px4::params::FD_FAIL_LOW_R>) _param_fd_fail_low_r,
+		(ParamFloat<px4::params::FD_FAIL_LOW_R_TR>) _param_fd_fail_low_r_ttri,
+		(ParamFloat<px4::params::FD_FAIL_LOW_P_TR>) _param_fd_fail_low_p_ttri,
+		(ParamFloat<px4::params::FD_FAIL_LOW_ALT>) _param_fd_fail_low_alt,
 		(ParamBool<px4::params::FD_EXT_ATS_EN>) _param_fd_ext_ats_en,
 		(ParamInt<px4::params::FD_EXT_ATS_TRIG>) _param_fd_ext_ats_trig,
 		(ParamInt<px4::params::FD_ESCS_EN>) _param_escs_en,

--- a/src/modules/commander/failure_detector/failure_detector_params.c
+++ b/src/modules/commander/failure_detector/failure_detector_params.c
@@ -107,6 +107,73 @@ PARAM_DEFINE_FLOAT(FD_FAIL_R_TTRI, 0.3);
 PARAM_DEFINE_FLOAT(FD_FAIL_P_TTRI, 0.3);
 
 /**
+ * Low altitude roll failure threshold
+ *
+ * Roll angle (degrees) at which the roll failure detector triggers when the altitude is less than 1 meter.
+ *
+ * @min 0
+ * @max 180
+ * @unit deg
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_FAIL_LOW_R, 3);
+
+/**
+ * Low altitude pitch failure threshold
+ *
+ * Pitch angle (degrees) at which the pitch failure detector triggers when the altitude is less than 1 meter.
+ *
+ * @min 0
+ * @max 180
+ * @unit deg
+ * @group Failure Detector
+ */
+PARAM_DEFINE_INT32(FD_FAIL_LOW_P, 3);
+
+/**
+ * Low altitude roll failure trigger time
+ *
+ * Seconds (decimal) that roll has to exceed FD_FAIL_LOW_R before being considered as a failure.
+ *
+ * @unit s
+ * @min 0.02
+ * @max 5
+ * @decimal 2
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_FAIL_LOW_R_TR, 0.3);
+
+/**
+ * Low altitude pitch failure trigger time
+ *
+ * Seconds (decimal) that pitch has to exceed FD_FAIL_LOW_P before being considered as a failure.
+ *
+ * @unit s
+ * @min 0.02
+ * @max 5
+ * @decimal 2
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_FAIL_LOW_P_TR, 0.3);
+
+/**
+ * Low altitude failure meter
+ *
+ * The altitude, in meters, at which the maximum roll and pitch angles at takeoff are to be determined.
+ *
+ * @unit m
+ * @min 0.0
+ * @max 1.0
+ * @decimal 1
+ * @increment 0.1
+ *
+ * @group Failure Detector
+ */
+PARAM_DEFINE_FLOAT(FD_FAIL_LOW_ALT, 0.3f);
+
+/**
  * Enable PWM input on for engaging failsafe from an external automatic trigger system (ATS).
  *
  * Enabled on either AUX5 or MAIN5 depending on board.


### PR DESCRIPTION
### Solved Problem

The large roll and pitch angles allowed at arm release and at the start of takeoff make it prone to contact with the ground.

### Solution

By providing roll and pitch angles at arm release and at the start of takeoff, an abnormality can be detected with a small tilt.

### Changelog Entry

Define roll and pitch angles at arm release and takeoff start to detect fail check anomalies.

Add the following parameters for detection.
Roll angle and pitch angle during arm release and takeoff,
Roll angle over duration time and pitch angle over duration time during arm release and takeoff.
Switching altitude of normal judgment.

### Alternatives

None

### Test coverage

Confirmed detection by SITL and CUAV X7PRO.

### Context

None