### PR TITLE
ARK RTK GPS support baro on I2C bus 1 instead of 2

### DIFF
--- a/boards/ark/can-rtk-gps/init/rc.board_sensors
+++ b/boards/ark/can-rtk-gps/init/rc.board_sensors
@@ -6,6 +6,9 @@ gps start -d /dev/ttyS0 -p ubx
 
 icm42688p -R 0 -s start
 
-bmp388 -I -b 2 start
+if ! bmp388 -I -b 2 start
+then
+	bmp388 -I -b 1 start
+fi
 
 bmm150 -I -b 1 start


### PR DESCRIPTION
This PR adds support for running the barometer on the ARK RTK GPS on bus 1 instead of 2.