### PR TITLE
dds_topics: export estimator_status_flags

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -20,6 +20,9 @@ publications:
   - topic: /fmu/out/collision_constraints
     type: px4_msgs::msg::CollisionConstraints
 
+  - topic: /fmu/out/estimator_status_flags
+    type: px4_msgs::msg::EstimatorStatusFlags
+
   - topic: /fmu/out/failsafe_flags
     type: px4_msgs::msg::FailsafeFlags
 


### PR DESCRIPTION
Export estimator_status_flags to ROS 2.
Use case: PX4 ROS 2 navigation interface requires feedback from PX4 when requesting measurement updates.
