### PR TITLE
Fix load monitoring inconsistency bug

### DIFF
--- a/src/modules/load_mon/LoadMon.cpp
+++ b/src/modules/load_mon/LoadMon.cpp
@@ -202,7 +202,7 @@ void LoadMon::cpuload()
 			}
 		}
 
-		fseek(_proc_fd, 0, SEEK_END);
+		fseek(_proc_fd, 0, SEEK_SET);
 
 		if (parsedCount == 5) {
 			int32_t kb_main_cached = kb_page_cache + kb_slab_reclaimable;


### PR DESCRIPTION
### Solved Problem
Inconsistency in load monitoring for memory when running on a Linux based system. This bug does not always occur, but I found it when running in an Ubuntu 22.04 incus container.  See linked Github issue for more detail. 

Fixes #{Github issue ID}
#23361

### Solution
Reset the file descriptor back to the beginning of the file, rather than to the end of the file, to continually get new updates. 

### Changelog Entry
For release notes:
```
Bug fix of load monitoring inconsistency bug
```
### Test coverage
- Tested fix in SITL in incus Ubuntu 22.04 container. 

### Context
Related links, screenshot before/after, video
Before console output: 
![image](https://github.com/PX4/PX4-Autopilot/assets/8635542/c71584a5-98a6-4032-af2e-6a5903745178)

After console output:
![image](https://github.com/PX4/PX4-Autopilot/assets/8635542/97727edf-3729-47a7-bfc6-e98909d0eeb0)
