### PR TITLE
flightmodes: flag advanced modes accordingly

### DIFF
--- a/src/lib/modes/standard_modes.hpp
+++ b/src/lib/modes/standard_modes.hpp
@@ -93,5 +93,36 @@ static inline uint8_t getNavStateFromStandardMode(StandardMode mode)
 	return vehicle_status_s::NAVIGATION_STATE_MAX;
 }
 
+/**
+ * @return returns true for advanced modes
+ */
+static inline bool isAdvanced(uint8_t nav_state)
+{
+	switch (nav_state) {
+	case vehicle_status_s::NAVIGATION_STATE_ALTCTL: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_POSCTL: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL1: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL2: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL3: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL4: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL5: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL6: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL7: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL8: return false;
+
+	}
+
+	return true;
+}
+
 
 } // namespace mode_util

--- a/src/lib/modes/standard_modes.hpp
+++ b/src/lib/modes/standard_modes.hpp
@@ -93,36 +93,5 @@ static inline uint8_t getNavStateFromStandardMode(StandardMode mode)
 	return vehicle_status_s::NAVIGATION_STATE_MAX;
 }
 
-/**
- * @return returns true for advanced modes
- */
-static inline bool isAdvanced(uint8_t nav_state)
-{
-	switch (nav_state) {
-	case vehicle_status_s::NAVIGATION_STATE_ALTCTL: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_POSCTL: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL1: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL2: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL3: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL4: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL5: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL6: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL7: return false;
-
-	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL8: return false;
-
-	}
-
-	return true;
-}
-
 
 } // namespace mode_util

--- a/src/lib/modes/ui.hpp
+++ b/src/lib/modes/ui.hpp
@@ -99,4 +99,35 @@ const char *const nav_state_names[vehicle_status_s::NAVIGATION_STATE_MAX] = {
 	"External 8",
 };
 
+/**
+ * @return returns true for advanced modes
+ */
+static inline bool isAdvanced(uint8_t nav_state)
+{
+	switch (nav_state) {
+	case vehicle_status_s::NAVIGATION_STATE_ALTCTL: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_POSCTL: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL1: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL2: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL3: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL4: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL5: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL6: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL7: return false;
+
+	case vehicle_status_s::NAVIGATION_STATE_EXTERNAL8: return false;
+
+	}
+
+	return true;
+}
+
 } // namespace mode_util

--- a/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
+++ b/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
@@ -89,7 +89,7 @@ private:
 		available_modes.standard_mode = (uint8_t)mode_util::getStandardModeFromNavState(nav_state);
 
 		if (mode_util::isAdvanced(nav_state)) {
-			available_modes.properties = MAV_MODE_PROPERTY_ADVANCED;
+			available_modes.properties |= MAV_MODE_PROPERTY_ADVANCED;
 		}
 
 		if (available_modes.standard_mode == MAV_STANDARD_MODE_NON_STANDARD) {

--- a/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
+++ b/src/modules/mavlink/streams/AVAILABLE_MODES.hpp
@@ -88,6 +88,10 @@ private:
 		// Set the mode name if not a standard mode
 		available_modes.standard_mode = (uint8_t)mode_util::getStandardModeFromNavState(nav_state);
 
+		if (mode_util::isAdvanced(nav_state)) {
+			available_modes.properties = MAV_MODE_PROPERTY_ADVANCED;
+		}
+
 		if (available_modes.standard_mode == MAV_STANDARD_MODE_NON_STANDARD) {
 			static_assert(sizeof(available_modes.mode_name) >= sizeof(ExternalModeName::name), "mode name too short");
 


### PR DESCRIPTION
### Solved Problem
adds the MAV_MODE_PROPERTY_ADVANCED property to any flight mode that is not Altitude, Position, or external
