### PR TITLE
MPC_ACC_DECOUPLE - better description

### DIFF
--- a/src/modules/mc_pos_control/multicopter_position_control_limits_params.c
+++ b/src/modules/mc_pos_control/multicopter_position_control_limits_params.c
@@ -143,6 +143,8 @@ PARAM_DEFINE_FLOAT(MPC_THR_MAX, 1.f);
  * Acceleration to tilt coupling
  *
  * Set to decouple tilt from vertical acceleration.
+ * This provides smoother flight but slightly worse tracking in position and auto modes.
+ * Unset if accurate position tracking during dynamic maneuvers is more important than a smooth flight.
  *
  * @boolean
  * @group Multicopter Position Control


### PR DESCRIPTION
`MPC_ACC_DECOUPLE` description doesn't help readers understand when they should use it. 
This paraphrases text from @bresch in https://discuss.px4.io/t/px4-v1-15-public-changes-what-needs-docs/39850/12?u=hamishwillee

