### PR TITLE
code: add more style options in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,14 @@
 root = true
 
-[*.{c,cpp,cc,h,hpp}]
+[*]
+insert_final_newline = false
+
+[{*.{c,cpp,cc,h,hpp},CMakeLists.txt,Kconfig}]
 indent_style = tab
 tab_width = 8
+# Not in the official standard, but supported by many editors
 max_line_length = 120
+
+[*.yaml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Some file types were missing from the global `.editorconfig`.

### Solution
- Added more EditorConfig style settings to the `.editorconfig` to support YAML, Kconfig and `CMakeLists.txt` files.

### Changelog Entry
\/

### Alternatives
\/

### Test coverage
\/

### Context
I wanted to see whether a `.editorconfig` would be accepted before adding all the options. This will also be an ongoing effort as that's easier than adding all the options for all the files at once. People can add files that aren't displayed/edited correctly as they need it.

The options are decided both by looking at the developer documentation as well as by checking what most files use (e.g. for YAML where the style isn't documented anywhere).