### PR TITLE
VTOL Tailsitter: add automatic pitch ramps also in Stabilized mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -50,11 +50,11 @@ param set-default SENS_IMU_MODE 1
 
 param set-default FW_P_TC 0.6
 
-param set-default FW_PR_FF 0.1
+param set-default FW_PR_FF 0.0
 param set-default FW_PSP_OFF 2
 param set-default FW_RR_FF 0.1
 param set-default FW_RR_I 0.2
-param set-default FW_RR_P 0.3
+param set-default FW_RR_P 0.5
 param set-default FW_THR_TRIM 0.35
 param set-default FW_THR_MAX 0.8
 param set-default FW_THR_MIN 0.05
@@ -66,8 +66,6 @@ param set-default FW_T_SINK_MIN 1.6
 param set-default MC_AIRMODE 1
 param set-default MC_ROLL_P 3
 param set-default MC_PITCH_P 3
-param set-default MC_ROLLRATE_P 0.3
-param set-default MC_PITCHRATE_P 0.3
 
 param set-default VT_ARSP_TRANS 10
 param set-default VT_B_TRANS_DUR 5

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -193,9 +193,12 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt,
 	attitude_setpoint.timestamp = hrt_absolute_time();
 	_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
 
-	// update attitude controller setpoint immediately
-	_attitude_control.setAttitudeSetpoint(q_sp, attitude_setpoint.yaw_sp_move_rate);
-	_thrust_setpoint_body = Vector3f(attitude_setpoint.thrust_body);
+	// update attitude controller setpoint immediately (don't do it in vtol transition, then the VTOL module generates the attitude setpoint)
+	if (!_vtol_in_transition_mode) {
+		_attitude_control.setAttitudeSetpoint(q_sp, attitude_setpoint.yaw_sp_move_rate);
+		_thrust_setpoint_body = Vector3f(attitude_setpoint.thrust_body);
+	}
+
 	_last_attitude_setpoint = attitude_setpoint.timestamp;
 }
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -172,21 +172,20 @@ void Tailsitter::update_transition_state()
 			// calculate rotation axis for transition.
 			_q_trans_start = Quatf(_v_att->q);
 			Vector3f z = -_q_trans_start.dcm_z();
-			_trans_rot_axis = z.cross(Vector3f(0, 0, -1));
+			_trans_rot_axis = z.cross(Vector3f(0.f, 0.f, -1.f));
 
 			// as heading setpoint we choose the heading given by the direction the vehicle points
-			float yaw_sp = atan2f(z(1), z(0));
+			const float yaw_sp = atan2f(z(1), z(0));
 
 			// the intial attitude setpoint for a backtransition is a combination of the current fw pitch setpoint,
 			// the yaw setpoint and zero roll since we want wings level transition.
-			// If for some reason the fw attitude setpoint is not recent then don't sue it and assume 0 pitch
+			// If for some reason the fw attitude setpoint is not recent then don't use it and assume 0 pitch
 			if (_fw_virtual_att_sp->timestamp > (now - 1_s)) {
-				_q_trans_start = Eulerf(0.0f, _fw_virtual_att_sp->pitch_body, yaw_sp);
+				_q_trans_start = Eulerf(0.f, _fw_virtual_att_sp->pitch_body, yaw_sp);
 
 			} else {
-				_q_trans_start = Eulerf(0.0f, 0.f, yaw_sp);
+				_q_trans_start = Eulerf(0.f, 0.f, yaw_sp);
 			}
-
 
 			// attitude during transitions are controlled by mc attitude control so rotate the desired attitude to the
 			// multirotor frame
@@ -194,9 +193,9 @@ void Tailsitter::update_transition_state()
 
 		} else if (_vtol_mode == vtol_mode::TRANSITION_FRONT_P1) {
 			// initial attitude setpoint for the transition should be with wings level
-			_q_trans_start = Eulerf(0.0f, _mc_virtual_att_sp->pitch_body, _mc_virtual_att_sp->yaw_body);
-			Vector3f x = Dcmf(Quatf(_v_att->q)) * Vector3f(1, 0, 0);
-			_trans_rot_axis = -x.cross(Vector3f(0, 0, -1));
+			_q_trans_start = Eulerf(0.f, _mc_virtual_att_sp->pitch_body, _mc_virtual_att_sp->yaw_body);
+			Vector3f x = Dcmf(Quatf(_v_att->q)) * Vector3f(1.f, 0.f, 0.f);
+			_trans_rot_axis = -x.cross(Vector3f(0.f, 0.f, -1.f));
 		}
 
 		_q_trans_sp = _q_trans_start;
@@ -206,10 +205,8 @@ void Tailsitter::update_transition_state()
 	_q_trans_sp.normalize();
 
 	// tilt angle (zero if vehicle nose points up (hover))
-	float cos_tilt = _q_trans_sp(0) * _q_trans_sp(0) - _q_trans_sp(1) * _q_trans_sp(1) - _q_trans_sp(2) *
-			 _q_trans_sp(2) + _q_trans_sp(3) * _q_trans_sp(3);
-	cos_tilt = cos_tilt >  1.0f ?  1.0f : cos_tilt;
-	cos_tilt = cos_tilt < -1.0f ? -1.0f : cos_tilt;
+	const float cos_tilt = math::constrain(_q_trans_sp(0) * _q_trans_sp(0) - _q_trans_sp(1) * _q_trans_sp(1) -
+					       _q_trans_sp(2) * _q_trans_sp(2) + _q_trans_sp(3) * _q_trans_sp(3), -1.f, 1.f);
 	const float tilt = acosf(cos_tilt);
 
 	if (_vtol_mode == vtol_mode::TRANSITION_FRONT_P1) {

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -88,15 +88,8 @@ void Tailsitter::update_vtol_state()
 		case vtol_mode::TRANSITION_BACK:
 			const float pitch = Eulerf(Quatf(_v_att->q)).theta();
 
-			float pitch_threshold_mc = PITCH_THRESHOLD_AUTO_TRANSITION_TO_MC;
-
-			// if doing transition in Stabilized mode set threshold to max angle plus 5° margin
-			if (!_v_control_mode->flag_control_altitude_enabled) {
-				pitch_threshold_mc = math::radians(-_param_mpc_tilt_max.get() - 5.f);
-			}
-
 			// check if we have reached pitch angle to switch to MC mode
-			if (pitch >= pitch_threshold_mc || _time_since_trans_start > _param_vt_b_trans_dur.get()) {
+			if (pitch >= PITCH_THRESHOLD_AUTO_TRANSITION_TO_MC || _time_since_trans_start > _param_vt_b_trans_dur.get()) {
 				_vtol_mode = vtol_mode::MC_MODE;
 			}
 
@@ -326,14 +319,7 @@ bool Tailsitter::isFrontTransitionCompletedBase()
 	bool transition_to_fw = false;
 	const float pitch = Eulerf(Quatf(_v_att->q)).theta();
 
-	float pitch_threshold_fw = PITCH_THRESHOLD_AUTO_TRANSITION_TO_FW;
-
-	// if doing transition in Stabilized mode set threshold to max angle minus 5° margin
-	if (!_v_control_mode->flag_control_altitude_enabled) {
-		pitch_threshold_fw = math::radians(-_param_mpc_tilt_max.get() + 5.f);
-	}
-
-	if (pitch <= pitch_threshold_fw) {
+	if (pitch <= PITCH_THRESHOLD_AUTO_TRANSITION_TO_FW) {
 		if (airspeed_triggers_transition) {
 			transition_to_fw = _airspeed_validated->calibrated_airspeed_m_s >= _param_vt_arsp_trans.get() ;
 

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -88,8 +88,7 @@ private:
 	bool isFrontTransitionCompletedBase() override;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(VtolType,
-					(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off,
-					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _param_mpc_tilt_max
+					(ParamFloat<px4::params::FW_PSP_OFF>) _param_fw_psp_off
 				       )
 
 


### PR DESCRIPTION
### Solved Problem
Fixes https://github.com/PX4/PX4-Autopilot/issues/22316

Tailsitter transitions in Stabilized are currently handed the following way:
- transition to FW: user has to manually pitch down until within 5° of the max tilt in hover, MPC_MAN_TILT_MAX
- transition to MC: the pitch setpoint immediately changes to the hover interpretation, meaning that if the user doesn't pitch down while doing the transition then the vehicle will immediately try to pitch up to 0° hover pitch (so a 90° step)

### Solution
Do the same pitch ramp as in all altitude controlled modes also in Stabilized. 

### Changelog Entry
For release notes:
```
Feature: VTOL Tailsitter: add automatic pitch ramps also in Stabilized mode
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
Flight tested. 

### Context
Screen recording of a SITL flight with the changes as proposed in this PR, and at the end a failed transition with current main (there also the SITL tuning is bad, also fixed it in this PR).
https://github.com/PX4/PX4-Autopilot/assets/26798987/2eff901a-2aa1-484a-a0e5-116aad1c61c5
