### PR TITLE
px_process_events: fix empty base path being a list

### DIFF
--- a/Tools/px_process_events.py
+++ b/Tools/px_process_events.py
@@ -56,7 +56,7 @@ def main():
                         nargs='*',
                         help="one or more paths/files to source files to scan for events")
     parser.add_argument("-b", "--base-path",
-                        default=[""],
+                        default="",
                         metavar="PATH",
                         help="path prefix for everything passed with --src-path")
     parser.add_argument("-j", "--json",


### PR DESCRIPTION
### Solved Problem
After merging https://github.com/PX4/PX4-Autopilot/pull/22551 I was informed by @dagar that the additional CI command `make extract_events` which only runs on the main branch fails 😬

I actually tested an empty base path but in between testing and pushing I changed the `base-path` parameter to a single string instead of a list, forgot to adjust the default and didn't test again. Sorry for that.

### Solution
Adapt parameter to return an empty string instead of an empty string in a list after changing it to a single argument instead of multiple.

### Changelog Entry
```
Bugfix: CI events generation base path mistake
```

### Test coverage
I ran the command locally and verified the path was processed like before the change.