### PR TITLE
RC switch improvement for mid air (re)gain/fallback

### DIFF
--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -121,4 +121,3 @@ bool rc_calibration_in_progress
 bool calibration_enabled
 
 bool pre_flight_checks_pass		# true if all checks necessary to arm pass
-

--- a/src/lib/avoidance/ObstacleAvoidanceTest.cpp
+++ b/src/lib/avoidance/ObstacleAvoidanceTest.cpp
@@ -198,7 +198,6 @@ TEST_F(ObstacleAvoidanceTest, oa_desired)
 
 	// WHEN: we subscribe to the uORB message out of the interface
 	uORB::SubscriptionData<vehicle_trajectory_waypoint_s> _sub_traj_wp_avoidance_desired{ORB_ID(vehicle_trajectory_waypoint_desired)};
-	_sub_traj_wp_avoidance_desired.update();
 
 	// THEN: we expect the setpoints in POINT_0 and waypoints in POINT_1 and POINT_2
 	EXPECT_FLOAT_EQ(pos_sp(0),

--- a/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
+++ b/src/modules/flight_mode_manager/tasks/FlightTask/FlightTask.hpp
@@ -139,13 +139,12 @@ public:
 	const vehicle_trajectory_waypoint_s &getAvoidanceWaypoint() { return _desired_waypoint; }
 
 	/**
-	 * All setpoints are set to NAN (uncontrolled). Timestampt zero.
+	 * All setpoints are set to NAN (uncontrolled), timestamp to zero
 	 */
 	static const trajectory_setpoint_s empty_trajectory_setpoint;
 
 	/**
-	 * Empty constraints.
-	 * All constraints are set to NAN.
+	 * All constraints are set to NAN, timestamp to zero
 	 */
 	static const vehicle_constraints_s empty_constraints;
 

--- a/src/modules/manual_control/CMakeLists.txt
+++ b/src/modules/manual_control/CMakeLists.txt
@@ -46,4 +46,5 @@ px4_add_module(
 		px4_work_queue
 	)
 
+px4_add_functional_gtest(SRC ManualControlTest.cpp LINKLIBS modules__manual_control)
 px4_add_unit_gtest(SRC ManualControlSelectorTest.cpp LINKLIBS modules__manual_control)

--- a/src/modules/manual_control/CMakeLists.txt
+++ b/src/modules/manual_control/CMakeLists.txt
@@ -32,7 +32,7 @@
 ############################################################################
 
 px4_add_module(
-	MODULE module__manual_control
+	MODULE modules__manual_control
 	MAIN manual_control
 	COMPILE_FLAGS
 	SRCS
@@ -42,7 +42,8 @@ px4_add_module(
 		ManualControlSelector.hpp
 		ManualControlSelector.cpp
 	DEPENDS
+		hysteresis
 		px4_work_queue
 	)
 
-px4_add_unit_gtest(SRC ManualControlSelectorTest.cpp LINKLIBS module__manual_control)
+px4_add_unit_gtest(SRC ManualControlSelectorTest.cpp LINKLIBS modules__manual_control)

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -81,6 +81,7 @@ void ManualControl::processInput(hrt_abstime now)
 		vehicle_status_s vehicle_status;
 
 		if (_vehicle_status_sub.copy(&vehicle_status)) {
+			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
 			_system_id = vehicle_status.system_id;
 			_rotary_wing = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING);
 			_vtol = vehicle_status.is_vtol;
@@ -269,8 +270,8 @@ void ManualControl::processSwitches(hrt_abstime &now)
 					}
 				}
 
-			} else {
-				// Send an initial request to switch to the mode requested by RC
+			} else if (!_armed) {
+				// Directly initialize mode using RC switch but only before arming
 				evaluateModeSlot(switches.mode_slot);
 			}
 

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -86,7 +86,16 @@ void ManualControl::Run()
 		updateParams();
 	}
 
-	const hrt_abstime now = hrt_absolute_time();
+	processInput(hrt_absolute_time());
+
+	// reschedule timeout
+	ScheduleDelayed(200_ms);
+
+	perf_end(_loop_perf);
+}
+
+void ManualControl::processInput(hrt_abstime now)
+{
 	_selector.updateValidityOfChosenInput(now);
 
 	for (int i = 0; i < MAX_MANUAL_INPUT_COUNT; i++) {
@@ -267,11 +276,6 @@ void ManualControl::Run()
 	}
 
 	_last_time = now;
-
-	// reschedule timeout
-	ScheduleDelayed(200_ms);
-
-	perf_end(_loop_perf);
 }
 
 void ManualControl::updateParams()

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -92,7 +92,7 @@ void ManualControl::Run()
 	for (int i = 0; i < MAX_MANUAL_INPUT_COUNT; i++) {
 		manual_control_setpoint_s manual_control_input;
 
-		if (_manual_control_setpoint_subs[i].update(&manual_control_input)) {
+		if (_manual_control_input_subs[i].update(&manual_control_input)) {
 			_selector.updateWithNewInputSample(now, manual_control_input, i);
 		}
 	}
@@ -239,11 +239,11 @@ void ManualControl::Run()
 		if (instance != _previous_manual_control_input_instance) {
 			if ((0 <= _previous_manual_control_input_instance)
 			    && (_previous_manual_control_input_instance < MAX_MANUAL_INPUT_COUNT)) {
-				_manual_control_setpoint_subs[_previous_manual_control_input_instance].unregisterCallback();
+				_manual_control_input_subs[_previous_manual_control_input_instance].unregisterCallback();
 			}
 
 			if ((0 <= instance) && (instance < MAX_MANUAL_INPUT_COUNT)) {
-				_manual_control_setpoint_subs[instance].registerCallback();
+				_manual_control_input_subs[instance].registerCallback();
 			}
 
 			_previous_manual_control_input_instance = instance;

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -74,6 +74,9 @@ public:
 
 	int print_status() override;
 
+protected:
+	void processInput(hrt_abstime now);
+
 private:
 	static constexpr int MAX_MANUAL_INPUT_COUNT = 3;
 

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -104,7 +104,7 @@ private:
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	int _previous_manual_control_input_instance{-1};
-	uORB::SubscriptionCallbackWorkItem _manual_control_setpoint_subs[MAX_MANUAL_INPUT_COUNT] {
+	uORB::SubscriptionCallbackWorkItem _manual_control_input_subs[MAX_MANUAL_INPUT_COUNT] {
 		{this, ORB_ID(manual_control_input), 0},
 		{this, ORB_ID(manual_control_input), 1},
 		{this, ORB_ID(manual_control_input), 2},

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -75,7 +75,7 @@ public:
 	int print_status() override;
 
 protected:
-	void processInput(hrt_abstime now);
+	void processInput(hrt_abstime now); // protected for testing
 
 private:
 	static constexpr int MAX_MANUAL_INPUT_COUNT = 3;
@@ -83,15 +83,13 @@ private:
 	void Run() override;
 	void updateParams() override;
 	void processStickArming(const manual_control_setpoint_s &input);
+	void processSwitches(hrt_abstime &now);
 
 	static int8_t navStateFromParam(int32_t param_value);
 
 	void evaluateModeSlot(uint8_t mode_slot);
 	void sendActionRequest(int8_t action, int8_t source, int8_t mode = 0);
 	void publishLandingGear(int8_t action);
-
-	uORB::Publication<action_request_s> _action_request_pub{ORB_ID(action_request)};
-	uORB::Publication<landing_gear_s> _landing_gear_pub{ORB_ID(landing_gear)};
 
 	enum class CameraMode {
 		Image = 0,
@@ -101,38 +99,46 @@ private:
 	void send_photo_command();
 	void send_video_command();
 
-	uORB::Publication<manual_control_setpoint_s> _manual_control_setpoint_pub{ORB_ID(manual_control_setpoint)};
-
-	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
-	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
-
-	int _previous_manual_control_input_instance{-1};
 	uORB::SubscriptionCallbackWorkItem _manual_control_input_subs[MAX_MANUAL_INPUT_COUNT] {
 		{this, ORB_ID(manual_control_input), 0},
 		{this, ORB_ID(manual_control_input), 1},
 		{this, ORB_ID(manual_control_input), 2},
 	};
 	uORB::SubscriptionCallbackWorkItem _manual_control_switches_sub{this, ORB_ID(manual_control_switches)};
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+
+	uORB::Publication<action_request_s> _action_request_pub{ORB_ID(action_request)};
+	uORB::Publication<landing_gear_s> _landing_gear_pub{ORB_ID(landing_gear)};
+	uORB::Publication<manual_control_setpoint_s> _manual_control_setpoint_pub{ORB_ID(manual_control_setpoint)};
+
+	ManualControlSelector _selector;
+
+	hrt_abstime _timestamp_last_loop{0};
+	int _previous_manual_control_input_instance{-1};
+	bool _previous_switches_initialized{false};
+	manual_control_switches_s _previous_switches{};
+	bool _published_invalid_once{false};
 
 	systemlib::Hysteresis _stick_arm_hysteresis{false};
 	systemlib::Hysteresis _stick_disarm_hysteresis{false};
 	systemlib::Hysteresis _button_hysteresis{false};
-
-	ManualControlSelector _selector;
-	bool _published_invalid_once{false};
 
 	MovingDiff _roll_diff{};
 	MovingDiff _pitch_diff{};
 	MovingDiff _yaw_diff{};
 	MovingDiff _throttle_diff{};
 
-	manual_control_switches_s _previous_switches{};
-	bool _previous_switches_initialized{false};
-
-	hrt_abstime _last_time{0};
-
 	perf_counter_t	_loop_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
 	perf_counter_t	_loop_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": interval")};
+
+	// Camera control state TODO: hopefully there is a command soon to toggle without keeping state
+	unsigned _image_sequence{0};
+	bool _video_recording{false};
+
+	uint8_t _system_id{1};
+	bool _rotary_wing{false};
+	bool _vtol{false};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
@@ -148,11 +154,4 @@ private:
 		(ParamInt<px4::params::COM_FLTMODE5>) _param_fltmode_5,
 		(ParamInt<px4::params::COM_FLTMODE6>) _param_fltmode_6
 	)
-
-	unsigned _image_sequence {0};
-	bool _video_recording {false}; // TODO: hopefully there is a command soon to toggle without keeping state
-
-	uint8_t _system_id{1};
-	bool _rotary_wing{false};
-	bool _vtol{false};
 };

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -136,6 +136,7 @@ private:
 	unsigned _image_sequence{0};
 	bool _video_recording{false};
 
+	bool _armed{false};
 	uint8_t _system_id{1};
 	bool _rotary_wing{false};
 	bool _vtol{false};

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -75,7 +75,9 @@ public:
 	int print_status() override;
 
 protected:
-	void processInput(hrt_abstime now); // protected for testing
+	// protected for testing
+	void processInput(hrt_abstime now);
+	static int8_t navStateFromParam(int32_t param_value);
 
 private:
 	static constexpr int MAX_MANUAL_INPUT_COUNT = 3;
@@ -84,8 +86,6 @@ private:
 	void updateParams() override;
 	void processStickArming(const manual_control_setpoint_s &input);
 	void processSwitches(hrt_abstime &now);
-
-	static int8_t navStateFromParam(int32_t param_value);
 
 	void evaluateModeSlot(uint8_t mode_slot);
 	void sendActionRequest(int8_t action, int8_t source, int8_t mode = 0);

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -78,6 +78,7 @@ private:
 	static constexpr int MAX_MANUAL_INPUT_COUNT = 3;
 
 	void Run() override;
+	void updateParams() override;
 	void processStickArming(const manual_control_setpoint_s &input);
 
 	static int8_t navStateFromParam(int32_t param_value);

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -46,7 +46,7 @@ void ManualControlSelector::updateWithNewInputSample(uint64_t now, const manual_
 	// First check if the chosen input got invalid, so it can get replaced
 	updateValidityOfChosenInput(now);
 
-	const bool update_existing_input = _setpoint.valid && input.data_source == _setpoint.data_source;
+	const bool update_existing_input = _setpoint.valid && (input.data_source == _setpoint.data_source);
 	const bool start_using_new_input = !_setpoint.valid;
 
 	// Switch to new input if it's valid and we don't already have a valid one

--- a/src/modules/manual_control/ManualControlTest.cpp
+++ b/src/modules/manual_control/ManualControlTest.cpp
@@ -1,0 +1,284 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#define MODULE_NAME "manual_control"
+
+#include <gtest/gtest.h>
+#include "ManualControl.hpp"
+
+static constexpr uint64_t SOME_TIME = 12345678;
+
+static constexpr uint8_t ACTION_KILL = action_request_s::ACTION_KILL;
+static constexpr uint8_t ACTION_UNKILL = action_request_s::ACTION_UNKILL;
+static constexpr uint8_t ACTION_VTOL_TRANSITION_TO_FIXEDWING = action_request_s::ACTION_VTOL_TRANSITION_TO_FIXEDWING;
+static constexpr uint8_t ACTION_VTOL_TRANSITION_TO_MULTICOPTER =
+	action_request_s::ACTION_VTOL_TRANSITION_TO_MULTICOPTER;
+static constexpr uint8_t ACTION_SWITCH_MODE = action_request_s::ACTION_SWITCH_MODE;
+
+static constexpr uint8_t NAVIGATION_STATE_MANUAL = vehicle_status_s::NAVIGATION_STATE_MANUAL;
+static constexpr uint8_t NAVIGATION_STATE_ALTCTL = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
+static constexpr uint8_t NAVIGATION_STATE_POSCTL = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+static constexpr uint8_t NAVIGATION_STATE_AUTO_MISSION = vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION;
+static constexpr uint8_t NAVIGATION_STATE_AUTO_LOITER = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
+static constexpr uint8_t NAVIGATION_STATE_ACRO = vehicle_status_s::NAVIGATION_STATE_ACRO;
+
+class TestManualControl : public ManualControl
+{
+public:
+	void processInput(hrt_abstime now) { ManualControl::processInput(now); }
+	static int8_t navStateFromParam(int32_t param_value) { return ManualControl::navStateFromParam(param_value); }
+};
+
+class SwitchTest : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		// Disable autosaving parameters to avoid busy loop in param_set()
+		param_control_autosave(false);
+
+		// Set stick input timeout to half a second
+		const float com_rc_loss_t = .5f;
+		param_set(param_find("COM_RC_LOSS_T"), &com_rc_loss_t);
+
+		int32_t mode = NAVIGATION_STATE_ACRO;
+		param_set(param_find("COM_FLTMODE1"), &mode);
+		mode = NAVIGATION_STATE_MANUAL;
+		param_set(param_find("COM_FLTMODE2"), &mode);
+		mode = NAVIGATION_STATE_ALTCTL;
+		param_set(param_find("COM_FLTMODE3"), &mode);
+		mode = NAVIGATION_STATE_POSCTL;
+		param_set(param_find("COM_FLTMODE4"), &mode);
+		mode = NAVIGATION_STATE_AUTO_LOITER;
+		param_set(param_find("COM_FLTMODE5"), &mode);
+		mode = NAVIGATION_STATE_AUTO_MISSION;
+		param_set(param_find("COM_FLTMODE6"), &mode);
+	}
+
+	uORB::Publication<manual_control_switches_s> _manual_control_switches_pub{ORB_ID(manual_control_switches)};
+	uORB::Publication<manual_control_setpoint_s> _manual_control_input_pub{ORB_ID(manual_control_input)};
+	uORB::SubscriptionData<manual_control_setpoint_s> _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
+	uORB::SubscriptionData<action_request_s> _action_request_sub{ORB_ID(action_request)};
+
+	TestManualControl _manual_control;
+	hrt_abstime _timestamp{SOME_TIME};
+};
+
+
+TEST_F(SwitchTest, KillSwitch)
+{
+	// GIVEN: valid stick input from RC
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	// and kill switch in off position
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .kill_switch = manual_control_switches_s::SWITCH_POS_ON});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: the stick input is published for use
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// but there is no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+
+	// WHEN: the kill switch is switched on
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .kill_switch = manual_control_switches_s::SWITCH_POS_OFF});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: a kill action request is published
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_UNKILL);
+
+	// WHEN: the kill switch is switched off again
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .kill_switch = manual_control_switches_s::SWITCH_POS_ON});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: an unkill action request is published
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_KILL);
+}
+
+TEST_F(SwitchTest, TransitionSwitch)
+{
+	// GIVEN: valid stick input from RC
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	// and transition switch in off position
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .transition_switch = manual_control_switches_s::SWITCH_POS_OFF});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: the stick input is published for use
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// but there is no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+
+	// WHEN: the transition switch is switched on
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .transition_switch = manual_control_switches_s::SWITCH_POS_ON});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: a forward transition action request is published
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_VTOL_TRANSITION_TO_FIXEDWING);
+
+	// WHEN: the kill switch is switched off again
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .transition_switch = manual_control_switches_s::SWITCH_POS_OFF});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: an backward transition action request is published
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_VTOL_TRANSITION_TO_MULTICOPTER);
+}
+
+TEST_F(SwitchTest, TransitionSwitchStaysRcLoss)
+{
+	// GIVEN: valid stick input from the RC
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	// and transition switch in off position
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .transition_switch = manual_control_switches_s::SWITCH_POS_OFF});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: the stick input is published for use
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// but there is no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+
+	// WHEN: RC signal times out
+	_manual_control.processInput(_timestamp += 1_s);
+
+	// THEN: the stick input is invalidated
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_FALSE(_manual_control_setpoint_sub.get().valid);
+	// and there is no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+
+	// WHEN: RC signal comes back
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: the stick input is avaialble again
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// but there is still no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+}
+
+TEST_F(SwitchTest, TransitionSwitchChangesRcLoss)
+{
+	// GIVEN: valid stick input from the RC
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	// and transition switch in off position
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .transition_switch = manual_control_switches_s::SWITCH_POS_OFF});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: the stick input is published for use
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// but there is no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+
+	// WHEN: RC signal times out
+	_manual_control.processInput(_timestamp += 1_s);
+
+	// THEN: the stick input is invalidated
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_FALSE(_manual_control_setpoint_sub.get().valid);
+	// and there is no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+
+	// WHEN: RC signal comes back with the switch on
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .transition_switch = manual_control_switches_s::SWITCH_POS_ON});
+	_manual_control.processInput(_timestamp += 100_ms);
+
+	// THEN: the stick input is avaialble again
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// but there is still no action requested
+	EXPECT_FALSE(_action_request_sub.update());
+}
+
+TEST_F(SwitchTest, ModeSwitch)
+{
+	// GIVEN: valid stick input from RC
+	_manual_control_input_pub.publish({.timestamp_sample = _timestamp, .valid = true, .data_source = manual_control_setpoint_s::SOURCE_RC});
+	// and mode switch in position 1
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .mode_slot = manual_control_switches_s::MODE_SLOT_1});
+	_manual_control.processInput(_timestamp += 10_ms);
+
+	// THEN: the stick input is published for use
+	EXPECT_TRUE(_manual_control_setpoint_sub.update());
+	EXPECT_TRUE(_manual_control_setpoint_sub.get().valid);
+	// and action requested to switch to mode 1
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
+	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_ACRO));
+
+	// WHEN: the mode switch is switched to 2
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .mode_slot = manual_control_switches_s::MODE_SLOT_2});
+	_manual_control.processInput(_timestamp += 10_ms);
+	// THEN: action requested to switch to mode 2
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
+	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_MANUAL));
+
+	// WHEN: the mode switch is switched to 3
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .mode_slot = manual_control_switches_s::MODE_SLOT_3});
+	_manual_control.processInput(_timestamp += 10_ms);
+	// THEN: action requested to switch to mode 3
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
+	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_ALTCTL));
+
+	// WHEN: the mode switch is switched to 4
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .mode_slot = manual_control_switches_s::MODE_SLOT_4});
+	_manual_control.processInput(_timestamp += 10_ms);
+	// THEN: action requested to switch to mode 4
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
+	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_POSCTL));
+
+	// WHEN: the mode switch is switched to 5
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .mode_slot = manual_control_switches_s::MODE_SLOT_5});
+	_manual_control.processInput(_timestamp += 10_ms);
+	// THEN: action requested to switch to mode 5
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
+	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_AUTO_LOITER));
+
+	// WHEN: the mode switch is switched to 6
+	_manual_control_switches_pub.publish({.timestamp_sample = _timestamp, .mode_slot = manual_control_switches_s::MODE_SLOT_6});
+	_manual_control.processInput(_timestamp += 10_ms);
+	// THEN: action requested to switch to mode 6
+	EXPECT_TRUE(_action_request_sub.update());
+	EXPECT_EQ(_action_request_sub.get().action, ACTION_SWITCH_MODE);
+	EXPECT_EQ(_action_request_sub.get().mode, TestManualControl::navStateFromParam(NAVIGATION_STATE_AUTO_MISSION));
+}

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -71,8 +71,6 @@ public:
 
 		// THEN: we receive the expected mode slot
 		uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-		manual_control_switches_sub.update();
-
 		EXPECT_EQ(manual_control_switches_sub.get().mode_slot, expected_slot);
 	}
 
@@ -102,8 +100,6 @@ public:
 
 		// THEN: we receive the expected mode slot
 		uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-		manual_control_switches_sub.update();
-
 		EXPECT_EQ(manual_control_switches_sub.get().mode_slot, expected_slot);
 
 		// Reset channel value for the next test
@@ -129,8 +125,6 @@ public:
 
 		// THEN: we receive the expected mode slot
 		uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-		manual_control_switches_sub.update();
-
 		EXPECT_EQ(manual_control_switches_sub.get().return_switch, expected_position);
 	}
 
@@ -155,8 +149,6 @@ TEST_F(RCUpdateTest, ModeSlotUnassigned)
 
 	// THEN: we receive no mode slot
 	uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-	manual_control_switches_sub.update();
-
 	EXPECT_EQ(manual_control_switches_sub.get().mode_slot, 0); // manual_control_switches_s::MODE_SLOT_NONE
 }
 
@@ -198,8 +190,6 @@ TEST_F(RCUpdateTest, ReturnSwitchUnassigned)
 
 	// THEN: we receive an unmapped return switch state
 	uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-	manual_control_switches_sub.update();
-
 	EXPECT_EQ(manual_control_switches_sub.get().return_switch, 0); // manual_control_switches_s::SWITCH_POS_NONE
 }
 


### PR DESCRIPTION
### Solved Problem
- 1 Unexpected action regaining RC
  - Valid RC with switch in position A
  - RC signal lost (or RC is turned off)
  - Switch is moved to position B
  - RC regained after a few minutes
  - trigger for switch position B is immediately executed
- 2 Unexpected action first time RC
  - Vehicle flying autonomously without RC input
  - RC is turned on with mode switch in e.g. Acro position
  - Vehicle switches to Acro mode and crashes because pilot is not prepared
- 3 Unexpected action RC as safety fallback (similar to previous)
  - Vehicle flying in any mode with joystick as stick input and RC configured as fallback
  - Joystick signal is lost because of link or ground station application outage
  - Vehicle falls back to RC stick input for safety but also switches mode to the mode switch position

### Solution
- Make `ManualControl` module testable by restructuring into functions
   `ScheduleDelayed(200_ms);` blocks the functional test indefinitely
- Add functional tests for the switch logic in the `ManualControl` module itself (so far there are only unit tests for the `ManualControlSelector`)
- Cover the cases mentioned above and fix the problems
  - 1 reinitialize switch latching when RC is regained
  - 2 / 3 only directly adapt to mode switch position if vehicle is not armed 

### Changelog Entry
```
Bugfix: RC switch causing some actions upon gaining/falling back to RC stick input
```

### Test coverage
- Functional tests added
- No bench/simulation tests were performed