### PR TITLE
fix compiling on ros2 platform

### DIFF
--- a/platforms/common/CMakeLists.txt
+++ b/platforms/common/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 set(SRCS)
 
-if(NOT "${PX4_PLATFORM}" MATCHES "qurt" AND NOT "${PX4_BOARD}" MATCHES "io-v2" AND NOT "${PX4_BOARD_LABEL}" MATCHES "bootloader")
+if(NOT "${PX4_PLATFORM}" MATCHES "qurt" AND NOT "${PX4_PLATFORM}" MATCHES "ros2" AND NOT "${PX4_BOARD}" MATCHES "io-v2" AND NOT "${PX4_BOARD_LABEL}" MATCHES "bootloader")
 	list(APPEND SRCS
 		px4_log.cpp
 		px4_log_history.cpp

--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -201,4 +201,8 @@ if(${PX4_PLATFORM} STREQUAL "nuttx")
 	target_link_libraries(parameters PRIVATE flashparams)
 endif()
 
+if(${PX4_PLATFORM} STREQUAL "posix" OR ${PX4_PLATFORM} STREQUAL "ros2")
+	target_include_directories(parameters PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../platforms/posix/include/")
+endif()
+
 px4_add_functional_gtest(SRC ParameterTest.cpp LINKLIBS parameters)


### PR DESCRIPTION
### Solved Problem
Fixes the compilation with `CONFIG_PLATFORM_ROS2=y`.

### Solution
Fix/workaround includes.