### PR TITLE
FeasibilityChecks: MIS_TKO_LAND_REQ=5: only require both or neither TO/LND when landed

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -587,7 +587,10 @@ bool FeasibilityChecker::checkTakeoffLandAvailable()
 		break;
 
 	case 5:
-		if (!_is_landed && !_has_vtol_approach) {
+		if (_is_landed) {
+			result = hasMissionBothOrNeitherTakeoffAndLanding();
+
+		} else if (!_has_vtol_approach) {
 			result = _landing_valid;
 
 			if (!result) {
@@ -595,9 +598,6 @@ bool FeasibilityChecker::checkTakeoffLandAvailable()
 				events::send(events::ID("feasibility_mis_in_air_landing_req"), {events::Log::Error, events::LogInternal::Info},
 					     "Mission rejected: Landing waypoint/pattern required");
 			}
-
-		} else {
-			result = hasMissionBothOrNeitherTakeoffAndLanding();
 		}
 
 		break;

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -68,7 +68,7 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
  * @value 2 Require a landing
  * @value 3 Require a takeoff and a landing
  * @value 4 Require both a takeoff and a landing, or neither
- * @value 5 Same as previous, but require a landing if in air and no valid VTOL landing approach is present
+ * @value 5 Same as previous when landed, in-air require landing only if no valid VTOL approach is present
  * @group Mission
  */
 PARAM_DEFINE_INT32(MIS_TKO_LAND_REQ, 0);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -266,7 +266,6 @@ public:
 	int get_loiter_min_alt() const { return _param_min_ltr_alt.get(); }
 	int get_landing_abort_min_alt() const { return _param_mis_lnd_abrt_alt.get(); }
 	float get_param_mis_takeoff_alt() const { return _param_mis_takeoff_alt.get(); }
-	int  get_takeoff_land_required() const { return _para_mis_takeoff_land_req.get(); }
 	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
 	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
 
@@ -406,7 +405,6 @@ private:
 
 		// non-navigator parameters: Mission (MIS_*)
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
-		(ParamInt<px4::params::MIS_TKO_LAND_REQ>)  _para_mis_takeoff_land_req,
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
 		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,


### PR DESCRIPTION
### Solved Problem
With MIS_TKO_LAND_REQ=5, it required a takeoff and a land or neither also when in air and there was a valid home/safe point approach. This is wrong, and it only should require that when on the ground.

### Solution
Fix logic, only handle hasMissionBothOrNeitherTakeoffAndLanding() if on ground if MIS_TKO_LAND_REQ=5, in air and without safe approach only check for landing.

### Changelog Entry
For release notes: 
```
Bugfix: FeasibilityChecks: MIS_TKO_LAND_REQ=5: only require both or neither TO/LND when landed
```


