### PR TITLE
Logging updates for VOXL2

### DIFF
--- a/boards/modalai/voxl2/target/voxl-px4-hitl-start
+++ b/boards/modalai/voxl2/target/voxl-px4-hitl-start
@@ -43,13 +43,6 @@ else
     param load
 fi
 
-# Start logging and use timestamps for log files when possible.
-# Add the "-e" option to start logging immediately. Default is
-# to log only when armed. Caution must be used with the "-e" option
-# because if power is removed without stopping the logger gracefully then
-# the log file may be corrupted.
-logger start -e -t -b 200
-
 /bin/sleep 1
 
 # Start all of the processing modules on DSP
@@ -96,6 +89,9 @@ mavlink stream -u 14556 -s GLOBAL_POSITION_INT -r 30
 
 # start the slow normal mode for voxl-mavlink-server to forward to GCS
 mavlink start -x -u 14558 -o 14559 -r 100000 -n lo
+
+# Start logging and use timestamps for log files when possible.
+logger start -t -b 256
 
 /bin/sleep 1
 

--- a/boards/modalai/voxl2/target/voxl-px4-start
+++ b/boards/modalai/voxl2/target/voxl-px4-start
@@ -62,13 +62,6 @@ param select /data/px4/param/parameters
 # Load in all of the parameters that have been saved in the file
 param load
 
-# Start logging and use timestamps for log files when possible.
-# Add the "-e" option to start logging immediately. Default is
-# to log only when armed. Caution must be used with the "-e" option
-# because if power is removed without stopping the logger gracefully then
-# the log file may be corrupted.
-logger start -t
-
 # IMU (accelerometer / gyroscope)
 if [ "$PLATFORM" == "M0104" ]; then
     /bin/echo "Starting IMU driver with rotation 12"
@@ -234,6 +227,14 @@ mavlink stream -u 14556 -s SCALED_PRESSURE -r 10
 
 # start the slow normal mode for voxl-mavlink-server to forward to GCS
 mavlink start -x -u 14558 -o 14559 -r 100000 -n lo
+
+# Start logging and use timestamps for log files when possible.
+# Add the "-e" option to start logging immediately. Default is
+# to log only when armed. Caution must be used with the "-e" option
+# because if power is removed without stopping the logger gracefully then
+# the log file may be corrupted. Rather than using "-e" option it's better
+# to use the SDLOG_MODE to do that.
+logger start -t -b 256
 
 mavlink boot_complete
 

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -316,7 +316,9 @@ void LoggedTopics::add_high_rate_topics()
 	add_topic("vehicle_attitude_setpoint");
 	add_topic("vehicle_rates_setpoint");
 
+	add_topic("esc_status", 5);
 	add_topic("actuator_motors");
+	add_topic("actuator_outputs_debug");
 	add_topic("actuator_servos");
 	add_topic_multi("vehicle_thrust_setpoint", 0, 2);
 	add_topic_multi("vehicle_torque_setpoint", 0, 2);


### PR DESCRIPTION

### Solved Problem

Added high rate esc_status logging to the high rate logging category along with actuator_outputs_debug. Both of these
really help diagnosing odd flight behavior / crashes on VOXL2. Also changed the logger start commands in the VOXL2
standard and HITL startup scripts.
