### PR TITLE
[bug] Remove Gyro/Accel INT16_MAX constraint on clip_limit

### DIFF
--- a/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
+++ b/src/lib/drivers/accelerometer/PX4Accelerometer.cpp
@@ -179,5 +179,5 @@ void PX4Accelerometer::updateFIFO(sensor_accel_fifo_s &sample)
 void PX4Accelerometer::UpdateClipLimit()
 {
 	// 99.9% of potential max
-	_clip_limit = math::constrain((_range / _scale) * 0.999f, 0.f, (float)INT16_MAX);
+	_clip_limit = fabsf(_range / _scale * 0.999f);
 }

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.cpp
@@ -178,5 +178,5 @@ void PX4Gyroscope::updateFIFO(sensor_gyro_fifo_s &sample)
 void PX4Gyroscope::UpdateClipLimit()
 {
 	// 99.9% of potential max
-	_clip_limit = math::constrain((_range / _scale) * 0.999f, 0.f, (float)INT16_MAX);
+	_clip_limit = fabsf(_range / _scale * 0.999f);
 }


### PR DESCRIPTION
The PX4Gyro and PX4Accel classes assume the raw sensor data is `int16_t`. The SCH16T IMU is `int32_t` and 1600bits per deg/s so this presents itself as a bug where the sensors module reports clipping as soon as the raw data exceeds INT16T_MAX.
 
This happens at 65535/1600 = ~41 deg/s as you can see in this log
https://review.px4.io/plot_app?log=080b77bf-2ef8-49fb-878a-e6873b9bb422

This will have to be revisited for the FIFO code once there is a 32bit IMU with a FIFO (the sch16t does not have a FIFO) since the FIFO code in PX4Gyro/PX4Accel also assumes 16bit raw data.