### PR TITLE
mavlink: Add MAVLINK_COMM_6 related

### DIFF
--- a/src/modules/mavlink/mavlink_bridge_header.h
+++ b/src/modules/mavlink/mavlink_bridge_header.h
@@ -56,9 +56,10 @@
 #define MAVLINK_GET_CHANNEL_STATUS mavlink_get_channel_status
 
 #if !defined(CONSTRAINED_MEMORY)
-# define MAVLINK_COMM_NUM_BUFFERS 6
+# define MAVLINK_COMM_NUM_BUFFERS 7
 # define MAVLINK_COMM_4 static_cast<mavlink_channel_t>(4)
 # define MAVLINK_COMM_5 static_cast<mavlink_channel_t>(5)
+# define MAVLINK_COMM_6 static_cast<mavlink_channel_t>(6)
 #endif
 
 #include <mavlink_types.h>

--- a/src/modules/mavlink/mavlink_command_sender.h
+++ b/src/modules/mavlink/mavlink_command_sender.h
@@ -108,8 +108,8 @@ private:
 		// -1: channel did not request this command to be sent, -2: channel got an ack for this command
 #if MAVLINK_COMM_NUM_BUFFERS == 4
 		int8_t num_sent_per_channel[MAVLINK_COMM_NUM_BUFFERS] {-1, -1, -1, -1};
-#elif MAVLINK_COMM_NUM_BUFFERS == 6
-		int8_t num_sent_per_channel[MAVLINK_COMM_NUM_BUFFERS] {-1, -1, -1, -1, -1, -1};
+#elif MAVLINK_COMM_NUM_BUFFERS == 7
+		int8_t num_sent_per_channel[MAVLINK_COMM_NUM_BUFFERS] {-1, -1, -1, -1, -1, -1, -1};
 #else
 # error Unknown number of MAVLINK_COMM_NUM_BUFFERS
 #endif


### PR DESCRIPTION
### Solved Problem

MAVLINK_COMM_6 is not enabled.

### Solution

Add the definition of MAVLINK_COMM_6.
Change MAVLINK_COMM_NUM_BUFFERS from 6 to 7.

### Changelog Entry

None

### Alternatives

None

### Test coverage

None

### Context

None
