### PR TITLE
Fix gz airspeed sensor

### DIFF
--- a/src/modules/simulation/gz_bridge/GZBridge.cpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.cpp
@@ -424,7 +424,7 @@ void GZBridge::barometerCallback(const gz::msgs::FluidPressure &air_pressure)
 	pthread_mutex_unlock(&_node_mutex);
 }
 
-void GZBridge::airspeedCallback(const gz::msgs::AirSpeed &air_speed)
+void GZBridge::airspeedCallback(const gz::msgs::AirSpeedSensor &air_speed)
 {
 	if (hrt_absolute_time() == 0) {
 		return;

--- a/src/modules/simulation/gz_bridge/GZBridge.hpp
+++ b/src/modules/simulation/gz_bridge/GZBridge.hpp
@@ -69,6 +69,7 @@
 #include <gz/msgs/model.pb.h>
 #include <gz/msgs/odometry_with_covariance.pb.h>
 #include <gz/msgs/laserscan.pb.h>
+#include <gz/msgs9/gz/msgs/air_speed_sensor.pb.h>
 
 using namespace time_literals;
 
@@ -102,7 +103,7 @@ private:
 
 	void clockCallback(const gz::msgs::Clock &clock);
 
-	void airspeedCallback(const gz::msgs::AirSpeed &air_speed);
+	void airspeedCallback(const gz::msgs::AirSpeedSensor &air_speed);
 	void barometerCallback(const gz::msgs::FluidPressure &air_pressure);
 	void imuCallback(const gz::msgs::IMU &imu);
 	void poseInfoCallback(const gz::msgs::Pose_V &pose);


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
There was a regression caused by #23455

Fixes #{Github issue ID}

### Solution
Fix wrong call of `gz::msgs::AirspeedSensor` to `gz::msgs::Airspeed`

This fixes the build problem for now, but
- `gz-msgs9` uses AirspeedSensor message
- `gz-msgs10` have both AirspeedSensor and Airspeedmessage


### Test coverage
All VTOLS/Planes still broken

### Context
Related links, screenshot before/after, video
