### PR TITLE
gps: add flexible GNSS receiver logging for Septentrio receivers

### DIFF
--- a/src/drivers/gnss/Kconfig
+++ b/src/drivers/gnss/Kconfig
@@ -1,0 +1,1 @@
+rsource "*/Kconfig"

--- a/src/drivers/gnss/septentrio/CMakeLists.txt
+++ b/src/drivers/gnss/septentrio/CMakeLists.txt
@@ -1,0 +1,45 @@
+############################################################################
+#
+#   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE driver__septentrio
+	MAIN septentrio
+	COMPILE_FLAGS
+		-Wno-stringop-overflow # due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91707
+	SRCS
+		septentrio.cpp
+		util.cpp
+		rtcm.cpp
+	MODULE_CONFIG
+		module.yaml
+	)

--- a/src/drivers/gnss/septentrio/Kconfig
+++ b/src/drivers/gnss/septentrio/Kconfig
@@ -1,0 +1,5 @@
+menuconfig DRIVERS_GNSS_SEPTENTRIO
+	bool "Septentrio GNSS receivers"
+	default n
+	---help---
+		Enable support for Septentrio receivers

--- a/src/drivers/gnss/septentrio/module.yaml
+++ b/src/drivers/gnss/septentrio/module.yaml
@@ -1,0 +1,75 @@
+module_name: Septentrio
+
+serial_config:
+    - command: septentrio start -d ${SERIAL_DEV}
+      port_config_param:
+        name: SEP_PORT_CONFIG
+        group: Septentrio GNSS Receiver
+        default: GPS1
+      label: GPS Port
+
+parameters:
+  - group: Septentrio GNSS Receiver
+    definitions:
+      SEP_YAW_OFFS:
+        description:
+          short: Heading/Yaw offset for dual antenna GPS
+          long: |
+            Heading offset angle for dual antenna GPS setups that support heading estimation.
+
+            Set this to 0 if the antennas are parallel to the forward-facing direction
+            of the vehicle and the rover antenna is in front.
+
+            The offset angle increases clockwise.
+
+            Set this to 90 if the rover antenna is placed on the
+            right side of the vehicle and the moving base antenna is on the left side.
+        type: float
+        decimal: 3
+        default: 0
+        min: 0
+        max: 360
+        unit: deg
+        reboot_required: true
+      SEP_SAT_INFO:
+        description:
+          short: Enable sat info
+          long: |
+            Enable publication of satellite info (ORB_ID(satellite_info)) if possible.
+        type: boolean
+        default: 0
+        reboot_required: true
+      SEP_PITCH_OFFS:
+        description:
+          short: Pitch offset for dual antenna GPS
+          long: |
+            Vertical offsets can be compensated for by adjusting the Pitch offset.
+
+            Note that this can be interpreted as the "roll" angle in case the antennas are aligned along the perpendicular axis.
+            This occurs in situations where the two antenna ARPs may not be exactly at the same height in the vehicle reference frame.
+            Since pitch is defined as the right-handed rotation about the vehicle Y axis,
+            a situation where the main antenna is mounted lower than the aux antenna (assuming the default antenna setup) will result in a positive pitch.
+        type: float
+        decimal: 3
+        default: 0
+        min: -90
+        max: 90
+        unit: deg
+        reboot_required: true
+      SEP_DUMP_COMM:
+        description:
+          short: Log GPS communication data
+          long: |
+            If this is set to 1, all GPS communication data will be published via uORB,
+            and written to the log file as gps_dump message.
+
+            If this is set to 2, the main GPS is configured to output RTCM data,
+            which is then logged as gps_dump and can be used for PPK.
+        type: enum
+        default: 0
+        min: 0
+        max: 2
+        values:
+          0: Disable
+          1: Full communication
+          2: RTCM output (PPK)

--- a/src/drivers/gnss/septentrio/module.yaml
+++ b/src/drivers/gnss/septentrio/module.yaml
@@ -73,3 +73,38 @@ parameters:
           0: Disable
           1: Full communication
           2: RTCM output (PPK)
+      SEP_LOG_HZ:
+        description:
+          short: Logging frequency for the receiver
+          long: |
+            Select the frequency at which the connected receiver should log data.
+        type: float
+        default: 1
+        min: 0
+        max: 20
+        unit: Hz
+        decimal: 1
+        reboot_required: true
+      SEP_LOG_LEVEL:
+        description:
+          short: Logging level for the receiver
+          long: |
+            Select the level of detail that needs to be logged by the receiver.
+        type: enum
+        default: 2
+        min: 0
+        max: 3
+        values:
+          0: Lite
+          1: Basic
+          2: Default
+          3: Full
+        reboot_required: true
+      SEP_LOG_FORCE:
+        description:
+          short: Whether to overwrite or add to existing logging
+          long: |
+            When the receiver is already set up to log data, this decides whether extra logged data should be added or overwrite existing data.
+        type: boolean
+        default: false
+        reboot_required: true

--- a/src/drivers/gnss/septentrio/rtcm.cpp
+++ b/src/drivers/gnss/septentrio/rtcm.cpp
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "rtcm.h"
+#include <cstring>
+
+RTCMParsing::RTCMParsing()
+{
+	reset();
+}
+
+RTCMParsing::~RTCMParsing()
+{
+	delete[] _buffer;
+}
+
+void RTCMParsing::reset()
+{
+	if (!_buffer) {
+		_buffer = new uint8_t[RTCM_INITIAL_BUFFER_LENGTH];
+		_buffer_len = RTCM_INITIAL_BUFFER_LENGTH;
+	}
+
+	_pos = 0;
+	_message_length = _buffer_len;
+}
+
+bool RTCMParsing::addByte(uint8_t b)
+{
+	if (!_buffer) {
+		return false;
+	}
+
+	_buffer[_pos++] = b;
+
+	if (_pos == 3) {
+		_message_length = (((uint16_t)_buffer[1] & 3) << 8) | (_buffer[2]);
+
+		if (_message_length + 6 > _buffer_len) {
+			uint16_t new_buffer_len = _message_length + 6;
+			uint8_t *new_buffer = new uint8_t[new_buffer_len];
+
+			if (!new_buffer) {
+				delete[](_buffer);
+				_buffer = nullptr;
+				return false;
+			}
+
+			memcpy(new_buffer, _buffer, 3);
+			delete[](_buffer);
+			_buffer = new_buffer;
+			_buffer_len = new_buffer_len;
+		}
+	}
+
+	return _message_length + 6 == _pos;
+}

--- a/src/drivers/gnss/septentrio/rtcm.h
+++ b/src/drivers/gnss/septentrio/rtcm.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+/* RTCM3 */
+#define RTCM3_PREAMBLE             0xD3
+#define RTCM_INITIAL_BUFFER_LENGTH 300  /**< initial maximum message length of an RTCM message */
+
+
+class RTCMParsing
+{
+public:
+	RTCMParsing();
+	~RTCMParsing();
+
+	/**
+	 * reset the parsing state
+	 */
+	void reset();
+
+	/**
+	 * add a byte to the message
+	 * @param b
+	 * @return true if message complete (use @message to get it)
+	 */
+	bool addByte(uint8_t b);
+
+	uint8_t *message() const { return _buffer; }
+	uint16_t messageLength() const { return _pos; }
+	uint16_t messageId() const { return (_buffer[3] << 4) | (_buffer[4] >> 4); }
+
+private:
+	uint8_t  *_buffer{nullptr};
+	uint16_t _buffer_len{};
+	uint16_t _pos{};            ///< next position in buffer
+	uint16_t _message_length{}; ///< message length without header & CRC (both 3 bytes)
+};

--- a/src/drivers/gnss/septentrio/sbf.h
+++ b/src/drivers/gnss/septentrio/sbf.h
@@ -1,0 +1,289 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+/**
+ * @file sbf.h
+ * @brief Septentrio binary format (SBF) protocol definitions.
+ */
+
+#define SBF_SYNC1           0x24     ///< Leading '$' of SBF blocks
+#define SBF_SYNC2           0x40     ///< Leading '@' of SBF blocks
+#define SBF_PVTGEODETIC_DNU 100000.0 ///< Do-Not-Use value for PVTGeodetic
+
+// Block IDs
+#define SBF_ID_DOP            4001
+#define SBF_ID_PVTGeodetic    4007
+#define SBF_ID_ChannelStatus  4013
+#define SBF_ID_VelCovGeodetic 5908
+#define SBF_ID_AttEuler       5938
+#define SBF_ID_AttCovEuler    5939
+
+#pragma pack(push, 1) // SBF protocol binary message and payload definitions
+
+typedef struct {
+	uint8_t mode_type: 4;       /**< Bit field indicating the PVT mode type, as follows:
+                                     0: No PVT available (the Error field indicates the cause of the absence of the PVT solution)
+                                     1: Stand-Alone PVT
+                                     2: Differential PVT
+                                     3: Fixed location
+                                     4: RTK with fixed ambiguities
+                                     5: RTK with float ambiguities
+                                     6: SBAS aided PVT
+                                     7: moving-base RTK with fixed ambiguities
+                                     8: moving-base RTK with float ambiguities
+                                     10:Precise Point Positioning (PPP) */
+	uint8_t mode_reserved: 2;   /**< Reserved */
+	uint8_t mode_base_fixed: 1; /**< Set if the user has entered the command setPVTMode,base,auto and the receiver
+                                     is still in the process of determining its fixed position. */
+	uint8_t mode_2d: 1;        /**< 2D/3D flag: set in 2D mode(height assumed constant and not computed). */
+	uint8_t error;             /**< PVT error code. The following values are defined:
+                                     0: No Error
+                                     1: Not enough measurements
+                                     2: Not enough ephemerides available
+                                     3: DOP too large (larger than 15)
+                                     4: Sum of squared residuals too large
+                                     5: No convergence
+                                     6: Not enough measurements after outlier rejection
+                                     7: Position output prohibited due to export laws
+                                     8: Not enough differential corrections available
+                                     9: Base station coordinates unavailable
+                                     10:Ambiguities not fixed and user requested to only output RTK-fixed positions
+                                     Note: if this field has a non-zero value, all following fields are set to their Do-Not-Use value. */
+	double latitude;          /**< Marker latitude, from -PI/2 to +PI/2, positive North of Equator */
+	double longitude;         /**< Marker longitude, from -PI to +PI, positive East of Greenwich */
+	double height;            /**< Marker ellipsoidal height (with respect to the ellipsoid specified by Datum) */
+	float undulation;        /**< Geoid undulation computed from the global geoid model defined in
+                                     the document 'Technical Characteristics of the NAVSTAR GPS, NATO, June 1991' */
+	float vn;                /**< Velocity in the North direction */
+	float ve;                /**< Velocity in the East direction */
+	float vu;                /**< Velocity in the Up direction */
+	float cog;               /**< Course over ground: this is defined as the angle of the vehicle with respect
+                                     to the local level North, ranging from 0 to 360, and increasing towards east.
+                                     Set to the do-not-use value when the speed is lower than 0.1m/s. */
+	double rx_clk_bias;       /**< Receiver clock bias relative to system time reported in the Time System field.
+                                     To transfer the receiver time to the system time, use: tGPS/GST=trx-RxClkBias */
+	float RxClkDrift;        /**< Receiver clock drift relative to system time (relative frequency error) */
+	uint8_t time_system;       /**< Time system of which the offset is provided in this sub-block:
+                                     0:GPStime
+                                     1:Galileotime
+                                     3:GLONASStime */
+	uint8_t datum;             /**< This field defines in which datum the coordinates are expressed:
+                                     0: WGS84/ITRS
+                                     19: Datum equal to that used by the DGNSS/RTK basestation
+                                     30: ETRS89(ETRF2000 realization)
+                                     31: NAD83(2011), North American Datum(2011)
+                                     32: NAD83(PA11), North American Datum, Pacificplate (2011)
+                                     33: NAD83(MA11), North American Datum, Marianas plate(2011)
+                                     34: GDA94(2010), Geocentric Datum of Australia (2010)
+                                     250:First user-defined datum
+                                     251:Second user-defined datum */
+	uint8_t nr_sv;             /**< Total number of satellites used in the PVT computation. */
+	uint8_t wa_corr_info;      /**< Bit field providing information about which wide area corrections have been applied:
+                                     Bit 0: set if orbit and satellite clock correction information is used
+                                     Bit 1: set if range correction information is used
+                                     Bit 2: set if ionospheric information is used
+                                     Bit 3: set if orbit accuracy information is used(UERE/SISA)
+                                     Bit 4: set if DO229 Precision Approach mode is active
+                                     Bits 5-7: Reserved */
+	uint16_t reference_id;      /**< In case of DGPS or RTK operation, this field is to be interpreted as the base station identifier.
+                                     In SBAS operation, this field is to be interpreted as the PRN of the geostationary satellite
+                                     used (from 120 to 158). If multiple base stations or multiple geostationary satellites are used
+                                     the value is set to 65534.*/
+	uint16_t mean_corr_age;     /**< In case of DGPS or RTK, this field is the mean age of the differential corrections.
+                                     In case of SBAS operation, this field is the mean age of the 'fast corrections'
+                                     provided by the SBAS satellites */
+	uint32_t signal_info;       /**< Bit field indicating the type of GNSS signals having been used in the PVT computations.
+                                     If a bit i is set, the signal type having index i has been used. */
+	uint8_t alert_flag;         /**< Bit field indicating integrity related information */
+
+	// Revision 1
+	uint8_t nr_bases;
+	uint16_t ppp_info;
+	// Revision 2
+	uint16_t latency;
+	uint16_t h_accuracy;
+	uint16_t v_accuracy;
+} sbf_payload_pvt_geodetic_t;
+
+typedef struct {
+	uint8_t mode_type: 4;       /**< Bit field indicating the PVT mode type, as follows:
+                                     0: No PVT available (the Error field indicates the cause of the absence of the PVT solution)
+                                     1: Stand-Alone PVT
+                                     2: Differential PVT
+                                     3: Fixed location
+                                     4: RTK with fixed ambiguities
+                                     5: RTK with float ambiguities
+                                     6: SBAS aided PVT
+                                     7: moving-base RTK with fixed ambiguities
+                                     8: moving-base RTK with float ambiguities
+                                     10:Precise Point Positioning (PPP) */
+	uint8_t mode_reserved: 2;  /**< Reserved */
+	uint8_t mode_base_fixed: 1;/**< Set if the user has entered the command setPVTMode,base,auto and the receiver
+                                     is still in the process of determining its fixed position. */
+	uint8_t mode_2d: 1;        /**< 2D/3D flag: set in 2D mode(height assumed constant and not computed). */
+	uint8_t error;             /**< PVT error code. The following values are defined:
+                                     0: No Error
+                                     1: Not enough measurements
+                                     2: Not enough ephemerides available
+                                     3: DOP too large (larger than 15)
+                                     4: Sum of squared residuals too large
+                                     5: No convergence
+                                     6: Not enough measurements after outlier rejection
+                                     7: Position output prohibited due to export laws
+                                     8: Not enough differential corrections available
+                                     9: Base station coordinates unavailable
+                                     10:Ambiguities not fixed and user requested to only output RTK-fixed positions
+                                     Note: if this field has a non-zero value, all following fields are set to their Do-Not-Use value. */
+	float cov_vn_vn;            /**< Variance of the north-velocity estimate */
+	float cov_ve_ve;            /**< Variance of the east-velocity estimate */
+	float cov_vu_vu;            /**< Variance of the up - velocity estimate */
+	float cov_dt_dt;            /**< Variance of the clock drift estimate */
+	float cov_vn_ve;            /**< Covariance between the north - and east - velocity estimates */
+	float cov_vn_vu;            /**< Covariance between the north - and up - velocity estimates */
+	float cov_vn_dt;            /**< Covariance between the north - velocity and clock drift estimates */
+	float cov_ve_vu;            /**< Covariance between the east - and up - velocity estimates */
+	float cov_ve_dt;            /**< Covariance between the east - velocity and clock drift estimates */
+	float cov_vu_dt;            /**< Covariance between the up - velocity and clock drift estimates */
+} sbf_payload_vel_cov_geodetic_t;
+
+typedef struct {
+	uint8_t nr_sv;              /**< Total number of satellites used in the PVT computation. */
+	uint8_t reserved;
+	uint16_t pDOP;
+	uint16_t tDOP;
+	uint16_t hDOP;
+	uint16_t vDOP;
+	float hpl;                  /**< Horizontal Protection Level (see the DO229 standard). */
+	float vpl;                  /**< Vertical Protection Level (see the DO229 standard). */
+} sbf_payload_dop_t;
+
+typedef struct {
+	uint8_t antenna;
+	uint8_t reserved;
+	uint16_t tracking_status;
+	uint16_t pvt_status;
+	uint16_t pvt_info;
+} sbf_payload_channel_state_info_t;
+
+typedef struct {
+	uint8_t nr_sv;                  /**< The average over all antennas of the number of satellites currently included in the attitude calculations. */
+	uint8_t error_aux1: 2;          /**< Bits 0-1: Error code for Main-Aux1 baseline:
+                                            0: No error
+                                            1: Not enough measurements
+                                            2: Reserved
+                                            3: Reserved */
+	uint8_t error_aux2: 2;          /**< Bits 2-3: Error code for Main-Aux2 baseline, same definition as bit 0-1. */
+	uint8_t error_reserved: 3;      /**< Bits 4-6: Reserved */
+uint8_t error_not_requested:
+	1; /**< Bit 7: Set when GNSS-based attitude not requested by user. In that case, the other bits are all zero. */
+
+	uint16_t mode;                  /**< Attitude mode code:
+                                            0: No attitude
+                                            1: Heading, pitch (roll = 0), aux antenna positions obtained with float
+                                            ambiguities
+                                            2: Heading, pitch (roll = 0), aux antenna positions obtained with fixed
+                                            ambiguities
+                                            3: Heading, pitch, roll, aux antenna positions obtained with float ambiguities
+                                            4: Heading, pitch, roll, aux antenna positions obtained with fixed ambiguities */
+	uint16_t reserved;              /**< Reserved for future use, to be ignored by decoding software */
+
+	float heading;                  /**< Heading */
+	float pitch;                    /**< Pitch */
+	float roll;                     /**< Roll */
+	float pitch_dot;                /**< Rate of change of the pitch angle */
+	float roll_dot;                 /**< Rate of change of the roll angle */
+	float heading_dot;              /**< Rate of change of the heading angle */
+} sbf_payload_att_euler;
+
+typedef struct {
+	uint8_t reserved;               /**< Reserved for future use, to be ignored by decoding software */
+
+	uint8_t error_aux1: 2;          /**< Bits 0-1: Error code for Main-Aux1 baseline:
+                                            0: No error
+                                            1: Not enough measurements
+                                            2: Reserved
+                                            3: Reserved */
+	uint8_t error_aux2: 2;          /**< Bits 2-3: Error code for Main-Aux2 baseline, same definition as bit 0-1. */
+	uint8_t error_reserved: 3;      /**< Bits 4-6: Reserved */
+uint8_t error_not_requested:
+	1; /**< Bit 7: Set when GNSS-based attitude not requested by user. In that case, the other bits are all zero. */
+
+	float cov_headhead;             /**< Variance of the heading estimate */
+	float cov_pitchpitch;           /**< Variance of the pitch estimate */
+	float cov_rollroll;             /**< Variance of the roll estimate */
+	float cov_headpitch;            /**< Covariance between Euler angle estimates.
+                                         Future functionality. The values are currently set to their Do-Not-Use values. */
+	float cov_headroll;             /**< Covariance between Euler angle estimates.
+                                         Future functionality. The values are currently set to their Do-Not-Use values. */
+	float cov_pitchroll;            /**< Covariance between Euler angle estimates.
+                                         Future functionality. The values are currently set to their Do-Not-Use values. */
+} sbf_payload_att_cov_euler;
+
+// General message and payload buffer union
+
+typedef struct {
+	uint16_t sync;              /** The Sync field is a 2-byte array always set to 0x24, 0x40. The first byte of every SBF block has
+                                        hexadecimal value 24 (decimal 36, ASCII '$'). The second byte of every SBF block has hexadecimal
+                                        value 40 (decimal 64, ASCII '@'). */
+	uint16_t crc16;             /** The CRC field is the 16-bit CRC of all the bytes in an SBF block from and including the ID field
+                                        to the last byte of the block. The generator polynomial for this CRC is the so-called CRC-CCITT
+                                        polynomial: x 16 + x 12 + x 5 + x 0 . The CRC is computed in the forward direction using a seed of 0, no
+                                        reverse and no final XOR. */
+uint16_t msg_id:
+	13;                 /** The ID field is a 2-byte block ID, which uniquely identifies the block type and its contents */
+uint8_t msg_revision:
+	3;                  /** block revision number, starting from 0 at the initial block definition, and incrementing
+                                        each time backwards - compatible changes are performed to the block  */
+	uint16_t length;            /** The Length field is a 2-byte unsigned integer containing the size of the SBF block.
+                                        It is the total number of bytes in the SBF block including the header.
+                                        It is always a multiple of 4. */
+	uint32_t TOW;               /** Time-Of-Week: Time-tag, expressed in whole milliseconds from
+                                        the beginning of the current Galileo/GPSweek. */
+	uint16_t WNc;               /** The GPS week number associated with the TOW. WNc is a continuous
+                                        weekcount (hence the "c"). It is not affected by GPS week roll overs,
+                                        which occur every 1024 weeks. By definition of the Galileo system time,
+                                        WNc is also the Galileo week number + 1024. */
+	union {
+		sbf_payload_pvt_geodetic_t payload_pvt_geodetic;
+		sbf_payload_vel_cov_geodetic_t payload_vel_col_geodetic;
+		sbf_payload_dop_t payload_dop;
+		sbf_payload_att_euler payload_att_euler;
+		sbf_payload_att_cov_euler payload_att_cov_euler;
+	};
+
+	uint8_t padding[16];
+} sbf_buf_t;
+
+#pragma pack(pop) // End of SBF protocol binary message and payload definitions

--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -1,0 +1,1439 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file septentrio.cpp
+ *
+ * Septentrio GNSS receiver driver
+ *
+ * @author Matej Franceskin <Matej.Franceskin@gmail.com>
+ * @author <a href="https://github.com/SeppeG">Seppe Geuens</a>
+ * @author Thomas Frans
+*/
+
+#include "septentrio.h"
+
+#include <cmath>
+#include <ctime>
+#include <string.h>
+#include <termios.h>
+#include <drivers/drv_hrt.h>
+#include <mathlib/mathlib.h>
+#include <matrix/math.hpp>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/time.h>
+#include <uORB/topics/gps_inject_data.h>
+
+#include "util.h"
+
+using namespace time_literals;
+
+#ifndef GPS_READ_BUFFER_SIZE
+#define GPS_READ_BUFFER_SIZE 150 ///< Buffer size for `read()` call
+#endif
+
+// TODO: This functionality is not available on the Snapdragon yet.
+#ifdef __PX4_QURT
+#define NO_MKTIME
+#endif
+
+#define SBF_CONFIG_TIMEOUT      1000    ///< Timeout for waiting on ACK in ms
+#define SBF_PACKET_TIMEOUT      2       ///< If no data during this delay (in ms) assume that full update received
+#define DISABLE_MSG_INTERVAL    1000000 ///< Try to disable message with this interval (in us)
+#define MSG_SIZE                100     ///< Size of the message to be sent to the receiver
+#define TIMEOUT_5HZ             500     ///< Timeout time in mS, 1000 mS (1Hz) + 300 mS delta for error
+#define RATE_MEASUREMENT_PERIOD 5_s     ///< Rate at which bandwith measurements are taken
+#define RECEIVER_BAUD_RATE      115200  ///< The baudrate of the serial connection to the receiver
+// TODO: This number seems wrong. It's also not clear why an ULL is created and casted to UL (time_t).
+#define GPS_EPOCH_SECS ((time_t)1234567890ULL)
+
+// Trace macros (disable for production builds)
+#define SBF_TRACE_PARSER(...)   {/*PX4_INFO(__VA_ARGS__);*/} ///< decoding progress in parse_char()
+#define SBF_TRACE_RXMSG(...)    {/*PX4_INFO(__VA_ARGS__);*/} ///< Rx msgs in payload_rx_done()
+
+// Warning macros (disable to save memory)
+#define SBF_WARN(...)           {PX4_WARN(__VA_ARGS__);}
+#define SBF_DEBUG(...)          {/*PX4_WARN(__VA_ARGS__);*/}
+
+// Commands
+#define SBF_FORCE_INPUT "SSSSSSSSSS\n"  /**< Force input on the connected port */
+
+#define SBF_CONFIG_RESET_HOT "" \
+	SBF_FORCE_INPUT"ExeResetReceiver, soft, none\n"
+
+#define SBF_CONFIG_RESET_WARM "" \
+	SBF_FORCE_INPUT"ExeResetReceiver, soft, PVTData\n"
+
+#define SBF_CONFIG_RESET_COLD "" \
+	SBF_FORCE_INPUT"ExeResetReceiver, hard, SatData\n"
+
+#define SBF_CONFIG "setSBFOutput, Stream1, %s, PVTGeodetic+VelCovGeodetic+DOP+AttEuler+AttCovEuler, msec100\n" /**< Configure the correct blocks for GPS positioning and heading */
+
+#define SBF_CONFIG_BAUDRATE "setCOMSettings, %s, baud%d\n"
+
+#define SBF_CONFIG_RESET "setSBFOutput, Stream1, %s, none, off\n"
+
+#define SBF_CONFIG_RECEIVER_DYNAMICS "setReceiverDynamics, %s, UAV\n"
+
+#define SBF_CONFIG_ATTITUDE_OFFSET "setAttitudeOffset, %.3f, %.3f\n"
+
+#define SBF_TX_CFG_PRT_BAUDRATE 115200
+
+#define SBF_DATA_IO "setDataInOut, %s, Auto, SBF\n"
+
+#define SBF_CONFIG_RTCM_STATIC1 "" \
+	"setReceiverDynamics, Low, Static\n"
+
+#define SBF_CONFIG_RTCM_STATIC2 "" \
+	"setPVTMode, Static, , Geodetic1\n"
+
+#define SBF_CONFIG_RTCM_STATIC_COORDINATES "" \
+	"setStaticPosGeodetic, Geodetic1, %f, %f, %f\n"
+
+#define SBF_CONFIG_RTCM_STATIC_OFFSET "" \
+	"setAntennaOffset, Main, %f, %f, %f\n"
+
+static constexpr int SEP_SET_CLOCK_DRIFT_TIME_S{5}; ///< RTC drift time when time synchronization is needed (in seconds)
+
+SeptentrioGPS::SeptentrioGPS(const char *device_path) :
+	Device(MODULE_NAME)
+{
+	strncpy(_port, device_path, sizeof(_port) - 1);
+	// Enforce null termination.
+	_port[sizeof(_port) - 1] = '\0';
+
+	_report_gps_pos.heading = NAN;
+	_report_gps_pos.heading_offset = NAN;
+
+	int32_t enable_sat_info = 0;
+	param_get(param_find("SEP_SAT_INFO"), &enable_sat_info);
+
+	// Create satellite info data object if requested
+	if (enable_sat_info) {
+		_sat_info = new GPSSatelliteInfo();
+		_p_report_sat_info = &_sat_info->_data;
+		memset(_p_report_sat_info, 0, sizeof(*_p_report_sat_info));
+	}
+}
+
+SeptentrioGPS::~SeptentrioGPS()
+{
+	delete _dump_from_device;
+	delete _dump_to_device;
+	delete _rtcm_parsing;
+	delete _sat_info;
+}
+
+int SeptentrioGPS::print_status()
+{
+	PX4_INFO("status: %s, port: %s", _healthy ? "OK" : "NOT OK", _port);
+	PX4_INFO("sat info: %s", (_p_report_sat_info != nullptr) ? "enabled" : "disabled");
+	PX4_INFO("rate reading: \t\t%6i B/s", _rate_reading);
+
+	if (_report_gps_pos.timestamp != 0) {
+		PX4_INFO("rate position: \t\t%6.2f Hz", (double)get_position_update_rate());
+		PX4_INFO("rate velocity: \t\t%6.2f Hz", (double)get_velocity_update_rate());
+
+		PX4_INFO("rate publication:\t\t%6.2f Hz", (double)_rate);
+		PX4_INFO("rate RTCM injection:\t%6.2f Hz", (double)_rate_rtcm_injection);
+
+		print_message(ORB_ID(sensor_gps), _report_gps_pos);
+	}
+
+	return 0;
+}
+
+void SeptentrioGPS::run()
+{
+	uint64_t last_rate_measurement = hrt_absolute_time();
+	unsigned last_rate_count = 0;
+	param_t handle = param_find("SEP_YAW_OFFS");
+	float heading_offset = 0.f;
+
+	if (handle != PARAM_INVALID) {
+		param_get(handle, &heading_offset);
+		heading_offset = matrix::wrap_pi(math::radians(heading_offset));
+	}
+
+	if (initialize_communication_dump() == PX4_ERROR) {
+		SBF_WARN("GPS communication logging could not be initialized");
+	}
+
+	// Set up the communication, configure the receiver and start processing data until we have to exit.
+	while (!should_exit()) {
+		if (serial_open() != 0) {
+			continue;
+		}
+
+		decode_init();
+
+		// TODO: Not sure whether this is still correct when drivers are separate modules.
+		set_device_type(DRV_GPS_DEVTYPE_SBF);
+
+		if (_dump_communication_mode == SeptentrioDumpCommMode::RTCM) {
+			_output_mode = SeptentrioGPSOutputMode::GPSAndRTCM;
+
+		} else {
+			_output_mode = SeptentrioGPSOutputMode::GPS;
+		}
+
+		// If configuration is successful, start processing messages.
+		if (configure(heading_offset) == 0) {
+
+			// Reset report
+			memset(&_report_gps_pos, 0, sizeof(_report_gps_pos));
+			_report_gps_pos.heading = NAN;
+			_report_gps_pos.heading_offset = heading_offset;
+
+			// Read data from the receiver and publish it until an error occurs.
+			int helper_ret;
+			unsigned receive_timeout = TIMEOUT_5HZ;
+
+			while ((helper_ret = receive(receive_timeout)) > 0 && !should_exit()) {
+
+				if (helper_ret & 1) {
+					publish();
+
+					last_rate_count++;
+				}
+
+				if (_p_report_sat_info && (helper_ret & 2)) {
+					publish_satellite_info();
+				}
+
+				reset_if_scheduled();
+
+				// Measure update rate every 5 seconds
+				if (hrt_absolute_time() - last_rate_measurement > RATE_MEASUREMENT_PERIOD) {
+					float dt = (float)((hrt_absolute_time() - last_rate_measurement)) / 1000000.0f;
+					_rate = last_rate_count / dt;
+					_rate_rtcm_injection = _last_rate_rtcm_injection_count / dt;
+					_rate_reading = _num_bytes_read / dt;
+					last_rate_measurement = hrt_absolute_time();
+					last_rate_count = 0;
+					_last_rate_rtcm_injection_count = 0;
+					_num_bytes_read = 0;
+					store_update_rates();
+					reset_update_rates();
+				}
+
+				if (!_healthy) {
+					_healthy = true;
+				}
+			}
+
+			if (_healthy) {
+				_healthy = false;
+				_rate = 0.0f;
+				_rate_rtcm_injection = 0.0f;
+			}
+		}
+
+		serial_close();
+	}
+
+	PX4_INFO("exiting");
+}
+
+int SeptentrioGPS::task_spawn(int argc, char *argv[])
+{
+	static constexpr int TASK_STACK_SIZE = PX4_STACK_ADJUSTED(2040);
+
+	px4_task_t task_id = px4_task_spawn_cmd("septentrio",
+						SCHED_DEFAULT,
+						SCHED_PRIORITY_SLOW_DRIVER,
+						TASK_STACK_SIZE,
+						&run_trampoline,
+						(char *const *)argv);
+
+	if (task_id < 0) {
+		// `_task_id` of module that hasn't been started before or has been stopped should already be -1.
+		// This is just to make sure.
+		_task_id = -1;
+		return -errno;
+	}
+
+	_task_id = task_id;
+
+	return 0;
+}
+
+SeptentrioGPS *SeptentrioGPS::instantiate(int argc, char *argv[])
+{
+	const char *device_path = nullptr;
+	SeptentrioGPS *gps = nullptr;
+	bool error_flag = false;
+	int ch;
+	int myoptind = 1;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "d:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'd':
+			device_path = myoptarg;
+			break;
+
+		case '?':
+			error_flag = true;
+			break;
+
+		default:
+			PX4_WARN("unrecognized flag");
+			error_flag = true;
+			break;
+		}
+	}
+
+	if (error_flag) {
+		return nullptr;
+	}
+
+	if (device_path && (access(device_path, R_OK | W_OK) == 0)) {
+		gps = new SeptentrioGPS(device_path);
+
+	} else {
+		PX4_ERR("invalid device (-d) %s", device_path ? device_path : "");
+	}
+
+	return gps;
+}
+
+// Called from outside driver thread.
+// Return 0 on success, -1 otherwise.
+int SeptentrioGPS::custom_command(int argc, char *argv[])
+{
+	bool handled = false;
+	SeptentrioGPS *driver_instance;
+
+	if (!is_running()) {
+		PX4_INFO("not running");
+		return -1;
+	}
+
+	driver_instance = get_instance();
+
+	if (argc == 2 && !strcmp(argv[0], "reset")) {
+
+		if (!strcmp(argv[1], "hot")) {
+			handled = true;
+			driver_instance->schedule_reset(SeptentrioGPSResetType::Hot);
+
+		} else if (!strcmp(argv[1], "cold")) {
+			handled = true;
+			driver_instance->schedule_reset(SeptentrioGPSResetType::Cold);
+
+		} else if (!strcmp(argv[1], "warm")) {
+			handled = true;
+			driver_instance->schedule_reset(SeptentrioGPSResetType::Warm);
+		}
+	}
+
+	if (handled) {
+		PX4_INFO("Resetting GPS - %s", argv[1]);
+		return 0;
+	}
+
+	return (handled) ? 0 : print_usage("unknown command");
+}
+
+int SeptentrioGPS::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+GPS driver module that handles the communication with Septentrio devices and publishes the position via uORB.
+
+The module currently only supports a single GPS device.
+)DESCR_STR");
+	PRINT_MODULE_USAGE_NAME("septentrio", "driver");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyS3", "<file:dev>", "GPS device", true);
+
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+	PRINT_MODULE_USAGE_COMMAND_DESCR("reset", "Reset connected receiver");
+	PRINT_MODULE_USAGE_ARG("cold|warm|hot", "Specify reset type", false);
+
+	return 0;
+}
+
+int SeptentrioGPS::reset(SeptentrioGPSResetType type)
+{
+	bool res = false;
+
+	switch (type) {
+	case SeptentrioGPSResetType::Hot:
+		res = send_message_and_wait_for_ack(SBF_CONFIG_RESET_HOT, SBF_CONFIG_TIMEOUT);
+		break;
+
+	case SeptentrioGPSResetType::Warm:
+		res = send_message_and_wait_for_ack(SBF_CONFIG_RESET_WARM, SBF_CONFIG_TIMEOUT);
+		break;
+
+	case SeptentrioGPSResetType::Cold:
+		res = send_message_and_wait_for_ack(SBF_CONFIG_RESET_COLD, SBF_CONFIG_TIMEOUT);
+		break;
+
+	default:
+		break;
+	}
+
+	return !res;
+}
+
+float SeptentrioGPS::get_position_update_rate()
+{
+	return _rate_lat_lon;
+}
+
+float SeptentrioGPS::get_velocity_update_rate()
+{
+	return _rate_vel;
+}
+
+void SeptentrioGPS::schedule_reset(SeptentrioGPSResetType reset_type)
+{
+	_scheduled_reset.store((int)reset_type);
+}
+
+int SeptentrioGPS::configure(float heading_offset)
+{
+	_configured = false;
+
+	param_t handle = param_find("SEP_PITCH_OFFS");
+	float pitch_offset = 0.f;
+
+	if (handle != PARAM_INVALID) {
+		param_get(handle, &pitch_offset);
+	}
+
+	set_baudrate(RECEIVER_BAUD_RATE);
+
+	send_message(SBF_FORCE_INPUT);
+
+	// flush input and wait for at least 50 ms silence
+	decode_init();
+	receive(50);
+	decode_init();
+
+	char buf[GPS_READ_BUFFER_SIZE];
+	char com_port[5] {};
+
+	size_t offset = 1;
+	bool response_detected = false;
+	hrt_abstime time_started = hrt_absolute_time();
+	send_message("\n\r");
+
+	// Read buffer to get the COM port
+	do {
+		--offset; //overwrite the null-char
+		int ret = read(reinterpret_cast<uint8_t *>(buf) + offset, sizeof(buf) - offset - 1, SBF_CONFIG_TIMEOUT);
+
+		if (ret < 0) {
+			// something went wrong when polling or reading
+			SBF_WARN("sbf poll_or_read err");
+			return PX4_ERROR;
+
+		}
+
+		offset += ret;
+		buf[offset++] = '\0';
+
+
+		char *p = strstr(buf, ">");
+
+		if (p) { //check if the length of the com port == 4 and contains a > sign
+			for (int i = 0; i < 4; i++) {
+				com_port[i] = buf[i];
+			}
+
+			response_detected = true;
+		}
+
+		if (offset >= sizeof(buf)) {
+			offset = 1;
+		}
+
+	} while (time_started + 1000 * SBF_CONFIG_TIMEOUT > hrt_absolute_time() && !response_detected);
+
+	if (response_detected) {
+		PX4_INFO("Septentrio GNSS receiver COM port: %s", com_port);
+		response_detected = false; // for future use
+
+	} else {
+		SBF_WARN("No COM port detected")
+		return PX4_ERROR;
+	}
+
+	// Delete all sbf outputs on current COM port to remove clutter data
+	char msg[MSG_SIZE];
+	snprintf(msg, sizeof(msg), SBF_CONFIG_RESET, com_port);
+
+	if (!send_message_and_wait_for_ack(msg, SBF_CONFIG_TIMEOUT)) {
+		return PX4_ERROR; // connection and/or baudrate detection failed
+	}
+
+	// Set baut rate
+	snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, com_port, RECEIVER_BAUD_RATE);
+
+	if (!send_message_and_wait_for_ack(msg, SBF_CONFIG_TIMEOUT)) {
+		SBF_DEBUG("Connection and/or baudrate detection failed (SBF_CONFIG_BAUDRATE)");
+		return PX4_ERROR; // connection and/or baudrate detection failed
+	}
+
+	// Flush input and wait for at least 50 ms silence
+	decode_init();
+	receive(50);
+	decode_init();
+
+
+	// At this point we have correct baudrate on both ends
+	SBF_DEBUG("Correct baud rate on both ends");
+
+	// Define/inquire the type of data that the receiver should accept/send on a given connection descriptor
+	snprintf(msg, sizeof(msg), SBF_DATA_IO, com_port);
+
+	if (!send_message_and_wait_for_ack(msg, SBF_CONFIG_TIMEOUT)) {
+		return PX4_ERROR;
+	}
+
+	// Specify the offsets that the receiver applies to the computed attitude angles.
+	snprintf(msg, sizeof(msg), SBF_CONFIG_ATTITUDE_OFFSET, (double)(heading_offset * 180 / M_PI_F), (double)pitch_offset);
+
+	if (!send_message_and_wait_for_ack(msg, SBF_CONFIG_TIMEOUT)) {
+		return PX4_ERROR;
+	}
+
+	snprintf(msg, sizeof(msg), SBF_CONFIG_RECEIVER_DYNAMICS, "high");
+	send_message_and_wait_for_ack(msg, SBF_CONFIG_TIMEOUT);
+
+	decode_init();
+	receive(50);
+	decode_init();
+
+	// Output a set of SBF blocks on a given connection at a regular interval.
+	int i = 0;
+	snprintf(msg, sizeof(msg), SBF_CONFIG, com_port);
+
+	do {
+		++i;
+
+		if (!send_message_and_wait_for_ack(msg, SBF_CONFIG_TIMEOUT)) {
+			if (i >= 5) {
+				return PX4_ERROR; // connection and/or baudrate detection failed
+			}
+
+		} else {
+			response_detected = true;
+		}
+	} while (i < 5 && !response_detected);
+
+	_configured = true;
+
+	return PX4_OK;
+}
+
+int SeptentrioGPS::serial_open()
+{
+	if (_serial_fd < 0) {
+		_serial_fd = ::open(_port, O_RDWR | O_NOCTTY);
+
+		if (_serial_fd < 0) {
+			PX4_ERR("failed to open %s err: %d", _port, errno);
+			px4_sleep(1);
+			return PX4_ERROR;
+		}
+
+	}
+
+	return PX4_OK;
+}
+
+int SeptentrioGPS::serial_close()
+{
+	int result = PX4_OK;
+
+	if (_serial_fd >= 0) {
+		if (::close(_serial_fd) != 0) {
+			result = PX4_ERROR;
+		}
+		_serial_fd = -1;
+	}
+
+	return result;
+}
+
+int SeptentrioGPS::parse_char(const uint8_t byte)
+{
+	int ret = 0;
+
+	switch (_decode_state) {
+
+	// Expecting Sync1
+	case SBF_DECODE_SYNC1:
+		if (byte == SBF_SYNC1) { // Sync1 found --> expecting Sync2
+			SBF_TRACE_PARSER("A");
+			payload_rx_add(byte); // add a payload byte
+			_decode_state = SBF_DECODE_SYNC2;
+
+		} else if (byte == RTCM3_PREAMBLE && _rtcm_parsing) {
+			SBF_TRACE_PARSER("RTCM");
+			_decode_state = SBF_DECODE_RTCM3;
+			_rtcm_parsing->addByte(byte);
+		}
+
+		break;
+
+	// Expecting Sync2
+	case SBF_DECODE_SYNC2:
+		if (byte == SBF_SYNC2) { // Sync2 found --> expecting CRC
+			SBF_TRACE_PARSER("B");
+			payload_rx_add(byte); // add a payload byte
+			_decode_state = SBF_DECODE_PAYLOAD;
+
+		} else { // Sync1 not followed by Sync2: reset parser
+			decode_init();
+		}
+
+		break;
+
+	// Expecting payload
+	case SBF_DECODE_PAYLOAD: SBF_TRACE_PARSER(".");
+
+		ret = payload_rx_add(byte); // add a payload byte
+
+		if (ret < 0) {
+			// payload not handled, discard message
+			ret = 0;
+			decode_init();
+
+		} else if (ret > 0) {
+			ret = payload_rx_done(); // finish payload processing
+			decode_init();
+
+		} else {
+			// expecting more payload, stay in state SBF_DECODE_PAYLOAD
+			ret = 0;
+
+		}
+
+		break;
+
+	case SBF_DECODE_RTCM3:
+		if (_rtcm_parsing->addByte(byte)) {
+			SBF_DEBUG("got RTCM message with length %i", (int) _rtcm_parsing->messageLength());
+			got_rtcm_message(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decode_init();
+		}
+
+		break;
+
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+int SeptentrioGPS::payload_rx_add(const uint8_t byte)
+{
+	int ret = 0;
+	uint8_t *p_buf = reinterpret_cast<uint8_t *>(&_buf);
+
+	p_buf[_rx_payload_index++] = byte;
+
+	if ((_rx_payload_index > 7 && _rx_payload_index >= _buf.length) || _rx_payload_index >= sizeof(_buf)) {
+		ret = 1; // payload received completely
+	}
+
+	return ret;
+}
+
+int SeptentrioGPS::payload_rx_done()
+{
+	int ret = 0;
+
+	if (_buf.length <= 4 ||
+	    _buf.length > _rx_payload_index ||
+	    _buf.crc16 != sep_crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
+		return 0;
+	}
+
+	// Handle message
+	switch (_buf.msg_id) {
+	case SBF_ID_PVTGeodetic: SBF_TRACE_RXMSG("Rx PVTGeodetic");
+		_msg_status |= 1;
+
+		if (_buf.payload_pvt_geodetic.mode_type < 1) {
+			_report_gps_pos.fix_type = 1;
+
+		} else if (_buf.payload_pvt_geodetic.mode_type == 6) {
+			_report_gps_pos.fix_type = 4;
+
+		} else if (_buf.payload_pvt_geodetic.mode_type == 5 || _buf.payload_pvt_geodetic.mode_type == 8) {
+			_report_gps_pos.fix_type = 5;
+
+		} else if (_buf.payload_pvt_geodetic.mode_type == 4 || _buf.payload_pvt_geodetic.mode_type == 7) {
+			_report_gps_pos.fix_type = 6;
+
+		} else {
+			_report_gps_pos.fix_type = 3;
+		}
+
+		// Check fix and error code
+		_report_gps_pos.vel_ned_valid = _report_gps_pos.fix_type > 1 && _buf.payload_pvt_geodetic.error == 0;
+
+		// Check boundaries and invalidate GPS velocities
+		// We're not just checking for the do-not-use value (-2*10^10) but for any value beyond the specified max values
+		if (fabsf(_buf.payload_pvt_geodetic.vn) > 600.0f || fabsf(_buf.payload_pvt_geodetic.ve) > 600.0f ||
+		    fabsf(_buf.payload_pvt_geodetic.vu) > 600.0f) {
+			_report_gps_pos.vel_ned_valid = false;
+		}
+
+		// Check boundaries and invalidate position
+		// We're not just checking for the do-not-use value (-2*10^10) but for any value beyond the specified max values
+		if (fabs(_buf.payload_pvt_geodetic.latitude) > (double)(M_PI_F / 2.0f) ||
+		    fabs(_buf.payload_pvt_geodetic.longitude) > (double) M_PI_F ||
+		    fabs(_buf.payload_pvt_geodetic.height) > SBF_PVTGEODETIC_DNU ||
+		    fabsf(_buf.payload_pvt_geodetic.undulation) > (float) SBF_PVTGEODETIC_DNU) {
+			_report_gps_pos.fix_type = 0;
+		}
+
+		if (_buf.payload_pvt_geodetic.nr_sv < 255) {  // 255 = do not use value
+			_report_gps_pos.satellites_used = _buf.payload_pvt_geodetic.nr_sv;
+
+			if (_p_report_sat_info) {
+				// Only fill in the satellite count for now (we could use the ChannelStatus message for the
+				// other data, but it's really large: >800B)
+				_p_report_sat_info->timestamp = hrt_absolute_time();
+				_p_report_sat_info->count = _report_gps_pos.satellites_used;
+				ret = 2;
+			}
+
+		} else {
+			_report_gps_pos.satellites_used = 0;
+		}
+
+		_report_gps_pos.latitude_deg = _buf.payload_pvt_geodetic.latitude * M_RAD_TO_DEG;
+		_report_gps_pos.longitude_deg = _buf.payload_pvt_geodetic.longitude * M_RAD_TO_DEG;
+		_report_gps_pos.altitude_ellipsoid_m = _buf.payload_pvt_geodetic.height;
+		_report_gps_pos.altitude_msl_m = _buf.payload_pvt_geodetic.height - static_cast<double>
+						(_buf.payload_pvt_geodetic.undulation);
+
+		/* H and V accuracy are reported in 2DRMS, but based off the uBlox reporting we expect RMS.
+		 * Devide by 100 from cm to m and in addition divide by 2 to get RMS. */
+		_report_gps_pos.eph = static_cast<float>(_buf.payload_pvt_geodetic.h_accuracy) / 200.0f;
+		_report_gps_pos.epv = static_cast<float>(_buf.payload_pvt_geodetic.v_accuracy) / 200.0f;
+
+		_report_gps_pos.vel_n_m_s = static_cast<float>(_buf.payload_pvt_geodetic.vn);
+		_report_gps_pos.vel_e_m_s = static_cast<float>(_buf.payload_pvt_geodetic.ve);
+		_report_gps_pos.vel_d_m_s = -1.0f * static_cast<float>(_buf.payload_pvt_geodetic.vu);
+		_report_gps_pos.vel_m_s = sqrtf(_report_gps_pos.vel_n_m_s * _report_gps_pos.vel_n_m_s +
+					       _report_gps_pos.vel_e_m_s * _report_gps_pos.vel_e_m_s);
+
+		_report_gps_pos.cog_rad = static_cast<float>(_buf.payload_pvt_geodetic.cog) * M_DEG_TO_RAD_F;
+		_report_gps_pos.c_variance_rad = 1.0f * M_DEG_TO_RAD_F;
+
+		// _buf.payload_pvt_geodetic.cog is set to -2*10^10 for velocities below 0.1m/s
+		if (_buf.payload_pvt_geodetic.cog > 360.0f) {
+			_buf.payload_pvt_geodetic.cog = NAN;
+		}
+
+		_report_gps_pos.time_utc_usec = 0;
+#ifndef NO_MKTIME
+		struct tm timeinfo;
+		time_t epoch;
+
+		// Convert to unix timestamp
+		memset(&timeinfo, 0, sizeof(timeinfo));
+
+		timeinfo.tm_year = 1980 - 1900;
+		timeinfo.tm_mon = 0;
+		timeinfo.tm_mday = 6 + _buf.WNc * 7;
+		timeinfo.tm_hour = 0;
+		timeinfo.tm_min = 0;
+		timeinfo.tm_sec = _buf.TOW / 1000;
+
+		epoch = mktime(&timeinfo);
+
+		if (epoch > GPS_EPOCH_SECS) {
+			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
+			// and control its drift. Since we rely on the HRT for our monotonic
+			// clock, updating it from time to time is safe.
+
+			timespec ts;
+			memset(&ts, 0, sizeof(ts));
+			ts.tv_sec = epoch;
+			ts.tv_nsec = (_buf.TOW % 1000) * 1000 * 1000;
+			set_clock(ts);
+
+			_report_gps_pos.time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
+			_report_gps_pos.time_utc_usec += (_buf.TOW % 1000) * 1000;
+		}
+
+#endif
+		_report_gps_pos.timestamp = hrt_absolute_time();
+		_last_timestamp_time = _report_gps_pos.timestamp;
+		_rate_count_vel++;
+		_rate_count_lat_lon++;
+		// NOTE: Isn't this just `ret |= (_msg_status == 7)`?
+		ret |= (_msg_status == 7) ? 1 : 0;
+		break;
+
+	case SBF_ID_VelCovGeodetic: SBF_TRACE_RXMSG("Rx VelCovGeodetic");
+		_msg_status |= 2;
+		_report_gps_pos.s_variance_m_s = _buf.payload_vel_col_geodetic.cov_ve_ve;
+
+		if (_report_gps_pos.s_variance_m_s < _buf.payload_vel_col_geodetic.cov_vn_vn) {
+			_report_gps_pos.s_variance_m_s = _buf.payload_vel_col_geodetic.cov_vn_vn;
+		}
+
+		if (_report_gps_pos.s_variance_m_s < _buf.payload_vel_col_geodetic.cov_vu_vu) {
+			_report_gps_pos.s_variance_m_s = _buf.payload_vel_col_geodetic.cov_vu_vu;
+		}
+
+		//SBF_DEBUG("VelCovGeodetic handled");
+		break;
+
+	case SBF_ID_DOP: SBF_TRACE_RXMSG("Rx DOP");
+		_msg_status |= 4;
+		_report_gps_pos.hdop = _buf.payload_dop.hDOP * 0.01f;
+		_report_gps_pos.vdop = _buf.payload_dop.vDOP * 0.01f;
+		//SBF_DEBUG("DOP handled");
+		break;
+
+	case SBF_ID_AttEuler: SBF_TRACE_RXMSG("Rx AttEuler");
+
+		if (!_buf.payload_att_euler.error_not_requested) {
+
+			int error_aux1 = _buf.payload_att_euler.error_aux1;
+			int error_aux2 = _buf.payload_att_euler.error_aux2;
+
+			// SBF_DEBUG("Mode: %u", _buf.payload_att_euler.mode)
+			if (error_aux1 == 0 && error_aux2 == 0) {
+				float heading = _buf.payload_att_euler.heading;
+				heading *= M_PI_F / 180.0f; // deg to rad, now in range [0, 2pi]
+
+
+				if (heading > M_PI_F) {
+					heading -= 2.f * M_PI_F; // final range is [-pi, pi]
+				}
+
+				_report_gps_pos.heading = heading;
+				// SBF_DEBUG("Heading: %.3f rad", (double) _report_gps_pos.heading)
+				//SBF_DEBUG("AttEuler handled");
+
+			} else if (error_aux1 != 0) {
+				//SBF_DEBUG("Error code for Main-Aux1 baseline: Not enough measurements");
+			} else if (error_aux2 != 0) {
+				//SBF_DEBUG("Error code for Main-Aux2 baseline: Not enough measurements");
+			}
+		} else {
+			//SBF_DEBUG("AttEuler: attitude not requested by user");
+		}
+
+
+		break;
+
+	case SBF_ID_AttCovEuler: SBF_TRACE_RXMSG("Rx AttCovEuler");
+
+		if (!_buf.payload_att_cov_euler.error_not_requested) {
+			int error_aux1 = _buf.payload_att_cov_euler.error_aux1;
+			int error_aux2 = _buf.payload_att_cov_euler.error_aux2;
+
+			if (error_aux1 == 0 && error_aux2 == 0) {
+				float heading_acc = _buf.payload_att_cov_euler.cov_headhead;
+				heading_acc *= M_PI_F / 180.0f; // deg to rad, now in range [0, 2pi]
+				_report_gps_pos.heading_accuracy = heading_acc;
+				// SBF_DEBUG("Heading-Accuracy: %.3f rad", (double) _report_gps_pos.heading_accuracy)
+				//SBF_DEBUG("AttCovEuler handled");
+
+			} else if (error_aux1 != 0) {
+				//SBF_DEBUG("Error code for Main-Aux1 baseline: %u: Not enough measurements", error_aux1);
+			} else if (error_aux2 != 0) {
+				//SBF_DEBUG("Error code for Main-Aux2 baseline: %u: Not enough measurements", error_aux2);
+			}
+		} else {
+			//SBF_DEBUG("AttCovEuler: attitude not requested by user");
+		}
+
+		break;
+
+	default:
+		break;
+	}
+
+	if (ret > 0) {
+		// NOTE: Isn't this always 0?
+		_report_gps_pos.timestamp_time_relative = static_cast<int32_t>(_last_timestamp_time - _report_gps_pos.timestamp);
+	}
+
+	if (ret == 1) {
+		_msg_status &= ~1;
+	}
+
+	return ret;
+}
+
+void SeptentrioGPS::decode_init()
+{
+	_decode_state = SBF_DECODE_SYNC1;
+	_rx_payload_index = 0;
+
+	if (_output_mode == SeptentrioGPSOutputMode::GPSAndRTCM) {
+		if (!_rtcm_parsing) {
+			_rtcm_parsing = new RTCMParsing();
+		}
+
+		if (_rtcm_parsing) {
+			_rtcm_parsing->reset();
+		}
+	}
+}
+
+bool SeptentrioGPS::send_message(const char *msg)
+{
+	SBF_DEBUG("Send MSG: %s", msg);
+	int length = strlen(msg);
+
+	return (write(reinterpret_cast<const uint8_t*>(msg), length) == length);
+}
+
+bool SeptentrioGPS::send_message_and_wait_for_ack(const char *msg, const int timeout)
+{
+	SBF_DEBUG("Send MSG: %s", msg);
+
+	int length = strlen(msg);
+
+	if (write(reinterpret_cast<const uint8_t*>(msg), length) != length) {
+		return false;
+	}
+
+	// Wait for acknowledge
+	// For all valid set -, get - and exe -commands, the first line of the reply is an exact copy
+	// of the command as entered by the user, preceded with "$R:"
+	char buf[GPS_READ_BUFFER_SIZE];
+	size_t offset = 1;
+	hrt_abstime time_started = hrt_absolute_time();
+
+	bool found_response = false;
+
+	do {
+		--offset; //overwrite the null-char
+		int ret = read(reinterpret_cast<uint8_t *>(buf) + offset, sizeof(buf) - offset - 1, timeout);
+
+		if (ret < 0) {
+			// something went wrong when polling or reading
+			SBF_WARN("sbf poll_or_read err");
+			return false;
+		}
+
+		offset += ret;
+		buf[offset++] = '\0';
+
+		if (!found_response && strstr(buf, "$R: ") != nullptr) {
+			//SBF_DEBUG("READ %d: %s", (int) offset, buf);
+			found_response = true;
+		}
+
+		if (offset >= sizeof(buf)) {
+			offset = 1;
+		}
+
+	} while (time_started + 1000 * timeout > hrt_absolute_time());
+
+	SBF_DEBUG("response: %u", found_response)
+	return found_response;
+}
+
+int SeptentrioGPS::receive(unsigned timeout)
+{
+	int ret = 0;
+	int handled = 0;
+	uint8_t buf[GPS_READ_BUFFER_SIZE];
+
+	if (!_configured) {
+		px4_usleep(timeout * 1000);
+		return 0;
+	}
+
+	// timeout additional to poll
+	hrt_abstime time_started = hrt_absolute_time();
+
+	while (true) {
+		// Wait for only SBF_PACKET_TIMEOUT if something already received.
+		ret = read(buf, sizeof(buf), handled ? SBF_PACKET_TIMEOUT : timeout);
+
+		if (ret < 0) {
+			// Something went wrong when polling or reading.
+			SBF_WARN("ubx poll_or_read err");
+			return -1;
+
+		} else {
+			SBF_DEBUG("Read %d bytes (receive)", ret);
+
+			// Pass received bytes to the packet decoder.
+			for (int i = 0; i < ret; i++) {
+				handled |= parse_char(buf[i]);
+				SBF_DEBUG("parsed %d: 0x%x", i, buf[i]);
+			}
+		}
+
+		if (handled > 0) {
+			return handled;
+		}
+
+		// abort after timeout if no useful packets received
+		if (time_started + timeout * 1000 < hrt_absolute_time()) {
+			SBF_DEBUG("timed out, returning");
+			return -1;
+		}
+	}
+}
+
+int SeptentrioGPS::read(uint8_t *buf, size_t buf_length, int timeout)
+{
+	int num_read = poll_or_read(buf, buf_length, timeout);
+
+	if (num_read > 0) {
+		dump_gps_data(buf, (size_t)num_read, SeptentrioDumpCommMode::Full, false);
+	}
+
+	return num_read;
+}
+
+int SeptentrioGPS::poll_or_read(uint8_t *buf, size_t buf_length, int timeout)
+{
+	handle_inject_data_topic();
+
+#if !defined(__PX4_QURT)
+
+	// For non QURT, use the usual polling.
+
+	// Poll only for the serial data. In the same thread we also need to handle orb messages,
+	// so ideally we would poll on both, the serial fd and orb subscription. Unfortunately the
+	// two pollings use different underlying mechanisms (at least under posix), which makes this
+	// impossible. Instead we limit the maximum polling interval and regularly check for new orb
+	// messages.
+	//FIXME: add a unified poll() API
+	const int max_timeout = 50;
+
+	pollfd fds[1];
+	fds[0].fd = _serial_fd;
+	fds[0].events = POLLIN;
+
+	int ret = poll(fds, sizeof(fds) / sizeof(fds[0]), math::min(max_timeout, timeout));
+
+	if (ret > 0) {
+		/* if we have new data from GPS, go handle it */
+		if (fds[0].revents & POLLIN) {
+			/*
+			 * We are here because poll says there is some data, so this
+			 * won't block even on a blocking device. But don't read immediately
+			 * by 1-2 bytes, wait for some more data to save expensive read() calls.
+			 * If we have all requested data available, read it without waiting.
+			 * If more bytes are available, we'll go back to poll() again.
+			 */
+			const unsigned character_count = 32; // minimum bytes that we want to read
+			const unsigned sleeptime = character_count * 1000000 / (RECEIVER_BAUD_RATE / 10);
+
+#ifdef __PX4_NUTTX
+			int err = 0;
+			int bytes_available = 0;
+			err = ::ioctl(_serial_fd, FIONREAD, (unsigned long)&bytes_available);
+
+			if (err != 0 || bytes_available < (int)character_count) {
+				px4_usleep(sleeptime);
+			}
+
+#else
+			px4_usleep(sleeptime);
+#endif // __PX4_NUTTX
+
+			ret = ::read(_serial_fd, buf, buf_length);
+
+			if (ret > 0) {
+				_num_bytes_read += ret;
+			}
+
+		} else {
+			ret = -1;
+		}
+	}
+
+	return ret;
+
+#else
+	// For QURT, just use read for now, since this doesn't block, we need to slow it down just a bit.
+	px4_usleep(10000);
+	return ::read(_serial_fd, buf, buf_length);
+#endif // !defined(__PX4_QURT)
+}
+
+int SeptentrioGPS::write(const uint8_t* buf, size_t buf_length)
+{
+	dump_gps_data(buf, buf_length, SeptentrioDumpCommMode::Full, true);
+
+	return ::write(_serial_fd, buf, buf_length);
+}
+
+int SeptentrioGPS::initialize_communication_dump()
+{
+	param_t handle = param_find("SEP_DUMP_COMM");
+	int32_t param_dump_comm;
+
+	if (handle == PARAM_INVALID || param_get(handle, &param_dump_comm) != 0) {
+		return PX4_ERROR;
+	}
+
+	// Check whether dumping is disabled.
+	if (param_dump_comm < 1 || param_dump_comm > 2) {
+		return PX4_ERROR;
+	}
+
+	_dump_from_device = new gps_dump_s();
+	_dump_to_device = new gps_dump_s();
+
+	if (!_dump_from_device || !_dump_to_device) {
+		PX4_ERR("failed to allocated dump data");
+		return PX4_ERROR;
+	}
+
+	memset(_dump_to_device, 0, sizeof(gps_dump_s));
+	memset(_dump_from_device, 0, sizeof(gps_dump_s));
+
+	// Make sure to use a large enough queue size, so that we don't lose
+	// messages. You may also want to increase the logger rate for that.
+	_dump_communication_pub.advertise();
+
+	_dump_communication_mode = (SeptentrioDumpCommMode)param_dump_comm;
+
+	return PX4_OK;
+}
+
+void SeptentrioGPS::reset_if_scheduled()
+{
+	SeptentrioGPSResetType reset_type = (SeptentrioGPSResetType)_scheduled_reset.load();
+
+	if (reset_type != SeptentrioGPSResetType::None) {
+		_scheduled_reset.store((int)SeptentrioGPSResetType::None);
+		int res = reset(reset_type);
+
+		if (res == -1) {
+			PX4_INFO("Reset is not supported on this device.");
+		} else if (res > 0) {
+			PX4_INFO("Reset failed.");
+		} else {
+			PX4_INFO("Reset succeeded.");
+		}
+	}
+}
+
+int SeptentrioGPS::set_baudrate(unsigned baud)
+{
+	/* process baud rate */
+	int speed = RECEIVER_BAUD_RATE;
+
+	struct termios uart_config;
+
+	int termios_state;
+
+	/* fill the struct for the new configuration */
+	tcgetattr(_serial_fd, &uart_config);
+
+	/* properly configure the terminal (see also https://en.wikibooks.org/wiki/Serial_Programming/termios ) */
+
+	//
+	// Input flags - Turn off input processing
+	//
+	// convert break to null byte, no CR to NL translation,
+	// no NL to CR translation, don't mark parity errors or breaks
+	// no input parity check, don't strip high bit off,
+	// no XON/XOFF software flow control
+	//
+	uart_config.c_iflag &= ~(IGNBRK | BRKINT | ICRNL |
+				 INLCR | PARMRK | INPCK | ISTRIP | IXON);
+	//
+	// Output flags - Turn off output processing
+	//
+	// no CR to NL translation, no NL to CR-NL translation,
+	// no NL to CR translation, no column 0 CR suppression,
+	// no Ctrl-D suppression, no fill characters, no case mapping,
+	// no local output processing
+	//
+	// config.c_oflag &= ~(OCRNL | ONLCR | ONLRET |
+	//                     ONOCR | ONOEOT| OFILL | OLCUC | OPOST);
+	uart_config.c_oflag = 0;
+
+	//
+	// No line processing
+	//
+	// echo off, echo newline off, canonical mode off,
+	// extended input processing off, signal chars off
+	//
+	uart_config.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
+
+	/* no parity, one stop bit, disable flow control */
+	uart_config.c_cflag &= ~(CSTOPB | PARENB | CRTSCTS);
+
+	/* set baud rate */
+	if ((termios_state = cfsetispeed(&uart_config, speed)) < 0) {
+		PX4_ERR("ERR: %d (cfsetispeed)", termios_state);
+		return PX4_ERROR;
+	}
+
+	if ((termios_state = cfsetospeed(&uart_config, speed)) < 0) {
+		PX4_ERR("ERR: %d (cfsetospeed)", termios_state);
+		return PX4_ERROR;
+	}
+
+	if ((termios_state = tcsetattr(_serial_fd, TCSANOW, &uart_config)) < 0) {
+		PX4_ERR("ERR: %d (tcsetattr)", termios_state);
+		return PX4_ERROR;
+	}
+
+	return PX4_OK;
+}
+
+void SeptentrioGPS::handle_inject_data_topic()
+{
+	// We don't want to call copy again further down if we have already done a copy in the selection process.
+	bool already_copied = false;
+	gps_inject_data_s msg;
+
+	// If there has not been a valid RTCM message for a while, try to switch to a different RTCM link
+	if ((hrt_absolute_time() - _last_rtcm_injection_time) > 5_s) {
+
+		for (int instance = 0; instance < _orb_inject_data_sub.size(); instance++) {
+			const bool exists = _orb_inject_data_sub[instance].advertised();
+
+			if (exists) {
+				if (_orb_inject_data_sub[instance].copy(&msg)) {
+					if ((hrt_absolute_time() - msg.timestamp) < 5_s) {
+						// Remember that we already did a copy on this instance.
+						already_copied = true;
+						_selected_rtcm_instance = instance;
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	bool updated = already_copied;
+
+	// Limit maximum number of GPS injections to 8 since usually
+	// GPS injections should consist of 1-4 packets (GPS, Glonass, BeiDou, Galileo).
+	// Looking at 8 packets thus guarantees, that at least a full injection
+	// data set is evaluated.
+	// Moving Base requires a higher rate, so we allow up to 8 packets.
+	const size_t max_num_injections = gps_inject_data_s::ORB_QUEUE_LENGTH;
+	size_t num_injections = 0;
+
+	do {
+		if (updated) {
+			num_injections++;
+
+			// Prevent injection of data from self
+			if (msg.device_id != get_device_id()) {
+				/* Write the message to the gps device. Note that the message could be fragmented.
+				* But as we don't write anywhere else to the device during operation, we don't
+				* need to assemble the message first.
+				*/
+				inject_data(msg.data, msg.len);
+
+				++_last_rate_rtcm_injection_count;
+				_last_rtcm_injection_time = hrt_absolute_time();
+			}
+		}
+
+		updated = _orb_inject_data_sub[_selected_rtcm_instance].update(&msg);
+
+	} while (updated && num_injections < max_num_injections);
+}
+
+bool SeptentrioGPS::inject_data(uint8_t *data, size_t len)
+{
+	dump_gps_data(data, len, SeptentrioDumpCommMode::Full, true);
+
+	size_t written = ::write(_serial_fd, data, len);
+	::fsync(_serial_fd);
+	return written == len;
+}
+
+void SeptentrioGPS::publish()
+{
+	_report_gps_pos.device_id = get_device_id();
+	_report_gps_pos.selected_rtcm_instance = _selected_rtcm_instance;
+	_report_gps_pos.rtcm_injection_rate = _rate_rtcm_injection;
+
+	_report_gps_pos_pub.publish(_report_gps_pos);
+
+	// Heading/yaw data can be updated at a lower rate than the other navigation data.
+	// The uORB message definition requires this data to be set to a NAN if no new valid data is available.
+	_report_gps_pos.heading = NAN;
+
+	if (_report_gps_pos.spoofing_state != _spoofing_state) {
+
+		if (_report_gps_pos.spoofing_state > sensor_gps_s::SPOOFING_STATE_NONE) {
+			PX4_WARN("GPS spoofing detected! (state: %d)", _report_gps_pos.spoofing_state);
+		}
+
+		_spoofing_state = _report_gps_pos.spoofing_state;
+	}
+
+	if (_report_gps_pos.jamming_state != _jamming_state) {
+
+		if (_report_gps_pos.jamming_state > sensor_gps_s::JAMMING_STATE_WARNING) {
+			PX4_WARN("GPS jamming detected! (state: %d) (indicator: %d)", _report_gps_pos.jamming_state,
+					(uint8_t)_report_gps_pos.jamming_indicator);
+		}
+
+		_jamming_state = _report_gps_pos.jamming_state;
+	}
+}
+
+void SeptentrioGPS::publish_satellite_info()
+{
+	if (_p_report_sat_info != nullptr) {
+		_report_sat_info_pub.publish(*_p_report_sat_info);
+	}
+}
+
+void SeptentrioGPS::publish_rtcm_corrections(uint8_t *data, size_t len)
+{
+	gps_inject_data_s gps_inject_data{};
+
+	gps_inject_data.timestamp = hrt_absolute_time();
+	gps_inject_data.device_id = get_device_id();
+
+	size_t capacity = (sizeof(gps_inject_data.data) / sizeof(gps_inject_data.data[0]));
+
+	if (len > capacity) {
+		gps_inject_data.flags = 1; //LSB: 1=fragmented
+
+	} else {
+		gps_inject_data.flags = 0;
+	}
+
+	size_t written = 0;
+
+	while (written < len) {
+
+		gps_inject_data.len = len - written;
+
+		if (gps_inject_data.len > capacity) {
+			gps_inject_data.len = capacity;
+		}
+
+		memcpy(gps_inject_data.data, &data[written], gps_inject_data.len);
+
+		_gps_inject_data_pub.publish(gps_inject_data);
+
+		written = written + gps_inject_data.len;
+	}
+}
+
+void SeptentrioGPS::dump_gps_data(const uint8_t *data, size_t len, SeptentrioDumpCommMode mode, bool msg_to_gps_device)
+{
+	gps_dump_s *dump_data  = msg_to_gps_device ? _dump_to_device : _dump_from_device;
+
+	if (_dump_communication_mode != mode || !dump_data) {
+		return;
+	}
+
+	dump_data->instance = 0;
+
+	while (len > 0) {
+		size_t write_len = len;
+
+		if (write_len > sizeof(dump_data->data) - dump_data->len) {
+			write_len = sizeof(dump_data->data) - dump_data->len;
+		}
+
+		memcpy(dump_data->data + dump_data->len, data, write_len);
+		data += write_len;
+		dump_data->len += write_len;
+		len -= write_len;
+
+		if (dump_data->len >= sizeof(dump_data->data)) {
+			if (msg_to_gps_device) {
+				dump_data->len |= 1 << 7;
+			}
+
+			dump_data->timestamp = hrt_absolute_time();
+			_dump_communication_pub.publish(*dump_data);
+			dump_data->len = 0;
+		}
+	}
+}
+
+void SeptentrioGPS::got_rtcm_message(uint8_t *data, size_t len)
+{
+	publish_rtcm_corrections(data, len);
+	dump_gps_data(data, len, SeptentrioDumpCommMode::RTCM, false);
+}
+
+void SeptentrioGPS::store_update_rates()
+{
+	_rate_vel = _rate_count_vel / (((float)(hrt_absolute_time() - _interval_rate_start)) / 1000000.0f);
+	_rate_lat_lon = _rate_count_lat_lon / (((float)(hrt_absolute_time() - _interval_rate_start)) / 1000000.0f);
+}
+
+void SeptentrioGPS::reset_update_rates()
+{
+	_rate_count_vel = 0;
+	_rate_count_lat_lon = 0;
+	_interval_rate_start = hrt_absolute_time();
+}
+
+void SeptentrioGPS::set_clock(timespec rtc_gps_time)
+{
+	timespec rtc_system_time;
+	px4_clock_gettime(CLOCK_REALTIME, &rtc_system_time);
+	int drift_time = abs(rtc_system_time.tv_sec - rtc_gps_time.tv_sec);
+
+    	// As of 2021 setting the time on Nuttx temporarily pauses interrupts so only set the time if it is very wrong.
+	if (drift_time >= SEP_SET_CLOCK_DRIFT_TIME_S) {
+		// TODO: clock slewing of the RTC for small time differences
+		px4_clock_settime(CLOCK_REALTIME, &rtc_gps_time);
+	}
+}
+
+extern "C" __EXPORT int septentrio_main(int argc, char *argv[])
+{
+	return SeptentrioGPS::main(argc, argv);
+}

--- a/src/drivers/gnss/septentrio/septentrio.cpp
+++ b/src/drivers/gnss/septentrio/septentrio.cpp
@@ -44,6 +44,7 @@
 #include "septentrio.h"
 
 #include <cmath>
+#include <cstdio>
 #include <ctime>
 #include <string.h>
 #include <termios.h>
@@ -71,6 +72,7 @@ using namespace time_literals;
 #define SBF_PACKET_TIMEOUT      2       ///< If no data during this delay (in ms) assume that full update received
 #define DISABLE_MSG_INTERVAL    1000000 ///< Try to disable message with this interval (in us)
 #define MSG_SIZE                100     ///< Size of the message to be sent to the receiver
+#define LOG_MSG_SIZE            200     ///< Size of log message to be sent to the receiver
 #define TIMEOUT_5HZ             500     ///< Timeout time in mS, 1000 mS (1Hz) + 300 mS delta for error
 #define RATE_MEASUREMENT_PERIOD 5_s     ///< Rate at which bandwith measurements are taken
 #define RECEIVER_BAUD_RATE      115200  ///< The baudrate of the serial connection to the receiver
@@ -99,6 +101,16 @@ using namespace time_literals;
 
 #define SBF_CONFIG "setSBFOutput, Stream1, %s, PVTGeodetic+VelCovGeodetic+DOP+AttEuler+AttCovEuler, msec100\n" /**< Configure the correct blocks for GPS positioning and heading */
 
+/**
+ * Configure logging on stream 4.
+ * The first argument %s defines overwrite behavior.
+ * The second argument %s are the blocks that should be output.
+ * The third argument %s is the frequency at which they need to be output.
+ */
+#define SBF_CONFIG_LOGGING "setSBFOutput, Stream4, DSK1, %s%s, %s\n"
+
+#define SBF_CONFIG_LOGGING_FILENAME "setFileNaming, DSK1, Incremental, px4\n"
+
 #define SBF_CONFIG_BAUDRATE "setCOMSettings, %s, baud%d\n"
 
 #define SBF_CONFIG_RESET "setSBFOutput, Stream1, %s, none, off\n"
@@ -122,6 +134,25 @@ using namespace time_literals;
 
 #define SBF_CONFIG_RTCM_STATIC_OFFSET "" \
 	"setAntennaOffset, Main, %f, %f, %f\n"
+
+#define SBF_LOGGING_LITE    "Comment+ReceiverStatus"
+#define SBF_LOGGING_BASIC   "Comment+ReceiverStatus+PostProcess+Event"
+#define SBF_LOGGING_DEFAULT "Comment+ReceiverStatus+PostProcess+Event+Support"
+#define SBF_LOGGING_FULL    "Comment+ReceiverStatus+PostProcess+Event+Support+BBSamples"
+
+#define SBF_0_1_HZ  "sec10"
+#define SBF_0_2_HZ  "sec5"
+#define SBF_0_5_HZ  "sec2"
+#define SBF_1_0_HZ  "sec1"
+#define SBF_2_0_HZ  "msec500"
+#define SBF_5_0_HZ  "msec200"
+#define SBF_10_0_HZ "msec100"
+#define SBF_20_0_HZ "msec50"
+
+#define SBF_LOGGING_LEVEL_LITE    0
+#define SBF_LOGGING_LEVEL_BASIC   1
+#define SBF_LOGGING_LEVEL_DEFAULT 2
+#define SBF_LOGGING_LEVEL_FULL    3
 
 static constexpr int SEP_SET_CLOCK_DRIFT_TIME_S{5}; ///< RTC drift time when time synchronization is needed (in seconds)
 
@@ -431,10 +462,13 @@ void SeptentrioGPS::schedule_reset(SeptentrioGPSResetType reset_type)
 
 int SeptentrioGPS::configure(float heading_offset)
 {
-	_configured = false;
-
 	param_t handle = param_find("SEP_PITCH_OFFS");
 	float pitch_offset = 0.f;
+	float logging_frequency = 1;
+	int32_t logging_level = SBF_LOGGING_LEVEL_DEFAULT;
+	int32_t logging_overwrite = 0;
+
+	_configured = false;
 
 	if (handle != PARAM_INVALID) {
 		param_get(handle, &pitch_offset);
@@ -560,6 +594,66 @@ int SeptentrioGPS::configure(float heading_offset)
 			response_detected = true;
 		}
 	} while (i < 5 && !response_detected);
+
+	param_get(param_find("SEP_LOG_HZ"), &logging_frequency);
+	param_get(param_find("SEP_LOG_LEVEL"), &logging_level);
+	param_get(param_find("SEP_LOG_FORCE"), &logging_overwrite);
+
+	if (logging_frequency <= 0.f) {
+		if (logging_overwrite) {
+			// hard-disable logging, clear existing stream
+			send_message_and_wait_for_ack("setSBFOutput,Stream4,none,none,off\n", SBF_CONFIG_TIMEOUT);
+		} else {
+			// soft-disable logging, keep existing stream
+			send_message_and_wait_for_ack("setSBFOutput,Stream4,,,off\n", SBF_CONFIG_TIMEOUT);
+		}
+	} else {
+		const char* logging_frequency_msg;
+		const char* logging_blocks_msg;
+		char logging_msg[LOG_MSG_SIZE];
+
+		switch (logging_level) {
+			case SBF_LOGGING_LEVEL_LITE:
+				logging_blocks_msg = SBF_LOGGING_LITE;
+			break;
+			case SBF_LOGGING_LEVEL_BASIC:
+				logging_blocks_msg = SBF_LOGGING_BASIC;
+			break;
+			default:
+			case SBF_LOGGING_LEVEL_DEFAULT:
+				logging_blocks_msg = SBF_LOGGING_DEFAULT;
+			break;
+			case SBF_LOGGING_LEVEL_FULL:
+				logging_blocks_msg = SBF_LOGGING_FULL;
+			break;
+		}
+
+		if (logging_frequency <= 0.1f) {
+			logging_frequency_msg = SBF_0_1_HZ;
+		} else if (logging_frequency <= 0.2f) {
+			logging_frequency_msg = SBF_0_2_HZ;
+		} else if (logging_frequency <= 0.5f) {
+			logging_frequency_msg = SBF_0_5_HZ;
+		} else if (logging_frequency <= 1.0f) {
+			logging_frequency_msg = SBF_1_0_HZ;
+		} else if (logging_frequency <= 2.0f) {
+			logging_frequency_msg = SBF_2_0_HZ;
+		} else if (logging_frequency <= 5.0f) {
+			logging_frequency_msg = SBF_5_0_HZ;
+		} else if (logging_frequency <= 10.0f) {
+			logging_frequency_msg = SBF_10_0_HZ;
+		} else {
+			logging_frequency_msg = SBF_20_0_HZ;
+		}
+
+		snprintf(logging_msg, sizeof(logging_msg), SBF_CONFIG_LOGGING,
+			logging_overwrite ? "" : "+",
+			logging_blocks_msg, logging_frequency_msg);
+
+		// needs to be sent first, otherwise we have a small file gathering some data every so often
+		send_message_and_wait_for_ack(SBF_CONFIG_LOGGING_FILENAME, SBF_CONFIG_TIMEOUT);
+		send_message_and_wait_for_ack(logging_msg, SBF_CONFIG_TIMEOUT);
+        }
 
 	_configured = true;
 

--- a/src/drivers/gnss/septentrio/septentrio.h
+++ b/src/drivers/gnss/septentrio/septentrio.h
@@ -1,0 +1,414 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file septentrio.h
+ *
+ * Septentrio GNSS receiver driver
+ *
+ * @author Matej Franceskin <Matej.Franceskin@gmail.com>
+ * @author <a href="https://github.com/SeppeG">Seppe Geuens</a>
+ * @author Thomas Frans
+*/
+
+#pragma once
+
+#include <px4_platform_common/atomic.h>
+#include <px4_platform_common/getopt.h>
+#include <px4_platform_common/module.h>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/SubscriptionMultiArray.hpp>
+#include <uORB/topics/satellite_info.h>
+#include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/gps_dump.h>
+#include <uORB/topics/gps_inject_data.h>
+#include <lib/drivers/device/Device.hpp>
+#include <lib/parameters/param.h>
+
+#include "sbf.h"
+#include "rtcm.h"
+
+/* Message decoder state */
+typedef enum {
+	SBF_DECODE_SYNC1 = 0,
+	SBF_DECODE_SYNC2,
+	SBF_DECODE_PAYLOAD,
+	SBF_DECODE_RTCM3,
+} sbf_decode_state_t;
+
+/**
+ *  Struct for dynamic allocation of satellite info data.
+ */
+struct GPSSatelliteInfo {
+	satellite_info_s _data;
+};
+
+enum class SeptentrioDumpCommMode : int32_t {
+	Disabled = 0,
+	Full, ///< dump full RX and TX data for all devices
+	RTCM, ///< dump received RTCM from Main GPS
+};
+
+/**
+ * The type of serial connection to the receiver.
+ */
+enum class SeptentrioSerialInterface : uint8_t {
+	UART = 0,
+	SPI,
+};
+
+enum class SeptentrioGPSResetType {
+	/**
+	 * There is no pending GPS reset.
+	 */
+	None,
+
+	/**
+	 * In hot start mode, the receiver was powered down only for a short time (4 hours or less),
+	 * so that its ephemeris is still valid. Since the receiver doesn't need to download ephemeris
+	 * again, this is the fastest startup method.
+	 */
+	Hot,
+
+	/**
+	 * In warm start mode, the receiver has approximate information for time, position, and coarse
+	 * satellite position data (Almanac). In this mode, after power-up, the receiver normally needs
+	 * to download ephemeris before it can calculate position and velocity data.
+	 */
+	Warm,
+
+	/**
+	 * In cold start mode, the receiver has no information from the last position at startup.
+	 * Therefore, the receiver must search the full time and frequency space, and all possible
+	 * satellite numbers. If a satellite signal is found, it is tracked to decode the ephemeris,
+	 * whereas the other channels continue to search satellites. Once there is a sufficient number
+	 * of satellites with valid ephemeris, the receiver can calculate position and velocity data.
+	 */
+	Cold
+};
+
+/**
+ * The type of data the receiver should output.
+ */
+enum class SeptentrioGPSOutputMode {
+	GPS,        ///< Only GPS output
+	GPSAndRTCM, ///< GPS and RTCM output
+};
+
+class SeptentrioGPS : public ModuleBase<SeptentrioGPS>, public device::Device
+{
+public:
+	SeptentrioGPS(const char *device_path);
+	~SeptentrioGPS() override;
+
+	int print_status() override;
+
+	void run() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static SeptentrioGPS *instantiate(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	/**
+	 * @brief Reset the connected GPS receiver.
+	 *
+	 * @return 0 on success, -1 on not implemented, >0 on error
+	 */
+	int reset(SeptentrioGPSResetType type);
+
+	/**
+	 * @brief Get the update rate for position information from the receiver.
+	 *
+	 * @return the position update rate of the receiver
+	 */
+	float get_position_update_rate();
+
+	/**
+	 * @brief Get the update rate for velocity information from the receiver.
+	 *
+	 * @return the velocity update rate of the receiver
+	 */
+	float get_velocity_update_rate();
+private:
+	/**
+	 * @brief Schedule a reset of the connected receiver.
+	 */
+	void schedule_reset(SeptentrioGPSResetType type);
+
+	/**
+	 * Configure the receiver.
+	 *
+	 * @return `PX4_OK` on success, `PX4_ERROR` otherwise
+	 */
+	int configure(float heading_offset);
+
+	/**
+	 * Open the serial connection to the receiver.
+	 * On error, wait a second and return.
+	 * Does nothing if the connection is already open.
+	 *
+	 * @return `PX4_OK` on success, `PX4_ERROR` on error
+	 */
+	int serial_open();
+
+	/**
+	 * @brief Close the serial connection to the receiver.
+	 *
+	 * Does nothing if the connection is already closed.
+	 * If an error occurs while closing the file,`_serial_fd` is still set to -1.
+	 *
+	 * @return `PX4_OK` on success or closed connection, `PX4_ERROR` on error
+	 */
+	int serial_close();
+
+	/**
+	 * @brief Parse the next byte of a received message from the receiver.
+	 *
+	 * @return 0 = decoding, 1 = message handled, 2 = sat info message handled
+	 */
+	int parse_char(const uint8_t byte);
+
+	/**
+	 * @brief Add payload rx byte.
+	 *
+	 * @return -1 = error, 0 = ok, 1 = payload received completely
+	 */
+	int payload_rx_add(const uint8_t byte);
+
+	/**
+	 * @brief Parses incoming SBF blocks.
+	 *
+	 * @return bitfield: all 0 = no message handled, 1 = position handled, 2 = satellite info handled
+	 */
+	int payload_rx_done();
+
+	/**
+	 * @brief Reset the parse state machine for a fresh start.
+	 */
+	void decode_init();
+
+	/**
+	 * @brief Send a message.
+	 *
+	 * @return true on success, false on write error (errno set)
+	 */
+	bool send_message(const char *msg);
+
+	/**
+	 * @brief Send a message and waits for acknowledge.
+	 *
+	 * @param msg The message to send to the receiver
+	 * @param timeout The time before sending the message times out
+	 *
+	 * @return true on success, false on write error (errno set) or ack wait timeout
+	 */
+	bool send_message_and_wait_for_ack(const char *msg, const int timeout);
+
+	/**
+	 * @brief Receive incoming messages.
+	 *
+	 * @return -1 = error, 0 = no message handled, 1 = message handled, 2 = sat info message handled
+	 */
+	int receive(unsigned timeout);
+
+	/**
+	 * @brief Read from the receiver.
+	 *
+	 * @param buf        Data that is read
+	 * @param buf_length Size of the buffer
+	 * @param timeout    Reading timeout
+	 *
+	 * @return 0 on nothing read or poll timeout, <0 on error and >0 on bytes read (nr of bytes)
+	*/
+	int read(uint8_t *buf, size_t buf_length, int timeout);
+
+	/**
+	 * This is an abstraction for the poll on serial used.
+	 *
+	 * @param buf        The read buffer
+	 * @param buf_length Size of the read buffer
+	 * @param timeout    Read timeout in ms
+	 *
+	 * @return 0 on nothing read or poll timeout, <0 on error and >0 on bytes read (nr of bytes)
+	 */
+	int poll_or_read(uint8_t *buf, size_t buf_length, int timeout);
+
+	/**
+	 * @brief Write to the receiver.
+	 *
+	 * @param buf Data to be written
+	 * @param buf_length Amount of bytes to be written
+	 *
+	 * @return the number of bytes written on success, or -1 otherwise
+	 */
+	int write(const uint8_t *buf, size_t buf_length);
+
+	/**
+	 * @brief Initialize uORB GPS logging and advertise the topic.
+	 *
+	 * @return `PX4_OK` on success, `PX4_ERROR` otherwise
+	 */
+	int initialize_communication_dump();
+
+	/**
+	 * @brief Reset the receiver if it was requested by the user.
+	 */
+	void reset_if_scheduled();
+
+	/**
+	 * @brief Set the baudrate of the serial connection.
+	 *
+	 * @param baud The baud rate of the connection
+	 *
+	 * @return `PX4_OK` on success, `PX4_ERROR` on otherwise
+	 */
+	int set_baudrate(unsigned baud);
+
+	/**
+	 * @brief Handle incoming messages on the "inject data" uORB topic and send them to the receiver.
+	 */
+	void handle_inject_data_topic();
+
+	/**
+	 * @brief Send data to the receiver, such as RTCM injections.
+	 *
+	 * @param data The raw data to send to the device
+	 * @param len The size of `data`
+	 *
+	 * @return `true` if all the data was written correctly, `false` otherwise
+	 */
+	inline bool inject_data(uint8_t *data, size_t len);
+
+	/**
+	 * Publish the gps struct.
+	 */
+	void publish();
+
+	/**
+	 * Publish the satellite info.
+	 */
+	void publish_satellite_info();
+
+	/**
+	 * Publish RTCM corrections.
+	 *
+	 * @param data: The raw data to publish
+	 * @param len: The size of `data`
+	 */
+	void publish_rtcm_corrections(uint8_t *data, size_t len);
+
+	/**
+	 * Dump gps communication.
+	 *
+	 * @param data The raw data of the message
+	 * @param len The size of `data`
+	 * @param mode The calling source
+	 * @param msg_to_gps_device `true` if the message should be sent to the device, `false` otherwise
+	 */
+	void dump_gps_data(const uint8_t *data, size_t len, SeptentrioDumpCommMode mode, bool msg_to_gps_device);
+
+	/**
+	 * Handle an RTCM message.
+	 */
+	void got_rtcm_message(uint8_t *data, size_t len);
+
+	/**
+	 * @brief Store the currently recorded update rates.
+	 */
+	void store_update_rates();
+
+	/**
+	 * @brief Reset the update rate measurement state.
+	 */
+	void reset_update_rates();
+
+	/**
+	 * Used to set the system clock accurately.
+	 *
+	 * @param time The current time.
+	 */
+	void set_clock(timespec rtc_gps_time);
+
+	px4::atomic<int>                               _scheduled_reset{(int)SeptentrioGPSResetType::None};                                   ///< The type of receiver reset that is scheduled
+	SeptentrioGPSOutputMode                        _output_mode{SeptentrioGPSOutputMode::GPS};                                       ///< The type of data the receiver should output
+	SeptentrioDumpCommMode                         _dump_communication_mode{SeptentrioDumpCommMode::Disabled};                       ///< GPS communication dump mode
+	sbf_decode_state_t                             _decode_state{SBF_DECODE_SYNC1};                                                  ///< State of the SBF parser
+	int                                            _serial_fd{-1};                                                                   ///< The file descriptor used for communication with the receiver
+	char                                           _port[20] {};                                                                     ///< The path of the used serial device
+	bool                                           _configured{false};                                                               ///< Configuration status of the connected receiver
+	uint64_t                                       _last_timestamp_time{0};                                                          ///< The last time a timestamp was added to a position uORB message (us)
+	hrt_abstime                                    _last_rtcm_injection_time{0};                                                     ///< Time of last RTCM injection
+	uint8_t                                        _msg_status{0};
+	uint16_t                                       _rx_payload_index{0};                                                             ///< State for the message parser
+	sbf_buf_t
+	_buf;                                                                             ///< The complete received message
+	RTCMParsing                                    *_rtcm_parsing{nullptr};                                                          ///< RTCM message parser
+	uint8_t                                        _selected_rtcm_instance{0};                                                       ///< uORB instance that is being used for RTCM corrections
+	bool                                           _healthy{false};                                                                  ///< Flag to signal if the GPS is OK
+	uint8_t                                        _spoofing_state{0};                                                               ///< Receiver spoofing state
+	uint8_t                                        _jamming_state{0};                                                                ///< Receiver jamming state
+
+	// uORB topics and subscriptions
+	gps_dump_s                                     *_dump_to_device{nullptr};                                                        ///< uORB GPS dump data (to the receiver)
+	gps_dump_s                                     *_dump_from_device{nullptr};                                                      ///< uORB GPS dump data (from the receiver)
+	sensor_gps_s                                   _report_gps_pos{};                                                                ///< uORB topic for gps position
+	satellite_info_s                               *_p_report_sat_info{nullptr};                                                     ///< Pointer to uORB topic for satellite info
+	GPSSatelliteInfo                               *_sat_info{nullptr};                                                              ///< Instance of GPS sat info data object
+	uORB::Publication<gps_dump_s>                  _dump_communication_pub{ORB_ID(gps_dump)};                                        ///< uORB topic for dump GPS data
+	uORB::Publication<gps_inject_data_s>           _gps_inject_data_pub{ORB_ID(gps_inject_data)};                                    ///< uORB topic for injected data to the receiver
+	uORB::PublicationMulti<sensor_gps_s>           _report_gps_pos_pub{ORB_ID(sensor_gps)};                                          ///< uORB topic for gps position
+	uORB::PublicationMulti<satellite_info_s>       _report_sat_info_pub{ORB_ID(satellite_info)};                                     ///< uORB topic for satellite info
+	uORB::SubscriptionMultiArray<gps_inject_data_s, gps_inject_data_s::MAX_INSTANCES> _orb_inject_data_sub{ORB_ID::gps_inject_data}; ///< uORB topic about data to inject to the receiver
+
+	// Reading and update rates
+	// NOTE: Both `_rate_vel` and `_rate_lat_lon` seem to be used in exactly the same way.
+	uint64_t _interval_rate_start{0};            ///< Start moment of measurement interval for position and velocity messages from the receiver
+	float    _rate{0.0f};                        ///< uORB position data publish rate (Hz)
+	uint8_t  _rate_count_vel;                    ///< Velocity messages from receiver in current measurement interval
+	uint8_t  _rate_count_lat_lon{};              ///< Position messages from receiver in current measurement interval
+	unsigned _last_rate_rtcm_injection_count{0}; ///< Counter for number of RTCM messages
+	float    _rate_vel{0.0f};                    ///< Velocity message rate from receiver in the last measurement interval (Hz)
+	float    _rate_lat_lon{0.0f};                ///< Position message rate from receiver in the last measurement interval (Hz)
+	float    _rate_rtcm_injection{0.0f};         ///< RTCM message injection rate (Hz)
+	unsigned _rate_reading{0};                   ///< Byte reading rate (Hz)
+	unsigned _num_bytes_read{0};                 ///< Number of bytes read in last measurement interval
+};

--- a/src/drivers/gnss/septentrio/util.cpp
+++ b/src/drivers/gnss/septentrio/util.cpp
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "util.h"
+
+uint16_t sep_crc16(const uint8_t *data_p, uint32_t length)
+{
+	uint8_t x;
+	uint16_t crc = 0;
+
+	while (length--) {
+		x = crc >> 8 ^ *data_p++;
+		x ^= x >> 4;
+		crc = static_cast<uint16_t>((crc << 8) ^ (x << 12) ^ (x << 5) ^ x);
+	}
+
+	return crc;
+}

--- a/src/drivers/gnss/septentrio/util.h
+++ b/src/drivers/gnss/septentrio/util.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+/**
+ * @brief Calculate buffer CRC16
+ */
+uint16_t sep_crc16(const uint8_t *data_p, uint32_t length);


### PR DESCRIPTION
Add three new parameters that allow users to configure logging on their receiver from their ground control station.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
If users wanted logging on their GNSS receiver, they had to manually set it up.

### Solution
- Add three new parameters `SEP_LOG_HZ`, `SEP_LOG_LEVEL` and `SEP_LOG_FORCE`
- `SEP_LOG_HZ`: Set the logging frequency
- `SEP_LOG_LEVEL`: Set the amount of detail the receiver should log
- `SEP_LOG_FORCE`: Set whether any existing logging should be overwritten

### Changelog Entry
For release notes:
```
Feature Add three parameters to set up GNSS receiver logging
```

### Alternatives
The alternative was in #22874 which is now closed in favor of this PR on top of the extracted driver.

### Test coverage
\/

### Context
I will keep this as a draft for now for context only. Once the separate driver in #22904 is merged, I will rebase this branch onto main and open it.