### PR TITLE
Add the capability to use Gazebo Harmonic if it is installed

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -32,13 +32,13 @@
 ############################################################################
 
 # Find the gz_Transport library
-find_package(gz-transport
-	#REQUIRED COMPONENTS core
-	NAMES
-		#ignition-transport11 # IGN (Fortress and earlier) no longer supported
-		gz-transport12
-	#QUIET
-)
+# First look for GZ Harmonic libraries
+find_package(gz-transport NAMES gz-transport13)
+
+# If Harmonic not found, look for GZ Garden libraries
+if(NOT gz-transport_FOUND)
+	find_package(gz-transport NAMES gz-transport12)
+endif()
 
 if(gz-transport_FOUND)
 

--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceESC.hpp
@@ -35,6 +35,7 @@
 
 #include <lib/mixer_module/mixer_module.hpp>
 
+#include <gz/msgs.hh>
 #include <gz/transport.hh>
 
 #include <uORB/PublicationMulti.hpp>


### PR DESCRIPTION
### Solved Problem
Gazebo simulation would not work if Gazebo Harmonic was installed. This was due to the fact that the `gz sim` call used in `px4-rc.simulator` uses the newest version of gz sim on the machine, but the `gz_bridge` build is hard-coded to use the transport library for Gazebo Garden.

Fixes #22180

### Solution
- Search for the gz-transport for Harmonic first before checking for Garden, defaulting to the newest version.

### Changelog Entry
For release notes:
```
Feature: Add the capability to use Gazebo Harmonic for simulation
```

### Alternatives
The alternative to this would be to force the simulator to use Garden. This could be done by editing the `gz_sub_command` in `px4-rc.simulator` to be ```gz_sub_command="sim --force-version 7```.
This didn't seem necessary since Gazebo Harmonic works fine as long as gz bridge is built with the transport libraries for Harmonic. 

I'm not terribly thrilled with the CMakeLists.txt changes. I am more used to checking the version as part of find_package, but that did not appear to be possible since the packages have different names for major version updates. I attempted to have both options input as NAMES, but the order of the NAMES did not appear to set precedence for which one it found and used first. Perhaps there is a cleaner way to check for gz-transport13, but this wasn't too messy.

### Test coverage
- Gazebo simulation now works with Gazebo Harmonic if it is installed, using gz sim version 8.0.0.
- Gazebo simulation still works with Gazebo Garden if Harmonic is not installed. 

### Context

