### PR TITLE
Add px4_sitl_allyes to CI target

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,7 @@ jobs:
           "shellcheck_all",
           "NO_NINJA_BUILD=1 px4_fmu-v5_default",
           "NO_NINJA_BUILD=1 px4_sitl_default",
+          "px4_sitl_allyes",
           "airframe_metadata",
           "module_documentation",
           "parameters_metadata",


### PR DESCRIPTION
#22957 Introduced allyes config but CI wasn't compiling them.

This PR adds the px4_sitl_allyes to the CI workflows.