### PR TITLE
Avoid unexpected repositions

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -724,7 +724,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 			const bool unsupported_bits_set = (change_mode_flags & ~1) != 0;
 
 			if (mode_switch_not_requested || unsupported_bits_set) {
-				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
 
 			} else {
 				if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -719,8 +719,14 @@ Commander::handle_command(const vehicle_command_s &cmd)
 			// to not require navigator and command to receive / process
 			// the data at the exact same time.
 
-			// Check if a mode switch had been requested
-			if ((((uint32_t)cmd.param2) & 1) > 0) {
+			const uint32_t change_mode_flags = uint32_t(cmd.param2);
+			const bool mode_switch_not_requested = (change_mode_flags & 1) == 0;
+			const bool unsupported_bits_set = (change_mode_flags & ~1) != 0;
+
+			if (mode_switch_not_requested || unsupported_bits_set) {
+				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+
+			} else {
 				if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)) {
 					cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
@@ -728,9 +734,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					printRejectMode(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
 					cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
 				}
-
-			} else {
-				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 			}
 		}
 		break;

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -51,7 +51,8 @@ Loiter::Loiter(Navigator *navigator) :
 void
 Loiter::on_activation()
 {
-	if (_navigator->get_reposition_triplet()->current.valid) {
+	if (_navigator->get_reposition_triplet()->current.valid
+	    && hrt_elapsed_time(&_navigator->get_reposition_triplet()->current.timestamp) < 500_ms) {
 		reposition();
 
 	} else {
@@ -66,7 +67,8 @@ Loiter::on_activation()
 void
 Loiter::on_active()
 {
-	if (_navigator->get_reposition_triplet()->current.valid) {
+	if (_navigator->get_reposition_triplet()->current.valid
+	    && hrt_elapsed_time(&_navigator->get_reposition_triplet()->current.timestamp) < 500_ms) {
 		reposition();
 	}
 }


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
1. Geofence reposition lifetime: when in RTL, the geofence reposition setpoint is ignored (ok, fine) - however, the reposition struct that holds that geofence position is stored until the next flight. If a manual control loss then engages a hold (during RTL delay time), the reposition setpoint is taken for the hold, which may be anywhere else other than the vehicle's current position.. which would be the desired hold position.
2. External reposition commands without a requested mode switch (flag) are silently accepted and can cause unexpected positioning when hold is engaged.

### Solution
1. In the loiter activation methods, check the reposition setpoint's timestamp in addition to validity.
3. Don't allow reposition commands without a requested mode switch.

### Changelog Entry
For release notes:
```
Bugfix: Don't allow external reposition commands without a mode switch, and ensure old reposition commands are not erroneously set.
```

### Alternatives
Real solution is not sharing the reposition struct between multiple modes, and not reusing loiter mode for goto and hold.

### Test coverage
- used libmav to send a reposition command without the modeswitch bit.. it rejects now
- test case:
  - unplug manual control
  - let the multicopter rtl with geo fence boundary set near home
  - geo fence sets reposition struct somewhere along the path towards home (but rtl ignores)
  - vehicle lands, disarms
  - arm and takeoff again in manual
  - unplug manual control
  - rtl ensues
  - the rtl hold delay before returning to home is correctly set to the vehicle's current position (not the previously set reposition struct from last flight)