### PR TITLE
Fix CI errors on 1.15 release branch

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -47,7 +47,7 @@ pipeline {
                      "ark_fmu-v6x_bootloader",
                      "ark_fmu-v6x_default",
                      "ark_pi6x_bootloader",
-                     "ark_pi6x_default"
+                     "ark_pi6x_default",
                      "atl_mantis-edu_default",
                      "av_x-v1_default",
                      "bitcraze_crazyflie21_default",

--- a/boards/spracing/h7extreme/src/rcc.c
+++ b/boards/spracing/h7extreme/src/rcc.c
@@ -364,7 +364,7 @@ __ramfunc__ void stm32_board_clockconfig(void)
 		 */
 
 		regval = getreg32(STM32_PWR_CR3);
-		regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_LDOESCUEN;
+		regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_SCUEN;
 		putreg32(regval, STM32_PWR_CR3);
 
 		/* Set the voltage output scale */


### PR DESCRIPTION
### Solved Problem
When checking CI of the `release/1.15` branch I found that some backports are certainly missing:

![image](https://github.com/user-attachments/assets/74213106-dee7-433b-8075-fd7b79c5edd7)
https://github.com/PX4/PX4-Autopilot/pull/23198

![image](https://github.com/user-attachments/assets/64de1828-7c6a-4d08-88d4-c273ef8379f1)
https://github.com/PX4/PX4-Autopilot/pull/23265/commits/7a65a8f73cea666449ff74db35e19b058c524b43

### Changelog Entry
For release notes:
```
Fix CI errors on 1.15 release branch
```

### Test coverage
Let's see if that's everything for now.