### PR TITLE
ads1115: Driver improvements

### DIFF
--- a/src/drivers/adc/ads1115/ADS1115.cpp
+++ b/src/drivers/adc/ads1115/ADS1115.cpp
@@ -39,7 +39,6 @@ int ADS1115::init()
 	int ret = I2C::init();
 
 	if (ret != PX4_OK) {
-		PX4_ERR("I2C init failed");
 		return ret;
 	}
 
@@ -57,6 +56,24 @@ int ADS1115::init()
 	setChannel(ADS1115::A0);  // prepare for the first measure.
 
 	ScheduleOnInterval(SAMPLE_INTERVAL / 4, SAMPLE_INTERVAL / 4);
+
+	return PX4_OK;
+}
+
+int ADS1115::probe()
+{
+	uint8_t buf[2] = {};
+	int ret = readReg(ADDRESSPOINTER_REG_CONFIG, buf, 2);
+
+	if (ret != PX4_OK) {
+		DEVICE_DEBUG("readReg failed (%i)", ret);
+		return ret;
+	}
+
+	if (buf[0] != CONFIG_RESET_VALUE_HIGH || buf[1] != CONFIG_RESET_VALUE_LOW) {
+		DEVICE_DEBUG("ADS1115 not found");
+		return PX4_ERROR;
+	}
 
 	return PX4_OK;
 }

--- a/src/drivers/adc/ads1115/ADS1115.h
+++ b/src/drivers/adc/ads1115/ADS1115.h
@@ -93,6 +93,9 @@
 #define CONFIG_LOW_COMP_QU_AFTER4    0x02
 #define CONFIG_LOW_COMP_QU_DISABLE    0x03
 
+#define CONFIG_RESET_VALUE_HIGH 0x85
+#define CONFIG_RESET_VALUE_LOW 0x83
+
 using namespace time_literals;
 
 /*
@@ -114,6 +117,8 @@ public:
 
 	void RunImpl();
 
+	int probe() override;
+
 protected:
 
 	void print_status() override;
@@ -131,6 +136,8 @@ private:
 	perf_counter_t			_cycle_perf;
 
 	int     _channel_cycle_count{0};
+
+	bool    _reported_ready_last_cycle{false};
 
 	// ADS1115 logic part
 	enum ChannelSelection {

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -80,6 +80,11 @@ void ADS1115::RunImpl()
 	_adc_report.timestamp = hrt_absolute_time();
 
 	if (isSampleReady()) { // whether ADS1115 is ready to be read or not
+		if (!_reported_ready_last_cycle) {
+			PX4_INFO("ADS1115: reported ready");
+			_reported_ready_last_cycle = true;
+		}
+
 		int16_t buf;
 		ADS1115::ChannelSelection ch = cycleMeasure(&buf);
 		++_channel_cycle_count;
@@ -118,7 +123,10 @@ void ADS1115::RunImpl()
 		}
 
 	} else {
-		PX4_WARN("ADS1115 not ready!");
+		if (_reported_ready_last_cycle) {
+			_reported_ready_last_cycle = false;
+			PX4_ERR("ADS1115: not ready. Device lost?");
+		}
 	}
 
 	perf_end(_cycle_perf);


### PR DESCRIPTION

### Solved Problem

This improves the ADS1115 adc driver with the following:

- Adds a `probe` function to check for the config register default value. This prevents the driver to accidentally recognize another device with the same address on the bus. For example, the SE050 chip on FMUv5X can have the same basic address of `0x48`.
- Prevent printing an error on init failure when just probe fails
- Prevent spamming of console when the device is lost

### Alternatives
The random probing of I2C buses is not nice. Also, this chip has no chip ID register, so probing for the config register default value is the best we can do.

