### PR TITLE
Cleanup: include problem, float literals

### DIFF
--- a/src/lib/mixer_module/functions/FunctionMotors.hpp
+++ b/src/lib/mixer_module/functions/FunctionMotors.hpp
@@ -35,7 +35,7 @@
 
 #include "FunctionProviderBase.hpp"
 
-#include <uORB/topics/actuator_servos.h>
+#include <uORB/topics/actuator_motors.h>
 
 /**
  * Functions: Motor1 ... MotorMax

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -171,9 +171,9 @@ void PositionControl::_velocityControl(const float dt)
 
 	// Determine how much horizontal thrust is left after prioritizing vertical control
 	const float thrust_max_xy_squared = thrust_max_squared - math::sq(_thr_sp(2));
-	float thrust_max_xy = 0;
+	float thrust_max_xy = 0.f;
 
-	if (thrust_max_xy_squared > 0) {
+	if (thrust_max_xy_squared > 0.f) {
 		thrust_max_xy = sqrtf(thrust_max_xy_squared);
 	}
 


### PR DESCRIPTION
### Solved Problem
1. When checking the multicopter position controller I found that https://github.com/PX4/PX4-Autopilot/pull/16030/files#diff-4a755e9af489c034497b67e34c4217b79dbd151a029f622e8cb3fe645efdc87fR168 used integer literals that get implicitly casted to float.
2. When including `FunctionMotors.hpp` I realized I had to include `actuator_motors.h` just before for it to compile. That brought me to assume it's a copy-paste error from https://github.com/PX4/PX4-Autopilot/commit/9ed861e0a3060de84df3eb46759c86eac6a64e45#diff-907d7c7904906f82013983fc380e1918a46bb1f1b381b3f0d57ae3c941e3eb3cR38

### Solution
1. I made it explicit.
2. include the motors header instead of the servos one

### Changelog Entry
Small code cleanup nothing user-facing


### Test coverage
- Still compiles