### PR TITLE
advertise esc_status uorb message where it publishes

### DIFF
--- a/src/drivers/actuators/modal_io/modal_io.cpp
+++ b/src/drivers/actuators/modal_io/modal_io.cpp
@@ -75,6 +75,8 @@ ModalIo::ModalIo() :
 		_esc_status.esc[i].esc_power       = 0;
 	}
 
+	_esc_status_pub.advertise();
+
 	qc_esc_packet_init(&_fb_packet);
 	qc_esc_packet_init(&_uart_bridge_packet);
 

--- a/src/drivers/tap_esc/TAP_ESC.cpp
+++ b/src/drivers/tap_esc/TAP_ESC.cpp
@@ -65,6 +65,8 @@ int TAP_ESC::init()
 		return ret;
 	}
 
+	_esc_feedback_pub.advertise();
+
 	/* Respect boot time required by the ESC FW */
 	hrt_abstime uptime_us = hrt_absolute_time();
 

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -64,6 +64,8 @@ UavcanEscController::init()
 		return res;
 	}
 
+	_esc_status_pub.advertise();
+
 	return res;
 }
 

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.cpp
@@ -53,6 +53,8 @@ bool GZMixingInterfaceESC::init(const std::string &model_name)
 		return false;
 	}
 
+	_esc_status_pub.advertise();
+
 	ScheduleNow();
 
 	return true;

--- a/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
+++ b/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp
@@ -96,6 +96,8 @@ SimulatorMavlink::SimulatorMavlink() :
 		snprintf(param_name, sizeof(param_name), "%s_%s%d", "PWM_MAIN", "FUNC", i + 1);
 		param_get(param_find(param_name), &_output_functions[i]);
 	}
+
+	_esc_status_pub.advertise();
 }
 
 void SimulatorMavlink::parameters_update(bool force)


### PR DESCRIPTION
- esc_status is an optional logging topic resulting in it not being logged if it doesn't get advertise -> Add advertise where applicable.
- Main application was to get feedback from dronecan esc, but added it to other instances, 