### PR TITLE
Ubuntu 24.04 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ GTAGS
 *.creator.user
 *.files
 *.includes
+.venv
 
 # CLion ignores
 .idea

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -108,7 +108,7 @@ if [ -n "$VIRTUAL_ENV" ]; then
 	python -m pip install -r ${DIR}/requirements.txt
 else
 	# older versions of Ubuntu require --user option
-	python3 -m pip install --user -r ${DIR}/requirements.txt
+	python3 -m pip install --break-system-packages --user -r ${DIR}/requirements.txt
 fi
 
 # NuttX toolchain (arm-none-eabi-gcc)
@@ -135,7 +135,6 @@ if [[ $INSTALL_NUTTX == "true" ]]; then
 		libisl-dev \
 		libmpc-dev \
 		libmpfr-dev \
-		libncurses5 \
 		libncurses5-dev \
 		libncursesw5-dev \
 		libtool \
@@ -205,6 +204,8 @@ if [[ $INSTALL_SIM == "true" ]]; then
 		java_version=13
 	elif [[ "${UBUNTU_RELEASE}" == "22.04" ]]; then
 		java_version=11
+	elif [[ "${UBUNTU_RELEASE}" == "24.04" ]]; then
+		java_version=11
 	else
 		java_version=14
 	fi
@@ -249,7 +250,6 @@ if [[ $INSTALL_SIM == "true" ]]; then
 
 	sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		dmidecode \
-		$gazebo_packages \
 		gstreamer1.0-plugins-bad \
 		gstreamer1.0-plugins-base \
 		gstreamer1.0-plugins-good \


### PR DESCRIPTION
### Solved Problem
[Ubuntu 24.04 stable](https://releases.ubuntu.com/noble/) came out and we already have the first developer @haumarco using it on a new laptop. Some things need to be adapted.

### Issues
- [x] When I followed https://docs.px4.io/main/en/dev_setup/dev_env_linux_ubuntu.html and ran `git clone https://github.com/PX4/PX4-Autopilot.git --recursive` I got prompted to enter https credentials for `Tools/simulation/jsbsim/jsbsim_bridge/models/Rascal` and `ATI-Resolution`. I don't know why that is since the repos are still public.
Ticking this one since it's unrelated and tracked here: https://github.com/PX4/PX4-Autopilot/issues/23124
- [ ] The newer python versions have this annoying [pip package environment enforcement](https://stackoverflow.com/questions/75602063/pip-install-r-requirements-txt-is-failing-this-environment-is-externally-mana). For Arch Linux which had this problem already quite some time ago [I added the `--break-system-packages` parameter](https://github.com/PX4/PX4-Autopilot/pull/21340/files#diff-4ce953c96a002a55eb9773fd29372540c47d736556a63852df9f6950991e6149R70) which is in my understanding not the proper solution so we might as well do it correctly now and use a virtual environment. But I need to first figure out how to do it correctly before rolling that out.
**Related:**
    - https://github.com/PX4/PX4-Autopilot/issues/23073
    - https://github.com/PX4/PX4-Autopilot/commit/d25938698715dbb6a10e0891471c33a08687bf85
- [ ] `libncurses5` seems not available. Only `libncurses5-dev`? Why? New version?
- [ ] The Java version condition by default uses 14 which doesn't exist. 11 works but we should probably use a newer one if possible.
- [ ] Gazebo neither classic nor gz exist as packages for 24.04 yet.
- [ ] There's a Warning about Compatibility with CMake < 3.5

### Changelog Entry
```
Ubuntu 24.04 support of toolchain
Documentation: Make sure it's reflected on the development environment page.
```

### Test coverage
With this hacky draft I could successfully build `make px4_sitl` and `make px4_fmu-v5x`. I haven't tested more. Let's cooperate to work through the items and do more testing.