### PR TITLE
SF45 fixes to restart the state machine if sensor does not init correctly

### DIFF
--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
@@ -45,7 +45,6 @@
 
 /* Configuration Constants */
 #define SF45_MAX_PAYLOAD 256
-// TODO: decide what happens next. Maybe switch out of guided mode.
 #define SF45_SCALE_FACTOR 0.01f
 
 SF45LaserSerial::SF45LaserSerial(const char *port, uint8_t rotation) :

--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.cpp
@@ -164,9 +164,8 @@ int SF45LaserSerial::collect()
 	/* read from the sensor (uart buffer) */
 	const hrt_abstime timestamp_sample = hrt_absolute_time();
 
-	if (_consecutive_fail_count > 15 && !_sensor_ready) {
+	if (_consecutive_fail_count > 50 && !_sensor_ready) {
 		PX4_ERR("Restarting the state machine");
-		_consecutive_fail_count = 0;
 		start();
 	}
 

--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.hpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.hpp
@@ -105,7 +105,7 @@ private:
 	uint8_t                         _parsed_state{0};
 	bool                            _sop_valid{false};
 	uint16_t                        _calc_crc{0};
-	uint8_t                         _num_retries{2};
+	uint8_t                         _num_retries{0};
 	int32_t                         _yaw_cfg{0};
 	int32_t                         _orient_cfg{0};
 	int32_t                         _collision_constraint{0};

--- a/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.hpp
+++ b/src/drivers/distance_sensor/lightware_sf45_serial/lightware_sf45_serial.hpp
@@ -53,6 +53,16 @@
 #include <uORB/topics/distance_sensor.h>
 
 #include "sf45_commands.h"
+
+enum SF_SERIAL_STATE {
+	STATE_UNINIT = 0,
+	STATE_SEND_PRODUCT_NAME = 1,
+	STATE_SEND_UPDATE_RATE = 2,
+	STATE_SEND_DISTANCE_DATA = 3,
+	STATE_SEND_STREAM = 4,
+};
+
+
 class SF45LaserSerial : public px4::ScheduledWorkItem
 {
 public:


### PR DESCRIPTION
Fixes https://github.com/PX4/PX4-Autopilot/issues/23308 when the SF45 is on specific UARTS, the sensor never reports distance data due to being stuck in init. 

Also populates comms_errs if there are issues reading/writing data.

The serial uart data being read reports the start of packet invalid, payload length invalid, and CRC mismatch in the early sensor init state, so the SF_STREAM command never gets sent out. This PR restarts the state machine if there are too many consecutive  errors in the beginning that are the result of UART data mismatch on what the driver expects and what the sensor sends. For unknown reasons the sensor seems to work much better on TELEM1 and TELEM2

Tested on holybro 6x where TELEM 1 and TELEM2 worked fine with the original driver, but TELEM3 did not and the start of packet invalids caused the sensor to never stream distance data. With this fix the driver actually reports distance data on telem 3.

![errors](https://github.com/user-attachments/assets/6e41e668-612c-43c2-b581-f7a37372fee7)
![sf45](https://github.com/user-attachments/assets/e36dad18-691d-4b9f-9f87-87df1a8010b1)

