### PR TITLE
FW Position Controller: reset position-mode line following after position reset

### DIFF
--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -328,6 +328,7 @@ bool Ekf::resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, fl
 		    && fuseDirectStateMeasurement(innov(1), innov_var(1), obs_var, State::pos.idx + 1)
 		   ) {
 			ECL_INFO("fused external observation as position measurement");
+			_state_reset_status.reset_count.posNE++;
 			_time_last_hor_pos_fuse = _time_delayed_us;
 			_last_known_pos.xy() = _state.pos.xy();
 			return true;

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2170,7 +2170,7 @@ FixedwingPositionControl::control_manual_position(const float control_interval, 
 
 			// if there's a reset-by-fusion, the ekf needs some time to converge,
 			// therefore we go into track holiding for 2 seconds
-			if (_local_pos.timestamp - _time_last_xy_reset < 2e6) {
+			if (_local_pos.timestamp - _time_last_xy_reset < 2_s) {
 				_hdg_hold_position.lat = _current_latitude;
 				_hdg_hold_position.lon = _current_longitude;
 			}

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2321,14 +2321,14 @@ FixedwingPositionControl::Run()
 
 		// handle estimator reset events. we only adjust setpoins for manual modes
 		if (_control_mode.flag_control_manual_enabled) {
-			if (_control_mode.flag_control_altitude_enabled && _local_pos.vz_reset_counter != _vz_reset_counter) {
+			if (_control_mode.flag_control_altitude_enabled && _local_pos.z_reset_counter != _z_reset_counter) {
 				// make TECS accept step in altitude and demanded altitude
 				_tecs.handle_alt_step(_current_altitude, -_local_pos.vz);
 			}
 
 			// adjust navigation waypoints in position control mode
 			if (_control_mode.flag_control_altitude_enabled && _control_mode.flag_control_velocity_enabled
-			    && _local_pos.vxy_reset_counter != _vxy_reset_counter) {
+			    && _local_pos.xy_reset_counter != _xy_reset_counter) {
 
 				// reset heading hold flag, which will re-initialise position control
 				_hdg_hold_enabled = false;
@@ -2338,7 +2338,7 @@ FixedwingPositionControl::Run()
 		// Convert Local setpoints to global setpoints
 		if (!_global_local_proj_ref.isInitialized()
 		    || (_global_local_proj_ref.getProjectionReferenceTimestamp() != _local_pos.ref_timestamp)
-		    || (_local_pos.vxy_reset_counter != _vxy_reset_counter)) {
+		    || (_local_pos.xy_reset_counter != _xy_reset_counter)) {
 
 			double reference_latitude = 0.;
 			double reference_longitude = 0.;
@@ -2623,8 +2623,7 @@ FixedwingPositionControl::Run()
 			_spoilers_setpoint_pub.publish(spoilers_setpoint);
 		}
 
-		_vz_reset_counter = _local_pos.vz_reset_counter;
-		_vxy_reset_counter = _local_pos.vxy_reset_counter;
+		_z_reset_counter = _local_pos.z_reset_counter;
 		_xy_reset_counter = _local_pos.xy_reset_counter;
 
 		perf_end(_loop_perf);

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -406,12 +406,10 @@ private:
 	matrix::Vector2d _transition_waypoint{(double)NAN, (double)NAN};
 
 	// ESTIMATOR RESET COUNTERS
-
-	// captures the number of times the estimator has reset the horizontal position
-	uint8_t _pos_reset_counter{0};
-
-	// captures the number of times the estimator has reset the altitude state
-	uint8_t _alt_reset_counter{0};
+	uint8_t _vxy_reset_counter{0};
+	uint8_t _vz_reset_counter{0};
+	uint8_t _xy_reset_counter{0};
+	uint64_t _time_last_xy_reset{0};
 
 	// LATERAL-DIRECTIONAL GUIDANCE
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -406,9 +406,8 @@ private:
 	matrix::Vector2d _transition_waypoint{(double)NAN, (double)NAN};
 
 	// ESTIMATOR RESET COUNTERS
-	uint8_t _vxy_reset_counter{0};
-	uint8_t _vz_reset_counter{0};
 	uint8_t _xy_reset_counter{0};
+	uint8_t _z_reset_counter{0};
 	uint64_t _time_last_xy_reset{0};
 
 	// LATERAL-DIRECTIONAL GUIDANCE


### PR DESCRIPTION

### Solved Problem
In posiiton-mode, the controller tries to follow a straight line to keep consistent track and avoid lateral drift.
After a position reset, either by fusion or hard reset, the line was not updated. This resulted in a "correction" path. Since the position difference from the reset does not represent the truth, we would expect the vehicle to fly straight on in the same direction.

### Solution
After a position reset, the switches to track-hold mode for 2 seconds. During those 2 seconds it does not correct for any later drift. A time-based approach is needed since the states do not converge immediately after a reset-by-fusion.

Screenshots: position-mode, flight from W to E. position reset in N direction.
old:
![image](https://github.com/user-attachments/assets/1d47ebde-9424-46e6-b9c5-028a4084ac6d)
new:
![Screenshot from 2024-07-24 14-18-02](https://github.com/user-attachments/assets/e09b80ac-cb5b-4312-92c8-c70101fd496a)
