### PR TITLE
Navigator: add set_gimbal_neutral() logic

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -65,6 +65,12 @@ Land::on_activation()
 
 	// reset cruising speed to default
 	_navigator->reset_cruising_speed();
+
+	// set gimbal to neutral position (level with horizon) to reduce change of damage on landing
+	_navigator->acquire_gimbal_control();
+	_navigator->set_gimbal_neutral();
+	_navigator->release_gimbal_control();
+
 }
 
 void

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -189,6 +189,7 @@ MissionBase::on_inactivation()
 	_navigator->disable_camera_trigger();
 
 	_navigator->stop_capturing_images();
+	_navigator->set_gimbal_neutral(); // point forward
 	_navigator->release_gimbal_control();
 
 	if (_navigator->get_precland()->is_activated()) {

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -619,6 +619,11 @@ void MissionBase::handleLanding(WorkItemType &new_work_item_type, mission_item_s
 			// if the vehicle drifted off the path during back-transition it should just go straight to the landing point
 			_navigator->reset_position_setpoint(pos_sp_triplet->previous);
 
+			// set gimbal to neutral position (level with horizon) to reduce change of damage on landing
+			_navigator->acquire_gimbal_control();
+			_navigator->set_gimbal_neutral();
+			_navigator->release_gimbal_control();
+
 		} else {
 
 			if (_mission_item.land_precision > 0 && _mission_item.land_precision < 3) {

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -65,6 +65,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/geofence_result.h>
+#include <uORB/topics/gimbal_manager_set_attitude.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
@@ -276,6 +277,7 @@ public:
 
 	void acquire_gimbal_control();
 	void release_gimbal_control();
+	void set_gimbal_neutral();
 
 	void calculate_breaking_stop(double &lat, double &lon, float &yaw);
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1508,6 +1508,18 @@ void Navigator::disable_camera_trigger()
 	publish_vehicle_cmd(&cmd);
 }
 
+void Navigator::set_gimbal_neutral()
+{
+	vehicle_command_s vcmd = {};
+	vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW;
+	vcmd.param1 = NAN;
+	vcmd.param2 = NAN;
+	vcmd.param3 = NAN;
+	vcmd.param4 = NAN;
+	vcmd.param5 = gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_NEUTRAL;
+	publish_vehicle_cmd(&vcmd);
+}
+
 int Navigator::print_usage(const char *reason)
 {
 	if (reason) {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -256,6 +256,11 @@ void RTL::on_activation()
 	default:
 		break;
 	}
+
+	// set gimbal to neutral position (level with horizon) to reduce change of damage on landing
+	_navigator->acquire_gimbal_control();
+	_navigator->set_gimbal_neutral();
+	_navigator->release_gimbal_control();
 }
 
 void RTL::on_active()


### PR DESCRIPTION

### Solved Problem
- cameras have higher chance to get damaged when pointing down (like they do while flying a survey)
- on Holding a survey mission, most users seem to prefer to have the camera pan upwards such that they can look at the surroundings

### Solution
Introduce set_gimabl_neutral() method that sets `gimbal_manager_set_attitude_s::GIMBAL_MANAGER_FLAGS_NEUTRAL`. Call it on entering RTL and Land flight modes, as well as when in a mission and the next item is Land, or on pausing a mission.

### Changelog Entry
For release notes:
```
Feature: set gimbal to neutral (horizontal) in Landing scenarios and on pausing a Mission
```

### Test coverage
SITL tested. 
