### PR TITLE
ci: try runs-on Dronecode Infra

### DIFF
--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -1,3 +1,9 @@
+# NOTE: this workflow is now running on Dronecode / PX4 AWS account.
+# - For questions about this setup please reach out to rroche@linuxfoundation.org
+# - If you want to keep the tests running in GitHub Actions you need to uncomment the "runs-on: ubuntu-latest" lines
+#   and comment the "runs-on: [runs-on,runner=..." lines.
+# - If you would like to duplicate this setup try setting up "RunsOn" on your own AWS account try https://runs-on.com
+
 name: Build all targets
 
 on:
@@ -14,6 +20,7 @@ on:
 jobs:
   group_targets:
     name: Scan for Board Targets
+    # runs-on: ubuntu-latest
     runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}"]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -34,6 +41,7 @@ jobs:
 
   setup:
     name: ${{ matrix.group }}
+    # runs-on: ubuntu-latest
     runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}"]
     needs: group_targets
     strategy:

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -1,5 +1,4 @@
 # NOTE: this workflow is now running on Dronecode / PX4 AWS account.
-# - For questions about this setup please reach out to rroche@linuxfoundation.org
 # - If you want to keep the tests running in GitHub Actions you need to uncomment the "runs-on: ubuntu-latest" lines
 #   and comment the "runs-on: [runs-on,runner=..." lines.
 # - If you would like to duplicate this setup try setting up "RunsOn" on your own AWS account try https://runs-on.com

--- a/.github/workflows/build_all_targets.yml
+++ b/.github/workflows/build_all_targets.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   group_targets:
     name: Scan for Board Targets
-    runs-on: ubuntu-latest
+    runs-on: [runs-on,runner=1cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}"]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       timestamp: ${{ steps.set-timestamp.outputs.timestamp }}
@@ -34,7 +34,7 @@ jobs:
 
   setup:
     name: ${{ matrix.group }}
-    runs-on: ubuntu-latest
+    runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}"]
     needs: group_targets
     strategy:
       matrix: ${{ fromJson(needs.group_targets.outputs.matrix) }}


### PR DESCRIPTION
## Sponsored by Dronecode Foundation
Use the Dronecode AWS Infrastructure for CI workflow runs. This PR introduces access to a paid Dronecode/PX4 AWS account for workflows. Initially, we are only using it for the new "Build All targets" workflow. 

To use the Dronecode Infrastructure, you have to add a similar line ([runner types available](https://runs-on.com/features/custom-runners/)):

> runs-on: [runs-on,runner=8cpu-linux-x64,image=ubuntu22-full-x64,"run-id=${{ github.run_id }}"]

**Current Setup**
* CPU: 8 cores
* RAM: 32GB
* AWS EC2 Type: m7a.2xlarge
* Max Concurrent Servers: 60

**Debug Access**
* Any user with Github admin access and a valid SSH key configured in github.com
* Click on the "Set up job" step and access the runner details

![Screenshot 2024-08-19 at 10 27 17 AM](https://github.com/user-attachments/assets/b78094a9-e419-4498-9934-84c7990b8373)

**Build Time Comparison (additive)**

* Dronecode Infra: **2h 18m 42s**
* Github Runners: **4h 34m 2s**

![Screenshot 2024-08-19 at 10 39 50 AM](https://github.com/user-attachments/assets/a399eabc-ce4c-46d2-a5b1-043fef9f5b1f)

## Cost Considerations
We have provisioned 4k build minutes and expect to not meet the limit any time soon, but we will be heavily monitoring for any abuse of the system.

Note: we are using the [runs-on](https://runs-on.com) project for our AWS deployments.