### PR TITLE
PM Selector Auterion: remove INA226_SHUNT value reset (skynode only)

### DIFF
--- a/src/drivers/power_monitor/pm_selector_auterion/PowerMonitorSelectorAuterion.cpp
+++ b/src/drivers/power_monitor/pm_selector_auterion/PowerMonitorSelectorAuterion.cpp
@@ -87,14 +87,6 @@ void PowerMonitorSelectorAuterion::Run()
 			int ret_val = ina226_probe(i);
 
 			if (ret_val == PX4_OK) {
-
-				float current_shunt_value = 0.0f;
-				param_get(param_find("INA226_SHUNT"), &current_shunt_value);
-
-				if (fabsf(current_shunt_value - _sensors[i].shunt_value) > FLT_EPSILON) {
-					param_set(param_find("INA226_SHUNT"), &(_sensors[i].shunt_value));
-				}
-
 				char bus_number[4] = {0};
 				itoa(_sensors[i].bus_number, bus_number, 10);
 				const char *start_argv[] {


### PR DESCRIPTION
### Solved Problem
PowerMonitorSelectorAuterion did not allow to set different INA226_SHUNT values. We recently have seen multiple instances where a different value was required though for  providing a correct current reading.
Since the default value for this param is already set to the one we by default expect as well, I deem it okay to just remove that part of the code.

### Solution
- remove the param reset logic

### Test coverage
- tested on a Skynode