### PR TITLE
Added device specifier to gps start line

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -95,7 +95,7 @@ if [ "$GPS" != "NONE" ]; then
 	    gps start -d /dev/ttyHS2
 	# On M0054 and M0104 the GPS driver runs on SLPI DSP
 	else
-	    qshell gps start
+	    qshell gps start -d 6
 	fi
 fi
 


### PR DESCRIPTION

### Solved Problem
The start script for VOXL2 board needed the device to be specified for the gps start command