### PR TITLE
Update px4-rc.mavlink

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
@@ -32,7 +32,7 @@ mavlink start -x -u $udp_onboard_payload_port_local -r 4000 -f -m onboard -o $ud
 mavlink start -x -u $udp_onboard_gimbal_port_local -r 400000 -m gimbal -o $udp_onboard_gimbal_port_remote
 
 # To display for SIH sitl
-if [ "$PX4_SIMULATOR" = "sihsim" ]; then
+if [ "$PX4_SIMULATOR" == "sihsim" ]; then
 	udp_sihsim_port_local=$((19450+px4_instance))
 	udp_sihsim_port_remote=$((19410+px4_instance))
 	mavlink start -x -u $udp_sihsim_port_local -r 400000 -m custom -o $udp_sihsim_port_remote


### PR DESCRIPTION
Fixing typo to display sih sitl in jmavsim.

I was trying to display the sih sitl in jmavsim. I encounter this uggly typo in the shell script :/
It works now. The sih can be compiled from onw terminal
```
 make px4_sitl_default sihsim_quadx 
```
and jmavsim can be started from another terminal
```
./Tools/simulation/jmavsim/jmavsim_run.sh -p 19410 -u -q -o
```

next step: Currently I need to open to terminals. Is it possible to start them in one command line?
