### PR TITLE
uXRCE-DDS Client: Expose custom participant and localhost-only flags

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -18,6 +18,12 @@ param set-default SENS_EN_INA226 1
 
 param set-default SYS_USE_IO 1
 
+if ver hwtypecmp V5X009000 V5X009001 V5X00a000 V5X00a001 V5X008000 V5X008001 V5X010001
+then
+	# Skynode: use the "custom participant" config for uxrce_dds_client
+	param set-default UXRCE_DDS_PTCFG 2
+fi
+
 safety_button start
 
 # GPIO Expander driver on external I2C3

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -18,4 +18,10 @@ param set-default SENS_EN_INA226 1
 
 param set-default SYS_USE_IO 1
 
+if ver hwtypecmp V6X009010 V6X010010
+then
+	# Skynode: use the "custom participant" config for uxrce_dds_client
+	param set-default UXRCE_DDS_PTCFG 2
+fi
+
 safety_button start

--- a/src/modules/uxrce_dds_client/module.yaml
+++ b/src/modules/uxrce_dds_client/module.yaml
@@ -28,7 +28,7 @@ parameters:
 
         UXRCE_DDS_KEY:
             description:
-                short: uXRCE-DDS Session key
+                short: uXRCE-DDS session key
                 long: |
                     uXRCE-DDS key, must be different from zero.
                     In a single agent - multi client configuration, each client
@@ -40,10 +40,10 @@ parameters:
 
         UXRCE_DDS_PRT:
             description:
-                short: uXRCE-DDS UDP Port
+                short: uXRCE-DDS UDP port
                 long: |
-                    If ethernet enabled and selected as configuration for uXRCE-DDS,
-                    selected udp port will be set and used.
+                    If ethernet is enabled and is the selected configuration for uXRCE-DDS,
+                    the selected UDP port will be set and used.
             type: int32
             min: 0
             max: 65535
@@ -55,8 +55,8 @@ parameters:
             description:
                 short: uXRCE-DDS Agent IP address
                 long: |
-                    If ethernet enabled and selected as configuration for uXRCE-DDS,
-                    selected Agent IP address will be set and used.
+                    If ethernet is enabled and is the selected configuration for uXRCE-DDS,
+                    the selected Agent IP address will be set and used.
                     Decimal dot notation is not supported. IP address must be provided
                     in int32 format. For example, 192.168.1.2 is mapped to -1062731518;
                     127.0.0.1 is mapped to 2130706433.
@@ -67,7 +67,7 @@ parameters:
 
         UXRCE_DDS_SYNCT:
             description:
-                short: uXRCE-DDS timestamp synchronization enable
+                short: Enable uXRCE-DDS timestamp synchronization
                 long: When enabled, uxrce_dds_client will synchronize the timestamps
                     of the incoming and outgoing messages measuring the offset
                     between the Agent OS time and the PX4 time.

--- a/src/modules/uxrce_dds_client/module.yaml
+++ b/src/modules/uxrce_dds_client/module.yaml
@@ -65,6 +65,26 @@ parameters:
             default: 2130706433
             requires_ethernet: true
 
+        UXRCE_DDS_PTCFG:
+            description:
+                short: uXRCE-DDS participant configuration
+                long: |
+                    Set the participant configuration on the Agent's system.
+                    0: Use the default configuration.
+                    1: Restrict messages to localhost
+                       (use in combination with ROS_LOCALHOST_ONLY=1).
+                    2: Use a custom participant with the profile name "px4_participant".
+            category: System
+            reboot_required: true
+            type: enum
+            values:
+                0: Default
+                1: Localhost-only
+                2: Custom participant
+            min: 0
+            max: 2
+            default: 0
+
         UXRCE_DDS_SYNCT:
             description:
                 short: Enable uXRCE-DDS timestamp synchronization

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -563,21 +563,22 @@ int UxrceddsClient::print_status()
 #if defined(UXRCE_DDS_CLIENT_UDP)
 
 	if (_transport_udp != nullptr) {
-		PX4_INFO("Using transport: udp");
-		PX4_INFO("Agent IP: %s", _agent_ip);
-		PX4_INFO("Agent port: %s", _port);
-
+		PX4_INFO("Using transport:     udp");
+		PX4_INFO("Agent IP:            %s", _agent_ip);
+		PX4_INFO("Agent port:          %s", _port);
+		PX4_INFO("Custom participant:  %s", _custom_participant ? "yes" : "no");
+		PX4_INFO("Localhost only:      %s", _localhost_only ? "yes" : "no");
 	}
 
 #endif
 
 	if (_transport_serial != nullptr) {
-		PX4_INFO("Using transport: serial");
+		PX4_INFO("Using transport:     serial");
 	}
 
 	if (_connected) {
-		PX4_INFO("Payload tx: %i B/s", _last_payload_tx_rate);
-		PX4_INFO("Payload rx: %i B/s", _last_payload_rx_rate);
+		PX4_INFO("Payload tx:          %i B/s", _last_payload_tx_rate);
+		PX4_INFO("Payload rx:          %i B/s", _last_payload_rx_rate);
 	}
 
 	return 0;

--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -235,58 +235,55 @@ void UxrceddsClient::run()
 
 		uint16_t domain_id = _param_xrce_dds_dom_id.get();
 
-		// const char *participant_name = "px4_micro_xrce_dds";
-		// uint16_t participant_req = uxr_buffer_create_participant_bin(&session, reliable_out, participant_id, domain_id,
-		// 			   participant_name, UXR_REPLACE);
-
-		char participant_xml[PARTICIPANT_XML_SIZE];
-		int ret = snprintf(participant_xml, PARTICIPANT_XML_SIZE, "%s<name>%s/px4_micro_xrce_dds</name>%s",
-				   _localhost_only ?
-				   "<dds>"
-				   "<profiles>"
-				   "<transport_descriptors>"
-				   "<transport_descriptor>"
-				   "<transport_id>udp_localhost</transport_id>"
-				   "<type>UDPv4</type>"
-				   "<interfaceWhiteList><address>127.0.0.1</address></interfaceWhiteList>"
-				   "</transport_descriptor>"
-				   "</transport_descriptors>"
-				   "</profiles>"
-				   "<participant>"
-				   "<rtps>"
-				   :
-				   "<dds>"
-				   "<participant>"
-				   "<rtps>",
-				   _client_namespace != nullptr ?
-				   _client_namespace
-				   :
-				   "",
-				   _localhost_only ?
-				   "<useBuiltinTransports>false</useBuiltinTransports>"
-				   "<userTransports><transport_id>udp_localhost</transport_id></userTransports>"
-				   "</rtps>"
-				   "</participant>"
-				   "</dds>"
-				   :
-				   "</rtps>"
-				   "</participant>"
-				   "</dds>"
-				  );
-
-		if (ret < 0 || ret >= PARTICIPANT_XML_SIZE) {
-			PX4_ERR("create entities failed: namespace too long");
-			return;
-		}
-
-
 		uint16_t participant_req{};
 
 		if (_custom_participant) {
+			// Create participant by reference (XML not required)
 			participant_req = uxr_buffer_create_participant_ref(&session, reliable_out, participant_id, domain_id,
 					  "px4_participant", UXR_REPLACE);
 
 		} else {
+			// Construct participant XML and create participant by XML
+			char participant_xml[PARTICIPANT_XML_SIZE];
+			int ret = snprintf(participant_xml, PARTICIPANT_XML_SIZE, "%s<name>%s/px4_micro_xrce_dds</name>%s",
+					   _localhost_only ?
+					   "<dds>"
+					   "<profiles>"
+					   "<transport_descriptors>"
+					   "<transport_descriptor>"
+					   "<transport_id>udp_localhost</transport_id>"
+					   "<type>UDPv4</type>"
+					   "<interfaceWhiteList><address>127.0.0.1</address></interfaceWhiteList>"
+					   "</transport_descriptor>"
+					   "</transport_descriptors>"
+					   "</profiles>"
+					   "<participant>"
+					   "<rtps>"
+					   :
+					   "<dds>"
+					   "<participant>"
+					   "<rtps>",
+					   _client_namespace != nullptr ?
+					   _client_namespace
+					   :
+					   "",
+					   _localhost_only ?
+					   "<useBuiltinTransports>false</useBuiltinTransports>"
+					   "<userTransports><transport_id>udp_localhost</transport_id></userTransports>"
+					   "</rtps>"
+					   "</participant>"
+					   "</dds>"
+					   :
+					   "</rtps>"
+					   "</participant>"
+					   "</dds>"
+					  );
+
+			if (ret < 0 || ret >= PARTICIPANT_XML_SIZE) {
+				PX4_ERR("create entities failed: namespace too long");
+				return;
+			}
+
 			participant_req = uxr_buffer_create_participant_xml(&session, reliable_out, participant_id, domain_id,
 					  participant_xml, UXR_REPLACE);
 		}
@@ -607,7 +604,7 @@ UxrceddsClient *UxrceddsClient::instantiate(int argc, char *argv[])
 
 	const char *client_namespace = nullptr;//"px4";
 
-	while ((ch = px4_getopt(argc, argv, "t:d:b:h:p:lcn:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "t:d:b:h:p:n:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 't':
 			if (!strcmp(myoptarg, "serial")) {
@@ -643,14 +640,6 @@ UxrceddsClient *UxrceddsClient::instantiate(int argc, char *argv[])
 
 		case 'p':
 			snprintf(port, PORT_MAX_LENGTH, "%s", myoptarg);
-			break;
-
-		case 'l':
-			localhost_only = true;
-			break;
-
-		case 'c':
-			custom_participant = true;
 			break;
 #endif // UXRCE_DDS_CLIENT_UDP
 
@@ -692,6 +681,19 @@ UxrceddsClient *UxrceddsClient::instantiate(int argc, char *argv[])
 			 static_cast<uint8_t>(((ip_i) >> 16) & 0xff),
 			 static_cast<uint8_t>(((ip_i) >> 8) & 0xff),
 			 static_cast<uint8_t>(ip_i & 0xff));
+	}
+
+	int32_t participant_config = 0;
+	param_get(param_find("UXRCE_DDS_PTCFG"), &participant_config);
+
+	switch (participant_config) {
+	case 1:
+		localhost_only = true;
+		break;
+
+	case 2:
+		custom_participant = true;
+		break;
 	}
 
 #endif // UXRCE_DDS_CLIENT_UDP
@@ -743,8 +745,6 @@ $ uxrce_dds_client start -t udp -h 127.0.0.1 -p 15555
 	PRINT_MODULE_USAGE_PARAM_INT('b', 0, 0, 3000000, "Baudrate (can also be p:<param_name>)", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('h', nullptr, "<IP>", "Agent IP. If not provided, defaults to UXRCE_DDS_AG_IP", true);
 	PRINT_MODULE_USAGE_PARAM_INT('p', -1, 0, 65535, "Agent listening port. If not provided, defaults to UXRCE_DDS_PRT", true);
-	PRINT_MODULE_USAGE_PARAM_FLAG('l', "Restrict to localhost (use in combination with ROS_LOCALHOST_ONLY=1)", true);
-	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Use custom participant config (profile_name=\"px4_participant\")", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('n', nullptr, nullptr, "Client DDS namespace", true);
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 


### PR DESCRIPTION
### Solved Problem

The `uxrce_dds_client` can be started with flags to enable using a custom participant (`-c`) or localhost-only on the agent side (`-l`), but these were only available when starting the client by hand in the console.

### Solution

Remove the CLI flags and instead a parameter for selecting the participant configuration, `UXRCE_DDS_PTCFG`.

This allows for selecting either the custom participant or localhost-only configuration, or neither (the default).

#### To Do
- [ ] Update docs: https://github.com/PX4/PX4-user_guide/blob/main/en/middleware/uxrce_dds.md

#### Additionally

- Improve other parameter descriptions for the `uxrce_dds_client`.
- Improve formatting of `uxrce_dds_client status`. For example:
```bash
INFO  [uxrce_dds_client] Running, connected
INFO  [uxrce_dds_client] Using transport:    udp
INFO  [uxrce_dds_client] Agent IP:           192.168.0.5
INFO  [uxrce_dds_client] Agent port:         8888
INFO  [uxrce_dds_client] Custom participant: no
INFO  [uxrce_dds_client] Localhost only:     yes
INFO  [uxrce_dds_client] Payload tx:         47811 B/s
INFO  [uxrce_dds_client] Payload rx:         0 B/s
```

### Changelog Entry
For release notes:
```
uXRCE-DDS Client: expose custom participant and localhost-only flags as parameters
New parameters: UXRCE_DDS_PTCFG
```


### Test coverage
- Tested on n FMU v5x. Enabled the parameter in various combinations to verify the behaviour.