### PR TITLE
Allow changing parameters during replay

### DIFF
--- a/src/modules/replay/Replay.cpp
+++ b/src/modules/replay/Replay.cpp
@@ -65,6 +65,7 @@
 #include "ReplayEkf2.hpp"
 
 #define PARAMS_OVERRIDE_FILE PX4_ROOTFSDIR "/replay_params.txt"
+#define DYNAMIC_PARAMS_OVERRIDE_FILE PX4_ROOTFSDIR "/replay_params_dynamic.txt"
 
 using namespace std;
 using namespace time_literals;
@@ -125,6 +126,38 @@ Replay::setupReplayFile(const char *file_name)
 }
 
 void
+Replay::setParameter(const string &parameter_name, const double parameter_value)
+{
+	param_t handle = param_find(parameter_name.c_str());
+	param_type_t param_format = param_type(handle);
+
+	if (param_format == PARAM_TYPE_INT32) {
+		int32_t orig_value = 0;
+		param_get(handle, &orig_value);
+
+		int32_t value = (int32_t)parameter_value;
+
+		if (orig_value != value) {
+			PX4_WARN("Setting %s (INT32) %d -> %d", param_name(handle), orig_value, value);
+		}
+
+		param_set(handle, (const void *)&value);
+
+	} else if (param_format == PARAM_TYPE_FLOAT) {
+		float orig_value = 0;
+		param_get(handle, &orig_value);
+
+		float value = (float)parameter_value;
+
+		if (fabsf(orig_value - value) > FLT_EPSILON) {
+			PX4_WARN("Setting %s (FLOAT) %.3f -> %.3f", param_name(handle), (double)orig_value, (double)value);
+		}
+
+		param_set(handle, (const void *)&value);
+	}
+}
+
+void
 Replay::setUserParams(const char *filename)
 {
 	string line;
@@ -149,37 +182,57 @@ Replay::setUserParams(const char *filename)
 		mystrstream >> pname;
 		mystrstream >> value_string;
 
-		double param_value_double = stod(value_string);
-
-		param_t handle = param_find(pname.c_str());
-		param_type_t param_format = param_type(handle);
 		_overridden_params.insert(pname);
 
-		if (param_format == PARAM_TYPE_INT32) {
-			int32_t orig_value = 0;
-			param_get(handle, &orig_value);
+		double param_value_double = stod(value_string);
 
-			int32_t value = (int32_t)param_value_double;
-
-			if (orig_value != value) {
-				PX4_WARN("setting %s (INT32) %d -> %d", param_name(handle), orig_value, value);
-			}
-
-			param_set(handle, (const void *)&value);
-
-		} else if (param_format == PARAM_TYPE_FLOAT) {
-			float orig_value = 0;
-			param_get(handle, &orig_value);
-
-			float value = (float)param_value_double;
-
-			if (fabsf(orig_value - value) > FLT_EPSILON) {
-				PX4_WARN("setting %s (FLOAT) %.3f -> %.3f", param_name(handle), (double)orig_value, (double)value);
-			}
-
-			param_set(handle, (const void *)&value);
-		}
+		setParameter(pname, param_value_double);
 	}
+}
+
+void
+Replay::readDynamicParams(const char *filename)
+{
+	_dynamic_parameter_schedule.clear();
+
+	string line;
+	string param_name;
+	string value_string;
+	string time_string;
+	ifstream myfile(filename);
+
+	if (!myfile.is_open()) {
+		return;
+	}
+
+	PX4_INFO("Reading dynamic params from %s...", filename);
+
+	while (!myfile.eof()) {
+		getline(myfile, line);
+
+		if (line.empty() || line[0] == '#') {
+			continue;
+		}
+
+		istringstream mystrstream(line);
+		mystrstream >> param_name;
+		mystrstream >> value_string;
+		mystrstream >> time_string;
+
+		_dynamic_parameters.insert(param_name);
+
+		double param_value = stod(value_string);
+		uint64_t change_timestamp = (uint64_t)(stod(time_string) * 1e6);
+
+		// Construct and store parameter change event
+		tuple<uint64_t, string, double> change_event = make_tuple(change_timestamp, param_name, param_value);
+		_dynamic_parameter_schedule.push_back(change_event);
+	}
+
+	// Sort by event time
+	sort(_dynamic_parameter_schedule.begin(), _dynamic_parameter_schedule.end());
+
+	next_param_change = 0;
 }
 
 bool
@@ -611,7 +664,8 @@ Replay::readAndApplyParameter(std::ifstream &file, uint16_t msg_size)
 	string type = key.substr(0, pos);
 	string param_name = key.substr(pos + 1);
 
-	if (_overridden_params.find(param_name) != _overridden_params.end()) {
+	if (_overridden_params.find(param_name) != _overridden_params.end() ||
+	    _dynamic_parameters.find(param_name) != _dynamic_parameters.end()) {
 		//this parameter is overridden, so don't apply it
 		return true;
 	}
@@ -826,6 +880,7 @@ Replay::readDefinitionsAndApplyParams(std::ifstream &file)
 	}
 
 	setUserParams(PARAMS_OVERRIDE_FILE);
+	readDynamicParams(DYNAMIC_PARAMS_OVERRIDE_FILE);
 	return true;
 }
 
@@ -896,7 +951,7 @@ Replay::run()
 
 		Subscription &sub = *_subscriptions[next_msg_id];
 
-		if (next_file_time == 0) {
+		if (next_file_time == 0 || next_file_time < _file_start_time) {
 			//someone didn't set the timestamp properly. Consider the message invalid
 			nextDataMessage(replay_file, sub, next_msg_id);
 			continue;
@@ -907,6 +962,19 @@ Replay::run()
 		streampos next_additional_message_pos = sub.next_read_pos;
 		readAndHandleAdditionalMessages(replay_file, next_additional_message_pos);
 		last_additional_message_pos = next_additional_message_pos;
+
+		// Perform scheduled parameter changes
+		while (next_param_change < _dynamic_parameter_schedule.size() &&
+		       get<0>(_dynamic_parameter_schedule[next_param_change]) <= next_file_time) {
+			const auto param_change = _dynamic_parameter_schedule[next_param_change];
+			PX4_WARN("Performing param change scheduled for t=%.3lf at t=%.3lf.",
+				 (double)get<0>(param_change) / 1.e6,
+				 (double)next_file_time / 1.e6);
+			const std::string &param_name = get<1>(param_change);
+			const double new_value = get<2>(param_change);
+			setParameter(param_name, new_value);
+			next_param_change++;
+		}
 
 		const uint64_t publish_timestamp = handleTopicDelay(next_file_time, timestamp_offset);
 

--- a/src/modules/replay/Replay.hpp
+++ b/src/modules/replay/Replay.hpp
@@ -33,6 +33,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <fstream>
 #include <map>
 #include <vector>
@@ -220,6 +221,11 @@ protected:
 
 private:
 	std::set<std::string> _overridden_params;
+
+	std::set<std::string> _dynamic_parameters;
+	std::vector<std::tuple<uint64_t, std::string, double>> _dynamic_parameter_schedule;
+	size_t next_param_change;
+
 	std::map<std::string, std::string> _file_formats; ///< all formats we read from the file
 
 	uint64_t _file_start_time;
@@ -275,7 +281,9 @@ private:
 	/** get the size of a type that can be an array */
 	static size_t sizeOfFullType(const std::string &type_name_full);
 
+	void setParameter(const std::string &parameter_name, const double parameter_value);
 	void setUserParams(const char *filename);
+	void readDynamicParams(const char *filename);
 
 	std::string parseOrbFields(const std::string &fields);
 

--- a/src/modules/replay/Replay.hpp
+++ b/src/modules/replay/Replay.hpp
@@ -222,9 +222,21 @@ protected:
 private:
 	std::set<std::string> _overridden_params;
 
+	struct ParameterChangeEvent {
+		uint64_t timestamp;
+		std::string parameter_name;
+		double parameter_value;
+
+		// Comparison operator such that sorting is done by timestamp
+		bool operator<(const ParameterChangeEvent &other) const
+		{
+			return timestamp < other.timestamp;
+		}
+	};
+
 	std::set<std::string> _dynamic_parameters;
-	std::vector<std::tuple<uint64_t, std::string, double>> _dynamic_parameter_schedule;
-	size_t next_param_change;
+	std::vector<ParameterChangeEvent> _dynamic_parameter_schedule;
+	size_t _next_param_change;
 
 	std::map<std::string, std::string> _file_formats; ///< all formats we read from the file
 


### PR DESCRIPTION
### Solved Problem

It is possible to override parameters when replaying a log, but these are then fixed for the entire replay.
This means the replay can't be used to assess the effects of parameter changes.

### Solution

Allow scheduling changes to "dynamic parameters" at specific flight times during the replay in `replay_params_dynamic.txt`.

- All parameters are initialised as before - either from `replay_params.txt` or the values in the log.
- At each time step:
   - Check for scheduled changes that should have occurred since the last step and apply them.
   - If a dynamic parameter was changed _in the log_, do not apply the change.


#### How to specify changes to dynamic parameters

`replay_params_dynamic.txt` should be created in the same location as `replay_params.txt`. That is, in `build/px4_[target]_replay/rootfs/`. See https://docs.px4.io/main/en/debug/system_wide_replay.html.

Each line in describes a parameter-change event and gives the parameter name, new value and timestamp at which to apply the change. The time is given in seconds relative to the log start, as this is likely how a person would think about the timing.

For example, with this `replay_params_dynamic.txt` file, the EKF external vision fusion is turned on at 45.67s and the GPS fusion is switched off at 67.89s:

```
EKF2_EV_CTRL 1 45.67
EKF2_GPS_CTRL 0 67.89
```

### Changelog Entry

For release notes:
```
Feature: Allow changing parameters during replay
Documentation: To be updated with details of how to schedule parameter changes.
```

### Test coverage
- Tested by running EKF2 replays with and without the `replay_params_dynamic.txt` file present.

### To Do

- [ ] Update https://docs.px4.io/main/en/debug/system_wide_replay.html
