### PR TITLE
blockingqueue.hpp: Fix sem_wait not blocking if task is signaled

### DIFF
--- a/src/include/containers/BlockingQueue.hpp
+++ b/src/include/containers/BlockingQueue.hpp
@@ -56,7 +56,7 @@ public:
 
 	void push(T newItem)
 	{
-		px4_sem_wait(&_sem_head);
+		do {} while (px4_sem_wait(&_sem_head) != 0);
 
 		_data[_tail] = newItem;
 		_tail = (_tail + 1) % N;
@@ -66,7 +66,7 @@ public:
 
 	T pop()
 	{
-		px4_sem_wait(&_sem_tail);
+		do {} while (px4_sem_wait(&_sem_tail) != 0);
 
 		T ret = _data[_head];
 		_head = (_head + 1) % N;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
sem_wait() can be interrupted if the process receives a signal, however the queue implementation assumes the caller blocks on the barrier until something is posted in the queue, which means the call to px4_sem_wait() should loop until the return value is OK (not -EINTR).

Work queue manager is affected, when this happens multiple instances of the same work queue are started.

### Solution
Fix the simple bug

### Test coverage
Verify the issue does not happen any more
