### PR TITLE
Spoolup in Stabilized/Manual Mode

### DIFF
--- a/src/lib/slew_rate/SlewRate.hpp
+++ b/src/lib/slew_rate/SlewRate.hpp
@@ -49,6 +49,7 @@ class SlewRate
 {
 public:
 	SlewRate() = default;
+	SlewRate(Type initial_value) { setForcedValue(initial_value); }
 	~SlewRate() = default;
 
 	/**

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -122,6 +122,7 @@ private:
 	float _man_tilt_max;                    /**< maximum tilt allowed for manual flight [rad] */
 
 	SlewRate<float> _manual_throttle_minimum{0.f}; ///< 0 when landed and ramped to MPC_MANTHR_MIN in air
+	SlewRate<float> _manual_throttle_maximum{0.f}; ///< 0 when disarmed ramped to 1 when spooled up
 	AlphaFilter<float> _man_roll_input_filter;
 	AlphaFilter<float> _man_pitch_input_filter;
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -50,10 +50,12 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <lib/slew_rate/SlewRate.hpp>
 
 #include <AttitudeControl.hpp>
 
@@ -100,6 +102,7 @@ private:
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _vehicle_attitude_setpoint_sub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
+	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
 	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
@@ -118,12 +121,14 @@ private:
 	float _man_yaw_sp{0.f};                 /**< current yaw setpoint in manual mode */
 	float _man_tilt_max;                    /**< maximum tilt allowed for manual flight [rad] */
 
+	SlewRate<float> _manual_throttle_minimum{0.f}; ///< 0 when landed and ramped to MPC_MANTHR_MIN in air
 	AlphaFilter<float> _man_roll_input_filter;
 	AlphaFilter<float> _man_pitch_input_filter;
 
 	hrt_abstime _last_run{0};
 	hrt_abstime _last_attitude_setpoint{0};
 
+	bool _landed{true};
 	bool _reset_yaw_sp{true};
 	bool _heading_good_for_control{true}; ///< initialized true to have heading lock when local position never published
 	bool _vehicle_type_rotary_wing{true};

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -128,6 +128,7 @@ private:
 	hrt_abstime _last_run{0};
 	hrt_abstime _last_attitude_setpoint{0};
 
+	bool _spooled_up{false}; ///< used to make sure the vehicle cannot take off during the spoolup time
 	bool _landed{true};
 	bool _reset_yaw_sp{true};
 	bool _heading_good_for_control{true}; ///< initialized true to have heading lock when local position never published
@@ -157,7 +158,9 @@ private:
 		(ParamFloat<px4::params::MPC_MANTHR_MIN>)   _param_mpc_manthr_min,      /**< minimum throttle for stabilized */
 		(ParamFloat<px4::params::MPC_THR_MAX>)      _param_mpc_thr_max,         /**< maximum throttle for stabilized */
 		(ParamFloat<px4::params::MPC_THR_HOVER>)    _param_mpc_thr_hover,       /**< throttle at stationary hover */
-		(ParamInt<px4::params::MPC_THR_CURVE>)      _param_mpc_thr_curve        /**< throttle curve behavior */
+		(ParamInt<px4::params::MPC_THR_CURVE>)      _param_mpc_thr_curve,       /**< throttle curve behavior */
+
+		(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time
 	)
 };
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -109,7 +109,7 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 					   _manual_throttle_minimum.getState(), _param_mpc_thr_max.get());
 		break;
 
-	default: // 0 or other: rescale to hover throttle at 0.5 stick
+	default: // 0 or other: rescale such that a centered throttle stick corresponds to hover throttle
 		thrust = math::interpolateNXY(throttle_stick_input, {-1.f, 0.f, 1.f},
 		{_manual_throttle_minimum.getState(), _param_mpc_thr_hover.get(), _param_mpc_thr_max.get()});
 		break;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -60,8 +60,9 @@ MulticopterAttitudeControl::MulticopterAttitudeControl(bool vtol) :
 	_loop_perf(perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")),
 	_vtol(vtol)
 {
-
 	parameters_updated();
+	// Rate of change 5% per second -> 1.6 seconds to ramp to default 8% MPC_MANTHR_MIN
+	_manual_throttle_minimum.setSlewRate(0.05f);
 }
 
 MulticopterAttitudeControl::~MulticopterAttitudeControl()
@@ -101,10 +102,10 @@ MulticopterAttitudeControl::throttle_curve(float throttle_stick_input)
 	// throttle_stick_input is in range [0, 1]
 	switch (_param_mpc_thr_curve.get()) {
 	case 1: // no rescaling to hover throttle
-		return math::interpolate(throttle_stick_input, 0.f, 1.f, _param_mpc_manthr_min.get(), _param_mpc_thr_max.get());
+		return math::interpolate(throttle_stick_input, 0.f, 1.f, _manual_throttle_minimum.getState(), _param_mpc_thr_max.get());
 
 	default: // 0 or other: rescale to hover throttle at 0.5 stick
-		return math::interpolateN(throttle_stick_input, {_param_mpc_manthr_min.get(), _param_mpc_thr_hover.get(), _param_mpc_thr_max.get()});
+		return math::interpolateN(throttle_stick_input, {_manual_throttle_minimum.getState(), _param_mpc_thr_hover.get(), _param_mpc_thr_max.get()});
 	}
 }
 
@@ -265,6 +266,14 @@ MulticopterAttitudeControl::Run()
 			}
 		}
 
+		if (_vehicle_land_detected_sub.updated()) {
+			vehicle_land_detected_s vehicle_land_detected;
+
+			if (_vehicle_land_detected_sub.copy(&vehicle_land_detected)) {
+				_landed = vehicle_land_detected.landed;
+			}
+		}
+
 		if (_vehicle_local_position_sub.updated()) {
 			vehicle_local_position_s vehicle_local_position;
 
@@ -322,6 +331,13 @@ MulticopterAttitudeControl::Run()
 			rates_setpoint.timestamp = hrt_absolute_time();
 
 			_vehicle_rates_setpoint_pub.publish(rates_setpoint);
+		}
+
+		if (_landed) {
+			_manual_throttle_minimum.update(0.f, dt);
+
+		} else {
+			_manual_throttle_minimum.update(_param_mpc_manthr_min.get(), dt);
 		}
 
 		// reset yaw setpoint during transitions, tailsitter.cpp generates


### PR DESCRIPTION
### Solved Problem
1. We had a crash because:
   - The spoolup time is a phase after arming where ESC/Motor checks are done e.g. is the rotor stuck?
   - Commander / failure detector is allowed to disarm immediately again if such a check fails sich that the vehicle doesn't even take off
   - Climb rate controlled modes don't allow the vehicle taking off in this phase
   - Stabilized mode did not prohibit that
   - If the spoolup time is long enough e.g. many seconds and the ESC reports a failure only after a certain time the vehicle can drop again
2. Certain very specific setups require the spoolup throttle to be zero (purely idle). This is the case in climb rate controlled modes thanks to https://github.com/PX4/PX4-Autopilot/blob/23b31cc5fdc33fe1f43dcf12bb6fe4a5afbbc24d/src/modules/mc_pos_control/MulticopterPositionControl.cpp#L507-L509 and https://github.com/PX4/PX4-Autopilot/blob/23b31cc5fdc33fe1f43dcf12bb6fe4a5afbbc24d/src/modules/mc_pos_control/Takeoff/Takeoff.cpp#L45 but not in Stabilized mode anymore after my change in https://github.com/PX4/PX4-Autopilot/pull/20031.

Fixes #{Github issue ID}

### Solution
1. Hold the throttle output low during the spoolup time in Stabilized mode. To avoid any sudden thrust jump I made a ramp of the maximum that takes 2 seconds until full thrust can be commanded.
2. While landed the minimum throttle the stick maps to is zero but compared to https://github.com/PX4/PX4-Autopilot/commit/2fbb70d9ca94f442de1345221be18ba738cda952 it's then ramped up to the minimum throttle in air instead of jumping up.

### Changelog Entry
For release notes:
```
Feature: Respect spoolup time in Stabilized mode and have zero throttle while still landed
```

### Alternatives
2. I'd like to replace with an always enabled airmode that makes it obsolete to hold a minimum collective thrust but have its effect limited to how it would be with a minimum thrust to avoid negative effects like possible tip over or oscillations because of too much authority. The solution here is for the time until I have that ready.

### Test coverage
1. Tested in simulation to respect the expected time and thrust profile. Not flown on a real vehicle yet.
2. Verified in simulation to have the expected thrust profile. Heavily tested on many different vehicles also in production.

### Context
Desired effect shown from a simulated log:
1. only
![image](https://user-images.githubusercontent.com/4668506/216632816-c6813801-72da-48d5-b97f-731368a625c1.png)
2. on top
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/8b4bfad2-6772-4fae-875b-bcb4617112ab)

