### PR TITLE
LogMessage.msg - expand out descriptive string

### DIFF
--- a/msg/LogMessage.msg
+++ b/msg/LogMessage.msg
@@ -1,4 +1,4 @@
-# A logging message, output with PX4_{WARN,ERR,INFO}
+# A logging message, output with PX4_WARN, PX4_ERR, PX4_INFO
 
 uint64 timestamp		# time since system start (microseconds)
 


### PR DESCRIPTION
The use of `{` in the descriptive string `PX4_{WARN,ERR,INFO}` looks like a macro to the generated docs, and since that macro is not defined, vitepress doesn't render the page.

The easiest fix is to just expand this out. If needed in future we could fix the docs generation.