### PR TITLE
FMU-V6XRT release/1.15 backports

### DIFF
--- a/boards/px4/fmu-v6xrt/nuttx-config/include/board.h
+++ b/boards/px4/fmu-v6xrt/nuttx-config/include/board.h
@@ -52,6 +52,7 @@
 #define IMXRT_IPG_PODF_DIVIDER 5
 #define BOARD_GPT_FREQUENCY  24000000
 #define BOARD_XTAL_FREQUENCY 24000000
+#define BOARD_FLEXIO_PREQ    108000000
 
 /* SDIO *********************************************************************/
 

--- a/boards/px4/fmu-v6xrt/src/imxrt_clockconfig.c
+++ b/boards/px4/fmu-v6xrt/src/imxrt_clockconfig.c
@@ -114,11 +114,11 @@ const struct clock_configuration_s g_initial_clkconfig = {
 			.div           = 1,
 			.mux           = ACMP_CLK_ROOT_OSC_RC_48M_DIV2,
 		},
-		.flexio1_clk_root =
+		.flexio1_clk_root = /* 432 / 4 = 108Mhz */
 		{
 			.enable        = 1,
-			.div           = 2,
-			.mux           = FLEXIO1_CLK_ROOT_SYS_PLL3_DIV2,
+			.div           = 4,
+			.mux           = FLEXIO1_CLK_ROOT_SYS_PLL2_PFD3,
 		},
 		.flexio2_clk_root =
 		{
@@ -492,9 +492,9 @@ const struct clock_configuration_s g_initial_clkconfig = {
 		.mfd             = 268435455,
 		.ss_enable       = 0,
 		.pfd0            = 27, /* (528 * 18) / 27 = 352 MHz */
-		.pfd1            = 16, /* (528 * 16) / 16 = 594 MHz */
-		.pfd2            = 24, /* (528 * 24) / 27 = 396 MHz */
-		.pfd3            = 32, /* (528 * 32) / 27 = 297 MHz */
+		.pfd1            = 16, /* (528 * 18) / 16 = 594 MHz */
+		.pfd2            = 24, /* (528 * 18) / 24 = 396 MHz */
+		.pfd3            = 22, /* (528 * 18) / 22 = 216 MHz */
 	},
 	.sys_pll3 =
 	{

--- a/boards/px4/fmu-v6xrt/src/mtd.cpp
+++ b/boards/px4/fmu-v6xrt/src/mtd.cpp
@@ -53,18 +53,12 @@ static const px4_mft_device_t i2c6 = {             // 24LC64T on BASE  8K 32 X 2
 
 static const px4_mtd_entry_t fmum_fram = {
 	.device = &qspi_flash,
-	.npart = 2,
+	.npart = 1,
 	.partd = {
 		{
 			.type = MTD_PARAMETERS,
 			.path = "/fs/mtd_params",
-			.nblocks = 32
-		},
-		{
-			.type = MTD_WAYPOINTS,
-			.path = "/fs/mtd_waypoints",
-			.nblocks = 32
-
+			.nblocks = 256
 		}
 	},
 };

--- a/platforms/nuttx/src/px4/nxp/imxrt/dshot/dshot.c
+++ b/platforms/nuttx/src/px4/nxp/imxrt/dshot/dshot.c
@@ -81,24 +81,8 @@ static int flexio_irq_handler(int irq, void *context, void *arg)
 
 int up_dshot_init(uint32_t channel_mask, unsigned dshot_pwm_freq)
 {
-	uint32_t timer_compare;
+	uint32_t timer_compare = 0x2F00 | (((BOARD_FLEXIO_PREQ / (dshot_pwm_freq * 3) / 2) - 1) & 0xFF);
 
-	if (dshot_pwm_freq == 150000) {
-		timer_compare = 0x2F8A;
-
-	} else if (dshot_pwm_freq == 300000) {
-		timer_compare = 0x2F45;
-
-	} else if (dshot_pwm_freq == 600000) {
-		timer_compare = 0x2F22;
-
-	} else if (dshot_pwm_freq == 1200000) {
-		timer_compare = 0x2F11;
-
-	} else {
-		// Not supported Dshot frequency
-		return 0;
-	}
 
 	/* Init FlexIO peripheral */
 


### PR DESCRIPTION
- Increase core voltage for stability.
- DShot timing fix
- Increase mtd_param size

Also pulls in stm32h7x7xx and ethernet changes from NuttX.