### PR TITLE
Pr gps ev status

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -102,6 +102,7 @@ private:
 	bool _position_reliant_on_optical_flow{false};
 
 	bool _gps_was_fused{false};
+	bool _ev_was_fused{false};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::SYS_MC_EST_GROUP>) _param_sys_mc_est_group,


### PR DESCRIPTION


### Solved Problem


### Solution

The solution extends the PX4 code snippet to announce the start or stop of EV fusion. It adds additional conditions and log messages to check the state of the ekf_ev_fusion flag and triggers appropriate announcements.

### Changelog Entry

For release notes:
```
Feature: Extended PX4 code snippet to announce EV fusion start/stop
New parameter: N/A
Documentation: N/A
```

### Alternatives

An alternative approach could have been to modify the existing log messages or events to include both GNSS and EV fusion information in a single announcement. However, the chosen solution keeps the announcements separate for clarity.

### Test coverage

Unit/integration test: @farhangnaderi will do it.

Simulation/hardware testing logs: https://review.px4.io/plot_app?log=2fc71b57-b9c6-4458-858a-2e97a211b084

### Context

N/A
