### PR TITLE
Fix Helicopter saturation logic

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -229,6 +229,9 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.roll_neg) {
 		status.unallocated_torque[0] = -1.f;
+
+	} else {
+		status.unallocated_torque[0] = 0.f;
 	}
 
 	if (_saturation_flags.pitch_pos) {
@@ -236,6 +239,9 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.pitch_neg) {
 		status.unallocated_torque[1] = -1.f;
+
+	} else {
+		status.unallocated_torque[1] = 0.f;
 	}
 
 	if (_saturation_flags.yaw_pos) {
@@ -243,6 +249,9 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.yaw_neg) {
 		status.unallocated_torque[2] = -1.f;
+
+	} else {
+		status.unallocated_torque[2] = 0.f;
 	}
 
 	if (_saturation_flags.thrust_pos) {
@@ -250,5 +259,8 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.thrust_neg) {
 		status.unallocated_thrust[2] = -1.f;
+
+	} else {
+		status.unallocated_thrust[2] = 0.f;
 	}
 }


### PR DESCRIPTION
This became necessary otherwise
the allocation reports saturation all
the time and the rate integrator doesn't work.

### Solved Problem
When using a helicopter on the latest version I found that the integrator doesn't have any effect. The issue seems to be the same as was fixed for tiltrotors in https://github.com/PX4/PX4-Autopilot/pull/21994 I'm looking for the original change that made this necessary.

### Solution
Handle the unsaturated case explicitly and report 0 unallocated torque in that case.

### Changelog Entry
For release notes:
```
Bugfix: Helicopter saturation logic leads to rate control integrator not working
```

### Test coverage
After this change it was working like expected again, tested on a real helicopter.

### Context
Before
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/ffc75af5-a05f-4461-af86-9691283df33a)
After
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/05f94b55-93ca-4bc9-82b9-f6e8e11316d5)
