### PR TITLE
dataman: explicitly check file existance to init

### DIFF
--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -529,6 +529,8 @@ _file_clear(dm_item_t item)
 static int
 _file_initialize(unsigned max_offset)
 {
+	const bool file_existed = (access(k_data_manager_device_path, F_OK) == 0);
+
 	/* Open or create the data manager file */
 	dm_operations_data.file.fd = open(k_data_manager_device_path, O_RDWR | O_CREAT | O_BINARY, PX4_O_MODE_666);
 
@@ -553,7 +555,7 @@ _file_initialize(unsigned max_offset)
 
 	dm_operations_data.silence = false;
 
-	if (compat_state.key != DM_COMPAT_KEY) {
+	if (!file_existed || (compat_state.key != DM_COMPAT_KEY)) {
 
 		/* Write current compat info */
 		compat_state.key = DM_COMPAT_KEY;


### PR DESCRIPTION
On NuttX if the SD card was just cleared (quick format) it's possible for the newly created dataman file to still have the same compatibility key. If the file was created we should always init.