### PR TITLE
bat_sim: parameter for disabling battery simulator

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -248,7 +248,12 @@ then
 fi
 
 load_mon start
-battery_simulator start
+
+if param compare SIM_BAT_ENABLE 1
+then
+	battery_simulator start
+fi
+
 tone_alarm start
 rc_update start
 manual_control start

--- a/src/modules/simulation/battery_simulator/battery_simulator_params.c
+++ b/src/modules/simulation/battery_simulator/battery_simulator_params.c
@@ -32,6 +32,18 @@
  ****************************************************************************/
 
 /**
+ * Simulator Battery enabled
+ *
+ * Enable or disable the internal battery simulation. This is useful
+ * when the battery is simulated externally and interfaced with PX4
+ * through MAVLink for example.
+ *
+ * @boolean
+ * @group SITL
+ */
+PARAM_DEFINE_INT32(SIM_BAT_ENABLE, 1);
+
+/**
  * Simulator Battery drain interval
  *
  * @min 1


### PR DESCRIPTION
### Solved Problem
I would like to run a more complex battery simulation in a standalone application. This can currently be achieved by stopping PX4's internal battery simulator after a boot, and then sending [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) MAVLink messages.

This PR proposes a parameter that controls the startup of the internal battery simulator. When disabling the battery simulator, it removes the extra step necessary after each boot to stop the battery simulator. But it also produces consistent measurements for PX4, since there will then only be the battery messages coming in through MAVLink.

### Solution
- New parameter `SIM_BAT_ENABLE` that defaults to 1, but when set to 0 it won't start the internal battery simulator

### Changelog Entry
For release notes:
```
Feature Parameter for enabling/disabling PX4's internal battery simulator in SITL
New parameter: SIM_BAT_ENABLE
```

### Alternatives
Alternatively custom board configs for SITL would be required, where the battery_simulator is not launched. But that's not maintainable.

### Test coverage
- Tested in simulation with `make px4_sitl gz_x500`
- Tested external battery simulator by setting `SIM_BAT_ENABLE = 0`, and then sending [BATTERY_STATUS](https://mavlink.io/en/messages/common.html#BATTERY_STATUS) via MAVLink to PX4

