### PR TITLE
logger: add timesync_status to default logged topics

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -145,6 +145,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("rate_ctrl_status", 200, 2);
 	add_optional_topic_multi("sensor_hygrometer", 500, 4);
 	add_optional_topic_multi("rpm", 200);
+	add_topic_multi("timesync_status", 1000, 3);
 	add_optional_topic_multi("telemetry_status", 1000, 4);
 
 	// EKF multi topics (currently max 9 estimators)


### PR DESCRIPTION
Useful for logging RTT data of MAVLink and uxrce_dds instances.