### PR TITLE
Add mission point check when update the geofence

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -291,11 +291,9 @@ bool Geofence::checkMissionRequirementsForGeofence(const PolygonInfo &polygon)
 		//missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
 		checks_pass = checkPointAgainstPolygonCircle(polygon,missionitem.lat, missionitem.lon, missionitem.altitude);
 		if (!checks_pass) {
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence invalid, against mission waypoint {1}\t",i+1);
-		events::send(events::ID("navigator_geofence_invalid_against_mission"), {events::Log::Critical, events::LogInternal::Warning},
-			     "Geofence invalid, against mission");
-
-
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence invalid, against mission waypoint %zu\t",i + 1);
+		events::send<int16_t>(events::ID("navigator_geofence_invalid_against_mission"), {events::Log::Critical, events::LogInternal::Warning},
+			     "Geofence invalid, against mission waypoint {1} ",i + 1);
 		break;
 		}
 	}

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -291,7 +291,7 @@ bool Geofence::checkMissionRequirementsForGeofence(const PolygonInfo &polygon)
 		//missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
 		checks_pass = checkPointAgainstPolygonCircle(polygon,missionitem.lat, missionitem.lon, missionitem.altitude);
 		if (!checks_pass) {
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence invalid, against mission\t");
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence invalid, against mission waypoint {1}\t",i+1);
 		events::send(events::ID("navigator_geofence_invalid_against_mission"), {events::Log::Critical, events::LogInternal::Warning},
 			     "Geofence invalid, against mission");
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -258,8 +258,11 @@ void Geofence::_updateFence()
 				// check if current position is inside the fence and vehicle is armed
 				const bool current_position_check_okay = checkCurrentPositionRequirementsForGeofence(polygon);
 
+				//check if current mission point inside the geofence
+				const bool current_mission_check_okay = checkMissionRequirementsForGeofence(polygon);
+
 				// discard the polygon if at least one check fails by not incrementing the counter in that case
-				if (home_check_okay && current_position_check_okay) {
+				if (home_check_okay && current_position_check_okay  && current_mission_check_okay) {
 					++_num_polygons;
 
 				}
@@ -273,6 +276,30 @@ void Geofence::_updateFence()
 			break;
 		}
 	}
+}
+
+bool Geofence::checkMissionRequirementsForGeofence(const PolygonInfo &polygon)
+{
+	mission_s mission;
+	_dataman_client.readSync(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission),sizeof(mission_s));
+	bool checks_pass = false;
+	//check all mission  against all geofence
+	for (size_t i = 0; i < mission.count; i++) {
+		struct mission_item_s missionitem = {};
+		_dataman_client.readSync((dm_item_t)mission.dataman_id, i, reinterpret_cast<uint8_t *>(&missionitem),
+					sizeof(mission_item_s));
+		//missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
+		checks_pass = checkPointAgainstPolygonCircle(polygon,missionitem.lat, missionitem.lon, missionitem.altitude);
+		if (!checks_pass) {
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence invalid, against mission\t");
+		events::send(events::ID("navigator_geofence_invalid_against_mission"), {events::Log::Critical, events::LogInternal::Warning},
+			     "Geofence invalid, against mission");
+
+
+		break;
+		}
+	}
+	return  checks_pass;
 }
 
 bool Geofence::checkHomeRequirementsForGeofence(const PolygonInfo &polygon)

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -207,6 +207,12 @@ private:
 	bool insideCircle(const PolygonInfo &polygon, double lat, double lon, float altitude);
 
 	/**
+	 * Check polygon or circle geofence fullfills the requirements relative to the current mission.
+	 * @return true if checks pass
+	 */
+	bool checkMissionRequirementsForGeofence(const PolygonInfo &polygon);
+
+	/**
 	 * Check if a single point is within a polygon or circle
 	 * @return true if within polygon or circle
 	 */


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

1.  https://github.com/PX4/PX4-Autopilot/blob/c5101c70b31aa0c1454162c6ad1420e5af8086b2/src/modules/navigator/mission_feasibility_checker.cpp#L108 I've found that the MissionFeasibilityChecker()  is only triggered correctly when updating a mission.  when only updating a geofence,user need to click upload twice to invoke check function. Currently, the geofence update only checks the origin and the current position associated with the geofence, and I've added a check for mission waypoints to make the check on upload more complete.The problem is related to the state machine and asynchronous message reading in geofence.cpp.The checkMissionAgainstGeofence() is written in the mission and the geofence is still being read when the mission has finished uploading and checking.
 
![%`%3Z`6)VGYLVSF_)N0L{BT](https://github.com/PX4/PX4-Autopilot/assets/151698793/38b3fe89-4ed8-47d7-8822-c5254984f679)

Fixes #{#22362}
In this bug issue , @czbxzm said ,"1. When swapping the order, uploading the mission waypoint routes first and then plotting the no-fly zones does not trigger any checks, even if there is an overlap between the two;"Actually this check triggers, but requires a second click on upload.(in the version reporting this bug issue)


### Solution

1. I've added a check for mission waypoints when update geofence.
 
![95$0I@SC~0)3RA G`Q2XMCR](https://github.com/PX4/PX4-Autopilot/assets/151698793/d96db40e-0b0e-4061-9a9c-358a5bde2268)


### Test coverage

 test on jmavsim/gz_x500 and QGC



