### PR TITLE
Allow auto modes with local position estimate if global origin is set manually

### DIFF
--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -375,8 +375,8 @@ protected:
 	bool _initialised{false};      // true if the ekf interface instance (data buffering) is initialized
 
 	bool _NED_origin_initialised{false};
-	float _gps_origin_eph{0.0f}; // horizontal position uncertainty of the GPS origin
-	float _gps_origin_epv{0.0f}; // vertical position uncertainty of the GPS origin
+	float _gpos_origin_eph{0.0f}; // horizontal position uncertainty of the global origin
+	float _gpos_origin_epv{0.0f}; // vertical position uncertainty of the global origin
 	MapProjection _pos_ref{}; // Contains WGS-84 position latitude and longitude of the EKF origin
 	MapProjection _gps_pos_prev{}; // Contains WGS-84 position latitude and longitude of the previous GPS message
 	float _gps_alt_prev{0.0f};	// height from the previous GPS message (m)

--- a/src/modules/ekf2/EKF/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/gps_checks.cpp
@@ -85,8 +85,8 @@ bool Ekf::collect_gps(const gpsMessage &gps)
 		_NED_origin_initialised = true;
 
 		// save the horizontal and vertical position uncertainty of the origin
-		_gps_origin_eph = gps.eph;
-		_gps_origin_epv = gps.epv;
+		_gpos_origin_eph = gps.eph;
+		_gpos_origin_epv = gps.epv;
 
 		_information_events.flags.gps_checks_passed = true;
 		ECL_INFO("GPS checks passed");

--- a/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
+++ b/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
@@ -183,7 +183,6 @@ TEST_F(EkfFusionLogicTest, fallbackFromGpsToFlow)
 	const float max_ground_distance = 50.f;
 	_ekf->set_optical_flow_limits(max_flow_rate, min_ground_distance, max_ground_distance);
 	_sensor_simulator.startFlow();
-	_sensor_simulator.startFlow();
 	_ekf_wrapper.enableFlowFusion();
 
 	_ekf->set_in_air_status(true);


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/17249

### Solution
Even if the aiding is local only, a valid global estimate can be sent as long as we know the EKF's origin.

### Changelog Entry
For release notes:
```
Allow auto modes with local position estimate if global origin is set manually
New parameter: -
Documentation: see https://github.com/PX4/PX4-user_guide/pull/2689
```

### Test coverage
- unit tests

