### PR TITLE
Disable timer callback in CameraCapture::stop()

### DIFF
--- a/src/drivers/camera_capture/camera_capture.cpp
+++ b/src/drivers/camera_capture/camera_capture.cpp
@@ -226,7 +226,9 @@ void
 CameraCapture::capture_trampoline(void *context, uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state,
 				  uint32_t overflow)
 {
-	camera_capture::g_camera_capture->capture_callback(chan_index, edge_time, edge_state, overflow);
+	if (camera_capture::g_camera_capture) {
+		camera_capture::g_camera_capture->capture_callback(chan_index, edge_time, edge_state, overflow);
+	}
 }
 
 void
@@ -358,6 +360,11 @@ CameraCapture::stop()
 	ScheduleClear();
 
 	work_cancel(HPWORK, &_work_publisher);
+
+	if (_capture_channel >= 0) {
+		up_input_capture_set(_capture_channel, Disabled, 0, nullptr, nullptr);
+	}
+
 
 	if (camera_capture::g_camera_capture != nullptr) {
 		delete (camera_capture::g_camera_capture);


### PR DESCRIPTION
### Solved Problem

When receiving a camera trigger in hardware after calling `camera_capture stop`, the FMU hardfaults.

```
Program received signal SIGTRAP, Trace/breakpoint trap.
exception_common () at platforms/nuttx/NuttX/nuttx/arch/arm/src/armv7-m/gnu/arm_exception.S:144
144		mrs		r0, ipsr				/* R0=exception number */
=> 0x08008244 <exception_common+0>:	ef f3 05 80	mrs	r0, IPSR

(gdb) backtrace
#0  exception_common () at platforms/nuttx/NuttX/nuttx/arch/arm/src/armv7-m/gnu/arm_exception.S:144
#1  <signal handler called>
#2  0x0802783c in CameraCapture::capture_callback (this=0x0, chan_index=6, edge_time=176203508, edge_state=0, overflow=0) at src/drivers/camera_capture/camera_capture.cpp:110
#3  0x0815459a in io_timer_handler (timer_index=<optimized out>) at platforms/nuttx/src/px4/stm/stm32_common/io_pins/io_timer.c:216
#4  0x0800b19e in irq_dispatch (irq=irq@entry=59, context=context@entry=0x20030e94) at platforms/nuttx/NuttX/nuttx/sched/irq/irq_dispatch.c:178
#5  0x08008384 in arm_doirq (irq=59, regs=0x20030e94) at platforms/nuttx/NuttX/nuttx/arch/arm/src/armv7-m/arm_doirq.c:71
#6  0x08008272 in exception_common () at platforms/nuttx/NuttX/nuttx/arch/arm/src/armv7-m/gnu/arm_exception.S:214
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

(gdb) arm scb
CFSR                             = 00008200
    BFSR                           ....82.. - 82
    BFARVALID                      ....8... - 1
    PRECISERR                      .....2.. - 1
BFAR                             = 000000e0

(gdb) frame 2
#2  0x0802783c in CameraCapture::capture_callback (this=0x0, chan_index=6, edge_time=176203508, edge_state=0, overflow=0) at src/drivers/camera_capture/camera_capture.cpp:110
110	{
   0x08027834 <_ZN13CameraCapture16capture_callbackEmymm+4>:	15 46	mov	r5, r2
   0x08027836 <_ZN13CameraCapture16capture_callbackEmymm+6>:	0f 46	mov	r7, r1
   0x08027838 <_ZN13CameraCapture16capture_callbackEmymm+8>:	1e 46	mov	r6, r3
   0x0802783a <_ZN13CameraCapture16capture_callbackEmymm+10>:	04 46	mov	r4, r0
=> 0x0802783c <_ZN13CameraCapture16capture_callbackEmymm+12>:	90 f8 e0 30	ldrb.w	r3, [r0, #224]	; 0xe0
(gdb) list
105		camera_capture::g_camera_capture = nullptr;
106	}
107
108	void
109	CameraCapture::capture_callback(uint32_t chan_index, hrt_abstime edge_time, uint32_t edge_state, uint32_t overflow)
110	{
111		// Maximum acceptable rate is 5kHz
112		if ((edge_time - _trigger.hrt_edge_time) < 200_us) {
113			++_trigger_rate_exceeded_counter;
114
```

The reason is that the `camera_capture::g_camera_capture` gets deleted in the `CameraCapture::stop()` function and is thus a `nullptr`, but the input capture timer is not disabled, thus calling the trampoline which calls the `CameraCapture ::capture_callback()` function with the this pointer being nullptr.

### Solution

Disable the input capture timer callback in the stop function. For additional safety, I also added a check for `camera_capture::g_camera_capture != nullptr` since it costs almost nothing.

### Changelog Entry

For release notes:
```
Bugfix Fix hardfault when receiving a camera trigger after camera_capture has been stopped.
```

### Alternatives

We could also… just™ not write buggy code????

### Test coverage

1. Reproduced issue 100% of the time.
2. Single-stepped through the code to see the exact instruction `r3, [r0, #224]	; 0xe0`
3. Applied the fix and tested it with and without GDB.

cc @eyeam3 