### PR TITLE
FW Position Control: fix setting of _control_mode_current to AUTO in VTOL land

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -710,6 +710,7 @@ FixedwingPositionControl::set_control_mode_current(const hrt_abstime &now)
 				}
 
 			} else {
+				_control_mode_current = FW_POSCTRL_MODE_AUTO;
 				// in this case we want the waypoint handled as a position setpoint -- a submode in control_auto()
 				_pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 			}


### PR DESCRIPTION
This is the only if/else condition that didn't update _control_mode_current. Probably we should re-write this method to make it more robust.

It had no effect because we also set _pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_POSITION, which then made it enter another conditional. 