### PR TITLE
Fix multi-instance publishing of satellite_info topic

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -1214,10 +1214,12 @@ GPS::publish()
 void
 GPS::publishSatelliteInfo()
 {
-	if (_instance == Instance::Main) {
+	if (_instance == Instance::Main || _is_gps_main_advertised.load()) {
 		if (_p_report_sat_info != nullptr) {
 			_report_sat_info_pub.publish(*_p_report_sat_info);
 		}
+
+		_is_gps_main_advertised.store(true);
 
 	} else {
 		//we don't publish satellite info for the secondary gps


### PR DESCRIPTION
### Solved Problem
When debugging some GNSS issues I found that only the main instance of satellite_info topic was logged. This is annoying when you need to find out why one GNSS is degraded compared to the other one.

### Solution
- Use `_is_gps_main_advertised.load()` the same way as sensor_gps is published

### Changelog Entry
For release notes:
```
Feature/Bugfix Fix multi-instance publishing of satellite_info topic
```

### Test coverage
- Unit/integration test: Nothing done
- Simulation/hardware testing logs: https://review.px4.io/:

1. Reference log with only one logged instance of satellite_info : https://logs.px4.io/plot_app?log=5ce58347-adf4-4905-88bd-aafe2a36341b

There are two gps instances as confirmed by sensor_gps, but only one satellite_info
![image](https://github.com/user-attachments/assets/c6aead22-969b-4d67-9d11-a20511eadbcf)

2. Log with my fix: https://logs.px4.io/plot_app?log=e6eeb080-2be6-40e5-b2f8-b32a0e263ee9
Now there are two instances of satellite_info that are logged correctly (`satellite_info.00` and `satellite_info.01`), but also still a "zombie" `satellite_info` that contains one datapoint from what I can see...
![image](https://github.com/user-attachments/assets/c5aaf0fb-3589-4215-b941-2fedde39fbb0)

