### PR TITLE
Added ObstacleDistance publishing from downsampled depth camera point…

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -49,21 +49,25 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/sensor_gyro.h>
+#include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
-#include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/vehicle_odometry.h>
 
 #include <gz/math.hh>
 #include <gz/msgs.hh>
 #include <gz/transport.hh>
 
+
 #include <gz/msgs/imu.pb.h>
 #include <gz/msgs/fluid_pressure.pb.h>
 #include <gz/msgs/odometry_with_covariance.pb.h>
+#include <gz/msgs/pointcloud_packed.pb.h>
+#include <gz/msgs/float_v.pb.h>
 
 using namespace time_literals;
 
@@ -102,6 +106,7 @@ private:
 	void imuCallback(const gz::msgs::IMU &imu);
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
+	void pointCloudCallback(const gz::msgs::PointCloudPacked &pointcloud);
 
 	/**
 	*
@@ -116,6 +121,10 @@ private:
 	// Subscriptions
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
+	gz::transport::Node::Publisher _pointcloudSumPub;
+	gz::transport::Node::Publisher _pointcloudDownsamplePub;
+
+	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};
 	//uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
 	uORB::Publication<vehicle_attitude_s>         _attitude_ground_truth_pub{ORB_ID(vehicle_attitude_groundtruth)};


### PR DESCRIPTION
…cloud to test CollisionPrevention in gz-sim.

In this example the FOV of the camera is 73 degrees, the width is 640 and height is 480. I've downsampled this by 8 to get a width of 80 points. I use the middle row from the downsampled point cloud as the input to the ObstacleDistance.distances[] array. Unfortunately CollisionPrevention in PX4 uses 5 degree sectors, so therefore we can only get 14 points from the 73 degree FOV (73 / 5 = 14.6). Over the width of 80 points I chose to leave off the first and last 5 points such that we can take the 70 points and divide them evenly by 14 (70/14 = 5). So our down sampled points end up being from -35 degrees to +35 degrees FOV at 5 degree increments.

To use:
make px4_sitl gz_x500_depth

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
