### PR TITLE
EKF2: rename delta vel/ang bias

### DIFF
--- a/Tools/ecl_ekf/plotting/pdf_report.py
+++ b/Tools/ecl_ekf/plotting/pdf_report.py
@@ -44,6 +44,11 @@ def create_pdf_report(ulog: ULog, multi_instance: int, output_plot_filename: str
         raise PreconditionError('could not find estimator_states instance', multi_instance)
 
     try:
+        estimator_sensor_bias = ulog.get_dataset('estimator_sensor_bias', multi_instance).data
+    except:
+        raise PreconditionError('could not find estimator_sensor_bias instance', multi_instance)
+
+    try:
         estimator_innovations = ulog.get_dataset('estimator_innovations', multi_instance).data
         estimator_innovation_variances = ulog.get_dataset('estimator_innovation_variances', multi_instance).data
         innovation_data = estimator_innovations
@@ -299,21 +304,21 @@ def create_pdf_report(ulog: ULog, multi_instance: int, output_plot_filename: str
         data_plot.save()
         data_plot.close()
 
-        # Plot the delta angle bias estimates
+        # Plot the gyro bias estimates
         data_plot = CheckFlagsPlot(
-            1e-6 * estimator_states['timestamp'], estimator_states,
-            [['states[10]'], ['states[11]'], ['states[12]']],
-            x_label='time (sec)', y_labels=['X (rad)', 'Y (rad)', 'Z (rad)'],
-            plot_title='Delta Angle Bias Estimates', annotate=False, pdf_handle=pdf_pages)
+            1e-6 * estimator_sensor_bias['timestamp'], estimator_sensor_bias,
+            [['gyro_bias[0]'], ['gyro_bias[1]'], ['gyro_bias[2]']],
+            x_label='time (sec)', y_labels=['X (rad/s)', 'Y (rad/s)', 'Z (rad/s)'],
+            plot_title='Gyro Bias Estimates', annotate=False, pdf_handle=pdf_pages)
         data_plot.save()
         data_plot.close()
 
-        # Plot the delta velocity bias estimates
+        # Plot the accel bias estimates
         data_plot = CheckFlagsPlot(
-            1e-6 * estimator_states['timestamp'], estimator_states,
-            [['states[13]'], ['states[14]'], ['states[15]']],
-            x_label='time (sec)', y_labels=['X (m/s)', 'Y (m/s)', 'Z (m/s)'],
-            plot_title='Delta Velocity Bias Estimates', annotate=False, pdf_handle=pdf_pages)
+            1e-6 * estimator_sensor_bias['timestamp'], estimator_sensor_bias,
+            [['accel_bias[0]'], ['accel_bias[1]'], ['accel_bias[2]']],
+            x_label='time (sec)', y_labels=['X (m/s^2)', 'Y (m/s^2)', 'Z (m/s^2)'],
+            plot_title='Accel Bias Estimates', annotate=False, pdf_handle=pdf_pages)
         data_plot.save()
         data_plot.close()
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1383,7 +1383,7 @@ PARAM_DEFINE_FLOAT(EKF2_PCOEF_Z, 0.0f);
 /**
  * Accelerometer bias learning limit.
  *
- * The ekf delta velocity bias states will be limited to within a range equivalent to +- of this value.
+ * The ekf accel bias states will be limited to within a range equivalent to +- of this value.
  *
  * @group EKF2
  * @min 0.0
@@ -1396,8 +1396,8 @@ PARAM_DEFINE_FLOAT(EKF2_ABL_LIM, 0.4f);
 /**
  * Maximum IMU accel magnitude that allows IMU bias learning.
  *
- * If the magnitude of the IMU accelerometer vector exceeds this value, the EKF delta velocity state estimation will be inhibited.
- * This reduces the adverse effect of high manoeuvre accelerations and IMU nonlinerity and scale factor errors on the delta velocity bias estimates.
+ * If the magnitude of the IMU accelerometer vector exceeds this value, the EKF accel bias state estimation will be inhibited.
+ * This reduces the adverse effect of high manoeuvre accelerations and IMU nonlinerity and scale factor errors on the accel bias estimates.
  *
  * @group EKF2
  * @min 20.0
@@ -1410,8 +1410,8 @@ PARAM_DEFINE_FLOAT(EKF2_ABL_ACCLIM, 25.0f);
 /**
  * Maximum IMU gyro angular rate magnitude that allows IMU bias learning.
  *
- * If the magnitude of the IMU angular rate vector exceeds this value, the EKF delta velocity state estimation will be inhibited.
- * This reduces the adverse effect of rapid rotation rates and associated errors on the delta velocity bias estimates.
+ * If the magnitude of the IMU angular rate vector exceeds this value, the EKF accel bias state estimation will be inhibited.
+ * This reduces the adverse effect of rapid rotation rates and associated errors on the accel bias estimates.
  *
  * @group EKF2
  * @min 2.0
@@ -1422,7 +1422,7 @@ PARAM_DEFINE_FLOAT(EKF2_ABL_ACCLIM, 25.0f);
 PARAM_DEFINE_FLOAT(EKF2_ABL_GYRLIM, 3.0f);
 
 /**
- * Time constant used by acceleration and angular rate magnitude checks used to inhibit delta velocity bias learning.
+ * Time constant used by acceleration and angular rate magnitude checks used to inhibit accel bias learning.
  *
  * The vector magnitude of angular rate and acceleration used to check if learning should be inhibited has a peak hold filter applied to it with an exponential decay.
  * This parameter controls the time constant of the decay.
@@ -1438,7 +1438,7 @@ PARAM_DEFINE_FLOAT(EKF2_ABL_TAU, 0.5f);
 /**
  * Gyro bias learning limit.
  *
- * The ekf delta angle bias states will be limited to within a range equivalent to +- of this value.
+ * The ekf gyro bias states will be limited to within a range equivalent to +- of this value.
  *
  * @group EKF2
  * @min 0.0


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

We're not estimating delta vel/ang biases anymore, but accel and gyro biases. 


Not sure if anyone is still using the ekf pdf report, but I updated it anyway.