### PR TITLE
commander_params: more precise COM_FAIL_ACT_T description

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -262,8 +262,8 @@ PARAM_DEFINE_INT32(COM_LOW_BAT_ACT, 0);
  *
  * Before entering failsafe (RTL, Land, Hold), wait COM_FAIL_ACT_T seconds in Hold mode
  * for the user to realize.
- * During that time the user cannot take over control.
- * Afterwards the configured failsafe action is triggered and the user may take over.
+ * During that time the user cannot take over control via the stick override feature see COM_RC_OVERRIDE.
+ * Afterwards the configured failsafe action is triggered and the user may use stick override.
  *
  * A zero value disables the delay and the user cannot take over via stick movements (switching modes is still allowed).
  *


### PR DESCRIPTION
### Solved Problem
Found thanks to @sfuhrer 's question:
> In the param description is says "During that time the user cannot take over control." I guess that refers to "not able to manually override using the sticks"? But taking over control by switching the flight mode is completely fine, right? Can we adapt the param description if that's the case?

### Solution
Be more clear that the override by stick is not possible during the failsafe action delay. The mode RC switch and mode siwtch commands allow any other kind of takeover.

### Changelog Entry
```
Documentation: Clarify COM_FAIL_ACT_T description
```