### PR TITLE
platforms: nuttx: SerialImpl: fix poll timeout and integer underflow

### DIFF
--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -272,11 +272,11 @@ ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t char
 		fds[0].fd = _serial_fd;
 		fds[0].events = POLLIN;
 
-		hrt_abstime remaining_time = timeout_us - hrt_elapsed_time(&start_time_us);
+		hrt_abstime elapsed_time_us = hrt_elapsed_time(&start_time_us);
 
-		if (remaining_time <= 0) { break; }
+		if (elapsed_time_us > timeout_us) { break; }
 
-		int ret = poll(fds, sizeof(fds) / sizeof(fds[0]), remaining_time);
+		int ret = poll(fds, sizeof(fds) / sizeof(fds[0]), (timeout_us - elapsed_time_us) / 1000);
 
 		if (ret > 0) {
 			if (fds[0].revents & POLLIN) {

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -265,11 +265,11 @@ ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t char
 		fds[0].fd = _serial_fd;
 		fds[0].events = POLLIN;
 
-		hrt_abstime remaining_time = timeout_us - hrt_elapsed_time(&start_time_us);
+		hrt_abstime elapsed_time_us = hrt_elapsed_time(&start_time_us);
 
-		if (remaining_time <= 0) { break; }
+		if (elapsed_time_us > timeout_us) { break; }
 
-		int ret = poll(fds, sizeof(fds) / sizeof(fds[0]), remaining_time);
+		int ret = poll(fds, sizeof(fds) / sizeof(fds[0]), (timeout_us - elapsed_time_us) / 1000);
 
 		if (ret > 0) {
 			if (fds[0].revents & POLLIN) {


### PR DESCRIPTION
A microsecond time was being passed to `poll()`, which takes a millisecond timeout. Also if the elapsed time was already greater than the timeout an integer underflow would occur which causes poll to block forever.

- fix poll timeout
- fix integer underflow