### PR TITLE
navigator: Align MAVLINK message level with EVENT message level

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -648,7 +648,7 @@ Geofence::loadFromFile(const char *filename)
 
 	} else {
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence: import error\t");
-		events::send(events::ID("navigator_geofence_import_failed"), events::Log::Error, "Geofence: import error");
+		events::send(events::ID("navigator_geofence_import_failed"), events::Log::Critical, "Geofence: import error");
 	}
 
 	updateFence();


### PR DESCRIPTION
### Solved Problem

MAVLINK message level and EVENT message level are different.

### Solution

Match the EVENT message level to the MAVLINK message level.

### Changelog Entry

None.

### Alternatives

None.

### Test coverage

None.

### Context

None.