### PR TITLE
ROMFS: rc.fw_defaults set more conservative range finder requirements

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -34,6 +34,7 @@ param set-default EKF2_REQ_EPV 10
 param set-default EKF2_REQ_HDRIFT 0.5
 param set-default EKF2_REQ_SACC 1
 param set-default EKF2_REQ_VDRIFT 1.0
+param set-default EKF2_RNG_QLTY_T 3.0
 
 param set-default RTL_TYPE 1
 param set-default RTL_RETURN_ALT 100


### PR DESCRIPTION
 - for FW the primary range finder usage is estimating the distance to the ground (terrain estimate) to guide the landing approach and initiate flare
 - increase EKF2_RNG_QLTY_T default 1->3 seconds

FYI @ryanjAA 

I wouldn't necessarily claim this is a fix, but is there any real current usage where being more conservative with range finder validity (requiring 3 seconds of consistently good data) would be problematic? 