### PR TITLE
Fix mission check for init mission

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -99,6 +99,7 @@ set(msg_files
 	FollowTargetStatus.msg
 	GeneratorStatus.msg
 	GeofenceResult.msg
+	GeofenceStatus.msg
 	GimbalControls.msg
 	GimbalDeviceAttitudeStatus.msg
 	GimbalDeviceInformation.msg

--- a/msg/GeofenceStatus.msg
+++ b/msg/GeofenceStatus.msg
@@ -1,0 +1,7 @@
+uint64 timestamp                        # time since system start (microseconds)
+
+uint32 geofence_id 			# loaded geofence id
+uint8 status 				# Current geofence status
+
+uint8 GF_STATUS_LOADING = 0
+uint8 GF_STATUS_READY = 1

--- a/msg/MissionResult.msg
+++ b/msg/MissionResult.msg
@@ -1,8 +1,8 @@
 uint64 timestamp		# time since system start (microseconds)
 
-uint16 mission_id   		# Id for the mission for which the result was generated
-uint16 geofence_id  		# Id for the corresponding geofence for which the result was generated (used for mission feasibility)
-uint64 home_position_counter  	# Counter of the home position for which the result was generated (used for mission feasibility)
+uint32 mission_id   		# Id for the mission for which the result was generated
+uint32 geofence_id  		# Id for the corresponding geofence for which the result was generated (used for mission feasibility)
+uint32 home_position_counter  	# Counter of the home position for which the result was generated (used for mission feasibility)
 
 int32 seq_reached		# Sequence of the mission item which has been reached, default -1
 uint16 seq_current		# Sequence of the current mission item

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -46,13 +46,6 @@ FeasibilityChecker::FeasibilityChecker() :
 
 void FeasibilityChecker::reset()
 {
-
-	_is_landed = false;
-	_home_alt_msl = NAN;
-	_home_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
-	_current_position_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
-	_vehicle_type = VehicleType::RotaryWing;
-
 	_mission_validity_failed = false;
 	_takeoff_failed = false;
 	_land_pattern_validity_failed = false;
@@ -86,10 +79,16 @@ void FeasibilityChecker::updateData()
 
 		if (home.valid_hpos) {
 			_home_lat_lon = matrix::Vector2d(home.lat, home.lon);
+
+		} else {
+			_home_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
 		}
 
 		if (home.valid_alt) {
 			_home_alt_msl = home.alt;
+
+		} else {
+			_home_alt_msl = NAN;
 		}
 	}
 

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -65,6 +65,18 @@ public:
 		orb_publish(ORB_ID(home_position), home_pub, &home);
 	}
 
+	void publishInvalidHome()
+	{
+		home_position_s home = {};
+		home.alt = 0.f;
+		home.valid_alt = false;
+		home.lat = 0.;
+		home.lon = 0.;
+		home.valid_hpos = false;
+		orb_advert_t home_pub = orb_advertise(ORB_ID(home_position), &home);
+		orb_publish(ORB_ID(home_position), home_pub, &home);
+	}
+
 	void publishCurrentPosition(double lat, double lon)
 	{
 		vehicle_global_position_s gpos = {};
@@ -122,6 +134,7 @@ TEST_F(FeasibilityCheckerTest, mission_item_validity)
 	ASSERT_EQ(ret, false);
 
 	checker.reset();
+	checker.publishInvalidHome();
 	mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 	mission_item.altitude_is_relative = true;
 	ret = checker.processNextItem(mission_item, 0, 5);
@@ -190,6 +203,7 @@ TEST_F(FeasibilityCheckerTest, check_below_home)
 
 	// this is done to invalidate the home position
 	checker.reset();
+	checker.publishInvalidHome();
 	checker.publishLanded(true);
 	checker.processNextItem(mission_item, 0, 1);
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -81,6 +81,8 @@ Geofence::Geofence(Navigator *navigator) :
 	if (_navigator != nullptr) {
 		updateFence();
 	}
+
+	_geofence_status_pub.advertise();
 }
 
 Geofence::~Geofence()
@@ -101,6 +103,14 @@ void Geofence::run()
 		if (_initiate_fence_updated) {
 			_initiate_fence_updated = false;
 			_dataman_state	= DatamanState::Read;
+
+			geofence_status_s status;
+			status.timestamp = hrt_absolute_time();
+			status.geofence_id = _opaque_id;
+			status.status = geofence_status_s::GF_STATUS_LOADING;
+
+			_geofence_status_pub.publish(status);
+
 		}
 
 		break;
@@ -147,6 +157,14 @@ void Geofence::run()
 
 			} else {
 				_dataman_state = DatamanState::UpdateRequestWait;
+				_fence_updated = true;
+
+				geofence_status_s status;
+				status.timestamp = hrt_absolute_time();
+				status.geofence_id = _opaque_id;
+				status.status = geofence_status_s::GF_STATUS_READY;
+
+				_geofence_status_pub.publish(status);
 			}
 		}
 
@@ -160,6 +178,13 @@ void Geofence::run()
 			_dataman_state = DatamanState::UpdateRequestWait;
 			_updateFence();
 			_fence_updated = true;
+
+			geofence_status_s status;
+			status.timestamp = hrt_absolute_time();
+			status.geofence_id = _opaque_id;
+			status.status = geofence_status_s::GF_STATUS_READY;
+
+			_geofence_status_pub.publish(status);
 		}
 
 		break;

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -49,6 +49,7 @@
 #include <lib/geo/geo.h>
 #include <px4_platform_common/defines.h>
 #include <uORB/Subscription.hpp>
+#include <uORB/topics/geofence_status.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/sensor_gps.h>
@@ -171,7 +172,7 @@ private:
 	mission_stats_entry_s _stats;
 	DatamanState _dataman_state{DatamanState::UpdateRequestWait};
 	DatamanState _error_state{DatamanState::UpdateRequestWait};
-	DatamanCache _dataman_cache{"geofence_dm_cache_miss", 4};
+	DatamanCache _dataman_cache{"geofence_dm_cache_miss", 0};
 	DatamanClient	&_dataman_client = _dataman_cache.client();
 
 	float _altitude_min{0.0f};
@@ -184,6 +185,8 @@ private:
 	uint32_t _opaque_id{0}; ///< dataman geofence id: if it does not match, the polygon data was updated
 	bool _fence_updated{true};  ///< flag indicating if fence are updated to dataman cache
 	bool _initiate_fence_updated{true}; ///< flag indicating if fence updated is needed
+
+	uORB::Publication<geofence_status_s> _geofence_status_pub{ORB_ID(geofence_status)};
 
 	/**
 	 * implementation of updateFence()

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -207,7 +207,7 @@ MissionBase::on_activation()
 	_mission_has_been_activated = true;
 	_system_disarmed_while_inactive = false;
 
-	check_mission_valid();
+	check_mission_valid(true);
 
 	update_mission();
 
@@ -687,11 +687,13 @@ MissionBase::checkMissionRestart()
 }
 
 void
-MissionBase::check_mission_valid()
+MissionBase::check_mission_valid(bool forced)
 {
-	if ((_navigator->get_mission_result()->mission_id != _mission.mission_id)
-	    || (_navigator->get_mission_result()->geofence_id != _mission.geofence_id)
-	    || (_navigator->get_mission_result()->home_position_counter != _navigator->get_home_position()->update_count)) {
+	// Allow forcing it, since we currently not rechecking if parameters have changed.
+	if (forced ||
+	    (_navigator->get_mission_result()->mission_id != _mission.mission_id) ||
+	    (_navigator->get_mission_result()->geofence_id != _mission.geofence_id) ||
+	    (_navigator->get_mission_result()->home_position_counter != _navigator->get_home_position()->update_count)) {
 
 		_navigator->get_mission_result()->mission_id = _mission.mission_id;
 		_navigator->get_mission_result()->geofence_id = _mission.geofence_id;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1369,8 +1369,9 @@ bool MissionBase::checkMissionDataChanged(mission_s new_mission)
 
 bool MissionBase::canRunMissionFeasibility()
 {
-	return _navigator->home_global_position_valid() &&
-	       (_geofence_status_sub.get().timestamp > 0) &&
+	return _navigator->home_global_position_valid() && // Need to have a home position checked
+	       _navigator->get_global_position()->timestamp > 0 && // Need to have a position, for first waypoint check
+	       (_geofence_status_sub.get().timestamp > 0) && // Geofence data must be loaded
 	       (_geofence_status_sub.get().geofence_id == _mission.geofence_id) &&
 	       (_geofence_status_sub.get().status == geofence_status_s::GF_STATUS_READY);
 }

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -52,36 +52,20 @@ MissionBase::MissionBase(Navigator *navigator, int32_t dataman_cache_size_signed
 	_dataman_cache_size_signed(dataman_cache_size_signed)
 {
 	_dataman_cache.resize(abs(dataman_cache_size_signed));
-	_is_current_planned_mission_item_valid = (initMission() == PX4_OK);
 
-	updateDatamanCache();
+	// Reset _mission here, and listen on changes on the uorb topic instead of initialize from dataman.
+	_mission.mission_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
+	_mission.fence_dataman_id = DM_KEY_FENCE_POINTS_0;
+	_mission.safepoint_dataman_id = DM_KEY_SAFE_POINTS_0;
+	_mission.count = 0;
+	_mission.current_seq = 0;
+	_mission.land_start_index = -1;
+	_mission.land_index = -1;
+	_mission.mission_id = 0;
+	_mission.geofence_id = 0;
+	_mission.safe_points_id = 0;
 
 	_mission_pub.advertise();
-}
-
-int MissionBase::initMission()
-{
-	mission_s mission;
-	int ret_val{PX4_ERROR};
-
-	bool success = _dataman_client.readSync(DM_KEY_MISSION_STATE, 0, reinterpret_cast<uint8_t *>(&mission),
-						sizeof(mission_s));
-
-	if (success) {
-		if (isMissionValid(mission)) {
-			_mission = mission;
-			ret_val = PX4_OK;
-
-		} else {
-			resetMission();
-		}
-
-	} else {
-		PX4_ERR("Could not initialize Mission: Dataman read failed");
-		resetMission();
-	}
-
-	return ret_val;
 }
 
 void

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -102,6 +102,11 @@ void MissionBase::updateMavlinkMission()
 						  static_cast<int32_t>(new_mission.count) - 1);
 		}
 
+		if (new_mission.geofence_id != _mission.geofence_id) {
+			// New geofence data, need to check mission again.
+			_mission_checked = false;
+		}
+
 		_mission = new_mission;
 
 		/* Relevant mission items updated externally*/

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -342,9 +342,10 @@ private:
 	void updateMavlinkMission();
 
 	/**
-	 * Check whether a mission is ready to go
+	 * @brief Check whether a mission is ready to go
+	 * @param[in] forced flag if the check has to be run irregardles of any updates.
 	 */
-	void check_mission_valid();
+	void check_mission_valid(bool forced = false);
 
 	/**
 	 * Reset mission

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -207,13 +207,12 @@ protected:
 	int getNonJumpItem(int32_t &mission_index, mission_item_s &mission, bool execute_jump, bool write_jumps,
 			   bool mission_direction_backward = false);
 	/**
-	 * @brief Is Mission Parameters Valid
+	 * @brief Is Mission Valid
 	 *
-	 * @param mission Mission struct
-	 * @return true is mission parameters are valid
+	 * @return true is mission is valid
 	 * @return false otherwise
 	 */
-	bool isMissionValid(mission_s &mission) const;
+	bool isMissionValid() const;
 
 	/**
 	 * On mission update

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -43,6 +43,7 @@
 #include <drivers/drv_hrt.h>
 #include <px4_platform_common/module_params.h>
 #include <dataman_client/DatamanClient.hpp>
+#include <uORB/topics/geofence_status.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/navigator_mission_item.h>
 #include <uORB/topics/parameter_update.h>
@@ -308,7 +309,7 @@ protected:
 
 	bool _is_current_planned_mission_item_valid{false};	/**< Flag indicating if the currently loaded mission item is valid*/
 	bool _mission_has_been_activated{false};		/**< Flag indicating if the mission has been activated*/
-	bool _initialized_mission_checked{false};		/**< Flag indicating if the initialized mission has been checked by the mission validator*/
+	bool _mission_checked{false};				/**< Flag indicating if the mission has been checked by the mission validator*/
 	bool _system_disarmed_while_inactive{false};		/**< Flag indicating if the system has been disarmed while mission is inactive*/
 	mission_s _mission;					/**< Currently active mission*/
 	float _mission_init_climb_altitude_amsl{NAN}; 		/**< altitude AMSL the vehicle will climb to when mission starts */
@@ -443,6 +444,8 @@ private:
 	 */
 	bool checkMissionDataChanged(mission_s new_mission);
 
+	bool canRunMissionFeasibility();
+
 	int32_t _load_mission_index{-1}; /**< Mission inted of loaded mission items in dataman cache*/
 	int32_t _dataman_cache_size_signed; /**< Size of the dataman cache. A negativ value indicates that previous mission items should be loaded, a positiv value the next mission items*/
 
@@ -460,4 +463,5 @@ private:
 	)
 
 	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::SubscriptionData<geofence_status_s> _geofence_status_sub{ORB_ID(geofence_status)};
 };


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The mission feasibility checks could return a wrong result on startup for the loaded mission on the storage.

### Solution
- Only run the mission feasibility check after the geofence has loaded all the data.
- Only run mission feasibility check after a global position topic has been published.
- Some Bugfixes

### Changelog Entry
For release notes:
```
Bugfix Correclty check mission feasilbity on startup
```

### Alternatives
We really should decouple the feasibility check from the mission execution.

### Test coverage
- SITL test:
  - Test case 1: Define a valid mission and store it on the vehicle. Stop the simulation. Start it again, with a different location far away.
  - Test case 2: Define a mission and a geofence, where the mission violates the geofence. Stop the simulation. Start it again.
  - Test results: Prior in both cases, the vehicle would arm then immediately shut down again since the reevaluation of the mission feasibility returned the expected result. However, with the PR, the vehicle is not even armed, as it properly determines the mission feasibility at startup.

#### BE AWARE OF

- What should be happening if we don't have a global position? (i guess we anyways can't fly the mission, so it should be fine).
