### PR TITLE
Fix Default Output Protocol - Airframe 4019_x500_v2

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4019_x500_v2
+++ b/ROMFS/px4fmu_common/init.d/airframes/4019_x500_v2
@@ -38,5 +38,3 @@ param set-default PWM_MAIN_FUNC1 101
 param set-default PWM_MAIN_FUNC2 102
 param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
-param set-default PWM_MAIN_TIM0 -4
-


### PR DESCRIPTION
### Solved Problem
Currently, in master & 1.14.0 RC1, the X500v2 Airframe defaults Main 1-2 output protocol to `Unknown: -4` 
![V%R68 1L2UOVSH%RBXQ98`B](https://github.com/PX4/PX4-Autopilot/assets/46874772/31267f4e-82f0-47c3-828b-7554d1baaf4f)

It was found that this PR https://github.com/PX4/PX4-Autopilot/pull/21841 changed the default output protocol of X500v2 airframe from Aux to Main but forgot to remove the line that set it to DShot `param set-default PWM_AUX_TIM0`, DShot is not available in Main output (IO PWM) , only Aux (FMU PWM) does. 

Removing this line should make default output protocol back to `PWM 400 Hz`

