### PR TITLE
Cmake 3.12 modernization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-# Copyright (c) 2017 - 2022 PX4 Development Team. All rights reserved.
+# Copyright (c) 2017-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@
 #
 # * Common functions should be included in px_base.cmake.
 #
-# * OS/ board specific fucntions should be include in
+# * OS/ board specific fucntions should be included in
 #	px_impl_${PX4_PLATFORM}.cmake
 #
 # Formatting
@@ -99,10 +99,22 @@
 #
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+
+project(px4 CXX C ASM)
+set(package-contact "px4users@googlegroups.com")
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(PX4_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE FILEPATH "PX4 source directory" FORCE)
 set(PX4_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE FILEPATH "PX4 binary directory" FORCE)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PX4_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${PX4_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${PX4_BINARY_DIR})
 
 list(APPEND CMAKE_MODULE_PATH ${PX4_SOURCE_DIR}/cmake)
 include(px4_parse_function_args)
@@ -162,13 +174,13 @@ set(config_module_list)
 set(config_kernel_list)
 
 # Find Python
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter Development)
 # We have a custom error message to tell users how to install python3.
-if(NOT PYTHONINTERP_FOUND)
-	message(FATAL_ERROR "Python 3 not found. Please install Python 3:\n"
-		"    Ubuntu: sudo apt install python3 python3-dev python3-pip\n"
-		"    macOS: brew install python")
+if(NOT Python3_FOUND)
+	message(FATAL_ERROR "Python 3 not found.\nPlease install toolchain using scripts in \"Tools/setup\" folder.\n")
 endif()
+# Compatibility with PYTHON_EXECUTABLE variable
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 option(PYTHON_COVERAGE "Python code coverage" OFF)
 if(PYTHON_COVERAGE)
@@ -214,9 +226,8 @@ if(EXISTS "${PX4_SOURCE_DIR}/platforms/${PX4_PLATFORM}/cmake/init.cmake")
 endif()
 
 #=============================================================================
-# project definition
+# build type
 #
-project(px4 CXX C ASM)
 
 # CMake build type (Debug Release RelWithDebInfo MinSizeRel Coverage)
 if(NOT CMAKE_BUILD_TYPE)
@@ -253,18 +264,6 @@ if(LTO)
     message(AUTHOR_WARNING "LTO enabled: LTO is highly experimental and should not be used in production")
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
-
-set(package-contact "px4users@googlegroups.com")
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PX4_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${PX4_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${PX4_BINARY_DIR})
 
 #=============================================================================
 

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -16,7 +16,6 @@ pandas>=0.21
 pkgconfig
 psutil
 pygments
-wheel>=0.31.1
 pymavlink
 pyros-genmsg
 pyserial
@@ -25,5 +24,7 @@ pyyaml
 requests
 setuptools>=39.2.0
 six>=1.12.0
-toml>=0.9
+symforce>=0.9
 sympy>=1.10.1
+toml>=0.9
+wheel>=0.31.1

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -105,10 +105,10 @@ echo
 echo "Installing PX4 Python3 dependencies"
 if [ -n "$VIRTUAL_ENV" ]; then
 	# virtual environments don't allow --user option
-	python -m pip install -r ${DIR}/requirements.txt
+	python -m pip install -r ${DIR}/${REQUIREMENTS_FILE}
 else
 	# older versions of Ubuntu require --user option
-	python3 -m pip install --user -r ${DIR}/requirements.txt
+	python3 -m pip install --user -r ${DIR}/${REQUIREMENTS_FILE}
 fi
 
 # NuttX toolchain (arm-none-eabi-gcc)

--- a/cmake/gtest/CMakeLists.txt.in
+++ b/cmake/gtest/CMakeLists.txt.in
@@ -1,4 +1,37 @@
-cmake_minimum_required(VERSION 2.8.4)
+############################################################################
+#
+# Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+cmake_minimum_required(VERSION 3.12)
 
 project(googletest-download NONE)
 
@@ -11,8 +44,9 @@ ExternalProject_Add(googletest
 	BUILD_COMMAND ""
 	INSTALL_COMMAND ""
 	TEST_COMMAND ""
+	DOWNLOAD_EXTRACT_TIMESTAMP ON
 	# Wrap download, configure and build steps in a script to log output
-    LOG_DOWNLOAD ON
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
+	LOG_DOWNLOAD ON
+	LOG_CONFIGURE ON
+	LOG_BUILD ON
 )

--- a/platforms/posix/src/px4/common/lockstep_scheduler/CMakeLists.txt
+++ b/platforms/posix/src/px4/common/lockstep_scheduler/CMakeLists.txt
@@ -1,4 +1,35 @@
-cmake_minimum_required(VERSION 2.8.12)
+############################################################################
+#
+#   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
 
 # We want to test the lockstep schedule even if it is not used otherwise.
 px4_add_library(lockstep_scheduler


### PR DESCRIPTION
### Solved Problem
When rinning an up-to-date Linux system I found that there are multiple cmake warnings about deprecated functions or new more specific behavior.

Mildly related to #21340 

### Solution
- Switch to minimum cmake 3.12
- Use "new" python finder from 3.12
- Shift project definition to beginning such that required information is available
- Remove lockstep_scheduler defining its own cmake version, it's not a separate project in this context
- Specify gtest download behavior
- Add symforce to python requirements because it's included during config step

### Changelog Entry
```
Build system: Switch to cmake 3.12
```

### Test coverage
I built `make px4_sitl` and `make tests` and get no warning but a successful build. I'm interested if CI versions are reasonably up to date.

### Context
<img width="856" alt="image" src="https://github.com/PX4/PX4-Autopilot/assets/4668506/a7cdef60-680c-4d9d-aa50-183d03cd76a9">
