### PR TITLE
Fix param typo in quadtailsitter airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1045_gazebo-classic_quadtailsitter
@@ -33,7 +33,7 @@ param set-default PWM_MAIN_FUNC3 103
 param set-default PWM_MAIN_FUNC4 104
 param set-default PWM_MAIN_FUNC5 0
 
-parm set-default FD_FAIL_R 70
+param set-default FD_FAIL_R 70
 
 param set-default FW_P_TC 0.6
 


### PR DESCRIPTION

### Solved Problem
When running the gazebo classic quadtailsitter, I noticed one of the params in the airframe folder had a typo. This fixes that.

### Solution
Switch `parm` for `param`

### Changelog Entry
For release notes:
```
Fixed a small param typo in the gazebo classic quadtailsitter
```


### Test coverage
- This was run in simulation before and after the change. I didn't see any difference because the FailureDetector was never triggered with or without the fix. 