### PR TITLE
ekf2: Fix description of EKF2_HDG_GATE

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -445,7 +445,7 @@ PARAM_DEFINE_FLOAT(EKF2_BETA_GATE, 5.0f);
 PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 0.3f);
 
 /**
- * Gate size for magnetic heading fusion
+ * Gate size for heading fusion
  *
  * Sets the number of standard deviations used by the innovation consistency test.
  *


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

The description of EKF2_HDG_GATE made me assume this parameter was irrelevant for a vehicle that doesn't use a magnetometer:

I'm working on a multicopter with external odometry input (via mavlink ODOMETRY type VISION). I want the external odometry system's heading to always be trusted, so I had set EKF2_HDG_GATE very high. Later, having forgotten about the original reason for setting EKF2_HDG_GATE, I found that the docs for this parameter say "Gate size for magnetic heading fusion". Since I do not use a magnetometer, this made me think I'd set this parameter by mistake, so I reset it to the default value. When flying, it became clear that it does indeed also affect yaw estimation with only external vision/odometry yaw, but the parameter description is a bit misleading.

### Solution
The simplest fix is to just not mention "magnetometer" in the description of EKF2_HDG_GATE.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Clarified description of EKF2_HDG_GATE
```

### Alternatives
Not sure, maybe separate parameters for magnetometer heading fusion and other types of heading fusion, but that seems overkill.

### Test coverage
N/A

### Context

I verified that EKF2_HDG_GATE does affect my system (no magnetometer, using external odometry), by

1. Flying, and seeing that with low EKF2_HDG_GATE, PX4's heading can diverge from the odemetry's yaw. This does not happen when EKF2_HDG_GATE is set to a high value.
2. Looking at the call sequence:
    * mavlink_receiver gets mavlink ODOMETRY type VISION
    * published as uorb vehicle_visual_odometry
    * received by the ekf, calls `setExtVisionData`
    * data pushed into the `_ext_vision_buffer`
    * `Ekf::update` runs
    * `Ekf::controlFusionModes`
    * `Ekf::controlExternalVisionFusion`
    * `Ekf::controlEvYawFusion`
    * `Ekf::fuseYaw(3 args)`
    * `Ekf::fuseYaw(4 args)`
    * this uses `_params.heading_innov_gate` which is EKF2_HDG_GATE
    * (it seems to also be used in `Ekf::updateGpsYaw`)

