### PR TITLE
mavlink: make SimulatorMavlink module build with any dialect

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -88,11 +88,7 @@ set_source_files_properties(${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}/${C
 # mavlink header only library
 add_library(mavlink_c INTERFACE)
 target_compile_options(mavlink_c INTERFACE -Wno-address-of-packed-member -Wno-cast-align)
-target_sources(mavlink_c
-	INTERFACE
-		${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}/${CONFIG_MAVLINK_DIALECT}.h
-		${MAVLINK_LIBRARY_DIR}/${MAVLINK_DIALECT_UAVIONIX}/${MAVLINK_DIALECT_UAVIONIX}.h
-)
+add_dependencies(mavlink_c mavlink_c_generate)
 target_include_directories(mavlink_c
 	INTERFACE
 		${MAVLINK_LIBRARY_DIR}

--- a/src/modules/simulation/simulator_mavlink/CMakeLists.txt
+++ b/src/modules/simulation/simulator_mavlink/CMakeLists.txt
@@ -38,16 +38,11 @@ px4_add_module(
 		-Wno-double-promotion
 		-Wno-cast-align
 		-Wno-address-of-packed-member # TODO: fix in c_library_v2
-	INCLUDES
-		${CMAKE_BINARY_DIR}/mavlink
-		${CMAKE_BINARY_DIR}/mavlink/development
-		${CMAKE_BINARY_DIR}/mavlink/common
-		${CMAKE_BINARY_DIR}/mavlink/standard
 	SRCS
 		SimulatorMavlink.cpp
 		SimulatorMavlink.hpp
 	DEPENDS
-		mavlink_c_generate
+		mavlink_c
 		conversion
 		geo
 		drivers_accelerometer


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When I changed the PX4_SITL_Default Mavlink Dialect from "development" to our custom dialect I found that the Simulator Mavlink module stopped building correctly due to include errors, with MAV enums not being found in the correct mavlink.h files

### Solution
- Changes to src/modules/simulation/simulator_mavlink/CMakeLists.txt to not name specific dialect, but depend on `mavlink_c` target created in src/modules/mavlink/CMakeLists.txt
- src/modules/mavlink/CMakeLists.txt `mavlink_c` target modified to not list mavlink header files as sources, as this was also causing build issues.

### Changelog Entry
For release notes:
```
Simulator Mavlink will build with custom dialects
```
