### PR TITLE
[BACKPORT 1.14] [gz-bridge] fix GZ timeout for slow starting simulations

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -282,7 +282,7 @@ int GZBridge::task_spawn(int argc, char *argv[])
 
 #if defined(ENABLE_LOCKSTEP_SCHEDULER)
 			// lockstep scheduler wait for initial clock set before returning
-			int sleep_count_limit = 1000;
+			int sleep_count_limit = 10000;
 
 			while ((instance->world_time_us() == 0) && sleep_count_limit > 0) {
 				// wait for first clock message


### PR DESCRIPTION
Backport of #22194.

Fixes #21903 