### PR TITLE
[BACKPORT v1.13] gps: add support for uBlox M10 chip

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -824,7 +824,7 @@ GPS::run()
 		/* FALLTHROUGH */
 		case gps_driver_mode_t::UBX:
 			_helper = new GPSDriverUBX(_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info,
-						   gps_ubx_dynmodel, heading_offset, ubx_mode);
+						   gps_ubx_dynmodel, heading_offset, 230400, ubx_mode);
 			set_device_type(DRV_GPS_DEVTYPE_UBX);
 			break;
 #ifndef CONSTRAINED_FLASH


### PR DESCRIPTION
This backports most UBX related changes required to get the uBlox M10 chip to with v1.13.

Also see: https://github.com/PX4/PX4-GPSDrivers/pull/134

FYI @vincentpoont2 