### PR TITLE
update mission after changing home position

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -253,6 +253,7 @@ MissionBase::on_active()
 
 	updateMavlinkMission();
 	updateDatamanCache();
+	updateMissionAltAfterHomeChanged();
 
 	/* Check the mission */
 	if (!_mission_checked && canRunMissionFeasibility()) {
@@ -1374,4 +1375,13 @@ bool MissionBase::canRunMissionFeasibility()
 	       (_geofence_status_sub.get().timestamp > 0) && // Geofence data must be loaded
 	       (_geofence_status_sub.get().geofence_id == _mission.geofence_id) &&
 	       (_geofence_status_sub.get().status == geofence_status_s::GF_STATUS_READY);
+}
+
+void MissionBase::updateMissionAltAfterHomeChanged()
+{
+	if (_navigator->get_home_position()->update_count > _home_update_counter) {
+		_navigator->get_position_setpoint_triplet()->current.alt = get_absolute_altitude_for_item(_mission_item);
+		_navigator->set_position_setpoint_triplet_updated();
+		_home_update_counter = _navigator->get_home_position()->update_count;
+	}
 }

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1380,8 +1380,12 @@ bool MissionBase::canRunMissionFeasibility()
 void MissionBase::updateMissionAltAfterHomeChanged()
 {
 	if (_navigator->get_home_position()->update_count > _home_update_counter) {
-		_navigator->get_position_setpoint_triplet()->current.alt = get_absolute_altitude_for_item(_mission_item);
+		float altitude_diff = _navigator->get_home_position()->alt - _last_home_alt;
+		_navigator->get_position_setpoint_triplet()->previous.alt = _navigator->get_position_setpoint_triplet()->previous.alt + altitude_diff;
+		_navigator->get_position_setpoint_triplet()->current.alt = _navigator->get_position_setpoint_triplet()->current.alt + altitude_diff;
+		_navigator->get_position_setpoint_triplet()->next.alt = _navigator->get_position_setpoint_triplet()->next.alt + altitude_diff;
 		_navigator->set_position_setpoint_triplet_updated();
 		_home_update_counter = _navigator->get_home_position()->update_count;
 	}
+	_last_home_alt = _navigator->get_home_position()->alt;
 }

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1380,12 +1380,16 @@ bool MissionBase::canRunMissionFeasibility()
 void MissionBase::updateMissionAltAfterHomeChanged()
 {
 	if (_navigator->get_home_position()->update_count > _home_update_counter) {
-		float altitude_diff = _navigator->get_home_position()->alt - _last_home_alt;
-		_navigator->get_position_setpoint_triplet()->previous.alt = _navigator->get_position_setpoint_triplet()->previous.alt + altitude_diff;
+		float new_alt = get_absolute_altitude_for_item(_mission_item);
+		float altitude_diff = new_alt - _navigator->get_position_setpoint_triplet()->current.alt;
+		if (_navigator->get_position_setpoint_triplet()->previous.valid && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->previous.alt)) {
+		    _navigator->get_position_setpoint_triplet()->previous.alt = _navigator->get_position_setpoint_triplet()->previous.alt + altitude_diff;
+		    }
 		_navigator->get_position_setpoint_triplet()->current.alt = _navigator->get_position_setpoint_triplet()->current.alt + altitude_diff;
-		_navigator->get_position_setpoint_triplet()->next.alt = _navigator->get_position_setpoint_triplet()->next.alt + altitude_diff;
+		if (_navigator->get_position_setpoint_triplet()->next.valid && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->next.alt)) {
+		    _navigator->get_position_setpoint_triplet()->next.alt = _navigator->get_position_setpoint_triplet()->next.alt + altitude_diff;
+		    }
 		_navigator->set_position_setpoint_triplet_updated();
 		_home_update_counter = _navigator->get_home_position()->update_count;
 	}
-	_last_home_alt = _navigator->get_home_position()->alt;
 }

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1382,13 +1382,22 @@ void MissionBase::updateMissionAltAfterHomeChanged()
 	if (_navigator->get_home_position()->update_count > _home_update_counter) {
 		float new_alt = get_absolute_altitude_for_item(_mission_item);
 		float altitude_diff = new_alt - _navigator->get_position_setpoint_triplet()->current.alt;
-		if (_navigator->get_position_setpoint_triplet()->previous.valid && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->previous.alt)) {
-		    _navigator->get_position_setpoint_triplet()->previous.alt = _navigator->get_position_setpoint_triplet()->previous.alt + altitude_diff;
-		    }
-		_navigator->get_position_setpoint_triplet()->current.alt = _navigator->get_position_setpoint_triplet()->current.alt + altitude_diff;
-		if (_navigator->get_position_setpoint_triplet()->next.valid && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->next.alt)) {
-		    _navigator->get_position_setpoint_triplet()->next.alt = _navigator->get_position_setpoint_triplet()->next.alt + altitude_diff;
-		    }
+
+		if (_navigator->get_position_setpoint_triplet()->previous.valid
+		    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->previous.alt)) {
+			_navigator->get_position_setpoint_triplet()->previous.alt = _navigator->get_position_setpoint_triplet()->previous.alt +
+					altitude_diff;
+		}
+
+		_navigator->get_position_setpoint_triplet()->current.alt = _navigator->get_position_setpoint_triplet()->current.alt +
+				altitude_diff;
+
+		if (_navigator->get_position_setpoint_triplet()->next.valid
+		    && PX4_ISFINITE(_navigator->get_position_setpoint_triplet()->next.alt)) {
+			_navigator->get_position_setpoint_triplet()->next.alt = _navigator->get_position_setpoint_triplet()->next.alt +
+					altitude_diff;
+		}
+
 		_navigator->set_position_setpoint_triplet_updated();
 		_home_update_counter = _navigator->get_home_position()->update_count;
 	}

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -448,7 +448,15 @@ private:
 	 */
 	bool checkMissionDataChanged(mission_s new_mission);
 
+	/**
+	 * @brief update current mission altitude after the home position has changed.
+	 */
+
+	void updateMissionAltAfterHomeChanged();
+
 	bool canRunMissionFeasibility();
+
+	uint32_t _home_update_counter = 0; /**< Variable to store the previous value for home change detection.*/
 
 	bool _align_heading_necessary{false}; // if true, heading of vehicle needs to be aligned with heading of next waypoint. Used to create new mission items for heading alignment.
 

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -457,7 +457,7 @@ private:
 	bool canRunMissionFeasibility();
 
 	uint32_t _home_update_counter = 0; /**< Variable to store the previous value for home change detection.*/
-
+	float _last_home_alt = 0; /**< A variable used to store the altitude of the previous home point is employed to update the mission after a home modification.*/
 	bool _align_heading_necessary{false}; // if true, heading of vehicle needs to be aligned with heading of next waypoint. Used to create new mission items for heading alignment.
 
 	mission_item_s _last_gimbal_configure_item {};

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -457,7 +457,7 @@ private:
 	bool canRunMissionFeasibility();
 
 	uint32_t _home_update_counter = 0; /**< Variable to store the previous value for home change detection.*/
-	float _last_home_alt = 0; /**< A variable used to store the altitude of the previous home point is employed to update the mission after a home modification.*/
+
 	bool _align_heading_necessary{false}; // if true, heading of vehicle needs to be aligned with heading of next waypoint. Used to create new mission items for heading alignment.
 
 	mission_item_s _last_gimbal_configure_item {};


### PR DESCRIPTION
### Solved Problem
fix the bug which cause  drone can't finish mission after changing home altitude.Update mission after changing home position.

 ### Summary
This state management bug will result in the drone being unable to reach the waypoint and thus continuing the mission.And continues to drift irregularly near the waypoints.

### Details
1. When the drone is executing a mission, PX4 calculates the distance between the drone and the current target waypoint, and checks if it has reached the vicinity.

   Here calculates the distance.
https://github.com/PX4/PX4-Autopilot/blob/8b96cd5372c343ef2a3f8a8b805d5b39b47a8008/src/modules/navigator/mission_block.cpp#L197-L201
   When mission altitude mode is **Relative to Launch** `mission_item_altitude_amsl=mission_item.altitude + home_alt`

   And here checks whether it is less than the acceptable radius.
https://github.com/PX4/PX4-Autopilot/blob/8b96cd5372c343ef2a3f8a8b805d5b39b47a8008/src/modules/navigator/mission_block.cpp#L394-L396

2. When the drone is executing a mission, if the user modifies the home point to a new location (with a different altitude), the value of 'dist' will immediately change based on the new home point's altitude (which determines the check for whether the drone has reached the waypoint). However, the current actual executed 'mission_item' does not get updated.

   This will result in a discrepancy between the actual executed target of the drone and the checked completion target, causing the drone to start randomly oscillating near the waypoint.

![image](https://github.com/PX4/PX4-Autopilot/assets/151698793/59782bec-8394-4621-9250-27d0e4ec038e)


### Verification

We added some debug output to watch the drone's state change,and found every time the user changes the home point, 'dist_z' (altitude) also changes accordingly, but the 'mission_item' does not.

### Temporary Patch

There are currently two patching approaches based on the expectations for how the drone should operate after modifying the home point: 
1. After changing the drone's home point altitude, the currently executed mission target should also change immediately 
2. Once the mission is uploaded and completed, the 'mission_item' should no longer change, even if the home altitude changes; the waypoint altitude should remain relative to the altitude at the time of mission upload

### Impact
- This vulnerability could be exploited by attackers for covert attacks
- When a benign user modifies the home point while the drone is executing a mission, the drone may oscillate, come into contact with surrounding obstacles, and ultimately crash
- Modifying the home point to a new location during the mission execution will result in the drone randomly drifting near the next waypoint. This could lead to collisions and crashes.https://github.com/PX4/PX4-Autopilot/issues/22576



https://github.com/PX4/PX4-Autopilot/assets/151698793/273dd910-c92e-4817-8385-45c7ad38c3f8

Some bugs prevent you from directly viewing the video.You can **download** and check this vedio.

![image](https://github.com/PX4/PX4-Autopilot/assets/151698793/41d03721-bdd4-4e6d-a1ec-e6b47780ffb5)



### Solution
- Add an update for the current setpoint altitude when the home point is changed. 


### Test coverage
- Simulation/hardware testing logs:https://logs.px4.io/plot_app?log=0488b27d-6137-481a-9bb1-1b084777b2de


