### PR TITLE
ekf2: EKFGSF always run

### DIFF
--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -71,8 +71,12 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 		}
 	}
 
-	// run EKF-GSF yaw estimator once per imu_delayed update after all main EKF data samples available
-	_yawEstimator.update(imu_delayed, _control_status.flags.in_air, getGyroBias());
+	if (!gyro_bias_inhibited()) {
+		_yawEstimator.setGyroBias(getGyroBias());
+	}
+
+	// run EKF-GSF yaw estimator once per imu_delayed update
+	_yawEstimator.update(imu_delayed, _control_status.flags.in_air && !_control_status.flags.vehicle_at_rest);
 
 	// Check for new GPS data that has fallen behind the fusion time horizon
 	if (_gps_data_ready) {
@@ -423,6 +427,8 @@ void Ekf::stopGpsFusion()
 #if defined(CONFIG_EKF2_GNSS_YAW)
 	stopGpsYawFusion();
 #endif // CONFIG_EKF2_GNSS_YAW
+
+	_yawEstimator.reset();
 }
 
 bool Ekf::isYawEmergencyEstimateAvailable() const


### PR DESCRIPTION
 - if not in air the accel noise is doubled
 - if landed don't init unless GPS velocity is non-negligible (magnitude of GPS velocity exceeds reported accuracy)
 - when inactive continue seeding with EKF gyro bias
 - reset yaw estimator if GPS fusion is stopped