### PR TITLE
Some parameter cleanup

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.cpp
@@ -79,8 +79,7 @@ void AirspeedChecks::checkAndReport(const Context &context, Report &reporter)
 			}
 		}
 
-		if (!context.isArmed() && _param_com_arm_arsp_en.get()
-		    && fabsf(airspeed_validated.calibrated_airspeed_m_s) > arming_max_airspeed_allowed) {
+		if (!context.isArmed() && fabsf(airspeed_validated.calibrated_airspeed_m_s) > arming_max_airspeed_allowed) {
 			/* EVENT
 			 * @description
 			 * Current airspeed reading too high. Check if wind is below maximum airspeed and redo airspeed
@@ -89,7 +88,7 @@ void AirspeedChecks::checkAndReport(const Context &context, Report &reporter)
 			 * <profile name="dev">
 			 * Measured: {1:.1m/s}, limit: {2:.1m/s}.
 			 *
-			 * This check can be configured via <param>COM_ARM_ARSP_EN</param> and <param>FW_AIRSPD_MAX</param> parameter.
+			 * This check can be configured via <param>FW_AIRSPD_MAX</param> parameter.
 			 * </profile>
 			 */
 			reporter.armingCheckFailure<float, float>(NavModes::None, health_component_t::differential_pressure,

--- a/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/airspeedCheck.hpp
@@ -53,7 +53,6 @@ private:
 	const param_t _param_fw_airspd_max_handle;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::CBRK_AIRSPD_CHK>) _param_cbrk_airspd_chk,
-					(ParamBool<px4::params::COM_ARM_ARSP_EN>) _param_com_arm_arsp_en
+					(ParamInt<px4::params::CBRK_AIRSPD_CHK>) _param_cbrk_airspd_chk
 				       )
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -956,18 +956,6 @@ PARAM_DEFINE_INT32(COM_POWER_COUNT, 1);
 PARAM_DEFINE_FLOAT(COM_LKDOWN_TKO, 3.0f);
 
 /**
-* Enable preflight check for maximal allowed airspeed when arming.
-*
-* Deny arming if the current airspeed measurement is greater than half the cruise airspeed (FW_AIRSPD_TRIM).
-* Excessive airspeed measurements on ground are either caused by wind or bad airspeed calibration.
-*
-* @group Commander
-* @value 0 Disabled
-* @value 1 Enabled
-*/
-PARAM_DEFINE_INT32(COM_ARM_ARSP_EN, 1);
-
-/**
  * Enable FMU SD card detection check
  *
  * This check detects if the FMU SD card is missing.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -45,9 +45,7 @@
  * Roll trim
  *
  * The trim value is the actuator control value the system needs
- * for straight and level flight. It can be calibrated by
- * flying manually straight and level using the RC trims and
- * copying them using the GCS.
+ * for straight and level flight.
  *
  * @group Radio Calibration
  * @min -0.5
@@ -61,9 +59,7 @@ PARAM_DEFINE_FLOAT(TRIM_ROLL, 0.0f);
  * Pitch trim
  *
  * The trim value is the actuator control value the system needs
- * for straight and level flight. It can be calibrated by
- * flying manually straight and level using the RC trims and
- * copying them using the GCS.
+ * for straight and level flight.
  *
  * @group Radio Calibration
  * @min -0.5
@@ -77,9 +73,7 @@ PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
  * Yaw trim
  *
  * The trim value is the actuator control value the system needs
- * for straight and level flight. It can be calibrated by
- * flying manually straight and level using the RC trims and
- * copying them using the GCS.
+ * for straight and level flight.
  *
  * @group Radio Calibration
  * @min -0.5
@@ -231,8 +225,6 @@ PARAM_DEFINE_FLOAT(COM_DISARM_PRFLT, 10.0f);
 
 /**
  * Allow arming without GPS
- *
- * The default allows the vehicle to arm without GPS signal.
  *
  * @group Commander
  * @value 0 Require GPS lock to arm
@@ -597,9 +589,6 @@ PARAM_DEFINE_INT32(COM_ARM_MAG_STR, 2);
  * immediately gives control back to the pilot by switching to Position mode and
  * if position is unavailable Altitude mode.
  * Note: Only has an effect on multicopters, and VTOLs in multicopter mode.
- *
- * This parameter is not considered in case of a GPS failure (Descend flight mode), where stick
- * override is always enabled.
  *
  * @min 0
  * @max 3

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -43,7 +43,7 @@
 /**
  * Loiter radius (FW only)
  *
- * Default value of loiter radius for missions, Hold mode, Return mode, etc. (fixedwing only).
+ * Default value of loiter radius in FW mode (e.g. for Loiter mode).
  *
  * @unit m
  * @min 25

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -79,7 +79,6 @@ PARAM_DEFINE_FLOAT(VT_F_TRANS_DUR, 5.0f);
 /**
  * Maximum duration of a back transition
  *
- * Time in seconds used for a back transition maximally.
  * Transition is also declared over if the groundspeed drops below MPC_XY_CRUISE.
  *
  * @unit s
@@ -94,10 +93,6 @@ PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 10.0f);
 /**
  * Target throttle value for the transition to fixed-wing flight.
  *
- * standard vtol: pusher
- *
- * tailsitter, tiltrotor: main throttle
- *
  * @min 0.0
  * @max 1.0
  * @increment 0.01
@@ -109,7 +104,6 @@ PARAM_DEFINE_FLOAT(VT_F_TRANS_THR, 1.0f);
 /**
  * Approximate deceleration during back transition
  *
- * The approximate deceleration during a back transition in m/s/s
  * Used to calculate back transition distance in an auto mode.
  * For standard vtol and tiltrotors a controller is used to track this value during the transition.
  *
@@ -373,9 +367,8 @@ PARAM_DEFINE_FLOAT(VT_B_DEC_I, 0.1f);
 /**
  * Minimum pitch angle during hover.
  *
- * Minimum pitch angle during hover flight. If the desired pitch angle is is lower than this value
- * then the fixed-wing forward actuation can be used to compensate for the missing thrust in forward direction
- * (see VT_FW_TRHUST_EN)
+ * Any pitch setpoint below this value is translated to a forward force by the fixed-wing forward actuation if
+ * VT_FW_TRHUST_EN is set to 1.
  *
  * @unit deg
  * @min -10.0

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -339,21 +339,7 @@ PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_P, 1.f);
 PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_Y, 0.1f);
 
 /**
- * Backtransition deceleration setpoint to pitch feedforward gain.
- *
- *
- * @unit rad s^2/m
- * @min 0
- * @max 0.2
- * @decimal 2
- * @increment 0.01
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_B_DEC_FF, 0.f);
-
-/**
  * Backtransition deceleration setpoint to pitch I gain.
- *
  *
  * @unit rad s/m
  * @min 0

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -176,7 +176,7 @@ float VtolType::update_and_get_backtransition_pitch_sp()
 	// get accel error, positive means decelerating too slow, need to pitch up (must reverse dec_max, as it is a positive number)
 	const float accel_error_forward = dec_sp + accel_body_forward;
 
-	const float pitch_sp_new = _param_vt_b_dec_ff.get() * dec_sp + _accel_to_pitch_integ;
+	const float pitch_sp_new = _accel_to_pitch_integ;
 
 	float integrator_input = _param_vt_b_dec_i.get() * accel_error_forward;
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -335,7 +335,6 @@ protected:
 					(ParamFloat<px4::params::VT_FW_DIFTHR_S_Y>) _param_vt_fw_difthr_s_y,
 					(ParamFloat<px4::params::VT_FW_DIFTHR_S_P>) _param_vt_fw_difthr_s_p,
 					(ParamFloat<px4::params::VT_FW_DIFTHR_S_R>) _param_vt_fw_difthr_s_r,
-					(ParamFloat<px4::params::VT_B_DEC_FF>) _param_vt_b_dec_ff,
 					(ParamFloat<px4::params::VT_B_DEC_I>) _param_vt_b_dec_i,
 					(ParamFloat<px4::params::VT_B_DEC_MSS>) _param_vt_b_dec_mss,
 


### PR DESCRIPTION
### Solved Problem
Safes a bit of flash and reduces entropy by removing two params that aren't really required anymore. 

### Solution

### Changelog Entry

```
Remove COM_ARM_ARSP_EN and VT_B_DEC_FF params, plus shorten parameter descriptions
```

