### PR TITLE
fix wrong running status in app.h if start an app after stop it.

### DIFF
--- a/platforms/common/include/px4_platform_common/app.h
+++ b/platforms/common/include/px4_platform_common/app.h
@@ -48,16 +48,16 @@ class AppState
 public:
 	~AppState() {}
 
-	AppState() : _exitRequested(false), _isRunning(false) {}
+	AppState() :_isRunning(false) {}
 
-	bool exitRequested() { return _exitRequested; }
-	void requestExit() { _exitRequested = true; }
+	bool exitRequested() { return (!_isRunning); }
+	void requestExit() { _isRunning = false; }
 
 	bool isRunning() { return _isRunning; }
 	void setRunning(bool running) { _isRunning = running; }
 
 protected:
-	bool _exitRequested;
+	// bool _exitRequested;
 	bool _isRunning;
 private:
 	AppState(const AppState &);


### PR DESCRIPTION
### Solved Problem
I found that if I start hello example in the console,   stop it, and start it again,  the status is still running.  Just like below:
~~~
pxh> hello start
hello starting.
hello
pxh> hello  Doing work...
pxh> hello stop
pxh> Doing work...
goodbye
pxh> hello start
INFO  [hello] already running

pxh> hello status
INFO  [hello] is running
~~~

The problem could be showed in nsh shell also.


### Solution
- Using a single variable instead of two to indicate the running status  in app.h, which can solve the problem.

### Context
This problem was reported before: https://discuss.px4.io/t/px4-hello-example-cannot-exit/33682
