### PR TITLE
hardfault_log: revert to explicit path to not trip the module documentation parser

### DIFF
--- a/src/systemcmds/hardfault_log/hardfault_log.c
+++ b/src/systemcmds/hardfault_log/hardfault_log.c
@@ -1289,7 +1289,7 @@ static void print_usage(void)
 			       "Hardfault type: 0=divide by 0, 1=Assertion, 2=jump to 0x0, 3=write to 0x0 (default=0)", true);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("commit",
-					 "Write uncommitted hardfault to " CONFIG_BOARD_ROOT_PATH "/fault_%i.txt (and rearm, but don't reset)");
+					 "Write uncommitted hardfault to /fs/microsd/fault_%i.txt (and rearm, but don't reset)");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("count",
 					 "Read the reboot counter, counts the number of reboots of an uncommitted hardfault (returned as the exit code of the program)");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("reset", "Reset the reboot counter");


### PR DESCRIPTION
### Solved Problem
CI fails to `make module_documentation` on main after https://github.com/PX4/PX4-Autopilot/pull/23003/files#diff-7d9b8a304c07e253fd338d3cd6df043d5793f60183255ee302e6c144bf194fecR1276

- the module documentation parser can only resolve defines from the same file
- also it cannot deal with defines embeded in strings
- what board should it add for the general documentation anyways?

### Solution
As a result of these issues I suggest to stay with the original hardcoded /fs/microsd for the documentation. It's still the most common path as far as I can see.

### Test coverage
I built it locally and removing the define it works again.

### Context
![image](https://github.com/user-attachments/assets/5c8ededc-0926-49ef-8f10-93e8f4c76d92)