### PR TITLE
Add the missing rc.sysinit file in the ROMFS

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -44,6 +44,7 @@ px4_add_romfs_files(
 	# TODO
 	rc.balloon_apps
 	rc.balloon_defaults
+	rc.sysinit
 )
 
 if(CONFIG_MODULES_AIRSHIP_ATT_CONTROL)

--- a/ROMFS/px4fmu_common/init.d/rc.sysinit
+++ b/ROMFS/px4fmu_common/init.d/rc.sysinit
@@ -1,0 +1,4 @@
+#!/bin/sh
+#
+# Standard system init script
+#


### PR DESCRIPTION
### Solved Problem
Every time we open the `nsh`, we receive the error: `nsh: sysinit: fopen failed: No such file or directory`.

### Solution
- Add the missing default file `rc.sysinit` to the ROMFS.

### Changelog Entry

```
Fix/NSH failed to open file error
Adding the missing default file which causes the NSH to report an error on each boot. 
```

### Alternatives

We could also find a way to disable it from NuttX side but like `rcS`, `rc.sysinit` is an important file in normal NuttX setups.

### Context

The error is triggering on this `fopen()` (using gdb with stlink and `px4_fbreak fopen`)

```c
0x0802bd32 in nsh_script (vtbl=vtbl@entry=0x30020bc0,
    cmd=cmd@entry=0x813c454 "sysinit",
    path=path@entry=0x813c445 "/etc/init.d/rc.sysinit")
    at /home/alexis/work/PX4-Autopilot/platforms/nuttx/NuttX/apps/nsh_script.c:109
```

The error is "polluting" logs when we are debugging the Pixhawk, for example in this issue of Decembre 2022: https://github.com/PX4/PX4-Autopilot/issues/20743

After the patch, the error is gone. 

![image](https://github.com/user-attachments/assets/5c5cdd8c-3fe8-47bd-9030-65ec5f384856)
