### PR TITLE
Commander: trigger warning when arming denied due to check failure

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -598,6 +598,9 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 
 		if (!_health_and_arming_checks.canArm(_vehicle_status.nav_state)) {
 			tune_negative(true);
+			mavlink_log_critical(&_mavlink_log_pub, "Arming denied: Resolve system health failures first\t");
+			events::send(events::ID("commander_arm_denied_resolve_failures"), {events::Log::Critical, events::LogInternal::Info},
+				     "Arming denied: Resolve system health failures first");
 			return TRANSITION_DENIED;
 		}
 	}


### PR DESCRIPTION

### Solved Problem
There is currently no warning/event sent by PX4 when arming is denied due to a preflight check failure (though the preflight field in the top bar is red). 

### Solution
Add a warning message to make clear that 
1) there was an arming attempt (not that e.g. sticks are not working)
2) give hint to why arming failed

![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/db71a63c-fcab-4412-9993-c4a910a39ae8)

### Changelog Entry
For release notes:
```
Feature: 
```
