### PR TITLE
Slow Position Mode

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -224,6 +224,7 @@ set(msg_files
 	VehicleTorqueSetpoint.msg
 	VehicleTrajectoryBezier.msg
 	VehicleTrajectoryWaypoint.msg
+	VelocityLimits.msg
 	VtolVehicleStatus.msg
 	Wind.msg
 	YawEstimatorStatus.msg

--- a/msg/VehicleStatus.msg
+++ b/msg/VehicleStatus.msg
@@ -52,7 +52,8 @@ uint8 NAVIGATION_STATE_AUTO_FOLLOW_TARGET = 19  # Auto Follow
 uint8 NAVIGATION_STATE_AUTO_PRECLAND = 20       # Precision land with landing target
 uint8 NAVIGATION_STATE_ORBIT = 21               # Orbit in a circle
 uint8 NAVIGATION_STATE_AUTO_VTOL_TAKEOFF = 22   # Takeoff, transition, establish loiter
-uint8 NAVIGATION_STATE_MAX = 23
+uint8 NAVIGATION_STATE_POSITION_SLOW = 23
+uint8 NAVIGATION_STATE_MAX = 24
 
 # Bitmask of detected failures
 uint16 failure_detector_status

--- a/msg/VelocityLimits.msg
+++ b/msg/VelocityLimits.msg
@@ -1,0 +1,8 @@
+# Velocity and yaw rate limits for a multicopter position slow mode only
+
+uint64 timestamp # time since system start (microseconds)
+
+# absolute speeds, NAN means use default limit
+float32 horizontal_velocity # [m/s]
+float32 vertical_velocity # [m/s]
+float32 yaw_rate # [rad/s]

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -532,6 +532,10 @@
                             "name": "auto_vtol_takeoff",
                             "description": "Vtol Takeoff"
                         },
+                        "16": {
+                            "name": "position_slow",
+                            "description": "Position Slow"
+                        },
                         "255": {
                             "name": "unknown",
                             "description": "[Unknown]"

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -374,6 +374,10 @@ int Commander::custom_command(int argc, char *argv[])
 			} else if (!strcmp(argv[1], "posctl")) {
 				send_vehicle_command(vehicle_command_s::VEHICLE_CMD_DO_SET_MODE, 1, PX4_CUSTOM_MAIN_MODE_POSCTL);
 
+			} else if (!strcmp(argv[1], "position:slow")) {
+				send_vehicle_command(vehicle_command_s::VEHICLE_CMD_DO_SET_MODE, 1, PX4_CUSTOM_MAIN_MODE_POSCTL,
+						     PX4_CUSTOM_SUB_MODE_POSCTL_SLOW);
+
 			} else if (!strcmp(argv[1], "auto:mission")) {
 				send_vehicle_command(vehicle_command_s::VEHICLE_CMD_DO_SET_MODE, 1, PX4_CUSTOM_MAIN_MODE_AUTO,
 						     PX4_CUSTOM_SUB_MODE_AUTO_MISSION);
@@ -773,7 +777,16 @@ Commander::handle_command(const vehicle_command_s &cmd)
 					desired_nav_state = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
 
 				} else if (custom_main_mode == PX4_CUSTOM_MAIN_MODE_POSCTL) {
-					desired_nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+					switch (custom_sub_mode) {
+					default:
+					case PX4_CUSTOM_SUB_MODE_POSCTL_POSCTL:
+						desired_nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+						break;
+
+					case PX4_CUSTOM_SUB_MODE_POSCTL_SLOW:
+						desired_nav_state = vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW;
+						break;
+					}
 
 				} else if (custom_main_mode == PX4_CUSTOM_MAIN_MODE_AUTO) {
 					if (custom_sub_mode > 0) {
@@ -2783,7 +2796,7 @@ The commander module contains the state machine for mode switching and failsafe 
 	PRINT_MODULE_USAGE_COMMAND("land");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("transition", "VTOL transition");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("mode", "Change flight mode");
-	PRINT_MODULE_USAGE_ARG("manual|acro|offboard|stabilized|altctl|posctl|auto:mission|auto:loiter|auto:rtl|auto:takeoff|auto:land|auto:precland",
+	PRINT_MODULE_USAGE_ARG("manual|acro|offboard|stabilized|altctl|posctl|position:slow|auto:mission|auto:loiter|auto:rtl|auto:takeoff|auto:land|auto:precland",
 			"Flight mode", false);
 	PRINT_MODULE_USAGE_COMMAND("pair");
 	PRINT_MODULE_USAGE_COMMAND("lockdown");

--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -71,6 +71,7 @@ void getVehicleControlMode(bool armed, uint8_t nav_state, uint8_t vehicle_type,
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_POSCTL:
+	case vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW:
 		vehicle_control_mode.flag_control_manual_enabled = true;
 		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_attitude_enabled = true;

--- a/src/modules/commander/ModeUtil/conversions.hpp
+++ b/src/modules/commander/ModeUtil/conversions.hpp
@@ -75,9 +75,11 @@ static inline navigation_mode_t navigation_mode(uint8_t nav_state)
 	case vehicle_status_s::NAVIGATION_STATE_ORBIT: return navigation_mode_t::orbit;
 
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF: return navigation_mode_t::auto_vtol_takeoff;
+
+	case vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW: return navigation_mode_t::position_slow;
 	}
 
-	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX  == 23, "code requires update");
+	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 24, "code requires update");
 
 	return navigation_mode_t::unknown;
 }
@@ -104,7 +106,9 @@ const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
 	"AUTO_LAND",
 	"AUTO_FOLLOW_TARGET",
 	"AUTO_PRECLAND",
-	"ORBIT"
+	"ORBIT",
+	"AUTO_VTOL_TAKEOFF",
+	"POSITION_SLOW"
 };
 
 } // namespace mode_util

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -170,8 +170,14 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_position);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF, flags.mode_req_local_alt);
 
+	// NAVIGATION_STATE_POSITION_SLOW
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_angular_velocity);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_attitude);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_local_alt);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_local_position_relaxed);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_manual_control);
 
-	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 23, "update mode requirements");
+	static_assert(vehicle_status_s::NAVIGATION_STATE_MAX == 24, "update mode requirements");
 }
 
 } // namespace mode_util

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -364,6 +364,7 @@ PARAM_DEFINE_FLOAT(COM_OBC_LOSS_T, 5.0f);
  * @value 8 Stabilized
  * @value 12 Follow Me
  * @value 13 Precision Land
+ * @value 16 Position Slow
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLTMODE1, -1);
@@ -388,6 +389,7 @@ PARAM_DEFINE_INT32(COM_FLTMODE1, -1);
  * @value 8 Stabilized
  * @value 12 Follow Me
  * @value 13 Precision Land
+ * @value 16 Position Slow
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLTMODE2, -1);
@@ -412,6 +414,7 @@ PARAM_DEFINE_INT32(COM_FLTMODE2, -1);
  * @value 8 Stabilized
  * @value 12 Follow Me
  * @value 13 Precision Land
+ * @value 16 Position Slow
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLTMODE3, -1);
@@ -436,6 +439,7 @@ PARAM_DEFINE_INT32(COM_FLTMODE3, -1);
  * @value 8 Stabilized
  * @value 12 Follow Me
  * @value 13 Precision Land
+ * @value 16 Position Slow
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLTMODE4, -1);
@@ -460,6 +464,7 @@ PARAM_DEFINE_INT32(COM_FLTMODE4, -1);
  * @value 8 Stabilized
  * @value 12 Follow Me
  * @value 13 Precision Land
+ * @value 16 Position Slow
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLTMODE5, -1);
@@ -484,6 +489,7 @@ PARAM_DEFINE_INT32(COM_FLTMODE5, -1);
  * @value 8 Stabilized
  * @value 12 Follow Me
  * @value 13 Precision Land
+ * @value 16 Position Slow
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLTMODE6, -1);

--- a/src/modules/commander/px4_custom_mode.h
+++ b/src/modules/commander/px4_custom_mode.h
@@ -68,7 +68,8 @@ enum PX4_CUSTOM_SUB_MODE_AUTO {
 
 enum PX4_CUSTOM_SUB_MODE_POSCTL {
 	PX4_CUSTOM_SUB_MODE_POSCTL_POSCTL = 0,
-	PX4_CUSTOM_SUB_MODE_POSCTL_ORBIT
+	PX4_CUSTOM_SUB_MODE_POSCTL_ORBIT,
+	PX4_CUSTOM_SUB_MODE_POSCTL_SLOW
 };
 
 union px4_custom_mode {
@@ -170,6 +171,11 @@ static inline union px4_custom_mode get_px4_custom_mode(uint8_t nav_state)
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
 		custom_mode.main_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
 		custom_mode.sub_mode = PX4_CUSTOM_SUB_MODE_AUTO_VTOL_TAKEOFF;
+		break;
+
+	case vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW:
+		custom_mode.main_mode = PX4_CUSTOM_MAIN_MODE_POSCTL;
+		custom_mode.sub_mode = PX4_CUSTOM_SUB_MODE_POSCTL_SLOW;
 		break;
 	}
 

--- a/src/modules/flight_mode_manager/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND flight_tasks_all
 	Descend
 	Failsafe
 	ManualAcceleration
+	ManualAccelerationSlow
 	ManualAltitude
 	ManualAltitudeSmoothVel
 	ManualPosition

--- a/src/modules/flight_mode_manager/FlightModeManager.cpp
+++ b/src/modules/flight_mode_manager/FlightModeManager.cpp
@@ -195,6 +195,13 @@ void FlightModeManager::start_flight_task()
 		}
 	}
 
+	// position slow mode
+	if (_vehicle_status_sub.get().nav_state == vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW) {
+		found_some_task = true;
+		FlightTaskError error = switchTask(FlightTaskIndex::ManualAccelerationSlow);
+		task_failure = error != FlightTaskError::NoError;
+	}
+
 	// Manual position control
 	if ((_vehicle_status_sub.get().nav_state == vehicle_status_s::NAVIGATION_STATE_POSCTL) || task_failure) {
 		found_some_task = true;

--- a/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAcceleration/FlightTaskManualAcceleration.hpp
@@ -31,13 +31,6 @@
  *
  ****************************************************************************/
 
-/**
- * @file FlightTaskManualPosition.hpp
- *
- * Flight task for manual position controlled mode.
- *
- */
-
 #pragma once
 
 #include "FlightTaskManualAltitudeSmoothVel.hpp"
@@ -53,7 +46,7 @@ public:
 	bool activate(const trajectory_setpoint_s &last_setpoint) override;
 	bool update() override;
 
-private:
+protected:
 	void _ekfResetHandlerPositionXY(const matrix::Vector2f &delta_xy) override;
 	void _ekfResetHandlerVelocityXY(const matrix::Vector2f &delta_vxy) override;
 

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/CMakeLists.txt
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/CMakeLists.txt
@@ -1,0 +1,39 @@
+############################################################################
+#
+#   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_library(FlightTaskManualAccelerationSlow
+	FlightTaskManualAccelerationSlow.cpp
+)
+target_include_directories(FlightTaskManualAccelerationSlow PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(FlightTaskManualAccelerationSlow PUBLIC FlightTaskManualAcceleration FlightTaskUtility)

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.cpp
@@ -1,0 +1,138 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskManualAccelerationSlow.cpp
+ */
+
+#include "FlightTaskManualAccelerationSlow.hpp"
+#include <px4_platform_common/events.h>
+
+using namespace time_literals;
+
+bool FlightTaskManualAccelerationSlow::update()
+{
+	// Used to apply a configured default slowdown if neither MAVLink nor remote knob commands limits
+	bool velocity_horizontal_limited = false;
+	bool velocity_vertical_limited = false;
+	bool yaw_rate_limited = false;
+
+	// Limits which can only slow down from the nominal configuration we initialize with here
+	// This is ensured by the executing classes
+	float velocity_horizontal = _param_mpc_vel_manual.get();
+	float velocity_up = _param_mpc_z_vel_max_up.get();
+	float velocity_down = _param_mpc_z_vel_max_dn.get();
+	float yaw_rate = math::radians(_param_mpc_man_y_max.get());
+
+	// MAVLink commanded limits
+	if (_velocity_limits_sub.update(&_velocity_limits)) {
+		_velocity_limits_received_before = true;
+	}
+
+	if (_velocity_limits_received_before) {
+		// message received once since mode was started
+		if (PX4_ISFINITE(_velocity_limits.horizontal_velocity)) {
+			velocity_horizontal = fmaxf(_velocity_limits.horizontal_velocity, _param_posslow_min_hvel.get());
+			velocity_horizontal_limited = true;
+		}
+
+		if (PX4_ISFINITE(_velocity_limits.vertical_velocity)) {
+			velocity_up = velocity_down = fmaxf(_velocity_limits.vertical_velocity, _param_posslow_min_vvel.get());
+			velocity_vertical_limited = true;
+		}
+
+		if (PX4_ISFINITE(_velocity_limits.yaw_rate)) {
+			yaw_rate = fmaxf(_velocity_limits.yaw_rate, math::radians(_param_posslow_min_yawr.get()));
+			yaw_rate_limited = true;
+		}
+	}
+
+	// Remote knob commanded limits
+	if (_param_posslow_map_hvel.get() != 0) {
+		const float min_horizontal_velocity_scale = _param_posslow_min_hvel.get() / fmaxf(velocity_horizontal, FLT_EPSILON);
+		const float aux_input = getInputFromSanitizedAuxParameterIndex(_param_posslow_map_hvel.get());
+		const float aux_based_scale =
+			math::interpolate(aux_input, -1.f, 1.f, min_horizontal_velocity_scale, 1.f);
+		velocity_horizontal *= aux_based_scale;
+		velocity_horizontal_limited = true;
+	}
+
+	if (_param_posslow_map_vvel.get() != 0) {
+		const float min_up_speed_scale = _param_posslow_min_vvel.get() / fmaxf(velocity_up, FLT_EPSILON);
+		const float min_down_speed_scale = _param_posslow_min_vvel.get() / fmaxf(velocity_down, FLT_EPSILON);
+		const float aux_input = getInputFromSanitizedAuxParameterIndex(_param_posslow_map_vvel.get());
+		const float up_aux_based_scale =
+			math::interpolate(aux_input, -1.f, 1.f, min_up_speed_scale, 1.f);
+		const float down_aux_based_scale =
+			math::interpolate(aux_input, -1.f, 1.f, min_down_speed_scale, 1.f);
+		velocity_up *= up_aux_based_scale;
+		velocity_down *= down_aux_based_scale;
+		velocity_vertical_limited = true;
+	}
+
+	if (_param_posslow_map_yawr.get() != 0) {
+		const float min_yaw_rate_scale = math::radians(_param_posslow_min_yawr.get()) / fmaxf(yaw_rate, FLT_EPSILON);
+		const float aux_input = getInputFromSanitizedAuxParameterIndex(_param_posslow_map_yawr.get());
+		const float aux_based_scale =
+			math::interpolate(aux_input, -1.f, 1.f, min_yaw_rate_scale, 1.f);
+		yaw_rate *= aux_based_scale;
+		yaw_rate_limited = true;
+	}
+
+	// No input from remote and MAVLink -> use default slow mode limits
+	if (!velocity_horizontal_limited) {
+		velocity_horizontal = _param_posslow_def_hvel.get();
+	}
+
+	if (!velocity_vertical_limited) {
+		velocity_up = velocity_down = _param_posslow_def_vvel.get();
+	}
+
+	if (!yaw_rate_limited) {
+		yaw_rate = math::radians(_param_posslow_def_yawr.get());
+	}
+
+	// Interface to set resulting velocity limits
+	FlightTaskManualAcceleration::_stick_acceleration_xy.setVelocityConstraint(velocity_horizontal);
+	FlightTaskManualAltitude::_velocity_constraint_up = velocity_up;
+	FlightTaskManualAltitude::_velocity_constraint_down = velocity_down;
+	FlightTaskManualAcceleration::_stick_yaw.setYawspeedConstraint(yaw_rate);
+
+	return FlightTaskManualAcceleration::update();
+}
+
+float FlightTaskManualAccelerationSlow::getInputFromSanitizedAuxParameterIndex(int parameter_value)
+{
+	const int sanitized_index = math::constrain(parameter_value - 1, 0, 5);
+	return _sticks.getAux()(sanitized_index);
+}

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/FlightTaskManualAccelerationSlow.hpp
@@ -1,0 +1,90 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskManualAccelerationSlow.hpp
+ *
+ * Flight task for manual position mode with knobs for slower velocity and acceleration.
+ *
+ */
+
+#pragma once
+
+#include "FlightTaskManualAcceleration.hpp"
+#include "StickAccelerationXY.hpp"
+
+#include <lib/weather_vane/WeatherVane.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/velocity_limits.h>
+#include <systemlib/mavlink_log.h>
+
+class FlightTaskManualAccelerationSlow : public FlightTaskManualAcceleration
+{
+public:
+	FlightTaskManualAccelerationSlow() = default;
+	~FlightTaskManualAccelerationSlow() = default;
+	bool update() override;
+
+private:
+
+	/**
+	 * Get the input from a sanitized parameter aux index
+	 * @param parameter_value value of the parameter that specifies the AUX channel index to use
+	 * @return input from that AUX channel [-1,1]
+	 */
+	float getInputFromSanitizedAuxParameterIndex(int parameter_value);
+
+	orb_advert_t _mavlink_log_pub{nullptr};
+
+	bool _velocity_limits_received_before{false};
+
+	uORB::Subscription _velocity_limits_sub{ORB_ID(velocity_limits)};
+	velocity_limits_s _velocity_limits{};
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualAcceleration,
+					(ParamInt<px4::params::POSSLOW_MAP_HVEL>) _param_posslow_map_hvel,
+					(ParamInt<px4::params::POSSLOW_MAP_VVEL>) _param_posslow_map_vvel,
+					(ParamInt<px4::params::POSSLOW_MAP_YAWR>) _param_posslow_map_yawr,
+					(ParamFloat<px4::params::POSSLOW_MIN_HVEL>) _param_posslow_min_hvel,
+					(ParamFloat<px4::params::POSSLOW_MIN_VVEL>) _param_posslow_min_vvel,
+					(ParamFloat<px4::params::POSSLOW_MIN_YAWR>) _param_posslow_min_yawr,
+					(ParamFloat<px4::params::POSSLOW_DEF_HVEL>) _param_posslow_def_hvel,
+					(ParamFloat<px4::params::POSSLOW_DEF_VVEL>) _param_posslow_def_vvel,
+					(ParamFloat<px4::params::POSSLOW_DEF_YAWR>) _param_posslow_def_yawr,
+					(ParamFloat<px4::params::MPC_VEL_MANUAL>) _param_mpc_vel_manual,
+					(ParamFloat<px4::params::MPC_Z_VEL_MAX_UP>) _param_mpc_z_vel_max_up,
+					(ParamFloat<px4::params::MPC_Z_VEL_MAX_DN>) _param_mpc_z_vel_max_dn,
+					(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max
+				       )
+};

--- a/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/flight_task_acceleration_slow_params.c
+++ b/src/modules/flight_mode_manager/tasks/ManualAccelerationSlow/flight_task_acceleration_slow_params.c
@@ -1,0 +1,158 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Manual input mapped to scale horizontal velocity in position slow mode
+ *
+ * @value 0 No rescaling
+ * @value 1 AUX1
+ * @value 2 AUX2
+ * @value 3 AUX3
+ * @value 4 AUX4
+ * @value 5 AUX5
+ * @value 6 AUX6
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_INT32(POSSLOW_MAP_HVEL, 0);
+
+/**
+ * Manual input mapped to scale vertical velocity in position slow mode
+ *
+ * @value 0 No rescaling
+ * @value 1 AUX1
+ * @value 2 AUX2
+ * @value 3 AUX3
+ * @value 4 AUX4
+ * @value 5 AUX5
+ * @value 6 AUX6
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_INT32(POSSLOW_MAP_VVEL, 0);
+
+/**
+ * Manual input mapped to scale yaw rate in position slow mode
+ *
+ * @value 0 No rescaling
+ * @value 1 AUX1
+ * @value 2 AUX2
+ * @value 3 AUX3
+ * @value 4 AUX4
+ * @value 5 AUX5
+ * @value 6 AUX6
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_INT32(POSSLOW_MAP_YAWR, 0);
+
+/**
+ * Horizontal velocity lower limit
+ *
+ * The lowest input maps and is clamped to this velocity.
+ *
+ * @unit m/s
+ * @min 0.1
+ * @increment 0.1
+ * @decimal 2
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_FLOAT(POSSLOW_MIN_HVEL, .3f);
+
+/**
+ * Vertical velocity lower limit
+ *
+ * The lowest input maps and is clamped to this velocity.
+ *
+ * @unit m/s
+ * @min 0.1
+ * @increment 0.1
+ * @decimal 2
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_FLOAT(POSSLOW_MIN_VVEL, .3f);
+
+/**
+ * Yaw rate lower limit
+ *
+ * The lowest input maps and is clamped to this rate.
+ *
+ * @unit deg/s
+ * @min 1
+ * @increment 0.1
+ * @decimal 0
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_FLOAT(POSSLOW_MIN_YAWR, 3.f);
+
+/**
+ * Default horizontal velocity limit
+ *
+ * This value is used in slow mode if
+ * no aux channel is mapped and
+ * no limit is commanded through MAVLink.
+ *
+ * @unit m/s
+ * @min 0.1
+ * @increment 0.1
+ * @decimal 2
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_FLOAT(POSSLOW_DEF_HVEL, 3.f);
+
+/**
+ * Default vertical velocity limit
+ *
+ * This value is used in slow mode if
+ * no aux channel is mapped and
+ * no limit is commanded through MAVLink.
+ *
+ * @unit m/s
+ * @min 0.1
+ * @increment 0.1
+ * @decimal 2
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_FLOAT(POSSLOW_DEF_VVEL, 1.f);
+
+/**
+ * Default yaw rate limit
+ *
+ * This value is used in slow mode if
+ * no aux channel is mapped and
+ * no limit is commanded through MAVLink.
+ *
+ * @unit deg/s
+ * @min 1
+ * @increment 0.1
+ * @decimal 0
+ * @group Multicopter Position Slow Mode
+ */
+PARAM_DEFINE_FLOAT(POSSLOW_DEF_YAWR, 45.f);

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -92,8 +92,9 @@ void FlightTaskManualAltitude::_updateConstraintsFromEstimator()
 void FlightTaskManualAltitude::_scaleSticks()
 {
 	// Use sticks input with deadzone and exponential curve for vertical velocity
-	const float vel_max_z = (_sticks.getPosition()(2) > 0.0f) ? _param_mpc_z_vel_max_dn.get() :
-				_param_mpc_z_vel_max_up.get();
+	const float vel_max_up = fminf(_param_mpc_z_vel_max_up.get(), _velocity_constraint_up);
+	const float vel_max_down = fminf(_param_mpc_z_vel_max_dn.get(), _velocity_constraint_down);
+	const float vel_max_z = (_sticks.getPosition()(2) > 0.0f) ? vel_max_down : vel_max_up;
 	_velocity_setpoint(2) = vel_max_z * _sticks.getPositionExpo()(2);
 }
 

--- a/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/modules/flight_mode_manager/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -74,6 +74,9 @@ protected:
 
 	bool _sticks_data_required = true; ///< let inherited task-class define if it depends on stick data
 
+	float _velocity_constraint_up{INFINITY};
+	float _velocity_constraint_down{INFINITY};
+
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
 					(ParamFloat<px4::params::MPC_HOLD_MAX_Z>) _param_mpc_hold_max_z,
 					(ParamInt<px4::params::MPC_ALT_MODE>) _param_mpc_alt_mode,

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -73,10 +73,12 @@ void StickAccelerationXY::resetAcceleration(const matrix::Vector2f &acceleration
 void StickAccelerationXY::generateSetpoints(Vector2f stick_xy, const float yaw, const float yaw_sp, const Vector3f &pos,
 		const matrix::Vector2f &vel_sp_feedback, const float dt)
 {
-	// maximum commanded acceleration and velocity
-	Vector2f acceleration_scale(_param_mpc_acc_hor.get(), _param_mpc_acc_hor.get());
+	// maximum commanded velocity can be constrained dynamically
 	const float velocity_sc = fminf(_param_mpc_vel_manual.get(), _velocity_constraint);
 	Vector2f velocity_scale(velocity_sc, velocity_sc);
+	// maximum commanded acceleration is scaled down with velocity
+	const float acceleration_sc = _param_mpc_acc_hor.get() * (velocity_sc / _param_mpc_vel_manual.get());
+	Vector2f acceleration_scale(acceleration_sc, acceleration_sc);
 
 	acceleration_scale *= 2.f; // because of drag the average acceleration is half
 

--- a/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickAccelerationXY.cpp
@@ -157,7 +157,13 @@ Vector2f StickAccelerationXY::calculateDrag(Vector2f drag_coefficient, const flo
 
 	// increase drag with squareroot function when velocity is lower than 1m/s
 	const Vector2f velocity_with_sqrt_boost = vel_sp.unit_or_zero() * math::sqrt_linear(vel_sp.norm());
-	return drag_coefficient.emult(velocity_with_sqrt_boost);
+
+	// only apply the drag increase below 1m/s when actually brakeing such that speeds below 1m/s
+	// are exactly reached but do so by blending it with the filter to avoid any discontinuity when switching
+	const float brake_scale = math::interpolate(_brake_boost_filter.getState(), 1.f, 2.f, 0.f, 1.f);
+	const Vector2f mixed_velocity = brake_scale * velocity_with_sqrt_boost + (1.f - brake_scale) * vel_sp;
+
+	return drag_coefficient.emult(mixed_velocity);
 }
 
 void StickAccelerationXY::applyTiltLimit(Vector2f &acceleration)

--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.cpp
@@ -66,7 +66,8 @@ void StickYaw::generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint
 	}
 
 	_yawspeed_filter.setParameters(deltatime, _param_mpc_man_y_tau.get());
-	yawspeed_setpoint = _yawspeed_filter.update(stick_yaw * math::radians(_param_mpc_man_y_max.get()));
+	const float yawspeed_scale = math::min(math::radians(_param_mpc_man_y_max.get()), _yawspeed_constraint);
+	yawspeed_setpoint = _yawspeed_filter.update(stick_yaw * yawspeed_scale);
 	yaw_setpoint = updateYawLock(yaw, yawspeed_setpoint, yaw_setpoint, yaw_correction_prev);
 }
 

--- a/src/modules/flight_mode_manager/tasks/Utility/StickYaw.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/StickYaw.hpp
@@ -52,6 +52,7 @@ public:
 	void ekfResetHandler(float delta_yaw);
 	void generateYawSetpoint(float &yawspeed_setpoint, float &yaw_setpoint, float stick_yaw, float yaw, float deltatime,
 				 float unaided_yaw = NAN);
+	void setYawspeedConstraint(float yawspeed) { _yawspeed_constraint = yawspeed; };
 
 private:
 	AlphaFilter<float> _yawspeed_filter;
@@ -77,6 +78,8 @@ private:
 	 * @return yaw setpoint to execute to have a yaw lock at the correct moment in time
 	 */
 	float updateYawLock(float yaw, float yawspeed_setpoint, float yaw_setpoint, float yaw_correction_prev) const;
+
+	float _yawspeed_constraint{INFINITY};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max, ///< Maximum yaw speed with full stick deflection

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.cpp
@@ -62,6 +62,13 @@ bool Sticks::checkAndUpdateStickInputs()
 		_positions_expo(2) = math::expo_deadzone(_positions(2), _param_mpc_z_man_expo.get(),  _param_mpc_hold_dz.get());
 		_positions_expo(3) = math::expo_deadzone(_positions(3), _param_mpc_yaw_expo.get(),    _param_mpc_hold_dz.get());
 
+		_aux_positions(0) = manual_control_setpoint.aux1;
+		_aux_positions(1) = manual_control_setpoint.aux2;
+		_aux_positions(2) = manual_control_setpoint.aux3;
+		_aux_positions(3) = manual_control_setpoint.aux4;
+		_aux_positions(4) = manual_control_setpoint.aux5;
+		_aux_positions(5) = manual_control_setpoint.aux6;
+
 		// valid stick inputs are required
 		_input_available = manual_control_setpoint.valid && _positions.isAllFinite();
 

--- a/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
+++ b/src/modules/flight_mode_manager/tasks/Utility/Sticks.hpp
@@ -74,6 +74,8 @@ public:
 	const matrix::Vector2f getPitchRoll() { return _positions.slice<2, 1>(0, 0); }
 	const matrix::Vector2f getPitchRollExpo() { return _positions_expo.slice<2, 1>(0, 0); }
 
+	const matrix::Vector<float, 6> &getAux() const { return _aux_positions; }
+
 	/**
 	 * Limit the the horizontal input from a square shaped joystick gimbal to a unit circle
 	 * @param v Vector containing x, y, z axis of the joystick gimbal. x, y get adjusted
@@ -92,6 +94,8 @@ private:
 	bool _input_available{false};
 	matrix::Vector4f _positions; ///< unmodified manual stick inputs
 	matrix::Vector4f _positions_expo; ///< modified manual sticks using expo function
+
+	matrix::Vector<float, 6> _aux_positions;
 
 	uORB::Subscription _manual_control_setpoint_sub{ORB_ID(manual_control_setpoint)};
 	uORB::Subscription _failsafe_flags_sub{ORB_ID(failsafe_flags)};

--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -555,6 +555,7 @@ int8_t ManualControl::navStateFromParam(int32_t param_value)
 		case 13: return vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND;
 		case 14: return vehicle_status_s::NAVIGATION_STATE_ORBIT;
 		case 15: return vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF;
+		case 16: return vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW;
 	}
 	return -1;
 }


### PR DESCRIPTION
### Solved Problem
@marcinolokk and I implemented a slow version of the Position mode. It allows to fly like in Position mode but with slower horizontal and vertical velocity plus yaw turn rate. The sources for how much slower it goes in these dimensions can be:
- Parameters for metric limits as defaults
- Mappable auxiliary remote inputs e.g. knobs that allow scaling down
- uORB/MAVLink message specifying metric limits

Fixes #19799 (note that the default horizontal speed is 3m/s which should fulfill the requirement)

### Solution
- Add interfaces in the existing flight task components that are in use for Position mode to slow down
- Add a new mode "Position Slow"
- Add a new message for velocity limits which is supposed to be filled with the contents of the MAVLink message from https://github.com/mavlink/mavlink/pull/2015
- Implement a new `FlightTaskManualAccelerationSlow` that orchestrates the inputs

### Changelog Entry
For release notes:
```
Feature: Add new multicopter slowed-down Position mode
Documentation: Missing so far. It needs a new mode page best situated under the Position mode.
```

### Test coverage
The full solution was tested in simulation and on a real quadrotor with different settings and all the different inputs and combinations. It will soon be rolled out to production.

### Context
- I realized in https://github.com/PX4/PX4-Autopilot/pull/22084 that there are probably conflicts with https://github.com/PX4/PX4-Autopilot/pull/20707
   I'm happy to rebase and resolve.
- With https://github.com/mavlink/mavlink/pull/2031 we can also bring in auxiliary remote inputs through MAVLink. I'm adding support for this separately from this pr.
