### PR TITLE
FW/VTOL: open up a couple of param constraints

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -50,8 +50,8 @@
  * copying them using the GCS.
  *
  * @group Radio Calibration
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -66,8 +66,8 @@ PARAM_DEFINE_FLOAT(TRIM_ROLL, 0.0f);
  * copying them using the GCS.
  *
  * @group Radio Calibration
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -82,8 +82,8 @@ PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
  * copying them using the GCS.
  *
  * @group Radio Calibration
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -40,11 +40,6 @@
  * @author Thomas Gubler <thomas@px4.io>
  */
 
-/*
- * Controller parameters, accessible via MAVLink
- *
- */
-
 /**
  * Attitude Roll Time Constant
  *
@@ -86,7 +81,7 @@ PARAM_DEFINE_FLOAT(FW_P_TC, 0.4f);
  *
  * @unit deg/s
  * @min 0.0
- * @max 90.0
+ * @max 180
  * @decimal 1
  * @increment 0.5
  * @group FW Attitude Control
@@ -98,7 +93,7 @@ PARAM_DEFINE_FLOAT(FW_P_RMAX_POS, 60.0f);
  *
  * @unit deg/s
  * @min 0.0
- * @max 90.0
+ * @max 180
  * @decimal 1
  * @increment 0.5
  * @group FW Attitude Control
@@ -110,7 +105,7 @@ PARAM_DEFINE_FLOAT(FW_P_RMAX_NEG, 60.0f);
  *
  * @unit deg/s
  * @min 0.0
- * @max 90.0
+ * @max 180
  * @decimal 1
  * @increment 0.5
  * @group FW Attitude Control
@@ -122,7 +117,7 @@ PARAM_DEFINE_FLOAT(FW_R_RMAX, 70.0f);
  *
  * @unit deg/s
  * @min 0.0
- * @max 90.0
+ * @max 180
  * @decimal 1
  * @increment 0.5
  * @group FW Attitude Control
@@ -140,7 +135,6 @@ PARAM_DEFINE_FLOAT(FW_Y_RMAX, 50.0f);
  */
 PARAM_DEFINE_INT32(FW_W_EN, 0);
 
-
 /**
  * Wheel steering rate proportional gain
  *
@@ -149,7 +143,7 @@ PARAM_DEFINE_INT32(FW_W_EN, 0);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Attitude Control
@@ -164,7 +158,7 @@ PARAM_DEFINE_FLOAT(FW_WR_P, 0.5f);
  *
  * @unit %/rad
  * @min 0.0
- * @max 0.5
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Attitude Control
@@ -207,7 +201,7 @@ PARAM_DEFINE_FLOAT(FW_W_RMAX, 30.0f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 2
  * @increment 0.05
  * @group FW Attitude Control

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -540,7 +540,7 @@ PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.1f);
  * @increment 0.05
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.1f);
+PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.05f);
 
 /**
  * Integrator gain pitch

--- a/src/modules/fw_rate_control/fw_rate_control_params.c
+++ b/src/modules/fw_rate_control/fw_rate_control_params.c
@@ -34,15 +34,10 @@
 /**
  * @file fw_rate_control_params.c
  *
- * Parameters defined by the fixed-wing attitude control task
+ * Parameters defined by the fixed-wing rate control task
  *
  * @author Lorenz Meier <lorenz@px4.io>
  * @author Thomas Gubler <thomas@px4.io>
- */
-
-/*
- * Controller parameters, accessible via MAVLink
- *
  */
 
 /**
@@ -58,7 +53,6 @@
  *
  * @unit m/s
  * @min 0.5
- * @max 40
  * @decimal 1
  * @increment 0.5
  * @group FW TECS
@@ -72,7 +66,6 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
  *
  * @unit m/s
  * @min 0.5
- * @max 40
  * @decimal 1
  * @increment 0.5
  * @group FW TECS
@@ -99,7 +92,6 @@ PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
  *
  * @unit m/s
  * @min 0.5
- * @max 40
  * @decimal 1
  * @increment 0.5
  * @group FW TECS
@@ -115,7 +107,6 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
  *
  * @unit m/s
  * @min 0.5
- * @max 40
  * @decimal 1
  * @increment 0.5
  * @group FW TECS
@@ -127,7 +118,7 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_STALL, 7.0f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -141,7 +132,7 @@ PARAM_DEFINE_FLOAT(FW_PR_P, 0.08f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -156,7 +147,7 @@ PARAM_DEFINE_FLOAT(FW_PR_D, 0.f);
  *
  * @unit %/rad
  * @min 0.0
- * @max 0.5
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -182,7 +173,7 @@ PARAM_DEFINE_FLOAT(FW_PR_IMAX, 0.4f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -197,7 +188,7 @@ PARAM_DEFINE_FLOAT(FW_RR_P, 0.05f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -212,9 +203,9 @@ PARAM_DEFINE_FLOAT(FW_RR_D, 0.00f);
  *
  * @unit %/rad
  * @min 0.0
- * @max 0.2
- * @decimal 3
- * @increment 0.005
+ * @max 10
+ * @decimal 2
+ * @increment 0.01
  * @group FW Rate Control
  */
 PARAM_DEFINE_FLOAT(FW_RR_I, 0.1f);
@@ -237,7 +228,7 @@ PARAM_DEFINE_FLOAT(FW_RR_IMAX, 0.2f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -252,7 +243,7 @@ PARAM_DEFINE_FLOAT(FW_YR_P, 0.05f);
  *
  * @unit %/rad/s
  * @min 0.0
- * @max 1.0
+ * @max 10
  * @decimal 3
  * @increment 0.005
  * @group FW Rate Control
@@ -267,7 +258,7 @@ PARAM_DEFINE_FLOAT(FW_YR_D, 0.0f);
  *
  * @unit %/rad
  * @min 0.0
- * @max 50.0
+ * @max 10
  * @decimal 1
  * @increment 0.5
  * @group FW Rate Control
@@ -338,7 +329,7 @@ PARAM_DEFINE_FLOAT(FW_YR_FF, 0.3f);
  * This is the rate the controller is trying to achieve if the user applies full roll
  * stick input in acro mode.
  *
- * @min 45
+ * @min 10
  * @max 720
  * @unit deg
  * @group FW Rate Control
@@ -348,7 +339,7 @@ PARAM_DEFINE_FLOAT(FW_ACRO_X_MAX, 90);
 /**
  * Acro body pitch max rate setpoint.
  *
- * @min 45
+ * @min 10
  * @max 720
  * @unit deg
  * @group FW Rate Control
@@ -359,7 +350,7 @@ PARAM_DEFINE_FLOAT(FW_ACRO_Y_MAX, 90);
  * Acro body yaw max rate setpoint.
  *
  * @min 10
- * @max 180
+ * @max 720
  * @unit deg
  * @group FW Rate Control
  */
@@ -397,8 +388,8 @@ PARAM_DEFINE_INT32(FW_ARSP_SCALE_EN, 1);
 * This increment is added to TRIM_ROLL when airspeed is FW_AIRSPD_MIN.
  *
  * @group FW Rate Control
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -410,8 +401,8 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_R_VMIN, 0.0f);
 * This increment is added to TRIM_PITCH when airspeed is FW_AIRSPD_MIN.
  *
  * @group FW Rate Control
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -423,8 +414,8 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_P_VMIN, 0.0f);
 * This increment is added to TRIM_YAW when airspeed is FW_AIRSPD_MIN.
  *
  * @group FW Rate Control
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -436,8 +427,8 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_Y_VMIN, 0.0f);
 * This increment is added to TRIM_ROLL when airspeed is FW_AIRSPD_MAX.
  *
  * @group FW Rate Control
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -449,8 +440,8 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_R_VMAX, 0.0f);
 * This increment is added to TRIM_PITCH when airspeed is FW_AIRSPD_MAX.
  *
  * @group FW Rate Control
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */
@@ -462,8 +453,8 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_P_VMAX, 0.0f);
 * This increment is added to TRIM_YAW when airspeed is FW_AIRSPD_MAX.
  *
  * @group FW Rate Control
- * @min -0.25
- * @max 0.25
+ * @min -0.5
+ * @max 0.5
  * @decimal 2
  * @increment 0.01
  */

--- a/src/modules/fw_rate_control/fw_rate_control_params.c
+++ b/src/modules/fw_rate_control/fw_rate_control_params.c
@@ -80,7 +80,7 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
  *
  * @value 0 Use airspeed in controller
  * @value 1 Do not use airspeed in controller
- * @group FW Attitude Control
+ * @group FW Rate Control
  */
 PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);
 
@@ -471,7 +471,7 @@ PARAM_DEFINE_FLOAT(FW_DTRIM_Y_VMAX, 0.0f);
  * @max 1.0
  * @decimal 2
  * @increment 0.01
- * @group FW Attitude Control
+ * @group FW Rate Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_R_SC, 1.0f);
 
@@ -485,7 +485,7 @@ PARAM_DEFINE_FLOAT(FW_MAN_R_SC, 1.0f);
  * @min 0.0
  * @decimal 2
  * @increment 0.01
- * @group FW Attitude Control
+ * @group FW Rate Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_P_SC, 1.0f);
 
@@ -499,7 +499,7 @@ PARAM_DEFINE_FLOAT(FW_MAN_P_SC, 1.0f);
  * @min 0.0
  * @decimal 2
  * @increment 0.01
- * @group FW Attitude Control
+ * @group FW Rate Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_Y_SC, 1.0f);
 
@@ -513,7 +513,7 @@ PARAM_DEFINE_FLOAT(FW_MAN_Y_SC, 1.0f);
  * @min 0.0
  * @decimal 1
  * @increment 0.01
- * @group FW Attitude Control
+ * @group FW Rate Control
  */
 PARAM_DEFINE_FLOAT(FW_RLL_TO_YAW_FF, 0.0f);
 
@@ -525,6 +525,6 @@ PARAM_DEFINE_FLOAT(FW_RLL_TO_YAW_FF, 0.0f);
  * @value 0 Disabled
  * @value 1 Flaps channel
  * @value 2 Aux1
- * @group FW Attitude Control
+ * @group FW Rate Control
  */
 PARAM_DEFINE_INT32(FW_SPOILERS_MAN, 0);

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -71,6 +71,8 @@ PARAM_DEFINE_INT32(VT_FWD_THRUST_EN, 0);
  *
  * @min 0.0
  * @max 2.0
+ * @increment 0.01
+ * @decimal 2
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_FWD_THRUST_SC, 0.7f);
@@ -83,6 +85,8 @@ PARAM_DEFINE_FLOAT(VT_FWD_THRUST_SC, 0.7f);
  * @unit s
  * @min 0.0
  * @max 20.0
+ * @increment 0.1
+ * @decimal 1
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_B_TRANS_RAMP, 3.0f);

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -39,7 +39,7 @@
  */
 
 /**
- * Position of tilt servo in mc mode
+ * Normalized tilt in Hover
  *
  * @min 0.0
  * @max 1.0
@@ -50,7 +50,7 @@
 PARAM_DEFINE_FLOAT(VT_TILT_MC, 0.0f);
 
 /**
- * Position of tilt servo in transition mode
+ * Normalized tilt transition to FW
  *
  * @min 0.0
  * @max 1.0
@@ -58,10 +58,10 @@ PARAM_DEFINE_FLOAT(VT_TILT_MC, 0.0f);
  * @decimal 3
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_TILT_TRANS, 0.3f);
+PARAM_DEFINE_FLOAT(VT_TILT_TRANS, 0.4f);
 
 /**
- * Position of tilt servo in fw mode
+ * Normalized tilt in FW
  *
  * @min 0.0
  * @max 1.0

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -50,7 +50,7 @@
 PARAM_DEFINE_FLOAT(VT_TILT_MC, 0.0f);
 
 /**
- * Normalized tilt transition to FW
+ * Normalized tilt in transition to FW
  *
  * @min 0.0
  * @max 1.0


### PR DESCRIPTION
While setting up planes lately I noticed that a couple of parameter min/max constraints don't make sense or that some param meta data is missing. 

Further I reduce the default of FW_T_I_GAIN_THR further, as testing on a wide variety of vehicles showed that 0.05 is a more appropriate value. Follow up on https://github.com/PX4/PX4-Autopilot/pull/21360.

I also change the default of VT_TILT_TRANS to the more appropriate 0.4 (0.3 is usually too low to accelerate enough for the transition to complete). 