### PR TITLE
rtl_status.msg logging fixes

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -103,7 +103,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("px4io_status");
 	add_topic("radio_status");
 	add_topic("rtl_time_estimate", 1000);
-	add_topic("rtl_status", 5000);
+	add_topic("rtl_status", 2000);
 	add_optional_topic("sensor_airflow", 100);
 	add_topic("sensor_combined");
 	add_optional_topic("sensor_correction");

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -103,7 +103,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("px4io_status");
 	add_topic("radio_status");
 	add_topic("rtl_time_estimate", 1000);
-	add_optional_topic("rtl_status", 5000);
+	add_topic("rtl_status", 5000);
 	add_optional_topic("sensor_airflow", 100);
 	add_topic("sensor_combined");
 	add_optional_topic("sensor_correction");


### PR DESCRIPTION
`rtl_status` seems to not get logged atm because it's not advertised at init. My proposal is to change `add_optional_topic()` to `add_topic()` for it, as we e.g. also add `rtl_time_estimate` as not optional. Otherwise we can advertise `_rtl_status_pub` in the RTL constructor.

I've also reduced the logging interval of `rtl_status` a bit.