### PR TITLE
ci: update macos runner

### DIFF
--- a/.github/workflows/compile_macos.yml
+++ b/.github/workflows/compile_macos.yml
@@ -10,13 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     strategy:
       matrix:
         config: [
           px4_fmu-v5_default,
           px4_sitl
-          #tests, # includes px4_sitl
           ]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
### Solved Problem
The MacOS workflow for CI was set for macOS-10.5, which isn't available anymore at GitHub, causing macOS builds to fail when they couldn't find a runner.

Fixes #{Github issue ID}

### Changelog Entry
```
CI: Bump macOS Runner OS to the latest
```

### Context
**[For context here's github runners page](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)**
