### PR TITLE
Hardfault_log progmem always clear when re-arming

### DIFF
--- a/src/systemcmds/hardfault_log/hardfault_log.c
+++ b/src/systemcmds/hardfault_log/hardfault_log.c
@@ -955,10 +955,6 @@ static int hardfault_commit(char *caller)
 							}
 						}
 
-#ifdef HAS_PROGMEM
-						// Clear flash sector to write new hardfault
-						hardfault_clear(caller, false);
-#endif
 						ret = hardfault_rearm(caller);
 
 						close(fdout);
@@ -1079,6 +1075,10 @@ static int hardfault_dowrite(char *caller, int infd, int outfd,
  ****************************************************************************/
 __EXPORT int hardfault_rearm(char *caller)
 {
+#ifdef HAS_PROGMEM
+	// Clear flash sector to write new hardfault
+	hardfault_clear(caller, false);
+#endif
 	int ret = OK;
 	int rv = unlink(HARDFAULT_PATH);
 


### PR DESCRIPTION

### Solved Problem
When using progmem backend and `hardfault_log rearm` previous fault didn't got cleared

### Solution
Always clear on rearm when using progmem backend

Tested on MR-CANHUBK344