### PR TITLE
Adding vehicle_acceleration and actuator_motors to the logged topics for system identification

### DIFF
--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -396,6 +396,8 @@ void LoggedTopics::add_system_identification_topics()
 	add_topic("sensor_combined");
 	add_topic("vehicle_angular_velocity");
 	add_topic("vehicle_torque_setpoint");
+	add_topic("vehicle_acceleration");
+	add_topic("actuator_motors");
 }
 
 void LoggedTopics::add_mavlink_tunnel()


### PR DESCRIPTION
Hi, 

for full system identification, the motor commands as well as the observed acceleration are required to be logged at high frequencies. We are working on a system identification utility that people can use to find accurate dynamics parameters for their quadrotors just based on about a minute of flying data. 

The utility is available at [https://sysid.tools](https://sysid.tools) and the only missing piece is that people have to modify PX4 and re-compile/flash to include high-frequency logging of `actuator_motors` and `vehicle_acceleration` to be able to use it. Hence we propose to include it in the "Topics for system identification" option of the `SDLOG_PROFILE` parameter. By default, this option is deactivated so it will not affect most users, and even for users that have it enabled this should only add additional data but not interfere with anything else.

For more information about the method implemented by [https://sysid.tools](https://sysid.tools) please refer to our paper: [https://arxiv.org/abs/2404.07837](https://arxiv.org/abs/2404.07837) and the corresponding video [https://www.youtube.com/watch?v=G3WGthRx2KE](https://www.youtube.com/watch?v=G3WGthRx2KE) or our repo [https://github.com/arplaboratory/data-driven-system-identification](https://github.com/arplaboratory/data-driven-system-identification)

If you have any questions please let me know!

