### PR TITLE
Allow UavcanEscController to operate using KDECAN protocol

### DIFF
--- a/msg/EscReport.msg
+++ b/msg/EscReport.msg
@@ -14,6 +14,9 @@ uint8 actuator_function				# actuator output function (one of Motor1...MotorN)
 uint16 failures					# Bitmask to indicate the internal ESC faults
 int8 esc_power					# Applied power 0-100 in % (negative values reserved)
 
+uint16 input_throttle				# input throttle that was given to the ESC
+float32 output_throttle				# output throttle that the ESC is trying to achieve as a percentage of the maximum throttle
+
 uint8 FAILURE_OVER_CURRENT = 0 			# (1 << 0)
 uint8 FAILURE_OVER_VOLTAGE = 1 			# (1 << 1)
 uint8 FAILURE_MOTOR_OVER_TEMPERATURE = 2 	# (1 << 2)

--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -45,10 +45,20 @@
 
 using namespace time_literals;
 
-UavcanEscController::UavcanEscController(uavcan::INode &node) :
+UavcanEscController::UavcanEscController(uavcan::INode &node, uavcan::Protocol can_protocol) :
 	_node(node),
 	_uavcan_pub_raw_cmd(node),
-	_uavcan_sub_status(node)
+	_uavcan_sub_status(node),
+	_orb_timer(node),
+	_kde_status_pub(node),
+	_kde_status_sub(node),
+	_kde_ith_sub(node),
+	_kde_ith_pub(node),
+	_kde_oth_sub(node),
+	_kde_oth_pub(node),
+	_kde_pwm_pub(node),
+	_can_protocol(can_protocol),
+	_extended_id(true)
 {
 	_uavcan_pub_raw_cmd.setPriority(uavcan::TransferPriority::NumericallyMin); // Highest priority
 }
@@ -56,17 +66,31 @@ UavcanEscController::UavcanEscController(uavcan::INode &node) :
 int
 UavcanEscController::init()
 {
-	// ESC status subscription
-	int res = _uavcan_sub_status.start(StatusCbBinder(this, &UavcanEscController::esc_status_sub_cb));
+	// ESC status subscription (only enabled if in UAVCAN mode)
+	if (_can_protocol == uavcan::Protocol::Standard) {
+		int res = _uavcan_sub_status.start(StatusCbBinder(this, &UavcanEscController::esc_status_sub_cb));
 
-	if (res < 0) {
-		PX4_ERR("ESC status sub failed %i", res);
-		return res;
+		if (res < 0) {
+			PX4_ERR("ESC status sub failed %i", res);
+			return res;
+		}
+
+		_esc_status_pub.advertise();
+
+	} else if (_can_protocol == kdecan::protocolID) {
+		_kde_status_sub.setCallback(KdeStatusCbBinder(this, &UavcanEscController::kdeesc_status_sub_cb));
+		_kde_ith_sub.setCallback(KdeInputThrottleCbBinder(this, &UavcanEscController::kdeesc_input_throttle_sub_cb));
+		_kde_oth_sub.setCallback(KdeOutputThrottleCbBinder(this, &UavcanEscController::kdeesc_output_throttle_sub_cb));
+		_node.getDispatcher().registerCustomCanListener(_kde_status_sub.getKdeListener());
+		_node.getDispatcher().registerCustomCanListener(_kde_ith_sub.getKdeListener());
+		_node.getDispatcher().registerCustomCanListener(_kde_oth_sub.getKdeListener());
+
+		// Callback needed to trigger status queries
+		_orb_timer.setCallback(TimerCbBinder(this, &UavcanEscController::kdeesc_status_timer_cb));
+		_orb_timer.startPeriodic(uavcan::MonotonicDuration::fromMSec(1000 / ESC_STATUS_UPDATE_RATE_HZ));
 	}
 
-	_esc_status_pub.advertise();
-
-	return res;
+	return OK;
 }
 
 void
@@ -83,45 +107,62 @@ UavcanEscController::update_outputs(bool stop_motors, uint16_t outputs[MAX_ACTUA
 
 	_prev_cmd_pub = timestamp;
 
-	/*
-	 * Fill the command message
-	 * If unarmed, we publish an empty message anyway
-	 */
-	uavcan::equipment::esc::RawCommand msg;
+	if (_can_protocol == uavcan::Protocol::Standard) {\
 
-	for (unsigned i = 0; i < num_outputs; i++) {
-		if (stop_motors || outputs[i] == DISARMED_OUTPUT_VALUE) {
-			msg.cmd.push_back(static_cast<unsigned>(0));
+		/*
+		 * Fill the command message
+		 * If unarmed, we publish an empty message anyway
+		 */
+		uavcan::equipment::esc::RawCommand msg;
 
-		} else {
-			msg.cmd.push_back(static_cast<int>(outputs[i]));
+		for (unsigned i = 0; i < num_outputs; i++) {
+			if (stop_motors || outputs[i] == DISARMED_OUTPUT_VALUE) {
+				msg.cmd.push_back(static_cast<unsigned>(0));
+
+			} else {
+				msg.cmd.push_back(static_cast<int>(outputs[i]));
+			}
+		}
+
+		/*
+		 * Remove channels that are always zero.
+		 * transfer would be enough. This is a valid optimization as the UAVCAN specification implies that all
+		 * non-specified ESC setpoints should be considered zero.
+		 * The positive outcome is a (marginally) lower bus traffic and lower CPU load.
+		 *
+		 * From the standpoint of the PX4 architecture, however, this is a hack. It should be investigated why
+		 * the mixer returns more outputs than are actually used.
+		 */
+		for (int index = int(msg.cmd.size()) - 1; index >= _max_number_of_nonzero_outputs; index--) {
+			if (msg.cmd[index] != 0) {
+				_max_number_of_nonzero_outputs = index + 1;
+				break;
+			}
+		}
+
+		msg.cmd.resize(_max_number_of_nonzero_outputs);
+
+		/*
+		 * Publish the command message to the bus
+		 * Note that for a quadrotor it takes one CAN frame
+		 */
+		_uavcan_pub_raw_cmd.broadcast(msg);
+
+	} else if (_can_protocol == kdecan::protocolID) {
+		// Fill and publish the command message - one command per each ESC
+		for (unsigned i = 0; i < num_outputs; i++) {
+			uint16_t kdecan_output = 0;
+
+			if (stop_motors || outputs[i] == DISARMED_OUTPUT_VALUE) {
+				kdecan_output = kdecan::minPwmValue;
+
+			} else {
+				kdecan_output = kdecan::minPwmValue + (uint16_t)(((float)outputs[i]/max_output_value()) * (kdecan::maxPwmValue - kdecan::minPwmValue));
+			}
+
+			_kde_pwm_pub.publish(kdecan::PwmThrottle(kdecan::escNodeIdOffset + i, kdecan_output), _extended_id);
 		}
 	}
-
-	/*
-	 * Remove channels that are always zero.
-	 * The objective of this optimization is to avoid broadcasting multi-frame transfers when a single frame
-	 * transfer would be enough. This is a valid optimization as the UAVCAN specification implies that all
-	 * non-specified ESC setpoints should be considered zero.
-	 * The positive outcome is a (marginally) lower bus traffic and lower CPU load.
-	 *
-	 * From the standpoint of the PX4 architecture, however, this is a hack. It should be investigated why
-	 * the mixer returns more outputs than are actually used.
-	 */
-	for (int index = int(msg.cmd.size()) - 1; index >= _max_number_of_nonzero_outputs; index--) {
-		if (msg.cmd[index] != 0) {
-			_max_number_of_nonzero_outputs = index + 1;
-			break;
-		}
-	}
-
-	msg.cmd.resize(_max_number_of_nonzero_outputs);
-
-	/*
-	 * Publish the command message to the bus
-	 * Note that for a quadrotor it takes one CAN frame
-	 */
-	_uavcan_pub_raw_cmd.broadcast(msg);
 }
 
 void
@@ -153,6 +194,70 @@ UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<uavca
 		_esc_status_pub.publish(_esc_status);
 	}
 }
+
+void
+UavcanEscController::kdeesc_status_sub_cb(const kdecan::EscStatus& received_structure)
+{
+	if (received_structure.source_address_ - kdecan::escNodeIdOffset < esc_status_s::CONNECTED_ESC_MAX) {
+		auto &ref = _esc_status.esc[received_structure.source_address_  - kdecan::escNodeIdOffset];
+
+		/*PX4_INFO("status received: id=%d V=%.4f C=%.4F RPM=%.4f T=%d Warn=%d",
+			received_structure.source_address_,
+			(double)received_structure.voltage_,
+			(double)received_structure.current_,
+			(double)received_structure.erpm_,
+			received_structure.temperature_,
+			received_structure.warnings_);*/
+
+		ref.esc_address     = received_structure.source_address_;
+		ref.timestamp       = hrt_absolute_time();
+		ref.esc_voltage     = received_structure.voltage_;
+		ref.esc_current     = received_structure.current_;
+		ref.esc_temperature = received_structure.temperature_;
+		ref.esc_rpm         = received_structure.erpm_ / _kdecan_motor_poles;
+		ref.esc_errorcount  = received_structure.warnings_;
+	}
+}
+
+void
+UavcanEscController::kdeesc_input_throttle_sub_cb(const kdecan::InputThrottle& received_structure)
+{
+	if (received_structure.source_address_ - kdecan::escNodeIdOffset < esc_status_s::CONNECTED_ESC_MAX) {
+		auto &ref = _esc_status.esc[received_structure.source_address_  - kdecan::escNodeIdOffset];
+
+		/*PX4_INFO("in throttle: id = %d Th=%d",
+			received_structure.source_address_,
+			received_structure.input_throttle_);*/
+
+		ref.input_throttle = received_structure.input_throttle_;
+	}
+}
+
+void
+UavcanEscController::kdeesc_output_throttle_sub_cb(const kdecan::OutputThrottle& received_structure)
+{
+	if (received_structure.source_address_ - kdecan::escNodeIdOffset < esc_status_s::CONNECTED_ESC_MAX) {
+		auto &ref = _esc_status.esc[received_structure.source_address_  - kdecan::escNodeIdOffset];
+
+		/*PX4_INFO("out throttle: id = %d Th=%.4f",
+			received_structure.source_address_,
+			(double)received_structure.output_throttle_);*/
+
+		ref.output_throttle = received_structure.output_throttle_;
+	}
+}
+
+void
+UavcanEscController::kdeesc_status_timer_cb(const uavcan::TimerEvent &)
+{
+	// we need to actively send a request for the KDE protocol
+	if (_can_protocol == kdecan::protocolID) {
+		_kde_status_pub.publish(kdecan::EscStatus(kdecan::escNodeIdBroadcast), _extended_id);
+		_kde_ith_pub.publish(kdecan::InputThrottle(kdecan::escNodeIdBroadcast), _extended_id);
+		_kde_oth_pub.publish(kdecan::OutputThrottle(kdecan::escNodeIdBroadcast), _extended_id);
+	}
+}
+
 
 uint8_t
 UavcanEscController::check_escs_status()

--- a/src/drivers/uavcan/third_party_protocols/kdecan.hpp
+++ b/src/drivers/uavcan/third_party_protocols/kdecan.hpp
@@ -1,0 +1,450 @@
+#ifndef UAVCAN_KDECAN_HPP_INCLUDED
+#define UAVCAN_KDECAN_HPP_INCLUDED
+
+#include "third_party_protocols.hpp"
+
+namespace kdecan
+{
+
+static const int escNodeIdBroadcast = 1;
+static const int escNodeIdOffset = 2;
+static const int minPwmValue = 1100;
+static const int maxPwmValue = 1940;
+
+static const int MASTER_NODE_ID = 0;
+
+enum kdeCanObjAddr
+{
+	ESCInformation = 0,
+	PWMThrottle = 1,
+	ESCInputThrottle = 6,
+	ESCOutputThrottle = 7,
+	ESCStatus = 11,
+	GetMCUId = 8,
+	UpdateNodeAddress = 9,
+	StartESCEnumeration = 10,
+	Shutdown = 32,
+	Restart = 33,
+	Invalid = 50
+};
+
+class KdeFrame
+{
+public:
+	static const uint8_t PayloadCapacity = 8;
+
+	KdeFrame(const uavcan::CanRxFrame& in_can_frame)
+	{
+		parse(in_can_frame);
+	}
+
+	KdeFrame(const uint8_t source_address,
+		 const uint8_t destination_address,
+		 const kdeCanObjAddr object_address,
+		 const uint8_t* data,
+		 const uint8_t data_length) :
+		source_address_(source_address),
+		destination_address_(destination_address),
+		object_address_(object_address)
+	{
+		const uint8_t adjusted_data_length = (PayloadCapacity > data_length) ? data_length : PayloadCapacity;
+
+		memcpy(data_, data, adjusted_data_length);
+		data_length_ = adjusted_data_length;
+	}
+
+	uint8_t getSourceAddress() const { return source_address_; }
+	uint8_t getDestinationAddress() const { return destination_address_; }
+	kdeCanObjAddr getObjectAddress() const { return object_address_; }
+	const uint8_t *getData() const { return data_; }
+
+	void parse(const uavcan::CanRxFrame& in_can_frame)
+	{
+		uint32_t can_id = in_can_frame.id;
+
+		uint8_t object_address;
+
+		const bool extended_id = (in_can_frame.id & uavcan::CanFrame::FlagEFF) != 0;
+
+		if (extended_id)
+		{
+			object_address = can_id & 0x000000FF;
+			destination_address_ = (can_id & 0x0000FF00) >> 8;
+			source_address_ = (can_id & 0x00FF0000) >> 16;
+			data_length_ = in_can_frame.dlc;
+
+			if (destination_address_ != MASTER_NODE_ID)
+			{
+				object_address = Invalid;
+			}
+		}
+		else
+		{
+			object_address = can_id & 0x0000001F;
+			source_address_ = (can_id >> 5) & 0x0000001F; // ((can_id & 0x000003E0) >> 5);
+			destination_address_ = (can_id >> 10) & 0x0000001F; // ((can_id & 0x00000400) >> 10);
+			data_length_ = in_can_frame.dlc;
+
+			if (destination_address_ != 1)
+			{
+				object_address = Invalid;
+			}
+		}
+
+		switch(object_address)
+		{
+			case ESCInformation: { object_address_ = (data_length_ >= 5) ? ESCInformation : Invalid; } break;
+			case PWMThrottle: { object_address_ = (data_length_ >= 2) ? PWMThrottle : Invalid; } break;
+			case ESCInputThrottle: { object_address_ = (data_length_ >= 2) ? ESCInputThrottle : Invalid; } break;
+			case ESCOutputThrottle: { object_address_ = (data_length_ >= 1) ? ESCOutputThrottle : Invalid; } break;
+			case ESCStatus: { object_address_ = (data_length_ >= 8) ? ESCStatus : Invalid; } break;
+			case GetMCUId: { object_address_ = (data_length_ >= 8) ? GetMCUId : Invalid; } break;
+			case UpdateNodeAddress: { object_address_ = (data_length_ >= 1) ? UpdateNodeAddress : Invalid; } break;
+			case StartESCEnumeration: { object_address_ = (data_length_ >= 8) ? StartESCEnumeration : Invalid; } break;
+			case Shutdown: { object_address_ = (data_length_ >= 1) ? Shutdown : Invalid; } break;
+			case Restart: { object_address_ = (data_length_ >= 1) ? Restart : Invalid; } break;
+			default: { object_address_ = Invalid; }
+		}
+
+		memcpy(data_, in_can_frame.data, data_length_);
+	}
+
+	bool compile(uavcan::CanFrame& out_can_frame, const bool extended_id)
+	{
+		return compile(out_can_frame.id, out_can_frame.dlc, out_can_frame.data, extended_id);
+	}
+
+	bool compile(uint32_t& id, uint8_t& dlc, uint8_t* data, const bool extended_id)
+
+	{
+		if (extended_id)
+		{
+			id = ((uint32_t)0x00000000) |
+			     ((uint32_t)object_address_) |
+			     (((uint32_t)destination_address_) << 8) |
+			     (((uint32_t)source_address_) << 16) |
+			     uavcan::CanFrame::FlagEFF;
+		}
+		else
+		{
+			id = ((uint32_t)0x00000000) |
+			     ((uint32_t)object_address_ & 0x0000001F) |
+			     (((uint32_t)destination_address_ & 0x0000001F) << 5);
+		}
+
+		switch(object_address_)
+		{
+			case ESCInformation: { dlc = 0; } break;
+			case PWMThrottle: { dlc = 2; } break;
+			case ESCInputThrottle: { dlc = 0; } break;
+			case ESCOutputThrottle: { dlc = 0; } break;
+			case ESCStatus: { dlc = 0; } break;
+			case GetMCUId: { dlc = 0; } break;
+			case UpdateNodeAddress: { dlc = 8; } break;
+			case StartESCEnumeration: { dlc = 2; } break;
+			case Shutdown: { dlc = 0; } break;
+			case Restart: { dlc = 0; } break;
+
+			default: { return false; }
+		}
+
+		// this function will take care of little/big endian conversions
+		(void)uavcan::copy(data_, data_ + dlc, data);
+
+		return true;
+	}
+private:
+	uint8_t source_address_;
+	uint8_t destination_address_;
+	kdeCanObjAddr object_address_;
+	uint8_t data_[PayloadCapacity];
+	uint8_t data_length_;
+};
+
+
+class KdecanType
+{
+public:
+	KdecanType() { valid_ = true; }
+
+	virtual bool parse(const KdeFrame& frame) { return true; }
+
+	virtual void generate_data(uint8_t* data) { memset(data, 0, KdeFrame::PayloadCapacity); }
+
+	bool isValid() const { return valid_; }
+
+protected:
+	bool valid_;
+};
+
+
+class EscStatus : public KdecanType
+{
+public:
+	static const kdeCanObjAddr object_address_ = ESCStatus;
+
+	uint8_t source_address_;
+
+	float voltage_;
+	float current_;
+	uint32_t erpm_;
+	uint16_t temperature_;
+	uint16_t warnings_;
+
+	EscStatus() { valid_ = false;}
+
+	EscStatus(const KdeFrame& frame) { valid_ = parse(frame); }
+
+	EscStatus(uint8_t source_address, float voltage = 0.0f, float current = 0.0f, uint32_t erpm = 0, uint16_t temperature = 0, uint16_t warnings = 0) :
+		KdecanType(),
+		source_address_(source_address),
+		voltage_(voltage),
+		current_(current),
+		erpm_(erpm),
+		temperature_(temperature),
+		warnings_(warnings)
+	{ ; }
+
+	bool parse(const KdeFrame& frame) override
+	{
+		source_address_ = frame.getSourceAddress();
+
+		if (frame.getObjectAddress() == object_address_)
+		{
+			const uint8_t* data = frame.getData();
+
+			voltage_ = (float)(data[1] + (0xFF00 & (data[0] << 8))) / 100.0f;
+			current_ = (float)(data[3] + (0xFF00 & (data[2] << 8))) / 100.0f;
+			erpm_ = (int)(data[5] + (0xFF00 & (data[4] << 8))) * 60 * 2;
+			temperature_ = data[6];
+			warnings_ = data[7];
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+class InputThrottle : public KdecanType
+{
+public:
+	static const kdeCanObjAddr object_address_ = ESCInputThrottle;
+
+	uint8_t source_address_;
+
+	uint16_t input_throttle_;
+
+	InputThrottle() { valid_ = false;}
+
+	InputThrottle(const KdeFrame& frame) { valid_ = parse(frame); }
+
+	InputThrottle(uint8_t source_address, float input_throttle = 0.0f) :
+		KdecanType(),
+		source_address_(source_address),
+		input_throttle_(input_throttle)
+	{ ; }
+
+	bool parse(const KdeFrame& frame) override
+	{
+		source_address_ = frame.getSourceAddress();
+
+		if (frame.getObjectAddress() == object_address_)
+		{
+			const uint8_t* data = frame.getData();
+
+			input_throttle_ = (data[1] + (0xFF00 & (data[0] << 8)));
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+class OutputThrottle : public KdecanType
+{
+public:
+	static const kdeCanObjAddr object_address_ = ESCOutputThrottle;
+
+	uint8_t source_address_;
+
+	float output_throttle_;
+
+	OutputThrottle() { valid_ = false; }
+
+	OutputThrottle(const KdeFrame& frame) { valid_ = parse(frame); }
+
+	OutputThrottle(uint8_t source_address, float output_throttle = 0.0f) :
+		KdecanType(),
+		source_address_(source_address),
+		output_throttle_(output_throttle)
+	{ ; }
+
+	bool parse(const KdeFrame& frame) override
+	{
+		source_address_ = frame.getSourceAddress();
+
+		if (frame.getObjectAddress() == object_address_)
+		{
+			const uint8_t* data = frame.getData();
+
+			output_throttle_ = (float)data[0] / 100.0f;
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
+class PwmThrottle : public KdecanType
+{
+public:
+	static const kdeCanObjAddr object_address_ = PWMThrottle;
+
+	uint8_t source_address_;
+
+	uint16_t pwm_throttle_;
+
+	PwmThrottle() { valid_ = false; }
+
+	PwmThrottle(const KdeFrame& frame) { valid_ = parse(frame); }
+
+	PwmThrottle(uint8_t source_address, uint16_t pwm_throttle) :
+		KdecanType(),
+		source_address_(source_address),
+		pwm_throttle_(pwm_throttle)
+	{
+		valid_ = true;
+	}
+
+	void generate_data(uint8_t* data) override
+	{
+		data[0] = (uint8_t)((0xFF00 & pwm_throttle_) >> 8);
+		data[1] = (uint8_t)(0x00FF & pwm_throttle_);
+	}
+};
+
+
+
+template <typename DataType_,
+#if UAVCAN_CPP_VERSION >= UAVCAN_CPP11
+	typename Callback_ = std::function<void (const DataType_&)>
+#else
+	typename Callback_ = void (*)(const DataType_&)
+#endif
+>
+class Subscriber
+{
+public:
+	typedef Subscriber<DataType_, Callback_> SelfType;
+	typedef Callback_ Callback;
+
+	class kdeTransferForwarder : public uavcan::CustomTransferListener
+	{
+	public:
+		SelfType& obj_;
+
+		bool handleFrame(const uavcan::CanRxFrame& can_frame, uavcan::Protocol protocol) override
+		{
+			if (protocol == kdecan::protocolID || !can_frame.isExtended())
+			{
+				return obj_.handleIncomingTransfer(can_frame);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		kdeTransferForwarder(SelfType& obj) :
+			uavcan::CustomTransferListener(kdecan::protocolID),
+			obj_(obj)
+		{;}
+	};
+
+	uavcan::INode& node_;
+	Callback callback_;
+	kdeTransferForwarder forwarder_;
+	kdeCanObjAddr target_object_address_;
+
+	Subscriber(uavcan::INode& node) :
+		node_(node),
+		callback_(),
+		forwarder_(*this),
+		target_object_address_(DataType_::object_address_)
+	{;}
+
+	bool handleIncomingTransfer(const uavcan::CanRxFrame& can_frame)
+	{
+		const KdeFrame incoming_frame(can_frame);
+		const DataType_ received_structure = DataType_(incoming_frame);
+
+		if (received_structure.isValid())
+		{
+			if(callback_)
+			{
+				callback_(received_structure);
+			}
+
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	void setCallback(Callback callback)
+	{
+		callback_ = callback;
+	}
+
+	uavcan::CustomTransferListener* getKdeListener()
+	{
+		return &(this->forwarder_);
+	}
+};
+
+template <typename DataType_>
+class Publisher
+{
+public:
+	uavcan::INode& node_;
+	kdeCanObjAddr target_object_address_;
+
+	Publisher(uavcan::INode& node) :
+		node_(node),
+		target_object_address_(DataType_::object_address_)
+	{;}
+
+	bool publish(DataType_ outgoing_structure, const bool extended_id)
+	{
+		uint8_t data[KdeFrame::PayloadCapacity];
+
+		outgoing_structure.generate_data(data);
+
+		KdeFrame kde_frame(MASTER_NODE_ID, outgoing_structure.source_address_, target_object_address_, data, KdeFrame::PayloadCapacity);
+
+		uavcan::CanFrame can_frame;
+		kde_frame.compile(can_frame, extended_id);
+
+		// in case we are not using the extended ID, we are assuming that we should be using the same protocol as the
+		// standard UAVCAN protocol
+		node_.getDispatcher().getCanIOManager().send(can_frame,
+							     extended_id ? kdecan::protocolID : uavcan::Protocol::Standard,
+							     node_.getMonotonicTime() + uavcan::MonotonicDuration::fromMSec(100),
+							     uavcan::MonotonicTime(),
+							     (uint8_t)0xFF,
+							     uavcan::CanTxQueue::Qos::Volatile,
+							     uavcan::CanIOFlags(0));
+
+		// so far we do no checks in this
+		return true;
+	}
+};
+
+};
+
+#endif // UAVCAN_KDECAN_HPP_INCLUDED

--- a/src/drivers/uavcan/third_party_protocols/third_party_protocols.hpp
+++ b/src/drivers/uavcan/third_party_protocols/third_party_protocols.hpp
@@ -1,0 +1,14 @@
+#ifndef UAVCAN_THIRD_PARTY_PROTOCOLS_HPP_INCLUDED
+#define UAVCAN_THIRD_PARTY_PROTOCOLS_HPP_INCLUDED
+
+#include <uavcan/transport/custom_protocols.hpp>
+#include <uavcan/node/abstract_node.hpp>
+
+namespace kdecan
+{
+
+static const uavcan::Protocol protocolID = uavcan::Protocol::Custom1;
+
+};
+
+#endif  // UAVCAN_INDEPENDENT_KDECAN_HPP_INCLUDED

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -378,3 +378,48 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_RNG, 0);
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_SUB_BTN, 0);
+
+/**
+ * CAN protocol selection for interface 1
+ *
+ *
+ * @min 0
+ * @max 1
+ * @value 0 UAVCAN
+ * @value 1 KDECAN
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CAN1_PROTO, 0);
+
+/**
+ * CAN protocol selection for interface 2
+ *
+ *
+ * @min 0
+ * @max 1
+ * @value 0 UAVCAN
+ * @value 1 KDECAN
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CAN2_PROTO, 0);
+
+/**
+ * CAN protocol selection for esc controls
+ *
+ *
+ * @min 0
+ * @max 1
+ * @value 0 UAVCAN
+ * @value 1 KDECAN
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(CAN_ESC_PROTO, 0);
+
+/**
+ * KDECAN motor pole number for RPM conversion
+ *
+ * @min 0
+ * @max 100
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(KDECAN_MOT_POLES, 28);


### PR DESCRIPTION
It is based on the PR in dronecan to allow tunneling of custom CAN protocol through the uavcan driver: https://github.com/dronecan/libuavcan/pull/16 (most likely need to wait for its approval, and then cross-check hash of libuavcan submodule).

Some uavcan parameters are created to define the intended behavior of the uavcan node. By default it will only read/send UAVCAN messages, and not allow other protocols. The other operating modes, and performed test cases are described in the above PR.
