### PR TITLE
Exclude Frame Configurations Not Added to ROMFS from airframes.xml Generation

### DIFF
--- a/Tools/px4airframes/srcscanner.py
+++ b/Tools/px4airframes/srcscanner.py
@@ -8,14 +8,21 @@ class SourceScanner(object):
     to the Parser.
     """
 
-    def ScanDir(self, srcdir, parser):
+    def ScanDir(self, srcdir, parser, excluded_airframes=None):
         """
         Scans provided path and passes all found contents to the parser using
         parser.Parse method.
         """
+        if excluded_airframes is not None:
+            excluded_airframes = set(excluded_airframes)
+
         extensions = tuple(parser.GetSupportedExtensions())
         for dirname, dirnames, filenames in os.walk(srcdir):
             for filename in filenames:
+                # Skip excluded airframes if provided
+                if excluded_airframes and filename in excluded_airframes:
+                    continue
+
                 extension = os.path.splitext(filename)[1]
                 if extension in extensions:
                     path = os.path.join(dirname, filename)

--- a/Tools/px_process_airframes.py
+++ b/Tools/px_process_airframes.py
@@ -84,6 +84,7 @@ def main():
                          metavar="BOARD",
                          help="Board to create airframes xml for")
     parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
+    parser.add_argument("-e", "--excluded_airframes", nargs='+', help='Directory to read files from')
     args = parser.parse_args()
 
     # Check for valid command
@@ -98,7 +99,7 @@ def main():
 
     # Scan directories, and parse the files
     if args.verbose: print("Scanning source path " + args.airframes_path)
-    if not scanner.ScanDir(args.airframes_path, parser):
+    if not scanner.ScanDir(args.airframes_path, parser, args.excluded_airframes):
         sys.exit(1)
     # We can't validate yet
     # if not parser.Validate():

--- a/cmake/px4_metadata.cmake
+++ b/cmake/px4_metadata.cmake
@@ -59,6 +59,139 @@
 #	Example:
 #		px4_generate_airframes_xml(OUT airframes.xml)
 #
+
+set(EXCLUDED_AIRFRAMES NULL)
+
+
+if(NOT CONFIG_MODULES_SIMULATION_PWM_OUT_SIM)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [1000, 1999] Simulation setups
+		1001_rc_quad_x.hil
+		1002_standard_vtol.hil
+		1100_rc_quad_x_sih.hil
+		1101_rc_plane_sih.hil
+		1102_tailsitter_duo_sih.hil
+	)
+endif()
+
+if(NOT CONFIG_MODULES_MC_RATE_CONTROL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [4000, 4999] Quadrotor x
+		4001_quad_x
+		4014_s500
+		4015_holybro_s500
+		4016_holybro_px4vision
+		4017_nxp_hovergames
+		4019_x500_v2
+		4020_holybro_px4vision_v1_5
+		4041_beta75x
+		4050_generic_250
+		4052_holybro_qav250
+		4053_holybro_kopis2
+		4061_atl_mantis_edu
+		4071_ifo
+		4073_ifo-s
+		4500_clover4
+		4601_droneblocks_dexi_5
+		4901_crazyflie21
+
+		# [5000, 5999] Quadrotor +
+		5001_quad_+
+
+		# [6000, 6999] Hexarotor x
+		6001_hexa_x
+		6002_draco_r
+
+		# [7000, 7999] Hexarotor +
+		7001_hexa_+
+
+		# [8000, 8999] Octorotor +
+		8001_octo_x
+
+		# [9000, 9999] Octorotor +
+		9001_octo_+
+
+		# [11000, 11999] Hexa Cox
+		11001_hexa_cox
+
+		# [12000, 12999] Octo Cox
+		12001_octo_cox
+
+		# [14000, 14999] MC with tilt
+		14001_generic_mc_with_tilt
+
+		16001_helicopter
+
+		24001_dodeca_cox
+	)
+endif()
+
+if(NOT CONFIG_MODULES_FW_RATE_CONTROL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [2000, 2999] Standard planes
+		2100_standard_plane
+		2106_albatross
+
+		# [3000, 3999] Flying wing
+		3000_generic_wing
+
+		# [17000, 17999] Autogyro
+		17002_TF-AutoG2
+		17003_TF-G2
+	)
+endif()
+
+if(NOT CONFIG_MODULES_AIRSHIP_ATT_CONTROL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		2507_cloudship
+	)
+endif()
+
+if(NOT CONFIG_MODULES_VTOL_ATT_CONTROL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [13000, 13999] VTOL
+		13000_generic_vtol_standard
+		13100_generic_vtol_tiltrotor
+		13013_deltaquad
+		13014_vtol_babyshark
+		13030_generic_vtol_quad_tiltrotor
+		13200_generic_vtol_tailsitter
+	)
+endif()
+
+if(NOT CONFIG_MODULES_ROVER_DIFFERENTIAL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [50000, 50999] Differential rovers
+		50000_generic_rover_differential
+		50001_aion_robotics_r1_rover
+	)
+endif()
+
+if(NOT CONFIG_MODULES_ROVER_ACKERMANN)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [51000, 51999] Ackermann rovers
+		51000_generic_rover_ackermann
+		51001_axial_scx10_2_trail_honcho
+	)
+endif()
+
+if(NOT CONFIG_MODULES_ROVER_POS_CONTROL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [59000, 59999] Rover position control (deprecated)
+		59000_generic_ground_vehicle
+		59001_nxpcup_car_dfrobot_gpx
+	)
+endif()
+
+if(NOT CONFIG_MODULES_UUV_ATT_CONTROL)
+	list(APPEND EXCLUDED_AIRFRAMES
+		# [60000, 61000] (Unmanned) Underwater Robots
+		60000_uuv_generic
+		60001_uuv_hippocampus
+		60002_uuv_bluerov2_heavy
+	)
+endif()
+
 function(px4_generate_airframes_xml)
 	px4_parse_function_args(
 		NAME px4_generate_airframes_xml
@@ -71,6 +204,7 @@ function(px4_generate_airframes_xml)
 			--airframes-path ${PX4_SOURCE_DIR}/ROMFS/${config_romfs_root}/init.d
 			--board CONFIG_ARCH_BOARD_${PX4_BOARD}
 			--xml ${PX4_BINARY_DIR}/airframes.xml
+			--excluded_airframes ${EXCLUDED_AIRFRAMES}
 		DEPENDS ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 		COMMENT "Creating airframes.xml"
 		)


### PR DESCRIPTION

### Solved Problem
In the current firmware build process, the airframes.xml file was incorrectly including frame configurations for various vehicle types (copter, fixed-wing, rover, etc.) even if those configurations were not added to the ROMFS.

This caused inconsistencies between the firmware's actual build configuration and the information provided to the GCS, potentially leading to misconfigurations.

### Solution
Aligned with the existing logic for adding frame configuration files to the ROMFS (as seen in this [script](https://github.com/PX4/PX4-Autopilot/blob/main/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt)), the px4_metadata.cmake file identifies files to be excluded. The updated script then excludes these files from the input values used to generate airframes.xml. This adjustment prevents unnecessary or incorrect frame configurations from being listed, ensuring that airframes.xml accurately reflects the firmware's build and ROMFS setup.

### Test 
1. make boards_[multicopter | fixedwing | rover | ... ] & Upload Firmware
2. Check Vehicle Setup->Airframe in QGroundcontrol.