### PR TITLE
ekf2: consider drag fusion as air data aiding (allowing wind dead reckoning)

### DIFF
--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -105,7 +105,7 @@ TEST_F(EkfGpsTest, gpsFixLoss)
 	_sensor_simulator._gps.setFixType(0);
 
 	// THEN: after dead-reconing for a couple of seconds, the local position gets invalidated
-	_sensor_simulator.runSeconds(5);
+	_sensor_simulator.runSeconds(6);
 	EXPECT_TRUE(_ekf->control_status_flags().inertial_dead_reckoning);
 	EXPECT_FALSE(_ekf->local_position_is_valid());
 


### PR DESCRIPTION
Now that we're no longer throwing away non-wind drag fusion Kalman gains it can be used to extend dead reckoning time because it constrains the velocity estimate.