### PR TITLE
Add Open Drone ID arming check

### DIFF
--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -240,6 +240,10 @@
                         "536870912": {
                             "name": "gyro",
                             "description": "Gyroscope"
+                        },
+                        "1073741824": {
+                            "name": "open_drone_id",
+                            "description": "Open Drone ID system"
                         }
                     }
                 },

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -61,6 +61,7 @@ px4_add_library(health_and_arming_checks
 	checks/rcAndDataLinkCheck.cpp
 	checks/vtolCheck.cpp
 	checks/offboardCheck.cpp
+	checks/openDroneIDCheck.cpp
 )
 add_dependencies(health_and_arming_checks mode_util)
 

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -67,6 +67,7 @@
 #include "checks/rcAndDataLinkCheck.hpp"
 #include "checks/vtolCheck.hpp"
 #include "checks/offboardCheck.hpp"
+#include "checks/openDroneIDCheck.hpp"
 
 class HealthAndArmingChecks : public ModuleParams
 {
@@ -126,6 +127,7 @@ private:
 	ManualControlChecks _manual_control_checks;
 	HomePositionChecks _home_position_checks;
 	ModeChecks _mode_checks;
+	OpenDroneIDChecks _open_drone_id_checks;
 	ParachuteChecks _parachute_checks;
 	PowerChecks _power_checks;
 	RcCalibrationChecks _rc_calibration_checks;
@@ -140,7 +142,7 @@ private:
 	VtolChecks _vtol_checks;
 	OffboardChecks _offboard_checks;
 
-	HealthAndArmingCheckBase *_checks[30] = {
+	HealthAndArmingCheckBase *_checks[31] = {
 		&_accelerometer_checks,
 		&_airspeed_checks,
 		&_baro_checks,
@@ -157,6 +159,7 @@ private:
 		&_mission_checks,
 		&_offboard_checks, // must be after _estimator_checks
 		&_mode_checks, // must be after _estimator_checks, _home_position_checks, _mission_checks, _offboard_checks
+		&_open_drone_id_checks,
 		&_parachute_checks,
 		&_power_checks,
 		&_rc_calibration_checks,

--- a/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "openDroneIDCheck.hpp"
+
+
+void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
+{
+	// Check to see if the check has been disabled
+	if (!_param_com_arm_odid.get()) {
+		return;
+	}
+
+	NavModes affected_modes{NavModes::None};
+
+	if (_param_com_arm_odid.get() == 2) {
+		// disallow arming without the Open Drone ID system
+		affected_modes = NavModes::All;
+	}
+
+	if (!context.status().open_drone_id_system_present) {
+		/* EVENT
+		 * @description
+		 * Open Drone ID system failed to report. Make sure it it setup and installed properly.
+		 *
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id, events::ID("check_open_drone_id_missing"),
+				       events::Log::Error, "Open Drone ID system missing");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Open Drone ID system missing");
+		}
+
+	} else if (!context.status().open_drone_id_system_healthy) {
+		/* EVENT
+		 * @description
+		 * Open Drone ID system reported being unhealthy.
+		 *
+		 * <profile name="dev">
+		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.
+		 * </profile>
+		 */
+		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id, events::ID("check_open_drone_id_unhealthy"),
+				       events::Log::Error, "Open Drone ID system not ready");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Open Drone ID system not ready");
+		}
+
+	}
+}

--- a/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
@@ -57,8 +57,9 @@ void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
 		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id, events::ID("check_open_drone_id_missing"),
-				       events::Log::Error, "Open Drone ID system missing");
+		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id,
+					    events::ID("check_open_drone_id_missing"),
+					    events::Log::Error, "Open Drone ID system missing");
 
 		if (reporter.mavlink_log_pub()) {
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Open Drone ID system missing");
@@ -73,8 +74,9 @@ void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
 		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id, events::ID("check_open_drone_id_unhealthy"),
-				       events::Log::Error, "Open Drone ID system not ready");
+		reporter.armingCheckFailure(affected_modes, health_component_t::open_drone_id,
+					    events::ID("check_open_drone_id_unhealthy"),
+					    events::Log::Error, "Open Drone ID system not ready");
 
 		if (reporter.mavlink_log_pub()) {
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Open Drone ID system not ready");

--- a/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.cpp
@@ -51,7 +51,7 @@ void OpenDroneIDChecks::checkAndReport(const Context &context, Report &reporter)
 	if (!context.status().open_drone_id_system_present) {
 		/* EVENT
 		 * @description
-		 * Open Drone ID system failed to report. Make sure it it setup and installed properly.
+		 * Open Drone ID system failed to report. Make sure it is setup and installed properly.
 		 *
 		 * <profile name="dev">
 		 * This check can be configured via <param>COM_ARM_ODID</param> parameter.

--- a/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/openDroneIDCheck.hpp
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../Common.hpp"
+
+class OpenDroneIDChecks : public HealthAndArmingCheckBase
+{
+public:
+	OpenDroneIDChecks() = default;
+	~OpenDroneIDChecks() = default;
+
+	void checkAndReport(const Context &context, Report &reporter) override;
+
+private:
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamInt<px4::params::COM_ARM_ODID>) _param_com_arm_odid
+				       )
+};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -230,6 +230,18 @@ PARAM_DEFINE_FLOAT(COM_DISARM_LAND, 2.0f);
 PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 
 /**
+ * Force disarming from external commands.
+ *
+ * Disables the default checks which prevent disarming in unsafe situations,
+ * like when not landed.
+ *
+ * @group Commander
+ * @value 0 Subject external disarm commands to normal checks (e.g. landed)
+ * @value 1 Disable all checks for disarming requests.
+ */
+PARAM_DEFINE_INT32(COM_DISARM_FORCE, 0);
+
+/**
  * Allow arming without GPS
  *
  * The default allows the vehicle to arm without GPS signal.
@@ -239,6 +251,17 @@ PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
  * @value 1 Allow arming without GPS
  */
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
+
+/**
+ * Allow arming with bad EKF innovation.
+ *
+ * The default only allows arming if EKF innovations are reasonable.
+ *
+ * @group Commander
+ * @value 0 Require reasonable innovations to arm.
+ * @value 1 Allow arming with any innovation.
+ */
+PARAM_DEFINE_INT32(COM_ARM_BAD_INOV, 0);
 
 /**
  * Arm switch is a momentary button
@@ -497,10 +520,12 @@ PARAM_DEFINE_INT32(COM_FLTMODE5, -1);
 PARAM_DEFINE_INT32(COM_FLTMODE6, -1);
 
 /**
- * Maximum EKF position innovation test ratio that will allow arming
+ * Maximum EKF height innovation test ratio that will allow arming.
+ *
+ * A value of 0 disables the check.
  *
  * @group Commander
- * @min 0.1
+ * @min 0.0
  * @max 1.0
  * @decimal 2
  * @increment 0.05
@@ -510,8 +535,10 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_POS, 0.5f);
 /**
  * Maximum EKF velocity innovation test ratio that will allow arming
  *
+ * A value of 0.0 disables the check.
+ *
  * @group Commander
- * @min 0.1
+ * @min 0.0
  * @max 1.0
  * @decimal 2
  * @increment 0.05
@@ -519,10 +546,12 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_POS, 0.5f);
 PARAM_DEFINE_FLOAT(COM_ARM_EKF_VEL, 0.5f);
 
 /**
- * Maximum EKF height innovation test ratio that will allow arming
+ * Maximum EKF height innovation test ratio that will allow arming.
+ *
+ * A value of 0.0 disables the check.
  *
  * @group Commander
- * @min 0.1
+ * @min 0.0
  * @max 1.0
  * @decimal 2
  * @increment 0.05
@@ -532,13 +561,28 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_HGT, 1.0f);
 /**
  * Maximum EKF yaw innovation test ratio that will allow arming
  *
+ * A value of 0.0 disables the check.
+ *
  * @group Commander
- * @min 0.1
+ * @min 0.0
  * @max 1.0
  * @decimal 2
  * @increment 0.05
  */
 PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
+
+/**
+ * Maximum allowed uncertainty in EFK sensor bias estimates for arming.
+ *
+ * A value of 0.0 disables the test.
+ *
+ * @group Commander
+ * @min 0.0
+ * @max 10.0
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_BIAS, 3.0f);
 
 /**
  * Maximum accelerometer inconsistency between IMU units that will allow arming
@@ -1002,6 +1046,20 @@ PARAM_DEFINE_INT32(COM_ARM_SDCARD, 1);
  * @boolean
  */
 PARAM_DEFINE_INT32(COM_ARM_HFLT_CHK, 1);
+
+/**
+ * Enable Drone ID system detection and health check
+ *
+ * This check detects if the Open Drone ID system is missing.
+ * Depending on the value of the parameter, the check can be
+ * disabled, warn only or deny arming.
+ *
+ * @group Commander
+ * @value 0 Disabled
+ * @value 1 Warning only
+ * @value 2 Enforce Open Drone ID system presence
+ */
+PARAM_DEFINE_INT32(COM_ARM_ODID, 2);
 
 /**
  * Enforced delay between arming and further navigation

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -230,18 +230,6 @@ PARAM_DEFINE_FLOAT(COM_DISARM_LAND, 2.0f);
 PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 
 /**
- * Force disarming from external commands.
- *
- * Disables the default checks which prevent disarming in unsafe situations,
- * like when not landed.
- *
- * @group Commander
- * @value 0 Subject external disarm commands to normal checks (e.g. landed)
- * @value 1 Disable all checks for disarming requests.
- */
-PARAM_DEFINE_INT32(COM_DISARM_FORCE, 0);
-
-/**
  * Allow arming without GPS
  *
  * The default allows the vehicle to arm without GPS signal.
@@ -251,17 +239,6 @@ PARAM_DEFINE_INT32(COM_DISARM_FORCE, 0);
  * @value 1 Allow arming without GPS
  */
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
-
-/**
- * Allow arming with bad EKF innovation.
- *
- * The default only allows arming if EKF innovations are reasonable.
- *
- * @group Commander
- * @value 0 Require reasonable innovations to arm.
- * @value 1 Allow arming with any innovation.
- */
-PARAM_DEFINE_INT32(COM_ARM_BAD_INOV, 0);
 
 /**
  * Arm switch is a momentary button
@@ -520,12 +497,10 @@ PARAM_DEFINE_INT32(COM_FLTMODE5, -1);
 PARAM_DEFINE_INT32(COM_FLTMODE6, -1);
 
 /**
- * Maximum EKF height innovation test ratio that will allow arming.
- *
- * A value of 0 disables the check.
+ * Maximum EKF position innovation test ratio that will allow arming
  *
  * @group Commander
- * @min 0.0
+ * @min 0.1
  * @max 1.0
  * @decimal 2
  * @increment 0.05
@@ -535,10 +510,8 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_POS, 0.5f);
 /**
  * Maximum EKF velocity innovation test ratio that will allow arming
  *
- * A value of 0.0 disables the check.
- *
  * @group Commander
- * @min 0.0
+ * @min 0.1
  * @max 1.0
  * @decimal 2
  * @increment 0.05
@@ -546,12 +519,10 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_POS, 0.5f);
 PARAM_DEFINE_FLOAT(COM_ARM_EKF_VEL, 0.5f);
 
 /**
- * Maximum EKF height innovation test ratio that will allow arming.
- *
- * A value of 0.0 disables the check.
+ * Maximum EKF height innovation test ratio that will allow arming
  *
  * @group Commander
- * @min 0.0
+ * @min 0.1
  * @max 1.0
  * @decimal 2
  * @increment 0.05
@@ -561,28 +532,13 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_HGT, 1.0f);
 /**
  * Maximum EKF yaw innovation test ratio that will allow arming
  *
- * A value of 0.0 disables the check.
- *
  * @group Commander
- * @min 0.0
+ * @min 0.1
  * @max 1.0
  * @decimal 2
  * @increment 0.05
  */
 PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
-
-/**
- * Maximum allowed uncertainty in EFK sensor bias estimates for arming.
- *
- * A value of 0.0 disables the test.
- *
- * @group Commander
- * @min 0.0
- * @max 10.0
- * @decimal 2
- * @increment 0.05
- */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_BIAS, 3.0f);
 
 /**
  * Maximum accelerometer inconsistency between IMU units that will allow arming
@@ -1046,20 +1002,6 @@ PARAM_DEFINE_INT32(COM_ARM_SDCARD, 1);
  * @boolean
  */
 PARAM_DEFINE_INT32(COM_ARM_HFLT_CHK, 1);
-
-/**
- * Enable Drone ID system detection and health check
- *
- * This check detects if the Open Drone ID system is missing.
- * Depending on the value of the parameter, the check can be
- * disabled, warn only or deny arming.
- *
- * @group Commander
- * @value 0 Disabled
- * @value 1 Warning only
- * @value 2 Enforce Open Drone ID system presence
- */
-PARAM_DEFINE_INT32(COM_ARM_ODID, 2);
 
 /**
  * Enforced delay between arming and further navigation

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1004,6 +1004,20 @@ PARAM_DEFINE_INT32(COM_ARM_SDCARD, 1);
 PARAM_DEFINE_INT32(COM_ARM_HFLT_CHK, 1);
 
 /**
+ * Enable Drone ID system detection and health check
+ *
+ * This check detects if the Open Drone ID system is missing.
+ * Depending on the value of the parameter, the check can be
+ * disabled, warn only or deny arming.
+ *
+ * @group Commander
+ * @value 0 Disabled
+ * @value 1 Warning only
+ * @value 2 Enforce Open Drone ID system presence
+ */
+PARAM_DEFINE_INT32(COM_ARM_ODID, 2);
+
+/**
  * Enforced delay between arming and further navigation
  *
  * The minimal time from arming the motors until moving the vehicle is possible is COM_SPOOLUP_TIME seconds.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1015,7 +1015,7 @@ PARAM_DEFINE_INT32(COM_ARM_HFLT_CHK, 1);
  * @value 1 Warning only
  * @value 2 Enforce Open Drone ID system presence
  */
-PARAM_DEFINE_INT32(COM_ARM_ODID, 2);
+PARAM_DEFINE_INT32(COM_ARM_ODID, 0);
 
 /**
  * Enforced delay between arming and further navigation


### PR DESCRIPTION
### Solved Problem
The Open Drone ID system (aka Remote ID) should be present and healthy before the system can arm. There was no check for this so it has been added. A convenience parameter has also been added to change it to a warning but still allow arming or to disable the check completely.

