### PR TITLE
drivers: px4io add 'support' command and update rcS logic

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -274,36 +274,38 @@ else
 		. $FCONFIG
 	fi
 
-	# Check if PX4IO present and update firmware if needed.
-	if [ -f $IOFW ]
+	if px4io supported
 	then
-		if ! px4io checkcrc ${IOFW}
+	# Check if PX4IO present and update firmware if needed.
+		if [ -f $IOFW ]
 		then
-			# tune Program PX4IO
-			tune_control play -t 16 # tune 16 = PROG_PX4IO
-
-			if px4io update ${IOFW}
+			if ! px4io checkcrc ${IOFW}
 			then
-				usleep 10000
-				tune_control stop
-				if px4io checkcrc ${IOFW}
+				# tune Program PX4IO
+				tune_control play -t 16 # tune 16 = PROG_PX4IO
+
+				if px4io update ${IOFW}
 				then
-					tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
+					usleep 10000
+					tune_control stop
+					if px4io checkcrc ${IOFW}
+					then
+						tune_control play -t 17 # tune 17 = PROG_PX4IO_OK
+					else
+						tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
+					fi
 				else
-					tune_control play -t 18 # tune 18 = PROG_PX4IO_ERR
+					tune_control stop
 				fi
-			else
-				tune_control stop
+			fi
+
+			if ! px4io start
+			then
+				echo "PX4IO start failed"
+				set STARTUP_TUNE 2 # tune 2 = ERROR_TUNE
 			fi
 		fi
-
-		if ! px4io start
-		then
-			echo "PX4IO start failed"
-			set STARTUP_TUNE 2 # tune 2 = ERROR_TUNE
-		fi
 	fi
-
 
 	#
 	# RC update (map raw RC input to calibrate manual control)

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1556,6 +1556,10 @@ int PX4IO::custom_command(int argc, char *argv[])
 {
 	const char *verb = argv[0];
 
+	if (!strcmp(verb, "supported")) {
+		return 0;
+	}
+
 	if (!strcmp(verb, "checkcrc")) {
 		if (is_running()) {
 			PX4_ERR("io must be stopped");

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1765,7 +1765,7 @@ Output driver communicating with the IO co-processor.
 extern "C" __EXPORT int px4io_main(int argc, char *argv[])
 {
 	if (!PX4_MFT_HW_SUPPORTED(PX4_MFT_PX4IO)) {
-		PX4_ERR("PX4IO Not Supported");
+		PX4_INFO("PX4IO Not Supported");
 		return -1;
 	}
 	return PX4IO::main(argc, argv);


### PR DESCRIPTION
This PR adds a "supported" command to the px4io driver. If its not supported, then rcS won't attempt to update the IO MCU and start it.

Fixes https://github.com/PX4/PX4-Autopilot/issues/22356