### PR TITLE
reduce transition pusher throttle

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4004_gz_standard_vtol
@@ -104,6 +104,6 @@ param set-default NAV_ACC_RAD 5
 param set-default NAV_DLL_ACT 2
 
 param set-default VT_FWD_THRUST_EN 4
-param set-default VT_F_TRANS_THR 0.75
+param set-default VT_F_TRANS_THR 0.3
 param set-default VT_TYPE 2
 param set-default FD_ESCS_EN 0


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Standard VTOL accelerates a lot during transition and gets unstable while trying to loiter.

### Solution
Reduce VT_F_TRANS_THR from 0.75 to 0.3


### Alternatives
We could also add some other parameters which were also used in the gazebo-classic model? Improve model itself?

with 0.75
![Screenshot from 2024-06-07 13-55-37](https://github.com/PX4/PX4-Autopilot/assets/58551738/46c63cab-cb95-44bd-a257-ad6eb34a1b29)

with 0.3
![Screenshot from 2024-06-12 11-18-45](https://github.com/PX4/PX4-Autopilot/assets/58551738/32de8177-53ed-450f-a9ee-29a9e46e5280)
