### PR TITLE
Tiltrotor: move spin up tilt to control allocation

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -48,8 +48,19 @@ ActuatorEffectivenessTiltrotorVTOL::ActuatorEffectivenessTiltrotorVTOL(ModulePar
 	  _mc_rotors(this, ActuatorEffectivenessRotors::AxisConfiguration::Configurable, true),
 	  _control_surfaces(this), _tilts(this)
 {
+	_param_handles.com_spoolup_time = param_find("COM_SPOOLUP_TIME");
+
+	updateParams();
 	setFlightPhase(FlightPhase::HOVER_FLIGHT);
 }
+
+void ActuatorEffectivenessTiltrotorVTOL::updateParams()
+{
+	ModuleParams::updateParams();
+
+	param_get(_param_handles.com_spoolup_time, &_param_spoolup_time);
+}
+
 bool
 ActuatorEffectivenessTiltrotorVTOL::getEffectivenessMatrix(Configuration &configuration,
 		EffectivenessUpdateReason external_update)
@@ -230,5 +241,5 @@ bool ActuatorEffectivenessTiltrotorVTOL::throttleSpoolupFinished()
 		_armed_time = vehicle_status.armed_time;
 	}
 
-	return _armed && hrt_elapsed_time(&_armed_time) > 1_s;
+	return _armed && hrt_elapsed_time(&_armed_time) > _param_spoolup_time * 1_s;
 }

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -48,7 +48,7 @@
 
 #include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/tiltrotor_extra_controls.h>
-
+#include <uORB/topics/vehicle_status.h>
 #include <uORB/Subscription.hpp>
 
 class ActuatorEffectivenessTiltrotorVTOL : public ModuleParams, public ActuatorEffectiveness
@@ -111,4 +111,11 @@ protected:
 	YawTiltSaturationFlags _yaw_tilt_saturation_flags{};
 
 	uORB::Subscription _tiltrotor_extra_controls_sub{ORB_ID(tiltrotor_extra_controls)};
+
+private:
+	// Tilt handling during motor spoolup: leave the tilts in their disarmed position unitil 1s after arming
+	bool throttleSpoolupFinished();
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	bool _armed{false};
+	uint64_t _armed_time{0};
 };

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -46,6 +46,8 @@
 #include "ActuatorEffectivenessControlSurfaces.hpp"
 #include "ActuatorEffectivenessTilts.hpp"
 
+#include <px4_platform_common/module_params.h>
+
 #include <uORB/topics/normalized_unsigned_setpoint.h>
 #include <uORB/topics/tiltrotor_extra_controls.h>
 #include <uORB/topics/vehicle_status.h>
@@ -113,6 +115,17 @@ protected:
 	uORB::Subscription _tiltrotor_extra_controls_sub{ORB_ID(tiltrotor_extra_controls)};
 
 private:
+
+	void updateParams() override;
+
+	struct ParamHandles {
+		param_t com_spoolup_time;
+	};
+
+	ParamHandles _param_handles{};
+
+	float _param_spoolup_time{1.f};
+
 	// Tilt handling during motor spoolup: leave the tilts in their disarmed position unitil 1s after arming
 	bool throttleSpoolupFinished();
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -43,7 +43,6 @@
 #include "vtol_att_control_main.h"
 
 using namespace matrix;
-using namespace time_literals;
 
 #define FRONTTRANS_THR_MIN 0.25f
 #define BACKTRANS_THROTTLE_DOWNRAMP_DUR_S 0.5f
@@ -182,44 +181,8 @@ void Tiltrotor::update_mc_state()
 {
 	VtolType::update_mc_state();
 
-	/*Motor spin up: define the first second after arming as motor spin up time, during which
-	* the tilt is set to the value of VT_TILT_SPINUP. This allows the user to set a spin up
-	* tilt angle in case the propellers don't spin up smoothly in full upright (MC mode) position.
-	*/
-
-	const int spin_up_duration_p1 = 1000_ms; // duration of 1st phase of spinup (at fixed tilt)
-	const int spin_up_duration_p2 = 700_ms; // duration of 2nd phase of spinup (transition from spinup tilt to mc tilt)
-
-	// reset this timestamp while disarmed
-	if (!_v_control_mode->flag_armed) {
-		_last_timestamp_disarmed = hrt_absolute_time();
-		_tilt_motors_for_startup = _param_vt_tilt_spinup.get() > 0.01f; // spinup phase only required if spinup tilt > 0
-
-	} else if (_tilt_motors_for_startup) {
-		// leave motors tilted forward after arming to allow them to spin up easier
-		if (hrt_absolute_time() - _last_timestamp_disarmed > (spin_up_duration_p1 + spin_up_duration_p2)) {
-			_tilt_motors_for_startup = false;
-		}
-	}
-
-	if (_tilt_motors_for_startup) {
-		if (hrt_absolute_time() - _last_timestamp_disarmed < spin_up_duration_p1) {
-			_tilt_control = _param_vt_tilt_spinup.get();
-
-		} else {
-			// duration phase 2: begin to adapt tilt to multicopter tilt
-			float delta_tilt = (_param_vt_tilt_mc.get() - _param_vt_tilt_spinup.get());
-			_tilt_control = _param_vt_tilt_spinup.get() + delta_tilt / spin_up_duration_p2 * (hrt_absolute_time() -
-					(_last_timestamp_disarmed + spin_up_duration_p1));
-		}
-
-		_mc_yaw_weight = 0.0f; //disable yaw control during spinup
-
-	} else {
-		// normal operation
-		_tilt_control = VtolType::pusher_assist() + _param_vt_tilt_mc.get();
-		_mc_yaw_weight = 1.0f;
-	}
+	_tilt_control = VtolType::pusher_assist() + _param_vt_tilt_mc.get();
+	_mc_yaw_weight = 1.0f;
 }
 
 void Tiltrotor::update_fw_state()

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -91,14 +91,11 @@ private:
 	void blendThrottleDuringBacktransition(const float scale, const float target_throttle);
 	bool isFrontTransitionCompletedBase() override;
 
-	hrt_abstime _last_timestamp_disarmed{0}; /**< used for calculating time since arming */
-	bool _tilt_motors_for_startup{false};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(VtolType,
 					(ParamFloat<px4::params::VT_TILT_MC>) _param_vt_tilt_mc,
 					(ParamFloat<px4::params::VT_TILT_TRANS>) _param_vt_tilt_trans,
 					(ParamFloat<px4::params::VT_TILT_FW>) _param_vt_tilt_fw,
-					(ParamFloat<px4::params::VT_TILT_SPINUP>) _param_vt_tilt_spinup,
 					(ParamFloat<px4::params::VT_TRANS_P2_DUR>) _param_vt_trans_p2_dur,
 					(ParamFloat<px4::params::VT_BT_TILT_DUR>) _param_vt_bt_tilt_dur
 				       )

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -72,20 +72,6 @@ PARAM_DEFINE_FLOAT(VT_TILT_TRANS, 0.4f);
 PARAM_DEFINE_FLOAT(VT_TILT_FW, 1.0f);
 
 /**
- * Tilt when disarmed and in the first second after arming
- *
- * This specific tilt during spin-up is necessary for some systems whose motors otherwise don't
- * spin-up freely.
- *
- * @min 0.0
- * @max 1.0
- * @increment 0.01
- * @decimal 2
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_TILT_SPINUP, 0.0f);
-
-/**
  * Duration of front transition phase 2
  *
  * Time in seconds it takes to tilt form VT_TILT_TRANS to VT_TILT_FW.


### PR DESCRIPTION
### Solved Problem
This removes the [functionality around specifying a spin up tilt thorough the param VT_TILT_SPINUP in the VTOL module ](https://github.com/PX4/PX4-Autopilot/pull/14330), and instead adds the functionality in slightly altered fashion in the control allocation for tiltrotor VTOLs. How it works now:
- set the tilt outputs to NAN if in hover mode and disarmed
- NAN in the outputs corresponds by definition to "set this actuator to the disarmed state"
- allow the tilts to go to normal operation once spool up is completed (tunable through COM_SPOOLUP_TIME)

### Changelog Entry
For release notes:
```
Feature: VTOL tiltrotor: remove VT_TILT_SPINUP and instead have tilts at the disarmed value during the spoolup (COM_SPOOLUP_TIME)
```

### Alternatives
It would be nice if the specified slew rate limiting on the tilts is also active during the spin up. To achieve that we could again use a customized tilt for spin up (re-use VT_TILT_SPINUP in the control allocation) and set the tilts to this value until 1s after arming. Problem with that approach is that then the allocation will compensate for the loss in vertical thrust effectiveness due to the motor tilt, with results in the motor throttle going above the specified minimum when the motors are tilted for spin up, only to then go down again when idling on the ground with the tilts in MC configuration. 


### Test coverage
flight tested. 

