### PR TITLE
TECS controller: do not adapt the airspeed setpoint in case of underspeed.

### DIFF
--- a/msg/TecsStatus.msg
+++ b/msg/TecsStatus.msg
@@ -26,4 +26,4 @@ float32 throttle_sp			# Current throttle setpoint [-]
 float32 pitch_sp_rad			# Current pitch setpoint [rad]
 float32 throttle_trim			# estimated throttle value [0,1] required to fly level at equivalent_airspeed_sp in the current atmospheric conditions
 
-bool underspeed_mode_enabled		# System has detected a low airspeed and takes measures to avoid stalling the plane
+float32 underspeed_ratio		# 0: no underspeed, 1: maximal underspeed. Controller takes measures to avoid stall proportional to ratio if >0.

--- a/msg/TecsStatus.msg
+++ b/msg/TecsStatus.msg
@@ -26,7 +26,4 @@ float32 throttle_sp			# Current throttle setpoint [-]
 float32 pitch_sp_rad			# Current pitch setpoint [rad]
 float32 throttle_trim			# estimated throttle value [0,1] required to fly level at equivalent_airspeed_sp in the current atmospheric conditions
 
-# TECS mode
-uint8 mode
-uint8 TECS_MODE_NORMAL = 0
-uint8 TECS_MODE_UNDERSPEED = 1
+bool underspeed_mode_enabled		# System has detected a low airspeed and takes measures to avoid stalling the plane

--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -649,7 +649,6 @@ void TECS::initialize(const float altitude, const float altitude_rate, const flo
 
 	_control.initialize(control_setpoint, control_input, _control_param, _control_flag);
 
-	_debug_status.tecs_mode = _tecs_mode;
 	_debug_status.control = _control.getDebugOutput();
 	_debug_status.true_airspeed_filtered = eas_to_tas * _airspeed_filter.getState().speed;
 	_debug_status.true_airspeed_derivative = eas_to_tas * _airspeed_filter.getState().speed_rate;
@@ -721,17 +720,6 @@ void TECS::update(float pitch, float altitude, float hgt_setpoint, float EAS_set
 		// Update time stamps
 		_update_timestamp = now;
 
-
-		// Set TECS mode for next frame
-		if (_control.getRatioUndersped() > FLT_EPSILON) {
-			_tecs_mode = ECL_TECS_MODE_UNDERSPEED;
-
-		} else {
-			// This is the default operation mode
-			_tecs_mode = ECL_TECS_MODE_NORMAL;
-		}
-
-		_debug_status.tecs_mode = _tecs_mode;
 		_debug_status.control = _control.getDebugOutput();
 		_debug_status.true_airspeed_filtered = eas_to_tas * eas.speed;
 		_debug_status.true_airspeed_derivative = eas_to_tas * eas.speed_rate;

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -614,7 +614,6 @@ public:
 	void set_altitude_rate_ff(float altitude_rate_ff) { _control_param.altitude_setpoint_gain_ff = altitude_rate_ff; };
 	void set_altitude_error_time_constant(float time_const) { _control_param.altitude_error_gain = 1.0f / math::max(time_const, 0.1f);; };
 
-	void set_equivalent_airspeed_max(float airspeed) { _equivalent_airspeed_max = airspeed; }
 	void set_equivalent_airspeed_min(float airspeed) { _equivalent_airspeed_min = airspeed; }
 	void set_equivalent_airspeed_trim(float airspeed) { _control_param.equivalent_airspeed_trim = airspeed; _airspeed_filter_param.equivalent_airspeed_trim = airspeed; }
 
@@ -665,7 +664,6 @@ private:
 	hrt_abstime _update_timestamp{0};				///< last timestamp of the update function call.
 
 	float _equivalent_airspeed_min{3.0f};				///< equivalent airspeed demand lower limit (m/sec)
-	float _equivalent_airspeed_max{30.0f};				///< equivalent airspeed demand upper limit (m/sec)
 
 	static constexpr float DT_MIN = 0.001f;				///< minimum allowed value of _dt (sec)
 	static constexpr float DT_MAX = 1.0f;				///< max value of _dt allowed before a filter state reset is performed (sec)
@@ -723,10 +721,5 @@ private:
 		.airspeed_enabled = false,
 		.detect_underspeed_enabled = false,
 	};
-
-	/**
-	 * Update the desired airspeed
-	 */
-	float _update_speed_setpoint(const float tas_min, const float tas_max, const float tas_setpoint, const float tas);
 };
 

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -539,11 +539,6 @@ private:
 class TECS
 {
 public:
-	enum ECL_TECS_MODE {
-		ECL_TECS_MODE_NORMAL = 0,
-		ECL_TECS_MODE_UNDERSPEED
-	};
-
 	struct DebugOutput {
 		TECSControl::DebugOutput control;
 		float true_airspeed_filtered;
@@ -551,7 +546,6 @@ public:
 		float altitude_reference;
 		float height_rate_reference;
 		float height_rate_direct;
-		enum ECL_TECS_MODE tecs_mode;
 	};
 public:
 	TECS() = default;
@@ -652,14 +646,12 @@ public:
 	float get_throttle_setpoint() {return _control.getThrottleSetpoint();}
 
 	uint64_t timestamp() { return _update_timestamp; }
-	ECL_TECS_MODE tecs_mode() { return _tecs_mode; }
+	bool underspeed_detected() { return _control.getRatioUndersped() > 0.f; }
 
 private:
 	TECSControl 			_control;			///< Control submodule.
 	TECSAirspeedFilter 		_airspeed_filter;		///< Airspeed filter submodule.
 	TECSAltitudeReferenceModel 	_altitude_reference_model;	///< Setpoint reference model submodule.
-
-	enum ECL_TECS_MODE _tecs_mode {ECL_TECS_MODE_NORMAL};		///< Current activated mode.
 
 	hrt_abstime _update_timestamp{0};				///< last timestamp of the update function call.
 

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -646,7 +646,7 @@ public:
 	float get_throttle_setpoint() {return _control.getThrottleSetpoint();}
 
 	uint64_t timestamp() { return _update_timestamp; }
-	bool underspeed_detected() { return _control.getRatioUndersped() > 0.f; }
+	float get_underspeed_ratio() { return _control.getRatioUndersped(); }
 
 private:
 	TECSControl 			_control;			///< Control submodule.

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -485,16 +485,6 @@ FixedwingPositionControl::tecs_status_publish(float alt_sp, float equivalent_air
 
 	const TECS::DebugOutput &debug_output{_tecs.getStatus()};
 
-	switch (_tecs.tecs_mode()) {
-	case TECS::ECL_TECS_MODE_NORMAL:
-		tecs_status.mode = tecs_status_s::TECS_MODE_NORMAL;
-		break;
-
-	case TECS::ECL_TECS_MODE_UNDERSPEED:
-		tecs_status.mode = tecs_status_s::TECS_MODE_UNDERSPEED;
-		break;
-	}
-
 	tecs_status.altitude_sp = alt_sp;
 	tecs_status.altitude_reference = debug_output.altitude_reference;
 	tecs_status.height_rate_reference = debug_output.height_rate_reference;
@@ -516,6 +506,7 @@ FixedwingPositionControl::tecs_status_publish(float alt_sp, float equivalent_air
 	tecs_status.throttle_sp = _tecs.get_throttle_setpoint();
 	tecs_status.pitch_sp_rad = _tecs.get_pitch_setpoint();
 	tecs_status.throttle_trim = throttle_trim;
+	tecs_status.underspeed_mode_enabled = _tecs.underspeed_detected();
 
 	tecs_status.timestamp = hrt_absolute_time();
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -132,7 +132,6 @@ FixedwingPositionControl::parameters_update()
 	_tecs.set_speed_weight(_param_fw_t_spdweight.get());
 	_tecs.set_equivalent_airspeed_trim(_param_fw_airspd_trim.get());
 	_tecs.set_equivalent_airspeed_min(_param_fw_airspd_min.get());
-	_tecs.set_equivalent_airspeed_max(_param_fw_airspd_max.get());
 	_tecs.set_throttle_damp(_param_fw_t_thr_damp.get());
 	_tecs.set_integrator_gain_throttle(_param_fw_t_I_gain_thr.get());
 	_tecs.set_integrator_gain_pitch(_param_fw_t_I_gain_pit.get());
@@ -1210,7 +1209,7 @@ FixedwingPositionControl::control_auto_velocity(const float control_interval, co
 				   tecs_fw_thr_max,
 				   _param_sinkrate_target.get(),
 				   _param_climbrate_target.get(),
-				   tecs_status_s::TECS_MODE_NORMAL,
+				   false,
 				   pos_sp_curr.vz);
 }
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -506,7 +506,7 @@ FixedwingPositionControl::tecs_status_publish(float alt_sp, float equivalent_air
 	tecs_status.throttle_sp = _tecs.get_throttle_setpoint();
 	tecs_status.pitch_sp_rad = _tecs.get_pitch_setpoint();
 	tecs_status.throttle_trim = throttle_trim;
-	tecs_status.underspeed_mode_enabled = _tecs.underspeed_detected();
+	tecs_status.underspeed_ratio = _tecs.get_underspeed_ratio();
 
 	tecs_status.timestamp = hrt_absolute_time();
 


### PR DESCRIPTION
### Solved Problem
The underspeed logic inside TECS overwrites the incoming airspeed setpoint and sets that one to FW_AIRSPD_MIN. That way, in case an underspeed is detected, the airspeed setpoint it then applies may not even be enough to not stall (there is no bank angle or high wind compensation in that case). 

### Solution
Remove the airspeed setpoint adaption in case of underspeed. 

It now does the following in the underspeed state:
- set the speed weight to 2 (foll prio on airpseed and not height rate error)
- set throttle to FW_THR_MAX (it is debatable if that is needed and beneficial or if simply setting the speed weight is enough)

Beside that I took the opportunity and changed the `TECS_MODE` enum into a boolean `underspeed_mode_enabled`. That's more descriptive and cleaner in my view.

### Changelog Entry
For release notes:
```
Improvement: Fixed-wing TECS controller: do not adapt the airspeed setpoint in case of underspeed.
```

### Alternatives
Move the logic around the detection and taking action for an underspeed event to the FW position controller (instead of inside TECS). Would need to change the interfaces then slightly (likely feed in the underspeed ratio).

### Test coverage
SITL tested.

