### PR TITLE
Fix oscillations when using GNSS velocity fusion only

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -320,7 +320,8 @@ bool Ekf::shouldResetGpsFusion() const
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 	const bool is_reset_required = has_horizontal_aiding_timed_out
-				       || isTimedOut(_time_last_hor_pos_fuse, 2 * _params.reset_timeout_max);
+				       || (isTimedOut(_time_last_hor_pos_fuse, 2 * _params.reset_timeout_max)
+					   && (_params.gnss_ctrl & static_cast<int32_t>(GnssCtrl::HPOS)));
 
 	const bool is_inflight_nav_failure = _control_status.flags.in_air
 					     && isTimedOut(_time_last_hor_vel_fuse, _params.reset_timeout_max)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When fusing GNSS 3D velocity and not lat/lon, the control logic continuously resets the velocity state as the position fusion timeout triggers at every loop. This makes the flight task trajectory setpoint reset and results in a constant oscillation of the drone.

### Solution
Ignore position timeout when GNSS lat/lon is disabled.

### Alternatives
Split GNSS control flag (velocity and hpos)

### Test coverage
Reproducible in SITL.
Main:
![Screenshot from 2024-05-27 16-01-33](https://github.com/PX4/PX4-Autopilot/assets/14822839/81860705-31c6-4f71-a07a-5442b1918f57)

This PR:
![Screenshot from 2024-05-27 16-01-47](https://github.com/PX4/PX4-Autopilot/assets/14822839/2d2b0893-dd37-4dd2-b1b0-e73deb16d1b1)
