### PR TITLE
workqueue: increase hp_default stack

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -72,7 +72,7 @@ static constexpr wq_config_t INS1{"wq:INS1", 6000, -15};
 static constexpr wq_config_t INS2{"wq:INS2", 6000, -16};
 static constexpr wq_config_t INS3{"wq:INS3", 6000, -17};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1900, -18};
+static constexpr wq_config_t hp_default{"wq:hp_default", 2392, -18};
 
 static constexpr wq_config_t uavcan{"wq:uavcan", 3624, -19};
 


### PR DESCRIPTION
In my earlier testing of https://github.com/PX4/PX4-Autopilot/pull/21432 I didn't notice any hardfaults. I just did another build of units and started noticing random hardfaults on boot. I traced it back to the AFBR 1.4.4 library update. Sometimes on boot it uses more stack than is allocated in hp_default.

Before increasing the total stack allowed for the task. Non hardfault case.
``` 
PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                   34313 48.250   260/  768   0 (  0)  READY  3
   1 hpwork                        318  2.668  1324/ 2944 254 (254)  w:sem  3
   2 lpwork                          0  0.000   284/ 1576  50 ( 50)  w:sem  3
   3 nsh_main                        0  0.000  1548/ 2576 100 (100)  w:sem  3
   4 wq:manager                      0  0.000   452/ 1232 255 (255)  w:sem  3
   5 wq:lp_default                  39  0.358  1076/ 1896 205 (205)  READY  3
  62 wq:nav_and_controllers        596  5.135  1404/ 2216 242 (242)  w:sem  3
  38 wq:SPI1                      2056 17.531  1804/ 2368 253 (253)  w:sem  3
  55 wq:hp_default                  34  0.290  1872/ 1872 237 (237)  READY  3
  75 top                           292  2.526  3068/ 4056 237 (237)  RUN    3
  63 wq:rate_ctrl                  896  7.631  1404/ 3120 255 (255)  w:sem  3
  72 wq:INS0                       916  7.842  1244/ 5976 241 (241)  w:sem  3
  74 wq:uavcan                     642  5.486  2388/ 3600 236 (236)  READY  3

Processes: 13 total, 5 running, 8 sleeping
CPU usage: 49.47% tasks, 2.28% sched, 48.25% idle
Uptime: 64.611s total, 34.314s idle
nsh>
```

After increasing total stack. Does not hardfault. Low stack instance.
``` 
PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                     948 51.218   260/  768   0 (  0)  READY  3
   1 hpwork                          5  2.813  1324/ 2944 254 (254)  w:sem  3
   2 lpwork                          0  0.000   284/ 1576  50 ( 50)  w:sem  3
   3 nsh_main                        0  0.000  1540/ 2576 100 (100)  w:sem  3
   4 wq:manager                      0  0.000   628/ 1232 255 (255)  w:sem  3
   5 wq:lp_default                   0  0.324  1028/ 1896 205 (205)  READY  3
  75 top                             0  0.000  3068/ 4056 237 (237)  RUN    3
  38 wq:SPI1                        34 17.213  1892/ 2368 253 (253)  w:sem  3
  55 wq:hp_default                   0  0.310  1876/ 2368 237 (237)  READY  3
  62 wq:nav_and_controllers         10  5.091  1380/ 2216 242 (242)  w:sem  3
  63 wq:rate_ctrl                   15  7.600  1380/ 3120 255 (255)  w:sem  3
  72 wq:INS0                        15  7.522  1244/ 5976 241 (241)  w:sem  3
  74 wq:uavcan                      11  5.537  2388/ 3600 236 (236)  READY  3

Processes: 13 total, 5 running, 8 sleeping
CPU usage: 46.41% tasks, 2.37% sched, 51.22% idle
Uptime: 1.779s total, 0.949s idle
nsh>
```

After increasing total stack. Does not hardfault. High stack instance.
```nsh> top
 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
   0 Idle Task                    2346 48.122   260/  768   0 (  0)  READY  3
   1 hpwork                         91  2.725  1324/ 2944 254 (254)  w:sem  3
   2 lpwork                          0  0.000   284/ 1576  50 ( 50)  w:sem  3
   3 nsh_main                        0  0.000  1548/ 2576 100 (100)  w:sem  3
   4 wq:manager                      0  0.000   580/ 1232 255 (255)  w:sem  3
   5 wq:lp_default                  10  0.306  1076/ 1896 205 (205)  READY  3
  75 top                            79  2.537  3068/ 4056 237 (237)  RUN    3
  38 wq:SPI1                       586 17.516  1908/ 2368 253 (253)  w:sem  3
  55 wq:hp_default                   9  0.298  2068/ 2368 237 (237)  READY  3
  62 wq:nav_and_controllers        174  5.214  1404/ 2216 242 (242)  w:sem  3
  63 wq:rate_ctrl                  257  7.684  1412/ 3120 255 (255)  w:sem  3
  72 wq:INS0                       260  7.783  1244/ 5976 241 (241)  w:sem  3
  74 wq:uavcan                     187  5.576  2380/ 3600 236 (236)  READY  3

Processes: 13 total, 5 running, 8 sleeping
CPU usage: 49.64% tasks, 2.24% sched, 48.12% idle
Uptime: 4.714s total, 2.347s idle
nsh>```