### PR TITLE
Update ecl_yaw_controller.cpp

### DIFF
--- a/src/modules/fw_att_control/ecl_yaw_controller.cpp
+++ b/src/modules/fw_att_control/ecl_yaw_controller.cpp
@@ -82,7 +82,7 @@ float ECL_YawController::control_attitude(const float dt, const ECL_ControlData 
 
 	if (!inverted) {
 		/* Calculate desired yaw rate from coordinated turn constraint / (no side forces) */
-		_euler_rate_setpoint = tanf(constrained_roll) * cosf(ctl_data.pitch) * CONSTANTS_ONE_G / ctl_data.airspeed_constrained;
+		_euler_rate_setpoint = tanf(constrained_roll) * CONSTANTS_ONE_G / ctl_data.airspeed_constrained;
 
 		/* Transform setpoint to body angular rates (jacobian) */
 		const float yaw_body_rate_setpoint_raw = -sinf(ctl_data.roll) * ctl_data.euler_pitch_rate_setpoint +


### PR DESCRIPTION
The ratio of horizontal acceleration to horizontal velocity is the yaw rate. However, the statement "yaw_rate=tan(roll) * cos(pitch) * G/airspeed" in the px4 code calculates the ratio of horizontal acceleration to airspeed, but the direction of airspeed may not be horizontal.

So, this statement should be changed to "tan(roll) * cos(pitch) * G/(airspeed * cos(pitch))", because the denominator "airspeed * cos(pitch)" is the horizontal component of airspeed.

After eliminating the cos(pitch) of the numerator and denominator,  a new formula ”yaw_rate=tan(roll) * G/airspeed“ is obtained.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarfiy page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
