### PR TITLE
POSCTL: Make descent an option with automatic flight mode transition

### DIFF
--- a/src/modules/commander/UserModeIntention.hpp
+++ b/src/modules/commander/UserModeIntention.hpp
@@ -80,6 +80,7 @@ private:
 	bool _had_mode_change{false}; ///< true if there was a mode change call since the last getHadModeChangeAndClear()
 
 	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl
+		(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl,
+		(ParamInt<px4::params::COM_TERM_MODE>) _param_com_term_mode
 	);
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -641,6 +641,22 @@ PARAM_DEFINE_INT32(COM_ARM_MIS_REQ, 0);
 PARAM_DEFINE_INT32(COM_POSCTL_NAVL, 0);
 
 /**
+ * Position control navigation loss last flight mode.
+ *
+ * Sets the last flight mode to be used when navigation accuracy is no longer sufficient for position control.
+ *
+ * If Manual is selected: assumes remote control will be used after fallback. If altitude estimation is not available, switches to MANUAL.
+ *
+ * If Descend is selected: Assumes remote control is not used after fallback. If altitude estimation is unavailable, switch to Descend.
+ *
+ * @value 0 Manual
+ * @value 1 Descend
+ *
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_TERM_MODE, 0);
+
+/**
  * Require arm authorization to arm
  *
  * By default off. The default allows to arm the vehicle without a arm authorization.

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -507,8 +507,14 @@ FailsafeBase::Action Failsafe::checkModeFallback(const failsafe_flags_s &status_
 		// AltCtrl -> Stabilized
 		if (user_intended_mode == vehicle_status_s::NAVIGATION_STATE_ALTCTL
 		    && !modeCanRun(status_flags, user_intended_mode)) {
-			action = Action::FallbackStab;
-			user_intended_mode = vehicle_status_s::NAVIGATION_STATE_STAB;
+			if (_param_com_term_mode.get() == 0) {
+				action = Action::FallbackStab;
+				user_intended_mode = vehicle_status_s::NAVIGATION_STATE_STAB;
+
+			} else {
+				action = Action::Descend;
+				user_intended_mode = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+			}
 		}
 
 		break;

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -163,6 +163,7 @@ private:
 					(ParamInt<px4::params::COM_RCL_EXCEPT>) _param_com_rcl_except,
 					(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
 					(ParamInt<px4::params::COM_POSCTL_NAVL>) _param_com_posctl_navl,
+					(ParamInt<px4::params::COM_TERM_MODE>) _param_com_term_mode,
 					(ParamInt<px4::params::GF_ACTION>)  	_param_gf_action,
 					(ParamFloat<px4::params::COM_SPOOLUP_TIME>) _param_com_spoolup_time,
 					(ParamInt<px4::params::COM_IMB_PROP_ACT>) _param_com_imb_prop_act,


### PR DESCRIPTION
### Solved Problem

Some operators do not like MANUAL mode operation operation.
Automatic flight mode switching ends up in MANUAL mode.

Fixes #{Github issue ID}

None.

### Solution

If ALTITUDE mode is abnormal, select MANUAL mode or DESCEND in the configuration parameters.

### Changelog Entry

None.

### Alternatives

None

### Test coverage

None

### Context

![Screenshot from 2023-10-21 19-46-57](https://github.com/PX4/PX4-Autopilot/assets/646194/f9606798-813d-41f0-8a30-b89a0286615c)

