### PR TITLE
commander: notify when arming denied due to RTL enabled

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -593,6 +593,13 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 		_health_and_arming_checks.update();
 
 		if (!_health_and_arming_checks.canArm(_vehicle_status.nav_state)) {
+
+			if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
+				mavlink_log_critical(&_mavlink_log_pub, "Arming denied: RTL enabled\t");
+				events::send(events::ID("commander_arm_denied_rtl"), {events::Log::Critical, events::LogInternal::Info},
+					     "Arming denied: RTL enabled");
+			}
+
 			tune_negative(true);
 			return TRANSITION_DENIED;
 		}


### PR DESCRIPTION
I ran into a situation when I couldn't figure out why my drone was denying arming. Even after running the logger, there was no logged reason why arming was denied. I eventually realized I had RTL'ed the drone in the previous flight through my RC transmitter switch and it was still toggled.

Commander should log that arming was denied due to the RTL switch being active and send out a mavlink warning.

I'm not sure if this PR will actually work since the vehicle can be in manual, altitude, position, etc nav state when the RTL switch is active.