### PR TITLE
netman fix usage on a filesystem

### DIFF
--- a/src/systemcmds/netman/netman.cpp
+++ b/src/systemcmds/netman/netman.cpp
@@ -201,7 +201,7 @@ public:
 		struct ipv4cfg_s ipcfg;
 		int rv = ipcfg_read(netdev, (FAR struct ipcfg_s *) &ipcfg, AF_INET);
 
-		if (rv == -EINVAL ||
+		if (rv == -EINVAL || rv == -ENOENT ||
 		    (rv == OK  && (ipcfg.proto > IPv4PROTO_FALLBACK || ipcfg.ipaddr == 0xffffffff))) {
 			// Build a default
 			ipcfg.ipaddr  = HTONL(DEFAULT_IP);


### PR DESCRIPTION
Allows netman config to be file instead of a mtd device.
ENOENT returns if the file doesn't exist yet, when using mtd the /fs/mtd_net always exist. 
On a filesystem you've to generate the file so if ENOENT returns we've to regenerate the default config as well.

Also updates apps to allow for delayed opening of ipcfg file by polling if the filesystem ha been mounted, this can be done by setting the retry KConfig symbol 
