### PR TITLE
Minor fixes in magnetometer temperature compensation

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.thermal_cal
+++ b/ROMFS/px4fmu_common/init.d/rc.thermal_cal
@@ -22,6 +22,11 @@ then
 	set TEMP_COMP_START "true"
 fi
 
+if param compare -s TC_M_ENABLE 1
+then
+	set TEMP_COMP_START "true"
+fi
+
 if [ "x$TEMP_COMP_START" != "x" ]
 then
 	temperature_compensation start

--- a/src/modules/temperature_compensation/temperature_calibration/mag.cpp
+++ b/src/modules/temperature_compensation/temperature_calibration/mag.cpp
@@ -163,10 +163,10 @@ int TemperatureCalibrationMag::finish()
 	}
 
 	int32_t enabled = 1;
-	int result = param_set_no_notification(param_find("TC_A_ENABLE"), &enabled);
+	int result = param_set_no_notification(param_find("TC_M_ENABLE"), &enabled);
 
 	if (result != PX4_OK) {
-		PX4_ERR("unable to reset TC_A_ENABLE (%i)", result);
+		PX4_ERR("unable to reset TC_M_ENABLE (%i)", result);
 	}
 
 	return result;


### PR DESCRIPTION
This fix if only `TC_M_ENABLE` is enabled but not any other parameter, temperature_compensation  will not start.
It also renames `TC_A_ENABLE` to `TC_M_ENABLE` inside `temperature_calibration/mag.cpp`

@mcsauder can you have a look if this makes sense? 