### PR TITLE
Fix up notes boxes for docs

### DIFF
--- a/Tools/msg/generate_msg_docs.py
+++ b/Tools/msg/generate_msg_docs.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # Write out the index.md file
     index_text="""# uORB Message Reference
 
-:::note
+::: info
 This list is [auto-generated](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/msg/generate_msg_docs.py) from the source code.
 :::
 

--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -7,7 +7,7 @@ class MarkdownTablesOutput():
     def __init__(self, groups, board, image_path):
         result = """# Airframes Reference
 
-:::note
+::: info
 **This list is [auto-generated](https://github.com/PX4/PX4-Autopilot/blob/main/Tools/px4airframes/markdownout.py) from the source code** using the build command: `make airframe_metadata`.
 :::
 

--- a/Tools/px4moduledoc/markdownout.py
+++ b/Tools/px4moduledoc/markdownout.py
@@ -19,7 +19,7 @@ The following pages document the PX4 modules, drivers and commands.
 They describe the provided functionality, high-level implementation overview and how
 to use the command-line interface.
 
-:::note
+::: info
 **This is auto-generated from the source code** and contains the most recent modules documentation.
 :::
 

--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -7,11 +7,11 @@ class MarkdownTablesOutput():
         result = (
 """# Parameter Reference
 
-:::note
+::: info
 This documentation was auto-generated from the source code for this PX4 version (using `make parameters_metadata`).
 :::
 
-:::tip
+::: tip
 If a listed parameter is missing from the Firmware see: [Finding/Updating Parameters](../advanced_config/parameters.md#parameter-not-in-firmware).
 :::
 


### PR DESCRIPTION
The new infrastructure uses a different notes format. This just updates from "note" to "info". 