### PR TITLE
Stale bot configure

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,13 +7,10 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4.1.1
+      - uses: actions/stale@v8
         with:
-          days-before-issue-stale: 30
+          days-before-stale: 30
+          days-before-close: -1
           stale-issue-label: 'stale'
-
-          days-before-pr-stale: 30
           stale-pr-label: 'stale'
-
           remove-stale-when-updated: true
-          debug-only: true


### PR DESCRIPTION
## Changes
Having newline between I think didn't apply the PR stale days setting of 30 properly (it was using 45), so removed newline.

And it seemd that unless I set the days-before-close to -1 intentionally, it would still close the Issue/PRs, as the default value
is 7 already. So set the days to -1 to disable closing action.

Also updated version of the stale action to v8, cuz why not.

Debug is now removed, and will actually apply the action!