### PR TITLE
ekf2: reset globlal position uncertainty when GNSS is fused

### DIFF
--- a/src/modules/ekf2/EKF/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/gnss_height_control.cpp
@@ -142,6 +142,7 @@ void Ekf::controlGnssHeightFusion(const gpsSample &gps_sample)
 
 					_information_events.flags.reset_hgt_to_gps = true;
 					resetVerticalPositionTo(-measurement, measurement_var);
+					_gpos_origin_epv = 0.f; // The uncertainty of the global origin is now contained in the local position uncertainty
 					bias_est.reset();
 
 				} else {

--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -248,6 +248,7 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 					// reset position
 					_information_events.flags.reset_pos_to_gps = true;
 					resetHorizontalPositionTo(position, pos_obs_var);
+					_gpos_origin_eph = 0.f; // The uncertainty of the global origin is now contained in the local position uncertainty
 					_aid_src_gnss_pos.time_last_fuse = _time_delayed_us;
 				}
 


### PR DESCRIPTION
There is no reason to keep an uncertainty on the origin as it is then already contained in the local position estimate when GNSS data is fused in the filter.