### PR TITLE
uavcan: prevent system crash on stm32h7 when restarting uavcan node

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
+++ b/src/drivers/uavcan/uavcan_drivers/stm32h7/driver/src/uc_stm32h7_can.cpp
@@ -1174,13 +1174,8 @@ int CanDriver::init(const uavcan::uint32_t bitrate, const CanIface::OperatingMod
 
 	UAVCAN_STM32H7_LOG("Bitrate %lu mode %d", static_cast<unsigned long>(bitrate), static_cast<int>(mode));
 
-	static bool initialized_once = false;
 
-	if (!initialized_once) {
-		initialized_once = true;
-		UAVCAN_STM32H7_LOG("First initialization");
-		initOnce();
-	}
+	initOnce();
 
 	/*
 	 * FDCAN1


### PR DESCRIPTION
### Solved Problem
When restarting uavcan on STM32, for example by running `uavcan stop` `uavcan start`, the system crashes.

The issue was introduced with https://github.com/PX4/PX4-Autopilot/pull/20746, and affects 1.14 stable release and current main.

The issue occurs because the can driver is re-initialized when the node is restarted. The previous author noted in a comment that it shouldn't be re-initialized, but accidentally put the init call in the node initialization section of `UavcanNode::Run`. This made it run once per node restart instead of once per system boot.

### Solution
Move driver initialization to `UavcanNode::start`, where the `CanInitHelper` is initialized, and where there is already a check if the can driver has been previously initialized.

Now we can also avoid fetching the bitrate parameter twice.

### Changelog Entry
For release notes:
```
Bugfix: Prevent system crash on stm32 when restarting uavcan node
```

### Test coverage
- Tested on a CubeOrange flight controller

### Context
Crash dump from 1.14 when stopping and starting uavcan:
[fault_2000_01_01_00_02_28.log](https://github.com/PX4/PX4-Autopilot/files/14948090/fault_2000_01_01_00_02_28.log)

