### PR TITLE
ekf2: fake_pos don't use fuseHorizontalPosition helper

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/airspeed/airspeed_fusion.cpp
@@ -217,6 +217,10 @@ void Ekf::fuseAirspeed(const airspeedSample &airspeed_sample, estimator_aid_sour
 
 	if (is_fused) {
 		aid_src.time_last_fuse = _time_delayed_us;
+
+		if (!update_wind_only) {
+			_time_last_hor_vel_fuse = _time_delayed_us;
+		}
 	}
 }
 

--- a/src/modules/ekf2/EKF/aid_sources/fake_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/fake_height_control.cpp
@@ -63,7 +63,13 @@ void Ekf::controlFakeHgtFusion()
 
 				// always protect against extreme values that could result in a NaN
 				if (aid_src.test_ratio < sq(100.0f / innov_gate)) {
-					fuseVerticalPosition(aid_src);
+					if (!aid_src.innovation_rejected
+					    && fuseDirectStateMeasurement(aid_src.innovation, aid_src.innovation_variance, aid_src.observation_variance,
+									  State::pos.idx + 2)
+					   ) {
+						aid_src.fused = true;
+						aid_src.time_last_fuse = _time_delayed_us;
+					}
 				}
 
 				const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, (uint64_t)4e5);

--- a/src/modules/ekf2/EKF/aid_sources/fake_pos_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/fake_pos_control.cpp
@@ -87,7 +87,15 @@ void Ekf::controlFakePosFusion()
 				if ((aid_src.test_ratio[0] < sq(100.0f / innov_gate))
 				    && (aid_src.test_ratio[1] < sq(100.0f / innov_gate))
 				   ) {
-					fuseHorizontalPosition(aid_src);
+					if (!aid_src.innovation_rejected
+					    && fuseDirectStateMeasurement(aid_src.innovation[0], aid_src.innovation_variance[0], aid_src.observation_variance[0],
+									  State::pos.idx + 0)
+					    && fuseDirectStateMeasurement(aid_src.innovation[1], aid_src.innovation_variance[1], aid_src.observation_variance[1],
+									  State::pos.idx + 1)
+					   ) {
+						aid_src.fused = true;
+						aid_src.time_last_fuse = _time_delayed_us;
+					}
 				}
 
 				const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, (uint64_t)4e5);

--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
@@ -99,6 +99,8 @@ bool Ekf::fuseOptFlow(VectorState &H, const bool update_terrain)
 		_aid_src_optical_flow.time_last_fuse = _time_delayed_us;
 		_aid_src_optical_flow.fused = true;
 
+		_time_last_hor_vel_fuse = _time_delayed_us;
+
 		if (update_terrain) {
 			_time_last_terrain_fuse = _time_delayed_us;
 		}


### PR DESCRIPTION
 - fake_pos shouldn't update _time_last_hor_pos_fuse