### PR TITLE
style(editorconfig): update newline setting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-insert_final_newline = false
+insert_final_newline = true
 
 [{*.{c,cpp,cc,h,hpp},CMakeLists.txt,Kconfig}]
 indent_style = tab


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The setting wasn't consistent with the one used in the Visual Studio Code settings, which caused different newline formatting depending on whether the user uses Visual Studio Code or another editor that uses EditorConfig.

Fixes \/

### Solution
- Change newline ending setting in the EditorConfig file to be consistent with the Visual Studio Code setting

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
Maybe remove the formatting settings from the Visual Studio Code `.vscode/settings.json` configuration file as the EditorConfig extension is now in the recommended list and it can therefore use the settings from the `.editorconfig` file.

### Test coverage
\/

### Context
The original EditorConfig was based on the style in most files. After using it for actual development, some errors are showing up that weren't immediately visible by just looking at the files (e.g. due to different settings in Visual Studio Code config), like this one. I will make more PRs if I encounter other problems.