### PR TITLE
FW auto hand/catapult takeoff: fix case with disabeld takeoff detection

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -576,7 +576,7 @@ void TECSControl::_calcThrottleControlUpdate(float dt, const STERateLimit &limit
 
 			// Calculate a throttle demand from the integrated total energy rate error
 			// This will be added to the total throttle demand to compensate for steady state errors
-			_throttle_integ_state = _throttle_integ_state + throttle_integ_input;
+			_throttle_integ_state = PX4_ISFINITE(throttle_integ_input) ? _throttle_integ_state + throttle_integ_input : 0.f;
 
 		} else {
 			_throttle_integ_state = 0.0f;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1551,8 +1551,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 			_launchDetector.forceSetFlyState();
 		}
 
-		if (!_launch_detected && _launchDetector.getLaunchDetected() > launch_detection_status_s::STATE_WAITING_FOR_LAUNCH
-		    && _param_fw_laun_detcn_on.get()) {
+		if (!_launch_detected && _launchDetector.getLaunchDetected() > launch_detection_status_s::STATE_WAITING_FOR_LAUNCH) {
 			_launch_detected = true;
 			_launch_global_position = global_position;
 			_takeoff_ground_alt = _current_altitude;
@@ -1577,8 +1576,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		}
 
 		/* Set control values depending on the detection state */
-		if (_launchDetector.getLaunchDetected() > launch_detection_status_s::STATE_WAITING_FOR_LAUNCH
-		    && _param_fw_laun_detcn_on.get()) {
+		if (_launchDetector.getLaunchDetected() > launch_detection_status_s::STATE_WAITING_FOR_LAUNCH) {
 			/* Launch has been detected, hence we have to control the plane. */
 
 			float target_airspeed = adapt_airspeed_setpoint(control_interval, takeoff_airspeed, adjusted_min_airspeed, ground_speed,

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1609,7 +1609,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 				_att_sp.thrust_body[0] = _param_fw_thr_idle.get();
 
 			} else {
-				_att_sp.thrust_body[0] = (_landed) ? min(_param_fw_thr_idle.get(), 1.f) : get_tecs_thrust();
+				_att_sp.thrust_body[0] = get_tecs_thrust();
 			}
 
 			_att_sp.pitch_body = get_tecs_pitch();


### PR DESCRIPTION
### Solved Problem
FW auto hand/catapult launch takeoff without takeoff detection is currently broken. 
We though claim to support it, see [description of FW_LAUN_DETCN_ON](https://docs.px4.io/main/en/flight_modes_fw/takeoff.html#parameters-launch-detector).

### Solution
required 2 fixes, plus added one hardening:
 - within takeoff logic, do not set throttle to MIN if landed is true but launch detection state is FLYING
 - remove checks for param FW_LAUN_DETCN_ON set to true to execute takeoff logic. FW_LAUN_DETCN_ON should only be checked to set the launch detection states, and if set to false this state is already forced to FLYING
 - TECS throttle integrator: only apply if finite. I had cases in SITL where it would be nan shortly after booting, and would then stay nan for the whole flight, resulting in the throttle output being nan.

### Changelog Entry
For release notes:
```
Bugfix: FW auto hand/catapult takeoff: fix case with disabeld takeoff detection
```

### Alternatives
Workaround: 
FWTO_TKOFF to false
FW_LAUNCH_DETC_ON to true
LW_LAUN_AC_THLD to -10m/s/s to instantly trigger the launch detection
LNDFW_AIRSPD_MAX to -5m/s to never detect landing
Big drawback is ofc that you never will have land detected, so the operator has to kill the vehicle after touchdown.

### Test coverage
SITL tested. To test:
- FWTO_TKOFF to false
- FW_LAUNCH_DETC_ON to false
- plan mission with takeoff, start mission, vehicle should takeoff and fly the mission

