### PR TITLE
Create stale bot (Github actions)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.1
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10
+          debug-only: true


### PR DESCRIPTION
## About
Bring back stale bot as described in: https://discuss.px4.io/t/px4-maintainers-call-may-23-2023/32245#stale-bot-bringup-10

Referenced https://github.com/marketplace/actions/close-stale-issues for setting up the action.

## Discussion
We can customize the messages as ramon said, but for now I kept it simple for testing.

Also, `debug-only` being set to `true` for now will prevent the stale bot from taking any actions, Adding this to prevent irreversible actions in case it isn't behaving as we want!