### PR TITLE
battery: reset current filter when transitioning to FW

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -312,15 +312,12 @@ float Battery::computeRemainingTime(float current_a)
 
 		if (_vehicle_status_sub.copy(&vehicle_status)) {
 			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
-			_vehicle_status_is_fw = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
 
-			if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && _vtol_was_in_mc_mode) {
+			if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && !_vehicle_status_is_fw) {
 				reset_current_avg_filter = true;
-				_vtol_was_in_mc_mode = false;
-
-			} else if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-				_vtol_was_in_mc_mode = true;
 			}
+
+			_vehicle_status_is_fw = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
 		}
 	}
 

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -305,6 +305,7 @@ void Battery::computeScale()
 float Battery::computeRemainingTime(float current_a)
 {
 	float time_remaining_s = NAN;
+	bool reset_current_avg_filter = false;
 
 	if (_vehicle_status_sub.updated()) {
 		vehicle_status_s vehicle_status;
@@ -312,12 +313,22 @@ float Battery::computeRemainingTime(float current_a)
 		if (_vehicle_status_sub.copy(&vehicle_status)) {
 			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
 			_vehicle_status_is_fw = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
+
+			if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && _vtol_was_in_mc_mode) {
+				reset_current_avg_filter = true;
+				_vtol_was_in_mc_mode = false;
+
+			} else if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+				_vtol_was_in_mc_mode = true;
+			}
 		}
 	}
 
 	_flight_phase_estimation_sub.update();
 
-	if (!PX4_ISFINITE(_current_average_filter_a.getState()) || _current_average_filter_a.getState() < FLT_EPSILON) {
+	// reset filter if not feasible, negative or we did a VTOL transition to FW mode
+	if (!PX4_ISFINITE(_current_average_filter_a.getState()) || _current_average_filter_a.getState() < FLT_EPSILON
+	    || reset_current_avg_filter) {
 		_current_average_filter_a.reset(_params.bat_avrg_current);
 	}
 

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -183,5 +183,4 @@ private:
 	bool _armed{false};
 	bool _vehicle_status_is_fw{false};
 	hrt_abstime _last_unconnected_timestamp{0};
-	bool _vtol_was_in_mc_mode{false};
 };

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -183,4 +183,5 @@ private:
 	bool _armed{false};
 	bool _vehicle_status_is_fw{false};
 	hrt_abstime _last_unconnected_timestamp{0};
+	bool _vtol_was_in_mc_mode{false};
 };


### PR DESCRIPTION
VTOLs consume a lot more power in hover compared to fixed-wing flight. The remaining flight time thus should reset if one switches from MC to FW, as otherwise it takes several minutes until the estimate goes down.


### Changelog Entry
For release notes:
```
Improvement: battery: reset current filter when transitioning to FW
```

### Alternatives
Only update the filter in FW for VTOL. As VTOLs though also can have full hover flights this is for me the worse option.


