### PR TITLE
Navigation state cleanup

### DIFF
--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -37,15 +37,17 @@ uint8 NAVIGATION_STATE_POSCTL = 2               # Position control mode
 uint8 NAVIGATION_STATE_AUTO_MISSION = 3         # Auto mission mode
 uint8 NAVIGATION_STATE_AUTO_LOITER = 4          # Auto loiter mode
 uint8 NAVIGATION_STATE_AUTO_RTL = 5             # Auto return to launch mode
-uint8 NAVIGATION_STATE_UNUSED3 = 8              # Free slot
-uint8 NAVIGATION_STATE_UNUSED = 9               # Free slot
+# 6 free
+# 7 free
+# 8 free
+# 9 free
 uint8 NAVIGATION_STATE_ACRO = 10                # Acro mode
-uint8 NAVIGATION_STATE_UNUSED1 = 11             # Free slot
+# 11 free
 uint8 NAVIGATION_STATE_DESCEND = 12             # Descend mode (no position control)
 uint8 NAVIGATION_STATE_TERMINATION = 13         # Termination mode
 uint8 NAVIGATION_STATE_OFFBOARD = 14
 uint8 NAVIGATION_STATE_STAB = 15                # Stabilized mode
-uint8 NAVIGATION_STATE_UNUSED2 = 16             # Free slot
+# 16 free
 uint8 NAVIGATION_STATE_AUTO_TAKEOFF = 17        # Takeoff
 uint8 NAVIGATION_STATE_AUTO_LAND = 18           # Land
 uint8 NAVIGATION_STATE_AUTO_FOLLOW_TARGET = 19  # Auto Follow

--- a/src/drivers/osd/atxxxx/atxxxx.cpp
+++ b/src/drivers/osd/atxxxx/atxxxx.cpp
@@ -41,6 +41,7 @@
 
 #include "atxxxx.h"
 #include "symbols.h"
+#include <modules/commander/ModeUtil/conversions.hpp>
 
 using namespace time_literals;
 
@@ -373,61 +374,6 @@ OSDatxxxx::update_topics()
 	return PX4_OK;
 }
 
-const char *
-OSDatxxxx::get_flight_mode(uint8_t nav_state)
-{
-	const char *flight_mode = "UNKNOWN";
-
-	switch (nav_state) {
-	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
-		flight_mode = "MANUAL";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
-		flight_mode = "ALTITUDE";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_POSCTL:
-		flight_mode = "POSITION";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
-		flight_mode = "RETURN";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
-		flight_mode = "MISSION";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
-	case vehicle_status_s::NAVIGATION_STATE_DESCEND:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
-		flight_mode = "AUTO";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_ACRO:
-		flight_mode = "ACRO";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
-		flight_mode = "TERMINATE";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
-		flight_mode = "OFFBOARD";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_STAB:
-		flight_mode = "STABILIZED";
-		break;
-	}
-
-	return flight_mode;
-}
-
 int
 OSDatxxxx::update_screen()
 {
@@ -455,7 +401,7 @@ OSDatxxxx::update_screen()
 		ret |= add_flighttime(flight_time_sec, 1, 14);
 
 	} else {
-		flight_mode = get_flight_mode(_nav_state);
+		flight_mode = mode_util::nav_state_names[_nav_state];
 	}
 
 	add_string_to_screen_centered(flight_mode, 12, 10);

--- a/src/drivers/osd/atxxxx/atxxxx.h
+++ b/src/drivers/osd/atxxxx/atxxxx.h
@@ -98,8 +98,6 @@ private:
 	int add_altitude(uint8_t pos_x, uint8_t pos_y);
 	int add_flighttime(float flight_time, uint8_t pos_x, uint8_t pos_y);
 
-	static const char *get_flight_mode(uint8_t nav_state);
-
 	int enable_screen();
 	int disable_screen();
 

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -102,16 +102,8 @@ msp_name_t construct_display_message(const vehicle_status_s &vehicle_status,
 			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_RTL");
 			break;
 
-		case vehicle_status_s::NAVIGATION_STATE_UNUSED:
-			display.set(MessageDisplayType::FLIGHT_MODE, "UNUSED");
-			break;
-
 		case vehicle_status_s::NAVIGATION_STATE_ACRO:
 			display.set(MessageDisplayType::FLIGHT_MODE, "ACRO");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_UNUSED1:
-			display.set(MessageDisplayType::FLIGHT_MODE, "UNUSED1");
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_DESCEND:
@@ -128,10 +120,6 @@ msp_name_t construct_display_message(const vehicle_status_s &vehicle_status,
 
 		case vehicle_status_s::NAVIGATION_STATE_STAB:
 			display.set(MessageDisplayType::FLIGHT_MODE, "STAB");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_UNUSED2:
-			display.set(MessageDisplayType::FLIGHT_MODE, "UNUSED2");
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:

--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -40,6 +40,7 @@
 #include <math.h>
 #include <matrix/math.hpp>
 #include <lib/geo/geo.h>
+#include <modules/commander/ModeUtil/conversions.hpp>
 
 // clock access
 #include <px4_platform_common/defines.h>
@@ -77,82 +78,7 @@ msp_name_t construct_display_message(const vehicle_status_s &vehicle_status,
 		}
 
 		// display flight mode
-		switch (vehicle_status.nav_state) {
-		case vehicle_status_s::NAVIGATION_STATE_MANUAL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "MANUAL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "ALTCTL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_POSCTL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "POSCTL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_MISSION");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_LOITER");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_RTL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_ACRO:
-			display.set(MessageDisplayType::FLIGHT_MODE, "ACRO");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_DESCEND:
-			display.set(MessageDisplayType::FLIGHT_MODE, "DESCEND");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
-			display.set(MessageDisplayType::FLIGHT_MODE, "TERMINATION");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
-			display.set(MessageDisplayType::FLIGHT_MODE, "OFFBOARD");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_STAB:
-			display.set(MessageDisplayType::FLIGHT_MODE, "STAB");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_TAKEOFF");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_LAND");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_FOLLOW_TARGET");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_PRECLAND");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_ORBIT:
-			display.set(MessageDisplayType::FLIGHT_MODE, "ORBIT");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_VTOL_TAKEOFF");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_MAX:
-			display.set(MessageDisplayType::FLIGHT_MODE, "MAX");
-			break;
-
-		default:
-			display.set(MessageDisplayType::FLIGHT_MODE, "???");
-		}
+		display.set(MessageDisplayType::FLIGHT_MODE, mode_util::nav_state_names[vehicle_status.nav_state]);
 	}
 
 	// display, if updated

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -301,10 +301,6 @@ void CrsfRc::Run()
 						flight_mode = "Auto";
 						break;
 
-					/*case vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL:
-						flight_mode = "Failure";
-						break;*/
-
 					case vehicle_status_s::NAVIGATION_STATE_ACRO:
 						flight_mode = "Acro";
 						break;

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -39,6 +39,8 @@
 #include <termios.h>
 #include <fcntl.h>
 
+#include <modules/commander/ModeUtil/conversions.hpp>
+
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/sensor_gps.h>
@@ -269,59 +271,7 @@ void CrsfRc::Run()
 				vehicle_status_s vehicle_status;
 
 				if (_vehicle_status_sub.update(&vehicle_status)) {
-					const char *flight_mode = "(unknown)";
-
-					switch (vehicle_status.nav_state) {
-					case vehicle_status_s::NAVIGATION_STATE_MANUAL:
-						flight_mode = "Manual";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
-						flight_mode = "Altitude";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_POSCTL:
-						flight_mode = "Position";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
-						flight_mode = "Return";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
-						flight_mode = "Mission";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
-					case vehicle_status_s::NAVIGATION_STATE_DESCEND:
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
-					case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
-						flight_mode = "Auto";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_ACRO:
-						flight_mode = "Acro";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
-						flight_mode = "Terminate";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
-						flight_mode = "Offboard";
-						break;
-
-					case vehicle_status_s::NAVIGATION_STATE_STAB:
-						flight_mode = "Stabilized";
-						break;
-
-					default:
-						flight_mode = "Unknown";
-					}
-
-					this->SendTelemetryFlightMode(flight_mode);
+					this->SendTelemetryFlightMode(mode_util::nav_state_names[vehicle_status.nav_state]);
 				}
 
 				break;

--- a/src/drivers/rc_input/crsf_telemetry.cpp
+++ b/src/drivers/rc_input/crsf_telemetry.cpp
@@ -33,6 +33,7 @@
 
 #include "crsf_telemetry.h"
 #include <lib/rc/crsf.h>
+#include <modules/commander/ModeUtil/conversions.hpp>
 
 CRSFTelemetry::CRSFTelemetry(int uart_fd) :
 	_uart_fd(uart_fd)
@@ -130,54 +131,5 @@ bool CRSFTelemetry::send_flight_mode()
 		return false;
 	}
 
-	const char *flight_mode = "(unknown)";
-
-	switch (vehicle_status.nav_state) {
-	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
-		flight_mode = "Manual";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
-		flight_mode = "Altitude";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_POSCTL:
-		flight_mode = "Position";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
-		flight_mode = "Return";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
-		flight_mode = "Mission";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
-	case vehicle_status_s::NAVIGATION_STATE_DESCEND:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
-	case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
-		flight_mode = "Auto";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_ACRO:
-		flight_mode = "Acro";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
-		flight_mode = "Terminate";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
-		flight_mode = "Offboard";
-		break;
-
-	case vehicle_status_s::NAVIGATION_STATE_STAB:
-		flight_mode = "Stabilized";
-		break;
-	}
-
-	return crsf_send_telemetry_flight_mode(_uart_fd, flight_mode);
+	return crsf_send_telemetry_flight_mode(_uart_fd, mode_util::nav_state_names[vehicle_status.nav_state]);
 }

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -478,11 +478,11 @@
                         },
                         "1": {
                             "name": "altctl",
-                            "description": "Altitude control"
+                            "description": "Altitude"
                         },
                         "2": {
                             "name": "posctl",
-                            "description": "Position control"
+                            "description": "Position"
                         },
                         "3": {
                             "name": "auto_mission",
@@ -522,7 +522,7 @@
                         },
                         "13": {
                             "name": "auto_precland",
-                            "description": "Precision Landing"
+                            "description": "Precision Land"
                         },
                         "14": {
                             "name": "orbit",

--- a/src/modules/commander/ModeUtil/conversions.hpp
+++ b/src/modules/commander/ModeUtil/conversions.hpp
@@ -83,28 +83,29 @@ static inline navigation_mode_t navigation_mode(uint8_t nav_state)
 }
 
 const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
-	"MANUAL",
-	"ALTCTL",
-	"POSCTL",
-	"AUTO_MISSION",
-	"AUTO_LOITER",
-	"AUTO_RTL",
-	"6: unallocated",
-	"7: unallocated",
-	"AUTO_LANDENGFAIL",
-	"9: unallocated",
-	"ACRO",
-	"11: UNUSED",
-	"DESCEND",
-	"TERMINATION",
-	"OFFBOARD",
-	"STAB",
-	"16: UNUSED2",
-	"AUTO_TAKEOFF",
-	"AUTO_LAND",
-	"AUTO_FOLLOW_TARGET",
-	"AUTO_PRECLAND",
-	"ORBIT"
+	"Manual", // 0
+	"Altitude", // 1
+	"Position", // 2
+	"Mission", // 3
+	"Hold", // 4
+	"RTL", // 5
+	"6 unused", // 6
+	"7 unused", // 7
+	"8 unused", // 8
+	"9 unused", // 9
+	"Acro", // 10
+	"11 unused", // 11
+	"Descend", // 12
+	"Termination", // 13
+	"Offboard", // 14
+	"Stabilized", // 15
+	"16 unused", // 16
+	"Takeoff", // 17
+	"Land", // 18
+	"Follow Target", // 19
+	"Precision Land", // 20
+	"Orbit", // 21
+	"Vtol Takeoff" // 22
 };
 
 } // namespace mode_util


### PR DESCRIPTION
### Solved Problem
When looking into porting the slow position mode I found that there are slightly different sets of navigation states.

### Solution
- Make it very clear which number is used and which one is free because a mode was deprecated. We don't want to move the numbers because there are external dependencies e.g. log analysis.
- Slightly reword the string conversion for the navigation states and make them consistent over events and other places.
- Reuse the string conversion of the `ModeUtil` in all the telemetry drivers like analog OSD, Crossfire, digital OSD.

### Changelog Entry
For release notes:
```
Cleanup: Unify navigation state strings
```

### Test coverage
I did not test this.