### PR TITLE
px4io: Fix dependency problem caused by #22957

### DIFF
--- a/src/drivers/px4io/Kconfig
+++ b/src/drivers/px4io/Kconfig
@@ -1,6 +1,6 @@
 menuconfig DRIVERS_PX4IO
 	bool "px4io"
 	default n
-	depends on platform_nuttx
+	depends on PLATFORM_NUTTX
 	---help---
 		Enable support for px4io


### PR DESCRIPTION
#22957 has a typo in the dependencies thus PX4IO wasn't building.
This PR Fixes that