### PR TITLE
RTL: fix corner case where vehicle loiters in place instead of doing the RTL to Home

### DIFF
--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -118,12 +118,12 @@ protected:
 	void getNextPositionItems(int32_t start_index, int32_t items_index[], size_t &num_found_items,
 				  uint8_t max_num_items);
 	/**
-	 * @brief Has Mission a Land Start or Land Item
+	 * @brief Mission has a land start, a land, and is valid
 	 *
-	 * @return true If mission has a land start of land item and a land item
+	 * @return true If mission has a land start and a land item and is valid
 	 * @return false otherwise
 	 */
-	bool hasMissionLandStart() const { return _mission.land_start_index >= 0 && _mission.land_index >= 0;};
+	bool hasMissionLandStart() const { return _mission.land_start_index >= 0 && _mission.land_index >= 0 && isMissionValid();};
 	/**
 	 * @brief Go to next Mission Item
 	 * Go to next non jump mission item

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -617,7 +617,8 @@ void RTL::parameters_update()
 
 bool RTL::hasMissionLandStart() const
 {
-	return _mission_sub.get().land_start_index >= 0 && _mission_sub.get().land_index >= 0;
+	return _mission_sub.get().land_start_index >= 0 && _mission_sub.get().land_index >= 0
+	       && _navigator->get_mission_result()->valid;
 }
 
 bool RTL::hasVtolLandApproach(const PositionYawSetpoint &rtl_position) const

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -97,6 +97,11 @@ private:
 	};
 
 private:
+
+	/**
+	 * @brief Check mission landing validity
+	 * @return true if mission has a land start, a land and is valid
+	 */
 	bool hasMissionLandStart() const;
 
 	/**


### PR DESCRIPTION
### Solved Problem
With `RTL_TYPE=0` and `RTL_APPR_FORCE=1`, the logic in [RTL::findRtlDestination()](https://github.com/PX4/PX4-Autopilot/blob/4d0a88fdf8745c02f19f4142f0e98765a0a47b02/src/modules/navigator/rtl.cpp#L402-L403) does not check if the mission is valid, only if the mission has a valid land item. If the mission is not valid, it will result in anyway switching into the Mission RTL, only to then find that the mission is invalid and loiter at place instead of returning. 

### Solution
 Instead of adding an additional check for the mission validity there, the proposal here is to not return `hasMissionLandStart()` as true.

### Changelog Entry
For release notes:
```
Bugfix: RTL: fix corner case where vehicle loiters in place instead of doing the RTL to Home.
```

### Alternatives
Add a check for mission validity in https://github.com/PX4/PX4-Autopilot/blob/4d0a88fdf8745c02f19f4142f0e98765a0a47b02/src/modules/navigator/rtl.cpp#L402-L403
