### PR TITLE
Other CI: Use Debian 11 for linux targets and have the required cmake version

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -9,7 +9,7 @@ pipeline {
         script {
           def build_nodes = [:]
           def docker_images = [
-            armhf: "px4io/px4-dev-armhf:2022-08-12",
+            armhf: "px4io/px4-dev-armhf:2023-06-26",
             arm64: "px4io/px4-dev-aarch64:2022-08-12",
             base: "px4io/px4-dev-ros2-foxy:2022-08-12",
             nuttx: "px4io/px4-dev-nuttx-focal:2022-08-12",

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -7,13 +7,13 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2021-09-08"
 	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]] || [[ $@ =~ .*pilotpi.default ]]; then
 		# beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default, scumaker_pilotpi_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-08-18"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
 	elif [[ $@ =~ .*pilotpi.arm64 ]]; then
 		# scumaker_pilotpi_arm64
 		PX4_DOCKER_REPO="px4io/px4-dev-aarch64:latest"
 	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# posix_rpi_cross, posix_bebop_default
-		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2021-08-18"
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2021-02-04"


### PR DESCRIPTION
### Solved Problem
It's a follow up to https://github.com/PX4/PX4-Autopilot/pull/21749 since I see Jenkins and metadata builds failing on the main branch still with the same error that was solved on the normal linux target GitHub Actions before.

I wasn't aware that there are multiple different container versions used for almost the same build.

### Solution
Of course they need to use the updated container.

I'm assuming the update metadata uses what's specified in `Tools/docker_run.sh` and Jenkins uses `.ci/Jenkinsfile-compile`.

### Changelog Entry
```
- Fix remaining CI by updating to Debian 11 for linux targets and have the required cmake version
```

### Test coverage
- Not tested locally. I'm assuming these other jobs will run fine with the updated container since their current error was solved before the same way.