### PR TITLE
2 Hz OpenDroneID rate + unknown pressure altitude accuracy

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1515,8 +1515,8 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("LOCAL_POSITION_NED", 1.0f);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.0f);
 		configure_stream_local("OBSTACLE_DISTANCE", 1.0f);
-		configure_stream_local("OPEN_DRONE_ID_LOCATION", 1.f);
-		configure_stream_local("OPEN_DRONE_ID_SYSTEM", 1.f);
+		configure_stream_local("OPEN_DRONE_ID_LOCATION", 2.f);
+		configure_stream_local("OPEN_DRONE_ID_SYSTEM", 2.f);
 		configure_stream_local("ORBIT_EXECUTION_STATUS", 2.0f);
 		configure_stream_local("PING", 0.1f);
 		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 1.0f);

--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_LOCATION.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_LOCATION.hpp
@@ -236,7 +236,7 @@ private:
 
 			if (_vehicle_air_data_sub.copy(&vehicle_air_data) && (hrt_elapsed_time(&vehicle_air_data.timestamp) < 10_s)) {
 				msg.altitude_barometric = vehicle_air_data.baro_alt_meter;
-				msg.barometer_accuracy = MAV_ODID_VER_ACC_150_METER; // TODO
+				// TODO: msg.barometer_accuracy
 				updated = true;
 			}
 		}


### PR DESCRIPTION
### Solved Problem
The remote ID broadcast latency and message rate must be <= 1 per sec. If there is any delay in relaying the message to the beacon, packing the message, and broadcasting the message, the system will not meet the requirement.

In addition, the pressure altitude accuracy is given an arbitrary large default value instead of just 'unknown'.

### Solution
- Increased location and system messages from 1 Hz to 2 Hz
- Changed pressure altitude accuracy to 'unknown'