### PR TITLE
VSCode: add EditorConfig extension to recommended and devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 	"extensions": [
 		"chiehyu.vscode-astyle",
 		"dan-c-underwood.arm",
+		"editorconfig.editorconfig",
 		"fredericbonnet.cmake-test-adapter",
 		"github.vscode-pull-request-github",
 		"marus25.cortex-debug",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
         "chiehyu.vscode-astyle",
         "dan-c-underwood.arm",
+        "editorconfig.editorconfig",
         "fredericbonnet.cmake-test-adapter",
         "github.vscode-pull-request-github",
         "marus25.cortex-debug",


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The EditorConfig extension (`editorconfig.editorconfig`) wasn't recommended by VSCode.

Fixes \/

### Solution
- Add EditorConfig (`editorconfig.editorconfig`) extension to `.vscode/extensions.json` and `.devcontainer/devcontainer.json`

### Changelog Entry
For release notes:
```
\/
```

### Alternatives
\/

### Test coverage
\/

### Context
\/