### PR TITLE
ArmingStatus set to Armed based on actuator_armed.armed

### DIFF
--- a/src/drivers/uavcan/arming_status.cpp
+++ b/src/drivers/uavcan/arming_status.cpp
@@ -69,7 +69,7 @@ void UavcanArmingStatus::periodic_update(const uavcan::TimerEvent &)
 		if (actuator_armed.lockdown || actuator_armed.manual_lockdown) {
 			cmd.status = cmd.STATUS_DISARMED;
 
-		} else if (actuator_armed.armed || actuator_armed.prearmed) {
+		} else if (actuator_armed.armed) {
 			cmd.status = cmd.STATUS_FULLY_ARMED;
 
 		} else {

--- a/src/drivers/uavcannode/Subscribers/ArmingStatus.hpp
+++ b/src/drivers/uavcannode/Subscribers/ArmingStatus.hpp
@@ -89,6 +89,7 @@ private:
 			actuator_armed.armed = false;
 		}
 
+		actuator_armed.prearmed = true;
 		actuator_armed.timestamp = hrt_absolute_time();
 		_actuator_armed_pub.publish(actuator_armed);
 	}


### PR DESCRIPTION
Previously, the DroneCAN message `uavcan::equipment::safety::ArmingStatus::status` was set to STATUS_FULLY_ARMED if we were prearmed or armed. This would result in actuators being able to actuate such as ESC's  even if the arm switch on the transmitter were on the disarm position, because the FMU entered prearmed.

This change sets `uavcan::equipment::safety::ArmingStatus::status` to STATUS_FULLY_ARMED if actuator_armed::armed is true.

On the cannode side, we hardcode prearm to true on receiving the uavcan::equipment::safety::ArmingStatus message, to allow servos/lights and other devices to be controlled in a disarmed state.

