### PR TITLE
EKF2: vision attitude error filter

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -1003,6 +1003,7 @@ private:
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	// control fusion of external vision observations
 	void controlExternalVisionFusion();
+	void updateEvAttitudeErrorFilter(extVisionSample &ev_sample, bool ev_reset);
 	void controlEvHeightFusion(const extVisionSample &ev_sample, const bool common_starting_conditions_passing, const bool ev_reset, const bool quality_sufficient, estimator_aid_source1d_s &aid_src);
 	void controlEvPosFusion(const extVisionSample &ev_sample, const bool common_starting_conditions_passing, const bool ev_reset, const bool quality_sufficient, estimator_aid_source2d_s &aid_src);
 	void controlEvVelFusion(const extVisionSample &ev_sample, const bool common_starting_conditions_passing, const bool ev_reset, const bool quality_sufficient, estimator_aid_source3d_s &aid_src);
@@ -1161,7 +1162,7 @@ private:
 	HeightBiasEstimator _ev_hgt_b_est{HeightSensor::EV, _height_sensor_ref};
 	PositionBiasEstimator _ev_pos_b_est{static_cast<uint8_t>(PositionSensor::EV), _position_sensor_ref};
 	AlphaFilter<AxisAnglef> _ev_q_error_filt{0.001f};
-	bool _ev_q_error_init{false};
+	bool _ev_q_error_initialized{false};
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	// Resets the main Nav EKf yaw to the estimator from the EKF-GSF yaw estimator

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -1160,6 +1160,8 @@ private:
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	HeightBiasEstimator _ev_hgt_b_est{HeightSensor::EV, _height_sensor_ref};
 	PositionBiasEstimator _ev_pos_b_est{static_cast<uint8_t>(PositionSensor::EV), _position_sensor_ref};
+	AlphaFilter<AxisAnglef> _ev_q_error_filt{0.001f};
+	bool _ev_q_error_init{false};
 #endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	// Resets the main Nav EKf yaw to the estimator from the EKF-GSF yaw estimator

--- a/src/modules/ekf2/EKF/ev_height_control.cpp
+++ b/src/modules/ekf2/EKF/ev_height_control.cpp
@@ -56,10 +56,9 @@ void Ekf::controlEvHeightFusion(const extVisionSample &ev_sample, const bool com
 	Matrix3f pos_cov{matrix::diag(ev_sample.position_var)};
 
 	// rotate EV to the EKF reference frame unless we're operating entirely in vision frame
-	// TODO: only necessary if there's a roll/pitch offset between VIO and EKF
 	if (!(_control_status.flags.ev_yaw && _control_status.flags.ev_pos)) {
 
-		const Quatf q_error((_state.quat_nominal * ev_sample.quat.inversed()).normalized());
+		const Quatf q_error(_ev_q_error_filt.getState());
 
 		if (q_error.isAllFinite()) {
 			const Dcmf R_ev_to_ekf(q_error);

--- a/src/modules/ekf2/EKF/ev_pos_control.cpp
+++ b/src/modules/ekf2/EKF/ev_pos_control.cpp
@@ -95,8 +95,16 @@ void Ekf::controlEvPosFusion(const extVisionSample &ev_sample, const bool common
 
 		} else {
 			// rotate EV to the EKF reference frame
-			const Quatf q_error((_state.quat_nominal * ev_sample.quat.inversed()).normalized());
-			const Dcmf R_ev_to_ekf = Dcmf(q_error);
+			const AxisAnglef q_error((_state.quat_nominal * ev_sample.quat.inversed()).normalized());
+			if (_ev_q_error_init) {
+				_ev_q_error_filt.update(q_error);
+
+			} else {
+				_ev_q_error_filt.reset(q_error);
+				_ev_q_error_init = true;
+			}
+
+			const Dcmf R_ev_to_ekf = Dcmf(_ev_q_error_filt.getState());
 
 			pos = R_ev_to_ekf * ev_sample.pos - pos_offset_earth;
 			pos_cov = R_ev_to_ekf * matrix::diag(ev_sample.position_var) * R_ev_to_ekf.transpose();

--- a/src/modules/ekf2/EKF/ev_pos_control.cpp
+++ b/src/modules/ekf2/EKF/ev_pos_control.cpp
@@ -95,15 +95,6 @@ void Ekf::controlEvPosFusion(const extVisionSample &ev_sample, const bool common
 
 		} else {
 			// rotate EV to the EKF reference frame
-			const AxisAnglef q_error((_state.quat_nominal * ev_sample.quat.inversed()).normalized());
-			if (_ev_q_error_init) {
-				_ev_q_error_filt.update(q_error);
-
-			} else {
-				_ev_q_error_filt.reset(q_error);
-				_ev_q_error_init = true;
-			}
-
 			const Dcmf R_ev_to_ekf = Dcmf(_ev_q_error_filt.getState());
 
 			pos = R_ev_to_ekf * ev_sample.pos - pos_offset_earth;

--- a/src/modules/ekf2/EKF/ev_vel_control.cpp
+++ b/src/modules/ekf2/EKF/ev_vel_control.cpp
@@ -80,8 +80,7 @@ void Ekf::controlEvVelFusion(const extVisionSample &ev_sample, const bool common
 
 		} else {
 			// rotate EV to the EKF reference frame
-			const Quatf q_error((_state.quat_nominal * ev_sample.quat.inversed()).normalized());
-			const Dcmf R_ev_to_ekf = Dcmf(q_error);
+			const Dcmf R_ev_to_ekf = Dcmf(_ev_q_error_filt.getState());
 
 			vel = R_ev_to_ekf * ev_sample.vel - vel_offset_earth;
 			vel_cov = R_ev_to_ekf * matrix::diag(ev_sample.velocity_var) * R_ev_to_ekf.transpose();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When the vision frame is not NED, we need to rotate the EV data by the attitude difference between the two frames. The issue is that any noise in that difference will be transferred on the EV position and velocity measurements.
This can in some extreme case cause a constant reset of the estimator as the data can often fail the innovation check.
![ev_sawtooth_sitl](https://github.com/PX4/PX4-Autopilot/assets/14822839/d9a97292-ac0a-4dd4-b457-9bab7cfbb9c7)

### Solution
Since the attitude error is almost constant (really slow drift), it can be heavily low-passed to remove most of the noise.
![ev_sawtooth_fixed_sitl](https://github.com/PX4/PX4-Autopilot/assets/14822839/34e13770-5877-4c0e-a070-5cf73e95034f)

### Changelog Entry
For release notes:
```
Add vision attitude error filter
New parameter: -
Documentation: -
```

### Alternatives
estimate the attitude error

### Test coverage
unit and sitl tests