### PR TITLE
EKF2::task_spawn - Cleanup and refactor

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2634,75 +2634,7 @@ int EKF2::task_spawn(int argc, char *argv[])
 			return PX4_ERROR;
 		}
 
-		const hrt_abstime time_started = hrt_absolute_time();
-		const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
-		int multi_instances_allocated = 0;
-
-		// allocate EKF2 instances until all found or arming
-		uORB::SubscriptionData<vehicle_status_s> vehicle_status_sub{ORB_ID(vehicle_status)};
-
-		bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS] {}; // IMUs * mags
-
-		while ((multi_instances_allocated < multi_instances)
-		       && (vehicle_status_sub.get().arming_state != vehicle_status_s::ARMING_STATE_ARMED)
-		       && ((hrt_elapsed_time(&time_started) < 30_s)
-			   || (vehicle_status_sub.get().hil_state == vehicle_status_s::HIL_STATE_ON))) {
-
-			vehicle_status_sub.update();
-
-			for (uint8_t mag = 0; mag < mag_instances; mag++) {
-				uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
-
-				for (uint8_t imu = 0; imu < imu_instances; imu++) {
-
-					uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
-					vehicle_mag_sub.update();
-
-					// Mag & IMU data must be valid, first mag can be ignored initially
-					if ((vehicle_mag_sub.advertised() || mag == 0) && (vehicle_imu_sub.advertised())) {
-
-						if (!ekf2_instance_created[imu][mag]) {
-							EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false);
-
-							if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
-								int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
-
-								if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
-									_objects[actual_instance].store(ekf2_inst);
-									success = true;
-									multi_instances_allocated++;
-									ekf2_instance_created[imu][mag] = true;
-
-									PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
-										  imu, vehicle_imu_sub.get().accel_device_id,
-										  mag, vehicle_mag_sub.get().device_id);
-
-									_ekf2_selector.load()->ScheduleNow();
-
-								} else {
-									PX4_ERR("instance numbering problem instance: %d", actual_instance);
-									delete ekf2_inst;
-									break;
-								}
-
-							} else {
-								PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
-								px4_usleep(100000);
-								break;
-							}
-						}
-
-					} else {
-						px4_usleep(1000); // give the sensors extra time to start
-						break;
-					}
-				}
-			}
-
-			if (multi_instances_allocated < multi_instances) {
-				px4_usleep(10000);
-			}
-		}
+		success = EKF2::MultiEKF2SpawnHandler(imu_instances, mag_instances);
 
 	} else
 
@@ -2735,6 +2667,96 @@ bool EKF2::StartSingleEFK2Instance(const px4::wq_config_t wq, bool replay_mode)
 	}
 
 	return false;
+}
+
+int EKF2::StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag)
+{
+	EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false); //Might be done by start order
+
+	if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
+		int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
+
+		if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
+			_objects[actual_instance].store(ekf2_inst);
+			_ekf2_selector.load()->ScheduleNow();
+
+			return actual_instance;
+
+		} else {
+			PX4_ERR("instance numbering problem instance: %d", actual_instance);
+			delete ekf2_inst;
+
+			return PX4_ERROR;
+		}
+
+	} else {
+		PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
+		px4_usleep(100000);
+
+		return PX4_ERROR;
+	}
+}
+
+int EKF2::MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances)
+{
+	bool success = false;
+	const hrt_abstime time_started = hrt_absolute_time();
+	const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
+	int multi_instances_allocated = 0;
+
+	// allocate EKF2 instances until all found or arming
+	uORB::SubscriptionData<vehicle_status_s> vehicle_status_sub{ORB_ID(vehicle_status)};
+
+	bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS] {}; // IMUs * mags
+
+	while ((multi_instances_allocated < multi_instances)
+	       && (vehicle_status_sub.get().arming_state != vehicle_status_s::ARMING_STATE_ARMED)
+	       && ((hrt_elapsed_time(&time_started) < 30_s)
+		   || (vehicle_status_sub.get().hil_state == vehicle_status_s::HIL_STATE_ON))) {
+
+		vehicle_status_sub.update();
+
+		for (uint8_t mag = 0; mag < mag_instances; mag++) {
+			uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
+
+			for (uint8_t imu = 0; imu < imu_instances; imu++) {
+
+				uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
+				vehicle_mag_sub.update();
+
+				// Mag & IMU data must be valid, first mag (mag0) can be ignored initially
+				if ((vehicle_mag_sub.advertised() || mag == 0) && (vehicle_imu_sub.advertised())) {
+					if (!ekf2_instance_created[imu][mag]) {
+
+						int actual_instance = EKF2::StartMultiModeEKF2Instance(px4::ins_instance_to_wq(imu), false, imu, mag);
+
+						if (PX4_ERROR != actual_instance) {
+							success = true;
+							multi_instances_allocated++;
+							ekf2_instance_created[imu][mag] = true;
+							PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
+								  imu, vehicle_imu_sub.get().accel_device_id,
+								  mag, vehicle_mag_sub.get().device_id);
+
+						} else {
+							break;
+						}
+
+					}
+
+				} else {
+					px4_usleep(1000); // give the sensors extra time to start
+					break;
+				}
+			}
+		}
+
+		if (multi_instances_allocated < multi_instances) {
+			px4_usleep(10000);
+		}
+	}
+
+	return success;
 }
 
 int EKF2::print_usage(const char *reason)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2541,6 +2541,22 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 	}
 }
 
+bool EKF2::StartEKF2Selector()
+{
+	if (_ekf2_selector.load() == nullptr) {
+		EKF2Selector *inst = new EKF2Selector();
+
+		if (inst) {
+			_ekf2_selector.store(inst);
+			return true;
+		}
+
+		return false;
+	}
+
+	return true;
+}
+
 int EKF2::custom_command(int argc, char *argv[])
 {
 	return print_usage("unknown command");
@@ -2613,16 +2629,9 @@ int EKF2::task_spawn(int argc, char *argv[])
 
 	if (multi_mode && !replay_mode) {
 		// Start EKF2Selector if it's not already running
-		if (_ekf2_selector.load() == nullptr) {
-			EKF2Selector *inst = new EKF2Selector();
-
-			if (inst) {
-				_ekf2_selector.store(inst);
-
-			} else {
-				PX4_ERR("Failed to create EKF2 selector");
-				return PX4_ERROR;
-			}
+		if (!EKF2::StartEKF2Selector()) {
+			PX4_ERR("Failed to create EKF2 selector");
+			return PX4_ERROR;
 		}
 
 		const hrt_abstime time_started = hrt_absolute_time();

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2557,9 +2557,9 @@ bool EKF2::StartSingleEFK2Instance(const px4::wq_config_t wq, bool replay_mode)
 }
 
 #if defined(CONFIG_EKF2_MULTI_INSTANCE)
-int EKF2::StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag)
+int EKF2::StartMultiModeEKF2Instance(const px4::wq_config_t wq, int imu, int mag, bool replay_mode)
 {
-	EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false); //Might be done by start order
+	EKF2 *ekf2_inst = new EKF2(true, wq, replay_mode);
 
 	if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
 		int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
@@ -2621,7 +2621,7 @@ bool EKF2::MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances)
 					break;
 				}
 
-				int actual_instance = EKF2::StartMultiModeEKF2Instance(px4::ins_instance_to_wq(imu), false, imu, mag);
+				int actual_instance = EKF2::StartMultiModeEKF2Instance(px4::ins_instance_to_wq(imu), imu, mag, false);
 
 				if (PX4_ERROR == actual_instance) { break; }
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2541,6 +2541,108 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 	}
 }
 
+bool EKF2::StartSingleEFK2Instance(const px4::wq_config_t wq, bool replay_mode)
+{
+	// Instance number could probably be obtained from
+	EKF2 *ekf2_inst = new EKF2(false, wq, replay_mode);
+
+	if (ekf2_inst) {
+		int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
+		_objects[actual_instance].store(ekf2_inst);
+		ekf2_inst->ScheduleNow();
+		return true;
+	}
+
+	return false;
+}
+
+#if defined(CONFIG_EKF2_MULTI_INSTANCE)
+int EKF2::StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag)
+{
+	EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false); //Might be done by start order
+
+	if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
+		int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
+
+		if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
+			_objects[actual_instance].store(ekf2_inst);
+			_ekf2_selector.load()->ScheduleNow();
+
+			return actual_instance;
+
+		} else {
+			PX4_ERR("instance numbering problem instance: %d", actual_instance);
+			delete ekf2_inst;
+
+			return PX4_ERROR;
+		}
+
+	} else {
+		PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
+		px4_usleep(100000);
+
+		return PX4_ERROR;
+	}
+}
+
+bool EKF2::MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances)
+{
+	bool success = false;
+	const hrt_abstime time_started = hrt_absolute_time();
+	const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
+	int multi_instances_allocated = 0;
+
+	// allocate EKF2 instances until all found or arming
+	uORB::SubscriptionData<vehicle_status_s> vehicle_status_sub{ORB_ID(vehicle_status)};
+
+	bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS] {}; // IMUs * mags
+
+	while ((multi_instances_allocated < multi_instances)
+	       && (vehicle_status_sub.get().arming_state != vehicle_status_s::ARMING_STATE_ARMED)
+	       && ((hrt_elapsed_time(&time_started) < 30_s)
+		   || (vehicle_status_sub.get().hil_state == vehicle_status_s::HIL_STATE_ON))) {
+
+		vehicle_status_sub.update();
+
+		for (uint8_t mag = 0; mag < mag_instances; mag++) {
+			uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
+
+			for (uint8_t imu = 0; imu < imu_instances; imu++) {
+
+				// Don't respawn already created instances
+				if (ekf2_instance_created[imu][mag]) { continue; }
+
+				uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
+				vehicle_mag_sub.update();
+
+				// IMU & Mag data must be valid, first mag (mag0) can be ignored initially
+				if ((!vehicle_imu_sub.advertised()) || (!vehicle_mag_sub.advertised() && mag > 0)) {
+					px4_usleep(1000); // give the sensors extra time to start
+					break;
+				}
+
+				int actual_instance = EKF2::StartMultiModeEKF2Instance(px4::ins_instance_to_wq(imu), false, imu, mag);
+
+				if (PX4_ERROR == actual_instance) { break; }
+
+				success = true;
+				multi_instances_allocated++;
+				ekf2_instance_created[imu][mag] = true;
+				PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
+					  imu, vehicle_imu_sub.get().accel_device_id,
+					  mag, vehicle_mag_sub.get().device_id);
+
+			}
+		}
+
+		if (multi_instances_allocated < multi_instances) {
+			px4_usleep(10000);
+		}
+	}
+
+	return success;
+}
+
 bool EKF2::StartEKF2Selector()
 {
 	if (_ekf2_selector.load() == nullptr) {
@@ -2556,6 +2658,7 @@ bool EKF2::StartEKF2Selector()
 
 	return true;
 }
+#endif // #if defined(CONFIG_EKF2_MULTI_INSTANCE)
 
 int EKF2::custom_command(int argc, char *argv[])
 {
@@ -2652,107 +2755,6 @@ int EKF2::task_spawn(int argc, char *argv[])
 	}
 
 	return success ? PX4_OK : PX4_ERROR;
-}
-
-bool EKF2::StartSingleEFK2Instance(const px4::wq_config_t wq, bool replay_mode)
-{
-	// Instance number could probably be obtained from
-	EKF2 *ekf2_inst = new EKF2(false, wq, replay_mode);
-
-	if (ekf2_inst) {
-		int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
-		_objects[actual_instance].store(ekf2_inst);
-		ekf2_inst->ScheduleNow();
-		return true;
-	}
-
-	return false;
-}
-
-int EKF2::StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag)
-{
-	EKF2 *ekf2_inst = new EKF2(true, px4::ins_instance_to_wq(imu), false); //Might be done by start order
-
-	if (ekf2_inst && ekf2_inst->multi_init(imu, mag)) {
-		int actual_instance = ekf2_inst->instance(); // match uORB instance numbering
-
-		if ((actual_instance >= 0) && (_objects[actual_instance].load() == nullptr)) {
-			_objects[actual_instance].store(ekf2_inst);
-			_ekf2_selector.load()->ScheduleNow();
-
-			return actual_instance;
-
-		} else {
-			PX4_ERR("instance numbering problem instance: %d", actual_instance);
-			delete ekf2_inst;
-
-			return PX4_ERROR;
-		}
-
-	} else {
-		PX4_ERR("alloc and init failed imu: %" PRIu8 " mag:%" PRIu8, imu, mag);
-		px4_usleep(100000);
-
-		return PX4_ERROR;
-	}
-}
-
-bool EKF2::MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances)
-{
-	bool success = false;
-	const hrt_abstime time_started = hrt_absolute_time();
-	const int multi_instances = math::min(imu_instances * mag_instances, static_cast<int32_t>(EKF2_MAX_INSTANCES));
-	int multi_instances_allocated = 0;
-
-	// allocate EKF2 instances until all found or arming
-	uORB::SubscriptionData<vehicle_status_s> vehicle_status_sub{ORB_ID(vehicle_status)};
-
-	bool ekf2_instance_created[MAX_NUM_IMUS][MAX_NUM_MAGS] {}; // IMUs * mags
-
-	while ((multi_instances_allocated < multi_instances)
-	       && (vehicle_status_sub.get().arming_state != vehicle_status_s::ARMING_STATE_ARMED)
-	       && ((hrt_elapsed_time(&time_started) < 30_s)
-		   || (vehicle_status_sub.get().hil_state == vehicle_status_s::HIL_STATE_ON))) {
-
-		vehicle_status_sub.update();
-
-		for (uint8_t mag = 0; mag < mag_instances; mag++) {
-			uORB::SubscriptionData<vehicle_magnetometer_s> vehicle_mag_sub{ORB_ID(vehicle_magnetometer), mag};
-
-			for (uint8_t imu = 0; imu < imu_instances; imu++) {
-
-				// Don't respawn already created instances
-				if (ekf2_instance_created[imu][mag]) { continue; }
-
-				uORB::SubscriptionData<vehicle_imu_s> vehicle_imu_sub{ORB_ID(vehicle_imu), imu};
-				vehicle_mag_sub.update();
-
-				// IMU & Mag data must be valid, first mag (mag0) can be ignored initially
-				if ((!vehicle_imu_sub.advertised()) || (!vehicle_mag_sub.advertised() && mag > 0)) {
-					px4_usleep(1000); // give the sensors extra time to start
-					break;
-				}
-
-				int actual_instance = EKF2::StartMultiModeEKF2Instance(px4::ins_instance_to_wq(imu), false, imu, mag);
-
-				if (PX4_ERROR == actual_instance) { break; }
-
-				success = true;
-				multi_instances_allocated++;
-				ekf2_instance_created[imu][mag] = true;
-				PX4_DEBUG("starting instance %d, IMU:%" PRIu8 " (%" PRIu32 "), MAG:%" PRIu8 " (%" PRIu32 ")", actual_instance,
-					  imu, vehicle_imu_sub.get().accel_device_id,
-					  mag, vehicle_mag_sub.get().device_id);
-
-			}
-		}
-
-		if (multi_instances_allocated < multi_instances) {
-			px4_usleep(10000);
-		}
-	}
-
-	return success;
 }
 
 int EKF2::print_usage(const char *reason)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -198,6 +198,12 @@ private:
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
+	/**
+	 * @brief Starts EKF2Selector if it's not already running.
+	 * @param result true if it is already started of it was able to start it. False otherwise.
+	 */
+	static bool StartEKF2Selector();
+
 #if defined(CONFIG_EKF2_AIRSPEED)
 	void UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps);
 #endif // CONFIG_EKF2_AIRSPEED

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -213,9 +213,9 @@ private:
 
 	/**
 	 * @brief Starts an EKF2 instance in multi EKF mode and updates all the internal variables
-	 * @param result instance number if could be started. PX4_ERROR otherwise.
+	 * @param result EKF2 instance number if could be started. PX4_ERROR otherwise.
 	 */
-	static int StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag);
+	static int StartMultiModeEKF2Instance(const px4::wq_config_t wq, int imu, int mag, bool replay_mode);
 #endif // #if defined(CONFIG_EKF2_MULTI_INSTANCE)
 
 	/**

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -198,6 +198,7 @@ private:
 	void PublishWindEstimate(const hrt_abstime &timestamp);
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
+#if defined(CONFIG_EKF2_MULTI_INSTANCE)
 	/**
 	 * @brief Handles the spawning of multiple EKF2 instances based on the input number of sensors.
 	 * @param result true if it has managed to successfully start at least one instance. False if it hasn't.
@@ -215,6 +216,7 @@ private:
 	 * @param result instance number if could be started. PX4_ERROR otherwise.
 	 */
 	static int StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag);
+#endif // #if defined(CONFIG_EKF2_MULTI_INSTANCE)
 
 	/**
 	 * @brief Starts an EKF2 instance in single EKF mode and updates all the internal variables

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -199,10 +199,22 @@ private:
 	void PublishYawEstimatorStatus(const hrt_abstime &timestamp);
 
 	/**
+	 * @brief Handles the spawning of multiple EKF2 instances based on the input number of sensors.
+	 * @param result true if it has managed to successfully start at least one instance. False if it hasn't.
+	 */
+	static int MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances);
+
+	/**
 	 * @brief Starts EKF2Selector if it's not already running.
 	 * @param result true if it is already started of it was able to start it. False otherwise.
 	 */
 	static bool StartEKF2Selector();
+
+	/**
+	 * @brief Starts an EKF2 instance in multi EKF mode and updates all the internal variables
+	 * @param result instance number if could be started. PX4_ERROR otherwise.
+	 */
+	static int StartMultiModeEKF2Instance(const px4::wq_config_t wq, bool replay_mode, int imu, int mag);
 
 	/**
 	 * @brief Starts an EKF2 instance in single EKF mode and updates all the internal variables

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -204,6 +204,12 @@ private:
 	 */
 	static bool StartEKF2Selector();
 
+	/**
+	 * @brief Starts an EKF2 instance in single EKF mode and updates all the internal variables
+	 * @param result true if it could be started. False otherwise.
+	 */
+	static bool StartSingleEFK2Instance(const px4::wq_config_t wq, bool replay_mode);
+
 #if defined(CONFIG_EKF2_AIRSPEED)
 	void UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps);
 #endif // CONFIG_EKF2_AIRSPEED

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -202,7 +202,7 @@ private:
 	 * @brief Handles the spawning of multiple EKF2 instances based on the input number of sensors.
 	 * @param result true if it has managed to successfully start at least one instance. False if it hasn't.
 	 */
-	static int MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances);
+	static bool MultiEKF2SpawnHandler(int32_t imu_instances, int32_t mag_instances);
 
 	/**
 	 * @brief Starts EKF2Selector if it's not already running.


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
- Current *main** `EKF2::task_spawn` method is 165 lines long.
- Maximum indentation level is: 7
- The method does many different task. It should aim to only do one thing
- Lots of low level tasks, like spawning the EKF2 instances and performing are mixed with high level checks
- Due to its complexity it's hard to unit-test, verify and debug

This proposal tries to introduce a cleaner code that is easier to handle. The main changes are:
- 4 new auxiliary methods, each one with a simple purpose.
- `EKF2::task_spawn` lenght has been reduced to 90 lines (it could still be done better)
- Early-breaking has been favored instead of really long if and if-else chains
- Early-breaking has been introduced to remove unnecessary checks (Ex: Don't respawn already created instances, continue)
- General indentation has been reduced to 3 levels (4 if early-breaking is taken into account)

**No behavioral changes have been introduced, with one exception:**
- Checking if an instance was already created is now done before sensor publishing is checked. This means that both actions have had their order interchanged.

Related #21815

### Changelog Entry
For release notes:
```
Refactor: EKF2::task_spawn
```

### Test coverage
- Simulation testing output:
```
______  __   __    ___ 
| ___ \ \ \ / /   /   |
| |_/ /  \ V /   / /| |
|  __/   /   \  / /_| |
| |     / /^\ \ \___  |
\_|     \/   \/     |_/

px4 starting.

INFO  [px4] startup script: /bin/sh etc/init.d-posix/rcS 0
INFO  [init] found model autostart file as SYS_AUTOSTART=10015
INFO  [param] selected parameter default file parameters.bson
INFO  [param] importing from 'parameters.bson'
INFO  [parameters] BSON document size 404 bytes, decoded 404 bytes (INT32:14, FLOAT:6)
INFO  [param] selected parameter backup file parameters_backup.bson
INFO  [dataman] data manager file './dataman' size is 7866640 bytes
etc/init.d-posix/rcS: 39: [: Illegal number: 
INFO  [init] PX4_SIM_HOSTNAME: localhost
INFO  [simulator_mavlink] Waiting for simulator to accept connection on TCP port 4560
INFO  [simulator_mavlink] Simulator connected on TCP port 4560.
INFO  [lockstep_scheduler] setting initial absolute time to 3164000 us
INFO  [commander] LED: open /dev/led0 failed (22)
WARN  [health_and_arming_checks] Preflight Fail: ekf2 missing data
Gazebo multi-robot simulator, version 11.8.1
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Msg] Waiting for master.
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.1.42
INFO  [mavlink] mode: Normal, data rate: 4000000 B/s on udp port 18570 remote port 14550
INFO  [mavlink] mode: Onboard, data rate: 4000000 B/s on udp port 14580 remote port 14540
INFO  [mavlink] mode: Onboard, data rate: 4000 B/s on udp port 14280 remote port 14030
INFO  [mavlink] mode: Gimbal, data rate: 400000 B/s on udp port 13030 remote port 13280
INFO  [logger] logger started (mode=all)
INFO  [logger] Start file log (type: full)
INFO  [logger] [logger] ./log/2023-07-07/16_58_41.ulg	
INFO  [logger] Opened full log file: ./log/2023-07-07/16_58_41.ulg
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [px4] Startup script returned successfully
pxh> INFO  [tone_alarm] home set
INFO  [tone_alarm] notify negative
INFO  [mavlink] partner IP: 127.0.0.1
[Wrn] [Event.cc:61] Warning: Deleting a connection right after creation. Make sure to save the ConnectionPtr from a Connect call
INFO  [commander] Ready for takeoff!

pxh> commander takeoff
pxh> INFO  [commander] Armed by internal command	
INFO  [tone_alarm] arming warning
INFO  [navigator] Using minimum takeoff altitude: 2.50 m	
INFO  [commander] Takeoff detected	

pxh> ekf2 status
INFO  [ekf2] available instances: 1
INFO  [ekf2] 0: ACC: 1310988, GYRO: 1310988, MAG: 197388, healthy, test ratio: 0.0161799 (0.00000) *

ekf2:0 EKF dt: 0.0080s, attitude: 1, local position: 1, global position: 1
ekf2: ECL update: 2904 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 2904 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events
ekf2: vehicle_air_data messages missed: 0 events
ekf2: vehicle_gps_position messages missed: 0 events
ekf2: vehicle_magnetometer messages missed: 0 events

ekf2:1 EKF dt: 0.0100s, attitude: 0, local position: 0, global position: 0
ekf2: ECL update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events

ekf2:2 EKF dt: 0.0100s, attitude: 0, local position: 0, global position: 0
ekf2: ECL update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: ECL full update: 0 events, 0us elapsed, 0.00us avg, min 0us max 0us 0.000us rms
ekf2: IMU message missed: 0 events
pxh> 
pxh> commander land
pxh> INFO  [commander] Landing at current position	
INFO  [commander] Landing detected	
INFO  [commander] Disarmed by landing	
INFO  [tone_alarm] notify neutral
INFO  [logger] closed logfile, bytes written: 8218218

pxh> shutdown
Exiting NOW.
```

