### PR TITLE
FW Position Control: control_backtransition():  always track line from start

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -710,11 +710,9 @@ private:
 	 *
 	 * @param control_interval Time since last position control call [s]
 	 * @param ground_speed Local 2D ground speed of vehicle [m/s]
-	 * @param pos_sp_prev previous position setpoint
 	 * @param pos_sp_curr current position setpoint
 	 */
 	void control_backtransition(const float control_interval, const Vector2f &ground_speed,
-				    const position_setpoint_s &pos_sp_prev,
 				    const position_setpoint_s &pos_sp_curr);
 
 	float get_tecs_pitch();


### PR DESCRIPTION

### Solved Problem
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/fb3bd13c-aded-4c12-986e-6997aa18eda2)
VTOL RTL to Home without safe approaches defined doesn't do proper path following to Home point. The reason is that the previous wp = current wp, which causes navigateLine() to not not track properly the Home point. 

### Solution
Remove option to track from previous wp to reduce complexity and fix case where prev=current point and the line following broke down.
I think it doesn't make a big difference tracking the line from the (correctly set) previous wp or the current location at transition start. When the vehicle is strongly diverging from the line before the transition starts then it's likely better to not force the vehicle back to the line but instead track a new line from the beginning of the transition to the landing point.

### Changelog Entry
For release notes: 
```
Bugfix: FW Position Control: control_backtransition():  always track line from start of transition
```


