### PR TITLE
[uxrce_dds_client] add minimal request-reply support

### DIFF
--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -128,4 +128,6 @@ jobs:
       run: |
         git clone https://github.com/PX4/px4_msgs.git
         rm px4_msgs/msg/*.msg
+        rm px4_msgs/srv/*.srv
         cp msg/*.msg px4_msgs/msg/
+        cp srv/*.srv px4_msgs/srv/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,7 +230,9 @@ pipeline {
               sh("git clone https://${GIT_USER}:${GIT_PASS}@github.com/PX4/px4_msgs.git")
               // 'main' branch
               sh('rm -f px4_msgs/msg/*.msg')
+              sh('rm -f px4_msgs/srv/*.srv')
               sh('cp msg/*.msg px4_msgs/msg/')
+              sh('cp srv/*.srv px4_msgs/srv/')
               sh('cd px4_msgs; git status; git add .; git commit -a -m "Update message definitions `date`" || true')
               sh('cd px4_msgs; git push origin main || true')
               sh('rm -rf px4_msgs')

--- a/src/modules/uxrce_dds_client/CMakeLists.txt
+++ b/src/modules/uxrce_dds_client/CMakeLists.txt
@@ -142,6 +142,10 @@ else()
 			${CMAKE_CURRENT_BINARY_DIR}/dds_topics.h
 			uxrce_dds_client.cpp
 			uxrce_dds_client.h
+			vehicle_command_srv.cpp
+			vehicle_command_srv.h
+			srv_base.cpp
+			srv_base.h
 		DEPENDS
 			microxrceddsclient
 			libmicroxrceddsclient

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -79,9 +79,6 @@ subscriptions:
   - topic: /fmu/in/vehicle_visual_odometry
     type: px4_msgs::msg::VehicleOdometry
 
-  - topic: /fmu/in/vehicle_command
-    type: px4_msgs::msg::VehicleCommand
-
   - topic: /fmu/in/vehicle_trajectory_bezier
     type: px4_msgs::msg::VehicleTrajectoryBezier
 

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -2,7 +2,7 @@
 ################################################################################
 #
 # Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
-# Copyright (c) 2018-2021 PX4 Development Team. All rights reserved.
+# Copyright (c) 2018-2023 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/src/modules/uxrce_dds_client/srv_base.cpp
+++ b/src/modules/uxrce_dds_client/srv_base.cpp
@@ -1,0 +1,150 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "srv_base.h"
+
+#include<cstdio>
+//#include "utilities.hpp"
+
+
+#define TOPIC_NAME_SIZE 128
+#define REQUEST_TYPE_SIZE 128
+#define REPLY_TYPE_SIZE 128
+
+static bool generate_request_name(char *request, const char *client_namespace, const char *name)
+{
+	if (client_namespace != nullptr) {
+		int ret = snprintf(request, TOPIC_NAME_SIZE, "rq/%s/fmu/%sRequest", client_namespace, name);
+		return (ret > 0 && ret < TOPIC_NAME_SIZE);
+	}
+
+	int ret = snprintf(request, TOPIC_NAME_SIZE, "rq/fmu/%sRequest", name);
+	return (ret > 0 && ret < TOPIC_NAME_SIZE);
+}
+
+static bool generate_reply_name(char *reply, const char *client_namespace, const char *name)
+{
+	if (client_namespace != nullptr) {
+		int ret = snprintf(reply, TOPIC_NAME_SIZE, "rr/%s/fmu/%sReply", client_namespace, name);
+		return (ret > 0 && ret < TOPIC_NAME_SIZE);
+	}
+
+	int ret = snprintf(reply, TOPIC_NAME_SIZE, "rr/fmu/%sReply", name);
+	return (ret > 0 && ret < TOPIC_NAME_SIZE);
+}
+
+static bool generate_request_type_name(char *request, const char *name)
+{
+	int ret = snprintf(request, REQUEST_TYPE_SIZE, "px4_msgs::srv::dds_::%s_Request_", name);
+	return (ret > 0 && ret < REQUEST_TYPE_SIZE);
+}
+
+static bool generate_reply_type_name(char *reply, const char *name)
+{
+	int ret = snprintf(reply, REPLY_TYPE_SIZE, "px4_msgs::srv::dds_::%s_Response_", name);
+	return (ret > 0 && ret < REPLY_TYPE_SIZE);
+}
+
+SrvBase::SrvBase(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId input_stream_id,
+		 uxrObjectId participant_id) :
+	session_(session),
+	reliable_out_stream_id_(reliable_out_stream_id)
+
+{
+
+}
+
+bool SrvBase::create_replier(uxrStreamId input_stream_id,
+			     uxrObjectId participant_id, uint16_t index, const char *client_namespace, const char *service_name_simple,
+			     const char *service_type_name_simple, uint16_t queue_depth)
+{
+// request and reply names
+	char request_name[TOPIC_NAME_SIZE];
+	char reply_name[TOPIC_NAME_SIZE];
+
+	if (!generate_request_name(request_name, client_namespace, service_name_simple)) {
+		return false;
+	}
+
+	if (!generate_reply_name(reply_name, client_namespace, service_name_simple)) {
+		return false;
+	}
+
+	// request and reply types
+	char request_type_name[REQUEST_TYPE_SIZE];
+	char reply_type_name[REPLY_TYPE_SIZE];
+
+	if (!generate_request_type_name(request_type_name, service_type_name_simple)) {
+		return false;
+	}
+
+	if (!generate_reply_type_name(reply_type_name, service_type_name_simple)) {
+		return false;
+	}
+
+
+	// Use the second half of the available ID space.
+	// Add 1 so that we get a nice hex starting number: 0x800 instead of 0x7ff.
+	uint16_t id = index + (65535U / 32U) + 1;
+
+	replier_id_ = uxr_object_id(id, UXR_REPLIER_ID);
+
+	//char service_name[TOPIC_NAME_SIZE];
+
+	const uxrQoS_t qos = {
+		.durability = UXR_DURABILITY_PERSISTENT,
+		.reliability = UXR_RELIABILITY_RELIABLE,
+		.history = UXR_HISTORY_KEEP_LAST,
+		.depth = 1,
+	};
+
+	uint16_t replier_req = uxr_buffer_create_replier_bin(session_, reliable_out_stream_id_, replier_id_, participant_id,
+			       service_name_simple, request_type_name, reply_type_name, request_name, reply_name, qos, UXR_REPLACE);
+	uint8_t status;
+
+	if (!uxr_run_session_until_all_status(session_, 1000, &replier_req, &status, 1)) {
+		return false;
+	}
+
+
+	// Request  requests
+	uxrDeliveryControl delivery_control = {
+		0
+	};
+	delivery_control.max_samples = UXR_MAX_SAMPLES_UNLIMITED;
+	uint16_t read_data_req =
+		uxr_buffer_request_data(session_, reliable_out_stream_id_, replier_id_, input_stream_id, &delivery_control);
+	(void) read_data_req;
+
+	return true;
+}

--- a/src/modules/uxrce_dds_client/srv_base.h
+++ b/src/modules/uxrce_dds_client/srv_base.h
@@ -1,0 +1,102 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <uxr/client/client.h>
+
+/** @class SrvBase The SrvBase class defines the common properties and methods of a service requester. */
+class SrvBase
+{
+public:
+	/**
+	 * @brief Constructor.
+	 * @param session pointer to the micro xrce-dds session.
+	 * @param reliable_out_stream_id output stream ID.
+	 * @param input_stream_id input stream ID.
+	 * @param participant_id participant ID.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	SrvBase(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId input_stream_id,
+		uxrObjectId participant_id);
+
+	virtual ~SrvBase()
+	{
+
+	};
+
+	/**
+	 * @brief Virtual method that process an incoming request from xrce_dds.
+	 * @param ub Buffer that stores the incoming request message.
+	 * @param time_offset_us time offset between agent and client.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	virtual bool process_request(ucdrBuffer *ub, const int64_t time_offset_us) = 0;
+
+	/**
+	 * @brief Virtual method that process and send a reply.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	virtual bool process_reply() = 0;
+
+	/** @var is_reply_pending_ Flag for pending replies */
+	bool is_reply_pending_;
+
+	/** @var session_ xrce_dds session pointer */
+	uxrSession *session_;
+
+	/** @var reliable_out_stream_id_ output stream */
+	uxrStreamId reliable_out_stream_id_;
+
+	/** @var replier_id_ uxrce_dds replier */
+	uxrObjectId replier_id_;
+
+	/** @var sample_id_ uxrce_dds sample identifier to link request and reply */
+	SampleIdentity sample_id_;
+
+protected:
+	/**
+	 * @brief xrce_dds replier creator.
+	 * @param input_stream_id input stream.
+	 * @param participant_id partecipant id.
+	 * @param index index used to create the replier id.
+	 * @param client_namespace namespace of the client.
+	 * @param service_name_simple name of the service.
+	 * @param service_type_name_simple name of the service type.
+	 * @param queue_depth lenght of the queue.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	bool create_replier(uxrStreamId input_stream_id, uxrObjectId participant_id, uint16_t index,
+			    const char *client_namespace, const char *service_name_simple, const char *service_type_name_simple,
+			    uint16_t queue_depth);
+};

--- a/src/modules/uxrce_dds_client/vehicle_command_srv.cpp
+++ b/src/modules/uxrce_dds_client/vehicle_command_srv.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "vehicle_command_srv.h"
+#include <uORB/ucdr/vehicle_command.h>
+#include <uORB/ucdr/vehicle_command_ack.h>
+
+VehicleCommandSrv::VehicleCommandSrv(uxrSession *session, uxrStreamId reliable_out_stream_id,
+				     uxrStreamId input_stream_id, uxrObjectId participant_id, const char *client_namespace, const uint8_t index) :
+	SrvBase(session, reliable_out_stream_id, input_stream_id, participant_id)
+{
+	uint16_t queue_depth = uORB::DefaultQueueSize<vehicle_command_s>::value *
+			       2; // use a bit larger queue size than internal
+	create_replier(input_stream_id, participant_id, index, client_namespace, "vehicle_command", "VehicleCommand",
+		       queue_depth);
+};
+
+VehicleCommandSrv::~VehicleCommandSrv()
+{
+
+};
+
+bool VehicleCommandSrv::process_request(ucdrBuffer *ub, const int64_t time_offset_us)
+{
+	vehicle_command_s data;
+
+	if (ucdr_deserialize_vehicle_command(*ub, data, time_offset_us)) {
+		vehicle_command_pub_.publish(data);
+		is_reply_pending_ = true;
+		last_command_sent_ = data.command;
+		last_command_sent_timestamp_ = hrt_absolute_time();
+	}
+
+	return 0;
+}
+
+bool VehicleCommandSrv::process_reply()
+{
+	vehicle_command_ack_s cmd_ack;
+
+	if (is_reply_pending_ && vehicle_command_ack_sub_.update(&cmd_ack)) {
+		if (cmd_ack.command == last_command_sent_ && cmd_ack.timestamp > last_command_sent_timestamp_) {
+			last_command_sent_ = 0;
+			is_reply_pending_ = false;
+
+			ucdrBuffer reply_ub;
+			const uint32_t topic_size = ucdr_topic_size_vehicle_command_ack();
+			uint8_t reply_buffer[topic_size] = {
+				0
+
+			};
+			const int64_t time_offset_us = session_->time_offset / 1000; // ns -> us
+			ucdr_init_buffer(&reply_ub, reply_buffer, sizeof(reply_buffer));
+			ucdr_serialize_vehicle_command_ack(&cmd_ack, reply_ub, time_offset_us);
+
+			uxr_buffer_reply(session_, reliable_out_stream_id_, replier_id_, &sample_id_, reply_buffer, sizeof(reply_buffer));
+		}
+	}
+
+	return 0;
+}

--- a/src/modules/uxrce_dds_client/vehicle_command_srv.h
+++ b/src/modules/uxrce_dds_client/vehicle_command_srv.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <uORB/Subscription.hpp>
+#include <uORB/Publication.hpp>
+
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
+
+#include "srv_base.h"
+
+/**
+ * @see SrvBase
+ * @class VehicleCommandSrv The VehicleCommandSrv class implement the VehicleCommand service server.
+ */
+class VehicleCommandSrv : public SrvBase
+{
+private:
+	uORB::Publication<vehicle_command_s> vehicle_command_pub_{ORB_ID(vehicle_command)};
+	uORB::Subscription vehicle_command_ack_sub_{ORB_ID(vehicle_command_ack)};
+	uint32_t last_command_sent_{0};
+	hrt_abstime last_command_sent_timestamp_{0};
+public:
+	/**
+	 * @brief Constructor.
+	 * @see SrvBase.
+	 * @param client_namespace namespace for the client service.
+	 * @param index index used to create the replier id.
+	 * @return Returns false iff successful, otherwise false.
+	 */
+	VehicleCommandSrv(uxrSession *session, uxrStreamId reliable_out_stream_id, uxrStreamId input_stream_id,
+			  uxrObjectId participant_id, const char *client_namespace, const uint8_t index);
+
+	~VehicleCommandSrv();
+
+	/** @see SrvBase */
+	bool process_request(ucdrBuffer *ub, const int64_t time_offset_us);
+
+	/** @see SrvBase */
+	bool process_reply();
+};

--- a/srv/VehicleCommand.srv
+++ b/srv/VehicleCommand.srv
@@ -1,0 +1,3 @@
+VehicleCommand request
+---
+VehicleCommandAck reply


### PR DESCRIPTION
### New Feature
- Add minimal support for requests and replies over micro xrce_dds.
- The service `/fmu/vehicle_command`:
  ```
  VehicleCommand request
  ---
  VehicleCommandAck reply
  ```
  replaces `/fmu/in/vehicle_command` and `fmu/out/vehicle_command_ack`.

### Base services
The virtual class `SrvBase` allows to define new services, each new service must implement its new constructor, the `process_request` method, which is called whenever a new request is received the `process_reply` method, which process and send the reply. `VehicleCommandSrv` gives an example of implementation.

The registration of new services is performed by `UxrceddsClient::add_replier()`, the maximum number of services that can be instantiated is fixed by `MAX_NUM_REPLIERS`.

### How to test
The easiest way to test this PR is in simulation.
The PR requires custom versions `px4_msgs`: https://github.com/PX4/px4_msgs/tree/pr-srv , which defines the new `px4_msgs::srv::Vehicle_Command` service.
Then a modified version of `px4_ros_com`: https://github.com/PX4/px4_ros_com/tree/pr-srv ,  which implements a version of the `offboard_control` node using `px4_msgs::srv::Vehicle_Command`.

### Changelog Entry
For release notes:
- Documentation: need to update documentation of https://docs.px4.io/main/en/middleware/uxrce_dds.html and https://docs.px4.io/main/en/middleware/uxrce_dds.html
- Documentation PR:
