### PR TITLE
EKF2: remove sparse vector optimization

### DIFF
--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -63,9 +63,6 @@ public:
 	typedef matrix::Vector<float, State::size> VectorState;
 	typedef matrix::SquareMatrix<float, State::size> SquareMatrixState;
 	typedef matrix::SquareMatrix<float, 2> Matrix2f;
-	template<int ... Idxs>
-
-	using SparseVectorState = matrix::SparseVectorf<State::size, Idxs...>;
 
 	Ekf()
 	{

--- a/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
+++ b/src/modules/ekf2/EKF/gps_yaw_fusion.cpp
@@ -100,8 +100,6 @@ void Ekf::fuseGpsYaw()
 	sym::ComputeGnssYawPredInnovVarAndH(getStateAtFusionHorizonAsVector(), P, _gps_yaw_offset, gnss_yaw.observation_variance, FLT_EPSILON, &heading_pred, &heading_innov_var, &H);
 	}
 
-	const SparseVectorState<0,1,2,3> Hfusion(H);
-
 	// check if the innovation variance calculation is badly conditioned
 	if (gnss_yaw.innovation_variance < gnss_yaw.observation_variance) {
 		// the innovation variance contribution from the state covariances is negative which means the covariance matrix is badly conditioned
@@ -129,7 +127,7 @@ void Ekf::fuseGpsYaw()
 
 	// calculate the Kalman gains
 	// only calculate gains for states we are using
-	VectorState Kfusion = P * Hfusion / gnss_yaw.innovation_variance;
+	VectorState Kfusion = P * H / gnss_yaw.innovation_variance;
 
 	const bool is_fused = measurementUpdate(Kfusion, gnss_yaw.innovation_variance, gnss_yaw.innovation);
 	_fault_status.flags.bad_hdg = !is_fused;

--- a/src/modules/ekf2/EKF/optflow_fusion.cpp
+++ b/src/modules/ekf2/EKF/optflow_fusion.cpp
@@ -146,8 +146,7 @@ void Ekf::fuseOptFlow()
 			}
 		}
 
-		SparseVectorState<0,1,2,3,4,5,6> Hfusion(H);
-		VectorState Kfusion = P * Hfusion / _aid_src_optical_flow.innovation_variance[index];
+		VectorState Kfusion = P * H / _aid_src_optical_flow.innovation_variance[index];
 
 		if (measurementUpdate(Kfusion, _aid_src_optical_flow.innovation_variance[index], _aid_src_optical_flow.innovation[index])) {
 			fused[index] = true;


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The sparse vector template requires to know which states are non-zero in the observation jacobian. This complicates the modularity of the code when the state vector or the derivation is changed. The risk of forgetting to update the list of non-zero states is also high and since it's only used for a couple of matrix-vector multiplications, the reduced CPU load is very minimal (on fmu-v5, removing the optimization on the mag 3D fusion doesn't show any change in CPU usage).

### Solution
Use dense vectors. The computation cost difference is almost negligible for this size.

### Changelog Entry
For release notes:
```
-
New parameter: -
Documentation: -
```

### Alternatives
I tried to directly compute the Kalman gain in the SymForce derivation. This could make the code faster but increases flash space. Since we're short on flash space but not on CPU usage, this option was rejected.

### Test coverage
Unit tests
