### PR TITLE
baro tuning: make hpf argument optional

### DIFF
--- a/src/modules/ekf2/EKF/python/tuning_tools/baro_static_pressure_compensation/baro_static_pressure_compensation_tuning.py
+++ b/src/modules/ekf2/EKF/python/tuning_tools/baro_static_pressure_compensation/baro_static_pressure_compensation_tuning.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
 
     # Provide parameter file path and name
     parser.add_argument('logfile', help='Full ulog file path, name and extension', type=str)
-    parser.add_argument('--hpf', help='Cuttoff frequency of high-pass filter on baro error (Hz)', type=float)
+    parser.add_argument('--hpf', help='Cuttoff frequency of high-pass filter on baro error (Hz)', type=float, default=-1)
     args = parser.parse_args()
 
     logfile = os.path.abspath(args.logfile) # Convert to absolute path


### PR DESCRIPTION
This filter is often not needed. Setting the default value to -1 makes it optional.