### PR TITLE
Added RTL and Land to modes that can be ignored for RC loss failsafe

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -677,6 +677,8 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
  * @bit 0 Mission
  * @bit 1 Hold
  * @bit 2 Offboard
+ * @bit 3 RTL
+ * @bit 4 Land
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_RCL_EXCEPT, 0);

--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -423,8 +423,13 @@ void Failsafe::checkStateAndMode(const hrt_abstime &time_us, const State &state,
 	const bool rc_loss_ignored_takeoff = (state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF ||
 					      state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF)
 					     && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Hold);
+	const bool rc_loss_ignored_rtl = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL
+					     && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::RTL);
+	const bool rc_loss_ignored_land = state.user_intended_mode == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND
+					  && (_param_com_rcl_except.get() & (int)ManualControlLossExceptionBits::Land);
 	const bool rc_loss_ignored = rc_loss_ignored_mission || rc_loss_ignored_loiter || rc_loss_ignored_offboard ||
-				     rc_loss_ignored_takeoff || ignore_link_failsafe || _manual_control_lost_at_arming;
+				     rc_loss_ignored_takeoff || ignore_link_failsafe || _manual_control_lost_at_arming ||
+				     rc_loss_ignored_rtl || rc_loss_ignored_land;
 
 	if (_param_com_rc_in_mode.get() != int32_t(RcInMode::StickInputDisabled) && !rc_loss_ignored) {
 		CHECK_FAILSAFE(status_flags, manual_control_signal_lost,

--- a/src/modules/commander/failsafe/failsafe.h
+++ b/src/modules/commander/failsafe/failsafe.h
@@ -56,7 +56,9 @@ private:
 	enum class ManualControlLossExceptionBits : int32_t {
 		Mission = (1 << 0),
 		Hold = (1 << 1),
-		Offboard = (1 << 2)
+		Offboard = (1 << 2),
+		RTL = (1 << 3),
+		Land = (1 << 4)
 	};
 
 	// COM_LOW_BAT_ACT parameter values


### PR DESCRIPTION
### Solved Problem
When the drone is in RTL mode at the end of a mission I found that the RC loss failsafe is still triggered, even if  COM_RCL_EXCEPT is set to ignore RC Loss in RTL



### Solution
- Add RTL and Land for as modes in COM_RCL_EXCEPT for which RC loss can be set to be ignored



