### PR TITLE
cdcacm_autostart: handle USB with no data lines

### DIFF
--- a/src/drivers/cdcacm_autostart/cdcacm_autostart.cpp
+++ b/src/drivers/cdcacm_autostart/cdcacm_autostart.cpp
@@ -206,7 +206,8 @@ void CdcAcmAutostart::state_connecting()
 
 	if (_ttyacm_fd < 0) {
 		PX4_DEBUG("can't open port");
-		goto fail;
+		// fail silently and keep trying to open the port
+		return;
 	}
 
 	if (_sys_usb_auto.get() == 2) {


### PR DESCRIPTION
Fixes logic if USB does not have data lines, ie powering the flight controller with USB wall wart. The module will stay in the `connecting` state and `px4_open()` will fail silently.

Closes https://github.com/PX4/PX4-Autopilot/issues/23179 