### PR TITLE
imu consistency: don't scale param threshold

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/imuConsistencyCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/imuConsistencyCheck.cpp
@@ -48,13 +48,7 @@ void ImuConsistencyChecks::checkAndReport(const Context &context, Report &report
 
 			const float accel_inconsistency_m_s_s = imu.accel_inconsistency_m_s_s[i];
 
-			NavModes required_groups = NavModes::None;
-
 			if (accel_inconsistency_m_s_s > _param_com_arm_imu_acc.get()) {
-				required_groups = NavModes::All;
-			}
-
-			if (accel_inconsistency_m_s_s > _param_com_arm_imu_acc.get() * 0.8f) {
 				/* EVENT
 				 * @description
 				 * Check the calibration.
@@ -66,7 +60,7 @@ void ImuConsistencyChecks::checkAndReport(const Context &context, Report &report
 				 * This check can be configured via <param>COM_ARM_IMU_ACC</param> parameter.
 				 * </profile>
 				 */
-				reporter.armingCheckFailure<uint8_t, float, float>(required_groups, health_component_t::accel,
+				reporter.armingCheckFailure<uint8_t, float, float>(NavModes::All, health_component_t::accel,
 						events::ID("check_imu_accel_inconsistent"),
 						events::Log::Warning, "Accel {1} inconsistent", i, accel_inconsistency_m_s_s, _param_com_arm_imu_acc.get());
 
@@ -85,13 +79,7 @@ void ImuConsistencyChecks::checkAndReport(const Context &context, Report &report
 
 			const float gyro_inconsistency_rad_s = imu.gyro_inconsistency_rad_s[i];
 
-			NavModes required_groups = NavModes::None;
-
 			if (gyro_inconsistency_rad_s > _param_com_arm_imu_gyr.get()) {
-				required_groups = NavModes::All;
-			}
-
-			if (gyro_inconsistency_rad_s > _param_com_arm_imu_gyr.get() * 0.5f) {
 				/* EVENT
 				 * @description
 				 * Check the calibration.
@@ -103,7 +91,7 @@ void ImuConsistencyChecks::checkAndReport(const Context &context, Report &report
 				 * This check can be configured via <param>COM_ARM_IMU_GYR</param> parameter.
 				 * </profile>
 				 */
-				reporter.armingCheckFailure<uint8_t, float, float>(required_groups, health_component_t::gyro,
+				reporter.armingCheckFailure<uint8_t, float, float>(NavModes::All, health_component_t::gyro,
 						events::ID("check_imu_gyro_inconsistent"),
 						events::Log::Warning, "Gyro {1} inconsistent", i, gyro_inconsistency_rad_s, _param_com_arm_imu_gyr.get());
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Accel/gyro consistency mavlink preflight failure triggers below threshold.
In the past we had 2 different failures (see [here](https://github.com/PX4/PX4-Autopilot/blob/437b6b98448ff6587a98a4396a02b1223552f325/src/modules/commander/Arming/PreFlightCheck/checks/imuConsistencyCheck.cpp#L69-L87)):
- \> 0.8 * threshold: "Preflight advice" (mavlink log info)
- \> threshold: "Preflight fail" (mavling log critical)

Now we have:
- \> 0.8 * threshold: "Preflight fail" (mavling log critical)

### Solution
Have a simpler check:
- \> threshold: "Preflight fail" (mavling log critical)

No magic number. 
I don't think that the warning at 0.8 * threshold is worth it.