### PR TITLE
Vuepress removal /changes for vitepress

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,10 +171,8 @@ pipeline {
               sh('cp airframes.md PX4-user_guide/en/airframes/airframe_reference.md')
               sh('cp parameters.md PX4-user_guide/en/advanced_config/parameter_reference.md')
               sh('cp -R modules/*.md PX4-user_guide/en/modules/')
-              sh('cp -R graph_*.json PX4-user_guide/.vuepress/public/en/middleware/') // vuepress
               sh('cp -R graph_*.json PX4-user_guide/public/middleware/')  // vitepress
               sh('cp -R msg_docs/*.md PX4-user_guide/en/msg_docs/')
-              sh('cp -R failsafe_sim/* PX4-user_guide/.vuepress/public/en/config/failsafe') // vuepress
               sh('cp -R failsafe_sim/* PX4-user_guide/public/config/failsafe')  // vitepress
               sh('cd PX4-user_guide; git status; git add .; git commit -a -m "Update PX4 Firmware metadata `date`" || true')
               sh('cd PX4-user_guide; git push origin main || true')

--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -81,13 +81,13 @@ if __name__ == "__main__":
         with open(output_file, 'w') as content_file:
             content_file.write(markdown_output)
 
-        readme_markdown_file_link='- [%s](%s.md)' % (msg_name,msg_name)
+        index_markdown_file_link='- [%s](%s.md)' % (msg_name,msg_name)
         if summary_description:
-            readme_markdown_file_link+=" — %s" % summary_description
-        filelist_in_markdown+=readme_markdown_file_link+"\n"
+            index_markdown_file_link+=" — %s" % summary_description
+        filelist_in_markdown+=index_markdown_file_link+"\n"
 
-    # Write out the README.md file
-    readme_text="""# uORB Message Reference
+    # Write out the index.md file
+    index_text="""# uORB Message Reference
 
 :::note
 This list is [auto-generated](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/msg/generate_msg_docs.py) from the source code.
@@ -98,6 +98,6 @@ Graphs showing how these are used [can be found here](../middleware/uorb_graph.m
 
 %s
     """ % (filelist_in_markdown)
-    readme_file = os.path.join(output_dir, 'README.md')
-    with open(readme_file, 'w') as content_file:
-            content_file.write(readme_text)
+    index_file = os.path.join(output_dir, 'index.md')
+    with open(index_file, 'w') as content_file:
+            content_file.write(index_text)


### PR DESCRIPTION
Vitepress is now in, so this is changes to remove changes needed only by vuepress, or to better suit vitepress.

(copying files to vuepress that are no longer needed + outputing an index.md rather than readme.md since vitepress doesn't auto convert the readme anymore.