### PR TITLE
Craziflie configs: remove default 100% thrust parameter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
@@ -43,7 +43,6 @@ param set-default MC_ROLLRATE_P 0.07
 param set-default MC_YAW_P 3
 
 param set-default MPC_THR_HOVER 0.7
-param set-default MPC_THR_MAX 1
 param set-default MPC_Z_P 1.5
 param set-default MPC_Z_VEL_P_ACC 8
 param set-default MPC_Z_VEL_I_ACC 6

--- a/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
+++ b/ROMFS/px4fmu_common/init.d/airframes/4901_crazyflie21
@@ -42,7 +42,6 @@ param set-default MC_ROLLRATE_P 0.07
 param set-default MC_YAW_P 3
 
 param set-default MPC_THR_HOVER 0.7
-param set-default MPC_THR_MAX 1
 param set-default MPC_Z_P 1.5
 param set-default MPC_Z_VEL_P_ACC 8
 param set-default MPC_Z_VEL_I_ACC 6


### PR DESCRIPTION
### Solved Problem
When browsing through the maximum thrust settings of different airframes I found that the Crazyflies config sets the default to the same value as the default which is 100% thrust.

Since https://github.com/PX4/PX4-Autopilot/pull/9359 the default is 100% thrust and when the parameter for the Crazyflie was commited that was already there: https://github.com/PX4/PX4-Autopilot/commit/28f616b1c170dd3f416ddd60c3ca2947208b357d#diff-0c848f9e92ff14731d314da17e247ea2312673f6c8018c94c9a22153419e79d9R41

### Solution
Don't set the global default as airframe default with no apparent reason.

### Changelog Entry
```
Cleanup: Crazyflie airframe sets global default again
```

### Test coverage
I'm certain the value stays the same.