### PR TITLE
Fix gazebo don't run on faster systems everytime when launched with sitl_run.sh

### DIFF
--- a/Tools/simulation/gazebo-classic/sitl_run.sh
+++ b/Tools/simulation/gazebo-classic/sitl_run.sh
@@ -127,6 +127,9 @@ if [ -x "$(command -v gazebo)" ]; then
 		echo "Using: ${modelpath}/${model}/${model}.sdf"
 	fi
 
+	# wait sometime so gzserver become responsive
+	sleep 3
+ 
 	while gz model --verbose --spawn-file="${modelpath}/${model}/${model_name}.sdf" --model-name=${model} -x 1.01 -y 0.98 -z 0.83 2>&1 | grep -q "An instance of Gazebo is not running."; do
 		echo "gzserver not ready yet, trying again!"
 		sleep 1


### PR DESCRIPTION
# Problem
This is for the issue listed on gazebo forum. gazebo don't run on faster systems everytime when launched with sitl_run.sh.(i.e somemtime it loads properly sometime not). I tested the behaviour on 2 different processor systems (i3  2120 4-threads & ryzen 5625 12-threads) running exactly same code. the faster one often doesn't work as expected.

# Solution
Added a sleep to wait for the gzserver to become responsive. Tested on both systems.

# Fixes
[Simtime realtime iteration fps etc not displaying also gazebo crashes after clicking an item](https://answers.gazebosim.org/question/29195/simtime-realtime-iteration-fps-etc-not-displaying-also-gazebo-crashes-after-clicking-an-item/)

I am sure this is not a gazebo error.
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->
