### PR TITLE
fmu-v6xrt: Move external BMP388 outside of config parameter determination

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_sensors
+++ b/boards/px4/fmu-v6xrt/init/rc.board_sensors
@@ -84,6 +84,8 @@ ist8310 -X -b 1 -R 10 start
 if param compare SENS_INT_BARO_EN 1
 then
 	bmp388 -I -b 3 -a 0x77 start
-	bmp388 -X -b 2 start
 fi
+
+bmp388 -X -b 2 start
+
 unset HAVE_PM2


### PR DESCRIPTION
### Solved Problem

During a FAULT investigation of PIXHAWK 6X-RT, the activation of the external barometric sensor was affected by a config parameter.

The external barometric pressure sensor of PIXHAWK 6X was not affected by the config parameter.

### Solution

Make the configuration parameter determination unaffected.

### Changelog Entry

None

### Alternatives

None

### Test coverage

1. Confirm that it is started by DMESG.     Result: OK

### Context

DMESG Output Result:

bmm150 #0 on I2C bus 3 address 0x10
ist8310 #0 on I2C bus 1 (external) address 0xE rotation 10
bmp388 #0 on I2C bus 3 address 0x77
bmp388 #1 on I2C bus 2 (external) address 0x76
WARN  [SPI_I2C] Already running on bus 1
WARN  [vehicle_angular_velocity] no gyro selected, using sensor_gyro_fifo:0 2949130
ekf2 [498:237]
Board mavlink: /etc/init.d/rc.board_mavlink
Starting Main GPS on /dev/ttyS1

![Screenshot from 2024-01-05 02-10-39](https://github.com/PX4/PX4-Autopilot/assets/646194/5c4a2f8a-3098-4aac-9fd8-2ed1e4c19cd6)

