### PR TITLE
navigator: cleanups

### DIFF
--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -86,15 +86,6 @@
 
 using namespace time_literals;
 
-/**
- * Number of navigation modes that need on_active/on_inactive calls
- */
-#if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-#define NAVIGATOR_MODE_ARRAY_SIZE 7
-#else
-#define NAVIGATOR_MODE_ARRAY_SIZE 6
-#endif
-
 class Navigator : public ModuleBase<Navigator>, public ModuleParams
 {
 public:
@@ -356,7 +347,11 @@ private:
 	AdsbConflict 	_adsb_conflict;			/**< class that handles ADSB conflict avoidance */
 
 	NavigatorMode *_navigation_mode{nullptr};	/**< abstract pointer to current navigation mode class */
-	NavigatorMode *_navigation_mode_array[NAVIGATOR_MODE_ARRAY_SIZE] {};	/**< array of navigation modes */
+#if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
+	NavigatorMode *const _navigation_mode_array[7] {&_mission, &_loiter, &_rtl, &_takeoff, &_land, &_precland, &_vtol_takeoff}; //	/**< array of navigation modes */
+#else
+	NavigatorMode *const _navigation_mode_array[6] {&_mission, &_loiter, &_rtl, &_takeoff, &_land, &_precland}; //	/**< array of navigation modes */
+#endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
 
 	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
 	param_t _handle_mpc_jerk_auto{PARAM_INVALID};

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -89,7 +89,11 @@ using namespace time_literals;
 /**
  * Number of navigation modes that need on_active/on_inactive calls
  */
-#define NAVIGATOR_MODE_ARRAY_SIZE 8
+#if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
+#define NAVIGATOR_MODE_ARRAY_SIZE 7
+#else
+#define NAVIGATOR_MODE_ARRAY_SIZE 6
+#endif
 
 class Navigator : public ModuleBase<Navigator>, public ModuleParams
 {
@@ -331,8 +335,8 @@ private:
 
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
-	Geofence	_geofence;			/**< class that handles the geofence */
-	GeofenceBreachAvoidance _gf_breach_avoidance;
+	Geofence	_geofence{this};			/**< class that handles the geofence */
+	GeofenceBreachAvoidance _gf_breach_avoidance{this};
 	hrt_abstime _last_geofence_check = 0;
 
 	bool		_geofence_violation_warning_sent{false};	/**< prevents spaming to mavlink */
@@ -340,15 +344,15 @@ private:
 	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
 	bool		_mission_result_updated{false};			/**< flags if mission result has seen an update */
 
-	Mission		_mission;			/**< class that handles the missions */
-	Loiter		_loiter;			/**< class that handles loiter */
-	Takeoff		_takeoff;			/**< class for handling takeoff commands */
+	Mission		_mission{this};			/**< class that handles the missions */
+	Loiter		_loiter{this};			/**< class that handles loiter */
+	Takeoff		_takeoff{this};			/**< class for handling takeoff commands */
 #if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-	VtolTakeoff	_vtol_takeoff;			/**< class for handling VEHICLE_CMD_NAV_VTOL_TAKEOFF command */
+	VtolTakeoff	_vtol_takeoff {this};	/**< class for handling VEHICLE_CMD_NAV_VTOL_TAKEOFF command */
 #endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-	Land		_land;			/**< class for handling land commands */
-	PrecLand	_precland;			/**< class for handling precision land commands */
-	RTL 		_rtl;				/**< class that handles RTL */
+	Land		_land {this};			/**< class for handling land commands */
+	PrecLand	_precland{this};		/**< class for handling precision land commands */
+	RTL 		_rtl{this};				/**< class that handles RTL */
 	AdsbConflict 	_adsb_conflict;			/**< class that handles ADSB conflict avoidance */
 
 	NavigatorMode *_navigation_mode{nullptr};	/**< abstract pointer to current navigation mode class */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -69,18 +69,7 @@ Navigator *g_navigator;
 
 Navigator::Navigator() :
 	ModuleParams(nullptr),
-	_loop_perf(perf_alloc(PC_ELAPSED, "navigator")),
-	_geofence(this),
-	_gf_breach_avoidance(this),
-	_mission(this),
-	_loiter(this),
-	_takeoff(this),
-#if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-	_vtol_takeoff(this),
-#endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-	_land(this),
-	_precland(this),
-	_rtl(this)
+	_loop_perf(perf_alloc(PC_ELAPSED, "navigator"))
 {
 	/* Create a list of our possible navigation types */
 	_navigation_mode_array[0] = &_mission;
@@ -94,10 +83,8 @@ Navigator::Navigator() :
 #endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
 
 	/* iterate through navigation modes and initialize _mission_item for each */
-	for (unsigned int i = 0; i < NAVIGATOR_MODE_ARRAY_SIZE; i++) {
-		if (_navigation_mode_array[i]) {
-			_navigation_mode_array[i]->initialize();
-		}
+	for (auto &navigation_mode_array_item : _navigation_mode_array) {
+		navigation_mode_array_item->initialize();
 	}
 
 	_handle_back_trans_dec_mss = param_find("VT_B_DEC_MSS");
@@ -811,10 +798,8 @@ void Navigator::run()
 		_navigation_mode = navigation_mode_new;
 
 		/* iterate through navigation modes and set active/inactive for each */
-		for (unsigned int i = 0; i < NAVIGATOR_MODE_ARRAY_SIZE; i++) {
-			if (_navigation_mode_array[i]) {
-				_navigation_mode_array[i]->run(_navigation_mode == _navigation_mode_array[i]);
-			}
+		for (auto &navigation_mode_array_item : _navigation_mode_array) {
+			navigation_mode_array_item->run(_navigation_mode == navigation_mode_array_item);
 		}
 
 		/* if nothing is running, set position setpoint triplet invalid once */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -71,17 +71,6 @@ Navigator::Navigator() :
 	ModuleParams(nullptr),
 	_loop_perf(perf_alloc(PC_ELAPSED, "navigator"))
 {
-	/* Create a list of our possible navigation types */
-	_navigation_mode_array[0] = &_mission;
-	_navigation_mode_array[1] = &_loiter;
-	_navigation_mode_array[2] = &_rtl;
-	_navigation_mode_array[3] = &_takeoff;
-	_navigation_mode_array[4] = &_land;
-	_navigation_mode_array[5] = &_precland;
-#if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-	_navigation_mode_array[6] = &_vtol_takeoff;
-#endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-
 	/* iterate through navigation modes and initialize _mission_item for each */
 	for (auto &navigation_mode_array_item : _navigation_mode_array) {
 		navigation_mode_array_item->initialize();


### PR DESCRIPTION
- save some memory by reduce the navigation mode array size
- iterate by using auto

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I found that NAVIGATOR_MODE_ARRAY_SIZE defined as 8, while it has only 7 (or 6 items if no vtol) .
on the way, I done more clean ups:
- moved the initialization to the member declaration. Do you see problem with that? (it init to '_this_')
- moved iterations to &auto

it also seems that checking that item on the list is not null is non-necessary.  