### PR TITLE
Adapt to compilation under Android NDK

### DIFF
--- a/platforms/posix/include/bionic_pthread_cancel.h
+++ b/platforms/posix/include/bionic_pthread_cancel.h
@@ -1,0 +1,35 @@
+#ifndef BIONIC_PTHREAD_CANCEL_H
+#define BIONIC_PTHREAD_CANCEL_H
+
+#ifdef __ANDROID__
+
+#include <pthread.h>
+
+/* The signal used for asynchronous cancelation.  */
+#define SIGCANCEL       __SIGRTMIN
+
+namespace {
+    static void handler_pthread_cancel(int sig)
+    {
+        pthread_exit(0);
+    }
+
+    int pthread_cancel(pthread_t thread)
+    {
+        return pthread_kill(thread, SIGCANCEL);
+    }
+
+    void register_handler_pthread_cancel()
+    {
+        struct sigaction actions;
+        memset(&actions, 0, sizeof(actions));
+        sigemptyset(&actions.sa_mask);
+        actions.sa_flags = 0;
+        actions.sa_handler = handler_pthread_cancel;
+        sigaction(SIGCANCEL,&actions,NULL);
+    }
+}
+
+#endif
+
+#endif // BIONIC_PTHREAD_CANCEL_H

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -81,7 +81,11 @@
 
 #define MODULE_NAME "px4"
 
+#ifdef __ANDROID__
+static const char *LOCK_FILE_PATH = "/data/local/tmp/px4_lock";
+#else
 static const char *LOCK_FILE_PATH = "/tmp/px4_lock";
+#endif
 
 #ifndef PATH_MAX
 #define PATH_MAX 1024

--- a/platforms/posix/src/px4/common/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/server.cpp
@@ -53,6 +53,7 @@
 #include <vector>
 
 #include <px4_platform_common/log.h>
+#include <bionic_pthread_cancel.h>
 
 #include "pxh.h"
 #include "server.h"
@@ -238,6 +239,10 @@ void
 {
 	FILE *out = (FILE *)arg;
 	int fd = fileno(out);
+
+#ifdef __ANDROID__
+	register_handler_pthread_cancel();
+#endif
 
 	// Read until the end of the incoming stream.
 	std::string cmd;

--- a/platforms/posix/src/px4/common/px4_daemon/sock_protocol.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/sock_protocol.cpp
@@ -43,8 +43,12 @@ namespace px4_daemon
 
 std::string get_socket_path(int instance_id)
 {
+#ifdef __ANDROID__
+	return "/data/local/tmp/px4-sock-" + std::to_string(instance_id);
+#else
 	// TODO: Use /var/run/px4/$instance/sock (or /var/run/user/$UID/... for non-root).
 	return "/tmp/px4-sock-" + std::to_string(instance_id);
+#endif
 }
 
 } // namespace px4_daemon

--- a/platforms/posix/src/px4/common/tasks.cpp
+++ b/platforms/posix/src/px4/common/tasks.cpp
@@ -58,6 +58,7 @@
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/posix.h>
 #include <systemlib/err.h>
+#include <bionic_pthread_cancel.h>
 
 #define PX4_MAX_TASKS 50
 
@@ -83,6 +84,10 @@ typedef struct {
 static void *entry_adapter(void *ptr)
 {
 	pthdata_t *data = (pthdata_t *) ptr;
+
+#ifdef __ANDROID__
+	register_handler_pthread_cancel();
+#endif
 
 	// set the threads name
 #ifdef __PX4_DARWIN


### PR DESCRIPTION
Since NDK does not provide the `pthread_cancel` function, a function to replace `pthread_cancel` in the NDK environment has been added.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The source code cannot be compiled in the Android NDK environment.


### Solution
A function to replace `pthread_cancel` in the NDK environment has been added.

### Test coverage
- With my Android 13 cell phone.
