### PR TITLE
commander: low flight time failsafe: set UserTakeoverAllowed::Auto to enter Hold first

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -369,7 +369,7 @@ FailsafeBase::ActionOptions Failsafe::fromRemainingFlightTimeLowActParam(int par
 {
 	ActionOptions options{};
 
-	options.allow_user_takeover = UserTakeoverAllowed::Always;
+	options.allow_user_takeover = UserTakeoverAllowed::Auto;
 	options.cause = Cause::RemainingFlightTimeLow;
 
 	switch (command_after_remaining_flight_time_low(param_value)) {


### PR DESCRIPTION

### Solved Problem
Low flight time action is executed immediately, doesn't enter Hold.

### Solution
Set it to UserTakeoverAllowed::Auto to make it go to Hold first (without manual takeover possible), and then allow take over once in the failsafe action.

