### PR TITLE
mission: skip a vtol takoff mission item if already in air

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -216,6 +216,23 @@ void Mission::setActiveMissionItems()
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	const position_setpoint_s current_setpoint_copy = pos_sp_triplet->current;
 
+	/* Skip VTOL/FW Takeoff item if in air, fixed-wing and didn't start the takeoff already*/
+	if ((_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_TAKEOFF) &&
+	    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
+	    (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
+	    !_land_detected_sub.get().landed) {
+		if (setNextMissionItem()) {
+			if (!loadCurrentMissionItem()) {
+				setEndOfMissionItems();
+				return;
+			}
+
+		} else {
+			setEndOfMissionItems();
+			return;
+		}
+	}
+
 	if (item_contains_position(_mission_item)) {
 
 		handleTakeoff(new_work_item_type, next_mission_items, num_found_items);

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -451,20 +451,7 @@ MissionBase::set_mission_items()
 				_mission_item.nav_cmd = NAV_CMD_VTOL_LAND;
 			}
 
-			/* Skip VTOL/FW Takeoff item if in air, fixed-wing and didn't start the takeoff already*/
-			if ((_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_TAKEOFF) &&
-			    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
-			    (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
-			    !_land_detected_sub.get().landed) {
-				if (setNextMissionItem()) {
-					if (!loadCurrentMissionItem()) {
-						set_end_of_mission = true;
-					}
-
-				} else {
-					set_end_of_mission = true;
-				}
-			}
+			setActiveMissionItems();
 
 		} else {
 			set_end_of_mission = true;
@@ -477,9 +464,6 @@ MissionBase::set_mission_items()
 	if (set_end_of_mission) {
 		setEndOfMissionItems();
 		_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
-
-	} else {
-		setActiveMissionItems();
 	}
 }
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -456,7 +456,7 @@ MissionBase::set_mission_items()
 			    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
 			    (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
 			    !_land_detected_sub.get().landed) {
-				if (goToNextItem(false) == PX4_OK) {
+				if (setNextMissionItem()) {
 					if (!loadCurrentMissionItem()) {
 						set_end_of_mission = true;
 					}

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -451,7 +451,20 @@ MissionBase::set_mission_items()
 				_mission_item.nav_cmd = NAV_CMD_VTOL_LAND;
 			}
 
-			setActiveMissionItems();
+			/* Skip VTOL takeoff item if in air and already in fixed wing and didn't started with VTOL takeoff already*/
+			if ((_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF) &&
+			    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
+			    (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
+			    !_land_detected_sub.get().landed) {
+				if (goToNextItem(false) == PX4_OK) {
+					if (!loadCurrentMissionItem()) {
+						set_end_of_mission = true;
+					}
+
+				} else {
+					set_end_of_mission = true;
+				}
+			}
 
 		} else {
 			set_end_of_mission = true;
@@ -464,6 +477,9 @@ MissionBase::set_mission_items()
 	if (set_end_of_mission) {
 		setEndOfMissionItems();
 		_navigator->mode_completed(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
+
+	} else {
+		setActiveMissionItems();
 	}
 }
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -451,8 +451,8 @@ MissionBase::set_mission_items()
 				_mission_item.nav_cmd = NAV_CMD_VTOL_LAND;
 			}
 
-			/* Skip VTOL takeoff item if in air and already in fixed wing and didn't started with VTOL takeoff already*/
-			if ((_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF) &&
+			/* Skip VTOL/FW Takeoff item if in air, fixed-wing and didn't start the takeoff already*/
+			if ((_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_TAKEOFF) &&
 			    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
 			    (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
 			    !_land_detected_sub.get().landed) {

--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -92,6 +92,23 @@ void RtlMissionFast::setActiveMissionItems()
 	WorkItemType new_work_item_type{WorkItemType::WORK_ITEM_TYPE_DEFAULT};
 	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
+	/* Skip VTOL/FW Takeoff item if in air, fixed-wing and didn't start the takeoff already*/
+	if ((_mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_TAKEOFF) &&
+	    (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) &&
+	    (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) &&
+	    !_land_detected_sub.get().landed) {
+		if (setNextMissionItem()) {
+			if (!loadCurrentMissionItem()) {
+				setEndOfMissionItems();
+				return;
+			}
+
+		} else {
+			setEndOfMissionItems();
+			return;
+		}
+	}
+
 	// Transition to fixed wing if necessary.
 	if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING &&
 	    _vehicle_status_sub.get().is_vtol &&


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When a mission is planned including a vtol takeoff item while the VTOL is already in Air and converted to a fixed wing, the VTOL immediately accepts the takeoff item, but is using an altitude ramp to the next waypoint item. This is due to the fact that although the vtol takeoff item is accepted immediately, it is still set as the position setpoint previous item including the transition altitude specified. This results in the VTOL losing altitude up to the transition item when the current altitude is higher. It should completely ignore the vtol takeoff item when already airborne.

Fixes #{Github issue ID}

### Solution
- For all mission modes, ignore the VTOL Takeoff item if the vehicle is already in Air and already transitioned to fixed wing.

### Changelog Entry
For release notes:
```
Bugfix Ignore VTOL takeoff when already in air and transitioned to fixed wing
```

### Test coverage
- SITL testing using the standard vtol. 

