### PR TITLE
Separate BAT_V_OFFSET_CURR per battery -> BAT${i}_V_OFFSET_CURR

### DIFF
--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -55,7 +55,7 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 	Battery::setPriority(priority);
 	char param_name[17];
 
-  snprintf(param_name, sizeof(param_name), "BAT%d_V_OFFS_CURR", index);
+	snprintf(param_name, sizeof(param_name), "BAT%d_V_OFFS_CURR", index);
 	_analog_param_handles.v_offs_cur = param_find(param_name);
 
 	snprintf(param_name, sizeof(param_name), "BAT%d_V_DIV", index);

--- a/src/modules/battery_status/analog_battery.cpp
+++ b/src/modules/battery_status/analog_battery.cpp
@@ -55,7 +55,8 @@ AnalogBattery::AnalogBattery(int index, ModuleParams *parent, const int sample_i
 	Battery::setPriority(priority);
 	char param_name[17];
 
-	_analog_param_handles.v_offs_cur = param_find("BAT_V_OFFS_CURR");
+  snprintf(param_name, sizeof(param_name), "BAT%d_V_OFFS_CURR", index);
+	_analog_param_handles.v_offs_cur = param_find(param_name);
 
 	snprintf(param_name, sizeof(param_name), "BAT%d_V_DIV", index);
 	_analog_param_handles.v_div = param_find(param_name);

--- a/src/modules/battery_status/analog_battery_params_common.c
+++ b/src/modules/battery_status/analog_battery_params_common.c
@@ -31,13 +31,4 @@
  *
  ****************************************************************************/
 
-/**
- * Offset in volt as seen by the ADC input of the current sensor.
- *
- * This offset will be subtracted before calculating the battery
- * current based on the voltage.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_V_OFFS_CURR, 0.0);
+

--- a/src/modules/battery_status/analog_battery_params_deprecated.c
+++ b/src/modules/battery_status/analog_battery_params_deprecated.c
@@ -37,3 +37,10 @@
  * @group Battery Calibration
  */
 PARAM_DEFINE_INT32(BAT_ADC_CHANNEL, -1);
+
+/**
+ * This parameter is deprecated. Please use BAT1_V_OFFS_CURR
+ *
+ * @group Battery Calibration
+ */
+PARAM_DEFINE_FLOAT(BAT_V_OFFS_CURR, 0.0);

--- a/src/modules/battery_status/module.yaml
+++ b/src/modules/battery_status/module.yaml
@@ -38,7 +38,7 @@ parameters:
 
         BAT${i}_V_OFFS_CURR:
             description:
-                short: Battery ${i} offset in volt as seen by the ADC input of the current sensor.
+                short: Battery ${i} current measurement ADC offset in V.
                 long: |
                     This offset will be subtracted before calculating the battery
                     current based on the voltage.

--- a/src/modules/battery_status/module.yaml
+++ b/src/modules/battery_status/module.yaml
@@ -36,6 +36,19 @@ parameters:
             instance_start: 1
             default: [-1.0, -1.0]
 
+        BAT${i}_V_OFFS_CURR:
+            description:
+                short: Battery ${i} offset in volt as seen by the ADC input of the current sensor.
+                long: |
+                    This offset will be subtracted before calculating the battery
+                    current based on the voltage.
+            type: float
+            decimal: 8
+            reboot_required: true
+            num_instances: *max_num_config_instances
+            instance_start: 1
+            default: [0.0, 0.0]
+
         BAT${i}_V_CHANNEL:
             description:
                 short: Battery ${i} Voltage ADC Channel


### PR DESCRIPTION
### Solved Problem
When I was calibrating [TFSBEC01](https://github.com/ThunderFly-aerospace/TFSBEC01) , I needed set voltage offset for zero current. I found parameter in source code, but it is global for all batteries. I think, it should be set up per battery.

### Changelog Entry
For release notes:
```
Set current measurement ADC voltage offset per battery
New parameter: BAT${i}_V_OFFSET_CURR
```

### Test coverage
Tested with single battery only (for now).
