### PR TITLE
Updated xmlstarlet command to be more concise

### DIFF
--- a/launch/single_vehicle_spawn_sdf.launch
+++ b/launch/single_vehicle_spawn_sdf.launch
@@ -19,7 +19,7 @@
     <!-- PX4 configs -->
     <arg name="interactive" default="true"/>
     <!-- generate sdf vehicle model -->
-    <arg name="cmd" default="xmlstarlet ed -d '//plugin[@name=&quot;mavlink_interface&quot;]/mavlink_tcp_port' -s '//plugin[@name=&quot;mavlink_interface&quot;]' -t elem -n mavlink_tcp_port -v $(arg mavlink_tcp_port) $(find px4)/Tools/simulation/gazebo-classic/sitl_gazebo-classic/models/$(arg vehicle)/$(arg vehicle).sdf"/>
+    <arg name="cmd" default="xmlstarlet ed -u '//plugin[@name=&quot;mavlink_interface&quot;]/mavlink_tcp_port' -v $(arg mavlink_tcp_port) $(find px4)/Tools/simulation/gazebo-classic/sitl_gazebo-classic/models/$(arg vehicle)/$(arg vehicle).sdf"/>
     <param command="$(arg cmd)" name="model_description"/>
     <!-- PX4 SITL -->
     <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>


### PR DESCRIPTION
We could use the `-u` flag in `xmlstartlet` to update the selected subnode and shorten the original command.
The original command deletes the `mavlink_interface/mavlink_tcp_port` subnode and adds the same subnode with the desired value. 
