### PR TITLE
[backport] fix metadata.cmake: add missing paths to json & xml parameter outputs…

### DIFF
--- a/cmake/metadata.cmake
+++ b/cmake/metadata.cmake
@@ -74,13 +74,13 @@ add_custom_target(metadata_parameters
 		--markdown ${PX4_BINARY_DIR}/docs/parameters.md
 
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
-		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
+		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d` ${generated_params_dir}
 		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
 		--json ${PX4_BINARY_DIR}/docs/parameters.json
 		--compress
 
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
-		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
+		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d` ${generated_params_dir}
 		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
 		--xml ${PX4_BINARY_DIR}/docs/parameters.xml
 


### PR DESCRIPTION
This backports #23464 to v1.15. It fixes parameter metadata generation, which is most important because this information is used to provide data about parameters to QGC.

FYI @bkueng @mrpollo 