### PR TITLE
wind_est_replay: report scale instead of inverse_scale

### DIFF
--- a/src/lib/wind_estimator/python/wind_estimator_replay.py
+++ b/src/lib/wind_estimator/python/wind_estimator_replay.py
@@ -78,7 +78,9 @@ def run(logfile, use_gnss, scale_init):
     if scale_init is None:
         scale_init = 1.0
 
-    state = np.array([0.0, 0.0, scale_init])
+    # The estimator estimates the inverse scale factor to have a simpler measurement jacobian
+    inverse_scale_init = 1 / scale_init
+    state = np.array([0.0, 0.0, inverse_scale_init])
     P = np.diag([1.0, 1.0, 1e-4])
     wind_nsd = 1e-2
     scale_nsd = 1e-4
@@ -118,7 +120,7 @@ def run(logfile, use_gnss, scale_init):
 
         wind_est_n[i] = state[0]
         wind_est_e[i] = state[1]
-        scale_est[i] = state[2]
+        scale_est[i] = 1 / state[2]
 
     plt.figure(1)
     ax1 = plt.subplot(2, 1, 1)


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This script returns the scale state but in reality, it is the inverse of the airspeed scale factor.

### Solution
The estimator internally estimates the scale inverse, but the interface should be the scale as "airspeed_corrected = scale * airspeed" to be consistent with the reported `tas_scale_raw` and the `ASPD_SCALE_X` params.

https://github.com/PX4/PX4-Autopilot/blob/4f64acb3524d39967bd7f516ae2ebfe4be5246bc/src/lib/wind_estimator/WindEstimator.hpp#L78