### PR TITLE
bmp388: Change the message to a register name

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -373,7 +373,7 @@ BMP388::set_sensor_settings()
 	ret = _interface->set_reg(odr_ctl_reg, BMP3_ODR_ADDR);
 
 	if (ret != OK) {
-		PX4_WARN("failed to set output data rate register");
+		PX4_WARN("failed to set settings BMP3_ODR_ADDR");
 		return false;
 	}
 
@@ -382,7 +382,7 @@ BMP388::set_sensor_settings()
 	ret = _interface->set_reg(iir_ctl_reg, BMP3_IIR_ADDR);
 
 	if (ret != OK) {
-		PX4_WARN("failed to set IIR settings");
+		PX4_WARN("failed to set settings BMP3_IIR_ADDR");
 		return false;
 	}
 


### PR DESCRIPTION
### Solved Problem

Message mismatch between config parameter name and register name.

### Solution

Unify with config parameter name.

### Changelog Entry

None.

### Alternatives

None.

### Test coverage

Must be able to build successfully.
Value should change in QGC's MAVLINK inspector.
HARD FAULT should not occur in PIXHAWK6X-RT

### Context

None
