### PR TITLE
Handle illogical LOG_REQUEST_LIST messages more gracefully

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -275,7 +275,7 @@ MavlinkLogHandler::_log_send_listing()
 	mavlink_msg_log_entry_send_struct(_mavlink->get_channel(), &response);
 
 	//-- If we're done listing, flag it.
-	if (_next_entry == _last_entry) {
+	if (_next_entry >= _last_entry) {
 		_current_status = LogHandlerState::Idle;
 
 	} else {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When you send a LOG_REQUEST_LIST message with the `start` log id > the `end` log id, PX4 responds with LOG_ENTRY messages for every single log ID up until, I assume, `_next_entry` overflows and finally `== _last_entry` at some point.

### Solution
This change results in just a single LOG_ENTRY being sent for the `start` log id if `end > start`. I think this is a little better than sending up to u32 max value LOG_ENTRY messages.

### Test coverage
I really only tested this manually, but happy to perform other testing if necessary.