### PR TITLE
rc_update: throttle trim centering fix for reverse channel

### DIFF
--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -215,8 +215,12 @@ void RCUpdate::parameters_updated()
 		const uint16_t throttle_min = _parameters.min[throttle_channel];
 		const uint16_t throttle_trim = _parameters.trim[throttle_channel];
 		const uint16_t throttle_max = _parameters.max[throttle_channel];
+		const bool throttle_rev = _parameters.rev[throttle_channel];
 
-		if (throttle_min == throttle_trim) {
+		const bool normal_case = !throttle_rev && (throttle_trim == throttle_min);
+		const bool reversed_case = throttle_rev && (throttle_trim == throttle_max);
+
+		if (normal_case || reversed_case) {
 			const uint16_t new_throttle_trim = (throttle_min + throttle_max) / 2;
 			_parameters.trim[throttle_channel] = new_throttle_trim;
 		}


### PR DESCRIPTION
### Solved Problem
When integrating an airframe I found that if the throttle channel is reversed the logic that corrects for QGC calibrating the throttle to half the range (see https://github.com/PX4/PX4-Autopilot/pull/15949#issuecomment-1318728541)

### Solution
- Take care of the case where the channel is reversed because then QGC sets the trim parameter equal to the maximum channel value to achieve the same half range that was in use before #15949.

### Changelog Entry
For release notes:
```
Bugfix: Get full throttle range for QGC RC calibration with reverse throttle channel
```

### Alternatives
This can be removed again once the calibration in QGC is revised and available in a stable release for long enough.

### Test coverage
- I tested this on the real vehicle with SBUS and a reversed throttle.
- I also double-checked that the unreversed normal case still works as expected on the same setup by changing the parameters to a non-reversed throttle case.