### PR TITLE
dds_topics: Add multi publication for topics subscribed over dds

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -166,7 +166,7 @@ static void on_topic_update(uxrSession *session, uxrObjectId object_id, uint16_t
 
 bool RcvTopicsPubs::init(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId reliable_in_stream_id, uxrStreamId best_effort_in_stream_id, uxrObjectId participant_id, const char *client_namespace)
 {
-@[    for idx, sub in enumerate(subscriptions)]@
+@[    for idx, sub in enumerate(subscriptions + subscriptions_multi)]@
 	{
 			uint16_t queue_depth = uORB::DefaultQueueSize<@(sub['simple_base_type'])_s>::value * 2; // use a bit larger queue size than internal
 			create_data_reader(session, reliable_out_stream_id, best_effort_in_stream_id, participant_id, @(idx), client_namespace, "@(sub['topic_simple'])", "@(sub['dds_type'])", queue_depth);

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -23,6 +23,7 @@ import os
 
 #include <mathlib/mathlib.h>
 #include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
 #include <uORB/uORB.h>
 @[for include in type_includes]@
 #include <uORB/ucdr/@(include).h>
@@ -127,6 +128,10 @@ struct RcvTopicsPubs {
 	uORB::Publication<@(sub['simple_base_type'])_s> @(sub['topic_simple'])_pub{ORB_ID(@(sub['topic_simple']))};
 @[    end for]@
 
+@[    for sub in subscriptions_multi]@
+	uORB::PublicationMulti<@(sub['simple_base_type'])_s> @(sub['topic_simple'])_pub{ORB_ID(@(sub['topic_simple']))};
+@[    end for]@
+
 	uint32_t num_payload_received{};
 
 	bool init(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId reliable_in_stream_id, uxrStreamId best_effort_in_stream_id, uxrObjectId participant_id, const char *client_namespace);
@@ -140,7 +145,7 @@ static void on_topic_update(uxrSession *session, uxrObjectId object_id, uint16_t
 	pubs->num_payload_received += length;
 
 	switch (object_id.id) {
-@[    for idx, sub in enumerate(subscriptions)]@
+@[    for idx, sub in enumerate(subscriptions + subscriptions_multi)]@
 	case @(idx)+ (65535U / 32U) + 1: {
 			@(sub['simple_base_type'])_s data;
 

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -47,6 +47,7 @@ publications:
   - topic: /fmu/out/vehicle_trajectory_waypoint_desired
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
 
+# Create uORB::Publication
 subscriptions:
 
   - topic: /fmu/in/offboard_control_mode
@@ -87,3 +88,7 @@ subscriptions:
 
   - topic: /fmu/in/vehicle_trajectory_waypoint
     type: px4_msgs::msg::VehicleTrajectoryWaypoint
+
+# Create uORB::PublicationMulti
+subscriptions_multi:
+

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -91,4 +91,3 @@ subscriptions:
 
 # Create uORB::PublicationMulti
 subscriptions_multi:
-

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -99,21 +99,26 @@ def process_message_type(msg_type):
     # topic_simple: eg vehicle_status
     msg_type['topic_simple'] = msg_type['topic'].split('/')[-1]
 
+pubs_not_empty = msg_map['publications'] is not None
+if pubs_not_empty:
+    for p in msg_map['publications']:
+        process_message_type(p)
 
-for p in msg_map['publications']:
-    process_message_type(p)
+merged_em_globals['publications'] = msg_map['publications'] if pubs_not_empty else []
 
-merged_em_globals['publications'] = msg_map['publications']
+subs_not_empty = msg_map['subscriptions'] is not None
+if subs_not_empty:
+    for s in msg_map['subscriptions']:
+        process_message_type(s)
 
-for s in msg_map['subscriptions']:
-    process_message_type(s)
+merged_em_globals['subscriptions'] = msg_map['subscriptions'] if subs_not_empty else []
 
-merged_em_globals['subscriptions'] = msg_map['subscriptions']
+subs_multi_not_empty = msg_map['subscriptions_multi'] is not None
+if subs_multi_not_empty:
+    for sm in msg_map['subscriptions_multi']:
+        process_message_type(sm)
 
-for sm in msg_map['subscriptions_multi']:
-    process_message_type(sm)
-
-merged_em_globals['subscriptions_multi'] = msg_map['subscriptions_multi']
+merged_em_globals['subscriptions_multi'] = msg_map['subscriptions_multi'] if subs_multi_not_empty else []
 
 merged_em_globals['type_includes'] = sorted(set(all_type_includes))
 

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -110,6 +110,11 @@ for s in msg_map['subscriptions']:
 
 merged_em_globals['subscriptions'] = msg_map['subscriptions']
 
+for sm in msg_map['subscriptions_multi']:
+    process_message_type(sm)
+
+merged_em_globals['subscriptions_multi'] = msg_map['subscriptions_multi']
+
 merged_em_globals['type_includes'] = sorted(set(all_type_includes))
 
 


### PR DESCRIPTION
### Solved Problem
Currently we cannot have topics subscribed over DDS be republished via `uORB::PublicationMulti`.

Scenario: I want to test and compare two sources of `vehicle_optical_flow_vel`, one produced internally and one produced from an external app. I want to log both topics on the same mission for evaluation. Currently dds subscribing to `/fmu/in/vehicle_optical_flow_vel` will prevent from being able to view `vehicle_optical_flow_vel` published internally.

### Solution
- Add `subscriptions_multi` field to `dds_topics.yaml`. This create a `uORB::PublicationMulti` for the specified topics.

### Changelog Entry
For release notes:
```
Feature: Adds multi publication option for subscribed dds topics
```

### Context

After: logging multiple sources of a topic. internal and over DDS.
![dds_multi](https://github.com/PX4/PX4-Autopilot/assets/44861207/548d5b32-1731-4d26-a892-1063d43838d4)

### Testing
I can produce instructions to reproduce the results above if this PR could be worth merging.  
