### PR TITLE
battery: make time remaining estimation dependent on level flight cha…

### DIFF
--- a/msg/BatteryStatus.msg
+++ b/msg/BatteryStatus.msg
@@ -4,7 +4,7 @@ float32 voltage_v			# Battery voltage in volts, 0 if unknown
 float32 voltage_filtered_v	# Battery voltage in volts, filtered, 0 if unknown
 float32 current_a			# Battery current in amperes, -1 if unknown
 float32 current_filtered_a	# Battery current in amperes, filtered, 0 if unknown
-float32 current_average_a	# Battery current average in amperes, -1 if unknown
+float32 current_average_a	# Battery current average in amperes (for FW average in level flight), -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown
 float32 scale				# Power scaling factor, >= 1, or -1 if unknown

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -92,6 +92,7 @@ set(msg_files
 	FigureEightStatus.msg
 	FailsafeFlags.msg
 	FailureDetectorStatus.msg
+	FlightPhaseEstimation.msg
 	FollowTarget.msg
 	FollowTargetEstimator.msg
 	FollowTargetStatus.msg

--- a/msg/FlightPhaseEstimation.msg
+++ b/msg/FlightPhaseEstimation.msg
@@ -1,0 +1,8 @@
+uint64 timestamp               # time since system start (microseconds)
+
+uint8 flight_phase 		# Estimate of current flight phase
+
+uint8 FLIGHT_PHASE_UNKNOWN = 0  # vehicle flight phase is unknown
+uint8 FLIGHT_PHASE_LEVEL = 1	# Vehicle is in level flight
+uint8 FLIGHT_PHASE_DESCEND = 2	# vehicle is in descend
+uint8 FLIGHT_PHASE_CLIMB = 3   # vehicle is climbing

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -306,11 +306,12 @@ float Battery::computeRemainingTime(float current_a)
 {
 	float time_remaining_s = NAN;
 
-	vehicle_status_s vehicle_status;
-
 	if (_vehicle_status_sub.updated()) {
+		vehicle_status_s vehicle_status;
+
 		if (_vehicle_status_sub.copy(&vehicle_status)) {
 			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+			_vehicle_status_is_fw = (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING);
 		}
 	}
 
@@ -322,9 +323,8 @@ float Battery::computeRemainingTime(float current_a)
 
 	if (_armed && PX4_ISFINITE(current_a)) {
 		// For FW only update when we are in level flight
-		if (vehicle_status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_FIXED_WING
-		    || ((hrt_absolute_time() - _flight_phase_estimation_sub.get().timestamp) < 2_s
-			&& _flight_phase_estimation_sub.get().flight_phase == flight_phase_estimation_s::FLIGHT_PHASE_LEVEL)) {
+		if (!_vehicle_status_is_fw || ((hrt_absolute_time() - _flight_phase_estimation_sub.get().timestamp) < 2_s
+					       && _flight_phase_estimation_sub.get().flight_phase == flight_phase_estimation_s::FLIGHT_PHASE_LEVEL)) {
 			// only update with positive numbers
 			_current_average_filter_a.update(fmaxf(current_a, 0.f));
 		}

--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -306,21 +306,28 @@ float Battery::computeRemainingTime(float current_a)
 {
 	float time_remaining_s = NAN;
 
-	if (_vehicle_status_sub.updated()) {
-		vehicle_status_s vehicle_status;
+	vehicle_status_s vehicle_status;
 
+	if (_vehicle_status_sub.updated()) {
 		if (_vehicle_status_sub.copy(&vehicle_status)) {
 			_armed = (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
 		}
 	}
+
+	_flight_phase_estimation_sub.update();
 
 	if (!PX4_ISFINITE(_current_average_filter_a.getState()) || _current_average_filter_a.getState() < FLT_EPSILON) {
 		_current_average_filter_a.reset(_params.bat_avrg_current);
 	}
 
 	if (_armed && PX4_ISFINITE(current_a)) {
-		// only update with positive numbers
-		_current_average_filter_a.update(fmaxf(current_a, 0.f));
+		// For FW only update when we are in level flight
+		if (vehicle_status.vehicle_type != vehicle_status_s::VEHICLE_TYPE_FIXED_WING
+		    || ((hrt_absolute_time() - _flight_phase_estimation_sub.get().timestamp) < 2_s
+			&& _flight_phase_estimation_sub.get().flight_phase == flight_phase_estimation_s::FLIGHT_PHASE_LEVEL)) {
+			// only update with positive numbers
+			_current_average_filter_a.update(fmaxf(current_a, 0.f));
+		}
 	}
 
 	// Remaining time estimation only possible with capacity

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -181,5 +181,6 @@ private:
 	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
 	hrt_abstime _last_timestamp{0};
 	bool _armed{false};
+	bool _vehicle_status_is_fw{false};
 	hrt_abstime _last_unconnected_timestamp{0};
 };

--- a/src/lib/battery/battery.h
+++ b/src/lib/battery/battery.h
@@ -56,6 +56,7 @@
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/battery_status.h>
+#include <uORB/topics/flight_phase_estimation.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_thrust_setpoint.h>
 
@@ -156,6 +157,7 @@ private:
 
 	uORB::Subscription _vehicle_thrust_setpoint_0_sub{ORB_ID(vehicle_thrust_setpoint)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::SubscriptionData<flight_phase_estimation_s> _flight_phase_estimation_sub{ORB_ID(flight_phase_estimation)};
 	uORB::PublicationMulti<battery_status_s> _battery_status_pub{ORB_ID(battery_status)};
 
 	bool _external_state_of_charge{false}; ///< inticates that the soc is injected and not updated by this library
@@ -168,7 +170,8 @@ private:
 	AlphaFilter<float> _voltage_filter_v;
 	float _current_a{-1};
 	AlphaFilter<float> _current_filter_a;
-	AlphaFilter<float> _current_average_filter_a;
+	AlphaFilter<float>
+	_current_average_filter_a; ///< averaging filter for current. For FW, it is the current in level flight.
 	AlphaFilter<float> _throttle_filter;
 	float _discharged_mah{0.f};
 	float _discharged_mah_loop{0.f};

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -48,8 +48,6 @@ using matrix::Vector2d;
 using matrix::Vector3f;
 using matrix::wrap_pi;
 
-static constexpr float MAX_ALT_REF_RATE_FOR_LEVEL_FLIGHT{0.1f};
-
 FixedwingPositionControl::FixedwingPositionControl(bool vtol) :
 	ModuleParams(nullptr),
 	WorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers),

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -72,6 +72,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionCallback.hpp>
 #include <uORB/topics/airspeed_validated.h>
+#include <uORB/topics/flight_phase_estimation.h>
 #include <uORB/topics/landing_gear.h>
 #include <uORB/topics/launch_detection_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
@@ -214,6 +215,7 @@ private:
 	uORB::Publication<landing_gear_s> _landing_gear_pub {ORB_ID(landing_gear)};
 	uORB::Publication<normalized_unsigned_setpoint_s> _flaps_setpoint_pub{ORB_ID(flaps_setpoint)};
 	uORB::Publication<normalized_unsigned_setpoint_s> _spoilers_setpoint_pub{ORB_ID(spoilers_setpoint)};
+	uORB::PublicationData<flight_phase_estimation_s> _flight_phase_estimation_pub{ORB_ID(flight_phase_estimation)};
 
 	manual_control_setpoint_s _manual_control_setpoint{};
 	position_setpoint_triplet_s _pos_sp_triplet{};
@@ -384,6 +386,8 @@ private:
 	TECS _tecs;
 
 	bool _tecs_is_running{false};
+	float _last_tecs_alt_sp{0.f}; //< last tecs altitude setpoint [m]
+
 	// VTOL / TRANSITION
 	bool _is_vtol_tailsitter{false};
 	matrix::Vector2d _transition_waypoint{(double)NAN, (double)NAN};

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -389,7 +389,6 @@ private:
 	TECS _tecs;
 
 	bool _tecs_is_running{false};
-	float _last_tecs_alt_sp{0.f}; //< last tecs altitude setpoint [m]
 
 	// VTOL / TRANSITION
 	bool _is_vtol_tailsitter{false};

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -165,6 +165,9 @@ static constexpr float MANUAL_TOUCHDOWN_NUDGE_INPUT_DEADZONE = 0.15f;
 // [s] time interval after touchdown for ramping in runway clamping constraints (touchdown is assumed at FW_LND_TD_TIME after start of flare)
 static constexpr float POST_TOUCHDOWN_CLAMP_TIME = 0.5f;
 
+// [m/s] maximum reference altitude rate threshhold
+static constexpr float MAX_ALT_REF_RATE_FOR_LEVEL_FLIGHT = 0.1f;
+
 class FixedwingPositionControl final : public ModuleBase<FixedwingPositionControl>, public ModuleParams,
 	public px4::WorkItem
 {

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -68,6 +68,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("follow_target_estimator", 200);
 	add_optional_topic("follow_target_status", 400);
 	add_optional_topic("flaps_setpoint", 1000);
+	add_optional_topic("flight_phase_estimation", 1000);
 	add_topic("gimbal_manager_set_attitude", 500);
 	add_optional_topic("generator_status");
 	add_optional_topic("gps_dump");


### PR DESCRIPTION
…racteristis for FW

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
For fixed wing vehicles the remaining time estimate can significantly reduce when the vehicle is climbing for a longer period and trigger an RTL. The flight time estimate should be based on the level flight power consumption as this is the relevant data for the majority of the RTL flight profile.

Fixes #{Github issue ID}

### Solution
- Add simple level flight estimator in the fixed wing position controller. For now the estimator is only run when the vehicle controls the altitude or altitude rate, the altitude setpoint is constant and the vehicle is close to the altitude setpoint.
- The battery current_average is modified to only update the average, when level flight is detected for FW.

### Changelog Entry
For release notes:
```
Feature Battery remainig time estimate for FW is estimating time for level flight
```

### Alternatives
The current implementation makes the battery status dependent on the vehicle which is wrong. A better solution would be to actually have sort of a power consumption module which checks the battery that are relevant and make one consolidated estimate and battery overview. However, this would take considerable more effort and should be considered in the future.
Also the current implementation is dependent on the auto modes and does not update the estimate for manual modes.
