### PR TITLE
EKF2-yaw estimator: force set gyro bias when at rest

### DIFF
--- a/src/modules/ekf2/EKF/EKFGSF_yaw.h
+++ b/src/modules/ekf2/EKF/EKFGSF_yaw.h
@@ -67,11 +67,11 @@ public:
 
 	void setTrueAirspeed(float true_airspeed) { _true_airspeed = true_airspeed; }
 
-	void setGyroBias(const Vector3f &imu_gyro_bias)
+	void setGyroBias(const Vector3f &imu_gyro_bias, const bool force = false)
 	{
 		// Initialise to gyro bias estimate from main filter because there could be a large
 		// uncorrected rate gyro bias error about the gravity vector
-		if (!_ahrs_ekf_gsf_tilt_aligned || !_ekf_gsf_vel_fuse_started) {
+		if (!_ahrs_ekf_gsf_tilt_aligned || !_ekf_gsf_vel_fuse_started || force) {
 			// init gyro bias for each model
 			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
 				_ahrs_ekf_gsf[model_index].gyro_bias = imu_gyro_bias;

--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -47,7 +47,7 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 	}
 
 	if (!gyro_bias_inhibited()) {
-		_yawEstimator.setGyroBias(getGyroBias());
+		_yawEstimator.setGyroBias(getGyroBias(), _control_status.flags.vehicle_at_rest);
 	}
 
 	// run EKF-GSF yaw estimator once per imu_delayed update


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The yaw estimate from the yaw emergency estimator can drift on ground due to incorrect gyro bias calibration.

Example log where the yaw composite drifts after every landing:
![Screenshot from 2024-03-05 17-16-40](https://github.com/PX4/PX4-Autopilot/assets/14822839/ba6eb54d-2683-4680-bb63-2b058aef54b6)


### Solution
The gyro bias estimate from EFK2 is really good when at rest and should be used by the yaw estimator to prevent heading drifts due to poor heading observability.

Same log replayed with the fix:
![Screenshot from 2024-03-05 17-16-22](https://github.com/PX4/PX4-Autopilot/assets/14822839/5285e324-a132-4989-8dd1-79033ece68bb)


### Changelog Entry
For release notes:
```
Fix yaw emergency estimate drift on ground
New parameter: -
Documentation: No
```

### Test coverage
- EKF2 replay

