### PR TITLE
MAVLink: remove never used `_mavlink_link_termination_allowed`

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1963,10 +1963,6 @@ Mavlink::task_main(int argc, char *argv[])
 			break;
 #endif
 
-//		case 'e':
-//			_mavlink_link_termination_allowed = true;
-//			break;
-
 		case 'm': {
 
 				int mode;

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -597,8 +597,6 @@ private:
 	 */
 	unsigned int		_mavlink_param_queue_index{0};
 
-	bool			_mavlink_link_termination_allowed{false};
-
 	char			*_subscribe_to_stream{nullptr};
 	float			_subscribe_to_stream_rate{0.0f};  ///< rate of stream to subscribe to (0=disable, -1=unlimited, -2=default)
 	bool			_udp_initialised{false};


### PR DESCRIPTION
### Solved Problem
When looking through the MAVLink implementation I found this commented out code to set a member that wasn't used for 10+ years. See: https://github.com/PX4/PX4-Autopilot/commit/346ae5b9f4fc2da13e6d890521f48768b6b6e8c2#diff-6128b04d894d13fd44974cb4c71a674ccd1338cbeb7e25c464f931fd666b7721

### Solution
Remove it