### PR TITLE
uORB::Publication skip unadvertise on destruction if there are still subscribers

### DIFF
--- a/platforms/common/uORB/Publication.hpp
+++ b/platforms/common/uORB/Publication.hpp
@@ -84,7 +84,7 @@ protected:
 	{
 		if (_handle != nullptr) {
 			// don't automatically unadvertise queued publications (eg vehicle_command)
-			if (Manager::orb_get_queue_size(_handle) == 1) {
+			if ((Manager::orb_get_queue_size(_handle) == 1) && (Manager::orb_get_subscriber_count(_handle) <= 0)) {
 				unadvertise();
 			}
 		}

--- a/platforms/common/uORB/uORBDeviceNode.cpp
+++ b/platforms/common/uORB/uORBDeviceNode.cpp
@@ -219,13 +219,15 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 
 	memcpy(_data + (_meta->o_size * (generation % _queue_size)), buffer, _meta->o_size);
 
+	/* Mark at least one data has been published */
+	_data_valid = true;
+
+	mark_as_advertised();
+
 	// callbacks
 	for (auto item : _callbacks) {
 		item->call();
 	}
-
-	/* Mark at least one data has been published */
-	_data_valid = true;
 
 	ATOMIC_LEAVE;
 

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -455,6 +455,11 @@ void uORB::Manager::orb_remove_internal_subscriber(void *node_handle)
 
 uint8_t uORB::Manager::orb_get_queue_size(const void *node_handle) { return static_cast<const DeviceNode *>(node_handle)->get_queue_size(); }
 
+int8_t uORB::Manager::orb_get_subscriber_count(const void *node_handle)
+{
+	return static_cast<const DeviceNode *>(node_handle)->subscriber_count();
+}
+
 bool uORB::Manager::orb_data_copy(void *node_handle, void *dst, unsigned &generation, bool only_if_updated)
 {
 	if (!is_advertised(node_handle)) {

--- a/platforms/common/uORB/uORBManager.hpp
+++ b/platforms/common/uORB/uORBManager.hpp
@@ -445,6 +445,8 @@ public:
 
 	static uint8_t orb_get_queue_size(const void *node_handle);
 
+	static int8_t orb_get_subscriber_count(const void *node_handle);
+
 	static bool orb_data_copy(void *node_handle, void *dst, unsigned &generation, bool only_if_updated);
 
 	static bool register_callback(void *node_handle, SubscriptionCallback *callback_sub);


### PR DESCRIPTION
This is a potential fix with uORB::Publication's in flight tasks. 