### PR TITLE
ekf2_ev: do not reset learned bias

### DIFF
--- a/src/modules/ekf2/EKF/ev_pos_control.cpp
+++ b/src/modules/ekf2/EKF/ev_pos_control.cpp
@@ -230,8 +230,7 @@ void Ekf::updateEvPosFusion(const Vector2f &measurement, const Vector2f &measure
 			if (!_control_status.flags.gps) {
 				ECL_INFO("reset to %s", EV_AID_SRC_NAME);
 				_information_events.flags.reset_pos_to_vision = true;
-				resetHorizontalPositionTo(measurement, measurement_var);
-				_ev_pos_b_est.reset();
+				resetHorizontalPositionTo(measurement - _ev_pos_b_est.getBias(), measurement_var);
 
 			} else {
 				_ev_pos_b_est.setBias(-Vector2f(_state.pos.xy()) + measurement);


### PR DESCRIPTION


### Solved Problem
When fusing GNSS position and EV position, stopping GNSS makes the local position reset to the EV data. The issues is that this could be far from the current location given that the vision source can drift over time. 

Fixes #{Github issue ID}

### Solution
Keep the current estimated EV bias to reset the position.

### Changelog Entry
For release notes:
```
Feature/Bugfix -
New parameter: -
Documentation: -
```

### Alternatives
Do not trigger a reset when the bias estimator starts/stops?

### Test coverage
SITL tests
