### PR TITLE
Mission feasibility checks with changing home

### DIFF
--- a/msg/HomePosition.msg
+++ b/msg/HomePosition.msg
@@ -17,3 +17,5 @@ bool valid_hpos		# true when the latitude and longitude have been set
 bool valid_lpos		# true when the local position (xyz) has been set
 
 bool manual_home	# true when home position was set manually
+
+uint32 update_count 	# update counter of the home position

--- a/msg/MissionResult.msg
+++ b/msg/MissionResult.msg
@@ -1,9 +1,6 @@
 uint64 timestamp				# time since system start (microseconds)
-uint8 MISSION_EXECUTION_MODE_NORMAL = 0	# Execute the mission according to the planned items
-uint8 MISSION_EXECUTION_MODE_REVERSE = 1	# Execute the mission in reverse order, ignoring commands and converting all waypoints to normal ones
-uint8 MISSION_EXECUTION_MODE_FAST_FORWARD = 2	# Execute the mission as fast as possible, for example converting loiter waypoints to normal ones
 
-uint32 instance_count		# Instance count of this mission. Increments monotonically whenever the mission is modified
+uint16 mission_update_counter   # Counter for the mission for which the result was generated
 
 int32 seq_reached		# Sequence of the mission item which has been reached, default -1
 uint16 seq_current		# Sequence of the current mission item

--- a/msg/MissionResult.msg
+++ b/msg/MissionResult.msg
@@ -1,6 +1,8 @@
 uint64 timestamp				# time since system start (microseconds)
 
 uint16 mission_update_counter   # Counter for the mission for which the result was generated
+uint16 geofence_update_counter  # Counter for the corresponding geofence for which the result was generated (used for mission feasibility)
+uint64 home_position_counter  	# Counter of the home position for which the result was generated (used for mission feasibility)
 
 int32 seq_reached		# Sequence of the mission item which has been reached, default -1
 uint16 seq_current		# Sequence of the current mission item

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1849,19 +1849,19 @@ void Commander::checkForMissionUpdate()
 	if (_mission_result_sub.updated()) {
 		const mission_result_s &mission_result = _mission_result_sub.get();
 
-		const auto prev_mission_instance_count = mission_result.instance_count;
+		const auto prev_mission_mission_update_counter = mission_result.mission_update_counter;
 		_mission_result_sub.update();
 
 		// if mission_result is valid for the current mission
 		const bool mission_result_ok = (mission_result.timestamp > _boot_timestamp)
-					       && (mission_result.instance_count > 0);
+					       && (mission_result.mission_update_counter > 0);
 
 		bool auto_mission_available = mission_result_ok && mission_result.valid;
 
 		if (mission_result_ok) {
 			/* Only evaluate mission state if home is set */
 			if (!_failsafe_flags.home_position_invalid &&
-			    (prev_mission_instance_count != mission_result.instance_count)) {
+			    (prev_mission_mission_update_counter != mission_result.mission_update_counter)) {
 
 				if (!auto_mission_available) {
 					/* the mission is invalid */

--- a/src/modules/commander/HealthAndArmingChecks/checks/missionCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/missionCheck.cpp
@@ -56,6 +56,6 @@ void MissionChecks::checkAndReport(const Context &context, Report &reporter)
 		}
 
 		// This is a mode requirement, no need to report
-		reporter.failsafeFlags().auto_mission_missing = mission_result.instance_count <= 0;
+		reporter.failsafeFlags().auto_mission_missing = mission_result.mission_update_counter <= 0;
 	}
 }

--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -129,6 +129,7 @@ bool HomePosition::setHomePosition(bool force)
 	if (updated) {
 		home.timestamp = hrt_absolute_time();
 		home.manual_home = false;
+		home.update_count = _home_position_pub.get().update_count + 1U;
 		updated = _home_position_pub.update(home);
 	}
 
@@ -193,6 +194,7 @@ void HomePosition::setInAirHomePosition()
 
 			setHomePosValid();
 			home.timestamp = hrt_absolute_time();
+			home.update_count++;
 			_home_position_pub.update();
 
 		} else if (!_failsafe_flags.local_position_invalid && _gps_position_for_home_valid) {
@@ -211,6 +213,7 @@ void HomePosition::setInAirHomePosition()
 
 			setHomePosValid();
 			home.timestamp = hrt_absolute_time();
+			home.update_count++;
 			_home_position_pub.update();
 		}
 
@@ -230,6 +233,7 @@ void HomePosition::setInAirHomePosition()
 			fillLocalHomePos(home, home_x, home_y, home_z, NAN);
 
 			home.timestamp = hrt_absolute_time();
+			home.update_count++;
 			_home_position_pub.update();
 		}
 
@@ -268,6 +272,7 @@ bool HomePosition::setManually(double lat, double lon, float alt, float yaw)
 	home.yaw = yaw;
 
 	home.timestamp = hrt_absolute_time();
+	home.update_count++;
 	_home_position_pub.update();
 	setHomePosValid();
 	return true;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -142,7 +142,6 @@ void MissionBase::onMissionUpdate(bool has_mission_items_changed)
 		// only warn if the check failed on merit
 		if ((!_navigator->get_mission_result()->valid) && _mission.count > 0U) {
 			PX4_WARN("mission check failed");
-			resetMission();
 		}
 	}
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -692,14 +692,14 @@ MissionBase::checkMissionRestart()
 void
 MissionBase::check_mission_valid()
 {
-	if (_navigator->get_mission_result()->instance_count != _mission.mission_update_counter) {
+	if (_navigator->get_mission_result()->mission_update_counter != _mission.mission_update_counter) {
 		MissionFeasibilityChecker missionFeasibilityChecker(_navigator, _dataman_client);
 
 		bool is_mission_valid =
 			missionFeasibilityChecker.checkMissionFeasible(_mission);
 
 		_navigator->get_mission_result()->valid = is_mission_valid;
-		_navigator->get_mission_result()->instance_count = _mission.mission_update_counter;
+		_navigator->get_mission_result()->mission_update_counter = _mission.mission_update_counter;
 		_navigator->get_mission_result()->seq_total = _mission.count;
 		_navigator->get_mission_result()->seq_reached = -1;
 		_navigator->get_mission_result()->failure = false;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -691,17 +691,20 @@ MissionBase::checkMissionRestart()
 void
 MissionBase::check_mission_valid()
 {
-	if (_navigator->get_mission_result()->mission_update_counter != _mission.mission_update_counter) {
-		MissionFeasibilityChecker missionFeasibilityChecker(_navigator, _dataman_client);
+	if ((_navigator->get_mission_result()->mission_update_counter != _mission.mission_update_counter)
+	    || (_navigator->get_mission_result()->geofence_update_counter != _mission.geofence_update_counter)
+	    || (_navigator->get_mission_result()->home_position_counter != _navigator->get_home_position()->update_count)) {
 
-		bool is_mission_valid =
-			missionFeasibilityChecker.checkMissionFeasible(_mission);
-
-		_navigator->get_mission_result()->valid = is_mission_valid;
 		_navigator->get_mission_result()->mission_update_counter = _mission.mission_update_counter;
+		_navigator->get_mission_result()->geofence_update_counter = _mission.geofence_update_counter;
+		_navigator->get_mission_result()->home_position_counter = _navigator->get_home_position()->update_count;
+
+		MissionFeasibilityChecker missionFeasibilityChecker(_navigator, _dataman_client);
+		_navigator->get_mission_result()->valid = missionFeasibilityChecker.checkMissionFeasible(_mission);
 		_navigator->get_mission_result()->seq_total = _mission.count;
 		_navigator->get_mission_result()->seq_reached = -1;
 		_navigator->get_mission_result()->failure = false;
+
 		set_mission_result();
 	}
 }

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -249,7 +249,7 @@ public:
 
 	orb_advert_t *get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
-	int mission_instance_count() const { return _mission_result.instance_count; }
+	int mission_instance_count() const { return _mission_result.mission_update_counter; }
 
 	void set_mission_failure_heading_timeout();
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Misison feasibility was not checked again, if the home position or the geofence changed after it was checked once. Further, if the mission was invalid during upload (e.g. home position not valid yet) the mission is cleared.

Fixes #{Github issue ID}

### Solution
- Remove clearing the mission when the mission is invalid during mission upload.
- Mission feasibility checks also checks if the geofence counter or the home position timestamp has changed since last check.

### Changelog Entry
For release notes:
```
Bugfix: Do not clear invalid mission after upload
Bugfix: Mission feasibility checks also checks if the geofence counter or the home position timestamp has changed since last check
```

### Alternatives
The mission feasibility checks should be moved to another location instead of being performed in the mission mode. They should be moved to the mavlink_mission class where it can be recalculated directly after a mission or geofence is uploaded.


