### PR TITLE
increase lp default stack to 2000

### DIFF
--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -89,7 +89,7 @@ static constexpr wq_config_t ttyS9{"wq:ttyS9", 1728, -30};
 static constexpr wq_config_t ttyACM0{"wq:ttyACM0", 1728, -31};
 static constexpr wq_config_t ttyUnknown{"wq:ttyUnknown", 1728, -32};
 
-static constexpr wq_config_t lp_default{"wq:lp_default", 1920, -50};
+static constexpr wq_config_t lp_default{"wq:lp_default", 2000, -50};
 
 static constexpr wq_config_t test1{"wq:test1", 2000, 0};
 static constexpr wq_config_t test2{"wq:test2", 2000, 0};


### PR DESCRIPTION
Increase lp default stack for targets such as the mr-canhubk3

Existing lp default stack size:
![log_lp_def](https://github.com/PX4/PX4-Autopilot/assets/35986980/5c2e6784-abf7-4773-ab28-bae4049eb42f)
![no_lp_def_left](https://github.com/PX4/PX4-Autopilot/assets/35986980/faeaa63b-e8b5-4f8f-93c1-2a857467bf67)


With the increased stack size:
![lp_default](https://github.com/PX4/PX4-Autopilot/assets/35986980/285c757b-03a5-4786-aecd-e1200dde951a)



