### PR TITLE
SITL: fix parse error on start

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -36,7 +36,7 @@ if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0"
 		exit 1
 	fi
 
-elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; then
+elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" = "1" ]; then
 
 	# set local coordinate frame reference
 	if [ -n "${PX4_HOME_LAT}" ]; then


### PR DESCRIPTION
~Two things that caught my eye. See commits.~

This fixes the error:
```etc/init.d-posix/rcS: 39: [: Illegal number:```