### PR TITLE
PositionSmoothing: fix corner altitude bug

### DIFF
--- a/src/lib/motion_planning/PositionSmoothing.cpp
+++ b/src/lib/motion_planning/PositionSmoothing.cpp
@@ -134,21 +134,20 @@ const Vector3f PositionSmoothing::_getCrossingPoint(const Vector3f &position, co
 	}
 
 	// Get the crossing point using L1-style guidance
-	auto l1_point = _getL1Point(position, waypoints);
-	return {l1_point(0), l1_point(1), target(2)};
+	return _getL1Point(position, waypoints);
 }
 
-const Vector2f PositionSmoothing::_getL1Point(const Vector3f &position, const Vector3f(&waypoints)[3]) const
+const Vector3f PositionSmoothing::_getL1Point(const Vector3f &position, const Vector3f(&waypoints)[3]) const
 {
-	const Vector2f pos_traj(_trajectory[0].getCurrentPosition(),
-				_trajectory[1].getCurrentPosition());
-	const Vector2f u_prev_to_target = Vector2f(waypoints[1] - waypoints[0]).unit_or_zero();
-	const Vector2f prev_to_pos(pos_traj - Vector2f(waypoints[0]));
-	const Vector2f prev_to_closest(u_prev_to_target * (prev_to_pos * u_prev_to_target));
-	const Vector2f closest_pt = Vector2f(waypoints[0]) + prev_to_closest;
+	const Vector3f pos_traj(_trajectory[0].getCurrentPosition(), _trajectory[1].getCurrentPosition(),
+				_trajectory[2].getCurrentPosition());
+	const Vector3f u_prev_to_target = (waypoints[1] - waypoints[0]).unit_or_zero();
+	const Vector3f prev_to_pos(pos_traj - waypoints[0]);
+	const Vector3f prev_to_closest(u_prev_to_target * (prev_to_pos * u_prev_to_target));
+	const Vector3f closest_pt = waypoints[0] + prev_to_closest;
 
 	// Compute along-track error using L1 distance and cross-track error
-	const float crosstrack_error = Vector2f(closest_pt - pos_traj).length();
+	const float crosstrack_error = (closest_pt - pos_traj).length();
 
 	const float l1 = math::max(_target_acceptance_radius, 5.f);
 	float alongtrack_error = 0.f;
@@ -159,9 +158,7 @@ const Vector2f PositionSmoothing::_getL1Point(const Vector3f &position, const Ve
 	}
 
 	// Position of the point on the line where L1 intersect the line between the two waypoints
-	const Vector2f l1_point = closest_pt + alongtrack_error * u_prev_to_target;
-
-	return l1_point;
+	return closest_pt + alongtrack_error * u_prev_to_target;
 }
 
 const Vector3f PositionSmoothing::_generateVelocitySetpoint(const Vector3f &position, const Vector3f(&waypoints)[3],

--- a/src/lib/motion_planning/PositionSmoothing.hpp
+++ b/src/lib/motion_planning/PositionSmoothing.hpp
@@ -438,7 +438,7 @@ private:
 	const Vector3f _generateVelocitySetpoint(const Vector3f &position, const Vector3f(&waypoints)[3],
 			bool is_single_waypoint,
 			const Vector3f &feedforward_velocity_setpoint);
-	const Vector2f _getL1Point(const Vector3f &position, const Vector3f(&waypoints)[3]) const;
+	const Vector3f _getL1Point(const Vector3f &position, const Vector3f(&waypoints)[3]) const;
 	const Vector3f _getCrossingPoint(const Vector3f &position, const Vector3f(&waypoints)[3]) const;
 	float _getMaxXYSpeed(const Vector3f(&waypoints)[3]) const;
 	float _getMaxZSpeed(const Vector3f(&waypoints)[3]) const;


### PR DESCRIPTION
### Solved Problem
We got multiple reports that the altitude profile between two waypoints is not a diagonal line but changes altitude much quicker when leaving the previous waypoint and getting much flatter after that.

During a round corner the L1 distance calculation
was only done in 2D and the z-axis coordinate
was directly coming from the next waypoint.
This lead to an unpredictable altitude profile
between two waypoints. Sometimes almost all
altitude difference was already covered during
the turn instead of going diagonally.

Fixes #{Github issue ID}

### Solution
- Make the entire L1 distance and intersection calculation 3D
- Refactor ...

### Changelog Entry
```
Bugfix: Multicopter altitude change sometimes not linear between two waypoints
```

### Test coverage
Simulation testing procedure:

1. Command to test: `PX4_SIM_SPEED_FACTOR=100 make px4_sitl jmavsim`
1. [Load plan file](https://docs.qgroundcontrol.com/master/en/PlanView/PlanView.html#file) for jMAVsim location through QGC: [rounded_altitude_change.plan](https://github.com/PX4/PX4-Autopilot/files/13283004/rounded_altitude_change.plan.txt)

I still need to verify the 2D only case with no valid altitude works as expected.

### Context
Before: https://logs.px4.io/3d?log=45c8f43e-32e7-4c7f-ab30-975e1c8aa32b
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/d7da8173-9016-48f8-ada5-49fb1e6c2d25)
After: https://logs.px4.io/3d?log=17dd1c3e-bd5e-46b0-abad-3bba6c517e2f
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/e161ac7a-5966-4623-97f1-47192f13683c)

