### PR TITLE
systemcmds/i2c_launcher: fix USER_I2C_LAUNCHER warning

### DIFF
--- a/src/systemcmds/i2c_launcher/Kconfig
+++ b/src/systemcmds/i2c_launcher/Kconfig
@@ -5,6 +5,6 @@ menuconfig SYSTEMCMDS_I2C_LAUNCHER
 		Daemon that starts drivers based on found I2C devices.
 
 menuconfig USER_I2C_LAUNCHER
-	bool
+	bool "i2c_launcher running as userspace module"
 	default n
 	depends on SYSTEMCMDS_I2C_LAUNCHER


### PR DESCRIPTION
```
warning: the menuconfig symbol USER_I2C_LAUNCHER (defined at src/systemcmds/i2c_launcher/Kconfig:7) has no prompt
```