### PR TITLE
battery_status.msg: remove unused fields

### DIFF
--- a/msg/BatteryStatus.msg
+++ b/msg/BatteryStatus.msg
@@ -68,12 +68,8 @@ uint8 BATTERY_MODE_COUNT = 3 # Counter - keep it as last element (once we're ful
 
 uint8 MAX_INSTANCES = 4
 
-float32 average_power               # The average power of the current discharge
-float32 available_energy            # The predicted charge or energy remaining in the battery
 float32 full_charge_capacity_wh     # The compensated battery capacity
 float32 remaining_capacity_wh       # The compensated battery capacity remaining
-float32 design_capacity             # The design capacity of the battery
-uint16 average_time_to_full         # The predicted remaining time until the battery reaches full charge, in minutes
 uint16 over_discharge_count         # Number of battery overdischarge
 float32 nominal_voltage             # Nominal voltage of the battery pack
 


### PR DESCRIPTION

### Solved Problem
All these fields in the battery message aren't filled or used anywhere in PX4, so I don't see why they should be in the mainline PX4. Seemed to been [introduced](https://github.com/PX4/PX4-Autopilot/pull/17104/files#diff-2b038c042562ed5e0c53f450b7f7c3f7ef695087496853759f964f9be107cd30) as they get published by some power module over UAVCAN. Do we need to have battery_status in sync with the UAVCAN message?
I find all these empty fields quite annoying when debugging battery stuff, as they distract form the important ones. And it's empty weight in the log files.


