### PR TITLE
Terrain following fix

### DIFF
--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -106,5 +106,7 @@ void FlightTaskManualAltitudeSmoothVel::_setOutputState()
 	_jerk_setpoint(2) = _smoothing.getCurrentJerk();
 	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
 	_velocity_setpoint(2) = _smoothing.getCurrentVelocity();
-	_position_setpoint(2) = _smoothing.getCurrentPosition();
+	if (!PX4_ISFINITE(_position_setpoint(2))) {
+		_position_setpoint(2) = _smoothing.getCurrentPosition();
+	}
 }

--- a/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -106,6 +106,7 @@ void FlightTaskManualAltitudeSmoothVel::_setOutputState()
 	_jerk_setpoint(2) = _smoothing.getCurrentJerk();
 	_acceleration_setpoint(2) = _smoothing.getCurrentAcceleration();
 	_velocity_setpoint(2) = _smoothing.getCurrentVelocity();
+
 	if (!PX4_ISFINITE(_position_setpoint(2))) {
 		_position_setpoint(2) = _smoothing.getCurrentPosition();
 	}

--- a/src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -171,5 +171,8 @@ void FlightTaskManualPositionSmoothVel::_setOutputStateZ()
 	_jerk_setpoint(2) = _smoothing_z.getCurrentJerk();
 	_acceleration_setpoint(2) = _smoothing_z.getCurrentAcceleration();
 	_velocity_setpoint(2) = _smoothing_z.getCurrentVelocity();
-	_position_setpoint(2) = _smoothing_z.getCurrentPosition();
+	if (!PX4_ISFINITE(_position_setpoint(2))) {
+		_position_setpoint(2) = _smoothing_z.getCurrentPosition();
+	}
+
 }

--- a/src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -171,6 +171,7 @@ void FlightTaskManualPositionSmoothVel::_setOutputStateZ()
 	_jerk_setpoint(2) = _smoothing_z.getCurrentJerk();
 	_acceleration_setpoint(2) = _smoothing_z.getCurrentAcceleration();
 	_velocity_setpoint(2) = _smoothing_z.getCurrentVelocity();
+
 	if (!PX4_ISFINITE(_position_setpoint(2))) {
 		_position_setpoint(2) = _smoothing_z.getCurrentPosition();
 	}


### PR DESCRIPTION


### Solved Problem
When using jerk limited/acceleration based input position controllers I found that terrain following was not functional. Terrain following z position setpoints were ignored.

### Solution
Only set position setpoint to current position if z position setpoint is not already set
