### PR TITLE
PowerCheck: reduce threshold for low avionics voltage warning to 4.6V

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/powerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/powerCheck.cpp
@@ -75,7 +75,7 @@ void PowerChecks::checkAndReport(const Context &context, Report &reporter)
 			float avionics_power_rail_voltage = system_power.voltage5v_v;
 
 			const float low_error_threshold = 4.5f;
-			const float low_warning_threshold = 4.8f;
+			const float low_warning_threshold = 4.6f;
 			const float high_warning_threshold = 5.4f;
 
 			if (avionics_power_rail_voltage < low_warning_threshold) {


### PR DESCRIPTION

### Solved Problem
The current warning threshold is rather over-sensitive and triggers quite some false-positives, as most (all?) Pixhawk type flight controllers work fine with voltages slightly below the old warning threshold of 4.8V.

### Solution
Reduce warning threshold from 4.8V to 4.6V.

### Changelog Entry
For release notes:
```
Improvement: PowerCheck: reduce threshold for low avionics voltage warning to 4.6V
```

