### PR TITLE
update default omnicopter pose in gazebo

### DIFF
--- a/Tools/simulation/gz/models/omnicopter/model.sdf
+++ b/Tools/simulation/gz/models/omnicopter/model.sdf
@@ -2,7 +2,7 @@
 <sdf version='1.9'>
   <include>
       <name>omnicopter</name>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 0 0.2 0 0 0</pose>
       <uri>https://fuel.gazebosim.org/1.0/PX4/models/Omnicopter</uri>
     </include>
 </sdf>


### PR DESCRIPTION
### Solved Problem
When running the command line instructions found on the PX4 manual related to Gazebo, I found that vehicles would clip into the ground as their default pose was placed at 0,0,0,0,0,0. No fix is required except running a different command that uses an alias of `PX4_GZ_MODEL`. This is currently being updated in: https://github.com/PX4/PX4-user_guide/pull/2801. 

This PR addresses movign the default pose provided in the omniocopter's model.sdf file. It is set at 0,0,0,0,0,0 meaning that it will clip into the ground regardless of command. By moving the default pose, the omnicoper will sit on top of the ground rather than in it. 

Fixes #22214 

### Solution
Move default pose of omnicopter in sdf file along z-axis by 20cm. 
