### PR TITLE
MC rate control: let the user set P gain to 1 to use K instead

### DIFF
--- a/src/modules/mc_rate_control/mc_rate_control_params.c
+++ b/src/modules/mc_rate_control/mc_rate_control_params.c
@@ -43,7 +43,7 @@
  * Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.
  *
  * @min 0.01
- * @max 0.5
+ * @max 1.0
  * @decimal 3
  * @increment 0.01
  * @group Multicopter Rate Control
@@ -124,7 +124,7 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_K, 1.0f);
  * Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.
  *
  * @min 0.01
- * @max 0.6
+ * @max 1.0
  * @decimal 3
  * @increment 0.01
  * @group Multicopter Rate Control
@@ -204,7 +204,7 @@ PARAM_DEFINE_FLOAT(MC_PITCHRATE_K, 1.0f);
  * Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.
  *
  * @min 0.0
- * @max 0.6
+ * @max 1.0
  * @decimal 2
  * @increment 0.01
  * @group Multicopter Rate Control


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
To tune the PID controller using the standard/ideal form, one needs to set the P gain to 1.
Fixes https://github.com/PX4/PX4-Autopilot/issues/22170

### Changelog Entry
For release notes:
```
Fix multirotor P gain limit for KID tuning
```