### PR TITLE
AirspeedValidator: Remove extra delay from airspeed innovation check

### DIFF
--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -247,7 +247,7 @@ AirspeedValidator::check_airspeed_innovation(uint64_t time_now, float estimator_
 			_aspd_innov_integ_state = 0.f;
 		}
 
-		_innovations_check_failed = _tas_innov_integ_threshold > 0.0f && _aspd_innov_integ_state > _tas_innov_integ_threshold;
+		_innovations_check_failed = _aspd_innov_integ_state > _tas_innov_integ_threshold;
 	}
 
 	_time_last_aspd_innov_check = time_now;

--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -223,7 +223,7 @@ AirspeedValidator::check_airspeed_innovation(uint64_t time_now, float estimator_
 
 	// reset states if check is disabled, we are not flying or wind estimator was just initialized/reset
 	if (!_innovation_check_enabled || !_in_fixed_wing_flight || (time_now - _time_wind_estimator_initialized) < 5_s
-	    || _tas_innov_integ_threshold <= 0.f) {
+	    || _tas_innov_integ_threshold < -FLT_EPSILON) {
 		_innovations_check_failed = false;
 		_aspd_innov_integ_state = 0.f;
 

--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -225,13 +225,11 @@ AirspeedValidator::check_airspeed_innovation(uint64_t time_now, float estimator_
 	if (!_innovation_check_enabled || !_in_fixed_wing_flight || (time_now - _time_wind_estimator_initialized) < 5_s
 	    || _tas_innov_integ_threshold <= 0.f) {
 		_innovations_check_failed = false;
-		_time_last_tas_pass = time_now;
 		_aspd_innov_integ_state = 0.f;
 
 	} else if (!lpos_valid || estimator_status_vel_test_ratio > 1.f || estimator_status_mag_test_ratio > 1.f) {
 		//nav velocity data is likely not good
 		//don't run the test but don't reset the check if it had previously failed when nav velocity data was still likely good
-		_time_last_tas_pass = time_now;
 		_aspd_innov_integ_state = 0.f;
 
 	} else {
@@ -249,11 +247,7 @@ AirspeedValidator::check_airspeed_innovation(uint64_t time_now, float estimator_
 			_aspd_innov_integ_state = 0.f;
 		}
 
-		if (_tas_innov_integ_threshold > 0.f && _aspd_innov_integ_state < _tas_innov_integ_threshold) {
-			_time_last_tas_pass = time_now;
-		}
-
-		_innovations_check_failed = (time_now - _time_last_tas_pass) > TAS_INNOV_FAIL_DELAY;
+		_innovations_check_failed = _tas_innov_integ_threshold > 0.0f && _aspd_innov_integ_state > _tas_innov_integ_threshold;
 	}
 
 	_time_last_aspd_innov_check = time_now;

--- a/src/modules/airspeed_selector/AirspeedValidator.cpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.cpp
@@ -222,8 +222,7 @@ AirspeedValidator::check_airspeed_innovation(uint64_t time_now, float estimator_
 	}
 
 	// reset states if check is disabled, we are not flying or wind estimator was just initialized/reset
-	if (!_innovation_check_enabled || !_in_fixed_wing_flight || (time_now - _time_wind_estimator_initialized) < 5_s
-	    || _tas_innov_integ_threshold < -FLT_EPSILON) {
+	if (!_innovation_check_enabled || !_in_fixed_wing_flight || (time_now - _time_wind_estimator_initialized) < 5_s) {
 		_innovations_check_failed = false;
 		_aspd_innov_integ_state = 0.f;
 

--- a/src/modules/airspeed_selector/AirspeedValidator.hpp
+++ b/src/modules/airspeed_selector/AirspeedValidator.hpp
@@ -150,9 +150,7 @@ private:
 	float _tas_innov_threshold{1.0}; ///< innovation error threshold for triggering innovation check failure
 	float _tas_innov_integ_threshold{-1.0}; ///< integrator innovation error threshold for triggering innovation check failure
 	uint64_t	_time_last_aspd_innov_check{0};	///< time airspeed innovation was last checked (uSec)
-	uint64_t	_time_last_tas_pass{0};		///< last time innovation checks passed
 	float		_aspd_innov_integ_state{0.0f};	///< integral of excess normalised airspeed innovation (sec)
-	static constexpr uint64_t TAS_INNOV_FAIL_DELAY{1_s};	///< time required for innovation levels to pass or fail (usec)
 	uint64_t	_time_wind_estimator_initialized{0};		///< time last time wind estimator was initialized (uSec)
 
 	// states of load factor check


### PR DESCRIPTION
### Solved Problem
The additional hardcoded delay of 1 second on the airspeed innovation check does not add any value as the check itself uses an integrator to trigger and just makes analyzing a failure in a log file more difficult.
There is a separate parameter to control the delay between a detecting a failure and declaring airspeed invalid.

### Solution
Remove the additional delay.

### Changelog Entry
For release notes:
```
Remove additional 1 second of delay from airspeed innovation check.
```

