### PR TITLE
Add mission point check when update the geofence

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -258,6 +258,9 @@ void Geofence::_updateFence()
 				// check if current position is inside the fence and vehicle is armed
 				const bool current_position_check_okay = checkCurrentPositionRequirementsForGeofence(polygon);
 
+				//check if current mission point inside the geofence
+				const bool current_mission_check_okay = checkMissionRequirementsForGeofence(polygon);
+				
 				// discard the polygon if at least one check fails by not incrementing the counter in that case
 				if (home_check_okay && current_position_check_okay) {
 					++_num_polygons;
@@ -273,6 +276,30 @@ void Geofence::_updateFence()
 			break;
 		}
 	}
+}
+
+bool Geofence::checkMissionRequirementsForGeofence(const PolygonInfo &polygon)
+{
+	mission_s mission;
+	_dataman_client.readSync(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission),sizeof(mission_s));
+	bool checks_pass = false;
+	//check all mission  against all geofence
+	for (size_t i = 0; i < mission.count; i++) {
+		struct mission_item_s missionitem = {};
+		_dataman_client.readSync((dm_item_t)mission.dataman_id, i, reinterpret_cast<uint8_t *>(&missionitem),
+					sizeof(mission_item_s));
+		//missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
+		checks_pass = checkPointAgainstPolygonCircle(polygon,missionitem.lat, missionitem.lon, missionitem.altitude);
+		if (!checks_pass) {
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence invalid, against mission\t");
+		events::send(events::ID("navigator_geofence_invalid_against_mission"), {events::Log::Critical, events::LogInternal::Warning},
+			     "Geofence invalid, against mission");
+
+
+		break;
+		}
+	}
+	return  checks_pass;
 }
 
 bool Geofence::checkHomeRequirementsForGeofence(const PolygonInfo &polygon)

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -262,7 +262,7 @@ void Geofence::_updateFence()
 				const bool current_mission_check_okay = checkMissionRequirementsForGeofence(polygon);
 				
 				// discard the polygon if at least one check fails by not incrementing the counter in that case
-				if (home_check_okay && current_position_check_okay) {
+				if (home_check_okay && current_position_check_okay && current_mission_check_okay) {
 					++_num_polygons;
 
 				}

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -207,6 +207,12 @@ private:
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	/**
+	 * Check polygon or circle geofence fullfills the requirements relative to the current mission.
+	 * @return true if checks pass
+	 */
+	bool checkMissionRequirementsForGeofence(const PolygonInfo &polygon);
+
+	/**
 	 * Check if a single point is within a polygon or circle
 	 * @return true if within polygon or circle
 	 */

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -240,6 +240,8 @@ void RTL::on_activation()
 {
 	setRtlTypeAndDestination();
 
+	bool check_home_result = check_home_valid();
+
 	switch (_rtl_type) {
 	case RtlType::RTL_DIRECT_MISSION_LAND:	// Fall through
 	case RtlType::RTL_MISSION_FAST: // Fall through
@@ -661,4 +663,29 @@ land_approaches_s RTL::readVtolLandApproaches(DestinationPosition rtl_position) 
 	}
 
 	return vtol_land_approaches;
+}
+
+
+bool RTL::check_home_valid()
+{
+	_home_pos_sub.update();
+	if (_navigator->get_geofence().valid()) {
+
+		_vehicle_gps_position_sub.copy(&_home_check_gps_pos);
+
+		vehicle_global_position_s home_pos_check{};
+
+		home_pos_check.lat = _home_pos_sub.get().lat;
+		home_pos_check.lon = _home_pos_sub.get().lon;
+		home_pos_check.alt = _home_pos_sub.get().alt;
+
+		if ((_navigator->get_geofence().getGeofenceAction() != geofence_result_s::GF_ACTION_NONE) &&
+		(_navigator->get_geofence().getGeofenceAction() != geofence_result_s::GF_ACTION_WARN)) {
+			if (PX4_ISFINITE(_home_pos_sub.get().alt) && PX4_ISFINITE(_home_pos_sub.get().lon)) {
+				return _navigator->get_geofence().check(home_pos_check, _home_check_gps_pos);
+			}
+		}
+
+	}
+	return true;
 }

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -59,6 +59,7 @@
 #include <uORB/topics/mission.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/rtl_time_estimate.h>
+#include <uORB/topics/sensor_gps.h>
 
 class Navigator;
 
@@ -165,6 +166,12 @@ private:
 	bool hasVtolLandApproach(const DestinationPosition &rtl_position) const;
 
 	/**
+	 * @brief Check if the home point is valid when switching to RTL mode
+	 *
+	 */
+	bool check_home_valid();
+
+	/**
 	 * @brief Choose best landing approach
 	 *
 	 * Choose best landing approach for home considering wind
@@ -198,6 +205,8 @@ private:
 	mutable DatamanCache _dataman_cache_landItem{"rtl_dm_cache_miss_land", 2};
 	uint32_t _mission_id = 0u;
 
+	sensor_gps_s				_home_check_gps_pos{};
+
 	mission_stats_entry_s _stats;
 
 	RtlDirect _rtl_direct;
@@ -214,6 +223,8 @@ private:
 	)
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+
+	uORB::Subscription			_vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
 
 	uORB::SubscriptionData<vehicle_global_position_s> _global_pos_sub{ORB_ID(vehicle_global_position)};	/**< global position subscription */
 	uORB::SubscriptionData<vehicle_status_s> _vehicle_status_sub{ORB_ID(vehicle_status)};	/**< vehicle status subscription */


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

1.  https://github.com/PX4/PX4-Autopilot/blob/c5101c70b31aa0c1454162c6ad1420e5af8086b2/src/modules/navigator/mission_feasibility_checker.cpp#L108 I've found that the MissionFeasibilityChecker()  is only triggered correctly when updating a mission.  when only updating a geofence,user need to click upload twice to invoke check function. Currently, the geofence update only checks the origin and the current position associated with the geofence, and I've added a check for mission waypoints to make the check on upload more complete.The problem is related to the state machine and asynchronous message reading in geofence.cpp.The checkMissionAgainstGeofence() is written in the mission and the geofence is still being read when the mission has finished uploading and checking.
 
![%`%3Z`6)VGYLVSF_)N0L{BT](https://github.com/PX4/PX4-Autopilot/assets/151698793/38b3fe89-4ed8-47d7-8822-c5254984f679)

2. Regarding the issue of being unable to perform geofence breach checks for the home point using VEHICLE_CMD_DO_SET_HOME in commander.cpp due to geofence not being available in the navigator, the following solution is proposed:**When the drone switches to RTL mode, check whether the home point triggers a geofence breach.**
However, at present, we only return the result and have successfully tested it. We have not yet implemented handling for the detected issues and event notifications because there may be some irregularities or issues in the code. We would appreciate your feedback on this matter.

Fixes #{#22362}
In this bug issue , @czbxzm said ,"1. When swapping the order, uploading the mission waypoint routes first and then plotting the no-fly zones does not trigger any checks, even if there is an overlap between the two;"Actually this check triggers, but requires a second click on upload.(in the version reporting this bug issue)

#｛#22373｝
In this bug issue, @BladeY1 said,"In SITL simulation, we observed that the Home point can be arbitrarily set by the operator. Since Return to Launch (RTL) navigates the drone back to the Home point, inadvertent placement of the Home point within a no-fly zone can result in the drone breaching no-fly zone checks or entering the restricted area when the operator manually selects RTL. We validated this behavior using a drone equipped with PX4 flight control. It indeed demonstrated the ability to enter a no-fly zone through the aforementioned actions.We believe that operators typically intend to avoid their drones entering no-fly zones to prevent potential damage or safety incidents. No-fly zones, often manually designated by operators, are crucial in areas like airports, amusement parks with high-altitude ride systems, or locations with dense obstacles such as forests, lakes, and clusters of buildings."



### Solution

1. I've added a check for mission waypoints when update geofence.
 
![95$0I@SC~0)3RA G`Q2XMCR](https://github.com/PX4/PX4-Autopilot/assets/151698793/d96db40e-0b0e-4061-9a9c-358a5bde2268)

2. When the drone switches to RTL mode, check whether the home point triggers a geofence breach.


### Test coverage

 test on jmavsim/gz_x500 and QGC



