### PR TITLE
ekf optical flow only compensate to a lower value

### DIFF
--- a/src/modules/ekf2/EKF/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/optical_flow_control.cpp
@@ -62,6 +62,15 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 			calcOptFlowBodyRateComp(imu_delayed);
 			_flow_rate_compensated = _flow_sample_delayed.flow_rate - _flow_sample_delayed.gyro_rate.xy();
 
+			// Only compensate to a lower value, don't allow the rate to increase
+			if (abs(_flow_rate_compensated(0)) > abs(_flow_sample_delayed.flow_rate(0))) {
+				_flow_rate_compensated(0) = _flow_sample_delayed.flow_rate(0);
+			}
+
+			if (abs(_flow_rate_compensated(1)) > abs(_flow_sample_delayed.flow_rate(1))) {
+				_flow_rate_compensated(1) = _flow_sample_delayed.flow_rate(1);
+			}
+
 		} else {
 			// don't use this flow data and wait for the next data to arrive
 			_flow_data_ready = false;


### PR DESCRIPTION
This PR is an attempt to remove fake velocity oscillations for the optical flow data. Where there is 0 or little pixel flow, the gyro noise oscillations dominate the optical flow velocity output.

Continuation of https://github.com/PX4/PX4-Autopilot/pull/22095

@dirksavage88 

Current behavior in main.
![image](https://github.com/PX4/PX4-Autopilot/assets/2019539/fcde1c30-0412-498d-9f7c-a5082df74e20)

Current behavior in main.
![image](https://github.com/PX4/PX4-Autopilot/assets/2019539/d50fd72e-1047-4053-90ab-f12d76c202c1)

