### PR TITLE
v6x board_sensors: publish system_power if ADC_ADS1115_EN is enabled

### DIFF
--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -12,6 +12,7 @@ fi
 if param compare -s ADC_ADS1115_EN 1
 then
 	ads1115 start -X
+	board_adc start -n
 else
 	board_adc start
 fi


### PR DESCRIPTION
### Solved Problem
I noticed that the system_power topic was not published if the ADS1115 driver is running on a v6x board.