### PR TITLE
[HealthCheck] Logger (is_logging?)

### DIFF
--- a/msg/LoggerStatus.msg
+++ b/msg/LoggerStatus.msg
@@ -9,6 +9,8 @@ uint8 BACKEND_MAVLINK = 2
 uint8 BACKEND_ALL     = 3
 uint8 backend
 
+bool is_logging
+
 float32 total_written_kb       # total written to log in kiloBytes
 float32 write_rate_kb_s        # write rate in kiloBytes/s
 

--- a/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
+++ b/src/modules/commander/HealthAndArmingChecks/CMakeLists.txt
@@ -50,6 +50,7 @@ px4_add_library(health_and_arming_checks
 	checks/gyroCheck.cpp
 	checks/homePositionCheck.cpp
 	checks/imuConsistencyCheck.cpp
+	checks/loggerCheck.cpp
 	checks/magnetometerCheck.cpp
 	checks/manualControlCheck.cpp
 	checks/missionCheck.cpp

--- a/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/HealthAndArmingChecks.hpp
@@ -51,6 +51,7 @@
 #include "checks/failureDetectorCheck.hpp"
 #include "checks/gyroCheck.hpp"
 #include "checks/imuConsistencyCheck.hpp"
+#include "checks/loggerCheck.hpp"
 #include "checks/magnetometerCheck.hpp"
 #include "checks/manualControlCheck.hpp"
 #include "checks/homePositionCheck.hpp"
@@ -130,6 +131,7 @@ private:
 	FailureDetectorChecks _failure_detector_checks;
 	GyroChecks _gyro_checks;
 	ImuConsistencyChecks _imu_consistency_checks;
+	LoggerChecks _logger_checks;
 	MagnetometerChecks _magnetometer_checks;
 	ManualControlChecks _manual_control_checks;
 	HomePositionChecks _home_position_checks;
@@ -167,6 +169,7 @@ private:
 		&_failure_detector_checks,
 		&_gyro_checks,
 		&_imu_consistency_checks,
+		&_logger_checks,
 		&_magnetometer_checks,
 		&_manual_control_checks,
 		&_home_position_checks,

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
@@ -35,13 +35,19 @@
 
 using namespace time_literals;
 
+LoggerChecks::LoggerChecks()
+	: _param_sdlog_mode_handle(param_find("SDLOG_MODE"))
+{
+}
+
 void LoggerChecks::checkAndReport(const Context &context, Report &reporter)
 {
-#if defined(CONFIG_MODULES_LOGGER)
+	int32_t sdlog_mode = -1;
+	param_get(_param_sdlog_mode_handle, &sdlog_mode);
 
 	bool active = false;
 
-	if (_param_sdlog_mode.get() >= 0) {
+	if (sdlog_mode >= 0) {
 		for (int instance = 0; instance < _logger_status_sub.size(); instance++) {
 			const bool exists = _logger_status_sub[instance].advertised();
 
@@ -57,5 +63,4 @@ void LoggerChecks::checkAndReport(const Context &context, Report &reporter)
 	}
 
 	reporter.setHealth(health_component_t::logging, active, false, false);
-#endif
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
@@ -38,26 +38,20 @@ using namespace time_literals;
 LoggerChecks::LoggerChecks()
 	: _param_sdlog_mode_handle(param_find("SDLOG_MODE"))
 {
+	param_get(_param_sdlog_mode_handle, &_sdlog_mode);
 }
 
 void LoggerChecks::checkAndReport(const Context &context, Report &reporter)
 {
-	int32_t sdlog_mode = -1;
-	param_get(_param_sdlog_mode_handle, &sdlog_mode);
-
 	bool active = false;
 
-	if (sdlog_mode >= 0) {
-		for (int instance = 0; instance < _logger_status_sub.size(); instance++) {
-			const bool exists = _logger_status_sub[instance].advertised();
+	if (_sdlog_mode >= 0) {
+		if (_logger_status_sub.advertised()) {
+			logger_status_s status;
+			_logger_status_sub.copy(&status);
 
-			if (exists) {
-				logger_status_s status;
-				_logger_status_sub[instance].copy(&status);
-
-				if (hrt_elapsed_time(&status.timestamp) < 3_s && status.is_logging) {
-					active = true;
-				}
+			if (hrt_elapsed_time(&status.timestamp) < 3_s && status.is_logging) {
+				active = true;
 			}
 		}
 	}

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
@@ -37,6 +37,8 @@ using namespace time_literals;
 
 void LoggerChecks::checkAndReport(const Context &context, Report &reporter)
 {
+#if defined(CONFIG_MODULES_LOGGER)
+
 	bool active = false;
 
 	if (_param_sdlog_mode.get() >= 0) {
@@ -55,4 +57,5 @@ void LoggerChecks::checkAndReport(const Context &context, Report &reporter)
 	}
 
 	reporter.setHealth(health_component_t::logging, active, false, false);
+#endif
 }

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.cpp
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "loggerCheck.hpp"
+
+using namespace time_literals;
+
+void LoggerChecks::checkAndReport(const Context &context, Report &reporter)
+{
+	bool active = false;
+
+	if (_param_sdlog_mode.get() >= 0) {
+		for (int instance = 0; instance < _logger_status_sub.size(); instance++) {
+			const bool exists = _logger_status_sub[instance].advertised();
+
+			if (exists) {
+				logger_status_s status;
+				_logger_status_sub[instance].copy(&status);
+
+				if (hrt_elapsed_time(&status.timestamp) < 3_s && status.is_logging) {
+					active = true;
+				}
+			}
+		}
+	}
+
+	reporter.setHealth(health_component_t::logging, active, false, false);
+}

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
@@ -48,7 +48,7 @@ public:
 	void checkAndReport(const Context &context, Report &reporter) override;
 
 private:
-	uORB::SubscriptionMultiArray<logger_status_s> _logger_status_sub{ORB_ID::logger_status};
-
+	uORB::Subscription _logger_status_sub{ORB_ID::logger_status};
 	const param_t _param_sdlog_mode_handle;
+	int32_t _sdlog_mode = -1;
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
@@ -42,7 +42,7 @@
 class LoggerChecks : public HealthAndArmingCheckBase
 {
 public:
-	LoggerChecks() = default;
+	LoggerChecks();
 	~LoggerChecks() = default;
 
 	void checkAndReport(const Context &context, Report &reporter) override;
@@ -50,9 +50,5 @@ public:
 private:
 	uORB::SubscriptionMultiArray<logger_status_s> _logger_status_sub{ORB_ID::logger_status};
 
-#if defined(CONFIG_MODULES_LOGGER)
-	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamInt<px4::params::SDLOG_MODE>) _param_sdlog_mode
-				       )
-#endif
+	const param_t _param_sdlog_mode_handle;
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
@@ -50,7 +50,9 @@ public:
 private:
 	uORB::SubscriptionMultiArray<logger_status_s> _logger_status_sub{ORB_ID::logger_status};
 
+#if defined(CONFIG_MODULES_LOGGER)
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::SDLOG_MODE>) _param_sdlog_mode
 				       )
+#endif
 };

--- a/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/loggerCheck.hpp
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "../Common.hpp"
+
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
+#include <uORB/topics/logger_status.h>
+
+class LoggerChecks : public HealthAndArmingCheckBase
+{
+public:
+	LoggerChecks() = default;
+	~LoggerChecks() = default;
+
+	void checkAndReport(const Context &context, Report &reporter) override;
+
+private:
+	uORB::SubscriptionMultiArray<logger_status_s> _logger_status_sub{ORB_ID::logger_status};
+
+	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
+					(ParamInt<px4::params::SDLOG_MODE>) _param_sdlog_mode
+				       )
+};

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1037,6 +1037,12 @@ void Logger::publish_logger_status()
 	if (hrt_elapsed_time(&_logger_status_last) >= 1_s) {
 		for (int i = 0; i < (int)LogType::Count; ++i) {
 
+			logger_status_s status = {};
+			status.type = i;
+			status.backend = _writer.backend();
+			status.num_messages = _num_subscriptions;
+			status.timestamp = hrt_absolute_time();
+
 			const LogType log_type = static_cast<LogType>(i);
 
 			if (_writer.is_started(log_type)) {
@@ -1046,19 +1052,16 @@ void Logger::publish_logger_status()
 				const float kb_written = _writer.get_total_written_file(log_type) / 1024.0f;
 				const float seconds = hrt_elapsed_time(&_statistics[i].start_time_file) * 1e-6f;
 
-				logger_status_s status;
-				status.type = i;
-				status.backend = _writer.backend();
+				status.is_logging = true;
 				status.total_written_kb = kb_written;
 				status.write_rate_kb_s = kb_written / seconds;
 				status.dropouts = _statistics[i].write_dropouts;
 				status.message_gaps = _message_gaps;
 				status.buffer_used_bytes = buffer_fill_count_file;
 				status.buffer_size_bytes = _writer.get_buffer_size_file(log_type);
-				status.num_messages = _num_subscriptions;
-				status.timestamp = hrt_absolute_time();
-				_logger_status_pub[i].publish(status);
 			}
+
+			_logger_status_pub[i].publish(status);
 		}
 
 		_logger_status_last = hrt_absolute_time();

--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -151,6 +151,7 @@ private:
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_GPS, health_component_t::gps, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_RC_RECEIVER, health_component_t::remote_control, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_AHRS, health_component_t::local_position_estimate, msg);
+			fillOutComponent(health_report, MAV_SYS_STATUS_LOGGING, health_component_t::logging, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE, health_component_t::absolute_pressure, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE, health_component_t::differential_pressure,
 					 msg);


### PR DESCRIPTION
### Solved Problem
I have a piece of companion software that automatically downloads flight logs from the vehicle over mavlink and uploads them to a server. I need to know when the logger is running or not so that I don't try to download a log file which is being actively written to (results in a partial log download and repeated downloads).

### Solution
The mavlink SYS_STATUS message can tell us if the logger is running or not. We just need to check the LoggerStatus in the health and arming checks and set the MAV_SYS_STATUS_LOGGING bit.