### PR TITLE
multiple: Fix abs(int) usage on float values

### DIFF
--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -231,7 +231,7 @@ void Heater::Run()
 
 		_controller_time_on_usec = math::constrain(_controller_time_on_usec, 0, _controller_period_usec);
 
-		if (abs(temperature_delta) < TEMPERATURE_TARGET_THRESHOLD) {
+		if (fabsf(temperature_delta) < TEMPERATURE_TARGET_THRESHOLD) {
 			_temperature_target_met = true;
 
 		} else {

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -249,7 +249,7 @@ build_gps_response(uint8_t *buffer, size_t *size)
 
 		if (lat < 0) {
 			msg.latitude_ns = 1;
-			lat = abs(lat);
+			lat = fabs(lat);
 		}
 
 		int deg;

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -159,7 +159,7 @@ GeofenceBreachAvoidance::generateLoiterPointForMultirotor(geofence_violation_typ
 		Vector2d test_point;
 
 		// binary search for the distance from the drone to the geofence in the given direction
-		while (abs(current_max - current_min) > 0.5f) {
+		while (fabsf(current_max - current_min) > 0.5f) {
 			test_point = waypointFromBearingAndDistance(_current_pos_lat_lon, _test_point_bearing, current_distance);
 
 			if (!geofence->isInsidePolygonOrCircle(test_point(0), test_point(1), _current_alt_amsl)) {


### PR DESCRIPTION
### Solved Problem
Resolves https://github.com/PX4/PX4-Autopilot/issues/21924

### Solution
Solves incorrect usage of abs. See https://github.com/PX4/PX4-Autopilot/issues/21924 for details

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Solves incorrect usage of abs
```

### Alternatives
N/A

### Test coverage
- Unit/integration test: All tests still pass
- Simulation/hardware testing logs: None

### Context
I realized that using abs() on float values casts them to int, which caused problems in some code I was working on. While searching through the code I realized that there were 3 places abs is currently being used on float values which can cause problems/inaccuracies.  I don't have a setup to test these changes, so I have not tested it beyond verifying that no tests fail.
