### PR TITLE
Commander: Failsafe: set clear condition for action Land like for RTL (OnModeChangeOrDisarm)

### DIFF
--- a/src/modules/commander/failsafe/failsafe.cpp
+++ b/src/modules/commander/failsafe/failsafe.cpp
@@ -60,6 +60,7 @@ FailsafeBase::ActionOptions Failsafe::fromNavDllOrRclActParam(int param_value)
 
 	case gcs_connection_loss_failsafe_mode::Land_mode:
 		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
 	case gcs_connection_loss_failsafe_mode::Terminate:
@@ -113,6 +114,7 @@ FailsafeBase::ActionOptions Failsafe::fromGfActParam(int param_value)
 
 	case geofence_violation_action::Land_mode:
 		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
 	default:
@@ -355,6 +357,7 @@ FailsafeBase::ActionOptions Failsafe::fromHighWindLimitActParam(int param_value)
 
 	case command_after_high_wind_failsafe::Land_mode:
 		options.action = Action::Land;
+		options.clear_condition = ClearCondition::OnModeChangeOrDisarm;
 		break;
 
 	default:


### PR DESCRIPTION
For many failsafes, it is possible to select RTL and Land as actions. In this commit I synchronize the clear condition for these two action options, to always only clear on Disarm or manual mode change. Reasoning is that for the user RTL and Land is a similar action and I would thus expect them to be as similar as possible. And I in general would rather not clear a failsafe state instead of too often clearing it.

Example: GF failsafe with action Land --> even if the drone is marginally within the GF again, I want it to proceed with the Landing unless I manually intervene.

### Changelog Entry
For release notes:
```
Improvement: Commander: Failsafe: set clear condition for action Land like for RTL (OnModeChangeOrDisarm)
```

### Alternatives
We can also discuss if for each failsafe and set the clear condition of Land differently to RTL in some.
- GF --> that was the motivation for this PR
- link loss
- high wind


