### PR TITLE
BATTERY_STATUS: improve voltage reporting

### DIFF
--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -35,7 +35,6 @@
 #define BATTERY_STATUS_HPP
 
 #include <uORB/topics/battery_status.h>
-#include <cmath>
 
 class MavlinkStreamBatteryStatus : public MavlinkStream
 {
@@ -162,7 +161,7 @@ private:
 
 							for (int i = 0; i < mavlink_cell_slots; i++) {
 								if (voltage_mV > 0.0001f) {
-									new_cell_voltage_mV = math::min(voltage_mV, max_cell_voltage_mV);
+									new_cell_voltage_mV = (voltage_mV < max_cell_voltage_mV) ? voltage_mV : max_cell_voltage_mV;
 									cell_voltages[i] = new_cell_voltage_mV;
 									voltage_mV -= new_cell_voltage_mV;
 								}


### PR DESCRIPTION
### Solved Problem
If the battery does not report individual cell voltages and the total battery's voltage exceeds 65.534V, the voltage was misreported to GCS.

### Solution
According to the [spec](https://mavlink.io/en/messages/common.html#BATTERY_STATUS):
> If the voltage of the battery is greater than (UINT16_MAX - 1), then cell 0 should be set to (UINT16_MAX - 1), and cell 1 to the remaining voltage. This can be extended to multiple cells if the total voltage is greater than 2 * (UINT16_MAX - 1).

So that's what I did. Now the code fills the cells with the remaining voltage. This way, we can report batteries up to 655.34V.

### Changelog Entry
For release notes:
```
BATTERY_STATUS: improve voltage reporting
```

### Test coverage
- Tested on a CUAV Pixhawk V6X and a "battery" that reports ~410V

### Context
<details>
  <summary>Before the fix</summary>

![photo_2023-07-10_20-03-51](https://github.com/PX4/PX4-Autopilot/assets/15573098/162d22d0-9c33-48d9-a0f2-b813755fd8e4)
![photo_2023-07-10_20-03-54](https://github.com/PX4/PX4-Autopilot/assets/15573098/e129033e-0f01-4f17-9e55-ca7c0e11029b)

</details>

<details>
  <summary>After the fix</summary>

![photo_2023-07-10_20-09-41](https://github.com/PX4/PX4-Autopilot/assets/15573098/787cf42e-78b8-4bfd-85de-d8b4e3b611a6)
![photo_2023-07-10_20-09-43](https://github.com/PX4/PX4-Autopilot/assets/15573098/67d3adb3-e6a8-45a6-a95a-eba34cedfb23)

</details>
