### PR TITLE
  uavcan: handle uavcan sensors on multiple buses properly

### DIFF
--- a/src/drivers/uavcan/sensors/accel.cpp
+++ b/src/drivers/uavcan/sensors/accel.cpp
@@ -59,7 +59,7 @@ int UavcanAccelBridge::init()
 
 void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::RawIMU> &msg)
 {
-	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get());
+	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getIfaceIndex(), msg.getSrcNodeID().get());
 
 	const hrt_abstime timestamp_sample = hrt_absolute_time();
 
@@ -81,9 +81,9 @@ void UavcanAccelBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::e
 
 int UavcanAccelBridge::init_driver(uavcan_bridge::Channel *channel)
 {
-	// update device id as we now know our device node_id
-	DeviceId device_id{_device_id};
-
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = channel->iface_idx;
 	device_id.devid_s.devtype = DRV_ACC_DEVTYPE_UAVCAN;
 	device_id.devid_s.address = static_cast<uint8_t>(channel->node_id);
 

--- a/src/drivers/uavcan/sensors/airspeed.cpp
+++ b/src/drivers/uavcan/sensors/airspeed.cpp
@@ -106,5 +106,5 @@ UavcanAirspeedBridge::ias_sub_cb(const
 	report.true_airspeed_m_s   	= _last_tas_m_s;
 	report.air_temperature_celsius 	= _last_outside_air_temp_k + atmosphere::kAbsoluteNullCelsius;
 
-	publish(msg.getSrcNodeID().get(), &report);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &report);
 }

--- a/src/drivers/uavcan/sensors/baro.cpp
+++ b/src/drivers/uavcan/sensors/baro.cpp
@@ -91,7 +91,7 @@ void UavcanBarometerBridge::air_pressure_sub_cb(const
 {
 	const hrt_abstime timestamp_sample = hrt_absolute_time();
 
-	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get());
+	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getIfaceIndex(), msg.getSrcNodeID().get());
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return
@@ -105,12 +105,11 @@ void UavcanBarometerBridge::air_pressure_sub_cb(const
 		return;
 	}
 
-	DeviceId device_id{};
-	device_id.devid_s.bus = 0;
-	device_id.devid_s.bus_type = DeviceBusType_UAVCAN;
-
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = msg.getIfaceIndex();
 	device_id.devid_s.devtype = DRV_BARO_DEVTYPE_UAVCAN;
-	device_id.devid_s.address = static_cast<uint8_t>(channel->node_id);
+	device_id.devid_s.address = msg.getSrcNodeID().get();
 
 	// publish
 	sensor_baro_s sensor_baro{};

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -146,7 +146,7 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	_battery_status[instance].warning = _warning;
 
 	if (_batt_update_mod[instance] == BatteryDataType::Raw) {
-		publish(msg.getSrcNodeID().get(), &_battery_status[instance]);
+		publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &_battery_status[instance]);
 	}
 }
 
@@ -188,7 +188,7 @@ UavcanBatteryBridge::battery_aux_sub_cb(const uavcan::ReceivedDataStructure<ardu
 		_battery_status[instance].voltage_cell_v[i] = msg.voltage_cell[i];
 	}
 
-	publish(msg.getSrcNodeID().get(), &_battery_status[instance]);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &_battery_status[instance]);
 }
 
 void
@@ -243,5 +243,5 @@ UavcanBatteryBridge::filterData(const uavcan::ReceivedDataStructure<uavcan::equi
 	_battery_status[instance].serial_number = msg.model_instance_id;
 	_battery_status[instance].id = msg.getSrcNodeID().get(); // overwrite zeroed index from _battery
 
-	publish(msg.getSrcNodeID().get(), &_battery_status[instance]);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &_battery_status[instance]);
 }

--- a/src/drivers/uavcan/sensors/differential_pressure.cpp
+++ b/src/drivers/uavcan/sensors/differential_pressure.cpp
@@ -67,18 +67,21 @@ void UavcanDifferentialPressureBridge::air_sub_cb(const
 {
 	const hrt_abstime timestamp_sample = hrt_absolute_time();
 
-	_device_id.devid_s.devtype = DRV_DIFF_PRESS_DEVTYPE_UAVCAN;
-	_device_id.devid_s.address = msg.getSrcNodeID().get() & 0xFF;
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = msg.getIfaceIndex();
+	device_id.devid_s.devtype = DRV_DIFF_PRESS_DEVTYPE_UAVCAN;
+	device_id.devid_s.address = msg.getSrcNodeID().get();
 
 	float diff_press_pa = msg.differential_pressure;
 	float temperature_c = msg.static_air_temperature + atmosphere::kAbsoluteNullCelsius;
 
 	differential_pressure_s report{};
 	report.timestamp_sample = timestamp_sample;
-	report.device_id = _device_id.devid;
+	report.device_id = device_id.devid;
 	report.differential_pressure_pa = diff_press_pa;
 	report.temperature = temperature_c;
 	report.timestamp = hrt_absolute_time();
 
-	publish(msg.getSrcNodeID().get(), &report);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &report);
 }

--- a/src/drivers/uavcan/sensors/flow.cpp
+++ b/src/drivers/uavcan/sensors/flow.cpp
@@ -62,11 +62,10 @@ void UavcanFlowBridge::flow_sub_cb(const uavcan::ReceivedDataStructure<com::hex:
 	flow.timestamp_sample = hrt_absolute_time(); // TODO
 
 	device::Device::DeviceId device_id;
-	device_id.devid_s.bus_type = device::Device::DeviceBusType::DeviceBusType_UAVCAN;
-	device_id.devid_s.bus = 0;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = msg.getIfaceIndex();
 	device_id.devid_s.devtype = DRV_FLOW_DEVTYPE_UAVCAN;
-	device_id.devid_s.address = msg.getSrcNodeID().get() & 0xFF;
-
+	device_id.devid_s.address = msg.getSrcNodeID().get();
 	flow.device_id = device_id.devid;
 
 	flow.pixel_flow[0] = msg.flow_integral[0];
@@ -94,5 +93,5 @@ void UavcanFlowBridge::flow_sub_cb(const uavcan::ReceivedDataStructure<com::hex:
 
 	flow.timestamp = hrt_absolute_time();
 
-	publish(msg.getSrcNodeID().get(), &flow);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &flow);
 }

--- a/src/drivers/uavcan/sensors/gnss_relative.cpp
+++ b/src/drivers/uavcan/sensors/gnss_relative.cpp
@@ -70,9 +70,15 @@ void UavcanGnssRelativeBridge::rel_pos_heading_sub_cb(const
 	sensor_gnss_relative.position_length = msg.relative_distance_m;
 	sensor_gnss_relative.position[2] = msg.relative_down_pos_m;
 
-	sensor_gnss_relative.device_id = get_device_id();
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = msg.getIfaceIndex();
+	//device_id.devid_s.devtype = ??
+	device_id.devid_s.address = msg.getSrcNodeID().get();
+
+	sensor_gnss_relative.device_id = device_id.devid;
 
 	sensor_gnss_relative.timestamp = hrt_absolute_time();
 
-	publish(msg.getSrcNodeID().get(), &sensor_gnss_relative);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &sensor_gnss_relative);
 }

--- a/src/drivers/uavcan/sensors/gyro.cpp
+++ b/src/drivers/uavcan/sensors/gyro.cpp
@@ -59,7 +59,7 @@ int UavcanGyroBridge::init()
 
 void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::RawIMU> &msg)
 {
-	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get());
+	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getIfaceIndex(), msg.getSrcNodeID().get());
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return
@@ -81,11 +81,11 @@ void UavcanGyroBridge::imu_sub_cb(const uavcan::ReceivedDataStructure<uavcan::eq
 
 int UavcanGyroBridge::init_driver(uavcan_bridge::Channel *channel)
 {
-	// update device id as we now know our device node_id
-	DeviceId device_id{_device_id};
-
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN;
+	device_id.devid_s.bus = channel->iface_idx;
 	device_id.devid_s.devtype = DRV_GYR_DEVTYPE_UAVCAN;
-	device_id.devid_s.address = static_cast<uint8_t>(channel->node_id);
+	device_id.devid_s.address =  static_cast<uint8_t>(channel->node_id);
 
 	channel->h_driver = new PX4Gyroscope(device_id.devid);
 

--- a/src/drivers/uavcan/sensors/hygrometer.cpp
+++ b/src/drivers/uavcan/sensors/hygrometer.cpp
@@ -69,5 +69,5 @@ void UavcanHygrometerBridge::hygro_sub_cb(const uavcan::ReceivedDataStructure<dr
 	report.humidity = msg.humidity;
 	report.timestamp = hrt_absolute_time();
 
-	publish(msg.getSrcNodeID().get(), &report);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &report);
 }

--- a/src/drivers/uavcan/sensors/ice_status.cpp
+++ b/src/drivers/uavcan/sensors/ice_status.cpp
@@ -88,7 +88,7 @@ void UavcanIceStatusBridge::ice_status_sub_cb(const
 		report.lambda_coefficient = msg.cylinder_status[0].lambda_coefficient;
 	}
 
-	publish(msg.getSrcNodeID().get(), &report);
+	publish(msg.getIfaceIndex(), msg.getSrcNodeID().get(), &report);
 }
 
 int UavcanIceStatusBridge::init_driver(uavcan_bridge::Channel *channel)

--- a/src/drivers/uavcan/sensors/mag.cpp
+++ b/src/drivers/uavcan/sensors/mag.cpp
@@ -73,7 +73,7 @@ int UavcanMagnetometerBridge::init()
 void UavcanMagnetometerBridge::mag_sub_cb(const
 		uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength> &msg)
 {
-	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get());
+	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getIfaceIndex(), msg.getSrcNodeID().get());
 
 	if (channel == nullptr) {
 		// Something went wrong - no channel to publish on; return
@@ -98,7 +98,7 @@ void
 UavcanMagnetometerBridge::mag2_sub_cb(const
 				      uavcan::ReceivedDataStructure<uavcan::equipment::ahrs::MagneticFieldStrength2> &msg)
 {
-	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get());
+	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getIfaceIndex(), msg.getSrcNodeID().get());
 
 	if (channel == nullptr || channel->instance < 0) {
 		// Something went wrong - no channel to publish on; return
@@ -121,11 +121,11 @@ UavcanMagnetometerBridge::mag2_sub_cb(const
 
 int UavcanMagnetometerBridge::init_driver(uavcan_bridge::Channel *channel)
 {
-	// update device id as we now know our device node_id
-	DeviceId device_id{_device_id};
-
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN,
+	device_id.devid_s.bus = channel->iface_idx,
 	device_id.devid_s.devtype = DRV_MAG_DEVTYPE_UAVCAN;
-	device_id.devid_s.address = static_cast<uint8_t>(channel->node_id);
+	device_id.devid_s.address =  static_cast<uint8_t>(channel->node_id);
 
 	channel->h_driver = new PX4Magnetometer(device_id.devid, ROTATION_NONE);
 

--- a/src/drivers/uavcan/sensors/rangefinder.cpp
+++ b/src/drivers/uavcan/sensors/rangefinder.cpp
@@ -66,7 +66,7 @@ int UavcanRangefinderBridge::init()
 void UavcanRangefinderBridge::range_sub_cb(const
 		uavcan::ReceivedDataStructure<uavcan::equipment::range_sensor::Measurement> &msg)
 {
-	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getSrcNodeID().get());
+	uavcan_bridge::Channel *channel = get_channel_for_node(msg.getIfaceIndex(), msg.getSrcNodeID().get());
 
 	if (channel == nullptr || channel->instance < 0) {
 		// Something went wrong - no channel to publish on; return
@@ -119,11 +119,11 @@ void UavcanRangefinderBridge::range_sub_cb(const
 
 int UavcanRangefinderBridge::init_driver(uavcan_bridge::Channel *channel)
 {
-	// update device id as we now know our device node_id
-	DeviceId device_id{_device_id};
-
+	device::Device::DeviceId device_id;
+	device_id.devid_s.bus_type = device::Device::DeviceBusType_UAVCAN,
+	device_id.devid_s.bus = channel->iface_idx,
 	device_id.devid_s.devtype = DRV_DIST_DEVTYPE_UAVCAN;
-	device_id.devid_s.address = static_cast<uint8_t>(channel->node_id);
+	device_id.devid_s.address =  static_cast<uint8_t>(channel->node_id);
 
 	channel->h_driver = new PX4Rangefinder(device_id.devid, distance_sensor_s::ROTATION_DOWNWARD_FACING);
 


### PR DESCRIPTION
### Solved Problem
BUG: When using multiple DroneCAN GNSS sensors, they all get the same device id, as the id is stored in a variable shared by all `sensor_gps` channels.

MISSING FEATURE: The previous code always sets the `bus_idx`  of `device_id` for DroneCAN devices to 0, not taking into account on which CAN bus the device actually is.

### Solution
Extend `sensor_bridge` channels to also consider the CAN bus index and not only the node ID. This involves changing functions for publishing and getting channels.

For GPS, use the node id and bus index from the actual DroneCAN messages, and not a single variable for all GPSes. 

Also, make `UavcanSensorBridgeBase`  not inherit from `device::Device`. We want to remove this, because each sensor bridge represents multiple devices.

Because of this, I also has to update all uavcan sensor types, but it is just minor changes. Don't be scared by number of files changed!

### Changelog Entry
For release notes:
```
Bugfix: publish correct device ID for sensors on multiple buses
```

### Alternatives
This considers two DroneCAN nodes with the same node ID but on different buses as different devices. I think this is the best approach. It could also be possible to consider these cases the same device.

### Test coverage
Ground tested on a CubeOrange with two Here4 GPS units.

### Context
See that GPSes got the same device id earlier, but now they get different IDs

Before:
![before, same ID](https://github.com/PX4/PX4-Autopilot/assets/28607452/a575c2df-ef69-4585-924e-57b53a2b23be)

After:
![after, different IDs](https://github.com/PX4/PX4-Autopilot/assets/28607452/eb11e27d-493e-4c96-97b3-e5ffc02999c7)

uavcan_status:
![uavcan status](https://github.com/PX4/PX4-Autopilot/assets/28607452/5583072f-6d52-404c-84a4-610820cc9fe1)