### PR TITLE
Added preferred RC input parameter

### DIFF
--- a/src/modules/manual_control/ManualControl.cpp
+++ b/src/modules/manual_control/ManualControl.cpp
@@ -296,6 +296,7 @@ void ManualControl::updateParams()
 	_stick_kill_hysteresis.set_hysteresis_time_from(false, _param_man_kill_gest_t.get() * 1_s);
 
 	_selector.setRcInMode(_param_com_rc_in_mode.get());
+	_selector.setRcInSourcePreferred(_param_com_rc_in_source.get());
 	_selector.setTimeout(_param_com_rc_loss_t.get() * 1_s);
 
 	// MAN_ARM_GESTURE

--- a/src/modules/manual_control/ManualControl.hpp
+++ b/src/modules/manual_control/ManualControl.hpp
@@ -144,6 +144,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::COM_RC_IN_MODE>) _param_com_rc_in_mode,
+		(ParamInt<px4::params::COM_RC_IN_SOURCE>) _param_com_rc_in_source,
 		(ParamFloat<px4::params::COM_RC_LOSS_T>) _param_com_rc_loss_t,
 		(ParamFloat<px4::params::COM_RC_STICK_OV>) _param_com_rc_stick_ov,
 		(ParamBool<px4::params::MAN_ARM_GESTURE>) _param_man_arm_gesture,

--- a/src/modules/manual_control/ManualControlSelector.cpp
+++ b/src/modules/manual_control/ManualControlSelector.cpp
@@ -47,7 +47,7 @@ void ManualControlSelector::updateWithNewInputSample(uint64_t now, const manual_
 	updateValidityOfChosenInput(now);
 
 	const bool update_existing_input = _setpoint.valid && (input.data_source == _setpoint.data_source);
-	const bool start_using_new_input = !_setpoint.valid;
+	const bool start_using_new_input = !_setpoint.valid | (input.data_source == _rc_in_source_preferred);
 
 	// Switch to new input if it's valid and we don't already have a valid one
 	if (isInputValid(input, now) && (update_existing_input || start_using_new_input)) {

--- a/src/modules/manual_control/ManualControlSelector.hpp
+++ b/src/modules/manual_control/ManualControlSelector.hpp
@@ -40,6 +40,7 @@ class ManualControlSelector
 {
 public:
 	void setRcInMode(int32_t rc_in_mode) { _rc_in_mode = rc_in_mode; }
+	void setRcInSourcePreferred(int32_t rc_in_source_preferred) { _rc_in_source_preferred = rc_in_source_preferred; }
 	void setTimeout(uint64_t timeout) { _timeout = timeout; }
 	void updateValidityOfChosenInput(uint64_t now);
 	void updateWithNewInputSample(uint64_t now, const manual_control_setpoint_s &input, int instance);
@@ -52,6 +53,7 @@ private:
 	manual_control_setpoint_s _setpoint{};
 	uint64_t _timeout{0};
 	int32_t _rc_in_mode{0};
+	int32_t _rc_in_source_preferred{0};
 	int _instance{-1};
 	uint8_t _first_valid_source{manual_control_setpoint_s::SOURCE_UNKNOWN};
 };

--- a/src/modules/manual_control/manual_control_params.c
+++ b/src/modules/manual_control/manual_control_params.c
@@ -58,3 +58,21 @@ PARAM_DEFINE_INT32(MAN_ARM_GESTURE, 1);
  * @max 15
  */
 PARAM_DEFINE_FLOAT(MAN_KILL_GEST_T, -1.f);
+
+/**
+ * Set primary RC input source. This works only if COM_RC_IN_MODE = 2
+ *
+ * This determines which RC input has the priority
+ *
+ * @value -1 Source selection disabled (use last valid source)
+ * @value 1 RC
+ * @value 2 MAVLink 0
+ * @value 3 MAVLink 1
+ * @value 4 MAVLink 2
+ * @value 5 MAVLink 3
+ * @value 6 MAVLink 4
+ * @value 7 MAVLink 5
+ *
+ * @group Manual Control
+ */
+PARAM_DEFINE_INT32(COM_RC_IN_SOURCE, -1);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When using muliple RC inputs over different datalinks I found that always the last valid is kept. Therefore, it's not possible to set a preferred input, for example to prefer the lowest latency datalink.

Fixes #{Github issue ID}

### Solution
- Add parameter for setting the preferred RC input 
- If the preferred RC input is valid, always use that one

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
