### PR TITLE
FixedWingPosControl: Handle waypoint type LAND for VTOL

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -401,6 +401,8 @@ private:
 	matrix::Vector2d _transition_waypoint{(double)NAN, (double)NAN};
 	param_t _param_handle_airspeed_trans{PARAM_INVALID};
 	float _param_airspeed_trans{NAN}; // [m/s]
+	param_t _param_handle_force_vtol{PARAM_INVALID};
+	bool _param_force_vtol{true};
 
 	// ESTIMATOR RESET COUNTERS
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1019,7 +1019,6 @@ Mission::set_mission_items()
 
 					_mission_item.altitude = altitude;
 					_mission_item.altitude_is_relative = false;
-					_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 					_mission_item.autocontinue = true;
 					_mission_item.time_inside = 0.0f;
 					_mission_item.vtol_back_transition = true;


### PR DESCRIPTION

### Solved Problem
Until now the navigator was hiding LAND type setpoints from the fixed wing position controller for VTOL_LAND items.
It published the wayoint as a normal position waypoint which made the position controller unaware of an impending transition. Furthermore, navigator internally set the altitude acceptance radius for a VTOL_LAND item to infinity (don't care about altitude) while the position controller was still using the default fixed wing altitude acceptance radius. In the worst case this causes the position controller to initiate a loiter during the approach to the land waypoint when the altitude error exceeded the threshold defined by the acceptance value.


Fixes #{Github issue ID}

### Solution
It makes more sense to make the position controller aware of the setpoint type. This allows the position controller to take actions depending on the setpoint type (e.g. never loiter to recover altitude during the approach to a land waypoint.)

### Changelog Entry
For release notes:
Fixed issues where fixed wing position controller could instantiate a loiter when approaching a VTOL_LAND waypoint.
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives


### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
