### PR TITLE
battery: Rely less on battery capacity based estimate when voltage is low

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -239,10 +239,10 @@ float Battery::calculateStateOfChargeVoltageBased(const float voltage_v, const f
 void Battery::estimateStateOfCharge()
 {
 	// choose which quantity we're using for final reporting
-	if (_params.capacity > 0.f && _battery_initialized) {
+	if ((_params.capacity > 0.f) && _battery_initialized) {
 		// if battery capacity is known, fuse voltage measurement with used capacity
 		// The lower the voltage the more adjust the estimate with it to avoid deep discharge
-		const float weight_v = 3e-4f * (1 - _state_of_charge_volt_based);
+		const float weight_v = 3e-2f * (1 - _state_of_charge_volt_based);
 		_state_of_charge = (1 - weight_v) * _state_of_charge + weight_v * _state_of_charge_volt_based;
 		// directly apply current capacity slope calculated using current
 		_state_of_charge -= _discharged_mah_loop / _params.capacity;


### PR DESCRIPTION
### Solved Problem
When analyzing test vehicle crashes I found that it happens regularly that people set a "random" battery capacity and then still rely on the battery estimate which is in that case completely wrong.

### Solution
This is a minimal change to make it harder to crash a vehicle with an empty battery if the capacity was set completely wrong.

### Changelog Entry
```
Fix: Rely less on battery capacity based estimate when voltage is low
Documentation: Battery estimate configuration docs are too sparse in general.
```

### Alternatives
We need better documentation and improvements to the estimation.

### Test coverage
- Not tested yet. I'll see if there's a simple simulation test to verify.

### Context
FYI @jongell @Dani3L9H
