### PR TITLE
bmp388: Driver print BMP390 identifier when detected

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -77,6 +77,7 @@ BMP388::init()
 
 	if (_chip_id == BMP390_CHIP_ID) {
 		_interface->set_device_type(DRV_BARO_DEVTYPE_BMP390);
+		this->_item_name = "bmp390";
 	}
 
 	_chip_rev_id = _interface->get_reg(BMP3_REV_ID_ADDR);


### PR DESCRIPTION
The BMP388 Driver supports both BMP388 and BMP390 but doesn't show this on startup.
This patch changes the `_item_name` on startup when a BMP390 gets detected

For example a board with a BMP338 and BMP390 shows the following now.
```
bmp388 #0 on I2C bus 3 address 0x77
bmp390 #1 on I2C bus 2 (external) address 0x76
```