### PR TITLE
Fix Orbit Crash

### DIFF
--- a/msg/VehicleControlMode.msg
+++ b/msg/VehicleControlMode.msg
@@ -6,15 +6,15 @@ bool flag_multicopter_position_control_enabled
 bool flag_control_manual_enabled		# true if manual input is mixed in
 bool flag_control_auto_enabled			# true if onboard autopilot should act
 bool flag_control_offboard_enabled		# true if offboard control should be used
-bool flag_control_rates_enabled			# true if rates are stabilized
-bool flag_control_attitude_enabled		# true if attitude stabilization is mixed in
-bool flag_control_acceleration_enabled		# true if acceleration is controlled
-bool flag_control_velocity_enabled		# true if horizontal velocity (implies direction) is controlled
 bool flag_control_position_enabled		# true if position is controlled
+bool flag_control_velocity_enabled		# true if horizontal velocity (implies direction) is controlled
 bool flag_control_altitude_enabled		# true if altitude is controlled
 bool flag_control_climb_rate_enabled		# true if climb rate is controlled
-bool flag_control_termination_enabled		# true if flighttermination is enabled
+bool flag_control_acceleration_enabled		# true if acceleration is controlled
+bool flag_control_attitude_enabled		# true if attitude stabilization is mixed in
+bool flag_control_rates_enabled			# true if rates are stabilized
 bool flag_control_allocation_enabled		# true if control allocation is enabled
+bool flag_control_termination_enabled		# true if flighttermination is enabled
 
 # TODO: use dedicated topic for external requests
 uint8 source_id                  # Mode ID (nav_state)

--- a/src/modules/commander/ModeManagement.hpp
+++ b/src/modules/commander/ModeManagement.hpp
@@ -92,8 +92,8 @@ public:
 			config_control_setpoint_.flag_control_altitude_enabled = true;
 			config_control_setpoint_.flag_control_climb_rate_enabled = true;
 			config_control_setpoint_.flag_control_acceleration_enabled = true;
-			config_control_setpoint_.flag_control_rates_enabled = true;
 			config_control_setpoint_.flag_control_attitude_enabled = true;
+			config_control_setpoint_.flag_control_rates_enabled = true;
 			config_control_setpoint_.flag_control_allocation_enabled = true;
 		}
 

--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -50,35 +50,35 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 	switch (nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
 		vehicle_control_mode.flag_control_manual_enabled = true;
-		vehicle_control_mode.flag_control_rates_enabled = stabilization_required(vehicle_type);
 		vehicle_control_mode.flag_control_attitude_enabled = stabilization_required(vehicle_type);
+		vehicle_control_mode.flag_control_rates_enabled = stabilization_required(vehicle_type);
 		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_STAB:
 		vehicle_control_mode.flag_control_manual_enabled = true;
-		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
 		vehicle_control_mode.flag_control_manual_enabled = true;
-		vehicle_control_mode.flag_control_rates_enabled = true;
-		vehicle_control_mode.flag_control_attitude_enabled = true;
 		vehicle_control_mode.flag_control_altitude_enabled = true;
 		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_POSCTL:
 		vehicle_control_mode.flag_control_manual_enabled = true;
-		vehicle_control_mode.flag_control_rates_enabled = true;
-		vehicle_control_mode.flag_control_attitude_enabled = true;
-		vehicle_control_mode.flag_control_altitude_enabled = true;
-		vehicle_control_mode.flag_control_climb_rate_enabled = true;
 		vehicle_control_mode.flag_control_position_enabled = true;
 		vehicle_control_mode.flag_control_velocity_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
@@ -90,12 +90,12 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
 		vehicle_control_mode.flag_control_auto_enabled = true;
-		vehicle_control_mode.flag_control_rates_enabled = true;
-		vehicle_control_mode.flag_control_attitude_enabled = true;
-		vehicle_control_mode.flag_control_altitude_enabled = true;
-		vehicle_control_mode.flag_control_climb_rate_enabled = true;
 		vehicle_control_mode.flag_control_position_enabled = true;
 		vehicle_control_mode.flag_control_velocity_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
@@ -107,9 +107,9 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 
 	case vehicle_status_s::NAVIGATION_STATE_DESCEND:
 		vehicle_control_mode.flag_control_auto_enabled = true;
-		vehicle_control_mode.flag_control_rates_enabled = true;
-		vehicle_control_mode.flag_control_attitude_enabled = true;
 		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
 		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 

--- a/src/modules/commander/ModeUtil/control_mode.cpp
+++ b/src/modules/commander/ModeUtil/control_mode.cpp
@@ -168,12 +168,13 @@ void getVehicleControlMode(uint8_t nav_state, uint8_t vehicle_type,
 	case vehicle_status_s::NAVIGATION_STATE_ORBIT:
 		vehicle_control_mode.flag_control_manual_enabled = false;
 		vehicle_control_mode.flag_control_auto_enabled = false;
-		vehicle_control_mode.flag_control_rates_enabled = true;
-		vehicle_control_mode.flag_control_attitude_enabled = true;
-		vehicle_control_mode.flag_control_altitude_enabled = true;
-		vehicle_control_mode.flag_control_climb_rate_enabled = true;
 		vehicle_control_mode.flag_control_position_enabled = true;
 		vehicle_control_mode.flag_control_velocity_enabled = true;
+		vehicle_control_mode.flag_control_altitude_enabled = true;
+		vehicle_control_mode.flag_control_climb_rate_enabled = true;
+		vehicle_control_mode.flag_control_attitude_enabled = true;
+		vehicle_control_mode.flag_control_rates_enabled = true;
+		vehicle_control_mode.flag_control_allocation_enabled = true;
 		break;
 
 	// vehicle_status_s::NAVIGATION_STATE_EXTERNALx: handled in ModeManagement


### PR DESCRIPTION
### Solved Problem
When running an orbit in simulation I found that the vehicle immediately crashes upon the first command.
A quick bisect led me to https://github.com/PX4/PX4-Autopilot/pull/22222 which disabled the allocation for orbit mode so there is not even rate tracking anymore.

### Solution
Add `flag_control_allocation_enabled` for Orbit mode.
The rest is reordering the flags according to the control cascade while going through them. None of the other modes is missing anything according to my inspection. I assume the allocation flag is useful only in the case where you're in `NAVIGATION_STATE_OFFBOARD` but none of the `offboard_control_mode` flags are set then the allocation is not running and the offboard thing can command the motors.

### Changelog Entry
```
Critical bugfix: Multicopter orbit leads to crash only in main for a few hours
```

### Test coverage
- I tested in SITL SIH and it works again like expected.

### Context
Complete rate divergence in Orbit mode without allocation enabled:
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/3421dd5a-3e1c-487b-bf73-0235e734526e)