### PR TITLE
Reintroduce optional parameter versioning mechanism for airframe maintainers

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -36,6 +36,12 @@ set SDCARD_FORMAT no
 set STARTUP_TUNE 1
 set VEHICLE_TYPE none
 
+# Airframe parameter versioning
+# Value set to 1 by default but can optionally be overridden in the airframe configuration startup script.
+# Airframe maintainers can ensure a reset to the airframe defaults during an update by increasing by one.
+# e.g. add line "set PARAM_DEFAULTS_VER 2" in your airframe file to build the first update that enfoces a reset.
+set PARAM_DEFAULTS_VER 1
+
 #
 # Print full system version.
 #
@@ -182,13 +188,11 @@ else
 		netman update -i eth0
 	fi
 
-	#
-	# If the airframe has been previously reset SYS_AUTCONFIG will have been set to 1 and other params will be reset on the next boot.
-	#
+	# To trigger a parameter reset during boot SYS_AUTCONFIG was set to 1 before
 	if param greater SYS_AUTOCONFIG 0
 	then
-		# Reset params except Airframe, RC calibration, sensor calibration, flight modes, total flight time, and next flight UUID.
-		param reset_all SYS_AUTOSTART RC* CAL_* COM_FLTMODE* LND_FLIGHT* TC_* COM_FLIGHT*
+		# Reset parameters except airframe, parameter version, RC calibration, sensor calibration, flight modes, total flight time, flight UUID
+		param reset_all SYS_AUTOSTART SYS_PARAM_VER RC* CAL_* COM_FLTMODE* LND_FLIGHT* TC_* COM_FLIGHT*
 	fi
 
 	#
@@ -232,6 +236,17 @@ else
 		. ${R}$AUTOSTART_PATH
 	fi
 	unset AUTOSTART_PATH
+
+	# Check parameter version and reset upon airframe configuration version mismatch.
+	# Reboot required because "param reset_all" would reset all "param set" lines from airframe.
+	if ! param compare SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
+	then
+		echo "Switched to different parameter version. Resetting parameters."
+		param set SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
+		param set SYS_AUTOCONFIG 1
+		param save
+		reboot
+	fi
 
 	#
 	# Start the tone_alarm driver.
@@ -598,6 +613,7 @@ unset LOGGER_ARGS
 unset LOGGER_BUF
 unset PARAM_FILE
 unset PARAM_BACKUP_FILE
+unset PARAM_DEFAULTS_VER
 unset RC_INPUT_ARGS
 unset SDCARD_AVAILABLE
 unset SDCARD_EXT_PATH

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -84,6 +84,19 @@ PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
 PARAM_DEFINE_INT32(SYS_HITL, 0);
 
 /**
+ * Parameter version
+ *
+ * This is used internally only: an airframe configuration might set an expected
+ * parameter version value via PARAM_DEFAULTS_VER. This is checked on bootup
+ * against SYS_PARAM_VER, and if they do not match, parameters are reset and
+ * reloaded from the airframe configuration.
+ *
+ * @min 0
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_PARAM_VER, 1);
+
+/**
  * Enable auto start of rate gyro thermal calibration at the next power up.
  *
  * 0 : Set to 0 to do nothing

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -310,6 +310,9 @@ MavlinkParametersManager::send()
 		param_find("TRIG_MODE");
 		param_find("UAVCAN_ENABLE");
 
+		// parameter only used in startup script but should show on ground station
+		param_find("SYS_PARAM_VER");
+
 		_first_send = true;
 	}
 


### PR DESCRIPTION
### Solved Problem
When working on multiple projects I found that many reintroduced a mechanism to allow automatically resetting the parameter configuration during a product update. This functionality was initially introduced in https://github.com/PX4/PX4-Autopilot/pull/11760 and removed again in https://github.com/PX4/PX4-Autopilot/pull/17279 because we (including me) thought that the `param set-default` mechanism of https://github.com/PX4/PX4-Autopilot/pull/16796 would solve all the cases. But the case where the airframe maintainer wants to enforce a reset to airframe defaults is not covered anymore with the `param set-default` mechanism. For products based on PX4 this is still required to ensure proper functionality after a major update.

### Solution
I suggest to reintroduce what was removed in https://github.com/PX4/PX4-Autopilot/pull/17279 in a slightly adapted way.
The mechanism is still exactly the same. An airframe maintainer can **optionally** add e.g. an `set PARAM_DEFAULTS_VER 2` line in the airframe file such that vehicles coming from an older (or newer) version airframe as detected using the `SYS_PARAM_VER` parameter get reset to the default configuration. As usual accumulating flight numbers, hours, RC, sensor and **newly also airspeed calibration** are preserved.

### Changelog Entry
```
Feature: Reintroduce optional parameter versioning mechanism for airframe maintainers
```

### Alternatives
I tried to work around the necessity to trigger a reboot for the mechanism but after some testing it's still the most useful way in my eyes. The parameter version is only available after loading the airframe but arch and board defaults need to be loaded before that and the reset has to be done before that even because otherwise all `param set` lines in these configurations would be reset again. So either we'd load the airframe twice per boot or just reboot the system if a reset is required.

### Test coverage
I tested this on a vehicle which already had a parameter version from the previous mechanism and it seamlessly reset to the latest defaults even if I manually changed the parameters manually before the update.

### Context
I was in discussion with @dagar about a possibly better less shotgun way to address the specific use cases solved by this mechanism but at least to me it's not clear yet how to solve all cases especially during bringups and major updates where a known working configuration is usually crucial to move multiple vehicles forward.