### PR TITLE
[BACKPORT] Avoid unexpected repositions

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -701,7 +701,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 			const bool unsupported_bits_set = (change_mode_flags & ~1) != 0;
 
 			if (mode_switch_not_requested || unsupported_bits_set) {
-				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED);
 
 			} else {
 				if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -696,8 +696,14 @@ Commander::handle_command(const vehicle_command_s &cmd)
 			// to not require navigator and command to receive / process
 			// the data at the exact same time.
 
-			// Check if a mode switch had been requested
-			if ((((uint32_t)cmd.param2) & 1) > 0) {
+			const uint32_t change_mode_flags = uint32_t(cmd.param2);
+			const bool mode_switch_not_requested = (change_mode_flags & 1) == 0;
+			const bool unsupported_bits_set = (change_mode_flags & ~1) != 0;
+
+			if (mode_switch_not_requested || unsupported_bits_set) {
+				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_UNSUPPORTED;
+
+			} else {
 				if (_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER)) {
 					cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
@@ -705,9 +711,6 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					printRejectMode(vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER);
 					cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
 				}
-
-			} else {
-				cmd_result = vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED;
 			}
 		}
 		break;

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -57,7 +57,8 @@ Loiter::on_inactive()
 void
 Loiter::on_activation()
 {
-	if (_navigator->get_reposition_triplet()->current.valid) {
+	if (_navigator->get_reposition_triplet()->current.valid
+	    && hrt_elapsed_time(&_navigator->get_reposition_triplet()->current.timestamp) < 500_ms) {
 		reposition();
 
 	} else {
@@ -72,7 +73,8 @@ Loiter::on_activation()
 void
 Loiter::on_active()
 {
-	if (_navigator->get_reposition_triplet()->current.valid) {
+	if (_navigator->get_reposition_triplet()->current.valid
+	    && hrt_elapsed_time(&_navigator->get_reposition_triplet()->current.timestamp) < 500_ms) {
 		reposition();
 	}
 


### PR DESCRIPTION
backport of https://github.com/PX4/PX4-Autopilot/pull/22078

### Changelog Entry
For release notes:
```
Bugfix: Don't allow external reposition commands without a mode switch, and ensure old reposition commands are not erroneously set.
```