### PR TITLE
escCheck: only warn if param for ESC checks is enabeld

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/escCheck.cpp
@@ -77,7 +77,8 @@ void EscChecks::checkAndReport(const Context &context, Report &reporter)
 
 	esc_status_s esc_status;
 
-	if (_esc_status_sub.copy(&esc_status) && now - esc_status.timestamp < esc_telemetry_timeout) {
+	if (_param_escs_checks_required.get() && _esc_status_sub.copy(&esc_status)
+	    && now - esc_status.timestamp < esc_telemetry_timeout) {
 
 		checkEscStatus(context, reporter, esc_status);
 		reporter.setIsPresent(health_component_t::motors_escs);


### PR DESCRIPTION


### Solved Problem
Currently the ESC preflight checks are always run, also when COM_ARM_CHK_ESCS is not set to enabled. COM_ARM_CHK_ESCS only has an effect on whether there is a warning published when there is no ESC feedback. 


### Changelog Entry
For release notes:
```
Bugfix: Do not run ESC checks if COM_ARM_CHK_ESCS is set to disabled.
```
