### PR TITLE
temperature_compensation: use snprintf instead of sprintf

### DIFF
--- a/src/modules/temperature_compensation/temperature_calibration/mag.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/mag.cpp
@@ -212,7 +212,7 @@ int TemperatureCalibrationMag::finish_sensor_instance(PerSensorData &data, int s
 
 	for (unsigned axis_index = 0; axis_index < 3; axis_index++) {
 		for (unsigned coef_index = 0; coef_index <= 3; coef_index++) {
-			sprintf(str, "TC_M%d_X%d_%d", sensor_index, 3 - coef_index, axis_index);
+			snprintf(str, sizeof(str), "TC_M%d_X%d_%d", sensor_index, 3 - coef_index, axis_index);
 			param = (float)res[axis_index][coef_index];
 			result = param_set_no_notification(param_find(str), &param);
 


### PR DESCRIPTION
### Solved Problem
MacOS CI failing with:
```
'sprintf' is deprecated: This function is provided for compatibility reasons only. Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.
```

### Solution
Use snprintf with the buffer limit since it's better practise and hopefully will fix MacOS CI.

### Changelog Entry
```
Refactor: thermal calibration cstring better practise
```

### Alternatives
There are many more sprintfs mostly in the xrce log functionality (submodule) but apparently that's not compiled by default for SITL.

### Test coverage
Builds locally on Ubuntu, let's see what MacOS CI does.

### Context
Example failed build: https://github.com/PX4/PX4-Autopilot/actions/runs/5602138930/jobs/10246984717
