### PR TITLE
gnss: update supported baud rates

### DIFF
--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -97,7 +97,15 @@ bool SerialImpl::configure()
 
 	case 460800: speed = B460800; break;
 
+#ifndef B500000
+#define B500000 500000
+#endif
+
 	case 500000: speed = B500000; break;
+
+#ifndef B576000
+#define B576000 576000
+#endif
 
 	case 576000: speed = B576000; break;
 
@@ -107,7 +115,15 @@ bool SerialImpl::configure()
 
 	case 921600: speed = B921600; break;
 
+#ifndef B1000000
+#define B1000000 1000000
+#endif
+
 	case 1000000: speed = B1000000; break;
+
+#ifndef B1500000
+#define B1500000 1500000
+#endif
 
 	case 1500000: speed = B1500000; break;
 

--- a/platforms/nuttx/src/px4/common/SerialImpl.cpp
+++ b/platforms/nuttx/src/px4/common/SerialImpl.cpp
@@ -97,11 +97,19 @@ bool SerialImpl::configure()
 
 	case 460800: speed = B460800; break;
 
+	case 500000: speed = B500000; break;
+
+	case 576000: speed = B576000; break;
+
 #ifndef B921600
 #define B921600 921600
 #endif
 
 	case 921600: speed = B921600; break;
+
+	case 1000000: speed = B1000000; break;
+
+	case 1500000: speed = B1500000; break;
 
 	default:
 		speed = _baudrate;

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -90,7 +90,15 @@ bool SerialImpl::configure()
 
 	case 460800: speed = B460800; break;
 
+#ifndef B500000
+#define B500000 500000
+#endif
+
 	case 500000: speed = B500000; break;
+
+#ifndef B576000
+#define B576000 576000
+#endif
 
 	case 576000: speed = B576000; break;
 
@@ -100,7 +108,15 @@ bool SerialImpl::configure()
 
 	case 921600: speed = B921600; break;
 
+#ifndef B1000000
+#define B1000000 1000000
+#endif
+
 	case 1000000: speed = B1000000; break;
+
+#ifndef B1500000
+#define B1500000 1500000
+#endif
 
 	case 1500000: speed = B1500000; break;
 

--- a/platforms/posix/src/px4/common/SerialImpl.cpp
+++ b/platforms/posix/src/px4/common/SerialImpl.cpp
@@ -90,11 +90,19 @@ bool SerialImpl::configure()
 
 	case 460800: speed = B460800; break;
 
+	case 500000: speed = B500000; break;
+
+	case 576000: speed = B576000; break;
+
 #ifndef B921600
 #define B921600 921600
 #endif
 
 	case 921600: speed = B921600; break;
+
+	case 1000000: speed = B1000000; break;
+
+	case 1500000: speed = B1500000; break;
 
 	default:
 		speed = _baudrate;


### PR DESCRIPTION
The Septentrio GNSS driver requires certain baud rates to test all the supported baud rates of the receiver. Without these changes, certain "non-standard" ones would print an error to the MAVLink console when the driver was started through the console.

### Solved Problem

This is an alternative to #23374 with the change suggested by @julianoes.

Fixes #23374

### Solution

- Add the required baud rates to `SerialImpl.cpp`
- Test on a Holybro Pixhawk 6C mini to make sure all of them work

### Changelog Entry

For release notes:
```
Bugfix Add new baud rates required by Septentrio driver
```

### Alternatives

See #23374 for alternatives.

### Test coverage

- Manual testing of all the newly added baud rates with the Septentrio driver, making sure no more warnings are printed and the driver successfully discovers the receiver.

### Context

\/