### PR TITLE
ARK Jetson Carrier support 3rd power module

### DIFF
--- a/boards/ark/fmu-v6x/init/rc.board_sensors
+++ b/boards/ark/fmu-v6x/init/rc.board_sensors
@@ -3,10 +3,12 @@
 # ARK FMUARKV6X specific board sensors init
 #------------------------------------------------------------------------------
 set HAVE_PM2 yes
+set HAVE_PM3 yes
 
 if ver hwtypecmp ARKV6X005000 ARKV6X005001 ARKV6X005002 ARKV6X005003 ARKV6X005004
 then
 	set HAVE_PM2 no
+	set HAVE_PM3 no
 fi
 
 if param compare -s ADC_ADS1115_EN 1
@@ -25,15 +27,26 @@ then
 	then
 		ina226 -X -b 2 -t 2 -k start
 	fi
+
+	if [ $HAVE_PM3 = yes ]
+	then
+		ina226 -X -b 3 -t 2 -k start
+	fi
 fi
 
 if param compare SENS_EN_INA228 1
 then
 	# Start Digital power monitors
 	ina228 -X -b 1 -t 1 -k start
+
 	if [ $HAVE_PM2 = yes ]
 	then
 		ina228 -X -b 2 -t 2 -k start
+	fi
+
+	if [ $HAVE_PM3 = yes ]
+	then
+		ina228 -X -b 3 -t 2 -k start
 	fi
 fi
 
@@ -41,9 +54,15 @@ if param compare SENS_EN_INA238 1
 then
 	# Start Digital power monitors
 	ina238 -X -b 1 -t 1 -k start
+
 	if [ $HAVE_PM2 = yes ]
 	then
 		ina238 -X -b 2 -t 2 -k start
+	fi
+
+	if [ $HAVE_PM3 = yes ]
+	then
+		ina238 -X -b 3 -t 2 -k start
 	fi
 fi
 
@@ -63,3 +82,4 @@ bmm150 -I start
 bmp388 -I start
 
 unset HAVE_PM2
+unset HAVE_PM3


### PR DESCRIPTION
This PR adds support for a 3rd power module input on the ARKV6X which is present on the ARK Jetson PAB Carrier.