### PR TITLE
Control Allocation: fixes in yaw saturation detection for vehicles with tilt-for-yaw

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
@@ -91,20 +91,20 @@ void ActuatorEffectivenessMCTilt::updateSetpoint(const matrix::Vector<float, NUM
 		// custom yaw saturation logic: only declare yaw saturated if all tilts are at the negative or positive yawing limit
 		if (_tilts.getYawTorqueOfTilt(i) > FLT_EPSILON) {
 
-			if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+			if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx) - FLT_EPSILON) {
 				yaw_saturated_positive = false;
 			}
 
-			if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+			if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx) + FLT_EPSILON) {
 				yaw_saturated_negative = false;
 			}
 
-		} else if (_tilts.getYawTorqueOfTilt(i) < FLT_EPSILON) {
-			if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+		} else if (_tilts.getYawTorqueOfTilt(i) < -FLT_EPSILON) {
+			if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx) - FLT_EPSILON) {
 				yaw_saturated_negative = false;
 			}
 
-			if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+			if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx) + FLT_EPSILON) {
 				yaw_saturated_positive = false;
 			}
 		}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2021-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,7 +55,7 @@ ActuatorEffectivenessMCTilt::getEffectivenessMatrix(Configuration &configuration
 	const bool rotors_added_successfully = _mc_rotors.addActuators(configuration);
 
 	// Tilts
-	int first_tilt_idx = configuration.num_actuators_matrix[0];
+	_first_tilt_idx = configuration.num_actuators_matrix[0];
 	_tilts.updateTorqueSign(_mc_rotors.geometry());
 	const bool tilts_added_successfully = _tilts.addActuators(configuration);
 
@@ -69,7 +69,7 @@ ActuatorEffectivenessMCTilt::getEffectivenessMatrix(Configuration &configuration
 
 		if (delta_angle > FLT_EPSILON) {
 			float trim = -1.f - 2.f * _tilts.config(i).min_angle / delta_angle;
-			_tilt_offsets(first_tilt_idx + i) = trim;
+			_tilt_offsets(_first_tilt_idx + i) = trim;
 		}
 	}
 
@@ -82,4 +82,49 @@ void ActuatorEffectivenessMCTilt::updateSetpoint(const matrix::Vector<float, NUM
 {
 	actuator_sp += _tilt_offsets;
 	// TODO: dynamic matrix update
+
+	bool yaw_saturated_positive = true;
+	bool yaw_saturated_negative = true;
+
+	for (int i = 0; i < _tilts.count(); ++i) {
+
+		// custom yaw saturation logic: only declare yaw saturated if all tilts are at the negative or positive yawing limit
+		if (_tilts.getYawTorqueOfTilt(i) > FLT_EPSILON) {
+
+			if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+				yaw_saturated_positive = false;
+			}
+
+			if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+				yaw_saturated_negative = false;
+			}
+
+		} else if (_tilts.getYawTorqueOfTilt(i) < FLT_EPSILON) {
+			if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+				yaw_saturated_negative = false;
+			}
+
+			if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+				yaw_saturated_positive = false;
+			}
+		}
+	}
+
+	_yaw_tilt_saturation_flags.tilt_yaw_neg = yaw_saturated_negative;
+	_yaw_tilt_saturation_flags.tilt_yaw_pos = yaw_saturated_positive;
+}
+
+void ActuatorEffectivenessMCTilt::getUnallocatedControl(int matrix_index, control_allocator_status_s &status)
+{
+	// Note: the values '-1', '1' and '0' are just to indicate a negative,
+	// positive or no saturation to the rate controller. The actual magnitude is not used.
+	if (_yaw_tilt_saturation_flags.tilt_yaw_pos) {
+		status.unallocated_torque[2] = 1.f;
+
+	} else if (_yaw_tilt_saturation_flags.tilt_yaw_neg) {
+		status.unallocated_torque[2] = -1.f;
+
+	} else {
+		status.unallocated_torque[2] = 0.f;
+	}
 }

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2021-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -61,8 +61,18 @@ public:
 
 	const char *name() const override { return "MC Tilt"; }
 
+	void getUnallocatedControl(int matrix_index, control_allocator_status_s &status) override;
+
 protected:
 	ActuatorVector _tilt_offsets;
 	ActuatorEffectivenessRotors _mc_rotors;
 	ActuatorEffectivenessTilts _tilts;
+	int _first_tilt_idx{0};
+
+	struct YawTiltSaturationFlags {
+		bool tilt_yaw_pos;
+		bool tilt_yaw_neg;
+	};
+
+	YawTiltSaturationFlags _yaw_tilt_saturation_flags{};
 };

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -148,20 +148,20 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 				// custom yaw saturation logic: only declare yaw saturated if all tilts are at the negative or positive yawing limit
 				if (_tilts.getYawTorqueOfTilt(i) > FLT_EPSILON) {
 
-					if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+					if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx) - FLT_EPSILON) {
 						yaw_saturated_positive = false;
 					}
 
-					if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+					if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx) + FLT_EPSILON) {
 						yaw_saturated_negative = false;
 					}
 
-				} else if (_tilts.getYawTorqueOfTilt(i) < FLT_EPSILON) {
-					if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+				} else if (_tilts.getYawTorqueOfTilt(i) < -FLT_EPSILON) {
+					if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx) - FLT_EPSILON) {
 						yaw_saturated_negative = false;
 					}
 
-					if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+					if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx) + FLT_EPSILON) {
 						yaw_saturated_positive = false;
 					}
 				}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -137,11 +137,38 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 				_last_collective_tilt_control = control_collective_tilt;
 			}
 
+			bool yaw_saturated_positive = true;
+			bool yaw_saturated_negative = true;
+
 			for (int i = 0; i < _tilts.count(); ++i) {
 				if (_tilts.config(i).tilt_direction == ActuatorEffectivenessTilts::TiltDirection::TowardsFront) {
 					actuator_sp(i + _first_tilt_idx) += control_collective_tilt;
 				}
+
+				// custom yaw saturation logic: only declare yaw saturated if all tilts are at the negative or positive yawing limit
+				if (_tilts.getYawTorqueOfTilt(i) > FLT_EPSILON) {
+
+					if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+						yaw_saturated_positive = false;
+					}
+
+					if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+						yaw_saturated_negative = false;
+					}
+
+				} else if (_tilts.getYawTorqueOfTilt(i) < FLT_EPSILON) {
+					if (yaw_saturated_negative && actuator_sp(i + _first_tilt_idx) < actuator_max(i + _first_tilt_idx)) {
+						yaw_saturated_negative = false;
+					}
+
+					if (yaw_saturated_positive && actuator_sp(i + _first_tilt_idx) > actuator_min(i + _first_tilt_idx)) {
+						yaw_saturated_positive = false;
+					}
+				}
 			}
+
+			_yaw_tilt_saturation_flags.tilt_yaw_neg = yaw_saturated_negative;
+			_yaw_tilt_saturation_flags.tilt_yaw_pos = yaw_saturated_positive;
 
 			// in FW directly use throttle sp
 			if (_flight_phase == FlightPhase::FORWARD_FLIGHT) {
@@ -153,21 +180,6 @@ void ActuatorEffectivenessTiltrotorVTOL::updateSetpoint(const matrix::Vector<flo
 
 		if (_flight_phase == FlightPhase::FORWARD_FLIGHT) {
 			stopMaskedMotorsWithZeroThrust(_motors & ~_untiltable_motors, actuator_sp);
-		}
-	}
-
-	// Set yaw saturation flag in case of yaw through tilt. As in this case the yaw actuation is decoupled from
-	// the other axes (for now neglecting the case of 0 collective thrust), we set the saturation flags
-	// directly if the (normalized) yaw torque setpoint is outside of range (-1, 1).
-	if (matrix_index == 0 && _tilts.hasYawControl()) {
-		_yaw_tilt_saturation_flags.tilt_yaw_neg = false;
-		_yaw_tilt_saturation_flags.tilt_yaw_pos = false;
-
-		if (control_sp(2) < -1.f) {
-			_yaw_tilt_saturation_flags.tilt_yaw_neg = true;
-
-		} else if (control_sp(2) > 1.f) {
-			_yaw_tilt_saturation_flags.tilt_yaw_pos = true;
 		}
 	}
 }

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTilts.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTilts.hpp
@@ -79,6 +79,8 @@ public:
 
 	bool hasYawControl() const;
 
+	float getYawTorqueOfTilt(int tilt_index) const { return _torque[tilt_index](2); }
+
 private:
 	void updateParams() override;
 


### PR DESCRIPTION


### Solved Problem
VTOL Tiltrotors require a special yaw saturation detection. Simply looking at whether there is unallocated yaw torque leads to almost constant saturation reporting, as often one of the tilts is saturated (they usually can't tilt backwards). I patched this previously in https://github.com/PX4/PX4-Autopilot/pull/20518, where I simply declared the yaw saturated if the torque setpoint was saturated. Given that there is also a  collective tilt this assumption is quite rough. 

While flying a tricopter with sideways tiltable tail I further noticed that there the reported unallocated yaw was never 0, while the tilt servo clearly never reached saturation:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/df0456de-22ca-494c-81bd-56d21a6e2725)
I didn't investigate further why the unallocated torque calculation is so wrong, but given that MC tilt vehicles would anyway have the same issues as VTOL tiltrotor if they have tilts that only tilt in one direction, it makes sense to me to customize the saturation handling anyway also for them.

### Solution
Customize yaw saturation detection for VTOL tiltrotor and MC tilts. Taking the sign of the yaw effectiveness of the corresponding tilt into account, check if the tilt is at the min or max value and set the positive or negative saturation flag if all the tilts are saturated in this direction. 

### Changelog Entry
For release notes:
```
Bugfix: fix yaw saturation logic for tilting motors (tiltrotor VTOL and MC with tilts)
```

### Alternatives
Extend it to have it generic for all axis with tilt actuation. I wonder though if we also should first remove the tilts from the effectiveness matrix and do custom allocation of them (something similar to what is done in the Helicopter allocation).

### Test coverage
SITL tested (tiltrotor). 

