### PR TITLE
lib/timesync: relax warnings

### DIFF
--- a/src/lib/timesync/Timesync.cpp
+++ b/src/lib/timesync/Timesync.cpp
@@ -66,7 +66,7 @@ void Timesync::update(const uint64_t now_us, const int64_t remote_timestamp_ns, 
 				// We reset the filter if we received 5 consecutive samples which violate our present estimate.
 				// This is most likely due to a time jump on the offboard system.
 				if (_high_deviation_count > MAX_CONSECUTIVE_HIGH_DEVIATION) {
-					PX4_ERR("Time jump detected. Resetting time synchroniser.");
+					PX4_WARN("time jump detected. Resetting time synchroniser.");
 					// Reset the filter
 					reset_filter();
 				}
@@ -103,12 +103,9 @@ void Timesync::update(const uint64_t now_us, const int64_t remote_timestamp_ns, 
 			// Increment counter if round trip time is too high for accurate timesync
 			_high_rtt_count++;
 
-			if (_high_rtt_count > MAX_CONSECUTIVE_HIGH_RTT) {
+			if (_high_rtt_count == MAX_CONSECUTIVE_HIGH_RTT) {
 				PX4_WARN("RTT too high for timesync: %llu ms", rtt_us / 1000ULL);
-				// Reset counter to rate-limit warnings
-				_high_rtt_count = 0;
 			}
-
 		}
 
 		// Publish status message

--- a/src/lib/timesync/Timesync.hpp
+++ b/src/lib/timesync/Timesync.hpp
@@ -87,8 +87,8 @@ static constexpr uint32_t CONVERGENCE_WINDOW = 500;
 // TODO : automatically determine these using ping statistics?
 static constexpr uint64_t MAX_RTT_SAMPLE = 10_ms;
 static constexpr uint64_t MAX_DEVIATION_SAMPLE = 100_ms;
-static constexpr uint32_t MAX_CONSECUTIVE_HIGH_RTT = 5;
-static constexpr uint32_t MAX_CONSECUTIVE_HIGH_DEVIATION = 5;
+static constexpr uint32_t MAX_CONSECUTIVE_HIGH_RTT = 10;
+static constexpr uint32_t MAX_CONSECUTIVE_HIGH_DEVIATION = 10;
 
 class Timesync
 {


### PR DESCRIPTION
 - double required max consecutive counts
 - don't continuously complain about round trip time (RTT) unless there's been at least one acceptable round trip (latency < 100 ms)

![image](https://github.com/PX4/PX4-Autopilot/assets/84712/4dd0aa84-d5be-4c2f-aa52-5f1f3221394c)
