### PR TITLE
FW Position Controller: use FW_TKO_PITCH_MIN to not dive into ground

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1030_gazebo-classic_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1030_gazebo-classic_plane
@@ -5,9 +5,6 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
-
 param set-default FW_LND_ANG 8
 
 param set-default NPFG_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1031_gazebo-classic_plane_cam
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1031_gazebo-classic_plane_cam
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1031_gazebo-classic_plane_cam
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1031_gazebo-classic_plane_cam
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default NPFG_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default NPFG_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
@@ -46,8 +46,6 @@ param set-default MIS_TAKEOFF_ALT 30
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
-param set-default RWTO_TKOFF 1
-
 param set-default CA_AIRFRAME 1
 
 param set-default CA_ROTOR_COUNT 1
@@ -72,6 +70,4 @@ param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_FUNC8 203
 param set-default PWM_MAIN_FUNC9 206
 param set-default PWM_MAIN_REV 256
-
-param set-default RWTO_TKOFF 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
@@ -5,7 +5,8 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-
+param set-default FW_LAUN_DETCN_ON 1
+param set-default FW_THR_IDLE 0.1 # needs to be running before throw as that's how gazebo detects arming
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1035_gazebo-classic_techpod
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1035_gazebo-classic_techpod
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_gazebo-classic_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_gazebo-classic_believer
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default NPFG_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1038_gazebo-classic_glider
@@ -46,8 +46,6 @@ param set-default MIS_TAKEOFF_ALT 30
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2
 
-param set-default RWTO_TKOFF 1
-
 param set-default CA_AIRFRAME 1
 
 param set-default CA_ROTOR_COUNT 1
@@ -74,4 +72,3 @@ param set-default PWM_MAIN_FUNC9 206
 param set-default PWM_MAIN_REV 256
 
 param set-default FW_THR_TRIM 0.0
-param set-default RWTO_TKOFF 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
@@ -5,7 +5,6 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default FW_LND_AIRSPD_SC 1.1
 param set-default FW_LND_ANG 5
 param set-default FW_LND_FL_PMIN 9.5
 param set-default FW_LND_FL_PMAX 20

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_gazebo-classic_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_gazebo-classic_advanced_plane
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 param set-default FW_THR_LND_MAX 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1044_gazebo-classic_plane_lidar
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1044_gazebo-classic_plane_lidar
@@ -5,8 +5,7 @@
 
 . ${R}etc/init.d/rc.fw_defaults
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1044_gazebo-classic_plane_lidar
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1044_gazebo-classic_plane_lidar
@@ -8,7 +8,6 @@
 param set-default EKF2_MAG_ACCLIM 0
 param set-default EKF2_MAG_YAWLIM 0
 
-param set-default FW_LND_AIRSPD_SC 1
 param set-default FW_LND_ANG 8
 
 param set-default NPFG_PERIOD 12

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/17002_flightgear_tf-g2
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/17002_flightgear_tf-g2
@@ -26,7 +26,6 @@ param set-default NAV_ACC_RAD 20
 param set-default NAV_DLL_ACT 2
 param set-default NAV_LOITER_RAD 50
 
-param set-default RWTO_TKOFF 0
 # Parameters related to autogyro takeoff PR
 #param set-default AG_TKOFF 1
 #param set-default AG_PROT_TYPE 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4003_gz_rc_cessna
@@ -17,8 +17,7 @@ param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
 param set-default SENS_EN_ARSPDSIM 1
 
-param set-default EKF2_MAG_ACCLIM 0
-param set-default EKF2_MAG_YAWLIM 0
+
 
 param set-default FW_LND_ANG 8
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1466,7 +1466,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			tecs_update_pitch_throttle(control_interval,
 						   altitude_setpoint_amsl,
 						   target_airspeed,
-						   radians(_param_fw_p_lim_min.get()),
+						   radians(_takeoff_pitch_min.get()),
 						   radians(_param_fw_p_lim_max.get()),
 						   _param_fw_thr_min.get(),
 						   max_takeoff_throttle,


### PR DESCRIPTION
### Solved Problem

Fixes https://github.com/PX4/PX4-Autopilot/issues/21567

### Solution
Use FW_TKO_PITCH_MIN in takeoff phase instead of global min pitch. That prevents the system from diving after the throw to gain airspeed. 

Further we could filter the airspeed in TECS less, eg by increasing FW_T_SPD_DEV_STD (as we anyway fix the airspeed rate input into TECS to 0 currently, see https://github.com/PX4/PX4-Autopilot/pull/21317).

I also fixed the simulation along the way (see attached screen recording).

### Changelog Entry
For release notes:
```
Bugfix Plane catapult use FW_TKO_PITCH_MIN
```



### Test coverage
Would be cool!

### Context
How to simulate:
`make px4_sitl_default gazebo_plane_catapult`
Plan mission with takeoff, arm vehicle.
https://github.com/PX4/PX4-Autopilot/assets/26798987/1b953c42-07d6-4110-b222-3f5543d949da


