### PR TITLE
rc gimbal attitude fix

### DIFF
--- a/src/modules/gimbal/common.h
+++ b/src/modules/gimbal/common.h
@@ -84,6 +84,7 @@ struct ControlData {
 	uint8_t compid_primary_control = 0; // The MAVLink component ID selected to be in control, 0 for no one.
 	// uint8_t sysid_secondary_control = 0; // The MAVLink system ID selected for additional input, not implemented yet.
 	// uint8_t compid_secondary_control = 0; // The MAVLink component ID selected for additional input, not implemented yet.
+	uint8_t device_compid = 0;
 };
 
 

--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -211,6 +211,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 			// Reset control as no one is active anymore, or yet.
 			thread_data.control_data.sysid_primary_control = 0;
 			thread_data.control_data.compid_primary_control = 0;
+			thread_data.control_data.device_compid = 0;
 		}
 
 		InputBase::UpdateResult update_result = InputBase::UpdateResult::NoUpdate;

--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2022 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,6 +44,7 @@
  * - MAVLink gimbal protocol v2
  */
 
+#include <cstdint>
 #include <stdlib.h>
 #include <string.h>
 #include <px4_platform_common/defines.h>
@@ -77,6 +78,7 @@ struct ThreadData {
 	int last_input_active = -1;
 	OutputBase *output_obj = nullptr;
 	InputTest *test_input = nullptr;
+	ControlData control_data {};
 };
 static ThreadData *g_thread_data = nullptr;
 
@@ -102,7 +104,6 @@ static int gimbal_thread_main(int argc, char *argv[])
 
 	uORB::SubscriptionInterval parameter_update_sub{ORB_ID(parameter_update), 1_s};
 	thread_running.store(true);
-	ControlData control_data {};
 	g_thread_data = &thread_data;
 
 	thread_data.test_input = new InputTest(params);
@@ -208,8 +209,8 @@ static int gimbal_thread_main(int argc, char *argv[])
 
 		if (thread_data.last_input_active == -1) {
 			// Reset control as no one is active anymore, or yet.
-			control_data.sysid_primary_control = 0;
-			control_data.compid_primary_control = 0;
+			thread_data.control_data.sysid_primary_control = 0;
+			thread_data.control_data.compid_primary_control = 0;
 		}
 
 		InputBase::UpdateResult update_result = InputBase::UpdateResult::NoUpdate;
@@ -226,7 +227,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 				const unsigned int poll_timeout =
 					(already_active || thread_data.last_input_active == -1) ? 20 : 0;
 
-				update_result = thread_data.input_objs[i]->update(poll_timeout, control_data, already_active);
+				update_result = thread_data.input_objs[i]->update(poll_timeout, thread_data.control_data, already_active);
 
 				bool break_loop = false;
 
@@ -271,7 +272,7 @@ static int gimbal_thread_main(int argc, char *argv[])
 
 			// Update output
 			thread_data.output_obj->update(
-				control_data,
+				thread_data.control_data,
 				update_result != InputBase::UpdateResult::NoUpdate);
 
 			// Only publish the mount orientation if the mode is not mavlink v1 or v2
@@ -399,6 +400,33 @@ int gimbal_main(int argc, char *argv[])
 		}
 	}
 
+	else if (!strcmp(argv[1], "primary-control")) {
+
+		if (thread_running.load() && g_thread_data && g_thread_data->test_input) {
+
+			if (argc == 4) {
+				g_thread_data->control_data.sysid_primary_control = (uint8_t)strtol(argv[2], nullptr, 0);
+				g_thread_data->control_data.compid_primary_control = (uint8_t)strtol(argv[3], nullptr, 0);
+
+				PX4_INFO("Control set to: %d/%d",
+					 g_thread_data->control_data.sysid_primary_control,
+					 g_thread_data->control_data.compid_primary_control);
+
+				return 0;
+
+			} else {
+				PX4_ERR("not enough arguments");
+				usage();
+				return 1;
+			}
+
+		} else {
+			PX4_WARN("not running");
+			usage();
+			return 1;
+		}
+	}
+
 	else if (!strcmp(argv[1], "status")) {
 		if (thread_running.load() && g_thread_data && g_thread_data->test_input) {
 
@@ -421,6 +449,9 @@ int gimbal_main(int argc, char *argv[])
 						g_thread_data->input_objs[i]->print_status();
 					}
 				}
+
+				PX4_INFO("Primary control:   %d/%d",
+					 g_thread_data->control_data.sysid_primary_control, g_thread_data->control_data.compid_primary_control);
 
 			}
 
@@ -544,6 +575,9 @@ $ gimbal test pitch -45 yaw 30
 
 	PRINT_MODULE_USAGE_NAME("gimbal", "driver");
 	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_COMMAND("status");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("primary-control", "Set who is in control of gimbal");
+	PRINT_MODULE_USAGE_ARG("<sysid> <compid>", "MAVLink system ID and MAVLink component ID", false);
 	PRINT_MODULE_USAGE_COMMAND_DESCR("test", "Test the output: set a fixed angle for one or multiple axes (gimbal must be running)");
 	PRINT_MODULE_USAGE_ARG("roll|pitch|yaw <angle>", "Specify an axis and an angle in degrees", false);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();

--- a/src/modules/gimbal/input_mavlink.cpp
+++ b/src/modules/gimbal/input_mavlink.cpp
@@ -376,7 +376,6 @@ void InputMavlinkCmdMount::print_status() const
 InputMavlinkGimbalV2::InputMavlinkGimbalV2(Parameters &parameters) :
 	InputBase(parameters)
 {
-	_stream_gimbal_manager_information();
 }
 
 InputMavlinkGimbalV2::~InputMavlinkGimbalV2()
@@ -454,7 +453,7 @@ void InputMavlinkGimbalV2::_stream_gimbal_manager_status(const ControlData &cont
 		gimbal_manager_status_s gimbal_manager_status{};
 		gimbal_manager_status.timestamp = hrt_absolute_time();
 		gimbal_manager_status.flags = gimbal_device_attitude_status.device_flags;
-		gimbal_manager_status.gimbal_device_id = 0;
+		gimbal_manager_status.gimbal_device_id = control_data.device_compid;
 		gimbal_manager_status.primary_control_sysid = control_data.sysid_primary_control;
 		gimbal_manager_status.primary_control_compid = control_data.compid_primary_control;
 		gimbal_manager_status.secondary_control_sysid = 0; // TODO: support secondary control
@@ -463,7 +462,7 @@ void InputMavlinkGimbalV2::_stream_gimbal_manager_status(const ControlData &cont
 	}
 }
 
-void InputMavlinkGimbalV2::_stream_gimbal_manager_information()
+void InputMavlinkGimbalV2::_stream_gimbal_manager_information(const ControlData &control_data)
 {
 	// TODO: Take gimbal_device_information into account.
 
@@ -483,6 +482,8 @@ void InputMavlinkGimbalV2::_stream_gimbal_manager_information()
 	gimbal_manager_info.pitch_min = -M_PI_F / 2;
 	gimbal_manager_info.yaw_max = M_PI_F;
 	gimbal_manager_info.yaw_min = -M_PI_F;
+
+	gimbal_manager_info.gimbal_device_id = control_data.device_compid;
 
 	_gimbal_manager_info_pub.publish(gimbal_manager_info);
 }
@@ -578,6 +579,11 @@ InputMavlinkGimbalV2::update(unsigned int timeout_ms, ControlData &control_data,
 	}
 
 	_stream_gimbal_manager_status(control_data);
+
+	if (_last_device_compid != control_data.device_compid) {
+		_last_device_compid = control_data.device_compid;
+		_stream_gimbal_manager_information(control_data);
+	}
 
 	return update_result;
 }

--- a/src/modules/gimbal/input_mavlink.h
+++ b/src/modules/gimbal/input_mavlink.h
@@ -114,7 +114,7 @@ private:
 	void _set_control_data_from_set_attitude(ControlData &control_data, const uint32_t flags, const matrix::Quatf &q,
 			const matrix::Vector3f &angular_velocity);
 	void _ack_vehicle_command(const vehicle_command_s &cmd, uint8_t result);
-	void _stream_gimbal_manager_information();
+	void _stream_gimbal_manager_information(const ControlData &control_data);
 	void _stream_gimbal_manager_status(const ControlData &control_data);
 	void _read_control_data_from_position_setpoint_sub(ControlData &control_data);
 
@@ -128,6 +128,8 @@ private:
 	uORB::Publication<gimbal_manager_information_s> _gimbal_manager_info_pub{ORB_ID(gimbal_manager_information)};
 	uORB::Publication<gimbal_manager_status_s> _gimbal_manager_status_pub{ORB_ID(gimbal_manager_status)};
 	uint8_t _cur_roi_mode = vehicle_roi_s::ROI_NONE;
+
+	uint8_t _last_device_compid = 0;
 };
 
 } /* namespace gimbal */

--- a/src/modules/gimbal/output.h
+++ b/src/modules/gimbal/output.h
@@ -55,7 +55,7 @@ public:
 	explicit OutputBase(const Parameters &parameters);
 	virtual ~OutputBase() = default;
 
-	virtual void update(const ControlData &control_data, bool new_setpoints) = 0;
+	virtual void update(ControlData &control_data, bool new_setpoints) = 0;
 
 	virtual void print_status() const = 0;
 

--- a/src/modules/gimbal/output_mavlink.cpp
+++ b/src/modules/gimbal/output_mavlink.cpp
@@ -46,7 +46,7 @@ OutputMavlinkV1::OutputMavlinkV1(const Parameters &parameters)
 	: OutputBase(parameters)
 {}
 
-void OutputMavlinkV1::update(const ControlData &control_data, bool new_setpoints)
+void OutputMavlinkV1::update(ControlData &control_data, bool new_setpoints)
 {
 	vehicle_command_s vehicle_command{};
 	vehicle_command.timestamp = hrt_absolute_time();
@@ -142,7 +142,7 @@ OutputMavlinkV2::OutputMavlinkV2(const Parameters &parameters)
 {
 }
 
-void OutputMavlinkV2::update(const ControlData &control_data, bool new_setpoints)
+void OutputMavlinkV2::update(ControlData &control_data, bool new_setpoints)
 {
 	_check_for_gimbal_device_information();
 
@@ -161,6 +161,8 @@ void OutputMavlinkV2::update(const ControlData &control_data, bool new_setpoints
 			_handle_position_update(control_data);
 			_last_update = t;
 		}
+
+		control_data.device_compid = _gimbal_device_found ? _gimbal_device_compid : 0;
 
 		_publish_gimbal_device_set_attitude();
 	}
@@ -206,6 +208,13 @@ void OutputMavlinkV2::print_status() const
 		     (double)_angle_velocity[0],
 		     (double)_angle_velocity[1],
 		     (double)_angle_velocity[2]);
+
+	if (_gimbal_device_found) {
+		PX4_INFO_RAW("  gimbal device compid found: %d\n", _gimbal_device_compid);
+
+	} else {
+		PX4_INFO_RAW("  gimbal device compid not found\n");
+	}
 }
 
 void OutputMavlinkV2::_publish_gimbal_device_set_attitude()

--- a/src/modules/gimbal/output_mavlink.h
+++ b/src/modules/gimbal/output_mavlink.h
@@ -51,7 +51,7 @@ public:
 	OutputMavlinkV1(const Parameters &parameters);
 	virtual ~OutputMavlinkV1() = default;
 
-	virtual void update(const ControlData &control_data, bool new_setpoints);
+	virtual void update(ControlData &control_data, bool new_setpoints);
 
 	virtual void print_status() const;
 
@@ -69,7 +69,7 @@ public:
 	OutputMavlinkV2(const Parameters &parameters);
 	virtual ~OutputMavlinkV2() = default;
 
-	virtual void update(const ControlData &control_data, bool new_setpoints);
+	virtual void update(ControlData &control_data, bool new_setpoints);
 
 	virtual void print_status() const;
 

--- a/src/modules/gimbal/output_rc.cpp
+++ b/src/modules/gimbal/output_rc.cpp
@@ -48,7 +48,7 @@ OutputRC::OutputRC(const Parameters &parameters)
 {
 }
 
-void OutputRC::update(const ControlData &control_data, bool new_setpoints)
+void OutputRC::update(ControlData &control_data, bool new_setpoints)
 {
 	if (new_setpoints) {
 		_retract_gimbal = control_data.gimbal_shutter_retract;
@@ -61,6 +61,9 @@ void OutputRC::update(const ControlData &control_data, bool new_setpoints)
 	_calculate_angle_output(t);
 
 	_stream_device_attitude_status();
+
+	// If the output is RC, then it means we are also the gimbal device.
+	control_data.device_compid = (uint8_t)_parameters.mnt_mav_compid_v1;
 
 	// _angle_outputs are in radians, gimbal_controls are in [-1, 1]
 	gimbal_controls_s gimbal_controls{};

--- a/src/modules/gimbal/output_rc.cpp
+++ b/src/modules/gimbal/output_rc.cpp
@@ -60,30 +60,42 @@ void OutputRC::update(ControlData &control_data, bool new_setpoints)
 	hrt_abstime t = hrt_absolute_time();
 	_calculate_angle_output(t);
 
-	_stream_device_attitude_status();
-
 	// If the output is RC, then it means we are also the gimbal device.
 	control_data.device_compid = (uint8_t)_parameters.mnt_mav_compid_v1;
 
 	// _angle_outputs are in radians, gimbal_controls are in [-1, 1]
 	gimbal_controls_s gimbal_controls{};
-	gimbal_controls.control[gimbal_controls_s::INDEX_ROLL] = constrain(
-				(_angle_outputs[0] + math::radians(_parameters.mnt_off_roll)) *
-				(1.0f / (math::radians(_parameters.mnt_range_roll / 2.0f))),
-				-1.f, 1.f);
-	gimbal_controls.control[gimbal_controls_s::INDEX_PITCH] = constrain(
-				(_angle_outputs[1] + math::radians(_parameters.mnt_off_pitch)) *
-				(1.0f / (math::radians(_parameters.mnt_range_pitch / 2.0f))),
-				-1.f, 1.f);
-	gimbal_controls.control[gimbal_controls_s::INDEX_YAW] = constrain(
-				(_angle_outputs[2] + math::radians(_parameters.mnt_off_yaw)) *
-				(1.0f / (math::radians(_parameters.mnt_range_yaw / 2.0f))),
-				-1.f, 1.f);
+	auto roll_limit = math::radians(_parameters.mnt_range_roll / 2.0f);
+	auto roll = (_angle_outputs[0] + math::radians(_parameters.mnt_off_roll)) * (1.0f / roll_limit);
+	if (roll < -1.0f) {
+		_angle_outputs[0] = -roll_limit;
+	} else if (roll > 1.0f) {
+		_angle_outputs[0] = roll_limit;
+	}
+	gimbal_controls.control[gimbal_controls_s::INDEX_ROLL] = constrain(roll, -1.f, 1.f);
+	auto pitch_limit = math::radians(_parameters.mnt_range_pitch / 2.0f);
+	auto pitch = (_angle_outputs[1] + math::radians(_parameters.mnt_off_pitch)) * (1.0f / pitch_limit);
+	if (pitch < -1.0f) {
+		_angle_outputs[1] = -pitch_limit;
+	} else if (pitch > 1.0f) {
+		_angle_outputs[1] = pitch_limit;
+	}
+	gimbal_controls.control[gimbal_controls_s::INDEX_PITCH] = constrain(pitch, -1.f, 1.f);
+	auto yaw_limit = math::radians(_parameters.mnt_range_yaw / 2.0f);
+	auto yaw = (_angle_outputs[2] + math::radians(_parameters.mnt_off_yaw)) * (1.0f / yaw_limit);
+	if (yaw < -1.0f) {
+		_angle_outputs[2] = -yaw_limit;
+	} else if (yaw > 1.0f) {
+		_angle_outputs[2] = yaw_limit;
+	}
+	gimbal_controls.control[gimbal_controls_s::INDEX_YAW] = constrain(yaw, -1.f, 1.f);
 	gimbal_controls.retract_gimbal = constrain(
 			_retract_gimbal ? _parameters.mnt_ob_lock_mode : _parameters.mnt_ob_norm_mode,
 			-1.f, 1.f);
 	gimbal_controls.timestamp = hrt_absolute_time();
 	_gimbal_controls_pub.publish(gimbal_controls);
+	
+	_stream_device_attitude_status();
 
 	_last_update = t;
 }
@@ -106,6 +118,20 @@ void OutputRC::_stream_device_attitude_status()
 
 	matrix::Eulerf euler(_angle_outputs[0], _angle_outputs[1], _angle_outputs[2]);
 	matrix::Quatf q(euler);
+
+	// Adjust the angles if stabilization is being applied to represent the gimbal attitude in earth frame
+	// to comply with Mavlink 2 GIMBAL_DEVICE_ATTITUDE_STATUS definition
+	vehicle_attitude_s vehicle_attitude;
+	matrix::Eulerf euler_vehicle{};
+	if (_vehicle_attitude_sub.copy(&vehicle_attitude)) {
+		euler_vehicle = matrix::Quatf(vehicle_attitude.q);
+	}
+	const matrix::Quatf q_vehicle(matrix::Eulerf(
+		(_stabilize[0]) ? euler_vehicle(0) : 0.0f, 
+		(_stabilize[1]) ? euler_vehicle(1) : 0.0f, 
+		(_stabilize[2]) ? euler_vehicle(2) : 0.0f));
+	q = q_vehicle * q;
+
 	q.copyTo(attitude_status.q);
 
 	attitude_status.failure_flags = 0;

--- a/src/modules/gimbal/output_rc.cpp
+++ b/src/modules/gimbal/output_rc.cpp
@@ -68,11 +68,11 @@ void OutputRC::update(const ControlData &control_data, bool new_setpoints)
 				(_angle_outputs[0] + math::radians(_parameters.mnt_off_roll)) *
 				(1.0f / (math::radians(_parameters.mnt_range_roll / 2.0f))),
 				-1.f, 1.f);
-	gimbal_controls.control[gimbal_controls_s::INDEX_ROLL] = constrain(
+	gimbal_controls.control[gimbal_controls_s::INDEX_PITCH] = constrain(
 				(_angle_outputs[1] + math::radians(_parameters.mnt_off_pitch)) *
 				(1.0f / (math::radians(_parameters.mnt_range_pitch / 2.0f))),
 				-1.f, 1.f);
-	gimbal_controls.control[gimbal_controls_s::INDEX_ROLL] = constrain(
+	gimbal_controls.control[gimbal_controls_s::INDEX_YAW] = constrain(
 				(_angle_outputs[2] + math::radians(_parameters.mnt_off_yaw)) *
 				(1.0f / (math::radians(_parameters.mnt_range_yaw / 2.0f))),
 				-1.f, 1.f);

--- a/src/modules/gimbal/output_rc.h
+++ b/src/modules/gimbal/output_rc.h
@@ -50,7 +50,7 @@ public:
 	explicit OutputRC(const Parameters &parameters);
 	virtual ~OutputRC() = default;
 
-	virtual void update(const ControlData &control_data, bool new_setpoints);
+	virtual void update(ControlData &control_data, bool new_setpoints);
 	virtual void print_status() const;
 
 private:

--- a/src/modules/gimbal/output_rc.h
+++ b/src/modules/gimbal/output_rc.h
@@ -55,6 +55,7 @@ public:
 
 private:
 	void _stream_device_attitude_status();
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
 
 	uORB::Publication <gimbal_controls_s>	_gimbal_controls_pub{ORB_ID(gimbal_controls)};
 	uORB::Publication <gimbal_device_attitude_status_s>	_attitude_status_pub{ORB_ID(gimbal_device_attitude_status)};

--- a/src/modules/mavlink/streams/GIMBAL_MANAGER_INFORMATION.hpp
+++ b/src/modules/mavlink/streams/GIMBAL_MANAGER_INFORMATION.hpp
@@ -71,7 +71,7 @@ private:
 
 			msg.time_boot_ms = gimbal_manager_information.timestamp / 1000;
 			msg.cap_flags = gimbal_manager_information.cap_flags;
-			msg.gimbal_device_id = 0;
+			msg.gimbal_device_id = gimbal_manager_information.gimbal_device_id;
 			msg.roll_min = gimbal_manager_information.roll_min;
 			msg.roll_max = gimbal_manager_information.roll_max;
 			msg.pitch_min = gimbal_manager_information.pitch_min;


### PR DESCRIPTION
### Solved Problem
I was doing some surveying flights with an RC gimbal and realized that the attitude reported by the camera_capture and gimbal_attitude mavlink messages were wrong, going into the code I realized that it was not accounting for the mount limits or the stabilization in case of servo gimbals. This PR fixes both.

Fixes #{Github issue ID}

### Solution
-I added checks for the limits and adjust the output angles accordingly, before reporting them out.
-I also do a check for stabilization and apply the rotations accordingly to offset for the vehicle orientation.

### Changelog Entry
For release notes:
```
Bugfix: Fix attitude reported by rc gimbal
```

### Test coverage
- In flight testing, logs were too big to upload.
