### PR TITLE
Integration tests for external navigation interface

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -20,6 +20,9 @@ publications:
   - topic: /fmu/out/collision_constraints
     type: px4_msgs::msg::CollisionConstraints
 
+  - topic: /fmu/out/estimator_status_flags
+    type: px4_msgs::msg::EstimatorStatusFlags
+
   - topic: /fmu/out/failsafe_flags
     type: px4_msgs::msg::FailsafeFlags
 

--- a/test/ros_tests/config.json
+++ b/test/ros_tests/config.json
@@ -6,8 +6,26 @@
         {
             "model": "iris",
             "vehicle": "iris",
-            "test_filter": "*",
+            "test_filter": "ModesTest.*",
             "timeout_min": 10
+        },
+        {
+            "model": "iris",
+            "vehicle": "iris",
+            "test_filter": "LocalPositionInterfaceTest.*",
+            "timeout_min": 10,
+            "env": {
+                "PX4_PARAM_EKF2_EV_CTRL": 15
+            }
+        },
+        {
+            "model": "iris",
+            "vehicle": "iris",
+            "test_filter": "GlobalPositionInterfaceTest.*",
+            "timeout_min": 10,
+            "env": {
+                "PX4_PARAM_EKF2_AGP_CTRL": 1
+            }
         }
     ]
 }


### PR DESCRIPTION
This enables integration tests for the external navigation ros2 interface: https://github.com/Auterion/px4-ros2-interface-lib/pull/5

Adds `estimator_status_flags` to dds published topics, required for these integration tests.

- [ ] Requires https://github.com/PX4/PX4-Autopilot/pull/22494

