### PR TITLE
EstimatorCheck: GNSS data fusion stopped as INFO if local position is already invalid

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -293,7 +293,9 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 					mavlink_log_warning(reporter.mavlink_log_pub(), "GNSS data fusion stopped\t");
 				}
 
-				events::send(events::ID("check_estimator_gnss_fusion_stopped"), {events::Log::Error, events::LogInternal::Info},
+				// only report this failure as critical if not already in a local position invalid state
+				events::Log log_level = reporter.failsafeFlags().local_position_invalid ? events::Log::Info : events::Log::Error;
+				events::send(events::ID("check_estimator_gnss_fusion_stopped"), {log_level, events::LogInternal::Info},
 					     "GNSS data fusion stopped");
 
 			} else if (!_gps_was_fused && ekf_gps_fusion) {


### PR DESCRIPTION
### Solved Problem
The "GNSS data stopped" warning is sent after the system is already in local position estimate invalid failsafe (at least for hovering systems without wind dead-reckoning). That warning then distracts from the real issue (that the vehicle switched into a failsafe mode). 

https://github.com/PX4/PX4-Autopilot/assets/26798987/ad1b0710-7aec-4bd3-8439-2a440985eada

### Solution
Reduce the severity level of the message to INFO in case of invalid local position. 
https://github.com/PX4/PX4-Autopilot/assets/26798987/648e97f6-6753-4474-82da-b2ee43ff2410

### Changelog Entry
For release notes:
```
Improvement: EstimatorCheck: GNSS data fusion stopped as INFO if local position is already invalid
```

