### PR TITLE
Limit transition airspeed using minimum airspeed compensated for weight

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -204,16 +204,16 @@ void Standard::update_transition_state()
 						     _param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
 		}
 
-		_airspeed_trans_blend_margin = _param_vt_arsp_trans.get() - _param_vt_arsp_blend.get();
+		_airspeed_trans_blend_margin = getTransitionAirspeed() - getBlendAirspeed();
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_airspeed_trans_blend_margin > 0.0f &&
 		    PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
 		    _airspeed_validated->calibrated_airspeed_m_s > 0.0f &&
-		    _airspeed_validated->calibrated_airspeed_m_s >= _param_vt_arsp_blend.get() &&
+		    _airspeed_validated->calibrated_airspeed_m_s >= getBlendAirspeed() &&
 		    _time_since_trans_start > getMinimumFrontTransitionTime()) {
 
-			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - _param_vt_arsp_blend.get()) /
+			mc_weight = 1.0f - fabsf(_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -244,9 +244,9 @@ void Tiltrotor::update_transition_state()
 		_mc_yaw_weight = 1.0f;
 
 		if (!_param_fw_arsp_mode.get()  && PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
-		    _airspeed_validated->calibrated_airspeed_m_s >= _param_vt_arsp_blend.get()) {
-			const float weight = 1.0f - (_airspeed_validated->calibrated_airspeed_m_s - _param_vt_arsp_blend.get()) /
-					     (_param_vt_arsp_trans.get()  - _param_vt_arsp_blend.get());
+		    _airspeed_validated->calibrated_airspeed_m_s >= getBlendAirspeed()) {
+			const float weight = 1.0f - (_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
+					     (getTransitionAirspeed()  - getBlendAirspeed());
 			_mc_roll_weight = weight;
 			_mc_yaw_weight = weight;
 		}

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -588,9 +588,9 @@ float VtolType::getOpenLoopFrontTransitionTime() const
 }
 float VtolType::getTransitionAirspeed() const
 {
-	return  math::max(_param_vt_arsp_trans.get(), getMinimumAirspeed());
+	return  math::max(_param_vt_arsp_trans.get(), getMinimumTransitionAirspeed());
 }
-float VtolType::getMinimumAirspeed() const
+float VtolType::getMinimumTransitionAirspeed() const
 {
 	float weight_ratio = 1.0f;
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -241,7 +241,7 @@ public:
 	 *
 	 * @return The minimum calibrated airspeed compensated for weight [m/s]
 	 */
-	float getMinimumAirspeed() const;
+	float getMinimumTransitionAirspeed() const;
 
 	/**
 	 *

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -237,6 +237,24 @@ public:
 	*/
 	float getOpenLoopFrontTransitionTime() const;
 
+	/**
+	 *
+	 * @return The minimum calibrated airspeed compensated for weight [m/s]
+	 */
+	float getMinimumAirspeed() const;
+
+	/**
+	 *
+	 * @return The calibrated blending airspeed [m/s]
+	 */
+	float getBlendAirspeed() const;
+
+	/**
+	 *
+	 * @return The calibrated transition airspeed [m/s]
+	 */
+	float getTransitionAirspeed() const;
+
 	virtual void parameters_update() = 0;
 
 	/**
@@ -343,7 +361,11 @@ protected:
 					(ParamInt<px4::params::VT_FWD_THRUST_EN>) _param_vt_fwd_thrust_en,
 					(ParamFloat<px4::params::MPC_LAND_ALT1>) _param_mpc_land_alt1,
 					(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2,
-					(ParamFloat<px4::params::VT_LND_PITCH_MIN>) _param_vt_lnd_pitch_min
+					(ParamFloat<px4::params::VT_LND_PITCH_MIN>) _param_vt_lnd_pitch_min,
+					(ParamFloat<px4::params::WEIGHT_BASE>) _param_weight_base,
+					(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
+					(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_airspeed_min
+
 				       )
 
 private:


### PR DESCRIPTION
### Solved Problem
Since the stall airspeed increases with vehicle weight, we want to make sure that the transition airspeed is at least as high as the minimum airspeed compensated for weight.


### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
