### PR TITLE
VehicleAngularVelocity: Fix force SensorSelectionUpdate

### DIFF
--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -79,7 +79,7 @@ bool VehicleAngularVelocity::Start()
 		return false;
 	}
 
-	if (!SensorSelectionUpdate(true)) {
+	if (!SensorSelectionUpdate(hrt_absolute_time(), true)) {
 		ScheduleNow();
 	}
 
@@ -906,7 +906,7 @@ void VehicleAngularVelocity::Run()
 
 	// force reselection on timeout
 	if (time_now_us > _last_publish + 500_ms) {
-		SensorSelectionUpdate(true);
+		SensorSelectionUpdate(time_now_us, true);
 	}
 
 	perf_end(_cycle_perf);


### PR DESCRIPTION
### Solved Problem
- This fixes the force call on SensorSelectionUpdate
- In contrary to the rest of the codebase, this method also takes a timestamp: When you call SensorSelectionUpdate(true), time_now_us is actually set to 1 and force stays false, as this is the default value for in the method.

### Solution
- Add time_now_us always when calling SensorSelectionUpdate in VehicleAngularVelocity 

### Changelog Entry
For release notes:
```
Feature/Bugfix Fix force SensorSelectionUpdate in VehicleAngularVelocity
New parameter:
Documentation:
```

### Alternatives
-

### Test coverage
-

### Context
-
