### PR TITLE
ekf2-gnss-yaw: require "RTK fixed" fix type

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -193,6 +193,7 @@ struct gpsSample {
 	float       vacc{};     ///< 1-std vertical position error (m)
 	float       sacc{};     ///< 1-std speed error (m/sec)
 	float       yaw_acc{};  ///< 1-std yaw error (rad)
+	uint8_t     fix_type{}; ///< 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time Kinematic
 };
 
 struct magSample {

--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -178,6 +178,8 @@ void EstimatorInterface::setGpsData(const gpsMessage &gps)
 
 		gps_sample_new.hgt = (float)gps.alt * 1e-3f;
 
+		gps_sample_new.fix_type = gps.fix_type;
+
 #if defined(CONFIG_EKF2_GNSS_YAW)
 
 		if (PX4_ISFINITE(gps.yaw)) {

--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -328,7 +328,8 @@ void Ekf::controlGpsYawFusion(const gpsSample &gps_sample, bool gps_checks_passi
 
 	if (is_new_data_available) {
 
-		const bool continuing_conditions_passing = !gps_checks_failing;
+		const bool continuing_conditions_passing = !gps_checks_failing
+				&& gps_sample.fix_type >= 6; // RTK "fixed" is required for accurate heading
 
 		const bool is_gps_yaw_data_intermittent = !isNewestSampleRecent(_time_last_gps_yaw_buffer_push,
 				2 * GNSS_YAW_MAX_INTERVAL);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
GNSS yaw data is really poor when the receiver is in "float" mode as the receiver is still converging.

We can see in the plot below that the vehicle isn't moving (integral of raw gyro is almost constant) and that the GNSS heading is moving while `fix_type < fixed`
![gnss_yaw_fix_type](https://github.com/PX4/PX4-Autopilot/assets/14822839/6f8abdc9-b2fd-4ec0-a103-8dd01d2e1036)



### Solution
Only use GNSS yaw data after convergence, when the receiver switches to "fix" mode.

### Test coverage
added unit test
