### PR TITLE
Add check for high RAM usage

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -157,6 +157,7 @@ param set-default CBRK_SUPPLY_CHK 894281
 
 # disable check, no CPU load reported on posix yet
 param set-default COM_CPU_MAX -1
+param set-default COM_RAM_MAX -1
 
 # Don't require RC calibration and configuration
 param set-default COM_RC_IN_MODE 1

--- a/src/modules/commander/HealthAndArmingChecks/checks/cpuResourceCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/cpuResourceCheck.hpp
@@ -54,6 +54,7 @@ private:
 	systemlib::Hysteresis _high_cpu_load_hysteresis{false};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
-					(ParamFloat<px4::params::COM_CPU_MAX>) _param_com_cpu_max
+					(ParamFloat<px4::params::COM_CPU_MAX>) _param_com_cpu_max,
+					(ParamFloat<px4::params::COM_RAM_MAX>) _param_com_ram_max
 				       )
 };

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -803,6 +803,21 @@ PARAM_DEFINE_FLOAT(COM_KILL_DISARM, 5.0f);
 PARAM_DEFINE_FLOAT(COM_CPU_MAX, 95.0f);
 
 /**
+ * Maximum allowed RAM usage to pass checks
+ *
+ * The check fails if the RAM usage is above this threshold.
+ *
+ * A negative value disables the check.
+ *
+ * @group Commander
+ * @unit %
+ * @min -1
+ * @max 100
+ * @increment 1
+ */
+PARAM_DEFINE_FLOAT(COM_RAM_MAX, 95.0f);
+
+/**
  * Required number of redundant power modules
  *
  * This configures a check to verify the expected number of 5V rail power supplies are present. By default only one is expected.


### PR DESCRIPTION
### Solved Problem
We had a case where someone took off with an experimental system with 100% RAM usage on the embedded system
without noticing. This lead to problems during flight.

Since we already have a CPU load check it seems natural to also check the reported RAM usage.

### Solution
- Extend existing CPU load check to also look at RAM usage which is available in the same system resources uORB message `cpuload`.

### Changelog Entry
```
Feature: Add check for high RAM usage
```

### Test coverage
I tested this in SITL SIH and even though the reported RAM usage was pretty low I just enabled the check and lowered the threshold until it failed exactly like expected.
![image](https://github.com/PX4/PX4-Autopilot/assets/4668506/dc442d54-2fe4-4b46-b8ca-a4eda3d4b8d9)
