### PR TITLE
Fix gazebo-classic_iris_opt_flow not arming

### DIFF
--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.cpp
@@ -215,7 +215,7 @@ void VehicleOpticalFlow::Run()
 			const float interval_us = 1e6f / _param_sens_flow_rate.get();
 
 			// don't allow publishing faster than SENS_FLOW_RATE
-			if (_integration_timespan_us < interval_us) {
+			if (sensor_optical_flow.timestamp_sample < _last_publication_timestamp + interval_us) {
 				publish = false;
 			}
 		}
@@ -278,6 +278,7 @@ void VehicleOpticalFlow::Run()
 
 			vehicle_optical_flow.timestamp = hrt_absolute_time();
 			_vehicle_optical_flow_pub.publish(vehicle_optical_flow);
+			_last_publication_timestamp = vehicle_optical_flow.timestamp_sample;
 
 			// vehicle_optical_flow_vel if distance is available (for logging)
 			if (_distance_sum_count > 0 && PX4_ISFINITE(_distance_sum)) {

--- a/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
+++ b/src/modules/sensors/vehicle_optical_flow/VehicleOpticalFlow.hpp
@@ -117,6 +117,8 @@ private:
 	uint16_t _quality_sum{0};
 	uint8_t _accumulated_count{0};
 
+	hrt_abstime _last_publication_timestamp{0};
+
 	int _distance_sensor_selected{-1}; // because we can have several distance sensor instances with different orientations
 	hrt_abstime _last_range_sensor_update{0};
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

Enables the gazebo-classic_iris_optical_flow model to arm, which was currently impossible.
Previously `make px4_sitl gazebo-classic_iris_opt_flow` with `commander arm` would fail. Caused by the SITL and PX4Flow returning a 0 integration timespan before takeoff, which never summed to the desired publishing time delay and disabled publishing to `vehicle_optical_flow`. This caused preflight checks to fail. 

### Solution
Publishing frequency check now compares sensor time with last publication time instead of summing integration timespan

### Changelog Entry
For release notes:
```
Bugfix: Fix a bug that prevented gazebo-classic_iris_optical_flow model from arming.
```

### Alternatives
We could also alter the PX4Flow plugin to publish a `sensor_optical_flow` message with more meaningful/non-zero timespan.