### PR TITLE
events: pass relative paths plus base path to source parser script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ define_property(GLOBAL PROPERTY PX4_MODULE_PATHS
                  BRIEF_DOCS "PX4 module paths"
                  FULL_DOCS "List of paths to all PX4 modules"
                  )
+
 define_property(GLOBAL PROPERTY PX4_SRC_FILES
                  BRIEF_DOCS "src files from all PX4 modules & libs"
                  FULL_DOCS "SRC files from px4_add_{module,library}"

--- a/Tools/px_process_events.py
+++ b/Tools/px_process_events.py
@@ -55,6 +55,10 @@ def main():
                         metavar="PATH",
                         nargs='*',
                         help="one or more paths/files to source files to scan for events")
+    parser.add_argument("-b", "--base-path",
+                        default=[""],
+                        metavar="PATH",
+                        help="path prefix for everything passed with --src-path")
     parser.add_argument("-j", "--json",
                         nargs='?',
                         const="events.json",
@@ -84,7 +88,7 @@ def main():
     # canonicalize + remove duplicates
     src_paths = set()
     for path in args.src_path:
-        src_paths.add(os.path.realpath(path))
+        src_paths.add(os.path.realpath(os.path.join(args.base_path, path)))
 
     if not scanner.ScanDir(src_paths, parser):
         sys.exit(1)

--- a/src/lib/events/CMakeLists.txt
+++ b/src/lib/events/CMakeLists.txt
@@ -35,13 +35,21 @@ px4_add_git_submodule(TARGET git_libevents PATH "libevents")
 
 get_property(all_px4_src_files GLOBAL PROPERTY PX4_SRC_FILES)
 
+# Use relative path list to wrok around Makefile command character limit
+set(all_px4_src_files_relative "")
+foreach(f ${all_px4_src_files})
+	file(RELATIVE_PATH relative_path ${PX4_SOURCE_DIR}/src ${f})
+	list(APPEND all_px4_src_files_relative "${relative_path}")
+endforeach(f)
+
 set(generated_events_dir ${PX4_BINARY_DIR}/events)
 set(generated_events_px4_file ${generated_events_dir}/px4.json)
 set(generated_events_common_enums_file ${generated_events_dir}/common_with_enums.json)
 add_custom_command(OUTPUT ${generated_events_px4_file}
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${generated_events_dir}
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_events.py
-		--src-path ${all_px4_src_files}
+		--base-path ${PX4_SOURCE_DIR}/src
+		--src-path ${all_px4_src_files_relative}
 		--json ${generated_events_px4_file} #--verbose
 	DEPENDS
 		${all_px4_src_files}


### PR DESCRIPTION
### Solved Problem
When running the `make NO_NINJA_BUILD=1 px4_fmu-v5_default` target in CI on our fork I found that the build fails because the command to parse all source files to generate the events json file can easily exceed the limit of maximum characters in a Makefile command if the base path is a bit longer because of CI subfolders or even just a long repository name.

![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/f4c18368-f025-4de5-8773-d22f8fc0e526)

### Solution
Since all source files that are built get passed as arguments in the full absolute path the command gets 100'000+ characters long and the solution I propose is to pass the base path in a separate parameter once and have all other paths relative to that.

Example before:
```
px_process_events.py --src-path
/home/maetugr/PX4-Autopilot/src/lib/adsb/AdsbConflict.cpp 
/home/maetugr/PX4-Autopilot/src/lib/airspeed/airspeed.cpp 
/home/maetugr/PX4-Autopilot/src/lib/atmosphere/atmosphere.cpp
...
```

Example after:
```
px_process_events.py --base-path /home/maetugr/PX4-Autopilot/src --src-path
lib/adsb/AdsbConflict.cpp 
lib/airspeed/airspeed.cpp 
lib/atmosphere/atmosphere.cpp
...
```

In my local example test this roughly halfs the number of characters of the full build command but it could make a much bigger difference if the base path is longer.

### Changelog Entry
```
Build system: pass relative paths for events.json generation
```

### Test coverage
Both builds with and without ninja work locally and with GitHub actions. The command length is not exceeded anymore.