### PR TITLE
Solving Segmentation Fault on "differential_drive stop" (Patch for issue #22818)

### DIFF
--- a/src/modules/differential_drive/DifferentialDrive.cpp
+++ b/src/modules/differential_drive/DifferentialDrive.cpp
@@ -66,6 +66,7 @@ void DifferentialDrive::Run()
 	if (should_exit()) {
 		ScheduleClear();
 		exit_and_cleanup();
+		return;
 	}
 
 	hrt_abstime now = hrt_absolute_time();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When calling "differential_drive stop" during a simulation involving a robot with differential drive like r1_rover, a missing return statement in DifferentialDrive.cpp was causing a segmentation fault due to access to already freed memory.

Fixes issue #22818

### Solution
Adding a return statement after line 68 solves the issue.
