### PR TITLE
increased uxrce-dds stack size to prevent overflow

### DIFF
--- a/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
+++ b/src/modules/uxrce_dds_client/uxrce_dds_client.cpp
@@ -754,7 +754,7 @@ int UxrceddsClient::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("uxrce_dds_client",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_DEFAULT,
-				      PX4_STACK_ADJUSTED(10000),
+				      PX4_STACK_ADJUSTED(12000),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The uxrce-dds bridge is close to the stack limit. When topics are added (sensor_uwb alone is enough) stack overflows occour.

### Solution
To fix that increasing the stack size of the uxrce-dds-client prevents that issue.