### PR TITLE
Improvement: Reset RC passthrough functions to disarmed value when no stick input

### DIFF
--- a/src/lib/mixer_module/functions/FunctionManualRC.hpp
+++ b/src/lib/mixer_module/functions/FunctionManualRC.hpp
@@ -45,9 +45,7 @@ class FunctionManualRC : public FunctionProviderBase
 public:
 	FunctionManualRC()
 	{
-		for (int i = 0; i < num_data_points; ++i) {
-			_data[i] = NAN;
-		}
+		resetAllToDisarmedValue();
 	}
 
 	static FunctionProviderBase *allocate(const Context &context) { return new FunctionManualRC(); }
@@ -57,17 +55,22 @@ public:
 		manual_control_setpoint_s manual_control_setpoint;
 
 		if (_topic.update(&manual_control_setpoint)) {
-			_data[0] = manual_control_setpoint.roll;
-			_data[1] = manual_control_setpoint.pitch;
-			_data[2] = manual_control_setpoint.throttle;
-			_data[3] = manual_control_setpoint.yaw;
-			_data[4] = manual_control_setpoint.flaps;
-			_data[5] = manual_control_setpoint.aux1;
-			_data[6] = manual_control_setpoint.aux2;
-			_data[7] = manual_control_setpoint.aux3;
-			_data[8] = manual_control_setpoint.aux4;
-			_data[9] = manual_control_setpoint.aux5;
-			_data[10] = manual_control_setpoint.aux6;
+			if (manual_control_setpoint.valid) {
+				_data[0] = manual_control_setpoint.roll;
+				_data[1] = manual_control_setpoint.pitch;
+				_data[2] = manual_control_setpoint.throttle;
+				_data[3] = manual_control_setpoint.yaw;
+				_data[4] = manual_control_setpoint.flaps;
+				_data[5] = manual_control_setpoint.aux1;
+				_data[6] = manual_control_setpoint.aux2;
+				_data[7] = manual_control_setpoint.aux3;
+				_data[8] = manual_control_setpoint.aux4;
+				_data[9] = manual_control_setpoint.aux5;
+				_data[10] = manual_control_setpoint.aux6;
+
+			} else {
+				resetAllToDisarmedValue();
+			}
 		}
 	}
 
@@ -75,6 +78,13 @@ public:
 
 private:
 	static constexpr int num_data_points = 11;
+
+	void resetAllToDisarmedValue()
+	{
+		for (int i = 0; i < num_data_points; ++i) {
+			_data[i] = NAN;
+		}
+	}
 
 	static_assert(num_data_points == (int)OutputFunction::RC_AUXMax - (int)OutputFunction::RC_Roll + 1,
 		      "number of functions mismatch");


### PR DESCRIPTION
### Solved Problem
1. I got multiple reports that when an actuator is mapped directly to an RC passthrough e.g. the roll stick and the RC is not present on boot the actuator goes to its middle position instead of staying on the disarmed value.
2. When the RC input is lost the actuator would stay in the last position it had. I quickly discussed with @sfuhrer and this could be unexpected or even dangerous depending on the use case.

Note: 1. very likely broke when I started publishing one `manual_control_setpoint` which has the valid flag set to false on boot to inform the clients.

### Solution
Reset the actuators mapped to RC passthrough to their disarmed value whenever no valid stick input is present (anymore).

### Changelog Entry
```
Improvement: Reset RC passthrough functions to disarmed value when no stick input
```

### Test coverage
I quickly tested this in SITL and with `COM_PREARM_MODE` set to always and one of the simulated channels mapped to the RC roll function it initializes to disarmed value with no stick input, works as before with stick input and returns to its disarmed value whenever stick input is lost (disabling virtual joystick in QGC again).