### PR TITLE
Update msg_files to PARENT_SCOPE

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -284,6 +284,9 @@ foreach(msg_file ${msg_files})
 	list(APPEND uorb_json_files ${msg_source_out_path}/${msg}.json)
 endforeach()
 
+# set parent scope msg_files for other modules to consume (eg topic_listener)
+set(msg_files ${msg_files} PARENT_SCOPE)
+
 # Generate uORB headers
 add_custom_command(
 	OUTPUT


### PR DESCRIPTION
### Solved Problem
The `main` branch cannot be built right now with Ubuntu 22 and ROS Humble. See the error message below:
```
CMake Error at /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:59 (message):
  rosidl_generate_interfaces() called without any interface files
Call Stack (most recent call first):
  platforms/ros2/CMakeLists.txt:63 (rosidl_generate_interfaces)
```

As the error message already implies, `rosidl_generate_interfaces` is called without any arguments in the file below. https://github.com/PX4/PX4-Autopilot/blob/d98800521644ff2ba5d761c66a0d601016b96dac/platforms/ros2/CMakeLists.txt#L56-L65

The source for this problem lies within the variable `msg_files` being unpopulated, because the scope of the variable was changed in commit 1ad5a9de087789546f1c26b5dc8d11f4f9633abc by @tstastny and @bkueng.

See file `msg/CMakeLists.txt` of the above commit:
```diff
- # set parent scope msg_files for other modules to consume (eg topic_listener)
- set(msg_files ${msg_files} PARENT_SCOPE)
-
```

### Solution
Set the scope of `msg_files` to `PARENT_SCOPE` again.
