### PR TITLE
TiltrotorEffectiveness: limit thrust axis tilt to z effectiveness scaling

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -148,6 +148,17 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 				_last_collective_tilt_control = control_collective_tilt;
 			}
 
+			// During transition to FF, only allow update thrust axis up to 45° as with a high tilt angle the effectiveness
+			// of the thrust axis in z is apporaching 0, and by that is increasing the motor output to max.
+			// Transition to HF: disable thrust axis tilting, and assume motors are vertical. This is to avoid
+			// a thrust spike when the transition is initiated (as then the tilt is fully forward).
+			if (_flight_phase == FlightPhase::TRANSITION_HF_TO_FF) {
+				_last_collective_tilt_control = math::constrain(_last_collective_tilt_control, -1.f, 0.f);
+
+			} else if (_flight_phase == FlightPhase::TRANSITION_FF_TO_HF) {
+				_last_collective_tilt_control = -1.f;
+			}
+
 			bool yaw_saturated_positive = true;
 			bool yaw_saturated_negative = true;
 


### PR DESCRIPTION

### Solved Problem
Two related issues and fixes:
- During transition to FW, only allow update thrust axis up to 45° as with a high tilt angle the effectiveness of the thrust axis in z is approaching 0, and by that is increasing the motor output to max. As the vehicle picks up airspeed during the transition and with that the wings start to generate lift, it is not required to produce the same about of vertical thrust as in pure hover.
- Transition to HF: disable thrust axis tilting, and assume motors are vertical. This is to avoid a thrust spike when the transition is initiated (as then the tilt is fully forward). 

Before this PR (notice the thrust spikes when the vehicle is still in transition phases with the collective tilt being almost at horizontal):
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/1822cee0-eca4-4874-b85a-d2a72aaf423b)

After this PR (note how the thrust spikes during front transition are reduced, and completely gone during the backtransition):
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/e4247e5e-fede-4bd7-82a9-cfd8cb2f215c)

### Changelog Entry
For release notes:
```
Bugfix: VTOL tiltrotor: limit the thrust compensation due to non-vertical motors in transition phases.
```


### Test coverage
Flight tested.
