### PR TITLE
EKF2: optical flow refactoring

### DIFF
--- a/msg/VehicleOpticalFlowVel.msg
+++ b/msg/VehicleOpticalFlowVel.msg
@@ -4,14 +4,12 @@ uint64 timestamp_sample                # the timestamp of the raw data (microsec
 float32[2] vel_body                    # velocity obtained from gyro-compensated and distance-scaled optical flow raw measurements in body frame(m/s)
 float32[2] vel_ne                      # same as vel_body but in local frame (m/s)
 
-float32[2] flow_uncompensated_integral # integrated optical flow measurement (rad)
-float32[2] flow_compensated_integral   # integrated optical flow measurement compensated for angular motion (rad)
+float32[2] flow_rate_uncompensated     # integrated optical flow measurement (rad/s)
+float32[2] flow_rate_compensated       # integrated optical flow measurement compensated for angular motion (rad/s)
 
 float32[3] gyro_rate                   # gyro measurement synchronized with flow measurements (rad/s)
-float32[3] gyro_rate_integral          # gyro measurement integrated to flow rate and synchronized with flow measurements (rad)
 
 float32[3] gyro_bias
 float32[3] ref_gyro
-float32[3] meas_gyro
 
 # TOPICS estimator_optical_flow_vel vehicle_optical_flow_vel

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -225,11 +225,10 @@ struct airspeedSample {
 };
 
 struct flowSample {
-	uint64_t    time_us{};     ///< timestamp of the integration period leading edge (uSec)
-	Vector2f    flow_xy_rad{}; ///< measured delta angle of the image about the X and Y body axes (rad), RH rotation is positive
-	Vector3f    gyro_xyz{};    ///< measured delta angle of the inertial frame about the body axes obtained from rate gyro measurements (rad), RH rotation is positive
-	float       dt{};          ///< amount of integration time (sec)
-	uint8_t     quality{};     ///< quality indicator between 0 and 255
+	uint64_t    time_us{};   ///< timestamp of the integration period midpoint (uSec)
+	Vector2f    flow_rate{}; ///< measured angular rate of the image about the X and Y body axes (rad/s), RH rotation is positive
+	Vector3f    gyro_rate{}; ///< measured angular rate of the inertial frame about the body axes obtained from rate gyro measurements (rad/s), RH rotation is positive
+	uint8_t     quality{};   ///< quality indicator between 0 and 255
 };
 
 #if defined(CONFIG_EKF2_EXTERNAL_VISION)

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -120,7 +120,7 @@ public:
 #endif // CONFIG_EKF2_RANGE_FINDER
 
 #if defined(CONFIG_EKF2_OPTICAL_FLOW)
-	// if optical flow sensor gyro delta angles are not available, set gyro_xyz vector fields to NaN and the EKF will use its internal delta angle data instead
+	// if optical flow sensor gyro delta angles are not available, set gyro_rate vector fields to NaN and the EKF will use its internal gyro data instead
 	void setOpticalFlowData(const flowSample &flow);
 
 	// set sensor limitations reported by the optical flow sensor

--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -41,237 +41,118 @@
 void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 {
 	if (_flow_buffer) {
-		// We don't fuse flow data immediately because we have to wait for the mid integration point to fall behind the fusion time horizon.
-		// This means we stop looking for new data until the old data has been fused, unless we are not fusing optical flow,
-		// in this case we need to empty the buffer
-		if (!_flow_data_ready || (!_control_status.flags.opt_flow && !_hagl_sensor_status.flags.flow)) {
-			_flow_data_ready = _flow_buffer->pop_first_older_than(imu_delayed.time_us, &_flow_sample_delayed);
-		}
-	}
-
-	// Check if on ground motion is un-suitable for use of optical flow
-	if (!_control_status.flags.in_air) {
-		updateOnGroundMotionForOpticalFlowChecks();
-
-	} else {
-		resetOnGroundMotionForOpticalFlowChecks();
-	}
-
-	// Accumulate autopilot gyro data across the same time interval as the flow sensor
-	const Vector3f delta_angle(imu_delayed.delta_ang - (getGyroBias() * imu_delayed.delta_ang_dt));
-	if (_delta_time_of < 0.2f) {
-		_imu_del_ang_of += delta_angle;
-		_delta_time_of += imu_delayed.delta_ang_dt;
-
-	} else {
-		// reset the accumulators if the time interval is too large
-		_imu_del_ang_of = delta_angle;
-		_delta_time_of = imu_delayed.delta_ang_dt;
-	}
-
-	if (_flow_data_ready) {
-		int32_t min_quality = _params.flow_qual_min;
-		if (!_control_status.flags.in_air) {
-			min_quality = _params.flow_qual_min_gnd;
-		}
-
-		const bool is_quality_good = (_flow_sample_delayed.quality >= min_quality);
-		const bool is_magnitude_good = !_flow_sample_delayed.flow_xy_rad.longerThan(_flow_sample_delayed.dt * _flow_max_rate);
-		const bool is_tilt_good = (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
-
-		const float delta_time_min = fmaxf(0.7f * _delta_time_of, 0.001f);
-		const float delta_time_max = fminf(1.3f * _delta_time_of, 0.2f);
-		bool is_delta_time_good = _flow_sample_delayed.dt >= delta_time_min && _flow_sample_delayed.dt <= delta_time_max;
-
-		if (!is_delta_time_good && (_flow_sample_delayed.dt > FLT_EPSILON)) {
-
-			if (fabsf(imu_delayed.delta_ang_dt - _flow_sample_delayed.dt) < 0.1f) {
-				// reset accumulators to current IMU
-				_imu_del_ang_of = delta_angle;
-				_delta_time_of = imu_delayed.delta_ang_dt;
-
-				is_delta_time_good = true;
-			}
-
-			if (is_quality_good && !is_delta_time_good) {
-				ECL_DEBUG("Optical flow: bad delta time: OF dt %.6f s (min: %.3f, max: %.3f), IMU dt %.6f s",
-					  (double)_flow_sample_delayed.dt, (double)delta_time_min, (double)delta_time_max,
-					  (double)imu_delayed.delta_ang_dt);
-			}
-		}
-
-		const bool is_body_rate_comp_available = calcOptFlowBodyRateComp();
-
-		// don't allow invalid flow gyro_xyz to propagate
-		if (!_flow_sample_delayed.gyro_xyz.isAllFinite()) {
-			_flow_sample_delayed.gyro_xyz.zero();
-		}
-
-		if (is_quality_good
-		    && is_magnitude_good
-		    && is_tilt_good
-		    && is_body_rate_comp_available
-		    && is_delta_time_good) {
-			// compensate for body motion to give a LOS rate
-			_flow_compensated_XY_rad = _flow_sample_delayed.flow_xy_rad - _flow_sample_delayed.gyro_xyz.xy();
-
-		} else if (!_control_status.flags.in_air) {
-
-			if (!is_delta_time_good) {
-				// handle special case of SITL and PX4Flow where dt is forced to
-				// zero when the quaity is 0
-				_flow_sample_delayed.dt = delta_time_min;
-			}
-
-			// when on the ground with poor flow quality,
-			// assume zero ground relative velocity and LOS rate
-			_flow_compensated_XY_rad.setZero();
-
-		} else {
-			// don't use this flow data and wait for the next data to arrive
-			_flow_data_ready = false;
-			_flow_compensated_XY_rad.setZero();
-		}
-
-		updateOptFlow(_aid_src_optical_flow);
-
-	} else {
-		_flow_compensated_XY_rad.setZero();
+		_flow_data_ready = _flow_buffer->pop_first_older_than(imu_delayed.time_us, &_flow_sample_delayed);
 	}
 
 	// New optical flow data is available and is ready to be fused when the midpoint of the sample falls behind the fusion time horizon
 	if (_flow_data_ready) {
+		const int32_t min_quality = _control_status.flags.in_air
+					    ? _params.flow_qual_min
+					    : _params.flow_qual_min_gnd;
+
+		const bool is_quality_good = (_flow_sample_delayed.quality >= min_quality);
+		const bool is_magnitude_good = _flow_sample_delayed.flow_rate.isAllFinite()
+					       && !_flow_sample_delayed.flow_rate.longerThan(_flow_max_rate);
+		const bool is_tilt_good = (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
+
+		if (is_quality_good
+		    && is_magnitude_good
+		    && is_tilt_good) {
+			// compensate for body motion to give a LOS rate
+			calcOptFlowBodyRateComp(imu_delayed);
+			_flow_rate_compensated = _flow_sample_delayed.flow_rate - _flow_sample_delayed.gyro_rate.xy();
+
+		} else {
+			// don't use this flow data and wait for the next data to arrive
+			_flow_data_ready = false;
+			_flow_rate_compensated.setZero();
+		}
+	}
+
+	if (_flow_data_ready) {
+		updateOptFlow(_aid_src_optical_flow);
 
 		// Check if we are in-air and require optical flow to control position drift
 		bool is_flow_required = _control_status.flags.in_air
-					      && (_control_status.flags.inertial_dead_reckoning // is doing inertial dead-reckoning so must constrain drift urgently
-						  || isOnlyActiveSourceOfHorizontalAiding(_control_status.flags.opt_flow));
+					&& (_control_status.flags.inertial_dead_reckoning // is doing inertial dead-reckoning so must constrain drift urgently
+					|| isOnlyActiveSourceOfHorizontalAiding(_control_status.flags.opt_flow));
 
-#if defined(CONFIG_EKF2_GNSS)
-		// check if using GPS, but GPS is bad
-		if (_control_status.flags.gps) {
-			if (_control_status.flags.in_air && !is_flow_required) {
-				// Inhibit flow use if motion is un-suitable or we have good quality GPS
-				// Apply hysteresis to prevent rapid mode switching
-				const float gps_err_norm_lim = _control_status.flags.opt_flow ? 0.7f : 1.0f;
+		// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
+		// use a relaxed time criteria to enable it to coast through bad range finder data
+		const bool terrain_available = isTerrainEstimateValid() || isRecent(_aid_src_terrain_range_finder.time_last_fuse, (uint64_t)10e6);
 
-				if (_gps_error_norm > gps_err_norm_lim) {
-					is_flow_required = true;
-				}
-			}
-		}
-#endif // CONFIG_EKF2_GNSS
+		const bool continuing_conditions_passing = (_params.flow_ctrl == 1)
+							   && _control_status.flags.tilt_align
+							   && (terrain_available || is_flow_required);
 
-		// inhibit use of optical flow if motion is unsuitable and we are not reliant on it for flight navigation
-		const bool preflight_motion_not_ok = !_control_status.flags.in_air
-						     && ((_time_delayed_us > (_time_good_motion_us + (uint64_t)1E5))
-								     || (_time_delayed_us < (_time_bad_motion_us + (uint64_t)5E6)));
-		const bool flight_condition_not_ok = _control_status.flags.in_air && !isTerrainEstimateValid();
+		const bool starting_conditions_passing = continuing_conditions_passing
+							 && isTimedOut(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6); // Prevent rapid switching
 
-		const bool inhibit_flow_use = ((preflight_motion_not_ok || flight_condition_not_ok) && !is_flow_required)
-				    || !_control_status.flags.tilt_align;
-
-		// Handle cases where we are using optical flow but we should not use it anymore
 		if (_control_status.flags.opt_flow) {
-			if (!(_params.flow_ctrl == 1)
-			    || inhibit_flow_use) {
+			if (continuing_conditions_passing) {
+				fuseOptFlow();
 
+				// handle the case when we have optical flow, are reliant on it, but have not been using it for an extended period
+				if (isTimedOut(_aid_src_optical_flow.time_last_fuse, _params.no_aid_timeout_max)) {
+					if (is_flow_required) {
+						resetFlowFusion();
+
+					} else {
+						stopFlowFusion();
+					}
+				}
+
+			} else {
 				stopFlowFusion();
-				return;
+			}
+
+		} else {
+			if (starting_conditions_passing) {
+				startFlowFusion();
 			}
 		}
 
-		// optical flow fusion mode selection logic
-		if ((_params.flow_ctrl == 1) // optical flow has been selected by the user
-		    && !_control_status.flags.opt_flow // we are not yet using flow data
-		    && !inhibit_flow_use) {
-
-			// set the flag and reset the fusion timeout
-			ECL_INFO("starting optical flow fusion");
-
-			// if we are not using GPS or external vision aiding, then the velocity and position states and covariances need to be set
-			if (!isHorizontalAidingActive()) {
-				ECL_INFO("reset velocity to flow");
-				_information_events.flags.reset_vel_to_flow = true;
-				resetHorizontalVelocityTo(_flow_vel_ne, calcOptFlowMeasVar(_flow_sample_delayed));
-
-				// reset position, estimate is relative to initial position in this mode, so we start with zero error
-				if (!_control_status.flags.in_air) {
-					ECL_INFO("reset position to zero");
-					resetHorizontalPositionTo(Vector2f(0.f, 0.f), 0.f);
-					_last_known_pos.xy() = _state.pos.xy();
-
-				} else {
-					_information_events.flags.reset_pos_to_last_known = true;
-					ECL_INFO("reset position to last known (%.3f, %.3f)", (double)_last_known_pos(0), (double)_last_known_pos(1));
-					resetHorizontalPositionTo(_last_known_pos.xy(), 0.f);
-				}
-			}
-
-			_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
-			_control_status.flags.opt_flow = true;
-
-			return;
-		}
-
-		if (_control_status.flags.opt_flow) {
-			// Wait until the midpoint of the flow sample has fallen behind the fusion time horizon
-			if (_time_delayed_us > (_flow_sample_delayed.time_us - uint32_t(1e6f * _flow_sample_delayed.dt) / 2)) {
-				// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
-				// but use a relaxed time criteria to enable it to coast through bad range finder data
-				if (isRecent(_aid_src_terrain_range_finder.time_last_fuse, (uint64_t)10e6)) {
-					fuseOptFlow();
-					_last_known_pos.xy() = _state.pos.xy();
-				}
-
-				_flow_data_ready = false;
-			}
-
-			// handle the case when we have optical flow, are reliant on it, but have not been using it for an extended period
-			if (isTimedOut(_aid_src_optical_flow.time_last_fuse, _params.no_aid_timeout_max)
-			    && !isOtherSourceOfHorizontalAidingThan(_control_status.flags.opt_flow)) {
-
-				ECL_INFO("reset velocity to flow");
-				_information_events.flags.reset_vel_to_flow = true;
-				resetHorizontalVelocityTo(_flow_vel_ne, calcOptFlowMeasVar(_flow_sample_delayed));
-
-				// reset position, estimate is relative to initial position in this mode, so we start with zero error
-				ECL_INFO("reset position to last known (%.3f, %.3f)", (double)_last_known_pos(0), (double)_last_known_pos(1));
-				_information_events.flags.reset_pos_to_last_known = true;
-				resetHorizontalPositionTo(_last_known_pos.xy(), 0.f);
-
-				_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
-			}
-		}
-
-	} else if (_control_status.flags.opt_flow && !isRecent(_flow_sample_delayed.time_us, (uint64_t)10e6)) {
-
+	} else if (_control_status.flags.opt_flow && isTimedOut(_flow_sample_delayed.time_us, _params.reset_timeout_max)) {
 		stopFlowFusion();
 	}
 }
 
-void Ekf::updateOnGroundMotionForOpticalFlowChecks()
+void Ekf::startFlowFusion()
 {
-	// When on ground check if the vehicle is being shaken or moved in a way that could cause a loss of navigation
-	const float accel_norm = _accel_vec_filt.norm();
+	ECL_INFO("starting optical flow fusion");
 
-	const bool motion_is_excessive = ((accel_norm > (CONSTANTS_ONE_G * 1.5f)) // upper g limit
-					  || (accel_norm < (CONSTANTS_ONE_G * 0.5f)) // lower g limit
-					  || (_ang_rate_magnitude_filt > _flow_max_rate) // angular rate exceeds flow sensor limit
-					  || (_R_to_earth(2, 2) < cosf(math::radians(30.0f)))); // tilted excessively
+	if (!_aid_src_optical_flow.innovation_rejected && isHorizontalAidingActive()) {
+		// Consistent with the current velocity state, simply fuse the data without reset
+		fuseOptFlow();
+		_control_status.flags.opt_flow = true;
 
-	if (motion_is_excessive) {
-		_time_bad_motion_us = _time_delayed_us;
+	} else if (!isHorizontalAidingActive()) {
+		resetFlowFusion();
+		_control_status.flags.opt_flow = true;
 
 	} else {
-		_time_good_motion_us = _time_delayed_us;
+		ECL_INFO("optical flow fusion failed to start");
+		_control_status.flags.opt_flow = false;
 	}
 }
 
-void Ekf::resetOnGroundMotionForOpticalFlowChecks()
+void Ekf::resetFlowFusion()
 {
-	_time_bad_motion_us = 0;
-	_time_good_motion_us = _time_delayed_us;
+	ECL_INFO("reset velocity to flow");
+	_information_events.flags.reset_vel_to_flow = true;
+	resetHorizontalVelocityTo(_flow_vel_ne, calcOptFlowMeasVar(_flow_sample_delayed));
+
+	// reset position, estimate is relative to initial position in this mode, so we start with zero error
+	if (!_control_status.flags.in_air) {
+		ECL_INFO("reset position to zero");
+		resetHorizontalPositionTo(Vector2f(0.f, 0.f), 0.f);
+	}
+
+	updateOptFlow(_aid_src_optical_flow);
+	_innov_check_fail_status.flags.reject_optflow_X = false;
+	_innov_check_fail_status.flags.reject_optflow_Y = false;
+
+	_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
 }
 
 void Ekf::stopFlowFusion()
@@ -282,4 +163,25 @@ void Ekf::stopFlowFusion()
 
 		resetEstimatorAidStatus(_aid_src_optical_flow);
 	}
+}
+
+void Ekf::calcOptFlowBodyRateComp(const imuSample &imu_delayed)
+{
+	if (imu_delayed.delta_ang_dt > FLT_EPSILON) {
+		_ref_body_rate = -imu_delayed.delta_ang / imu_delayed.delta_ang_dt - getGyroBias(); // flow gyro has opposite sign convention
+
+	} else {
+		_ref_body_rate.zero();
+	}
+
+	if (!PX4_ISFINITE(_flow_sample_delayed.gyro_rate(0)) || !PX4_ISFINITE(_flow_sample_delayed.gyro_rate(1))) {
+		_flow_sample_delayed.gyro_rate = _ref_body_rate;
+
+	} else if (!PX4_ISFINITE(_flow_sample_delayed.gyro_rate(2))) {
+		// Some flow modules only provide X ind Y angular rates. If this is the case, complete the vector with our own Z gyro
+		_flow_sample_delayed.gyro_rate(2) = _ref_body_rate(2);
+	}
+
+	// calculate the bias estimate using  a combined LPF and spike filter
+	_flow_gyro_bias = _flow_gyro_bias * 0.99f + matrix::constrain(_flow_sample_delayed.gyro_rate - _ref_body_rate, -0.1f, 0.1f) * 0.01f;
 }

--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -239,7 +239,7 @@ void Ekf::updateHaglRng(estimator_aid_source1d_s &aid_src) const
 
 	aid_src.timestamp_sample = _time_delayed_us; // TODO
 
-	aid_src.observation = pred_hagl;
+	aid_src.observation = meas_hagl;
 	aid_src.observation_variance = obs_variance;
 
 	aid_src.innovation = hagl_innov;

--- a/src/modules/ekf2/test/sensor_simulator/flow.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/flow.cpp
@@ -28,9 +28,8 @@ void Flow::setData(const flowSample &flow)
 flowSample Flow::dataAtRest()
 {
 	flowSample flow_at_rest;
-	flow_at_rest.dt = static_cast<float>(_update_period) * 1e-6f;
-	flow_at_rest.flow_xy_rad = Vector2f{0.0f, 0.0f};
-	flow_at_rest.gyro_xyz = Vector3f{0.0f, 0.0f, 0.0f};
+	flow_at_rest.flow_rate = Vector2f{0.0f, 0.0f};
+	flow_at_rest.gyro_rate = Vector3f{0.0f, 0.0f, 0.0f};
 	flow_at_rest.quality = 255;
 	return flow_at_rest;
 }

--- a/src/modules/ekf2/test/sensor_simulator/sensor_simulator.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/sensor_simulator.cpp
@@ -266,11 +266,11 @@ void SensorSimulator::setSingleReplaySample(const sensor_info &sample)
 
 	} else if (sample.sensor_type == sensor_info::measurement_t::FLOW) {
 		flowSample flow_sample;
-		flow_sample.flow_xy_rad = Vector2f(sample.sensor_data[0],
-						   sample.sensor_data[1]);
-		flow_sample.gyro_xyz = Vector3f(sample.sensor_data[2],
-						sample.sensor_data[3],
-						sample.sensor_data[4]);
+		flow_sample.flow_rate = Vector2f(sample.sensor_data[0],
+						 sample.sensor_data[1]);
+		flow_sample.gyro_rate = Vector3f(sample.sensor_data[2],
+						 sample.sensor_data[3],
+						 sample.sensor_data[4]);
 		flow_sample.quality = sample.sensor_data[5];
 		_flow.setData(flow_sample);
 
@@ -373,9 +373,9 @@ void SensorSimulator::setSensorDataFromTrajectory()
 	if (_flow.isRunning()) {
 		flowSample flow_sample = _flow.dataAtRest();
 		const Vector3f vel_body = R_world_to_body * vel_world;
-		flow_sample.flow_xy_rad =
-			Vector2f(vel_body(1) * flow_sample.dt / distance_to_ground,
-				 -vel_body(0) * flow_sample.dt / distance_to_ground);
+		flow_sample.flow_rate =
+			Vector2f(vel_body(1) / distance_to_ground,
+				 -vel_body(0) / distance_to_ground);
 		_flow.setData(flow_sample);
 	}
 

--- a/src/modules/ekf2/test/test_EKF_flow.cpp
+++ b/src/modules/ekf2/test/test_EKF_flow.cpp
@@ -102,9 +102,9 @@ void EkfFlowTest::startZeroFlowFusion()
 void EkfFlowTest::setFlowFromHorizontalVelocityAndDistance(flowSample &flow_sample,
 		const Vector2f &simulated_horz_velocity, float estimated_distance_to_ground)
 {
-	flow_sample.flow_xy_rad =
-		Vector2f(simulated_horz_velocity(1) * flow_sample.dt / estimated_distance_to_ground,
-			 -simulated_horz_velocity(0) * flow_sample.dt / estimated_distance_to_ground);
+	flow_sample.flow_rate =
+		Vector2f(simulated_horz_velocity(1) / estimated_distance_to_ground,
+			 -simulated_horz_velocity(0) / estimated_distance_to_ground);
 }
 
 TEST_F(EkfFlowTest, resetToFlowVelocityInAir)
@@ -140,6 +140,8 @@ TEST_F(EkfFlowTest, resetToFlowVelocityInAir)
 
 	// THEN: estimated velocity should match simulated velocity
 	const Vector3f estimated_velocity = _ekf->getVelocity();
+	estimated_velocity.print();
+	simulated_velocity.print();
 	EXPECT_TRUE(isEqual(estimated_velocity, simulated_velocity))
 			<< "estimated vel = " << estimated_velocity(0) << ", "
 			<< estimated_velocity(1);
@@ -163,11 +165,11 @@ TEST_F(EkfFlowTest, resetToFlowVelocityOnGround)
 
 	// WHEN: start fusing flow data
 	flowSample flow_sample = _sensor_simulator._flow.dataAtRest();
-	flow_sample.dt = 0.f; // some sensors force dt to zero when quality is low
 	flow_sample.quality = 0;
 	_sensor_simulator._flow.setData(flow_sample);
 	_ekf_wrapper.enableFlowFusion();
 	_sensor_simulator.startFlow();
+	_sensor_simulator.startRangeFinder();
 	_sensor_simulator.runSeconds(1.0);
 
 	// THEN: estimated velocity should match simulated velocity
@@ -248,7 +250,7 @@ TEST_F(EkfFlowTest, yawMotionCorrectionWithAutopilotGyroData)
 	setFlowFromHorizontalVelocityAndDistance(flow_sample, simulated_horz_velocity, simulated_distance_to_ground);
 
 	// use autopilot gyro data
-	flow_sample.gyro_xyz.setAll(NAN);
+	flow_sample.gyro_rate.setAll(NAN);
 
 	_sensor_simulator._flow.setData(flow_sample);
 	_sensor_simulator._imu.setGyroData(body_rate);
@@ -286,7 +288,7 @@ TEST_F(EkfFlowTest, yawMotionCorrectionWithFlowGyroData)
 
 	// use flow sensor gyro data
 	// for clarification of the sign, see definition of flowSample
-	flow_sample.gyro_xyz = -body_rate * flow_sample.dt;
+	flow_sample.gyro_rate = -body_rate;
 
 	_sensor_simulator._flow.setData(flow_sample);
 	_sensor_simulator._imu.setGyroData(body_rate);

--- a/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
+++ b/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
@@ -183,6 +183,7 @@ TEST_F(EkfFusionLogicTest, fallbackFromGpsToFlow)
 	const float max_ground_distance = 50.f;
 	_ekf->set_optical_flow_limits(max_flow_rate, min_ground_distance, max_ground_distance);
 	_sensor_simulator.startFlow();
+	_sensor_simulator.startRangeFinder();
 	_ekf_wrapper.enableFlowFusion();
 
 	_ekf->set_in_air_status(true);

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -192,6 +192,7 @@ TEST_F(EkfGpsTest, gpsHgtToBaroFallback)
 	_sensor_simulator._flow.setData(_sensor_simulator._flow.dataAtRest());
 	_ekf_wrapper.enableFlowFusion();
 	_sensor_simulator.startFlow();
+	_sensor_simulator.startRangeFinder();
 
 	_ekf_wrapper.enableGpsHeightFusion();
 

--- a/src/modules/ekf2/test/test_EKF_terrain_estimator.cpp
+++ b/src/modules/ekf2/test/test_EKF_terrain_estimator.cpp
@@ -98,9 +98,9 @@ public:
 
 		// Configure optical flow simulator data
 		flowSample flow_sample = _sensor_simulator._flow.dataAtRest();
-		flow_sample.flow_xy_rad =
-			Vector2f(simulated_velocity(1) * flow_sample.dt / flow_height,
-				 -simulated_velocity(0) * flow_sample.dt / flow_height);
+		flow_sample.flow_rate =
+			Vector2f(simulated_velocity(1) / flow_height,
+				 -simulated_velocity(0) / flow_height);
 		_sensor_simulator._flow.setData(flow_sample);
 		const float max_flow_rate = 5.f;
 		const float min_ground_distance = 0.f;

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -291,6 +291,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("estimator_aid_src_mag", 0, MAX_ESTIMATOR_INSTANCES);
 	add_optional_topic_multi("estimator_aid_src_optical_flow", 0, MAX_ESTIMATOR_INSTANCES);
 	add_optional_topic_multi("estimator_aid_src_terrain_optical_flow", 0, MAX_ESTIMATOR_INSTANCES);
+	add_optional_topic_multi("estimator_aid_src_terrain_range_finder", 0, MAX_ESTIMATOR_INSTANCES);
 	add_optional_topic_multi("estimator_aid_src_sideslip", 0, MAX_ESTIMATOR_INSTANCES);
 
 #endif /* CONFIG_ARCH_BOARD_PX4_SITL */

--- a/src/modules/replay/Replay.cpp
+++ b/src/modules/replay/Replay.cpp
@@ -395,7 +395,7 @@ Replay::readFormat(std::ifstream &file, uint16_t msg_size)
 string Replay::getOrbFields(const orb_metadata *meta)
 {
 	char format[3000];
-	char buffer[512];
+	char buffer[2048];
 	uORB::MessageFormatReader format_reader(buffer, sizeof(buffer));
 
 	if (!format_reader.readUntilFormat(meta->o_id)) {


### PR DESCRIPTION
replaces https://github.com/PX4/PX4-Autopilot/pull/21005

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The optical flow control logic is way too complicated to read, has a lot of strange behaviors due to the multiple possible paths in the code and several strange legacy checks.
Furthermore, it tries to compensate the flow due to angular motion by popping the data from the buffer early to be able to accumulate gyro data during the flow integration interval, which makes the code even more complicated. I also think that it wasn't working as expected and that most of the time, only 1 gyro sample is available between the start of the integration and the midpoint (where we want to fuse it), so IMO, there is no real benefit of doing it this way. Also note that this integration is also now done in `VehicleOpticalFlow`.

### Solution
- convert to flow rate before sending to EKF2 backend
- align flow rate data at midpoint of integration time
- allow the flow fusion and terrain estimator to run before arming (not only really useful for bench tests but also makes the navigation more consistent before and after arming).

### Changelog Entry
For release notes:
```
Refactor EKF2 optical flow fusion
```

### Test coverage
- Unit tests
- flight tests