### PR TITLE
mag calibration: minor cleanup

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -1006,8 +1006,8 @@ int do_mag_calibration_quick(orb_advert_t *mavlink_log_pub, float heading_radian
 			return PX4_ERROR;
 		}
 
-		calibration_log_critical(mavlink_log_pub, "Assuming vehicle is facing heading %.1f degrees",
-					 (double)math::radians(heading_radians));
+		calibration_log_info(mavlink_log_pub, "Assuming vehicle is facing heading %.1f degrees",
+					 (double)math::degrees(heading_radians));
 
 		matrix::Eulerf euler{matrix::Quatf{attitude.q}};
 		euler(2) = heading_radians;

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -1007,7 +1007,7 @@ int do_mag_calibration_quick(orb_advert_t *mavlink_log_pub, float heading_radian
 		}
 
 		calibration_log_info(mavlink_log_pub, "Assuming vehicle is facing heading %.1f degrees",
-					 (double)math::degrees(heading_radians));
+				     (double)math::degrees(heading_radians));
 
 		matrix::Eulerf euler{matrix::Quatf{attitude.q}};
 		euler(2) = heading_radians;


### PR DESCRIPTION
### Solved Problem

- The existing code erroneously converts a variable containing a radian value into radians again for output. This update converts the variable containing the radian value into degrees for output. 
- The log level has been changed from critical to info.

And I have many questions about quick calibration.
Could you please check this issue - https://discuss.px4.io/t/quick-accel-magnetometer-calibration/37078

