### PR TITLE
Define px4_access as a proxy to the posix access function

### DIFF
--- a/platforms/common/include/px4_platform_common/posix.h
+++ b/platforms/common/include/px4_platform_common/posix.h
@@ -104,6 +104,12 @@ typedef struct {
 // Qurt has no fsync implementation so need to declare one here
 // and then define a fake one in the Qurt platform code.
 void fsync(int fd);
+
+// The access function on Qurt is defined but it crashes if you use it!
+// So, on Qurt, we will use px4_access instead of access and create a benign
+// implementation of it
+int px4_access(const char *pathname, int mode);
+
 // Qurt doesn't have a way to set the scheduler policy. It is always, essentially,
 // SCHED_FIFO. So have to add a fake function for the code that tries to set it.
 #include <pthread.h>
@@ -113,13 +119,17 @@ __EXPORT int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy);
 #define SIGCONT SIGALRM
 #endif
 
+// For non-Qurt Posix platforms just use the normal access
+#if ! defined(__PX4_QURT)
+#define px4_access access
+#endif
+
 __EXPORT int 		px4_open(const char *path, int flags, ...);
 __EXPORT int 		px4_close(int fd);
 __EXPORT ssize_t	px4_read(int fd, void *buffer, size_t buflen);
 __EXPORT ssize_t	px4_write(int fd, const void *buffer, size_t buflen);
 __EXPORT int		px4_ioctl(int fd, int cmd, unsigned long arg);
 __EXPORT int		px4_poll(px4_pollfd_struct_t *fds, unsigned int nfds, int timeout);
-__EXPORT int		px4_access(const char *pathname, int mode);
 __EXPORT px4_task_t	px4_getpid(void);
 
 __END_DECLS

--- a/platforms/qurt/src/px4/px4_qurt_impl.cpp
+++ b/platforms/qurt/src/px4/px4_qurt_impl.cpp
@@ -37,5 +37,7 @@ __BEGIN_DECLS
 long PX4_TICKS_PER_SEC = 1000L;
 void fsync(int fd) { return; }
 uint32_t crc32part(const uint8_t *src, size_t len, uint32_t crc32val) { return 1; }
+int px4_access(const char *pathname, int mode) { return 0; }
+
 
 __END_DECLS

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1528,7 +1528,7 @@ GPS *GPS::instantiate(int argc, char *argv[], Instance instance)
 
 	GPS *gps = nullptr;
 	if (instance == Instance::Main) {
-		if (device_name && (access(device_name, R_OK|W_OK) == 0)) {
+		if (device_name && (px4_access(device_name, R_OK|W_OK) == 0)) {
 			gps = new GPS(device_name, mode, interface, instance, baudrate_main);
 
 		} else {

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1551,7 +1551,7 @@ GPS *GPS::instantiate(int argc, char *argv[], Instance instance)
 			}
 		}
 	} else { // secondary instance
-		if (device_name_secondary && (access(device_name_secondary, R_OK|W_OK) == 0)) {
+		if (device_name_secondary && (px4_access(device_name_secondary, R_OK|W_OK) == 0)) {
 			gps = new GPS(device_name_secondary, mode, interface_secondary, instance, baudrate_secondary);
 
 		} else {

--- a/src/lib/cdev/posix/cdev_platform.cpp
+++ b/src/lib/cdev/posix/cdev_platform.cpp
@@ -442,17 +442,6 @@ extern "C" {
 		return (count) ? count : ret;
 	}
 
-	int px4_access(const char *pathname, int mode)
-	{
-		if (mode != F_OK) {
-			errno = EINVAL;
-			return -1;
-		}
-
-		cdev::CDev *dev = getDev(pathname);
-		return (dev != nullptr) ? 0 : -1;
-	}
-
 	void px4_show_files()
 	{
 		PX4_INFO("Files:");


### PR DESCRIPTION
### Solved Problem
GPS, along with some other driver code, uses the posix access function to check for the existence of a path. The access
function is defined on the Qurt platform but crashes when used. To avoid that, a px4_access proxy is defined. On non-Qurt
platforms it just maps straight to the underlying access function. But on Qurt it has a definition that is safe to use. The CDEV library has a px4_access definition but it wasn't being used so it was removed.