### PR TITLE
Fixed an issue where if the GCC_VER_STR would not contain the right N…

### DIFF
--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -165,7 +165,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	source $HOME/.profile # load changed path for the case the script is reran before relogin
 	if [ $(which arm-none-eabi-gcc) ]; then
 		GCC_VER_STR=$(arm-none-eabi-gcc --version)
-		GCC_FOUND_VER=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}")
+		GCC_FOUND_VER=$(echo $GCC_VER_STR || grep -c "${NUTTX_GCC_VERSION}")
 	fi
 
 	if [[ "$GCC_FOUND_VER" == "1" ]]; then

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -165,7 +165,7 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 	source $HOME/.profile # load changed path for the case the script is reran before relogin
 	if [ $(which arm-none-eabi-gcc) ]; then
 		GCC_VER_STR=$(arm-none-eabi-gcc --version)
-		GCC_FOUND_VER=$(echo $GCC_VER_STR || grep -c "${NUTTX_GCC_VERSION}")
+		GCC_FOUND_VER=$(echo $GCC_VER_STR | grep -c "${NUTTX_GCC_VERSION}" || true)
 	fi
 
 	if [[ "$GCC_FOUND_VER" == "1" ]]; then


### PR DESCRIPTION
### Solved Problem
When trying to run the Ubuntu setup script I found that it silently failed somewhere, failing to execute part of the setup script.
As it turns out, when the GCC_VER_STR would not contain the right NUTTX_GCC_VERSION (i.e. you have the wrong version, and the right version should be installed), the grep -c command would throw a failure, silently exiting the entire ubuntu.sh setup script

I wanted to make a bugreport, but I found this issue that appears to have the same problem without being spotted: #21585

For the other occurrences of grep this is not an issue apparently due to the way the are used (e.g. as part of an if statement).

### Solution
Change the grep -c with an || true such that it doesn't allow for the bash script to fail when the grep -c returns 0.


### Test coverage
See also:

```
#! /usr/bin/env bash

set -e

WORDS="random words"
SEARCH_FOR="words"

WORDS_FOUND=$(echo $WORDS | grep -c "${SEARCH_FOR}" || true)


if [[ "$WORDS_FOUND" == "1" ]]; then
	echo "yes, words found"	
else
	echo "no, words not found"	
fi

SEARCH_FOR2="w0rds"

WORDS2_FOUND=$(echo $WORDS | grep -c "${SEARCH_FOR2}" || true)


if [[ "$WORDS2_FOUND" == "1" ]]; then
	echo "yes, words2 found"	
else
	echo "no, words2 not found"	
fi


WORDS3_FOUND=$(echo $WORDS | grep -c "${SEARCH_FOR2}" )

if [[ "$WORDS3_FOUND" == "1" ]]; then
	echo "yes, words found"	
else
	echo "no, words not found"	
fi

echo "done"
```

This script won't print the last echo line, due to the grep -c throwing a failure, ending the bash script early. Similar to in the setup script.
