### PR TITLE
Fix Figure Eight CI Test

### DIFF
--- a/test/mavsdk_tests/test_vtol_figure_eight.cpp
+++ b/test/mavsdk_tests/test_vtol_figure_eight.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Figure eight execution clockwise", "[vtol]")
 	tester.arm();
 	tester.takeoff();
 	tester.wait_until_hovering();
-	tester.wait_until_altitude(takeoff_altitude - 1.f, std::chrono::seconds(60));
+	tester.wait_until_altitude(takeoff_altitude, std::chrono::seconds(30));
 	tester.transition_to_fixedwing();
 	tester.wait_until_fixedwing(std::chrono::seconds(5));
 	std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -71,7 +71,7 @@ TEST_CASE("Figure eight execution counterclockwise", "[vtol]")
 	tester.arm();
 	tester.takeoff();
 	tester.wait_until_hovering();
-	tester.wait_until_altitude(takeoff_altitude - 1.f, std::chrono::seconds(60));
+	tester.wait_until_altitude(takeoff_altitude, std::chrono::seconds(30));
 	tester.transition_to_fixedwing();
 	tester.wait_until_fixedwing(std::chrono::seconds(5));
 	std::this_thread::sleep_for(std::chrono::seconds(1));


### PR DESCRIPTION
### Solved Problem
When working on PRs I was going nuts about the figure eight test failing more often than not.

### Solution
wait_until_altitude() checks for absolute altitude being close so checking for 1m below the setpoint can fail if the speedup results in no sample inside the altitude window being checked.

### Changelog Entry
```
CI fix: Make figure-eight test pass consistently
```

### Alternatives
Ideally the test could check if the takeoff is done directly instead of comparing altitudes in the first place.

### Test coverage
I successfully ran the test 100 times with the altitude thershold 5 times narrower at 10cm instead of 50cm. Without the fix I had it fail locally basically every single time.
<img width="656" alt="image" src="https://github.com/PX4/PX4-Autopilot/assets/4668506/b2a2ad06-5a4a-4f56-8f1d-73bd6d9ffc1b">
