### PR TITLE
cmake: relax git tag requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,11 +113,19 @@ include(px4_parse_function_args)
 include(px4_git)
 
 execute_process(
-	COMMAND git describe --exclude ext/* --always --tags
+	COMMAND git describe --exclude ext/* --tags --match "v[0-9]*"
 	OUTPUT_VARIABLE PX4_GIT_TAG
 	OUTPUT_STRIP_TRAILING_WHITESPACE
+	RESULTS_VARIABLE GIT_DESCRIBE_RESULT
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	)
+
+# if proper git tag unavilable default to v0.0.0
+if(NOT ${GIT_DESCRIBE_RESULT} MATCHES "0")
+	set(PX4_GIT_TAG "v0.0.0")
+endif()
+
+message(STATUS "PX4_GIT_TAG: ${PX4_GIT_TAG}")
 
 # git describe to X.Y.Z version
 string(REPLACE "." ";" VERSION_LIST ${PX4_GIT_TAG})

--- a/src/lib/version/CMakeLists.txt
+++ b/src/lib/version/CMakeLists.txt
@@ -53,7 +53,8 @@ endif()
 
 set(px4_git_ver_header ${CMAKE_CURRENT_BINARY_DIR}/build_git_version.h)
 add_custom_command(OUTPUT ${px4_git_ver_header}
-	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py ${px4_git_ver_header} --validate
+	COMMAND
+		${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py ${px4_git_ver_header} --validate --git_tag '${PX4_GIT_TAG}'
 	DEPENDS
 		${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py
 		${git_dir_path}/HEAD


### PR DESCRIPTION
We've been kind of obnoxious trying to enforce our git tagging convention for versioning, but this causes problems for 3rd parties that might clone without tags or may want to do their own thing.

I've updated the PX4_GIT_TAG in cmake so that it defaults to v0.0.0 if it doesn't find a match, and to pass that same found tag into `src/lib/version/px_update_git_header.py` so we don't have multiple areas of the codebase independently doing the same thing.

 - default to v0.0.0 if tag isn't available
 - src/lib/px_update_git_header.py use same PX4_GIT_TAG as cmake
 - update lingering `master` branch references to `main`

For reference this is the obscure build failure someone will see if they happen to not have the tags (or the wrong tags).

![image](https://github.com/user-attachments/assets/c55cd559-cad2-442e-8ca8-8d9cfb19cc89)
