### PR TITLE
Fix maximum rotation value in GetBoardRotation()

### DIFF
--- a/src/lib/sensor_calibration/Utilities.cpp
+++ b/src/lib/sensor_calibration/Utilities.cpp
@@ -222,7 +222,7 @@ enum Rotation GetBoardRotation()
 	int32_t board_rot = -1;
 	param_get(param_find("SENS_BOARD_ROT"), &board_rot);
 
-	if (board_rot >= 0 && board_rot <= Rotation::ROTATION_MAX) {
+	if (board_rot >= 0 && board_rot < Rotation::ROTATION_MAX) {
 		return static_cast<enum Rotation>(board_rot);
 
 	} else {


### PR DESCRIPTION
This is a minor issue found in static code analysis:

Fix a memory overflow in case SENS_BOARD_ROT is set to Rotation::ROTATION_MAX (41) which is not a valid value
