### PR TITLE
Bugfix: Fail build early if MAVLink generation has an error

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -44,8 +44,7 @@ add_custom_command(
 	COMMAND
 		${PYTHON_EXECUTABLE} ${MAVLINK_GIT_DIR}/pymavlink/tools/mavgen.py
 			--lang C --wire-protocol 2.0
-			#--no-validate
-			#--strict-units
+			--exit-code
 			--output ${MAVLINK_LIBRARY_DIR}
 			${MAVLINK_GIT_DIR}/message_definitions/v1.0/${MAVLINK_DIALECT_UAVIONIX}.xml > ${CMAKE_CURRENT_BINARY_DIR}/mavgen_${MAVLINK_DIALECT_UAVIONIX}.log
 	DEPENDS
@@ -64,8 +63,7 @@ add_custom_command(
 	COMMAND
 		${PYTHON_EXECUTABLE} ${MAVLINK_GIT_DIR}/pymavlink/tools/mavgen.py
 			--lang C --wire-protocol 2.0
-			#--no-validate
-			#--strict-units
+			--exit-code
 			--output ${MAVLINK_LIBRARY_DIR}
 			${MAVLINK_GIT_DIR}/message_definitions/v1.0/${CONFIG_MAVLINK_DIALECT}.xml > ${CMAKE_CURRENT_BINARY_DIR}/mavgen_${CONFIG_MAVLINK_DIALECT}.log
 	DEPENDS


### PR DESCRIPTION
### Solved Problem
The mavlink generator command silently succeeds even though the logs could contain errors.

When working through a hard to debug error I found that the generation command for a dialect can silently fail and since the uavionix dialect is still included in most places the some builds succeed without the primary dialect included while other specific test builds that don't contain the uavionix dialect (mavlink FTP test) fail unexpectedly.

### Solution
Use https://github.com/ArduPilot/pymavlink/pull/863 to flag the error. I'll propose to make that default in pymavlink.

It's much more developer friendly to fail early in case of an error. The log path is then also shown in the console output.

### Changelog Entry
```
Bugfix: Fail build early if MAVLink generation has an error
```

### Test coverage
I ran this locally while debugging and lo and behold, it shows an error and the reference to the log output.
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/01ad551d-58d3-4d01-bb1f-6e37c46c83e4)
