### PR TITLE
CI fix 'Fly forward in position control' MAVSDK test

### DIFF
--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -438,6 +438,9 @@ void AutopilotTester::fly_forward_in_posctl()
 	}
 
 	CHECK(_manual_control->start_position_control() == ManualControl::Result::Success);
+	store_home();
+	wait_until_ready();
+	arm();
 
 	// Climb up for 20 seconds
 	for (unsigned i = 0; i < 20 * manual_control_rate_hz; ++i) {

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -476,6 +476,9 @@ void AutopilotTester::fly_forward_in_altctl()
 	}
 
 	CHECK(_manual_control->start_altitude_control() == ManualControl::Result::Success);
+	store_home();
+	wait_until_ready();
+	arm();
 
 	// Climb up for 20 seconds
 	for (unsigned i = 0; i < 20 * manual_control_rate_hz; ++i) {

--- a/test/mavsdk_tests/autopilot_tester.cpp
+++ b/test/mavsdk_tests/autopilot_tester.cpp
@@ -442,14 +442,14 @@ void AutopilotTester::fly_forward_in_posctl()
 	wait_until_ready();
 	arm();
 
-	// Climb up for 20 seconds
-	for (unsigned i = 0; i < 20 * manual_control_rate_hz; ++i) {
+	// Climb up for 5 seconds
+	for (unsigned i = 0; i < 5 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.f, 0.f, 1.f, 0.f) == ManualControl::Result::Success);
 		sleep_for(std::chrono::milliseconds(1000 / manual_control_rate_hz));
 	}
 
-	// Fly forward for 60 seconds
-	for (unsigned i = 0; i < 60 * manual_control_rate_hz; ++i) {
+	// Fly forward for 10 seconds
+	for (unsigned i = 0; i < 10 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.5f, 0.f, 0.5f, 0.f) == ManualControl::Result::Success);
 		sleep_for(std::chrono::milliseconds(1000 / manual_control_rate_hz));
 	}
@@ -480,14 +480,14 @@ void AutopilotTester::fly_forward_in_altctl()
 	wait_until_ready();
 	arm();
 
-	// Climb up for 20 seconds
-	for (unsigned i = 0; i < 20 * manual_control_rate_hz; ++i) {
+	// Climb up for 5 seconds
+	for (unsigned i = 0; i < 5 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.f, 0.f, 1.f, 0.f) == ManualControl::Result::Success);
 		sleep_for(std::chrono::milliseconds(1000 / manual_control_rate_hz));
 	}
 
-	// Fly forward for 60 seconds
-	for (unsigned i = 0; i < 60 * manual_control_rate_hz; ++i) {
+	// Fly forward for 10 seconds
+	for (unsigned i = 0; i < 10 * manual_control_rate_hz; ++i) {
 		CHECK(_manual_control->set_manual_control_input(0.5f, 0.f, 0.5f, 0.f) == ManualControl::Result::Success);
 		sleep_for(std::chrono::milliseconds(1000 / manual_control_rate_hz));
 	}

--- a/test/mavsdk_tests/test_multicopter_manual.cpp
+++ b/test/mavsdk_tests/test_multicopter_manual.cpp
@@ -38,9 +38,6 @@ TEST_CASE("Fly forward in position control", "[multicopter][vtol]")
 {
 	AutopilotTester tester;
 	tester.connect(connection_url);
-	tester.wait_until_ready();
-	tester.store_home();
-	tester.arm();
 	tester.fly_forward_in_posctl();
 	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);

--- a/test/mavsdk_tests/test_multicopter_manual.cpp
+++ b/test/mavsdk_tests/test_multicopter_manual.cpp
@@ -48,9 +48,6 @@ TEST_CASE("Fly forward in altitude control", "[multicopter][vtol]")
 {
 	AutopilotTester tester;
 	tester.connect(connection_url);
-	tester.wait_until_ready();
-	tester.store_home();
-	tester.arm();
 	tester.fly_forward_in_altctl();
 	std::chrono::seconds until_disarmed_timeout = std::chrono::seconds(180);
 	tester.wait_until_disarmed(until_disarmed_timeout);

--- a/test/mavsdk_tests/test_multicopter_offboard.cpp
+++ b/test/mavsdk_tests/test_multicopter_offboard.cpp
@@ -34,6 +34,7 @@
 #include "autopilot_tester.h"
 #include <chrono>
 
+static constexpr float acceptance_radius = 0.3f;
 
 TEST_CASE("Offboard takeoff and land", "[multicopter][offboard]")
 {
@@ -45,7 +46,7 @@ TEST_CASE("Offboard takeoff and land", "[multicopter][offboard]")
 	tester.set_rc_loss_exception(AutopilotTester::RcLossException::Offboard);
 	tester.arm();
 	std::chrono::seconds goto_timeout = std::chrono::seconds(90);
-	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);
+	tester.offboard_goto(takeoff_position, acceptance_radius, goto_timeout);
 	tester.offboard_land();
 	tester.wait_until_disarmed(std::chrono::seconds(120));
 	tester.check_home_within(1.0f);
@@ -63,12 +64,12 @@ TEST_CASE("Offboard position control", "[multicopter][offboard]")
 	tester.store_home();
 	tester.set_rc_loss_exception(AutopilotTester::RcLossException::Offboard);
 	tester.arm();
-	std::chrono::seconds goto_timeout = std::chrono::seconds(120);
-	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);
-	tester.offboard_goto(setpoint_1, 0.1f, goto_timeout);
-	tester.offboard_goto(setpoint_2, 0.1f, goto_timeout);
-	tester.offboard_goto(setpoint_3, 0.1f, goto_timeout);
-	tester.offboard_goto(takeoff_position, 0.1f, goto_timeout);
+	std::chrono::seconds goto_timeout = std::chrono::seconds(10);
+	tester.offboard_goto(takeoff_position, acceptance_radius, goto_timeout);
+	tester.offboard_goto(setpoint_1, acceptance_radius, goto_timeout);
+	tester.offboard_goto(setpoint_2, acceptance_radius, goto_timeout);
+	tester.offboard_goto(setpoint_3, acceptance_radius, goto_timeout);
+	tester.offboard_goto(takeoff_position, acceptance_radius, goto_timeout);
 	tester.offboard_land();
 	tester.wait_until_disarmed(std::chrono::seconds(120));
 	tester.check_home_within(1.0f);


### PR DESCRIPTION
### Solved Problem
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/7a5dbb33-9481-4b93-b0fa-04dfaf62e43b)

This PR solves the issue of the CI SITL Tests failing for the iris, specifically when the **'Fly forward in position control'** test is run. 

To verify, run the following locally: 

`DONT_RUN=1 make px4_sitl gazebo-classic mavsdk_tests && test/mavsdk_tests/mavsdk_test_runner.py test/mavsdk_tests/configs/sitl.json --speed-factor 20 --model iris --iterations 100  --case 'Fly forward in position control'`

### Solution
These tests are written with the assumption, that PX4 will not switch to Position mode if it's not allowed to fly it yet. But now you can switch to Position mode even if it's not flyable yet when the vehicle is still disarmed. PX4 will actually automatically switch to position mode when there's stick input but we don't want to rely on that in this test.

Order:
- Send stick input (manual control) because MAVSDK sets a flag that only allows switching to position if samples have been sent even though it would not be necessary for PX4
- Switch to Position mode
- Wait for things to be ready (this would include sticks being available now)
- Fly the pattern

### Alternatives
The test could be made faster because it's not necessary to fly 20+ seconds in one direction to get further than 5 meters away from home.