### PR TITLE
Add Cube Orange Plus to CMake variants

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -191,6 +191,11 @@ CONFIG:
       buildType: MinSizeRel
       settings:
         CONFIG: cubepilot_cubeorange_test
+    cubepilot_cubeorangeplus_test:
+      short: cubepilot_cubeorangeplus
+      buildType: MinSizeRel
+      settings:
+        CONFIG: cubepilot_cubeorangeplus_test
     emlid_navio2_default:
       short: emlid_navio2
       buildType: MinSizeRel


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
There is currently no CMake variant for the Cube Orange Plus meaning that full VSCode development (including building through VSCode) for this target is not possible.

### Solution
- Add new variant to the list of CMake variants
- Used the _test target (as used for standard Cube Orange) to allow hardware debugging by default (serial console)

### Changelog Entry
For release notes:
```
Cube Orange Plus variant added to list of CMake variants
```

### Alternatives
N/A

### Test coverage
- Build is successful through VSCode

### Context
N/A
