### PR TITLE
ekf2: fix WMM NAN checks

### DIFF
--- a/src/modules/ekf2/EKF/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/gps_checks.cpp
@@ -113,9 +113,9 @@ bool Ekf::collect_gps(const gpsMessage &gps)
 				const bool mag_inclination_changed = (fabsf(mag_inclination_gps - _mag_inclination_gps) > math::radians(1.f));
 
 				if ((_wmm_gps_time_last_set == 0)
-				    || !PX4_ISFINITE(mag_declination_gps)
-				    || !PX4_ISFINITE(mag_inclination_gps)
-				    || !PX4_ISFINITE(mag_strength_gps)
+				    || !PX4_ISFINITE(_mag_declination_gps)
+				    || !PX4_ISFINITE(_mag_inclination_gps)
+				    || !PX4_ISFINITE(_mag_strength_gps)
 				    || mag_declination_changed
 				    || mag_inclination_changed
 				   ) {

--- a/src/modules/ekf2/EKF/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/gps_checks.cpp
@@ -92,7 +92,7 @@ bool Ekf::collect_gps(const gpsMessage &gps)
 		ECL_INFO("GPS checks passed");
 	}
 
-	if (isTimedOut(_wmm_gps_time_last_checked, 1e6)) {
+	if ((isTimedOut(_wmm_gps_time_last_checked, 1e6)) || (_wmm_gps_time_last_set == 0)) {
 		// a rough 2D fix is sufficient to lookup declination
 		const bool gps_rough_2d_fix = (gps.fix_type >= 2) && (gps.eph < 1000);
 


### PR DESCRIPTION
This should have been if any of the stored WMM fields are NAN to allow them to be set immediately. In typical usage this is redundant with the time check (_wmm_gps_time_last_set).