### PR TITLE
Refactor uncommanded descend Quad-Chute

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -198,8 +198,8 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
  * Quad-chute uncommanded descent threshold
  *
  * Altitude error threshold for quad-chute triggering during fixed-wing flight.
- * The check is only active if the vehicle is below the current altitude reference and the error
- * is relative to the highest altitude the vehicle has achieved since it has flown below the current
+ * The check is only active if altitude is controlled and the vehicle is below the current altitude reference.
+ * The altitude error is relative to the highest altitude the vehicle has achieved since it has flown below the current
  * altitude reference.
  *
  * Set to 0 do disable.
@@ -211,7 +211,7 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
  * @decimal 1
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_QC_ALT_LOSS, 30.0f);
+PARAM_DEFINE_FLOAT(VT_QC_ALT_LOSS, 0.0f);
 
 /**
  * Quad-chute transition altitude loss threshold

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -197,12 +197,12 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
 /**
  * Quad-chute uncommanded descent threshold
  *
- * Threshold for integrated height rate error to trigger a uncommanded-descent quad-chute.
- * Only checked in altitude-controlled fixed-wing flight.
- * Additional conditions that have to be met for uncommanded descent detection are a positive (climbing) height
- * rate setpoint and a negative (sinking) current height rate estimate.
+ * Altitude error threshold for quad-chute triggering during fixed-wing flight.
+ * The check is only active if the vehicle is below the current altitude reference and the error
+ * is relative to the highest altitude the vehicle has achieved since it has flown below the current
+ * altitude reference.
  *
- * Set to 0 do disable this threshold.
+ * Set to 0 do disable.
  *
  * @unit m
  * @min 0.0
@@ -211,7 +211,7 @@ PARAM_DEFINE_FLOAT(VT_FW_MIN_ALT, 0.0f);
  * @decimal 1
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_QC_HR_ERROR_I, 0.0f);
+PARAM_DEFINE_FLOAT(VT_QC_ALT_LOSS, 30.0f);
 
 /**
  * Quad-chute transition altitude loss threshold

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -274,7 +274,8 @@ bool VtolType::isUncommandedDescent()
 {
 	const float current_altitude = -_local_pos->z + _local_pos->ref_alt;
 
-	if (_param_vt_qc_alt_loss.get() > FLT_EPSILON && _v_control_mode->flag_control_altitude_enabled
+	if (_param_vt_qc_alt_loss.get() > FLT_EPSILON && _local_pos->z_valid && _local_pos->z_global
+	    && _v_control_mode->flag_control_altitude_enabled
 	    && PX4_ISFINITE(_tecs_status->altitude_reference)
 	    && (current_altitude < _tecs_status->altitude_reference)
 	    && hrt_elapsed_time(&_tecs_status->timestamp) < 1_s) {

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -272,26 +272,20 @@ bool VtolType::isMinAltBreached()
 
 bool VtolType::isUncommandedDescent()
 {
-	if (_param_vt_qc_hr_error_i.get() > FLT_EPSILON && _v_control_mode->flag_control_altitude_enabled
+	const float current_altitude = -_local_pos->z + _local_pos->ref_alt;
+
+	if (_param_vt_qc_alt_loss.get() > FLT_EPSILON && _v_control_mode->flag_control_altitude_enabled
+	    && PX4_ISFINITE(_tecs_status->altitude_reference)
+	    && (current_altitude < _tecs_status->altitude_reference)
 	    && hrt_elapsed_time(&_tecs_status->timestamp) < 1_s) {
 
-		// TODO if TECS publishes local_position_setpoint dependency on tecs_status can be dropped here
+		_quadchute_ref_alt = math::min(math::max(_quadchute_ref_alt, current_altitude),
+					       _tecs_status->altitude_reference);
 
-		if (_tecs_status->height_rate < -FLT_EPSILON && _tecs_status->height_rate_setpoint > FLT_EPSILON) {
-			// vehicle is currently in uncommended descend, start integrating error
+		return (_quadchute_ref_alt - current_altitude) > _param_vt_qc_alt_loss.get();
 
-			const hrt_abstime now = hrt_absolute_time();
-			float dt = static_cast<float>(now - _last_loop_quadchute_timestamp) / 1e6f;
-			dt = math::constrain(dt, 0.0001f, 0.1f);
-			_last_loop_quadchute_timestamp = now;
-
-			_height_rate_error_integral += (_tecs_status->height_rate_setpoint - _tecs_status->height_rate) * dt;
-
-		} else {
-			_height_rate_error_integral = 0.f; // reset
-		}
-
-		return (_height_rate_error_integral > _param_vt_qc_hr_error_i.get());
+	} else {
+		_quadchute_ref_alt = -MAXFLOAT;
 	}
 
 	return false;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -288,9 +288,6 @@ protected:
 	float _thrust_transition = 0.0f;	// thrust value applied during a front transition (tailsitter & tiltrotor only)
 	float _last_thr_in_fw_mode = 0.0f;
 
-	float _height_rate_error_integral{0.f};
-
-
 	hrt_abstime _trans_finished_ts = 0;
 	hrt_abstime _transition_start_timestamp{0};
 	float _time_since_trans_start{0};
@@ -300,7 +297,8 @@ protected:
 
 	hrt_abstime _last_loop_ts = 0;
 	float _transition_dt = 0;
-	hrt_abstime _last_loop_quadchute_timestamp = 0;
+
+	float _quadchute_ref_alt{-MAXFLOAT};	// altitude (AMSL) reference to compute quad-chute altitude loss condition
 
 	float _accel_to_pitch_integ = 0;
 
@@ -317,7 +315,7 @@ protected:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(ModuleParams,
 					(ParamBool<px4::params::VT_ELEV_MC_LOCK>) _param_vt_elev_mc_lock,
 					(ParamFloat<px4::params::VT_FW_MIN_ALT>) _param_vt_fw_min_alt,
-					(ParamFloat<px4::params::VT_QC_HR_ERROR_I>) _param_vt_qc_hr_error_i,
+					(ParamFloat<px4::params::VT_QC_ALT_LOSS>) _param_vt_qc_alt_loss,
 					(ParamInt<px4::params::VT_FW_QC_P>) _param_vt_fw_qc_p,
 					(ParamInt<px4::params::VT_FW_QC_R>) _param_vt_fw_qc_r,
 					(ParamFloat<px4::params::VT_QC_T_ALT_LOSS>) _param_vt_qc_t_alt_loss,


### PR DESCRIPTION
### Solved Problem
The current implementation of the uncommanded descend quadchute revealed two issues:
1) It was possible for a vehicle to enter a limit cycle in which it would stall, loose a lot of altitude, recover, slightly climb up, stall, ...
This behavior has been observed on a vehicle that suffered an airspeed sensor failure and was flying with a too low trim throttle value. In the phases during which the vehicle climbed again after recovering from the stall, the quadchute height rate error integral (current implementation) was reset to 0 and therefore quadchute never triggered, although the vehicle lost close to 100m altitude.

2) Users found it difficult to tune the quadchute as there was no one to one relation between the parameter value and the actual altitude error at which quadchute would trigger.

### Solution
I am proposing a new solution which uses an "altitude error" criteria to trigger quadchute. This is similar to what was implemented in the past with an important difference. The altitude reference used to compute the altitude error is set to the maximum altitude the vehicle has achieved from the time since it has flown BELOW the current altitude setpoint. Additionally, the altitude reference is constrained not to be larger than the current altitude setpoint (in case the setpoint decreases). We use the value of the TECS reference model as our current altitude setpoint.

This method allows quadchute to only be triggered if the vehicle is actually losing altitude. Quadchute will not trigger if the altitude setpoint is increasing faster than what the vehicle can follow, as long as the vehicle is not descending, no quadchute will be triggered.

### Changelog Entry
For release notes:
Refactor uncommanded descend quad-chute to use deterministic altitude error threshold.
```
Feature/Bugfix XYZ
New parameter: VT_QC_ALT_LOSS
Documentation: Need to clarfiy page ... / done, read docs.px4.io/...
```

### Alternatives


### Test coverage
Simulation tests have been done.

### Context
Related links, screenshot before/after, video
