### PR TITLE
FW Pos Control: add in_takeoff_situation argument to adapt_airspeed_setpoint()

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
@@ -7,6 +7,7 @@
 
 param set-default FW_LAUN_DETCN_ON 1
 param set-default FW_THR_IDLE 0.1 # needs to be running before throw as that's how gazebo detects arming
+param set-default FW_LAUN_AC_THLD 10
 
 param set-default FW_LND_ANG 8
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -669,10 +669,11 @@ private:
 	 * @param calibrated_airspeed_setpoint Calibrated airspeed septoint (generally from the position setpoint) [m/s]
 	 * @param calibrated_min_airspeed Minimum calibrated airspeed [m/s]
 	 * @param ground_speed Vehicle ground velocity vector (NE) [m/s]
+	 * @param in_takeoff_situation Vehicle is currently in a takeoff situation
 	 * @return Adjusted calibrated airspeed setpoint [m/s]
 	 */
 	float adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
-				      float calibrated_min_airspeed, const Vector2f &ground_speed);
+				      float calibrated_min_airspeed, const Vector2f &ground_speed, bool in_takeoff_situation = false);
 
 	void reset_takeoff_state();
 	void reset_landing_state();


### PR DESCRIPTION

### Solved Problem
Airspeed setpoint at beginning of FW takeoff is set to AIRSPD_TRIM, and then slowly ramped down to TKO_AIRSPD. 

Fixes https://github.com/PX4/PX4-Autopilot/issues/21567 (beside other PRs)

### Solution
Add argument in_takeoff_situation to adapt_airspeed_setpoint(), and do not run airspeed setpoint slew rate limiting then. Also disable some other logic, and only keep the load factor to airspeed setpoint logic while in takeoff.

### Test coverage
SITL tested.

Prior this PR:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/d33e9645-21ac-4630-949f-7a0bb80b3ef3)

After this PR:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/6a156585-3041-4c62-8e1a-79f53d00459d)

Now the airspeed setpoint is at the set 12m/s when the takeoff starts, and not at the TRIM airspeed (15).