### PR TITLE
CI: deploy_all: add git ownership workaround

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -30,6 +30,9 @@ jobs:
       with:
         token: ${{secrets.ACCESS_TOKEN}}
 
+    - name: ownership workaround
+      run: git config --system --add safe.directory '*'
+
     - name: make ${{matrix.target}}
       run: make ${{matrix.target}}
 


### PR DESCRIPTION
### Solved Problem
`Deploy metadata for all targets / build beaglebone` still failing now with the new error:
`fatal: detected dubious ownership in repository at '/__w/PX4-Autopilot/PX4-Autopilot'`

### Solution
Port the workaround from https://github.com/PX4/PX4-Autopilot/pull/21749 namely commit a6d2c2cf5e21ecdad8d737c31de81fab128898c5 to the metadata deployment. I double-checked that if you have an older version of git this setting gets added without failing.

### Test coverage
It builds locally, I cannot reproduce the permission setup that GitHub Actions creates with the checkout plugin but the same fix worked on the other ci pipelines that use this container and failed with the same error.