### PR TITLE
rc_update: Fix broken negative threshold logic

### DIFF
--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -564,8 +564,9 @@ switch_pos_t RCUpdate::get_rc_sw2pos_position(uint8_t func, float on_th) const
 {
 	if (_rc.function[func] >= 0) {
 		const bool on_inv = (on_th < 0.f);
+		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f; // Scale to 0..1 range
 
-		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f;
+		on_th = fabsf(on_th); // Remove sign from threshold
 
 		if (on_inv ? value < on_th : value > on_th) {
 			return manual_control_switches_s::SWITCH_POS_ON;

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -117,7 +117,13 @@ public:
 	float		get_rc_value(uint8_t func, float min_value, float max_value) const;
 
 	/**
-	 * Get switch position for specified function.
+	 * Get switch position for specified function based on threshold setting
+	 *
+	 * If threshold is positive, the switch has to be above the threshold to be on.
+	 * If threshold is negative, the switch has to be below the threshold to be on.
+	 *
+	 * @param func The function to get the switch position for
+	 * @param on_th The threshold (-1 .. +1) for the switch
 	 */
 	switch_pos_t	get_rc_sw2pos_position(uint8_t func, float on_th) const;
 


### PR DESCRIPTION
### Solved Problem
Previously the negative threshold, which the absolute value of it indicates the threshold RC channel should be lower than, was being compared without removing it's sign.

And since the rescaled RC channel value could never be negative, it could never be lower than the threshold value, leading to the negative (inversed) threshold function to not work.

Fixes https://github.com/PX4/PX4-Autopilot/issues/19809

### Solution
Apply absolute value operation to the threshold value.

### Changelog Entry
Bugfix broken negative RC switch threshold logic

### Test coverage
Haven't done test on real hardware
