### PR TITLE
Landing horizontal velocity compensation / unsteady landing

### DIFF
--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -247,12 +247,12 @@ void FlightTaskAuto::_prepareLandSetpoints()
 	if (_type_previous != WaypointType::land) {
 		// initialize yaw and xy-position
 		_land_heading = _yaw_setpoint;
-		_stick_acceleration_xy.resetPosition(Vector2f(_triplet_target(0), _triplet_target(1)));
-		_initial_land_position = Vector3f(_triplet_target(0), _triplet_target(1), NAN);
+		_stick_acceleration_xy.resetPosition(Vector2f(_target(0), _target(1)));
+		_initial_land_position = Vector3f(_target(0), _target(1), NAN);
 	}
 
 	// Update xy-position in case of landing position changes (etc. precision landing)
-	_land_position = Vector3f(_triplet_target(0), _triplet_target(1), NAN);
+	_land_position = Vector3f(_target(0), _target(1), NAN);
 
 	// User input assisted landing
 	if (_param_mpc_land_rc_help.get() && _sticks.checkAndUpdateStickInputs()) {
@@ -452,7 +452,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 			_triplet_prev_wp(2) = -(_sub_triplet_setpoint.get().previous.alt - _reference_altitude);
 
 		} else {
-			_triplet_prev_wp = _position;
+			_triplet_prev_wp = _triplet_target;
 		}
 
 		_prev_was_valid = _sub_triplet_setpoint.get().previous.valid;

--- a/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/modules/flight_mode_manager/tasks/Auto/FlightTaskAuto.cpp
@@ -247,12 +247,12 @@ void FlightTaskAuto::_prepareLandSetpoints()
 	if (_type_previous != WaypointType::land) {
 		// initialize yaw and xy-position
 		_land_heading = _yaw_setpoint;
-		_stick_acceleration_xy.resetPosition(Vector2f(_target(0), _target(1)));
-		_initial_land_position = Vector3f(_target(0), _target(1), NAN);
+		_stick_acceleration_xy.resetPosition(Vector2f(_triplet_target(0), _triplet_target(1)));
+		_initial_land_position = Vector3f(_triplet_target(0), _triplet_target(1), NAN);
 	}
 
 	// Update xy-position in case of landing position changes (etc. precision landing)
-	_land_position = Vector3f(_target(0), _target(1), NAN);
+	_land_position = Vector3f(_triplet_target(0), _triplet_target(1), NAN);
 
 	// User input assisted landing
 	if (_param_mpc_land_rc_help.get() && _sticks.checkAndUpdateStickInputs()) {

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -57,10 +57,13 @@ Land::on_activation()
 
 	/* convert mission item to current setpoint */
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-	pos_sp_triplet->previous.valid = false;
-	// set current mission_item so that we can breake before reaching the landing waypoint
-	_navigator->calculate_breaking_stop(_mission_item.lat, _mission_item.lon);
+
+	if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING) {
+		_navigator->calculate_breaking_stop(_mission_item.lat, _mission_item.lon);
+	}
+
 	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_position_setpoint_triplet_updated();

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -58,6 +58,8 @@ Land::on_activation()
 	/* convert mission item to current setpoint */
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	pos_sp_triplet->previous.valid = false;
+	// set current mission_item so that we can breake before reaching the landing waypoint
+	_navigator->calculate_breaking_stop(_mission_item.lat, _mission_item.lon);
 	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 


### PR DESCRIPTION
### Solved Problem
There was a problem where triggering Land, while having a forward velocity, the landing algorithm didn't compensate it, meaning the vehicle remained drifting while getting closer to the ground , and in some cases jerking unsteadily

### Solution
i set the target landing location based on the current velocity, maximum acceleration and jerk. this way the drone is able to compensate the velocity and land smoothly at the target location.

### Changelog Entry

- changed the lat and long in the triplet generation process in the navigator to be at a location in front of the vehicle, dependent on its current state.
- set the previous setpoint triplet to be the same as the target one, this way we avoid getting into offtrack mode.

```
Bugfix: Unsteady landing with horizontal velocity
Documentation: the position set point for landing gets set to a location in front of the vehicle where its able to halt before. greatly improving landing performance when triggering landing while moving
```

### Test coverage
 SITL and on Hardware
