### PR TITLE
Release 1.14 Backport. Fix Rover Thrust Normalization

### DIFF
--- a/src/modules/rover_pos_control/RoverPositionControl.cpp
+++ b/src/modules/rover_pos_control/RoverPositionControl.cpp
@@ -138,7 +138,7 @@ RoverPositionControl::manual_control_setpoint_poll()
 					}
 
 					_att_sp.yaw_body = _manual_yaw_sp;
-					_att_sp.thrust_body[0] = (_manual_control_setpoint.throttle + 1.f) * .5f;
+					_att_sp.thrust_body[0] = _manual_control_setpoint.throttle;
 
 					Quatf q(Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body));
 					q.copyTo(_att_sp.q_d);
@@ -152,7 +152,7 @@ RoverPositionControl::manual_control_setpoint_poll()
 					// Set heading from the manual roll input channel
 					_yaw_control = _manual_control_setpoint.roll; // Nominally yaw: _manual_control_setpoint.yaw;
 					// Set throttle from the manual throttle channel
-					_throttle_control = (_manual_control_setpoint.throttle + 1.f) * .5f;
+					_throttle_control = _manual_control_setpoint.throttle;
 					_reset_yaw_sp = true;
 				}
 


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/pull/21271 to 1.14 release