### PR TITLE
Matek H743 Slim: Add BOARD_ADC macros to support system_power uORB pub

### DIFF
--- a/boards/matek/h743-slim/src/board_config.h
+++ b/boards/matek/h743-slim/src/board_config.h
@@ -142,6 +142,15 @@
 
 #define GPIO_OTGFS_VBUS         /* PE2 */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_SPEED_100MHz|GPIO_PORTE|GPIO_PIN2)
 
+/* By Providing BOARD_ADC_USB_CONNECTED (using the px4_arch abstraction)
+ * this board support the ADC system_power interface, and therefore
+ * provides the true logic GPIO BOARD_ADC_xxxx macros.
+ */
+#define BOARD_ADC_USB_CONNECTED (px4_arch_gpioread(GPIO_OTGFS_VBUS)) // This enables publishing of sysetm_power topic
+#define BOARD_ADC_BRICK_VALID   (1)
+#define BOARD_ADC_SERVO_VALID   (1)  /* never powers off the Servo rail */
+#define BOARD_ADC_PERIPH_5V_OC  (0)
+#define BOARD_ADC_HIPOWER_5V_OC (0)
 
 /* High-resolution timer */
 #define HRT_TIMER               2  /* use timer8 for the HRT */


### PR DESCRIPTION
## About
Since we have USB connected check pin, we can enable the ADC_USB_CONNECTED macro to read the status whether USB is connected.

Other parts such as brick, servo, periph, hipower are arbitrarily set (copied from Airmind MindPX v2), and hence may need to change

### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/19814

### Changelog Entry
For release notes:
```
Matek H743-Slim: Enabled USB Connected check
```

## Notes
It seems that the fact that `system_power` topic is only published when we have that USB_CONNECTED GPIO pin defined is a bit weird:
https://github.com/PX4/PX4-Autopilot/blob/c0084ab24d9f5993ce4dea28e0aed85747d8a959/src/drivers/adc/board_adc/ADC.cpp#L196-L200

And the other parts of the SystemPower uORB topic seems a bit vague & the concept of 'brick' in ADC seems confusing, so that part may need to be redefined:
https://github.com/PX4/PX4-Autopilot/blob/c0084ab24d9f5993ce4dea28e0aed85747d8a959/msg/SystemPower.msg#L2-L12