### PR TITLE
failsafe: rtl_time_estimate failsafe disable only on mode change/disarm

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -404,7 +404,8 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 	CHECK_FAILSAFE(status_flags, primary_geofence_breached, fromGfActParam(_param_gf_action.get()).cannotBeDeferred());
 
 	// Battery
-	CHECK_FAILSAFE(status_flags, battery_low_remaining_time, ActionOptions(Action::RTL).causedBy(Cause::BatteryLow));
+	CHECK_FAILSAFE(status_flags, battery_low_remaining_time,
+		       ActionOptions(Action::RTL).causedBy(Cause::BatteryLow).clearOn(ClearCondition::OnModeChangeOrDisarm));
 	CHECK_FAILSAFE(status_flags, battery_unhealthy, Action::Warn);
 
 	switch (status_flags.battery_warning) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When flying with a low battery, the remaining rtl flight time estimate can be triggered, performing an RTL. But while performing an RTL and getting closer to the landing position, it can happen the the "battery_low_remaining_time" flag is toggled, because the estimate is lower when approaching the land position. Thus it can happen, that the failsafe is completed and retriggered several times.
![Screenshot from 2023-09-13 13-32-25](https://github.com/PX4/PX4-Autopilot/assets/98741601/97dffbb8-e0ac-45a5-b873-d96cf2c3ae3f)



### Solution
- Only allow to clear the Low battery based on remaining flight time failsafe, when the user changes the mode or the vehicle is disarmed.

### Changelog Entry
For release notes:
```
Bugfix: Only allow to clear the Low battery based on remaining flight time failsafe, when the user changes the mode or the vehicle is disarmed.
```
### Test coverage
- Tested using the failsafe web simulation while toggling the "Low battery based on remaining flight time" flag.

### Context
Related links, screenshot before/after, video
