### PR TITLE
Check mission climb always on current mission item

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -141,6 +141,9 @@ Mission::set_current_mission_index(uint16_t index)
 			set_mission_items();
 		}
 
+		// User has actively set new index, reset.
+		_inactivation_index = -1;
+
 		return true;
 	}
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -243,7 +243,7 @@ MissionBase::on_activation()
 		}
 	}
 
-	checkClimbRequired(resume_index);
+	checkClimbRequired(_mission.current_seq);
 	set_mission_items();
 
 	_inactivation_index = -1; // reset

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -557,6 +557,7 @@ MissionBase::checkMissionRestart()
 	if (_system_disarmed_while_inactive && _mission_has_been_activated && (_mission.count > 0U)
 	    && ((_mission.current_seq + 1) == _mission.count)) {
 		setMissionIndex(0);
+		_inactivation_index = -1; // reset
 		_is_current_planned_mission_item_valid = isMissionValid(_mission);
 		resetMissionJumpCounter();
 		_navigator->reset_cruising_speed();

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -295,6 +295,7 @@ protected:
 	bool _system_disarmed_while_inactive{false};		/**< Flag indicating if the system has been disarmed while mission is inactive*/
 	mission_s _mission;					/**< Currently active mission*/
 	float _mission_init_climb_altitude_amsl{NAN}; 		/**< altitude AMSL the vehicle will climb to when mission starts */
+	int _inactivation_index{-1}; // index of mission item at which the mission was paused. Used to resume survey missions at previous waypoint to not lose images.
 
 	DatamanCache _dataman_cache{"mission_dm_cache_miss", 10}; /**< Dataman cache of mission items*/
 	DatamanClient	&_dataman_client = _dataman_cache.client(); /**< Dataman client*/
@@ -428,7 +429,6 @@ private:
 	int32_t _load_mission_index{-1}; /**< Mission inted of loaded mission items in dataman cache*/
 	int32_t _dataman_cache_size_signed; /**< Size of the dataman cache. A negativ value indicates that previous mission items should be loaded, a positiv value the next mission items*/
 
-	int _inactivation_index{-1}; // index of mission item at which the mission was paused. Used to resume survey missions at previous waypoint to not lose images.
 	bool _align_heading_necessary{false}; // if true, heading of vehicle needs to be aligned with heading of next waypoint. Used to create new mission items for heading alignment.
 
 	mission_item_s _last_gimbal_configure_item {};


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
There is a bug when activating a mission for checking if a climb is required. The check is performed on the inactivation_index instead of the chosen mission index. The inactivation index should only be used when infering, if a mission was interrupted during a survey, instead the climb required check should always be performed on the mission item that comes first. In addition the inactivation index should be reset, when a misison is interrupted and the user changes the current sequence as well as when the mission is reset.

Fixes #{Github issue ID}

### Solution
- Make sure to use the current mission index when performing the climb check.
- Reset inactivation index when user sets current sequence of the mission is reset.

### Changelog Entry
For release notes:
```
Bugfix Make sure the climb check at the start of a mission is performed at the current mission item.
```

### Test coverage
- Unit/integration test: Tested in SITL gazebo-classic_standard_vtol
