### PR TITLE
add cyphal driver selection of CAN interface

### DIFF
--- a/src/drivers/cyphal/CanardHandle.cpp
+++ b/src/drivers/cyphal/CanardHandle.cpp
@@ -97,12 +97,14 @@ CanardHandle::~CanardHandle()
 }
 
 
-bool CanardHandle::init()
+bool CanardHandle::init(const char* can_iface_name)
 {
 	if (_can_interface) {
-		if (_can_interface->init() == PX4_OK) {
-			return true;
-		}
+		  if (_can_interface->init(can_iface_name) == PX4_OK) {
+			  return true;
+		  }
+
+		//}
 	}
 
 	return false;

--- a/src/drivers/cyphal/CanardHandle.hpp
+++ b/src/drivers/cyphal/CanardHandle.hpp
@@ -51,7 +51,7 @@ public:
 	CanardHandle(uint32_t node_id, const size_t capacity, const size_t mtu_bytes);
 	~CanardHandle();
 
-	bool init();
+	bool init(const char *can_iface_name);
 
 	void receive();
 	void transmit();

--- a/src/drivers/cyphal/CanardInterface.hpp
+++ b/src/drivers/cyphal/CanardInterface.hpp
@@ -49,7 +49,7 @@ public:
 	CanardInterface() = default;
 	virtual ~CanardInterface() = default;
 
-	virtual int init() { return 0; };
+	virtual int init(const char* can_iface_name) { return 0; };
 
 	virtual int close() { return 0; };
 

--- a/src/drivers/cyphal/CanardSocketCAN.cpp
+++ b/src/drivers/cyphal/CanardSocketCAN.cpp
@@ -48,9 +48,9 @@ uint64_t getMonotonicTimestampUSec(void)
 	return ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
 }
 
-int CanardSocketCAN::init()
+int CanardSocketCAN::init(const char *can_iface_name)
 {
-	const char *const can_iface_name = "can0";
+	// const char *const can_iface_name = "can0";
 
 	struct sockaddr_can addr;
 	struct ifreq ifr;
@@ -65,7 +65,7 @@ int CanardSocketCAN::init()
 		PX4_ERR("socket");
 		return -1;
 	}
-
+  PX4_INFO("Iface chosen: %s", can_iface_name);
 	strncpy(ifr.ifr_name, can_iface_name, IFNAMSIZ - 1);
 	ifr.ifr_name[IFNAMSIZ - 1] = '\0';
 	ifr.ifr_ifindex = if_nametoindex(ifr.ifr_name);

--- a/src/drivers/cyphal/CanardSocketCAN.hpp
+++ b/src/drivers/cyphal/CanardSocketCAN.hpp
@@ -60,7 +60,7 @@ public:
 	/// Also sets up the message structures required for socketcanTransmit & socketcanReceive
 	/// can_fd determines to use CAN FD frame when is 1, and classical CAN frame when is 0
 	/// The return value is 0 on succes and -1 on error
-	int init();
+	int init(const char *can_iface_name);
 
 	/// Close socket connection
 	int close()

--- a/src/drivers/cyphal/Cyphal.cpp
+++ b/src/drivers/cyphal/Cyphal.cpp
@@ -62,7 +62,7 @@ using namespace time_literals;
 
 CyphalNode *CyphalNode::_instance;
 
-CyphalNode::CyphalNode(uint32_t node_id, size_t capacity, size_t mtu_bytes) :
+CyphalNode::CyphalNode(uint32_t node_id, size_t capacity, size_t mtu_bytes, const char* can_iface) :
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::uavcan),
 	_canard_handle(node_id, capacity, mtu_bytes)
@@ -85,6 +85,8 @@ CyphalNode::CyphalNode(uint32_t node_id, size_t capacity, size_t mtu_bytes) :
 	_sub_manager.subscribe();
 
 	_mixing_output.mixingOutput().setMaxTopicUpdateRate(1000000 / 200);
+
+	_can_iface_name = can_iface;
 }
 
 CyphalNode::~CyphalNode()
@@ -112,7 +114,7 @@ CyphalNode::~CyphalNode()
 	perf_free(_interval_perf);
 }
 
-int CyphalNode::start(uint32_t node_id, uint32_t bitrate)
+int CyphalNode::start(uint32_t node_id, uint32_t bitrate, const char *can_iface)
 {
 	if (_instance != nullptr) {
 		PX4_WARN("Already started");
@@ -121,11 +123,14 @@ int CyphalNode::start(uint32_t node_id, uint32_t bitrate)
 
 	bool can_fd = false;
 
+
+	
 	if (can_fd) {
-		_instance = new CyphalNode(node_id, 8, CANARD_MTU_CAN_FD);
+
+		_instance = new CyphalNode(node_id, 8, CANARD_MTU_CAN_FD, can_iface);
 
 	} else {
-		_instance = new CyphalNode(node_id, 64, CANARD_MTU_CAN_CLASSIC);
+		_instance = new CyphalNode(node_id, 64, CANARD_MTU_CAN_CLASSIC, can_iface);
 	}
 
 	if (_instance == nullptr) {
@@ -145,7 +150,9 @@ int CyphalNode::start(uint32_t node_id, uint32_t bitrate)
 void CyphalNode::init()
 {
 	// interface init
-	if (_canard_handle.init()) {
+	
+  PX4_INFO("Cyphal node init interface: %s", _can_iface_name);
+	if (_canard_handle.init(_can_iface_name)) {
 		_initialized = true;
 	}
 
@@ -299,11 +306,14 @@ void CyphalNode::print_info()
 static void print_usage()
 {
 	PX4_INFO("usage: \n"
-		 "\tuavcannode {start|status|stop}");
+		 "\tcyphal {start|status|stop}\n cyphal start -d can{x}");
 }
 
 extern "C" __EXPORT int cyphal_main(int argc, char *argv[])
 {
+
+  const char *can_if;
+
 	if (argc < 2) {
 		print_usage();
 		return 1;
@@ -327,9 +337,20 @@ extern "C" __EXPORT int cyphal_main(int argc, char *argv[])
 			node_id = CANARD_NODE_ID_UNSET;
 		}
 
+    if(!strcmp(argv[2], "-i")) {
+			if(argv[3]) {
+      	can_if = argv[3];
+      	PX4_INFO("CAN interface: %s", can_if);
+			}
+			else {
+				print_usage();
+				return 1;
+			}
+    }
+
 		// Start
 		PX4_INFO("Node ID %" PRIu32 ", bitrate %" PRIu32, node_id, bitrate);
-		return CyphalNode::start(node_id, bitrate);
+		return CyphalNode::start(node_id, bitrate, can_if);
 	}
 
 	/* commands below require the app to be started */

--- a/src/drivers/cyphal/Cyphal.hpp
+++ b/src/drivers/cyphal/Cyphal.hpp
@@ -117,10 +117,10 @@ class CyphalNode : public ModuleParams, public px4::ScheduledWorkItem
 
 public:
 
-	CyphalNode(uint32_t node_id, size_t capacity, size_t mtu_bytes);
+	CyphalNode(uint32_t node_id, size_t capacity, size_t mtu_bytes, const char* can_iface);
 	~CyphalNode() override;
 
-	static int start(uint32_t node_id, uint32_t bitrate);
+	static int start(uint32_t node_id, uint32_t bitrate, const char* can_iface);
 
 	void print_info();
 
@@ -147,6 +147,9 @@ private:
 
 	pthread_mutex_t _node_mutex;
 
+  // CAN interface to start Cyphal on
+  const char *_can_iface_name;
+	
 	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
 
 	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle time")};
@@ -156,7 +159,7 @@ private:
 	uint8_t _uavcan_node_heartbeat_buffer[uavcan_node_Heartbeat_1_0_EXTENT_BYTES_];
 	hrt_abstime _uavcan_node_heartbeat_last{0};
 	CanardTransferID _uavcan_node_heartbeat_transfer_id{0};
-
+	
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CYPHAL_ENABLE>) _param_uavcan_v1_enable,
 		(ParamInt<px4::params::CYPHAL_ID>) _param_uavcan_v1_id,


### PR DESCRIPTION

Cyphal expansion of can interfaces beyond can0. This allows selecting a different CAN interface than what dronecan is already using on boards with greater than 3 CAN interfaces such as the NXP Canhub. Instead of the drivers both accessing CAN0 you can set Cyphal its own interface. You could also only run cyphal but still want to access a specialized CAN interface such as secureCAN or SIC…that does not come up on CAN0 but you want to leave that interface/network enabled.

alternative: instead of instantiating a single CAN interface on driver start, implement a param so that you can tell cyphal driver it is allowed to use select CAN interfaces, but this can’t conflict with what DroneCAN is already using if using both drivers on the pixhawk. 