### PR TITLE
Fix hardfault in uORB calloc implementation

### DIFF
--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -188,7 +188,10 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 			if (nullptr == _data) {
 				const size_t data_size = _meta->o_size * _queue_size;
 				_data = (uint8_t *) px4_cache_aligned_alloc(data_size);
-				if (_data) memset(_data, 0, data_size);
+
+				if (_data) {
+					memset(_data, 0, data_size);
+				}
 			}
 
 			unlock();

--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -188,7 +188,7 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 			if (nullptr == _data) {
 				const size_t data_size = _meta->o_size * _queue_size;
 				_data = (uint8_t *) px4_cache_aligned_alloc(data_size);
-				memset(_data, 0, data_size);
+				if (_data) memset(_data, 0, data_size);
 			}
 
 			unlock();


### PR DESCRIPTION
### Solved Problem

When running out-of-memory, the malloc returns NULL and the memset then tries to write to address 0 which results in a hardfault.

### Solution

I mean… just™ don't write to address 0.

### Changelog Entry

For release notes:
```
Bugfix: Fix hardfault in uORB DeviceNode::write when OOM
```

### Alternatives

We could also… not use dynamic memory. LOL.

### Test coverage

Forced by automatic GDB scripting.

### Context

A [longer analysis of additional hardfault sources in OOM conditions is available here](https://gist.github.com/niklaut/a438bf711d5890099c2d3457b48707a0).
(There'll be more fixes coming).
