### PR TITLE
Dont shut off throttle in fast descend while stil climbing

### DIFF
--- a/src/lib/tecs/TECS.cpp
+++ b/src/lib/tecs/TECS.cpp
@@ -524,8 +524,13 @@ void TECSControl::_calcThrottleControl(float dt, const SpecificEnergyRates &spec
 	float throttle_setpoint{param.throttle_min};
 
 	if (1.f - param.fast_descend < FLT_EPSILON) {
-		// During fast descend, we control airspeed over the pitch control loop and give minimal thrust.
-		throttle_setpoint = param.throttle_min;
+		// During fast descend, we control airspeed over the pitch control loop. Give minimal thrust as soon as we are descending
+		if (specific_energy_rates.spe_rate.estimate > 0) { // We have a positive altitude rate and are stil climbing
+			throttle_setpoint = param.throttle_trim; // Do not cut off throttle yet
+
+		} else {
+			throttle_setpoint = param.throttle_min;
+		}
 
 	} else {
 		_calcThrottleControlUpdate(dt, limit, ste_rate, param, flag);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When fast descend is enable and prior to the descend the vehicle is climbing the airspeed can drop and could potentially stall. The reason is that on fast decend the throttle is set to minimum, but if we are still climbing it takes some time until the vehicle pitches down. in this phase the airspeed can drop. The underspeed prevention should kick in eventually as this has higher priority than the fat descend.

![image (5)](https://github.com/user-attachments/assets/9b80a0cd-5fa6-42bd-80c1-23b7b0e076f2)


### Solution
- Make sure to give a trim throttle in fast descend, as long as the vehicle is still climbing

### Changelog Entry
For release notes:
```
Bugfix Still enable throttle at the beginning of the fast descend while still climbing
```

### Alternatives
**There could potentially be an issue with thermals, when it is not sinking although it has already pitched down. In this case it would also activate the motors instead of shutting them off. I don't think that is an issue though, happy for feedback.**

### Test coverage
- Simulation testing: tested on SITL with standard_vtol using a loiter. First loiter up, and while still not reached the loiter, set another loiter below.

### Context
Related links, screenshot before/after, video
