### PR TITLE
fmu-v6xrt: MTD use full FRAM (32KB)

### DIFF
--- a/boards/px4/fmu-v6xrt/src/mtd.cpp
+++ b/boards/px4/fmu-v6xrt/src/mtd.cpp
@@ -53,18 +53,12 @@ static const px4_mft_device_t i2c6 = {             // 24LC64T on BASE  8K 32 X 2
 
 static const px4_mtd_entry_t fmum_fram = {
 	.device = &qspi_flash,
-	.npart = 2,
+	.npart = 1,
 	.partd = {
 		{
 			.type = MTD_PARAMETERS,
 			.path = "/fs/mtd_params",
-			.nblocks = 32
-		},
-		{
-			.type = MTD_WAYPOINTS,
-			.path = "/fs/mtd_waypoints",
-			.nblocks = 32
-
+			.nblocks = 256
 		}
 	},
 };


### PR DESCRIPTION
MTD was only using 4KB of the 32KB available on the fram, increase block counts.