### PR TITLE
Update 13030_generic_vtol_quad_tiltrotor

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13030_generic_vtol_quad_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/13030_generic_vtol_quad_tiltrotor
@@ -40,8 +40,10 @@ param set-default CA_SV_CS0_TRQ_R -0.5
 param set-default CA_SV_CS1_TRQ_R 0.5
 param set-default CA_SV_CS1_TYPE 2
 param set-default CA_SV_CS2_TRQ_P 1.0
+param set-default CA_SV_CS2_TRQ_Y 0.0  #Parameter is not available when CS2 changed to V tail left
 param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS3_TRQ_Y 1.0
+param set-default CA_SV_CS3_TRQ_P 0.0  #Parameter is not available when CS3 changed to V tail left
 param set-default CA_SV_CS3_TYPE 4
 param set-default CA_SV_TL_COUNT 4
 


### PR DESCRIPTION
Added line 43 and 46, As when the CS2 and CS3 is changed to V tail left and right, the CA_SV_CS2_TRQ_Y and CA_SV_CS2_TRQ_P is not available in QGC.  adding these two parameters would help to use the same frame with different Tail type.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
