### PR TITLE
mavlink: with cmake policy CMP0118 verion 3.20 we can depend on the mavlink_c` library

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -31,6 +31,9 @@
 #
 ############################################################################
 
+# Make GENERATED property available outside of this directory e.g. for simulator_mavlink and mavlink_tests which depend on mavlink_c
+cmake_policy(SET CMP0118 NEW)
+
 set(MAVLINK_GIT_DIR "${CMAKE_CURRENT_LIST_DIR}/mavlink")
 set(MAVLINK_LIBRARY_DIR "${CMAKE_BINARY_DIR}/mavlink")
 file(RELATIVE_PATH MAVLINK_GIT_DIR_RELATIVE ${CMAKE_SOURCE_DIR} ${MAVLINK_GIT_DIR})
@@ -78,9 +81,7 @@ add_custom_command(
 
 	COMMENT "Generating Mavlink ${CONFIG_MAVLINK_DIALECT}: ${MAVLINK_GIT_DIR_RELATIVE}/message_definitions/v1.0/${CONFIG_MAVLINK_DIALECT}.xml"
 )
-add_custom_target(mavlink_c_generate DEPENDS ${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}/${CONFIG_MAVLINK_DIALECT}.h)
 set_source_files_properties(${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}/${CONFIG_MAVLINK_DIALECT}.h PROPERTIES GENERATED true)
-
 
 
 # mavlink header only library

--- a/src/modules/mavlink/mavlink_bridge_header.h
+++ b/src/modules/mavlink/mavlink_bridge_header.h
@@ -93,9 +93,7 @@ extern mavlink_status_t *mavlink_get_channel_status(uint8_t chan);
 extern mavlink_message_t *mavlink_get_channel_buffer(uint8_t chan);
 
 #include <mavlink.h>
-#if !MAVLINK_FTP_UNIT_TEST
 #include <uAvionix.h>
-#endif
 
 __END_DECLS
 

--- a/src/modules/mavlink/mavlink_tests/CMakeLists.txt
+++ b/src/modules/mavlink/mavlink_tests/CMakeLists.txt
@@ -35,16 +35,12 @@ px4_add_module(
 	MODULE modules__mavlink__mavlink_tests
 	MAIN mavlink_tests
 	STACK_MAIN 8192
-	INCLUDES
-		${MAVLINK_LIBRARY_DIR}
-		${MAVLINK_LIBRARY_DIR}/${CONFIG_MAVLINK_DIALECT}
 	COMPILE_FLAGS
 		-DMAVLINK_FTP_UNIT_TEST
 		#-DMAVLINK_FTP_DEBUG
 		-DMavlinkStream=MavlinkStreamTest
 		-DMavlinkFTP=MavlinkFTPTest
 		-Wno-cast-align # TODO: fix and enable
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 		-Wno-double-promotion # The fix has been proposed as PR upstream (2020-03-08)
 	SRCS
 		mavlink_tests.cpp
@@ -52,5 +48,5 @@ px4_add_module(
 		../mavlink_stream.cpp
 		../mavlink_ftp.cpp
 	DEPENDS
-		mavlink_c_generate
+		mavlink_c
 	)

--- a/src/modules/simulation/simulator_mavlink/CMakeLists.txt
+++ b/src/modules/simulation/simulator_mavlink/CMakeLists.txt
@@ -31,23 +31,20 @@
 #
 ############################################################################
 
+# Make GENERATED property from mavlink_c available
+cmake_policy(SET CMP0118 NEW)
+
 px4_add_module(
 	MODULE modules__simulation__simulator_mavlink
 	MAIN simulator_mavlink
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align
-		-Wno-address-of-packed-member # TODO: fix in c_library_v2
-	INCLUDES
-		${CMAKE_BINARY_DIR}/mavlink
-		${CMAKE_BINARY_DIR}/mavlink/development
-		${CMAKE_BINARY_DIR}/mavlink/common
-		${CMAKE_BINARY_DIR}/mavlink/standard
 	SRCS
 		SimulatorMavlink.cpp
 		SimulatorMavlink.hpp
 	DEPENDS
-		mavlink_c_generate
+		mavlink_c
 		conversion
 		geo
 		drivers_accelerometer


### PR DESCRIPTION
### Solved Problem
When debugging problems related to #23313 I found that in our CMake `simulator_mavlink` and `mavlink_tests`  include the `mavlink_c_generated` target instead of the `mavlink_c` library and duplicate the included folders and build options.

I assume this is the case because of a problem in older CMake versions where the generated property is only available to subdirectories of where it's defined see [here](https://gitlab.kitware.com/cmake/cmake/-/issues/18399).

### Solution
With CMake policy [CMP0118](https://cmake.org/cmake/help/latest/policy/CMP0118.html#policy:CMP0118) this problem was resolved. It's available in CMake version 3.20+. If we are ready for that version everywhere we should switch the minimum version and the default will be the new policy before that I have this draft to see where it fails in CI.

This works because the policy now allows to have the generated property available in other places than the library directory itself. Are we ready for cmake 3.20? Then we should increase the minimum version instead of just enabling the policy in a few files.

### Test coverage
This works locally for me on Ubuntu 22.04 inside WSL.