### PR TITLE
ekf2: apply yaw reset to vision attitude error filter

### DIFF
--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1142,11 +1142,13 @@ void Ekf::resetQuatStateYaw(float yaw, float yaw_variance)
 	// add the reset amount to the output observer buffered data
 	_output_predictor.resetQuaternion(q_error);
 
+#if defined(CONFIG_EKF2_EXTERNAL_VISION)
 	// update EV attitude error filter
 	if (_ev_q_error_initialized) {
 		const Quatf ev_q_error_updated = (q_error * _ev_q_error_filt.getState()).normalized();
 		_ev_q_error_filt.reset(ev_q_error_updated);
 	}
+#endif // CONFIG_EKF2_EXTERNAL_VISION
 
 	// record the state change
 	if (_state_reset_status.reset_count.quat == _state_reset_count_prev.quat) {

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -1142,6 +1142,12 @@ void Ekf::resetQuatStateYaw(float yaw, float yaw_variance)
 	// add the reset amount to the output observer buffered data
 	_output_predictor.resetQuaternion(q_error);
 
+	// update EV attitude error filter
+	if (_ev_q_error_initialized) {
+		const Quatf ev_q_error_updated = (q_error * _ev_q_error_filt.getState()).normalized();
+		_ev_q_error_filt.reset(ev_q_error_updated);
+	}
+
 	// record the state change
 	if (_state_reset_status.reset_count.quat == _state_reset_count_prev.quat) {
 		_state_reset_status.quat_change = q_error;

--- a/src/modules/ekf2/EKF/ev_control.cpp
+++ b/src/modules/ekf2/EKF/ev_control.cpp
@@ -81,6 +81,8 @@ void Ekf::controlExternalVisionFusion()
 		stopEvYawFusion();
 		stopEvHgtFusion();
 
+		_ev_q_error_initialized = false;
+
 		_warning_events.flags.vision_data_stopped = true;
 		ECL_WARN("vision data stopped");
 	}


### PR DESCRIPTION
 - set vision attitude error filter uninitalized if vision data stops
