### PR TITLE
Commander: add warning for imminent navigation failure

### DIFF
--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -49,7 +49,6 @@ bool vtol_fixed_wing_system_failure   # vehicle in fixed-wing system failure fai
 bool wind_limit_exceeded              # Wind limit exceeded
 bool flight_time_limit_exceeded       # Maximum flight time exceeded
 bool local_position_accuracy_low      # Local position estimate has dropped below threshold, but is currently still declared valid
-bool nav_failure_imminent_warned      # True if a warning for low
 
 # Failure detector
 bool fd_critical_failure              # Critical failure (attitude/altitude limit exceeded, or external ATS)

--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -49,6 +49,7 @@ bool vtol_fixed_wing_system_failure   # vehicle in fixed-wing system failure fai
 bool wind_limit_exceeded              # Wind limit exceeded
 bool flight_time_limit_exceeded       # Maximum flight time exceeded
 bool local_position_accuracy_low      # Local position estimate has dropped below threshold, but is currently still declared valid
+bool nav_failure_imminent_warned      # True if a warning for low
 
 # Failure detector
 bool fd_critical_failure              # Critical failure (attitude/altitude limit exceeded, or external ATS)

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -782,18 +782,18 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 		    && dead_reckoning) {
 			/* EVENT
 			 * @description
-			 * Estimated position error is approaching the failsafe threshold.
+			 * Switch to manual mode recommended.
 			 *
 			 * <profile name="dev">
 			 * This warning is triggered when the position error estimate is 90% of (or only 10m below) <param>COM_POS_FS_EPH</param> parameter.
 			 * </profile>
 			 */
 			events::send(events::ID("check_estimator_position_failure_imminent"), {events::Log::Error, events::LogInternal::Info},
-				     "Critical navigation failure, failsafe imminent. Switch to manual mode recommended");
+				     "Estimated position error is approaching the failsafe threshold");
 
 			if (reporter.mavlink_log_pub()) {
 				mavlink_log_critical(reporter.mavlink_log_pub(),
-						     "Critical navigation failure, failsafe imminent. Switch to manual mode recommended\t");
+						     "Estimated position error is approaching the failsafe threshold\t");
 			}
 
 			_nav_failure_imminent_warned = true;

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -117,7 +117,7 @@ void EstimatorChecks::checkAndReport(const Context &context, Report &reporter)
 
 	// set mode requirements
 	setModeRequirementFlags(context, pre_flt_fail_innov_heading, pre_flt_fail_innov_vel_horiz, lpos, vehicle_gps_position,
-				reporter.failsafeFlags());
+				reporter.failsafeFlags(), reporter);
 
 
 	lowPositionAccuracy(context, reporter, lpos);
@@ -726,7 +726,8 @@ void EstimatorChecks::lowPositionAccuracy(const Context &context, Report &report
 
 void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_flt_fail_innov_heading,
 		bool pre_flt_fail_innov_vel_horiz,
-		const vehicle_local_position_s &lpos, const sensor_gps_s &vehicle_gps_position, failsafe_flags_s &failsafe_flags)
+		const vehicle_local_position_s &lpos, const sensor_gps_s &vehicle_gps_position, failsafe_flags_s &failsafe_flags,
+		Report &reporter)
 {
 	// The following flags correspond to mode requirements, and are reported in the corresponding mode checks
 	vehicle_global_position_s gpos;
@@ -764,6 +765,44 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 	failsafe_flags.global_position_invalid =
 		!checkPosVelValidity(now, xy_valid, gpos.eph, _param_com_pos_fs_eph.get(), gpos.timestamp,
 				     _last_gpos_fail_time_us, !failsafe_flags.global_position_invalid);
+
+	// Additional warning if the system is about to enter position-loss failsafe after dead-reckoning period
+	const float eph_critical = 2.5f * _param_com_pos_fs_eph.get(); // threshold used to trigger the navigation failsafe
+	const float gpos_critical_warning_thrld = math::max(0.9f * eph_critical, math::max(eph_critical - 10.f, 0.f));
+
+	estimator_status_flags_s estimator_status_flags;
+
+	if (_estimator_status_flags_sub.copy(&estimator_status_flags)) {
+		const bool dead_reckoning = estimator_status_flags.cs_inertial_dead_reckoning
+					    || estimator_status_flags.cs_wind_dead_reckoning;
+
+		if (!failsafe_flags.global_position_invalid
+		    && !failsafe_flags.nav_failure_imminent_warned
+		    && gpos.eph > gpos_critical_warning_thrld
+		    && dead_reckoning) {
+			/* EVENT
+			 * @description
+			 * Estimated position error is approaching the failsafe threshold.
+			 *
+			 * <profile name="dev">
+			 * This warning is triggered when the position error estimate is 90% of (or only 10m below) <param>COM_POS_FS_EPH</param> parameter.
+			 * </profile>
+			 */
+			events::send(events::ID("check_estimator_position_failure_imminent"), {events::Log::Error, events::LogInternal::Info},
+				     "Critical navigation failure, failsafe imminent. Switch to manual mode recommended");
+
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_critical(reporter.mavlink_log_pub(),
+						     "Critical navigation failure, failsafe imminent. Switch to manual mode recommended\t");
+			}
+
+			failsafe_flags.nav_failure_imminent_warned = true;
+
+		} else if (!dead_reckoning) {
+			failsafe_flags.nav_failure_imminent_warned = false;
+		}
+
+	}
 
 	failsafe_flags.local_position_invalid =
 		!checkPosVelValidity(now, xy_valid, lpos.eph, _param_com_pos_fs_eph.get(), lpos.timestamp,

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -777,7 +777,7 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 					    || estimator_status_flags.cs_wind_dead_reckoning;
 
 		if (!failsafe_flags.global_position_invalid
-		    && !failsafe_flags.nav_failure_imminent_warned
+		    && !_nav_failure_imminent_warned
 		    && gpos.eph > gpos_critical_warning_thrld
 		    && dead_reckoning) {
 			/* EVENT
@@ -796,10 +796,10 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 						     "Critical navigation failure, failsafe imminent. Switch to manual mode recommended\t");
 			}
 
-			failsafe_flags.nav_failure_imminent_warned = true;
+			_nav_failure_imminent_warned = true;
 
 		} else if (!dead_reckoning) {
-			failsafe_flags.nav_failure_imminent_warned = false;
+			_nav_failure_imminent_warned = false;
 		}
 
 	}

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -69,7 +69,7 @@ private:
 	void lowPositionAccuracy(const Context &context, Report &reporter, const vehicle_local_position_s &lpos) const;
 	void setModeRequirementFlags(const Context &context, bool pre_flt_fail_innov_heading, bool pre_flt_fail_innov_vel_horiz,
 				     const vehicle_local_position_s &lpos, const sensor_gps_s &vehicle_gps_position,
-				     failsafe_flags_s &failsafe_flags);
+				     failsafe_flags_s &failsafe_flags, Report &reporter);
 
 	bool checkPosVelValidity(const hrt_abstime &now, const bool data_valid, const float data_accuracy,
 				 const float required_accuracy,

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -103,6 +103,8 @@ private:
 
 	bool _gps_was_fused{false};
 
+	bool _nav_failure_imminent_warned{false};
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::SYS_MC_EST_GROUP>) _param_sys_mc_est_group,
 					(ParamInt<px4::params::SENS_IMU_MODE>) _param_sens_imu_mode,


### PR DESCRIPTION


### Solved Problem
Some system are able to dead-reckon for a while after losing GPS or other sources providing positional feedback. If the estimated position error grows above the failsafe threshold, the system enters a failsafe mode. As the position error estimate is growing linearly over time, and it is recommended to take action before entering the failsafe, we here warn the user about the imminent failsafe and propose to take manual control.

### Solution
Warn the user when the position error estimate (eph) is either 90% of threshold (COM_POS_FS_EPH) or less than 10m below it (which ever is reached later). 

### Changelog Entry
For release notes:
```
Feature: warn user when navigation failure is imminent 
```

### Alternatives
As this is a purely a notification thing, it could also happen exclusively on the ground station. The envisioned mechanism would be that PX4 provides a error estimate (eg link it to the current wind turbulence, as that heavily effects the position error growth when dead reckoning) over MAVLink, and the ground station shows that as a circle around the vehicle in the GNSS denied case.

### Test coverage
SITL tested. That's how a GNSS fusion timeout now looks like on a VTOL with the following thresholds:
COM_POS_LOW_EPH = 15m (trigger RTL at 15m position error)
COM_POS_FS_EPH = 10m (trigger failsafe action at 2.5*10=25m error). Failsafe action for a VTOL is transition to MC and descend (NAV_FORCE_VT=1, default). 

https://github.com/PX4/PX4-Autopilot/assets/26798987/1590723e-ac4c-426f-90dd-09981051377d

