### PR TITLE
Migrate S3 metadata upload from Jenkins to Github Actions

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -1,4 +1,4 @@
-name: Deploy metadata for all targets
+name: Deploy metadata
 
 on:
   push:
@@ -54,8 +54,35 @@ jobs:
         AWS_REGION: 'us-west-1'
         SOURCE_DIR: 'build/${{ matrix.target }}/_metadata/'
         DEST_DIR: 'Firmware/${{ env.version }}/${{ matrix.target }}/'
-  generic_metadata:
+  airframe_parameter_metadata:
     runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-focal:2021-08-18
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{secrets.ACCESS_TOKEN}}
+    - name: Build airframe & parameter metadata
+      run: |
+        make airframe_metadata parameters_metadata
+    - name: Archive airframe & parameter metadata
+      uses: actions/upload-artifact@v3
+  module_documentation:
+    runs-on: ubuntu-latest
+  uorb_msg_documentation:
+    runs-on: ubuntu-latest
+  failsafe_documentation:
+    runs-on: ubuntu-latest
+  update_userguide:
+    runs-on: ubuntu-latest
+    needs: [airframe_parameter_metadata, module_documentation, uorb_msg_documentation, failsafe_documentation]
+  update_qgroundcontrol:
+    runs-on: ubuntu-latest
+    needs: airframe_parameter_metadata
+  update_px4_ros_msgs:
+    runs-on: ubuntu-latest
+  upload_s3_metadata:
+    runs-on: ubuntu-latest
+    needs: airframe_parameter_metadata
     container: px4io/px4-dev-base-focal:2021-09-08
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -54,4 +54,26 @@ jobs:
         AWS_REGION: 'us-west-1'
         SOURCE_DIR: 'build/${{ matrix.target }}/_metadata/'
         DEST_DIR: 'Firmware/${{ env.version }}/${{ matrix.target }}/'
-
+  generic_metadata:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-focal:2021-09-08
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{secrets.ACCESS_TOKEN}}
+    - name: Build generic metadata
+      run: |
+        make airframe_metadata parameters_metadata
+        cd build/px4_sitl_default/docs
+        mkdir _metadata || true
+        cp parameters.xml, parameters.json.xz, airframes.xml _metadata
+    - uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read
+      env:
+        AWS_S3_BUCKET: 'px4-travis'
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-west-1'
+        SOURCE_DIR: 'build/px4_sitl_default/_metadata/'
+        DEST_DIR: 'Firmware/${{ env.version }}/px4_sitl_default/'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,33 +243,6 @@ pipeline {
           }
         }
 
-        stage('S3') {
-          agent {
-            docker { image 'px4io/px4-dev-base-focal:2021-08-18' }
-          }
-          steps {
-            sh('export')
-            unstash 'metadata_airframes'
-            unstash 'metadata_parameters'
-            sh('ls')
-            withAWS(credentials: 'px4_aws_s3_key', region: 'us-east-1') {
-              s3Upload(acl: 'PublicRead', bucket: 'px4-travis', file: 'airframes.xml', path: 'Firmware/master/')
-              s3Upload(acl: 'PublicRead', bucket: 'px4-travis', file: 'parameters.xml', path: 'Firmware/master/')
-              s3Upload(acl: 'PublicRead', bucket: 'px4-travis', file: 'parameters.json.xz', path: 'Firmware/master/')
-            }
-          }
-          when {
-            anyOf {
-              branch 'main'
-              branch 'master' // should be removed, but in case there is something going on...
-              branch 'pr-jenkins' // for testing
-            }
-          }
-          options {
-            skipDefaultCheckout()
-          }
-        }
-
       } // parallel
     } // stage: Generate Metadata
 


### PR DESCRIPTION
### Solved Problem
Jenkins was handling updating the generic metadata update in S3, while Github actions (deploy_all.yml) was handling per-target metadata deployment.

### Solution
Unify S3 deployment into Github action

### Changelog Entry
For release notes:
```
Migrate S3 metadata upload in Jenkins to Github Actions
```

### Context
While writing https://github.com/PX4/PX4-user_guide/pull/2284 I discovered this redundancy in CI.

Replaces https://github.com/PX4/PX4-Autopilot/pull/21786

Related PR from the past: https://github.com/PX4/PX4-Autopilot/pull/18772