### PR TITLE
mc_position_control: avoid calculating arw if not needed

### DIFF
--- a/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl/PositionControl.cpp
@@ -185,15 +185,15 @@ void PositionControl::_velocityControl(const float dt)
 	// Use tracking Anti-Windup for horizontal direction: during saturation, the integrator is used to unsaturate the output
 	// see Anti-Reset Windup for PID controllers, L.Rundqwist, 1990
 	const Vector2f acc_sp_xy_produced = Vector2f(_thr_sp) * (CONSTANTS_ONE_G / _hover_thrust);
-	const float arw_gain = 2.f / _gain_vel_p(0);
 
 	// The produced acceleration can be greater or smaller than the desired acceleration due to the saturations and the actual vertical thrust (computed independently).
 	// The ARW loop needs to run if the signal is saturated only.
-	const Vector2f acc_sp_xy = _acc_sp.xy();
-	const Vector2f acc_limited_xy = (acc_sp_xy.norm_squared() > acc_sp_xy_produced.norm_squared())
-					? acc_sp_xy_produced
-					: acc_sp_xy;
-	vel_error.xy() = Vector2f(vel_error) - arw_gain * (acc_sp_xy - acc_limited_xy);
+	if (_acc_sp.xy().norm_squared() > acc_sp_xy_produced.norm_squared()) {
+		const float arw_gain = 2.f / _gain_vel_p(0);
+		const Vector2f acc_sp_xy = _acc_sp.xy();
+
+		vel_error.xy() = Vector2f(vel_error) - arw_gain * (acc_sp_xy - acc_sp_xy_produced);
+	}
 
 	// Make sure integral doesn't get NAN
 	ControlMath::setZeroIfNanVector3f(vel_error);


### PR DESCRIPTION
### Solved Problem
it seems that there is none needed calculation of Anti-Reset Windup on the PositionControl::_velocityControl().
it also make it more readable to understand when the ARW is active or not
