### PR TITLE
Custom leds

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1970,15 +1970,15 @@ void Commander::checkForMissionUpdate()
 
 				if (!auto_mission_available) {
 					/* the mission is invalid */
-					tune_mission_fail(true);
+					tune_mission_fail(true, _param_mission_is_fail.get(), _param_mission_is_fail_mode.get());
 
 				} else if (mission_result.warning) {
 					/* the mission has a warning */
-					tune_mission_warn(true);
+					tune_mission_warn(true, _param_mission_is_warning.get(), _param_mission_is_warning_mode.get());
 
 				} else {
 					/* the mission is valid */
-					tune_mission_ok(true);
+					tune_mission_ok(true, _param_mission_is_ok.get(), _param_mission_is_ok_mode.get());
 				}
 			}
 		}

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -353,12 +353,8 @@ private:
 		(ParamInt<px4::params::COM_MISN_O_CLR>)    _param_mission_is_ok,
 		(ParamInt<px4::params::COM_MISN_W_CLR>)  _param_mission_is_warning,
 		(ParamInt<px4::params::COM_MISN_F_CLR>)  _param_mission_is_fail,
-		(ParamInt<px4::params::COM_HOME_SET_CLR>)   _param_home_set,
 		(ParamInt<px4::params::COM_MISN_O_MD>)   _param_mission_is_ok_mode,
 		(ParamInt<px4::params::COM_MISN_W_MD>)   _param_mission_is_warning_mode,
-		(ParamInt<px4::params::COM_MISN_F_MD>)   _param_mission_is_fail_mode,
-		(ParamInt<px4::params::COM_HOME_SET_MD>)   _param_home_set_mode
-
-
+		(ParamInt<px4::params::COM_MISN_F_MD>)   _param_mission_is_fail_mode
 	)
 };

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -349,6 +349,10 @@ private:
 		(ParamInt<px4::params::COM_RC_OVERRIDE>)    _param_com_rc_override,
 		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_takeoff_finished_action,
-		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max
+		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
+		(ParamInt<px4::params::COM_MISN_OK_CLR>)    _param_mission_is_ok,
+		(ParamInt<px4::params::COM_MISN_WARN_CLR>)  _param_mission_is_warning,
+		(ParamInt<px4::params::COM_MISN_FAIL_CLR>)  _param_mission_is_fail,
+		(ParamInt<px4::params::COM_HOME_SET_CLR>)   _param_home_set
 	)
 };

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -350,9 +350,15 @@ private:
 		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_flight_uuid,
 		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_takeoff_finished_action,
 		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max,
-		(ParamInt<px4::params::COM_MISN_OK_CLR>)    _param_mission_is_ok,
-		(ParamInt<px4::params::COM_MISN_WARN_CLR>)  _param_mission_is_warning,
-		(ParamInt<px4::params::COM_MISN_FAIL_CLR>)  _param_mission_is_fail,
-		(ParamInt<px4::params::COM_HOME_SET_CLR>)   _param_home_set
+		(ParamInt<px4::params::COM_MISN_O_CLR>)    _param_mission_is_ok,
+		(ParamInt<px4::params::COM_MISN_W_CLR>)  _param_mission_is_warning,
+		(ParamInt<px4::params::COM_MISN_F_CLR>)  _param_mission_is_fail,
+		(ParamInt<px4::params::COM_HOME_SET_CLR>)   _param_home_set,
+		(ParamInt<px4::params::COM_MISN_O_MD>)   _param_mission_is_ok_mode,
+		(ParamInt<px4::params::COM_MISN_W_MD>)   _param_mission_is_warning_mode,
+		(ParamInt<px4::params::COM_MISN_F_MD>)   _param_mission_is_fail_mode,
+		(ParamInt<px4::params::COM_HOME_SET_MD>)   _param_home_set_mode
+
+
 	)
 };

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -229,30 +229,30 @@ void tune_home_set(bool use_buzzer)
 	}
 }
 
-void tune_mission_ok(bool use_buzzer)
+void tune_mission_ok(bool use_buzzer, int led_color, int led_mode)
 {
 	blink_msg_end = hrt_absolute_time() + BLINK_MSG_TIME;
-	rgbled_set_color_and_mode(led_control_s::COLOR_GREEN, led_control_s::MODE_BLINK_FAST);
+	rgbled_set_color_and_mode(led_color, led_mode);
 
 	if (use_buzzer) {
 		set_tune(tune_control_s::TUNE_ID_NOTIFY_POSITIVE);
 	}
 }
 
-void tune_mission_warn(bool use_buzzer)
+void tune_mission_warn(bool use_buzzer, int led_color, int led_mode)
 {
 	blink_msg_end = hrt_absolute_time() + BLINK_MSG_TIME;
-	rgbled_set_color_and_mode(led_control_s::COLOR_YELLOW, led_control_s::MODE_BLINK_FAST);
+	rgbled_set_color_and_mode(led_color, led_mode);
 
 	if (use_buzzer) {
 		set_tune(tune_control_s::TUNE_ID_NOTIFY_NEUTRAL);
 	}
 }
 
-void tune_mission_fail(bool use_buzzer)
+void tune_mission_fail(bool use_buzzer, int led_color, int led_mode)
 {
 	blink_msg_end = hrt_absolute_time() + BLINK_MSG_TIME;
-	rgbled_set_color_and_mode(led_control_s::COLOR_RED, led_control_s::MODE_BLINK_FAST);
+	rgbled_set_color_and_mode(led_color, led_mode);
 
 	if (use_buzzer) {
 		set_tune(tune_control_s::TUNE_ID_NOTIFY_NEGATIVE);

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -79,9 +79,9 @@ void set_tune_override(const int tune_id);
 void set_tune(const int tune_id);
 
 void tune_home_set(bool use_buzzer);
-void tune_mission_ok(bool use_buzzer);
-void tune_mission_warn(bool use_buzzer);
-void tune_mission_fail(bool use_buzzer);
+void tune_mission_ok(bool use_buzzer, int led_color, int led_mode);
+void tune_mission_warn(bool use_buzzer, int led_color, int led_mode);
+void tune_mission_fail(bool use_buzzer, int led_color, int led_mode);
 void tune_positive(bool use_buzzer);
 void tune_neutral(bool use_buzzer);
 void tune_negative(bool use_buzzer);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1059,3 +1059,65 @@ PARAM_DEFINE_FLOAT(COM_THROW_SPEED, 5);
  * @increment 1
  */
 PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
+
+/**
+ * It is the color that indicates that the mission is suitable.
+ *
+ * @group Commander
+ * @value 0 COLOR_OFF
+ * @value 1 COLOR_RED
+ * @value 2 COLOR_GREEN
+ * @value 3 COLOR_BLUE
+ * @value 4 COLOR_YELLOW
+ * @value 5 COLOR_PURPLE
+ * @value 6 COLOR_AMBER
+ * @value 7 COLOR_CYAN
+ * @value 8 COLOR_WHITE
+ */
+PARAM_DEFINE_INT32(COM_MISN_OK_CLR, 2);
+
+/**
+ * It is the color that indicates that the mission is warning.
+ *
+ * @group Commander
+ * @value 0 COLOR_OFF
+ * @value 1 COLOR_RED
+ * @value 2 COLOR_GREEN
+ * @value 3 COLOR_BLUE
+ * @value 4 COLOR_YELLOW
+ * @value 5 COLOR_PURPLE
+ * @value 6 COLOR_AMBER
+ * @value 7 COLOR_CYAN
+ * @value 8 COLOR_WHITE
+ */
+PARAM_DEFINE_INT32(COM_MISN_WARN_CLR, 4);
+/**
+ * It is the color that indicates that the mission is fail.
+ *
+ * @group Commander
+ * @value 0 COLOR_OFF
+ * @value 1 COLOR_RED
+ * @value 2 COLOR_GREEN
+ * @value 3 COLOR_BLUE
+ * @value 4 COLOR_YELLOW
+ * @value 5 COLOR_PURPLE
+ * @value 6 COLOR_AMBER
+ * @value 7 COLOR_CYAN
+ * @value 8 COLOR_WHITE
+ */
+PARAM_DEFINE_INT32(COM_MISN_FAIL_CLR, 1);
+/**
+ * It is the color that indicates that the home is setted.
+ *
+ * @group Commander
+ * @value 0 COLOR_OFF
+ * @value 1 COLOR_RED
+ * @value 2 COLOR_GREEN
+ * @value 3 COLOR_BLUE
+ * @value 4 COLOR_YELLOW
+ * @value 5 COLOR_PURPLE
+ * @value 6 COLOR_AMBER
+ * @value 7 COLOR_CYAN
+ * @value 8 COLOR_WHITE
+ */
+PARAM_DEFINE_INT32(COM_HOME_SET_CLR, 2);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1074,7 +1074,7 @@ PARAM_DEFINE_INT32(COM_FLTT_LOW_ACT, 3);
  * @value 7 COLOR_CYAN
  * @value 8 COLOR_WHITE
  */
-PARAM_DEFINE_INT32(COM_MISN_OK_CLR, 2);
+PARAM_DEFINE_INT32(COM_MISN_O_CLR, 2);
 
 /**
  * It is the color that indicates that the mission is warning.
@@ -1090,7 +1090,7 @@ PARAM_DEFINE_INT32(COM_MISN_OK_CLR, 2);
  * @value 7 COLOR_CYAN
  * @value 8 COLOR_WHITE
  */
-PARAM_DEFINE_INT32(COM_MISN_WARN_CLR, 4);
+PARAM_DEFINE_INT32(COM_MISN_W_CLR, 4);
 /**
  * It is the color that indicates that the mission is fail.
  *
@@ -1105,7 +1105,7 @@ PARAM_DEFINE_INT32(COM_MISN_WARN_CLR, 4);
  * @value 7 COLOR_CYAN
  * @value 8 COLOR_WHITE
  */
-PARAM_DEFINE_INT32(COM_MISN_FAIL_CLR, 1);
+PARAM_DEFINE_INT32(COM_MISN_F_CLR, 1);
 /**
  * It is the color that indicates that the home is setted.
  *
@@ -1121,3 +1121,63 @@ PARAM_DEFINE_INT32(COM_MISN_FAIL_CLR, 1);
  * @value 8 COLOR_WHITE
  */
 PARAM_DEFINE_INT32(COM_HOME_SET_CLR, 2);
+
+/**
+ * It is the mode that indicates that the mission is suitable.
+ *
+ * @group Commander
+ * @value 0 MODE_OFF # turn LED off
+ * @value 1 MODE_ON  # turn LED on
+ * @value 2 MODE_DISABLED # disable this priority (switch to lower priority setting)
+ * @value 3 MODE_BLINK_SLOW
+ * @value 4 MODE_BLINK_NORMAL
+ * @value 5 MODE_BLINK_FAST
+ * @value 6 MODE_BREATHE # continuously increase & decrease brightness (solid color if driver does not support it)
+ * @value 7 MODE_FLASH # two fast blinks (on/off) with timing as in MODE_BLINK_FAST and then off for a while
+ */
+PARAM_DEFINE_INT32(COM_MISN_O_MD, 5);
+
+/**
+ * It is the mode that indicates that the mission is warning.
+ *
+ * @group Commander
+ * @value 0 MODE_OFF # turn LED off
+ * @value 1 MODE_ON  # turn LED on
+ * @value 2 MODE_DISABLED # disable this priority (switch to lower priority setting)
+ * @value 3 MODE_BLINK_SLOW
+ * @value 4 MODE_BLINK_NORMAL
+ * @value 5 MODE_BLINK_FAST
+ * @value 6 MODE_BREATHE # continuously increase & decrease brightness (solid color if driver does not support it)
+ * @value 7 MODE_FLASH # two fast blinks (on/off) with timing as in MODE_BLINK_FAST and then off for a while
+ */
+PARAM_DEFINE_INT32(COM_MISN_W_MD, 5);
+
+/**
+ * It is the mode that indicates that the mission is fail.
+ *
+ * @group Commander
+ * @value 0 MODE_OFF # turn LED off
+ * @value 1 MODE_ON  # turn LED on
+ * @value 2 MODE_DISABLED # disable this priority (switch to lower priority setting)
+ * @value 3 MODE_BLINK_SLOW
+ * @value 4 MODE_BLINK_NORMAL
+ * @value 5 MODE_BLINK_FAST
+ * @value 6 MODE_BREATHE # continuously increase & decrease brightness (solid color if driver does not support it)
+ * @value 7 MODE_FLASH # two fast blinks (on/off) with timing as in MODE_BLINK_FAST and then off for a while
+ */
+PARAM_DEFINE_INT32(COM_MISN_F_MD, 5);
+
+/**
+ * It is the mode that indicates that the home is setted.
+ *
+ * @group Commander
+ * @value 0 MODE_OFF # turn LED off
+ * @value 1 MODE_ON  # turn LED on
+ * @value 2 MODE_DISABLED # disable this priority (switch to lower priority setting)
+ * @value 3 MODE_BLINK_SLOW
+ * @value 4 MODE_BLINK_NORMAL
+ * @value 5 MODE_BLINK_FAST
+ * @value 6 MODE_BREATHE # continuously increase & decrease brightness (solid color if driver does not support it)
+ * @value 7 MODE_FLASH # two fast blinks (on/off) with timing as in MODE_BLINK_FAST and then off for a while
+ */
+PARAM_DEFINE_INT32(COM_HOME_SET_MD, 5);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -1106,21 +1106,6 @@ PARAM_DEFINE_INT32(COM_MISN_W_CLR, 4);
  * @value 8 COLOR_WHITE
  */
 PARAM_DEFINE_INT32(COM_MISN_F_CLR, 1);
-/**
- * It is the color that indicates that the home is setted.
- *
- * @group Commander
- * @value 0 COLOR_OFF
- * @value 1 COLOR_RED
- * @value 2 COLOR_GREEN
- * @value 3 COLOR_BLUE
- * @value 4 COLOR_YELLOW
- * @value 5 COLOR_PURPLE
- * @value 6 COLOR_AMBER
- * @value 7 COLOR_CYAN
- * @value 8 COLOR_WHITE
- */
-PARAM_DEFINE_INT32(COM_HOME_SET_CLR, 2);
 
 /**
  * It is the mode that indicates that the mission is suitable.
@@ -1166,18 +1151,3 @@ PARAM_DEFINE_INT32(COM_MISN_W_MD, 5);
  * @value 7 MODE_FLASH # two fast blinks (on/off) with timing as in MODE_BLINK_FAST and then off for a while
  */
 PARAM_DEFINE_INT32(COM_MISN_F_MD, 5);
-
-/**
- * It is the mode that indicates that the home is setted.
- *
- * @group Commander
- * @value 0 MODE_OFF # turn LED off
- * @value 1 MODE_ON  # turn LED on
- * @value 2 MODE_DISABLED # disable this priority (switch to lower priority setting)
- * @value 3 MODE_BLINK_SLOW
- * @value 4 MODE_BLINK_NORMAL
- * @value 5 MODE_BLINK_FAST
- * @value 6 MODE_BREATHE # continuously increase & decrease brightness (solid color if driver does not support it)
- * @value 7 MODE_FLASH # two fast blinks (on/off) with timing as in MODE_BLINK_FAST and then off for a while
- */
-PARAM_DEFINE_INT32(COM_HOME_SET_MD, 5);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The color of the autopilot and GPS led have fixed settings. I added a few parameters to change mission information leads. Now, we can customize the color indicator of autopilot for mission updates. 
Fixes #{Github issue ID}

### Solution
- Refactor, A few parameters were added to the commander module, and these colors and modes are given to the led module.

### Changelog Entry
For release notes:
```

New parameter: 
- COM_MISN_O_CLR
- COM_MISN_W_CLR
- COM_MISN_F_CLR
- COM_MISN_O_MD
- COM_MISN_W_MD
- COM_MISN_F_MD

```


