### PR TITLE
Added a VOXL 2 board specific shutdown hook to run on exit

### DIFF
--- a/platforms/common/apps.cpp.in
+++ b/platforms/common/apps.cpp.in
@@ -2,6 +2,7 @@
 #include <px4_platform_common/time.h>
 #include <px4_platform_common/posix.h>
 #include <px4_platform_common/log.h>
+#include <px4_platform_common/shutdown.h>
 
 #include "apps.h"
 
@@ -42,8 +43,9 @@ void list_builtins(apps_map_type &apps)
 
 int shutdown_main(int argc, char *argv[])
 {
-	printf("Exiting NOW.\n");
-	system_exit(0);
+	printf("Exiting in shutdown_main\n");
+	px4_shutdown_request(0);
+	return 0;
 }
 
 int list_tasks_main(int argc, char *argv[])

--- a/platforms/common/include/px4_platform_common/shutdown.h
+++ b/platforms/common/include/px4_platform_common/shutdown.h
@@ -70,6 +70,14 @@ __EXPORT int px4_register_shutdown_hook(shutdown_hook_t hook);
  */
 __EXPORT int px4_unregister_shutdown_hook(shutdown_hook_t hook);
 
+
+/**
+ * Execute all shutdown hooks
+ * @return true on success, false if one or more hooks failed
+ */
+__EXPORT bool px4_execute_shutdown_hooks();
+
+
 /** Types of reboot requests for PX4 */
 typedef enum {
 	REBOOT_REQUEST = 0,          ///< Normal reboot

--- a/platforms/common/shutdown.cpp
+++ b/platforms/common/shutdown.cpp
@@ -111,7 +111,7 @@ static uint16_t shutdown_counter = 0; ///< count how many times the shutdown wor
 #define SHUTDOWN_ARG_TO_ISP (1<<3)
 static uint8_t shutdown_args = 0;
 
-static constexpr int max_shutdown_hooks = 1;
+static constexpr int max_shutdown_hooks = 2;
 static shutdown_hook_t shutdown_hooks[max_shutdown_hooks] = {};
 
 static hrt_abstime shutdown_time_us = 0;
@@ -150,6 +150,25 @@ int px4_unregister_shutdown_hook(shutdown_hook_t hook)
 	return -EINVAL;
 }
 
+bool px4_execute_shutdown_hooks()
+{
+	bool done = true;
+
+	pthread_mutex_lock(&shutdown_mutex);
+
+	for (int i = 0; i < max_shutdown_hooks; ++i) {
+		if (shutdown_hooks[i]) {
+			if (!shutdown_hooks[i]()) {
+				done = false;
+			}
+		}
+	}
+
+	pthread_mutex_unlock(&shutdown_mutex);
+
+	return done;
+}
+
 /**
  * work queue callback method to shutdown.
  * @param arg unused
@@ -157,7 +176,7 @@ int px4_unregister_shutdown_hook(shutdown_hook_t hook)
 static void shutdown_worker(void *arg)
 {
 	PX4_DEBUG("shutdown worker (%i)", shutdown_counter);
-	bool done = true;
+	bool done = px4_execute_shutdown_hooks();
 
 	pthread_mutex_lock(&shutdown_mutex);
 
@@ -201,7 +220,7 @@ static void shutdown_worker(void *arg)
 #endif
 #elif defined(__PX4_POSIX)
 			// simply exit on posix if real shutdown (poweroff) not available
-			PX4_INFO_RAW("Exiting NOW.");
+			PX4_INFO_RAW("Exiting NOW in Posix shutdown_worker\n");
 			system_exit(0);
 #else
 			PX4_PANIC("board shutdown not available");

--- a/platforms/posix/src/px4/common/main.cpp
+++ b/platforms/posix/src/px4/common/main.cpp
@@ -73,6 +73,7 @@
 #include <px4_platform_common/getopt.h>
 #include <px4_platform_common/tasks.h>
 #include <px4_platform_common/posix.h>
+#include <px4_platform_common/shutdown.h>
 
 #include "apps.h"
 #include "px4_daemon/client.h"
@@ -502,9 +503,11 @@ void register_sig_handler()
 
 void sig_int_handler(int sig_num)
 {
+	(void) px4_execute_shutdown_hooks();
 	fflush(stdout);
-	printf("\nPX4 Exiting...\n");
+	printf("\nPX4 Exiting in sig_int_handler\n");
 	fflush(stdout);
+	px4_shutdown_request(0);
 	px4_daemon::Pxh::stop();
 	_exit_requested = true;
 }

--- a/src/modules/muorb/apps/muorb_main.cpp
+++ b/src/modules/muorb/apps/muorb_main.cpp
@@ -32,12 +32,15 @@
  ****************************************************************************/
 
 #include <string.h>
+#include <px4_platform_common/shutdown.h>
 #include "uORBAppsProtobufChannel.hpp"
 #include "uORB/uORBManager.hpp"
+#include "fc_sensor.h"
 
 extern "C" {
 	__EXPORT int muorb_main(int argc, char *argv[]);
 	__EXPORT int muorb_init();
+	__EXPORT bool muorb_kill_slpi();
 }
 
 static bool enable_debug = false;
@@ -46,6 +49,15 @@ int
 muorb_main(int argc, char *argv[])
 {
 	return muorb_init();
+}
+
+bool
+muorb_kill_slpi(void)
+{
+	PX4_ERR("Sending kill command to SLPI!!!");
+	fc_sensor_kill_slpi();
+	sleep(1);
+	return true;
 }
 
 int
@@ -58,7 +70,11 @@ muorb_init()
 	if (channel && channel->Initialize(enable_debug)) {
 		uORB::Manager::get_instance()->set_uorb_communicator(channel);
 
-		if (channel->Test()) { return OK; }
+		px4_register_shutdown_hook(&muorb_kill_slpi);
+
+		if (channel->Test()) {
+			return OK;
+		}
 	}
 
 	return -EINVAL;


### PR DESCRIPTION

### Solved Problem
If the apps processor side of PX4 running on VOXL 2 exits the DSP side continues on. If PX4 is then restarted it will fail because the DSP side will still be running the old instance. This PR will send a new custom kill command to the DSP to reset it and get it back into it's ready state. This is done within a shutdown hook that's installed on px4 start up.