### PR TITLE
Increase default of MIS_DIST_1WP to 10km

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1033_jsbsim_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1033_jsbsim_rascal
@@ -24,7 +24,6 @@ param set-default FW_RR_P 0.085
 param set-default FW_W_EN 1
 
 param set-default MIS_TAKEOFF_ALT 20
-param set-default MIS_DIST_1WP 2500
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1034_flightgear_rascal-electric
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1034_flightgear_rascal-electric
@@ -24,7 +24,6 @@ param set-default FW_RR_P 0.085
 param set-default FW_W_EN 1
 
 param set-default MIS_TAKEOFF_ALT 20
-param set-default MIS_DIST_1WP 2500
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1036_jsbsim_malolo
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1036_jsbsim_malolo
@@ -24,7 +24,6 @@ param set-default FW_RR_P 0.085
 param set-default FW_W_EN 1
 
 param set-default MIS_TAKEOFF_ALT 20
-param set-default MIS_DIST_1WP 2500
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1039_flightgear_rascal
@@ -25,7 +25,6 @@ param set-default FW_W_EN 1
 
 param set-default MIS_LTRMIN_ALT 30
 param set-default MIS_TAKEOFF_ALT 20
-param set-default MIS_DIST_1WP 2500
 
 param set-default NAV_ACC_RAD 15
 param set-default NAV_DLL_ACT 2

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -66,7 +66,6 @@ param set-default MC_PITCHRATE_I 0.05
 param set-default MC_YAWRATE_MAX 20
 param set-default MC_AIRMODE 1
 
-param set-default MIS_DIST_1WP 100
 param set-default MIS_TAKEOFF_ALT 15
 
 param set-default MPC_XY_P 0.8

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -87,7 +87,7 @@ PARAM_DEFINE_INT32(MIS_TKO_LAND_REQ, 0);
  * @increment 100
  * @group Mission
  */
-PARAM_DEFINE_FLOAT(MIS_DIST_1WP, 900);
+PARAM_DEFINE_FLOAT(MIS_DIST_1WP, 10000);
 
 /**
 * Enable yaw control of the mount. (Only affects multicopters and ROI mission items)


### PR DESCRIPTION

### Solved Problem
A too low value on this check is very annoying and not really necessary. It's main purpose is to prevent a mission plan that was not planned at the current flight location to be executed.

### Solution
Increase default to 10km. 

I've also removed a custom setting of MIS_DIST_1WP from some aiframes that I think is not needed anymore. 

### Changelog Entry
For release notes:
```
Improvement: Increase default of MIS_DIST_1WP to 10km
```

### Alternatives
We could also remove the check around MIS_DIST_1WP completely?
