### PR TITLE
uXRCE - Allow to set the uORB polling rate per subscription

### DIFF
--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -44,7 +44,7 @@ struct SendSubscription {
 	const char* topic;
 	uint32_t topic_size;
 	UcdrSerializeMethod ucdr_serialize_method;
-	uint16_t max_rate_hz;
+	float max_rate_hz;
 };
 
 // Subscribers for messages to send
@@ -75,7 +75,7 @@ void SendTopicsSubs::init() {
 	for (unsigned idx = 0; idx < sizeof(send_subscriptions)/sizeof(send_subscriptions[0]); ++idx) {
 		fds[idx].fd = orb_subscribe(send_subscriptions[idx].orb_meta);
 		fds[idx].events = POLLIN;
-		orb_set_interval(fds[idx].fd, send_subscriptions[idx].max_rate_hz ? 1000 / send_subscriptions[idx].max_rate_hz : 0);
+		orb_set_interval(fds[idx].fd, send_subscriptions[idx].max_rate_hz > 0 ? 1000 / send_subscriptions[idx].max_rate_hz : 100);
 	}
 }
 

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -75,7 +75,7 @@ void SendTopicsSubs::init() {
 	for (unsigned idx = 0; idx < sizeof(send_subscriptions)/sizeof(send_subscriptions[0]); ++idx) {
 		fds[idx].fd = orb_subscribe(send_subscriptions[idx].orb_meta);
 		fds[idx].events = POLLIN;
-		orb_set_interval(fds[idx].fd, send_subscriptions[idx].max_rate_hz ? 1000000 / send_subscriptions[idx].max_rate_hz : 0);
+		orb_set_interval(fds[idx].fd, send_subscriptions[idx].max_rate_hz ? 1000 / send_subscriptions[idx].max_rate_hz : 0);
 	}
 }
 

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -44,7 +44,7 @@ struct SendSubscription {
 	const char* topic;
 	uint32_t topic_size;
 	UcdrSerializeMethod ucdr_serialize_method;
-	uint16_t polling_interval;
+	uint16_t max_rate_hz;
 };
 
 // Subscribers for messages to send
@@ -57,7 +57,7 @@ struct SendTopicsSubs {
 			  "@(pub['topic'])",
 			  ucdr_topic_size_@(pub['simple_base_type'])(),
 			  &ucdr_serialize_@(pub['simple_base_type']),
-			  @(pub['polling_interval']),
+			  @(pub['max_rate_hz']),
 			},
 @[    end for]@
 	};
@@ -75,7 +75,7 @@ void SendTopicsSubs::init() {
 	for (unsigned idx = 0; idx < sizeof(send_subscriptions)/sizeof(send_subscriptions[0]); ++idx) {
 		fds[idx].fd = orb_subscribe(send_subscriptions[idx].orb_meta);
 		fds[idx].events = POLLIN;
-		orb_set_interval(fds[idx].fd, send_subscriptions[idx].polling_interval);
+		orb_set_interval(fds[idx].fd, send_subscriptions[idx].max_rate_hz ? 1000000 / send_subscriptions[idx].max_rate_hz : 0);
 	}
 }
 

--- a/src/modules/uxrce_dds_client/dds_topics.h.em
+++ b/src/modules/uxrce_dds_client/dds_topics.h.em
@@ -30,8 +30,6 @@ import os
 #include <uORB/topics/@(include).h>
 @[end for]@
 
-#define UXRCE_DEFAULT_POLL_RATE 10
-
 typedef bool (*UcdrSerializeMethod)(const void* data, ucdrBuffer& buf, int64_t time_offset);
 
 static constexpr int max_topic_size = 512;
@@ -46,6 +44,7 @@ struct SendSubscription {
 	const char* topic;
 	uint32_t topic_size;
 	UcdrSerializeMethod ucdr_serialize_method;
+	uint16_t polling_interval;
 };
 
 // Subscribers for messages to send
@@ -58,6 +57,7 @@ struct SendTopicsSubs {
 			  "@(pub['topic'])",
 			  ucdr_topic_size_@(pub['simple_base_type'])(),
 			  &ucdr_serialize_@(pub['simple_base_type']),
+			  @(pub['polling_interval']),
 			},
 @[    end for]@
 	};
@@ -75,7 +75,7 @@ void SendTopicsSubs::init() {
 	for (unsigned idx = 0; idx < sizeof(send_subscriptions)/sizeof(send_subscriptions[0]); ++idx) {
 		fds[idx].fd = orb_subscribe(send_subscriptions[idx].orb_meta);
 		fds[idx].events = POLLIN;
-		orb_set_interval(fds[idx].fd, UXRCE_DEFAULT_POLL_RATE);
+		orb_set_interval(fds[idx].fd, send_subscriptions[idx].polling_interval);
 	}
 }
 

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -37,6 +37,7 @@ publications:
 
   - topic: /fmu/out/sensor_combined
     type: px4_msgs::msg::SensorCombined
+    polling_interval: 1
 
   - topic: /fmu/out/timesync_status
     type: px4_msgs::msg::TimesyncStatus

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -3,7 +3,7 @@
 # This file maps all the topics that are to be used on the uXRCE-DDS client.
 #
 #####
-default_max_rate_hz: 100
+default_max_rate_hz: 100.0
 
 publications:
 
@@ -39,7 +39,7 @@ publications:
 
   - topic: /fmu/out/sensor_combined
     type: px4_msgs::msg::SensorCombined
-    max_rate_hz: 1000
+    max_rate_hz: 1000.0
 
   - topic: /fmu/out/timesync_status
     type: px4_msgs::msg::TimesyncStatus

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -3,6 +3,8 @@
 # This file maps all the topics that are to be used on the uXRCE-DDS client.
 #
 #####
+default_max_rate_hz: 100
+
 publications:
 
   - topic: /fmu/out/register_ext_component_reply

--- a/src/modules/uxrce_dds_client/dds_topics.yaml
+++ b/src/modules/uxrce_dds_client/dds_topics.yaml
@@ -37,7 +37,7 @@ publications:
 
   - topic: /fmu/out/sensor_combined
     type: px4_msgs::msg::SensorCombined
-    polling_interval: 1
+    max_rate_hz: 1000
 
   - topic: /fmu/out/timesync_status
     type: px4_msgs::msg::TimesyncStatus

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -42,7 +42,7 @@ import re
 import em
 import yaml
 
-DEFAULT_POLLING_RATE = 10
+DEFAULT_MAX_RATE_HZ = 100
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-m", "--topic-msg-dir", dest='msgdir', type=str,
@@ -100,10 +100,10 @@ def process_message_type(msg_type):
     msg_type['dds_type'] = msg_type['type'].replace("::msg::", "::msg::dds_::") + "_"
     # topic_simple: eg vehicle_status
     msg_type['topic_simple'] = msg_type['topic'].split('/')[-1]
-    if "polling_interval" not in msg_type:
-        msg_type["polling_interval"] = DEFAULT_POLLING_RATE
+    if "max_rate_hz" not in msg_type:
+        msg_type["max_rate_hz"] = DEFAULT_MAX_RATE_HZ
     else:
-        msg_type["polling_interval"] = int(msg_type["polling_interval"])
+        msg_type["max_rate_hz"] = int(msg_type["max_rate_hz"])
 
 pubs_not_empty = msg_map['publications'] is not None
 if pubs_not_empty:

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -85,10 +85,10 @@ with open(args.yaml_file, 'r') as file:
 merged_em_globals = {}
 all_type_includes = []
 
-if "default_max_rate_hz" not in msg_map:
-    msg_map["default_max_rate_hz"] = 100
+if 'default_max_rate_hz' not in msg_map:
+    msg_map['default_max_rate_hz'] = 100.0
 else:
-    msg_map["default_max_rate_hz"] = int(msg_map["default_max_rate_hz"])
+    msg_map['default_max_rate_hz'] = int(msg_map['default_max_rate_hz'])
 
 def process_message_type(msg_type):
     # eg TrajectoryWaypoint from px4_msgs::msg::TrajectoryWaypoint
@@ -103,16 +103,18 @@ def process_message_type(msg_type):
     msg_type['dds_type'] = msg_type['type'].replace("::msg::", "::msg::dds_::") + "_"
     # topic_simple: eg vehicle_status
     msg_type['topic_simple'] = msg_type['topic'].split('/')[-1]
-    if "max_rate_hz" not in msg_type:
-        msg_type["max_rate_hz"] = msg_map["default_max_rate_hz"]
+    if 'max_rate_hz' not in msg_type:
+        msg_type['max_rate_hz'] = msg_map['default_max_rate_hz']
     else:
-        msg_type["max_rate_hz"] = int(msg_type["max_rate_hz"])
+        msg_type['max_rate_hz'] = float(msg_type['max_rate_hz'])
 
 pubs_not_empty = msg_map['publications'] is not None
 if pubs_not_empty:
     for p in msg_map['publications']:
         process_message_type(p)
 
+# Remove disabled publications
+msg_map['publications'] = list(filter(lambda x: x['max_rate_hz'] > 0, msg_map['publications']))
 merged_em_globals['publications'] = msg_map['publications'] if pubs_not_empty else []
 
 subs_not_empty = msg_map['subscriptions'] is not None

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -42,8 +42,6 @@ import re
 import em
 import yaml
 
-DEFAULT_MAX_RATE_HZ = 100
-
 parser = argparse.ArgumentParser()
 parser.add_argument("-m", "--topic-msg-dir", dest='msgdir', type=str,
                     help="Topics message, by default using relative path 'msg/'", default="msg")
@@ -87,6 +85,11 @@ with open(args.yaml_file, 'r') as file:
 merged_em_globals = {}
 all_type_includes = []
 
+if "default_max_rate_hz" not in msg_map:
+    msg_map["default_max_rate_hz"] = 100
+else:
+    msg_map["default_max_rate_hz"] = int(msg_map["default_max_rate_hz"])
+
 def process_message_type(msg_type):
     # eg TrajectoryWaypoint from px4_msgs::msg::TrajectoryWaypoint
     simple_base_type = msg_type['type'].split('::')[-1]
@@ -101,7 +104,7 @@ def process_message_type(msg_type):
     # topic_simple: eg vehicle_status
     msg_type['topic_simple'] = msg_type['topic'].split('/')[-1]
     if "max_rate_hz" not in msg_type:
-        msg_type["max_rate_hz"] = DEFAULT_MAX_RATE_HZ
+        msg_type["max_rate_hz"] = msg_map["default_max_rate_hz"]
     else:
         msg_type["max_rate_hz"] = int(msg_type["max_rate_hz"])
 

--- a/src/modules/uxrce_dds_client/generate_dds_topics.py
+++ b/src/modules/uxrce_dds_client/generate_dds_topics.py
@@ -42,6 +42,8 @@ import re
 import em
 import yaml
 
+DEFAULT_POLLING_RATE = 10
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-m", "--topic-msg-dir", dest='msgdir', type=str,
                     help="Topics message, by default using relative path 'msg/'", default="msg")
@@ -98,6 +100,10 @@ def process_message_type(msg_type):
     msg_type['dds_type'] = msg_type['type'].replace("::msg::", "::msg::dds_::") + "_"
     # topic_simple: eg vehicle_status
     msg_type['topic_simple'] = msg_type['topic'].split('/')[-1]
+    if "polling_interval" not in msg_type:
+        msg_type["polling_interval"] = DEFAULT_POLLING_RATE
+    else:
+        msg_type["polling_interval"] = int(msg_type["polling_interval"])
 
 pubs_not_empty = msg_map['publications'] is not None
 if pubs_not_empty:


### PR DESCRIPTION
### Solved Problem

Having a configurable polling rate can have 2 usages:
- Increase the polling interval for rate limiting of uORB message
- Decrease the polling interface for reducing the latency of critical topics

The main issue with latency is if we have a 100Hz topic with a 10ms interface, which means we will get a systematic delay between [0-10ms] which is different for each run.

This is especially important to have little/limited delays when using external control modes such as with [Auterion/px4-ros2-interface-lib](https://github.com/Auterion/px4-ros2-interface-lib)

### Solution
- Add an optional `max_rate_hz` parameter to the `dds_topics.yaml` file
- Moved the optional `default_max_rate_hz` parameter to the `dds_topics.yaml` file or set it to 100
- Use the new `max_rate_hz` parameter or the default rate

### Changelog Entry
For release notes:
```
Feature/Add the max frequency per subscription for uXRCE
New parameter: `max_rate_hz` in `dds_topics.yaml` to set the uORB subscription maximal data frequency.
New parameter: `default_max_rate_hz` in `dds_topics.yaml` 
Higher frequency (1000Hz) on a lower frequency channel (100Hz) will reduce latencies. 
A max frequency of `0 Hz` means `unlimited`. 
```

### Alternatives
We could make the default interval as a PX4 parameter, but that impacts every topic. Not all topics needs a low polling interval.

Closes: https://github.com/PX4/PX4-Autopilot/pull/21716
Closes: https://github.com/PX4/PX4-Autopilot/pull/21997