### PR TITLE
navigator: send commands to anyone listening

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1428,7 +1428,7 @@ void Navigator::publish_vehicle_cmd(vehicle_command_s *vcmd)
 		break;
 
 	default:
-		vcmd->target_component = _vstatus.component_id;
+		vcmd->target_component = 0;
 		break;
 	}
 


### PR DESCRIPTION
### Solved Problem
 POI commands that are part of a mission do not work when the gimbal is controlled by a companion computer. 

### Solution
Send commands to anyone listening. 

### Test coverage
We have been flying with that change for some years now.


