### PR TITLE
Enable Target Compile Github Actions also on stable, beta, release branches

### DIFF
--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -1,9 +1,12 @@
-name: Linux Targets
+name: Compile Linux Targets
 
 on:
   push:
     branches:
     - 'main'
+    - 'stable'
+    - 'beta'
+    - 'release/*'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/compile_linux_arm64.yml
+++ b/.github/workflows/compile_linux_arm64.yml
@@ -1,9 +1,12 @@
-name: Linux ARM64 Targets
+name: Compile Linux ARM64 Targets
 
 on:
   push:
     branches:
     - 'main'
+    - 'stable'
+    - 'beta'
+    - 'release/*'
   pull_request:
     branches:
     - '*'

--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -1,9 +1,12 @@
-name: Nuttx Targets
+name: Compile Nuttx Targets
 
 on:
   push:
     branches:
     - 'main'
+    - 'stable'
+    - 'beta'
+    - 'release/*'
   pull_request:
     branches:
     - '*'


### PR DESCRIPTION
## About
As discussed in [maintainer's call](https://discuss.px4.io/t/px4-maintainers-call-july-18-2023/33189#ci-improvements-6), this adds `stable`, `beta`, and `release/*` branches to the triggering conditions for target compile actions.

## Benefit
Now we will be able to confirm whether the release branches (as well as manually controlled stable and beta branches) have any target compilation issues constantly.