### PR TITLE
fix commander: make sure to count all valid mags in preflight check

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/magnetometerCheck.cpp
@@ -50,10 +50,6 @@ void MagnetometerChecks::checkAndReport(const Context &context, Report &reporter
 		bool is_mag_fault = false;
 		const bool is_required = instance == 0 || isMagRequired(instance, is_mag_fault);
 
-		if (!is_required) {
-			continue;
-		}
-
 		const bool exists = _sensor_mag_sub[instance].advertised();
 		bool is_valid = false;
 		bool is_calibration_valid = false;
@@ -81,6 +77,11 @@ void MagnetometerChecks::checkAndReport(const Context &context, Report &reporter
 			}
 
 			reporter.setIsPresent(health_component_t::magnetometer);
+		}
+
+		// Do not raise errors if a mag is not required
+		if (!is_required) {
+			continue;
 		}
 
 		const bool is_sensor_ok = is_valid && is_calibration_valid && !is_mag_fault;


### PR DESCRIPTION
Previously, if a mag was not required (not index 0 and not used by ekf), it was not counted in num_enabled_and_valid_calibration. If a user set SYS_HAS_MAG to e.g. 3, it would then trigger a preflight failure, even if there were 3 calibrated and enabled mags.

