### PR TITLE
Quad Tailsitter SITL tuning proposal

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -33,23 +33,25 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 param set-default PWM_MAIN_FUNC5 0
 
-param set-default FW_PR_I 0.2
-param set-default FW_PR_P 0.4
+parm set-default FD_FAIL_R 70
+
+param set-default FW_P_TC 0.6
+
+param set-default FW_PR_I 0.3
+param set-default FW_PR_P 0.5
 param set-default FW_PSP_OFF 2
-param set-default FW_RR_P 0.4
-param set-default FW_YR_P 0.2
-param set-default FW_THR_TRIM 0.33
-param set-default FW_THR_MAX 0.6
+param set-default FW_RR_FF 0.1
+param set-default FW_RR_I 0.1
+param set-default FW_RR_P 0.2
+param set-default FW_YR_FF 0 # make yaw rate controller very weak, only keep default P
+param set-default FW_YR_I 0
+param set-default FW_THR_TRIM 0.35
+param set-default FW_THR_MAX 0.8
 param set-default FW_THR_MIN 0.05
-param set-default FW_T_ALT_TC 2
-param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_CLMB_MAX 6
 param set-default FW_T_HRATE_FF 0.5
-param set-default FW_T_SINK_MAX 2.7
-param set-default FW_T_SINK_MIN 2.2
-param set-default FW_T_TAS_TC 2
-param set-default FW_R_TC 0.1
-param set-default FW_P_TC 0.1
-param set-default FW_R_LIM 60.0
+param set-default FW_T_SINK_MAX 3
+param set-default FW_T_SINK_MIN 1.6
 param set-default FW_AIRSPD_STALL 10
 param set-default FW_AIRSPD_MIN 14
 param set-default FW_AIRSPD_TRIM 18
@@ -62,15 +64,8 @@ param set-default MC_PITCH_P 3
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_PITCHRATE_P 0.3
 
-param set-default MPC_XY_P 0.8
-param set-default MPC_XY_VEL_P_ACC 3
-param set-default MPC_XY_VEL_I_ACC 4
-param set-default MPC_XY_VEL_D_ACC 0.1
-
+param set-default VT_ARSP_TRANS 15
 param set-default VT_FW_DIFTHR_EN 7
-param set-default VT_FW_DIFTHR_S_R 0.5
-param set-default VT_FW_DIFTHR_S_P 0.5
-param set-default VT_FW_DIFTHR_S_Y 0.5
 param set-default VT_F_TRANS_DUR 1.5
 param set-default VT_TYPE 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -62,21 +62,16 @@ param set-default MC_PITCH_P 3
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_PITCHRATE_P 0.3
 
-param set-default MPC_ACC_HOR_MAX 2
 param set-default MPC_XY_P 0.8
 param set-default MPC_XY_VEL_P_ACC 3
 param set-default MPC_XY_VEL_I_ACC 4
 param set-default MPC_XY_VEL_D_ACC 0.1
-
-param set-default NPFG_PERIOD 10
-param set-default NAV_ACC_RAD 10
 
 param set-default VT_FW_DIFTHR_EN 7
 param set-default VT_FW_DIFTHR_S_R 0.5
 param set-default VT_FW_DIFTHR_S_P 0.5
 param set-default VT_FW_DIFTHR_S_Y 0.5
 param set-default VT_F_TRANS_DUR 1.5
-param set-default VT_F_TRANS_THR 0.7
 param set-default VT_TYPE 0
 
 param set-default WV_EN 0

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -244,3 +244,31 @@ PARAM_DEFINE_FLOAT(FW_PSP_OFF, 0.0f);
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_YR_MAX, 30.f);
+
+/**
+ * Maximum manual roll angle
+ *
+ * Maximum manual roll angle setpoint (positive & negative) in manual attitude-only stabilized mode
+ *
+ * @unit deg
+ * @min 0.0
+ * @max 90.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW Attitude Control
+ */
+PARAM_DEFINE_FLOAT(FW_MAN_R_MAX, 45.0f);
+
+/**
+ * Maximum manual pitch angle
+ *
+ * Maximum manual pitch angle setpoint (positive & negative) in manual attitude-only stabilized mode
+ *
+ * @unit deg
+ * @min 0.0
+ * @max 90.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW Attitude Control
+ */
+PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 30.0f);

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -166,9 +166,7 @@ private:
 		(ParamFloat<px4::params::FW_DTRIM_Y_VMAX>) _param_fw_dtrim_y_vmax,
 		(ParamFloat<px4::params::FW_DTRIM_Y_VMIN>) _param_fw_dtrim_y_vmin,
 
-		(ParamFloat<px4::params::FW_MAN_P_MAX>) _param_fw_man_p_max,
 		(ParamFloat<px4::params::FW_MAN_P_SC>) _param_fw_man_p_sc,
-		(ParamFloat<px4::params::FW_MAN_R_MAX>) _param_fw_man_r_max,
 		(ParamFloat<px4::params::FW_MAN_R_SC>) _param_fw_man_r_sc,
 		(ParamFloat<px4::params::FW_MAN_Y_SC>) _param_fw_man_y_sc,
 

--- a/src/modules/fw_rate_control/fw_rate_control_params.c
+++ b/src/modules/fw_rate_control/fw_rate_control_params.c
@@ -485,20 +485,6 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_Y_VMAX, 0.0f);
 PARAM_DEFINE_FLOAT(FW_MAN_R_SC, 1.0f);
 
 /**
- * Maximum manual pitch angle
- *
- * Maximum manual pitch angle setpoint (positive & negative) in manual attitude-only stabilized mode
- *
- * @unit deg
- * @min 0.0
- * @max 90.0
- * @decimal 1
- * @increment 0.5
- * @group FW Attitude Control
- */
-PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 30.0f);
-
-/**
  * Manual pitch scale
  *
  * Scale factor applied to the desired pitch actuator command in full manual mode. This parameter allows
@@ -511,20 +497,6 @@ PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 30.0f);
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_P_SC, 1.0f);
-
-/**
- * Maximum manual roll angle
- *
- * Maximum manual roll angle setpoint (positive & negative) in manual attitude-only stabilized mode
- *
- * @unit deg
- * @min 0.0
- * @max 90.0
- * @decimal 1
- * @increment 0.5
- * @group FW Attitude Control
- */
-PARAM_DEFINE_FLOAT(FW_MAN_R_MAX, 45.0f);
 
 /**
  * Manual yaw scale


### PR DESCRIPTION
A couple of tuning proposals for https://github.com/PX4/PX4-Autopilot/pull/20558 (PR against PR). 

- keep as many params at default as possible to reduce maintenance load
- make pitch loop tighter
- reduce aggressiveness on yaw controller as not as important as pitch/roll, and it had negative side effects on pitch/roll
- adapt TECS params

And https://github.com/PX4/PX4-Autopilot/commit/377034d43337904d1e30061b9458f74642a45154 is acutally unrelated to the PR, but looked wrong to me.