### PR TITLE
Navigator: Resume mission with last flight speed

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1483,17 +1483,18 @@ Mission::heading_sp_update()
 void
 Mission::cruising_speed_sp_update()
 {
+	// allows speed changes made via mavlink to be applied immediately in a mission
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	const float cruising_speed = _navigator->get_cruising_speed();
+	const float new_cruising_speed_setpoint = _navigator->get_cruising_speed();
 
 	/* Don't change setpoint if the current waypoint is not valid */
 	if (!pos_sp_triplet->current.valid ||
-	    fabsf(pos_sp_triplet->current.cruising_speed - cruising_speed) < FLT_EPSILON) {
+	    fabsf(pos_sp_triplet->current.cruising_speed - new_cruising_speed_setpoint) < FLT_EPSILON) {
 		return;
 	}
 
-	pos_sp_triplet->current.cruising_speed = cruising_speed;
+	pos_sp_triplet->current.cruising_speed = new_cruising_speed_setpoint;
 
 	publish_navigator_mission_item();
 	_navigator->set_position_setpoint_triplet_updated();

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -2106,7 +2106,7 @@ void Mission::replayCachedTriggerItems()
 
 void Mission::replayCachedSpeedChangeItems()
 {
-	if (_last_speed_change_item.nav_cmd > 0) {
+	if (_last_speed_change_item.nav_cmd == NAV_CMD_DO_CHANGE_SPEED) {
 		issue_command(_last_speed_change_item);
 		_last_speed_change_item = {}; // delete cached item
 	}

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -305,11 +305,6 @@ Mission::on_active()
 		}
 	}
 
-	/* check if a cruise speed change has been commanded */
-	if (_mission_type != MISSION_TYPE_NONE) {
-		cruising_speed_sp_update();
-	}
-
 	/* see if we need to update the current yaw heading */
 	if (!_param_mis_mnt_yaw_ctl.get()
 	    && (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING)
@@ -1481,26 +1476,6 @@ Mission::heading_sp_update()
 		publish_navigator_mission_item();
 		_navigator->set_position_setpoint_triplet_updated();
 	}
-}
-
-void
-Mission::cruising_speed_sp_update()
-{
-	// allows speed changes made via mavlink to be applied immediately in a mission
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
-	const float new_cruising_speed_setpoint = _navigator->get_cruising_speed();
-
-	/* Don't change setpoint if the current waypoint is not valid */
-	if (!pos_sp_triplet->current.valid ||
-	    fabsf(pos_sp_triplet->current.cruising_speed - new_cruising_speed_setpoint) < FLT_EPSILON) {
-		return;
-	}
-
-	pos_sp_triplet->current.cruising_speed = new_cruising_speed_setpoint;
-
-	publish_navigator_mission_item();
-	_navigator->set_position_setpoint_triplet_updated();
 }
 
 void

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -296,6 +296,12 @@ private:
 	void replayCachedTriggerItems();
 
 	/**
+	 * @brief Replay the cached speed change items and delete them afterwards
+	 *
+	 */
+	void replayCachedSpeedChangeItems();
+
+	/**
 	 * @brief Reset the item cache
 	 */
 	void resetItemCache();
@@ -373,4 +379,5 @@ private:
 	mission_item_s _last_gimbal_control_item {};
 	mission_item_s _last_camera_mode_item {};
 	mission_item_s _last_camera_trigger_item {};
+	mission_item_s _last_speed_change_item {};
 };

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -164,11 +164,6 @@ private:
 	void heading_sp_update();
 
 	/**
-	 * Update the cruising speed setpoint.
-	 */
-	void cruising_speed_sp_update();
-
-	/**
 	 * Abort landing
 	 */
 	void do_abort_landing();

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -385,8 +385,6 @@ private:
 	float _param_mpc_jerk_auto{4.f}; 	/**< initialized with the default jerk auto value to prevent division by 0 if the parameter is accidentally set to 0 */
 	float _param_mpc_acc_hor{3.f};		/**< initialized with the default horizontal acc value to prevent division by 0 if the parameter is accidentally set to 0 */
 
-	// float _mission_cruising_speed_mc{-1.0f};
-	// float _mission_cruising_speed_fw{-1.0f};
 	float _cruising_speed_current_mode{-1.0f};
 	float _mission_throttle{NAN};
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -199,25 +199,21 @@ public:
 	 *
 	 * @return the desired cruising speed for this mission
 	 */
-	float get_cruising_speed();
+	float get_cruising_speed() { return _cruising_speed_current_mode; }
 
 	/**
 	 * Set the cruising speed
 	 *
-	 * Passing a negative value or leaving the parameter away will reset the cruising speed
-	 * to its default value.
-	 *
-	 * For VTOL: sets cruising speed for current mode only (multirotor or fixed-wing).
-	 *
+	 * Passing a negative value will reset the cruising speed
+	 * to its default value. Will automatically be reset to default
+	 * on mode switch.
 	 */
-	void set_cruising_speed(float speed = -1.0f);
+	void set_cruising_speed(float desired_speed) { _cruising_speed_current_mode = desired_speed; }
 
 	/**
 	 * Reset cruising speed to default values
-	 *
-	 * For VTOL: resets both cruising speeds.
 	 */
-	void reset_cruising_speed();
+	void reset_cruising_speed() { _cruising_speed_current_mode = -1.f; }
 
 	/**
 	 *  Set triplets to invalid
@@ -389,8 +385,9 @@ private:
 	float _param_mpc_jerk_auto{4.f}; 	/**< initialized with the default jerk auto value to prevent division by 0 if the parameter is accidentally set to 0 */
 	float _param_mpc_acc_hor{3.f};		/**< initialized with the default horizontal acc value to prevent division by 0 if the parameter is accidentally set to 0 */
 
-	float _mission_cruising_speed_mc{-1.0f};
-	float _mission_cruising_speed_fw{-1.0f};
+	// float _mission_cruising_speed_mc{-1.0f};
+	// float _mission_cruising_speed_fw{-1.0f};
+	float _cruising_speed_current_mode{-1.0f};
 	float _mission_throttle{NAN};
 
 	traffic_buffer_s _traffic_buffer{};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -605,7 +605,7 @@ void Navigator::run()
 					set_cruising_speed(cmd.param2);
 
 				} else {
-					set_cruising_speed();
+					reset_cruising_speed();
 
 					/* if no speed target was given try to set throttle */
 					if (cmd.param3 > FLT_EPSILON) {
@@ -1142,43 +1142,6 @@ float Navigator::get_altitude_acceptance_radius()
 
 		return alt_acceptance_radius;
 	}
-}
-
-float Navigator::get_cruising_speed()
-{
-	/* there are three options: The mission-requested cruise speed, or the current hover / plane speed */
-	if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-		if (_mission_cruising_speed_mc > 0.0f) {
-			return _mission_cruising_speed_mc;
-
-		} else {
-			return -1.0f;
-		}
-
-	} else {
-		if (_mission_cruising_speed_fw > 0.0f) {
-			return _mission_cruising_speed_fw;
-
-		} else {
-			return -1.0f;
-		}
-	}
-}
-
-void Navigator::set_cruising_speed(float speed)
-{
-	if (_vstatus.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-		_mission_cruising_speed_mc = speed;
-
-	} else {
-		_mission_cruising_speed_fw = speed;
-	}
-}
-
-void Navigator::reset_cruising_speed()
-{
-	_mission_cruising_speed_mc = -1.0f;
-	_mission_cruising_speed_fw = -1.0f;
 }
 
 void Navigator::reset_triplets()


### PR DESCRIPTION
Based on https://github.com/PX4/PX4-Autopilot/pull/21710

### Solved Problem
On resuming a mission, the flight speed was reset to the vehicle default. Especially for surveys this is not acceptable. 

### Solution
Further extend the ideas from https://github.com/PX4/PX4-Autopilot/pull/21710: some mission items contain not momentary setpoints (like go to point A), but instead contain settings that are then relevant for the whole mission (or until over-turned by a negating command). 
DO_CHANGE_SPEED items belong to the same category as eg camera settings: you want to re-apply them when resuming a mission. 

I've further removed the separated mc/fw stored flight speeds, as it's only ever needed to store the speed of the current mode we're in, and we reset it during VTOL transitions. 

### Changelog Entry

```
Feature: Resume mission with flight speed from previous mission items
Documentation: Need to clarify page ...
```

### Alternatives


