### PR TITLE
Quadchute: Fixed sign for handling altitude resets

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -324,7 +324,7 @@ void VtolType::handleEkfResets()
 		_altitude_reset_counter = _local_pos->z_reset_counter;
 
 		if (PX4_ISFINITE(_quadchute_ref_alt)) {
-			_quadchute_ref_alt += _local_pos->delta_z;
+			_quadchute_ref_alt -= _local_pos->delta_z;
 		}
 
 	}


### PR DESCRIPTION
Local position and quadchute reference altitude have opposite signs, so the delta local position needs to be subtracted rather than added.