### PR TITLE
FlightTaskAuto: set state to None if previous and current setpoint are equal

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -636,7 +636,11 @@ State FlightTaskAuto::_getCurrentState()
 
 	State return_state = State::none;
 
-	if (u_prev_to_target_xy * pos_to_target_xy < 0.0f) {
+	if (u_prev_to_target_xy.length() < FLT_EPSILON) {
+		// Previous and target are the same point, so we better don't try to do any special line following
+		return_state = State::none;
+
+	} else if (u_prev_to_target_xy * pos_to_target_xy < 0.0f) {
 		// Target is behind
 		return_state = State::target_behind;
 


### PR DESCRIPTION
### Solved Problem
If the previous and current setpoint are set to the same, the logic in `FlightTaskAuto::_getCurrentState()` sets the state to offtrack, which then though doesn't get handled correctly as we don't have a track to follow in the first place.

### Solution
Set state to None in that case.

### Changelog Entry
For release notes:
```
Bugfix: FlightTaskAuto: harden line following logic (only do line following if previous and current setpoints are not equal).
```

### Alternatives
It would also be nice to simply the whole (currently very convoluted) logic in `FlightTaskAuto` and `PositionSmoother`. Likely the desired behavior would be that on triggering Land, the vehicle breaks and then descends vertically where it came to reset, instead of going back to the point where the land was triggered as it does currently. 

### Test coverage
SITL tests.


Some prints from the state where the vehicle is drifting away in land mode:
```
******************
triplet_update: 0, _current_state: 0
OFFTRACK
_next_wp: -56.693569, -7.025488
_target: -56.693569, -7.025488
_prev_wp: -79.595253, -10.094345
turning
return_l1_point: -79.595253, -10.094345, -14.527375
closest_pt: -79.595253, -10.094345, -14.527375
alongtrack_error: 4.943437
crosstrack_error: 0.749954
xy_target_valid, is single waypoint: 0
2D pos sp to vel sp, vel_sp_constrained: -1.145724, -0.260856
set tmp_target from lock_position_xy, _lock_position_xy: -56.693569, -7.025488 
return_state: 0, _target_acceptance_radius: 2.000000
_triplet_target: -56.693569, -7.025488
_triplet_prev_wp: -56.693569, -7.025488
u_prev_to_target_xy: 0.000000, 0.000000
pos_to_target_xy: 22.915249, 3.071390
prev_to_pos_xy: -22.915249, -3.071390
closest_pt_xy: -56.693569, -7.025488
_position: -79.608818, -10.096878
_closest_pt: -56.693569, -7.025488
******************
```

