### PR TITLE
Autostart: load all airframes IDs with priority ROMFS -> SD card

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -217,25 +217,31 @@ else
 	fi
 	unset BOARD_RC_DEFAULTS
 
-	#
-	# Set parameters and env variables for selected SYS_AUTOSTART.
-	#
-	set AUTOSTART_PATH etc/init.d/rc.autostart
+	# Load airframe configuration based on SYS_AUTOSTART parameter
 	if ! param compare SYS_AUTOSTART 0
 	then
-		if param greater SYS_AUTOSTART 1000000
+		# rc.autostart directly run the right airframe script which sets the VEHICLE_TYPE
+		# Look for airframe in ROMFS
+		. ${R}etc/init.d/rc.autostart
+
+		if [ ${VEHICLE_TYPE} == none ]
 		then
-			# Use external startup file
+			# Look for airframe on SD card
 			if [ $SDCARD_AVAILABLE = yes ]
 			then
-				set AUTOSTART_PATH etc/init.d/rc.autostart_ext
+				. ${R}etc/init.d/rc.autostart_ext
 			else
-				echo "ERROR [init] SD card not mounted - trying to load airframe from ROMFS"
+				echo "ERROR [init] SD card not mounted - can't load external airframe"
 			fi
 		fi
-		. ${R}$AUTOSTART_PATH
+
+		if [ ${VEHICLE_TYPE} == none ]
+		then
+			echo "ERROR [init] No airframe file found for SYS_AUTOSTART value"
+			param set SYS_AUTOSTART 0
+			tune_control play error
+		fi
 	fi
-	unset AUTOSTART_PATH
 
 	# Check parameter version and reset upon airframe configuration version mismatch.
 	# Reboot required because "param reset_all" would reset all "param set" lines from airframe.

--- a/Tools/px4airframes/rcout.py
+++ b/Tools/px4airframes/rcout.py
@@ -79,12 +79,6 @@ class RCOutput():
         result += "then\n"
         result += "\techo \"Loading airframe: /etc/init.d/airframes/${AIRFRAME}\"\n"
         result += "\t. /etc/init.d/airframes/${AIRFRAME}\n"
-        if not post_start:
-            result += "else\n"
-            result += "\techo \"ERROR [init] No file matches SYS_AUTOSTART value found in : /etc/init.d/airframes\"\n"
-            # Reset the configuration
-            result += "\tparam set SYS_AUTOSTART 0\n"
-            result += "\ttone_alarm ${TUNE_ERR}\n"
         result += "fi\n"
         result += "unset AIRFRAME"
         self.output = result


### PR DESCRIPTION
### Solved Problem
When updating a vehicle configuration I had the requirement to not change the startup ID (`SYS_AUTOSTART`) but want to move the airframe file from the SD card to ROMFS.

Of course I can just remove the logic to load any airframe from the SD card from that vehicle but that would make that part custom. While going through what prevents the current logic from achieving the goal I stumbled across the number partitioning of external airframes needing to have numbers > 1'000'000 which was already talked about here: https://github.com/PX4/PX4-Autopilot/pull/18459#discussion_r732107774 I talked with @ThomasDebrunner about why there's no fallback for looking for airframes in the currently available two locations ROMFS and SD card except for when the SD card is completely missing.

### Solution
My proposal is to look for airframes first in ROMFS and then on the SD card independent of their numbering. The error handling for the case where no airframe was found is moved outside of the generated `rc.autostart`.

### Changelog Entry
```
Improvement: Look for airframe files in ROMFS and then SD card independent of the autostart number.
```

### Alternatives
We could also swap the priorities to look first on the SD card and then in the ROMFS. I'm not a fan of this because:
+ Existing airframe IDs could be overridden with an airfame file on the SD card
- This could lead to confusion
- It's more likely to have a version mismatched airframe on the SD card if there is also one in ROMFS
- In case the SD card is available but the corresponding file missing or corrupted it would silently load the internal airframe which could lead to unexpected behavior and even be safety relevant

### Test coverage
I tested this on a vehicle with fmu-v5x. Like expected if the corresponding airframe is available in ROMFS it's loaded with priority
with the message `Loading airframe: /etc/init.d/airframes/000_XXX`, if it isn't part of `rc.autostart` in ROMFS it's loaded from the SD card with only the message that's part of the SD card autostart file. And if there is no matching airframe you get the error `ERROR [init] No airframe file found for SYS_AUTOSTART value` and `SYS_AUTOSTART` is reset to the value 0.