### PR TITLE
FWPosControl: Bugfix wrong conversion from VZ target to height rate

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2594,7 +2594,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(const float control_interva
 		     desired_max_sinkrate,
 		     airspeed_rate_estimate,
 		     -_local_pos.vz,
-		     hgt_rate_sp);
+		     -hgt_rate_sp);
 
 	tecs_status_publish(alt_sp, airspeed_sp, airspeed_rate_estimate, throttle_trim_adjusted);
 }

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -715,7 +715,7 @@ private:
 	 * @param desired_max_sink_rate The desired max sink rate commandable when altitude errors are large [m/s]
 	 * @param desired_max_climb_rate The desired max climb rate commandable when altitude errors are large [m/s]
 	 * @param disable_underspeed_detection True if underspeed detection should be disabled
-	 * @param hgt_rate_sp Height rate setpoint [m/s]
+	 * @param hgt_rate_sp Height rate setpoint (positive equals going up) [m/s]
 	 */
 	void tecs_update_pitch_throttle(const float control_interval, float alt_sp, float airspeed_sp, float pitch_min_rad,
 					float pitch_max_rad, float throttle_min, float throttle_max,


### PR DESCRIPTION
## About
The `vz` field (which is used for example when user sets target velocity via https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED, which then sets `trajectory_setpoint`, which then gets copied to `position_setpoint_triplet` inside the class) was incorrectly getting passed directly as the "height rate setpoint" to the TECS.

This resulted in sending desired speed of Vz = 3.0 (should descend at 3.0 m/s), to result in a plane going up instead, and thus the `control_auto_velocity` function's vertical velocity control was broken.

## Changes
- Added a parameter description in `tecs_update_pitch_throttle()` to indicate that height_rate is positive when going up
- Added a negative sign in `control_auto_velocity()` to correctly interpret the velocity target