### PR TITLE
Navigator: fix VTOL land waypoint calculation

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -83,7 +83,7 @@ Land::on_active()
 
 		// create a virtual wp 1m in front of the vehicle to track during the backtransition
 		waypoint_from_heading_and_distance(_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
-						   _navigator->get_position_setpoint_triplet()->current.yaw, 1.f,
+						   _navigator->get_local_position()->heading, 1.f,
 						   &pos_sp_triplet->current.lat, &pos_sp_triplet->current.lon);
 
 		_navigator->set_position_setpoint_triplet_updated();


### PR DESCRIPTION
The setpoint.yaw can be NAN, and this made the calculated land point NAN as well. Looking at the current yaw is anyway a better way to approximate the course over ground that fundamentally should be used.

NB As we only need a rough idea of the current course over ground, I think it's not worth to calculate it by using the ground velocity, as then we'd have instabilities when approaching 0 ground speed.


### Changelog Entry
For release notes:
```
Bugfix 
```
