### PR TITLE
battery: simplify battery scale calculation

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -339,17 +339,12 @@ uint16_t Battery::determineFaults()
 
 void Battery::computeScale()
 {
-	const float voltage_range = (_params.v_charged - _params.v_empty);
+	_scale = _params.v_charged / _cell_voltage_filter_v.getState();
 
-	// reusing capacity calculation to get single cell voltage before drop
-	const float bat_v = _params.v_empty + (voltage_range * _state_of_charge_volt_based);
+	if (PX4_ISFINITE(_scale)) {
+		_scale = math::constrain(_scale, 1.f, 1.3f); // Allow at most 30% compensation
 
-	_scale = _params.v_charged / bat_v;
-
-	if (_scale > 1.3f) { // Allow at most 30% compensation
-		_scale = 1.3f;
-
-	} else if (!PX4_ISFINITE(_scale) || _scale < 1.f) { // Shouldn't ever be more than the power at full battery
+	} else {
 		_scale = 1.f;
 	}
 }


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
Due to the internal resistance estimator (https://github.com/PX4/PX4-Autopilot/pull/23205) there is now a variable with the load compensated voltage that can be used to simplify the battery scale calculation. This does not change any functionality.