### PR TITLE
FlightModeManager: avoid internal flight task running concurrently with external mode

### DIFF
--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -137,7 +137,9 @@ void FlightModeManager::updateParams()
 void FlightModeManager::start_flight_task()
 {
 	// Do not run any flight task for VTOLs in fixed-wing mode
-	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+	if ((_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING)
+	    || ((_vehicle_status_sub.get().nav_state >= vehicle_status_s::NAVIGATION_STATE_EXTERNAL1)
+		&& (_vehicle_status_sub.get().nav_state <= vehicle_status_s::NAVIGATION_STATE_EXTERNAL8))) {
 		switchTask(FlightTaskIndex::None);
 		return;
 	}


### PR DESCRIPTION
### Solved Problem
Concurrent internal task sending setpoint at the same time as external mode when testing https://github.com/PX4/PX4-Autopilot/pull/20707:
<img src="https://github.com/PX4/PX4-Autopilot/assets/4668506/db0a5af0-4eca-4a5b-926e-0bed855d75cd" width="300">

### Solution
- Add exclusion for external modes when starting internal flight tasks.

### Alternatives
A direct mapping from the navigation state to flight task would be even more desired. I should look into this.

### Test coverage
This was reported to fix the issue as expected.