### PR TITLE
skip SSH key check for simpler builds in the Docker container

### DIFF
--- a/boards/px4/raspberrypi/cmake/upload.cmake
+++ b/boards/px4/raspberrypi/cmake/upload.cmake
@@ -38,7 +38,7 @@ else()
 endif()
 
 add_custom_target(upload
-	COMMAND rsync -arh --progress
+	COMMAND rsync -arh --progress -e "ssh -o StrictHostKeyChecking=no"
 			${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_BINARY_DIR}/etc # source
 			pi@${AUTOPILOT_HOST}:/home/pi/px4 # destination
 	DEPENDS px4


### PR DESCRIPTION
### Solved Problem
Backport of https://github.com/PX4/PX4-Autopilot/pull/21940/commits/a527a94f7c86b335987bff20dc2d6765b57c27a5 to stable.

### Changelog Entry
For release notes:
See https://github.com/PX4/PX4-Autopilot/pull/21940
