### PR TITLE
Correct units of CRSF GPS altitude

### DIFF
--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -241,7 +241,7 @@ void CrsfRc::Run()
 					int32_t longitude = static_cast<int32_t>(round(sensor_gps.longitude_deg * 1e7));
 					uint16_t groundspeed = sensor_gps.vel_d_m_s / 3.6f * 10.f;
 					uint16_t gps_heading = math::degrees(sensor_gps.cog_rad) * 100.f;
-					uint16_t altitude = static_cast<int16_t>(sensor_gps.altitude_msl_m * 1e3) + 1000;
+					uint16_t altitude = static_cast<int16_t>(sensor_gps.altitude_msl_m) + 1000;
 					uint8_t num_satellites = sensor_gps.satellites_used;
 					this->SendTelemetryGps(latitude, longitude, groundspeed, gps_heading, altitude, num_satellites);
 				}


### PR DESCRIPTION
### Solved Problem
When sending CRSF telemetry, the GPS message provided an incorrect value for altitude [m]. This is because the existing PX4 code assumed the altitude_msl_m in the SensorGPS uORB message was in units of mm, instead of m.  

### Solution
Removed scaling of the altitude in the uORB message  by 1000. 

### Changelog Entry
Bugfix for CRSF GPS telemetry

### Test coverage
Tested with ELRS transmitter in the loop to confirm correct values.
