### PR TITLE
Additions to the Serial UART API

### DIFF
--- a/platforms/common/Serial.cpp
+++ b/platforms/common/Serial.cpp
@@ -36,6 +36,10 @@
 namespace device
 {
 
+Serial::Serial() :
+	_impl(nullptr, 57600, ByteSize::EightBits, Parity::None, StopBits::One, FlowControl::Disabled) {}
+
+
 Serial::Serial(const char *port, uint32_t baudrate, ByteSize bytesize, Parity parity, StopBits stopbits,
 	       FlowControl flowcontrol) :
 	_impl(port, baudrate, bytesize, parity, stopbits, flowcontrol)
@@ -133,6 +137,16 @@ bool Serial::setFlowcontrol(FlowControl flowcontrol)
 const char *Serial::getPort() const
 {
 	return _impl.getPort();
+}
+
+bool Serial::validatePort(const char *port)
+{
+	return SerialImpl::validatePort(port);
+}
+
+bool Serial::setPort(const char *port)
+{
+	return _impl.setPort(port);
 }
 
 } // namespace device

--- a/platforms/common/include/px4_platform_common/Serial.hpp
+++ b/platforms/common/include/px4_platform_common/Serial.hpp
@@ -48,6 +48,7 @@ namespace device __EXPORT
 class Serial
 {
 public:
+	Serial();
 	Serial(const char *port, uint32_t baudrate = 57600,
 	       ByteSize bytesize = ByteSize::EightBits, Parity parity = Parity::None,
 	       StopBits stopbits = StopBits::One, FlowControl flowcontrol = FlowControl::Disabled);
@@ -83,6 +84,8 @@ public:
 	FlowControl getFlowcontrol() const;
 	bool setFlowcontrol(FlowControl flowcontrol);
 
+	static bool validatePort(const char *port);
+	bool setPort(const char *port);
 	const char *getPort() const;
 
 private:

--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -53,9 +53,8 @@ SerialImpl::SerialImpl(const char *port, uint32_t baudrate, ByteSize bytesize, P
 	_stopbits(stopbits),
 	_flowcontrol(flowcontrol)
 {
-	if (port) {
-		strncpy(_port, port, sizeof(_port) - 1);
-		_port[sizeof(_port) - 1] = '\0';
+	if (validatePort(port)) {
+		setPort(port);
 
 	} else {
 		_port[0] = 0;
@@ -190,6 +189,11 @@ bool SerialImpl::open()
 {
 	if (isOpen()) {
 		return true;
+	}
+
+	if (!validatePort(_port)) {
+		PX4_ERR("Invalid port %s", _port);
+		return false;
 	}
 
 	// Open the serial port

--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -324,6 +324,22 @@ const char *SerialImpl::getPort() const
 	return _port;
 }
 
+bool SerialImpl::validatePort(const char *port)
+{
+	return (port && (access(port, R_OK | W_OK) == 0));
+}
+
+bool SerialImpl::setPort(const char *port)
+{
+	if (validatePort(port)) {
+		strncpy(_port, port, sizeof(_port) - 1);
+		_port[sizeof(_port) - 1] = '\0';
+		return true;
+	}
+
+	return false;
+}
+
 uint32_t SerialImpl::getBaudrate() const
 {
 	return _baudrate;

--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -331,6 +331,11 @@ bool SerialImpl::validatePort(const char *port)
 
 bool SerialImpl::setPort(const char *port)
 {
+	if (_open) {
+		PX4_ERR("Cannot set port after port has already been opened");
+		return false;
+	}
+
 	if (validatePort(port)) {
 		strncpy(_port, port, sizeof(_port) - 1);
 		_port[sizeof(_port) - 1] = '\0';

--- a/platforms/nuttx/src/px4/common/include/SerialImpl.hpp
+++ b/platforms/nuttx/src/px4/common/include/SerialImpl.hpp
@@ -65,6 +65,8 @@ public:
 	ssize_t write(const void *buffer, size_t buffer_size);
 
 	const char *getPort() const;
+	static bool validatePort(const char *port);
+	bool setPort(const char *port);
 
 	uint32_t getBaudrate() const;
 	bool setBaudrate(uint32_t baudrate);

--- a/platforms/posix/include/SerialImpl.hpp
+++ b/platforms/posix/include/SerialImpl.hpp
@@ -65,6 +65,8 @@ public:
 	ssize_t write(const void *buffer, size_t buffer_size);
 
 	const char *getPort() const;
+	static bool validatePort(const char *port);
+	bool setPort(const char *port);
 
 	uint32_t getBaudrate() const;
 	bool setBaudrate(uint32_t baudrate);

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -51,9 +51,8 @@ SerialImpl::SerialImpl(const char *port, uint32_t baudrate, ByteSize bytesize, P
 	_stopbits(stopbits),
 	_flowcontrol(flowcontrol)
 {
-	if (port) {
-		strncpy(_port, port, sizeof(_port) - 1);
-		_port[sizeof(_port) - 1] = '\0';
+	if (validatePort(port)) {
+		setPort(port);
 
 	} else {
 		_port[0] = 0;
@@ -188,6 +187,11 @@ bool SerialImpl::open()
 {
 	if (isOpen()) {
 		return true;
+	}
+
+	if (!validatePort(_port)) {
+		PX4_ERR("Invalid port %s", _port);
+		return false;
 	}
 
 	// Open the serial port

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -324,6 +324,11 @@ bool SerialImpl::validatePort(const char *port)
 
 bool SerialImpl::setPort(const char *port)
 {
+	if (_open) {
+		PX4_ERR("Cannot set port after port has already been opened");
+		return false;
+	}
+
 	if (validatePort(port)) {
 		strncpy(_port, port, sizeof(_port) - 1);
 		_port[sizeof(_port) - 1] = '\0';

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -317,6 +317,22 @@ const char *SerialImpl::getPort() const
 	return _port;
 }
 
+bool SerialImpl::validatePort(const char *port)
+{
+	return (port && (access(port, R_OK | W_OK) == 0));
+}
+
+bool SerialImpl::setPort(const char *port)
+{
+	if (validatePort(port)) {
+		strncpy(_port, port, sizeof(_port) - 1);
+		_port[sizeof(_port) - 1] = '\0';
+		return true;
+	}
+
+	return false;
+}
+
 uint32_t SerialImpl::getBaudrate() const
 {
 	return _baudrate;

--- a/platforms/qurt/include/SerialImpl.hpp
+++ b/platforms/qurt/include/SerialImpl.hpp
@@ -65,6 +65,7 @@ public:
 
 	const char *getPort() const;
 	bool setPort(const char *port);
+	static bool validatePort(const char *port);
 
 	uint32_t getBaudrate() const;
 	bool setBaudrate(uint32_t baudrate);

--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -258,11 +258,16 @@ const char *SerialImpl::getPort() const
 
 bool SerialImpl::validatePort(const char *port)
 {
-	return (port != nullptr);
+	return (qurt_uart_get_port(port) >= 0);
 }
 
 bool SerialImpl::setPort(const char *port)
 {
+	if (_open) {
+		PX4_ERR("Cannot set port after port has already been opened");
+		return false;
+	}
+
 	if (validatePort(port)) {
 		strncpy(_port, port, sizeof(_port) - 1);
 		_port[sizeof(_port) - 1] = '\0';

--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -48,9 +48,8 @@ SerialImpl::SerialImpl(const char *port, uint32_t baudrate, ByteSize bytesize, P
 	_stopbits(stopbits),
 	_flowcontrol(flowcontrol)
 {
-	if (port) {
-		strncpy(_port, port, sizeof(_port) - 1);
-		_port[sizeof(_port) - 1] = '\0';
+	if (validatePort(port)) {
+		setPort(port);
 
 	} else {
 		_port[0] = 0;
@@ -114,6 +113,11 @@ bool SerialImpl::open()
 
 	if (_flowcontrol != FlowControl::Disabled) {
 		PX4_ERR("Qurt platform only supports FlowControl::Disabled");
+		return false;
+	}
+
+	if (!validatePort(_port)) {
+		PX4_ERR("Invalid port %s", _port);
 		return false;
 	}
 

--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -256,6 +256,22 @@ const char *SerialImpl::getPort() const
 	return _port;
 }
 
+bool SerialImpl::validatePort(const char *port)
+{
+	return (port != nullptr);
+}
+
+bool SerialImpl::setPort(const char *port)
+{
+	if (validatePort(port)) {
+		strncpy(_port, port, sizeof(_port) - 1);
+		_port[sizeof(_port) - 1] = '\0';
+		return true;
+	}
+
+	return false;
+}
+
 uint32_t SerialImpl::getBaudrate() const
 {
 	return _baudrate;

--- a/src/lib/drivers/device/qurt/uart.c
+++ b/src/lib/drivers/device/qurt/uart.c
@@ -25,19 +25,32 @@ void configure_uart_callbacks(open_uart_func_t open_func,
 	}
 }
 
-int qurt_uart_open(const char *dev, speed_t speed)
+int qurt_uart_get_port(const char *dev)
 {
-	if (_callbacks_configured) {
+	if (dev != NULL) {
 		// Convert device string into a uart port number
 		char *endptr = NULL;
-		uint8_t port_number = (uint8_t) strtol(dev, &endptr, 10);
+		int port_number = strtol(dev, &endptr, 10);
 
 		if ((port_number == 0) && (endptr == dev)) {
 			PX4_ERR("Could not convert %s into a valid uart port number", dev);
 			return -1;
-		}
 
-		return _open_uart(port_number, speed);
+		} else {
+			return port_number;
+		}
+	}
+
+	return -1;
+}
+
+int qurt_uart_open(const char *dev, speed_t speed)
+{
+	int port_number = qurt_uart_get_port(dev);
+
+	if (_callbacks_configured && (port_number >= 0)) {
+
+		return _open_uart((uint8_t) port_number, speed);
 
 	} else {
 		PX4_ERR("Cannot open uart until callbacks have been configured");

--- a/src/lib/drivers/device/qurt/uart.h
+++ b/src/lib/drivers/device/qurt/uart.h
@@ -7,6 +7,7 @@ extern "C" {
 #include <stdbool.h>
 #include <termios.h>
 
+int qurt_uart_get_port(const char *dev);
 int qurt_uart_open(const char *dev, speed_t speed);
 int qurt_uart_write(int fd, const char *buf, size_t len);
 int qurt_uart_read(int fd, char *buf, size_t len, uint32_t timeout_us);


### PR DESCRIPTION

### Solved Problem
Serial UART had to be created dynamically in order to set the port since it could only be set in the constructor. Added a new constructor and a setPort function so that the port can be set after the Serial object has been created. Added a static validatePort function. The new validatePort function will call the access function on Nuttx and Posix platforms to verify the port name in the file system. The Qurt platform does not have a file system so it does not call access. The GPS driver was modified to make use of these new functions. It no longer dynamically allocates the Serial driver. And it uses the new validatePort function instead of calling access. This allows the GPS driver to now work on the Qurt platform.