### PR TITLE
ekf2: optical flow adjust jacobian epsilon to avoid numerical issues

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
@@ -91,8 +91,9 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 		// calculate the optical flow observation variance
 		const float R_LOS = calcOptFlowMeasVar(flow_sample);
 
+		const float epsilon = 1e-3f;
 		Vector2f innov_var;
-		sym::ComputeFlowXyInnovVarAndHx(_state.vector(), P, R_LOS, FLT_EPSILON, &innov_var, &H);
+		sym::ComputeFlowXyInnovVarAndHx(_state.vector(), P, R_LOS, epsilon, &innov_var, &H);
 
 		// run the innovation consistency check and record result
 		updateAidSourceStatus(_aid_src_optical_flow,

--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_fusion.cpp
@@ -72,7 +72,8 @@ bool Ekf::fuseOptFlow(VectorState &H, const bool update_terrain)
 		} else if (index == 1) {
 			// recalculate innovation variance because state covariances have changed due to previous fusion (linearise using the same initial state for all axes)
 			const float R_LOS = _aid_src_optical_flow.observation_variance[1];
-			sym::ComputeFlowYInnovVarAndH(state_vector, P, R_LOS, FLT_EPSILON, &_aid_src_optical_flow.innovation_variance[1], &H);
+			const float epsilon = 1e-3f;
+			sym::ComputeFlowYInnovVarAndH(state_vector, P, R_LOS, epsilon, &_aid_src_optical_flow.innovation_variance[1], &H);
 
 			// recalculate the innovation using the updated state
 			const Vector3f flow_gyro_corrected = _flow_sample_delayed.gyro_rate - _flow_gyro_bias;

--- a/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/sideslip/sideslip_fusion.cpp
@@ -82,10 +82,10 @@ void Ekf::updateSideslip(estimator_aid_source1d_s &aid_src) const
 {
 	float observation = 0.f;
 	const float R = math::max(sq(_params.beta_noise), sq(0.01f)); // observation noise variance
-
+	const float epsilon = 1e-3f;
 	float innov;
 	float innov_var;
-	sym::ComputeSideslipInnovAndInnovVar(_state.vector(), P, R, FLT_EPSILON, &innov, &innov_var);
+	sym::ComputeSideslipInnovAndInnovVar(_state.vector(), P, R, epsilon, &innov, &innov_var);
 
 	updateAidSourceStatus(aid_src,
 			      _time_delayed_us,                         // sample timestamp
@@ -130,10 +130,11 @@ void Ekf::fuseSideslip(estimator_aid_source1d_s &sideslip)
 
 	_fault_status.flags.bad_sideslip = false;
 
+	const float epsilon = 1e-3f;
 	VectorState H; // Observation jacobian
 	VectorState K; // Kalman gain vector
 
-	sym::ComputeSideslipHAndK(_state.vector(), P, sideslip.innovation_variance, FLT_EPSILON, &H, &K);
+	sym::ComputeSideslipHAndK(_state.vector(), P, sideslip.innovation_variance, epsilon, &H, &K);
 
 	if (update_wind_only) {
 		const Vector2f K_wind = K.slice<State::wind_vel.dof, 1>(State::wind_vel.idx, 0);


### PR DESCRIPTION
 - in the symforce generated code there's a 1 / eps^2 term if the height and terrain estimates are the same
