### PR TITLE
ekf2: enable all GNSS checks by default

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
@@ -189,15 +189,15 @@ bool Ekf::runGnssChecks(const gnssSample &gps)
 		// Apply a low pass filter
 		_gps_pos_deriv_filt = pos_derived * filter_coef + _gps_pos_deriv_filt * (1.0f - filter_coef);
 
-		// Calculate the horizontal drift speed and fail if too high
+		// hdrift: calculate the horizontal drift speed and fail if too high
 		_gps_horizontal_position_drift_rate_m_s = Vector2f(_gps_pos_deriv_filt.xy()).norm();
 		_gps_check_fail_status.flags.hdrift = (_gps_horizontal_position_drift_rate_m_s > _params.req_hdrift);
 
-		// Fail if the vertical drift speed is too high
+		// vdrift: fail if the vertical drift speed is too high
 		_gps_vertical_position_drift_rate_m_s = fabsf(_gps_pos_deriv_filt(2));
 		_gps_check_fail_status.flags.vdrift = (_gps_vertical_position_drift_rate_m_s > _params.req_vdrift);
 
-		// Check the magnitude of the filtered horizontal GPS velocity
+		// hspeed: check the magnitude of the filtered horizontal GNSS velocity
 		const Vector2f gps_velNE = matrix::constrain(Vector2f(gps.vel.xy()),
 					   -10.0f * _params.req_hdrift,
 					   10.0f * _params.req_hdrift);
@@ -205,12 +205,20 @@ bool Ekf::runGnssChecks(const gnssSample &gps)
 		_gps_filtered_horizontal_velocity_m_s = _gps_velNE_filt.norm();
 		_gps_check_fail_status.flags.hspeed = (_gps_filtered_horizontal_velocity_m_s > _params.req_hdrift);
 
+		// vspeed: check the magnitude of the filtered vertical GNSS velocity
+		const float gnss_vz_limit = 10.f * _params.req_vdrift;
+		const float gnss_vz = math::constrain(gps.vel(2), -gnss_vz_limit, gnss_vz_limit);
+		_gps_vel_d_filt = gnss_vz * filter_coef + _gps_vel_d_filt * (1.f - filter_coef);
+
+		_gps_check_fail_status.flags.vspeed = (fabsf(_gps_vel_d_filt) > _params.req_vdrift);
+
 	} else if (_control_status.flags.in_air) {
 		// These checks are always declared as passed when flying
 		// If on ground and moving, the last result before movement commenced is kept
 		_gps_check_fail_status.flags.hdrift = false;
 		_gps_check_fail_status.flags.vdrift = false;
 		_gps_check_fail_status.flags.hspeed = false;
+		_gps_check_fail_status.flags.vspeed = false;
 
 		resetGpsDriftCheckFilters();
 
@@ -222,12 +230,6 @@ bool Ekf::runGnssChecks(const gnssSample &gps)
 	// save GPS fix for next time
 	_gps_pos_prev.initReference(lat, lon, gps.time_us);
 	_gps_alt_prev = gps.alt;
-
-	// Check  the filtered difference between GPS and EKF vertical velocity
-	const float vz_diff_limit = 10.0f * _params.req_vdrift;
-	const float vertVel = math::constrain(gps.vel(2) - _state.vel(2), -vz_diff_limit, vz_diff_limit);
-	_gps_velD_diff_filt = vertVel * filter_coef + _gps_velD_diff_filt * (1.0f - filter_coef);
-	_gps_check_fail_status.flags.vspeed = (fabsf(_gps_velD_diff_filt) > _params.req_vdrift);
 
 	// assume failed first time through
 	if (_last_gps_fail_us == 0) {
@@ -260,6 +262,8 @@ bool Ekf::runGnssChecks(const gnssSample &gps)
 void Ekf::resetGpsDriftCheckFilters()
 {
 	_gps_velNE_filt.setZero();
+	_gps_vel_d_filt = 0.f;
+
 	_gps_pos_deriv_filt.setZero();
 
 	_gps_horizontal_position_drift_rate_m_s = NAN;

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -652,7 +652,7 @@ private:
 	Vector3f _gps_pos_deriv_filt{};	///< GPS NED position derivative (m/sec)
 	Vector2f _gps_velNE_filt{};	///< filtered GPS North and East velocity (m/sec)
 
-	float _gps_velD_diff_filt{0.0f};	///< GPS filtered Down velocity (m/sec)
+	float _gps_vel_d_filt{0.0f};		///< GNSS filtered Down velocity (m/sec)
 	uint64_t _last_gps_fail_us{0};		///< last system time in usec that the GPS failed it's checks
 	uint64_t _last_gps_pass_us{0};		///< last system time in usec that the GPS passed it's checks
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time

--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -149,7 +149,7 @@ parameters:
         7: Max horizontal speed (EKF2_REQ_HDRIFT)
         8: Max vertical velocity discrepancy (EKF2_REQ_VDRIFT)
         9: Spoofing check
-      default: 245
+      default: 1023
       min: 0
       max: 1023
     EKF2_REQ_EPH:

--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -125,30 +125,20 @@ parameters:
     EKF2_GPS_CHECK:
       description:
         short: Integer bitmask controlling GPS checks
-        long: 'Set bits to 1 to enable checks. Checks enabled by the following bit
-          positions 0 : Minimum required sat count set by EKF2_REQ_NSATS 1 : Maximum
-          allowed PDOP set by EKF2_REQ_PDOP 2 : Maximum allowed horizontal position
-          error set by EKF2_REQ_EPH 3 : Maximum allowed vertical position error set
-          by EKF2_REQ_EPV 4 : Maximum allowed speed error set by EKF2_REQ_SACC 5 :
-          Maximum allowed horizontal position rate set by EKF2_REQ_HDRIFT. This check
-          will only run when the vehicle is on ground and stationary. 6 : Maximum
-          allowed vertical position rate set by EKF2_REQ_VDRIFT. This check will only
-          run when the vehicle is on ground and stationary. 7 : Maximum allowed horizontal
-          speed set by EKF2_REQ_HDRIFT. This check will only run when the vehicle
-          is on ground and stationary. 8 : Maximum allowed vertical velocity discrepancy
-          set by EKF2_REQ_VDRIFT. 9: Fails if GPS driver detects consistent spoofing'
+        long: 'Each threshold value is defined by the parameter indicated next to the check.
+          Drift and offset checks only run when the vehicle is on ground and stationary.'
       type: bitmask
       bit:
-        0: Min sat count (EKF2_REQ_NSATS)
-        1: Max PDOP (EKF2_REQ_PDOP)
-        2: Max horizontal position error (EKF2_REQ_EPH)
-        3: Max vertical position error (EKF2_REQ_EPV)
-        4: Max speed error (EKF2_REQ_SACC)
-        5: Max horizontal position rate (EKF2_REQ_HDRIFT)
-        6: Max vertical position rate (EKF2_REQ_VDRIFT)
-        7: Max horizontal speed (EKF2_REQ_HDRIFT)
-        8: Max vertical velocity discrepancy (EKF2_REQ_VDRIFT)
-        9: Spoofing check
+        0: Sat count (EKF2_REQ_NSATS)
+        1: PDOP (EKF2_REQ_PDOP)
+        2: EPH (EKF2_REQ_EPH)
+        3: EPV (EKF2_REQ_EPV)
+        4: Speed accuracy (EKF2_REQ_SACC)
+        5: Horizontal position drift (EKF2_REQ_HDRIFT)
+        6: Vertical position drift (EKF2_REQ_VDRIFT)
+        7: Horizontal speed offset (EKF2_REQ_HDRIFT)
+        8: Vertical speed offset (EKF2_REQ_VDRIFT)
+        9: Spoofing
       default: 1023
       min: 0
       max: 1023


### PR DESCRIPTION

### Solved Problem
Various GNSS checks are implemented to avoid using incorrect data but a couple of them are disabled by default for some unknown reason.

### Solution
Enable all GNSS checks by default. The thresholds are wide enough to no cause unnecessary pain to the user but adds a layer of protection against really bad data.

### Changelog Entry
For release notes:
```
-
New parameter: -
Documentation: -
```
