### PR TITLE
OPEN_DRONE_ID_SYSTEM publish operator altitude in geodetic frame as specified in mavlink message definition

### DIFF
--- a/src/modules/mavlink/streams/OPEN_DRONE_ID_SYSTEM.hpp
+++ b/src/modules/mavlink/streams/OPEN_DRONE_ID_SYSTEM.hpp
@@ -86,7 +86,8 @@ private:
 				msg.area_floor = -1000;
 				msg.category_eu = MAV_ODID_CATEGORY_EU_UNDECLARED;
 				msg.class_eu = MAV_ODID_CLASS_EU_UNDECLARED;
-				msg.operator_altitude_geo = home_position.alt;
+				float wgs84_amsl_offset = vehicle_gps_position.altitude_ellipsoid_m - vehicle_gps_position.altitude_msl_m;
+				msg.operator_altitude_geo = home_position.alt + wgs84_amsl_offset;
 
 				// timestamp: 32 bit Unix Timestamp in seconds since 00:00:00 01/01/2019.
 				static uint64_t utc_offset_s = 1'546'300'800; // UTC seconds since 00:00:00 01/01/2019


### PR DESCRIPTION
### Solved Problem
I found that the operator altitude field was set in AMSL frame whereas mavlink specs require geodetic (WGS84)

### Solution
Calculate the difference between the two frames based on `vehicle_gps_position` fields

### Changelog Entry
For release notes:
```
Bugfix : Correct frame for operator_altitude_geo field in OPEN_DRONE_ID_SYSTEM message
```

### Test coverage
Screenshots from a Pixhawk 4 live telemetry:
![Screenshot from 2024-03-11 15-46-14](https://github.com/PX4/PX4-Autopilot/assets/48206725/ce0e53c0-5492-4fad-acf7-de44c88fb158)
![Screenshot from 2024-03-11 15-46-03](https://github.com/PX4/PX4-Autopilot/assets/48206725/0838ecc4-9cec-4a20-8969-bdfd79f42596)

