### PR TITLE
Fixed-wing auto takeoff: enable setting takeoff flaps for hand/catapult launch.

### DIFF
--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1532,8 +1532,6 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		_att_sp.pitch_body = _runway_takeoff.getPitch(get_tecs_pitch());
 		_att_sp.thrust_body[0] = _runway_takeoff.getThrottle(_param_fw_thr_idle.get(), get_tecs_thrust());
 
-		_flaps_setpoint = _param_fw_flaps_to_scl.get();
-
 		// retract ladning gear once passed the climbout state
 		if (_runway_takeoff.getState() > RunwayTakeoffState::CLIMBOUT) {
 			_new_landing_gear_position = landing_gear_s::GEAR_UP;
@@ -1634,6 +1632,7 @@ FixedwingPositionControl::control_auto_takeoff(const hrt_abstime &now, const flo
 		_launch_detection_status_pub.publish(launch_detection_status);
 	}
 
+	_flaps_setpoint = _param_fw_flaps_to_scl.get();
 	_att_sp.roll_body = constrainRollNearGround(_att_sp.roll_body, _current_altitude, _takeoff_ground_alt);
 
 	if (!_vehicle_status.in_transition_to_fw) {


### PR DESCRIPTION

### Solved Problem
Flaps support during takeoff currently only possible in runway takeoff, not in hand/catapult launch. Was raised here: https://discord.com/channels/1022170275984457759/1265569056237555734

### Solution
Enable it also for hand/catapult launch (for as long as control_auto_takeoff() is running). 

### Changelog Entry
For release notes:
```
Improvement: Fixed-wing auto takeoff: enable setting takeoff flaps for hand/catapult launch.
```


### Test coverage
Untested yet. To test: Configure flaps and enable them during takeoff through FW_FLAPS_TO_SCL.
