### PR TITLE
Px4 specify with time units appended

### DIFF
--- a/platforms/common/i2c_spi_buses.cpp
+++ b/platforms/common/i2c_spi_buses.cpp
@@ -45,6 +45,8 @@
 
 #include <pthread.h>
 
+using namespace time_literals;
+
 static List<I2CSPIInstance *> i2c_spi_module_instances; ///< list of currently running instances
 static pthread_mutex_t i2c_spi_module_instances_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -833,7 +835,7 @@ void I2CSPIDriverBase::request_stop_and_wait()
 	unsigned int i = 0;
 
 	do {
-		px4_usleep(20000); // 20 ms
+		px4_usleep(20_ms); // 20 ms
 		// wait at most 2 sec
 	} while (++i < 100 && !_task_exited.load());
 

--- a/src/drivers/lights/rgbled_pwm/rgbled_pwm.cpp
+++ b/src/drivers/lights/rgbled_pwm/rgbled_pwm.cpp
@@ -95,7 +95,7 @@ RGBLED_PWM::~RGBLED_PWM()
 	int counter = 0;
 
 	while (_running && ++counter < 10) {
-		px4_usleep(100000);
+		px4_usleep(100_ms);
 	}
 }
 

--- a/src/drivers/optical_flow/pmw3901/PMW3901.cpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.cpp
@@ -58,7 +58,7 @@ PMW3901::sensorInit()
 
 	// Power on reset
 	writeRegister(0x3A, 0x5A);
-	usleep(5000);
+	usleep(5_ms);
 
 	// Reading the motion registers one time
 	readRegister(0x02, &data[0], 1);
@@ -67,7 +67,7 @@ PMW3901::sensorInit()
 	readRegister(0x05, &data[3], 1);
 	readRegister(0x06, &data[4], 1);
 
-	usleep(1000);
+	usleep(1_ms);
 
 	// set performance optimization registers
 	// from PixArt PMW3901MB Optical Motion Tracking chip demo kit V3.20 (21 Aug 2018)
@@ -184,7 +184,7 @@ PMW3901::sensorInit()
 	writeRegister(0x40, 0x41);
 	writeRegister(0x70, 0x00);
 
-	px4_usleep(10000); // delay 10ms
+	px4_usleep(10_ms); // delay 10ms
 
 	writeRegister(0x32, 0x44);
 	writeRegister(0x7F, 0x07);

--- a/src/drivers/optical_flow/pmw3901/PMW3901.hpp
+++ b/src/drivers/optical_flow/pmw3901/PMW3901.hpp
@@ -50,6 +50,8 @@
 #include <uORB/topics/sensor_optical_flow.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 
+using namespace time_literals;
+
 /* Configuration Constants */
 
 #define PMW3901_SPI_BUS_SPEED (2000000L) // 2MHz


### PR DESCRIPTION
### Solved Problem

The time specification is set to a microsecond value and the time unit is described in a comment.

### Solution

If writing in comments, add time units.

### Changelog Entry

None

### Alternatives

None

### Test coverage

None

### Context

None