### PR TITLE
ackermann: add protection against float precision problem in acceptance radius update

### DIFF
--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
@@ -268,8 +268,10 @@ float RoverAckermannGuidance::updateAcceptanceRadius(const Vector2f &curr_wp_ned
 
 	// Calculate acceptance radius s.t. the rover cuts the corner tangential to the current and next line segment
 	if (curr_to_next_wp_ned.norm() > FLT_EPSILON && curr_to_prev_wp_ned.norm() > FLT_EPSILON) {
-		const float theta = acosf((curr_to_prev_wp_ned * curr_to_next_wp_ned) / (curr_to_prev_wp_ned.norm() *
-					  curr_to_next_wp_ned.norm())) / 2.f;
+		float cosin = (curr_to_prev_wp_ned * curr_to_next_wp_ned) / (curr_to_prev_wp_ned.norm() *
+				curr_to_next_wp_ned.norm());
+		cosin = math::constrain<float>(cosin, -1.f, 1.f); // Protect against float precision problem
+		const float theta = acosf(cosin) / 2.f;
 		const float min_turning_radius = wheel_base / sinf(max_steer_angle);
 		const float acceptance_radius_temp = min_turning_radius / tanf(theta);
 		const float acceptance_radius_temp_scaled = acceptance_radius_gain *

--- a/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
+++ b/src/modules/rover_ackermann/RoverAckermannGuidance/RoverAckermannGuidance.cpp
@@ -268,8 +268,7 @@ float RoverAckermannGuidance::updateAcceptanceRadius(const Vector2f &curr_wp_ned
 
 	// Calculate acceptance radius s.t. the rover cuts the corner tangential to the current and next line segment
 	if (curr_to_next_wp_ned.norm() > FLT_EPSILON && curr_to_prev_wp_ned.norm() > FLT_EPSILON) {
-		float cosin = (curr_to_prev_wp_ned * curr_to_next_wp_ned) / (curr_to_prev_wp_ned.norm() *
-				curr_to_next_wp_ned.norm());
+		float cosin = curr_to_prev_wp_ned.unit_or_zero() * curr_to_next_wp_ned.unit_or_zero();
 		cosin = math::constrain<float>(cosin, -1.f, 1.f); // Protect against float precision problem
 		const float theta = acosf(cosin) / 2.f;
 		const float min_turning_radius = wheel_base / sinf(max_steer_angle);


### PR DESCRIPTION
### Solved Problem
Sometimes when three waypoints are aligned, the acceptance radius returned by `updateAcceptanceRadius` can be NaN due to a float precision problem.

in `updateAcceptanceRadius` we use `acosf` that accept only numbers in range of [-1.0;1.0] and sometimes the value we get from this formula can be sligthly outside of the range due to float precision :
`(curr_to_prev_wp_ned * curr_to_next_wp_ned) / (curr_to_prev_wp_ned.norm() * curr_to_next_wp_ned.norm())`

For the same mission, the problem doesn't happen always at the same waypoints, because the position of the rover seems have an influence on it.

### Solution
Constrain the value between [-1;1] and use it for `acosf`

### Test coverage
- SITL test

### Context
Before (NaN value at the end):

https://github.com/user-attachments/assets/557f01c5-32c9-418e-9c29-262f0b27ebbd


After (Correction at the end):

https://github.com/user-attachments/assets/a59894a4-ee0d-4018-b3a8-f096a702f1dd


