### PR TITLE
ROMFS: rcS: check for updated ext_autostart and rename if existing

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -93,6 +93,16 @@ then
 		fi
 	fi
 
+	# Check for an update of the ext_autostart folder, and rename it if found
+	if [ -e /fs/microsd/ext_autostart_new ]
+	then
+		echo "Updating external autostart files"
+		# FIXME: add NuttX support for recursive rm, then we can remove the
+		# directory (for now this is done during updating via MAVLink FTP)
+		# rm -r $SDCARD_EXT_PATH
+		mv /fs/microsd/ext_autostart_new $SDCARD_EXT_PATH
+	fi
+
 	set PARAM_FILE /fs/microsd/params
 	set PARAM_BACKUP_FILE "/fs/microsd/parameters_backup.bson"
 fi


### PR DESCRIPTION
This allows to inject an updated ext_autostart folder with the name `ext_autostart_new`, and then PX4 takes care of renaming it to `ext_autostart` during bootup. Usually the injection is done from a companion computer. 


