### PR TITLE
SYS_STATUS: fill correct attitude, horizontal position flags

### DIFF
--- a/src/modules/mavlink/streams/SYS_STATUS.hpp
+++ b/src/modules/mavlink/streams/SYS_STATUS.hpp
@@ -150,7 +150,11 @@ private:
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_3D_MAG, health_component_t::magnetometer, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_GPS, health_component_t::gps, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_RC_RECEIVER, health_component_t::remote_control, msg);
-			fillOutComponent(health_report, MAV_SYS_STATUS_AHRS, health_component_t::local_position_estimate, msg);
+			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION, health_component_t::attitude_estimate,
+					 msg);
+			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL, health_component_t::local_position_estimate,
+					 msg);
+			fillOutComponent(health_report, MAV_SYS_STATUS_AHRS, health_component_t::attitude_estimate, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_LOGGING, health_component_t::logging, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE, health_component_t::absolute_pressure, msg);
 			fillOutComponent(health_report, MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE, health_component_t::differential_pressure,


### PR DESCRIPTION
### Solved Problem
In https://github.com/PX4/PX4-Autopilot/pull/23001 the correct health components are updated to reflect the system state. However, during testing, I found that this causes the wrong or unexpected [MAVLink system status flag](https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_SENSOR) to be set.

The AHRS flag should in my understanding indicate IMU and magnetometer health and be unrelated to position estimates. Since there are separate flags for gyroscope, accelerometer, and magnetometer, it seems the AHRS flag was meant to represent an estimator in ArduPilot (see https://github.com/mavlink/mavlink/commit/66c4190b4400e4168655a6135b5169967b2df2c6). To me, its definition is too unclear to map to any specific EKF2 estimator state.

### Solution
1. Map `health_component_t::local_position_estimate` to `MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL` because with a local position estimate position control is possible
2. Map `health_component_t::attitude_estimate` to `MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION` because with a valid attitude estimate attitude stabilization is possible
3. Don't set the `MAV_SYS_STATUS_AHRS` flags due to unclear definition.

### Changelog Entry
```
Improvement: fill MAVLink's SYS_STATUS flags for horizontal position and attitude estimate
```

### Test coverage
This was not tested yet. @cmic0 could you provide feedback after you tried?