### PR TITLE
Battery parameters: clarify empty, full voltage description

### DIFF
--- a/boards/diatone/mamba-f405-mk2/src/board_config.h
+++ b/boards/diatone/mamba-f405-mk2/src/board_config.h
@@ -74,8 +74,7 @@
 #define ADC_BATTERY_CURRENT_CHANNEL  13
 #define ADC_RC_RSSI_CHANNEL          12
 
-/* Define Battery 1 Voltage Divider and A per V
- */
+/* Define Battery Voltage Divider and A per V */
 #define BOARD_BATTERY1_V_DIV         (11.12f)
 #define BOARD_BATTERY1_A_PER_V       (31.f)
 

--- a/boards/matek/h743-mini/src/board_config.h
+++ b/boards/matek/h743-mini/src/board_config.h
@@ -102,9 +102,7 @@
 	 (1 << ADC_RSSI_IN_CHANNEL))
 
 
-/* Define Battery 1 Voltage Divider and A per V
- */
-
+/* Define Battery Voltage Divider and A per V */
 #define BOARD_BATTERY1_V_DIV         (11.0f)     /* measured with the provided PM board */
 #define BOARD_BATTERY1_A_PER_V       (40.0f)
 #define BOARD_BATTERY2_V_DIV         (11.0f)     /* measured with the provided PM board */

--- a/boards/matek/h743/src/board_config.h
+++ b/boards/matek/h743/src/board_config.h
@@ -102,9 +102,7 @@
 	 (1 << ADC_RSSI_IN_CHANNEL))
 
 
-/* Define Battery 1 Voltage Divider and A per V
- */
-
+/* Define Battery Voltage Divider and A per V */
 #define BOARD_BATTERY1_V_DIV         (11.0f)     /* measured with the provided PM board */
 #define BOARD_BATTERY1_A_PER_V       (40.0f)
 #define BOARD_BATTERY2_V_DIV         (11.0f)     /* measured with the provided PM board */

--- a/boards/sky-drones/smartap-airlink/src/board_config.h
+++ b/boards/sky-drones/smartap-airlink/src/board_config.h
@@ -196,7 +196,7 @@
  */
 #define DIRECT_PWM_OUTPUT_CHANNELS  8
 
-/* Define Battery 1 g Divider and A per V. */
+/* Define Battery Voltage Divider and A per V */
 #define BOARD_BATTERY_V_DIV         (13.653333333f)
 #define BOARD_BATTERY_A_PER_V       (36.367515152f)
 

--- a/src/lib/battery/module.yaml
+++ b/src/lib/battery/module.yaml
@@ -7,12 +7,12 @@ parameters:
       definitions:
         BAT${i}_V_EMPTY:
             description:
-                short: Empty cell voltage (5C load)
+                short: Empty cell voltage
                 long: |
-                    Defines the voltage where a single cell of battery 1 is considered empty.
-                    The voltage should be chosen before the steep dropoff to 2.8V. A typical
-                    lithium battery can only be discharged down to 10% before it drops off
-                    to a voltage level damaging the cells.
+                    Defines the voltage where a single cell of the battery is considered empty.
+                    The voltage should be chosen above the steep dropoff at 3.5V. A typical
+                    lithium battery can only be discharged under high load down to 10% before
+                    it drops off to a voltage level damaging the cells.
 
             type: float
             unit: V
@@ -25,10 +25,10 @@ parameters:
 
         BAT${i}_V_CHARGED:
             description:
-                short: Full cell voltage (5C load)
+                short: Full cell voltage
                 long: |
-                    Defines the voltage where a single cell of battery 1 is considered full
-                    under a mild load. This will never be the nominal voltage of 4.2V
+                    Defines the voltage where a single cell of the battery is considered full.
+                    For a more accurate estimate set this below the nominal voltage of e.g. 4.2V
 
             type: float
             unit: V
@@ -44,7 +44,7 @@ parameters:
                 short: Voltage drop per cell on full throttle
                 long: |
                     This implicitly defines the internal resistance
-                    to maximum current ratio for battery 1 and assumes linearity.
+                    to maximum current ratio for the battery and assumes linearity.
                     A good value to use is the difference between the
                     5C and 20-25C load. Not used if BAT${i}_R_INTERNAL is
                     set.


### PR DESCRIPTION
### Solved Problem
When helping @sfuhrer with battery configuration he hinted me towards the description not being accurate.
Feel free to add to this.

### Solution
- Correct the fact that these voltages are ideally with the load completely compensated.
This requires an accurate current measurement and configured internal resistance.
- Clarify the text a bit.

### Changelog Entry
```
Documentation: clarify empty, full battery voltage description
```