### PR TITLE
dataman: Add client sync perf counter and increase default timeout to 5s

### DIFF
--- a/src/lib/dataman_client/DatamanClient.cpp
+++ b/src/lib/dataman_client/DatamanClient.cpp
@@ -39,6 +39,8 @@
 
 DatamanClient::DatamanClient()
 {
+	_sync_perf = perf_alloc(PC_ELAPSED, "DatamanClient: sync");
+
 	_dataman_request_pub.advertise();
 	_dataman_response_sub = orb_subscribe(ORB_ID(dataman_response));
 
@@ -74,6 +76,8 @@ DatamanClient::DatamanClient()
 
 DatamanClient::~DatamanClient()
 {
+	perf_free(_sync_perf);
+
 	if (_dataman_response_sub >= 0) {
 		orb_unsubscribe(_dataman_response_sub);
 	}
@@ -85,6 +89,7 @@ bool DatamanClient::syncHandler(const dataman_request_s &request, dataman_respon
 	bool response_received = false;
 	int32_t ret = 0;
 	hrt_abstime time_elapsed = hrt_elapsed_time(&start_time);
+	perf_begin(_sync_perf);
 	_dataman_request_pub.publish(request);
 
 	while (!response_received && (time_elapsed < timeout)) {
@@ -131,6 +136,8 @@ bool DatamanClient::syncHandler(const dataman_request_s &request, dataman_respon
 
 		time_elapsed = hrt_elapsed_time(&start_time);
 	}
+
+	perf_end(_sync_perf);
 
 	if (!response_received && ret >= 0) {
 		PX4_ERR("timeout after %" PRIu32 " ms!", static_cast<uint32_t>(timeout / 1000));

--- a/src/lib/dataman_client/DatamanClient.hpp
+++ b/src/lib/dataman_client/DatamanClient.hpp
@@ -62,7 +62,7 @@ public:
 	 *
 	 * @return true if data was read successfully within the timeout, false otherwise.
 	 */
-	bool readSync(dm_item_t item, uint32_t index, uint8_t *buffer, uint32_t length, hrt_abstime timeout = 1000_ms);
+	bool readSync(dm_item_t item, uint32_t index, uint8_t *buffer, uint32_t length, hrt_abstime timeout = 5000_ms);
 
 	/**
 	 * @brief Write data to the dataman synchronously.
@@ -75,7 +75,7 @@ public:
 	 *
 	 * @return True if the write operation succeeded, false otherwise.
 	 */
-	bool writeSync(dm_item_t item, uint32_t index, uint8_t *buffer, uint32_t length, hrt_abstime timeout = 1000_ms);
+	bool writeSync(dm_item_t item, uint32_t index, uint8_t *buffer, uint32_t length, hrt_abstime timeout = 5000_ms);
 
 	/**
 	 * @brief Clears the data in the specified dataman item.
@@ -85,7 +85,7 @@ public:
 	 *
 	 * @return True if the operation was successful, false otherwise.
 	 */
-	bool clearSync(dm_item_t item, hrt_abstime timeout = 1000_ms);
+	bool clearSync(dm_item_t item, hrt_abstime timeout = 5000_ms);
 
 	/**
 	 * @brief Initiates an asynchronous request to read the data from dataman for a specific item and index.
@@ -185,6 +185,8 @@ private:
 
 	uint8_t _client_id{0};
 
+	perf_counter_t _sync_perf{nullptr};
+
 	static constexpr uint8_t CLIENT_ID_NOT_SET{0};
 };
 
@@ -246,7 +248,7 @@ public:
 	 *
 	 * @return True if the write operation succeeded, false otherwise.
 	 */
-	bool writeWait(dm_item_t item, uint32_t index, uint8_t *buffer, uint32_t length, hrt_abstime timeout = 1000_ms);
+	bool writeWait(dm_item_t item, uint32_t index, uint8_t *buffer, uint32_t length, hrt_abstime timeout = 5000_ms);
 
 	/**
 	 * @brief Updates the dataman cache by checking for responses from the DatamanClient and processing them.


### PR DESCRIPTION
### Solved Problem

Dataman requests occasionally time out during boot. My suspicion is that its a combination of slow SDCard and unfortunate scheduling order during boot when the CPU is very busy. The timeout of 1s may be reached more quickly than expected. 

However, it is notoriously difficult to reproduce this issue under controlled and debuggable/traceable conditions. I was only able to catch it once and the `dataman: write` perf counter "only" recorded most=310ms. However, [on unrelated traces](https://github.com/niklaut/orbetto-support-files/raw/main/orbetto_pc.perfetto_trace.gz) I've seen scheduling latencies on the dataman thread in the hundreds of milliseconds, here 271ms:
![](https://github.com/PX4/PX4-Autopilot/assets/121870655/60a0b3f2-11b5-4817-bf8a-a523432b48ea)

### Solution

This increases the dataman client timeout to 5s and logs the time it took to service the sync requests.
There are already two perf counters `dataman: write` and `dataman: read`, however, those are running in the dataman thread, while the client is running on another thread. Thus adding this perf counter will show scheduling latencies between the dataman and its client threads.

### Changelog Entry

For release notes:
```
Bugfix Increase dataman client timeout
```

### Alternatives

Dataman request timeouts are bad anyways, since the data is needed to fulfill the mission. There really isn't any alternative to not getting any data.

### Context

See also #22778.