### PR TITLE
FlightTaskAuto: Limit land nudging horizontal speed close to the ground

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -281,6 +281,12 @@ void FlightTaskAuto::_prepareLandSetpoints()
 			sticks_xy.setZero();
 		}
 
+		// If ground distance estimate valid (distance sensor) during nudging then limit horizontal speed
+		if (PX4_ISFINITE(_dist_to_bottom)) {
+			// Below 50cm no horizontal speed, above allow per meter altitude 0.5m/s speed
+			max_speed = math::max(0.f, math::min(max_speed, (_dist_to_bottom - .5f) * .5f));
+		}
+
 		_stick_acceleration_xy.setVelocityConstraint(max_speed);
 		_stick_acceleration_xy.generateSetpoints(sticks_xy, _yaw, _land_heading, _position,
 				_velocity_setpoint_feedback.xy(), _deltatime);


### PR DESCRIPTION
### Solved Problem
@RomanBapst reported that on a frame with brittle landing gear it's crucial to have zero speed at touch down. Since the frame is only ever influenced manually when nudging we discussed it could be made more idiot-proof in a way that the horizontal nudging is limited in speed when you get close to the ground.

### Solution
If the ground distance estimate is valid then during nudging the speed gets limited the closer the vehicle flies to the ground.
The logic is to not allow horizontal nudging below 50cm altitude above ground and above that allow half the speed in m/s of the altitude in meters e.g.

|Altitude|Horizontal speed with full stick input|
|-|-|
|0m|0m/s|
|0.5m|0m/s|
|1.5m|0.5m/s|
|2.5m|1m/s|
|3.5m|1.5m/s|
|4.5m|2m/s|

### Changelog Entry
```
Feature: Limit land nudging horizontal speed close to the ground
```

### Test coverage
To test you need:
1. `COM_RC_OVERRIDE 0` (or untick all the boxes in the UI)
1. `MPC_LAND_RC_HELP 1` (Nudging enabled in the UI)

I simulation tested with gazebo classic iris with a distance sensor:
https://github.com/PX4/PX4-Autopilot/assets/4668506/c6e0f6ce-8724-4037-aa1c-18e2021981d8
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/be624bb5-e552-4eda-bbc9-ea0258eea585)
