### PR TITLE
Max position uncertainty failsafe fixes

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -739,7 +739,9 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 
 	// run position and velocity accuracy checks
 	// Check if quality checking of position accuracy and consistency is to be performed
-	float lpos_eph_threshold_relaxed = _param_com_pos_fs_eph.get();
+	const float lpos_eph_threshold = (_param_com_pos_fs_eph.get() < 0) ? INFINITY : _param_com_pos_fs_eph.get();
+
+	float lpos_eph_threshold_relaxed = lpos_eph_threshold;
 
 	// Set the allowable position uncertainty based on combination of flight and estimator state
 	// When we are in a operator demanded position control mode and are solely reliant on optical flow,
@@ -762,11 +764,11 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 	}
 
 	failsafe_flags.global_position_invalid =
-		!checkPosVelValidity(now, xy_valid, gpos.eph, _param_com_pos_fs_eph.get(), gpos.timestamp,
+		!checkPosVelValidity(now, xy_valid, gpos.eph, lpos_eph_threshold, gpos.timestamp,
 				     _last_gpos_fail_time_us, !failsafe_flags.global_position_invalid);
 
 	failsafe_flags.local_position_invalid =
-		!checkPosVelValidity(now, xy_valid, lpos.eph, _param_com_pos_fs_eph.get(), lpos.timestamp,
+		!checkPosVelValidity(now, xy_valid, lpos.eph, lpos_eph_threshold, lpos.timestamp,
 				     _last_lpos_fail_time_us, !failsafe_flags.local_position_invalid);
 
 	failsafe_flags.local_position_invalid_relaxed =

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -708,8 +708,11 @@ PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1);
  * If the previous position error was below this threshold, there is an additional
  * factor of 2.5 applied (threshold for invalidation 2.5 times the one for validation).
  *
+ * Set to -1 to disable.
+ *
  * @unit m
- * @min 0
+ * @min -1
+ * @max 400
  * @decimal 1
  * @group Commander
  */
@@ -1076,8 +1079,9 @@ PARAM_DEFINE_FLOAT(COM_WIND_MAX, -1.f);
  *
  * Set to -1 to disable.
  *
- * @group Commander
  * @min -1
+ * @max 1000
+ * @group Commander
  * @unit m
  */
 PARAM_DEFINE_FLOAT(COM_POS_LOW_EPH, -1.0f);

--- a/src/modules/ekf2/EKF/covariance.cpp
+++ b/src/modules/ekf2/EKF/covariance.cpp
@@ -302,17 +302,6 @@ void Ekf::predictCovariance(const imuSample &imu_delayed)
 		nextP(i, i) += process_noise(i);
 	}
 
-	// stop position covariance growth if our total position variance reaches 100m
-	// this can happen if we lose gps for some time
-	if ((P(7, 7) + P(8, 8)) > 1e4f) {
-		for (uint8_t i = 7; i <= 8; i++) {
-			for (uint8_t j = 0; j < _k_num_states; j++) {
-				nextP(i, j) = P(i, j);
-				nextP(j, i) = P(j, i);
-			}
-		}
-	}
-
 	// covariance matrix is symmetrical, so copy upper half to lower half
 	for (unsigned row = 0; row <= 15; row++) {
 		for (unsigned column = 0 ; column < row; column++) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
EKF2 has 2 constraints on the position variance https://github.com/PX4/PX4-Autopilot/blob/e878d0c0ef33b4f2692bb0c0bfa8f0628928854a/src/modules/ekf2/EKF/covariance.cpp#L361
https://github.com/PX4/PX4-Autopilot/blob/1ef9ee762208e9f8a135daf9168122400647274b/src/modules/ekf2/EKF/covariance.cpp#L305-L307

The failsafe params of commander weren't considering the constraint. If the param is set too high, the failsafe will never occur.

### Solution
- Remove duplicate pos var constraint
- Add min and max values for pos uncertainty failsafe parameters
- Add a way to disable `COM_POS_FS_EPH`

