### PR TITLE
Remove checkIfBelowHomeAltitude in Navigator

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -58,7 +58,6 @@ void FeasibilityChecker::reset()
 	_land_pattern_validity_failed = false;
 	_distance_first_waypoint_failed = false;
 	_distance_between_waypoints_failed = false;
-	_below_home_alt_failed = false;
 	_fixed_wing_land_approach_failed = false;
 	_takeoff_land_available_failed = false;
 
@@ -197,10 +196,6 @@ void FeasibilityChecker::doCommonChecks(mission_item_s &mission_item, const int 
 
 	if (!_distance_first_waypoint_failed) {
 		_distance_first_waypoint_failed = !checkHorizontalDistanceToFirstWaypoint(mission_item);
-	}
-
-	if (!_below_home_alt_failed) {
-		_below_home_alt_failed = !checkIfBelowHomeAltitude(mission_item, current_index);
 	}
 
 	if (!_takeoff_failed) {
@@ -679,21 +674,6 @@ bool FeasibilityChecker::checkDistancesBetweenWaypoints(const mission_item_s &mi
 	_last_cmd = mission_item.nav_cmd;
 
 	/* We ran through all waypoints and have not found any distances between waypoints that are too far. */
-	return true;
-}
-
-bool FeasibilityChecker::checkIfBelowHomeAltitude(const mission_item_s &mission_item, const int current_index)
-{
-	/* calculate the global waypoint altitude */
-	float wp_alt = (mission_item.altitude_is_relative) ? mission_item.altitude + _home_alt_msl : mission_item.altitude;
-
-	if (PX4_ISFINITE(_home_alt_msl) && _home_alt_msl > wp_alt && MissionBlock::item_contains_position(mission_item)) {
-
-		mavlink_log_critical(_mavlink_log_pub, "Warning: Waypoint %d below home\t", current_index + 1);
-		events::send<int16_t>(events::ID("navigator_mis_wp_below_home"), {events::Log::Warning, events::LogInternal::Info},
-				      "Waypoint {1} below home", current_index + 1);
-	}
-
 	return true;
 }
 

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -81,7 +81,6 @@ public:
 		       _distance_between_waypoints_failed ||
 		       _land_pattern_validity_failed ||
 		       _fixed_wing_land_approach_failed ||
-		       _below_home_alt_failed ||
 		       _mission_validity_failed ||
 		       _takeoff_land_available_failed;
 	}
@@ -117,7 +116,6 @@ private:
 	bool _land_pattern_validity_failed{false};
 	bool _distance_first_waypoint_failed{false};
 	bool _distance_between_waypoints_failed{false};
-	bool _below_home_alt_failed{false};
 	bool _fixed_wing_land_approach_failed{false};
 	bool _takeoff_land_available_failed{false};
 	bool _items_fit_to_vehicle_type_failed{false};
@@ -197,15 +195,6 @@ private:
 	 * @return False if the check failed.
 	*/
 	bool checkDistancesBetweenWaypoints(const mission_item_s &mission_item);
-
-	/**
-	 * @brief Check if any waypoint is below the home altitude. Issues warning only.
-	 *
-	 * @param mission_item The current mission item
-	 * @param current_index The current mission index
-	 * @return Always returns true, only issues warning.
-	*/
-	bool checkIfBelowHomeAltitude(const mission_item_s &mission_item, const int current_index);
 
 	/**
 	 * @brief Check fixed wing land approach (fixed wing only)


### PR DESCRIPTION
### Solved Problem
When taking off an elevated location (hill, mountain) and planning a mission in a valley relative to the take off location, PX4 will throw warnings for each single waypoint whose altitude is below the home location's altitude. This warning was most likely added to protect the user from mistakes, but flying below the home altitude with a drone is not so uncommon and the warnings are therefore too excessive.


### Solution
The check for the waypoint altitude being below home has been completely removed. 

### Changelog Entry
For release notes:
```
Feature: Don't print warnings for waypoints with altitudes below the home position
```

### Alternatives
We could also limit to one warning per mission that contains waypoints below home, instead of one warning per waypoint. But I'd rather not have any unnecessary warnings during nominal operation of the drone.

### Test coverage
Tested in simulation.

#### Prior to this PR
```
INFO  [mavlink] mode: Onboard, data rate: 4000000 B/s on udp port 14580 remote port 14540
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.0.30
INFO  [mavlink] mode: Onboard, data rate: 4000 B/s on udp port 14280 remote port 14030
INFO  [mavlink] mode: Gimbal, data rate: 400000 B/s on udp port 13030 remote port 13280
INFO  [logger] logger started (mode=all)
INFO  [logger] Start file log (type: full)
INFO  [logger] [logger] ./log/2023-07-28/06_55_16.ulg	
INFO  [logger] Opened full log file: ./log/2023-07-28/06_55_16.ulg
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [px4] Startup script returned successfully
pxh> INFO  [tone_alarm] home set
WARN  [mission_feasibility_checker] Warning: Waypoint 2 below home	
WARN  [mission_feasibility_checker] Warning: Waypoint 3 below home	
WARN  [mission_feasibility_checker] Warning: Waypoint 4 below home	
[Wrn] [Event.cc:61] Warning: Deleting a connection right after creation. Make sure to save the ConnectionPtr from a Connect call
INFO  [tone_alarm] notify positive
INFO  [commander] Ready for takeoff!
INFO  [commander] Armed by external command	
INFO  [tone_alarm] arming warning
INFO  [navigator] Executing Mission	
INFO  [navigator] Takeoff to 2.5 meters above home	
INFO  [commander] Takeoff detected	
INFO  [navigator] Mission finished, loitering
```
https://logs.px4.io/plot_app?log=b91adbc1-f7e4-448d-aa3b-5194d4fb407f

#### After this PR
No warnings:
```
INFO  [mavlink] mode: Onboard, data rate: 4000000 B/s on udp port 14580 remote port 14540
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 192.168.0.30
INFO  [mavlink] mode: Onboard, data rate: 4000 B/s on udp port 14280 remote port 14030
INFO  [mavlink] mode: Gimbal, data rate: 400000 B/s on udp port 13030 remote port 13280
INFO  [logger] logger started (mode=all)
INFO  [logger] Start file log (type: full)
INFO  [logger] [logger] ./log/2023-07-28/06_53_28.ulg	
INFO  [logger] Opened full log file: ./log/2023-07-28/06_53_28.ulg
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
INFO  [px4] Startup script returned successfully
pxh> INFO  [tone_alarm] home set
[Wrn] [Event.cc:61] Warning: Deleting a connection right after creation. Make sure to save the ConnectionPtr from a Connect call
INFO  [tone_alarm] notify positive
INFO  [commander] Ready for takeoff!
INFO  [commander] Armed by external command	
INFO  [tone_alarm] arming warning
INFO  [navigator] Executing Mission	
INFO  [navigator] Takeoff to 2.5 meters above home	
INFO  [commander] Takeoff detected	
INFO  [navigator] Mission finished, loitering
```
https://logs.px4.io/plot_app?log=330407db-73a0-4fc5-8203-09a3a94da4c6

