### PR TITLE
mavlink: properly set mission_type

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1561,6 +1561,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 	mavlink_mission_item->frame = mission_item->frame;
 	mavlink_mission_item->command = mission_item->nav_cmd;
 	mavlink_mission_item->autocontinue = mission_item->autocontinue;
+	mavlink_mission_item->mission_type = _mission_type;
 
 	/* default mappings for generic commands */
 	if (mission_item->frame == MAV_FRAME_MISSION) {


### PR DESCRIPTION
Fixes #22069.

The mission_type was defaulted to 0 before which messed with transmitting geofence and rally items.

Needs to go into v1.14 as well.

Thanks to [av-jeroen](https://github.com/av-jeroen) for reporting the bug.