### PR TITLE
mc_pos_control: Publish velocity integrals for debug purposes

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -239,6 +239,7 @@ set(msg_files
 	WheelEncoders.msg
 	Wind.msg
 	YawEstimatorStatus.msg
+	velocity_ctrl_status.msg
 )
 list(SORT msg_files)
 

--- a/msg/velocity_ctrl_status.msg
+++ b/msg/velocity_ctrl_status.msg
@@ -1,0 +1,6 @@
+uint64 timestamp		# time since system start (microseconds)
+
+# velocity controller integrator status
+float32 vx_integ
+float32 vy_integ
+float32 vz_integ

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -129,6 +129,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("vehicle_rates_setpoint", 20);
 	add_topic("vehicle_roi", 1000);
 	add_topic("vehicle_status");
+	add_topic("velocity_ctrl_status", 200);
 	add_optional_topic("vtol_vehicle_status", 200);
 	add_topic("wind", 1000);
 
@@ -310,7 +311,7 @@ void LoggedTopics::add_high_rate_topics()
 	add_topic("vehicle_attitude");
 	add_topic("vehicle_attitude_setpoint");
 	add_topic("vehicle_rates_setpoint");
-
+	add_topic("velocity_ctrl_status", 20);
 	add_topic("actuator_motors");
 	add_topic("vehicle_thrust_setpoint");
 	add_topic("vehicle_torque_setpoint");

--- a/src/modules/mc_pos_control/MulticopterPositionControl.cpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.cpp
@@ -537,6 +537,11 @@ void MulticopterPositionControl::Run()
 			attitude_setpoint.timestamp = hrt_absolute_time();
 			_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
 
+			velocity_ctrl_status_s velocity_ctrl_status{};
+			_control.getVelocityControlStatus(velocity_ctrl_status);
+			velocity_ctrl_status.timestamp = hrt_absolute_time();
+			_velocity_controller_status_pub.publish(velocity_ctrl_status);
+
 		} else {
 			// an update is necessary here because otherwise the takeoff state doesn't get skipped with non-altitude-controlled modes
 			_takeoff.updateTakeoffState(_vehicle_control_mode.flag_armed, _vehicle_land_detected.landed, false, 10.f, true,

--- a/src/modules/mc_pos_control/MulticopterPositionControl.hpp
+++ b/src/modules/mc_pos_control/MulticopterPositionControl.hpp
@@ -65,6 +65,7 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/velocity_ctrl_status.h>
 
 using namespace time_literals;
 
@@ -96,6 +97,7 @@ private:
 	uORB::PublicationData<takeoff_status_s>              _takeoff_status_pub{ORB_ID(takeoff_status)};
 	uORB::Publication<vehicle_attitude_setpoint_s>	     _vehicle_attitude_setpoint_pub{ORB_ID(vehicle_attitude_setpoint)};
 	uORB::Publication<vehicle_local_position_setpoint_s> _local_pos_sp_pub{ORB_ID(vehicle_local_position_setpoint)};	/**< vehicle local position setpoint publication */
+	uORB::Publication<velocity_ctrl_status_s>            _velocity_controller_status_pub {ORB_ID(velocity_ctrl_status)};
 
 	uORB::SubscriptionCallbackWorkItem _local_pos_sub{this, ORB_ID(vehicle_local_position)};	/**< vehicle local position */
 

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -261,3 +261,10 @@ void PositionControl::getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_
 	ControlMath::thrustToAttitude(_thr_sp, _yaw_sp, attitude_setpoint);
 	attitude_setpoint.yaw_sp_move_rate = _yawspeed_sp;
 }
+
+void PositionControl::getVelocityControlStatus(velocity_ctrl_status_s &velocity_ctrl_status) const
+{
+	velocity_ctrl_status.vx_integ = _vel_int(0);
+	velocity_ctrl_status.vy_integ = _vel_int(1);
+	velocity_ctrl_status.vz_integ = _vel_int(2);
+}

--- a/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.hpp
@@ -44,6 +44,7 @@
 #include <uORB/topics/trajectory_setpoint.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/velocity_ctrl_status.h>
 
 struct PositionControlStates {
 	matrix::Vector3f position;
@@ -178,6 +179,12 @@ public:
 	 * @param attitude_setpoint reference to struct to fill up
 	 */
 	void getAttitudeSetpoint(vehicle_attitude_setpoint_s &attitude_setpoint) const;
+
+	/**
+	 * Get status message of controller for logging/debugging
+	 * @param velocity_ctrl_status status message to fill with internal states
+	 */
+	void getVelocityControlStatus(velocity_ctrl_status_s &velocity_ctrl_status) const;
 
 	/**
 	 * All setpoints are set to NAN (uncontrolled). Timestampt zero.


### PR DESCRIPTION
Currently only the rate integrals are logged. This PR mimics the implementation for logging the rate integrals but for the velocity integrals.

### Solved Problem
Missing debug info on velocity integrals

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
