### PR TITLE
[uxrce-dds-client]: add parameter to disable time synchronization between Agent and Client.

### DIFF
--- a/src/modules/uxrce_dds_client/module.yaml
+++ b/src/modules/uxrce_dds_client/module.yaml
@@ -64,3 +64,14 @@ parameters:
             reboot_required: true
             default: 2130706433
             requires_ethernet: true
+
+        UXRCE_DDS_SYNCT:
+            description:
+                short: uXRCE-DDS timesync enable
+                long: |
+                    If set to 1, enable time synchronization between Agent and Client.
+                    If set to 0, timestaps are not synchonized.
+            type: boolean
+            category: System
+            reboot_required: true
+            default: 1

--- a/src/modules/uxrce_dds_client/module.yaml
+++ b/src/modules/uxrce_dds_client/module.yaml
@@ -67,10 +67,10 @@ parameters:
 
         UXRCE_DDS_SYNCT:
             description:
-                short: uXRCE-DDS timesync enable
-                long: |
-                    If set to 1, enable time synchronization between Agent and Client.
-                    If set to 0, timestaps are not synchonized.
+                short: uXRCE-DDS timestamp synchronization enable
+                long: When enabled, uxrce_dds_client will synchronize the timestamps
+                    of the incoming and outgoing messages measuring the offset
+                    between the Agent OS time and the PX4 time.
             type: boolean
             category: System
             reboot_required: true

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.h
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.h
@@ -49,7 +49,7 @@ public:
 	};
 
 	UxrceddsClient(Transport transport, const char *device, int baudrate, const char *host, const char *port,
-		       bool localhost_only, bool custom_participant, const char *client_namespace);
+		       bool localhost_only, bool custom_participant, const char *client_namespace, bool synchornize_timestamps);
 
 	~UxrceddsClient();
 
@@ -77,6 +77,7 @@ private:
 	const bool _localhost_only;
 	const bool _custom_participant;
 	const char *_client_namespace;
+	const bool _synchronize_timestamps;
 
 
 	// max port characters (5+'\0')


### PR DESCRIPTION
### Problem Solved
micro XRCE-DDS synchronizes the messages timestamp based on the Agent _wall clock_ and the client clock. This is the desired behavior in real applications, but it falls short in simulation.

During Gazebo (Garden) simulations, PX4 gets it time from the Gazebo `/clock` topic which:
- start from zero when the simulation starts.
- Can be faster or slower than the OS wall clock.

It makes sense for a ROS developer to use the same clock source for its nodes. In this scenario the time synchronization is managed by Gazebo itself.
However, by doing so, the micro XRCE-DDS bridge will apply the wrong time offset as it always assumes that the Agent side is using the _wall clock_.

With client side and agent side (the ROS applications) synchronized by Gazebo, there is no need to use the micro XRCE-DDS synchronization routines.

### Solution
- This PR adds a parameter to the `uxrce-dds-client` module, `UXRCE_DDS_SYNCT` that is used to disable time synchronization between Agent and Client. It's default value is `true`.

### Notes
The new parameter is not automatically set to `false` for Gz simulations and there is no automatic way to detect if ROS 2 applications are using the Gazebo clock. Users must manually set / reset its value depending on their needs.

### Changelog Entry
For release notes:

Feature/Bugfix XYZ
New parameter: `UXRCE_DDS_SYNCT`
Documentation: PX4/PX4-user_guide#2594


### Alternatives
- We could also modify the Agent, such that it can use the Gazebo clock.