### PR TITLE
ist8310: do reset before WHOAMI call

### DIFF
--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -85,6 +85,15 @@ void IST8310::print_status()
 
 int IST8310::probe()
 {
+	// Apparently, the IST8310's WHOAMI register is writeable. Presumably,
+	// this can get corrupted by bus noise. It is only reset if powered off
+	// for 30s.
+	//
+	// Therefore, we do a reset before doing the WHOAMI.
+	RegisterWrite(Register::CNTL2, CNTL2_BIT::SRST);
+
+	px4_usleep(10000);
+
 	const uint8_t WAI = RegisterRead(Register::WAI);
 
 	if (WAI != Device_ID) {

--- a/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
+++ b/src/drivers/magnetometer/isentek/ist8310/IST8310.cpp
@@ -87,7 +87,7 @@ int IST8310::probe()
 {
 	// Apparently, the IST8310's WHOAMI register is writeable. Presumably,
 	// this can get corrupted by bus noise. It is only reset if powered off
-	// for 30s.
+	// for 30s or by a reset.
 	//
 	// Therefore, we do a reset before doing the WHOAMI.
 	RegisterWrite(Register::CNTL2, CNTL2_BIT::SRST);


### PR DESCRIPTION
Apparently, the IST8310's WHOAMI register is writeable. Presumably, this can get corrupted by bus noise. It is only reset if powered off for 30s.

Therefore, we do a reset before doing the WHOAMI.

Credit goes to:
https://github.com/ArduPilot/ardupilot/pull/26929

Testing done: Verified that the sensor still works. I have not tried to reproduce the failure case.