### PR TITLE
docker: pass DISPLAY variable and enable X11 forwarding

### DIFF
--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -61,6 +61,9 @@ docker run -it --rm -w "${SRC_DIR}" \
 	--env=PX4_UBSAN \
 	--env=TRAVIS_BRANCH \
 	--env=TRAVIS_BUILD_ID \
+	--env=DISPLAY \
+	--volume /tmp/.X11-unix:/tmp/.X11-unix \
+	--volume $HOME/.Xauthority:/home/root/.Xauthority \
 	--publish 14556:14556/udp \
 	--volume=${CCACHE_DIR}:${CCACHE_DIR}:rw \
 	--volume=${SRC_DIR}:${SRC_DIR}:rw \


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem

When using the `docker_run.sh` it wasn't possible to start Gazebo without modifying the parameters passed to `docker run` inside the script.

This PR allows running Gazebo out of the box without any manual file changes.

### Solution

- Add `DISPLAY` environment to docker
- Mount X11 folders to docker

### Context
![image](https://github.com/user-attachments/assets/c61d19e2-1c2b-4737-8497-8dc1cd54cf26)
