### PR TITLE
Define airspeed selector start stop params as floats

### DIFF
--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -162,8 +162,8 @@ private:
 
 	// states of airspeed valid declaration
 	bool _airspeed_valid{true}; ///< airspeed valid (pitot or groundspeed-windspeed)
-	int _checks_fail_delay{3}; ///< delay for airspeed invalid declaration after single check failure (Sec)
-	int _checks_clear_delay{-1}; ///< delay for airspeed valid declaration after all checks passed again (Sec)
+	float _checks_fail_delay{2.f}; ///< delay for airspeed invalid declaration after single check failure (Sec)
+	float _checks_clear_delay{-1.f}; ///< delay for airspeed valid declaration after all checks passed again (Sec)
 	uint64_t	_time_checks_passed{0};	///< time the checks have last passed (uSec)
 	uint64_t	_time_checks_failed{0};	///< time the checks have last not passed (uSec)
 

--- a/src/modules/airspeed_selector/airspeed_selector_main.cpp
+++ b/src/modules/airspeed_selector/airspeed_selector_main.cpp
@@ -182,8 +182,8 @@ private:
 
 		(ParamFloat<px4::params::ASPD_FS_INNOV>) _tas_innov_threshold, /**< innovation check threshold */
 		(ParamFloat<px4::params::ASPD_FS_INTEG>) _tas_innov_integ_threshold, /**< innovation check integrator threshold */
-		(ParamInt<px4::params::ASPD_FS_T_STOP>) _checks_fail_delay, /**< delay to declare airspeed invalid */
-		(ParamInt<px4::params::ASPD_FS_T_START>) _checks_clear_delay, /**<  delay to declare airspeed valid again */
+		(ParamFloat<px4::params::ASPD_FS_T_STOP>) _checks_fail_delay, /**< delay to declare airspeed invalid */
+		(ParamFloat<px4::params::ASPD_FS_T_START>) _checks_clear_delay, /**<  delay to declare airspeed valid again */
 
 		(ParamFloat<px4::params::FW_AIRSPD_STALL>) _param_fw_airspd_stall,
 		(ParamFloat<px4::params::ASPD_WERR_THR>) _param_wind_sigma_max_synth_tas

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -208,11 +208,10 @@ PARAM_DEFINE_FLOAT(ASPD_FS_INTEG, 10.f);
  *
  * @unit s
  * @group Airspeed Validator
- * @min 1
- * @max 10
+ * @min 0.0
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(ASPD_FS_T_STOP, 2.f);
+PARAM_DEFINE_FLOAT(ASPD_FS_T_STOP, 1.f);
 
 /**
  * Airspeed failsafe start delay
@@ -222,8 +221,7 @@ PARAM_DEFINE_FLOAT(ASPD_FS_T_STOP, 2.f);
  *
  * @unit s
  * @group Airspeed Validator
- * @min -1
- * @max 1000
+ * @min -1.0
  * @decimal 1
  */
 PARAM_DEFINE_FLOAT(ASPD_FS_T_START, -1.f);

--- a/src/modules/airspeed_selector/airspeed_selector_params.c
+++ b/src/modules/airspeed_selector/airspeed_selector_params.c
@@ -210,8 +210,9 @@ PARAM_DEFINE_FLOAT(ASPD_FS_INTEG, 10.f);
  * @group Airspeed Validator
  * @min 1
  * @max 10
+ * @decimal 1
  */
-PARAM_DEFINE_INT32(ASPD_FS_T_STOP, 2);
+PARAM_DEFINE_FLOAT(ASPD_FS_T_STOP, 2.f);
 
 /**
  * Airspeed failsafe start delay
@@ -223,8 +224,9 @@ PARAM_DEFINE_INT32(ASPD_FS_T_STOP, 2);
  * @group Airspeed Validator
  * @min -1
  * @max 1000
+ * @decimal 1
  */
-PARAM_DEFINE_INT32(ASPD_FS_T_START, -1);
+PARAM_DEFINE_FLOAT(ASPD_FS_T_START, -1.f);
 
 /**
  * Horizontal wind uncertainty threshold for synthetic airspeed.


### PR DESCRIPTION
### Solved Problem
Using integers for the airspeed selector start / stop delay parameters did not provide sufficient granularity in practice.
Also reduce the default hysteresis time for declaring airspeed invalid from 2 to 1.

### Solution
Define those parameters as floats.

### Changelog Entry
For release notes:
```
ASPD_FS_T_START and ASPD_FS_T_STOP can now be set to floating points values.
```