### PR TITLE
ekf2: disable EKF2_EV_CTRL and EKF2_AGP_CTRL by default

### DIFF
--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -524,7 +524,7 @@ parameters:
         1: Vertical position
         2: 3D velocity
         3: Yaw
-      default: 15
+      default: 0
       min: 0
       max: 15
     EKF2_GPS_CTRL:
@@ -1317,7 +1317,7 @@ parameters:
       bit:
         0: Horizontal position
         1: Vertical position
-      default: 1
+      default: 0
       min: 0
       max: 3
     EKF2_AGP_DELAY:


### PR DESCRIPTION
For both logging (https://github.com/PX4/PX4-Autopilot/pull/23306), safety, and minor memory optimization I think EKF2_EV_CTRL and EKF2_AGP_CTRL should be off by default.

Arguably nearly everything (except IMU) would be off by default and enabled per board and per airframe, but at the moment I don't think that's worth the hassle.