### PR TITLE
Support mavlink opaque ID

### DIFF
--- a/msg/Mission.msg
+++ b/msg/Mission.msg
@@ -7,6 +7,6 @@ int32 current_seq	# default -1, start at the one changed latest
 int32 land_start_index  # Index of the land start marker, if unavailable index of the land item, -1 otherwise
 int32 land_index 	# Index of the land item, -1 otherwise
 
-uint16 mission_update_counter # indicates updates to the mission, reload from dataman if increased
-uint16 geofence_update_counter # indicates updates to the geofence, reload from dataman if increased
-uint16 safe_points_update_counter # indicates updates to the safe points, reload from dataman if increased
+uint32 mission_id # indicates updates to the mission, reload from dataman if changed
+uint32 geofence_id # indicates updates to the geofence, reload from dataman if changed
+uint32 safe_points_id # indicates updates to the safe points, reload from dataman if changed

--- a/msg/MissionResult.msg
+++ b/msg/MissionResult.msg
@@ -1,7 +1,7 @@
-uint64 timestamp				# time since system start (microseconds)
+uint64 timestamp		# time since system start (microseconds)
 
-uint16 mission_update_counter   # Counter for the mission for which the result was generated
-uint16 geofence_update_counter  # Counter for the corresponding geofence for which the result was generated (used for mission feasibility)
+uint16 mission_id   		# Id for the mission for which the result was generated
+uint16 geofence_id  		# Id for the corresponding geofence for which the result was generated (used for mission feasibility)
 uint64 home_position_counter  	# Counter of the home position for which the result was generated (used for mission feasibility)
 
 int32 seq_reached		# Sequence of the mission item which has been reached, default -1

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1935,19 +1935,19 @@ void Commander::checkForMissionUpdate()
 	if (_mission_result_sub.updated()) {
 		const mission_result_s &mission_result = _mission_result_sub.get();
 
-		const auto prev_mission_mission_update_counter = mission_result.mission_update_counter;
+		const auto prev_mission_mission_id = mission_result.mission_id;
 		_mission_result_sub.update();
 
 		// if mission_result is valid for the current mission
 		const bool mission_result_ok = (mission_result.timestamp > _boot_timestamp)
-					       && (mission_result.mission_update_counter > 0);
+					       && (mission_result.mission_id > 0);
 
 		bool auto_mission_available = mission_result_ok && mission_result.valid;
 
 		if (mission_result_ok) {
 			/* Only evaluate mission state if home is set */
 			if (!_failsafe_flags.home_position_invalid &&
-			    (prev_mission_mission_update_counter != mission_result.mission_update_counter)) {
+			    (prev_mission_mission_id != mission_result.mission_id)) {
 
 				if (!auto_mission_available) {
 					/* the mission is invalid */

--- a/src/modules/commander/HealthAndArmingChecks/checks/missionCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/missionCheck.cpp
@@ -56,6 +56,6 @@ void MissionChecks::checkAndReport(const Context &context, Report &reporter)
 		}
 
 		// This is a mode requirement, no need to report
-		reporter.failsafeFlags().auto_mission_missing = mission_result.mission_update_counter <= 0;
+		reporter.failsafeFlags().auto_mission_missing = mission_result.mission_id <= 0;
 	}
 }

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -574,10 +574,13 @@ _file_initialize(unsigned max_offset)
 		mission.dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 		mission.count = 0;
 		mission.current_seq = 0;
+		mission.mission_id = 0u;
+		mission.geofence_id = 0u;
+		mission.safe_points_id = 0u;
 
 		mission_stats_entry_s stats;
 		stats.num_items = 0;
-		stats.update_counter = 1;
+		stats.opaque_id = 0;
 
 		g_dm_ops->write(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission), sizeof(mission_s));
 		g_dm_ops->write(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats), sizeof(mission_stats_entry_s));

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -256,6 +256,7 @@ MavlinkMissionManager::send_mission_current(uint16_t seq)
 {
 	mavlink_mission_current_t wpc{};
 	wpc.seq = seq;
+	wpc.total = _count[MAV_MISSION_TYPE_MISSION] > 0 ? _count[MAV_MISSION_TYPE_MISSION] : UINT16_MAX;
 	wpc.mission_id = _crc32[MAV_MISSION_TYPE_MISSION];
 	wpc.fence_id = _crc32[MAV_MISSION_TYPE_FENCE];
 	wpc.rally_points_id = _crc32[MAV_MISSION_TYPE_RALLY];
@@ -516,10 +517,9 @@ MavlinkMissionManager::send()
 		}
 
 	} else if (_slow_rate_limiter.check(hrt_absolute_time())) {
+		send_mission_current(_current_seq);
+
 		if ((_count[MAV_MISSION_TYPE_MISSION] > 0) && (_current_seq >= 0)) {
-
-			send_mission_current(_current_seq);
-
 			// send the reached message another 10 times
 			if (_last_reached >= 0 && (_reached_sent_count < 10)) {
 				send_mission_item_reached((uint16_t)_last_reached);

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -140,7 +140,7 @@ private:
 	int32_t 		_land_start_marker{-1}; 	///< index of loaded land start mission item (if unavailable, index of land mission item, -1 otherwise)
 	int32_t 		_land_marker{-1}; 		///< index of loaded land mission item (-1 if unavailable)
 
-	MavlinkRateLimiter	_slow_rate_limiter{100 * 1000};		///< Rate limit sending of the current WP sequence to 10 Hz
+	MavlinkRateLimiter	_slow_rate_limiter{1000 * 1000};		///< Rate limit sending of the current WP sequence to 1 Hz
 
 	Mavlink *_mavlink;
 

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -183,8 +183,7 @@ private:
 
 	MapProjection _projection_reference{}; ///< class to convert (lon, lat) to local [m]
 
-
-	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, polygon data was updated
+	uint32_t _opaque_id{0}; ///< dataman geofence id: if it does not match, the polygon data was updated
 	bool _fence_updated{true};  ///< flag indicating if fence are updated to dataman cache
 	bool _initiate_fence_updated{true}; ///< flag indicating if fence updated is needed
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -473,7 +473,7 @@ Mission::save_mission_state()
 	if (success) {
 		/* data read successfully, check dataman ID and items count */
 		if (mission_state.dataman_id == _mission.dataman_id && mission_state.count == _mission.count
-		    && mission_state.mission_update_counter == _mission.mission_update_counter) {
+		    && mission_state.mission_id == _mission.mission_id) {
 			/* navigator may modify only sequence, write modified state only if it changed */
 			if (mission_state.current_seq != _mission.current_seq) {
 				mission_state = _mission;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -114,7 +114,7 @@ void MissionBase::updateMavlinkMission()
 		if (isMissionValid(new_mission)) {
 			/* Relevant mission items updated externally*/
 			if (checkMissionDataChanged(new_mission)) {
-				bool mission_items_changed = (new_mission.mission_update_counter != _mission.mission_update_counter);
+				bool mission_items_changed = (new_mission.mission_id != _mission.mission_id);
 
 				if (new_mission.current_seq < 0) {
 					new_mission.current_seq = math::max(math::min(_mission.current_seq, static_cast<int32_t>(new_mission.count) - 1),
@@ -689,12 +689,12 @@ MissionBase::checkMissionRestart()
 void
 MissionBase::check_mission_valid()
 {
-	if ((_navigator->get_mission_result()->mission_update_counter != _mission.mission_update_counter)
-	    || (_navigator->get_mission_result()->geofence_update_counter != _mission.geofence_update_counter)
+	if ((_navigator->get_mission_result()->mission_id != _mission.mission_id)
+	    || (_navigator->get_mission_result()->geofence_id != _mission.geofence_id)
 	    || (_navigator->get_mission_result()->home_position_counter != _navigator->get_home_position()->update_count)) {
 
-		_navigator->get_mission_result()->mission_update_counter = _mission.mission_update_counter;
-		_navigator->get_mission_result()->geofence_update_counter = _mission.geofence_update_counter;
+		_navigator->get_mission_result()->mission_id = _mission.mission_id;
+		_navigator->get_mission_result()->geofence_id = _mission.geofence_id;
 		_navigator->get_mission_result()->home_position_counter = _navigator->get_home_position()->update_count;
 
 		MissionFeasibilityChecker missionFeasibilityChecker(_navigator, _dataman_client);
@@ -1153,7 +1153,7 @@ void MissionBase::resetMission()
 	new_mission.land_start_index = -1;
 	new_mission.land_index = -1;
 	new_mission.count = 0u;
-	new_mission.mission_update_counter = _mission.mission_update_counter + 1;
+	new_mission.mission_id = 0u;
 	new_mission.dataman_id = _mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 ? DM_KEY_WAYPOINTS_OFFBOARD_1 :
 				 DM_KEY_WAYPOINTS_OFFBOARD_0;
 
@@ -1355,8 +1355,8 @@ void MissionBase::checkClimbRequired(int32_t mission_item_index)
 
 bool MissionBase::checkMissionDataChanged(mission_s new_mission)
 {
-	/* count and land_index are the same if the mission_counter did not change. We do not care about changes in geofence or rally counters.*/
+	/* count and land_index are the same if the mission_id did not change. We do not care about changes in geofence or rally counters.*/
 	return ((new_mission.dataman_id != _mission.dataman_id) ||
-		(new_mission.mission_update_counter != _mission.mission_update_counter) ||
+		(new_mission.mission_id != _mission.mission_id) ||
 		(new_mission.current_seq != _mission.current_seq));
 }

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -203,8 +203,9 @@ struct mission_item_s {
  * Corresponds to the first dataman entry of DM_KEY_FENCE_POINTS and DM_KEY_SAFE_POINTS
  */
 struct mission_stats_entry_s {
+	uint32_t opaque_id;			/**< opaque identifier for current stored mission stats */
 	uint16_t num_items;			/**< total number of items stored (excluding this one) */
-	uint16_t update_counter;			/**< This counter is increased when (some) items change (this can wrap) */
+	uint8_t padding[2];
 };
 
 /**
@@ -238,6 +239,18 @@ struct DestinationPosition {
 	float alt;	/**< altitude in MSL [m].*/
 	float yaw;	/**< final yaw when landed [rad].*/
 };
+
+
+/**
+ * Crc32 mission item struct.
+ * Used to pack relevant mission item ifnromation for us in crc32 mission calculation.
+ */
+typedef struct __attribute__((packed)) CrcMissionItem {
+	uint8_t frame;
+	uint16_t command;
+	uint8_t autocontinue;
+	float params[7];
+} CrcMissionItem_t;
 
 #if (__GNUC__ >= 5) || __clang__
 #pragma GCC diagnostic pop

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -249,7 +249,7 @@ public:
 
 	orb_advert_t *get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
-	int mission_instance_count() const { return _mission_result.mission_update_counter; }
+	int mission_instance_count() const { return _mission_result.mission_id; }
 
 	void set_mission_failure_heading_timeout();
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -171,8 +171,8 @@ void Navigator::run()
 	fds[2].fd = _mission_sub;
 	fds[2].events = POLLIN;
 
-	uint16_t geofence_update_counter{0};
-	uint16_t safe_points_update_counter{0};
+	uint32_t geofence_id{0};
+	uint32_t safe_points_id{0};
 
 	/* rate-limit position subscription to 20 Hz / 50 ms */
 	orb_set_interval(_local_pos_sub, 50);
@@ -201,13 +201,13 @@ void Navigator::run()
 			mission_s mission;
 			orb_copy(ORB_ID(mission), _mission_sub, &mission);
 
-			if (mission.geofence_update_counter != geofence_update_counter) {
-				geofence_update_counter = mission.geofence_update_counter;
+			if (mission.geofence_id != geofence_id) {
+				geofence_id = mission.geofence_id;
 				_geofence.updateFence();
 			}
 
-			if (mission.safe_points_update_counter != safe_points_update_counter) {
-				safe_points_update_counter = mission.safe_points_update_counter;
+			if (mission.safe_points_id != safe_points_id) {
+				safe_points_id = mission.safe_points_id;
 				_rtl.updateSafePoints();
 			}
 		}

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -99,9 +99,9 @@ void RTL::updateDatamanCache()
 				_error_state = DatamanState::ReadWait;
 				_dataman_state = DatamanState::Error;
 
-			} else if (_update_counter != _stats.update_counter) {
+			} else if (_opaque_id != _stats.opaque_id) {
 
-				_update_counter = _stats.update_counter;
+				_opaque_id = _stats.opaque_id;
 				_safe_points_updated = false;
 
 				_dataman_cache_safepoint.invalidate();
@@ -144,8 +144,8 @@ void RTL::updateDatamanCache()
 
 	}
 
-	if (_mission_counter != _mission_sub.get().mission_update_counter) {
-		_mission_counter = _mission_sub.get().mission_update_counter;
+	if (_mission_id != _mission_sub.get().mission_id) {
+		_mission_id = _mission_sub.get().mission_id;
 		const dm_item_t dm_item = static_cast<dm_item_t>(_mission_sub.get().dataman_id);
 		_dataman_cache_landItem.invalidate();
 

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -190,13 +190,13 @@ private:
 
 	DatamanState _dataman_state{DatamanState::UpdateRequestWait};
 	DatamanState _error_state{DatamanState::UpdateRequestWait};
-	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, safe points data was updated
+	uint32_t _opaque_id{0}; ///< dataman safepoint id: if it does not match, safe points data was updated
 	bool _safe_points_updated{false}; ///< flag indicating if safe points are updated to dataman cache
 	mutable DatamanCache _dataman_cache_safepoint{"rtl_dm_cache_miss_geo", 4};
 	DatamanClient	&_dataman_client_safepoint = _dataman_cache_safepoint.client();
 	bool _initiate_safe_points_updated{true}; ///< flag indicating if safe points update is needed
 	mutable DatamanCache _dataman_cache_landItem{"rtl_dm_cache_miss_land", 2};
-	int16_t _mission_counter = -1;
+	uint32_t _mission_id = 0u;
 
 	mission_stats_entry_s _stats;
 

--- a/src/systemcmds/tests/test_dataman.cpp
+++ b/src/systemcmds/tests/test_dataman.cpp
@@ -1096,7 +1096,7 @@ DatamanTest::testResetItems()
 
 	mission_stats_entry_s stats;
 	stats.num_items = 0;
-	stats.update_counter = 1;
+	stats.opaque_id = 0;
 
 	success = _dataman_client1.writeSync(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
 					     sizeof(mission_stats_entry_s));


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds support for the Mavlink Mission opaque ID as defined in https://github.com/mavlink/mavlink/pull/2012. It is based on the earlier implementation for the mission checksum support in https://github.com/PX4/PX4-Autopilot/pull/18418, but the mission checksum in Mavlink will be deprecated in https://github.com/mavlink/mavlink/pull/2010.

### Solution
- Add an opaque Id for the mission, geofence and rally points. The opaque id is based on a Crc32 checksum as in the implementation in https://github.com/PX4/PX4-Autopilot/pull/18418
- Opaque id is send from the System in the MISSION_COUNT on download. On upload, the opaque id is sent on the final MISSION_ACK
- The opaque Id is also streamed continuously in the MISSION_CURRENT message, such that a GCS can detect plan changes.
- The opaque id internally also replaces the mission counter, as those serves the same purpose.

### Changelog Entry
For release notes:
```
Feature: Add Support for Mavlink mission opaque Id.
```

### Alternatives
Opqaue id could also just be a counter instead of the Crc32. The hash implementation has the advantage that on loading the same mission (e.g. also from a file) should result in the same Id and thus the potentially multiple connected GCS does not need to download it again. Also it would allow for the feature, that a GCS does not need to download the mission on first connection if the old stored mission and opaque id is the same.

### Test coverage
- Unit/integration test: SITL testing by observing the mavlink message sent from the system.

### Context
- Before this can be merged, the respective mavlink PR should be merged
