### PR TITLE
FW Position Controller: handle IDLE waypoints in FW_POSCTRL_MODE_AUTO also with NAN setpoints

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -723,7 +723,11 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now)
 	_skipping_takeoff_detection = false;
 
 	if (((_control_mode.flag_control_auto_enabled && _control_mode.flag_control_position_enabled) ||
-	     _control_mode.flag_control_offboard_enabled) && _position_setpoint_current_valid) {
+	     _control_mode.flag_control_offboard_enabled) && (_position_setpoint_current_valid
+			     || _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE)) {
+
+		// Enter this mode only if the current waypoint has valid 3D position setpoints or is of type IDLE.
+		// A setpoint of type IDLE can be published by Navigator without a valid position, and is handled here in FW_POSCTRL_MODE_AUTO.
 
 		if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
 


### PR DESCRIPTION

### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/22072

### Solution
A setpoint of type IDLE can be published by Navigator without a valid position, and should be handled in the auto function in `FW_POSCTRL_MODE_AUTO`. If it wouldn't be handled there the controller would switch to mode `FW_POSCTRL_MODE_OTHER`, in which case no attitude setpoint is published and the lower controllers would be stuck with the last published value (incl. thrust).


### Changelog Entry
For release notes:
```
Bugfix: FW Position Controller: handle IDLE waypoints in FW_POSCTRL_MODE_AUTO
```

### Alternatives
- prevent arming in case of invalid mission
- also publish an attitude setpoint if in `FW_POSCTRL_MODE_OTHER`? With thrust set to 0 like when in `FW_POSCTRL_MODE_AUTO` and `SETPOINT_TYPE_IDLE`?

### Test coverage
SITL tested.

### Context
This falls into the context of interfaces cleanup. Why does a "position setpoint" message contain non-position items? Why does it only have one .valid field, and when is this true, when false? What is an IDLE setpoint at all?
