### PR TITLE
Multi GNSS fallback improvements

### DIFF
--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -76,7 +76,7 @@ void GpsBlending::update(uint64_t hrt_now_us)
 		// Only use a secondary instance if the fallback is allowed
 		if ((_primary_instance > -1)
 		    && (gps_select_index != _primary_instance)
-		    && !_fallback_allowed) {
+		    && _primary_instance_available) {
 			gps_select_index = _primary_instance;
 		}
 
@@ -86,6 +86,10 @@ void GpsBlending::update(uint64_t hrt_now_us)
 		for (uint8_t i = 0; i < GPS_MAX_RECEIVERS_BLEND; i++) {
 			_gps_updated[gps_select_index] = false;
 		}
+	}
+
+	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS_BLEND; i++) {
+		_time_prev_us[i] = _gps_state[i].timestamp;
 	}
 }
 
@@ -121,6 +125,10 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 		if (raw_dt > 0.0f && raw_dt < GPS_TIMEOUT_S) {
 			_gps_dt[i] = 0.1f * raw_dt + 0.9f * _gps_dt[i];
 
+			if (i == _primary_instance) {
+				_primary_instance_available = true;
+			}
+
 		} else if ((present_dt >= GPS_TIMEOUT_S) && (_gps_state[i].timestamp > 0)) {
 			// Timed out - kill the stored fix for this receiver and don't track its (stale) gps_dt
 			_gps_state[i].timestamp = 0;
@@ -129,9 +137,8 @@ bool GpsBlending::blend_gps_data(uint64_t hrt_now_us)
 			_gps_state[i].vel_ned_valid = 0;
 
 			if (i == _primary_instance) {
-				// Allow using a secondary instance when the primary
-				// receiver has timed out
-				_fallback_allowed = true;
+				// Allow using a secondary instance when the primary receiver has timed out
+				_primary_instance_available = false;
 			}
 
 			continue;
@@ -523,8 +530,6 @@ void GpsBlending::update_gps_offsets(const sensor_gps_s &gps_blended_state)
 			// calculate the filter coefficient that achieves the time constant specified by the user adjustable parameter
 			alpha[i] = constrain(omega_lpf * 1e-6f * (float)(_gps_state[i].timestamp - _time_prev_us[i]),
 					     0.0f, 1.0f);
-
-			_time_prev_us[i] = _gps_state[i].timestamp;
 		}
 	}
 

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.cpp
@@ -76,7 +76,8 @@ void GpsBlending::update(uint64_t hrt_now_us)
 		// Only use a secondary instance if the fallback is allowed
 		if ((_primary_instance > -1)
 		    && (gps_select_index != _primary_instance)
-		    && _primary_instance_available) {
+		    && _primary_instance_available
+		    && (_gps_state[_primary_instance].fix_type >= 3)) {
 			gps_select_index = _primary_instance;
 		}
 

--- a/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending.hpp
@@ -126,7 +126,7 @@ private:
 	int _selected_gps{0};
 	int _np_gps_suitable_for_blending{0};
 	int _primary_instance{0}; ///< if -1, there is no primary isntance and the best receiver is used // TODO: use device_id
-	bool _fallback_allowed{false};
+	bool _primary_instance_available{false};
 
 	bool _is_new_output_data_available{false};
 

--- a/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
@@ -235,11 +235,10 @@ TEST_F(GpsBlendingTest, dualReceiverFailover)
 	const float duration_s = 10.f;
 	runSeconds(duration_s, gps_blending, gps_data1, 1);
 
-	// THEN: the primary instance should be selected even if
-	// not available. No data is then available
-	EXPECT_EQ(gps_blending.getSelectedGps(), 0);
+	// THEN: the secondary instance as the primary one is not available
+	EXPECT_EQ(gps_blending.getSelectedGps(), 1);
 	EXPECT_EQ(gps_blending.getNumberOfGpsSuitableForBlending(), 1);
-	EXPECT_FALSE(gps_blending.isNewOutputDataAvailable());
+	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
 
 	// BUT WHEN: the data of the primary receiver is avaialbe
 	sensor_gps_s gps_data0 = getDefaultGpsData();
@@ -281,6 +280,15 @@ TEST_F(GpsBlendingTest, dualReceiverFailover)
 
 	// THEN: the selector shouldn't switch again as the primary one is available
 	EXPECT_EQ(gps_blending.getSelectedGps(), 0);
+	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
+
+	// BUT IF: the primary receiver looses its fix
+	gps_data0.fix_type = 1;
+
+	runSeconds(1.f, gps_blending, gps_data0, gps_data1);
+
+	// THEN: the selector should switch as the primary one is unable to provide correct data
+	EXPECT_EQ(gps_blending.getSelectedGps(), 1);
 	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
 }
 

--- a/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
+++ b/src/modules/sensors/vehicle_gps_position/gps_blending_test.cpp
@@ -243,8 +243,7 @@ TEST_F(GpsBlendingTest, dualReceiverFailover)
 
 	// BUT WHEN: the data of the primary receiver is avaialbe
 	sensor_gps_s gps_data0 = getDefaultGpsData();
-	gps_blending.setGpsData(gps_data0, 0);
-	gps_blending.update(_time_now_us);
+	runSeconds(1.f, gps_blending, gps_data0, gps_data1);
 
 	// THEN: the primary instance is selected and the data
 	// is available
@@ -272,6 +271,15 @@ TEST_F(GpsBlendingTest, dualReceiverFailover)
 	runSeconds(1.f, gps_blending, gps_data0, gps_data1);
 
 	// THEN: the primary receiver should be used again
+	EXPECT_EQ(gps_blending.getSelectedGps(), 0);
+	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
+
+	// BUT IF: the secondary receiver has better metrics than the primary one
+	gps_data1.satellites_used = gps_data0.satellites_used + 2;
+
+	runSeconds(1.f, gps_blending, gps_data0, gps_data1);
+
+	// THEN: the selector shouldn't switch again as the primary one is available
 	EXPECT_EQ(gps_blending.getSelectedGps(), 0);
 	EXPECT_TRUE(gps_blending.isNewOutputDataAvailable());
 }


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The current implementation allows continuous instance switching based on the number of satellites as soon as the primary GNSS receiver had a timeout. A timeout could occur just after boot and it shouldn't allow switching once the primary receiver is regained.

![Screenshot from 2023-12-13 15-05-00](https://github.com/PX4/PX4-Autopilot/assets/14822839/cd8c9744-149b-4220-b52f-d480415c7592)

### Solution
Only allow switching while the primary GNSS receiver is unavailable. Otherwise, force back the selection.

In addition to that, I also took the opportunity to allow switching if the primary GNSS lost its 3D fix. I've seen several incidents where the antenna disconnected but no switch the the secondary GNSS occurred because we're solely relying on data timeout.

### Changelog Entry
For release notes:
```
Fix continuous GNSS instance switch. Add fallback if fix is lost.
New parameter: -
Documentation: -
```

### Alternatives
We should refactor the GNSS selector completely. This is just a quick patch to fix this specific bug.

### Test coverage
- unit tests