### PR TITLE
[uxrce_dds_client] disable UXRCE_DDS_SYNCC by default

### DIFF
--- a/src/modules/uxrce_dds_client/module.yaml
+++ b/src/modules/uxrce_dds_client/module.yaml
@@ -104,4 +104,4 @@ parameters:
             type: boolean
             category: System
             reboot_required: true
-            default: 1
+            default: 0


### PR DESCRIPTION
If a system has both a GPS and a companion computer and UXRCE_DDS_SYNCC is enabled, there is the potential for them to fight over the time. If the companion computer does not have an accurate time source (no network connection) it might set the clock to some time in the past. 