### PR TITLE
ver: Add VER_GIT_DIFF option to print changes to config and files on startup

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -40,6 +40,35 @@ message(STATUS "ROMFS: ${romfs_path_relative}")
 set_property(GLOBAL PROPERTY PX4_ROMFS_FILES)
 set_property(GLOBAL PROPERTY PX4_ROMFS_CMAKE_FILES)
 
+
+if(CONFIG_VER_GIT_DIFF)
+	set(OPTIONAL_EXTRA_DIFF)
+	# Generate list of modified files
+	execute_process(COMMAND git status -uno --porcelain
+			WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+			OUTPUT_FILE ${PX4_BINARY_DIR}/modified_files )
+	file (SIZE ${PX4_BINARY_DIR}/modified_files modified_files_size)
+	if(${modified_files_size} GREATER 0)
+		list(APPEND OPTIONAL_EXTRA_DIFF ${PX4_BINARY_DIR}/modified_files)
+	endif()
+	execute_process(COMMAND bash "-c" "git diff -U0 ${PX4_CONFIG_FILE} | grep ^[-+][^-+]"
+			WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+			OUTPUT_FILE ${PX4_BINARY_DIR}/boardconfig_diff )
+	file (SIZE ${PX4_BINARY_DIR}/boardconfig_diff boardconfig_diff_size)
+	if(${boardconfig_diff_size} GREATER 0)
+		list(APPEND OPTIONAL_EXTRA_DIFF ${PX4_BINARY_DIR}/boardconfig_diff)
+	endif()
+	if(CONFIG_PLATFORM_NUTTX)
+		execute_process(COMMAND bash "-c" "git diff -U0 ${NUTTX_DEFCONFIG} | grep ^[-+][^-+]"
+				WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+				OUTPUT_FILE ${PX4_BINARY_DIR}/nuttx_diff )
+		file (SIZE ${PX4_BINARY_DIR}/nuttx_diff nuttx_diff_size)
+		if(${nuttx_diff_size} GREATER 0)
+			list(APPEND OPTIONAL_EXTRA_DIFF ${PX4_BINARY_DIR}/nuttx_diff)
+		endif()
+	endif()
+endif()
+
 #=============================================================================
 #
 #	px4_add_romfs_files
@@ -246,6 +275,33 @@ foreach(board_extra_file ${OPTIONAL_BOARD_EXTRAS})
 	endif()
 
 endforeach()
+
+foreach(diff_extra_file ${OPTIONAL_EXTRA_DIFF})
+
+	if(EXISTS "${diff_extra_file}")
+		file(RELATIVE_PATH diff_extra_file_name ${PX4_BINARY_DIR} ${diff_extra_file})
+		file(RELATIVE_PATH diff_extra_file_relative_source ${PX4_SOURCE_DIR} ${diff_extra_file})
+		message(STATUS "ROMFS:  Adding ${diff_extra_file_relative_source} -> /etc/extras/${diff_extra_file_name}")
+
+		add_custom_command(
+			OUTPUT
+				${romfs_gen_root_dir}/extras/${diff_extra_file_name}
+				${diff_extra_file_name}.stamp
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${diff_extra_file} ${romfs_gen_root_dir}/extras/${diff_extra_file_name}
+			COMMAND ${CMAKE_COMMAND} -E touch ${diff_extra_file_name}.stamp
+			DEPENDS
+				${diff_extra_file}
+				romfs_copy.stamp
+			COMMENT "ROMFS: copying ${diff_extra_file}"
+		)
+
+		list(APPEND extras_dependencies
+			${diff_extra_file_name}.stamp
+		)
+	endif()
+
+endforeach()
+
 
 
 

--- a/src/systemcmds/ver/Kconfig
+++ b/src/systemcmds/ver/Kconfig
@@ -4,6 +4,15 @@ menuconfig SYSTEMCMDS_VER
 	---help---
 		Enable support for ver
 
+if SYSTEMCMDS_VER
+    config VER_GIT_DIFF
+        bool "Include Git diff"
+        default n
+        depends on SYSTEMCMDS_VER
+        help
+            Generate diff for config and list modified files in firmware.
+endif #SYSTEMCMDS_VER
+
 menuconfig USER_VER
 	bool "ver running as userspace module"
 	default n

--- a/src/systemcmds/ver/ver.cpp
+++ b/src/systemcmds/ver/ver.cpp
@@ -210,6 +210,61 @@ extern "C" __EXPORT int ver_main(int argc, char *argv[])
 					PX4_INFO_RAW("OS git-hash: %s\n", os_git_hash);
 				}
 
+#ifdef CONFIG_VER_GIT_DIFF
+				FILE *file;
+				char buf[64];
+				size_t nread;
+
+				file  = fopen("/etc/extras/modified_files", "r");
+
+				if (file) {
+					PX4_INFO_RAW("MODIFIED BUILD !!!\n");
+
+					while ((nread = fread(buf, 1, sizeof buf, file)) > 0) {
+						PX4_INFO_RAW("%.*s", nread, buf);
+					}
+
+					if (ferror(file)) {
+						/* deal with error */
+					}
+
+					fclose(file);
+				}
+
+				file  = fopen("/etc/extras/boardconfig_diff", "r");
+
+				if (file) {
+					PX4_INFO_RAW("Boardconfig diff\n");
+
+					while ((nread = fread(buf, 1, sizeof buf, file)) > 0) {
+						PX4_INFO_RAW("%.*s", nread, buf);
+					}
+
+					if (ferror(file)) {
+						/* deal with error */
+					}
+
+					fclose(file);
+				}
+
+				file  = fopen("/etc/extras/nuttx_diff", "r");
+
+				if (file) {
+					PX4_INFO_RAW("NuttX diff\n");
+
+					while ((nread = fread(buf, 1, sizeof buf, file)) > 0) {
+						PX4_INFO_RAW("%.*s", nread, buf);
+					}
+
+					if (ferror(file)) {
+						/* deal with error */
+					}
+
+					fclose(file);
+				}
+
+#endif
+
 				ret = 0;
 
 			}


### PR DESCRIPTION
Adds VER_GIT_DIFF config to the ver command.
When enabled it will indicate if the build is dirty and shows a list of modified files.
Furthermore if the PX4 or NuttX configuration has changed it includes the changes as well.

This is useful since it will be incorporated in the px4 logs, so for analysis we know if the build was clean or not. And what changes there are. 

By default it's disabled due to its flash impact, targets with enough flash can utilize this functionality.


### Alternatives
Incorporate dirty tag in PX4 git-hash
Also compression could be considered to limit flash impact.

### Test coverage
px4_v6x-rt

### Context
```
HW arch: PX4_FMU_V6XRT
HW type: V6XRT000000
HW version: 0x000
HW revision: 0x000
PX4 git-hash: 44a219a9ef7994571b957cf83c2a3bb728d3ec7a
PX4 version: 1.15.0 0 (17760256)
PX4 git-branch: pr-px4_fmu-v6xrt
OS: NuttX
OS version: Release 12.2.1 (201458175)
OS git-hash: 796461da1301cf576687b11d03c21eda20dff0b7
MODIFIED BUILD !!!
M ROMFS/CMakeLists.txt
M boards/px4/fmu-v6xrt/default.px4board
M boards/px4/fmu-v6xrt/extras/px4_fmu-v6xrt_bootloader.bin
M boards/px4/fmu-v6xrt/nuttx-config/nsh/defconfig
M src/lib/crypto/monocypher
M src/systemcmds/ver/Kconfig
M src/systemcmds/ver/ver.cpp
Boardconfig diff
+CONFIG_VER_GIT_DIFF=y
NuttX diff
+# CONFIG_NDEBUG is not set
-CONFIG_DEBUG_ASSERTIONS=y
-CONFIG_ETH0_PHY_LAN8742A=y
+CONFIG_ETH0_PHY_TJA1103=y

```
