### PR TITLE
Fixed-wing: fix Altitude mode without valid global z reference (e.g. no GPS)

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2304,7 +2304,7 @@ FixedwingPositionControl::Run()
 			_reference_altitude = 0.f;
 		}
 
-		_current_altitude = -_local_pos.z + _local_pos.ref_alt; // Altitude AMSL in meters
+		_current_altitude = -_local_pos.z + _reference_altitude; // Altitude AMSL in meters
 
 		// handle estimator reset events. we only adjust setpoins for manual modes
 		if (_control_mode.flag_control_manual_enabled) {


### PR DESCRIPTION
### Solved Problem
In case of no global position estimate, the local_position.ref_alt is nan, which is directly passed into TECS and results in the output being nan as well. 

One can for example end up in this situation when one switches into Altitude mode without having a GPS sensor installed. The outcome is having all attitude setpoints at nan.

### Solution
Use `_current_altitude`, which in turn already has a check for valid reference. I don't know why that wasn't done in the first place (likely was just missed). 

### Changelog Entry
For release notes:
```
Bugfix: Fixed-wing: fix Altitude mode without valid global z reference (e.g. no GPS)
```

### Alternatives
We need to add protections against this kind of invalid inputs into TECS. At very lest it has to throw an error.

### Test coverage
SITL tested (set EKF2_GPS_CTRL to 0, restart simulation, takeoff in Altitude mode, transition to FW, re-enable GPS fusion). 
When GPS fusion starts and thus the z reference becomes valid, there is a small jump on the outputs as tecs.handle_alt_step() resets the height rate setpoint is reset to the current height rate.
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/71d56ff9-f295-47dc-90ae-1acfcc3fa77a)



### Context

