### PR TITLE
Changed Serial readAtLeast timeout from microseconds to milliseconds

### DIFF
--- a/platforms/common/Serial.cpp
+++ b/platforms/common/Serial.cpp
@@ -74,9 +74,9 @@ ssize_t Serial::read(uint8_t *buffer, size_t buffer_size)
 	return _impl.read(buffer, buffer_size);
 }
 
-ssize_t Serial::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_us)
+ssize_t Serial::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_ms)
 {
-	return _impl.readAtLeast(buffer, buffer_size, character_count, timeout_us);
+	return _impl.readAtLeast(buffer, buffer_size, character_count, timeout_ms);
 }
 
 ssize_t Serial::write(const void *buffer, size_t buffer_size)

--- a/platforms/common/include/px4_platform_common/Serial.hpp
+++ b/platforms/common/include/px4_platform_common/Serial.hpp
@@ -62,7 +62,7 @@ public:
 	bool close();
 
 	ssize_t read(uint8_t *buffer, size_t buffer_size);
-	ssize_t readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count = 1, uint32_t timeout_us = 0);
+	ssize_t readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count = 1, uint32_t timeout_ms = 0);
 
 	ssize_t write(const void *buffer, size_t buffer_size);
 

--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -251,7 +251,7 @@ ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
 	return ret;
 }
 
-ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_us)
+ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_ms)
 {
 	if (!_open) {
 		PX4_ERR("Cannot readAtLeast from serial device until it has been opened");
@@ -264,6 +264,7 @@ ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t char
 	}
 
 	const hrt_abstime start_time_us = hrt_absolute_time();
+	hrt_abstime timeout_us = timeout_ms * 1000;
 	int total_bytes_read = 0;
 
 	while ((total_bytes_read < (int) character_count) && (hrt_elapsed_time(&start_time_us) < timeout_us)) {

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -244,7 +244,7 @@ ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
 	return ret;
 }
 
-ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_us)
+ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_ms)
 {
 	if (!_open) {
 		PX4_ERR("Cannot readAtLeast from serial device until it has been opened");
@@ -257,6 +257,7 @@ ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t char
 	}
 
 	const hrt_abstime start_time_us = hrt_absolute_time();
+	hrt_abstime timeout_us = timeout_ms * 1000;
 	int total_bytes_read = 0;
 
 	while ((total_bytes_read < (int) character_count) && (hrt_elapsed_time(&start_time_us) < timeout_us)) {

--- a/platforms/qurt/src/px4/SerialImpl.cpp
+++ b/platforms/qurt/src/px4/SerialImpl.cpp
@@ -173,7 +173,7 @@ ssize_t SerialImpl::read(uint8_t *buffer, size_t buffer_size)
 	return ret_read;
 }
 
-ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_us)
+ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t character_count, uint32_t timeout_ms)
 {
 	if (!_open) {
 		PX4_ERR("Cannot readAtLeast from serial device until it has been opened");
@@ -186,6 +186,7 @@ ssize_t SerialImpl::readAtLeast(uint8_t *buffer, size_t buffer_size, size_t char
 	}
 
 	const hrt_abstime start_time_us = hrt_absolute_time();
+	hrt_abstime timeout_us = timeout_ms * 1000;
 	int total_bytes_read = 0;
 
 	while (total_bytes_read < (int) character_count) {


### PR DESCRIPTION

### Solved Problem
There are currently three users of the new Serial driver (Septentrio GNSS, CRSF, and GPS). They all assume that the timeout for the readAtLeast call is specified in milliseconds but it is actually specified in microseconds. On top of this there was a bug where the implementation was actually using the microsecond timeout as an argument to a function that needed milliseconds and that was fixed in PR #23248. But because users were expecting milliseconds the timeout was now way too short and it caused CPU utilization to spike as the read kept timing out. See issue #23289. This PR changes the timeout to milliseconds to align with what the users are expecting.