### PR TITLE
Bugfix: Timestamp wrapping when initializing SubscriptionInterval less than the interval time after boot

### DIFF
--- a/platforms/common/uORB/SubscriptionInterval.hpp
+++ b/platforms/common/uORB/SubscriptionInterval.hpp
@@ -130,11 +130,10 @@ public:
 			if (now > _interval_us) {
 				// shift last update time forward, but don't let it get further behind than the interval
 				_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+
 			} else {
 				_last_update = now;
 			}
-			
-			
 
 			return true;
 		}

--- a/platforms/common/uORB/SubscriptionInterval.hpp
+++ b/platforms/common/uORB/SubscriptionInterval.hpp
@@ -130,7 +130,11 @@ public:
 			if (now > _interval_us) {
 				// shift last update time forward, but don't let it get further behind than the interval
 				_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+			} else {
+				_last_update = now;
 			}
+			
+			
 
 			return true;
 		}

--- a/platforms/common/uORB/SubscriptionInterval.hpp
+++ b/platforms/common/uORB/SubscriptionInterval.hpp
@@ -125,8 +125,13 @@ public:
 	{
 		if (_subscription.copy(dst)) {
 			const hrt_abstime now = hrt_absolute_time();
-			// shift last update time forward, but don't let it get further behind than the interval
-			_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+
+			// make sure we don't set a timestamp before the timer started counting (now - _interval_us would wrap because it's unsigned)
+			if (now > _interval_us) {
+				// shift last update time forward, but don't let it get further behind than the interval
+				_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+			}
+
 			return true;
 		}
 
@@ -160,7 +165,7 @@ public:
 protected:
 
 	Subscription	_subscription;
-	uint64_t	_last_update{0};	// last update in microseconds
+	uint64_t	_last_update{0};	// last subscription update in microseconds
 	uint32_t	_interval_us{0};	// maximum update interval in microseconds
 
 };


### PR DESCRIPTION
### Solved Problem
When debugging #23378 , the only instance where timestamps get negative/wrap the unsigned datatype was the case where `SubscriptionInterval`s are initialized less than the interval time (e.g. 1 second) after boot and hence the start of the microcontroller timer. This made the cases fail after invalid assumptions were made that this case would never normally happen without checking even once here: https://github.com/PX4/PX4-Autopilot/pull/22881/files#diff-5971d648b2b246dfb01ec5d5006b5258cfdbc41b73f50db1abe7dd5236f855e1R167-R172

The change producing a few timestamps after boot that wrap was introduced here:
https://github.com/PX4/PX4-Autopilot/pull/14181/files#diff-c82d12a48f93eeb820597a14504a6a2d58cb7c09ad86d2e7da6aa6b04e144628L124-R128
and it never resulted in any problem because even across the wrapping the result of the elapsed time calculation was correct again.

Fixes #23378

### Solution
The stamp stays 0 if subscriptions are initialized less than the interval time after boot instead of wrapping the unsigned timestamp.

It might not be optimal when the 64 bit time actually wraps because then for one intervals time the `_last_update` is not updated anymore but I hope that's acceptable given this should only happen after 500+k years of runtime.

### Changelog Entry
```
Bugfix: Timestamp wrapping when initializing SubscriptionInterval less than the interval time after boot
```

### Alternatives
Even with this fix I highly suggest reverting the change that made elapsed time across wrapping calculations impossible: https://github.com/PX4/PX4-Autopilot/pull/23380

### Test coverage
I ran this in SITL printing out all the `_last_update` timestamps of all instances and they do not wrap anymore shortly after boot but rather stay zero until the interval time passed once.