### PR TITLE
ekf2: stopMagFusion() reset yaw_align if mag heading was active

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/magnetometer/mag_control.cpp
@@ -277,6 +277,15 @@ void Ekf::stopMagFusion()
 	if (_control_status.flags.mag) {
 		ECL_INFO("stopping mag fusion");
 
+		if (_control_status.flags.yaw_align && (_control_status.flags.mag_3D || _control_status.flags.mag_hdg)) {
+			// reset yaw alignment from mag unless using GNSS aiding
+			const bool using_ne_aiding = _control_status.flags.gps || _control_status.flags.aux_gpos;
+
+			if (!using_ne_aiding) {
+				_control_status.flags.yaw_align = false;
+			}
+		}
+
 		_control_status.flags.mag = false;
 		_control_status.flags.mag_dec = false;
 
@@ -290,6 +299,8 @@ void Ekf::stopMagFusion()
 			_control_status.flags.mag_hdg = false;
 			_fault_status.flags.bad_hdg = false;
 		}
+
+		_control_status.flags.mag_aligned_in_flight = false;
 
 		_fault_status.flags.bad_mag_x = false;
 		_fault_status.flags.bad_mag_y = false;


### PR DESCRIPTION
 - we also need to clear mag_aligned_in_flight
