### PR TITLE
[RELEASE/1.13] Stop GNSS fusion when fix is loss

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.cpp
+++ b/src/modules/ekf2/EKF/estimator_interface.cpp
@@ -148,6 +148,11 @@ void EstimatorInterface::setGpsData(const gps_message &gps)
 	}
 
 	if ((gps.time_usec - _time_last_gps) > _min_obs_interval_us) {
+
+		if (!gps.vel_ned_valid || (gps.fix_type == 0)) {
+			return;
+		}
+
 		_time_last_gps = gps.time_usec;
 
 		gpsSample gps_sample_new;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
fixes https://github.com/PX4/PX4-Autopilot/issues/21828
Already fixed on 1.14 (https://github.com/PX4/PX4-Autopilot/pull/20686) but this was a regression from 1.12 that could lead to a crash

Added unit test for this exact condition.