### PR TITLE
fix crsf_rc: prevent potential buffer overflow for unknown packets

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfParser.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfParser.cpp
@@ -293,9 +293,9 @@ bool CrsfParser_TryParseCrsfPacket(CrsfPacket_t *const new_packet, CrsfParserSta
 			} else {
 				// We don't know what this packet is, so we'll let the parser continue
 				// just so that we can dequeue it in one shot
-				working_segment_size = packet_size + PACKET_SIZE_TYPE_SIZE;
+				working_segment_size = packet_size - PACKET_SIZE_TYPE_SIZE;
 
-				if (working_segment_size > CRSF_MAX_PACKET_LEN) {
+				if (working_index + working_segment_size + CRC_SIZE > CRSF_MAX_PACKET_LEN) {
 					parser_statistics->invalid_unknown_packet_sizes++;
 					parser_state = PARSER_STATE_HEADER;
 					working_segment_size = HEADER_SIZE;


### PR DESCRIPTION
The length check for unknown packets did not include PACKET_SIZE_TYPE_SIZE and CRC_SIZE, and hence working_index could overflow CRSF_MAX_PACKET_LEN, triggering invalid memory access further down in QueueBuffer_PeekBuffer.

Also the working_segment_size was wrong for unknown packets.

Credits for finding this go to @Pwn9uin.

I did not test this, as I currrently don't have hw.