### PR TITLE
[WIP] Bidirectional DroneCAN ESC 

### DIFF
--- a/Tools/module_config/generate_params.py
+++ b/Tools/module_config/generate_params.py
@@ -302,10 +302,10 @@ When set to -1 (default), the value depends on the function (see {:}).
         for key, label, param_suffix, description in standard_params_array:
             if key in standard_params:
 
-                # values must be in range of an uint16_t
-                if standard_params[key]['min'] < 0:
+                # values must be in range of an int16_t
+                if standard_params[key]['min'] <= (-1<<15) :
                     raise Exception('minimum value for {:} expected >= 0 (got {:})'.format(key, standard_params[key]['min']))
-                if standard_params[key]['max'] >= 1<<16:
+                if standard_params[key]['max'] >= 1<<15:
                     raise Exception('maximum value for {:} expected <= {:} (got {:})'.format(key, 1<<16, standard_params[key]['max']))
 
                 if key == 'failsafe':

--- a/Tools/module_config/generate_params.py
+++ b/Tools/module_config/generate_params.py
@@ -303,10 +303,10 @@ When set to -1 (default), the value depends on the function (see {:}).
             if key in standard_params:
 
                 # values must be in range of an int16_t
-                if standard_params[key]['min'] <= (-1<<15) :
-                    raise Exception('minimum value for {:} expected >= 0 (got {:})'.format(key, standard_params[key]['min']))
-                if standard_params[key]['max'] >= 1<<15:
-                    raise Exception('maximum value for {:} expected <= {:} (got {:})'.format(key, 1<<16, standard_params[key]['max']))
+                if standard_params[key]['min'] < -1*(1<<16) :
+                    raise Exception('minimum value for {:} expected >= {:} (got {:})'.format(key, -1200, standard_params[key]['min']))
+                if standard_params[key]['max'] >= 1<<16-1:
+                    raise Exception('maximum value for {:} expected <= {:} (got {:})'.format(key, 1<<16-1, standard_params[key]['max']))
 
                 if key == 'failsafe':
                     standard_params[key]['default'] = -1
@@ -317,7 +317,7 @@ When set to -1 (default), the value depends on the function (see {:}).
                         'short': channel_label+' ${i} '+label+' Value',
                         'long': description
                         },
-                    'type': 'float',
+                    'type': 'int32',
                     'instance_start': instance_start,
                     'instance_start_label': instance_start_label,
                     'num_instances': num_channels,

--- a/Tools/module_config/generate_params.py
+++ b/Tools/module_config/generate_params.py
@@ -317,7 +317,7 @@ When set to -1 (default), the value depends on the function (see {:}).
                         'short': channel_label+' ${i} '+label+' Value',
                         'long': description
                         },
-                    'type': 'int32',
+                    'type': 'float',
                     'instance_start': instance_start,
                     'instance_start_label': instance_start_label,
                     'num_instances': num_channels,

--- a/src/drivers/actuators/modal_io/modal_io.cpp
+++ b/src/drivers/actuators/modal_io/modal_io.cpp
@@ -877,7 +877,7 @@ void ModalIo::update_leds(vehicle_control_mode_s mode, led_control_s control)
 	}
 }
 
-void ModalIo::mix_turtle_mode(int16_t outputs[MAX_ACTUATORS])
+void ModalIo::mix_turtle_mode(float outputs[MAX_ACTUATORS])
 {
 	bool use_pitch = true;
 	bool use_roll  = true;
@@ -1052,7 +1052,7 @@ void ModalIo::mix_turtle_mode(int16_t outputs[MAX_ACTUATORS])
 }
 
 /* OutputModuleInterface */
-bool ModalIo::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+bool ModalIo::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			    unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (num_outputs != MODAL_IO_OUTPUT_CHANNELS) {
@@ -1070,11 +1070,11 @@ bool ModalIo::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 
 		} else {
 			if (!_turtle_mode_en) {
-				_esc_chans[i].rate_req = outputs[i] * _output_map[i].direction;
+				_esc_chans[i].rate_req = static_cast<int16_t>(outputs[i]) * _output_map[i].direction;
 
 			} else {
 				// mapping updated in mixTurtleMode, no remap needed here, but reverse direction
-				_esc_chans[i].rate_req = outputs[i] * _output_map[i].direction * (-1);
+				_esc_chans[i].rate_req = static_cast<int16_t>(outputs[i]) * _output_map[i].direction * (-1);
 			}
 		}
 	}

--- a/src/drivers/actuators/modal_io/modal_io.cpp
+++ b/src/drivers/actuators/modal_io/modal_io.cpp
@@ -877,7 +877,7 @@ void ModalIo::update_leds(vehicle_control_mode_s mode, led_control_s control)
 	}
 }
 
-void ModalIo::mix_turtle_mode(uint16_t outputs[MAX_ACTUATORS])
+void ModalIo::mix_turtle_mode(int16_t outputs[MAX_ACTUATORS])
 {
 	bool use_pitch = true;
 	bool use_roll  = true;
@@ -1052,7 +1052,7 @@ void ModalIo::mix_turtle_mode(uint16_t outputs[MAX_ACTUATORS])
 }
 
 /* OutputModuleInterface */
-bool ModalIo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool ModalIo::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			    unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (num_outputs != MODAL_IO_OUTPUT_CHANNELS) {

--- a/src/drivers/actuators/modal_io/modal_io.hpp
+++ b/src/drivers/actuators/modal_io/modal_io.hpp
@@ -225,6 +225,6 @@ private:
 	int 			parse_response(uint8_t *buf, uint8_t len, bool print_feedback);
 	int			flush_uart_rx();
 	int			check_for_esc_timeout();
-	void			mix_turtle_mode(uint16_t outputs[]);
+	void			mix_turtle_mode(float outputs[]);
 	void			handle_actuator_test();
 };

--- a/src/drivers/actuators/modal_io/modal_io.hpp
+++ b/src/drivers/actuators/modal_io/modal_io.hpp
@@ -75,7 +75,7 @@ public:
 	int print_status() override;
 
 	/** @see OutputModuleInterface */
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	virtual int	init();

--- a/src/drivers/actuators/modal_io/modal_io.hpp
+++ b/src/drivers/actuators/modal_io/modal_io.hpp
@@ -75,7 +75,7 @@ public:
 	int print_status() override;
 
 	/** @see OutputModuleInterface */
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	virtual int	init();

--- a/src/drivers/cyphal/Actuators/EscClient.hpp
+++ b/src/drivers/cyphal/Actuators/EscClient.hpp
@@ -97,7 +97,7 @@ public:
 		}
 	};
 
-	void update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+	void update_outputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs)
 	{
 		if (_port_id > 0) {
 			reg_udral_service_actuator_common_sp_Vector31_0_1 msg_sp {0};
@@ -105,7 +105,7 @@ public:
 
 			for (uint8_t i = 0; i < MAX_ACTUATORS; i++) {
 				if (i < num_outputs) {
-					msg_sp.value[i] = static_cast<float>(outputs[i]);
+					msg_sp.value[i] = outputs[i];
 
 				} else {
 					// "unset" values published as NaN

--- a/src/drivers/cyphal/Actuators/EscClient.hpp
+++ b/src/drivers/cyphal/Actuators/EscClient.hpp
@@ -97,7 +97,7 @@ public:
 		}
 	};
 
-	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+	void update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
 	{
 		if (_port_id > 0) {
 			reg_udral_service_actuator_common_sp_Vector31_0_1 msg_sp {0};

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -392,7 +392,7 @@ void CyphalNode::sendHeartbeat()
 	}
 }
 
-bool UavcanMixingInterface::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterface::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	// Note: This gets called from MixingOutput from within its update() function

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -392,7 +392,7 @@ void CyphalNode::sendHeartbeat()
 	}
 }
 
-bool UavcanMixingInterface::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterface::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	// Note: This gets called from MixingOutput from within its update() function

--- a/src/drivers/cyphal/Cyphal.hpp
+++ b/src/drivers/cyphal/Cyphal.hpp
@@ -87,7 +87,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _pub_manager(pub_manager) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void printInfo() { _mixing_output.printStatus(); }

--- a/src/drivers/cyphal/Cyphal.hpp
+++ b/src/drivers/cyphal/Cyphal.hpp
@@ -87,7 +87,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _pub_manager(pub_manager) {}
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void printInfo() { _mixing_output.printStatus(); }

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -336,7 +336,7 @@ void DShot::mixerChanged()
 	update_telemetry_num_motors();
 }
 
-bool DShot::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+bool DShot::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			  unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (!_outputs_on) {
@@ -388,9 +388,9 @@ bool DShot::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 
 		for (int i = 0; i < (int)num_outputs; i++) {
 
-			uint16_t output = outputs[i];
+			float output = outputs[i];
 
-			if (output == DSHOT_DISARM_VALUE) {
+			if (fabsf(output - DSHOT_DISARM_VALUE) < 0.00001f) {
 				up_dshot_motor_command(i, DShot_cmd_motor_stop, telemetry_index == requested_telemetry_index);
 
 			} else {
@@ -407,10 +407,10 @@ bool DShot::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 						bool upper_range = output >= 1000;
 
 						if (upper_range) {
-							output -= 1000;
+							output -= 1000.f;
 
 						} else {
-							output = 999 - output; // lower range is inverted
+							output = 999.f - output; // lower range is inverted
 						}
 
 						float max_output = 999.f;
@@ -418,13 +418,13 @@ bool DShot::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 						output = math::min(max_output, (min_output + output * (max_output - min_output) / max_output));
 
 						if (upper_range) {
-							output += 1000;
+							output += 1000.0f;
 						}
 
 					}
 				}
 
-				up_dshot_motor_data_set(i, math::min(output, static_cast<uint16_t>(DSHOT_MAX_THROTTLE)),
+				up_dshot_motor_data_set(i, math::min(static_cast<uint16_t>(output), static_cast<uint16_t>(DSHOT_MAX_THROTTLE)),
 							telemetry_index == requested_telemetry_index);
 			}
 
@@ -595,7 +595,7 @@ void DShot::update_params()
 	updateParams();
 
 	// we use a minimum value of 1, since 0 is for disarmed
-	_mixing_output.setAllMinValues(math::constrain(static_cast<int>((_param_dshot_min.get() *
+	_mixing_output.setAllMinValues(math::constrain(static_cast<float>((_param_dshot_min.get() *
 				       static_cast<float>(DSHOT_MAX_THROTTLE))),
 				       DSHOT_MIN_THROTTLE, DSHOT_MAX_THROTTLE));
 

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -336,7 +336,7 @@ void DShot::mixerChanged()
 	update_telemetry_num_motors();
 }
 
-bool DShot::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool DShot::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			  unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (!_outputs_on) {

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -54,9 +54,9 @@ static constexpr unsigned int DSHOT300  =  300000u;
 static constexpr unsigned int DSHOT600  =  600000u;
 static constexpr unsigned int DSHOT1200 = 1200000u;
 
-static constexpr int DSHOT_DISARM_VALUE = 0;
-static constexpr int DSHOT_MIN_THROTTLE = 1;
-static constexpr int DSHOT_MAX_THROTTLE = 1999;
+static constexpr float DSHOT_DISARM_VALUE = 0;
+static constexpr float DSHOT_MIN_THROTTLE = 1;
+static constexpr float DSHOT_MAX_THROTTLE = 1999;
 
 class DShot final : public ModuleBase<DShot>, public OutputModuleInterface
 {
@@ -93,7 +93,7 @@ public:
 
 	bool telemetry_enabled() const { return _telemetry != nullptr; }
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
@@ -173,8 +173,8 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::DSHOT_MIN>)    _param_dshot_min,
 		(ParamBool<px4::params::DSHOT_3D_ENABLE>) _param_dshot_3d_enable,
-		(ParamInt<px4::params::DSHOT_3D_DEAD_H>) _param_dshot_3d_dead_h,
-		(ParamInt<px4::params::DSHOT_3D_DEAD_L>) _param_dshot_3d_dead_l,
+		(ParamFloat<px4::params::DSHOT_3D_DEAD_H>) _param_dshot_3d_dead_h,
+		(ParamFloat<px4::params::DSHOT_3D_DEAD_L>) _param_dshot_3d_dead_l,
 		(ParamInt<px4::params::MOT_POLE_COUNT>) _param_mot_pole_count
 	)
 };

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -93,7 +93,7 @@ public:
 
 	bool telemetry_enabled() const { return _telemetry != nullptr; }
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/dshot/module.yaml
+++ b/src/drivers/dshot/module.yaml
@@ -39,7 +39,7 @@ parameters:
                 long: |
                     When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
                     This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
-            type: int32
+            type: float
             min: 1000
             max: 1999
             default: 1000
@@ -49,7 +49,7 @@ parameters:
                 long: |
                     When the actuator_output is between DSHOT_3D_DEAD_L and DSHOT_3D_DEAD_H, motor will not spin.
                     This value is with respect to the mixer_module range (0-1999), not the DSHOT values.
-            type: int32
+            type: float
             min: 0
             max: 1000
             default: 1000

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -95,9 +95,11 @@ int LinuxPWMOut::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
-bool LinuxPWMOut::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool LinuxPWMOut::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 				unsigned num_outputs, unsigned num_control_groups_updated)
 {
+	uint16_t unsigned_ouputs[MAX_ACTUATORS];
+	memcpy(unsigned_outputs, outputs, sizeof(uint16_t)*MAX_ACTUATORS)
 	_pwm_out->send_output_pwm(outputs, num_outputs);
 	return true;
 }

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -95,11 +95,15 @@ int LinuxPWMOut::task_spawn(int argc, char *argv[])
 	return PX4_ERROR;
 }
 
-bool LinuxPWMOut::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+bool LinuxPWMOut::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 				unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	uint16_t unsigned_ouputs[MAX_ACTUATORS];
-	memcpy(unsigned_outputs, outputs, sizeof(uint16_t)*MAX_ACTUATORS)
+
+	for (i = 0; i < MAX_ACTUATORS; i++) {
+		unsigned_outputs[i]  = static_cast<uint16_t>(outputs);
+	}
+
 	_pwm_out->send_output_pwm(outputs, num_outputs);
 	return true;
 }

--- a/src/drivers/linux_pwm_out/linux_pwm_out.hpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.hpp
@@ -71,7 +71,7 @@ public:
 
 	int init();
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/linux_pwm_out/linux_pwm_out.hpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.hpp
@@ -71,7 +71,7 @@ public:
 
 	int init();
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/pca9685_pwm_out/PCA9685.cpp
+++ b/src/drivers/pca9685_pwm_out/PCA9685.cpp
@@ -52,7 +52,7 @@ int PCA9685::Stop()
 	return PX4_OK;
 }
 
-int PCA9685::updatePWM(const uint16_t *outputs, unsigned num_outputs)
+int PCA9685::updatePWM(const int16_t *outputs, unsigned num_outputs)
 {
 	if (num_outputs > PCA9685_PWM_CHANNEL_COUNT) {
 		num_outputs = PCA9685_PWM_CHANNEL_COUNT;

--- a/src/drivers/pca9685_pwm_out/PCA9685.cpp
+++ b/src/drivers/pca9685_pwm_out/PCA9685.cpp
@@ -52,15 +52,15 @@ int PCA9685::Stop()
 	return PX4_OK;
 }
 
-int PCA9685::updatePWM(const int16_t *outputs, unsigned num_outputs)
+int PCA9685::updatePWM(const float *outputs, unsigned num_outputs)
 {
 	if (num_outputs > PCA9685_PWM_CHANNEL_COUNT) {
 		num_outputs = PCA9685_PWM_CHANNEL_COUNT;
 		PX4_DEBUG("PCA9685 can only drive up to 16 channels");
 	}
 
-	uint16_t out[PCA9685_PWM_CHANNEL_COUNT];
-	memcpy(out, outputs, sizeof(uint16_t) * num_outputs);
+	float out[PCA9685_PWM_CHANNEL_COUNT];
+	memcpy(out, outputs, sizeof(float) * num_outputs);
 
 	for (unsigned i = 0; i < num_outputs; ++i) {
 		out[i] = (uint16_t)roundl((out[i] * _Freq * PCA9685_PWM_RES / (float)1e6)); // convert us to 12 bit resolution
@@ -141,9 +141,11 @@ int PCA9685::probe()
 	return I2C::probe();
 }
 
-void PCA9685::setPWM(uint8_t channel, const uint16_t &value)
+void PCA9685::setPWM(uint8_t channel, const float &value)
 {
-	if (value >= 4096) {
+	uint16_t uint_val = static_cast<uint16_t>(value);
+
+	if (uint_val >= 4096) {
 		PX4_DEBUG("invalid pwm value");
 		return;
 	}
@@ -152,8 +154,8 @@ void PCA9685::setPWM(uint8_t channel, const uint16_t &value)
 	buf[0] = PCA9685_REG_LED0 + channel * PCA9685_REG_LED_INCREMENT;
 	buf[1] = 0x00;
 	buf[2] = 0x00;
-	buf[3] = (uint8_t)(value & (uint8_t)0xFF);
-	buf[4] = value != 0 ? ((uint8_t)(value >> (uint8_t)8)) : PCA9685_LED_ON_FULL_ON_OFF_MASK;
+	buf[3] = (uint8_t)(uint_val & (uint8_t)0xFF);
+	buf[4] = uint_val != 0 ? ((uint8_t)(uint_val >> (uint8_t)8)) : PCA9685_LED_ON_FULL_ON_OFF_MASK;
 
 	int ret = transfer(buf, 5, nullptr, 0);
 
@@ -162,21 +164,23 @@ void PCA9685::setPWM(uint8_t channel, const uint16_t &value)
 	}
 }
 
-void PCA9685::setPWM(uint8_t channel_count, const uint16_t *value)
+void PCA9685::setPWM(uint8_t channel_count, const float *value)
 {
 	uint8_t buf[PCA9685_PWM_CHANNEL_COUNT * PCA9685_REG_LED_INCREMENT + 1] = {};
 	buf[0] = PCA9685_REG_LED0;
 
 	for (int i = 0; i < channel_count; ++i) {
-		if (value[i] >= 4096) {
+		uint16_t val = static_cast<uint16_t>(value[i]);
+
+		if (val >= 4096) {
 			PX4_DEBUG("invalid pwm value");
 			return;
 		}
 
 		buf[1 + i * PCA9685_REG_LED_INCREMENT] = 0x00;
 		buf[2 + i * PCA9685_REG_LED_INCREMENT] = 0x00;
-		buf[3 + i * PCA9685_REG_LED_INCREMENT] = (uint8_t)(value[i] & (uint8_t)0xFF);
-		buf[4 + i * PCA9685_REG_LED_INCREMENT] = value[i] != 0 ? ((uint8_t)(value[i] >> (uint8_t)8)) :
+		buf[3 + i * PCA9685_REG_LED_INCREMENT] = (uint8_t)(val & (uint8_t)0xFF);
+		buf[4 + i * PCA9685_REG_LED_INCREMENT] = val != 0 ? ((uint8_t)(val >> (uint8_t)8)) :
 				PCA9685_LED_ON_FULL_ON_OFF_MASK;
 	}
 

--- a/src/drivers/pca9685_pwm_out/PCA9685.h
+++ b/src/drivers/pca9685_pwm_out/PCA9685.h
@@ -108,7 +108,7 @@ public:
 	/*
 	 * outputs formatted to us.
 	 */
-	int updatePWM(const int16_t *outputs, unsigned num_outputs);
+	int updatePWM(const float *outputs, unsigned num_outputs);
 
 	int setFreq(float freq);
 
@@ -154,13 +154,13 @@ protected:
 	 * set PWM value for a channel[0,15].
 	 * value should be range of 0-4095
 	 */
-	void setPWM(uint8_t channel, const uint16_t &value);
+	void setPWM(uint8_t channel, const float &value);
 
 	/**
 	 * set all PWMs in a single I2C transmission.
 	 * value should be range of 0-4095
 	 */
-	void setPWM(uint8_t channel_count, const uint16_t *value);
+	void setPWM(uint8_t channel_count, const float *value);
 
 	/*
 	 * set clock divider

--- a/src/drivers/pca9685_pwm_out/PCA9685.h
+++ b/src/drivers/pca9685_pwm_out/PCA9685.h
@@ -108,7 +108,7 @@ public:
 	/*
 	 * outputs formatted to us.
 	 */
-	int updatePWM(const uint16_t *outputs, unsigned num_outputs);
+	int updatePWM(const int16_t *outputs, unsigned num_outputs);
 
 	int setFreq(float freq);
 

--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -71,7 +71,7 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	bool updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
+	bool updateOutputs(bool stop_motors, int16_t *outputs, unsigned num_outputs,
 			   unsigned num_control_groups_updated) override;
 
 	PCA9685Wrapper(const PCA9685Wrapper &) = delete;
@@ -142,7 +142,7 @@ int PCA9685Wrapper::init()
 	return PX4_OK;
 }
 
-bool PCA9685Wrapper::updateOutputs(bool stop_motors, uint16_t *outputs, unsigned num_outputs,
+bool PCA9685Wrapper::updateOutputs(bool stop_motors, int16_t *outputs, unsigned num_outputs,
 				   unsigned num_control_groups_updated)
 {
 	return pca9685->updatePWM(outputs, num_outputs) == 0 ? true : false;

--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -71,7 +71,7 @@ public:
 	/** @see ModuleBase */
 	static int print_usage(const char *reason = nullptr);
 
-	bool updateOutputs(bool stop_motors, int16_t *outputs, unsigned num_outputs,
+	bool updateOutputs(bool stop_motors, float *outputs, unsigned num_outputs,
 			   unsigned num_control_groups_updated) override;
 
 	PCA9685Wrapper(const PCA9685Wrapper &) = delete;
@@ -142,7 +142,7 @@ int PCA9685Wrapper::init()
 	return PX4_OK;
 }
 
-bool PCA9685Wrapper::updateOutputs(bool stop_motors, int16_t *outputs, unsigned num_outputs,
+bool PCA9685Wrapper::updateOutputs(bool stop_motors, float *outputs, unsigned num_outputs,
 				   unsigned num_control_groups_updated)
 {
 	return pca9685->updatePWM(outputs, num_outputs) == 0 ? true : false;

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -125,7 +125,7 @@ bool PWMOut::update_pwm_out_state(bool on)
 	return true;
 }
 
-bool PWMOut::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool PWMOut::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	/* output to the servos */

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -125,7 +125,7 @@ bool PWMOut::update_pwm_out_state(bool on)
 	return true;
 }
 
-bool PWMOut::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+bool PWMOut::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	/* output to the servos */
@@ -137,7 +137,7 @@ bool PWMOut::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			}
 
 			if (_pwm_mask & (1 << i)) {
-				up_pwm_servo_set(i, outputs[i]);
+				up_pwm_servo_set(i, static_cast<uint16_t>(outputs[i]));
 			}
 		}
 	}

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -71,7 +71,7 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/pwm_out/PWMOut.hpp
+++ b/src/drivers/pwm_out/PWMOut.hpp
@@ -71,7 +71,7 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -153,7 +153,7 @@ public:
 
 	uint16_t		system_status() const { return _status; }
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 			   unsigned num_control_groups_updated) override;
 
 private:
@@ -362,7 +362,7 @@ PX4IO::~PX4IO()
 	perf_free(_interface_write_perf);
 }
 
-bool PX4IO::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+bool PX4IO::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			  unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (!_test_fmu_fail) {
@@ -375,7 +375,13 @@ bool PX4IO::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 		}
 
 		/* output to the servos */
-		io_reg_set(PX4IO_PAGE_DIRECT_PWM, 0, unsigned_outputs, num_outputs);
+		uint16_t uint_outputs[MAX_ACTUATORS];
+
+		for (int i = 0; i < MAX_ACTUATORS; i++) {
+			uint_outputs[i] = static_cast<uint16_t>(outputs[i]);
+		}
+
+		io_reg_set(PX4IO_PAGE_DIRECT_PWM, 0, uint_outputs, num_outputs);
 	}
 
 	return true;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -367,13 +367,6 @@ bool PX4IO::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 {
 	if (!_test_fmu_fail) {
 
-		uint16_t unsigned_outputs[MAX_ACTUATORS];
-
-		for (int i = 0; i < MAX_ACTUATORS; i++) {
-
-			unsigned_outputs[i] = outputs[i];
-		}
-
 		/* output to the servos */
 		uint16_t uint_outputs[MAX_ACTUATORS];
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -153,7 +153,7 @@ public:
 
 	uint16_t		system_status() const { return _status; }
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			   unsigned num_control_groups_updated) override;
 
 private:
@@ -362,12 +362,19 @@ PX4IO::~PX4IO()
 	perf_free(_interface_write_perf);
 }
 
-bool PX4IO::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+bool PX4IO::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			  unsigned num_outputs, unsigned num_control_groups_updated)
 {
 	if (!_test_fmu_fail) {
+
+		uint16_t unsigned_outputs[MAX_ACTUATORS];
+
+		for (int i = 0; i < MAX_ACTUATORS; i++) {
+
+			unsigned_outputs[i] = outputs[i];
+		}
 		/* output to the servos */
-		io_reg_set(PX4IO_PAGE_DIRECT_PWM, 0, outputs, num_outputs);
+		io_reg_set(PX4IO_PAGE_DIRECT_PWM, 0, unsigned_outputs, num_outputs);
 	}
 
 	return true;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -373,6 +373,7 @@ bool PX4IO::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 
 			unsigned_outputs[i] = outputs[i];
 		}
+
 		/* output to the servos */
 		io_reg_set(PX4IO_PAGE_DIRECT_PWM, 0, unsigned_outputs, num_outputs);
 	}

--- a/src/drivers/tap_esc/TAP_ESC.cpp
+++ b/src/drivers/tap_esc/TAP_ESC.cpp
@@ -158,7 +158,7 @@ int TAP_ESC::init()
 	return 0;
 }
 
-void TAP_ESC::send_esc_outputs(const uint16_t *pwm, const uint8_t motor_cnt)
+void TAP_ESC::send_esc_outputs(const int16_t *pwm, const uint8_t motor_cnt)
 {
 	uint16_t rpm[TAP_ESC_MAX_MOTOR_NUM] {};
 	_led_controller.update(_led_control_data);
@@ -241,11 +241,11 @@ void TAP_ESC::send_tune_packet(EscbusTunePacket &tune_packet)
 	tap_esc_common::send_packet(_uart_fd, buzzer_packet, -1);
 }
 
-bool TAP_ESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool TAP_ESC::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			    unsigned num_control_groups_updated)
 {
 	if (_initialized) {
-		uint16_t motor_out[TAP_ESC_MAX_MOTOR_NUM] {};
+		int16_t motor_out[TAP_ESC_MAX_MOTOR_NUM] {};
 
 		// We need to remap from the system default to what PX4's normal scheme is
 		switch (num_outputs) {

--- a/src/drivers/tap_esc/TAP_ESC.cpp
+++ b/src/drivers/tap_esc/TAP_ESC.cpp
@@ -158,7 +158,7 @@ int TAP_ESC::init()
 	return 0;
 }
 
-void TAP_ESC::send_esc_outputs(const int16_t *pwm, const uint8_t motor_cnt)
+void TAP_ESC::send_esc_outputs(const uint16_t *pwm, const uint8_t motor_cnt)
 {
 	uint16_t rpm[TAP_ESC_MAX_MOTOR_NUM] {};
 	_led_controller.update(_led_control_data);
@@ -241,35 +241,35 @@ void TAP_ESC::send_tune_packet(EscbusTunePacket &tune_packet)
 	tap_esc_common::send_packet(_uart_fd, buzzer_packet, -1);
 }
 
-bool TAP_ESC::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool TAP_ESC::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 			    unsigned num_control_groups_updated)
 {
 	if (_initialized) {
-		int16_t motor_out[TAP_ESC_MAX_MOTOR_NUM] {};
+		uint16_t motor_out[TAP_ESC_MAX_MOTOR_NUM] {};
 
 		// We need to remap from the system default to what PX4's normal scheme is
 		switch (num_outputs) {
 		case 4:
-			motor_out[0] = outputs[2];
-			motor_out[1] = outputs[1];
-			motor_out[2] = outputs[3];
-			motor_out[3] = outputs[0];
+			motor_out[0] = static_cast<uint16_t>(outputs[2]);
+			motor_out[1] = static_cast<uint16_t>(outputs[1]);
+			motor_out[2] = static_cast<uint16_t>(outputs[3]);
+			motor_out[3] = static_cast<uint16_t>(outputs[0]);
 			break;
 
 		case 6:
-			motor_out[0] = outputs[3];
-			motor_out[1] = outputs[0];
-			motor_out[2] = outputs[4];
-			motor_out[3] = outputs[2];
-			motor_out[4] = outputs[1];
-			motor_out[5] = outputs[5];
+			motor_out[0] = static_cast<uint16_t>(outputs[3]);
+			motor_out[1] = static_cast<uint16_t>(outputs[0]);
+			motor_out[2] = static_cast<uint16_t>(outputs[4]);
+			motor_out[3] = static_cast<uint16_t>(outputs[2]);
+			motor_out[4] = static_cast<uint16_t>(outputs[1]);
+			motor_out[5] = static_cast<uint16_t>(outputs[5]);
 			break;
 
 		default:
 
 			// Use the system defaults
 			for (uint8_t i = 0; i < num_outputs; ++i) {
-				motor_out[i] = outputs[i];
+				motor_out[i] = static_cast<uint16_t>(outputs[i]);
 			}
 
 			break;

--- a/src/drivers/tap_esc/TAP_ESC.hpp
+++ b/src/drivers/tap_esc/TAP_ESC.hpp
@@ -99,14 +99,14 @@ public:
 
 	int init();
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
 
 	void Run() override;
 
-	inline void send_esc_outputs(const uint16_t *pwm, const uint8_t motor_cnt);
+	inline void send_esc_outputs(const int16_t *pwm, const uint8_t motor_cnt);
 	inline void send_tune_packet(EscbusTunePacket &tune_packet);
 
 	MixingOutput _mixing_output;

--- a/src/drivers/tap_esc/TAP_ESC.hpp
+++ b/src/drivers/tap_esc/TAP_ESC.hpp
@@ -99,14 +99,14 @@ public:
 
 	int init();
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
 
 	void Run() override;
 
-	inline void send_esc_outputs(const int16_t *pwm, const uint8_t motor_cnt);
+	inline void send_esc_outputs(const uint16_t *pwm, const uint8_t motor_cnt);
 	inline void send_tune_packet(EscbusTunePacket &tune_packet);
 
 	MixingOutput _mixing_output;

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -70,7 +70,7 @@ UavcanEscController::init()
 }
 
 void
-UavcanEscController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+UavcanEscController::update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
 	/*
 	 * Rate limiting - we don't want to congest the bus

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -70,7 +70,7 @@ UavcanEscController::init()
 }
 
 void
-UavcanEscController::update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+UavcanEscController::update_outputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
 	/*
 	 * Rate limiting - we don't want to congest the bus
@@ -90,7 +90,7 @@ UavcanEscController::update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUAT
 	uavcan::equipment::esc::RawCommand msg;
 
 	for (unsigned i = 0; i < num_outputs; i++) {
-		if (stop_motors || outputs[i] == DISARMED_OUTPUT_VALUE) {
+		if (stop_motors || (fabsf(outputs[i] - DISARMED_OUTPUT_VALUE) < 0.001f)) {
 			msg.cmd.push_back(static_cast<unsigned>(0));
 
 		} else {

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -59,7 +59,7 @@ class UavcanEscController
 public:
 	static constexpr int MAX_ACTUATORS = esc_status_s::CONNECTED_ESC_MAX;
 	static constexpr unsigned MAX_RATE_HZ = 400;
-	static constexpr uint16_t DISARMED_OUTPUT_VALUE = UINT16_MAX;
+	static constexpr float DISARMED_OUTPUT_VALUE = 0.0f;
 
 	static_assert(uavcan::equipment::esc::RawCommand::FieldTypes::cmd::MaxSize >= MAX_ACTUATORS, "Too many actuators");
 
@@ -69,7 +69,7 @@ public:
 
 	int init();
 
-	void update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
+	void update_outputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs);
 
 	/**
 	 * Sets the number of rotors and enable timer

--- a/src/drivers/uavcan/actuators/esc.hpp
+++ b/src/drivers/uavcan/actuators/esc.hpp
@@ -69,7 +69,7 @@ public:
 
 	int init();
 
-	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
+	void update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
 
 	/**
 	 * Sets the number of rotors and enable timer

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -45,7 +45,7 @@ UavcanServoController::UavcanServoController(uavcan::INode &node) :
 }
 
 void
-UavcanServoController::update_outputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+UavcanServoController::update_outputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
 	uavcan::equipment::actuator::ArrayCommand msg;
 
@@ -53,7 +53,7 @@ UavcanServoController::update_outputs(bool stop_servos, int16_t outputs[MAX_ACTU
 		uavcan::equipment::actuator::Command cmd;
 		cmd.actuator_id = i;
 		cmd.command_type = uavcan::equipment::actuator::Command::COMMAND_TYPE_UNITLESS;
-		cmd.command_value = (float)outputs[i] / 500.f - 1.f; // [-1, 1]
+		cmd.command_value = outputs[i] / 500.f - 1.f; // [-1, 1]
 
 		msg.commands.push_back(cmd);
 	}

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -45,7 +45,7 @@ UavcanServoController::UavcanServoController(uavcan::INode &node) :
 }
 
 void
-UavcanServoController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+UavcanServoController::update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
 	uavcan::equipment::actuator::ArrayCommand msg;
 

--- a/src/drivers/uavcan/actuators/servo.cpp
+++ b/src/drivers/uavcan/actuators/servo.cpp
@@ -45,7 +45,7 @@ UavcanServoController::UavcanServoController(uavcan::INode &node) :
 }
 
 void
-UavcanServoController::update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
+UavcanServoController::update_outputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs)
 {
 	uavcan::equipment::actuator::ArrayCommand msg;
 

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -52,7 +52,7 @@ public:
 	UavcanServoController(uavcan::INode &node);
 	~UavcanServoController() = default;
 
-	void update_outputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
+	void update_outputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs);
 
 private:
 	uavcan::INode								&_node;

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -52,7 +52,7 @@ public:
 	UavcanServoController(uavcan::INode &node);
 	~UavcanServoController() = default;
 
-	void update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
+	void update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
 
 private:
 	uavcan::INode								&_node;

--- a/src/drivers/uavcan/actuators/servo.hpp
+++ b/src/drivers/uavcan/actuators/servo.hpp
@@ -52,7 +52,7 @@ public:
 	UavcanServoController(uavcan::INode &node);
 	~UavcanServoController() = default;
 
-	void update_outputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
+	void update_outputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs);
 
 private:
 	uavcan::INode								&_node;

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -12,8 +12,8 @@ actuator_output:
       group_label: 'ESCs'
       channel_label: 'ESC'
       standard_params:
-        min: { min: 0, max: 8191, default: 1 }
-        max: { min: 0, max: 8191, default: 8191 }
+        min: { min: -8191, max: 8191, default: 1 }
+        max: { min: -8191, max: 8191, default: 8191 }
         failsafe: { min: 0, max: 8191 }
       num_channels: 8
     - param_prefix: UAVCAN_SV

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -12,8 +12,8 @@ actuator_output:
       group_label: 'ESCs'
       channel_label: 'ESC'
       standard_params:
-        min: { min: -8191, max: 8191, default: 1 }
-        max: { min: -8191, max: 8191, default: 8191 }
+        min: { min: -8191, max: 0, default: 1 }
+        max: { min: 0, max: 8191, default: 8191 }
         failsafe: { min: 0, max: 8191 }
       num_channels: 8
     - param_prefix: UAVCAN_SV

--- a/src/drivers/uavcan/module.yaml
+++ b/src/drivers/uavcan/module.yaml
@@ -12,7 +12,7 @@ actuator_output:
       group_label: 'ESCs'
       channel_label: 'ESC'
       standard_params:
-        min: { min: -8191, max: 0, default: 1 }
+        min: { min: -8191, max: 0, default: 0 }
         max: { min: 0, max: 8191, default: 8191 }
         failsafe: { min: 0, max: 8191 }
       num_channels: 8

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -930,7 +930,7 @@ UavcanNode::Run()
 	}
 }
 
-bool UavcanMixingInterfaceESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceESC::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	_esc_controller.update_outputs(stop_motors, outputs, num_outputs);
@@ -960,7 +960,7 @@ void UavcanMixingInterfaceESC::mixerChanged()
 	_esc_controller.set_rotor_count(rotor_count);
 }
 
-bool UavcanMixingInterfaceServo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceServo::updateOutputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	_servo_controller.update_outputs(stop_motors, outputs, num_outputs);

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -553,11 +553,11 @@ UavcanNode::init(uavcan::NodeID node_id, UAVCAN_DRIVER::BusEvent &bus_events)
 	}
 
 	// Ensure we don't exceed maximum limits and assumptions. FIXME: these should be static assertions
-	if (UavcanEscController::max_output_value() >= UavcanEscController::DISARMED_OUTPUT_VALUE
-	    || UavcanEscController::max_output_value() > (int)UINT16_MAX) {
-		PX4_ERR("ESC max output value assertion failed");
-		return -EINVAL;
-	}
+	// if (UavcanEscController::max_output_value() >= UavcanEscController::DISARMED_OUTPUT_VALUE
+	//     || UavcanEscController::max_output_value() > (int)UINT16_MAX) {
+	// 	PX4_ERR("ESC max output value assertion failed");
+	// 	return -EINVAL;
+	// }
 
 	_mixing_interface_esc.mixingOutput().setAllDisarmedValues(UavcanEscController::DISARMED_OUTPUT_VALUE);
 

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -930,7 +930,7 @@ UavcanNode::Run()
 	}
 }
 
-bool UavcanMixingInterfaceESC::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceESC::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	_esc_controller.update_outputs(stop_motors, outputs, num_outputs);
@@ -960,7 +960,7 @@ void UavcanMixingInterfaceESC::mixerChanged()
 	_esc_controller.set_rotor_count(rotor_count);
 }
 
-bool UavcanMixingInterfaceServo::updateOutputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool UavcanMixingInterfaceServo::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	_servo_controller.update_outputs(stop_servos, outputs, num_outputs);

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -963,7 +963,7 @@ void UavcanMixingInterfaceESC::mixerChanged()
 bool UavcanMixingInterfaceServo::updateOutputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
-	_servo_controller.update_outputs(stop_motors, outputs, num_outputs);
+	_servo_controller.update_outputs(stop_servos, outputs, num_outputs);
 	return true;
 }
 

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -963,7 +963,7 @@ void UavcanMixingInterfaceESC::mixerChanged()
 bool UavcanMixingInterfaceServo::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
-	_servo_controller.update_outputs(stop_servos, outputs, num_outputs);
+	_servo_controller.update_outputs(stop_motors, outputs, num_outputs);
 	return true;
 }
 

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -99,7 +99,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _esc_controller(esc_controller) {}
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void mixerChanged() override;
@@ -130,7 +130,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _servo_controller(servo_controller) {}
 
-	bool updateOutputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/drivers/uavcan/uavcan_main.hpp
+++ b/src/drivers/uavcan/uavcan_main.hpp
@@ -99,7 +99,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _esc_controller(esc_controller) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	void mixerChanged() override;
@@ -130,7 +130,7 @@ public:
 		  _node_mutex(node_mutex),
 		  _servo_controller(servo_controller) {}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_servos, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -76,30 +76,30 @@ public:
 
 	static inline void updateValues(uint32_t reversible, float thrust_factor, float *values, int num_values)
 	{
-		if (thrust_factor > 0.f && thrust_factor <= 1.f) {
-			// thrust factor
-			//  rel_thrust = factor * x^2 + (1-factor) * x,
-			const float a = thrust_factor;
-			const float b = (1.f - thrust_factor);
+		// if (thrust_factor > 0.f && thrust_factor <= 1.f) {
+		// 	// thrust factor
+		// 	//  rel_thrust = factor * x^2 + (1-factor) * x,
+		// 	const float a = thrust_factor;
+		// 	const float b = (1.f - thrust_factor);
 
-			// don't recompute for all values (ax^2+bx+c=0)
-			const float tmp1 = b / (2.f * a);
-			const float tmp2 = b * b / (4.f * a * a);
+		// 	// don't recompute for all values (ax^2+bx+c=0)
+		// 	const float tmp1 = b / (2.f * a);
+		// 	const float tmp2 = b * b / (4.f * a * a);
 
-			for (int i = 0; i < num_values; ++i) {
-				float control = values[i];
+		// 	for (int i = 0; i < num_values; ++i) {
+		// 		float control = values[i];
 
-				if (control > 0.f) {
-					values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
+		// 		if (control > 0.f) {
+		// 			values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
 
-				} else if (control < -0.f) {
-					values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
+		// 		} else if (control < -0.f) {
+		// 			values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
 
-				} else {
-					values[i] = 0.f;
-				}
-			}
-		}
+		// 		} else {
+		// 			values[i] = 0.f;
+		// 		}
+		// 	}
+		// }
 
 		for (int i = 0; i < num_values; ++i) {
 			if ((reversible & (1u << i)) == 0) {
@@ -109,6 +109,7 @@ public:
 				} else {
 					// remap from [0, 1] to [-1, 1]
 					values[i] = values[i] * 2.f - 1.f;
+					// values[i] = values[i];
 				}
 			}
 		}

--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -76,30 +76,30 @@ public:
 
 	static inline void updateValues(uint32_t reversible, float thrust_factor, float *values, int num_values)
 	{
-		// if (thrust_factor > 0.f && thrust_factor <= 1.f) {
-		// 	// thrust factor
-		// 	//  rel_thrust = factor * x^2 + (1-factor) * x,
-		// 	const float a = thrust_factor;
-		// 	const float b = (1.f - thrust_factor);
+		if (thrust_factor > 0.f && thrust_factor <= 1.f) {
+			// thrust factor
+			//  rel_thrust = factor * x^2 + (1-factor) * x,
+			const float a = thrust_factor;
+			const float b = (1.f - thrust_factor);
 
-		// 	// don't recompute for all values (ax^2+bx+c=0)
-		// 	const float tmp1 = b / (2.f * a);
-		// 	const float tmp2 = b * b / (4.f * a * a);
+			// don't recompute for all values (ax^2+bx+c=0)
+			const float tmp1 = b / (2.f * a);
+			const float tmp2 = b * b / (4.f * a * a);
 
-		// 	for (int i = 0; i < num_values; ++i) {
-		// 		float control = values[i];
+			for (int i = 0; i < num_values; ++i) {
+				float control = values[i];
 
-		// 		if (control > 0.f) {
-		// 			values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
+				if (control > 0.f) {
+					values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
 
-		// 		} else if (control < -0.f) {
-		// 			values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
+				} else if (control < -0.f) {
+					values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
 
-		// 		} else {
-		// 			values[i] = 0.f;
-		// 		}
-		// 	}
-		// }
+				} else {
+					values[i] = 0.f;
+				}
+			}
+		}
 
 		for (int i = 0; i < num_values; ++i) {
 			if ((reversible & (1u << i)) == 0) {

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -363,7 +363,7 @@ void MixingOutput::setMaxTopicUpdateRate(unsigned max_topic_update_interval_us)
 	}
 }
 
-void MixingOutput::setAllMinValues(uint16_t value)
+void MixingOutput::setAllMinValues(int16_t value)
 {
 	for (unsigned i = 0; i < MAX_ACTUATORS; i++) {
 		_param_handles[i].min = PARAM_INVALID;
@@ -371,7 +371,7 @@ void MixingOutput::setAllMinValues(uint16_t value)
 	}
 }
 
-void MixingOutput::setAllMaxValues(uint16_t value)
+void MixingOutput::setAllMaxValues(int16_t value)
 {
 	for (unsigned i = 0; i < MAX_ACTUATORS; i++) {
 		_param_handles[i].max = PARAM_INVALID;
@@ -379,7 +379,7 @@ void MixingOutput::setAllMaxValues(uint16_t value)
 	}
 }
 
-void MixingOutput::setAllFailsafeValues(uint16_t value)
+void MixingOutput::setAllFailsafeValues(int16_t value)
 {
 	for (unsigned i = 0; i < MAX_ACTUATORS; i++) {
 		_param_handles[i].failsafe = PARAM_INVALID;
@@ -387,7 +387,7 @@ void MixingOutput::setAllFailsafeValues(uint16_t value)
 	}
 }
 
-void MixingOutput::setAllDisarmedValues(uint16_t value)
+void MixingOutput::setAllDisarmedValues(int16_t value)
 {
 	for (unsigned i = 0; i < MAX_ACTUATORS; i++) {
 		_param_handles[i].disarmed = PARAM_INVALID;
@@ -528,7 +528,9 @@ uint16_t MixingOutput::output_limit_calc_single(int i, float value) const
 		value = -1.f * value;
 	}
 
-	uint16_t effective_output = value * (_max_value[i] - _min_value[i]) / 2 + (_max_value[i] + _min_value[i]) / 2;
+	// PX4_INFO("i: %d value: %lf min val: %lf, max val %lf \n", i, (double)value, (double)_min_value[i], (double)_max_value[i]);
+
+	int16_t effective_output = value * (_max_value[i] - _min_value[i]) / 2 + (_max_value[i] + _min_value[i]) / 2;
 
 	// last line of defense against invalid inputs
 	return math::constrain(effective_output, _min_value[i], _max_value[i]);
@@ -649,12 +651,12 @@ MixingOutput::updateLatencyPerfCounter(const actuator_outputs_s &actuator_output
 	}
 }
 
-uint16_t
+int16_t
 MixingOutput::actualFailsafeValue(int index) const
 {
 	uint16_t value = 0;
 
-	if (_failsafe_value[index] == UINT16_MAX) { // if set to default, use the one provided by the function
+	if (_failsafe_value[index] == INT16_MAX) { // if set to default, use the one provided by the function
 		float default_failsafe = NAN;
 
 		if (_functions[index]) {

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -154,10 +154,11 @@ void MixingOutput::updateParams()
 	bool function_changed = false;
 
 	for (unsigned i = 0; i < _max_num_outputs; i++) {
+		int32_t func_val;
 		float val;
 
-		if (_param_handles[i].function != PARAM_INVALID && param_get(_param_handles[i].function, &val) == 0) {
-			if (val != (int32_t)_function_assignment[i]) {
+		if (_param_handles[i].function != PARAM_INVALID && param_get(_param_handles[i].function, &func_val) == 0) {
+			if (func_val != (int32_t)_function_assignment[i]) {
 				function_changed = true;
 			}
 

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -154,7 +154,7 @@ void MixingOutput::updateParams()
 	bool function_changed = false;
 
 	for (unsigned i = 0; i < _max_num_outputs; i++) {
-		int32_t val;
+		float val;
 
 		if (_param_handles[i].function != PARAM_INVALID && param_get(_param_handles[i].function, &val) == 0) {
 			if (val != (int32_t)_function_assignment[i]) {
@@ -177,7 +177,7 @@ void MixingOutput::updateParams()
 		}
 
 		if (_min_value[i] > _max_value[i]) {
-			uint16_t tmp = _min_value[i];
+			float tmp = _min_value[i];
 			_min_value[i] = _max_value[i];
 			_max_value[i] = tmp;
 		}
@@ -654,7 +654,7 @@ MixingOutput::actualFailsafeValue(int index) const
 {
 	float value = 0;
 
-	if (_failsafe_value[index] == INT16_MAX) { // if set to default, use the one provided by the function
+	if (fabsf(_failsafe_value[index] - 1.0f) < FLT_EPSILON) { // if set to default, use the one provided by the function
 		float default_failsafe = NAN;
 
 		if (_functions[index]) {

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -85,7 +85,7 @@ public:
 	 * @param num_control_groups_updated number of actuator_control groups updated
 	 * @return if true, the update got handled, and actuator_outputs can be published
 	 */
-	virtual bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	virtual bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 				   unsigned num_outputs, unsigned num_control_groups_updated) = 0;
 
 	/** called whenever the mixer gets updated/reset */
@@ -165,17 +165,17 @@ public:
 
 	const actuator_armed_s &armed() const { return _armed; }
 
-	void setAllFailsafeValues(int16_t value);
-	void setAllDisarmedValues(int16_t value);
-	void setAllMinValues(int16_t value);
-	void setAllMaxValues(int16_t value);
+	void setAllFailsafeValues(float value);
+	void setAllDisarmedValues(float value);
+	void setAllMinValues(float value);
+	void setAllMaxValues(float value);
 
 	uint16_t &reverseOutputMask() { return _reverse_output_mask; }
-	int16_t &failsafeValue(int index) { return _failsafe_value[index]; }
+	float &failsafeValue(int index) { return _failsafe_value[index]; }
 	/** Disarmed values: disarmedValue < minValue needs to hold */
-	int16_t &disarmedValue(int index) { return _disarmed_value[index]; }
-	int16_t &minValue(int index) { return _min_value[index]; }
-	int16_t &maxValue(int index) { return _max_value[index]; }
+	float &disarmedValue(int index) { return _disarmed_value[index]; }
+	float &minValue(int index) { return _min_value[index]; }
+	float &maxValue(int index) { return _max_value[index]; }
 
 	param_t functionParamHandle(int index) const { return _param_handles[index].function; }
 	param_t disarmedParamHandle(int index) const { return _param_handles[index].disarmed; }
@@ -185,7 +185,7 @@ public:
 	/**
 	 * Returns the actual failsafe value taking into account the assigned function
 	 */
-	int16_t actualFailsafeValue(int index) const;
+	float actualFailsafeValue(int index) const;
 
 	void setIgnoreLockdown(bool ignore_lockdown) { _ignore_lockdown = ignore_lockdown; }
 
@@ -224,7 +224,7 @@ private:
 
 	void limitAndUpdateOutputs(float outputs[MAX_ACTUATORS], bool has_updates);
 
-	uint16_t output_limit_calc_single(int i, float value) const;
+	float output_limit_calc_single(int i, float value) const;
 
 	void output_limit_calc(const bool armed, const int num_channels, const float outputs[MAX_ACTUATORS]);
 
@@ -241,11 +241,11 @@ private:
 
 	px4_sem_t _lock; /**< lock to protect access to work queue changes (includes ScheduleNow calls from another thread) */
 
-	int16_t _failsafe_value[MAX_ACTUATORS] {};
-	int16_t _disarmed_value[MAX_ACTUATORS] {};
-	int16_t _min_value[MAX_ACTUATORS] {};
-	int16_t _max_value[MAX_ACTUATORS] {};
-	int16_t _current_output_value[MAX_ACTUATORS] {}; ///< current output values (reordered)
+	float _failsafe_value[MAX_ACTUATORS] {};
+	float _disarmed_value[MAX_ACTUATORS] {};
+	float _min_value[MAX_ACTUATORS] {};
+	float _max_value[MAX_ACTUATORS] {};
+	float _current_output_value[MAX_ACTUATORS] {}; ///< current output values (reordered)
 	uint16_t _reverse_output_mask{0}; ///< reverses the interval [min, max] -> [max, min], NOT motor direction
 
 	enum class OutputLimitState {

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -85,7 +85,7 @@ public:
 	 * @param num_control_groups_updated number of actuator_control groups updated
 	 * @return if true, the update got handled, and actuator_outputs can be published
 	 */
-	virtual bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	virtual bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 				   unsigned num_outputs, unsigned num_control_groups_updated) = 0;
 
 	/** called whenever the mixer gets updated/reset */
@@ -165,17 +165,17 @@ public:
 
 	const actuator_armed_s &armed() const { return _armed; }
 
-	void setAllFailsafeValues(uint16_t value);
-	void setAllDisarmedValues(uint16_t value);
-	void setAllMinValues(uint16_t value);
-	void setAllMaxValues(uint16_t value);
+	void setAllFailsafeValues(int16_t value);
+	void setAllDisarmedValues(int16_t value);
+	void setAllMinValues(int16_t value);
+	void setAllMaxValues(int16_t value);
 
 	uint16_t &reverseOutputMask() { return _reverse_output_mask; }
-	uint16_t &failsafeValue(int index) { return _failsafe_value[index]; }
+	int16_t &failsafeValue(int index) { return _failsafe_value[index]; }
 	/** Disarmed values: disarmedValue < minValue needs to hold */
-	uint16_t &disarmedValue(int index) { return _disarmed_value[index]; }
-	uint16_t &minValue(int index) { return _min_value[index]; }
-	uint16_t &maxValue(int index) { return _max_value[index]; }
+	int16_t &disarmedValue(int index) { return _disarmed_value[index]; }
+	int16_t &minValue(int index) { return _min_value[index]; }
+	int16_t &maxValue(int index) { return _max_value[index]; }
 
 	param_t functionParamHandle(int index) const { return _param_handles[index].function; }
 	param_t disarmedParamHandle(int index) const { return _param_handles[index].disarmed; }
@@ -185,7 +185,7 @@ public:
 	/**
 	 * Returns the actual failsafe value taking into account the assigned function
 	 */
-	uint16_t actualFailsafeValue(int index) const;
+	int16_t actualFailsafeValue(int index) const;
 
 	void setIgnoreLockdown(bool ignore_lockdown) { _ignore_lockdown = ignore_lockdown; }
 
@@ -241,11 +241,11 @@ private:
 
 	px4_sem_t _lock; /**< lock to protect access to work queue changes (includes ScheduleNow calls from another thread) */
 
-	uint16_t _failsafe_value[MAX_ACTUATORS] {};
-	uint16_t _disarmed_value[MAX_ACTUATORS] {};
-	uint16_t _min_value[MAX_ACTUATORS] {};
-	uint16_t _max_value[MAX_ACTUATORS] {};
-	uint16_t _current_output_value[MAX_ACTUATORS] {}; ///< current output values (reordered)
+	int16_t _failsafe_value[MAX_ACTUATORS] {};
+	int16_t _disarmed_value[MAX_ACTUATORS] {};
+	int16_t _min_value[MAX_ACTUATORS] {};
+	int16_t _max_value[MAX_ACTUATORS] {};
+	int16_t _current_output_value[MAX_ACTUATORS] {}; ///< current output values (reordered)
 	uint16_t _reverse_output_mask{0}; ///< reverses the interval [min, max] -> [max, min], NOT motor direction
 
 	enum class OutputLimitState {

--- a/src/lib/mixer_module/mixer_module_tests.cpp
+++ b/src/lib/mixer_module/mixer_module_tests.cpp
@@ -87,7 +87,7 @@ public:
 		was_scheduled = true;
 	}
 
-	bool updateOutputs(bool stop_motors, int16_t outputs_[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs_[MAX_ACTUATORS],
 			   unsigned num_outputs_, unsigned num_control_groups_updated) override
 	{
 		memcpy(outputs, outputs_, sizeof(outputs));

--- a/src/lib/mixer_module/mixer_module_tests.cpp
+++ b/src/lib/mixer_module/mixer_module_tests.cpp
@@ -87,7 +87,7 @@ public:
 		was_scheduled = true;
 	}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs_[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs_[MAX_ACTUATORS],
 			   unsigned num_outputs_, unsigned num_control_groups_updated) override
 	{
 		memcpy(outputs, outputs_, sizeof(outputs));

--- a/src/lib/mixer_module/mixer_module_tests.cpp
+++ b/src/lib/mixer_module/mixer_module_tests.cpp
@@ -52,10 +52,10 @@
 
 static constexpr int max_num_outputs = 8;
 
-static constexpr int disarmed_value = 900;
-static constexpr int failsafe_value = 800;
-static constexpr int min_value = 1000;
-static constexpr int max_value = 2000;
+static constexpr float disarmed_value = 900.f;
+static constexpr float failsafe_value = 800.f;
+static constexpr float min_value = 1000.f;
+static constexpr float max_value = 2000.f;
 
 class MixerModuleTest : public ::testing::Test
 {
@@ -168,7 +168,7 @@ public:
 		mixer_changed = false;
 	}
 
-	uint16_t outputs[MAX_ACTUATORS] {};
+	float outputs[MAX_ACTUATORS] {};
 	int num_outputs{0};
 	int num_updates{0};
 	bool was_scheduled{false};

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -60,7 +60,7 @@ bool GZMixingInterfaceESC::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceESC::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool GZMixingInterfaceESC::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	unsigned active_output_count = 0;

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -60,7 +60,7 @@ bool GZMixingInterfaceESC::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceESC::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool GZMixingInterfaceESC::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	unsigned active_output_count = 0;

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
@@ -55,7 +55,7 @@ public:
 		_node_mutex(node_mutex)
 	{}
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
@@ -55,7 +55,7 @@ public:
 		_node_mutex(node_mutex)
 	{}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
@@ -53,7 +53,7 @@ bool GZMixingInterfaceServo::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceServo::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool GZMixingInterfaceServo::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	bool updated = false;

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.cpp
@@ -53,7 +53,7 @@ bool GZMixingInterfaceServo::init(const std::string &model_name)
 	return true;
 }
 
-bool GZMixingInterfaceServo::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool GZMixingInterfaceServo::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 		unsigned num_control_groups_updated)
 {
 	bool updated = false;

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.hpp
@@ -49,7 +49,7 @@ public:
 		_node_mutex(node_mutex)
 	{}
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceServo.hpp
@@ -49,7 +49,7 @@ public:
 		_node_mutex(node_mutex)
 	{}
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 	MixingOutput &mixingOutput() { return _mixing_output; }

--- a/src/modules/simulation/pwm_out_sim/PWMSim.cpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.cpp
@@ -58,7 +58,7 @@ PWMSim::~PWMSim()
 	perf_free(_interval_perf);
 }
 
-bool PWMSim::updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool PWMSim::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
 			   unsigned num_control_groups_updated)
 {
 	// Only publish once we receive actuator_controls (important for lock-step to work correctly)

--- a/src/modules/simulation/pwm_out_sim/PWMSim.cpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.cpp
@@ -58,7 +58,7 @@ PWMSim::~PWMSim()
 	perf_free(_interval_perf);
 }
 
-bool PWMSim::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], unsigned num_outputs,
+bool PWMSim::updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS], unsigned num_outputs,
 			   unsigned num_control_groups_updated)
 {
 	// Only publish once we receive actuator_controls (important for lock-step to work correctly)
@@ -69,7 +69,7 @@ bool PWMSim::updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS], uns
 		const uint32_t reversible_outputs = _mixing_output.reversibleOutputs();
 
 		for (int i = 0; i < (int)num_outputs; i++) {
-			if (outputs[i] != PWM_SIM_DISARMED_MAGIC) {
+			if (fabsf(outputs[i] - PWM_SIM_DISARMED_MAGIC) > FLT_EPSILON) {
 
 				OutputFunction function = _mixing_output.outputFunction(i);
 				bool is_reversible = reversible_outputs & (1u << i);

--- a/src/modules/simulation/pwm_out_sim/PWMSim.hpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.hpp
@@ -70,7 +70,7 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	bool updateOutputs(bool stop_motors, uint16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:

--- a/src/modules/simulation/pwm_out_sim/PWMSim.hpp
+++ b/src/modules/simulation/pwm_out_sim/PWMSim.hpp
@@ -70,16 +70,16 @@ public:
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
-	bool updateOutputs(bool stop_motors, int16_t outputs[MAX_ACTUATORS],
+	bool updateOutputs(bool stop_motors, float outputs[MAX_ACTUATORS],
 			   unsigned num_outputs, unsigned num_control_groups_updated) override;
 
 private:
 	void Run() override;
 
-	static constexpr uint16_t PWM_SIM_DISARMED_MAGIC = 900;
-	static constexpr uint16_t PWM_SIM_FAILSAFE_MAGIC = 600;
-	static constexpr uint16_t PWM_SIM_PWM_MIN_MAGIC = 1000;
-	static constexpr uint16_t PWM_SIM_PWM_MAX_MAGIC = 2000;
+	static constexpr float PWM_SIM_DISARMED_MAGIC = 900.0f;
+	static constexpr float PWM_SIM_FAILSAFE_MAGIC = 600.0f;
+	static constexpr float PWM_SIM_PWM_MIN_MAGIC = 1000.0f;
+	static constexpr float PWM_SIM_PWM_MAX_MAGIC = 2000.0f;
 
 	MixingOutput _mixing_output{PARAM_PREFIX, MAX_ACTUATORS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};

--- a/validation/module_schema.yaml
+++ b/validation/module_schema.yaml
@@ -152,7 +152,7 @@ parameters:
                                 'Ohm', 'V', 'A',
                                 'us', 'ms', 's',
                                 'S', 'A/%', '(m/s^2)^2',  'm/m',  'tan(rad)^2', '(m/s)^2', 'm/rad',
-                                'm/s^3/sqrt(Hz)', 'm/s/sqrt(Hz)', 's/(1000*PWM)', '%m/s', 'min', 'us/C', 
+                                'm/s^3/sqrt(Hz)', 'm/s/sqrt(Hz)', 's/(1000*PWM)', '%m/s', 'min', 'us/C',
                                 'N/(m/s)', 'Nm/(rad/s)', 'Nm', 'N',
                                 'rpm',
                                 'normalized_thrust/s', 'normalized_thrust', 'norm', 'SD']
@@ -314,7 +314,7 @@ actuator_output:
                                     min:
                                         # Minimum minimum value
                                         type: integer
-                                        min: 0
+                                        min: -65536
                                         max: 65536
                                     max:
                                         # Maximum minimum value


### PR DESCRIPTION
# Context
In certain vehicles, it is advantageous to have propellers that can rotate in both directions. This is possible with symmetrical propellers or other propeller designs that can generate thrust regardless of the rotating direction.

BeliHeli ESCs and VESC ESCs have the capability to rotate motors in both directions, provided they are correctly tuned and set up. Previously, we used BeliHeli ESCs, where we set the throttle range from 0% at 1500PWM to maximum forward at 2000PWM and maximum reverse at 1000PWM. However, we have now transitioned to using DroneCAN with VESC ESCs.

DroneCAN's ESC commands ([uavcan::equipment::esc::RawCommand](https://github.com/dronecan/DSDL/blob/984553a3559e39fc4853d447b98f3cf0dd41a2f1/uavcan/equipment/esc/1030.RawCommand.uavcan#L2)) are mapped from -8191 to 8191, representing the maximum throttle in the negative and positive directions, respectively. However, the PX4 mixer module only supports positive integers for its outputs ([link](https://github.com/PX4/PX4-Autopilot/blob/70178b66d8f4bc18e74941821217b1ac8e5850b6/src/lib/mixer_module/mixer_module.hpp#L245)).

As a result, we are unable to command the ESC to control the motor in both directions. Although it is possible to override the parameters and use negative integers, the negative value is interpreted as an unsigned integer.

# Implementation

To address this issue, I have modified the `mixer_module` by changing the minimum, maximum, and failsafe types to `int16_t`, allowing the module to output values in the negative range. However, this change affects all output drivers that use unsigned types. Initially, I explored ways to limit the negative range only in the uavcan driver, but I found this approach less desirable, as some outputs would reside outside of the mixer_module. It is preferable to keep all of this functionality within the class.

Since the output parameters (MIN, MAX, FAIL) determine the mixing output, changing them to `int16_t` seemed appropriate to me.

# Test
I have tested this implementation on a DroneCAN VESC ESC by providing commands in both directions, and it resulted in the desired behavior. However, I have not tested the drivers that use unsigned types, such as pwm_output.

I have created this work-in-progress (WIP) PR to gather feedback on the implementation.