### PR TITLE
Navigator: loiter: remove unnecessary _loiter_pos_set

### DIFF
--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -49,12 +49,6 @@ Loiter::Loiter(Navigator *navigator) :
 }
 
 void
-Loiter::on_inactive()
-{
-	_loiter_pos_set = false;
-}
-
-void
 Loiter::on_activation()
 {
 	if (_navigator->get_reposition_triplet()->current.valid) {
@@ -74,11 +68,6 @@ Loiter::on_active()
 	if (_navigator->get_reposition_triplet()->current.valid) {
 		reposition();
 	}
-
-	// reset the loiter position if we get disarmed
-	if (_navigator->get_vstatus()->arming_state != vehicle_status_s::ARMING_STATE_ARMED) {
-		_loiter_pos_set = false;
-	}
 }
 
 void
@@ -93,15 +82,9 @@ Loiter::set_loiter_position()
 		_navigator->set_can_loiter_at_sp(false);
 		_navigator->get_position_setpoint_triplet()->current.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
 		_navigator->set_position_setpoint_triplet_updated();
-		_loiter_pos_set = false;
 		return;
 
-	} else if (_loiter_pos_set) {
-		// Already set, nothing to do.
-		return;
 	}
-
-	_loiter_pos_set = true;
 
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -51,7 +51,7 @@ public:
 	Loiter(Navigator *navigator);
 	~Loiter() = default;
 
-	void on_inactive() override;
+	// void on_inactive() override;
 	void on_activation() override;
 	void on_active() override;
 
@@ -67,5 +67,4 @@ private:
 	 */
 	void set_loiter_position();
 
-	bool _loiter_pos_set{false};
 };

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -51,7 +51,6 @@ public:
 	Loiter(Navigator *navigator);
 	~Loiter() = default;
 
-	// void on_inactive() override;
 	void on_activation() override;
 	void on_active() override;
 


### PR DESCRIPTION
### Solved Problem
While working on https://github.com/PX4/PX4-Autopilot/pull/21775 I noticed this seemingly unnecessary class variable `_loiter_pos_set`, that was set to false in `on_inactive()` or in `on_active`, and then though only ever checked in `on_activation` (through `set_loiter_position()`). I don't see how it could be false when entering on_activation(), and thus can just be removed, or am I missing something?

### Solution
Remove it!

### Changelog Entry
For release notes:
```
Refactor: remove unnecessary variable
```

### Test coverage
Bit of SITL testing.

