### PR TITLE
[WIP] Convert Jenkins metadata / binary upload to GitHub actions

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -11,6 +11,10 @@ on:
     - 'main'
     - 'release/*'
     - 'pr-metadata-test'
+  pull_request:
+    branches:
+    - '*'
+# EXPERIMENTAL: Remove the PR trigger above before merging the PR!!!
 
 jobs:
   enumerate_targets:
@@ -45,15 +49,3 @@ jobs:
         cd build/${{ matrix.target }}
         mkdir _metadata || true
         cp parameters.* events/*.xz actuators.json* _metadata
-
-    - uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl public-read
-      env:
-        AWS_S3_BUCKET: 'px4-travis'
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: 'us-west-1'
-        SOURCE_DIR: 'build/${{ matrix.target }}/_metadata/'
-        DEST_DIR: 'Firmware/${{ env.version }}/${{ matrix.target }}/'
-

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         token: ${{secrets.ACCESS_TOKEN}}
     - id: set-matrix
-      run: echo "::set-output name=matrix::$(./Tools/generate_board_targets_json.py)"
+      run: echo "matrix=$(./Tools/generate_board_targets_json.py)" >> $GITHUB_OUTPUT
   build:
     runs-on: ubuntu-latest
     needs: enumerate_targets

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -1,4 +1,9 @@
-name: Deploy metadata for all targets
+name: Deploy per-target metadata
+
+# This action deploys target specific metadata to the S3 bucket
+# This is needed because QGC needs to fetch correct metadata for the target
+# to show correct set of parameter / event / airframes that is supported on
+# the target, as it varies quite a bit between targets.
 
 on:
   push:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -1,4 +1,10 @@
-name: Metadata
+name: Deploy general metadata
+
+# This action deploys the general metadata of the main branch & release branches to the S3 bucket
+# This is needed for multiple purposes:
+# 1. User documentation (Parameters, Airframes, uORB messages, Failsafe simulation, etc)
+# 2. QGC metadata (Parameter reference, Airframes, etc)
+# 3. ROS2 messages definition
 
 on:
   push:


### PR DESCRIPTION
## About
This is one of the desired changes we have been [discussing in the maintainer's call](https://discuss.px4.io/t/px4-maintainers-call-may-30-2023/32372#beta-binaries-not-showing-up-7) for the past few months.

Currently, the CI is split between Jenkins and Github Actions, and they both perform almost similar (and sometimes overlapping) roles, thus making the whole setup a bit confusing.

However, back in May the Cube Orange Plus target was found to not being built in Jenkins, which was traced back to a manual list of targets that were getting built and it's binary being uploaded to S3 bucket from Jenkins. Thus, it showed the disadvantage of having 2 different CI systems!

This PR aims to convert all Jenkins workflow into Github Actions.

## TODOs
- [ ] Transfer Jenkins metadata upload into `metadata.yml` action, and delete Jenkins file
- [ ] Transfer S3 target binary (.px4) upload into `deploy_all.yml` action, and disable Jenkins for binary upload

Note, the `Jenkinsfile` in PX4-Autopilot directory corresponds to the metadata upload, and the px4 binary upload Jenkins script is hidden in the http://ci.px4.io/ server, thus not accessible from the codebase.

## Reousrces
- Jenkins metadata script pipeline: http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2FPX4-Autopilot/activity/
- Jenkins firmware binary build pipeline: http://ci.px4.io/blue/organizations/jenkins/PX4_misc%2FFirmware-compile/activity/
- PX4 CI structure overview: https://github.com/PX4/PX4-user_guide/pull/2284