### PR TITLE
Mag check: report strength and inclination values in case of preflight failure

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -184,12 +184,17 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 		/* EVENT
 		 * @description
 		 * <profile name="dev">
+		 * Measured strength: {1:.3}, expected: {2:.3} ± <param>EKF2_MAG_CHK_STR</param>
+		 * Measured inclination: {3:.3}, expected: {4:.3} ± <param>EKF2_MAG_CHK_INC</param>
 		 * This check can be configured via <param>COM_ARM_MAG_STR</param> and <param>EKF2_MAG_CHECK</param> parameters.
 		 * </profile>
 		 */
-		reporter.armingCheckFailure(required_groups_mag, health_component_t::local_position_estimate,
-					    events::ID("check_estimator_mag_interference"),
-					    events::Log::Warning, "Strong magnetic interference");
+		reporter.armingCheckFailure<float, float, float, float>(required_groups_mag,
+				health_component_t::local_position_estimate,
+				events::ID("check_estimator_mag_interference"),
+				events::Log::Warning, "Strong magnetic interference",
+				estimator_status.mag_strength_gs, estimator_status.mag_strength_ref_gs,
+				estimator_status.mag_inclination_deg, estimator_status.mag_inclination_ref_deg);
 
 		if (reporter.mavlink_log_pub()) {
 			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Strong magnetic interference");

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1514,7 +1514,6 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_GPS_H, 10.0f);
  * 2 : Wait for GNSS to find the theoretical strength and inclination using the WMM
  *
  * @group EKF2
- * @boolean
  * @min 0
  * @max 7
  * @bit 0 Strength (EKF2_MAG_CHK_STR)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
It's hard to tune the mag strength and inclination thresholds if the user can't see the current and reference values.

### Solution
Add the measured and expected mag strength and inclination + tolerance parameters
