### PR TITLE
mission: The mission check not reevaluated for RTL

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -86,6 +86,8 @@ Mission::on_activation()
 {
 	_need_mission_save = true;
 
+	check_mission_valid(true);
+
 	MissionBase::on_activation();
 }
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -207,8 +207,6 @@ MissionBase::on_activation()
 	_mission_has_been_activated = true;
 	_system_disarmed_while_inactive = false;
 
-	check_mission_valid(true);
-
 	update_mission();
 
 	// reset the cache and fill it with the items up to the previous item. The cache contains

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -216,6 +216,12 @@ protected:
 	bool isMissionValid() const;
 
 	/**
+	 * @brief Check whether a mission is ready to go
+	 * @param[in] forced flag if the check has to be run irregardles of any updates.
+	 */
+	void check_mission_valid(bool forced = false);
+
+	/**
 	 * On mission update
 	 * Change behaviour after external mission update.
 	 * @param[in] has_mission_items_changed flag if the mission items have been changed.
@@ -343,12 +349,6 @@ private:
 	 *
 	 */
 	void updateMavlinkMission();
-
-	/**
-	 * @brief Check whether a mission is ready to go
-	 * @param[in] forced flag if the check has to be run irregardles of any updates.
-	 */
-	void check_mission_valid(bool forced = false);
 
 	/**
 	 * Reset mission


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
A mission on RTL mission landing can not be executed, when the mission is invalid on activation (e.g. when the vehicle in the meantime is too far away to pass the first mission item).

### Solution
- We need to make sure that when the RTL is triggered, it should not reevaluate it, as when it was valid but evaluated to false on activation, it can't do a RTL.

### Changelog Entry
For release notes:
```
Bugfix Fix a mission RTL not being executed if mission validity changes.

```

### Alternatives
This is only a quick fix for the problem. The mission validity should not change depending on the vehicle current position. If it is evaluated once for the takeoff/current position, it should not reevaluate it. Also the mission feasibility checker should be run separately when any of the relevant data changes (mission, geofence, parameters, etc.). So the state of the mission validity is always known.

### Test coverage


### Context
Related links, screenshot before/after, video
