### PR TITLE
[1.14] rc_update: throttle trim centering fix for reverse channel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ For release notes:
 ```
 Feature/Bugfix XYZ
 New parameter: XYZ_Z
-Documentation: Need to clarfiy page ... / done, read docs.px4.io/...
+Documentation: Need to clarify page ... / done, read docs.px4.io/...
 ```
 
 ### Alternatives

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -210,8 +210,12 @@ void RCUpdate::parameters_updated()
 		const uint16_t throttle_min = _parameters.min[throttle_channel];
 		const uint16_t throttle_trim = _parameters.trim[throttle_channel];
 		const uint16_t throttle_max = _parameters.max[throttle_channel];
+		const bool throttle_rev = _parameters.rev[throttle_channel];
 
-		if (throttle_min == throttle_trim) {
+		const bool normal_case = !throttle_rev && (throttle_trim == throttle_min);
+		const bool reversed_case = throttle_rev && (throttle_trim == throttle_max);
+
+		if (normal_case || reversed_case) {
 			const uint16_t new_throttle_trim = (throttle_min + throttle_max) / 2;
 			_parameters.trim[throttle_channel] = new_throttle_trim;
 		}


### PR DESCRIPTION
Release port of https://github.com/PX4/PX4-Autopilot/pull/21682

### Changelog Entry
For release notes:
```
Bugfix: Get full throttle range for QGC RC calibration with reverse throttle channel
```
