### PR TITLE
[gz-bridge] fix GZ timeout for slow starting simulations

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -282,7 +282,7 @@ int GZBridge::task_spawn(int argc, char *argv[])
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 			// lockstep scheduler wait for initial clock set before returning
-			int sleep_count_limit = 1000;
+			int sleep_count_limit = 10000;
 
 			while ((instance->world_time_us() == 0) && sleep_count_limit > 0) {
 				// wait for first clock message


### PR DESCRIPTION
### Solved Problem
`gz_bridge` does not allow Gazebo to start and triggers the timeout.
![image](https://github.com/PX4/PX4-Autopilot/assets/38298699/9390fef3-32d8-4b49-becf-cc08ef98780a)


### Solution
Increased the timeout value to 10s.

### Changelog Entry
None