### PR TITLE
Disarm if battery failure is detected during spool-up

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -447,7 +447,15 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 	// Battery
 	CHECK_FAILSAFE(status_flags, battery_low_remaining_time,
 		       ActionOptions(Action::RTL).causedBy(Cause::BatteryLow).clearOn(ClearCondition::OnModeChangeOrDisarm));
-	CHECK_FAILSAFE(status_flags, battery_unhealthy, Action::Warn);
+
+	if ((_armed_time != 0)
+	    && (time_us < _armed_time + static_cast<hrt_abstime>(_param_com_spoolup_time.get() * 1_s))
+	   ) {
+		CHECK_FAILSAFE(status_flags, battery_unhealthy, ActionOptions(Action::Disarm).cannotBeDeferred());
+
+	} else {
+		CHECK_FAILSAFE(status_flags, battery_unhealthy, Action::Warn);
+	}
 
 	switch (status_flags.battery_warning) {
 	case battery_status_s::BATTERY_WARNING_LOW:


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Some batteries issues can only be seen after arming. If a failure occurs between arming and takeoff, it's safer to disarm immediately.

### Changelog Entry
For release notes:
```
Disarm if battery failure is detected during spool-up
New parameter: -
Documentation: -
```
