### PR TITLE
Random fixes for GCC 13

### DIFF
--- a/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/pxh.cpp
@@ -40,6 +40,7 @@
  * @author Julian Oes <julian@oes.ch>
  */
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <vector>

--- a/src/lib/matrix/matrix/SquareMatrix.hpp
+++ b/src/lib/matrix/matrix/SquareMatrix.hpp
@@ -322,6 +322,19 @@ SquareMatrix<Type, M> expm(const Matrix<Type, M, M> &A, size_t order = 5)
 	return res;
 }
 
+/**
+ * Deal with the special case where the square matrix is 1
+ */
+template<typename Type>
+bool inv(const SquareMatrix<Type, 1> &A, SquareMatrix<Type, 1> &inv, size_t rank = 1)
+{
+	if (std::fabs(A(0, 0)) < Type(FLT_EPSILON)) {
+		return false;
+	}
+
+	inv(0, 0) = Type(1) / A(0, 0);
+	return true;
+}
 
 /**
  * inverse based on LU factorization with partial pivotting


### PR DESCRIPTION
### Solved SITL compilation problem with GCC 13

px4:
```
/home/patrick/git/blue/PX4-Autopilot/platforms/posix/src/px4/common/px4_daemon/pxh.cpp: In member function ‘void px4_daemon::Pxh::run_remote_pxh(int, int)’:                                                                   
/home/patrick/git/blue/PX4-Autopilot/platforms/posix/src/px4/common/px4_daemon/pxh.cpp:208:25: error: ‘uint8_t’ was not declared in this scope                                                                                 
  208 |                         uint8_t buffer[512];    
```

SquareMatrix:
```
In file included from /home/patrick/git/blue/PX4-Autopilot/src/lib/matrix/matrix/math.hpp:8,                                                                                                                                   
                 from /home/patrick/git/blue/PX4-Autopilot/src/lib/mathlib/math/Functions.hpp:45,                                                                                                                              
                 from /home/patrick/git/blue/PX4-Autopilot/src/lib/mathlib/math/filter/LowPassFilter2p.hpp:41,                                                                                                                 
                 from /home/patrick/git/blue/PX4-Autopilot/src/lib/controllib/BlockDelay.hpp:48,                                                                                                                               
                 from /home/patrick/git/blue/PX4-Autopilot/src/lib/controllib/blocks.hpp:42,                                                                                                                                   
                 from /home/patrick/git/blue/PX4-Autopilot/src/modules/local_position_estimator/sensors/../BlockLocalPositionEstimator.hpp:7,                                                                                  
                 from /home/patrick/git/blue/PX4-Autopilot/src/modules/local_position_estimator/sensors/lidar.cpp:1:                                                                                                           
In member function ‘Type& matrix::Matrix<Type, M, N>::operator()(size_t, size_t) [with Type = float; long unsigned int M = 1; long unsigned int N = 1]’,                                                                       
    inlined from ‘bool matrix::inv(const SquareMatrix<Type, M>&, SquareMatrix<Type, M>&, size_t) [with Type = float; long unsigned int M = 1]’ at /home/patrick/git/blue/PX4-Autopilot/src/lib/matrix/matrix/SquareMatrix.hpp:3
49:20:                                                                                                                                                                                                                         
/home/patrick/git/blue/PX4-Autopilot/src/lib/matrix/matrix/Matrix.hpp:96:29: error: array subscript 1 is above array bounds of ‘float [1][1]’ [-Werror=array-bounds=]                                                          
   96 |                 return _data[i][j];                                                                                                                                                                                    
      |           
```
