### PR TITLE
FWPosCtrl: Rearrange VTOL transition code into separate functions.

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -242,8 +242,11 @@ private:
 		FW_POSCTRL_MODE_AUTO_TAKEOFF,
 		FW_POSCTRL_MODE_AUTO_LANDING_STRAIGHT,
 		FW_POSCTRL_MODE_AUTO_LANDING_CIRCULAR,
+		FW_POSCTRL_MODE_AUTO_VTOL_TRANSITION_POSITION,
+		FW_POSCTRL_MODE_AUTO_VTOL_TRANSITION_FIXED,
 		FW_POSCTRL_MODE_MANUAL_POSITION,
 		FW_POSCTRL_MODE_MANUAL_ALTITUDE,
+		FW_POSCTRL_MODE_MANUAL_VTOL_TRANSITION,
 		FW_POSCTRL_MODE_OTHER
 	} _control_mode_current{FW_POSCTRL_MODE_OTHER}; // used to check if the mode has changed
 
@@ -390,7 +393,6 @@ private:
 	TECS _tecs;
 
 	bool _reinitialize_tecs{true};
-	bool _tecs_is_running{false};
 	hrt_abstime _time_last_tecs_update{0}; // [us]
 
 	// VTOL / TRANSITION
@@ -511,12 +513,12 @@ private:
 	void update_in_air_states(const hrt_abstime now);
 
 	/**
-	 * @brief Moves the current position setpoint to a value far ahead of the current vehicle yaw when in  a VTOL
+	 * @brief Set the current position setpoint to a value far ahead of the current vehicle yaw when in  a VTOL
 	 * transition.
 	 *
 	 * @param[in,out] current_sp Current position setpoint
 	 */
-	void move_position_setpoint_for_vtol_transition(position_setpoint_s &current_sp);
+	void set_position_setpoint_for_vtol_transition(const position_setpoint_s &current_sp);
 
 	/**
 	 * @brief Changes the position setpoint type to achieve the desired behavior in some instances.
@@ -540,6 +542,26 @@ private:
 	 */
 	void control_auto(const float control_interval, const Vector2d &curr_pos, const Vector2f &ground_speed,
 			  const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr, const position_setpoint_s &pos_sp_next);
+
+	/**
+	 * @brief Automatic position control for VTOL transition
+	 *
+	 * @param curr_pos Current 2D local position vector of vehicle [m]
+	 * @param ground_speed Local 2D ground speed of vehicle [m/s]
+	 * @param pos_sp_curr current position setpoint
+	 */
+	void control_auto_transition_position(const Vector2d &curr_pos, const Vector2f &ground_speed,
+					      const position_setpoint_s &pos_sp_curr);
+
+	/**
+	 * @brief Automatic fixed bank control for VTOL transition
+	 */
+	void control_auto_transition_fixed();
+
+	/**
+	 * @brief Manual control for for VTOL transition
+	 */
+	void control_manual_transition();
 
 	/**
 	 * @brief Controls altitude and airspeed for a fixed-bank loiter.


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
In the FWPosCtrl Module, the logic for the VTOL transition is scattered around inthe module and within several subfunctions. This makes it hard to understand what is executed during a VTOL transition.

### Solution
- Refactor The FWPosCtrl module to have a separate VTOL transition function to handle the FW control part during the transition and remove the scattered code in the control_auto and the tecs_update_pitch_throttle functions.
- **This adds a new behavior. So far the position setpoint was altered to follow the current heading when transition to FW. Is there a reason why this is not done when transition to MC? Previously a transition into MC could happen while the FW part did a steep turn. Is this a wanted behaviour?**

### Changelog Entry
For release notes:
```
Refactor FWPosCtrl: Rearrange VTOl transition into separate function.
```

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
