### PR TITLE
rc_update: Added support for range-based threshold RTL switch

### DIFF
--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1925,23 +1925,6 @@ PARAM_DEFINE_FLOAT(RC_RETURN_TH_MIN, 0.75f);
 */
 PARAM_DEFINE_FLOAT(RC_RETURN_TH_MAX, 1.0f);
 
-
-/**
- * Threshold for selecting return to launch mode
- *
- * 0-1 indicate where in the full channel range the threshold sits
- * 		0 : min
- * 		1 : max
- * sign indicates polarity of comparison
- * 		positive : true when channel>th
- * 		negative : true when channel<th
- *
- * @min -1
- * @max 1
- * @group Radio Switches
- */
-PARAM_DEFINE_FLOAT(RC_RETURN_TH, 0.75f);
-
 /**
  * Threshold for selecting loiter mode
  *

--- a/src/modules/rc_update/params.c
+++ b/src/modules/rc_update/params.c
@@ -1902,6 +1902,31 @@ PARAM_DEFINE_INT32(RC_MAP_ENG_MOT, 0);
 PARAM_DEFINE_INT32(RC_FAILS_THR, 0);
 
 /**
+ * Minimum threshold for selecting return to launch mode.
+ *
+ * Together with  RC_RETURN_TH_MAX defines the range for the return to launch mode selection.
+ * If both value are negative then the polarity is inverted.
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+*/
+PARAM_DEFINE_FLOAT(RC_RETURN_TH_MIN, 0.75f);
+
+/**
+ * Maximum threshold for selecting return to launch mode.
+ *
+ * Together with  RC_RETURN_TH_MIN defines the range for the return to launch mode selection.
+ * If both value are negative then the polarity is inverted.
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+*/
+PARAM_DEFINE_FLOAT(RC_RETURN_TH_MAX, 1.0f);
+
+
+/**
  * Threshold for selecting return to launch mode
  *
  * 0-1 indicate where in the full channel range the threshold sits

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -576,6 +576,38 @@ switch_pos_t RCUpdate::getRCSwitchOnOffPosition(uint8_t function, float threshol
 	return manual_control_switches_s::SWITCH_POS_NONE;
 }
 
+switch_pos_t RCUpdate::getRCSwitchOnOffPositionFromRange(uint8_t function, float threshold_min,
+		float threshold_max) const
+{
+	if (_rc.function[function] >= 0) {
+
+		// _rc.channels contains values is in the range [-1, 1] -> Remap it to [0, 1]
+		const float value = 0.5f * _rc.channels[_rc.function[function]] + 0.5f;
+
+		// On negative thresholds -> enable inverted mode
+		const bool on_inv = threshold_min < 0.0f && threshold_max < 0.0f;
+
+		// Flip threshold sign in inverted mode
+		const bool within_range = on_inv ?
+					  (value > -threshold_min && value < -threshold_max) :
+					  (value > threshold_min && value < threshold_max);
+
+		if (on_inv) {
+			// ON and OFF are flipped, i.e. ON when NOT in range, OFF otherwise
+			return !within_range ?
+			       manual_control_switches_s::SWITCH_POS_ON :
+			       manual_control_switches_s::SWITCH_POS_OFF;
+
+		} else {
+			return within_range ?
+			       manual_control_switches_s::SWITCH_POS_ON :
+			       manual_control_switches_s::SWITCH_POS_OFF;
+		}
+	}
+
+	return manual_control_switches_s::SWITCH_POS_NONE;
+}
+
 void RCUpdate::UpdateManualSwitches(const hrt_abstime &timestamp_sample)
 {
 	manual_control_switches_s switches{};
@@ -637,7 +669,8 @@ void RCUpdate::UpdateManualSwitches(const hrt_abstime &timestamp_sample)
 		}
 	}
 
-	switches.return_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_RETURN, _param_rc_return_th.get());
+	switches.return_switch = getRCSwitchOnOffPositionFromRange(rc_channels_s::FUNCTION_RETURN,
+				 _param_rc_return_th_min.get(), _param_rc_return_th_max.get());
 	switches.loiter_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_LOITER, _param_rc_loiter_th.get());
 	switches.offboard_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_OFFBOARD, _param_rc_offb_th.get());
 	switches.kill_switch = getRCSwitchOnOffPosition(rc_channels_s::FUNCTION_KILLSWITCH, _param_rc_killswitch_th.get());

--- a/src/modules/rc_update/rc_update.cpp
+++ b/src/modules/rc_update/rc_update.cpp
@@ -585,24 +585,18 @@ switch_pos_t RCUpdate::getRCSwitchOnOffPositionFromRange(uint8_t function, float
 		const float value = 0.5f * _rc.channels[_rc.function[function]] + 0.5f;
 
 		// On negative thresholds -> enable inverted mode
-		const bool on_inv = threshold_min < 0.0f && threshold_max < 0.0f;
+		const bool on_inv = threshold_min <= 0.0f && threshold_max <= 0.0f;
 
 		// Flip threshold sign in inverted mode
-		const bool within_range = on_inv ?
-					  (value > -threshold_min && value < -threshold_max) :
-					  (value > threshold_min && value < threshold_max);
+		const bool is_on = on_inv ?
+				   (value <= -threshold_min || value >= -threshold_max) :
+				   (value > threshold_min && value < threshold_max);
 
-		if (on_inv) {
-			// ON and OFF are flipped, i.e. ON when NOT in range, OFF otherwise
-			return !within_range ?
-			       manual_control_switches_s::SWITCH_POS_ON :
-			       manual_control_switches_s::SWITCH_POS_OFF;
 
-		} else {
-			return within_range ?
-			       manual_control_switches_s::SWITCH_POS_ON :
-			       manual_control_switches_s::SWITCH_POS_OFF;
-		}
+		return is_on ?
+		       manual_control_switches_s::SWITCH_POS_ON :
+		       manual_control_switches_s::SWITCH_POS_OFF;
+
 	}
 
 	return manual_control_switches_s::SWITCH_POS_NONE;

--- a/src/modules/rc_update/rc_update.h
+++ b/src/modules/rc_update/rc_update.h
@@ -118,12 +118,23 @@ protected:
 	float		get_rc_value(uint8_t func, float min_value, float max_value) const;
 
 	/**
-	 * Get on/off switch position from the RC channel of the specified function
+	 * Get on/off switch position from the RC channel of the specified function, based on a single threshold.
 	 *
 	 * @param function according to rc_channels_s::FUNCTION_XXX
 	 * @param threshold according to RC_XXX_TH parameters, negative means on and off are flipped
 	 */
 	switch_pos_t getRCSwitchOnOffPosition(uint8_t function, float threshold) const;
+
+	/**
+	 * Get on/off switch position from the RC channel of the specified function, based on a range.
+	 *
+	 * If BOTH thresholds are negative, on and off are flipped.
+	 *
+	 * @param function according to rc_channels_s::FUNCTION_XXX
+	 * @param threshold_min according to RC_XXX_TH_MIN parameters
+	 * @param threshold_max according to RC_XXX_TH_MAX parameters
+	 */
+	switch_pos_t getRCSwitchOnOffPositionFromRange(uint8_t function, float threshold_min, float threshold_max) const;
 
 	/**
 	 * Update parameters from RC channels if the functionality is activated and the
@@ -236,7 +247,8 @@ protected:
 		(ParamFloat<px4::params::RC_ARMSWITCH_TH>) _param_rc_armswitch_th,
 		(ParamFloat<px4::params::RC_TRANS_TH>) _param_rc_trans_th,
 		(ParamFloat<px4::params::RC_GEAR_TH>) _param_rc_gear_th,
-		(ParamFloat<px4::params::RC_RETURN_TH>) _param_rc_return_th,
+		(ParamFloat<px4::params::RC_RETURN_TH_MIN>) _param_rc_return_th_min,
+		(ParamFloat<px4::params::RC_RETURN_TH_MAX>) _param_rc_return_th_max,
 		(ParamFloat<px4::params::RC_ENG_MOT_TH>) _param_rc_eng_mot_th,
 
 		(ParamInt<px4::params::RC_CHAN_CNT>) _param_rc_chan_cnt


### PR DESCRIPTION
Added support for range-based threshold RTL switches.

This is the case for Skydroid H30 GCS:
- short press on the RLT switch sets the return channel to 1
- long press on the RTL switch sets the return channel to 0.5

RTL shall be triggered upon a long press of the RTL switch button, and therefore a range threshold (e.g. [0.4, 0.6] is required.