### PR TITLE
Optionally disable SF1xx sensor in forward flight

### DIFF
--- a/src/drivers/distance_sensor/lightware_laser_i2c/parameters.c
+++ b/src/drivers/distance_sensor/lightware_laser_i2c/parameters.c
@@ -48,3 +48,15 @@
  * @value 7 SF/LW30/d
  */
 PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);
+
+/**
+ * Lightware SF1xx/SF20/LW20 Operation Mode
+ *
+ * @value 0 Disabled
+ * @value 1 Enabled
+ * @value 2 Disabled during VTOL fast forward flight
+ *
+ * @min 0
+ * @max 2
+ */
+PARAM_DEFINE_INT32(SF1XX_MODE, 1);


### PR DESCRIPTION
Adds a parameter `SF1XX_MODE` that controls if the SF1xx distance sensor will disable automatically in forward flight after a commander transition.

### Test coverage

Tested in hardware via NSH commands `commander transition` and `param set`.

### Context

<details>
<summary>Example Behavior</summary>

```
nsh> lightware_laser_i2c start -X
lightware_laser_i2c #0 on I2C bus 1 (external) address 0x66 rotation 25
nsh> commander transition
INFO  [lightware_laser_i2c] Emission Control: disabling sensor!
nsh> commander transition
INFO  [lightware_laser_i2c] Emission Control: enabling sensor!
nsh> commander transition
INFO  [lightware_laser_i2c] Emission Control: disabling sensor!
nsh> param set SF1XX_MODE 1
+ SF1XX_MODE: curr: 2 -> new: 1
INFO  [lightware_laser_i2c] Emission Control: enabling sensor!
nsh> param set SF1XX_MODE 0
  SF1XX_MODE: curr: 1 -> new: 0
INFO  [lightware_laser_i2c] Emission Control: disabling sensor!
nsh> commander transition
nsh> commander transition
nsh> param set SF1XX_MODE 2
+ SF1XX_MODE: curr: 0 -> new: 2
nsh> commander transition
INFO  [lightware_laser_i2c] Emission Control: enabling sensor!
nsh> param set SF1XX_MODE 0
+ SF1XX_MODE: curr: 2 -> new: 0
INFO  [lightware_laser_i2c] Emission Control: disabling sensor!
nsh> param set SF1XX_MODE 2
+ SF1XX_MODE: curr: 0 -> new: 2
INFO  [lightware_laser_i2c] Emission Control: enabling sensor!
nsh> param set SF1XX_MODE 1
+ SF1XX_MODE: curr: 2 -> new: 1
nsh> commander transition
nsh> param set SF1XX_MODE 1param set SF1XX_MODE 2
  SF1XX_MODE: curr: 1 -> new: 2
INFO  [lightware_laser_i2c] Emission Control: disabling sensor!
nsh> param set SF1XX_MODE 1
+ SF1XX_MODE: curr: 2 -> new: 1
INFO  [lightware_laser_i2c] Emission Control: enabling sensor!
nsh> param set SF1XX_MODE 2
  SF1XX_MODE: curr: 1 -> new: 2
INFO  [lightware_laser_i2c] Emission Control: disabling sensor!
nsh> commander transition
INFO  [lightware_laser_i2c] Emission Control: enabling sensor!
```

</details>

### Changelog Entry

For release notes:
```
Optionally disable SF1xx distance sensor in forward flight.
```