### PR TITLE
EKF2 global position validity

### DIFF
--- a/msg/VehicleGlobalPosition.msg
+++ b/msg/VehicleGlobalPosition.msg
@@ -13,6 +13,10 @@ float64 lon			# Longitude, (degrees)
 float32 alt			# Altitude AMSL, (meters)
 float32 alt_ellipsoid		# Altitude above ellipsoid, (meters)
 
+bool lat_lon_valid
+bool alt_valid
+bool alt_ellipsoid_valid
+
 float32 delta_alt 	# Reset delta for altitude
 float32 delta_terrain   # Reset delta for terrain
 uint8 lat_lon_reset_counter	# Counter for reset events on horizontal position coordinates

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -745,7 +745,7 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 	}
 
 	failsafe_flags.global_position_invalid =
-		!checkPosVelValidity(now, xy_valid, gpos.eph, lpos_eph_threshold, gpos.timestamp,
+		!checkPosVelValidity(now, gpos.lat_lon_valid, gpos.eph, lpos_eph_threshold, gpos.timestamp,
 				     _last_gpos_fail_time_us, !failsafe_flags.global_position_invalid);
 
 	// Additional warning if the system is about to enter position-loss failsafe after dead-reckoning period

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -533,19 +533,6 @@ void EstimatorChecks::checkEstimatorStatusFlags(const Context &context, Report &
 	estimator_status_flags_s estimator_status_flags;
 
 	if (_estimator_status_flags_sub.copy(&estimator_status_flags)) {
-
-		bool dead_reckoning = estimator_status_flags.cs_wind_dead_reckoning
-				      || estimator_status_flags.cs_inertial_dead_reckoning;
-
-		if (!dead_reckoning) {
-			// position requirements (update if not dead reckoning)
-			bool gps             = estimator_status_flags.cs_gps;
-			bool optical_flow    = estimator_status_flags.cs_opt_flow;
-			bool vision_position = estimator_status_flags.cs_ev_pos;
-
-			_position_reliant_on_optical_flow = !gps && optical_flow && !vision_position;
-		}
-
 		// Check for a magnetometer fault and notify the user
 		if (estimator_status_flags.cs_mag_fault) {
 			/* EVENT
@@ -722,15 +709,6 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 	// Check if quality checking of position accuracy and consistency is to be performed
 	const float lpos_eph_threshold = (_param_com_pos_fs_eph.get() < 0) ? INFINITY : _param_com_pos_fs_eph.get();
 
-	float lpos_eph_threshold_relaxed = lpos_eph_threshold;
-
-	// Set the allowable position uncertainty based on combination of flight and estimator state
-	// When we are in a operator demanded position control mode and are solely reliant on optical flow,
-	// do not check position error because it will gradually increase throughout flight and the operator will compensate for the drift
-	if (_position_reliant_on_optical_flow) {
-		lpos_eph_threshold_relaxed = INFINITY;
-	}
-
 	bool xy_valid = lpos.xy_valid && !_nav_test_failed;
 	bool v_xy_valid = lpos.v_xy_valid && !_nav_test_failed;
 
@@ -792,6 +770,10 @@ void EstimatorChecks::setModeRequirementFlags(const Context &context, bool pre_f
 	failsafe_flags.local_position_invalid =
 		!checkPosVelValidity(now, xy_valid, lpos.eph, lpos_eph_threshold, lpos.timestamp,
 				     _last_lpos_fail_time_us, !failsafe_flags.local_position_invalid);
+
+
+	// In some modes we assume that the operator will compensate for the drift so we do not need to check the position error
+	const float lpos_eph_threshold_relaxed = INFINITY;
 
 	failsafe_flags.local_position_invalid_relaxed =
 		!checkPosVelValidity(now, xy_valid, lpos.eph, lpos_eph_threshold_relaxed, lpos.timestamp,

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -100,8 +100,6 @@ private:
 	bool		_nav_test_passed{false};	///< true if the post takeoff navigation test has passed
 	bool		_nav_test_failed{false};	///< true if the post takeoff navigation test has failed
 
-	bool _position_reliant_on_optical_flow{false};
-
 	bool _gps_was_fused{false};
 	bool _gnss_spoofed{false};
 

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -82,11 +82,6 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_manual_control);
 
-	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
-		setRequirement(vehicle_status_s::NAVIGATION_STATE_POSCTL, flags.mode_req_global_position);
-		setRequirement(vehicle_status_s::NAVIGATION_STATE_POSITION_SLOW, flags.mode_req_global_position);
-	}
-
 	// NAVIGATION_STATE_AUTO_MISSION
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION, flags.mode_req_attitude);

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -142,12 +142,20 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_alt);
 
+	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_global_position);
+	}
+
 	// NAVIGATION_STATE_AUTO_LAND
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_attitude);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_alt);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_prevent_arming);
+
+	if (vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+		setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_global_position);
+	}
 
 	// NAVIGATION_STATE_AUTO_FOLLOW_TARGET
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET, flags.mode_req_angular_velocity);

--- a/src/modules/commander/ModeUtil/mode_requirements.cpp
+++ b/src/modules/commander/ModeUtil/mode_requirements.cpp
@@ -139,14 +139,14 @@ void getModeRequirements(uint8_t vehicle_type, failsafe_flags_s &flags)
 	// NAVIGATION_STATE_AUTO_TAKEOFF
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_attitude);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF, flags.mode_req_local_alt);
 
 	// NAVIGATION_STATE_AUTO_LAND
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_angular_velocity);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_attitude);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_alt);
-	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position);
+	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_local_position_relaxed);
 	setRequirement(vehicle_status_s::NAVIGATION_STATE_AUTO_LAND, flags.mode_req_prevent_arming);
 
 	// NAVIGATION_STATE_AUTO_FOLLOW_TARGET

--- a/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp
@@ -107,7 +107,13 @@ void AuxGlobalPosition::update(Ekf &ekf, const estimator::imuSample &imu_delayed
 				_state = State::starting;
 
 				if (ekf.global_origin_valid()) {
+					if (aid_src.innovation_rejected) {
+						ekf.resetHorizontalPositionTo(Vector2f(aid_src.observation), Vector2f(aid_src.observation_variance));
+						ekf.resetAidSourceStatusZeroInnovation(aid_src);
+					}
+
 					ekf.enableControlStatusAuxGpos();
+					ekf.setNedOriginInitialised();
 					_reset_counters.lat_lon = sample.lat_lon_reset_counter;
 					_state = State::active;
 

--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -199,7 +199,7 @@ void Ekf::stopBaroHgtFusion()
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
 float Ekf::compensateBaroForDynamicPressure(const imuSample &imu_sample, const float baro_alt_uncompensated) const
 {
-	if (_control_status.flags.wind && local_position_is_valid()) {
+	if (_control_status.flags.wind && isLocalHorizontalPositionValid()) {
 		// calculate static pressure error = Pmeas - Ptruth
 		// model position error sensitivity as a body fixed ellipse with a different scale in the positive and
 		// negative X and Y directions. Used to correct baro data for positional errors

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -87,7 +87,7 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 		// determine if we should use height aiding
 		const bool continuing_conditions_passing = (_params.gnss_ctrl & static_cast<int32_t>(GnssCtrl::VPOS))
 				&& measurement_valid
-				&& _NED_origin_initialised
+				&& _pos_ref.isInitialized()
 				&& _gps_checks_passed;
 
 		const bool starting_conditions_passing = continuing_conditions_passing

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -87,7 +87,7 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 		// determine if we should use height aiding
 		const bool continuing_conditions_passing = (_params.gnss_ctrl & static_cast<int32_t>(GnssCtrl::VPOS))
 				&& measurement_valid
-				&& _pos_ref.isInitialized()
+				&& _ned_global_ref.isInitialized()
 				&& _gps_checks_passed;
 
 		const bool starting_conditions_passing = continuing_conditions_passing

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_checks.cpp
@@ -61,29 +61,26 @@
 
 void Ekf::collect_gps(const gnssSample &gps)
 {
-	if (_filter_initialised && !_NED_origin_initialised && _gps_checks_passed) {
+	if (_filter_initialised && !_pos_ref.isInitialized() && _gps_checks_passed) {
 		// If we have good GPS data set the origin's WGS-84 position to the last gps fix
 		const double lat = gps.lat;
 		const double lon = gps.lon;
 
-		if (!_pos_ref.isInitialized()) {
-			_pos_ref.initReference(lat, lon, gps.time_us);
+		_pos_ref.initReference(lat, lon, gps.time_us);
 
-			// if we are already doing aiding, correct for the change in position since the EKF started navigating
-			if (isHorizontalAidingActive()) {
-				double est_lat;
-				double est_lon;
-				_pos_ref.reproject(-_state.pos(0), -_state.pos(1), est_lat, est_lon);
-				_pos_ref.initReference(est_lat, est_lon, gps.time_us);
-			}
+		// if we are already doing aiding, correct for the change in position since the EKF started navigating
+		if (isHorizontalAidingActive()) {
+			double est_lat;
+			double est_lon;
+			_pos_ref.reproject(-_state.pos(0), -_state.pos(1), est_lat, est_lon);
+			_pos_ref.initReference(est_lat, est_lon, gps.time_us);
+			_NED_origin_initialised = true;
 		}
 
 		// Take the current GPS height and subtract the filter height above origin to estimate the GPS height of the origin
 		if (!PX4_ISFINITE(_gps_alt_ref)) {
 			_gps_alt_ref = gps.alt + _state.pos(2);
 		}
-
-		_NED_origin_initialised = true;
 
 		// save the horizontal and vertical position uncertainty of the origin
 		_gpos_origin_eph = gps.hacc;
@@ -97,7 +94,7 @@ void Ekf::collect_gps(const gnssSample &gps)
 		// a rough 2D fix is sufficient to lookup declination
 		const bool gps_rough_2d_fix = (gps.fix_type >= 2) && (gps.hacc < 1000);
 
-		if (gps_rough_2d_fix && (_gps_checks_passed || !_NED_origin_initialised)) {
+		if (gps_rough_2d_fix && (_gps_checks_passed || !_pos_ref.isInitialized())) {
 
 			// If we have good GPS data set the origin's WGS-84 position to the last gps fix
 #if defined(CONFIG_EKF2_MAGNETOMETER)

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -109,7 +109,7 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 		const bool continuing_conditions_passing = (gnss_vel_enabled || gnss_pos_enabled)
 				&& _control_status.flags.tilt_align
 				&& _control_status.flags.yaw_align
-				&& _NED_origin_initialised;
+				&& _pos_ref.isInitialized();
 		const bool starting_conditions_passing = continuing_conditions_passing && _gps_checks_passed;
 
 		if (_control_status.flags.gps) {
@@ -318,6 +318,7 @@ void Ekf::resetHorizontalPositionToGnss(estimator_aid_source2d_s &aid_src)
 	_information_events.flags.reset_pos_to_gps = true;
 	resetHorizontalPositionTo(Vector2f(aid_src.observation), Vector2f(aid_src.observation_variance));
 	_gpos_origin_eph = 0.f; // The uncertainty of the global origin is now contained in the local position uncertainty
+	_NED_origin_initialised = true;
 
 	resetAidSourceStatusZeroInnovation(aid_src);
 }

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gps_control.cpp
@@ -82,7 +82,7 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 			}
 		}
 
-		if (_pos_ref.isInitialized()) {
+		if (_ned_global_ref.isInitialized()) {
 			updateGnssPos(gnss_sample, _aid_src_gnss_pos);
 		}
 
@@ -109,7 +109,7 @@ void Ekf::controlGpsFusion(const imuSample &imu_delayed)
 		const bool continuing_conditions_passing = (gnss_vel_enabled || gnss_pos_enabled)
 				&& _control_status.flags.tilt_align
 				&& _control_status.flags.yaw_align
-				&& _pos_ref.isInitialized();
+				&& _ned_global_ref.isInitialized();
 		const bool starting_conditions_passing = continuing_conditions_passing && _gps_checks_passed;
 
 		if (_control_status.flags.gps) {
@@ -216,7 +216,7 @@ void Ekf::updateGnssPos(const gnssSample &gnss_sample, estimator_aid_source2d_s 
 	// correct position and height for offset relative to IMU
 	const Vector3f pos_offset_body = _params.gps_pos_body - _params.imu_pos_body;
 	const Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
-	const Vector2f position = _pos_ref.project(gnss_sample.lat, gnss_sample.lon) - pos_offset_earth.xy();
+	const Vector2f position = _ned_global_ref.project(gnss_sample.lat, gnss_sample.lon) - pos_offset_earth.xy();
 
 	// relax the upper observation noise limit which prevents bad GPS perturbing the position estimate
 	float pos_noise = math::max(gnss_sample.hacc, _params.gps_pos_noise);
@@ -318,7 +318,7 @@ void Ekf::resetHorizontalPositionToGnss(estimator_aid_source2d_s &aid_src)
 	_information_events.flags.reset_pos_to_gps = true;
 	resetHorizontalPositionTo(Vector2f(aid_src.observation), Vector2f(aid_src.observation_variance));
 	_gpos_origin_eph = 0.f; // The uncertainty of the global origin is now contained in the local position uncertainty
-	_NED_origin_initialised = true;
+	_ned_global_ref_valid = true;
 
 	resetAidSourceStatusZeroInnovation(aid_src);
 }

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -163,4 +163,10 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 
 	// check if we are no longer fusing measurements that directly constrain velocity drift
 	updateDeadReckoningStatus();
+
+	if (!local_position_is_valid()) {
+		_NED_origin_initialised = false;
+		_gpos_origin_eph = INFINITY;
+		_gpos_origin_epv = INFINITY;
+	}
 }

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -164,7 +164,7 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 	// check if we are no longer fusing measurements that directly constrain velocity drift
 	updateDeadReckoningStatus();
 
-	if (!local_position_is_valid()) {
+	if (!isLocalHorizontalPositionValid()) {
 		_NED_origin_initialised = false;
 		_gpos_origin_eph = INFINITY;
 		_gpos_origin_epv = INFINITY;

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -165,7 +165,7 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 	updateDeadReckoningStatus();
 
 	if (!isLocalHorizontalPositionValid()) {
-		_NED_origin_initialised = false;
+		_ned_global_ref_valid = false;
 		_gpos_origin_eph = INFINITY;
 		_gpos_origin_epv = INFINITY;
 	}

--- a/src/modules/ekf2/EKF/ekf.cpp
+++ b/src/modules/ekf2/EKF/ekf.cpp
@@ -279,12 +279,12 @@ void Ekf::predictState(const imuSample &imu_delayed)
 bool Ekf::resetGlobalPosToExternalObservation(double lat_deg, double lon_deg, float accuracy,
 		uint64_t timestamp_observation)
 {
-	if (!_pos_ref.isInitialized()) {
+	if (!_ned_global_ref.isInitialized()) {
 		ECL_WARN("unable to reset global position, position reference not initialized");
 		return false;
 	}
 
-	Vector2f pos_corrected = _pos_ref.project(lat_deg, lon_deg);
+	Vector2f pos_corrected = _ned_global_ref.project(lat_deg, lon_deg);
 
 	// apply a first order correction using velocity at the delayed time horizon and the delta time
 	if ((timestamp_observation > 0) && (isHorizontalAidingActive() || !_horizontal_deadreckon_time_exceeded)) {

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -284,12 +284,12 @@ public:
 
 	bool isGlobalHorizontalPositionValid() const
 	{
-		return (_NED_origin_initialised && isLocalHorizontalPositionValid());
+		return _ned_global_ref_valid && isLocalHorizontalPositionValid();
 	}
 
 	bool isGlobalVerticalPositionValid() const
 	{
-		return _NED_origin_initialised && isLocalVerticalPositionValid();
+		return _ned_global_ref_valid && isLocalVerticalPositionValid();
 	}
 
 	bool isLocalHorizontalPositionValid() const

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -282,16 +282,17 @@ public:
 	void resetAccelBias();
 	void resetAccelBiasCov();
 
-	// return true if the global position estimate is valid
-	// return true if the origin is set we are not doing unconstrained free inertial navigation
-	// and have not started using synthetic position observations to constrain drift
-	bool global_position_is_valid() const
+	bool isGlobalHorizontalPositionValid() const
 	{
-		return (_NED_origin_initialised && local_position_is_valid());
+		return (_NED_origin_initialised && isLocalHorizontalPositionValid());
 	}
 
-	// return true if the local position estimate is valid
-	bool local_position_is_valid() const
+	bool isGlobalVerticalPositionValid() const
+	{
+		return _NED_origin_initialised && isLocalVerticalPositionValid();
+	}
+
+	bool isLocalHorizontalPositionValid() const
 	{
 		return (!_horizontal_deadreckon_time_exceeded && !_control_status.flags.fake_pos);
 	}

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -294,17 +294,17 @@ public:
 
 	bool isLocalHorizontalPositionValid() const
 	{
-		return (!_horizontal_deadreckon_time_exceeded && !_control_status.flags.fake_pos);
+		return !_horizontal_deadreckon_time_exceeded;
 	}
 
 	bool isLocalVerticalPositionValid() const
 	{
-		return !_vertical_position_deadreckon_time_exceeded && !_control_status.flags.fake_hgt;
+		return !_vertical_position_deadreckon_time_exceeded;
 	}
 
 	bool isLocalVerticalVelocityValid() const
 	{
-		return !_vertical_velocity_deadreckon_time_exceeded && !_control_status.flags.fake_hgt;
+		return !_vertical_velocity_deadreckon_time_exceeded;
 	}
 
 	bool isYawFinalAlignComplete() const

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -777,7 +777,6 @@ void Ekf::updateHorizontalDeadReckoningstatus()
 
 	if (inertial_dead_reckoning) {
 		if (isTimedOut(_time_last_horizontal_aiding, (uint64_t)_params.valid_timeout_max)) {
-			// deadreckon time exceeded
 			if (!_horizontal_deadreckon_time_exceeded) {
 				ECL_WARN("horizontal dead reckon time exceeded");
 				_horizontal_deadreckon_time_exceeded = true;

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -604,19 +604,19 @@ uint16_t Ekf::get_ekf_soln_status() const
 	soln_status.flags.attitude = attitude_valid();
 
 	// 2	ESTIMATOR_VELOCITY_HORIZ	True if the horizontal velocity estimate is good
-	soln_status.flags.velocity_horiz = local_position_is_valid();
+	soln_status.flags.velocity_horiz = isLocalHorizontalPositionValid();
 
 	// 4	ESTIMATOR_VELOCITY_VERT	True if the vertical velocity estimate is good
 	soln_status.flags.velocity_vert = isLocalVerticalVelocityValid() || isLocalVerticalPositionValid();
 
 	// 8	ESTIMATOR_POS_HORIZ_REL	True if the horizontal position (relative) estimate is good
-	soln_status.flags.pos_horiz_rel = local_position_is_valid();
+	soln_status.flags.pos_horiz_rel = isLocalHorizontalPositionValid();
 
 	// 16	ESTIMATOR_POS_HORIZ_ABS	True if the horizontal position (absolute) estimate is good
-	soln_status.flags.pos_horiz_abs = global_position_is_valid();
+	soln_status.flags.pos_horiz_abs = isGlobalHorizontalPositionValid();
 
 	// 32	ESTIMATOR_POS_VERT_ABS	True if the vertical position (absolute) estimate is good
-	soln_status.flags.pos_vert_abs = isVerticalAidingActive();
+	soln_status.flags.pos_vert_abs = isGlobalVerticalPositionValid();
 
 	// 64	ESTIMATOR_POS_VERT_AGL	True if the vertical position (above ground) estimate is good
 #if defined(CONFIG_EKF2_TERRAIN)

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -65,11 +65,11 @@ Vector3f Ekf::calcEarthRateNED(float lat_rad) const
 
 bool Ekf::getEkfGlobalOrigin(uint64_t &origin_time, double &latitude, double &longitude, float &origin_alt) const
 {
-	origin_time = _pos_ref.getProjectionReferenceTimestamp();
-	latitude = _pos_ref.getProjectionReferenceLat();
-	longitude = _pos_ref.getProjectionReferenceLon();
+	origin_time = _ned_global_ref.getProjectionReferenceTimestamp();
+	latitude = _ned_global_ref.getProjectionReferenceLat();
+	longitude = _ned_global_ref.getProjectionReferenceLon();
 	origin_alt  = getEkfGlobalOriginAltitude();
-	return _pos_ref.isInitialized();
+	return _ned_global_ref.isInitialized();
 }
 
 bool Ekf::setEkfGlobalOrigin(const double latitude, const double longitude, const float altitude, const float eph,
@@ -85,15 +85,15 @@ bool Ekf::setEkfGlobalOrigin(const double latitude, const double longitude, cons
 		double current_lon = static_cast<double>(NAN);
 
 		// if we are already doing aiding, correct for the change in position since the EKF started navigating
-		if (_pos_ref.isInitialized() && isHorizontalAidingActive()) {
-			_pos_ref.reproject(_state.pos(0), _state.pos(1), current_lat, current_lon);
+		if (_ned_global_ref.isInitialized() && isGlobalHorizontalPositionValid()) {
+			_ned_global_ref.reproject(_state.pos(0), _state.pos(1), current_lat, current_lon);
 			current_gpos_available = true;
 		}
 
 		const float gps_alt_ref_prev = _gps_alt_ref;
 
 		// reinitialize map projection to latitude, longitude, altitude, and reset position
-		_pos_ref.initReference(latitude, longitude, _time_delayed_us);
+		_ned_global_ref.initReference(latitude, longitude, _time_delayed_us);
 		_gps_alt_ref = altitude;
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
@@ -115,16 +115,16 @@ bool Ekf::setEkfGlobalOrigin(const double latitude, const double longitude, cons
 		_gpos_origin_epv = epv;
 
 		if (current_gpos_available) {
-			// reset horizontal position if we already have a global origin
-			Vector2f position = _pos_ref.project(current_lat, current_lon);
+			// reset horizontal position if we already have a global reference
+			Vector2f position = _ned_global_ref.project(current_lat, current_lon);
 			resetHorizontalPositionTo(position);
-			_NED_origin_initialised = true;
+			_ned_global_ref_valid = true;
 
-		} else if (isHorizontalAidingActive()) {
-			_NED_origin_initialised = true;
+		} else if (isLocalHorizontalPositionValid()) {
+			_ned_global_ref_valid = true;
 		}
 
-		if (PX4_ISFINITE(gps_alt_ref_prev) && isVerticalPositionAidingActive()) {
+		if (PX4_ISFINITE(gps_alt_ref_prev) && isGlobalVerticalPositionValid()) {
 			// determine current z
 			const float z_prev = _state.pos(2);
 			const float current_alt = -z_prev + gps_alt_ref_prev;
@@ -151,7 +151,7 @@ void Ekf::get_ekf_gpos_accuracy(float *ekf_eph, float *ekf_epv) const
 	float eph = INFINITY;
 	float epv = INFINITY;
 
-	if (global_origin_valid()) {
+	if (_ned_global_ref_valid) {
 		// report absolute accuracy taking into account the uncertainty in location of the origin
 		eph = sqrtf(P.trace<2>(State::pos.idx + 0) + sq(_gpos_origin_eph));
 		epv = sqrtf(P.trace<1>(State::pos.idx + 2) + sq(_gpos_origin_epv));

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -247,7 +247,7 @@ public:
 	// At the next startup, set param.mag_declination_deg to the value saved
 	bool get_mag_decl_deg(float &val) const
 	{
-		if (_pos_ref.isInitialized() && (_params.mag_declination_source & GeoDeclinationMask::SAVE_GEO_DECL)) {
+		if (_ned_global_ref.isInitialized() && (_params.mag_declination_source & GeoDeclinationMask::SAVE_GEO_DECL)) {
 			val = math::degrees(_mag_declination_gps);
 			return true;
 
@@ -258,7 +258,7 @@ public:
 
 	bool get_mag_inc_deg(float &val) const
 	{
-		if (_pos_ref.isInitialized()) {
+		if (_ned_global_ref.isInitialized()) {
 			val = math::degrees(_mag_inclination_gps);
 			return true;
 
@@ -304,9 +304,8 @@ public:
 	const imuSample &get_imu_sample_delayed() const { return _imu_buffer.get_oldest(); }
 	const uint64_t &time_delayed_us() const { return _time_delayed_us; }
 
-	bool global_origin_valid() const { return _pos_ref.isInitialized(); }
-	void setNedOriginInitialised() { _NED_origin_initialised = true; }
-	const MapProjection &global_origin() const { return _pos_ref; }
+	void setNedGlobalRefValid() { _ned_global_ref_valid = true; }
+	const MapProjection &getNedGlobalRef() const { return _ned_global_ref; }
 	float getEkfGlobalOriginAltitude() const { return PX4_ISFINITE(_gps_alt_ref) ? _gps_alt_ref : 0.f; }
 
 	OutputPredictor &output_predictor() { return _output_predictor; };
@@ -377,8 +376,8 @@ protected:
 	bool _initialised{false};      // true if the ekf interface instance (data buffering) is initialized
 
 	// Variables used to publish the WGS-84 location of the EKF local NED origin
-	bool _NED_origin_initialised{false};
-	MapProjection _pos_ref{}; // Contains WGS-84 position latitude and longitude of the EKF origin
+	bool _ned_global_ref_valid{false};
+	MapProjection _ned_global_ref{}; // Contains WGS-84 position latitude and longitude of the EKF origin
 	float _gps_alt_ref{NAN};		///< WGS-84 height (m)
 	float _gpos_origin_eph{0.0f}; // horizontal position uncertainty of the global origin
 	float _gpos_origin_epv{0.0f}; // vertical position uncertainty of the global origin

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -247,7 +247,7 @@ public:
 	// At the next startup, set param.mag_declination_deg to the value saved
 	bool get_mag_decl_deg(float &val) const
 	{
-		if (_NED_origin_initialised && (_params.mag_declination_source & GeoDeclinationMask::SAVE_GEO_DECL)) {
+		if (_pos_ref.isInitialized() && (_params.mag_declination_source & GeoDeclinationMask::SAVE_GEO_DECL)) {
 			val = math::degrees(_mag_declination_gps);
 			return true;
 
@@ -258,7 +258,7 @@ public:
 
 	bool get_mag_inc_deg(float &val) const
 	{
-		if (_NED_origin_initialised) {
+		if (_pos_ref.isInitialized()) {
 			val = math::degrees(_mag_inclination_gps);
 			return true;
 
@@ -304,7 +304,8 @@ public:
 	const imuSample &get_imu_sample_delayed() const { return _imu_buffer.get_oldest(); }
 	const uint64_t &time_delayed_us() const { return _time_delayed_us; }
 
-	const bool &global_origin_valid() const { return _NED_origin_initialised; }
+	bool global_origin_valid() const { return _pos_ref.isInitialized(); }
+	void setNedOriginInitialised() { _NED_origin_initialised = true; }
 	const MapProjection &global_origin() const { return _pos_ref; }
 	float getEkfGlobalOriginAltitude() const { return PX4_ISFINITE(_gps_alt_ref) ? _gps_alt_ref : 0.f; }
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -1166,7 +1166,7 @@ void EKF2::PublishGlobalPosition(const hrt_abstime &timestamp)
 	global_pos.timestamp_sample = timestamp;
 
 	// Position of local NED origin in GPS / WGS84 frame
-	_ekf.global_origin().reproject(position(0), position(1), global_pos.lat, global_pos.lon);
+	_ekf.getNedGlobalRef().reproject(position(0), position(1), global_pos.lat, global_pos.lon);
 	global_pos.lat_lon_valid = _ekf.isGlobalHorizontalPositionValid();
 
 	global_pos.alt = -position(2) + _ekf.getEkfGlobalOriginAltitude(); // Altitude AMSL in meters
@@ -1561,13 +1561,14 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 	lpos.v_z_valid = _ekf.isLocalVerticalVelocityValid() || _ekf.isLocalVerticalPositionValid();
 
 	// Position of local NED origin in GPS / WGS84 frame
-	if (_ekf.global_origin_valid()) {
-		lpos.ref_timestamp = _ekf.global_origin().getProjectionReferenceTimestamp();
-		lpos.ref_lat = _ekf.global_origin().getProjectionReferenceLat(); // Reference point latitude in degrees
-		lpos.ref_lon = _ekf.global_origin().getProjectionReferenceLon(); // Reference point longitude in degrees
+	if (_ekf.getNedGlobalRef().isInitialized()) {
+		lpos.ref_timestamp = _ekf.getNedGlobalRef().getProjectionReferenceTimestamp();
+		lpos.ref_lat = _ekf.getNedGlobalRef().getProjectionReferenceLat(); // Reference point latitude in degrees
+		lpos.ref_lon = _ekf.getNedGlobalRef().getProjectionReferenceLon(); // Reference point longitude in degrees
 		lpos.ref_alt = _ekf.getEkfGlobalOriginAltitude();           // Reference point in MSL altitude meters
-		lpos.xy_global = true;
-		lpos.z_global = true;
+
+		lpos.xy_global = _ekf.isGlobalHorizontalPositionValid();
+		lpos.z_global = _ekf.isGlobalVerticalPositionValid();
 
 	} else {
 		lpos.ref_timestamp = 0;

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -415,7 +415,7 @@ int EKF2::print_status(bool verbose)
 {
 	PX4_INFO_RAW("ekf2:%d EKF dt: %.4fs, attitude: %d, local position: %d, global position: %d\n",
 		     _instance, (double)_ekf.get_dt_ekf_avg(), _ekf.attitude_valid(),
-		     _ekf.local_position_is_valid(), _ekf.global_position_is_valid());
+		     _ekf.isLocalHorizontalPositionValid(), _ekf.isGlobalHorizontalPositionValid());
 
 	perf_print_counter(_ekf_update_perf);
 	perf_print_counter(_msg_missed_imu_perf);
@@ -1159,61 +1159,54 @@ void EKF2::PublishEventFlags(const hrt_abstime &timestamp)
 
 void EKF2::PublishGlobalPosition(const hrt_abstime &timestamp)
 {
-	if (_ekf.global_position_is_valid()) {
-		const Vector3f position{_ekf.getPosition()};
+	const Vector3f position{_ekf.getPosition()};
 
-		// generate and publish global position data
-		vehicle_global_position_s global_pos{};
-		global_pos.timestamp_sample = timestamp;
+	// generate and publish global position data
+	vehicle_global_position_s global_pos{};
+	global_pos.timestamp_sample = timestamp;
 
-		// Position of local NED origin in GPS / WGS84 frame
-		_ekf.global_origin().reproject(position(0), position(1), global_pos.lat, global_pos.lon);
+	// Position of local NED origin in GPS / WGS84 frame
+	_ekf.global_origin().reproject(position(0), position(1), global_pos.lat, global_pos.lon);
+	global_pos.lat_lon_valid = _ekf.isGlobalHorizontalPositionValid();
 
-		global_pos.alt = -position(2) + _ekf.getEkfGlobalOriginAltitude(); // Altitude AMSL in meters
+	global_pos.alt = -position(2) + _ekf.getEkfGlobalOriginAltitude(); // Altitude AMSL in meters
+	global_pos.alt_valid = _ekf.isGlobalVerticalPositionValid();
+
 #if defined(CONFIG_EKF2_GNSS)
-		global_pos.alt_ellipsoid = filter_altitude_ellipsoid(global_pos.alt);
-#else
-		global_pos.alt_ellipsoid = global_pos.alt;
+	global_pos.alt_ellipsoid = filter_altitude_ellipsoid(global_pos.alt);
+	global_pos.alt_ellipsoid_valid = _ekf.isGlobalVerticalPositionValid();
 #endif
 
-		// delta_alt, alt_reset_counter
-		//  global altitude has opposite sign of local down position
-		float delta_z = 0.f;
-		uint8_t z_reset_counter = 0;
-		_ekf.get_posD_reset(&delta_z, &z_reset_counter);
-		global_pos.delta_alt = -delta_z;
-		global_pos.alt_reset_counter = z_reset_counter;
+	// global altitude has opposite sign of local down position
+	float delta_z = 0.f;
+	uint8_t z_reset_counter = 0;
+	_ekf.get_posD_reset(&delta_z, &z_reset_counter);
+	global_pos.delta_alt = -delta_z;
+	global_pos.alt_reset_counter = z_reset_counter;
 
-		// lat_lon_reset_counter
-		float delta_xy[2] {};
-		uint8_t xy_reset_counter = 0;
-		_ekf.get_posNE_reset(delta_xy, &xy_reset_counter);
-		global_pos.lat_lon_reset_counter = xy_reset_counter;
+	float delta_xy[2] {};
+	uint8_t xy_reset_counter = 0;
+	_ekf.get_posNE_reset(delta_xy, &xy_reset_counter);
+	global_pos.lat_lon_reset_counter = xy_reset_counter;
 
-		_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv);
-
-		global_pos.terrain_alt = NAN;
-		global_pos.terrain_alt_valid = false;
+	_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv);
 
 #if defined(CONFIG_EKF2_TERRAIN)
 
-		if (_ekf.isTerrainEstimateValid()) {
-			// Terrain altitude in m, WGS84
-			global_pos.terrain_alt = _ekf.getEkfGlobalOriginAltitude() - _ekf.getTerrainVertPos();
-			global_pos.terrain_alt_valid = true;
-		}
+	// Terrain altitude in m, WGS84
+	global_pos.terrain_alt = _ekf.getEkfGlobalOriginAltitude() - _ekf.getTerrainVertPos();
+	global_pos.terrain_alt_valid = _ekf.isTerrainEstimateValid();
 
-		float delta_hagl = 0.f;
-		_ekf.get_hagl_reset(&delta_hagl, &global_pos.terrain_reset_counter);
-		global_pos.delta_terrain = -delta_z;
+	float delta_hagl = 0.f;
+	_ekf.get_hagl_reset(&delta_hagl, &global_pos.terrain_reset_counter);
+	global_pos.delta_terrain = -delta_z;
 #endif // CONFIG_EKF2_TERRAIN
 
-		global_pos.dead_reckoning = _ekf.control_status_flags().inertial_dead_reckoning
-					    || _ekf.control_status_flags().wind_dead_reckoning;
+	global_pos.dead_reckoning = _ekf.control_status_flags().inertial_dead_reckoning
+				    || _ekf.control_status_flags().wind_dead_reckoning;
 
-		global_pos.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
-		_global_position_pub.publish(global_pos);
-	}
+	global_pos.timestamp = _replay_mode ? timestamp : hrt_absolute_time();
+	_global_position_pub.publish(global_pos);
 }
 
 #if defined(CONFIG_EKF2_GNSS)
@@ -1560,8 +1553,8 @@ void EKF2::PublishLocalPosition(const hrt_abstime &timestamp)
 	lpos.ay = vel_deriv(1);
 	lpos.az = vel_deriv(2);
 
-	lpos.xy_valid = _ekf.local_position_is_valid();
-	lpos.v_xy_valid = _ekf.local_position_is_valid();
+	lpos.xy_valid = _ekf.isLocalHorizontalPositionValid();
+	lpos.v_xy_valid = _ekf.isLocalHorizontalPositionValid();
 
 	// TODO: some modules (e.g.: mc_pos_control) don't handle v_z_valid != z_valid properly
 	lpos.z_valid = _ekf.isLocalVerticalPositionValid() || _ekf.isLocalVerticalVelocityValid();

--- a/src/modules/ekf2/test/sensor_simulator/gps.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/gps.cpp
@@ -98,11 +98,11 @@ void Gps::stepHorizontalPositionByMeters(const Vector2f hpos_change)
 	double lat_new {0.0};
 	double lon_new {0.0};
 
-	_ekf->global_origin().project(_gps_data.lat, _gps_data.lon, hposN_curr, hposE_curr);
+	_ekf->getNedGlobalRef().project(_gps_data.lat, _gps_data.lon, hposN_curr, hposE_curr);
 
 	Vector2f hpos_new = Vector2f{hposN_curr, hposE_curr} + hpos_change;
 
-	_ekf->global_origin().reproject(hpos_new(0), hpos_new(1), lat_new, lon_new);
+	_ekf->getNedGlobalRef().reproject(hpos_new(0), hpos_new(1), lat_new, lon_new);
 
 	_gps_data.lon = lon_new;
 	_gps_data.lat = lat_new;

--- a/src/modules/ekf2/test/test_EKF_basics.cpp
+++ b/src/modules/ekf2/test/test_EKF_basics.cpp
@@ -283,7 +283,7 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_uninitialized)
 	// Global origin has been initialized but since there is no position aiding, the global
 	// position is still not valid
 	EXPECT_TRUE(_ekf->global_origin_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_sensor_simulator.runSeconds(1);
 
@@ -307,9 +307,9 @@ TEST_F(EkfBasicsTest, global_position_from_local_ev)
 	_sensor_simulator.runSeconds(1);
 
 	// THEN; since there is no origin, only the local position can be valid
-	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 	EXPECT_FALSE(_ekf->global_origin_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_latitude_new  = 45.0000005;
 	_longitude_new = 111.0000005;
@@ -320,8 +320,8 @@ TEST_F(EkfBasicsTest, global_position_from_local_ev)
 
 	// THEN: local and global positions are valid
 	EXPECT_TRUE(_ekf->global_origin_valid());
-	EXPECT_TRUE(_ekf->global_position_is_valid());
-	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 }
 
 TEST_F(EkfBasicsTest, global_position_from_opt_flow)
@@ -338,9 +338,9 @@ TEST_F(EkfBasicsTest, global_position_from_opt_flow)
 	_sensor_simulator.runSeconds(1);
 
 	// THEN; since there is no origin, only the local position can be valid
-	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 	EXPECT_FALSE(_ekf->global_origin_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_latitude_new  = 45.0000005;
 	_longitude_new = 111.0000005;
@@ -351,8 +351,8 @@ TEST_F(EkfBasicsTest, global_position_from_opt_flow)
 
 	// THEN: local and global positions are valid
 	EXPECT_TRUE(_ekf->global_origin_valid());
-	EXPECT_TRUE(_ekf->global_position_is_valid());
-	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 }
 
 // TODO: Add sampling tests

--- a/src/modules/ekf2/test/test_EKF_basics.cpp
+++ b/src/modules/ekf2/test/test_EKF_basics.cpp
@@ -212,7 +212,7 @@ TEST_F(EkfBasicsTest, accelBiasEstimation)
 			<< "gyro_bias = " << gyro_bias(0) << ", " << gyro_bias(1) << ", " << gyro_bias(2);
 }
 
-TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_initialized)
+TEST_F(EkfBasicsTest, reset_ekf_ned_global_ref_gps_initialized)
 {
 	_latitude_new  = 15.0000005;
 	_longitude_new = 115.0000005;
@@ -259,7 +259,7 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_initialized)
 	EXPECT_NEAR(_ekf->aid_src_gnss_vel().test_ratio[2], 0.f, 0.02f);
 }
 
-TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_uninitialized)
+TEST_F(EkfBasicsTest, reset_ekf_ned_global_ref_gps_uninitialized)
 {
 	_ekf->getEkfGlobalOrigin(_origin_time, _latitude_new, _longitude_new, _altitude_new);
 
@@ -267,7 +267,7 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_uninitialized)
 	EXPECT_DOUBLE_EQ(_longitude, _longitude_new);
 	EXPECT_FLOAT_EQ(_altitude, _altitude_new);
 
-	EXPECT_FALSE(_ekf->global_origin_valid());
+	EXPECT_FALSE(_ekf->getNedGlobalRef().isInitialized());
 
 	_latitude_new  = 45.0000005;
 	_longitude_new = 111.0000005;
@@ -282,7 +282,7 @@ TEST_F(EkfBasicsTest, reset_ekf_global_origin_gps_uninitialized)
 
 	// Global origin has been initialized but since there is no position aiding, the global
 	// position is still not valid
-	EXPECT_TRUE(_ekf->global_origin_valid());
+	EXPECT_TRUE(_ekf->getNedGlobalRef().isInitialized());
 	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_sensor_simulator.runSeconds(1);
@@ -308,7 +308,7 @@ TEST_F(EkfBasicsTest, global_position_from_local_ev)
 
 	// THEN; since there is no origin, only the local position can be valid
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
-	EXPECT_FALSE(_ekf->global_origin_valid());
+	EXPECT_FALSE(_ekf->getNedGlobalRef().isInitialized());
 	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_latitude_new  = 45.0000005;
@@ -319,7 +319,7 @@ TEST_F(EkfBasicsTest, global_position_from_local_ev)
 	_ekf->setEkfGlobalOrigin(_latitude_new, _longitude_new, _altitude_new);
 
 	// THEN: local and global positions are valid
-	EXPECT_TRUE(_ekf->global_origin_valid());
+	EXPECT_TRUE(_ekf->getNedGlobalRef().isInitialized());
 	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 }
@@ -339,7 +339,7 @@ TEST_F(EkfBasicsTest, global_position_from_opt_flow)
 
 	// THEN; since there is no origin, only the local position can be valid
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
-	EXPECT_FALSE(_ekf->global_origin_valid());
+	EXPECT_FALSE(_ekf->getNedGlobalRef().isInitialized());
 	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_latitude_new  = 45.0000005;
@@ -350,7 +350,7 @@ TEST_F(EkfBasicsTest, global_position_from_opt_flow)
 	_ekf->setEkfGlobalOrigin(_latitude_new, _longitude_new, _altitude_new);
 
 	// THEN: local and global positions are valid
-	EXPECT_TRUE(_ekf->global_origin_valid());
+	EXPECT_TRUE(_ekf->getNedGlobalRef().isInitialized());
 	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
 	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
 }

--- a/src/modules/ekf2/test/test_EKF_externalVision.cpp
+++ b/src/modules/ekf2/test/test_EKF_externalVision.cpp
@@ -85,8 +85,8 @@ TEST_F(EkfExternalVisionTest, checkVisionFusionLogic)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
 
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_ekf_wrapper.enableExternalVisionVelocityFusion();
 	_sensor_simulator.runSeconds(2);
@@ -95,8 +95,8 @@ TEST_F(EkfExternalVisionTest, checkVisionFusionLogic)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
 
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	_ekf_wrapper.enableExternalVisionHeadingFusion();
 	_sensor_simulator.runSeconds(2);
@@ -105,8 +105,8 @@ TEST_F(EkfExternalVisionTest, checkVisionFusionLogic)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
 
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 }
 
 TEST_F(EkfExternalVisionTest, visionVelocityReset)

--- a/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
+++ b/src/modules/ekf2/test/test_EKF_fusionLogic.cpp
@@ -84,13 +84,13 @@ TEST_F(EkfFusionLogicTest, doNoFusion)
 	// GIVEN: a tilt and heading aligned filter
 	// WHEN: having no aiding source
 	// THEN: EKF should not have a valid position estimate
-	EXPECT_FALSE(_ekf->local_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
 
 	_sensor_simulator.runSeconds(4);
 
 	// THEN: Local and global position should not be valid
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 }
 
 TEST_F(EkfFusionLogicTest, doGpsFusion)
@@ -104,8 +104,8 @@ TEST_F(EkfFusionLogicTest, doGpsFusion)
 	// THEN: EKF should intend to fuse GPS
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
 	// THEN: Local and global position should be valid
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_TRUE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: GPS data is not send for 11s
 	_sensor_simulator.stopGps();
@@ -113,8 +113,8 @@ TEST_F(EkfFusionLogicTest, doGpsFusion)
 
 	// THEN: EKF should stop to intend to fuse GPS
 	EXPECT_FALSE(_ekf_wrapper.isIntendingGpsFusion());
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: GPS data is send again for 11s
 	_sensor_simulator.startGps();
@@ -122,8 +122,8 @@ TEST_F(EkfFusionLogicTest, doGpsFusion)
 
 	// THEN: EKF should to intend to fuse GPS
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_TRUE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: clients decides to stop GPS fusion
 	_ekf_wrapper.disableGpsFusion();
@@ -230,8 +230,8 @@ TEST_F(EkfFusionLogicTest, doFlowFusion)
 	// THEN: EKF should not intend to fuse flow measurements
 	EXPECT_FALSE(_ekf_wrapper.isIntendingFlowFusion());
 	// THEN: Local and global position should not be valid
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: Flow data is not send and we enable flow fusion
 	_sensor_simulator.stopFlow();
@@ -242,8 +242,8 @@ TEST_F(EkfFusionLogicTest, doFlowFusion)
 	// THEN: EKF should not intend to fuse flow
 	EXPECT_FALSE(_ekf_wrapper.isIntendingFlowFusion());
 	// THEN: Local and global position should not be valid
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: Flow data is sent and we enable flow fusion
 	_sensor_simulator.startFlow();
@@ -253,8 +253,8 @@ TEST_F(EkfFusionLogicTest, doFlowFusion)
 	// THEN: EKF should intend to fuse flow
 	EXPECT_TRUE(_ekf_wrapper.isIntendingFlowFusion());
 	// THEN: Local and global position should be valid
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: Stop sending flow data
 	_sensor_simulator.stopFlow();
@@ -263,8 +263,8 @@ TEST_F(EkfFusionLogicTest, doFlowFusion)
 	// THEN: EKF should not intend to fuse flow measurements
 	EXPECT_FALSE(_ekf_wrapper.isIntendingFlowFusion());
 	// THEN: Local and global position should not be valid
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 }
 
 TEST_F(EkfFusionLogicTest, doVisionPositionFusion)
@@ -279,8 +279,8 @@ TEST_F(EkfFusionLogicTest, doVisionPositionFusion)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: stop sending vision data
 	_sensor_simulator.stopExternalVision();
@@ -291,8 +291,8 @@ TEST_F(EkfFusionLogicTest, doVisionPositionFusion)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 }
 
 TEST_F(EkfFusionLogicTest, doVisionVelocityFusion)
@@ -307,8 +307,8 @@ TEST_F(EkfFusionLogicTest, doVisionVelocityFusion)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 
 	// WHEN: stop sending vision data
 	_sensor_simulator.stopExternalVision();
@@ -319,8 +319,8 @@ TEST_F(EkfFusionLogicTest, doVisionVelocityFusion)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 }
 
 TEST_F(EkfFusionLogicTest, doVisionHeadingFusion)
@@ -336,8 +336,8 @@ TEST_F(EkfFusionLogicTest, doVisionHeadingFusion)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 	// THEN: Yaw state should be reset to vision
 	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 1);
 
@@ -350,8 +350,8 @@ TEST_F(EkfFusionLogicTest, doVisionHeadingFusion)
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
 	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
-	EXPECT_FALSE(_ekf->local_position_is_valid());
-	EXPECT_FALSE(_ekf->global_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_FALSE(_ekf->isGlobalHorizontalPositionValid());
 	// THEN: Yaw state shoud be reset to mag
 	EXPECT_TRUE(_ekf_wrapper.isIntendingMagHeadingFusion());
 	EXPECT_EQ(_ekf_wrapper.getQuaternionResetCounter(), initial_quat_reset_counter + 2);

--- a/src/modules/ekf2/test/test_EKF_gps.cpp
+++ b/src/modules/ekf2/test/test_EKF_gps.cpp
@@ -107,7 +107,7 @@ TEST_F(EkfGpsTest, gpsFixLoss)
 	// THEN: after dead-reconing for a couple of seconds, the local position gets invalidated
 	_sensor_simulator.runSeconds(6);
 	EXPECT_TRUE(_ekf->control_status_flags().inertial_dead_reckoning);
-	EXPECT_FALSE(_ekf->local_position_is_valid());
+	EXPECT_FALSE(_ekf->isLocalHorizontalPositionValid());
 
 	// The control logic takes a bit more time to deactivate the GNSS fusion completely
 	_sensor_simulator.runSeconds(5);

--- a/src/modules/ekf2/test/test_EKF_yaw_estimator.cpp
+++ b/src/modules/ekf2/test/test_EKF_yaw_estimator.cpp
@@ -111,6 +111,6 @@ TEST_F(EKFYawEstimatorTest, inAirYawAlignment)
 	EXPECT_TRUE(reset_logging_checker.isHorizontalVelocityResetCounterIncreasedBy(1));
 	EXPECT_TRUE(reset_logging_checker.isHorizontalPositionResetCounterIncreasedBy(1));
 
-	EXPECT_TRUE(_ekf->local_position_is_valid());
-	EXPECT_TRUE(_ekf->global_position_is_valid());
+	EXPECT_TRUE(_ekf->isLocalHorizontalPositionValid());
+	EXPECT_TRUE(_ekf->isGlobalHorizontalPositionValid());
 }

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -2164,23 +2164,20 @@ FixedwingPositionControl::control_manual_position(const float control_interval, 
 				_hdg_hold_enabled = true;
 				_hdg_hold_yaw = _yaw;
 
-				_hdg_hold_position.lat = _current_latitude;
-				_hdg_hold_position.lon = _current_longitude;
+				_hdg_hold_position = Vector2f(_local_pos.x, _local_pos.y);
 			}
 
 			// if there's a reset-by-fusion, the ekf needs some time to converge,
 			// therefore we go into track holiding for 2 seconds
 			if (_local_pos.timestamp - _time_last_xy_reset < 2_s) {
-				_hdg_hold_position.lat = _current_latitude;
-				_hdg_hold_position.lon = _current_longitude;
+				_hdg_hold_position = Vector2f(_local_pos.x, _local_pos.y);
 			}
 
 			Vector2f curr_pos_local{_local_pos.x, _local_pos.y};
-			Vector2f curr_wp_local = _global_local_proj_ref.project(_hdg_hold_position.lat, _hdg_hold_position.lon);
 
 			_npfg.setAirspeedNom(calibrated_airspeed_sp * _eas2tas);
 			_npfg.setAirspeedMax(_performance_model.getMaximumCalibratedAirspeed() * _eas2tas);
-			navigateLine(curr_wp_local, _hdg_hold_yaw, curr_pos_local, ground_speed, _wind_vel);
+			navigateLine(_hdg_hold_position, _hdg_hold_yaw, curr_pos_local, ground_speed, _wind_vel);
 			_att_sp.roll_body = getCorrectedNpfgRollSetpoint();
 			calibrated_airspeed_sp = _npfg.getAirspeedRef() / _eas2tas;
 

--- a/src/modules/fw_pos_control/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.hpp
@@ -298,7 +298,7 @@ private:
 	bool _hdg_hold_enabled{false}; // heading hold enabled
 	bool _yaw_lock_engaged{false}; // yaw is locked for heading hold
 
-	position_setpoint_s _hdg_hold_position{}; // position where heading hold started
+	Vector2f _hdg_hold_position{}; // position where heading hold started
 
 	// [.] normalized setpoint for manual altitude control [-1,1]; -1,0,1 maps to min,zero,max height rate commands
 	float _manual_control_setpoint_for_height_rate{0.0f};

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -806,7 +806,9 @@ void BlockLocalPositionEstimator::publishGlobalPos()
 		_pub_gpos.get().timestamp_sample = _timeStamp;
 		_pub_gpos.get().lat = lat;
 		_pub_gpos.get().lon = lon;
+		_pub_gpos.get().lat_lon_valid = _estimatorInitialized & EST_XY;
 		_pub_gpos.get().alt = alt;
+		_pub_gpos.get().alt_valid = _estimatorInitialized & EST_Z;
 		_pub_gpos.get().eph = eph;
 		_pub_gpos.get().epv = epv;
 		_pub_gpos.get().terrain_alt = _altOrigin - xLP(X_tz);

--- a/src/modules/mavlink/streams/GLOBAL_POSITION_INT.hpp
+++ b/src/modules/mavlink/streams/GLOBAL_POSITION_INT.hpp
@@ -72,8 +72,8 @@ private:
 
 			mavlink_global_position_int_t msg{};
 
-			if (lpos.z_valid && lpos.z_global) {
-				msg.alt = (-lpos.z + lpos.ref_alt) * 1000.0f;
+			if (gpos.alt_valid) {
+				msg.alt = gpos.alt * 1000.0f;
 
 			} else {
 				// fall back to baro altitude
@@ -103,8 +103,15 @@ private:
 			}
 
 			msg.time_boot_ms = gpos.timestamp / 1000;
-			msg.lat = gpos.lat * 1e7;
-			msg.lon = gpos.lon * 1e7;
+
+			if (gpos.lat_lon_valid) {
+				msg.lat = gpos.lat * 1e7;
+				msg.lon = gpos.lon * 1e7;
+
+			} else {
+				msg.lat = INT32_MAX;
+				msg.lon = INT32_MAX;
+			}
 
 			msg.vx = lpos.vx * 100.0f;
 			msg.vy = lpos.vy * 100.0f;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -1383,6 +1383,8 @@ bool MissionBase::canRunMissionFeasibility()
 {
 	return _navigator->home_global_position_valid() && // Need to have a home position checked
 	       _navigator->get_global_position()->timestamp > 0 && // Need to have a position, for first waypoint check
+	       _navigator->get_global_position()->lat_lon_valid &&
+	       _navigator->get_global_position()->alt_valid &&
 	       (_geofence_status_sub.get().timestamp > 0) && // Geofence data must be loaded
 	       (_geofence_status_sub.get().geofence_id == _mission.geofence_id) &&
 	       (_geofence_status_sub.get().status == geofence_status_s::GF_STATUS_READY);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -220,6 +220,20 @@ void Navigator::run()
 		/* global position updated */
 		if (_global_pos_sub.updated()) {
 			_global_pos_sub.copy(&_global_pos);
+
+			// Navigator assumes that fields are NAN when not valid
+			if (!_global_pos.lat_lon_valid) {
+				_global_pos.lat = static_cast<double>(NAN);
+				_global_pos.lon = static_cast<double>(NAN);
+			}
+
+			if (!_global_pos.alt_valid) {
+				_global_pos.alt = NAN;
+			}
+
+			if (!_global_pos.alt_ellipsoid_valid) {
+				_global_pos.alt_ellipsoid = NAN;
+			}
 		}
 
 		/* check for parameter updates */


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
1. Once in inertial dead-reckoning, the position estimate drifts exponentially and even if a velocity-aiding sensor starts after some time, the global position shouldn't be valid anymore.
2. FW manual position control mode requires a valid global position estimate but internally works using local coordinates. The mode thus cannot run without a GNSS fix or a manual reset despite having a "valid local position" (due to airspeed and sideslip fusion).
3. Flying in FW using wind dead-reckoning requires to set the COM_FS_EPH to a really large value as commander would otherwise invalidate the local position validity
4. FW auto takeoff and auto land modes don't require a valid global position to start but the backend can't execute correctly because it relies on a valid global position estimate.

### Solution
1. Invalidate global position when exceeding maximum the inertial dead-reckoning time (5s). The global position can then be valid again if the local position is valid and that a global position measurement is available (e.g.: GNSS, AGP or manual pos aiding).
2. Make FW manual position work with local coordinates only
3. Generalize the local position "relaxed" logic (currently used for optical flow) to work when the local position is obtained from velocity-aided dead reckoning (e.g.: optical flow, ev_vel, airspeed+sideslip)
4. Deny switching to auto takeoff and auto land if global position is invalid. In the future we could also fix the logic to enable it correctly.

Note that we could publish NANs in the global position fields that are invalid but I wanted to follow the same scheme than in `vehicle_local_position`.

### Test coverage
SITL tests:
In FW, start and stop several times GNSS and sideslip fusion. Modes switch correctly.
![Screenshot from 2024-07-31 14-56-28](https://github.com/user-attachments/assets/e94121ec-dae8-41b2-8c73-2f8f2b755d05)
