### PR TITLE
fix navigator: prevent race condition when receiving multiple commands at once

### DIFF
--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -335,6 +335,8 @@ private:
 	GeofenceBreachAvoidance _gf_breach_avoidance;
 	hrt_abstime _last_geofence_check = 0;
 
+	hrt_abstime _wait_for_vehicle_status_timestamp{0}; /**< If non-zero, wait for vehicle_status update before processing next cmd */
+
 	bool		_geofence_reposition_sent{false};		/**< flag if reposition command has been sent for current geofence breach*/
 	hrt_abstime	_time_loitering_after_gf_breach{0};		/**< timestamp of when loitering after a geofence breach was started */
 	bool		_pos_sp_triplet_updated{false};			/**< flags if position SP triplet needs to be published */


### PR DESCRIPTION
When handling multiple commands, it could happen that the first command updates _reposition_triplet. Normally this would then get handled after getting the mode change from commander through vehicle_status. But if the next command is handled before an update from commander, it could overwrite the triplet.
This patch ensures that navigator waits for an update from commander (and therefore process the _reposition_triplet) before handling the next command.

This happened specifically when pressing 'Pause' from QGC during a mission. QGC sends VEHICLE_CMD_DO_REPOSITION twice, first for pausing, then changing the altitude.
The result was that the vehicle would not stop at the current location but continue to the next mission waypoint and stop there.

Fixes https://github.com/PX4/PX4-Autopilot/issues/22492

Thanks to @Drone-Lab for the investigation and testing.