### PR TITLE
gz_bridge: add rover world to cmake

### DIFF
--- a/src/modules/simulation/gz_bridge/CMakeLists.txt
+++ b/src/modules/simulation/gz_bridge/CMakeLists.txt
@@ -93,6 +93,7 @@ if(gz-transport_FOUND)
 		windy
 		baylands
   		lawn
+		rover
 	)
 
 	# find corresponding airframes


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
This PR adds the rover world introduced in https://github.com/PX4/PX4-gazebo-models/pull/46 to the gazebo bridge cmake such that vehicles can be spawend in it by using the _rover suffix.
