### PR TITLE
gimbal - input_mavlink: return NoUpdate by default

### DIFF
--- a/src/modules/gimbal/input_mavlink.cpp
+++ b/src/modules/gimbal/input_mavlink.cpp
@@ -518,7 +518,7 @@ InputMavlinkGimbalV2::update(unsigned int timeout_ms, ControlData &control_data,
 	// We can't return early instead because we need to copy all topics that triggered poll.
 
 	bool exit_loop = false;
-	UpdateResult update_result = already_active ? UpdateResult::UpdatedActive : UpdateResult::NoUpdate;
+	UpdateResult update_result = UpdateResult::NoUpdate;
 
 	while (!exit_loop && poll_timeout >= 0) {
 


### PR DESCRIPTION
### Solved Problem
I debugged a case where the auto setting for `MNT_MODE_IN` would not work: The mavlink input just stayed active after being engaged once, adjusting primary control would not suffice to enable RC control.
Turns out that if the mavlink_input just once returned UpdatedActive, it would keep doing so until e. g. a `VEHICLE_CMD_DO_GIMBAL_MANAGER_PITCHYAW` is received (there, UpdatedActiveOnce is returned instead).
This corner case is a combination of the following issues:
- in the input object list, mavlink comes first: https://github.com/PX4/PX4-Autopilot/blob/9c83f842bee11e3942e578377245b6a3fc9b5a7d/src/modules/gimbal/gimbal.cpp#L116-L123. Therefore, if we receive an UpdatedActive from mavlink input, we will never check what the RC is doing: https://github.com/PX4/PX4-Autopilot/blob/9c83f842bee11e3942e578377245b6a3fc9b5a7d/src/modules/gimbal/gimbal.cpp#L217-L254
- manual control in mavlink input returns UpdatedActive: https://github.com/PX4/PX4-Autopilot/blob/9c83f842bee11e3942e578377245b6a3fc9b5a7d/src/modules/gimbal/input_mavlink.cpp#L902
- because of UpdatedActive, mavlink will be flagged with already_active here: https://github.com/PX4/PX4-Autopilot/blob/9c83f842bee11e3942e578377245b6a3fc9b5a7d/src/modules/gimbal/gimbal.cpp#L219 and therefore stay active without the change in this PR if there is NO update.

Let me know if you have any questions, and also if there are other suggestions on how to approach this issue.

### Solution
- This PR makes sure that the mavlink_input only returns UpdatedActive if there was actually an update that should control the gimbal

### Test coverage
Tested with SIH, an SBUS input to a v5x and a Gremsy V3T3

