### PR TITLE
Control Allocation: Differential thrust vs control surfaces, servo failsafe mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/10042_sihsim_xvert
@@ -21,7 +21,6 @@ param set-default VT_B_TRANS_DUR 5
 param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_S_Y 0.3
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1041_gazebo-classic_tailsitter
@@ -70,7 +70,6 @@ param set-default MC_PITCH_P 3
 param set-default VT_ARSP_TRANS 10
 param set-default VT_B_TRANS_DUR 5
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_S_Y 1
 param set-default VT_F_TRANS_DUR 1.5
 param set-default VT_TYPE 0
 

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -67,7 +67,6 @@ param set-default MC_PITCHRATE_P 0.3
 param set-default VT_ARSP_TRANS 15
 param set-default VT_B_TRANS_DUR 5
 param set-default VT_FW_DIFTHR_EN 7
-param set-default VT_FW_DIFTHR_S_Y 1
 param set-default VT_F_TRANS_DUR 1.5
 param set-default VT_TYPE 0
 

--- a/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1102_tailsitter_duo_sih.hil
@@ -25,7 +25,6 @@ param set-default VT_ELEV_MC_LOCK 0
 param set-default VT_MOT_COUNT 2
 param set-default VT_TYPE 0
 param set-default VT_FW_DIFTHR_EN 1
-param set-default VT_FW_DIFTHR_S_Y 0.3
 param set-default MPC_MAN_Y_MAX 60
 param set-default MC_PITCH_P 5
 

--- a/msg/ControlAllocatorStatus.msg
+++ b/msg/ControlAllocatorStatus.msg
@@ -1,5 +1,8 @@
 uint64 timestamp                        # time since system start (microseconds)
 
+float32[3] torque_setpoint              # Current torque setpoint (normalized) for specific allocation matrix.
+float32[3] thrust_setpoint              # Current thrust setpoint (normalized) for specific allocation matrix.
+
 bool torque_setpoint_achieved           # Boolean indicating whether the 3D torque setpoint was correctly allocated to actuators. 0 if not achieved, 1 if achieved.
 float32[3] unallocated_torque           # Unallocated torque. Equal to 0 if the setpoint was achieved.
                                         # Computed as: unallocated_torque = torque_setpoint - allocated_torque

--- a/msg/FailureDetectorStatus.msg
+++ b/msg/FailureDetectorStatus.msg
@@ -9,6 +9,8 @@ bool fd_arm_escs
 bool fd_battery
 bool fd_imbalanced_prop
 bool fd_motor
+bool fd_servo
 
 float32 imbalanced_prop_metric      # Metric of the imbalanced propeller check (low-passed)
 uint16 motor_failure_mask           # Bit-mask with motor indices, indicating critical motor failures
+uint16 servo_failure_mask           # Bit-mask with servo indices, indicating critical servo failures

--- a/src/lib/matrix/matrix/Slice.hpp
+++ b/src/lib/matrix/matrix/Slice.hpp
@@ -351,6 +351,21 @@ public:
 		return min_val;
 	}
 
+	// sum of absolute values
+	Type sum_abs() const
+	{
+		const SliceT<MatrixT, Type, P, Q, M, N> &self = *this;
+		Type accum(0);
+
+		for (size_t i = 0; i < P; i++) {
+			for (size_t j = 0; j < Q; j++) {
+				accum += std::abs(self(i, j));
+			}
+		}
+
+		return accum;
+	}
+
 private:
 	size_t _x0, _y0;
 	MatrixT *_data;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.cpp
@@ -87,6 +87,8 @@ int ActuatorEffectiveness::Configuration::totalNumActuators() const
 
 void ActuatorEffectiveness::stopMaskedMotorsWithZeroThrust(uint32_t stoppable_motors_mask, ActuatorVector &actuator_sp)
 {
+	_stopped_motors_mask = 0; // TODO: as we have to reset here every iteration, there is no need to store this in the class
+
 	for (int actuator_idx = 0; actuator_idx < NUM_ACTUATORS; actuator_idx++) {
 		const uint32_t motor_mask = (1u << actuator_idx);
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
@@ -153,7 +153,7 @@ public:
 	/**
 	 * Query if the roll, pitch and yaw columns of the mixing matrix should be normalized
 	 */
-	virtual void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const
+	virtual void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const
 	{
 		for (int i = 0; i < MAX_NUM_MATRICES; ++i) {
 			normalize[i] = false;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectiveness.hpp
@@ -63,7 +63,7 @@ enum class ActuatorType {
 enum class EffectivenessUpdateReason {
 	NO_EXTERNAL_UPDATE = 0,
 	CONFIGURATION_UPDATE = 1,
-	MOTOR_ACTIVATION_UPDATE = 2,
+	ACTUATOR_ACTIVATION_UPDATE = 2,
 };
 
 
@@ -135,6 +135,17 @@ public:
 	}
 
 	/**
+	 * Set flag to enable/disable auxiliary motors (effectiveness-type specific)
+	 *
+	 * Auxiliary motors are switched off (stopped) by default, but can be enabled
+	 * in certain cases (e.g. MC motors on a Standard VTOL in forward flight for
+	 * attitude control support).
+	 *
+	 * @param enable True to enable auxiliary motors, false to disable them.
+	 */
+	virtual void setEnableAuxiliaryMotors(bool enable) {}
+
+	/**
 	 * Get the number of effectiveness matrices. Must be <= MAX_NUM_MATRICES.
 	 * This is expected to stay constant.
 	 */
@@ -201,9 +212,19 @@ public:
 				    const matrix::Vector<float, NUM_ACTUATORS> &actuator_max) {}
 
 	/**
-	 * Get a bitmask of motors to be stopped
+	 * Get a bitmask of motors to be stopped.
+	 * Stopped motors are by definition NOT to be removed from the control allocation matrix,
+	 * but their output is to be stopped (setpoint=NAN).
+	 * Usually is used to not have motors spinning at 0 thrust.
 	 */
 	virtual uint32_t getStoppedMotors() const { return _stopped_motors_mask; }
+
+	/**
+	 * Get a bitmask of motors to be disabled.
+	 * Disabled motors are by definition to be removed from the control allocation matrix and
+	 * their output is to be stopped (setpoint=NAN).
+	 */
+	virtual uint32_t getDisabledMotors() const { return _disabled_motors_mask; }
 
 	/**
 	 * Fill in the unallocated torque and thrust, customized by effectiveness type.
@@ -222,4 +243,5 @@ public:
 protected:
 	FlightPhase _flight_phase{FlightPhase::HOVER_FLIGHT};
 	uint32_t _stopped_motors_mask{0};
+	uint32_t _disabled_motors_mask{0};
 };

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessHelicopterTest.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessHelicopterTest.cpp
@@ -55,7 +55,7 @@ TEST(ActuatorEffectivenessHelicopterTest, ThrottleCurve)
 	ActuatorEffectivenessHelicopter helicopter(nullptr, ActuatorType::MOTORS);
 	// run getEffectivenessMatrix with empty configuration to correctly initialize _first_swash_plate_servo_index
 	ActuatorEffectiveness::Configuration configuration{};
-	EffectivenessUpdateReason external_update = EffectivenessUpdateReason::MOTOR_ACTIVATION_UPDATE;
+	EffectivenessUpdateReason external_update = EffectivenessUpdateReason::ACTUATOR_ACTIVATION_UPDATE;
 	helicopter.getEffectivenessMatrix(configuration, external_update);
 
 	Vector<float, 6> control_sp{};

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMCTilt.hpp
@@ -50,7 +50,7 @@ public:
 		allocation_method_out[0] = AllocationMethod::SEQUENTIAL_DESATURATION;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 	}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessMultirotor.hpp
@@ -49,7 +49,7 @@ public:
 		allocation_method_out[0] = AllocationMethod::SEQUENTIAL_DESATURATION;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 	}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessRotors.hpp
@@ -90,7 +90,7 @@ public:
 		allocation_method_out[0] = AllocationMethod::SEQUENTIAL_DESATURATION;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 	}

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.cpp
@@ -101,16 +101,26 @@ void ActuatorEffectivenessStandardVTOL::setFlightPhase(const FlightPhase &flight
 
 	ActuatorEffectiveness::setFlightPhase(flight_phase);
 
-	// update stopped motors
+	// update disabled motors
 	switch (flight_phase) {
 	case FlightPhase::FORWARD_FLIGHT:
-		_stopped_motors_mask |= _upwards_motors_mask;
+		_disabled_motors_mask |= _upwards_motors_mask;
 		break;
 
 	case FlightPhase::HOVER_FLIGHT:
 	case FlightPhase::TRANSITION_FF_TO_HF:
 	case FlightPhase::TRANSITION_HF_TO_FF:
-		_stopped_motors_mask &= ~_upwards_motors_mask;
+		_disabled_motors_mask &= ~_upwards_motors_mask;
 		break;
+	}
+}
+
+void ActuatorEffectivenessStandardVTOL::setEnableAuxiliaryMotors(bool enable)
+{
+	if (enable) {
+		_disabled_motors_mask = 0;
+
+	} else {
+		_disabled_motors_mask = _upwards_motors_mask;
 	}
 }

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
@@ -67,7 +67,7 @@ public:
 		allocation_method_out[1] = AllocationMethod::PSEUDO_INVERSE;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 		normalize[1] = false;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessStandardVTOL.hpp
@@ -80,6 +80,7 @@ public:
 			    const matrix::Vector<float, NUM_ACTUATORS> &actuator_max) override;
 
 	void setFlightPhase(const FlightPhase &flight_phase) override;
+	void setEnableAuxiliaryMotors(bool enable) override;
 
 private:
 	ActuatorEffectivenessRotors _rotors;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.cpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.cpp
@@ -93,7 +93,13 @@ void ActuatorEffectivenessTailsitterVTOL::updateSetpoint(const matrix::Vector<fl
 		const matrix::Vector<float, NUM_ACTUATORS> &actuator_max)
 {
 	if (matrix_index == 0) {
-		stopMaskedMotorsWithZeroThrust(_forwards_motors_mask, actuator_sp);
+		if (_flight_phase == FlightPhase::FORWARD_FLIGHT) {
+			stopMaskedMotorsWithZeroThrust(_forwards_motors_mask, actuator_sp);
+
+		} else {
+			// make sure all motors are un-stopped when out of forward flight
+			stopMaskedMotorsWithZeroThrust(0, actuator_sp);
+		}
 	}
 }
 
@@ -115,7 +121,12 @@ void ActuatorEffectivenessTailsitterVTOL::setFlightPhase(const FlightPhase &flig
 	case FlightPhase::TRANSITION_FF_TO_HF:
 	case FlightPhase::TRANSITION_HF_TO_FF:
 		_forwards_motors_mask = 0;
-		_stopped_motors_mask = 0;
+		_disabled_motors_mask = 0;
 		break;
 	}
+}
+
+void ActuatorEffectivenessTailsitterVTOL::setEnableAuxiliaryMotors(bool enable)
+{
+	// keep auxiliary motors disabled for now
 }

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
@@ -64,7 +64,7 @@ public:
 		allocation_method_out[1] = AllocationMethod::PSEUDO_INVERSE;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 		normalize[1] = false;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTailsitterVTOL.hpp
@@ -78,6 +78,7 @@ public:
 
 
 	void setFlightPhase(const FlightPhase &flight_phase) override;
+	void setEnableAuxiliaryMotors(bool enable) override;
 
 	const char *name() const override { return "VTOL Tailsitter"; }
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -77,6 +77,7 @@ public:
 	}
 
 	void setFlightPhase(const FlightPhase &flight_phase) override;
+	void setEnableAuxiliaryMotors(bool enable) override;
 
 	void allocateAuxilaryControls(const float dt, int matrix_index, ActuatorVector &actuator_sp) override;
 

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessTiltrotorVTOL.hpp
@@ -70,7 +70,7 @@ public:
 		allocation_method_out[1] = AllocationMethod::PSEUDO_INVERSE;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 		normalize[1] = false;

--- a/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessUUV.hpp
+++ b/src/modules/control_allocator/ActuatorEffectiveness/ActuatorEffectivenessUUV.hpp
@@ -49,7 +49,7 @@ public:
 		allocation_method_out[0] = AllocationMethod::SEQUENTIAL_DESATURATION;
 	}
 
-	void getNormalizeRPY(bool normalize[MAX_NUM_MATRICES]) const override
+	void getNormalizeAsPlanarMC(bool normalize[MAX_NUM_MATRICES]) const override
 	{
 		normalize[0] = true;
 	}

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -150,7 +150,7 @@ public:
 	 *
 	 * @return Effectiveness matrix
 	 */
-	const matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &getEffectivenessMatrix() const { return _effectiveness; }
+	const matrix::Matrix<float, NUM_AXES, NUM_ACTUATORS> &getEffectivenessMatrixAllocation() const { return _effectiveness; }
 
 	/**
 	 * Set the minimum actuator values

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -227,6 +227,7 @@ public:
 	int numConfiguredActuators() const { return _num_actuators; }
 
 	void setNormalizeAsPlanarMC(bool normalize_as_mc) { _normalize_matrix_as_planar_mc = normalize_as_mc; }
+	void setAirmode(const int airmode) {_airmode = airmode; }
 
 protected:
 	friend class ControlAllocator; // for _actuator_sp
@@ -244,4 +245,5 @@ protected:
 	int _num_actuators{0};
 	bool _normalize_matrix_as_planar_mc{false};		///< if true, normalize roll, pitch and yaw columns optimized for planar MC
 	bool _had_actuator_failure{false};
+	int _airmode{0};					///< 0: disabled, 1: RP airmode, 2: RPY airmode
 };

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -99,15 +99,6 @@ public:
 	virtual void allocate() = 0;
 
 	/**
-	 * Set actuator failure flag
-	 * This prevents a change of the scaling in the matrix normalization step
-	 * in case of a motor failure.
-	 *
-	 * @param failure  Motor failure flag
-	 */
-	void setHadActuatorFailure(bool failure) { _had_actuator_failure = failure; }
-
-	/**
 	 * Set the control effectiveness matrix
 	 *
 	 * @param B Effectiveness matrix
@@ -244,6 +235,5 @@ protected:
 	matrix::Vector<float, NUM_AXES> _control_trim; 		///< Control at trim actuator values
 	int _num_actuators{0};
 	bool _normalize_matrix_as_planar_mc{false};		///< if true, normalize roll, pitch and yaw columns optimized for planar MC
-	bool _had_actuator_failure{false};
 	int _airmode{0};					///< 0: disabled, 1: RP airmode, 2: RPY airmode
 };

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -226,7 +226,7 @@ public:
 
 	int numConfiguredActuators() const { return _num_actuators; }
 
-	void setNormalizeRPY(bool normalize_rpy) { _normalize_rpy = normalize_rpy; }
+	void setNormalizeAsPlanarMC(bool normalize_as_mc) { _normalize_matrix_as_planar_mc = normalize_as_mc; }
 
 protected:
 	friend class ControlAllocator; // for _actuator_sp
@@ -242,6 +242,6 @@ protected:
 	matrix::Vector<float, NUM_AXES> _control_sp;   		///< Control setpoint
 	matrix::Vector<float, NUM_AXES> _control_trim; 		///< Control at trim actuator values
 	int _num_actuators{0};
-	bool _normalize_rpy{false};				///< if true, normalize roll, pitch and yaw columns
+	bool _normalize_matrix_as_planar_mc{false};		///< if true, normalize roll, pitch and yaw columns optimized for planar MC
 	bool _had_actuator_failure{false};
 };

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocation.hpp
@@ -220,6 +220,9 @@ public:
 	void setNormalizeAsPlanarMC(bool normalize_as_mc) { _normalize_matrix_as_planar_mc = normalize_as_mc; }
 	void setAirmode(const int airmode) {_airmode = airmode; }
 
+	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> getMixMatrix() {return _mix; }
+	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> getNormalizedMixMatrix() {return _normalized_mix; }
+
 protected:
 	friend class ControlAllocator; // for _actuator_sp
 
@@ -236,4 +239,6 @@ protected:
 	int _num_actuators{0};
 	bool _normalize_matrix_as_planar_mc{false};		///< if true, normalize roll, pitch and yaw columns optimized for planar MC
 	int _airmode{0};					///< 0: disabled, 1: RP airmode, 2: RPY airmode
+	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _mix;
+	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _normalized_mix;
 };

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
@@ -107,34 +107,52 @@ ControlAllocationPseudoInverse::updateControlAllocationMatrixScale()
 		// Scale yaw separately
 		_control_allocation_scale(2) = _mix.col(2).max();
 
-	} else {
-		_control_allocation_scale(0) = 1.f;
-		_control_allocation_scale(1) = 1.f;
-		_control_allocation_scale(2) = 1.f;
-	}
+		// Scale thrust by the sum of the individual thrust axes, and use the scaling for the Z axis if there's no actuators
+		// (for tilted actuators)
+		_control_allocation_scale(THRUST_Z) = 1.f;
 
-	// Scale thrust by the sum of the individual thrust axes, and use the scaling for the Z axis if there's no actuators
-	// (for tilted actuators)
-	_control_allocation_scale(THRUST_Z) = 1.f;
+		for (int axis_idx = 2; axis_idx >= 0; --axis_idx) {
+			int num_non_zero_thrust = 0;
+			float norm_sum = 0.f;
 
-	for (int axis_idx = 2; axis_idx >= 0; --axis_idx) {
-		int num_non_zero_thrust = 0;
-		float norm_sum = 0.f;
+			for (int i = 0; i < _num_actuators; i++) {
+				float norm = fabsf(_mix(i, 3 + axis_idx));
+				norm_sum += norm;
 
-		for (int i = 0; i < _num_actuators; i++) {
-			float norm = fabsf(_mix(i, 3 + axis_idx));
-			norm_sum += norm;
+				if (norm > FLT_EPSILON) {
+					++num_non_zero_thrust;
+				}
+			}
 
-			if (norm > FLT_EPSILON) {
-				++num_non_zero_thrust;
+			if (num_non_zero_thrust > 0) {
+				_control_allocation_scale(3 + axis_idx) = norm_sum / num_non_zero_thrust;
+
+			} else {
+				_control_allocation_scale(3 + axis_idx) = _control_allocation_scale(THRUST_Z);
 			}
 		}
 
-		if (num_non_zero_thrust > 0) {
-			_control_allocation_scale(3 + axis_idx) = norm_sum / num_non_zero_thrust;
+	} else {
+		// Fixed-wing with control surfaces normalization
+		for (int i = 0; i < NUM_AXES; i++) {
 
-		} else {
-			_control_allocation_scale(3 + axis_idx) = _control_allocation_scale(THRUST_Z);
+			int num_non_zero_actuators = 0;
+
+			for (int j = 0; j < _num_actuators; j++) {
+
+				if (fabsf(_mix(j, i)) > 1e-3f) {
+					++num_non_zero_actuators;
+				}
+			}
+
+			const float axis_norm_scale = _mix.col(i).sum_abs();
+
+			if (num_non_zero_actuators > 0) {
+				_control_allocation_scale(i) = axis_norm_scale / num_non_zero_actuators;
+
+			} else {
+				_control_allocation_scale(i) = 1.f;
+			}
 		}
 	}
 }
@@ -142,27 +160,22 @@ ControlAllocationPseudoInverse::updateControlAllocationMatrixScale()
 void
 ControlAllocationPseudoInverse::normalizeControlAllocationMatrix()
 {
-	if (_control_allocation_scale(0) > FLT_EPSILON) {
-		_mix.col(0) /= _control_allocation_scale(0);
-		_mix.col(1) /= _control_allocation_scale(1);
-	}
+	// build the normalized matrix with the raw mixer matrix and the per-axis scales
+	_normalized_mix = _mix;
 
-	if (_control_allocation_scale(2) > FLT_EPSILON) {
-		_mix.col(2) /= _control_allocation_scale(2);
-	}
-
-	if (_control_allocation_scale(3) > FLT_EPSILON) {
-		_mix.col(3) /= _control_allocation_scale(3);
-		_mix.col(4) /= _control_allocation_scale(4);
-		_mix.col(5) /= _control_allocation_scale(5);
+	// TODO check for tilting motors if normalization is correct
+	for (int i = 0; i < NUM_AXES; i++) {
+		if (_control_allocation_scale(i) > FLT_EPSILON) {
+			_normalized_mix.col(i) = _mix.col(i) / _control_allocation_scale(i);
+		}
 	}
 
 	// Set all the small elements to 0 to avoid issues
 	// in the control allocation algorithms
 	for (int i = 0; i < _num_actuators; i++) {
 		for (int j = 0; j < NUM_AXES; j++) {
-			if (fabsf(_mix(i, j)) < 1e-3f) {
-				_mix(i, j) = 0.f;
+			if (fabsf(_normalized_mix(i, j)) < 1e-3f) {
+				_normalized_mix(i, j) = 0.f;
 			}
 		}
 	}
@@ -177,5 +190,5 @@ ControlAllocationPseudoInverse::allocate()
 	_prev_actuator_sp = _actuator_sp;
 
 	// Allocate
-	_actuator_sp = _actuator_trim + _mix * (_control_sp - _control_trim);
+	_actuator_sp = _actuator_trim + _normalized_mix * (_control_sp - _control_trim);
 }

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
@@ -73,7 +73,7 @@ void
 ControlAllocationPseudoInverse::updateControlAllocationMatrixScale()
 {
 	// Same scale on roll and pitch
-	if (_normalize_rpy) {
+	if (_normalize_matrix_as_planar_mc) {
 
 		int num_non_zero_roll_torque = 0;
 		int num_non_zero_pitch_torque = 0;

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.cpp
@@ -59,7 +59,7 @@ ControlAllocationPseudoInverse::updatePseudoInverse()
 	if (_mix_update_needed) {
 		matrix::geninv(_effectiveness, _mix);
 
-		if (_normalization_needs_update && !_had_actuator_failure) {
+		if (_normalization_needs_update) {
 			updateControlAllocationMatrixScale();
 			_normalization_needs_update = false;
 		}

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.hpp
@@ -59,8 +59,6 @@ public:
 				    bool update_normalization_scale) override;
 
 protected:
-	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _mix;
-	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _normalized_mix;
 
 	bool _mix_update_needed{false};
 

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationPseudoInverse.hpp
@@ -60,6 +60,7 @@ public:
 
 protected:
 	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _mix;
+	matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> _normalized_mix;
 
 	bool _mix_update_needed{false};
 

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
@@ -128,12 +128,14 @@ ControlAllocationSequentialDesaturation::mixAirmodeRP()
 
 	for (int i = 0; i < _num_actuators; i++) {
 		_actuator_sp(i) = _actuator_trim(i) +
-				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
-				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
-				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
-				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
-				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
+				  _normalized_mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
+				  _normalized_mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
+				  _normalized_mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(
+						  ControlAxis::THRUST_X)) +
+				  _normalized_mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(
+						  ControlAxis::THRUST_Y)) +
+				  _normalized_mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
+		thrust_z(i) = _normalized_mix(i, ControlAxis::THRUST_Z);
 	}
 
 	desaturateActuators(_actuator_sp, thrust_z);
@@ -153,14 +155,16 @@ ControlAllocationSequentialDesaturation::mixAirmodeRPY()
 
 	for (int i = 0; i < _num_actuators; i++) {
 		_actuator_sp(i) = _actuator_trim(i) +
-				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
-				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
-				  _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW)) +
-				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
-				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
-				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
-		yaw(i) = _mix(i, ControlAxis::YAW);
+				  _normalized_mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
+				  _normalized_mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
+				  _normalized_mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW)) +
+				  _normalized_mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(
+						  ControlAxis::THRUST_X)) +
+				  _normalized_mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(
+						  ControlAxis::THRUST_Y)) +
+				  _normalized_mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
+		thrust_z(i) = _normalized_mix(i, ControlAxis::THRUST_Z);
+		yaw(i) = _normalized_mix(i, ControlAxis::YAW);
 	}
 
 	desaturateActuators(_actuator_sp, thrust_z);
@@ -182,14 +186,16 @@ ControlAllocationSequentialDesaturation::mixAirmodeDisabled()
 
 	for (int i = 0; i < _num_actuators; i++) {
 		_actuator_sp(i) = _actuator_trim(i) +
-				  _mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
-				  _mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
-				  _mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(ControlAxis::THRUST_X)) +
-				  _mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(ControlAxis::THRUST_Y)) +
-				  _mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
-		roll(i) = _mix(i, ControlAxis::ROLL);
-		pitch(i) = _mix(i, ControlAxis::PITCH);
+				  _normalized_mix(i, ControlAxis::ROLL) * (_control_sp(ControlAxis::ROLL) - _control_trim(ControlAxis::ROLL)) +
+				  _normalized_mix(i, ControlAxis::PITCH) * (_control_sp(ControlAxis::PITCH) - _control_trim(ControlAxis::PITCH)) +
+				  _normalized_mix(i, ControlAxis::THRUST_X) * (_control_sp(ControlAxis::THRUST_X) - _control_trim(
+						  ControlAxis::THRUST_X)) +
+				  _normalized_mix(i, ControlAxis::THRUST_Y) * (_control_sp(ControlAxis::THRUST_Y) - _control_trim(
+						  ControlAxis::THRUST_Y)) +
+				  _normalized_mix(i, ControlAxis::THRUST_Z) * (_control_sp(ControlAxis::THRUST_Z) - _control_trim(ControlAxis::THRUST_Z));
+		thrust_z(i) = _normalized_mix(i, ControlAxis::THRUST_Z);
+		roll(i) = _normalized_mix(i, ControlAxis::ROLL);
+		pitch(i) = _normalized_mix(i, ControlAxis::PITCH);
 	}
 
 	// only reduce thrust
@@ -211,9 +217,10 @@ ControlAllocationSequentialDesaturation::mixYaw()
 	ActuatorVector thrust_z;
 
 	for (int i = 0; i < _num_actuators; i++) {
-		_actuator_sp(i) += _mix(i, ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
-		yaw(i) = _mix(i, ControlAxis::YAW);
-		thrust_z(i) = _mix(i, ControlAxis::THRUST_Z);
+		_actuator_sp(i) += _normalized_mix(i,
+						   ControlAxis::YAW) * (_control_sp(ControlAxis::YAW) - _control_trim(ControlAxis::YAW));
+		yaw(i) = _normalized_mix(i, ControlAxis::YAW);
+		thrust_z(i) = _normalized_mix(i, ControlAxis::THRUST_Z);
 	}
 
 	// Change yaw acceleration to unsaturate the outputs if needed (do not change roll/pitch),

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.cpp
@@ -49,7 +49,7 @@ ControlAllocationSequentialDesaturation::allocate()
 
 	_prev_actuator_sp = _actuator_sp;
 
-	switch (_param_mc_airmode.get()) {
+	switch (_airmode) {
 	case 1:
 		mixAirmodeRP();
 		break;

--- a/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.hpp
+++ b/src/modules/control_allocator/ControlAllocation/ControlAllocationSequentialDesaturation.hpp
@@ -121,8 +121,4 @@ private:
 	 * but yaw is decreased as much as required.
 	 */
 	void mixYaw();
-
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode   ///< air-mode
-	);
 };

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -314,7 +314,7 @@ ControlAllocator::Run()
 #endif
 
 	// Check if parameters have changed
-	if (_parameter_update_sub.updated() && !_armed) {
+	if (_parameter_update_sub.updated()) {
 		// clear update
 		parameter_update_s param_update;
 		_parameter_update_sub.copy(&param_update);

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -815,7 +815,8 @@ int ControlAllocator::print_status()
 
 	// Print current effectiveness matrix
 	for (int i = 0; i < _num_control_allocation; ++i) {
-		const ActuatorEffectiveness::EffectivenessMatrix &effectiveness = _control_allocation[i]->getEffectivenessMatrix();
+		const ActuatorEffectiveness::EffectivenessMatrix &effectiveness =
+			_control_allocation[i]->getEffectivenessMatrixAllocation();
 
 		if (_num_control_allocation > 1) {
 			PX4_INFO("Instance: %i", i);

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -338,28 +338,26 @@ ControlAllocator::Run()
 
 			_armed = vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED;
 
-			ActuatorEffectiveness::FlightPhase flight_phase{ActuatorEffectiveness::FlightPhase::HOVER_FLIGHT};
-
 			// Check if the current flight phase is HOVER or FIXED_WING
 			if (vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
-				flight_phase = ActuatorEffectiveness::FlightPhase::HOVER_FLIGHT;
+				_flight_phase = ActuatorEffectiveness::FlightPhase::HOVER_FLIGHT;
 
 			} else {
-				flight_phase = ActuatorEffectiveness::FlightPhase::FORWARD_FLIGHT;
+				_flight_phase = ActuatorEffectiveness::FlightPhase::FORWARD_FLIGHT;
 			}
 
 			// Special cases for VTOL in transition
 			if (vehicle_status.is_vtol && vehicle_status.in_transition_mode) {
 				if (vehicle_status.in_transition_to_fw) {
-					flight_phase = ActuatorEffectiveness::FlightPhase::TRANSITION_HF_TO_FF;
+					_flight_phase = ActuatorEffectiveness::FlightPhase::TRANSITION_HF_TO_FF;
 
 				} else {
-					flight_phase = ActuatorEffectiveness::FlightPhase::TRANSITION_FF_TO_HF;
+					_flight_phase = ActuatorEffectiveness::FlightPhase::TRANSITION_FF_TO_HF;
 				}
 			}
 
 			// Forward to effectiveness source
-			_actuator_effectiveness->setFlightPhase(flight_phase);
+			_actuator_effectiveness->setFlightPhase(_flight_phase);
 		}
 	}
 

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -931,8 +931,28 @@ int ControlAllocator::print_status()
 			PX4_INFO("Instance: %i", i);
 		}
 
-		PX4_INFO("  Effectiveness.T =");
-		effectiveness.T().print();
+		// const size_t num_actuators = _control_allocation[i]->numConfiguredActuators();
+		const size_t num_actuators = 6;
+
+		matrix::Matrix<float, num_actuators, NUM_AXES> effectiveness_sliced_transposed(
+			effectiveness.T().slice<num_actuators, NUM_AXES>(0, 0));
+
+		const matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> mix_raw = _control_allocation[i]->getMixMatrix();
+		const matrix::Matrix<float, num_actuators, NUM_AXES> mix_raw_sliced(mix_raw.slice<num_actuators, NUM_AXES>(0, 0));
+
+		const matrix::Matrix<float, NUM_ACTUATORS, NUM_AXES> mix_normalized = _control_allocation[i]->getNormalizedMixMatrix();
+		const matrix::Matrix<float, num_actuators, NUM_AXES> mix_normalized_sliced(
+			mix_normalized.slice<num_actuators, NUM_AXES>(0, 0));
+
+		PX4_INFO("  Effectiveness.T (sliced) =");
+		effectiveness_sliced_transposed.print();
+
+		PX4_INFO(" Mixer matrix raw (sliced) =");
+		mix_raw_sliced.print();
+
+		PX4_INFO(" Mixer matrix normalized (sliced) =");
+		mix_normalized_sliced.print();
+
 		PX4_INFO("  minimum =");
 		_control_allocation[i]->getActuatorMin().T().print();
 		PX4_INFO("  maximum =");

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -705,6 +705,13 @@ ControlAllocator::publish_control_allocator_status(int matrix_index)
 	control_allocator_status.unallocated_thrust[1] = unallocated_control(4);
 	control_allocator_status.unallocated_thrust[2] = unallocated_control(5);
 
+	control_allocator_status.torque_setpoint[0] = _control_allocation[matrix_index]->getControlSetpoint()(0);
+	control_allocator_status.torque_setpoint[1] = _control_allocation[matrix_index]->getControlSetpoint()(1);
+	control_allocator_status.torque_setpoint[2] = _control_allocation[matrix_index]->getControlSetpoint()(2);
+	control_allocator_status.thrust_setpoint[0] = _control_allocation[matrix_index]->getControlSetpoint()(3);
+	control_allocator_status.thrust_setpoint[1] = _control_allocation[matrix_index]->getControlSetpoint()(4);
+	control_allocator_status.thrust_setpoint[2] = _control_allocation[matrix_index]->getControlSetpoint()(5);
+
 	// override control_allocator_status in customized saturation logic for certain effectiveness types
 	_actuator_effectiveness->getUnallocatedControl(matrix_index, control_allocator_status);
 

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -168,8 +168,8 @@ ControlAllocator::update_allocation_method(bool force)
 		AllocationMethod desired_methods[ActuatorEffectiveness::MAX_NUM_MATRICES];
 		_actuator_effectiveness->getDesiredAllocationMethod(desired_methods);
 
-		bool normalize_rpy[ActuatorEffectiveness::MAX_NUM_MATRICES];
-		_actuator_effectiveness->getNormalizeRPY(normalize_rpy);
+		bool normalize_as_planar_mc[ActuatorEffectiveness::MAX_NUM_MATRICES];
+		_actuator_effectiveness->getNormalizeAsPlanarMC(normalize_as_planar_mc);
 
 		for (int i = 0; i < _num_control_allocation; ++i) {
 			AllocationMethod method = configured_method;
@@ -197,7 +197,7 @@ ControlAllocator::update_allocation_method(bool force)
 				_num_control_allocation = 0;
 
 			} else {
-				_control_allocation[i]->setNormalizeRPY(normalize_rpy[i]);
+				_control_allocation[i]->setNormalizeAsPlanarMC(normalize_as_planar_mc[i]);
 				_control_allocation[i]->setActuatorSetpoint(actuator_sp[i]);
 			}
 		}

--- a/src/modules/control_allocator/ControlAllocator.cpp
+++ b/src/modules/control_allocator/ControlAllocator.cpp
@@ -428,6 +428,9 @@ ControlAllocator::Run()
 		c[0](4) = _thrust_sp(1);
 		c[0](5) = _thrust_sp(2);
 
+		const int airmode = _flight_phase != ActuatorEffectiveness::FlightPhase::FORWARD_FLIGHT ? _param_mc_airmode.get() :
+				    _param_ca_fw_dthr_airmd.get();
+
 		if (_num_control_allocation > 1) {
 			matrix::Vector<float, NUM_AXES> vehicle_torque_setpoint_matrix_1;
 
@@ -475,6 +478,7 @@ ControlAllocator::Run()
 
 		for (int i = 0; i < _num_control_allocation; ++i) {
 
+			_control_allocation[i]->setAirmode(airmode);
 			_control_allocation[i]->setControlSetpoint(c[i]);
 
 			// Do allocation

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -223,7 +223,9 @@ private:
 		(ParamFloat<px4::params::CA_FW_DTHR_SC_Y>) _param_ca_fw_dthr_sc_y,
 		(ParamFloat<px4::params::CA_FW_DTHR_WGT_R>) _param_ca_fw_dthr_wgt_r,
 		(ParamFloat<px4::params::CA_FW_DTHR_WGT_P>) _param_ca_fw_dthr_wgt_p,
-		(ParamFloat<px4::params::CA_FW_DTHR_WGT_Y>) _param_ca_fw_dthr_wgt_y
+		(ParamFloat<px4::params::CA_FW_DTHR_WGT_Y>) _param_ca_fw_dthr_wgt_y,
+		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,
+		(ParamInt<px4::params::CA_FW_DTHR_AIRMD>) _param_ca_fw_dthr_airmd
 	)
 
 };

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -209,6 +209,7 @@ private:
 	ParamHandles _param_handles{};
 	Params _params{};
 	bool _has_slew_rate{false};
+	ActuatorEffectiveness::FlightPhase _flight_phase{ActuatorEffectiveness::FlightPhase::HOVER_FLIGHT};
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CA_AIRFRAME>) _param_ca_airframe,

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -198,6 +198,7 @@ private:
 	// Reflects motor failures that are currently handled, not motor failures that are reported.
 	// For example, the system might report two motor failures, but only the first one is handled by CA
 	uint16_t _handled_motor_failure_bitmask{0};
+	uint16_t _handled_servo_failure_bitmask{0};
 
 	uint16_t _handled_motor_disabled_bitmask{0};
 
@@ -213,6 +214,8 @@ private:
 	bool _has_slew_rate{false};
 	ActuatorEffectiveness::FlightPhase _flight_phase{ActuatorEffectiveness::FlightPhase::HOVER_FLIGHT};
 
+	bool _has_control_authority[2][6] = {false};
+
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::CA_AIRFRAME>) _param_ca_airframe,
 		(ParamInt<px4::params::CA_METHOD>) _param_ca_method,
@@ -225,7 +228,8 @@ private:
 		(ParamFloat<px4::params::CA_FW_DTHR_WGT_P>) _param_ca_fw_dthr_wgt_p,
 		(ParamFloat<px4::params::CA_FW_DTHR_WGT_Y>) _param_ca_fw_dthr_wgt_y,
 		(ParamInt<px4::params::MC_AIRMODE>) _param_mc_airmode,
-		(ParamInt<px4::params::CA_FW_DTHR_AIRMD>) _param_ca_fw_dthr_airmd
+		(ParamInt<px4::params::CA_FW_DTHR_AIRMD>) _param_ca_fw_dthr_airmd,
+		(ParamBool<px4::params::CA_FW_DTHR_FB_EN>) _param_ca_fw_dthr_fb_en
 	)
 
 };

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -132,7 +132,7 @@ private:
 
 	void update_effectiveness_matrix_if_needed(EffectivenessUpdateReason reason);
 
-	void check_for_motor_failures();
+	bool check_for_actuator_activation_update();
 
 	void publish_control_allocator_status(int matrix_index);
 
@@ -198,6 +198,8 @@ private:
 	// Reflects motor failures that are currently handled, not motor failures that are reported.
 	// For example, the system might report two motor failures, but only the first one is handled by CA
 	uint16_t _handled_motor_failure_bitmask{0};
+
+	uint16_t _handled_motor_disabled_bitmask{0};
 
 	perf_counter_t	_loop_perf;			/**< loop duration performance counter */
 

--- a/src/modules/control_allocator/ControlAllocator.hpp
+++ b/src/modules/control_allocator/ControlAllocator.hpp
@@ -217,7 +217,13 @@ private:
 		(ParamInt<px4::params::CA_AIRFRAME>) _param_ca_airframe,
 		(ParamInt<px4::params::CA_METHOD>) _param_ca_method,
 		(ParamInt<px4::params::CA_FAILURE_MODE>) _param_ca_failure_mode,
-		(ParamInt<px4::params::CA_R_REV>) _param_r_rev
+		(ParamInt<px4::params::CA_R_REV>) _param_r_rev,
+		(ParamFloat<px4::params::CA_FW_DTHR_SC_R>) _param_ca_fw_dthr_sc_r,
+		(ParamFloat<px4::params::CA_FW_DTHR_SC_P>) _param_ca_fw_dthr_sc_p,
+		(ParamFloat<px4::params::CA_FW_DTHR_SC_Y>) _param_ca_fw_dthr_sc_y,
+		(ParamFloat<px4::params::CA_FW_DTHR_WGT_R>) _param_ca_fw_dthr_wgt_r,
+		(ParamFloat<px4::params::CA_FW_DTHR_WGT_P>) _param_ca_fw_dthr_wgt_p,
+		(ParamFloat<px4::params::CA_FW_DTHR_WGT_Y>) _param_ca_fw_dthr_wgt_y
 	)
 
 };

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -619,6 +619,20 @@ parameters:
                 1: Roll/Pitch
                 2: Roll/Pitch/Yaw
             default: 0
+
+        CA_FW_DTHR_FB_EN:
+            description:
+                short: Enable fallback to differential thrust for control in fixed-wing
+                long: |
+                    Enable fallback to differential thrust for rate control around axes that have
+                    0 effectiveness in the servo matrix after the detected servo failure.
+            type: boolean
+            values:
+                0: Disabled
+                1: Enabled
+            default: 1
+
+
 # Mixer
 mixer:
     actuator_types:

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -40,7 +40,7 @@ parameters:
                   If set to Automtic, the selection is based on the airframe (CA_AIRFRAME).
             type: enum
             values:
-                0: Pseudo-inverse with output clipping
+                0: Pseudo-inverse without any desaturation
                 1: Pseudo-inverse with sequential desaturation technique
                 2: Automatic
             default: 2
@@ -541,6 +541,71 @@ parameters:
                 1: Remove first failed motor from effectiveness
             default: 0
 
+        CA_FW_DTHR_SC_R:
+            description:
+                short: Fixed-wing differential thrust roll scale
+            type: float
+            decimal: 2
+            increment: 0.1
+            min: 0
+            max: 10
+            default: 1
+
+        CA_FW_DTHR_SC_P:
+            description:
+                short: Fixed-wing differential thrust pitch scale
+            type: float
+            decimal: 2
+            increment: 0.1
+            min: 0
+            max: 10
+            default: 1
+
+        CA_FW_DTHR_SC_Y:
+            description:
+                short: Fixed-wing differential thrust yaw scale
+            type: float
+            decimal: 2
+            increment: 0.1
+            min: 0
+            max: 10
+            default: 1
+
+        CA_FW_DTHR_WGT_R:
+            description:
+                short: Fixed-wing differential thrust roll weight
+                long: |
+                    Weight of torque allocated through differential thrust vs control surface.
+            type: float
+            decimal: 2
+            increment: 0.1
+            min: 0
+            max: 1
+            default: 0
+
+        CA_FW_DTHR_WGT_P:
+            description:
+                short: Pitch weight of differential thrust in fixed-wing
+                long: |
+                    Weight of torque allocated through differential thrust vs control surface.
+            type: float
+            decimal: 2
+            increment: 0.1
+            min: 0
+            max: 1
+            default: 0
+
+        CA_FW_DTHR_WGT_Y:
+            description:
+                short: Yaw weight of differential thrust in fixed-wing
+                long: |
+                    Weight of torque allocated through differential thrust vs control surface.
+            type: float
+            decimal: 2
+            increment: 0.1
+            min: 0
+            max: 1
+            default: 0
 # Mixer
 mixer:
     actuator_types:

--- a/src/modules/control_allocator/module.yaml
+++ b/src/modules/control_allocator/module.yaml
@@ -606,6 +606,19 @@ parameters:
             min: 0
             max: 1
             default: 0
+
+        CA_FW_DTHR_AIRMD:
+            description:
+                short: Enable airmode for fixed-wing differential thrust
+                long: |
+                    If enabeld it allows the allocator to increase collective thrust to achieve
+                    thorque setpoints.
+            type: enum
+            values:
+                0: Disabled
+                1: Roll/Pitch
+                2: Roll/Pitch/Yaw
+            default: 0
 # Mixer
 mixer:
     actuator_types:

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -291,19 +291,6 @@ void Tailsitter::fill_actuator_outputs()
 
 		_thrust_setpoint_0->xyz[2] = -_vehicle_thrust_setpoint_virtual_fw->xyz[0];
 
-		/* allow differential thrust if enabled */
-		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::YAW_BIT)) {
-			_torque_setpoint_0->xyz[0] = _vehicle_torque_setpoint_virtual_fw->xyz[0] * _param_vt_fw_difthr_s_y.get();
-		}
-
-		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::PITCH_BIT)) {
-			_torque_setpoint_0->xyz[1] = _vehicle_torque_setpoint_virtual_fw->xyz[1] * _param_vt_fw_difthr_s_p.get();
-		}
-
-		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::ROLL_BIT)) {
-			_torque_setpoint_0->xyz[2] = _vehicle_torque_setpoint_virtual_fw->xyz[2] * _param_vt_fw_difthr_s_r.get();
-		}
-
 		// for the short period after switching to FW where there is no thrust published yet from the FW controller,
 		// keep publishing the last MC thrust to keep the motors running
 		if (hrt_elapsed_time(&_trans_finished_ts) < 50_ms) {

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -379,10 +379,6 @@ void Tiltrotor::fill_actuator_outputs()
 		collective_thrust_normalized_setpoint = _vehicle_thrust_setpoint_virtual_fw->xyz[0];
 		_thrust_setpoint_0->xyz[2] = -collective_thrust_normalized_setpoint;
 
-		/* allow differential thrust if enabled */
-		if (_param_vt_fw_difthr_en.get() & static_cast<int32_t>(VtFwDifthrEnBits::YAW_BIT)) {
-			_torque_setpoint_0->xyz[2] = _vehicle_torque_setpoint_virtual_fw->xyz[2] * _param_vt_fw_difthr_s_y.get() ;
-		}
 
 	} else {
 		collective_thrust_normalized_setpoint = -_vehicle_thrust_setpoint_virtual_mc->xyz[2] * _mc_throttle_weight;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -284,61 +284,6 @@ PARAM_DEFINE_INT32(VT_FW_QC_HMAX, 0);
 PARAM_DEFINE_FLOAT(VT_F_TR_OL_TM, 6.0f);
 
 /**
- * Differential thrust in forwards flight.
- *
- * Enable differential thrust seperately for roll, pitch, yaw in forward (fixed-wing) mode.
- * The effectiveness of differential thrust around the corresponding axis can be
- * tuned by setting VT_FW_DIFTHR_S_R / VT_FW_DIFTHR_S_P / VT_FW_DIFTHR_S_Y.
- *
- * @min 0
- * @max 7
- * @bit 0 Yaw
- * @bit 1 Roll
- * @bit 2 Pitch
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_INT32(VT_FW_DIFTHR_EN, 0);
-
-/**
- * Roll differential thrust factor in forward flight
- *
- * Differential thrust in forward flight is enabled via VT_FW_DIFTHR_EN.
- *
- * @min 0.0
- * @max 2.0
- * @decimal 2
- * @increment 0.1
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_R, 1.f);
-
-/**
- * Pitch differential thrust factor in forward flight
- *
- * Differential thrust in forward flight is enabled via VT_FW_DIFTHR_EN.
- *
- * @min 0.0
- * @max 2.0
- * @decimal 2
- * @increment 0.1
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_P, 1.f);
-
-/**
- * Yaw differential thrust factor in forward flight
- *
- * Differential thrust in forward flight is enabled via VT_FW_DIFTHR_EN.
- *
- * @min 0.0
- * @max 2.0
- * @decimal 2
- * @increment 0.1
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_S_Y, 0.1f);
-
-/**
  * Backtransition deceleration setpoint to pitch I gain.
  *
  * @unit rad s/m

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -76,12 +76,6 @@ enum VtolForwardActuationMode {
 	ENABLE_ABOVE_MPC_LAND_ALT2_WITHOUT_LAND
 };
 
-// enum for bitmask of VT_FW_DIFTHR_EN parameter options
-enum class VtFwDifthrEnBits : int32_t {
-	YAW_BIT = (1 << 0),
-	ROLL_BIT = (1 << 1),
-	PITCH_BIT = (1 << 2),
-};
 
 enum class QuadchuteReason {
 	None = 0,
@@ -344,10 +338,6 @@ protected:
 					(ParamBool<px4::params::FW_USE_AIRSPD>) _param_fw_use_airspd,
 					(ParamFloat<px4::params::VT_TRANS_TIMEOUT>) _param_vt_trans_timeout,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise,
-					(ParamInt<px4::params::VT_FW_DIFTHR_EN>) _param_vt_fw_difthr_en,
-					(ParamFloat<px4::params::VT_FW_DIFTHR_S_Y>) _param_vt_fw_difthr_s_y,
-					(ParamFloat<px4::params::VT_FW_DIFTHR_S_P>) _param_vt_fw_difthr_s_p,
-					(ParamFloat<px4::params::VT_FW_DIFTHR_S_R>) _param_vt_fw_difthr_s_r,
 					(ParamFloat<px4::params::VT_B_DEC_I>) _param_vt_b_dec_i,
 					(ParamFloat<px4::params::VT_B_DEC_MSS>) _param_vt_b_dec_mss,
 


### PR DESCRIPTION
### Solved Problem
- Feature: use MC motors in VTOL fixed-wing flight in case of servo failure
- Clean up differential thrust vs. servo torque generation for fixed-wing vehicles

### Solution
[summary TBD, see commit messages for details]


TODOs:

- [ ] fix interface to rate controllers for actuator saturation (current idea is to set control_allocator.unallocated_torque to NAN if allocation instance doesn't have any effectiveness, to 0 if not saturated and to -1/1 if saturated
- [ ] unit tests for normalization/allocation

Followups:
- [ ] enable differential thrust for planes (enable it by moving motors to matrix 0, servos to matrix 1 also for planes?)
- [ ] remove tilt servos from effectiveness in fixed-wing flight (VTOL tiltrotor)
- [ ] introduce ability to switch off certain motors in forward flight (VTOL tailsitter, tiltrotor), additionally could be based on thrust requirement (switch off certain motors if running on low thrust setting)

### Changelog Entry
For release notes: 
```
Feature: Control Allocation: Differential thrust vs control surfaces, servo failsafe mode
```

### Alternatives


### Test coverage
An older version of this PR was tested extensively on a Standard VTOL, including single aileron failures (remove one aileron from effectiveness), and double aileron failure (remove both and fall back to differential thrust). See attached video. 

### Context
Screen recording from flight with induced double aileron failure on a Standard VTOL. After the failure is injected the ailerons are locked at zero and a service running on an onboard computer detectes the system failure by monitoring the system response (not part of PX4). it then sends a message to notify PX4 about the failure (see [this additional testing commit](https://github.com/PX4/PX4-Autopilot/commit/619812cbdd071bdf5141b5e09711784fb73498e6)), and PX4 reacts by removing the failed servos from effectiveness.

https://github.com/PX4/PX4-Autopilot/assets/26798987/84f131a1-cd6f-4f9d-a2fd-5b3f60dceb2b


The fallback to differential thrust in case of servo failure can be simulated in SITL by putting https://github.com/PX4/PX4-Autopilot/commit/619812cbdd071bdf5141b5e09711784fb73498e6 on top of this PR.
