### PR TITLE
Commander check reporting improvements

### DIFF
--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -402,19 +402,19 @@
                         },
                         "2": {
                             "name": "fallback_posctrl",
-                            "description": "fallback to position control"
+                            "description": "fallback to Position mode"
                         },
                         "3": {
                             "name": "fallback_altctrl",
-                            "description": "fallback to altitude control"
+                            "description": "fallback to Altitude mode"
                         },
                         "4": {
                             "name": "fallback_stabilized",
-                            "description": "fallback to stabilized"
+                            "description": "fallback to Stabilized mode"
                         },
                         "5": {
                             "name": "hold",
-                            "description": "hold"
+                            "description": "Hold"
                         },
                         "6": {
                             "name": "rtl",
@@ -422,11 +422,11 @@
                         },
                         "7": {
                             "name": "land",
-                            "description": "land"
+                            "description": "Land"
                         },
                         "8": {
                             "name": "descend",
-                            "description": "descend"
+                            "description": "Descend"
                         },
                         "9": {
                             "name": "disarm",

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -364,7 +364,7 @@
                         },
                         "1": {
                             "name": "manual_control_loss",
-                            "description": "manual control loss"
+                            "description": "Manual control loss"
                         },
                         "2": {
                             "name": "gcs_connection_loss",
@@ -384,7 +384,7 @@
                         },
                         "6": {
                             "name": "low_remaining_flight_time",
-                            "description": "low remaining flight time"
+                            "description": "Remaining flight time low"
                         }
                     }
                 },
@@ -402,15 +402,15 @@
                         },
                         "2": {
                             "name": "fallback_posctrl",
-                            "description": "fallback to Position mode"
+                            "description": "Position mode"
                         },
                         "3": {
                             "name": "fallback_altctrl",
-                            "description": "fallback to Altitude mode"
+                            "description": "Altitude mode"
                         },
                         "4": {
                             "name": "fallback_stabilized",
-                            "description": "fallback to Stabilized mode"
+                            "description": "Stabilized mode"
                         },
                         "5": {
                             "name": "hold",

--- a/src/lib/events/enums.json
+++ b/src/lib/events/enums.json
@@ -372,15 +372,15 @@
                         },
                         "3": {
                             "name": "low_battery_level",
-                            "description": "low battery level"
+                            "description": "Low battery level"
                         },
                         "4": {
                             "name": "critical_battery_level",
-                            "description": "critical battery level"
+                            "description": "Critical battery level"
                         },
                         "5": {
                             "name": "emergency_battery_level",
-                            "description": "emergency battery level"
+                            "description": "Emergency battery level"
                         },
                         "6": {
                             "name": "low_remaining_flight_time",

--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -195,7 +195,7 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 			events::send<uint32_t, events::px4::enums::failsafe_action_t, uint16_t>(
 				events::ID("commander_failsafe_enter_generic_hold"),
 			{events::Log::Critical, events::LogInternal::Warning},
-			"Failsafe activated, triggering {2} in {3} seconds", mavlink_mode, failsafe_action,
+			"Failsafe, triggering {2} in {3} seconds", mavlink_mode, failsafe_action,
 			(uint16_t) delay_s);
 
 		} else {
@@ -204,7 +204,7 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 			events::send<uint32_t, events::px4::enums::failsafe_action_t, uint16_t, events::px4::enums::failsafe_cause_t>(
 				events::ID("commander_failsafe_enter_hold"),
 			{events::Log::Critical, events::LogInternal::Warning},
-			"Failsafe activated due to {4}, triggering {2} in {3} seconds", mavlink_mode, failsafe_action,
+			"{4}, triggering {2} in {3} seconds", mavlink_mode, failsafe_action,
 			(uint16_t) delay_s, failsafe_cause);
 		}
 
@@ -231,7 +231,7 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				events::send<uint32_t, events::px4::enums::failsafe_action_t>(
 					events::ID("commander_failsafe_enter_generic"),
 				{events::Log::Critical, events::LogInternal::Warning},
-				"Failsafe activated, triggering {2}", mavlink_mode, failsafe_action);
+				"Failsafe, triggering {2}", mavlink_mode, failsafe_action);
 			}
 
 		} else {
@@ -272,7 +272,7 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				events::send<uint32_t, events::px4::enums::failsafe_action_t, events::px4::enums::failsafe_cause_t>(
 					events::ID("commander_failsafe_enter"),
 				{events::Log::Critical, events::LogInternal::Warning},
-				"Failsafe activated due to {3}, triggering {2}", mavlink_mode, failsafe_action, failsafe_cause);
+				"{3}, triggering {2}", mavlink_mode, failsafe_action, failsafe_cause);
 			}
 		}
 


### PR DESCRIPTION

### Solved Problem
The failsafe event messages are a bit long.

### Solution
Make them shorter.
That's how it would look like now:
https://github.com/PX4/PX4-Autopilot/assets/26798987/ece1ea4e-74de-473c-8458-a7c24d986d6e



### Changelog Entry
For release notes:
```
Improvement: Commander: make failsafe warnings shorter
```

