### PR TITLE
param translation: fix too early return

### DIFF
--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -210,8 +210,6 @@ bool param_modify_on_import(bson_node_t node)
 		}
 	}
 
-	return false;
-
 	//2023-02-08: translate L1 parameters after removing l1 control
 	{
 		if (strcmp("RWTO_L1_PERIOD", node->name) == 0) {
@@ -232,4 +230,6 @@ bool param_modify_on_import(bson_node_t node)
 			return true;
 		}
 	}
+
+	return false;
 }


### PR DESCRIPTION
Currently the translation of RWTO_L1_PERIOD, FW_L1_R_SLEW_MAX and FW_L1_PERIOD is not applied as the function returns before that. Was an oversight in https://github.com/PX4/PX4-Autopilot/pull/19629.