### PR TITLE
Auterion Skynode upload scripts

### DIFF
--- a/Tools/auterion/remote_update_fmu.sh
+++ b/Tools/auterion/remote_update_fmu.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Flash PX4 to a device running AuterionOS in the local network
+if [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ $# -lt 2 ]; then
+	echo "Usage: $0 -f <firmware.px4|.elf> [-c <configuration_dir>] -d <IP/Device> [-u <user>] [-p <ssh_port>]"
+	exit 1
+fi
+
+ssh_port=22
+ssh_user=root
+
+while getopts ":f:c:d:p:u:" opt; do
+	case ${opt} in
+		f )
+			if [ -n "$OPTARG" ]; then
+				firmware_file="$OPTARG"
+			else
+				echo "ERROR: -f requires a non-empty option argument."
+				exit 1
+			fi
+			;;
+		c )
+			if [ -f "$OPTARG/rc.autostart" ]; then
+				config_dir="$OPTARG"
+			else
+				echo "ERROR: -c configuration directory is empty or does not contain a valid rc.autostart"
+				exit 1
+			fi
+			;;
+		d )
+			if [ "$OPTARG" ]; then
+				device="$OPTARG"
+			else
+				echo "ERROR: -d requires a non-empty option argument."
+				exit 1
+			fi
+			;;
+		p )
+			if [[ "$OPTARG" =~ ^[0-9]+$ ]]; then
+				ssh_port="$OPTARG"
+			else
+				echo "ERROR: -p ssh_port must be a number."
+				exit 1
+			fi
+			;;
+		u )
+			if [ "$OPTARG" ]; then
+				ssh_user="$OPTARG"
+			else
+				echo "ERROR: -u requires a non-empty option argument."
+				exit 1
+			fi
+			;;
+	esac
+done
+
+target_dir=/shared_container_dir/fmu
+
+# create update-dev.tar
+target_file_name="update-dev.tar"
+tmp_dir="$(mktemp -d)"
+config_path=""
+firmware_path=""
+
+if [ -d "$config_dir" ]; then
+	cp -r "$config_dir" "$tmp_dir/config"
+	config_path=config
+fi
+
+if [ -f "$firmware_file" ]; then
+	extension="${firmware_file##*.}"
+	cp "$firmware_file" "$tmp_dir/firmware.$extension"
+	if [ "$extension" == "elf" ]; then
+		# ensure the file is stripped to reduce file size
+		arm-none-eabi-strip "$tmp_dir/firmware.$extension"
+	fi
+	firmware_path="firmware.$extension"
+fi
+
+if [ -z "$device" ]; then
+	echo "Error: missing device"
+	exit 1
+fi
+
+pushd "$tmp_dir" &>/dev/null
+
+if [ -z $firmware_path ] && [ -z $config_path ]; then
+	exit 1
+fi
+
+# check if gnu-tar is installed on macOS and use that instead
+tar_name="tar"
+if [ -x "$(command -v gtar)" ]; then
+	tar_name="gtar"
+fi
+$tar_name -C "$tmp_dir" --sort=name --owner=root:0 --group=root:0 --mtime='2019-01-01 00:00:00' -cvf $target_file_name $firmware_path $config_path
+scp -P $ssh_port "$target_file_name" $ssh_user@"$device":$target_dir
+popd &>/dev/null
+rm -rf "$tmp_dir"
+
+# grab status output
+cmd="tail --follow=name $target_dir/update_status 2>/dev/null || true"
+ssh -t -p $ssh_port $ssh_user@$device "$cmd"

--- a/Tools/auterion/remote_update_fmu.sh
+++ b/Tools/auterion/remote_update_fmu.sh
@@ -61,9 +61,12 @@ if [ -z "$device" ]; then
 	exit 1
 fi
 
+target_dir=/shared_container_dir/fmu
+target_file_name="update-dev.tar"
+
 if [ "$revert" == true ]; then
 	# revert to the release version which was originally deployed
-	cmd="cp /persistent/shared_container_dir/fmu/update.tar /persistent/shared_container_dir/fmu/update-dev.tar"
+	cmd="cp $target_dir/update.tar $target_dir/$target_file_name"
 	ssh -t -p $ssh_port $ssh_user@$device "$cmd"
 else
 	# create custom update-dev.tar
@@ -99,9 +102,6 @@ else
 		tar_name="gtar"
 	fi
 
-	target_dir=/shared_container_dir/fmu
-	target_file_name="update-dev.tar"
-
 	$tar_name -C "$tmp_dir" --sort=name --owner=root:0 --group=root:0 --mtime='2019-01-01 00:00:00' -cvf $target_file_name $firmware_path $config_path
 
 	# send it to the target to start flashing
@@ -110,6 +110,6 @@ else
 	rm -rf "$tmp_dir"
 fi
 
-# grab status output for flshing progress
+# grab status output for flashing progress
 cmd="tail --follow=name $target_dir/update_status 2>/dev/null || true"
 ssh -t -p $ssh_port $ssh_user@$device "$cmd"

--- a/Tools/auterion/remote_update_fmu.sh
+++ b/Tools/auterion/remote_update_fmu.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # Flash PX4 to a device running AuterionOS in the local network
 if [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ $# -lt 2 ]; then
-	echo "Usage: $0 -f <firmware.px4|.elf> [-c <configuration_dir>] -d <IP/Device> [-u <user>] [-p <ssh_port>]"
+	echo "Usage: $0 -f <firmware.px4|.elf> [-c <configuration_dir>] -d <IP/Device> [-u <user>] [-p <ssh_port>] [--revert]"
 	exit 1
 fi
 
 ssh_port=22
 ssh_user=root
 
-while getopts ":f:c:d:p:u:" opt; do
+while getopts ":f:c:d:p:u:r" opt; do
 	case ${opt} in
 		f )
 			if [ -n "$OPTARG" ]; then
@@ -50,53 +50,66 @@ while getopts ":f:c:d:p:u:" opt; do
 				exit 1
 			fi
 			;;
+		r )
+			revert=true
+			;;
 	esac
 done
-
-target_dir=/shared_container_dir/fmu
-
-# create update-dev.tar
-target_file_name="update-dev.tar"
-tmp_dir="$(mktemp -d)"
-config_path=""
-firmware_path=""
-
-if [ -d "$config_dir" ]; then
-	cp -r "$config_dir" "$tmp_dir/config"
-	config_path=config
-fi
-
-if [ -f "$firmware_file" ]; then
-	extension="${firmware_file##*.}"
-	cp "$firmware_file" "$tmp_dir/firmware.$extension"
-	if [ "$extension" == "elf" ]; then
-		# ensure the file is stripped to reduce file size
-		arm-none-eabi-strip "$tmp_dir/firmware.$extension"
-	fi
-	firmware_path="firmware.$extension"
-fi
 
 if [ -z "$device" ]; then
 	echo "Error: missing device"
 	exit 1
 fi
 
-pushd "$tmp_dir" &>/dev/null
+if [ "$revert" == true ]; then
+	# revert to the release version which was originally deployed
+	cmd="cp /persistent/shared_container_dir/fmu/update.tar /persistent/shared_container_dir/fmu/update-dev.tar"
+	ssh -t -p $ssh_port $ssh_user@$device "$cmd"
+else
+	# create custom update-dev.tar
+	tmp_dir="$(mktemp -d)"
+	config_path=""
+	firmware_path=""
 
-if [ -z $firmware_path ] && [ -z $config_path ]; then
-	exit 1
+	if [ -d "$config_dir" ]; then
+		cp -r "$config_dir" "$tmp_dir/config"
+		config_path=config
+	fi
+
+	if [ -f "$firmware_file" ]; then
+		extension="${firmware_file##*.}"
+		cp "$firmware_file" "$tmp_dir/firmware.$extension"
+		if [ "$extension" == "elf" ]; then
+			# ensure the file is stripped to reduce file size
+			arm-none-eabi-strip "$tmp_dir/firmware.$extension"
+		fi
+		firmware_path="firmware.$extension"
+	fi
+
+	pushd "$tmp_dir" &>/dev/null
+
+	if [ -z $firmware_path ] && [ -z $config_path ]; then
+		exit 1
+	fi
+
+	tar_name="tar"
+
+	if [ -x "$(command -v gtar)" ]; then
+		# check if gnu-tar is installed on macOS and use that instead
+		tar_name="gtar"
+	fi
+
+	target_dir=/shared_container_dir/fmu
+	target_file_name="update-dev.tar"
+
+	$tar_name -C "$tmp_dir" --sort=name --owner=root:0 --group=root:0 --mtime='2019-01-01 00:00:00' -cvf $target_file_name $firmware_path $config_path
+
+	# send it to the target to start flashing
+	scp -P $ssh_port "$target_file_name" $ssh_user@"$device":$target_dir
+	popd &>/dev/null
+	rm -rf "$tmp_dir"
 fi
 
-# check if gnu-tar is installed on macOS and use that instead
-tar_name="tar"
-if [ -x "$(command -v gtar)" ]; then
-	tar_name="gtar"
-fi
-$tar_name -C "$tmp_dir" --sort=name --owner=root:0 --group=root:0 --mtime='2019-01-01 00:00:00' -cvf $target_file_name $firmware_path $config_path
-scp -P $ssh_port "$target_file_name" $ssh_user@"$device":$target_dir
-popd &>/dev/null
-rm -rf "$tmp_dir"
-
-# grab status output
+# grab status output for flshing progress
 cmd="tail --follow=name $target_dir/update_status 2>/dev/null || true"
 ssh -t -p $ssh_port $ssh_user@$device "$cmd"

--- a/Tools/auterion/upload_skynode.sh
+++ b/Tools/auterion/upload_skynode.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+DIR="$(dirname $(readlink -f $0))"
+PX4_BINARY_FILE="$1"
+DEFAULT_AUTOPILOT_HOST=10.41.0.1
+DEFAULT_AUTOPILOT_PORT=33333
+DEFAULT_AUTOPILOT_USER=auterion
+
+for i in "$@"
+do
+    case $i in
+        --default-ip=*)
+        DEFAULT_AUTOPILOT_HOST="${i#*=}"
+        ;;
+        --default-port=*)
+        DEFAULT_AUTOPILOT_PORT="${i#*=}"
+        ;;
+        --default-user=*)
+        DEFAULT_AUTOPILOT_USER="${i#*=}"
+        ;;
+        *)
+            # unknown option
+        ;;
+    esac
+done
+
+# allow these to be overridden
+[ -z "$AUTOPILOT_HOST" ] && AUTOPILOT_HOST=$DEFAULT_AUTOPILOT_HOST
+[ -z "$AUTOPILOT_PORT" ] && AUTOPILOT_PORT=$DEFAULT_AUTOPILOT_PORT
+[ -z "$AUTOPILOT_USER" ] && AUTOPILOT_USER=$DEFAULT_AUTOPILOT_USER
+
+echo "Uploading to $AUTOPILOT_HOST..."
+
+"$DIR"/remote_update_fmu.sh -f "$PX4_BINARY_FILE" -d "$AUTOPILOT_HOST" -p $AUTOPILOT_PORT -u $AUTOPILOT_USER
+
+exit 0

--- a/Tools/auterion/upload_skynode.sh
+++ b/Tools/auterion/upload_skynode.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 DIR="$(dirname $(readlink -f $0))"
-PX4_BINARY_FILE="$1"
-DEFAULT_AUTOPILOT_HOST=10.41.0.1
+DEFAULT_AUTOPILOT_HOST=10.41.1.1
 DEFAULT_AUTOPILOT_PORT=33333
 DEFAULT_AUTOPILOT_USER=auterion
 
 for i in "$@"
 do
     case $i in
+        --file=*)
+        PX4_BINARY_FILE_ARGUMENT=" -f ${i#*=}"
+        ;;
         --default-ip=*)
         DEFAULT_AUTOPILOT_HOST="${i#*=}"
         ;;
@@ -17,6 +19,12 @@ do
         ;;
         --default-user=*)
         DEFAULT_AUTOPILOT_USER="${i#*=}"
+        ;;
+        --revert)
+        REVERT_AUTOPILOT_ARGUMENT=" -r"
+        ;;
+        --wifi)
+        DEFAULT_AUTOPILOT_HOST=10.41.0.1
         ;;
         *)
             # unknown option
@@ -29,8 +37,15 @@ done
 [ -z "$AUTOPILOT_PORT" ] && AUTOPILOT_PORT=$DEFAULT_AUTOPILOT_PORT
 [ -z "$AUTOPILOT_USER" ] && AUTOPILOT_USER=$DEFAULT_AUTOPILOT_USER
 
-echo "Uploading to $AUTOPILOT_HOST..."
+ARGUMENTS=""
+ARGUMENTS+=" -d $AUTOPILOT_HOST"
+ARGUMENTS+=" -p $AUTOPILOT_PORT"
+ARGUMENTS+=" -u $AUTOPILOT_USER"
+ARGUMENTS+=$PX4_BINARY_FILE_ARGUMENT
+ARGUMENTS+=$REVERT_AUTOPILOT_ARGUMENT
 
-"$DIR"/remote_update_fmu.sh -f "$PX4_BINARY_FILE" -d "$AUTOPILOT_HOST" -p $AUTOPILOT_PORT -u $AUTOPILOT_USER
+echo "Flashing $AUTOPILOT_HOST ..."
+
+"$DIR"/remote_update_fmu.sh $ARGUMENTS
 
 exit 0

--- a/Tools/auterion/upload_skynode.sh
+++ b/Tools/auterion/upload_skynode.sh
@@ -9,7 +9,7 @@ for i in "$@"
 do
     case $i in
         --file=*)
-        PX4_BINARY_FILE_ARGUMENT=" -f ${i#*=}"
+        PX4_BINARY_FILE="${i#*=}"
         ;;
         --default-ip=*)
         DEFAULT_AUTOPILOT_HOST="${i#*=}"
@@ -21,7 +21,7 @@ do
         DEFAULT_AUTOPILOT_USER="${i#*=}"
         ;;
         --revert)
-        REVERT_AUTOPILOT_ARGUMENT=" -r"
+        REVERT_AUTOPILOT_ARGUMENT=-r
         ;;
         --wifi)
         DEFAULT_AUTOPILOT_HOST=10.41.0.1
@@ -37,15 +37,15 @@ done
 [ -z "$AUTOPILOT_PORT" ] && AUTOPILOT_PORT=$DEFAULT_AUTOPILOT_PORT
 [ -z "$AUTOPILOT_USER" ] && AUTOPILOT_USER=$DEFAULT_AUTOPILOT_USER
 
-ARGUMENTS=""
-ARGUMENTS+=" -d $AUTOPILOT_HOST"
-ARGUMENTS+=" -p $AUTOPILOT_PORT"
-ARGUMENTS+=" -u $AUTOPILOT_USER"
-ARGUMENTS+=$PX4_BINARY_FILE_ARGUMENT
-ARGUMENTS+=$REVERT_AUTOPILOT_ARGUMENT
+ARGUMENTS=()
+ARGUMENTS+=(-d "$AUTOPILOT_HOST")
+ARGUMENTS+=(-p "$AUTOPILOT_PORT")
+ARGUMENTS+=(-u "$AUTOPILOT_USER")
+ARGUMENTS+=(${PX4_BINARY_FILE:+-f "$PX4_BINARY_FILE"})
+ARGUMENTS+=($REVERT_AUTOPILOT_ARGUMENT)
 
 echo "Flashing $AUTOPILOT_HOST ..."
 
-"$DIR"/remote_update_fmu.sh $ARGUMENTS
+"$DIR"/remote_update_fmu.sh "${ARGUMENTS[@]}"
 
 exit 0

--- a/boards/px4/fmu-v5x/cmake/upload.cmake
+++ b/boards/px4/fmu-v5x/cmake/upload.cmake
@@ -1,0 +1,49 @@
+############################################################################
+#
+#   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+
+set(PX4_FW_NAME ${PX4_BINARY_DIR}/${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_${PX4_BOARD_LABEL}.px4)
+
+add_custom_target(upload_skynode_usb
+	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh ${PX4_FW_NAME} --default-ip=10.41.1.1
+	DEPENDS ${PX4_FW_NAME}
+	COMMENT "Uploading PX4"
+	USES_TERMINAL
+)
+
+add_custom_target(upload_skynode_wifi
+	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh ${PX4_FW_NAME}
+	DEPENDS ${PX4_FW_NAME}
+	COMMENT "Uploading PX4"
+	USES_TERMINAL
+)

--- a/boards/px4/fmu-v5x/cmake/upload.cmake
+++ b/boards/px4/fmu-v5x/cmake/upload.cmake
@@ -35,14 +35,14 @@
 set(PX4_FW_NAME ${PX4_BINARY_DIR}/${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_${PX4_BOARD_LABEL}.px4)
 
 add_custom_target(upload_skynode_usb
-	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh ${PX4_FW_NAME} --default-ip=10.41.1.1
+	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh --file=${PX4_FW_NAME}
 	DEPENDS ${PX4_FW_NAME}
 	COMMENT "Uploading PX4"
 	USES_TERMINAL
 )
 
 add_custom_target(upload_skynode_wifi
-	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh ${PX4_FW_NAME}
+	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh --file=${PX4_FW_NAME} --wifi
 	DEPENDS ${PX4_FW_NAME}
 	COMMENT "Uploading PX4"
 	USES_TERMINAL

--- a/boards/px4/fmu-v6x/cmake/upload.cmake
+++ b/boards/px4/fmu-v6x/cmake/upload.cmake
@@ -1,0 +1,49 @@
+############################################################################
+#
+#   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+
+set(PX4_FW_NAME ${PX4_BINARY_DIR}/${PX4_BOARD_VENDOR}_${PX4_BOARD_MODEL}_${PX4_BOARD_LABEL}.px4)
+
+add_custom_target(upload_skynode_usb
+	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh --file=${PX4_FW_NAME}
+	DEPENDS ${PX4_FW_NAME}
+	COMMENT "Uploading PX4"
+	USES_TERMINAL
+)
+
+add_custom_target(upload_skynode_wifi
+	COMMAND ${PX4_SOURCE_DIR}/Tools/auterion/upload_skynode.sh --file=${PX4_FW_NAME} --wifi
+	DEPENDS ${PX4_FW_NAME}
+	COMMENT "Uploading PX4"
+	USES_TERMINAL
+)


### PR DESCRIPTION
### Solved Problem
When building firmware for Auterion Skynode with `make px4_fmu-v5x` there is no upload script to directly flash it but the user has to manually flash the binary.

### Solution
- Add scripts to simplify flashing Skynode over either USB or Wifi.

### Changelog Entry
```
Tools: Skynode flash scripts
Documentation: Still needs to be added to the documentation
```

### Alternatives
Instead of `make px4_fmu-v5x upload_usb` it could be either a more specific upload target `make px4_fmu-v5x upload_skynode_usb` or a completely different build target `make auterion_skynode upload`. I'd need to check how the latter can be achieved without duplicating anything from the v5x target.

### Test coverage
- I did not test this pr but am using the same exact rebased scripts a lot. I can quickly double-check.

### Context
See example output in https://github.com/PX4/PX4-Autopilot/pull/21842#issuecomment-1634477701
