### PR TITLE
Commander: Termination: do not switch out of mode on disarm and prevent user switching out of it

### DIFF
--- a/src/modules/commander/UserModeIntention.cpp
+++ b/src/modules/commander/UserModeIntention.cpp
@@ -69,6 +69,9 @@ bool UserModeIntention::change(uint8_t user_intended_nav_state, ModeChangeSource
 		}
 	}
 
+	// never allow to change out of termination state
+	allow_change &= _vehicle_status.nav_state != vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+
 	if (allow_change) {
 		_had_mode_change = true;
 		_user_intented_nav_state = user_intended_nav_state;

--- a/src/modules/commander/UserModeIntention.cpp
+++ b/src/modules/commander/UserModeIntention.cpp
@@ -73,7 +73,10 @@ bool UserModeIntention::change(uint8_t user_intended_nav_state, ModeChangeSource
 		_had_mode_change = true;
 		_user_intented_nav_state = user_intended_nav_state;
 
-		if (!_health_and_arming_checks.modePreventsArming(user_intended_nav_state)) {
+		// Special case termination state: even though this mode prevents arming,
+		// still don't switch out of it after disarm and thus store it in _nav_state_after_disarming.
+		if (!_health_and_arming_checks.modePreventsArming(user_intended_nav_state)
+		    || user_intended_nav_state == vehicle_status_s::NAVIGATION_STATE_TERMINATION) {
 			_nav_state_after_disarming = user_intended_nav_state;
 		}
 


### PR DESCRIPTION
### Solved Problem
Two kind of separate problems:
- when after the `VEHICLE_CMD_DO_FLIGHTTERMINATION` there was a `VEHICLE_CMD_COMPONENT_ARM_DISARM` (to disarm) command, the system reset the flight mode from Termination to whatever was there previously. This then e.g. allowed to re-arm.
- the user could switch out of the Termination mode (I don't think this is intended?)

### Solution
- allow _nav_state_after_disarming to be set to Terminate
- disallow mode changes if the nav_state is Termination

### Changelog Entry
For release notes:
```
Bugfix: Commander: Termination: do not switch out of mode on disarm and prevent user switching out of it
```
