### PR TITLE
RTL Direct: terrain collision avoidance fix

### DIFF
--- a/msg/NavigatorMissionItem.msg
+++ b/msg/NavigatorMissionItem.msg
@@ -1,7 +1,5 @@
 uint64 timestamp                 # time since system start (microseconds)
 
-uint32 instance_count            # Instance count of this mission. Increments monotonically whenever the mission is modified
-
 uint16 sequence_current          # Sequence of the current mission item
 
 uint16 nav_cmd

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -870,7 +870,6 @@ void MissionBase::publish_navigator_mission_item()
 {
 	navigator_mission_item_s navigator_mission_item{};
 
-	navigator_mission_item.instance_count = _navigator->mission_instance_count();
 	navigator_mission_item.sequence_current = _mission.current_seq;
 	navigator_mission_item.nav_cmd = _mission_item.nav_cmd;
 	navigator_mission_item.latitude = _mission_item.lat;

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -249,8 +249,6 @@ public:
 
 	orb_advert_t *get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
-	int mission_instance_count() const { return _mission_result.mission_id; }
-
 	void set_mission_failure_heading_timeout();
 
 	bool get_mission_start_land_available() { return _mission.get_land_start_available(); }

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -337,6 +337,8 @@ void RtlDirect::set_rtl_item()
 			_navigator->set_position_setpoint_triplet_updated();
 		}
 	}
+
+	publish_rtl_direct_navigator_mission_item(); // for logging
 }
 
 RtlDirect::RTLState RtlDirect::getActivationLandState()
@@ -514,4 +516,33 @@ loiter_point_s RtlDirect::sanitizeLandApproach(loiter_point_s land_approach) con
 	}
 
 	return sanitized_land_approach;
+}
+
+void RtlDirect::publish_rtl_direct_navigator_mission_item()
+{
+	navigator_mission_item_s navigator_mission_item{};
+
+	navigator_mission_item.sequence_current = static_cast<uint16_t>(_rtl_state);
+	navigator_mission_item.nav_cmd = _mission_item.nav_cmd;
+	navigator_mission_item.latitude = _mission_item.lat;
+	navigator_mission_item.longitude = _mission_item.lon;
+	navigator_mission_item.altitude = _mission_item.altitude;
+
+	navigator_mission_item.time_inside = get_time_inside(_mission_item);
+	navigator_mission_item.acceptance_radius = _mission_item.acceptance_radius;
+	navigator_mission_item.loiter_radius = _mission_item.loiter_radius;
+	navigator_mission_item.yaw = _mission_item.yaw;
+
+	navigator_mission_item.frame = _mission_item.frame;
+	navigator_mission_item.frame = _mission_item.origin;
+
+	navigator_mission_item.loiter_exit_xtrack = _mission_item.loiter_exit_xtrack;
+	navigator_mission_item.force_heading = _mission_item.force_heading;
+	navigator_mission_item.altitude_is_relative = _mission_item.altitude_is_relative;
+	navigator_mission_item.autocontinue = _mission_item.autocontinue;
+	navigator_mission_item.vtol_back_transition = _mission_item.vtol_back_transition;
+
+	navigator_mission_item.timestamp = hrt_absolute_time();
+
+	_navigator_mission_item_pub.publish(navigator_mission_item);
 }

--- a/src/modules/navigator/rtl_direct.cpp
+++ b/src/modules/navigator/rtl_direct.cpp
@@ -104,8 +104,9 @@ void RtlDirect::on_active()
 		set_rtl_item();
 	}
 
-	if (_rtl_state == RTLState::LOITER_HOLD) { //TODO: rename _rtl_state to _rtl_state_next
+	if (_rtl_state != RTLState::IDLE) { //TODO: rename _rtl_state to _rtl_state_next (when in IDLE we're actually in LAND)
 		//check for terrain collision and update altitude if needed
+		// note: it may trigger multiple times during a RTL, as every time the altitude set is reset
 		updateAltToAvoidTerrainCollisionAndRepublishTriplet(_mission_item);
 	}
 

--- a/src/modules/navigator/rtl_direct.h
+++ b/src/modules/navigator/rtl_direct.h
@@ -47,6 +47,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionInterval.hpp>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/navigator_mission_item.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/rtl_time_estimate.h>
 #include <uORB/topics/vehicle_global_position.h>
@@ -137,6 +138,12 @@ private:
 	 */
 	void parameters_update();
 
+	/**
+	 * @brief Publish navigator mission item
+	 *
+	 */
+	void publish_rtl_direct_navigator_mission_item();
+
 	RTLState getActivationLandState();
 
 	void setLoiterPosition();
@@ -167,4 +174,5 @@ private:
 	uORB::SubscriptionData<vehicle_land_detected_s> _land_detected_sub{ORB_ID(vehicle_land_detected)};	/**< vehicle land detected subscription */
 	uORB::SubscriptionData<vehicle_status_s> _vehicle_status_sub{ORB_ID(vehicle_status)};	/**< vehicle status subscription */
 	uORB::SubscriptionData<wind_s>		_wind_sub{ORB_ID(wind)};
+	uORB::Publication<navigator_mission_item_s> _navigator_mission_item_pub{ORB_ID::navigator_mission_item}; /**< Navigator mission item publication*/
 };


### PR DESCRIPTION

### Solved Problem
Followup from https://github.com/PX4/PX4-Autopilot/pull/23429: When in RTLDirect the terrain avoidance check was only done when in Loiter down state. Once this state was passed the altitude setpoint was opened again and the vehicle proceeded descending.

### Solution
- add publication of NavigatorMissionItem to RTLDirect for logging and easier trouble shooting
- run updateAltToAvoidTerrainCollisionAndRepublishTriplet() in entire RTLDirect except for when state is in IDLE (which is the case then the vehicle is vertically Landing)



