### PR TITLE
Fix wind covariance prediction

### DIFF
--- a/src/modules/ekf2/EKF/covariance.cpp
+++ b/src/modules/ekf2/EKF/covariance.cpp
@@ -201,14 +201,15 @@ void Ekf::predictCovariance(const imuSample &imu_delayed)
 #if defined(CONFIG_EKF2_WIND)
 
 	// wind vel: add process noise
-	if (!_external_wind_init) {
-		float wind_vel_nsd_scaled = math::constrain(_params.wind_vel_nsd, 0.f, 1.f)
-					    * (1.f + _params.wind_vel_nsd_scaler * fabsf(_height_rate_lpf));
-		float wind_vel_process_noise = sq(wind_vel_nsd_scaled) * dt;
+	float wind_vel_nsd_scaled = math::constrain(_params.wind_vel_nsd, 0.f, 1.f)
+				    * (1.f + _params.wind_vel_nsd_scaler * fabsf(_height_rate_lpf));
+	float wind_vel_process_noise = sq(wind_vel_nsd_scaled) * dt;
 
-		for (unsigned index = 0; index < State::wind_vel.dof; index++) {
-			const unsigned i = State::wind_vel.idx + index;
-			P(i, i) = fminf(P(i, i) + wind_vel_process_noise, sq(_params.initial_wind_uncertainty));
+	for (unsigned index = 0; index < State::wind_vel.dof; index++) {
+		const unsigned i = State::wind_vel.idx + index;
+
+		if (P(i, i) < sq(_params.initial_wind_uncertainty)) {
+			P(i, i) += wind_vel_process_noise;
 		}
 	}
 


### PR DESCRIPTION


<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
The wind variance can be reset to a value larger than the wind init variance (e.g.: when the reset occurs when flying close to the N or E axis). Constraining the variance after a covariance initialization would artificially increase the correlation and could destabilize the filter.

To reproduce:
- In sitl with a standard vtol plane, takeoff and transition towards the East **without** GNSS fusion.
- After a couple of seconds the wind state are diverging and because the airspeed fusion is used to update the other states, the vel/pos states are also diverging

![Screenshot from 2024-07-24 15-18-41](https://github.com/user-attachments/assets/6e0d0d57-8cda-4844-b697-d2143834714e)


### Solution
Do not constrain the wind variance but rather stop the process noise when the wind variance is large enough.
I also think that the process noise should continue to run even when the wind has been initialized manually as the uncertainty of this initialization should grow over time.
![Screenshot from 2024-07-24 11-18-36](https://github.com/user-attachments/assets/1a9b3e96-0353-44ee-b42b-8126bd1963df)


### Changelog Entry
For release notes:
```
New parameter: -
Documentation: -
```

### Alternatives
Never stop the process noise

### Test coverage
SITL test
