### PR TITLE
ICP201: increase startup delay with B2 version

### DIFF
--- a/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
+++ b/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
@@ -144,7 +144,7 @@ ICP201XX::RunImpl()
 			if (version == 0xB2) {
 				/* B2 version Asic is detected. Boot up sequence is not required for B2 Asic, so returning */
 				_state = STATE::CONFIG;
-				ScheduleDelayed(10_ms);
+				ScheduleDelayed(30_ms);
 			}
 
 			/* Read boot up status and avoid re running boot up sequence if it is already done */


### PR DESCRIPTION
Fixes wrong altitude reporting trough barometer with the ICP201XX B2 version sensor by InvenSense.