### PR TITLE
AirspeedSelector: remvoe @volatile from the ASPD_SCALE params

### DIFF
--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -97,7 +97,6 @@ PARAM_DEFINE_INT32(ASPD_SCALE_APPLY, 2);
  * @decimal 2
  * @reboot_required true
  * @group Airspeed Validator
- * @volatile
  */
 PARAM_DEFINE_FLOAT(ASPD_SCALE_1, 1.0f);
 
@@ -111,7 +110,6 @@ PARAM_DEFINE_FLOAT(ASPD_SCALE_1, 1.0f);
  * @decimal 2
  * @reboot_required true
  * @group Airspeed Validator
- * @volatile
  */
 PARAM_DEFINE_FLOAT(ASPD_SCALE_2, 1.0f);
 
@@ -125,7 +123,6 @@ PARAM_DEFINE_FLOAT(ASPD_SCALE_2, 1.0f);
  * @decimal 2
  * @reboot_required true
  * @group Airspeed Validator
- * @volatile
  */
 PARAM_DEFINE_FLOAT(ASPD_SCALE_3, 1.0f);
 


### PR DESCRIPTION
This flag prevents the params from being loaded from a param file. Originally it was thought that this scale was more airspeed sensor specific, but it has shown that it's mainly the position of the pitot on the vehicle that influences it, and thus it's similar for a model and should be passed to new vehicles.


### Changelog Entry
For release notes:
```
Improvement: remvoe @volatile from the ASPD_SCALE params
```

