### PR TITLE
ekf2: simplify fuseYaw() signature and use consistently

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -747,8 +747,8 @@ private:
 	bool fuseMag(const Vector3f &mag, estimator_aid_source3d_s &aid_src_mag, bool update_all_states = true);
 
 	// update quaternion states and covariances using an innovation, observation variance and Jacobian vector
-	bool fuseYaw(float innovation, float variance, estimator_aid_source1d_s &aid_src_status);
-	bool fuseYaw(float innovation, float variance, estimator_aid_source1d_s &aid_src_status, const Vector24f &H_YAW);
+	bool fuseYaw(estimator_aid_source1d_s &aid_src_status);
+	bool fuseYaw(estimator_aid_source1d_s &aid_src_status, const Vector24f &H_YAW);
 	void computeYawInnovVarAndH(float variance, float &innovation_variance, Vector24f &H_YAW) const;
 
 #if defined(CONFIG_EKF2_GNSS_YAW)

--- a/src/modules/ekf2/EKF/ev_yaw_control.cpp
+++ b/src/modules/ekf2/EKF/ev_yaw_control.cpp
@@ -92,7 +92,7 @@ void Ekf::controlEvYawFusion(const extVisionSample &ev_sample, const bool common
 				}
 
 			} else if (quality_sufficient) {
-				fuseYaw(aid_src.innovation, aid_src.observation_variance, aid_src);
+				fuseYaw(aid_src);
 
 			} else {
 				aid_src.innovation_rejected = true;

--- a/src/modules/ekf2/EKF/mag_control.cpp
+++ b/src/modules/ekf2/EKF/mag_control.cpp
@@ -440,9 +440,12 @@ void Ekf::runMagAndMagDeclFusions(const Vector3f &mag)
 		float innovation = wrap_pi(getEulerYaw(_R_to_earth) - measured_hdg);
 		float obs_var = fmaxf(sq(_params.mag_heading_noise), 1.e-4f);
 
+		_aid_src_mag_heading.observation = measured_hdg;
+		_aid_src_mag_heading.observation_variance = obs_var;
+		_aid_src_mag_heading.innovation = innovation;
 		_aid_src_mag_heading.fusion_enabled = _control_status.flags.mag_hdg;
 
-		fuseYaw(innovation, obs_var, _aid_src_mag_heading);
+		fuseYaw(_aid_src_mag_heading);
 	}
 }
 

--- a/src/modules/ekf2/EKF/zero_innovation_heading_update.cpp
+++ b/src/modules/ekf2/EKF/zero_innovation_heading_update.cpp
@@ -50,16 +50,21 @@ void Ekf::controlZeroInnovationHeadingUpdate()
 
 		// Use an observation variance larger than usual but small enough
 		// to constrain the yaw variance just below the threshold
-		float obs_var = 0.25f;
-		estimator_aid_source1d_s aid_src_status;
+		const float obs_var = 0.25f;
+
+		estimator_aid_source1d_s aid_src_status{};
+		aid_src_status.observation = getEulerYaw(_state.quat_nominal);
+		aid_src_status.observation_variance = obs_var;
+		aid_src_status.innovation = 0.f;
+
 		Vector24f H_YAW;
 
 		computeYawInnovVarAndH(obs_var, aid_src_status.innovation_variance, H_YAW);
 
 		if ((aid_src_status.innovation_variance - obs_var) > sq(_params.mag_heading_noise)) {
 			// The yaw variance is too large, fuse fake measurement
-			float innovation = 0.f;
-			fuseYaw(innovation, obs_var, aid_src_status, H_YAW);
+			aid_src_status.fusion_enabled = true;
+			fuseYaw(aid_src_status, H_YAW);
 		}
 	}
 }


### PR DESCRIPTION
 - make it safe to call for other aid sources, no EKF state is changed unless fusion_enabled