### PR TITLE
dronecan: gps add noise, jamming, and spoofing data

### DIFF
--- a/msg/SensorGnssRelative.msg
+++ b/msg/SensorGnssRelative.msg
@@ -15,8 +15,8 @@ float32[3] position_accuracy      # Accuracy of relative position (m)
 float32 heading                   # Heading of the relative position vector (radians)
 float32 heading_accuracy          # Accuracy of heading of the relative position vector (radians)
 
-float32 position_length
-float32 accuracy_length
+float32 position_length           # Length of the position vector (m)
+float32 accuracy_length           # Accuracy of the position length (m)
 
 bool gnss_fix_ok                  # GNSS valid fix (i.e within DOP & accuracy masks)
 bool differential_solution        # differential corrections were applied

--- a/src/drivers/uavcan/CMakeLists.txt
+++ b/src/drivers/uavcan/CMakeLists.txt
@@ -167,6 +167,7 @@ px4_add_module(
 		sensors/battery.cpp
 		sensors/airspeed.cpp
 		sensors/flow.cpp
+		sensors/gnss_relative.cpp
 		sensors/gnss.cpp
 		sensors/mag.cpp
 		sensors/rangefinder.cpp

--- a/src/drivers/uavcan/Kconfig
+++ b/src/drivers/uavcan/Kconfig
@@ -57,6 +57,10 @@ if DRIVERS_UAVCAN
         bool "Subscribe to GPS:                         uavcan::equipment::gnss::Auxiliary | uavcan::equipment::gnss::Fix | uavcan::equipment::gnss::Fix2"
         default y
 
+    config UAVCAN_SENSOR_GNSS_RELATIVE
+        bool "Subscribe to GPS Relative:                ardupilot::equipment::gnss::RelPosHeading"
+        default y
+
     config UAVCAN_SENSOR_HYGROMETER
         bool "Subscribe to Hygrometer:                  dronecan::sensors::hygrometer::Hygrometer"
         default y

--- a/src/drivers/uavcan/sensors/gnss.cpp
+++ b/src/drivers/uavcan/sensors/gnss.cpp
@@ -155,7 +155,7 @@ UavcanGnssBridge::gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 	float vel_cov[9];
 	msg.velocity_covariance.unpackSquareMatrix(vel_cov);
 
-	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_pos_cov, valid_vel_cov, NAN, NAN, NAN);
+	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_pos_cov, valid_vel_cov, NAN, NAN, NAN, -1, -1, 0, 0);
 }
 
 void
@@ -299,9 +299,16 @@ UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 	float heading_offset = NAN;
 	float heading_accuracy = NAN;
 
+	int32_t noise_per_ms = -1;
+	int32_t jamming_indicator = -1;
+	uint8_t jamming_state = 0;
+	uint8_t spoofing_state = 0;
+
 	// Use ecef_position_velocity for now... There is no heading field
 	if (!msg.ecef_position_velocity.empty()) {
-		heading = msg.ecef_position_velocity[0].velocity_xyz[0];
+		if (!std::isnan(msg.ecef_position_velocity[0].velocity_xyz[0])) {
+			heading = msg.ecef_position_velocity[0].velocity_xyz[0];
+		}
 
 		if (!std::isnan(msg.ecef_position_velocity[0].velocity_xyz[1])) {
 			heading_offset = msg.ecef_position_velocity[0].velocity_xyz[1];
@@ -310,10 +317,16 @@ UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 		if (!std::isnan(msg.ecef_position_velocity[0].velocity_xyz[2])) {
 			heading_accuracy = msg.ecef_position_velocity[0].velocity_xyz[2];
 		}
+
+		noise_per_ms = msg.ecef_position_velocity[0].position_xyz_mm[0];
+		jamming_indicator = msg.ecef_position_velocity[0].position_xyz_mm[1];
+
+		jamming_state = msg.ecef_position_velocity[0].position_xyz_mm[2] >> 8;
+		spoofing_state = msg.ecef_position_velocity[0].position_xyz_mm[2] & 0xFF;
 	}
 
 	process_fixx(msg, fix_type, pos_cov, vel_cov, valid_covariances, valid_covariances, heading, heading_offset,
-		     heading_accuracy);
+		     heading_accuracy, noise_per_ms, jamming_indicator, jamming_state, spoofing_state);
 }
 
 template <typename FixType>
@@ -322,7 +335,9 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 				    const float (&pos_cov)[9], const float (&vel_cov)[9],
 				    const bool valid_pos_cov, const bool valid_vel_cov,
 				    const float heading, const float heading_offset,
-				    const float heading_accuracy)
+				    const float heading_accuracy, const int32_t noise_per_ms,
+				    const int32_t jamming_indicator, const uint8_t jamming_state,
+				    const uint8_t spoofing_state)
 {
 	sensor_gps_s report{};
 	report.device_id = get_device_id();
@@ -451,6 +466,11 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	report.heading = heading;
 	report.heading_offset = heading_offset;
 	report.heading_accuracy = heading_accuracy;
+
+	report.noise_per_ms = noise_per_ms;
+	report.jamming_indicator = jamming_indicator;
+	report.jamming_state = jamming_state;
+	report.spoofing_state = spoofing_state;
 
 	publish(msg.getSrcNodeID().get(), &report);
 }

--- a/src/drivers/uavcan/sensors/gnss.hpp
+++ b/src/drivers/uavcan/sensors/gnss.hpp
@@ -89,7 +89,9 @@ private:
 			  const float (&pos_cov)[9], const float (&vel_cov)[9],
 			  const bool valid_pos_cov, const bool valid_vel_cov,
 			  const float heading, const float heading_offset,
-			  const float heading_accuracy);
+			  const float heading_accuracy, const int32_t noise_per_ms,
+			  const int32_t jamming_indicator, const uint8_t jamming_state,
+			  const uint8_t spoofing_state);
 
 	void handleInjectDataTopic();
 	bool PublishRTCMStream(const uint8_t *data, size_t data_len);

--- a/src/drivers/uavcan/sensors/gnss_relative.cpp
+++ b/src/drivers/uavcan/sensors/gnss_relative.cpp
@@ -1,0 +1,78 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "gnss_relative.hpp"
+
+#include <drivers/drv_hrt.h>
+#include <lib/mathlib/math/Limits.hpp>
+
+const char *const UavcanGnssRelativeBridge::NAME = "gnss_relative";
+
+UavcanGnssRelativeBridge::UavcanGnssRelativeBridge(uavcan::INode &node) :
+	UavcanSensorBridgeBase("uavcan_gnss_relative", ORB_ID(sensor_gnss_relative)),
+	_sub_rel_pos_heading(node)
+{
+}
+
+int
+UavcanGnssRelativeBridge::init()
+{
+	int res = _sub_rel_pos_heading.start(RelPosHeadingCbBinder(this, &UavcanGnssRelativeBridge::rel_pos_heading_sub_cb));
+
+	if (res < 0) {
+		DEVICE_LOG("failed to start uavcan sub: %d", res);
+		return res;
+	}
+
+	return 0;
+}
+
+void UavcanGnssRelativeBridge::rel_pos_heading_sub_cb(const
+		uavcan::ReceivedDataStructure<ardupilot::gnss::RelPosHeading> &msg)
+{
+	sensor_gnss_relative_s sensor_gnss_relative{};
+
+	sensor_gnss_relative.timestamp_sample = uavcan::UtcTime(msg.timestamp).toUSec();
+
+	sensor_gnss_relative.heading_valid = msg.reported_heading_acc_available;
+	sensor_gnss_relative.heading = math::radians(msg.reported_heading_deg);
+	sensor_gnss_relative.heading_accuracy = math::radians(msg.reported_heading_acc_deg);
+	sensor_gnss_relative.position_length = msg.relative_distance_m;
+	sensor_gnss_relative.position[2] = msg.relative_down_pos_m;
+
+	sensor_gnss_relative.device_id = get_device_id();
+
+	sensor_gnss_relative.timestamp = hrt_absolute_time();
+
+	publish(msg.getSrcNodeID().get(), &sensor_gnss_relative);
+}

--- a/src/drivers/uavcan/sensors/gnss_relative.hpp
+++ b/src/drivers/uavcan/sensors/gnss_relative.hpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "sensor_bridge.hpp"
+
+#include <stdint.h>
+
+#include <uORB/topics/sensor_gnss_relative.h>
+
+#include <ardupilot/gnss/RelPosHeading.hpp>
+
+class UavcanGnssRelativeBridge : public UavcanSensorBridgeBase
+{
+public:
+	static const char *const NAME;
+
+	UavcanGnssRelativeBridge(uavcan::INode &node);
+
+	const char *get_name() const override { return NAME; }
+
+	int init() override;
+
+private:
+
+	void rel_pos_heading_sub_cb(const uavcan::ReceivedDataStructure<ardupilot::gnss::RelPosHeading> &msg);
+
+	typedef uavcan::MethodBinder < UavcanGnssRelativeBridge *,
+		void (UavcanGnssRelativeBridge::*)(const uavcan::ReceivedDataStructure<ardupilot::gnss::RelPosHeading> &) >
+		RelPosHeadingCbBinder;
+
+	uavcan::Subscriber<ardupilot::gnss::RelPosHeading, RelPosHeadingCbBinder> _sub_rel_pos_heading;
+
+};

--- a/src/drivers/uavcan/sensors/sensor_bridge.cpp
+++ b/src/drivers/uavcan/sensors/sensor_bridge.cpp
@@ -60,6 +60,9 @@
 #if defined(CONFIG_UAVCAN_SENSOR_GNSS)
 #include "gnss.hpp"
 #endif
+#if defined(CONFIG_UAVCAN_SENSOR_GNSS_RELATIVE)
+#include "gnss_relative.hpp"
+#endif
 #if defined(CONFIG_UAVCAN_SENSOR_HYGROMETER)
 #include "hygrometer.hpp"
 #endif
@@ -143,6 +146,17 @@ void IUavcanSensorBridge::make_all(uavcan::INode &node, List<IUavcanSensorBridge
 
 	if (uavcan_sub_gps != 0) {
 		list.add(new UavcanGnssBridge(node));
+	}
+
+#endif
+
+	// GPS relative
+#if defined(CONFIG_UAVCAN_SENSOR_GNSS_RELATIVE)
+	int32_t uavcan_sub_gps_rel = 1;
+	param_get(param_find("UAVCAN_SUB_GPS_R"), &uavcan_sub_gps_rel);
+
+	if (uavcan_sub_gps_rel != 0) {
+		list.add(new UavcanGnssRelativeBridge(node));
 	}
 
 #endif

--- a/src/drivers/uavcan/uavcan_params.c
+++ b/src/drivers/uavcan/uavcan_params.c
@@ -307,6 +307,18 @@ PARAM_DEFINE_INT32(UAVCAN_SUB_FLOW, 0);
 PARAM_DEFINE_INT32(UAVCAN_SUB_GPS, 1);
 
 /**
+ * subscription GPS Relative
+ *
+ * Enable UAVCAN GPS Relative subscription.
+ * ardupilot::gnss::RelPosHeading
+ *
+ * @boolean
+ * @reboot_required true
+ * @group UAVCAN
+ */
+PARAM_DEFINE_INT32(UAVCAN_SUB_GPS_R, 1);
+
+/**
  * subscription hygrometer
  *
  * Enable UAVCAN hygrometer subscriptions.

--- a/src/drivers/uavcannode/Publishers/GnssFix2.hpp
+++ b/src/drivers/uavcannode/Publishers/GnssFix2.hpp
@@ -127,6 +127,11 @@ public:
 			ecefpositionvelocity.velocity_xyz[1] = NAN;
 			ecefpositionvelocity.velocity_xyz[2] = NAN;
 
+			// Use ecef_position_velocity for now... There are no fields for these
+			ecefpositionvelocity.position_xyz_mm[0] = gps.noise_per_ms;
+			ecefpositionvelocity.position_xyz_mm[1] = gps.jamming_indicator;
+			ecefpositionvelocity.position_xyz_mm[2] = (gps.jamming_state << 8) | gps.spoofing_state;
+
 			// Use ecef_position_velocity for now... There is no heading field
 			if (!std::isnan(gps.heading)) {
 				ecefpositionvelocity.velocity_xyz[0] = gps.heading;
@@ -138,9 +143,9 @@ public:
 				if (!std::isnan(gps.heading_accuracy)) {
 					ecefpositionvelocity.velocity_xyz[2] = gps.heading_accuracy;
 				}
-
-				fix2.ecef_position_velocity.push_back(ecefpositionvelocity);
 			}
+
+			fix2.ecef_position_velocity.push_back(ecefpositionvelocity);
 
 			uavcan::Publisher<uavcan::equipment::gnss::Fix2>::broadcast(fix2);
 


### PR DESCRIPTION
This PR hacks noise, jamming, and spoofing data into the dronecan gps fix2 message. This has been a big complaint about CAN GPS not providing this info. We were already using ecef_position_velocity for heading over the past two years. 

ARK Jetson, ARKV6X, ARK GPS
https://review.px4.io/plot_app?log=4cd6e706-4e15-42ee-aedd-95f5792fa944

Moving base setup with heading.
https://review.px4.io/plot_app?log=dd1198a5-d0ef-48ce-a361-ca0dfe8edd9c - sensor_gnns_relative heading is in degrees
https://review.px4.io/plot_app?log=de32ab72-e175-4ea4-8d6b-a76fae956b7e