### PR TITLE
fmu-v6xrt: Change image size

### DIFF
--- a/boards/px4/fmu-v6xrt/firmware.prototype
+++ b/boards/px4/fmu-v6xrt/firmware.prototype
@@ -7,7 +7,7 @@
     "summary": "PX4FMUv6XRT",
     "version": "0.1",
     "image_size": 0,
-    "image_maxsize": 7340032,
+    "image_maxsize": 4063232,
     "git_identity": "",
     "board_revision": 0
 }


### PR DESCRIPTION
### Solved Problem

When uploading PIXHAWK6X-RT, the write flash size percentage was different.

### Solution

Change the flash size of PIXHAWK6X-RT to "4063232".

### Changelog Entry

None

### Alternatives

None

### Test coverage

The percentage of flash size at build time and the percentage of flash at upload time should be the same.　　Result: OK

### Context

AFTER
![Screenshot from 2024-01-13 06-44-49](https://github.com/PX4/PX4-Autopilot/assets/646194/d3b20a02-0538-447b-8879-dadfd5c8934e)


BEFORE

![Screenshot from 2024-01-13 06-43-24](https://github.com/PX4/PX4-Autopilot/assets/646194/f7a00b7d-a8ff-4d31-aed9-6df4587e5757)