### PR TITLE
fmu-v6xrt: Fix redundant 'fi'

### DIFF
--- a/boards/px4/fmu-v6xrt/init/rc.board_sensors
+++ b/boards/px4/fmu-v6xrt/init/rc.board_sensors
@@ -83,7 +83,6 @@ else
 		fi
 	fi
 fi
-fi
 
 # Internal SPI bus ICM42686p (hard-mounted)
 icm42688p -6 -R 12 -b 1 -s start


### PR DESCRIPTION
Fix redundant 'fi'
