### PR TITLE
Reasonable defaults for Lawnmower SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/4011_gz_lawnmower
@@ -15,14 +15,29 @@ param set-default SIM_GZ_EN 1 # Gazebo bridge
 param set-default SENS_EN_GPSSIM 1
 param set-default SENS_EN_BAROSIM 0
 param set-default SENS_EN_MAGSIM 1
-param set-default SENS_EN_ARSPDSIM 1
+param set-default SENS_EN_ARSPDSIM 0
 # We can arm and drive in manual mode when it slides and GPS check fails:
 param set-default COM_ARM_WO_GPS 1
 
-# Set Differential Drive Kinematics Library parameters:
-param set RD_WHEEL_BASE 0.9
-param set RD_WHEEL_RADIUS 0.22
-param set RD_WHEEL_SPEED 10.0	# Maximum wheel speed rad/s, approx 8 km/h
+# Rover parameters
+param set-default RD_WHEEL_TRACK 0.9
+param set-default RD_MAN_YAW_SCALE 0.1
+param set-default RD_YAW_RATE_I 0.1
+param set-default RD_YAW_RATE_P 5
+param set-default RD_MAX_ACCEL 1
+param set-default RD_MAX_JERK 3
+param set-default RD_MAX_SPEED 8
+param set-default RD_HEADING_P 5
+param set-default RD_HEADING_I 0.1
+param set-default RD_MAX_YAW_RATE 30
+param set-default RD_MISS_SPD_DEF 8
+param set-default RD_TRANS_DRV_TRN 0.349066
+param set-default RD_TRANS_TRN_DRV 0.174533
+
+# Pure pursuit parameters
+param set-default PP_LOOKAHD_MAX 30
+param set-default PP_LOOKAHD_MIN 2
+param set-default PP_LOOKAHD_GAIN 1
 
 # Actuator mapping - set SITL motors/servos output parameters:
 
@@ -36,7 +51,7 @@ param set-default SIM_GZ_WH_FUNC1 101 # right wheel
 param set-default SIM_GZ_WH_FUNC2 102 # left wheel
 #param set-default SIM_GZ_WH_MIN2 0
 #param set-default SIM_GZ_WH_MAX2 200
-#aram set-default SIM_GZ_WH_DIS2 100
+#param set-default SIM_GZ_WH_DIS2 100
 #param set-default SIM_GZ_WH_FAIL2 100
 
 param set-default SIM_GZ_WH_REV 0 # no need to reverse any wheels

--- a/src/modules/rover_differential/module.yaml
+++ b/src/modules/rover_differential/module.yaml
@@ -155,7 +155,7 @@ parameters:
         type: float
         unit: rad
         min: 0.001
-        max: 180
+        max: 3.14159
         increment: 0.01
         decimal: 3
         default: 0.0872665
@@ -166,7 +166,7 @@ parameters:
         type: float
         unit: rad
         min: 0.001
-        max: 180
+        max: 3.14159
         increment: 0.01
         decimal: 3
         default: 0.174533


### PR DESCRIPTION
### Solved Problem
When running '''make px4_sitl gz_lawnmower_lawn``` the vehicle completes the mission, but its movements aren't smooth.

To fix that, ```RD_*``` parameters must be adjusted in the airframe definition file.

Ammends #{[23430](https://github.com/PX4/PX4-Autopilot/pull/23430)}

### Solution

Speed, accelerations and turn rate were adjusted.

also, it looks like with Units being *rad*, the upper limit for RD_TRANS_DRV_TRN and RD_TRANS_TRN_DRV parameters should be in radians too.

### Test coverage
Running '''make px4_sitl gz_lawnmower_lawn``` produces smooth movements.

