### PR TITLE
linux_pwm_out must link mixer_module

### DIFF
--- a/src/drivers/linux_pwm_out/CMakeLists.txt
+++ b/src/drivers/linux_pwm_out/CMakeLists.txt
@@ -40,5 +40,5 @@ px4_add_module(
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS
+		mixer_module
 	)
-


### PR DESCRIPTION
### Solved Problem
Backport of https://github.com/PX4/PX4-Autopilot/pull/21137.

### Changelog Entry
For release notes:
```
Feature/Bugfix fix linking of linux_pwm_out
```

### Test coverage
Build with custom linux_pwm_out implementation.
