### PR TITLE
ekf2: GNSS velocity control should own vertical velocity reset if height faiing

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -134,8 +134,10 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 					resetVerticalPositionTo(-(_baro_lpf.getState() - bias_est.getBias()), measurement_var);
 					bias_est.setBias(_state.pos(2) + _baro_lpf.getState());
 
-					// reset vertical velocity
-					resetVerticalVelocityToZero();
+					// reset vertical velocity if no valid sources available
+					if (!isVerticalVelocityAidingActive()) {
+						resetVerticalVelocityToZero();
+					}
 
 					aid_src.time_last_fuse = imu_sample.time_us;
 

--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
@@ -149,34 +149,6 @@ void Ekf::controlEvHeightFusion(const imuSample &imu_sample, const extVisionSamp
 				resetVerticalPositionTo(measurement - bias_est.getBias(), measurement_var);
 				bias_est.setBias(-_state.pos(2) + measurement);
 
-				// reset vertical velocity
-				if (ev_sample.vel.isAllFinite() && (_params.ev_ctrl & static_cast<int32_t>(EvCtrl::VEL))) {
-
-					// correct velocity for offset relative to IMU
-					const Vector3f angular_velocity = (imu_sample.delta_ang / imu_sample.delta_ang_dt) - _state.gyro_bias;
-					const Vector3f vel_offset_body = angular_velocity % pos_offset_body;
-					const Vector3f vel_offset_earth = _R_to_earth * vel_offset_body;
-
-					switch (ev_sample.vel_frame) {
-					case VelocityFrame::LOCAL_FRAME_NED:
-					case VelocityFrame::LOCAL_FRAME_FRD: {
-							const Vector3f reset_vel = ev_sample.vel - vel_offset_earth;
-							resetVerticalVelocityTo(reset_vel(2), math::max(ev_sample.velocity_var(2), sq(_params.ev_vel_noise)));
-						}
-						break;
-
-					case VelocityFrame::BODY_FRAME_FRD: {
-							const Vector3f reset_vel = _R_to_earth * (ev_sample.vel - vel_offset_body);
-							const Matrix3f reset_vel_cov = _R_to_earth * matrix::diag(ev_sample.velocity_var) * _R_to_earth.transpose();
-							resetVerticalVelocityTo(reset_vel(2), math::max(reset_vel_cov(2, 2), sq(_params.ev_vel_noise)));
-						}
-						break;
-					}
-
-				} else {
-					resetVerticalVelocityToZero();
-				}
-
 				aid_src.time_last_fuse = _time_delayed_us;
 
 			} else if (is_fusion_failing) {

--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_vel_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_vel_control.cpp
@@ -212,6 +212,17 @@ void Ekf::controlEvVelFusion(const imuSample &imu_sample, const extVisionSample 
 
 					stopEvVelFusion();
 				}
+
+			} else if (isHeightResetRequired()) {
+				// reset vertical velocity if height is failing
+				if (ev_sample.vel_frame == VelocityFrame::BODY_FRAME_FRD) {
+					const Vector3f measurement_ekf_frame = _R_to_earth * measurement;
+					const Vector3f measurement_var_ekf_frame = rotateVarianceToEkf(measurement_var);
+					resetVerticalVelocityTo(measurement_ekf_frame(2), measurement_var_ekf_frame(2));
+
+				} else {
+					resetVerticalVelocityTo(measurement(2), measurement_var(2));
+				}
 			}
 
 		} else {

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -108,15 +108,6 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 					resetVerticalPositionTo(-(measurement - bias_est.getBias()), measurement_var);
 					bias_est.setBias(_state.pos(2) + measurement);
 
-					// reset vertical velocity
-					if (PX4_ISFINITE(gps_sample.vel(2)) && (_params.gnss_ctrl & static_cast<int32_t>(GnssCtrl::VEL))) {
-						// use 1.5 as a typical ratio of vacc/hacc
-						resetVerticalVelocityTo(gps_sample.vel(2), sq(math::max(1.5f * gps_sample.sacc, _params.gps_vel_noise)));
-
-					} else {
-						resetVerticalVelocityToZero();
-					}
-
 					aid_src.time_last_fuse = _time_delayed_us;
 
 				} else if (is_fusion_failing) {

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -132,15 +132,21 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 				}
 
 				if (do_vel_pos_reset) {
-					ECL_WARN("GPS fusion timeout, resetting velocity / position");
+					ECL_WARN("GPS fusion timeout, resetting");
+				}
 
-					if (gnss_vel_enabled) {
+				if (gnss_vel_enabled) {
+					if (do_vel_pos_reset) {
 						resetVelocityToGnss(_aid_src_gnss_vel);
-					}
 
-					if (gnss_pos_enabled) {
-						resetHorizontalPositionToGnss(_aid_src_gnss_pos);
+					} else if (isHeightResetRequired()) {
+						// reset vertical velocity if height is failing
+						resetVerticalVelocityTo(_aid_src_gnss_vel.observation[2], _aid_src_gnss_vel.observation_variance[2]);
 					}
+				}
+
+				if (gnss_pos_enabled && do_vel_pos_reset) {
+					resetHorizontalPositionToGnss(_aid_src_gnss_pos);
 				}
 
 			} else {

--- a/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
@@ -180,8 +180,10 @@ void Ekf::controlRangeHaglFusion(const imuSample &imu_sample)
 					_information_events.flags.reset_hgt_to_rng = true;
 					resetVerticalPositionTo(-(aid_src.observation - _state.terrain));
 
-					// reset vertical velocity
-					resetVerticalVelocityToZero();
+					// reset vertical velocity if no valid sources available
+					if (!isVerticalVelocityAidingActive()) {
+						resetVerticalVelocityToZero();
+					}
 
 					aid_src.time_last_fuse = imu_sample.time_us;
 

--- a/src/modules/ekf2/test/test_EKF_terrain.cpp
+++ b/src/modules/ekf2/test/test_EKF_terrain.cpp
@@ -207,9 +207,9 @@ TEST_F(EkfTerrainTest, testHeightReset)
 	const float new_baro_height = _sensor_simulator._baro.getData() + 50.f;
 	_sensor_simulator._baro.setData(new_baro_height);
 	_sensor_simulator.stopGps(); // prevent from switching to GNSS height
-	_sensor_simulator.runSeconds(6);
+	_sensor_simulator.runSeconds(10);
 
-	// THEN: a height reset occured and the estimated distance to the ground remains constant
+	// THEN: a height reset occurred and the estimated distance to the ground remains constant
 	reset_logging_checker.capturePostResetState();
 	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(1));
 	EXPECT_NEAR(estimated_distance_to_ground, _ekf->getHagl(), 1e-3f);


### PR DESCRIPTION
 - GNSS height control using the velocity sample directly is ignoring potential position offsets