### PR TITLE
Navigator: do not leave mission path with RTL_TYPE=2 when RTL triggered in Mission

### DIFF
--- a/msg/RtlStatus.msg
+++ b/msg/RtlStatus.msg
@@ -8,8 +8,8 @@ bool has_vtol_approach 		      # flag if approaches are defined for current RTL_
 uint8 rtl_type	      		      # Type of RTL chosen
 uint8 safe_point_index 		      # index of the chosen safe point, if in RTL_STATUS_TYPE_DIRECT_SAFE_POINT mode
 
-uint8 RTL_STATUS_TYPE_NONE=0       # RTL type is pending if evaluation can't pe performed currently e.g. when it is still loading the safe points
-uint8 RTL_STATUS_TYPE_DIRECT_SAFE_POINT=1 # RTL type is chosen to directly go to a safe point or home position
-uint8 RTL_STATUS_TYPE_DIRECT_MISSION_LAND=2 # RTL type is going straight to the beginning of the mission landing
-uint8 RTL_STATUS_TYPE_FOLLOW_MISSION=3 	# RTL type is following the mission from closest point to mission landing
-uint8 RTL_STATUS_TYPE_FOLLOW_MISSION_REVERSE=4 # RTL type is following the mission in reverse to the start position
+uint8 RTL_STATUS_TYPE_NONE=0       		# pending if evaluation can't pe performed currently e.g. when it is still loading the safe points
+uint8 RTL_STATUS_TYPE_DIRECT_SAFE_POINT=1 	# chosen to directly go to a safe point or home position
+uint8 RTL_STATUS_TYPE_DIRECT_MISSION_LAND=2 	# going straight to the beginning of the mission landing
+uint8 RTL_STATUS_TYPE_FOLLOW_MISSION=3 		# Following the mission from start index to mission landing. Start index is current WP if in Mission mode, and closest WP otherwise.
+uint8 RTL_STATUS_TYPE_FOLLOW_MISSION_REVERSE=4 	# Following the mission in reverse from start index to the beginning of the mission. Start index is previous WP if in Mission mode, and closest WP otherwise.

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -314,6 +314,13 @@ protected:
 	 */
 	bool position_setpoint_equal(const position_setpoint_s *p1, const position_setpoint_s *p2) const;
 
+	/**
+	 * @brief Set the Mission Index
+	 *
+	 * @param[in] index Index of the mission item
+	 */
+	void setMissionIndex(int32_t index);
+
 	bool _is_current_planned_mission_item_valid{false};	/**< Flag indicating if the currently loaded mission item is valid*/
 	bool _mission_has_been_activated{false};		/**< Flag indicating if the mission has been activated*/
 	bool _mission_checked{false};				/**< Flag indicating if the mission has been checked by the mission validator*/
@@ -420,13 +427,6 @@ private:
 	 * @return true if there was a camera trigger command in the cached items that didn't disable triggering
 	 */
 	bool cameraWasTriggering();
-
-	/**
-	 * @brief Set the Mission Index
-	 *
-	 * @param[in] index Index of the mission item
-	 */
-	void setMissionIndex(int32_t index);
 
 	/**
 	 * @brief Parameters update

--- a/src/modules/navigator/rtl_mission_fast.h
+++ b/src/modules/navigator/rtl_mission_fast.h
@@ -56,12 +56,15 @@ public:
 	~RtlMissionFast() = default;
 
 	void on_activation() override;
+	void on_inactive() override;
 
 	rtl_time_estimate_s calc_rtl_time_estimate() override;
 
 private:
 	bool setNextMissionItem() override;
 	void setActiveMissionItems() override;
+
+	int _mission_index_prior_rtl{-1};
 
 	uORB::SubscriptionData<home_position_s> _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
 };

--- a/src/modules/navigator/rtl_mission_fast_reverse.h
+++ b/src/modules/navigator/rtl_mission_fast_reverse.h
@@ -57,6 +57,7 @@ public:
 
 	void on_activation() override;
 	void on_active() override;
+	void on_inactive() override;
 
 	rtl_time_estimate_s calc_rtl_time_estimate() override;
 
@@ -64,6 +65,8 @@ private:
 	bool setNextMissionItem() override;
 	void setActiveMissionItems() override;
 	void handleLanding(WorkItemType &new_work_item_type);
+
+	int _mission_index_prior_rtl{-1};
 
 	uORB::SubscriptionData<home_position_s> _home_pos_sub{ORB_ID(home_position)};		/**< home position subscription */
 };


### PR DESCRIPTION

### Solved Problem
On a system with RTL_TYPE=2, the current behavior is that it will always start the RTL from the closes WP, and not from the current active one. If by chance e.g. WP 5 is closer than the current WP 2, it will go to 5. If there's an obstacle between 2 and 5 there is no way to ensure it won't hit it.

### Solution
Only start from closest WP if not in Mission when RTL is started. Otherwise, if in Mission, the proceed mission from currently active one (case where it follows mission to the Land), or start from the previous item (if mission doesn't include a landing and it thus does it in reverse).  

### Changelog Entry
For release notes: 
```
Feature: do not leave mission path with RTL_TYPE=2 when RTL triggered in Mission
```

### Test coverage
Basic SITL testing. 

