### PR TITLE
uxrce_dds_client: add option to limit publications rates

### DIFF
--- a/platforms/common/uORB/SubscriptionInterval.hpp
+++ b/platforms/common/uORB/SubscriptionInterval.hpp
@@ -140,6 +140,8 @@ public:
 	unsigned	get_last_generation() const { return _subscription.get_last_generation(); }
 	orb_id_t	get_topic() const { return _subscription.get_topic(); }
 
+	ORB_ID		orb_id() { return _subscription.orb_id(); }
+
 	/**
 	 * Set the interval in microseconds
 	 * @param interval The interval in microseconds.

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -21,7 +21,7 @@ import os
 #include <uxr/client/client.h>
 #include <ucdr/microcdr.h>
 
-#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
 #include <uORB/Publication.hpp>
 @[for include in type_includes]@
 #include <uORB/ucdr/@(include).h>
@@ -35,7 +35,7 @@ static_assert(sizeof(@(pub['simple_base_type'])_s) <= max_topic_size, "topic too
 @[    end for]@
 
 struct SendSubscription {
-	uORB::Subscription subscription;
+	uORB::SubscriptionInterval subscription;
 	uxrObjectId data_writer;
 	const char* dds_type_name;
 	uint32_t topic_size;
@@ -46,7 +46,7 @@ struct SendSubscription {
 struct SendTopicsSubs {
 	SendSubscription send_subscriptions[@(len(publications))] = {
 @[    for pub in publications]@
-			{ uORB::Subscription(ORB_ID(@(pub['topic_simple']))),
+			{ uORB::SubscriptionInterval(ORB_ID(@(pub['topic_simple'])), @(pub['interval_us'])),
 			  uxr_object_id(0, UXR_INVALID_ID),
 			  "@(pub['dds_type'])",
 			  ucdr_topic_size_@(pub['simple_base_type'])(),

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -102,6 +102,12 @@ for p in msg_map['publications']:
     # topic_simple: eg vehicle_status
     p['topic_simple'] = p['topic'].split('/')[-1]
 
+    # optional minimum interval between two samples in µs
+    if 'interval_us' in p:
+        p['interval_us'] = int(p['interval_us'])
+    else:
+        p['interval_us'] = 0
+
 
 merged_em_globals['publications'] = msg_map['publications']
 


### PR DESCRIPTION
### Solved Problem
I want to subscribe to px4 topics through the uxrce_dds_client but not at the full uorb topic rate.

### Solution
- Use `SubscriptionInterval` instead of `Subscription` in the uxrce_dds_client
- Add an optional argument to the `dds_topics.yaml` to give desired minimal interval between message

Example of `dds_topics.yaml` file:
```
publications:

  - topic: /fmu/out/vehicle_attitude
    type: px4_msgs::msg::VehicleAttitude

  - topic: /fmu/out/vehicle_global_position
    type: px4_msgs::msg::VehicleGlobalPosition
    interval_us: 1000000

  - topic: /fmu/out/vehicle_control_mode
    type: px4_msgs::msg::VehicleControlMode


subscriptions:

  - topic: /fmu/in/offboard_control_mode
    type: px4_msgs::msg::OffboardControlMode

  - topic: /fmu/in/vehicle_attitude_setpoint
    type: px4_msgs::msg::VehicleAttitudeSetpoint

```

### Changelog Entry
For release notes:
```
Feature: dds_topic optional minimum interval 
```

### Test coverage
- tested with sitl


I also have this change on the 1.14 branch if you are interested in cherrypick

