### PR TITLE
reboot: Add reboot to ISP option

### DIFF
--- a/platforms/common/include/px4_platform_common/shutdown.h
+++ b/platforms/common/include/px4_platform_common/shutdown.h
@@ -70,6 +70,12 @@ __EXPORT int px4_register_shutdown_hook(shutdown_hook_t hook);
  */
 __EXPORT int px4_unregister_shutdown_hook(shutdown_hook_t hook);
 
+/** Types of reboot requests for PX4 */
+typedef enum {
+	REBOOT_REQUEST = 0,          ///< Normal reboot
+	REBOOT_TO_BOOTLOADER = 1,    ///< Reboot to PX4 bootloader
+	REBOOT_TO_ISP = 2,           ///< Reboot to ISP bootloader
+} reboot_request_t;
 
 /**
  * Request the system to reboot.
@@ -83,7 +89,7 @@ __EXPORT int px4_unregister_shutdown_hook(shutdown_hook_t hook);
  * @return 0 on success, <0 on error
  */
 #if defined(CONFIG_BOARDCTL_RESET)
-__EXPORT int px4_reboot_request(bool to_bootloader = false, uint32_t delay_us = 0);
+__EXPORT int px4_reboot_request(reboot_request_t request = REBOOT_REQUEST, uint32_t delay_us = 0);
 #endif // CONFIG_BOARDCTL_RESET
 
 

--- a/platforms/nuttx/src/px4/common/cdc_acm_check.cpp
+++ b/platforms/nuttx/src/px4/common/cdc_acm_check.cpp
@@ -187,7 +187,7 @@ static void mavlink_usb_check(void *arg)
 
 										if (param1 == 1) {
 											// 1: Reboot autopilot
-											px4_reboot_request(false, 0);
+											px4_reboot_request(REBOOT_REQUEST, 0);
 
 										} else if (param1 == 2) {
 											// 2: Shutdown autopilot
@@ -197,7 +197,7 @@ static void mavlink_usb_check(void *arg)
 
 										} else if (param1 == 3) {
 											// 3: Reboot autopilot and keep it in the bootloader until upgraded.
-											px4_reboot_request(true, 0);
+											px4_reboot_request(REBOOT_TO_BOOTLOADER, 0);
 										}
 									}
 								}

--- a/platforms/nuttx/src/px4/nxp/imxrt/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/imxrt/board_reset/board_reset.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/shutdown.h>
 #include <errno.h>
 #include <nuttx/board.h>
 #include <arm_internal.h>
@@ -61,7 +62,7 @@ static int board_reset_enter_bootloader()
 
 int board_reset(int status)
 {
-	if (status == 1) {
+	if (status == REBOOT_TO_BOOTLOADER) {
 		board_reset_enter_bootloader();
 	}
 

--- a/platforms/nuttx/src/px4/nxp/kinetis/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/kinetis/board_reset/board_reset.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/shutdown.h>
 #include <errno.h>
 #include <nuttx/board.h>
 
@@ -72,7 +73,7 @@ static int board_reset_enter_bootloader()
 
 int board_reset(int status)
 {
-	if (status == 1) {
+	if (status == REBOOT_TO_BOOTLOADER) {
 		board_reset_enter_bootloader();
 	}
 

--- a/platforms/nuttx/src/px4/nxp/s32k1xx/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/s32k1xx/board_reset/board_reset.cpp
@@ -39,6 +39,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/shutdown.h>
 #include <systemlib/px4_macros.h>
 #include <errno.h>
 #include <nuttx/board.h>
@@ -96,7 +97,7 @@ int board_configure_reset(reset_mode_e mode, uint32_t arg)
 
 int board_reset(int status)
 {
-	if (status == 1) {
+	if (status == REBOOT_TO_BOOTLOADER) {
 		board_reset_enter_bootloader();
 	}
 

--- a/platforms/nuttx/src/px4/nxp/s32k3xx/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/nxp/s32k3xx/board_reset/board_reset.cpp
@@ -39,6 +39,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/shutdown.h>
 #include <errno.h>
 #include <nuttx/board.h>
 #include <hardware/s32k3xx_mc_me.h>

--- a/platforms/nuttx/src/px4/rpi/rpi_common/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/rpi/rpi_common/board_reset/board_reset.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/shutdown.h>
 #include <systemlib/px4_macros.h>
 #include <errno.h>
 
@@ -119,7 +120,7 @@
 
 int board_reset(int status)
 {
-	if (status == 1) {
+	if (status == REBOOT_TO_BOOTLOADER) {
 		// board_configure_reset(BOARD_RESET_MODE_BOOT_TO_BL, 0);
 	}
 

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_reset/board_reset.cpp
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_reset/board_reset.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/shutdown.h>
 #include <systemlib/px4_macros.h>
 #include <errno.h>
 #include <stm32_pwr.h>
@@ -117,7 +118,7 @@ int board_configure_reset(reset_mode_e mode, uint32_t arg)
 
 int board_reset(int status)
 {
-	if (status == 1) {
+	if (status == REBOOT_TO_BOOTLOADER) {
 		board_configure_reset(BOARD_RESET_MODE_BOOT_TO_BL, 0);
 	}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1201,7 +1201,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 #if defined(CONFIG_BOARDCTL_RESET)
 
-			} else if ((param1 == 1) && !isArmed() && (px4_reboot_request(false, 400_ms) == 0)) {
+			} else if ((param1 == 1) && !isArmed() && (px4_reboot_request(REBOOT_REQUEST, 400_ms) == 0)) {
 				// 1: Reboot autopilot
 				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
@@ -1221,7 +1221,7 @@ Commander::handle_command(const vehicle_command_s &cmd)
 
 #if defined(CONFIG_BOARDCTL_RESET)
 
-			} else if ((param1 == 3) && !isArmed() && (px4_reboot_request(true, 400_ms) == 0)) {
+			} else if ((param1 == 3) && !isArmed() && (px4_reboot_request(REBOOT_TO_BOOTLOADER, 400_ms) == 0)) {
 				// 3: Reboot autopilot and keep it in the bootloader until upgraded.
 				answer_command(cmd, vehicle_command_ack_s::VEHICLE_CMD_RESULT_ACCEPTED);
 

--- a/src/modules/commander/worker_thread.cpp
+++ b/src/modules/commander/worker_thread.cpp
@@ -177,7 +177,7 @@ void WorkerThread::threadEntry()
 			param_reset_specific(reset_cal, sizeof(reset_cal) / sizeof(reset_cal[0]));
 			_ret_value = param_save_default(true);
 #if defined(CONFIG_BOARDCTL_RESET)
-			px4_reboot_request(false, 400_ms);
+			px4_reboot_request(REBOOT_REQUEST, 400_ms);
 #endif // CONFIG_BOARDCTL_RESET
 			break;
 		}

--- a/src/systemcmds/netman/netman.cpp
+++ b/src/systemcmds/netman/netman.cpp
@@ -375,7 +375,7 @@ write_reboot:
 
 	sleep(1);
 
-	px4_reboot_request(false);
+	px4_reboot_request(REBOOT_REQUEST);
 
 	while (1) { px4_usleep(1); } // this command should not return on success
 


### PR DESCRIPTION
Extend px4_reboot_request with enum to add REBOOT_TO_ISP request for devices with a bootrom to boot into the rom bootloader.