### PR TITLE
gazebo-classic: make iris initialise scripts consistent

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10018_gazebo-classic_iris_foggy_lidar
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10018_gazebo-classic_iris_foggy_lidar
@@ -5,29 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 param set-default EKF2_RNG_A_HMAX 10
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
@@ -5,29 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 # EKF2
 param set-default EKF2_GPS_CTRL 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1011_gazebo-classic_iris_irlock
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1011_gazebo-classic_iris_irlock
@@ -5,29 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 # enable fusion of landing target velocity
 param set-default LTEST_MODE 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1012_gazebo-classic_iris_rplidar
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1012_gazebo-classic_iris_rplidar
@@ -5,29 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 param set-default LPE_FUSION 242
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1013_gazebo-classic_iris_vision
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1013_gazebo-classic_iris_vision
@@ -5,7 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d-posix/airframes/10016_gazebo-classic_iris
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 # EKF2: Vision position and heading, no GPS
 param set-default EKF2_EV_DELAY 5

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1014_gazebo-classic_iris_obs_avoid
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1014_gazebo-classic_iris_obs_avoid
@@ -5,28 +5,6 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 param set-default COM_OBS_AVOID 1

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1017_gazebo-classic_iris_opt_flow_mockup
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1017_gazebo-classic_iris_opt_flow_mockup
@@ -5,29 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 # EKF2
 param set-default EKF2_GPS_CTRL 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1019_gazebo-classic_iris_dual_gps
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1019_gazebo-classic_iris_dual_gps
@@ -5,29 +5,7 @@
 # @type Quadrotor Wide
 #
 
-. ${R}etc/init.d/rc.mc_defaults
-
-
-param set-default CA_AIRFRAME 0
-
-param set-default CA_ROTOR_COUNT 4
-param set-default CA_ROTOR0_PX 0.1515
-param set-default CA_ROTOR0_PY 0.245
-param set-default CA_ROTOR0_KM 0.05
-param set-default CA_ROTOR1_PX -0.1515
-param set-default CA_ROTOR1_PY -0.1875
-param set-default CA_ROTOR1_KM 0.05
-param set-default CA_ROTOR2_PX 0.1515
-param set-default CA_ROTOR2_PY -0.245
-param set-default CA_ROTOR2_KM -0.05
-param set-default CA_ROTOR3_PX -0.1515
-param set-default CA_ROTOR3_PY 0.1875
-param set-default CA_ROTOR3_KM -0.05
-
-param set-default PWM_MAIN_FUNC1 101
-param set-default PWM_MAIN_FUNC2 102
-param set-default PWM_MAIN_FUNC3 103
-param set-default PWM_MAIN_FUNC4 104
+. ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris
 
 # EKF2: Multi GPS blending
 param set-default SENS_GPS_MASK 7


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When trying to run the gazebo-classic_vision_iris model I found that the startup script would not complete successfully

```
robbie@robbie-ubuntu22:~/px4$ make px4_sitl gazebo-classic_iris_vision
...builds...
...starts running...
etc/init.d-posix/rcS: 8: .: cannot open /home/robbie/px4/build/px4_sitl_default/rootfs/etc/init.d-posix/airframes/10016_gazebo-classic_iris: No such file
ERROR [px4] Startup script returned with return value: 512
```
### Solution
- Fix typo in ROMFS/px4fmu_common/init.d-posix/airframes/1013_gazebo-classic_iris_vision
- Change all start up scripts in ROMFS/px4fmu_common/init.d-posix/airframes for iris to include . ${R}etc/init.d-posix/airframes/10015_gazebo-classic_iris for consistency

### Alternative
- make all start-up scripts independent, and take relative params defaults from 10015_gazebo-classic_iris into 1013_gazebo-classic_iris_vision, however IMO this is less preferable
