### PR TITLE
sensors: update loop limit iterations

### DIFF
--- a/src/modules/mag_bias_estimator/MagBiasEstimator.cpp
+++ b/src/modules/mag_bias_estimator/MagBiasEstimator.cpp
@@ -157,10 +157,11 @@ void MagBiasEstimator::Run()
 		bool updated = false;
 
 		for (int mag_index = 0; mag_index < MAX_SENSOR_COUNT; mag_index++) {
+			int sensor_mag_updates = 0;
 			sensor_mag_s sensor_mag;
 
-			while (_sensor_mag_subs[mag_index].update(&sensor_mag)) {
-
+			while ((sensor_mag_updates < sensor_mag_s::ORB_QUEUE_LENGTH) && _sensor_mag_subs[mag_index].update(&sensor_mag)) {
+				sensor_mag_updates++;
 				updated = true;
 
 				// apply existing mag calibration

--- a/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
+++ b/src/modules/sensors/vehicle_acceleration/VehicleAcceleration.cpp
@@ -231,9 +231,12 @@ void VehicleAcceleration::Run()
 	}
 
 	// process all outstanding messages
+	int sensor_sub_updates = 0;
 	sensor_accel_s sensor_data;
 
-	while (_sensor_sub.update(&sensor_data)) {
+	while ((sensor_sub_updates < sensor_accel_s::ORB_QUEUE_LENGTH) && _sensor_sub.update(&sensor_data)) {
+		sensor_sub_updates++;
+
 		const Vector3f accel_raw{sensor_data.x, sensor_data.y, sensor_data.z};
 
 		if (accel_raw.isAllFinite()) {

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -163,9 +163,11 @@ void VehicleAirData::Run()
 		}
 
 		if (_advertised[uorb_index]) {
+			int sensor_sub_updates = 0;
 			sensor_baro_s report;
 
-			while (_sensor_sub[uorb_index].update(&report)) {
+			while ((sensor_sub_updates < sensor_baro_s::ORB_QUEUE_LENGTH) && _sensor_sub[uorb_index].update(&report)) {
+				sensor_sub_updates++;
 
 				if (_calibration[uorb_index].device_id() != report.device_id) {
 					_calibration[uorb_index].set_device_id(report.device_id);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -822,9 +822,12 @@ void VehicleAngularVelocity::Run()
 
 	if (_fifo_available) {
 		// process all outstanding fifo messages
+		int sensor_sub_updates = 0;
 		sensor_gyro_fifo_s sensor_fifo_data;
 
-		while (_sensor_gyro_fifo_sub.update(&sensor_fifo_data)) {
+		while ((sensor_sub_updates < sensor_gyro_fifo_s::ORB_QUEUE_LENGTH) && _sensor_gyro_fifo_sub.update(&sensor_fifo_data)) {
+			sensor_sub_updates++;
+
 			const float inverse_dt_s = 1e6f / sensor_fifo_data.dt;
 			const int N = sensor_fifo_data.samples;
 			static constexpr int FIFO_SIZE_MAX = sizeof(sensor_fifo_data.x) / sizeof(sensor_fifo_data.x[0]);
@@ -863,9 +866,12 @@ void VehicleAngularVelocity::Run()
 
 	} else {
 		// process all outstanding messages
+		int sensor_sub_updates = 0;
 		sensor_gyro_s sensor_data;
 
-		while (_sensor_sub.update(&sensor_data)) {
+		while ((sensor_sub_updates < sensor_gyro_s::ORB_QUEUE_LENGTH) && _sensor_sub.update(&sensor_data)) {
+			sensor_sub_updates++;
+
 			if (Vector3f(sensor_data.x, sensor_data.y, sensor_data.z).isAllFinite()) {
 
 				if (_timestamp_sample_last == 0 || (sensor_data.timestamp_sample <= _timestamp_sample_last)) {

--- a/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
+++ b/src/modules/sensors/vehicle_magnetometer/VehicleMagnetometer.cpp
@@ -461,9 +461,11 @@ void VehicleMagnetometer::Run()
 		}
 
 		if (_advertised[uorb_index]) {
+			int sensor_mag_updates = 0;
 			sensor_mag_s report;
 
-			while (_sensor_sub[uorb_index].update(&report)) {
+			while ((sensor_mag_updates < sensor_mag_s::ORB_QUEUE_LENGTH) && _sensor_sub[uorb_index].update(&report)) {
+				sensor_mag_updates++;
 
 				if (_calibration[uorb_index].device_id() != report.device_id) {
 					_calibration[uorb_index].set_device_id(report.device_id);


### PR DESCRIPTION
In several places where sensor data is grabbed we have the update in a while loop so that if the data is being generated faster than the consumer runs we don't miss it. For additional safety I've put an upper bound on the number of iterations to prevent any timing issues resulting in these updates looping indefinitely.

