### PR TITLE
EKF2: fix offset from height reference after resets

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -126,7 +126,7 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 
 				const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, _params.hgt_fusion_timeout_max);
 
-				if (isHeightResetRequired()) {
+				if (isHeightResetRequired() && (_height_sensor_ref == HeightSensor::BARO)) {
 					// All height sources are failing
 					ECL_WARN("%s height fusion reset required, all height sources failing", HGT_SRC_NAME);
 
@@ -142,10 +142,13 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 					aid_src.time_last_fuse = imu_sample.time_us;
 
 				} else if (is_fusion_failing) {
-					// Some other height source is still working
 					ECL_WARN("stopping %s height fusion, fusion failing", HGT_SRC_NAME);
 					stopBaroHgtFusion();
-					_baro_hgt_faulty = true;
+
+					if (isRecent(_time_last_hgt_fuse, _params.hgt_fusion_timeout_max)) {
+						// Some other height source is still working
+						_baro_hgt_faulty = true;
+					}
 				}
 
 			} else {

--- a/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/external_vision/ev_height_control.cpp
@@ -142,7 +142,7 @@ void Ekf::controlEvHeightFusion(const imuSample &imu_sample, const extVisionSamp
 
 			const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, _params.hgt_fusion_timeout_max);
 
-			if (isHeightResetRequired() && quality_sufficient) {
+			if (isHeightResetRequired() && quality_sufficient && (_height_sensor_ref == HeightSensor::EV)) {
 				// All height sources are failing
 				ECL_WARN("%s fusion reset required, all height sources failing", AID_SRC_NAME);
 				_information_events.flags.reset_hgt_to_ev = true;

--- a/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/gnss/gnss_height_control.cpp
@@ -100,12 +100,12 @@ void Ekf::controlGnssHeightFusion(const gnssSample &gps_sample)
 
 				const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, _params.hgt_fusion_timeout_max);
 
-				if (isHeightResetRequired()) {
+				if (isHeightResetRequired() && (_height_sensor_ref == HeightSensor::GNSS)) {
 					// All height sources are failing
 					ECL_WARN("%s height fusion reset required, all height sources failing", HGT_SRC_NAME);
 
 					_information_events.flags.reset_hgt_to_gps = true;
-					resetVerticalPositionTo(-(measurement - bias_est.getBias()), measurement_var);
+					resetVerticalPositionTo(aid_src.observation, measurement_var);
 					bias_est.setBias(_state.pos(2) + measurement);
 
 					aid_src.time_last_fuse = _time_delayed_us;

--- a/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/range_finder/range_height_control.cpp
@@ -173,7 +173,7 @@ void Ekf::controlRangeHaglFusion(const imuSample &imu_sample)
 
 				const bool is_fusion_failing = isTimedOut(aid_src.time_last_fuse, _params.hgt_fusion_timeout_max);
 
-				if (isHeightResetRequired() && _control_status.flags.rng_hgt) {
+				if (isHeightResetRequired() && _control_status.flags.rng_hgt && (_height_sensor_ref == HeightSensor::RANGE)) {
 					// All height sources are failing
 					ECL_WARN("%s height fusion reset required, all height sources failing", HGT_SRC_NAME);
 

--- a/src/modules/ekf2/test/sensor_simulator/gps.h
+++ b/src/modules/ekf2/test/sensor_simulator/gps.h
@@ -66,6 +66,7 @@ public:
 	void setPdop(const float pdop);
 
 	gnssSample getDefaultGpsData();
+	const gnssSample &getData() const { return _gps_data; }
 
 private:
 	void send(uint64_t time) override;


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When several height sensors are failing at the same time, the EKF resets to the first available measurement. If the height is reset to a secondary height source, this leads to a bias buildup of the height reference.

### Solution
Only allow the primary height source to perform a height reset. A secondary height source can only stop and restart (and automatically adjust its own bias to match the current height estimate).

### Test coverage
covered by new unit tests