### PR TITLE
Fix high yaw rate before front-transition

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -321,12 +321,12 @@ void FlightTaskAuto::_limitYawRate()
 		if (!PX4_ISFINITE(_yawspeed_setpoint) && (_deltatime > FLT_EPSILON)) {
 			// Create a feedforward using the filtered derivative
 			_yawspeed_filter.setParameters(_deltatime, .2f);
-			_yawspeed_filter.update(dyaw);
-			_yawspeed_setpoint = _yawspeed_filter.getState() / _deltatime;
+			_yawspeed_filter.update(dyaw / _deltatime);
+			_yawspeed_setpoint = _yawspeed_filter.getState();
 		}
 	}
 
-	_yaw_sp_prev = _yaw_setpoint;
+	_yaw_sp_prev = PX4_ISFINITE(_yaw_setpoint) ? _yaw_setpoint : _yaw;
 
 	if (PX4_ISFINITE(_yawspeed_setpoint)) {
 		// The yaw setpoint is aligned when its rate is not saturated


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
A VTOL plane in MC mode has no yaw setpoint during takeoff because of weather-vane. To align for the front transition, the yaw target jumps and caused a step in the controller, making it reach saturation.

### Solution
With this commit, the previous yaw setpoint is set to the current yaw when no yaw setpoint is sent in order to create a smooth yaw trajectory starting at the current orientation when yaw target is suddenly finite.

The yawspeed filter also now contains the yaw speed instead of dyaw in order to prevent chattering due to dt jitter.

### Changelog Entry
For release notes:
```
Fix high yaw rate before front-transition
New parameter: -
Documentation: -
```

### Test coverage
SITL gazebo vtol standard

### Context
before:
![vtol_yaw_step](https://github.com/Auterion/PX4_firmware_private/assets/14822839/a038ade3-04fe-4c2c-abc3-506a9c2a8351)
after:
![vtol_yaw_step_fix](https://github.com/Auterion/PX4_firmware_private/assets/14822839/dfeb0707-fbcc-4ad7-94ac-945a14358558)
