### PR TITLE
code: add `.editorconfig` for consistent code style across editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.{c,cpp,cc,h,hpp}]
+indent_style = tab
+tab_width = 8
+max_line_length = 120


### PR DESCRIPTION
EditorConfig is a well-known convention to share style settings across different editors. Adding one will make it easier for new contributors or people who like to use a different editor to contribute.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
I've switched from using Visual Studio Code to Neovim because the language server works quite a lot better. Neovim has no way to tell how to indent lines or how to represent tabs. Having this file tells a lot of different editors some basic information like how many spaces a tab represents, whether to indent with spaces or tabs, what the maximum line length should be... It can also tell editors to use a certain encoding, add a newline at the end of files and some other QOL settings.

The developer documentation mentions that a lot of files do not yet follow the style guidelines. This file could help to organically convert more and more files to the correct format as quite a lot of editors are automatically set up correctly.

### Solution
- Add a `.editorconfig` file with shared options for all C/C++ files.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
I think this is the most general approach. It's used [by a ton of editors](https://editorconfig.org/#pre-installed). Sadly Visual Studio Code requires an extension, which could be added to the list of recommended extensions.

### Context
I find it weird that nobody has suggested this before. Maybe I'm overlooking something but I can't find a single mention of EditorConfig anywhere in the issues or PRs. Sorry if this has been proposed before.