### PR TITLE
iotimer: Enable timer when configuring input capture

### DIFF
--- a/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c
@@ -898,11 +898,13 @@ int io_timer_set_enable(bool state, io_timer_channel_mode_t mode, io_timer_chann
 
 	case IOTimerChanMode_Dshot:
 		dier_bit = 0;
-		cr1_bit  = state ? GTIM_CR1_CEN : 0;
-		break;
 
-	case IOTimerChanMode_PWMIn:
+	/* fallthrough */
 	case IOTimerChanMode_Capture:
+		cr1_bit  = state ? GTIM_CR1_CEN : 0;
+
+	/* fallthrough */
+	case IOTimerChanMode_PWMIn:
 		break;
 
 	default:


### PR DESCRIPTION
### Solved Problem

We provide a latency measurement in the input capture handler. However, since the timer was not enabled, none of the counter were running therefore all counters were zero, thus latency was also zero.

Since the HRT is used to provide a timestamp, the lack of the running timer was never noticed. After enabling the timer, latency now correctly shows 9-10 counts.

```
nsh> camera_capture status
INFO  [camera_capture] Capture enabled : YES
INFO  [camera_capture] Frame sequence : 148
INFO  [camera_capture] Last trigger timestamp : 131463420 (6236 ms ago)
INFO  [camera_capture] Number of overflows : 0
INFO  [camera_capture] Status chan: 6 edges: 159 last time: 131463420 last state: 1 overflows: 19 latency: 10
```

Watching the register file differences via the debugger during camera triggers after the fix. Note the differences in  the CNT and CCR1 registers, which were stuck at all zeroes before.

<details>
<summary>GDB peripheral watcher output</summary>

```
capture_trigger@368558730us
Differences for TIM12:
- TIM12.SR                         = 00000000000000000000000000000101                   // status register
-     CC1IF                          ..............................0. - 0               // Capture/compare 1 interrupt flag
+ TIM12.SR                         = 00000000000000000000000000000111                   // status register
+     CC1IF                          ..............................1. - 1               // Capture/compare 1 interrupt flag
- TIM12.CNT                        = 00000000000000000010100111001010                   // counter
-     CNT                            ................0010100111001010 - 29ca            // counter value
+ TIM12.CNT                        = 00000000000000000010101000011101                   // counter
+     CNT                            ................0010101000011101 - 2a1d            // counter value
- TIM12.CCR1                       = 00000000000000000010100111001000                   // capture/compare register 1
-     CCR1                           ................0010100111001000 - 29c8            // Capture/Compare 1 value
+ TIM12.CCR1                       = 00000000000000000010101000011011                   // capture/compare register 1
+     CCR1                           ................0010101000011011 - 2a1b            // Capture/Compare 1 value
capture_trigger@368558813us
Differences for TIM12:
- TIM12.SR                         = 00000000000000000000000000000101                   // status register
-     CC1IF                          ..............................0. - 0               // Capture/compare 1 interrupt flag
+ TIM12.SR                         = 00000000000000000000000000000111                   // status register
+     CC1IF                          ..............................1. - 1               // Capture/compare 1 interrupt flag
- TIM12.CNT                        = 00000000000000000010101000011101                   // counter
-     CNT                            ................0010101000011101 - 2a1d            // counter value
+ TIM12.CNT                        = 00000000000000000001010000011110                   // counter
+     CNT                            ................0001010000011110 - 141e            // counter value
- TIM12.CCR1                       = 00000000000000000010101000011011                   // capture/compare register 1
-     CCR1                           ................0010101000011011 - 2a1b            // Capture/Compare 1 value
+ TIM12.CCR1                       = 00000000000000000001010000011100                   // capture/compare register 1
+     CCR1                           ................0001010000011100 - 141c            // Capture/Compare 1 value
capture_trigger@368813182us
Differences for TIM12:
- TIM12.SR                         = 00000000000000000000000000000101                   // status register
-     CC1IF                          ..............................0. - 0               // Capture/compare 1 interrupt flag
+ TIM12.SR                         = 00000000000000000000000000000111                   // status register
+     CC1IF                          ..............................1. - 1               // Capture/compare 1 interrupt flag
- TIM12.CNT                        = 00000000000000000001010000011110                   // counter
-     CNT                            ................0001010000011110 - 141e            // counter value
+ TIM12.CNT                        = 00000000000000000011110111001101                   // counter
+     CNT                            ................0011110111001101 - 3dcd            // counter value
- TIM12.CCR1                       = 00000000000000000001010000011100                   // capture/compare register 1
-     CCR1                           ................0001010000011100 - 141c            // Capture/Compare 1 value
+ TIM12.CCR1                       = 00000000000000000011110111000101                   // capture/compare register 1
+     CCR1                           ................0011110111000101 - 3dc5            // Capture/Compare 1 value
capture_trigger@368823854us
Differences for TIM12:
- TIM12.SR                         = 00000000000000000000000000000101                   // status register
-     CC1IF                          ..............................0. - 0               // Capture/compare 1 interrupt flag
+ TIM12.SR                         = 00000000000000000000000000000111                   // status register
+     CC1IF                          ..............................1. - 1               // Capture/compare 1 interrupt flag
- TIM12.CNT                        = 00000000000000000011110111001101                   // counter
-     CNT                            ................0011110111001101 - 3dcd            // counter value
+ TIM12.CNT                        = 00000000000000000010000110010100                   // counter
+     CNT                            ................0010000110010100 - 2194            // counter value
- TIM12.CCR1                       = 00000000000000000011110111000101                   // capture/compare register 1
-     CCR1                           ................0011110111000101 - 3dc5            // Capture/Compare 1 value
+ TIM12.CCR1                       = 00000000000000000010000110010010                   // capture/compare register 1
+     CCR1                           ................0010000110010010 - 2192            // Capture/Compare 1 value
capture_trigger@369196628us
Differences for TIM12:
- TIM12.SR                         = 00000000000000000000000000000101                   // status register
-     CC1IF                          ..............................0. - 0               // Capture/compare 1 interrupt flag
-     CC1OF                          ......................0......... - 0               // Capture/Compare 1 overcapture flag
+ TIM12.SR                         = 00000000000000000000001000000111                   // status register
+     CC1IF                          ..............................1. - 1               // Capture/compare 1 interrupt flag
+     CC1OF                          ......................1......... - 1               // Capture/Compare 1 overcapture flag
- TIM12.CNT                        = 00000000000000000010000110010100                   // counter
-     CNT                            ................0010000110010100 - 2194            // counter value
+ TIM12.CNT                        = 00000000000000000001110011000001                   // counter
+     CNT                            ................0001110011000001 - 1cc1            // counter value
- TIM12.CCR1                       = 00000000000000000010000110010010                   // capture/compare register 1
-     CCR1                           ................0010000110010010 - 2192            // Capture/Compare 1 value
+ TIM12.CCR1                       = 00000000000000000001110011000001                   // capture/compare register 1
+     CCR1                           ................0001110011000001 - 1cc1            // Capture/Compare 1 value
```
</details>

### Changelog Entry

For release notes:
```
Enable input capture timer for accurate latency measurement.
```

### Test coverage

Verified with debugger and NSH.

@dagar was there a reason the timer was disabled? Does enabling it break other use cases, perhaps when using the same timer in multiple configurations (if that is even supported).
cc @eyeam3 
