### PR TITLE
ekf2: fix a shadow warning

### DIFF
--- a/src/modules/ekf2/EKF/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aux_global_position.cpp
@@ -68,7 +68,7 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 
 	if (_aux_global_position_buffer.pop_first_older_than(imu_delayed.time_us, &sample)) {
 
-		if (!(_param_ekf2_agp_ctrl.get() & static_cast<int32_t>(Ctrl::HPOS))) {
+		if (!(_param_ekf2_agp_ctrl.get() & static_cast<int32_t>(GnssCtrl::HPOS))) {
 			return;
 		}
 

--- a/src/modules/ekf2/EKF/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aux_global_position.cpp
@@ -68,7 +68,7 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 
 	if (_aux_global_position_buffer.pop_first_older_than(imu_delayed.time_us, &sample)) {
 
-		if (!(_param_ekf2_agp_ctrl.get() & static_cast<int32_t>(GnssCtrl::HPOS))) {
+		if (!(_param_ekf2_agp_ctrl.get() & static_cast<int32_t>(AuxGlobalPositionCtrl::HPOS))) {
 			return;
 		}
 

--- a/src/modules/ekf2/EKF/aux_global_position.hpp
+++ b/src/modules/ekf2/EKF/aux_global_position.hpp
@@ -88,11 +88,6 @@ private:
 	RingBuffer<AuxGlobalPositionSample> _aux_global_position_buffer{20}; // TODO: size with _obs_buffer_length and actual publication rate
 	uint64_t _time_last_buffer_push{0};
 
-	enum class Ctrl : uint8_t {
-		HPOS  = (1<<0),
-		VPOS  = (1<<1)
-	};
-
 	enum class State {
 		stopped,
 		starting,


### PR DESCRIPTION
Presumably this enum was defined twice.

Fixes #22485.