### PR TITLE
Allow ignoring loss of non-essential stick input in external modes

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -670,13 +670,14 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 /**
  * RC loss exceptions
  *
- * Specify modes in which RC loss is ignored and the failsafe action not triggered.
+ * Specify modes in which the loss of non-essential stick input is ignored and no failsafe action is triggered.
  *
  * @min 0
  * @max 31
  * @bit 0 Mission
  * @bit 1 Hold
  * @bit 2 Offboard
+ * @bit 3 External Mode
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RCL_EXCEPT, 0);

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -388,13 +388,24 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 					     && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Mission);
 	const bool rc_loss_ignored_loiter = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER
 					    && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Hold);
-	const bool rc_loss_ignored_offboard = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_OFFBOARD
-					      && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Offboard);
 	const bool rc_loss_ignored_takeoff = (state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF ||
 					      state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
 					     && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Hold);
-	const bool rc_loss_ignored = rc_loss_ignored_mission || rc_loss_ignored_loiter || rc_loss_ignored_offboard ||
-				     rc_loss_ignored_takeoff || ignore_link_failsafe || _manual_control_lost_at_arming;
+	const bool rc_loss_ignored_offboard = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_OFFBOARD
+					      && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Offboard);
+	const bool rc_loss_ignored_external_mode =
+		(state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL1 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL2 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL3 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL4 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL5 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL6 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL7 ||
+		 state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_EXTERNAL8)
+		&& (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::ExternalMode);
+
+	const bool rc_loss_ignored = rc_loss_ignored_mission || rc_loss_ignored_loiter || rc_loss_ignored_takeoff
+				     || rc_loss_ignored_offboard || rc_loss_ignored_external_mode || ignore_link_failsafe || _manual_control_lost_at_arming;
 
 	if (_param_com_rc_in_mode.get() != int32_t(RcInMode::StickInputDisabled) && !rc_loss_ignored) {
 		CHECK_FAILSAFE(status_flags, manual_control_signal_lost,

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -56,7 +56,8 @@ private:
 	enum class ManualControlLossExceptionBits : int32_t {
 		Mission = (1 << 0),
 		Hold = (1 << 1),
-		Offboard = (1 << 2)
+		Offboard = (1 << 2),
+		ExternalMode = (1 << 3)
 	};
 
 	// COM_LOW_BAT_ACT parameter values


### PR DESCRIPTION
### Solved Problem
@fury1895 found that it's currently not possible to ignore non-essential stick input in external modes. The external mode could implement a mission that's supposed to fly out of RC link reception but RC is still used for takeoff and landing.

### Solution
I suggest allowing to ignore RC loss using `COM_RCL_EXCEPT` to enable such a specific use case.

### Changelog Entry
```
Feature: Allow ignoring loss of non-essential stick input in external modes
```

### Alternatives
I couldn't think of a scalable way to do this per external mode.

### Test coverage
Not tested yet.
@fury1895 Please test at least two cases when the option is configured:
- External mode that doesn't require stick input doesn't failsafe upon loss of previously available stick input
- External mode that *requires* stick input failsafes upon loss of stick input