### PR TITLE
matrix: Vector2/Vector4 override ops so specific Vector type is returned

### DIFF
--- a/src/lib/matrix/matrix/Vector2.hpp
+++ b/src/lib/matrix/matrix/Vector2.hpp
@@ -56,6 +56,45 @@ public:
 		return a(0) * b(1, 0) - a(1) * b(0, 0);
 	}
 
+	/**
+	 * Override matrix ops so Vector2 type is returned
+	 */
+
+	Vector2 operator+(Vector2 other) const
+	{
+		return Matrix21::operator+(other);
+	}
+
+	Vector2 operator+(Type scalar) const
+	{
+		return Matrix21::operator+(scalar);
+	}
+
+	Vector2 operator-(Vector2 other) const
+	{
+		return Matrix21::operator-(other);
+	}
+
+	Vector2 operator-(Type scalar) const
+	{
+		return Matrix21::operator-(scalar);
+	}
+
+	Vector2 operator-() const
+	{
+		return Matrix21::operator-();
+	}
+
+	Vector2 operator*(Type scalar) const
+	{
+		return Matrix21::operator*(scalar);
+	}
+
+	Type operator*(Vector2 b) const
+	{
+		return Vector<Type, 2>::operator*(b);
+	}
+
 	Type operator%(const Matrix21 &b) const
 	{
 		return (*this).cross(b);

--- a/src/lib/matrix/matrix/Vector4.hpp
+++ b/src/lib/matrix/matrix/Vector4.hpp
@@ -82,6 +82,46 @@ public:
 	Vector4(const Slice<Type, 1, 4, P, Q> &slice_in) : Vector<Type, 4>(slice_in)
 	{
 	}
+
+	/**
+	 * Override matrix ops so Vector4 type is returned
+	 */
+
+	Vector4 operator+(Vector4 other) const
+	{
+		return Matrix41::operator+(other);
+	}
+
+	Vector4 operator+(Type scalar) const
+	{
+		return Matrix41::operator+(scalar);
+	}
+
+	Vector4 operator-(Vector4 other) const
+	{
+		return Matrix41::operator-(other);
+	}
+
+	Vector4 operator-(Type scalar) const
+	{
+		return Matrix41::operator-(scalar);
+	}
+
+	Vector4 operator-() const
+	{
+		return Matrix41::operator-();
+	}
+
+	Vector4 operator*(Type scalar) const
+	{
+		return Matrix41::operator*(scalar);
+	}
+
+	Type operator*(Vector4 b) const
+	{
+		return Vector<Type, 4>::operator*(b);
+	}
+
 };
 
 using Vector4f = Vector4<float>;


### PR DESCRIPTION
 - mirrored from Vector3


This was originally done as part of https://github.com/PX4/PX4-Autopilot/pull/23233.