### PR TITLE
Fix seconds vs milliseconds comparison in ControlAllocator.cpp

### DIFF
--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -393,7 +393,7 @@ ControlAllocator::Run()
 	if (_vehicle_thrust_setpoint_sub.update(&vehicle_thrust_setpoint)) {
 		_thrust_sp = matrix::Vector3f(vehicle_thrust_setpoint.xyz);
 
-		if (dt > 5_ms) {
+		if (dt > 0.005f) {
 			do_update = true;
 			_timestamp_sample = vehicle_thrust_setpoint.timestamp_sample;
 		}


### PR DESCRIPTION
### Solved Problem
In `src/modules/control_allocator/ControlAllocator.cpp`, there was an incorrect comparison between a float variable `dt` representing seconds and a `uint64_t` value representing 5 milliseconds (`5_ms` = 5000). As a result, `do_update` could never become true, even if the last torque setpoint had been received more than 5 milliseconds before. I didn't find any issue linked to this.

### Solution
To solve this, the `5_ms` value has been converted to seconds (0.005f) for the comparison with `dt`.
