### PR TITLE
mavlink_ftp: handle relative paths correctly 

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -326,7 +326,7 @@ MavlinkFTP::_reply(mavlink_file_transfer_protocol_t *ftp_req)
 	// we can simply resend the response.
 	// we only keep small responses to reduce RAM usage and avoid large memcpy's. The larger responses are all data
 	// retrievals without side-effects, meaning it's ok to reexecute them if a response gets lost
-	if (payload->size <= sizeof(uint32_t)) {
+	if (payload->size <= sizeof(uint32_t) && payload->data[0] != kErrNoSessionsAvailable) {
 		_last_reply_valid = true;
 		memcpy(_last_reply, ftp_req, sizeof(_last_reply));
 	}
@@ -514,7 +514,7 @@ MavlinkFTP::ErrorCode
 MavlinkFTP::_workOpen(PayloadHeader *payload, int oflag)
 {
 	if (_session_info.fd >= 0) {
-		PX4_ERR("FTP: Open failed - out of sessions\n");
+		PX4_ERR("FTP: Open failed - out of sessions");
 		return kErrNoSessionsAvailable;
 	}
 

--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -838,7 +838,7 @@ MavlinkFTP::_workRename(PayloadHeader *payload)
 	char *ptr = _data_as_cstring(payload);
 	size_t oldpath_sz = strlen(ptr);
 
-	if (oldpath_sz == payload->size) {
+	if (oldpath_sz + 2 >= payload->size) {
 		// no newpath
 		errno = EINVAL;
 		return kErrFailErrno;

--- a/src/modules/mavlink/mavlink_ftp.h
+++ b/src/modules/mavlink/mavlink_ftp.h
@@ -155,6 +155,11 @@ private:
 	uint8_t _getServerComponentId(void);
 	uint8_t _getServerChannel(void);
 
+	/**
+	 * Construct local path by appending `path` to `_root_dir` and storing the result in `dst`.
+	 */
+	void _constructPath(char *dst, int dst_len, const char *path) const;
+
 	bool _validatePathIsWritable(const char *path);
 
 	/**


### PR DESCRIPTION
By ensuring there's a '/' in between when concatenating the path with _root_dir.

It turns out there's a bug in GQC where a component metadata uri like `mftp://etc/extras/component_general.json.xz` is turned into an ftp request with path `/etc/extras/component_general.json.xz`, whereas it should be `etc/extras/component_general.json.xz`.