### PR TITLE
FixedwingPositionControl: initialize airspeed slew controller in constructor

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -76,6 +76,8 @@ FixedwingPositionControl::FixedwingPositionControl(bool vtol) :
 
 	/* fetch initial parameter values */
 	parameters_update();
+
+	_airspeed_slew_rate_controller.setForcedValue(_param_fw_airspd_trim.get());
 }
 
 FixedwingPositionControl::~FixedwingPositionControl()
@@ -429,14 +431,6 @@ FixedwingPositionControl::adapt_airspeed_setpoint(const float control_interval, 
 						    _wind_vel.length(), _param_fw_airspd_max.get());
 	}
 
-	if (_airspeed_slew_rate_controller.getState() < calibrated_min_airspeed) {
-		_airspeed_slew_rate_controller.setForcedValue(calibrated_min_airspeed);
-	}
-
-	if (_airspeed_slew_rate_controller.getState() > _param_fw_airspd_max.get()) {
-		_airspeed_slew_rate_controller.setForcedValue(_param_fw_airspd_max.get());
-	}
-
 	// --- airspeed *setpoint adjustments ---
 
 	if (!PX4_ISFINITE(calibrated_airspeed_setpoint) || calibrated_airspeed_setpoint <= FLT_EPSILON) {
@@ -468,6 +462,14 @@ FixedwingPositionControl::adapt_airspeed_setpoint(const float control_interval, 
 	if (control_interval > FLT_EPSILON) {
 		// constrain airspeed setpoint changes with slew rate of ASPD_SP_SLEW_RATE m/s/s
 		_airspeed_slew_rate_controller.update(calibrated_airspeed_setpoint, control_interval);
+	}
+
+	if (_airspeed_slew_rate_controller.getState() < calibrated_min_airspeed) {
+		_airspeed_slew_rate_controller.setForcedValue(calibrated_min_airspeed);
+	}
+
+	if (_airspeed_slew_rate_controller.getState() > _param_fw_airspd_max.get()) {
+		_airspeed_slew_rate_controller.setForcedValue(_param_fw_airspd_max.get());
 	}
 
 	return _airspeed_slew_rate_controller.getState();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The airspeed slew rate controller in the fixed wing position controller is only explicitly intialized in takeoff modes - but otherwise defaults to zero.. which then gets bounded to min airspeed on first pass to the airspeed handling logic.. which then requires a slewed ramp in of whatever actual setpoint the mode demands. Undesireable.

Fixes #{Github issue ID}

### Solution
Initialize the slew rate to trim airspeed in the constructor. This way no matter what mode enters the slewing logic first.. the starting point is a reasonable one. And takeoff modes still initialize to takeoff speed explicitly.

Additionally move the slew constraint checks to end of adapt airspeed method to make sure setpoint and constraints are decoupled.

### Changelog Entry
For release notes:
```
Bugfix: initialize airspeed setpoint by default at at trim speed
```

### Alternatives
In 1.15 we need to handle mode switches better.. ideally considering for each one exactly when we want to explicitly reinit the airspeed slewer or not.

### Test coverage

example of takeoff force set slew value -- switches immediately (no slew) to takeoff speed:
![image](https://github.com/PX4/PX4-Autopilot/assets/8026163/615e2901-0782-49cf-993f-6eed84ca0249)

example of position mode start -- starts at trim speed:
![image](https://github.com/PX4/PX4-Autopilot/assets/8026163/c651ddbf-6522-4847-a21a-c9536264bf01)

