### PR TITLE
Update GZ Bridge CMakeLists.txt to include lawn world in build process

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -92,6 +92,7 @@ if(gz-transport_FOUND)
 		default
 		windy
 		baylands
+  		lawn
 	)
 
 	# find corresponding airframes


### PR DESCRIPTION
Added _lawn_ world to the GZ Bridge make process to allow GZ SITL builds like "```make px4_sitl gz_r1_rover_lawn```"

### Context
This is a follow-up to https://github.com/PX4/PX4-gazebo-models/pull/35 - "_Adding lawn.sdf world to have sky and grassy ground plane for rovers_"

@Jaeyoung-Lim  @dagar  - please take a look.