### PR TITLE
Double storage for rally points and geofence

### DIFF
--- a/msg/Mission.msg
+++ b/msg/Mission.msg
@@ -1,5 +1,7 @@
 uint64 timestamp	# time since system start (microseconds)
 uint8 mission_dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
+uint8 fence_dataman_id		# default 0, there are two offboard storage places in the dataman: 0 or 1
+uint8 safepoint_dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
 
 uint16 count		# count of the missions stored in the dataman
 int32 current_seq	# default -1, start at the one changed latest

--- a/msg/Mission.msg
+++ b/msg/Mission.msg
@@ -1,5 +1,5 @@
 uint64 timestamp	# time since system start (microseconds)
-uint8 dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
+uint8 mission_dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
 
 uint16 count		# count of the missions stored in the dataman
 int32 current_seq	# default -1, start at the one changed latest

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -129,8 +129,12 @@ static unsigned g_func_counts[DM_NUMBER_OF_FUNCS];
 
 /* Table of the len of each item type including HDR size */
 static constexpr size_t g_per_item_size_with_hdr[DM_KEY_NUM_KEYS] = {
-	g_per_item_size[DM_KEY_SAFE_POINTS] + DM_SECTOR_HDR_SIZE,
-	g_per_item_size[DM_KEY_FENCE_POINTS] + DM_SECTOR_HDR_SIZE,
+	g_per_item_size[DM_KEY_SAFE_POINTS_0] + DM_SECTOR_HDR_SIZE,
+	g_per_item_size[DM_KEY_SAFE_POINTS_1] + DM_SECTOR_HDR_SIZE,
+	g_per_item_size[DM_KEY_SAFE_POINTS_STATE] + DM_SECTOR_HDR_SIZE,
+	g_per_item_size[DM_KEY_FENCE_POINTS_0] + DM_SECTOR_HDR_SIZE,
+	g_per_item_size[DM_KEY_FENCE_POINTS_1] + DM_SECTOR_HDR_SIZE,
+	g_per_item_size[DM_KEY_FENCE_POINTS_STATE] + DM_SECTOR_HDR_SIZE,
 	g_per_item_size[DM_KEY_WAYPOINTS_OFFBOARD_0] + DM_SECTOR_HDR_SIZE,
 	g_per_item_size[DM_KEY_WAYPOINTS_OFFBOARD_1] + DM_SECTOR_HDR_SIZE,
 	g_per_item_size[DM_KEY_MISSION_STATE] + DM_SECTOR_HDR_SIZE,
@@ -565,7 +569,7 @@ _file_initialize(unsigned max_offset)
 			PX4_ERR("Failed writing compat: %d", ret);
 		}
 
-		for (uint32_t item = DM_KEY_SAFE_POINTS; item <= DM_KEY_MISSION_STATE; ++item) {
+		for (uint32_t item = DM_KEY_SAFE_POINTS_0; item <= DM_KEY_MISSION_STATE; ++item) {
 			g_dm_ops->clear((dm_item_t)item);
 		}
 
@@ -583,8 +587,8 @@ _file_initialize(unsigned max_offset)
 		stats.opaque_id = 0;
 
 		g_dm_ops->write(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission), sizeof(mission_s));
-		g_dm_ops->write(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats), sizeof(mission_stats_entry_s));
-		g_dm_ops->write(DM_KEY_SAFE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats), sizeof(mission_stats_entry_s));
+		g_dm_ops->write(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats), sizeof(mission_stats_entry_s));
+		g_dm_ops->write(DM_KEY_SAFE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats), sizeof(mission_stats_entry_s));
 	}
 
 	dm_operations_data.running = true;
@@ -879,10 +883,6 @@ Each type has a specific type and a fixed maximum amount of storage items, so th
 
 ### Implementation
 Reading and writing a single item is always atomic.
-
-**DM_KEY_FENCE_POINTS** and **DM_KEY_SAFE_POINTS** items: the first data element is a `mission_stats_entry_s` struct,
-which stores the number of items for these types. These items are always updated atomically in one transaction (from
-the mavlink mission manager).
 
 )DESCR_STR");
 

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -571,7 +571,7 @@ _file_initialize(unsigned max_offset)
 
 		mission_s mission{};
 		mission.timestamp = hrt_absolute_time();
-		mission.dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
+		mission.mission_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 		mission.count = 0;
 		mission.current_seq = 0;
 		mission.mission_id = 0u;

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -44,8 +44,12 @@
 
 /** Types of items that the data manager can store */
 typedef enum {
-	DM_KEY_SAFE_POINTS = 0,			///< Safe points coordinates, safe point 0 is home point
-	DM_KEY_FENCE_POINTS,			///< Fence vertex coordinates
+	DM_KEY_SAFE_POINTS_0 = 0,	///< Safe points storage 0
+	DM_KEY_SAFE_POINTS_1,		///< Safe points storage 1 (alternate between 0 and 1)
+	DM_KEY_SAFE_POINTS_STATE,	///< Persistent safe point state
+	DM_KEY_FENCE_POINTS_0,		///< Fence vertex storage 0
+	DM_KEY_FENCE_POINTS_1,		///< Fence vertex storage 1 (alternate between 0 and 1)
+	DM_KEY_FENCE_POINTS_STATE,	///< Persistent fence vertex state
 	DM_KEY_WAYPOINTS_OFFBOARD_0,	///< Mission way point coordinates sent over mavlink
 	DM_KEY_WAYPOINTS_OFFBOARD_1,	///< (alternate between 0 and 1)
 	DM_KEY_MISSION_STATE,			///< Persistent mission state
@@ -66,7 +70,9 @@ typedef enum {
 #if defined(MEMORY_CONSTRAINED_SYSTEM)
 enum {
 	DM_KEY_SAFE_POINTS_MAX = 8,
+	DM_KEY_SAFE_POINTS_STATE_MAX = 1,
 	DM_KEY_FENCE_POINTS_MAX = 16,
+	DM_KEY_FENCE_POINTS_STATE_MAX = 1,
 	DM_KEY_WAYPOINTS_OFFBOARD_0_MAX = NUM_MISSIONS_SUPPORTED,
 	DM_KEY_WAYPOINTS_OFFBOARD_1_MAX = NUM_MISSIONS_SUPPORTED,
 	DM_KEY_MISSION_STATE_MAX = 1,
@@ -75,7 +81,9 @@ enum {
 #else
 enum {
 	DM_KEY_SAFE_POINTS_MAX = 32,
+	DM_KEY_SAFE_POINTS_STATE_MAX = 1,
 	DM_KEY_FENCE_POINTS_MAX = 64,
+	DM_KEY_FENCE_POINTS_STATE_MAX = 1,
 	DM_KEY_WAYPOINTS_OFFBOARD_0_MAX = NUM_MISSIONS_SUPPORTED,
 	DM_KEY_WAYPOINTS_OFFBOARD_1_MAX = NUM_MISSIONS_SUPPORTED,
 	DM_KEY_MISSION_STATE_MAX = 1,
@@ -86,7 +94,11 @@ enum {
 /* table of maximum number of instances for each item type */
 static const unsigned g_per_item_max_index[DM_KEY_NUM_KEYS] = {
 	DM_KEY_SAFE_POINTS_MAX,
+	DM_KEY_SAFE_POINTS_MAX,
+	DM_KEY_SAFE_POINTS_STATE_MAX,
 	DM_KEY_FENCE_POINTS_MAX,
+	DM_KEY_FENCE_POINTS_MAX,
+	DM_KEY_FENCE_POINTS_STATE_MAX,
 	DM_KEY_WAYPOINTS_OFFBOARD_0_MAX,
 	DM_KEY_WAYPOINTS_OFFBOARD_1_MAX,
 	DM_KEY_MISSION_STATE_MAX,
@@ -98,7 +110,9 @@ struct dataman_compat_s {
 };
 
 constexpr uint32_t MISSION_SAFE_POINT_SIZE = sizeof(struct mission_item_s);
+constexpr uint32_t MISSION_SAFE_POINT_STATE_SIZE = sizeof(struct mission_stats_entry_s);
 constexpr uint32_t MISSION_FENCE_POINT_SIZE = sizeof(struct mission_fence_point_s);
+constexpr uint32_t MISSION_FENCE_POINT_STATE_SIZE = sizeof(struct mission_stats_entry_s);
 constexpr uint32_t MISSION_ITEM_SIZE = sizeof(struct mission_item_s);
 constexpr uint32_t MISSION_SIZE = sizeof(struct mission_s);
 constexpr uint32_t DATAMAN_COMPAT_SIZE = sizeof(struct dataman_compat_s);
@@ -106,7 +120,11 @@ constexpr uint32_t DATAMAN_COMPAT_SIZE = sizeof(struct dataman_compat_s);
 /** The table of the size of each item type */
 static constexpr size_t g_per_item_size[DM_KEY_NUM_KEYS] = {
 	MISSION_SAFE_POINT_SIZE,
+	MISSION_SAFE_POINT_SIZE,
+	MISSION_SAFE_POINT_STATE_SIZE,
 	MISSION_FENCE_POINT_SIZE,
+	MISSION_FENCE_POINT_SIZE,
+	MISSION_FENCE_POINT_STATE_SIZE,
 	MISSION_ITEM_SIZE,
 	MISSION_ITEM_SIZE,
 	MISSION_SIZE,
@@ -114,7 +132,7 @@ static constexpr size_t g_per_item_size[DM_KEY_NUM_KEYS] = {
 };
 
 /* increment this define whenever a binary incompatible change is performed */
-#define DM_COMPAT_VERSION	4ULL
+#define DM_COMPAT_VERSION	5ULL
 
 #define DM_COMPAT_KEY ((DM_COMPAT_VERSION << 32) + (sizeof(struct mission_item_s) << 24) + \
 		       (sizeof(struct mission_s) << 16) + (sizeof(struct mission_stats_entry_s) << 12) + \

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -93,11 +93,15 @@ static const unsigned g_per_item_max_index[DM_KEY_NUM_KEYS] = {
 	DM_KEY_COMPAT_MAX
 };
 
+struct dataman_compat_s {
+	uint64_t key;
+};
+
 constexpr uint32_t MISSION_SAFE_POINT_SIZE = sizeof(struct mission_item_s);
 constexpr uint32_t MISSION_FENCE_POINT_SIZE = sizeof(struct mission_fence_point_s);
 constexpr uint32_t MISSION_ITEM_SIZE = sizeof(struct mission_item_s);
 constexpr uint32_t MISSION_SIZE = sizeof(struct mission_s);
-constexpr uint32_t DATAMAN_COMPAT_SIZE = sizeof(struct mission_s);
+constexpr uint32_t DATAMAN_COMPAT_SIZE = sizeof(struct dataman_compat_s);
 
 /** The table of the size of each item type */
 static constexpr size_t g_per_item_size[DM_KEY_NUM_KEYS] = {
@@ -107,10 +111,6 @@ static constexpr size_t g_per_item_size[DM_KEY_NUM_KEYS] = {
 	MISSION_ITEM_SIZE,
 	MISSION_SIZE,
 	DATAMAN_COMPAT_SIZE
-};
-
-struct dataman_compat_s {
-	uint64_t key;
 };
 
 /* increment this define whenever a binary incompatible change is performed */

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -90,6 +90,9 @@ MavlinkMissionManager::MavlinkMissionManager(Mavlink *mavlink) :
 		} else {
 			PX4_WARN("offboard mission init failed");
 		}
+
+		update_active_mission(_mission_dataman_id, _count[MAV_MISSION_TYPE_MISSION], _current_seq,
+				      _crc32[MAV_MISSION_TYPE_MISSION], false);
 	}
 
 	_my_mission_dataman_id = _mission_dataman_id;

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -110,7 +110,7 @@ MavlinkMissionManager::load_geofence_stats()
 {
 	mission_stats_entry_s stats;
 	// initialize fence points count
-	bool success = _dataman_client.readSync(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+	bool success = _dataman_client.readSync(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 						sizeof(mission_stats_entry_s));
 
 	if (success) {
@@ -126,7 +126,7 @@ MavlinkMissionManager::load_safepoint_stats()
 {
 	mission_stats_entry_s stats;
 	// initialize safe points count
-	bool success = _dataman_client.readSync(DM_KEY_SAFE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+	bool success = _dataman_client.readSync(DM_KEY_SAFE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 						sizeof(mission_stats_entry_s));
 
 	if (success) {
@@ -182,7 +182,7 @@ MavlinkMissionManager::update_geofence_count(unsigned count, uint32_t crc32)
 	stats.opaque_id = crc32;
 
 	/* update stats in dataman */
-	bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+	bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 			sizeof(mission_stats_entry_s));
 
 	if (success) {
@@ -214,7 +214,7 @@ MavlinkMissionManager::update_safepoint_count(unsigned count, uint32_t crc32)
 	stats.opaque_id = crc32;
 
 	/* update stats in dataman */
-	bool success = _dataman_client.writeSync(DM_KEY_SAFE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+	bool success = _dataman_client.writeSync(DM_KEY_SAFE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 			sizeof(mission_stats_entry_s));
 
 	if (success) {
@@ -303,7 +303,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 
 	case MAV_MISSION_TYPE_FENCE: { // Read a geofence point
 			mission_fence_point_s mission_fence_point;
-			read_success = _dataman_client.readSync(DM_KEY_FENCE_POINTS, seq + 1,
+			read_success = _dataman_client.readSync(DM_KEY_FENCE_POINTS_STATE, seq,
 								reinterpret_cast<uint8_t *>(&mission_fence_point), sizeof(mission_fence_point_s));
 
 			mission_item.nav_cmd = mission_fence_point.nav_cmd;
@@ -323,7 +323,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 		break;
 
 	case MAV_MISSION_TYPE_RALLY: { // Read a safe point / rally point
-			read_success = _dataman_client.readSync(DM_KEY_SAFE_POINTS, seq + 1, reinterpret_cast<uint8_t *>(&mission_item),
+			read_success = _dataman_client.readSync(DM_KEY_SAFE_POINTS_0, seq, reinterpret_cast<uint8_t *>(&mission_item),
 								sizeof(mission_item_s));
 		}
 		break;
@@ -1152,7 +1152,7 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 				mission_fence_point.frame = mission_item.frame;
 
 				if (!check_failed) {
-					write_failed = !_dataman_client.writeSync(DM_KEY_FENCE_POINTS, wp.seq + 1,
+					write_failed = !_dataman_client.writeSync(DM_KEY_FENCE_POINTS_STATE, wp.seq,
 							reinterpret_cast<uint8_t *>(&mission_fence_point), sizeof(mission_fence_point_s));
 				}
 
@@ -1160,7 +1160,7 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 			break;
 
 		case MAV_MISSION_TYPE_RALLY: { // Write a safe point / rally point
-				write_failed = !_dataman_client.writeSync(DM_KEY_SAFE_POINTS, wp.seq + 1,
+				write_failed = !_dataman_client.writeSync(DM_KEY_SAFE_POINTS_0, wp.seq,
 						reinterpret_cast<uint8_t *>(&mission_item), sizeof(mission_item_s), 2_s);
 			}
 			break;

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -106,8 +106,8 @@ private:
 
 	unsigned		_filesystem_errcount{0};		///< File system error count
 
-	static dm_item_t		_dataman_id;				///< Global Dataman storage ID for active mission
-	dm_item_t			_my_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_0};			///< class Dataman storage ID
+	static dm_item_t	_mission_dataman_id;			///< Global Dataman storage ID for active mission
+	dm_item_t		_my_mission_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_0};		///< class Dataman storage ID for mission
 
 	static bool		_dataman_init;				///< Dataman initialized
 
@@ -117,7 +117,7 @@ private:
 
 	int32_t			_last_reached{-1};			///< Last reached waypoint in active mission (-1 means nothing reached)
 
-	dm_item_t			_transfer_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_1};		///< Dataman storage ID for current transmission
+	dm_item_t		_transfer_mission_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_1};	///< Dataman storage ID for current mission transmission
 
 	uint16_t		_transfer_count{0};			///< Items count in current transmission
 	uint32_t		_transfer_current_crc32{0};		///< Current CRC32 checksum of current transmission
@@ -168,7 +168,7 @@ private:
 
 	void init_offboard_mission(const mission_s &mission_state);
 
-	void update_active_mission(dm_item_t dataman_id, uint16_t count, int32_t seq, uint32_t crc32,
+	void update_active_mission(dm_item_t mission_dataman_id, uint16_t count, int32_t seq, uint32_t crc32,
 				   bool write_to_dataman = true);
 
 	/** store the geofence count to dataman */

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -148,8 +148,8 @@ private:
 		2;	///< Error count limit before stopping to report FS errors
 	static constexpr uint16_t	MAX_COUNT[] = {
 		DM_KEY_WAYPOINTS_OFFBOARD_0_MAX,
-		DM_KEY_FENCE_POINTS_MAX - 1,
-		DM_KEY_SAFE_POINTS_MAX - 1
+		DM_KEY_FENCE_POINTS_MAX,
+		DM_KEY_SAFE_POINTS_MAX
 	};	/**< Maximum number of mission items for each type
 					(fence & safe points use the first item for the stats) */
 

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -107,7 +107,11 @@ private:
 	unsigned		_filesystem_errcount{0};		///< File system error count
 
 	static dm_item_t	_mission_dataman_id;			///< Global Dataman storage ID for active mission
+	static dm_item_t 	_safepoint_dataman_id; 			///< Global dataman storage id for active safepoints
+	static dm_item_t 	_fence_dataman_id; 			///< Global dataman storage id for active geofence
 	dm_item_t		_my_mission_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_0};		///< class Dataman storage ID for mission
+	dm_item_t		_my_safepoint_dataman_id{DM_KEY_SAFE_POINTS_0};			///< class Dataman storage ID for safepoints
+	dm_item_t		_my_fence_dataman_id{DM_KEY_FENCE_POINTS_0};			///< class Dataman storage ID for geofence
 
 	static bool		_dataman_init;				///< Dataman initialized
 
@@ -117,7 +121,7 @@ private:
 
 	int32_t			_last_reached{-1};			///< Last reached waypoint in active mission (-1 means nothing reached)
 
-	dm_item_t		_transfer_mission_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_1};	///< Dataman storage ID for current mission transmission
+	dm_item_t		_transfer_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_1};	///< Dataman storage ID for current transmission
 
 	uint16_t		_transfer_count{0};			///< Items count in current transmission
 	uint32_t		_transfer_current_crc32{0};		///< Current CRC32 checksum of current transmission
@@ -172,10 +176,10 @@ private:
 				   bool write_to_dataman = true);
 
 	/** store the geofence count to dataman */
-	int update_geofence_count(unsigned count, uint32_t crc32);
+	int update_geofence_count(dm_item_t fence_dataman_id, unsigned count, uint32_t crc32);
 
 	/** store the safepoint count to dataman */
-	int update_safepoint_count(unsigned count, uint32_t crc32);
+	int update_safepoint_count(dm_item_t safepoint_dataman_id, unsigned count, uint32_t crc32);
 
 	/** load geofence stats from dataman */
 	bool load_geofence_stats();

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -140,7 +140,7 @@ void Geofence::run()
 				}
 
 				for (int index = 0; index < _dataman_cache.size(); ++index) {
-					_dataman_cache.load(DM_KEY_FENCE_POINTS_0, index);
+					_dataman_cache.load(static_cast<dm_item_t>(_stats.dataman_id), index);
 				}
 
 				_dataman_state = DatamanState::Load;
@@ -191,7 +191,7 @@ void Geofence::_updateFence()
 
 	while (current_seq < _dataman_cache.size()) {
 
-		bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, current_seq,
+		bool success = _dataman_cache.loadWait(static_cast<dm_item_t>(_stats.dataman_id), current_seq,
 						       reinterpret_cast<uint8_t *>(&mission_fence_point),
 						       sizeof(mission_fence_point_s));
 
@@ -412,14 +412,15 @@ bool Geofence::insidePolygon(const PolygonInfo &polygon, double lat, double lon,
 
 	for (unsigned i = 0, j = polygon.vertex_count - 1; i < polygon.vertex_count; j = i++) {
 
-		bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, polygon.dataman_index + i,
+		dm_item_t fence_dataman_id{static_cast<dm_item_t>(_stats.dataman_id)};
+		bool success = _dataman_cache.loadWait(fence_dataman_id, polygon.dataman_index + i,
 						       reinterpret_cast<uint8_t *>(&temp_vertex_i), sizeof(mission_fence_point_s));
 
 		if (!success) {
 			break;
 		}
 
-		success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, polygon.dataman_index + j,
+		success = _dataman_cache.loadWait(fence_dataman_id, polygon.dataman_index + j,
 						  reinterpret_cast<uint8_t *>(&temp_vertex_j), sizeof(mission_fence_point_s));
 
 		if (!success) {
@@ -448,7 +449,7 @@ bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, 
 {
 
 	mission_fence_point_s circle_point{};
-	bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, polygon.dataman_index,
+	bool success = _dataman_cache.loadWait(static_cast<dm_item_t>(_stats.dataman_id), polygon.dataman_index,
 					       reinterpret_cast<uint8_t *>(&circle_point), sizeof(mission_fence_point_s));
 
 	if (!success) {
@@ -491,8 +492,18 @@ Geofence::loadFromFile(const char *filename)
 	const char commentChar = '#';
 	int ret_val = PX4_ERROR;
 
-	/* Make sure no data is left in the datamanager */
-	clearDm();
+	mission_stats_entry_s stat;
+	{
+		const bool success = _dataman_client.readAsync(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stat),
+				     sizeof(mission_stats_entry_s));
+
+		if (!success) {
+			PX4_ERR("Could not read fence dataman state");
+			return PX4_ERROR;
+		}
+	}
+
+	dm_item_t write_fence_dataman_id{static_cast<dm_item_t>(stat.dataman_id) == DM_KEY_FENCE_POINTS_0 ? DM_KEY_FENCE_POINTS_1 : DM_KEY_FENCE_POINTS_0};
 
 	/* open the mixer definition file */
 	fp = fopen(GEOFENCE_FILENAME, "r");
@@ -554,7 +565,7 @@ Geofence::loadFromFile(const char *filename)
 				}
 			}
 
-			bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS_0, pointCounter, reinterpret_cast<uint8_t *>(&vertex),
+			bool success = _dataman_client.writeSync(write_fence_dataman_id, pointCounter, reinterpret_cast<uint8_t *>(&vertex),
 					sizeof(vertex));
 
 			if (!success) {
@@ -588,13 +599,13 @@ Geofence::loadFromFile(const char *filename)
 		for (int seq = 0; seq < pointCounter; ++seq) {
 			mission_fence_point_s mission_fence_point;
 
-			bool success = _dataman_client.readSync(DM_KEY_FENCE_POINTS_0, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
+			bool success = _dataman_client.readSync(write_fence_dataman_id, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
 								sizeof(mission_fence_point_s));
 
 			if (success) {
 				mission_fence_point.vertex_count = pointCounter;
 				crc32 = crc32_for_fence_point(mission_fence_point, crc32);
-				_dataman_client.writeSync(DM_KEY_FENCE_POINTS_0, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
+				_dataman_client.writeSync(write_fence_dataman_id, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
 							  sizeof(mission_fence_point_s));
 			}
 		}
@@ -620,13 +631,6 @@ Geofence::loadFromFile(const char *filename)
 error:
 	fclose(fp);
 	return ret_val;
-}
-
-int Geofence::clearDm()
-{
-	_dataman_client.clearSync(DM_KEY_FENCE_POINTS_STATE);
-	updateFence();
-	return PX4_OK;
 }
 
 bool Geofence::isHomeRequired()

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -108,7 +108,7 @@ void Geofence::run()
 	case DatamanState::Read:
 
 		_dataman_state = DatamanState::ReadWait;
-		success = _dataman_client.readAsync(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&_stats),
+		success = _dataman_client.readAsync(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&_stats),
 						    sizeof(mission_stats_entry_s));
 
 		if (!success) {
@@ -139,8 +139,8 @@ void Geofence::run()
 					_dataman_cache.resize(_stats.num_items);
 				}
 
-				for (int index = 1; index <= _dataman_cache.size(); ++index) {
-					_dataman_cache.load(DM_KEY_FENCE_POINTS, index);
+				for (int index = 0; index < _dataman_cache.size(); ++index) {
+					_dataman_cache.load(DM_KEY_FENCE_POINTS_0, index);
 				}
 
 				_dataman_state = DatamanState::Load;
@@ -187,11 +187,11 @@ void Geofence::_updateFence()
 
 	// iterate over all polygons and store their starting vertices
 	_num_polygons = 0;
-	int current_seq = 1;
+	int current_seq = 0;
 
-	while (current_seq <= _dataman_cache.size()) {
+	while (current_seq < _dataman_cache.size()) {
 
-		bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS, current_seq,
+		bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, current_seq,
 						       reinterpret_cast<uint8_t *>(&mission_fence_point),
 						       sizeof(mission_fence_point_s));
 
@@ -412,14 +412,14 @@ bool Geofence::insidePolygon(const PolygonInfo &polygon, double lat, double lon,
 
 	for (unsigned i = 0, j = polygon.vertex_count - 1; i < polygon.vertex_count; j = i++) {
 
-		bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS, polygon.dataman_index + i,
+		bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, polygon.dataman_index + i,
 						       reinterpret_cast<uint8_t *>(&temp_vertex_i), sizeof(mission_fence_point_s));
 
 		if (!success) {
 			break;
 		}
 
-		success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS, polygon.dataman_index + j,
+		success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, polygon.dataman_index + j,
 						  reinterpret_cast<uint8_t *>(&temp_vertex_j), sizeof(mission_fence_point_s));
 
 		if (!success) {
@@ -448,7 +448,7 @@ bool Geofence::insideCircle(const PolygonInfo &polygon, double lat, double lon, 
 {
 
 	mission_fence_point_s circle_point{};
-	bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS, polygon.dataman_index,
+	bool success = _dataman_cache.loadWait(DM_KEY_FENCE_POINTS_0, polygon.dataman_index,
 					       reinterpret_cast<uint8_t *>(&circle_point), sizeof(mission_fence_point_s));
 
 	if (!success) {
@@ -554,7 +554,7 @@ Geofence::loadFromFile(const char *filename)
 				}
 			}
 
-			bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS, pointCounter + 1, reinterpret_cast<uint8_t *>(&vertex),
+			bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS_0, pointCounter, reinterpret_cast<uint8_t *>(&vertex),
 					sizeof(vertex));
 
 			if (!success) {
@@ -585,16 +585,16 @@ Geofence::loadFromFile(const char *filename)
 		uint32_t crc32{0U};
 
 		/* do a second pass, now that we know the number of vertices */
-		for (int seq = 1; seq <= pointCounter; ++seq) {
+		for (int seq = 0; seq < pointCounter; ++seq) {
 			mission_fence_point_s mission_fence_point;
 
-			bool success = _dataman_client.readSync(DM_KEY_FENCE_POINTS, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
+			bool success = _dataman_client.readSync(DM_KEY_FENCE_POINTS_0, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
 								sizeof(mission_fence_point_s));
 
 			if (success) {
 				mission_fence_point.vertex_count = pointCounter;
 				crc32 = crc32_for_fence_point(mission_fence_point, crc32);
-				_dataman_client.writeSync(DM_KEY_FENCE_POINTS, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
+				_dataman_client.writeSync(DM_KEY_FENCE_POINTS_0, seq, reinterpret_cast<uint8_t *>(&mission_fence_point),
 							  sizeof(mission_fence_point_s));
 			}
 		}
@@ -603,7 +603,7 @@ Geofence::loadFromFile(const char *filename)
 		stats.num_items = pointCounter;
 		stats.opaque_id = crc32;
 
-		bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+		bool success = _dataman_client.writeSync(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 				sizeof(mission_stats_entry_s));
 
 		if (success) {
@@ -624,7 +624,7 @@ error:
 
 int Geofence::clearDm()
 {
-	_dataman_client.clearSync(DM_KEY_FENCE_POINTS);
+	_dataman_client.clearSync(DM_KEY_FENCE_POINTS_STATE);
 	updateFence();
 	return PX4_OK;
 }

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -108,8 +108,6 @@ public:
 
 	virtual bool isInsidePolygonOrCircle(double lat, double lon, float altitude);
 
-	int clearDm();
-
 	bool valid();
 
 	/**

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -192,11 +192,11 @@ void Mission::setActiveMissionItems()
 	getNextPositionItems(_mission.current_seq + 1, next_mission_items_index, num_found_items, max_num_next_items);
 
 	mission_item_s next_mission_items[max_num_next_items];
-	const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+	const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 
 	for (size_t i = 0U; i < num_found_items; i++) {
 		mission_item_s next_mission_item;
-		bool success = _dataman_cache.loadWait(dataman_id, next_mission_items_index[i],
+		bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_items_index[i],
 						       reinterpret_cast<uint8_t *>(&next_mission_item), sizeof(next_mission_item), MAX_DATAMAN_LOAD_WAIT);
 
 		if (success) {
@@ -459,7 +459,7 @@ Mission::save_mission_state()
 
 	if (success) {
 		/* data read successfully, check dataman ID and items count */
-		if (mission_state.dataman_id == _mission.dataman_id && mission_state.count == _mission.count
+		if (mission_state.mission_dataman_id == _mission.mission_dataman_id && mission_state.count == _mission.count
 		    && mission_state.mission_id == _mission.mission_id) {
 			/* navigator may modify only sequence, write modified state only if it changed */
 			if (mission_state.current_seq != _mission.current_seq) {

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -111,20 +111,22 @@ void MissionBase::updateMavlinkMission()
 		mission_s new_mission;
 		_mission_sub.update(&new_mission);
 
-		if (isMissionValid(new_mission)) {
-			/* Relevant mission items updated externally*/
-			if (checkMissionDataChanged(new_mission)) {
-				bool mission_items_changed = (new_mission.mission_id != _mission.mission_id);
+		const bool mission_items_changed = (new_mission.mission_id != _mission.mission_id);
+		const bool mission_data_changed = checkMissionDataChanged(new_mission);
 
-				if (new_mission.current_seq < 0) {
-					new_mission.current_seq = math::max(math::min(_mission.current_seq, static_cast<int32_t>(new_mission.count) - 1),
-									    INT32_C(0));
-				}
+		if (new_mission.current_seq < 0) {
+			new_mission.current_seq = math::max(math::min(_mission.current_seq, static_cast<int32_t>(new_mission.count) - 1),
+							    INT32_C(0));
+		}
 
-				_mission = new_mission;
+		_mission = new_mission;
 
-				onMissionUpdate(mission_items_changed);
-			}
+		_is_current_planned_mission_item_valid = isMissionValid(_mission);
+
+		/* Relevant mission items updated externally*/
+		if (mission_data_changed) {
+
+			onMissionUpdate(mission_items_changed);
 		}
 	}
 }

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -835,7 +835,7 @@ MissionBase::do_abort_landing()
 
 	} else {
 		// move mission index back (landing approach point)
-		_is_current_planned_mission_item_valid = goToPreviousItem(false);
+		_is_current_planned_mission_item_valid = (goToPreviousItem(false) == PX4_OK);
 	}
 
 	// send reposition cmd to get out of mission

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -96,7 +96,7 @@ MissionBase::updateDatamanCache()
 
 		for (int32_t index = start_index; index != end_index; index += math::signNoZero(_dataman_cache_size_signed)) {
 
-			_dataman_cache.load(static_cast<dm_item_t>(_mission.dataman_id), index);
+			_dataman_cache.load(static_cast<dm_item_t>(_mission.mission_dataman_id), index);
 		}
 
 		_load_mission_index = _mission.current_seq;
@@ -274,8 +274,8 @@ MissionBase::on_active()
 
 		if (num_found_items == 1U && !PX4_ISFINITE(_mission_item.yaw)) {
 			mission_item_s next_position_mission_item;
-			const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
-			bool success = _dataman_cache.loadWait(dataman_id, next_mission_item_index,
+			const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
+			bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_item_index,
 							       reinterpret_cast<uint8_t *>(&next_position_mission_item), sizeof(next_position_mission_item), MAX_DATAMAN_LOAD_WAIT);
 
 			if (success) {
@@ -460,7 +460,7 @@ MissionBase::set_mission_items()
 
 void MissionBase::loadCurrentMissionItem()
 {
-	const dm_item_t dm_item = static_cast<dm_item_t>(_mission.dataman_id);
+	const dm_item_t dm_item = static_cast<dm_item_t>(_mission.mission_dataman_id);
 	bool success = _dataman_cache.loadWait(dm_item, _mission.current_seq, reinterpret_cast<uint8_t *>(&_mission_item),
 					       sizeof(mission_item_s), MAX_DATAMAN_LOAD_WAIT);
 
@@ -884,7 +884,8 @@ bool MissionBase::isMissionValid(mission_s &mission) const
 	bool ret_val{false};
 
 	if (((mission.current_seq < mission.count) || (mission.count == 0U && mission.current_seq <= 0)) &&
-	    (mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 || mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) &&
+	    (mission.mission_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0
+	     || mission.mission_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) &&
 	    (mission.timestamp != 0u)) {
 		ret_val = true;
 
@@ -900,13 +901,13 @@ int MissionBase::getNonJumpItem(int32_t &mission_index, mission_item_s &mission,
 		return PX4_ERROR;
 	}
 
-	const dm_item_t dataman_id = (dm_item_t)_mission.dataman_id;
+	const dm_item_t mission_dataman_id = (dm_item_t)_mission.mission_dataman_id;
 	int32_t new_mission_index{mission_index};
 	mission_item_s new_mission;
 
 	for (uint16_t jump_count = 0u; jump_count < MAX_JUMP_ITERATION; jump_count++) {
 		/* read mission item from datamanager */
-		bool success = _dataman_cache.loadWait(dataman_id, new_mission_index, reinterpret_cast<uint8_t *>(&new_mission),
+		bool success = _dataman_cache.loadWait(mission_dataman_id, new_mission_index, reinterpret_cast<uint8_t *>(&new_mission),
 						       sizeof(mission_item_s), MAX_DATAMAN_LOAD_WAIT);
 
 		if (!success) {
@@ -926,7 +927,7 @@ int MissionBase::getNonJumpItem(int32_t &mission_index, mission_item_s &mission,
 			if ((new_mission.do_jump_current_count < new_mission.do_jump_repeat_count) && execute_jump) {
 				if (write_jumps) {
 					new_mission.do_jump_current_count++;
-					success = _dataman_cache.writeWait(dataman_id, new_mission_index, reinterpret_cast<uint8_t *>(&new_mission),
+					success = _dataman_cache.writeWait(mission_dataman_id, new_mission_index, reinterpret_cast<uint8_t *>(&new_mission),
 									   sizeof(struct mission_item_s));
 
 					if (!success) {
@@ -1099,12 +1100,12 @@ int MissionBase::setMissionToClosestItem(double lat, double lon, float alt, floa
 {
 	int32_t min_dist_index(-1);
 	float min_dist(FLT_MAX), dist_xy(FLT_MAX), dist_z(FLT_MAX);
-	const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+	const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 
 	for (int32_t mission_item_index = 0; mission_item_index < _mission.count; mission_item_index++) {
 		mission_item_s mission;
 
-		bool success = _dataman_cache.loadWait(dataman_id, mission_item_index, reinterpret_cast<uint8_t *>(&mission),
+		bool success = _dataman_cache.loadWait(mission_dataman_id, mission_item_index, reinterpret_cast<uint8_t *>(&mission),
 						       sizeof(mission_item_s), MAX_DATAMAN_LOAD_WAIT);
 
 		if (!success) {
@@ -1155,8 +1156,9 @@ void MissionBase::resetMission()
 	new_mission.land_index = -1;
 	new_mission.count = 0u;
 	new_mission.mission_id = 0u;
-	new_mission.dataman_id = _mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 ? DM_KEY_WAYPOINTS_OFFBOARD_1 :
-				 DM_KEY_WAYPOINTS_OFFBOARD_0;
+	new_mission.mission_dataman_id = _mission.mission_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 ?
+					 DM_KEY_WAYPOINTS_OFFBOARD_1 :
+					 DM_KEY_WAYPOINTS_OFFBOARD_0;
 
 	bool success = _dataman_client.writeSync(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&new_mission),
 			sizeof(mission_s));
@@ -1172,12 +1174,12 @@ void MissionBase::resetMission()
 
 void MissionBase::resetMissionJumpCounter()
 {
-	const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+	const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 
 	for (size_t mission_index = 0u; mission_index < _mission.count; mission_index++) {
 		mission_item_s mission_item;
 
-		bool success = _dataman_client.readSync(dataman_id, mission_index, reinterpret_cast<uint8_t *>(&mission_item),
+		bool success = _dataman_client.readSync(mission_dataman_id, mission_index, reinterpret_cast<uint8_t *>(&mission_item),
 							sizeof(mission_item_s), MAX_DATAMAN_LOAD_WAIT);
 
 		if (!success) {
@@ -1191,7 +1193,8 @@ void MissionBase::resetMissionJumpCounter()
 		if (mission_item.nav_cmd == NAV_CMD_DO_JUMP) {
 			mission_item.do_jump_current_count = 0u;
 
-			bool write_success = _dataman_cache.writeWait(dataman_id, mission_index, reinterpret_cast<uint8_t *>(&mission_item),
+			bool write_success = _dataman_cache.writeWait(mission_dataman_id, mission_index,
+					     reinterpret_cast<uint8_t *>(&mission_item),
 					     sizeof(struct mission_item_s));
 
 			if (!write_success) {
@@ -1300,7 +1303,7 @@ void MissionBase::updateCachedItemsUpToIndex(const int end_index)
 {
 	for (int i = 0; i <= end_index; i++) {
 		mission_item_s mission_item;
-		const dm_item_t dm_current = (dm_item_t)_mission.dataman_id;
+		const dm_item_t dm_current = (dm_item_t)_mission.mission_dataman_id;
 		bool success = _dataman_client.readSync(dm_current, i, reinterpret_cast<uint8_t *>(&mission_item),
 							sizeof(mission_item), 500_ms);
 
@@ -1330,11 +1333,12 @@ void MissionBase::checkClimbRequired(int32_t mission_item_index)
 
 	if (num_found_items > 0U) {
 
-		const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+		const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 		mission_item_s mission;
 		_mission_init_climb_altitude_amsl = NAN; // default to NAN, overwrite below if applicable
 
-		const bool success = _dataman_cache.loadWait(dataman_id, next_mission_item_index, reinterpret_cast<uint8_t *>(&mission),
+		const bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_item_index,
+				     reinterpret_cast<uint8_t *>(&mission),
 				     sizeof(mission), MAX_DATAMAN_LOAD_WAIT);
 
 		const bool is_fw_and_takeoff = mission.nav_cmd == NAV_CMD_TAKEOFF
@@ -1357,7 +1361,7 @@ void MissionBase::checkClimbRequired(int32_t mission_item_index)
 bool MissionBase::checkMissionDataChanged(mission_s new_mission)
 {
 	/* count and land_index are the same if the mission_id did not change. We do not care about changes in geofence or rally counters.*/
-	return ((new_mission.dataman_id != _mission.dataman_id) ||
+	return ((new_mission.mission_dataman_id != _mission.mission_dataman_id) ||
 		(new_mission.mission_id != _mission.mission_id) ||
 		(new_mission.current_seq != _mission.current_seq));
 }

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -79,7 +79,8 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission)
 	for (size_t i = 0; i < mission.count; i++) {
 		struct mission_item_s missionitem = {};
 
-		bool success = _dataman_client.readSync((dm_item_t)mission.dataman_id, i, reinterpret_cast<uint8_t *>(&missionitem),
+		bool success = _dataman_client.readSync((dm_item_t)mission.mission_dataman_id, i,
+							reinterpret_cast<uint8_t *>(&missionitem),
 							sizeof(mission_item_s));
 
 		if (!success) {
@@ -119,7 +120,8 @@ MissionFeasibilityChecker::checkMissionAgainstGeofence(const mission_s &mission,
 		for (size_t i = 0; i < mission.count; i++) {
 			struct mission_item_s missionitem = {};
 
-			bool success = _dataman_client.readSync((dm_item_t)mission.dataman_id, i, reinterpret_cast<uint8_t *>(&missionitem),
+			bool success = _dataman_client.readSync((dm_item_t)mission.mission_dataman_id, i,
+								reinterpret_cast<uint8_t *>(&missionitem),
 								sizeof(mission_item_s));
 
 			if (!success) {

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -200,7 +200,7 @@ struct mission_item_s {
 
 /**
  * dataman housekeeping information for a specific item.
- * Corresponds to the first dataman entry of DM_KEY_FENCE_POINTS and DM_KEY_SAFE_POINTS
+ * Corresponds to the dataman entry of DM_KEY_FENCE_POINTS_STATE and DM_KEY_SAFE_POINTS_STATE
  */
 struct mission_stats_entry_s {
 	uint32_t opaque_id;			/**< opaque identifier for current stored mission stats */
@@ -210,7 +210,7 @@ struct mission_stats_entry_s {
 
 /**
  * Geofence vertex point.
- * Corresponds to the DM_KEY_FENCE_POINTS dataman item
+ * Corresponds to the DM_KEY_FENCE_POINTS_0 dataman item
  */
 struct mission_fence_point_s {
 	double lat;

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -205,7 +205,8 @@ struct mission_item_s {
 struct mission_stats_entry_s {
 	uint32_t opaque_id;			/**< opaque identifier for current stored mission stats */
 	uint16_t num_items;			/**< total number of items stored (excluding this one) */
-	uint8_t padding[2];
+	uint8_t dataman_id;			/**< dm_item_t storage place*/
+	uint8_t padding[1];
 };
 
 /**

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -111,7 +111,7 @@ void RTL::updateDatamanCache()
 				}
 
 				for (int index = 0; index < _dataman_cache_safepoint.size(); ++index) {
-					_dataman_cache_safepoint.load(DM_KEY_SAFE_POINTS_0, index);
+					_dataman_cache_safepoint.load(static_cast<dm_item_t>(_stats.dataman_id), index);
 				}
 
 				_dataman_state = DatamanState::Load;
@@ -397,7 +397,7 @@ void RTL::findRtlDestination(DestinationType &destination_type, DestinationPosit
 		for (int current_seq = 0; current_seq < _dataman_cache_safepoint.size(); ++current_seq) {
 			mission_item_s mission_safe_point;
 
-			bool success = _dataman_cache_safepoint.loadWait(DM_KEY_SAFE_POINTS_0, current_seq,
+			bool success = _dataman_cache_safepoint.loadWait(static_cast<dm_item_t>(_stats.dataman_id), current_seq,
 					reinterpret_cast<uint8_t *>(&mission_safe_point),
 					sizeof(mission_item_s), 500_ms);
 
@@ -629,7 +629,7 @@ land_approaches_s RTL::readVtolLandApproaches(DestinationPosition rtl_position) 
 	for (int current_seq = 0; current_seq < _stats.num_items; ++current_seq) {
 		mission_item_s mission_item{};
 
-		bool success_mission_item = _dataman_cache_safepoint.loadWait(DM_KEY_SAFE_POINTS_0, current_seq,
+		bool success_mission_item = _dataman_cache_safepoint.loadWait(static_cast<dm_item_t>(_stats.dataman_id), current_seq,
 					    reinterpret_cast<uint8_t *>(&mission_item),
 					    sizeof(mission_item_s));
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -146,7 +146,7 @@ void RTL::updateDatamanCache()
 
 	if (_mission_id != _mission_sub.get().mission_id) {
 		_mission_id = _mission_sub.get().mission_id;
-		const dm_item_t dm_item = static_cast<dm_item_t>(_mission_sub.get().dataman_id);
+		const dm_item_t dm_item = static_cast<dm_item_t>(_mission_sub.get().mission_dataman_id);
 		_dataman_cache_landItem.invalidate();
 
 		if (_mission_sub.get().land_index > 0) {
@@ -365,7 +365,7 @@ void RTL::findRtlDestination(DestinationType &destination_type, DestinationPosit
 	if (((_param_rtl_type.get() == 1) || (_param_rtl_type.get() == 3) || (fabsf(FLT_MAX - min_dist) < FLT_EPSILON))
 	    && hasMissionLandStart()) {
 		mission_item_s land_mission_item;
-		const dm_item_t dm_item = static_cast<dm_item_t>(_mission_sub.get().dataman_id);
+		const dm_item_t dm_item = static_cast<dm_item_t>(_mission_sub.get().mission_dataman_id);
 		bool success = _dataman_cache_landItem.loadWait(dm_item, _mission_sub.get().land_index,
 				reinterpret_cast<uint8_t *>(&land_mission_item), sizeof(mission_item_s), 500_ms);
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -79,7 +79,7 @@ void RTL::updateDatamanCache()
 	case DatamanState::Read:
 
 		_dataman_state	= DatamanState::ReadWait;
-		success = _dataman_client_safepoint.readAsync(DM_KEY_SAFE_POINTS, 0, reinterpret_cast<uint8_t *>(&_stats),
+		success = _dataman_client_safepoint.readAsync(DM_KEY_SAFE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&_stats),
 				sizeof(mission_stats_entry_s));
 
 		if (!success) {
@@ -110,8 +110,8 @@ void RTL::updateDatamanCache()
 					_dataman_cache_safepoint.resize(_stats.num_items);
 				}
 
-				for (int index = 1; index <= _dataman_cache_safepoint.size(); ++index) {
-					_dataman_cache_safepoint.load(DM_KEY_SAFE_POINTS, index);
+				for (int index = 0; index < _dataman_cache_safepoint.size(); ++index) {
+					_dataman_cache_safepoint.load(DM_KEY_SAFE_POINTS_0, index);
 				}
 
 				_dataman_state = DatamanState::Load;
@@ -394,10 +394,10 @@ void RTL::findRtlDestination(DestinationType &destination_type, DestinationPosit
 
 	if (_safe_points_updated) {
 
-		for (int current_seq = 1; current_seq <= _dataman_cache_safepoint.size(); ++current_seq) {
+		for (int current_seq = 0; current_seq < _dataman_cache_safepoint.size(); ++current_seq) {
 			mission_item_s mission_safe_point;
 
-			bool success = _dataman_cache_safepoint.loadWait(DM_KEY_SAFE_POINTS, current_seq,
+			bool success = _dataman_cache_safepoint.loadWait(DM_KEY_SAFE_POINTS_0, current_seq,
 					reinterpret_cast<uint8_t *>(&mission_safe_point),
 					sizeof(mission_item_s), 500_ms);
 
@@ -626,10 +626,10 @@ land_approaches_s RTL::readVtolLandApproaches(DestinationPosition rtl_position) 
 	bool foundHomeLandApproaches = false;
 	uint8_t sector_counter = 0;
 
-	for (int current_seq = 1; current_seq <= _stats.num_items; ++current_seq) {
+	for (int current_seq = 0; current_seq < _stats.num_items; ++current_seq) {
 		mission_item_s mission_item{};
 
-		bool success_mission_item = _dataman_cache_safepoint.loadWait(DM_KEY_SAFE_POINTS, current_seq,
+		bool success_mission_item = _dataman_cache_safepoint.loadWait(DM_KEY_SAFE_POINTS_0, current_seq,
 					    reinterpret_cast<uint8_t *>(&mission_item),
 					    sizeof(mission_item_s));
 

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -146,11 +146,11 @@ void RtlDirectMissionLand::setActiveMissionItems()
 		getNextPositionItems(_mission.current_seq + 1, next_mission_items_index, num_found_items, max_num_next_items);
 
 		mission_item_s next_mission_items[max_num_next_items];
-		const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+		const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 
 		for (size_t i = 0U; i < num_found_items; i++) {
 			mission_item_s next_mission_item;
-			bool success = _dataman_cache.loadWait(dataman_id, next_mission_items_index[i],
+			bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_items_index[i],
 							       reinterpret_cast<uint8_t *>(&next_mission_item), sizeof(next_mission_item), MAX_DATAMAN_LOAD_WAIT);
 
 			if (success) {

--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -97,11 +97,11 @@ void RtlMissionFast::setActiveMissionItems()
 		getNextPositionItems(_mission.current_seq + 1, next_mission_items_index, num_found_items, max_num_next_items);
 
 		mission_item_s next_mission_items[max_num_next_items];
-		const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+		const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 
 		for (size_t i = 0U; i < num_found_items; i++) {
 			mission_item_s next_mission_item;
-			bool success = _dataman_cache.loadWait(dataman_id, next_mission_items_index[i],
+			bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_items_index[i],
 							       reinterpret_cast<uint8_t *>(&next_mission_item), sizeof(next_mission_item), MAX_DATAMAN_LOAD_WAIT);
 
 			if (success) {

--- a/src/modules/navigator/rtl_mission_fast_reverse.cpp
+++ b/src/modules/navigator/rtl_mission_fast_reverse.cpp
@@ -120,9 +120,9 @@ void RtlMissionFastReverse::setActiveMissionItems()
 
 		if (num_found_items > 0) {
 
-			const dm_item_t dataman_id = static_cast<dm_item_t>(_mission.dataman_id);
+			const dm_item_t mission_dataman_id = static_cast<dm_item_t>(_mission.mission_dataman_id);
 			mission_item_s next_mission_item;
-			bool success = _dataman_cache.loadWait(dataman_id, next_mission_item_index,
+			bool success = _dataman_cache.loadWait(mission_dataman_id, next_mission_item_index,
 							       reinterpret_cast<uint8_t *>(&next_mission_item), sizeof(mission_item_s), MAX_DATAMAN_LOAD_WAIT);
 
 			if (success) {

--- a/src/systemcmds/tests/test_dataman.cpp
+++ b/src/systemcmds/tests/test_dataman.cpp
@@ -153,14 +153,14 @@ DatamanTest::testSyncWriteInvalidItem()
 bool
 DatamanTest::testSyncReadInvalidIndex()
 {
-	bool success = _dataman_client1.readSync(DM_KEY_SAFE_POINTS, DM_KEY_SAFE_POINTS_MAX, _buffer_read, 2);
+	bool success = _dataman_client1.readSync(DM_KEY_SAFE_POINTS_0, DM_KEY_SAFE_POINTS_MAX, _buffer_read, 2);
 	return !success;
 }
 
 bool
 DatamanTest::testSyncWriteInvalidIndex()
 {
-	bool success = _dataman_client1.writeSync(DM_KEY_SAFE_POINTS, DM_KEY_SAFE_POINTS_MAX, _buffer_write, 2);
+	bool success = _dataman_client1.writeSync(DM_KEY_SAFE_POINTS_0, DM_KEY_SAFE_POINTS_MAX, _buffer_write, 2);
 	return !success;
 }
 
@@ -238,7 +238,7 @@ DatamanTest::testSyncWriteReadAllItemsMaxSize()
 	bool success = false;
 
 	// Iterate all items
-	for (uint32_t item = DM_KEY_SAFE_POINTS; item < DM_KEY_NUM_KEYS; ++item) {
+	for (uint32_t item = DM_KEY_SAFE_POINTS_0; item < DM_KEY_NUM_KEYS; ++item) {
 
 		// writeSync
 		for (uint32_t index = 0U; index < _max_index[item]; ++index) {
@@ -289,7 +289,7 @@ DatamanTest::testSyncClearAll()
 	bool success = false;
 
 	// Iterate all items
-	for (uint32_t item = DM_KEY_SAFE_POINTS; item < DM_KEY_NUM_KEYS; ++item) {
+	for (uint32_t item = DM_KEY_SAFE_POINTS_0; item < DM_KEY_NUM_KEYS; ++item) {
 
 		success = _dataman_client1.clearSync((dm_item_t)item);
 
@@ -433,7 +433,7 @@ DatamanTest::testAsyncReadInvalidIndex()
 		case State::Read:
 
 			state = State::ReadWait;
-			success = _dataman_client1.readAsync(DM_KEY_SAFE_POINTS, DM_KEY_SAFE_POINTS_MAX, _buffer_read, 2);
+			success = _dataman_client1.readAsync(DM_KEY_SAFE_POINTS_0, DM_KEY_SAFE_POINTS_MAX, _buffer_read, 2);
 
 			if (!success) {
 				return false;
@@ -489,7 +489,7 @@ DatamanTest::testAsyncWriteInvalidIndex()
 		case State::Write:
 
 			state = State::WriteWait;
-			success = _dataman_client1.writeAsync(DM_KEY_SAFE_POINTS, DM_KEY_SAFE_POINTS_MAX, _buffer_write, 2);
+			success = _dataman_client1.writeAsync(DM_KEY_SAFE_POINTS_0, DM_KEY_SAFE_POINTS_MAX, _buffer_write, 2);
 
 			if (!success) {
 				return false;
@@ -529,7 +529,7 @@ DatamanTest::testAsyncWriteInvalidIndex()
 bool
 DatamanTest::testAsyncReadBufferOverflow()
 {
-	bool success = _dataman_client1.readAsync(DM_KEY_SAFE_POINTS, DM_KEY_SAFE_POINTS_MAX, _buffer_read, OVERFLOW_LENGTH);
+	bool success = _dataman_client1.readAsync(DM_KEY_SAFE_POINTS_0, DM_KEY_SAFE_POINTS_MAX, _buffer_read, OVERFLOW_LENGTH);
 
 	return !success;
 }
@@ -537,7 +537,8 @@ DatamanTest::testAsyncReadBufferOverflow()
 bool
 DatamanTest::testAsyncWriteBufferOverflow()
 {
-	bool success = _dataman_client1.writeAsync(DM_KEY_SAFE_POINTS, DM_KEY_SAFE_POINTS_MAX, _buffer_write, OVERFLOW_LENGTH);
+	bool success = _dataman_client1.writeAsync(DM_KEY_SAFE_POINTS_0, DM_KEY_SAFE_POINTS_MAX, _buffer_write,
+			OVERFLOW_LENGTH);
 
 	return !success;
 }
@@ -715,7 +716,7 @@ DatamanTest::testAsyncWriteReadAllItemsMaxSize()
 	bool success = false;
 	State state = State::Write;
 
-	uint32_t item = DM_KEY_SAFE_POINTS;
+	uint32_t item = DM_KEY_SAFE_POINTS_0;
 	uint32_t index = 0U;
 
 	hrt_abstime start_time = hrt_absolute_time();
@@ -828,7 +829,7 @@ DatamanTest::testAsyncClearAll()
 
 	State state = State::Clear;
 	hrt_abstime start_time = hrt_absolute_time();
-	uint32_t item = DM_KEY_SAFE_POINTS;
+	uint32_t item = DM_KEY_SAFE_POINTS_0;
 
 	//While loop represents a task
 	while (state != State::Exit) {
@@ -1098,19 +1099,19 @@ DatamanTest::testResetItems()
 	stats.num_items = 0;
 	stats.opaque_id = 0;
 
-	success = _dataman_client1.writeSync(DM_KEY_FENCE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+	success = _dataman_client1.writeSync(DM_KEY_FENCE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 					     sizeof(mission_stats_entry_s));
 
 	if (!success) {
-		PX4_ERR("failed to reset DM_KEY_FENCE_POINTS");
+		PX4_ERR("failed to reset DM_KEY_FENCE_POINTS_STATE");
 		return false;
 	}
 
-	success = _dataman_client1.writeSync(DM_KEY_SAFE_POINTS, 0, reinterpret_cast<uint8_t *>(&stats),
+	success = _dataman_client1.writeSync(DM_KEY_SAFE_POINTS_STATE, 0, reinterpret_cast<uint8_t *>(&stats),
 					     sizeof(mission_stats_entry_s));
 
 	if (!success) {
-		PX4_ERR("failed to reset DM_KEY_SAFE_POINTS");
+		PX4_ERR("failed to reset DM_KEY_SAFE_POINTS_STATE");
 		return false;
 	}
 

--- a/src/systemcmds/tests/test_dataman.cpp
+++ b/src/systemcmds/tests/test_dataman.cpp
@@ -1076,7 +1076,7 @@ DatamanTest::testResetItems()
 
 	mission_s mission{};
 	mission.timestamp = hrt_absolute_time();
-	mission.dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
+	mission.mission_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 	mission.count = 0;
 	mission.current_seq = 0;
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
If there is an error during uploading of the rally points or geofence, the old fence points get overwritten and are not accessible anymore.

### Solution
- Extend dataman to have double storage for rally points and geofence the same way as is already done for missions
- On upload write the uploaded points t othe inactive slot and switch at the end when upload was successful.

### Changelog Entry
For release notes:
```
Feature: Enable double storage slots for rally points and geofence
```

### Test coverage
- Tested in SITL while observing the mission topic when uploading rally points and missions.
