### PR TITLE
Navigator RTL: run find_RTL_destination() only on_inactive

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -322,9 +322,8 @@ void RTL::on_active()
 		rtl_time_estimate_s rtl_time_estimate{};
 		rtl_time_estimate.valid = false;
 
-		// Calculate RTL destination and time estimate only when there is a valid home and global position
+		// Calculate time estimate only when there is a valid home and global position
 		if (_navigator->home_global_position_valid() && global_position_recently_updated) {
-			find_RTL_destination();
 			calcRtlTimeEstimate(_rtl_state, rtl_time_estimate);
 			rtl_time_estimate.valid = true;
 		}


### PR DESCRIPTION

### Solved Problem
RTL::find_RTL_destination() is called also when the RTL has already started, and can override the set _destination etc. I don't think that's desired.

This was introduced through a refactor commit: https://github.com/PX4/PX4-Autopilot/pull/21208/commits/2bff49475b504b29eba8fb5cf1cb65400ea80482

### Solution
Remove it again.

### Changelog Entry
For release notes:
```
Bugfix: RTL: do not edit RTL destination once RTL is started
```


### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

