### PR TITLE
[CRITICAL] empy version fixed to 3.3.4

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -2,7 +2,7 @@ argcomplete
 argparse>=1.2
 cerberus
 coverage
-empy>=3.3
+empy==3.3.4
 future
 jinja2>=2.8
 jsonschema


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When installing PX4 in a docker container, I could no longer seem to run `make px4_sitl`. it turns out that the empy package, as part of the setup.sh script, get installed to versions larger than 3.3. Last, night, for the first time in 4 years, empy was upgraded from version 3.3.4 to version 4.0. This broke `make px4_sitl` completely. 
This issue is critical because it breaks px4 for any machine that runs a new setup or something like a docker container where there is a chance that pip installs empy 4.0


### Solution
Set empy fix to 3.3.4

### Alternatives
We could also use a wildcard to set 3.3.*

### Context
http://www.alcyone.com/software/empy/ANNOUNCE.html#announcement
