### PR TITLE
Allow extra nuttx config options via PX4_EXTRA_NUTTX_CONFIG env var

### DIFF
--- a/.github/workflows/nuttx_env_config.yml
+++ b/.github/workflows/nuttx_env_config.yml
@@ -1,0 +1,32 @@
+name: Nuttx Target with extra env config
+
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-nuttx-focal:2022-08-12
+    strategy:
+      matrix:
+        config: [
+          px4_fmu-v5,
+          ]
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{secrets.ACCESS_TOKEN}}
+
+    - name: make ${{matrix.config}}
+      env:
+        PX4_EXTRA_NUTTX_CONFIG: "CONFIG_NSH_LOGIN_PASSWORD=\"test\";CONFIG_NSH_CONSOLE_LOGIN=y"
+      run: |
+        echo "PX4_EXTRA_NUTTX_CONFIG: $PX4_EXTRA_NUTTX_CONFIG"
+        make ${{matrix.config}} nuttx_context
+        # Check that the config option is set
+        grep CONFIG_NSH_LOGIN_PASSWORD build/${{matrix.config}}_default/NuttX/nuttx/.config

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -40,11 +40,22 @@ set(APPS_DIR ${NUTTX_SRC_DIR}/apps)
 
 configure_file(${PX4_SOURCE_DIR}/platforms/nuttx/NuttX/Make.defs.in ${CMAKE_CURRENT_BINARY_DIR}/nuttx/Make.defs)
 
+set(EXTRA_NUTTX_CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/extra_config_options)
+file(WRITE ${EXTRA_NUTTX_CONFIG_FILE} "")
+if(DEFINED ENV{PX4_EXTRA_NUTTX_CONFIG})
+	message(STATUS "Adding extra nuttx config: $ENV{PX4_EXTRA_NUTTX_CONFIG}")
+	# Allow to specify extra options via 'export PX4_EXTRA_NUTTX_CONFIG="CONFIG_xy=y;CONFIG_z=y"'
+	foreach(OPTION $ENV{PX4_EXTRA_NUTTX_CONFIG})
+		file(APPEND ${EXTRA_NUTTX_CONFIG_FILE} "${OPTION}\n")
+	endforeach ()
+endif()
+
+
 # inflate .config
 add_custom_command(
 	OUTPUT ${NUTTX_DIR}/.config
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/nuttx/Make.defs ${NUTTX_DIR}/Make.defs
-	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DEFCONFIG} ${NUTTX_DIR}/.config
+	COMMAND cat ${NUTTX_DEFCONFIG} ${EXTRA_NUTTX_CONFIG_FILE} > ${NUTTX_DIR}/.config
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DEFCONFIG} ${NUTTX_DIR}/defconfig
 	COMMAND ${NUTTX_SRC_DIR}/tools/px4_nuttx_make_olddefconfig.sh > ${CMAKE_CURRENT_BINARY_DIR}/nuttx_olddefconfig.log
 	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/.config ${CMAKE_CURRENT_BINARY_DIR}/nuttx/.config
@@ -52,6 +63,7 @@ add_custom_command(
 		${NUTTX_DEFCONFIG}
 		${NUTTX_DIR}/defconfig
 		${CMAKE_CURRENT_BINARY_DIR}/nuttx/Make.defs
+		${CMAKE_CURRENT_BINARY_DIR}/../defconfig_inflate_stamp
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	#USES_TERMINAL
 )

--- a/platforms/nuttx/cmake/init.cmake
+++ b/platforms/nuttx/cmake/init.cmake
@@ -77,6 +77,10 @@ execute_process(
 	OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/nuttx_olddefconfig.log
 	RESULT_VARIABLE ret
 )
+execute_process(
+	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/defconfig_inflate_stamp
+	WORKING_DIRECTORY ${NUTTX_DIR}
+)
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/.config ${PX4_BINARY_DIR}/NuttX/nuttx/.config)
 
 ###############################################################################


### PR DESCRIPTION
Our use-case is to enable nsh password protection for release builds.

For example:
```
export PX4_EXTRA_NUTTX_CONFIG="CONFIG_NSH_LOGIN_PASSWORD=\"test\";CONFIG_NSH_CONSOLE_LOGIN=y"
make px4_fmu-v5x
```

### Changelog Entry
For release notes:
```
Allow extra nuttx config options via PX4_EXTRA_NUTTX_CONFIG env var
```
