### PR TITLE
Standard VTOL: fix pusher transition ramp up slew rate

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -200,8 +200,11 @@ void Standard::update_transition_state()
 
 		} else if (_pusher_throttle <= _param_vt_f_trans_thr.get()) {
 			// ramp up throttle to the target throttle value
+			const float dt = math::min((now - _last_time_pusher_transition_update) / 1e6f, 0.05f);
 			_pusher_throttle = math::min(_pusher_throttle +
-						     _param_vt_psher_slew.get() * _dt, _param_vt_f_trans_thr.get());
+						     _param_vt_psher_slew.get() * dt, _param_vt_f_trans_thr.get());
+
+			_last_time_pusher_transition_update = now;
 		}
 
 		_airspeed_trans_blend_margin = getTransitionAirspeed() - getBlendAirspeed();

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -76,6 +76,7 @@ private:
 
 	float _pusher_throttle{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
+	hrt_abstime _last_time_pusher_transition_update{0};
 
 	void parameters_update() override;
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -284,9 +284,9 @@ VtolAttitudeControl::Run()
 		return;
 	}
 
-	const hrt_abstime now = hrt_absolute_time();
-
 #if !defined(ENABLE_LOCKSTEP_SCHEDULER)
+
+	const hrt_abstime now = hrt_absolute_time();
 
 	// prevent excessive scheduling (> 500 Hz)
 	if (now - _last_run_timestamp < 2_ms) {
@@ -294,9 +294,6 @@ VtolAttitudeControl::Run()
 	}
 
 #endif // !ENABLE_LOCKSTEP_SCHEDULER
-
-	const float dt = math::min((now - _last_run_timestamp) / 1e6f, kMaxVTOLAttitudeControlTimeStep);
-	_last_run_timestamp = now;
 
 	if (!_initialized) {
 
@@ -308,8 +305,6 @@ VtolAttitudeControl::Run()
 			return;
 		}
 	}
-
-	_vtol_type->setDt(dt);
 
 	perf_begin(_loop_perf);
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -92,8 +92,6 @@ using namespace time_literals;
 
 extern "C" __EXPORT int vtol_att_control_main(int argc, char *argv[]);
 
-static constexpr float kMaxVTOLAttitudeControlTimeStep = 0.1f; // max time step [s]
-
 class VtolAttitudeControl : public ModuleBase<VtolAttitudeControl>, public ModuleParams, public px4::WorkItem
 {
 public:
@@ -211,7 +209,9 @@ private:
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};	// [kg/m^3]
 
-	hrt_abstime _last_run_timestamp{0};
+#if !defined(ENABLE_LOCKSTEP_SCHEDULER)
+	hrt_abstime _last_run_timestamp {0};
+#endif // !ENABLE_LOCKSTEP_SCHEDULER
 
 	/* For multicopters it is usual to have a non-zero idle speed of the engines
 	 * for fixed wings we want to have an idle speed of zero since we do not want

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -251,12 +251,6 @@ public:
 
 	virtual void parameters_update() = 0;
 
-	/**
-	 * @brief Set current time delta
-	 *
-	 * @param dt Current time delta [s]
-	 */
-	void setDt(float dt) {_dt = dt; }
 
 	/**
 	 * @brief Resets the transition timer states.
@@ -325,8 +319,6 @@ protected:
 	float update_and_get_backtransition_pitch_sp();
 	bool isFrontTransitionCompleted();
 	virtual bool isFrontTransitionCompletedBase();
-
-	float _dt{0.0025f}; // time step [s]
 
 	float _local_position_z_start_of_transition{0.f}; // altitude at start of transition
 


### PR DESCRIPTION

### Solved Problem
The pusher ramp up time is much longer than set in the pusher slew rate param (`VT_PSHER_SLEW`). Reason is that we pass the `dt` from the main loop of the VTOL Attitude Controller to the `update_transition_state()`, which though is only run if a new attitude setpoint is present and thus would require a bigger `dt` to have the slew rate working correctly. 

### Solution
Calculate the dt at the spot of usage.

### Changelog Entry
For release notes:
```
Bugfix Standard VTOL: fix pusher transition ramp up slew rate
```


