### PR TITLE
CameraFeedback: shorten line length such that documentation parser works

### DIFF
--- a/src/modules/camera_feedback/CameraFeedback.cpp
+++ b/src/modules/camera_feedback/CameraFeedback.cpp
@@ -196,7 +196,7 @@ CameraFeedback::print_usage(const char *reason)
 
 The camera_feedback module publishes `CameraCapture` UORB topics when image capture has been triggered.
 
-If camera capture is enabled, then trigger information from the camera capture pin is published; 
+If camera capture is enabled, then trigger information from the camera capture pin is published;
 otherwise trigger information at the point the camera was commanded to trigger is published
 (from the `camera_trigger` module).
 
@@ -205,8 +205,9 @@ The `CAMERA_IMAGE_CAPTURED` message is then emitted (by streaming code) followin
 
 ### Implementation
 
-`CameraTrigger` topics are published by the `camera_trigger` module (`feedback` field set `false`) when image capture is triggered,
-and may also be published by the  `camera_capture` driver (with `feedback` field set `true`) if the camera capture pin is activated.
+`CameraTrigger` topics are published by the `camera_trigger` module (`feedback` field set `false`)
+when image capture is triggered, and may also be published by the  `camera_capture` driver
+(with `feedback` field set `true`) if the camera capture pin is activated.
 
 The `camera_feedback` module subscribes to `CameraTrigger`.
 It discards topics from the `camera_trigger` module if camera capture is enabled.


### PR DESCRIPTION
### Solved Problem
When checking CI failures I found that https://github.com/PX4/PX4-Autopilot/pull/23103 broke the automatic documenation generator by exceeding the maximum line length of the parser.

This was flagged by CI also on the PR see https://github.com/PX4/PX4-Autopilot/actions/runs/9184141819/job/25255983514 but apparently ignored presumably because other checks are failing on main.

### Solution
Shortening the lines.

### Test coverage
I ran the documentation target locally to verify this change makes it run through.
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/3b64b666-f666-4c08-9127-870995005e85)
