### PR TITLE
Fix AppState unable to restart after requestExit

### DIFF
--- a/platforms/common/include/px4_platform_common/app.h
+++ b/platforms/common/include/px4_platform_common/app.h
@@ -54,7 +54,9 @@ public:
 	void requestExit() { _exitRequested = true; }
 
 	bool isRunning() { return _isRunning; }
-	void setRunning(bool running) { _isRunning = running; }
+	void setRunning(bool running) { 
+    if(running) _exitRequested = false;
+    _isRunning = running; }
 
 protected:
 	bool _exitRequested;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When developing an external module I found that after requesting exit from the start program, any other attempt to start the module would have it instantly quit. This is because setting an AppState to running doesn't clear the request exit flag.

### Solution
- Clear the request exit flag after setting AppState to running

### Changelog Entry
For release notes:
```
Bugfix AppState unable to run after requesting exit
```
