### PR TITLE
Bugfix. EKF2 Warning messages don't display lower_error_availa…

### DIFF
--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -656,6 +656,7 @@ void EKF2Selector::Run()
 			if ((_instance[i].accel_device_id != 0)
 			    && (_instance[i].gyro_device_id != 0)) {
 				_ekf_change_reason = EKFChangeReason::INIT;
+
 				if (SelectInstance(i)) {
 					break;
 				}
@@ -719,6 +720,7 @@ void EKF2Selector::Run()
 
 		if (!_instance[_selected_instance].healthy.get_state()) {
 			_ekf_change_reason = CalculateHealthChangeReason();
+
 			// prefer the best healthy instance using a different IMU
 			if (!SelectInstance(best_ekf_different_imu)) {
 				// otherwise switch to the healthy instance with best overall test ratio
@@ -861,29 +863,35 @@ void EKF2Selector::PrintInstanceChange(const uint8_t old_instance, uint8_t new_i
 
 	if (_ekf_change_reason == EKFChangeReason::NONE || _ekf_change_reason == EKFChangeReason::INIT) {return;}
 
-	switch (_ekf_change_reason)
-	{
+	switch (_ekf_change_reason) {
 	case FILTER_FAULT:
 		reason = "(filter fault)";
 		break;
+
 	case TIMEOUT:
 		reason = "(timeout)";
 		break;
+
 	case GYRO_FAULT:
 		reason = "(gyro fault)";
 		break;
+
 	case ACCEL_FAULT:
 		reason = "(accel fault)";
 		break;
+
 	case UNHEALTHY:
 		reason = "(unhealthy)";
 		break;
+
 	case LOWER_ERROR_AVAILABLE:
 		reason = "(lower error available)";
 		break;
+
 	case USER_SELECTED:
 		reason = "(user selected)";
 		break;
+
 	case UNKNOWN:
 	default:
 		reason = "(unknown)";

--- a/src/modules/ekf2/EKF2Selector.cpp
+++ b/src/modules/ekf2/EKF2Selector.cpp
@@ -67,46 +67,6 @@ void EKF2Selector::Stop()
 	ScheduleClear();
 }
 
-void EKF2Selector::PrintInstanceChange(const uint8_t old_instance, uint8_t new_instance)
-{
-	const char *old_reason = nullptr;
-
-	if (_instance[old_instance].filter_fault) {
-		old_reason = " (filter fault)";
-
-	} else if (_instance[old_instance].timeout) {
-		old_reason = " (timeout)";
-
-	} else if (_gyro_fault_detected) {
-		old_reason = " (gyro fault)";
-
-	} else if (_accel_fault_detected) {
-		old_reason = " (accel fault)";
-
-	} else if (!_instance[_selected_instance].healthy.get_state() && (_instance[_selected_instance].healthy_count > 0)) {
-		// skipped if previous instance was never healthy in the first place (eg initialization)
-		old_reason = " (unhealthy)";
-	}
-
-	const char *new_reason = nullptr;
-
-	if (_request_instance.load() == new_instance) {
-		new_reason = " (user selected)";
-	}
-
-	if (old_reason || new_reason) {
-		if (old_reason == nullptr) {
-			old_reason = "";
-		}
-
-		if (new_reason == nullptr) {
-			new_reason = "";
-		}
-
-		PX4_WARN("primary EKF changed %" PRIu8 "%s -> %" PRIu8 "%s", old_instance, old_reason, new_instance, new_reason);
-	}
-}
-
 bool EKF2Selector::SelectInstance(uint8_t ekf_instance)
 {
 	if ((ekf_instance != _selected_instance) && (ekf_instance < _available_instances)) {
@@ -687,12 +647,15 @@ void EKF2Selector::Run()
 	// update combined test ratio for all estimators
 	const bool updated = UpdateErrorScores();
 
+	// restore value, EKF instance still hasn't changed
+	_ekf_change_reason = EKFChangeReason::NONE;
+
 	// if no valid instance then force select first instance with valid IMU
 	if (_selected_instance == INVALID_INSTANCE) {
 		for (uint8_t i = 0; i < EKF2_MAX_INSTANCES; i++) {
 			if ((_instance[i].accel_device_id != 0)
 			    && (_instance[i].gyro_device_id != 0)) {
-
+				_ekf_change_reason = EKFChangeReason::INIT;
 				if (SelectInstance(i)) {
 					break;
 				}
@@ -755,6 +718,7 @@ void EKF2Selector::Run()
 		}
 
 		if (!_instance[_selected_instance].healthy.get_state()) {
+			_ekf_change_reason = CalculateHealthChangeReason();
 			// prefer the best healthy instance using a different IMU
 			if (!SelectInstance(best_ekf_different_imu)) {
 				// otherwise switch to the healthy instance with best overall test ratio
@@ -768,11 +732,14 @@ void EKF2Selector::Run()
 
 			// if this instance has a significantly lower relative error to the active primary, we consider it as a
 			// better instance and would like to switch to it even if the current primary is healthy
+			_ekf_change_reason = EKFChangeReason::LOWER_ERROR_AVAILABLE;
 			SelectInstance(best_ekf_alternate);
 
 		} else if (_request_instance.load() != INVALID_INSTANCE) {
 
 			const uint8_t new_instance = _request_instance.load();
+
+			_ekf_change_reason = EKFChangeReason::USER_SELECTED;
 
 			// attempt to switch to user manually selected instance
 			if (!SelectInstance(new_instance)) {
@@ -837,6 +804,38 @@ void EKF2Selector::PublishEstimatorSelectorStatus()
 	_last_status_publish = selector_status.timestamp;
 }
 
+EKF2Selector::EKFChangeReason EKF2Selector::CalculateHealthChangeReason()
+{
+	/*
+	Multiple problems can be active at the same time. This function keeps the previously implemented
+	priority order
+	*/
+
+	if (_selected_instance == INVALID_INSTANCE) {return EKFChangeReason::NONE;}
+
+	EKFChangeReason reason = EKFChangeReason::UNKNOWN;
+
+	if (_instance[_selected_instance].filter_fault) {
+		reason = EKFChangeReason::FILTER_FAULT;
+
+	} else if (_instance[_selected_instance].timeout) {
+		reason = EKFChangeReason::TIMEOUT;
+
+	} else if (_gyro_fault_detected) {
+		reason = EKFChangeReason::GYRO_FAULT;
+
+	} else if (_accel_fault_detected) {
+		reason = EKFChangeReason::ACCEL_FAULT;
+
+	} else if (!_instance[_selected_instance].healthy.get_state() && (_instance[_selected_instance].healthy_count > 0)) {
+		// TODO. Not sure if this && is correct
+		// skipped if previous instance was never healthy in the first place (eg initialization)
+		reason = EKFChangeReason::UNHEALTHY;
+	}
+
+	return reason;
+}
+
 void EKF2Selector::PrintStatus()
 {
 	PX4_INFO("available instances: %" PRIu8, _available_instances);
@@ -854,4 +853,41 @@ void EKF2Selector::PrintStatus()
 			 (double)inst.combined_test_ratio, (double)inst.relative_test_ratio,
 			 (_selected_instance == i) ? "*" : "");
 	}
+}
+
+void EKF2Selector::PrintInstanceChange(const uint8_t old_instance, uint8_t new_instance)
+{
+	const char *reason = nullptr;
+
+	if (_ekf_change_reason == EKFChangeReason::NONE || _ekf_change_reason == EKFChangeReason::INIT) {return;}
+
+	switch (_ekf_change_reason)
+	{
+	case FILTER_FAULT:
+		reason = "(filter fault)";
+		break;
+	case TIMEOUT:
+		reason = "(timeout)";
+		break;
+	case GYRO_FAULT:
+		reason = "(gyro fault)";
+		break;
+	case ACCEL_FAULT:
+		reason = "(accel fault)";
+		break;
+	case UNHEALTHY:
+		reason = "(unhealthy)";
+		break;
+	case LOWER_ERROR_AVAILABLE:
+		reason = "(lower error available)";
+		break;
+	case USER_SELECTED:
+		reason = "(user selected)";
+		break;
+	case UNKNOWN:
+	default:
+		reason = "(unknown)";
+	}
+
+	PX4_WARN("primary EKF changed %" PRIu8 " %s -> %" PRIu8, old_instance, reason, new_instance);
 }

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -96,6 +96,23 @@ private:
 	// Update the error scores for all available instances
 	bool UpdateErrorScores();
 
+
+	typedef enum EKFChangeReason {
+		NONE = 0, //Indicates that it hasn't changed
+		INIT, // EKF initialization can't be considered a change
+		FILTER_FAULT,
+		TIMEOUT,
+		GYRO_FAULT,
+		ACCEL_FAULT,
+		UNHEALTHY,
+		LOWER_ERROR_AVAILABLE,
+		USER_SELECTED,
+		UNKNOWN
+	} EKFChangeReason;
+
+	// Calculates the instance health issue with the highest priority
+	EKFChangeReason CalculateHealthChangeReason();
+
 	// Subscriptions (per estimator instance)
 	struct EstimatorInstance {
 
@@ -186,6 +203,7 @@ private:
 
 	uint32_t _instance_changed_count{0};
 	hrt_abstime _last_instance_change{0};
+	EKFChangeReason _ekf_change_reason{EKFChangeReason::NONE};
 
 	hrt_abstime _last_status_publish{0};
 	bool _selector_status_publish{false};

--- a/src/modules/ekf2/EKF2Selector.hpp
+++ b/src/modules/ekf2/EKF2Selector.hpp
@@ -203,7 +203,7 @@ private:
 
 	uint32_t _instance_changed_count{0};
 	hrt_abstime _last_instance_change{0};
-	EKFChangeReason _ekf_change_reason{EKFChangeReason::NONE};
+	EKFChangeReason _ekf_last_change_reason{EKFChangeReason::NONE};
 
 	hrt_abstime _last_status_publish{0};
 	bool _selector_status_publish{false};


### PR DESCRIPTION
If the EKF instance switch is done because there's an instance with a lower available error the PrintInstanceChange function doesn't contemplate it and thus, it doesn't print any warning

### Solved Problem
Fixes #21457

### Solution
- Add attribute to store which is the reason of the EKF switch
- Add Enum to represent switch reason types
- Add case to print the lower_error_available option

