### PR TITLE
Jankinsfile-compile: add missing comma after `ark_pi6x_default`

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -47,7 +47,7 @@ pipeline {
                      "ark_fmu-v6x_bootloader",
                      "ark_fmu-v6x_default",
                      "ark_pi6x_bootloader",
-                     "ark_pi6x_default"
+                     "ark_pi6x_default",
                      "atl_mantis-edu_default",
                      "av_x-v1_default",
                      "bitcraze_crazyflie21_default",


### PR DESCRIPTION
### Solved Problem
In https://github.com/PX4/PX4-Autopilot/pull/22829 the Jenkins build for the new board was added here:
https://github.com/PX4/PX4-Autopilot/commit/528ad1e87d4aba286be9a5133ba775e922d2005b#diff-1b600ac63a07cb41bf62e2cf4c19fcd9cc6b4ff52b35acb181383e44b839db37R50
but the comma was forgotten, this makes Jenkins fail on main with a Syntax error:
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/dd39a8a9-d189-4e7c-a4f4-815d280be462)
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/ef382703-d441-403b-8c52-7b24da9ac524)

### Solution
Add the missing comma.

### Test coverage
I can't test locally but I'm confident it will fix at least this error and show us the next one.