### PR TITLE
system: never call task_delete on nuttx, never force stop tasks

### DIFF
--- a/platforms/common/include/px4_platform_common/module.h
+++ b/platforms/common/include/px4_platform_common/module.h
@@ -239,21 +239,9 @@ public:
 					unlock_module();
 					px4_usleep(10000); // 10 ms
 					lock_module();
-
-					if (++i > 500 && _task_id != -1) { // wait at most 5 sec
-						PX4_ERR("timeout, forcing stop");
-
-						if (_task_id != task_id_is_work_queue) {
-							px4_task_delete(_task_id);
-						}
-
-						_task_id = -1;
-
-						delete _object.load();
-						_object.store(nullptr);
-
-						ret = -1;
-						break;
+					i++;
+					if (i % 500 == 0) {
+						PX4_INFO("Waiting for task to stop...");
 					}
 				} while (_task_id != -1);
 

--- a/platforms/nuttx/src/px4/common/tasks.cpp
+++ b/platforms/nuttx/src/px4/common/tasks.cpp
@@ -45,6 +45,7 @@
 #include <nuttx/kthread.h>
 
 #include <sys/wait.h>
+#include <syslog.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -88,7 +89,8 @@ int px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_
 
 int px4_task_delete(int pid)
 {
-	return task_delete(pid);
+	syslog(LOG_ERR, "Ignoring force task delete on NuttX\n");
+	return ERROR;
 }
 
 const char *px4_get_taskname(void)


### PR DESCRIPTION
I found that calling `task_delete` (pre-emptively destroying a running task) is unsafe on NuttX. 

The logic does not seem to clean up resources properly, which can leave hardware in undefined states. This can cause all kinds of problems, generally hardfaults though.  

This PR changes changes the following
- Never forcefully destroy a task on NuttX
- Remove the timeout logic for PX4 that kills a task when it doesn't finish in time

### Reproduce

This is actually reasonably easy to reproduce. 
1. Connect a GPS, cut the TX wire (the one next to the power)
2. Now, the GPS driver will try to configure the GPS on every loop. This takes >10s
3. Now run `gps stop`
4. This usually times out, and makes PX4 call `task_delete`
5. When the gps task was in a `poll` during that time, it never calls the `poll_teardown` logic. This leaves a stray pointer to a pollfd in the uart device struct. This pointer points to stack memory that is no longer valid
6. When you now run `gps start`, it will restart the UART, which still has invalid resources in it. This will generally hardfault.

I believe that in general, it is not safe on NuttX to call `task_delete`. Potentially, this is also just a bug in NuttX.
