### PR TITLE
MC autotune: change signal input to sine sweep

### DIFF
--- a/src/lib/system_identification/arx_rls.hpp
+++ b/src/lib/system_identification/arx_rls.hpp
@@ -84,13 +84,13 @@ public:
 	float getInnovation() const { return _innovation; }
 	const matrix::Vector < float, N + M + 1 > &getDiffEstimate() const { return _diff_theta_hat; }
 
-	void reset(const matrix::Vector < float, N + M + 1 > &theta_init = {})
+	void reset(const matrix::Vector < float, N + M + 1 > &theta_init = {}, const float var_init = 100.f)
 	{
 		/* _P.uncorrelateCovarianceSetVariance<N + M + 1>(0, 10e3f); // does not work */
 		_P.setZero();
 
 		for (size_t i = 0; i < (N + M + 1); i++) {
-			_P(i, i) = 10.f;
+			_P(i, i) = var_init;
 		}
 
 		_diff_theta_hat.setZero();

--- a/src/lib/system_identification/signal_generator.hpp
+++ b/src/lib/system_identification/signal_generator.hpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file signal_generator.hpp
+ */
+
+#pragma once
+
+namespace signal_generator
+{
+
+float getLinearSineSweep(float f_start, float f_end, float duration, float t)
+{
+	if (t > duration) {
+		return 0.f;
+	}
+
+	const float w_start = f_start * M_TWOPI_F;
+	const float w_end = f_end * M_TWOPI_F;
+
+	return sinf(w_start * t + 0.5f * (w_end - w_start) * t * t / duration);
+}
+
+float getLogSineSweep(float f_start, float f_end, float duration, float t)
+{
+	if (t > duration) {
+		return 0.f;
+
+	}
+
+	float w_start = f_start * M_TWOPI_F;
+	float w_end = f_end * M_TWOPI_F;
+
+	if (f_start > f_end) {
+		// Handle high-to-low sweep correctly
+		w_start = f_end * M_TWOPI_F;
+		w_end = f_start * M_TWOPI_F;
+		t = duration - t;
+	}
+
+	return sinf(t * powf(10.f, log10f(w_start) + (log10f(w_end) - log10f(w_start)) * t / duration));
+}
+
+} /* namespace signal_generator */

--- a/src/lib/system_identification/system_identification.cpp
+++ b/src/lib/system_identification/system_identification.cpp
@@ -79,8 +79,8 @@ void SystemIdentification::updateFilters(float u, float y)
 
 	const float u_lpf = _u_lpf.apply(u);
 	const float y_lpf = _y_lpf.apply(y);
-	_u_hpf = _alpha_hpf * _u_hpf + _alpha_hpf * (u_lpf - _u_prev);
-	_y_hpf = _alpha_hpf * _y_hpf + _alpha_hpf * (y_lpf - _y_prev);
+	_u_hpf = u_lpf - _u_prev - (_gamma_hpf - 1.f) * _u_hpf;
+	_y_hpf = y_lpf - _y_prev - (_gamma_hpf - 1.f) * _y_hpf;
 
 	_u_prev = u_lpf;
 	_y_prev = y_lpf;

--- a/src/lib/system_identification/system_identification.cpp
+++ b/src/lib/system_identification/system_identification.cpp
@@ -39,9 +39,9 @@
 
 #include "system_identification.hpp"
 
-void SystemIdentification::reset(const matrix::Vector<float, _kParameters> &id_state_init)
+void SystemIdentification::reset(const matrix::Vector<float, _kParameters> &id_state_init, const float var_init)
 {
-	_rls.reset(id_state_init);
+	_rls.reset(id_state_init, var_init);
 	_u_lpf.reset(0.f);
 	_u_lpf.reset(0.f);
 	_u_hpf = 0.f;

--- a/src/lib/system_identification/system_identification.cpp
+++ b/src/lib/system_identification/system_identification.cpp
@@ -39,7 +39,7 @@
 
 #include "system_identification.hpp"
 
-void SystemIdentification::reset(const matrix::Vector<float, 5> &id_state_init)
+void SystemIdentification::reset(const matrix::Vector<float, _kParameters> &id_state_init)
 {
 	_rls.reset(id_state_init);
 	_u_lpf.reset(0.f);
@@ -88,10 +88,10 @@ void SystemIdentification::updateFilters(float u, float y)
 
 void SystemIdentification::updateFitness()
 {
-	const matrix::Vector<float, 5> &diff = _rls.getDiffEstimate();
+	const matrix::Vector<float, _kParameters> &diff = _rls.getDiffEstimate();
 	float sum = 0.f;
 
-	for (size_t i = 0; i < 5; i++) {
+	for (size_t i = 0; i < _kParameters; i++) {
 		sum += diff(i);
 	}
 

--- a/src/lib/system_identification/system_identification.hpp
+++ b/src/lib/system_identification/system_identification.hpp
@@ -58,7 +58,7 @@ public:
 	SystemIdentification() = default;
 	~SystemIdentification() = default;
 
-	void reset(const matrix::Vector<float, _kParameters> &id_state_init = {});
+	void reset(const matrix::Vector<float, _kParameters> &id_state_init = {}, float var_init = 100.f);
 	void update(float u, float y); // update filters and model
 	void update(); // update model only (to be called after updateFilters)
 	void updateFilters(float u, float y);

--- a/src/lib/system_identification/system_identification.hpp
+++ b/src/lib/system_identification/system_identification.hpp
@@ -70,7 +70,7 @@ public:
 		_u_lpf.set_cutoff_frequency(sample_freq, cutoff);
 		_y_lpf.set_cutoff_frequency(sample_freq, cutoff);
 	}
-	void setHpfCutoffFrequency(float sample_freq, float cutoff) { _alpha_hpf = sample_freq / (sample_freq + 2.f * M_PI_F * cutoff); }
+	void setHpfCutoffFrequency(float sample_freq, float cutoff) { _gamma_hpf = tanf(M_PI_F * cutoff / sample_freq); }
 
 	void setForgettingFactor(float time_constant, float dt) { _rls.setForgettingFactor(time_constant, dt); }
 	void setFitnessLpfTimeConstant(float time_constant, float dt)
@@ -88,7 +88,7 @@ private:
 	math::LowPassFilter2p<float> _y_lpf{400.f, 30.f};
 
 	//TODO: replace by HighPassFilter class
-	float _alpha_hpf{0.f};
+	float _gamma_hpf{0.f};
 	float _u_hpf{0.f};
 	float _y_hpf{0.f};
 

--- a/src/lib/system_identification/system_identification.hpp
+++ b/src/lib/system_identification/system_identification.hpp
@@ -50,18 +50,23 @@
 class SystemIdentification final
 {
 public:
+	static constexpr int _kPoles = 2;
+	static constexpr int _kZeros = 2;
+	static constexpr int _kDelays = 1;
+	static constexpr int _kParameters = _kPoles + _kZeros + 1;
+
 	SystemIdentification() = default;
 	~SystemIdentification() = default;
 
-	void reset(const matrix::Vector<float, 5> &id_state_init = {});
+	void reset(const matrix::Vector<float, _kParameters> &id_state_init = {});
 	void update(float u, float y); // update filters and model
 	void update(); // update model only (to be called after updateFilters)
 	void updateFilters(float u, float y);
 	bool areFiltersInitialized() const { return _are_filters_initialized; }
 	void updateFitness();
-	const matrix::Vector<float, 5> &getCoefficients() const { return _rls.getCoefficients(); }
-	const matrix::Vector<float, 5> getVariances() const { return _rls.getVariances(); }
-	const matrix::Vector<float, 5> &getDiffEstimate() const { return _rls.getDiffEstimate(); }
+	const matrix::Vector<float, _kParameters> getCoefficients() const { return  _rls.getCoefficients(); }
+	const matrix::Vector<float, _kParameters> getVariances() const { return _rls.getVariances(); }
+	const matrix::Vector<float, _kParameters> getDiffEstimate() const { return _rls.getDiffEstimate(); }
 	float getFitness() const { return _fitness_lpf.getState(); }
 	float getInnovation() const { return _rls.getInnovation(); }
 
@@ -83,7 +88,7 @@ public:
 	float getFilteredOutputData() const { return _y_hpf; }
 
 private:
-	ArxRls<2, 2, 1> _rls;
+	ArxRls<_kPoles, _kZeros, _kDelays> _rls;
 	math::LowPassFilter2p<float> _u_lpf{400.f, 30.f};
 	math::LowPassFilter2p<float> _y_lpf{400.f, 30.f};
 

--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -299,7 +299,9 @@ void FwAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 	// when identifying an axis, check if the estimate has converged
 	const float converged_thr = 1.f;
 
-	const Vector<float, SystemIdentification::_kParameters> sys_id_init;
+	Vector<float, 5> sys_id_init;
+	sys_id_init(0) = -1.5f;
+	sys_id_init(1) = 0.5f;
 
 	switch (_state) {
 	case state::idle:

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -50,7 +50,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("actuator_controls_status_0", 300);
 	add_topic("airspeed", 1000);
 	add_optional_topic("airspeed_validated", 200);
-	add_optional_topic("autotune_attitude_control_status", 100);
+	add_optional_topic("autotune_attitude_control_status");
 	add_optional_topic("camera_capture");
 	add_optional_topic("camera_trigger");
 	add_topic("cellular_status", 200);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -391,6 +391,7 @@ void LoggedTopics::add_system_identification_topics()
 	add_topic("sensor_combined");
 	add_topic("vehicle_angular_velocity");
 	add_topic("vehicle_torque_setpoint");
+	add_optional_topic("autotune_attitude_control_status");
 }
 
 void LoggedTopics::add_mavlink_tunnel()

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -241,7 +241,7 @@ void McAutotuneAttitudeControl::checkFilters()
 			const float filter_rate_hz = 1.f / _filter_dt;
 
 			_sys_id.setLpfCutoffFrequency(filter_rate_hz, _param_imu_gyro_cutoff.get());
-			_sys_id.setHpfCutoffFrequency(filter_rate_hz, .5f);
+			_sys_id.setHpfCutoffFrequency(filter_rate_hz, .1f);
 
 			// Set the model sampling time depending on the gyro cutoff frequency
 			// as this is a good indicator of the maximum control loop bandwidth

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -275,7 +275,10 @@ void McAutotuneAttitudeControl::checkFilters()
 void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 {
 	// when identifying an axis, check if the estimate has converged
-	const float converged_thr = 50.f;
+	const float converged_thr = 10.f;
+	Vector<float, 5> state_init;
+	state_init(0) = -1.5f;
+	state_init(1) = 0.5f;
 
 	switch (_state) {
 	case state::idle:
@@ -296,7 +299,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if (_are_filters_initialized) {
 			_state = state::roll;
 			_state_start_time = now;
-			_sys_id.reset();
+			_sys_id.reset(state_init);
 			_gains_backup_available = false;
 		}
 
@@ -318,7 +321,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if ((now - _state_start_time) > 2_s) {
 			_state = state::pitch;
 			_state_start_time = now;
-			_sys_id.reset();
+			_sys_id.reset(state_init);
 		}
 
 		break;
@@ -337,7 +340,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if ((now - _state_start_time) > 2_s) {
 			_state = state::yaw;
 			_state_start_time = now;
-			_sys_id.reset();
+			_sys_id.reset(state_init);
 		}
 
 		break;

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -141,15 +141,15 @@ void McAutotuneAttitudeControl::Run()
 
 	// Send data to the filters at maximum frequency
 	if (_state == state::roll) {
-		_sys_id.updateFilters(_input_scale * vehicle_torque_setpoint.xyz[0],
+		_sys_id.updateFilters(vehicle_torque_setpoint.xyz[0],
 				      angular_velocity.xyz[0]);
 
 	} else if (_state == state::pitch) {
-		_sys_id.updateFilters(_input_scale * vehicle_torque_setpoint.xyz[1],
+		_sys_id.updateFilters(vehicle_torque_setpoint.xyz[1],
 				      angular_velocity.xyz[1]);
 
 	} else if (_state == state::yaw) {
-		_sys_id.updateFilters(_input_scale * vehicle_torque_setpoint.xyz[2],
+		_sys_id.updateFilters(vehicle_torque_setpoint.xyz[2],
 				      angular_velocity.xyz[2]);
 	}
 
@@ -170,9 +170,6 @@ void McAutotuneAttitudeControl::Run()
 		updateStateMachine(now);
 
 		Vector<float, 5> coeff = _sys_id.getCoefficients();
-		coeff(2) *= _input_scale;
-		coeff(3) *= _input_scale;
-		coeff(4) *= _input_scale;
 
 		const Vector3f num(coeff(2), coeff(3), coeff(4));
 		const Vector3f den(1.f, coeff(0), coeff(1));
@@ -287,7 +284,6 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 			_state = state::roll;
 			_state_start_time = now;
 			_sys_id.reset();
-			_input_scale = 1.f / (_param_mc_rollrate_p.get() * _param_mc_rollrate_k.get());
 			_gains_backup_available = false;
 		}
 
@@ -310,7 +306,6 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 			_state = state::pitch;
 			_state_start_time = now;
 			_sys_id.reset();
-			_input_scale = 1.f / (_param_mc_pitchrate_p.get() * _param_mc_pitchrate_k.get());
 		}
 
 		break;
@@ -330,7 +325,6 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 			_state = state::yaw;
 			_state_start_time = now;
 			_sys_id.reset();
-			_input_scale = 1.f / (_param_mc_yawrate_p.get() * _param_mc_yawrate_k.get());
 		}
 
 		break;

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -274,8 +274,6 @@ void McAutotuneAttitudeControl::checkFilters()
 
 void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 {
-	// when identifying an axis, check if the estimate has converged
-	const float converged_thr = 10.f;
 	Vector<float, 5> state_init;
 	state_init(0) = -1.5f;
 	state_init(1) = 0.5f;
@@ -299,14 +297,14 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if (_are_filters_initialized) {
 			_state = state::roll;
 			_state_start_time = now;
-			_sys_id.reset(state_init);
+			_sys_id.reset(state_init, _kInitVar);
 			_gains_backup_available = false;
 		}
 
 		break;
 
 	case state::roll:
-		if ((_sys_id.getVariances().max() < converged_thr)
+		if ((_sys_id.getVariances().max() < _kInitVar)
 		    && ((now - _state_start_time) > (_param_mc_at_sysid_time.get() * 1_s))) {
 			copyGains(0);
 
@@ -321,13 +319,13 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if ((now - _state_start_time) > 2_s) {
 			_state = state::pitch;
 			_state_start_time = now;
-			_sys_id.reset(state_init);
+			_sys_id.reset(state_init, _kInitVar);
 		}
 
 		break;
 
 	case state::pitch:
-		if ((_sys_id.getVariances().max() < converged_thr)
+		if ((_sys_id.getVariances().max() < _kInitVar)
 		    && ((now - _state_start_time) > (_param_mc_at_sysid_time.get() * 1_s))) {
 			copyGains(1);
 			_state = state::pitch_pause;
@@ -340,13 +338,13 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		if ((now - _state_start_time) > 2_s) {
 			_state = state::yaw;
 			_state_start_time = now;
-			_sys_id.reset(state_init);
+			_sys_id.reset(state_init, _kInitVar);
 		}
 
 		break;
 
 	case state::yaw:
-		if ((_sys_id.getVariances().max() < converged_thr)
+		if ((_sys_id.getVariances().max() < _kInitVar)
 		    && ((now - _state_start_time) > (_param_mc_at_sysid_time.get() * 1_s))) {
 			copyGains(2);
 			_state = state::yaw_pause;

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -294,7 +294,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		break;
 
 	case state::roll:
-		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
+		if ((_sys_id.getVariances().max() < converged_thr)
 		    && ((now - _state_start_time) > (_param_mc_at_sysid_time.get() * 1_s))) {
 			copyGains(0);
 
@@ -316,7 +316,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		break;
 
 	case state::pitch:
-		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
+		if ((_sys_id.getVariances().max() < converged_thr)
 		    && ((now - _state_start_time) > (_param_mc_at_sysid_time.get() * 1_s))) {
 			copyGains(1);
 			_state = state::pitch_pause;
@@ -336,7 +336,7 @@ void McAutotuneAttitudeControl::updateStateMachine(hrt_abstime now)
 		break;
 
 	case state::yaw:
-		if (areAllSmallerThan(_sys_id.getVariances(), converged_thr)
+		if ((_sys_id.getVariances().max() < converged_thr)
 		    && ((now - _state_start_time) > (_param_mc_at_sysid_time.get() * 1_s))) {
 			copyGains(2);
 			_state = state::yaw_pause;
@@ -484,15 +484,6 @@ bool McAutotuneAttitudeControl::registerActuatorControlsCallback()
 	}
 
 	return true;
-}
-
-bool McAutotuneAttitudeControl::areAllSmallerThan(const Vector<float, 5> &vect, float threshold) const
-{
-	return (vect(0) < threshold)
-	       && (vect(1) < threshold)
-	       && (vect(2) < threshold)
-	       && (vect(3) < threshold)
-	       && (vect(4) < threshold);
 }
 
 void McAutotuneAttitudeControl::copyGains(int index)

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -174,6 +174,7 @@ private:
 		(ParamFloat<px4::params::MC_AT_SYSID_AMP>) _param_mc_at_sysid_amp,
 		(ParamFloat<px4::params::MC_AT_SYSID_F0>) _param_mc_at_sysid_f0,
 		(ParamFloat<px4::params::MC_AT_SYSID_F1>) _param_mc_at_sysid_f1,
+		(ParamFloat<px4::params::MC_AT_SYSID_FYAW>) _param_mc_at_sysid_fyaw,
 		(ParamFloat<px4::params::MC_AT_SYSID_TIME>) _param_mc_at_sysid_time,
 		(ParamInt<px4::params::MC_AT_SYSID_TYPE>) _param_mc_at_sysid_type,
 		(ParamInt<px4::params::MC_AT_APPLY>) _param_mc_at_apply,

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -152,13 +152,6 @@ private:
 
 	bool _gains_backup_available{false}; // true if a backup of the parameters has been done
 
-	/**
-	 * Scale factor applied to the input data to have the same input/output range
-	 * When input and output scales are a lot different, some elements of the covariance
-	 * matrix will collapse much faster than other ones, creating an ill-conditionned matrix
-	 */
-	float _input_scale{1.f};
-
 	hrt_abstime _last_run{0};
 	hrt_abstime _last_publish{0};
 	hrt_abstime _last_model_update{0};

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -94,7 +94,6 @@ private:
 	void updateStateMachine(hrt_abstime now);
 	bool registerActuatorControlsCallback();
 	void stopAutotune();
-	bool areAllSmallerThan(const matrix::Vector<float, 5> &vect, float threshold) const;
 	void copyGains(int index);
 	bool areGainsGood() const;
 	void saveGainsToParams();

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -200,4 +200,5 @@ private:
 	)
 
 	static constexpr float _publishing_dt_s = 5e-3f;
+	static constexpr float _kInitVar = 10.f;
 };

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.hpp
@@ -140,6 +140,8 @@ private:
 
 	bool _armed{false};
 
+	matrix::Vector3f _angular_velocity{};
+
 	matrix::Vector3f _kid{};
 	matrix::Vector3f _rate_k{};
 	matrix::Vector3f _rate_i{};
@@ -157,13 +159,11 @@ private:
 	hrt_abstime _last_model_update{0};
 
 	float _interval_sum{0.f};
-	float _interval_count{0.f};
+	uint32_t _interval_count{0};
 	float _sample_interval_avg{0.01f};
 	float _filter_dt{0.01f};
 	bool _are_filters_initialized{false};
 
-	static constexpr float _model_dt_min{2e-3f}; // 2ms = 500Hz
-	static constexpr float _model_dt_max{10e-3f}; // 10ms = 100Hz
 	int _model_update_scaler{1};
 	int _model_update_counter{0};
 

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control_params.c
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control_params.c
@@ -103,6 +103,21 @@ PARAM_DEFINE_FLOAT(MC_AT_SYSID_F0, 1.f);
 PARAM_DEFINE_FLOAT(MC_AT_SYSID_F1, 20.f);
 
 /**
+ * Yaw axis maximum frequency
+ *
+ * End frequency of the identification for the yaw axis.
+ * This is usually set lower than the roll and pitch axes
+ * to only consider the yaw actuation produced by propeller drag.
+ *
+ * @min 0.1
+ * @max 30.0
+ * @decimal 1
+ * @unit Hz
+ * @group Autotune
+ */
+PARAM_DEFINE_FLOAT(MC_AT_SYSID_FYAW, 5.f);
+
+/**
  * Maneuver time for each axis
  *
  * Duration of the input signal sent on each axis during system identification

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control_params.c
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control_params.c
@@ -77,6 +77,56 @@ PARAM_DEFINE_INT32(MC_AT_START, 0);
 PARAM_DEFINE_FLOAT(MC_AT_SYSID_AMP, 0.7);
 
 /**
+ * Start frequency of the injected signal
+ *
+ * Can be set lower or higher than the end frequency
+ *
+ * @min 0.1
+ * @max 30.0
+ * @decimal 1
+ * @unit Hz
+ * @group Autotune
+ */
+PARAM_DEFINE_FLOAT(MC_AT_SYSID_F0, 1.f);
+
+/**
+ * End frequency of the injected signal
+ *
+ * Can be set lower or higher than the start frequency
+ *
+ * @min 0.1
+ * @max 30.0
+ * @decimal 1
+ * @unit Hz
+ * @group Autotune
+ */
+PARAM_DEFINE_FLOAT(MC_AT_SYSID_F1, 20.f);
+
+/**
+ * Maneuver time for each axis
+ *
+ * Duration of the input signal sent on each axis during system identification
+ *
+ * @min 5
+ * @max 120
+ * @decimal 0
+ * @unit s
+ * @group Autotune
+ */
+PARAM_DEFINE_FLOAT(MC_AT_SYSID_TIME, 10.f);
+
+/**
+ * Input signal type
+ *
+ * Type of signal used during system identification to excite the system.
+ *
+ * @value 0 Linear sine sweep
+ * @value 1 Logarithmic sine sweep
+ * @group Autotune
+ */
+PARAM_DEFINE_INT32(MC_AT_SYSID_TYPE, 1);
+
+/**
  * Controls when to apply the new gains
  *
  * After the auto-tuning sequence is completed,


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
In some cases, the gains obtained by auto-tuning weren't good enough because the system identification wasn't able to capture the dynamics properly.

### Solution
One possible cause of a poor model identification is when the dominant dynamics are not correctly excited. 
This PR changes the current doublet input signal to sine sweeps (as suggested by Ryan Beall). As they cover a wider range of frequencies, they give a higher chance to correctly capture the system dynamics.

The current implementation is also more generic and other signal types can be added.

### Changelog Entry
For release notes:
```
Changed MC autotune input signal from doublets to sine sweep
New parameter: MC_AT_SYSID_F0, MC_AT_SYSID_F1, MC_AT_SYSID_TIME, MC_AT_SYSID_TYPE
Documentation: Need to update autotune page
```

### Test coverage
SITL tests for now

![log_sine_sweep_sitl](https://github.com/PX4/PX4-Autopilot/assets/14822839/d65c57e0-aa51-489d-86c5-959ba2b54f92)

