### PR TITLE
fix: remove L1 deprecated parameter in VTOL simulation

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -76,7 +76,6 @@ param set-default CA_SV_CS1_TRQ_R 0.5
 param set-default CA_SV_CS2_TYPE 3
 param set-default CA_SV_CS2_TRQ_P 1.0
 
-param set-default FW_L1_PERIOD 12
 param set-default FW_PR_FF 0.2
 param set-default FW_PR_P 0.9
 param set-default FW_PSP_OFF 2


### PR DESCRIPTION
### Solved Problem
VTOL simulation was still using the L1 deprecated a warning message was displayed at startup.

### Solution
Just removed the setting of the deprecated parameter in the configuration script for simulated VTOL.