### PR TITLE
Remove argparse from the requirements.txt.

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -1,5 +1,4 @@
 argcomplete
-argparse>=1.2
 cerberus
 coverage
 empy==3.3.4


### PR DESCRIPTION
The argparse module has been builtin to Python since Python 3.2, released in 2011 (see
https://docs.python.org/3/whatsnew/3.2.html).  Further, the argparse pip module has not been released or updated since 2015, and lacks some of the features of the modern, built-in argparse.  Drop the pip installed version in favor of the built-in version.

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

It was reported to ROS 2 that it couldn't be properly run after installing PX4; see https://github.com/ament/ament_cmake/pull/500 .  However, we prefer not to put in a workaround, because that actually downgrades functionality.  Instead, I think it makes sense to drop this dependency from PX4, and use the built-in Python version.

### Solution
Remove argparse from the requirements.txt.

### Changelog Entry
For release notes:
```
Dropped argparse from requirements.txt, as it is built-in to Python proper.
```

### Alternatives
N/A

### Test coverage
I verified that basic functionality works, though I did not exhaustively test that all scripts that use argparse in this repository work.

### Context
N/A