### PR TITLE
Commander: adhere to parameter naming convention

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -670,9 +670,9 @@ transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool f
 	}
 
 	// update flight uuid
-	const int32_t flight_uuid = _param_flight_uuid.get() + 1;
-	_param_flight_uuid.set(flight_uuid);
-	_param_flight_uuid.commit_no_notification();
+	const int32_t flight_uuid = _param_com_flight_uuid.get() + 1;
+	_param_com_flight_uuid.set(flight_uuid);
+	_param_com_flight_uuid.commit_no_notification();
 
 	_status_changed = true;
 
@@ -1991,7 +1991,7 @@ void Commander::checkForMissionUpdate()
 			if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF
 			    || _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_VTOL_TAKEOFF) {
 				// Transition mode to loiter or auto-mission after takeoff is completed.
-				if ((_param_takeoff_finished_action.get() == 1) && auto_mission_available) {
+				if ((_param_com_takeoff_act.get() == 1) && auto_mission_available) {
 					_user_mode_intention.change(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION);
 
 				} else {
@@ -2236,7 +2236,7 @@ void Commander::handleAutoDisarm()
 	if (isArmed()) {
 
 		// Check for auto-disarm on landing or pre-flight
-		if (_param_com_disarm_land.get() > 0 || _param_com_disarm_preflight.get() > 0) {
+		if (_param_com_disarm_land.get() > 0 || _param_com_disarm_prflt.get() > 0) {
 
 			const bool landed_amid_mission = (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION)
 							 && !_mission_result_sub.get().finished;
@@ -2247,8 +2247,8 @@ void Commander::handleAutoDisarm()
 				_auto_disarm_landed.set_hysteresis_time_from(false, _param_com_disarm_land.get() * 1_s);
 				_auto_disarm_landed.set_state_and_update(_vehicle_land_detected.landed, hrt_absolute_time());
 
-			} else if (_param_com_disarm_preflight.get() > 0 && !_have_taken_off_since_arming) {
-				_auto_disarm_landed.set_hysteresis_time_from(false, _param_com_disarm_preflight.get() * 1_s);
+			} else if (_param_com_disarm_prflt.get() > 0 && !_have_taken_off_since_arming) {
+				_auto_disarm_landed.set_hysteresis_time_from(false, _param_com_disarm_prflt.get() * 1_s);
 				_auto_disarm_landed.set_state_and_update(true, hrt_absolute_time());
 			}
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -332,7 +332,7 @@ private:
 	DEFINE_PARAMETERS(
 
 		(ParamFloat<px4::params::COM_DISARM_LAND>)  _param_com_disarm_land,
-		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_preflight,
+		(ParamFloat<px4::params::COM_DISARM_PRFLT>) _param_com_disarm_prflt,
 		(ParamBool<px4::params::COM_DISARM_MAN>)    _param_com_disarm_man,
 		(ParamInt<px4::params::COM_DL_LOSS_T>)      _param_com_dl_loss_t,
 		(ParamInt<px4::params::COM_HLDL_LOSS_T>)    _param_com_hldl_loss_t,
@@ -347,8 +347,8 @@ private:
 		(ParamFloat<px4::params::COM_OBC_LOSS_T>)   _param_com_obc_loss_t,
 		(ParamInt<px4::params::COM_PREARM_MODE>)    _param_com_prearm_mode,
 		(ParamInt<px4::params::COM_RC_OVERRIDE>)    _param_com_rc_override,
-		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_flight_uuid,
-		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_takeoff_finished_action,
+		(ParamInt<px4::params::COM_FLIGHT_UUID>)    _param_com_flight_uuid,
+		(ParamInt<px4::params::COM_TAKEOFF_ACT>)    _param_com_takeoff_act,
 		(ParamFloat<px4::params::COM_CPU_MAX>)      _param_com_cpu_max
 	)
 };


### PR DESCRIPTION
### Solved Problem
When looking through code to answer questions I found that some parameters don't follow the naming convention and as a result it's harder to find the places they are used by doing a full text search.

We agreed on the convention `_param_{lower case parameter name}` in https://github.com/PX4/PX4-Autopilot/pull/11686 the only thing missing is an automated check to preserve it consistently. Maybe we could add it to the style checks similar to https://github.com/PX4/PX4-Autopilot/pull/23166

### Solution
I quickly fixed up the ones I saw in Commander.

### Changelog Entry
```
Cleanup: internal member names for parameter in Commander
```

### Test coverage
Compiles and I don't see any mistake. Do you?

### Context
Just as reminder why it's useful to have the naming: One full text search shows the parameter definition with metadata, all airframes that set it and with the convention all uses of it in the code.
![image](https://github.com/user-attachments/assets/4e40b7be-bd77-4778-9b8a-023094cd00c3)