### PR TITLE
Allow user to specify Gazebo Garden render engine in simulations

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -53,6 +53,13 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; th
 		# "gz sim" from Garden on
 		gz_command="gz"
 		gz_sub_command="sim"
+		
+		# Specify render engine if `GZ_SIM_RENDER_ENGINE` is set
+    		# (for example, if you want to use Ogre 1.x instead of Ogre 2.x):
+    		if [ -n "${PX4_GZ_SIM_RENDER_ENGINE}" ]; then
+      			echo "[WARNING] Setting Gazebo Sim engine to '${PX4_GZ_SIM_RENDER_ENGINE}'!"
+      			gz_sub_command="${gz_sub_command} --render-engine ${PX4_GZ_SIM_RENDER_ENGINE}"
+    		fi
 	else
 		echo "ERROR [init] Gazebo gz please install gz-garden"
 		exit 1

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -57,7 +57,7 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; th
 		# Specify render engine if `GZ_SIM_RENDER_ENGINE` is set
     		# (for example, if you want to use Ogre 1.x instead of Ogre 2.x):
     		if [ -n "${PX4_GZ_SIM_RENDER_ENGINE}" ]; then
-      			echo "[WARNING] Setting Gazebo Sim engine to '${PX4_GZ_SIM_RENDER_ENGINE}'!"
+      			echo "INFO  [init] Setting Gazebo render engine to '${PX4_GZ_SIM_RENDER_ENGINE}'!"
       			gz_sub_command="${gz_sub_command} --render-engine ${PX4_GZ_SIM_RENDER_ENGINE}"
     		fi
 	else


### PR DESCRIPTION
## Allow user to specify Gazebo Garden render engine in simulations

Hi! I am running simulations on the system which does not supports Ogre 2.x (actually it's Parallels over Apple Silicon which has a limited support for the newest OpengGL). This can be fixed by downgrading to earlier Ogre version [as described](https://gazebosim.org/docs/garden/troubleshooting#ubuntu) in Gazebo documentation.

We probably have to mention this workaround in documentation.

### Solved Problem

Allow running simulations on Gazebo Garden for systems which do not support Ogre 2.x.

### Solution

Add `--render-engine` argument if `PX4_GZ_SIM_RENDER_ENGINE` environment variable is set.

For example:

```shell
PX4_GZ_SIM_RENDER_ENGINE=ogre make px4_sitl gz_x500
```
