### PR TITLE
VTOL takeoff: do not change loiter location after VTOL takeoff completed

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -747,7 +747,8 @@ MissionBlock::setLoiterItemFromCurrentPositionSetpoint(struct mission_item_s *it
 	item->lat = pos_sp_triplet->current.lat;
 	item->lon = pos_sp_triplet->current.lon;
 	item->altitude = pos_sp_triplet->current.alt;
-	item->loiter_radius = pos_sp_triplet->current.loiter_radius;
+	item->loiter_radius = pos_sp_triplet->current.loiter_direction_counter_clockwise ?
+			      -pos_sp_triplet->current.loiter_radius : pos_sp_triplet->current.loiter_radius;
 }
 
 void


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When using a VTOL takeoff, a loiter location can be set. when the system reaches the takeoff altitude, it starts loitering at the current position instead of continuing at the loiter location defined in the VTOL takeoff. 

### Solution
- Check in the loiter activation is the current position setpoint is a valid loiter point. If this is true and no reposition is active, set the loiter position to the loiter position item.
- Refactor ...

### Changelog Entry
For release notes:
```
Bugfix VTOL takeoff: do not change loiter location after VTOL takeoff completed.
```
### Test coverage
- Simulation tests: using gazebo-classic_standard_vtol.
  - Check correct loiter location for vtol takeoff.
  - Check correct functionality for hold when currently flying to an orbit/mission orbit
