### PR TITLE
mc_att_control: remove direct setting of att sp in Stabilized

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -192,14 +192,6 @@ MulticopterAttitudeControl::generate_attitude_setpoint(const Quatf &q, float dt,
 
 	attitude_setpoint.timestamp = hrt_absolute_time();
 	_vehicle_attitude_setpoint_pub.publish(attitude_setpoint);
-
-	// update attitude controller setpoint immediately (don't do it in vtol transition, then the VTOL module generates the attitude setpoint)
-	if (!_vtol_in_transition_mode) {
-		_attitude_control.setAttitudeSetpoint(q_sp, attitude_setpoint.yaw_sp_move_rate);
-		_thrust_setpoint_body = Vector3f(attitude_setpoint.thrust_body);
-	}
-
-	_last_attitude_setpoint = attitude_setpoint.timestamp;
 }
 
 void

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -226,34 +226,6 @@ MulticopterAttitudeControl::Run()
 
 		const Quatf q{v_att.q};
 
-		// Check for new attitude setpoint
-		if (_vehicle_attitude_setpoint_sub.updated()) {
-			vehicle_attitude_setpoint_s vehicle_attitude_setpoint;
-
-			if (_vehicle_attitude_setpoint_sub.copy(&vehicle_attitude_setpoint)
-			    && (vehicle_attitude_setpoint.timestamp > _last_attitude_setpoint)) {
-
-				_attitude_control.setAttitudeSetpoint(Quatf(vehicle_attitude_setpoint.q_d), vehicle_attitude_setpoint.yaw_sp_move_rate);
-				_thrust_setpoint_body = Vector3f(vehicle_attitude_setpoint.thrust_body);
-				_last_attitude_setpoint = vehicle_attitude_setpoint.timestamp;
-			}
-		}
-
-		// Check for a heading reset
-		if (_quat_reset_counter != v_att.quat_reset_counter) {
-			const Quatf delta_q_reset(v_att.delta_q_reset);
-
-			// for stabilized attitude generation only extract the heading change from the delta quaternion
-			_man_yaw_sp = wrap_pi(_man_yaw_sp + Eulerf(delta_q_reset).psi());
-
-			if (v_att.timestamp > _last_attitude_setpoint) {
-				// adapt existing attitude setpoint unless it was generated after the current attitude estimate
-				_attitude_control.adaptAttitudeSetpoint(delta_q_reset);
-			}
-
-			_quat_reset_counter = v_att.quat_reset_counter;
-		}
-
 		/* check for updates in other topics */
 		_manual_control_setpoint_sub.update(&_manual_control_setpoint);
 		_vehicle_control_mode_sub.update(&_vehicle_control_mode);
@@ -295,7 +267,8 @@ MulticopterAttitudeControl::Run()
 		// vehicle is a tailsitter in transition mode
 		const bool is_tailsitter_transition = (_vtol_tailsitter && _vtol_in_transition_mode);
 
-		bool run_att_ctrl = _vehicle_control_mode.flag_control_attitude_enabled && (is_hovering || is_tailsitter_transition);
+		const bool run_att_ctrl = _vehicle_control_mode.flag_control_attitude_enabled && (is_hovering
+					  || is_tailsitter_transition);
 
 		if (run_att_ctrl) {
 
@@ -311,6 +284,34 @@ MulticopterAttitudeControl::Run()
 			} else {
 				_man_roll_input_filter.reset(0.f);
 				_man_pitch_input_filter.reset(0.f);
+			}
+
+			// Check for new attitude setpoint
+			if (_vehicle_attitude_setpoint_sub.updated()) {
+				vehicle_attitude_setpoint_s vehicle_attitude_setpoint;
+
+				if (_vehicle_attitude_setpoint_sub.copy(&vehicle_attitude_setpoint)
+				    && (vehicle_attitude_setpoint.timestamp > _last_attitude_setpoint)) {
+
+					_attitude_control.setAttitudeSetpoint(Quatf(vehicle_attitude_setpoint.q_d), vehicle_attitude_setpoint.yaw_sp_move_rate);
+					_thrust_setpoint_body = Vector3f(vehicle_attitude_setpoint.thrust_body);
+					_last_attitude_setpoint = vehicle_attitude_setpoint.timestamp;
+				}
+			}
+
+			// Check for a heading reset
+			if (_quat_reset_counter != v_att.quat_reset_counter) {
+				const Quatf delta_q_reset(v_att.delta_q_reset);
+
+				// for stabilized attitude generation only extract the heading change from the delta quaternion
+				_man_yaw_sp = wrap_pi(_man_yaw_sp + Eulerf(delta_q_reset).psi());
+
+				if (v_att.timestamp > _last_attitude_setpoint) {
+					// adapt existing attitude setpoint unless it was generated after the current attitude estimate
+					_attitude_control.adaptAttitudeSetpoint(delta_q_reset);
+				}
+
+				_quat_reset_counter = v_att.quat_reset_counter;
 			}
 
 			Vector3f rates_sp = _attitude_control.update(q);


### PR DESCRIPTION
Currently in the MC attitude controller, in Stabilized mode, the generated attitude setpoints are copied inside the module to where they are used (plus also published over uORB). 
Here I propose to remove this internal copying and only publish it to the uorb topic, which is subscribed to in the same module.

This "should" have no behavior change - unless we deem the passing of the attitude setpoint over uorb less stable and want to keep the internal copying of it through `setAttitudeSetpoint()`. I propose this change to be able to remove the "if(vtol_transition)" and keep the controller flows as consistent as possible. 

Context: https://github.com/PX4/PX4-Autopilot/pull/22584#discussion_r1453376530

FYI @MaEtUgR 
