### PR TITLE
VTOL: change transition airspeed threshold: only look at VT_ARSP_TRANS, not FW_AIRSPD_MIN

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -598,18 +598,19 @@ float VtolType::getOpenLoopFrontTransitionTime() const
 }
 float VtolType::getTransitionAirspeed() const
 {
-	return  math::max(_param_vt_arsp_trans.get(), getMinimumTransitionAirspeed());
-}
-float VtolType::getMinimumTransitionAirspeed() const
-{
+	// Since the stall airspeed increases with vehicle weight, we increase the transition airspeed
+	// by the same factor.
+
 	float weight_ratio = 1.0f;
 
 	if (_param_weight_base.get() > FLT_EPSILON && _param_weight_gross.get() > FLT_EPSILON) {
-		weight_ratio = math::constrain(_param_weight_gross.get() / _param_weight_base.get(), kMinWeightRatio, kMaxWeightRatio);
+		weight_ratio = math::constrain(_param_weight_gross.get() /
+					       _param_weight_base.get(), kMinWeightRatio, kMaxWeightRatio);
 	}
 
-	return sqrtf(weight_ratio) * _param_airspeed_min.get();
+	return sqrtf(weight_ratio) * _param_vt_arsp_trans.get();
 }
+
 float VtolType::getBlendAirspeed() const
 {
 	return _param_vt_arsp_blend.get();

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -239,12 +239,6 @@ public:
 
 	/**
 	 *
-	 * @return The minimum calibrated airspeed compensated for weight [m/s]
-	 */
-	float getMinimumTransitionAirspeed() const;
-
-	/**
-	 *
 	 * @return The calibrated blending airspeed [m/s]
 	 */
 	float getBlendAirspeed() const;
@@ -371,8 +365,7 @@ protected:
 					(ParamFloat<px4::params::MPC_LAND_ALT2>) _param_mpc_land_alt2,
 					(ParamFloat<px4::params::VT_LND_PITCH_MIN>) _param_vt_lnd_pitch_min,
 					(ParamFloat<px4::params::WEIGHT_BASE>) _param_weight_base,
-					(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross,
-					(ParamFloat<px4::params::FW_AIRSPD_MIN>) _param_airspeed_min
+					(ParamFloat<px4::params::WEIGHT_GROSS>) _param_weight_gross
 
 				       )
 


### PR DESCRIPTION

### Solved Problem
https://github.com/PX4/PX4-Autopilot/pull/22140 brought in the scaling of the transition airspeed with the currently set vehicle weight. It though did that by limiting the minimum transition airspeed to the minimum airspeed in fixed-wing mode, `FW_AIRSPD_MIN`, which can lead to transitions not happening because `FW_AIRSPD_MIN` is set considerably higher than `VT_ARSP_TRANS`, and  the transition is tuned for `VT_ARSP_TRANS`.

### Solution
I don't see the need to check `FW_AIRSPD_MIN` in the transition logic, and here propose to remove it, and instead scale the `VT_ARSP_TRANS` with the weight factor.  

### Changelog Entry
For release notes:
```
Bugfix: VTOL: change transition airspeed threshold: only look at VT_ARSP_TRANS, not  FW_AIRSPD_MIN
```
