### PR TITLE
Fixed Wing: Compensate maximum climbrate based on weight ratio and air density

### DIFF
--- a/src/lib/parameters/px4params/srcparser.py
+++ b/src/lib/parameters/px4params/srcparser.py
@@ -357,7 +357,7 @@ class SourceParser(object):
                                 'bit/s', 'B/s',
                                 'deg', 'deg*1e7', 'deg/s',
                                 'celcius', 'gauss', 'gauss/s', 'gauss^2',
-                                'hPa', 'kg', 'kg/m^2', 'kg m^2',
+                                'hPa', 'kg', 'kg/m^2', 'kg m^2', 'kg/m^3',
                                 'mm', 'm', 'm/s', 'm^2', 'm/s^2', 'm/s^3', 'm/s^2/sqrt(Hz)', '1/s/sqrt(Hz)', 'm/s/rad',
                                 'Ohm', 'V', 'A',
                                 'us', 'ms', 's',

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -106,10 +106,12 @@ float FixedwingPositionControl::getMaximumClimbRate()
 
 	float climbrate_max = _param_fw_t_clmb_max.get();
 
-	if (_param_density_min.get() > 0.0f) {
-		const float min_density = math::max(_param_density_min.get(), AIR_DENSITY_STANDARD_ATMOS_5000_AMSL);
+	const float density_min = _param_density_min.get();
+
+	if (density_min < AIR_DENSITY_STANDARD_ATMOS_1000_AMSL
+	    && density_min > AIR_DENSITY_STANDARD_ATMOS_5000_AMSL) {
 		const float density_gradient = (_param_fw_t_clmb_max.get() - CLIMBRATE_MIN) / (CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C -
-					       min_density);
+					       density_min);
 		const float delta_rho = _air_density - CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C;
 		climbrate_max = _param_fw_t_clmb_max.get() + density_gradient * delta_rho;
 	}

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -150,6 +150,9 @@ static constexpr float MAX_WEIGHT_RATIO = 2.0f;
 // air density of standard athmosphere at 5000m above mean sea level [kg/m^3]
 static constexpr float AIR_DENSITY_STANDARD_ATMOS_5000_AMSL = 0.7363f;
 
+// air density of standard athmosphere at 1000m above mean sea level [kg/m^3]
+static constexpr float AIR_DENSITY_STANDARD_ATMOS_1000_AMSL = 1.112f;
+
 // climbrate defining the service ceiling, used to compensate max climbrate based on air density
 static constexpr float CLIMBRATE_MIN = 0.5f; // [m/s]
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -150,6 +150,9 @@ static constexpr float MAX_WEIGHT_RATIO = 2.0f;
 // air density of standard athmosphere at 5000m above mean sea level [kg/m^3]
 static constexpr float AIR_DENSITY_STANDARD_ATMOS_5000_AMSL = 0.7363f;
 
+// climbrate defining the service ceiling, used to compensate max climbrate based on air density
+static constexpr float CLIMBRATE_MIN = 0.5f; // [m/s]
+
 // [rad] minimum pitch while airspeed has not yet reached a controllable value in manual position controlled takeoff modes
 static constexpr float MIN_PITCH_DURING_MANUAL_TAKEOFF = 0.0f;
 
@@ -482,6 +485,7 @@ private:
 	 */
 	float get_terrain_altitude_takeoff(float takeoff_alt);
 
+	float getMaximumClimbRate();
 	/**
 	 * @brief Maps the manual control setpoint (pilot sticks) to height rate commands
 	 *
@@ -938,6 +942,8 @@ private:
 
 		(ParamFloat<px4::params::WEIGHT_BASE>) _param_weight_base,
 		(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
+		(ParamFloat<px4::params::FW_DENSITY_MIN>) _param_density_min,
+
 
 		(ParamFloat<px4::params::FW_WING_SPAN>) _param_fw_wing_span,
 		(ParamFloat<px4::params::FW_WING_HEIGHT>) _param_fw_wing_height,

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -1093,3 +1093,18 @@ PARAM_DEFINE_FLOAT(FW_THR_ASPD_MIN, 0.f);
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_THR_ASPD_MAX, 0.f);
+
+
+/**
+ * Service ceiling density
+ *
+ * Air density at which the vehicle in normal configuration is able to achieve a maximum climb rate of
+ * 0.5m/s at maximum throttle (FW_THR_MAX). Used to compensate for air density in FW_CLMB_MAX.
+ * Set < 0 to disable compensation of (FW_T_CLMB_MAX) based on air density.
+ *
+ * @max 1.225
+ * @decimal 2
+ * @increment 0.01
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_DENSITY_MIN, -1.0f);

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -1099,12 +1099,14 @@ PARAM_DEFINE_FLOAT(FW_THR_ASPD_MAX, 0.f);
  * Service ceiling density
  *
  * Air density at which the vehicle in normal configuration is able to achieve a maximum climb rate of
- * 0.5m/s at maximum throttle (FW_THR_MAX). Used to compensate for air density in FW_CLMB_MAX.
- * Set < 0 to disable compensation of (FW_T_CLMB_MAX) based on air density.
+ * 0.5m/s at maximum throttle (FW_THR_MAX). Used to compensate for air density in FW_T_CLMB_MAX.
+ * Will only have an effect if value is between 0.7363 (5000m) and 1.112 (1000m).
  *
+ * @min 0.7363
  * @max 1.225
+ * @unit kg/m^3
  * @decimal 2
  * @increment 0.01
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_DENSITY_MIN, -1.0f);
+PARAM_DEFINE_FLOAT(FW_DENSITY_MIN, 1.225);

--- a/validation/module_schema.yaml
+++ b/validation/module_schema.yaml
@@ -147,7 +147,7 @@ parameters:
                                 'bit/s', 'B/s',
                                 'deg', 'deg*1e7', 'deg/s',
                                 'celcius', 'gauss', 'gauss/s', 'mgauss', 'mgauss^2',
-                                'hPa', 'kg', 'kg/m^2', 'kg m^2',
+                                'hPa', 'kg', 'kg/m^2', 'kg m^2', 'kg/m^3',
                                 'mm', 'm', 'm/s', 'm^2', 'm/s^2', 'm/s^3', 'm/s^2/sqrt(Hz)', 'm/s/rad',
                                 'Ohm', 'V', 'A',
                                 'us', 'ms', 's',


### PR DESCRIPTION
### Solved Problem
In PX4 we currently use the parameter `FW_T_CLMB_MAX` to specify the maximum climbrate the vehicle can achieve. This parameter is very important to get right as it determines the mapping between commanded climbrate and commanded throttle.
If this value is set too large, e.g. the vehicle can not realistically achieve the climbrate at trim airspeed, then there will be a transient phase where airspeed control is degraded (vehicle applies too little throttle to climb).

Generally speaking the maximum climbrate for a fixed wing can be formulated as:

$v = {P_{avail} - P_{req} \over mg}$ (1)

where $P_{avail}$ is the available power to climb, $P_{req}$ is the power required to overcome the drag and $mg$ is the product of vehicle weight and gravity constant.

Furthermore, $P_{avail}$ can be expressed as

$P_{avail} = P_{shaft} * \eta$

where $P_{shaft}$ is the mechanical power available at the propeller shaft and $\eta$ is the propeller efficiency.

From equation (1) we can see that we can directly compensate the maximum climbrate based on the vehicle weight.

We also know that our maximum climbrate decreases with increasing altitude. This is a consequence of the density decreasing and with that the excessive power available for climbing ($P_{avail} - P_{req}$).
This relation is more difficult to model as is depends on the exact propeller efficiency curve.

### Solution
Given the relations explained above this PR proposes to calculate the maximum climbrate at any time based on the base parameter (FW_T_CLMB_MAX), the  weight ratio and air density.
Both the weight ratio and the air density are assumed to influence the maximum climbrate linearly. For the air density this is an approximation but it should be better than not compensating at all.

For the weight ratio we make use of the exiting parameter `WEIGHT_BASE` and `WEIGHT_GROSS`.

For the air density compensation we introduce a new parameter `FW_DENSITY_MIN` which defines the air density at which the vehicle can still achieve a climbrate of 0.5m/s at trim airspeed and maximum throttle.

These assumptions have to be validated experimentally, specifically the benefit of improved altitude and airspeed tracking with different configurations and at different altitudes need to be demonstrated.

### Changelog Entry
For release notes:
- Added option to compensate maximum fixed wing climbrate based on vehicle weight (`WEIGHT_BASE` and `WEIGHT_GROSS`)
- Added option to compensate maximum fixed wing climbrate based on air density (FW_DENSITY_MIN)
```
Feature
New parameter: FW_DENSITY_MIN
Documentation: Defines the air density at which the vehicle can still achieve a climbrate of 0.5m/s at trim airspeed and maximum throttle.
```

### Alternatives
Instead of a minimum density we could also specify at service ceiling (altitude).

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
