### PR TITLE
Navigator: Land: Improve it for VTOL by taking breaking distance into account

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -86,10 +86,8 @@ Land::on_active()
 	    _navigator->get_vstatus()->in_transition_mode) {
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-		// create a virtual wp 1m in front of the vehicle to track during the backtransition
-		waypoint_from_heading_and_distance(_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
-						   _navigator->get_local_position()->heading, 1.f,
-						   &pos_sp_triplet->current.lat, &pos_sp_triplet->current.lon);
+		// create a wp in front of the VTOL until which the VTOL in multicopter mode is able to decelerate
+		_navigator->calculate_breaking_stop(pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
 
 		_navigator->set_position_setpoint_triplet_updated();
 	}

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -86,7 +86,7 @@ Land::on_active()
 	    _navigator->get_vstatus()->in_transition_mode) {
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-		// create a wp in front of the VTOL until which the VTOL in multicopter mode is able to decelerate
+		// create a wp in front of the VTOL while in back-transition, based on MPC settings that will apply in MC phase afterwards
 		_navigator->calculate_breaking_stop(pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
 
 		_navigator->set_position_setpoint_triplet_updated();


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
When triggering a Land on a VTOL, the horizontal speed might not be zero after the back transition, resulting in a weird flying back movement, which comes from the fact that the setpoint is only updated until the transition is done, and not until it has come to a stop.
<img src="https://github.com/user-attachments/assets/62ffd314-60cf-4ad9-9bb7-044ef6174926"  width="300" />
<img src="https://github.com/user-attachments/assets/138862e5-f633-4b8f-adbe-b642e8f2f345"  width="400" />



### Solution
I propose we adapt the target landing location location setpoint based on the current velocity, and possible acceleration and jerk in MC mode.
<img src="https://github.com/user-attachments/assets/d2b19b23-b963-4d81-a0ef-1932c9c9a861"  width="300" />
<img src="https://github.com/user-attachments/assets/e420e871-36a3-4660-a67a-f3e78ef785ac"  width="400" />

### Changelog Entry
```
Bugfix: VTOL Landing Location
Documentation: Landing location for VTOL is where it came to an full halt, and not where backtransition was completed.
```


### Test coverage
Tested in SITL & on [Hardware](https://review.px4.io/plot_app?log=629ef75e-c257-4a24-912b-527d2f9634e6)


