### PR TITLE
Ignore mission yaw setpoints in `WV_EN` enabled

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -439,6 +439,13 @@ MissionBlock::is_mission_item_reached_or_completed()
 				_navigator->set_mission_failure_heading_timeout();
 			}
 
+			// If Weathervane is enabled, ignore yaw setpoint
+			position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+			if ((_navigator->get_weathervane_enabled() == true) && (pos_sp_triplet->current.disable_weather_vane == false)) {
+				_waypoint_yaw_reached = true;
+			}
+
 		} else {
 			_waypoint_yaw_reached = true;
 		}

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -442,7 +442,7 @@ MissionBlock::is_mission_item_reached_or_completed()
 			// If Weathervane is enabled, ignore yaw setpoint
 			position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-			if ((_navigator->get_weathervane_enabled() == true) && (pos_sp_triplet->current.disable_weather_vane == false)) {
+			if (_navigator->get_weathervane_enabled() && !pos_sp_triplet->current.disable_weather_vane) {
 				_waypoint_yaw_reached = true;
 			}
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -292,6 +292,7 @@ public:
 	float get_takeoff_min_alt() const { return _param_mis_takeoff_alt.get(); }
 	int  get_takeoff_land_required() const { return _para_mis_takeoff_land_req.get(); }
 	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
+	bool get_weathervane_enabled() const { return _param_wv_en.get(); }
 	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
 	float get_lndmc_alt_max() const { return _param_lndmc_alt_max.get(); }
 
@@ -432,6 +433,7 @@ private:
 		(ParamInt<px4::params::MIS_TKO_LAND_REQ>)  _para_mis_takeoff_land_req,
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
+		(ParamBool<px4::params::WV_EN>)		_param_wv_en,
 		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
 		(ParamFloat<px4::params::LNDMC_ALT_MAX>)   _param_lndmc_alt_max,
 		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
In mission mode or return mode, weather-vaning can cause the drones' heading to change by more than MIS_YAW_ERROR. This causes the drone to remain at its current mission setpoint indefinitely.

Fixes #22355

### Solution
Added a conditional to make `_waypoint_yaw_reached = true` if `WV_EN` is enabled and `position_setpoint.disable_weather_vane=false`

### Test coverage
- Tested in sitl with the windy environment. 
- Ran a mission specifying yaw setpoints at each waypoint
- with `WV_EN=1` vehicle ignored yaw setpoints and completed the mission pointing into the wind (https://review.px4.io/plot_app?log=f0720db6-dd2e-486d-8d38-dfa08e58048f)
- with  `WV_EN=0` the vehicle follows yaw setpoints specified in the mission (https://review.px4.io/plot_app?log=f95a52a1-3710-491d-a8d1-3655c709ccb9)


