### PR TITLE
Remove SYS_USE_IO param

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -274,32 +274,26 @@ else
 		. $FCONFIG
 	fi
 
-	#
-	# Start IO for PWM output or RC input if enabled
-	#
-	if param compare -s SYS_USE_IO 1
+	# Check if PX4IO present and update firmware if needed.
+	if [ -f $IOFW ]
 	then
-		# Check if PX4IO present and update firmware if needed.
-		if [ -f $IOFW ]
+		if ! px4io checkcrc ${IOFW}
 		then
-			if ! px4io checkcrc ${IOFW}
-			then
-				# tune Program PX4IO
-				tune_control play -t 16 # tune 16 = PROG_PX4IO
+			# tune Program PX4IO
+			tune_control play -t 16 # tune 16 = PROG_PX4IO
 
-				if px4io update ${IOFW}
+			if px4io update ${IOFW}
+			then
+				usleep 10000
+				tune_control stop
+				if px4io checkcrc ${IOFW}
 				then
-					usleep 10000
-					tune_control stop
-					if px4io checkcrc ${IOFW}
-					then
-						tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
-					else
-						tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
-					fi
+					tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
 				else
-					tune_control stop
+					tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
 				fi
+			else
+				tune_control stop
 			fi
 		fi
 
@@ -309,6 +303,7 @@ else
 			set STARTUP_TUNE 2 # tune 2 = ERROR_TUNE
 		fi
 	fi
+
 
 	#
 	# RC update (map raw RC input to calibrate manual control)

--- a/boards/ark/fmu-v6x/init/rc.board_defaults
+++ b/boards/ark/fmu-v6x/init/rc.board_defaults
@@ -32,11 +32,4 @@ then
 	param set-default SENS_TEMP_ID 3014666
 fi
 
-if ver hwtypecmp ARKV6X001000 ARKV6X001001 ARKV6X001002 ARKV6X001003 ARKV6X001004 ARKV6X001005 ARKV6X001006 ARKV6X001007
-then
-	param set-default SYS_USE_IO 0
-else
-	param set-default SYS_USE_IO 1
-fi
-
 safety_button start

--- a/boards/cubepilot/cubeorange/init/rc.board_defaults
+++ b/boards/cubepilot/cubeorange/init/rc.board_defaults
@@ -14,6 +14,4 @@ param set-default SENS_EN_THERMAL 0
 
 param set-default -s SENS_TEMP_ID 2621474
 
-param set-default SYS_USE_IO 1
-
 set IOFW "/etc/extras/cubepilot_io-v2_default.bin"

--- a/boards/cubepilot/cubeorangeplus/init/rc.board_defaults
+++ b/boards/cubepilot/cubeorangeplus/init/rc.board_defaults
@@ -14,6 +14,4 @@ param set-default SENS_EN_THERMAL 0
 
 param set-default -s SENS_TEMP_ID 2621474
 
-param set-default SYS_USE_IO 1
-
 set IOFW "/etc/extras/cubepilot_io-v2_default.bin"

--- a/boards/cubepilot/cubeyellow/init/rc.board_defaults
+++ b/boards/cubepilot/cubeyellow/init/rc.board_defaults
@@ -13,6 +13,4 @@ param set-default BAT2_A_PER_V 17
 # Disable IMU thermal control
 param set-default SENS_EN_THERMAL 0
 
-param set-default SYS_USE_IO 1
-
 set IOFW "/etc/extras/cubepilot_io-v2_default.bin"

--- a/boards/holybro/durandal-v1/init/rc.board_defaults
+++ b/boards/holybro/durandal-v1/init/rc.board_defaults
@@ -11,5 +11,3 @@ param set-default BAT2_A_PER_V 36.367515152
 
 # Enable IMU thermal control
 param set-default SENS_EN_THERMAL 1
-
-param set-default SYS_USE_IO 1

--- a/boards/holybro/pix32v5/init/rc.board_defaults
+++ b/boards/holybro/pix32v5/init/rc.board_defaults
@@ -9,7 +9,5 @@ param set-default BAT2_V_DIV 18.1
 param set-default BAT1_A_PER_V 36.367515152
 param set-default BAT2_A_PER_V 36.367515152
 
-param set-default SYS_USE_IO 1
-
 rgbled_pwm start
 safety_button start

--- a/boards/mro/x21-777/init/rc.board_defaults
+++ b/boards/mro/x21-777/init/rc.board_defaults
@@ -5,5 +5,3 @@
 
 param set-default BAT1_V_DIV 10.177939394
 param set-default BAT1_A_PER_V 15.391030303
-
-param set-default SYS_USE_IO 1

--- a/boards/mro/x21/init/rc.board_defaults
+++ b/boards/mro/x21/init/rc.board_defaults
@@ -5,5 +5,3 @@
 
 param set-default BAT1_V_DIV 10.177939394
 param set-default BAT1_A_PER_V 15.391030303
-
-param set-default SYS_USE_IO 1

--- a/boards/px4/fmu-v2/init/rc.board_defaults
+++ b/boards/px4/fmu-v2/init/rc.board_defaults
@@ -5,5 +5,3 @@
 
 param set-default BAT1_V_DIV 10.177939394
 param set-default BAT1_A_PER_V 15.391030303
-
-param set-default SYS_USE_IO 1

--- a/boards/px4/fmu-v3/init/rc.board_defaults
+++ b/boards/px4/fmu-v3/init/rc.board_defaults
@@ -5,5 +5,3 @@
 
 param set-default BAT1_V_DIV 10.177939394
 param set-default BAT1_A_PER_V 15.391030303
-
-param set-default SYS_USE_IO 1

--- a/boards/px4/fmu-v4pro/init/rc.board_defaults
+++ b/boards/px4/fmu-v4pro/init/rc.board_defaults
@@ -13,6 +13,4 @@ param set-default BAT2_A_PER_V 26.4
 param set-default EKF2_MULTI_IMU 2
 param set-default SENS_IMU_MODE 0
 
-param set-default SYS_USE_IO 1
-
 set LOGGER_BUF 64

--- a/boards/px4/fmu-v5/init/rc.board_defaults
+++ b/boards/px4/fmu-v5/init/rc.board_defaults
@@ -9,13 +9,6 @@ param set-default BAT2_V_DIV 18.1
 param set-default BAT1_A_PER_V 36.367515152
 param set-default BAT2_A_PER_V 36.367515152
 
-if ver hwtypecmp V5004000 V5006000
-then
-	param set-default SYS_USE_IO 0
-else
-	param set-default SYS_USE_IO 1
-fi
-
 if ver hwtypecmp V5005000 V5005002 V5006000 V5006002
 then
 	# CUAV V5+ (V550/V552) and V5nano (V560/V562) have 3 IMUs

--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -16,8 +16,6 @@ param set-default SENS_EN_INA238 0
 param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 1
 
-param set-default SYS_USE_IO 1
-
 if ver hwtypecmp V5X009000 V5X009001 V5X00a000 V5X00a001 V5X008000 V5X008001 V5X010001
 then
 	# Skynode: use the "custom participant" config for uxrce_dds_client

--- a/boards/px4/fmu-v6c/init/rc.board_defaults
+++ b/boards/px4/fmu-v6c/init/rc.board_defaults
@@ -9,5 +9,3 @@ param set-default BAT2_V_DIV 18.1
 
 param set-default BAT1_A_PER_V 36.367515152
 param set-default BAT2_A_PER_V 36.367515152
-
-param set-default SYS_USE_IO 1

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -16,8 +16,6 @@ param set-default SENS_EN_INA238 0
 param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 1
 
-param set-default SYS_USE_IO 1
-
 if ver hwtypecmp V6X009010 V6X010010
 then
 	# Skynode: use the "custom participant" config for uxrce_dds_client

--- a/boards/siyi/n7/init/rc.board_defaults
+++ b/boards/siyi/n7/init/rc.board_defaults
@@ -10,5 +10,3 @@ param set-default BAT1_A_PER_V 36.367515152
 
 # Enable IMU thermal control
 param set-default SENS_EN_THERMAL 1
-
-param set-default SYS_USE_IO 1

--- a/boards/sky-drones/smartap-airlink/init/rc.board_defaults
+++ b/boards/sky-drones/smartap-airlink/init/rc.board_defaults
@@ -25,8 +25,6 @@ param set-default BAT_V_OFFS_CURR 0.413
 # Disable safety switch
 param set-default CBRK_IO_SAFETY 22027
 
-param set-default SYS_USE_IO 1
-
 safety_button start
 
 set LOGGER_BUF 32

--- a/boards/thepeach/k1/init/rc.board_defaults
+++ b/boards/thepeach/k1/init/rc.board_defaults
@@ -5,5 +5,3 @@
 
 param set-default BAT1_V_DIV 18.1
 param set-default BAT1_A_PER_V 36.367515152
-
-param set-default SYS_USE_IO 1

--- a/boards/thepeach/r1/init/rc.board_defaults
+++ b/boards/thepeach/r1/init/rc.board_defaults
@@ -5,5 +5,3 @@
 
 param set-default BAT1_V_DIV 18.1
 param set-default BAT1_A_PER_V 36.367515152
-
-param set-default SYS_USE_IO 1

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -336,8 +336,7 @@ private:
 		(ParamInt<px4::params::RC_RSSI_PWM_MAX>) _param_rc_rssi_pwm_max,
 		(ParamInt<px4::params::RC_RSSI_PWM_MIN>) _param_rc_rssi_pwm_min,
 		(ParamInt<px4::params::SENS_EN_THERMAL>) _param_sens_en_themal,
-		(ParamInt<px4::params::SYS_HITL>) _param_sys_hitl,
-		(ParamInt<px4::params::SYS_USE_IO>) _param_sys_use_io
+		(ParamInt<px4::params::SYS_HITL>) _param_sys_hitl
 	)
 };
 
@@ -468,7 +467,7 @@ int PX4IO::init()
 	}
 
 	/* try to claim the generic PWM output device node as well - it's OK if we fail at this */
-	if (_param_sys_hitl.get() <= 0 && _param_sys_use_io.get() == 1) {
+	if (_param_sys_hitl.get() <= 0) {
 		_mixing_output.setMaxTopicUpdateRate(MIN_TOPIC_UPDATE_INTERVAL);
 	}
 

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -43,18 +43,6 @@
 #include <parameters/param.h>
 
 /**
- * Set usage of IO board
- *
- * Can be used to use a configure the use of the IO board.
- *
- * @value 0 IO PWM disabled (RC only)
- * @value 1 IO enabled (RC & PWM)
- * @reboot_required true
- * @group System
- */
-PARAM_DEFINE_INT32(SYS_USE_IO, 0);
-
-/**
  * S.BUS out
  *
  * Set to 1 to enable S.BUS version 1 output instead of RSSI.


### PR DESCRIPTION
The param is not really required anymore with the actuator configuration. Also, when it is set to 0, RC doesn't work for some boards which would be nice to avoid.

If you have alternative ways to fix #22206, that's fine with me, but as it is now, the param description is a lie and this is a major regression with v1.14.

Fixes https://github.com/PX4/PX4-Autopilot/issues/22206

Needs to go into v1.14.