### PR TITLE
ci: disable GPS fusion when testing external local nav

### DIFF
--- a/test/ros_tests/config.json
+++ b/test/ros_tests/config.json
@@ -15,6 +15,7 @@
             "test_filter": "LocalPositionInterfaceTest.*",
             "timeout_min": 10,
             "env": {
+                "PX4_EKF2_GPS_CTRL": 0,
                 "PX4_PARAM_EKF2_EV_CTRL": 15
             }
         },


### PR DESCRIPTION
ROS Integration Tests are passing here