### PR TITLE
mavlink: Add a second barometric sensor message

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1669,6 +1669,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SCALED_IMU2", 25.0f);
 		configure_stream_local("SCALED_IMU3", 25.0f);
 		configure_stream_local("SCALED_PRESSURE", 1.0f);
+		configure_stream_local("SCALED_PRESSURE2", 1.0f);
 		configure_stream_local("SERVO_OUTPUT_RAW_0", 20.0f);
 		configure_stream_local("SERVO_OUTPUT_RAW_1", 20.0f);
 		configure_stream_local("SYS_STATUS", 1.0f);


### PR DESCRIPTION
### Solved Problem


While checking the operation of PIXHAWK 6X-RT, only one barometric pressure sensor was shown in the MAVLINK inspector.

### Solution

Add a second barometric sensor message to the MAVLINK message transmission list.

### Changelog Entry

None

### Alternatives

None

### Test coverage

1. No build errors.      RESULT: OK
2. No errors when running on FC.    RESULT: OK

### Context

AFTER

![Screenshot from 2024-01-04 20-28-27](https://github.com/PX4/PX4-Autopilot/assets/646194/baf47b59-3401-48d8-9f3b-9b16b9797f28)

BEFORE

![Screenshot from 2024-01-04 20-18-05](https://github.com/PX4/PX4-Autopilot/assets/646194/7b186678-bf01-4414-a764-ddf0fa05aade)