### PR TITLE
rc.board_arch_defaults: add the silent flag for EKF2_MULTI_IMU

### DIFF
--- a/platforms/nuttx/init/kinetis/rc.board_arch_defaults
+++ b/platforms/nuttx/init/kinetis/rc.board_arch_defaults
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 # Multi-EKF (off by default)
-param set-default EKF2_MULTI_IMU 0
+param set-default -s EKF2_MULTI_IMU 0
 param set-default SENS_IMU_MODE 1
 
 set LOGGER_BUF 8

--- a/platforms/nuttx/init/stm32/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32/rc.board_arch_defaults
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 # Multi-EKF (off by default)
-param set-default EKF2_MULTI_IMU 0
+param set-default -s EKF2_MULTI_IMU 0
 param set-default SENS_IMU_MODE 1
 
 set LOGGER_BUF 8

--- a/platforms/nuttx/init/stm32f7/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32f7/rc.board_arch_defaults
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 # Multi-EKF (across IMUs only)
-param set-default EKF2_MULTI_IMU 3
+param set-default -s EKF2_MULTI_IMU 3
 param set-default SENS_IMU_MODE 0
 
 param set-default -s IMU_GYRO_FFT_EN 1

--- a/platforms/nuttx/init/stm32h7/rc.board_arch_defaults
+++ b/platforms/nuttx/init/stm32h7/rc.board_arch_defaults
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 # Multi-EKF
-param set-default EKF2_MULTI_IMU 3
+param set-default -s EKF2_MULTI_IMU 3
 param set-default SENS_IMU_MODE 0
 
 param set-default -s IMU_GYRO_FFT_EN 1


### PR DESCRIPTION
Not all boards (kakutef7, omnibus) have EKF2 enabled so adding silent flag

![image](https://github.com/PX4/PX4-Autopilot/assets/10188706/de8020d0-22a0-4943-9aec-6924cbca1735)
