### PR TITLE
Fix mission failed bug

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -92,6 +92,7 @@ MavlinkMissionManager::init_offboard_mission()
 			_dataman_id = (dm_item_t)mission_state.dataman_id;
 			_count[MAV_MISSION_TYPE_MISSION] = mission_state.count;
 			_current_seq = mission_state.current_seq;
+			_mission_update_counter = mission_state.mission_update_counter;
 
 		} else {
 			PX4_WARN("offboard mission init failed");
@@ -131,6 +132,7 @@ MavlinkMissionManager::load_safepoint_stats()
 
 	if (success) {
 		_count[MAV_MISSION_TYPE_RALLY] = stats.num_items;
+		_safepoint_update_counter = stats.update_counter;
 	}
 
 	return success;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -586,7 +586,7 @@ void
 Mission::update_mission()
 {
 
-	bool failed = true;
+	bool failed = !_navigator->get_mission_result()->valid;
 
 	_dataman_cache.invalidate();
 	_load_mission_index = -1;
@@ -653,6 +653,7 @@ Mission::update_mission()
 
 	} else {
 		PX4_ERR("mission update failed");
+		failed = true;
 	}
 
 	if (failed) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I found two issues with mission uploading in the newest main. 

1. Mission module per default assumed the mission was not valid when the mission uorb topic changed. Only when the mission counter is updated, it actually checks the validity of the mission. But since the mission topic gets updated as well when the geofence or safepoints changed, this would lead to wrongly failed missions in the mission module where the mission would be reset.
2. The mission counter in mavlink_mission module was always set to 0 on startup. When on the last powercycle, exactly one mission was loaded, the mission counter in the dataman was set to one. On the next powerccle and the first mission upload, the mavlink_mission would report again a mission counter of 1. This would lead in the mission module to believe, that the mission was not updated at all.

Fixes #{Github issue ID}

### Solution

1. Mission module loads the previously calculated mission validity and if the mission changes, calculates it newly.
2. mavlink_mission loads the mission counter on startup from the datamn (safepoints as well, already done for geofence).

### Changelog Entry
For release notes:
```
Bugfix: Mission failed on geofence/safepoint upload
Bufgix: Mission failed on first mission upload
```

### Test coverage
- SITL test: checking the px4 console output.
