### PR TITLE
check if bson document size is set to zero and set to decoded size

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -123,6 +123,13 @@ else
 		set PARAM_FILE /fs/mtd_params
 	fi
 
+	# Check if /fs/mtd_params is a valid BSON file
+	if ! bsondump docsize /fs/mtd_caldata
+	then
+		echo "New /fs/mtd_caldata size is:"
+		bsondump docsize /fs/mtd_caldata
+	fi
+
 	#
 	# Load parameters.
 	#

--- a/src/systemcmds/bsondump/bsondump.cpp
+++ b/src/systemcmds/bsondump/bsondump.cpp
@@ -148,7 +148,7 @@ extern "C" __EXPORT int bsondump_main(int argc, char *argv[])
 		return -1;
 	}
 
-	char *command = argv[1];
+	const char *command = argv[1];
 	char *file_name = argv[3];
 
 	if (strcmp(command, "docsize") == 0) {

--- a/src/systemcmds/bsondump/bsondump.cpp
+++ b/src/systemcmds/bsondump/bsondump.cpp
@@ -37,6 +37,7 @@
 
 #include <lib/tinybson/tinybson.h>
 #include <sys/stat.h>
+#include <libgen.h>
 
 #include <fcntl.h>
 
@@ -215,6 +216,17 @@ extern "C" __EXPORT int bsondump_main(int argc, char *argv[])
 			// Modify the first 4 bytes with the correct decoded size
 			uint32_t corrected_size = decoder.total_decoded_size;
 			memcpy(buffer, &corrected_size, sizeof(corrected_size));
+
+			char *dir_path = strdup(temp_path);
+			char *dir = dirname(dir_path);
+
+			struct stat st2 = {0};
+
+			if (stat(dir, &st2) == -1) {
+				mkdir(dir, 0777);
+			}
+
+			free(dir_path);
 
 			int temp_fd = open(temp_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 

--- a/src/systemcmds/bsondump/bsondump.cpp
+++ b/src/systemcmds/bsondump/bsondump.cpp
@@ -102,44 +102,6 @@ bson_docsize_callback(bson_decoder_t decoder, bson_node_t node)
 	return 1;
 }
 
-int copy_file(const char *src_path, const char *dst_path)
-{
-	int src_fd = open(src_path, O_RDONLY);
-	int dst_fd = open(dst_path, O_WRONLY | O_TRUNC);
-
-	if (src_fd == -1 || dst_fd == -1) {
-		perror("Failed to open files for copying");
-
-		if (src_fd != -1) { close(src_fd); }
-
-		if (dst_fd != -1) { close(dst_fd); }
-
-		return -1;
-	}
-
-	char buffer[1024];
-	ssize_t bytes_read;
-
-	while ((bytes_read = read(src_fd, buffer, sizeof(buffer))) > 0) {
-		if (write(dst_fd, buffer, bytes_read) != bytes_read) {
-			perror("Failed to copy file");
-			close(src_fd);
-			close(dst_fd);
-			return -1;
-		}
-	}
-
-	close(src_fd);
-	close(dst_fd);
-
-	if (bytes_read == -1) {
-		perror("Error reading from source file");
-		return -1;
-	}
-
-	return 0;
-}
-
 extern "C" __EXPORT int bsondump_main(int argc, char *argv[])
 {
 

--- a/src/systemcmds/bsondump/bsondump.cpp
+++ b/src/systemcmds/bsondump/bsondump.cpp
@@ -36,19 +36,27 @@
 #include <px4_platform_common/module.h>
 
 #include <lib/tinybson/tinybson.h>
+#include <sys/stat.h>
 
 #include <fcntl.h>
 
-static void print_usage(const char *reason = nullptr)
+static void print_usage(const char *reason = nullptr, const char *command = nullptr)
 {
 	if (reason) {
 		PX4_ERR("%s", reason);
 	}
 
-	PRINT_MODULE_DESCRIPTION("read BSON from a file and print in human form");
+	PRINT_MODULE_DESCRIPTION("Utility to read BSON from a file and print or output document size.");
 
-	PRINT_MODULE_USAGE_NAME_SIMPLE("bsondump", "command");
-	PRINT_MODULE_USAGE_ARG("<file>", "File name", false);
+	if (command == nullptr || strcmp(command, "docsize") == 0) {
+		PRINT_MODULE_USAGE_NAME_SIMPLE("bsondump docsize", "command");
+		PRINT_MODULE_USAGE_ARG("<file>", "The BSON file to decode for document size.", false);
+	}
+
+	if (command == nullptr) {
+		PRINT_MODULE_USAGE_NAME_SIMPLE("bsondump", "command");
+		PRINT_MODULE_USAGE_ARG("<file>", "The BSON file to decode and print.", false);
+	}
 }
 
 static int bson_print_callback(bson_decoder_t decoder, bson_node_t node)
@@ -82,58 +90,213 @@ static int bson_print_callback(bson_decoder_t decoder, bson_node_t node)
 	return -1;
 }
 
+static int
+bson_docsize_callback(bson_decoder_t decoder, bson_node_t node)
+{
+
+	if (node->type == BSON_EOO) {
+		PX4_DEBUG("end of parameters");
+		return 0;
+	}
+
+	return 1;
+}
+
+int copy_file(const char *src_path, const char *dst_path)
+{
+	int src_fd = open(src_path, O_RDONLY);
+	int dst_fd = open(dst_path, O_WRONLY | O_TRUNC);
+
+	if (src_fd == -1 || dst_fd == -1) {
+		perror("Failed to open files for copying");
+
+		if (src_fd != -1) { close(src_fd); }
+
+		if (dst_fd != -1) { close(dst_fd); }
+
+		return -1;
+	}
+
+	char buffer[1024];
+	ssize_t bytes_read;
+
+	while ((bytes_read = read(src_fd, buffer, sizeof(buffer))) > 0) {
+		if (write(dst_fd, buffer, bytes_read) != bytes_read) {
+			perror("Failed to copy file");
+			close(src_fd);
+			close(dst_fd);
+			return -1;
+		}
+	}
+
+	close(src_fd);
+	close(dst_fd);
+
+	if (bytes_read == -1) {
+		perror("Error reading from source file");
+		return -1;
+	}
+
+	return 0;
+}
+
 extern "C" __EXPORT int bsondump_main(int argc, char *argv[])
 {
-	if (argc != 2) {
-		print_usage();
+	if (argc < 2) {
+		print_usage("Invalid number of arguments.");
+		return -1;
+	}
+
+	char *command = argv[1];
+	char *file_name = argv[3];
+
+	if (strcmp(command, "docsize") == 0) {
+		if (argc != 3) {
+			print_usage("Usage: bsondump docsize <file>", "docsize");
+			return -1;
+		}
+
+		file_name = argv[2];
+		int source_fd = open(file_name, O_RDONLY);
+
+		if (source_fd < 0) {
+			PX4_ERR("open '%s' failed (%i)", file_name, errno);
+			return 1;
+		}
+
+		bson_decoder_s decoder{};
+		int result = -1;
+
+		if (bson_decoder_init_file(&decoder, source_fd, bson_docsize_callback) == 0) {
+
+			do {
+				result = bson_decoder_next(&decoder);
+
+			} while (result > 0);
+
+			PX4_INFO("DECODED_SIZE:%" PRId32 " SAVED_SIZE:%" PRId32 "\n",
+				 decoder.total_decoded_size, decoder.total_document_size);
+		}
+
+		close(source_fd);
+
+		if (decoder.total_decoded_size != decoder.total_document_size && decoder.total_document_size == 0
+		    && strstr(file_name, "mtd_caldata") != NULL) {
+
+			PX4_WARN("Mismatch in BSON sizes and saved size is zero. Setting document size to decoded size.");
+
+			const char *source_path = "/fs/mtd_caldata";
+			const char *temp_path = "/fs/microsd/tmp/mtd_caldata";
+
+			source_fd = open(source_path, O_RDONLY);
+
+			if (source_fd == -1) {
+				perror("Failed to re-open source file for reading");
+				return -1;
+			}
+
+			struct stat st;
+
+			if (fstat(source_fd, &st) != 0) {
+				perror("Failed to stat source file");
+				close(source_fd);
+				return -1;
+			}
+
+			char *buffer = new char[st.st_size];
+
+			if (read(source_fd, buffer, st.st_size) != st.st_size) {
+				perror("Failed to read source file");
+				delete[] buffer;
+				close(source_fd);
+				return -1;
+			}
+
+			// Modify the first 4 bytes with the correct decoded size
+			uint32_t corrected_size = decoder.total_decoded_size;
+			memcpy(buffer, &corrected_size, sizeof(corrected_size));
+
+			int temp_fd = open(temp_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+
+			if (temp_fd == -1) {
+				perror("Failed to open temp file");
+				delete[] buffer;
+				return -1;
+			}
+
+			if (write(temp_fd, buffer, st.st_size) != st.st_size) {
+				perror("Failed to write to temp file");
+				delete[] buffer;
+				close(temp_fd);
+				return -1;
+			}
+
+			close(source_fd);
+			close(temp_fd);
+			delete[] buffer;
+
+			if (copy_file(temp_path, source_path) != 0) {
+				perror("Failed to copy temp file to source file");
+				return -1;
+			}
+
+			if (remove(temp_path) != 0) {
+				perror("Failed to remove temp file");
+				return -1;
+			}
+
+			return 1;
+		}
+
+		return 0;
+
 
 	} else {
-		char *file_name = argv[1];
 
-		if (file_name) {
-			int fd = open(file_name, O_RDONLY);
+		file_name = argv[1];
+		int fd = open(file_name, O_RDONLY);
 
-			if (fd < 0) {
-				PX4_ERR("open '%s' failed (%i)", file_name, errno);
-				return 1;
+		if (fd < 0) {
+			PX4_ERR("open '%s' failed (%i)", file_name, errno);
+			return 1;
 
-			} else {
-				PX4_INFO_RAW("[bsondump] reading from %s\n", file_name);
+		} else {
+			PX4_INFO_RAW("[bsondump] reading from %s\n", file_name);
 
-				bson_decoder_s decoder{};
+			bson_decoder_s decoder{};
 
-				if (bson_decoder_init_file(&decoder, fd, bson_print_callback) == 0) {
-					PX4_INFO_RAW("BSON document size %" PRId32 "\n", decoder.total_document_size);
+			if (bson_decoder_init_file(&decoder, fd, bson_print_callback) == 0) {
+				PX4_INFO_RAW("BSON document size %" PRId32 "\n", decoder.total_document_size);
 
-					int result = -1;
+				int result = -1;
 
-					do {
-						result = bson_decoder_next(&decoder);
+				do {
+					result = bson_decoder_next(&decoder);
 
-					} while (result > 0);
+				} while (result > 0);
 
-					close(fd);
+				close(fd);
 
-					if (result == 0) {
-						PX4_INFO_RAW("BSON decoded %" PRId32 " bytes (double:%" PRIu16 ", string:%" PRIu16 ", bin:%" PRIu16 ", bool:%" PRIu16
-							     ", int32:%" PRIu16 ", int64:%" PRIu16 ")\n",
-							     decoder.total_decoded_size,
-							     decoder.count_node_double, decoder.count_node_string, decoder.count_node_bindata, decoder.count_node_bool,
-							     decoder.count_node_int32, decoder.count_node_int64);
+				if (result == 0) {
+					PX4_INFO_RAW("BSON decoded %" PRId32 " bytes (double:%" PRIu16 ", string:%" PRIu16 ", bin:%" PRIu16 ", bool:%" PRIu16
+						     ", int32:%" PRIu16 ", int64:%" PRIu16 ")\n",
+						     decoder.total_decoded_size,
+						     decoder.count_node_double, decoder.count_node_string, decoder.count_node_bindata, decoder.count_node_bool,
+						     decoder.count_node_int32, decoder.count_node_int64);
 
-						return 0;
+					return 0;
 
-					} else if (result == -ENODATA) {
-						PX4_WARN("no data");
-						return -1;
+				} else if (result == -ENODATA) {
+					PX4_WARN("no data");
+					return -1;
 
-					} else {
-						PX4_ERR("failed (%d)", result);
-						return -1;
-					}
+				} else {
+					PX4_ERR("failed (%d)", result);
+					return -1;
 				}
 			}
 		}
+
 	}
 
 	return -1;


### PR DESCRIPTION
```nsh> dmesg
ERROR [parameters] BSON document size (0) doesn't match bytes decoded (984)
ERROR [parameters] BSON document size (0) doesn't match bytes decoded (984)
ERROR [parameters] BSON document size (0) doesn't match bytes decoded (984)
ERROR [param] importing from '/fs/mtd_caldata' failed (-1)
INFO  [param] selected parameter default file /fs/mtd_params
INFO  [param] importing from '/fs/mtd_params'
INFO  [parameters] BSON document size 1052 bytes, decoded 1052 bytes (INT32:25, FLOAT:25)
INFO  [param] selected parameter backup file /fs/microsd/parameters_backup.bson
Board architecture defaults: /etc/init.d/rc.board_arch_defaults
...
INFO  [logger] Opened full log file: /fs/microsd/log/2024-05-02/08_49_46.ulg
...

nsh> bsondump /fs/mtd_caldata
[bsondump] reading from /fs/mtd_caldata
BSON document size 0
BSON_INT32:  CAL_ACC0_ID = 6946842
BSON_INT32:  CAL_ACC0_PRIO = 50
BSON_DOUBLE: CAL_ACC0_TEMP = 29.750000
BSON_DOUBLE: CAL_ACC0_XOFF = -0.242272
BSON_DOUBLE: CAL_ACC0_YOFF = -0.021063
BSON_DOUBLE: CAL_ACC0_ZOFF = 0.052917
BSON_INT32:  CAL_ACC1_ID = 2490386
BSON_INT32:  CAL_ACC1_PRIO = 50
BSON_DOUBLE: CAL_ACC1_TEMP = 30.628038
BSON_DOUBLE: CAL_ACC1_XOFF = 0.015622
BSON_DOUBLE: CAL_ACC1_YOFF = -0.003541
BSON_DOUBLE: CAL_ACC1_ZOFF = -0.190400
BSON_INT32:  CAL_ACC2_ID = 3670026
BSON_INT32:  CAL_ACC2_PRIO = 50
BSON_DOUBLE: CAL_ACC2_TEMP = 39.248993
BSON_DOUBLE: CAL_ACC2_XOFF = -0.062558
BSON_DOUBLE: CAL_ACC2_YOFF = -0.071253
BSON_DOUBLE: CAL_ACC2_ZOFF = 0.210980
BSON_INT32:  CAL_GYRO0_ID = 6684698
BSON_INT32:  CAL_GYRO0_PRIO = 50
BSON_INT32:  CAL_GYRO1_ID = 2490386
BSON_INT32:  CAL_GYRO1_PRIO = 50
BSON_DOUBLE: CAL_GYRO1_TEMP = 30.735466
BSON_DOUBLE: CAL_GYRO1_XOFF = 0.005639
BSON_DOUBLE: CAL_GYRO1_YOFF = -0.028320
BSON_DOUBLE: CAL_GYRO1_ZOFF = -0.012881
BSON_INT32:  CAL_GYRO2_ID = 3670026
BSON_INT32:  CAL_GYRO2_PRIO = 50
BSON_DOUBLE: CAL_GYRO2_TEMP = 39.465210
BSON_DOUBLE: CAL_GYRO2_XOFF = 0.053147
BSON_DOUBLE: CAL_GYRO2_YOFF = -0.013886
BSON_DOUBLE: CAL_GYRO2_ZOFF = 0.014507
BSON_INT32:  CAL_MAG0_ID = 4395041
BSON_INT32:  CAL_MAG0_PRIO = 50
BSON_DOUBLE: CAL_MAG0_XOFF = 0.093995
BSON_DOUBLE: CAL_MAG0_YOFF = -0.600546
BSON_DOUBLE: CAL_MAG0_ZOFF = -0.303116
BSON_INT32:  CAL_MAG1_ID = 396809
BSON_INT32:  CAL_MAG1_PRIO = 75
BSON_INT32:  CAL_MAG1_ROT = 31
BSON_DOUBLE: CAL_MAG1_TEMP = 35.747513
BSON_DOUBLE: CAL_MAG1_XOFF = -0.029191
BSON_DOUBLE: CAL_MAG1_YOFF = -0.061451
BSON_DOUBLE: CAL_MAG1_ZOFF = -0.054446
BSON_INT32:  CAL_MAG2_PRIO = 50
BSON_INT32:  CAL_MAG3_PRIO = 50
BSON_EOO
BSON decoded 984 bytes (double:27, string:0, bin:0, bool:0, int32:19, int64:0)
nsh> bsondump docsize /fs/mtd_caldata
INFO  [bsondump] DECODED_SIZE:984 SAVED_SIZE:0

WARN  [bsondump] Mismatch in BSON sizes and saved size is zero. Setting document size to decoded size.
nsh> bsondump docsize /fs/mtd_caldata
INFO  [bsondump] DECODED_SIZE:984 SAVED_SIZE:984

nsh> bsondump /fs/mtd_caldata
[bsondump] reading from /fs/mtd_caldata
BSON document size 984
BSON_INT32:  CAL_ACC0_ID = 6946842
BSON_INT32:  CAL_ACC0_PRIO = 50
BSON_DOUBLE: CAL_ACC0_TEMP = 29.750000
BSON_DOUBLE: CAL_ACC0_XOFF = -0.242272
BSON_DOUBLE: CAL_ACC0_YOFF = -0.021063
BSON_DOUBLE: CAL_ACC0_ZOFF = 0.052917
BSON_INT32:  CAL_ACC1_ID = 2490386
BSON_INT32:  CAL_ACC1_PRIO = 50
BSON_DOUBLE: CAL_ACC1_TEMP = 30.628038
BSON_DOUBLE: CAL_ACC1_XOFF = 0.015622
BSON_DOUBLE: CAL_ACC1_YOFF = -0.003541
BSON_DOUBLE: CAL_ACC1_ZOFF = -0.190400
BSON_INT32:  CAL_ACC2_ID = 3670026
BSON_INT32:  CAL_ACC2_PRIO = 50
BSON_DOUBLE: CAL_ACC2_TEMP = 39.248993
BSON_DOUBLE: CAL_ACC2_XOFF = -0.062558
BSON_DOUBLE: CAL_ACC2_YOFF = -0.071253
BSON_DOUBLE: CAL_ACC2_ZOFF = 0.210980
BSON_INT32:  CAL_GYRO0_ID = 6684698
BSON_INT32:  CAL_GYRO0_PRIO = 50
BSON_INT32:  CAL_GYRO1_ID = 2490386
BSON_INT32:  CAL_GYRO1_PRIO = 50
BSON_DOUBLE: CAL_GYRO1_TEMP = 30.735466
BSON_DOUBLE: CAL_GYRO1_XOFF = 0.005639
BSON_DOUBLE: CAL_GYRO1_YOFF = -0.028320
BSON_DOUBLE: CAL_GYRO1_ZOFF = -0.012881
BSON_INT32:  CAL_GYRO2_ID = 3670026
BSON_INT32:  CAL_GYRO2_PRIO = 50
BSON_DOUBLE: CAL_GYRO2_TEMP = 39.465210
BSON_DOUBLE: CAL_GYRO2_XOFF = 0.053147
BSON_DOUBLE: CAL_GYRO2_YOFF = -0.013886
BSON_DOUBLE: CAL_GYRO2_ZOFF = 0.014507
BSON_INT32:  CAL_MAG0_ID = 4395041
BSON_INT32:  CAL_MAG0_PRIO = 50
BSON_DOUBLE: CAL_MAG0_XOFF = 0.093995
BSON_DOUBLE: CAL_MAG0_YOFF = -0.600546
BSON_DOUBLE: CAL_MAG0_ZOFF = -0.303116
BSON_INT32:  CAL_MAG1_ID = 396809
BSON_INT32:  CAL_MAG1_PRIO = 75
BSON_INT32:  CAL_MAG1_ROT = 31
BSON_DOUBLE: CAL_MAG1_TEMP = 35.747513
BSON_DOUBLE: CAL_MAG1_XOFF = -0.029191
BSON_DOUBLE: CAL_MAG1_YOFF = -0.061451
BSON_DOUBLE: CAL_MAG1_ZOFF = -0.054446
BSON_INT32:  CAL_MAG2_PRIO = 50
BSON_INT32:  CAL_MAG3_PRIO = 50
BSON_EOO
BSON decoded 984 bytes (double:27, string:0, bin:0, bool:0, int32:19, int64:0)
nsh> 
```
test mtd_caldata with size zero:
[mtd_caldata.txt](https://github.com/PX4/PX4-Autopilot/files/15196786/mtd_caldata.txt)
