### PR TITLE
fix: `make help` target on Ubuntu 22.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,7 +557,7 @@ help:
 	@echo "Usage: $(MAKE) <target>"
 	@echo "Where <target> is one of:"
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | \
-		awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | \
+		awk -v RS= -F: '/(^|\n)# Files(\n|$$)/,/(^|\n)# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | \
 		egrep -v -e '^[^[:alnum:]]' -e '^($(subst $(space),|,$(ALL_CONFIG_TARGETS)))$$' -e '_default$$' -e '^(Makefile)'
 	@echo
 	@echo "Or, $(MAKE) <config_target> [<make_target(s)>]"


### PR DESCRIPTION
Ubuntu 22.04 uses make 4.3 which broke the current `make help` target Reference:
https://stackoverflow.com/a/26339924

### Solved Problem
Running `make help` on Ubuntu 22.04 (make 4.3) returned:
```
Usage: make <target>
Where <target> is one of:
make: *** [Makefile:559: help] Error 1
```

### Solution
Update the `make help` target so that it compatible with make 4.3 as suggested in https://stackoverflow.com/a/26339924

### Changelog Entry
For release notes: NONE

### Test coverage
- Unit/integration test: ...
- Simulation/hardware testing logs: https://review.px4.io/