### PR TITLE
arch.sh: Fix syntax error

### DIFF
--- a/Tools/setup/arch.sh
+++ b/Tools/setup/arch.sh
@@ -95,7 +95,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 
 	# java (jmavsim)
 	sudo pacman -S --noconfirm --needed \
-		ant
+		ant \
 		;
 
 	# Gazebo setup


### PR DESCRIPTION
Fix error of script failing with following error:
PX4-Autopilot/Tools/setup/arch.sh: line 99: syntax error near unexpected token `;'

### Solved Problem
When running the script it failed with following error:
`./Tools/setup/arch.sh: line 99: syntax error near unexpected token ';'`

### Solution
- Added missing \ in the script

### Test coverage
- Script worked after changes
