### PR TITLE
Adapt for FMU with only FRAM and EEPROM

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -30,7 +30,7 @@ set LOGGER_BUF 8
 set PARAM_FILE ""
 set PARAM_BACKUP_FILE ""
 set RC_INPUT_ARGS ""
-set SDCARD_AVAILABLE no
+set STORAGE_AVAILABLE no
 set SDCARD_EXT_PATH /fs/microsd/ext_autostart
 set SDCARD_FORMAT no
 set STARTUP_TUNE 1
@@ -62,11 +62,11 @@ then
 			umount /fs/microsd
 
 		else
-			set SDCARD_AVAILABLE yes
+			set STORAGE_AVAILABLE yes
 		fi
 	fi
 
-	if [ $SDCARD_AVAILABLE = no -o $SDCARD_FORMAT = yes ]
+	if [ $STORAGE_AVAILABLE = no -o $SDCARD_FORMAT = yes ]
 	then
 		echo "INFO [init] formatting /dev/mmcsd0"
 		set STARTUP_TUNE 15 # tune 15 = SD_ERROR (overridden to SD_INIT if format + mount succeeds)
@@ -77,7 +77,7 @@ then
 
 			if mount -t vfat /dev/mmcsd0 /fs/microsd
 			then
-				set SDCARD_AVAILABLE yes
+				set STORAGE_AVAILABLE yes
 				set STARTUP_TUNE 14 # tune 14 = SD_INIT
 			else
 				echo "ERROR [init] card mount failed"
@@ -86,16 +86,22 @@ then
 			echo "ERROR [init] format failed"
 		fi
 	fi
-
-	if [ $SDCARD_AVAILABLE = yes ]
+else
+	# Is there a device mounted for storage
+	if mft query -q -k MTD -s MTD_PARAMETERS -v /mnt/microsd
 	then
-		if hardfault_log check
+		set STORAGE_AVAILABLE yes
+	fi
+fi
+
+if [ $STORAGE_AVAILABLE = yes ]
+then
+	if hardfault_log check
+	then
+		set STARTUP_TUNE 2 # tune 2 = ERROR_TUNE
+		if hardfault_log commit
 		then
-			set STARTUP_TUNE 2 # tune 2 = ERROR_TUNE
-			if hardfault_log commit
-			then
-				hardfault_log reset
-			fi
+			hardfault_log reset
 		fi
 	fi
 
@@ -172,7 +178,7 @@ else
 		fi
 	fi
 
-	if [ $SDCARD_AVAILABLE = yes ]
+	if [ $STORAGE_AVAILABLE = yes ]
 	then
 		param select-backup $PARAM_BACKUP_FILE
 	fi
@@ -220,8 +226,8 @@ else
 
 		if [ ${VEHICLE_TYPE} == none ]
 		then
-			# Look for airframe on SD card
-			if [ $SDCARD_AVAILABLE = yes ]
+			# Use external startup file
+			if [ $STORAGE_AVAILABLE = yes ]
 			then
 				. ${R}etc/init.d/rc.autostart_ext
 			else
@@ -615,7 +621,7 @@ unset PARAM_FILE
 unset PARAM_BACKUP_FILE
 unset PARAM_DEFAULTS_VER
 unset RC_INPUT_ARGS
-unset SDCARD_AVAILABLE
+unset STORAGE_AVAILABLE
 unset SDCARD_EXT_PATH
 unset SDCARD_FORMAT
 unset STARTUP_TUNE

--- a/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
+++ b/platforms/common/include/px4_platform_common/px4_work_queue/WorkQueueManager.hpp
@@ -89,7 +89,7 @@ static constexpr wq_config_t ttyS9{"wq:ttyS9", 1728, -30};
 static constexpr wq_config_t ttyACM0{"wq:ttyACM0", 1728, -31};
 static constexpr wq_config_t ttyUnknown{"wq:ttyUnknown", 1728, -32};
 
-static constexpr wq_config_t lp_default{"wq:lp_default", 2000, -50};
+static constexpr wq_config_t lp_default{"wq:lp_default", 2350, -50};
 
 static constexpr wq_config_t test1{"wq:test1", 2000, 0};
 static constexpr wq_config_t test2{"wq:test2", 2000, 0};

--- a/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/board_hw_rev_ver.c
+++ b/platforms/nuttx/src/px4/stm/stm32_common/board_hw_info/board_hw_rev_ver.c
@@ -73,7 +73,7 @@ static char hw_base_info[HW_INFO_SIZE] = {0};
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
-
+#if !defined(BOARD_HAS_ONLY_EEPROM_VERSIONING)
 static int dn_to_ordinal(uint16_t dn)
 {
 	/* Table is scaled for 12, so if ADC is in 16 bit mode
@@ -111,6 +111,7 @@ static int dn_to_ordinal(uint16_t dn)
 
 	return -1;
 }
+#endif /* BOARD_HAS_ONLY_EEPROM_VERSIONING */
 
 /************************************************************************************
  * Name: read_id_dn
@@ -143,7 +144,7 @@ static int dn_to_ordinal(uint16_t dn)
  *   -EIO  - FAiled to init or read the ADC
  *
  ************************************************************************************/
-
+#if !defined(BOARD_HAS_ONLY_EEPROM_VERSIONING)
 static int read_id_dn(int *id, uint32_t gpio_drive, uint32_t gpio_sense, int adc_channel)
 {
 	int rv = -EIO;
@@ -328,9 +329,15 @@ static int read_id_dn(int *id, uint32_t gpio_drive, uint32_t gpio_sense, int adc
 	stm32_configgpio(gpio_drive);
 	return rv;
 }
+#endif /* BOARD_HAS_ONLY_EEPROM_VERSIONING */
 
 static int determine_hw_info(int *revision, int *version)
 {
+#if defined(BOARD_HAS_ONLY_EEPROM_VERSIONING)
+	*revision = HW_ID_EEPROM;
+	*version  = HW_ID_EEPROM;
+	return OK;
+#else
 	int dn;
 	int rv = read_id_dn(&dn, GPIO_HW_REV_DRIVE, GPIO_HW_REV_SENSE, ADC_HW_REV_SENSE_CHANNEL);
 
@@ -344,6 +351,7 @@ static int determine_hw_info(int *revision, int *version)
 	}
 
 	return rv;
+#endif
 }
 
 /****************************************************************************

--- a/src/modules/logger/Kconfig
+++ b/src/modules/logger/Kconfig
@@ -10,3 +10,11 @@ menuconfig USER_LOGGER
 	depends on BOARD_PROTECTED && MODULES_LOGGER
 	---help---
 		Put logger in userspace memory
+
+menuconfig LOGGER_STACK_SIZE
+	int "stack size of logger task"
+	default 3700
+	depends on MODULES_LOGGER
+	---help---
+		Stack size of the logger task. Some configurations require more stack
+		than the default.

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -176,7 +176,7 @@ int Logger::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("logger",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_LOG_CAPTURE,
-				      PX4_STACK_ADJUSTED(3700),
+				      PX4_STACK_ADJUSTED(CONFIG_LOGGER_STACK_SIZE),
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 

--- a/src/systemcmds/hardfault_log/CMakeLists.txt
+++ b/src/systemcmds/hardfault_log/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MAIN hardfault_log
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
+	STACK_MAIN 4096
 	SRCS
 		hardfault_log.c
 	DEPENDS

--- a/src/systemcmds/param/CMakeLists.txt
+++ b/src/systemcmds/param/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MAIN param
 	COMPILE_FLAGS
 		-Wno-array-bounds
+	STACK_MAIN 4096
 	SRCS
 		param.cpp
 	DEPENDS


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

We built a smol FMU without SD card only with FRAM as minimal file system. Also doesn't have the revision resistors only EEPROM.

### Solution

1. LittleFS manages the FRAM as `/mnt/microsd` and mounts it as `/fs/microsd`. We chose to keep the paths the same for compatibility. The `rcS` needs minor updates to allow the hardfault handler to still work.
2. The FRAM can do 30MHz writes, but the RamTron only does 10MHz by default. Adding a new `BOARD_SPI_RAMTRON_SPEED_MHZ` define to make that configurable.
3. LittleFS requires more stack in a couple of tasks (this is probably not the best solution).
4. Our board does not have a resistor for revisions, it only stores it in the EEPROM. Adding a new `BOARD_HAS_ONLY_EEPROM_VERSIONING` define to enable that behavior.

### Changelog Entry

For release notes:
```
Feature Allow using FRAM as file system storage
Feature Allow using only EEPROM for versioning
```

### Alternatives

All changes are backward compatible, except for:
- the stack increases due to LittleFS is dependent on configuration. Not sure how to handle that without impacting other boards.

### Test coverage

- Lot's of hardware testing on our board
