### PR TITLE
px4-rc.simulator: set Gazebo coordinate frame reference (SIM_GZ_HOME_…

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -38,6 +38,19 @@ if [ "$PX4_SIMULATOR" = "sihsim" ] || [ "$(param show -q SYS_AUTOSTART)" -eq "0"
 
 elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" -eq "1" ]; then
 
+	# set local coordinate frame reference
+	if [ -n "${PX4_HOME_LAT}" ]; then
+		param set SIM_GZ_HOME_LAT ${PX4_HOME_LAT}
+	fi
+
+	if [ -n "${PX4_HOME_LON}" ]; then
+		param set SIM_GZ_HOME_LON ${PX4_HOME_LON}
+	fi
+
+	if [ -n "${PX4_HOME_ALT}" ]; then
+		param set SIM_GZ_HOME_ALT ${PX4_HOME_LON}
+	fi
+
 	# source generated gz_env.sh for GZ_SIM_RESOURCE_PATH
 	if [ -f ./gz_env.sh ]; then
 		. ./gz_env.sh


### PR DESCRIPTION
…* params) from PX4_HOME_* env variables

Enables setting the PX4 local frame reference at specified global position. This results in reporting drone's GPS position based on PX4_HOME_* env variables, as it worked in previous versions before gz garden.

If env variables PX4_HOME_LAT, PX4_HOME_LON, PX4_HOME_ALT are set, SIM_GZ_HOME_LAT, SIM_GZ_HOME_LON, SIM_GZ_HOME_ALT will be set to match those env variables.

SensorGpsSim uses SIM_GZ_HOME_LAT/LON global point to compute the gps position of the drone based on this point as reference and ground truth local position. When the drone is spawned, assuming PX4_GZ_MODEL_POSE is not set, it will have local coordinates of 0, 0, 0, which would be transformed into GPS position (SIM_GZ_HOME_LAT, SIM_GZ_HOME_LON, SIM_GZ_HOME_ALT).

To use this, before running the simulation, set env variables:
```
export PX4_HOME_LAT=12.3456789
export PX4_HOME_LON=12.3456789
export PX4_HOME_ALT=123.456
```
then
`make px4_sitl gz_x500`