### PR TITLE
Commander: only add *autopilot disengaged* to failsafe notifactions in special cases

### DIFF
--- a/src/modules/commander/failsafe/framework.cpp
+++ b/src/modules/commander/failsafe/framework.cpp
@@ -224,6 +224,16 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				{events::Log::Warning, events::LogInternal::Warning},
 				"Failsafe warning:", mavlink_mode);
 
+			} else if (action == Action::Descend || action == Action::FallbackAltCtrl || action == Action::FallbackStab) {
+				/* EVENT
+				* @description Failsafe actions that disengage the autopilot (remove position control)
+				* @type append_health_and_arming_messages
+				*/
+				events::send<uint32_t, events::px4::enums::failsafe_action_t>(
+					events::ID("commander_failsafe_enter_autopilot_disengaged"),
+				{events::Log::Critical, events::LogInternal::Warning},
+				"Failsafe activated: Autopilot disengaged, switching to {2}", mavlink_mode, failsafe_action);
+
 			} else {
 				/* EVENT
 				* @type append_health_and_arming_messages
@@ -231,7 +241,7 @@ void FailsafeBase::notifyUser(uint8_t user_intended_mode, Action action, Action 
 				events::send<uint32_t, events::px4::enums::failsafe_action_t>(
 					events::ID("commander_failsafe_enter_generic"),
 				{events::Log::Critical, events::LogInternal::Warning},
-				"Failsafe activated: Autopilot disengaged, switching to {2}", mavlink_mode, failsafe_action);
+				"Failsafe activated: switching to {2}", mavlink_mode, failsafe_action);
 			}
 
 		} else {


### PR DESCRIPTION

### Solved Problem
In a generic failsafe, the message "autopilot disengaged" is wrong. E.g. it now displays the following for a Land failsafe due to geofence breach:
![image](https://github.com/user-attachments/assets/79b790c6-3405-4fd1-b27a-b148743642b6)


### Solution
Only keep the "autopilot disengaged" in case the autopilot is no longer controlling the vehicle's position. This is a bit arbitrary but I guess the best approximation to what  "autopilot disengaged" implies, as then without any user input the vehicle will likely crash - thus the extra warning with the implication that the pilot should take over control if possible. 

With this change the geofence breach failsafe notification would looks like this:
![image](https://github.com/user-attachments/assets/8f1db020-8540-4d0c-a181-20109268745b)


### Changelog Entry
For release notes:
```
Improvement: Commander: only add *autopilot disengaged* to failsafe notifactions in special cases
```

### Context
This was originally added in https://github.com/PX4/PX4-Autopilot/pull/22902.
