### PR TITLE
Fix incremental builds when msg files change

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -331,7 +331,7 @@ add_custom_command(
 		--source-output-file ${uorb_message_fields_cpp_file}
 		--header-output-file ${uorb_message_fields_header_file}
 	DEPENDS
-		uorb_json_files
+		${uorb_json_files}
 		${PX4_SOURCE_DIR}/Tools/msg/px_generate_uorb_compressed_fields.py
 	COMMENT "Generating uORB compressed fields"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Apparently add_custom_command needs to depend on files instead of the custom_command target name

Introduced with https://github.com/PX4/PX4-Autopilot/pull/21995.