### PR TITLE
Removal of i2c software reset for specific i2c device functionality

### DIFF
--- a/platforms/nuttx/src/px4/common/px4_init.cpp
+++ b/platforms/nuttx/src/px4/common/px4_init.cpp
@@ -144,20 +144,6 @@ int px4_platform_init()
 #if defined(CONFIG_I2C_RESET)
 		I2C_RESET(i2c_dev);
 #endif // CONFIG_I2C_RESET
-
-		// send software reset to all
-		uint8_t buf[1] {};
-		buf[0] = 0x06; // software reset
-
-		i2c_msg_s msg{};
-		msg.frequency = I2C_SPEED_STANDARD;
-		msg.addr = 0x00; // general call address
-		msg.buffer = &buf[0];
-		msg.length = 1;
-
-		I2C_TRANSFER(i2c_dev, &msg, 1);
-
-		px4_i2cbus_uninitialize(i2c_dev);
 	}
 
 #endif // CONFIG_I2C


### PR DESCRIPTION
The lightware LW20/C and SF30/d require the i2c reset here to be removed for it to work properly. If you plug in the commonly used MS4525do airspeed without this PR the entire i2c bus stops responding. This fixes it. Been flown without issue since early June.

The LW20/c just doesnt handle the reset command and won't work so this is needed for that as well (see here https://github.com/PX4/PX4-Autopilot/pull/20809#issuecomment-1577984639)

This should be in 1.14.