### PR TITLE
fix mavlink: cmd_logging_{start,stop}_acknowledgement flags were not reset

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -709,7 +709,7 @@ private:
 
 	void handleCommands();
 
-	void handleAndGetCurrentCommandAck(bool &logging_start_ack, bool &logging_stop_ack);
+	void handleAndGetCurrentCommandAck();
 
 	void handleStatus();
 


### PR DESCRIPTION
Regression from https://github.com/PX4/PX4-Autopilot/pull/23043

Also avoids a race condition by making sure the command ack is handled before sending out the mavlink message (in case an external component reacts immediately to the mavlink message).