### PR TITLE
ARK CANnode disable OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO

### DIFF
--- a/boards/ark/cannode/src/boot_config.h
+++ b/boards/ark/cannode/src/boot_config.h
@@ -92,7 +92,11 @@
  *
  */
 #define OPT_WAIT_FOR_GETNODEINFO                    0
-#define OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO        1
+/* The ARK CANnode uses PH1 for GPIO_BOOT_CONFIG but it is not
+ * compatible with px4_arch_gpioread as Port H = 7 which is greater
+ * than STM32_NPORTS
+ * #define OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO        0
+ */
 #define OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO_INVERT 1
 
 #define OPT_ENABLE_WD           1


### PR DESCRIPTION
On the ARK CANnode, switching to OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO_INVERT caused the OPT_WAIT_FOR_GETNODEINFO_JUMPER_GPIO logic in the bootloader to not work.