### PR TITLE
Update px_uploader.py

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -867,9 +867,11 @@ def main():
                         # Windows, don't open POSIX ports
                         if "/" not in port:
                             up = uploader(port, args.baud_bootloader, baud_flightstack)
-                except Exception:
+                except Exception as e:
                     # open failed, rate-limit our attempts
                     time.sleep(0.05)
+                    #I'm not sure what exception you're expecting, but just catching all is a bad idea
+                    print(e)
 
                     # and loop to the next port
                     continue
@@ -887,7 +889,7 @@ def main():
                         print("Found board id: %s,%s bootloader version: %s on %s" % (up.board_type, up.board_rev, up.bl_rev, port))
                         break
 
-                    except Exception:
+                    except Exception as e:
 
                         if not up.send_reboot(args.use_protocol_splitter_format):
                             break
@@ -900,6 +902,8 @@ def main():
 
                         # wait for the close, without we might run into Serial I/O Error 6
                         time.sleep(0.3)
+                        print(e)
+
 
                 if not found_bootloader:
                     # Go to the next port


### PR DESCRIPTION
Having catchall exceptions like this is a really bad idea, in our case due to another library called "Serial" being installed this would just hang indefinitely with no feedback.

This could be made cleaner if I knew exactly what exception you're expecting to catch, but honestly this whole script seems pretty fragile.

I'm not going to have much time to work on this, but I figure I'll add this commit just so you can see the problem. Most times when a user has gotten stuck "waiting for bootloader" it's probably been due to some kind of exception here being silenced.

For people googling this, if your PX4 build is stuck at "Waiting for bootloader..." it probably has something to do with this. Make sure you have python3-serial installed.