### PR TITLE
[gz-sim] x500_lidar for testing CollisionPrevention

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4013_gz_x500_lidar
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4013_gz_x500_lidar
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+# @name Gazebo x500 lidar
+#
+# @type Quadrotor
+#
+
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=x500_lidar}
+
+. ${R}etc/init.d-posix/airframes/4001_gz_x500

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -84,6 +84,7 @@ px4_add_romfs_files(
 	4010_gz_x500_mono_cam
 	4011_gz_lawnmower
 	4012_gz_rover_ackermann
+	4013_gz_x500_lidar
 
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post

--- a/msg/ObstacleDistance.msg
+++ b/msg/ObstacleDistance.msg
@@ -19,6 +19,6 @@ float32 increment # Angular width in degrees of each array element.
 uint16 min_distance # Minimum distance the sensor can measure in centimeters.
 uint16 max_distance # Maximum distance the sensor can measure in centimeters.
 
-float32 angle_offset # Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive values are offsets to the right.
+float32 angle_offset # Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive is clockwise direction, negative is counter-clockwise.
 
 # TOPICS obstacle_distance obstacle_distance_fused

--- a/platforms/posix/Debug/launch_sitl.json.in
+++ b/platforms/posix/Debug/launch_sitl.json.in
@@ -223,6 +223,7 @@
             "options": [
               "x500",
               "x500_depth",
+              "x500_lidar",
               "rc_cessna",
               "standard_vtol",
             ],

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -196,6 +196,14 @@ int GZBridge::init()
 		return PX4_ERROR;
 	}
 
+	// Laser Scan
+	std::string laser_scan_topic = "/world/" + _world_name + "/model/" + _model_name + "/link/link/sensor/lidar_2d_v2/scan";
+
+	if (!_node.Subscribe(laser_scan_topic, &GZBridge::laserScanCallback, this)) {
+		PX4_ERR("failed to subscribe to %s", laser_scan_topic.c_str());
+		return PX4_ERROR;
+	}
+
 #if 0
 	// Airspeed: /world/$WORLD/model/$MODEL/link/airspeed_link/sensor/air_speed/air_speed
 	std::string airpressure_topic = "/world/" + _world_name + "/model/" + _model_name +
@@ -739,6 +747,87 @@ void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 	}
 
 	pthread_mutex_unlock(&_node_mutex);
+}
+
+void GZBridge::laserScanCallback(const gz::msgs::LaserScan &scan)
+{
+	static constexpr int SECTOR_SIZE_DEG = 10; // PX4 Collision Prevention only has 36 sectors of 10 degrees each
+
+	double angle_min_deg = scan.angle_min() * 180 / M_PI;
+	double angle_step_deg = scan.angle_step() * 180 / M_PI;
+
+	int samples_per_sector = std::round(SECTOR_SIZE_DEG / angle_step_deg);
+	int number_of_sectors = scan.ranges_size() / samples_per_sector;
+
+	std::vector<double> ds_array(number_of_sectors, UINT16_MAX);
+
+	// Downsample -- take average of samples per sector
+	for (int i = 0; i < number_of_sectors; i++) {
+
+		double sum = 0;
+
+		int samples_used_in_sector = 0;
+
+		for (int j = 0; j < samples_per_sector; j++) {
+
+			double distance = scan.ranges()[i * samples_per_sector + j];
+
+			// inf values mean no object
+			if (isinf(distance)) {
+				continue;
+			}
+
+			sum += distance;
+			samples_used_in_sector++;
+		}
+
+		// If all samples in a sector are inf then it means the sector is clear
+		if (samples_used_in_sector == 0) {
+			ds_array[i] = scan.range_max();
+
+		} else {
+			ds_array[i] = sum / samples_used_in_sector;
+		}
+	}
+
+	// Publish to uORB
+	obstacle_distance_s obs {};
+
+	// Initialize unknown
+	for (auto &i : obs.distances) {
+		i = UINT16_MAX;
+	}
+
+	obs.timestamp = hrt_absolute_time();
+	obs.frame = obstacle_distance_s::MAV_FRAME_BODY_FRD;
+	obs.sensor_type = obstacle_distance_s::MAV_DISTANCE_SENSOR_LASER;
+	obs.min_distance = static_cast<uint16_t>(scan.range_min() * 100.);
+	obs.max_distance = static_cast<uint16_t>(scan.range_max() * 100.);
+	obs.angle_offset = static_cast<float>(angle_min_deg);
+	obs.increment = static_cast<float>(SECTOR_SIZE_DEG);
+
+	// Map samples in FOV into sectors in ObstacleDistance
+	int index = 0;
+
+	// Iterate in reverse because array is FLU and we need FRD
+	for (std::vector<double>::reverse_iterator i = ds_array.rbegin(); i != ds_array.rend(); ++i) {
+
+		uint16_t distance_cm = (*i) * 100.;
+
+		if (distance_cm >= obs.max_distance) {
+			obs.distances[index] = obs.max_distance + 1;
+
+		} else if (distance_cm < obs.min_distance) {
+			obs.distances[index] = 0;
+
+		} else {
+			obs.distances[index] = distance_cm;
+		}
+
+		index++;
+	}
+
+	_obstacle_distance_pub.publish(obs);
 }
 
 void GZBridge::rotateQuaternion(gz::math::Quaterniond &q_FRD_to_NED, const gz::math::Quaterniond q_FLU_to_ENU)

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -196,12 +196,11 @@ int GZBridge::init()
 		return PX4_ERROR;
 	}
 
-	// Laser Scan
+	// Laser Scan: optional
 	std::string laser_scan_topic = "/world/" + _world_name + "/model/" + _model_name + "/link/link/sensor/lidar_2d_v2/scan";
 
 	if (!_node.Subscribe(laser_scan_topic, &GZBridge::laserScanCallback, this)) {
-		PX4_ERR("failed to subscribe to %s", laser_scan_topic.c_str());
-		return PX4_ERROR;
+		PX4_WARN("failed to subscribe to %s", laser_scan_topic.c_str());
 	}
 
 #if 0

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -58,6 +58,7 @@
 #include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/wheel_encoders.h>
+#include <uORB/topics/obstacle_distance.h>
 
 #include <gz/math.hh>
 #include <gz/msgs.hh>
@@ -67,6 +68,7 @@
 #include <gz/msgs/fluid_pressure.pb.h>
 #include <gz/msgs/model.pb.h>
 #include <gz/msgs/odometry_with_covariance.pb.h>
+#include <gz/msgs/laserscan.pb.h>
 
 using namespace time_literals;
 
@@ -106,6 +108,7 @@ private:
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
 	void navSatCallback(const gz::msgs::NavSat &nav_sat);
+	void laserScanCallback(const gz::msgs::LaserScan &scan);
 
 	/**
 	*
@@ -121,6 +124,7 @@ private:
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
 
 	//uORB::Publication<differential_pressure_s>    _differential_pressure_pub{ORB_ID(differential_pressure)};
+	uORB::Publication<obstacle_distance_s>        _obstacle_distance_pub{ORB_ID(obstacle_distance)};
 	uORB::Publication<vehicle_angular_velocity_s> _angular_velocity_ground_truth_pub{ORB_ID(vehicle_angular_velocity_groundtruth)};
 	uORB::Publication<vehicle_attitude_s>         _attitude_ground_truth_pub{ORB_ID(vehicle_attitude_groundtruth)};
 	uORB::Publication<vehicle_global_position_s>  _gpos_ground_truth_pub{ORB_ID(vehicle_global_position_groundtruth)};


### PR DESCRIPTION
Added another x500 model with a lidar attached.
https://app.gazebosim.org/OpenRobotics/fuel/models/Lidar%202d%20v2

Subscribes to gz::msgs::LaserScan and publishes to ObstacleDistance. 



**requires** https://github.com/PX4/PX4-gazebo-models/pull/41

![image](https://github.com/PX4/PX4-Autopilot/assets/37091262/0632f3c5-1e8c-4ac5-9aea-743137a2c12e)
![image](https://github.com/PX4/PX4-Autopilot/assets/37091262/02368bfa-0f67-4c88-b622-79a38d85418c)

