### PR TITLE
params: change return type of param_modify_on_import to enum

### DIFF
--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -189,7 +189,9 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 		return 0;
 	}
 
-	param_modify_on_import(node);
+	if (param_modify_on_import(node) == param_modify_on_import_ret::PARAM_SKIP_IMPORT) {
+		return 1;
+	}
 
 	/*
 	 * Find the parameter this node represents.  If we don't know it,

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -40,7 +40,7 @@
 #include <lib/parameters/param.h>
 #include <lib/mathlib/mathlib.h>
 
-bool param_modify_on_import(bson_node_t node)
+param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 {
 	// 2023-12-06: translate and invert FW_ARSP_MODE-> FW_USE_AIRSPD
 	{
@@ -54,7 +54,7 @@ bool param_modify_on_import(bson_node_t node)
 
 			strcpy(node->name, "FW_USE_AIRSPD");
 			PX4_INFO("copying and inverting %s -> %s", "FW_ARSP_MODE", "FW_USE_AIRSPD");
-			return true;
+			return param_modify_on_import_ret::PARAM_MODIFIED;
 		}
 	}
 
@@ -69,9 +69,9 @@ bool param_modify_on_import(bson_node_t node)
 
 			}
 
-			return true;
+			return param_modify_on_import_ret::PARAM_MODIFIED;
 		}
 	}
 
-	return false;
+	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/lib/parameters/param_translation.h
+++ b/src/lib/parameters/param_translation.h
@@ -35,4 +35,10 @@
 
 #include "tinybson/tinybson.h"
 
-__EXPORT bool param_modify_on_import(bson_node_t node);
+enum class param_modify_on_import_ret {
+	PARAM_SKIP_IMPORT = 0,
+	PARAM_NOT_MODIFIED = 1,
+	PARAM_MODIFIED = 2
+};
+
+__EXPORT param_modify_on_import_ret param_modify_on_import(bson_node_t node);

--- a/src/lib/parameters/param_translation_unit_tests.cpp
+++ b/src/lib/parameters/param_translation_unit_tests.cpp
@@ -33,8 +33,8 @@
 
 #include "param_translation.h"
 
-bool param_modify_on_import(bson_node_t node)
+param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 {
 	// don't modify params for unit tests
-	return false;
+	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -1078,7 +1078,10 @@ param_import_callback(bson_decoder_t decoder, bson_node_t node)
 		return 0;
 	}
 
-	param_modify_on_import(node);
+	// if we do param_set() directly in the translation, set PARAM_SKIP_IMPORT as return value and return here
+	if (param_modify_on_import(node) == param_modify_on_import_ret::PARAM_SKIP_IMPORT) {
+		return 1;
+	}
 
 	// Find the parameter this node represents.  If we don't know it, ignore the node.
 	param_t param = param_find_no_notification(node->name);


### PR DESCRIPTION

### Solved Problem
`WARN  [parameters] ignoring unrecognised parameter XXX`  when we do param_set() in the param translation. 

### Solution
Return early in param_import_callback() with 1 if we do a param_set in the param translation.

### Changelog Entry
For release notes:
```
Improvement: Param translation: enable the use of param_set() in the translation
```

