### PR TITLE
sys-id: implement linear and log sine sweeps

### DIFF
--- a/src/lib/system_identification/signal_generator.hpp
+++ b/src/lib/system_identification/signal_generator.hpp
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file signal_generator.hpp
+ */
+
+#pragma once
+
+namespace signal_generator
+{
+
+float getLinearSineSweep(float f_start, float f_end, float duration, float t)
+{
+	if (t > duration) {
+		return 0.f;
+	}
+
+	const float w_start = f_start * M_TWOPI_F;
+	const float w_end = f_end * M_TWOPI_F;
+
+	return sinf(w_start * t + 0.5f * (w_end - w_start) * t * t / duration);
+}
+
+float getLogSineSweep(float f_start, float f_end, float duration, float t)
+{
+	if (t > duration) {
+		return 0.f;
+	}
+
+	const float f_ratio = f_end / fmaxf(f_start, 0.1f);
+
+	return sinf(M_TWOPI_F * f_start * duration * (powf(f_ratio, t / duration) - 1.f) / logf(f_ratio));
+}
+
+} /* namespace signal_generator */


### PR DESCRIPTION
Ref: https://www.recordingblogs.com/wiki/sine-sweep

To be used in 
- https://github.com/PX4/PX4-Autopilot/pull/22666 (auto-tune Fixed-wing)
- https://github.com/PX4/PX4-Autopilot/pull/21857 (auto-tune MC)

Linear sweep:
![Screenshot from 2024-01-24 14-47-13](https://github.com/PX4/PX4-Autopilot/assets/14822839/c9ee2060-a719-46a5-9ba7-ad4b4e518d7f)

Log sweep:
![Screenshot from 2024-01-24 14-48-33](https://github.com/PX4/PX4-Autopilot/assets/14822839/6a664176-215d-4902-b116-e9d54f3be578)

