### PR TITLE
vtol_rtl_test: explicitly disable RTL_FORCE_APPROACH for RTL home test

### DIFF
--- a/test/mavsdk_tests/test_vtol_rtl.cpp
+++ b/test/mavsdk_tests/test_vtol_rtl.cpp
@@ -42,6 +42,7 @@ TEST_CASE("RTL direct Home", "[vtol]")
 	tester.load_qgc_mission_raw_and_move_here("test/mavsdk_tests/vtol_mission_with_land_start.plan");
 	// fly directly to home position
 	tester.set_rtl_type(0);
+	tester.set_rtl_appr_force(0);
 	tester.arm();
 	tester.execute_rtl_when_reaching_mission_sequence(2);
 	tester.wait_until_disarmed(std::chrono::seconds(120));


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solution
- explicitly disable RTL_FORCE_APPROACH for RTL direct Home testcase

### Context
Related links, screenshot before/after, video
