### PR TITLE
FW Attitude Controller: fix manual yaw rate setpoint limit

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -361,7 +361,7 @@ void FixedwingAttitudeControl::Run()
 
 					/* add yaw rate setpoint from sticks in all attitude-controlled modes */
 					if (_vcontrol_mode.flag_control_manual_enabled) {
-						body_rates_setpoint(2) += math::constrain(_manual_control_setpoint.yaw * radians(_param_fw_y_rmax.get()),
+						body_rates_setpoint(2) += math::constrain(_manual_control_setpoint.yaw * radians(_param_man_yr_max.get()),
 									  -radians(_param_fw_y_rmax.get()), radians(_param_fw_y_rmax.get()));
 					}
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -155,7 +155,8 @@ private:
 		(ParamFloat<px4::params::FW_WR_IMAX>) _param_fw_wr_imax,
 		(ParamFloat<px4::params::FW_WR_P>) _param_fw_wr_p,
 
-		(ParamFloat<px4::params::FW_Y_RMAX>) _param_fw_y_rmax
+		(ParamFloat<px4::params::FW_Y_RMAX>) _param_fw_y_rmax,
+		(ParamFloat<px4::params::FW_MAN_YR_MAX>) _param_man_yr_max
 
 	)
 


### PR DESCRIPTION
### Solved Problem
FW_Y_RMAX and not FW_MAN_YR_MAX used for max manual yawing rate in Attitude controlled modes, thus not possible to disable manual yaw rate input without disabling yaw rate control completely. 

### Solution
Use FW_MAN_YR_MAX.

### Changelog Entry
For release notes:
```
Bugfix: FW Attitude Controller: fix manual yaw rate setpoint limit


### Context
Original PR of the "add option to disable manual yaw": https://github.com/PX4/PX4-Autopilot/pull/20647
