### PR TITLE
Update the DSM library to allow use of protocol parsing without UART interaction

### DIFF
--- a/boards/modalai/voxl2-slpi/src/CMakeLists.txt
+++ b/boards/modalai/voxl2-slpi/src/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(drivers_board
 # Add custom drivers for SLPI
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/rc_controller)
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/mavlink_rc_in)
-# add_subdirectory(${PX4_BOARD_DIR}/src/drivers/spektrum_rc)
+add_subdirectory(${PX4_BOARD_DIR}/src/drivers/spektrum_rc)
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/ghst_rc)
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/dsp_hitl)
 add_subdirectory(${PX4_BOARD_DIR}/src/drivers/dsp_sbus)

--- a/boards/modalai/voxl2-slpi/src/drivers/spektrum_rc/spektrum_rc.cpp
+++ b/boards/modalai/voxl2-slpi/src/drivers/spektrum_rc/spektrum_rc.cpp
@@ -110,15 +110,17 @@ void task_main(int argc, char *argv[])
 		}
 	}
 
-	int uart_fd = dsm_init(device_path);
+	int uart_fd = qurt_uart_open(device_path, 115200);
 
 	if (uart_fd < 0) {
-		PX4_ERR("dsm init failed");
+		PX4_ERR("uart open failed");
 		return;
 
 	} else if (verbose) {
-		PX4_INFO("Spektrum RC: dsm_init succeeded");
+		PX4_INFO("Spektrum RC: uart open succeeded");
 	}
+
+	dsm_proto_init_and_reset();
 
 	orb_advert_t rc_pub = nullptr;
 

--- a/boards/modalai/voxl2-slpi/src/drivers/spektrum_rc/spektrum_rc.cpp
+++ b/boards/modalai/voxl2-slpi/src/drivers/spektrum_rc/spektrum_rc.cpp
@@ -120,7 +120,7 @@ void task_main(int argc, char *argv[])
 		PX4_INFO("Spektrum RC: uart open succeeded");
 	}
 
-	dsm_proto_init_and_reset();
+	dsm_proto_init();
 
 	orb_advert_t rc_pub = nullptr;
 

--- a/src/lib/rc/dsm.cpp
+++ b/src/lib/rc/dsm.cpp
@@ -483,6 +483,14 @@ void dsm_proto_init()
 	}
 }
 
+void dsm_proto_init_and_reset()
+{
+	dsm_proto_init();
+
+	/* reset the format detector */
+	dsm_guess_format(true);
+}
+
 /**
  * Initialize the DSM receive functionality
  *

--- a/src/lib/rc/dsm.cpp
+++ b/src/lib/rc/dsm.cpp
@@ -481,11 +481,6 @@ void dsm_proto_init()
 		channel_buffer[i].last_seen = 0;
 		channel_buffer[i].value = 0;
 	}
-}
-
-void dsm_proto_init_and_reset()
-{
-	dsm_proto_init();
 
 	/* reset the format detector */
 	dsm_guess_format(true);

--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -68,7 +68,6 @@ typedef  struct dsm_decode_t {
 __EXPORT int	dsm_init(const char *device);
 __EXPORT void	dsm_deinit(void);
 __EXPORT void	dsm_proto_init(void);
-__EXPORT void	dsm_proto_init_and_reset(void);
 __EXPORT int	dsm_config(int dsm_fd);
 __EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes,
 			  uint8_t **bytes, int8_t *rssi, unsigned *frame_drops, unsigned max_values);

--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -68,6 +68,7 @@ typedef  struct dsm_decode_t {
 __EXPORT int	dsm_init(const char *device);
 __EXPORT void	dsm_deinit(void);
 __EXPORT void	dsm_proto_init(void);
+__EXPORT void	dsm_proto_init_and_reset(void);
 __EXPORT int	dsm_config(int dsm_fd);
 __EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes,
 			  uint8_t **bytes, int8_t *rssi, unsigned *frame_drops, unsigned max_values);


### PR DESCRIPTION
### Solved Problem
The RC library has UART configuration and protocol parsing mixed together. This PR allows use of the DSM protocol parser
without the need to configure / use a UART which is needed for the Voxl board specific DSM RC driver.