### PR TITLE
ekf2: fix EV height bias predict call

### DIFF
--- a/src/modules/ekf2/EKF/ev_control.cpp
+++ b/src/modules/ekf2/EKF/ev_control.cpp
@@ -41,6 +41,7 @@
 void Ekf::controlExternalVisionFusion()
 {
 	_ev_pos_b_est.predict(_dt_ekf_avg);
+	_ev_hgt_b_est.predict(_dt_ekf_avg);
 
 	// Check for new external vision data
 	extVisionSample ev_sample;

--- a/src/modules/ekf2/EKF/ev_height_control.cpp
+++ b/src/modules/ekf2/EKF/ev_height_control.cpp
@@ -45,7 +45,7 @@ void Ekf::controlEvHeightFusion(const extVisionSample &ev_sample, const bool com
 
 	HeightBiasEstimator &bias_est = _ev_hgt_b_est;
 
-	bias_est.predict(_dt_ekf_avg);
+	// bias_est.predict(_dt_ekf_avg) called by controlExternalVisionFusion()
 
 	// correct position for offset relative to IMU
 	const Vector3f pos_offset_body = _params.ev_pos_body - _params.imu_pos_body;


### PR DESCRIPTION
 - needs to be called every iteration
