### PR TITLE
EKF2: use dedicated time-delay parameter

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -265,7 +265,7 @@ struct parameters {
 	int32_t height_sensor_ref{static_cast<int32_t>(HeightSensor::BARO)};
 	int32_t position_sensor_ref{static_cast<int32_t>(PositionSensor::GNSS)};
 
-	int32_t sensor_interval_max_ms{10};     ///< maximum time of arrival difference between non IMU sensor updates. Sets the size of the observation buffers. (mSec)
+	float delay_max_ms{110.f};              ///< maximum time delay of all the aiding sensors. Sets the size of the observation buffers. (mSec)
 
 	// input noise
 	float gyro_noise{1.5e-2f};              ///< IMU angular rate noise used for covariance prediction (rad/sec)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -498,6 +498,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamExtInt<px4::params::EKF2_PREDICT_US>) _param_ekf2_predict_us,
+		(ParamExtFloat<px4::params::EKF2_DELAY_MAX>) _param_ekf2_delay_max,
 		(ParamExtInt<px4::params::EKF2_IMU_CTRL>) _param_ekf2_imu_ctrl,
 
 #if defined(CONFIG_EKF2_AUXVEL)

--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -29,6 +29,18 @@ parameters:
       default: 7
       min: 0
       max: 7
+    EKF2_DELAY_MAX:
+      description:
+        short: Maximum delay of all the aiding sensors
+        long: Defines the delay between the current time and the delayed-time horizon.
+          This value should be at least as large as the largest EKF2_XXX_DELAY parameter.
+      type: float
+      default: 200
+      min: 0
+      max: 1000
+      unit: ms
+      reboot_required: true
+      decimal: 1
     EKF2_MAG_DELAY:
       description:
         short: Magnetometer measurement delay relative to IMU measurements


### PR DESCRIPTION
Requires:
- [ ] https://github.com/PX4/PX4-Autopilot/pull/22982
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
1. It is quite common to enable/disable an aiding source after takeoff to test the robustness of the system. With the current way of calculating the delayed time horizon, booting with or without an aiding source enabled leads to different results (especially for GNSS as it usually has the highest delay).
2. VIO systems are time-synchronized, meaning that their delay parameter is set to 0 but the actual delay is usually much higher, a known workaround is to set the VIO delay in the auxvel delay to size the buffer correctly.

### Solution
Add `EKF2_DELAY_MAX` parameter to define the delay between the current time and delayed-time horizon.

### Changelog Entry
For release notes:
```
New parameter: EKF2_DELAY_MAX
Documentation: TBD
```

Todo: 
- [x] bump `EKF2_MAX_DELAY` if smaller than sensor-specific delay

![Screenshot from 2024-04-17 10-46-50](https://github.com/PX4/PX4-Autopilot/assets/14822839/63d818f4-df5a-4e7a-bfcb-a24cd149b069)
