### PR TITLE
[offboard control] allow for direct actuator control

### DIFF
--- a/msg/OffboardControlMode.msg
+++ b/msg/OffboardControlMode.msg
@@ -7,4 +7,5 @@ bool velocity
 bool acceleration
 bool attitude
 bool body_rate
-bool actuator
+bool thrust_and_torque
+bool direct_actuator

--- a/src/modules/commander/HealthAndArmingChecks/checks/offboardCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/offboardCheck.cpp
@@ -48,7 +48,7 @@ void OffboardChecks::checkAndReport(const Context &context, Report &reporter)
 
 		bool offboard_available = (offboard_control_mode.position || offboard_control_mode.velocity
 					   || offboard_control_mode.acceleration || offboard_control_mode.attitude || offboard_control_mode.body_rate
-					   || offboard_control_mode.actuator) && data_is_recent;
+					   || offboard_control_mode.thrust_and_torque || offboard_control_mode.direct_actuator) && data_is_recent;
 
 		if (offboard_control_mode.position && reporter.failsafeFlags().local_position_invalid) {
 			offboard_available = false;

--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -46,19 +46,20 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 			   const offboard_control_mode_s &offboard_control_mode,
 			   vehicle_control_mode_s &vehicle_control_mode)
 {
-	vehicle_control_mode.flag_control_allocation_enabled = true; // Always enabled by default
 
 	switch (nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
 		vehicle_control_mode.flag_control_manual_enabled = true;
 		vehicle_control_mode.flag_control_rates_enabled = stabilization_required(vehicle_type);
 		vehicle_control_mode.flag_control_attitude_enabled = stabilization_required(vehicle_type);
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_STAB:
 		vehicle_control_mode.flag_control_manual_enabled = true;
 		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
@@ -67,6 +68,7 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 		vehicle_control_mode.flag_control_attitude_enabled = true;
 		vehicle_control_mode.flag_control_altitude_enabled = true;
 		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_POSCTL:
@@ -77,6 +79,7 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 		vehicle_control_mode.flag_control_climb_rate_enabled = true;
 		vehicle_control_mode.flag_control_position_enabled = true;
 		vehicle_control_mode.flag_control_velocity_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
@@ -93,11 +96,13 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 		vehicle_control_mode.flag_control_climb_rate_enabled = true;
 		vehicle_control_mode.flag_control_position_enabled = true;
 		vehicle_control_mode.flag_control_velocity_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_ACRO:
 		vehicle_control_mode.flag_control_manual_enabled = true;
 		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_DESCEND:
@@ -105,6 +110,7 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_attitude_enabled = true;
 		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
@@ -121,28 +127,36 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 			vehicle_control_mode.flag_control_altitude_enabled = true;
 			vehicle_control_mode.flag_control_climb_rate_enabled = true;
 			vehicle_control_mode.flag_control_acceleration_enabled = true;
-			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_allocation_enabled = true;
 
 		} else if (offboard_control_mode.velocity) {
 			vehicle_control_mode.flag_control_velocity_enabled = true;
 			vehicle_control_mode.flag_control_altitude_enabled = true;
 			vehicle_control_mode.flag_control_climb_rate_enabled = true;
 			vehicle_control_mode.flag_control_acceleration_enabled = true;
-			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_allocation_enabled = true;
 
 		} else if (offboard_control_mode.acceleration) {
 			vehicle_control_mode.flag_control_acceleration_enabled = true;
-			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_allocation_enabled = true;
 
 		} else if (offboard_control_mode.attitude) {
-			vehicle_control_mode.flag_control_rates_enabled = true;
 			vehicle_control_mode.flag_control_attitude_enabled = true;
+			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_allocation_enabled = true;
 
 		} else if (offboard_control_mode.body_rate) {
 			vehicle_control_mode.flag_control_rates_enabled = true;
+			vehicle_control_mode.flag_control_allocation_enabled = true;
+
+		} else if (offboard_control_mode.thrust_and_torque) {
+			vehicle_control_mode.flag_control_allocation_enabled = true;
 		}
 
 		break;

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -136,5 +136,17 @@ subscriptions:
   - topic: /fmu/in/vehicle_trajectory_waypoint
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
+  - topic: /fmu/in/vehicle_thrust_setpoint
+    type: px4_msgs::msg::VehicleThrustSetpoint
+
+  - topic: /fmu/in/vehicle_torque_setpoint
+    type: px4_msgs::msg::VehicleTorqueSetpoint
+
+  - topic: /fmu/in/actuator_motors
+    type: px4_msgs::msg::ActuatorMotors
+
+  - topic: /fmu/in/actuator_servos
+    type: px4_msgs::msg::ActuatorServos
+
 # Create uORB::PublicationMulti
 subscriptions_multi:


### PR DESCRIPTION
EDITED on 2023/11/18

### Solved Problem
- The `actuator` flag of the `offboard_control_mode` was referring to _thrust_ and _torque_ control, requesting `vehicle_thrust_setpoints` and `vehicle_torque_setpoint`.
- direct actuator control (bypassing the control allocator) was not possible.

### Solution
- The current `actuator` flag of the `offboard_control_mode` is renamed `thrust_and_torque`.
- The new ~~`actuator`~~ `direct_actuator` flag disables the control allocator module. The offboard controller has then to provide `actuator_motors` and `actuator_servos` messages.
- New topics added to the uxrce_dds bridge (subscriptions). No additioal load is introduced as the topics are only used if published by the offboard controller.
  - `vehicle_thrust_setpoints` and `vehicle_torque_setpoint`
  - `actuator_motors` and `actuator_servos`
- The old `actuator` flag is removed after considering the risks related to keeping it.

### Changelog Entry
For release notes: new feature: direct actuator control in offboard mode
Documentation: Need to clarify page https://docs.px4.io/main/en/flight_modes/offboard.html