### PR TITLE
Fix selectable flight modes

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_mavlink
+++ b/boards/px4/fmu-v5x/init/rc.board_mavlink
@@ -7,6 +7,7 @@ if ver hwtypecmp V5X009000 V5X009001 V5X00a000 V5X00a001 V5X008000 V5X008001 V5X
 then
 	# Start MAVLink on the UART connected to the mission computer
 	mavlink start -d /dev/ttyS4 -b 3000000 -r 290000 -m onboard_low_bandwidth -x -z
+	mavlink stream -d /dev/ttyS4 -s ATTITUDE_QUATERNION -r 30
 	mavlink stream -d /dev/ttyS4 -s HIGHRES_IMU -r 20
 
 fi

--- a/src/modules/commander/ModeManagement.cpp
+++ b/src/modules/commander/ModeManagement.cpp
@@ -519,7 +519,9 @@ void ModeManagement::checkConfigOverrides()
 void ModeManagement::getModeStatus(uint32_t &valid_nav_state_mask, uint32_t &can_set_nav_state_mask) const
 {
 	valid_nav_state_mask = mode_util::getValidNavStates();
-	can_set_nav_state_mask = valid_nav_state_mask & ~(1u << vehicle_status_s::NAVIGATION_STATE_TERMINATION);
+	const uint32_t selectable_nav_state_mask = mode_util::getSelectableNavStates();
+	can_set_nav_state_mask = valid_nav_state_mask & selectable_nav_state_mask & ~(1u <<
+				 vehicle_status_s::NAVIGATION_STATE_TERMINATION);
 
 	// Add external modes
 	for (int i = Modes::FIRST_EXTERNAL_NAV_STATE; i <= Modes::LAST_EXTERNAL_NAV_STATE; ++i) {

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -213,7 +213,9 @@ public:
 	void getModeStatus(uint32_t &valid_nav_state_mask, uint32_t &can_set_nav_state_mask) const
 	{
 		valid_nav_state_mask = mode_util::getValidNavStates();
-		can_set_nav_state_mask = valid_nav_state_mask & ~(1u << vehicle_status_s::NAVIGATION_STATE_TERMINATION);
+		const uint32_t selectable_nav_state_mask = mode_util::getSelectableNavStates();
+		can_set_nav_state_mask = valid_nav_state_mask & selectable_nav_state_mask & ~(1u <<
+					 vehicle_status_s::NAVIGATION_STATE_TERMINATION);
 	}
 
 	void updateActiveConfigOverrides(uint8_t nav_state, config_overrides_s &overrides_in_out) { }

--- a/src/modules/commander/ModeUtil/ui.hpp
+++ b/src/modules/commander/ModeUtil/ui.hpp
@@ -65,6 +65,17 @@ static inline uint32_t getValidNavStates()
 	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX  == 31, "code requires update");
 }
 
+/**
+ * @return Bitmask with all selectable modes
+ */
+static inline uint32_t getSelectableNavStates()
+{
+	return (1u << vehicle_status_s::NAVIGATION_STATE_ALTCTL) |
+	       (1u << vehicle_status_s::NAVIGATION_STATE_POSCTL);
+
+	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX  == 31, "code requires update");
+}
+
 const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
 	"Manual",
 	"Altitude",


### PR DESCRIPTION
### Solved Problem

- All available flight modes showed up in the selector, not just the ones we want to be able to select.
- Missing `ATTITUDE_QUATERNION` which was needed by the external mode.

### Solution

- Define user-selectable flight modes separately from valid flight modes.
- Add `ATTITUDE_QUATERNION` MAVLink stream

### Changelog Entry
N/A

### Alternatives
N/A

### Test coverage
Flight tests

### Context
N/A