### PR TITLE
battery: show unknown cell count

### DIFF
--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -86,6 +86,7 @@ parameters:
 
             type: enum
             values:
+                0: Unknown
                 1: 1S Battery
                 2: 2S Battery
                 3: 3S Battery


### PR DESCRIPTION
### Solved Problem
When switching back and forth between power modules on I2C1 and 2 resulting in using different driver instances that publish as batteries 1 or 2 I found that it's not possible with the current parameter metadata to restore the unknown cell count which the configuration starts with. I think we should not hide this since it can life in a corner case unnecessary complicated.

### Solution
Add metadata for the default value such that it shows up in the drop down.

### Changelog Entry
For release notes:
```
Bugfix: allow choosing unknown battery cell count from the dropdown
```

### Test coverage
Tested in simulation to work as expected:
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/df3cace4-0614-4b63-95de-ef51d5beeea5)