### PR TITLE
Fix mag offset correction from estimated bias

### DIFF
--- a/src/lib/sensor_calibration/Magnetometer.cpp
+++ b/src/lib/sensor_calibration/Magnetometer.cpp
@@ -110,7 +110,7 @@ void Magnetometer::SensorCorrectionsUpdate(bool force)
 
 bool Magnetometer::set_offset(const Vector3f &offset)
 {
-	if (Vector3f(_offset - offset).longerThan(0.01f)) {
+	if (Vector3f(_offset - offset).longerThan(0.005f)) {
 		if (offset.isAllFinite()) {
 			_offset = offset;
 			_calibration_count++;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2454,8 +2454,10 @@ void EKF2::UpdateCalibration(const hrt_abstime &timestamp, InFlightCalibration &
 		// consider bias estimates stable when all checks pass consistently and bias hasn't changed more than 10% of the limit
 		const float bias_change_limit = 0.1f * bias_limit;
 
-		if ((cal.last_us != 0) && !(cal.bias - bias).longerThan(bias_change_limit)) {
-			cal.total_time_us += timestamp - cal.last_us;
+		if (!(cal.bias - bias).longerThan(bias_change_limit)) {
+			if (cal.last_us != 0) {
+				cal.total_time_us += timestamp - cal.last_us;
+			}
 
 			if (cal.total_time_us > 30_s) {
 				cal.cal_available = true;
@@ -2515,7 +2517,6 @@ void EKF2::UpdateGyroCalibration(const hrt_abstime &timestamp)
 void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 {
 	const bool bias_valid = (_ekf.control_status_flags().mag_hdg || _ekf.control_status_flags().mag_3D)
-				&& _ekf.control_status_flags().mag_aligned_in_flight
 				&& !_ekf.control_status_flags().mag_fault
 				&& !_ekf.control_status_flags().mag_field_disturbed;
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2459,7 +2459,7 @@ void EKF2::UpdateCalibration(const hrt_abstime &timestamp, InFlightCalibration &
 				cal.total_time_us += timestamp - cal.last_us;
 			}
 
-			if (cal.total_time_us > 30_s) {
+			if (cal.total_time_us > 10_s) {
 				cal.cal_available = true;
 			}
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -259,7 +259,7 @@ void VehicleMagnetometer::UpdateMagCalibration()
 	// State variance assumed for magnetometer bias storage.
 	// This is a reference variance used to calculate the fraction of learned magnetometer bias that will be used to update the stored value.
 	// Larger values cause a larger fraction of the learned biases to be used.
-	static constexpr float magb_vref = 2.5e-7f;
+	static constexpr float magb_vref = 2.5e-6f;
 	static constexpr float min_var_allowed = magb_vref * 0.01f;
 	static constexpr float max_var_allowed = magb_vref * 500.f;
 

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -329,7 +329,7 @@ void VehicleMagnetometer::UpdateMagCalibration()
 
 					if (_calibration[mag_index].set_offset(mag_cal_offset)) {
 
-						PX4_INFO("%d (%" PRIu32 ") EST:%d offset: [%.2f, %.2f, %.2f]->[%.2f, %.2f, %.2f] (full [%.3f, %.3f, %.3f])",
+						PX4_INFO("%d (%" PRIu32 ") EST:%d offset: [%.3f, %.3f, %.3f]->[%.3f, %.3f, %.3f] (full [%.3f, %.3f, %.3f])",
 							 mag_index, _calibration[mag_index].device_id(), i,
 							 (double)mag_cal_orig(0), (double)mag_cal_orig(1), (double)mag_cal_orig(2),
 							 (double)mag_cal_offset(0), (double)mag_cal_offset(1), (double)mag_cal_offset(2),


### PR DESCRIPTION
### Solved Problem
I realized that the estimated mag bias was never applied back to the calibration. I found the following bugs:
1. since last_us is set to 0 every time the bias is not observable, the total time was also reset -> needed 30 consecutive seconds in mag 3D to be declared "stable"
2. after landing, the mag_aligned_in_flight flag is reset. Using this for bias validity makes it invalid before we have a chance to save it to the calibration.
3. the change in parameter is (at least in sim) < 0.01gs when the parameter is wrong by 0.1 gs, making it being rejected in `set_offset`

### Solution
Fix 1.; now it's truly a period of accumulated time, no need to be consecutive anymore
Remove check for mag_aligned_in_flight; we anyway don't enter mag 3D before that
Reduce the minimum mag offset param change to 0.001gs

Additionally:
- Reduce the required stability period to 10s. For the mag, 30s of bias learning is a lot, given that it is only active during turns and that it usually converges in < 5 seconds (and we start counting after convergence)

- Increase uncertainty of calibration parameters: in air bias estimation is usually really accurate and should be weighted more heavily compared to the calibration parameters that are often more approximate given the worse magnetic environment near the ground.

### Changelog Entry
For release notes:
```
Fix mag offset correction from estimated bias
```

### Alternatives
-

### Test coverage
SITL

