### PR TITLE
Fix macos homebrew python env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 *.dSYM
 *.o
 *.gch

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,7 @@
 	path = platforms/nuttx/NuttX/nuttx
 	url = https://github.com/PX4/NuttX.git
 	branch = px4_firmware_nuttx-10.3.0+
+	ignore = dirty
 [submodule "platforms/nuttx/NuttX/apps"]
 	path = platforms/nuttx/NuttX/apps
 	url = https://github.com/PX4/NuttX-apps.git

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ define cmake-build
 	@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ] || [ $(CMAKE_CACHE_CHECK) ]; then \
 		mkdir -p $(BUILD_DIR) \
 		&& cd $(BUILD_DIR) \
+		&& . ${SRC_DIR}/.venv/bin/activate \
 		&& cmake "$(SRC_DIR)" -G"$(PX4_CMAKE_GENERATOR)" $(CMAKE_ARGS) \
 		|| (rm -rf $(BUILD_DIR)); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,13 @@ define colorecho
 +@echo -e '${COLOR_BLUE}${1} ${NO_COLOR}'
 endef
 
+.venv: .venv/touchfile
+
+.venv/touchfile: Tools/setup/requirements.txt
+	test -d .venv || python3 -m venv .venv
+	. .venv/bin/activate; pip install -Ur Tools/setup/requirements.txt
+	touch .venv/touchfile
+
 # Get a list of all config targets boards/*/*.px4board
 ALL_CONFIG_TARGETS := $(shell find boards -maxdepth 3 -mindepth 3 -name '*.px4board' -print | sed -e 's|boards\/||' | sed -e 's|\.px4board||' | sed -e 's|\/|_|g' | sort)
 
@@ -224,7 +231,7 @@ ALL_CONFIG_TARGETS := $(shell find boards -maxdepth 3 -mindepth 3 -name '*.px4bo
 #  Do not put any spaces between function arguments.
 
 # All targets.
-$(ALL_CONFIG_TARGETS):
+$(ALL_CONFIG_TARGETS): .venv
 	@$(call cmake-build,$@$(BUILD_DIR_SUFFIX))
 
 # Filter for only default targets to allow omiting the "_default" postfix

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ $(ALL_CONFIG_TARGETS): .venv
 
 # Filter for only default targets to allow omiting the "_default" postfix
 CONFIG_TARGETS_DEFAULT := $(patsubst %_default,%,$(filter %_default,$(ALL_CONFIG_TARGETS)))
-$(CONFIG_TARGETS_DEFAULT):
+$(CONFIG_TARGETS_DEFAULT): .venv
 	@$(call cmake-build,$@_default$(BUILD_DIR_SUFFIX))
 
 all_config_targets: $(ALL_CONFIG_TARGETS)

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -66,8 +66,21 @@ sudo pacman -Sy --noconfirm --needed \
 	;
 
 # Python dependencies
+echo
 echo "Installing PX4 Python3 dependencies"
-pip install --break-system-packages -r ${DIR}/${REQUIREMENTS_FILE}
+if [ ! -d ".venv" ]; then
+	echo "Python venv not found. Creating a new virtual vnvironment at .venv"
+	python3 -m venv ${PX4_DIR}/.venv
+fi
+activate () {
+  . $PX4_DIR/.venv/bin/activate
+}
+if [ -z "$VIRTUAL_ENV" ]; then
+	echo "Activating Python virtual environment"
+	activate
+	python -m pip install -r ${DIR}/requirements.txt
+fi
+
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then

--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -75,11 +75,9 @@ fi
 activate () {
   . $PX4_DIR/.venv/bin/activate
 }
-if [ -z "$VIRTUAL_ENV" ]; then
-	echo "Activating Python virtual environment"
-	activate
-	python -m pip install -r ${DIR}/requirements.txt
-fi
+echo "Activating Python virtual environment"
+activate
+python -m pip install -r ${DIR}/requirements.txt
 
 
 # NuttX toolchain (arm-none-eabi-gcc)

--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -60,11 +60,9 @@ fi
 activate () {
   . $PX4_DIR/.venv/bin/activate
 }
-if [ -z "$VIRTUAL_ENV" ]; then
-	echo "Activating Python virtual environment"
-	activate
-	python -m pip install -r ${DIR}/requirements.txt
-fi
+echo "Activating Python virtual environment"
+activate
+python -m pip install -r ${DIR}/requirements.txt
 
 
 # Optional, but recommended additional simulation tools:

--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -3,6 +3,9 @@
 # script directory
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+# store the project root directory path in a variable
+PX4_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )
+
 # Reinstall if --reinstall set
 REINSTALL_FORMULAS=""
 # Install simulation tools?
@@ -49,9 +52,11 @@ fi
 
 # Python dependencies
 echo "Installing PX4 Python3 dependencies"
-# We need to have future to install pymavlink later.
-python3 -m pip install future
-python3 -m pip install --user -r ${DIR}/requirements.txt
+# initialize venv and install dependencies
+python3 -m venv ${PX4_DIR}/.venv
+#activate venv
+source ${PX4_DIR}/.venv/bin/activate
+python3 -m pip install -r ${DIR}/requirements.txt
 
 # Optional, but recommended additional simulation tools:
 if [[ $INSTALL_SIM == "--sim-tools" ]]; then
@@ -61,5 +66,8 @@ if [[ $INSTALL_SIM == "--sim-tools" ]]; then
 		brew reinstall px4-sim
 	fi
 fi
+
+#deactivate venv
+deactivate
 
 echo "All set! PX4 toolchain installed!"

--- a/Tools/setup/macos.sh
+++ b/Tools/setup/macos.sh
@@ -51,12 +51,21 @@ else
 fi
 
 # Python dependencies
+echo
 echo "Installing PX4 Python3 dependencies"
-# initialize venv and install dependencies
-python3 -m venv ${PX4_DIR}/.venv
-#activate venv
-source ${PX4_DIR}/.venv/bin/activate
-python3 -m pip install -r ${DIR}/requirements.txt
+if [ ! -d ".venv" ]; then
+	echo "Python venv not found. Creating a new virtual vnvironment at .venv"
+	python3 -m venv ${PX4_DIR}/.venv
+fi
+activate () {
+  . $PX4_DIR/.venv/bin/activate
+}
+if [ -z "$VIRTUAL_ENV" ]; then
+	echo "Activating Python virtual environment"
+	activate
+	python -m pip install -r ${DIR}/requirements.txt
+fi
+
 
 # Optional, but recommended additional simulation tools:
 if [[ $INSTALL_SIM == "--sim-tools" ]]; then
@@ -68,6 +77,6 @@ if [[ $INSTALL_SIM == "--sim-tools" ]]; then
 fi
 
 #deactivate venv
-deactivate
+# deactivate
 
 echo "All set! PX4 toolchain installed!"

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -114,11 +114,9 @@ fi
 activate () {
   . $PX4_DIR/.venv/bin/activate
 }
-if [ -z "$VIRTUAL_ENV" ]; then
-	echo "Activating Python virtual environment"
-	activate
-	python -m pip install -r ${DIR}/requirements.txt
-fi
+echo "Activating Python virtual environment"
+activate
+python -m pip install -r ${DIR}/requirements.txt
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -41,6 +41,8 @@ fi
 
 # script directory
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+# store the project root directory path in a variable
+PX4_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )
 
 # check requirements.txt exists (script not run in source tree)
 REQUIREMENTS_FILE="requirements.txt"
@@ -107,13 +109,15 @@ echo
 echo "Installing PX4 Python3 dependencies"
 if [ ! -d ".venv" ]; then
 	echo "Python venv not found. Creating a new virtual vnvironment at .venv"
-	python3 -m venv .venv
+	python3 -m venv ${PX4_DIR}/.venv
 fi
+activate () {
+  . $PX4_DIR/.venv/bin/activate
+}
 if [ -z "$VIRTUAL_ENV" ]; then
 	echo "Activating Python virtual environment"
-	source .venv/bin/activate
+	activate
 	python -m pip install -r ${DIR}/requirements.txt
-	deactivate
 fi
 
 # NuttX toolchain (arm-none-eabi-gcc)

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -105,12 +105,15 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 # Python3 dependencies
 echo
 echo "Installing PX4 Python3 dependencies"
-if [ -n "$VIRTUAL_ENV" ]; then
-	# virtual environments don't allow --user option
+if [ ! -d ".venv" ]; then
+	echo "Python venv not found. Creating a new virtual vnvironment at .venv"
+	python3 -m venv .venv
+fi
+if [ -z "$VIRTUAL_ENV" ]; then
+	echo "Activating Python virtual environment"
+	source .venv/bin/activate
 	python -m pip install -r ${DIR}/requirements.txt
-else
-	# older versions of Ubuntu require --user option
-	python3 -m pip install --user -r ${DIR}/requirements.txt
+	deactivate
 fi
 
 # NuttX toolchain (arm-none-eabi-gcc)


### PR DESCRIPTION
This is a work in progress, intending to solve a problem with newer python requirements which don't allow user or system level dependencies.

https://github.com/PX4/PX4-Autopilot/issues/23073
Solved Problem

This PR implements a Python Virtual Environment which allows for local installation of all python dependencies. 

I chose to use a hidden directory (.venv/) for the virtual environment, as this directory is often just extra noise in filesystem explorer apps. If necessary, we can use the more conventional and unhidden venv/.

If testing out locally, please use the Tools/setup/ubuntu.sh or Tools/setup/macos.sh scripts, as that is what creates the virtual environment.This is a work in progress, intending to solve a problem with newer python requirements which don't allow user or system level dependencies.


