### PR TITLE
Fix fmu rc_input on v5x and v6x

### DIFF
--- a/boards/px4/fmu-v5x/src/board_config.h
+++ b/boards/px4/fmu-v5x/src/board_config.h
@@ -287,9 +287,12 @@
 #define GPIO_PPM_IN             /* PI5 T8C1 */ GPIO_TIM8_CH1IN_2
 
 /* RC Serial port */
-
 #define RC_SERIAL_PORT                     "/dev/ttyS5"
+/* Some RC protocols are bi-directional, therefore we need a half-duplex UART */
 #define RC_SERIAL_SINGLEWIRE
+/* The STM32 UART by default wires half-duplex mode to the TX pin, but our
+ * signal in routed to the RX pin, so we need to swap the pins */
+#define RC_SERIAL_SWAP_RXTX
 
 /* Input Capture Channels. */
 #define INPUT_CAP1_TIMER                  5

--- a/boards/px4/fmu-v6x/src/board_config.h
+++ b/boards/px4/fmu-v6x/src/board_config.h
@@ -319,9 +319,12 @@
 #define GPIO_PPM_IN             /* PI5 T8C1 */ GPIO_TIM8_CH1IN_2
 
 /* RC Serial port */
-
 #define RC_SERIAL_PORT                     "/dev/ttyS5"
+/* Some RC protocols are bi-directional, therefore we need a half-duplex UART */
 #define RC_SERIAL_SINGLEWIRE
+/* The STM32 UART by default wires half-duplex mode to the TX pin, but our
+ * signal in routed to the RX pin, so we need to swap the pins */
+#define RC_SERIAL_SWAP_RXTX
 
 /* Input Capture Channels. */
 #define INPUT_CAP1_TIMER                  1


### PR DESCRIPTION
As far as I can see fmu v5x and fmu v6x are not designed to have rc_input as a single wire uart.

### Solved Problem
This PR disables this for both targets and fix my issue where RC works only through the px4io but not directly to the fmu.

### Changelog Entry
For release notes:
```
Fix rc_input when connecting the RC receiver directly to the FMU (no px4io).

```

### Test coverage
- Tested on Auterion Skynode with both FMU V5X and FMU V6X

