### PR TITLE
Fix flow gyro bias corrections

### DIFF
--- a/msg/VehicleOpticalFlowVel.msg
+++ b/msg/VehicleOpticalFlowVel.msg
@@ -10,4 +10,6 @@ float32[2] flow_compensated_integral   # integrated optical flow measurement com
 float32[3] gyro_rate                   # gyro measurement synchronized with flow measurements (rad/s)
 float32[3] gyro_rate_integral          # gyro measurement integrated to flow rate and synchronized with flow measurements (rad)
 
+float32[3] gyro_bias
+
 # TOPICS estimator_optical_flow_vel vehicle_optical_flow_vel

--- a/msg/VehicleOpticalFlowVel.msg
+++ b/msg/VehicleOpticalFlowVel.msg
@@ -11,5 +11,7 @@ float32[3] gyro_rate                   # gyro measurement synchronized with flow
 float32[3] gyro_rate_integral          # gyro measurement integrated to flow rate and synchronized with flow measurements (rad)
 
 float32[3] gyro_bias
+float32[3] ref_gyro
+float32[3] meas_gyro
 
 # TOPICS estimator_optical_flow_vel vehicle_optical_flow_vel

--- a/src/drivers/uavcan/sensors/flow.cpp
+++ b/src/drivers/uavcan/sensors/flow.cpp
@@ -79,7 +79,7 @@ void UavcanFlowBridge::flow_sub_cb(const uavcan::ReceivedDataStructure<com::hex:
 	if (PX4_ISFINITE(msg.rate_gyro_integral[0]) && PX4_ISFINITE(msg.rate_gyro_integral[1])) {
 		flow.delta_angle[0] = msg.rate_gyro_integral[0];
 		flow.delta_angle[1] = msg.rate_gyro_integral[1];
-		flow.delta_angle[2] = 0.f;
+		flow.delta_angle[2] = NAN;
 		flow.delta_angle_available = true;
 
 	} else {

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -183,6 +183,7 @@ public:
 
 	const Vector3f getFlowGyro() const { return _flow_sample_delayed.gyro_xyz * (1.f / _flow_sample_delayed.dt); }
 	const Vector3f &getFlowGyroIntegral() const { return _flow_sample_delayed.gyro_xyz; }
+	const Vector3f &getFlowGyroBias() const { return _flow_gyro_bias; }
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 #if defined(CONFIG_EKF2_AUXVEL)

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -184,6 +184,8 @@ public:
 	const Vector3f getFlowGyro() const { return _flow_sample_delayed.gyro_xyz * (1.f / _flow_sample_delayed.dt); }
 	const Vector3f &getFlowGyroIntegral() const { return _flow_sample_delayed.gyro_xyz; }
 	const Vector3f &getFlowGyroBias() const { return _flow_gyro_bias; }
+	const Vector3f &getRefBodyRate() const { return _ref_body_rate; }
+	const Vector3f &getMeasuredBodyRate() const { return _measured_body_rate; }
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 #if defined(CONFIG_EKF2_AUXVEL)
@@ -660,6 +662,8 @@ private:
 	Vector2f _flow_vel_body{};	///< velocity from corrected flow measurement (body frame)(m/s)
 	Vector2f _flow_vel_ne{};		///< velocity from corrected flow measurement (local frame) (m/s)
 	Vector3f _imu_del_ang_of{};	///< bias corrected delta angle measurements accumulated across the same time frame as the optical flow rates (rad)
+	Vector3f _ref_body_rate{};
+	Vector3f _measured_body_rate{};
 
 	float _delta_time_of{0.0f};	///< time in sec that _imu_del_ang_of was accumulated over (sec)
 	uint64_t _time_bad_motion_us{0};	///< last system time that on-ground motion exceeded limits (uSec)

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -203,39 +203,29 @@ Vector2f Ekf::predictFlowVelBody()
 bool Ekf::calcOptFlowBodyRateComp()
 {
 	bool is_body_rate_comp_available = false;
-	const bool use_flow_sensor_gyro = _flow_sample_delayed.gyro_xyz.isAllFinite();
 
-	if (use_flow_sensor_gyro) {
+	if ((_delta_time_of > FLT_EPSILON)
+	    && (_flow_sample_delayed.dt > FLT_EPSILON)) {
+		const Vector3f reference_body_rate = -_imu_del_ang_of / _delta_time_of; // flow gyro has opposite sign convention
+		_ref_body_rate = reference_body_rate;
 
-		// if accumulation time differences are not excessive and accumulation time is adequate
-		// compare the optical flow and and navigation rate data and calculate a bias error
-		if ((_delta_time_of > FLT_EPSILON)
-		    && (_flow_sample_delayed.dt > FLT_EPSILON)
-		    && (fabsf(_delta_time_of - _flow_sample_delayed.dt) < 0.1f)) {
+		if (!PX4_ISFINITE(_flow_sample_delayed.gyro_xyz(0)) || !PX4_ISFINITE(_flow_sample_delayed.gyro_xyz(1))) {
+			_flow_sample_delayed.gyro_xyz = reference_body_rate * _flow_sample_delayed.dt;
 
-			const Vector3f reference_body_rate(-_imu_del_ang_of * (1.0f / _delta_time_of)); // flow gyro has opposite sign convention
-			_ref_body_rate = reference_body_rate;
+		} else if (!PX4_ISFINITE(_flow_sample_delayed.gyro_xyz(2))) {
+			// Some flow modules only provide X ind Y angular rates. If this is the case, complete the vector with our own Z gyro
+			_flow_sample_delayed.gyro_xyz(2) = reference_body_rate(2) * _flow_sample_delayed.dt;
+		}
 
-			const Vector3f measured_body_rate(_flow_sample_delayed.gyro_xyz * (1.0f / _flow_sample_delayed.dt));
-			_measured_body_rate = measured_body_rate;
+		const Vector3f measured_body_rate = _flow_sample_delayed.gyro_xyz / _flow_sample_delayed.dt;
+		_measured_body_rate = measured_body_rate;
 
+		if (fabsf(_delta_time_of - _flow_sample_delayed.dt) < 0.1f) {
 			// calculate the bias estimate using  a combined LPF and spike filter
 			_flow_gyro_bias = _flow_gyro_bias * 0.99f + matrix::constrain(measured_body_rate - reference_body_rate, -0.1f, 0.1f) * 0.01f;
 		}
 
 		is_body_rate_comp_available = true;
-
-	} else {
-		// Use the EKF gyro data if optical flow sensor gyro data is not available
-		// for clarification of the sign see definition of flowSample and imuSample in common.h
-		if ((_delta_time_of > FLT_EPSILON)
-		    && (_flow_sample_delayed.dt > FLT_EPSILON)) {
-
-			_flow_sample_delayed.gyro_xyz = -_imu_del_ang_of / _delta_time_of * _flow_sample_delayed.dt;
-			_flow_gyro_bias.zero();
-
-			is_body_rate_comp_available = true;
-		}
 	}
 
 	// reset the accumulators

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -219,12 +219,12 @@ bool Ekf::calcOptFlowBodyRateComp()
 
 			// calculate the bias estimate using  a combined LPF and spike filter
 			_flow_gyro_bias = _flow_gyro_bias * 0.99f + matrix::constrain(measured_body_rate - reference_body_rate, -0.1f, 0.1f) * 0.01f;
-
-			// apply gyro bias
-			_flow_sample_delayed.gyro_xyz -= (_flow_gyro_bias * _flow_sample_delayed.dt);
-
-			is_body_rate_comp_available = true;
 		}
+
+		// apply gyro bias
+		_flow_sample_delayed.gyro_xyz -= (_flow_gyro_bias * _flow_sample_delayed.dt);
+
+		is_body_rate_comp_available = true;
 
 	} else {
 		// Use the EKF gyro data if optical flow sensor gyro data is not available

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -214,8 +214,10 @@ bool Ekf::calcOptFlowBodyRateComp()
 		    && (fabsf(_delta_time_of - _flow_sample_delayed.dt) < 0.1f)) {
 
 			const Vector3f reference_body_rate(-_imu_del_ang_of * (1.0f / _delta_time_of)); // flow gyro has opposite sign convention
+			_ref_body_rate = reference_body_rate;
 
 			const Vector3f measured_body_rate(_flow_sample_delayed.gyro_xyz * (1.0f / _flow_sample_delayed.dt));
+			_measured_body_rate = measured_body_rate;
 
 			// calculate the bias estimate using  a combined LPF and spike filter
 			_flow_gyro_bias = _flow_gyro_bias * 0.99f + matrix::constrain(measured_body_rate - reference_body_rate, -0.1f, 0.1f) * 0.01f;

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -213,7 +213,7 @@ bool Ekf::calcOptFlowBodyRateComp()
 		    && (_flow_sample_delayed.dt > FLT_EPSILON)
 		    && (fabsf(_delta_time_of - _flow_sample_delayed.dt) < 0.1f)) {
 
-			const Vector3f reference_body_rate(_imu_del_ang_of * (1.0f / _delta_time_of));
+			const Vector3f reference_body_rate(-_imu_del_ang_of * (1.0f / _delta_time_of)); // flow gyro has opposite sign convention
 
 			const Vector3f measured_body_rate(_flow_sample_delayed.gyro_xyz * (1.0f / _flow_sample_delayed.dt));
 

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -188,7 +188,7 @@ Vector2f Ekf::predictFlowVelBody()
 
 	// calculate the velocity of the sensor relative to the imu in body frame
 	// Note: _flow_sample_delayed.gyro_xyz is the negative of the body angular velocity, thus use minus sign
-	const Vector3f vel_rel_imu_body = Vector3f(-_flow_sample_delayed.gyro_xyz / _flow_sample_delayed.dt) % pos_offset_body;
+	const Vector3f vel_rel_imu_body = Vector3f(-(_flow_sample_delayed.gyro_xyz / _flow_sample_delayed.dt - _flow_gyro_bias)) % pos_offset_body;
 
 	// calculate the velocity of the sensor in the earth frame
 	const Vector3f vel_rel_earth = _state.vel + _R_to_earth * vel_rel_imu_body;
@@ -220,9 +220,6 @@ bool Ekf::calcOptFlowBodyRateComp()
 			// calculate the bias estimate using  a combined LPF and spike filter
 			_flow_gyro_bias = _flow_gyro_bias * 0.99f + matrix::constrain(measured_body_rate - reference_body_rate, -0.1f, 0.1f) * 0.01f;
 		}
-
-		// apply gyro bias
-		_flow_sample_delayed.gyro_xyz -= (_flow_gyro_bias * _flow_sample_delayed.dt);
 
 		is_body_rate_comp_available = true;
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2002,6 +2002,8 @@ void EKF2::PublishOpticalFlowVel(const hrt_abstime &timestamp)
 		_ekf.getFlowGyroIntegral().copyTo(flow_vel.gyro_rate_integral);
 
 		_ekf.getFlowGyroBias().copyTo(flow_vel.gyro_bias);
+		_ekf.getRefBodyRate().copyTo(flow_vel.ref_gyro);
+		_ekf.getMeasuredBodyRate().copyTo(flow_vel.meas_gyro);
 
 		flow_vel.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2001,6 +2001,8 @@ void EKF2::PublishOpticalFlowVel(const hrt_abstime &timestamp)
 		_ekf.getFlowGyro().copyTo(flow_vel.gyro_rate);
 		_ekf.getFlowGyroIntegral().copyTo(flow_vel.gyro_rate_integral);
 
+		_ekf.getFlowGyroBias().copyTo(flow_vel.gyro_bias);
+
 		flow_vel.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
 
 		_estimator_optical_flow_vel_pub.publish(flow_vel);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Position oscillations with ArkFlow

### Solution
- fix sign in flow gyro bias estimation
- avoid possibility to remove gyro bias multiple times
- add Z gyro in flow gyro data to compensate for apparent flow while doing yaw rotations (when the sensor has an X or Y offset)

### Changelog Entry
For release notes:
```
Improve estimation performance when using ArkFlow
```