### PR TITLE
fixing the turning direction of the Cessna Propeller

### DIFF
--- a/Tools/simulation/gz/models/rc_cessna/model.sdf
+++ b/Tools/simulation/gz/models/rc_cessna/model.sdf
@@ -806,7 +806,7 @@
     <plugin filename="gz-sim-multicopter-motor-model-system" name="gz::sim::systems::MulticopterMotorModel">
       <jointName>rotor_puller_joint</jointName>
       <linkName>rotor_puller</linkName>
-      <turningDirection>cw</turningDirection>
+      <turningDirection>ccw</turningDirection>
       <timeConstantUp>0.0125</timeConstantUp>
       <timeConstantDown>0.025</timeConstantDown>
       <maxRotVelocity>1000</maxRotVelocity>


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The Cessna Propeller has a mismatch between the turning direction and the propeller used. This PR fixes this so that the propeller direction is the same as in real Cessnas and also matches the correct propeller mesh. This PR does not fix the ugly the visual bug that is encountered in the `iris_prop_cw.dae` mesh when it is viewed from the rear. 
Fixes #22275 

### Solution
Change the `<turningDirection>` parameter from `cw` to `ccw`.
