### PR TITLE
rc_update: fix on-off-switch with negative threshold values

### DIFF
--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -233,7 +233,7 @@ TEST_F(RCUpdateTest, ReturnSwitchNegativeThresholds)
 
 	checkReturnSwitch(1.f, -0.75f, 3); // Above threshold -> SWITCH_POS_OFF
 	checkReturnSwitch(.5f, -0.75f, 3); // On threshold -> SWITCH_POS_OFF
-	checkReturnSwitch(-.001f, -0.75f, 1); // Slightly below threshold -> SWITCH_POS_ON
+	checkReturnSwitch(.499f, -0.75f, 1); // Slightly below threshold -> SWITCH_POS_ON
 	checkReturnSwitch(-1.f, -0.75f, 1); // Below threshold -> SWITCH_POS_ON
 
 	checkReturnSwitch(1.f, -1.f, 3); // On maximum threshold -> SWITCH_POS_OFF

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -38,15 +38,87 @@
 
 using namespace rc_update;
 
-TEST(RCUpdateTest, ModeSlotUnassigned)
+class TestRCUpdate : public RCUpdate
 {
-	RCUpdate rc_update;
+public:
+	void UpdateManualSwitches(const hrt_abstime &timestamp_sample) { RCUpdate::UpdateManualSwitches(timestamp_sample); }
+	void update_rc_functions() { RCUpdate::update_rc_functions(); }
+	void setChannel(size_t index, float channel_value) { _rc.channels[index] = channel_value; }
+};
+
+class RCUpdateTest : public ::testing::Test, ModuleParams
+{
+public:
+	RCUpdateTest() : ModuleParams(nullptr) {}
+
+	void SetUp() override
+	{
+		// Disable autosaving parameters to avoid busy loop in param_set()
+		param_control_autosave(false);
+	}
+
+	void checkModeSlotSwitch(float channel_value, uint8_t expected_slot)
+	{
+		// GIVEN: First channel is configured as mode switch
+		_param_rc_map_fltmode.set(1);
+		EXPECT_EQ(_param_rc_map_fltmode.get(), 1);
+		// GIVEN: First channel has some value
+		_rc_update.setChannel(0, channel_value);
+
+		// WHEN: we update the switches two times to pass the simple outlier protection
+		_rc_update.UpdateManualSwitches(0);
+		_rc_update.UpdateManualSwitches(0);
+
+		// THEN: we receive the expected mode slot
+		uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
+		manual_control_switches_sub.update();
+
+		EXPECT_EQ(manual_control_switches_sub.get().mode_slot, expected_slot);
+	}
+
+	void checkModeSlotButton(uint8_t button_configuration, uint8_t channel, float channel_value, uint8_t expected_slot)
+	{
+		// GIVEN: Buttons are configured
+		_param_rc_map_fltm_btn.set(button_configuration);
+		EXPECT_EQ(_param_rc_map_fltm_btn.get(), button_configuration);
+		// GIVEN: buttons are mapped
+		_rc_update.update_rc_functions();
+		// GIVEN: First channel has some value
+		_rc_update.setChannel(channel - 1, channel_value);
+
+		// WHEN: we update the switches 4 times:
+		// - initiate the button press
+		// - keep the same button pressed
+		// - hold the button for 50ms
+		// - pass the simple outlier protection
+		_rc_update.UpdateManualSwitches(0);
+		_rc_update.UpdateManualSwitches(0);
+		_rc_update.UpdateManualSwitches(51_ms);
+		_rc_update.UpdateManualSwitches(51_ms);
+
+		// THEN: we receive the expected mode slot
+		uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
+		manual_control_switches_sub.update();
+
+		EXPECT_EQ(manual_control_switches_sub.get().mode_slot, expected_slot);
+	}
+
+	TestRCUpdate _rc_update;
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::RC_MAP_FLTMODE>) _param_rc_map_fltmode,
+		(ParamInt<px4::params::RC_MAP_FLTM_BTN>) _param_rc_map_fltm_btn
+	)
+};
+
+TEST_F(RCUpdateTest, ModeSlotUnassigned)
+{
 	// GIVEN: Default configuration with no assigned mode switch
-	EXPECT_EQ(rc_update._param_rc_map_fltmode.get(), 0);
+	EXPECT_EQ(_param_rc_map_fltmode.get(), 0);
 
 	// WHEN: we update the switches two times to pass the simple outlier protection
-	rc_update.UpdateManualSwitches(0);
-	rc_update.UpdateManualSwitches(0);
+	_rc_update.UpdateManualSwitches(0);
+	_rc_update.UpdateManualSwitches(0);
 
 	// THEN: we receive no mode slot
 	uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
@@ -55,28 +127,7 @@ TEST(RCUpdateTest, ModeSlotUnassigned)
 	EXPECT_EQ(manual_control_switches_sub.get().mode_slot, 0); // manual_control_switches_s::MODE_SLOT_NONE
 }
 
-void checkModeSlotSwitch(float channel_value, uint8_t expected_slot)
-{
-	RCUpdate rc_update;
-
-	// GIVEN: First channel is configured as mode switch
-	rc_update._param_rc_map_fltmode.set(1);
-	EXPECT_EQ(rc_update._param_rc_map_fltmode.get(), 1);
-	// GIVEN: First channel has some value
-	rc_update._rc.channels[0] = channel_value;
-
-	// WHEN: we update the switches two times to pass the simple outlier protection
-	rc_update.UpdateManualSwitches(0);
-	rc_update.UpdateManualSwitches(0);
-
-	// THEN: we receive the expected mode slot
-	uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-	manual_control_switches_sub.update();
-
-	EXPECT_EQ(manual_control_switches_sub.get().mode_slot, expected_slot);
-}
-
-TEST(RCUpdateTest, ModeSlotSwitchAllValues)
+TEST_F(RCUpdateTest, ModeSlotSwitchAllValues)
 {
 	checkModeSlotSwitch(-1.f, 1); // manual_control_switches_s::MODE_SLOT_1
 	checkModeSlotSwitch(-.5f, 2); // manual_control_switches_s::MODE_SLOT_2
@@ -86,36 +137,7 @@ TEST(RCUpdateTest, ModeSlotSwitchAllValues)
 	checkModeSlotSwitch(1.f, 6); // manual_control_switches_s::MODE_SLOT_6
 }
 
-void checkModeSlotButton(uint8_t button_configuration, uint8_t channel, float channel_value, uint8_t expected_slot)
-{
-	RCUpdate rc_update;
-
-	// GIVEN: Buttons are configured
-	rc_update._param_rc_map_fltm_btn.set(button_configuration);
-	EXPECT_EQ(rc_update._param_rc_map_fltm_btn.get(), button_configuration);
-	// GIVEN: buttons are mapped
-	rc_update.update_rc_functions();
-	// GIVEN: First channel has some value
-	rc_update._rc.channels[channel - 1] = channel_value;
-
-	// WHEN: we update the switches 4 times:
-	// - initiate the button press
-	// - keep the same button pressed
-	// - hold the button for 50ms
-	// - pass the simple outlier protection
-	rc_update.UpdateManualSwitches(0);
-	rc_update.UpdateManualSwitches(0);
-	rc_update.UpdateManualSwitches(51_ms);
-	rc_update.UpdateManualSwitches(51_ms);
-
-	// THEN: we receive the expected mode slot
-	uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
-	manual_control_switches_sub.update();
-
-	EXPECT_EQ(manual_control_switches_sub.get().mode_slot, expected_slot);
-}
-
-TEST(RCUpdateTest, ModeSlotButtonAllValues)
+TEST_F(RCUpdateTest, ModeSlotButtonAllValues)
 {
 	checkModeSlotButton(1, 1, -1.f, 0); // button not pressed -> manual_control_switches_s::MODE_SLOT_NONE
 	checkModeSlotButton(1, 1, 0.f, 0); // button not pressed over threshold -> manual_control_switches_s::MODE_SLOT_NONE

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -110,11 +110,37 @@ public:
 		_rc_update.setChannel(channel - 1, 0.f);
 	}
 
+	void checkReturnSwitch(float channel_value, float threshold, uint8_t expected_position)
+	{
+		// GIVEN: First channel is configured as return switch
+		_param_rc_map_return_sw.set(1);
+		_param_rc_map_return_sw.commit();
+		_param_rc_return_th.set(threshold);
+		_param_rc_return_th.commit();
+		_rc_update.updateParams();
+		EXPECT_EQ(_param_rc_map_return_sw.get(), 1);
+		EXPECT_FLOAT_EQ(_param_rc_return_th.get(), threshold);
+		// GIVEN: First channel has some value
+		_rc_update.setChannel(0, channel_value);
+
+		// WHEN: we update the switches two times to pass the simple outlier protection
+		_rc_update.UpdateManualSwitches(0);
+		_rc_update.UpdateManualSwitches(0);
+
+		// THEN: we receive the expected mode slot
+		uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
+		manual_control_switches_sub.update();
+
+		EXPECT_EQ(manual_control_switches_sub.get().return_switch, expected_position);
+	}
+
 	TestRCUpdate _rc_update;
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::RC_MAP_FLTMODE>) _param_rc_map_fltmode,
-		(ParamInt<px4::params::RC_MAP_FLTM_BTN>) _param_rc_map_fltm_btn
+		(ParamInt<px4::params::RC_MAP_FLTM_BTN>) _param_rc_map_fltm_btn,
+		(ParamInt<px4::params::RC_MAP_RETURN_SW>) _param_rc_map_return_sw,
+		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th
 	)
 };
 
@@ -159,4 +185,41 @@ TEST_F(RCUpdateTest, ModeSlotButtonAllValues)
 	checkModeSlotButton(31, 5, 1.f, 5); // button 5 pressed -> manual_control_switches_s::MODE_SLOT_5
 	checkModeSlotButton(31, 6, 1.f, 0); // button 6 pressed but not configured -> manual_control_switches_s::MODE_SLOT_NONE
 	checkModeSlotButton(63, 6, 1.f, 6); // button 6 pressed -> manual_control_switches_s::MODE_SLOT_6
+}
+
+TEST_F(RCUpdateTest, ReturnSwitchUnassigned)
+{
+	// GIVEN: Default configuration with no assigned return switch
+	EXPECT_EQ(_param_rc_map_return_sw.get(), 0);
+
+	// WHEN: we update the switches two times to pass the simple outlier protection
+	_rc_update.UpdateManualSwitches(0);
+	_rc_update.UpdateManualSwitches(0);
+
+	// THEN: we receive an unmapped return switch state
+	uORB::SubscriptionData<manual_control_switches_s> manual_control_switches_sub{ORB_ID(manual_control_switches)};
+	manual_control_switches_sub.update();
+
+	EXPECT_EQ(manual_control_switches_sub.get().return_switch, 0); // manual_control_switches_s::SWITCH_POS_NONE
+}
+
+TEST_F(RCUpdateTest, ReturnSwitchPositiveThresholds)
+{
+	checkReturnSwitch(-1.f, 0.5f, 3); // Below threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(0.f, 0.5f, 3); // On threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(.001f, 0.5f, 1); // Slightly above threshold -> SWITCH_POS_ON
+	checkReturnSwitch(1.f, 0.5f, 1); // Above threshold -> SWITCH_POS_ON
+
+	checkReturnSwitch(-1.f, 0.75f, 3); // Below threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(0.f, 0.75f, 3); // Below threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(.5f, 0.75f, 3); // On threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(.501f, 0.75f, 1); // Slightly above threshold -> SWITCH_POS_ON
+	checkReturnSwitch(1.f, 0.75f, 1); // Above threshold -> SWITCH_POS_ON
+
+	checkReturnSwitch(-1.f, 0.f, 3); // On minimum threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(-.999f, 0.f, 1); // Slightly above minimum threshold -> SWITCH_POS_ON
+	checkReturnSwitch(1.f, 0.f, 1); // Above minimum threshold -> SWITCH_POS_ON
+
+	checkReturnSwitch(-1.f, 1.f, 3); // Below maximum threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(1.f, 1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
 }

--- a/src/modules/rc_update/RCUpdateTest.cpp
+++ b/src/modules/rc_update/RCUpdateTest.cpp
@@ -223,3 +223,23 @@ TEST_F(RCUpdateTest, ReturnSwitchPositiveThresholds)
 	checkReturnSwitch(-1.f, 1.f, 3); // Below maximum threshold -> SWITCH_POS_OFF
 	checkReturnSwitch(1.f, 1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
 }
+
+TEST_F(RCUpdateTest, ReturnSwitchNegativeThresholds)
+{
+	checkReturnSwitch(1.f, -0.5f, 3); // Above threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(0.f, -0.5f, 3); // On threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(-.001f, -0.5f, 1); // Slightly below threshold -> SWITCH_POS_ON
+	checkReturnSwitch(-1.f, -0.5f, 1); // Below threshold -> SWITCH_POS_ON
+
+	checkReturnSwitch(1.f, -0.75f, 3); // Above threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(.5f, -0.75f, 3); // On threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(-.001f, -0.75f, 1); // Slightly below threshold -> SWITCH_POS_ON
+	checkReturnSwitch(-1.f, -0.75f, 1); // Below threshold -> SWITCH_POS_ON
+
+	checkReturnSwitch(1.f, -1.f, 3); // On maximum threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(.999f, -1.f, 1); // Slighly below maximum threshold -> SWITCH_POS_ON
+	checkReturnSwitch(-1.f, -1.f, 1); // Below minimum threshold -> SWITCH_POS_ON
+
+	checkReturnSwitch(1.f, -.001f, 3); // Above minimum threshold -> SWITCH_POS_OFF
+	checkReturnSwitch(-1.f, -.001f, 1); // Slightly below minimum threshold -> SWITCH_POS_OFF
+}

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -561,19 +561,16 @@ void RCUpdate::Run()
 	perf_end(_loop_perf);
 }
 
-switch_pos_t RCUpdate::get_rc_sw2pos_position(uint8_t func, float on_th) const
+switch_pos_t RCUpdate::getRCSwitchOnOffPosition(uint8_t function, float threshold) const
 {
-	if (_rc.function[func] >= 0) {
-		const bool on_inv = (on_th < 0.f);
+	if (_rc.function[function] >= 0) {
+		float value = 0.5f * _rc.channels[_rc.function[function]] + 0.5f; // Rescale [-1,1] -> [0,1] range
 
-		const float value = 0.5f * _rc.channels[_rc.function[func]] + 0.5f;
-
-		if (on_inv ? value < on_th : value > on_th) {
-			return manual_control_switches_s::SWITCH_POS_ON;
-
-		} else {
-			return manual_control_switches_s::SWITCH_POS_OFF;
+		if (threshold < 0.f) {
+			value = -value;
 		}
+
+		return (value > threshold) ? manual_control_switches_s::SWITCH_POS_ON : manual_control_switches_s::SWITCH_POS_OFF;
 	}
 
 	return manual_control_switches_s::SWITCH_POS_NONE;
@@ -640,18 +637,18 @@ void RCUpdate::UpdateManualSwitches(const hrt_abstime &timestamp_sample)
 		}
 	}
 
-	switches.return_switch     = get_rc_sw2pos_position(rc_channels_s::FUNCTION_RETURN,     _param_rc_return_th.get());
-	switches.loiter_switch     = get_rc_sw2pos_position(rc_channels_s::FUNCTION_LOITER,     _param_rc_loiter_th.get());
-	switches.offboard_switch   = get_rc_sw2pos_position(rc_channels_s::FUNCTION_OFFBOARD,   _param_rc_offb_th.get());
-	switches.kill_switch       = get_rc_sw2pos_position(rc_channels_s::FUNCTION_KILLSWITCH, _param_rc_killswitch_th.get());
-	switches.arm_switch        = get_rc_sw2pos_position(rc_channels_s::FUNCTION_ARMSWITCH,  _param_rc_armswitch_th.get());
-	switches.transition_switch = get_rc_sw2pos_position(rc_channels_s::FUNCTION_TRANSITION, _param_rc_trans_th.get());
-	switches.gear_switch       = get_rc_sw2pos_position(rc_channels_s::FUNCTION_GEAR,       _param_rc_gear_th.get());
-	switches.engage_main_motor_switch = get_rc_sw2pos_position(rc_channels_s::FUNCTION_ENGAGE_MAIN_MOTOR,
-					    _param_rc_eng_mot_th.get());
+	switches.return_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_RETURN, _param_rc_return_th.get());
+	switches.loiter_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_LOITER, _param_rc_loiter_th.get());
+	switches.offboard_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_OFFBOARD, _param_rc_offb_th.get());
+	switches.kill_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_KILLSWITCH, _param_rc_killswitch_th.get());
+	switches.arm_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_ARMSWITCH, _param_rc_armswitch_th.get());
+	switches.transition_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_TRANSITION, _param_rc_trans_th.get());
+	switches.gear_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_GEAR, _param_rc_gear_th.get());
+	switches.engage_main_motor_switch =
+		getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_ENGAGE_MAIN_MOTOR, _param_rc_eng_mot_th.get());
 #if defined(ATL_MANTIS_RC_INPUT_HACKS)
-	switches.photo_switch = get_rc_sw2pos_position(rc_channels_s::FUNCTION_AUX_3, 0.5f);
-	switches.video_switch = get_rc_sw2pos_position(rc_channels_s::FUNCTION_AUX_4, 0.5f);
+	switches.photo_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_AUX_3, 0.5f);
+	switches.video_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_AUX_4, 0.5f);
 #endif
 
 	// last 2 switch updates identical within 1 second (simple protection from bad RC data)

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -101,7 +101,7 @@ RCUpdate::RCUpdate() :
 	}
 
 	rc_parameter_map_poll(true /* forced */);
-	parameters_updated();
+	updateParams(); // Call is needed to populate the _rc.function array
 
 	_button_pressed_hysteresis.set_hysteresis_time_from(false, 50_ms);
 }
@@ -123,8 +123,10 @@ bool RCUpdate::init()
 	return true;
 }
 
-void RCUpdate::parameters_updated()
+void RCUpdate::updateParams()
 {
+	ModuleParams::updateParams();
+
 	// rc values
 	for (unsigned int i = 0; i < RC_MAX_CHAN_COUNT; i++) {
 		float min = 0.f;
@@ -388,7 +390,6 @@ void RCUpdate::Run()
 
 		// update parameters from storage
 		updateParams();
-		parameters_updated();
 	}
 
 	rc_parameter_map_poll();

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -89,6 +89,7 @@ public:
 
 	int print_status() override;
 
+protected:
 	static constexpr uint64_t VALID_DATA_MIN_INTERVAL_US{1_s / 3}; // assume valid RC input is at least 3 Hz
 
 	void Run() override;

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -110,7 +110,7 @@ protected:
 	/**
 	 * Update our local parameter cache.
 	 */
-	void		parameters_updated();
+	void updateParams() override;
 
 	/**
 	 * Get and limit value for specified RC function. Returns NAN if not mapped.

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -118,15 +118,16 @@ protected:
 	float		get_rc_value(uint8_t func, float min_value, float max_value) const;
 
 	/**
-	 * Get switch position for specified function.
+	 * Get on/off switch position from the RC channel of the specified function
+	 *
+	 * @param function according to rc_channels_s::FUNCTION_XXX
+	 * @param threshold according to RC_XXX_TH parameters, negative means on and off are flipped
 	 */
-	switch_pos_t	get_rc_sw2pos_position(uint8_t func, float on_th) const;
+	switch_pos_t getRCSwitchOnOffPosition(uint8_t function, float threshold) const;
 
 	/**
 	 * Update parameters from RC channels if the functionality is activated and the
 	 * input has changed since the last update
-	 *
-	 * @param
 	 */
 	void		set_params_from_rc();
 


### PR DESCRIPTION
### Solved Problem
When reviewing #21763 I wasn't exactly sure why the fix is needed at all see https://github.com/PX4/PX4-Autopilot/pull/21763#issuecomment-1614360730. I tested on hardware and realized it's actually broken and I still don't know why it broke. But I was sure I wanted it to not break the same way again and the function to be more readable. So I added unit testing and fixed it by simplifying the function rather than adding to it.

Fixes #19809
Closes #21763

### Solution
- Improve unit testing of the RCUpdate class I added in #19579
  - adding protected scope again
  - setting parameters from outside the class
- Add unit tests for the return switch
  - Positive threshold cases
  - Corner cases
  - Negative threshold cases that failed
- Fix negative threshold cases

### Changelog Entry
```
Bugfix: Negative RC switch thresholds
```

### Test coverage
Unit tests that I added. I can also test on hardware if desired.