### PR TITLE
uxrce add manual control setpoint subscriber and battery status publisher

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -87,6 +87,9 @@ subscriptions:
   - topic: /fmu/in/config_control_setpoints
     type: px4_msgs::msg::VehicleControlMode
 
+  - topic: /fmu/in/manual_control_input
+    type: px4_msgs::msg::ManualControlSetpoint
+
   - topic: /fmu/in/offboard_control_mode
     type: px4_msgs::msg::OffboardControlMode
 

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -14,6 +14,9 @@ publications:
   - topic: /fmu/out/mode_completed
     type: px4_msgs::msg::ModeCompleted
 
+  - topic: /fmu/out/battery_status
+    type: px4_msgs::msg::BatteryStatus
+
   - topic: /fmu/out/collision_constraints
     type: px4_msgs::msg::CollisionConstraints
 


### PR DESCRIPTION
@bradenwagstaff is working on controlling a rover through uxrce and manual_control_setpoint is needed.