### PR TITLE
Fix buffer overflow in mavlink_receive.cpp

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1818,7 +1818,7 @@ MavlinkReceiver::handle_message_serial_control(mavlink_message_t *msg)
 
 	if (shell) {
 		// we ignore the timeout, EXCLUSIVE & BLOCKING flags of the SERIAL_CONTROL message
-		if (serial_control_mavlink.count > 0) {
+		if (serial_control_mavlink.count > 0 && serial_control_mavlink.count <= sizeof(serial_control_mavlink.data)){
 			shell->setTargetID(msg->sysid, msg->compid);
 			shell->write(serial_control_mavlink.data, serial_control_mavlink.count);
 		}


### PR DESCRIPTION
Fix the stack-buffer overflow vulnerability in the mavlink_receiver.cpp
Here is the reference link：https://github.com/PX4/PX4-Autopilot/security/advisories/GHSA-55wq-2hgm-75m4