### PR TITLE
Add mag inclination check

### DIFF
--- a/msg/EstimatorStatus.msg
+++ b/msg/EstimatorStatus.msg
@@ -127,3 +127,8 @@ uint32 mag_device_id
 # legacy local position estimator (LPE) flags
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)
+
+float32 mag_inclination_deg
+float32 mag_inclination_ref_deg
+float32 mag_strength_gs
+float32 mag_strength_ref_gs

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -494,6 +494,7 @@ struct parameters {
 	int32_t synthesize_mag_z{0};
 	int32_t mag_check{0};
 	float mag_check_strength_tolerance_gs{0.2f};
+	float mag_check_inclination_tolerance_deg{20.f};
 
 	// Parameters used to control when yaw is reset to the EKF-GSF yaw estimator value
 	float EKFGSF_tas_default{15.0f};                ///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -155,6 +155,12 @@ enum class EvCtrl : uint8_t {
 	YAW  = (1<<3)
 };
 
+enum class MagCheckMask : uint8_t {
+	STRENGTH    = (1 << 0),
+	INCLINATION = (1 << 1),
+	FORCE_WMM   = (1 << 2)
+};
+
 struct gpsMessage {
 	uint64_t    time_usec{};
 	int32_t     lat{};              ///< Latitude in 1E-7 degrees
@@ -486,7 +492,8 @@ struct parameters {
 
 	// compute synthetic magnetomter Z value if possible
 	int32_t synthesize_mag_z{0};
-	int32_t check_mag_strength{0};
+	int32_t mag_check{0};
+	float mag_check_strength_tolerance_gs{0.2f};
 
 	// Parameters used to control when yaw is reset to the EKF-GSF yaw estimator value
 	float EKFGSF_tas_default{15.0f};                ///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -585,6 +585,7 @@ private:
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
+	uint32_t _min_mag_health_time_us{1'000'000}; ///< magnetometer is marked as healthy only after this amount of time
 
 	SquareMatrix24f P{};	///< state covariance matrix
 
@@ -707,6 +708,7 @@ private:
 	// Variables used to control activation of post takeoff functionality
 	uint64_t _flt_mag_align_start_time{0};	///< time that inflight magnetic field alignment started (uSec)
 	uint64_t _time_last_mov_3d_mag_suitable{0};	///< last system time that sufficient movement to use 3-axis magnetometer fusion was detected (uSec)
+	uint64_t _time_last_mag_check_failing{0};
 	Vector3f _saved_mag_bf_variance {}; ///< magnetic field state variances that have been saved for use at the next initialisation (Gauss**2)
 	Matrix2f _saved_mag_ef_ne_covmat{}; ///< NE magnetic field state covariance sub-matrix saved for use at the next initialisation (Gauss**2)
 	float _saved_mag_ef_d_variance{};   ///< D magnetic field state variance saved for use at the next initialisation (Gauss**2)
@@ -1035,7 +1037,7 @@ private:
 
 	void checkMagDeclRequired();
 	bool shouldInhibitMag() const;
-	bool magFieldStrengthDisturbed(const Vector3f &mag) const;
+	bool checkMagField(const Vector3f &mag);
 	static bool isMeasuredMatchingExpected(float measured, float expected, float gate);
 	void runMagAndMagDeclFusions(const Vector3f &mag);
 	void run3DMagAndDeclFusions(const Vector3f &mag);

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -227,6 +227,14 @@ public:
 		}
 	}
 
+	void get_mag_checks(float &inc_deg, float &inc_ref_deg, float &strength_gs, float &strength_ref_gs) const
+	{
+		inc_deg = math::degrees(_mag_inclination);
+		inc_ref_deg = math::degrees(_mag_inclination_gps);
+		strength_gs = _mag_strength;
+		strength_ref_gs = _mag_strength_gps;
+	}
+
 	// get EKF mode status
 	const filter_control_status_u &control_status() const { return _control_status; }
 	const decltype(filter_control_status_u::flags) &control_status_flags() const { return _control_status.flags; }
@@ -405,6 +413,8 @@ protected:
 	float _mag_declination_gps{NAN};         // magnetic declination returned by the geo library using the last valid GPS position (rad)
 	float _mag_inclination_gps{NAN};	  // magnetic inclination returned by the geo library using the last valid GPS position (rad)
 	float _mag_strength_gps{NAN};	          // magnetic strength returned by the geo library using the last valid GPS position (T)
+	float _mag_inclination{NAN};
+	float _mag_strength{NAN};
 
 	// this is the current status of the filter control modes
 	filter_control_status_u _control_status{};

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -216,10 +216,10 @@ public:
 	// Get the value of magnetic declination in degrees to be saved for use at the next startup
 	// Returns true when the declination can be saved
 	// At the next startup, set param.mag_declination_deg to the value saved
-	bool get_mag_decl_deg(float *val) const
+	bool get_mag_decl_deg(float &val) const
 	{
 		if (_NED_origin_initialised && (_params.mag_declination_source & GeoDeclinationMask::SAVE_GEO_DECL)) {
-			*val = math::degrees(_mag_declination_gps);
+			val = math::degrees(_mag_declination_gps);
 			return true;
 
 		} else {

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -227,6 +227,17 @@ public:
 		}
 	}
 
+	bool get_mag_inc_deg(float &val) const
+	{
+		if (_NED_origin_initialised) {
+			val = math::degrees(_mag_inclination_gps);
+			return true;
+
+		} else {
+			return false;
+		}
+	}
+
 	void get_mag_checks(float &inc_deg, float &inc_ref_deg, float &strength_gs, float &strength_ref_gs) const
 	{
 		inc_deg = math::degrees(_mag_inclination);

--- a/src/modules/ekf2/EKF/mag_control.cpp
+++ b/src/modules/ekf2/EKF/mag_control.cpp
@@ -472,7 +472,7 @@ bool Ekf::checkMagField(const Vector3f &mag_sample)
 	}
 
 	const Vector3f mag_earth = _R_to_earth * mag_sample;
-	_mag_inclination = asin(mag_earth(2) / fmaxf(mag_earth.norm(), 1e-4f));
+	_mag_inclination = asinf(mag_earth(2) / fmaxf(mag_earth.norm(), 1e-4f));
 
 	if (_params.mag_check & static_cast<int32_t>(MagCheckMask::INCLINATION)) {
 		if (PX4_ISFINITE(_mag_inclination_gps)) {

--- a/src/modules/ekf2/EKF/mag_control.cpp
+++ b/src/modules/ekf2/EKF/mag_control.cpp
@@ -448,11 +448,11 @@ bool Ekf::checkMagField(const Vector3f &mag_sample)
 	}
 
 	bool is_check_failing = false;
-	const float mag_strength = mag_sample.length();
+	_mag_strength = mag_sample.length();
 
 	if (_params.mag_check & static_cast<int32_t>(MagCheckMask::STRENGTH)) {
 		if (PX4_ISFINITE(_mag_strength_gps)) {
-			if (!isMeasuredMatchingExpected(mag_strength, _mag_strength_gps, _params.mag_check_strength_tolerance_gs)) {
+			if (!isMeasuredMatchingExpected(_mag_strength, _mag_strength_gps, _params.mag_check_strength_tolerance_gs)) {
 				_control_status.flags.mag_field_disturbed = true;
 				is_check_failing = true;
 			}
@@ -472,12 +472,12 @@ bool Ekf::checkMagField(const Vector3f &mag_sample)
 	}
 
 	const Vector3f mag_earth = _R_to_earth * mag_sample;
-	const float mag_inclination = asin(mag_earth(2) / fmaxf(mag_earth.norm(), 1e-4f));
+	_mag_inclination = asin(mag_earth(2) / fmaxf(mag_earth.norm(), 1e-4f));
 
 	if (_params.mag_check & static_cast<int32_t>(MagCheckMask::INCLINATION)) {
 		if (PX4_ISFINITE(_mag_inclination_gps)) {
 			const float inc_tol_rad = radians(_params.mag_check_inclination_tolerance_deg);
-			const float inc_error_rad = wrap_pi(mag_inclination - _mag_inclination_gps);
+			const float inc_error_rad = wrap_pi(_mag_inclination - _mag_inclination_gps);
 
 			if (fabsf(inc_error_rad) > inc_tol_rad) {
 				_control_status.flags.mag_field_disturbed = true;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -191,6 +191,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 #endif // CONFIG_EKF2_BARO_COMPENSATION
 	_param_ekf2_mag_check(_params->mag_check),
 	_param_ekf2_mag_chk_str(_params->mag_check_strength_tolerance_gs),
+	_param_ekf2_mag_chk_inc(_params->mag_check_inclination_tolerance_deg),
 	_param_ekf2_synthetic_mag_z(_params->synthesize_mag_z),
 	_param_ekf2_gsf_tas_default(_params->EKFGSF_tas_default)
 {
@@ -2532,7 +2533,7 @@ void EKF2::UpdateMagCalibration(const hrt_abstime &timestamp)
 	if (!_mag_decl_saved) {
 		float declination_deg;
 
-		if (_ekf.get_mag_decl_deg(&declination_deg)) {
+		if (_ekf.get_mag_decl_deg(declination_deg)) {
 			_param_ekf2_mag_decl.update();
 
 			if (PX4_ISFINITE(declination_deg) && (fabsf(declination_deg - _param_ekf2_mag_decl.get()) > 0.1f)) {

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1665,6 +1665,9 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 	status.gyro_device_id = _device_id_gyro;
 	status.mag_device_id = _device_id_mag;
 
+	_ekf.get_mag_checks(status.mag_inclination_deg, status.mag_inclination_ref_deg, status.mag_strength_gs,
+			    status.mag_strength_ref_gs);
+
 	status.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 	_estimator_status_pub.publish(status);
 }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -189,7 +189,8 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_pcoef_yn(_params->static_pressure_coef_yn),
 	_param_ekf2_pcoef_z(_params->static_pressure_coef_z),
 #endif // CONFIG_EKF2_BARO_COMPENSATION
-	_param_ekf2_mag_check(_params->check_mag_strength),
+	_param_ekf2_mag_check(_params->mag_check),
+	_param_ekf2_mag_chk_str(_params->mag_check_strength_tolerance_gs),
 	_param_ekf2_synthetic_mag_z(_params->synthesize_mag_z),
 	_param_ekf2_gsf_tas_default(_params->EKFGSF_tas_default)
 {

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -738,6 +738,7 @@ private:
 		(ParamFloat<px4::params::EKF2_REQ_GPS_H>) _param_ekf2_req_gps_h, ///< Required GPS health time
 		(ParamExtInt<px4::params::EKF2_MAG_CHECK>) _param_ekf2_mag_check, ///< Mag field strength check
 		(ParamExtFloat<px4::params::EKF2_MAG_CHK_STR>) _param_ekf2_mag_chk_str,
+		(ParamExtFloat<px4::params::EKF2_MAG_CHK_INC>) _param_ekf2_mag_chk_inc,
 		(ParamExtInt<px4::params::EKF2_SYNT_MAG_Z>)
 		_param_ekf2_synthetic_mag_z, ///< Enables the use of a synthetic value for the Z axis of the magnetometer calculated from the 3D magnetic field vector at the location of the drone.
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -737,6 +737,7 @@ private:
 
 		(ParamFloat<px4::params::EKF2_REQ_GPS_H>) _param_ekf2_req_gps_h, ///< Required GPS health time
 		(ParamExtInt<px4::params::EKF2_MAG_CHECK>) _param_ekf2_mag_check, ///< Mag field strength check
+		(ParamExtFloat<px4::params::EKF2_MAG_CHK_STR>) _param_ekf2_mag_chk_str,
 		(ParamExtInt<px4::params::EKF2_SYNT_MAG_Z>)
 		_param_ekf2_synthetic_mag_z, ///< Enables the use of a synthetic value for the Z axis of the magnetometer calculated from the 3D magnetic field vector at the location of the drone.
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1510,7 +1510,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_GPS_H, 10.0f);
  *
  * Set bits to 1 to enable checks. Checks enabled by the following bit positions
  * 0 : Magnetic field strength. Set tolerance using EKF2_MAG_CHK_STR
- * 1 : Reserved
+ * 1 : Magnetic field inclination. Set tolerance using EKF2_MAG_CHK_INC
  * 2 : Wait for GNSS to find the theoretical strength and inclination using the WMM
  *
  * @group EKF2
@@ -1518,7 +1518,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_GPS_H, 10.0f);
  * @min 0
  * @max 7
  * @bit 0 Strength (EKF2_MAG_CHK_STR)
- * @bit 1 Reserved
+ * @bit 1 Inclination (EKF2_MAG_CHK_INC)
  * @bit 2 Wait for WMM
  */
 PARAM_DEFINE_INT32(EKF2_MAG_CHECK, 1);
@@ -1535,6 +1535,19 @@ PARAM_DEFINE_INT32(EKF2_MAG_CHECK, 1);
  * @decimal 2
  */
 PARAM_DEFINE_FLOAT(EKF2_MAG_CHK_STR, 0.2f);
+
+/**
+ * Magnetic field inclination check tolerance
+ *
+ * Maximum allowed deviation from the expected magnetic field inclination to pass the check.
+ *
+ * @group EKF2
+ * @min 0.0
+ * @max 90.0
+ * @unit deg
+ * @decimal 1
+ */
+PARAM_DEFINE_FLOAT(EKF2_MAG_CHK_INC, 20.f);
 
 /**
  * Enable synthetic magnetometer Z component measurement.

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1502,16 +1502,39 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_GPS_H, 10.0f);
 /**
  * Magnetic field strength test selection
  *
- * When set, the EKF checks the strength of the magnetic field
- * to decide whether the magnetometer data is valid.
- * If GPS data is received, the magnetic field is compared to a World
+ * Bitmask to set which check is used to decide whether the magnetometer data is valid.
+ *
+ * If GNSS data is received, the magnetic field is compared to a World
  * Magnetic Model (WMM), otherwise an average value is used.
  * This check is useful to reject occasional hard iron disturbance.
  *
+ * Set bits to 1 to enable checks. Checks enabled by the following bit positions
+ * 0 : Magnetic field strength. Set tolerance using EKF2_MAG_CHK_STR
+ * 1 : Reserved
+ * 2 : Wait for GNSS to find the theoretical strength and inclination using the WMM
+ *
  * @group EKF2
  * @boolean
+ * @min 0
+ * @max 7
+ * @bit 0 Strength (EKF2_MAG_CHK_STR)
+ * @bit 1 Reserved
+ * @bit 2 Wait for WMM
  */
 PARAM_DEFINE_INT32(EKF2_MAG_CHECK, 1);
+
+/**
+ * Magnetic field strength check tolerance
+ *
+ * Maximum allowed deviation from the expected magnetic field strength to pass the check.
+ *
+ * @group EKF2
+ * @min 0.0
+ * @max 1.0
+ * @unit gauss
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_MAG_CHK_STR, 0.2f);
 
 /**
  * Enable synthetic magnetometer Z component measurement.

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -212,7 +212,8 @@ void EkfWrapper::setMagFuseTypeNone()
 
 void EkfWrapper::enableMagStrengthCheck()
 {
-	_ekf_params->check_mag_strength = 1;
+	_ekf_params->mag_check |= static_cast<int32_t>(MagCheckMask::STRENGTH);
+}
 }
 
 bool EkfWrapper::isWindVelocityEstimated() const

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -214,6 +214,15 @@ void EkfWrapper::enableMagStrengthCheck()
 {
 	_ekf_params->mag_check |= static_cast<int32_t>(MagCheckMask::STRENGTH);
 }
+
+void EkfWrapper::enableMagInclinationCheck()
+{
+	_ekf_params->mag_check |= static_cast<int32_t>(MagCheckMask::INCLINATION);
+}
+
+void EkfWrapper::enableMagCheckForceWMM()
+{
+	_ekf_params->mag_check |= static_cast<int32_t>(MagCheckMask::FORCE_WMM);
 }
 
 bool EkfWrapper::isWindVelocityEstimated() const

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -102,6 +102,8 @@ public:
 	bool isIntendingMag3DFusion() const;
 	void setMagFuseTypeNone();
 	void enableMagStrengthCheck();
+	void enableMagInclinationCheck();
+	void enableMagCheckForceWMM();
 
 	bool isWindVelocityEstimated() const;
 

--- a/src/modules/ekf2/test/test_EKF_mag.cpp
+++ b/src/modules/ekf2/test/test_EKF_mag.cpp
@@ -95,7 +95,7 @@ TEST_F(EkfMagTest, fusionStartWithReset)
 	Vector3f mag_earth = _ekf->getMagEarthField();
 	float mag_decl = atan2f(mag_earth(1), mag_earth(0));
 	float mag_decl_wmm_deg = 0.f;
-	_ekf->get_mag_decl_deg(&mag_decl_wmm_deg);
+	_ekf->get_mag_decl_deg(mag_decl_wmm_deg);
 	EXPECT_NEAR(degrees(mag_decl), mag_decl_wmm_deg, 1e-6f);
 }
 
@@ -134,6 +134,73 @@ TEST_F(EkfMagTest, suddenLargeStrength)
 
 	// BUT WHEN: the mag field norm is suddenly too large
 	mag_data *= 5.f;
+	_sensor_simulator._mag.setData(mag_data);
+	_sensor_simulator.runSeconds(6.f);
+
+	// THEN: the mag fusion should stop after some time
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+}
+
+TEST_F(EkfMagTest, noInitLargeInclination)
+{
+	// GIVEN: a really large magnetic field
+	_ekf_wrapper.enableMagInclinationCheck();
+	// To prevent an early pass of the inclination check, "force WMM" must be set
+	_ekf_wrapper.enableMagCheckForceWMM();
+	_sensor_simulator.startGps();
+	Vector3f mag_data(0.4f, 0.f, 0.f);
+	_sensor_simulator._mag.setData(mag_data);
+
+	const int initial_quat_reset_counter = _ekf_wrapper.getQuaternionResetCounter();
+	_sensor_simulator.runSeconds(_init_duration_s + 10.f); // live some extra time fo GNSS checks to pass
+
+	// THEN: the fusion shouldn't start
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+	EXPECT_EQ(0, (int) _ekf->control_status_flags().yaw_align);
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter);
+
+	// BUT then: as soon as there is some meaningful data
+	const float mag_heading = -M_PI_F / 7.f;
+	mag_data = Vector3f(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f);
+	_sensor_simulator._mag.setData(mag_data);
+
+	_sensor_simulator.runSeconds(2.f);
+
+	float decl_deg = 0.f;
+	_ekf->get_mag_decl_deg(decl_deg);
+
+	// THEN: the fusion initializes using the mag data and runs normally
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), mag_heading + radians(decl_deg), radians(1.f));
+	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_EQ(1, (int) _ekf->control_status_flags().yaw_align);
+	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
+}
+
+TEST_F(EkfMagTest, suddenInclinationChange)
+{
+	_ekf_wrapper.enableMagInclinationCheck();
+	_ekf_wrapper.enableMagCheckForceWMM();
+	_sensor_simulator.startGps();
+
+	// GIVEN: some meaningful mag data
+	const float mag_heading = -M_PI_F / 7.f;
+	Vector3f mag_data(0.2f * cosf(mag_heading), -0.2f * sinf(mag_heading), 0.4f);
+	_sensor_simulator._mag.setData(mag_data);
+
+	_sensor_simulator.runSeconds(_init_duration_s + 10.f);
+
+	float decl_deg = 0.f;
+	_ekf->get_mag_decl_deg(decl_deg);
+
+	// THEN: the fusion initializes using the mag data and runs normally
+	EXPECT_NEAR(_ekf_wrapper.getYawAngle(), mag_heading + radians(decl_deg), radians(1.f));
+	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingMag3DFusion());
+
+	// BUT WHEN: the mag field inclination suddenly changes
+	mag_data(2) = -mag_data(2);
 	_sensor_simulator._mag.setData(mag_data);
 	_sensor_simulator.runSeconds(6.f);
 

--- a/src/modules/ekf2/test/test_EKF_mag.cpp
+++ b/src/modules/ekf2/test/test_EKF_mag.cpp
@@ -97,6 +97,11 @@ TEST_F(EkfMagTest, fusionStartWithReset)
 	float mag_decl_wmm_deg = 0.f;
 	_ekf->get_mag_decl_deg(mag_decl_wmm_deg);
 	EXPECT_NEAR(degrees(mag_decl), mag_decl_wmm_deg, 1e-6f);
+
+	float mag_incl = asinf(mag_earth(2) / fmaxf(mag_earth.norm(), 1e-4f));
+	float mag_incl_wmm_deg = 0.f;
+	_ekf->get_mag_inc_deg(mag_incl_wmm_deg);
+	EXPECT_NEAR(degrees(mag_incl), mag_incl_wmm_deg, 1e-6f);
 }
 
 TEST_F(EkfMagTest, noInitLargeStrength)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->
requires (implemented on top of) #21305 

### Solved Problem
A mag sample can be incorrect but have the expected strength but it's quite unlikely to have the correct inclination too.

### Solution
Adding a check for the inclination makes a bad sample less likely to be accepted.

Additionally:
- refactor the mag strength check
- add an option to force the ekf to wait for the World Magnetic Model before accepting mag samples (this makes sure we have the correct strength and inclination references)
- parameterize the strength and inclination tolerances
- log the expected and measured mag strength and references

### Changelog Entry
For release notes:
```
Add mag inclination check
New parameter: `EKF2_MAG_CHK_STR`, `EKF2_MAG_CHK_INC`. Modified `EKF2_MAG_CHECK` (was boolean, now bitmask)
Documentation: Need to add doc to mention those options
```

### Test coverage
- Unit tests
- SITL tests

![mag_str_and_incl](https://github.com/PX4/PX4-Autopilot/assets/14822839/b54aa952-be58-4fd2-8ab0-6ff5e5015636)
