### PR TITLE
[1.15] Fix: Save flash by not inlining SubscriptionInterval::copy()

### DIFF
--- a/platforms/common/uORB/CMakeLists.txt
+++ b/platforms/common/uORB/CMakeLists.txt
@@ -47,6 +47,7 @@ set(SRCS_COMMON
 	Subscription.cpp
 	Subscription.hpp
 	SubscriptionCallback.hpp
+	SubscriptionInterval.cpp
 	SubscriptionInterval.hpp
 	SubscriptionMultiArray.hpp
 	uORB.cpp

--- a/platforms/common/uORB/SubscriptionInterval.cpp
+++ b/platforms/common/uORB/SubscriptionInterval.cpp
@@ -1,0 +1,77 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2024 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "SubscriptionInterval.hpp"
+
+namespace uORB
+{
+
+bool SubscriptionInterval::updated()
+{
+	if (advertised() && (hrt_elapsed_time(&_last_update) >= _interval_us)) {
+		return _subscription.updated();
+	}
+
+	return false;
+}
+
+bool SubscriptionInterval::update(void *dst)
+{
+	if (updated()) {
+		return copy(dst);
+	}
+
+	return false;
+}
+
+bool SubscriptionInterval::copy(void *dst)
+{
+	if (_subscription.copy(dst)) {
+		const hrt_abstime now = hrt_absolute_time();
+
+		// make sure we don't set a timestamp before the timer started counting (now - _interval_us would wrap because it's unsigned)
+		if (now > _interval_us) {
+			// shift last update time forward, but don't let it get further behind than the interval
+			_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
+
+		} else {
+			_last_update = now;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+} // namespace uORB

--- a/platforms/common/uORB/SubscriptionInterval.hpp
+++ b/platforms/common/uORB/SubscriptionInterval.hpp
@@ -93,53 +93,21 @@ public:
 	/**
 	 * Check if there is a new update.
 	 * */
-	bool updated()
-	{
-		if (advertised() && (hrt_elapsed_time(&_last_update) >= _interval_us)) {
-			return _subscription.updated();
-		}
-
-		return false;
-	}
+	bool updated();
 
 	/**
 	 * Copy the struct if updated.
 	 * @param dst The destination pointer where the struct will be copied.
 	 * @return true only if topic was updated and copied successfully.
 	 */
-	bool update(void *dst)
-	{
-		if (updated()) {
-			return copy(dst);
-		}
-
-		return false;
-	}
+	bool update(void *dst);
 
 	/**
 	 * Copy the struct
 	 * @param dst The destination pointer where the struct will be copied.
 	 * @return true only if topic was copied successfully.
 	 */
-	bool copy(void *dst)
-	{
-		if (_subscription.copy(dst)) {
-			const hrt_abstime now = hrt_absolute_time();
-
-			// make sure we don't set a timestamp before the timer started counting (now - _interval_us would wrap because it's unsigned)
-			if (now > _interval_us) {
-				// shift last update time forward, but don't let it get further behind than the interval
-				_last_update = math::constrain(_last_update + _interval_us, now - _interval_us, now);
-
-			} else {
-				_last_update = now;
-			}
-
-			return true;
-		}
-
-		return false;
-	}
+	bool copy(void *dst);
 
 	bool		valid() const { return _subscription.valid(); }
 


### PR DESCRIPTION
### Solved Problem
Flash problems after https://github.com/PX4/PX4-Autopilot/pull/23392

### Solution
1:1 port of https://github.com/PX4/PX4-Autopilot/pull/23395

### Changelog Entry
For release notes:
```
Fix: Save flash memory by not inlining SubscriptionInterval::copy()
```

### Test coverage
Tested on main, see https://github.com/PX4/PX4-Autopilot/pull/23395#issuecomment-2225884685