### PR TITLE
mission_base: land_start_item invalid only when negative.

### DIFF
--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -123,7 +123,7 @@ protected:
 	 * @return true If mission has a land start of land item and a land item
 	 * @return false otherwise
 	 */
-	bool hasMissionLandStart() const { return _mission.land_start_index > 0 && _mission.land_index > 0;};
+	bool hasMissionLandStart() const { return _mission.land_start_index >= 0 && _mission.land_index >= 0;};
 	/**
 	 * @brief Go to next Mission Item
 	 * Go to next non jump mission item

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -604,7 +604,7 @@ void RTL::parameters_update()
 
 bool RTL::hasMissionLandStart() const
 {
-	return _mission_sub.get().land_start_index > 0;
+	return _mission_sub.get().land_start_index >= 0 && _mission_sub.get().land_index >= 0;
 }
 
 bool RTL::hasVtolLandApproach(const PositionYawSetpoint &rtl_position) const


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When flying and setting a mission with only a vtol land, it is not executed.

### Solution
- Check for land_start_inex is wrong. only check if it is negative.

