### PR TITLE
Auto: No YAW operation

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.hpp
@@ -81,6 +81,15 @@ enum class State {
 	none /**< Vehicle is in normal tracking mode from triplet previous to triplet target */
 };
 
+enum class yaw_mode : int32_t {
+	towards_waypoint = 0,
+	towards_home = 1,
+	away_from_home = 2,
+	along_trajectory = 3,
+	towards_waypoint_yaw_first = 4,
+	yaw_fixed = 5,
+};
+
 class FlightTaskAuto : public FlightTask
 {
 public:

--- a/src/modules/mc_pos_control/multicopter_autonomous_params.c
+++ b/src/modules/mc_pos_control/multicopter_autonomous_params.c
@@ -172,6 +172,7 @@ PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_ACC, 60.f);
  * @value 2 away from home
  * @value 3 along trajectory
  * @value 4 towards waypoint (yaw first)
+ * @value 5 yaw fixed
  * @group Mission
  */
 PARAM_DEFINE_INT32(MPC_YAW_MODE, 0);


### PR DESCRIPTION
re commit #20888 

Solved Problem

I am developing a multi-rotor machine for agricultural use.
This multirotor machine sprays pesticides.
The nose direction of this multirotor machine is fixed.
I specified "along trajectory" in MPC_YAW_MODE.

I set the Along trajectory to MPC_YAW_MODE.
I determined the direction of the YAW before starting the mission and started the mission.
Once I started the mission, the YAW rotated in the direction of the WP.

I found that I set NAN as a variable to enter the YAW operation.

I need a setting where the nose direction does not change until specified.

Solution

I will change the variable to not set a value to match the other process.

Alternatives
None

Test coverage

AFTER

![Screenshot from 2024-04-21 08-57-24](https://github.com/PX4/PX4-Autopilot/assets/646194/2856a29e-254d-4672-b246-80ada3a725bf)

![Screenshot from 2024-04-21 08-57-31](https://github.com/PX4/PX4-Autopilot/assets/646194/4e106f5c-60a1-4679-b7a1-2cac09859767)

![Screenshot from 2024-04-21 08-57-41](https://github.com/PX4/PX4-Autopilot/assets/646194/f2286696-1c18-4fcf-9c42-e2ef2a706356)