### PR TITLE
add a 'rate' parameter in the xrce published topics to reduce the bandwidth

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -47,6 +47,10 @@ publications:
   - topic: /fmu/out/vehicle_trajectory_waypoint_desired
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
+  - topic: /fmu/out/battery_status
+    type: px4_msgs::msg::BatteryStatus
+    rate: 1.
+
 subscriptions:
 
   - topic: /fmu/in/offboard_control_mode

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -102,6 +102,11 @@ for p in msg_map['publications']:
     # topic_simple: eg vehicle_status
     p['topic_simple'] = p['topic'].split('/')[-1]
 
+    # period
+    if 'rate' in p:
+        p['period_us'] = int(1e6 / float(p['rate']))
+    else:
+        p['period_us'] = 0
 
 merged_em_globals['publications'] = msg_map['publications']
 


### PR DESCRIPTION
Solve Issue  #19081

### Solved Problem
Allow to set the maximal published rate of a given uxrce topic.

Fixes #19081

### Solution
- Add a parameter 'rate' in the file 'dds_topics.yaml'
- Change the dds_topics.h.em template to save the last published time for configured topics and ignore the xrce publication if the time elapsed is too short when the uorb topics is updated.

### Test coverage
SITL tested.
