### PR TITLE
FixedwingPositionControl: Use constant bank angle on VTOL transition when groundspeed is low and wind invalid

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -237,7 +237,8 @@ private:
 
 	enum FW_POSCTRL_MODE {
 		FW_POSCTRL_MODE_AUTO,
-		FW_POSCTRL_MODE_AUTO_ALTITUDE,
+		FW_POSCTRL_MODE_AUTO_ALTITUDE_FAILSAFE,
+		FW_POSCTRL_MODE_AUTO_ALTITUDE_STRAIGHT,
 		FW_POSCTRL_MODE_AUTO_CLIMBRATE,
 		FW_POSCTRL_MODE_AUTO_TAKEOFF,
 		FW_POSCTRL_MODE_AUTO_LANDING_STRAIGHT,
@@ -547,8 +548,9 @@ private:
 	 * Used as a failsafe mode after a lateral position estimate failure.
 	 *
 	 * @param control_interval Time since last position control call [s]
+	 * @param[in] bank fixed bank angle [rad]
 	 */
-	void control_auto_fixed_bank_alt_hold(const float control_interval);
+	void control_auto_fixed_bank_alt_hold(float control_interval, float bank);
 
 	/**
 	 * @brief Control airspeed with a fixed descent rate and roll angle.


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When starting a VTOL transition after takeoff, the groundspeed starts from zero and the wind estimate is potentially not valid yet. In this case the track angle can't be computed since we don't have a clear direction we are flying to. Thus, the npfg navigation function cannot do much and can give unwanted roll signals.

### Solution
- At the start of VTOL transition, fly with a constant roll angle of 0° until the ground speed is above twice the velocity standard deviation. At this point we can assume that the track angle is not erratic anymore.

### Changelog Entry
For release notes:
```
Bugfix: Set constant bank angle when starting a VTOL transition while ground speed is low and no valid wind estimate available.
```

### Alternatives
We could also use other control logic besides horizontal position control, as long as the ground speed is low e.g. hold the current heading. However, this would end up in roll commands and as long as we do not have a high forward motion, this does not have much of an effect.

### Test coverage
- Tested in SITL with gazebo-classic_standard_vtol

### Context
Real flight with checks for valid track angle:
![Screenshot from 2023-08-25 10-00-20](https://github.com/PX4/PX4-Autopilot/assets/98741601/1c47680f-e64d-4a1c-a239-a1d4cbe81c4a)

As can be seen, the track angle gets smooth around where the groundspeed is bigger than the horizontal velocity standard deviation. To make it a bit more robust, i used twice the standard deviation as threshold.
