### PR TITLE
Report battery over voltage

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -166,6 +166,7 @@ battery_status_s Battery::getBatteryStatus()
 	battery_status.id = static_cast<uint8_t>(_index);
 	battery_status.warning = _warning;
 	battery_status.timestamp = hrt_absolute_time();
+	battery_status.faults = determineFaults();
 	return battery_status;
 }
 
@@ -265,6 +266,19 @@ uint8_t Battery::determineWarning(float state_of_charge)
 	} else {
 		return battery_status_s::BATTERY_WARNING_NONE;
 	}
+}
+
+uint16_t Battery::determineFaults()
+{
+	uint16_t faults{0};
+
+	if ((_params.n_cells > 0)
+	    && (_voltage_v > (_params.n_cells * _params.v_charged * 1.05f))) {
+		// Reported as a "spike" since "over-voltage" does not exist in MAV_BATTERY_FAULT
+		faults |= (1 << battery_status_s::BATTERY_FAULT_SPIKES);
+	}
+
+	return faults;
 }
 
 void Battery::computeScale()

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -150,6 +150,7 @@ private:
 	float calculateStateOfChargeVoltageBased(const float voltage_v, const float current_a);
 	void estimateStateOfCharge();
 	uint8_t determineWarning(float state_of_charge);
+	uint16_t determineFaults();
 	void computeScale();
 	float computeRemainingTime(float current_a);
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

Simple check to detect and report a battery over-voltage based on the cells count. This is helpful when the operator puts a battery with a higher number of cells than configured.