### PR TITLE
ekf2: merge mag yaw angle observability into heading consistency

### DIFF
--- a/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
+++ b/boards/px4/fmu-v6xrt/nuttx-config/scripts/itcm_functions_includes.ld
@@ -683,7 +683,6 @@
 *(.text._ZN18MavlinkStreamDebug8get_sizeEv)
 *(.text._ZN12GPSDriverUBX7receiveEj)
 *(.text._ZN13BatteryStatus21parameter_update_pollEb)
-*(.text._ZN3Ekf26checkYawAngleObservabilityEv)
 *(.text._ZN3RTL18updateDatamanCacheEv)
 *(.text.__ieee754_sqrtf)
 *(.text._ZThn24_N18mag_bias_estimator16MagBiasEstimator3RunEv)

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -703,7 +703,6 @@ private:
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
 	// used by magnetometer fusion mode selection
-	bool _yaw_angle_observable{false};	///< true when there is enough horizontal acceleration to make yaw observable
 	AlphaFilter<float> _mag_heading_innov_lpf{0.1f};
 	uint32_t _min_mag_health_time_us{1'000'000}; ///< magnetometer is marked as healthy only after this amount of time
 
@@ -1028,7 +1027,6 @@ private:
 	void resetMagStates(const Vector3f &mag, bool reset_heading = true);
 	bool haglYawResetReq();
 
-	void checkYawAngleObservability();
 	void checkMagHeadingConsistency(const magSample &mag_sample);
 
 	bool checkMagField(const Vector3f &mag);


### PR DESCRIPTION
 - the additional hysteresis logic for "yaw angle observable" was needed when it controlled time dependent mag_3d
