### PR TITLE
Add minimal Skynode RC13 config to the PAB manifest

### DIFF
--- a/boards/px4/fmu-v5x/init/rc.board_defaults
+++ b/boards/px4/fmu-v5x/init/rc.board_defaults
@@ -16,7 +16,7 @@ param set-default SENS_EN_INA238 0
 param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 1
 
-if ver hwbasecmp 008 009 00a 010
+if ver hwbasecmp 008 009 00a 010 011
 then
 	# Skynode: use the "custom participant" config for uxrce_dds_client
 	param set-default UXRCE_DDS_PTCFG 2

--- a/boards/px4/fmu-v5x/init/rc.board_mavlink
+++ b/boards/px4/fmu-v5x/init/rc.board_mavlink
@@ -3,7 +3,7 @@
 # board specific MAVLink startup script.
 #------------------------------------------------------------------------------
 
-if ver hwbasecmp 008 009 00a 010
+if ver hwbasecmp 008 009 00a 010 011
 then
 	# Start MAVLink on the UART connected to the mission computer
 	mavlink start -d /dev/ttyS4 -b 3000000 -r 290000 -m onboard_low_bandwidth -x -z

--- a/boards/px4/fmu-v5x/init/rc.board_sensors
+++ b/boards/px4/fmu-v5x/init/rc.board_sensors
@@ -49,7 +49,7 @@ then
 	fi
 fi
 
-if ver hwbasecmp 008 009 00a 010
+if ver hwbasecmp 008 009 00a 010 011
 then
 	#SKYNODE base fmu board orientation
 

--- a/boards/px4/fmu-v6x/init/rc.board_defaults
+++ b/boards/px4/fmu-v6x/init/rc.board_defaults
@@ -18,7 +18,7 @@ param set-default SENS_EN_INA238 0
 param set-default SENS_EN_INA228 0
 param set-default SENS_EN_INA226 0
 
-if ver hwbasecmp 009 010
+if ver hwbasecmp 009 010 011
 then
 	# Skynode: use the "custom participant" config for uxrce_dds_client
 	param set-default UXRCE_DDS_PTCFG 2

--- a/boards/px4/fmu-v6x/init/rc.board_mavlink
+++ b/boards/px4/fmu-v6x/init/rc.board_mavlink
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 # if skynode base board is detected start Mavlink on Telem2
-if ver hwbasecmp 009 010
+if ver hwbasecmp 009 010 011
 then
 	mavlink start -d /dev/ttyS4 -b 3000000 -r 290000 -m onboard_low_bandwidth -x -z
 

--- a/boards/px4/fmu-v6x/init/rc.board_sensors
+++ b/boards/px4/fmu-v6x/init/rc.board_sensors
@@ -56,7 +56,7 @@ then
 fi
 
 #Start Auterion Power Module selector for Skynode boards
-if ver hwbasecmp 009 010
+if ver hwbasecmp 009 010 011
 then
 	pm_selector_auterion start
 else
@@ -93,7 +93,7 @@ else
 		icm20649 -s -R 6 start
 	else
 		# Internal SPI BMI088
-		if ver hwbasecmp 009 010
+		if ver hwbasecmp 009 010 011
 		then
 			bmi088 -A -R 6 -s start
 			bmi088 -G -R 6 -s start
@@ -110,7 +110,7 @@ else
 	fi
 
 	# Internal SPI bus ICM42688p
-	if ver hwbasecmp 009 010
+	if ver hwbasecmp 009 010 011
 	then
 		icm42688p -R 12 -s start
 	else
@@ -127,7 +127,7 @@ else
 		# Internal SPI bus ICM-42670-P (hard-mounted)
 		icm42670p -R 10 -s start
 	else
-		if ver hwbasecmp 009 010
+		if ver hwbasecmp 009 010 011
 		then
 			icm20602 -R 6 -s start
 		else

--- a/boards/px4/fmu-v6xrt/init/rc.board_mavlink
+++ b/boards/px4/fmu-v6xrt/init/rc.board_mavlink
@@ -4,7 +4,7 @@
 #------------------------------------------------------------------------------
 
 # if skynode base board is detected start Mavlink on Telem2
-if ver hwbasecmp 009 010
+if ver hwbasecmp 009 010 011
 then
 	mavlink start -d /dev/ttyS5 -b 3000000 -r 290000 -m onboard_low_bandwidth -x -z
 

--- a/platforms/common/pab_manifest.c
+++ b/platforms/common/pab_manifest.c
@@ -294,12 +294,6 @@ static const px4_hw_mft_item_t base_configuration_9[] = {
 		.connection  = px4_hw_con_onboard,
 	},
 	{
-		.id          =  PX4_MFT_PM2,
-		.present     = 1,
-		.mandatory   = 1,
-		.connection  = px4_hw_con_onboard,
-	},
-	{
 		.id          = PX4_MFT_ETHERNET,
 		.present     = 1,
 		.mandatory   = 1,
@@ -316,6 +310,52 @@ static const px4_hw_mft_item_t base_configuration_9[] = {
 // BASE ID 10  Skynode QS no USB Alaised to ID 9
 // BASE ID 16  Auterion Skynode RC10, RC11, RC12, RC13 Alaised to ID 0
 
+// BASE ID 17  Auterion Skynode RC13 with many parts removed
+static const px4_hw_mft_item_t base_configuration_17[] = {
+	{
+		.id          = PX4_MFT_PX4IO,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_onboard,
+	},
+	{
+		.id          = PX4_MFT_USB,
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = px4_hw_con_unknown,
+	},
+	{
+		.id          = PX4_MFT_CAN2,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_onboard,
+	},
+	{
+		.id          = PX4_MFT_CAN3,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_unknown,
+	},
+	{
+		.id          = PX4_MFT_PM2,
+		.present     = 0,
+		.mandatory   = 0,
+		.connection  = px4_hw_con_onboard,
+	},
+	{
+		.id          = PX4_MFT_ETHERNET,
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = px4_hw_con_connector,
+	},
+	{
+		.id          = PX4_MFT_T100_ETH,
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = px4_hw_con_onboard,
+	},
+};
+
 
 static px4_hw_mft_list_entry_t mft_lists[] = {
 //  ver_rev
@@ -329,6 +369,7 @@ static px4_hw_mft_list_entry_t mft_lists[] = {
 	{HW_BASE_ID(9),  base_configuration_9, arraySize(base_configuration_9)},  // Auterion Skynode ver 9
 	{HW_BASE_ID(10), base_configuration_9, arraySize(base_configuration_9)},  // Auterion Skynode ver 10
 	{HW_BASE_ID(16), base_configuration_0, arraySize(base_configuration_0)},  // Auterion Skynode ver 16
+	{HW_BASE_ID(17), base_configuration_17, arraySize(base_configuration_17)},  // Auterion Skynode ver 17
 };
 
 /************************************************************************************


### PR DESCRIPTION
Adds a new baseboard revision for a Skynode RC13 baseboard without PX4IO, CAN2, CAN3, PM2.

### Changelog Entry

For release notes:
```
Feature: Add Skynode RC13 baseboard with many parts removed
```

### Test coverage

Yes. SBUS input has been tested.
