### PR TITLE
commander: remove multicopter nav test

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -100,12 +100,6 @@ private:
 	hrt_abstime	_last_lpos_relaxed_fail_time_us{0};	///< Last time that the relaxed local position validity recovery check failed (usec)
 	hrt_abstime	_last_lvel_fail_time_us{0};	///< Last time that the local velocity validity recovery check failed (usec)
 
-	// variables used to check for navigation failure after takeoff
-	hrt_abstime	_time_last_innov_pass{0};	///< last time velocity and position innovations passed
-	hrt_abstime	_time_last_innov_fail{0};	///< last time velocity and position innovations failed
-	bool		_nav_test_passed{false};	///< true if the post takeoff navigation test has passed
-	bool		_nav_test_failed{false};	///< true if the post takeoff navigation test has failed
-
 	bool _gps_was_fused{false};
 	bool _gnss_spoofed{false};
 


### PR DESCRIPTION
This needs careful review.

I'd like to remove the multicopter navigation test in commander because I think it's no longer needed and has the potential to do more harm than good latching on a false positive.

It's not that common anymore, but I've seen examples where we would have recovered (or were in the process of recovering), but this "nav test" triggers (latched) and you're done (velocity and position locked invalid).

The counter example I'm looking for is if this ever triggers and actually prevented a fallway that the EKF2 yaw estimator wouldn't have caught.

