### PR TITLE
Navigator: remove vtol_takeoff special handling for RTL

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -783,17 +783,7 @@ void Navigator::run()
 				_pos_sp_triplet_published_invalid_once = false;
 			}
 
-#if CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-
-			// If we are in VTOL takeoff, do not switch until it is finished.
-			if (_navigation_mode == &_vtol_takeoff && !get_mission_result()->finished) {
-				navigation_mode_new = &_vtol_takeoff;
-
-			} else
-#endif //CONFIG_MODE_NAVIGATOR_VTOL_TAKEOFF
-			{
-				navigation_mode_new = &_rtl;
-			}
+			navigation_mode_new = &_rtl;
 
 			break;
 


### PR DESCRIPTION
We had a special handling for RTL triggered in vtol_takeoff state. The idea is to wait until the VTOL Takeoff is completed and only then switch to RTL. On a second thought this special handling isn't really necessary and for the sake of simplicity should be removed. This also removes the side effect of the indicated flight mode after RTL being set to VTOL_Takeoff again.
While testing it I found that currently RTL in the hover phase of the VTOL Takeoff is completely broken, it just stays hovering. This change here fixes that.
Downside of this change: when triggering RTL shortly after the transition to FW is compete, the vehicle will loiter around the current location to climb to RTL_RETURN_ALT instead of climbing at the defined loiter position, but for me that's an acceptable state.

### Changelog Entry
For release notes:
```
Bugfix: RTL during VTOL Takeoff in hover phase not working
```

### Alternatives
