### PR TITLE
drv_hrt: allow time differences across timestamp wrap again

### DIFF
--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -162,16 +162,7 @@ static inline void abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
  */
 static inline hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
 {
-	hrt_abstime now = hrt_absolute_time();
-
-	// Cannot allow a negative elapsed time as this would appear
-	// to be a huge positive elapsed time when represented as an
-	// unsigned value!
-	if (*then > now) {
-		return 0;
-	}
-
-	return now - *then;
+	return hrt_absolute_time() - *then;
 }
 
 /**


### PR DESCRIPTION
### Solved Problem
Fixes #23378

### Solution
reverting a small part of 4a553938fb6bc7a853b83d175544fff26b404f68

### Changelog Entry
```
Bugfix: allow time differences across timestamp wrap again
```

### Alternatives
We could check why these occur in the first place.

### Test coverage
The SITL test procedure I used to reproduce the original issue passes again.

### Context
https://github.com/PX4/PX4-Autopilot/pull/22881
