### PR TITLE
[v1.14 backport] netman line too long

### DIFF
--- a/src/systemcmds/netman/netman.cpp
+++ b/src/systemcmds/netman/netman.cpp
@@ -405,23 +405,24 @@ static void usage(const char *reason)
   memory. On boot the `update` option will be run. If a network configuration
   does not exist. The default setting will be saved in non-volatile and the
   system rebooted.
-  
+
   #### update
-  
+
   `netman update` is run automatically by [a startup script](../concept/system_startup.md#system-startup).
   When run, the `update` option will check for the existence of `net.cfg` in the root of the SD Card.
-  It then saves the network settings from `net.cfg` in non-volatile memory, 
+  It then saves the network settings from `net.cfg` in non-volatile memory,
   deletes the file and reboots the system.
 
   #### save
-  
+
   The `save` option will save settings from non-volatile memory to a file named
-  `net.cfg` on the SD Card filesystem for editing. Use this to edit the settings. 
+  `net.cfg` on the SD Card filesystem for editing. Use this to edit the settings.
   Save does not immediately apply the network settings; the user must reboot the flight stack.
-  By contrast, the `update` command is run by the start-up script, commits the settings to non-volatile memory, and reboots the flight controller (which will then use the new settings).
-  
+  By contrast, the `update` command is run by the start-up script, commits the settings to non-volatile memory,
+  and reboots the flight controller (which will then use the new settings).
+
   #### show
-  
+
   The `show` option will display the network settings in `net.cfg` to the console.
 
   ### Examples


### PR DESCRIPTION
## About
Backport of https://github.com/PX4/PX4-Autopilot/pull/21680, to fix the Module documentation CI broken in `release/1.14` branch, caused by https://github.com/PX4/PX4-Autopilot/pull/21673.

![image](https://github.com/PX4/PX4-Autopilot/assets/23277211/1aacea2b-fd77-48a1-83b0-838b7859ed66)

Example CI run where the module documentation was not getting built: https://github.com/PX4/PX4-Autopilot/actions/runs/5510837000/jobs/10045596294#step:4:46