### PR TITLE
Only close server when errno is not EINTR

### DIFF
--- a/platforms/posix/src/px4/common/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4/common/px4_daemon/server.cpp
@@ -153,9 +153,8 @@ Server::_server_main()
 			// Reboot command causes System Interrupt to stop poll(). This is not an error
 			if (errno != EINTR) {
 				PX4_ERR("poll() failed: %s", strerror(errno));
+				break;
 			}
-
-			break;
 		}
 
 		_lock();


### PR DESCRIPTION
### Solved Problem
When I try to run a startup script I found that the system() call for that startup script was triggering a daemon server error that shuts down the socket early. Looks like another developer had handled this case by trying to ignore the specific errno for that system() triggered error, but left the `break` of that socket while loop outside of that errno check. 

### Solution
Moved `break` into the if errno check

### Changelog Entry
For release notes:
- Fixed daemon server errno handling bug
