### PR TITLE
FW Position Controller: do not publish roll angle constrain warning in VTOL transition

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -514,15 +514,17 @@ float FixedwingPositionControl::getCorrectedNpfgRollSetpoint()
 
 	hrt_abstime now{hrt_absolute_time()};
 
+	// Warn the user when the scale is less than 90% for at least 2 seconds (disable in transition)
+	const uint64_t warning_threshold = 2_s;
+
 	// If the npfg was not running before, reset the user warning variables.
-	if ((now - _time_since_last_npfg_call) > 2_s) {
+	if ((now - _time_since_last_npfg_call) > warning_threshold) {
 		_need_report_npfg_uncertain_condition = true;
 		_time_since_first_reduced_roll = 0U;
 	}
 
-	// Warn the user when the scale is less than 90% for at least 2 seconds.
-	if (can_run_factor > 0.9f) {
-		// NPFG reports a good condition, reset the user warning variables.
+	if (_vehicle_status.in_transition_mode || can_run_factor > 0.9f) {
+		// NPFG reports a good condition or we are in transition, reset the user warning variables.
 		_need_report_npfg_uncertain_condition = true;
 		_time_since_first_reduced_roll = 0U;
 
@@ -531,7 +533,7 @@ float FixedwingPositionControl::getCorrectedNpfgRollSetpoint()
 			_time_since_first_reduced_roll = now;
 		}
 
-		if ((now - _time_since_first_reduced_roll) > 2_s) {
+		if ((now - _time_since_first_reduced_roll) > warning_threshold) {
 			_need_report_npfg_uncertain_condition = false;
 			events::send(events::ID("npfg_roll_command_uncertain"), events::Log::Warning,
 				     "Roll command reduced due to uncertain velocity/wind estimates!");

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -512,22 +512,23 @@ float FixedwingPositionControl::getCorrectedNpfgRollSetpoint()
 	float new_roll_setpoint(_npfg.getRollSetpoint());
 	const float can_run_factor(constrain(_npfg.canRun(_local_pos, _wind_valid), 0.f, 1.f));
 
-	// If the npfg was not running before, reset the user warning variables.
 	hrt_abstime now{hrt_absolute_time()};
 
+	// If the npfg was not running before, reset the user warning variables.
 	if ((now - _time_since_last_npfg_call) > 2_s) {
 		_need_report_npfg_uncertain_condition = true;
 		_time_since_first_reduced_roll = 0U;
 	}
 
 	// Warn the user when the scale is less than 90% for at least 2 seconds.
-	if ((1.f - can_run_factor) < 0.1f) {
+	if (can_run_factor > 0.9f) {
+		// NPFG reports a good condition, reset the user warning variables.
 		_need_report_npfg_uncertain_condition = true;
 		_time_since_first_reduced_roll = 0U;
 
 	} else if (_need_report_npfg_uncertain_condition) {
 		if (_time_since_first_reduced_roll == 0U) {
-			_time_since_first_reduced_roll = hrt_absolute_time();
+			_time_since_first_reduced_roll = now;
 		}
 
 		if ((now - _time_since_first_reduced_roll) > 2_s) {


### PR DESCRIPTION


### Solved Problem
We're quite often close to the 2s threshold in transitions to FW, and even got some warnings reported. I would propose we disable the reporting in transitions, as it is quite expected that the roll angle is constrained in the first seconds of a transition.

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/b15500c8-193e-465f-96c6-d55318df3821)

