### PR TITLE
Fixed-wing/VTOL: High wind hardening

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1040_gazebo-classic_standard_vtol
@@ -47,6 +47,8 @@ param set-default PWM_MAIN_FUNC6 201
 param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_FUNC8 203
 
+param set-default FW_AIRSPD_MAX 25
+param set-default FW_THR_ASPD_MAX 0.4
 param set-default NPFG_PERIOD 12
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
@@ -62,19 +64,18 @@ param set-default FW_T_SINK_MAX 2.7
 param set-default FW_T_SINK_MIN 2.2
 
 param set-default MC_AIRMODE 1
+param set-default MC_ROLL_P 4
 param set-default MC_ROLLRATE_P 0.3
 param set-default MC_YAW_P 1.6
+param set-default MC_YAWRATE_P 0.3
+
 
 param set-default MIS_TAKEOFF_ALT 10
-
-param set-default MPC_XY_P 0.8
-param set-default MPC_XY_VEL_P_ACC 3
-param set-default MPC_XY_VEL_I_ACC 4
-param set-default MPC_XY_VEL_D_ACC 0.1
 
 param set-default NAV_ACC_RAD 5
 
 param set-default VT_FWD_THRUST_EN 4
+param set-default VT_FWD_THRUST_SC 1
 param set-default VT_F_TRANS_THR 0.75
 param set-default VT_TYPE 2
 

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -11,7 +11,7 @@
  * @decimal 2
  * @group Airspeed Validator
  */
-PARAM_DEFINE_FLOAT(ASPD_WIND_NSD, 1.e-2f);
+PARAM_DEFINE_FLOAT(ASPD_WIND_NSD, 1.e-1f);
 
 /**
  * Wind estimator true airspeed scale process noise spectral density
@@ -63,7 +63,7 @@ PARAM_DEFINE_FLOAT(ASPD_BETA_NOISE, 0.15f);
  * @unit SD
  * @group Airspeed Validator
  */
-PARAM_DEFINE_INT32(ASPD_TAS_GATE, 3);
+PARAM_DEFINE_INT32(ASPD_TAS_GATE, 4);
 
 /**
  * Gate size for sideslip angle fusion

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -51,7 +51,7 @@ PARAM_DEFINE_FLOAT(ASPD_TAS_NOISE, 1.4f);
  * @decimal 3
  * @group Airspeed Validator
  */
-PARAM_DEFINE_FLOAT(ASPD_BETA_NOISE, 0.3f);
+PARAM_DEFINE_FLOAT(ASPD_BETA_NOISE, 0.15f);
 
 /**
  * Gate size for true airspeed fusion

--- a/src/modules/ekf2/EKF/sideslip_fusion.cpp
+++ b/src/modules/ekf2/EKF/sideslip_fusion.cpp
@@ -71,9 +71,7 @@ void Ekf::controlBetaFusion(const imuSample &imu_delayed)
 				resetWindToZero();
 			}
 
-			if (Vector2f(Vector2f(_state.vel) - _state.wind_vel).longerThan(7.f)) {
-				fuseSideslip(_aid_src_sideslip);
-			}
+			fuseSideslip(_aid_src_sideslip);
 		}
 	}
 }

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -342,7 +342,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_E_NOISE, 1.0e-3f);
  * @unit m/s^2/sqrt(Hz)
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(EKF2_WIND_NSD, 1.0e-2f);
+PARAM_DEFINE_FLOAT(EKF2_WIND_NSD, 5.0e-2f);
 
 /**
  * Measurement noise for gps horizontal velocity.
@@ -601,7 +601,7 @@ PARAM_DEFINE_FLOAT(EKF2_GPS_V_GATE, 5.0f);
  * @unit SD
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
+PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 5.0f);
 
 /**
  * Will be removed after v1.14 release

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -327,10 +327,19 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 
 	// differential pressure
 	if ((sensors.fields_updated & SensorSource::DIFF_PRESS) == SensorSource::DIFF_PRESS && !_airspeed_disconnected) {
+
+		float airspeed_blockage_scale = 1.f;
+		const float airspeed_blockage_rampup_time = 60_s; // time it takes to block the airspeed sensor completely, linear ramp
+
+		if (_airspeed_blocked_timestamp > 0) {
+			airspeed_blockage_scale = math::constrain(1.f - (hrt_absolute_time() - _airspeed_blocked_timestamp) /
+						  airspeed_blockage_rampup_time, 0.5f, 1.f);
+		}
+
 		differential_pressure_s report{};
 		report.timestamp_sample = time;
 		report.device_id = 1377548; // 1377548: DRV_DIFF_PRESS_DEVTYPE_SIM, BUS: 1, ADDR: 5, TYPE: SIMULATION
-		report.differential_pressure_pa = sensors.diff_pressure * 100.f; // hPa to Pa;
+		report.differential_pressure_pa = sensors.diff_pressure * 100.f * airspeed_blockage_scale; // hPa to Pa;
 		report.temperature = _sensors_temperature;
 		report.timestamp = hrt_absolute_time();
 		_differential_pressure_pub.publish(report);
@@ -1433,10 +1442,16 @@ void SimulatorMavlink::check_failure_injections()
 				supported = true;
 				_airspeed_disconnected = true;
 
+			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_WRONG) {
+				PX4_WARN("CMD_INJECT_FAILURE, airspeed wrong (simulate icing)");
+				supported = true;
+				_airspeed_blocked_timestamp = hrt_absolute_time();
+
 			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
 				PX4_INFO("CMD_INJECT_FAILURE, airspeed ok");
 				supported = true;
 				_airspeed_disconnected = false;
+				_airspeed_blocked_timestamp = 0;
 			}
 
 		} else if (failure_unit == vehicle_command_s::FAILURE_UNIT_SENSOR_VIO) {

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -326,7 +326,7 @@ void SimulatorMavlink::update_sensors(const hrt_abstime &time, const mavlink_hil
 	}
 
 	// differential pressure
-	if ((sensors.fields_updated & SensorSource::DIFF_PRESS) == SensorSource::DIFF_PRESS && !_airspeed_blocked) {
+	if ((sensors.fields_updated & SensorSource::DIFF_PRESS) == SensorSource::DIFF_PRESS && !_airspeed_disconnected) {
 		differential_pressure_s report{};
 		report.timestamp_sample = time;
 		report.device_id = 1377548; // 1377548: DRV_DIFF_PRESS_DEVTYPE_SIM, BUS: 1, ADDR: 5, TYPE: SIMULATION
@@ -1431,12 +1431,12 @@ void SimulatorMavlink::check_failure_injections()
 			if (failure_type == vehicle_command_s::FAILURE_TYPE_OFF) {
 				PX4_WARN("CMD_INJECT_FAILURE, airspeed off");
 				supported = true;
-				_airspeed_blocked = true;
+				_airspeed_disconnected = true;
 
 			} else if (failure_type == vehicle_command_s::FAILURE_TYPE_OK) {
 				PX4_INFO("CMD_INJECT_FAILURE, airspeed ok");
 				supported = true;
-				_airspeed_blocked = false;
+				_airspeed_disconnected = false;
 			}
 
 		} else if (failure_unit == vehicle_command_s::FAILURE_UNIT_SENSOR_VIO) {

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -294,7 +294,7 @@ private:
 	bool _mag_stuck[MAG_COUNT_MAX] {};
 
 	bool _gps_blocked{false};
-	bool _airspeed_blocked{false};
+	bool _airspeed_disconnected{false};
 	bool _vio_blocked{false};
 
 	float _last_magx[MAG_COUNT_MAX] {};

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.hpp
@@ -295,6 +295,7 @@ private:
 
 	bool _gps_blocked{false};
 	bool _airspeed_disconnected{false};
+	hrt_abstime _airspeed_blocked_timestamp{0};
 	bool _vio_blocked{false};
 
 	float _last_magx[MAG_COUNT_MAX] {};

--- a/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
+++ b/src/modules/simulation/simulator_mavlink/sitl_targets_gazebo-classic.cmake
@@ -112,6 +112,7 @@ if(gazebo_FOUND)
 		empty
 		ksql_airport
 		mcmillan_airfield
+		ramped_up_wind
 		sonoma_raceway
 		warehouse
 		windy

--- a/test/mavsdk_tests/CMakeLists.txt
+++ b/test/mavsdk_tests/CMakeLists.txt
@@ -31,6 +31,8 @@ if(MAVSDK_FOUND)
         test_vtol_mission.cpp
         test_vtol_figure_eight.cpp
         test_vtol_rtl.cpp
+        test_vtol_mission_wind.cpp
+        test_vtol_loiter_airspeed_failure_blockage.cpp
         # test_multicopter_follow_me.cpp
     )
 

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -164,6 +164,11 @@ void AutopilotTester::set_rc_loss_exception(AutopilotTester::RcLossException mas
 	}
 }
 
+void AutopilotTester::set_param_vt_fwd_thrust_en(int value)
+{
+	CHECK(_param->set_param_int("VT_FWD_THRUST_EN", value) == Param::Result::Success);
+}
+
 void AutopilotTester::arm()
 {
 	const auto result = _action->arm();
@@ -946,4 +951,26 @@ void AutopilotTester::report_speed_factor()
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	}
+}
+
+void AutopilotTester::enable_fixedwing_mectrics()
+{
+	CHECK(getTelemetry()->set_rate_fixedwing_metrics(10.f) == Telemetry::Result::Success);
+}
+
+void AutopilotTester::check_airspeed_is_valid()
+{
+	// If the airspeed was invalidated during the flight, the airspeed is sent in the
+	// telemetry is NAN and stays so with the default parameter settings.
+	const Telemetry::FixedwingMetrics &metrics = getTelemetry()->fixedwing_metrics();
+	REQUIRE(std::isfinite(metrics.airspeed_m_s));
+}
+
+void AutopilotTester::check_airspeed_is_invalid()
+{
+	// If the airspeed was invalidated during the flight, the airspeed is sent in the
+	// telemetry is NAN and stays so with the default parameter settings.
+	const Telemetry::FixedwingMetrics &metrics = getTelemetry()->fixedwing_metrics();
+	std::cout << "Reported airspeed after failure: " << metrics.airspeed_m_s ;
+	REQUIRE(!std::isfinite(metrics.airspeed_m_s));
 }

--- a/test/mavsdk_tests/autopilot_tester.h
+++ b/test/mavsdk_tests/autopilot_tester.h
@@ -110,6 +110,7 @@ public:
 	void set_rtl_altitude(const float altitude_m);
 	void set_height_source(HeightSource height_source);
 	void set_rc_loss_exception(RcLossException mask);
+	void set_param_vt_fwd_thrust_en(int value);
 	void arm();
 	void takeoff();
 	void land();
@@ -150,6 +151,10 @@ public:
 	void send_custom_mavlink_command(const MavlinkPassthrough::CommandInt &command);
 	void send_custom_mavlink_message(mavlink_message_t &message);
 	void add_mavlink_message_callback(uint16_t message_id, std::function< void(const mavlink_message_t &)> callback);
+
+	void enable_fixedwing_mectrics();
+	void check_airspeed_is_valid();
+	void check_airspeed_is_invalid();
 
 	// Blocking call to get the drone's current position in NED frame
 	std::array<float, 3> get_current_position_ned();

--- a/test/mavsdk_tests/configs/sitl.json
+++ b/test/mavsdk_tests/configs/sitl.json
@@ -22,7 +22,7 @@
         {
             "model": "standard_vtol",
             "vehicle": "standard_vtol",
-            "test_filter": "[vtol]",
+            "test_filter": "[vtol], [vtol_wind], [vtol_airspeed_fail]",
             "timeout_min": 10
         },
         {

--- a/test/mavsdk_tests/mavsdk_test_runner.py
+++ b/test/mavsdk_tests/mavsdk_test_runner.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import psutil  # type: ignore
+import re
 import signal
 import subprocess
 import sys
@@ -402,6 +403,13 @@ class Tester:
 
         if self.config['mode'] == 'sitl':
             if self.config['simulator'] == 'gazebo':
+                # Use RegEx to extract worldname.world from case name
+                match = re.search(r'\((.*?\.world)\)', case)
+                if match:
+                    world_name = match.group(1)
+                else:
+                    world_name = 'empty.world'
+
                 gzserver_runner = ph.GzserverRunner(
                     os.getcwd(),
                     log_dir,
@@ -409,7 +417,8 @@ class Tester:
                     case,
                     self.get_max_speed_factor(test),
                     self.verbose,
-                    self.build_dir)
+                    self.build_dir,
+                    world_name)
                 self.active_runners.append(gzserver_runner)
 
                 gzmodelspawn_runner = ph.GzmodelspawnRunner(

--- a/test/mavsdk_tests/process_helper.py
+++ b/test/mavsdk_tests/process_helper.py
@@ -221,7 +221,8 @@ class GzserverRunner(Runner):
                  case: str,
                  speed_factor: float,
                  verbose: bool,
-                 build_dir: str):
+                 build_dir: str,
+                 world_name: str):
         super().__init__(log_dir, model, case, verbose)
         self.name = "gzserver"
         self.cwd = workspace_dir
@@ -234,7 +235,7 @@ class GzserverRunner(Runner):
         self.args = ["-o0", "-e0", "gzserver", "--verbose",
                      os.path.join(workspace_dir,
                                   PX4_GAZEBO_WORLDS,
-                                  "empty.world")]
+                                  world_name)]
 
     def has_started_ok(self) -> bool:
         # Wait until gzerver has started and connected to gazebo master.

--- a/test/mavsdk_tests/test_vtol_loiter_airspeed_failure_blockage.cpp
+++ b/test/mavsdk_tests/test_vtol_loiter_airspeed_failure_blockage.cpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "autopilot_tester.h"
+#include "autopilot_tester_failure.h"
+
+
+TEST_CASE("Fly VTOL Loiter with airspeed failure", "[vtol_airspeed_fail]")
+{
+	AutopilotTesterFailure tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+
+	tester.enable_fixedwing_mectrics();
+
+	// configuration
+	const float takeoff_altitude = 10.f;
+	tester.set_takeoff_altitude(takeoff_altitude);
+
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_straight_south.plan");
+	tester.arm();
+
+	tester.takeoff();
+	tester.wait_until_altitude(takeoff_altitude, std::chrono::seconds(30));
+	tester.transition_to_fixedwing();
+
+
+	// tester.wait_until_altitude(50.f, std::chrono::seconds(30));
+	std::this_thread::sleep_for(std::chrono::seconds(10));
+	tester.inject_failure(mavsdk::Failure::FailureUnit::SensorAirspeed, mavsdk::Failure::FailureType::Wrong, 0,
+			      mavsdk::Failure::Result::Success);
+
+
+	std::this_thread::sleep_for(std::chrono::seconds(10));
+
+	tester.check_airspeed_is_invalid(); // it's enough to check once after landing, as invalidation is permanent
+}

--- a/test/mavsdk_tests/test_vtol_mission_wind.cpp
+++ b/test/mavsdk_tests/test_vtol_mission_wind.cpp
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "autopilot_tester.h"
+
+
+TEST_CASE("Fly VTOL mission with wind change (ramped_up_wind.world)", "[vtol_wind]")
+{
+	AutopilotTester tester;
+	tester.connect(connection_url);
+	tester.wait_until_ready();
+
+	tester.set_param_vt_fwd_thrust_en(1); // disable in land to be more robust in wind (less lift)
+	tester.enable_fixedwing_mectrics();
+
+	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_straight_south.plan");
+	tester.arm();
+	tester.execute_mission_raw();
+	tester.wait_until_disarmed();
+
+	tester.check_airspeed_is_valid(); // it's enough to check once after landing, as invalidation is permanent
+}

--- a/test/mavsdk_tests/vtol_mission_straight_south.plan
+++ b/test/mavsdk_tests/vtol_mission_straight_south.plan
@@ -1,0 +1,73 @@
+{
+    "UUID": "6c95e3a0dedfb83ac6a4c3711fa182224c31dba9",
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "MISSION_ITEM_ID": "1",
+                "autoContinue": true,
+                "command": 84,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39712597967924,
+                    8.545720879548579,
+                    30
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 30,
+                "AltitudeMode": 1,
+                "MISSION_ITEM_ID": "2",
+                "autoContinue": true,
+                "command": 21,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.38497919751799,
+                    8.54578066404548,
+                    30
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            47.3977508,
+            8.5456074,
+            488.145
+        ],
+        "vehicleType": 20,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}


### PR DESCRIPTION
### Solved Problem
We had an incident lately where a VTOL flew into a thunderstorm, which caused a couple of (linked) issues to surface.


Chain of events:
- wind increases by 15m/s within roughly 1min, from 8m/s to ~23m/s. In the steepest part of the wind increase it went up  1m/s in average (from 10.5 to 22m/s within 15s)
- airspeed is declared invalid shortly after hitting the wind wall (due to high airspeed innovation compared to the wind estimate by the validator)
- the EKF wind states reset to wrong values and in the following never recover again (reset because of fusion timeout, both by airspeed and beta fusion)
- NPFG (lateral FW guidance) assumes wind valid and keeps using it. As the states are obviously majorly wrong the vehicle drifts away while doing circles

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/75cca8c1-dd51-4471-9e84-524f8ed29dd0)

Reproduced condition in SITL: constant wind of 5m/s from S, then a wind increase of 15m/s ramped up over 15s. To make it simple I focused on flying only fully straight, which in general is the most critical case (beta fusion is useless when not turning). I set the vehicle to fly in full head-wind.

In the following I will apply patch by patch:

**0. Current state:** 
Airspeed is declared invalid, vehicle gets blown to the north while doing circles. Both the wind estimates in the airspeed validator and the one in EKF don't keep up and the airspeed fusion times out, causing the airspeed one to be stuck at a low value, while the EKF one gets reset a couple of times to invalid values (initial reset triggered as beta fusion times out as well (hard coded 10s).

https://github.com/PX4/PX4-Autopilot/assets/26798987/b005b070-9896-4a1d-b5ca-00c9d69bf2d8

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/237e6ee7-3c03-48ee-a35a-199fa81ec186)

**1. With the extra check in the beta fusion removed:**
The airspeed is still declared invalid but as the beta fusion never stops, the wind states don't get reset. As beta is not observable when flying directly against the wind as in this example, the wind states though don't change anymore without airspeed fusion. The wind direction being estimated correctly but the magnitude being off results in the vehicle flying backwards.

https://github.com/PX4/PX4-Autopilot/assets/26798987/686bb899-435e-43d7-9c0f-eaea86ebc983

**2. With the airspeed wind noise increased:**
.ASPD_WIND_NSD is set to 0.1 from 0.01.
This makes the wind states of the validator dynamic enough that the innovations stay below the threshold of 5m/s, thus not triggering an airspeed failure.
The EKF2 wind tuning is left unchanged. It soon after the wind increase doesn't updated the wind states anymore because the TAS_test_ratio is above 1 (and beta is not observable when flying in direct head-wind). The EKF2 wind states thus stay at a too low value. 

https://github.com/PX4/PX4-Autopilot/assets/26798987/2b828569-5c51-43b7-874f-68a1324b9486

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/79849f1d-0ed6-4c69-aad1-3f38649547f2)

**3. EKF wind increased noise and gate:** 
Now we have nominal behavior. Thanks to the correct wind estimation NPFG increases the airspeed setpoint to keep a minimal groundspeed. 

https://github.com/PX4/PX4-Autopilot/assets/26798987/aa4eaa7e-6d3d-45cd-910e-aa65c368b916

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/1644d231-9b92-4ac7-9ce0-8a6a7a37a348)



### Solution
Step by step to address point 1, 2 and 3 from above:
1. [remove >7m/s constructed airspeed condition](https://github.com/PX4/PX4-Autopilot/pull/21764/commits/461dcd0bbeaa61ebdd31736cc3ece1ab9322c6bc) for beta fusion. Was this meant to not fuse beta when the vehicle is stalling? 
2. [increase ASPD_WIND_NSD from 0.01 to 0.1 and ASPD_TAS_GATE from 3 to 5](https://github.com/PX4/PX4-Autopilot/pull/21764/commits/bb6a3037935cf98e8eadd9d617b2fed4d17daf50)
3.[ increase EKF2_WIND_NSD from 0.01 to 0.05,](https://github.com/PX4/PX4-Autopilot/pull/21764/commits/2e431aebcd7b6cae85d90e2f51d064c447b5283c) thus still less dynamic compared to the airspeed validator wind estimator but it's enough for the defined requirements here. Also increase EKF2_TAS_GATE from 3 to 5.

The changes made for step 2 (increased wind process noise in the airspeed validator) could negatively affect airspeed failure detection. It can get less likely/slower to detect airspeed failures where the sensor slowly degrades, as the system is quicker to learn a wrong wind estimate. 

The case we need to cover is for example icing of the pitot tube. Data from a real case is the following:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/92084253-ac04-46df-9e65-48cea8c3b80b)

I've added a failure injection mode that simulates an icing occurrence (50% scale ramped up within 1min).

When flying dead straight there is nothing holding back the wind estimate from completely diverging to a wrong estimate in this case, but then as soon as a loiter is established the beta fusion pulls the states back closer to 0, and following invalidates the airspeed reading. To further accelerate this [I've reduced the default of ASPD_BETA_NOISE to 0.15 (from 0.3):
](https://github.com/PX4/PX4-Autopilot/pull/21764/commits/7090767c98b23227783ee5ad638ddfc7b824198e)
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/6bc77b0b-8f5b-42de-9bcc-d8a432e116f7)

My proposal is maybe a bit too biased towards circling/turning fixing-wings (=vehicles normally flying in use-cases that require them to loiter or fly patterns with lots of turns). We maybe want to come to a middle ground, to both handle dynamic wind increases and real airspeed failures in straight flights. If we add a bit of docs this customization is though also something that people can easily configure for their use case. 
Longer term it may make sense to link the airspeed innovation thresholds to the current variance of the wind states.

CI tests are WIP (to cover both dynamic wind handling and "icing").

### Changelog Entry
For release notes:
```
Improvement: Fixed-wing high (dynamic) wind hardening
```


### Test coverage
SITL tested. I added the test to the CI (WIP)

