### PR TITLE
ucans32k1: SPLLDIV2 set to 40Mhz

### DIFF
--- a/boards/nxp/ucans32k146/src/clockconfig.c
+++ b/boards/nxp/ucans32k146/src/clockconfig.c
@@ -109,10 +109,10 @@ const struct clock_configuration_s g_initial_clkconfig = {
 		.spll          =
 		{
 			.mode        = SCG_SPLL_MONITOR_DISABLE,         /* SPLLCM */
-			.div1        = SCG_ASYNC_CLOCK_DIV_BY_1,         /* SPLLDIV1 */
-			.div2        = SCG_ASYNC_CLOCK_DIV_BY_2,         /* SPLLDIV2 */
+			.div1        = SCG_ASYNC_CLOCK_DIV_BY_2,         /* SPLLDIV1 160 / 2 = 80Mhz */
+			.div2        = SCG_ASYNC_CLOCK_DIV_BY_4,         /* SPLLDIV2 160 / 4 = 40Mhz */
 			.prediv      = 1,                                /* PREDIV */
-			.mult        = 40,                               /* MULT */
+			.mult        = 40,                               /* MULT 8 / 1 * 40 / 2 = 160Mhz */
 			.src         = 0,                                /* SOURCE */
 			.initialize  = true,                             /* Initialize */
 			.locked      = false,                            /* LK */


### PR DESCRIPTION
As described in the S32K1XX reference manual table 27-1 SPLLDIV2 should be 40Mhz or less.

