### PR TITLE
only warn once when the last mag fails/gets disabled

### DIFF
--- a/src/modules/sensors/data_validator/DataValidatorGroup.cpp
+++ b/src/modules/sensors/data_validator/DataValidatorGroup.cpp
@@ -230,6 +230,10 @@ float *DataValidatorGroup::get_best(uint64_t timestamp, int *index)
 				if (_first_failover_time == 0) {
 					_first_failover_time = timestamp;
 				}
+
+				if (max_confidence < FLT_EPSILON) {
+					max_index = -1;
+				}
 			}
 		}
 


### PR DESCRIPTION

### Solved Problem
When the the last mag fails and there is no mag left to switch to, the current implementation keeps sending warnings to the user every 3 seconds.

### Solution
If the mag continues to fail, no new warning gets sent. It still works correctly for:
mag works -> mag fails (warns) -> mag fails -> mag works -> mag fails (warns) 
