### PR TITLE
Enable navsat plugin for accurate positioning of real life maps in Gazebo

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -42,14 +42,6 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" = "1" ]; then
 	echo "INFO  [init] Gazebo simulator"
 
 	# set local coordinate frame reference
-	if [ -n "${PX4_HOME_LAT}" ]; then
-		param set SIM_GZ_HOME_LAT ${PX4_HOME_LAT}
-	fi
-
-	if [ -n "${PX4_HOME_LON}" ]; then
-		param set SIM_GZ_HOME_LON ${PX4_HOME_LON}
-	fi
-
 	if [ -n "${PX4_HOME_ALT}" ]; then
 		param set SIM_GZ_HOME_ALT ${PX4_HOME_ALT}
 	fi

--- a/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
+++ b/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
@@ -41,11 +41,6 @@ elif [ "$PX4_SIMULATOR" = "gz" ] || [ "$(param show -q SIM_GZ_EN)" = "1" ]; then
 
 	echo "INFO  [init] Gazebo simulator"
 
-	# set local coordinate frame reference
-	if [ -n "${PX4_HOME_ALT}" ]; then
-		param set SIM_GZ_HOME_ALT ${PX4_HOME_ALT}
-	fi
-
 	# Only start up Gazebo if PX4_GZ_STANDALONE is not set.
 	if [ -z "${PX4_GZ_STANDALONE}" ]; then
 

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -718,9 +718,11 @@ void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 	pthread_mutex_lock(&_node_mutex);
 
 	const uint64_t time_us = (nav_sat.header().stamp().sec() * 1000000) + (nav_sat.header().stamp().nsec() / 1000);
+
 	if (time_us > _world_time_us.load()) {
 		updateClock(nav_sat.header().stamp().sec(), nav_sat.header().stamp().nsec());
 	}
+
 	_timestamp_prev = time_us;
 
 	double latitude_deg = nav_sat.latitude_deg();

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -217,7 +217,8 @@ int GZBridge::init()
 	}
 
 	// GPS: /world/$WORLD/model/$MODEL/link/base_link/sensor/navsat_sensor/navsat
-	std::string nav_sat_topic = "/world/" + _world_name + "/model/" + _model_name + "/link/base_link/sensor/navsat_sensor/navsat";
+	std::string nav_sat_topic = "/world/" + _world_name + "/model/" + _model_name +
+								"/link/base_link/sensor/navsat_sensor/navsat";
 
 	if (!_node.Subscribe(nav_sat_topic, &GZBridge::navSatCallback, this)) {
 		PX4_ERR("failed to subscribe to %s", nav_sat_topic.c_str());
@@ -727,7 +728,7 @@ void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 	double altitude = nav_sat.altitude();
 
 	// initialize gps position
-	if(!_pos_ref.isInitialized()) {
+	if (!_pos_ref.isInitialized()) {
 		_pos_ref.initReference(latitude_deg, longitude_deg, hrt_absolute_time());
 		_alt_ref = altitude;
 	}

--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -218,7 +218,7 @@ int GZBridge::init()
 
 	// GPS: /world/$WORLD/model/$MODEL/link/base_link/sensor/navsat_sensor/navsat
 	std::string nav_sat_topic = "/world/" + _world_name + "/model/" + _model_name +
-								"/link/base_link/sensor/navsat_sensor/navsat";
+				    "/link/base_link/sensor/navsat_sensor/navsat";
 
 	if (!_node.Subscribe(nav_sat_topic, &GZBridge::navSatCallback, this)) {
 		PX4_ERR("failed to subscribe to %s", nav_sat_topic.c_str());

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -140,7 +140,7 @@ private:
 	pthread_mutex_t _node_mutex;
 
 	MapProjection _pos_ref{};
-	double _alt_ref{};
+	double _alt_ref{}; // starting altitude reference
 
 	matrix::Vector3d _position_prev{};
 	matrix::Vector3d _velocity_prev{};
@@ -155,8 +155,4 @@ private:
 	float _temperature{288.15};  // 15 degrees
 
 	gz::transport::Node _node;
-
-	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::SIM_GZ_HOME_ALT>) _param_sim_home_alt
-	)
 };

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -105,6 +105,7 @@ private:
 	void imuCallback(const gz::msgs::IMU &imu);
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);
 	void odometryCallback(const gz::msgs::OdometryWithCovariance &odometry);
+	void navSatCallback(const gz::msgs::NavSat &nav_sat);
 
 	/**
 	*
@@ -139,6 +140,7 @@ private:
 	pthread_mutex_t _node_mutex;
 
 	MapProjection _pos_ref{};
+	double _alt_ref{};
 
 	matrix::Vector3d _position_prev{};
 	matrix::Vector3d _velocity_prev{};
@@ -155,8 +157,6 @@ private:
 	gz::transport::Node _node;
 
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::SIM_GZ_HOME_LAT>) _param_sim_home_lat,
-		(ParamFloat<px4::params::SIM_GZ_HOME_LON>) _param_sim_home_lon,
 		(ParamFloat<px4::params::SIM_GZ_HOME_ALT>) _param_sim_home_alt
 	)
 };

--- a/src/modules/simulation/gz_bridge/parameters.c
+++ b/src/modules/simulation/gz_bridge/parameters.c
@@ -40,10 +40,3 @@
  */
 PARAM_DEFINE_INT32(SIM_GZ_EN, 0);
 
-/**
- * simulator origin altitude
- *
- * @unit m
- * @group Simulator
- */
-PARAM_DEFINE_FLOAT(SIM_GZ_HOME_ALT, 488.0);

--- a/src/modules/simulation/gz_bridge/parameters.c
+++ b/src/modules/simulation/gz_bridge/parameters.c
@@ -41,22 +41,6 @@
 PARAM_DEFINE_INT32(SIM_GZ_EN, 0);
 
 /**
- * simulator origin latitude
- *
- * @unit deg
- * @group Simulator
- */
-PARAM_DEFINE_FLOAT(SIM_GZ_HOME_LAT, 47.397742f);
-
-/**
- * simulator origin longitude
- *
- * @unit deg
- * @group Simulator
- */
-PARAM_DEFINE_FLOAT(SIM_GZ_HOME_LON, 8.545594);
-
-/**
  * simulator origin altitude
  *
  * @unit m


### PR DESCRIPTION
This addition allows one to accurately position a vehicle based real life coordinates provided in a Gazebo world sdf file. It requires  the use of the `<spherical_coordinates> tag in world sdf files (as well as the navsat plugin) and the use of 

```
<sensor name="navsat_sensor" type="navsat">
        <always_on>1</always_on>
        <update_rate>30</update_rate>
      </sensor>
```
as a sensor in the model sdf file. 

The screenshot below shows the center of Turin and the respective position of an x500 on QGC. 

![image](https://github.com/PX4/PX4-Autopilot/assets/80588263/a8d47ce8-86a3-4676-9c62-5d3dd328d653)
