### PR TITLE
Add topic remap plugin for Gz

### DIFF
--- a/Tools/simulation/gz/models/x500/model.sdf
+++ b/Tools/simulation/gz/models/x500/model.sdf
@@ -584,5 +584,7 @@
       <rotorVelocitySlowdownSim>10</rotorVelocitySlowdownSim>
       <motorType>velocity</motorType>
     </plugin>
+    <plugin filename="gz-sim-topic-remap-system" name="px4::sim::TopicRemap">
+    </plugin>
   </model>
 </sdf>

--- a/Tools/simulation/gz/plugins/CMakeLists.txt
+++ b/Tools/simulation/gz/plugins/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(px4_gz_plugins)
+
+find_package(gz-cmake3 REQUIRED)
+gz_find_package(gz-sim7 REQUIRED)
+
+gz_find_package(gz-plugin2 REQUIRED COMPONENTS register)
+
+# Add sources for each plugin to be registered.
+add_library(topic_remap SHARED topicremap_plugin.cc )
+set_property(TARGET topic_remap PROPERTY CXX_STANDARD 17)
+target_link_libraries(topic_remap
+  gz-sim${gz-sim7_VERSION_MAJOR}::gz-sim${gz-sim7_VERSION_MAJOR}
+)

--- a/Tools/simulation/gz/plugins/topicremap_plugin.cc
+++ b/Tools/simulation/gz/plugins/topicremap_plugin.cc
@@ -1,0 +1,28 @@
+#include "topicremap_plugin.hh"
+
+#include <gz/plugin/RegisterMore.hh>
+#include <gz/transport/NodeOptions.hh>
+
+
+GZ_ADD_PLUGIN(
+    px4::sim::TopicRemap,
+    gz::sim::System
+)
+
+using namespace px4::sim;
+
+TopicRemap::TopicRemap()
+{
+  std::string target_topic = "/bar";
+  _node.Options().TopicRemap("/model/x500_0/servo_0", target_topic);
+}
+
+TopicRemap::~TopicRemap()
+{
+}
+
+void TopicRemap::PostUpdate(const gz::sim::UpdateInfo &_info,
+    const gz::sim::EntityComponentManager &_ecm)
+{
+  gzmsg << "TopicRemap::PostUpdate" << std::endl;
+}

--- a/Tools/simulation/gz/plugins/topicremap_plugin.hh
+++ b/Tools/simulation/gz/plugins/topicremap_plugin.hh
@@ -1,0 +1,21 @@
+#include <gz/sim/System.hh>
+#include <gz/transport.hh>
+
+namespace px4::sim
+{
+  class TopicRemap:
+    // This class is a system.
+    public gz::sim::System,
+    // This class also implements the ISystemPostUpdate interface.
+    public gz::sim::ISystemPostUpdate
+  {
+    public: TopicRemap();
+
+    public: ~TopicRemap() override;
+
+    public: void PostUpdate(const gz::sim::UpdateInfo &_info,
+                const gz::sim::EntityComponentManager &_ecm) override;
+    private:
+      gz::transport::Node _node;
+  };
+}

--- a/Tools/simulation/gz/worlds/default.sdf
+++ b/Tools/simulation/gz/worlds/default.sdf
@@ -15,6 +15,7 @@
     <plugin name='gz::sim::systems::Sensors' filename='gz-sim-sensors-system'>
       <render_engine>ogre2</render_engine>
     </plugin>
+    <plugin name='px4::sim::TopicRemap' filename='px4-sim-topicremap-system'/>
     <gui fullscreen='false'>
       <plugin name='3D View' filename='GzScene3D'>
         <gz-gui>

--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -52,6 +52,19 @@ if(gz-transport_FOUND)
 		set(GZ_TRANSPORT_LIB ignition-transport${GZ_TRANSPORT_VER}::core)
 	endif()
 
+	include(ExternalProject)
+	ExternalProject_Add(px4_gz_plugins
+		SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/simulation/gz/plugins
+		CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+		BINARY_DIR ${PX4_BINARY_DIR}/build_gz
+		INSTALL_COMMAND ""
+		USES_TERMINAL_CONFIGURE true
+		USES_TERMINAL_BUILD true
+		EXCLUDE_FROM_ALL true
+		BUILD_ALWAYS 1
+	)
+
+
 	px4_add_module(
 		MODULE modules__simulation__gz_bridge
 		MAIN gz_bridge
@@ -145,14 +158,14 @@ if(gz-transport_FOUND)
 					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model} $<TARGET_FILE:px4>
 					WORKING_DIRECTORY ${SITL_WORKING_DIR}
 					USES_TERMINAL
-					DEPENDS px4
+					DEPENDS px4 px4_gz_plugins
 				)
 			else()
 				add_custom_target(gz_${model}_${world_name}
 					COMMAND ${CMAKE_COMMAND} -E env PX4_SIM_MODEL=gz_${model} PX4_GZ_WORLD=${world_name} $<TARGET_FILE:px4>
 					WORKING_DIRECTORY ${SITL_WORKING_DIR}
 					USES_TERMINAL
-					DEPENDS px4
+					DEPENDS px4 px4_gz_plugins
 				)
 			endif()
 		endforeach()

--- a/src/modules/simulation/gz_bridge/gz_env.sh.in
+++ b/src/modules/simulation/gz_bridge/gz_env.sh.in
@@ -2,5 +2,7 @@
 
 export PX4_GZ_MODELS=@PX4_SOURCE_DIR@/Tools/simulation/gz/models
 export PX4_GZ_WORLDS=@PX4_SOURCE_DIR@/Tools/simulation/gz/worlds
+export PX4_GZ_PLUGINS=@PX4_SOURCE_DIR@/build/px4_sitl_default/build_gz
 
 export GZ_SIM_RESOURCE_PATH=$GZ_SIM_RESOURCE_PATH:$PX4_GZ_MODELS:$PX4_GZ_WORLDS
+export GZ_SIM_SYSTEM_PLUGIN_PATH=$GZ_SIM_SYSTEM_PLUGIN_PATH:$PX4_GZ_PLUGINS


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Currently, the actuator commands for the gz simulator is fixed with a prefix of `px4_servo_*`. This prevents us from using models in ignition fuel since joint names might be arbitrarily named


This has been a blocker for using models such as https://github.com/PX4/PX4-Autopilot/pull/21273
Fixes https://github.com/PX4/PX4-Autopilot/pull/21273


### Solution
This adds a plugin that can remap gz topics. By doing this, we can use any models in gz fuel and remap the commands to any joints in the model

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
