### PR TITLE
Add Parameter to Toggle Automatic GPS Receiver Configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,8 +16,8 @@
 	branch = main
 [submodule "src/drivers/gps/devices"]
 	path = src/drivers/gps/devices
-	url = https://github.com/PX4/PX4-GPSDrivers.git
-	branch = main
+	url = https://github.com/flyingthingsintothings/PX4-GPSDrivers
+	branch = gps-autoconfig-parameter
 [submodule "platforms/nuttx/NuttX/nuttx"]
 	path = platforms/nuttx/NuttX/nuttx
 	url = https://github.com/PX4/NuttX.git

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -828,6 +828,10 @@ GPS::run()
 		param_get(handle, &gnssSystemsParam);
 	}
 
+	int32_t configure_device = 0;
+	handle = param_find("GPS_AUTO_CONFIG");
+	param_get(handle, &configure_device);
+
 	initializeCommunicationDump();
 
 	uint64_t last_rate_measurement = hrt_absolute_time();
@@ -936,6 +940,7 @@ GPS::run()
 		}
 
 		gpsConfig.interface_protocols = static_cast<GPSHelper::InterfaceProtocolsMask>(gps_ubx_cfg_intf);
+		gpsConfig.configure_device = configure_device;
 
 		if (_helper && _helper->configure(_baudrate, gpsConfig) == 0) {
 

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -290,3 +290,16 @@ PARAM_DEFINE_INT32(GPS_1_GNSS, 0);
  * @group GPS
  */
 PARAM_DEFINE_INT32(GPS_2_GNSS, 0);
+
+/**
+ * Enable automatic receiver configuration
+ *
+ * Enable automatic configuration of the GPS receivers.
+ *
+ * Currently this functionality is just implemented for Septentrio receivers.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_AUTO_CONFIG, 1);


### PR DESCRIPTION
### Solved Problem
Currently the autopilot always automatically configures the attached receivers. For some GPS receivers, the driver overwrites the complete runtime configuration. If a user wants to make manual edits to the runtime configuration, for example because they want to enable more features or add logging, they need a way to preserve their changes.

### Solution
- Add a parameter called `GPS_AUTO_CONFIG` that lets users disable automatic receiver configuration.

### Changelog Entry
For release notes:
```
Feature: Add parameter that can disable automatic GPS receiver configuration
New parameter: GPS_AUTO_CONFIG
Documentation: Unknown
```

### Alternatives
\/

### Test coverage
- Unit/integration test: \/
- Simulation/hardware testing logs: https://review.px4.io/

### Context
See https://github.com/PX4/PX4-GPSDrivers/pull/152

@SeptentrioGNSS