### PR TITLE
stm32h7_can: fix filter memory initialization bug.

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
@@ -810,7 +810,7 @@ int CanIface::init(const uavcan::uint32_t bitrate, const OperatingMode mode)
 	message_ram_.StdIdFilterSA = gl_ram_base + ram_offset * WORD_LENGTH;
 	can_->SIDFC = ((n_stdid << FDCAN_SIDFC_LSS_Pos)
 		       | ram_offset << FDCAN_SIDFC_FLSSA_Pos);
-	memset((void*)message_ram_.StdIdFilterSA, 0, WORD_LENGTH * n_stdid); // make sure filters are disabled
+	memset((void *)message_ram_.StdIdFilterSA, 0, WORD_LENGTH * n_stdid); // make sure filters are disabled
 	ram_offset += n_stdid;
 
 	// Extended ID Filters: Allow space for 64 filters (128 words)
@@ -818,7 +818,7 @@ int CanIface::init(const uavcan::uint32_t bitrate, const OperatingMode mode)
 	message_ram_.ExtIdFilterSA = gl_ram_base + ram_offset * WORD_LENGTH;
 	can_->XIDFC = ((n_extid << FDCAN_XIDFC_LSE_Pos)
 		       | ram_offset << FDCAN_XIDFC_FLESA_Pos);
-	memset((void*)message_ram_.ExtIdFilterSA, 0, (2 * WORD_LENGTH) * n_extid); // make sure filters are disabled
+	memset((void *)message_ram_.ExtIdFilterSA, 0, (2 * WORD_LENGTH) * n_extid); // make sure filters are disabled
 	ram_offset += 2 * n_extid;
 
 	// Set size of each element in the Rx/Tx buffers and FIFOs

--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
@@ -798,6 +798,7 @@ int CanIface::init(const uavcan::uint32_t bitrate, const OperatingMode mode)
 	 * factor of 4 necessary in the address relative to the SA register values.
 	 */
 
+
 // Location of this interface's message RAM - address in CPU memory address
 // and relative address (in words) used for configuration
 	const uint32_t iface_ram_base = (2560 / 2) * self_index_;
@@ -809,14 +810,16 @@ int CanIface::init(const uavcan::uint32_t bitrate, const OperatingMode mode)
 	message_ram_.StdIdFilterSA = gl_ram_base + ram_offset * WORD_LENGTH;
 	can_->SIDFC = ((n_stdid << FDCAN_SIDFC_LSS_Pos)
 		       | ram_offset << FDCAN_SIDFC_FLSSA_Pos);
+	memset((void*)message_ram_.StdIdFilterSA, 0, WORD_LENGTH * n_stdid); // make sure filters are disabled
 	ram_offset += n_stdid;
 
-	// Extended ID Filters: Allow space for 128 filters (128 words)
-	const uint8_t n_extid = 128;
+	// Extended ID Filters: Allow space for 64 filters (128 words)
+	const uint8_t n_extid = 64;
 	message_ram_.ExtIdFilterSA = gl_ram_base + ram_offset * WORD_LENGTH;
 	can_->XIDFC = ((n_extid << FDCAN_XIDFC_LSE_Pos)
 		       | ram_offset << FDCAN_XIDFC_FLESA_Pos);
-	ram_offset += n_extid;
+	memset((void*)message_ram_.ExtIdFilterSA, 0, (2 * WORD_LENGTH) * n_extid); // make sure filters are disabled
+	ram_offset += 2 * n_extid;
 
 	// Set size of each element in the Rx/Tx buffers and FIFOs
 	can_->RXESC = 0; // 8 byte space for every element (Rx buffer, FIFO1, FIFO0)


### PR DESCRIPTION
While testing the reception of the feedback from KDECAN ESCs in the following public branch (https://github.com/duartecdias/PX4-Autopilot/tree/pr/uavcan/kdecanProtocol), it was noted that while using standard ids, some messages were not being received from the ESCs in a random fashion for different power cycles.

Problem was tracked down to the initialization of the filters (probably they are being initialized randomly at each power cycle). After proper memset of the respective filter areas the problem went away.

Also adjusted the number of maximum filters for extended IDs to 64, according to the h7 chip datasheet.