### PR TITLE
build support for vanilla DDS typenames in uxce_dds_client

### DIFF
--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -113,7 +113,10 @@ else()
 	add_dependencies(microxrceddsclient libmicroxrceddsclient_project)
 	target_include_directories(microxrceddsclient INTERFACE ${microxrceddsclient_build_dir}/include)
 
-
+        option(WITH_ROS_DDS_TYPES "Generate XRCE-DDS type names modified for ROS2 compatibility" ON)
+        if (WITH_ROS_DDS_TYPES)
+          set(GENERATE_ROS_DDS_TYPES_ARG "--typeros2")
+        endif()
 
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dds_topics.h
 		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_dds_topics.py
@@ -121,6 +124,7 @@ else()
 			--client-outdir ${CMAKE_CURRENT_BINARY_DIR}
 			--dds-topics-file ${CMAKE_CURRENT_SOURCE_DIR}/dds_topics.yaml
 			--template_file ${CMAKE_CURRENT_SOURCE_DIR}/dds_topics.h.em
+                        ${GENERATE_ROS_DDS_TYPES_ARG}
 		DEPENDS
 			${CMAKE_CURRENT_SOURCE_DIR}/generate_dds_topics.py
 			${CMAKE_CURRENT_SOURCE_DIR}/dds_topics.yaml

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -55,6 +55,9 @@ parser.add_argument("-t", "--template_file", dest='template_file', type=str,
 parser.add_argument("-u", "--client-outdir", dest='clientdir', type=str,
                     help="Client output dir, by default using relative path 'src/modules/uxrce_dds_client'", default=None)
 
+parser.add_argument("-r", "--typeros2", dest='typeros2', type=bool,
+                    help="generate ROS2-compatible DDS type names (as opposed to vanilla)", default=False)
+
 if len(sys.argv) <= 1:
     parser.print_usage()
     exit(-1)
@@ -96,9 +99,13 @@ for p in msg_map['publications']:
     # simple_base_type: eg vehicle_status
     p['simple_base_type'] = base_type_name_snake_case
 
-    # dds_type: eg px4_msgs::msg::dds_::VehicleStatus_
-    p['dds_type'] = p['type'].replace("::msg::", "::msg::dds_::") + "_"
-
+    # the dds type name created by e.g. fastddsgen *without* fastddsgen's '-typeros2' flag
+    # would be e.g. px4_msgs::msg::Ping
+    # the type that ros2 expects to see is
+    # e.g. px4_msgs::msg::dds_::Ping_
+    p['dds_type'] = p['type']
+    if args.ros2types:
+        p['dds_type'].replace("::msg::", "::msg::dds_::") + "_"
     # topic_simple: eg vehicle_status
     p['topic_simple'] = p['topic'].split('/')[-1]
 
@@ -117,7 +124,9 @@ for s in msg_map['subscriptions']:
     s['simple_base_type'] = base_type_name_snake_case
 
     # dds_type: eg px4_msgs::msg::dds_::VehicleStatus_
-    s['dds_type'] = s['type'].replace("::msg::", "::msg::dds_::") + "_"
+    s['dds_type'] = s['type']
+    if args.ros2types:
+        p['dds_type'].replace("::msg::", "::msg::dds_::") + "_"
 
     # topic_simple: eg vehicle_status
     s['topic_simple'] = s['topic'].split('/')[-1]


### PR DESCRIPTION
cmake flag and script tweak to not mangle DDS typenames into ROS2 format.

"vanilla" DDS typename:   `px4_msgs::msg::Ping`
ROS2 DDS typename:    `px4_msgs::msg::dds_::Ping_`

in this PR, the flag WITH_ROS_DDS_TYPES toggled OFF, the `uxce_dds_client` has vanilla DDS typenames for the topics it publishes.  These 'vanilla' typenames match those in `dds_topics.yaml`, and those that come out of `fastddsgen` if the `-typeros2` flag is *not* on.   Note that this logic mirrors the behavior of `fastddsgen` with the `-typeros2` flag, which I assume the ROS2 infrastructure uses everywhere by default.   

You want these vanilla types if what is subscribing to the data published by px4 isn't a ROS node.  e.g.  a coprocessor of some kind connected to the autopilot via serial.   

Thoughts:

Since the full information about the topic types is here, in `msg/`, seems one could dump `.idl` out while generating the uORB structs and fastcdr routines during this build process, which would comb out a few dependencies.   The path I found was to go via `rosidl`, which is pretty heavyweight for such a simple operation (but interestingly does not itself create further coupling, i.e. the `.idl` that comes out of it isn't "ros-required").

I wonder if one could handle this type name compatibility with a ROS2 compatible custom xrce-dds agent.   thus  type name conversions for ROSland are handled in ROSland, and there's a place for anything else that ROSland  needs to happen on the first hop off the flight controller, without FC firmware updates. 
