### PR TITLE
[1.14] Fix terrain estimator validity issue

### DIFF
--- a/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
+++ b/src/modules/ekf2/EKF/range_finder_consistency_check.hpp
@@ -47,7 +47,7 @@ public:
 	RangeFinderConsistencyCheck() = default;
 	~RangeFinderConsistencyCheck() = default;
 
-	void update(float dist_bottom, float dist_bottom_var, float vz, float vz_var, uint64_t time_us);
+	void update(float dist_bottom, float dist_bottom_var, float vz, float vz_var, bool horizontal_motion, uint64_t time_us);
 
 	void setGate(float gate) { _gate = gate; }
 
@@ -71,6 +71,7 @@ private:
 
 	bool _is_kinematically_consistent{true};
 	uint64_t _time_last_inconsistent_us{};
+	uint64_t _time_last_horizontal_motion{};
 
 	static constexpr float _signed_test_ratio_tau = 2.f;
 

--- a/src/modules/ekf2/EKF/terrain_estimator.cpp
+++ b/src/modules/ekf2/EKF/terrain_estimator.cpp
@@ -199,7 +199,6 @@ void Ekf::resetHaglRng()
 	_terrain_var = getRngVar();
 	_terrain_vpos_reset_counter++;
 	_time_last_hagl_fuse = _time_delayed_us;
-	_time_last_healthy_rng_data = 0;
 }
 
 void Ekf::stopHaglRngFusion()


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
fixes: https://github.com/PX4/PX4-Autopilot/issues/22357
The issues was caused by the reset function setting `_time_last_healthy_rng_data` to 0, leading to an immediate timeout at the next loop run.

Issue got introduces in https://github.com/PX4/PX4-Autopilot/pull/21338
and fixed in https://github.com/PX4/PX4-Autopilot/pull/22030

I also decided to pull https://github.com/PX4/PX4-Autopilot/pull/22117 to reduce the likelihood of hitting another corner care that we fixed recently on the range finder kinematic consistency check.

Verified in replay using https://review.px4.io/plot_app?log=76f8ab88-738c-4a14-a9f7-dd87dd617366
Before:
![Screenshot from 2023-11-21 13-52-44](https://github.com/PX4/PX4-Autopilot/assets/14822839/0c18e3a7-c43a-4370-9bc5-ad5516cce7f9)

After:
![Screenshot from 2023-11-21 13-52-35](https://github.com/PX4/PX4-Autopilot/assets/14822839/dc82b275-259a-4785-8142-27bef2b9436a)