### PR TITLE
Allow uuv_bluerov2_heavy in sitl_multiple_run.sh

### DIFF
--- a/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
+++ b/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
@@ -20,7 +20,7 @@ function spawn_model() {
 	X=${X:=0.0}
 	Y=${Y:=$((3*${N}))}
 
-	SUPPORTED_MODELS=("iris" "plane" "standard_vtol" "rover" "r1_rover" "typhoon_h480")
+	SUPPORTED_MODELS=("iris" "plane" "standard_vtol" "rover" "r1_rover" "typhoon_h480" "uuv_bluerov2_heavy")
 	if [[ " ${SUPPORTED_MODELS[*]} " != *"$MODEL"* ]];
 	then
 		echo "ERROR: Currently only vehicle model $MODEL is not supported!"


### PR DESCRIPTION
### Motivation for this PR
Recently, I noticed that the uuv_bluerov2_heavy model was not working in Gazebo Classic due to issues in the SDF model. I fixed the model and substituted the SDF with a Jinja template to allow for multi uuv_bluerov2_heavy simulations: 

https://github.com/PX4/PX4-SITL_gazebo-classic/pull/1042 

Hence, now the sitl_multiple_run.sh script should allow to simulate multiple uuv_bluerov2_heavy vehicles.
