### PR TITLE
[control_allocation] small typo fix in member function description

### DIFF
--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -131,9 +131,9 @@ public:
 	void setControlSetpoint(const matrix::Vector<float, NUM_AXES> &control) { _control_sp = control; }
 
 	/**
-	 * Set the desired control vector
+	 * Get the desired control vector
 	 *
-	 * @param Control vector
+	 * @return Control vector
 	 */
 	const matrix::Vector<float, NUM_AXES> &getControlSetpoint() const { return _control_sp; }
 


### PR DESCRIPTION
### Solved Problem
Just a small typo fix for the function description of `ControlAllocation::getControlSetPoint`.