### PR TITLE
Added Zero Turn Lawnmower model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -41,11 +41,10 @@ param set-default SIM_GZ_WH_FUNC2 102 # left wheel
 
 param set-default SIM_GZ_WH_REV 0 # no need to reverse any wheels
 
-// Note: The servo configurations ( SIM_GZ_SV_FUNC*) outlined below are intended for educational purposes in this simulation. 
-// They do not have physical effects in the simulated environment, except for actuating the joints. Their definitions are meant to demonstrate 
-// how actuators could be mapped and configured in a real-world application, providing a foundation for understanding and implementing actuator 
-// controls in practical scenarios.
-
+# Note: The servo configurations ( SIM_GZ_SV_FUNC*) outlined below are intended for educational purposes in this simulation. 
+# They do not have physical effects in the simulated environment, except for actuating the joints. Their definitions are meant to demonstrate 
+# how actuators could be mapped and configured in a real-world application, providing a foundation for understanding and implementing actuator 
+# controls in practical scenarios.
 
 # Cutter deck blades clutch, PCA9685 servo channel 3,  "RC FLAPS" (406) - leftmost switch, or "Servo 3" (203):
 param set-default SIM_GZ_SV_FUNC3 203

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
@@ -1,0 +1,130 @@
+#!/bin/sh
+#
+# @name Gazebo lawnmower
+# @type Rover
+#
+
+export MYSCRIPTNAME="`pwd`/.../5005_gz_lawnmower"
+echo "----------------------------"
+echo "IP: starting " $MYSCRIPTNAME
+
+#. ${R}etc/init.d/rc.rover_defaults
+. ${R}etc/init.d/rc.rover_differential_defaults
+
+PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
+PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
+PX4_SIM_MODEL=${PX4_SIM_MODEL:=lawnmower}
+
+param set-default SIM_GZ_EN 1
+
+param set-default SENS_EN_GPSSIM 1
+param set-default SENS_EN_BAROSIM 0
+param set-default SENS_EN_MAGSIM 1
+# We can drive in manual mode when GPS check fails:
+param set-default COM_ARM_WO_GPS 1
+
+# -------------------
+
+# Enable debug data logging:
+# Data logging to "SD card" (~/px4wrk/log):
+# "0" = armed to disarmed
+param set SDLOG_MODE 0
+# Bit 5 - Debug. 123 = 0b01111011  163 = 0b10100011
+param set SDLOG_PROFILE 32
+
+param set-default MIS_TAKEOFF_ALT 0.01
+#param set-default NAV_ACC_RAD 0.5
+param set NAV_ACC_RAD 0.3000
+param set-default NAV_LOITER_RAD 2
+
+# Simulated GPS works at fix level 3:
+param set GND_GPS_MINFIX 3
+param set GND_TRACING_LEV 4
+
+# Define airframe for startup scripts and Control Allocation (a.k.a. Mixers) behavior:
+param set CA_AIRFRAME 6
+
+# Set Differential Drive Kinematics Library parameters:
+param set RDD_WHEEL_BASE 0.9
+param set RDD_WHEEL_RADIUS 0.22
+param set RDD_WHL_SPEED 10.0	# Maximum wheel speed rad/s
+
+# Lawnmower parameters to scale Differential Drive Kinematics output:
+param set-default RDD_THRUST_SC 1.0
+param set-default RDD_TORQUE_SC 3.0
+
+# set SITL motors/servos output parameters:
+
+# "Motors" - motor channels 0 (Right) and 1 (Left) - via Wheels GZ bridge:
+param set-default SIM_GZ_WH_FUNC1 201 # right wheel
+#param set-default SIM_GZ_WH_MIN1 0
+#param set-default SIM_GZ_WH_MAX1 200
+#param set-default SIM_GZ_WH_DIS1 100
+#param set-default SIM_GZ_WH_FAIL1 100
+
+param set-default SIM_GZ_WH_FUNC2 202 # left wheel
+#param set-default SIM_GZ_WH_MIN2 0
+#param set-default SIM_GZ_WH_MAX2 200
+#param set-default SIM_GZ_WH_DIS2 100
+#param set-default SIM_GZ_WH_FAIL2 100
+
+#param set-default SIM_GZ_WH_REV 1 # reverse right wheel (no need here)
+
+# "Motors" - motor channels 0 (Right) and 1 (Left) - via Servo GZ bridge:
+#param set-default SIM_GZ_SV_FUNC1 201 # right wheel
+#param set-default SIM_GZ_SV_MIN1 0
+#param set-default SIM_GZ_SV_MAX1 5000
+#param set-default SIM_GZ_SV_DIS1 2500
+#param set-default SIM_GZ_SV_FAIL1 2500
+
+#param set-default SIM_GZ_SV_FUNC2 202 # left wheel
+#param set-default SIM_GZ_SV_MIN2 0
+#param set-default SIM_GZ_SV_MAX2 5000
+#param set-default SIM_GZ_SV_DIS2 2500
+#param set-default SIM_GZ_SV_FAIL2 2500
+
+# mark motors as bi-directional here for each channel (bitmask, usually 3):
+param set CA_R_REV 0
+param set SIM_GZ_SV_REV 0
+param set SIM_GZ_WH_REV 0
+param set SIM_GZ_EC_REV 0 # Same bitmask, "useful only for servos":
+
+# Cutter deck blades clutch, PCA9685 servo channel 3,  "RC FLAPS" (406) - leftmost switch, or "Servo 3" (203):
+param set-default SIM_GZ_SV_FUNC3 203
+param set-default SIM_GZ_SV_MIN3 0
+param set-default SIM_GZ_SV_MAX3 1000
+param set-default SIM_GZ_SV_DIS3 500
+param set-default SIM_GZ_SV_FAIL3 500
+
+# Gas engine throttle, PCA9685 servo channel 4, "RC AUX1" (407) - left knob, or "Servo 4" (204):
+#    - on minimum when disarmed or failed:
+param set-default SIM_GZ_SV_FUNC4 204
+param set-default SIM_GZ_SV_MIN4 0
+param set-default SIM_GZ_SV_MAX4 1000
+param set-default SIM_GZ_SV_DIS4 500
+param set-default SIM_GZ_SV_FAIL4 500
+
+# Controlling PCA9685 servos 5,6,7,8 directly via "Servo 5..8" setting, by publishing actuator_servos.control[]:
+
+# Strobes, PCA9685 servo channel 5, "Servo 5" (205) - flashing indicates Mission mode:
+#param set-default SIM_GZ_SV_FUNC5 205
+#param set-default SIM_GZ_SV_MIN5 1000
+#param set-default SIM_GZ_SV_MAX5 2000
+#param set-default SIM_GZ_SV_DIS5 1000
+#param set-default SIM_GZ_SV_FAIL5 1000
+
+# Horn, PCA9685 servo channel 6, "Servo 6" (206) - for alarms like GPS failure:
+#param set-default SIM_GZ_SV_FUNC6 206
+
+# Spare PCA9685 servo channel 7 on "RC AUX2" (408) - right knob, or "Servo 7" (207):
+#param set-default SIM_GZ_SV_FUNC7 207
+
+# Spare PCA9685 servo channel 8 - "Servo 8" (208):
+#param set-default SIM_GZ_SV_FUNC8 208
+
+
+#differential_drive_control stop
+rover_pos_control start
+
+echo "OK: finished " $MYSCRIPTNAME
+echo "----------------------------"

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
@@ -1,93 +1,45 @@
 #!/bin/sh
-#
 # @name Gazebo lawnmower
 # @type Rover
-#
+# @class Rover
 
-export MYSCRIPTNAME="`pwd`/.../5005_gz_lawnmower"
-echo "----------------------------"
-echo "IP: starting " $MYSCRIPTNAME
-
-#. ${R}etc/init.d/rc.rover_defaults
 . ${R}etc/init.d/rc.rover_differential_defaults
 
 PX4_SIMULATOR=${PX4_SIMULATOR:=gz}
 PX4_GZ_WORLD=${PX4_GZ_WORLD:=default}
 PX4_SIM_MODEL=${PX4_SIM_MODEL:=lawnmower}
 
-param set-default SIM_GZ_EN 1
+param set-default SIM_GZ_EN 1 # Gazebo bridge
 
+# Simulated sensors
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-# We can drive in manual mode when GPS check fails:
+param set-default SENS_EN_ARSPDSIM 1
+# We can arm and drive in manual mode when it slides and GPS check fails:
 param set-default COM_ARM_WO_GPS 1
-
-# -------------------
-
-# Enable debug data logging:
-# Data logging to "SD card" (~/px4wrk/log):
-# "0" = armed to disarmed
-param set SDLOG_MODE 0
-# Bit 5 - Debug. 123 = 0b01111011  163 = 0b10100011
-param set SDLOG_PROFILE 32
-
-param set-default MIS_TAKEOFF_ALT 0.01
-#param set-default NAV_ACC_RAD 0.5
-param set NAV_ACC_RAD 0.3000
-param set-default NAV_LOITER_RAD 2
-
-# Simulated GPS works at fix level 3:
-param set GND_GPS_MINFIX 3
-param set GND_TRACING_LEV 4
-
-# Define airframe for startup scripts and Control Allocation (a.k.a. Mixers) behavior:
-param set CA_AIRFRAME 6
 
 # Set Differential Drive Kinematics Library parameters:
 param set RDD_WHEEL_BASE 0.9
 param set RDD_WHEEL_RADIUS 0.22
 param set RDD_WHL_SPEED 10.0	# Maximum wheel speed rad/s
 
-# Lawnmower parameters to scale Differential Drive Kinematics output:
-param set-default RDD_THRUST_SC 1.0
-param set-default RDD_TORQUE_SC 3.0
-
-# set SITL motors/servos output parameters:
+# Actuator mapping - set SITL motors/servos output parameters:
 
 # "Motors" - motor channels 0 (Right) and 1 (Left) - via Wheels GZ bridge:
-param set-default SIM_GZ_WH_FUNC1 201 # right wheel
+param set-default SIM_GZ_WH_FUNC1 101 # right wheel
 #param set-default SIM_GZ_WH_MIN1 0
 #param set-default SIM_GZ_WH_MAX1 200
 #param set-default SIM_GZ_WH_DIS1 100
 #param set-default SIM_GZ_WH_FAIL1 100
 
-param set-default SIM_GZ_WH_FUNC2 202 # left wheel
+param set-default SIM_GZ_WH_FUNC2 102 # left wheel
 #param set-default SIM_GZ_WH_MIN2 0
 #param set-default SIM_GZ_WH_MAX2 200
-#param set-default SIM_GZ_WH_DIS2 100
+#aram set-default SIM_GZ_WH_DIS2 100
 #param set-default SIM_GZ_WH_FAIL2 100
 
-#param set-default SIM_GZ_WH_REV 1 # reverse right wheel (no need here)
-
-# "Motors" - motor channels 0 (Right) and 1 (Left) - via Servo GZ bridge:
-#param set-default SIM_GZ_SV_FUNC1 201 # right wheel
-#param set-default SIM_GZ_SV_MIN1 0
-#param set-default SIM_GZ_SV_MAX1 5000
-#param set-default SIM_GZ_SV_DIS1 2500
-#param set-default SIM_GZ_SV_FAIL1 2500
-
-#param set-default SIM_GZ_SV_FUNC2 202 # left wheel
-#param set-default SIM_GZ_SV_MIN2 0
-#param set-default SIM_GZ_SV_MAX2 5000
-#param set-default SIM_GZ_SV_DIS2 2500
-#param set-default SIM_GZ_SV_FAIL2 2500
-
-# mark motors as bi-directional here for each channel (bitmask, usually 3):
-param set CA_R_REV 0
-param set SIM_GZ_SV_REV 0
-param set SIM_GZ_WH_REV 0
-param set SIM_GZ_EC_REV 0 # Same bitmask, "useful only for servos":
+param set-default SIM_GZ_WH_REV 0 # no need to reverse any wheels
 
 # Cutter deck blades clutch, PCA9685 servo channel 3,  "RC FLAPS" (406) - leftmost switch, or "Servo 3" (203):
 param set-default SIM_GZ_SV_FUNC3 203
@@ -121,10 +73,3 @@ param set-default SIM_GZ_SV_FAIL4 500
 
 # Spare PCA9685 servo channel 8 - "Servo 8" (208):
 #param set-default SIM_GZ_SV_FUNC8 208
-
-
-#differential_drive_control stop
-rover_pos_control start
-
-echo "OK: finished " $MYSCRIPTNAME
-echo "----------------------------"

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
@@ -22,7 +22,7 @@ param set-default COM_ARM_WO_GPS 1
 # Set Differential Drive Kinematics Library parameters:
 param set RDD_WHEEL_BASE 0.9
 param set RDD_WHEEL_RADIUS 0.22
-param set RDD_WHL_SPEED 10.0	# Maximum wheel speed rad/s
+param set RDD_WHEEL_SPEED 10.0	# Maximum wheel speed rad/s, approx 8 km/h
 
 # Actuator mapping - set SITL motors/servos output parameters:
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/5005_gz_lawnmower
@@ -41,6 +41,12 @@ param set-default SIM_GZ_WH_FUNC2 102 # left wheel
 
 param set-default SIM_GZ_WH_REV 0 # no need to reverse any wheels
 
+// Note: The servo configurations ( SIM_GZ_SV_FUNC*) outlined below are intended for educational purposes in this simulation. 
+// They do not have physical effects in the simulated environment, except for actuating the joints. Their definitions are meant to demonstrate 
+// how actuators could be mapped and configured in a real-world application, providing a foundation for understanding and implementing actuator 
+// controls in practical scenarios.
+
+
 # Cutter deck blades clutch, PCA9685 servo channel 3,  "RC FLAPS" (406) - leftmost switch, or "Servo 3" (203):
 param set-default SIM_GZ_SV_FUNC3 203
 param set-default SIM_GZ_SV_MIN3 0

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -83,7 +83,7 @@ px4_add_romfs_files(
 	4009_gz_r1_rover
 	4010_gz_x500_mono_cam
 
-	5005_gz_lawnmower
+	4011_gz_lawnmower
 
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -83,6 +83,8 @@ px4_add_romfs_files(
 	4009_gz_r1_rover
 	4010_gz_x500_mono_cam
 
+	5005_gz_lawnmower
+
 	6011_gazebo-classic_typhoon_h480
 	6011_gazebo-classic_typhoon_h480.post
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -82,7 +82,6 @@ px4_add_romfs_files(
 	4008_gz_advanced_plane
 	4009_gz_r1_rover
 	4010_gz_x500_mono_cam
-
 	4011_gz_lawnmower
 
 	6011_gazebo-classic_typhoon_h480


### PR DESCRIPTION
### Solved Problem
This PR contributes full-size Zero Turm Lawnmower model to existing collection of Gazebo Ignition models. While crude visually, it tries to simulate masses, inertia and friction of an actual full-size machine.

Used _Husqvarna Z254_ dimensions.

This model works fine with current Differential Drive Controller (https://github.com/PX4/PX4-Autopilot/pull/22402) and my own fork (https://github.com/slgrobotics/PX4-Autopilot). It can be driven manually.

Please see https://github.com/PX4/PX4-gazebo-models/pull/27  for actual SDF file

**Testing:**
```
mkdir src21
cd src21
git clone https://github.com/slgrobotics/PX4-Autopilot.git --single-branch --recursive -b gz-lawnmower
cd PX4-Autopilot/
ls -al Tools/simulation/gz/models/
git tag v1.15.0-alpha1
make px4_sitl gz_lawnmower
```
You may need to repeat the "make" command twice, if the GZ SIM doesn't show the model (common problem)

At this point you can arm the robot in _QGroundControl_ and drive it manually.

**Note:**
My robot has PCA9685 PWM driver and all functions are controlled now by directly publishing _actuator_servos_ message. Wheels are 0 and 1, then goes cutter deck clutch (2), gas engine throttle (3), "mission strobe" (4), alarm horn (5) and two extra channels. Model works for me without any changes, as is, and is helpful in tuning and debugging.

I was not sure about naming logic in airframes folder, so 5005_gz_lawnmower can be changed to fit common practices. I think that having a 5* naming group for agricultural machines (or even all rovers) makes sense.

@dagar @PerFrivik  - please take a look, as discussed earlier.
