### PR TITLE
Tools/simulation/gz: load ApplyLinkWrench plugin by default

### DIFF
--- a/Tools/simulation/gz/worlds/default.sdf
+++ b/Tools/simulation/gz/worlds/default.sdf
@@ -11,6 +11,7 @@
     <plugin name='gz::sim::systems::Contact' filename='gz-sim-contact-system'/>
     <plugin name='gz::sim::systems::Imu' filename='gz-sim-imu-system'/>
     <plugin name='gz::sim::systems::AirPressure' filename='gz-sim-air-pressure-system'/>
+    <plugin name='gz::sim::systems::ApplyLinkWrench' filename='gz-sim-apply-link-wrench-system'/>
     <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
       <render_engine>ogre2</render_engine>
     </plugin>


### PR DESCRIPTION
This can be useful for apply arbitrary forces like simulating hand launching a vehicle (throwing it in the air).

Example
``` Bash
$ gz topic -t /world/default/wrench -m gz.msgs.EntityWrench -p '
  entity {
    name: "x500_0"
    type: 2
  }
  wrench {
    force {x:100, y:200, z:5000}
    torque {x:5, y:6, z:7}    
  }
'

```

![2023-07-21-165149_002](https://github.com/PX4/PX4-Autopilot/assets/84712/c62f7451-73e7-4557-9a47-cfc58022e907)

