### PR TITLE
mavlink heartbeat stream: Fix system status always reporting FLIGHT_TERMINATION in HITL

### DIFF
--- a/src/modules/mavlink/streams/HEARTBEAT.hpp
+++ b/src/modules/mavlink/streams/HEARTBEAT.hpp
@@ -122,7 +122,8 @@ private:
 			}
 
 			// system_status overrides
-			if (actuator_armed.force_failsafe || actuator_armed.lockdown || actuator_armed.manual_lockdown
+			if (actuator_armed.force_failsafe || (actuator_armed.lockdown
+							      && vehicle_status.hil_state == vehicle_status_s::HIL_STATE_OFF) || actuator_armed.manual_lockdown
 			    || vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_TERMINATION) {
 				system_status = MAV_STATE_FLIGHT_TERMINATION;
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When performing a HITL simulation, the PX4 heartbeat always sends the system_status FLIGHT_TERMINATION, although the simulation works just fine and the simulated vehicle reacts to the commands. This is due to the fact, that in HITL the actuators are always locked. This flag is mapped to the system status flight termination.

### Solution
- In the mavlink Heartbeat stream only consider the armed.lockdown flag, if the system is not configured as HITL.

### Changelog Entry
For release notes:
```
Bugfix Mavlink heartbeat stream: Fix system status always reporting FLIGHT_TERMINATION in HITL
```

### Alternatives
We could also ...

### Test coverage
- SIH simulation, check mavlink inspector in AMC.
