### PR TITLE
mavlink_receiver: limit access through instances with gimbal mode

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -431,7 +431,7 @@ void MavlinkReceiver::handle_messages_in_gimbal_mode(mavlink_message_t &msg)
 	}
 
 	// Message forwarding
-	_mavlink->handle_message(&msg);
+	_mavlink.handle_message(&msg);
 }
 
 bool
@@ -3201,7 +3201,7 @@ MavlinkReceiver::run()
 							break;
 						}
 
-						_mavlink->set_has_received_messages(true); // Received first message, unlock wait to transmit '-w' command-line flag
+						_mavlink.set_has_received_messages(true); // Received first message, unlock wait to transmit '-w' command-line flag
 						update_rx_stats(msg);
 
 						if (_message_statistics_enabled) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -406,6 +406,34 @@ MavlinkReceiver::handle_message(mavlink_message_t *msg)
 	_mavlink.handle_message(msg);
 }
 
+void MavlinkReceiver::handle_messages_in_gimbal_mode(mavlink_message_t &msg)
+{
+	switch (msg.msgid) {
+	case MAVLINK_MSG_ID_HEARTBEAT:
+		handle_message_heartbeat(&msg);
+		break;
+
+	case MAVLINK_MSG_ID_GIMBAL_MANAGER_SET_ATTITUDE:
+		handle_message_gimbal_manager_set_attitude(&msg);
+		break;
+
+	case MAVLINK_MSG_ID_GIMBAL_MANAGER_SET_MANUAL_CONTROL:
+		handle_message_gimbal_manager_set_manual_control(&msg);
+		break;
+
+	case MAVLINK_MSG_ID_GIMBAL_DEVICE_INFORMATION:
+		handle_message_gimbal_device_information(&msg);
+		break;
+
+	case MAVLINK_MSG_ID_GIMBAL_DEVICE_ATTITUDE_STATUS:
+		handle_message_gimbal_device_attitude_status(&msg);
+		break;
+	}
+
+	// Message forwarding
+	_mavlink->handle_message(&msg);
+}
+
 bool
 MavlinkReceiver::evaluate_target_ok(int command, int target_system, int target_component)
 {
@@ -3163,8 +3191,17 @@ MavlinkReceiver::run()
 							_mavlink.set_proto_version(2);
 						}
 
-						handle_message(&msg);
-						_mavlink.set_has_received_messages(true); // Received first message, unlock wait to transmit '-w' command-line flag
+						switch (_mavlink.get_mode()) {
+						case Mavlink::MAVLINK_MODE::MAVLINK_MODE_GIMBAL:
+							handle_messages_in_gimbal_mode(msg);
+							break;
+
+						default:
+							handle_message(&msg);
+							break;
+						}
+
+						_mavlink->set_has_received_messages(true); // Received first message, unlock wait to transmit '-w' command-line flag
 						update_rx_stats(msg);
 
 						if (_message_statistics_enabled) {

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -155,6 +155,7 @@ private:
 					       float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
 
 	void handle_message(mavlink_message_t *msg);
+	void handle_messages_in_gimbal_mode(mavlink_message_t &msg);
 
 	void handle_message_adsb_vehicle(mavlink_message_t *msg);
 	void handle_message_att_pos_mocap(mavlink_message_t *msg);


### PR DESCRIPTION
### Solved Problem
Connecting to the payload bus's UART allows full control over the autopilot, even when the MAVLink instance is configured for a gimbal/(camera) payload.

### Solution
This adds explicit handling for the relevant services for a gimbal/camera payload for MAVLink instances in gimbal mode.

### Changelog Entry
```
Feature: Restrict access on gimbal-specific MAVLink instances
```

### Alternatives
A more general approach may involve defining MAVLink instance modes with specific capability groups.

### Test coverage
Tested on hardware to ensure restricted access through the gimbal UART port when configured in gimbal mode.