### PR TITLE
Move Voxl from microdds client to uxrce dds client

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -213,8 +213,8 @@ navigator start
 # This bridge allows raw data packets to be sent over UART to the ESC
 voxl2_io_bridge start
 
-# Start microdds_client for ros2 offboard messages from agent over localhost
-microdds_client start -t udp -h 127.0.0.1 -p 8888
+# Start uxrce_dds_client for ros2 offboard messages from agent over localhost
+uxrce_dds_client start -t udp -h 127.0.0.1 -p 8888
 
 # On M0052 there is only one IMU. So, PX4 needs to
 # publish IMU samples externally for VIO to use.


### PR DESCRIPTION

### Solved Problem
Voxl2 startup script was attempting to start old microdds client instead of new uxrce dds client. This PR moves it to the correct one.