### PR TITLE
CI: Fix metadata deployment, unify all container versions in use

### DIFF
--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -12,7 +12,7 @@ pipeline {
             stage("build cubepilot_cubeorange_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -91,7 +91,7 @@ pipeline {
             stage("build cuav_x7pro_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -165,7 +165,7 @@ pipeline {
             stage("build px4_fmu-v4_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -238,7 +238,7 @@ pipeline {
             stage("build px4_fmu-v4pro_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -312,7 +312,7 @@ pipeline {
             stage("build px4_fmu-v5_debug") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -403,7 +403,7 @@ pipeline {
             stage("build px4_fmu-v5_stackcheck") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -486,7 +486,7 @@ pipeline {
             stage("build px4_fmu-v5_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }
@@ -560,7 +560,7 @@ pipeline {
             stage("build nxp_fmuk66-v3_test") {
               agent {
                 docker {
-                  image 'px4io/px4-dev-nuttx-focal:2021-09-08'
+                  image 'px4io/px4-dev-nuttx-focal:2022-08-12'
                   args '--cpu-shares 512 -e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
                 }
               }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/cpp
 {
 	"name": "px4-dev-nuttx",
-	"image": "px4io/px4-dev-nuttx-focal:2021-09-08",
+	"image": "px4io/px4-dev-nuttx-focal:2022-08-12",
 
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
           "parameters_metadata",
         ]
     container:
-      image: px4io/px4-dev-nuttx-focal:2021-09-08
+      image: px4io/px4-dev-nuttx-focal:2022-08-12
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-aarch64:2021-09-08
+    container: px4io/px4-dev-aarch64:2022-08-12
     strategy:
       matrix:
         config: [

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx-focal:2021-09-08
+    container: px4io/px4-dev-nuttx-focal:2022-08-12
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -24,7 +24,7 @@ jobs:
     needs: enumerate_targets
     strategy:
       matrix: ${{fromJson(needs.enumerate_targets.outputs.matrix)}}
-    container: px4io/px4-dev-${{ matrix.container }}:2021-09-08
+    container: ${{ matrix.container }}
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/failsafe_sim.yml
+++ b/.github/workflows/failsafe_sim.yml
@@ -21,7 +21,7 @@ jobs:
           "failsafe_web",
         ]
     container:
-      image: px4io/px4-dev-nuttx-focal:2021-09-08
+      image: px4io/px4-dev-nuttx-focal:2022-08-12
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -103,7 +103,7 @@ jobs:
 
   uorb_graph:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-nuttx-focal:2021-09-08
+    container: px4io/px4-dev-nuttx-focal:2022-08-12
     steps:
     - uses: actions/checkout@v1
       with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
 
         stage('failsafe docs') {
           agent {
-            docker { image 'px4io/px4-dev-nuttx-focal:2021-08-18' }
+            docker { image 'px4io/px4-dev-nuttx-focal:2022-08-12' }
           }
           steps {
             sh '''#!/bin/bash -l
@@ -125,7 +125,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx-focal:2021-08-18'
+              image 'px4io/px4-dev-nuttx-focal:2022-08-12'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,13 +4,13 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4_fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2021-09-08"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2022-08-12"
 	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*beaglebone.* ]] || [[ $@ =~ .*pilotpi.default ]]; then
 		# beaglebone_blue_default, emlid_navio2_default, px4_raspberrypi_default, scumaker_pilotpi_default
 		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
 	elif [[ $@ =~ .*pilotpi.arm64 ]]; then
 		# scumaker_pilotpi_arm64
-		PX4_DOCKER_REPO="px4io/px4-dev-aarch64:latest"
+		PX4_DOCKER_REPO="px4io/px4-dev-aarch64:2022-08-12"
 	elif [[ $@ =~ .*navio2.* ]] || [[ $@ =~ .*raspberry.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# posix_rpi_cross, posix_bebop_default
 		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2023-06-26"
@@ -27,7 +27,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2021-09-08"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx-focal:2022-08-12"
 fi
 
 # docker hygiene

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -61,18 +61,19 @@ def process_target(px4board_file, target_name):
 
     if platform not in excluded_platforms:
         # get the container based on the platform and toolchain
-        container = platform
         if platform == 'posix':
-            container = 'base-focal'
+            container = 'px4io/px4-dev-base-focal:2021-09-08'
             if toolchain:
                 if toolchain.startswith('aarch64'):
-                    container = 'aarch64'
+                    container = 'px4io/px4-dev-aarch64:2021-09-08'
                 elif toolchain == 'arm-linux-gnueabihf':
-                    container = 'armhf'
+                    container = 'px4io/px4-dev-armhf:2021-09-08'
                 else:
-                    if verbose: print(f'possibly unmatched toolchain: {toolchain}')
+                    if verbose: print(f'unmatched toolchain: {toolchain}')
         elif platform == 'nuttx':
-            container = 'nuttx-focal'
+            container = 'px4io/px4-dev-nuttx-focal:2021-09-08'
+        else:
+            if verbose: print(f'unmatched platform: {platform}')
 
         ret = {'target': target_name, 'container': container}
 
@@ -113,4 +114,3 @@ extra_args = {}
 if args.pretty:
     extra_args['indent'] = 2
 print(json.dumps(github_action_config, **extra_args))
-

--- a/Tools/generate_board_targets_json.py
+++ b/Tools/generate_board_targets_json.py
@@ -65,13 +65,13 @@ def process_target(px4board_file, target_name):
             container = 'px4io/px4-dev-base-focal:2021-09-08'
             if toolchain:
                 if toolchain.startswith('aarch64'):
-                    container = 'px4io/px4-dev-aarch64:2021-09-08'
+                    container = 'px4io/px4-dev-aarch64:2022-08-12'
                 elif toolchain == 'arm-linux-gnueabihf':
-                    container = 'px4io/px4-dev-armhf:2021-09-08'
+                    container = 'px4io/px4-dev-armhf:2023-06-26'
                 else:
                     if verbose: print(f'unmatched toolchain: {toolchain}')
         elif platform == 'nuttx':
-            container = 'px4io/px4-dev-nuttx-focal:2021-09-08'
+            container = 'px4io/px4-dev-nuttx-focal:2022-08-12'
         else:
             if verbose: print(f'unmatched platform: {platform}')
 


### PR DESCRIPTION
### Solved Problem
I realized I did not catch all the container version strings in #21831 
In today's maintainer call it was all about CI and one of the topics was the still failing metadata deployment target on all the builds on main see e.g. https://github.com/PX4/PX4-Autopilot/actions/runs/5584519814/jobs/10206077634. The error is still what I originally solved in #21749 so I did just not understand all the places different container versions are used.

### Solution
- I changed the `generate_board_targets_json.py` script to
   - not just infer the container name from the platform name (isn't that better error handling?)
   - explicitly output the full container tag for each platform and toolchain
- This is my (hopefully last) take at unifying all the versions of containers in use in CI.

### Changelog Entry
```
CI: unify all container versions in use
```

### Test coverage
- I ran the python script and inspected the output. For the rest of the testing I'd like CI to run through.

### Context
Output of the python script:

```
{"include": [{"target": "px4_fmu-v4_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_io-v2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v3_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_sitl_default", "container": "px4io/px4-dev-base-focal:2021-09-08"}, {"target": "px4_fmu-v6x_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v6x_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_cyphal", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_debug", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_protected", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_lto", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_cryptotest", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5_uavcanv0periph", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_raspberrypi_default", "container": "px4io/px4-dev-armhf:2023-06-26"}, {"target": "px4_fmu-v2_fixedwing", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v2_rover", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v2_lto", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v2_multicopter", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v6c_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v6c_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v4pro_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v6u_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v6u_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "px4_fmu-v5x_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "spracing_h7extreme_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cuav_nora_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cuav_nora_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cuav_x7pro_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cuav_x7pro_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cuav_can-gps-v1_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cuav_can-gps-v1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cubepilot_cubeorange_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cubepilot_cubeorange_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cubepilot_io-v2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cubepilot_cubeorangeplus_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cubepilot_cubeorangeplus_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "cubepilot_cubeyellow_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "flywoo_gn-f405_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_h743_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_h743_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_gnss-m9n-f4_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_gnss-m9n-f4_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_h743-mini_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_h743-mini_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_h743-slim_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "matek_h743-slim_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "thepeach_k1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "thepeach_r1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_can-rtk-gps_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_can-rtk-gps_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_fmu-v6x_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_fmu-v6x_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_can-flow_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_can-flow_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_can-gps_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_can-gps_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_cannode_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "ark_cannode_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "emlid_navio2_default", "container": "px4io/px4-dev-armhf:2023-06-26"}, {"target": "sky-drones_smartap-airlink_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "diatone_mamba-f405-mk2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "scumaker_pilotpi_default", "container": "px4io/px4-dev-armhf:2023-06-26"}, {"target": "scumaker_pilotpi_arm64", "container": "px4io/px4-dev-aarch64:2022-08-12"}, {"target": "freefly_can-rtk-gps_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "freefly_can-rtk-gps_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "bitcraze_crazyflie_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "bitcraze_crazyflie21_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "raspberrypi_pico_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "av_x-v1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "beaglebone_blue_default", "container": "px4io/px4-dev-armhf:2023-06-26"}, {"target": "uvify_core_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "omnibus_f4sd_icm20608g", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "omnibus_f4sd_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "modalai_fc-v2_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "modalai_fc-v2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "modalai_fc-v1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_fmurt1062-v1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_fmuk66-e_socketcan", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_fmuk66-e_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_ucans32k146_cyphal", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_ucans32k146_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_ucans32k146_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_fmuk66-v3_socketcan", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_fmuk66-v3_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_mr-canhubk3_fmu", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_mr-canhubk3_sysview", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "nxp_mr-canhubk3_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "atl_mantis-edu_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_pix32v5_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_durandal-v1_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_durandal-v1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakuteh7mini_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakuteh7mini_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakuteh7v2_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakuteh7v2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_can-gps-v1_canbootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_can-gps-v1_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakuteh7_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakuteh7_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "holybro_kakutef7_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "airmind_mindpx-v2_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-f7_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_pixracerpro_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_pixracerpro_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-f7-oem_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-h7-oem_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-h7-oem_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_x21_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-h7_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-h7_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-classic_bootloader", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_ctrl-zero-classic_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}, {"target": "mro_x21-777_default", "container": "px4io/px4-dev-nuttx-focal:2022-08-12"}]}
```