### PR TITLE
Navigator: Geofence improvements

### DIFF
--- a/msg/FailsafeFlags.msg
+++ b/msg/FailsafeFlags.msg
@@ -43,7 +43,7 @@ bool battery_low_remaining_time       # Low battery based on remaining flight ti
 bool battery_unhealthy                # Battery unhealthy
 
 # Other
-bool primary_geofence_breached        # Primary Geofence breached
+bool geofence_breached        	      # Geofence breached (one or multiple)
 bool mission_failure                  # Mission failure
 bool vtol_fixed_wing_system_failure   # vehicle in fixed-wing system failure failsafe mode (after quad-chute)
 bool wind_limit_exceeded              # Wind limit exceeded

--- a/msg/GeofenceResult.msg
+++ b/msg/GeofenceResult.msg
@@ -10,5 +10,3 @@ uint8 geofence_violation_reason         # one of geofence_violation_reason_t::*
 
 bool primary_geofence_breached          # true if the primary geofence is breached
 uint8 primary_geofence_action           # action to take when the primary geofence is breached
-
-bool home_required                      # true if the geofence requires a valid home position

--- a/msg/GeofenceResult.msg
+++ b/msg/GeofenceResult.msg
@@ -6,7 +6,8 @@ uint8 GF_ACTION_RTL = 3                 # switch to AUTO|RTL
 uint8 GF_ACTION_TERMINATE = 4           # flight termination
 uint8 GF_ACTION_LAND = 5                # switch to AUTO|LAND
 
-uint8 geofence_violation_reason         # one of geofence_violation_reason_t::*
+bool geofence_max_dist_triggered	# true the check for max distance from Home is triggered
+bool geofence_max_alt_triggered		# true the check for max altitude above Home is triggered
+bool geofence_custom_fence_triggered	# true the check for custom inclusion/exclusion geofence(s) is triggered
 
-bool primary_geofence_breached          # true if the primary geofence is breached
-uint8 primary_geofence_action           # action to take when the primary geofence is breached
+uint8 geofence_action           	# action to take when the geofence is breached

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -669,24 +669,6 @@
                             "description": "Reduce throttle!"
                         }
                     }
-                },
-                "geofence_violation_reason_t": {
-                    "type": "uint8_t",
-                    "description": "Reason for geofence violation",
-                    "entries": {
-                        "0": {
-                            "name": "dist_to_home_exceeded",
-                            "description": "maximum distance to home exceeded"
-                        },
-                        "1": {
-                            "name": "max_altitude_exceeded",
-                            "description": "maximum altitude exceeded"
-                        },
-                        "2": {
-                            "name": "fence_violation",
-                            "description": "approaching or outside geofence"
-                        }
-                    }
                 }
             },
             "navigation_mode_groups": {

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -442,7 +442,7 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 		CHECK_FAILSAFE(status_flags, local_position_accuracy_low, ActionOptions(Action::RTL));
 	}
 
-	CHECK_FAILSAFE(status_flags, primary_geofence_breached, fromGfActParam(_param_gf_action.get()).cannotBeDeferred());
+	CHECK_FAILSAFE(status_flags, geofence_breached, fromGfActParam(_param_gf_action.get()).cannotBeDeferred());
 
 	// Battery
 	CHECK_FAILSAFE(status_flags, battery_low_remaining_time,

--- a/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
+++ b/src/modules/mavlink/streams/HIGH_LATENCY2.hpp
@@ -339,7 +339,8 @@ private:
 		geofence_result_s geofence;
 
 		if (_geofence_sub.update(&geofence)) {
-			if (geofence.primary_geofence_breached) {
+			if (geofence.geofence_max_dist_triggered || geofence.geofence_max_alt_triggered
+			    || geofence.geofence_custom_fence_triggered) {
 				msg->failure_flags |= HL_FAILURE_FLAG_GEOFENCE;
 			}
 

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,7 +75,6 @@ void GeofenceBreachAvoidance::setHomePosition(double lat, double lon, float alt)
 {
 	_home_lat_lon(0) = lat;
 	_home_lat_lon(1) = lon;
-	_home_alt_amsl = alt;
 }
 
 matrix::Vector2<double> GeofenceBreachAvoidance::waypointFromBearingAndDistance(matrix::Vector2<double>

--- a/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
+++ b/src/modules/navigator/GeofenceBreachAvoidance/geofence_breach_avoidance.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2020-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@
 
 class Geofence;
 
-#define GEOFENCE_CHECK_INTERVAL_US 200000
+#define GEOFENCE_CHECK_INTERVAL_US 200000 // 0.2s
 
 union geofence_violation_type_u {
 	struct {
@@ -95,8 +95,6 @@ public:
 
 	void setMaxHorDistHome(float dist) { _max_hor_dist_home = dist; }
 
-	void setMaxVerDistHome(float dist) { _max_ver_dist_home = dist; }
-
 	void updateParameters();
 
 private:
@@ -134,10 +132,8 @@ private:
 
 	matrix::Vector2<double> _current_pos_lat_lon{};
 	matrix::Vector2<double> _home_lat_lon {};
-	float _home_alt_amsl{0.0f};
 
 	float _max_hor_dist_home{0.0f};
-	float _max_ver_dist_home{0.0f};
 
 	void updateMinHorDistToFenceMultirotor();
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -693,7 +693,7 @@ void Geofence::printStatus()
 		}
 	}
 
-	PX4_INFO("Geofence: %i inclusion, %i exclusion polygons, %i inclusion, %i exclusion circles, %i total vertices",
+	PX4_INFO("Geofence: %i inclusion, %i exclusion polygons, %i inclusion circles, %i exclusion circles, %i total vertices",
 		 num_inclusion_polygons, num_exclusion_polygons, num_inclusion_circles, num_exclusion_circles,
 		 total_num_vertices);
 }

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -244,38 +244,12 @@ void Geofence::_updateFence()
 	}
 }
 
-bool Geofence::checkAll(const struct vehicle_global_position_s &global_position)
+
+bool Geofence::checkPointAgainstAllGeofences(double lat, double lon, float altitude)
 {
-	return checkAll(global_position.lat, global_position.lon, global_position.alt);
-}
-
-bool Geofence::checkAll(double lat, double lon, float altitude)
-{
-	bool inside_fence = isCloserThanMaxDistToHome(lat, lon, altitude);
-
-	inside_fence = inside_fence && isBelowMaxAltitude(altitude);
-
-	// to be inside the geofence both fences have to report being inside
-	// as they both report being inside when not enabled
-	inside_fence = inside_fence && isInsidePolygonOrCircle(lat, lon, altitude);
-
+	const bool inside_fence = isCloserThanMaxDistToHome(lat, lon, altitude) && isBelowMaxAltitude(altitude)
+				  && isInsidePolygonOrCircle(lat, lon, altitude);
 	return inside_fence;
-}
-}
-
-bool Geofence::check(const vehicle_global_position_s &global_position, const sensor_gps_s &gps_position)
-{
-	if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
-		return checkAll(global_position);
-
-	} else {
-		return checkAll(gps_position.latitude_deg, gps_position.longitude_deg, gps_position.altitude_msl_m);
-	}
-}
-
-bool Geofence::check(const struct mission_item_s &mission_item)
-{
-	return checkAll(mission_item.lat, mission_item.lon, mission_item.altitude);
 }
 
 bool Geofence::isCloserThanMaxDistToHome(double lat, double lon, float altitude)

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -259,20 +259,8 @@ bool Geofence::checkAll(double lat, double lon, float altitude)
 	// as they both report being inside when not enabled
 	inside_fence = inside_fence && isInsidePolygonOrCircle(lat, lon, altitude);
 
-	if (inside_fence) {
-		_outside_counter = 0;
-		return inside_fence;
-
-	} else {
-		_outside_counter++;
-
-		if (_outside_counter > _param_gf_count.get()) {
-			return inside_fence;
-
-		} else {
-			return true;
-		}
-	}
+	return inside_fence;
+}
 }
 
 bool Geofence::check(const vehicle_global_position_s &global_position, const sensor_gps_s &gps_position)

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013,2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,8 +55,7 @@
 
 Geofence::Geofence(Navigator *navigator) :
 	ModuleParams(navigator),
-	_navigator(navigator),
-	_sub_airdata(ORB_ID(vehicle_air_data))
+	_navigator(navigator)
 {
 	if (_navigator != nullptr) {
 		updateFence();
@@ -250,11 +249,6 @@ bool Geofence::checkAll(const struct vehicle_global_position_s &global_position)
 	return checkAll(global_position.lat, global_position.lon, global_position.alt);
 }
 
-bool Geofence::checkAll(const struct vehicle_global_position_s &global_position, const float alt)
-{
-	return checkAll(global_position.lat, global_position.lon, alt);
-}
-
 bool Geofence::checkAll(double lat, double lon, float altitude)
 {
 	bool inside_fence = isCloserThanMaxDistToHome(lat, lon, altitude);
@@ -283,25 +277,11 @@ bool Geofence::checkAll(double lat, double lon, float altitude)
 
 bool Geofence::check(const vehicle_global_position_s &global_position, const sensor_gps_s &gps_position)
 {
-	if (_param_gf_altmode.get() == Geofence::GF_ALT_MODE_WGS84) {
-		if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
-			return checkAll(global_position);
-
-		} else {
-			return checkAll(gps_position.latitude_deg, gps_position.longitude_deg, gps_position.altitude_msl_m);
-		}
+	if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
+		return checkAll(global_position);
 
 	} else {
-		// get baro altitude
-		_sub_airdata.update();
-		const float baro_altitude_amsl = _sub_airdata.get().baro_alt_meter;
-
-		if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
-			return checkAll(global_position, baro_altitude_amsl);
-
-		} else {
-			return checkAll(gps_position.latitude_deg, gps_position.longitude_deg, baro_altitude_amsl);
-		}
+		return checkAll(gps_position.latitude_deg, gps_position.longitude_deg, gps_position.altitude_msl_m);
 	}
 }
 

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -193,17 +193,6 @@ private:
 	 */
 	void _updateFence();
 
-	/**
-	 * Check if a point passes the Geofence test.
-	 * This takes all polygons and minimum & maximum altitude into account
-	 *
-	 * The check passes if: (inside(polygon_inclusion_1) || inside(polygon_inclusion_2) || ... ) &&
-	 *                       !inside(polygon_exclusion_1) && !inside(polygon_exclusion_2) && ...
-	 *                       && (altitude within [min, max])
-	 *                  or: no polygon configured
-	 * @return result of the check above (false for a geofence violation)
-	 */
-	bool checkPolygons(double lat, double lon, float altitude);
 
 	/**
 	 * Check if a single point is within a polygon
@@ -217,6 +206,25 @@ private:
 	 * @return true if within polygon the circle
 	 */
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
+	/**
+	 * Check if a single point is within a polygon or circle
+	 * @return true if within polygon or circle
+	 */
+
+	bool checkPointAgainstPolygonCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
+
+	/**
+	 * Check polygon or circle geofence fullfills the requirements relative to Home.
+	 * @return true if checks pass
+	 */
+	bool checkHomeRequirementsForGeofence(const PolygonInfo &polygon);
+
+	/**
+	 * Check polygon or circle geofence fullfills the requirements relative to the current vehicle position.
+	 * @return true if checks pass
+	 */
+	bool checkCurrentPositionRequirementsForGeofence(const PolygonInfo &polygon);
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -189,7 +189,6 @@ private:
 	MapProjection _projection_reference{}; ///< class to convert (lon, lat) to local [m]
 
 
-	int _outside_counter{0};
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, polygon data was updated
 	bool _fence_updated{true};  ///< flag indicating if fence are updated to dataman cache
 	bool _initiate_fence_updated{true}; ///< flag indicating if fence updated is needed
@@ -231,7 +230,6 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,
 		(ParamInt<px4::params::GF_SOURCE>)         _param_gf_source,
-		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_gf_max_ver_dist,
 		(ParamBool<px4::params::GF_PREDICT>)       _param_gf_predict

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -81,28 +81,6 @@ public:
 	 */
 	void updateFence();
 
-	/**
-	 * Return whether the system obeys the geofence.
-	 *
-	 * @return true: system is obeying fence, false: system is violating fence
-	 */
-	bool check(const vehicle_global_position_s &global_position, const sensor_gps_s &gps_position);
-
-	/**
-	 * Return whether a mission item obeys the geofence.
-	 *
-	 * @return true: system is obeying fence, false: system is violating fence
-	 */
-	bool check(const struct mission_item_s &mission_item);
-
-	/**
-	 * Check if a point passes the Geofence test.
-	 * In addition to checkPolygons(), this takes all additional parameters into account.
-	 *
-	 * @return false for a geofence violation
-	 */
-	bool checkAll(double lat, double lon, float altitude);
-
 	bool isCloserThanMaxDistToHome(double lat, double lon, float altitude);
 
 	bool isBelowMaxAltitude(float altitude);
@@ -209,10 +187,6 @@ private:
 	 * @return result of the check above (false for a geofence violation)
 	 */
 	bool checkPolygons(double lat, double lon, float altitude);
-
-
-
-	bool checkAll(const vehicle_global_position_s &global_position);
 
 	/**
 	 * Check if a single point is within a polygon

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,7 +52,6 @@
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/sensor_gps.h>
-#include <uORB/topics/vehicle_air_data.h>
 
 #define GEOFENCE_FILENAME PX4_STORAGEDIR"/etc/geofence.txt"
 
@@ -65,12 +64,6 @@ public:
 	Geofence(const Geofence &) = delete;
 	Geofence &operator=(const Geofence &) = delete;
 	virtual ~Geofence();
-
-	/* Altitude mode, corresponding to the param GF_ALTMODE */
-	enum {
-		GF_ALT_MODE_WGS84 = 0,
-		GF_ALT_MODE_AMSL = 1
-	};
 
 	/* Source, corresponding to the param GF_SOURCE */
 	enum {
@@ -195,7 +188,6 @@ private:
 
 	MapProjection _projection_reference{}; ///< class to convert (lon, lat) to local [m]
 
-	uORB::SubscriptionData<vehicle_air_data_s> _sub_airdata;
 
 	int _outside_counter{0};
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, polygon data was updated
@@ -222,7 +214,6 @@ private:
 
 
 	bool checkAll(const vehicle_global_position_s &global_position);
-	bool checkAll(const vehicle_global_position_s &global_position, float baro_altitude_amsl);
 
 	/**
 	 * Check if a single point is within a polygon
@@ -239,7 +230,6 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::GF_ACTION>)         _param_gf_action,
-		(ParamInt<px4::params::GF_ALTMODE>)        _param_gf_altmode,
 		(ParamInt<px4::params::GF_SOURCE>)         _param_gf_source,
 		(ParamInt<px4::params::GF_COUNT>)          _param_gf_count,
 		(ParamFloat<px4::params::GF_MAX_HOR_DIST>) _param_gf_max_hor_dist,

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -81,8 +81,29 @@ public:
 	 */
 	void updateFence();
 
+
+	/**
+	 * Check if a 3D point passes the Geofence test.
+	 * Checks max distance, max altitude, inside polygon or circle.
+	 * In addition to checkPolygons(), this takes all additional parameters into account.
+	 *
+	 * @return false for a geofence violation
+	 */
+	bool checkPointAgainstAllGeofences(double lat, double lon, float altitude);
+
+	/**
+	 * @brief check if the horizontal distance to Home is greater than the maximum allowed distance
+	 *
+	 * @return true if the horizontal distance to Home is smaller than the maximum allowed distance
+	 */
 	bool isCloserThanMaxDistToHome(double lat, double lon, float altitude);
 
+
+	/**
+	 * @brief check if the altitude above Home is greater than the maximum allowed altitude
+	 *
+	 * @return true if the altitude above Home is smaller than the maximum allowed altitude
+	 */
 	bool isBelowMaxAltitude(float altitude);
 
 	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
@@ -118,7 +139,6 @@ public:
 	int getGeofenceAction() { return _param_gf_action.get(); }
 
 	float getMaxHorDistanceHome() { return _param_gf_max_hor_dist.get(); }
-	float getMaxVerDistanceHome() { return _param_gf_max_ver_dist.get(); }
 	bool getPredict() { return _param_gf_predict.get(); }
 
 	bool isHomeRequired();
@@ -155,9 +175,6 @@ private:
 	DatamanState _error_state{DatamanState::UpdateRequestWait};
 	DatamanCache _dataman_cache{"geofence_dm_cache_miss", 4};
 	DatamanClient	&_dataman_client = _dataman_cache.client();
-
-	hrt_abstime _last_horizontal_range_warning{0};
-	hrt_abstime _last_vertical_range_warning{0};
 
 	float _altitude_min{0.0f};
 	float _altitude_max{0.0f};

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -62,19 +62,6 @@
 PARAM_DEFINE_INT32(GF_ACTION, 2);
 
 /**
- * Geofence altitude mode
- *
- * Select which altitude (AMSL) source should be used for geofence calculations.
- *
- * @min 0
- * @max 1
- * @value 0 Autopilot estimator global position altitude (GPS)
- * @value 1 Raw barometer altitude (assuming standard atmospheric pressure)
- * @group Geofence
- */
-PARAM_DEFINE_INT32(GF_ALTMODE, 0);
-
-/**
  * Geofence source
  *
  * Select which position source should be used. Selecting GPS instead of global position makes sure that there is

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -76,17 +76,7 @@ PARAM_DEFINE_INT32(GF_ACTION, 2);
  */
 PARAM_DEFINE_INT32(GF_SOURCE, 0);
 
-/**
- * Geofence counter limit
- *
- * Set how many subsequent position measurements outside of the fence are needed before geofence violation is triggered
- *
- * @min -1
- * @max 10
- * @increment 1
- * @group Geofence
- */
-PARAM_DEFINE_INT32(GF_COUNT, -1);
+
 
 /**
  * Max horizontal distance in meters.

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -76,12 +76,11 @@ PARAM_DEFINE_INT32(GF_ACTION, 2);
  */
 PARAM_DEFINE_INT32(GF_SOURCE, 0);
 
-
-
 /**
- * Max horizontal distance in meters.
+ * Max horizontal distance from Home
  *
- * Maximum horizontal distance in meters the vehicle can be from home before triggering a geofence action. Disabled if 0.
+ * Maximum horizontal distance in meters the vehicle can be from Home before triggering a geofence action.
+ * Disabled if 0.
  *
  * @unit m
  * @min 0
@@ -89,12 +88,13 @@ PARAM_DEFINE_INT32(GF_SOURCE, 0);
  * @increment 1
  * @group Geofence
  */
-PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, 0);
+PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, 0.0f);
 
 /**
- * Max vertical distance in meters.
+ * Max vertical distance from Home
  *
- * Maximum vertical distance in meters the vehicle can be from home before triggering a geofence action. Disabled if 0.
+ * Maximum vertical distance in meters the vehicle can be from Home before triggering a geofence action.
+ * Disabled if 0.
  *
  * @unit m
  * @min 0
@@ -102,7 +102,7 @@ PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, 0);
  * @increment 1
  * @group Geofence
  */
-PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0);
+PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, 0.0f);
 
 /**
  * [EXPERIMENTAL] Use Pre-emptive geofence triggering

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -137,7 +137,8 @@ MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission,
 			// Geofence function checks against home altitude amsl
 			missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
 
-			if (MissionBlock::item_contains_position(missionitem) && !_navigator->get_geofence().check(missionitem)) {
+			if (MissionBlock::item_contains_position(missionitem) && !_navigator->get_geofence().checkPointAgainstAllGeofences(
+				    missionitem.lat, missionitem.lon, missionitem.altitude)) {
 
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence violation for waypoint %zu\t", i + 1);
 				events::send<int16_t>(events::ID("navigator_mis_geofence_violation"), {events::Log::Error, events::LogInternal::Info},

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -97,7 +97,7 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission)
 
 	failed |= _feasibility_checker.someCheckFailed();
 
-	failed |= !checkGeofence(mission, _navigator->get_home_position()->alt, home_valid);
+	failed |= !checkMissionAgainstGeofence(mission, _navigator->get_home_position()->alt, home_valid);
 
 	_navigator->get_mission_result()->warning = failed;
 
@@ -105,7 +105,7 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission)
 }
 
 bool
-MissionFeasibilityChecker::checkGeofence(const mission_s &mission, float home_alt, bool home_valid)
+MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission, float home_alt, bool home_valid)
 {
 	if (_navigator->get_geofence().isHomeRequired() && !home_valid) {
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence requires valid home position\t");

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -57,7 +57,7 @@ private:
 	DatamanClient &_dataman_client;
 	FeasibilityChecker _feasibility_checker;
 
-	bool checkGeofence(const mission_s &mission, float home_alt, bool home_valid);
+	bool checkMissionAgainstGeofence(const mission_s &mission, float home_alt, bool home_valid);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator, DatamanClient &dataman_client) :

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -47,7 +47,6 @@
 #include <px4_platform_common/module_params.h>
 #include "MissionFeasibility/FeasibilityChecker.hpp"
 
-class Geofence;
 class Navigator;
 
 class MissionFeasibilityChecker: public ModuleParams

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -260,7 +260,7 @@ public:
 
 	bool abort_landing();
 
-	void geofence_breach_check(bool &have_geofence_position_data);
+	void geofence_breach_check();
 
 	// Param access
 	int get_loiter_min_alt() const { return _param_min_ltr_alt.get(); }

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -335,7 +335,8 @@ private:
 	GeofenceBreachAvoidance _gf_breach_avoidance;
 	hrt_abstime _last_geofence_check = 0;
 
-	bool		_geofence_violation_warning_sent{false};	/**< prevents spaming to mavlink */
+	bool		_geofence_reposition_sent{false};		/**< flag if reposition command has been sent for current geofence breach*/
+	hrt_abstime	_time_loitering_after_gf_breach{0};		/**< timestamp of when loitering after a geofence breach was started */
 	bool		_pos_sp_triplet_updated{false};			/**< flags if position SP triplet needs to be published */
 	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
 	bool		_mission_result_updated{false};			/**< flags if mission result has seen an update */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1469,8 +1469,8 @@ bool Navigator::geofence_allows_position(const vehicle_global_position_s &pos)
 	if ((_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE) &&
 	    (_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_WARN)) {
 
-		if (PX4_ISFINITE(pos.lat) && PX4_ISFINITE(pos.lon)) {
-			return _geofence.check(pos, _gps_pos);
+		if (PX4_ISFINITE(pos.lat) && PX4_ISFINITE(pos.lon) && PX4_ISFINITE(pos.alt)) {
+			return _geofence.checkPointAgainstAllGeofences(pos.lat, pos.lon, pos.alt);
 		}
 	}
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -966,7 +966,6 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 		_gf_breach_avoidance.setTestPointBearing(test_point_bearing);
 		_gf_breach_avoidance.setCurrentPosition(_global_pos.lat, _global_pos.lon, _global_pos.alt);
 		_gf_breach_avoidance.setMaxHorDistHome(_geofence.getMaxHorDistanceHome());
-		_gf_breach_avoidance.setMaxVerDistHome(_geofence.getMaxVerDistanceHome());
 
 		if (home_global_position_valid()) {
 			_gf_breach_avoidance.setHomePosition(_home_pos.lat, _home_pos.lon, _home_pos.alt);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -995,7 +995,7 @@ void Navigator::geofence_breach_check(bool &have_geofence_position_data)
 
 		_geofence_result.timestamp = hrt_absolute_time();
 		_geofence_result.primary_geofence_action = _geofence.getGeofenceAction();
-		_geofence_result.home_required = _geofence.isHomeRequired();
+
 
 		if (gf_violation_type.value) {
 			/* inform other apps via the mission result */


### PR DESCRIPTION
### Solved Problem

Fixes: 
1) listen to GF_SOURCE (fixes https://github.com/PX4/PX4-Autopilot/issues/20677)
2) do not constantly send new reposition waypoints when GF is breached as a fixed-wing

New features:
3) if armed, do not allow to upload GF that would immediately trigger
4) do not allow to upload GF if it doesn't contain Home (to not break RTL)

Functional changes (neither new features nor fixes):
5) has to be in all inclusion GF 
6) remove GF_ALTMODE (with the big baro offset usually present this is quite unusable)
7) remove GF_COUNT (don't see need, don't find it intuitive)
8) change messaging
9) some code cleanup

### Solution
1) correctly listen to it.
2) if GF_ACTION is HOLD, and GF is breached: stay in the "GF breached mode" until the current loiter is changed (through new reposition or change of mode) --> see https://github.com/PX4/PX4-Autopilot/commit/66ca5c294952689e0775c5136ad0d7f6604a2d17
3) check GF breach in update function, and stop updating the current GF if it would immediately get breached --> see https://github.com/PX4/PX4-Autopilot/commit/83f3665d9576b453142196c2e4725e46728d1f46
4) check GF breach in update function, and stop updating the current GF if it doesn't contain Home --> see https://github.com/PX4/PX4-Autopilot/commit/83f3665d9576b453142196c2e4725e46728d1f46
5) Change logic that all GF action already gets triggered when the GF leaves one inclusion GF, not only when outside of all inclusion GF. 
I'm not entirely sure what we want, but for me it seems cleaner that way.
6) remove it.
7) remote it.
8) see https://github.com/PX4/PX4-Autopilot/commit/8e1c3e8093e3da0dbe9a276eb01d2672d7cd190b:
 - geofence_result.cpp contains to contain separate fields for the 3 geofence types
 -  remote "primary" from messages, as we don't distinguish primary vs secondary etc
 - do all user notification due to GF breach from Commander
9) various 

### Changelog Entry
For release notes:
```
Bugfix: Geofence: correctly listen to GF_SOURCE
Bugfix: Geofence: do not constantly send new reposition waypoints when GF is breached as a fixed-wing
Feature: Geofence: if armed, do not allow to upload GF that would immediately trigger
Feature: Geofence: do not allow to upload GF if it doesn't contain Home (to not break RTL)
Documentation: TODO
```

### Alternatives
We should also fix the pre-emptive geofence triggering (GF_PREDICT=1). I haven't touched that in this PR, and even split it up further (without GF_PREDICT=1 it will now always set the Hold point at the position it is currently at).

### Test coverage
SITL tested

### Context
Screen recording with current main, where issues 4) and 2) are visible:

https://github.com/PX4/PX4-Autopilot/assets/26798987/87cd8a30-1768-493f-afa6-9ce8dc84ac27

Screen recording of this PR, where the new features 3) and 4) are shown, plus fixed 2):

https://github.com/PX4/PX4-Autopilot/assets/26798987/2469124f-63e4-4f1e-9ac4-5315b2d020da



