### PR TITLE
rc_input: singlewire use push_pull

### DIFF
--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -314,7 +314,7 @@ void  RCInput::swap_rx_tx()
 #  ifdef TIOCSSINGLEWIRE
 
 	if (rv != OK) {
-		ioctl(_rcs_fd, TIOCSSINGLEWIRE, SER_SINGLEWIRE_ENABLED);
+		ioctl(_rcs_fd, TIOCSSINGLEWIRE, SER_SINGLEWIRE_ENABLED | SER_SINGLEWIRE_PUSHPULL);
 	}
 
 #  else


### PR DESCRIPTION
Typical RC receivers use weak-pull so for single-wire communication push_pull is recommended.
Tested on V6X-RT but also needs testing on Pixhawk 4 - FMUv5