### PR TITLE
Tiltrotor: VTOL back-transition: expose tilting time as parameter and reduce overall duration

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -46,7 +46,7 @@ using namespace matrix;
 using namespace time_literals;
 
 #define  FRONTTRANS_THR_MIN 0.25f
-#define BACKTRANS_THROTTLE_DOWNRAMP_DUR_S 1.0f
+#define BACKTRANS_THROTTLE_DOWNRAMP_DUR_S 0.5f;
 #define BACKTRANS_THROTTLE_UPRAMP_DUR_S 1.0f;
 #define BACKTRANS_MOTORS_UPTILT_DUR_S 1.0f;
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -47,7 +47,7 @@ using namespace time_literals;
 
 #define  FRONTTRANS_THR_MIN 0.25f
 #define BACKTRANS_THROTTLE_DOWNRAMP_DUR_S 0.5f;
-#define BACKTRANS_THROTTLE_UPRAMP_DUR_S 1.0f;
+#define BACKTRANS_THROTTLE_UPRAMP_DUR_S 0.5f;
 #define BACKTRANS_MOTORS_UPTILT_DUR_S 1.0f;
 
 Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -45,10 +45,9 @@
 using namespace matrix;
 using namespace time_literals;
 
-#define  FRONTTRANS_THR_MIN 0.25f
-#define BACKTRANS_THROTTLE_DOWNRAMP_DUR_S 0.5f;
-#define BACKTRANS_THROTTLE_UPRAMP_DUR_S 0.5f;
-#define BACKTRANS_MOTORS_UPTILT_DUR_S 1.0f;
+#define FRONTTRANS_THR_MIN 0.25f
+#define BACKTRANS_THROTTLE_DOWNRAMP_DUR_S 0.5f
+#define BACKTRANS_THROTTLE_UPRAMP_DUR_S 0.5f
 
 Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	VtolType(attc)
@@ -321,7 +320,8 @@ void Tiltrotor::update_transition_state()
 		// tilt rotors back once motors are idle
 		if (_time_since_trans_start > BACKTRANS_THROTTLE_DOWNRAMP_DUR_S) {
 
-			float progress = (_time_since_trans_start - BACKTRANS_THROTTLE_DOWNRAMP_DUR_S) / BACKTRANS_MOTORS_UPTILT_DUR_S;
+			float progress = (_time_since_trans_start - BACKTRANS_THROTTLE_DOWNRAMP_DUR_S) / math::max(_param_vt_bt_tilt_dur.get(),
+					 0.1f);
 			progress = math::constrain(progress, 0.0f, 1.0f);
 			_tilt_control = moveLinear(_param_vt_tilt_fw.get(), _param_vt_tilt_mc.get(), progress);
 		}
@@ -458,7 +458,7 @@ void Tiltrotor::blendThrottleDuringBacktransition(float scale, float target_thro
 
 float Tiltrotor::timeUntilMotorsAreUp()
 {
-	return BACKTRANS_THROTTLE_DOWNRAMP_DUR_S + BACKTRANS_MOTORS_UPTILT_DUR_S;
+	return BACKTRANS_THROTTLE_DOWNRAMP_DUR_S + _param_vt_bt_tilt_dur.get();
 }
 
 float Tiltrotor::moveLinear(float start, float stop, float progress)

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -99,7 +99,8 @@ private:
 					(ParamFloat<px4::params::VT_TILT_TRANS>) _param_vt_tilt_trans,
 					(ParamFloat<px4::params::VT_TILT_FW>) _param_vt_tilt_fw,
 					(ParamFloat<px4::params::VT_TILT_SPINUP>) _param_vt_tilt_spinup,
-					(ParamFloat<px4::params::VT_TRANS_P2_DUR>) _param_vt_trans_p2_dur
+					(ParamFloat<px4::params::VT_TRANS_P2_DUR>) _param_vt_trans_p2_dur,
+					(ParamFloat<px4::params::VT_BT_TILT_DUR>) _param_vt_bt_tilt_dur
 				       )
 
 };

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -98,3 +98,17 @@ PARAM_DEFINE_FLOAT(VT_TILT_SPINUP, 0.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_TRANS_P2_DUR, 0.5f);
+
+/**
+ * Duration motor tilt up in backtransition
+ *
+ * Time in seconds it takes to tilt form VT_TILT_FW to VT_TILT_MC.
+ *
+ * @unit s
+ * @min 0.1
+ * @max 10
+ * @increment 0.1
+ * @decimal 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_BT_TILT_DUR, 1.f);


### PR DESCRIPTION
This affects how soon after a backtransition the vehicle has the full hover controller running again. Specifically it reduces the duration of the ramp down of the motors prior to tilting them.


### Solved Problem

The backtransition logic is split into 4 parts:
- ramp down motors
- tilt motors
- ramp up motors
- wait till transition exit conditions are met (groundspeed and time)

The ramp down and the ramp are currently hard-coded to 1s each, as well as the tilting duration. That means that it currently takes 3s from starting the transition to having full MC controller effectiveness. During the first 2s of them purely the FW controller is running and working on stabilizing the system, and then for 1s the MC controller is running but not fully yet. If the vehicle decelerates very fast it can happen that the control surfaces stall already 1s after the back-transition is started, and in that case the vehicle has bad attitude tracking until the 3s when the motors stabilize it again.

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/68a732e8-1909-492b-a0ac-a5cbaa630243)


### Solution
- reduce BACKTRANS_THROTTLE_DOWNRAMP_DUR_S from 1 to 0.5s
- reduce BACKTRANS_THROTTLE_UPRAMP_DUR_S from 1s to 0.5s
- expose backtransition motor tilting time as a parameter `VT_BT_TILT_DUR`

### Changelog Entry
For release notes:
```
Feature: VTOL back-transition: expose tilting time as parameter and reduce overall duration
New parameter: VT_BT_TILT_DUR
```

### Alternatives


### Test coverage
SITL tested.


