### PR TITLE
mRo Control Zero Classic: Enable GPS2 port by default

### DIFF
--- a/boards/mro/ctrl-zero-classic/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-classic/init/rc.board_defaults
@@ -6,4 +6,5 @@
 param set-default BAT1_V_DIV 10.1
 param set-default BAT1_A_PER_V 17
 
+param set-default GPS_2_CONFIG 202
 param set-default TEL_FRSKY_CONFIG 103


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
While working with this board I encountered that defining GPS2 in the serial port map does not affect the generated params (`generated_params/serial_params.c`). This board needs such definition because the port is intended for said purpose by design. 

``` c
/**
 * Serial Configuration for Secondary GPS
 *
 * Configure on which serial port to run Secondary GPS.
 *
 * 
 *
 * @value 0 Disabled
 * @value 201 GPS 1
 * @value 202 GPS 2
 * @value 101 TELEM 1
 * @value 102 TELEM 2
 * @value 103 TELEM 3
 * @value 104 TELEM/SERIAL 4
 * @group GPS
 * @reboot_required true
 */
PARAM_DEFINE_INT32(GPS_2_CONFIG, 0);
```

### Solution
- Assigned GPS_2_CONFIG to GPS2 

### Alternatives
We could also consider this as a temporary workaround and modify the generation of parameters that assigns `202` to `GPS_2_CONFIG` whenever `CONFIG_BOARD_SERIAL_GPS2` is defined.

### Context
![Control Zero Classic](https://cdn11.bigcommerce.com/s-a49cczb9po/images/stencil/640w/products/208/392/M10048D-2__49560.1692993963.jpg?c=1)
