### PR TITLE
boards: arkv6x uart5 cts enable pulldown

### DIFF
--- a/boards/ark/fmu-v6x/nuttx-config/include/board.h
+++ b/boards/ark/fmu-v6x/nuttx-config/include/board.h
@@ -380,7 +380,7 @@
 #define GPIO_UART5_RX    GPIO_UART5_RX_3    /* PD2  */
 #define GPIO_UART5_TX    GPIO_UART5_TX_3    /* PC12 */
 // GPIO_UART5_RTS  No remap                 /* PC8  */
-// GPIO_UART5_CTS  No remap                 /* PC9  */
+#define GPIO_UART5_CTS   (GPIO_ALT|GPIO_AF8|GPIO_PORTC|GPIO_PIN9|GPIO_PULLDOWN)    /* PC9  */
 
 #define GPIO_USART6_RX   GPIO_USART6_RX_1   /* PC7 */
 #define GPIO_USART6_TX   GPIO_USART6_TX_1   /* PC6  */


### PR DESCRIPTION
With the new stm32 TX DMA changes, UART5 CTS pulldown needs to be enabled for mavlink to work on Telem 2. 

UPDATE: Even with this change, mavlink eventually disconnects and stops transmitting.