### PR TITLE
EKF: IN_AIR is determined first

### DIFF
--- a/src/modules/ekf2/EKF/gps_control.cpp
+++ b/src/modules/ekf2/EKF/gps_control.cpp
@@ -123,8 +123,8 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 
 				bool do_vel_pos_reset = shouldResetGpsFusion();
 
-				if (isYawFailure()
-				    && _control_status.flags.in_air
+				if (_control_status.flags.in_air
+				    && isYawFailure()
 				    && isTimedOut(_time_last_hor_vel_fuse, _params.EKFGSF_reset_delay)
 				    && (_time_last_hor_vel_fuse > _time_last_on_ground_us)) {
 					do_vel_pos_reset = tryYawEmergencyReset();


### PR DESCRIPTION
### Solved Problem

YAW Failure decision is being made after the YAW Failure decision and before the During Takeoff decision.

### Solution

YAW Failure Decision is effective by making the during-takeoff decision first.

### Changelog Entry

None

### Alternatives

None

### Test coverage

None

### Context

None