### PR TITLE
[1.14] Fix Helicopter saturation logic

### DIFF
--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessHelicopter.cpp
@@ -229,6 +229,9 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.roll_neg) {
 		status.unallocated_torque[0] = -1.f;
+
+	} else {
+		status.unallocated_torque[0] = 0.f;
 	}
 
 	if (_saturation_flags.pitch_pos) {
@@ -236,6 +239,9 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.pitch_neg) {
 		status.unallocated_torque[1] = -1.f;
+
+	} else {
+		status.unallocated_torque[1] = 0.f;
 	}
 
 	if (_saturation_flags.yaw_pos) {
@@ -243,6 +249,9 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.yaw_neg) {
 		status.unallocated_torque[2] = -1.f;
+
+	} else {
+		status.unallocated_torque[2] = 0.f;
 	}
 
 	if (_saturation_flags.thrust_pos) {
@@ -250,5 +259,8 @@ void ActuatorEffectivenessHelicopter::getUnallocatedControl(int matrix_index, co
 
 	} else if (_saturation_flags.thrust_neg) {
 		status.unallocated_thrust[2] = -1.f;
+
+	} else {
+		status.unallocated_thrust[2] = 0.f;
 	}
 }


### PR DESCRIPTION
### Solved Problem
Backport https://github.com/PX4/PX4-Autopilot/pull/22147 for the point release 1.14.1

### Changelog Entry
```
Bugfix: Helicopter saturation logic leads to rate control integrator not working
```

### Test coverage
I cannot test this specifically on 1.14 but it's a low-risk change because handling the extra case was even correct before it became necessary. On 1.14 it is necessary because this one was also necessary: https://github.com/PX4/PX4-Autopilot/pull/21994