### PR TITLE
commander: Use PX4_STACK_ADJUSTED to increase stack for 64-bit targets

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2634,7 +2634,7 @@ int Commander::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("commander",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_DEFAULT + 40,
-				      3250,
+				      PX4_STACK_ADJUSTED(3250),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 


### PR DESCRIPTION
The commander stack gets small on one of our 64-bit targets; using the PX4_STACK_ADJUSTED solves this without affecting any of the mainstream targets.