### PR TITLE
Fix gz_bridge gets wrong world name when GZ_VERBOSE=1

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -59,7 +59,7 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; th
 	fi
 
 	# look for running ${gz_command} gazebo world
-	gz_world=$( ${gz_command} topic -l | grep -m 1 -e "/world/.*/clock" | sed 's/\/world\///g; s/\/clock//g' )
+	gz_world=$( ${gz_command} topic -l | grep -m 1 -e "^/world/.*/clock" | sed 's/\/world\///g; s/\/clock//g' )
 
 	# shellcheck disable=SC2153
 	if [ -z "${gz_world}" ] && [ -n "${PX4_GZ_WORLDS}" ] && [ -n "${PX4_GZ_WORLD}" ]; then


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
In simulation, with env. var. `GZ_VERBOSE=1` and a Gazebo world is already running, GZBridge fails to start because it gets the wrong name for the running world. This is because the `grep` command used retrieve only the first occurrence of "/world/.*/clock" and thus, it gets `Topic: [@/theotime-Precision-5570:theotime@/world/multicopter/clock]` instead of the real name of the topic `/world/multicopter/clock`.

Fixes #{21727}

### Solution
- Grep only the lines that **start** with `/world/.*/clock`, which is the case 

### Changelog Entry
no need

### Alternatives
Gazebo's API has a "Name" endpoint for worlds, admittedly it could be cleaner to exploit that. The grep tech could create more issues in the future.

### Test coverage
- tested on my machine. Works with GZ_VERBOSE=0 and 1. The name of world is correctly found.

### Context
N/A
