### PR TITLE
Global: Change 1G to a more accurate value

### DIFF
--- a/src/modules/ekf2/EKF/python/tuning_tools/baro_static_pressure_compensation/baro_static_pressure_compensation_tuning.py
+++ b/src/modules/ekf2/EKF/python/tuning_tools/baro_static_pressure_compensation/baro_static_pressure_compensation_tuning.py
@@ -175,7 +175,7 @@ def run(logfile):
     res = optimize.minimize(J, x0, method='nelder-mead', options={'disp': True})
 
     # Convert results to parameters
-    g = 9.81
+    g = 9.80665
     pcoef_xn = res.x[0] * g
     pcoef_xp = res.x[1] * g
     pcoef_yn = res.x[2] * g

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -803,8 +803,8 @@ void FlightTaskAuto::_updateTrajConstraints()
 	if (_is_emergency_braking_active) {
 		// When initializing with large velocity, allow 1g of
 		// acceleration in 1s on all axes for fast braking
-		_position_smoothing.setMaxAcceleration({9.80665f, 9.80665f, 9.80665f});
-		_position_smoothing.setMaxJerk(9.80665f);
+		_position_smoothing.setMaxAcceleration({CONSTANTS_ONE_G, CONSTANTS_ONE_G, CONSTANTS_ONE_G});
+		_position_smoothing.setMaxJerk(CONSTANTS_ONE_G);
 
 		// If the current velocity is beyond the usual constraints, tell
 		// the controller to exceptionally increase its saturations to avoid

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -803,8 +803,8 @@ void FlightTaskAuto::_updateTrajConstraints()
 	if (_is_emergency_braking_active) {
 		// When initializing with large velocity, allow 1g of
 		// acceleration in 1s on all axes for fast braking
-		_position_smoothing.setMaxAcceleration({9.81f, 9.81f, 9.81f});
-		_position_smoothing.setMaxJerk(9.81f);
+		_position_smoothing.setMaxAcceleration({9.80665f, 9.80665f, 9.80665f});
+		_position_smoothing.setMaxJerk(9.80665f);
 
 		// If the current velocity is beyond the usual constraints, tell
 		// the controller to exceptionally increase its saturations to avoid


### PR DESCRIPTION
### Solved Problem

1G is calculated at 9.81.
Floating values are valid to 7 decimal places.
I would prefer to use the most accurate value possible.

### Solution

Make 9.81 the scientific calculated value of 9.80665.

### Changelog Entry

None

### Alternatives

None

### Test coverage

Perform SIH on PIXHAWK6X-RT.
SIH confirmed that the flight can be flown on the flight plan.

NOT HARD FALUT.

### Context

None