### PR TITLE
gps: fix incorrect task id in module startup

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1406,7 +1406,7 @@ int GPS::task_spawn(int argc, char *argv[], Instance instance)
 				   entry_point, (char *const *)argv);
 
 	if (task_id < 0) {
-		task_id = -1;
+		_task_id = -1;
 		return -errno;
 	}
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This is a small fix because when I read through the code, the `_task_id` does not seem to be set correctly in `gps.cpp` in the GPS module. It's setting a local variable instead of the member variable which is supposed to be set to -1 on error (see documentation of `ModuleBase::task_spawn()`).

Fixes \/

### Solution
- Change local variable to member variable

### Changelog Entry
For release notes:
```
Bugfix Correctly set GPS module task id on failure
```

### Alternatives
\/

### Test coverage
\/

### Context
Found this while working on extracting a GPS driver in #22904 