### PR TITLE
Update cmake-variants.yaml

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -71,6 +71,26 @@ CONFIG:
       buildType: MinSizeRel
       settings:
         CONFIG: px4_fmu-v5x_default
+    px4_fmu-v6c_default:
+      short: px4_fmu-v6c
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_fmu-v6c_default
+    px4_fmu-v6c_bootloader:
+      short: px4_fmu-v6c_bootloader
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_fmu-v6c_bootloader
+    px4_fmu-v6u_default:
+      short: px4_fmu-v6u
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_fmu-v6u_default
+    px4_fmu-v6u_bootloader:
+      short: px4_fmu-v6u_bootloader
+      buildType: MinSizeRel
+      settings:
+        CONFIG: px4_fmu-v6u_bootloader
     px4_fmu-v6x_default:
       short: px4_fmu-v6x
       buildType: MinSizeRel


### PR DESCRIPTION
### Solved Problem
**When** looking for the `px4_fmu-v6c` target **I found that** it was not present in the `cmake-variants.yaml` list

### Solution
Added the following targets:
- px4_fmu-v6c_bootloader
- px4_fmu-v6c[_default]
- px4_fmu-v6u_bootloader
- px4_fmu-v6u[_default]

### Changelog Entry
For release notes:
```
New parameters: px4_fmu-v6c_bootloader, px4_fmu-v6c[_default], px4_fmu-v6u_bootloader, px4_fmu-v6u[_default]
```

### Alternatives
N/A

### Test coverage
N/A

### Context
N/A
