### PR TITLE
Updates GZBridge to extract the drone name from a drone in a nested S…

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -68,8 +68,9 @@ GZBridge::~GZBridge()
 
 int GZBridge::init()
 {
-	if (!_model_sim.empty()) {
+	std::string model_name_no_nesting = model_name_trim_nesting();
 
+	if (!_model_sim.empty()) {
 		// service call to create model
 		gz::msgs::EntityFactory req{};
 		req.set_sdf_filename(_model_sim + "/model.sdf");
@@ -181,12 +182,12 @@ int GZBridge::init()
 		return PX4_ERROR;
 	}
 
-	if (!_mixing_interface_esc.init(_model_name)) {
+	if (!_mixing_interface_esc.init(model_name_no_nesting)) {
 		PX4_ERR("failed to init ESC output");
 		return PX4_ERROR;
 	}
 
-	if (!_mixing_interface_servo.init(_model_name)) {
+	if (!_mixing_interface_servo.init(model_name_no_nesting)) {
 		PX4_ERR("failed to init servo output");
 		return PX4_ERROR;
 	}
@@ -471,8 +472,10 @@ void GZBridge::poseInfoCallback(const gz::msgs::Pose_V &pose)
 
 	pthread_mutex_lock(&_node_mutex);
 
+	std::string model_name_no_nesting = model_name_trim_nesting();
+
 	for (int p = 0; p < pose.pose_size(); p++) {
-		if (pose.pose(p).name() == _model_name) {
+		if (pose.pose(p).name() == model_name_no_nesting) {
 
 			const uint64_t time_us = (pose.header().stamp().sec() * 1000000) + (pose.header().stamp().nsec() / 1000);
 
@@ -749,6 +752,20 @@ int GZBridge::print_usage(const char *reason)
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
 	return 0;
+}
+
+std::string GZBridge::model_name_trim_nesting()
+{
+	int ind_slash = _model_name.find_last_of("/");
+	std::string model_name_no_nesting = "";
+
+	if(ind_slash >= 0){
+		model_name_no_nesting = _model_name.substr(ind_slash+1, _model_name.length());
+	}else{
+		model_name_no_nesting = _model_name;
+	}
+
+	return model_name_no_nesting;
 }
 
 extern "C" __EXPORT int gz_bridge_main(int argc, char *argv[])

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -103,6 +103,8 @@ private:
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
 
+	std::string model_name_trim_nesting();
+
 	/**
 	*
 	* Convert a quaterion from FLU_to_ENU frames (ROS convention)


### PR DESCRIPTION
### Solved Problem
Allows drones in nested SDF models to be flown in gz simulation. This is important if drones are to be connected for multi-drone load carrying and other applications.

Fixes #21767

### Solution
- In GZBridge, extracted the actual drone name from the full nested name.

### Changelog Entry
For release notes:
```
Feature/Bugfix: Allows drones nested in other SDF models to be connected to and flown in gz simulation.
Documentation: Perhaps add clarification to page: https://docs.px4.io/main/en/sim_gazebo_gz/multi_vehicle_simulation.html. 
```

### Alternatives
- Set GZBridge's _model_name parameter to just be the drone name every time GZBridge is initialized. 
- Update the classes GZMixingInterfaceESC and GZMixingInterfaceServo to work with nested names. 

### Test coverage
- Ran single-drone sitl and functions exactly as before. Ran single drone in nested model and functions as expected.
- Simulation testing logs: https://logs.px4.io/plot_app?log=e5bd0ed5-c935-40ff-9b89-2ff85caefbf6

### Context
See [here](https://discuss.px4.io/t/simulating-multiple-physically-connected-drones-in-gazebo/31153) for full discussion.
