### PR TITLE
Support straight line mission landings

### DIFF
--- a/msg/PositionSetpoint.msg
+++ b/msg/PositionSetpoint.msg
@@ -30,7 +30,8 @@ bool loiter_direction_counter_clockwise # loiter direction is clockwise by defau
 float32 loiter_orientation 	# Orientation of the major axis with respect to true north in rad [-pi,pi)
 uint8 	loiter_pattern		# loitern pattern to follow
 
-float32 acceptance_radius   # navigation acceptance_radius if we're doing waypoint navigation
+float32 acceptance_radius   # horizontal acceptance_radius (meters)
+float32 alt_acceptance_radius # vertical acceptance radius, only used for fixed wing guidance, NAN = let guidance choose (meters)
 
 float32 cruising_speed		# the generally desired cruising speed (not a hard constraint)
 bool gliding_enabled		# commands the vehicle to glide if the capability is available (fixed wing only)

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1029,8 +1029,9 @@ FixedwingPositionControl::handle_setpoint_type(const position_setpoint_s &pos_sp
 					   _current_latitude, _current_longitude, _current_altitude,
 					   &dist_xy, &dist_z);
 
-		const float acc_rad_z =  PX4_ISFINITE(pos_sp_curr.alt_acceptance_radius) ? pos_sp_curr.alt_acceptance_radius :
-					 _param_nav_fw_alt_rad.get();
+		const float acc_rad_z = (PX4_ISFINITE(pos_sp_curr.alt_acceptance_radius)
+					 && pos_sp_curr.alt_acceptance_radius > FLT_EPSILON) ? pos_sp_curr.alt_acceptance_radius :
+					_param_nav_fw_alt_rad.get();
 
 		// Achieve position setpoint altitude via loiter when laterally close to WP.
 		// Detect if system has switchted into a Loiter before (check _position_sp_type), and in that

--- a/src/modules/fw_pos_control/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control/FixedwingPositionControl.cpp
@@ -1029,11 +1029,14 @@ FixedwingPositionControl::handle_setpoint_type(const position_setpoint_s &pos_sp
 					   _current_latitude, _current_longitude, _current_altitude,
 					   &dist_xy, &dist_z);
 
+		const float acc_rad_z =  PX4_ISFINITE(pos_sp_curr.alt_acceptance_radius) ? pos_sp_curr.alt_acceptance_radius :
+					 _param_nav_fw_alt_rad.get();
+
 		// Achieve position setpoint altitude via loiter when laterally close to WP.
 		// Detect if system has switchted into a Loiter before (check _position_sp_type), and in that
 		// case remove the dist_xy check (not switch out of Loiter until altitude is reached).
 		if ((!_vehicle_status.in_transition_mode) && (dist >= 0.f)
-		    && (dist_z > _param_nav_fw_alt_rad.get())
+		    && (dist_z > acc_rad_z)
 		    && (dist_xy < acc_rad || _position_sp_type == position_setpoint_s::SETPOINT_TYPE_LOITER)) {
 
 			// SETPOINT_TYPE_POSITION -> SETPOINT_TYPE_LOITER

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -209,9 +209,10 @@ void Mission::setActiveMissionItems()
 			mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 		}
 
-		// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
+		// prevent fixed wing lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
 		// is not achieved.
-		if (isLanding() && _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
+		if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && isLanding() &&
+		    && _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
 			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
 		}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -91,41 +91,6 @@ Mission::on_activation()
 	MissionBase::on_activation();
 }
 
-bool
-Mission::isLanding()
-{
-	if (get_land_start_available()) {
-		static constexpr size_t max_num_next_items{1u};
-		int32_t next_mission_items_index[max_num_next_items];
-		size_t num_found_items;
-
-		getNextPositionItems(_mission.land_start_index + 1, next_mission_items_index, num_found_items, max_num_next_items);
-
-		// vehicle is currently landing if
-		//  mission valid, still flying, and in the landing portion of mission (past land start marker)
-		bool on_landing_stage = (num_found_items > 0U) &&  _mission.current_seq > next_mission_items_index[0U];
-
-		// special case: if the land start index is at a LOITER_TO_ALT WP, then we're in the landing sequence already when the
-		// distance to the WP is below the loiter radius + acceptance.
-		if ((num_found_items > 0U) && _mission.current_seq == next_mission_items_index[0U]
-		    && _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT) {
-			const float d_current = get_distance_to_next_waypoint(_mission_item.lat, _mission_item.lon,
-						_navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
-
-			// consider mission_item.loiter_radius invalid if NAN or 0, use default value in this case.
-			const float mission_item_loiter_radius_abs = (PX4_ISFINITE(_mission_item.loiter_radius)
-					&& fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
-					_navigator->get_loiter_radius();
-
-			on_landing_stage = d_current <= (_navigator->get_acceptance_radius() + mission_item_loiter_radius_abs);
-		}
-
-		return _navigator->get_mission_result()->valid && on_landing_stage;
-
-	} else {
-		return false;
-	}
-}
 
 bool
 Mission::set_current_mission_index(uint16_t index)

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -244,6 +244,12 @@ void Mission::setActiveMissionItems()
 			mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 		}
 
+		// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
+		// is not achieved.
+		if (isLanding() && _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
+			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
+		}
+
 		// Allow a rotary wing vehicle to decelerate before reaching a wp with a hold time or a timeout
 		// This is done by setting the position triplet's next position's valid flag to false,
 		// which makes the FlightTask disregard the next position

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -212,7 +212,7 @@ void Mission::setActiveMissionItems()
 		// prevent fixed wing lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
 		// is not achieved.
 		if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && isLanding() &&
-		    && _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
+		    _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
 			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
 		}
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -67,7 +67,6 @@ public:
 	uint16_t get_land_start_index() const { return _mission.land_start_index; }
 	bool get_land_start_available() const { return hasMissionLandStart(); }
 
-	bool isLanding();
 
 private:
 

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -370,7 +370,7 @@ MissionBase::on_active()
 bool
 MissionBase::isLanding()
 {
-	if (hasMissionLandStart()) {
+	if (hasMissionLandStart() && (_mission.current_seq > _mission.land_start_index)) {
 		static constexpr size_t max_num_next_items{1u};
 		int32_t next_mission_items_index[max_num_next_items];
 		size_t num_found_items;

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -386,12 +386,12 @@ MissionBase::isLanding()
 		if ((num_found_items > 0U) && _mission.current_seq == next_mission_items_index[0U]
 		    && _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT) {
 			const float d_current = get_distance_to_next_waypoint(_mission_item.lat, _mission_item.lon,
-									      _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
+						_navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
 
 			// consider mission_item.loiter_radius invalid if NAN or 0, use default value in this case.
 			const float mission_item_loiter_radius_abs = (PX4_ISFINITE(_mission_item.loiter_radius)
-								      && fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
-								     _navigator->get_loiter_radius();
+					&& fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
+					_navigator->get_loiter_radius();
 
 			on_landing_stage = d_current <= (_navigator->get_acceptance_radius() + mission_item_loiter_radius_abs);
 		}

--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -367,6 +367,42 @@ MissionBase::on_active()
 	updateAltToAvoidTerrainCollisionAndRepublishTriplet(_mission_item);
 }
 
+bool
+MissionBase::isLanding()
+{
+	if (hasMissionLandStart()) {
+		static constexpr size_t max_num_next_items{1u};
+		int32_t next_mission_items_index[max_num_next_items];
+		size_t num_found_items;
+
+		getNextPositionItems(_mission.land_start_index + 1, next_mission_items_index, num_found_items, max_num_next_items);
+
+		// vehicle is currently landing if
+		//  mission valid, still flying, and in the landing portion of mission (past land start marker)
+		bool on_landing_stage = (num_found_items > 0U) &&  _mission.current_seq > next_mission_items_index[0U];
+
+		// special case: if the land start index is at a LOITER_TO_ALT WP, then we're in the landing sequence already when the
+		// distance to the WP is below the loiter radius + acceptance.
+		if ((num_found_items > 0U) && _mission.current_seq == next_mission_items_index[0U]
+		    && _mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT) {
+			const float d_current = get_distance_to_next_waypoint(_mission_item.lat, _mission_item.lon,
+									      _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
+
+			// consider mission_item.loiter_radius invalid if NAN or 0, use default value in this case.
+			const float mission_item_loiter_radius_abs = (PX4_ISFINITE(_mission_item.loiter_radius)
+								      && fabsf(_mission_item.loiter_radius) > FLT_EPSILON) ? fabsf(_mission_item.loiter_radius) :
+								     _navigator->get_loiter_radius();
+
+			on_landing_stage = d_current <= (_navigator->get_acceptance_radius() + mission_item_loiter_radius_abs);
+		}
+
+		return _navigator->get_mission_result()->valid && on_landing_stage;
+
+	} else {
+		return false;
+	}
+}
+
 void MissionBase::update_mission()
 {
 	if (_mission.count == 0u || !_is_current_planned_mission_item_valid || !isMissionValid()) {

--- a/src/modules/navigator/mission_base.h
+++ b/src/modules/navigator/mission_base.h
@@ -73,6 +73,8 @@ public:
 	virtual void on_activation() override;
 	virtual void on_active() override;
 
+	bool isLanding();
+
 protected:
 
 	/**
@@ -320,6 +322,7 @@ protected:
 	 * @param[in] index Index of the mission item
 	 */
 	void setMissionIndex(int32_t index);
+
 
 	bool _is_current_planned_mission_item_valid{false};	/**< Flag indicating if the currently loaded mission item is valid*/
 	bool _mission_has_been_activated{false};		/**< Flag indicating if the mission has been activated*/

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -359,6 +359,12 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 			}
 
+			// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
+			// is not achieved.
+			if (_mission_item.nav_cmd == NAV_CMD_WAYPOINT && _navigator->on_mission_landing()) {
+				alt_acc_rad_m = FLT_MAX;
+			}
+
 			bool passed_curr_wp = false;
 
 			if (_navigator->get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
@@ -672,6 +678,10 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	} else {
 		sp->acceptance_radius = _navigator->get_default_acceptance_radius();
 	}
+
+	// by default, FW guidance logic will take alt acceptance from NAV_FW_ALT_RAD, in some special cases
+	// we override it after this
+	sp->alt_acceptance_radius = NAN;
 
 	sp->cruising_speed = _navigator->get_cruising_speed();
 	sp->cruising_throttle = _navigator->get_cruising_throttle();

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -337,8 +337,6 @@ MissionBlock::is_mission_item_reached_or_completed()
 				acceptance_radius = _mission_item.acceptance_radius;
 			}
 
-			struct position_setpoint_s *curr_sp = &_navigator->get_position_setpoint_triplet()->current;
-
 			float alt_acc_rad_m = _navigator->get_altitude_acceptance_radius();
 
 			/* for vtol back transition calculate acceptance radius based on time and ground speed */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -339,9 +339,7 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 			struct position_setpoint_s *curr_sp = &_navigator->get_position_setpoint_triplet()->current;
 
-			float alt_acc_rad_m = (PX4_ISFINITE(curr_sp->alt_acceptance_radius)
-					       && curr_sp->alt_acceptance_radius > FLT_EPSILON) ? curr_sp->alt_acceptance_radius :
-					      _navigator->get_altitude_acceptance_radius();
+			float alt_acc_rad_m = _navigator->get_altitude_acceptance_radius();
 
 			/* for vtol back transition calculate acceptance radius based on time and ground speed */
 			if (_mission_item.vtol_back_transition

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -339,7 +339,8 @@ MissionBlock::is_mission_item_reached_or_completed()
 
 			struct position_setpoint_s *curr_sp = &_navigator->get_position_setpoint_triplet()->current;
 
-			float alt_acc_rad_m = PX4_ISFINITE(curr_sp->alt_acceptance_radius) ? curr_sp->alt_acceptance_radius :
+			float alt_acc_rad_m = (PX4_ISFINITE(curr_sp->alt_acceptance_radius)
+					       && curr_sp->alt_acceptance_radius > FLT_EPSILON) ? curr_sp->alt_acceptance_radius :
 					      _navigator->get_altitude_acceptance_radius();
 
 			/* for vtol back transition calculate acceptance radius based on time and ground speed */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -337,7 +337,10 @@ MissionBlock::is_mission_item_reached_or_completed()
 				acceptance_radius = _mission_item.acceptance_radius;
 			}
 
-			float alt_acc_rad_m = _navigator->get_altitude_acceptance_radius();
+			struct position_setpoint_s *curr_sp = &_navigator->get_position_setpoint_triplet()->current;
+
+			float alt_acc_rad_m = PX4_ISFINITE(curr_sp->alt_acceptance_radius) ? curr_sp->alt_acceptance_radius :
+					      _navigator->get_altitude_acceptance_radius();
 
 			/* for vtol back transition calculate acceptance radius based on time and ground speed */
 			if (_mission_item.vtol_back_transition
@@ -357,12 +360,6 @@ MissionBlock::is_mission_item_reached_or_completed()
 				// the vehicle to perform a sharp turn after passing the land waypoint and this causes worse unexected behavior
 				alt_acc_rad_m = INFINITY;
 
-			}
-
-			// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
-			// is not achieved.
-			if (_mission_item.nav_cmd == NAV_CMD_WAYPOINT && _navigator->on_mission_landing()) {
-				alt_acc_rad_m = FLT_MAX;
 			}
 
 			bool passed_curr_wp = false;

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -177,8 +177,6 @@ public:
 
 	float get_loiter_radius() { return _param_nav_loiter_rad.get(); }
 
-	bool on_mission_landing() { return _mission.isLanding(); }
-
 	/**
 	 * Returns the default acceptance radius defined by the parameter
 	 */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -177,6 +177,8 @@ public:
 
 	float get_loiter_radius() { return _param_nav_loiter_rad.get(); }
 
+	bool on_mission_landing() { return _mission.isLanding(); }
+
 	/**
 	 * Returns the default acceptance radius defined by the parameter
 	 */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1118,9 +1118,14 @@ float Navigator::get_default_acceptance_radius()
 float Navigator::get_altitude_acceptance_radius()
 {
 	if (get_vstatus()->vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING) {
+
+		const position_setpoint_s &curr_sp = get_position_setpoint_triplet()->current;
 		const position_setpoint_s &next_sp = get_position_setpoint_triplet()->next;
 
-		if (!force_vtol() && next_sp.type == position_setpoint_s::SETPOINT_TYPE_LAND && next_sp.valid) {
+		if ((PX4_ISFINITE(curr_sp.alt_acceptance_radius) && curr_sp.alt_acceptance_radius > FLT_EPSILON)) {
+			return curr_sp.alt_acceptance_radius;
+
+		} else if (!force_vtol() && next_sp.type == position_setpoint_s::SETPOINT_TYPE_LAND && next_sp.valid) {
 			// Use separate (tighter) altitude acceptance for clean altitude starting point before FW landing
 			return _param_nav_fw_altl_rad.get();
 

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -215,7 +215,8 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 		// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
 		// is not achieved.
-		if (_mission_item.nav_cmd == NAV_CMD_WAYPOINT && MissionBase::isLanding()) {
+		if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && MissionBase::isLanding()
+		    && _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
 			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
 		}
 	}

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -215,7 +215,7 @@ void RtlDirectMissionLand::setActiveMissionItems()
 
 		// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
 		// is not achieved.
-		if (_mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
+		if (_mission_item.nav_cmd == NAV_CMD_WAYPOINT && MissionBase::isLanding()) {
 			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
 		}
 	}

--- a/src/modules/navigator/rtl_direct_mission_land.cpp
+++ b/src/modules/navigator/rtl_direct_mission_land.cpp
@@ -212,6 +212,12 @@ void RtlDirectMissionLand::setActiveMissionItems()
 		}
 
 		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+
+		// prevent lateral guidance from loitering at a waypoint as part of a mission landing if the altitude
+		// is not achieved.
+		if (_mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
+			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
+		}
 	}
 
 	issue_command(_mission_item);

--- a/src/modules/navigator/rtl_mission_fast.cpp
+++ b/src/modules/navigator/rtl_mission_fast.cpp
@@ -168,6 +168,11 @@ void RtlMissionFast::setActiveMissionItems()
 		}
 
 		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+
+		if (_vehicle_status_sub.get().vehicle_type == vehicle_status_s::VEHICLE_TYPE_FIXED_WING && isLanding() &&
+		    _mission_item.nav_cmd == NAV_CMD_WAYPOINT) {
+			pos_sp_triplet->current.alt_acceptance_radius = FLT_MAX;
+		}
 	}
 
 	issue_command(_mission_item);


### PR DESCRIPTION
### Solved Problem
When flying Fixed Wings in a space constrained area, it can be difficult to plan the usual orbit type mission landings.
There might simply not be enough space for the vehicle to orbit while it's descending in altitude.

Of course, one can just plan a mission with simple waypoints and add a VTOL LAND waypoint at the end. However, there is always the risk that the altitude difference between the waypoints is too big and the vehicle cannot follow the glide-slope, causing it to loiter at the next waypoint in order to reduce altitude further. This behavior is highly undesirable as part of a mission landing, as already explained above.

Fixes #{Github issue ID}

### Solution
I propose a solution where all simple waypoints AFTER a land stark marker have their altitude acceptance radius set to INFINITY, which will cause the guidance logic to track altitude for these waypoints based on best effort.


### Changelog Entry
For release notes:
```
Feature
Documentation: Add documentation for QGC explaining the difference between the two types of landings.
```

### Test coverage
Tested regularly in production but on a much older branch. Only SITL tested on main.

### Context
Altitude profile for staright line landing. Notice, that for the first waypoints the altitude needs to reached, however, for the last waypoints (landing pattern), the altitude is not reached anymore, but the waypoint is still accepted.
![image](https://github.com/user-attachments/assets/e0e806a3-647a-4807-92a3-802be746ce67)

