### PR TITLE
hjust_nxt-dual board_config: disable FLASH_BASED_PARAMS to fix CI

### DIFF
--- a/boards/hkust/nxt-dual/src/board_config.h
+++ b/boards/hkust/nxt-dual/src/board_config.h
@@ -53,7 +53,7 @@
  * Definitions
  ****************************************************************************************************/
 
-#define FLASH_BASED_PARAMS
+// #define FLASH_BASED_PARAMS
 
 
 /* LEDs are driven with push open drain to support Anode to 5V or 3.3V */


### PR DESCRIPTION
### Solved Problem
When checking CI on main I found that many jobs are canceled
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/04a194d5-ab03-4272-843e-35986b5a2a67)
If I checked correctly this seems to be because one build fails
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/368264cb-2264-4e5e-8b3b-c48b449de567)
and here's the output from one of the runs:
https://github.com/PX4/PX4-Autopilot/actions/runs/9284046935/job/25548970580

Looking at what causes this I see @Peize-Liu added hkust_nxt-dual board support in
#22961 f7bc13dab0d7f5c32a104e7206036d435c4293d3
which presumably contains a flaw where `FLASH_BASED_PARAMS` is enabled but there's no memory allocated for that using `APP_RESERVATION_SIZE`. This went unnoticed until

@AlexKlimaj added an explicit check for that exact issue in
#22829 528ad1e87d4aba286be9a5133ba775e922d2005b
presumably because he did the mistake himself and wanted to prevent others from running into it.

### Solution
Looking at the very similar board hkust_nxt-v1 which doesn't have this issue because it does not enable `FLASH_BASED_PARAMS` I assume without further context that's the right thing to do here as well. Please correct me if I'm wrong.

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
The build `make hkust_nxt-dual_bootloader` runs through fine again locally which should fix CI. If the board ever did or still does what it should I cannot test. Please check @Peize-Liu
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/a464559e-6013-461c-b7ea-a305515f05dc)