### PR TITLE
lightware_laser_serial: fix pointer for enabling serial mode

### DIFF
--- a/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
@@ -308,7 +308,7 @@ void LightwareLaserSerial::Run()
 		// LW20: Enable serial mode by sending some characters
 		if (hw_model == 8) {
 			const char *data = "www\r\n";
-			(void)!::write(_fd, &data, strlen(data));
+			(void)!::write(_fd, data, strlen(data));
 		}
 	}
 


### PR DESCRIPTION
### Solved Problem
When trying to fix https://github.com/PX4/PX4-Autopilot/pull/21737#pullrequestreview-1489844308 and compiling `make beaglebone_blue` locally with `arm-linux-gnueabihf-gcc (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0` I got a compile warning -> error:
```
PX4-Autopilot/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp: In member function ‘virtual void LightwareLaserSerial::Run()’:
PX4-Autopilot/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp:311:39: error: ‘ssize_t write(int, const void*, size_t)’ reading 5 bytes from a region of size 4 [-Werror=stringop-overread]
  311 |                         (void)!::write(_fd, &data, strlen(data));
      |                                ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```

### Solution
`const char *data = "www\r\n";`
Defines a cstring of 6 bytes: `{'w', 'w', 'w', '\r', '\n', '\0'}`

type of data: `char const*`
type of &data: `char const**`

So when we call `write(_fd, &data, strlen(data));` then `strlen(data) == 5` (without the terminating null character) and we send the 4 byte memory address of data + some additional random byte to the distance sensor.

Correct is `write(_fd, data, strlen(data));` where `char const*` gets cast to `const void *` and we pass the pointer to the content of data so the 5 bytes w, w, w, \r, \n get sent out via serial.

The fundamental problem here is write() not being typesafe.

### Changelog Entry
For release notes:
```
Bugfix: lightware distance sensor serial initialization
```

### Alternatives
```
const char data[] = "www\r\n";
write(_fd, data, strlen(data));
```
would be correct as well but creates slightly more overhead since it makes a copy of the cstring on the stack and passes the pointer of that to `write()`.

### Test coverage
- Compiles without error
- I verified the findings with https://onlinegdb.com/GA21Q3LHp