### PR TITLE
Update compile_nuttx.yml

### DIFF
--- a/.github/workflows/compile_nuttx.yml
+++ b/.github/workflows/compile_nuttx.yml
@@ -48,6 +48,7 @@ jobs:
           matek_h743-slim,
           modalai_fc-v1,
           modalai_fc-v2,
+          mro_ctrl-zero-classic,
           mro_ctrl-zero-f7,
           mro_ctrl-zero-f7-oem,
           mro_ctrl-zero-h7,


### PR DESCRIPTION
Add mro_ctrl-zero-classic

### Solved Problem
Missing board added into NuttX workflow


