### PR TITLE
Navigator: Loiter: always establish new Loiter with center at current position

### DIFF
--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -61,6 +61,7 @@ Loiter::on_activation()
 		reposition();
 
 	} else {
+		// this is executed when the flight mode is switched to Hold manually, not through a reposition
 		set_loiter_position();
 	}
 
@@ -109,16 +110,11 @@ Loiter::set_loiter_position()
 		_mission_item.nav_cmd = NAV_CMD_IDLE;
 
 	} else {
-		if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
-			setLoiterItemFromCurrentPositionSetpoint(&_mission_item);
+		if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+			setLoiterItemFromCurrentPositionWithBreaking(&_mission_item);
 
 		} else {
-			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-				setLoiterItemFromCurrentPositionWithBreaking(&_mission_item);
-
-			} else {
-				setLoiterItemFromCurrentPosition(&_mission_item);
-			}
+			setLoiterItemFromCurrentPosition(&_mission_item);
 		}
 
 	}


### PR DESCRIPTION
### Solved Problem
https://github.com/PX4/PX4-Autopilot/issues/21702

Vehicle keeps flying towards Loiter waypoint if Hold mode is selected. In the past we within Navigator set the type to POSITION when far away from a Loiter waypoint, and then only to LOITER when really on established loiter, but this distinction is now no longer part of Navigator and the FW position controller handles it.

### Solution
When switching into Hold mode establish a Loiter around current position, even if we were before already loitering (eg in Mission mode). This results in the same behavior when switching into Hold/Loiter mode directly (either through RC switch or in the flight mode selection in QGC) or through the "Hold" button in QGC (which sends a DO_REPOSITION with the fields at the current position). 

In this screen recording you see the behavior prior and after this PR.
https://github.com/PX4/PX4-Autopilot/assets/26798987/9079b575-77fc-40a2-be54-b3c11816cca3

### Changelog Entry
For release notes:
```
Bugfix: Fixed-wing: Always establish loiter around current position when switching into Hold mode
```


### Alternatives
Fix detection on whether we're currently on an established loiter, and in that case don't loiter around current position but keep established loiter. Personally I though prefer to stick to Hold = Loiter around current position always. Imagine being on a huge loiter. If the vehicle then keeps following it it's hardly anymore "Holding position". 

