### PR TITLE
Revert part of PR that causes GZ simulation to send Acceleration and Gyro STALE error messages

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -164,6 +164,10 @@ param set-default COM_RC_IN_MODE 1
 # Speedup SITL startup
 param set-default EKF2_REQ_GPS_H 0.5
 
+# Multi-EKF
+param set-default EKF2_MULTI_IMU 3
+param set-default SENS_IMU_MODE 0
+
 param set-default IMU_GYRO_FFT_EN 1
 param set-default MAV_PROTO_VER 2 # Ensures QGC does not drop the first few packets after a SITL restart due to MAVLINK 1 packets
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The original PR #22736 from @dagar is here to disable multi EKF for SITL as there is only one IMU. But since the current IMU in GZ does not have any sensor noise, the messages coming in are basically duplicated and the non multi EKF will complain about it. Until we add noise to GZ, this would be the temporary fix. 

Fixes #{Github issue ID}
#22767

### Alternatives
We could also add the noise, but that might take a day to do properly, to also create the correct biases. 

### Test coverage
SITL 

