### PR TITLE
Navigator: mission_block: reduce margin to enforce aligned exit course to 105% of the loiter radius

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -473,8 +473,8 @@ MissionBlock::is_mission_item_reached_or_completed()
 							 && curr_sp_new->type == position_setpoint_s::SETPOINT_TYPE_LOITER
 							 && (_mission_item.force_heading || _mission_item.nav_cmd == NAV_CMD_WAYPOINT);
 
-			// can only enforce exit course if next waypoint is not within loiter radius of current waypoint
-			const bool exit_course_is_reachable = dist_current_next > 1.2f * curr_sp_new->loiter_radius;
+			// can only enforce exit course if next waypoint is not within loiter radius of current waypoint (with small margin)
+			const bool exit_course_is_reachable = dist_current_next > 1.05f * curr_sp_new->loiter_radius;
 
 			if (enforce_exit_course && exit_course_is_reachable) {
 


### PR DESCRIPTION
This margin helps to not have a vehicle stuck at a loiter waypoint if it is not perfectly tracked, (vehicle outside of path setpoint) and the next waypoint is just at the border of the loiter.
It should though be as small as necessary, as otherwise, with good loiter tracking,  waypoints that are close but not right on the loiter radius are not enforcing the exit course neither.

The previous margin of 120% seems rather a bit too high, I propose 105% here.

Reduces the likelihood of ugly loiter exits like this one here, where the loiter radius is huge and the distance to the next WP is small:

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/9b4d24f9-586c-451c-8587-387d8aa7c7eb)

