### PR TITLE
log from arm to disarm by default for sitl

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -169,8 +169,6 @@ param set-default MAV_PROTO_VER 2 # Ensures QGC does not drop the first few pack
 
 param set-default -s MC_AT_EN 1
 
-# By default log from boot until first disarm.
-param set-default SDLOG_MODE 1
 # enable default, estimator replay and vision/avoidance logging profiles
 param set-default SDLOG_PROFILE 131
 param set-default SDLOG_DIRS_MAX 7


### PR DESCRIPTION
- not ideal to log from boot by default when running sitl/sih on virtual devices with constrained memory
- log rotation doesn't kick in when only a single flight fills up the SD card