### PR TITLE
Fix the deprecated syntax in the "Tools/setup/requirements.txt"

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -7,7 +7,7 @@ jinja2>=2.8
 jsonschema
 kconfiglib
 lxml
-matplotlib>=3.0.*
+matplotlib>=3.0
 numpy>=1.13
 nunavut>=1.1.0
 packaging


### PR DESCRIPTION
Fix the wrong - deprecated - expression in the ```Tools/setup/requirements.txt```

- Fixes matplotlib version expression from ">=3.0.*" ro ">=3.0" which is the right syntax

Fixes issue #23329

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When ... I found that ...

Fixes #{Github issue ID}

### Solution
- Add ... for ...
- Refactor ...

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
