### PR TITLE
[mavlink_messages] Missmatch between header macros and class used

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -323,8 +323,11 @@ static const StreamListItem streams_list[] = {
 #if defined(COMMAND_LONG_HPP)
 	create_stream_list_item<MavlinkStreamCommandLong>(),
 #endif // COMMAND_LONG_HPP
-#if defined(SYSTEM_TIME_HPP)
+#if defined(SYS_STATUS_HPP)
 	create_stream_list_item<MavlinkStreamSysStatus>(),
+#endif // SYS_STATUS_HPP
+#if defined(SYSTEM_TIME_HPP)
+	create_stream_list_item<MavlinkStreamSystemTime>(),
 #endif // SYSTEM_TIME_HPP
 	create_stream_list_item<MavlinkStreamBatteryStatus>(),
 #if defined(SMART_BATTERY_INFO_HPP)

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -326,9 +326,6 @@ static const StreamListItem streams_list[] = {
 #if defined(SYS_STATUS_HPP)
 	create_stream_list_item<MavlinkStreamSysStatus>(),
 #endif // SYS_STATUS_HPP
-#if defined(SYSTEM_TIME_HPP)
-	create_stream_list_item<MavlinkStreamSystemTime>(),
-#endif // SYSTEM_TIME_HPP
 	create_stream_list_item<MavlinkStreamBatteryStatus>(),
 #if defined(SMART_BATTERY_INFO_HPP)
 	create_stream_list_item<MavlinkStreamSmartBatteryInfo>(),


### PR DESCRIPTION
### Solved Problem
Trying to get the SYSTEM_TIME mavlink stream to work 
```
WARN  [mavlink] stream SYSTEM_TIME not found
ERROR [mavlink] configure_streams_to_default() failed
```
Fixes #{Github issue ID}

### Solution
Simply add the stream corresponding to the right header preprocessor directives

### Changelog Entry
Bugfix: SYSTEM_TIME stream not found

### Alternatives
-

### Test coverage
- add stream to desired mode
- SITL starts without complaining

### Context
-
