### PR TITLE
mavlink: allow UDP client to reconnect

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2639,6 +2639,10 @@ Mavlink::task_main(int argc, char *argv[])
 			publish_telemetry_status();
 		}
 
+#if defined(MAVLINK_UDP)
+		check_client_source_timed_out();
+#endif // MAVLINK_UDP
+
 		perf_end(_loop_perf);
 	}
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -466,9 +466,20 @@ public:
 
 	struct sockaddr_in 	&get_client_source_address() { return _src_addr; }
 
-	void			set_client_source_initialized() { _src_addr_initialized = true; }
+	void			set_client_source_initialized()
+	{
+		_src_addr_initialized = true;
+		_time_src_addr_last_initialized = hrt_absolute_time();
+	}
 
 	bool			get_client_source_initialized() { return _src_addr_initialized; }
+
+	void			check_client_source_timed_out()
+	{
+		if (_src_addr_initialized && hrt_elapsed_time(&_time_src_addr_last_initialized) > 3000000) {
+			_src_addr_initialized = false;
+		}
+	}
 #endif
 
 	uint64_t		get_start_time() { return _mavlink_start_time; }
@@ -626,6 +637,7 @@ private:
 	sockaddr_in		_src_addr {};
 	sockaddr_in		_bcast_addr {};
 
+	hrt_abstime		_time_src_addr_last_initialized{0};
 	bool			_src_addr_initialized{false};
 	bool			_broadcast_address_found{false};
 	bool			_broadcast_address_not_found_warned{false};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -3157,6 +3157,11 @@ MavlinkReceiver::run()
 
 						PX4_INFO("partner IP: %s", inet_ntoa(srcaddr.sin_addr));
 					}
+
+				} else if (srcaddr_last.sin_addr.s_addr == srcaddr.sin_addr.s_addr &&
+					   srcaddr_last.sin_port == srcaddr.sin_port) {
+					// The client is still around, so confirm it.
+					_mavlink->set_client_source_initialized();
 				}
 			}
 


### PR DESCRIPTION
This handles the case where a UDP client disappears and then comes back with a different source address.

It's a bit of a weird pattern to connect to PX4 directly to the local address (e.g. 18570) instead of listening on 14550 or 14540, however, it can make connections in certain use cases easier, e.g. through docker.

The change is not very pretty and I'm not sure about the side effects for other UDP setups. It might warrant a broader change.

This came up in https://discuss.px4.io/t/mavsdk-server-udp-connection-requires-px4-restart/32228/13.