### PR TITLE
v6x: start mavlink on TELEM2 for skynode

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_mavlink
+++ b/boards/px4/fmu-v6x/init/rc.board_mavlink
@@ -1,11 +1,11 @@
 #!/bin/sh
 #
-# board specific MAVLink startup script.
+# PX4 FMUv6X specific board MAVLink startup script.
 #------------------------------------------------------------------------------
 
-if ver hwtypecmp V5X009000 V5X009001 V5X00a000 V5X00a001 V5X008000 V5X008001 V5X010001
+# if skynode base board is detected start Mavlink on Telem2
+if ver hwtypecmp V6X009010 V6X010010
 then
-	# Start MAVLink on the UART connected to the mission computer
 	mavlink start -d /dev/ttyS4 -b 3000000 -r 290000 -m onboard_low_bandwidth -x -z
 
 	# Ensure nothing else starts on TEL2 (ttyS4)


### PR DESCRIPTION
Equivalent to v5x
