### PR TITLE
SMART_BATTERY_INFO to BATTERY_INFO

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -132,6 +132,7 @@
 #if !defined(CONSTRAINED_FLASH)
 # include "streams/ADSB_VEHICLE.hpp"
 # include "streams/AUTOPILOT_STATE_FOR_GIMBAL_DEVICE.hpp"
+# include "streams/BATTERY_INFO.hpp"
 # include "streams/DEBUG.hpp"
 # include "streams/DEBUG_FLOAT_ARRAY.hpp"
 # include "streams/DEBUG_VECT.hpp"
@@ -147,7 +148,6 @@
 # include "streams/ODOMETRY.hpp"
 # include "streams/SCALED_PRESSURE2.hpp"
 # include "streams/SCALED_PRESSURE3.hpp"
-# include "streams/SMART_BATTERY_INFO.hpp"
 # include "streams/UAVIONIX_ADSB_OUT_CFG.hpp"
 # include "streams/UAVIONIX_ADSB_OUT_DYNAMIC.hpp"
 # include "streams/UTM_GLOBAL_POSITION.hpp"
@@ -259,9 +259,9 @@ static const StreamListItem streams_list[] = {
 	create_stream_list_item<MavlinkStreamSysStatus>(),
 #endif // SYS_STATUS_HPP
 	create_stream_list_item<MavlinkStreamBatteryStatus>(),
-#if defined(SMART_BATTERY_INFO_HPP)
-	create_stream_list_item<MavlinkStreamSmartBatteryInfo>(),
-#endif // SMART_BATTERY_INFO_HPP
+#if defined(BATTERY_INFO_HPP)
+	create_stream_list_item<MavlinkStreamBatteryInfo>(),
+#endif // BATTERY_INFO_HPP
 #if defined(HIGHRES_IMU_HPP)
 	create_stream_list_item<MavlinkStreamHighresIMU>(),
 #endif // HIGHRES_IMU_HPP

--- a/src/modules/mavlink/streams/BATTERY_INFO.hpp
+++ b/src/modules/mavlink/streams/BATTERY_INFO.hpp
@@ -87,10 +87,11 @@ private:
 					//Formatted as 'ddmmyyyy' (maxed 9 chars)
 					snprintf(msg.manufacture_date, sizeof(msg.manufacture_date), "%d%d%d", day, month, year);
 					//Formatted as 'dd/mm/yy-123456' (maxed 15 + 1 chars)
-					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d/%d/%d-%d", day, month, year2dig, battery_status.serial_number);
+					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d/%d/%d-%d", day, month, year2dig,
+						 battery_status.serial_number);
 
 				} else {
-					
+
 					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d", battery_status.serial_number);
 				}
 

--- a/src/modules/mavlink/streams/BATTERY_INFO.hpp
+++ b/src/modules/mavlink/streams/BATTERY_INFO.hpp
@@ -31,30 +31,30 @@
  *
  ****************************************************************************/
 
-#ifndef SMART_BATTERY_INFO_HPP
-#define SMART_BATTERY_INFO_HPP
+#ifndef BATTERY_INFO_HPP
+#define BATTERY_INFO_HPP
 
 #include <uORB/topics/battery_status.h>
 
-class MavlinkStreamSmartBatteryInfo : public MavlinkStream
+class MavlinkStreamBatteryInfo : public MavlinkStream
 {
 public:
-	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamSmartBatteryInfo(mavlink); }
+	static MavlinkStream *new_instance(Mavlink *mavlink) { return new MavlinkStreamBatteryInfo(mavlink); }
 
-	static constexpr const char *get_name_static() { return "SMART_BATTERY_INFO"; }
-	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_SMART_BATTERY_INFO; }
+	static constexpr const char *get_name_static() { return "BATTERY_INFO"; }
+	static constexpr uint16_t get_id_static() { return MAVLINK_MSG_ID_BATTERY_INFO; }
 
 	const char *get_name() const override { return get_name_static(); }
 	uint16_t get_id() override { return get_id_static(); }
 
 	unsigned get_size() override
 	{
-		static constexpr unsigned size_per_battery = MAVLINK_MSG_ID_SMART_BATTERY_INFO_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+		static constexpr unsigned size_per_battery = MAVLINK_MSG_ID_BATTERY_INFO_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 		return size_per_battery * _battery_status_subs.advertised_count();
 	}
 
 private:
-	explicit MavlinkStreamSmartBatteryInfo(Mavlink *mavlink) : MavlinkStream(mavlink) {}
+	explicit MavlinkStreamBatteryInfo(Mavlink *mavlink) : MavlinkStream(mavlink) {}
 
 	uORB::SubscriptionMultiArray<battery_status_s, battery_status_s::MAX_INSTANCES> _battery_status_subs{ORB_ID::battery_status};
 
@@ -67,36 +67,49 @@ private:
 
 			if (battery_sub.update(&battery_status)) {
 				if (battery_status.serial_number == 0) {
-					// This is not smart battery
+					// Required to emit
 					continue;
 				}
 
-				mavlink_smart_battery_info_t msg{};
+				mavlink_battery_info_t msg{};
 
 				msg.id = battery_status.id - 1;
-				msg.capacity_full_specification = battery_status.capacity;
-				msg.capacity_full = (int32_t)((float)(battery_status.state_of_health * battery_status.capacity) / 100.f);
+				msg.design_capacity = (float)(battery_status.capacity * 1000);
+				msg.full_charge_capacity = (float)(battery_status.state_of_health * battery_status.capacity * 1000.f) / 100.f;
 				msg.cycle_count = battery_status.cycle_count;
 
 				if (battery_status.manufacture_date) {
 					uint16_t day = battery_status.manufacture_date % 32;
 					uint16_t month = (battery_status.manufacture_date >> 5) % 16;
-					uint16_t year = (80 + (battery_status.manufacture_date >> 9)) % 100;
+					uint16_t year = (80 + (battery_status.manufacture_date >> 9));
+					uint16_t year2dig = year % 100;
 
+					//Formatted as 'ddmmyyyy' (maxed 9 chars)
+					snprintf(msg.manufacture_date, sizeof(msg.manufacture_date), "%d%d%d", day, month, year);
 					//Formatted as 'dd/mm/yy-123456' (maxed 15 + 1 chars)
-					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d/%d/%d-%d", day, month, year, battery_status.serial_number);
+					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d/%d/%d-%d", day, month, year2dig, battery_status.serial_number);
 
 				} else {
+					
 					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d", battery_status.serial_number);
 				}
 
-				//msg.device_name = ??
-				msg.weight = -1;
-				msg.discharge_minimum_voltage = -1;
-				msg.charging_minimum_voltage = -1;
-				msg.resting_minimum_voltage = -1;
+                // Not supported by PX4 (not in battery_status uorb topic)
+				/*
+				msg.name = 0; // char[50]
+				msg.weight = 0;
+				msg.discharge_minimum_voltage = 0;
+				msg.charging_minimum_voltage = 0;
+				msg.resting_minimum_voltage = 0;
+				msg.charging_maximum_voltage = 0;
+				msg.charging_maximum_current = 0;
+				msg.discharge_maximum_current = 0;
+				msg.discharge_maximum_burst_current = 0;
+				msg.cells_in_series = 0;
+				msg.nominal_voltage = 0;
+				*/
 
-				mavlink_msg_smart_battery_info_send_struct(_mavlink->get_channel(), &msg);
+				mavlink_msg_battery_info_send_struct(_mavlink->get_channel(), &msg);
 				updated = true;
 			}
 		}
@@ -105,4 +118,4 @@ private:
 	}
 };
 
-#endif // SMART_BATTERY_INFO_HPP
+#endif // BATTERY_INFO_HPP

--- a/src/modules/mavlink/streams/BATTERY_INFO.hpp
+++ b/src/modules/mavlink/streams/BATTERY_INFO.hpp
@@ -94,7 +94,7 @@ private:
 					snprintf(msg.serial_number, sizeof(msg.serial_number), "%d", battery_status.serial_number);
 				}
 
-                // Not supported by PX4 (not in battery_status uorb topic)
+				// Not supported by PX4 (not in battery_status uorb topic)
 				/*
 				msg.name = 0; // char[50]
 				msg.weight = 0;


### PR DESCRIPTION
#22724 is failing because SMART_BATTERY_INFO was renamed to BATTERY_INFO and aligned with UAVCAN in https://github.com/mavlink/mavlink/pull/2070/files

This was reasonable as there are no smart batteries, but breaks MAVLink import, because PX4 implements it. This includes the same MAVLink module commit, but also renames SMART_BATTERY_INFO to BATTERY_INFO.

I'm fairly sure I got it right (all builds) but I'm not a software engineer. NOTE, a bunch of these fields aren't implemented in PX4 uorb topic so can't be passed through to MAVLink.

You can see the changes in link above, but at high level:

- Unchanged fields: `id`, `battery_function`, `type`, cycle_count`, `weight`, `cells_in_series`, `cycle_count`
- Modified 
  - `serial_number` - char[16] to [32]
  - `capacity_full_specification` renamed to `design_capacity` and changed from mAh int32 to float Ah
  - `capacity_full` renamed to `full_charge_capacity` and changed from mAh int32 to float Ah
  - `device_name` renamed to `name`
  - `discharge_minimum_voltage`, `charging_minimum_voltage`, `resting_minimum_voltage`, `charging_maximum_voltage`, `discharge_maximum_current`, `discharge_maximum_burst_current` - were uint16_t mV, changed to float V and 0 if not supported
  - `manufacture_date` - char[11] to char[19] - stripped out the `/` separators
- New - `charging_maximum_current`, `nominal_voltage`
  - Also new is `state_of_health` which is in the uorb topic but not in old message.
