### PR TITLE
ekf2: Optical flow enabled by default

### DIFF
--- a/src/modules/ekf2/module.yaml
+++ b/src/modules/ekf2/module.yaml
@@ -670,7 +670,7 @@ parameters:
         short: Optical flow aiding
         long: Enable optical flow fusion.
       type: boolean
-      default: 0
+      default: 1
     EKF2_OF_N_MIN:
       description:
         short: Optical flow minimum noise


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solution
Changed default value of `EKF2_OF_CTRL` to `true`, resulting in Optical Flow being enabled by default. This change does not have an effect on vehicles that are not equipped with an OF sensor.

### Changelog Entry
For release notes:
```
Feature Optical flow enabled by default (EKF2_OF_CTRL =  true)
```

