### PR TITLE
Beginner/control tuning friendly Acro mode defaults

### DIFF
--- a/src/modules/mc_rate_control/mc_acro_params.c
+++ b/src/modules/mc_rate_control/mc_acro_params.c
@@ -49,7 +49,7 @@
  * @increment 5
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 100.f);
 
 /**
  * Acro mode maximum pitch rate
@@ -63,7 +63,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
  * @increment 5
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 100.f);
 
 /**
  * Acro mode maximum yaw rate
@@ -77,7 +77,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
  * @increment 5
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 100.f);
 
 /**
  * Acro mode roll, pitch expo factor
@@ -92,7 +92,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
  * @decimal 2
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.f);
 
 /**
  * Acro mode yaw expo factor
@@ -107,7 +107,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
  * @decimal 2
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.f);
 
 /**
  * Acro mode roll, pitch super expo factor
@@ -123,7 +123,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
  * @decimal 2
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.f);
 
 /**
  * Acro mode yaw super expo factor
@@ -139,4 +139,4 @@ PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
  * @decimal 2
  * @group Multicopter Acro Mode
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.f);

--- a/src/modules/mc_rate_control/mc_acro_params.c
+++ b/src/modules/mc_rate_control/mc_acro_params.c
@@ -1,0 +1,142 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mc_acro_params.c
+ *
+ * Parameters for Acro mode behavior
+ */
+
+/**
+ * Max acro roll rate
+ *
+ * default: 2 turns per second
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
+
+/**
+ * Max acro pitch rate
+ *
+ * default: 2 turns per second
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
+
+/**
+ * Max acro yaw rate
+ *
+ * default 1.5 turns per second
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 1800.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
+
+/**
+ * Acro mode Expo factor for Roll and Pitch.
+ *
+ * Exponential factor for tuning the input curve shape.
+ *
+ * 0 Purely linear input curve
+ * 1 Purely cubic input curve
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
+
+/**
+ * Acro mode Expo factor for Yaw.
+ *
+ * Exponential factor for tuning the input curve shape.
+ *
+ * 0 Purely linear input curve
+ * 1 Purely cubic input curve
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
+
+/**
+ * Acro mode SuperExpo factor for Roll and Pitch.
+ *
+ * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO.
+ *
+ * 0 Pure Expo function
+ * 0.7 reasonable shape enhancement for intuitive stick feel
+ * 0.95 very strong bent input curve only near maxima have effect
+ *
+ * @min 0
+ * @max 0.95
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
+
+/**
+ * Acro mode SuperExpo factor for Yaw.
+ *
+ * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO_Y.
+ *
+ * 0 Pure Expo function
+ * 0.7 reasonable shape enhancement for intuitive stick feel
+ * 0.95 very strong bent input curve only near maxima have effect
+ *
+ * @min 0
+ * @max 0.95
+ * @decimal 2
+ * @group Multicopter Rate Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);

--- a/src/modules/mc_rate_control/mc_acro_params.c
+++ b/src/modules/mc_rate_control/mc_acro_params.c
@@ -38,9 +38,9 @@
  */
 
 /**
- * Max acro roll rate
+ * Acro mode maximum roll rate
  *
- * default: 2 turns per second
+ * Full stick deflection leads to this rate.
  *
  * @unit deg/s
  * @min 0.0
@@ -52,9 +52,9 @@
 PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
 
 /**
- * Max acro pitch rate
+ * Acro mode maximum pitch rate
  *
- * default: 2 turns per second
+ * Full stick deflection leads to this rate.
  *
  * @unit deg/s
  * @min 0.0
@@ -66,9 +66,9 @@ PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
 PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
 
 /**
- * Max acro yaw rate
+ * Acro mode maximum yaw rate
  *
- * default 1.5 turns per second
+ * Full stick deflection leads to this rate.
  *
  * @unit deg/s
  * @min 0.0
@@ -80,7 +80,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
 PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
 
 /**
- * Acro mode Expo factor for Roll and Pitch.
+ * Acro mode roll, pitch expo factor
  *
  * Exponential factor for tuning the input curve shape.
  *
@@ -95,7 +95,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
 PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
 
 /**
- * Acro mode Expo factor for Yaw.
+ * Acro mode yaw expo factor
  *
  * Exponential factor for tuning the input curve shape.
  *
@@ -110,9 +110,9 @@ PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
 PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
 
 /**
- * Acro mode SuperExpo factor for Roll and Pitch.
+ * Acro mode roll, pitch super expo factor
  *
- * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO.
+ * "Superexponential" factor for refining the input curve shape tuned using MC_ACRO_EXPO.
  *
  * 0 Pure Expo function
  * 0.7 reasonable shape enhancement for intuitive stick feel
@@ -126,9 +126,9 @@ PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
 PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
 
 /**
- * Acro mode SuperExpo factor for Yaw.
+ * Acro mode yaw super expo factor
  *
- * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO_Y.
+ * "Superexponential" factor for refining the input curve shape tuned using MC_ACRO_EXPO_Y.
  *
  * 0 Pure Expo function
  * 0.7 reasonable shape enhancement for intuitive stick feel

--- a/src/modules/mc_rate_control/mc_acro_params.c
+++ b/src/modules/mc_rate_control/mc_acro_params.c
@@ -47,7 +47,7 @@
  * @max 1800.0
  * @decimal 1
  * @increment 5
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
 
@@ -61,7 +61,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
  * @max 1800.0
  * @decimal 1
  * @increment 5
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
 
@@ -75,7 +75,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
  * @max 1800.0
  * @decimal 1
  * @increment 5
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
 
@@ -90,7 +90,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
  * @min 0
  * @max 1
  * @decimal 2
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
 
@@ -105,7 +105,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
  * @min 0
  * @max 1
  * @decimal 2
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
 
@@ -121,7 +121,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
  * @min 0
  * @max 0.95
  * @decimal 2
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
 
@@ -137,6 +137,6 @@ PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
  * @min 0
  * @max 0.95
  * @decimal 2
- * @group Multicopter Rate Control
+ * @group Multicopter Acro Mode
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);

--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -33,10 +33,8 @@
 
 /**
  * @file mc_rate_control_params.c
- * Parameters for multicopter attitude controller.
  *
- * @author Lorenz Meier <lorenz@px4.io>
- * @author Anton Babushkin <anton@px4.io>
+ * Parameters for multicopter rate controller
  */
 
 /**
@@ -280,110 +278,6 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_FF, 0.0f);
  * @group Multicopter Rate Control
  */
 PARAM_DEFINE_FLOAT(MC_YAWRATE_K, 1.0f);
-
-/**
- * Max acro roll rate
- *
- * default: 2 turns per second
- *
- * @unit deg/s
- * @min 0.0
- * @max 1800.0
- * @decimal 1
- * @increment 5
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
-
-/**
- * Max acro pitch rate
- *
- * default: 2 turns per second
- *
- * @unit deg/s
- * @min 0.0
- * @max 1800.0
- * @decimal 1
- * @increment 5
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
-
-/**
- * Max acro yaw rate
- *
- * default 1.5 turns per second
- *
- * @unit deg/s
- * @min 0.0
- * @max 1800.0
- * @decimal 1
- * @increment 5
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
-
-/**
- * Acro mode Expo factor for Roll and Pitch.
- *
- * Exponential factor for tuning the input curve shape.
- *
- * 0 Purely linear input curve
- * 1 Purely cubic input curve
- *
- * @min 0
- * @max 1
- * @decimal 2
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
-
-/**
- * Acro mode Expo factor for Yaw.
- *
- * Exponential factor for tuning the input curve shape.
- *
- * 0 Purely linear input curve
- * 1 Purely cubic input curve
- *
- * @min 0
- * @max 1
- * @decimal 2
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_EXPO_Y, 0.69f);
-
-/**
- * Acro mode SuperExpo factor for Roll and Pitch.
- *
- * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO.
- *
- * 0 Pure Expo function
- * 0.7 reasonable shape enhancement for intuitive stick feel
- * 0.95 very strong bent input curve only near maxima have effect
- *
- * @min 0
- * @max 0.95
- * @decimal 2
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
-
-/**
- * Acro mode SuperExpo factor for Yaw.
- *
- * SuperExpo factor for refining the input curve shape tuned using MC_ACRO_EXPO_Y.
- *
- * 0 Pure Expo function
- * 0.7 reasonable shape enhancement for intuitive stick feel
- * 0.95 very strong bent input curve only near maxima have effect
- *
- * @min 0
- * @max 0.95
- * @decimal 2
- * @group Multicopter Rate Control
- */
-PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPOY, 0.7f);
 
 /**
  * Battery power level scaler


### PR DESCRIPTION
### Solved Problem
When discussing with @sfuhrer I found that most people lower these parameters to tune their vehicles and some even put that in the airframe because forgetting to lower them can lead to accidental flipping the drone.

### Solution
- Move acro mode parameters to separate file and parameter group
- Improve parameter description
- Lower the default rates to 100°/s and disable expo
  This is useless for acro flying but good for rate control tuning and avoids the danger of a beginner or someone tuning who forgot to lower the parameters from flipping the drone immediately.

### Changelog Entry
```
Much lower Multicopter Acro mode default rates
```
Documentation: Need to adjust [tuning guide](https://docs.px4.io/main/en/config_mc/pid_tuning_guide_multicopter.html#rate-pid-tuning) and  [Acro mode](https://docs.px4.io/main/en/flight_modes/acro_mc.html#stick-input-mapping)

### Alternatives
Ideally we get to an Acro mode-specific QGC page that shows the graph for rates and (super) expo while configuring it.

### Test coverage
- I use the default rates I propose every time I tune a vehicle for years.
- I quickly tested that it still works as expected in SITL SIH.

### Context
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/82381280-07f0-450e-8d97-e4033394cb72)
