### PR TITLE
ekf2: mag spikes preflight errors

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1808,6 +1808,8 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 					status.hgt_test_ratio, status.tas_test_ratio,
 					status.hagl_test_ratio, status.beta_test_ratio);
 
+	status.mag_test_ratio = _hdg_test_ratio_lpf.update(math::min(status.mag_test_ratio, 1.0f));
+
 	// Bit mismatch between ecl and Firmware, combine the 2 first bits to preserve msg definition
 	// TODO: legacy use only, those flags are also in estimator_status_flags
 	status.innovation_check_flags = (innov_check_flags_temp >> 1) | (innov_check_flags_temp & 0x1);

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -432,6 +432,8 @@ private:
 	uint32_t _filter_warning_event_changes{0};
 	uint32_t _filter_information_event_changes{0};
 
+	AlphaFilter<float> _hdg_test_ratio_lpf{0.1f};
+
 	uORB::PublicationMulti<ekf2_timestamps_s>            _ekf2_timestamps_pub{ORB_ID(ekf2_timestamps)};
 	uORB::PublicationMultiData<estimator_event_flags_s>  _estimator_event_flags_pub{ORB_ID(estimator_event_flags)};
 	uORB::PublicationMulti<estimator_innovations_s>      _estimator_innovation_test_ratios_pub{ORB_ID(estimator_innovation_test_ratios)};


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Spikes in Magnetometer measurements lead to `Preflight Fail: Yaw estimate error` warning after landing. The mag innovation test ratio check fails because it can be triggered by one outlier.

### Solution
Added a low-pass filter which also caps the max input to 1. Update weight of the filter is 0.1.

### Alternatives
Increase the check threshold (currently 0.5), which wouldn't really change the sensitivity to large spikes.

### Test coverage
A testing issue is that in most cases that I have logs of, the logging was only active until disarm. For logs which were recorded until shutdown, the logging frequency of 5 Hz was not fast enough to record the outlier(s). I still tried to use a reasonable value based on existing data and some hardware tests.

### Context
First, a test where I rigged the mag by placing my phone on it.
Second, no extreme smoothing during "normal" mag test ratio changes
![image](https://github.com/PX4/PX4-Autopilot/assets/58551738/20c5c88e-e4b5-456a-9f3e-ad8d832b3925)
![Screenshot from 2024-06-05 14-45-32](https://github.com/PX4/PX4-Autopilot/assets/58551738/5da54ba5-ed42-4269-b1cb-a4bbb9b72680)

