### PR TITLE
ekf2: send airspeed data to ekf backend regardless of sign

### DIFF
--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2076,14 +2076,19 @@ void EKF2::UpdateAirspeedSample(ekf2_timestamps_s &ekf2_timestamps)
 		if (_airspeed_validated_sub.update(&airspeed_validated)) {
 
 			if (PX4_ISFINITE(airspeed_validated.true_airspeed_m_s)
-			    && PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)
-			    && (airspeed_validated.calibrated_airspeed_m_s > 0.f)
 			    && (airspeed_validated.selected_airspeed_index > 0)
 			   ) {
+				float cas2tas = 1.f;
+
+				if (PX4_ISFINITE(airspeed_validated.calibrated_airspeed_m_s)
+				    && (airspeed_validated.calibrated_airspeed_m_s > FLT_EPSILON)) {
+					cas2tas = airspeed_validated.true_airspeed_m_s / airspeed_validated.calibrated_airspeed_m_s;
+				}
+
 				airspeedSample airspeed_sample {
 					.time_us = airspeed_validated.timestamp,
 					.true_airspeed = airspeed_validated.true_airspeed_m_s,
-					.eas2tas = airspeed_validated.true_airspeed_m_s / airspeed_validated.calibrated_airspeed_m_s,
+					.eas2tas = cas2tas,
 				};
 				_ekf.setAirspeedData(airspeed_sample);
 			}


### PR DESCRIPTION
### Solved Problem
On ground the airspeed can sometimes be slightly negative. If no airspeed data is sent to the backend, it cannot know that wind dead-reckoning will be possible post-takeoff and the inertial dead-reckoning is set.

See: https://github.com/PX4/PX4-Autopilot/blob/db8781e5311c876cb948fc2e10c0ec6d0ff96372/src/modules/ekf2/EKF/ekf_helper.cpp#L757-L763


### Solution
Send airspeed data to ekf2 backend as long as finite but ignore sign.