### PR TITLE
ekf2: cleanup legacy EKF solution_status_flags

### DIFF
--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -613,28 +613,6 @@ uint64_t mag_heading_consistent  :
 	uint64_t value;
 };
 
-// Mavlink bitmask containing state of estimator solution
-union ekf_solution_status_u {
-	struct {
-		uint16_t attitude           : 1; ///< 0 - True if the attitude estimate is good
-		uint16_t velocity_horiz     : 1; ///< 1 - True if the horizontal velocity estimate is good
-		uint16_t velocity_vert      : 1; ///< 2 - True if the vertical velocity estimate is good
-		uint16_t pos_horiz_rel      : 1; ///< 3 - True if the horizontal position (relative) estimate is good
-		uint16_t pos_horiz_abs      : 1; ///< 4 - True if the horizontal position (absolute) estimate is good
-		uint16_t pos_vert_abs       : 1; ///< 5 - True if the vertical position (absolute) estimate is good
-		uint16_t pos_vert_agl       : 1; ///< 6 - True if the vertical position (above ground) estimate is good
-uint16_t const_pos_mode     :
-		1; ///< 7 - True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)
-uint16_t pred_pos_horiz_rel :
-		1; ///< 8 - True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate
-uint16_t pred_pos_horiz_abs :
-		1; ///< 9 - True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate
-		uint16_t gps_glitch         : 1; ///< 10 - True if the EKF has detected a GPS glitch
-		uint16_t accel_error        : 1; ///< 11 - True if the EKF has detected bad accelerometer data
-	} flags;
-	uint16_t value;
-};
-
 // define structure used to communicate information events
 union information_event_status_u {
 	struct {

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -407,7 +407,7 @@ public:
 	float getHeightAboveGroundInnovationTestRatio() const;
 
 	// return a bitmask integer that describes which state estimates are valid
-	void get_ekf_soln_status(uint16_t *status) const;
+	uint16_t get_ekf_soln_status() const;
 
 	HeightSensor getHeightSensorRef() const { return _height_sensor_ref; }
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1825,7 +1825,7 @@ void EKF2::PublishStatus(const hrt_abstime &timestamp)
 	status.beta_test_ratio = _ekf.getSyntheticSideslipInnovationTestRatio();
 
 	_ekf.get_ekf_lpos_accuracy(&status.pos_horiz_accuracy, &status.pos_vert_accuracy);
-	_ekf.get_ekf_soln_status(&status.solution_status_flags);
+	status.solution_status_flags = _ekf.get_ekf_soln_status();
 
 	// reset counters
 	status.reset_count_vel_ne = _ekf.state_reset_status().reset_count.velNE;


### PR DESCRIPTION
The EKF estimator_status.solution_status_flags is a legacy set of bits we carry from mavlink that hardly matters anymore, but as long as we carry it we should try to keep it consistent with the rest of our usage.

https://mavlink.io/en/messages/common.html#ESTIMATOR_STATUS_FLAGS