### PR TITLE
Matrix: print full matrix already if only one element is not symmetric

### DIFF
--- a/src/lib/matrix/matrix/Matrix.hpp
+++ b/src/lib/matrix/matrix/Matrix.hpp
@@ -402,6 +402,7 @@ public:
 		}
 
 		const Matrix<Type, M, N> &self = *this;
+		bool is_prev_symmetric = true; // assume symmetric until one element is not
 
 		for (unsigned i = 0; i < M; i++) {
 			printf("%2u|", i); // print row numbering
@@ -410,7 +411,7 @@ public:
 				double d = static_cast<double>(self(i, j));
 
 				// if symmetric don't print upper triangular elements
-				if ((M == N) && (j > i) && (i < N) && (j < M)
+				if (is_prev_symmetric && (M == N) && (j > i) && (i < N) && (j < M)
 				    && (fabs(d - static_cast<double>(self(j, i))) < (double)eps)
 				   ) {
 					// print empty space
@@ -428,6 +429,8 @@ public:
 					} else {
 						printf("% 6.5f ", d);
 					}
+
+					is_prev_symmetric = false; // not symmetric if once inside here
 				}
 			}
 


### PR DESCRIPTION
Follow up from https://github.com/PX4/PX4-Autopilot/pull/22629, found while working on https://github.com/PX4/PX4-Autopilot/pull/23245. It's quite hard to read a print of a matrix that omits some of the elements because they are symmetric at this very point, but not the full matrix is.

With current main:
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/8657fc26-a8c1-44f7-88f3-6f4d160e3b0a)

After this PR: 
![image](https://github.com/PX4/PX4-Autopilot/assets/26798987/83f2e271-eef9-487d-ac1f-2e3558e7aef7)

