### PR TITLE
drivers: adis16507 reschedule reset after failed self test

### DIFF
--- a/src/drivers/imu/analog_devices/adis16507/ADIS16507.cpp
+++ b/src/drivers/imu/analog_devices/adis16507/ADIS16507.cpp
@@ -172,7 +172,9 @@ void ADIS16507::RunImpl()
 			const uint16_t DIAG_STAT = RegisterRead(Register::DIAG_STAT);
 
 			if (DIAG_STAT != 0) {
-				PX4_ERR("DIAG_STAT: %#X", DIAG_STAT);
+				PX4_ERR("self test failed, resetting. DIAG_STAT: %#X", DIAG_STAT);
+				_state = STATE::RESET;
+				ScheduleDelayed(100_ms);
 
 			} else {
 				PX4_DEBUG("self test passed");

--- a/src/drivers/imu/analog_devices/adis16507/ADIS16507.cpp
+++ b/src/drivers/imu/analog_devices/adis16507/ADIS16507.cpp
@@ -174,7 +174,7 @@ void ADIS16507::RunImpl()
 			if (DIAG_STAT != 0) {
 				PX4_ERR("self test failed, resetting. DIAG_STAT: %#X", DIAG_STAT);
 				_state = STATE::RESET;
-				ScheduleDelayed(100_ms);
+				ScheduleDelayed(3_s);
 
 			} else {
 				PX4_DEBUG("self test passed");


### PR DESCRIPTION
Found a sensor where the self test sometimes fails on boot. If the driver goes back through the rest sequence, it will pass.