### PR TITLE
Parameter metadata - improve/fix rendering

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -81,7 +81,7 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                 if bitmask_list:
                     result += bitmask_output
                 # Format the ranges as a table.
-                result += f"Reboot | minValue | maxValue | increment | default | unit\n--- | --- | --- | --- | --- | ---\n{reboot_required} | {min_val} | {max_val} | {increment} | {def_val} | {unit} \n\n"
+                result += f"Reboot | minValue | maxValue | increment | default | unit\n--- | --- | --- | --- | --- | ---\n{'&check;' if reboot_required else '&nbsp;' } | {min_val} | {max_val} | {increment} | {def_val} | {unit} \n\n"
 
         self.output = result
 

--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -26,7 +26,6 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
             for param in group.GetParams():
                 name = param.GetName()
                 short_desc = param.GetFieldValue("short_desc") or ''
-                #short_desc = html.escape(short_desc)
 
                 # Add fullstop to short_desc if not present
                 if short_desc:
@@ -34,7 +33,6 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
                         short_desc += "."
 
                 long_desc = param.GetFieldValue("long_desc") or ''
-                 #long_desc = html.escape(long_desc)
 
                 #Strip out short text from start of long text, if it ends in fullstop
                 if long_desc.startswith(short_desc):

--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -26,12 +26,20 @@ If a listed parameter is missing from the Firmware see: [Finding/Updating Parame
             for param in group.GetParams():
                 name = param.GetName()
                 short_desc = param.GetFieldValue("short_desc") or ''
+                #short_desc = html.escape(short_desc)
+
+                # Add fullstop to short_desc if not present
                 if short_desc:
                     if not short_desc.strip().endswith('.'):
                         short_desc += "."
-                #short_desc = html.escape(short_desc)
+
                 long_desc = param.GetFieldValue("long_desc") or ''
-                #long_desc = html.escape(long_desc)
+                 #long_desc = html.escape(long_desc)
+
+                #Strip out short text from start of long text, if it ends in fullstop
+                if long_desc.startswith(short_desc):
+                    long_desc = long_desc[len(short_desc):].lstrip()
+
                 min_val = param.GetFieldValue("min") or ''
                 max_val = param.GetFieldValue("max") or ''
                 increment = param.GetFieldValue("increment") or ''


### PR DESCRIPTION
Fix/improve rendering
- Insert either check mark or non breaking space for reboot required (fixes table rendering if reboot not required)
- Remove short description of parameter from start of long description IFF it ends in a full stop. This removes duplicate short/long descriptions, and improves the long description if it starts with the short description as a sentence.

As spotted by @Claudio-Chies :-)