### PR TITLE
Tiltrotor: disable MC yaw fade out during front transition blending

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -245,10 +245,8 @@ void Tiltrotor::update_transition_state()
 
 		if (_param_fw_use_airspd.get()  && PX4_ISFINITE(_airspeed_validated->calibrated_airspeed_m_s) &&
 		    _airspeed_validated->calibrated_airspeed_m_s >= getBlendAirspeed()) {
-			const float weight = 1.0f - (_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
-					     (getTransitionAirspeed()  - getBlendAirspeed());
-			_mc_roll_weight = weight;
-			_mc_yaw_weight = weight;
+			_mc_roll_weight = 1.0f - (_airspeed_validated->calibrated_airspeed_m_s - getBlendAirspeed()) /
+					  (getTransitionAirspeed()  - getBlendAirspeed());
 		}
 
 		// without airspeed do timed weight changes
@@ -256,7 +254,6 @@ void Tiltrotor::update_transition_state()
 		    _time_since_trans_start > getMinimumFrontTransitionTime()) {
 			_mc_roll_weight = 1.0f - (_time_since_trans_start - getMinimumFrontTransitionTime()) /
 					  (getOpenLoopFrontTransitionTime() - getMinimumFrontTransitionTime());
-			_mc_yaw_weight = _mc_roll_weight;
 		}
 
 		// add minimum throttle for front transition


### PR DESCRIPTION
### Solved Problem
Vehicle yawing strongly during final phase of front transition.

### Solution
MC yaw control is faded out during the blending phase of a VTOL front transition. As there can be a quite high yawing torque acting on the system (eg due to asymmetric motor setup), and the fixed-wing yaw actuator is not fully effective yet (if it is existing at all), the vehicle yaws often to a side. 
The effect is specially noticeable on Tiltrotors because there the blending phase doesn't always end with the transition airspeed reached, as also the transition motor tilt has to be reached first. It can thus stay in a prolonged blending phase of multiple seconds.
I propose to remove the MC yaw fade out for Tiltrotor. For standard VTOLs I would keep it for now due to two reasons:
- blending phase can be precisely controlled (see last point above, tiltrotors also have the tilt requirement)
- standard VTOLs control yaw through differential thrust generally. There the fade out can be beneficial to reduce the drag generated by MC thrust.


### Changelog Entry
For release notes:
```
Improvement: VTOL Tiltrotor: disable MC yaw fade out during front transition blending
```

### Alternatives
We could maybe re-think the whole blending logic - is it even something we need? Eg the pitch is never blended on tiltrotors already.

### Test coverage
Tested on a tri-tiltrotor VTOL (see plots below).

### Context
Without this change: this vehicle (tri-copter tiltrotor) yaws strongly to the right when it enters the blending phase of a front transition. 
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/e89074a5-ec85-4867-822c-d3129a4cf035)


With this change: the yaw disturbance is lower because the controller keeps fighting the yaw rate error (see `torque_setpoint_0[2]`). 


