### PR TITLE
Send parachute MAVLink command on disarm in air

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -879,6 +879,10 @@ Commander::handle_command(const vehicle_command_s &cmd)
 				} else if (arming_action == vehicle_command_s::ARMING_ACTION_DISARM) {
 					arming_res = disarm(arm_disarm_reason, forced);
 
+					if (arming_res == TRANSITION_CHANGED && !_vehicle_land_detected.landed) {
+						send_parachute_command();
+					}
+
 				}
 
 				if (arming_res == TRANSITION_DENIED) {


### PR DESCRIPTION
### Solved Problem
I found that performing a disarm in air (e.g. "terminating" from QGC by selecting disarm),
a MAVLink connected parachute is not deployed.
In my opinion, the behavior for a disarm in the air should be the same as for a terminate (regarding parachutes).

### Solution
- Send parachute MAVLink command on disarm **if** the vehicle is not landed.

### Changelog Entry
For release notes:
```
Feature/Bugfix Send MAVLink parachute command on disarm in air
New parameter: _NONE_
Documentation: _NONE_
```

### Alternatives
- Could not "terminate" the drone by disarming in air, but rather send the correct termination message (fix in QGC).
- Could add parameter to make behavior optional

### Test coverage
- Tested in simulator with quick python script to simulator parachute
  - Disarmed in air, verified deployed parachute
  - Disarmed on ground, verified no deployed parachute
  - Normal landing with automatic disarm, verified no deployed parachute

### Context
N/A
