### PR TITLE
driver: imu: sch16t: improvements

### DIFF
--- a/src/drivers/imu/murata/sch16t/Murata_SCH16T_registers.hpp
+++ b/src/drivers/imu/murata/sch16t/Murata_SCH16T_registers.hpp
@@ -37,16 +37,109 @@
 
 namespace Murata_SCH16T
 {
-static constexpr uint32_t SPI_SPEED = 5 * 1000 * 1000;  	// 5 MHz SPI serial interface
-static constexpr uint32_t SAMPLE_INTERVAL_US = 678;     	// 1500 Hz -- decimation factor 8, F_PRIM/16, 1.475 kHz
-static constexpr uint16_t EOI = (1 << 1); 			// End of Initialization
-static constexpr uint16_t EN_SENSOR = (1 << 0); 		// Enable RATE and ACC measurement
-static constexpr uint16_t DRY_DRV_EN = (1 << 5); 		// Enables Data ready function
-static constexpr uint16_t FILTER_BYPASS = (0b111); 		// Bypass filter
-static constexpr uint16_t RATE_300DPS_1475HZ = 0b0'001'001'011'011'011; // Gyro XYZ range 300 deg/s @ 1475Hz
-static constexpr uint16_t ACC12_8G_1475HZ = 0b0'001'001'011'011'011;  // Acc XYZ range 8 G and 1475 update rate
-static constexpr uint16_t ACC3_26G = (0b000 << 0);
+// General definitions
+static constexpr uint16_t EOI = (1 << 1);               // End of Initialization
+static constexpr uint16_t EN_SENSOR = (1 << 0);         // Enable RATE and ACC measurement
+static constexpr uint16_t DRY_DRV_EN = (1 << 5);        // Enables Data ready function
 static constexpr uint16_t SPI_SOFT_RESET = (0b1010);
+
+// Filter settings
+static constexpr uint8_t FILTER_13_HZ = (0b010);
+static constexpr uint8_t FILTER_30_HZ = (0b001);
+static constexpr uint8_t FILTER_68_HZ = (0b000);
+static constexpr uint8_t FILTER_280_HZ = (0b011);
+static constexpr uint8_t FILTER_370_HZ = (0b100);
+static constexpr uint8_t FILTER_235_HZ = (0b101);
+static constexpr uint8_t FILTER_BYPASS = (0b111);
+
+// Dynamic range settings
+static constexpr uint8_t RATE_RANGE_300 = (0b001);
+static constexpr uint8_t ACC12_RANGE_80 = (0b001);
+static constexpr uint8_t ACC3_RANGE_260 = (0b000);
+
+// Decimation ratio settings
+static constexpr uint8_t DECIMATION_NONE =	(0b000);
+static constexpr uint8_t DECIMATION_5900_HZ =	(0b001);
+static constexpr uint8_t DECIMATION_2950_HZ =	(0b010);
+static constexpr uint8_t DECIMATION_1475_HZ =	(0b011);
+static constexpr uint8_t DECIMATION_738_HZ =	(0b100);
+
+// TODO: remove the below
+// Range and decimation settings
+// static constexpr uint16_t RATE_300DPS_1475HZ = 0b0'001'001'011'011'011; // Gyro XYZ range 300 deg/s @ 1475Hz
+// static constexpr uint16_t ACC12_8G_1475HZ = 0b0'001'001'011'011'011;  // Acc XYZ range 8 G and 1475 update rate
+// static constexpr uint16_t ACC3_26G = (0b000 << 0);
+
+union CTRL_FILT_RATE_Register {
+	struct {
+		uint16_t FILT_SEL_RATE_X  : 3;
+		uint16_t FILT_SEL_RATE_Y  : 3;
+		uint16_t FILT_SEL_RATE_Z  : 3;
+		uint16_t reserved         : 7;
+	} bits;
+
+	uint16_t value;
+};
+
+union CTRL_FILT_ACC12_Register {
+	struct {
+		uint16_t FILT_SEL_ACC_X12  : 3;
+		uint16_t FILT_SEL_ACC_Y12  : 3;
+		uint16_t FILT_SEL_ACC_Z12  : 3;
+		uint16_t reserved         : 7;
+	} bits;
+
+	uint16_t value;
+};
+
+union CTRL_FILT_ACC3_Register {
+	struct {
+		uint16_t FILT_SEL_ACC_X3  : 3;
+		uint16_t FILT_SEL_ACC_Y3  : 3;
+		uint16_t FILT_SEL_ACC_Z3  : 3;
+		uint16_t reserved         : 7;
+	} bits;
+
+	uint16_t value;
+};
+
+union RATE_CTRL_Register {
+	struct {
+		uint16_t DEC_RATE_X2  : 3;
+		uint16_t DEC_RATE_Y2  : 3;
+		uint16_t DEC_RATE_Z2  : 3;
+		uint16_t DYN_RATE_XYZ2: 3;
+		uint16_t DYN_RATE_XYZ1: 3;
+		uint16_t reserved     : 1;
+	} bits;
+
+	// Allow direct access as a uint16_t
+	uint16_t value;
+};
+
+union ACC12_CTRL_Register {
+	struct {
+		uint16_t DEC_ACC_X2  : 3;
+		uint16_t DEC_ACC_Y2  : 3;
+		uint16_t DEC_ACC_Z2  : 3;
+		uint16_t DYN_ACC_XYZ2: 3;
+		uint16_t DYN_ACC_XYZ1: 3;
+		uint16_t reserved     : 1;
+	} bits;
+
+	// Allow direct access as a uint16_t
+	uint16_t value;
+};
+
+union ACC3_CTRL_Register {
+	struct {
+		uint16_t DYN_ACC_XYZ3  : 3;
+		uint16_t reserved     : 13;
+	} bits;
+
+	// Allow direct access as a uint16_t
+	uint16_t value;
+};
 
 // Data registers
 #define RATE_X1         0x01 // 20 bit

--- a/src/drivers/imu/murata/sch16t/Murata_SCH16T_registers.hpp
+++ b/src/drivers/imu/murata/sch16t/Murata_SCH16T_registers.hpp
@@ -64,12 +64,6 @@ static constexpr uint8_t DECIMATION_2950_HZ =	(0b010);
 static constexpr uint8_t DECIMATION_1475_HZ =	(0b011);
 static constexpr uint8_t DECIMATION_738_HZ =	(0b100);
 
-// TODO: remove the below
-// Range and decimation settings
-// static constexpr uint16_t RATE_300DPS_1475HZ = 0b0'001'001'011'011'011; // Gyro XYZ range 300 deg/s @ 1475Hz
-// static constexpr uint16_t ACC12_8G_1475HZ = 0b0'001'001'011'011'011;  // Acc XYZ range 8 G and 1475 update rate
-// static constexpr uint16_t ACC3_26G = (0b000 << 0);
-
 union CTRL_FILT_RATE_Register {
 	struct {
 		uint16_t FILT_SEL_RATE_X  : 3;
@@ -113,7 +107,6 @@ union RATE_CTRL_Register {
 		uint16_t reserved     : 1;
 	} bits;
 
-	// Allow direct access as a uint16_t
 	uint16_t value;
 };
 
@@ -127,7 +120,6 @@ union ACC12_CTRL_Register {
 		uint16_t reserved     : 1;
 	} bits;
 
-	// Allow direct access as a uint16_t
 	uint16_t value;
 };
 
@@ -137,7 +129,6 @@ union ACC3_CTRL_Register {
 		uint16_t reserved     : 13;
 	} bits;
 
-	// Allow direct access as a uint16_t
 	uint16_t value;
 };
 

--- a/src/drivers/imu/murata/sch16t/SCH16T.cpp
+++ b/src/drivers/imu/murata/sch16t/SCH16T.cpp
@@ -300,6 +300,7 @@ bool SCH16T::ReadData(SensorData *data)
 	static constexpr uint64_t STATUS_DOING_INIT = 0b11;
 
 	uint64_t values[] = { gyro_x, gyro_y, gyro_z, acc_x, acc_y, acc_z, temp };
+
 	for (auto v : values) {
 		// [1b ][1b][ 2b ]
 		// [IDS][CE][S1:0]
@@ -316,12 +317,15 @@ bool SCH16T::ReadData(SensorData *data)
 		if (v & MASK48_GENERAL_ERROR) {
 			perf_count(_perf_general_error);
 			return false;
+
 		} else if (v & MASK48_COMMAND_ERROR) {
 			perf_count(_perf_command_error);
 			return false;
+
 		} else if ((v & MASK48_DOING_INIT) == STATUS_DOING_INIT) {
 			perf_count(_perf_doing_initialization);
 			return false;
+
 		} else if (v & MASK48_SATURATION_ERROR) {
 			perf_count(_perf_saturation_error);
 			// Don't consider saturation an error
@@ -333,6 +337,7 @@ bool SCH16T::ReadData(SensorData *data)
 			return false;
 		}
 	}
+
 	// Data registers are 20bit 2s complement
 	data->acc_x    = SPI48_DATA_INT32(acc_x);
 	data->acc_y    = SPI48_DATA_INT32(acc_y);

--- a/src/drivers/imu/murata/sch16t/SCH16T.cpp
+++ b/src/drivers/imu/murata/sch16t/SCH16T.cpp
@@ -319,12 +319,12 @@ bool SCH16T::ReadData(SensorData *data)
 		} else if (v & MASK48_COMMAND_ERROR) {
 			perf_count(_perf_command_error);
 			return false;
-		} else if (v & MASK48_SATURATION_ERROR) {
-			perf_count(_perf_saturation_error);
-			return false;
 		} else if ((v & MASK48_DOING_INIT) == STATUS_DOING_INIT) {
 			perf_count(_perf_doing_initialization);
 			return false;
+		} else if (v & MASK48_SATURATION_ERROR) {
+			perf_count(_perf_saturation_error);
+			// Don't consider saturation an error
 		}
 
 		// Validate the CRC

--- a/src/drivers/imu/murata/sch16t/SCH16T.cpp
+++ b/src/drivers/imu/murata/sch16t/SCH16T.cpp
@@ -104,9 +104,7 @@ int SCH16T::probe()
 	PX4_INFO("COMP_ID:\t 0x%0x", comp_id);
 	PX4_INFO("ASIC_ID:\t 0x%0x", asic_id);
 
-	// SCH16T-K01 	- 	ID hex = 0x0020
-	// SCH1633-B13 	- 	ID hex = 0x0017
-	bool success = asic_id == 0x20 && comp_id == 0x17;
+	bool success = asic_id == 0x21 && comp_id == 0x23;
 
 	return success ? PX4_OK : PX4_ERROR;
 }
@@ -279,57 +277,29 @@ void SCH16T::RunImpl()
 
 bool SCH16T::ReadData(SensorData *data)
 {
-	uint64_t temp = 0;
-	uint64_t gyro_x = 0;
-	uint64_t gyro_y = 0;
-	uint64_t gyro_z = 0;
-	uint64_t acc_x = 0;
-	uint64_t acc_y = 0;
-	uint64_t acc_z = 0;
-
-	// Data registers are 20bit 2s complement
-	RegisterRead(TEMP);
-	temp   = RegisterRead(STAT_SUM_SAT);
-	_sensor_status.saturation = SPI48_DATA_UINT16(RegisterRead(RATE_X2));
-	gyro_x = RegisterRead(RATE_Y2);
-	gyro_y = RegisterRead(RATE_Z2);
-
-	// Check if ACC2 is saturated, if so, use ACC3
-	if ((_sensor_status.saturation & STAT_SUM_SAT_ACC_X2) || (_sensor_status.saturation & STAT_SUM_SAT_ACC_Y2)
-	    || (_sensor_status.saturation & STAT_SUM_SAT_ACC_Z2)) {
-		gyro_z = RegisterRead(ACC_X3);
-		acc_x  = RegisterRead(ACC_Y3);
-		acc_y  = RegisterRead(ACC_Z3);
-		acc_z  = RegisterRead(TEMP);
-		_px4_accel.set_scale(1.f / 1600.f);
-		_px4_accel.set_range(260.f);
-
-	} else {
-		gyro_z = RegisterRead(ACC_X2);
-		acc_x  = RegisterRead(ACC_Y2);
-		acc_y  = RegisterRead(ACC_Z2);
-		acc_z  = RegisterRead(TEMP);
-		_px4_accel.set_scale(1.f / 3200.f);
-		_px4_accel.set_range(163.4f);
-	}
+	RegisterRead(RATE_X2);
+	uint64_t gyro_x = RegisterRead(RATE_Y2);
+	uint64_t gyro_y = RegisterRead(RATE_Z2);
+	uint64_t gyro_z = RegisterRead(ACC_X3);
+	uint64_t acc_x  = RegisterRead(ACC_Y3);
+	uint64_t acc_y  = RegisterRead(ACC_Z3);
+	uint64_t acc_z  = RegisterRead(TEMP);
+	uint64_t temp   = RegisterRead(TEMP);
 
 	static constexpr uint64_t MASK48_ERROR = 0x001E00000000UL;
 	uint64_t values[] = { gyro_x, gyro_y, gyro_z, acc_x, acc_y, acc_z, temp };
-
 	for (auto v : values) {
 		// Check for frame errors
 		if (v & MASK48_ERROR) {
 			perf_count(_perf_frame_bad);
 			return false;
 		}
-
 		// Validate the CRC
 		if (uint8_t(v & 0xff) != CalculateCRC8(v)) {
 			perf_count(_perf_crc_bad);
 			return false;
 		}
 	}
-
 	// Data registers are 20bit 2s complement
 	data->acc_x    = SPI48_DATA_INT32(acc_x);
 	data->acc_y    = SPI48_DATA_INT32(acc_y);
@@ -339,7 +309,6 @@ bool SCH16T::ReadData(SensorData *data)
 	data->gyro_z   = SPI48_DATA_INT32(gyro_z);
 	// Temperature data is always 16 bits wide. Drop 4 LSBs as they are not used.
 	data->temp 	  = SPI48_DATA_INT32(temp) >> 4;
-
 	// Conver to PX4 coordinate system (FLU to FRD)
 	data->acc_x = data->acc_x;
 	data->acc_y = -data->acc_y;
@@ -347,7 +316,6 @@ bool SCH16T::ReadData(SensorData *data)
 	data->gyro_x = data->gyro_x;
 	data->gyro_y = -data->gyro_y;
 	data->gyro_z = -data->gyro_z;
-
 	return true;
 }
 

--- a/src/drivers/imu/murata/sch16t/SCH16T.hpp
+++ b/src/drivers/imu/murata/sch16t/SCH16T.hpp
@@ -143,7 +143,10 @@ private:
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};
 	perf_counter_t _perf_crc_bad{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": CRC8 bad"))};
-	perf_counter_t _perf_frame_bad{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Frame bad"))};
 	perf_counter_t _drdy_missed_perf{nullptr};
 
+	perf_counter_t _perf_general_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": General error"))};
+	perf_counter_t _perf_command_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Command error"))};
+	perf_counter_t _perf_saturation_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Saturation error"))};
+	perf_counter_t _perf_doing_initialization{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Doing initialization"))};
 };

--- a/src/drivers/imu/murata/sch16t/SCH16T.hpp
+++ b/src/drivers/imu/murata/sch16t/SCH16T.hpp
@@ -141,10 +141,10 @@ private:
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};
 	perf_counter_t _perf_crc_bad{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": CRC8 bad"))};
 	perf_counter_t _drdy_missed_perf{nullptr};
-	perf_counter_t _perf_general_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": General error"))};
-	perf_counter_t _perf_command_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Command error"))};
-	perf_counter_t _perf_saturation_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Saturation error"))};
-	perf_counter_t _perf_doing_initialization{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Doing initialization"))};
+	perf_counter_t _perf_general_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": general error"))};
+	perf_counter_t _perf_command_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": command error"))};
+	perf_counter_t _perf_saturation_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": saturation error"))};
+	perf_counter_t _perf_doing_initialization{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": re-initializing"))};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::SCH16T_GYRO_FILT>) _sch16t_gyro_filt,

--- a/src/drivers/imu/murata/sch16t/SCH16T.hpp
+++ b/src/drivers/imu/murata/sch16t/SCH16T.hpp
@@ -34,14 +34,14 @@
 #pragma once
 
 #include "Murata_SCH16T_registers.hpp"
-
+#include <px4_platform_common/module_params.h>
 #include <px4_platform_common/i2c_spi_buses.h>
 #include <lib/drivers/accelerometer/PX4Accelerometer.hpp>
 #include <lib/drivers/gyroscope/PX4Gyroscope.hpp>
 
 using namespace Murata_SCH16T;
 
-class SCH16T : public device::SPI, public I2CSPIDriver<SCH16T>
+class SCH16T : public device::SPI, public I2CSPIDriver<SCH16T>, public ModuleParams
 {
 public:
 	SCH16T(const I2CSPIDriverConfig &config);
@@ -79,7 +79,7 @@ private:
 	};
 
 	struct RegisterConfig {
-		RegisterConfig(uint16_t a, uint16_t v)
+		RegisterConfig(uint16_t a = 0, uint16_t v = 0)
 			: addr(a)
 			, value(v)
 		{};
@@ -100,6 +100,8 @@ private:
 	void ReadStatusRegisters();
 
 	void Configure();
+	void ConfigurationFromParameters();
+
 	void SoftwareReset();
 
 	void RegisterWrite(uint8_t addr, uint16_t value);
@@ -131,22 +133,22 @@ private:
 		READ,
 	} _state{STATE::RESET_INIT};
 
-	RegisterConfig _registers[6] = {
-		RegisterConfig(CTRL_FILT_RATE,  FILTER_BYPASS),         // Bypass filter
-		RegisterConfig(CTRL_FILT_ACC12, FILTER_BYPASS),         // Bypass filter
-		RegisterConfig(CTRL_FILT_ACC3,  FILTER_BYPASS),         // Bypass filter
-		RegisterConfig(CTRL_RATE,       RATE_300DPS_1475HZ),    // +/- 300 deg/s, 1600 LSB/(deg/s) -- default, Decimation 8, 1475Hz
-		RegisterConfig(CTRL_ACC12,      ACC12_8G_1475HZ),       // +/- 80 m/s^2, 3200 LSB/(m/s^2) -- default, Decimation 8, 1475Hz
-		RegisterConfig(CTRL_ACC3,       ACC3_26G)               // +/- 260 m/s^2, 1600 LSB/(m/s^2) -- default
-	};
+	RegisterConfig _registers[6];
+
+	uint32_t _sample_interval_us = 678;
 
 	perf_counter_t _reset_perf{perf_alloc(PC_COUNT, MODULE_NAME": reset")};
 	perf_counter_t _bad_transfer_perf{perf_alloc(PC_COUNT, MODULE_NAME": bad transfer")};
 	perf_counter_t _perf_crc_bad{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": CRC8 bad"))};
 	perf_counter_t _drdy_missed_perf{nullptr};
-
 	perf_counter_t _perf_general_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": General error"))};
 	perf_counter_t _perf_command_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Command error"))};
 	perf_counter_t _perf_saturation_error{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Saturation error"))};
 	perf_counter_t _perf_doing_initialization{perf_counter_t(perf_alloc(PC_COUNT, MODULE_NAME": Doing initialization"))};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::SCH16T_GYRO_FILT>) _sch16t_gyro_filt,
+		(ParamInt<px4::params::SCH16T_ACC_FILT>) _sch16t_acc_filt,
+		(ParamInt<px4::params::SCH16T_DECIM>) _sch16t_decim
+	)
 };

--- a/src/drivers/imu/murata/sch16t/parameters.c
+++ b/src/drivers/imu/murata/sch16t/parameters.c
@@ -42,3 +42,49 @@
  * @value 1 Enabled
   */
 PARAM_DEFINE_INT32(SENS_EN_SCH16T, 0);
+
+/**
+ * Gyro filter settings
+ *
+ * @value 0 13 Hz
+ * @value 1 30 Hz
+ * @value 2 68 Hz
+ * @value 3 235 Hz
+ * @value 4 280 Hz
+ * @value 5 370 Hz
+ * @value 6 No filter
+ *
+ * @reboot_required true
+ *
+ */
+PARAM_DEFINE_INT32(SCH16T_GYRO_FILT, 2);
+
+/**
+ * Accel filter settings
+ *
+ * @value 0 13 Hz
+ * @value 1 30 Hz
+ * @value 2 68 Hz
+ * @value 3 235 Hz
+ * @value 4 280 Hz
+ * @value 5 370 Hz
+ * @value 6 No filter
+ *
+ * @reboot_required true
+ *
+ */
+PARAM_DEFINE_INT32(SCH16T_ACC_FILT, 6);
+
+/**
+ * Gyro and Accel decimation settings
+ *
+ * @value 0 None
+ * @value 1 5900 Hz
+ * @value 2 2950 Hz
+ * @value 3 1475 Hz
+ * @value 4 738 Hz
+ *
+ * @reboot_required true
+ *
+ */
+PARAM_DEFINE_INT32(SCH16T_DECIM, 4);

--- a/src/drivers/imu/murata/sch16t/sch16t_main.cpp
+++ b/src/drivers/imu/murata/sch16t/sch16t_main.cpp
@@ -50,7 +50,7 @@ extern "C" int sch16t_main(int argc, char *argv[])
 	int ch;
 	using ThisDriver = SCH16T;
 	BusCLIArguments cli{false, true};
-	cli.default_spi_frequency = SPI_SPEED;
+	cli.default_spi_frequency = 5000000;
 	cli.spi_mode = SPIDEV_MODE0;
 
 	while ((ch = cli.getOpt(argc, argv, "R:")) != EOF) {


### PR DESCRIPTION
- Added perf counters for the individual errors
- don't report saturation as an error (instead it's just reported as clipping)
- use only ACC2 (decimated 8G range)
- added parameters to configure gyro / accel filter and decimation ratio