### PR TITLE
ackermann: added delay comand support

### DIFF
--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
@@ -125,47 +125,54 @@ RoverAckermannGuidance::motor_setpoint RoverAckermannGuidance::computeGuidance(c
 						  _curr_wp(0),
 						  _curr_wp(1));
 
-		if (_param_ra_miss_vel_min.get() > 0.f  && _param_ra_miss_vel_min.get() < _param_ra_miss_vel_def.get()
-		    && _param_ra_miss_vel_gain.get() > FLT_EPSILON) { // Cornering slow down effect
-			if (distance_to_prev_wp <= _prev_acceptance_radius && _prev_acceptance_radius > FLT_EPSILON) {
-				const float cornering_speed = _param_ra_miss_vel_gain.get() / _prev_acceptance_radius;
-				desired_speed = math::constrain(cornering_speed, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
+		if(distance_to_curr_wp > _param_nav_acc_rad.get()){
+			if (_param_ra_miss_vel_min.get() > 0.f  && _param_ra_miss_vel_min.get() < _param_ra_miss_vel_def.get()
+			&& _param_ra_miss_vel_gain.get() > FLT_EPSILON) { // Cornering slow down effect
+				if (distance_to_prev_wp <= _prev_acceptance_radius && _prev_acceptance_radius > FLT_EPSILON) {
+					const float cornering_speed = _param_ra_miss_vel_gain.get() / _prev_acceptance_radius;
+					desired_speed = math::constrain(cornering_speed, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
 
-			} else if (distance_to_curr_wp <= _acceptance_radius && _acceptance_radius > FLT_EPSILON) {
-				const float cornering_speed = _param_ra_miss_vel_gain.get() / _acceptance_radius;
-				desired_speed = math::constrain(cornering_speed, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
+				} else if (distance_to_curr_wp <= _acceptance_radius && _acceptance_radius > FLT_EPSILON) {
+					const float cornering_speed = _param_ra_miss_vel_gain.get() / _acceptance_radius;
+					desired_speed = math::constrain(cornering_speed, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
 
-			} else { // Straight line speed
-				if (_param_ra_max_accel.get() > FLT_EPSILON && _param_ra_max_jerk.get() > FLT_EPSILON
-				    && _acceptance_radius > FLT_EPSILON) {
-					float max_velocity{0.f};
+				} else { // Straight line speed
+					if (_param_ra_max_accel.get() > FLT_EPSILON && _param_ra_max_jerk.get() > FLT_EPSILON
+					&& _acceptance_radius > FLT_EPSILON) {
+						float max_velocity{0.f};
 
-					if (nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
-						max_velocity = math::trajectory::computeMaxSpeedFromDistance(_param_ra_max_jerk.get(),
-								_param_ra_max_accel.get(), distance_to_curr_wp, 0.f);
+						if (nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
+							max_velocity = math::trajectory::computeMaxSpeedFromDistance(_param_ra_max_jerk.get(),
+									_param_ra_max_accel.get(), distance_to_curr_wp, 0.f);
+
+						} else {
+							const float cornering_speed = _param_ra_miss_vel_gain.get() / _acceptance_radius;
+							max_velocity = math::trajectory::computeMaxSpeedFromDistance(_param_ra_max_jerk.get(),
+									_param_ra_max_accel.get(), distance_to_curr_wp - _acceptance_radius, cornering_speed);
+						}
+
+						desired_speed = math::constrain(max_velocity, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
 
 					} else {
-						const float cornering_speed = _param_ra_miss_vel_gain.get() / _acceptance_radius;
-						max_velocity = math::trajectory::computeMaxSpeedFromDistance(_param_ra_max_jerk.get(),
-								_param_ra_max_accel.get(), distance_to_curr_wp - _acceptance_radius, cornering_speed);
+						desired_speed = _param_ra_miss_vel_def.get();
 					}
-
-					desired_speed = math::constrain(max_velocity, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
-
-				} else {
-					desired_speed = _param_ra_miss_vel_def.get();
 				}
+
+			} else {
+				desired_speed = _param_ra_miss_vel_def.get();
 			}
 
-		} else {
-			desired_speed = _param_ra_miss_vel_def.get();
-		}
+			// Calculate desired steering
+			desired_steering = calcDesiredSteering(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned, _param_ra_lookahd_gain.get(),
+							_param_ra_lookahd_min.get(), _param_ra_lookahd_max.get(), _param_ra_wheel_base.get(), desired_speed, vehicle_yaw);
+			desired_steering = math::constrain(desired_steering, -_param_ra_max_steer_angle.get(),
+							_param_ra_max_steer_angle.get());
+			_prev_desired_steering = desired_steering;
 
-		// Calculate desired steering
-		desired_steering = calcDesiredSteering(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned, _param_ra_lookahd_gain.get(),
-						       _param_ra_lookahd_min.get(), _param_ra_lookahd_max.get(), _param_ra_wheel_base.get(), desired_speed, vehicle_yaw);
-		desired_steering = math::constrain(desired_steering, -_param_ra_max_steer_angle.get(),
-						   _param_ra_max_steer_angle.get());
+		} else { // In acceptance radius of current wp but still hasn't change meaning there is a delay to stay in
+			desired_steering = _prev_desired_steering; // To avoid steering on the spot and premature wheel wear
+			desired_speed = 0.f;
+		}
 	}
 
 	// Throttle PID

--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
@@ -125,9 +125,9 @@ RoverAckermannGuidance::motor_setpoint RoverAckermannGuidance::computeGuidance(c
 						  _curr_wp(0),
 						  _curr_wp(1));
 
-		if(distance_to_curr_wp > _param_nav_acc_rad.get()){
+		if (distance_to_curr_wp > _param_nav_acc_rad.get()) {
 			if (_param_ra_miss_vel_min.get() > 0.f  && _param_ra_miss_vel_min.get() < _param_ra_miss_vel_def.get()
-			&& _param_ra_miss_vel_gain.get() > FLT_EPSILON) { // Cornering slow down effect
+			    && _param_ra_miss_vel_gain.get() > FLT_EPSILON) { // Cornering slow down effect
 				if (distance_to_prev_wp <= _prev_acceptance_radius && _prev_acceptance_radius > FLT_EPSILON) {
 					const float cornering_speed = _param_ra_miss_vel_gain.get() / _prev_acceptance_radius;
 					desired_speed = math::constrain(cornering_speed, _param_ra_miss_vel_min.get(), _param_ra_miss_vel_def.get());
@@ -138,7 +138,7 @@ RoverAckermannGuidance::motor_setpoint RoverAckermannGuidance::computeGuidance(c
 
 				} else { // Straight line speed
 					if (_param_ra_max_accel.get() > FLT_EPSILON && _param_ra_max_jerk.get() > FLT_EPSILON
-					&& _acceptance_radius > FLT_EPSILON) {
+					    && _acceptance_radius > FLT_EPSILON) {
 						float max_velocity{0.f};
 
 						if (nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL) {
@@ -164,9 +164,9 @@ RoverAckermannGuidance::motor_setpoint RoverAckermannGuidance::computeGuidance(c
 
 			// Calculate desired steering
 			desired_steering = calcDesiredSteering(_curr_wp_ned, _prev_wp_ned, _curr_pos_ned, _param_ra_lookahd_gain.get(),
-							_param_ra_lookahd_min.get(), _param_ra_lookahd_max.get(), _param_ra_wheel_base.get(), desired_speed, vehicle_yaw);
+							       _param_ra_lookahd_min.get(), _param_ra_lookahd_max.get(), _param_ra_wheel_base.get(), desired_speed, vehicle_yaw);
 			desired_steering = math::constrain(desired_steering, -_param_ra_max_steer_angle.get(),
-							_param_ra_max_steer_angle.get());
+							   _param_ra_max_steer_angle.get());
 			_prev_desired_steering = desired_steering;
 
 		} else { // In acceptance radius of current wp but still hasn't change meaning there is a delay to stay in

--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
@@ -125,7 +125,7 @@ RoverAckermannGuidance::motor_setpoint RoverAckermannGuidance::computeGuidance(c
 						  _curr_wp(0),
 						  _curr_wp(1));
 
-		if (distance_to_curr_wp > _param_nav_acc_rad.get()) {
+		if (distance_to_curr_wp > _acceptance_radius) {
 			if (_param_ra_miss_vel_min.get() > 0.f  && _param_ra_miss_vel_min.get() < _param_ra_miss_vel_def.get()
 			    && _param_ra_miss_vel_gain.get() > FLT_EPSILON) { // Cornering slow down effect
 				if (distance_to_prev_wp <= _prev_acceptance_radius && _prev_acceptance_radius > FLT_EPSILON) {
@@ -169,8 +169,8 @@ RoverAckermannGuidance::motor_setpoint RoverAckermannGuidance::computeGuidance(c
 							   _param_ra_max_steer_angle.get());
 			_prev_desired_steering = desired_steering;
 
-		} else { // In acceptance radius of current wp but still hasn't change meaning there is a delay to stay in
-			desired_steering = _prev_desired_steering; // To avoid steering on the spot and premature wheel wear
+		} else { // Catch delay command
+			desired_steering = _prev_desired_steering; // Avoid steering on the spot
 			desired_speed = 0.f;
 		}
 	}

--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.hpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.hpp
@@ -151,6 +151,7 @@ private:
 	Vector2f _curr_pos_ned{};
 	PID_t _pid_throttle;
 	hrt_abstime _timestamp{0};
+	float _prev_desired_steering{0.f};
 
 	// Waypoint variables
 	Vector2d _curr_wp{};


### PR DESCRIPTION
### Solved Problem
The rover wasn't stopping at waypoint if there was a delay on it, and instead was looping around

### Solution
- Stop the rover when it is in the acceptance radius of the waypoint

### Test coverage
- SITL tested

### Context
Mission : 
![Mission3](https://github.com/user-attachments/assets/323e7813-6a32-4bf4-ae35-bfa054079bd9)
![mission1](https://github.com/user-attachments/assets/2c570601-ca6c-4efa-8a93-7a9b6f46de9d) ![Mission2](https://github.com/user-attachments/assets/b9ca1c6b-df4a-4634-b871-5428e9dc58ee)


Before :

https://github.com/user-attachments/assets/00bd1ac4-5260-4c51-824b-397e5b6fa3c2

After :

https://github.com/user-attachments/assets/72435e4f-ab17-4728-9f2c-e8a89d8ea696



