### PR TITLE
feat: add thruster actuation support to PX4

### DIFF
--- a/Tools/module_config/generate_actuators_metadata.py
+++ b/Tools/module_config/generate_actuators_metadata.py
@@ -364,6 +364,8 @@ def get_mixers(yaml_config, output_functions, verbose):
                     actuator['group-label'] = 'Motors'
                 elif actuator_conf['actuator_type'] == 'servo':
                     actuator['group-label'] = 'Servos'
+                elif actuator_conf['actuator_type'] == 'thruster':
+                    actuator['group-label'] = 'Thrusters'
                 else:
                     raise Exception('Missing group label for actuator type "{}"'.format(actuator_conf['actuator_type']))
 

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -107,6 +107,8 @@ class AirframeGroup(object):
             return "Balloon"
         elif (self.type == "Vectored 6 DOF UUV"):
             return "Vectored6DofUUV"
+        elif (self.type == "Space Robot"):
+            return "SpaceRobot"
         return "AirframeUnknown"
 
     def GetAirframes(self):

--- a/msg/ActuatorMotors.msg
+++ b/msg/ActuatorMotors.msg
@@ -5,6 +5,7 @@ uint64 timestamp_sample	    # the timestamp the data this control response is ba
 uint16 reversible_flags     # bitset which motors are configured to be reversible
 
 uint8 ACTUATOR_FUNCTION_MOTOR1 = 101
+uint16 ACTUATOR_FUNCTION_THRUSTER1 = 501
 
 uint8 NUM_CONTROLS = 12
 float32[12] control # range: [-1, 1], where 1 means maximum positive thrust,

--- a/src/lib/mixer_module/CMakeLists.txt
+++ b/src/lib/mixer_module/CMakeLists.txt
@@ -51,6 +51,7 @@ px4_add_library(mixer_module
 	functions/FunctionLandingGear.hpp
 	functions/FunctionManualRC.hpp
 	functions/FunctionMotors.hpp
+	functions/FunctionThrusters.hpp
 	functions/FunctionParachute.hpp
 	functions/FunctionServos.hpp
 

--- a/src/lib/mixer_module/functions/FunctionThrusters.hpp
+++ b/src/lib/mixer_module/functions/FunctionThrusters.hpp
@@ -1,0 +1,124 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021-2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FunctionProviderBase.hpp"
+
+/**
+ * Functions: Thruster1 ... ThrusterMax
+ */
+class FunctionThrusters : public FunctionProviderBase
+{
+public:
+	static_assert(actuator_motors_s::NUM_CONTROLS == (int)OutputFunction::ThrusterMax - (int)OutputFunction::Thruster1 + 1,
+		      "Unexpected num thrusters");
+
+	static_assert(actuator_motors_s::ACTUATOR_FUNCTION_THRUSTER1 == (int)OutputFunction::Thruster1,
+		      "Unexpected thruster idx");
+
+	FunctionThrusters(const Context &context) :
+		_topic(&context.work_item, ORB_ID(actuator_motors)),
+		_thrust_factor(context.thrust_factor)
+	{
+		for (int i = 0; i < actuator_motors_s::NUM_CONTROLS; ++i) {
+			_data.control[i] = NAN;
+		}
+	}
+
+	static FunctionProviderBase *allocate(const Context &context) { return new FunctionThrusters(context); }
+
+	void update() override
+	{
+		if (_topic.update(&_data)) {
+			updateValues(_data.reversible_flags, _thrust_factor, _data.control, actuator_motors_s::NUM_CONTROLS);
+		}
+	}
+
+	float value(OutputFunction func) override { return _data.control[(int)func - (int)OutputFunction::Thruster1]; }
+
+	bool allowPrearmControl() const override { return false; }
+
+	uORB::SubscriptionCallbackWorkItem *subscriptionCallback() override { return &_topic; }
+
+	bool getLatestSampleTimestamp(hrt_abstime &t) const override { t = _data.timestamp_sample; return t != 0; }
+
+	static inline void updateValues(uint32_t reversible, float thrust_factor, float *values, int num_values)
+	{
+		// TODO(@Pedro-Roque): for now bypass this
+		/*if (thrust_factor > 0.f && thrust_factor <= 1.f) {
+
+			// thrust factor
+			//  rel_thrust = factor * x^2 + (1-factor) * x,
+			const float a = thrust_factor;
+			const float b = (1.f - thrust_factor);
+
+			// don't recompute for all values (ax^2+bx+c=0)
+			const float tmp1 = b / (2.f * a);
+			const float tmp2 = b * b / (4.f * a * a);
+
+			for (int i = 0; i < num_values; ++i) {
+				float control = values[i];
+
+				if (control > 0.f) {
+					values[i] = -tmp1 + sqrtf(tmp2 + (control / a));
+
+				} else if (control < -0.f) {
+					values[i] =  tmp1 - sqrtf(tmp2 - (control / a));
+
+				} else {
+					values[i] = 0.f;
+				}
+			}
+		}
+
+		for (int i = 0; i < num_values; ++i) {
+			if ((reversible & (1u << i)) == 0) {
+				if (values[i] < -FLT_EPSILON) {
+					values[i] = NAN;
+
+				} else {
+					// remap from [0, 1] to [-1, 1]
+					values[i] = values[i] * 2.f - 1.f;
+				}
+			}
+		}*/
+	}
+
+	bool reversible(OutputFunction func) const override { return false; }
+
+private:
+	uORB::SubscriptionCallbackWorkItem _topic;
+	actuator_motors_s _data{};
+	const float &_thrust_factor;
+};

--- a/src/lib/mixer_module/mixer_module.cpp
+++ b/src/lib/mixer_module/mixer_module.cpp
@@ -56,6 +56,7 @@ static const FunctionProvider all_function_providers[] = {
 	{OutputFunction::Constant_Min, &FunctionConstantMin::allocate},
 	{OutputFunction::Constant_Max, &FunctionConstantMax::allocate},
 	{OutputFunction::Motor1, OutputFunction::MotorMax, &FunctionMotors::allocate},
+	{OutputFunction::Thruster1, OutputFunction::ThrusterMax, &FunctionThrusters::allocate},
 	{OutputFunction::Servo1, OutputFunction::ServoMax, &FunctionServos::allocate},
 	{OutputFunction::Peripheral_via_Actuator_Set1, OutputFunction::Peripheral_via_Actuator_Set6, &FunctionActuatorSet::allocate},
 	{OutputFunction::Landing_Gear, &FunctionLandingGear::allocate},
@@ -237,7 +238,8 @@ bool MixingOutput::updateSubscriptions(bool allow_wq_switch)
 			int32_t function;
 
 			if (_param_handles[i].function != PARAM_INVALID && param_get(_param_handles[i].function, &function) == 0) {
-				if (function >= (int32_t)OutputFunction::Motor1 && function <= (int32_t)OutputFunction::MotorMax) {
+				if ((function >= (int32_t)OutputFunction::Motor1 && function <= (int32_t)OutputFunction::MotorMax) ||
+				    (function >= (int32_t)OutputFunction::Thruster1 && function <= (int32_t)OutputFunction::ThrusterMax)) {
 					switch_requested = true;
 				}
 			}

--- a/src/lib/mixer_module/mixer_module.hpp
+++ b/src/lib/mixer_module/mixer_module.hpp
@@ -44,6 +44,7 @@
 #include "functions/FunctionLandingGearWheel.hpp"
 #include "functions/FunctionManualRC.hpp"
 #include "functions/FunctionMotors.hpp"
+#include "functions/FunctionThrusters.hpp"
 #include "functions/FunctionParachute.hpp"
 #include "functions/FunctionServos.hpp"
 

--- a/src/lib/mixer_module/output_functions.yaml
+++ b/src/lib/mixer_module/output_functions.yaml
@@ -10,6 +10,9 @@ functions:
     Motor:
       start: 101
       count: 12
+    Thruster:
+      start: 501
+      count: 12
     Servo:
       start: 201
       count: 8

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -78,6 +78,8 @@
 #define VEHICLE_TYPE_VTOL_TILTROTOR 21
 #define VEHICLE_TYPE_VTOL_FIXEDROTOR 22 // VTOL standard
 #define VEHICLE_TYPE_VTOL_TAILSITTER 23
+#define VEHICLE_TYPE_SPACECRAFT_2D 24
+#define VEHICLE_TYPE_SPACECRAFT_3D 25
 
 #define BLINK_MSG_TIME	700000	// 3 fast blinks (in us)
 
@@ -120,6 +122,12 @@ bool is_fixed_wing(const vehicle_status_s &current_status)
 bool is_ground_vehicle(const vehicle_status_s &current_status)
 {
 	return (current_status.system_type == VEHICLE_TYPE_BOAT || current_status.system_type == VEHICLE_TYPE_GROUND_ROVER);
+}
+
+bool is_spacecraft(const vehicle_status_s &current_status)
+{
+	return (current_status.system_type == VEHICLE_TYPE_SPACECRAFT_2D
+		|| current_status.system_type == VEHICLE_TYPE_SPACECRAFT_3D);
 }
 
 // End time for currently blinking LED message, 0 if no blink message

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -56,6 +56,7 @@ bool is_vtol(const vehicle_status_s &current_status);
 bool is_vtol_tailsitter(const vehicle_status_s &current_status);
 bool is_fixed_wing(const vehicle_status_s &current_status);
 bool is_ground_vehicle(const vehicle_status_s &current_status);
+bool is_spacecraft(const vehicle_status_s &current_status);
 
 int buzzer_init(void);
 void buzzer_deinit(void);

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
@@ -55,6 +55,7 @@ enum class AllocationMethod {
 
 enum class ActuatorType {
 	MOTORS = 0,
+	THRUSTERS,
 	SERVOS,
 
 	COUNT

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessSpacecraft.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessSpacecraft.cpp
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "ActuatorEffectivenessSpacecraft.hpp"
+
+using namespace matrix;
+
+ActuatorEffectivenessSpacecraft::ActuatorEffectivenessSpacecraft(ModuleParams *parent)
+	: ModuleParams(parent),
+	  _sc_thrusters(this)
+{
+}
+
+bool
+ActuatorEffectivenessSpacecraft::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
+{
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
+		return false;
+	}
+
+	// Thrusters
+	const bool thrusters_added_successfully = _sc_thrusters.addActuators(configuration);
+
+	return thrusters_added_successfully;
+}
+
+void ActuatorEffectivenessSpacecraft::updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp,
+		int matrix_index, ActuatorVector &actuator_sp, const matrix::Vector<float, NUM_ACTUATORS> &actuator_min,
+		const matrix::Vector<float, NUM_ACTUATORS> &actuator_max)
+{
+	// TODO(@E-Krantz): Here is where we can add the nonlinearity of multiple thrusters open
+	//   and how to adjust thrust in that time
+	return;
+}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessSpacecraft.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessSpacecraft.hpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "ActuatorEffectiveness.hpp"
+#include "ActuatorEffectivenessThrusters.hpp"
+
+class ActuatorEffectivenessSpacecraft : public ModuleParams, public ActuatorEffectiveness
+{
+public:
+	ActuatorEffectivenessSpacecraft(ModuleParams *parent);
+	virtual ~ActuatorEffectivenessSpacecraft() = default;
+
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
+
+	void getDesiredAllocationMethod(AllocationMethod allocation_method_out[MAX_NUM_MATRICES]) const override
+	{
+		// TODO(@Jaeyoung-Lim): to be updated
+		allocation_method_out[0] = AllocationMethod::SEQUENTIAL_DESATURATION;
+	}
+
+	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	{
+		// TODO(@Jaeyoung-Lim): to be updated
+		normalize[0] = true;
+	}
+
+	void updateSetpoint(const matrix::Vector<float, NUM_AXES> &control_sp, int matrix_index,
+			    ActuatorVector &actuator_sp, const matrix::Vector<float, NUM_ACTUATORS> &actuator_min,
+			    const matrix::Vector<float, NUM_ACTUATORS> &actuator_max) override;
+
+	const char *name() const override { return "Spacecraft"; }
+
+protected:
+	ActuatorEffectivenessThrusters _sc_thrusters;
+};

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessThrusters.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessThrusters.cpp
@@ -1,0 +1,205 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ActuatorEffectivenessThrusters.hpp
+ *
+ * Actuator effectiveness computed from thrusters position and orientation
+ *
+ * @author Pedro Roque, <padr@kth.se>
+ */
+
+#include "ActuatorEffectivenessThrusters.hpp"
+
+using namespace matrix;
+
+ActuatorEffectivenessThrusters::ActuatorEffectivenessThrusters(ModuleParams *parent, AxisConfiguration axis_config,
+		bool tilt_support)
+	: ModuleParams(parent), _axis_config(axis_config), _tilt_support(tilt_support)
+{
+
+	for (int i = 0; i < NUM_THRUSTERS_MAX; ++i) {
+		char buffer[17];
+		snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_PX", i);
+		_param_handles[i].position_x = param_find(buffer);
+		snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_PY", i);
+		_param_handles[i].position_y = param_find(buffer);
+		snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_PZ", i);
+		_param_handles[i].position_z = param_find(buffer);
+
+		if (_axis_config == AxisConfiguration::Configurable) {
+			snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_AX", i);
+			_param_handles[i].axis_x = param_find(buffer);
+			snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_AY", i);
+			_param_handles[i].axis_y = param_find(buffer);
+			snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_AZ", i);
+			_param_handles[i].axis_z = param_find(buffer);
+		}
+
+		snprintf(buffer, sizeof(buffer), "CA_THRUSTER%u_CT", i);
+		_param_handles[i].thrust_coef = param_find(buffer);
+
+		if (_tilt_support) {
+			PX4_ERR("Tilt support not implemented");
+		}
+	}
+
+	_count_handle = param_find("CA_THRUSTER_CNT");
+
+	updateParams();
+}
+
+void ActuatorEffectivenessThrusters::updateParams()
+{
+	ModuleParams::updateParams();
+
+	int32_t count = 0;
+
+	if (param_get(_count_handle, &count) != 0) {
+		PX4_ERR("param_get failed");
+		return;
+	}
+
+	_geometry.num_thrusters = math::min(NUM_THRUSTERS_MAX, (int)count);
+
+	for (int i = 0; i < _geometry.num_thrusters; ++i) {
+		Vector3f &position = _geometry.thrusters[i].position;
+		param_get(_param_handles[i].position_x, &position(0));
+		param_get(_param_handles[i].position_y, &position(1));
+		param_get(_param_handles[i].position_z, &position(2));
+
+		Vector3f &axis = _geometry.thrusters[i].axis;
+
+		switch (_axis_config) {
+		case AxisConfiguration::Configurable:
+			param_get(_param_handles[i].axis_x, &axis(0));
+			param_get(_param_handles[i].axis_y, &axis(1));
+			param_get(_param_handles[i].axis_z, &axis(2));
+			break;
+		}
+
+		param_get(_param_handles[i].thrust_coef, &_geometry.thrusters[i].thrust_coef);
+	}
+}
+
+bool
+ActuatorEffectivenessThrusters::addActuators(Configuration &configuration)
+{
+	if (configuration.num_actuators[(int)ActuatorType::SERVOS] > 0) {
+		PX4_ERR("Wrong actuator ordering: servos need to be after motors");
+		return false;
+	}
+
+	int num_actuators = computeEffectivenessMatrix(_geometry,
+			    configuration.effectiveness_matrices[configuration.selected_matrix],
+			    configuration.num_actuators_matrix[configuration.selected_matrix]);
+	configuration.actuatorsAdded(ActuatorType::THRUSTERS, num_actuators);
+	return true;
+}
+
+int
+ActuatorEffectivenessThrusters::computeEffectivenessMatrix(const Geometry &geometry,
+		EffectivenessMatrix &effectiveness, int actuator_start_index)
+{
+	int num_actuators = 0;
+
+	for (int i = 0; i < geometry.num_thrusters; i++) {
+
+		if (i + actuator_start_index >= NUM_ACTUATORS) {
+			break;
+		}
+
+		++num_actuators;
+
+		// Get rotor axis
+		Vector3f axis = geometry.thrusters[i].axis;
+
+		// Normalize axis
+		float axis_norm = axis.norm();
+
+		if (axis_norm > FLT_EPSILON) {
+			axis /= axis_norm;
+
+		} else {
+			// Bad axis definition, ignore this rotor
+			continue;
+		}
+
+		// Get rotor position
+		const Vector3f &position = geometry.thrusters[i].position;
+
+		// Get coefficients
+		float ct = geometry.thrusters[i].thrust_coef;
+
+		if (fabsf(ct) < FLT_EPSILON) {
+			continue;
+		}
+
+		// Compute thrust generated by this rotor
+		matrix::Vector3f thrust = ct * axis;
+
+		// Compute moment generated by this rotor
+		matrix::Vector3f moment = ct * position.cross(axis);
+
+		// Fill corresponding items in effectiveness matrix
+		for (size_t j = 0; j < 3; j++) {
+			effectiveness(j, i + actuator_start_index) = moment(j);
+			effectiveness(j + 3, i + actuator_start_index) = thrust(j);
+		}
+	}
+
+	return num_actuators;
+}
+
+
+uint32_t ActuatorEffectivenessThrusters::getThrusters() const
+{
+	uint32_t thrusters = 0;
+
+	for (int i = 0; i < _geometry.num_thrusters; ++i) {
+		thrusters |= 1u << i;
+	}
+
+	return thrusters;
+}
+
+bool
+ActuatorEffectivenessThrusters::getEffectivenessMatrix(Configuration &configuration,
+		EffectivenessUpdateReason external_update)
+{
+	if (external_update == EffectivenessUpdateReason::NO_EXTERNAL_UPDATE) {
+		return false;
+	}
+
+	return addActuators(configuration);
+}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessThrusters.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessThrusters.hpp
@@ -1,0 +1,121 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ActuatorEffectivenessThrusters.hpp
+ *
+ * Actuator effectiveness computed from thrusters position and orientation
+ *
+ * @author Pedro Roque, <padr@kth.se>
+ */
+
+#pragma once
+
+#include "ActuatorEffectiveness.hpp"
+
+#include <px4_platform_common/module_params.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+
+class ActuatorEffectivenessTilts;
+
+using namespace time_literals;
+
+class ActuatorEffectivenessThrusters : public ModuleParams, public ActuatorEffectiveness
+{
+public:
+	enum class AxisConfiguration {
+		Configurable, ///< axis can be configured
+	};
+
+	static constexpr int NUM_THRUSTERS_MAX = 12;
+
+	struct ThrusterGeometry {
+		matrix::Vector3f position;
+		matrix::Vector3f axis;
+		float thrust_coef;
+	};
+
+	struct Geometry {
+		ThrusterGeometry thrusters[NUM_THRUSTERS_MAX];
+		int num_thrusters{0};
+	};
+
+	ActuatorEffectivenessThrusters(ModuleParams *parent, AxisConfiguration axis_config = AxisConfiguration::Configurable,
+				       bool tilt_support = false);
+	virtual ~ActuatorEffectivenessThrusters() = default;
+
+	bool getEffectivenessMatrix(Configuration &configuration, EffectivenessUpdateReason external_update) override;
+
+	void getDesiredAllocationMethod(AllocationMethod allocation_method_out[MAX_NUM_MATRICES]) const override
+	{
+		allocation_method_out[0] =
+			AllocationMethod::SEQUENTIAL_DESATURATION;  // TODO(@Jaeyoung-Lim): needs to be updated based on metric mixer
+	}
+
+	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	{
+		// TODO(@Jaeyoung-Lim): needs to be updated based on metric mixer
+		normalize[0] = true;
+	}
+
+	static int computeEffectivenessMatrix(const Geometry &geometry,
+					      EffectivenessMatrix &effectiveness, int actuator_start_index = 0);
+
+	bool addActuators(Configuration &configuration);
+
+	const char *name() const override { return "Thrusters"; }
+
+	const Geometry &geometry() const { return _geometry; }
+
+	uint32_t getThrusters() const;
+
+private:
+	void updateParams() override;
+	const AxisConfiguration _axis_config;
+	const bool _tilt_support; ///< if true, tilt servo assignment params are loaded
+
+	struct ParamHandles {
+		param_t position_x;
+		param_t position_y;
+		param_t position_z;
+		param_t axis_x;
+		param_t axis_y;
+		param_t axis_z;
+		param_t thrust_coef;
+	};
+	ParamHandles _param_handles[NUM_THRUSTERS_MAX];
+	param_t _count_handle;
+
+	Geometry _geometry{};
+};

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessThrustersTest.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessThrustersTest.cpp
@@ -1,0 +1,135 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file ActuatorEffectivenessRotors.cpp
+ *
+ * Tests for Control Allocation Algorithms
+ *
+ * @author Julien Lecoeur <julien.lecoeur@gmail.com>
+ */
+
+#include <gtest/gtest.h>
+#include "ActuatorEffectivenessRotors.hpp"
+
+using namespace matrix;
+
+TEST(ActuatorEffectivenessRotors, AllZeroCase)
+{
+	// Quad wide geometry
+	ActuatorEffectivenessRotors::Geometry geometry = {};
+	geometry.rotors[0].position(0) = 1.0f;
+	geometry.rotors[0].position(1) = 1.0f;
+	geometry.rotors[0].position(2) = 0.0f;
+	geometry.rotors[0].axis(0) = 0.0f;
+	geometry.rotors[0].axis(1) = 0.0f;
+	geometry.rotors[0].axis(2) = -1.0f;
+	geometry.rotors[0].thrust_coef = 1.0f;
+	geometry.rotors[0].moment_ratio = 0.05f;
+
+	geometry.rotors[1].position(0) = -1.0f;
+	geometry.rotors[1].position(1) = -1.0f;
+	geometry.rotors[1].position(2) = 0.0f;
+	geometry.rotors[1].axis(0) = 0.0f;
+	geometry.rotors[1].axis(1) = 0.0f;
+	geometry.rotors[1].axis(2) = -1.0f;
+	geometry.rotors[1].thrust_coef = 1.0f;
+	geometry.rotors[1].moment_ratio = 0.05f;
+
+	geometry.rotors[2].position(0) = 1.0f;
+	geometry.rotors[2].position(1) = -1.0f;
+	geometry.rotors[2].position(2) = 0.0f;
+	geometry.rotors[2].axis(0) = 0.0f;
+	geometry.rotors[2].axis(1) = 0.0f;
+	geometry.rotors[2].axis(2) = -1.0f;
+	geometry.rotors[2].thrust_coef = 1.0f;
+	geometry.rotors[2].moment_ratio = -0.05f;
+
+	geometry.rotors[3].position(0) = -1.0f;
+	geometry.rotors[3].position(1) = 1.0f;
+	geometry.rotors[3].position(2) = 0.0f;
+	geometry.rotors[3].axis(0) = 0.0f;
+	geometry.rotors[3].axis(1) = 0.0f;
+	geometry.rotors[3].axis(2) = -1.0f;
+	geometry.rotors[3].thrust_coef = 1.0f;
+	geometry.rotors[3].moment_ratio = -0.05f;
+
+	geometry.num_rotors = 4;
+
+	ActuatorEffectiveness::EffectivenessMatrix effectiveness;
+	effectiveness.setZero();
+	ActuatorEffectivenessRotors::computeEffectivenessMatrix(geometry, effectiveness);
+
+	const float expected[ActuatorEffectiveness::NUM_AXES][ActuatorEffectiveness::NUM_ACTUATORS] = {
+		{-1.0f,   1.0f,   1.0f,  -1.0f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+		{ 1.0f,  -1.0f,   1.0f,  -1.0f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+		{ 0.05f,  0.05f, -0.05f, -0.05f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+		{ 0.f,    0.f,    0.f,    0.f,   0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+		{ 0.f,    0.f,    0.f,    0.f,   0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f},
+		{-1.0f,  -1.0f,  -1.0f,  -1.0f,  0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f}
+	};
+	ActuatorEffectiveness::EffectivenessMatrix effectiveness_expected(expected);
+
+	EXPECT_EQ(effectiveness, effectiveness_expected);
+}
+
+TEST(ActuatorEffectivenessRotors, Tilt)
+{
+	Vector3f axis_expected{0.f, 0.f, -1.f};
+	Vector3f axis = ActuatorEffectivenessRotors::tiltedAxis(0.f, 0.f);
+	EXPECT_EQ(axis, axis_expected);
+
+	axis_expected = Vector3f{1.f, 0.f, 0.f};
+	axis = ActuatorEffectivenessRotors::tiltedAxis(M_PI_F / 2.f, 0.f);
+	EXPECT_EQ(axis, axis_expected);
+
+	axis_expected = Vector3f{1.f / sqrtf(2.f), 0.f, -1.f / sqrtf(2.f)};
+	axis = ActuatorEffectivenessRotors::tiltedAxis(M_PI_F / 2.f / 2.f, 0.f);
+	EXPECT_EQ(axis, axis_expected);
+
+	axis_expected = Vector3f{-1.f, 0.f, 0.f};
+	axis = ActuatorEffectivenessRotors::tiltedAxis(-M_PI_F / 2.f, 0.f);
+	EXPECT_EQ(axis, axis_expected);
+
+	axis_expected = Vector3f{0.f, 0.f, -1.f};
+	axis = ActuatorEffectivenessRotors::tiltedAxis(0.f, M_PI_F / 2.f);
+	EXPECT_EQ(axis, axis_expected);
+
+	axis_expected = Vector3f{0.f, 1.f, 0.f};
+	axis = ActuatorEffectivenessRotors::tiltedAxis(M_PI_F / 2.f, M_PI_F / 2.f);
+	EXPECT_EQ(axis, axis_expected);
+
+	axis_expected = Vector3f{0.f, -1.f, 0.f};
+	axis = ActuatorEffectivenessRotors::tiltedAxis(-M_PI_F / 2.f, M_PI_F / 2.f);
+	EXPECT_EQ(axis, axis_expected);
+}

--- a/src/modules/control_allocator/ActuatorEffectiveness/CMakeLists.txt
+++ b/src/modules/control_allocator/ActuatorEffectiveness/CMakeLists.txt
@@ -54,6 +54,10 @@ px4_add_library(ActuatorEffectiveness
 	ActuatorEffectivenessTilts.hpp
 	ActuatorEffectivenessRotors.cpp
 	ActuatorEffectivenessRotors.hpp
+	ActuatorEffectivenessThrusters.cpp
+	ActuatorEffectivenessThrusters.hpp
+	ActuatorEffectivenessSpacecraft.cpp
+	ActuatorEffectivenessSpacecraft.hpp
 	ActuatorEffectivenessStandardVTOL.cpp
 	ActuatorEffectivenessStandardVTOL.hpp
 	ActuatorEffectivenessTiltrotorVTOL.cpp
@@ -73,3 +77,4 @@ target_link_libraries(ActuatorEffectiveness
 
 px4_add_functional_gtest(SRC ActuatorEffectivenessHelicopterTest.cpp LINKLIBS ActuatorEffectiveness)
 px4_add_functional_gtest(SRC ActuatorEffectivenessRotorsTest.cpp LINKLIBS ActuatorEffectiveness)
+px4_add_functional_gtest(SRC ActuatorEffectivenessThrustersTest.cpp LINKLIBS ActuatorEffectiveness)

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "ControlAllocationPseudoInverse.hpp"
+#include <px4_platform_common/log.h>
 
 void
 ControlAllocationPseudoInverse::setEffectivenessMatrix(

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -270,6 +270,14 @@ ControlAllocator::update_effectiveness_source()
 			tmp = new ActuatorEffectivenessHelicopterCoaxial(this);
 			break;
 
+		case EffectivenessSource::SPACECRAFT_2D:
+			tmp = new ActuatorEffectivenessSpacecraft(this);
+			break;
+
+		case EffectivenessSource::SPACECRAFT_3D:
+			tmp = new ActuatorEffectivenessSpacecraft(this);
+			break;
+
 		default:
 			PX4_ERR("Unknown airframe");
 			break;
@@ -519,6 +527,16 @@ ControlAllocator::update_effectiveness_matrix_if_needed(EffectivenessUpdateReaso
 
 					slew_rate[selected_matrix](actuator_idx_matrix[selected_matrix]) = _params.slew_rate_motors[actuator_type_idx];
 
+				} else if ((ActuatorType)actuator_type == ActuatorType::THRUSTERS) {
+					if (actuator_type_idx >= MAX_NUM_THRUSTERS) {
+						PX4_ERR("Too many thrusters");
+						_num_actuators[actuator_type] = 0;
+						break;
+					}
+
+					minimum[selected_matrix](actuator_idx_matrix[selected_matrix]) = 0.f;
+
+
 				} else if ((ActuatorType)actuator_type == ActuatorType::SERVOS) {
 					if (actuator_type_idx >= MAX_NUM_SERVOS) {
 						PX4_ERR("Too many servos");
@@ -672,10 +690,18 @@ ControlAllocator::publish_actuator_controls()
 
 	uint32_t stopped_motors = _actuator_effectiveness->getStoppedMotors() | _handled_motor_failure_bitmask;
 
+	// Actuator setpoints are shared between Motors or Thrusters. For now, we assume we have only either of them
+	int actuator_type = 0;
+
+	if (_num_actuators[(int)ActuatorType::THRUSTERS] > 0) {
+		actuator_type = (int)ActuatorType::THRUSTERS;
+	}
+
 	// motors
 	int motors_idx;
 
-	for (motors_idx = 0; motors_idx < _num_actuators[0] && motors_idx < actuator_motors_s::NUM_CONTROLS; motors_idx++) {
+	for (motors_idx = 0; motors_idx < _num_actuators[actuator_type]
+	     && motors_idx < actuator_motors_s::NUM_CONTROLS; motors_idx++) {
 		int selected_matrix = _control_allocation_selection_indexes[actuator_idx];
 		float actuator_sp = _control_allocation[selected_matrix]->getActuatorSetpoint()(actuator_idx_matrix[selected_matrix]);
 		actuator_motors.control[motors_idx] = PX4_ISFINITE(actuator_sp) ? actuator_sp : NAN;
@@ -695,10 +721,11 @@ ControlAllocator::publish_actuator_controls()
 	_actuator_motors_pub.publish(actuator_motors);
 
 	// servos
-	if (_num_actuators[1] > 0) {
+	if (_num_actuators[(int)ActuatorType::SERVOS] > 0) {
 		int servos_idx;
 
-		for (servos_idx = 0; servos_idx < _num_actuators[1] && servos_idx < actuator_servos_s::NUM_CONTROLS; servos_idx++) {
+		for (servos_idx = 0; servos_idx < _num_actuators[(int)ActuatorType::SERVOS]
+		     && servos_idx < actuator_servos_s::NUM_CONTROLS; servos_idx++) {
 			int selected_matrix = _control_allocation_selection_indexes[actuator_idx];
 			float actuator_sp = _control_allocation[selected_matrix]->getActuatorSetpoint()(actuator_idx_matrix[selected_matrix]);
 			actuator_servos.control[servos_idx] = PX4_ISFINITE(actuator_sp) ? actuator_sp : NAN;

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -44,6 +44,7 @@
 #include <ActuatorEffectiveness.hpp>
 #include <ActuatorEffectivenessMultirotor.hpp>
 #include <ActuatorEffectivenessStandardVTOL.hpp>
+#include <ActuatorEffectivenessSpacecraft.hpp>
 #include <ActuatorEffectivenessTiltrotorVTOL.hpp>
 #include <ActuatorEffectivenessTailsitterVTOL.hpp>
 #include <ActuatorEffectivenessRoverAckermann.hpp>
@@ -86,6 +87,7 @@ public:
 	static constexpr int NUM_AXES = ControlAllocation::NUM_AXES;
 
 	static constexpr int MAX_NUM_MOTORS = actuator_motors_s::NUM_CONTROLS;
+	static constexpr int MAX_NUM_THRUSTERS = actuator_motors_s::NUM_CONTROLS;
 	static constexpr int MAX_NUM_SERVOS = actuator_servos_s::NUM_CONTROLS;
 
 	using ActuatorVector = ActuatorEffectiveness::ActuatorVector;
@@ -158,6 +160,8 @@ private:
 		HELICOPTER_TAIL_ESC = 10,
 		HELICOPTER_TAIL_SERVO = 11,
 		HELICOPTER_COAXIAL = 12,
+		SPACECRAFT_2D = 13,
+		SPACECRAFT_3D = 14,
 	};
 
 	enum class FailureMode {

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -1,4 +1,5 @@
 __max_num_mc_motors: &max_num_mc_motors 12
+__max_num_mc_motors: &max_num_sc_thrusters 12
 __max_num_servos: &max_num_servos 8
 __max_num_tilts: &max_num_tilts 4
 
@@ -30,6 +31,8 @@ parameters:
                 10: Helicopter (tail ESC)
                 11: Helicopter (tail Servo)
                 12: Helicopter (Coaxial)
+                13: Spacecraft 2D
+                14: Spacecraft 3D
             default: 0
 
         CA_METHOD:
@@ -235,6 +238,108 @@ parameters:
             num_instances: *max_num_mc_motors
             instance_start: 0
             default: 0
+
+        # (SC) Thrusters
+        CA_THRUSTER_CNT:
+            description:
+                short: Total number of thrusters
+            type: enum
+            values:
+                0: '0'
+                1: '1'
+                2: '2'
+                3: '3'
+                4: '4'
+                5: '5'
+                6: '6'
+                7: '7'
+                8: '8'
+                9: '9'
+                10: '10'
+                11: '11'
+                12: '12'
+            default: 0
+        CA_THRUSTER${i}_PX:
+            description:
+                short: Position of thruster ${i} along X body axis
+            type: float
+            decimal: 2
+            increment: 0.1
+            unit: m
+            num_instances: *max_num_sc_thrusters
+            min: -100
+            max: 100
+            default: 0.0
+        CA_THRUSTER${i}_PY:
+            description:
+                short: Position of thruster ${i} along Y body axis
+            type: float
+            decimal: 2
+            increment: 0.1
+            unit: m
+            num_instances: *max_num_sc_thrusters
+            min: -100
+            max: 100
+            default: 0.0
+        CA_THRUSTER${i}_PZ:
+            description:
+                short: Position of thruster ${i} along Z body axis
+            type: float
+            decimal: 2
+            increment: 0.1
+            unit: m
+            num_instances: *max_num_sc_thrusters
+            min: -100
+            max: 100
+            default: 0.0
+        CA_THRUSTER${i}_AX:
+            description:
+                short: Axis of thruster ${i} thrust vector, X body axis component
+                long: Only the direction is considered (the vector is normalized).
+            type: float
+            decimal: 2
+            increment: 0.1
+            num_instances: *max_num_sc_thrusters
+            min: -100
+            max: 100
+            default: 0.0
+        CA_THRUSTER${i}_AY:
+            description:
+                short: Axis of thruster ${i} thrust vector, Y body axis component
+                long: Only the direction is considered (the vector is normalized).
+            type: float
+            decimal: 2
+            increment: 0.1
+            num_instances: *max_num_sc_thrusters
+            min: -100
+            max: 100
+            default: 0.0
+        CA_THRUSTER${i}_AZ:
+            description:
+                short: Axis of thruster ${i} thrust vector, Z body axis component
+                long: Only the direction is considered (the vector is normalized).
+            type: float
+            decimal: 2
+            increment: 0.1
+            num_instances: *max_num_sc_thrusters
+            min: -100
+            max: 100
+            default: -1.0
+
+        CA_THRUSTER${i}_CT:
+            description:
+                short: Thrust coefficient of rotor ${i}
+                long: |
+                  The thrust coefficient if defined as Thrust = CT * u^2,
+                  where u (with value between actuator minimum and maximum)
+                  is the output signal sent to the motor controller.
+            type: float
+            decimal: 1
+            increment: 1
+            num_instances: *max_num_sc_thrusters
+            min: 0
+            max: 100
+            default: 6.5
 
         # control surfaces
         CA_SV_CS_COUNT:
@@ -560,6 +665,12 @@ mixer:
                 label: 'Slew Rate'
                 index_offset: 0
                 advanced: true
+        thruster:
+            functions: 'Thruster'
+            actuator_testing_values:
+                min: 0
+                max: 1
+                default_is_nan: true
         servo:
             functions: 'Servo'
             actuator_testing_values:
@@ -1140,3 +1251,48 @@ mixer:
                     parameters:
                       - label: 'Throttle spoolup time'
                         name: COM_SPOOLUP_TIME
+
+            13: # Spacecraft 2D
+                type: 'spacecraft_2d'
+                title: 'Spacecraft 2D'
+                actuators:
+                  - actuator_type: 'thruster'
+                    count: 'CA_THRUSTER_CNT'  # count would be too long for 16 max size
+                    per_item_parameters:
+                        standard:
+                            position: [ 'CA_THRUSTER${i}_PX', 'CA_THRUSTER${i}_PY', 'CA_THRUSTER${i}_PZ' ]
+                        extra:
+                          - name: 'CA_THRUSTER${i}_AX'
+                            label: 'Axis X'
+                            function: 'axisx'
+                            advanced: true
+                          - name: 'CA_THRUSTER${i}_AY'
+                            label: 'Axis Y'
+                            function: 'axisy'
+                            advanced: true
+                          - name: 'CA_THRUSTER${i}_AZ'
+                            label: 'Axis Z'
+                            function: 'axisz'
+                            advanced: true
+
+            14: # Sapcecraft 3D
+                title: 'Spacecraft 3D'
+                actuators:
+                  - actuator_type: 'thruster'
+                    count: 'CA_THRUSTER_CNT'
+                    per_item_parameters:
+                        standard:
+                            position: [ 'CA_THRUSTER${i}_PX', 'CA_THRUSTER${i}_PY', 'CA_THRUSTER${i}_PZ' ]
+                        extra:
+                          - name: 'CA_THRUSTER${i}_AX'
+                            label: 'Axis X'
+                            function: 'axisx'
+                            advanced: true
+                          - name: 'CA_THRUSTER${i}_AY'
+                            label: 'Axis Y'
+                            function: 'axisy'
+                            advanced: true
+                          - name: 'CA_THRUSTER${i}_AZ'
+                            label: 'Axis Z'
+                            function: 'axisz'
+                            advanced: true


### PR DESCRIPTION
### Solved Problem
This PR addresses support on PX4 for thruster-based actuation, in-view of supporting spacecraft-type vehicles, or any vehicle using thruster-based propulsion.

This PR addresses control allocation changes.

This PR aims at integrating these additions, which will soon be published and updated on the source code, into the PX4 ecosystem to support space robotics facilities.

### Solution
- Add Thruster Effectiveness in the control allocation module

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
Reusing multicopter code. However, there are multiple problems associated with it:
1. Their actuation is not the same leading to different effectiveness models
2. Their PWM cycle is different than thruster-based platforms, which typically use solenoid-based valves

### Test coverage
Format and Unit tests pass successfully.

### Context
Currently being integrated in https://github.com/DISCOWER/PX4-Space-Systems/tree/dev-metric_control_allocator, as part of the [DISCOWER](https://discower.io/) project (a publication documenting this contribution as well as the entire lab facilities will be published by the end of August). Work developed together with @Jaeyoung-Lim and @E-Krantz .