### PR TITLE
Navigator: Avoid attitude stepoint resets by not going into Takeoff mode if VTOL_Takeoff is selected in-air

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -694,6 +694,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 		break;
 
 	case NAV_CMD_TAKEOFF:
+	case NAV_CMD_VTOL_TAKEOFF:
 
 		// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
 		if ((_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
@@ -705,10 +706,6 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 			sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
 		}
 
-		break;
-
-	case NAV_CMD_VTOL_TAKEOFF:
-		sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
 		break;
 
 	case NAV_CMD_LAND:


### PR DESCRIPTION
### Solved Problem
Attitude resets happening when switching to Mission mode with VTOL_Takeoff selected in-air.

Chain:
- Navigator sets the type to SETPOINT_TYPE_TAKEOFF for one sample
- FW position controller goes into _control_mode_current= FW_POSCTRL_MODE_AUTO_TAKEOFF
- FW position controller executes control_auto_takeoff() --> resets integrals [here](https://github.com/PX4/PX4-Autopilot/blob/main/src/modules/fw_pos_control/FixedwingPositionControl.cpp#L1552)

### Solution
Navigator: Avoid attitude stepoint resets by not going into Takeoff mode if VTOL_Takeoff is selected in-air

### Changelog Entry
For release notes:
```
Bugfix: Navigator: Avoid attitude stepoint resets by not going into Takeoff mode if VTOL_Takeoff is selected in-air.
```

### Test coverage
SITL

### Context
Reproducible in SITL (start mission with VTOL_Takeoff, change mission in-air, re-upload, start mission again).

Without the fix: 
![image](https://github.com/Auterion/PX4_firmware_private/assets/26798987/30ae797d-3aff-4e5b-b89c-2e8cb82cd929)

With the fix:

![image](https://github.com/Auterion/PX4_firmware_private/assets/26798987/cc97cc83-bbfd-46d9-b5d3-cefe0bd1b7ad)

