### PR TITLE
Rework 1st waypoint check

### DIFF
--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -642,6 +642,12 @@ bool FeasibilityChecker::checkHorizontalDistanceToFirstWaypoint(mission_item_s &
 			mavlink_log_critical(_mavlink_log_pub,
 					     "First waypoint far away from home: %dm. Correct mission loaded?\t",
 					     (int)dist_to_1wp_from_home_pos);
+			/* EVENT
+			* @description
+			* <profile name="dev">
+			* This check can be configured via <param>MIS_DIST_1WP</param> parameter.
+			* </profile>
+			*/
 			events::send<uint32_t>(events::ID("navigator_mis_first_wp_far"), {events::Log::Warning, events::LogInternal::Info},
 					       "First waypoint far away from Home: {1m} Correct mission loaded?", (uint32_t)dist_to_1wp_from_home_pos);
 

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.cpp
@@ -629,7 +629,7 @@ bool FeasibilityChecker::checkHorizontalDistanceToFirstWaypoint(mission_item_s &
 
 		_first_waypoint_found = true;
 
-		float dist_to_1wp_from_home_pos = get_distance_to_next_waypoint(
+		const float dist_to_1wp_from_home_pos = get_distance_to_next_waypoint(
 				mission_item.lat, mission_item.lon,
 				_home_lat_lon(0), _home_lat_lon(1));
 
@@ -643,7 +643,7 @@ bool FeasibilityChecker::checkHorizontalDistanceToFirstWaypoint(mission_item_s &
 					     "First waypoint far away from home: %dm. Correct mission loaded?\t",
 					     (int)dist_to_1wp_from_home_pos);
 			events::send<uint32_t>(events::ID("navigator_mis_first_wp_far"), {events::Log::Warning, events::LogInternal::Info},
-					       "First waypoint far away from home: {1m} Correct mission loaded?", (uint32_t)dist_to_1wp_from_home_pos);
+					       "First waypoint far away from Home: {1m} Correct mission loaded?", (uint32_t)dist_to_1wp_from_home_pos);
 
 			return false;
 		}

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -85,6 +85,11 @@ public:
 		       _takeoff_land_available_failed;
 	}
 
+	/**
+	 * @brief Reset all data
+	*/
+	void reset();
+
 private:
 	orb_advert_t *_mavlink_log_pub{nullptr};
 
@@ -132,11 +137,6 @@ private:
 	double _last_lat{(double)NAN};
 	double _last_lon{(double)NAN};
 	int _last_cmd{-1};
-
-	/**
-	 * @brief Reset all data
-	*/
-	void reset();
 
 	/**
 	 * @brief Update data from external topics, e.g home position

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -91,7 +91,6 @@ private:
 	uORB::Subscription _home_pos_sub{ORB_ID(home_position)};
 	uORB::Subscription _status_sub{ORB_ID(vehicle_status)};
 	uORB::Subscription _land_detector_sub{ORB_ID(vehicle_land_detected)};
-	uORB::Subscription _vehicle_global_position_sub{ORB_ID(vehicle_global_position)};
 	uORB::Subscription _rtl_status_sub{ORB_ID(rtl_status)};
 
 	// parameters
@@ -104,7 +103,6 @@ private:
 	float _home_alt_msl{NAN};
 	bool _has_vtol_approach{false};
 	matrix::Vector2d _home_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
-	matrix::Vector2d _current_position_lat_lon = matrix::Vector2d((double)NAN, (double)NAN);
 	VehicleType _vehicle_type{VehicleType::RotaryWing};
 
 	// internal flags to keep track of which checks failed

--- a/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityChecker.hpp
@@ -78,18 +78,12 @@ public:
 	bool someCheckFailed()
 	{
 		return _takeoff_failed ||
-		       _distance_first_waypoint_failed ||
 		       _distance_between_waypoints_failed ||
 		       _land_pattern_validity_failed ||
 		       _fixed_wing_land_approach_failed ||
 		       _mission_validity_failed ||
 		       _takeoff_land_available_failed;
 	}
-
-	/**
-	 * @brief Reset all data
-	*/
-	void reset();
 
 private:
 	orb_advert_t *_mavlink_log_pub{nullptr};
@@ -117,7 +111,6 @@ private:
 	bool _mission_validity_failed{false};
 	bool _takeoff_failed{false};
 	bool _land_pattern_validity_failed{false};
-	bool _distance_first_waypoint_failed{false};
 	bool _distance_between_waypoints_failed{false};
 	bool _fixed_wing_land_approach_failed{false};
 	bool _takeoff_land_available_failed{false};
@@ -141,6 +134,11 @@ private:
 	double _last_lat{(double)NAN};
 	double _last_lon{(double)NAN};
 	int _last_cmd{-1};
+
+	/**
+	 * @brief Reset all data
+	*/
+	void reset();
 
 	/**
 	 * @brief Update data from external topics, e.g home position

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -172,7 +172,7 @@ TEST_F(FeasibilityCheckerTest, check_dist_first_waypoint)
 
 	// THEN: fail
 	checker.processNextItem(mission_item, 0, 1);
-	ASSERT_EQ(checker.someCheckFailed(), true);
+	ASSERT_EQ(checker.someCheckFailed(), false);
 
 	// BUT WHEN: valid current position fist WP 499m away from current
 	checker.reset();

--- a/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
+++ b/src/modules/navigator/MissionFeasibility/FeasibilityCheckerTest.cpp
@@ -170,7 +170,7 @@ TEST_F(FeasibilityCheckerTest, check_dist_first_waypoint)
 	mission_item.lat = lat_new;
 	mission_item.lon = lon_new;
 
-	// THEN: fail
+	// THEN: pass
 	checker.processNextItem(mission_item, 0, 1);
 	ASSERT_EQ(checker.someCheckFailed(), false);
 

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -41,7 +41,6 @@
  */
 
 #include "mission_feasibility_checker.h"
-#include "MissionFeasibility/FeasibilityChecker.hpp"
 
 #include "mission_block.h"
 #include "navigator.h"


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
In the mission feasibility, it is checked if the 1st waypoint is too far from the current position. This means that the mission feasibility can change during flight if moving further away from the first waypoint. The mission feasibility should not be able to change depending on the current position of the AV.  Especially when a long mission is flown and interrupted, the mission check should make a mission infeasible because the AV did fly away from the fist mission item.

Since the first waypoint mission check should indicate that potentially an old mission from another location is loaded in PX4 it should not be able to change the feasibility in flight 

Fixes #{Github issue ID}

### Solution
- The 1st waypoint check only generates a warning in QGC, but does not invalidate a mission
- The 1st waypoint check is performed against the home position

### Changelog Entry
For release notes:
```
Change: First waypoint mission check only generates a warning, but mission can still be executed
```

### Alternatives
The home position can stil change during a flight and a even better point would be to specifically take a takeoff location which would be constant for an entire flight (AFAIK does not exist yet). Also it can still be argued if the check should make the whole mission infeasible, for simplicity, it was converted to a warning only.

### Test coverage
- Tested in SITL simulation with the standard VTOL configuration.
  - Upload a valid mission and test mission functionality
  - Reduce MIS_DIST_1WP to 1m and check that watning appears after mission feasibility is calculated again
  - Make sure mission can still be executed even with warning
  - Create a mission close to the vehicle and set MIS_DIST_1WP to barely include the first waypoint
  - Fly away manually
  - Execute mission again, make dure mission can still be flown but a warning is displayed.


### Context
Related links, screenshot before/after, video
