### PR TITLE
Specify which modes apply FW_PN_R_SLEW_MAX and fix comment for attitude_setpoint.thrust_body

### DIFF
--- a/msg/VehicleAttitudeSetpoint.msg
+++ b/msg/VehicleAttitudeSetpoint.msg
@@ -11,7 +11,7 @@ float32[4] q_d			# Desired quaternion for quaternion control
 
 # For clarification: For multicopters thrust_body[0] and thrust[1] are usually 0 and thrust[2] is the negative throttle demand.
 # For fixed wings thrust_x is the throttle demand and thrust_y, thrust_z will usually be zero.
-float32[3] thrust_body		# Normalized thrust command in body NED frame [-1,1]
+float32[3] thrust_body		# Normalized thrust command in body FRD frame [-1,1]
 
 bool reset_integral	# Reset roll/pitch/yaw integrals (navigation logic change)
 

--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -35,6 +35,7 @@
  * Path navigation roll slew rate limit.
  *
  * The maximum change in roll angle setpoint per second.
+ * This limit is applied in all Auto modes, plus manual Position and Altitude modes.
  *
  * @unit deg/s
  * @min 0


### PR DESCRIPTION
Just two comment fixes that I was made aware of recently. 