### PR TITLE
TECS throttle gains default reduction and transition values from previous PX4 version

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -129,7 +129,7 @@ FixedwingPositionControl::parameters_update()
 	_tecs.set_speed_weight(_param_fw_t_spdweight.get());
 	_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
 	_tecs.set_equivalent_airspeed_min(_performance_model.getMinimumCalibratedAirspeed());
-	_tecs.set_throttle_damp(_param_fw_t_thr_damp.get());
+	_tecs.set_throttle_damp(_param_fw_t_thr_damping.get());
 	_tecs.set_integrator_gain_throttle(_param_fw_t_I_gain_thr.get());
 	_tecs.set_integrator_gain_pitch(_param_fw_t_I_gain_pit.get());
 	_tecs.set_throttle_slewrate(_param_fw_thr_slew_max.get());

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -130,7 +130,7 @@ FixedwingPositionControl::parameters_update()
 	_tecs.set_equivalent_airspeed_trim(_performance_model.getCalibratedTrimAirspeed());
 	_tecs.set_equivalent_airspeed_min(_performance_model.getMinimumCalibratedAirspeed());
 	_tecs.set_throttle_damp(_param_fw_t_thr_damping.get());
-	_tecs.set_integrator_gain_throttle(_param_fw_t_I_gain_thr.get());
+	_tecs.set_integrator_gain_throttle(_param_fw_t_thr_integ.get());
 	_tecs.set_integrator_gain_pitch(_param_fw_t_I_gain_pit.get());
 	_tecs.set_throttle_slewrate(_param_fw_thr_slew_max.get());
 	_tecs.set_vertical_accel_limit(_param_fw_t_vert_acc.get());

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -941,7 +941,7 @@ private:
 		(ParamFloat<px4::params::FW_T_SINK_MAX>) _param_fw_t_sink_max,
 		(ParamFloat<px4::params::FW_T_SPDWEIGHT>) _param_fw_t_spdweight,
 		(ParamFloat<px4::params::FW_T_TAS_TC>) _param_fw_t_tas_error_tc,
-		(ParamFloat<px4::params::FW_T_THR_DAMP>) _param_fw_t_thr_damp,
+		(ParamFloat<px4::params::FW_T_THR_DAMPING>) _param_fw_t_thr_damping,
 		(ParamFloat<px4::params::FW_T_VERT_ACC>) _param_fw_t_vert_acc,
 		(ParamFloat<px4::params::FW_T_STE_R_TC>) _param_ste_rate_time_const,
 		(ParamFloat<px4::params::FW_T_SEB_R_FF>) _param_seb_rate_ff,

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -934,7 +934,7 @@ private:
 
 		(ParamFloat<px4::params::FW_T_HRATE_FF>) _param_fw_t_hrate_ff,
 		(ParamFloat<px4::params::FW_T_ALT_TC>) _param_fw_t_h_error_tc,
-		(ParamFloat<px4::params::FW_T_I_GAIN_THR>) _param_fw_t_I_gain_thr,
+		(ParamFloat<px4::params::FW_T_THR_INTEG>) _param_fw_t_thr_integ,
 		(ParamFloat<px4::params::FW_T_I_GAIN_PIT>) _param_fw_t_I_gain_pit,
 		(ParamFloat<px4::params::FW_T_PTCH_DAMP>) _param_fw_t_ptch_damp,
 		(ParamFloat<px4::params::FW_T_RLL2THR>) _param_fw_t_rll2thr,

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -485,7 +485,7 @@ PARAM_DEFINE_FLOAT(FW_T_THR_DAMPING, 0.05f);
  * @increment 0.005
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.02f);
+PARAM_DEFINE_FLOAT(FW_T_THR_INTEG, 0.02f);
 
 /**
  * Integrator gain pitch

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -470,7 +470,7 @@ PARAM_DEFINE_FLOAT(FW_T_SINK_MAX, 5.0f);
  * @increment 0.01
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.05f);
+PARAM_DEFINE_FLOAT(FW_T_THR_DAMPING, 0.05f);
 
 /**
  * Integrator gain throttle

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -465,9 +465,9 @@ PARAM_DEFINE_FLOAT(FW_T_SINK_MAX, 5.0f);
  * Increase to add damping to correct for oscillations in speed and height.
  *
  * @min 0.0
- * @max 2.0
- * @decimal 2
- * @increment 0.1
+ * @max 1.0
+ * @decimal 3
+ * @increment 0.01
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.05f);
@@ -475,16 +475,14 @@ PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.05f);
 /**
  * Integrator gain throttle
  *
- * This is the integrator gain on the throttle part of the control loop.
- * Increasing this gain increases the speed at which speed
- * and height offsets are trimmed out, but reduces damping and
- * increases overshoot. Set this value to zero to completely
- * disable all integrator action.
+ * Integrator gain on the throttle part of the control loop.
+ * Increase it to trim out speed and height offsets faster,
+ * with the downside of possible overshoots and oscillations.
  *
  * @min 0.0
- * @max 2.0
- * @decimal 2
- * @increment 0.05
+ * @max 1.0
+ * @decimal 3
+ * @increment 0.005
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.02f);
@@ -492,11 +490,9 @@ PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.02f);
 /**
  * Integrator gain pitch
  *
- * This is the integrator gain on the pitch part of the control loop.
- * Increasing this gain increases the speed at which speed
- * and height offsets are trimmed out, but reduces damping and
- * increases overshoot. Set this value to zero to completely
- * disable all integrator action.
+ * Integrator gain on the pitch part of the control loop.
+ * Increase it to trim out speed and height offsets faster,
+ * with the downside of possible overshoots and oscillations.
  *
  * @min 0.0
  * @max 2.0

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -470,7 +470,7 @@ PARAM_DEFINE_FLOAT(FW_T_SINK_MAX, 5.0f);
  * @increment 0.1
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.1f);
+PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.05f);
 
 /**
  * Integrator gain throttle

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -487,7 +487,7 @@ PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.1f);
  * @increment 0.05
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.05f);
+PARAM_DEFINE_FLOAT(FW_T_I_GAIN_THR, 0.02f);
 
 /**
  * Integrator gain pitch


### PR DESCRIPTION
### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/22540.
TL;DR: PX4 v1.12 and v1.13 contained a bug that resulted in FW_T_I_GAIN_THR and FW_T_THR_DAMP having a much lower effect. This bug is fixed now, resulting in these params to have much stronger effects on the controller, which can lead to controller instability. 

### Solution
- reduce the defaults
- introduce mechanism to warn user if gains are high    
  - The params `FW_T_I_GAIN_THR` and `FW_T_THR_DAMP` have a much stronger effect  in PX4 v1.14 then before, and therefore we warn the user if the current values are above normally reasonable values, unless they have acknowledged  knowing about the change by setting the new param `FW_T_CHNG_ACK`.

### Changelog Entry
For release notes:
```
Feature: FW TECS: Warn if throttle gains (that have changed effect with this release) are high
Documentation: To do.
```

### Alternatives
- Deprecate the old params `FW_T_I_GAIN_THR` and `FW_T_THR_DAMP` and in their place make new ones (on v1.14 and main). Then, on updating, previous tuning gets reset to default, which is much better than keeping it. Alternatively we could do some sort of param translation (eg with a factor of 20). --> this is though not optimal for users already flying with v1.14 and thus have re-tuned the gains, for them they would also get adjusted. 
- limit the params to sane values (hard coded, not just in param meta data)

