### PR TITLE
fmu-v6xrt: Delete a parameter setting that does not exist

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_defaults
+++ b/boards/px4/fmu-v6xrt/init/rc.board_defaults
@@ -16,8 +16,6 @@ param set-default SENS_EN_INA238 0
 param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 1
 
-param set-default SYS_USE_IO 1
-
 safety_button start
 
 if param greater -s UAVCAN_ENABLE 0


### PR DESCRIPTION
### Solved Problem

During a FAULT investigation of PIXHAWK 6X-RT, an error was found in DMESG.
Parameter "SYS_USE_IO" is missing.


nsh> dmesg
HW arch: PX4_FMU_V6XRT
HW type: V6XRT000000
HW version: 0x000
HW revision: 0x000
PX4 git-hash: 6be8cbe43966d57630e6743e163307c216444be7
PX4 version: 1.15.0 40 (17760320)
PX4 git-branch: main
OS: NuttX
OS version: Release 11.0.0 (184549631)
OS git-hash: 1e3aaefc60a18838dc696e8f0f335d8c989f35cc
Build datetime: Dec 22 2023 11:18:10
Build uri: localhost
Build variant: default
Toolchain: GNU GCC, 9.3.1 20200408 (release)
PX4GUID: 000900000000000000008292b37f2718600e
MCU: i.MX RT1170 rB0, rev. 0
INFO  [param] selected parameter default file /fs/mtd_params
INFO  [param] importing from '/fs/mtd_params'
INFO  [parameters] BSON document size 1288 bytes, decoded 1288 bytes (INT32:19, FLOAT:39)
INFO  [param] selected parameter backup file /fs/microsd/parameters_backup.bson
Board architecture defaults: /etc/init.d/rc.board_arch_defaults
Board defaults: /etc/init.d/rc.board_defaults
ERROR [param] Parameter SYS_USE_IO not found.  
Loading airframe: /etc/init.d/airframes/4019_x500_v2
INFO  [dataman] data manager file '/fs/microsd/dataman' size is 64312 bytes
INFO  [px4io] IO FW CRC match
Board sensors: /etc/init.d/rc.board_sensors
INFO  [ina226] Failed to init INA226 on bus 1, but will try again periodically.


### Solution

Delete SYS_USE_IO from the following file.

boards/px4/fmu-v6xrt/init/rc.board_defaults

### Changelog Entry

None

### Alternatives

None

### Test coverage

Confirmed error-free by DMESG.

### Context

None
