### PR TITLE
FW Rate Controller: fix saturation logic for VTOLs with differential thrust enabled

### DIFF
--- a/src/lib/rate_control/rate_control.cpp
+++ b/src/lib/rate_control/rate_control.cpp
@@ -47,11 +47,25 @@ void RateControl::setPidGains(const Vector3f &P, const Vector3f &I, const Vector
 	_gain_d = D;
 }
 
-void RateControl::setSaturationStatus(const Vector<bool, 3> &saturation_positive,
-				      const Vector<bool, 3> &saturation_negative)
+void RateControl::setSaturationStatus(const Vector3<bool> &saturation_positive,
+				      const Vector3<bool> &saturation_negative)
 {
 	_control_allocator_saturation_positive = saturation_positive;
 	_control_allocator_saturation_negative = saturation_negative;
+}
+
+void RateControl::setPositiveSaturationFlag(size_t axis, bool is_saturated)
+{
+	if (axis < 3) {
+		_control_allocator_saturation_positive(axis) = is_saturated;
+	}
+}
+
+void RateControl::setNegativeSaturationFlag(size_t axis, bool is_saturated)
+{
+	if (axis < 3) {
+		_control_allocator_saturation_negative(axis) = is_saturated;
+	}
 }
 
 Vector3f RateControl::update(const Vector3f &rate, const Vector3f &rate_sp, const Vector3f &angular_accel,

--- a/src/lib/rate_control/rate_control.hpp
+++ b/src/lib/rate_control/rate_control.hpp
@@ -75,8 +75,16 @@ public:
 	 * Set saturation status
 	 * @param control saturation vector from control allocator
 	 */
-	void setSaturationStatus(const matrix::Vector<bool, 3> &saturation_positive,
-				 const matrix::Vector<bool, 3> &saturation_negative);
+	void setSaturationStatus(const matrix::Vector3<bool> &saturation_positive,
+				 const matrix::Vector3<bool> &saturation_negative);
+
+	/**
+	 * Set individual saturation flags
+	 * @param axis 0 roll, 1 pitch, 2 yaw
+	 * @param is_saturated value to update the flag with
+	 */
+	void setPositiveSaturationFlag(size_t axis, bool is_saturated);
+	void setNegativeSaturationFlag(size_t axis, bool is_saturated);
 
 	/**
 	 * Run one control loop cycle calculation

--- a/src/modules/fw_rate_control/FixedwingRateControl.cpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.cpp
@@ -48,6 +48,8 @@ FixedwingRateControl::FixedwingRateControl(bool vtol) :
 	_vehicle_thrust_setpoint_pub(vtol ? ORB_ID(vehicle_thrust_setpoint_virtual_fw) : ORB_ID(vehicle_thrust_setpoint)),
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle"))
 {
+	_handle_param_vt_fw_difthr_en = param_find("VT_FW_DIFTHR_EN");
+
 	/* fetch initial parameter values */
 	parameters_update();
 
@@ -85,6 +87,10 @@ FixedwingRateControl::parameters_update()
 	_rate_control.setFeedForwardGain(
 		// set FF gains to 0 as we add the FF control outside of the rate controller
 		Vector3f(0.f, 0.f, 0.f));
+
+	if (_handle_param_vt_fw_difthr_en != PARAM_INVALID) {
+		param_get(_handle_param_vt_fw_difthr_en, &_param_vt_fw_difthr_en);
+	}
 
 
 	return PX4_OK;
@@ -281,9 +287,9 @@ void FixedwingRateControl::Run()
 			// Update saturation status from control allocation feedback
 			// TODO: send the unallocated value directly for better anti-windup
 			Vector3<bool> diffthr_enabled(
-				_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::ROLL_BIT),
-				_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::PITCH_BIT),
-				_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::YAW_BIT)
+				_param_vt_fw_difthr_en & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::ROLL_BIT),
+				_param_vt_fw_difthr_en & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::PITCH_BIT),
+				_param_vt_fw_difthr_en & static_cast<int32_t>(VTOLFixedWingDifferentialThrustEnabledBit::YAW_BIT)
 			);
 
 			if (_vehicle_status.is_vtol_tailsitter) {

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -144,6 +144,13 @@ private:
 
 	bool _in_fw_or_transition_wo_tailsitter_transition{false}; // only run the FW attitude controller in these states
 
+	// enum for bitmask of VT_FW_DIFTHR_EN parameter options
+	enum class VTOLFixedWingDifferentialThrustEnabledBit : int32_t {
+		YAW_BIT = (1 << 0),
+		ROLL_BIT = (1 << 1),
+		PITCH_BIT = (1 << 2),
+	};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::FW_ACRO_X_MAX>) _param_fw_acro_x_max,
 		(ParamFloat<px4::params::FW_ACRO_Y_MAX>) _param_fw_acro_y_max,
@@ -194,7 +201,8 @@ private:
 		(ParamFloat<px4::params::TRIM_ROLL>) _param_trim_roll,
 		(ParamFloat<px4::params::TRIM_YAW>) _param_trim_yaw,
 
-		(ParamInt<px4::params::FW_SPOILERS_MAN>) _param_fw_spoilers_man
+		(ParamInt<px4::params::FW_SPOILERS_MAN>) _param_fw_spoilers_man,
+		(ParamInt<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en
 	)
 
 	RateControl _rate_control; ///< class for rate control calculations

--- a/src/modules/fw_rate_control/FixedwingRateControl.hpp
+++ b/src/modules/fw_rate_control/FixedwingRateControl.hpp
@@ -151,6 +151,9 @@ private:
 		PITCH_BIT = (1 << 2),
 	};
 
+	param_t _handle_param_vt_fw_difthr_en{PARAM_INVALID};
+	int32_t _param_vt_fw_difthr_en{0};
+
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::FW_ACRO_X_MAX>) _param_fw_acro_x_max,
 		(ParamFloat<px4::params::FW_ACRO_Y_MAX>) _param_fw_acro_y_max,
@@ -201,8 +204,7 @@ private:
 		(ParamFloat<px4::params::TRIM_ROLL>) _param_trim_roll,
 		(ParamFloat<px4::params::TRIM_YAW>) _param_trim_yaw,
 
-		(ParamInt<px4::params::FW_SPOILERS_MAN>) _param_fw_spoilers_man,
-		(ParamInt<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en
+		(ParamInt<px4::params::FW_SPOILERS_MAN>) _param_fw_spoilers_man
 	)
 
 	RateControl _rate_control; ///< class for rate control calculations


### PR DESCRIPTION
Context: https://github.com/PX4/PX4-Autopilot/issues/21501#issuecomment-1584754445


### Solved Problem
Actuator saturation logic in the FW rate controller was not working as intended if the actuators for a certain axis aren't in the matrix 1 (servo matrix) for VTOL. That led to the rate controller being very often disabled as the controller thought it the axis was saturated. That in turn leads to very bad rate tracking. 
It is most prominent when flying a Quad tailsitter without control surfaces, as in this case all 3 axis are affected. 

### Solution
Add logic for when to use which allocation matrix.

### Changelog Entry
For release notes:
```
Bugfix: fix actuator saturation handling for VTOLs with differential thrust in fixed-wing flight
```

### Alternatives
We need to work towards keeping this customization per vehicle in the allocation.

### Test coverage
SITL tested. 


I would port this to 1.14.