### PR TITLE
Fixes upload.sh for arkv6x

### DIFF
--- a/Tools/upload.sh
+++ b/Tools/upload.sh
@@ -15,7 +15,7 @@ SERIAL_PORTS="/dev/tty.usbmodemPX*,/dev/tty.usbmodem*"
 fi
 
 if [ $SYSTYPE = "Linux" ]; then
-SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,/dev/serial/by-id/usb-UVify*,/dev/serial/by-id/usb-ArduPilot*,/dev/serial/by-id/ARK*,"
+SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,/dev/serial/by-id/usb-UVify*,/dev/serial/by-id/usb-ArduPilot*,/dev/serial/by-id/usb-ARK*,"
 fi
 
 if [[ $SYSTYPE = *"CYGWIN"* ]]; then


### PR DESCRIPTION

### Solved Problem
When trying to upload firmware via `upload.sh` we get infinite wait time for the bootloader. Fixing typo, fixes the issue.

If possible, @AlexKlimaj , take a look.

### Context
![image](https://github.com/user-attachments/assets/5bff4cdf-1b02-48f7-8ef8-2d970a98d3d2)
![image](https://github.com/user-attachments/assets/ad24bded-4225-4b82-8e54-00ec9c767931)
![image](https://github.com/user-attachments/assets/5405ccd5-7074-45ee-a2a4-6e516a1e82d1)


