### PR TITLE
ROMFS : POSIX Airframes reserve space for custom models

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -94,4 +94,6 @@ px4_add_romfs_files(
 
 	17001_flightgear_tf-g1
 	17002_flightgear_tf-g2
+
+	# [22000, 22999] Reserve for custom models
 )


### PR DESCRIPTION
This just reserves the airframe numbers for custom simulation models to avoid collisions with master.  The range was set such that it matches the custom range for actual airframes.