### PR TITLE
gps: add flexible receiver logging

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -935,6 +935,14 @@ GPS::run()
 			param_get(handle, &gps_ubx_cfg_intf);
 		}
 
+		param_get(param_find("GPS_LOG_HZ"), &gpsConfig.logging_configuration.frequency);
+		int32_t logging_level;
+		param_get(param_find("GPS_LOG_LEVEL"), &logging_level);
+		gpsConfig.logging_configuration.level = static_cast<GPSHelper::LoggingLevel>(logging_level);
+		int32_t logging_overwrite = 0;
+		param_get(param_find("GPS_LOG_FORCE"), &logging_overwrite);
+		gpsConfig.logging_configuration.overwrite = logging_overwrite;
+
 		gpsConfig.interface_protocols = static_cast<GPSHelper::InterfaceProtocolsMask>(gps_ubx_cfg_intf);
 
 		if (_helper && _helper->configure(_baudrate, gpsConfig) == 0) {

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -290,3 +290,44 @@ PARAM_DEFINE_INT32(GPS_1_GNSS, 0);
  * @group GPS
  */
 PARAM_DEFINE_INT32(GPS_2_GNSS, 0);
+
+/**
+ * Logging frequency for the receiver.
+ *
+ * Select the frequency at which the connected receiver should log data.
+ *
+ * @min 0
+ * @max 20
+ * @unit Hz
+ * @decimal 1
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_FLOAT(GPS_LOG_HZ, 1.f);
+
+/**
+ * Logging level for the receiver.
+ *
+ * Select the level of detail that needs to be logged by the receiver.
+ *
+ * @min 0
+ * @max 3
+ * @value 0 Lite
+ * @value 1 Basic
+ * @value 2 Default
+ * @value 3 Full
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_LOG_LEVEL, 2);
+
+/**
+ * Whether to overwrite or add to existing logging.
+ *
+ * When the receiver is already set up to log data, this decides whether extra logged data should be added or overwrite existing data.
+ *
+ * @boolean true
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(GPS_LOG_FORCE, 0);


### PR DESCRIPTION
Add three new parameters that allow users to configure logging on their receiver from their ground control station.
[The implementation in `PX4-GPSDrivers`](https://github.com/PX4/PX4-GPSDrivers/pull/154) is only for Septentrio receivers currently. It is kept generic enough so it can also be implemented by other drivers.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
If users wanted logging on their GNSS receiver, they had to manually set it up.

### Solution
- Add three new parameters `GPS_LOG_HZ`, `GPS_LOG_LEVEL` and `GPS_LOG_FORCE`
- `GPS_LOG_HZ`: Set the logging frequency
- `GPS_LOG_LEVEL`: Set the amount of detail the receiver should log
- `GPS_LOG_FORCE`: Set whether any existing logging should be overwritten

### Changelog Entry
For release notes:
```
Feature Add three parameters to set up GNSS receiver logging
```

### Alternatives
\/

### Test coverage
\/

### Context
\/