### PR TITLE
Fix force heading to NaN on mission landing approach

### DIFF
--- a/src/modules/navigator/mission_base.cpp
+++ b/src/modules/navigator/mission_base.cpp
@@ -566,6 +566,13 @@ void MissionBase::handleLanding(WorkItemType &new_work_item_type, mission_item_s
 				  (_mission_item.nav_cmd == NAV_CMD_VTOL_LAND) &&
 				  !_land_detected_sub.get().landed;
 
+	/* ignore yaw for landing items */
+	/* XXX: if specified heading for landing is desired we could add another step before the descent
+		* that aligns the vehicle first */
+	if (_mission_item.nav_cmd == NAV_CMD_LAND || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND) {
+		_mission_item.yaw = NAN;
+	}
+
 	/* move to land wp as fixed wing */
 	if (needs_vtol_landing) {
 		if (_work_item_type == WorkItemType::WORK_ITEM_TYPE_DEFAULT) {
@@ -653,13 +660,6 @@ void MissionBase::handleLanding(WorkItemType &new_work_item_type, mission_item_s
 				startPrecLand(_mission_item.land_precision);
 			}
 		}
-	}
-
-	/* ignore yaw for landing items */
-	/* XXX: if specified heading for landing is desired we could add another step before the descent
-		* that aligns the vehicle first */
-	if (_mission_item.nav_cmd == NAV_CMD_LAND || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND) {
-		_mission_item.yaw = NAN;
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
make sure to ignore any mission item yaw angle for the landing. Currently only the yaw angle for the final land item is ignored, but not for the part where the AV is moving to the land position. This can result in the AV turning while moving to the land location.

Fixes #{Github issue ID}

### Solution
- Force the yaw angle to NaN before the mission item is changed for the land sub state machine

### Changelog Entry
For release notes:
```
Bugfix: Force the heading angle to NaN for each mission landing substate 
```

### Alternatives
If the landing yaw needs to be considered, it should be another specific substate in the land state machine before the descend aligning the heading. Currently it is completely ignored.

### Test coverage
- Simulation testing

### Context
Related links, screenshot before/after, video
