### PR TITLE
TECS: reduce default of FW_T_SPD_STD to reduce airspeed measurement delay

### DIFF
--- a/src/modules/fw_pos_control/fw_path_navigation_params.c
+++ b/src/modules/fw_pos_control/fw_path_navigation_params.c
@@ -514,7 +514,7 @@ PARAM_DEFINE_FLOAT(FW_T_VERT_ACC, 7.0f);
  * @increment 0.1
  * @group FW TECS
  */
-PARAM_DEFINE_FLOAT(FW_T_SPD_STD, 0.2f);
+PARAM_DEFINE_FLOAT(FW_T_SPD_STD, 0.07f);
 
 /**
  * Airspeed rate measurement standard deviation


### PR DESCRIPTION

### Solved Problem
The TECS airspeed filter is setup with too much filtering, which causes high measurements delay, which in turn can lead to instability of the control loop.

### Solution
Reduce the default of FW_T_SPD_STD (airspeed measurement standard deviation) to reduce filtering. 

Current main, with default TECS airspeed filtering: delay of filtered airspeed input is about 1s:
![image](https://github.com/user-attachments/assets/dd2c47c1-5f29-459f-8a72-a273306dc295)

With the proposed change of FW_T_SPD_STD to 0.07: delay is about 0.7s
![image](https://github.com/user-attachments/assets/1baa2ea1-2e2e-4c9d-afee-1637efb9f470)

Old (previous to [TECS rework](https://github.com/PX4/PX4-Autopilot/pull/20443)): the delay was at about 0.5s:
![image](https://github.com/user-attachments/assets/7672ed27-89eb-4c7d-8cbf-1c34ae25e690)


### Changelog Entry
For release notes:
```
Improvement: TECS: reduce default of FW_T_SPD_STD to reduce airspeed measurement delay
```


### Test coverage
This was flown on different drones with much better results. 
