### PR TITLE
ekf2: disable multi-EKF across mags by default (H7 & SITL) for now

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -47,8 +47,6 @@ param set-default PWM_MAIN_REV 96 # invert both elevons
 # Single-EKF (for replay)
 param set-default EKF2_MULTI_IMU 0
 param set-default SENS_IMU_MODE 1
-param set-default EKF2_MULTI_MAG 0
-param set-default SENS_MAG_MODE 1
 
 param set-default NPFG_PERIOD 12
 param set-default FW_PR_I 0.2

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -168,8 +168,6 @@ param set-default EKF2_REQ_GPS_H 0.5
 # Multi-EKF
 param set-default EKF2_MULTI_IMU 3
 param set-default SENS_IMU_MODE 0
-param set-default EKF2_MULTI_MAG 2
-param set-default SENS_MAG_MODE 0
 
 param set-default IMU_GYRO_FFT_EN 1
 param set-default MAV_PROTO_VER 2 # Ensures QGC does not drop the first few packets after a SITL restart due to MAVLINK 1 packets

--- a/boards/atl/mantis-edu/init/rc.board_defaults
+++ b/boards/atl/mantis-edu/init/rc.board_defaults
@@ -11,11 +11,6 @@ param set-default COM_ARM_SDCARD 0
 
 param set-default SENS_EXT_I2C_PRB 0
 
-param set-default EKF2_MULTI_IMU 1
-param set-default EKF2_MULTI_MAG 1
-param set-default SENS_IMU_MODE 0
-param set-default SENS_MAG_MODE 0
-
 param set-default EV_TSK_STAT_DIS 1
 
 param set-default SYS_DM_BACKEND 1

--- a/boards/px4/fmu-v5/init/rc.board_defaults
+++ b/boards/px4/fmu-v5/init/rc.board_defaults
@@ -26,8 +26,6 @@ else
 	# Multi-EKF
 	param set-default EKF2_MULTI_IMU 2
 	param set-default SENS_IMU_MODE 0
-	param set-default EKF2_MULTI_MAG 2
-	param set-default SENS_MAG_MODE 0
 fi
 
 rgbled_pwm start

--- a/platforms/nuttx/init/kinetis/rc.board_arch_defaults
+++ b/platforms/nuttx/init/kinetis/rc.board_arch_defaults
@@ -6,8 +6,6 @@
 # Multi-EKF (off by default)
 param set-default EKF2_MULTI_IMU 0
 param set-default SENS_IMU_MODE 1
-param set-default EKF2_MULTI_MAG 0
-param set-default SENS_MAG_MODE 1
 
 set LOGGER_BUF 8
 

--- a/platforms/nuttx/init/stm32/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32/rc.board_arch_defaults
@@ -6,8 +6,6 @@
 # Multi-EKF (off by default)
 param set-default EKF2_MULTI_IMU 0
 param set-default SENS_IMU_MODE 1
-param set-default EKF2_MULTI_MAG 0
-param set-default SENS_MAG_MODE 1
 
 set LOGGER_BUF 8
 

--- a/platforms/nuttx/init/stm32f7/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32f7/rc.board_arch_defaults
@@ -6,8 +6,6 @@
 # Multi-EKF (across IMUs only)
 param set-default EKF2_MULTI_IMU 3
 param set-default SENS_IMU_MODE 0
-param set-default EKF2_MULTI_MAG 0
-param set-default SENS_MAG_MODE 1
 
 param set-default -s IMU_GYRO_FFT_EN 1
 

--- a/platforms/nuttx/init/stm32h7/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32h7/rc.board_arch_defaults
@@ -6,8 +6,6 @@
 # Multi-EKF
 param set-default EKF2_MULTI_IMU 3
 param set-default SENS_IMU_MODE 0
-param set-default EKF2_MULTI_MAG 3
-param set-default SENS_MAG_MODE 0
 
 param set-default -s IMU_GYRO_FFT_EN 1
 


### PR DESCRIPTION
 - re-enable once the estimator selector respects configured mag priority (at least initially) or is otherwise able to automatically prefer an external mag over internal
 - for SITL disabled because the full matrix of estimator instances (IMUs X mags) is too many topics for logger currently


FYI @bresch @AlexKlimaj @julianoes 
