### PR TITLE
Fix PWM/Oneshot calibration

### DIFF
--- a/src/drivers/actuators/modal_io/modal_io.cpp
+++ b/src/drivers/actuators/modal_io/modal_io.cpp
@@ -48,7 +48,6 @@ const char *_device;
 
 ModalIo::ModalIo() :
 	OutputModuleInterface(MODULE_NAME, px4::serial_port_to_wq(MODAL_IO_DEFAULT_PORT)),
-	_mixing_output{"MODAL_IO", MODAL_IO_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, false, false},
 	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")),
 	_output_update_perf(perf_alloc(PC_INTERVAL, MODULE_NAME": output update interval"))
 {

--- a/src/drivers/actuators/modal_io/modal_io.hpp
+++ b/src/drivers/actuators/modal_io/modal_io.hpp
@@ -174,7 +174,7 @@ private:
 	} led_rsc_t;
 
 	ch_assign_t		_output_map[MODAL_IO_OUTPUT_CHANNELS] {{1, 1}, {2, 1}, {3, 1}, {4, 1}};
-	MixingOutput 		_mixing_output;
+	MixingOutput _mixing_output{"MODAL_IO", MODAL_IO_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 
 	perf_counter_t		_cycle_perf;
 	perf_counter_t		_output_update_perf;

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -143,7 +143,7 @@ private:
 
 	void handle_vehicle_commands();
 
-	MixingOutput _mixing_output {PARAM_PREFIX, DIRECT_PWM_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
+	MixingOutput _mixing_output{PARAM_PREFIX, DIRECT_PWM_OUTPUT_CHANNELS, *this, MixingOutput::SchedulingPolicy::Auto, false, false};
 	uint32_t _reversible_outputs{};
 
 	Telemetry *_telemetry{nullptr};

--- a/src/lib/mixer_module/actuator_test.cpp
+++ b/src/lib/mixer_module/actuator_test.cpp
@@ -75,7 +75,7 @@ void ActuatorTest::update(int num_outputs, float thrust_curve)
 					float value = actuator_test.value;
 
 					// handle motors
-					if (actuator_test.function >= (int)OutputFunction::Motor1 && actuator_test.function <= (int)OutputFunction::MotorMax) {
+					if ((int)OutputFunction::Motor1 <= actuator_test.function && actuator_test.function <= (int)OutputFunction::MotorMax) {
 						actuator_motors_s motors;
 						motors.reversible_flags = 0;
 						_actuator_motors_sub.copy(&motors);
@@ -84,7 +84,7 @@ void ActuatorTest::update(int num_outputs, float thrust_curve)
 					}
 
 					// handle servos: add trim
-					if (actuator_test.function >= (int)OutputFunction::Servo1 && actuator_test.function <= (int)OutputFunction::ServoMax) {
+					if ((int)OutputFunction::Servo1 <= actuator_test.function && actuator_test.function <= (int)OutputFunction::ServoMax) {
 						actuator_servos_trim_s trim{};
 						_actuator_servos_trim_sub.copy(&trim);
 						int idx = actuator_test.function - (int)OutputFunction::Servo1;

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -490,6 +490,24 @@ MixingOutput::limitAndUpdateOutputs(float outputs[MAX_ACTUATORS], bool has_updat
 		output_limit_calc(_throttle_armed || _actuator_test.inTestMode(), _max_num_outputs, outputs);
 	}
 
+	// We must calibrate the PWM and Oneshot ESCs to a consistent range of 1000-2000us (gets mapped to 125-250us for Oneshot)
+	// Doing so makes calibrations consistent among different configurations and hence PWM minimum and maximum have a consistent effect
+	// hence the defaults for these parameters also make most setups work out of the box
+	if (_armed.in_esc_calibration_mode) {
+		static constexpr uint16_t PWM_CALIBRATION_LOW = 1000;
+		static constexpr uint16_t PWM_CALIBRATION_HIGH = 2000;
+
+		for (int i = 0; i < _max_num_outputs; i++) {
+			if (_current_output_value[i] == _min_value[i]) {
+				_current_output_value[i] = PWM_CALIBRATION_LOW;
+			}
+
+			if (_current_output_value[i] == _max_value[i]) {
+				_current_output_value[i] = PWM_CALIBRATION_HIGH;
+			}
+		}
+	}
+
 	/* now return the outputs to the driver */
 	if (_interface.updateOutputs(stop_motors, _current_output_value, _max_num_outputs, has_updates)) {
 		actuator_outputs_s actuator_outputs{};

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -58,18 +58,19 @@ using namespace time_literals;
 
 bool check_battery_disconnected(orb_advert_t *mavlink_log_pub)
 {
-	uORB::SubscriptionData<battery_status_s> batt_sub{ORB_ID(battery_status)};
-	const battery_status_s &battery = batt_sub.get();
-	batt_sub.update();
+	uORB::SubscriptionData<battery_status_s> battery_status_sub{ORB_ID(battery_status)};
+	battery_status_sub.update();
 
-	if (battery.timestamp == 0) {
-		calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "battery unavailable");
+	const bool recent_battery_measurement = (hrt_absolute_time() - battery_status_sub.get().timestamp) < 1_s;
+
+	if (!recent_battery_measurement) {
+		// We have to send this message for now because "battery unavailable" gets ignored by QGC
+		calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "Disconnect battery and try again");
 		return false;
 	}
 
-	// Make sure battery is disconnected
-	// battery is not connected if the connected flag is not set and we have a recent battery measurement
-	if (!battery.connected && (hrt_elapsed_time(&battery.timestamp) < 500_ms)) {
+	// Make sure battery is reported to be disconnected
+	if (recent_battery_measurement && !battery_status_sub.get().connected) {
 		return true;
 	}
 
@@ -93,66 +94,79 @@ static void set_motor_actuators(uORB::Publication<actuator_test_s> &publisher, f
 
 int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 {
-	calibration_log_info(mavlink_log_pub, CAL_QGC_STARTED_MSG, "esc");
+	// 1 Initialization
+	bool calibration_failed = false;
 
-	int	return_code = PX4_OK;
 	uORB::Publication<actuator_test_s> actuator_test_pub{ORB_ID(actuator_test)};
 	// since we publish multiple at once, make sure the output driver subscribes before we publish
 	actuator_test_pub.advertise();
-	px4_usleep(10000);
 
-	// set motors to high
+	uORB::SubscriptionData<battery_status_s> battery_status_sub{ORB_ID(battery_status)};
+	battery_status_sub.update();
+	const bool battery_connected_before_calibration = battery_status_sub.get().connected;
+	const float current_before_calibration = battery_status_sub.get().current_a;
+
+	calibration_log_info(mavlink_log_pub, CAL_QGC_STARTED_MSG, "esc");
+
+	px4_usleep(10_ms);
+
+	// 2 Set motors to high
 	set_motor_actuators(actuator_test_pub, 1.f, false);
 	calibration_log_info(mavlink_log_pub, "[cal] Connect battery now");
 
-
-	uORB::SubscriptionData<battery_status_s> batt_sub{ORB_ID(battery_status)};
-	const battery_status_s &battery = batt_sub.get();
-	batt_sub.update();
-	bool batt_connected = battery.connected;
 	hrt_abstime timeout_start = hrt_absolute_time();
 
+	// 3 Wait for user to connect power
 	while (true) {
-		// We are either waiting for the user to connect the battery. Or we are waiting to let the PWM
-		// sit high.
-		static constexpr hrt_abstime battery_connect_wait_timeout{20_s};
-		static constexpr hrt_abstime pwm_high_timeout{3_s};
-		hrt_abstime timeout_wait = batt_connected ? pwm_high_timeout : battery_connect_wait_timeout;
+		hrt_abstime now = hrt_absolute_time();
+		battery_status_sub.update();
 
-		if (hrt_elapsed_time(&timeout_start) > timeout_wait) {
-			if (!batt_connected) {
-				calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "Timeout waiting for battery");
-				return_code = PX4_ERROR;
-			}
-
-			// PWM was high long enough
+		if ((now - timeout_start) < 1_s && (battery_status_sub.get().current_a > current_before_calibration + 1.f)) {
+			// Safety termination, current rises immediately, user didn't unplug power before
+			calibration_failed = true;
 			break;
 		}
 
-		if (!batt_connected) {
-			if (batt_sub.update()) {
-				if (battery.connected) {
-					// Battery is connected, signal to user and start waiting again
-					batt_connected = true;
-					timeout_start = hrt_absolute_time();
-					calibration_log_info(mavlink_log_pub, "[cal] Battery connected");
-				}
-			}
+		if (!battery_connected_before_calibration && battery_status_sub.get().connected) {
+			// Battery connection detected we can go to the next step immediately
+			break;
 		}
 
-		px4_usleep(50000);
+		if ((now - timeout_start) > 10_s) {
+			// Timeout, we abort here
+			calibration_failed = true;
+			break;
+		}
+
+		px4_usleep(50_ms);
 	}
 
-	if (return_code == PX4_OK) {
-		// set motors to low
+	// 4 Wait for ESCs to measure high signal
+	if (!calibration_failed) {
+		calibration_log_info(mavlink_log_pub, "[cal] Battery connected");
+		px4_usleep(8_s);
+	}
+
+	// 5 Set motors to low
+	if (!calibration_failed) {
 		set_motor_actuators(actuator_test_pub, 0.f, false);
-		px4_usleep(4000000);
-
-		// release control
-		set_motor_actuators(actuator_test_pub, 0.f, true);
-
-		calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, "esc");
 	}
 
-	return return_code;
+	// 6 Wait for ESCs to measure low signal
+	if (!calibration_failed) {
+		px4_usleep(8_s);
+	}
+
+	// 7 release control
+	set_motor_actuators(actuator_test_pub, 0.f, true);
+
+	// 8 Report
+	if (calibration_failed) {
+		calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "Timeout waiting for battery");
+		return PX4_ERROR;
+
+	} else {
+		calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, "esc");
+		return PX4_OK;
+	}
 }

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -133,8 +133,9 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 		}
 
 		if ((now - timeout_start) > 6_s) {
-			// Timeout, we abort here
-			calibration_failed = true;
+			// Timeout, we continue since maybe the battery cannot be detected properly
+			// If we abort here and the ESCs are infact connected and started calibrating
+			// they will measure the disarmed value as the lower limit instead of the fixed 1000us
 			break;
 		}
 

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -132,7 +132,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 			break;
 		}
 
-		if ((now - timeout_start) > 10_s) {
+		if ((now - timeout_start) > 6_s) {
 			// Timeout, we abort here
 			calibration_failed = true;
 			break;
@@ -144,7 +144,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 	// 4 Wait for ESCs to measure high signal
 	if (!calibration_failed) {
 		calibration_log_info(mavlink_log_pub, "[cal] Battery connected");
-		px4_usleep(8_s);
+		px4_usleep(3_s);
 	}
 
 	// 5 Set motors to low
@@ -154,7 +154,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub)
 
 	// 6 Wait for ESCs to measure low signal
 	if (!calibration_failed) {
-		px4_usleep(8_s);
+		px4_usleep(5_s);
 	}
 
 	// 7 release control


### PR DESCRIPTION
### Solved Problem
When testing https://github.com/PX4/PX4-Autopilot/pull/21513 I found (again) that PWM calibration does not do what I expect and leads to it almost being impossible to configure PWM outputs consistently once a calibration was performed. That's why I opened #21634 and want to fix that first.

Fixes #21634 

### Solution
- Make PWM calibration range consistent 1000-2000us (which maps to 125-250us for Oneshot) independent of minimum and maximum PWM configuration. These parameters represent the PWM value where the motors start spinning and stops going faster and producing more thrust. These definitions are separate from the calibration and do not match the same values for any ESC I've ever used. This was also discussed for example here: https://github.com/PX4/PX4-Autopilot/pull/11663#issuecomment-473406492
- Make sure the motor output is always released and reverts to normal operation after a calibration even if it fails!
- Change the timing of the ESC calibration to mostly give more time for the calibration. It's worth to give the ESC enough time for the steps compared to having some ESCs fail or calibrate to wrong values. In my experience the ESC's timeouts are pretty long because the calibration process is originally a manual one.
- I added a safety check where an increase in measured current upon applying the high PWM value leats to an immediate abortion. I did this because on my test setup, the battery detection doesn't work reliably and this is an additional layer of preventing a screw-up.

### Changelog Entry
For release notes:
```
Bugfix: Fix PWM/Oneshot calibration to consistent range
Documentation: Need to clarify https://docs.px4.io/main/en/advanced_config/esc_calibration.html#esc-calibration 
```

### Alternatives
~I want to also allow PWM calibration when the battery detection is not possible e.g. because the user has no power module or it needs to stay connected to power the autopilot. I suggest we take this PR without additional functionality together with https://github.com/PX4/PX4-Autopilot/pull/21513 first for the 1.14 release and deal with the manual calibration with the corresponding UI as a next step. The problem right now is the tight integration with the QGC UI being very limited. The first step would be to at least have a backward-compatible MAVLink shell way of doing that.~

**EDIT:** I allowed to calibrate without battery detection because of the following reasons:
- There are many setups where at the time of ESC calibration the user has either no power module or it needs to stay connected to power the autopilot.
- Without this the ESC calibration aborts after a timeout if battery detection doesn't work. The problem is if the user still connects the battery as he gets instructed to and the calibration aborts then the ESCs are in calibration mode and after abortion just calibrate to the wrong value.
- There's no additional safety by aborting the calibration if the battery cannot be detected during the timeout because a pixhawk board without power module will report a battery status from the ADC driverand in it that no battery is connected which is the best it can do. In this situation the motors will still spin if the ESCs are powered.

So the only disadvantage is that the UI does not show when the user did actually not plug the battery which is much less bad than not allowing a calibration at all and aborting in the worst moment which makes the ESC calibrate to the wrong value. So I suggest this as the in-between step and fixing the UI next.

### Test coverage
- Hardware testing of PWM and Oneshot on [Holybro QAV250](https://holybro.com/products/qav250-kit) with pixhawk 4 mini. I get extremely consistent calibrations with well better tolerances than what's needed for useful vehicle operation.

![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/f576eef5-b993-42bd-b85f-d0dcdb4499cc)

I'm testing with more ESCs now.