### PR TITLE
logger: log all GPS data

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -120,7 +120,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_constraints", 1000);
 	add_topic("vehicle_control_mode");
 	add_topic("vehicle_global_position", 200);
-	add_topic("vehicle_gps_position", 500);
+	add_topic("vehicle_gps_position", 100);
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_local_position", 100);
 	add_topic("vehicle_local_position_setpoint", 100);


### PR DESCRIPTION
I propose to log GPS data at full rate instead of once a second because GPS data is usually only 10 Hz anyway, and for debugging every sample can be an important clue.

For instance, not all sensor_gps messages contain the heading, and so heading is completely missed and impossible to debug.

This came up when debugging https://discuss.px4.io/t/um982-isnt-providing-heading-data/35195.