### PR TITLE
tone_alarm: Log alarm designation

### DIFF
--- a/src/drivers/tone_alarm/ToneAlarm.cpp
+++ b/src/drivers/tone_alarm/ToneAlarm.cpp
@@ -39,6 +39,7 @@
 
 #include <px4_platform_common/time.h>
 #include <uORB/Publication.hpp>
+#include <lib/systemlib/mavlink_log.h>
 
 using namespace time_literals;
 
@@ -47,6 +48,9 @@ ToneAlarm::ToneAlarm() :
 {
 	// ensure ORB_ID(tune_control) is advertised with correct queue depth
 	orb_advertise_queue(ORB_ID(tune_control), nullptr, tune_control_s::ORB_QUEUE_LENGTH);
+
+	// Enable Tone alarm number notification
+	param_get(param_find("TONE_NUM_NOTICE"), &_tone_num_notice);
 }
 
 ToneAlarm::~ToneAlarm()
@@ -104,6 +108,10 @@ void ToneAlarm::Run()
 				switch (tune_result) {
 				case Tunes::ControlResult::Success:
 					PX4_DEBUG("new tune %d", tune_control.tune_id);
+
+					if (_tone_num_notice) {
+						mavlink_log_info(&_mavlink_log_pub, "new tune %d", tune_control.tune_id);
+					}
 
 					if (tune_control.tune_override) {
 						// clear existing

--- a/src/drivers/tone_alarm/ToneAlarm_params.c
+++ b/src/drivers/tone_alarm/ToneAlarm_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2018-2019 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2023 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,62 +32,18 @@
  ****************************************************************************/
 
 /**
- * @file ToneAlarm.h
- *
- * Low Level Driver for the PX4 audio alarm port. Subscribes to
- * tune_control and plays notes on this architecture specific timer HW.
+ * @file ToneAlarm_params.c
+ * Tone Alarm driver parameters for ToneAlarm
  */
 
-#pragma once
-
-#include <px4_platform_common/px4_config.h>
-#include <px4_platform_common/getopt.h>
-#include <px4_platform_common/log.h>
-#include <px4_platform_common/module.h>
-#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
-#include <lib/circuit_breaker/circuit_breaker.h>
-#include <lib/parameters/param.h>
-#include <lib/tunes/tunes.h>
-#include <uORB/Subscription.hpp>
-#include <uORB/SubscriptionCallback.hpp>
-#include <uORB/topics/tune_control.h>
-
-#include <drivers/drv_tone_alarm.h>
-
-#include <string.h>
-
-class ToneAlarm : public ModuleBase<ToneAlarm>, public px4::ScheduledWorkItem
-{
-public:
-	ToneAlarm();
-	~ToneAlarm() override;
-
-	/** @see ModuleBase */
-	static int task_spawn(int argc, char *argv[]);
-
-	/** @see ModuleBase */
-	static int custom_command(int argc, char *argv[]) { return 0; };
-
-	/** @see ModuleBase */
-	static int print_usage(const char *reason = nullptr);
-
-private:
-	static void InterruptStopNote(void *arg);
-
-	bool Init();
-	void Run() override;
-
-	hrt_call _hrt_call{};
-
-	Tunes _tunes;
-
-	hrt_abstime _next_note_time{0};
-
-	uORB::SubscriptionCallbackWorkItem _tune_control_sub{this, ORB_ID(tune_control)};
-
-	bool _circuit_break_initialized{false};
-	bool _play_tone{false};
-	int32_t _tone_num_notice{0};
-
-	orb_advert_t _mavlink_log_pub{nullptr};
-};
+/**
+ * Enable Tone alarm number notification
+ *
+ * @reboot_required true
+ * @value 0 Disable
+ * @value 1 Enable
+ * @min 0
+ * @max 1
+ * @group ToneAlarm
+ */
+PARAM_DEFINE_INT32(TONE_NUM_NOTICE, 0);


### PR DESCRIPTION
### Solved Problem

The alarm sound is a good way to know the status of the vehicle.
However, not all alarm sounds are memorized.
Knowing which alarm sounds were made facilitates investigation.

### Solution

I notify the alarm number with a MAVLINK message.
By notifying, I can check it in GCS and ULOG.

### Changelog Entry

NONE

### Alternatives

NONE

### Test coverage

NONE

### Context

![Screenshot from 2023-12-17 10-42-37](https://github.com/PX4/PX4-Autopilot/assets/646194/d91c3005-9385-4f9e-8373-afbe99eaa0ab)

