### PR TITLE
Commander: set vehicle_status.failsafe flag only if action for faileded check is more than warning

### DIFF
--- a/src/modules/commander/failsafe/framework.h
+++ b/src/modules/commander/failsafe/framework.h
@@ -147,7 +147,7 @@ public:
 		       bool rc_sticks_takeover_request,
 		       const failsafe_flags_s &status_flags);
 
-	bool inFailsafe() const { return _selected_action != Action::None; }
+	bool inFailsafe() const { return (_selected_action != Action::None && _selected_action != Action::Warn); }
 
 	Action selectedAction() const { return _selected_action; }
 


### PR DESCRIPTION
### Solved Problem
`vehicle_status.failsafe `is set when action is only a warning (e.g. battery warning level reached). That further set `system_status` to `MAV_STATE_CRITICAL` in the hearbeat that's sent to the ground station. 

### Solution
Do not set the failsafe flag for Action::Warn.

It's debatable if this flag also should be set if the action is only warning. For me personally a failsafe is only a failsafe if the system has actually changed it's behavior in response to the system check that failed (e.g. switched to RTL if battery empty). If the system has detected a critical issue but cannot act to safe it then it should send a "system state critical" or similar message. 

### Changelog Entry
For release notes:
```
Improvement:  Commander: set vehicle_status.failsafe flag only if action for failed check is more than warning
```

I've checked where `vehicle_status.failsafe` is used internally:
- heartbeat (see above)
- open drone id --> send MAV_ODID_STATUS_EMERGENCY
- buzzer (note: low battery warning has a separate tune)
- LED color (note: low battery is handled separately)
- board status LED control




