### PR TITLE
VehicleOdometry.msg - clarify frames

### DIFF
--- a/msg/VehicleOdometry.msg
+++ b/msg/VehicleOdometry.msg
@@ -3,17 +3,21 @@ uint64 timestamp		# time since system start (microseconds)
 uint64 timestamp_sample
 
 uint8 POSE_FRAME_UNKNOWN = 0
-uint8 POSE_FRAME_NED     = 1 # NED earth-fixed frame
-uint8 POSE_FRAME_FRD     = 2 # FRD world-fixed frame, arbitrary heading reference
+uint8 POSE_FRAME_NED     = 1 # NED earth-fixed frame. Origin X, Y, Z, is position of IMU at EFK startup.
+uint8 POSE_FRAME_FRD     = 2 # FRD world-fixed frame. 
+                             # Origin and heading (X) fixed to arbitrary values at EKF startup. Z is down.
 uint8 pose_frame            # Position and orientation frame of reference
 
 float32[3] position         # Position in meters. Frame of reference defined by local_frame. NaN if invalid/unknown
 float32[4] q                # Quaternion rotation from FRD body frame to reference frame. First value NaN if invalid/unknown
 
 uint8 VELOCITY_FRAME_UNKNOWN  = 0
-uint8 VELOCITY_FRAME_NED      = 1 # NED earth-fixed frame
-uint8 VELOCITY_FRAME_FRD      = 2 # FRD world-fixed frame, arbitrary heading reference
-uint8 VELOCITY_FRAME_BODY_FRD = 3 # FRD body-fixed frame
+uint8 VELOCITY_FRAME_NED      = 1 # NED earth-fixed frame. Origin X, Y, Z, is position of IMU at EFK startup.
+uint8 VELOCITY_FRAME_FRD      = 2 # FRD world-fixed frame.
+                                  #  Origin X, Y, Z, is position of IMU at EFK startup. Z is down.
+uint8 VELOCITY_FRAME_BODY_FRD = 3 # FRD body-fixed frame.
+                                  # Origin travels with vehicle.
+                                  # Frame X, Y, Z is aligned to vehicle Front Right Down.
 uint8 velocity_frame        # Reference frame of the velocity data
 
 float32[3] velocity         # Velocity in meters/sec. Frame of reference defined by velocity_frame variable. NaN if invalid/unknown


### PR DESCRIPTION
This attempts to clarify frames used in VehicleOdometry UORB topic in response to this discuss post https://discuss.px4.io/t/uav-frames/39688/5

@bresch Sorry, really not sure I "got it right" or this helps. If you think it is correct and useful we can merge, otherwise I'll leave to you to decide if it can be improved or should just be closed.