### PR TITLE
Fixes mavlink id starting at 2 for sitl_multiple_run

### DIFF
--- a/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
+++ b/Tools/simulation/gazebo-classic/sitl_multiple_run.sh
@@ -119,7 +119,7 @@ if [ -z ${SCRIPT} ]; then
 	fi
 
 	while [ $n -lt $num_vehicles ]; do
-		spawn_model ${vehicle_model} $(($n + 1))
+		spawn_model ${vehicle_model} $n
 		n=$(($n + 1))
 	done
 else


### PR DESCRIPTION
### Solved Problem

Fixes #23480

### Solution
- Fixes off by one error. 

### Changelog Entry
For release notes:
```
Bugfix: Fixes mavlink id starting at 2 for sitl_multiple_run for gazebo_classic
```

### Alternatives
We could also leave it as is. mav_sys_id=2 is not perse wrong, just unexpected. 

### Test coverage
not added

### Context
not added
