### PR TITLE
fix PCA9685 character device

### DIFF
--- a/src/drivers/pca9685_pwm_out/main.cpp
+++ b/src/drivers/pca9685_pwm_out/main.cpp
@@ -121,7 +121,7 @@ protected:
 };
 
 PCA9685Wrapper::PCA9685Wrapper(int schd_rate_limit) :
-	CDev(nullptr),
+	CDev(PWM_OUTPUT_BASE_DEVICE_PATH),
 	OutputModuleInterface(MODULE_NAME, px4::wq_configurations::hp_default),
 	_cycle_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")),
 	_schd_rate_limit(schd_rate_limit)


### PR DESCRIPTION
### Solved Problem
Starting the PCA9685 driver fails as CDev is set to nullptr.

### Solution
Set it to the default `"/dev/pwm_out"`.

### Changelog Entry
For release notes:
```
Feature/Bugfix fix character device for PCA9685
```

### Test coverage
PCA9685 breakout board via I2C.
