### PR TITLE
BMP388: Check I2C/SPI bus transfer return code after register read

### DIFF
--- a/src/drivers/barometer/bmp388/bmp388.cpp
+++ b/src/drivers/barometer/bmp388/bmp388.cpp
@@ -68,7 +68,10 @@ BMP388::init()
 		return -EIO;
 	}
 
-	_chip_id = _interface->get_reg(BMP3_CHIP_ID_ADDR);
+	if (_interface->get_reg(BMP3_CHIP_ID_ADDR, &_chip_id) != OK) {
+		PX4_WARN("failed to get chip id");
+		return -EIO;
+	}
 
 	if (_chip_id != BMP388_CHIP_ID && _chip_id != BMP390_CHIP_ID) {
 		PX4_WARN("id of your baro is not: 0x%02x or 0x%02x", BMP388_CHIP_ID, BMP390_CHIP_ID);
@@ -80,7 +83,10 @@ BMP388::init()
 		this->_item_name = "bmp390";
 	}
 
-	_chip_rev_id = _interface->get_reg(BMP3_REV_ID_ADDR);
+	if (_interface->get_reg(BMP3_REV_ID_ADDR, &_chip_rev_id) != OK) {
+		PX4_WARN("failed to get chip rev id");
+		return -EIO;
+	}
 
 	_cal = _interface->get_calibration(BMP3_CALIB_DATA_ADDR);
 
@@ -204,14 +210,22 @@ BMP388::soft_reset()
 	uint8_t status;
 	int     ret;
 
-	status = _interface->get_reg(BMP3_SENS_STATUS_REG_ADDR);
+	ret = _interface->get_reg(BMP3_SENS_STATUS_REG_ADDR, &status);
+
+	if (ret != OK) {
+		return false;
+	}
 
 	if (status & BMP3_CMD_RDY) {
 		ret = _interface->set_reg(BPM3_CMD_SOFT_RESET, BMP3_CMD_ADDR);
 
 		if (ret == OK) {
 			usleep(BMP3_POST_RESET_WAIT_TIME);
-			status = _interface->get_reg(BMP3_ERR_REG_ADDR);
+			ret = _interface->get_reg(BMP3_ERR_REG_ADDR, &status);
+
+			if (ret != OK) {
+				return false;
+			}
 
 			if ((status & BMP3_CMD_ERR) == 0) {
 				result = true;
@@ -269,7 +283,9 @@ BMP388::validate_trimming_param()
 
 	crc = (crc ^ 0xFF);
 
-	stored_crc = _interface->get_reg(BMP3_TRIM_CRC_DATA_ADDR);
+	if (_interface->get_reg(BMP3_TRIM_CRC_DATA_ADDR, &stored_crc) != OK) {
+		return false;
+	}
 
 	return stored_crc == crc;
 }
@@ -404,7 +420,12 @@ BMP388::set_op_mode(uint8_t op_mode)
 	uint8_t op_mode_reg_val;
 	int     ret = OK;
 
-	op_mode_reg_val = _interface->get_reg(BMP3_PWR_CTRL_ADDR);
+	ret = _interface->get_reg(BMP3_PWR_CTRL_ADDR, &op_mode_reg_val);
+
+	if (ret != OK) {
+		return false;
+	}
+
 	last_set_mode = BMP3_GET_BITS(op_mode_reg_val, BMP3_OP_MODE);
 
 	/* Device needs to be put in sleep mode to transition */
@@ -420,7 +441,12 @@ BMP388::set_op_mode(uint8_t op_mode)
 	}
 
 	if (ret == OK) {
-		op_mode_reg_val = _interface->get_reg(BMP3_PWR_CTRL_ADDR);
+		ret = _interface->get_reg(BMP3_PWR_CTRL_ADDR, &op_mode_reg_val);
+
+		if (ret != OK) {
+			return false;
+		}
+
 		op_mode_reg_val = BMP3_SET_BITS(op_mode_reg_val, BMP3_OP_MODE, op_mode);
 		ret = _interface->set_reg(op_mode_reg_val, BMP3_PWR_CTRL_ADDR);
 

--- a/src/drivers/barometer/bmp388/bmp388.h
+++ b/src/drivers/barometer/bmp388/bmp388.h
@@ -292,7 +292,7 @@ public:
 	virtual int init() = 0;
 
 	// read reg value
-	virtual uint8_t get_reg(uint8_t addr) = 0;
+	virtual int get_reg(uint8_t addr, uint8_t *value) = 0;
 
 	// bulk read reg value
 	virtual int get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len) = 0;

--- a/src/drivers/barometer/bmp388/bmp388_i2c.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_i2c.cpp
@@ -49,7 +49,7 @@ public:
 
 	int init();
 
-	uint8_t get_reg(uint8_t addr);
+	int get_reg(uint8_t addr, uint8_t *value);
 	int get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len);
 	int set_reg(uint8_t value, uint8_t addr);
 	calibration_s *get_calibration(uint8_t addr);
@@ -78,12 +78,10 @@ int BMP388_I2C::init()
 	return I2C::init();
 }
 
-uint8_t BMP388_I2C::get_reg(uint8_t addr)
+int BMP388_I2C::get_reg(uint8_t addr, uint8_t *value)
 {
-	uint8_t cmd[2] = { (uint8_t)(addr), 0};
-	transfer(&cmd[0], 1, &cmd[1], 1);
-
-	return cmd[1];
+	const uint8_t cmd = (uint8_t)(addr);
+	return transfer(&cmd, sizeof(cmd), value, 1);
 }
 
 int BMP388_I2C::get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len)

--- a/src/drivers/barometer/bmp388/bmp388_spi.cpp
+++ b/src/drivers/barometer/bmp388/bmp388_spi.cpp
@@ -66,7 +66,7 @@ public:
 
 	int init();
 
-	uint8_t get_reg(uint8_t addr);
+	int get_reg(uint8_t addr, uint8_t *value);
 	int get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len);
 	int set_reg(uint8_t value, uint8_t addr);
 	calibration_s *get_calibration(uint8_t addr);
@@ -95,12 +95,16 @@ int BMP388_SPI::init()
 	return SPI::init();
 };
 
-uint8_t BMP388_SPI::get_reg(uint8_t addr)
+int BMP388_SPI::get_reg(uint8_t addr, uint8_t *value)
 {
 	uint8_t cmd[2] = { (uint8_t)(addr | DIR_READ), 0}; //set MSB bit
-	transfer(&cmd[0], &cmd[0], 2);
+	int ret = transfer(&cmd[0], &cmd[0], 2);
 
-	return cmd[1];
+	if (ret == OK) {
+		*value = cmd[1];
+	}
+
+	return ret;
 }
 
 int BMP388_SPI::get_reg_buf(uint8_t addr, uint8_t *buf, uint8_t len)


### PR DESCRIPTION
### Solved Problem
BMP388 sensor driver does not check the return value of I2C/SPI bus transfer function, when a single register is read. This could lead to the situation where the driver deactivates its temperature and pressure measurements.

`PWR_CTRL` register value is read in `BMP388::set_op_mode()`. If the read operation fails, the bus driver returns ‘0’ as register value. Then the function sets power mode bits and writes the value back to the register, which disables pressure and temperature sensors (bits 0 & 1).

### Test coverage
Tested with custom risc-v based board.
