### PR TITLE
Fixing batt_smbus timeout problem with BQ40Z80 BMS.

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -392,6 +392,12 @@ int BATT_SMBUS::get_startup_info()
 	uint16_t state_of_health;
 	ret |= _interface->read_word(BATT_SMBUS_STATE_OF_HEALTH, state_of_health);
 
+	/* ManufacturerAccess dummy command to init the ManufacturerBlockAccess routine
+	in the BQ40Zx0 and avoid timeout during LifetimeDataFlush.
+	test Sleep > 20 ms to give time to init the ManufacturerBlockAccess routine*/
+	ret |= _interface->write_word(BATT_SMBUS_MANUFACTURER_ACCESS, BATT_SMBUS_DEVICE_TYPE);
+	px4_usleep(30_ms);
+
 	if (!ret) {
 		_serial_number = serial_num;
 		_batt_startup_capacity = (uint16_t)((float)remaining_cap * _c_mult);

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -107,6 +107,7 @@ using namespace time_literals;
 
 #define BATT_SMBUS_SECURITY_KEYS                        0x0035
 
+#define BATT_SMBUS_DEVICE_TYPE                          0x0001
 #define BATT_SMBUS_LIFETIME_FLUSH                       0x002E
 #define BATT_SMBUS_LIFETIME_BLOCK_ONE                   0x0060
 #define BATT_SMBUS_ENABLED_PROTECTIONS_A_ADDRESS        0x4938


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When BQ40Z80 is going out of Shutdown mode we can't retrieve some telemetry message.

When using a SMbus ManufacturerAccess command in the batt_smbus driver (for example lifetime_data_flush()) the BQ40Z80 is stretching the clock for more than 20 ms.
The timeout configured for STM32H7 based autopilot is 10 ms.
As soon as the BQ40Z80 is releasing the clock, the PX4 try to send the command again (address + command + 2 byte block) but BMS can't resolve it as it is expecting only a 2 byte command and it receive 4 byte.
The result is that all the telemetry using ManufacturerBlockAccess in batt_smbus driver can't be refreshed.


### Solution
By adding a dummy ManufacturerAccess command before sending the first ManufacturerBlockAccess command (LifetimeDataFlush in the get_startup_info() function) and a 30 ms tempo, we can initialize the ManufacturerBlockAccess routine in the BQ40Z80 and reduce the clock stretching to be compatible with the timeout of 10 ms.


### Changelog Entry
For release notes:
```
Fix batt_smbus driver timeout issues when BQ40Z80 is waking up from shutdown state.
```


### Test coverage
Tested on cubeorangeplus with PX4 v1.14. BMS is using BQ40Z80.
Should also work with BQ40Z50 BMS as the command used to solve problem is identical, but not tested.
To reproduce the problem you can either send a ManufacturerAccess ShutdownMode command or unplugging the battery from the BMS.


### Context
LifetimeDataFlush command when ManufacturerAccess is already initialized:
![image](https://github.com/PX4/PX4-Autopilot/assets/16023641/2942e556-5e87-4c36-92cc-d4f63b63edc5)
LifetimeDataFlush command with timeout issue:
![image](https://github.com/PX4/PX4-Autopilot/assets/16023641/d5d90c20-5d91-4ddf-95fb-9d8e8bf5a720)
![image](https://github.com/PX4/PX4-Autopilot/assets/16023641/852e2335-cf05-440a-b5ee-55fb2ab1b425)
![image](https://github.com/PX4/PX4-Autopilot/assets/16023641/afdb0dfd-fb08-4699-b370-4f6829d82caf)

