### PR TITLE
drivers/uwb/uwb_sr150: don't enable by default

### DIFF
--- a/src/drivers/uwb/uwb_sr150/module.yaml
+++ b/src/drivers/uwb/uwb_sr150/module.yaml
@@ -4,7 +4,6 @@ serial_config:
     port_config_param:
       name: UWB_PORT_CFG
       group: UWB
-      default: "TEL2"
 
 parameters:
     - group: UWB


### PR DESCRIPTION
This was running (and failing) by default on the test rack.

<img width="359" alt="Screenshot 2023-09-07 at 7 04 15 PM" src="https://github.com/PX4/PX4-Autopilot/assets/84712/88d77dcf-fb84-4977-8f3b-88d10612df3d">
