### PR TITLE
ADS1115 Update docs - for discussion

### DIFF
--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -134,7 +134,7 @@ void ADS1115::RunImpl()
 
 void ADS1115::print_usage()
 {
-	
+
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 ### Description

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -141,11 +141,11 @@ void ADS1115::print_usage()
 
 Driver to enable an external [ADS1115](https://www.adafruit.com/product/1085) ADC connected via I2C.
 
-This is included by default in firmware for boards that do not have an internal analog to digital converter,
+The driver is included by default in firmware for boards that do not have an internal analog to digital converter,
 such as [PilotPi](../flight_controller/raspberry_pi_pilotpi.md) or [CUAV Nora](../flight_controller/cuav_nora.md)
 (search for `CONFIG_DRIVERS_ADC_ADS1115` in board configuration files).
 
-It can be enabled with the [ADC_ADS1115_EN](../advanced_config/parameter_reference.md#ADC_ADS1115_EN) parameter.
+It is enabled/disabled using the [ADC_ADS1115_EN](../advanced_config/parameter_reference.md#ADC_ADS1115_EN) parameter, and is disabled by default.
 If enabled, internal ADCs are not used.
 
 )DESCR_STR");

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -145,7 +145,9 @@ The driver is included by default in firmware for boards that do not have an int
 such as [PilotPi](../flight_controller/raspberry_pi_pilotpi.md) or [CUAV Nora](../flight_controller/cuav_nora.md)
 (search for `CONFIG_DRIVERS_ADC_ADS1115` in board configuration files).
 
-It is enabled/disabled using the [ADC_ADS1115_EN](../advanced_config/parameter_reference.md#ADC_ADS1115_EN) parameter, and is disabled by default.
+It is enabled/disabled using the
+[ADC_ADS1115_EN](../advanced_config/parameter_reference.md#ADC_ADS1115_EN)
+parameter, and is disabled by default.
 If enabled, internal ADCs are not used.
 
 )DESCR_STR");

--- a/src/drivers/adc/ads1115/ads1115_main.cpp
+++ b/src/drivers/adc/ads1115/ads1115_main.cpp
@@ -134,6 +134,22 @@ void ADS1115::RunImpl()
 
 void ADS1115::print_usage()
 {
+	
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+Driver to enable an external [ADS1115](https://www.adafruit.com/product/1085) ADC connected via I2C.
+
+This is included by default in firmware for boards that do not have an internal analog to digital converter,
+such as [PilotPi](../flight_controller/raspberry_pi_pilotpi.md) or [CUAV Nora](../flight_controller/cuav_nora.md)
+(search for `CONFIG_DRIVERS_ADC_ADS1115` in board configuration files).
+
+It can be enabled with the [ADC_ADS1115_EN](../advanced_config/parameter_reference.md#ADC_ADS1115_EN) parameter.
+If enabled, internal ADCs are not used.
+
+)DESCR_STR");
+	
 	PRINT_MODULE_USAGE_NAME("ads1115", "driver");
 	PRINT_MODULE_USAGE_COMMAND("start");
 	PRINT_MODULE_USAGE_PARAMS_I2C_SPI_DRIVER(true, false);


### PR DESCRIPTION
This updates the docs for the ADC1115 ADC in order to make it clear:
- whether the driver is installed by default, and if not where.
- how the driver is enabled and whether/where it is enabled by default.
- if it is enabled, having a link to the parameter.
- What the ADC1115 actually is, with a link to the manufacturer.

It is a test case for similar changes I hope to make across the docs, and to explore what might be automated. I'll add that discussion in a separate comment.