### PR TITLE
[1.15] Bugfix: Timestamp wrapping when initializing SubscriptionInterval less than the interval time after boot

### DIFF
--- a/platforms/common/uORB/SubscriptionInterval.hpp
+++ b/platforms/common/uORB/SubscriptionInterval.hpp
@@ -125,8 +125,16 @@ public:
 	{
 		if (_subscription.copy(dst)) {
 			const hrt_abstime now = hrt_absolute_time();
-			// shift last update time forward, but don't let it get further behind than the interval
-			_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+
+			// make sure we don't set a timestamp before the timer started counting (now - _interval_us would wrap because it's unsigned)
+			if (now > _interval_us) {
+				// shift last update time forward, but don't let it get further behind than the interval
+				_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+
+			} else {
+				_last_update = now;
+			}
+
 			return true;
 		}
 
@@ -160,7 +168,7 @@ public:
 protected:
 
 	Subscription	_subscription;
-	uint64_t	_last_update{0};	// last update in microseconds
+	uint64_t	_last_update{0};	// last subscription update in microseconds
 	uint32_t	_interval_us{0};	// maximum update interval in microseconds
 
 };


### PR DESCRIPTION
1:1 backport of https://github.com/PX4/PX4-Autopilot/pull/23384 after varifying the problem is present on the 1.15 release.
I also successfully checked the SITL test documented in https://github.com/PX4/PX4-Autopilot/issues/23378 and it works with the fix.