### PR TITLE
Fixed Wing: Compensate minimum sink rate based on weight ratio and air density

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -94,16 +94,21 @@ FixedwingPositionControl::init()
 	return true;
 }
 
-float FixedwingPositionControl::getMaximumClimbRate()
+float FixedwingPositionControl::getWeightRatio()
 {
 
 	float weight_factor = 1.0f;
 
 	if (_param_weight_base.get() > 0.0f && _param_weight_gross.get() > 0.0f) {
-		weight_factor = math::constrain(_param_weight_base.get() / _param_weight_gross.get(), MIN_WEIGHT_RATIO,
+		weight_factor = math::constrain(_param_weight_gross.get() / _param_weight_base.get(), MIN_WEIGHT_RATIO,
 						MAX_WEIGHT_RATIO);
 	}
 
+	return weight_factor;
+}
+
+float FixedwingPositionControl::getMaximumClimbRate()
+{
 	float climbrate_max = _param_fw_t_clmb_max.get();
 
 	const float density_min = _param_density_min.get();
@@ -116,7 +121,12 @@ float FixedwingPositionControl::getMaximumClimbRate()
 		climbrate_max = _param_fw_t_clmb_max.get() + density_gradient * delta_rho;
 	}
 
-	return climbrate_max * weight_factor;
+	return climbrate_max / getWeightRatio();
+}
+
+float FixedwingPositionControl::getMinimumSinkRate()
+{
+	return _param_fw_t_sink_min.get() * sqrtf(getWeightRatio() * CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C / _air_density);
 }
 
 int

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -488,7 +488,24 @@ private:
 	 */
 	float get_terrain_altitude_takeoff(float takeoff_alt);
 
+	/**
+	 * @brief Return the maximum climb rate achievable under the current conditions.
+	 * @return Maximum climbrate.
+	 */
 	float getMaximumClimbRate();
+
+	/**
+	 * @brief Return the minimum sink rate achievable under the current conditions.
+	 * @return Minimum sink rate.
+	 */
+	float getMinimumSinkRate();
+
+	/**
+	 * @brief Return the ratio of actual vehicle weight to vehicle base weight.
+	 * @return Weight ratio.
+	 */
+	float getWeightRatio();
+
 	/**
 	 * @brief Maps the manual control setpoint (pilot sticks) to height rate commands
 	 *

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -489,14 +489,14 @@ private:
 	float get_terrain_altitude_takeoff(float takeoff_alt);
 
 	/**
-	 * @brief Return the maximum climb rate achievable under the current conditions.
-	 * @return Maximum climbrate.
+	 * @brief Return the maximum climb rate achievable given the estimated air density and the vehicle weight.
+	 * @return Maximum climbrate [m/s].
 	 */
 	float getMaximumClimbRate();
 
 	/**
-	 * @brief Return the minimum sink rate achievable under the current conditions.
-	 * @return Minimum sink rate.
+	 * @brief Return the minimum sink rate achievable given the estimated air density and the vehicle weight.
+	 * @return Minimum sink rate [m/s].
 	 */
 	float getMinimumSinkRate();
 


### PR DESCRIPTION
### Solved Problem
The minimum sink rate (gliding) of a fixed wing is a function of vehicle weight, air density, wing area and the airfoil polars.
While the wing area and the polars are generally constant, the weight and the air density are likely to change.

In PX4 the parameter `FW_T_SINK_MIN` determines the mapping between commanded sink rate and throttle output. If the commanded sinkrate equals or exceeds `FW_T_SINK_MIN` then generally TECS will command minimum throttle (since we are gliding or maybe even descending faster).

Since the minimum sink rate changes with weight and air density, it's important to compensate for this, as it affects how well TECS tracks desired energy rate.

For both the vehicle weight and the air density there is a square root relation to sinkrate. This makes compensation based on these two factors straightforward.

$V_{sink} = \sqrt{2mg \over {\rho  S}} * f(C_A, C_D)$

where $S$ is the wing area.

### Solution
Compensate minimum sink rate based on weight ration and air density.

### Changelog Entry
For release notes:
```
Feature: Compensate TECS minimum sink speed for weight ratio and air density.
Documentation: Need to clarify TECS tuning.
```

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
