### PR TITLE
ROMFS: auto try RGBLED is31fl3195

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -255,6 +255,7 @@ else
 	rgbled start -X -q
 	rgbled_ncp5623c start -X -q
 	rgbled_lp5562 start -X -q
+	rgbled_is31fl3195 start -X -q
 
 	#
 	# Override parameters from user configuration file.


### PR DESCRIPTION
This is required to auto-start the is31fl3195 driver if connected.

@vincentpoont2 

Needs to also go into v1.14.