### PR TITLE
Implemented protection against flying into terrain during landing

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -92,42 +92,6 @@ Mission::on_activation()
 }
 
 bool
-Mission::isLanding()
-{
-	if (get_land_start_available()) {
-		static constexpr size_t max_num_next_items{1u};
-		int32_t next_mission_items_index[max_num_next_items];
-		size_t num_found_items;
-
-		getNextPositionItems(_mission.land_start_index + 1, next_mission_items_index, num_found_items, max_num_next_items);
-
-		// vehicle is currently landing if
-		//  mission valid, still flying, and in the landing portion of mission (past land start marker)
-		bool on_landing_stage = (num_found_items > 0U) &&  _mission.current_seq > next_mission_items_index[0U];
-
-		// special case: if the land start index is at a LOITER_TO_ALT WP, then we're in the landing sequence already when the
-		// distance to the WP is below the loiter radius + acceptance.
-		if ((num_found_items > 0U) && _mission.current_seq == next_mission_items_index[0U]
-		    && _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT) {
-			const float d_current = get_distance_to_next_waypoint(_mission_item.lat, _mission_item.lon,
-						_navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
-
-			// consider mission_item.loiter_radius invalid if NAN or 0, use default value in this case.
-			const float mission_item_loiter_radius_abs = (PX4_ISFINITE(_mission_item.loiter_radius)
-					&& fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
-					_navigator->get_loiter_radius();
-
-			on_landing_stage = d_current <= (_navigator->get_acceptance_radius() + mission_item_loiter_radius_abs);
-		}
-
-		return _navigator->get_mission_result()->valid && on_landing_stage;
-
-	} else {
-		return false;
-	}
-}
-
-bool
 Mission::set_current_mission_index(uint16_t index)
 {
 	if (index == _mission.current_seq) {

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -67,8 +67,6 @@ public:
 	uint16_t get_land_start_index() const { return _mission.land_start_index; }
 	bool get_land_start_available() const { return hasMissionLandStart(); }
 
-	bool isLanding();
-
 private:
 
 	bool setNextMissionItem() override;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -352,6 +352,8 @@ MissionBase::on_active()
 	} else if (_navigator->get_precland()->is_activated()) {
 		_navigator->get_precland()->on_inactivation();
 	}
+
+	updateMinAltDuringVtolLandingAndRepublishTriplet(_mission_item);
 }
 
 void MissionBase::update_mission()
@@ -1411,5 +1413,43 @@ void MissionBase::updateMissionAltAfterHomeChanged()
 
 		_navigator->set_position_setpoint_triplet_updated();
 		_home_update_counter = _navigator->get_home_position()->update_count;
+	}
+}
+
+bool
+MissionBase::isLanding()
+{
+	if (hasMissionLandStart()) {
+		static constexpr size_t max_num_next_items{1u};
+		int32_t next_mission_items_index[max_num_next_items];
+		size_t num_found_items;
+
+		getNextPositionItems(_mission.land_start_index + 1, next_mission_items_index, num_found_items, max_num_next_items);
+
+		// vehicle is currently landing if
+		//  mission valid, still flying, and in the landing portion of mission (past land start marker)
+		bool on_landing_stage = (num_found_items > 0U) &&  _mission.current_seq > next_mission_items_index[0U];
+
+		// special case: if the land start index is at a LOITER_TO_ALT WP, then we're in the landing sequence already when the
+		// distance to the WP is below the loiter radius + acceptance.
+		if ((num_found_items > 0U) && _mission.current_seq == next_mission_items_index[0U]
+		    && _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT) {
+			const float d_current = get_distance_to_next_waypoint(_mission_item.lat, _mission_item.lon,
+						_navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
+
+			// consider mission_item.loiter_radius invalid if NAN or 0, use default value in this case.
+			const float mission_item_loiter_radius_abs = (PX4_ISFINITE(_mission_item.loiter_radius)
+					&& fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
+					_navigator->get_loiter_radius();
+
+			on_landing_stage = d_current <= (_navigator->get_acceptance_radius() + mission_item_loiter_radius_abs);
+		}
+
+
+
+		return _navigator->get_mission_result()->valid && on_landing_stage;
+
+	} else {
+		return false;
 	}
 }

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -73,6 +73,8 @@ public:
 	virtual void on_activation() override;
 	virtual void on_active() override;
 
+	bool isLanding();
+
 protected:
 
 	/**
@@ -320,6 +322,7 @@ protected:
 	 * @param[in] index Index of the mission item
 	 */
 	void setMissionIndex(int32_t index);
+
 
 	bool _is_current_planned_mission_item_valid{false};	/**< Flag indicating if the currently loaded mission item is valid*/
 	bool _mission_has_been_activated{false};		/**< Flag indicating if the mission has been activated*/

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -248,4 +248,6 @@ protected:
 	bool _payload_deploy_ack_successful{false};	// Flag to keep track of whether we received an acknowledgement for a successful payload deployment
 	hrt_abstime _payload_deployed_time{0};		// Last payload deployment start time to handle timeouts
 	float _payload_deploy_timeout_s{0.0f};		// Timeout for payload deployment in Mission class, to prevent endless loop if successful deployment ack is never received
+
+	void updateMinAltDuringVtolLandingAndRepublishTriplet(mission_item_s mission_item);
 };

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -255,6 +255,11 @@ public:
 
 	bool get_mission_start_land_available() { return _mission.get_land_start_available(); }
 
+	bool isLanding()
+	{
+		return (_navigation_mode == &_rtl && _rtl.isLanding()) || (_navigation_mode == &_mission && _mission.isLanding());
+	}
+
 	// RTL
 	bool in_rtl_state() const { return _vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL; }
 
@@ -268,6 +273,7 @@ public:
 	float get_param_mis_takeoff_alt() const { return _param_mis_takeoff_alt.get(); }
 	float get_yaw_timeout() const { return _param_mis_yaw_tmt.get(); }
 	float get_yaw_threshold() const { return math::radians(_param_mis_yaw_err.get()); }
+	float get_fw_min_height() const { return _param_fw_min_height.get(); }
 
 	float get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss; }
 
@@ -408,6 +414,7 @@ private:
 		(ParamFloat<px4::params::MIS_YAW_TMT>)     _param_mis_yaw_tmt,
 		(ParamFloat<px4::params::MIS_YAW_ERR>)     _param_mis_yaw_err,
 		(ParamFloat<px4::params::MIS_PD_TO>)       _param_mis_payload_delivery_timeout,
-		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt
+		(ParamInt<px4::params::MIS_LND_ABRT_ALT>)  _param_mis_lnd_abrt_alt,
+		(ParamFloat<px4::params::NAV_VTL_MIN_HGT>)   _param_fw_min_height
 	)
 };

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -187,3 +187,20 @@ PARAM_DEFINE_INT32(NAV_FORCE_VT, 1);
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_MIN_LTR_ALT, -1.f);
+
+
+/**
+ * Minimum height above ground for vtol landings.
+ *
+ * Minimum height above ground in fixed wing mode during a vtol landing (mission landing or rtl with landing pattern).
+ * When the estimated distance to the ground is below this value, the system will
+ * increase the current altitude setpoint (by max 30m) to maintain this distance.
+ * Setting the value to 0 will disable the feature.
+ *
+ * @unit m
+ * @min 0
+ * @decimal 1
+ * @increment 1
+ * @group Mission
+ */
+PARAM_DEFINE_FLOAT(NAV_VTL_MIN_HGT, 0.0f);

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -712,3 +712,26 @@ land_approaches_s RTL::readVtolLandApproaches(PositionYawSetpoint rtl_position) 
 
 	return vtol_land_approaches;
 }
+
+bool RTL::isLanding()
+{
+	bool is_landing = false;
+
+	switch (_rtl_type) {
+	case RtlType::RTL_MISSION_FAST: // Fall through
+	case RtlType::RTL_MISSION_FAST_REVERSE: // Fall through
+	case RtlType::RTL_DIRECT_MISSION_LAND:
+		is_landing = _rtl_mission_type_handle && _rtl_mission_type_handle->isLanding();
+		break;
+
+	case RtlType::RTL_DIRECT:
+		is_landing = _rtl_direct.isLoiterindDownOrMovingToTransitionPoint();
+		break;
+
+	default:
+		break;
+
+	}
+
+	return is_landing;
+}

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -89,6 +89,8 @@ public:
 
 	void updateSafePoints(uint32_t new_safe_point_id) { _initiate_safe_points_updated = true; _safe_points_id = new_safe_point_id; }
 
+	bool isLanding();
+
 private:
 	enum class DestinationType {
 		DESTINATION_TYPE_HOME,

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -104,6 +104,8 @@ void RtlDirect::on_active()
 		set_rtl_item();
 	}
 
+	updateMinAltDuringVtolLandingAndRepublishTriplet(_mission_item);
+
 	if (_rtl_state == RTLState::LAND && _param_rtl_pld_md.get() > 0) {
 		// Need to update the position and type on the current setpoint triplet.
 		_navigator->get_precland()->on_active();

--- a/src/modules/navigator/rtl_direct.h
+++ b/src/modules/navigator/rtl_direct.h
@@ -102,6 +102,14 @@ public:
 
 	void setRtlPosition(PositionYawSetpoint position, loiter_point_s loiter_pos);
 
+	bool isLoiterindDownOrMovingToTransitionPoint() const
+	{
+		// during the following states the vehicle is loitering down to transition altitude or moving to the
+		// land waypoint at transition altitude
+		return _rtl_state == RTLState::LOITER_HOLD || _rtl_state == RTLState::MOVE_TO_LAND
+		       || _rtl_state == RTLState::TRANSITION_TO_MC;
+	}
+
 private:
 	/**
 	 * @brief Return to launch state machine.


### PR DESCRIPTION
### Solved Problem
There are several reasons why during a landing approach (landing with a pattern) a VTOL might fly into terrain.
The baro bias estimate could not be correct (especially when flying GPS denied) or the user might have not planned the mission correctly.

### Solution
Added parameter which user can set to define minimum distance from terrain during land pattern. 

### Changelog Entry
For release notes:
```
Feature: Add option to specify a minimum distance from terrain for VTOL Landings. This includes all landings that use a mission landing pattern.
New parameter: NAV_VTL_MIN_HGT
```

