### PR TITLE
BatteryStatus: remove filtered voltage/current fields

### DIFF
--- a/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/dsp_hitl.cpp
+++ b/boards/modalai/voxl2-slpi/src/drivers/dsp_hitl/dsp_hitl.cpp
@@ -1148,7 +1148,6 @@ handle_message_hil_sensor_dsp(mavlink_message_t *msg)
 
 		hil_battery_status.timestamp = gyro_accel_time;
 		hil_battery_status.voltage_v = 16.0f;
-		hil_battery_status.voltage_filtered_v = 16.0f;
 		hil_battery_status.current_a = 10.0f;
 		hil_battery_status.discharged_mah = -1.0f;
 		hil_battery_status.connected = true;

--- a/msg/BatteryStatus.msg
+++ b/msg/BatteryStatus.msg
@@ -3,7 +3,6 @@ bool connected				# Whether or not a battery is connected, based on a voltage th
 float32 voltage_v			# Battery voltage in volts, 0 if unknown
 float32 voltage_filtered_v	# Battery voltage in volts, filtered, 0 if unknown
 float32 current_a			# Battery current in amperes, -1 if unknown
-float32 current_filtered_a	# Battery current in amperes, filtered, 0 if unknown
 float32 current_average_a	# Battery current average in amperes (for FW average in level flight), -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining			# From 1 to 0, -1 if unknown

--- a/msg/BatteryStatus.msg
+++ b/msg/BatteryStatus.msg
@@ -1,7 +1,6 @@
 uint64 timestamp			# time since system start (microseconds)
 bool connected				# Whether or not a battery is connected, based on a voltage threshold
 float32 voltage_v			# Battery voltage in volts, 0 if unknown
-float32 voltage_filtered_v	# Battery voltage in volts, filtered, 0 if unknown
 float32 current_a			# Battery current in amperes, -1 if unknown
 float32 current_average_a	# Battery current average in amperes (for FW average in level flight), -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -122,7 +122,6 @@ void BATT_SMBUS::RunImpl()
 	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);
 
 	new_report.current_a = (-1.0f * ((float)(*(int16_t *)&result)) / 1000.0f) * _c_mult;
-	new_report.current_filtered_a = new_report.current_a;
 
 	// Read average current.
 	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_CURRENT, result);

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -116,7 +116,6 @@ void BATT_SMBUS::RunImpl()
 
 	// Convert millivolts to volts.
 	new_report.voltage_v = ((float)result) / 1000.0f;
-	new_report.voltage_filtered_v = new_report.voltage_v;
 
 	// Read current.
 	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);

--- a/src/drivers/cyphal/Subscribers/legacy/LegacyBatteryInfo.hpp
+++ b/src/drivers/cyphal/Subscribers/legacy/LegacyBatteryInfo.hpp
@@ -77,7 +77,6 @@ public:
 		battery_status_s bat_status {0};
 		bat_status.timestamp = hrt_absolute_time();
 		bat_status.voltage_filtered_v = bat_info.voltage;
-		bat_status.current_filtered_a = bat_info.current;
 		bat_status.current_average_a = bat_info.average_power_10sec;
 		bat_status.remaining = bat_info.state_of_charge_pct / 100.0f;
 		bat_status.scale = -1;

--- a/src/drivers/cyphal/Subscribers/legacy/LegacyBatteryInfo.hpp
+++ b/src/drivers/cyphal/Subscribers/legacy/LegacyBatteryInfo.hpp
@@ -76,7 +76,6 @@ public:
 
 		battery_status_s bat_status {0};
 		bat_status.timestamp = hrt_absolute_time();
-		bat_status.voltage_filtered_v = bat_info.voltage;
 		bat_status.current_average_a = bat_info.average_power_10sec;
 		bat_status.remaining = bat_info.state_of_charge_pct / 100.0f;
 		bat_status.scale = -1;

--- a/src/drivers/osd/atxxxx/atxxxx.cpp
+++ b/src/drivers/osd/atxxxx/atxxxx.cpp
@@ -241,7 +241,7 @@ OSDatxxxx::add_battery_info(uint8_t pos_x, uint8_t pos_y)
 	int ret = PX4_OK;
 
 	// TODO: show battery symbol based on battery fill level
-	snprintf(buf, sizeof(buf), "%c%5.2f", OSD_SYMBOL_BATT_3, (double)_battery_voltage_filtered_v);
+	snprintf(buf, sizeof(buf), "%c%5.2f", OSD_SYMBOL_BATT_3, (double)_battery_voltage_v);
 	buf[sizeof(buf) - 1] = '\0';
 
 	for (int i = 0; buf[i] != '\0'; i++) {
@@ -330,7 +330,7 @@ OSDatxxxx::update_topics()
 		_battery_sub.copy(&battery);
 
 		if (battery.connected) {
-			_battery_voltage_filtered_v = battery.voltage_filtered_v;
+			_battery_voltage_v = battery.voltage_v;
 			_battery_discharge_mah = battery.discharged_mah;
 			_battery_valid = true;
 

--- a/src/drivers/osd/atxxxx/atxxxx.h
+++ b/src/drivers/osd/atxxxx/atxxxx.h
@@ -111,7 +111,7 @@ private:
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
 
 	// battery
-	float _battery_voltage_filtered_v{0.f};
+	float _battery_voltage_v{0.f};
 	float _battery_discharge_mah{0.f};
 	bool _battery_valid{false};
 

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -224,7 +224,7 @@ void CrsfRc::Run()
 				battery_status_s battery_status;
 
 				if (_battery_status_sub.update(&battery_status)) {
-					uint16_t voltage = battery_status.voltage_filtered_v * 10;
+					uint16_t voltage = battery_status.voltage_v * 10;
 					uint16_t current = battery_status.current_a * 10;
 					int fuel = battery_status.discharged_mah;
 					uint8_t remaining = battery_status.remaining * 100;

--- a/src/drivers/rc/crsf_rc/CrsfRc.cpp
+++ b/src/drivers/rc/crsf_rc/CrsfRc.cpp
@@ -225,7 +225,7 @@ void CrsfRc::Run()
 
 				if (_battery_status_sub.update(&battery_status)) {
 					uint16_t voltage = battery_status.voltage_filtered_v * 10;
-					uint16_t current = battery_status.current_filtered_a * 10;
+					uint16_t current = battery_status.current_a * 10;
 					int fuel = battery_status.discharged_mah;
 					uint8_t remaining = battery_status.remaining * 100;
 					this->SendTelemetryBattery(voltage, current, fuel, remaining);

--- a/src/drivers/rc_input/crsf_telemetry.cpp
+++ b/src/drivers/rc_input/crsf_telemetry.cpp
@@ -82,7 +82,7 @@ bool CRSFTelemetry::send_battery()
 	}
 
 	uint16_t voltage = battery_status.voltage_filtered_v * 10;
-	uint16_t current = battery_status.current_filtered_a * 10;
+	uint16_t current = battery_status.current_a * 10;
 	int fuel = battery_status.discharged_mah;
 	uint8_t remaining = battery_status.remaining * 100;
 	return crsf_send_telemetry_battery(_uart_fd, voltage, current, fuel, remaining);

--- a/src/drivers/rc_input/crsf_telemetry.cpp
+++ b/src/drivers/rc_input/crsf_telemetry.cpp
@@ -81,7 +81,7 @@ bool CRSFTelemetry::send_battery()
 		return false;
 	}
 
-	uint16_t voltage = battery_status.voltage_filtered_v * 10;
+	uint16_t voltage = battery_status.voltage_v * 10;
 	uint16_t current = battery_status.current_a * 10;
 	int fuel = battery_status.discharged_mah;
 	uint8_t remaining = battery_status.remaining * 100;

--- a/src/drivers/rc_input/ghst_telemetry.cpp
+++ b/src/drivers/rc_input/ghst_telemetry.cpp
@@ -91,7 +91,7 @@ bool GHSTTelemetry::send_battery_status()
 
 	if (_battery_status_sub.update(&battery_status)) {
 		voltage_in_10mV = battery_status.voltage_filtered_v * FACTOR_VOLTS_TO_10MV;
-		current_in_10mA = battery_status.current_filtered_a * FACTOR_AMPS_TO_10MA;
+		current_in_10mA = battery_status.current_a * FACTOR_AMPS_TO_10MA;
 		fuel_in_10mAh = battery_status.discharged_mah * FACTOR_MAH_TO_10MAH;
 		success = ghst_send_telemetry_battery_status(_uart_fd,
 				static_cast<uint16_t>(voltage_in_10mV),

--- a/src/drivers/rc_input/ghst_telemetry.cpp
+++ b/src/drivers/rc_input/ghst_telemetry.cpp
@@ -90,7 +90,7 @@ bool GHSTTelemetry::send_battery_status()
 	battery_status_s battery_status;
 
 	if (_battery_status_sub.update(&battery_status)) {
-		voltage_in_10mV = battery_status.voltage_filtered_v * FACTOR_VOLTS_TO_10MV;
+		voltage_in_10mV = battery_status.voltage_v * FACTOR_VOLTS_TO_10MV;
 		current_in_10mA = battery_status.current_a * FACTOR_AMPS_TO_10MA;
 		fuel_in_10mAh = battery_status.discharged_mah * FACTOR_MAH_TO_10MAH;
 		success = ghst_send_telemetry_battery_status(_uart_fd,

--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -146,7 +146,6 @@ void Batmon::RunImpl()
 
 	// Convert millivolts to volts.
 	new_report.voltage_v = ((float)result) / 1000.0f;
-	new_report.voltage_filtered_v = new_report.voltage_v;
 
 	// Read current.
 	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);

--- a/src/drivers/smart_battery/batmon/batmon.cpp
+++ b/src/drivers/smart_battery/batmon/batmon.cpp
@@ -152,7 +152,6 @@ void Batmon::RunImpl()
 	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);
 
 	new_report.current_a = (-1.0f * ((float)(*(int16_t *)&result)) / 1000.0f);
-	new_report.current_filtered_a = new_report.current_a;
 
 	// Read average current.
 	ret |= _interface->read_word(BATT_SMBUS_AVERAGE_CURRENT, result);

--- a/src/drivers/tattu_can/TattuCan.cpp
+++ b/src/drivers/tattu_can/TattuCan.cpp
@@ -117,7 +117,6 @@ void TattuCan::Run()
 		battery_status.voltage_v = static_cast<float>(tattu_message.voltage) / 1000.0f;
 		battery_status.voltage_filtered_v = static_cast<float>(tattu_message.voltage) / 1000.0f;
 		battery_status.current_a = static_cast<float>(tattu_message.current) / 1000.0f;
-		battery_status.current_filtered_a = static_cast<float>(tattu_message.current) / 1000.0f;
 		battery_status.remaining = static_cast<float>(tattu_message.remaining_percent) / 100.0f;
 		battery_status.temperature = static_cast<float>(tattu_message.temperature);
 		battery_status.capacity = tattu_message.standard_capacity;

--- a/src/drivers/tattu_can/TattuCan.cpp
+++ b/src/drivers/tattu_can/TattuCan.cpp
@@ -115,7 +115,6 @@ void TattuCan::Run()
 		battery_status.state_of_health = static_cast<uint16_t>(tattu_message.health_status);
 
 		battery_status.voltage_v = static_cast<float>(tattu_message.voltage) / 1000.0f;
-		battery_status.voltage_filtered_v = static_cast<float>(tattu_message.voltage) / 1000.0f;
 		battery_status.current_a = static_cast<float>(tattu_message.current) / 1000.0f;
 		battery_status.remaining = static_cast<float>(tattu_message.remaining_percent) / 100.0f;
 		battery_status.temperature = static_cast<float>(tattu_message.temperature);

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -106,7 +106,6 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 	_battery_status[instance].voltage_v = msg.voltage;
 	_battery_status[instance].voltage_filtered_v = msg.voltage;
 	_battery_status[instance].current_a = msg.current;
-	_battery_status[instance].current_filtered_a = msg.current;
 	_battery_status[instance].current_average_a = msg.current;
 
 	if (_batt_update_mod[instance] == BatteryDataType::Raw) {

--- a/src/drivers/uavcan/sensors/battery.cpp
+++ b/src/drivers/uavcan/sensors/battery.cpp
@@ -104,7 +104,6 @@ UavcanBatteryBridge::battery_sub_cb(const uavcan::ReceivedDataStructure<uavcan::
 
 	_battery_status[instance].timestamp = hrt_absolute_time();
 	_battery_status[instance].voltage_v = msg.voltage;
-	_battery_status[instance].voltage_filtered_v = msg.voltage;
 	_battery_status[instance].current_a = msg.current;
 	_battery_status[instance].current_average_a = msg.current;
 

--- a/src/lib/battery/int_res_est_replay.py
+++ b/src/lib/battery/int_res_est_replay.py
@@ -31,15 +31,11 @@ def rls_update(theta, P, x, V, I, lam):
         return theta_corr, P_corr, error, data_cov, 0, 0
     return theta_temp, P_temp, error, data_cov, gamma[0], gamma[1]
 
-def main(log_name, n_cells, full_cell, empty_cell, lam, filtered):
+def main(log_name, n_cells, full_cell, empty_cell, lam):
     log = ULog(log_name)
     timestamps = us2s(getData(log, 'battery_status', 'timestamp'))
-    if (filtered):
-        I = getData(log, 'battery_status', 'current_filtered_a')
-        V = getData(log, 'battery_status', 'voltage_filtered_v')
-    else:
-        I = getData(log, 'battery_status', 'current_a')
-        V = getData(log, 'battery_status', 'voltage_v')
+    I = getData(log, 'battery_status', 'current_a')
+    V = getData(log, 'battery_status', 'voltage_v')
     remaining = getData(log, 'battery_status', 'remaining')
 
     if not timestamps.size or not I.size or not V.size or not remaining.size:
@@ -176,6 +172,5 @@ if __name__ == "__main__":
     parser.add_argument('-u', type = float, required = False, default = 4.05, help = 'Full cell voltage')
     parser.add_argument('-e', type = float, required = False, default = 3.6,  help = 'Empty cell voltage')
     parser.add_argument('-l', type = float, required = False, default = 0.99, help = 'Forgetting factor')
-    parser.add_argument('-d', type = bool,  required = False, default = False,    help = 'Filter measurements')
     args = parser.parse_args()
-    main(args.f, args.c, args.u, args.e, args.l, args.d)
+    main(args.f, args.c, args.u, args.e, args.l)

--- a/src/lib/drivers/smbus_sbs/SBS.hpp
+++ b/src/lib/drivers/smbus_sbs/SBS.hpp
@@ -261,7 +261,6 @@ int SMBUS_SBS_BaseClass<T>::populate_smbus_data(battery_status_s &data)
 
 	// Convert millivolts to volts.
 	data.voltage_v = ((float)result) * 0.001f;
-	data.voltage_filtered_v = data.voltage_v;
 
 	// Read current.
 	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);

--- a/src/lib/drivers/smbus_sbs/SBS.hpp
+++ b/src/lib/drivers/smbus_sbs/SBS.hpp
@@ -267,7 +267,6 @@ int SMBUS_SBS_BaseClass<T>::populate_smbus_data(battery_status_s &data)
 	ret |= _interface->read_word(BATT_SMBUS_CURRENT, result);
 
 	data.current_a = (-1.0f * ((float)(*(int16_t *)&result)) * 0.001f);
-	data.current_filtered_a = data.current_a;
 
 	// Read remaining capacity.
 	ret |= _interface->read_word(BATT_SMBUS_RELATIVE_SOC, result);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1772,7 +1772,6 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.voltage_v = voltage_sum;
 	battery_status.voltage_filtered_v  = voltage_sum;
 	battery_status.current_a = (float)(battery_mavlink.current_battery) / 100.0f;
-	battery_status.current_filtered_a = battery_status.current_a;
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
 	battery_status.discharged_mah = (float)battery_mavlink.current_consumed;
 	battery_status.cell_count = cell_count;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1770,7 +1770,6 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	}
 
 	battery_status.voltage_v = voltage_sum;
-	battery_status.voltage_filtered_v  = voltage_sum;
 	battery_status.current_a = (float)(battery_mavlink.current_battery) / 100.0f;
 	battery_status.remaining = (float)battery_mavlink.battery_remaining / 100.0f;
 	battery_status.discharged_mah = (float)battery_mavlink.current_consumed;
@@ -2372,7 +2371,6 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 
 		hil_battery_status.timestamp = timestamp;
 		hil_battery_status.voltage_v = 16.0f;
-		hil_battery_status.voltage_filtered_v = 16.0f;
 		hil_battery_status.current_a = 10.0f;
 		hil_battery_status.discharged_mah = -1.0f;
 		hil_battery_status.connected = true;
@@ -2726,7 +2724,6 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 	{
 		battery_status_s hil_battery_status{};
 		hil_battery_status.voltage_v = 11.1f;
-		hil_battery_status.voltage_filtered_v = 11.1f;
 		hil_battery_status.current_a = 10.0f;
 		hil_battery_status.discharged_mah = -1.0f;
 		hil_battery_status.timestamp = hrt_absolute_time();

--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -161,10 +161,10 @@ private:
 						// If it doesn't fit, we have to split it into UINT16-1 chunks and the remaining
 						// voltage for the subsequent field.
 						// This won't work for voltages of more than 655 volts.
-						const int num_fields_required = static_cast<int>(battery_status.voltage_filtered_v * 1000.f) / (UINT16_MAX - 1) + 1;
+						const int num_fields_required = static_cast<int>(battery_status.voltage_v * 1000.f) / (UINT16_MAX - 1) + 1;
 
 						if (num_fields_required <= mavlink_cell_slots) {
-							float remaining_voltage = battery_status.voltage_filtered_v * 1000.f;
+							float remaining_voltage = battery_status.voltage_v * 1000.f;
 
 							for (int i = 0; i < num_fields_required - 1; ++i) {
 								bat_msg.voltages[i] = UINT16_MAX - 1;

--- a/src/modules/mavlink/streams/BATTERY_STATUS.hpp
+++ b/src/modules/mavlink/streams/BATTERY_STATUS.hpp
@@ -74,7 +74,7 @@ private:
 				bat_msg.type = MAV_BATTERY_TYPE_LIPO;
 				bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
 				bat_msg.energy_consumed = -1;
-				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
+				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_a * 100 : -1;
 				bat_msg.battery_remaining = (battery_status.connected) ? roundf(battery_status.remaining * 100.f) : -1;
 				// MAVLink extension: 0 is unsupported, in uORB it's NAN
 				bat_msg.time_remaining = (battery_status.connected && (PX4_ISFINITE(battery_status.time_remaining_s))) ?

--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -166,7 +166,7 @@ private:
 			const battery_status_s &lowest_battery = battery_status[lowest_battery_index];
 
 			if (lowest_battery.connected) {
-				msg.voltage_battery = lowest_battery.voltage_filtered_v * 1000.0f;
+				msg.voltage_battery = lowest_battery.voltage_v * 1000.0f;
 				msg.current_battery = lowest_battery.current_a * 100.0f;
 				msg.battery_remaining = ceilf(lowest_battery.remaining * 100.0f);
 

--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -167,7 +167,7 @@ private:
 
 			if (lowest_battery.connected) {
 				msg.voltage_battery = lowest_battery.voltage_filtered_v * 1000.0f;
-				msg.current_battery = lowest_battery.current_filtered_a * 100.0f;
+				msg.current_battery = lowest_battery.current_a * 100.0f;
 				msg.battery_remaining = ceilf(lowest_battery.remaining * 100.0f);
 
 			} else {


### PR DESCRIPTION

### Solved Problem
In https://github.com/PX4/PX4-Autopilot/pull/23205 we removed the filtering of voltage and current as it's not used anymore in the battery SOC estimate. We though didn't yet remove the fields in the battery_status message, which are instead just not filled.

### Solution
Remove the "filtered" fields from the BatteryStatus message. I argue that it is better to publish only the directly measured value instead of the filtered one. Reason: the amount of filtering is arbitrary, and there is likely no "optimal" way, it always a tradeoff between smoothness and delay. If the consumer of the BatteryStatus wants to do filtering before it is sent further it can be done there, though I personally am not convinced that it is needed. I as a pilot would prefer to see the raw measurement in the telemetry instead of a filtered value of which I don't know how much filtered it is and how much delay it has.


### Changelog Entry
For release notes:
```
Cleanup: BatteryStatus: remove filtered voltage/current fields
```

### Alternatives
Add a filter before the publication over MAVLink in SYS_STATUS. 
