### PR TITLE
Control Allocation Sequential Desaturation unit tests

### DIFF
--- a/src/modules/control_allocator/ControlAllocation/CMakeLists.txt
+++ b/src/modules/control_allocator/ControlAllocation/CMakeLists.txt
@@ -44,3 +44,4 @@ target_include_directories(ControlAllocation PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(ControlAllocation PRIVATE mathlib)
 
 px4_add_unit_gtest(SRC ControlAllocationPseudoInverseTest.cpp LINKLIBS ControlAllocation)
+px4_add_functional_gtest(SRC ControlAllocationSequentialDesaturationTest.cpp LINKLIBS ControlAllocation ActuatorEffectiveness)

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -130,11 +130,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledOnlyYaw)
 	setup_quad_allocator(allocator);
 	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
 	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
-	control_sp(ControlAllocation::ControlAxis::PITCH) = 0;
+	control_sp(ControlAllocation::ControlAxis::PITCH) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::YAW) = 1.f;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = 0;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = 0.f;
 	allocator.setControlSetpoint(control_sp);
 
 	// Since MC_AIRMODE was not set explicitly, assume airmode is disabled.
@@ -155,11 +155,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustZ)
 	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
 	// Negative, because +z is "downward".
 	constexpr float THRUST_Z_TOTAL{-0.75f};
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
-	control_sp(ControlAllocation::ControlAxis::PITCH) = 0;
-	control_sp(ControlAllocation::ControlAxis::YAW) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::PITCH) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::YAW) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = THRUST_Z_TOTAL;
 	allocator.setControlSetpoint(control_sp);
 
@@ -170,12 +170,12 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustZ)
 	constexpr int MOTOR_COUNT{4};
 	constexpr float THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT};
 
-	for (size_t i{0}; i < 4; ++i) {
+	for (int i{0}; i < MOTOR_COUNT; ++i) {
 		EXPECT_NEAR(actuator_sp(i), THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	}
 
-	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
-		EXPECT_NEAR(actuator_sp(i), 0, EXPECT_NEAR_TOL);
+	for (int i{MOTOR_COUNT}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_NEAR(actuator_sp(i), 0.f, EXPECT_NEAR_TOL);
 	}
 }
 
@@ -190,11 +190,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndYaw)
 	constexpr float THRUST_Z_TOTAL{-0.75f};
 	// This is low enough to not saturate the motors.
 	constexpr float YAW_CONTROL_SP{0.02f};
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
-	control_sp(ControlAllocation::ControlAxis::PITCH) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::PITCH) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::YAW) = YAW_CONTROL_SP;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = THRUST_Z_TOTAL;
 	allocator.setControlSetpoint(control_sp);
 
@@ -207,20 +207,20 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndYaw)
 	constexpr float YAW_EFFECTIVENESS_FACTOR{5.f};
 	constexpr float YAW_DIFF_PER_MOTOR{YAW_CONTROL_SP * YAW_EFFECTIVENESS_FACTOR};
 	// At yaw condition, there will be 2 different actuator values.
-	constexpr float MOTOR_COUNT{4.f};
+	constexpr int MOTOR_COUNT{4};
 	constexpr float HIGH_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT + YAW_DIFF_PER_MOTOR};
 	constexpr float LOW_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT - YAW_DIFF_PER_MOTOR};
 
-	for (size_t i{0}; i < 2; ++i) {
+	for (int i{0}; i < MOTOR_COUNT / 2; ++i) {
 		EXPECT_NEAR(actuator_sp(i), HIGH_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	}
 
-	for (size_t i{2}; i < 4; ++i) {
+	for (int i{MOTOR_COUNT / 2}; i < MOTOR_COUNT; ++i) {
 		EXPECT_NEAR(actuator_sp(i), LOW_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	}
 
-	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
-		EXPECT_NEAR(actuator_sp(i), 0, EXPECT_NEAR_TOL);
+	for (int i{MOTOR_COUNT}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_NEAR(actuator_sp(i), 0.f, EXPECT_NEAR_TOL);
 	}
 }
 
@@ -235,11 +235,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndSatura
 	constexpr float THRUST_Z_TOTAL{-0.75f};
 	// This is arbitrarily high to trigger strongest possible (saturated) yaw response.
 	constexpr float YAW_CONTROL_SP{0.25f};
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
-	control_sp(ControlAllocation::ControlAxis::PITCH) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::PITCH) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::YAW) = YAW_CONTROL_SP;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = THRUST_Z_TOTAL;
 	allocator.setControlSetpoint(control_sp);
 
@@ -248,15 +248,15 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndSatura
 
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	// At max yaw, only 2 motors will carry all of the thrust.
-	constexpr float YAW_MOTORS{2.f};
+	constexpr int YAW_MOTORS{2};
 	constexpr float THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / YAW_MOTORS};
 
-	for (size_t i{0}; i < 2; ++i) {
+	for (int i{0}; i < YAW_MOTORS; ++i) {
 		EXPECT_NEAR(actuator_sp(i), THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	}
 
-	for (size_t i{2}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
-		EXPECT_NEAR(actuator_sp(i), 0, EXPECT_NEAR_TOL);
+	for (int i{YAW_MOTORS}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_NEAR(actuator_sp(i), 0.f, EXPECT_NEAR_TOL);
 	}
 }
 
@@ -271,11 +271,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 	constexpr float THRUST_Z_TOTAL{-0.75f};
 	// This is low enough to not saturate the motors.
 	constexpr float PITCH_CONTROL_SP{0.1f};
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::PITCH) = PITCH_CONTROL_SP;
-	control_sp(ControlAllocation::ControlAxis::YAW) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAllocation::ControlAxis::YAW) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = THRUST_Z_TOTAL;
 	allocator.setControlSetpoint(control_sp);
 
@@ -285,7 +285,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	// This value is based off of the effectiveness matrix. If the effectiveness matrix is changed,
 	// this will need to be changed.
-	constexpr float MOTOR_COUNT{4.f};
+	constexpr int MOTOR_COUNT{4};
 	constexpr float PITCH_DIFF_PER_MOTOR{PITCH_CONTROL_SP / MOTOR_COUNT};
 	// At control set point, there will be 2 different actuator values.
 	constexpr float HIGH_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT + PITCH_DIFF_PER_MOTOR};
@@ -295,8 +295,8 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 	EXPECT_NEAR(actuator_sp(2), HIGH_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	EXPECT_NEAR(actuator_sp(3), LOW_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 
-	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
-		EXPECT_NEAR(actuator_sp(i), 0, EXPECT_NEAR_TOL);
+	for (int i{MOTOR_COUNT}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_NEAR(actuator_sp(i), 0.f, EXPECT_NEAR_TOL);
 	}
 }
 
@@ -309,15 +309,15 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
 	// Negative, because +z is "downward".
 	constexpr float DESIRED_THRUST_Z_PER_MOTOR{0.8f};
-	constexpr float MOTOR_COUNT{4.f};
+	constexpr int MOTOR_COUNT{4};
 	constexpr float THRUST_Z_TOTAL{-DESIRED_THRUST_Z_PER_MOTOR * MOTOR_COUNT};
 	// This is arbitrarily high to trigger strongest possible (saturated) yaw response.
 	constexpr float YAW_CONTROL_SP{1.f};
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
-	control_sp(ControlAllocation::ControlAxis::PITCH) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::PITCH) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::YAW) = YAW_CONTROL_SP;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = THRUST_Z_TOTAL;
 	allocator.setControlSetpoint(control_sp);
 
@@ -337,8 +337,8 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	EXPECT_NEAR(actuator_sp(2), LOW_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	EXPECT_NEAR(actuator_sp(3), LOW_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 
-	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
-		EXPECT_NEAR(actuator_sp(i), 0, EXPECT_NEAR_TOL);
+	for (int i{MOTOR_COUNT}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_NEAR(actuator_sp(i), 0.f, EXPECT_NEAR_TOL);
 	}
 }
 
@@ -353,11 +353,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	constexpr float THRUST_Z_TOTAL{-0.75f * 4.f};
 	// This is high enough to saturate the pitch control.
 	constexpr float PITCH_CONTROL_SP{2.f};
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::PITCH) = PITCH_CONTROL_SP;
-	control_sp(ControlAllocation::ControlAxis::YAW) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;
-	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAllocation::ControlAxis::YAW) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0.f;
+	control_sp(ControlAllocation::ControlAxis::THRUST_Y) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_Z) = THRUST_Z_TOTAL;
 	allocator.setControlSetpoint(control_sp);
 
@@ -365,13 +365,13 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	allocator.allocate();
 
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
-	constexpr float MOTOR_COUNT{4.f};
+	constexpr int MOTOR_COUNT{4};
 	// The maximum actuator value is
 	// 	THRUST_Z_TOTAL / MOTOR_COUNT + PITCH_CONTROL_SP / MOTOR_COUNT.
 	// The amount over 1 is the amount that each motor is reduced by.
 	// At control set point, there will be 2 different actuator values.
 	constexpr float OVERAGE_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT + PITCH_CONTROL_SP / MOTOR_COUNT - 1};
-	EXPECT_TRUE(OVERAGE_PER_MOTOR > 0);
+	EXPECT_TRUE(OVERAGE_PER_MOTOR > 0.f);
 	constexpr float HIGH_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT + PITCH_CONTROL_SP / MOTOR_COUNT - OVERAGE_PER_MOTOR};
 	constexpr float LOW_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT - PITCH_CONTROL_SP / MOTOR_COUNT - OVERAGE_PER_MOTOR};
 	EXPECT_NEAR(actuator_sp(0), HIGH_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
@@ -379,7 +379,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	EXPECT_NEAR(actuator_sp(2), HIGH_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 	EXPECT_NEAR(actuator_sp(3), LOW_THRUST_Z_PER_MOTOR, EXPECT_NEAR_TOL);
 
-	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
-		EXPECT_NEAR(actuator_sp(i), 0, EXPECT_NEAR_TOL);
+	for (int i{MOTOR_COUNT}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
+		EXPECT_NEAR(actuator_sp(i), 0.f, EXPECT_NEAR_TOL);
 	}
 }

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -129,7 +129,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledOnlyYaw)
 	ControlAllocationSequentialDesaturation allocator;
 	setup_quad_allocator(allocator);
 	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
-	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
+	control_sp(ControlAllocation::ControlAxis::ROLL) = 0.f;
 	control_sp(ControlAllocation::ControlAxis::PITCH) = 0;
 	control_sp(ControlAllocation::ControlAxis::YAW) = 1.f;
 	control_sp(ControlAllocation::ControlAxis::THRUST_X) = 0;

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -118,7 +118,7 @@ void setup_quad_allocator(ControlAllocationSequentialDesaturation &allocator)
 	);
 }
 
-static constexpr float EXPECT_NEAR_TOL{1e-4};
+static constexpr float EXPECT_NEAR_TOL{1e-4f};
 
 } // namespace
 

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -218,7 +218,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndYaw)
 }
 
 // This tests that a control setpoint for z-thrust + yaw returns the desired actuator setpoint.
-// This test saturates the yaw response.
+// This test saturates the yaw response, but does not reduce total thrust.
 TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndSaturatedYaw)
 {
 	ControlAllocationSequentialDesaturation allocator;
@@ -289,7 +289,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 }
 
 // This tests that a control setpoint for z-thrust + yaw returns the desired actuator setpoint.
-// This test demonstrates a trade-off between thrust and yaw.
+// This test saturates yaw and demonstrates reduction of thrust for yaw.
 TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAndYaw)
 {
 	ControlAllocationSequentialDesaturation allocator;

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -1,0 +1,155 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ControlAllocationSequentialDesaturationTest.cpp
+ *
+ * Tests for Control Allocation Sequential Desaturation Algorithms
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <ControlAllocationSequentialDesaturation.hpp>
+#include <../ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp>
+
+using namespace matrix;
+
+namespace {
+
+// Makes and returns a Geometry object for a "standard" quadcopter.
+ActuatorEffectivenessRotors::Geometry make_quad_geometry() {
+	ActuatorEffectivenessRotors::Geometry geometry = {};
+	geometry.rotors[0].position(0) = 1.0f;
+	geometry.rotors[0].position(1) = 1.0f;
+	geometry.rotors[0].position(2) = 0.0f;
+	geometry.rotors[0].axis(0) = 0.0f;
+	geometry.rotors[0].axis(1) = 0.0f;
+	geometry.rotors[0].axis(2) = -1.0f;
+	geometry.rotors[0].thrust_coef = 1.0f;
+	geometry.rotors[0].moment_ratio = 0.05f;
+
+	geometry.rotors[1].position(0) = -1.0f;
+	geometry.rotors[1].position(1) = -1.0f;
+	geometry.rotors[1].position(2) = 0.0f;
+	geometry.rotors[1].axis(0) = 0.0f;
+	geometry.rotors[1].axis(1) = 0.0f;
+	geometry.rotors[1].axis(2) = -1.0f;
+	geometry.rotors[1].thrust_coef = 1.0f;
+	geometry.rotors[1].moment_ratio = 0.05f;
+
+	geometry.rotors[2].position(0) = 1.0f;
+	geometry.rotors[2].position(1) = -1.0f;
+	geometry.rotors[2].position(2) = 0.0f;
+	geometry.rotors[2].axis(0) = 0.0f;
+	geometry.rotors[2].axis(1) = 0.0f;
+	geometry.rotors[2].axis(2) = -1.0f;
+	geometry.rotors[2].thrust_coef = 1.0f;
+	geometry.rotors[2].moment_ratio = -0.05f;
+
+	geometry.rotors[3].position(0) = -1.0f;
+	geometry.rotors[3].position(1) = 1.0f;
+	geometry.rotors[3].position(2) = 0.0f;
+	geometry.rotors[3].axis(0) = 0.0f;
+	geometry.rotors[3].axis(1) = 0.0f;
+	geometry.rotors[3].axis(2) = -1.0f;
+	geometry.rotors[3].thrust_coef = 1.0f;
+	geometry.rotors[3].moment_ratio = -0.05f;
+
+	geometry.num_rotors = 4;
+
+	return geometry;
+}
+
+ActuatorEffectiveness::EffectivenessMatrix make_quad_effectiveness() {
+	ActuatorEffectiveness::EffectivenessMatrix effectiveness;
+	effectiveness.setZero();
+	const auto geometry = make_quad_geometry();
+	ActuatorEffectivenessRotors::computeEffectivenessMatrix(geometry, effectiveness);
+	return effectiveness;
+}
+
+} // namespace
+
+// This tests that yaw-only control setpoint at zero actuator setpoint results in zero actuator
+// allocation.
+TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledOnlyYaw)
+{
+	ControlAllocationSequentialDesaturation method;
+
+	const auto effectiveness = make_quad_effectiveness();
+	matrix::Vector<float, ActuatorEffectiveness::NUM_ACTUATORS> actuator_trim;
+	matrix::Vector<float, ActuatorEffectiveness::NUM_ACTUATORS> linearization_point;
+	constexpr bool UPDATE_NORMALIZATION_SCALE{false};
+	method.setEffectivenessMatrix(
+		effectiveness,
+		actuator_trim,
+		linearization_point,
+		ActuatorEffectiveness::NUM_ACTUATORS,
+		UPDATE_NORMALIZATION_SCALE
+	);
+
+	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
+	control_sp(ControlAxis::ROLL) = 0;
+	control_sp(ControlAxis::PITCH) = 0;
+	control_sp(ControlAxis::YAW) = 1;
+	control_sp(ControlAxis::THRUST_X) = 0;
+	control_sp(ControlAxis::THRUST_Y) = 0;
+	control_sp(ControlAxis::THRUST_Z) = 0;
+	method.setControlSetpoint(control_sp);
+
+	// Since MC_AIRMODE was not set explicitly, assume airmode is disabled.
+	method.allocate();
+
+	const auto &actuator_sp = method.getActuatorSetpoint()
+	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> zero;
+	EXPECT_EQ(actuator_sp, zero);
+ /*
+	matrix::Vector<float, 6> control_sp;
+	matrix::Vector<float, 6> control_allocated;
+	matrix::Vector<float, 6> control_allocated_expected;
+	matrix::Matrix<float, 6, 16> effectiveness;
+	matrix::Vector<float, 16> actuator_sp;
+	matrix::Vector<float, 16> linearization_point;
+	matrix::Vector<float, 16> actuator_sp_expected;
+
+	method.setEffectivenessMatrix(effectiveness, actuator_trim, linearization_point, 16, false);
+	method.setControlSetpoint(control_sp);
+	method.allocate();
+	method.clipActuatorSetpoint();
+	actuator_sp = method.getActuatorSetpoint();
+	control_allocated_expected = method.getAllocatedControl();
+
+	EXPECT_EQ(actuator_sp, actuator_sp_expected);
+	EXPECT_EQ(control_allocated, control_allocated_expected);
+ */
+}

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -44,10 +44,12 @@
 
 using namespace matrix;
 
-namespace {
+namespace
+{
 
 // Makes and returns a Geometry object for a "standard" quadcopter.
-ActuatorEffectivenessRotors::Geometry make_quad_geometry() {
+ActuatorEffectivenessRotors::Geometry make_quad_geometry()
+{
 	ActuatorEffectivenessRotors::Geometry geometry = {};
 	geometry.rotors[0].position(0) = 1.0f;
 	geometry.rotors[0].position(1) = 1.0f;
@@ -91,7 +93,8 @@ ActuatorEffectivenessRotors::Geometry make_quad_geometry() {
 }
 
 // Returns an effective matrix for a sample quad-copter configuration.
-ActuatorEffectiveness::EffectivenessMatrix make_quad_effectiveness() {
+ActuatorEffectiveness::EffectivenessMatrix make_quad_effectiveness()
+{
 	ActuatorEffectiveness::EffectivenessMatrix effectiveness;
 	effectiveness.setZero();
 	const auto geometry = make_quad_geometry();
@@ -100,7 +103,8 @@ ActuatorEffectiveness::EffectivenessMatrix make_quad_effectiveness() {
 }
 
 // Configures a ControlAllocationSequentialDesaturation object for a sample quad-copter.
-void setup_quad_allocator(ControlAllocationSequentialDesaturation &allocator) {
+void setup_quad_allocator(ControlAllocationSequentialDesaturation &allocator)
+{
 	const auto effectiveness = make_quad_effectiveness();
 	matrix::Vector<float, ActuatorEffectiveness::NUM_ACTUATORS> actuator_trim;
 	matrix::Vector<float, ActuatorEffectiveness::NUM_ACTUATORS> linearization_point;
@@ -115,7 +119,8 @@ void setup_quad_allocator(ControlAllocationSequentialDesaturation &allocator) {
 }
 
 // Returns true if the 2 input values are within TOLERANCE of each other.
-bool is_similar(float a, float b) {
+bool is_similar(float a, float b)
+{
 	constexpr float TOLERANCE{1e-4};
 	const auto diff = std::abs(a - b);
 	return diff <= TOLERANCE;
@@ -148,7 +153,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledOnlyYaw)
 
 // This tests that a control setpoint for z-thrust returns the desired actuator setpoint.
 // Each motor should have an actuator setpoint that when summed together should be equal to
-// control setpoint. 
+// control setpoint.
 TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustZ)
 {
 	ControlAllocationSequentialDesaturation allocator;
@@ -169,9 +174,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustZ)
 
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	constexpr float THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / 4};
+
 	for (size_t i{0}; i < 4; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), THRUST_Z_PER_MOTOR));
 	}
+
 	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), 0));
 	}
@@ -202,16 +209,19 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndYaw)
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	// This value is based off of the effectiveness matrix. If the effectiveness matrix is changed,
 	// this will need to be changed.
-	constexpr float YAW_DIFF_PER_MOTOR{YAW_CONTROL_SP * 5}; 
+	constexpr float YAW_DIFF_PER_MOTOR{YAW_CONTROL_SP * 5};
 	// At yaw condition, there will be 2 different actuator values.
 	constexpr float HIGH_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / 4 + YAW_DIFF_PER_MOTOR};
 	constexpr float LOW_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / 4 - YAW_DIFF_PER_MOTOR};
+
 	for (size_t i{0}; i < 2; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), HIGH_THRUST_Z_PER_MOTOR));
 	}
+
 	for (size_t i{2}; i < 4; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), LOW_THRUST_Z_PER_MOTOR));
 	}
+
 	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), 0));
 	}
@@ -242,9 +252,11 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndSatura
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	// At max yaw, only 2 motors will carry all of the thrust.
 	constexpr float THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / 2};
+
 	for (size_t i{0}; i < 2; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), THRUST_Z_PER_MOTOR));
 	}
+
 	for (size_t i{2}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), 0));
 	}
@@ -259,7 +271,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
 	// Negative, because +z is "downward".
 	constexpr float THRUST_Z_TOTAL{-0.75};
-	// This is low enough to not saturate the motors. 
+	// This is low enough to not saturate the motors.
 	constexpr float PITCH_CONTROL_SP{0.1};
 	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
 	control_sp(ControlAllocation::ControlAxis::PITCH) = PITCH_CONTROL_SP;
@@ -275,7 +287,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	// This value is based off of the effectiveness matrix. If the effectiveness matrix is changed,
 	// this will need to be changed.
-	constexpr float PITCH_DIFF_PER_MOTOR{PITCH_CONTROL_SP / 4}; 
+	constexpr float PITCH_DIFF_PER_MOTOR{PITCH_CONTROL_SP / 4};
 	// At control set point, there will be 2 different actuator values.
 	constexpr float HIGH_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / 4 + PITCH_DIFF_PER_MOTOR};
 	constexpr float LOW_THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / 4 - PITCH_DIFF_PER_MOTOR};
@@ -283,6 +295,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustAndPitch)
 	EXPECT_TRUE(is_similar(actuator_sp(1), LOW_THRUST_Z_PER_MOTOR));
 	EXPECT_TRUE(is_similar(actuator_sp(2), HIGH_THRUST_Z_PER_MOTOR));
 	EXPECT_TRUE(is_similar(actuator_sp(3), LOW_THRUST_Z_PER_MOTOR));
+
 	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), 0));
 	}
@@ -313,7 +326,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
 	// In the case of yaw saturation, thrust per motor will be reduced by the hard-coded
-	// magic-number yaw margin of 0.15f. 
+	// magic-number yaw margin of 0.15f.
 	constexpr float YAW_MARGIN{0.15f}; // get this from a centralized source when available.
 	constexpr float YAW_DIFF_PER_MOTOR{1.0f + YAW_MARGIN - DESIRED_THRUST_Z_PER_MOTOR};
 	// At control set point, there will be 2 different actuator values.
@@ -323,6 +336,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	EXPECT_TRUE(is_similar(actuator_sp(1), HIGH_THRUST_Z_PER_MOTOR));
 	EXPECT_TRUE(is_similar(actuator_sp(2), LOW_THRUST_Z_PER_MOTOR));
 	EXPECT_TRUE(is_similar(actuator_sp(3), LOW_THRUST_Z_PER_MOTOR));
+
 	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), 0));
 	}
@@ -337,7 +351,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	matrix::Vector<float, ActuatorEffectiveness::NUM_AXES> control_sp;
 	// Negative, because +z is "downward".
 	constexpr float THRUST_Z_TOTAL{-0.75 * 4};
-	// This is high enough to saturate the pitch control. 
+	// This is high enough to saturate the pitch control.
 	constexpr float PITCH_CONTROL_SP{2};
 	control_sp(ControlAllocation::ControlAxis::ROLL) = 0;
 	control_sp(ControlAllocation::ControlAxis::PITCH) = PITCH_CONTROL_SP;
@@ -362,6 +376,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledReducedThrustAn
 	EXPECT_TRUE(is_similar(actuator_sp(1), LOW_THRUST_Z_PER_MOTOR));
 	EXPECT_TRUE(is_similar(actuator_sp(2), HIGH_THRUST_Z_PER_MOTOR));
 	EXPECT_TRUE(is_similar(actuator_sp(3), LOW_THRUST_Z_PER_MOTOR));
+
 	for (size_t i{4}; i < ActuatorEffectiveness::NUM_ACTUATORS; ++i) {
 		EXPECT_TRUE(is_similar(actuator_sp(i), 0));
 	}

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturationTest.cpp
@@ -167,7 +167,7 @@ TEST(ControlAllocationSequentialDesaturationTest, AirmodeDisabledThrustZ)
 	allocator.allocate();
 
 	const auto &actuator_sp = allocator.getActuatorSetpoint();
-	constexpr float MOTOR_COUNT{4.f};
+	constexpr int MOTOR_COUNT{4};
 	constexpr float THRUST_Z_PER_MOTOR{-THRUST_Z_TOTAL / MOTOR_COUNT};
 
 	for (size_t i{0}; i < 4; ++i) {


### PR DESCRIPTION
### Solved Problem
Unit tests for ControlAllocationSequentialDesaturation. No code changes are made to any existing library, this only adds unit tests. The unit tests serve 2 purposes: 1) help ensure that expected functionality remains the same and 2) documents and demonstrates (through examples) the desaturation algorithm.