### PR TITLE
EKF2: fix gnss yaw unit test

### DIFF
--- a/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps_yaw.cpp
@@ -81,9 +81,10 @@ public:
 void EkfGpsHeadingTest::runConvergenceScenario(float yaw_offset_rad, float antenna_offset_rad)
 {
 	// GIVEN: an initial GPS yaw, not aligned with the current one
-	float gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle() + yaw_offset_rad);
+	// The yaw antenna offset has already been corrected in the driver
+	float gps_heading = matrix::wrap_pi(_ekf_wrapper.getYawAngle());
 
-	_sensor_simulator._gps.setYaw(gps_heading);
+	_sensor_simulator._gps.setYaw(gps_heading); // used to remove the correction to fuse the real measurement
 	_sensor_simulator._gps.setYawOffset(antenna_offset_rad);
 
 	// WHEN: the GPS yaw fusion is activated
@@ -91,7 +92,7 @@ void EkfGpsHeadingTest::runConvergenceScenario(float yaw_offset_rad, float anten
 	_sensor_simulator.runSeconds(5);
 
 	// THEN: the estimate is reset and stays close to the measurement
-	checkConvergence(gps_heading, 0.05f);
+	checkConvergence(gps_heading, 0.01f);
 }
 
 void EkfGpsHeadingTest::checkConvergence(float truth, float tolerance_deg)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The heading wasn't following the GNSS yaw precisely. After investigation I found that the unit test was incorrectly designed.

### Solution
Make the unit test work the same way a real driver does.
Reduce the tolerance threshold (it was too high to make the unit test pass).