### PR TITLE
[BACKPORT] FixedwingPositionControl: refine / refactor waypoint navigation methods

### DIFF
--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -59,7 +59,7 @@ void NPFG::guideToPath(const matrix::Vector2f &curr_pos_local, const Vector2f &g
 	const float wind_speed = wind_vel.norm();
 
 	const Vector2f path_pos_to_vehicle{curr_pos_local - position_on_path};
-	const float signed_track_error = unit_path_tangent.cross(path_pos_to_vehicle);
+	signed_track_error_ = unit_path_tangent.cross(path_pos_to_vehicle);
 
 	// on-track wind triangle projections
 	const float wind_cross_upt = wind_vel.cross(unit_path_tangent);
@@ -68,7 +68,7 @@ void NPFG::guideToPath(const matrix::Vector2f &curr_pos_local, const Vector2f &g
 	// calculate the bearing feasibility on the track at the current closest point
 	feas_on_track_ = bearingFeasibility(wind_cross_upt, wind_dot_upt, airspeed, wind_speed);
 
-	const float track_error = fabsf(signed_track_error);
+	const float track_error = fabsf(signed_track_error_);
 
 	// update control parameters considering upper and lower stability bounds (if enabled)
 	// must be called before trackErrorBound() as it updates time_const_
@@ -86,7 +86,7 @@ void NPFG::guideToPath(const matrix::Vector2f &curr_pos_local, const Vector2f &g
 
 	track_proximity_ = trackProximity(look_ahead_ang);
 
-	bearing_vec_ = bearingVec(unit_path_tangent, look_ahead_ang, signed_track_error);
+	bearing_vec_ = bearingVec(unit_path_tangent, look_ahead_ang, signed_track_error_);
 
 	// wind triangle projections
 	const float wind_cross_bearing = wind_vel.cross(bearing_vec_);
@@ -112,7 +112,7 @@ void NPFG::guideToPath(const matrix::Vector2f &curr_pos_local, const Vector2f &g
 
 	// lateral acceleration needed to stay on curved track (assuming no heading error)
 	lateral_accel_ff_ = lateralAccelFF(unit_path_tangent, ground_vel, wind_dot_upt,
-					   wind_cross_upt, airspeed, wind_speed, signed_track_error, path_curvature);
+					   wind_cross_upt, airspeed, wind_speed, signed_track_error_, path_curvature);
 
 	// total lateral acceleration to drive aircaft towards track as well as account
 	// for path curvature. The full effect of the feed-forward acceleration is smoothly

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -156,6 +156,10 @@ void TECSAltitudeReferenceModel::update(const float dt, const AltitudeReferenceS
 	_alt_control_traj_generator.setMaxAccel(param.vert_accel_limit);
 	_alt_control_traj_generator.setMaxVel(fmax(param.max_climb_rate, param.max_sink_rate));
 
+	// XXX: this is a bit risky.. .alt_rate here could be NAN (by interface design) - and is only ok to input to the
+	// setVelSpFeedback() method because it calls the reset in the logic below when it is NAN.
+	// TODO: stop it with the NAN interfaces, make sure to take care of this when refactoring and separating altitude
+	// and height rate control loops.
 	_velocity_control_traj_generator.setVelSpFeedback(setpoint.alt_rate);
 
 	bool control_altitude = true;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1036,8 +1036,11 @@ FixedwingPositionControl::control_auto_position(const float control_interval, co
 		prev_wp(1) = pos_sp_prev.lon;
 
 	} else {
-		// No valid previous waypoint, go along the line between aircraft and current waypoint
-		prev_wp = curr_pos;
+		// No valid previous waypoint, fly directly to current waypoint
+		// NOTE: this is a bad interface - navigateWaypoints() takes two waypoints on top of each other as an
+		// indication it should fly directly to that waypoint. Better would be e.g. an alternative overload with
+		// singular setpoint input. (just an idea for future refactoring/refinement)
+		prev_wp = curr_wp;
 	}
 
 	float tecs_fw_thr_min;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2926,12 +2926,16 @@ void FixedwingPositionControl::navigateLoiter(const Vector2f &loiter_center, con
 			  loiter_center + unit_vec_center_to_closest_pt * radius, path_curvature);
 }
 
-
 void FixedwingPositionControl::navigatePathTangent(const matrix::Vector2f &vehicle_pos,
 		const matrix::Vector2f &position_setpoint,
 		const matrix::Vector2f &tangent_setpoint,
 		const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature)
 {
+	if (tangent_setpoint.norm() <= FLT_EPSILON) {
+		// degenerate case: no direction. maintain the last npfg command.
+		return;
+	}
+
 	const Vector2f unit_path_tangent{tangent_setpoint.normalized()};
 	_target_bearing = atan2f(unit_path_tangent(1), unit_path_tangent(0));
 	_closest_point_on_path = position_setpoint;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -783,11 +783,9 @@ private:
 	 * method of the same name. Takes two waypoints and determines the relevant
 	 * parameters for evaluating the NPFG guidance law, then updates control setpoints.
 	 *
-	 * @param[in] waypoint_A Waypoint A (segment start) position in WGS84 coordinates
-	 *            (lat,lon) [deg]
-	 * @param[in] waypoint_B Waypoint B (segment end) position in WGS84 coordinates
-	 *            (lat,lon) [deg]
-	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] waypoint_A Waypoint A (segment start) position in local coordinates. (N,E) [m]
+	 * @param[in] waypoint_B Waypoint B (segment end) position in local coordinates. (N,E) [m]
+	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
 	 * @param[in] wind_vel Wind velocity vector [m/s]
 	 */
@@ -802,7 +800,7 @@ private:
 	 *
 	 * @param[in] point_on_line_1 Line segment start position in local coordinates. (N,E) [m]
 	 * @param[in] point_on_line_2 Line segment end position in local coordinates. (N,E) [m]
-	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (N,E) [m]
+	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
 	 * @param[in] wind_vel Wind velocity vector [m/s]
 	 */
@@ -843,8 +841,8 @@ private:
 	 * Path following logic. Takes poisiton, path tangent, curvature and
 	 * then updates control setpoints to follow a path setpoint.
 	 *
-	 * @param[in] vehicle_pos vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
-	 * @param[in] position_setpoint closest point on a path in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] vehicle_pos vehicle_pos Vehicle position in local coordinates. (N,E) [m]
+	 * @param[in] position_setpoint closest point on a path in local coordinates. (N,E) [m]
 	 * @param[in] tangent_setpoint unit tangent vector of the path [m]
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
 	 * @param[in] wind_vel Wind velocity vector [m/s]
@@ -860,7 +858,7 @@ private:
 	 * This only holds a certain (ground relative) direction and does not perform
 	 * cross track correction. Helpful for semi-autonomous modes. Similar to navigateHeading.
 	 *
-	 * @param[in] vehicle_pos vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] vehicle_pos vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] bearing Bearing angle [rad]
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
 	 * @param[in] wind_vel Wind velocity vector [m/s]

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -780,8 +780,8 @@ private:
 
 	/*
 	 * Waypoint handling logic following closely to the ECL_L1_Pos_Controller
-	 * method of the same name. Takes two waypoints and determines the relevant
-	 * parameters for evaluating the NPFG guidance law, then updates control setpoints.
+	 * method of the same name. Takes two waypoints, steering the vehicle to track
+	 * the line segment between them.
 	 *
 	 * @param[in] waypoint_A Waypoint A (segment start) position in local coordinates. (N,E) [m]
 	 * @param[in] waypoint_B Waypoint B (segment end) position in local coordinates. (N,E) [m]
@@ -792,6 +792,20 @@ private:
 	void navigateWaypoints(const matrix::Vector2f &waypoint_A, const matrix::Vector2f &waypoint_B,
 			       const matrix::Vector2f &vehicle_pos, const matrix::Vector2f &ground_vel,
 			       const matrix::Vector2f &wind_vel);
+
+	/*
+	 * Takes one waypoint and steers the vehicle towards this.
+	 *
+	 * NOTE: this *will lead to "flowering" behavior if no higher level state machine or
+	 * switching condition changes the waypoint.
+	 *
+	 * @param[in] waypoint_pos Waypoint position in local coordinates. (N,E) [m]
+	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigateWaypoint(const matrix::Vector2f &waypoint_pos, const matrix::Vector2f &vehicle_pos,
+			      const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel);
 
 	/*
 	 * Line (infinite) following logic. Two points on the line are used to define the

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -783,13 +783,13 @@ private:
 	 * method of the same name. Takes two waypoints, steering the vehicle to track
 	 * the line segment between them.
 	 *
-	 * @param[in] waypoint_A Waypoint A (segment start) position in local coordinates. (N,E) [m]
-	 * @param[in] waypoint_B Waypoint B (segment end) position in local coordinates. (N,E) [m]
+	 * @param[in] start_waypoint Segment starting position in local coordinates. (N,E) [m]
+	 * @param[in] end_waypoint Segment end position in local coordinates. (N,E) [m]
 	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
 	 * @param[in] wind_vel Wind velocity vector [m/s]
 	 */
-	void navigateWaypoints(const matrix::Vector2f &waypoint_A, const matrix::Vector2f &waypoint_B,
+	void navigateWaypoints(const matrix::Vector2f &start_waypoint, const matrix::Vector2f &end_waypoint,
 			       const matrix::Vector2f &vehicle_pos, const matrix::Vector2f &ground_vel,
 			       const matrix::Vector2f &wind_vel);
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -287,8 +287,7 @@ private:
 	bool _hdg_hold_enabled{false}; // heading hold enabled
 	bool _yaw_lock_engaged{false}; // yaw is locked for heading hold
 
-	position_setpoint_s _hdg_hold_prev_wp{}; // position where heading hold started
-	position_setpoint_s _hdg_hold_curr_wp{}; // position to which heading hold flies
+	position_setpoint_s _hdg_hold_position{}; // position where heading hold started
 
 	// [.] normalized setpoint for manual altitude control [-1,1]; -1,0,1 maps to min,zero,max height rate commands
 	float _manual_control_setpoint_for_height_rate{0.0f};

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -812,8 +812,8 @@ private:
 	 * line in 2D space (first to second point determines the direction). Determines the
 	 * relevant parameters for evaluating the NPFG guidance law, then updates control setpoints.
 	 *
-	 * @param[in] point_on_line_1 Line segment start position in local coordinates. (N,E) [m]
-	 * @param[in] point_on_line_2 Line segment end position in local coordinates. (N,E) [m]
+	 * @param[in] point_on_line_1 Arbitrary first position on line in local coordinates. (N,E) [m]
+	 * @param[in] point_on_line_2 Arbitrary second position on line in local coordinates. (N,E) [m]
 	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
 	 * @param[in] wind_vel Wind velocity vector [m/s]
@@ -855,6 +855,8 @@ private:
 	 * Path following logic. Takes poisiton, path tangent, curvature and
 	 * then updates control setpoints to follow a path setpoint.
 	 *
+	 * TODO: deprecate this function with a proper API to NPFG.
+	 *
 	 * @param[in] vehicle_pos vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] position_setpoint closest point on a path in local coordinates. (N,E) [m]
 	 * @param[in] tangent_setpoint unit tangent vector of the path [m]
@@ -870,7 +872,7 @@ private:
 	 * Navigate on a fixed bearing.
 	 *
 	 * This only holds a certain (ground relative) direction and does not perform
-	 * cross track correction. Helpful for semi-autonomous modes. Similar to navigateHeading.
+	 * cross track correction. Helpful for semi-autonomous modes.
 	 *
 	 * @param[in] vehicle_pos vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] bearing Bearing angle [rad]

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -733,15 +733,6 @@ private:
 	float constrainRollNearGround(const float roll_setpoint, const float altitude, const float terrain_altitude) const;
 
 	/**
-	 * @brief Calculates the unit takeoff bearing vector from the launch position to takeoff waypont.
-	 *
-	 * @param launch_position Vehicle launch position in local coordinates (NE) [m]
-	 * @param takeoff_waypoint Takeoff waypoint position in local coordinates (NE) [m]
-	 * @return Unit takeoff bearing vector
-	 */
-	Vector2f calculateTakeoffBearingVector(const Vector2f &launch_position, const Vector2f &takeoff_waypoint) const;
-
-	/**
 	 * @brief Calculates the touchdown position for landing with optional manual lateral adjustments.
 	 *
 	 * Manual inputs (from the remote) are used to command a rate at which the position moves and the integrated
@@ -805,12 +796,40 @@ private:
 			       const matrix::Vector2f &wind_vel);
 
 	/*
+	 * Line (infinite) following logic. Two points on the line are used to define the
+	 * line in 2D space (first to second point determines the direction). Determines the
+	 * relevant parameters for evaluating the NPFG guidance law, then updates control setpoints.
+	 *
+	 * @param[in] point_on_line_1 Line segment start position in local coordinates. (N,E) [m]
+	 * @param[in] point_on_line_2 Line segment end position in local coordinates. (N,E) [m]
+	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (N,E) [m]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigateLine(const Vector2f &point_on_line_1, const Vector2f &point_on_line_2, const Vector2f &vehicle_pos,
+			  const Vector2f &ground_vel, const Vector2f &wind_vel);
+
+	/*
+	 * Line (infinite) following logic. One point on the line and a line bearing are used to define
+	 * the line in 2D space. Determines the relevant parameters for evaluating the NPFG guidance law,
+	 * then updates control setpoints.
+	 *
+	 * @param[in] point_on_line Arbitrary position on line in local coordinates. (N,E) [m]
+	 * @param[in] line_bearing Line bearing [rad] (from north)
+	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigateLine(const Vector2f &point_on_line, const float line_bearing, const Vector2f &vehicle_pos,
+			  const Vector2f &ground_vel, const Vector2f &wind_vel);
+
+	/*
 	 * Loitering (unlimited) logic. Takes loiter center, radius, and direction and
 	 * determines the relevant parameters for evaluating the NPFG guidance law,
 	 * then updates control setpoints.
 	 *
 	 * @param[in] loiter_center The position of the center of the loiter circle [m]
-	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] vehicle_pos Vehicle position in local coordinates. (N,E) [m]
 	 * @param[in] radius Loiter radius [m]
 	 * @param[in] loiter_direction_counter_clockwise Specifies loiter direction
 	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]


### PR DESCRIPTION
Backport #21988

### Changelog Entry
For release notes:
```
Bugfix FixedwingPositionControl: Fixes landing regression where the vehicle could turn back towards the landing point after passing it.
Documentation: Should update docs.px4.io/ with waypoint logic description and perhaps the figure included above.
```