### PR TITLE
ekf2: allow wind dead-reckoning after manual position reset

### DIFF
--- a/src/modules/ekf2/EKF/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/airspeed_fusion.cpp
@@ -93,7 +93,7 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 		const bool is_airspeed_significant = airspeed_sample.true_airspeed > _params.arsp_thr;
 		const bool is_airspeed_consistent = (_aid_src_airspeed.test_ratio > 0.f && _aid_src_airspeed.test_ratio < 1.f);
 		const bool starting_conditions_passing = continuing_conditions_passing && is_airspeed_significant
-		                                         && (is_airspeed_consistent || !_control_status.flags.wind); // if wind isn't already estimated, the states are reset when starting airspeed fusion
+		                                         && (is_airspeed_consistent || !_control_status.flags.wind || _control_status.flags.inertial_dead_reckoning);
 
 		if (_control_status.flags.fuse_aspd) {
 			if (continuing_conditions_passing) {
@@ -118,17 +118,16 @@ void Ekf::controlAirDataFusion(const imuSample &imu_delayed)
 		} else if (starting_conditions_passing) {
 			ECL_INFO("starting airspeed fusion");
 
-			// If starting wind state estimation, reset the wind states and covariances before fusing any data
-			// Also catch the case where sideslip fusion enabled wind estimation recently and didn't converge yet.
-			const Vector2f wind_var_xy = getWindVelocityVariance();
+			if (_control_status.flags.inertial_dead_reckoning && !is_airspeed_consistent) {
+				resetVelUsingAirspeed(airspeed_sample);
 
-			if (!_control_status.flags.wind || (wind_var_xy(0) + wind_var_xy(1) > sq(_params.initial_wind_uncertainty))) {
-				// activate the wind states
-				_control_status.flags.wind = true;
-				// reset the wind speed states and corresponding covariances
+			} else if (!_control_status.flags.wind || getWindVelocityVariance().longerThan(_params.initial_wind_uncertainty)) {
+				// If starting wind state estimation, reset the wind states and covariances before fusing any data
+				// Also catch the case where sideslip fusion enabled wind estimation recently and didn't converge yet.
 				resetWindUsingAirspeed(airspeed_sample);
 			}
 
+			_control_status.flags.wind = true;
 			_control_status.flags.fuse_aspd = true;
 		}
 
@@ -244,6 +243,21 @@ void Ekf::resetWindUsingAirspeed(const airspeedSample &airspeed_sample)
 	resetStateCovariance<State::wind_vel>(P_wind);
 
 	ECL_INFO("reset wind using airspeed to (%.3f, %.3f)", (double)_state.wind_vel(0), (double)_state.wind_vel(1));
+
+	_aid_src_airspeed.time_last_fuse = _time_delayed_us;
+}
+
+void Ekf::resetVelUsingAirspeed(const airspeedSample &airspeed_sample)
+{
+	const float euler_yaw = getEulerYaw(_R_to_earth);
+
+	// Estimate velocity using zero sideslip assumption and airspeed measurement
+	Vector2f horizontal_velocity;
+	horizontal_velocity(0) = _state.wind_vel(0) + airspeed_sample.true_airspeed * cosf(euler_yaw);
+	horizontal_velocity(1) = _state.wind_vel(1) + airspeed_sample.true_airspeed * sinf(euler_yaw);
+
+	float vel_var = NAN; // Do not reset the velocity variance as wind variance estimate is most likely not correct
+	resetHorizontalVelocityTo(horizontal_velocity, vel_var);
 
 	_aid_src_airspeed.time_last_fuse = _time_delayed_us;
 }

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -788,6 +788,7 @@ private:
 
 	// Reset the wind states using the current airspeed measurement, ground relative nav velocity, yaw angle and assumption of zero sideslip
 	void resetWindUsingAirspeed(const airspeedSample &airspeed_sample);
+	void resetVelUsingAirspeed(const airspeedSample &airspeed_sample);
 #endif // CONFIG_EKF2_AIRSPEED
 
 #if defined(CONFIG_EKF2_SIDESLIP)

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.cpp
@@ -100,6 +100,11 @@ bool EkfWrapper::isIntendingBetaFusion() const
 	return _ekf->control_status_flags().fuse_beta;
 }
 
+bool EkfWrapper::isIntendingAirspeedFusion() const
+{
+	return _ekf->control_status_flags().fuse_aspd;
+}
+
 void EkfWrapper::enableGpsFusion()
 {
 	_ekf_params->gnss_ctrl |= static_cast<int32_t>(GnssCtrl::HPOS) | static_cast<int32_t>(GnssCtrl::VEL);

--- a/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
+++ b/src/modules/ekf2/test/sensor_simulator/ekf_wrapper.h
@@ -73,6 +73,8 @@ public:
 	void disableBetaFusion();
 	bool isIntendingBetaFusion() const;
 
+	bool isIntendingAirspeedFusion() const;
+
 	void enableGpsFusion();
 	void disableGpsFusion();
 	bool isIntendingGpsFusion() const;


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Wind dead-reckoning using sideslip and airspeed fusion isn't able to start if the airspeed data isn't consistent with the filter. Since the ekf is doing inertial dead-reckoning, the estimate is probably worse than the airspeed measurement and we should allow a velocity reset.

### Solution
When doing inertial dead-reckoning, allow airspeed fusion to start and reset the velocity estimate using airspeed if the consistency check is failing.

### Changelog Entry
For release notes:
```
Allow wind dead-reckoning after manual position reset
New parameter: -
Documentation: -
```