### PR TITLE
Don't fuse optical flow samples when distance to ground is above sensor limits

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
@@ -55,9 +55,13 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 					       && !_flow_sample_delayed.flow_rate.longerThan(_flow_max_rate);
 		const bool is_tilt_good = (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
 
+		// don't enforce this condition if terrain estimate is not valid as we have logic below to coast through bad range finder data
+		const bool is_within_max_sensor_dist = isTerrainEstimateValid() ? (_terrain_vpos - _state.pos(2) <= _flow_max_distance) : true;
+
 		if (is_quality_good
 		    && is_magnitude_good
-		    && is_tilt_good) {
+		    && is_tilt_good
+		    && is_within_max_sensor_dist) {
 			// compensate for body motion to give a LOS rate
 			calcOptFlowBodyRateComp(imu_delayed);
 			_flow_rate_compensated = _flow_sample_delayed.flow_rate - _flow_sample_delayed.gyro_rate.xy();


### PR DESCRIPTION
### Solved Problem
A flow sensor should publish a maximum distance to the ground below which it's expected to work well.
If the distance to the ground exceeds this value the estimator should not fuse these samples.

### Solution
In this particular case we were using the Ark flow sensor which happens to work reliably up to about 10m.

### Changelog Entry
For release notes:
```
Feature: EKF: Don't fuse optical flow samples when distance to the ground exceeds maximum flow sensor distance.
```