### PR TITLE
boards: arkv6x fix wrong pwm output values

### DIFF
--- a/boards/ark/fmu-v6x/src/board_config.h
+++ b/boards/ark/fmu-v6x/src/board_config.h
@@ -247,7 +247,6 @@
 /* PWM
  */
 #define DIRECT_PWM_OUTPUT_CHANNELS   8
-#define BOARD_PWM_FREQ	             1024000
 
 #define GPIO_FMU_CH1                    /* PI0  */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTI|GPIO_PIN0)
 #define GPIO_FMU_CH2                    /* PH12 */ (GPIO_INPUT|GPIO_PULLDOWN|GPIO_PORTH|GPIO_PIN12)

--- a/boards/ark/fmu-v6x/src/spix_sync.c
+++ b/boards/ark/fmu-v6x/src/spix_sync.c
@@ -82,9 +82,7 @@
 #define rDMAR(_tmr)     REG(_tmr, STM32_GTIM_DMAR_OFFSET)
 #define rBDTR(_tmr)     REG(_tmr, STM32_ATIM_BDTR_OFFSET)
 
-#if !defined(BOARD_PWM_FREQ)
-#define BOARD_PWM_FREQ 1000000
-#endif
+#define BOARD_SPIX_SYNC_PWM_FREQ 1024000
 
 unsigned
 spix_sync_timer_get_period(unsigned timer)
@@ -129,11 +127,11 @@ static void spix_sync_timer_init_timer(unsigned timer, unsigned rate)
 		 * Otherwise, other frequencies are attainable by adjusting .clock_freq accordingly.
 		 */
 
-		rPSC(timer) = (spix_sync_timers[timer].clock_freq / BOARD_PWM_FREQ) - 1;
+		rPSC(timer) = (spix_sync_timers[timer].clock_freq / BOARD_SPIX_SYNC_PWM_FREQ) - 1;
 
 		/* configure the timer to update at the desired rate */
 
-		rARR(timer) = (BOARD_PWM_FREQ / rate) - 1;
+		rARR(timer) = (BOARD_SPIX_SYNC_PWM_FREQ / rate) - 1;
 
 		/* generate an update event; reloads the counter and all registers */
 		rEGR(timer) = GTIM_EGR_UG;


### PR DESCRIPTION
In an attempt to get the SPIX_SYNC output frequency I wanted, I inadvertadntly caused the PWM output value calculation to be wrong by 25-50us. This fix separates the SPIX_SYNC from the BOARD_PWM_FREQ.

Will need to backport into 1.14.

@ryanjAA 