### PR TITLE
fix lightware_laser_serial: prevent potential heap buffer overflow

### DIFF
--- a/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
@@ -219,6 +219,10 @@ int LightwareLaserSerial::collect()
 
 	} else {
 		for (int i = 0; i < ret; i++) {
+			// Check for overflow
+			if (_linebuf_index >= sizeof(_linebuf)) {
+				_parse_state = LW_PARSE_STATE0_UNSYNC;
+			}
 			if (OK == lightware_parser(readbuf[i], _linebuf, &_linebuf_index, &_parse_state, &distance_m)) {
 				valid = true;
 			}

--- a/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_laser_serial/lightware_laser_serial.cpp
@@ -223,6 +223,7 @@ int LightwareLaserSerial::collect()
 			if (_linebuf_index >= sizeof(_linebuf)) {
 				_parse_state = LW_PARSE_STATE0_UNSYNC;
 			}
+
 			if (OK == lightware_parser(readbuf[i], _linebuf, &_linebuf_index, &_parse_state, &distance_m)) {
 				valid = true;
 			}


### PR DESCRIPTION
In the lightware_parser function, LW_PARSE_STATE2_GOT_DIGIT0 state can be repeated unexpectedly without proper parserbuf_index or state checking. This behavior will trigger a heap buffer overflow vulnerability by allowing to write some data. And the writable size is sizeof(unsigned).

We've discussed for this bug with @bkueng 