### PR TITLE
Battery: Enable parameters to dynamically change

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -113,6 +113,14 @@ void Battery::updateCurrent(const float current_a)
 
 void Battery::updateBatteryStatus(const hrt_abstime &timestamp)
 {
+	if (_parameter_update_sub.updated()) {
+		// Read from topic to clear updated flag
+		parameter_update_s parameter_update;
+		_parameter_update_sub.copy(&parameter_update);
+
+		updateParams();
+	}
+
 	if (!_battery_initialized) {
 		_voltage_filter_v.reset(_voltage_v);
 		_current_filter_a.reset(_current_a);

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -58,6 +58,10 @@
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/parameter_update.h>
+
+using namespace time_literals;
 
 /**
  * BatteryBase is a base class for any type of battery.
@@ -156,6 +160,7 @@ private:
 	uORB::Subscription _vehicle_thrust_setpoint_0_sub{ORB_ID(vehicle_thrust_setpoint)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	bool _external_state_of_charge{false}; ///< inticates that the soc is injected and not updated by this library
 

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -73,7 +73,7 @@ parameters:
             max: 0.2
             decimal: 4
             increment: 0.0005
-            reboot_required: true
+            reboot_required: false
             num_instances: *max_num_config_instances
             instance_start: 1
             default: [0.005, 0.005]
@@ -119,7 +119,7 @@ parameters:
             max: 100000
             decimal: 0
             increment: 50
-            reboot_required: true
+            reboot_required: false
             num_instances: *max_num_config_instances
             instance_start: 1
             default: [-1.0, -1.0]


### PR DESCRIPTION
### Solved Problem
Some setups have auxiliary batteries that are connected to the system in parallel when the system is already powered.
A system e.g. running on the companion can monitor for auxiliary batteries and adjust the battery parameter for capacity and internal resistance accordingly. However, PX4 currently does not update the battery paramaters and so a reboot is required which is not a nice user experience.


### Changelog Entry
Allow battery parameters to update, specifically 
BAT{X}_CAPACITY and BAT{X}_R_INTERNAL
```