### PR TITLE
GZ Sim: Bugfix removed conversion from rpm to rad s

### DIFF
--- a/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
+++ b/src/modules/simulation/gz_bridge/GZMixingInterfaceWheel.cpp
@@ -111,8 +111,7 @@ void GZMixingInterfaceWheel::wheelSpeedCallback(const gz::msgs::Actuators &actua
 	wheel_encoders_s wheel_encoders{};
 
 	for (int i = 0; i < actuators.velocity_size(); i++) {
-		// Convert from RPM to rad/s
-		wheel_encoders.wheel_speed[i] = (float)actuators.velocity(i) * (2.0f * M_PI_F / 60.0f);
+		wheel_encoders.wheel_speed[i] = (float)actuators.velocity(i);
 	}
 
 	if (actuators.velocity_size() > 0) {


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I realized that the joint state publisher [plugin](https://github.com/gazebosim/gz-sim/blob/gz-sim8/src/systems/joint_state_publisher/JointStatePublisher.cc) from GZ used in the following PR #22402 publishes in rad/s instead of RPM, which means I can remove the conversion from RPM to rad/s. 


https://github.com/gazebosim/gz-sim/blob/18c535f4bf360132bb8825321e3e8a2bc8ee1947/src/systems/joint_state_publisher/JointStatePublisher.cc#L263-L285