### PR TITLE
drv_hrt: remove whitespace for operator ""

### DIFF
--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -294,17 +294,17 @@ namespace time_literals
 // User-defined integer literals for different time units.
 // The base unit is hrt_abstime in microseconds
 
-constexpr hrt_abstime operator "" _s(unsigned long long seconds)
+constexpr hrt_abstime operator ""_s(unsigned long long seconds)
 {
 	return hrt_abstime(seconds * 1000000ULL);
 }
 
-constexpr hrt_abstime operator "" _ms(unsigned long long milliseconds)
+constexpr hrt_abstime operator ""_ms(unsigned long long milliseconds)
 {
 	return hrt_abstime(milliseconds * 1000ULL);
 }
 
-constexpr hrt_abstime operator "" _us(unsigned long long microseconds)
+constexpr hrt_abstime operator ""_us(unsigned long long microseconds)
 {
 	return hrt_abstime(microseconds);
 }


### PR DESCRIPTION
Fixes the clang error:
```
/__w/PX4-Autopilot/PX4-Autopilot/src/drivers/drv_hrt.h:297:35: fatal error: identifier '_s' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
  297 | constexpr hrt_abstime operator "" _s(unsigned long long seconds)
```

Let's see if CI passes.