### PR TITLE
spi.cpp remove null check

### DIFF
--- a/platforms/common/spi.cpp
+++ b/platforms/common/spi.cpp
@@ -87,7 +87,7 @@ const px4_spi_bus_t *px4_spi_buses{nullptr};
 
 int px4_find_spi_bus(uint32_t devid)
 {
-	for (int i = 0; ((px4_spi_bus_t *) px4_spi_buses) != nullptr && i < SPI_BUS_MAX_BUS_ITEMS; ++i) {
+	for (int i = 0; i < SPI_BUS_MAX_BUS_ITEMS; ++i) {
 		const px4_spi_bus_t &bus_data = px4_spi_buses[i];
 
 		if (bus_data.bus == -1) {


### PR DESCRIPTION
Using GCC 13.2.1, spi.cpp doesn't compile due to an error with the px4_spi_buses null check. Removing the null check fixes the error.

```error: the address of 'px4_spi_buses' will never be NULL [-Werror=address] 90 | for (int i = 0; ((px4_spi_bus_t *) px4_spi_buses) != nullptr && i < SPI_BUS_MAX_BUS_ITEMS; ++i) { | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~ compilation terminated due to -Wfatal-errors.```