### PR TITLE
drivers: broadcom AFBR fix close to ground false readings

### DIFF
--- a/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/AFBRS50.hpp
@@ -85,7 +85,7 @@ private:
 	static status_t measurement_ready_callback(status_t status, argus_hnd_t *hnd);
 
 	void get_info();
-	status_t set_rate(uint32_t rate_hz);
+	status_t set_rate_and_dfm(uint32_t rate_hz, argus_dfm_mode_t dfm_mode);
 
 	argus_hnd_t *_hnd{nullptr};
 

--- a/src/drivers/distance_sensor/broadcom/afbrs50/parameters.c
+++ b/src/drivers/distance_sensor/broadcom/afbrs50/parameters.c
@@ -46,7 +46,7 @@
  * @value 2 High Speed Short Range Mode
  * @value 3 High Speed Long Range Mode
  */
-PARAM_DEFINE_INT32(SENS_AFBR_MODE, 1);
+PARAM_DEFINE_INT32(SENS_AFBR_MODE, 0);
 
 /**
  * AFBR Rangefinder Short Range Rate
@@ -85,7 +85,7 @@ PARAM_DEFINE_INT32(SENS_AFBR_L_RATE, 25);
  * @group Sensors
  *
  */
-PARAM_DEFINE_INT32(SENS_AFBR_THRESH, 5);
+PARAM_DEFINE_INT32(SENS_AFBR_THRESH, 4);
 
 
 /**


### PR DESCRIPTION
This PR attempts to fix the broadcom AFBR reading false readings when very close to the ground. 

https://review.px4.io/plot_app?log=4da0db08-522e-488a-942e-369b6085f239#Nav-Distance-Sensor
https://review.px4.io/plot_app?log=10f570a2-89f7-4696-8ea5-bb79e320d72f#Nav-Distance-Sensor
https://review.px4.io/plot_app?log=290041ef-6abb-4e1f-b236-fd2363087bf5#Nav-Distance-Sensor
https://review.px4.io/plot_app?log=aaad65cd-3eff-4237-b918-b2fbaf7ffe9a#Nav-Distance-Sensor
https://review.px4.io/plot_app?log=8c5acf8d-e921-49fd-8dc2-dda2aa7444b3#Nav-Distance-Sensor

It still looks like it can get into a state when right next to the ground where it reads ~3cm.

![image](https://github.com/PX4/PX4-Autopilot/assets/2019539/b20c4e3b-a250-4c22-9d7e-77fb689590a5)
![image](https://github.com/PX4/PX4-Autopilot/assets/2019539/aeea0000-3710-42b6-ba2d-dc5f9e8bffac)
![image](https://github.com/PX4/PX4-Autopilot/assets/2019539/802307e9-a7f0-4e2d-bce0-db677ba269fe)
https://review.px4.io/plot_app?log=8c5acf8d-e921-49fd-8dc2-dda2aa7444b3#Nav-Distance-Sensor