### PR TITLE
ekf2-flow: only allow flow when in range

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/optical_flow/optical_flow_control.cpp
@@ -118,16 +118,17 @@ void Ekf::controlOpticalFlowFusion(const imuSample &imu_delayed)
 					&& (_control_status.flags.inertial_dead_reckoning // is doing inertial dead-reckoning so must constrain drift urgently
 					    || isOnlyActiveSourceOfHorizontalAiding(_control_status.flags.opt_flow));
 
-		const bool is_within_max_sensor_dist = getHagl() <= _flow_max_distance;
+		const bool is_within_sensor_dist = (getHagl() >= _flow_min_distance) && (getHagl() <= _flow_max_distance);
 
 		const bool continuing_conditions_passing = (_params.flow_ctrl == 1)
 				&& _control_status.flags.tilt_align
-				&& is_within_max_sensor_dist;
+				&& is_within_sensor_dist;
 
 		const bool starting_conditions_passing = continuing_conditions_passing
 				&& is_quality_good
 				&& is_magnitude_good
 				&& is_tilt_good
+				&& (isTerrainEstimateValid() || isHorizontalAidingActive())
 				&& isTimedOut(_aid_src_optical_flow.time_last_fuse, (uint64_t)2e6); // Prevent rapid switching
 
 		// If the height is relative to the ground, terrain height cannot be observed.


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
1. When the height above ground (hagl) is not directly observed and that the vehicle is close to the ground (e.g.: during touchdown), the height estimate can go below the terrain estimate. Fusing optical flow with a negative distance isn't safe and should be avoided.
2. When neither the hagl nor the horizontal velocity is currently estimated, starting the optical flow can be hazardous as the filter might struggle to make both values converge at the same time.

### Solution
1. Allow flow fusion when hagl is between min and max flow distance
3. As the flow makes the link between range and horizontal velocity, only allow it to start if at least one of the two is known

### Changelog Entry
For release notes:
```
Feature/Bugfix XYZ
New parameter: XYZ_Z
Documentation: Need to clarify page ... / done, read docs.px4.io/...
```

### Test coverage
SITL

