### PR TITLE
[BACKPORT] mRo Control Zero Classic: Definition for GPS2 by default added

### DIFF
--- a/boards/mro/ctrl-zero-classic/init/rc.board_defaults
+++ b/boards/mro/ctrl-zero-classic/init/rc.board_defaults
@@ -6,4 +6,5 @@
 param set-default BAT1_V_DIV 10.1
 param set-default BAT1_A_PER_V 17
 
+param set-default GPS_2_CONFIG 202
 param set-default TEL_FRSKY_CONFIG 103


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

This is a backport from `main` to modify the default parameter of GPS2 for mRo Control Zero Classic.

 Already been tested on HW and working without issues.
