### PR TITLE
HomePosition: Home position only changes on ground after minimum horizontal and vertical displacement

### DIFF
--- a/src/modules/commander/HomePosition.cpp
+++ b/src/modules/commander/HomePosition.cpp
@@ -34,6 +34,8 @@
 
 #include "HomePosition.hpp"
 
+#include <math.h>
+
 #include <lib/geo/geo.h>
 #include "commander_helper.h"
 
@@ -83,7 +85,8 @@ bool HomePosition::hasMovedFromCurrentHomeLocation()
 		}
 	}
 
-	return (home_dist_xy > eph * 2.f) || (home_dist_z > epv * 2.f);
+	return (home_dist_xy > fmaxf(eph * 2.f, kMinHomePositionChangeEPH))
+	       || (home_dist_z > fmaxf(epv * 2.f, kMinHomePositionChangeEPV));
 }
 
 bool HomePosition::setHomePosition(bool force)

--- a/src/modules/commander/HomePosition.hpp
+++ b/src/modules/commander/HomePosition.hpp
@@ -45,6 +45,8 @@ static constexpr int kHomePositionGPSRequiredFixType = 2;
 static constexpr float kHomePositionGPSRequiredEPH = 5.f;
 static constexpr float kHomePositionGPSRequiredEPV = 10.f;
 static constexpr float kHomePositionGPSRequiredEVH = 1.f;
+static constexpr float kMinHomePositionChangeEPH = 1.f;
+static constexpr float kMinHomePositionChangeEPV = 1.5f;
 
 class HomePosition
 {


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When the vehicle is not yet armed and on the ground, the home position is allowed to change when it is detected that the vehicle position has changed. When the EKF estimator is initialized the home position is changed if the local position change is higher than the estimated deviations in eph and epv. Those can be pretty small number ( <15cm in my tests) although the altitude might change more. This leads to a lot of new home position changes before taking off. However those changes are unnecessary, as the home position is set again when taking off. Changing the home position that often can negatively influence other modules depending on the home position (as the e.g. the mission validity).

### Solution
- Add a minimum horizontal distance of 1m needed horizontally and 1.5m vertically before changing the home position.
- Refactor ...

### Changelog Entry
For release notes:
```
Feature: Home position only changes on ground after minimum horizontal and vertical displacement.

```

### Test coverage
- simulation tests: using make px4_sitl gazebo-classic_standard_vtol and observing the home_position uOrb topic

