### PR TITLE
Update quaternion covariance at yaw reset

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -1075,7 +1075,8 @@ private:
 	// gravity fusion: heuristically enable / disable gravity fusion
 	void controlGravityFusion(const imuSample &imu_delayed);
 
-	void resetQuatCov(float yaw_noise = NAN);
+	void resetQuatCov(const float yaw_noise = NAN);
+	void resetQuatCov(const Vector3f &euler_noise_ned);
 
 	void resetMagCov();
 


### PR DESCRIPTION
### Solved Problem
When looking in detail at quaternion states variances in the logs, I noticed that on similar missions, values are not the same depending on the initial yaw.
The problem is that quaternion variances depend on the quternion itself. So if there is a reset in yaw, which changes the quaternion states, quaternion covariance matrix also needs to be updated, which is not the case for now.

### Solution
When doing a yaw reset, save the quaternion covariances as Euler angles so that they can be restored after the reset.