### PR TITLE
fix: Fix error message when cannot find target board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -549,7 +549,7 @@ distclean:
 # All other targets are handled by PX4_MAKE. Add a rule here to avoid printing an error.
 %:
 	$(if $(filter $(FIRST_ARG),$@), \
-		$(error "Make target $@ not found. It either does not exist or $@ cannot be the first argument. Use '$(MAKE) help|list_config_targets' to get a list of all possible [configuration] targets."),@#)
+		$(error "Make target $@ not found. It either does not exist or $@ cannot be the first argument. Use '$(MAKE) list_config_targets' to get a list of all possible [configuration] targets."),@#)
 
 # Print a list of non-config targets (based on http://stackoverflow.com/a/26339924/1487069)
 help:


### PR DESCRIPTION
### Solved Problem
When we type wrong argument in first argument, the error said:
```
"Make target $@ not found. It either does not exist or $@ cannot be the first argument. Use '$(MAKE) help|list_config_targets' to get a list of all possible [configuration] targets."
```

But when typing `make help|list_config_targets`, it still not work.

### Solution
- The command has been changed to `$(MAKE) list_config_targets`, so I changed Makefile too.


