### PR TITLE
gimbal: make device ID a clear out argument

### DIFF
--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -274,7 +274,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 			// Update output
 			thread_data.output_obj->update(
 				thread_data.control_data,
-				update_result != InputBase::UpdateResult::NoUpdate);
+				update_result != InputBase::UpdateResult::NoUpdate, thread_data.control_data.device_compid);
 
 			// Only publish the mount orientation if the mode is not mavlink v1 or v2
 			// If the gimbal speaks mavlink it publishes its own orientation.

--- a/src/modules/gimbal/output.h
+++ b/src/modules/gimbal/output.h
@@ -55,7 +55,7 @@ public:
 	explicit OutputBase(const Parameters &parameters);
 	virtual ~OutputBase() = default;
 
-	virtual void update(ControlData &control_data, bool new_setpoints) = 0;
+	virtual void update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id) = 0;
 
 	virtual void print_status() const = 0;
 

--- a/src/modules/gimbal/output_mavlink.cpp
+++ b/src/modules/gimbal/output_mavlink.cpp
@@ -46,7 +46,7 @@ OutputMavlinkV1::OutputMavlinkV1(const Parameters &parameters)
 	: OutputBase(parameters)
 {}
 
-void OutputMavlinkV1::update(ControlData &control_data, bool new_setpoints)
+void OutputMavlinkV1::update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id)
 {
 	vehicle_command_s vehicle_command{};
 	vehicle_command.timestamp = hrt_absolute_time();
@@ -142,7 +142,7 @@ OutputMavlinkV2::OutputMavlinkV2(const Parameters &parameters)
 {
 }
 
-void OutputMavlinkV2::update(ControlData &control_data, bool new_setpoints)
+void OutputMavlinkV2::update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id)
 {
 	_check_for_gimbal_device_information();
 
@@ -162,7 +162,7 @@ void OutputMavlinkV2::update(ControlData &control_data, bool new_setpoints)
 			_last_update = t;
 		}
 
-		control_data.device_compid = _gimbal_device_found ? _gimbal_device_compid : 0;
+		gimbal_device_id = _gimbal_device_found ? _gimbal_device_compid : 0;
 
 		_publish_gimbal_device_set_attitude();
 	}

--- a/src/modules/gimbal/output_mavlink.h
+++ b/src/modules/gimbal/output_mavlink.h
@@ -51,7 +51,7 @@ public:
 	OutputMavlinkV1(const Parameters &parameters);
 	virtual ~OutputMavlinkV1() = default;
 
-	virtual void update(ControlData &control_data, bool new_setpoints);
+	virtual void update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id);
 
 	virtual void print_status() const;
 
@@ -69,7 +69,7 @@ public:
 	OutputMavlinkV2(const Parameters &parameters);
 	virtual ~OutputMavlinkV2() = default;
 
-	virtual void update(ControlData &control_data, bool new_setpoints);
+	virtual void update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id);
 
 	virtual void print_status() const;
 

--- a/src/modules/gimbal/output_rc.cpp
+++ b/src/modules/gimbal/output_rc.cpp
@@ -48,7 +48,7 @@ OutputRC::OutputRC(const Parameters &parameters)
 {
 }
 
-void OutputRC::update(ControlData &control_data, bool new_setpoints)
+void OutputRC::update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id)
 {
 	if (new_setpoints) {
 		_set_angle_setpoints(control_data);
@@ -61,8 +61,7 @@ void OutputRC::update(ControlData &control_data, bool new_setpoints)
 
 	_stream_device_attitude_status();
 
-	// If the output is RC, then it means we are also the gimbal device.
-	control_data.device_compid = (uint8_t)_parameters.mnt_mav_compid_v1;
+	// If the output is RC, then it means we are also the gimbal device. gimbal_device_id = (uint8_t)_parameters.mnt_mav_compid_v1;
 
 	// _angle_outputs are in radians, gimbal_controls are in [-1, 1]
 	gimbal_controls_s gimbal_controls{};

--- a/src/modules/gimbal/output_rc.h
+++ b/src/modules/gimbal/output_rc.h
@@ -50,7 +50,7 @@ public:
 	explicit OutputRC(const Parameters &parameters);
 	virtual ~OutputRC() = default;
 
-	virtual void update(ControlData &control_data, bool new_setpoints);
+	virtual void update(const ControlData &control_data, bool new_setpoints, uint8_t &gimbal_device_id);
 	virtual void print_status() const;
 
 private:


### PR DESCRIPTION
The API is cleaner if the control_data is const reference and the device compid is an explicit output argument.

Follow up to #21529.