### PR TITLE
mission_base: if FW and Takeoff do not enter climb before mission start

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_gazebo-classic_advanced_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_gazebo-classic_advanced_plane
@@ -8,7 +8,6 @@
 
 
 param set-default FW_LND_ANG 8
-param set-default FW_THR_LND_MAX 0
 
 param set-default NPFG_PERIOD 12
 
@@ -36,7 +35,6 @@ param set-default NAV_DLL_ACT 2
 
 param set-default RWTO_TKOFF 1
 
-#param set-default SYS_CTRL_ALLOC 1
 param set-default CA_AIRFRAME 1
 
 param set-default CA_ROTOR_COUNT 1
@@ -61,7 +59,3 @@ param set-default PWM_MAIN_FUNC7 202
 param set-default PWM_MAIN_FUNC8 203
 param set-default PWM_MAIN_FUNC9 206
 param set-default PWM_MAIN_REV 256
-
-
-set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
-set MIXER custom

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1213,7 +1213,11 @@ void MissionBase::checkClimbRequired(int32_t mission_item_index)
 		const bool success = _dataman_cache.loadWait(dataman_id, next_mission_item_index, reinterpret_cast<uint8_t *>(&mission),
 				     sizeof(mission), MAX_DATAMAN_LOAD_WAIT);
 
-		if (success) {
+		const bool is_fw_and_takeoff = mission.nav_cmd == NAV_CMD_TAKEOFF
+					       && _vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING;
+
+		// for FW when on a Takeoff item do not require climb before mission, as we need to keep course to takeoff item straight
+		if (success && !is_fw_and_takeoff) {
 			const float altitude_amsl_next_position_item = MissionBlock::get_absolute_altitude_for_item(mission);
 			const float error_below_setpoint = altitude_amsl_next_position_item -
 							   _navigator->get_global_position()->alt;


### PR DESCRIPTION
### Solved Problem
Fixes issue raised [here](https://discord.com/channels/1022170275984457759/1022186266957201480/1156841185160204329) about weird FW takeoff path. 

### Solution
Issue was introduced with https://github.com/PX4/PX4-Autopilot/pull/20908. There was a missing customization for FW, where we don't want to do the same as for MC/VTOLs in hover when starting a mission (go directly to first WP and not first climb to altitude).

I also removed some outdated config in the advanced_plane config. 

### Changelog Entry
For release notes:
```
Bugfix: FW Mission start with Takeoff item: by-pass climbing-first logic and go straight to the Takeoff item.
```

