### PR TITLE
Navigator: MissionFeasibilityCheck: check if items fit to the current vehicle type

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -120,6 +120,7 @@ private:
 	bool _below_home_alt_failed{false};
 	bool _fixed_wing_land_approach_failed{false};
 	bool _takeoff_land_available_failed{false};
+	bool _items_fit_to_vehicle_type_failed{false};
 
 	// internal checkTakeoff related variables
 	bool _found_item_with_position{false};
@@ -162,6 +163,14 @@ private:
 	 * @return False if the check failed.
 	*/
 	bool checkTakeoff(mission_item_s &mission_item);
+
+	/**
+	 * @brief Check if the mission items fit to the vehicle type
+	 *
+	 * @param mission_item The current mission item
+	 * @return False if the check failed.
+	*/
+	bool checkItemsFitToVehicleType(const mission_item_s &mission_item);
 
 	/**
 	 * @brief Check validity of landing pattern (fixed wing & vtol)


### PR DESCRIPTION
### Solved Problem
When switching between different vehicle types on the same groundstation, it can happen that by accident a mission that was planned for example for a VTOL gets uploaded to a Multicopter. This is can lead to undesired/unexpected behavior.

### Solution
Add `checkItemsFitToVehicleType()` check that checks if the vehicle type is non-VTOL but there are VTOL mission items (VTOL_TAKEOFF, VTOL_LAND, VTOL_TRANSITION). The check can later be extended to handle all kind of vehicle type vs mission item checks.

### Changelog Entry
For release notes:
```
Feature: Mission Feasibility Check: prevent uploading a mission containing VTOL items to non-VTOL vehicles
```

