### PR TITLE
TECS: addition of pitch in turns based on load factor

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -240,7 +240,7 @@ void TECSControl::initialize(const Setpoint &setpoint, const Input &input, Param
 	_detectUnderspeed(input, param, flag);
 
 	const SpecificEnergyWeighting weight{_updateSpeedAltitudeWeights(param, flag)};
-	ControlValues seb_rate{_calcPitchControlSebRate(weight, specific_energy_rate)};
+	ControlValues seb_rate{_calcPitchControlSebRate(weight, specific_energy_rate, param)};
 
 	_pitch_setpoint = _calcPitchControlOutput(input, seb_rate, param, flag);
 
@@ -409,7 +409,7 @@ void TECSControl::_calcPitchControl(float dt, const Input &input, const Specific
 				    const Flag &flag)
 {
 	const SpecificEnergyWeighting weight{_updateSpeedAltitudeWeights(param, flag)};
-	ControlValues seb_rate{_calcPitchControlSebRate(weight, specific_energy_rates)};
+	ControlValues seb_rate{_calcPitchControlSebRate(weight, specific_energy_rates, param)};
 
 	_calcPitchControlUpdate(dt, input, seb_rate, param);
 	const float pitch_setpoint{_calcPitchControlOutput(input, seb_rate, param, flag)};
@@ -428,7 +428,7 @@ void TECSControl::_calcPitchControl(float dt, const Input &input, const Specific
 }
 
 TECSControl::ControlValues TECSControl::_calcPitchControlSebRate(const SpecificEnergyWeighting &weight,
-		const SpecificEnergyRates &specific_energy_rates) const
+		const SpecificEnergyRates &specific_energy_rates,  const Param &param) const
 {
 	ControlValues seb_rate;
 	/*
@@ -444,6 +444,8 @@ TECSControl::ControlValues TECSControl::_calcPitchControlSebRate(const SpecificE
 	seb_rate.setpoint = specific_energy_rates.spe_rate.setpoint * weight.spe_weighting -
 			    specific_energy_rates.ske_rate.setpoint *
 			    weight.ske_weighting;
+
+	seb_rate.setpoint += param.load_factor_correction_pitch * (param.load_factor - 1.f);
 
 	seb_rate.estimate = (specific_energy_rates.spe_rate.estimate * weight.spe_weighting) -
 			    (specific_energy_rates.ske_rate.estimate * weight.ske_weighting);

--- a/src/lib/tecs/TECS.hpp
+++ b/src/lib/tecs/TECS.hpp
@@ -233,6 +233,7 @@ public:
 
 		float load_factor_correction;				///< Gain from normal load factor increase to total energy rate demand [m²/s³].
 		float load_factor;					///< Additional normal load factor.
+		float load_factor_correction_pitch;			///< Gain from normal load factor increase to total balance energy rate demand [m²/s³].
 	};
 
 	/**
@@ -454,7 +455,7 @@ private:
 	 * @return specific energy balance rate values in [m²/s³].
 	 */
 	ControlValues _calcPitchControlSebRate(const SpecificEnergyWeighting &weight,
-					       const SpecificEnergyRates &specific_energy_rate) const;
+					       const SpecificEnergyRates &specific_energy_rate, const Param &param) const;
 
 	/**
 	 * @brief Calculate the pitch control update function.
@@ -618,6 +619,7 @@ public:
 
 	void set_roll_throttle_compensation(float compensation) { _control_param.load_factor_correction = compensation; };
 	void set_load_factor(float load_factor) { _control_param.load_factor = load_factor; };
+	void set_roll_pitch_compensation(float compensation) { _control_param.load_factor_correction_pitch = compensation; };
 
 	void set_ste_rate_time_const(float time_const) { _control_param.ste_rate_time_const = time_const; };
 
@@ -716,6 +718,7 @@ private:
 		.throttle_slewrate = 0.0f,
 		.load_factor_correction = 0.0f,
 		.load_factor = 1.0f,
+		.load_factor_correction_pitch = 0.0f,
 	};
 
 	TECSControl::Flag _control_flag{

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -135,6 +135,7 @@ FixedwingPositionControl::parameters_update()
 	_tecs.set_throttle_slewrate(_param_fw_thr_slew_max.get());
 	_tecs.set_vertical_accel_limit(_param_fw_t_vert_acc.get());
 	_tecs.set_roll_throttle_compensation(_param_fw_t_rll2thr.get());
+	_tecs.set_roll_pitch_compensation(_param_fw_t_rll2ptch.get());
 	_tecs.set_pitch_damping(_param_fw_t_ptch_damp.get());
 	_tecs.set_altitude_error_time_constant(_param_fw_t_h_error_tc.get());
 	_tecs.set_altitude_rate_ff(_param_fw_t_hrate_ff.get());

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -968,6 +968,7 @@ private:
 		(ParamFloat<px4::params::FW_T_I_GAIN_PIT>) _param_fw_t_I_gain_pit,
 		(ParamFloat<px4::params::FW_T_PTCH_DAMP>) _param_fw_t_ptch_damp,
 		(ParamFloat<px4::params::FW_T_RLL2THR>) _param_fw_t_rll2thr,
+		(ParamFloat<px4::params::FW_T_RLL2PTCH>)  _param_fw_t_rll2ptch,
 		(ParamFloat<px4::params::FW_T_SINK_MAX>) _param_fw_t_sink_max,
 		(ParamFloat<px4::params::FW_T_SPDWEIGHT>) _param_fw_t_spdweight,
 		(ParamFloat<px4::params::FW_T_TAS_TC>) _param_fw_t_tas_error_tc,

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -587,6 +587,23 @@ PARAM_DEFINE_FLOAT(FW_T_SPD_PRC_STD, 0.2f);
 PARAM_DEFINE_FLOAT(FW_T_RLL2THR, 15.0f);
 
 /**
+ * Roll -> Pitch feedforward
+ *
+ * Increasing this gain turn increases the amount of pitch that will
+ * be used to compensate for the loss of lift created by turning.
+ * Increase this parameter only if needed. If the value is to high is
+ * more likely to reach the critical angle and stall. Stall angle reduces
+ * in bank tunrs with respect to straight flight.
+ *
+ * @min 0.0
+ * @max 20.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_T_RLL2PTCH, 15.0f);
+
+/**
  * Speed <--> Altitude priority
  *
  * This parameter adjusts the amount of weighting that the pitch control


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
While flying a standard VTOL in FW we notice a drop in altitude that we would like to reduce as much as possible. We already set FW_T_RLL2THR to 20 (max value) and we didn't want to push throttle more than needed. Since during turns lift decreases with bank angle, my proposal is to add some pitch based on load factor in order to increase AoA

Fixes #{Github issue ID}

### Solution
- Inside the computation of Energy balance, add a term proportional to load factor similarly on how is already done inside total energy for additional throttle. The two computations are independent one from the other, so the additional load factor term is added only once for each output.
- Creation of a new PX4 parameter FW_T_RLL2PTCH, so to be independent from value of FW_T_RLL2THR. Maybe for some platforms is not needed so can be simply set to 0

### Changelog Entry
For release notes:
```
Feature/Bugfix: tecs additional pitch during turns
New parameter: FW_T_RLL2PTCH
Documentation: Find a better description for the parameter
```

### Alternatives
Don't have any other option in mind for the moment but open to discussion

### Test coverage
For the moment I just tested it in SITL , waiting for any feedback before traying on a real standard VTOL
Simulation has of course its limits and I think that the model itself could be tuned better
Comparisson of the same mission. I tried to show as better as possible the difference
- [standard TECS](https://review.px4.io/plot_app?log=d3f92280-b797-46a5-8cea-9beadfcd5491)
- [TECS + additional pitch](https://review.px4.io/plot_app?log=3945415e-1086-4514-ba88-9a616c240647)
Single logs don't say much, so I thought that this comparison could give a better idea
Altitude (peaks happen when turning)
![vtol_altitude_pr](https://github.com/PX4/PX4-Autopilot/assets/149970685/b4b6fe99-4b20-4fa2-9fa5-3fcf6bb0100d)
Pitch Sp
![vtol_pitch_sp_pr](https://github.com/PX4/PX4-Autopilot/assets/149970685/edcc1ecc-d820-4ff4-9921-4a5ad0a2b12e)
Pitch
![vtol_pitch_pr](https://github.com/PX4/PX4-Autopilot/assets/149970685/4d3d15c7-144e-49fc-a49b-a7b6dd0d143e)
The interesting thing in my opinion is reduction of the jump in performing the same turns
If needed I'm happy to do more test. Please let me know because it's possible that I'm missing something
### Context
Follow-up from [discord thread](https://discord.com/channels/1022170275984457759/1232316087434219613). I presented another comparison
