### PR TITLE
ekf2: Make sensor_range_finder stuck detector optional

### DIFF
--- a/src/modules/ekf2/EKF/sensor_range_finder.cpp
+++ b/src/modules/ekf2/EKF/sensor_range_finder.cpp
@@ -114,6 +114,12 @@ inline bool SensorRangeFinder::isDataInRange() const
 
 void SensorRangeFinder::updateStuckCheck()
 {
+	if(!isStuckDetectorEnabled()){
+		// Stuck detector disabled
+		_is_stuck = false;
+		return;
+	}
+
 	// Check for "stuck" range finder measurements when range was not valid for certain period
 	// This handles a failure mode observed with some lidar sensors
 	if (((_sample.time_us - _time_last_valid_us) > (uint64_t)10e6)) {

--- a/src/modules/ekf2/EKF/sensor_range_finder.hpp
+++ b/src/modules/ekf2/EKF/sensor_range_finder.hpp
@@ -60,6 +60,7 @@ public:
 	bool isDataHealthy() const override { return _is_sample_ready && _is_sample_valid; }
 	bool isDataReady() const { return _is_sample_ready; }
 	bool isRegularlySendingData() const override { return _is_regularly_sending_data; }
+	bool isStuckDetectorEnabled() const { return _stuck_threshold > 0.f; }
 
 	void setSample(const rangeSample &sample)
 	{
@@ -131,7 +132,7 @@ private:
 	 * Stuck check
 	 */
 	bool _is_stuck{};
-	float _stuck_threshold{0.1f};	///< minimum variation in range finder reading required to declare a range finder 'unstuck' when readings recommence after being out of range (m)
+	float _stuck_threshold{0.1f};	///< minimum variation in range finder reading required to declare a range finder 'unstuck' when readings recommence after being out of range (m), set to zero to disable
 	float _stuck_min_val{};		///< minimum value for new rng measurement when being stuck
 	float _stuck_max_val{};		///< maximum value for new rng measurement when being stuck
 

--- a/src/modules/ekf2/test/test_SensorRangeFinder.cpp
+++ b/src/modules/ekf2/test/test_SensorRangeFinder.cpp
@@ -240,8 +240,16 @@ TEST_F(SensorRangeFinderTest, rangeStuck)
 
 	// THEN: the data should be marked as unhealthy
 	// because the sensor is "stuck"
-	EXPECT_FALSE(_range_finder.isDataHealthy());
-	EXPECT_FALSE(_range_finder.isHealthy());
+	if (_range_finder.isStuckDetectorEnabled()) {
+		EXPECT_FALSE(_range_finder.isDataHealthy());
+		EXPECT_FALSE(_range_finder.isHealthy());
+
+	} else {
+		// If stuck detector is disabled then the
+		// data should instantly be marked as healthy
+		EXPECT_TRUE(_range_finder.isDataHealthy());
+		EXPECT_TRUE(_range_finder.isHealthy());
+	}
 
 	// BUT WHEN: we continue to send samples but with changing distance
 	for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
### Solved Problem
The stuck detector in the `sensor_range_finder` is not relevant for our sensor and causes a short delay before the sensor becomes healthy again after pointing at something it cannot detect for a while.

### Solution
This PR makes the stuck detector optional by explicitly checking whether `_stuck_threshold` is 0 and then always setting _is_stuck = false.

With this PR the stuck detector can be disabled by setting `_stuck_threshold = 0.f`
https://github.com/scoutdi/PX4-PX4-Autopilot/blob/97ca7b9b215f55dd7d27463062cd1ec958f20cac/src/modules/ekf2/EKF/sensor_range_finder.hpp#L135

### Changelog Entry
For release notes:
```
Make sensor_range_finder stuck detector optional
New parameter: N/A
Documentation: Set _stuck_threshold = 0.f to disable.
```

### Alternatives
We could already disable it in practice by setting _stuck_treshold < 0, which would ensure that the following line always is false:
https://github.com/scoutdi/PX4-PX4-Autopilot/blob/97ca7b9b215f55dd7d27463062cd1ec958f20cac/src/modules/ekf2/EKF/sensor_range_finder.cpp#L128

But this would break the tests, and be less clear than with the proposed PR.  

### Test coverage
- Unit/integration test: Tests are updated and still pass. 
- Simulation/hardware testing logs: N/A
