### PR TITLE
fix gimbal driver for mavlink gimbal v2 input and AUX output

### DIFF
--- a/src/modules/gimbal/gimbal.cpp
+++ b/src/modules/gimbal/gimbal.cpp
@@ -211,7 +211,10 @@ static int gimbal_thread_main(int argc, char *argv[])
 			// Reset control as no one is active anymore, or yet.
 			thread_data.control_data.sysid_primary_control = 0;
 			thread_data.control_data.compid_primary_control = 0;
-			thread_data.control_data.device_compid = 0;
+			// If the output is set to AUX we still want the input to be able to control the gimbal
+			// via mavlink, so we set the device_compid to 1. This follows the mavlink spec which states
+			// that the gimbal_device_id should be between 1 and 6.
+			thread_data.control_data.device_compid = params.mnt_mode_out == 0 ? 1 : 0;
 		}
 
 		InputBase::UpdateResult update_result = InputBase::UpdateResult::NoUpdate;


### PR DESCRIPTION
Controlling the gimbal when the gimbal driver was configured to mavlink gimbal v2 input and AUX output was not working. PX4 would never send out the gimbal manager information when requested.

The actual issue I was chasing was that our GCS (based on QGC) would always switch to mavlink gimbal v1 when the gimbal configuration in PX4 was mavlink gimbal v2 as input and AUX (pwm) as output. This was then causing other side effects that are not relevant in this PR.

The main problem was that during initial negotiation the GCS would request the gimbal_manager_information as specified in the gimbal v2 discovery protocol: https://mavlink.io/en/services/gimbal_v2.html#discovery-of-gimbal-manager
If no response came back the GCS would assume we were using the v1 gimbal protocol, while if the message came in the GCS would use gimbal v2.

The gimbal_manager_information stream is implemented in PX4 so it would try to respond to the message_request but it would fail because the gimbal_manager_info uorb topic was never published by the gimbal driver.
Steps:
- message request calls send() in this mavlink stream. Up to this point everything is correct: https://github.com/Auterion/PX4_firmware_private/blob/45c756efda1e3dfa9a33d74a2b0577f956c4c32a/src/modules/mavlink/streams/GIMBAL_MANAGER_INFORMATION.hpp#L64
- check on published uorb topic that was failing: https://github.com/Auterion/PX4_firmware_private/blob/45c756efda1e3dfa9a33d74a2b0577f956c4c32a/src/modules/mavlink/streams/GIMBAL_MANAGER_INFORMATION.hpp#L68

The reason why the gimbal driver would never publish this message is because of this check:
https://github.com/Auterion/PX4_firmware_private/blob/45c756efda1e3dfa9a33d74a2b0577f956c4c32a/src/modules/gimbal/input_mavlink.cpp#L582

Basically what it's saying is that if there is no change in the gimbal device compid it will never publish this message. In our case we don't have a gimbal device when using AUX output so the gimbal device compid was kept to 0 as it was initialized.

### Solution
When the gimbal output is set to AUX we still need to "fake" a gimbal device (as we already do in the payload manager). To do this I think the best idea is for both the gimbal device and gimbal manager to have the same compid as the autopilot. This respects the protocol and makes AMC happy.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
Manually tested with a pwm servo gimbal on an fmu-v5x
