### PR TITLE
add pca9685 parameter again

### DIFF
--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -133,6 +133,15 @@ int PCA9685Wrapper::init()
 		return ret;
 	}
 
+	param_t param_h = param_find("PCA9685_RATE");
+
+	if (param_h != PARAM_INVALID) {
+		param_get(param_h, &_targetFreq);
+
+	} else {
+		PX4_DEBUG("PARAM_INVALID: PCA9685_RATE");
+	}
+
 	this->ChangeWorkQueue(px4::device_bus_to_wq(pca9685->get_device_id()));
 
 	PX4_INFO("running on I2C bus %d address 0x%.2x", pca9685->get_device_bus(), pca9685->get_device_address());

--- a/src/drivers/pca9685_pwm_out/module.yaml
+++ b/src/drivers/pca9685_pwm_out/module.yaml
@@ -9,3 +9,19 @@ actuator_output:
         max: { min: 1600, max: 2200, default: 2000 }
         failsafe: { min: 800, max: 2200 }
       num_channels: 16
+parameters:
+    - group: PCA9685
+      definitions:
+        PCA9685_RATE:
+            description:
+                short: PWM frequency for PCA9685
+                long: |
+                    Update rate at which the PWM signal is sent to the ESC.
+            type: float
+            decimal: 1
+            increment: 0.1
+            default: 50
+            min: 50
+            max: 450
+            unit: Hz
+            reboot_required: true


### PR DESCRIPTION
### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/21929 for `beta` branch.

Fixes #21929

### Solution
Add parameter `PCA9685_RATE` again to set `_targetFreq`.

### Changelog Entry
For release notes:
```
Feature/Bugfix add parameter PCA9685_RATE as a replacement for removed PWM_MAIN_RATE again
New parameter: PCA9685_RATE
```

### Test coverage
Tested with PCA9685 breakout board.
