### PR TITLE
Jenkinsfile: correct typo, missing comma

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -120,7 +120,7 @@ pipeline {
                      "px4_fmu-v6xrt_rover",
                      "px4_io-v2_default",
                      "raspberrypi_pico_default",
-                     "siyi_n7_default"
+                     "siyi_n7_default",
                      "sky-drones_smartap-airlink_default",
                      "spracing_h7extreme_default",
                      "thepeach_k1_default",


### PR DESCRIPTION
### Solved Problem
@PerFrivik was asking me about the following CI issue:
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/f1303a48-590d-4250-ab31-8fb9b9799732)

A quick investigation showed it's probably due to a missing comma.

Introduced in:
#22675 (2c81c9fdea0f589f4021a549d86969dc317327fa)

### Solution
Add comma

### Changelog Entry
```
Cleanup: CI script typo
```

### Test coverage
Let's see if Jenkins feels better 👀 