### PR TITLE
vscode: cmake default status bar visibility

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "cmake.buildDirectory": "${workspaceFolder}/build/${variant:CONFIG}",
         "cmake.configureOnOpen": true,
         "cmake.ctest.parallelJobs": 1,
+        "cmake.options.statusBarVisibility": "compact",
         "cmake.skipConfigureIfCachePresent": true,
         "cmakeExplorer.buildDir": "${workspaceFolder}/build/px4_sitl_test",
         "cmakeExplorer.parallelJobs": 1,


### PR DESCRIPTION
Generally I'm trying to not be too opinionated with the default config, but it's quite important to see (and set) the current PX4 config or quite a lot won't resolve properly in the IDE.