### PR TITLE
Autotune: fix state machine stuck in "Initializing"

### DIFF
--- a/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
+++ b/src/modules/fw_autotune_attitude_control/fw_autotune_attitude_control.cpp
@@ -229,7 +229,7 @@ void FwAutotuneAttitudeControl::checkFilters()
 			reset_filters = true;
 		}
 
-		if (reset_filters) {
+		if (reset_filters || !_are_filters_initialized) {
 			_are_filters_initialized = true;
 			_filter_sample_rate = update_rate_hz;
 			_sys_id.setLpfCutoffFrequency(_filter_sample_rate, _param_imu_gyro_cutoff.get());

--- a/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
+++ b/src/modules/mc_autotune_attitude_control/mc_autotune_attitude_control.cpp
@@ -236,7 +236,7 @@ void McAutotuneAttitudeControl::checkFilters()
 			reset_filters = true;
 		}
 
-		if (reset_filters && !_are_filters_initialized) {
+		if (reset_filters || !_are_filters_initialized) {
 			_filter_dt = _sample_interval_avg;
 
 			const float filter_rate_hz = 1.f / _filter_dt;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Autotune is sometimes stuck in the Init state because it waits for the filters to initialize but nothing happens because there is no need for a reset.

### Changelog Entry
For release notes:
```
Autotune: fix state machine stuck in "Initializing"
```