### PR TITLE
sdcardCheck: shorten hardfault log availability message

### DIFF
--- a/platforms/common/px4_log.cpp
+++ b/platforms/common/px4_log.cpp
@@ -136,7 +136,7 @@ __EXPORT void px4_log_modulename(int level, const char *module_name, const char 
 #if defined(PX4_LOG_COLORIZED_OUTPUT)
 
 		if (use_color) {
-			// alway reset color
+			// always reset color
 			const ssize_t sz = math::min(pos, max_length - (ssize_t)strlen(PX4_ANSI_COLOR_RESET) - (ssize_t)1);
 			pos += snprintf(buf + sz, math::max(max_length - sz, (ssize_t)0), "%s\n", PX4_ANSI_COLOR_RESET);
 

--- a/src/modules/commander/HealthAndArmingChecks/checks/sdcardCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/sdcardCheck.cpp
@@ -122,7 +122,7 @@ void SdCardChecks::checkAndReport(const Context &context, Report &reporter)
 				       events::Log::Error, "Crash dumps present on SD card");
 
 		if (reporter.mavlink_log_pub()) {
-			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Crash dumps present on SD, vehicle needs service");
+			mavlink_log_critical(reporter.mavlink_log_pub(), "Preflight Fail: Crash dumps present on SD");
 		}
 	}
 


### PR DESCRIPTION
### Solved Problem
Fix expected behavior points 2. and 3. from https://github.com/PX4/PX4-Autopilot/issues/22259
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/e6197956-a8eb-4615-bc3f-2b4e2a6e21d7)

### Solution
Shorten the message
It seems to cause multiple issues to have a long message:
- The full message doesn't show on the console because the buffer only has length of `log_message.text` which is 127.
- The additional text shows even if the event that replaces this message already exists. I honestly didn't find the mechanism that breaks there.

### Changelog Entry
```
Bugfix: Show hard fault log availability message correctly
```

### Alternatives
Ideally, longer messages would be supported correctly or there would be a compile error preventing developers from using them. Note that it's not that easy because e.g. the colorized console output uses up > 50 bytes for all the WARN, coloring and module name from the 127-byte buffer.

### Test coverage
- Tested the change on a pixhawk 4 and the message ending doesn't show up unexpectedly anymore.