### PR TITLE
V6X-RT Add reboot into ISP (1st stage bootloader)

### DIFF
--- a/boards/px4/fmu-v6xrt/src/board_config.h
+++ b/boards/px4/fmu-v6xrt/src/board_config.h
@@ -539,6 +539,8 @@
 
 /* This board provides the board_on_reset interface */
 
+#define BOARD_HAS_ISP_BOOTLOADER 1
+
 #define BOARD_HAS_ON_RESET 1
 
 #define PX4_GPIO_INIT_LIST { \

--- a/platforms/nuttx/src/px4/nxp/imxrt/board_reset/CMakeLists.txt
+++ b/platforms/nuttx/src/px4/nxp/imxrt/board_reset/CMakeLists.txt
@@ -35,6 +35,8 @@ px4_add_library(arch_board_reset
 	board_reset.cpp
 )
 
+target_link_libraries(arch_board_reset PRIVATE arch_board_romapi)
+
 # up_systemreset
 if (NOT DEFINED CONFIG_BUILD_FLAT)
 	target_link_libraries(arch_board_reset PRIVATE nuttx_karch)

--- a/platforms/nuttx/src/px4/nxp/imxrt/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/imxrt/board_reset/board_reset.cpp
@@ -44,6 +44,10 @@
 #include <arm_internal.h>
 #include <hardware/rt117x/imxrt117x_snvs.h>
 
+
+#include <px4_arch/imxrt_flexspi_nor_flash.h>
+#include <px4_arch/imxrt_romapi.h>
+
 #define BOOT_RTC_SIGNATURE                0xb007b007
 #define PX4_IMXRT_RTC_REBOOT_REG          3
 #define PX4_IMXRT_RTC_REBOOT_REG_ADDRESS  IMXRT_SNVS_LPGPR3
@@ -64,6 +68,11 @@ int board_reset(int status)
 {
 	if (status == REBOOT_TO_BOOTLOADER) {
 		board_reset_enter_bootloader();
+
+	} else if (status == REBOOT_TO_ISP) {
+		uint32_t arg = 0xeb100000;
+		ROM_API_Init();
+		ROM_RunBootloader(&arg);
 	}
 
 #if defined(BOARD_HAS_ON_RESET)


### PR DESCRIPTION
Add -i option to reboot command and reboot into the rom ISP 1st stage bootloader.

Allows to flash px4 bootloader from USB using ISP bootloader.