### PR TITLE
gz-bridge: use correct prev_timestamp for dt calc 

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -719,8 +719,6 @@ void GZBridge::navSatCallback(const gz::msgs::NavSat &nav_sat)
 		updateClock(nav_sat.header().stamp().sec(), nav_sat.header().stamp().nsec());
 	}
 
-	_timestamp_prev = time_us;
-
 	// initialize gps position
 	if (!_pos_ref.isInitialized()) {
 		_pos_ref.initReference(nav_sat.latitude_deg(), nav_sat.longitude_deg(), hrt_absolute_time());


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/22839

with the addition of the navsat plugin in PR https://github.com/PX4/PX4-Autopilot/pull/22638, the callback would reassign the previous timestamp used in the calculations of the angular_velocity causing derivative type noise in the groundtruth measurements

![image](https://github.com/PX4/PX4-Autopilot/assets/24815968/43e6225f-7f23-44cd-afc3-18b855836e20)


Main https://github.com/PX4/PX4-Autopilot/tree/416b6a35a478482fe021b9261e15911338598d09
![image](https://github.com/PX4/PX4-Autopilot/assets/24815968/107e10fe-f6eb-4a27-b291-23996d2e4416)


