### PR TITLE
Disable I2C interface in ICM42688P sensor when it is initialized

### DIFF
--- a/boards/modalai/voxl2-slpi/src/drivers/icm42688p/InvenSense_ICM42688P_registers.hpp
+++ b/boards/modalai/voxl2-slpi/src/drivers/icm42688p/InvenSense_ICM42688P_registers.hpp
@@ -133,6 +133,15 @@ enum INT_CONFIG_BIT : uint8_t {
 	INT1_POLARITY       = Bit0,
 };
 
+// INTF_CONFIG0
+enum INTF_CONFIG0_BIT : uint8_t {
+	FIFO_HOLD_LAST_DATA_EN  = Bit7,
+	FIFO_COUNT_REC          = Bit6,
+	FIFO_COUNT_ENDIAN       = Bit5,
+	SENSOR_DATA_ENDIAN      = Bit4,
+	UI_SIFS_CFG_DISABLE_I2C = Bit1 | Bit0,
+};
+
 // FIFO_CONFIG
 enum FIFO_CONFIG_BIT : uint8_t {
 	// 7:6 FIFO_MODE

--- a/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
+++ b/src/drivers/imu/invensense/icm42688p/ICM42688P.hpp
@@ -179,11 +179,12 @@ private:
 	int32_t _fifo_gyro_samples{static_cast<int32_t>(_fifo_empty_interval_us / (1000000 / GYRO_RATE))};
 
 	uint8_t _checked_register_bank0{0};
-	static constexpr uint8_t size_register_bank0_cfg{16};
+	static constexpr uint8_t size_register_bank0_cfg{17};
 	register_bank0_config_t _register_bank0_cfg[size_register_bank0_cfg] {
 		// Register                              | Set bits, Clear bits
 		{ Register::BANK_0::INT_CONFIG,           INT_CONFIG_BIT::INT1_MODE | INT_CONFIG_BIT::INT1_DRIVE_CIRCUIT, INT_CONFIG_BIT::INT1_POLARITY },
 		{ Register::BANK_0::FIFO_CONFIG,          FIFO_CONFIG_BIT::FIFO_MODE_STOP_ON_FULL, 0 },
+		{ Register::BANK_0::INTF_CONFIG0,         INTF_CONFIG0_BIT::FIFO_COUNT_ENDIAN | INTF_CONFIG0_BIT::SENSOR_DATA_ENDIAN | INTF_CONFIG0_BIT::UI_SIFS_CFG_DISABLE_I2C, 0},
 		{ Register::BANK_0::INTF_CONFIG1,         0, 0}, // RTC_MODE[2] set at runtime
 		{ Register::BANK_0::PWR_MGMT0,            PWR_MGMT0_BIT::GYRO_MODE_LOW_NOISE | PWR_MGMT0_BIT::ACCEL_MODE_LOW_NOISE, 0 },
 		{ Register::BANK_0::GYRO_CONFIG0,         GYRO_CONFIG0_BIT::GYRO_FS_SEL_2000_DPS | GYRO_CONFIG0_BIT::GYRO_ODR_8KHZ_SET, GYRO_CONFIG0_BIT::GYRO_ODR_8KHZ_CLEAR },

--- a/src/drivers/imu/invensense/icm42688p/InvenSense_ICM42688P_registers.hpp
+++ b/src/drivers/imu/invensense/icm42688p/InvenSense_ICM42688P_registers.hpp
@@ -159,6 +159,16 @@ enum SIGNAL_PATH_RESET_BIT : uint8_t {
 	FIFO_FLUSH      = Bit1,
 };
 
+// INTF_CONFIG0
+enum INTF_CONFIG0_BIT : uint8_t {
+	FIFO_HOLD_LAST_DATA_EN  = Bit7,
+	FIFO_COUNT_REC          = Bit6,
+	FIFO_COUNT_ENDIAN       = Bit5,
+	SENSOR_DATA_ENDIAN      = Bit4,
+	UI_SIFS_CFG_DISABLE_I2C = Bit1 | Bit0,
+};
+
+// INTF_CONFIG1
 enum INTF_CONFIG1_BIT : uint8_t {
 	RTC_MODE = Bit2, // 0: No input RTC clock is required, 1: RTC clock input is required
 	CLKSEL = Bit0,


### PR DESCRIPTION
This prevents accidental misconfiguration via I2C if there are multiple SPI devices on the same bus. The device may hear it's i2c address and write some register, while there is data transfer ongoing with another device.
