### PR TITLE
TECS: init _velocity_control_traj_generator properly

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -211,6 +211,7 @@ void TECSAltitudeReferenceModel::initialize(const AltitudeReferenceState &state)
 	const float init_state_alt_rate = PX4_ISFINITE(state.alt_rate) ? state.alt_rate : 0.f;
 
 	_alt_control_traj_generator.reset(0.0f, init_state_alt_rate, init_state_alt);
+	_velocity_control_traj_generator.reset(0.f, init_state_alt_rate, init_state_alt);
 }
 
 void TECSControl::initialize(const Setpoint &setpoint, const Input &input, Param &param, const Flag &flag)


### PR DESCRIPTION
### Solved Problem
The manual trajectory generator was never initialized, and then if you did a VTOL transition in Altitude or Position mode, it's position was at 0 instead of the current altitude, resulting in a big height rate down setpoint. 
It was then correctly reset once the sticks are moved ([here](https://github.com/PX4/PX4-Autopilot/blob/cf74d5ff5aa6b0461bb209a845a9f4f75c0d238b/src/lib/tecs/TECS.cpp#L172)), but if you never moved your sticks the vehicle would have crashed.  

### Solution
Reset _velocity_control_traj_generator when also _alt_control_traj_generator is reset. 
