### PR TITLE
mavlink_mission: clear rally points with approaches on startup

### DIFF
--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -46,6 +46,7 @@
 #pragma once
 
 #include <dataman_client/DatamanClient.hpp>
+#include <px4_platform_common/module_params.h>
 #include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/mission_result.h>
@@ -74,7 +75,7 @@ static constexpr uint64_t MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT = 250000; ///< P
 
 class Mavlink;
 
-class MavlinkMissionManager
+class MavlinkMissionManager : public ModuleParams
 {
 public:
 	explicit MavlinkMissionManager(Mavlink *mavlink);
@@ -267,4 +268,10 @@ private:
 	 */
 	void copy_params_from_mavlink_to_mission_item(struct mission_item_s *mission_item,
 			const mavlink_mission_item_t *mavlink_mission_item, int8_t start_idx = 1, int8_t end_idx = 7);
+
+	void clear_rally_points_with_approaches();
+
+	DEFINE_PARAMETERS(
+		(ParamBool<px4::params::RP_APPR_CLEAR>)   _param_rally_approach_clear
+	)
 };

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -155,3 +155,13 @@ PARAM_DEFINE_INT32(MAV_HB_FORW_EN, 1);
  * @max 250
  */
 PARAM_DEFINE_INT32(MAV_RADIO_TOUT, 5);
+
+/**
+ * Clear rally points with approaches on startup
+ *
+ * If set to true, all rally points with associated approaches are cleared on startup.
+ *
+ * @boolean
+ * @group Return To Land
+ */
+PARAM_DEFINE_INT32(RP_APPR_CLEAR, 0);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
it can be confusing when rally points with approaches where used on a previous VTOL flight and then a new flight was executed (e.g. on another day) at the same location with a complete mission. Triggering RTL will still fly to the previously stored rally point with approaches although they are not set in this flight. We should make sure the approaches are always set before using them.

Fixes #{Github issue ID}

### Solution
- Clear all rally points with approaches on startup if the corresponding parameter is set.

### Changelog Entry
For release notes:
```
Feature: Clear rally points with approaches on startup
```
