### PR TITLE
fmu-v6xrt: Change the description to the device name in the WIKI

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_sensors
+++ b/boards/px4/fmu-v6xrt/init/rc.board_sensors
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# PX4 FMUv5 specific board sensors init
+# PX4 FMUv6X-RT specific board sensors init
 #------------------------------------------------------------------------------
 #
 # UART mapping on PX4 FMU-V6XRT:
@@ -8,11 +8,11 @@
 # LPUART1       /dev/ttyS0      CONSOLE
 # LPUART3       /dev/ttyS1      GPS
 # LPUART4       /dev/ttyS2      TELEM1
-# LPUART5       /dev/ttyS4      GPS2
-# LPUART6       /dev/ttyS5      PX4IO
-# LPUART8       /dev/ttyS6      TELEM2
-# LPUART10      /dev/ttyS7      TELEM3
-# LPUART11      /dev/ttyS8      EXT2
+# LPUART5       /dev/ttyS3      GPS2
+# LPUART6       /dev/ttyS4      PX4IO
+# LPUART8       /dev/ttyS5      TELEM2
+# LPUART10      /dev/ttyS6      TELEM3
+# LPUART11      /dev/ttyS7      EXT2
 #
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Solved Problem

While investigating the cause of a FAULT on PIXHAWK 6X-RT, we discovered that the UART device name specification was different from WIKI.

### Solution

Match the file description to the WIKI.

### Changelog Entry

None

### Alternatives

None

### Test coverage

None

### Context

None