### PR TITLE
nuttx: fix <new>

### DIFF
--- a/platforms/nuttx/NuttX/include/cxx/new
+++ b/platforms/nuttx/NuttX/include/cxx/new
@@ -31,6 +31,8 @@
  *
  ****************************************************************************/
 
+#include <cstddef>
+
 inline void* operator new  (std::size_t, void* ptr) { return ptr; }
 inline void* operator new[](std::size_t, void* ptr) { return ptr; }
 inline void  operator delete  (void*, void*) {}


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When adding a new third-party library to our project ([HFSM2](https://github.com/andrew-gresyk/HFSM2), FWIW), I found that there were compilation issues with **platforms/nuttx/NuttX/include/cxx/new**:

```
/home/robbie/px4/platforms/nuttx/NuttX/include/cxx/new:34:34: error: declaration of 'operator new' as non-function
   34 | inline void* operator new  (std::size_t, void* ptr) { return ptr; }
      |                                  ^~~~~~
```
Despite the warning from the compiler, the error in my IDE (VSCode) reported that "namespace 'std' has no member 'size_t'"

I found that the compilation error went away when I included the library header later in my code, suggesting that something in the include chain could fix the error

### Solution
- Explicitly `#include <cstddef>` in platforms/nuttx/NuttX/include/cxx/new

