### PR TITLE
Correct automatic servo/motor PWM configuration console output

### DIFF
--- a/src/drivers/distance_sensor/cm8jl65/CM8JL65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/CM8JL65.cpp
@@ -113,7 +113,7 @@ CM8JL65::CM8JL65(const char *port, uint8_t rotation) :
 	_px4_rangefinder.set_max_distance(7.9f);	// Datasheet: 8.0m
 	_px4_rangefinder.set_fov(0.0488692f);
 	_px4_rangefinder.set_device_type(DRV_DIST_DEVTYPE_CM8JL65);
-	_px4_rangefinder.set_rangefinder_type(distance_sensor_s::MAV_DISTANCE_SENSOR_LASER);
+	_px4_rangefinder.set_rangefinder_type(distance_sensor_s::MAV_DISTANCE_SENSOR_INFRARED);
 }
 
 CM8JL65::~CM8JL65()

--- a/src/drivers/pwm_out/PWMOut.cpp
+++ b/src/drivers/pwm_out/PWMOut.cpp
@@ -229,7 +229,7 @@ void PWMOut::update_params()
 					if (output_function >= (int)OutputFunction::Servo1
 					    && output_function <= (int)OutputFunction::ServoMax) { // Function got set to a servo
 						int32_t val = 1500;
-						PX4_INFO("Setting channel %i disarmed to %i", (int) val, i);
+						PX4_INFO("Setting channel %i disarmed to %i", i + 1, (int)val);
 						param_set(_mixing_output.disarmedParamHandle(i), &val);
 
 						// If the whole timer group was not set previously, then set the pwm rate to 50 Hz
@@ -250,7 +250,7 @@ void PWMOut::update_params()
 
 								if (param_get(handle, &tim_config) == 0 && tim_config == 400) {
 									tim_config = 50;
-									PX4_INFO("setting timer %i to %i Hz", timer, (int) tim_config);
+									PX4_INFO("Setting timer %i to %i Hz", timer, (int)tim_config);
 									param_set(handle, &tim_config);
 								}
 							}
@@ -261,10 +261,10 @@ void PWMOut::update_params()
 					if (output_function >= (int)OutputFunction::Motor1
 					    && output_function <= (int)OutputFunction::MotorMax) { // Function got set to a motor
 						int32_t val = 1100;
-						PX4_INFO("Setting channel %i minimum to %i", (int) val, i);
+						PX4_INFO("Setting channel %i minimum to %i", i + 1, (int)val);
 						param_set(_mixing_output.minParamHandle(i), &val);
 						val = 1900;
-						PX4_INFO("Setting channel %i maximum to %i", (int) val, i);
+						PX4_INFO("Setting channel %i maximum to %i", i + 1, (int)val);
 						param_set(_mixing_output.maxParamHandle(i), &val);
 					}
 				}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -705,7 +705,7 @@ void PX4IO::update_params()
 						if (output_function >= (int)OutputFunction::Servo1
 						    && output_function <= (int)OutputFunction::ServoMax) { // Function got set to a servo
 							int32_t val = 1500;
-							PX4_INFO("Setting channel %i disarmed to %i", (int) val, i);
+							PX4_INFO("Setting channel %i disarmed to %i", i + 1, (int)val);
 							param_set(_mixing_output.disarmedParamHandle(i), &val);
 
 							// If the whole timer group was not set previously, then set the pwm rate to 50 Hz
@@ -726,7 +726,7 @@ void PX4IO::update_params()
 
 									if (param_get(handle, &tim_config) == 0 && tim_config == 400) {
 										tim_config = 50;
-										PX4_INFO("setting timer %i to %i Hz", timer, (int) tim_config);
+										PX4_INFO("Setting timer %i to %i Hz", timer, (int)tim_config);
 										param_set(handle, &tim_config);
 									}
 								}
@@ -737,10 +737,10 @@ void PX4IO::update_params()
 						if (output_function >= (int)OutputFunction::Motor1
 						    && output_function <= (int)OutputFunction::MotorMax) { // Function got set to a motor
 							int32_t val = 1100;
-							PX4_INFO("Setting channel %i minimum to %i", (int) val, i);
+							PX4_INFO("Setting channel %i minimum to %i", i + 1, (int)val);
 							param_set(_mixing_output.minParamHandle(i), &val);
 							val = 1900;
-							PX4_INFO("Setting channel %i maximum to %i", (int) val, i);
+							PX4_INFO("Setting channel %i maximum to %i", i + 1, (int)val);
 							param_set(_mixing_output.maxParamHandle(i), &val);
 						}
 					}


### PR DESCRIPTION
### Solved Problem
1. When working with PWM configurations I found that the output of what gets changed with the automatic servo/motor configuration is interchanged:

<img width="284" alt="Screenshot_5" src="https://github.com/PX4/PX4-Autopilot/assets/4668506/54885101-dfdb-4ab6-b17a-b9cdc6e0b607">

2. The Lanbao distance sensor is according to shops and even our docs an infrared sensor but the type was set to a laser.
https://docs.px4.io/main/en/sensor/cm8jl65_ir_distance_sensor.html

### Solution
1. I swapped the outputs and made the channel number 1 based to avoid confusion with the UI.
2. Declared it IR.

### Changelog Entry
```
Maintenance: Correct automatic servo/motor PWM configuration console output
Fix: Report Lanbao distance sensor as infrared instead of laser
```