### PR TITLE
ArmingChecks: disallow arming via parameter

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_library(health_and_arming_checks
 
 	checks/accelerometerCheck.cpp
 	checks/airspeedCheck.cpp
+	checks/armPermissionCheck.cpp
 	checks/baroCheck.cpp
 	checks/batteryCheck.cpp
 	checks/cpuResourceCheck.cpp

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -34,34 +34,36 @@
 px4_add_library(health_and_arming_checks
 	Common.cpp
 	HealthAndArmingChecks.cpp
-	checks/systemCheck.cpp
-	checks/magnetometerCheck.cpp
+
 	checks/accelerometerCheck.cpp
-	checks/gyroCheck.cpp
-	checks/baroCheck.cpp
-	checks/imuConsistencyCheck.cpp
 	checks/airspeedCheck.cpp
+	checks/baroCheck.cpp
+	checks/batteryCheck.cpp
+	checks/cpuResourceCheck.cpp
 	checks/distanceSensorChecks.cpp
 	checks/escCheck.cpp
-	checks/rcCalibrationCheck.cpp
-	checks/powerCheck.cpp
 	checks/estimatorCheck.cpp
 	checks/failureDetectorCheck.cpp
-	checks/manualControlCheck.cpp
-	checks/modeCheck.cpp
-	checks/cpuResourceCheck.cpp
-	checks/sdcardCheck.cpp
-	checks/parachuteCheck.cpp
-	checks/batteryCheck.cpp
-	checks/windCheck.cpp
-	checks/geofenceCheck.cpp
-	checks/homePositionCheck.cpp
 	checks/flightTimeCheck.cpp
+	checks/geofenceCheck.cpp
+	checks/gyroCheck.cpp
+	checks/homePositionCheck.cpp
+	checks/imuConsistencyCheck.cpp
+	checks/magnetometerCheck.cpp
+	checks/manualControlCheck.cpp
 	checks/missionCheck.cpp
-	checks/rcAndDataLinkCheck.cpp
-	checks/vtolCheck.cpp
+	checks/modeCheck.cpp
 	checks/offboardCheck.cpp
 	checks/openDroneIDCheck.cpp
+	checks/parachuteCheck.cpp
+	checks/powerCheck.cpp
+	checks/rcAndDataLinkCheck.cpp
+	checks/rcCalibrationCheck.cpp
+	checks/sdcardCheck.cpp
+	checks/systemCheck.cpp
+	checks/vtolCheck.cpp
+	checks/windCheck.cpp
+
 )
 add_dependencies(health_and_arming_checks mode_util)
 

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -42,6 +42,7 @@
 
 #include "checks/accelerometerCheck.hpp"
 #include "checks/airspeedCheck.hpp"
+#include "checks/armPermissionCheck.hpp"
 #include "checks/baroCheck.hpp"
 #include "checks/cpuResourceCheck.hpp"
 #include "checks/distanceSensorChecks.hpp"
@@ -115,6 +116,7 @@ private:
 	// all checks
 	AccelerometerChecks _accelerometer_checks;
 	AirspeedChecks _airspeed_checks;
+	ArmPermissionChecks _arm_permission_checks;
 	BaroChecks _baro_checks;
 	CpuResourceChecks _cpu_resource_checks;
 	DistanceSensorChecks _distance_sensor_checks;
@@ -145,6 +147,7 @@ private:
 	HealthAndArmingCheckBase *_checks[31] = {
 		&_accelerometer_checks,
 		&_airspeed_checks,
+		&_arm_permission_checks,
 		&_baro_checks,
 		&_cpu_resource_checks,
 		&_distance_sensor_checks,

--- a/src/modules/commander/HealthAndArmingChecks/checks/armPermissionCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/armPermissionCheck.cpp
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "armPermissionCheck.hpp"
+
+void ArmPermissionChecks::checkAndReport(const Context &context, Report &reporter)
+{
+	if (_param_com_armable.get() < 1) {
+		/* EVENT
+		* @description
+		* Vehicle is in safety configuration and denies arming.
+		*
+		* <profile name="dev">
+		* This check can be configured via <param>COM_ARMABLE</param> parameter.
+		* </profile>
+		*/
+		reporter.armingCheckFailure(NavModes::All, health_component_t::system,
+					    events::ID("check_armable_configuration"),
+					    events::Log::Error, "Vehicle is in safety configuration");
+
+		if (reporter.mavlink_log_pub()) {
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Vehicle is in safety configuration");
+		}
+	}
+}

--- a/src/modules/commander/HealthAndArmingChecks/checks/armPermissionCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/armPermissionCheck.hpp
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../Common.hpp"
+
+class ArmPermissionChecks : public HealthAndArmingCheckBase
+{
+public:
+	ArmPermissionChecks() = default;
+	~ArmPermissionChecks() = default;
+
+	void checkAndReport(const Context &context, Report &reporter) override;
+
+private:
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamInt<px4::params::COM_ARMABLE>) _param_com_armable
+				       )
+};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1104,3 +1104,15 @@ PARAM_DEFINE_FLOAT(COM_WIND_MAX, -1.f);
  * @unit m
  */
 PARAM_DEFINE_FLOAT(COM_POS_LOW_EPH, -1.0f);
+
+/**
+ * Flag to allow arming
+ *
+ * Set 0 to prevent accidental use of the vehicle e.g. for safety or maintenance reasons.
+ *
+ * @boolean
+ * @value 0 Disallow arming
+ * @value 1 Allow arming
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_ARMABLE, 1);


### PR DESCRIPTION
### Solved Problem
The carrier is maintaining or showcasing the vehicle powered but not armed and wants to make sure it's not accidentally armed.

### Solution
- Add parameter `COM_ARMABLE` defaulting to allow arming which can be set to false to disallow arming

### Changelog Entry
For release notes:
```
Feature: New parameter: COM_ARMABLE if set to 0 arming is disallowed
```
Documentation: Parameter reference is automatically updated. Safety chapter does not specifically exist or does it?

### Test coverage
- I tested this in Simulation. Like expected it does prevent arming when disallowed but does not failsafe when the parameter is set in air.

### Context
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/5ba004f9-eb41-4479-b63f-d5e3a3265f56)
