### PR TITLE
nuttx/semaphore: Disable priority inheritance for signaling semaphores.

### DIFF
--- a/platforms/common/px4_work_queue/WorkItemSingleShot.cpp
+++ b/platforms/common/px4_work_queue/WorkItemSingleShot.cpp
@@ -41,6 +41,7 @@ WorkItemSingleShot::WorkItemSingleShot(const px4::wq_config_t &config, worker_me
 	: px4::WorkItem("<single_shot>", config), _argument(argument), _method(method)
 {
 	px4_sem_init(&_sem, 0, 0);
+	px4_sem_setprotocol(&_sem, SEM_PRIO_NONE);
 }
 
 WorkItemSingleShot::WorkItemSingleShot(const px4::WorkItem &work_item, worker_method method, void *argument)

--- a/src/include/containers/BlockingQueue.hpp
+++ b/src/include/containers/BlockingQueue.hpp
@@ -46,6 +46,8 @@ public:
 	{
 		px4_sem_init(&_sem_head, 0, N);
 		px4_sem_init(&_sem_tail, 0, 0);
+		px4_sem_setprotocol(&_sem_head, SEM_PRIO_NONE);
+		px4_sem_setprotocol(&_sem_tail, SEM_PRIO_NONE);
 	}
 
 	~BlockingQueue()


### PR DESCRIPTION
This disables priority inheritance for signaling semaphores. These two cause issues for me, although there might be other semaphores that require similar fixes.