### PR TITLE
ICP201: increase config delay

### DIFF
--- a/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
+++ b/src/drivers/barometer/invensense/icp201xx/ICP201XX.cpp
@@ -251,7 +251,7 @@ ICP201XX::RunImpl()
 	case STATE::CONFIG: {
 			if (configure()) {
 				_state = STATE::WAIT_READ;
-				ScheduleDelayed(30_ms);
+				ScheduleDelayed(50_ms);
 
 			} else {
 				if (hrt_elapsed_time(&_reset_timestamp) > 1000_ms) {


### PR DESCRIPTION
Fixes wrong altitude reporting trough barometer with the ICP201XX sensor by InvenSense in external I2C.