### PR TITLE
ekf2: EV vel (body) update last vel fuse timestamps

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_vel_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_vel_control.cpp
@@ -292,6 +292,11 @@ bool Ekf::fuseEvVelocity(estimator_aid_source3d_s &aid_src, const extVisionSampl
 
 		}
 
+		if (aid_src.fused) {
+			_time_last_hor_vel_fuse = _time_delayed_us;
+			_time_last_ver_vel_fuse = _time_delayed_us;
+		}
+
 		aid_src.timestamp_sample = current_aid_src.timestamp_sample;
 		return !aid_src.innovation_rejected;
 


### PR DESCRIPTION
 - these are set by the NED fuseVelocity() helper, so also need to be set in the body frame velocity case