### PR TITLE
ROMFS gazebo iris opt flow: increase SENS_FLOW_MAXHGT to 15m

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1010_gazebo-classic_iris_opt_flow
@@ -47,5 +47,5 @@ param set-default MPC_ALT_MODE 2
 
 param set-default SENS_FLOW_ROT 6
 param set-default SENS_FLOW_MINHGT 0.7
-param set-default SENS_FLOW_MAXHGT 3
+param set-default SENS_FLOW_MAXHGT 15
 param set-default SENS_FLOW_MAXR 2.5


### PR DESCRIPTION
With the current setting of 3m this model is not possible to fly for more than some seconds with optical flow. 15m seems more reasonable. 