### PR TITLE
msp_osd: reuse existing mode name conversion

### DIFF
--- a/src/drivers/osd/msp_osd/uorb_to_msp.cpp
+++ b/src/drivers/osd/msp_osd/uorb_to_msp.cpp
@@ -40,6 +40,7 @@
 #include <math.h>
 #include <matrix/math.hpp>
 #include <lib/geo/geo.h>
+#include <lib/modes/ui.hpp>
 
 // clock access
 #include <px4_platform_common/defines.h>
@@ -77,82 +78,7 @@ msp_name_t construct_display_message(const vehicle_status_s &vehicle_status,
 		}
 
 		// display flight mode
-		switch (vehicle_status.nav_state) {
-		case vehicle_status_s::NAVIGATION_STATE_MANUAL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "MANUAL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_ALTCTL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "ALTCTL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_POSCTL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "POSCTL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_MISSION");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_LOITER");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_RTL");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_ACRO:
-			display.set(MessageDisplayType::FLIGHT_MODE, "ACRO");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_DESCEND:
-			display.set(MessageDisplayType::FLIGHT_MODE, "DESCEND");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_TERMINATION:
-			display.set(MessageDisplayType::FLIGHT_MODE, "TERMINATION");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
-			display.set(MessageDisplayType::FLIGHT_MODE, "OFFBOARD");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_STAB:
-			display.set(MessageDisplayType::FLIGHT_MODE, "STAB");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_TAKEOFF");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_LAND");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_FOLLOW_TARGET");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_PRECLAND");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_ORBIT:
-			display.set(MessageDisplayType::FLIGHT_MODE, "ORBIT");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF:
-			display.set(MessageDisplayType::FLIGHT_MODE, "AUTO_VTOL_TAKEOFF");
-			break;
-
-		case vehicle_status_s::NAVIGATION_STATE_MAX:
-			display.set(MessageDisplayType::FLIGHT_MODE, "MAX");
-			break;
-
-		default:
-			display.set(MessageDisplayType::FLIGHT_MODE, "???");
-		}
+		display.set(MessageDisplayType::FLIGHT_MODE, mode_util::nav_state_names[vehicle_status.nav_state]);
 	}
 
 	// display, if updated


### PR DESCRIPTION
### Solved Problem
When having a first look at the OSD code I found that all the modes names are explicitly defined again. This is also done in the corssfire driver and analog OSD for a long time already. I might fix those when I have things ready to test next.

### Solution
Reuse the existing mode utility `nav_state_names[]` string definitions.
This saves a bit of flash, keeps the mode names up to date and works like expected.

### Changelog Entry
```
Improvement: MSP OSD mode names come from common list
```

### Test coverage
I finally assembled the hardware to fly and test the digital FPV system. Here are potato pictures of me switching through the modes. It works great, still only shows the 3 first letters but we can improve that later once I understand all the limitations.
![IMG_20231208_213117](https://github.com/PX4/PX4-Autopilot/assets/4668506/f745f69d-e4ea-4a15-a49c-a3fdccd085be)
![IMG_20231208_213123](https://github.com/PX4/PX4-Autopilot/assets/4668506/e05e11b2-80a8-48e1-ac41-6671072cb829)
![IMG_20231208_213132](https://github.com/PX4/PX4-Autopilot/assets/4668506/35e24f06-112d-4d81-997a-bdd1fe28bc63)
![IMG_20231208_213138](https://github.com/PX4/PX4-Autopilot/assets/4668506/4a612d71-8b2f-4f4c-8870-f4dbebb83bbe)
![IMG_20231208_213059](https://github.com/PX4/PX4-Autopilot/assets/4668506/fa0f5098-2a56-4718-a296-f4d9e478fa0a)
![IMG_20231208_213105](https://github.com/PX4/PX4-Autopilot/assets/4668506/da9e8d5b-d7bb-4867-b2e0-b7423f6a0e95)
![IMG_20231208_213110](https://github.com/PX4/PX4-Autopilot/assets/4668506/e2c974ef-afd8-4bbf-b8b7-aad281ce8039)