### PR TITLE
Geofence: Disable pre-emptive geofence predictor by default

### DIFF
--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -128,7 +128,9 @@ PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, 0);
 PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
 
 /**
- * Use Pre-emptive geofence triggering
+ * [EXPERIMENTAL] Use Pre-emptive geofence triggering
+ *
+ * WARNING: This experimental feature may cause flyaways. Use at your own risk.
  *
  * Predict the motion of the vehicle and trigger the breach if it is determined that the current trajectory
  * would result in a breach happening before the vehicle can make evasive maneuvers.
@@ -137,4 +139,4 @@ PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
  * @boolean
  * @group Geofence
  */
-PARAM_DEFINE_INT32(GF_PREDICT, 1);
+PARAM_DEFINE_INT32(GF_PREDICT, 0);


### PR DESCRIPTION
## About
As discussed in https://discuss.px4.io/t/px4-maintainers-call-may-30-2023/32372#v114-new-beta-release-5, Geofence predictor feature was not well tested / maintained, hence was agreed upon to be disabled for the 1.14 release. And this was merged with the PR: https://github.com/PX4/PX4-Autopilot/pull/21657

Although we didn't discuss how to proceed with this feature in `main`, since it isn't actively maintained, I think it makes sense to backport this back to `main`.