### PR TITLE
Ublox add UBX-RXM-RTCM for RTCM input status

### DIFF
--- a/msg/SensorGps.msg
+++ b/msg/SensorGps.msg
@@ -55,4 +55,11 @@ float32 heading_accuracy	# heading accuracy (rad, [0, 2PI])
 float32 rtcm_injection_rate	# RTCM message injection rate Hz
 uint8 selected_rtcm_instance	# uorb instance that is being used for RTCM corrections
 
+bool rtcm_crc_failed		# RTCM message CRC failure detected
+
+uint8 RTCM_MSG_USED_UNKNOWN = 0
+uint8 RTCM_MSG_USED_NOT_USED = 1
+uint8 RTCM_MSG_USED_USED = 2
+uint8 rtcm_msg_used		# Indicates if the RTCM message was used successfully by the receiver
+
 # TOPICS sensor_gps vehicle_gps_position

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -60,6 +60,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/topics/gps_dump.h>
 #include <uORB/topics/gps_inject_data.h>
 #include <uORB/topics/sensor_gps.h>
@@ -203,7 +204,7 @@ private:
 
 	const Instance 			_instance;
 
-	uORB::Subscription		     _orb_inject_data_sub{ORB_ID(gps_inject_data)};
+	uORB::SubscriptionMultiArray<gps_inject_data_s, gps_inject_data_s::MAX_INSTANCES> _orb_inject_data_sub{ORB_ID::gps_inject_data};
 	uORB::Publication<gps_inject_data_s> _gps_inject_data_pub{ORB_ID(gps_inject_data)};
 	uORB::Publication<gps_dump_s>	     _dump_communication_pub{ORB_ID(gps_dump)};
 	gps_dump_s			     *_dump_to_device{nullptr};
@@ -530,22 +531,21 @@ void GPS::handleInjectDataTopic()
 	// If there has not been a valid RTCM message for a while, try to switch to a different RTCM link
 	if ((hrt_absolute_time() - _last_rtcm_injection_time) > 5_s) {
 
-		for (uint8_t i = 0; i < gps_inject_data_s::MAX_INSTANCES; i++) {
-			if (_orb_inject_data_sub.ChangeInstance(i)) {
-				if (_orb_inject_data_sub.copy(&msg)) {
+		for (int instance = 0; instance < _orb_inject_data_sub.size(); instance++) {
+			const bool exists = _orb_inject_data_sub[instance].advertised();
+
+			if (exists) {
+				if (_orb_inject_data_sub[instance].copy(&msg)) {
 					if ((hrt_absolute_time() - msg.timestamp) < 5_s) {
 						// Remember that we already did a copy on this instance.
 						already_copied = true;
-						_selected_rtcm_instance = i;
+						_selected_rtcm_instance = instance;
 						break;
 					}
 				}
 			}
 		}
 	}
-
-	// Reset instance in case we didn't actually want to switch
-	_orb_inject_data_sub.ChangeInstance(_selected_rtcm_instance);
 
 	bool updated = already_copied;
 
@@ -574,7 +574,7 @@ void GPS::handleInjectDataTopic()
 			}
 		}
 
-		updated = _orb_inject_data_sub.update(&msg);
+		updated = _orb_inject_data_sub[_selected_rtcm_instance].update(&msg);
 
 	} while (updated && num_injections < max_num_injections);
 }

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -467,29 +467,61 @@ void UavcanGnssBridge::update()
 // to work.
 void UavcanGnssBridge::handleInjectDataTopic()
 {
+	// We don't want to call copy again further down if we have already done a
+	// copy in the selection process.
+	bool already_copied = false;
+	gps_inject_data_s msg;
+
+	// If there has not been a valid RTCM message for a while, try to switch to a different RTCM link
+	if ((hrt_absolute_time() - _last_rtcm_injection_time) > 5_s) {
+
+		for (int instance = 0; instance < _orb_inject_data_sub.size(); instance++) {
+			const bool exists = _orb_inject_data_sub[instance].advertised();
+
+			if (exists) {
+				if (_orb_inject_data_sub[instance].copy(&msg)) {
+					if ((hrt_absolute_time() - msg.timestamp) < 5_s) {
+						// Remember that we already did a copy on this instance.
+						already_copied = true;
+						_selected_rtcm_instance = instance;
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	bool updated = already_copied;
+
 	// Limit maximum number of GPS injections to 8 since usually
 	// GPS injections should consist of 1-4 packets (GPS, Glonass, BeiDou, Galileo).
-	// Looking at 6 packets thus guarantees, that at least a full injection
+	// Looking at 8 packets thus guarantees, that at least a full injection
 	// data set is evaluated.
-	static constexpr size_t MAX_NUM_INJECTIONS = gps_inject_data_s::ORB_QUEUE_LENGTH;;
-
+	// Moving Base requires a higher rate, so we allow up to 8 packets.
+	const size_t max_num_injections = gps_inject_data_s::ORB_QUEUE_LENGTH;
 	size_t num_injections = 0;
-	gps_inject_data_s gps_inject_data;
 
-	while ((num_injections <= MAX_NUM_INJECTIONS) && _gps_inject_data_sub.update(&gps_inject_data)) {
-		// Write the message to the gps device. Note that the message could be fragmented.
-		// But as we don't write anywhere else to the device during operation, we don't
-		// need to assemble the message first.
-		if (_publish_rtcm_stream) {
-			PublishRTCMStream(gps_inject_data.data, gps_inject_data.len);
+	do {
+		if (updated) {
+			num_injections++;
+
+			// Write the message to the gps device. Note that the message could be fragmented.
+			// But as we don't write anywhere else to the device during operation, we don't
+			// need to assemble the message first.
+			if (_publish_rtcm_stream) {
+				PublishRTCMStream(msg.data, msg.len);
+			}
+
+			if (_publish_moving_baseline_data) {
+				PublishMovingBaselineData(msg.data, msg.len);
+			}
+
+			_last_rtcm_injection_time = hrt_absolute_time();
 		}
 
-		if (_publish_moving_baseline_data) {
-			PublishMovingBaselineData(gps_inject_data.data, gps_inject_data.len);
-		}
+		updated = _orb_inject_data_sub[_selected_rtcm_instance].update(&msg);
 
-		num_injections++;
-	}
+	} while (updated && num_injections < max_num_injections);
 }
 
 bool UavcanGnssBridge::PublishRTCMStream(const uint8_t *const data, const size_t data_len)

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -467,11 +467,11 @@ void UavcanGnssBridge::update()
 // to work.
 void UavcanGnssBridge::handleInjectDataTopic()
 {
-	// Limit maximum number of GPS injections to 6 since usually
+	// Limit maximum number of GPS injections to 8 since usually
 	// GPS injections should consist of 1-4 packets (GPS, Glonass, BeiDou, Galileo).
 	// Looking at 6 packets thus guarantees, that at least a full injection
 	// data set is evaluated.
-	static constexpr size_t MAX_NUM_INJECTIONS = 6;
+	static constexpr size_t MAX_NUM_INJECTIONS = gps_inject_data_s::ORB_QUEUE_LENGTH;;
 
 	size_t num_injections = 0;
 	gps_inject_data_s gps_inject_data;

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -45,6 +45,7 @@
 #pragma once
 
 #include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_gps.h>
 #include <uORB/topics/gps_inject_data.h>
@@ -123,7 +124,9 @@ private:
 	float		_last_gnss_auxiliary_hdop{0.0f};
 	float		_last_gnss_auxiliary_vdop{0.0f};
 
-	uORB::Subscription _gps_inject_data_sub{ORB_ID(gps_inject_data)};
+	uORB::SubscriptionMultiArray<gps_inject_data_s, gps_inject_data_s::MAX_INSTANCES> _orb_inject_data_sub{ORB_ID::gps_inject_data};
+	hrt_abstime		_last_rtcm_injection_time{0};	///< time of last rtcm injection
+	uint8_t			_selected_rtcm_instance{0};	///< uorb instance that is being used for RTCM corrections
 
 	bool _system_clock_set{false};  ///< Have we set the system clock at least once from GNSS data?
 


### PR DESCRIPTION
This PR adds support for the UBX-RXM-RTCM message which gives feedback on whether the ublox module is using the RTCM data that is being sent to it.

Requires https://github.com/PX4/PX4-GPSDrivers/pull/130

I also discovered a bug in the uavcan rtcm publisher. When the mavlink stream goes down there is a chance that a second instance of the gps_inject_data topic is created. When that happens the uavcan publisher isn't setup to handle switching streams. 

I mirrored the gps driver instance switching logic but discovered it will get stuck on a non existing gps_inject_data instance. 

@julianoes Can you take a look? 

```
nsh> gps status
INFO  [gps] Main GPS
INFO  [gps] protocol: UBX
INFO  [gps] status: OK, port: /dev/ttyS0, baudrate: 921600
INFO  [gps] sat info: disabled
INFO  [gps] rate reading:                  925 B/s
INFO  [gps] rate position:                1.00 Hz
INFO  [gps] rate velocity:                1.00 Hz
INFO  [gps] rate publication:             1.00 Hz
INFO  [gps] rate RTCM injection:         40.02 Hz
 sensor_gps
    timestamp: 244102098 (0.781204 seconds ago)
    timestamp_sample: 0
    time_utc_usec: 1684174039124558
    device_id: 11141125 (Type: 0xAA, SERIAL:0 (0x00))
    lat: 406203100
    lon: -1118287492
    alt: 1433548
    alt_ellipsoid: 1414764
    s_variance_m_s: 0.76600
    c_variance_rad: 2.39044
    eph: 6.32000
    epv: 10.58200
    hdop: 1.12000
    vdop: 1.75000
    noise_per_ms: 72
    jamming_indicator: 13
    vel_m_s: 0.18500
    vel_n_m_s: -0.00900
    vel_e_m_s: 0.18500
    vel_d_m_s: -0.06700
    cog_rad: 5.42557
    timestamp_time_relative: 0
    heading: nan
    heading_offset: -1.57080
    heading_accuracy: 0.00000
    rtcm_injection_rate: 40.01656
    automatic_gain_control: 0
    fix_type: 4
    jamming_state: 2
    spoofing_state: 1
    vel_ned_valid: True
    satellites_used: 11
    selected_rtcm_instance: 0
    rtcm_crc_failed: False
    rtcm_msg_used: 2
```