### PR TITLE
platforms: nuttx: SerialImpl: fix hang if baudrate is 0

### DIFF
--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -74,6 +74,11 @@ bool SerialImpl::configure()
 	int speed;
 
 	switch (_baudrate) {
+	case 0:
+		// special case, if baudrate is 0 it hangs entire system
+		PX4_ERR("baudrate not specified");
+		return false;
+
 	case 9600:   speed = B9600;   break;
 
 	case 19200:  speed = B19200;  break;


### PR DESCRIPTION
If you pass a value of zero as the baudrate the entire system hangs