### PR TITLE
kakute f7/h7/h7mini/h7v2: fix EKF2_IMU_CTRL typo

### DIFF
--- a/boards/holybro/kakutef7/init/rc.board_defaults
+++ b/boards/holybro/kakutef7/init/rc.board_defaults
@@ -15,7 +15,7 @@ param set-default SYS_AUTOSTART 4050
 param set-default SYS_HAS_MAG 0
 
 # enable gravity fusion
-param set-default EKF2_IMU_CONTROL 7
+param set-default EKF2_IMU_CTRL 7
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090

--- a/boards/holybro/kakuteh7/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7/init/rc.board_defaults
@@ -25,7 +25,7 @@ param set-default SYS_AUTOSTART 4050
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion
-param set-default EKF2_IMU_CONTROL 7
+param set-default EKF2_IMU_CTRL 7
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090

--- a/boards/holybro/kakuteh7mini/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7mini/init/rc.board_defaults
@@ -25,7 +25,7 @@ param set-default SYS_AUTOSTART 4050
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion
-param set-default EKF2_IMU_CONTROL 7
+param set-default EKF2_IMU_CTRL 7
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090

--- a/boards/holybro/kakuteh7v2/init/rc.board_defaults
+++ b/boards/holybro/kakuteh7v2/init/rc.board_defaults
@@ -25,7 +25,7 @@ param set-default SYS_AUTOSTART 4050
 # use EKF2 without mag
 param set-default SYS_HAS_MAG 0
 # and enable gravity fusion
-param set-default EKF2_IMU_CONTROL 7
+param set-default EKF2_IMU_CTRL 7
 
 # the startup tune is not great on a binary output buzzer, so disable it
 param set-default CBRK_BUZZER 782090


### PR DESCRIPTION
### Problem
When checking the latest release 1.14.3, I found that the modification in #21961 is a good start.

But there is a typo of EKF2_IMU_CTRL (EKF2_IMU_CONTROL in the codes).

### Solution
- Fix the param typos for kakute f7/h7/h7mini/h7v2