### PR TITLE
Motor output ramp consistent for higher than minimum initial motor command

### DIFF
--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -526,21 +526,6 @@ MixingOutput::output_limit_calc(const bool armed, const int num_channels, const 
 
 	/* first evaluate state changes */
 	switch (_output_state) {
-	case OutputLimitState::INIT:
-		if (armed) {
-			// set arming time for the first call
-			if (_output_time_armed == 0) {
-				_output_time_armed = hrt_absolute_time();
-			}
-
-			// time for the ESCs to initialize (this is not actually needed if the signal is sent right after boot)
-			if (hrt_elapsed_time(&_output_time_armed) >= 50_ms) {
-				_output_state = OutputLimitState::OFF;
-			}
-		}
-
-		break;
-
 	case OutputLimitState::OFF:
 		if (armed) {
 			if (_output_ramp_up) {
@@ -589,7 +574,6 @@ MixingOutput::output_limit_calc(const bool armed, const int num_channels, const 
 	// then set _current_output_value based on state
 	switch (local_limit_state) {
 	case OutputLimitState::OFF:
-	case OutputLimitState::INIT:
 		for (int i = 0; i < num_channels; i++) {
 			_current_output_value[i] = _disarmed_value[i];
 		}

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -248,10 +248,9 @@ private:
 
 	enum class OutputLimitState {
 		OFF = 0,
-		INIT,
 		RAMP,
 		ON
-	} _output_state{OutputLimitState::INIT};
+	} _output_state{OutputLimitState::OFF};
 
 	hrt_abstime _output_time_armed{0};
 	const bool _output_ramp_up; ///< if true, motors will ramp up from disarmed to min_output after arming


### PR DESCRIPTION
### Solved Problem
When integrating a product with PWM ESCs I found that the current PWM is suboptimal:

Excpected: When the mixed motor command is exactly the minimum during the ramp time it ramps from the disarmed PWM value to the minimum PWM value.

Unexpected: When the mixed motor command is even just slightly higher than the minimum the ramp jumps up to a higher value than the disarmed PWM value and then ramps from there to the commanded throttle scaled between minimum PWM and maximum PWM. Additionally the first time a vehicle is armed after boot there is a 50 millisecond delay until the ramp actually starts.
<img width="1598" alt="ramp before" src="https://github.com/PX4/PX4-Autopilot/assets/4668506/b6493c74-3447-4296-9678-94bd505715ce">

### Solution
- Replace the complicated ramp calculation with a simpler one that fades the current motor command in with a scale ramping from 0 to 1.
- Remove the ancient init state of the ramp state machine that was introduced in https://github.com/PX4/PX4-Autopilot/commit/cc452834c0dabd2689f5f102ce1cbbe714f056dd#diff-53cf9e4cbf5fe3dc0c623b0be8c562859b714628e061dcfb548c4690311b18d3R186-R195 presumably as a workaround for some specific timing problem in the very very early days. And possibly just produced confusion later on at least for me.

As a result the ramp always starts immediately after arming from the disarmed PWM value and ends at the commanded throttle scaled between minimum PWM and maximum PWM. If the commanded throttle changes during the ramp then the scale and hence also end value of the ramp changes.
<img width="1605" alt="ramp after" src="https://github.com/PX4/PX4-Autopilot/assets/4668506/9c0f2b96-4117-4db0-a1b7-dd8a1ad08372">

### Changelog Entry
For release notes:
```
Bugfix: Make arming motor output ramp consistent for higher than minimum initial motor command
```

### Alternatives
I'm thinking about removing the output ramp on arming completely but this will come as a separate pr and requires more testing.

### Test coverage
- [x] Check if the disarmed value can ever be not set. I saw that we rely on the disarmed value everywhere in the mixer_module and also the PWM drivers set it correctly even if there's just a default disarmed value for all channels.
- [x] Check functionality when the disarmed value is higher than the minimum value. It then ramps down instead of up but still works.
- [x] Check functionality with a reversed output. It ramps from the disarmed value (default 900) up to the reversed throttle value (close to 2000). If the disarmed value is customized to e.g. 2100 then it ramps down so even if I've never seen this case that works. My guess from reading the previous implementation is that this never worked despite extra case handling.
- I bench-tested this solution on two vehicles with PWM ESCs.

### Context
Since https://github.com/PX4/PX4-Autopilot/pull/20031 the throttle even with no roll and pitch torques is not necessarily zero when arming but directly starts at the configured minimum throttle in multicopter modes that have manual throttle control. Also https://github.com/PX4/PX4-Autopilot/pull/21010 can add additional non-zero motor commands while arming.
