### PR TITLE
Increased the size of the memory heap available to qurt platform

### DIFF
--- a/platforms/qurt/CMakeLists.txt
+++ b/platforms/qurt/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(
 
 add_library(px4 SHARED
 	${PX4_SOURCE_DIR}/platforms/qurt/unresolved_symbols.c
+	${PX4_SOURCE_DIR}/platforms/qurt/c++.cpp
 	${PX4_BINARY_DIR}/apps.cpp
 	)
 

--- a/platforms/qurt/CMakeLists.txt
+++ b/platforms/qurt/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories(
 
 add_library(px4 SHARED
 	${PX4_SOURCE_DIR}/platforms/qurt/unresolved_symbols.c
-	${PX4_SOURCE_DIR}/platforms/qurt/c++.cpp
+	${PX4_SOURCE_DIR}/platforms/qurt/new_delete.cpp
 	${PX4_BINARY_DIR}/apps.cpp
 	)
 

--- a/platforms/qurt/c++.cpp
+++ b/platforms/qurt/c++.cpp
@@ -1,0 +1,93 @@
+#include <stdlib.h>
+#include <new>
+#include <px4_log.h>
+
+/*
+  These are the heap access function exported by the SLPI DSP image.
+*/
+extern "C" {
+	void *fc_heap_alloc(size_t size);
+	void fc_heap_free(void *ptr);
+}
+
+/*
+  Globally override new and delete so that it can use the correct
+  heap manager for the Qurt platform.
+
+  Note that new comes in multiple different variants. When new is used
+  without std::nothrow the compiler is free to assume it will not fail
+  as it assumes exceptions are enabled. This makes code like this
+  unsafe when using -fno-exceptions:
+
+    a = new b;
+    if (a == nullptr) {
+      handle_error()
+    }
+
+  The compiler may remove the error handling. With g++ you can use
+  -fcheck-new to avoid this, but on clang++ the compiler accepts
+  -fcheck-new as a valid flag, but doesn't implement it, and may remove
+  the error checking. That makes using clang++ unsafe with
+  -fno-exceptions if you ever call new without std::nothrow.
+..It has been verified that hexagon-clang++ will remove the nullptr checks
+  after new if any optimization is selected for the compiler.
+*/
+
+/*
+  variant for new(std::nothrow), which is all that should be used in
+  PX4
+ */
+void *operator new (size_t size, std::nothrow_t const &nothrow) noexcept
+{
+	if (size < 1) {
+		size = 1;
+	}
+
+	return (fc_heap_alloc(size));
+}
+
+void *operator new[](size_t size, std::nothrow_t const &nothrow) noexcept
+{
+	if (size < 1) {
+		size = 1;
+	}
+
+	return (fc_heap_alloc(size));
+}
+
+/*
+  These variants are for new without std::nothrow. We don't want to ever
+  use these from PX4 code
+ */
+void *operator new (size_t size)
+{
+	if (size < 1) {
+		size = 1;
+	}
+
+	return (fc_heap_alloc(size));
+}
+
+
+void *operator new[](size_t size)
+{
+	if (size < 1) {
+		size = 1;
+	}
+
+	return (fc_heap_alloc(size));
+}
+
+/*
+	Override delete to free up memory to correct heap
+*/
+
+void operator delete (void *p) noexcept
+{
+	if (p) { fc_heap_free(p); }
+}
+
+void operator delete[](void *ptr) noexcept
+{
+	if (ptr) { fc_heap_free(ptr); }
+}

--- a/platforms/qurt/new_delete.cpp
+++ b/platforms/qurt/new_delete.cpp
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <new>
-#include <px4_log.h>
 
 /*
   These are the heap access function exported by the SLPI DSP image.


### PR DESCRIPTION

### Solved Problem
The qurt platform is using one of multiple heaps available that only has 700KB of space. This PR changes that heap to one
with 3MB and is not shared with any other services. This is important because the qurt platform will crash if a C++ new operator operation fails so it needs to have a nice safety margin in the heap size. In order to use the larger heap the new and delete operators had to be overridden. To avoid a crash when a new operation fails all of the PX4 code would need to move from "new" to "new (nothrow)" but that's a whole different discussion.