### PR TITLE
Added MANUAL_CONTROL stream in the MAVLINK_MODE_NORMAL mode

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1426,6 +1426,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("HYGROMETER_SENSOR", 0.1f);
 		configure_stream_local("LOCAL_POSITION_NED", 1.0f);
 		configure_stream_local("MOUNT_ORIENTATION", 10.0f);
+		configure_stream_local("MANUAL_CONTROL", 5.0f);
 		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.0f);
 		configure_stream_local("OBSTACLE_DISTANCE", 1.0f);
 		configure_stream_local("OPEN_DRONE_ID_LOCATION", 1.f);


### PR DESCRIPTION
In the case of using Joystick to control the drone, one needs these MANUAL_CONTROL messages for control pitch and roll servos, connected to a companion computer (Raspberry Pi), that is connected to FC by UART.

### Solved Problem
I use a Joystick to control the drone. The joystick is connected to PC with QGC. The drone has a companion computer (Raspberry Pi Zero 2W) with a 4G modem. The companion computer is connected by UART to the flight controller (Kakute H7 mini). My drone also has wheels. I found that there only in MANUAL_CONTROL mavlink massage has the information about joystick axes. I need these values to control wheel servos, that are connected to the companion computer.

