### PR TITLE
[BACKPORT] FW Pos Control: add in_takeoff_situation argument to adapt_airspeed_setpoint()

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1032_gazebo-classic_plane_catapult
@@ -7,6 +7,7 @@
 
 param set-default FW_LAUN_DETCN_ON 1
 param set-default FW_THR_IDLE 0.1 # needs to be running before throw as that's how gazebo detects arming
+param set-default FW_LAUN_AC_THLD 10
 
 param set-default FW_LND_ANG 8
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -669,10 +669,11 @@ private:
 	 * @param calibrated_airspeed_setpoint Calibrated airspeed septoint (generally from the position setpoint) [m/s]
 	 * @param calibrated_min_airspeed Minimum calibrated airspeed [m/s]
 	 * @param ground_speed Vehicle ground velocity vector (NE) [m/s]
+	 * @param in_takeoff_situation Vehicle is currently in a takeoff situation
 	 * @return Adjusted calibrated airspeed setpoint [m/s]
 	 */
 	float adapt_airspeed_setpoint(const float control_interval, float calibrated_airspeed_setpoint,
-				      float calibrated_min_airspeed, const Vector2f &ground_speed);
+				      float calibrated_min_airspeed, const Vector2f &ground_speed, bool in_takeoff_situation = false);
 
 	void reset_takeoff_state();
 	void reset_landing_state();


### PR DESCRIPTION
Backport of https://github.com/PX4/PX4-Autopilot/pull/21581

### Changelog Entry
For release notes:
```
Bugfix: initialize fixed-wing takeoff airspeed at correct value, disable airspeed increments except load factor during takeoff
```
