### PR TITLE
ucans32K146: fix pwm startup

### DIFF
--- a/boards/nxp/ucans32k146/init/rc.board_defaults
+++ b/boards/nxp/ucans32k146/init/rc.board_defaults
@@ -3,7 +3,7 @@
 # board specific defaults
 #------------------------------------------------------------------------------
 
-pwm_out mode_pwm1 start
+pwm_out start
 
 ifup can0
 


### PR DESCRIPTION
I think the mixer/pwm changes missed the ucans32k146 where pwm wasn't working because the arguments were invalid.
This PR updates start command so that PWM works again