### PR TITLE
Optical Flow Fixes

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -416,6 +416,7 @@ struct parameters {
 	float flow_noise{0.15f};                ///< observation noise for optical flow LOS rate measurements (rad/sec)
 	float flow_noise_qual_min{0.5f};        ///< observation noise for optical flow LOS rate measurements when flow sensor quality is at the minimum useable (rad/sec)
 	int32_t flow_qual_min{1};               ///< minimum acceptable quality integer from  the flow sensor
+	int32_t flow_qual_min_gnd{0};           ///< minimum acceptable quality integer from  the flow sensor when on ground
 	float flow_innov_gate{3.0f};            ///< optical flow fusion innovation consistency gate size (STD)
 
 	Vector3f flow_pos_body{};               ///< xyz position of range sensor focal point in body frame (m)

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -83,13 +83,10 @@ void Ekf::updateOptFlow(estimator_aid_source2d_s &aid_src)
 	Vector2f innov_var;
 	Vector24f H;
 	sym::ComputeFlowXyInnovVarAndHx(state_vector, P, range, R_LOS, FLT_EPSILON, &innov_var, &H);
-	innov_var.copyTo(_aid_src_optical_flow.innovation_variance);
+	innov_var.copyTo(aid_src.innovation_variance);
 
 	// run the innovation consistency check and record result
-	setEstimatorAidStatusTestRatio(_aid_src_optical_flow, math::max(_params.flow_innov_gate, 1.f));
-
-	_innov_check_fail_status.flags.reject_optflow_X = (_aid_src_optical_flow.test_ratio[0] > 1.f);
-	_innov_check_fail_status.flags.reject_optflow_Y = (_aid_src_optical_flow.test_ratio[1] > 1.f);
+	setEstimatorAidStatusTestRatio(aid_src, math::max(_params.flow_innov_gate, 1.f));
 }
 
 void Ekf::fuseOptFlow()

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -90,8 +90,6 @@ void Ekf::updateOptFlow(estimator_aid_source2d_s &aid_src)
 
 	_innov_check_fail_status.flags.reject_optflow_X = (_aid_src_optical_flow.test_ratio[0] > 1.f);
 	_innov_check_fail_status.flags.reject_optflow_Y = (_aid_src_optical_flow.test_ratio[1] > 1.f);
-
-	// PX4_WARN("updateOptFlow: %f,%f   %f,%f\n", (double)aid_src.innovation[0], (double)aid_src.innovation[1], (double)aid_src.innovation_variance[0], (double)aid_src.innovation_variance[1]);
 }
 
 void Ekf::fuseOptFlow()

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -70,7 +70,12 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 	}
 
 	if (_flow_data_ready) {
-		const bool is_quality_good = (_flow_sample_delayed.quality >= _params.flow_qual_min);
+		int32_t min_quality = _params.flow_qual_min;
+		if (!_control_status.flags.in_air) {
+			min_quality = _params.flow_qual_min_gnd;
+		}
+
+		const bool is_quality_good = (_flow_sample_delayed.quality >= min_quality);
 		const bool is_magnitude_good = !_flow_sample_delayed.flow_xy_rad.longerThan(_flow_sample_delayed.dt * _flow_max_rate);
 		const bool is_tilt_good = (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
 

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -204,7 +204,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 			if (_time_delayed_us > (_flow_sample_delayed.time_us - uint32_t(1e6f * _flow_sample_delayed.dt) / 2)) {
 				// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
 				// but use a relaxed time criteria to enable it to coast through bad range finder data
-				if (isRecent(_time_last_hagl_fuse, (uint64_t)100e6)) {
+				if (isRecent(_time_last_hagl_fuse, (uint64_t)10e6)) {
 					fuseOptFlow();
 					_last_known_pos.xy() = _state.pos.xy();
 				}

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -59,7 +59,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 
 	// Accumulate autopilot gyro data across the same time interval as the flow sensor
 	const Vector3f delta_angle(imu_delayed.delta_ang - (getGyroBias() * imu_delayed.delta_ang_dt));
-	if (_delta_time_of < 0.5f) {
+	if (_delta_time_of < 0.2f) {
 		_imu_del_ang_of += delta_angle;
 		_delta_time_of += imu_delayed.delta_ang_dt;
 
@@ -75,7 +75,7 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 		const bool is_tilt_good = (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
 
 		const float delta_time_min = fmaxf(0.7f * _delta_time_of, 0.001f);
-		const float delta_time_max = fminf(1.3f * _delta_time_of, 0.5f);
+		const float delta_time_max = fminf(1.3f * _delta_time_of, 0.2f);
 		bool is_delta_time_good = _flow_sample_delayed.dt >= delta_time_min && _flow_sample_delayed.dt <= delta_time_max;
 
 		if (!is_delta_time_good && (_flow_sample_delayed.dt > FLT_EPSILON)) {

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -59,7 +59,6 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 
 	// Accumulate autopilot gyro data across the same time interval as the flow sensor
 	const Vector3f delta_angle(imu_delayed.delta_ang - (getGyroBias() * imu_delayed.delta_ang_dt));
-	// increase limit from 0.1f to 0.5f
 	if (_delta_time_of < 0.5f) {
 		_imu_del_ang_of += delta_angle;
 		_delta_time_of += imu_delayed.delta_ang_dt;
@@ -76,7 +75,6 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 		const bool is_tilt_good = (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
 
 		const float delta_time_min = fmaxf(0.7f * _delta_time_of, 0.001f);
-		// increase hard max to 0.5f from 0.2f
 		const float delta_time_max = fminf(1.3f * _delta_time_of, 0.5f);
 		bool is_delta_time_good = _flow_sample_delayed.dt >= delta_time_min && _flow_sample_delayed.dt <= delta_time_max;
 
@@ -206,15 +204,10 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 			if (_time_delayed_us > (_flow_sample_delayed.time_us - uint32_t(1e6f * _flow_sample_delayed.dt) / 2)) {
 				// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
 				// but use a relaxed time criteria to enable it to coast through bad range finder data
-
-				// give much larger timeout (10x) for hagl fuse
 				if (isRecent(_time_last_hagl_fuse, (uint64_t)100e6)) {
 					fuseOptFlow();
 					_last_known_pos.xy() = _state.pos.xy();
 				}
-				// else {
-				// 	PX4_WARN("terrain estimator sad %ld", _time_last_hagl_fuse);
-				// }
 
 				_flow_data_ready = false;
 			}

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -154,6 +154,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_of_n_min(_params->flow_noise),
 	_param_ekf2_of_n_max(_params->flow_noise_qual_min),
 	_param_ekf2_of_qmin(_params->flow_qual_min),
+	_param_ekf2_of_qmin_gnd(_params->flow_qual_min_gnd),
 	_param_ekf2_of_gate(_params->flow_innov_gate),
 	_param_ekf2_of_pos_x(_params->flow_pos_body(0)),
 	_param_ekf2_of_pos_y(_params->flow_pos_body(1)),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -662,7 +662,9 @@ private:
 		(ParamExtFloat<px4::params::EKF2_OF_N_MAX>)
 		_param_ekf2_of_n_max, ///< worst quality observation noise for optical flow LOS rate measurements (rad/sec)
 		(ParamExtInt<px4::params::EKF2_OF_QMIN>)
-		_param_ekf2_of_qmin, ///< minimum acceptable quality integer from  the flow sensor
+		_param_ekf2_of_qmin, ///< minimum acceptable quality integer from  the flow sensor when in air
+		(ParamExtInt<px4::params::EKF2_OF_QMIN_GND>)
+		_param_ekf2_of_qmin_gnd, ///< minimum acceptable quality integer from  the flow sensor when on ground
 		(ParamExtFloat<px4::params::EKF2_OF_GATE>)
 		_param_ekf2_of_gate, ///< optical flow fusion innovation consistency gate size (STD)
 		(ParamExtFloat<px4::params::EKF2_OF_POS_X>)

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -901,13 +901,22 @@ PARAM_DEFINE_FLOAT(EKF2_OF_N_MIN, 0.15f);
 PARAM_DEFINE_FLOAT(EKF2_OF_N_MAX, 0.5f);
 
 /**
- * Optical Flow data will only be used if the sensor reports a quality metric >= EKF2_OF_QMIN.
+ * Optical Flow data will only be used in air if the sensor reports a quality metric >= EKF2_OF_QMIN.
  *
  * @group EKF2
  * @min 0
  * @max 255
  */
 PARAM_DEFINE_INT32(EKF2_OF_QMIN, 1);
+
+/**
+ * Optical Flow data will only be used on the ground if the sensor reports a quality metric >= EKF2_OF_QMIN_GND.
+ *
+ * @group EKF2
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(EKF2_OF_QMIN_GND, 0);
 
 /**
  * Gate size for optical flow fusion


### PR DESCRIPTION
This PR brings in @katzfey changes from https://github.com/PX4/PX4-Autopilot/pull/21436 and adds a new parameter EKF2_OF_QMIN_GND to set the minimum optical flow quality when on the ground. Solves https://github.com/PX4/PX4-Autopilot/issues/20929

When the optical flow sensor is sitting in tall grass, it will output a 0 quality and is_quality_good is become false. 

This will need to be backported into the 1.14 release branch.

Optical Flow fusion with GPS fusion on
https://review.px4.io/plot_app?log=d6a23cd7-a292-49c5-a543-cc483856d019
On a different 250 - https://review.px4.io/plot_app?log=2e87a149-4992-47d1-84fe-693675a0221c
https://review.px4.io/plot_app?log=f353442a-f324-4b15-b4cb-109403e36ebe

Optical Flow fusion with GPS fusion off
https://review.px4.io/plot_app?log=92315c6d-ed04-4e06-b534-995f269ffd85

![PXL_20230627_234210543 cropped](https://github.com/PX4/PX4-Autopilot/assets/2019539/2086b6cd-0aa6-4651-88f2-1041b4ba3346)