### PR TITLE
system_params: improve distance sensor check description

### DIFF
--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -217,13 +217,11 @@ PARAM_DEFINE_INT32(SYS_HAS_MAG, 1);
 PARAM_DEFINE_INT32(SYS_HAS_BARO, 1);
 
 /**
- * Control the number of distance sensors on the vehicle
+ * Number of distance sensors to check being available
  *
- * If set to the number of distance sensors, the preflight check will check
- * for their presence and valid data publication. Disable with 0 if no distance
- * sensor present or to disable the preflight check.
+ * The preflight check will fail if fewer than this number of distance sensors with valid data is present.
  *
- * @reboot_required true
+ * Disable the check with 0.
  *
  * @group System
  * @min 0


### PR DESCRIPTION
### Solved Problem
When helping @marcinolokk I found that the description of the parameter for the distance sensor preflight check is not entirely clear to either me or him so I went ahead to suggest an improvement.

### Solution
- Different wording, please check if it makes sense
- I checked in simulation and no reboot is required, it applies immediately.

### Changelog Entry
```
Documentation: Improve parameter description for distance sensor preflight check
```