### PR TITLE
mavlink: Display instance number

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -3299,12 +3299,16 @@ Mavlink::set_boot_complete()
 #if defined(MAVLINK_UDP)
 	LockGuard lg {mavlink_module_mutex};
 
+	uint8_t index = 0;
+
 	for (Mavlink *inst : mavlink_module_instances) {
 		if (inst && (inst->get_mode() != MAVLINK_MODE_ONBOARD) &&
 		    !inst->broadcast_enabled() && inst->get_protocol() == Protocol::UDP) {
 
-			PX4_INFO("MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)");
+			PX4_INFO("MAVLink only on localhost (set param MAV_%d_BROADCAST = 1 to enable network)", index);
 		}
+
+		++index;
 	}
 
 #endif // MAVLINK_UDP


### PR DESCRIPTION
### Solved Problem

When starting SITL, "MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)" is displayed.

Fixes #{Github issue ID}

### Solution

Display "{i}" as instance number.

### Changelog Entry

none

### Alternatives

none

### Test coverage

Start SITL and verify that it displays "MAVLink only on localhost (set param MAV_x_BROADCAST = 1 to enable network)".

x is the maximum instance number from 0

### Context

none
