### PR TITLE
batteryCheck: add new battery threshold for arming (COM_ARM_BAT_MIN) 

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.cpp
@@ -195,6 +195,7 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 	}
 
 	if (context.isArmed()) {
+		// if armed, only allow increase of battery warning severity
 		if (worst_warning > reporter.failsafeFlags().battery_warning) {
 			reporter.failsafeFlags().battery_warning = worst_warning;
 		}
@@ -205,16 +206,23 @@ void BatteryChecks::checkAndReport(const Context &context, Report &reporter)
 
 	if (reporter.failsafeFlags().battery_warning > battery_status_s::BATTERY_WARNING_NONE
 	    && reporter.failsafeFlags().battery_warning < battery_status_s::BATTERY_WARNING_FAILED) {
-		bool critical_or_higher = reporter.failsafeFlags().battery_warning >= battery_status_s::BATTERY_WARNING_CRITICAL;
+		const bool critical_or_higher = reporter.failsafeFlags().battery_warning >= battery_status_s::BATTERY_WARNING_CRITICAL;
 		NavModes affected_modes = critical_or_higher ? NavModes::All : NavModes::None;
 		events::LogLevel log_level = critical_or_higher ? events::Log::Critical : events::Log::Warning;
 		/* EVENT
+		 * @description
+		 * The battery state of charge of the worst battery is below the warning threshold.
+		 *
+		 * <profile name="dev">
+		 * This check can be configured via <param>BAT_LOW_THR</param>, <param>BAT_CRIT_THR</param> and <param>BAT_EMERGEN_THR</param> parameters.
+		 * </profile>
 		 */
 		reporter.armingCheckFailure(affected_modes, health_component_t::battery, events::ID("check_battery_low"), log_level,
 					    "Low battery");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_emergency(reporter.mavlink_log_pub(), "Preflight Fail: low battery\t");
+			mavlink_log_emergency(reporter.mavlink_log_pub(), "Low battery level\t");
+		}
 		}
 
 	}

--- a/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/batteryCheck.hpp
@@ -56,4 +56,7 @@ private:
 	bool _last_armed{false};
 	bool _battery_connected_at_arming[battery_status_s::MAX_INSTANCES] {};
 
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamFloat<px4::params::COM_ARM_BAT_MIN>) _param_arm_battery_level_min
+				       )
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1097,3 +1097,20 @@ PARAM_DEFINE_FLOAT(COM_POS_LOW_EPH, -1.0f);
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_ARMABLE, 1);
+
+/**
+ * Minimum battery level for arming
+ *
+ * Additional battery level check that only allows arming if the state of charge of the emptiest
+ *  connected battery is above this value.
+ *
+ * A value of 0 disables the check.
+ *
+ * @unit norm
+ * @min 0
+ * @max 0.9
+ * @decimal 2
+ * @increment 0.01
+ * @group Commander
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_BAT_MIN, 0.f);


### PR DESCRIPTION


### Solved Problem
Currently the battery checks make sure that arming is not possible when the SOC is below the warning threshold (BAT_LOW_THR). BAT_LOW_THR is though in the first place thought to be the in-flight battery level warning. For systems that require a lot of energy during takeoff (eg VTOLs) it is beneficial to have a separate, higher threshold to prevent arming.

### Solution
Add new battery threshold for arming (new parameter COM_ARM_BAT_MIN).

### Changelog Entry
For release notes:
```
Feature: add additional battery level preflight check.
New parameter: COM_ARM_BAT_MIN
```

