### PR TITLE
rtl_direct: fix on_inactive()

### DIFF
--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -83,7 +83,7 @@ RtlDirectMissionLand::updateDatamanCache()
 
 void RtlDirectMissionLand::on_inactive()
 {
-	MissionBase::on_active();
+	MissionBase::on_inactive();
 
 	updateDatamanCache();
 }


### PR DESCRIPTION
Came in yesterday with https://github.com/PX4/PX4-Autopilot/pull/22742
Symptom: on every boot with an invalid mission the system gave warning "No valid mission available, refusing takeoff"