### PR TITLE
Send mavlink manual control buttons field in manual control input topic

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2089,6 +2089,8 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 	// For backwards compatibility at the moment interpret throttle in range [0,1000]
 	manual_control_setpoint.throttle = ((mavlink_manual_control.z / 1000.f) * 2.f) - 1.f;
 	manual_control_setpoint.yaw = mavlink_manual_control.r / 1000.f;
+	// Pass along the button states in aux1
+	manual_control_setpoint.aux1 = (float) mavlink_manual_control.buttons;
 	manual_control_setpoint.data_source = manual_control_setpoint_s::SOURCE_MAVLINK_0 + _mavlink->get_instance_id();
 	manual_control_setpoint.timestamp = manual_control_setpoint.timestamp_sample = hrt_absolute_time();
 	manual_control_setpoint.valid = true;


### PR DESCRIPTION

### Solved Problem
The buttons field in the manual control mavlink message was not being put into the corresponding
manual control input topic. This PR places the buttons data into the aux1 field so that it is accessible
within PX4.