### PR TITLE
mc_wind_estimator_tuning: Changed Quaternion package installed 

### DIFF
--- a/src/modules/ekf2/EKF/python/tuning_tools/mc_wind_estimator/requirements.txt
+++ b/src/modules/ekf2/EKF/python/tuning_tools/mc_wind_estimator/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==3.5.1
 numpy==1.22.2
 pyulog==0.9.0
-quaternion==3.5.2.post4
+numpy-quaternion==2023.0.4
 scipy==1.8.0
 sympy==1.10.1


### PR DESCRIPTION

<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When installing the required packages through `requirements.txt` and running the script, an error message appears which states that the required "quaternion" package cannot be found, even though `quaternion==3.5.2.post4` is specified in `requirements.txt`

Fixes #{Github issue ID}

### Solution
- Specify for the `numpy-quaternion 2023.0.4` package to be installed instead of the `Quaternion 3.5.2.post4 ` package.
### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Alternatives
We could also ...

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/

### Context
Related links, screenshot before/after, video
