### PR TITLE
Fixed a small memory leak in uORBManager.cpp

### DIFF
--- a/platforms/common/uORB/ORBSet.hpp
+++ b/platforms/common/uORB/ORBSet.hpp
@@ -62,6 +62,11 @@ public:
 	{
 		Node **p;
 
+		// Don't allow duplicates to be inserted
+		if (find(node_name)) {
+			return;
+		}
+
 		if (_top == nullptr) {
 			p = &_top;
 

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -621,7 +621,11 @@ int16_t uORB::Manager::process_remote_topic(const char *topic_name)
 			if (node) {
 				PX4_DEBUG("Marking DeviceNode(%s) as advertised in process_remote_topic", topic_name);
 				node->mark_as_advertised();
-				_remote_topics.insert(topic_name);
+
+				if (_remote_topics.find(topic_name) == false) {
+					_remote_topics.insert(topic_name);
+				}
+
 				return 0;
 			}
 		}

--- a/platforms/common/uORB/uORBManager.cpp
+++ b/platforms/common/uORB/uORBManager.cpp
@@ -621,11 +621,7 @@ int16_t uORB::Manager::process_remote_topic(const char *topic_name)
 			if (node) {
 				PX4_DEBUG("Marking DeviceNode(%s) as advertised in process_remote_topic", topic_name);
 				node->mark_as_advertised();
-
-				if (_remote_topics.find(topic_name) == false) {
-					_remote_topics.insert(topic_name);
-				}
-
+				_remote_topics.insert(topic_name);
 				return 0;
 			}
 		}


### PR DESCRIPTION
### Solved Problem
On VOXL 2 platform where CONFIG_ORB_COMMUNICATOR is used there was a small memory leak where a topic name was being added to an ORBSet even if it was already in there. This PR fixes that so it's only added if it isn't in there already.
