### PR TITLE
EKF2. Use existing sensor priority to spawn multi-ekf instances.

### DIFF
--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -76,6 +76,7 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/sensor_selection.h>
+#include <uORB/topics/sensors_status.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>

--- a/src/modules/ekf2/Utility/CMakeLists.txt
+++ b/src/modules/ekf2/Utility/CMakeLists.txt
@@ -33,6 +33,7 @@
 
 px4_add_library(EKF2Utility
 	PreFlightChecker.cpp
+	Sorting.hpp
 )
 
 target_include_directories(EKF2Utility

--- a/src/modules/ekf2/Utility/Sorting.hpp
+++ b/src/modules/ekf2/Utility/Sorting.hpp
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file Sorting.hpp
+ * Implementation of Sorting algorithms.
+ *
+ */
+
+
+/**
+ * @brief Performs an insert sort on the input pair array.
+ * First array is used as the main key. Second array is sorted in the same order as the first one.
+ * @param arr1 The base array to be sorted
+ * @param arr2 The secondary array to be sorted
+ * @param size Size of the input array
+ * @param inverse false to order from lower to higher values. true to order from higher to lower
+ * @param result void
+ */
+template<typename T, typename T1>
+void sortPair(T arr[], T1 arr1[], int size, bool inverse = false)
+{
+	T key{};
+	T1 index_key{};
+	int j = 0;
+
+	for (int i = 0; i < size; i++) {
+		key = arr[i];
+		index_key = arr1[i];
+		j = i - 1;
+
+		if (!inverse) {
+			while (j >= 0 && arr[j] > key) {
+				arr[j + 1] = arr[j];
+				arr1[j + 1] = arr1[j];
+				j--;
+			}
+
+		} else {
+			while (j >= 0 && arr[j] <= key) {
+				arr[j + 1] = arr[j];
+				arr1[j + 1] = arr1[j];
+				j--;
+			}
+
+		}
+
+		arr[j + 1] = key;
+		arr1[j + 1] = index_key;
+	}
+
+}


### PR DESCRIPTION
### Solved Problem
EKF2.cpp isn't taking into account sensor priorities. Instances are spawned following a basic 0 to maximum number of sensors approach.

Uninitialized or disabled sensors are being used, which results in spawned EKF instances with wrong sensors, this takes up more memory (I think so, might be wrong) and CPU.

Fixes #21225

### Solution
- Read priorities from parameters
- Discard sensors that are uninitialized or disabled
- Update the calculation of the maximum number of EKF instances that should be spawned
- Only try to spawn the correct number of EKF instances

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
- Simulation/hardware testing logs: https://review.px4.io/plot_app?log=d1aae94d-c9f4-4605-b2a3-2a7e5fedbee5
- Tested in SITL

### Test context
I enabled some Debug prints as Info to get a better understanding of how this new approach is working.

This flight was commanded both from the shell and from QGroundControl.

`make px4_sitl gazebo` flight output (commit: ded751e3ae) :

```
______  __   __    ___ 
| ___ \ \ \ / /   /   |
| |_/ /  \ V /   / /| |
|  __/   /   \  / /_| |
| |     / /^\ \ \___  |
\_|     \/   \/     |_/

px4 starting.

INFO  [px4] startup script: /bin/sh etc/init.d-posix/rcS 0
INFO  [init] found model autostart file as SYS_AUTOSTART=10015
INFO  [param] selected parameter default file parameters.bson
INFO  [param] importing from 'parameters.bson'
INFO  [parameters] BSON document size 404 bytes, decoded 404 bytes (INT32:14, FLOAT:6)
INFO  [param] selected parameter backup file parameters_backup.bson
INFO  [dataman] data manager file './dataman' size is 7866640 bytes
etc/init.d-posix/rcS: 39: [: Illegal number: 
INFO  [init] PX4_SIM_HOSTNAME: localhost
INFO  [simulator_mavlink] Waiting for simulator to accept connection on TCP port 4560
INFO  [simulator_mavlink] Simulator connected on TCP port 4560.
INFO  [lockstep_scheduler] setting initial absolute time to 3352000 us
INFO  [commander] LED: open /dev/led0 failed (22)
WARN  [health_and_arming_checks] Preflight Fail: ekf2 missing data
INFO  [ekf2] Initialized MAGs (positive priority): 2
INFO  [ekf2] MAGs priorities - i: 0  MAG1  Priority: 50
INFO  [ekf2] MAGs priorities - i: 1  MAG0  Priority: 50
INFO  [ekf2] MAGs priorities - i: 2  MAG3  Priority: -1
INFO  [ekf2] MAGs priorities - i: 3  MAG2  Priority: -1
INFO  [ekf2] Initialized IMUs (positive priority): 1
INFO  [ekf2] IMUs priorities - i: 0  ACC0  Priority: 50
INFO  [ekf2] IMUs priorities - i: 1  ACC3  Priority: -1
INFO  [ekf2] IMUs priorities - i: 2  ACC2  Priority: -1
INFO  [ekf2] IMUs priorities - i: 3  ACC1  Priority: -1
INFO  [ekf2] all valid EKF instances have been started. Started instances: 1
INFO  [mavlink] mode: Normal, data rate: 4000000 B/s on udp port 18570 remote port 14550
Gazebo multi-robot simulator, version 11.8.1
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Msg] Waiting for master.
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.1.42
INFO  [mavlink] mode: Onboard, data rate: 4000000 B/s on udp port 14580 remote port 14540
INFO  [mavlink] mode: Onboard, data rate: 4000 B/s on udp port 14280 remote port 14030
INFO  [mavlink] mode: Gimbal, data rate: 400000 B/s on udp port 13030 remote port 13280
INFO  [logger] logger started (mode=all)
INFO  [logger] Start file log (type: full)
INFO  [logger] [logger] ./log/2023-07-11/22_22_29.ulg	
INFO  [logger] Opened full log file: ./log/2023-07-11/22_22_29.ulg
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [px4] Startup script returned successfully
pxh> INFO  [tone_alarm] home set
INFO  [tone_alarm] notify negative

pxh> 
pxh> INFO  [commander] Ready for takeoff!
pxh> commander takeoff
pxh> INFO  [commander] Armed by internal command	
INFO  [tone_alarm] arming warning
INFO  [navigator] Using minimum takeoff altitude: 2.50 m	

pxh> INFO  [commander] Takeoff detected	

pxh> ekf2 status
INFO  [ekf2] available instances: 1
INFO  [ekf2] 0: ACC: 1310988, GYRO: 1310988, MAG: 197388, healthy, test ratio: 0.0047039 (0.00000) *

ekf2:0 EKF dt: 0.0080s, attitude: 1, local position: 1, global position: 1
ekf2: ECL update: 1702 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 1701 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events
ekf2: vehicle_air_data messages missed: 0 events
ekf2: vehicle_gps_position messages missed: 0 events
ekf2: vehicle_magnetometer messages missed: 0 events
pxh> commander land
pxh> INFO  [commander] Landing at current position	
INFO  [commander] Landing detected	
INFO  [commander] Disarmed by landing	
INFO  [tone_alarm] notify neutral
INFO  [logger] closed logfile, bytes written: 6349087

pxh> shutdown
Exiting NOW.
```

### Testing information with current main

```
INFO  [ekf2] available instances: 1
INFO  [ekf2] 0: ACC: 1310988, GYRO: 1310988, MAG: 197388, healthy, test ratio: 0.0212503 (0.00000) *

ekf2:0 EKF dt: 0.0080s, attitude: 1, local position: 1, global position: 1
ekf2: ECL update: 5977 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 5978 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events
ekf2: vehicle_air_data messages missed: 0 events
ekf2: vehicle_gps_position messages missed: 0 events
ekf2: vehicle_magnetometer messages missed: 0 events

ekf2:1 EKF dt: 0.0100s, attitude: 0, local position: 0, global position: 0
ekf2: ECL update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events

ekf2:2 EKF dt: 0.0100s, attitude: 0, local position: 0, global position: 0
ekf2: ECL update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events
```


### More info
- *EKF2::task_spawn* method is too long. It should be splitted into smaller private methods or as functions in a utils file.
- Further testing has to be done and it should include real drones. I will try to do a test next week