### PR TITLE
[Sponsored by CubePilot] stm32h7: Reset USART clock selection

### DIFF
--- a/boards/cubepilot/cubeorange/nuttx-config/include/board.h
+++ b/boards/cubepilot/cubeorange/nuttx-config/include/board.h
@@ -194,6 +194,12 @@
 
 #define STM32_RCC_D3CCIPR_ADCSRC     RCC_D3CCIPR_ADCSEL_PLL2     /* ADC 1 2 3 clock source */
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FLASH wait states */
 #define BOARD_FLASH_WAITSTATES 2
 

--- a/boards/cubepilot/cubeorangeplus/nuttx-config/include/board.h
+++ b/boards/cubepilot/cubeorangeplus/nuttx-config/include/board.h
@@ -195,6 +195,12 @@
 
 #define STM32_RCC_D3CCIPR_ADCSRC     RCC_D3CCIPR_ADCSEL_PLL2     /* ADC 1 2 3 clock source */
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FLASH wait states */
 #define BOARD_FLASH_WAITSTATES 2
 

--- a/boards/px4/fmu-v6c/nuttx-config/include/board.h
+++ b/boards/px4/fmu-v6c/nuttx-config/include/board.h
@@ -246,6 +246,12 @@
 
 #define STM32_RCC_D2CCIP2R_USBSRC    RCC_D2CCIP2R_USBSEL_PLL3
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* ADC 1 2 3 clock source */
 
 #define STM32_RCC_D3CCIPR_ADCSRC     RCC_D3CCIPR_ADCSEL_PLL2

--- a/boards/px4/fmu-v6x/nuttx-config/include/board.h
+++ b/boards/px4/fmu-v6x/nuttx-config/include/board.h
@@ -250,6 +250,12 @@
 
 #define STM32_RCC_D3CCIPR_ADCSRC     RCC_D3CCIPR_ADCSEL_PLL2
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FDCAN 1 2 clock source */
 
 #define STM32_RCC_D2CCIP1R_FDCANSEL  RCC_D2CCIP1R_FDCANSEL_HSE   /* FDCAN 1 2 clock source */


### PR DESCRIPTION
This resets the USARTs' clock source selection to the default, in case it has been changed by the bootloader.

This is required if booting from the ArduPilot bootloader which happens to reset the clock selection to PLL.

Without this fix, UARTs (including the console) is garbled, so presumably at an invalid baudrate. I suspect this will solve a lot of frustration where serials "just don't work".

I have added defines for Pixhawk 6C and 6X, as well as CubePilot Orange and Orange+. I assume we need to add this to a bunch more boards.

Depends on https://github.com/PX4/NuttX/pull/319.

Needs backporting to v1.14 and v1.15!