### PR TITLE
mavlink: BATTERY_STATUS use unfiltered current. Fix missing voltage.

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -153,7 +153,9 @@ battery_status_s Battery::getBatteryStatus()
 {
 	battery_status_s battery_status{};
 	battery_status.voltage_v = _voltage_v;
+	battery_status.voltage_filtered_v = _ocv_filter_v.getState();
 	battery_status.current_a = _current_a;
+	battery_status.current_filtered_a = _current_average_filter_a.getState();
 	battery_status.current_average_a = _current_average_filter_a.getState();
 	battery_status.discharged_mah = _discharged_mah;
 	battery_status.remaining = _state_of_charge;

--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -74,7 +74,7 @@ private:
 				bat_msg.type = MAV_BATTERY_TYPE_LIPO;
 				bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
 				bat_msg.energy_consumed = -1;
-				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
+				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_a * 100 : -1;
 				bat_msg.battery_remaining = (battery_status.connected) ? roundf(battery_status.remaining * 100.f) : -1;
 				// MAVLink extension: 0 is unsupported, in uORB it's NAN
 				bat_msg.time_remaining = (battery_status.connected && (PX4_ISFINITE(battery_status.time_remaining_s))) ?


### PR DESCRIPTION
https://github.com/PX4/PX4-Autopilot/pull/23205 broke the BATTERY_STATUS message in QGC. 

Also, current_filtered_a is only updated when the drone is armed. So the current sent over mavlink is invalid until the drone is armed. Changing to non-filtered current ensures a value is always sent.