### PR TITLE
Fix opt flow logging for EKF2 replay

### DIFF
--- a/src/modules/ekf2/test/sensor_simulator/convertULogToSensorData.py
+++ b/src/modules/ekf2/test/sensor_simulator/convertULogToSensorData.py
@@ -22,14 +22,14 @@ def getVioData(ulog: ULog) -> pd.DataFrame:
 
 def getOpticalFlowData(ulog: ULog) -> pd.DataFrame:
 
-	optical_flow = ulog.get_dataset("optical_flow").data
+	optical_flow = ulog.get_dataset("vehicle_optical_flow").data
 	flow = pd.DataFrame({'timestamp': optical_flow['timestamp'],
 	'sensor' : 'flow',
-	'pixel_flow_x_integral': optical_flow["pixel_flow_x_integral"],
-	'pixel_flow_y_integral': optical_flow["pixel_flow_y_integral"],
-	'gyro_x_rate_integral': optical_flow["gyro_x_rate_integral"],
-	'gyro_y_rate_integral': optical_flow["gyro_y_rate_integral"],
-	'gyro_z_rate_integral': optical_flow["gyro_z_rate_integral"],
+	'pixel_flow_x': optical_flow["pixel_flow[0]"],
+	'pixel_flow_y': optical_flow["pixel_flow[1]"],
+	'delta_angle_x': optical_flow["delta_angle[0]"],
+	'delta_angle_y': optical_flow["delta_angle[1]"],
+	'delta_angle_z': optical_flow["delta_angle[2]"],
 	'quality': optical_flow["quality"]
 		})
 	return flow

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -330,7 +330,7 @@ void LoggedTopics::add_estimator_replay_topics()
 
 	// current EKF2 subscriptions
 	add_topic("airspeed");
-	add_topic("optical_flow");
+	add_topic("vehicle_optical_flow");
 	add_topic("sensor_combined");
 	add_topic("sensor_selection");
 	add_topic("vehicle_air_data");


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Optical flow data isn't logged at full rate when ekf replay logging is selected

### Solution
optical_flow got replaced by sensor_optical_flow and vehicle_optical_flow in https://github.com/PX4/PX4-Autopilot/pull/19714 but we forgot to also rename it in two places

### Changelog Entry
For release notes:
```
Fix vehicle_optical_flow logging for EKF2 replay
```

### Test coverage
bench tested