### PR TITLE
Add analog RSSI for boards without dedicated RSSI in pin

### DIFF
--- a/boards/ark/fmu-v6x/src/board_config.h
+++ b/boards/ark/fmu-v6x/src/board_config.h
@@ -194,6 +194,8 @@
 	 (1 << ADC_ADC3_3V3_CHANNEL))               | \
 	(1 << ADC_SCALED_VDD_3V3_SENSORS4_CHANNEL)
 
+#define ADC_RC_RSSI_ADIO TRUE
+
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 
 #define HW_REV_VER_ADC_BASE STM32_ADC3_BASE

--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -167,6 +167,8 @@
 	 (1 << ADC_SCALED_VDD_3V3_SENSORS4_CHANNEL) | \
 	 (1 << ADC_ADC1_3V3_CHANNEL))
 
+#define ADC_RC_RSSI_ADIO TRUE
+
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 
 #define HW_REV_VER_ADC_BASE STM32_ADC3_BASE

--- a/boards/px4/fmu-v6x/src/board_config.h
+++ b/boards/px4/fmu-v6x/src/board_config.h
@@ -198,6 +198,8 @@
 	 (1 << ADC_ADC3_3V3_CHANNEL))               | \
 	(1 << ADC_SCALED_VDD_3V3_SENSORS4_CHANNEL)
 
+#define ADC_RC_RSSI_ADIO TRUE
+
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 
 #define HW_REV_VER_ADC_BASE STM32_ADC3_BASE

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -393,18 +393,54 @@ void RCInput::Run()
 		}
 
 
-#if defined(ADC_RC_RSSI_CHANNEL)
+#if defined(ADC_RC_RSSI_CHANNEL) || defined(ADC_RC_RSSI_ADIO)
+
+#if defined(ADC_RC_RSSI_ADIO)
+		int32_t rssi_adc_chan = 0;
+
+		switch (_param_rc_rssi_adc_chan.get()) {
+		case 1:
+			rssi_adc_chan = ADC_ADC3_3V3_CHANNEL;
+			break;
+
+		case 2:
+			rssi_adc_chan = ADC_ADC3_6V6_CHANNEL;
+			break;
+
+		default:
+			rssi_adc_chan = 0;
+			break;
+		}
+
+#elif defined(ADC_RC_RSSI_CHANNEL)
+		int32_t rssi_adc_chan = ADC_RC_RSSI_CHANNEL;
+#endif
 
 		// update ADC sampling
 		if (_adc_report_sub.updated()) {
 			adc_report_s adc;
 
+#if defined(ADC_RC_RSSI_ADIO)
+
+			if (_adc_report_sub.copy(&adc) && (_param_rc_rssi_adc_chan.get() > 0)) {
+#elif defined(ADC_RC_RSSI_CHANNEL)
+
 			if (_adc_report_sub.copy(&adc)) {
+#endif
+
 				for (unsigned i = 0; i < PX4_MAX_ADC_CHANNELS; ++i) {
-					if (adc.channel_id[i] == ADC_RC_RSSI_CHANNEL) {
+					if (adc.channel_id[i] == rssi_adc_chan) {
 						float adc_volt = adc.raw_data[i] *
 								 adc.v_ref /
 								 adc.resolution;
+
+#if defined(ADC_RC_RSSI_ADIO)
+
+						if (rssi_adc_chan == ADC_ADC3_6V6_CHANNEL) {
+							adc_volt = adc_volt * 2;
+						}
+
+#endif
 
 						if (_analog_rc_rssi_volt < 0.0f) {
 							_analog_rc_rssi_volt = adc_volt;
@@ -421,7 +457,7 @@ void RCInput::Run()
 			}
 		}
 
-#endif // ADC_RC_RSSI_CHANNEL
+#endif // ADC_RC_RSSI_CHANNEL || ADC_RC_RSSI_ADIO
 
 		bool rc_updated = false;
 
@@ -785,8 +821,7 @@ void RCInput::Run()
 }
 
 #if defined(SPEKTRUM_POWER)
-bool RCInput::bind_spektrum(int arg) const
-{
+bool RCInput::bind_spektrum(int arg) const {
 	int ret = PX4_ERROR;
 
 	/* specify 11ms DSMX. RX will automatically fall back to 22ms or DSM2 if necessary */
@@ -825,8 +860,7 @@ bool RCInput::bind_spektrum(int arg) const
 }
 #endif /* SPEKTRUM_POWER */
 
-int RCInput::custom_command(int argc, char *argv[])
-{
+int RCInput::custom_command(int argc, char *argv[]) {
 #if defined(SPEKTRUM_POWER)
 	const char *verb = argv[0];
 
@@ -853,8 +887,7 @@ int RCInput::custom_command(int argc, char *argv[])
 	return print_usage("unknown command");
 }
 
-int RCInput::print_status()
-{
+int RCInput::print_status() {
 	PX4_INFO("Max update rate: %u Hz", 1000000 / _current_update_interval);
 
 	if (_device[0] != '\0') {
@@ -902,13 +935,13 @@ int RCInput::print_status()
 		}
 	}
 
-#if ADC_RC_RSSI_CHANNEL
+#if ADC_RC_RSSI_CHANNEL || ADC_RC_RSSI_ADIO
 
 	if (_analog_rc_rssi_stable) {
 		PX4_INFO("vrssi: %dmV", (int)(_analog_rc_rssi_volt * 1000.0f));
 	}
 
-#endif
+#endif // ADC_RC_RSSI_CHANNEL || ADC_RC_RSSI_ADIO
 
 	perf_print_counter(_cycle_perf);
 	perf_print_counter(_publish_interval_perf);
@@ -921,8 +954,7 @@ int RCInput::print_status()
 }
 
 int
-RCInput::print_usage(const char *reason)
-{
+RCInput::print_usage(const char *reason) {
 	if (reason) {
 		PX4_WARN("%s\n", reason);
 	}

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -165,6 +165,7 @@ private:
 	uint32_t	_bytes_rx{0};
 
 	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::RC_RSSI_ADC_CHAN>) _param_rc_rssi_adc_chan,
 		(ParamInt<px4::params::RC_RSSI_PWM_CHAN>) _param_rc_rssi_pwm_chan,
 		(ParamInt<px4::params::RC_RSSI_PWM_MIN>) _param_rc_rssi_pwm_min,
 		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max,

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -2030,6 +2030,24 @@ PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.75f);
 PARAM_DEFINE_FLOAT(RC_ENG_MOT_TH, 0.75f);
 
 /**
+ * ADC input channel that provides RSSI.
+ *
+ * 0: do not read RSSI from input
+ * 1: read RSSI from external 3V3 input
+ * 2: read RSSI from external 6V6 input
+ *
+ *
+ * @min 0
+ * @max 2
+ * @value 0 Do not read RSSI from input
+ * @value 1 Read RSSI from external 3V3 input
+ * @value 2 Read RSSI from external 6V6 input
+ * @group Radio Calibration
+ *
+ */
+PARAM_DEFINE_INT32(RC_RSSI_ADC_CHAN, 0);
+
+/**
  * PWM input channel that provides RSSI.
  *
  * 0: do not read RSSI from input channel


### PR DESCRIPTION
@ryanjAA This adds the ability to have analog RSSI input on the ADIO 3V3 or 6V6 input on boards without a dedicated RSSI ADC input.

A new param called RC_RSSI_ADC_CHAN defines which pin RSSI is connected to. 