### PR TITLE
Support MAVLink MANUAL_CONTROL.aux extension

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2110,6 +2110,19 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 	manual_control_setpoint.yaw = mavlink_manual_control.r / 1000.f;
 	// Pass along the button states
 	manual_control_setpoint.buttons = mavlink_manual_control.buttons;
+
+	if (mavlink_manual_control.enabled_extensions & (1u << 2)) { manual_control_setpoint.aux1 = mavlink_manual_control.aux1 / 1000.0f; }
+
+	if (mavlink_manual_control.enabled_extensions & (1u << 3)) { manual_control_setpoint.aux2 = mavlink_manual_control.aux2 / 1000.0f; }
+
+	if (mavlink_manual_control.enabled_extensions & (1u << 4)) { manual_control_setpoint.aux3 = mavlink_manual_control.aux3 / 1000.0f; }
+
+	if (mavlink_manual_control.enabled_extensions & (1u << 5)) { manual_control_setpoint.aux4 = mavlink_manual_control.aux4 / 1000.0f; }
+
+	if (mavlink_manual_control.enabled_extensions & (1u << 6)) { manual_control_setpoint.aux5 = mavlink_manual_control.aux5 / 1000.0f; }
+
+	if (mavlink_manual_control.enabled_extensions & (1u << 7)) { manual_control_setpoint.aux6 = mavlink_manual_control.aux6 / 1000.0f; }
+
 	manual_control_setpoint.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0 + _mavlink.get_instance_id();
 	manual_control_setpoint.timestamp = manual_control_setpoint.timestamp_sample = hrt_absolute_time();
 	manual_control_setpoint.valid = true;

--- a/src/modules/mavlink/streams/MANUAL_CONTROL.hpp
+++ b/src/modules/mavlink/streams/MANUAL_CONTROL.hpp
@@ -68,10 +68,10 @@ private:
 			mavlink_manual_control_t msg{};
 
 			msg.target = mavlink_system.sysid;
-			msg.x = manual_control_setpoint.pitch * 1000;
-			msg.y = manual_control_setpoint.roll * 1000;
-			msg.z = manual_control_setpoint.throttle * 1000;
-			msg.r = manual_control_setpoint.yaw * 1000;
+			msg.x = manual_control_setpoint.pitch * 1000.f;
+			msg.y = manual_control_setpoint.roll * 1000.f;
+			msg.z = manual_control_setpoint.throttle * 1000.f;
+			msg.r = manual_control_setpoint.yaw * 1000.f;
 
 			manual_control_switches_s manual_control_switches{};
 
@@ -82,6 +82,36 @@ private:
 				msg.buttons |= (manual_control_switches.loiter_switch << (shift * 3));
 				msg.buttons |= (manual_control_switches.offboard_switch << (shift * 5));
 				msg.buttons |= (manual_control_switches.kill_switch << (shift * 6));
+			}
+
+			if (PX4_ISFINITE(manual_control_setpoint.aux1)) {
+				msg.enabled_extensions |= (1u << 2);
+				msg.aux1 = manual_control_setpoint.aux1 * 1000.f;
+			}
+
+			if (PX4_ISFINITE(manual_control_setpoint.aux2)) {
+				msg.enabled_extensions |= (1u << 3);
+				msg.aux2 = manual_control_setpoint.aux2 * 1000.f;
+			}
+
+			if (PX4_ISFINITE(manual_control_setpoint.aux3)) {
+				msg.enabled_extensions |= (1u << 4);
+				msg.aux3 = manual_control_setpoint.aux3 * 1000.f;
+			}
+
+			if (PX4_ISFINITE(manual_control_setpoint.aux4)) {
+				msg.enabled_extensions |= (1u << 5);
+				msg.aux4 = manual_control_setpoint.aux4 * 1000.f;
+			}
+
+			if (PX4_ISFINITE(manual_control_setpoint.aux5)) {
+				msg.enabled_extensions |= (1u << 6);
+				msg.aux5 = manual_control_setpoint.aux5 * 1000.f;
+			}
+
+			if (PX4_ISFINITE(manual_control_setpoint.aux6)) {
+				msg.enabled_extensions |= (1u << 7);
+				msg.aux6 = manual_control_setpoint.aux6 * 1000.f;
 			}
 
 			mavlink_msg_manual_control_send_struct(_mavlink->get_channel(), &msg);


### PR DESCRIPTION
### Solved Problem
When working on #22102 I realized there's no way to get auxiliary continuous inputs in over MAVLink. That's why we came up with the suggestion to support it in MAVLink https://github.com/mavlink/mavlink/pull/2031 and this pr brings the implementation to PX4.

### Solution
- https://github.com/mavlink/mavlink/pull/2031
- Read `MANUAL_CONTROL` fields when it's an input
   main use case
- Fill the fields when sending out `MANUAL_CONTROL` as telemetry
   only done sent with the USB telemtry profile

### Changelog Entry
```
Feature: Support MAVLink MANUAL_CONTROL.aux extension
```

### Alternatives
Note that in uORB we don't currently know if the aux fields are specifically valid or not so we can also not set the corresponding bits in the field and vice versa. I'll propose to set the fields differently from just zero-initialized to indicate them being valid or not.

### Test coverage
I have no counterpart to test this with just yet.

### Context
The requirement to have these auxiliary inputs available for a remote communicating via MAVLink arose from mapping a knob to slow down an axis in https://github.com/PX4/PX4-Autopilot/pull/22102