### PR TITLE
param save: Add a blocking API for param saves to be used from shell.

### DIFF
--- a/src/lib/parameters/autosave.cpp
+++ b/src/lib/parameters/autosave.cpp
@@ -110,10 +110,22 @@ void ParamAutosave::Run()
 	}
 
 	PX4_DEBUG("Autosaving params");
-	int ret = param_save_default();
+	int ret = param_save_default(false);
 
-	if (ret != 0) {
-		PX4_ERR("param auto save failed (%i)", ret);
+	if (ret != PX4_OK) {
+		// re-request to be saved in the future, try 3 times at most
+		if (_retry_count < 3) {
+			_retry_count++;
+			PX4_INFO("param auto save unavailable (%i), retrying..", ret);
+			request();
+
+		} else {
+			PX4_ERR("param auto save failed (%i)", ret);
+			_retry_count = 0;
+		}
+
+	} else {
+		_retry_count = 0;
 	}
 }
 

--- a/src/lib/parameters/autosave.h
+++ b/src/lib/parameters/autosave.h
@@ -59,5 +59,6 @@ public:
 private:
 	hrt_abstime _last_timestamp{0};
 	px4::atomic_bool _scheduled{false};
+	int _retry_count{0};
 	bool _disabled{false};
 };

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -400,13 +400,17 @@ __EXPORT const char	*param_get_backup_file(void);
 
 /**
  * Save parameters to the default file.
+ *
  * Note: this method requires a large amount of stack size!
  *
  * This function saves all parameters with non-default values.
  *
- * @return		Zero on success.
+ * @param blocking	If true, in case the default file is busy, the function blocks
+ * 			until the file is available for writing.
+ *
+ * @return		Zero on success, -EWOULDBLOCK if the file is busy and blocking is false.
  */
-__EXPORT int 		param_save_default(void);
+__EXPORT int 		param_save_default(bool blocking);
 
 /**
  * Load parameters from the default parameter file.

--- a/src/lib/parameters/parameters_ioctl.cpp
+++ b/src/lib/parameters/parameters_ioctl.cpp
@@ -168,7 +168,7 @@ int	param_ioctl(unsigned int cmd, unsigned long arg)
 
 	case PARAMIOCSAVEDEFAULT: {
 			paramiocsavedefault_t *data = (paramiocsavedefault_t *)arg;
-			data->ret = param_save_default();
+			data->ret = param_save_default(data->blocking);
 		}
 		break;
 

--- a/src/lib/parameters/parameters_ioctl.h
+++ b/src/lib/parameters/parameters_ioctl.h
@@ -140,6 +140,7 @@ typedef struct paramiocresetgroup {
 
 #define PARAMIOCSAVEDEFAULT	_PARAMIOC(15)
 typedef struct paramiocsavedefault {
+	bool blocking;
 	int ret;
 } paramiocsavedefault_t;
 

--- a/src/lib/parameters/usr_parameters_if.cpp
+++ b/src/lib/parameters/usr_parameters_if.cpp
@@ -187,9 +187,9 @@ param_reset_specific(const char *resets[], int num_resets)
 	boardctl(PARAMIOCRESETGROUP, reinterpret_cast<unsigned long>(&data));
 }
 
-int param_save_default()
+int param_save_default(bool blocking)
 {
-	paramiocsavedefault_t data = {PX4_ERROR};
+	paramiocsavedefault_t data = {blocking, PX4_ERROR};
 	boardctl(PARAMIOCSAVEDEFAULT, reinterpret_cast<unsigned long>(&data));
 	return data.ret;
 }

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -180,7 +180,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 					/* save */
 					calibration_log_info(mavlink_log_pub, CAL_QGC_PROGRESS_MSG, 0);
-					param_save_default();
+					param_save_default(true);
 
 					feedback_calibration_failed(mavlink_log_pub);
 					return PX4_ERROR;

--- a/src/modules/commander/worker_thread.cpp
+++ b/src/modules/commander/worker_thread.cpp
@@ -158,7 +158,7 @@ void WorkerThread::threadEntry()
 		break;
 
 	case Request::ParamSaveDefault:
-		_ret_value = param_save_default();
+		_ret_value = param_save_default(true);
 
 		if (_ret_value != 0) {
 			mavlink_log_critical(&_mavlink_log_pub, "Error saving settings\t");
@@ -175,7 +175,7 @@ void WorkerThread::threadEntry()
 	case Request::ParamResetSensorFactory: {
 			const char *reset_cal[] = { "CAL_ACC*", "CAL_GYRO*", "CAL_MAG*" };
 			param_reset_specific(reset_cal, sizeof(reset_cal) / sizeof(reset_cal[0]));
-			_ret_value = param_save_default();
+			_ret_value = param_save_default(true);
 #if defined(CONFIG_BOARDCTL_RESET)
 			px4_reboot_request(false, 400_ms);
 #endif // CONFIG_BOARDCTL_RESET

--- a/src/modules/temperature_compensation/temperature_calibration/task.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/task.cpp
@@ -284,7 +284,7 @@ void TemperatureCalibration::task_main()
 		}
 
 		param_notify_changes();
-		int ret = param_save_default();
+		int ret = param_save_default(true);
 
 		if (ret != 0) {
 			PX4_ERR("Failed to save params (%i)", ret);

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -509,7 +509,7 @@ do_import(const char *param_file_name)
 static int
 do_save_default()
 {
-	return param_save_default();
+	return param_save_default(true);
 }
 
 static int

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -316,7 +316,7 @@ bool ParameterTest::exportImport()
 	}
 
 	// save
-	if (param_save_default() != PX4_OK) {
+	if (param_save_default(true) != PX4_OK) {
 		PX4_ERR("param_save_default failed");
 		return false;
 	}
@@ -461,7 +461,7 @@ bool ParameterTest::exportImportAll()
 	}
 
 	// save
-	if (param_save_default() != PX4_OK) {
+	if (param_save_default(true) != PX4_OK) {
 		PX4_ERR("param_save_default failed");
 		return false;
 	}
@@ -561,7 +561,7 @@ bool ParameterTest::exportImportAll()
 	}
 
 	// save
-	if (param_save_default() != PX4_OK) {
+	if (param_save_default(true) != PX4_OK) {
 		PX4_ERR("param_save_default failed");
 		return false;
 	}


### PR DESCRIPTION
### Solved Problem

After the latest param rework, the file lock in `param_save_default` was changed to a `trylock`, to prevent any blocking in the param system. This makes `param_save_default` occasionally fail, if it is called from multiple threads at the same time. This is correct, but unexpected especially when used from the shell.

### Solution
This changes the `param_save_default` function to have be either blocking or non-blocking.

From the shell and from modules that expect a synchronous API, the blocking version is called. From the work queue, the non blocking version is called. 

This also modifies the autosave worker, to re-schedule writing up to three times, in case writes fail.

### Changelog Entry
For release notes:

- Bugfix: Blocking API for param save

### Alternatives
As an alternative, we could disable the autosave worker in the CI tests. This would solve the error in the CI tests. But still, a user typing in `param save` could still hit it then. 

### Test coverage
- All unit tests still pass
- Bench test on v5x

