### PR TITLE
mRo boards: Fix for USART clock selection

### DIFF
--- a/boards/mro/ctrl-zero-classic/nuttx-config/include/board.h
+++ b/boards/mro/ctrl-zero-classic/nuttx-config/include/board.h
@@ -197,6 +197,12 @@
 
 #define STM32_FDCANCLK               STM32_HSE_FREQUENCY
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FLASH wait states */
 #define BOARD_FLASH_WAITSTATES 2
 

--- a/boards/mro/ctrl-zero-h7-oem/nuttx-config/include/board.h
+++ b/boards/mro/ctrl-zero-h7-oem/nuttx-config/include/board.h
@@ -197,6 +197,12 @@
 
 #define STM32_FDCANCLK               STM32_HSE_FREQUENCY
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FLASH wait states */
 #define BOARD_FLASH_WAITSTATES 2
 

--- a/boards/mro/ctrl-zero-h7/nuttx-config/include/board.h
+++ b/boards/mro/ctrl-zero-h7/nuttx-config/include/board.h
@@ -196,6 +196,12 @@
 
 #define STM32_FDCANCLK               STM32_HSE_FREQUENCY
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FLASH wait states */
 #define BOARD_FLASH_WAITSTATES 2
 

--- a/boards/mro/pixracerpro/nuttx-config/include/board.h
+++ b/boards/mro/pixracerpro/nuttx-config/include/board.h
@@ -196,6 +196,12 @@
 
 #define STM32_FDCANCLK               STM32_HSE_FREQUENCY
 
+/* UART clock selection */
+/* reset to default to overwrite any changes done by any bootloader */
+
+#define STM32_RCC_D2CCIP2R_USART234578_SEL RCC_D2CCIP2R_USART234578SEL_RCC
+#define STM32_RCC_D2CCIP2R_USART16_SEL     RCC_D2CCIP2R_USART16SEL_RCC
+
 /* FLASH wait states */
 #define BOARD_FLASH_WAITSTATES 2
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

This PR applies #23498 fix to mRo boards, which as boards that use Ardupilot BL, might end up with wrong values for clock selection to PLLs. I can confirm that this helped to configure GPS devices correctly. This PR possibly can fix #21242, #18968, and #18505.

I am willing to help find and mitigate these bugs and undesired behaviors for boards using AP BLs and PX4.
