### PR TITLE
L1 bug - fix Crosstrack Error angle calculation in ECL_L1_Pos_Controller.cpp

### DIFF
--- a/src/lib/l1/ECL_L1_Pos_Controller.cpp
+++ b/src/lib/l1/ECL_L1_Pos_Controller.cpp
@@ -83,7 +83,7 @@ ECL_L1_Pos_Controller::navigate_waypoints(const Vector2f &vector_A, const Vector
 	Vector2f vector_A_to_airplane = vector_curr_position - vector_A;
 
 	/* calculate crosstrack error (output only) */
-	_crosstrack_error = vector_AB % vector_A_to_airplane;
+	_crosstrack_error = vector_AB % vector_A_to_airplane.normalized();
 
 	/*
 	 * If the current position is in a +-135 degree angle behind waypoint A


### PR DESCRIPTION
"vector_A_to_airplane" should be normalized for proper angle calculation

### Solved Problem
L1 algorithm allows a vehicle to closely follow a line between two waypoints (A and B).
In current code there is a calculation of an angle between A-P line and A-B line (P being current position).
It can be queried using crosstrack_error() method, and cab be used by a consumer to calculate crosstrack distance (how far from the A-B line the vehicle is).
It is important to have these calculations done correctly, as some vehicles in agricultural and survey areas have to stick to scan lines precisely.

### Testing
I tested the correction in SITL and live in my lawnmower robot.
