### PR TITLE
Add source file information to parameter metadata json file

### DIFF
--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -67,6 +67,7 @@ class JsonOutput():
                 if (last_param_name == param.GetName() and not board_specific_param_set) or last_param_name != param.GetName():
                     curr_param=dict()
                     curr_param['name'] = param.GetName()
+                    curr_param['file'] = param.GetPath()
                     type_name = param.GetType().capitalize()
                     curr_param['type'] = type_name
                     if not type_name in allowed_types:

--- a/src/lib/parameters/px4params/jsonout.py
+++ b/src/lib/parameters/px4params/jsonout.py
@@ -67,7 +67,7 @@ class JsonOutput():
                 if (last_param_name == param.GetName() and not board_specific_param_set) or last_param_name != param.GetName():
                     curr_param=dict()
                     curr_param['name'] = param.GetName()
-                    curr_param['file'] = param.GetPath()
+                    curr_param['file'] = param.GetSourceFile()
                     type_name = param.GetType().capitalize()
                     curr_param['type'] = type_name
                     if not type_name in allowed_types:

--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -61,6 +61,7 @@ class Parameter(object):
         self.category = ""
         self.volatile = False
         self.boolean = False
+        self.path = ""
 
     def GetName(self):
         return self.name
@@ -116,6 +117,12 @@ class Parameter(object):
         """
         self.category = category
 
+    def SetPath(self, path):
+        """
+        Set param file path
+        """
+        self.path = path
+
     def GetFieldCodes(self):
         """
         Return list of existing field codes in convenient order
@@ -168,6 +175,12 @@ class Parameter(object):
                 return ""
         return fv.strip()
 
+    def GetPath(self):
+        """
+        Return value of the file path in which the parameter was defined.
+        """
+        return self.path
+
 class SourceParser(object):
     """
     Parses provided data and stores all found parameters internally.
@@ -197,7 +210,7 @@ class SourceParser(object):
     def __init__(self):
         self.param_groups = {}
 
-    def Parse(self, contents):
+    def Parse(self, contents, file):
         """
         Incrementally parse program contents and append all found parameters
         to the list.
@@ -299,6 +312,7 @@ class SourceParser(object):
                     if defval != "" and self.re_is_a_number.match(defval):
                         defval = self.re_cut_type_specifier.sub('', defval)
                     param = Parameter(name, tp, defval)
+                    param.SetPath(file)
                     param.SetField("short_desc", name)
                     # If comment was found before the parameter declaration,
                     # inject its data into the newly created parameter.

--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -61,7 +61,7 @@ class Parameter(object):
         self.category = ""
         self.volatile = False
         self.boolean = False
-        self.path = ""
+        self.file = ""
 
     def GetName(self):
         return self.name
@@ -117,11 +117,11 @@ class Parameter(object):
         """
         self.category = category
 
-    def SetPath(self, path):
+    def SetSourceFile(self, file):
         """
-        Set param file path
+        Set file path of parameter definition (relative to repo root).
         """
-        self.path = path
+        self.file = file
 
     def GetFieldCodes(self):
         """
@@ -175,11 +175,11 @@ class Parameter(object):
                 return ""
         return fv.strip()
 
-    def GetPath(self):
+    def GetSourceFile(self):
         """
-        Return value of the file path in which the parameter was defined.
+        Return value of source file for parameter definition (relative to repo root).
         """
-        return self.path
+        return self.file
 
 class SourceParser(object):
     """
@@ -312,7 +312,6 @@ class SourceParser(object):
                     if defval != "" and self.re_is_a_number.match(defval):
                         defval = self.re_cut_type_specifier.sub('', defval)
                     param = Parameter(name, tp, defval)
-                    param.SetPath(file)
                     param.SetField("short_desc", name)
                     # If comment was found before the parameter declaration,
                     # inject its data into the newly created parameter.
@@ -345,6 +344,16 @@ class SourceParser(object):
                             param.SetEnumValue(def_value, def_values[def_value])
                         for def_bit in def_bitmask:
                             param.SetBitmaskBit(def_bit, def_bitmask[def_bit])
+
+                    # Add source file of parameter
+                    try:
+                        #Only works for non-yaml sources
+                        filefromRoot = file.split('/src/')[1]
+                        filefromRoot = f'src/{filefromRoot}'
+                        param.SetSourceFile(filefromRoot)
+                    except:
+                        pass
+
                     # Store the parameter
                     if group not in self.param_groups:
                         self.param_groups[group] = ParameterGroup(group)

--- a/src/lib/parameters/px4params/srcscanner.py
+++ b/src/lib/parameters/px4params/srcscanner.py
@@ -42,4 +42,4 @@ class SourceScanner(object):
                 contents = ''
                 print('Failed reading file: %s, skipping content.' % path)
                 pass
-        return parser.Parse(contents)
+        return parser.Parse(contents, path)


### PR DESCRIPTION
This adds the source file information for each parameter to the `json` output file. It looks like this.

```
      "category": "Standard",
      "default": 1,
      "file": "src/drivers/gps/params.c",
      "group": "GPS",
```

This is the first step in allowing the parameter information to be injected into the modules documentation - because with this we can map modules to their associated parameters.

I chose not to output in XML, which is used by QGC (I understand) and it is not needed in the markdown for parameters.

@bkueng It "works", but might not be to your taste.