### PR TITLE
6x: fix internal mag rotation

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -102,13 +102,8 @@ if ver hwtypecmp V6X002001
 then
 	rm3100 -I -b 4 start
 else
-	if ver hwtypecmp V6X009010 V6X010010
-	then
-		# Internal magnetometer on I2C
-		bmm150 -I -R 0 start
-	else
-		bmm150 -I -R 6 start
-	fi
+	# Internal magnetometer on I2C
+	bmm150 -I -R 0 start
 fi
 
 # External compass on GPS1/I2C1 (the 3rd external bus): standard Holybro Pixhawk 4 or CUAV V5 GPS/compass puck (with lights, safety button, and buzzer)


### PR DESCRIPTION
From looking at the history the BMM150 rotation was initially 0. Then, this was changed to 6 when the intent was to only change it for Skynode.

A bit later, the rotation was changed back to 0, but only for Skynode.

This tells me that rotation 0 was correct for all 6X including Skynode all along.

Tested on my Holybro 6X and 6X mini.

Fixes #22004.

Needs backporting to v1.14.

FYI @baumanta and @marcoraeth.