### PR TITLE
FW Position Controller: increase default of FW_T_SPD_DEV_STD to 0.2

### DIFF
--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -603,7 +603,7 @@ PARAM_DEFINE_FLOAT(FW_T_SPD_STD, 0.2f);
  * @increment 0.1
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_SPD_DEV_STD, 0.05f);
+PARAM_DEFINE_FLOAT(FW_T_SPD_DEV_STD, 0.2f);
 
 /**
  * Process noise standard deviation for the airspeed rate in the airspeed filter.


### PR DESCRIPTION

### Solved Problem
We currently fuse 0 as airspeed rate measurement, and thus simply low-pass filter the airspeed measurements. Testing has shown that the current default on the airspeed rate measurement noise is set to low, and thus the airspeed measurement is filtered too much.

Fixes https://github.com/PX4/PX4-Autopilot/issues/21567 (beside other PRs)

### Solution
Increase default to 0.2

### Alternatives
We could also ...

### Test coverage
Tested on different FW and VTOLs. E.g.
https://review.px4.io/plot_app?log=f1a4a437-b99f-4b22-b711-c5674c4b2b62
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/c88d05a8-0c83-4952-a4e2-4595ce0aa7d8)
The cursor is at the moment where the value of FW_T_SPD_DEV_STD was changed from 0.05 to 0.2. Note how the filtered airspeed value then follows the measurement closer, and the raw airspeed oscillations are reduced as the controller is able to react earlier to disturbances. 

It also has a positive effect on FW catapult takeoff, as there the airspeed is rapidly increased from 0 to a flying airspeed, and the filtered valued tended to lag a lot behind.
Here examples of SITL catapult launches:

Prior:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/708ee1e5-dbb7-4b9d-a54a-408c7ff4bcd9)


After this PR:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/79a159e2-5a3d-4ed3-be0a-2fa741b6b487)



