### PR TITLE
delete unused ECL_LIB_GIT_VERSION

### DIFF
--- a/src/lib/version/px_update_git_header.py
+++ b/src/lib/version/px_update_git_header.py
@@ -119,21 +119,6 @@ header += f"""
 """
 
 
-# ECL
-if (os.path.exists('src/lib/ecl/.git')):
-    ecl_git_tag = subprocess.check_output('git describe --always --tags --dirty'.split(),
-                                  cwd='src/lib/ecl', stderr=subprocess.STDOUT).decode('utf-8')
-
-    ecl_git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),
-                                      cwd='src/lib/ecl', stderr=subprocess.STDOUT).decode('utf-8').strip()
-    ecl_git_version_short = ecl_git_version[0:16]
-
-    header += f"""
-#define ECL_LIB_GIT_VERSION_STR  "{ecl_git_version}"
-#define ECL_LIB_GIT_VERSION_BINARY 0x{ecl_git_version_short}
-"""
-
-
 # Mavlink
 if (os.path.exists('src/modules/mavlink/mavlink/.git')):
     mavlink_git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -345,14 +345,6 @@ uint64_t px4_firmware_version_binary(void)
 	return PX4_GIT_VERSION_BINARY;
 }
 
-const char *px4_ecl_lib_version_string(void)
-{
-#ifdef ECL_LIB_GIT_VERSION_STRING
-	return ECL_LIB_GIT_VERSION_STRING;
-#else
-	return NULL;
-#endif
-}
 
 #ifdef MAVLINK_LIB_GIT_VERSION_BINARY
 uint64_t px4_mavlink_lib_version_binary(void)

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -180,11 +180,6 @@ __EXPORT const char *px4_firmware_git_branch(void);
 __EXPORT uint64_t px4_firmware_version_binary(void);
 
 /**
- * ECL lib version as human readable string (git tag)
- */
-__EXPORT const char *px4_ecl_lib_version_string(void);
-
-/**
  * MAVLink lib version in binary form (first part of the git tag)
  */
 __EXPORT uint64_t px4_mavlink_lib_version_binary(void);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2075,12 +2075,6 @@ void Logger::write_version(LogType type)
 	write_info(type, "sys_toolchain", px4_toolchain_name());
 	write_info(type, "sys_toolchain_ver", px4_toolchain_version());
 
-	const char *ecl_version = px4_ecl_lib_version_string();
-
-	if (ecl_version && ecl_version[0]) {
-		write_info(type, "sys_lib_ecl_ver", ecl_version);
-	}
-
 	char revision = 'U';
 	const char *chip_name = nullptr;
 


### PR DESCRIPTION
Since 'ecl' is nomore a git submodule, code lines related to 'ECL_LIB_GIT_VERSION' could be deleted

### Solved Problem
I found that in src/lib/version/px_update_git_header.py (line 123) :
~~~
 if (os.path.exists('src/lib/ecl/.git')):
~~~
where 'ecl' used to be a submodule but now does not exist anymore, and  the macro definition 'ECL_LIB_GIT_VERSION' is not referenced by any code, so it could be deleted.

### Solution
- delete unused code

### Test coverage
- tested in sitl